### PR TITLE
fix(tui): anchor splitReasoning unclosed-tag regex; stop eating last paragraph

### DIFF
--- a/ui-tui/src/__tests__/reasoning.test.ts
+++ b/ui-tui/src/__tests__/reasoning.test.ts
@@ -21,11 +21,26 @@ describe('splitReasoning', () => {
     expect(text).toBe('body')
   })
 
-  it('treats unclosed trailing <think>… as reasoning', () => {
-    const { reasoning, text } = splitReasoning('answer start <think>still deciding')
+  it('treats unclosed leading <think>… as reasoning (real reasoning-model stream)', () => {
+    const { reasoning, text } = splitReasoning('<think>still deciding')
 
     expect(reasoning).toBe('still deciding')
-    expect(text).toBe('answer start')
+    expect(text).toBe('')
+  })
+
+  it('does not strip trailing prose after a stray mid-text <think> mention', () => {
+    // Regression for "TUI eats last paragraph of output": when the model
+    // emits a literal `<think>` somewhere in prose (quoted explanation, code
+    // example, partial stream-mid-tag), the trailing greedy unclosed-tag
+    // regex used to consume every paragraph after it. Real unclosed
+    // reasoning blocks always lead the message — anchor to ^ so prose
+    // mentions are preserved.
+    const { reasoning, text } = splitReasoning(
+      'final answer paragraph one.\n\n<think>internal note never closed\n\nfinal answer paragraph two.'
+    )
+
+    expect(reasoning).toBe('')
+    expect(text).toBe('final answer paragraph one.\n\n<think>internal note never closed\n\nfinal answer paragraph two.')
   })
 
   it('returns empty reasoning and untouched text when no tags present', () => {

--- a/ui-tui/src/lib/reasoning.ts
+++ b/ui-tui/src/lib/reasoning.ts
@@ -21,7 +21,12 @@ export function splitReasoning(input: string): SplitReasoning {
       return ''
     })
 
-    const unclosed = new RegExp(`<${tag}>([\\s\\S]*)$`, 'i')
+    // Anchor to start-of-input so a literal `<think>` mid-prose (model quoting
+    // the word, code blocks containing the tag, etc.) doesn't eat every
+    // paragraph after it. Real unclosed reasoning blocks always lead the
+    // message — that's how reasoning models stream. See test
+    // "does not strip trailing prose after a stray mid-text <think> mention".
+    const unclosed = new RegExp(`^\\s*<${tag}>([\\s\\S]*)$`, 'i')
     text = text.replace(unclosed, (_m, inner: string) => {
       const trimmed = inner.trim()
 


### PR DESCRIPTION
## Symptom

User report: "TUI eats last paragraph of output" — happens both during streaming and on completed turns, intermittent.

## Root cause

`ui-tui/src/lib/reasoning.ts → splitReasoning()` first strips paired `<think>…</think>` blocks, then runs an **unclosed-trailing** regex to catch reasoning that hasn't yet streamed its closer. That second regex was unanchored and greedy:

```ts
const unclosed = new RegExp(`<${tag}>([\\s\\S]*)$`, 'i')
```

So **any literal `<think>` anywhere in prose** — a model quoting the tag, a code example, partial stream-mid-tag before the `</think>` arrives — consumed every paragraph after it to EOF. The trailing content was reclassified as reasoning (hidden behind details) and silently disappeared from the visible message body.

This applied to all five tags handled: `think`, `reasoning`, `thinking`, `thought`, `REASONING_SCRATCHPAD`.

## Empirical repro (pre-fix)

```ts
splitReasoning(
  'final answer paragraph one.\n\n<think>internal note\n\nfinal answer paragraph two.'
)
// text:      'final answer paragraph one.'        ← paragraph two GONE
// reasoning: 'internal note\n\nfinal answer paragraph two.'
```

## Fix

Anchor the unclosed-trailing regex to start-of-input (allowing leading whitespace). Real reasoning streams always lead the message — that's the only place an unclosed opener legitimately appears during streaming. Mid-prose `<think>` mentions stay in the visible text.

```diff
- const unclosed = new RegExp(`<${tag}>([\\s\\S]*)$`, 'i')
+ const unclosed = new RegExp(`^\\s*<${tag}>([\\s\\S]*)$`, 'i')
```

## Post-fix

```ts
splitReasoning(
  'final answer paragraph one.\n\n<think>internal note\n\nfinal answer paragraph two.'
)
// text:      'final answer paragraph one.\n\n<think>internal note\n\nfinal answer paragraph two.'  ✓
// reasoning: ''
```

Leading unclosed reasoning still works:

```ts
splitReasoning('<think>still deciding')
// reasoning: 'still deciding'
// text: ''
```

## Tests

- Updated `treats unclosed trailing <think>… as reasoning` → `treats unclosed leading <think>… as reasoning (real reasoning-model stream)`. The old fixture pinned the buggy behavior (mid-text `<think>` eating the prefix); replaced with the real-world shape.
- Added regression test `does not strip trailing prose after a stray mid-text <think> mention` pinning the exact symptom.

## Verification

```
cd ui-tui
npm run type-check  # clean
npm test            # 808/808 passing (1 unrelated slashParity skipped — missing pyyaml in venv)
npm run build       # clean
```

## Related

This is one cause of the symptom — the other plausible class is over-aggressive stripping in `finalTail` (`turnController.ts`). I investigated that path during diagnosis and didn't find a concrete eating-case in the empirical test matrix, so leaving it alone. If "eats last paragraph" recurs after this lands, that's the next place to look.
