### PR TITLE
fix(gateway): recognize markdown files in MEDIA tags

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2159,7 +2159,7 @@ class BasePlatformAdapter(ABC):
         # Extract MEDIA:<path> tags, allowing optional whitespace after the colon
         # and quoted/backticked paths for LLM-formatted outputs.
         media_pattern = re.compile(
-            r'''[`"']?MEDIA:\s*(?P<path>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|(?:~/|/)\S+(?:[^\S\n]+\S+)*?\.(?:png|jpe?g|gif|webp|mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|flac|epub|pdf|zip|rar|7z|docx?|xlsx?|pptx?|txt|csv|apk|ipa)(?=[\s`"',;:)\]}]|$))[`"']?'''
+            r'''[`"']?MEDIA:\s*(?P<path>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|(?:~/|/)\S+(?:[^\S\n]+\S+)*?\.(?:png|jpe?g|gif|webp|mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|flac|epub|pdf|zip|rar|7z|docx?|xlsx?|pptx?|txt|md|csv|apk|ipa)(?=[\s`"',;:)\]}]|$))[`"']?'''
         )
         for match in media_pattern.finditer(content):
             path = match.group("path").strip()

--- a/tests/gateway/test_base_media_document_extensions.py
+++ b/tests/gateway/test_base_media_document_extensions.py
@@ -1,0 +1,11 @@
+from gateway.platforms.base import BasePlatformAdapter
+
+
+def test_extract_media_accepts_markdown_files():
+    content = "Report attached\nMEDIA:/tmp/example_report.md"
+
+    media, cleaned = BasePlatformAdapter.extract_media(content)
+
+    assert media == [("/tmp/example_report.md", False)]
+    assert "MEDIA:" not in cleaned
+    assert cleaned == "Report attached"


### PR DESCRIPTION
## Summary
- Add `.md` to the `MEDIA:` attachment extension allowlist.
- Add a regression test that verifies markdown files are extracted as native media attachments instead of remaining in visible text.

## Why this matters
Today, `MEDIA:/path/to/report.md` is not recognized by the `MEDIA:` parser even though Hermes documents `MEDIA:` as supporting local files and the gateway document path can upload markdown through `send_document()`.

Without this fix, a generated markdown report is sent as literal text like:

```text
MEDIA:/path/to/report.md
```

For users, that is awkward: the artifact exists locally, but it does not arrive as a downloadable file. The practical workaround is to manually package the markdown into a `.zip` because `.zip` is already in the allowlist. That adds friction for a common agent workflow: generate a report as markdown and send it back through a messaging gateway.

This keeps `.md` behavior consistent with other document extensions already supported by `MEDIA:` such as `.txt`, `.pdf`, `.docx`, and `.zip`.

## Test Plan
- `python -m pytest tests/gateway/test_base_media_document_extensions.py -q -o 'addopts='`
- `git diff --check`
