### PR TITLE
fix(gateway): prevent silent message loss when extract pipeline strip…

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -3232,6 +3232,17 @@ class BasePlatformAdapter(ABC):
                         except OSError:
                             pass
 
+                # Log a warning when the extract pipeline stripped a
+                # non-empty response to empty, and fall back to sending
+                # the raw response to prevent silent message loss.
+                if not text_content and response:
+                    logger.warning(
+                        "[%s] Response stripped to empty after extract pipeline "
+                        "(orig=%d chars). Sending raw response as fallback.",
+                        self.name, len(response),
+                    )
+                    text_content = response
+
                 # Send the text portion
                 if text_content and not _tts_caption_delivered:
                     logger.info("[%s] Sending response (%d chars) to %s", self.name, len(text_content), event.source.chat_id)


### PR DESCRIPTION
Title: fix(gateway): prevent silent message loss when extract pipeline strips tool-using responses

## Summary
When a response with `api_calls >= 2` goes through the extract pipeline
(extract_media → extract_images → extract_local_files), `text_content`
can be reduced to an empty string. The `if text_content:` send guard on
line 3236 then silently drops the response — no error, no warning, just
a missing `Sending response` log line.

Log a `WARNING` when this happens and fall back to the raw response so
the message is delivered instead of silently lost.

## Changes
| File | Change |
|---|---|
| `gateway/platforms/base.py:3201-3210` | Added warning + fallback when text_content is empty after extract pipeline |

Fixes #29346