### PR TITLE
fix(feishu): stop using root_id as thread_id for DM replies

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -2977,7 +2977,11 @@ class FeishuAdapter(BasePlatformAdapter):
             if hint:
                 text = f"{hint}\n\n{text}" if text else hint
 
-        thread_id = getattr(message, "thread_id", None) or getattr(message, "root_id", None) or None
+        # Only use explicit thread_id (forum topics).  Do NOT fall back to
+        # root_id — Feishu sets root_id for ordinary inline DM replies, which
+        # should stay in the main chat session rather than spawning a new
+        # thread-keyed session.  See #29466.
+        thread_id = getattr(message, "thread_id", None) or None
         reply_to_message_id = (
             getattr(message, "parent_id", None)
             or getattr(message, "upper_message_id", None)


### PR DESCRIPTION
## Summary

- Stop using Feishu `root_id` as a fallback `thread_id` for inbound messages
- Feishu sets `root_id` on ordinary inline DM replies (not just forum topics), which causes reply messages to be routed to a separate thread-keyed session
- Keep `root_id` available as reply context via `reply_to_message_id` (unchanged)

## Problem

When a user replies to a specific message in a Feishu DM, the bot's typing indicator appears in the main chat, but the actual response is posted as a thread reply — invisible in the main chat window.

**Root cause:** `thread_id` falls back to `root_id`, and Feishu sets `root_id` for all inline replies. This changes the session key from `dm:oc_xxx` to `dm:oc_xxx:om_xxx`, causing the response to be sent with `reply_in_thread=True`.

## Fix

Only use the explicit `thread_id` attribute (Feishu forum topics) for session routing. Remove `root_id` from the `thread_id` fallback chain.

Fixes #29466
