### PR TITLE
fix(dashboard): use {name:path} for plugin enable/disable routes

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -4316,13 +4316,19 @@ async def post_agent_plugin_install(request: Request, body: _AgentPluginInstallB
 
 
 def _validate_plugin_name(name: str) -> str:
-    """Reject path-traversal attempts in plugin name URL parameters."""
-    if not name or "/" in name or "\\" in name or ".." in name:
+    """Reject path-traversal attempts in plugin name URL parameters.
+
+    Plugin names from discovery contain ``/`` (e.g. ``model-providers/alibaba``,
+    ``browser/browser_use``).  We allow ``/`` here because the route captures
+    the full path segment via ``{name:path}``.  Only reject ``..`` and empty
+    names.
+    """
+    if not name or ".." in name:
         raise HTTPException(status_code=400, detail="Invalid plugin name.")
     return name
 
 
-@app.post("/api/dashboard/agent-plugins/{name}/enable")
+@app.post("/api/dashboard/agent-plugins/{name:path}/enable")
 async def post_agent_plugin_enable(request: Request, name: str):
     _require_token(request)
     name = _validate_plugin_name(name)
@@ -4334,7 +4340,7 @@ async def post_agent_plugin_enable(request: Request, name: str):
     return result
 
 
-@app.post("/api/dashboard/agent-plugins/{name}/disable")
+@app.post("/api/dashboard/agent-plugins/{name:path}/disable")
 async def post_agent_plugin_disable(request: Request, name: str):
     _require_token(request)
     name = _validate_plugin_name(name)
@@ -4346,7 +4352,7 @@ async def post_agent_plugin_disable(request: Request, name: str):
     return result
 
 
-@app.post("/api/dashboard/agent-plugins/{name}/update")
+@app.post("/api/dashboard/agent-plugins/{name:path}/update")
 async def post_agent_plugin_update(request: Request, name: str):
     _require_token(request)
     name = _validate_plugin_name(name)
@@ -4359,7 +4365,7 @@ async def post_agent_plugin_update(request: Request, name: str):
     return result
 
 
-@app.delete("/api/dashboard/agent-plugins/{name}")
+@app.delete("/api/dashboard/agent-plugins/{name:path}")
 async def delete_agent_plugin(request: Request, name: str):
     _require_token(request)
     name = _validate_plugin_name(name)


### PR DESCRIPTION
## What does this PR do?

Fixes **405 Method Not Allowed** errors when enabling/disabling any plugin with a `/` in its discovery name (e.g. `model-providers/alibaba`, `browser/browser_use`, `image_gen/openai`).

The original FastAPI routes used `{name}` which only matches single path segments. Starlette does not decode `%2F` during route matching, so `model-providers%2Falibaba` counts as multiple segments and the route never fires. The SPA catch-all `GET /{full_path:path}` intercepts instead → 405.

## Related Issue

Fixes #29452

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/web_server.py` — changed `{name}` to `{name:path}` on 4 routes:
  - `POST /api/dashboard/agent-plugins/{name:path}/enable`
  - `POST /api/dashboard/agent-plugins/{name:path}/disable`
  - `POST /api/dashboard/agent-plugins/{name:path}/update`
  - `DELETE /api/dashboard/agent-plugins/{name:path}`
- Updated `_validate_plugin_name()` to allow `/` (valid plugin identifiers) while still rejecting `..` (path traversal)

## How to Test

```bash
TOKEN=$(curl -s http://127.0.0.1:9119/ | grep -o __HERMES_SESSION_TOKEN__:[^]*' | cut -d' -f4)

curl -X POST http://127.0.0.1:9119/api/dashboard/agent-plugins/model-providers/alibaba/enable -H "Authorization: Bearer \$TOKEN"
# → {"ok": true}
```

## Checklist

- [x] Conventional Commits
- [x] No unrelated changes
- [x] Tested on Ubuntu 24.04
- [N/A] No config/architecture changes
