### PR TITLE
Reject non-regular files before reading

### DIFF
--- a/tests/tools/test_file_operations.py
+++ b/tests/tools/test_file_operations.py
@@ -281,6 +281,8 @@ class TestShellFileOpsHelpers:
         )
 
         def side_effect(command, **kwargs):
+            if command.startswith("if [ ! -e "):
+                return {"output": "regular\n", "returncode": 0}
             if command.startswith("wc -c"):
                 return {"output": "12\n", "returncode": 0}
             if command.startswith("head -c"):
@@ -309,6 +311,8 @@ class TestShellFileOpsHelpers:
         )
 
         def side_effect(command, **kwargs):
+            if command.startswith("if [ ! -e "):
+                return {"output": "regular\n", "returncode": 0}
             if command.startswith("wc -c"):
                 return {"output": "6\n", "returncode": 0}
             if command.startswith("head -c"):
@@ -323,6 +327,40 @@ class TestShellFileOpsHelpers:
 
         assert result.error is None
         assert result.content == "alpha\n"
+
+    def test_read_file_rejects_non_regular_before_read_commands(self, mock_env):
+        commands = []
+
+        def side_effect(command, **kwargs):
+            commands.append(command)
+            if command.startswith("if [ ! -e "):
+                return {"output": "non_regular\n", "returncode": 0}
+            return {"output": "", "returncode": 0}
+
+        mock_env.execute.side_effect = side_effect
+        ops = ShellFileOperations(mock_env)
+        result = ops.read_file("/tmp/test/fifo")
+
+        assert result.error is not None
+        assert "non-regular" in result.error
+        assert not any(command.startswith(("wc -c", "head -c", "sed -n", "wc -l")) for command in commands)
+
+    def test_read_file_raw_rejects_non_regular_before_read_commands(self, mock_env):
+        commands = []
+
+        def side_effect(command, **kwargs):
+            commands.append(command)
+            if command.startswith("if [ ! -e "):
+                return {"output": "non_regular\n", "returncode": 0}
+            return {"output": "", "returncode": 0}
+
+        mock_env.execute.side_effect = side_effect
+        ops = ShellFileOperations(mock_env)
+        result = ops.read_file_raw("/tmp/test/device")
+
+        assert result.error is not None
+        assert "non-regular" in result.error
+        assert not any(command.startswith(("wc -c", "head -c", "cat ")) for command in commands)
 
 
 class TestSearchPathValidation:

--- a/tests/tools/test_file_read_guards.py
+++ b/tests/tools/test_file_read_guards.py
@@ -90,6 +90,20 @@ class TestDevicePathBlocking(unittest.TestCase):
         self.assertIn("error", result)
         self.assertIn("device file", result["error"])
 
+    @unittest.skipUnless(
+        hasattr(os, "symlink") and os.path.exists("/dev/zero"),
+        "requires POSIX symlinks and /dev/zero",
+    )
+    def test_read_file_tool_rejects_symlink_to_device(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            link_path = os.path.join(tmpdir, "zero-link")
+            os.symlink("/dev/zero", link_path)
+
+            result = json.loads(read_file_tool(link_path, task_id="dev_symlink_test"))
+
+        self.assertIn("error", result)
+        self.assertIn("regular file", result["error"])
+
 
 # ---------------------------------------------------------------------------
 # Character-count limits

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -642,6 +642,41 @@ class ShellFileOperations(FileOperations):
         """Check if file is an image we can return as base64."""
         ext = os.path.splitext(path)[1].lower()
         return ext in IMAGE_EXTENSIONS
+
+    def _readable_regular_file_status(self, path: str) -> str:
+        """Return regular, missing, or non_regular for a read target."""
+        escaped = self._escape_shell_arg(path)
+        status_cmd = (
+            f"if [ ! -e {escaped} ]; then "
+            "printf '%s\\n' missing; "
+            f"elif [ -f {escaped} ]; then "
+            "printf '%s\\n' regular; "
+            "else "
+            "printf '%s\\n' non_regular; "
+            "fi"
+        )
+        result = self._exec(status_cmd, timeout=5)
+        if result.exit_code != 0:
+            return "unknown"
+        lines = _strip_terminal_fence_leaks(result.stdout).strip().splitlines()
+        return lines[-1].strip() if lines else "unknown"
+
+    def _reject_non_regular_read_target(self, path: str) -> Optional[ReadResult]:
+        """Reject missing and non-regular files before running read commands."""
+        status = self._readable_regular_file_status(path)
+        if status == "regular":
+            return None
+        if status == "missing":
+            return self._suggest_similar_files(path)
+        if status == "non_regular":
+            return ReadResult(
+                error=(
+                    f"Cannot read non-regular file: {path}. "
+                    "Refusing to read directories, devices, FIFOs, sockets, "
+                    "and other special files."
+                )
+            )
+        return ReadResult(error=f"Failed to inspect file type before reading: {path}")
     
     def _add_line_numbers(self, content: str, start_line: int = 1) -> str:
         """Add line numbers to content in LINE_NUM|CONTENT format."""
@@ -729,6 +764,10 @@ class ShellFileOperations(FileOperations):
         path = self._expand_path(path)
         
         offset, limit = normalize_read_pagination(offset, limit)
+
+        preflight_error = self._reject_non_regular_read_target(path)
+        if preflight_error is not None:
+            return preflight_error
         
         # Check if file exists and get size (wc -c is POSIX, works on Linux + macOS)
         stat_cmd = f"wc -c < {self._escape_shell_arg(path)} 2>/dev/null"
@@ -864,6 +903,11 @@ class ShellFileOperations(FileOperations):
         Uses cat so the full file is returned regardless of size.
         """
         path = self._expand_path(path)
+
+        preflight_error = self._reject_non_regular_read_target(path)
+        if preflight_error is not None:
+            return preflight_error
+
         stat_cmd = f"wc -c < {self._escape_shell_arg(path)} 2>/dev/null"
         stat_result = self._exec(stat_cmd)
         if stat_result.exit_code != 0:

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -146,6 +146,14 @@ def _is_blocked_device(filepath: str) -> bool:
     return False
 
 
+def _is_existing_non_regular_path(path: Path) -> bool:
+    """Return True when a resolved local path exists but is not a regular file."""
+    try:
+        return path.exists() and not path.is_file()
+    except OSError:
+        return False
+
+
 # Paths that file tools should refuse to write to without going through the
 # terminal tool's approval system.  These match prefixes after os.path.realpath.
 _SENSITIVE_PATH_PREFIXES = (
@@ -461,6 +469,14 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 500, task_id: str = 
             })
 
         _resolved = _resolve_path_for_task(path, task_id)
+        if _is_blocked_device(str(_resolved)) or _is_existing_non_regular_path(_resolved):
+            return json.dumps({
+                "error": (
+                    f"Cannot read '{path}': resolved path is not a regular "
+                    "file. Refusing to read directories, devices, FIFOs, "
+                    "sockets, and other special files."
+                ),
+            })
 
         # ── Binary file guard ─────────────────────────────────────────
         # Block binary files by extension (no I/O).


### PR DESCRIPTION
## Summary
- reject resolved local read targets that are devices, FIFOs, directories, sockets, or other non-regular files
- add a shell-backed regular-file preflight before running wc, head, sed, or cat for file reads
- add regression coverage for symlinked devices and non-regular read targets

## Validation
- scripts/run_tests.sh tests/tools/test_file_operations.py tests/tools/test_file_read_guards.py
- scripts/run_tests.sh tests/tools/test_file_tools_live.py