### PR TITLE
feat: add project and kanban usage surfaces

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -623,6 +623,15 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
     )
     p_stats.add_argument("--json", action="store_true")
 
+    # --- usage ---
+    p_usage = sub.add_parser(
+        "usage", help="Show token/cost usage by board/task from the project usage ledger",
+    )
+    p_usage.add_argument("--task", dest="task_id", default=None, help="Drill down to a single task id")
+    p_usage.add_argument("--refresh", action="store_true", help="Refresh the derived ledger before reading")
+    p_usage.add_argument("--no-refresh", dest="no_refresh", action="store_true", help="Read existing ledger rows without backfill")
+    p_usage.add_argument("--json", action="store_true")
+
     # --- notify subscribe / list / remove ---
     p_nsub = sub.add_parser(
         "notify-subscribe",
@@ -905,6 +914,7 @@ def kanban_command(args: argparse.Namespace) -> int:
         "daemon":   _cmd_daemon,
         "watch":    _cmd_watch,
         "stats":    _cmd_stats,
+        "usage":   _cmd_usage,
         "log":      _cmd_log,
         "runs":     _cmd_runs,
         "heartbeat": _cmd_heartbeat,
@@ -1857,7 +1867,11 @@ def _cmd_complete(args: argparse.Namespace) -> int:
                 conn, tid,
                 result=args.result,
                 summary=summary,
-                metadata=metadata,
+                metadata=(
+                    __import__("hermes_cli.project_usage_ledger", fromlist=["stamp_usage_metadata"])
+                    .stamp_usage_metadata(metadata, os.environ.get("HERMES_SESSION_ID"))
+                    if os.environ.get("HERMES_KANBAN_TASK") == tid else metadata
+                ),
                 expected_run_id=_worker_run_id_for(tid),
             ):
                 failed.append(tid)
@@ -1909,6 +1923,11 @@ def _cmd_block(args: argparse.Namespace) -> int:
                 tid,
                 reason=reason,
                 expected_run_id=_worker_run_id_for(tid),
+                metadata=(
+                    __import__("hermes_cli.project_usage_ledger", fromlist=["stamp_usage_metadata"])
+                    .stamp_usage_metadata(None, os.environ.get("HERMES_SESSION_ID"))
+                    if os.environ.get("HERMES_KANBAN_TASK") == tid else None
+                ),
             ):
                 failed.append(tid)
                 print(f"cannot block {tid}", file=sys.stderr)
@@ -2241,6 +2260,68 @@ def _cmd_watch(args: argparse.Namespace) -> int:
     except KeyboardInterrupt:
         print("\n(stopped)")
         return 0
+
+
+def _cmd_usage(args: argparse.Namespace) -> int:
+    from hermes_cli import project_usage_ledger as usage
+
+    refresh = bool(getattr(args, "refresh", False)) or not bool(getattr(args, "no_refresh", False))
+    board = getattr(args, "board", None)
+    if board:
+        board = kb._normalize_board_slug(board)
+    data = usage.get_summary(
+        board=board,
+        task_id=getattr(args, "task_id", None),
+        refresh=refresh,
+    )
+    if getattr(args, "json", False):
+        print(json.dumps(data, indent=2, ensure_ascii=False))
+        return 0
+
+    totals = data.get("totals") or {}
+    print("Project usage" + (f" for board {board}" if board else ""))
+    print(f"  ledger: {data.get('ledger_path')}")
+    if data.get("last_backfill_at"):
+        print(f"  refreshed: {_fmt_ts(int(data['last_backfill_at']))}")
+    if data.get("last_backfill_error"):
+        print(f"  warning: {data['last_backfill_error']}")
+    print(
+        "  total: "
+        f"{int(totals.get('input_tokens') or 0)} in / "
+        f"{int(totals.get('output_tokens') or 0)} out / "
+        f"{int(totals.get('reasoning_tokens') or 0)} reasoning / "
+        f"${float(totals.get('estimated_cost_usd') or 0):.4f} est"
+    )
+    print("\nBy board:")
+    for r in data.get("boards") or []:
+        print(
+            f"  {str(r.get('board_slug')):18s} "
+            f"tasks={int(r.get('tasks') or 0):4d} sessions={int(r.get('sessions') or 0):4d} "
+            f"tok={int(r.get('input_tokens') or 0) + int(r.get('output_tokens') or 0):8d} "
+            f"est=${float(r.get('estimated_cost_usd') or 0):.4f}"
+        )
+    tasks = data.get("tasks") or []
+    if tasks:
+        print("\nTop tasks:")
+        for r in tasks[:25]:
+            title = (r.get("task_title") or "")[:60]
+            print(
+                f"  {str(r.get('task_id')):14s} "
+                f"runs={int(r.get('runs') or 0):3d} "
+                f"tok={int(r.get('input_tokens') or 0) + int(r.get('output_tokens') or 0):8d} "
+                f"est=${float(r.get('estimated_cost_usd') or 0):.4f}  {title}"
+            )
+    runs = data.get("runs") or []
+    if runs:
+        print("\nRuns:")
+        for r in runs:
+            print(
+                f"  #{int(r.get('run_id') or 0):4d} {str(r.get('run_outcome') or r.get('run_status') or '-'):12s} "
+                f"session={str(r.get('session_id') or '-')[:20]:20s} "
+                f"tok={int(r.get('input_tokens') or 0) + int(r.get('output_tokens') or 0):8d} "
+                f"est=${float(r.get('estimated_cost_usd') or 0):.4f}"
+            )
+    return 0
 
 
 def _cmd_stats(args: argparse.Namespace) -> int:

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -2981,6 +2981,7 @@ def block_task(
     *,
     reason: Optional[str] = None,
     expected_run_id: Optional[int] = None,
+    metadata: Optional[dict] = None,
 ) -> bool:
     """Transition ``running -> blocked``."""
     with write_txn(conn):
@@ -3017,6 +3018,7 @@ def block_task(
             conn, task_id,
             outcome="blocked", status="blocked",
             summary=reason,
+            metadata=metadata,
         )
         # Synthesize a run when blocking a never-claimed task so the
         # reason is preserved in attempt history.
@@ -3025,6 +3027,7 @@ def block_task(
                 conn, task_id,
                 outcome="blocked",
                 summary=reason,
+                metadata=metadata,
             )
         _append_event(conn, task_id, "blocked", {"reason": reason}, run_id=run_id)
         return True

--- a/hermes_cli/project_usage_ledger.py
+++ b/hermes_cli/project_usage_ledger.py
@@ -1,0 +1,482 @@
+"""Project usage ledger for dashboard-level board/task cost visibility.
+
+The ledger is a derived, idempotently backfilled SQLite database under the
+active Hermes home.  It correlates:
+
+* session usage stored in ``state.db`` (tokens/cost/model/provider), and
+* Kanban board/task/run metadata stored in each board DB.
+
+The source databases remain authoritative; this module only materializes a
+query-friendly view for dashboards and future reporting jobs.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import sqlite3
+import time
+from pathlib import Path
+from typing import Any, Optional
+
+from hermes_constants import get_hermes_home
+from hermes_state import apply_wal_with_fallback
+from hermes_cli import kanban_db
+
+log = logging.getLogger(__name__)
+
+LEDGER_SCHEMA_VERSION = 1
+
+
+SCHEMA_SQL = """
+CREATE TABLE IF NOT EXISTS schema_version (
+    version INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS usage_entries (
+    source_type          TEXT NOT NULL,
+    source_id            TEXT NOT NULL,
+    board_slug           TEXT,
+    board_name           TEXT,
+    task_id              TEXT,
+    task_title           TEXT,
+    task_status          TEXT,
+    run_id               INTEGER,
+    run_status           TEXT,
+    run_outcome          TEXT,
+    session_id           TEXT,
+    session_title        TEXT,
+    session_source       TEXT,
+    user_id              TEXT,
+    model                TEXT,
+    billing_provider     TEXT,
+    billing_mode         TEXT,
+    input_tokens         INTEGER NOT NULL DEFAULT 0,
+    output_tokens        INTEGER NOT NULL DEFAULT 0,
+    cache_read_tokens    INTEGER NOT NULL DEFAULT 0,
+    cache_write_tokens   INTEGER NOT NULL DEFAULT 0,
+    reasoning_tokens     INTEGER NOT NULL DEFAULT 0,
+    api_call_count       INTEGER NOT NULL DEFAULT 0,
+    tool_call_count      INTEGER NOT NULL DEFAULT 0,
+    estimated_cost_usd   REAL,
+    actual_cost_usd      REAL,
+    cost_status          TEXT,
+    started_at           REAL,
+    ended_at             REAL,
+    metadata             TEXT,
+    backfilled_at        REAL NOT NULL,
+    PRIMARY KEY (source_type, source_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_usage_board ON usage_entries(board_slug);
+CREATE INDEX IF NOT EXISTS idx_usage_task ON usage_entries(task_id);
+CREATE INDEX IF NOT EXISTS idx_usage_session ON usage_entries(session_id);
+CREATE INDEX IF NOT EXISTS idx_usage_started ON usage_entries(started_at DESC);
+
+CREATE TABLE IF NOT EXISTS ledger_meta (
+    key TEXT PRIMARY KEY,
+    value TEXT
+);
+"""
+
+
+def ledger_path() -> Path:
+    """Return ``<HERMES_HOME>/usage/project_usage.db``."""
+    return get_hermes_home() / "usage" / "project_usage.db"
+
+
+def state_db_path() -> Path:
+    return get_hermes_home() / "state.db"
+
+
+def connect(path: Optional[Path] = None) -> sqlite3.Connection:
+    p = path or ledger_path()
+    p.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(str(p), isolation_level=None, timeout=30)
+    conn.row_factory = sqlite3.Row
+    apply_wal_with_fallback(conn, db_label=f"project_usage.db ({p.name})")
+    conn.execute("PRAGMA synchronous=NORMAL")
+    conn.executescript(SCHEMA_SQL)
+    existing = conn.execute("SELECT version FROM schema_version LIMIT 1").fetchone()
+    if existing is None:
+        conn.execute("INSERT INTO schema_version(version) VALUES (?)", (LEDGER_SCHEMA_VERSION,))
+    else:
+        conn.execute("UPDATE schema_version SET version = ?", (LEDGER_SCHEMA_VERSION,))
+    return conn
+
+
+def _json_loads(raw: Any) -> dict[str, Any]:
+    if not raw:
+        return {}
+    if isinstance(raw, dict):
+        return raw
+    try:
+        parsed = json.loads(str(raw))
+    except Exception:
+        return {}
+    return parsed if isinstance(parsed, dict) else {}
+
+
+def _get_state_session(conn: sqlite3.Connection, session_id: Optional[str]) -> Optional[sqlite3.Row]:
+    if not session_id:
+        return None
+    return conn.execute("SELECT * FROM sessions WHERE id = ?", (session_id,)).fetchone()
+
+
+def _session_values(row: Optional[sqlite3.Row]) -> dict[str, Any]:
+    if row is None:
+        return {
+            "session_id": None,
+            "session_title": None,
+            "session_source": None,
+            "user_id": None,
+            "model": None,
+            "billing_provider": None,
+            "billing_mode": None,
+            "input_tokens": 0,
+            "output_tokens": 0,
+            "cache_read_tokens": 0,
+            "cache_write_tokens": 0,
+            "reasoning_tokens": 0,
+            "api_call_count": 0,
+            "tool_call_count": 0,
+            "estimated_cost_usd": None,
+            "actual_cost_usd": None,
+            "cost_status": None,
+            "started_at": None,
+            "ended_at": None,
+        }
+    return {
+        "session_id": row["id"],
+        "session_title": row["title"],
+        "session_source": row["source"],
+        "user_id": row["user_id"],
+        "model": row["model"],
+        "billing_provider": row["billing_provider"],
+        "billing_mode": row["billing_mode"],
+        "input_tokens": int(row["input_tokens"] or 0),
+        "output_tokens": int(row["output_tokens"] or 0),
+        "cache_read_tokens": int(row["cache_read_tokens"] or 0),
+        "cache_write_tokens": int(row["cache_write_tokens"] or 0),
+        "reasoning_tokens": int(row["reasoning_tokens"] or 0),
+        "api_call_count": int(row["api_call_count"] or 0),
+        "tool_call_count": int(row["tool_call_count"] or 0),
+        "estimated_cost_usd": row["estimated_cost_usd"],
+        "actual_cost_usd": row["actual_cost_usd"],
+        "cost_status": row["cost_status"],
+        "started_at": row["started_at"],
+        "ended_at": row["ended_at"],
+    }
+
+
+def _upsert_entry(conn: sqlite3.Connection, entry: dict[str, Any]) -> None:
+    cols = [
+        "source_type", "source_id", "board_slug", "board_name", "task_id",
+        "task_title", "task_status", "run_id", "run_status", "run_outcome",
+        "session_id", "session_title", "session_source", "user_id", "model",
+        "billing_provider", "billing_mode", "input_tokens", "output_tokens",
+        "cache_read_tokens", "cache_write_tokens", "reasoning_tokens",
+        "api_call_count", "tool_call_count", "estimated_cost_usd", "actual_cost_usd",
+        "cost_status", "started_at", "ended_at", "metadata", "backfilled_at",
+    ]
+    placeholders = ", ".join(["?"] * len(cols))
+    updates = ", ".join([f"{c}=excluded.{c}" for c in cols if c not in {"source_type", "source_id"}])
+    conn.execute(
+        f"INSERT INTO usage_entries ({', '.join(cols)}) VALUES ({placeholders}) "
+        f"ON CONFLICT(source_type, source_id) DO UPDATE SET {updates}",
+        tuple(entry.get(c) for c in cols),
+    )
+
+
+def backfill(*, ledger_conn: Optional[sqlite3.Connection] = None) -> dict[str, Any]:
+    """Backfill the ledger from current ``state.db`` and all Kanban boards.
+
+    Returns a compact summary with the number of session-only and task-run
+    entries materialized.  The operation is safe to call repeatedly.
+    """
+    owns_conn = ledger_conn is None
+    lconn = ledger_conn or connect()
+    now = time.time()
+    state_path = state_db_path()
+    session_entries = 0
+    run_entries = 0
+    linked_sessions: set[str] = set()
+
+    if not state_path.exists():
+        lconn.execute("INSERT OR REPLACE INTO ledger_meta(key, value) VALUES ('last_backfill_error', ?)", (f"missing state db: {state_path}",))
+        if owns_conn:
+            lconn.close()
+        return {"session_entries": 0, "run_entries": 0, "boards": 0, "ledger_path": str(ledger_path())}
+
+    sconn = sqlite3.connect(str(state_path), timeout=30)
+    sconn.row_factory = sqlite3.Row
+    try:
+        # First materialize all board/task/run usage entries.  A run can link
+        # to a worker session via task_runs.metadata.worker_session_id or to an
+        # originating session via tasks.session_id.
+        boards = kanban_db.list_boards(include_archived=False)
+        for board in boards:
+            slug = board.get("slug") or kanban_db.DEFAULT_BOARD
+            try:
+                kanban_db.init_db(board=slug)
+                kconn = kanban_db.connect(board=slug)
+            except Exception as exc:
+                log.warning("project usage backfill skipped board %s: %s", slug, exc)
+                continue
+            try:
+                rows = kconn.execute(
+                    """
+                    SELECT
+                        r.id AS run_id,
+                        r.task_id AS task_id,
+                        r.status AS run_status,
+                        r.outcome AS run_outcome,
+                        r.started_at AS run_started_at,
+                        r.ended_at AS run_ended_at,
+                        r.metadata AS run_metadata,
+                        t.title AS task_title,
+                        t.status AS task_status,
+                        t.session_id AS task_session_id
+                    FROM task_runs r
+                    LEFT JOIN tasks t ON t.id = r.task_id
+                    ORDER BY r.id
+                    """
+                ).fetchall()
+                for row in rows:
+                    meta = _json_loads(row["run_metadata"])
+                    session_id = (
+                        meta.get("worker_session_id")
+                        or meta.get("session_id")
+                        or row["task_session_id"]
+                    )
+                    if session_id:
+                        linked_sessions.add(str(session_id))
+                    session_row = _get_state_session(sconn, session_id)
+                    values = _session_values(session_row)
+                    _upsert_entry(lconn, {
+                        **values,
+                        "source_type": "task_run",
+                        "source_id": f"{slug}:{row['run_id']}",
+                        "board_slug": slug,
+                        "board_name": board.get("name") or slug,
+                        "task_id": row["task_id"],
+                        "task_title": row["task_title"],
+                        "task_status": row["task_status"],
+                        "run_id": row["run_id"],
+                        "run_status": row["run_status"],
+                        "run_outcome": row["run_outcome"],
+                        "started_at": values.get("started_at") or row["run_started_at"],
+                        "ended_at": values.get("ended_at") or row["run_ended_at"],
+                        "metadata": json.dumps(meta, sort_keys=True) if meta else None,
+                        "backfilled_at": now,
+                    })
+                    run_entries += 1
+            finally:
+                kconn.close()
+
+        # Also materialize raw sessions that were not attributable to a board.
+        for row in sconn.execute("SELECT * FROM sessions ORDER BY started_at"):
+            if row["id"] in linked_sessions:
+                continue
+            values = _session_values(row)
+            _upsert_entry(lconn, {
+                **values,
+                "source_type": "session",
+                "source_id": row["id"],
+                "board_slug": None,
+                "board_name": None,
+                "task_id": None,
+                "task_title": None,
+                "task_status": None,
+                "run_id": None,
+                "run_status": None,
+                "run_outcome": None,
+                "metadata": None,
+                "backfilled_at": now,
+            })
+            session_entries += 1
+
+        lconn.execute(
+            "INSERT OR REPLACE INTO ledger_meta(key, value) VALUES ('last_backfill_at', ?)",
+            (str(now),),
+        )
+        lconn.execute("DELETE FROM ledger_meta WHERE key = 'last_backfill_error'")
+        return {
+            "session_entries": session_entries,
+            "run_entries": run_entries,
+            "boards": len(boards),
+            "ledger_path": str(ledger_path()),
+        }
+    finally:
+        sconn.close()
+        if owns_conn:
+            lconn.close()
+
+
+
+def session_usage_snapshot(session_id: Optional[str]) -> dict[str, Any]:
+    """Return a compact token/cost snapshot for a session id from state.db.
+
+    Intended for embedding into Kanban task_run metadata at terminal
+    transitions.  Missing state/session rows return only ``session_id`` so the
+    ledger can still join/backfill once the session row appears.
+    """
+    if not session_id:
+        return {}
+    snapshot: dict[str, Any] = {"session_id": str(session_id)}
+    p = state_db_path()
+    if not p.exists():
+        return snapshot
+    conn = sqlite3.connect(str(p), timeout=5)
+    conn.row_factory = sqlite3.Row
+    try:
+        row = _get_state_session(conn, str(session_id))
+        if row is None:
+            return snapshot
+        vals = _session_values(row)
+        for key in (
+            "input_tokens", "output_tokens", "cache_read_tokens",
+            "cache_write_tokens", "reasoning_tokens", "api_call_count",
+            "tool_call_count", "estimated_cost_usd", "actual_cost_usd",
+            "cost_status", "model", "billing_provider", "billing_mode",
+            "started_at", "ended_at",
+        ):
+            snapshot[key] = vals.get(key)
+        return snapshot
+    finally:
+        conn.close()
+
+
+def stamp_usage_metadata(metadata: Optional[dict[str, Any]], session_id: Optional[str]) -> Optional[dict[str, Any]]:
+    """Return metadata with worker_session_id + usage_snapshot merged in."""
+    if not session_id:
+        return metadata
+    out = dict(metadata or {})
+    # Trusted dispatcher/tool metadata wins over any user-supplied/spoofed value.
+    out["worker_session_id"] = str(session_id)
+    out["usage_snapshot"] = session_usage_snapshot(str(session_id))
+    return out
+
+def _totals_where(board: Optional[str] = None, task_id: Optional[str] = None) -> tuple[str, list[Any]]:
+    clauses: list[str] = []
+    params: list[Any] = []
+    if board:
+        clauses.append("board_slug = ?")
+        params.append(board)
+    if task_id:
+        clauses.append("task_id = ?")
+        params.append(task_id)
+    return ("WHERE " + " AND ".join(clauses)) if clauses else "", params
+
+
+def get_summary(*, board: Optional[str] = None, task_id: Optional[str] = None, refresh: bool = True) -> dict[str, Any]:
+    """Return dashboard-ready per-board totals and task drilldown rows."""
+    conn = connect()
+    try:
+        if refresh:
+            backfill(ledger_conn=conn)
+        where, params = _totals_where(board, task_id)
+        totals = conn.execute(
+            f"""
+            SELECT
+                COUNT(*) AS entries,
+                COUNT(DISTINCT session_id) AS sessions,
+                COUNT(DISTINCT task_id) AS tasks,
+                COALESCE(SUM(input_tokens), 0) AS input_tokens,
+                COALESCE(SUM(output_tokens), 0) AS output_tokens,
+                COALESCE(SUM(cache_read_tokens), 0) AS cache_read_tokens,
+                COALESCE(SUM(cache_write_tokens), 0) AS cache_write_tokens,
+                COALESCE(SUM(reasoning_tokens), 0) AS reasoning_tokens,
+                COALESCE(SUM(api_call_count), 0) AS api_call_count,
+                COALESCE(SUM(tool_call_count), 0) AS tool_call_count,
+                COALESCE(SUM(estimated_cost_usd), 0.0) AS estimated_cost_usd,
+                COALESCE(SUM(actual_cost_usd), 0.0) AS actual_cost_usd
+            FROM usage_entries
+            {where}
+            """,
+            params,
+        ).fetchone()
+        board_where = "WHERE board_slug = ?" if board else ""
+        board_params: list[Any] = [board] if board else []
+        board_rows = conn.execute(
+            f"""
+            SELECT
+                COALESCE(board_slug, '__unassigned__') AS board_slug,
+                COALESCE(board_name, 'Unassigned sessions') AS board_name,
+                COUNT(*) AS entries,
+                COUNT(DISTINCT task_id) AS tasks,
+                COUNT(DISTINCT session_id) AS sessions,
+                COALESCE(SUM(input_tokens), 0) AS input_tokens,
+                COALESCE(SUM(output_tokens), 0) AS output_tokens,
+                COALESCE(SUM(reasoning_tokens), 0) AS reasoning_tokens,
+                COALESCE(SUM(estimated_cost_usd), 0.0) AS estimated_cost_usd,
+                COALESCE(SUM(actual_cost_usd), 0.0) AS actual_cost_usd,
+                MAX(started_at) AS latest_started_at
+            FROM usage_entries
+            {board_where}
+            GROUP BY COALESCE(board_slug, '__unassigned__'), COALESCE(board_name, 'Unassigned sessions')
+            ORDER BY estimated_cost_usd DESC, input_tokens + output_tokens DESC
+            """,
+            board_params,
+        ).fetchall()
+        task_where = "WHERE task_id IS NOT NULL"
+        task_params: list[Any] = []
+        if board:
+            task_where += " AND board_slug = ?"
+            task_params.append(board)
+        if task_id:
+            task_where += " AND task_id = ?"
+            task_params.append(task_id)
+        task_rows = conn.execute(
+            f"""
+            SELECT
+                board_slug,
+                board_name,
+                task_id,
+                MAX(task_title) AS task_title,
+                MAX(task_status) AS task_status,
+                COUNT(*) AS runs,
+                COUNT(DISTINCT session_id) AS sessions,
+                COALESCE(SUM(input_tokens), 0) AS input_tokens,
+                COALESCE(SUM(output_tokens), 0) AS output_tokens,
+                COALESCE(SUM(reasoning_tokens), 0) AS reasoning_tokens,
+                COALESCE(SUM(estimated_cost_usd), 0.0) AS estimated_cost_usd,
+                COALESCE(SUM(actual_cost_usd), 0.0) AS actual_cost_usd,
+                MIN(started_at) AS first_started_at,
+                MAX(ended_at) AS last_ended_at
+            FROM usage_entries
+            {task_where}
+            GROUP BY board_slug, board_name, task_id
+            ORDER BY estimated_cost_usd DESC, input_tokens + output_tokens DESC
+            LIMIT 500
+            """,
+            task_params,
+        ).fetchall()
+        run_rows: list[sqlite3.Row] = []
+        if task_id:
+            run_where = "task_id = ?"
+            run_params: list[Any] = [task_id]
+            if board:
+                run_where += " AND board_slug = ?"
+                run_params.append(board)
+            run_rows = conn.execute(
+                f"""
+                SELECT * FROM usage_entries
+                WHERE {run_where}
+                ORDER BY COALESCE(started_at, 0) DESC, run_id DESC
+                LIMIT 200
+                """,
+                run_params,
+            ).fetchall()
+        meta = {r["key"]: r["value"] for r in conn.execute("SELECT key, value FROM ledger_meta")}
+        return {
+            "ledger_path": str(ledger_path()),
+            "last_backfill_at": float(meta["last_backfill_at"]) if meta.get("last_backfill_at") else None,
+            "last_backfill_error": meta.get("last_backfill_error"),
+            "totals": dict(totals) if totals else {},
+            "boards": [dict(r) for r in board_rows],
+            "tasks": [dict(r) for r in task_rows],
+            "runs": [dict(r) for r in run_rows],
+        }
+    finally:
+        conn.close()

--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -151,6 +151,19 @@
     return tx(t, key, FALLBACK_DIAGNOSTIC_EVENT_LABELS[kind]);
   }
 
+  function formatCompactNumber(n) {
+    n = Number(n || 0);
+    if (n >= 1000000) return (n / 1000000).toFixed(1).replace(/\.0$/, "") + "M";
+    if (n >= 1000) return (n / 1000).toFixed(1).replace(/\.0$/, "") + "k";
+    return String(Math.round(n));
+  }
+
+  function taskUsageTokens(t) {
+    const u = t && t.usage ? t.usage : null;
+    if (!u) return 0;
+    return Number(u.input_tokens || 0) + Number(u.output_tokens || 0) + Number(u.reasoning_tokens || 0);
+  }
+
   const COLUMN_DOT = {
     triage: "hermes-kanban-dot-triage",
     todo: "hermes-kanban-dot-todo",
@@ -2573,6 +2586,11 @@
               ? h("span", { className: "hermes-kanban-count",
                             title: `${t.link_counts.parents} parent${t.link_counts.parents === 1 ? "" : "s"}, ${t.link_counts.children} child${t.link_counts.children === 1 ? "" : "ren"}. Children stay blocked until their parent is done.` },
                   "↔ ", t.link_counts.parents + t.link_counts.children)
+              : null,
+            taskUsageTokens(t) > 0
+              ? h("span", { className: "hermes-kanban-count hermes-kanban-usage",
+                            title: `Usage: ${taskUsageTokens(t)} tokens, estimated cost $${Number((t.usage && t.usage.estimated_cost_usd) || 0).toFixed(4)}` },
+                  "◈ ", formatCompactNumber(taskUsageTokens(t)))
               : null,
             h("span", { className: "hermes-kanban-ago",
                         title: t.created_at ? `Created ${t.created_at}` : "" },

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -186,6 +186,32 @@ def _comment_dict(c: kanban_db.Comment) -> dict[str, Any]:
     }
 
 
+def _usage_by_task(board_slug: Optional[str], task_ids: list[str]) -> dict[str, dict[str, Any]]:
+    if not task_ids:
+        return {}
+    try:
+        from hermes_cli import project_usage_ledger as usage
+        summary = usage.get_summary(board=board_slug, refresh=True)
+    except Exception as exc:
+        log.debug("kanban usage rollup unavailable: %s", exc)
+        return {}
+    wanted = set(task_ids)
+    out: dict[str, dict[str, Any]] = {}
+    for row in summary.get("tasks") or []:
+        tid = row.get("task_id")
+        if tid in wanted:
+            out[str(tid)] = {
+                "runs": row.get("runs", 0),
+                "sessions": row.get("sessions", 0),
+                "input_tokens": row.get("input_tokens", 0),
+                "output_tokens": row.get("output_tokens", 0),
+                "reasoning_tokens": row.get("reasoning_tokens", 0),
+                "estimated_cost_usd": row.get("estimated_cost_usd", 0.0),
+                "actual_cost_usd": row.get("actual_cost_usd", 0.0),
+            }
+    return out
+
+
 def _run_dict(r: kanban_db.Run) -> dict[str, Any]:
     """Serialise a Run for the drawer's Run history section."""
     return {
@@ -431,7 +457,9 @@ def get_board(
         # window-function query (avoids N+1 ``latest_summary`` calls
         # for boards with hundreds of tasks). Truncated to a card-size
         # preview here — the full text is available via /tasks/:id.
-        summary_map = kanban_db.latest_summaries(conn, [t.id for t in tasks])
+        task_ids = [t.id for t in tasks]
+        summary_map = kanban_db.latest_summaries(conn, task_ids)
+        usage_map = _usage_by_task(board or kanban_db.get_current_board(), task_ids)
 
         for t in tasks:
             full = summary_map.get(t.id)
@@ -442,6 +470,10 @@ def get_board(
             d["link_counts"] = link_counts.get(t.id, {"parents": 0, "children": 0})
             d["comment_count"] = comment_counts.get(t.id, 0)
             d["progress"] = progress.get(t.id)  # None when the task has no children
+            d["usage"] = usage_map.get(t.id, {
+                "runs": 0, "sessions": 0, "input_tokens": 0, "output_tokens": 0,
+                "reasoning_tokens": 0, "estimated_cost_usd": 0.0, "actual_cost_usd": 0.0,
+            })
             diags = diagnostics_per_task.get(t.id)
             if diags:
                 # Full list goes into the payload so the drawer can render
@@ -1629,6 +1661,24 @@ def unsubscribe_home(task_id: str, platform: str, board: Optional[str] = Query(N
         return {"ok": True, "task_id": task_id, "home_channel": home}
     finally:
         conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Usage (token/cost rollups from the project usage ledger)
+# ---------------------------------------------------------------------------
+
+@router.get("/usage")
+def get_usage(
+    board: Optional[str] = Query(None),
+    task_id: Optional[str] = Query(None),
+    refresh: bool = Query(True),
+):
+    board = _resolve_board(board)
+    try:
+        from hermes_cli import project_usage_ledger as usage
+        return usage.get_summary(board=board, task_id=task_id, refresh=refresh)
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=f"usage summary failed: {exc}")
 
 
 # ---------------------------------------------------------------------------

--- a/plugins/project_usage/dashboard/dist/index.js
+++ b/plugins/project_usage/dashboard/dist/index.js
@@ -1,0 +1,225 @@
+(function () {
+  var sdk = window.__HERMES_PLUGIN_SDK__;
+  var registry = window.__HERMES_PLUGINS__;
+  if (!sdk || !registry) return;
+
+  var React = sdk.React;
+  var hooks = sdk.hooks;
+  var fetchJSON = sdk.fetchJSON;
+  var Card = sdk.components.Card;
+  var CardHeader = sdk.components.CardHeader;
+  var CardTitle = sdk.components.CardTitle;
+  var CardContent = sdk.components.CardContent;
+  var Button = sdk.components.Button;
+  var Badge = sdk.components.Badge;
+  var Input = sdk.components.Input;
+  var Select = sdk.components.Select;
+  var SelectOption = sdk.components.SelectOption;
+
+  function h(type, props) {
+    var children = Array.prototype.slice.call(arguments, 2);
+    return React.createElement.apply(React, [type, props || {}].concat(children));
+  }
+
+  function fmtInt(v) {
+    return Number(v || 0).toLocaleString();
+  }
+
+  function fmtUsd(v) {
+    var n = Number(v || 0);
+    if (!Number.isFinite(n)) n = 0;
+    return "$" + n.toFixed(n >= 1 ? 2 : 4);
+  }
+
+  function fmtTs(v) {
+    if (!v) return "—";
+    var ms = Number(v) * 1000;
+    if (!Number.isFinite(ms)) return "—";
+    return new Date(ms).toLocaleString();
+  }
+
+  function tokenTotal(row) {
+    return Number(row.input_tokens || 0) + Number(row.output_tokens || 0) + Number(row.reasoning_tokens || 0);
+  }
+
+  function SummaryCard(props) {
+    return h(Card, { className: "project-usage-card" },
+      h(CardHeader, null, h(CardTitle, null, props.label)),
+      h(CardContent, null,
+        h("div", { className: "project-usage-metric" }, props.value),
+        props.sub ? h("div", { className: "project-usage-muted" }, props.sub) : null
+      )
+    );
+  }
+
+  function ProjectUsagePage() {
+    var _useState = hooks.useState(null), data = _useState[0], setData = _useState[1];
+    var _useState2 = hooks.useState(""), error = _useState2[0], setError = _useState2[1];
+    var _useState3 = hooks.useState(true), loading = _useState3[0], setLoading = _useState3[1];
+    var _useState4 = hooks.useState(""), board = _useState4[0], setBoard = _useState4[1];
+    var _useState5 = hooks.useState(""), taskId = _useState5[0], setTaskId = _useState5[1];
+    var _useState6 = hooks.useState(""), search = _useState6[0], setSearch = _useState6[1];
+
+    var load = hooks.useCallback(function (opts) {
+      opts = opts || {};
+      setLoading(true);
+      setError("");
+      var params = new URLSearchParams();
+      if (board) params.set("board", board);
+      if (taskId) params.set("task_id", taskId);
+      params.set("refresh", opts.refresh === false ? "false" : "true");
+      fetchJSON("/api/plugins/project_usage/summary?" + params.toString())
+        .then(function (json) { setData(json); })
+        .catch(function (err) { setError(String(err && err.message ? err.message : err)); })
+        .finally(function () { setLoading(false); });
+    }, [board, taskId]);
+
+    hooks.useEffect(function () { load({ refresh: true }); }, [load]);
+
+    var boards = data && data.boards ? data.boards : [];
+    var tasks = data && data.tasks ? data.tasks : [];
+    var runs = data && data.runs ? data.runs : [];
+    var totals = data && data.totals ? data.totals : {};
+    var query = search.trim().toLowerCase();
+    var visibleTasks = tasks.filter(function (t) {
+      if (!query) return true;
+      return String(t.task_id || "").toLowerCase().includes(query) ||
+        String(t.task_title || "").toLowerCase().includes(query) ||
+        String(t.board_slug || "").toLowerCase().includes(query);
+    });
+
+    return h("div", { className: "project-usage" },
+      h("div", { className: "project-usage-header" },
+        h("div", null,
+          h("h1", null, "Project Usage"),
+          h("p", null, "Usage ledger under Hermes home, backfilled from state.db and Kanban board metadata.")
+        ),
+        h("div", { className: "project-usage-actions" },
+          h(Button, { onClick: function () { load({ refresh: true }); }, disabled: loading }, loading ? "Refreshing…" : "Refresh ledger")
+        )
+      ),
+
+      error ? h("div", { className: "project-usage-error" }, error) : null,
+
+      h("div", { className: "project-usage-grid" },
+        h(SummaryCard, { label: "Estimated cost", value: fmtUsd(totals.estimated_cost_usd), sub: "actual " + fmtUsd(totals.actual_cost_usd) }),
+        h(SummaryCard, { label: "Input tokens", value: fmtInt(totals.input_tokens), sub: "cache read " + fmtInt(totals.cache_read_tokens) }),
+        h(SummaryCard, { label: "Output tokens", value: fmtInt(totals.output_tokens), sub: "reasoning " + fmtInt(totals.reasoning_tokens) }),
+        h(SummaryCard, { label: "Coverage", value: fmtInt(totals.tasks) + " tasks", sub: fmtInt(totals.sessions) + " sessions / " + fmtInt(totals.entries) + " entries" })
+      ),
+
+      h(Card, null,
+        h(CardHeader, null, h(CardTitle, null, "Filters")),
+        h(CardContent, null,
+          h("div", { className: "project-usage-filters" },
+            h("label", null, "Board",
+              h(Select, {
+                value: board || "__all__",
+                onValueChange: function (v) { setTaskId(""); setBoard(v === "__all__" ? "" : v); },
+                onChange: function (e) { var v = e.target.value; setTaskId(""); setBoard(v === "__all__" ? "" : v); }
+              },
+                h(SelectOption, { value: "__all__" }, "All boards"),
+                boards.filter(function (b) { return b.board_slug !== "__unassigned__"; }).map(function (b) {
+                  return h(SelectOption, { key: b.board_slug, value: b.board_slug }, b.board_name + " (" + b.board_slug + ")");
+                })
+              )
+            ),
+            h("label", null, "Search tasks",
+              h(Input, { value: search, placeholder: "task id/title/board", onChange: function (e) { setSearch(e.target.value); } })
+            ),
+            taskId ? h("div", { className: "project-usage-selected" },
+              h(Badge, null, "Drilldown: " + taskId),
+              h(Button, { onClick: function () { setTaskId(""); } }, "Clear")
+            ) : null
+          )
+        )
+      ),
+
+      h("div", { className: "project-usage-columns" },
+        h(Card, null,
+          h(CardHeader, null, h(CardTitle, null, "Per-board totals")),
+          h(CardContent, null,
+            h("div", { className: "project-usage-table-wrap" },
+              h("table", { className: "project-usage-table" },
+                h("thead", null, h("tr", null,
+                  h("th", null, "Board"), h("th", null, "Tasks"), h("th", null, "Sessions"),
+                  h("th", null, "Tokens"), h("th", null, "Est. cost"), h("th", null, "Latest")
+                )),
+                h("tbody", null,
+                  boards.map(function (b) {
+                    return h("tr", { key: b.board_slug, onClick: function () { if (b.board_slug !== "__unassigned__") { setTaskId(""); setBoard(b.board_slug); } } },
+                      h("td", null, h("strong", null, b.board_name), h("div", { className: "project-usage-muted" }, b.board_slug)),
+                      h("td", null, fmtInt(b.tasks)),
+                      h("td", null, fmtInt(b.sessions)),
+                      h("td", null, fmtInt(tokenTotal(b))),
+                      h("td", null, fmtUsd(b.estimated_cost_usd)),
+                      h("td", null, fmtTs(b.latest_started_at))
+                    );
+                  })
+                )
+              )
+            )
+          )
+        ),
+
+        h(Card, null,
+          h(CardHeader, null, h(CardTitle, null, "Per-task drilldown")),
+          h(CardContent, null,
+            h("div", { className: "project-usage-table-wrap" },
+              h("table", { className: "project-usage-table" },
+                h("thead", null, h("tr", null,
+                  h("th", null, "Task"), h("th", null, "Board"), h("th", null, "Runs"),
+                  h("th", null, "Tokens"), h("th", null, "Est. cost"), h("th", null, "Last ended")
+                )),
+                h("tbody", null,
+                  visibleTasks.map(function (t) {
+                    return h("tr", { key: t.board_slug + ":" + t.task_id, onClick: function () { setBoard(t.board_slug || ""); setTaskId(t.task_id); } },
+                      h("td", null, h("strong", null, t.task_title || t.task_id), h("div", { className: "project-usage-muted" }, t.task_id + " · " + (t.task_status || "unknown"))),
+                      h("td", null, t.board_name || t.board_slug || "—"),
+                      h("td", null, fmtInt(t.runs)),
+                      h("td", null, fmtInt(tokenTotal(t))),
+                      h("td", null, fmtUsd(t.estimated_cost_usd)),
+                      h("td", null, fmtTs(t.last_ended_at))
+                    );
+                  })
+                )
+              )
+            )
+          )
+        )
+      ),
+
+      taskId ? h(Card, null,
+        h(CardHeader, null, h(CardTitle, null, "Run/session rows for " + taskId)),
+        h(CardContent, null,
+          h("div", { className: "project-usage-table-wrap" },
+            h("table", { className: "project-usage-table" },
+              h("thead", null, h("tr", null,
+                h("th", null, "Run"), h("th", null, "Session"), h("th", null, "Model"),
+                h("th", null, "Tokens"), h("th", null, "Est. cost"), h("th", null, "Status")
+              )),
+              h("tbody", null,
+                runs.map(function (r) {
+                  return h("tr", { key: r.source_id },
+                    h("td", null, r.run_id || "—"),
+                    h("td", null, h("div", null, r.session_title || r.session_id || "unlinked"), h("div", { className: "project-usage-muted" }, r.session_id || "—")),
+                    h("td", null, r.model || "—"),
+                    h("td", null, fmtInt(tokenTotal(r))),
+                    h("td", null, fmtUsd(r.estimated_cost_usd)),
+                    h("td", null, (r.run_status || "—") + (r.run_outcome ? " / " + r.run_outcome : ""))
+                  );
+                })
+              )
+            )
+          )
+        )
+      ) : null,
+
+      data ? h("div", { className: "project-usage-footer" },
+        "Ledger: " + data.ledger_path + " · Last backfill: " + fmtTs(data.last_backfill_at)
+      ) : null
+    );
+  }
+
+  registry.register("project_usage", ProjectUsagePage);
+})();

--- a/plugins/project_usage/dashboard/dist/style.css
+++ b/plugins/project_usage/dashboard/dist/style.css
@@ -1,0 +1,116 @@
+.project-usage {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 1rem;
+}
+
+.project-usage-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.project-usage-header h1 {
+  margin: 0;
+  font-size: 1.5rem;
+  font-weight: 700;
+}
+
+.project-usage-header p,
+.project-usage-muted,
+.project-usage-footer {
+  color: hsl(var(--muted-foreground, 240 3.8% 46.1%));
+  font-size: 0.85rem;
+}
+
+.project-usage-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(190px, 1fr));
+  gap: 0.75rem;
+}
+
+.project-usage-metric {
+  font-size: 1.5rem;
+  font-weight: 700;
+}
+
+.project-usage-filters {
+  display: grid;
+  grid-template-columns: minmax(220px, 1fr) minmax(220px, 1fr) auto;
+  gap: 0.75rem;
+  align-items: end;
+}
+
+.project-usage-filters label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  font-size: 0.8rem;
+  font-weight: 600;
+}
+
+.project-usage-selected,
+.project-usage-actions {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.project-usage-columns {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(360px, 1fr));
+  gap: 1rem;
+}
+
+.project-usage-table-wrap {
+  overflow-x: auto;
+}
+
+.project-usage-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.85rem;
+}
+
+.project-usage-table th,
+.project-usage-table td {
+  padding: 0.55rem 0.6rem;
+  border-bottom: 1px solid hsl(var(--border, 240 5.9% 90%));
+  text-align: left;
+  vertical-align: top;
+}
+
+.project-usage-table th {
+  color: hsl(var(--muted-foreground, 240 3.8% 46.1%));
+  font-weight: 700;
+  white-space: nowrap;
+}
+
+.project-usage-table tbody tr {
+  cursor: pointer;
+}
+
+.project-usage-table tbody tr:hover {
+  background: hsl(var(--muted, 240 4.8% 95.9%) / 0.45);
+}
+
+.project-usage-error {
+  border: 1px solid hsl(var(--destructive, 0 84.2% 60.2%));
+  color: hsl(var(--destructive, 0 84.2% 60.2%));
+  border-radius: 0.5rem;
+  padding: 0.75rem;
+}
+
+.project-usage-footer {
+  word-break: break-all;
+}
+
+@media (max-width: 760px) {
+  .project-usage-header,
+  .project-usage-filters {
+    grid-template-columns: 1fr;
+    flex-direction: column;
+  }
+}

--- a/plugins/project_usage/dashboard/manifest.json
+++ b/plugins/project_usage/dashboard/manifest.json
@@ -1,0 +1,14 @@
+{
+  "name": "project_usage",
+  "label": "Project Usage",
+  "description": "Per-board and per-task token/cost usage ledger for Kanban projects",
+  "icon": "BarChart3",
+  "version": "1.0.0",
+  "tab": {
+    "path": "/project-usage",
+    "position": "after:kanban"
+  },
+  "entry": "dist/index.js",
+  "css": "dist/style.css",
+  "api": "plugin_api.py"
+}

--- a/plugins/project_usage/dashboard/plugin_api.py
+++ b/plugins/project_usage/dashboard/plugin_api.py
@@ -1,0 +1,30 @@
+"""Project Usage dashboard plugin backend.
+
+Mounted at /api/plugins/project_usage/ by the dashboard plugin loader.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from fastapi import APIRouter, Query
+
+from hermes_cli import project_usage_ledger
+
+router = APIRouter()
+
+
+@router.get("/summary")
+def get_project_usage_summary(
+    board: Optional[str] = Query(None, description="Optional board slug filter"),
+    task_id: Optional[str] = Query(None, description="Optional task id drilldown"),
+    refresh: bool = Query(True, description="Refresh ledger from source DBs before reading"),
+):
+    """Return per-board totals and per-task drilldown usage rows."""
+    return project_usage_ledger.get_summary(board=board, task_id=task_id, refresh=refresh)
+
+
+@router.post("/backfill")
+def backfill_project_usage():
+    """Force an idempotent ledger backfill."""
+    return project_usage_ledger.backfill()

--- a/tests/hermes_cli/test_project_usage_ledger.py
+++ b/tests/hermes_cli/test_project_usage_ledger.py
@@ -1,0 +1,112 @@
+"""Tests for the derived project usage ledger and Kanban usage CLI."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from hermes_state import SessionDB
+from hermes_cli import kanban as kc
+from hermes_cli import kanban_db as kb
+from hermes_cli import project_usage_ledger as usage
+
+
+@pytest.fixture
+def usage_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb._INITIALIZED_PATHS.clear()
+    kb.init_db(board="default")
+    return home
+
+
+def _seed_session(home: Path, session_id: str, *, in_tok: int, out_tok: int, cost: float) -> None:
+    db = SessionDB(home / "state.db")
+    try:
+        db.create_session(session_id, "kanban", model="gpt-test", user_id="u-test")
+        db.update_token_counts(
+            session_id,
+            input_tokens=in_tok,
+            output_tokens=out_tok,
+            reasoning_tokens=7,
+            estimated_cost_usd=cost,
+            billing_provider="test-provider",
+            billing_mode="api",
+            api_call_count=2,
+            absolute=True,
+        )
+        db.end_session(session_id, "done")
+    finally:
+        db.close()
+
+
+def _seed_completed_run(session_id: str, *, title: str = "usage task") -> str:
+    with kb.connect(board="default") as conn:
+        tid = kb.create_task(conn, title=title, assignee="worker")
+        assert kb.claim_task(conn, tid)
+        assert kb.complete_task(
+            conn,
+            tid,
+            summary="finished",
+            metadata={"worker_session_id": session_id},
+        )
+        return tid
+
+
+def test_project_usage_backfill_correlates_kanban_run_to_session(usage_home):
+    _seed_session(usage_home, "sess-usage-1", in_tok=100, out_tok=50, cost=0.0123)
+    tid = _seed_completed_run("sess-usage-1")
+
+    data = usage.get_summary(board="default", task_id=tid, refresh=True)
+
+    assert data["ledger_path"].endswith("usage/project_usage.db")
+    assert data["totals"]["input_tokens"] == 100
+    assert data["totals"]["output_tokens"] == 50
+    assert data["totals"]["reasoning_tokens"] == 7
+    assert data["totals"]["estimated_cost_usd"] == pytest.approx(0.0123)
+    assert [b["board_slug"] for b in data["boards"]] == ["default"]
+    assert data["tasks"][0]["task_id"] == tid
+    assert data["tasks"][0]["sessions"] == 1
+    assert data["runs"][0]["session_id"] == "sess-usage-1"
+
+
+def test_project_usage_summary_keeps_unassigned_sessions_visible(usage_home):
+    _seed_session(usage_home, "sess-unassigned", in_tok=11, out_tok=22, cost=0.003)
+
+    data = usage.get_summary(refresh=True)
+
+    unassigned = next(b for b in data["boards"] if b["board_slug"] == "__unassigned__")
+    assert unassigned["board_name"] == "Unassigned sessions"
+    assert unassigned["sessions"] == 1
+    assert data["totals"]["input_tokens"] == 11
+    assert data["totals"]["output_tokens"] == 22
+
+
+def test_stamp_usage_metadata_embeds_worker_session_snapshot(usage_home):
+    _seed_session(usage_home, "sess-snapshot", in_tok=5, out_tok=6, cost=0.0009)
+
+    stamped = usage.stamp_usage_metadata({"keep": True}, "sess-snapshot")
+
+    assert stamped["keep"] is True
+    assert stamped["worker_session_id"] == "sess-snapshot"
+    assert stamped["usage_snapshot"]["input_tokens"] == 5
+    assert stamped["usage_snapshot"]["output_tokens"] == 6
+    assert stamped["usage_snapshot"]["estimated_cost_usd"] == pytest.approx(0.0009)
+
+
+def test_kanban_usage_cli_outputs_json_summary(usage_home):
+    _seed_session(usage_home, "sess-cli", in_tok=13, out_tok=17, cost=0.0042)
+    tid = _seed_completed_run("sess-cli", title="cli usage task")
+
+    out = kc.run_slash("usage --json")
+    data = json.loads(out)
+
+    assert data["totals"]["input_tokens"] == 13
+    assert data["totals"]["output_tokens"] == 17
+    row = next(t for t in data["tasks"] if t["task_id"] == tid)
+    assert row["task_title"] == "cli usage task"
+    assert row["estimated_cost_usd"] == pytest.approx(0.0042)

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -2195,3 +2195,84 @@ def test_dashboard_failed_card_highlight_class_exists():
     assert "hermes-kanban-card--failed" in js
     assert "hermes-kanban-card--failed" in css
     assert "failedIds" in js
+
+
+def test_board_cards_include_usage_rollup(client, kanban_home):
+    """Board cards expose per-task token/cost rollups from the usage ledger."""
+    from hermes_state import SessionDB
+
+    db = SessionDB(kanban_home / "state.db")
+    try:
+        db.create_session("sess-card-usage", "kanban", model="gpt-test")
+        db.update_token_counts(
+            "sess-card-usage",
+            input_tokens=21,
+            output_tokens=34,
+            reasoning_tokens=5,
+            estimated_cost_usd=0.007,
+            absolute=True,
+        )
+    finally:
+        db.close()
+
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="usage badge", assignee="worker")
+        assert kb.claim_task(conn, tid)
+        assert kb.complete_task(
+            conn,
+            tid,
+            summary="done",
+            metadata={"worker_session_id": "sess-card-usage"},
+        )
+
+    r = client.get("/api/plugins/kanban/board")
+    assert r.status_code == 200, r.text
+    tasks = [task for col in r.json()["columns"] for task in col["tasks"]]
+    card = next(t for t in tasks if t["id"] == tid)
+
+    assert card["usage"]["input_tokens"] == 21
+    assert card["usage"]["output_tokens"] == 34
+    assert card["usage"]["reasoning_tokens"] == 5
+    assert card["usage"]["estimated_cost_usd"] == pytest.approx(0.007)
+
+
+def test_usage_route_returns_board_filtered_summary(client, kanban_home):
+    from hermes_state import SessionDB
+
+    db = SessionDB(kanban_home / "state.db")
+    try:
+        db.create_session("sess-route", "kanban", model="gpt-test")
+        db.update_token_counts(
+            "sess-route",
+            input_tokens=8,
+            output_tokens=9,
+            estimated_cost_usd=0.002,
+            absolute=True,
+        )
+    finally:
+        db.close()
+
+    with kb.connect(board="default") as conn:
+        tid = kb.create_task(conn, title="route usage", assignee="worker")
+        assert kb.claim_task(conn, tid)
+        assert kb.complete_task(
+            conn, tid, summary="done", metadata={"worker_session_id": "sess-route"}
+        )
+
+    r = client.get(f"/api/plugins/kanban/usage?board=default&task_id={tid}")
+    assert r.status_code == 200, r.text
+    data = r.json()
+    assert data["totals"]["input_tokens"] == 8
+    assert [b["board_slug"] for b in data["boards"]] == ["default"]
+    assert data["tasks"][0]["task_id"] == tid
+    assert data["runs"][0]["session_id"] == "sess-route"
+
+
+def test_dashboard_bundle_renders_usage_badge():
+    repo_root = Path(__file__).resolve().parents[2]
+    bundle = repo_root / "plugins" / "kanban" / "dashboard" / "dist" / "index.js"
+    js = bundle.read_text()
+
+    assert "function taskUsageTokens(t)" in js
+    assert "hermes-kanban-usage" in js
+    assert "estimated cost" in js

--- a/tests/plugins/test_project_usage_dashboard_plugin.py
+++ b/tests/plugins/test_project_usage_dashboard_plugin.py
@@ -1,0 +1,183 @@
+"""Tests for the Project Usage dashboard plugin and ledger backfill."""
+
+from __future__ import annotations
+
+import importlib.util
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from hermes_cli import kanban_db as kb
+from hermes_cli import project_usage_ledger as ledger
+
+
+SESSION_COLUMNS_SQL = """
+CREATE TABLE sessions (
+    id TEXT PRIMARY KEY,
+    source TEXT NOT NULL,
+    user_id TEXT,
+    model TEXT,
+    model_config TEXT,
+    system_prompt TEXT,
+    parent_session_id TEXT,
+    started_at REAL NOT NULL,
+    ended_at REAL,
+    end_reason TEXT,
+    message_count INTEGER DEFAULT 0,
+    tool_call_count INTEGER DEFAULT 0,
+    input_tokens INTEGER DEFAULT 0,
+    output_tokens INTEGER DEFAULT 0,
+    cache_read_tokens INTEGER DEFAULT 0,
+    cache_write_tokens INTEGER DEFAULT 0,
+    reasoning_tokens INTEGER DEFAULT 0,
+    billing_provider TEXT,
+    billing_base_url TEXT,
+    billing_mode TEXT,
+    estimated_cost_usd REAL,
+    actual_cost_usd REAL,
+    cost_status TEXT,
+    cost_source TEXT,
+    pricing_version TEXT,
+    title TEXT,
+    api_call_count INTEGER DEFAULT 0,
+    handoff_state TEXT,
+    handoff_platform TEXT,
+    handoff_error TEXT
+);
+"""
+
+
+def _load_plugin_router():
+    repo_root = Path(__file__).resolve().parents[2]
+    plugin_file = repo_root / "plugins" / "project_usage" / "dashboard" / "plugin_api.py"
+    assert plugin_file.exists(), f"plugin file missing: {plugin_file}"
+    spec = importlib.util.spec_from_file_location(
+        "hermes_dashboard_plugin_project_usage_test", plugin_file,
+    )
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod.router
+
+
+@pytest.fixture
+def usage_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.delenv("HERMES_KANBAN_HOME", raising=False)
+    monkeypatch.delenv("HERMES_KANBAN_BOARD", raising=False)
+    monkeypatch.delenv("HERMES_KANBAN_DB", raising=False)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    # Avoid module-level kanban init cache carrying paths across tests.
+    kb._INITIALIZED_PATHS.clear()
+    yield home
+    kb._INITIALIZED_PATHS.clear()
+
+
+def _seed_state_db(home: Path):
+    conn = sqlite3.connect(home / "state.db")
+    conn.execute(SESSION_COLUMNS_SQL)
+    conn.execute(
+        """
+        INSERT INTO sessions (
+            id, source, user_id, model, started_at, ended_at, title,
+            input_tokens, output_tokens, cache_read_tokens, cache_write_tokens,
+            reasoning_tokens, billing_provider, billing_mode,
+            estimated_cost_usd, actual_cost_usd, cost_status,
+            api_call_count, tool_call_count
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            "sess-worker-1", "kanban", "u1", "test/model", 1000.0, 1060.0,
+            "Worker session", 120, 45, 10, 5, 7, "openrouter", "estimated",
+            0.0123, None, "estimated", 2, 3,
+        ),
+    )
+    conn.execute(
+        """
+        INSERT INTO sessions (
+            id, source, user_id, model, started_at, ended_at, title,
+            input_tokens, output_tokens, estimated_cost_usd, api_call_count, tool_call_count
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            "sess-unassigned", "cli", "u1", "test/model", 900.0, 930.0,
+            "Loose session", 10, 4, 0.001, 1, 0,
+        ),
+    )
+    conn.commit()
+    conn.close()
+
+
+def _seed_board():
+    kb.create_board("proj", name="Project One")
+    conn = kb.connect(board="proj")
+    try:
+        task_id = kb.create_task(conn, title="Implement thing", assignee="default")
+        conn.execute(
+            """
+            INSERT INTO task_runs (
+                task_id, profile, status, started_at, ended_at, outcome, metadata
+            ) VALUES (?, 'default', 'done', 1000, 1060, 'completed', ?)
+            """,
+            (task_id, '{"worker_session_id":"sess-worker-1"}'),
+        )
+        return task_id
+    finally:
+        conn.close()
+
+
+def test_backfill_creates_ledger_and_correlates_board_task_usage(usage_home):
+    _seed_state_db(usage_home)
+    task_id = _seed_board()
+
+    summary = ledger.get_summary(refresh=True)
+
+    assert Path(summary["ledger_path"]).exists()
+    project = next(b for b in summary["boards"] if b["board_slug"] == "proj")
+    assert project["board_name"] == "Project One"
+    assert project["tasks"] == 1
+    assert project["sessions"] == 1
+    assert project["input_tokens"] == 120
+    assert project["output_tokens"] == 45
+    assert project["estimated_cost_usd"] == pytest.approx(0.0123)
+
+    unassigned = next(b for b in summary["boards"] if b["board_slug"] == "__unassigned__")
+    assert unassigned["sessions"] == 1
+
+    drilldown = ledger.get_summary(board="proj", task_id=task_id, refresh=False)
+    assert drilldown["totals"]["tasks"] == 1
+    assert drilldown["runs"][0]["session_id"] == "sess-worker-1"
+
+
+def test_project_usage_plugin_summary_endpoint(usage_home):
+    _seed_state_db(usage_home)
+    task_id = _seed_board()
+    app = FastAPI()
+    app.include_router(_load_plugin_router(), prefix="/api/plugins/project_usage")
+    client = TestClient(app)
+
+    r = client.get(f"/api/plugins/project_usage/summary?board=proj&task_id={task_id}")
+
+    assert r.status_code == 200, r.text
+    payload = r.json()
+    assert payload["totals"]["input_tokens"] == 120
+    assert payload["tasks"][0]["task_id"] == task_id
+    assert payload["runs"][0]["session_id"] == "sess-worker-1"
+
+
+def test_project_usage_dashboard_bundle_registers_plugin():
+    repo_root = Path(__file__).resolve().parents[2]
+    bundle = repo_root / "plugins" / "project_usage" / "dashboard" / "dist" / "index.js"
+    js = bundle.read_text()
+
+    assert 'registry.register("project_usage", ProjectUsagePage)' in js
+    assert "/api/plugins/project_usage/summary" in js
+    assert "Per-board totals" in js
+    assert "Per-task drilldown" in js

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -354,10 +354,9 @@ def test_complete_stamps_worker_session_id_from_env(monkeypatch, worker_env):
     conn = kb.connect()
     try:
         run = kb.latest_run(conn, worker_env)
-        assert run.metadata == {
-            "files": 2,
-            "worker_session_id": "session-trusted",
-        }
+        assert run.metadata["files"] == 2
+        assert run.metadata["worker_session_id"] == "session-trusted"
+        assert run.metadata["usage_snapshot"]["session_id"] == "session-trusted"
     finally:
         conn.close()
 

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -118,15 +118,19 @@ def _worker_run_id(task_id: str) -> Optional[int]:
 def _stamp_worker_session_metadata(
     task_id: str, metadata: Optional[dict]
 ) -> Optional[dict]:
-    """Add trusted worker session id metadata for this worker's own task."""
+    """Add trusted worker session id + token usage metadata for this worker."""
     if os.environ.get("HERMES_KANBAN_TASK") != task_id:
         return metadata
     session_id = os.environ.get("HERMES_SESSION_ID")
     if not session_id:
         return metadata
-    stamped = dict(metadata or {})
-    stamped["worker_session_id"] = session_id
-    return stamped
+    try:
+        from hermes_cli.project_usage_ledger import stamp_usage_metadata
+        return stamp_usage_metadata(metadata, session_id)
+    except Exception:
+        stamped = dict(metadata or {})
+        stamped["worker_session_id"] = session_id
+        return stamped
 
 
 def _enforce_worker_task_ownership(tid: str) -> Optional[str]:
@@ -528,10 +532,12 @@ def _handle_block(args: dict, **kw) -> str:
     try:
         kb, conn = _connect(board=board)
         try:
+            metadata = _stamp_worker_session_metadata(tid, None)
             ok = kb.block_task(
                 conn, tid,
                 reason=reason,
                 expected_run_id=_worker_run_id(tid),
+                metadata=metadata,
             )
             if not ok:
                 return tool_error(


### PR DESCRIPTION
## Summary
- Add a shared project usage ledger that records local project usage snapshots and exposes summary helpers.
- Add a Project Usage dashboard plugin with native API support.
- Surface Kanban token/tool/turn usage in the CLI, dashboard API, dashboard card badges, and kanban tool responses.

## Validation
- `git diff --check origin/main...HEAD`
- `./scripts/run_tests.sh tests/hermes_cli/test_project_usage_ledger.py tests/plugins/test_project_usage_dashboard_plugin.py tests/plugins/test_kanban_dashboard_plugin.py tests/tools/test_kanban_tools.py` (185 passed)

<!-- BEGIN:codex-cursor-sweep-summary -->
## Cursor/Bugbot sweep summary

### Bugs found and fixed
- none; no Cursor/Bugbot findings were emitted for current head `8d062bc1e21d75fcb454157ffefe2430e47fcd88`.

### Implemented changes in the PR
- Added `hermes_cli/project_usage_ledger.py` for shared local project usage snapshots and rollups.
- Added the Project Usage dashboard plugin API, manifest, bundled JS, and styles.
- Added Kanban usage fields through the native tool response, CLI formatting, dashboard API, dashboard card badges, and tests.

### Validation
- `git diff --check origin/main...HEAD`
- `./scripts/run_tests.sh tests/hermes_cli/test_project_usage_ledger.py tests/plugins/test_project_usage_dashboard_plugin.py tests/plugins/test_kanban_dashboard_plugin.py tests/tools/test_kanban_tools.py` (185 passed)

### Sweep status
- Blocked: after a 21-minute current-head poll timed out with no matching review/check, I posted `bugbot run`; Cursor replied that Bugbot is disabled for this repository. Merge was not attempted because the required current-head clean Bugbot signal is unavailable.
<!-- END:codex-cursor-sweep-summary -->
