### PR TITLE
feat: add goblin quote extractor

### DIFF
--- a/agent/goblin_quotes.py
+++ b/agent/goblin_quotes.py
@@ -1,0 +1,175 @@
+"""Goblin quote extraction from Hermes session history.
+
+This is intentionally tiny and boring: scan stored messages for the word
+"goblin", extract the matching sentence-ish chunks, and append new finds to a
+profile-local Markdown log. No LLM needed; the goblin trap is regex-powered.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from pathlib import Path
+from typing import Any, Dict, Iterable, Iterator, Optional
+
+from hermes_constants import get_hermes_home
+
+_GOBLIN_RE = re.compile(r"\bgoblins?\b", re.IGNORECASE)
+_SENTENCE_RE = re.compile(r"[^.!?\n]*\bgoblins?\b[^.!?\n]*(?:[.!?]|$)", re.IGNORECASE)
+_FINGERPRINT_RE = re.compile(r"<!--\s*goblin:([0-9a-f]{16,64})\s*-->")
+
+
+def _content_to_text(content: Any) -> str:
+    """Flatten stored message content into searchable text."""
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, (int, float, bytes)):
+        return str(content)
+    if isinstance(content, list):
+        parts: list[str] = []
+        for item in content:
+            if isinstance(item, dict):
+                text = item.get("text")
+                if isinstance(text, str):
+                    parts.append(text)
+                elif item.get("type") == "input_text" and isinstance(item.get("content"), str):
+                    parts.append(item["content"])
+            elif isinstance(item, str):
+                parts.append(item)
+        return "\n".join(parts)
+    if isinstance(content, dict):
+        text = content.get("text")
+        return text if isinstance(text, str) else str(content)
+    return str(content)
+
+
+def _extract_goblin_quotes(text: str) -> list[str]:
+    """Return sentence-ish chunks containing goblin/goblins, preserving order."""
+    if not _GOBLIN_RE.search(text):
+        return []
+    quotes: list[str] = []
+    seen: set[str] = set()
+    for match in _SENTENCE_RE.finditer(text):
+        quote = " ".join(match.group(0).strip().split())
+        if quote and quote not in seen:
+            seen.add(quote)
+            quotes.append(quote)
+    if quotes:
+        return quotes
+    # Fallback for weird punctuation/control text: log the matching line.
+    for line in text.splitlines() or [text]:
+        if _GOBLIN_RE.search(line):
+            quote = " ".join(line.strip().split())
+            if quote and quote not in seen:
+                seen.add(quote)
+                quotes.append(quote)
+    return quotes
+
+
+def iter_goblin_quotes(db, source: Optional[str] = None, limit: Optional[int] = None) -> Iterator[Dict[str, Any]]:
+    """Yield goblin quote records from a ``SessionDB``.
+
+    Only user/assistant messages are scanned. Tool output can contain arbitrary
+    web/code junk, and this log is for conversational goblin lore, not every
+    npm package that accidentally summons a cave creature.
+    """
+    params: list[Any] = []
+    source_sql = ""
+    if source:
+        source_sql = " AND s.source = ?"
+        params.append(source)
+    limit_sql = ""
+    if limit is not None:
+        limit_sql = " LIMIT ?"
+        params.append(max(0, int(limit)))
+
+    # Do the goblin match in Python instead of SQL LIKE. Multimodal messages are
+    # stored with a NUL-prefixed JSON sentinel; SQLite LIKE treats embedded NULs
+    # like a tiny string guillotine. Python doesn't care, because it has manners.
+    query = f"""
+        SELECT
+            m.id AS message_id,
+            m.session_id,
+            m.role,
+            m.content,
+            s.source,
+            s.title
+        FROM messages m
+        JOIN sessions s ON s.id = m.session_id
+        WHERE m.role IN ('user', 'assistant')
+          {source_sql}
+        ORDER BY m.id ASC
+        {limit_sql}
+    """
+
+    with db._lock:  # SessionDB exposes no arbitrary query helper; keep reads locked.
+        rows = [dict(row) for row in db._conn.execute(query, params).fetchall()]
+
+    for row in rows:
+        text = _content_to_text(db._decode_content(row.get("content")))
+        for quote in _extract_goblin_quotes(text):
+            yield {
+                "session_id": row["session_id"],
+                "message_id": row["message_id"],
+                "role": row["role"],
+                "source": row["source"],
+                "title": row.get("title"),
+                "quote": quote,
+            }
+
+
+def _fingerprint(record: Dict[str, Any]) -> str:
+    raw = f"{record['session_id']}\0{record['message_id']}\0{record['quote']}"
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()[:16]
+
+
+def _existing_fingerprints(log_path: Path) -> set[str]:
+    if not log_path.exists():
+        return set()
+    text = log_path.read_text(encoding="utf-8")
+    return set(_FINGERPRINT_RE.findall(text))
+
+
+def _format_entry(record: Dict[str, Any], fingerprint: str) -> str:
+    title = record.get("title") or "untitled"
+    return (
+        f"<!-- goblin:{fingerprint} -->\n"
+        f"- **{record['role']}** — {record['quote']}\n"
+        f"  - session: `{record['session_id']}`; message: `{record['message_id']}`; "
+        f"source: `{record['source']}`; title: {title}\n"
+    )
+
+
+def append_goblin_log(
+    db,
+    log_path: Optional[Path | str] = None,
+    source: Optional[str] = None,
+    limit: Optional[int] = None,
+) -> Dict[str, Any]:
+    """Append newly discovered goblin quotes to a Markdown log.
+
+    Returns a small summary dict so CLI/cron callers can report what changed.
+    """
+    path = Path(log_path) if log_path is not None else get_hermes_home() / "goblin-quotes.md"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    existing = _existing_fingerprints(path)
+    entries: list[str] = []
+    scanned = 0
+
+    for record in iter_goblin_quotes(db, source=source, limit=limit):
+        scanned += 1
+        fp = _fingerprint(record)
+        if fp in existing:
+            continue
+        existing.add(fp)
+        entries.append(_format_entry(record, fp))
+
+    if not path.exists():
+        path.write_text("# Goblin Quote Log\n\n", encoding="utf-8")
+    if entries:
+        with path.open("a", encoding="utf-8") as f:
+            f.write("".join(entries))
+
+    return {"path": str(path), "scanned": scanned, "added": len(entries)}

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -12301,6 +12301,19 @@ Examples:
         "--limit", type=int, default=500, help="Max sessions to load (default: 500)"
     )
 
+    sessions_goblins = sessions_subparsers.add_parser(
+        "goblins",
+        help="Extract goblin quotes from session history into a Markdown log",
+    )
+    sessions_goblins.add_argument("--source", help="Filter by source")
+    sessions_goblins.add_argument(
+        "--output",
+        help="Markdown log path (default: $HERMES_HOME/goblin-quotes.md)",
+    )
+    sessions_goblins.add_argument(
+        "--limit", type=int, help="Maximum messages to scan before extraction"
+    )
+
     def _confirm_prompt(prompt: str) -> bool:
         """Prompt for y/N confirmation, safe against non-TTY environments."""
         try:
@@ -12453,6 +12466,23 @@ Examples:
 
             relaunch(["--resume", selected_id])
             return  # won't reach here after execvp
+
+        elif action == "goblins":
+            from pathlib import Path as _Path
+
+            from agent.goblin_quotes import append_goblin_log
+
+            output = _Path(args.output).expanduser() if args.output else None
+            summary = append_goblin_log(
+                db,
+                log_path=output,
+                source=getattr(args, "source", None),
+                limit=getattr(args, "limit", None),
+            )
+            print(
+                f"Goblin quotes: scanned {summary['scanned']}, "
+                f"added {summary['added']} → {summary['path']}"
+            )
 
         elif action == "stats":
             total = db.session_count()

--- a/tests/hermes_state/test_goblin_quotes.py
+++ b/tests/hermes_state/test_goblin_quotes.py
@@ -1,0 +1,85 @@
+"""Tests for extracting Brian-grade goblin references from session history."""
+
+from pathlib import Path
+
+from agent.goblin_quotes import append_goblin_log, iter_goblin_quotes
+from hermes_state import SessionDB
+
+
+def _session_db(tmp_path: Path) -> SessionDB:
+    return SessionDB(tmp_path / "state.db")
+
+
+def test_iter_goblin_quotes_extracts_sentence_level_matches(tmp_path):
+    db = _session_db(tmp_path)
+    try:
+        db.create_session("s-gob", source="slack")
+        db.set_session_title("s-gob", "Goblin science")
+        first_id = db.append_message(
+            "s-gob",
+            "assistant",
+            "Normal setup. The goblin calibration rig is screaming again! Carry on.",
+        )
+        db.append_message("s-gob", "assistant", "No gremlins here, different creature.")
+
+        quotes = list(iter_goblin_quotes(db))
+
+        assert quotes == [
+            {
+                "session_id": "s-gob",
+                "message_id": first_id,
+                "role": "assistant",
+                "source": "slack",
+                "title": "Goblin science",
+                "quote": "The goblin calibration rig is screaming again!",
+            }
+        ]
+    finally:
+        db.close()
+
+
+def test_iter_goblin_quotes_handles_multimodal_text_parts_and_source_filter(tmp_path):
+    db = _session_db(tmp_path)
+    try:
+        db.create_session("s-cli", source="cli")
+        db.append_message("s-cli", "user", "CLI goblin should be ignored by source filter.")
+        db.create_session("s-slack", source="slack")
+        message_id = db.append_message(
+            "s-slack",
+            "user",
+            [
+                {"type": "text", "text": "Look at this goblin-shaped stack trace."},
+                {"type": "image_url", "image_url": {"url": "https://example.test/goblin.png"}},
+            ],
+        )
+
+        quotes = list(iter_goblin_quotes(db, source="slack"))
+
+        assert len(quotes) == 1
+        assert quotes[0]["session_id"] == "s-slack"
+        assert quotes[0]["message_id"] == message_id
+        assert quotes[0]["quote"] == "Look at this goblin-shaped stack trace."
+    finally:
+        db.close()
+
+
+def test_append_goblin_log_is_markdown_and_dedupes_existing_entries(tmp_path):
+    db = _session_db(tmp_path)
+    try:
+        db.create_session("s-gob", source="telegram")
+        db.set_session_title("s-gob", "Lab notes")
+        db.append_message("s-gob", "assistant", "Release the deployment goblins.")
+        log_path = tmp_path / "goblin-quotes.md"
+
+        first = append_goblin_log(db, log_path)
+        second = append_goblin_log(db, log_path)
+
+        text = log_path.read_text(encoding="utf-8")
+        assert first["added"] == 1
+        assert second["added"] == 0
+        assert text.startswith("# Goblin Quote Log\n")
+        assert text.count("Release the deployment goblins.") == 1
+        assert "session: `s-gob`" in text
+        assert "source: `telegram`" in text
+    finally:
+        db.close()


### PR DESCRIPTION
## Summary
- adds `hermes sessions goblins` to extract goblin/goblins quotes from session history
- writes a deduped Markdown log to `/home/bdmorin/.hermes/goblin-quotes.md` or `--output`
- handles NUL-prefixed multimodal JSON content in Python instead of relying on SQLite LIKE

## Test Plan
- [x] `pytest tests/hermes_state/test_goblin_quotes.py -q -o 'addopts='`
- [x] `pytest tests/hermes_state/test_goblin_quotes.py tests/hermes_cli/test_completion.py -q -o 'addopts='`
- [x] `py_compile agent/goblin_quotes.py hermes_cli/main.py tests/hermes_state/test_goblin_quotes.py`
- [x] `hermes sessions goblins --output /tmp/hermes-goblin-quotes-test.md --limit 200` + rerun dedupe check

Kanban: t_ab7785ab