### PR TITLE
docs(xai): add capability matrix

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -258,7 +258,7 @@ except Exception:
 import logging
 import threading
 import time as _time
-from datetime import datetime
+from datetime import datetime, UTC
 
 from hermes_cli import __version__, __release_date__
 logger = logging.getLogger(__name__)
@@ -407,7 +407,7 @@ def _has_any_provider_configured() -> bool:
     return False
 
 
-def _session_browse_picker(sessions: list) -> Optional[str]:
+def _session_browse_picker(sessions: list) -> str | None:
     """Interactive curses-based session browser with live search filtering.
 
     Returns the selected session ID, or None if cancelled.
@@ -648,7 +648,7 @@ def _session_browse_picker(sessions: list) -> Optional[str]:
             return None
 
 
-def _resolve_last_session(source: str = "cli") -> Optional[str]:
+def _resolve_last_session(source: str = "cli") -> str | None:
     """Look up the most recently-used session ID for a source."""
     db = None
     try:
@@ -779,7 +779,7 @@ def _exec_in_container(container_info: dict, cli_args: list):
     os.execvp(exec_cmd[0], exec_cmd)
 
 
-def _resolve_session_by_name_or_id(name_or_id: str) -> Optional[str]:
+def _resolve_session_by_name_or_id(name_or_id: str) -> str | None:
     """Resolve a session name (title) or ID to a session ID.
 
     - If it looks like a session ID (contains underscore + hex), try direct lookup first.
@@ -797,7 +797,7 @@ def _resolve_session_by_name_or_id(name_or_id: str) -> Optional[str]:
 
         # Try as exact session ID first
         session = db.get_session(name_or_id)
-        resolved_id: Optional[str] = None
+        resolved_id: str | None = None
         if session:
             resolved_id = session["id"]
         else:
@@ -819,7 +819,7 @@ def _resolve_session_by_name_or_id(name_or_id: str) -> Optional[str]:
     return None
 
 
-def _read_tui_active_session_file(path: Optional[str]) -> Optional[str]:
+def _read_tui_active_session_file(path: str | None) -> str | None:
     if not path:
         return None
     try:
@@ -831,7 +831,7 @@ def _read_tui_active_session_file(path: Optional[str]) -> Optional[str]:
 
 
 def _print_tui_exit_summary(
-    session_id: Optional[str], active_session_file: Optional[str] = None
+    session_id: str | None, active_session_file: str | None = None
 ) -> None:
     """Print a shell-visible epilogue after TUI exits."""
     target = (
@@ -1257,20 +1257,20 @@ def _normalize_tui_toolsets(toolsets: object) -> list[str]:
 
 
 def _launch_tui(
-    resume_session_id: Optional[str] = None,
+    resume_session_id: str | None = None,
     tui_dev: bool = False,
-    model: Optional[str] = None,
-    provider: Optional[str] = None,
+    model: str | None = None,
+    provider: str | None = None,
     toolsets: object = None,
     skills: object = None,
     verbose: bool = False,
     quiet: bool = False,
-    query: Optional[str] = None,
-    image: Optional[str] = None,
+    query: str | None = None,
+    image: str | None = None,
     worktree: bool = False,
     checkpoints: bool = False,
     pass_session_id: bool = False,
-    max_turns: Optional[int] = None,
+    max_turns: int | None = None,
     accept_hooks: bool = False,
 ):
     """Replace current process with the TUI."""
@@ -1374,7 +1374,7 @@ def _launch_tui(
         env["HERMES_TUI_RESUME"] = resume_session_id
 
     argv, cwd = _make_tui_argv(tui_dir, tui_dev)
-    code: Optional[int] = None
+    code: int | None = None
     try:
         try:
             code = subprocess.call(argv, cwd=str(cwd), env=env)
@@ -3550,7 +3550,7 @@ def _model_flow_custom(config):
     )
 
 
-def _prompt_custom_api_mode_selection(base_url: str, current_api_mode: str = "") -> Optional[str]:
+def _prompt_custom_api_mode_selection(base_url: str, current_api_mode: str = "") -> str | None:
     """Prompt for a custom provider API mode.
 
     Returns an explicit mode string, or None to keep auto-detect behavior.
@@ -6554,8 +6554,8 @@ def _format_time_ago(iso_ts: str) -> str:
         from datetime import datetime, timezone
         ts = datetime.fromisoformat(iso_ts.replace("Z", "+00:00"))
         if ts.tzinfo is None:
-            ts = ts.replace(tzinfo=timezone.utc)
-        delta = datetime.now(timezone.utc) - ts
+            ts = ts.replace(tzinfo=UTC)
+        delta = datetime.now(UTC) - ts
         secs = int(delta.total_seconds())
         if secs < 60:
             return "just now"
@@ -6820,7 +6820,7 @@ def _update_via_zip(args):
     _kill_stale_dashboard_processes()
 
 
-def _stash_local_changes_if_needed(git_cmd: list[str], cwd: Path) -> Optional[str]:
+def _stash_local_changes_if_needed(git_cmd: list[str], cwd: Path) -> str | None:
     status = subprocess.run(
         git_cmd + ["status", "--porcelain"],
         cwd=cwd,
@@ -6847,7 +6847,7 @@ def _stash_local_changes_if_needed(git_cmd: list[str], cwd: Path) -> Optional[st
 
     from datetime import datetime, timezone
 
-    stash_name = datetime.now(timezone.utc).strftime(
+    stash_name = datetime.now(UTC).strftime(
         "hermes-update-autostash-%Y%m%d-%H%M%S"
     )
     print("→ Local changes detected — stashing before update...")
@@ -6868,7 +6868,7 @@ def _stash_local_changes_if_needed(git_cmd: list[str], cwd: Path) -> Optional[st
 
 def _resolve_stash_selector(
     git_cmd: list[str], cwd: Path, stash_ref: str
-) -> Optional[str]:
+) -> str | None:
     stash_list = subprocess.run(
         git_cmd + ["stash", "list", "--format=%gd %H"],
         cwd=cwd,
@@ -6884,7 +6884,7 @@ def _resolve_stash_selector(
 
 
 def _print_stash_cleanup_guidance(
-    stash_ref: str, stash_selector: Optional[str] = None
+    stash_ref: str, stash_selector: str | None = None
 ) -> None:
     print(
         "  Check `git status` first so you don't accidentally reapply the same change twice."
@@ -7020,7 +7020,7 @@ OFFICIAL_REPO_URL = "https://github.com/NousResearch/hermes-agent.git"
 SKIP_UPSTREAM_PROMPT_FILE = ".skip_upstream_prompt"
 
 
-def _get_origin_url(git_cmd: list[str], cwd: Path) -> Optional[str]:
+def _get_origin_url(git_cmd: list[str], cwd: Path) -> str | None:
     """Get the URL of the origin remote, or None if not set."""
     try:
         result = subprocess.run(
@@ -7036,7 +7036,7 @@ def _get_origin_url(git_cmd: list[str], cwd: Path) -> Optional[str]:
     return None
 
 
-def _is_fork(origin_url: Optional[str]) -> bool:
+def _is_fork(origin_url: str | None) -> bool:
     """Check if the origin remote points to a fork (not the official repo)."""
     if not origin_url:
         return False
@@ -9760,9 +9760,7 @@ def cmd_profile(args):
                     print(f"{copied} bundled skills synced.")
                 else:
                     print(
-                        "⚠ Skills could not be seeded. Run `{} update` to retry.".format(
-                            name
-                        )
+                        f"⚠ Skills could not be seeded. Run `{name} update` to retry."
                     )
 
             # Create wrapper alias

--- a/tests/website/test_xai_capability_matrix_docs.py
+++ b/tests/website/test_xai_capability_matrix_docs.py
@@ -1,0 +1,86 @@
+"""Regression tests for the xAI capability matrix docs page."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DOC_PATH = REPO_ROOT / "website" / "docs" / "guides" / "xai-capability-matrix.md"
+SIDEBAR_PATH = REPO_ROOT / "website" / "sidebars.ts"
+OAUTH_GUIDE_PATH = REPO_ROOT / "website" / "docs" / "guides" / "xai-grok-oauth.md"
+PROVIDERS_GUIDE_PATH = REPO_ROOT / "website" / "docs" / "integrations" / "providers.md"
+
+
+def _doc_text() -> str:
+    return DOC_PATH.read_text(encoding="utf-8")
+
+
+def test_xai_capability_matrix_is_in_guides_sidebar():
+    sidebar = SIDEBAR_PATH.read_text(encoding="utf-8")
+
+    assert "'guides/xai-grok-oauth'" in sidebar
+    assert "'guides/xai-capability-matrix'" in sidebar
+    assert sidebar.index("'guides/xai-grok-oauth'") < sidebar.index("'guides/xai-capability-matrix'")
+
+
+def test_xai_guides_link_to_capability_matrix():
+    oauth_guide = OAUTH_GUIDE_PATH.read_text(encoding="utf-8")
+    providers_guide = PROVIDERS_GUIDE_PATH.read_text(encoding="utf-8")
+
+    assert "./xai-capability-matrix.md" in oauth_guide
+    assert "../guides/xai-capability-matrix.md" in providers_guide
+
+
+def test_xai_capability_matrix_covers_supported_surfaces():
+    text = _doc_text()
+
+    for expected in (
+        "Chat / agent runtime",
+        "OAuth and shared credentials",
+        "General web search",
+        "X search",
+        "Image generation",
+        "Video generation",
+        "Text to speech",
+        "Speech to text",
+        "Model retirement guard",
+        "`XAI_API_KEY`",
+        "`xai-oauth`",
+    ):
+        assert expected in text
+
+
+def test_xai_capability_matrix_keeps_not_exposed_gap_list():
+    text = _doc_text()
+
+    for expected in (
+        "Not First-Class In Hermes Yet",
+        "Batch jobs",
+        "Deferred chat completions",
+        "Server-side code execution",
+        "Collections search / RAG",
+        "Image editing",
+        "Video editing",
+        "Video extension",
+    ):
+        assert expected in text
+
+
+def test_xai_capability_matrix_links_to_primary_xai_docs():
+    text = _doc_text()
+
+    for expected_link in (
+        "https://docs.x.ai/developers/models",
+        "https://docs.x.ai/developers/tools/web-search",
+        "https://docs.x.ai/developers/tools/x-search",
+        "https://docs.x.ai/developers/tools/code-execution",
+        "https://docs.x.ai/developers/tools/collections-search",
+        "https://docs.x.ai/developers/model-capabilities/images/generation",
+        "https://docs.x.ai/developers/model-capabilities/video/generation",
+        "https://docs.x.ai/developers/model-capabilities/audio/text-to-speech",
+        "https://docs.x.ai/developers/model-capabilities/audio/speech-to-text",
+        "https://docs.x.ai/developers/advanced-api-usage/batch-api",
+        "https://docs.x.ai/developers/advanced-api-usage/deferred-chat-completions",
+    ):
+        assert expected_link in text

--- a/website/docs/guides/xai-capability-matrix.md
+++ b/website/docs/guides/xai-capability-matrix.md
@@ -1,0 +1,60 @@
+---
+sidebar_position: 17
+title: "xAI Capability Matrix"
+description: "What xAI/Grok capabilities Hermes Agent supports today, what is partial, and which xAI API surfaces are not exposed yet."
+---
+
+# xAI Capability Matrix
+
+This matrix describes the current Hermes Agent surface for xAI/Grok. It is a support matrix, not a roadmap: "supported" means Hermes has a first-class provider, tool, plugin, command, or guide on `main`; "not exposed" means xAI documents the API surface, but Hermes does not yet provide a dedicated user-facing integration for it.
+
+Last reviewed against xAI docs on May 20, 2026.
+
+## Credential Paths
+
+Most direct xAI surfaces in Hermes share one credential resolver:
+
+| Credential | Hermes path | Notes |
+|------------|-------------|-------|
+| xAI API key | `XAI_API_KEY`, provider `xai` | Uses `https://api.x.ai/v1` by default. |
+| Grok OAuth | `hermes auth add xai-oauth`, provider `xai-oauth` | Browser OAuth for SuperGrok / X Premium+ users. Hermes prefers this bearer token when it is available. |
+
+See [xAI Grok OAuth](./xai-grok-oauth.md) for setup details.
+
+## Supported Or Partially Supported
+
+| Capability | xAI API surface | Hermes surface | Status | Notes |
+|------------|-----------------|----------------|--------|-------|
+| Chat / agent runtime | [Responses-compatible text generation](https://docs.x.ai/developers/models) | Providers `xai` and `xai-oauth` | Supported | Hermes routes xAI through the `codex_responses` transport. `grok-4.3` is pinned as the safe top model, and retired May 15, 2026 models are excluded from the curated fallback list. |
+| OAuth and shared credentials | xAI account OAuth plus API keys | `xai-oauth`, shared `tools.xai_http` resolver | Supported | The same xAI bearer can cover chat, web search, X search, image generation, video generation, TTS, and STT. |
+| General web search | [Responses `web_search`](https://docs.x.ai/developers/tools/web-search) | `web_search` with `web.search_backend: "xai"` or `web.backend: "xai"` | Supported, search-only | Hermes exposes xAI as an explicit web-search backend. It supports domain filters, respecting xAI's max-5 `allowed_domains` / `excluded_domains` limit, but does not expose `web_extract` or crawl through this backend. |
+| X search | [Responses `x_search`](https://docs.x.ai/developers/tools/x-search) | `x_search` toolset | Supported | Read-only discovery over public X content. It supports allowed/excluded handles, date filters, and optional image/video understanding flags. |
+| Image generation | [`/images/generations`](https://docs.x.ai/developers/model-capabilities/images/generation) | `image_gen.provider: xai`, `image_generate` | Supported for text-to-image | Hermes exposes `grok-imagine-image` and `grok-imagine-image-quality`, 1k / 2k output, and the common Hermes aspect-ratio set. xAI image editing and multi-image editing are not exposed by this provider. |
+| Video generation | [`/videos/generations`](https://docs.x.ai/developers/model-capabilities/video/generation) | `video_gen.provider: xai`, `video_generate` | Partially supported | Hermes supports text-to-video, image-to-video, and up to 7 reference images. xAI video edit and extend endpoints are not exposed in the unified Hermes video tool. |
+| Text to speech | [`/tts`](https://docs.x.ai/developers/model-capabilities/audio/text-to-speech) | `tts.provider: xai`, `text_to_speech` | Supported | Defaults to voice `eve`, language `en`, MP3 output, and the documented 15,000-character xAI text limit. Hermes can optionally insert conservative pause speech tags. |
+| Speech to text | [`/stt`](https://docs.x.ai/developers/model-capabilities/audio/speech-to-text) | `stt.provider: xai`, voice-message transcription | Supported | Uses the xAI STT endpoint with optional `language`, `format`, and `diarize` settings. Hermes resolves either Grok OAuth or `XAI_API_KEY`. |
+| Model retirement guard | [May 15, 2026 retirement guide](https://docs.x.ai/developers/migration/may-15-retirement) | `hermes doctor`, `hermes migrate xai` | Supported | Hermes detects retired xAI model IDs in config and can rewrite them with `hermes migrate xai --apply`. |
+
+:::note X Search vs xurl
+`x_search` is xAI's read-only server-side search tool for public X content. The `xurl` skill is separate: it wraps the official X developer-platform CLI for authenticated X API actions such as posting, replying, liking, DMs, timelines, and account-specific lookups.
+:::
+
+## Not First-Class In Hermes Yet
+
+These xAI surfaces are documented by xAI, but Hermes does not currently expose them as dedicated first-class xAI integrations:
+
+| xAI surface | xAI docs | Hermes status |
+|-------------|----------|---------------|
+| Batch jobs | [Batch API](https://docs.x.ai/developers/advanced-api-usage/batch-api) | Not exposed as an `xai_batch` tool or job manager. Hermes chat remains interactive/synchronous from the user's point of view. |
+| Deferred chat completions | [Deferred Chat Completions](https://docs.x.ai/developers/advanced-api-usage/deferred-chat-completions) | Not exposed as a submit-and-poll xAI tool. |
+| Server-side code execution | [Code Execution Tool](https://docs.x.ai/developers/tools/code-execution) | Hermes has its own `code_execution` tool, but it is not xAI's server-side Responses `code_execution` / `code_interpreter` surface. |
+| Collections search / RAG | [Collections Search](https://docs.x.ai/developers/tools/collections-search) | Not exposed as an xAI collections or `file_search` tool. |
+| Image editing | [Image Editing](https://docs.x.ai/developers/model-capabilities/images/editing) | Not exposed by the Hermes xAI image provider, which currently implements text-to-image generation. |
+| Video editing | [Video Editing](https://docs.x.ai/developers/model-capabilities/video/editing) | Not exposed by the Hermes xAI video provider. |
+| Video extension | [Video Extension](https://docs.x.ai/developers/model-capabilities/video/extension) | Not exposed by the Hermes xAI video provider. |
+
+## Maintenance Notes
+
+- When xAI adds, retires, or renames capabilities, update this page and the focused docs test together.
+- Prefer linking to this matrix when reviewing xAI PRs that add a new Hermes surface. It keeps the distinction between xAI API availability and Hermes user-facing availability explicit.
+- Keep provider-agnostic Hermes tools separate from xAI-specific surfaces. For example, `web_search` can use xAI as one backend, while `x_search` is a distinct xAI/X tool.

--- a/website/docs/guides/xai-grok-oauth.md
+++ b/website/docs/guides/xai-grok-oauth.md
@@ -12,7 +12,7 @@ When you sign in with an X account that has Premium+, xAI automatically links th
 
 The transport reuses the `codex_responses` adapter (xAI exposes a Responses-style endpoint), so reasoning, tool-calling, streaming, and prompt caching work without any adapter changes.
 
-The same OAuth bearer token is also reused by every direct-to-xAI surface in Hermes — TTS, image generation, video generation, and transcription — so a single login covers all four.
+The same OAuth bearer token is also reused by every direct-to-xAI surface in Hermes — TTS, image generation, video generation, transcription, web search, and X search — so a single login covers the supported xAI tool surface. See the [xAI capability matrix](./xai-capability-matrix.md) for the full support map.
 
 ## Overview
 
@@ -146,7 +146,7 @@ hermes --provider x-ai-oauth       # alias
 hermes --provider xai-grok-oauth   # alias
 ```
 
-## Direct-to-xAI Tools (TTS / Image / Video / Transcription / X Search)
+## Direct-to-xAI Tools (TTS / Image / Video / Transcription / Web Search / X Search)
 
 Once you're logged in via OAuth, every direct-to-xAI tool reuses the same bearer token automatically — there is **no separate setup** unless you'd rather use an API key.
 
@@ -157,6 +157,7 @@ hermes tools
 # → Text-to-Speech       → "xAI TTS"
 # → Image Generation     → "xAI Grok Imagine (image)"
 # → Video Generation     → "xAI Grok Imagine"
+# → Web Search           → "xAI Web Search (Grok)"
 # → X (Twitter) Search   → "xAI Grok OAuth (SuperGrok / X Premium+)"
 ```
 

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -30,7 +30,7 @@ You need at least one way to connect to an LLM. Use `hermes model` to switch pro
 | **MiniMax** | `MINIMAX_API_KEY` in `~/.hermes/.env` (provider: `minimax`) |
 | **MiniMax China** | `MINIMAX_CN_API_KEY` in `~/.hermes/.env` (provider: `minimax-cn`) |
 | **xAI (Grok) — Responses API** | `XAI_API_KEY` in `~/.hermes/.env` (provider: `xai`) |
-| **xAI Grok OAuth (SuperGrok)** | `hermes model` → "xAI Grok OAuth (SuperGrok Subscription)" — browser login, no API key. See [guide](../guides/xai-grok-oauth.md) |
+| **xAI Grok OAuth (SuperGrok)** | `hermes model` → "xAI Grok OAuth (SuperGrok Subscription)" — browser login, no API key. See [guide](../guides/xai-grok-oauth.md) and [capability matrix](../guides/xai-capability-matrix.md) |
 | **Qwen Cloud (Alibaba DashScope)** | `DASHSCOPE_API_KEY` in `~/.hermes/.env` (provider: `alibaba`) |
 | **Alibaba Cloud (Coding Plan)** | `DASHSCOPE_API_KEY` (provider: `alibaba-coding-plan`, alias: `alibaba_coding`) — separate billing SKU, different endpoint |
 | **Kilo Code** | `KILOCODE_API_KEY` in `~/.hermes/.env` (provider: `kilocode`) |

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -673,6 +673,7 @@ const sidebars: SidebarsConfig = {
         'guides/aws-bedrock',
         'guides/azure-foundry',
         'guides/xai-grok-oauth',
+        'guides/xai-capability-matrix',
         'guides/oauth-over-ssh',
         'guides/microsoft-graph-app-registration',
         'guides/operate-teams-meeting-pipeline',


### PR DESCRIPTION
## Summary

Adds a dedicated xAI capability matrix guide that separates:

- supported Hermes xAI surfaces (chat/runtime, OAuth credential reuse, web_search, x_search, image gen, video gen, TTS, STT, retirement guard)
- partially supported xAI surfaces (notably image/video generation where Hermes exposes generation but not edit/extend)
- xAI API surfaces that are documented upstream but not first-class in Hermes yet (Batch API, deferred completions, server-side code execution, Collections Search/RAG, image editing, video editing/extension)

Also links the matrix from the xAI OAuth guide, providers page, and guides sidebar.

## Sources checked

- xAI Models: https://docs.x.ai/developers/models
- xAI Web Search: https://docs.x.ai/developers/tools/web-search
- xAI X Search: https://docs.x.ai/developers/tools/x-search
- xAI Code Execution: https://docs.x.ai/developers/tools/code-execution
- xAI Collections Search: https://docs.x.ai/developers/tools/collections-search
- xAI Image Generation/Edit docs
- xAI Video Generation/Edit/Extension docs
- xAI TTS/STT docs
- xAI Batch API + Deferred Chat Completions docs
- current Hermes xAI provider/tool/plugin code on `main`

## Tests

- `uv run --extra dev pytest tests/website/test_xai_capability_matrix_docs.py -q`
- `uv run --extra dev ruff check tests/website/test_xai_capability_matrix_docs.py`
- `uv run --extra dev pytest tests/hermes_cli/test_xai_retirement.py tests/hermes_cli/test_migrate_xai.py tests/plugins/image_gen/test_xai_provider.py tests/plugins/video_gen/test_xai_plugin.py tests/plugins/video_gen/test_xai_plugin_integration.py tests/tools/test_tts_xai_speech_tags.py tests/tools/test_web_providers_xai.py tests/website/test_xai_capability_matrix_docs.py -q`
- `PATH="../.venv/bin:$PATH" npm run lint:diagrams` from `website/`
- `PATH="../.venv/bin:$PATH" npm run build` from `website/` (passes; existing unrelated broken-link warnings remain)
