### PR TITLE
feat(google_meet): extend safe join flow with chat and reactions

### DIFF
--- a/plugins/google_meet/__init__.py
+++ b/plugins/google_meet/__init__.py
@@ -22,14 +22,18 @@ from plugins.google_meet import process_manager as pm
 from plugins.google_meet.cli import register_cli as _register_meet_cli
 from plugins.google_meet.cli import meet_command as _meet_command
 from plugins.google_meet.tools import (
+    MEET_CHAT_SCHEMA,
     MEET_JOIN_SCHEMA,
     MEET_LEAVE_SCHEMA,
+    MEET_REACT_SCHEMA,
     MEET_SAY_SCHEMA,
     MEET_STATUS_SCHEMA,
     MEET_TRANSCRIPT_SCHEMA,
     check_meet_requirements,
+    handle_meet_chat,
     handle_meet_join,
     handle_meet_leave,
+    handle_meet_react,
     handle_meet_say,
     handle_meet_status,
     handle_meet_transcript,
@@ -44,6 +48,8 @@ _TOOLS = (
     ("meet_transcript", MEET_TRANSCRIPT_SCHEMA, handle_meet_transcript, "📝"),
     ("meet_leave",      MEET_LEAVE_SCHEMA,      handle_meet_leave,      "👋"),
     ("meet_say",        MEET_SAY_SCHEMA,        handle_meet_say,        "🗣️"),
+    ("meet_chat",       MEET_CHAT_SCHEMA,       handle_meet_chat,       "💬"),
+    ("meet_react",      MEET_REACT_SCHEMA,      handle_meet_react,      "👍"),
 )
 
 

--- a/plugins/google_meet/cli.py
+++ b/plugins/google_meet/cli.py
@@ -79,6 +79,14 @@ def register_cli(subparser: argparse.ArgumentParser) -> None:
     say_p.add_argument("text", help="what to say")
     say_p.add_argument("--node", default=None)
 
+    chat_p = subs.add_parser("chat", help="Send a chat message in the active meeting")
+    chat_p.add_argument("text", help="chat message text")
+    chat_p.add_argument("--node", default=None)
+
+    react_p = subs.add_parser("react", help="Send a reaction in the active meeting")
+    react_p.add_argument("emoji", help="emoji or common reaction label")
+    react_p.add_argument("--node", default=None)
+
     subs.add_parser("stop", help="Leave the current meeting")
 
     # v3: remote node host management.
@@ -108,7 +116,7 @@ def register_cli(subparser: argparse.ArgumentParser) -> None:
 def meet_command(args: argparse.Namespace) -> int:
     sub = getattr(args, "meet_command", None)
     if not sub:
-        print("usage: hermes meet {setup,auth,join,status,transcript,say,stop,node}")
+        print("usage: hermes meet {setup,auth,join,status,transcript,say,chat,react,stop,node}")
         return 2
     if sub == "setup":
         return _cmd_setup()
@@ -134,6 +142,10 @@ def meet_command(args: argparse.Namespace) -> int:
         return _cmd_transcript(last=args.last)
     if sub == "say":
         return _cmd_say(text=args.text, node=getattr(args, "node", None))
+    if sub == "chat":
+        return _cmd_chat(text=args.text, node=getattr(args, "node", None))
+    if sub == "react":
+        return _cmd_react(emoji=args.emoji, node=getattr(args, "node", None))
     if sub == "stop":
         return _cmd_stop()
     if sub == "node":
@@ -445,6 +457,66 @@ def _cmd_say(text: str, node: Optional[str] = None) -> int:
         return 0 if res.get("ok") else 1
 
     res = pm.enqueue_say(text)
+    print(json.dumps(res, indent=2))
+    return 0 if res.get("ok") else 1
+
+
+def _cmd_chat(text: str, node: Optional[str] = None) -> int:
+    if not (text or "").strip():
+        print("refusing: empty text")
+        return 2
+    if node:
+        try:
+            from plugins.google_meet.node.registry import NodeRegistry
+            from plugins.google_meet.node.client import NodeClient
+        except ImportError as e:
+            print(f"node module unavailable: {e}")
+            return 1
+        reg = NodeRegistry()
+        entry = reg.resolve(node if node != "auto" else None)
+        if entry is None:
+            print(f"no registered node matches {node!r}")
+            return 1
+        client = NodeClient(url=entry["url"], token=entry["token"])
+        try:
+            res = client.chat(text)
+        except Exception as e:
+            print(f"remote chat failed: {e}")
+            return 1
+        print(json.dumps({"node": entry.get("name"), **res}, indent=2))
+        return 0 if res.get("ok") else 1
+
+    res = pm.enqueue_chat(text)
+    print(json.dumps(res, indent=2))
+    return 0 if res.get("ok") else 1
+
+
+def _cmd_react(emoji: str, node: Optional[str] = None) -> int:
+    if not (emoji or "").strip():
+        print("refusing: empty emoji")
+        return 2
+    if node:
+        try:
+            from plugins.google_meet.node.registry import NodeRegistry
+            from plugins.google_meet.node.client import NodeClient
+        except ImportError as e:
+            print(f"node module unavailable: {e}")
+            return 1
+        reg = NodeRegistry()
+        entry = reg.resolve(node if node != "auto" else None)
+        if entry is None:
+            print(f"no registered node matches {node!r}")
+            return 1
+        client = NodeClient(url=entry["url"], token=entry["token"])
+        try:
+            res = client.react(emoji)
+        except Exception as e:
+            print(f"remote react failed: {e}")
+            return 1
+        print(json.dumps({"node": entry.get("name"), **res}, indent=2))
+        return 0 if res.get("ok") else 1
+
+    res = pm.enqueue_reaction(emoji)
     print(json.dumps(res, indent=2))
     return 0 if res.get("ok") else 1
 

--- a/plugins/google_meet/meet_bot.py
+++ b/plugins/google_meet/meet_bot.py
@@ -51,6 +51,10 @@ MEET_URL_RE = re.compile(
 
 # Filenames the bot reads/writes in ``HERMES_MEET_OUT_DIR``.
 SAY_QUEUE_FILENAME = "say_queue.jsonl"
+CHAT_QUEUE_FILENAME = "chat_queue.jsonl"
+REACTION_QUEUE_FILENAME = "reaction_queue.jsonl"
+CHAT_DEAD_LETTER_FILENAME = "chat_failed.jsonl"
+REACTION_DEAD_LETTER_FILENAME = "reaction_failed.jsonl"
 SAY_PCM_FILENAME = "speaker.pcm"
 
 
@@ -106,6 +110,9 @@ class _BotState:
         self.audio_bytes_out: int = 0
         self.last_audio_out_at: Optional[float] = None
         self.last_barge_in_at: Optional[float] = None
+        self.last_chat_at: Optional[float] = None
+        self.last_reaction_at: Optional[float] = None
+        self.last_action_error: Optional[str] = None
         self.leave_reason: Optional[str] = None
         # Scraped captions, in order, deduped. Each entry is a dict of
         # {"ts": <epoch>, "speaker": str, "text": str}.
@@ -161,6 +168,9 @@ class _BotState:
             "audioBytesOut": self.audio_bytes_out,
             "lastAudioOutAt": self.last_audio_out_at,
             "lastBargeInAt": self.last_barge_in_at,
+            "lastChatAt": self.last_chat_at,
+            "lastReactionAt": self.last_reaction_at,
+            "lastActionError": self.last_action_error,
             "leaveReason": self.leave_reason,
         }
         tmp = self.status_path.with_suffix(".json.tmp")
@@ -260,6 +270,100 @@ def _enable_captions_js() -> str:
       return true;
     })();
     """
+
+
+def _append_jsonl(path: Path, entries: list[dict]) -> None:
+    """Append JSONL *entries* to *path*. Ignores empty payloads."""
+    if not entries:
+        return
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as fh:
+        for entry in entries:
+            fh.write(json.dumps(entry) + "\n")
+
+
+def _claim_jsonl_queue(path: Path) -> list[dict]:
+    """Atomically move the current JSONL queue aside and parse its entries."""
+    try:
+        if not path.is_file():
+            return []
+        claimed = path.with_name(f"{path.name}.{os.getpid()}.processing")
+        path.replace(claimed)
+    except FileNotFoundError:
+        return []
+    except OSError:
+        return []
+
+    try:
+        path.touch(exist_ok=True)
+    except OSError:
+        pass
+
+    try:
+        raw = claimed.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        raw = ""
+    finally:
+        try:
+            claimed.unlink(missing_ok=True)
+        except OSError:
+            pass
+
+    out = []
+    for line in raw.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            item = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(item, dict):
+            out.append(item)
+    return out
+
+
+def _process_action_queue(
+    *,
+    page,
+    state: _BotState,
+    queue_path: Path,
+    dead_letter_path: Path,
+    payload_key: str,
+    deliver_fn,
+    success_field: str,
+    action_label: str,
+) -> None:
+    """Deliver queued chat/reaction actions with retry + dead-letter handling."""
+    for entry in _claim_jsonl_queue(queue_path):
+        payload = str(entry.get(payload_key, "")).strip()
+        if not payload:
+            continue
+
+        error: Optional[str] = None
+        delivered = False
+        try:
+            delivered = bool(deliver_fn(page, payload))
+            if not delivered:
+                error = f"{action_label} delivery failed"
+        except Exception as exc:  # noqa: BLE001 - status should surface UI failures
+            error = f"{action_label} delivery raised: {exc}"
+
+        if delivered:
+            state.set(**{success_field: time.time(), "last_action_error": None})
+            continue
+
+        attempts = int(entry.get("attempts", 0) or 0) + 1
+        retry_entry = dict(entry)
+        retry_entry["attempts"] = attempts
+        retry_entry["last_error"] = error or f"{action_label} delivery failed"
+        if attempts >= 3:
+            retry_entry["failed_at"] = time.time()
+            _append_jsonl(dead_letter_path, [retry_entry])
+            state.set(last_action_error=f"{action_label} dropped after {attempts} attempts: {retry_entry['last_error']}")
+        else:
+            _append_jsonl(queue_path, [retry_entry])
+            state.set(last_action_error=f"{action_label} queued for retry ({attempts}/3): {retry_entry['last_error']}")
 
 
 def _start_realtime_speaker(
@@ -678,6 +782,28 @@ def run_bot() -> int:  # noqa: C901 — orchestration, explicit branches
                         state.set(leave_reason="page_closed")
                         break
 
+                if state.in_call:
+                    _process_action_queue(
+                        page=page,
+                        state=state,
+                        queue_path=out_dir / CHAT_QUEUE_FILENAME,
+                        dead_letter_path=out_dir / CHAT_DEAD_LETTER_FILENAME,
+                        payload_key="text",
+                        deliver_fn=_send_chat_message,
+                        success_field="last_chat_at",
+                        action_label="chat",
+                    )
+                    _process_action_queue(
+                        page=page,
+                        state=state,
+                        queue_path=out_dir / REACTION_QUEUE_FILENAME,
+                        dead_letter_path=out_dir / REACTION_DEAD_LETTER_FILENAME,
+                        payload_key="emoji",
+                        deliver_fn=_send_reaction,
+                        success_field="last_reaction_at",
+                        action_label="reaction",
+                    )
+
                 # Fold the realtime session's byte/timestamp counters into
                 # the status file so meet_status can surface them.
                 if rt["session"] is not None:
@@ -740,22 +866,14 @@ def _try_guest_name(page, guest_name: str) -> None:
 
 
 def _detect_admission(page) -> bool:
-    """True if we're clearly past the lobby and in the call itself.
-
-    Uses a JS-side probe because Meet's DOM structure varies by client
-    version. We check several high-signal indicators and declare admission
-    on the first hit:
-
-      1. Leave-call button is present (``aria-label`` contains "eave call").
-      2. Caption region has appeared (we installed the observer and it attached).
-      3. The participant list container is visible.
-
-    Conservative by default — returns False on any error.
-    """
+    """True if we're clearly past the lobby and in the call itself."""
     probe = r"""
     (() => {
-      const leave = document.querySelector('button[aria-label*="eave call" i]');
-      if (leave) return true;
+      const body = document.body ? (document.body.innerText || '') : '';
+      const hasText = rx => rx.test(body);
+      const hasButton = label => !!document.querySelector(`button[aria-label*="${label}" i], [role="button"][aria-label*="${label}" i]`);
+
+      if (document.querySelector('button[aria-label*="eave call" i]')) return true;
       if (window.__hermesMeetInstalled) {
         const caps = document.querySelector(
           '[role="region"][aria-label*="aption" i], ' +
@@ -763,8 +881,10 @@ def _detect_admission(page) -> bool:
         );
         if (caps) return true;
       }
-      const parts = document.querySelector('[aria-label*="articipants" i]');
-      if (parts) return true;
+      if (document.querySelector('[aria-label*="articipants" i]')) return true;
+      if (hasButton('Turn off captions') || hasButton('Chat with everyone') || hasButton('Send a reaction')) return true;
+      if (hasText(/You(?:'|’)re in Companion Mode/i)) return true;
+      if (hasText(/You have joined the call/i)) return true;
       return false;
     })();
     """
@@ -794,23 +914,128 @@ def _detect_denied(page) -> bool:
 
 
 def _looks_like_human_speaker(speaker: str, bot_guest_name: str) -> bool:
-    """Whether a caption line's speaker is probably a human, not our bot echo.
-
-    Meet attributes captions to the speaker's display name. When Chrome is
-    reading our fake mic, Meet still attributes captions to *our* bot name
-    (because the bot is the one "speaking"). We don't want those to trigger
-    barge-in. Anything else — real participant names — does.
-
-    Conservative: unknown / blank speakers (common when caption scraping
-    falls back to raw text) do NOT trigger barge-in, because we can't tell
-    whether it was a human or us.
-    """
+    """Whether a caption line's speaker is probably a human, not our bot echo."""
     if not speaker or not speaker.strip():
         return False
     spk = speaker.strip().lower()
     if spk in {"unknown", "you", bot_guest_name.strip().lower()}:
         return False
     return True
+
+
+def _open_chat_panel(page) -> bool:
+    try:
+        btn = page.get_by_role("button", name="Chat with everyone", exact=False).first
+        if btn.count() and btn.is_visible():
+            btn.click(timeout=3_000)
+            page.wait_for_timeout(500)
+            return True
+    except Exception:
+        pass
+    return False
+
+
+def _send_chat_message(page, text: str) -> bool:
+    text = (text or "").strip()
+    if not text:
+        return False
+    if not _open_chat_panel(page):
+        return False
+    selectors = [
+        'textarea[aria-label*="message" i]',
+        'textarea[placeholder*="message" i]',
+        'div[contenteditable="true"][aria-label*="message" i]',
+    ]
+    for selector in selectors:
+        editor = page.locator(selector).first
+        try:
+            if not (editor.count() and editor.is_visible()):
+                continue
+            try:
+                editor.click(timeout=2_000)
+            except Exception:
+                pass
+            try:
+                editor.fill(text, timeout=2_000)
+            except Exception:
+                try:
+                    editor.type(text, timeout=4_000)
+                except Exception:
+                    continue
+            page.keyboard.press("Enter")
+            return True
+        except Exception:
+            continue
+    return False
+
+
+def _reaction_labels(emoji: str) -> list[str]:
+    raw = (emoji or "").strip()
+    norm = raw.lower()
+    if norm in {"👍", "+1", "thumbsup", "thumbs up", "like"}:
+        return ["Thumbs up", "👍", "like"]
+    if norm in {"❤️", "heart", "love"}:
+        return ["Heart", "❤️", "love"]
+    if norm in {"😂", "laugh", "laughing"}:
+        return ["Laugh", "😂"]
+    if norm in {"😮", "wow", "surprised"}:
+        return ["Surprised", "😮", "wow"]
+    if norm in {"😢", "sad", "cry"}:
+        return ["Sad", "😢"]
+    if norm in {"😡", "angry", "dislike"}:
+        return ["Dislike", "😡", "angry"]
+    return [raw]
+
+
+def _send_reaction(page, emoji: str) -> bool:
+    labels = [label for label in _reaction_labels(emoji) if label]
+    if not labels:
+        return False
+    try:
+        btn = page.get_by_role("button", name="Send a reaction", exact=False).first
+        if btn.count() and btn.is_visible():
+            btn.click(timeout=3_000)
+            page.wait_for_timeout(500)
+    except Exception:
+        return False
+
+    for label in labels:
+        try:
+            rb = page.get_by_role("button", name=label, exact=False).first
+            if rb.count() and rb.is_visible():
+                rb.click(timeout=2_000)
+                return True
+        except Exception:
+            continue
+    return False
+
+
+_JOIN_CTA_PRIORITY = (
+    "Join now",
+    "Ask to join",
+    "Use Companion Mode",
+    "Use Companion mode",
+    "Join here too",
+)
+
+
+def _prepare_join_options(page) -> None:
+    """Dismiss pre-join overlays and expand secondary join choices."""
+    for label in ("Got it", "OK"):
+        try:
+            btn = page.get_by_role("button", name=label, exact=False).first
+            if btn.count() and btn.is_visible():
+                btn.click(timeout=3_000)
+                break
+        except Exception:
+            continue
+
+    try:
+        btn = page.get_by_role("button", name="Other ways to join", exact=False).first
+        if btn.count() and btn.is_visible():
+            btn.click(timeout=3_000)
+    except Exception:
+        pass
 
 
 def _click_join_dom_fallback(page) -> Optional[str]:
@@ -890,7 +1115,7 @@ def _click_join_dom_fallback(page) -> Optional[str]:
     })
     '''
     try:
-        clicked = page.evaluate(probe, ["Join now", "Ask to join", "Switch here"])
+        clicked = page.evaluate(probe, list(_JOIN_CTA_PRIORITY))
     except Exception:
         return None
     return str(clicked).strip() if clicked else None
@@ -898,13 +1123,20 @@ def _click_join_dom_fallback(page) -> Optional[str]:
 
 
 def _click_join(page, state: _BotState) -> None:
-    """Click 'Join now' or 'Ask to join' if either button is visible.
+    """Click the safest visible pre-join CTA.
+
+    Preference order matters:
+    - normal join buttons first
+    - Companion mode before Switch here, because Switch here transfers the
+      active call away from another device/session on the same account
 
     Flags ``lobby_waiting`` when we hit the "waiting for host to admit you"
     state so the agent can surface that in status.
     """
+    _prepare_join_options(page)
+
     clicked_label: Optional[str] = None
-    for label in ("Join now", "Ask to join"):
+    for label in _JOIN_CTA_PRIORITY:
         try:
             btn = page.get_by_role("button", name=label, exact=False).first
             if btn.count() and btn.is_visible():

--- a/plugins/google_meet/meet_bot.py
+++ b/plugins/google_meet/meet_bot.py
@@ -813,22 +813,113 @@ def _looks_like_human_speaker(speaker: str, bot_guest_name: str) -> bool:
     return True
 
 
+def _click_join_dom_fallback(page) -> Optional[str]:
+    """Return the clicked join label when a DOM-text fallback succeeds.
+
+    Meet's visible pre-join CTA sometimes isn't discoverable via Playwright's
+    role/name lookup even though the button is plainly rendered on the page.
+    Fall back to DOM text probes that match the live May 2026 Meet markup and
+    walk up to the nearest clickable ancestor.
+    """
+    probe = r'''
+    (labels => {
+      const texts = labels.map(label => String(label || '').trim()).filter(Boolean);
+      const seen = new Set();
+
+      const candidateRoots = [
+        ...document.querySelectorAll('button, [role="button"]'),
+        ...document.querySelectorAll('span[jsname="V67aGc"], div[jsname], span, div')
+      ];
+
+      const norm = value => String(value || '').replace(/\s+/g, ' ').trim();
+      const hasVisibleBox = el => {
+        const rect = el && typeof el.getBoundingClientRect === 'function'
+          ? el.getBoundingClientRect()
+          : null;
+        return !!rect && rect.width > 0 && rect.height > 0;
+      };
+      const isVisible = el => {
+        if (!el || !el.isConnected) return false;
+        const style = window.getComputedStyle(el);
+        if (!style) return false;
+        if (style.display === 'none' || style.visibility === 'hidden' || style.opacity === '0') {
+          return false;
+        }
+        return hasVisibleBox(el);
+      };
+      const clickableAncestor = node => {
+        let cur = node;
+        while (cur) {
+          if ((cur.matches && cur.matches('button, [role="button"]')) || cur.onclick || cur.tabIndex >= 0) {
+            return cur;
+          }
+          cur = cur.parentElement;
+        }
+        return null;
+      };
+
+      for (const node of candidateRoots) {
+        if (!node || seen.has(node)) continue;
+        seen.add(node);
+        const text = norm(node.innerText || node.textContent || '');
+        if (!text) continue;
+        const label = texts.find(target => text === target || text.includes(target));
+        if (!label) continue;
+        const target = clickableAncestor(node) || node;
+        if (!isVisible(target) && !isVisible(node)) continue;
+        try {
+          if (typeof target.scrollIntoView === 'function') {
+            target.scrollIntoView({block: 'center', inline: 'center'});
+          }
+        } catch (_) {}
+        for (const el of [target, node]) {
+          if (!el) continue;
+          try {
+            el.click();
+            return label;
+          } catch (_) {}
+          try {
+            ['pointerdown', 'mousedown', 'pointerup', 'mouseup', 'click'].forEach(type => {
+              el.dispatchEvent(new MouseEvent(type, {bubbles: true, cancelable: true, view: window}));
+            });
+            return label;
+          } catch (_) {}
+        }
+      }
+      return null;
+    })
+    '''
+    try:
+        clicked = page.evaluate(probe, ["Join now", "Ask to join", "Switch here"])
+    except Exception:
+        return None
+    return str(clicked).strip() if clicked else None
+
+
+
 def _click_join(page, state: _BotState) -> None:
     """Click 'Join now' or 'Ask to join' if either button is visible.
 
     Flags ``lobby_waiting`` when we hit the "waiting for host to admit you"
     state so the agent can surface that in status.
     """
+    clicked_label: Optional[str] = None
     for label in ("Join now", "Ask to join"):
         try:
             btn = page.get_by_role("button", name=label, exact=False).first
             if btn.count() and btn.is_visible():
                 btn.click(timeout=3_000)
-                if label == "Ask to join":
-                    state.set(lobby_waiting=True)
+                clicked_label = label
                 break
         except Exception:
             continue
+
+    if clicked_label is None:
+        clicked_label = _click_join_dom_fallback(page)
+
+    if clicked_label == "Ask to join":
+        state.set(lobby_waiting=True)
+
 
 
 def _parse_duration(raw: str) -> Optional[float]:

--- a/plugins/google_meet/node/client.py
+++ b/plugins/google_meet/node/client.py
@@ -103,5 +103,11 @@ class NodeClient:
     def say(self, text: str) -> Dict[str, Any]:
         return self._rpc("say", {"text": str(text)})
 
+    def chat(self, text: str) -> Dict[str, Any]:
+        return self._rpc("chat", {"text": str(text)})
+
+    def react(self, emoji: str) -> Dict[str, Any]:
+        return self._rpc("react", {"emoji": str(emoji)})
+
     def ping(self) -> Dict[str, Any]:
         return self._rpc("ping", {})

--- a/plugins/google_meet/node/protocol.py
+++ b/plugins/google_meet/node/protocol.py
@@ -24,6 +24,8 @@ VALID_REQUEST_TYPES = frozenset({
     "status",
     "transcript",
     "say",
+    "chat",
+    "react",
     "ping",
 })
 

--- a/plugins/google_meet/node/server.py
+++ b/plugins/google_meet/node/server.py
@@ -125,7 +125,7 @@ class NodeServer:
                 kwargs = {
                     k: payload[k]
                     for k in ("url", "guest_name", "duration", "headed",
-                              "auth_state", "session_id", "out_dir")
+                              "auth_state", "session_id", "out_dir", "mode")
                     if k in payload
                 }
                 if "url" not in kwargs:
@@ -143,25 +143,11 @@ class NodeServer:
                 result = pm.transcript(last=last)
                 return _proto.make_response(req_id, result)
             if t == "say":
-                # v2 wiring: enqueue into say_queue.jsonl inside the
-                # active meeting's out_dir when present. The bot-side
-                # consumer is v3+ (for v1 this is a stub returning ok).
-                text = payload.get("text", "")
-                active = pm._read_active()  # type: ignore[attr-defined]
-                enqueued = False
-                if active and active.get("out_dir"):
-                    queue = Path(active["out_dir"]) / "say_queue.jsonl"
-                    try:
-                        queue.parent.mkdir(parents=True, exist_ok=True)
-                        with queue.open("a", encoding="utf-8") as fh:
-                            fh.write(json.dumps({"text": text, "ts": time.time()}) + "\n")
-                        enqueued = True
-                    except OSError:
-                        enqueued = False
-                return _proto.make_response(
-                    req_id,
-                    {"ok": True, "enqueued": enqueued, "text": text},
-                )
+                return _proto.make_response(req_id, pm.enqueue_say(str(payload.get("text", ""))))
+            if t == "chat":
+                return _proto.make_response(req_id, pm.enqueue_chat(str(payload.get("text", ""))))
+            if t == "react":
+                return _proto.make_response(req_id, pm.enqueue_reaction(str(payload.get("emoji", ""))))
         except Exception as exc:  # noqa: BLE001 — surface any pm crash to client
             return _proto.make_error(req_id, f"{type(exc).__name__}: {exc}")
 

--- a/plugins/google_meet/process_manager.py
+++ b/plugins/google_meet/process_manager.py
@@ -22,6 +22,10 @@ from typing import Any, Dict, Optional
 
 from hermes_constants import get_hermes_home
 
+SAY_QUEUE_FILENAME = "say_queue.jsonl"
+CHAT_QUEUE_FILENAME = "chat_queue.jsonl"
+REACTION_QUEUE_FILENAME = "reaction_queue.jsonl"
+
 # File + directory layout (under $HERMES_HOME):
 #
 #   workspace/meetings/
@@ -243,24 +247,16 @@ def transcript(last: Optional[int] = None) -> Dict[str, Any]:
     }
 
 
-def enqueue_say(text: str) -> Dict[str, Any]:
-    """Append a ``say`` request to the active bot's JSONL queue.
-
-    Returns ``{"ok": False, "reason": ...}`` when no meeting is active or
-    the active bot is in transcribe-only mode. Otherwise writes a line to
-    ``<out_dir>/say_queue.jsonl`` that the bot's realtime speaker thread
-    will consume.
-    """
-    import uuid
-
-    text = (text or "").strip()
-    if not text:
-        return {"ok": False, "reason": "text is required"}
-
+def _enqueue_jsonl(
+    payload: Dict[str, Any],
+    *,
+    queue_name: str,
+    require_realtime: bool = False,
+) -> Dict[str, Any]:
     active = _read_active()
     if not active:
         return {"ok": False, "reason": "no active meeting"}
-    if active.get("mode") != "realtime":
+    if require_realtime and active.get("mode") != "realtime":
         return {
             "ok": False,
             "reason": (
@@ -273,16 +269,53 @@ def enqueue_say(text: str) -> Dict[str, Any]:
     if not out_dir.is_dir():
         return {"ok": False, "reason": f"out_dir missing: {out_dir}"}
 
-    queue_path = out_dir / "say_queue.jsonl"
-    entry = {"id": uuid.uuid4().hex[:12], "text": text}
-    with queue_path.open("a", encoding="utf-8") as f:
-        f.write(json.dumps(entry) + "\n")
-    return {
+    queue_path = out_dir / queue_name
+    try:
+        with queue_path.open("a", encoding="utf-8") as f:
+            f.write(json.dumps(payload) + "\n")
+    except OSError as e:
+        return {"ok": False, "reason": f"failed to write {queue_name}: {e}"}
+    res = {
         "ok": True,
         "meetingId": active.get("meeting_id"),
-        "enqueued_id": entry["id"],
         "queue_path": str(queue_path),
     }
+    if "id" in payload:
+        res["enqueued_id"] = payload["id"]
+    return res
+
+
+def enqueue_say(text: str) -> Dict[str, Any]:
+    """Append a ``say`` request to the active bot's JSONL queue."""
+    import uuid
+
+    text = (text or "").strip()
+    if not text:
+        return {"ok": False, "reason": "text is required"}
+    entry = {"id": uuid.uuid4().hex[:12], "text": text}
+    return _enqueue_jsonl(entry, queue_name=SAY_QUEUE_FILENAME, require_realtime=True)
+
+
+def enqueue_chat(text: str) -> Dict[str, Any]:
+    """Append a chat-message request to the active bot's JSONL queue."""
+    import uuid
+
+    text = (text or "").strip()
+    if not text:
+        return {"ok": False, "reason": "text is required"}
+    entry = {"id": uuid.uuid4().hex[:12], "text": text}
+    return _enqueue_jsonl(entry, queue_name=CHAT_QUEUE_FILENAME)
+
+
+def enqueue_reaction(emoji: str) -> Dict[str, Any]:
+    """Append a reaction request to the active bot's JSONL queue."""
+    import uuid
+
+    emoji = (emoji or "").strip()
+    if not emoji:
+        return {"ok": False, "reason": "emoji is required"}
+    entry = {"id": uuid.uuid4().hex[:12], "emoji": emoji}
+    return _enqueue_jsonl(entry, queue_name=REACTION_QUEUE_FILENAME)
 
 
 def stop(*, reason: str = "requested") -> Dict[str, Any]:

--- a/plugins/google_meet/tools.py
+++ b/plugins/google_meet/tools.py
@@ -14,9 +14,15 @@ Tools:
 from __future__ import annotations
 
 import json
+from pathlib import Path
 from typing import Any, Dict, Optional
 
 from plugins.google_meet import process_manager as pm
+
+
+def _default_auth_state() -> Optional[str]:
+    path = Path(pm.get_hermes_home()) / "workspace" / "meetings" / "auth.json"
+    return str(path) if path.is_file() else None
 
 
 # ---------------------------------------------------------------------------
@@ -220,6 +226,40 @@ MEET_SAY_SCHEMA: Dict[str, Any] = {
     },
 }
 
+MEET_CHAT_SCHEMA: Dict[str, Any] = {
+    "name": "meet_chat",
+    "description": (
+        "Send a chat message into the active Meet call. Works in both "
+        "transcribe and realtime meetings once the bot is in-call."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "text": {"type": "string", "description": "Chat message text."},
+            "node": {"type": "string"},
+        },
+        "required": ["text"],
+        "additionalProperties": False,
+    },
+}
+
+MEET_REACT_SCHEMA: Dict[str, Any] = {
+    "name": "meet_react",
+    "description": (
+        "Send a reaction in the active Meet call. Pass an emoji like 👍 or a "
+        "common label like 'thumbs up'."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "emoji": {"type": "string", "description": "Reaction emoji or label."},
+            "node": {"type": "string"},
+        },
+        "required": ["emoji"],
+        "additionalProperties": False,
+    },
+}
+
 
 # ---------------------------------------------------------------------------
 # Handlers
@@ -271,6 +311,7 @@ def handle_meet_join(args: Dict[str, Any], **_kw) -> str:
     res = pm.start(
         url=url,
         headed=bool(args.get("headed", False)),
+        auth_state=_default_auth_state(),
         guest_name=str(args.get("guest_name") or "Hermes Agent"),
         duration=str(args.get("duration")) if args.get("duration") else None,
         mode=mode,
@@ -345,4 +386,40 @@ def handle_meet_say(args: Dict[str, Any], **_kw) -> str:
         except Exception as e:
             return _err(f"remote node say failed: {e}", node=node_name)
     res = pm.enqueue_say(text)
+    return _json({"success": bool(res.get("ok")), **res})
+
+
+def handle_meet_chat(args: Dict[str, Any], **_kw) -> str:
+    text = (args.get("text") or "").strip()
+    if not text:
+        return _err("text is required")
+    try:
+        client, node_name = _resolve_node_client(args.get("node"))
+    except RuntimeError as e:
+        return _err(str(e))
+    if client is not None:
+        try:
+            res = client.chat(text)
+            return _json({"success": bool(res.get("ok")), "node": node_name, **res})
+        except Exception as e:
+            return _err(f"remote node chat failed: {e}", node=node_name)
+    res = pm.enqueue_chat(text)
+    return _json({"success": bool(res.get("ok")), **res})
+
+
+def handle_meet_react(args: Dict[str, Any], **_kw) -> str:
+    emoji = (args.get("emoji") or "").strip()
+    if not emoji:
+        return _err("emoji is required")
+    try:
+        client, node_name = _resolve_node_client(args.get("node"))
+    except RuntimeError as e:
+        return _err(str(e))
+    if client is not None:
+        try:
+            res = client.react(emoji)
+            return _json({"success": bool(res.get("ok")), "node": node_name, **res})
+        except Exception as e:
+            return _err(f"remote node react failed: {e}", node=node_name)
+    res = pm.enqueue_reaction(emoji)
     return _json({"success": bool(res.get("ok")), **res})

--- a/tests/plugins/test_google_meet_node.py
+++ b/tests/plugins/test_google_meet_node.py
@@ -381,42 +381,37 @@ def test_server_handle_request_transcript(tmp_path, monkeypatch):
     assert got["last"] == 5
 
 
-def test_server_handle_request_say_enqueues_when_active(tmp_path, monkeypatch):
+def test_server_handle_request_say_delegates_to_process_manager(tmp_path, monkeypatch):
     from plugins.google_meet.node.server import NodeServer
     from plugins.google_meet.node import protocol
     from plugins.google_meet import process_manager as pm
 
-    out = tmp_path / "meet-out"
-    out.mkdir()
-    monkeypatch.setattr(pm, "_read_active",
-                        lambda: {"pid": 1, "meeting_id": "m", "out_dir": str(out)})
+    monkeypatch.setattr(pm, "enqueue_say", lambda text: {"ok": True, "text": text, "kind": "say"})
 
     s = NodeServer(token_path=tmp_path / "t.json")
     tok = s.ensure_token()
     req = protocol.make_request("say", tok, {"text": "hello"})
     resp = asyncio.run(s._handle_request(req))
     assert resp["type"] == "response"
-    assert resp["payload"]["ok"] is True
-    assert resp["payload"]["enqueued"] is True
-    q = (out / "say_queue.jsonl").read_text(encoding="utf-8").strip().splitlines()
-    assert len(q) == 1
-    assert json.loads(q[0])["text"] == "hello"
+    assert resp["payload"] == {"ok": True, "text": "hello", "kind": "say"}
 
 
-def test_server_handle_request_say_without_active_still_ok(tmp_path, monkeypatch):
+def test_server_handle_request_chat_and_react_delegate_to_process_manager(tmp_path, monkeypatch):
     from plugins.google_meet.node.server import NodeServer
     from plugins.google_meet.node import protocol
     from plugins.google_meet import process_manager as pm
 
-    monkeypatch.setattr(pm, "_read_active", lambda: None)
+    monkeypatch.setattr(pm, "enqueue_chat", lambda text: {"ok": True, "text": text, "kind": "chat"})
+    monkeypatch.setattr(pm, "enqueue_reaction", lambda emoji: {"ok": True, "emoji": emoji, "kind": "react"})
 
     s = NodeServer(token_path=tmp_path / "t.json")
     tok = s.ensure_token()
-    req = protocol.make_request("say", tok, {"text": "hi"})
-    resp = asyncio.run(s._handle_request(req))
-    assert resp["type"] == "response"
-    assert resp["payload"]["ok"] is True
-    assert resp["payload"]["enqueued"] is False
+    chat_req = protocol.make_request("chat", tok, {"text": "hi team"})
+    react_req = protocol.make_request("react", tok, {"emoji": "👍"})
+    chat_resp = asyncio.run(s._handle_request(chat_req))
+    react_resp = asyncio.run(s._handle_request(react_req))
+    assert chat_resp["payload"] == {"ok": True, "text": "hi team", "kind": "chat"}
+    assert react_resp["payload"] == {"ok": True, "emoji": "👍", "kind": "react"}
 
 
 def test_server_handle_request_wraps_pm_exceptions(tmp_path, monkeypatch):
@@ -547,16 +542,20 @@ def test_client_convenience_methods_hit_correct_types(monkeypatch):
     c.status()
     c.transcript(last=3)
     c.say("hi")
+    c.chat("hello chat")
+    c.react("👍")
     c.ping()
 
     types = [t for t, _ in seen]
-    assert types == ["start_bot", "stop", "status", "transcript", "say", "ping"]
+    assert types == ["start_bot", "stop", "status", "transcript", "say", "chat", "react", "ping"]
     # Check specific payload routing
     assert seen[0][1]["url"] == "https://meet.google.com/a-b-c"
     assert seen[0][1]["guest_name"] == "G"
     assert seen[0][1]["duration"] == "10m"
     assert seen[3][1]["last"] == 3
     assert seen[4][1]["text"] == "hi"
+    assert seen[5][1]["text"] == "hello chat"
+    assert seen[6][1]["emoji"] == "👍"
 
 
 def test_client_init_rejects_bad_args():
@@ -673,3 +672,34 @@ def test_cli_status_reports_client_error(capsys, monkeypatch):
     data = json.loads(capsys.readouterr().out.strip())
     assert data["ok"] is False
     assert "connection refused" in data["error"]
+
+
+def test_protocol_valid_request_types_include_chat_and_react():
+    from plugins.google_meet.node import protocol
+
+    assert "chat" in protocol.VALID_REQUEST_TYPES
+    assert "react" in protocol.VALID_REQUEST_TYPES
+
+
+def test_server_handle_request_start_bot_threads_mode(tmp_path, monkeypatch):
+    from plugins.google_meet.node.server import NodeServer
+    from plugins.google_meet.node import protocol
+    from plugins.google_meet import process_manager as pm
+
+    captured = {}
+
+    def fake_start(**kwargs):
+        captured.update(kwargs)
+        return {"ok": True}
+
+    monkeypatch.setattr(pm, "start", fake_start)
+
+    s = NodeServer(token_path=tmp_path / "t.json")
+    tok = s.ensure_token()
+    req = protocol.make_request("start_bot", tok, {
+        "url": "https://meet.google.com/abc-defg-hij",
+        "mode": "realtime",
+    })
+    resp = asyncio.run(s._handle_request(req))
+    assert resp["type"] == "response"
+    assert captured["mode"] == "realtime"

--- a/tests/plugins/test_google_meet_plugin.py
+++ b/tests/plugins/test_google_meet_plugin.py
@@ -684,6 +684,104 @@ def test_detect_denied_returns_false_on_error():
     assert _detect_denied(_FakePage()) is False
 
 
+class _FakeLocator:
+    def __init__(self, *, count=0, visible=False, click_raises=False, clicked=None):
+        self._count = count
+        self._visible = visible
+        self._click_raises = click_raises
+        self._clicked = clicked if clicked is not None else []
+
+    @property
+    def clicked(self):
+        return self._clicked
+
+    @property
+    def first(self):
+        return self
+
+    def count(self):
+        return self._count
+
+    def is_visible(self):
+        return self._visible
+
+    def click(self, timeout=None):
+        if self._click_raises:
+            raise RuntimeError("click failed")
+        self._clicked.append(timeout)
+
+
+class _FakeJoinPage:
+    def __init__(self, locators=None, evaluate_result=None, evaluate_raises=False):
+        self._locators = locators or {}
+        self._evaluate_result = evaluate_result
+        self._evaluate_raises = evaluate_raises
+        self.evaluate_calls = []
+
+    def get_by_role(self, role, name=None, exact=False):
+        return self._locators.get(name, _FakeLocator())
+
+    def evaluate(self, script, arg=None):
+        self.evaluate_calls.append((script, arg))
+        if self._evaluate_raises:
+            raise RuntimeError("evaluate failed")
+        return self._evaluate_result
+
+
+class _FakeState:
+    def __init__(self):
+        self.calls = []
+
+    def set(self, **kwargs):
+        self.calls.append(kwargs)
+
+
+def test_click_join_uses_role_selector_when_available():
+    from plugins.google_meet.meet_bot import _click_join
+
+    locator = _FakeLocator(count=1, visible=True)
+    page = _FakeJoinPage(locators={"Join now": locator})
+    state = _FakeState()
+
+    _click_join(page, state)
+
+    assert locator.clicked == [3_000]
+    assert page.evaluate_calls == []
+    assert state.calls == []
+
+
+def test_click_join_falls_back_to_dom_probe_when_role_lookup_misses():
+    from plugins.google_meet.meet_bot import _click_join
+
+    page = _FakeJoinPage(evaluate_result="Join now")
+    state = _FakeState()
+
+    _click_join(page, state)
+
+    assert len(page.evaluate_calls) == 1
+    _script, labels = page.evaluate_calls[0]
+    assert labels == ["Join now", "Ask to join", "Switch here"]
+    assert state.calls == []
+
+
+def test_click_join_sets_lobby_waiting_when_dom_fallback_hits_ask_to_join():
+    from plugins.google_meet.meet_bot import _click_join
+
+    page = _FakeJoinPage(evaluate_result="Ask to join")
+    state = _FakeState()
+
+    _click_join(page, state)
+
+    assert state.calls == [{"lobby_waiting": True}]
+
+
+def test_click_join_fallback_returns_none_on_evaluate_error():
+    from plugins.google_meet.meet_bot import _click_join_dom_fallback
+
+    page = _FakeJoinPage(evaluate_raises=True)
+    assert _click_join_dom_fallback(page) is None
+
+
 # ---------------------------------------------------------------------------
 # Realtime session counters + cancel_response (barge-in)
 # ---------------------------------------------------------------------------

--- a/tests/plugins/test_google_meet_plugin.py
+++ b/tests/plugins/test_google_meet_plugin.py
@@ -359,7 +359,13 @@ def test_register_wires_tools_cli_and_hook_on_linux():
         plugin.register(_Ctx())
 
     assert set(calls["tools"]) == {
-        "meet_join", "meet_status", "meet_transcript", "meet_leave", "meet_say",
+        "meet_join",
+        "meet_status",
+        "meet_transcript",
+        "meet_leave",
+        "meet_say",
+        "meet_chat",
+        "meet_react",
     }
     assert calls["cli"] == ["meet"]
     assert calls["hooks"] == ["on_session_end"]
@@ -760,7 +766,13 @@ def test_click_join_falls_back_to_dom_probe_when_role_lookup_misses():
 
     assert len(page.evaluate_calls) == 1
     _script, labels = page.evaluate_calls[0]
-    assert labels == ["Join now", "Ask to join", "Switch here"]
+    assert labels == [
+        "Join now",
+        "Ask to join",
+        "Use Companion Mode",
+        "Use Companion mode",
+        "Join here too",
+    ]
     assert state.calls == []
 
 


### PR DESCRIPTION
## Summary
- keep the safer prejoin CTA selection in sync across role-based lookup and DOM fallback, including Companion Mode / Join here too handling and local auth-state propagation
- add in-call chat and reaction support across the local bot, tool surface, CLI, and remote meet-node RPC path
- surface richer Meet action status and queue retry/dead-letter behavior for managed runs

## Problem
PR #29367 originally fixed one part of the Meet join issue: DOM fallback when role-based button lookup misses the visible prejoin CTA.

While extending and validating the managed Meet flow, the scope grew in three directions:
- the safe CTA policy needed to cover same-account second-screen flows more explicitly (`Use Companion Mode`, `Use Companion mode`, `Join here too`) while still avoiding `Switch here`
- the local `meet_join` tool path needed to propagate the saved Meet auth state, not just the CLI path
- once the bot is in-call, Hermes needed a first-class way to send chat messages and reactions, including node-hosted runs

## What changed
### Safer join handling
- centralize prejoin CTA priority in `_JOIN_CTA_PRIORITY`
- run `_prepare_join_options()` before CTA selection to dismiss `Got it` / `OK` overlays and expand `Other ways to join`
- prefer safe options in this order:
  - `Join now`
  - `Ask to join`
  - `Use Companion Mode`
  - `Use Companion mode`
  - `Join here too`
- keep `Switch here` out of the automation candidate list
- use the same ordered CTA list in both role-based lookup and DOM fallback
- extend admission detection for in-call UI variants such as Companion Mode / chat / reaction affordances

### Local auth-state propagation
- thread the saved Meet auth file into the local `meet_join` tool path via `_default_auth_state()` so managed tool runs use the same signed-in state as the CLI path

### Chat + reaction actions
- add `meet_chat` and `meet_react` tools
- add `hermes meet chat` and `hermes meet react` CLI subcommands
- add `NodeClient.chat()` / `NodeClient.react()` and corresponding `chat` / `react` RPC request types on the meet node server
- process queued chat and reaction actions in-call with retry handling and dead-letter files
- surface `lastChatAt`, `lastReactionAt`, and `lastActionError` in Meet status

## Test plan
- `./scripts/run_tests.sh tests/plugins/test_google_meet_plugin.py tests/plugins/test_google_meet_node.py`
  - result locally: `99 passed`
- `python -m py_compile plugins/google_meet/__init__.py plugins/google_meet/cli.py plugins/google_meet/meet_bot.py plugins/google_meet/node/client.py plugins/google_meet/node/protocol.py plugins/google_meet/node/server.py plugins/google_meet/process_manager.py plugins/google_meet/tools.py tests/plugins/test_google_meet_node.py tests/plugins/test_google_meet_plugin.py`

## Notes
This PR now covers both the safer managed join path and the follow-on in-call action surface needed for authenticated / companion-style Meet automation.