### PR TITLE
fix(sessions): guard _save_session_log against list-type assistant content

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -1548,7 +1548,7 @@ class AIAgent:
         try:
             cleaned = []
             for msg in messages:
-                if msg.get("role") == "assistant" and msg.get("content"):
+                if msg.get("role") == "assistant" and isinstance(msg.get("content"), str) and msg.get("content"):
                     msg = dict(msg)
                     msg["content"] = self._clean_session_content(msg["content"])
                 cleaned.append(msg)

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -592,6 +592,32 @@ class TestSessionJsonSnapshotOptIn:
             "Opt-in writer must produce session_{sid}.json under logs_dir"
         )
 
+    def test_save_session_log_writes_with_list_content(self, agent, tmp_path):
+        # Regression: assistant messages whose content is a list of OpenAI-style
+        # content parts (e.g. multimodal or tool-use turns) must not cause
+        # _clean_session_content to raise TypeError and silently abort the write.
+        agent._session_json_enabled = True
+        agent.logs_dir = tmp_path
+        messages = [
+            {"role": "user", "content": "find something"},
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "text", "text": "I will search for that."},
+                    {"type": "tool_use", "id": "call_1", "name": "web_search", "input": {}},
+                ],
+            },
+        ]
+        agent._save_session_log(messages)
+        expected = tmp_path / f"session_{agent.session_id}.json"
+        assert expected.exists(), (
+            "Writer must succeed even when assistant content is a list of content parts"
+        )
+        data = json.loads(expected.read_text())
+        assert data["messages"][1]["content"] == messages[1]["content"], (
+            "List-type content must be preserved unchanged in the snapshot"
+        )
+
     def test_logs_dir_retained_for_request_dumps(self, agent):
         # logs_dir is kept unconditionally because
         # agent_runtime_helpers.dump_api_request_debug still writes


### PR DESCRIPTION
## Problem

`_save_session_log` (introduced in #29490) silently writes no file when any assistant message in the session has list-type content — the kind produced by multimodal turns or tool-use responses where the API returns content as a list of parts rather than a bare string.

The loop unconditionally calls `_clean_session_content(msg["content"])`, which is typed and implemented for `str`. When `content` is a list, `re.sub` raises `TypeError`. The outer `try/except Exception` swallows it silently (only logged under `verbose_logging`), so users who set `sessions.write_json_snapshots = true` see no JSON files and no error message.

`_flush_messages_to_session_db`, which handles the same `messages` list, already has an explicit `isinstance(content, list)` branch — confirming this format occurs in real sessions.

## Fix

Add an `isinstance(content, str)` guard before the `_clean_session_content` call. List-type content passes through unchanged; `REASONING_SCRATCHPAD` tags cannot appear in structured content blocks, so skipping normalisation for them is correct.

```python
# before
if msg.get("role") == "assistant" and msg.get("content"):

# after
if msg.get("role") == "assistant" and isinstance(msg.get("content"), str) and msg.get("content"):
```

## Tests

Added `test_save_session_log_writes_with_list_content` to `TestSessionJsonSnapshotOptIn`. It passes an assistant message whose content is `[{"type": "text", …}, {"type": "tool_use", …}]`, asserts the snapshot file is written, and asserts the list is preserved unchanged.

All 5 tests in `TestSessionJsonSnapshotOptIn` pass; 338/339 in `test_run_agent.py` pass (the 1 pre-existing failure is an unrelated missing `openai` module in the local env).

## Checklist

- [x] Reproduces with `write_json_snapshots = true` and a session containing tool calls before the fix
- [x] Regression test added
- [x] No behavior change when content is a string
- [x] No behavior change when `write_json_snapshots` is false (fast no-op path is unchanged)