### PR TITLE
fix(migrate): propagate non-zero exit codes from hermes migrate xai

### DIFF
--- a/hermes_cli/migrate.py
+++ b/hermes_cli/migrate.py
@@ -20,7 +20,7 @@ def cmd_migrate(args: Any) -> int:
         return cmd_migrate_xai(args)
 
     print("usage: hermes migrate xai [--apply] [--no-backup]", file=sys.stderr)
-    return 2
+    sys.exit(2)
 
 
 def cmd_migrate_xai(args: Any) -> int:
@@ -75,7 +75,7 @@ def cmd_migrate_xai(args: Any) -> int:
             f"(looked at: {config_path})",
             file=sys.stderr,
         )
-        return 1
+        sys.exit(1)
 
     try:
         result = apply_migration(
@@ -88,7 +88,7 @@ def cmd_migrate_xai(args: Any) -> int:
             f"  {color('✗', Colors.RED)} Migration failed: {exc}",
             file=sys.stderr,
         )
-        return 1
+        sys.exit(1)
 
     if not result.config_changed:
         print(f"  {color('⚠', Colors.YELLOW)} No changes written.")


### PR DESCRIPTION
## Summary

- `cmd_migrate_xai` and `cmd_migrate` returned `int` exit codes, but `main()`'s generic dispatch (`args.func(args)`) discards all return values — only commands that call `sys.exit()` directly propagate exit codes
- As a result, `hermes migrate xai --apply` always exited `0` even when the config file could not be located or `apply_migration` raised an exception
- Replace `return 1` / `return 2` with `sys.exit(1)` / `sys.exit(2)` to match the pattern used by every other subcommand (e.g. `cmd_doctor`)

## Root cause

```python
# hermes_cli/main.py
if hasattr(args, "func"):
    args.func(args)   # return value silently discarded
```

`cmd_doctor` (and all other commands) call `sys.exit()` directly inside the function body. `migrate.py` was written with a function-returns-int pattern that is incompatible with this dispatch.

## Affected paths

| Path | Before | After |
|---|---|---|
| config.yaml not found (`--apply`) | exits `0` | exits `1` |
| `apply_migration` raises | exits `0` | exits `1` |
| `hermes migrate` (no subcommand) | exits `0` | exits `2` |

## Test plan

- [x] Verified manually: `sys.exit(1)` fires on config-not-found and apply exception
- [x] Verified manually: `sys.exit(2)` fires when no subcommand is given
- [x] Success paths (`return 0`) are unaffected — process exits `0` naturally
- [ ] Existing `tests/hermes_cli/test_migrate_xai.py` tests cover the underlying `apply_migration` logic (no change to that layer)