### PR TITLE
fix(plugins): surface reasoning_content in Langfuse assistant message (#29482)

### DIFF
--- a/plugins/observability/langfuse/__init__.py
+++ b/plugins/observability/langfuse/__init__.py
@@ -470,16 +470,34 @@ def _serialize_tool_calls(tool_calls: Any) -> list[dict[str, Any]]:
 
 
 def _serialize_assistant_message(message: Any) -> dict[str, Any]:
-    # Providers that emit chain-of-thought via the `reasoning_content`
-    # convention (LM Studio, Moonshot, Qwen3 thinking, DeepSeek) leave the
-    # top-level `reasoning` field unset and stash the text under
-    # `provider_data["reasoning_content"]`, which NormalizedResponse exposes
-    # as the `reasoning_content` property.  Read `reasoning` first to keep
-    # Anthropic / Codex behaviour unchanged, then fall back so Langfuse's
-    # observation actually shows the thinking instead of `reasoning: None`.
+    # Mirrors agent.agent_runtime_helpers.extract_reasoning so the Langfuse
+    # observation shows whichever reasoning surface the provider actually
+    # populated: top-level `reasoning` (Anthropic / Codex), `reasoning_content`
+    # (LM Studio / Moonshot / Qwen3 thinking / DeepSeek), then the
+    # `reasoning_details` array (OpenRouter's unified format, list of
+    # ``{type, summary|thinking|content|text}`` dicts).  Without the
+    # `reasoning_details` branch, OpenRouter-routed traffic still records
+    # `reasoning: None` even though the structured payload is present.
     reasoning = getattr(message, "reasoning", None)
     if not reasoning:
         reasoning = getattr(message, "reasoning_content", None)
+    if not reasoning:
+        details = getattr(message, "reasoning_details", None)
+        if isinstance(details, list):
+            parts: list[str] = []
+            for detail in details:
+                if not isinstance(detail, dict):
+                    continue
+                text = (
+                    detail.get("summary")
+                    or detail.get("thinking")
+                    or detail.get("content")
+                    or detail.get("text")
+                )
+                if isinstance(text, str) and text.strip() and text not in parts:
+                    parts.append(text)
+            if parts:
+                reasoning = "\n\n".join(parts)
     return {
         "content": _safe_value(getattr(message, "content", None)),
         "reasoning": _safe_value(reasoning),

--- a/plugins/observability/langfuse/__init__.py
+++ b/plugins/observability/langfuse/__init__.py
@@ -469,6 +469,17 @@ def _serialize_tool_calls(tool_calls: Any) -> list[dict[str, Any]]:
     return serialized
 
 
+def _reasoning_is_blank(value: Any) -> bool:
+    # Only `None` and empty/whitespace strings should trigger the fallback —
+    # never overwrite a legitimately falsy non-string payload (`0`, `False`,
+    # `{}`, `[]`) the provider may have placed in `reasoning` deliberately.
+    if value is None:
+        return True
+    if isinstance(value, str) and not value.strip():
+        return True
+    return False
+
+
 def _serialize_assistant_message(message: Any) -> dict[str, Any]:
     # Mirrors agent.agent_runtime_helpers.extract_reasoning so the Langfuse
     # observation shows whichever reasoning surface the provider actually
@@ -479,9 +490,9 @@ def _serialize_assistant_message(message: Any) -> dict[str, Any]:
     # `reasoning_details` branch, OpenRouter-routed traffic still records
     # `reasoning: None` even though the structured payload is present.
     reasoning = getattr(message, "reasoning", None)
-    if not reasoning:
+    if _reasoning_is_blank(reasoning):
         reasoning = getattr(message, "reasoning_content", None)
-    if not reasoning:
+    if _reasoning_is_blank(reasoning):
         details = getattr(message, "reasoning_details", None)
         if isinstance(details, list):
             parts: list[str] = []

--- a/plugins/observability/langfuse/__init__.py
+++ b/plugins/observability/langfuse/__init__.py
@@ -470,9 +470,19 @@ def _serialize_tool_calls(tool_calls: Any) -> list[dict[str, Any]]:
 
 
 def _serialize_assistant_message(message: Any) -> dict[str, Any]:
+    # Providers that emit chain-of-thought via the `reasoning_content`
+    # convention (LM Studio, Moonshot, Qwen3 thinking, DeepSeek) leave the
+    # top-level `reasoning` field unset and stash the text under
+    # `provider_data["reasoning_content"]`, which NormalizedResponse exposes
+    # as the `reasoning_content` property.  Read `reasoning` first to keep
+    # Anthropic / Codex behaviour unchanged, then fall back so Langfuse's
+    # observation actually shows the thinking instead of `reasoning: None`.
+    reasoning = getattr(message, "reasoning", None)
+    if not reasoning:
+        reasoning = getattr(message, "reasoning_content", None)
     return {
         "content": _safe_value(getattr(message, "content", None)),
-        "reasoning": _safe_value(getattr(message, "reasoning", None)),
+        "reasoning": _safe_value(reasoning),
         "tool_calls": _serialize_tool_calls(getattr(message, "tool_calls", None)),
     }
 

--- a/tests/plugins/test_langfuse_plugin.py
+++ b/tests/plugins/test_langfuse_plugin.py
@@ -706,11 +706,12 @@ class TestToolObservationKeying:
 
 
 class TestSerializeAssistantMessageReasoning:
-    """`_serialize_assistant_message` must surface reasoning for both the
-    top-level `reasoning` convention (Anthropic, Codex) and the
-    `reasoning_content` convention (LM Studio / Moonshot / Qwen3 thinking /
-    DeepSeek), which NormalizedResponse exposes via a property reading from
-    `provider_data["reasoning_content"]`.  Regression coverage for #29482."""
+    """`_serialize_assistant_message` must surface reasoning for the three
+    conventions ``agent.agent_runtime_helpers.extract_reasoning`` covers:
+    top-level `reasoning` (Anthropic, Codex), `reasoning_content` (LM Studio /
+    Moonshot / Qwen3 thinking / DeepSeek — exposed by NormalizedResponse via
+    `provider_data["reasoning_content"]`), and the `reasoning_details` array
+    (OpenRouter's unified format).  Regression coverage for #29482."""
 
     def _mod(self):
         sys.modules.pop("plugins.observability.langfuse", None)
@@ -786,3 +787,61 @@ class TestSerializeAssistantMessageReasoning:
 
         out = mod._serialize_assistant_message(_Msg())
         assert out["reasoning"] is None
+
+    def test_falls_back_to_reasoning_details_openrouter_unified(self):
+        """OpenRouter's unified `reasoning_details` array — keys mirror
+        ``agent.agent_runtime_helpers.extract_reasoning`` precedence
+        (``summary`` > ``thinking`` > ``content`` > ``text``).  When the
+        top-level `reasoning` / `reasoning_content` fields are unset, the
+        Langfuse observation must still surface the structured payload."""
+        mod = self._mod()
+
+        class _Msg:
+            content = "answer"
+            reasoning = None
+            reasoning_content = None
+            reasoning_details = [
+                {"type": "reasoning.summary", "summary": "first summary"},
+                {"type": "reasoning.thinking", "thinking": "deeper thought"},
+                {"type": "reasoning.text", "text": "trailing text"},
+            ]
+            tool_calls = None
+
+        out = mod._serialize_assistant_message(_Msg())
+        assert out["reasoning"] == (
+            "first summary\n\ndeeper thought\n\ntrailing text"
+        )
+
+    def test_reasoning_details_skips_non_dict_and_empty(self):
+        mod = self._mod()
+
+        class _Msg:
+            content = "answer"
+            reasoning = None
+            reasoning_content = None
+            reasoning_details = [
+                "not a dict",
+                {"type": "reasoning.summary", "summary": "   "},
+                {"type": "reasoning.summary"},  # no recognised key
+                {"type": "reasoning.summary", "summary": "kept"},
+                {"type": "reasoning.summary", "summary": "kept"},  # duplicate
+            ]
+            tool_calls = None
+
+        out = mod._serialize_assistant_message(_Msg())
+        assert out["reasoning"] == "kept"
+
+    def test_top_level_reasoning_wins_over_reasoning_details(self):
+        mod = self._mod()
+
+        class _Msg:
+            content = "answer"
+            reasoning = "top-level wins"
+            reasoning_content = None
+            reasoning_details = [
+                {"type": "reasoning.summary", "summary": "should be ignored"},
+            ]
+            tool_calls = None
+
+        out = mod._serialize_assistant_message(_Msg())
+        assert out["reasoning"] == "top-level wins"

--- a/tests/plugins/test_langfuse_plugin.py
+++ b/tests/plugins/test_langfuse_plugin.py
@@ -845,3 +845,21 @@ class TestSerializeAssistantMessageReasoning:
 
         out = mod._serialize_assistant_message(_Msg())
         assert out["reasoning"] == "top-level wins"
+
+    def test_falsy_non_string_reasoning_is_not_overwritten(self):
+        """Only ``None`` or blank strings trigger the fallback — a provider
+        that deliberately surfaces a falsy non-string structure (e.g. an
+        empty dict from a typed payload) must be preserved verbatim rather
+        than silently overwritten by ``reasoning_content``."""
+        mod = self._mod()
+
+        class _Msg:
+            content = "answer"
+            reasoning = {}  # falsy but explicitly set by provider
+            reasoning_content = "should NOT replace the empty-dict payload"
+            tool_calls = None
+
+        out = mod._serialize_assistant_message(_Msg())
+        # ``_safe_value`` serialises the empty dict; the key point is the
+        # ``reasoning_content`` fallback did not fire.
+        assert out["reasoning"] == {}

--- a/tests/plugins/test_langfuse_plugin.py
+++ b/tests/plugins/test_langfuse_plugin.py
@@ -704,3 +704,85 @@ class TestToolObservationKeying:
         assert ended["output"] == {"status": "done"}
         assert not state.tools
 
+
+class TestSerializeAssistantMessageReasoning:
+    """`_serialize_assistant_message` must surface reasoning for both the
+    top-level `reasoning` convention (Anthropic, Codex) and the
+    `reasoning_content` convention (LM Studio / Moonshot / Qwen3 thinking /
+    DeepSeek), which NormalizedResponse exposes via a property reading from
+    `provider_data["reasoning_content"]`.  Regression coverage for #29482."""
+
+    def _mod(self):
+        sys.modules.pop("plugins.observability.langfuse", None)
+        return importlib.import_module("plugins.observability.langfuse")
+
+    def test_top_level_reasoning_takes_precedence(self):
+        mod = self._mod()
+
+        class _Msg:
+            content = "answer"
+            reasoning = "top-level thinking"
+            reasoning_content = "should be ignored"
+            tool_calls = None
+
+        out = mod._serialize_assistant_message(_Msg())
+        assert out["reasoning"] == "top-level thinking"
+        assert out["content"] == "answer"
+
+    def test_falls_back_to_reasoning_content_when_reasoning_missing(self):
+        mod = self._mod()
+
+        class _Msg:
+            content = "answer"
+            reasoning = None
+            reasoning_content = "deepseek-style chain of thought"
+            tool_calls = None
+
+        out = mod._serialize_assistant_message(_Msg())
+        assert out["reasoning"] == "deepseek-style chain of thought"
+
+    def test_falls_back_to_reasoning_content_when_reasoning_empty_string(self):
+        mod = self._mod()
+
+        class _Msg:
+            content = "answer"
+            reasoning = ""
+            reasoning_content = "qwen3 thinking"
+            tool_calls = None
+
+        out = mod._serialize_assistant_message(_Msg())
+        assert out["reasoning"] == "qwen3 thinking"
+
+    def test_reads_reasoning_content_from_normalized_response_provider_data(self):
+        """Use the real NormalizedResponse — the production code path that
+        the issue reporter hits (transport stores reasoning_content on
+        provider_data, the property surfaces it)."""
+        mod = self._mod()
+        from agent.transports.types import NormalizedResponse
+
+        resp = NormalizedResponse(
+            content="final answer",
+            tool_calls=None,
+            finish_reason="stop",
+            provider_data={"reasoning_content": "lm-studio chain of thought"},
+        )
+
+        # Sanity check: top-level `reasoning` is None, the property surfaces
+        # the provider_data field as documented in transports/types.py:115.
+        assert resp.reasoning is None
+        assert resp.reasoning_content == "lm-studio chain of thought"
+
+        out = mod._serialize_assistant_message(resp)
+        assert out["reasoning"] == "lm-studio chain of thought"
+        assert out["content"] == "final answer"
+
+    def test_returns_none_when_both_missing(self):
+        mod = self._mod()
+
+        class _Msg:
+            content = "answer"
+            tool_calls = None
+            # No reasoning, no reasoning_content.
+
+        out = mod._serialize_assistant_message(_Msg())
+        assert out["reasoning"] is None


### PR DESCRIPTION
## What does this PR do?

The bundled `observability/langfuse` plugin's `_serialize_assistant_message` reads only the top-level `reasoning` attribute, so providers that emit chain-of-thought via the `reasoning_content` convention (LM Studio, Moonshot, Qwen3 thinking, DeepSeek) silently lose their reasoning in Langfuse observations even though Hermes captures it correctly. Every `LLM call N` shows `reasoning: None` for these providers.

Root cause: `NormalizedResponse` (`agent/transports/types.py`) stores the reasoning text in `provider_data["reasoning_content"]` and exposes it via the `reasoning_content` property (line 115). The serializer never reads that property — only the top-level `reasoning` field. Fall back to `reasoning_content` when `reasoning` is empty/missing so the property is read on the production code path the issue reporter hits.

Mirrors the existing reasoning resolution shape used downstream — top-level `reasoning` (Anthropic / Codex) wins when set, `reasoning_content` (OpenAI-compatible `reasoning_content` convention) fills in for the providers that use it.

> Audited siblings: the other two output-construction sites in the same hook (`post_llm_call` string path at line 828, `post_api_request` summary path at line 833) do not receive an assistant message object and hardcode `reasoning: None`. No widening needed in this PR.

## Related Issue

Fixes #29482

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `plugins/observability/langfuse/__init__.py` — `_serialize_assistant_message` falls back to `getattr(message, "reasoning_content", None)` when the top-level `reasoning` is empty. Comment explains the two reasoning conventions.
- `tests/plugins/test_langfuse_plugin.py` — new `TestSerializeAssistantMessageReasoning` class with 5 cases: top-level precedence, fallback when `reasoning is None`, fallback when `reasoning == ""`, end-to-end via real `NormalizedResponse(provider_data={"reasoning_content": ...})`, and both-missing returns `None`.

## How to Test

1. `uv run --with pytest --with pytest-xdist --with pytest-asyncio --with pytest-timeout python3 -m pytest tests/plugins/test_langfuse_plugin.py::TestSerializeAssistantMessageReasoning -v`
2. Full file regression: `uv run --with pytest --with pytest-xdist --with pytest-asyncio --with pytest-timeout python3 -m pytest tests/plugins/test_langfuse_plugin.py -v` → 42 passed.
3. Regression guard: reverting only the production change makes the 3 fallback tests fail with `AssertionError: assert '' == 'qwen3 thinking'` (and similar); restoring it makes them pass — confirming the tests actually exercise the new behavior.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(plugins):`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run focused tests for the touched code and all pass (42/42 in the langfuse file)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15.x

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (internal serializer)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — N/A (pure-Python serializer, no platform paths)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Before (current `main`):
```
# Langfuse "LLM call N" observation, LM Studio + Qwen3 thinking
output:
  content: "final answer …"
  reasoning: None     # ← lost
  tool_calls: [...]
```

After this PR:
```
output:
  content: "final answer …"
  reasoning: "the model's chain of thought …"   # ← surfaced
  tool_calls: [...]
```