### PR TITLE
fix(matrix): add TLS verify escape hatch

### DIFF
--- a/gateway/platforms/matrix.py
+++ b/gateway/platforms/matrix.py
@@ -7,6 +7,7 @@ when installed with ``pip install "mautrix[encryption]"``.
 Environment variables:
     MATRIX_HOMESERVER           Homeserver URL (e.g. https://matrix.example.org)
     MATRIX_ACCESS_TOKEN         Access token (preferred auth method)
+    MATRIX_SSL_VERIFY           Set "false" only for known private/self-signed homeservers
     MATRIX_USER_ID              Full user ID (@bot:server) — required for password login
     MATRIX_PASSWORD             Password (alternative to access token)
     MATRIX_ENCRYPTION           Set "true" to enable E2EE
@@ -155,6 +156,16 @@ _MATRIX_IMAGE_FILENAME_EXTS = frozenset({
 })
 
 
+def _matrix_ssl_verify_enabled() -> bool:
+    """Return whether Matrix HTTPS certificate verification should be enabled."""
+    return os.getenv("MATRIX_SSL_VERIFY", "true").strip().lower() not in {
+        "false",
+        "0",
+        "no",
+        "off",
+    }
+
+
 def _looks_like_matrix_image_filename(text: str) -> bool:
     """Return True when Matrix image body text is probably just a transport filename.
 
@@ -189,18 +200,34 @@ def _create_matrix_session(proxy_url: str | None):
     we use ``aiohttp_socks.ProxyConnector`` (connector-level).
     When no proxy is configured we enable ``trust_env`` so standard env vars
     (``HTTP_PROXY`` / ``HTTPS_PROXY``) are honoured automatically.
+
+    ``MATRIX_SSL_VERIFY=false`` is a scoped escape hatch for known private
+    homeservers with self-signed or private-CA TLS chains.
     """
     import aiohttp
 
+    ssl_verify = _matrix_ssl_verify_enabled()
+    connector = None
+    if not ssl_verify:
+        logger.warning(
+            "Matrix: MATRIX_SSL_VERIFY=false — TLS certificate verification disabled "
+            "for Matrix homeserver requests"
+        )
+        connector = aiohttp.TCPConnector(ssl=False)
+
     if not proxy_url:
-        return aiohttp.ClientSession(trust_env=True)
+        return aiohttp.ClientSession(trust_env=True, connector=connector)
 
     if proxy_url.split("://")[0].lower().startswith("socks"):
         try:
             from aiohttp_socks import ProxyConnector
 
             return aiohttp.ClientSession(
-                connector=ProxyConnector.from_url(proxy_url, rdns=True),
+                connector=ProxyConnector.from_url(
+                    proxy_url,
+                    rdns=True,
+                    ssl=None if ssl_verify else False,
+                ),
             )
         except ImportError:
             logger.warning(
@@ -208,9 +235,9 @@ def _create_matrix_session(proxy_url: str | None):
                 "Run: pip install aiohttp-socks",
                 proxy_url,
             )
-            return aiohttp.ClientSession(trust_env=True)
+            return aiohttp.ClientSession(trust_env=True, connector=connector)
 
-    return aiohttp.ClientSession(proxy=proxy_url)
+    return aiohttp.ClientSession(proxy=proxy_url, connector=connector)
 
 
 def _check_e2ee_deps() -> bool:

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -131,7 +131,7 @@ _EXTRA_ENV_KEYS = frozenset({
     "MATTERMOST_HOME_CHANNEL", "MATTERMOST_HOME_CHANNEL_NAME", "MATTERMOST_REPLY_MODE",
     "MATRIX_PASSWORD", "MATRIX_ENCRYPTION", "MATRIX_DEVICE_ID", "MATRIX_HOME_ROOM",
     "MATRIX_REQUIRE_MENTION", "MATRIX_FREE_RESPONSE_ROOMS", "MATRIX_AUTO_THREAD", "MATRIX_DM_AUTO_THREAD",
-    "MATRIX_RECOVERY_KEY",
+    "MATRIX_SSL_VERIFY", "MATRIX_RECOVERY_KEY",
     # Langfuse observability plugin — optional tuning keys + standard SDK vars.
     # Activation is via plugins.enabled (opt-in through `hermes plugins enable
     # observability/langfuse`); credentials gate the plugin at runtime.
@@ -2531,6 +2531,14 @@ OPTIONAL_ENV_VARS = {
         "url": None,
         "password": True,
         "category": "messaging",
+    },
+    "MATRIX_SSL_VERIFY": {
+        "description": "Verify Matrix homeserver TLS certificates (default: true). Set false only for known private/self-signed homeservers.",
+        "prompt": "Verify Matrix TLS certificates (true/false)",
+        "url": None,
+        "password": False,
+        "category": "messaging",
+        "advanced": True,
     },
     "MATRIX_USER_ID": {
         "description": "Matrix user ID (e.g. @hermes:example.org)",

--- a/tests/gateway/test_matrix.py
+++ b/tests/gateway/test_matrix.py
@@ -2561,22 +2561,26 @@ class TestCreateMatrixSession:
     """Verify _create_matrix_session applies proxy at the session level."""
 
     @pytest.mark.asyncio
-    async def test_no_proxy_returns_trust_env_session(self):
+    async def test_no_proxy_returns_trust_env_session(self, monkeypatch):
+        monkeypatch.delenv("MATRIX_SSL_VERIFY", raising=False)
         with patch.dict("sys.modules", _make_fake_mautrix()):
             from gateway.platforms.matrix import _create_matrix_session
             session = _create_matrix_session(None)
             try:
                 assert session.trust_env is True
+                assert getattr(session.connector, "_ssl") is not False
             finally:
                 await session.close()
 
     @pytest.mark.asyncio
-    async def test_http_proxy_sets_default_proxy(self):
+    async def test_http_proxy_sets_default_proxy(self, monkeypatch):
+        monkeypatch.delenv("MATRIX_SSL_VERIFY", raising=False)
         with patch.dict("sys.modules", _make_fake_mautrix()):
             from gateway.platforms.matrix import _create_matrix_session
             session = _create_matrix_session("http://proxy:8080")
             try:
                 assert str(session._default_proxy) == "http://proxy:8080"
+                assert getattr(session.connector, "_ssl") is not False
             finally:
                 await session.close()
 
@@ -2595,5 +2599,51 @@ class TestCreateMatrixSession:
                 session = _create_matrix_session("socks5://proxy:1080")
                 try:
                     assert session.connector is fake_connector
+                finally:
+                    await session.close()
+
+    @pytest.mark.asyncio
+    async def test_ssl_verify_false_disables_connector_ssl(self, monkeypatch):
+        monkeypatch.setenv("MATRIX_SSL_VERIFY", "false")
+        with patch.dict("sys.modules", _make_fake_mautrix()):
+            from gateway.platforms.matrix import _create_matrix_session
+            session = _create_matrix_session(None)
+            try:
+                assert getattr(session.connector, "_ssl") is False
+            finally:
+                await session.close()
+
+    @pytest.mark.asyncio
+    async def test_http_proxy_preserves_ssl_verify_false(self, monkeypatch):
+        monkeypatch.setenv("MATRIX_SSL_VERIFY", "false")
+        with patch.dict("sys.modules", _make_fake_mautrix()):
+            from gateway.platforms.matrix import _create_matrix_session
+            session = _create_matrix_session("http://proxy:8080")
+            try:
+                assert str(session._default_proxy) == "http://proxy:8080"
+                assert getattr(session.connector, "_ssl") is False
+            finally:
+                await session.close()
+
+    @pytest.mark.asyncio
+    async def test_socks_proxy_passes_ssl_false_when_disabled(self, monkeypatch):
+        monkeypatch.setenv("MATRIX_SSL_VERIFY", "false")
+        fake_connector = MagicMock()
+        from_url = MagicMock(return_value=fake_connector)
+        with patch.dict("sys.modules", _make_fake_mautrix()):
+            with patch.dict("sys.modules", {
+                "aiohttp_socks": MagicMock(
+                    ProxyConnector=MagicMock(from_url=from_url)
+                ),
+            }):
+                from gateway.platforms.matrix import _create_matrix_session
+                session = _create_matrix_session("socks5://proxy:1080")
+                try:
+                    assert session.connector is fake_connector
+                    from_url.assert_called_once_with(
+                        "socks5://proxy:1080",
+                        rdns=True,
+                        ssl=False,
+                    )
                 finally:
                     await session.close()

--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -982,16 +982,16 @@ class TestParseTargetRefMatrix:
         """Session-derived Matrix thread targets round-trip as room + event id."""
         chat_id, thread_id, is_explicit = _parse_target_ref(
             "matrix",
-            "!HLOQwxYGgFPMPJUSNR:matrix.org:$thread123:matrix.org",
+            "!roomid:example.org:$thread123:matrix.org",
         )
-        assert chat_id == "!HLOQwxYGgFPMPJUSNR:matrix.org"
+        assert chat_id == "!roomid:example.org"
         assert thread_id == "$thread123:matrix.org"
         assert is_explicit is True
 
     def test_matrix_room_id_is_explicit(self):
         """Matrix room IDs (!) are recognized as explicit targets."""
-        chat_id, thread_id, is_explicit = _parse_target_ref("matrix", "!HLOQwxYGgFPMPJUSNR:matrix.org")
-        assert chat_id == "!HLOQwxYGgFPMPJUSNR:matrix.org"
+        chat_id, thread_id, is_explicit = _parse_target_ref("matrix", "!roomid:example.org")
+        assert chat_id == "!roomid:example.org"
         assert thread_id is None
         assert is_explicit is True
 
@@ -1415,7 +1415,7 @@ class TestSendMatrixUrlEncoding:
                 _send_matrix(
                     "test_token",
                     {"homeserver": "https://matrix.example.org"},
-                    "!HLOQwxYGgFPMPJUSNR:matrix.org",
+                    "!roomid:example.org",
                     "hello",
                 )
             )
@@ -1423,8 +1423,41 @@ class TestSendMatrixUrlEncoding:
         assert result["success"] is True
         # Verify the URL was called with percent-encoded room ID
         put_url = mock_session.put.call_args[0][0]
-        assert "%21HLOQwxYGgFPMPJUSNR%3Amatrix.org" in put_url
-        assert "!HLOQwxYGgFPMPJUSNR:matrix.org" not in put_url
+        assert "%21roomid%3Aexample.org" in put_url
+        assert "!roomid:example.org" not in put_url
+
+
+    def test_matrix_ssl_verify_false_disables_aiohttp_ssl(self, monkeypatch):
+        """MATRIX_SSL_VERIFY=false should be honored by lightweight Matrix sends."""
+        import aiohttp
+
+        mock_resp = MagicMock()
+        mock_resp.status = 200
+        mock_resp.json = AsyncMock(return_value={"event_id": "$evt123"})
+        mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
+        mock_resp.__aexit__ = AsyncMock(return_value=None)
+
+        mock_session = MagicMock()
+        mock_session.put = MagicMock(return_value=mock_resp)
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=None)
+
+        monkeypatch.setenv("MATRIX_SSL_VERIFY", "false")
+        with patch("aiohttp.ClientSession", return_value=mock_session) as session_cls:
+            from tools.send_message_tool import _send_matrix
+            result = asyncio.get_event_loop().run_until_complete(
+                _send_matrix(
+                    "test_token",
+                    {"homeserver": "https://matrix.example.org"},
+                    "!roomid:example.org",
+                    "hello",
+                )
+            )
+
+        assert result["success"] is True
+        connector = session_cls.call_args.kwargs["connector"]
+        assert isinstance(connector, aiohttp.TCPConnector)
+        assert connector._ssl is False
 
 
 # ---------------------------------------------------------------------------

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -13,7 +13,7 @@ import re
 import ssl
 import time
 from email.utils import formatdate
-from typing import Dict, Optional
+from typing import Any, Dict, Optional
 
 from agent.redact import redact_sensitive_text
 
@@ -70,6 +70,16 @@ def _sanitize_error_text(text) -> str:
 def _error(message: str) -> dict:
     """Build a standardized error payload with redacted content."""
     return {"error": _sanitize_error_text(message)}
+
+
+def _matrix_ssl_verify_enabled() -> bool:
+    """Return whether Matrix HTTPS certificate verification should be enabled."""
+    return os.getenv("MATRIX_SSL_VERIFY", "true").strip().lower() not in {
+        "false",
+        "0",
+        "no",
+        "off",
+    }
 
 
 def _telegram_retry_delay(exc: Exception, attempt: int) -> float | None:
@@ -1626,7 +1636,15 @@ async def _send_matrix(token, extra, chat_id, message):
         except ImportError:
             pass
 
-        async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=30)) as session:
+        session_kwargs: dict[str, Any] = {"timeout": aiohttp.ClientTimeout(total=30)}
+        if not _matrix_ssl_verify_enabled():
+            logger.warning(
+                "Matrix: MATRIX_SSL_VERIFY=false — TLS certificate verification disabled "
+                "for lightweight send"
+            )
+            session_kwargs["connector"] = aiohttp.TCPConnector(ssl=False)
+
+        async with aiohttp.ClientSession(**session_kwargs) as session:
             async with session.put(url, headers=headers, json=payload) as resp:
                 if resp.status not in {200, 201}:
                     body = await resp.text()

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -395,6 +395,7 @@ For cloud sandbox backends, persistence is filesystem-oriented. `TERMINAL_LIFETI
 | `MATTERMOST_REPLY_MODE` | Reply style: `thread` (threaded replies) or `off` (flat messages, default) |
 | `MATRIX_HOMESERVER` | Matrix homeserver URL (e.g. `https://matrix.org`) |
 | `MATRIX_ACCESS_TOKEN` | Matrix access token for bot authentication |
+| `MATRIX_SSL_VERIFY` | Verify Matrix homeserver TLS certificates (default: `true`). Set `false` only for known private/self-signed homeservers. |
 | `MATRIX_USER_ID` | Matrix user ID (e.g. `@hermes:matrix.org`) — required for password login, optional with access token |
 | `MATRIX_PASSWORD` | Matrix password (alternative to access token) |
 | `MATRIX_ALLOWED_USERS` | Comma-separated Matrix user IDs allowed to message the bot (e.g. `@alice:matrix.org`) |

--- a/website/docs/user-guide/messaging/matrix.md
+++ b/website/docs/user-guide/messaging/matrix.md
@@ -197,6 +197,10 @@ MATRIX_ALLOWED_USERS=@alice:matrix.example.org
 
 # Multiple allowed users (comma-separated)
 # MATRIX_ALLOWED_USERS=@alice:matrix.example.org,@bob:matrix.example.org
+
+# Optional TLS escape hatch for known private/self-signed homeservers only.
+# Default is true; leave this unset for public or CA-trusted homeservers.
+# MATRIX_SSL_VERIFY=false
 ```
 
 **Using password login:**
@@ -414,6 +418,18 @@ curl -H "Authorization: Bearer YOUR_TOKEN" \
 ```
 
 If this returns your user info, the token is valid. If it returns an error, generate a new token.
+
+### TLS certificate verification fails for a private homeserver
+
+**Cause**: The homeserver uses a self-signed certificate or a private CA that Python's TLS stack does not trust.
+
+**Fix**: Prefer installing the private CA certificate into the system trust store. If this is a known private homeserver and you intentionally accept the risk, set the Matrix-scoped escape hatch and restart Hermes:
+
+```bash
+MATRIX_SSL_VERIFY=false
+```
+
+This disables TLS certificate verification only for Matrix homeserver requests. Hermes logs a warning when the escape hatch is active. Do not use it for public or untrusted homeservers.
 
 ### "mautrix not installed" error
 


### PR DESCRIPTION
## What does this PR do?

Adds a Matrix-scoped TLS verification escape hatch for private/self-hosted homeservers that use self-signed or private-CA certificates.

Default behavior stays secure: Matrix TLS verification remains enabled unless `MATRIX_SSL_VERIFY=false` is explicitly set. When disabled, Hermes logs a warning. The setting is applied to both the Matrix gateway adapter and the lightweight Matrix send path.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/platforms/matrix.py`: honors `MATRIX_SSL_VERIFY=false` when creating Matrix gateway sessions, including HTTP and SOCKS proxy paths.
- `tools/send_message_tool.py`: honors the same setting for lightweight Matrix sends.
- `hermes_cli/config.py`: adds `MATRIX_SSL_VERIFY` to the known optional environment variables.
- `tests/gateway/test_matrix.py` and `tests/tools/test_send_message_tool.py`: add regression coverage for default verification behavior and the opt-out path.
- `website/docs/user-guide/messaging/matrix.md` and `website/docs/reference/environment-variables.md`: document the setting and recommend installing a private CA as the preferred fix.

## How to Test

1. Run focused Matrix and send-message tests:
   ```bash
   /home/neon/.hermes/hermes-agent/venv/bin/python -m pytest -q tests/gateway/test_matrix.py tests/tools/test_send_message_tool.py -q
   ```
2. Run config regression coverage:
   ```bash
   /home/neon/.hermes/hermes-agent/venv/bin/python -m pytest -q tests/hermes_cli/test_config.py tests/test_utils_truthy_values.py -q
   ```
3. Verify code hygiene:
   ```bash
   git diff --check origin/main...HEAD
   /home/neon/.hermes/hermes-agent/venv/bin/python -m py_compile gateway/platforms/matrix.py tools/send_message_tool.py hermes_cli/config.py
   ```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu/Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A

## Screenshots / Logs

Focused verification passed locally:

```text
/home/neon/.hermes/hermes-agent/venv/bin/python -m pytest -q \
  tests/tools/test_send_message_tool.py::TestParseTargetRefMatrix \
  tests/tools/test_send_message_tool.py::TestSendMatrixUrlEncoding \
  tests/gateway/test_matrix.py::TestCreateMatrixSession \
  tests/hermes_cli/test_config.py \
  tests/test_utils_truthy_values.py \
  -q
# 100% passed

/home/neon/.hermes/hermes-agent/venv/bin/python -m pytest -q tests/gateway/test_matrix.py tests/tools/test_send_message_tool.py -q
# 100% passed

/home/neon/.hermes/hermes-agent/venv/bin/python -m py_compile gateway/platforms/matrix.py tools/send_message_tool.py hermes_cli/config.py
# passed

git diff --check origin/main...HEAD
# passed
```

Full `scripts/run_tests.sh` was also attempted. It completed with `24646 passed, 52 skipped` and 10 failures in unrelated areas (`tests/cron/test_scheduler.py`, `tests/gateway/test_signal.py`, `tests/hermes_cli/test_auth_nous_provider.py`, `tests/hermes_cli/test_backup.py`, bundled web plugin config tests, and `tests/tui_gateway/test_goal_command.py`). The Matrix/send-message suites touched by this PR pass.