### PR TITLE
fix(mcp): prevent event loop freeze by running OSV malware check via …

### DIFF
--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -1269,7 +1269,7 @@ class MCPServerTask:
 
         # Check package against OSV malware database before spawning
         from tools.osv_check import check_package_for_malware
-        malware_error = check_package_for_malware(command, args)
+        malware_error = await asyncio.to_thread(check_package_for_malware, command, args)
         if malware_error:
             raise ValueError(
                 f"MCP server '{self.name}': {malware_error}"


### PR DESCRIPTION
Title: fix(mcp): prevent event loop freeze by running OSV malware check via asyncio.to_thread


## Summary
The synchronous `urllib.request.urlopen()` call in
`check_package_for_malware()` blocks the asyncio event loop when the
OSV API SSL handshake intermittently hangs. This freezes MCP discovery
for up to 120s, causing the TUI's 15s startup timeout to fire and the
gateway to become unusable.

Wrap the call in `await asyncio.to_thread()` to keep the event loop
responsive during malware checks.

## Changes

| File | Change |
|---|---|
| `tools/mcp_tool.py:1272` | `await asyncio.to_thread(check_package_for_malware, ...)` |

Fixes #29184