### PR TITLE
Guard move patches against sensitive paths

### DIFF
--- a/tests/tools/test_file_tools.py
+++ b/tests/tools/test_file_tools.py
@@ -198,6 +198,35 @@ class TestPatchHandler:
         assert result["status"] == "ok"
         mock_ops.patch_v4a.assert_called_once()
 
+    def test_v4a_path_extraction_includes_move_source_and_destination(self):
+        from tools.file_tools import _extract_v4a_patch_paths_for_checks
+
+        paths = _extract_v4a_patch_paths_for_checks(
+            "*** Begin Patch\n"
+            "*** Update File: app.py\n"
+            "*** Move File: src/config.py -> /etc/hosts\n"
+            "*** End Patch"
+        )
+
+        assert paths == ["app.py", "src/config.py", "/etc/hosts"]
+
+    @patch("tools.file_tools._get_file_ops")
+    def test_patch_mode_blocks_sensitive_move_destination(self, mock_get):
+        from tools.file_tools import patch_tool
+
+        result = json.loads(patch_tool(
+            mode="patch",
+            patch=(
+                "*** Begin Patch\n"
+                "*** Move File: src/config.py -> /etc/hosts\n"
+                "*** End Patch"
+            ),
+        ))
+
+        assert "error" in result
+        assert "sensitive system path" in result["error"]
+        mock_get.assert_not_called()
+
     @patch("tools.file_tools._get_file_ops")
     def test_patch_mode_missing_content_errors(self, mock_get):
         from tools.file_tools import patch_tool

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -5,6 +5,7 @@ import errno
 import json
 import logging
 import os
+import re
 import threading
 from pathlib import Path
 
@@ -847,6 +848,26 @@ def write_file_tool(path: str, content: str, task_id: str = "default") -> str:
         return tool_error(str(e))
 
 
+def _extract_v4a_patch_paths_for_checks(patch_content: str) -> list[str]:
+    """Return every filesystem path referenced by V4A file operation markers."""
+    paths: list[str] = []
+    for line in patch_content.splitlines():
+        file_match = re.match(
+            r"^\*\*\*\s*(?:Update|Add|Delete)\s+File:\s*(.+)$",
+            line,
+        )
+        if file_match:
+            paths.append(file_match.group(1).strip())
+            continue
+
+        move_match = re.match(r"^\*\*\*\s*Move\s+File:\s*(.+?)\s*->\s*(.+)$", line)
+        if move_match:
+            paths.append(move_match.group(1).strip())
+            paths.append(move_match.group(2).strip())
+
+    return paths
+
+
 def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
                new_string: str = None, replace_all: bool = False, patch: str = None,
                task_id: str = "default") -> str:
@@ -856,9 +877,7 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
     if path:
         _paths_to_check.append(path)
     if mode == "patch" and patch:
-        import re as _re
-        for _m in _re.finditer(r'^\*\*\*\s+(?:Update|Add|Delete)\s+File:\s*(.+)$', patch, _re.MULTILINE):
-            _paths_to_check.append(_m.group(1).strip())
+        _paths_to_check.extend(_extract_v4a_patch_paths_for_checks(patch))
     for _p in _paths_to_check:
         sensitive_err = _check_sensitive_path(_p, task_id)
         if sensitive_err:


### PR DESCRIPTION
## Summary
- include V4A Move File source and destination paths in patch preflight checks
- apply the existing sensitive-path guard, lock, and staleness bookkeeping to move operations
- add regression coverage for sensitive move destinations

## Validation
- scripts/run_tests.sh tests/tools/test_file_tools.py tests/tools/test_file_write_safety.py