### PR TITLE
fix(gateway): disconnect partial adapter when reconnect fails

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5491,6 +5491,14 @@ class GatewayRunner:
                         )
                         del self._failed_platforms[platform]
                     else:
+                        # Defensive cleanup: connect() returned False but the
+                        # adapter may still hold a half-open ClientSession,
+                        # child subprocess, or socket from partial init. Without
+                        # this, the next reconnect attempt overwrites the only
+                        # reference and the old resources are GC'd with sockets
+                        # still in CLOSE_WAIT, surfacing later as cryptic
+                        # "Session is closed" / "Connector is closed" errors.
+                        await self._safe_adapter_disconnect(adapter, platform)
                         self._update_platform_runtime_status(
                             platform.value,
                             platform_state="retrying",
@@ -5513,6 +5521,15 @@ class GatewayRunner:
                                 ),
                             )
                 except Exception as e:
+                    # Same defensive cleanup for the exception path: connect()
+                    # raised partway through, so the adapter may hold live
+                    # resources. ``adapter`` may not be bound if _create_adapter
+                    # itself raised — guard with locals().
+                    if "adapter" in locals() and adapter is not None:
+                        try:
+                            await self._safe_adapter_disconnect(adapter, platform)
+                        except Exception:
+                            pass
                     self._update_platform_runtime_status(
                         platform.value,
                         platform_state="retrying",

--- a/tests/gateway/test_platform_reconnect.py
+++ b/tests/gateway/test_platform_reconnect.py
@@ -26,6 +26,7 @@ class StubAdapter(BasePlatformAdapter):
         self._succeed = succeed
         self._fatal_error = fatal_error
         self._fatal_retryable = fatal_retryable
+        self.disconnect_count = 0
 
     async def connect(self):
         if self._fatal_error:
@@ -34,6 +35,7 @@ class StubAdapter(BasePlatformAdapter):
         return self._succeed
 
     async def disconnect(self):
+        self.disconnect_count += 1
         return None
 
     async def send(self, chat_id, content, reply_to=None, metadata=None):
@@ -292,6 +294,53 @@ class TestPlatformReconnectWatcher:
 
         assert Platform.TELEGRAM in runner._failed_platforms
         assert runner._failed_platforms[Platform.TELEGRAM]["attempts"] == 2
+        # Defensive-cleanup contract: a partially-initialized adapter from a
+        # failed reconnect must have disconnect() invoked exactly once before
+        # being dropped, so its ClientSession/subprocess/socket are released.
+        assert fail_adapter.disconnect_count == 1
+
+    @pytest.mark.asyncio
+    async def test_reconnect_exception_disconnects_partial_adapter(self):
+        """If connect() raises, the watcher must still call disconnect() on
+        the adapter — otherwise a half-open ClientSession or child process is
+        leaked, and the next reconnect attempt overwrites the only reference
+        with the old one still holding resources."""
+        runner = _make_runner()
+
+        platform_config = PlatformConfig(enabled=True, token="test")
+        runner._failed_platforms[Platform.TELEGRAM] = {
+            "config": platform_config,
+            "attempts": 1,
+            "next_retry": time.monotonic() - 1,
+        }
+
+        class RaisingAdapter(StubAdapter):
+            async def connect(self):
+                raise RuntimeError("temporary network failure")
+
+        fail_adapter = RaisingAdapter()
+        real_sleep = asyncio.sleep
+
+        with patch.object(runner, "_create_adapter", return_value=fail_adapter):
+            async def run_one_iteration():
+                runner._running = True
+                call_count = 0
+
+                async def fake_sleep(n):
+                    nonlocal call_count
+                    call_count += 1
+                    if call_count > 1:
+                        runner._running = False
+                    await real_sleep(0)
+
+                with patch("asyncio.sleep", side_effect=fake_sleep):
+                    await runner._platform_reconnect_watcher()
+
+            await run_one_iteration()
+
+        assert Platform.TELEGRAM in runner._failed_platforms
+        assert runner._failed_platforms[Platform.TELEGRAM]["attempts"] == 2
+        assert fail_adapter.disconnect_count == 1
 
     @pytest.mark.asyncio
     async def test_reconnect_pauses_after_circuit_breaker_threshold(self):


### PR DESCRIPTION
Extracted from #21673 per CONTRIBUTING.md ("one logical change per PR"). #21673's other hunks have already landed as #29196 (telegram bootstrap), #29197 (media dedup); this PR is the safe-disconnect change those splits dropped on the floor.

## Problem

`_platform_reconnect_watcher` in `gateway/run.py` runs a reconnect loop that drops its `adapter` local on every iteration but never calls `adapter.disconnect()` on the two failure paths:

- `connect()` returns `False` (`else` branch around the success check)
- `connect()` raises (`except Exception`)

A partially-initialized adapter that allocated a `ClientSession`, child subprocess, or socket before giving up keeps those resources alive until GC runs. The next reconnect attempt overwrites the only reference, and the old session is collected with sockets still in `CLOSE_WAIT`, surfacing later as cryptic `"Session is closed"` / `"Connector is closed"` aiohttp errors on subsequent requests.

Same class of bug as #29388 (which fixes it for the HA websocket handshake path).

## Fix

Both branches now call `self._safe_adapter_disconnect(adapter, platform)` before computing back-off. The exception branch guards on `locals()` in case `_create_adapter` itself raised (so `adapter` may not be bound), and wraps the disconnect in its own try/except so a failing disconnect doesn't suppress the original exception's back-off bookkeeping.

`_safe_adapter_disconnect` already exists (`gateway/run.py:1825`) and is used by the same module's startup-connect cleanup path — this PR just extends the same hygiene to the reconnect path.

## Test plan

- `test_reconnect_retryable_stays_in_queue` now asserts `fail_adapter.disconnect_count == 1` (proves the connect-returns-False path calls disconnect).
- New `test_reconnect_exception_disconnects_partial_adapter` with a `RaisingAdapter` subclass that raises `RuntimeError` from `connect()` — asserts `disconnect_count == 1` so the exception path also calls disconnect.

Full file: 30 tests, all green.