### PR TITLE
feat(web): route GitHub and X URLs in web_extract

### DIFF
--- a/tests/tools/test_web_extract_routing.py
+++ b/tests/tools/test_web_extract_routing.py
@@ -1,0 +1,365 @@
+import json
+
+import httpx
+import pytest
+
+
+async def _always_safe_url(_url: str) -> bool:
+    return True
+
+
+ROUTING_PATCHES = {
+    "_get_extract_backend": lambda: "fake",
+    "check_website_access": lambda url: None,
+    "_ensure_web_plugins_loaded": lambda: None,
+}
+
+
+def patch_web_extract_dependencies(monkeypatch, web_tools, provider=None):
+    for name, value in ROUTING_PATCHES.items():
+        monkeypatch.setattr(web_tools, name, value)
+    monkeypatch.setattr(web_tools, "async_is_safe_url", _always_safe_url)
+    monkeypatch.setattr("tools.interrupt.is_interrupted", lambda: False)
+    if provider is not None:
+        monkeypatch.setattr("agent.web_search_registry.get_provider", lambda name: provider)
+        monkeypatch.setattr(
+            "agent.web_search_registry.get_active_extract_provider",
+            lambda: provider,
+        )
+
+
+def patch_direct_fetch(
+    monkeypatch,
+    web_tools,
+    body,
+    content_type="text/plain; charset=utf-8",
+):
+    def fake_direct_fetch(url, timeout=20):
+        return body, content_type, url
+
+    monkeypatch.setattr(web_tools, "_direct_fetch_text", fake_direct_fetch)
+
+
+class FakeStreamResponse:
+    def __init__(
+        self,
+        url,
+        body="",
+        status_code=200,
+        headers=None,
+        content_type="text/plain; charset=utf-8",
+    ):
+        self.url = httpx.URL(url)
+        self.status_code = status_code
+        self.headers = {"content-type": content_type, **(headers or {})}
+        self.encoding = "utf-8"
+        self._body = body.encode()
+        self.is_redirect = status_code in {301, 302, 303, 307, 308}
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, traceback):
+        return False
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise httpx.HTTPStatusError(
+                "error",
+                request=httpx.Request("GET", self.url),
+                response=httpx.Response(
+                    self.status_code,
+                    request=httpx.Request("GET", self.url),
+                ),
+            )
+
+    def iter_bytes(self):
+        yield self._body
+
+
+def patch_stream_sequence(monkeypatch, web_tools, responses):
+    calls = []
+    queue = list(responses)
+
+    def fake_stream(method, url, **kwargs):
+        calls.append((url, kwargs))
+        if not queue:
+            pytest.fail(f"unexpected stream call for {url}")
+        return queue.pop(0)
+
+    monkeypatch.setattr(web_tools.httpx, "stream", fake_stream)
+    return calls
+
+
+class FakeExtractProvider:
+    name = "fake"
+    display_name = "Fake"
+
+    def __init__(self, results=None):
+        self.calls = []
+        self.results = results or []
+
+    def supports_extract(self):
+        return True
+
+    def extract(self, urls, **kwargs):
+        self.calls.append((urls, kwargs))
+        return self.results
+
+
+@pytest.mark.asyncio
+async def test_web_extract_routes_github_blob_to_raw(monkeypatch):
+    from tools import web_tools
+
+    provider = FakeExtractProvider()
+    patch_web_extract_dependencies(monkeypatch, web_tools, provider)
+
+    calls = []
+
+    def fake_direct_fetch(url, timeout=20):
+        calls.append(url)
+        return "# Hello from raw github\n", "text/plain; charset=utf-8", url
+
+    monkeypatch.setattr(web_tools, "_direct_fetch_text", fake_direct_fetch)
+
+    result = json.loads(
+        await web_tools.web_extract_tool(
+            ["https://github.com/octo/repo/blob/main/README.md"],
+        )
+    )
+
+    assert calls == ["https://raw.githubusercontent.com/octo/repo/main/README.md"]
+    entry = result["results"][0]
+    assert entry["content"] == "# Hello from raw github\n"
+    assert entry["url"] == "https://raw.githubusercontent.com/octo/repo/main/README.md"
+    assert entry["title"] == "README.md"
+    assert provider.calls == []
+
+
+@pytest.mark.asyncio
+async def test_web_extract_uses_github_raw_link_when_ref_contains_slashes(monkeypatch):
+    from tools import web_tools
+
+    provider = FakeExtractProvider()
+    patch_web_extract_dependencies(monkeypatch, web_tools, provider)
+
+    calls = []
+
+    def fake_direct_fetch(url, timeout=20):
+        calls.append(url)
+        if url == "https://raw.githubusercontent.com/octo/repo/feature/foo/README.md":
+            raise httpx.HTTPStatusError(
+                "not found",
+                request=httpx.Request("GET", url),
+                response=httpx.Response(404),
+            )
+        if url == "https://github.com/octo/repo/blob/feature/foo/README.md":
+            return (
+                '<a id="raw-url" href="/octo/repo/raw/refs/heads/feature/foo/README.md">Raw</a>',
+                "text/html; charset=utf-8",
+                url,
+            )
+        return "# Feature branch README\n", "text/plain; charset=utf-8", url
+
+    monkeypatch.setattr(web_tools, "_direct_fetch_text", fake_direct_fetch)
+
+    result = json.loads(
+        await web_tools.web_extract_tool(
+            ["https://github.com/octo/repo/blob/feature/foo/README.md"],
+        )
+    )
+
+    assert calls == [
+        "https://raw.githubusercontent.com/octo/repo/feature/foo/README.md",
+        "https://github.com/octo/repo/blob/feature/foo/README.md",
+        "https://raw.githubusercontent.com/octo/repo/refs/heads/feature/foo/README.md",
+    ]
+    assert result["results"][0]["content"] == "# Feature branch README\n"
+    assert provider.calls == []
+
+
+@pytest.mark.asyncio
+async def test_web_extract_routed_only_urls_skip_provider_dispatch(monkeypatch):
+    from tools import web_tools
+
+    patch_web_extract_dependencies(monkeypatch, web_tools)
+    monkeypatch.setattr(
+        "agent.web_search_registry.get_provider",
+        lambda name: pytest.fail("provider lookup should not run for routed-only URLs"),
+    )
+
+    patch_direct_fetch(monkeypatch, web_tools, "# Hello from raw github\n")
+
+    result = json.loads(
+        await web_tools.web_extract_tool(
+            ["https://github.com/octo/repo/blob/main/README.md"],
+        )
+    )
+
+    assert result["results"][0]["url"] == (
+        "https://raw.githubusercontent.com/octo/repo/main/README.md"
+    )
+
+
+@pytest.mark.asyncio
+async def test_web_extract_routes_x_status_to_raw_html_fallback(monkeypatch):
+    from tools import web_tools
+
+    provider = FakeExtractProvider()
+    patch_web_extract_dependencies(monkeypatch, web_tools, provider)
+
+    html_doc = r'''
+    <html>
+      <head>
+        <meta property="og:title" content="helicerat (@helicerat0x)">
+        <meta property="og:description" content="linked article preview text">
+      </head>
+      <body>
+        <script>
+          window.__DATA__ = {"full_text":"https://t.co/rwV6oYg5Rd","expanded_url":"https:\/\/x.com\/i\/article\/2053497254510460928"};
+        </script>
+      </body>
+    </html>
+    '''
+
+    patch_direct_fetch(monkeypatch, web_tools, html_doc, "text/html; charset=utf-8")
+
+    result = json.loads(
+        await web_tools.web_extract_tool(
+            ["https://x.com/helicerat0x/status/2054223640573493523"],
+        )
+    )
+
+    entry = result["results"][0]
+    assert entry["title"] == "helicerat (@helicerat0x)"
+    assert "Author: @helicerat0x" in entry["content"]
+    assert "Tweet ID: 2054223640573493523" in entry["content"]
+    assert "Linked article: https://x.com/i/article/2053497254510460928" in entry["content"]
+    assert provider.calls == []
+
+
+@pytest.mark.asyncio
+async def test_web_extract_uses_provider_for_general_urls(monkeypatch):
+    from tools import web_tools
+
+    provider = FakeExtractProvider([
+        {
+            "url": "https://example.com",
+            "title": "Example Domain",
+            "content": "Example Domain body",
+            "raw_content": "Example Domain body",
+        }
+    ])
+    patch_web_extract_dependencies(monkeypatch, web_tools, provider)
+    monkeypatch.setattr(
+        web_tools,
+        "_direct_fetch_text",
+        lambda *a, **k: pytest.fail("direct fetch should not run for general URLs"),
+    )
+
+    result = json.loads(
+        await web_tools.web_extract_tool(
+            ["https://example.com"],
+        )
+    )
+
+    entry = result["results"][0]
+    assert entry["url"] == "https://example.com"
+    assert entry["title"] == "Example Domain"
+    assert entry["content"] == "Example Domain body"
+    assert provider.calls == [(["https://example.com"], {"format": None})]
+
+
+@pytest.mark.asyncio
+async def test_web_extract_preserves_input_order_with_routed_and_generic_urls(monkeypatch):
+    from tools import web_tools
+
+    provider = FakeExtractProvider([
+        {
+            "url": "https://example.com",
+            "title": "Example Domain",
+            "content": "Example Domain body",
+            "raw_content": "Example Domain body",
+        }
+    ])
+    patch_web_extract_dependencies(monkeypatch, web_tools, provider)
+
+    patch_direct_fetch(monkeypatch, web_tools, "# Hello from raw github\n")
+
+    result = json.loads(
+        await web_tools.web_extract_tool(
+            [
+                "https://example.com",
+                "https://github.com/octo/repo/blob/main/README.md",
+            ],
+        )
+    )
+
+    urls = [entry["url"] for entry in result["results"]]
+    assert urls == [
+        "https://example.com",
+        "https://raw.githubusercontent.com/octo/repo/main/README.md",
+    ]
+    assert provider.calls == [(["https://example.com"], {"format": None})]
+
+
+@pytest.mark.asyncio
+async def test_web_extract_drops_extra_provider_results(monkeypatch):
+    from tools import web_tools
+
+    provider = FakeExtractProvider([
+        {
+            "url": "https://example.com",
+            "title": "Example Domain",
+            "content": "Example Domain body",
+            "raw_content": "Example Domain body",
+        },
+        {
+            "url": "https://extra.example.com",
+            "title": "Unexpected",
+            "content": "Unexpected extra result",
+            "raw_content": "Unexpected extra result",
+        },
+    ])
+    patch_web_extract_dependencies(monkeypatch, web_tools, provider)
+
+    result = json.loads(
+        await web_tools.web_extract_tool(
+            ["https://example.com"],
+        )
+    )
+
+    assert [entry["url"] for entry in result["results"]] == ["https://example.com"]
+
+
+@pytest.mark.asyncio
+async def test_direct_fetch_validates_redirect_targets(monkeypatch):
+    from tools import web_tools
+
+    patch_web_extract_dependencies(monkeypatch, web_tools)
+    monkeypatch.setattr(
+        web_tools,
+        "is_safe_url",
+        lambda url: not url.startswith("http://127.0.0.1"),
+    )
+    calls = patch_stream_sequence(
+        monkeypatch,
+        web_tools,
+        [
+            FakeStreamResponse(
+                "https://example.com/README.md",
+                status_code=302,
+                headers={"location": "http://127.0.0.1/private"},
+            ),
+        ],
+    )
+
+    result = json.loads(
+        await web_tools.web_extract_tool(
+            ["https://example.com/README.md"],
+        )
+    )
+
+    assert len(calls) == 1
+    assert result["results"][0]["url"] == "http://127.0.0.1/private"
+    assert "private or internal" in result["results"][0]["error"]

--- a/tests/tools/test_web_extract_routing.py
+++ b/tests/tools/test_web_extract_routing.py
@@ -1,0 +1,579 @@
+"""Regression coverage for direct web_extract routes."""
+
+import asyncio
+import json
+import threading
+
+import httpx
+import pytest
+
+from tools import web_tools
+
+
+class _StreamResponse:
+    def __init__(
+        self,
+        url: str,
+        body: str = "",
+        *,
+        headers: dict[str, str] | None = None,
+        is_redirect: bool = False,
+        status_code: int = 200,
+    ) -> None:
+        self.url = httpx.URL(url)
+        self.headers = {"content-type": "text/plain; charset=utf-8", **(headers or {})}
+        self.encoding = "utf-8"
+        self.is_redirect = is_redirect
+        self.status_code = status_code
+        self._body = body.encode()
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            raise httpx.HTTPStatusError(
+                "error",
+                request=httpx.Request("GET", self.url),
+                response=httpx.Response(self.status_code),
+            )
+
+    def iter_bytes(self):
+        yield self._body
+
+
+class _SafeClient:
+    def __init__(
+        self, responses: list[_StreamResponse], seen: list[tuple[str, str, dict]]
+    ) -> None:
+        self.responses = responses
+        self.seen = seen
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, traceback):
+        return False
+
+    def stream(self, method: str, url: str, **kwargs):
+        self.seen.append((method, url, kwargs))
+        return _StreamContext(self.responses.pop(0))
+
+
+class _StreamContext:
+    def __init__(self, response: _StreamResponse) -> None:
+        self.response = response
+
+    def __enter__(self):
+        return self.response
+
+    def __exit__(self, exc_type, exc, traceback):
+        return False
+
+
+def _dispatch_extract(urls: list[str]) -> dict:
+    raw = web_tools.registry.dispatch("web_extract", {"urls": urls})
+    assert isinstance(raw, str)
+    return json.loads(raw)
+
+
+def test_web_extract_registry_routes_github_blob_without_provider(monkeypatch):
+    """A public GitHub file uses raw.githubusercontent.com without a web backend."""
+    requested = "https://github.com/octo/repo/blob/main/README.md"
+    raw_url = "https://raw.githubusercontent.com/octo/repo/main/README.md"
+    seen = []
+
+    page = _StreamResponse(
+        requested,
+        '<a id="raw-url" href="/octo/repo/raw/main/README.md">Raw</a>',
+    )
+    response = _StreamResponse(raw_url, "# Raw README\n")
+    responses = [page, response]
+
+    def fake_safe_client(**_kwargs):
+        return _SafeClient(responses, seen)
+
+    async def safe_url(_url):
+        return True
+
+    monkeypatch.setattr("tools.url_safety.create_ssrf_safe_client", fake_safe_client)
+    monkeypatch.setattr(web_tools, "async_is_safe_url", safe_url)
+    monkeypatch.setattr(
+        web_tools,
+        "_get_extract_backend",
+        lambda: pytest.fail("direct GitHub routing must not resolve a web provider"),
+    )
+
+    result = _dispatch_extract([requested])
+
+    assert [call[1] for call in seen] == [requested, raw_url]
+    assert result["results"] == [
+        {
+            "url": raw_url,
+            "title": "README.md",
+            "content": "# Raw README\n",
+            "error": None,
+        }
+    ]
+
+
+def test_web_extract_routes_github_raw_path_without_reconstructing_the_ref(monkeypatch):
+    """A GitHub raw URL is fetched as supplied, so slash refs stay unambiguous."""
+    requested = "https://github.com/octo/repo/raw/feature/foo/README.md"
+    seen = []
+
+    def fake_safe_client(**_kwargs):
+        return _SafeClient([_StreamResponse(requested, "# Raw README\n")], seen)
+
+    async def safe_url(_url):
+        return True
+
+    monkeypatch.setattr("tools.url_safety.create_ssrf_safe_client", fake_safe_client)
+    monkeypatch.setattr(web_tools, "async_is_safe_url", safe_url)
+    monkeypatch.setattr(
+        web_tools,
+        "_get_extract_backend",
+        lambda: pytest.fail("direct GitHub routing must not resolve a web provider"),
+    )
+
+    result = _dispatch_extract([requested])
+
+    assert [call[1] for call in seen] == [requested]
+    assert result["results"][0]["content"] == "# Raw README\n"
+
+
+def test_web_extract_blocks_github_source_matched_by_website_policy(monkeypatch):
+    """A source-host block stops routing before GitHub's raw host is requested."""
+    requested = "https://github.com/octo/repo/blob/main/README.md"
+    seen = []
+
+    def website_policy(url):
+        if url == requested:
+            return {
+                "host": "github.com",
+                "rule": "github.com",
+                "source": "config",
+                "message": "Blocked by website policy: 'github.com' matched rule 'github.com' from config",
+            }
+        return None
+
+    def fake_safe_client(**_kwargs):
+        return _SafeClient([], seen)
+
+    async def safe_url(_url):
+        return True
+
+    monkeypatch.setattr("tools.website_policy.check_website_access", website_policy)
+    monkeypatch.setattr("tools.url_safety.create_ssrf_safe_client", fake_safe_client)
+    monkeypatch.setattr(web_tools, "async_is_safe_url", safe_url)
+    monkeypatch.setattr(
+        web_tools,
+        "_get_extract_backend",
+        lambda: pytest.fail(
+            "a policy-blocked source URL must not fall through to a provider"
+        ),
+    )
+
+    result = _dispatch_extract([requested])
+
+    assert seen == []
+    assert result["results"] == [
+        {
+            "url": requested,
+            "title": "",
+            "content": "",
+            "error": "Blocked by website policy: 'github.com' matched rule 'github.com' from config",
+        }
+    ]
+
+
+def test_web_extract_blocks_github_redirect_matched_by_website_policy(monkeypatch):
+    """Direct routing must not let a GitHub redirect bypass the website blocklist."""
+    requested = "https://github.com/octo/repo/blob/main/README.md"
+    blocked_url = "https://blocked.example/private"
+    seen = []
+
+    response = _StreamResponse(
+        requested, headers={"location": blocked_url}, is_redirect=True
+    )
+
+    def fake_safe_client(**_kwargs):
+        return _SafeClient([response], seen)
+
+    def website_policy(url):
+        if url == blocked_url:
+            return {
+                "host": "blocked.example",
+                "rule": "blocked.example",
+                "source": "config",
+                "message": "Blocked by website policy: 'blocked.example' matched rule 'blocked.example' from config",
+            }
+        return None
+
+    async def safe_url(_url):
+        return True
+
+    monkeypatch.setattr("tools.url_safety.create_ssrf_safe_client", fake_safe_client)
+    monkeypatch.setattr("tools.website_policy.check_website_access", website_policy)
+    monkeypatch.setattr(web_tools, "async_is_safe_url", safe_url)
+    monkeypatch.setattr(
+        web_tools,
+        "_get_extract_backend",
+        lambda: pytest.fail(
+            "blocked direct routing must not fall through to a provider"
+        ),
+    )
+
+    result = _dispatch_extract([requested])
+
+    assert seen[0][0:2] == ("GET", requested)
+    assert result["results"] == [
+        {
+            "url": blocked_url,
+            "title": "",
+            "content": "",
+            "error": "Blocked by website policy: 'blocked.example' matched rule 'blocked.example' from config",
+        }
+    ]
+
+
+def test_web_extract_blocks_github_redirect_to_ssrf_target(monkeypatch):
+    """A redirect into an internal address is blocked instead of reaching the provider."""
+    from tools.url_safety import SSRFConnectionBlocked
+
+    requested = "https://github.com/octo/repo/blob/main/README.md"
+    blocked_url = "http://127.0.0.1/private"
+    seen = []
+
+    class RedirectingClient:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, traceback):
+            return False
+
+        def stream(self, method, url, **_kwargs):
+            seen.append((method, url))
+            if url == blocked_url:
+                raise SSRFConnectionBlocked("blocked at connect time")
+            return _StreamContext(
+                _StreamResponse(
+                    requested, headers={"location": blocked_url}, is_redirect=True
+                )
+            )
+
+    async def safe_url(_url):
+        return True
+
+    monkeypatch.setattr(
+        "tools.url_safety.create_ssrf_safe_client",
+        lambda **_kwargs: RedirectingClient(),
+    )
+    monkeypatch.setattr(web_tools, "async_is_safe_url", safe_url)
+    monkeypatch.setattr(
+        web_tools,
+        "_get_extract_backend",
+        lambda: pytest.fail(
+            "an SSRF-blocked redirect must not fall through to a provider"
+        ),
+    )
+
+    result = _dispatch_extract([requested])
+
+    assert seen == [("GET", requested), ("GET", blocked_url)]
+    assert result["results"] == [
+        {
+            "url": blocked_url,
+            "title": "",
+            "content": "",
+            "error": "Blocked: URL targets a private or internal network address",
+        }
+    ]
+
+
+def test_web_extract_registry_routes_x_status_without_provider(monkeypatch):
+    """A public X status uses its public HTML instead of requiring an extract backend."""
+    requested = "https://x.com/alice/status/1234567890"
+    seen = []
+    document = r"""
+    <html><head>
+      <meta property="og:title" content="Alice (@alice)">
+      <meta property="og:description" content="fallback description">
+    </head><body>
+      <script>window.__DATA__ = {"full_text":"hello from x","expanded_url":"https:\/\/x.com\/i\/article\/42"};</script>
+    </body></html>
+    """
+
+    def fake_safe_client(**_kwargs):
+        return _SafeClient([_StreamResponse(requested, document)], seen)
+
+    async def safe_url(_url):
+        return True
+
+    monkeypatch.setattr("tools.url_safety.create_ssrf_safe_client", fake_safe_client)
+    monkeypatch.setattr(web_tools, "async_is_safe_url", safe_url)
+    monkeypatch.setattr(
+        web_tools,
+        "_get_extract_backend",
+        lambda: pytest.fail("direct X routing must not resolve a web provider"),
+    )
+
+    result = _dispatch_extract([requested])
+
+    assert seen[0][0:2] == ("GET", requested)
+    entry = result["results"][0]
+    assert entry["url"] == requested
+    assert entry["title"] == "Alice (@alice)"
+    assert "Author: @alice" in entry["content"]
+    assert "Tweet ID: 1234567890" in entry["content"]
+    assert "Text: hello from x" in entry["content"]
+    assert "Linked article: https://x.com/i/article/42" in entry["content"]
+
+
+def test_web_extract_falls_back_to_provider_when_x_direct_fetch_fails(monkeypatch):
+    """A transient X route failure keeps the URL eligible for provider extraction."""
+    requested = "https://x.com/alice/status/1234567890"
+    seen = []
+
+    class Provider:
+        name = "fake"
+
+        async def extract(self, urls, **_kwargs):
+            assert urls == [requested]
+            return [
+                {"url": requested, "title": "Fallback", "content": "provider content"}
+            ]
+
+    def fake_safe_client(**_kwargs):
+        return _SafeClient([_StreamResponse(requested, status_code=503)], seen)
+
+    async def safe_url(_url):
+        return True
+
+    monkeypatch.setattr("tools.url_safety.create_ssrf_safe_client", fake_safe_client)
+    monkeypatch.setattr(web_tools, "async_is_safe_url", safe_url)
+    monkeypatch.setattr(web_tools, "_get_extract_backend", lambda: "fake")
+    monkeypatch.setattr(web_tools, "_ensure_web_plugins_loaded", lambda: None)
+    monkeypatch.setattr(
+        web_tools, "_resolve_extract_provider", lambda _backend: (Provider(), None)
+    )
+
+    result = _dispatch_extract([requested])
+
+    assert [call[1] for call in seen] == [requested]
+    assert result["results"][0]["content"] == "provider content"
+
+
+def test_web_extract_uses_github_raw_link_for_refs_with_slashes(monkeypatch):
+    """GitHub's raw href disambiguates a branch name containing slashes."""
+    requested = "https://github.com/octo/repo/blob/feature/foo/README.md"
+    guessed_raw = "https://raw.githubusercontent.com/octo/repo/feature/foo/README.md"
+    page_url = requested
+    resolved_raw = (
+        "https://raw.githubusercontent.com/octo/repo/refs/heads/feature/foo/README.md"
+    )
+    seen = []
+    responses = [
+        _StreamResponse(
+            page_url,
+            '<a id="raw-url" href="/octo/repo/raw/refs/heads/feature/foo/README.md">Raw</a>',
+        ),
+        _StreamResponse(resolved_raw, "# Feature branch README\n"),
+    ]
+
+    def fake_safe_client(**_kwargs):
+        return _SafeClient(responses, seen)
+
+    async def safe_url(_url):
+        return True
+
+    monkeypatch.setattr("tools.url_safety.create_ssrf_safe_client", fake_safe_client)
+    monkeypatch.setattr(web_tools, "async_is_safe_url", safe_url)
+    monkeypatch.setattr(
+        web_tools,
+        "_get_extract_backend",
+        lambda: pytest.fail("direct GitHub routing must not resolve a web provider"),
+    )
+
+    result = _dispatch_extract([requested])
+
+    assert [call[1] for call in seen] == [page_url, resolved_raw]
+    assert guessed_raw not in [call[1] for call in seen]
+    assert result["results"][0]["url"] == resolved_raw
+    assert result["results"][0]["content"] == "# Feature branch README\n"
+
+
+def test_web_extract_falls_back_to_provider_when_github_direct_fetch_fails(monkeypatch):
+    """A transient direct-route failure preserves the normal extract backend fallback."""
+    requested = "https://github.com/octo/repo/blob/main/README.md"
+    seen = []
+
+    class Provider:
+        name = "fake"
+
+        async def extract(self, urls, **_kwargs):
+            assert urls == [requested]
+            return [
+                {"url": requested, "title": "Fallback", "content": "provider content"}
+            ]
+
+    def fake_safe_client(**_kwargs):
+        return _SafeClient([_StreamResponse(requested, status_code=503)], seen)
+
+    async def safe_url(_url):
+        return True
+
+    monkeypatch.setattr("tools.url_safety.create_ssrf_safe_client", fake_safe_client)
+    monkeypatch.setattr(web_tools, "async_is_safe_url", safe_url)
+    monkeypatch.setattr(web_tools, "_get_extract_backend", lambda: "fake")
+    monkeypatch.setattr(web_tools, "_ensure_web_plugins_loaded", lambda: None)
+    monkeypatch.setattr(
+        web_tools, "_resolve_extract_provider", lambda _backend: (Provider(), None)
+    )
+
+    result = _dispatch_extract([requested])
+
+    assert [call[1] for call in seen] == [requested]
+    assert result["results"][0]["content"] == "provider content"
+
+
+def test_web_extract_preserves_input_order_between_direct_and_provider_routes(
+    monkeypatch,
+):
+    """Provider output and direct-route output are merged at their original input positions."""
+    direct_url = "https://github.com/octo/repo/blob/main/README.md"
+    raw_url = "https://raw.githubusercontent.com/octo/repo/main/README.md"
+    generic_url = "https://example.com/page"
+    seen = []
+
+    class Provider:
+        name = "fake"
+
+        async def extract(self, urls, **_kwargs):
+            assert urls == [generic_url]
+            return [
+                {"url": generic_url, "title": "Generic", "content": "provider content"}
+            ]
+
+    responses = [
+        _StreamResponse(
+            direct_url,
+            '<a id="raw-url" href="/octo/repo/raw/main/README.md">Raw</a>',
+        ),
+        _StreamResponse(raw_url, "# Raw README\n"),
+    ]
+
+    def fake_safe_client(**_kwargs):
+        return _SafeClient(responses, seen)
+
+    async def safe_url(_url):
+        return True
+
+    monkeypatch.setattr("tools.url_safety.create_ssrf_safe_client", fake_safe_client)
+    monkeypatch.setattr(web_tools, "async_is_safe_url", safe_url)
+    monkeypatch.setattr(web_tools, "_get_extract_backend", lambda: "fake")
+    monkeypatch.setattr(web_tools, "_ensure_web_plugins_loaded", lambda: None)
+    monkeypatch.setattr(
+        web_tools, "_resolve_extract_provider", lambda _backend: (Provider(), None)
+    )
+
+    result = _dispatch_extract([direct_url, generic_url])
+
+    assert [call[1] for call in seen] == [direct_url, raw_url]
+    assert [entry["url"] for entry in result["results"]] == [raw_url, generic_url]
+    assert [entry["content"] for entry in result["results"]] == [
+        "# Raw README\n",
+        "provider content",
+    ]
+
+
+def test_web_extract_blocks_direct_route_when_safe_client_rejects_target(monkeypatch):
+    """A connection-time SSRF rejection is returned as blocked, never retried through a provider."""
+    from tools.url_safety import SSRFConnectionBlocked
+
+    requested = "https://github.com/octo/repo/blob/main/README.md"
+    seen = []
+
+    class BlockedClient:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, traceback):
+            return False
+
+        def stream(self, method, url, **_kwargs):
+            seen.append((method, url))
+            raise SSRFConnectionBlocked("blocked at connect time")
+
+    async def safe_url(_url):
+        return True
+
+    monkeypatch.setattr(
+        "tools.url_safety.create_ssrf_safe_client", lambda **_kwargs: BlockedClient()
+    )
+    monkeypatch.setattr(web_tools, "async_is_safe_url", safe_url)
+    monkeypatch.setattr(
+        web_tools,
+        "_get_extract_backend",
+        lambda: pytest.fail(
+            "SSRF-blocked direct routing must not fall through to a provider"
+        ),
+    )
+
+    result = _dispatch_extract([requested])
+
+    assert seen == [("GET", requested)]
+    assert result["results"] == [
+        {
+            "url": requested,
+            "title": "",
+            "content": "",
+            "error": "Blocked: URL targets a private or internal network address",
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_web_extract_special_routing_does_not_block_the_event_loop(monkeypatch):
+    """Direct fetch runs in a worker so the event loop can release a blocked request."""
+    routed_url = "https://raw.githubusercontent.com/octo/repo/main/README.md"
+    thread_started = threading.Event()
+    release_direct_route = threading.Event()
+
+    async def safe_url(_url):
+        return True
+
+    def blocking_direct_route(_url, *, format=None):
+        thread_started.set()
+        assert release_direct_route.wait(timeout=2)
+        return {
+            "url": routed_url,
+            "title": "README.md",
+            "content": "# Raw README\n",
+            "raw_content": "# Raw README\n",
+            "error": None,
+        }
+
+    monkeypatch.setattr(web_tools, "async_is_safe_url", safe_url)
+    monkeypatch.setattr(web_tools, "extract_special_url", blocking_direct_route)
+
+    task = asyncio.create_task(web_tools.web_extract_tool([routed_url]))
+    assert await asyncio.to_thread(thread_started.wait, 2)
+    assert not task.done()
+    release_direct_route.set()
+
+    result = json.loads(await task)
+    assert result["results"][0]["content"] == "# Raw README\n"
+
+
+def test_web_extract_registry_gate_keeps_direct_routes_available_without_provider(
+    monkeypatch,
+):
+    """Direct GitHub/X extraction stays discoverable even when no vendor backend is configured."""
+    monkeypatch.setattr(web_tools, "check_web_api_key", lambda: False)
+
+    assert web_tools.check_web_extract_available()
+    entry = web_tools.registry.get_entry("web_extract")
+    assert entry is not None
+    assert entry.check_fn is web_tools.check_web_extract_available
+    assert [
+        item["function"]["name"]
+        for item in web_tools.registry.get_definitions({"web_extract"})
+    ] == ["web_extract"]

--- a/tests/tools/test_web_extract_routing.py
+++ b/tests/tools/test_web_extract_routing.py
@@ -114,13 +114,27 @@ def test_web_extract_registry_routes_github_blob_without_provider(monkeypatch):
     ]
 
 
-def test_web_extract_routes_github_raw_path_without_reconstructing_the_ref(monkeypatch):
-    """A GitHub raw URL is fetched as supplied, so slash refs stay unambiguous."""
+def test_web_extract_follows_github_raw_path_redirect_without_provider_fallback(
+    monkeypatch,
+):
+    """A GitHub raw view redirects to raw content without reparsing it as HTML."""
     requested = "https://github.com/octo/repo/raw/feature/foo/README.md"
+    raw_url = "https://raw.githubusercontent.com/octo/repo/feature/foo/README.md"
     seen = []
 
     def fake_safe_client(**_kwargs):
-        return _SafeClient([_StreamResponse(requested, "# Raw README\n")], seen)
+        return _SafeClient(
+            [
+                _StreamResponse(
+                    requested,
+                    headers={"location": raw_url},
+                    is_redirect=True,
+                    status_code=302,
+                ),
+                _StreamResponse(raw_url, "# Raw README\n"),
+            ],
+            seen,
+        )
 
     async def safe_url(_url):
         return True
@@ -135,7 +149,8 @@ def test_web_extract_routes_github_raw_path_without_reconstructing_the_ref(monke
 
     result = _dispatch_extract([requested])
 
-    assert [call[1] for call in seen] == [requested]
+    assert [call[1] for call in seen] == [requested, raw_url]
+    assert result["results"][0]["url"] == raw_url
     assert result["results"][0]["content"] == "# Raw README\n"
 
 

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -36,11 +36,13 @@ Usage:
     content = web_extract_tool(["https://example.com"], format="markdown")
 """
 
+import asyncio
+import html
 import json
 import logging
 import os
 import re
-import asyncio
+from urllib.parse import urljoin, urlparse
 from typing import List, Dict, Any, Optional, TYPE_CHECKING
 import httpx  # noqa: F401 — kept at module top so tests can patch tools.web_tools.httpx
 # After the web-provider plugin migration (PR #25182), the Firecrawl SDK
@@ -97,7 +99,13 @@ from tools.tool_backend_helpers import (  # noqa: F401
     nous_tool_gateway_unavailable_message,
     prefers_gateway,
 )
-from tools.url_safety import async_is_safe_url, normalize_url_for_request, sensitive_query_param_name
+from tools.url_safety import (
+    async_is_safe_url,
+    is_safe_url,
+    normalize_url_for_request,
+    sensitive_query_param_name,
+)
+from tools.website_policy import check_website_access
 import sys
 
 logger = logging.getLogger(__name__)
@@ -616,6 +624,339 @@ def _ensure_web_plugins_loaded() -> None:
         logger.warning("Web plugin discovery failed (non-fatal): %s", exc)
 
 
+_DIRECT_FETCH_USER_AGENT = (
+    "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
+    "(KHTML, like Gecko) Chrome/136.0.0.0 Safari/537.36"
+)
+_DIRECT_TEXT_EXTENSIONS = (
+    ".md", ".markdown", ".txt", ".rst", ".json", ".yaml", ".yml",
+    ".toml", ".csv", ".tsv", ".xml", ".log",
+)
+_SPECIAL_ROUTE_TEXT_MAX_BYTES = 2_000_000
+_GITHUB_HTML_HOSTS = {"github.com", "www.github.com"}
+_GITHUB_RAW_HOST = "raw.githubusercontent.com"
+_X_STATUS_HOSTS = {"x.com", "www.x.com", "twitter.com", "www.twitter.com"}
+_X_ARTICLE_PATH_RE = re.compile(r"/i/article/\d+")
+
+
+class _SpecialRouteBlocked(Exception):
+    """Raised when a special URL route discovers a blocked redirected target."""
+
+    def __init__(
+        self,
+        url: str,
+        message: str,
+        blocked_by_policy: Optional[Dict[str, Any]] = None,
+    ):
+        super().__init__(message)
+        self.url = url
+        self.message = message
+        self.blocked_by_policy = blocked_by_policy
+
+
+def _collapse_whitespace(value: str) -> str:
+    return re.sub(r"[ \t\r\f\v]+", " ", value or "").strip()
+
+
+def _strip_html_fallback(value: str) -> str:
+    """Naive HTML → text fallback for lightweight direct fetch routes."""
+    text = re.sub(r"(?is)<script[^>]*>.*?</script>", " ", value or "")
+    text = re.sub(r"(?is)<style[^>]*>.*?</style>", " ", text)
+    text = re.sub(r"(?i)<br\s*/?>", "\n", text)
+    text = re.sub(r"(?i)</p\s*>", "\n", text)
+    text = re.sub(r"(?i)<p[^>]*>", "\n", text)
+    text = re.sub(r"<[^>]+>", " ", text)
+    text = html.unescape(text)
+    text = re.sub(r"\n{3,}", "\n\n", text)
+    return "\n".join(
+        _collapse_whitespace(line)
+        for line in text.splitlines()
+        if _collapse_whitespace(line)
+    )
+
+
+def _extract_meta_content(document: str, *, name: str = "", prop: str = "") -> str:
+    if not document:
+        return ""
+    attr_name = "property" if prop else "name"
+    attr_value = prop or name
+    if not attr_value:
+        return ""
+    patterns = [
+        rf'<meta[^>]+{attr_name}=["\']{re.escape(attr_value)}["\'][^>]+content=["\']([^"\']*)["\']',
+        rf'<meta[^>]+content=["\']([^"\']*)["\'][^>]+{attr_name}=["\']{re.escape(attr_value)}["\']',
+    ]
+    for pattern in patterns:
+        match = re.search(pattern, document, re.IGNORECASE)
+        if match:
+            return html.unescape(match.group(1)).strip()
+    return ""
+
+
+def _direct_fetch_text(url: str, timeout: int = 20) -> tuple[str, str, str]:
+    """Fetch small text responses while validating each redirect target."""
+    headers = {
+        "User-Agent": _DIRECT_FETCH_USER_AGENT,
+        "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,text/plain;q=0.8,*/*;q=0.7",
+    }
+    current_url = url
+    for _redirect_count in range(5):
+        if not is_safe_url(current_url):
+            raise _SpecialRouteBlocked(
+                current_url,
+                "Blocked: URL targets a private or internal network address",
+            )
+        blocked = check_website_access(current_url)
+        if blocked:
+            raise _SpecialRouteBlocked(
+                current_url,
+                blocked["message"],
+                {
+                    "host": blocked["host"],
+                    "rule": blocked["rule"],
+                    "source": blocked["source"],
+                },
+            )
+
+        with httpx.stream(
+            "GET",
+            current_url,
+            headers=headers,
+            follow_redirects=False,
+            timeout=timeout,
+        ) as response:
+            if response.is_redirect:
+                location = response.headers.get("location")
+                if not location:
+                    raise ValueError("Redirect response is missing a Location header")
+                current_url = urljoin(str(response.url), location)
+                continue
+
+            response.raise_for_status()
+            content_type = response.headers.get("content-type", "")
+            body = bytearray()
+            for chunk in response.iter_bytes():
+                body.extend(chunk)
+                if len(body) > _SPECIAL_ROUTE_TEXT_MAX_BYTES:
+                    raise ValueError("Special-routed response is larger than 2MB")
+            encoding = response.encoding or "utf-8"
+            return body.decode(encoding, errors="replace"), content_type, str(response.url)
+
+    raise ValueError("Too many redirects while fetching special-routed URL")
+
+
+def _is_textish_url(url: str) -> bool:
+    parsed = urlparse(url)
+    host = (parsed.hostname or "").lower()
+    path = parsed.path.lower()
+    return host == _GITHUB_RAW_HOST or path.endswith(_DIRECT_TEXT_EXTENSIONS)
+
+
+def _github_raw_url(url: str) -> str:
+    parsed = urlparse(url)
+    host = (parsed.hostname or "").lower()
+    path_parts = [part for part in parsed.path.split("/") if part]
+    if host == _GITHUB_RAW_HOST:
+        return url
+    if host not in _GITHUB_HTML_HOSTS:
+        return ""
+    if len(path_parts) < 5 or path_parts[2] not in {"blob", "raw"}:
+        return ""
+
+    owner, repo, _, ref, *rest_parts = path_parts
+    rest = "/".join(rest_parts)
+    if rest:
+        return f"https://raw.githubusercontent.com/{owner}/{repo}/{ref}/{rest}"
+    return ""
+
+
+def _github_raw_url_from_html_link(raw_link: str, base_url: str) -> str:
+    candidate = urljoin(base_url, html.unescape(raw_link))
+    parsed = urlparse(candidate)
+    host = (parsed.hostname or "").lower()
+    if host == _GITHUB_RAW_HOST:
+        return candidate
+    path_parts = [part for part in parsed.path.split("/") if part]
+    if host in _GITHUB_HTML_HOSTS and len(path_parts) >= 4 and path_parts[2] == "raw":
+        owner, repo, _, *raw_path = path_parts
+        if raw_path:
+            return f"https://raw.githubusercontent.com/{owner}/{repo}/{'/'.join(raw_path)}"
+    return ""
+
+
+def _github_raw_url_from_html(document: str, base_url: str) -> str:
+    for pattern in (
+        r'href=["\']([^"\']*/raw/[^"\']+)["\']',
+        r'data-permalink-href=["\']([^"\']*/raw/[^"\']+)["\']',
+    ):
+        for match in re.finditer(pattern, document or "", re.IGNORECASE):
+            raw_url = _github_raw_url_from_html_link(match.group(1), base_url)
+            if raw_url:
+                return raw_url
+    return ""
+
+
+def _build_extract_result(
+    *,
+    url: str,
+    title: str,
+    content: str,
+    route: str,
+    requested_url: str,
+    metadata: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    final_metadata = {
+        "sourceURL": url,
+        "title": title,
+        "route": route,
+        "requestedURL": requested_url,
+    }
+    if metadata:
+        final_metadata.update(metadata)
+    return {
+        "url": url,
+        "title": title,
+        "content": content,
+        "raw_content": content,
+        "metadata": final_metadata,
+    }
+
+
+def _extract_direct_text_result(
+    url: str,
+    format: Optional[str] = None,
+) -> Optional[Dict[str, Any]]:
+    raw_url = _github_raw_url(url)
+    target_url = raw_url or url
+    if not raw_url and not _is_textish_url(target_url):
+        return None
+
+    try:
+        body, content_type, final_url = _direct_fetch_text(target_url)
+    except _SpecialRouteBlocked:
+        raise
+    except Exception:
+        parsed = urlparse(url)
+        if (parsed.hostname or "").lower() not in _GITHUB_HTML_HOSTS:
+            raise
+        html_body, _html_content_type, html_url = _direct_fetch_text(url)
+        html_raw_url = _github_raw_url_from_html(html_body, html_url)
+        if not html_raw_url or html_raw_url == target_url:
+            raise
+        body, content_type, final_url = _direct_fetch_text(html_raw_url)
+    parsed_final = urlparse(final_url)
+    title = parsed_final.path.rsplit("/", 1)[-1] or final_url
+
+    if format == "html" and "html" in content_type.lower() and not _is_textish_url(final_url):
+        content = body
+    else:
+        content = body if _is_textish_url(final_url) else _strip_html_fallback(body)
+
+    return _build_extract_result(
+        url=final_url,
+        title=title,
+        content=content,
+        route="direct-text",
+        requested_url=url,
+    )
+
+
+def _extract_x_status_result(url: str) -> Optional[Dict[str, Any]]:
+    parsed = urlparse(url)
+    host = (parsed.hostname or "").lower()
+    if host not in _X_STATUS_HOSTS:
+        return None
+
+    match = re.search(r"/([^/]+)/status/(\d+)", parsed.path)
+    if not match:
+        return None
+
+    screen_name, status_id = match.groups()
+    document, _content_type, final_url = _direct_fetch_text(url)
+
+    full_text = ""
+    text_match = re.search(r'"full_text":"((?:\\.|[^"\\])*)"', document)
+    if text_match:
+        try:
+            full_text = bytes(text_match.group(1), "utf-8").decode("unicode_escape")
+        except Exception:
+            full_text = text_match.group(1)
+    full_text = _collapse_whitespace(html.unescape(full_text.replace("\n", " ")))
+
+    title = (
+        _extract_meta_content(document, prop="og:title")
+        or _extract_meta_content(document, name="twitter:title")
+        or f"@{screen_name} on X"
+    )
+
+    article_url = ""
+    normalized_document = document.replace(r"\/", "/")
+    for article_path in re.findall(
+        r'https?://x\.com(?P<path>/[^"\s<]+)',
+        normalized_document,
+    ):
+        article_match = _X_ARTICLE_PATH_RE.search(article_path)
+        if article_match:
+            article_url = urljoin("https://x.com", article_match.group(0))
+            break
+
+    description = (
+        _extract_meta_content(document, prop="og:description")
+        or _extract_meta_content(document, name="twitter:description")
+    )
+    description = _collapse_whitespace(description)
+
+    recovered_lines = [
+        f"Author: @{screen_name}",
+        f"Tweet ID: {status_id}",
+    ]
+    if full_text:
+        recovered_lines.append(f"Text: {full_text}")
+    if article_url:
+        recovered_lines.append(f"Linked article: {article_url}")
+    if description and description != full_text:
+        recovered_lines.append(f"Description: {description}")
+    recovered_lines.append(
+        "Note: extracted via raw public X HTML fallback; linked article bodies may still require stronger browser/API support."
+    )
+
+    content = "# X Post\n\n" + "\n".join(f"- {line}" for line in recovered_lines)
+    return _build_extract_result(
+        url=final_url,
+        title=title,
+        content=content,
+        route="x-status-fallback",
+        requested_url=url,
+        metadata={
+            "author": screen_name,
+            "tweetId": status_id,
+            "articleUrl": article_url,
+        },
+    )
+
+
+def _extract_special_url_result(
+    url: str,
+    format: Optional[str] = None,
+) -> Optional[Dict[str, Any]]:
+    """Auto-route URLs that are better handled outside the generic crawler path."""
+    extractors = (
+        lambda current_url: _extract_x_status_result(current_url),
+        lambda current_url: _extract_direct_text_result(current_url, format=format),
+    )
+    for extractor in extractors:
+        try:
+            result = extractor(url)
+        except _SpecialRouteBlocked:
+            raise
+        except Exception as exc:
+            logger.debug("Special URL extractor failed for %s: %s", url, exc)
+            continue
+        if result:
+            return result
+    return None
+
+
 def web_search_tool(query: str, limit: int = 5) -> str:
     """
     Search the web for information using available search API backend.
@@ -750,7 +1091,9 @@ async def web_extract_tool(
 
     Returns clean page content (markdown/text) with NO LLM summarization. The
     extract backends (Firecrawl, Tavily, Exa, Parallel) already return clean,
-    boilerplate-stripped content, so we return it directly and fast. Pages over
+    boilerplate-stripped content, so we return it directly and fast. Certain
+    predictable public URLs are handled inline before the generic provider path:
+    GitHub blob/raw/text files and public X/Twitter status pages. Pages over
     ``char_limit`` are head+tail truncated with an explicit footer; the full
     text is stored under cache/web and the footer tells the model how to
     read_file the omitted middle. Inline base64 images are replaced with
@@ -837,24 +1180,107 @@ async def web_extract_tool(
     try:
         logger.info("Extracting content from %d URL(s)", len(normalized_urls))
 
-        # ── SSRF protection — filter out private/internal URLs before any backend ──
+        # ── Invalid/blocked/routed/provider results all preserve input order ──
+        ordered_results: List[Optional[Dict[str, Any]]] = [None] * len(urls)
+        for index, invalid_result in invalid_urls.items():
+            ordered_results[index] = invalid_result
+
         safe_urls = []
         safe_indices = []
-        ssrf_blocked: Dict[int, Dict[str, Any]] = {}
         for index, url in zip(normalized_indices, normalized_urls):
             if not await async_is_safe_url(url):
-                ssrf_blocked[index] = {
-                    "url": url, "title": "", "content": "",
+                ordered_results[index] = {
+                    "url": url,
+                    "title": "",
+                    "content": "",
                     "error": "Blocked: URL targets a private or internal network address",
                 }
             else:
                 safe_urls.append(url)
                 safe_indices.append(index)
 
-        # Dispatch only safe URLs to the configured backend
-        if not safe_urls:
-            results = []
-        else:
+        generic_urls: List[str] = []
+        generic_positions: List[int] = []
+        from tools.interrupt import is_interrupted as _is_interrupted
+
+        for index, url in zip(safe_indices, safe_urls):
+            if _is_interrupted():
+                ordered_results[index] = {
+                    "url": url,
+                    "title": "",
+                    "content": "",
+                    "error": "Interrupted",
+                }
+                continue
+
+            blocked = check_website_access(url)
+            if blocked:
+                logger.info(
+                    "Blocked web_extract for %s by rule %s",
+                    blocked["host"],
+                    blocked["rule"],
+                )
+                ordered_results[index] = {
+                    "url": url,
+                    "title": "",
+                    "content": "",
+                    "error": blocked["message"],
+                    "blocked_by_policy": {
+                        "host": blocked["host"],
+                        "rule": blocked["rule"],
+                        "source": blocked["source"],
+                    },
+                }
+                continue
+
+            try:
+                special_result = await asyncio.to_thread(
+                    _extract_special_url_result,
+                    url,
+                    format,
+                )
+            except _SpecialRouteBlocked as exc:
+                ordered_results[index] = {
+                    "url": exc.url,
+                    "title": "",
+                    "content": "",
+                    "error": exc.message,
+                    **(
+                        {"blocked_by_policy": exc.blocked_by_policy}
+                        if exc.blocked_by_policy
+                        else {}
+                    ),
+                }
+                continue
+
+            if special_result:
+                final_url = special_result.get("metadata", {}).get(
+                    "sourceURL",
+                    special_result.get("url", url),
+                )
+                final_blocked = check_website_access(final_url)
+                if final_blocked:
+                    ordered_results[index] = {
+                        "url": final_url,
+                        "title": "",
+                        "content": "",
+                        "error": final_blocked["message"],
+                        "blocked_by_policy": {
+                            "host": final_blocked["host"],
+                            "rule": final_blocked["rule"],
+                            "source": final_blocked["source"],
+                        },
+                    }
+                    continue
+
+                ordered_results[index] = special_result
+                continue
+
+            generic_urls.append(url)
+            generic_positions.append(index)
+
+        # Dispatch only the remaining generic safe URLs to the configured backend
+        if generic_urls:
             backend = _get_extract_backend()
 
             # All seven providers (brave-free, ddgs, searxng, exa, parallel,
@@ -928,40 +1354,45 @@ async def web_extract_tool(
                     )
 
             logger.info(
-                "Web extract via %s: %d URL(s)", provider.name, len(safe_urls)
+                "Web extract via %s: %d URL(s)", provider.name, len(generic_urls)
             )
 
             # Async-or-sync dispatch: parallel + firecrawl have async
             # extract(); exa + tavily are sync.
             import inspect
             if inspect.iscoroutinefunction(provider.extract):
-                results = await provider.extract(safe_urls, format=format)
+                generic_results = await provider.extract(generic_urls, format=format)
             else:
                 # Run sync extract() in a thread so we don't block the
                 # event loop on network I/O.
-                results = await asyncio.to_thread(
-                    provider.extract, safe_urls, format=format
+                generic_results = await asyncio.to_thread(
+                    provider.extract, generic_urls, format=format
                 )
 
-        # Reconstruct the original input order across invalid, blocked, and
-        # provider-processed entries. Providers are expected to preserve the
-        # order of the safe URL list they receive.
-        if invalid_urls or ssrf_blocked:
-            safe_results = {
-                index: (
-                    results[position]
-                    if position < len(results)
-                    else {
-                        "url": safe_urls[position],
+            generic_results = generic_results or []
+            for index, result in zip(generic_positions, generic_results):
+                ordered_results[index] = result
+
+            if len(generic_results) > len(generic_positions):
+                logger.warning(
+                    "Web extract provider %s returned %d extra result(s); dropping extras to preserve input/result alignment",
+                    provider.name,
+                    len(generic_results) - len(generic_positions),
+                )
+
+            if len(generic_results) < len(generic_positions):
+                for index, url in zip(
+                    generic_positions[len(generic_results):],
+                    generic_urls[len(generic_results):],
+                ):
+                    ordered_results[index] = {
+                        "url": url,
                         "title": "",
                         "content": "",
                         "error": "Extract backend returned no result for this URL",
                     }
-                )
-                for position, index in enumerate(safe_indices)
-            }
-            by_index = {**safe_results, **ssrf_blocked, **invalid_urls}
-            results = [by_index[index] for index in range(len(urls))]
+
+        results = [result for result in ordered_results if result is not None]
 
         response = {"results": results}
         

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -9,6 +9,7 @@ caching, keyless rescue, and the truncate-and-store result pipeline.
 Debug: ``WEB_TOOLS_DEBUG=true`` writes ``logs/web_tools_debug_<UUID>.json``.
 """
 
+import asyncio
 import json
 import logging
 import os
@@ -26,6 +27,7 @@ from tools.web_tools_extract import (
     _extract_safe_urls, _merge_in_order, _no_provider_error, _resolve_extract_provider, _result_entry,
     _strict_selection_error, _validate_extract_urls,
 )
+from tools.web_tools_routing import SpecialRouteBlocked, SpecialRouteUnavailable, extract_special_url
 
 logger = logging.getLogger(__name__)
 
@@ -371,19 +373,37 @@ async def web_extract_tool(urls: List[Any], format: str = None, char_limit: Opti
                     url, "Blocked: URL targets a private or internal network address"
                 )
 
+        routed_results: dict[int, dict[str, Any]] = {}
+        provider_urls: list[str] = []
+        provider_indices: list[int] = []
+        for index, url in zip(safe_indices, safe_urls):
+            try:
+                routed = await asyncio.to_thread(extract_special_url, url, format=format)
+            except SpecialRouteBlocked as exc:
+                routed_results[index] = _result_entry(exc.url, exc.message)
+                continue
+            except SpecialRouteUnavailable:
+                provider_urls.append(url)
+                provider_indices.append(index)
+                continue
+            if routed is None:
+                provider_urls.append(url)
+                provider_indices.append(index)
+            else:
+                routed_results[index] = routed
+
         results = []
-        if safe_urls:
+        if provider_urls:
             backend = _get_extract_backend()
             _ensure_web_plugins_loaded()
             provider, error_json = _resolve_extract_provider(backend)
             if error_json is not None:
                 return error_json
-            results = await _extract_safe_urls(provider, safe_urls, format)
-        # Reconstruct input order across invalid, blocked, and provider entries (providers preserve
-        # the order of the safe URL list they receive).
-        if invalid_urls or ssrf_blocked:
-            fixed = {**ssrf_blocked, **invalid_urls}
-            results = _merge_in_order(len(urls), fixed, safe_indices, safe_urls, results)
+            results = await _extract_safe_urls(provider, provider_urls, format)
+        # Reconstruct input order across invalid, blocked, routed, and provider entries.
+        if invalid_urls or ssrf_blocked or routed_results:
+            fixed = {**ssrf_blocked, **invalid_urls, **routed_results}
+            results = _merge_in_order(len(urls), fixed, provider_indices, provider_urls, results)
 
         logger.info("Extracted content from %d pages", len(results))
         debug_call_data["pages_extracted"] = len(results)
@@ -446,6 +466,15 @@ def check_web_api_key() -> bool:
         return False
 
 
+def check_web_extract_available() -> bool:
+    """Keep ``web_extract`` registered for public direct routes without a configured vendor.
+
+    The handler still emits the normal provider-selection error for ordinary URLs when no extract
+    backend is available. GitHub file and X status routes are self-contained and can succeed without one.
+    """
+    return True
+
+
 # ─── Registry ─────────────────────────────────────────────────────────────────
 from tools.registry import registry, tool_error
 
@@ -505,7 +534,7 @@ registry.register(
         args.get("urls", [])[:5] if isinstance(args.get("urls"), list) else [], "markdown",
         char_limit=args.get("char_limit"),
     ),
-    check_fn=check_web_api_key, requires_env=_web_requires_env(), is_async=True, emoji="📄",
+    check_fn=check_web_extract_available, requires_env=_web_requires_env(), is_async=True, emoji="📄",
     max_result_size_chars=100_000,
 )
 

--- a/tools/web_tools_routing.py
+++ b/tools/web_tools_routing.py
@@ -1,0 +1,221 @@
+"""Direct, safety-preserving routes for public GitHub file URLs."""
+
+from __future__ import annotations
+
+import html
+import json
+import re
+from typing import Any, Optional
+from urllib.parse import urljoin, urlparse
+
+import httpx
+
+from tools import url_safety, website_policy
+
+_DIRECT_FETCH_USER_AGENT = (
+    "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
+    "(KHTML, like Gecko) Chrome/136.0.0.0 Safari/537.36"
+)
+_DIRECT_TEXT_MAX_BYTES = 2_000_000
+_GITHUB_HTML_HOSTS = {"github.com", "www.github.com"}
+_GITHUB_RAW_HOST = "raw.githubusercontent.com"
+_X_STATUS_HOSTS = {"x.com", "www.x.com", "twitter.com", "www.twitter.com"}
+_X_STATUS_PATH_RE = re.compile(r"/([^/]+)/status/(\d+)(?:/|$)")
+_X_ARTICLE_URL_RE = re.compile(r"https?://(?:x\.com|twitter\.com)/i/article/\d+")
+
+
+class SpecialRouteBlocked(Exception):
+    """A direct route encountered a URL rejected by the website policy."""
+
+    def __init__(self, url: str, message: str) -> None:
+        super().__init__(message)
+        self.url = url
+        self.message = message
+
+
+class SpecialRouteUnavailable(Exception):
+    """A direct route failed transiently and should use ordinary provider dispatch instead."""
+
+
+def _check_website_policy(url: str) -> None:
+    if blocked := website_policy.check_website_access(url):
+        raise SpecialRouteBlocked(url, blocked["message"])
+
+
+def _direct_fetch_text(url: str, timeout: int = 20) -> tuple[str, str]:
+    """Fetch bounded text using the SSRF-safe client and guard every redirect by policy."""
+    headers = {
+        "User-Agent": _DIRECT_FETCH_USER_AGENT,
+        "Accept": "text/plain,text/markdown,text/*;q=0.9,*/*;q=0.1",
+    }
+    current_url = url
+    with url_safety.create_ssrf_safe_client(timeout=timeout) as client:
+        for _ in range(5):
+            _check_website_policy(current_url)
+            try:
+                with client.stream(
+                    "GET", current_url, headers=headers, follow_redirects=False
+                ) as response:
+                    if response.is_redirect:
+                        redirect_url = url_safety.redirect_target_from_response(
+                            response
+                        )
+                        if not redirect_url:
+                            raise ValueError(
+                                "Redirect response is missing a Location header"
+                            )
+                        _check_website_policy(redirect_url)
+                        current_url = redirect_url
+                        continue
+                    response.raise_for_status()
+                    body = bytearray()
+                    for chunk in response.iter_bytes():
+                        body.extend(chunk)
+                        if len(body) > _DIRECT_TEXT_MAX_BYTES:
+                            raise ValueError(
+                                "Direct-routed response is larger than 2MB"
+                            )
+                    return body.decode(
+                        response.encoding or "utf-8", errors="replace"
+                    ), str(response.url)
+            except url_safety.SSRFConnectionBlocked as exc:
+                raise SpecialRouteBlocked(
+                    current_url,
+                    "Blocked: URL targets a private or internal network address",
+                ) from exc
+    raise ValueError("Too many redirects while fetching direct-routed URL")
+
+
+def _is_github_file_url(url: str) -> bool:
+    """Whether *url* is a public GitHub file endpoint handled by the direct router."""
+    parsed = urlparse(url)
+    host = (parsed.hostname or "").lower()
+    parts = [part for part in parsed.path.split("/") if part]
+    if host == _GITHUB_RAW_HOST:
+        return len(parts) >= 4
+    return (
+        host in _GITHUB_HTML_HOSTS and len(parts) >= 5 and parts[2] in {"blob", "raw"}
+    )
+
+
+def _github_raw_url_from_html(document: str, base_url: str) -> str:
+    """Resolve GitHub's raw link so refs containing slashes are not guessed incorrectly."""
+    for match in re.finditer(
+        r'href=["\']([^"\']*/raw/[^"\']+)["\']', document, re.IGNORECASE
+    ):
+        candidate = urljoin(base_url, html.unescape(match.group(1)))
+        parsed = urlparse(candidate)
+        parts = [part for part in parsed.path.split("/") if part]
+        if (
+            (parsed.hostname or "").lower() in _GITHUB_HTML_HOSTS
+            and len(parts) >= 4
+            and parts[2] == "raw"
+        ):
+            owner, repo, _, *raw_path = parts
+            return f"https://{_GITHUB_RAW_HOST}/{owner}/{repo}/{'/'.join(raw_path)}"
+    return ""
+
+
+def _extract_github_file(url: str) -> Optional[dict[str, Any]]:
+    """Resolve GitHub's own raw link before fetching file content.
+
+    Git refs may contain slashes, so constructing a raw URL from ``/blob/<ref>/<path>`` is
+    ambiguous. Fetching the public file page first keeps GitHub authoritative for that split.
+    """
+    if not _is_github_file_url(url):
+        return None
+    # Check the caller's original URL before any direct fetch. A website-policy rule for
+    # github.com must apply even when raw.githubusercontent.com is allowed.
+    _check_website_policy(url)
+    parsed = urlparse(url)
+    host = (parsed.hostname or "").lower()
+    parts = [part for part in parsed.path.split("/") if part]
+    try:
+        if host == _GITHUB_RAW_HOST or parts[2] == "raw":
+            content, final_url = _direct_fetch_text(url)
+        else:
+            page, page_url = _direct_fetch_text(url)
+            resolved_raw_url = _github_raw_url_from_html(page, page_url)
+            if not resolved_raw_url:
+                raise ValueError("GitHub file page did not expose a raw-content link")
+            content, final_url = _direct_fetch_text(resolved_raw_url)
+    except SpecialRouteBlocked:
+        raise
+    except (httpx.HTTPError, ValueError) as exc:
+        raise SpecialRouteUnavailable from exc
+    return {
+        "url": final_url,
+        "title": urlparse(final_url).path.rsplit("/", 1)[-1] or final_url,
+        "content": content,
+        "raw_content": content,
+        "error": None,
+    }
+
+
+def _extract_meta_content(document: str, attr: str, value: str) -> str:
+    """Return a meta content value regardless of attribute order."""
+    escaped_attr = re.escape(attr)
+    escaped_value = re.escape(value)
+    for pattern in (
+        rf'<meta[^>]+{escaped_attr}=["\']{escaped_value}["\'][^>]+content=["\']([^"\']*)["\']',
+        rf'<meta[^>]+content=["\']([^"\']*)["\'][^>]+{escaped_attr}=["\']{escaped_value}["\']',
+    ):
+        if match := re.search(pattern, document, re.IGNORECASE):
+            return html.unescape(match.group(1)).strip()
+    return ""
+
+
+def _extract_x_status(url: str) -> Optional[dict[str, Any]]:
+    parsed = urlparse(url)
+    if (parsed.hostname or "").lower() not in _X_STATUS_HOSTS:
+        return None
+    if not (match := _X_STATUS_PATH_RE.fullmatch(parsed.path)):
+        return None
+
+    username, status_id = match.groups()
+    try:
+        document, final_url = _direct_fetch_text(url)
+    except SpecialRouteBlocked:
+        raise
+    except (httpx.HTTPError, ValueError) as exc:
+        raise SpecialRouteUnavailable from exc
+    title = (
+        _extract_meta_content(document, "property", "og:title") or f"@{username} on X"
+    )
+    normalized_document = document.replace(r"\/", "/")
+    article_match = _X_ARTICLE_URL_RE.search(normalized_document)
+    article_url = (
+        article_match.group(0).replace("twitter.com", "x.com") if article_match else ""
+    )
+
+    text = ""
+    if text_match := re.search(r'"full_text"\s*:\s*("(?:\\.|[^"\\])*")', document):
+        try:
+            text = json.loads(text_match.group(1))
+        except json.JSONDecodeError:
+            text = text_match.group(1).strip('"')
+    description = _extract_meta_content(document, "property", "og:description")
+    lines = [f"Author: @{username}", f"Tweet ID: {status_id}"]
+    if text:
+        lines.append(f"Text: {text}")
+    if article_url:
+        lines.append(f"Linked article: {article_url}")
+    if description and description != text:
+        lines.append(f"Description: {description}")
+    lines.append("Note: extracted via public X HTML fallback.")
+    content = "# X Post\n\n" + "\n".join(f"- {line}" for line in lines)
+    return {
+        "url": final_url,
+        "title": title,
+        "content": content,
+        "raw_content": content,
+        "error": None,
+    }
+
+
+def extract_special_url(
+    url: str, format: Optional[str] = None
+) -> Optional[dict[str, Any]]:
+    """Extract known public routes directly; return ``None`` for ordinary provider dispatch."""
+    del format
+    return _extract_x_status(url) or _extract_github_file(url)


### PR DESCRIPTION
## What does this PR do?

Ports the URL-aware `web_extract` routing work onto current `main`.

Problem statement:

- Generic extract backends are a poor fit for some predictable public URLs.
- GitHub `blob`/`raw` source-file URLs often return the full GitHub HTML shell instead of the file text, even though the raw target is deterministic.
- Text-like files such as Markdown, JSON, YAML, CSV, XML, logs, and raw GitHub content do not need crawler-style extraction.
- Public X/Twitter status pages often produce sparse crawler output, but the public HTML/meta payload still contains useful metadata and linked article references.

Solution:

- Add a conservative special-route layer inside the current `web_extract_tool` pipeline.
  - GitHub `blob`/`raw` file URLs are routed to `raw.githubusercontent.com` when possible.
  - Text-like URLs are fetched directly with a 2 MB response cap.
  - X/Twitter `/status/<id>` URLs get a best-effort public-HTML fallback that recovers author, status id, title/description, `full_text` when present, and linked `x.com/i/article/...` URLs when present.
- Preserve current-main behavior around URL normalization, async SSRF checks, website-policy checks, provider dispatch, and truncate-and-store output processing.
- Preserve input order when a request mixes routed and provider-backed URLs.
- Drop extra provider results instead of leaking entries that do not correspond to requested inputs.
- Validate redirect targets during direct fetches so a safe public URL cannot hop into a private/internal address.

Availability note:

- This PR intentionally changes routing *inside* `web_extract_tool` once the tool is available.
- The registered `web_extract` tool still uses the existing availability gate (`check_web_api_key`).
- Changing tool-registration availability for routed-only URLs is out of scope here.

This is intentionally not an authenticated X scraper. The X route is a best-effort public metadata fallback; URLs that need richer rendering can still use existing browser/provider paths.

## Related Issue

No issue filed.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/web_tools.py`
  - Ported the routing work into the current `web_extract_tool(urls, format, char_limit)` flow.
  - Added helpers for direct text fetches, GitHub raw-file routing, and public X/Twitter status fallback.
  - Added a 2 MB cap for direct special-route responses.
  - Preserved SSRF and website-policy checks before route execution, plus validation on redirected/final routed URLs.
  - Preserved input order across routed and provider-backed results.
  - Dropped extra provider results to keep output aligned with requested URLs.
- `tests/tools/test_web_extract_routing.py`
  - Added regression coverage for GitHub blob → raw routing.
  - Added coverage for slash-containing Git refs that require the GitHub HTML raw link fallback.
  - Added coverage that routed-only calls skip provider dispatch inside `web_extract_tool`.
  - Added coverage for public X/Twitter status fallback.
  - Added coverage that generic URLs still use the configured extract provider.
  - Added coverage that mixed routed/generic inputs preserve order.
  - Added coverage that extra provider results are dropped.
  - Added coverage that redirect targets are revalidated during direct fetches.

## How to Test

1. Run syntax/lint checks:
   ```bash
   python -m py_compile tools/web_tools.py tests/tools/test_web_extract_routing.py
   python -m ruff check tools/web_tools.py tests/tools/test_web_extract_routing.py
   ```
2. Run focused validation:
   ```bash
   python scripts/check-windows-footguns.py --diff origin/main
   git diff --check origin/main -- tools/web_tools.py tests/tools/test_web_extract_routing.py
   scripts/run_tests.sh tests/tools/test_web_extract_routing.py -q
   ```
3. Optional smoke checks:
   - `web_extract` on a GitHub blob URL returns raw file content.
   - `web_extract` on a normal webpage still dispatches to the configured provider.
   - `web_extract` on a public X status URL returns metadata fallback text instead of failing through a generic crawler.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu/WSL on Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Validation run locally:

```text
python -m py_compile tools/web_tools.py tests/tools/test_web_extract_routing.py
python -m ruff check tools/web_tools.py tests/tools/test_web_extract_routing.py
python scripts/check-windows-footguns.py --diff origin/main
git diff --check origin/main -- tools/web_tools.py tests/tools/test_web_extract_routing.py
scripts/run_tests.sh tests/tools/test_web_extract_routing.py -q
DIFF_SECRET_SCAN_OK
```

Result:

```text
All checks passed!
✓ No Windows footguns found (2 file(s) scanned).
▶ running pytest with 8 workers, hermetic env
........                                                                [100%]
8 passed
```

Note: I did not run the full `pytest tests/ -q` suite locally due to runtime/scope. I ran focused validation for the touched routing path plus lint, py_compile, Windows-footgun scan, diff-check, and a diff secret scan heuristic.
