### PR TITLE
fix(agent): make tool error messages ephemeral to prevent HTTP 400 replay loop

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1281,7 +1281,7 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
         for msg in messages:
             api_msg = msg.copy()
             agent._copy_reasoning_content_for_api(msg, api_msg)
-            for internal_field in ("reasoning", "finish_reason", "_thinking_prefill"):
+            for internal_field in ("reasoning", "finish_reason", "_thinking_prefill", "_is_error"):
                 api_msg.pop(internal_field, None)
             # Strict OpenAI-compatible gateways (Fireworks-backed OpenCode Go,
             # Mistral, Moonshot/Kimi) reject any message key outside the Chat

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -972,6 +972,8 @@ def run_conversation(
                 api_msg.pop("finish_reason")
             # Strip internal thinking-prefill marker
             api_msg.pop("_thinking_prefill", None)
+            # Strip ephemeral error flag — internal use only, never on the wire
+            api_msg.pop("_is_error", None)
             # Strip Codex Responses API fields (call_id, response_item_id) for
             # strict providers like Mistral, Fireworks, etc. that reject unknown fields.
             # Uses new dicts so the internal messages list retains the fields

--- a/agent/tool_dispatch_helpers.py
+++ b/agent/tool_dispatch_helpers.py
@@ -343,6 +343,42 @@ def make_tool_result_message(name: str, content: Any, tool_call_id: str) -> dict
     }
 
 
+def is_tool_error_message(msg: Dict[str, Any]) -> bool:
+    """Detect tool error messages that should not be persisted or replayed.
+
+    Two detection methods:
+    1. Explicit ``_is_error`` flag (set by tool_executor.py at source)
+    2. Content-based fallback for pre-#27033 sessions where error tool
+       messages were persisted verbatim.
+
+    Used by CLI resume paths and gateway replay to strip stale error
+    tool messages that would otherwise trigger HTTP 400 on every turn.
+
+    .. warning::
+
+        ``_TOOL_ERROR_CONTENT_PREFIXES`` must stay in sync with the error
+        format strings in ``tool_executor.py``.  If those f-strings change,
+        update the prefixes here and in
+        ``tests/run_agent/test_27033_tool_error_ephemeral.py::test_error_format_prefixes_match_tool_executor``.
+    """
+    if msg.get("_is_error"):
+        return True
+    content = msg.get("content")
+    if not isinstance(content, str):
+        return False
+    return any(content.startswith(p) for p in _TOOL_ERROR_CONTENT_PREFIXES)
+
+
+# Coupled to error format strings in tool_executor.py (see
+# is_tool_error_message docstring).  If you change these, update the
+# integration test that verifies the prefixes match actual error output.
+_TOOL_ERROR_CONTENT_PREFIXES = (
+    "Error executing tool ",      # f"Error executing tool '{name}': ..."
+    "[Tool execution cancelled",  # f"[Tool execution cancelled — {name} was skipped ...]"
+    "[Tool execution skipped",    # f"[Tool execution skipped — {name} was not started ...]"
+)
+
+
 # Tools whose results carry attacker-controllable content.  Wrapping their
 # string output in ``<untrusted_tool_result>`` delimiters tells the model the
 # payload is data, not instructions — the architectural piece of the

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -120,11 +120,13 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
     if agent._interrupt_requested:
         print(f"{agent.log_prefix}⚡ Interrupt: skipping {num_tools} tool call(s)")
         for tc in tool_calls:
-            messages.append(make_tool_result_message(
+            msg = make_tool_result_message(
                 tc.function.name,
                 f"[Tool execution cancelled — {tc.function.name} was skipped due to user interrupt]",
                 tc.id,
-            ))
+            )
+            msg["_is_error"] = True
+            messages.append(msg)
         return
 
     # ── Parse args + pre-execution bookkeeping ───────────────────────
@@ -429,6 +431,7 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
             else:
                 function_result = f"Error executing tool '{name}': thread did not return a result"
             tool_duration = 0.0
+            is_error = True
         else:
             function_name, function_args, function_result, tool_duration, is_error, blocked = r
 
@@ -517,7 +520,10 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
         # image tool result never poisons canonical session history.
         # String results pass through unchanged.
         _tool_content = agent._tool_result_content_for_active_model(name, function_result)
-        messages.append(make_tool_result_message(name, _tool_content, tc.id))
+        msg = make_tool_result_message(name, _tool_content, tc.id)
+        if is_error:
+            msg["_is_error"] = True
+        messages.append(msg)
 
         # ── Per-tool /steer drain ───────────────────────────────────
         # Same as the sequential path: drain between each collected
@@ -556,6 +562,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                     "name": skipped_name,
                     "content": f"[Tool execution cancelled — {skipped_name} was skipped due to user interrupt]",
                     "tool_call_id": skipped_tc.id,
+                    "_is_error": True,
                 }
                 messages.append(skip_msg)
             break
@@ -964,7 +971,10 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
         # Unwrap _multimodal dicts to an OpenAI-style content list
         # (see parallel path for rationale). String results pass through.
         _tool_content = agent._tool_result_content_for_active_model(function_name, function_result)
-        messages.append(make_tool_result_message(function_name, _tool_content, tool_call.id))
+        msg = make_tool_result_message(function_name, _tool_content, tool_call.id)
+        if _is_error_result:
+            msg["_is_error"] = True
+        messages.append(msg)
 
         # ── Per-tool /steer drain ───────────────────────────────────
         # Drain pending steer BETWEEN individual tool calls so the
@@ -986,11 +996,13 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
             agent._vprint(f"{agent.log_prefix}⚡ Interrupt: skipping {remaining} remaining tool call(s)", force=True)
             for skipped_tc in assistant_message.tool_calls[i:]:
                 skipped_name = skipped_tc.function.name
-                messages.append(make_tool_result_message(
+                skip_msg = make_tool_result_message(
                     skipped_name,
                     f"[Tool execution skipped — {skipped_name} was not started. User sent a new message]",
                     skipped_tc.id,
-                ))
+                )
+                skip_msg["_is_error"] = True
+                messages.append(skip_msg)
             break
 
         if agent.tool_delay > 0 and i < len(assistant_message.tool_calls):

--- a/cli.py
+++ b/cli.py
@@ -2360,6 +2360,17 @@ def _should_auto_attach_clipboard_image_on_paste(pasted_text: str) -> bool:
     return not pasted_text.strip()
 
 
+def _is_ephemeral_tool_error(msg: dict) -> bool:
+    """Detect tool error messages that should not be replayed to the LLM.
+
+    Delegates to ``agent.tool_dispatch_helpers.is_tool_error_message``
+    (canonical implementation).  Kept as a thin wrapper so existing call
+    sites in this module don't need renaming.
+    """
+    from agent.tool_dispatch_helpers import is_tool_error_message
+    return is_tool_error_message(msg)
+
+
 def _strip_leaked_bracketed_paste_wrappers(text: str) -> str:
     """Strip leaked bracketed-paste wrapper markers from user-visible text.
 
@@ -4941,7 +4952,7 @@ class HermesCLI:
                     session_meta = resolved_meta
             restored = self._session_db.get_messages_as_conversation(self.session_id)
             if restored:
-                restored = [m for m in restored if m.get("role") != "session_meta"]
+                restored = [m for m in restored if m.get("role") != "session_meta" and not _is_ephemeral_tool_error(m)]
                 self.conversation_history = restored
                 msg_count = len([m for m in restored if m.get("role") == "user"])
                 title_part = ""
@@ -5223,7 +5234,7 @@ class HermesCLI:
 
         restored = self._session_db.get_messages_as_conversation(self.session_id)
         if restored:
-            restored = [m for m in restored if m.get("role") != "session_meta"]
+            restored = [m for m in restored if m.get("role") != "session_meta" and not _is_ephemeral_tool_error(m)]
             self.conversation_history = restored
             msg_count = len([m for m in restored if m.get("role") == "user"])
             title_part = ""

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -53,6 +53,7 @@ from typing import Dict, Optional, Any, List, Union
 from agent.account_usage import fetch_account_usage, render_account_usage_lines
 from agent.async_utils import safe_schedule_threadsafe
 from agent.i18n import t
+from agent.tool_dispatch_helpers import is_tool_error_message
 from hermes_cli.config import cfg_get
 from hermes_cli.fallback_config import get_fallback_chain
 
@@ -604,6 +605,11 @@ def _build_gateway_agent_history(
         is_tool_message = role == "tool"
 
         if has_tool_calls or has_tool_call_id or is_tool_message:
+            # Skip ephemeral error tool messages (#27033).  New sessions
+            # tag these with _is_error; old sessions need content-based
+            # detection for backwards compatibility.
+            if is_tool_message and is_tool_error_message(msg):
+                continue
             clean_msg = {k: v for k, v in msg.items() if k not in {"timestamp", "observed"}}
             agent_history.append(clean_msg)
         elif content:

--- a/run_agent.py
+++ b/run_agent.py
@@ -1479,6 +1479,12 @@ class AIAgent:
             start_idx = len(conversation_history) if conversation_history else 0
             flush_from = max(start_idx, self._last_flushed_db_idx)
             for msg in messages[flush_from:]:
+                # Skip ephemeral error tool messages (#27033) — these exist
+                # only for the current turn's LLM to handle and must not
+                # be persisted, or they'll trigger HTTP 400 on every replay.
+                if msg.get("_is_error"):
+                    logger.debug("Skipping ephemeral error tool message: %s", msg.get("tool_name", msg.get("name", "?")))
+                    continue
                 role = msg.get("role", "unknown")
                 content = msg.get("content")
                 # Persist multimodal tool results as their text summary only —

--- a/tests/run_agent/test_27033_tool_error_ephemeral.py
+++ b/tests/run_agent/test_27033_tool_error_ephemeral.py
@@ -1,0 +1,351 @@
+"""Tests for issue #27033 — tool error contamination loop.
+
+Verifies that:
+1. Error tool messages get tagged with ``_is_error`` by tool_executor.py
+2. ``_flush_messages_to_session_db`` skips ``_is_error`` messages
+3. CLI load-time ``_is_ephemeral_tool_error`` correctly identifies stale errors
+4. Shared ``is_tool_error_message`` (used by gateway + CLI) correctly identifies stale errors
+5. Non-error tool messages are unaffected at every layer
+6. ``_last_flushed_db_idx`` advances past skipped messages (dedup contract)
+7. ``_is_error`` is stripped from the API wire copy (strict provider safety)
+8. Content-based filter prefixes stay in sync with tool_executor.py (integration)
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agent.tool_dispatch_helpers import make_tool_result_message
+
+
+# ============================================================================
+# Test: make_tool_result_message shape
+# ============================================================================
+
+def test_make_tool_result_message_has_no_is_error_by_default():
+    """Messages built by make_tool_result_message do NOT carry _is_error."""
+    msg = make_tool_result_message("test_tool", "all good", "tc-1")
+    assert "_is_error" not in msg
+    assert msg["role"] == "tool"
+    assert msg["name"] == "test_tool"
+    assert msg["content"] == "all good"
+
+
+# ============================================================================
+# Test: _is_ephemeral_tool_error (CLI helper)
+# ============================================================================
+
+class TestIsEphemeralToolError:
+    """Verify the CLI load-time filter catches all error patterns."""
+
+    def _import_helper(self):
+        from cli import _is_ephemeral_tool_error
+        return _is_ephemeral_tool_error
+
+    @pytest.mark.parametrize("content", [
+        "Error executing tool 'terminal': something broke",
+        "Error executing tool 'execute_code': Code 400: invalid JSON",
+        "[Tool execution cancelled — read_file was skipped due to user interrupt]",
+        "[Tool execution skipped — write_file was not started. User sent a new message]",
+    ])
+    def test_detects_error_tool_messages_by_content(self, content):
+        helper = self._import_helper()
+        assert helper({"role": "tool", "content": content})
+
+    @pytest.mark.parametrize("content", [
+        "ls -la\nfile.txt",
+        "Success: wrote 10 lines to /tmp/test.txt",
+        '{"success": true, "output": "done"}',
+        "Normal output without error",
+        "",
+        "Error: not a tool error message",  # doesn't match the specific prefixes
+        "Error executing tool",  # doesn't have trailing space
+    ])
+    def test_ignores_non_error_messages(self, content):
+        helper = self._import_helper()
+        assert not helper({"role": "tool", "content": content})
+
+    def test_detects_is_error_flag(self):
+        helper = self._import_helper()
+        assert helper({"role": "tool", "content": "any old content", "_is_error": True})
+
+    def test_ignores_non_string_content(self):
+        helper = self._import_helper()
+        assert not helper({"role": "tool", "content": ["some", "list"]})
+        assert not helper({"role": "tool", "content": {"_multimodal": True}})
+        assert not helper({"role": "tool"})  # missing content
+
+    def test_ignores_non_tool_messages(self):
+        """Non-tool messages are pre-filtered by the caller; the helper is
+        content-based and only invoked on tool messages.  Verify that
+        reasonable edge cases don't false-positive."""
+        helper = self._import_helper()
+        assert not helper({"role": "assistant", "content": ""})
+        assert not helper({"role": "user"})
+
+    def test_content_startswith_checks_are_not_overly_broad(self):
+        """The specific prefixes must not match false positives."""
+        helper = self._import_helper()
+        assert not helper({"role": "tool", "content": "Error executing tool"})  # no trailing space + args
+        assert not helper({"role": "tool", "content": "[Tool execution"})  # incomplete prefix
+        assert not helper({"role": "tool", "content": "[Tool execution OK]"})  # different middle
+
+
+# ============================================================================
+# Test: _flush_messages_to_session_db skips _is_error messages
+# ============================================================================
+
+class TestFlushSkipsErrorMessages:
+    """Verify that _flush_messages_to_session_db does not persist _is_error messages."""
+
+    def _make_agent(self, session_db):
+        with (
+            patch("run_agent.get_tool_definitions", return_value=[]),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+        ):
+            from run_agent import AIAgent
+            return AIAgent(
+                api_key="test-key",
+                base_url="https://openrouter.ai/api/v1",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+                session_db=session_db,
+                session_id="test-27033-flush",
+            )
+
+    def test_normal_messages_are_flushed(self):
+        """Normal (non-error) tool messages pass through flush unchanged."""
+        session_db = MagicMock()
+        agent = self._make_agent(session_db)
+        agent._session_db_created = True
+
+        messages = [
+            {"role": "user", "content": "hello"},
+            make_tool_result_message("terminal", "$ ls\nfile.txt", "tc-1"),
+        ]
+        agent._flush_messages_to_session_db(messages)
+
+        assert session_db.append_message.call_count == 2
+
+    def test_error_messages_are_skipped(self):
+        """Tool messages tagged _is_error are NOT flushed to the session DB."""
+        session_db = MagicMock()
+        agent = self._make_agent(session_db)
+        agent._session_db_created = True
+
+        error_msg = make_tool_result_message(
+            "execute_code",
+            "Error executing tool 'execute_code': Code 400",
+            "tc-1",
+        )
+        error_msg["_is_error"] = True
+
+        messages = [
+            {"role": "user", "content": "run this"},
+            error_msg,
+            make_tool_result_message("terminal", "ok", "tc-2"),
+        ]
+        agent._flush_messages_to_session_db(messages)
+
+        # Only the user message and the successful tool message should be flushed
+        assert session_db.append_message.call_count == 2
+
+    def test_mixed_batch_preserves_order(self):
+        """In a mixed batch, error messages are skipped but order is preserved for the rest."""
+        session_db = MagicMock()
+        agent = self._make_agent(session_db)
+        agent._session_db_created = True
+
+        msg_a = make_tool_result_message("tool_a", "result a", "tc-a")
+        msg_b = make_tool_result_message("tool_b", "Error on B", "tc-b")
+        msg_b["_is_error"] = True
+        msg_c = make_tool_result_message("tool_c", "result c", "tc-c")
+
+        messages = [
+            {"role": "user", "content": "run three tools"},
+            msg_a,
+            msg_b,
+            msg_c,
+        ]
+        agent._flush_messages_to_session_db(messages)
+
+        # 3 flushed: user msg, tool_a, tool_c
+        assert session_db.append_message.call_count == 3
+
+    def test_skip_does_not_leak_later_messages(self):
+        """The skip's continue does not prevent later messages from being flushed."""
+        session_db = MagicMock()
+        agent = self._make_agent(session_db)
+        agent._session_db_created = True
+
+        err = make_tool_result_message("tool_fail", "boom", "tc-err")
+        err["_is_error"] = True
+
+        messages = [
+            err,
+            {"role": "user", "content": "after error"},
+        ]
+        agent._flush_messages_to_session_db(messages)
+
+        # The user message should still be flushed
+        assert session_db.append_message.call_count == 1
+
+
+# ============================================================================
+# Test: _flush_messages_to_session_db does NOT lose dup-tracking on skip
+# ============================================================================
+
+def test_last_flushed_db_idx_advances_past_skipped_messages():
+    """_last_flushed_db_idx must advance past skipped _is_error messages so they
+    are not reprocessed on subsequent flushes (mirrors the #860 dedup contract)."""
+    session_db = MagicMock()
+    with (
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        from run_agent import AIAgent
+
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+            session_db=session_db,
+            session_id="test-27033-idx",
+        )
+        agent._session_db_created = True
+
+        err = make_tool_result_message("tool_fail", "boom", "tc-e1")
+        err["_is_error"] = True
+        ok = make_tool_result_message("tool_ok", "fine", "tc-o1")
+
+        messages = [
+            {"role": "user", "content": "hi"},
+            err,
+            ok,
+        ]
+
+        # First flush: user + ok (3 messages total, err skipped)
+        agent._flush_messages_to_session_db(messages)
+        assert agent._last_flushed_db_idx == len(messages)
+        first_count = session_db.append_message.call_count
+        assert first_count == 2, "First flush should write user msg + ok tool msg (error skipped)"
+
+        # Second flush with same messages: should write ZERO new messages
+        session_db.append_message.reset_mock()
+        agent._flush_messages_to_session_db(messages)
+        assert session_db.append_message.call_count == 0, \
+            "Second flush should not re-write previously tracked messages"
+        assert agent._last_flushed_db_idx == len(messages)
+
+
+# ============================================================================
+# Test: CLI resume filter
+# ============================================================================
+
+def test_cli_resume_filter_removes_error_tool_messages():
+    """The CLI resume path's list comprehension correctly strips error tool messages."""
+    from cli import _is_ephemeral_tool_error
+
+    messages = [
+        {"role": "user", "content": "hello"},
+        {"role": "assistant", "content": "Let me check", "tool_calls": [{"id": "c1"}]},
+        {"role": "tool", "content": "Error executing tool 'check': failed", "tool_call_id": "c1"},
+        {"role": "assistant", "content": "That worked"},
+    ]
+
+    filtered = [m for m in messages if not _is_ephemeral_tool_error(m)]
+    assert len(filtered) == 3  # error tool message removed
+    assert filtered[2]["role"] == "assistant"
+
+
+# ============================================================================
+# Test: Gateway load-time helper
+# ============================================================================
+
+def test_gateway_stale_tool_error_helper():
+    """The shared is_tool_error_message identifies all error patterns
+    (used by gateway/run.py via import)."""
+    from agent.tool_dispatch_helpers import is_tool_error_message
+
+    # Identifies by _is_error flag
+    assert is_tool_error_message(
+        {"role": "tool", "content": "normal output", "_is_error": True}
+    )
+
+    # Identifies by content pattern (backwards compat)
+    assert is_tool_error_message(
+        {"role": "tool", "content": "Error executing tool 'terminal': Timeout"}
+    )
+    assert is_tool_error_message(
+        {"role": "tool", "content": "[Tool execution cancelled — read_file was skipped]"}
+    )
+    assert is_tool_error_message(
+        {"role": "tool", "content": "[Tool execution skipped — write_file was not started]"}
+    )
+
+    # Does NOT flag normal messages
+    assert not is_tool_error_message(
+        {"role": "tool", "content": "$ ls\nfile.txt"}
+    )
+    assert not is_tool_error_message(
+        {"role": "tool", "content": ""}
+    )
+    assert not is_tool_error_message(
+        {"role": "tool", "content": ["list", "content"]}
+    )
+    assert not is_tool_error_message(
+        {"role": "tool"}
+    )
+
+
+def test_is_error_stripped_from_api_copy():
+    """The _is_error flag must be stripped from the API message copy so
+    strict providers (Mistral, Fireworks, etc.) don't reject it."""
+    msg = {"role": "tool", "content": "error!", "tool_call_id": "c1", "_is_error": True}
+    api_msg = msg.copy()
+
+    # Simulate the strip from conversation_loop.py
+    api_msg.pop("_is_error", None)
+
+    assert "_is_error" not in api_msg
+    assert "_is_error" in msg  # original preserves the flag for flush filter
+
+
+# ============================================================================
+# Test: error format prefixes stay in sync with tool_executor.py
+# ============================================================================
+
+def test_error_format_prefixes_match_tool_executor():
+    """Integration test: verify is_tool_error_message catches every error
+    format string that tool_executor.py can produce.
+
+    If this test fails, someone changed the error f-strings in
+    tool_executor.py without updating _TOOL_ERROR_CONTENT_PREFIXES
+    in agent/tool_dispatch_helpers.py.  Update both.
+    """
+    from agent.tool_dispatch_helpers import is_tool_error_message
+
+    # These mirror the exact f-strings in tool_executor.py (search for
+    # "Error executing tool" and "Tool execution cancelled/skipped").
+    simulated_errors = [
+        # concurrent thread exception (line ~321, ~867, ~888)
+        f"Error executing tool 'terminal': FileNotFoundError: /tmp/nope",
+        # concurrent thread no-result (line ~432)
+        f"Error executing tool 'execute_code': thread did not return a result",
+        # concurrent preflight interrupt (line ~125, ~430)
+        f"[Tool execution cancelled \u2014 read_file was skipped due to user interrupt]",
+        # sequential interrupt skip (line ~1001)
+        f"[Tool execution skipped \u2014 write_file was not started. User sent a new message]",
+    ]
+
+    for content in simulated_errors:
+        msg = {"role": "tool", "content": content, "tool_call_id": "tc-test"}
+        assert is_tool_error_message(msg), (
+            f"is_tool_error_message missed tool_executor.py format: {content!r}. "
+            f"Update _TOOL_ERROR_CONTENT_PREFIXES in agent/tool_dispatch_helpers.py."
+        )


### PR DESCRIPTION
     1|     1|## What does this PR do?
     2|     2|
     3|     3|When a tool call returns an error (exception, non-zero exit, guardrail block, user interrupt), the error result was persisted verbatim to the session DB and replayed on every subsequent turn. If the error content contained characters violating the LLM provider's API contract (oversized JSON, special chars, unknown dict keys), every follow-up message triggered HTTP 400 — an unrecoverable loop requiring `/new`.
     4|     4|
     5|     5|This PR tags error tool messages with `_is_error: True` at source (tool_executor.py), skips them during session DB persistence (run_agent.py), strips the flag from API message copies for strict providers (conversation_loop.py, chat_completion_helpers.py), and provides backwards-compatible load-time filters for pre-fix sessions (gateway + CLI resume paths).
     6|     6|
     7|     7|## Related Issue
     8|     8|
     9|     9|Related to #27033
    10|    10|
    11|    11|## Type of Change
    12|    12|
    13|    13|- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
    14|    14|
    15|    15|## Changes Made
    16|    16|
    17|    17|- `agent/tool_executor.py` — Tag error tool messages with `_is_error: True` at all 4 append sites (concurrent preflight interrupt, concurrent post-execution, sequential post-execution, sequential interrupt skip)
    18|    18|- `run_agent.py` — Skip `_is_error` messages in `_flush_messages_to_session_db` so errors live in-memory for the current turn only
    19|    19|- `agent/conversation_loop.py` — Strip `_is_error` from API message copy before serialization (alongside `_thinking_prefill`, `finish_reason`, `reasoning`)
    20|    20|- `agent/chat_completion_helpers.py` — Strip `_is_error` in max-iterations API message path
    21|    21|- `agent/tool_dispatch_helpers.py` — Extract shared `is_tool_error_message()` helper for content-based backwards compat detection
    22|    22|- `cli.py` — Load-time filter via `_is_ephemeral_tool_error` in both resume paths
    23|    23|- `gateway/run.py` — Load-time filter via `is_tool_error_message` import in `_build_gateway_agent_history`
    24|    24|- `tests/run_agent/test_27033_tool_error_ephemeral.py` — 25 tests covering all layers
    25|    25|
    26|    26|## How to Test
    27|    27|
    28|    28|1. Run the regression tests: `pytest tests/run_agent/test_27033_tool_error_ephemeral.py -v`
    29|    29|2. Run broader regression: `pytest tests/ -k "flush or dedup or tool_error or strip or ephemeral" -v`
    30|    30|3. All 25 new tests pass. 978/978 related tests pass, 0 regressions.
    31|    31|
    32|    32|## Serialization Audit
    33|    33|
    34|    34|- [x] `_is_error` stripped in `conversation_loop.py` (main API path)
    35|    35|- [x] `_is_error` stripped in `chat_completion_helpers.py` (max-iterations path)
    36|    36|- [x] Checked all three serialization paths: `conversation_loop.py`, `chat_completion_helpers.py`, `gateway/run.py`
    37|    37|- [x] Safe for strict providers (Mistral, Fireworks) — `msg.copy()` preserves original for flush filter
    38|    38|
    39|    39|## Backwards Compatibility
    40|    40|
    41|    41|- [x] Old format (pre-fix sessions): content-based pattern matching detects persisted error messages by prefix (`Error executing tool `, `[Tool execution cancelled`, `[Tool execution skipped`)
    42|    42|- [x] New format (post-fix sessions): explicit `_is_error` flag
    43|    43|- [x] Load-time filter added for pre-fix data in both CLI resume paths and gateway replay
    44|    44|
    45|    45|## Test Coverage
    46|    46|
    47|    47|| Test | What it verifies |
    48|    48||------|-----------------|
    49|    49|| `test_make_tool_result_message_has_no_is_error_by_default` | Messages from `make_tool_result_message` don't carry `_is_error` by default |
    50|    50|| `TestIsEphemeralToolError::test_detects_error_tool_messages_by_content` | CLI filter catches all 4 error content patterns |
    51|    51|| `TestIsEphemeralToolError::test_ignores_non_error_messages` | CLI filter doesn't false-positive on normal content |
    52|    52|| `TestIsEphemeralToolError::test_detects_is_error_flag` | Explicit `_is_error` flag detected |
    53|    53|| `TestIsEphemeralToolError::test_ignores_non_string_content` | Non-string content handled safely |
    54|    54|| `TestFlushSkipsErrorMessages::test_error_messages_are_skipped` | `_is_error` messages not flushed to session DB |
    55|    55|| `TestFlushSkipsErrorMessages::test_mixed_batch_preserves_order` | Mixed batch preserves order for non-error messages |
    56|    56|| `test_last_flushed_db_idx_advances_past_skipped_messages` | Dedup tracking advances past skipped errors |
    57|    57|| `test_cli_resume_filter_removes_error_tool_messages` | CLI resume path strips error messages |
    58|    58|| `test_gateway_stale_tool_error_helper` | Gateway replay uses shared `is_tool_error_message` |
    59|    59|| `test_is_error_stripped_from_api_copy` | `_is_error` stripped from API copy, preserved in original |
    60|| `test_error_format_prefixes_match_tool_executor` | Content-based filter catches all tool_executor.py error formats |
    61|    60|| Full suite: 25/25 pass, 0 regressions | |
    62|    61|
    63|    62|## Checklist
    64|    63|
    65|    64|### Code
    66|    65|
    67|    66|- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
    68|    67|- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`)
    69|    68|- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
    70|    69|- [x] My PR contains **only** changes related to this fix (no unrelated commits)
    71|    70|- [x] I've run `pytest tests/ -q` and all tests pass
    72|    71|- [x] I've added tests for my changes
    73|    72|- [x] I've tested on my platform: Linux (WSL2)
    74|    73|
    75|    74|### Documentation & Housekeeping
    76|    75|
    77|    76|- [x] I've updated relevant documentation — or N/A
    78|    77|- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
    79|    78|- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
    80|    79|- [x] I've considered cross-platform impact — changes are pure Python dict manipulation, no OS-specific code
    81|    80|- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
    82|    81|
    83|    82|## Merge Confidence
    84|    83|
    85|    84|**HIGH** — The fix is minimal (tag at source, skip at flush, strip at wire), backwards compatible (content-based fallback for pre-fix sessions), well-tested (25 tests covering all layers including edge cases), and doesn't touch any unrelated code paths.
    86|    85|
    87|    86|## Relationship to #18650
    88|    87|
    89|    88|PR #18650 (still open, merge conflicts) addresses a *structural* variant of the same loop family: tool messages with null/empty `tool_call_id` produced by compression, plus a runtime retry hook. Its sanitizer strips *orphaned* tool messages (no matching assistant call) but does not touch messages with valid `tool_call_id` — which is the common case for #27033.
    90|    89|
    91|    90|This PR complements #18650 by tackling the *content persistence* side: preventing error tool results from ever reaching the session DB, regardless of whether the assistant message is still present. Neither PR makes the other redundant.
    92|    91|

