### PR TITLE
feat(cron): add job tags

### DIFF
--- a/.hermes/plans/2026-05-21-cron-job-tags.md
+++ b/.hermes/plans/2026-05-21-cron-job-tags.md
@@ -1,0 +1,45 @@
+# Cron Job Tags Implementation Plan
+
+> **For Hermes:** Implement directly with strict TDD in this nightly cron run.
+
+**Goal:** Add lightweight tags to cron job records so Joe can group proactive jobs by domain (health, leads, side-projects, reminders) without overloading names or prompts.
+
+**Architecture:** Store an optional `tags: list[str]` field on cron job dicts. Normalize tags at create/update/read boundaries so legacy jobs get `[]`, duplicates collapse case-insensitively, and malformed hand-edited records cannot crash list/get callers.
+
+**Tech Stack:** Python cron storage (`cron/jobs.py`) and pytest coverage (`tests/cron/test_jobs.py`).
+
+---
+
+### Task 1: Add failing tag-normalization tests
+
+**Objective:** Lock in expected behavior before implementation.
+
+**Files:**
+- Modify: `tests/cron/test_jobs.py`
+
+**Steps:**
+1. Add tests that `create_job(..., tags=[...])` trims whitespace, drops blanks, and de-duplicates case-insensitively while preserving first spelling/order.
+2. Add tests that `list_jobs()` normalizes legacy missing/null/scalar tag fields to a safe list.
+3. Run focused tests and verify RED failure.
+
+### Task 2: Implement tag normalization
+
+**Objective:** Make cron jobs persist and read safe normalized tag lists.
+
+**Files:**
+- Modify: `cron/jobs.py`
+
+**Steps:**
+1. Add `_normalize_tags(tags)` helper.
+2. Apply it in `_normalize_job_record()`.
+3. Add `tags` parameter to `create_job()` and persist normalized tags.
+4. Add update handling so `update_job(job_id, {"tags": ...})` normalizes before save.
+5. Run focused tests and verify GREEN.
+
+### Task 3: Smoke and PR
+
+**Objective:** Verify no focused regressions, commit, push branch, open PR.
+
+**Commands:**
+- `scripts/run_tests.sh tests/cron/test_jobs.py -q`
+- `git diff --check`

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -63,6 +63,32 @@ def _normalize_skill_list(skill: Optional[str] = None, skills: Optional[Any] = N
     return normalized
 
 
+def _normalize_tags(tags: Optional[Any] = None) -> List[str]:
+    """Normalize cron job tags into a unique ordered list.
+
+    Tags are free-form labels used by humans and automation to group jobs
+    (e.g. ``health``, ``leads``, ``side-projects``). Legacy or hand-edited
+    storage may contain missing, null, scalar, or mixed-list values; readers
+    should always see a safe list of non-empty strings.
+    """
+    if tags is None:
+        raw_items: List[Any] = []
+    elif isinstance(tags, str):
+        raw_items = [tags]
+    else:
+        raw_items = list(tags)
+
+    normalized: List[str] = []
+    seen: set[str] = set()
+    for item in raw_items:
+        text = str(item or "").strip()
+        key = text.casefold()
+        if text and key not in seen:
+            normalized.append(text)
+            seen.add(key)
+    return normalized
+
+
 def _apply_skill_fields(job: Dict[str, Any]) -> Dict[str, Any]:
     """Return a job dict with canonical `skills` and legacy `skill` fields aligned."""
     normalized = dict(job)
@@ -104,6 +130,7 @@ def _normalize_job_record(job: Dict[str, Any]) -> Dict[str, Any]:
     ensure consumers never crash while formatting or running those records.
     """
     normalized = _apply_skill_fields(job)
+    normalized["tags"] = _normalize_tags(normalized.get("tags"))
     job_id = _coerce_job_text(normalized.get("id"), "unknown")
     prompt = _coerce_job_text(normalized.get("prompt"))
     normalized["id"] = job_id
@@ -521,6 +548,7 @@ def create_job(
     script: Optional[str] = None,
     context_from: Optional[Union[str, List[str]]] = None,
     enabled_toolsets: Optional[List[str]] = None,
+    tags: Optional[Any] = None,
     workdir: Optional[str] = None,
     profile: Optional[str] = None,
     no_agent: bool = False,
@@ -555,6 +583,9 @@ def create_job(
                           When set, only tools from these toolsets are loaded, reducing
                           token overhead. When omitted, all default tools are loaded.
                           Ignored when ``no_agent=True``.
+        tags: Optional human/automation labels for grouping jobs. Values are
+              trimmed, empty entries are dropped, and duplicates collapse
+              case-insensitively while preserving first spelling/order.
         workdir: Optional absolute path.  When set, the job runs as if launched
                 from that directory: AGENTS.md / CLAUDE.md / .cursorrules from
                 that directory are injected into the system prompt, and the
@@ -605,6 +636,7 @@ def create_job(
     normalized_script = normalized_script or None
     normalized_toolsets = [str(t).strip() for t in enabled_toolsets if str(t).strip()] if enabled_toolsets else None
     normalized_toolsets = normalized_toolsets or None
+    normalized_tags = _normalize_tags(tags)
     normalized_workdir = _normalize_workdir(workdir)
     normalized_profile = _normalize_profile(profile)
     normalized_no_agent = bool(no_agent)
@@ -660,6 +692,7 @@ def create_job(
         "deliver": deliver,
         "origin": origin,  # Tracks where job was created for "origin" delivery
         "enabled_toolsets": normalized_toolsets,
+        "tags": normalized_tags,
         "workdir": normalized_workdir,
         "profile": normalized_profile,
     }
@@ -753,6 +786,9 @@ def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]
 
         updated = _apply_skill_fields({**job, **updates})
         schedule_changed = "schedule" in updates
+
+        if "tags" in updates:
+            updated["tags"] = _normalize_tags(updates.get("tags"))
 
         if "skills" in updates or "skill" in updates:
             normalized_skills = _normalize_skill_list(updated.get("skill"), updated.get("skills"))

--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -32,6 +32,20 @@ def _normalize_skills(single_skill=None, skills: Optional[Iterable[str]] = None)
     return normalized
 
 
+def _normalize_tags(tags: Optional[Iterable[str]] = None) -> Optional[List[str]]:
+    if tags is None:
+        return None
+    normalized: List[str] = []
+    seen = set()
+    for item in tags:
+        text = str(item or "").strip()
+        key = text.casefold()
+        if text and key not in seen:
+            normalized.append(text)
+            seen.add(key)
+    return normalized
+
+
 def _cron_api(**kwargs):
     from tools.cronjob_tools import cronjob as cronjob_tool
 
@@ -90,6 +104,9 @@ def cron_list(show_all: bool = False):
         print(f"    Deliver:   {deliver_str}")
         if skills:
             print(f"    Skills:    {', '.join(skills)}")
+        tags = job.get("tags") or []
+        if tags:
+            print(f"    Tags:      {', '.join(tags)}")
         script = job.get("script")
         if script:
             print(f"    Script:    {script}")
@@ -175,6 +192,7 @@ def cron_create(args):
         repeat=getattr(args, "repeat", None),
         skill=getattr(args, "skill", None),
         skills=_normalize_skills(getattr(args, "skill", None), getattr(args, "skills", None)),
+        tags=_normalize_tags(getattr(args, "tags", None)),
         script=getattr(args, "script", None),
         workdir=getattr(args, "workdir", None),
         profile=getattr(args, "profile", None),
@@ -188,6 +206,8 @@ def cron_create(args):
     print(f"  Schedule: {result['schedule']}")
     if result.get("skills"):
         print(f"  Skills: {', '.join(result['skills'])}")
+    if result.get("job", {}).get("tags"):
+        print(f"  Tags: {', '.join(result['job']['tags'])}")
     job_data = result.get("job", {})
     if job_data.get("script"):
         print(f"  Script: {job_data['script']}")
@@ -221,6 +241,7 @@ def cron_edit(args):
     remove_skills = set(_normalize_skills(None, getattr(args, "remove_skills", None)) or [])
 
     final_skills = None
+    replacement_tags = _normalize_tags(getattr(args, "tags", None))
     if getattr(args, "clear_skills", False):
         final_skills = []
     elif replacement_skills is not None:
@@ -240,6 +261,7 @@ def cron_edit(args):
         deliver=getattr(args, "deliver", None),
         repeat=getattr(args, "repeat", None),
         skills=final_skills,
+        tags=replacement_tags,
         script=getattr(args, "script", None),
         workdir=getattr(args, "workdir", None),
         profile=getattr(args, "profile", None),
@@ -257,6 +279,10 @@ def cron_edit(args):
         print(f"  Skills: {', '.join(updated['skills'])}")
     else:
         print("  Skills: none")
+    if updated.get("tags"):
+        print(f"  Tags: {', '.join(updated['tags'])}")
+    else:
+        print("  Tags: none")
     if updated.get("script"):
         print(f"  Script: {updated['script']}")
     if updated.get("no_agent"):

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -11287,6 +11287,12 @@ def main():
         "--profile",
         help="Hermes profile name to run the job under. Use 'default' for the root profile. Named profiles must already exist. Omit to preserve the scheduler's existing profile.",
     )
+    cron_create.add_argument(
+        "--tag",
+        dest="tags",
+        action="append",
+        help="Attach a grouping tag such as health, leads, side-projects, or reminders. Repeat to add multiple tags.",
+    )
 
     # cron edit
     cron_edit = cron_subparsers.add_parser(
@@ -11354,6 +11360,12 @@ def main():
     cron_edit.add_argument(
         "--profile",
         help="Hermes profile name to run the job under. Use 'default' for the root profile. Pass empty string to clear.",
+    )
+    cron_edit.add_argument(
+        "--tag",
+        dest="tags",
+        action="append",
+        help="Replace the job's tags with this set. Repeat to attach multiple tags; pass no --tag to leave unchanged.",
     )
 
     # lifecycle actions

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -226,6 +226,36 @@ class TestJobCRUD:
         assert jobs[0]["prompt"] == ""
         assert jobs[0]["schedule_display"] == "every 60m"
         assert jobs[0]["state"] == "scheduled"
+        assert jobs[0]["tags"] == []
+
+    def test_create_job_normalizes_tags(self, tmp_cron_dir):
+        job = create_job(
+            prompt="Daily side-project triage",
+            schedule="every 1d",
+            tags=[" side-projects ", "Health", "", "health", None, "leads"],
+        )
+
+        fetched = get_job(job["id"])
+
+        assert job["tags"] == ["side-projects", "Health", "leads"]
+        assert fetched is not None
+        assert fetched["tags"] == ["side-projects", "Health", "leads"]
+
+    def test_list_jobs_normalizes_legacy_scalar_tags(self, tmp_cron_dir):
+        save_jobs([
+            {
+                "id": "tagged-legacy",
+                "name": "Legacy",
+                "prompt": "Legacy job",
+                "schedule": {"kind": "interval", "minutes": 60, "display": "every 60m"},
+                "enabled": True,
+                "tags": " reminders ",
+            }
+        ])
+
+        jobs = list_jobs()
+
+        assert jobs[0]["tags"] == ["reminders"]
 
     def test_remove_job(self, tmp_cron_dir):
         job = create_job(prompt="Temp job", schedule="30m")
@@ -295,6 +325,17 @@ class TestUpdateJob:
         assert updated["enabled"] is False
         fetched = get_job(job["id"])
         assert fetched["enabled"] is False
+
+    def test_update_tags_normalizes_values(self, tmp_cron_dir):
+        job = create_job(prompt="Retag me", schedule="every 1h")
+
+        updated = update_job(job["id"], {"tags": [" Health ", "health", "leads"]})
+
+        assert updated is not None
+        assert updated["tags"] == ["Health", "leads"]
+        fetched = get_job(job["id"])
+        assert fetched is not None
+        assert fetched["tags"] == ["Health", "leads"]
 
     def test_update_nonexistent_returns_none(self, tmp_cron_dir):
         result = update_job("nonexistent_id", {"name": "X"})

--- a/tests/hermes_cli/test_cron.py
+++ b/tests/hermes_cli/test_cron.py
@@ -111,3 +111,28 @@ class TestCronCommandLifecycle:
         assert jobs[0]["skills"] == ["blogwatcher", "maps"]
         assert jobs[0]["name"] == "Skill combo"
         assert jobs[0]["profile"] == "default"
+
+    def test_create_and_list_tags(self, tmp_cron_dir, capsys):
+        cron_command(
+            Namespace(
+                cron_command="create",
+                schedule="every 1h",
+                prompt="Track useful leads",
+                name="Lead tracker",
+                deliver=None,
+                repeat=None,
+                skill=None,
+                skills=None,
+                tags=[" leads ", "Health", "leads"],
+                profile=None,
+            )
+        )
+        create_out = capsys.readouterr().out
+        assert "Tags: leads, Health" in create_out
+
+        jobs = list_jobs()
+        assert jobs[0]["tags"] == ["leads", "Health"]
+
+        cron_command(Namespace(cron_command="list", all=True))
+        list_out = capsys.readouterr().out
+        assert "Tags:      leads, Health" in list_out

--- a/tests/tools/test_cronjob_tools.py
+++ b/tests/tools/test_cronjob_tools.py
@@ -177,6 +177,33 @@ class TestUnifiedCronjobTool:
         assert listing["jobs"][0]["name"] == "Server Check"
         assert listing["jobs"][0]["state"] == "scheduled"
 
+    def test_create_and_update_tags_visible_through_tool(self):
+        created = json.loads(
+            cronjob(
+                action="create",
+                prompt="Collect proactive ideas",
+                schedule="every 1h",
+                name="Idea collector",
+                tags=[" side-projects ", "Leads", "leads"],
+            )
+        )
+        assert created["success"] is True
+        assert created["job"]["tags"] == ["side-projects", "Leads"]
+
+        listing = json.loads(cronjob(action="list"))
+        assert listing["jobs"][0]["tags"] == ["side-projects", "Leads"]
+
+        updated = json.loads(
+            cronjob(
+                action="update",
+                job_id=created["job_id"],
+                tags=[" health ", "Health", "reminders"],
+            )
+        )
+
+        assert updated["success"] is True
+        assert updated["job"]["tags"] == ["health", "reminders"]
+
     def test_list_handles_partial_legacy_job_records(self):
         from cron.jobs import save_jobs
 

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -294,6 +294,7 @@ def _validate_cron_script_path(script: Optional[str]) -> Optional[str]:
 def _format_job(job: Dict[str, Any]) -> Dict[str, Any]:
     prompt = str(job.get("prompt") or "")
     skills = _canonical_skills(job.get("skill"), job.get("skills"))
+    tags = job.get("tags") or []
     job_id = str(job.get("id") or "unknown")
     name = str(job.get("name") or prompt[:50] or (skills[0] if skills else "") or job_id or "cron job")
     result = {
@@ -314,6 +315,7 @@ def _format_job(job: Dict[str, Any]) -> Dict[str, Any]:
         "last_delivery_error": job.get("last_delivery_error"),
         "enabled": job.get("enabled", True),
         "state": job.get("state", "scheduled" if job.get("enabled", True) else "paused"),
+        "tags": tags,
         "paused_at": job.get("paused_at"),
         "paused_reason": job.get("paused_reason"),
     }
@@ -348,6 +350,7 @@ def cronjob(
     script: Optional[str] = None,
     context_from: Optional[Union[str, List[str]]] = None,
     enabled_toolsets: Optional[List[str]] = None,
+    tags: Optional[List[str]] = None,
     workdir: Optional[str] = None,
     profile: Optional[str] = None,
     no_agent: Optional[bool] = None,
@@ -415,6 +418,7 @@ def cronjob(
                 script=_normalize_optional_job_value(script),
                 context_from=context_from,
                 enabled_toolsets=enabled_toolsets or None,
+                tags=tags,
                 workdir=_normalize_optional_job_value(workdir),
                 profile=_normalize_optional_job_value(profile),
                 no_agent=_no_agent,
@@ -547,6 +551,8 @@ def cronjob(
                 updates["context_from"] = refs or None
             if enabled_toolsets is not None:
                 updates["enabled_toolsets"] = enabled_toolsets or None
+            if tags is not None:
+                updates["tags"] = tags
             if workdir is not None:
                 # Empty string clears the field (restores old behaviour);
                 # otherwise pass raw — update_job() validates / normalizes.
@@ -704,6 +710,11 @@ Important safety rule: cron-run sessions should not recursively schedule more cr
                 "items": {"type": "string"},
                 "description": "Optional list of toolset names to restrict the job's agent to (e.g. [\"web\", \"terminal\", \"file\", \"delegation\"]). When set, only tools from these toolsets are loaded, significantly reducing input token overhead. When omitted, all default tools are loaded. Infer from the job's prompt — e.g. use \"web\" if it calls web_search, \"terminal\" if it runs scripts, \"file\" if it reads files, \"delegation\" if it calls delegate_task. On update, pass an empty array to clear."
             },
+            "tags": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Optional human/automation labels for grouping cron jobs (e.g. [\"health\", \"leads\", \"side-projects\", \"reminders\"]). Values are trimmed, blanks removed, and duplicates collapse case-insensitively. On update, pass an empty array to clear."
+            },
             "workdir": {
                 "type": "string",
                 "description": "Optional absolute path to run the job from. When set, AGENTS.md / CLAUDE.md / .cursorrules from that directory are injected into the system prompt, and the terminal/file/code_exec tools use it as their working directory — useful for running a job inside a specific project repo. Must be an absolute path that exists. When unset (default), preserves the original behaviour: no project context files, tools use the scheduler's cwd. On update, pass an empty string to clear. Jobs with workdir run sequentially (not parallel) to keep per-job directories isolated."
@@ -765,6 +776,7 @@ registry.register(
         script=args.get("script"),
         context_from=args.get("context_from"),
         enabled_toolsets=args.get("enabled_toolsets"),
+        tags=args.get("tags"),
         workdir=args.get("workdir"),
         profile=args.get("profile"),
         no_agent=args.get("no_agent"),


### PR DESCRIPTION
## Summary
- Add normalized optional tags to cron job records for grouping proactive jobs by domain
- Normalize tags on create, update, and legacy reads so missing/null/scalar fields stay safe
- Surface tags through the `cronjob` tool API/schema and `hermes cron create/list/edit --tag`
- Add a small spec plan plus focused cron storage/tool/CLI tests

## Why
Joe's nightly/proactive jobs increasingly span reminders, health, leads, and side-project workflows. Tags give automation and UI/API consumers a reversible grouping primitive without overloading names or prompts.

## Test Plan
- [x] RED: targeted pytest failed before implementation with missing tags behavior
- [x] GREEN: `python -m pytest tests/tools/test_cronjob_tools.py::TestUnifiedCronjobTool::test_create_and_update_tags_visible_through_tool tests/hermes_cli/test_cron.py::TestCronCommandLifecycle::test_create_and_list_tags -q -o 'addopts='`
- [x] `python -m pytest tests/cron/test_jobs.py tests/tools/test_cronjob_tools.py tests/hermes_cli/test_cron.py -q -o 'addopts='`
- [x] `python -m compileall cron/jobs.py tools/cronjob_tools.py hermes_cli/cron.py hermes_cli/main.py`
- [x] `git diff --check`

Note: `scripts/run_tests.sh ...` currently fails in this local worktree before tests start because pytest-timeout is unavailable in the shared stripped venv (unrecognized `--timeout` flags). I used direct pytest with addopts cleared as the fallback per AGENTS guidance.
