### PR TITLE
fix(dashboard): support categorized plugin names

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -4316,13 +4316,26 @@ async def post_agent_plugin_install(request: Request, body: _AgentPluginInstallB
 
 
 def _validate_plugin_name(name: str) -> str:
-    """Reject path-traversal attempts in plugin name URL parameters."""
-    if not name or "/" in name or "\\" in name or ".." in name:
+    """Validate a plugin identifier from a URL path parameter.
+
+    Plugin identifiers may be categorized (for example
+    ``observability/langfuse``), so forward slashes are valid separators.  Each
+    segment still has to be a plain name segment: no empty segments, absolute
+    paths, backslashes, or traversal markers.
+    """
+    import re
+
+    if not name or "\\" in name or name.startswith("/") or name.endswith("/"):
+        raise HTTPException(status_code=400, detail="Invalid plugin name.")
+    segments = name.split("/")
+    if any(segment in {"", ".", ".."} for segment in segments):
+        raise HTTPException(status_code=400, detail="Invalid plugin name.")
+    if any(not re.fullmatch(r"[A-Za-z0-9_.-]+", segment) for segment in segments):
         raise HTTPException(status_code=400, detail="Invalid plugin name.")
     return name
 
 
-@app.post("/api/dashboard/agent-plugins/{name}/enable")
+@app.post("/api/dashboard/agent-plugins/{name:path}/enable")
 async def post_agent_plugin_enable(request: Request, name: str):
     _require_token(request)
     name = _validate_plugin_name(name)
@@ -4334,7 +4347,7 @@ async def post_agent_plugin_enable(request: Request, name: str):
     return result
 
 
-@app.post("/api/dashboard/agent-plugins/{name}/disable")
+@app.post("/api/dashboard/agent-plugins/{name:path}/disable")
 async def post_agent_plugin_disable(request: Request, name: str):
     _require_token(request)
     name = _validate_plugin_name(name)
@@ -4346,7 +4359,7 @@ async def post_agent_plugin_disable(request: Request, name: str):
     return result
 
 
-@app.post("/api/dashboard/agent-plugins/{name}/update")
+@app.post("/api/dashboard/agent-plugins/{name:path}/update")
 async def post_agent_plugin_update(request: Request, name: str):
     _require_token(request)
     name = _validate_plugin_name(name)
@@ -4359,7 +4372,7 @@ async def post_agent_plugin_update(request: Request, name: str):
     return result
 
 
-@app.delete("/api/dashboard/agent-plugins/{name}")
+@app.delete("/api/dashboard/agent-plugins/{name:path}")
 async def delete_agent_plugin(request: Request, name: str):
     _require_token(request)
     name = _validate_plugin_name(name)
@@ -4397,7 +4410,7 @@ class _PluginVisibilityBody(BaseModel):
     hidden: bool
 
 
-@app.post("/api/dashboard/plugins/{name}/visibility")
+@app.post("/api/dashboard/plugins/{name:path}/visibility")
 async def post_plugin_visibility(request: Request, name: str, body: _PluginVisibilityBody):
     """Toggle a plugin's sidebar visibility (persists to config.yaml dashboard.hidden_plugins)."""
     _require_token(request)

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -1937,6 +1937,63 @@ class TestPluginAPIAuth:
             pass
 
 
+class TestDashboardAgentPluginRoutes:
+    """Tests for dashboard agent-plugin mutation endpoints."""
+
+    @pytest.fixture(autouse=True)
+    def _setup_test_client(self, monkeypatch, _isolate_hermes_home):
+        try:
+            from starlette.testclient import TestClient
+        except ImportError:
+            pytest.skip("fastapi/starlette not installed")
+
+        import hermes_state
+        from hermes_constants import get_hermes_home
+        from hermes_cli.web_server import app, _SESSION_HEADER_NAME, _SESSION_TOKEN
+
+        monkeypatch.setattr(hermes_state, "DEFAULT_DB_PATH", get_hermes_home() / "state.db")
+        self.client = TestClient(app)
+        self.client.headers[_SESSION_HEADER_NAME] = _SESSION_TOKEN
+
+    def test_enable_plugin_route_accepts_categorized_plugin_names(self, monkeypatch):
+        """Plugins such as ``observability/langfuse`` must be enableable from the dashboard.
+
+        The frontend URL-encodes the slash as ``%2F``.  FastAPI/Starlette decodes
+        it before route matching, so the backend route must explicitly accept a
+        path-like plugin name instead of returning 405 Method Not Allowed.
+        """
+        import hermes_cli.plugins_cmd as plugins_cmd
+
+        seen = []
+
+        def fake_set_enabled(name, enabled):
+            seen.append((name, enabled))
+            return {"ok": True, "name": name, "unchanged": False}
+
+        monkeypatch.setattr(
+            plugins_cmd,
+            "dashboard_set_agent_plugin_enabled",
+            fake_set_enabled,
+        )
+
+        resp = self.client.post(
+            "/api/dashboard/agent-plugins/observability%2Flangfuse/enable"
+        )
+
+        assert resp.status_code == 200
+        assert resp.json()["name"] == "observability/langfuse"
+        assert seen == [("observability/langfuse", True)]
+
+    def test_plugin_name_validation_rejects_traversal_even_with_path_segments(self):
+        from hermes_cli.web_server import _validate_plugin_name
+        from fastapi import HTTPException
+
+        assert _validate_plugin_name("observability/langfuse") == "observability/langfuse"
+        for bad in ("../langfuse", "observability/../langfuse", "/absolute", "trailing/", "bad\\name"):
+            with pytest.raises(HTTPException):
+                _validate_plugin_name(bad)
+
+
 class TestDashboardPluginManifestExtensions:
     """Tests for the extended plugin manifest fields (tab.override,
     tab.hidden, slots) read by _discover_dashboard_plugins()."""


### PR DESCRIPTION
## What does this PR do?

Fixes dashboard runtime actions for category-namespaced plugin IDs such as `observability/langfuse`, `browser/browser_use`, and `model-providers/openrouter`.

The dashboard frontend correctly URL-encodes plugin names before calling the API, so `observability/langfuse` becomes `observability%2Flangfuse`. FastAPI/Starlette decodes `%2F` before route matching, so the existing single-segment route:

```py
/api/dashboard/agent-plugins/{name}/enable
```

does not match:

```http
POST /api/dashboard/agent-plugins/observability%2Flangfuse/enable
```

That request fell through to the SPA fallback and returned `405 Method Not Allowed` instead of reaching the enable handler.

This PR switches dashboard plugin mutation routes to path-style parameters and keeps path traversal protection by validating each slash-separated plugin-name segment.

## Related Issue

No existing issue found. Reproduced from a live dashboard failure and covered by regression tests in this PR.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/web_server.py`
  - Use `{name:path}` for dashboard agent-plugin mutation routes:
    - enable
    - disable
    - update
    - delete
  - Use `{name:path}` for dashboard plugin visibility mutations.
  - Update `_validate_plugin_name()` to allow safe slash-separated category names while rejecting:
    - empty names/segments
    - absolute/trailing-slash paths
    - backslashes
    - `.` / `..` traversal segments
    - non-name characters outside `[A-Za-z0-9_.-]`
- `tests/hermes_cli/test_web_server.py`
  - Add regression coverage for `POST /api/dashboard/agent-plugins/observability%2Flangfuse/enable`.
  - Add validation coverage for safe slash-separated plugin IDs and traversal rejection.

## How to Test

1. Start the dashboard and open the Plugins page.
2. Try enabling a slash-named bundled plugin such as `observability/langfuse`.
3. Before this fix, the request returns `405 Method Not Allowed`; after this fix, the request reaches the runtime enable handler.

Local regression command run after rebasing onto latest `origin/main`:

```bash
python -m pytest \
  tests/hermes_cli/test_web_server.py::TestPluginAPIAuth \
  tests/hermes_cli/test_web_server.py::TestDashboardAgentPluginRoutes \
  tests/hermes_cli/test_web_server.py::TestDashboardPluginManifestExtensions \
  -q -o 'addopts='
```

Result:

```text
14 passed in 3.51s
```

Additional local check:

```bash
python scripts/check-windows-footguns.py --diff origin/main
```

Result:

```text
✓ No Windows footguns found (2 file(s) scanned).
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux / Ubuntu 24.04-compatible host

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A — this PR does not add or modify a skill.

## Screenshots / Logs

The regression is covered by `TestDashboardAgentPluginRoutes::test_enable_plugin_route_accepts_categorized_plugin_names`, which asserts that the URL-encoded slash path reaches `dashboard_set_agent_plugin_enabled("observability/langfuse", enabled=True)` instead of returning 405.
