### PR TITLE
Add deterministic kanban taskstoissues command

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -783,6 +783,42 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
         help="Emit one JSON object per task on stdout",
     )
 
+    # --- taskstoissues --- (Spec-Kit tasks.md -> deterministic tickets)
+    p_taskstoissues = sub.add_parser(
+        "taskstoissues",
+        help="Create deterministic kanban tickets from a Spec-Kit tasks.md file",
+    )
+    p_taskstoissues.add_argument(
+        "spec_id",
+        help="Spec id / directory name, e.g. 067-tasks-to-tickets",
+    )
+    p_taskstoissues.add_argument(
+        "--root-ticket",
+        required=True,
+        help="Root kanban ticket id",
+    )
+    p_taskstoissues.add_argument(
+        "--spec-root",
+        default=".specify/specs",
+        help="Directory containing spec folders (default: .specify/specs)",
+    )
+    p_taskstoissues.add_argument(
+        "--tasks-file",
+        default=None,
+        help="Explicit tasks.md path; overrides --spec-root/spec-id/tasks.md",
+    )
+    p_taskstoissues.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print the plan without writing",
+    )
+    p_taskstoissues.add_argument(
+        "--author",
+        default=None,
+        help="Author for audit comments",
+    )
+    p_taskstoissues.add_argument("--json", action="store_true", help="Emit JSON output")
+
     # --- gc ---
     p_gc = sub.add_parser(
         "gc", help="Garbage-collect archived-task workspaces, old events, and old logs",
@@ -915,6 +951,7 @@ def kanban_command(args: argparse.Namespace) -> int:
         "context":  _cmd_context,
         "specify":  _cmd_specify,
         "decompose":  _cmd_decompose,
+        "taskstoissues": _cmd_taskstoissues,
         "gc":       _cmd_gc,
     }
     handler = handlers.get(action)
@@ -2529,6 +2566,65 @@ def _cmd_decompose(args: argparse.Namespace) -> int:
     if not all_flag:
         return 0 if ok_count == 1 else 1
     return 0 if (ok_count > 0 or not ids) else 1
+
+
+def _cmd_taskstoissues(args: argparse.Namespace) -> int:
+    """Create kanban tickets from a deterministic Spec-Kit tasks.md."""
+    from hermes_cli import kanban_taskstoissues as tti
+
+    tasks_file = tti.resolve_tasks_file(
+        args.spec_id,
+        spec_root=getattr(args, "spec_root", None),
+        tasks_file=getattr(args, "tasks_file", None),
+    )
+    author = getattr(args, "author", None) or _profile_author()
+    want_json = bool(getattr(args, "json", False))
+
+    with kb.connect() as conn:
+        if getattr(args, "dry_run", False):
+            plan = tti.build_plan(
+                conn,
+                spec_id=args.spec_id,
+                root_ticket=args.root_ticket,
+                tasks_file=tasks_file,
+            )
+            data = tti.plan_to_dict(plan)
+            if want_json:
+                print(json.dumps(data, indent=2))
+            else:
+                print(
+                    f"Would create {plan.creates} ticket(s) from {plan.tasks_file} "
+                    f"({plan.existing} existing)."
+                )
+                for item in plan.items:
+                    label = item.ticket_id or "new"
+                    deps = ", ".join(item.task.depends_on) or "-"
+                    print(
+                        f"{item.task.task_id} [{item.action}:{label}] "
+                        f"deps={deps} {item.task.title}"
+                    )
+            return 0
+
+        result = tti.apply_tasks_to_issues(
+            conn,
+            spec_id=args.spec_id,
+            root_ticket=args.root_ticket,
+            tasks_file=tasks_file,
+            author=author,
+        )
+
+    data = tti.result_to_dict(result)
+    if want_json:
+        print(json.dumps(data, indent=2))
+    else:
+        print(
+            f"Created {len(result.created_ticket_ids)} ticket(s), "
+            f"reused {len(result.existing_ticket_ids)} existing ticket(s) "
+            f"for {result.spec_id}."
+        )
+        for task_id, ticket_id in result.task_ticket_ids.items():
+            print(f"{task_id} -> {ticket_id}")
+    return 0
 
 
 def _cmd_gc(args: argparse.Namespace) -> int:

--- a/hermes_cli/kanban_taskstoissues.py
+++ b/hermes_cli/kanban_taskstoissues.py
@@ -1,0 +1,315 @@
+"""Deterministic Spec-Kit tasks.md -> kanban tickets support."""
+
+from __future__ import annotations
+
+import re
+import sqlite3
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Iterable, Optional
+
+from hermes_cli import kanban_db as kb
+
+
+_TASK_RE = re.compile(r"^\s*[-*]\s+\[[ xX]\]\s+(T\d{3,})\b[:.)-]?\s*(.*)$")
+_DEPEND_RE = re.compile(
+    r"\bDepend(?:s|encies)?(?:\s+on)?\s*:\s*([Tt]\d{3,}(?:\s*,\s*[Tt]\d{3,})*)"
+)
+_TASK_ID_RE = re.compile(r"\b[Tt]\d{3,}\b")
+_TITLE_STOP_RE = re.compile(r"^\s*(Depend(?:s|encies)?(?:\s+on)?|Satisfies)\s*:", re.I)
+
+
+@dataclass(frozen=True)
+class ParsedTask:
+    task_id: str
+    title: str
+    body: str
+    depends_on: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class TicketPlanItem:
+    task: ParsedTask
+    idempotency_key: str
+    existing_ticket_id: Optional[str] = None
+    planned_ticket_id: Optional[str] = None
+    dependency_ticket_ids: tuple[str, ...] = ()
+
+    @property
+    def ticket_id(self) -> Optional[str]:
+        return self.existing_ticket_id or self.planned_ticket_id
+
+    @property
+    def action(self) -> str:
+        return "existing" if self.existing_ticket_id else "create"
+
+
+@dataclass(frozen=True)
+class TicketPlan:
+    spec_id: str
+    root_ticket: str
+    tasks_file: Path
+    items: tuple[TicketPlanItem, ...]
+
+    @property
+    def creates(self) -> int:
+        return sum(1 for item in self.items if item.action == "create")
+
+    @property
+    def existing(self) -> int:
+        return sum(1 for item in self.items if item.action == "existing")
+
+
+@dataclass(frozen=True)
+class ApplyResult:
+    spec_id: str
+    root_ticket: str
+    tasks_file: Path
+    created_ticket_ids: tuple[str, ...]
+    existing_ticket_ids: tuple[str, ...]
+    task_ticket_ids: dict[str, str] = field(default_factory=dict)
+
+    @property
+    def total(self) -> int:
+        return len(self.task_ticket_ids)
+
+
+def resolve_tasks_file(
+    spec_id: str,
+    *,
+    spec_root: Optional[Path | str] = None,
+    tasks_file: Optional[Path | str] = None,
+) -> Path:
+    if tasks_file:
+        return Path(tasks_file).expanduser()
+    if not spec_id:
+        raise ValueError("spec_id is required")
+    root = Path(spec_root).expanduser() if spec_root else Path(".specify/specs")
+    return root / spec_id / "tasks.md"
+
+
+def parse_tasks_md(path: Path | str) -> list[ParsedTask]:
+    tasks_path = Path(path).expanduser()
+    text = tasks_path.read_text(encoding="utf-8")
+    parsed: list[ParsedTask] = []
+    current_id: Optional[str] = None
+    current_title: Optional[str] = None
+    current_lines: list[str] = []
+
+    def flush() -> None:
+        nonlocal current_id, current_title, current_lines
+        if current_id is None or current_title is None:
+            return
+        body = "\n".join(line.rstrip() for line in current_lines).strip()
+        title_parts = [current_title.strip()]
+        for line in current_lines:
+            stripped = line.strip()
+            if not stripped:
+                continue
+            if _TITLE_STOP_RE.match(stripped):
+                break
+            title_parts.append(stripped)
+        title = " ".join(part for part in title_parts if part).strip()
+        depends: list[str] = []
+        for match in _DEPEND_RE.finditer("\n".join([current_title, body])):
+            for dep in _TASK_ID_RE.findall(match.group(1)):
+                dep_id = dep.upper()
+                if dep_id != current_id and dep_id not in depends:
+                    depends.append(dep_id)
+        parsed.append(
+            ParsedTask(
+                task_id=current_id,
+                title=title,
+                body=body,
+                depends_on=tuple(depends),
+            )
+        )
+        current_id = None
+        current_title = None
+        current_lines = []
+
+    for raw in text.splitlines():
+        match = _TASK_RE.match(raw)
+        if match:
+            flush()
+            current_id = match.group(1).upper()
+            current_title = match.group(2).strip()
+            current_lines = []
+            continue
+        if current_id is not None:
+            current_lines.append(raw)
+    flush()
+
+    seen: set[str] = set()
+    for task in parsed:
+        if not task.title:
+            raise ValueError(f"{task.task_id} is missing a title")
+        if task.task_id in seen:
+            raise ValueError(f"duplicate task id {task.task_id}")
+        seen.add(task.task_id)
+    known = {task.task_id for task in parsed}
+    missing = sorted({dep for task in parsed for dep in task.depends_on if dep not in known})
+    if missing:
+        raise ValueError(f"unknown dependency task id(s): {', '.join(missing)}")
+    return parsed
+
+
+def idempotency_key(spec_id: str, task_id: str) -> str:
+    return f"tasks-to-issues:{spec_id}:{task_id.upper()}"
+
+
+def _existing_by_key(conn: sqlite3.Connection, keys: Iterable[str]) -> dict[str, str]:
+    keys = tuple(keys)
+    if not keys:
+        return {}
+    placeholders = ",".join("?" for _ in keys)
+    rows = conn.execute(
+        "SELECT idempotency_key, id FROM tasks "
+        f"WHERE idempotency_key IN ({placeholders}) AND status != 'archived'",
+        keys,
+    ).fetchall()
+    return {row["idempotency_key"]: row["id"] for row in rows}
+
+
+def build_plan(
+    conn: sqlite3.Connection,
+    *,
+    spec_id: str,
+    root_ticket: str,
+    tasks_file: Path | str,
+) -> TicketPlan:
+    tasks_path = Path(tasks_file).expanduser()
+    tasks = parse_tasks_md(tasks_path)
+    existing = _existing_by_key(conn, [idempotency_key(spec_id, t.task_id) for t in tasks])
+    task_to_ticket: dict[str, str] = {}
+    items: list[TicketPlanItem] = []
+    for task in tasks:
+        key = idempotency_key(spec_id, task.task_id)
+        existing_id = existing.get(key)
+        if existing_id:
+            task_to_ticket[task.task_id] = existing_id
+        dep_ids = tuple(task_to_ticket[dep] for dep in task.depends_on if dep in task_to_ticket)
+        items.append(
+            TicketPlanItem(
+                task=task,
+                idempotency_key=key,
+                existing_ticket_id=existing_id,
+                dependency_ticket_ids=dep_ids,
+            )
+        )
+    return TicketPlan(spec_id=spec_id, root_ticket=root_ticket, tasks_file=tasks_path, items=tuple(items))
+
+
+def _ticket_body(*, spec_id: str, root_ticket: str, task: ParsedTask) -> str:
+    parts = [
+        f"Spec: {spec_id}",
+        f"Root ticket: {root_ticket}",
+        f"Source task: {task.task_id}",
+        "",
+        task.body.strip() if task.body else task.title,
+        "",
+        f"tasks-to-issues:{spec_id}:{task.task_id}",
+    ]
+    return "\n".join(parts).strip()
+
+
+def _link_if_missing(conn: sqlite3.Connection, parent_id: str, child_id: str) -> None:
+    row = conn.execute(
+        "SELECT 1 FROM task_links WHERE parent_id = ? AND child_id = ?",
+        (parent_id, child_id),
+    ).fetchone()
+    if row:
+        return
+    kb.link_tasks(conn, parent_id, child_id)
+
+
+def apply_tasks_to_issues(
+    conn: sqlite3.Connection,
+    *,
+    spec_id: str,
+    root_ticket: str,
+    tasks_file: Path | str,
+    author: str = "taskstoissues",
+) -> ApplyResult:
+    if not kb.get_task(conn, root_ticket):
+        raise ValueError(f"root ticket {root_ticket} not found")
+
+    tasks_path = Path(tasks_file).expanduser()
+    tasks = parse_tasks_md(tasks_path)
+    task_ticket_ids: dict[str, str] = {}
+    created: list[str] = []
+    existing: list[str] = []
+
+    for task in tasks:
+        key = idempotency_key(spec_id, task.task_id)
+        found = _existing_by_key(conn, [key]).get(key)
+        if found:
+            ticket_id = found
+            existing.append(ticket_id)
+        else:
+            ticket_id = kb.create_task(
+                conn,
+                title=f"{task.task_id}: {task.title}",
+                body=_ticket_body(spec_id=spec_id, root_ticket=root_ticket, task=task),
+                created_by=author,
+                idempotency_key=key,
+                workspace_kind="scratch",
+            )
+            created.append(ticket_id)
+        task_ticket_ids[task.task_id] = ticket_id
+
+    for task in tasks:
+        child_id = task_ticket_ids[task.task_id]
+        for dep in task.depends_on:
+            _link_if_missing(conn, task_ticket_ids[dep], child_id)
+        _link_if_missing(conn, child_id, root_ticket)
+
+    if created:
+        kb.add_comment(
+            conn,
+            root_ticket,
+            author,
+            "Created Spec-Kit task tickets: " + ", ".join(created),
+        )
+
+    return ApplyResult(
+        spec_id=spec_id,
+        root_ticket=root_ticket,
+        tasks_file=tasks_path,
+        created_ticket_ids=tuple(created),
+        existing_ticket_ids=tuple(existing),
+        task_ticket_ids=task_ticket_ids,
+    )
+
+
+def plan_to_dict(plan: TicketPlan) -> dict[str, Any]:
+    return {
+        "spec_id": plan.spec_id,
+        "root_ticket": plan.root_ticket,
+        "tasks_file": str(plan.tasks_file),
+        "creates": plan.creates,
+        "existing": plan.existing,
+        "items": [
+            {
+                "task_id": item.task.task_id,
+                "title": item.task.title,
+                "depends_on": list(item.task.depends_on),
+                "idempotency_key": item.idempotency_key,
+                "action": item.action,
+                "ticket_id": item.ticket_id,
+            }
+            for item in plan.items
+        ],
+    }
+
+
+def result_to_dict(result: ApplyResult) -> dict[str, Any]:
+    return {
+        "spec_id": result.spec_id,
+        "root_ticket": result.root_ticket,
+        "tasks_file": str(result.tasks_file),
+        "created": list(result.created_ticket_ids),
+        "existing": list(result.existing_ticket_ids),
+        "task_ticket_ids": dict(result.task_ticket_ids),
+        "total": result.total,
+    }

--- a/tests/hermes_cli/test_kanban_taskstoissues.py
+++ b/tests/hermes_cli/test_kanban_taskstoissues.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban as kanban_cli
+from hermes_cli import kanban_db as kb
+from hermes_cli import kanban_taskstoissues as tti
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    return home
+
+
+def _write_tasks(tmp_path: Path) -> Path:
+    tasks = tmp_path / "tasks.md"
+    tasks.write_text(
+        """
+# Tasks
+
+- [ ] T001 Add parser tests in `tests/test_taskstoissues.py`
+  for checkbox tasks and stable ids.
+
+- [ ] T002 Implement parser module.
+  Depends: T001.
+  Keep multiline bodies attached.
+
+- [ ] T003 Implement apply path.
+  Depends on: T001, T002.
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+    return tasks
+
+
+def test_parse_tasks_md_checkboxes_ids_multiline_and_dependencies(tmp_path):
+    tasks = tti.parse_tasks_md(_write_tasks(tmp_path))
+
+    assert [task.task_id for task in tasks] == ["T001", "T002", "T003"]
+    assert tasks[0].title == (
+        "Add parser tests in `tests/test_taskstoissues.py` "
+        "for checkbox tasks and stable ids."
+    )
+    assert "stable ids" in tasks[0].body
+    assert tasks[1].depends_on == ("T001",)
+    assert tasks[2].depends_on == ("T001", "T002")
+
+
+def test_build_plan_uses_stable_dedupe_keys_and_detects_existing(kanban_home, tmp_path):
+    tasks_file = _write_tasks(tmp_path)
+    with kb.connect() as conn:
+        root = kb.create_task(conn, title="root")
+        existing = kb.create_task(
+            conn,
+            title="T001 existing",
+            idempotency_key="tasks-to-issues:067-demo:T001",
+        )
+        plan = tti.build_plan(
+            conn,
+            spec_id="067-demo",
+            root_ticket=root,
+            tasks_file=tasks_file,
+        )
+
+    assert plan.items[0].idempotency_key == "tasks-to-issues:067-demo:T001"
+    assert plan.items[0].existing_ticket_id == existing
+    assert plan.items[1].action == "create"
+    assert plan.creates == 2
+    assert plan.existing == 1
+
+
+def test_dry_run_plan_does_not_mutate_db(kanban_home, tmp_path):
+    tasks_file = _write_tasks(tmp_path)
+    with kb.connect() as conn:
+        root = kb.create_task(conn, title="root")
+        before = len(kb.list_tasks(conn, include_archived=True))
+        plan = tti.build_plan(
+            conn,
+            spec_id="067-demo",
+            root_ticket=root,
+            tasks_file=tasks_file,
+        )
+        after = len(kb.list_tasks(conn, include_archived=True))
+
+    assert plan.creates == 3
+    assert before == after == 1
+
+
+def test_apply_creates_linked_tickets_and_rerun_is_idempotent(kanban_home, tmp_path):
+    tasks_file = _write_tasks(tmp_path)
+    with kb.connect() as conn:
+        root = kb.create_task(conn, title="root")
+        first = tti.apply_tasks_to_issues(
+            conn,
+            spec_id="067-demo",
+            root_ticket=root,
+            tasks_file=tasks_file,
+            author="tester",
+        )
+        second = tti.apply_tasks_to_issues(
+            conn,
+            spec_id="067-demo",
+            root_ticket=root,
+            tasks_file=tasks_file,
+            author="tester",
+        )
+        rows = conn.execute(
+            "SELECT parent_id, child_id FROM task_links ORDER BY parent_id, child_id"
+        ).fetchall()
+
+    assert len(first.created_ticket_ids) == 3
+    assert second.created_ticket_ids == ()
+    assert set(second.existing_ticket_ids) == set(first.created_ticket_ids)
+    t1 = first.task_ticket_ids["T001"]
+    t2 = first.task_ticket_ids["T002"]
+    t3 = first.task_ticket_ids["T003"]
+    links = {(row["parent_id"], row["child_id"]) for row in rows}
+    assert (t1, t2) in links
+    assert (t1, t3) in links
+    assert (t2, t3) in links
+    assert (t1, root) in links
+    assert (t2, root) in links
+    assert (t3, root) in links
+    assert len(links) == len(rows)
+
+
+def test_cli_taskstoissues_json_dry_run(kanban_home, tmp_path, capsys):
+    tasks_file = _write_tasks(tmp_path)
+    with kb.connect() as conn:
+        root = kb.create_task(conn, title="root")
+
+    rc = kanban_cli._cmd_taskstoissues(
+        argparse.Namespace(
+            spec_id="067-demo",
+            root_ticket=root,
+            spec_root=None,
+            tasks_file=str(tasks_file),
+            dry_run=True,
+            author="tester",
+            json=True,
+        )
+    )
+    out = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert out["creates"] == 3
+    assert out["items"][0]["idempotency_key"] == "tasks-to-issues:067-demo:T001"


### PR DESCRIPTION
Implements spec 067 for deterministic Spec-Kit `tasks.md` to kanban ticket conversion.

Changes:
- Adds `hermes_cli.kanban_taskstoissues` parser/planner/apply flow.
- Adds `hermes kanban taskstoissues <spec-id>` with `--root-ticket`, `--spec-root`, `--tasks-file`, `--dry-run`, and `--json`.
- Adds focused parser, idempotency, dry-run, DB-link, rerun, and CLI tests.

Validation:
- `uv run pytest -o addopts='' -q tests/hermes_cli/test_kanban_taskstoissues.py`
- `uv run hermes kanban taskstoissues --help`
- `uv run hermes kanban --board chitin taskstoissues 067-tasks-to-tickets --spec-root /home/red/workspace/chitin-067-tasks-to-tickets/.specify/specs --root-ticket t_7017fcab --dry-run --json`

Chitin ticket: t_7017fcab