### PR TITLE
fix(redact): return empty string for None input and fix ENV regex for quoted secrets

### DIFF
--- a/agent/redact.py
+++ b/agent/redact.py
@@ -109,7 +109,7 @@ _PREFIX_PATTERNS = [
 # ENV assignment patterns: KEY=value where KEY contains a secret-like name
 _SECRET_ENV_NAMES = r"(?:API_?KEY|TOKEN|SECRET|PASSWORD|PASSWD|CREDENTIAL|AUTH)"
 _ENV_ASSIGN_RE = re.compile(
-    rf"([A-Z0-9_]{{0,50}}{_SECRET_ENV_NAMES}[A-Z0-9_]{{0,50}})\s*=\s*(['\"]?)(\S+)\2",
+    rf"([A-Z0-9_]{{0,50}}{_SECRET_ENV_NAMES}[A-Z0-9_]{{0,50}})\s*=\s*(['\"]?)([^\r\n]+?)\2",
 )
 
 # JSON field patterns: "apiKey": "value", "token": "value", etc.
@@ -350,7 +350,7 @@ def redact_sensitive_text(text: str, *, force: bool = False, code_file: bool = F
     match.
     """
     if text is None:
-        return None
+        return ""
     if not isinstance(text, str):
         text = str(text)
     if not text:


### PR DESCRIPTION
## What does this PR do?

Fixes two bugs in `agent/redact.py`:

1. **`redact_sensitive_text` returns `None` for `None` input** — the function is typed `str -> str` but returned `None` when input was `None`. Any caller invoking string methods on the result (e.g. `.lower()`, `.strip()`) would get an `AttributeError`. Fixed to return `""` instead.

2. **ENV assignment regex fails on quoted secrets with spaces** — `_ENV_ASSIGN_RE` used `\S+` to capture the value, which stops at the first whitespace. Secrets like `API_KEY="my secret password"` were not redacted because the regex failed to match past the first space. Fixed by replacing `\S+` with `[^\r\n]+?"` (non-greedy, matches any non-newline character including spaces).

## Type of Change
- [x] Bug fix

## Changes Made
- `agent/redact.py` line 325: `return None` → `return ""`
- `agent/redact.py` line 112: `(\S+)` → `([^\r\n]+?)` in `_ENV_ASSIGN_RE`

## How to Test
```python
from agent.redact import redact_sensitive_text

# Fix 1: None input should return empty string, not None
assert redact_sensitive_text(None) == ""

# Fix 2: quoted secret with spaces should be redacted
result = redact_sensitive_text('API_KEY="my secret password"')
assert 'my secret password' not in result
```

## Checklist
- [x] Single commit
- [x] No hardcoded secrets
- [x] No Co-Authored-By lines