### PR TITLE
fix(tts): prevent double [pause] in xAI auto speech tags for multi-paragraph text

### DIFF
--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -961,7 +961,8 @@ def _apply_xai_auto_speech_tags(text: str) -> str:
 
     clean = re.sub(r"\n\s*\n+", " [pause] ", clean)
     clean = re.sub(r"\s*\n\s*", " ", clean)
-    clean = _XAI_FIRST_SENTENCE_RE.sub(r"\1 [pause] ", clean, count=1)
+    if not _XAI_SPEECH_TAG_RE.search(clean):
+        clean = _XAI_FIRST_SENTENCE_RE.sub(r"\1 [pause] ", clean, count=1)
     clean = re.sub(r"\s{2,}", " ", clean).strip()
     return clean
 


### PR DESCRIPTION
## Summary

`_apply_xai_auto_speech_tags` applied two pause-insertion passes unconditionally:

1. Paragraph breaks (`\n\n`) → `" [pause] "`
2. First-sentence boundary → `" [pause] "`

Both fired on every call, so multi-paragraph input produced a double pause in the TTS audio:

```
# Input
"Hello world.\n\nSecond paragraph."

# Before fix
"Hello world. [pause] [pause] Second paragraph."

# After fix
"Hello world. [pause] Second paragraph."
```

## Root cause

The tag-detection guard (`_XAI_SPEECH_TAG_RE.search(clean)`) only runs once, on the **original** input text. After the paragraph substitution injects `[pause]`, there is no re-check — so the first-sentence substitution fires even when a pause was already inserted.

## Fix

Wrap the first-sentence substitution in a `_XAI_SPEECH_TAG_RE.search(clean)` guard. If the paragraph pass already added a `[pause]` tag, the first-sentence pass is skipped. Single-paragraph behavior is unchanged.

```python
clean = re.sub(r"\n\s*\n+", " [pause] ", clean)
clean = re.sub(r"\s*\n\s*", " ", clean)
if not _XAI_SPEECH_TAG_RE.search(clean):   # ← new guard
    clean = _XAI_FIRST_SENTENCE_RE.sub(r"\1 [pause] ", clean, count=1)
```

## Test plan

- [x] Multi-paragraph input → single `[pause]` (bug case)
- [x] Single-paragraph input → first-sentence `[pause]` still added (regression)
- [x] Input with explicit speech tags → untouched (existing behavior)
- [x] Single newline (not paragraph break) → first-sentence pause still fires
- [x] Empty input → unchanged