### PR TITLE
Add Slack native progress cards

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -915,6 +915,8 @@ display:
   #   all:     Show every tool call with a short preview (default)
   #   verbose: Full args, results, and debug logs (same as /verbose)
   # Toggle at runtime with /verbose in the CLI
+  # Slack can render progress as native plan/task cards when enabled with:
+  # platforms.slack.extra.native_task_cards: true
   tool_progress: all
 
   # Auto-cleanup of temporary progress bubbles after the final response lands.

--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -72,6 +72,15 @@ class _ThreadContextCache:
     parent_text: str = ""  # Raw text of the thread parent (for reply_to_text injection)
 
 
+@dataclass
+class _NativeTaskCardStream:
+    """State for one Slack-native progress task-card stream."""
+    channel: str
+    thread_ts: str
+    stream_ts: str
+    stopped: bool = False
+
+
 def check_slack_requirements() -> bool:
     """Check if Slack dependencies are available.
 
@@ -348,6 +357,10 @@ class SlackAdapter(BasePlatformAdapter):
         # (channel_id, user_id) to avoid cross-user collisions.
         # Each value: {"response_url": str, "ts": float}
         self._slash_command_contexts: Dict[Tuple[str, str], Dict[str, Any]] = {}
+        # Slack-native task-card streams keyed by (channel_id, thread_ts).
+        # These are opt-in progress-only streams. Final assistant text still
+        # goes through send(), preserving the normal Hermes reply lifecycle.
+        self._native_task_card_streams: Dict[Tuple[str, str], _NativeTaskCardStream] = {}
 
     def _describe_slack_api_error(self, response: Any, *, file_obj: Optional[Dict[str, Any]] = None) -> Optional[str]:
         """Convert Slack API auth/permission failures into actionable user-facing text."""
@@ -754,6 +767,154 @@ class SlackAdapter(BasePlatformAdapter):
         if team_id and team_id in self._team_clients:
             return self._team_clients[team_id]
         return self._app.client  # fallback to primary
+
+    @staticmethod
+    def _truthy_config(value: Any) -> bool:
+        if isinstance(value, bool):
+            return value
+        if isinstance(value, str):
+            return value.strip().lower() in {"1", "true", "yes", "on"}
+        return bool(value)
+
+    def native_task_cards_enabled(self) -> bool:
+        """Return true when Slack-native progress task cards are enabled."""
+        extra = self.config.extra if isinstance(self.config.extra, dict) else {}
+        direct = extra.get("native_task_cards", extra.get("nativeTaskCards"))
+        if direct is not None:
+            return self._truthy_config(direct)
+
+        streaming = extra.get("streaming")
+        if isinstance(streaming, dict):
+            progress = streaming.get("progress")
+            if isinstance(progress, dict):
+                nested = progress.get("native_task_cards", progress.get("nativeTaskCards"))
+                if nested is not None:
+                    return self._truthy_config(nested)
+        return False
+
+    def _native_task_card_key(
+        self,
+        chat_id: str,
+        reply_to: Optional[str],
+        metadata: Optional[Dict[str, Any]],
+    ) -> Optional[Tuple[str, str]]:
+        thread_ts = self._resolve_thread_ts(reply_to, metadata)
+        if not thread_ts:
+            return None
+        return (chat_id, str(thread_ts))
+
+    async def send_native_task_card_progress(
+        self,
+        chat_id: str,
+        tasks: List[Dict[str, str]],
+        *,
+        title: str = "Hermes is working",
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        fallback_text: Optional[str] = None,
+    ) -> SendResult:
+        """Start or update a Slack-native plan/task progress stream.
+
+        This is intentionally separate from normal final-answer streaming:
+        it carries only progress chunks and leaves final text delivery to
+        send(). The config gate is checked by the gateway, but keeping the
+        helper Slack-owned prevents the native chunk contract from leaking
+        into generic platform streaming.
+        """
+        if not self._app:
+            return SendResult(success=False, error="Not connected")
+        if not tasks:
+            return SendResult(success=False, error="No tasks")
+
+        try:
+            client = self._get_client(chat_id)
+            key = self._native_task_card_key(chat_id, reply_to, metadata)
+            if key is None:
+                return SendResult(success=False, error="No Slack thread target")
+            thread_ts = key[1]
+            stream = self._native_task_card_streams.get(key)
+
+            if stream is None or stream.stopped:
+                start_payload = {
+                    "channel": chat_id,
+                    "thread_ts": thread_ts,
+                    "task_display_mode": "plan",
+                }
+                md = metadata or {}
+                recipient_team_id = md.get("recipient_team_id") or md.get("team_id")
+                recipient_user_id = md.get("recipient_user_id") or md.get("user_id")
+                if recipient_team_id:
+                    start_payload["recipient_team_id"] = recipient_team_id
+                if recipient_user_id:
+                    start_payload["recipient_user_id"] = recipient_user_id
+                result = await client.api_call("chat.startStream", json=start_payload)
+                stream_ts = ""
+                if isinstance(result, dict):
+                    stream_ts = str(result.get("ts") or result.get("message_ts") or "")
+                if not stream_ts and hasattr(result, "get"):
+                    stream_ts = str(result.get("ts") or result.get("message_ts") or "")
+                if not stream_ts:
+                    stream_ts = thread_ts
+                stream = _NativeTaskCardStream(
+                    channel=chat_id,
+                    thread_ts=thread_ts,
+                    stream_ts=stream_ts,
+                )
+                self._native_task_card_streams[key] = stream
+
+            chunks: List[Dict[str, Any]] = [{"type": "plan_update", "title": title}]
+            for task in tasks:
+                task_id = str(task.get("id") or task.get("task_id") or "task")
+                task_title = str(task.get("title") or task_id)
+                status = str(task.get("status") or "in_progress")
+                if status not in {"in_progress", "complete", "error"}:
+                    status = "in_progress"
+                chunks.append(
+                    {
+                        "type": "task_update",
+                        "id": task_id,
+                        "title": task_title,
+                        "status": status,
+                    }
+                )
+
+            append_payload = {
+                "channel": chat_id,
+                "ts": stream.stream_ts,
+                "chunks": chunks,
+            }
+            if fallback_text:
+                append_payload["markdown_text"] = fallback_text
+            await client.api_call("chat.appendStream", json=append_payload)
+            return SendResult(success=True, message_id=stream.stream_ts)
+        except Exception as e:  # pragma: no cover - defensive logging
+            logger.error("[Slack] Native task-card progress error: %s", e, exc_info=True)
+            return SendResult(success=False, error=str(e), retryable=True)
+
+    async def stop_native_task_card_progress(
+        self,
+        chat_id: str,
+        *,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        """Finalize an active Slack-native progress task-card stream."""
+        if not self._app:
+            return
+        key = self._native_task_card_key(chat_id, reply_to, metadata)
+        if key is None:
+            return
+        stream = self._native_task_card_streams.pop(key, None)
+        if not stream or stream.stopped:
+            return
+        stream.stopped = True
+        try:
+            await self._get_client(chat_id).api_call(
+                "chat.stopStream",
+                json={"channel": chat_id, "ts": stream.stream_ts},
+            )
+        except Exception as e:
+            logger.debug("[Slack] Native task-card stopStream failed: %s", e)
 
     async def send(
         self,
@@ -2187,6 +2348,7 @@ class SlackAdapter(BasePlatformAdapter):
             user_id=user_id,
             user_name=user_name,
             thread_id=thread_ts,
+            guild_id=team_id,
         )
 
         # Per-channel ephemeral prompt

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -15508,6 +15508,18 @@ class GatewayRunner:
         last_tool = [None]  # Mutable container for tracking in closure
         last_progress_msg = [None]  # Track last message for dedup
         repeat_count = [0]  # How many times the same message repeated
+        _progress_adapter = self.adapters.get(source.platform)
+        _native_slack_task_cards = False
+        if (
+            tool_progress_enabled
+            and source.platform == Platform.SLACK
+            and _progress_adapter is not None
+            and hasattr(_progress_adapter, "native_task_cards_enabled")
+        ):
+            try:
+                _native_slack_task_cards = bool(_progress_adapter.native_task_cards_enabled())
+            except Exception:
+                _native_slack_task_cards = False
 
         # Auto-cleanup of temporary progress bubbles (Telegram + any adapter
         # that implements ``delete_message``). When enabled via
@@ -15563,10 +15575,17 @@ class GatewayRunner:
                             mark_seen(_hermes_home / "config.yaml", TOOL_PROGRESS_FLAG)
                 except Exception as _hint_err:
                     logger.debug("tool-progress onboarding hint failed: %s", _hint_err)
+            if _native_slack_task_cards and event_type == "tool.completed":
+                progress_queue.put(
+                    {
+                        "type": "tool.completed",
+                        "tool_name": tool_name or "tool",
+                        "is_error": bool(kwargs.get("is_error")),
+                    }
+                )
                 return
 
-
-            # Only act on tool.started events (ignore tool.completed, reasoning.available, etc.)
+            # Only act on tool.started events (ignore reasoning.available, etc.)
             if event_type not in {"tool.started",}:
                 return
 
@@ -15590,6 +15609,16 @@ class GatewayRunner:
             if progress_mode == "new" and tool_name == last_tool[0]:
                 return
             last_tool[0] = tool_name
+
+            if _native_slack_task_cards:
+                progress_queue.put(
+                    {
+                        "type": "tool.started",
+                        "tool_name": tool_name or "tool",
+                        "preview": preview or "",
+                    }
+                )
+                return
             
             # Build progress message with primary argument preview
             from agent.display import get_tool_emoji
@@ -15660,6 +15689,11 @@ class GatewayRunner:
             if _progress_thread_id == source.thread_id
             else {"thread_id": _progress_thread_id}
         ) if _progress_thread_id else None
+        if source.platform == Platform.SLACK and _progress_metadata is not None:
+            if source.guild_id:
+                _progress_metadata.setdefault("recipient_team_id", source.guild_id)
+            if source.user_id:
+                _progress_metadata.setdefault("recipient_user_id", source.user_id)
         _progress_reply_to = (
             event_message_id
             if source.platform in (Platform.FEISHU, Platform.MATTERMOST) and source.thread_id and event_message_id
@@ -15673,6 +15707,198 @@ class GatewayRunner:
             adapter = self.adapters.get(source.platform)
             if not adapter:
                 return
+
+            if _native_slack_task_cards and hasattr(adapter, "send_native_task_card_progress"):
+                tasks: List[Dict[str, str]] = []
+                pending_by_tool: Dict[str, List[str]] = {}
+                task_seq = 0
+                native_failed = False
+
+                def _slug(value: str) -> str:
+                    slug = re.sub(r"[^a-z0-9]+", "_", str(value or "").strip().lower())
+                    slug = slug.strip("_")
+                    return slug or "task"
+
+                def _compact(value: str, limit: int = 96) -> str:
+                    text = re.sub(r"\s+", " ", str(value or "")).strip()
+                    if len(text) <= limit:
+                        return text
+                    keep_start = max(1, int((limit - 3) * 0.45))
+                    keep_end = max(1, limit - keep_start - 3)
+                    return f"{text[:keep_start].rstrip()}...{text[-keep_end:].lstrip()}"
+
+                def _fallback_text() -> str:
+                    status_label = {
+                        "in_progress": "running",
+                        "complete": "complete",
+                        "error": "error",
+                    }
+                    lines = [
+                        f"- {task['title']} - {status_label.get(task['status'], task['status'])}"
+                        for task in tasks[-8:]
+                    ]
+                    return "Hermes is working\n" + "\n".join(lines)
+
+                async def _send_native_update() -> bool:
+                    nonlocal native_failed
+                    if native_failed or not tasks:
+                        return False
+                    result = await adapter.send_native_task_card_progress(
+                        chat_id=source.chat_id,
+                        tasks=tasks[-8:],
+                        title="Hermes is working",
+                        reply_to=_progress_reply_to,
+                        metadata=_progress_metadata,
+                        fallback_text=_fallback_text(),
+                    )
+                    if not getattr(result, "success", False):
+                        native_failed = True
+                        logger.warning(
+                            "Slack native task-card progress failed; falling back to text progress: %s",
+                            getattr(result, "error", "unknown error"),
+                        )
+                        fallback = await adapter.send(
+                            chat_id=source.chat_id,
+                            content=_fallback_text(),
+                            reply_to=_progress_reply_to,
+                            metadata=_progress_metadata,
+                        )
+                        _track_native_fallback = (
+                            _cleanup_progress
+                            and getattr(fallback, "success", False)
+                            and getattr(fallback, "message_id", None)
+                        )
+                        if _track_native_fallback:
+                            _cleanup_msg_ids.append(str(fallback.message_id))
+                        return False
+                    return True
+
+                def _start_task(tool_name: str, preview: str) -> None:
+                    nonlocal task_seq
+                    task_seq += 1
+                    base = tool_name or "tool"
+                    task_id = f"{_slug(base)}_{task_seq}"
+                    title = base
+                    detail = _compact(preview or "", 64)
+                    if detail:
+                        title = f"{base} - {detail}"
+                    tasks.append(
+                        {
+                            "id": task_id,
+                            "title": _compact(title, 120),
+                            "status": "in_progress",
+                        }
+                    )
+                    pending_by_tool.setdefault(base, []).append(task_id)
+
+                def _complete_task(tool_name: str, *, is_error: bool = False) -> None:
+                    base = tool_name or "tool"
+                    pending = pending_by_tool.get(base) or []
+                    task_id = pending.pop(0) if pending else ""
+                    if pending:
+                        pending_by_tool[base] = pending
+                    else:
+                        pending_by_tool.pop(base, None)
+                    target = next(
+                        (
+                            task
+                            for task in tasks
+                            if task["id"] == task_id
+                        ),
+                        None,
+                    )
+                    if target is None:
+                        target = next(
+                            (
+                                task
+                                for task in reversed(tasks)
+                                if task["status"] == "in_progress"
+                                and task["id"].startswith(f"{_slug(base)}_")
+                            ),
+                            None,
+                        )
+                    if target is not None:
+                        target["status"] = "error" if is_error else "complete"
+
+                async def _finalize_native_progress() -> None:
+                    if tasks and not native_failed:
+                        for task in tasks:
+                            if task["status"] == "in_progress":
+                                task["status"] = "complete"
+                        await _send_native_update()
+                    if hasattr(adapter, "stop_native_task_card_progress"):
+                        await adapter.stop_native_task_card_progress(
+                            source.chat_id,
+                            reply_to=_progress_reply_to,
+                            metadata=_progress_metadata,
+                        )
+
+                def _drain_native_progress_queue() -> None:
+                    while not progress_queue.empty():
+                        try:
+                            raw = progress_queue.get_nowait()
+                        except Exception:
+                            break
+                        if not isinstance(raw, dict):
+                            continue
+                        if raw.get("type") == "tool.started":
+                            _start_task(
+                                str(raw.get("tool_name") or "tool"),
+                                str(raw.get("preview") or ""),
+                            )
+                        elif raw.get("type") == "tool.completed":
+                            _complete_task(
+                                str(raw.get("tool_name") or "tool"),
+                                is_error=bool(raw.get("is_error")),
+                            )
+
+                while True:
+                    try:
+                        if not _run_still_current():
+                            _drain_native_progress_queue()
+                            await _finalize_native_progress()
+                            return
+
+                        raw = progress_queue.get_nowait()
+
+                        try:
+                            _agent_for_interrupt = agent_holder[0] if agent_holder else None
+                            if _agent_for_interrupt is not None and getattr(
+                                _agent_for_interrupt, "is_interrupted", False
+                            ):
+                                await asyncio.sleep(0)
+                                continue
+                        except Exception:
+                            pass
+
+                        if not isinstance(raw, dict):
+                            continue
+                        if raw.get("type") == "tool.started":
+                            _start_task(str(raw.get("tool_name") or "tool"), str(raw.get("preview") or ""))
+                            await _send_native_update()
+                        elif raw.get("type") == "tool.completed":
+                            _complete_task(
+                                str(raw.get("tool_name") or "tool"),
+                                is_error=bool(raw.get("is_error")),
+                            )
+                            await _send_native_update()
+
+                        await asyncio.sleep(0.1)
+                    except queue.Empty:
+                        try:
+                            await asyncio.sleep(0.2)
+                        except asyncio.CancelledError:
+                            _drain_native_progress_queue()
+                            await _finalize_native_progress()
+                            return
+                    except asyncio.CancelledError:
+                        _drain_native_progress_queue()
+                        await _finalize_native_progress()
+                        return
+                    except Exception as e:
+                        logger.error("Slack native task-card progress error: %s", e)
+                        native_failed = True
+                        await asyncio.sleep(1)
 
             # Skip tool progress for platforms that don't support message
             # editing (e.g. iMessage/BlueBubbles) — each progress update

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -121,6 +121,87 @@ class NonEditingProgressCaptureAdapter(ProgressCaptureAdapter):
         raise AssertionError("non-editable adapters should not receive edit_message calls")
 
 
+class SlackNativeTaskCardAdapter(ProgressCaptureAdapter):
+    def __init__(self):
+        super().__init__(platform=Platform.SLACK)
+        self.config.extra["native_task_cards"] = True
+        self.native_updates = []
+        self.native_stops = []
+
+    def native_task_cards_enabled(self) -> bool:
+        return True
+
+    async def send_native_task_card_progress(
+        self,
+        chat_id,
+        tasks,
+        *,
+        title="Hermes is working",
+        reply_to=None,
+        metadata=None,
+        fallback_text=None,
+    ) -> SendResult:
+        self.native_updates.append(
+            {
+                "chat_id": chat_id,
+                "tasks": [dict(task) for task in tasks],
+                "title": title,
+                "reply_to": reply_to,
+                "metadata": metadata,
+                "fallback_text": fallback_text,
+            }
+        )
+        return SendResult(success=True, message_id="native-stream-1")
+
+    async def stop_native_task_card_progress(
+        self,
+        chat_id,
+        *,
+        reply_to=None,
+        metadata=None,
+    ) -> None:
+        self.native_stops.append(
+            {
+                "chat_id": chat_id,
+                "reply_to": reply_to,
+                "metadata": metadata,
+            }
+        )
+
+
+class SlackNativeTaskCardDisabledAdapter(SlackNativeTaskCardAdapter):
+    def __init__(self):
+        super().__init__()
+        self.config.extra["native_task_cards"] = False
+
+    def native_task_cards_enabled(self) -> bool:
+        return False
+
+
+class FailingSlackNativeTaskCardAdapter(SlackNativeTaskCardAdapter):
+    async def send_native_task_card_progress(
+        self,
+        chat_id,
+        tasks,
+        *,
+        title="Hermes is working",
+        reply_to=None,
+        metadata=None,
+        fallback_text=None,
+    ) -> SendResult:
+        self.native_updates.append(
+            {
+                "chat_id": chat_id,
+                "tasks": [dict(task) for task in tasks],
+                "title": title,
+                "reply_to": reply_to,
+                "metadata": metadata,
+                "fallback_text": fallback_text,
+            }
+        )
+        return SendResult(success=False, error="native stream unavailable")
+
+
 class FakeAgent:
     def __init__(self, **kwargs):
         # Capture anything passed via kwargs (older code path) but don't
@@ -137,6 +218,63 @@ class FakeAgent:
             time.sleep(0.35)
             cb("tool.started", "browser_navigate", "https://example.com", {})
             time.sleep(0.35)
+        return {
+            "final_response": "done",
+            "messages": [],
+            "api_calls": 1,
+        }
+
+
+class CompletingToolAgent:
+    def __init__(self, **kwargs):
+        self.tool_progress_callback = kwargs.get("tool_progress_callback")
+        self.tools = []
+
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        cb = self.tool_progress_callback
+        if cb is not None:
+            cb("tool.started", "terminal", "pwd", {})
+            time.sleep(0.35)
+            cb("tool.completed", "terminal", None, None, duration=0.2, is_error=False)
+            time.sleep(0.1)
+        return {
+            "final_response": "done",
+            "messages": [],
+            "api_calls": 1,
+        }
+
+
+class FailingToolAgent:
+    def __init__(self, **kwargs):
+        self.tool_progress_callback = kwargs.get("tool_progress_callback")
+        self.tools = []
+
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        cb = self.tool_progress_callback
+        if cb is not None:
+            cb("tool.started", "terminal", "false", {})
+            time.sleep(0.35)
+            cb("tool.completed", "terminal", None, None, duration=0.2, is_error=True)
+            time.sleep(0.1)
+        return {
+            "final_response": "handled failure",
+            "messages": [],
+            "api_calls": 1,
+        }
+
+
+class RepeatedToolAgent:
+    def __init__(self, **kwargs):
+        self.tool_progress_callback = kwargs.get("tool_progress_callback")
+        self.tools = []
+
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        cb = self.tool_progress_callback
+        if cb is not None:
+            cb("tool.started", "terminal", "pwd", {})
+            time.sleep(0.35)
+            cb("tool.started", "terminal", "ls", {})
+            time.sleep(0.1)
         return {
             "final_response": "done",
             "messages": [],
@@ -243,6 +381,151 @@ def _make_runner(adapter):
         stt_enabled=False,
     )
     return runner
+
+
+async def _run_slack_native_progress_case(
+    monkeypatch,
+    tmp_path,
+    adapter,
+    agent_cls,
+    *,
+    thread_id="parent_ts",
+    chat_type="group",
+    user_id=None,
+    guild_id=None,
+):
+    monkeypatch.setenv("HERMES_TOOL_PROGRESS_MODE", "all")
+
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = agent_cls
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+    runner = _make_runner(adapter)
+    gateway_run = importlib.import_module("gateway.run")
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "fake"})
+    source = SessionSource(
+        platform=Platform.SLACK,
+        chat_id="C123",
+        chat_type=chat_type,
+        thread_id=thread_id,
+        user_id=user_id,
+        guild_id=guild_id,
+    )
+
+    return await runner._run_agent(
+        message="hello",
+        context_prompt="",
+        history=[],
+        source=source,
+        session_id="sess-slack-native",
+        session_key=f"agent:main:slack:group:C123:{thread_id or 'root'}",
+        event_message_id="event_ts",
+    )
+
+
+@pytest.mark.asyncio
+async def test_slack_native_task_cards_receive_running_tool_update(monkeypatch, tmp_path):
+    adapter = SlackNativeTaskCardAdapter()
+    result = await _run_slack_native_progress_case(
+        monkeypatch, tmp_path, adapter, CompletingToolAgent
+    )
+
+    assert result["final_response"] == "done"
+    assert adapter.native_updates
+    first_update = adapter.native_updates[0]
+    assert first_update["metadata"] == {"thread_id": "parent_ts"}
+    assert first_update["tasks"][0]["title"] == "terminal - pwd"
+    assert first_update["tasks"][0]["status"] == "in_progress"
+    assert adapter.native_updates[-1]["tasks"][0]["status"] == "complete"
+    assert adapter.native_stops == [
+        {
+            "chat_id": "C123",
+            "reply_to": None,
+            "metadata": {"thread_id": "parent_ts"},
+        }
+    ]
+    assert adapter.sent == []
+    assert adapter.edits == []
+
+
+@pytest.mark.asyncio
+async def test_slack_native_task_cards_include_recipient_metadata(monkeypatch, tmp_path):
+    adapter = SlackNativeTaskCardAdapter()
+    result = await _run_slack_native_progress_case(
+        monkeypatch,
+        tmp_path,
+        adapter,
+        CompletingToolAgent,
+        user_id="U123",
+        guild_id="T123",
+    )
+
+    assert result["final_response"] == "done"
+    assert adapter.native_updates[0]["metadata"] == {
+        "thread_id": "parent_ts",
+        "recipient_team_id": "T123",
+        "recipient_user_id": "U123",
+    }
+
+
+@pytest.mark.asyncio
+async def test_slack_native_task_cards_are_off_by_default(monkeypatch, tmp_path):
+    adapter = SlackNativeTaskCardDisabledAdapter()
+    result = await _run_slack_native_progress_case(
+        monkeypatch, tmp_path, adapter, CompletingToolAgent
+    )
+
+    assert result["final_response"] == "done"
+    assert adapter.native_updates == []
+    assert adapter.native_stops == []
+    assert adapter.sent
+    assert adapter.sent[0]["metadata"] == {"thread_id": "parent_ts"}
+    assert adapter.edits
+
+
+@pytest.mark.asyncio
+async def test_slack_native_task_cards_map_failed_tools_to_error(monkeypatch, tmp_path):
+    adapter = SlackNativeTaskCardAdapter()
+    result = await _run_slack_native_progress_case(
+        monkeypatch, tmp_path, adapter, FailingToolAgent
+    )
+
+    assert result["final_response"] == "handled failure"
+    assert adapter.native_updates
+    assert adapter.native_updates[-1]["tasks"][0]["status"] == "error"
+    assert adapter.sent == []
+
+
+@pytest.mark.asyncio
+async def test_slack_native_task_cards_keep_repeated_tool_calls_distinct(monkeypatch, tmp_path):
+    adapter = SlackNativeTaskCardAdapter()
+    result = await _run_slack_native_progress_case(
+        monkeypatch, tmp_path, adapter, RepeatedToolAgent
+    )
+
+    assert result["final_response"] == "done"
+    latest_tasks = adapter.native_updates[-1]["tasks"]
+    assert [task["id"] for task in latest_tasks] == ["terminal_1", "terminal_2"]
+    assert [task["title"] for task in latest_tasks] == ["terminal - pwd", "terminal - ls"]
+
+
+@pytest.mark.asyncio
+async def test_slack_native_task_card_failure_falls_back_in_thread(monkeypatch, tmp_path):
+    adapter = FailingSlackNativeTaskCardAdapter()
+    result = await _run_slack_native_progress_case(
+        monkeypatch, tmp_path, adapter, CompletingToolAgent
+    )
+
+    assert result["final_response"] == "done"
+    assert adapter.native_updates
+    assert adapter.sent
+    assert adapter.sent[0]["metadata"] == {"thread_id": "parent_ts"}
+    assert adapter.sent[0]["content"].startswith("Hermes is working\n- terminal - pwd")
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -1390,6 +1390,153 @@ class TestSendTyping:
 
 
 # ---------------------------------------------------------------------------
+# TestNativeTaskCardProgress — Slack chat.*Stream plan/task chunks
+# ---------------------------------------------------------------------------
+
+
+class TestNativeTaskCardProgress:
+    def test_native_task_cards_config_gate_defaults_off(self):
+        adapter = SlackAdapter(PlatformConfig(enabled=True, token="xoxb-fake"))
+
+        assert adapter.native_task_cards_enabled() is False
+
+    def test_native_task_cards_config_gate_supports_nested_progress(self):
+        config = PlatformConfig(
+            enabled=True,
+            token="xoxb-fake",
+            extra={"streaming": {"progress": {"native_task_cards": True}}},
+        )
+        adapter = SlackAdapter(config)
+
+        assert adapter.native_task_cards_enabled() is True
+
+    @pytest.mark.asyncio
+    async def test_sends_plan_task_chunks_over_slack_stream(self, adapter):
+        adapter.config.extra["native_task_cards"] = True
+        adapter._app.client.api_call = AsyncMock(
+            side_effect=[
+                {"ok": True, "ts": "stream_ts"},
+                {"ok": True},
+            ]
+        )
+
+        result = await adapter.send_native_task_card_progress(
+            "C123",
+            [{"id": "terminal_1", "title": "terminal - pwd", "status": "in_progress"}],
+            metadata={"thread_id": "parent_ts"},
+            fallback_text="Hermes is working\n- terminal - pwd - running",
+        )
+
+        assert result.success
+        assert result.message_id == "stream_ts"
+        adapter._app.client.api_call.assert_has_awaits(
+            [
+                call(
+                    "chat.startStream",
+                    json={
+                        "channel": "C123",
+                        "thread_ts": "parent_ts",
+                        "task_display_mode": "plan",
+                    },
+                ),
+                call(
+                    "chat.appendStream",
+                    json={
+                        "channel": "C123",
+                        "ts": "stream_ts",
+                        "chunks": [
+                            {"type": "plan_update", "title": "Hermes is working"},
+                            {
+                                "type": "task_update",
+                                "id": "terminal_1",
+                                "title": "terminal - pwd",
+                                "status": "in_progress",
+                            },
+                        ],
+                        "markdown_text": "Hermes is working\n- terminal - pwd - running",
+                    },
+                ),
+            ]
+        )
+
+    @pytest.mark.asyncio
+    async def test_start_stream_includes_optional_recipient_metadata(self, adapter):
+        adapter.config.extra["native_task_cards"] = True
+        adapter._app.client.api_call = AsyncMock(
+            side_effect=[
+                {"ok": True, "ts": "stream_ts"},
+                {"ok": True},
+            ]
+        )
+
+        result = await adapter.send_native_task_card_progress(
+            "C123",
+            [{"id": "terminal_1", "title": "terminal - pwd", "status": "in_progress"}],
+            metadata={
+                "thread_id": "parent_ts",
+                "recipient_team_id": "T123",
+                "recipient_user_id": "U123",
+            },
+        )
+
+        assert result.success
+        start_payload = adapter._app.client.api_call.await_args_list[0].kwargs["json"]
+        assert start_payload == {
+            "channel": "C123",
+            "thread_ts": "parent_ts",
+            "task_display_mode": "plan",
+            "recipient_team_id": "T123",
+            "recipient_user_id": "U123",
+        }
+
+    @pytest.mark.asyncio
+    async def test_native_stream_requires_thread_target(self, adapter):
+        adapter.config.extra["native_task_cards"] = True
+        adapter._app.client.api_call = AsyncMock()
+
+        result = await adapter.send_native_task_card_progress(
+            "C123",
+            [{"id": "terminal_1", "title": "terminal - pwd", "status": "in_progress"}],
+        )
+
+        assert not result.success
+        assert result.error == "No Slack thread target"
+        adapter._app.client.api_call.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_updates_existing_stream_and_stops_it(self, adapter):
+        adapter.config.extra["native_task_cards"] = True
+        adapter._app.client.api_call = AsyncMock(
+            side_effect=[
+                {"ok": True, "ts": "stream_ts"},
+                {"ok": True},
+                {"ok": True},
+                {"ok": True},
+            ]
+        )
+
+        await adapter.send_native_task_card_progress(
+            "C123",
+            [{"id": "terminal_1", "title": "terminal - pwd", "status": "in_progress"}],
+            metadata={"thread_id": "parent_ts"},
+        )
+        await adapter.send_native_task_card_progress(
+            "C123",
+            [{"id": "terminal_1", "title": "terminal - pwd", "status": "complete"}],
+            metadata={"thread_id": "parent_ts"},
+        )
+        await adapter.stop_native_task_card_progress(
+            "C123",
+            metadata={"thread_id": "parent_ts"},
+        )
+
+        method_names = [args.args[0] for args in adapter._app.client.api_call.await_args_list]
+        assert method_names == ["chat.startStream", "chat.appendStream", "chat.appendStream", "chat.stopStream"]
+        stop_payload = adapter._app.client.api_call.await_args_list[-1].kwargs["json"]
+        assert stop_payload == {"channel": "C123", "ts": "stream_ts"}
+
+
+# ---------------------------------------------------------------------------
 # TestFormatMessage — Markdown → mrkdwn conversion
 # ---------------------------------------------------------------------------
 

--- a/website/docs/user-guide/messaging/slack.md
+++ b/website/docs/user-guide/messaging/slack.md
@@ -335,6 +335,10 @@ platforms:
       # (Slack's "Also send to channel" feature).
       # Only the first chunk of the first reply is broadcast.
       reply_broadcast: false
+
+      # Opt in to Slack-native plan/task cards for tool progress.
+      # Final assistant replies are still posted as normal messages.
+      native_task_cards: false
 ```
 
 | Key | Default | Description |
@@ -342,6 +346,7 @@ platforms:
 | `platforms.slack.reply_to_mode` | `"first"` | Threading mode for multi-part messages: `"off"`, `"first"`, or `"all"` |
 | `platforms.slack.extra.reply_in_thread` | `true` | When `false`, channel messages get direct replies instead of threads. Messages inside existing threads still reply in-thread. |
 | `platforms.slack.extra.reply_broadcast` | `false` | When `true`, thread replies are also posted to the main channel. Only the first chunk is broadcast. |
+| `platforms.slack.extra.native_task_cards` | `false` | When `true`, Slack tool-progress updates use native plan/task-card stream chunks while final replies remain normal messages. |
 
 ### Session Isolation
 


### PR DESCRIPTION
## Summary

Closes #29483.

This adds an opt-in Slack gateway progress path that renders tool progress through Slack native streaming task cards. When `platforms.slack.extra.native_task_cards: true` is set, Hermes starts a Slack stream with `task_display_mode: plan`, appends `plan_update` / `task_update` chunks as tools start and finish, and stops the stream once the run is finalized.

Final assistant replies still use the normal Hermes Slack send path. The native stream is progress-only and remains Slack-specific.

## Behavior

- Defaults remain unchanged. Native task cards are off unless explicitly enabled for Slack.
- Slack thread routing is preserved through existing thread metadata.
- Slack team/user recipient metadata is forwarded when available for stream startup.
- Repeated same-name tool calls get distinct task IDs.
- Tool completion maps to `complete`; tool errors map to `error`.
- If the native stream cannot start or update, Hermes falls back to an in-thread text progress message and still allows the final reply path to continue.

## Docs

- Added the new Slack config key to the Slack messaging guide.
- Added a short note to `cli-config.yaml.example` near the existing tool progress setting.

## Checks

- `python3 -m py_compile gateway/platforms/slack.py gateway/run.py tests/gateway/test_slack.py tests/gateway/test_run_progress_topics.py`
- `git diff --check`
- `UV_CACHE_DIR=/tmp/uv-cache uv run --with pytest --with pytest-xdist --with pytest-timeout --with pytest-asyncio pytest tests/gateway/test_slack.py::TestNativeTaskCardProgress tests/gateway/test_run_progress_topics.py -q` - 39 passed
- `UV_CACHE_DIR=/tmp/uv-cache uv run --with pytest --with pytest-xdist --with pytest-timeout --with pytest-asyncio pytest tests/gateway/test_slack.py -q` - 192 passed, 33 existing AsyncMock warnings

## Notes

I did not perform live Slack runtime validation in this draft. The PR has focused unit coverage for the adapter payloads, gateway progress routing, fallback behavior, and final-response separation.
