### PR TITLE
fix(gateway): prioritize Telegram command menu

### DIFF
--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -508,6 +508,64 @@ def telegram_bot_commands() -> list[tuple[str, str]]:
     return result
 
 
+_TELEGRAM_MENU_PRIORITY = (
+    "debug",
+    "restart",
+    "update",
+    "verbose",
+    "commands",
+    "help",
+    "new",
+    "stop",
+    "status",
+    "resume",
+    "sessions",
+    "approve",
+    "deny",
+    "queue",
+    "steer",
+    "background",
+    "model",
+    "reasoning",
+    "usage",
+    "platforms",
+    "platform",
+    "profile",
+    "whoami",
+)
+"""Built-in commands that should stay visible in Telegram's capped menu.
+
+Telegram only displays a small BotCommand menu in practice.  The full Hermes
+registry is still dispatchable when typed manually, but operational commands
+need to survive the visible menu cap ahead of lower-priority built-ins.
+"""
+
+
+def _prioritize_telegram_menu_commands(
+    commands: list[tuple[str, str]],
+) -> list[tuple[str, str]]:
+    priority = {
+        _sanitize_telegram_name(name): index
+        for index, name in enumerate(_TELEGRAM_MENU_PRIORITY)
+    }
+    return [
+        command
+        for _index, command in sorted(
+            enumerate(commands),
+            key=lambda item: (
+                0,
+                priority[item[1][0]],
+                item[0],
+            )
+            if item[1][0] in priority
+            else (
+                1,
+                item[0],
+            ),
+        )
+    ]
+
+
 _CMD_NAME_LIMIT = 32
 """Max command name length shared by Telegram and Discord."""
 
@@ -721,11 +779,12 @@ def telegram_menu_commands(max_commands: int = 100) -> tuple[list[tuple[str, str
 
     Returns:
         (menu_commands, hidden_count) where hidden_count is the number of
-        skill commands omitted due to the cap.
+        commands omitted due to the cap.
     """
-    core_commands = list(telegram_bot_commands())
+    core_commands = _prioritize_telegram_menu_commands(list(telegram_bot_commands()))
     reserved_names = {n for n, _ in core_commands}
     all_commands = list(core_commands)
+    hidden_core_count = max(0, len(all_commands) - max_commands)
 
     remaining_slots = max(0, max_commands - len(all_commands))
     entries, hidden_count = _collect_gateway_skill_entries(
@@ -737,7 +796,7 @@ def telegram_menu_commands(max_commands: int = 100) -> tuple[list[tuple[str, str
     )
     # Drop the cmd_key — Telegram only needs (name, desc) pairs.
     all_commands.extend((n, d) for n, d, _k in entries)
-    return all_commands[:max_commands], hidden_count
+    return all_commands[:max_commands], hidden_count + hidden_core_count
 
 
 def discord_skill_commands(

--- a/tests/hermes_cli/test_commands.py
+++ b/tests/hermes_cli/test_commands.py
@@ -951,6 +951,30 @@ class TestTelegramMenuCommands:
                 f"Command '{name}' is {len(name)} chars (limit {_TG_NAME_LIMIT})"
             )
 
+    def test_operational_builtins_survive_thirty_command_cap(self, tmp_path, monkeypatch):
+        (tmp_path / "config.yaml").write_text(
+            "display:\n  tool_progress_command: true\n"
+        )
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        menu, hidden = telegram_menu_commands(max_commands=30)
+        names = [name for name, _desc in menu]
+
+        assert len(names) == 30
+        assert hidden > 0
+        for name in (
+            "debug",
+            "restart",
+            "update",
+            "verbose",
+            "commands",
+            "help",
+            "new",
+            "stop",
+            "status",
+        ):
+            assert name in names
+
     def test_includes_plugin_commands_via_lazy_discovery(self, tmp_path, monkeypatch):
         """Telegram menu generation should discover plugin slash commands on first access."""
         from unittest.mock import patch


### PR DESCRIPTION
## What does this PR do?

Prioritizes the Telegram BotCommand menu so high-use operational Hermes commands stay visible when Telegram applies the 30-command registration cap.

The commands were still dispatchable when typed manually, but Telegram autocomplete could hide later built-in commands such as `/debug`, `/restart`, `/update`, and `/verbose` because the menu used raw registry order and sliced the first 30 entries.

This keeps built-in commands ahead of plugin/skill entries as before, but explicitly orders operational built-ins before lower-priority built-ins for Telegram's capped visible menu.

## Related Issue

Reported from Discord support. No GitHub issue yet.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/commands.py`: add an explicit Telegram menu priority list and apply it before slicing the menu to the Telegram cap.
- `hermes_cli/commands.py`: count hidden built-in commands when core commands alone exceed the cap.
- `tests/hermes_cli/test_commands.py`: add a regression test that `/debug`, `/restart`, `/update`, `/verbose`, `/commands`, `/help`, `/new`, `/stop`, and `/status` survive a 30-command Telegram menu cap.

## How to Test

1. `scripts/run_tests.sh tests/hermes_cli/test_commands.py::TestTelegramMenuCommands::test_operational_builtins_survive_thirty_command_cap -n 4`
2. `python -m compileall -q hermes_cli/commands.py tests/hermes_cli/test_commands.py`
3. `git diff --check -- hermes_cli/commands.py tests/hermes_cli/test_commands.py`
4. `scripts/run_tests.sh -n 4`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu / WSL Linux, Python 3.11.14

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

- [x] N/A — this PR does not add a skill.

## Screenshots / Logs

Focused regression test passed:

---
1 passed in 2.05s
---

`compileall` and `git diff --check` completed successfully.

Full suite result after creating the draft PR:

---
scripts/run_tests.sh -n 4
11 failed, 24636 passed, 54 skipped, 259 warnings in 597.69s (0:09:57)
---

Full-suite failures observed:

- `tests/gateway/test_api_server.py::TestAdapterInit::test_default_config`
- `tests/gateway/test_approve_deny_commands.py::TestBlockingApprovalE2E::test_blocking_approval_approve_once`
- `tests/gateway/test_approve_deny_commands.py::TestBlockingApprovalE2E::test_blocking_approval_deny`
- `tests/gateway/test_config.py::TestLoadGatewayConfig::test_bridges_quoted_false_platform_enabled_from_config_yaml`
- `tests/gateway/test_discord_bot_filter.py::TestDiscordBotFilter::test_default_is_none`
- `tests/gateway/test_runner_startup_failures.py::test_start_gateway_replace_force_uses_terminate_pid`
- `tests/plugins/web/test_web_search_provider_plugins.py::TestBundledPluginsRegister::test_all_seven_plugins_present_in_registry`
- `tests/tools/test_tirith_security.py::TestDiskFailureMarker::test_cosign_missing_marker_clears_when_cosign_appears`
- `tests/tui_gateway/test_goal_command.py::test_goal_bare_shows_status_when_none_set`
- `tests/tui_gateway/test_goal_command.py::test_goal_whitespace_only_shows_status`
- `tests/tui_gateway/test_goal_command.py::test_goal_status_alias_shows_status`

These failures are outside the files changed in this PR and appear unrelated to the Telegram menu priority change.
