### PR TITLE
fix(homeassistant): cleanup ClientSession when websocket handshake fails

### DIFF
--- a/gateway/platforms/homeassistant.py
+++ b/gateway/platforms/homeassistant.py
@@ -145,44 +145,58 @@ class HomeAssistantAdapter(BasePlatformAdapter):
         self._session = aiohttp.ClientSession(
             timeout=aiohttp.ClientTimeout(total=30)
         )
-        self._ws = await self._session.ws_connect(ws_url, heartbeat=30, timeout=30)
+        # Wrap the whole handshake so that a network error between
+        # ``ws_connect`` and the final ``auth_ok`` / ``subscribe_events``
+        # ack tears down the ``ClientSession`` (and the WebSocket if it
+        # opened) before the exception propagates. Without the wrapper an
+        # error here leaves ``self._session`` open; the next reconnect
+        # attempt then assigns over the live handle and the original
+        # session is garbage-collected with its TCP connection still in
+        # CLOSE_WAIT, surfacing later as cryptic "Session is closed" or
+        # "Connector is closed" errors from aiohttp.
+        try:
+            self._ws = await self._session.ws_connect(ws_url, heartbeat=30, timeout=30)
 
-        # Step 1: Receive auth_required
-        msg = await self._ws.receive_json()
-        if msg.get("type") != "auth_required":
-            logger.error("Expected auth_required, got: %s", msg.get("type"))
+            # Step 1: Receive auth_required
+            msg = await self._ws.receive_json()
+            if msg.get("type") != "auth_required":
+                logger.error("Expected auth_required, got: %s", msg.get("type"))
+                await self._cleanup_ws()
+                return False
+
+            # Step 2: Send auth
+            await self._ws.send_json({
+                "type": "auth",
+                "access_token": self._hass_token,
+            })
+
+            # Step 3: Wait for auth_ok
+            msg = await self._ws.receive_json()
+            if msg.get("type") != "auth_ok":
+                logger.error("Auth failed: %s", msg)
+                await self._cleanup_ws()
+                return False
+
+            # Step 4: Subscribe to state_changed events
+            sub_id = self._next_id()
+            await self._ws.send_json({
+                "id": sub_id,
+                "type": "subscribe_events",
+                "event_type": "state_changed",
+            })
+
+            # Verify subscription acknowledgement
+            msg = await self._ws.receive_json()
+            if not msg.get("success"):
+                logger.error("Failed to subscribe to events: %s", msg)
+                await self._cleanup_ws()
+                return False
+
+            return True
+
+        except Exception:
             await self._cleanup_ws()
-            return False
-
-        # Step 2: Send auth
-        await self._ws.send_json({
-            "type": "auth",
-            "access_token": self._hass_token,
-        })
-
-        # Step 3: Wait for auth_ok
-        msg = await self._ws.receive_json()
-        if msg.get("type") != "auth_ok":
-            logger.error("Auth failed: %s", msg)
-            await self._cleanup_ws()
-            return False
-
-        # Step 4: Subscribe to state_changed events
-        sub_id = self._next_id()
-        await self._ws.send_json({
-            "id": sub_id,
-            "type": "subscribe_events",
-            "event_type": "state_changed",
-        })
-
-        # Verify subscription acknowledgement
-        msg = await self._ws.receive_json()
-        if not msg.get("success"):
-            logger.error("Failed to subscribe to events: %s", msg)
-            await self._cleanup_ws()
-            return False
-
-        return True
+            raise
 
     async def _cleanup_ws(self) -> None:
         """Close WebSocket and session."""

--- a/tests/gateway/test_homeassistant.py
+++ b/tests/gateway/test_homeassistant.py
@@ -587,3 +587,73 @@ class TestWsUrlConstruction:
         adapter = HomeAssistantAdapter(config)
         ws_url = adapter._hass_url.replace("http://", "ws://").replace("https://", "wss://")
         assert ws_url == "wss://ha.example.com"
+
+
+# ---------------------------------------------------------------------------
+# WebSocket handshake lifecycle — failure paths must cleanup ClientSession
+# ---------------------------------------------------------------------------
+
+
+class TestWsConnectLifecycle:
+    """A failure between ``ws_connect`` and the final ``subscribe_events``
+    ack must leave neither a half-open WebSocket nor a leaked
+    ``ClientSession``. Without the wrapper, the next reconnect assigns
+    over ``self._session`` while the old one is still open, eventually
+    surfacing as cryptic ``"Session is closed"`` / ``"Connector is closed"``
+    errors from aiohttp on a later request."""
+
+    @pytest.mark.asyncio
+    async def test_ws_connect_failure_cleans_up_session(self):
+        config = PlatformConfig(enabled=True, token="t", extra={"url": "http://ha:8123"})
+        adapter = HomeAssistantAdapter(config)
+
+        leaked_session = AsyncMock()
+        leaked_session.closed = False
+        leaked_session.ws_connect = AsyncMock(
+            side_effect=ConnectionResetError("simulated reset during handshake")
+        )
+        leaked_session.close = AsyncMock()
+
+        with patch(
+            "gateway.platforms.homeassistant.aiohttp.ClientSession",
+            return_value=leaked_session,
+        ):
+            with pytest.raises(ConnectionResetError):
+                await adapter._ws_connect()
+
+        # Session was closed by the wrapper; adapter no longer holds a
+        # reference to it (the next reconnect won't double-assign).
+        leaked_session.close.assert_awaited()
+        assert adapter._session is None
+        assert adapter._ws is None
+
+    @pytest.mark.asyncio
+    async def test_auth_handshake_failure_cleans_up_ws_and_session(self):
+        """If ws_connect succeeds but a later step (receive_json, send_json)
+        raises, both the WebSocket and the ClientSession get closed."""
+        config = PlatformConfig(enabled=True, token="t", extra={"url": "http://ha:8123"})
+        adapter = HomeAssistantAdapter(config)
+
+        fake_ws = AsyncMock()
+        fake_ws.closed = False
+        fake_ws.close = AsyncMock()
+        fake_ws.receive_json = AsyncMock(
+            side_effect=ConnectionResetError("peer closed mid-handshake")
+        )
+
+        fake_session = AsyncMock()
+        fake_session.closed = False
+        fake_session.ws_connect = AsyncMock(return_value=fake_ws)
+        fake_session.close = AsyncMock()
+
+        with patch(
+            "gateway.platforms.homeassistant.aiohttp.ClientSession",
+            return_value=fake_session,
+        ):
+            with pytest.raises(ConnectionResetError):
+                await adapter._ws_connect()
+
+        fake_ws.close.assert_awaited()
+        fake_session.close.assert_awaited()
+        assert adapter._ws is None
+        assert adapter._session is None


### PR DESCRIPTION
Split out from #29199 per CONTRIBUTING.md ("one logical change per PR"). #29199 now scopes to the env-var split only; this PR is the websocket connection-lifecycle fix it originally bundled.

## Problem

`HomeAssistantAdapter._ws_connect` opens an `aiohttp.ClientSession` and then runs a 4-step handshake (`ws_connect` → `auth_required` → `auth` → `subscribe_events`). Any of those steps can raise — TCP reset, peer-closed-mid-handshake, JSON decode error — but the failure path didn't run `_cleanup_ws()`. The leaked `ClientSession` then bites on the next reconnect attempt: the new attempt assigns over `self._session` while the old one is still open, and the old one is GC'd with its TCP connection still in `CLOSE_WAIT`. Later requests on the new session surface as cryptic `"Session is closed"` or `"Connector is closed"` errors that don't point at the original handshake failure.

## Fix

Wrap the whole handshake in `try` / `except Exception:` so that any error tears down the `ClientSession` (and the `WebSocket` if it opened) via `_cleanup_ws()` before re-raising. `self._ws` and `self._session` are reset to `None`, so the next `_ws_connect` attempt starts from a clean slate.

The `except` block re-raises after cleanup — callers (`connect()`) keep their own broad-`except` that turns this into a return-`False` for the reconnect ladder; cleanup is purely additive.

## Test plan

New `TestWsConnectLifecycle` class in `tests/gateway/test_homeassistant.py` covers both failure points:

- `test_ws_connect_failure_cleans_up_session` — `ClientSession.ws_connect` raises before the handshake starts; session is closed, `self._session` is `None`.
- `test_auth_handshake_failure_cleans_up_ws_and_session` — `ws_connect` succeeds but `receive_json` raises mid-handshake; both the `WebSocket` and the `ClientSession` get closed.

Full file: 47 tests, all green.