### PR TITLE
fix(kanban): remove missing avoid-ai-writing skill from swarm synthesizer

### DIFF
--- a/hermes_cli/kanban_swarm.py
+++ b/hermes_cli/kanban_swarm.py
@@ -209,7 +209,7 @@ def create_swarm(
         priority=priority,
         workspace_kind=workspace_kind,
         workspace_path=workspace_path,
-        skills=["avoid-ai-writing"],
+        skills=[],
     )
 
     created = SwarmCreated(root, worker_ids, verifier, synthesizer)


### PR DESCRIPTION
## Summary

The `avoid-ai-writing` skill was hard-coded in the synthesizer task creation but is not present in the v0.14.0 skill bundle, causing every Kanban swarm synthesizer to crash with `Unknown skill(s): avoid-ai-writing` in an infinite retry loop.

## Root Cause

`hermes_cli/kanban_swarm.py:212` references `skills=["avoid-ai-writing"]` which was removed/renamed between v0.13 and v0.14.

## Fix

Remove the stale skill reference so the synthesizer spawns without requiring a non-existent skill. The synthesizer will run with no skill constraints (empty list), which is the correct behavior when the intended skill no longer exists.

## Testing

- Verified `avoid-ai-writing` is not in the current skill bundle
- Verified `writing-plans` exists as a possible intended replacement (but kept fix minimal)
- Test suite `test_kanban_swarm.py` should pass as it doesn't assert on specific skills

Fixes #29415