### PR TITLE
fix(auth): honor shared auth home for profiled workers

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -798,13 +798,29 @@ def _oauth_trace(event: str, *, sequence_id: Optional[str] = None, **fields: Any
 # Auth Store — persistence layer for ~/.hermes/auth.json
 # =============================================================================
 
+def _auth_home_override() -> Optional[Path]:
+    """Return the explicit auth-store root, if configured.
+
+    ``HERMES_HOME`` scopes runtime/profile state. ``HERMES_AUTH_HOME`` scopes
+    long-lived OAuth credentials. Profiled workers can therefore keep isolated
+    config, logs, memory, etc. while sharing one ``auth.json`` and one lock for
+    single-use refresh-token providers such as OpenAI Codex.
+    """
+    raw = os.environ.get("HERMES_AUTH_HOME", "").strip()
+    if not raw:
+        return None
+    return Path(raw).expanduser()
+
+
 def _auth_file_path() -> Path:
-    path = get_hermes_home() / "auth.json"
-    # Seat belt: if pytest is running and HERMES_HOME resolves to the real
-    # user's auth store, refuse rather than silently corrupt it. This catches
-    # tests that forgot to monkeypatch HERMES_HOME, tests invoked without the
-    # hermetic conftest, or sandbox escapes via threads/subprocesses. In
-    # production (no PYTEST_CURRENT_TEST) this is a single dict lookup.
+    auth_home = _auth_home_override()
+    path = (auth_home if auth_home is not None else get_hermes_home()) / "auth.json"
+    # Seat belt: if pytest is running and the selected auth root resolves to
+    # the real user's auth store, refuse rather than silently corrupt it. This
+    # catches tests that forgot to monkeypatch HERMES_HOME/HERMES_AUTH_HOME,
+    # tests invoked without the hermetic conftest, or sandbox escapes via
+    # threads/subprocesses. In production (no PYTEST_CURRENT_TEST) this is a
+    # single dict lookup.
     if os.environ.get("PYTEST_CURRENT_TEST"):
         real_home_auth = (Path.home() / ".hermes" / "auth.json").resolve(strict=False)
         try:
@@ -814,14 +830,19 @@ def _auth_file_path() -> Path:
         if resolved == real_home_auth:
             raise RuntimeError(
                 f"Refusing to touch real user auth store during test run: {path}. "
-                "Set HERMES_HOME to a tmp_path in your test fixture, or run "
-                "via scripts/run_tests.sh for hermetic CI-parity env."
+                "Set HERMES_HOME/HERMES_AUTH_HOME to a tmp_path in your test fixture, "
+                "or run via scripts/run_tests.sh for hermetic CI-parity env."
             )
     return path
 
 
 def _global_auth_file_path() -> Optional[Path]:
     """Return the global-root auth.json when the process is in profile mode.
+
+    Returns ``None`` when an explicit ``HERMES_AUTH_HOME`` is configured: in
+    that mode the shared auth root is already authoritative for both reads and
+    writes, so layering a read-only global fallback on top would reintroduce
+    split-brain credential state.
 
     Returns ``None`` when the profile and global root resolve to the same
     directory (classic mode, or custom HERMES_HOME that is not a profile).
@@ -830,6 +851,8 @@ def _global_auth_file_path() -> Optional[Path]:
 
     See issue #18594 follow-up (credential_pool shadowing).
     """
+    if _auth_home_override() is not None:
+        return None
     try:
         from hermes_constants import get_default_hermes_root
         global_root = get_default_hermes_root()

--- a/tests/hermes_cli/test_auth_profile_fallback.py
+++ b/tests/hermes_cli/test_auth_profile_fallback.py
@@ -15,6 +15,13 @@ import json
 from pathlib import Path
 
 import pytest
+from typing import Any, cast
+
+
+@pytest.fixture(autouse=True)
+def _clear_external_auth_home(monkeypatch):
+    """Keep ambient service env from leaking into hermetic auth tests."""
+    monkeypatch.delenv("HERMES_AUTH_HOME", raising=False)
 
 
 def _make_auth_store(pool: dict | None = None, providers: dict | None = None) -> dict:
@@ -278,6 +285,86 @@ def test_provider_auth_state_returns_none_when_neither_has_it(profile_env):
 # ---------------------------------------------------------------------------
 # Classic mode — no fallback path should ever trigger
 # ---------------------------------------------------------------------------
+
+
+def test_explicit_auth_home_is_authoritative_for_profile_reads(tmp_path, monkeypatch):
+    """HERMES_AUTH_HOME gives profiled workers one shared auth.json."""
+    from hermes_cli.auth import _auth_file_path, _global_auth_file_path, read_credential_pool
+
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: fake_home)
+
+    runtime_root = tmp_path / "runtime"
+    profile_dir = runtime_root / "profiles" / "coder"
+    profile_dir.mkdir(parents=True)
+    shared_auth = tmp_path / "shared-auth"
+    shared_auth.mkdir()
+
+    monkeypatch.setenv("HERMES_HOME", str(profile_dir))
+    monkeypatch.setenv("HERMES_AUTH_HOME", str(shared_auth))
+
+    _write(shared_auth / "auth.json", _make_auth_store(pool={
+        "openai-codex": [{
+            "id": "shared-codex",
+            "label": "shared-codex",
+            "auth_type": "oauth",
+            "priority": 0,
+            "source": "oauth",
+            "access_token": "at-shared",
+            "refresh_token": "rt-shared",
+        }],
+    }))
+    _write(profile_dir / "auth.json", _make_auth_store(pool={
+        "openai-codex": [{
+            "id": "profile-stale",
+            "label": "profile-stale",
+            "auth_type": "oauth",
+            "priority": 0,
+            "source": "oauth",
+            "access_token": "at-stale",
+            "refresh_token": "rt-stale",
+        }],
+    }))
+
+    assert _auth_file_path() == shared_auth / "auth.json"
+    assert _global_auth_file_path() is None
+    entries = cast(list[dict[str, Any]], read_credential_pool("openai-codex"))
+    assert [e["id"] for e in entries] == ["shared-codex"]
+    assert entries[0]["refresh_token"] == "rt-shared"
+
+
+def test_explicit_auth_home_is_authoritative_for_profile_writes(tmp_path, monkeypatch):
+    """Writes update the shared auth store, not the runtime profile store."""
+    from hermes_cli.auth import write_credential_pool
+
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: fake_home)
+
+    profile_dir = tmp_path / "runtime" / "profiles" / "coder"
+    profile_dir.mkdir(parents=True)
+    shared_auth = tmp_path / "shared-auth"
+    shared_auth.mkdir()
+
+    monkeypatch.setenv("HERMES_HOME", str(profile_dir))
+    monkeypatch.setenv("HERMES_AUTH_HOME", str(shared_auth))
+
+    _write(profile_dir / "auth.json", _make_auth_store(pool={}))
+    write_credential_pool("openai-codex", [{
+        "id": "shared-new",
+        "label": "shared-new",
+        "auth_type": "oauth",
+        "priority": 0,
+        "source": "oauth",
+        "access_token": "at-new",
+        "refresh_token": "rt-new",
+    }])
+
+    shared_data = json.loads((shared_auth / "auth.json").read_text())
+    profile_data = json.loads((profile_dir / "auth.json").read_text())
+    assert shared_data["credential_pool"]["openai-codex"][0]["id"] == "shared-new"
+    assert profile_data["credential_pool"] == {}
 
 
 def test_classic_mode_does_not_double_read_same_file(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- Add `HERMES_AUTH_HOME` as an explicit auth-store root for profiled Hermes workers.
- Keep profile/runtime state (`HERMES_HOME`) separate from long-lived OAuth credentials.
- Avoid read-only global fallback when an explicit shared auth home is configured, preventing split-brain auth state.

## Why
OAuth providers with rotating/single-use refresh tokens can fail when multiple profiled workers read/write different `auth.json` files. A shared auth root lets workers keep isolated config/logs while using one credential store and one lock.

## Test Plan
- `env -u HERMES_AUTH_HOME -u HERMES_SHARED_AUTH_DIR .venv/bin/python -m pytest tests/hermes_cli/test_auth_codex_provider.py tests/hermes_cli/test_auth_profile_fallback.py -q -o 'addopts='`
- Result: `29 passed`

## Privacy
This PR contains only generic code/tests. No deployment paths, profile names, tokens, hostnames, or install-specific data are included.
