### PR TITLE
feat(tool-result-compaction): add opt-in large tool result compaction

### DIFF
--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -48,6 +48,7 @@ from tools.tool_result_storage import (
     maybe_persist_tool_result,
     enforce_turn_budget,
 )
+from agent.tool_result_compaction import compact_tool_content_if_needed
 
 logger = logging.getLogger(__name__)
 
@@ -443,6 +444,11 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
         # image tool result never poisons canonical session history.
         # String results pass through unchanged.
         _tool_content = agent._tool_result_content_for_active_model(name, function_result)
+        # Only applies to string content (skips multimodal list/dict).
+        if isinstance(_tool_content, str):
+            _tool_content, _ = compact_tool_content_if_needed(
+                name, tc.id, _tool_content, agent,
+            )
         messages.append(make_tool_result_message(name, _tool_content, tc.id))
 
         # ── Per-tool /steer drain ───────────────────────────────────
@@ -858,6 +864,11 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
         # Unwrap _multimodal dicts to an OpenAI-style content list
         # (see parallel path for rationale). String results pass through.
         _tool_content = agent._tool_result_content_for_active_model(function_name, function_result)
+        # Only compact string content; multimodal content has already been converted/skipped.
+        if isinstance(_tool_content, str):
+            _tool_content, _ = compact_tool_content_if_needed(
+                function_name, tool_call.id, _tool_content, agent,
+            )
         messages.append(make_tool_result_message(function_name, _tool_content, tool_call.id))
 
         # ── Per-tool /steer drain ───────────────────────────────────

--- a/agent/tool_result_compaction.py
+++ b/agent/tool_result_compaction.py
@@ -1,0 +1,308 @@
+"""Tool result compaction — LLM-free truncation + local storage for cost reduction.
+
+This module keeps large text tool results out of the conversation history by
+saving the full result to local disk and returning a compact JSON reference.
+The feature is disabled by default and fails open on any error.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import time
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# Config defaults (overridable via config.yaml -> tool_result_compaction.*)
+DEFAULT_ENABLED = False
+DEFAULT_THRESHOLD_TOKENS = 5000
+DEFAULT_RAW_RESULT_DIR = ""  # empty = ~/.hermes/raw_results/
+DEFAULT_MAX_DISK_MB = 500
+DEFAULT_PREVIEW_CHARS = 1000
+
+_TOKEN_CHARS = 4
+_SAFE_COMPONENT_RE = re.compile(r"[^a-zA-Z0-9_.-]+")
+_BYTES_PER_MB = 1024 * 1024
+
+
+def get_config() -> dict:
+    """Read tool_result_compaction config section, with safe defaults.
+
+    Tests MUST monkeypatch this function rather than relying on the
+    real ~/.hermes/config.yaml.
+    """
+    try:
+        from hermes_cli.config import read_raw_config
+
+        cfg = read_raw_config().get("tool_result_compaction", {})
+        return cfg if isinstance(cfg, dict) else {}
+    except Exception:
+        logger.debug("Could not read tool_result_compaction config", exc_info=True)
+        return {}
+
+
+def _config_bool(cfg: dict, key: str, default: bool) -> bool:
+    value = cfg.get(key, default)
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "on"}
+    return bool(value)
+
+
+def _config_int(cfg: dict, key: str, default: int, *, minimum: int = 0) -> int:
+    value = cfg.get(key, default)
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return default
+    return max(minimum, parsed)
+
+
+def is_enabled() -> bool:
+    """Return True if compaction is enabled in config."""
+    return _config_bool(get_config(), "enabled", DEFAULT_ENABLED)
+
+
+def token_estimate(content: str) -> int:
+    """Estimate token count with a dependency-free chars/4 heuristic."""
+    return max(1, len(content) // _TOKEN_CHARS) if content else 0
+
+
+def sanitize_path_component(value: str, *, fallback: str = "unknown") -> str:
+    """Return a filesystem-safe path component."""
+    cleaned = _SAFE_COMPONENT_RE.sub("_", value).strip("._-")
+    return cleaned or fallback
+
+
+def default_raw_result_dir() -> Path:
+    """Return the default raw result storage directory."""
+    return Path.home() / ".hermes" / "raw_results"
+
+
+def resolve_raw_result_dir(cfg: dict) -> Path:
+    """Return configured raw result dir, expanding user/env vars."""
+    raw_dir = cfg.get("raw_result_dir", DEFAULT_RAW_RESULT_DIR)
+    if not isinstance(raw_dir, str) or not raw_dir.strip():
+        return default_raw_result_dir()
+    return Path(os.path.expandvars(os.path.expanduser(raw_dir)))
+
+
+def _first_last_preview(content: str, preview_chars: int) -> str:
+    """Return a compact first+last preview of content."""
+    if preview_chars <= 0:
+        return ""
+    if len(content) <= preview_chars * 2:
+        return content
+    omitted = len(content) - (preview_chars * 2)
+    return (
+        content[:preview_chars]
+        + f"\n\n... [omitted {omitted} chars] ...\n\n"
+        + content[-preview_chars:]
+    )
+
+
+def _raw_result_path(
+    base_dir: Path,
+    session_id: str,
+    tool_call_id: str,
+    tool_name: str,
+) -> Path:
+    session_component = sanitize_path_component(session_id, fallback="session")
+    call_component = sanitize_path_component(tool_call_id, fallback="call")
+    tool_component = sanitize_path_component(tool_name, fallback="tool")
+    timestamp_ns = time.time_ns()
+    filename = f"{call_component}_{tool_component}_{timestamp_ns}.json"
+    return base_dir / session_component / filename
+
+
+def _write_raw_result(path: Path, payload: dict[str, Any]) -> None:
+    """Write raw result payload with private filesystem permissions."""
+    path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+    try:
+        os.chmod(path.parent, 0o700)
+    except OSError:
+        logger.debug("Could not chmod raw result directory", exc_info=True)
+
+    encoded = json.dumps(payload, ensure_ascii=True, indent=2)
+    with path.open("w", encoding="utf-8") as fh:
+        fh.write(encoded)
+    try:
+        os.chmod(path, 0o600)
+    except OSError:
+        logger.debug("Could not chmod raw result file", exc_info=True)
+
+
+def _iter_raw_result_files(base_dir: Path) -> list[Path]:
+    if not base_dir.exists():
+        return []
+    return [path for path in base_dir.rglob("*.json") if path.is_file() and not path.is_symlink()]
+
+
+def _directory_size_bytes(base_dir: Path) -> int:
+    total = 0
+    for path in _iter_raw_result_files(base_dir):
+        try:
+            total += path.stat().st_size
+        except OSError:
+            logger.debug("Could not stat raw result file", exc_info=True)
+    return total
+
+
+def _cleanup_empty_dirs(base_dir: Path) -> None:
+    if not base_dir.exists():
+        return
+    for path in sorted(base_dir.rglob("*"), key=lambda p: len(p.parts), reverse=True):
+        if path.is_dir():
+            try:
+                path.rmdir()
+            except OSError:
+                pass
+
+
+def _safe_mtime(path: Path) -> float:
+    """Return st_mtime or 0.0 if stat fails (e.g. race with deletion)."""
+    try:
+        return path.stat().st_mtime
+    except OSError:
+        return 0.0
+
+
+def _enforce_disk_quota(
+    base_dir: Path,
+    max_disk_mb: int,
+    *,
+    protected_path: Path | None = None,
+) -> None:
+    """Delete oldest raw result files until usage is under 80% of quota.
+
+    A non-positive max_disk_mb disables quota cleanup. protected_path is never
+    deleted, so the compacted message for the current tool result cannot point
+    at a file that was immediately removed by cleanup.
+    """
+    if max_disk_mb <= 0 or not base_dir.exists():
+        return
+
+    max_bytes = max_disk_mb * _BYTES_PER_MB
+    target_bytes = int(max_bytes * 0.8)
+    current_bytes = _directory_size_bytes(base_dir)
+    if current_bytes <= max_bytes:
+        return
+
+    protected_resolved = None
+    if protected_path is not None:
+        try:
+            protected_resolved = protected_path.resolve()
+        except OSError:
+            protected_resolved = protected_path
+
+    files = sorted(
+        _iter_raw_result_files(base_dir),
+        key=lambda path: _safe_mtime(path),
+    )
+    for path in files:
+        if current_bytes <= target_bytes:
+            break
+        try:
+            candidate = path.resolve()
+        except OSError:
+            candidate = path
+        if protected_resolved is not None and candidate == protected_resolved:
+            continue
+        try:
+            size = path.stat().st_size
+            path.unlink()
+            current_bytes -= size
+        except OSError:
+            logger.debug("Could not remove old raw result file", exc_info=True)
+
+    _cleanup_empty_dirs(base_dir)
+
+
+def compact_tool_content_if_needed(
+    tool_name: str,
+    tool_call_id: str,
+    content: str,
+    agent: Any,
+) -> tuple[str, dict[str, Any] | None]:
+    """Compact large tool result content when enabled.
+
+    If enabled and the text content exceeds threshold_tokens, the full result is
+    saved to disk and the returned content becomes a compact JSON reference.
+
+    FAIL-OPEN: Any exception returns the original content unchanged.
+    """
+    try:
+        cfg = get_config()
+        if not _config_bool(cfg, "enabled", DEFAULT_ENABLED):
+            return content, None
+
+        threshold_tokens = _config_int(
+            cfg,
+            "threshold_tokens",
+            DEFAULT_THRESHOLD_TOKENS,
+            minimum=1,
+        )
+        original_token_estimate = token_estimate(content)
+        if original_token_estimate < threshold_tokens:
+            return content, None
+
+        preview_chars = _config_int(
+            cfg,
+            "preview_chars",
+            DEFAULT_PREVIEW_CHARS,
+            minimum=0,
+        )
+        max_disk_mb = _config_int(
+            cfg,
+            "max_disk_mb",
+            DEFAULT_MAX_DISK_MB,
+            minimum=0,
+        )
+        session_id = str(getattr(agent, "session_id", "session"))
+        base_dir = resolve_raw_result_dir(cfg)
+        raw_path = _raw_result_path(base_dir, session_id, tool_call_id, tool_name)
+
+        raw_payload: dict[str, Any] = {
+            "tool_name": tool_name,
+            "tool_call_id": tool_call_id,
+            "session_id": session_id,
+            "created_at_unix_ns": time.time_ns(),
+            "original_char_count": len(content),
+            "original_token_estimate": original_token_estimate,
+            "content": content,
+        }
+        _write_raw_result(raw_path, raw_payload)
+        _enforce_disk_quota(base_dir, max_disk_mb, protected_path=raw_path)
+
+        compacted_preview = _first_last_preview(content, preview_chars)
+        compacted_payload: dict[str, Any] = {
+            "type": "compacted_tool_result",
+            "tool_name": tool_name,
+            "tool_call_id": tool_call_id,
+            "original_char_count": len(content),
+            "original_token_estimate": original_token_estimate,
+            "compacted_preview": compacted_preview,
+            "raw_result_path": str(raw_path),
+            "note": (
+                "Full tool result saved locally as JSON. "
+                "Use read_file on raw_result_path and inspect the content field "
+                "if exact output is needed."
+            ),
+        }
+        compacted_content = json.dumps(compacted_payload, ensure_ascii=True, indent=2)
+        info = {
+            "raw_result_path": str(raw_path),
+            "original_chars": len(content),
+            "original_token_estimate": original_token_estimate,
+            "compacted_chars": len(compacted_content),
+            "compacted_token_estimate": token_estimate(compacted_content),
+        }
+        return compacted_content, info
+    except Exception:
+        logger.debug("Tool result compaction failed; returning original content", exc_info=True)
+        return content, None

--- a/docs/tool-result-compaction-review-checklist.md
+++ b/docs/tool-result-compaction-review-checklist.md
@@ -1,0 +1,43 @@
+# Tool Result Compaction Review Checklist
+
+Use this checklist before marking the draft PR ready for upstream review.
+
+## Behavior
+
+- Default behavior is unchanged when the feature is disabled.
+- Only string tool-result content is compacted.
+- Non-string tool results are skipped by the existing guard in `tool_executor.py`.
+- Tool messages keep `role`, `name`, `tool_name`, `content`, and `tool_call_id`.
+- Compacted content remains a string containing JSON metadata.
+- The compacted JSON includes enough information to recover the original output.
+
+## Failure handling
+
+- Config read errors keep the original tool output.
+- File write errors keep the original tool output.
+- Cleanup errors keep the original tool output.
+- Permission-setting failures do not stop tool execution.
+- The current raw result file is not removed by immediate cleanup.
+
+## Storage
+
+- Default storage path is `~/.hermes/raw_results`.
+- Empty `raw_result_dir` uses the default path.
+- Custom `raw_result_dir` expands `~` and environment variables.
+- Session ID, tool call ID, and tool name are sanitized before becoming path components.
+- `max_disk_mb <= 0` disables cleanup.
+
+## Benchmarks
+
+- `scripts/benchmark_tool_result_compaction.py` does not call an LLM.
+- `scripts/replay_tool_result_compaction.py` does not call an LLM.
+- Synthetic benchmark reports before/after token estimates and raw file counts.
+- Replay benchmark skips non-string content and supports `--content-field`.
+
+## Questions for review
+
+1. Is the insertion point correct: after existing tool-result persistence and active-model conversion, before `messages.append()`?
+2. Is default-off acceptable for first landing?
+3. Should exact-output recovery use local file paths or a session-scoped reference ID?
+4. Should benchmark scripts live in `scripts/`, docs, or tests only?
+5. Should this remain one draft PR or be split into smaller stacked PRs?

--- a/docs/tool-result-compaction.md
+++ b/docs/tool-result-compaction.md
@@ -1,0 +1,90 @@
+# Tool Result Compaction
+
+Tool result compaction is an opt-in feature for long, tool-heavy Hermes sessions. It reduces repeated message-history growth by saving large string tool results to local disk and replacing the message-history copy with a compact JSON reference.
+
+The feature is disabled by default and is designed to fail open: if anything goes wrong while reading config, writing raw output, or enforcing storage limits, Hermes keeps the original tool result unchanged.
+
+## Configuration
+
+Add this section to `~/.hermes/config.yaml`:
+
+```yaml
+tool_result_compaction:
+  enabled: false
+  threshold_tokens: 5000
+  raw_result_dir: ""      # empty => ~/.hermes/raw_results
+  max_disk_mb: 500
+  preview_chars: 1000    # first 1000 + last 1000 chars
+```
+
+A copyable example is also available at `examples/tool-result-compaction.config.yaml`.
+
+### Fields
+
+| Field | Default | Meaning |
+|---|---:|---|
+| `enabled` | `false` | Enables compaction when true. |
+| `threshold_tokens` | `5000` | Minimum estimated token count before a string tool result is compacted. Hermes uses a dependency-free `chars / 4` estimate. |
+| `raw_result_dir` | `""` | Directory for raw result JSON files. Empty means `~/.hermes/raw_results`. `~` and environment variables are expanded. |
+| `max_disk_mb` | `500` | Disk quota for raw result files. Set `0` or a negative value to disable quota cleanup. |
+| `preview_chars` | `1000` | Number of chars to keep from the start and end of the tool result in the compacted preview. |
+
+## Behavior
+
+When enabled and a string tool result is at or above the threshold:
+
+1. Hermes writes the full result to a JSON file under `raw_result_dir`.
+2. Hermes replaces the message-history content with a compact JSON object containing:
+   - `type: "compacted_tool_result"`
+   - tool name
+   - tool call id
+   - original char count
+   - estimated original token count
+   - first+last preview
+   - `raw_result_path`
+   - a note explaining how to recover exact output
+3. Hermes enforces the disk quota by deleting the oldest raw result files until usage drops below 80% of the quota.
+
+The current raw result file is protected from immediate quota cleanup so the compacted message never points to a file that was just deleted.
+
+## Storage and permissions
+
+Raw results are written as JSON files. Directories are created with private permissions (`0o700`) and raw result files are written with private permissions (`0o600`) where the operating system supports `chmod`.
+
+Example default path:
+
+```text
+~/.hermes/raw_results/<session_id>/<tool_call_id>_<tool_name>_<timestamp>.json
+```
+
+## Recovery
+
+If the model needs exact output later, it can read the file at `raw_result_path` and inspect the `content` field in the JSON payload.
+
+This path-based recovery is intentionally simple for the first draft. It makes exact-output recovery possible without introducing a new lookup service or identifier resolver. A future version could replace `raw_result_path` with a session-scoped reference ID if reviewers prefer not to expose local paths in model-visible messages.
+
+## Benchmarks
+
+Two local, LLM-free benchmark helpers are included:
+
+```bash
+python3 scripts/benchmark_tool_result_compaction.py --tool-results 10 --result-chars 50000
+```
+
+This generates synthetic tool outputs, runs them through the real compaction path, and prints estimated before/after token pressure.
+
+```bash
+python3 scripts/replay_tool_result_compaction.py path/to/tool_results.jsonl --content-field content
+```
+
+This replays recorded JSONL tool results. Each JSONL object should contain a string field with the tool output; non-string values are skipped. Use `--content-field` if the recorded output is stored under a different key.
+
+Both scripts use the same dependency-free `chars / 4` token estimate as the compaction module. They do not call an LLM.
+
+## Limitations
+
+- Only string tool-result content is compacted.
+- Multimodal/list/dict tool results are skipped.
+- This is not LLM summarization; it is deterministic preview + local raw storage.
+- Recovery currently uses a local `raw_result_path`; remote execution modes may need a reference-ID resolver in a future iteration.
+- Compaction happens after existing tool result persistence and active-model content conversion, before the tool result is appended to conversation history.

--- a/examples/tool-result-compaction.config.yaml
+++ b/examples/tool-result-compaction.config.yaml
@@ -1,0 +1,21 @@
+# Example Hermes config section for opt-in tool result compaction.
+# Copy this into ~/.hermes/config.yaml and change enabled to true to activate.
+
+tool_result_compaction:
+  # Disabled by default. Set true only after reviewing the storage path and quota.
+  enabled: false
+
+  # Compact string tool results at or above this estimated token count.
+  # Estimate is dependency-free and intentionally approximate: len(content) / 4.
+  threshold_tokens: 5000
+
+  # Empty means ~/.hermes/raw_results. Supports ~ and environment variables.
+  raw_result_dir: ""
+
+  # Raw result storage quota. Oldest JSON files are deleted when the quota is exceeded.
+  # Set 0 to disable quota cleanup.
+  max_disk_mb: 500
+
+  # Keep this many characters from both the start and end of the tool result.
+  # Effective preview can be up to preview_chars * 2 plus an omitted marker.
+  preview_chars: 1000

--- a/scripts/benchmark_tool_result_compaction.py
+++ b/scripts/benchmark_tool_result_compaction.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""Synthetic benchmark for tool result compaction.
+
+This script does not call an LLM. It estimates before/after token pressure for
+large text tool results using the same chars/4 heuristic as the compaction
+module, and it exercises the real compaction path against a temporary raw result
+directory.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+from agent.tool_result_compaction import compact_tool_content_if_needed, token_estimate
+
+
+@dataclass
+class DummyAgent:
+    session_id: str = "benchmark-session"
+
+
+def _build_payload(size_chars: int, index: int) -> str:
+    header = f"tool_result[{index}]\n"
+    footer = f"\nend_tool_result[{index}]"
+    body_size = max(0, size_chars - len(header) - len(footer))
+    line = f"line {index}: synthetic terminal/read_file output for compaction benchmark\n"
+    repeats = (body_size // len(line)) + 1
+    body = (line * repeats)[:body_size]
+    return header + body + footer
+
+
+def run_benchmark(
+    *,
+    tool_results: int,
+    result_chars: int,
+    threshold_tokens: int,
+    preview_chars: int,
+    max_disk_mb: int,
+    keep_dir: bool,
+) -> dict[str, Any]:
+    temp_dir = Path(tempfile.mkdtemp(prefix="hermes-tool-result-compaction-"))
+    cfg = {
+        "enabled": True,
+        "threshold_tokens": threshold_tokens,
+        "preview_chars": preview_chars,
+        "raw_result_dir": str(temp_dir),
+        "max_disk_mb": max_disk_mb,
+    }
+
+    before_tokens = 0
+    after_tokens = 0
+    compacted_count = 0
+    raw_paths: list[str] = []
+
+    try:
+        with patch("agent.tool_result_compaction.get_config", return_value=cfg):
+            for index in range(tool_results):
+                content = _build_payload(result_chars, index)
+                before_tokens += token_estimate(content)
+                compacted_content, info = compact_tool_content_if_needed(
+                    "benchmark_tool",
+                    f"call_{index}",
+                    content,
+                    DummyAgent(),
+                )
+                after_tokens += token_estimate(compacted_content)
+                if info is not None:
+                    compacted_count += 1
+                    raw_paths.append(info["raw_result_path"])
+
+        raw_files = list(temp_dir.rglob("*.json"))
+        raw_bytes = sum(path.stat().st_size for path in raw_files)
+        saved_tokens = before_tokens - after_tokens
+        saved_pct = (saved_tokens / before_tokens * 100.0) if before_tokens else 0.0
+        return {
+            "tool_results": tool_results,
+            "result_chars_each": result_chars,
+            "threshold_tokens": threshold_tokens,
+            "preview_chars": preview_chars,
+            "before_tokens_estimate": before_tokens,
+            "after_tokens_estimate": after_tokens,
+            "saved_tokens_estimate": saved_tokens,
+            "saved_percent_estimate": round(saved_pct, 2),
+            "compacted_count": compacted_count,
+            "raw_file_count": len(raw_files),
+            "raw_bytes": raw_bytes,
+            "raw_result_dir": str(temp_dir),
+            "sample_raw_path": raw_paths[0] if raw_paths else None,
+        }
+    finally:
+        if not keep_dir:
+            shutil.rmtree(temp_dir, ignore_errors=True)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--tool-results", type=int, default=10)
+    parser.add_argument("--result-chars", type=int, default=50_000)
+    parser.add_argument("--threshold-tokens", type=int, default=5_000)
+    parser.add_argument("--preview-chars", type=int, default=1_000)
+    parser.add_argument("--max-disk-mb", type=int, default=500)
+    parser.add_argument("--keep-dir", action="store_true")
+    args = parser.parse_args()
+
+    result = run_benchmark(
+        tool_results=args.tool_results,
+        result_chars=args.result_chars,
+        threshold_tokens=args.threshold_tokens,
+        preview_chars=args.preview_chars,
+        max_disk_mb=args.max_disk_mb,
+        keep_dir=args.keep_dir,
+    )
+    print(json.dumps(result, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/replay_tool_result_compaction.py
+++ b/scripts/replay_tool_result_compaction.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""Replay a JSONL file through tool result compaction.
+
+This is a local, LLM-free benchmark for recorded tool-heavy sessions. Each JSONL
+line should contain a string tool result in a configurable field (default:
+`content`). Lines with missing or non-string content are skipped.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable
+from unittest.mock import patch
+
+from agent.tool_result_compaction import compact_tool_content_if_needed, token_estimate
+
+
+@dataclass
+class ReplayAgent:
+    session_id: str = "replay-session"
+
+
+def _iter_jsonl(path: Path) -> Iterable[dict[str, Any]]:
+    with path.open("r", encoding="utf-8") as fh:
+        for line_number, line in enumerate(fh, 1):
+            stripped = line.strip()
+            if not stripped:
+                continue
+            try:
+                item = json.loads(stripped)
+            except json.JSONDecodeError as exc:
+                raise ValueError(f"Invalid JSON on line {line_number}: {exc}") from exc
+            if not isinstance(item, dict):
+                continue
+            yield item
+
+
+def run_replay(
+    *,
+    input_path: Path,
+    content_field: str,
+    threshold_tokens: int,
+    preview_chars: int,
+    max_disk_mb: int,
+    keep_dir: bool,
+) -> dict[str, Any]:
+    temp_dir = Path(tempfile.mkdtemp(prefix="hermes-tool-result-replay-"))
+    cfg = {
+        "enabled": True,
+        "threshold_tokens": threshold_tokens,
+        "preview_chars": preview_chars,
+        "raw_result_dir": str(temp_dir),
+        "max_disk_mb": max_disk_mb,
+    }
+
+    total_lines = 0
+    string_results = 0
+    compacted_count = 0
+    before_tokens = 0
+    after_tokens = 0
+
+    try:
+        with patch("agent.tool_result_compaction.get_config", return_value=cfg):
+            for index, item in enumerate(_iter_jsonl(input_path)):
+                total_lines += 1
+                content = item.get(content_field)
+                if not isinstance(content, str):
+                    continue
+                string_results += 1
+                before_tokens += token_estimate(content)
+                tool_name = str(item.get("tool_name") or item.get("name") or "tool")
+                tool_call_id = str(item.get("tool_call_id") or f"line_{index}")
+                compacted_content, info = compact_tool_content_if_needed(
+                    tool_name,
+                    tool_call_id,
+                    content,
+                    ReplayAgent(),
+                )
+                after_tokens += token_estimate(compacted_content)
+                if info is not None:
+                    compacted_count += 1
+
+        raw_files = list(temp_dir.rglob("*.json"))
+        raw_bytes = sum(path.stat().st_size for path in raw_files)
+        saved_tokens = before_tokens - after_tokens
+        saved_pct = (saved_tokens / before_tokens * 100.0) if before_tokens else 0.0
+        return {
+            "input_path": str(input_path),
+            "content_field": content_field,
+            "total_json_objects": total_lines,
+            "string_results": string_results,
+            "compacted_count": compacted_count,
+            "before_tokens_estimate": before_tokens,
+            "after_tokens_estimate": after_tokens,
+            "saved_tokens_estimate": saved_tokens,
+            "saved_percent_estimate": round(saved_pct, 2),
+            "raw_file_count": len(raw_files),
+            "raw_bytes": raw_bytes,
+            "raw_result_dir": str(temp_dir),
+        }
+    finally:
+        if not keep_dir:
+            shutil.rmtree(temp_dir, ignore_errors=True)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("input_path", type=Path)
+    parser.add_argument("--content-field", default="content")
+    parser.add_argument("--threshold-tokens", type=int, default=5_000)
+    parser.add_argument("--preview-chars", type=int, default=1_000)
+    parser.add_argument("--max-disk-mb", type=int, default=500)
+    parser.add_argument("--keep-dir", action="store_true")
+    args = parser.parse_args()
+
+    result = run_replay(
+        input_path=args.input_path,
+        content_field=args.content_field,
+        threshold_tokens=args.threshold_tokens,
+        preview_chars=args.preview_chars,
+        max_disk_mb=args.max_disk_mb,
+        keep_dir=args.keep_dir,
+    )
+    print(json.dumps(result, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/agent/test_tool_result_compaction.py
+++ b/tests/agent/test_tool_result_compaction.py
@@ -1,0 +1,262 @@
+"""Tests for tool_result_compaction.
+
+No real config, no writes outside pytest tmp dirs — all tests use monkeypatch to isolate.
+"""
+
+from __future__ import annotations
+
+import json
+import stat
+
+import pytest
+
+from agent.tool_result_compaction import (
+    DEFAULT_ENABLED,
+    DEFAULT_MAX_DISK_MB,
+    DEFAULT_PREVIEW_CHARS,
+    DEFAULT_RAW_RESULT_DIR,
+    DEFAULT_THRESHOLD_TOKENS,
+    compact_tool_content_if_needed,
+    get_config,
+    is_enabled,
+    sanitize_path_component,
+    token_estimate,
+)
+
+
+class DummyAgent:
+    session_id = "session/test:abc"
+
+
+class TestConfigDefaults:
+    """Default values — no config file read, pure constants."""
+
+    def test_default_enabled_is_false(self):
+        assert DEFAULT_ENABLED is False
+
+    def test_default_threshold_tokens(self):
+        assert DEFAULT_THRESHOLD_TOKENS == 5000
+
+    def test_default_preview_chars(self):
+        assert DEFAULT_PREVIEW_CHARS == 1000
+
+    def test_default_max_disk_mb(self):
+        assert DEFAULT_MAX_DISK_MB == 500
+
+    def test_default_raw_result_dir_is_empty(self):
+        assert DEFAULT_RAW_RESULT_DIR == ""
+
+
+class TestConfigMonkeypatch:
+    """get_config() and is_enabled() must be monkeypatchable.
+
+    These tests do NOT read the real ~/.hermes/config.yaml.
+    """
+
+    def test_is_enabled_default(self, monkeypatch):
+        monkeypatch.setattr(
+            "agent.tool_result_compaction.get_config",
+            lambda: {},
+        )
+        assert is_enabled() is False
+
+    def test_is_enabled_true_when_enabled(self, monkeypatch):
+        monkeypatch.setattr(
+            "agent.tool_result_compaction.get_config",
+            lambda: {"enabled": True},
+        )
+        assert is_enabled() is True
+
+    def test_get_config_empty_by_default(self, monkeypatch):
+        monkeypatch.setattr(
+            "hermes_cli.config.read_raw_config",
+            lambda: {},
+        )
+        cfg = get_config()
+        assert cfg == {}
+
+
+class TestHelpers:
+    def test_token_estimate_empty(self):
+        assert token_estimate("") == 0
+
+    def test_token_estimate_non_empty_minimum_one(self):
+        assert token_estimate("abc") == 1
+
+    def test_sanitize_path_component(self):
+        assert sanitize_path_component("session/test:abc") == "session_test_abc"
+
+    def test_sanitize_path_component_fallback(self):
+        assert sanitize_path_component("///", fallback="fallback") == "fallback"
+
+
+class TestDisabledPassthrough:
+    """compact_tool_content_if_needed passes through when disabled."""
+
+    def test_returns_original_content_when_disabled(self, monkeypatch):
+        monkeypatch.setattr(
+            "agent.tool_result_compaction.get_config",
+            lambda: {"enabled": False},
+        )
+        content = "some large tool output here"
+        result, info = compact_tool_content_if_needed(
+            "read_file", "call_abc", content, None,
+        )
+        assert result == content
+        assert info is None
+
+    def test_passthrough_with_large_content_when_disabled(self, monkeypatch):
+        monkeypatch.setattr(
+            "agent.tool_result_compaction.get_config",
+            lambda: {"enabled": False},
+        )
+        content = "x" * 100_000
+        result, info = compact_tool_content_if_needed(
+            "terminal", "call_def", content, None,
+        )
+        assert result == content
+        assert info is None
+
+    def test_passthrough_with_empty_string_when_disabled(self, monkeypatch):
+        monkeypatch.setattr(
+            "agent.tool_result_compaction.get_config",
+            lambda: {"enabled": False},
+        )
+        result, info = compact_tool_content_if_needed(
+            "read_file", "call_empty", "", None,
+        )
+        assert result == ""
+        assert info is None
+
+    def test_passthrough_with_special_characters_when_disabled(self, monkeypatch):
+        monkeypatch.setattr(
+            "agent.tool_result_compaction.get_config",
+            lambda: {"enabled": False},
+        )
+        content = "line1\nline2\n\t\ud83d\ude00  # emoji + tab"
+        result, info = compact_tool_content_if_needed(
+            "search_files", "call_special", content, None,
+        )
+        assert result == content
+        assert info is None
+
+    def test_passthrough_with_none_agent_when_disabled(self, monkeypatch):
+        """agent=None is valid when disabled — no access needed."""
+        monkeypatch.setattr(
+            "agent.tool_result_compaction.get_config",
+            lambda: {"enabled": False},
+        )
+        result, info = compact_tool_content_if_needed(
+            "web_search", "call_none", "some data", None,
+        )
+        assert result == "some data"
+        assert info is None
+
+    @pytest.mark.parametrize("tool_name", [
+        "read_file",
+        "terminal",
+        "search_files",
+        "web_search",
+        "vision_analyze",
+        "execute_code",
+    ])
+    def test_passthrough_for_all_tool_names_when_disabled(self, monkeypatch, tool_name):
+        monkeypatch.setattr(
+            "agent.tool_result_compaction.get_config",
+            lambda: {"enabled": False},
+        )
+        result, info = compact_tool_content_if_needed(
+            tool_name, "call_param", "content", None,
+        )
+        assert result == "content"
+        assert info is None
+
+
+class TestCompactionCore:
+    def test_below_threshold_passes_through_when_enabled(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(
+            "agent.tool_result_compaction.get_config",
+            lambda: {
+                "enabled": True,
+                "threshold_tokens": 1000,
+                "raw_result_dir": str(tmp_path),
+            },
+        )
+        result, info = compact_tool_content_if_needed(
+            "read_file", "call_small", "small content", DummyAgent(),
+        )
+        assert result == "small content"
+        assert info is None
+        assert list(tmp_path.rglob("*.json")) == []
+
+    def test_large_content_compacts_and_writes_raw_result(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(
+            "agent.tool_result_compaction.get_config",
+            lambda: {
+                "enabled": True,
+                "threshold_tokens": 10,
+                "preview_chars": 8,
+                "raw_result_dir": str(tmp_path),
+            },
+        )
+        content = "A" * 100 + "MIDDLE" + "Z" * 100
+        result, info = compact_tool_content_if_needed(
+            "read/file", "call:large", content, DummyAgent(),
+        )
+
+        compacted = json.loads(result)
+        assert compacted["type"] == "compacted_tool_result"
+        assert compacted["tool_name"] == "read/file"
+        assert compacted["tool_call_id"] == "call:large"
+        assert compacted["original_char_count"] == len(content)
+        assert compacted["original_token_estimate"] == token_estimate(content)
+        assert "omitted" in compacted["compacted_preview"]
+        assert compacted["compacted_preview"].startswith("A" * 8)
+        assert compacted["compacted_preview"].endswith("Z" * 8)
+        assert info is not None
+        assert info["original_chars"] == len(content)
+
+        raw_path = tmp_path / "session_test_abc" / next((tmp_path / "session_test_abc").iterdir()).name
+        assert raw_path.exists()
+        raw_payload = json.loads(raw_path.read_text(encoding="utf-8"))
+        assert raw_payload["content"] == content
+        assert raw_payload["tool_name"] == "read/file"
+        assert raw_payload["tool_call_id"] == "call:large"
+
+    def test_raw_result_file_permissions_are_private(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(
+            "agent.tool_result_compaction.get_config",
+            lambda: {
+                "enabled": True,
+                "threshold_tokens": 1,
+                "raw_result_dir": str(tmp_path),
+            },
+        )
+        _, info = compact_tool_content_if_needed(
+            "terminal", "call_perm", "x" * 100, DummyAgent(),
+        )
+        assert info is not None
+        raw_path = tmp_path / "session_test_abc" / next((tmp_path / "session_test_abc").iterdir()).name
+        assert stat.S_IMODE(raw_path.stat().st_mode) == 0o600
+        assert stat.S_IMODE(raw_path.parent.stat().st_mode) == 0o700
+
+    def test_fail_open_on_write_error(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(
+            "agent.tool_result_compaction.get_config",
+            lambda: {
+                "enabled": True,
+                "threshold_tokens": 1,
+                "raw_result_dir": str(tmp_path),
+            },
+        )
+
+        def boom(*args, **kwargs):
+            raise OSError("disk unavailable")
+
+        monkeypatch.setattr("agent.tool_result_compaction._write_raw_result", boom)
+        content = "x" * 100
+        result, info = compact_tool_content_if_needed(
+            "terminal", "call_fail", content, DummyAgent(),
+        )
+        assert result == content
+        assert info is None

--- a/tests/agent/test_tool_result_compaction_config.py
+++ b/tests/agent/test_tool_result_compaction_config.py
@@ -1,0 +1,78 @@
+"""Config and helper tests for tool result compaction."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+from agent.tool_result_compaction import (
+    DEFAULT_MAX_DISK_MB,
+    DEFAULT_PREVIEW_CHARS,
+    DEFAULT_THRESHOLD_TOKENS,
+    _config_bool,
+    _config_int,
+    _first_last_preview,
+    default_raw_result_dir,
+    resolve_raw_result_dir,
+)
+
+
+def test_config_bool_accepts_common_true_strings():
+    for value in ["1", "true", "TRUE", "yes", "on"]:
+        assert _config_bool({"enabled": value}, "enabled", False) is True
+
+
+def test_config_bool_rejects_common_false_strings():
+    for value in ["0", "false", "FALSE", "no", "off", ""]:
+        assert _config_bool({"enabled": value}, "enabled", True) is False
+
+
+def test_config_int_uses_default_for_invalid_values():
+    assert _config_int({"threshold_tokens": "not-an-int"}, "threshold_tokens", 5000) == 5000
+    assert _config_int({"threshold_tokens": None}, "threshold_tokens", 5000) == 5000
+
+
+def test_config_int_applies_minimum():
+    assert _config_int({"threshold_tokens": -10}, "threshold_tokens", 5000, minimum=1) == 1
+    assert _config_int({"threshold_tokens": 0}, "threshold_tokens", 5000, minimum=1) == 1
+
+
+def test_resolve_raw_result_dir_uses_default_for_empty_config():
+    assert resolve_raw_result_dir({}) == default_raw_result_dir()
+    assert resolve_raw_result_dir({"raw_result_dir": ""}) == default_raw_result_dir()
+
+
+def test_resolve_raw_result_dir_expands_user_and_env(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_COMPACTION_TEST_DIR", str(tmp_path))
+    expected = Path(tmp_path) / "raw"
+    assert resolve_raw_result_dir({"raw_result_dir": "$HERMES_COMPACTION_TEST_DIR/raw"}) == expected
+
+
+def test_first_last_preview_short_content_returns_original():
+    content = "short content"
+    assert _first_last_preview(content, DEFAULT_PREVIEW_CHARS) == content
+
+
+def test_first_last_preview_includes_head_tail_and_omission_marker():
+    content = "A" * 20 + "MIDDLE" + "Z" * 20
+    preview = _first_last_preview(content, 5)
+    assert preview.startswith("A" * 5)
+    assert preview.endswith("Z" * 5)
+    assert "omitted" in preview
+
+
+def test_first_last_preview_can_be_disabled():
+    assert _first_last_preview("some content", 0) == ""
+
+
+def test_example_config_matches_runtime_defaults():
+    example_path = Path("examples/tool-result-compaction.config.yaml")
+    data = yaml.safe_load(example_path.read_text(encoding="utf-8"))
+    cfg = data["tool_result_compaction"]
+
+    assert cfg["enabled"] is False
+    assert cfg["threshold_tokens"] == DEFAULT_THRESHOLD_TOKENS
+    assert cfg["raw_result_dir"] == ""
+    assert cfg["max_disk_mb"] == DEFAULT_MAX_DISK_MB
+    assert cfg["preview_chars"] == DEFAULT_PREVIEW_CHARS

--- a/tests/agent/test_tool_result_compaction_edges.py
+++ b/tests/agent/test_tool_result_compaction_edges.py
@@ -1,0 +1,105 @@
+"""Edge-case tests for tool result compaction."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from agent.tool_result_compaction import compact_tool_content_if_needed, token_estimate
+
+
+class AgentWithoutSessionId:
+    pass
+
+
+class AgentWithUnsafeSessionId:
+    session_id = "../unsafe/session:id"
+
+
+def test_equal_threshold_compacts(monkeypatch, tmp_path):
+    content = "x" * 40
+    threshold = token_estimate(content)
+    monkeypatch.setattr(
+        "agent.tool_result_compaction.get_config",
+        lambda: {
+            "enabled": True,
+            "threshold_tokens": threshold,
+            "preview_chars": 5,
+            "raw_result_dir": str(tmp_path),
+            "max_disk_mb": 500,
+        },
+    )
+
+    result, info = compact_tool_content_if_needed(
+        "terminal",
+        "call_equal_threshold",
+        content,
+        AgentWithoutSessionId(),
+    )
+
+    assert info is not None
+    assert json.loads(result)["type"] == "compacted_tool_result"
+
+
+def test_missing_agent_session_id_uses_session_fallback(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        "agent.tool_result_compaction.get_config",
+        lambda: {
+            "enabled": True,
+            "threshold_tokens": 1,
+            "raw_result_dir": str(tmp_path),
+            "max_disk_mb": 500,
+        },
+    )
+
+    _, info = compact_tool_content_if_needed(
+        "terminal",
+        "call_no_session",
+        "x" * 100,
+        AgentWithoutSessionId(),
+    )
+
+    assert info is not None
+    assert Path(info["raw_result_path"]).parent.name == "session"
+
+
+def test_unsafe_session_id_is_sanitized(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        "agent.tool_result_compaction.get_config",
+        lambda: {
+            "enabled": True,
+            "threshold_tokens": 1,
+            "raw_result_dir": str(tmp_path),
+            "max_disk_mb": 500,
+        },
+    )
+
+    _, info = compact_tool_content_if_needed(
+        "terminal",
+        "call_unsafe_session",
+        "x" * 100,
+        AgentWithUnsafeSessionId(),
+    )
+
+    assert info is not None
+    raw_path = Path(info["raw_result_path"])
+    assert raw_path.parent.parent == tmp_path
+    assert raw_path.parent.name == "unsafe_session_id"
+
+
+def test_compaction_fail_open_when_config_helper_raises(monkeypatch):
+    def boom():
+        raise RuntimeError("config unavailable")
+
+    monkeypatch.setattr("agent.tool_result_compaction.get_config", boom)
+    content = "x" * 100
+
+    result, info = compact_tool_content_if_needed(
+        "terminal",
+        "call_config_error",
+        content,
+        AgentWithoutSessionId(),
+    )
+
+    assert result == content
+    assert info is None

--- a/tests/agent/test_tool_result_compaction_quota.py
+++ b/tests/agent/test_tool_result_compaction_quota.py
@@ -1,0 +1,58 @@
+"""Disk quota tests for tool result compaction."""
+
+from __future__ import annotations
+
+import os
+
+from agent.tool_result_compaction import _enforce_disk_quota
+
+
+def test_quota_cleanup_deletes_oldest_files(tmp_path):
+    session_dir = tmp_path / "session"
+    session_dir.mkdir()
+    files = []
+    for idx in range(3):
+        path = session_dir / f"file_{idx}.json"
+        path.write_bytes(b"x" * 500_000)
+        os.utime(path, (100 + idx, 100 + idx))
+        files.append(path)
+
+    _enforce_disk_quota(tmp_path, max_disk_mb=1)
+
+    assert not files[0].exists()
+    assert not files[1].exists()
+    assert files[2].exists()
+
+
+def test_quota_cleanup_preserves_protected_path(tmp_path):
+    session_dir = tmp_path / "session"
+    session_dir.mkdir()
+
+    old_path = session_dir / "old.json"
+    old_path.write_bytes(b"x" * 500_000)
+    os.utime(old_path, (100, 100))
+
+    protected_path = session_dir / "protected.json"
+    protected_path.write_bytes(b"x" * 500_000)
+    os.utime(protected_path, (101, 101))
+
+    newer_path = session_dir / "newer.json"
+    newer_path.write_bytes(b"x" * 500_000)
+    os.utime(newer_path, (102, 102))
+
+    _enforce_disk_quota(tmp_path, max_disk_mb=1, protected_path=protected_path)
+
+    assert not old_path.exists()
+    assert protected_path.exists()
+    assert not newer_path.exists()
+
+
+def test_quota_cleanup_disabled_when_max_disk_mb_non_positive(tmp_path):
+    session_dir = tmp_path / "session"
+    session_dir.mkdir()
+    path = session_dir / "file.json"
+    path.write_bytes(b"x" * 1_500_000)
+
+    _enforce_disk_quota(tmp_path, max_disk_mb=0)
+
+    assert path.exists()

--- a/tests/agent/test_tool_result_compaction_tool_message.py
+++ b/tests/agent/test_tool_result_compaction_tool_message.py
@@ -1,0 +1,72 @@
+"""Integration-style tests for compacted tool-result message shape."""
+
+from __future__ import annotations
+
+import json
+
+from agent.tool_dispatch_helpers import make_tool_result_message
+from agent.tool_result_compaction import compact_tool_content_if_needed
+
+
+class DummyAgent:
+    session_id = "integration/session"
+
+
+def test_compacted_content_remains_valid_tool_message(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        "agent.tool_result_compaction.get_config",
+        lambda: {
+            "enabled": True,
+            "threshold_tokens": 1,
+            "preview_chars": 12,
+            "raw_result_dir": str(tmp_path),
+            "max_disk_mb": 500,
+        },
+    )
+    original_content = "alpha\n" + ("middle\n" * 50) + "omega\n"
+
+    compacted_content, info = compact_tool_content_if_needed(
+        "terminal",
+        "call_integration",
+        original_content,
+        DummyAgent(),
+    )
+    message = make_tool_result_message(
+        "terminal",
+        compacted_content,
+        "call_integration",
+    )
+
+    assert message["role"] == "tool"
+    assert message["name"] == "terminal"
+    assert message["tool_name"] == "terminal"
+    assert message["tool_call_id"] == "call_integration"
+    assert isinstance(message["content"], str)
+
+    payload = json.loads(message["content"])
+    assert payload["type"] == "compacted_tool_result"
+    assert payload["tool_name"] == "terminal"
+    assert payload["tool_call_id"] == "call_integration"
+    assert payload["raw_result_path"] == info["raw_result_path"]
+    assert "alpha" in payload["compacted_preview"]
+    assert "omega" in payload["compacted_preview"]
+
+
+def test_disabled_compaction_tool_message_is_unchanged(monkeypatch):
+    monkeypatch.setattr(
+        "agent.tool_result_compaction.get_config",
+        lambda: {"enabled": False},
+    )
+    original_content = "small output"
+
+    content, info = compact_tool_content_if_needed(
+        "read_file",
+        "call_disabled",
+        original_content,
+        DummyAgent(),
+    )
+    message = make_tool_result_message("read_file", content, "call_disabled")
+
+    assert info is None
+    assert message["content"] == original_content
+    assert message["tool_call_id"] == "call_disabled"

--- a/tests/scripts/test_benchmark_tool_result_compaction.py
+++ b/tests/scripts/test_benchmark_tool_result_compaction.py
@@ -1,0 +1,52 @@
+"""Tests for the synthetic tool result compaction benchmark."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts.benchmark_tool_result_compaction import run_benchmark
+
+
+def test_benchmark_reports_expected_compaction_metrics():
+    result = run_benchmark(
+        tool_results=3,
+        result_chars=20_000,
+        threshold_tokens=1_000,
+        preview_chars=200,
+        max_disk_mb=500,
+        keep_dir=False,
+    )
+
+    assert result["tool_results"] == 3
+    assert result["result_chars_each"] == 20_000
+    assert result["compacted_count"] == 3
+    assert result["raw_file_count"] == 3
+    assert result["before_tokens_estimate"] > result["after_tokens_estimate"]
+    assert result["saved_percent_estimate"] > 0
+    assert result["sample_raw_path"] is not None
+    assert not Path(result["raw_result_dir"]).exists()
+
+
+def test_benchmark_keep_dir_preserves_raw_result_dir():
+    result = run_benchmark(
+        tool_results=1,
+        result_chars=20_000,
+        threshold_tokens=1_000,
+        preview_chars=200,
+        max_disk_mb=500,
+        keep_dir=True,
+    )
+
+    raw_result_dir = Path(result["raw_result_dir"])
+    try:
+        assert raw_result_dir.exists()
+        assert result["raw_file_count"] == 1
+        assert result["sample_raw_path"] is not None
+        assert Path(result["sample_raw_path"]).exists()
+    finally:
+        for path in sorted(raw_result_dir.rglob("*"), reverse=True):
+            if path.is_file():
+                path.unlink()
+            elif path.is_dir():
+                path.rmdir()
+        raw_result_dir.rmdir()

--- a/tests/scripts/test_replay_tool_result_compaction.py
+++ b/tests/scripts/test_replay_tool_result_compaction.py
@@ -1,0 +1,94 @@
+"""Tests for JSONL replay benchmark for tool result compaction."""
+
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+
+from scripts.replay_tool_result_compaction import run_replay
+
+
+def _write_jsonl(path: Path, rows: list[dict]) -> None:
+    path.write_text(
+        "\n".join(json.dumps(row) for row in rows) + "\n",
+        encoding="utf-8",
+    )
+
+
+def test_replay_compacts_large_string_results(tmp_path):
+    input_path = tmp_path / "tool_results.jsonl"
+    _write_jsonl(
+        input_path,
+        [
+            {"tool_name": "terminal", "tool_call_id": "call_1", "content": "A" * 20_000},
+            {"tool_name": "read_file", "tool_call_id": "call_2", "content": "small"},
+            {"tool_name": "vision_analyze", "tool_call_id": "call_3", "content": ["not", "string"]},
+        ],
+    )
+
+    result = run_replay(
+        input_path=input_path,
+        content_field="content",
+        threshold_tokens=1_000,
+        preview_chars=100,
+        max_disk_mb=500,
+        keep_dir=False,
+    )
+
+    assert result["total_json_objects"] == 3
+    assert result["string_results"] == 2
+    assert result["compacted_count"] == 1
+    assert result["raw_file_count"] == 1
+    assert result["before_tokens_estimate"] > result["after_tokens_estimate"]
+    assert result["saved_percent_estimate"] > 0
+    assert not Path(result["raw_result_dir"]).exists()
+
+
+def test_replay_supports_custom_content_field(tmp_path):
+    input_path = tmp_path / "tool_results.jsonl"
+    _write_jsonl(
+        input_path,
+        [
+            {"tool_name": "terminal", "tool_call_id": "call_1", "result": "A" * 20_000},
+        ],
+    )
+
+    result = run_replay(
+        input_path=input_path,
+        content_field="result",
+        threshold_tokens=1_000,
+        preview_chars=100,
+        max_disk_mb=500,
+        keep_dir=False,
+    )
+
+    assert result["string_results"] == 1
+    assert result["compacted_count"] == 1
+
+
+def test_replay_keep_dir_preserves_raw_result_dir(tmp_path):
+    input_path = tmp_path / "tool_results.jsonl"
+    _write_jsonl(
+        input_path,
+        [
+            {"tool_name": "terminal", "tool_call_id": "call_1", "content": "A" * 20_000},
+        ],
+    )
+
+    result = run_replay(
+        input_path=input_path,
+        content_field="content",
+        threshold_tokens=1_000,
+        preview_chars=100,
+        max_disk_mb=500,
+        keep_dir=True,
+    )
+
+    raw_result_dir = Path(result["raw_result_dir"])
+    try:
+        assert raw_result_dir.exists()
+        assert result["raw_file_count"] == 1
+        assert list(raw_result_dir.rglob("*.json"))
+    finally:
+        shutil.rmtree(raw_result_dir, ignore_errors=True)


### PR DESCRIPTION
# Hermes Tool Result Compaction

Opt-in string-tool-result compaction with disk-backed raw storage, quota cleanup, documentation, benchmark/replay scripts, and 51 tests passing.

## What this PR does

When `tool_result_compaction.enabled: true` is set in `~/.hermes/config.yaml`, large string tool results above the configured threshold are:

1. **Saved to disk** at `~/.hermes/raw_results/<session_id>/<tool_call_id>_<tool_name>_<timestamp>.json`
2. **Replaced in message history** with a compact JSON reference containing tool name, call id, original char/token count, first+last preview, raw result path, and a recovery note
3. **Managed by disk quota** — oldest raw result files are purged when default 500 MB quota is exceeded; the current file is protected from immediate cleanup

**Disabled by default.** No behavior change without explicit opt-in to `config.yaml`.

## Design

- **Opt-in:** `DEFAULT_ENABLED = False`
- **String-only:** non-string / multimodal tool results are skipped by the existing `isinstance(..., str)` guard
- **Fail-open:** any config, filesystem, permission, or compaction error returns the original content unchanged (tested explicitly)
- **LLM-free:** deterministic first+last preview; no summarization model call
- **Private storage:** raw result directories use `0o700`; raw JSON files use `0o600`
- **Existing pipeline compatible:** runs after `maybe_persist_tool_result()` and `_tool_result_content_for_active_model()`
- **Race-safe:** symlinks excluded from iteration; stat failures in sort/cleanup fall back gracefully

## Files

| File | Purpose |
|---|---|
| `agent/tool_result_compaction.py` | Config schema, token estimate, compaction core, raw storage, permissions, quota cleanup, fail-open handling |
| `agent/tool_executor.py` | Integration in sequential and concurrent tool-result paths before `messages.append()` |
| `scripts/benchmark_tool_result_compaction.py` | Synthetic LLM-free benchmark |
| `scripts/replay_tool_result_compaction.py` | JSONL replay benchmark |
| `docs/tool-result-compaction.md` | Full documentation: config, behavior, storage, recovery, benchmarks, limitations |
| `docs/tool-result-compaction-review-checklist.md` | Pre-merge review checklist |
| `examples/tool-result-compaction.config.yaml` | Copyable config snippet |
| 5 test files under `tests/agent/` | Core, quota, tool message shape, config coercion, edge cases |
| 2 test files under `tests/scripts/` | Benchmark and replay script tests |

## Config

```yaml
tool_result_compaction:
  enabled: false
  threshold_tokens: 5000
  raw_result_dir: ""          # empty => ~/.hermes/raw_results
  max_disk_mb: 500
  preview_chars: 1000         # first 1000 + last 1000 chars
```

## Benchmarks

### Synthetic (10 results @ 50K chars each)
```
before_tokens_estimate: 125,000
after_tokens_estimate:    6,450
saved_percent_estimate:  94.84%
```

### Replay (2 JSONL objects: 50K + small string)
```
saved_percent_estimate:   94.94%
compacted_count:          1
```

Both are LLM-free, using the same `chars / 4` estimate as the compaction module.

## Verification

```
py_compile: OK
pytest: 51 passed in 1.99s
ruff: All checks passed (11 files)
benchmark: 94.84% estimated savings
```

## Commits (squashed to 4)

```
e2134a280 docs(tool-result-compaction): document configuration and tradeoffs
a60f96ef5 bench(tool-result-compaction): add synthetic and replay benchmarks
a5d301235 test(tool-result-compaction): cover compaction behavior and edge cases
74e14b732 feat(tool-result-compaction): add opt-in tool result compaction
```

## Known tradeoffs

- **`raw_result_path` is a local filesystem path** embedded in the compacted JSON for model recovery. Works locally; remote/docker modes would need a reference-ID resolver. (Documented in Limitations.)
- **Docs and benchmark scripts** are in the same PR. Could be split into a follow-up if upstream prefers a minimal diff.

## Status

Ready for review. 4 squashed commits, 51 tests passing, all checks green.
