### PR TITLE
fix(tests): update plugin registry count for xAI + fix hangup test xdist flake

### DIFF
--- a/tests/hermes_cli/test_update_hangup_protection.py
+++ b/tests/hermes_cli/test_update_hangup_protection.py
@@ -213,8 +213,12 @@ class TestInstallHangupProtection:
         try:
             # On Windows (no SIGHUP) we still wrap stdio and create the log.
             assert state["installed"] is True
-            assert isinstance(sys.stdout, _UpdateOutputStream)
-            assert isinstance(sys.stderr, _UpdateOutputStream)
+            # Use type-name check instead of isinstance to avoid xdist
+            # double-import race (editable install + sys.path.insert in
+            # conftest can load hermes_cli.main twice, producing two
+            # distinct _UpdateOutputStream class objects).
+            assert type(sys.stdout).__name__ == "_UpdateOutputStream"
+            assert type(sys.stderr).__name__ == "_UpdateOutputStream"
             assert state["log_file"] is not None
 
             sys.stdout.write("checking mirror\n")

--- a/tests/plugins/web/test_web_search_provider_plugins.py
+++ b/tests/plugins/web/test_web_search_provider_plugins.py
@@ -70,9 +70,9 @@ def _isolate_env(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 class TestBundledPluginsRegister:
-    """All seven bundled web plugins discover and register correctly."""
+    """All bundled web plugins discover and register correctly."""
 
-    def test_all_seven_plugins_present_in_registry(self) -> None:
+    def test_all_plugins_present_in_registry(self) -> None:
         _ensure_plugins_loaded()
         from agent.web_search_registry import list_providers
 
@@ -85,6 +85,7 @@ class TestBundledPluginsRegister:
             "parallel",
             "searxng",
             "tavily",
+            "xai",
         ]
 
     @pytest.mark.parametrize(
@@ -100,6 +101,7 @@ class TestBundledPluginsRegister:
             # disabled in the migration (fell through to a legacy inline
             # path); the follow-up commit enabled it natively.
             ("firecrawl", True, True, True),
+            ("xai", True, False, False),
         ],
     )
     def test_capability_flags_match_spec(
@@ -120,7 +122,7 @@ class TestBundledPluginsRegister:
 
     @pytest.mark.parametrize(
         "plugin_name",
-        ["brave-free", "ddgs", "searxng", "exa", "parallel", "tavily", "firecrawl"],
+        ["brave-free", "ddgs", "searxng", "exa", "parallel", "tavily", "firecrawl", "xai"],
     )
     def test_each_plugin_has_name_and_display_name(self, plugin_name: str) -> None:
         _ensure_plugins_loaded()
@@ -133,7 +135,7 @@ class TestBundledPluginsRegister:
 
     @pytest.mark.parametrize(
         "plugin_name",
-        ["brave-free", "ddgs", "searxng", "exa", "parallel", "tavily", "firecrawl"],
+        ["brave-free", "ddgs", "searxng", "exa", "parallel", "tavily", "firecrawl", "xai"],
     )
     def test_each_plugin_has_setup_schema(self, plugin_name: str) -> None:
         """``get_setup_schema()`` returns a dict the picker can consume."""


### PR DESCRIPTION
## Problem

Two test failures are present on `main` and cause every PR's CI to show red:

1. `test_all_seven_plugins_present_in_registry` — asserts exactly 7 web plugins, but commit `a0c031299` added xAI web search (now 8).
2. `test_wraps_stdout_and_stderr_with_mirror` — uses `isinstance(sys.stdout, _UpdateOutputStream)` which flakes under `pytest -n auto` due to a double-import race between editable install and `conftest.py`'s `sys.path.insert(0, PROJECT_ROOT)`.

## Solution

- Add `"xai"` to the expected provider list and all `@pytest.mark.parametrize` lists in `test_web_search_provider_plugins.py`.
- Replace `isinstance()` with `type().__name__` check in `test_update_hangup_protection.py` to avoid the xdist double-import race.

## Changes

- `tests/plugins/web/test_web_search_provider_plugins.py` — update 4 lists (expected providers, capability flags, name check, schema check) from 7 → 8 plugins.
- `tests/hermes_cli/test_update_hangup_protection.py` — use `type(sys.stdout).__name__ == "_UpdateOutputStream"` instead of `isinstance()`.

## How to test

```bash
python -m pytest \
  tests/plugins/web/test_web_search_provider_plugins.py::TestBundledPluginsRegister \
  tests/hermes_cli/test_update_hangup_protection.py::TestInstallHangupProtection::test_wraps_stdout_and_stderr_with_mirror \
  -xvs -n auto
```