### PR TITLE
docs(skills): clarify external dir mutations (salvage of #29411)

### DIFF
--- a/website/docs/user-guide/features/skills.md
+++ b/website/docs/user-guide/features/skills.md
@@ -236,7 +236,8 @@ Paths support `~` expansion and `${VAR}` environment variable substitution.
 
 ### How it works
 
-- **Read-only**: External dirs are only scanned for skill discovery. When the agent creates or edits a skill, it always writes to `~/.hermes/skills/`.
+- **Create locally, update in place**: New agent-created skills are written to `~/.hermes/skills/`. Existing skills are modified where they are found, including skills under `external_dirs`, when the agent uses `skill_manage` actions such as `patch`, `edit`, `write_file`, `remove_file`, or `delete`.
+- **External dirs are not a write-protection boundary**: If an external skill directory is writable by the Hermes process, agent-managed skill updates can change files in that directory. Use filesystem permissions or a separate profile/toolset setup if shared external skills must stay read-only.
 - **Local precedence**: If the same skill name exists in both the local dir and an external dir, the local version wins.
 - **Full integration**: External skills appear in the system prompt index, `skills_list`, `skill_view`, and as `/skill-name` slash commands — no different from local skills.
 - **Non-existent paths are silently skipped**: If a configured directory doesn't exist, Hermes ignores it without errors. Useful for optional shared directories that may not be present on every machine.
@@ -250,7 +251,7 @@ Paths support `~` expansion and `${VAR}` environment variable substitution.
 └── mlops/axolotl/
     └── SKILL.md
 
-~/.agents/skills/               # External (read-only, shared)
+~/.agents/skills/               # External (shared, mutable if writable)
 ├── my-custom-workflow/
 │   └── SKILL.md
 └── team-conventions/


### PR DESCRIPTION
Salvage of #29411 onto current `main`. Single docs-only commit, authorship preserved.

## What this fixes

The user-guide page `website/docs/user-guide/features/skills.md` still claimed external skill directories were read-only:

> External dirs are only scanned for skill discovery. When the agent creates or edits a skill, it always writes to `~/.hermes/skills/`.

That hasn't been true since #17512 (commit `8c8fc6c1e`, 2026-04-29), which removed the external-dir refusal from `skill_manage` so that `patch`/`edit`/`write_file`/`remove_file`/`delete` mutate skills in place wherever they were discovered, including under `skills.external_dirs`. Behavior verified on current `main`:

- `tools/skill_manager_tool.py` has no external-dir refusal path; the only mutation guard is `_pinned_guard()`, and pin only protects deletion (#20220).
- `tests/tools/test_skill_manager_tool.py` has the `TestExternalSkillMutations` block (`test_patch_external_skill_writes_in_place`, `test_edit_external_skill_writes_in_place`, `test_write_file_on_external_skill`, `test_remove_file_on_external_skill`) asserting in-place mutation.

The stale docs invite users to point `external_dirs` at shared/team/git-managed skill libraries assuming they're protected. Issue #25083 surfaced this mismatch; comment from @ntgussoni reports actually losing a skill directory this way.

This PR is the smallest fix for the mismatch — it does not implement #25083 (per-skill `immutable: true`). That feature is still open and the issue should remain open after this merges.

## Changes

- Replaces the "Read-only" bullet with:
  - "Create locally, update in place" — enumerates the mutating actions.
  - "External dirs are not a write-protection boundary" — points at filesystem permissions or a separate profile as the real read-only mechanism.
- Updates the directory-tree example comment from `External (read-only, shared)` to `External (shared, mutable if writable)`.

## Salvage details

- Cherry-picked `e1458d495` onto current `origin/main` (PR #29411 was 21 commits behind, but `git log origin/main -- website/docs/user-guide/features/skills.md` shows no intervening churn — cherry-pick was clean, no conflicts).
- Author preserved: `helix4u <4317663+helix4u@users.noreply.github.com>`.

## Credit

All credit to @helix4u for catching the mismatch and writing the fix. Closes #29411.

Related: #25083 (still open — `immutable: true` feature request).
