### PR TITLE
Verify Android psutil archives before extraction

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -7762,6 +7762,50 @@ def _is_android_python() -> bool:
     return sys.platform == "android"
 
 
+_PSUTIL_ANDROID_URL = (
+    "https://files.pythonhosted.org/packages/aa/c6/"
+    "d1ddf4abb55e93cebc4f2ed8b5d6dbad109ecb8d63748dd2b20ab5e57ebe/"
+    "psutil-7.2.2.tar.gz"
+)
+_PSUTIL_ANDROID_SHA256 = (
+    "0746f5f8d406af344fd547f1c8daa5f5c33dbc293bb8d6a16d80b4bb88f59372"
+)
+
+
+def _verify_psutil_android_archive(archive: Path) -> None:
+    import hashlib
+
+    digest = hashlib.sha256()
+    with archive.open("rb") as f:
+        for chunk in iter(lambda: f.read(1024 * 1024), b""):
+            digest.update(chunk)
+    actual = digest.hexdigest()
+    if actual != _PSUTIL_ANDROID_SHA256:
+        raise RuntimeError(
+            "psutil Android compatibility archive checksum mismatch: "
+            f"expected {_PSUTIL_ANDROID_SHA256}, got {actual}"
+        )
+
+
+def _safe_extract_psutil_android_tar(tar, destination: Path) -> None:
+    destination = destination.resolve()
+    members = tar.getmembers()
+    for member in members:
+        name = member.name
+        target = (destination / name).resolve()
+        try:
+            target.relative_to(destination)
+        except ValueError:
+            raise RuntimeError(f"Unsafe path in psutil archive: {name}") from None
+        if Path(name).is_absolute():
+            raise RuntimeError(f"Unsafe path in psutil archive: {name}")
+        if member.issym() or member.islnk():
+            raise RuntimeError(f"Unsafe link in psutil archive: {name}")
+        if not (member.isfile() or member.isdir()):
+            raise RuntimeError(f"Unsupported tar entry in psutil archive: {name}")
+    tar.extractall(destination, members=members)
+
+
 def _install_psutil_android_compat(
     install_cmd_prefix: list[str],
     *,
@@ -7787,18 +7831,13 @@ def _install_psutil_android_compat(
     import tempfile
     import urllib.request
 
-    psutil_url = (
-        "https://files.pythonhosted.org/packages/aa/c6/"
-        "d1ddf4abb55e93cebc4f2ed8b5d6dbad109ecb8d63748dd2b20ab5e57ebe/"
-        "psutil-7.2.2.tar.gz"
-    )
-
     with tempfile.TemporaryDirectory() as tmp:
         tmp_path = Path(tmp)
         archive = tmp_path / "psutil.tar.gz"
-        urllib.request.urlretrieve(psutil_url, archive)
+        urllib.request.urlretrieve(_PSUTIL_ANDROID_URL, archive)
+        _verify_psutil_android_archive(archive)
         with tarfile.open(archive) as tar:
-            tar.extractall(tmp_path)
+            _safe_extract_psutil_android_tar(tar, tmp_path)
 
         src_root = next(
             p for p in tmp_path.iterdir() if p.is_dir() and p.name.startswith("psutil-")

--- a/scripts/install_psutil_android.py
+++ b/scripts/install_psutil_android.py
@@ -24,6 +24,7 @@ https://github.com/giampaolo/psutil/pull/2762 and ships a release.
 from __future__ import annotations
 
 import argparse
+import hashlib
 import shutil
 import subprocess
 import sys
@@ -39,6 +40,7 @@ PSUTIL_URL = (
     "d1ddf4abb55e93cebc4f2ed8b5d6dbad109ecb8d63748dd2b20ab5e57ebe/"
     "psutil-7.2.2.tar.gz"
 )
+PSUTIL_SHA256 = "0746f5f8d406af344fd547f1c8daa5f5c33dbc293bb8d6a16d80b4bb88f59372"
 
 MARKER = 'LINUX = sys.platform.startswith("linux")'
 REPLACEMENT = 'LINUX = sys.platform.startswith(("linux", "android"))'
@@ -56,6 +58,37 @@ def _resolve_install_cmd(pip_arg: str | None, prefer_uv: bool) -> list[str]:
     if auto_uv:
         return [auto_uv, "pip"]
     return [sys.executable, "-m", "pip"]
+
+
+def _verify_archive_checksum(archive: Path, expected_sha256: str) -> None:
+    digest = hashlib.sha256()
+    with archive.open("rb") as f:
+        for chunk in iter(lambda: f.read(1024 * 1024), b""):
+            digest.update(chunk)
+    actual = digest.hexdigest()
+    if actual != expected_sha256:
+        raise RuntimeError(
+            f"psutil sdist checksum mismatch: expected {expected_sha256}, got {actual}"
+        )
+
+
+def _safe_extract_tar(tar: tarfile.TarFile, destination: Path) -> None:
+    destination = destination.resolve()
+    members = tar.getmembers()
+    for member in members:
+        name = member.name
+        target = (destination / name).resolve()
+        try:
+            target.relative_to(destination)
+        except ValueError:
+            raise RuntimeError(f"Unsafe path in psutil sdist: {name}") from None
+        if Path(name).is_absolute():
+            raise RuntimeError(f"Unsafe path in psutil sdist: {name}")
+        if member.issym() or member.islnk():
+            raise RuntimeError(f"Unsafe link in psutil sdist: {name}")
+        if not (member.isfile() or member.isdir()):
+            raise RuntimeError(f"Unsupported tar entry in psutil sdist: {name}")
+    tar.extractall(destination, members=members)
 
 
 def main() -> int:
@@ -82,8 +115,9 @@ def main() -> int:
         tmp_path = Path(tmp)
         archive = tmp_path / "psutil.tar.gz"
         urllib.request.urlretrieve(PSUTIL_URL, archive)
+        _verify_archive_checksum(archive, PSUTIL_SHA256)
         with tarfile.open(archive) as tar:
-            tar.extractall(tmp_path)
+            _safe_extract_tar(tar, tmp_path)
 
         try:
             src_root = next(

--- a/tests/hermes_cli/test_android_psutil_installer.py
+++ b/tests/hermes_cli/test_android_psutil_installer.py
@@ -1,0 +1,105 @@
+"""Tests for Android psutil archive verification and extraction guards."""
+
+from __future__ import annotations
+
+import hashlib
+import io
+import tarfile
+from importlib import import_module
+
+import pytest
+
+
+def _write_tar(path, members):
+    with tarfile.open(path, "w:gz") as tar:
+        for name, content in members:
+            data = content if isinstance(content, bytes) else content.encode("utf-8")
+            info = tarfile.TarInfo(name)
+            info.size = len(data)
+            tar.addfile(info, io.BytesIO(data))
+
+
+@pytest.mark.parametrize(
+    "module_name, helper_name",
+    [
+        ("scripts.install_psutil_android", "_safe_extract_tar"),
+        ("hermes_cli.main", "_safe_extract_psutil_android_tar"),
+    ],
+)
+def test_psutil_safe_extract_rejects_path_traversal(tmp_path, module_name, helper_name):
+    archive = tmp_path / "bad.tar.gz"
+    _write_tar(archive, [("../../escape.txt", "bad")])
+    dest = tmp_path / "dest"
+    dest.mkdir()
+
+    helper = getattr(import_module(module_name), helper_name)
+
+    with tarfile.open(archive) as tar, pytest.raises(RuntimeError, match="Unsafe path"):
+        helper(tar, dest)
+
+    assert not (tmp_path / "escape.txt").exists()
+
+
+@pytest.mark.parametrize(
+    "module_name, helper_name",
+    [
+        ("scripts.install_psutil_android", "_safe_extract_tar"),
+        ("hermes_cli.main", "_safe_extract_psutil_android_tar"),
+    ],
+)
+def test_psutil_safe_extract_rejects_links(tmp_path, module_name, helper_name):
+    archive = tmp_path / "link.tar.gz"
+    with tarfile.open(archive, "w:gz") as tar:
+        info = tarfile.TarInfo("psutil-7.2.2/link")
+        info.type = tarfile.SYMTYPE
+        info.linkname = "../../escape.txt"
+        tar.addfile(info)
+    dest = tmp_path / "dest"
+    dest.mkdir()
+
+    helper = getattr(import_module(module_name), helper_name)
+
+    with tarfile.open(archive) as tar, pytest.raises(RuntimeError, match="Unsafe link"):
+        helper(tar, dest)
+
+
+@pytest.mark.parametrize(
+    "module_name, helper_name",
+    [
+        ("scripts.install_psutil_android", "_safe_extract_tar"),
+        ("hermes_cli.main", "_safe_extract_psutil_android_tar"),
+    ],
+)
+def test_psutil_safe_extract_allows_regular_members(tmp_path, module_name, helper_name):
+    archive = tmp_path / "good.tar.gz"
+    _write_tar(archive, [("psutil-7.2.2/psutil/_common.py", "payload")])
+    dest = tmp_path / "dest"
+    dest.mkdir()
+
+    helper = getattr(import_module(module_name), helper_name)
+
+    with tarfile.open(archive) as tar:
+        helper(tar, dest)
+
+    assert (dest / "psutil-7.2.2" / "psutil" / "_common.py").read_text() == "payload"
+
+
+def test_script_checksum_verification_rejects_mismatch(tmp_path):
+    from scripts.install_psutil_android import _verify_archive_checksum
+
+    archive = tmp_path / "archive.tar.gz"
+    archive.write_bytes(b"payload")
+
+    with pytest.raises(RuntimeError, match="checksum mismatch"):
+        _verify_archive_checksum(archive, "0" * 64)
+
+
+def test_main_checksum_verification_accepts_expected_hash(tmp_path, monkeypatch):
+    main = import_module("hermes_cli.main")
+    archive = tmp_path / "archive.tar.gz"
+    archive.write_bytes(b"payload")
+    expected = hashlib.sha256(b"payload").hexdigest()
+
+    monkeypatch.setattr(main, "_PSUTIL_ANDROID_SHA256", expected)
+
+    main._verify_psutil_android_archive(archive)


### PR DESCRIPTION
## Summary
- pin the expected SHA-256 for the Android psutil source archive
- verify the downloaded archive before extracting it in both Android install paths
- validate tar members before extraction to reject traversal, links, devices, and unsupported entries

## Validation
- scripts/run_tests.sh tests/hermes_cli/test_android_psutil_installer.py