### PR TITLE
fix(gateway): flush pending tool-progress before __reset__ clears state (#29371)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -16250,6 +16250,18 @@ class GatewayRunner:
                         # order. Mirrors GatewayStreamConsumer.on_segment_break
                         # on the content side. (Issue: tool + content
                         # linearization regression after PR #7885.)
+                        # Flush any pending tail before clearing — a tool
+                        # event that arrived inside the throttle window has
+                        # been appended to progress_lines but not yet edited,
+                        # and __reset__ would otherwise drop it (#29371).
+                        # Mirrors the drain handler in the CancelledError path.
+                        if can_edit and progress_lines and progress_msg_id:
+                            try:
+                                await _edit_progress_message(
+                                    progress_msg_id, _progress_text(progress_lines)
+                                )
+                            except Exception:
+                                pass
                         progress_msg_id = None
                         progress_lines = []
                         last_progress_msg[0] = None

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -16260,6 +16260,8 @@ class GatewayRunner:
                                 await _edit_progress_message(
                                     progress_msg_id, _progress_text(progress_lines)
                                 )
+                            except asyncio.CancelledError:
+                                raise
                             except Exception:
                                 pass
                         progress_msg_id = None

--- a/tests/gateway/test_telegram_progress_reset_flush.py
+++ b/tests/gateway/test_telegram_progress_reset_flush.py
@@ -1,0 +1,126 @@
+"""Regression test for the __reset__ handler in send_progress_messages.
+
+Issue: #29371
+
+When a tool event arrives during the throttle window (1.5s) and is the last
+event of the turn, the consumer appends it to ``progress_lines`` and sleeps
+out the throttle. The next thing dequeued is the ``__reset__`` marker queued
+by the gateway when the final content bubble lands. Without an explicit
+flush in the __reset__ handler, ``progress_lines`` is cleared before any
+edit fires — the user sees N-1 lines in the progress bubble.
+
+The cancellation drain path at the bottom of send_progress_messages already
+flushes pending progress before clearing on __reset__; the hot-loop path
+must mirror that behavior.
+
+Mirrors the simulation pattern used in test_telegram_progress_edit_transient.py.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+
+async def _simulate_reset_handler(*, can_edit: bool, progress_lines: list,
+                                  progress_msg_id, edit_fn) -> tuple[list, object]:
+    """Mirror the hot-loop __reset__ handler from send_progress_messages.
+
+    Returns the (progress_lines, progress_msg_id) state after the handler
+    runs, so callers can assert state was cleared regardless of flush path.
+    """
+    if can_edit and progress_lines and progress_msg_id:
+        try:
+            await edit_fn(progress_msg_id, "\n".join(progress_lines))
+        except Exception:
+            pass
+    return [], None
+
+
+@pytest.mark.asyncio
+async def test_reset_flushes_pending_progress_before_clearing():
+    """The load-bearing case: pending tail line MUST be flushed before reset."""
+    edit_fn = AsyncMock()
+    progress_lines = ["tool A done", "tool B done", "tool C done (the tail)"]
+
+    new_lines, new_msg_id = await _simulate_reset_handler(
+        can_edit=True,
+        progress_lines=progress_lines,
+        progress_msg_id="msg-42",
+        edit_fn=edit_fn,
+    )
+
+    edit_fn.assert_awaited_once_with(
+        "msg-42", "tool A done\ntool B done\ntool C done (the tail)"
+    )
+    assert new_lines == []
+    assert new_msg_id is None
+
+
+@pytest.mark.asyncio
+async def test_reset_no_flush_when_progress_lines_empty():
+    """No edit if there's nothing to flush — avoid editing an empty bubble."""
+    edit_fn = AsyncMock()
+
+    new_lines, new_msg_id = await _simulate_reset_handler(
+        can_edit=True,
+        progress_lines=[],
+        progress_msg_id="msg-42",
+        edit_fn=edit_fn,
+    )
+
+    edit_fn.assert_not_awaited()
+    assert new_lines == []
+    assert new_msg_id is None
+
+
+@pytest.mark.asyncio
+async def test_reset_no_flush_when_no_progress_msg_id():
+    """No edit before the first progress message has been sent."""
+    edit_fn = AsyncMock()
+
+    new_lines, new_msg_id = await _simulate_reset_handler(
+        can_edit=True,
+        progress_lines=["tool A done"],
+        progress_msg_id=None,
+        edit_fn=edit_fn,
+    )
+
+    edit_fn.assert_not_awaited()
+    assert new_lines == []
+    assert new_msg_id is None
+
+
+@pytest.mark.asyncio
+async def test_reset_no_flush_when_edit_disabled():
+    """Edit-disabled platforms (e.g. iMessage) skip the flush."""
+    edit_fn = AsyncMock()
+
+    new_lines, new_msg_id = await _simulate_reset_handler(
+        can_edit=False,
+        progress_lines=["tool A done"],
+        progress_msg_id="msg-42",
+        edit_fn=edit_fn,
+    )
+
+    edit_fn.assert_not_awaited()
+    assert new_lines == []
+    assert new_msg_id is None
+
+
+@pytest.mark.asyncio
+async def test_reset_swallows_edit_failures_and_still_clears():
+    """An edit failure during flush must not block state from being cleared."""
+    edit_fn = AsyncMock(side_effect=RuntimeError("edit failed"))
+
+    new_lines, new_msg_id = await _simulate_reset_handler(
+        can_edit=True,
+        progress_lines=["tool A done"],
+        progress_msg_id="msg-42",
+        edit_fn=edit_fn,
+    )
+
+    edit_fn.assert_awaited_once()
+    assert new_lines == []
+    assert new_msg_id is None

--- a/tests/gateway/test_telegram_progress_reset_flush.py
+++ b/tests/gateway/test_telegram_progress_reset_flush.py
@@ -18,13 +18,22 @@ Mirrors the simulation pattern used in test_telegram_progress_edit_transient.py.
 
 from __future__ import annotations
 
+import asyncio
+from typing import Awaitable, Callable, Optional
 from unittest.mock import AsyncMock
 
 import pytest
 
+EditFn = Callable[[str, str], Awaitable[object]]
 
-async def _simulate_reset_handler(*, can_edit: bool, progress_lines: list,
-                                  progress_msg_id, edit_fn) -> tuple[list, object]:
+
+async def _simulate_reset_handler(
+    *,
+    can_edit: bool,
+    progress_lines: list[str],
+    progress_msg_id: Optional[str],
+    edit_fn: EditFn,
+) -> tuple[list[str], Optional[str]]:
     """Mirror the hot-loop __reset__ handler from send_progress_messages.
 
     Returns the (progress_lines, progress_msg_id) state after the handler
@@ -33,6 +42,8 @@ async def _simulate_reset_handler(*, can_edit: bool, progress_lines: list,
     if can_edit and progress_lines and progress_msg_id:
         try:
             await edit_fn(progress_msg_id, "\n".join(progress_lines))
+        except asyncio.CancelledError:
+            raise
         except Exception:
             pass
     return [], None


### PR DESCRIPTION
## What does this PR do?

The hot-loop `__reset__` handler in `send_progress_messages` (`gateway/run.py`) clears `progress_lines` without flushing first. When the last tool event of a turn arrives inside the 1.5s throttle window and no further tool events follow, that line sits in `progress_lines` waiting for the next event to push it out — but the next thing dequeued is `__reset__`, queued when the final content bubble lands. The pending tail is dropped silently and the user sees N-1 lines in the progress bubble (the agent's end-of-turn summary still reports all N tool calls, so the discrepancy is user-visible).

Mirror the existing flush from the `CancelledError` drain handler at the bottom of the same function: if the bubble is editable, the lines list is non-empty, and we have a message id to edit, send one final edit before clearing state. Exceptions are swallowed to match the existing pattern — the reset must still happen even if the trailing edit fails.

> Mirrors the `__reset__` flush in the `except asyncio.CancelledError:` drain handler within `send_progress_messages` (same function, ~100 lines below). Both paths now flush-then-clear; the hot-loop path was the missing mirror.

## Related Issue

Fixes #29371

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- \`gateway/run.py\` — in the hot-loop \`__reset__\` branch of \`send_progress_messages\`, flush \`progress_lines\` via \`_edit_progress_message\` before clearing state. Guarded by the same \`can_edit and progress_lines and progress_msg_id\` invariant as the drain-path flush, with the same \`except Exception: pass\` swallow so a failing trailing edit cannot block the reset.
- \`tests/gateway/test_telegram_progress_reset_flush.py\` — new file mirroring the simulation pattern in \`test_telegram_progress_edit_transient.py\` (which extracts the relevant block from \`send_progress_messages\` for unit testing). Five cases: pending tail is flushed, no-flush when lines empty, no-flush when msg id absent, no-flush when editing disabled, edit failure still clears state.

## How to Test

1. Reproduce per the issue: configure a Telegram-connected agent with \`display.tool_progress: all\`, ask it to fire ~7 tool calls in one turn where the last is fast (e.g. \`skill_view\`). On main, the bubble shows N-1 lines.
2. After this fix the bubble shows all N lines matching the agent's end-of-turn summary.
3. \`uv run --with pytest --with pytest-xdist --with pytest-asyncio --with pytest-timeout python3 -m pytest tests/gateway/test_telegram_progress_reset_flush.py tests/gateway/test_telegram_progress_edit_transient.py -v\` — 27 passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run focused tests for the touched code and all pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15.x

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, \`docs/\`, docstrings) — N/A
- [x] I've updated \`cli-config.yaml.example\` if I added/changed config keys — N/A
- [x] I've updated \`CONTRIBUTING.md\` or \`AGENTS.md\` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — N/A; the fix is platform-independent
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

_N/A._

---

> Audited siblings: the cancellation-drain \`__reset__\` handler (\`gateway/run.py\` ~100 lines below the touched block) already flushes the same way; this PR brings the hot-loop path into alignment. No other code path queues \`__reset__\` against \`progress_queue\`. No widening needed.