### PR TITLE
docs(skills): clarify external dir mutations

### DIFF
--- a/website/docs/user-guide/features/skills.md
+++ b/website/docs/user-guide/features/skills.md
@@ -236,7 +236,8 @@ Paths support `~` expansion and `${VAR}` environment variable substitution.
 
 ### How it works
 
-- **Read-only**: External dirs are only scanned for skill discovery. When the agent creates or edits a skill, it always writes to `~/.hermes/skills/`.
+- **Create locally, update in place**: New agent-created skills are written to `~/.hermes/skills/`. Existing skills are modified where they are found, including skills under `external_dirs`, when the agent uses `skill_manage` actions such as `patch`, `edit`, `write_file`, `remove_file`, or `delete`.
+- **External dirs are not a write-protection boundary**: If an external skill directory is writable by the Hermes process, agent-managed skill updates can change files in that directory. Use filesystem permissions or a separate profile/toolset setup if shared external skills must stay read-only.
 - **Local precedence**: If the same skill name exists in both the local dir and an external dir, the local version wins.
 - **Full integration**: External skills appear in the system prompt index, `skills_list`, `skill_view`, and as `/skill-name` slash commands — no different from local skills.
 - **Non-existent paths are silently skipped**: If a configured directory doesn't exist, Hermes ignores it without errors. Useful for optional shared directories that may not be present on every machine.
@@ -250,7 +251,7 @@ Paths support `~` expansion and `${VAR}` environment variable substitution.
 └── mlops/axolotl/
     └── SKILL.md
 
-~/.agents/skills/               # External (read-only, shared)
+~/.agents/skills/               # External (shared, mutable if writable)
 ├── my-custom-workflow/
 │   └── SKILL.md
 └── team-conventions/


### PR DESCRIPTION
## What does this PR do?

Updates the External Skill Directories docs to match current `skill_manage` behavior on `main`.

The docs previously said external dirs were read-only and that agent-created edits always wrote to `~/.hermes/skills/`. Current code and tests allow `skill_manage` to patch, edit, write supporting files, remove supporting files, and delete existing skills where they are discovered, including under `skills.external_dirs`.

This PR changes the docs to say new skills are still created locally, while existing external skills can be updated in place when the external directory is writable. It also updates the example directory comment so it no longer labels external dirs as read-only.

## Related Issue

Related: #25083

Also checked related PRs before opening this docs-only update:

- #17512 merged the current in-place mutation behavior.
- #5407 proposed copy-on-write behavior but is closed.
- #27993 protects pinned external skills from mutation but preserves unpinned external mutation compatibility.
- #5535 is adjacent shared-skills work, not a duplicate docs update.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Updated `website/docs/user-guide/features/skills.md` to clarify that `skill_manage` creates new skills under `~/.hermes/skills/`, but modifies existing skills where they are found, including writable `external_dirs`.
- Replaced the read-only external-dir example label with wording that matches current behavior.

## How to Test

1. Run `git diff --check HEAD~1 HEAD`.
2. Confirm the command prints no whitespace errors.

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu / WSL, docs-only markdown change

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Docs-only change. Validation:

```text
$ git diff --check HEAD~1 HEAD
# no output
```
