### PR TITLE
fix(tui): darken diff highlights on dark themes

### DIFF
--- a/tests/hermes_cli/test_update_hangup_protection.py
+++ b/tests/hermes_cli/test_update_hangup_protection.py
@@ -212,9 +212,14 @@ class TestInstallHangupProtection:
 
         try:
             # On Windows (no SIGHUP) we still wrap stdio and create the log.
+            # Assert the wrapper contract rather than exact class identity:
+            # other tests may reload hermes_cli.main under xdist, giving the
+            # same class name/module a different object identity.
             assert state["installed"] is True
-            assert isinstance(sys.stdout, _UpdateOutputStream)
-            assert isinstance(sys.stderr, _UpdateOutputStream)
+            assert sys.stdout is not prev_out
+            assert sys.stderr is not prev_err
+            assert getattr(sys.stdout, "_original", None) is prev_out
+            assert getattr(sys.stderr, "_original", None) is prev_err
             assert state["log_file"] is not None
 
             sys.stdout.write("checking mirror\n")

--- a/tests/plugins/web/test_web_search_provider_plugins.py
+++ b/tests/plugins/web/test_web_search_provider_plugins.py
@@ -2,8 +2,8 @@
 
 Covers:
 
-- All seven bundled plugins (brave-free, ddgs, searxng, exa, parallel,
-  tavily, firecrawl) instantiate and self-report the expected
+- All eight bundled plugins (brave-free, ddgs, searxng, exa, parallel,
+  tavily, firecrawl, xai) instantiate and self-report the expected
   capabilities + ABC-derived defaults.
 - Each plugin's ``is_available()`` correctly reflects env-var presence.
 - The web_search_registry resolves an active provider in the documented
@@ -47,6 +47,8 @@ def _clear_web_env(monkeypatch: pytest.MonkeyPatch) -> None:
         "FIRECRAWL_GATEWAY_URL",
         "TOOL_GATEWAY_DOMAIN",
         "TOOL_GATEWAY_USER_TOKEN",
+        "XAI_API_KEY",
+        "XAI_BASE_URL",
     ):
         monkeypatch.delenv(k, raising=False)
 
@@ -70,9 +72,9 @@ def _isolate_env(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 class TestBundledPluginsRegister:
-    """All seven bundled web plugins discover and register correctly."""
+    """All bundled web plugins discover and register correctly."""
 
-    def test_all_seven_plugins_present_in_registry(self) -> None:
+    def test_all_bundled_plugins_present_in_registry(self) -> None:
         _ensure_plugins_loaded()
         from agent.web_search_registry import list_providers
 
@@ -85,6 +87,7 @@ class TestBundledPluginsRegister:
             "parallel",
             "searxng",
             "tavily",
+            "xai",
         ]
 
     @pytest.mark.parametrize(
@@ -96,6 +99,7 @@ class TestBundledPluginsRegister:
             ("exa", True, True, False),
             ("parallel", True, True, False),
             ("tavily", True, True, True),
+            ("xai", True, False, False),
             # firecrawl: search + extract + crawl. Crawl was originally
             # disabled in the migration (fell through to a legacy inline
             # path); the follow-up commit enabled it natively.
@@ -120,7 +124,7 @@ class TestBundledPluginsRegister:
 
     @pytest.mark.parametrize(
         "plugin_name",
-        ["brave-free", "ddgs", "searxng", "exa", "parallel", "tavily", "firecrawl"],
+        ["brave-free", "ddgs", "searxng", "exa", "parallel", "tavily", "firecrawl", "xai"],
     )
     def test_each_plugin_has_name_and_display_name(self, plugin_name: str) -> None:
         _ensure_plugins_loaded()
@@ -133,7 +137,7 @@ class TestBundledPluginsRegister:
 
     @pytest.mark.parametrize(
         "plugin_name",
-        ["brave-free", "ddgs", "searxng", "exa", "parallel", "tavily", "firecrawl"],
+        ["brave-free", "ddgs", "searxng", "exa", "parallel", "tavily", "firecrawl", "xai"],
     )
     def test_each_plugin_has_setup_schema(self, plugin_name: str) -> None:
         """``get_setup_schema()`` returns a dict the picker can consume."""

--- a/ui-tui/src/__tests__/theme.test.ts
+++ b/ui-tui/src/__tests__/theme.test.ts
@@ -39,6 +39,41 @@ afterEach(() => {
   vi.resetModules()
 })
 
+function rgb(color: string): [number, number, number] {
+  const hex = color.match(/^#([0-9a-f]{6})$/i)?.[1]
+
+  if (hex) {
+    return [parseInt(hex.slice(0, 2), 16), parseInt(hex.slice(2, 4), 16), parseInt(hex.slice(4, 6), 16)]
+  }
+
+  const channels = color.match(/^rgb\((\d+),(\d+),(\d+)\)$/)?.slice(1).map(Number)
+
+  if (channels?.length === 3) {
+    return channels as [number, number, number]
+  }
+
+  throw new Error(`unsupported test color: ${color}`)
+}
+
+function relativeLuminance(color: string): number {
+  const channel = (v: number) => {
+    const normalized = v / 255
+
+    return normalized <= 0.03928 ? normalized / 12.92 : ((normalized + 0.055) / 1.055) ** 2.4
+  }
+
+  const [red, green, blue] = rgb(color)
+
+  return 0.2126 * channel(red) + 0.7152 * channel(green) + 0.0722 * channel(blue)
+}
+
+function contrastRatio(foreground: string, background: string): number {
+  const fg = relativeLuminance(foreground)
+  const bg = relativeLuminance(background)
+
+  return (Math.max(fg, bg) + 0.05) / (Math.min(fg, bg) + 0.05)
+}
+
 describe('DEFAULT_THEME', () => {
   it('has brand defaults', async () => {
     const { DEFAULT_THEME } = await importThemeWithCleanEnv()
@@ -53,6 +88,26 @@ describe('DEFAULT_THEME', () => {
 
     expect(DEFAULT_THEME.color.primary).toBe('#FFD700')
     expect(DEFAULT_THEME.color.error).toBe('#ef5350')
+  })
+})
+
+describe('diff highlight colors', () => {
+  it('keeps dark-theme diff backgrounds dark with readable foregrounds', async () => {
+    const { DARK_THEME } = await importThemeWithCleanEnv()
+
+    expect(relativeLuminance(DARK_THEME.color.diffAdded)).toBeLessThan(0.15)
+    expect(relativeLuminance(DARK_THEME.color.diffRemoved)).toBeLessThan(0.15)
+    expect(contrastRatio(DARK_THEME.color.diffAddedWord, DARK_THEME.color.diffAdded)).toBeGreaterThanOrEqual(4.5)
+    expect(contrastRatio(DARK_THEME.color.diffRemovedWord, DARK_THEME.color.diffRemoved)).toBeGreaterThanOrEqual(4.5)
+  })
+
+  it('keeps light-theme diff backgrounds light with readable foregrounds', async () => {
+    const { LIGHT_THEME } = await importThemeWithCleanEnv()
+
+    expect(relativeLuminance(LIGHT_THEME.color.diffAdded)).toBeGreaterThan(0.6)
+    expect(relativeLuminance(LIGHT_THEME.color.diffRemoved)).toBeGreaterThan(0.6)
+    expect(contrastRatio(LIGHT_THEME.color.diffAddedWord, LIGHT_THEME.color.diffAdded)).toBeGreaterThanOrEqual(4.0)
+    expect(contrastRatio(LIGHT_THEME.color.diffRemovedWord, LIGHT_THEME.color.diffRemoved)).toBeGreaterThanOrEqual(4.0)
   })
 })
 

--- a/ui-tui/src/theme.ts
+++ b/ui-tui/src/theme.ts
@@ -291,10 +291,15 @@ export const DARK_THEME: Theme = {
     statusCritical: '#FF6B6B',
     selectionBg: '#3a3a55',
 
-    diffAdded: 'rgb(220,255,220)',
-    diffRemoved: 'rgb(255,220,220)',
-    diffAddedWord: 'rgb(36,138,61)',
-    diffRemovedWord: 'rgb(207,34,46)',
+    // Diff line backgrounds are applied to whole added/removed rows in
+    // markdown ```diff fences and inline ==highlights.  Keep dark-theme
+    // backgrounds dark; using GitHub-light-style mint/pink here creates the
+    // large pale blocks shown in dark terminals and makes wrapped diff output
+    // hard to scan.
+    diffAdded: '#0f2e1d',
+    diffRemoved: '#3a1216',
+    diffAddedWord: '#7ee787',
+    diffRemovedWord: '#ffa198',
     shellDollar: '#4dabf7'
   },
 


### PR DESCRIPTION
## Summary
- Darken dark-theme diff row backgrounds so Markdown/diff highlighting no longer renders as large pale green/red blocks in dark terminals.
- Keep added/removed word colors bright enough for readable contrast on the new dark backgrounds.
- Add luminance/contrast regression tests for dark and light diff highlight colors.
- Align stale Python CI expectations with current main: include the bundled xAI web provider in registry tests, include `migrate` in the built-in subcommand fast-path set, and make the hangup-protection stream-wrapper test robust to module reload identity.

## Test Plan
- `cd ui-tui && npm test -- --run src/__tests__/theme.test.ts`
- `uv run --python 3.11 --extra dev python -m pytest tests/plugins/web/test_web_search_provider_plugins.py::TestBundledPluginsRegister tests/hermes_cli/test_startup_plugin_gating.py::test_builtin_set_covers_every_registered_subcommand tests/hermes_cli/test_update_hangup_protection.py::TestInstallHangupProtection::test_wraps_stdout_and_stderr_with_mirror -q -n auto --timeout=30 --timeout-method=signal`
- `uv run --python 3.11 --extra dev python -m ruff check hermes_cli/main.py tests/hermes_cli/test_update_hangup_protection.py tests/plugins/web/test_web_search_provider_plugins.py`
- `git diff --check`
- Earlier full TUI verification before the CI-alignment commit: `cd ui-tui && npm run build --prefix packages/hermes-ink && npm test && npm run type-check`, plus `npm run build`

## Notes
The first CI run failed in repo-wide Python checks unrelated to the color values. The follow-up commit addresses those stale current-base expectations so the PR can be evaluated cleanly on GitHub CI.
