### PR TITLE
fix(skills-hub): stream ZIP extraction to prevent zip bomb via manipulated metadata

### DIFF
--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -2134,8 +2134,22 @@ class ClawHubSource(SkillSource):
                             logger.debug("Skipping large file in ZIP: %s (%d bytes)", name, info.file_size)
                             continue
                         try:
-                            raw = zf.read(info.filename)
-                            files[name] = raw.decode("utf-8")
+                            chunks: list[bytes] = []
+                            total = 0
+                            with zf.open(info.filename) as fh:
+                                while True:
+                                    chunk = fh.read(65536)
+                                    if not chunk:
+                                        break
+                                    total += len(chunk)
+                                    if total > 500_000:
+                                        logger.debug("Skipping ZIP member exceeding size limit: %s", name)
+                                        chunks = []
+                                        break
+                                    chunks.append(chunk)
+                            if not chunks:
+                                continue
+                            files[name] = b"".join(chunks).decode("utf-8")
                         except (UnicodeDecodeError, KeyError):
                             logger.debug("Skipping non-text file in ZIP: %s", name)
                             continue


### PR DESCRIPTION
## What does this PR do?

Fixes a zip bomb vulnerability in `ClawHubSource._download_zip` in `tools/skills_hub.py`.

**Root cause:** The existing guard checks `info.file_size > 500_000` against the ZIP central directory metadata. This metadata is attacker-controlled — a malicious ZIP can declare `file_size=1000` in the central directory while the actual decompressed content is hundreds of MB. `zf.read(info.filename)` then loads the full decompressed content into memory, causing OOM.

**Fix:** Replace `zf.read()` with a streaming loop using `zf.open()`. Reads in 64 KB chunks, tracks actual decompressed bytes, and aborts if real size exceeds 500,000 bytes — regardless of what the central directory metadata claims.

## Type of Change
- [x] Bug fix (security)

## Changes Made
- `tools/skills_hub.py`: replaced `zf.read(info.filename)` with `zf.open()` streaming loop with hard byte counter

## How to Test
```python
import io, zipfile

# Create a malicious ZIP: metadata says 100 bytes, actual content is 1MB
buf = io.BytesIO()
with zipfile.ZipFile(buf, 'w', zipfile.ZIP_DEFLATED) as zf:
    zf.writestr('SKILL.md', 'A' * 1_000_000)

# Manually corrupt central directory file_size to 100
# With the fix, streaming read stops at 500_000 bytes and skips the file
```

## Checklist
- [x] Single commit
- [x] No hardcoded secrets
- [x] No Co-Authored-By lines