### PR TITLE
fix(custom-headers + approvals): close 3rd custom_headers leak in fallback + honor approvals.timeout=0 in callbacks.py

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -554,7 +554,18 @@ def init_agent(
             # the third-party identity-injection bug.
             from agent.anthropic_adapter import _is_oauth_token as _is_oat
             agent._is_anthropic_oauth = _is_oat(effective_key) if _is_native_anthropic else False
-            agent._anthropic_client = build_anthropic_client(effective_key, base_url, timeout=_provider_timeout)
+            # Resolve custom_headers + verify from custom_providers config
+            # via the shared helper so APIM-style gateways (subscription
+            # keys, self-signed certs) work uniformly across init,
+            # fallback activation, and request-client rebuild.
+            from hermes_cli.runtime_provider import resolve_custom_gateway_headers
+            _custom_default_headers, _verify_override = resolve_custom_gateway_headers(base_url)
+            _custom_verify = True if _verify_override is None else _verify_override
+            agent._anthropic_client = build_anthropic_client(
+                effective_key, base_url, timeout=_provider_timeout,
+                default_headers=_custom_default_headers,
+                verify=_custom_verify,
+            )
             # No OpenAI client needed for Anthropic mode
             agent.client = None
             agent._client_kwargs = {}
@@ -655,6 +666,20 @@ def init_agent(
                         client_kwargs["default_headers"] = dict(_ph.default_headers)
                 except Exception:
                     pass
+            # Resolve custom_headers + verify from custom_providers config
+            # via the shared helper. Without this mirror on the OpenAI-wire
+            # path, APIM-style gateways (e.g. AMD LLM Gateway's
+            # Ocp-Apim-Subscription-Key) silently 401 because the outbound
+            # request only carries the Bearer token the gateway doesn't
+            # recognise.
+            if "default_headers" not in client_kwargs:
+                from hermes_cli.runtime_provider import resolve_custom_gateway_headers
+                _ch, _verify = resolve_custom_gateway_headers(base_url)
+                if _ch:
+                    client_kwargs["default_headers"] = _ch
+                if _verify is False:
+                    import httpx as _httpx_local
+                    client_kwargs["http_client"] = _httpx_local.Client(verify=False)
         else:
             # No explicit creds — use the centralized provider router
             from agent.auxiliary_client import resolve_provider_client

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -814,16 +814,29 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
         if fb_api_mode == "anthropic_messages":
             # Build native Anthropic client instead of using OpenAI client
             from agent.anthropic_adapter import build_anthropic_client, resolve_anthropic_token, _is_oauth_token
+            from hermes_cli.runtime_provider import resolve_custom_gateway_headers
             effective_key = (fb_client.api_key or resolve_anthropic_token() or "") if fb_provider == "anthropic" else (fb_client.api_key or "")
             agent.api_key = effective_key
             agent._anthropic_api_key = effective_key
             agent._anthropic_base_url = fb_base_url
+            # Forward custom_headers + verify for APIM-style fallback gateways
+            # (e.g. AMD LLM Gateway). Without this, the fallback chain 401s
+            # on every Anthropic-wire gateway entry because the subscription
+            # key is dropped during client construction. See PR #28790.
+            _fb_headers, _fb_verify = resolve_custom_gateway_headers(fb_base_url)
+            _fb_verify_resolved = True if _fb_verify is None else _fb_verify
             agent._anthropic_client = build_anthropic_client(
                 effective_key, agent._anthropic_base_url, timeout=_fb_timeout,
+                default_headers=_fb_headers,
+                verify=_fb_verify_resolved,
             )
             agent._is_anthropic_oauth = _is_oauth_token(effective_key) if fb_provider == "anthropic" else False
             agent.client = None
             agent._client_kwargs = {}
+            # Store headers in _client_kwargs so auxiliary clients (vision,
+            # title generation, compression) re-use them on this provider.
+            if _fb_headers:
+                agent._client_kwargs["default_headers"] = _fb_headers
         else:
             # Swap OpenAI client and config in-place
             agent.api_key = fb_client.api_key

--- a/hermes_cli/callbacks.py
+++ b/hermes_cli/callbacks.py
@@ -201,7 +201,7 @@ def approval_callback(cli, command: str, description: str) -> str:
 
     with lock:
         from cli import CLI_CONFIG
-        timeout = CLI_CONFIG.get("approvals", {}).get("timeout", 60)
+        timeout = int(CLI_CONFIG.get("approvals", {}).get("timeout", 60))
         response_queue = queue.Queue()
         choices = ["once", "session", "always", "deny"]
         if len(command) > 70:
@@ -214,7 +214,14 @@ def approval_callback(cli, command: str, description: str) -> str:
             "selected": 0,
             "response_queue": response_queue,
         }
-        cli._approval_deadline = _time.monotonic() + timeout
+        # timeout=0 means "wait indefinitely" — no deadline.
+        # Mirror of cli.py:_approval_deadline assignment so this callback
+        # path honors the same `approvals.timeout: 0` config the main CLI
+        # path does. Without this guard, timeout=0 was setting the deadline
+        # to NOW and the first loop iteration immediately denied the
+        # command. See user-preference: "I don't want to see this again:
+        # Timeout — denying command".
+        cli._approval_deadline = 0 if not timeout else _time.monotonic() + timeout
 
         if hasattr(cli, "_app") and cli._app:
             cli._app.invalidate()
@@ -228,9 +235,11 @@ def approval_callback(cli, command: str, description: str) -> str:
                     cli._app.invalidate()
                 return result
             except queue.Empty:
-                remaining = cli._approval_deadline - _time.monotonic()
-                if remaining <= 0:
-                    break
+                # No deadline (timeout=0) → loop forever waiting for the user.
+                if cli._approval_deadline:
+                    remaining = cli._approval_deadline - _time.monotonic()
+                    if remaining <= 0:
+                        break
                 if hasattr(cli, "_app") and cli._app:
                     cli._app.invalidate()
 

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -5,12 +5,69 @@ from __future__ import annotations
 import logging
 import os
 import re
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Tuple
 
 logger = logging.getLogger(__name__)
 
 from hermes_cli import auth as auth_mod
 from agent.credential_pool import CredentialPool, PooledCredential, get_custom_provider_pool_key, load_pool
+
+
+def resolve_custom_gateway_headers(
+    base_url: str,
+) -> Tuple[Optional[Dict[str, str]], Optional[bool]]:
+    """Look up custom_headers + verify for ``base_url`` in custom_providers.
+
+    Returns ``(headers, verify)``:
+
+    * ``headers`` is a copy of the matched provider's ``custom_headers``
+      dict, or ``None`` if no entry matches.
+    * ``verify`` is the matched provider's ``verify`` flag (``True``/``False``)
+      or ``None`` if the entry omits it.
+
+    The match is case-insensitive on ``base_url`` with a trailing-slash
+    strip on both sides — runtime URLs sometimes carry a trailing slash,
+    config entries usually don't.
+
+    This is the single source of truth for "what extra headers does this
+    gateway need". Call sites that build a real client (init_agent,
+    fallback activation, request-client rebuild, auxiliary client) MUST
+    consult this helper before constructing the SDK client so APIM-style
+    subscription keys (Ocp-Apim-Subscription-Key, api-key, etc.) survive
+    the round-trip. See PR #28790 upstream.
+    """
+    if not base_url:
+        return None, None
+    my_base = base_url.rstrip("/").lower()
+    try:
+        from hermes_cli.config import load_config as _load_cp_cfg
+        cfg = _load_cp_cfg()
+        cp_list = cfg.get("custom_providers", [])
+        if not isinstance(cp_list, list):
+            return None, None
+        for cp in cp_list:
+            if not isinstance(cp, dict):
+                continue
+            cp_base = (cp.get("base_url") or "").rstrip("/").lower()
+            if cp_base and cp_base == my_base:
+                headers = (
+                    dict(cp["custom_headers"])
+                    if isinstance(cp.get("custom_headers"), dict)
+                    and cp["custom_headers"]
+                    else None
+                )
+                verify = cp.get("verify") if isinstance(cp.get("verify"), bool) else None
+                return headers, verify
+    except Exception:
+        logger.debug(
+            "resolve_custom_gateway_headers: lookup raised for base_url=%s; "
+            "treating as 'no headers'",
+            base_url,
+            exc_info=True,
+        )
+    return None, None
+
+
 from hermes_cli.auth import (
     AuthError,
     DEFAULT_CODEX_BASE_URL,


### PR DESCRIPTION
## What

Two independent fixes, both for behaviors that silently ignore user
configuration:

### 1. `fix(custom-headers): extract single resolver + close 3rd leak in fallback`

Custom `custom_providers[*].custom_headers` (e.g. Azure APIM
`Ocp-Apim-Subscription-Key`, AMD LLM Gateway subscription keys) were
forwarded on initial client construction but **dropped on fallback
activation** — every fallback through an APIM-gated Anthropic provider
would 401 with "missing subscription key" after the primary failed,
cascading through the entire fallback chain.

Three client-construction sites need to consult `custom_providers`:

1. `agent/agent_init.py:_create_anthropic_client` (anthropic_messages init) — already covered
2. `agent/agent_init.py` OpenAI-wire branch (chat_completions / codex_responses init) — already covered
3. `agent/chat_completion_helpers.py:try_activate_fallback` (Anthropic fallback rebuild) — **missing, this PR**

Refactored the three call sites to use a new shared helper
`hermes_cli.runtime_provider.resolve_custom_gateway_headers(base_url)`
that returns `(headers, verify)` — single source of truth so the next
person adding a client-construction path can't forget.

The OpenAI-wire fallback branch is already correct (it inherits headers
from `fb_client._custom_headers` via `resolve_provider_client()`).

**Smoke-verified live against AMD LLM Gateway:**
```
https://llm-api.amd.com:8443/Anthropic   → 3 headers, verify=False
https://llm-api.amd.com:8443/openai/     → 2 headers, verify=False
https://llm-api.amd.com:8443/OnPrem/     → 2 headers, verify=False
https://api.openai.com/v1                → no match (correct)
```

### 2. `fix(approvals): honor approvals.timeout=0 in hermes_cli/callbacks.py path`

There are TWO dangerous-command approval-prompt code paths:

- `cli.py:_approval_loop` (around line 10479) — correctly honors
  `approvals.timeout=0` with a sentinel deadline (`0 if not timeout
  else _time.monotonic() + timeout`) and a polling-loop guard
  (`if self._approval_deadline:` before checking remaining time).

- `hermes_cli/callbacks.py:_approval_prompt` (around line 217) —
  computed `deadline = monotonic() + timeout` unconditionally. With
  `timeout=0` the deadline was set to NOW and the first loop iteration
  printed `⏱ Timeout — denying command` instantly.

So users who set `approvals.timeout: 0` ("never auto-decide") still
got auto-denied through this second path. Fix mirrors cli.py's pattern
verbatim:

```python
# was:
cli._approval_deadline = _time.monotonic() + timeout
...
remaining = cli._approval_deadline - _time.monotonic()
if remaining <= 0:
    break

# now:
cli._approval_deadline = 0 if not timeout else _time.monotonic() + timeout
...
if cli._approval_deadline:
    remaining = cli._approval_deadline - _time.monotonic()
    if remaining <= 0:
        break
```

Both paths now wait indefinitely when the config says so. Also casts
the config value to `int` — `cli.py` does, and the falsy check fails
if YAML returns `'0'` (str) instead of `0` (int).

## Tests

Targeted suites green on this branch (rebased onto current upstream main):

```
tests/run_agent/test_provider_attribution_headers.py + test_callable_api_key.py
→ 26 passed
```

Broader runs (-k 'approval or callback') pass everything except 4
pre-existing test-isolation flakes in `tests/gateway/test_discord_*`
that pass in isolation and are unrelated to either changed file.

## Risk

- Custom-headers helper: returns `(None, None)` for any base_url not
  in `custom_providers` config → no behavior change for users without
  custom gateways.
- Approval-timeout fix: only changes behavior when user has explicitly
  set `approvals.timeout: 0` (default 60 stays unchanged).

## Background

These came out of a real production cascade against the AMD LLM Gateway:
every interrupt/retry triggered a fallback, every fallback dropped the
subscription key, every entry in the fallback chain returned 401, and
the user was eventually staring at "AuthenticationError" across every
model they had configured. The shared resolver makes the bug
mechanically impossible to re-introduce on a new client-construction
site.