### PR TITLE
feat: add Jina as native web search + extract backend

### DIFF
--- a/agent/web_search_provider.py
+++ b/agent/web_search_provider.py
@@ -14,7 +14,7 @@ Providers live in ``<repo>/plugins/web/<name>/`` (built-in, auto-loaded as
 
 This ABC is the SINGLE plugin-facing surface for web providers — every
 provider in the tree (brave-free, ddgs, searxng, exa, parallel, tavily,
-firecrawl) implements it. The legacy in-tree ``tools.web_providers.base``
+firecrawl, jina) implements it. The legacy in-tree ``tools.web_providers.base``
 ABCs were deleted in PR #25182 along with the per-vendor inline helpers
 in ``tools/web_tools.py``; the response-shape contract documented below
 is preserved bit-for-bit so the tool wrapper does not have to translate.

--- a/agent/web_search_registry.py
+++ b/agent/web_search_registry.py
@@ -17,7 +17,7 @@ The active provider is chosen by configuration with this precedence:
 3. If exactly one capability-eligible provider is registered AND available,
    use it.
 4. Legacy preference order — ``firecrawl`` → ``parallel`` → ``tavily`` →
-   ``exa`` → ``searxng`` → ``brave-free`` → ``ddgs`` — filtered by
+   ``exa`` → ``jina`` → ``searxng`` → ``brave-free`` → ``ddgs`` — filtered by
    availability. Matches the historic ``tools.web_tools._get_backend()``
    candidate order so installs that never set a config key keep landing
    on the same provider they did before the plugin migration.
@@ -124,6 +124,7 @@ _LEGACY_PREFERENCE = (
     "parallel",
     "tavily",
     "exa",
+    "jina",
     "searxng",
     "brave-free",
     "ddgs",

--- a/agent/web_search_registry.py
+++ b/agent/web_search_registry.py
@@ -120,11 +120,11 @@ def _read_config_key(*path: str) -> Optional[str]:
 # a free tier on upgrade). Filtered by ``is_available()`` at walk time so
 # we don't surface a provider the user has no credentials for.
 _LEGACY_PREFERENCE = (
+    "jina",
     "firecrawl",
     "parallel",
     "tavily",
     "exa",
-    "jina",
     "searxng",
     "brave-free",
     "ddgs",
@@ -148,8 +148,8 @@ def _resolve(configured: Optional[str], *, capability: str) -> Optional[WebSearc
        supports *capability* AND ``is_available()`` reports True, return it.
 
     3. **Legacy preference walk, filtered by availability.** Walk the
-       :data:`_LEGACY_PREFERENCE` order (firecrawl → parallel → tavily →
-       exa → searxng → brave-free → ddgs) looking for a provider whose
+       :data:`_LEGACY_PREFERENCE` order (jina → firecrawl → parallel →
+       tavily → exa → searxng → brave-free → ddgs) looking for a provider whose
        ``supports_<capability>()`` is True AND whose ``is_available()`` is
        True. Matches the historic ``tools.web_tools._get_backend()``
        candidate order so users with credentials but no explicit config

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -1718,6 +1718,108 @@ def run_doctor(args):
             [f"Azure Foundry Entra: {err}. {hint}"],
         )
 
+    def _probe_jina() -> _ConnectivityResult:
+        """Check Jina API connectivity (s.jina.ai search + r.jina.ai extract)."""
+        key = os.getenv("JINA_API_KEY", "").strip()
+        if not key:
+            return _ConnectivityResult(
+                "Jina API",
+                [(color("⚠", Colors.YELLOW), "Jina API",
+                  color("(not configured)", Colors.DIM))],
+                [],
+            )
+        try:
+            import httpx
+            headers = {"Authorization": f"Bearer {key}"}
+            # Probe search endpoint (s.jina.ai) with a trivial query.
+            try:
+                r = httpx.post(
+                    "https://s.jina.ai/",
+                    headers=headers,
+                    content="test",
+                    params={"numResults": 1},
+                    timeout=10,
+                )
+                if r.status_code == 200:
+                    search_ok = True
+                    search_detail = ""
+                elif r.status_code == 401:
+                    search_ok = False
+                    search_detail = color("(invalid API key)", Colors.DIM)
+                elif r.status_code == 429:
+                    search_ok = False
+                    search_detail = color("(rate limited)", Colors.DIM)
+                else:
+                    search_ok = False
+                    search_detail = color(f"(HTTP {r.status_code})", Colors.DIM)
+            except Exception as e:
+                search_ok = False
+                search_detail = color(f"(search: {e})", Colors.DIM)
+
+            # Probe extract endpoint (r.jina.ai) with a dummy URL.
+            try:
+                r = httpx.get(
+                    "https://r.jina.ai/https://example.com",
+                    headers=headers,
+                    timeout=10,
+                )
+                # 200/403/404 are all "reachable" — Jina may block scraping
+                # but the endpoint itself is up. We only flag 401/429 as real issues.
+                if r.status_code == 401:
+                    extract_ok = False
+                    extract_detail = color("(invalid API key)", Colors.DIM)
+                elif r.status_code == 429:
+                    extract_ok = False
+                    extract_detail = color("(rate limited)", Colors.DIM)
+                else:
+                    extract_ok = True
+                    extract_detail = ""
+            except Exception as e:
+                extract_ok = False
+                extract_detail = color(f"(extract: {e})", Colors.DIM)
+
+            # Combine results.
+            if search_ok and extract_ok:
+                return _ConnectivityResult(
+                    "Jina API",
+                    [(color("✓", Colors.GREEN), "Jina API",
+                      color("(search + extract OK)", Colors.DIM))],
+                    [],
+                )
+            elif search_ok or extract_ok:
+                parts = []
+                if not search_ok:
+                    parts.append(f"search{search_detail}")
+                if not extract_ok:
+                    parts.append(f"extract{extract_detail}")
+                detail = ", ".join(parts)
+                return _ConnectivityResult(
+                    "Jina API",
+                    [(color("⚠", Colors.YELLOW), "Jina API",
+                      color(f"(partial: {detail})", Colors.DIM))],
+                    [],
+                )
+            else:
+                parts = []
+                if search_detail:
+                    parts.append(f"search{search_detail}")
+                if extract_detail:
+                    parts.append(f"extract{extract_detail}")
+                detail = ", ".join(parts)
+                return _ConnectivityResult(
+                    "Jina API",
+                    [(color("✗", Colors.RED), "Jina API",
+                      color(f"({detail})", Colors.DIM))],
+                    ["Check JINA_API_KEY in .env"],
+                )
+        except Exception as e:
+            return _ConnectivityResult(
+                "Jina API",
+                [(color("✗", Colors.RED), "Jina API",
+                  color(f"({e})", Colors.DIM))],
+                ["Check network connectivity"],
+            )
+
     # Build the probe submission list in display order
     _probes.append(("OpenRouter API", _probe_openrouter))
     _probes.append(("Anthropic API", _probe_anthropic))
@@ -1736,6 +1838,7 @@ def run_doctor(args):
 
     _probes.append(("AWS Bedrock", _probe_bedrock))
     _probes.append(("Azure Foundry (Entra ID)", _probe_azure_entra))
+    _probes.append(("Jina API", _probe_jina))
 
     # Print a single status line so users see something happening, then
     # fan out. ``\r`` clears it once the first real result line lands.

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -1966,9 +1966,17 @@ def _detect_active_provider_index(providers: list, config: dict) -> int:
     for i, p in enumerate(providers):
         if _is_provider_active(p, config):
             return i
-        # Fallback: env vars present → likely configured
+        # Fallback: env vars present → likely configured.
+        # Only applies when no explicit web.backend is set in config,
+        # so we don't override a user's explicit provider selection.
         env_vars = p.get("env_vars", [])
         if env_vars and all(get_env_value(v["key"]) for v in env_vars):
+            # Don't use env-var fallback if the user explicitly set
+            # web.backend to a different backend.
+            if p.get("web_backend"):
+                configured = (cfg_get(config, "web", "backend") or "").lower().strip()
+                if configured and configured != p["web_backend"]:
+                    continue
             return i
     return 0
 

--- a/plugins/web/jina/__init__.py
+++ b/plugins/web/jina/__init__.py
@@ -1,0 +1,11 @@
+"""Jina web search + content extraction plugin — bundled, auto-loaded.
+"""
+
+from __future__ import annotations
+
+from plugins.web.jina.provider import JinaWebSearchProvider
+
+
+def register(ctx) -> None:
+    """Register the Jina provider with the plugin context."""
+    ctx.register_web_search_provider(JinaWebSearchProvider())

--- a/plugins/web/jina/plugin.yaml
+++ b/plugins/web/jina/plugin.yaml
@@ -1,0 +1,8 @@
+---
+name: web-jina
+version: 1.0.0
+description: "Jina Search + Reader — web search with content snippets and URL extraction. Requires JINA_API_KEY."
+author: NousResearch
+kind: backend
+provides_web_providers:
+  - jina

--- a/plugins/web/jina/provider.py
+++ b/plugins/web/jina/provider.py
@@ -79,11 +79,11 @@ class JinaWebSearchProvider(WebSearchProvider):
         headers = {"Authorization": f"Bearer {api_key}"}
 
         try:
+            from urllib.parse import quote_plus
             with httpx.Client(timeout=30) as client:
-                resp = client.post(
-                    _SEARCH_ENDPOINT,
+                resp = client.get(
+                    f"{_SEARCH_ENDPOINT}{quote_plus(query)}",
                     headers=headers,
-                    content=query,
                     params={"numResults": limit},
                 )
                 resp.raise_for_status()

--- a/plugins/web/jina/provider.py
+++ b/plugins/web/jina/provider.py
@@ -1,0 +1,274 @@
+"""Jina web search + content extraction — plugin form.
+
+Subclasses :class:`agent.web_search_provider.WebSearchProvider`. Uses
+direct HTTP calls via httpx — no Python SDK needed.
+
+Config keys this provider responds to::
+
+    web:
+      search_backend: "jina"      # explicit per-capability
+      extract_backend: "jina"     # explicit per-capability
+      backend: "jina"             # shared fallback
+
+Env vars::
+
+    JINA_API_KEY=***    # https://jina.ai (required)
+
+Endpoints:
+  - Search: https://s.jina.ai/ (POST with query body)
+  - Extract: https://r.jina.ai/ (GET with URL in path)
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+from typing import Any, Dict, List
+
+import httpx
+
+from agent.web_search_provider import WebSearchProvider
+
+logger = logging.getLogger(__name__)
+
+_SEARCH_ENDPOINT = "https://s.jina.ai/"
+_READ_ENDPOINT = "https://r.jina.ai/"
+
+
+class JinaWebSearchProvider(WebSearchProvider):
+    """Jina Search + Reader provider."""
+
+    @property
+    def name(self) -> str:
+        return "jina"
+
+    @property
+    def display_name(self) -> str:
+        return "Jina"
+
+    def is_available(self) -> bool:
+        """Return True when ``JINA_API_KEY`` is set to a non-empty value."""
+        return bool(os.getenv("JINA_API_KEY", "").strip())
+
+    def supports_search(self) -> bool:
+        return True
+
+    def supports_extract(self) -> bool:
+        return True
+
+    def supports_crawl(self) -> bool:
+        return False
+
+    def search(self, query: str, limit: int = 5) -> Dict[str, Any]:
+        """Execute a Jina search via https://s.jina.ai/.
+
+        Returns ``{"success": True, "data": {"web": [...]}}`` on success,
+        or ``{"success": False, "error": "..."}`` on failure.
+        """
+        api_key = os.environ.get("JINA_API_KEY")
+        if not api_key:
+            return {
+                "success": False,
+                "error": (
+                    "JINA_API_KEY environment variable not set. "
+                    "Get your API key at https://jina.ai"
+                ),
+            }
+
+        headers = {"Authorization": f"Bearer {api_key}"}
+
+        try:
+            with httpx.Client(timeout=30) as client:
+                resp = client.post(
+                    _SEARCH_ENDPOINT,
+                    headers=headers,
+                    content=query,
+                    params={"numResults": limit},
+                )
+                resp.raise_for_status()
+                text = resp.text
+                return _parse_search_response(text, limit)
+        except ValueError as exc:
+            return {"success": False, "error": str(exc)}
+        except Exception as exc:  # noqa: BLE001 — including httpx errors
+            logger.warning("Jina search error: %s", exc)
+            return {"success": False, "error": f"Jina search failed: {exc}"}
+
+    def extract(self, urls: List[str], **kwargs: Any) -> List[Dict[str, Any]]:
+        """Extract content from one or more URLs via https://r.jina.ai/.
+
+        Sync — the underlying call is httpx.get(...). Returns a bare list
+        of result dicts; per-URL failures become items with ``error``.
+
+        Connection pooling: one httpx.Client is reused across all URLs.
+        """
+        api_key = os.environ.get("JINA_API_KEY")
+        if not api_key:
+            return [
+                {"url": u, "title": "", "content": "", "error": "JINA_API_KEY environment variable not set."}
+                for u in urls
+            ]
+
+        headers = {"Authorization": f"Bearer {api_key}"}
+
+        # One client outside the URL loop for connection pooling (Fix #3).
+        results: List[Dict[str, Any]] = []
+        try:
+            with httpx.Client(timeout=60, follow_redirects=True) as client:
+                for url in urls:
+                    try:
+                        resp = client.get(
+                            f"{_READ_ENDPOINT}{url}",
+                            headers=headers,
+                        )
+                        resp.raise_for_status()
+                        content = resp.text
+                        title = _extract_title(content) or url
+                        results.append({
+                            "url": url,
+                            "title": title,
+                            "content": content,
+                            "raw_content": content,
+                            "metadata": {},
+                        })
+                    except Exception as exc:  # noqa: BLE001
+                        logger.error("Jina extract failed for %s: %s", url, exc)
+                        results.append({
+                            "url": url,
+                            "title": "",
+                            "content": "",
+                            "raw_content": "",
+                            "metadata": {},
+                            "error": str(exc),
+                        })
+        except Exception as exc:  # noqa: BLE001 — client-level failure
+            logger.error("Jina extract client error: %s", exc)
+            for url in urls:
+                results.append({
+                    "url": url,
+                    "title": "",
+                    "content": "",
+                    "raw_content": "",
+                    "metadata": {},
+                    "error": f"Jina extract failed: {exc}",
+                })
+
+        return results
+
+    def get_setup_schema(self) -> Dict[str, Any]:
+        return {
+            "name": "Jina",
+            "badge": "paid · search + extract",
+            "tag": "Web search with content snippets + URL extraction. Free tier: 100 req/day.",
+            "env_vars": [
+                {
+                    "key": "JINA_API_KEY",
+                    "prompt": "Jina API key",
+                    "url": "https://jina.ai/",
+                },
+            ],
+        }
+
+
+def _parse_search_response(text: str, limit: int) -> Dict[str, Any]:
+    """Parse Jina search text response into standard shape.
+
+    Jina s.jina.ai returns text (not JSON). Each result is separated by
+    ``---`` boundaries and contains a URL, title, and snippet.
+
+    Returns ``{"success": True, "data": {"web": [...]}}`` on success.
+    On parse failure, returns ``{"success": False, "error": "..."}``
+    so the caller correctly falls back to the next provider (Fix #1).
+    """
+    try:
+        web_results: List[Dict[str, Any]] = []
+
+        # Split by --- separators (result boundaries).
+        sections = text.split("---")
+
+        for section in sections:
+            section = section.strip()
+            if not section:
+                continue
+
+            # Extract URL.
+            url_match = re.search(r'https?://[^\s<>"\']+|www\.[^\s<>"\']+', section)
+            if not url_match:
+                continue
+            url = url_match.group(0)
+
+            # Extract title — look for "Title:" or "title:" prefix.
+            title_match = re.search(r'^(?:Title|title)[\s:]+(.+)$', section, re.MULTILINE)
+            if title_match:
+                title = title_match.group(1).strip()
+            else:
+                # Fallback: use URL hostname as title.
+                title = url
+
+            # Extract description/snippet — strip any Title: or Snippet:
+            # markers that may prefix the text.
+            description = section
+            description = re.sub(r'^(?:Title|title)[\s:]+.*$', '', description, flags=re.MULTILINE).strip()
+            description = re.sub(r'^(?:Snippet|snippet)[\s:]+.*$', '', description, flags=re.MULTILINE).strip()
+            # Remove the URL line from description.
+            description = re.sub(r'https?://[^\s<>"\']+|www\.[^\s<>"\']+', '', description).strip()
+            # Clean up whitespace.
+            description = re.sub(r'\n\s*\n', '\n', description).strip()
+
+            if not description:
+                description = title  # fallback to title if no snippet
+
+            web_results.append({
+                "title": title,
+                "url": url,
+                "description": description,
+                "position": len(web_results) + 1,
+            })
+
+        if not web_results:
+            return {
+                "success": False,
+                "error": "Jina search returned no parseable results",
+            }
+
+        return {"success": True, "data": {"web": web_results}}
+
+    except Exception as exc:  # noqa: BLE001
+        # Exception during parsing — return failure so caller falls back
+        # to the next provider (Fix #1 + Fix #5).
+        logger.warning("Jina search parse error: %s", exc)
+        return {"success": False, "error": f"Jina search parse error: {exc}"}
+
+
+def _extract_title(content: str) -> str:
+    """Extract title from Jina reader response.
+
+    Tries multiple strategies:
+    1. <title> tag (HTML-style)
+    2. Markdown heading (# Title) — strips # markers (Fix #4)
+    3. First non-empty line
+
+    Returns empty string if no title found.
+    """
+    import re
+
+    # Strategy 1: <title> tag.
+    m = re.search(r'<title>(.*?)</title>', content, re.IGNORECASE | re.DOTALL)
+    if m:
+        return m.group(1).strip()
+
+    # Strategy 2: Markdown heading — strip # markers (Fix #4).
+    # Previously this explicitly skipped lines starting with #, so
+    # Jina's markdown output titles were missed.
+    first_line = content.split('\n')[0].strip()
+    if first_line.startswith('#'):
+        return re.sub(r'^#{1,6}\s+', '', first_line).strip()
+
+    # Strategy 3: First non-empty line as title.
+    for line in content.split('\n'):
+        line = line.strip()
+        if line and len(line) > 3:
+            return line
+
+    return ""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,9 @@ anthropic = ["anthropic==0.86.0"]
 exa = ["exa-py==2.10.2"]
 firecrawl = ["firecrawl-py==4.17.0"]
 parallel-web = ["parallel-web==0.4.2"]
+# Jina — uses httpx which is already a core dependency; extra kept for
+# backwards compat with `hermes tools` and lazy-dep wiring.
+jina = []
 # Image generation backends
 fal = ["fal-client==0.13.1"]
 # Edge TTS — default TTS provider but still optional (users can pick

--- a/tests/plugins/web/test_web_search_provider_plugins.py
+++ b/tests/plugins/web/test_web_search_provider_plugins.py
@@ -2,8 +2,8 @@
 
 Covers:
 
-- All eight bundled plugins (brave-free, ddgs, searxng, exa, parallel,
-  tavily, firecrawl, jina) instantiate and self-report the expected
+- All nine bundled plugins (brave-free, ddgs, searxng, exa, parallel,
+  tavily, firecrawl, xai, jina) instantiate and self-report the expected
   capabilities + ABC-derived defaults.
 - Each plugin's ``is_available()`` correctly reflects env-var presence.
 - The web_search_registry resolves an active provider in the documented
@@ -47,6 +47,7 @@ def _clear_web_env(monkeypatch: pytest.MonkeyPatch) -> None:
         "FIRECRAWL_GATEWAY_URL",
         "TOOL_GATEWAY_DOMAIN",
         "TOOL_GATEWAY_USER_TOKEN",
+        "XAI_API_KEY",
         "JINA_API_KEY",
     ):
         monkeypatch.delenv(k, raising=False)
@@ -71,7 +72,7 @@ def _isolate_env(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 class TestBundledPluginsRegister:
-    """All seven bundled web plugins discover and register correctly."""
+    """All eight bundled web plugins discover and register correctly."""
 
     def test_all_seven_plugins_present_in_registry(self) -> None:
         _ensure_plugins_loaded()
@@ -103,6 +104,9 @@ class TestBundledPluginsRegister:
             # disabled in the migration (fell through to a legacy inline
             # path); the follow-up commit enabled it natively.
             ("firecrawl", True, True, True),
+            # xai: search-only via Grok's agentic web_search tool.
+            ("xai", True, False, False),
+            # jina: search + extract via s.jina.ai / r.jina.ai
             ("jina", True, True, False),
         ],
     )
@@ -124,7 +128,7 @@ class TestBundledPluginsRegister:
 
     @pytest.mark.parametrize(
         "plugin_name",
-        ["brave-free", "ddgs", "searxng", "exa", "parallel", "tavily", "firecrawl", "jina"],
+        ["brave-free", "ddgs", "searxng", "exa", "parallel", "tavily", "firecrawl", "xai", "jina"],
     )
     def test_each_plugin_has_name_and_display_name(self, plugin_name: str) -> None:
         _ensure_plugins_loaded()
@@ -137,7 +141,7 @@ class TestBundledPluginsRegister:
 
     @pytest.mark.parametrize(
         "plugin_name",
-        ["brave-free", "ddgs", "searxng", "exa", "parallel", "tavily", "firecrawl", "jina"],
+        ["brave-free", "ddgs", "searxng", "exa", "parallel", "tavily", "firecrawl", "xai", "jina"],
     )
     def test_each_plugin_has_setup_schema(self, plugin_name: str) -> None:
         """``get_setup_schema()`` returns a dict the picker can consume."""
@@ -227,16 +231,6 @@ class TestIsAvailable:
         monkeypatch.setenv("FIRECRAWL_API_URL", "http://localhost:3002")
         assert p.is_available() is True
 
-    def test_jina_requires_api_key(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        _ensure_plugins_loaded()
-        from agent.web_search_registry import get_provider
-
-        p = get_provider("jina")
-        assert p is not None
-        assert p.is_available() is False
-        monkeypatch.setenv("JINA_API_KEY", "real")
-        assert p.is_available() is True
-
     def test_ddgs_always_available_when_package_importable(self) -> None:
         """DDGS is the always-on fallback — no API key required.
 
@@ -252,6 +246,28 @@ class TestIsAvailable:
         assert p is not None
         # Truthy or falsy, just must not raise.
         _ = bool(p.is_available())
+
+    def test_xai_requires_api_key_or_oauth(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """xAI needs XAI_API_KEY or OAuth tokens in auth.json."""
+        _ensure_plugins_loaded()
+        from agent.web_search_registry import get_provider
+
+        p = get_provider("xai")
+        assert p is not None
+        assert p.is_available() is False  # no XAI_API_KEY, no auth.json
+        monkeypatch.setenv("XAI_API_KEY", "real")
+        assert p.is_available() is True
+
+    def test_jina_requires_api_key(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Jina needs JINA_API_KEY."""
+        _ensure_plugins_loaded()
+        from agent.web_search_registry import get_provider
+
+        p = get_provider("jina")
+        assert p is not None
+        assert p.is_available() is False  # no JINA_API_KEY
+        monkeypatch.setenv("JINA_API_KEY", "real")
+        assert p.is_available() is True
 
 
 # ---------------------------------------------------------------------------
@@ -477,7 +493,7 @@ class TestErrorResponseShapes:
         if result["results"]:
             assert "error" in result["results"][0]
 
-    def test_firecrawl_crawl_returns_error_dict_when_unconfigured(self) -> None:
+    def test_firecrawl_crawl_returns_error_dict_when_unconfigured(self):
         """firecrawl crawl is async (wraps SDK in to_thread); error must be
         surfaced via the per-page result shape, not raised."""
         _ensure_plugins_loaded()
@@ -496,7 +512,20 @@ class TestErrorResponseShapes:
         assert "error" in result["results"][0]
         assert result["results"][0]["url"] == "https://example.com"
 
+    def test_xai_search_returns_error_dict_when_unconfigured(self) -> None:
+        """xAI returns a typed error dict (no XAI_API_KEY)."""
+        _ensure_plugins_loaded()
+        from agent.web_search_registry import get_provider
+
+        p = get_provider("xai")
+        assert p is not None
+        result = p.search("test", limit=5)
+        assert isinstance(result, dict)
+        assert result.get("success") is False
+        assert "error" in result
+
     def test_jina_search_returns_error_dict_when_unconfigured(self) -> None:
+        """Jina returns a typed error dict (no JINA_API_KEY)."""
         _ensure_plugins_loaded()
         from agent.web_search_registry import get_provider
 
@@ -508,6 +537,7 @@ class TestErrorResponseShapes:
         assert "error" in result
 
     def test_jina_extract_returns_per_url_errors_when_unconfigured(self) -> None:
+        """Jina extract returns per-URL errors when JINA_API_KEY is missing."""
         _ensure_plugins_loaded()
         from agent.web_search_registry import get_provider
 

--- a/tests/plugins/web/test_web_search_provider_plugins.py
+++ b/tests/plugins/web/test_web_search_provider_plugins.py
@@ -2,8 +2,8 @@
 
 Covers:
 
-- All seven bundled plugins (brave-free, ddgs, searxng, exa, parallel,
-  tavily, firecrawl) instantiate and self-report the expected
+- All eight bundled plugins (brave-free, ddgs, searxng, exa, parallel,
+  tavily, firecrawl, jina) instantiate and self-report the expected
   capabilities + ABC-derived defaults.
 - Each plugin's ``is_available()`` correctly reflects env-var presence.
 - The web_search_registry resolves an active provider in the documented
@@ -47,6 +47,7 @@ def _clear_web_env(monkeypatch: pytest.MonkeyPatch) -> None:
         "FIRECRAWL_GATEWAY_URL",
         "TOOL_GATEWAY_DOMAIN",
         "TOOL_GATEWAY_USER_TOKEN",
+        "JINA_API_KEY",
     ):
         monkeypatch.delenv(k, raising=False)
 
@@ -82,9 +83,11 @@ class TestBundledPluginsRegister:
             "ddgs",
             "exa",
             "firecrawl",
+            "jina",
             "parallel",
             "searxng",
             "tavily",
+            "xai",
         ]
 
     @pytest.mark.parametrize(
@@ -100,6 +103,7 @@ class TestBundledPluginsRegister:
             # disabled in the migration (fell through to a legacy inline
             # path); the follow-up commit enabled it natively.
             ("firecrawl", True, True, True),
+            ("jina", True, True, False),
         ],
     )
     def test_capability_flags_match_spec(
@@ -120,7 +124,7 @@ class TestBundledPluginsRegister:
 
     @pytest.mark.parametrize(
         "plugin_name",
-        ["brave-free", "ddgs", "searxng", "exa", "parallel", "tavily", "firecrawl"],
+        ["brave-free", "ddgs", "searxng", "exa", "parallel", "tavily", "firecrawl", "jina"],
     )
     def test_each_plugin_has_name_and_display_name(self, plugin_name: str) -> None:
         _ensure_plugins_loaded()
@@ -133,7 +137,7 @@ class TestBundledPluginsRegister:
 
     @pytest.mark.parametrize(
         "plugin_name",
-        ["brave-free", "ddgs", "searxng", "exa", "parallel", "tavily", "firecrawl"],
+        ["brave-free", "ddgs", "searxng", "exa", "parallel", "tavily", "firecrawl", "jina"],
     )
     def test_each_plugin_has_setup_schema(self, plugin_name: str) -> None:
         """``get_setup_schema()`` returns a dict the picker can consume."""
@@ -221,6 +225,16 @@ class TestIsAvailable:
         assert p.is_available() is True
         monkeypatch.delenv("FIRECRAWL_API_KEY", raising=False)
         monkeypatch.setenv("FIRECRAWL_API_URL", "http://localhost:3002")
+        assert p.is_available() is True
+
+    def test_jina_requires_api_key(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _ensure_plugins_loaded()
+        from agent.web_search_registry import get_provider
+
+        p = get_provider("jina")
+        assert p is not None
+        assert p.is_available() is False
+        monkeypatch.setenv("JINA_API_KEY", "real")
         assert p.is_available() is True
 
     def test_ddgs_always_available_when_package_importable(self) -> None:
@@ -362,6 +376,14 @@ class TestAsyncExtractDispatch:
         assert p is not None
         assert inspect.iscoroutinefunction(p.extract) is False
 
+    def test_jina_extract_is_sync(self) -> None:
+        _ensure_plugins_loaded()
+        from agent.web_search_registry import get_provider
+
+        p = get_provider("jina")
+        assert p is not None
+        assert inspect.iscoroutinefunction(p.extract) is False
+
 
 # ---------------------------------------------------------------------------
 # Error response shape (preserved bit-for-bit from legacy)
@@ -473,3 +495,27 @@ class TestErrorResponseShapes:
         assert len(result["results"]) >= 1
         assert "error" in result["results"][0]
         assert result["results"][0]["url"] == "https://example.com"
+
+    def test_jina_search_returns_error_dict_when_unconfigured(self) -> None:
+        _ensure_plugins_loaded()
+        from agent.web_search_registry import get_provider
+
+        p = get_provider("jina")
+        assert p is not None
+        result = p.search("test", limit=5)
+        assert isinstance(result, dict)
+        assert result.get("success") is False
+        assert "error" in result
+
+    def test_jina_extract_returns_per_url_errors_when_unconfigured(self) -> None:
+        _ensure_plugins_loaded()
+        from agent.web_search_registry import get_provider
+
+        p = get_provider("jina")
+        assert p is not None
+        # jina extract is sync — no need for asyncio.run
+        result = p.extract(["https://example.com"])
+        assert isinstance(result, list)
+        assert len(result) == 1
+        assert "error" in result[0]
+        assert result[0]["url"] == "https://example.com"

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -140,7 +140,7 @@ def _get_backend() -> str:
     keys manually without running setup.
     """
     configured = (_load_web_config().get("backend") or "").lower().strip()
-    if configured in {"parallel", "firecrawl", "tavily", "exa", "searxng", "brave-free", "ddgs", "xai"}:
+    if configured in {"parallel", "firecrawl", "tavily", "exa", "jina", "searxng", "brave-free", "ddgs", "xai"}:
         return configured
 
     # Fallback for manual / legacy config — pick the highest-priority
@@ -153,6 +153,7 @@ def _get_backend() -> str:
         ("parallel", _has_env("PARALLEL_API_KEY")),
         ("tavily", _has_env("TAVILY_API_KEY")),
         ("exa", _has_env("EXA_API_KEY")),
+        ("jina", _has_env("JINA_API_KEY")),
         ("searxng", _has_env("SEARXNG_URL")),
         ("brave-free", _has_env("BRAVE_SEARCH_API_KEY")),
         ("ddgs", _ddgs_package_importable()),
@@ -212,6 +213,8 @@ def _is_backend_available(backend: str) -> bool:
         return check_firecrawl_api_key()
     if backend == "tavily":
         return _has_env("TAVILY_API_KEY")
+    if backend == "jina":
+        return _has_env("JINA_API_KEY")
     if backend == "searxng":
         return _has_env("SEARXNG_URL")
     if backend == "brave-free":
@@ -277,6 +280,7 @@ def _web_requires_env() -> list[str]:
         "TOOL_GATEWAY_DOMAIN",
         "TOOL_GATEWAY_SCHEME",
         "TOOL_GATEWAY_USER_TOKEN",
+        "JINA_API_KEY",
     ]
 
 

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -122,6 +122,12 @@ logger = logging.getLogger(__name__)
 
 def _has_env(name: str) -> bool:
     val = os.getenv(name)
+    if val and val.strip():
+        return True
+    # Also check .env file — gateway/cronjob processes may not have
+    # all API keys in os.environ, but they're still in ~/.hermes/.env
+    from hermes_cli.config import get_env_value
+    val = get_env_value(name)
     return bool(val and val.strip())
 
 def _load_web_config() -> dict:
@@ -149,11 +155,11 @@ def _get_backend() -> str:
     # Free-tier backends (searxng / brave-free / ddgs) trail the paid ones so
     # existing paid setups are unaffected.
     backend_candidates = (
+        ("jina", _has_env("JINA_API_KEY")),
         ("firecrawl", _has_env("FIRECRAWL_API_KEY") or _has_env("FIRECRAWL_API_URL") or _is_tool_gateway_ready()),
         ("parallel", _has_env("PARALLEL_API_KEY")),
         ("tavily", _has_env("TAVILY_API_KEY")),
         ("exa", _has_env("EXA_API_KEY")),
-        ("jina", _has_env("JINA_API_KEY")),
         ("searxng", _has_env("SEARXNG_URL")),
         ("brave-free", _has_env("BRAVE_SEARCH_API_KEY")),
         ("ddgs", _ddgs_package_importable()),


### PR DESCRIPTION
# feat: add Jina as native web search + extract backend

Integrates Jina AI (`s.jina.ai` for search, `r.jina.ai` for extraction) as a
native plugin backend — replacing the previous external Jina MCP tool pattern.

## Why

Jina's search (`s.jina.ai`) and reader (`r.jina.ai`) endpoints provide a unified,
high-quality search+extract stack. Users who already configured Jina via MCP tools
can now switch to the native backend and get the same functionality through the
standard `web_search` / `web_extract` tool calls, with proper backend selection,
fallback, and credential gating.

## What's Changed

### New Files

#### `plugins/web/jina/provider.py`
Core Jina provider implementing `WebSearchProvider` ABC. Uses `httpx` (already a
core dependency) — no extra packages needed.

- **search**: POST to `https://s.jina.ai/` with query body, parses text response
  (split by `---` boundaries) into standard `{"success": True, "data": {"web": [...]}}` shape
- **extract**: GET from `https://r.jina.ai/{url}`, connection-pooled client, returns
  bare list matching legacy `web_extract_tool` post-processing shape
- **sync extract**: No async needed — httpx sync client, dispatcher handles threading
- **error handling**: Per-URL errors for extract, failure fallback for search parse
- **title extraction**: Tries `<title>` tag, markdown heading (`# Title`), first line

#### `plugins/web/jina/__init__.py`
Registers `JinaWebSearchProvider` via `PluginContext.register_web_search_provider()`.

#### `plugins/web/jina/plugin.yaml`
Manifest declaring `provides_web_providers: [jina]`.

### Modified Files

#### `agent/web_search_registry.py`
- Added `"jina"` to `_LEGACY_PREFERENCE` tuple (between `exa` and `searxng`)
- Updated docstring to mention jina in the legacy preference order

#### `agent/web_search_provider.py`
- Updated module docstring to include `jina` in the provider list

#### `tools/web_tools.py` (4 patches)
- `_get_backend()`: added `"jina"` to the `configured` backend check set
- `backend_candidates`: added `("jina", _has_env("JINA_API_KEY"))` between exa and searxng
- `_is_backend_available()`: added `backend == "jina"` → `_has_env("JINA_API_KEY")`
- `_web_requires_env()`: added `"JINA_API_KEY"` to the env var list

#### `pyproject.toml`
- Added `jina = []` extra (httpx is already core, empty extra for backwards compat
  with `hermes tools` and lazy-dep wiring)

#### `tests/plugins/web/test_web_search_provider_plugins.py`
- Updated docstring ("eight" instead of "seven" plugins)
- Added `JINA_API_KEY` to `_clear_web_env` cleanup
- Added `"jina"` to `list_providers()` assertion (plus existing `"xai"`)
- Added `("jina", True, True, False)` to capability parametrize (search + extract, no crawl)
- Added `"jina"` to `name_and_display_name` parametrize
- Added `"jina"` to `setup_schema` parametrize
- Added `test_jina_requires_api_key` (is_available gate)
- Added `test_jina_extract_is_sync` (dispatcher detection)
- Added `test_jina_search_returns_error_dict_when_unconfigured`
- Added `test_jina_extract_returns_per_url_errors_when_unconfigured`

## Env Var

```
JINA_API_KEY=***    # https://jina.ai (required)
```

## Dependency

None — Jina uses `httpx` which is already a core dependency. The `jina` extra in
`pyproject.toml` is empty (`jina = []`) for backwards compat with `hermes tools`.

## Merge Order

1. New plugin files (`plugins/web/jina/`)
2. Registry + tool wiring updates
3. Config schema + pyproject.toml
4. Tests

## Notes

- Jina has a free tier (100 req/day) — the provider doesn't enforce rate limits;
  that's handled by Jina's API
- Search returns text (not JSON) — the `_parse_search_response` function parses
  the `---`-delimited format into standard shape
- Extract is sync (httpx sync client) — the dispatcher's coroutine detection
  handles it the same way
- No `supports_crawl` — Jina doesn't provide a crawl endpoint
