### PR TITLE
feat(config): increase default memory limits to 10000/5000 for better mobile UX

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -944,8 +944,8 @@ def init_agent(
             if agent._memory_enabled or agent._user_profile_enabled:
                 from tools.memory_tool import MemoryStore
                 agent._memory_store = MemoryStore(
-                    memory_char_limit=mem_config.get("memory_char_limit", 2200),
-                    user_char_limit=mem_config.get("user_char_limit", 1375),
+                    memory_char_limit=mem_config.get("memory_char_limit", 10000),
+                    user_char_limit=mem_config.get("user_char_limit", 5000),
                 )
                 agent._memory_store.load_from_disk()
         except Exception:

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -467,8 +467,8 @@ memory:
   user_profile_enabled: true
   
   # Character limits (~2.75 chars per token, model-independent)
-  memory_char_limit: 2200   # ~800 tokens
-  user_char_limit: 1375     # ~500 tokens
+  memory_char_limit: 10000  # ~3600 tokens
+  user_char_limit: 5000     # ~1800 tokens
 
   # Periodic memory nudge: remind the agent to consider saving memories
   # every N user turns. Set to 0 to disable. Only active when memory is enabled.

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1127,8 +1127,8 @@ DEFAULT_CONFIG = {
     "memory": {
         "memory_enabled": True,
         "user_profile_enabled": True,
-        "memory_char_limit": 2200,   # ~800 tokens at 2.75 chars/token
-        "user_char_limit": 1375,     # ~500 tokens at 2.75 chars/token
+        "memory_char_limit": 10000,  # ~3600 tokens at 2.75 chars/token
+        "user_char_limit": 5000,     # ~1800 tokens at 2.75 chars/token
         # External memory provider plugin (empty = built-in only).
         # Set to a provider name to activate: "openviking", "mem0",
         # "hindsight", "holographic", "retaindb", "byterover".

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -115,7 +115,7 @@ class MemoryStore:
         Tool responses always reflect this live state.
     """
 
-    def __init__(self, memory_char_limit: int = 2200, user_char_limit: int = 1375):
+    def __init__(self, memory_char_limit: int = 10000, user_char_limit: int = 5000):
         self.memory_entries: List[str] = []
         self.user_entries: List[str] = []
         self.memory_char_limit = memory_char_limit

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -498,8 +498,8 @@ When on, any flagged `skill_manage` write surfaces as an approval prompt with th
 memory:
   memory_enabled: true
   user_profile_enabled: true
-  memory_char_limit: 2200   # ~800 tokens
-  user_char_limit: 1375     # ~500 tokens
+  memory_char_limit: 10000  # ~3600 tokens
+  user_char_limit: 5000     # ~1800 tokens
 ```
 
 ## File Read Safety

--- a/website/docs/user-guide/features/memory.md
+++ b/website/docs/user-guide/features/memory.md
@@ -203,8 +203,8 @@ hermes sessions list    # Browse past sessions
 memory:
   memory_enabled: true
   user_profile_enabled: true
-  memory_char_limit: 2200   # ~800 tokens
-  user_char_limit: 1375     # ~500 tokens
+  memory_char_limit: 10000  # ~3600 tokens
+  user_char_limit: 5000     # ~1800 tokens
 ```
 
 ## External Memory Providers


### PR DESCRIPTION
## Summary

Increases the default `memory_char_limit` from 2200 → 10000 and `user_char_limit` from 1375 → 5000. The previous defaults were designed for minimal token usage but leave users with unusably small memory space — especially on mobile/PWA setups where the WebUI is the primary surface and character counts add up fast.

This change is motivated by real-world ARM64 mobile data (see related issue): running Hermes Agent via AVF on Android phones with constrained screen real estate makes small memory limits even more punishing. A user on a mid-range phone writing a few paragraphs of personal notes can hit the 1375-char limit in seconds.

## Changes

| File | Change |
|---|---|
| `tools/memory_tool.py:118` | `memory_char_limit` default: 2200 → 10000 |
| `agent/agent_init.py:947-948` | Fallback defaults for both limits |
| `hermes_cli/config.py:1130-1131` | Defaults + inline comments updated |
| `cli-config.yaml.example:470-471` | Example config values bumped |
| `website/docs/user-guide/configuration.md:501-502` | Documentation updated |
| `website/docs/user-guide/features/memory.md:206-207` | Feature docs updated |

## Validation

- All existing tests pass: `33/33 test_memory_tool.py`, `59/59 test_config.py`
- The limits remain user-overridable via `config.yaml` — no behavior changes for power users who have already customized them
- Tested locally with `memory_char_limit=15000` and `user_char_limit=8000` — no regressions in memory tool behavior

## Related

- Closes/References issue #2364 in nesquena/hermes-webui: "Running Hermes Agent on ARM64 mobile via AVF — real-world performance data point"
- Direct user feedback: 2200/1375 chars fills up in seconds when taking real notes via the WebUI on mobile

Signed-off-by: Keyos <espokaos@gmail.com>