### PR TITLE
fix(doctor): recognize gh_cli credential pool for Copilot provider

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -589,8 +589,9 @@ def _resolve_api_key_provider_secret(
             logger.warning("Copilot token validation failed: %s", exc)
         except Exception:
             pass
-        return "", ""
-
+        # Fall through to credential pool check below — the gh_cli
+        # credential stored via `hermes auth add` may be usable even
+        # when resolve_copilot_token() fails (e.g. classic PAT ghp_*).
     from hermes_cli.config import get_env_value
     for env_var in pconfig.api_key_env_vars:
         # Check both os.environ and ~/.hermes/.env file


### PR DESCRIPTION
## Summary

`hermes doctor` falsely reports 'No credentials found for provider copilot' even when a working `gh_cli` credential exists in the pool (visible via `hermes auth list copilot`).

## Root Cause

`_resolve_api_key_provider_secret()` has special handling for copilot that calls `resolve_copilot_token()`. When this fails (e.g. the user's `gh auth token` returns a classic PAT `ghp_*` which is rejected by `validate_copilot_token()`), the function returns empty string **immediately** — without falling through to the credential pool check that other providers use.

The credential pool is where `hermes auth add` stores the `gh_cli` credential, and what `hermes auth list` reads from.

## Fix

Remove the early `return "", ""` for copilot so the function falls through to the existing credential pool check. This makes doctor consistent with `hermes auth list`.

Fixes #29442