### PR TITLE
fix(doctor): use .env-aware config for SSH backend check

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -342,6 +342,7 @@ def run_doctor(args):
     # Doctor runs from the interactive CLI, so CLI-gated tool availability
     # checks (like cronjob management) should see the same context as `hermes`.
     os.environ.setdefault("HERMES_INTERACTIVE", "1")
+    from hermes_cli.config import get_env_value as _gev
 
     # Handle `hermes doctor --ack <id>` as a fast path. Persist the ack and
     # return without running the rest of the diagnostics — the user has
@@ -1075,7 +1076,7 @@ def run_doctor(args):
         check_info(f"Install for faster search: {_system_package_install_cmd('ripgrep')}")
     
     # Docker (optional)
-    terminal_env = os.getenv("TERMINAL_ENV", "local")
+    terminal_env = _gev("TERMINAL_ENV") or "local"
     if terminal_env == "docker":
         if _safe_which("docker"):
             # Check if docker daemon is running
@@ -1103,7 +1104,6 @@ def run_doctor(args):
     
     # SSH (if using ssh backend)
     if terminal_env == "ssh":
-        from hermes_cli.config import get_env_value as _gev
         ssh_host = _gev("TERMINAL_SSH_HOST")
         if ssh_host:
             ssh_user = _gev("TERMINAL_SSH_USER")
@@ -1163,7 +1163,7 @@ def run_doctor(args):
 
     # Vercel Sandbox (if using vercel_sandbox backend)
     if terminal_env == "vercel_sandbox":
-        runtime = os.getenv("TERMINAL_VERCEL_RUNTIME", "node24").strip() or "node24"
+        runtime = (_gev("TERMINAL_VERCEL_RUNTIME") or "node24").strip() or "node24"
         from tools.terminal_tool import _SUPPORTED_VERCEL_RUNTIMES
         if runtime in _SUPPORTED_VERCEL_RUNTIMES:
             check_ok("Vercel runtime", f"({runtime})")
@@ -1176,7 +1176,7 @@ def run_doctor(args):
                 issues,
             )
 
-        disk = os.getenv("TERMINAL_CONTAINER_DISK", "51200").strip()
+        disk = (_gev("TERMINAL_CONTAINER_DISK") or "51200").strip()
         if disk in {"", "0", "51200"}:
             check_ok("Vercel disk setting", "(uses platform default)")
         else:
@@ -1217,7 +1217,7 @@ def run_doctor(args):
         for line in auth_status.detail_lines:
             check_info(f"Vercel auth {line}")
 
-        persistent = os.getenv("TERMINAL_CONTAINER_PERSISTENT", "true").lower() in {"1", "true", "yes", "on"}
+        persistent = (_gev("TERMINAL_CONTAINER_PERSISTENT") or "true").lower() in {"1", "true", "yes", "on"}
         if persistent:
             check_info("Vercel persistence: snapshot filesystem only; live processes do not survive sandbox recreation")
         else:

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -1103,13 +1103,14 @@ def run_doctor(args):
     
     # SSH (if using ssh backend)
     if terminal_env == "ssh":
-        ssh_host = os.getenv("TERMINAL_SSH_HOST")
+        from hermes_cli.config import get_env_value as _gev
+        ssh_host = _gev("TERMINAL_SSH_HOST")
         if ssh_host:
-            ssh_user = os.getenv("TERMINAL_SSH_USER")
-            ssh_port = os.getenv("TERMINAL_SSH_PORT")
-            ssh_key = os.getenv("TERMINAL_SSH_KEY")
+            ssh_user = _gev("TERMINAL_SSH_USER")
+            ssh_port = _gev("TERMINAL_SSH_PORT")
+            ssh_key = _gev("TERMINAL_SSH_KEY")
             target = f"{ssh_user}@{ssh_host}" if ssh_user else ssh_host
-            cmd = ["ssh", "-o", "ConnectTimeout=5", "-o", "BatchMode=yes"]
+            cmd = ["ssh", "-o", "ConnectTimeout=5", "-o", "BatchMode=yes", "-o", "StrictHostKeyChecking=accept-new"]
             if ssh_port:
                 cmd += ["-p", ssh_port]
             if ssh_key:

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -285,8 +285,6 @@ def test_doctor_reports_vercel_backend_diagnostics(monkeypatch, tmp_path):
     assert "snapshot filesystem only" in out
 
 
-
-
 def test_doctor_ssh_probe_uses_strict_host_checking(monkeypatch, tmp_path):
     """SSH probe must include StrictHostKeyChecking=accept-new to match runtime backend."""
     home = tmp_path / ".hermes"
@@ -392,6 +390,54 @@ def test_doctor_ssh_reads_env_file(monkeypatch, tmp_path):
     assert "/home/deploy/.ssh/id_ed25519" in cmd  # key from .env
     assert "-p" in cmd and "2222" in cmd  # port from .env
     assert "SSH connection to remote-server" in buf.getvalue()
+
+
+def test_doctor_terminal_env_from_env_file(monkeypatch, tmp_path):
+    """TERMINAL_ENV should be read from .env file so doctor enters the right backend section."""
+    home = tmp_path / ".hermes"
+    home.mkdir(parents=True, exist_ok=True)
+    (home / "config.yaml").write_text("model:\n  provider: auto\n", encoding="utf-8")
+    (home / ".env").write_text(
+        "TERMINAL_ENV=ssh\n"
+        "TERMINAL_SSH_HOST=from-dotenv\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(doctor_mod, "HERMES_HOME", home)
+    monkeypatch.setattr(doctor_mod, "PROJECT_ROOT", tmp_path / "project")
+    monkeypatch.setattr(doctor_mod, "_DHH", str(home))
+    import hermes_cli.config as config_mod
+    monkeypatch.setattr(config_mod, "get_hermes_home", lambda: home)
+    config_mod._env_cache = None
+    (tmp_path / "project").mkdir(exist_ok=True)
+
+    # Remove TERMINAL_ENV from process env so ONLY .env has it
+    monkeypatch.delenv("TERMINAL_ENV", raising=False)
+    monkeypatch.delenv("TERMINAL_SSH_HOST", raising=False)
+
+    fake_model_tools = types.SimpleNamespace(
+        check_tool_availability=lambda *a, **kw: ([], []),
+        TOOLSET_REQUIREMENTS={},
+    )
+    monkeypatch.setitem(sys.modules, "model_tools", fake_model_tools)
+
+    ssh_commands = []
+
+    def fake_run(cmd, *args, **kwargs):
+        if cmd and cmd[0] == "ssh":
+            ssh_commands.append(cmd)
+            return SimpleNamespace(returncode=0, stdout="ok\n", stderr="")
+        return SimpleNamespace(returncode=1, stdout="", stderr="")
+
+    monkeypatch.setattr(doctor_mod.subprocess, "run", fake_run)
+
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        doctor_mod.run_doctor(Namespace(fix=False))
+
+    # If TERMINAL_ENV wasn't read from .env, doctor would skip SSH entirely
+    assert len(ssh_commands) == 1, "SSH probe not run — TERMINAL_ENV not read from .env"
+    assert "from-dotenv" in ssh_commands[0][-2]  # target host
 
 
 # ── Memory provider section (doctor should only check the *active* provider) ──
@@ -680,8 +726,6 @@ def test_run_doctor_accepts_hermes_provider_ids_that_catalog_aliases(
             f"model.default '{default_model}' uses a vendor/model slug but provider is '{provider}'"
             not in out
         )
-
-
 
 
 def test_run_doctor_accepts_kimi_coding_cn_provider(monkeypatch, tmp_path):

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -285,6 +285,115 @@ def test_doctor_reports_vercel_backend_diagnostics(monkeypatch, tmp_path):
     assert "snapshot filesystem only" in out
 
 
+
+
+def test_doctor_ssh_probe_uses_strict_host_checking(monkeypatch, tmp_path):
+    """SSH probe must include StrictHostKeyChecking=accept-new to match runtime backend."""
+    home = tmp_path / ".hermes"
+    home.mkdir(parents=True, exist_ok=True)
+    (home / "config.yaml").write_text("model:\n  provider: auto\n", encoding="utf-8")
+
+    monkeypatch.setattr(doctor_mod, "HERMES_HOME", home)
+    monkeypatch.setattr(doctor_mod, "PROJECT_ROOT", tmp_path / "project")
+    monkeypatch.setattr(doctor_mod, "_DHH", str(home))
+    (tmp_path / "project").mkdir(exist_ok=True)
+
+    monkeypatch.setenv("TERMINAL_ENV", "ssh")
+    monkeypatch.setenv("TERMINAL_SSH_HOST", "hermes-terminal")
+    monkeypatch.setenv("TERMINAL_SSH_USER", "hermes")
+    monkeypatch.setenv("TERMINAL_SSH_PORT", "2222")
+    monkeypatch.setenv("TERMINAL_SSH_KEY", "/opt/data/ssh/hermes_terminal")
+
+    fake_model_tools = types.SimpleNamespace(
+        check_tool_availability=lambda *a, **kw: ([], []),
+        TOOLSET_REQUIREMENTS={},
+    )
+    monkeypatch.setitem(sys.modules, "model_tools", fake_model_tools)
+
+    ssh_commands = []
+
+    def fake_run(cmd, *args, **kwargs):
+        if cmd and cmd[0] == "ssh":
+            ssh_commands.append(cmd)
+            return SimpleNamespace(returncode=0, stdout="ok\n", stderr="")
+        return SimpleNamespace(returncode=1, stdout="", stderr="")
+
+    monkeypatch.setattr(doctor_mod.subprocess, "run", fake_run)
+
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        doctor_mod.run_doctor(Namespace(fix=False))
+
+    assert ssh_commands == [[
+        "ssh",
+        "-o", "ConnectTimeout=5",
+        "-o", "BatchMode=yes",
+        "-o", "StrictHostKeyChecking=accept-new",
+        "-p", "2222",
+        "-i", "/opt/data/ssh/hermes_terminal",
+        "hermes@hermes-terminal",
+        "echo ok",
+    ]]
+    assert "SSH connection to hermes-terminal" in buf.getvalue()
+
+
+def test_doctor_ssh_reads_env_file(monkeypatch, tmp_path):
+    """SSH probe should read TERMINAL_SSH_* from .env file, not just process env."""
+    home = tmp_path / ".hermes"
+    home.mkdir(parents=True, exist_ok=True)
+    (home / "config.yaml").write_text("model:\n  provider: auto\n", encoding="utf-8")
+    # Write SSH config to .env file only (not process env)
+    (home / ".env").write_text(
+        "TERMINAL_SSH_HOST=remote-server\n"
+        "TERMINAL_SSH_USER=deploy\n"
+        "TERMINAL_SSH_PORT=2222\n"
+        "TERMINAL_SSH_KEY=/home/deploy/.ssh/id_ed25519\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(doctor_mod, "HERMES_HOME", home)
+    monkeypatch.setattr(doctor_mod, "PROJECT_ROOT", tmp_path / "project")
+    monkeypatch.setattr(doctor_mod, "_DHH", str(home))
+    # Patch get_hermes_home so get_env_value reads our tmp .env
+    import hermes_cli.config as config_mod
+    monkeypatch.setattr(config_mod, "get_hermes_home", lambda: home)
+    config_mod._env_cache = None
+    (tmp_path / "project").mkdir(exist_ok=True)
+
+    monkeypatch.setenv("TERMINAL_ENV", "ssh")
+    # Explicitly remove SSH vars from process env to force .env file reading
+    for k in ("TERMINAL_SSH_HOST", "TERMINAL_SSH_USER", "TERMINAL_SSH_PORT", "TERMINAL_SSH_KEY"):
+        monkeypatch.delenv(k, raising=False)
+
+    fake_model_tools = types.SimpleNamespace(
+        check_tool_availability=lambda *a, **kw: ([], []),
+        TOOLSET_REQUIREMENTS={},
+    )
+    monkeypatch.setitem(sys.modules, "model_tools", fake_model_tools)
+
+    ssh_commands = []
+
+    def fake_run(cmd, *args, **kwargs):
+        if cmd and cmd[0] == "ssh":
+            ssh_commands.append(cmd)
+            return SimpleNamespace(returncode=0, stdout="ok\n", stderr="")
+        return SimpleNamespace(returncode=1, stdout="", stderr="")
+
+    monkeypatch.setattr(doctor_mod.subprocess, "run", fake_run)
+
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        doctor_mod.run_doctor(Namespace(fix=False))
+
+    # Should have found the SSH config from .env and attempted connection
+    assert len(ssh_commands) == 1
+    cmd = ssh_commands[0]
+    assert "deploy@remote-server" in cmd  # user@host from .env
+    assert "/home/deploy/.ssh/id_ed25519" in cmd  # key from .env
+    assert "-p" in cmd and "2222" in cmd  # port from .env
+    assert "SSH connection to remote-server" in buf.getvalue()
+
+
 # ── Memory provider section (doctor should only check the *active* provider) ──
 
 


### PR DESCRIPTION
## Summary

`hermes doctor` uses `os.getenv()` to read all terminal backend config, which only checks process environment variables. Users who configure these in `~/.hermes/.env` get false negatives.

Also, the SSH probe was missing `StrictHostKeyChecking=accept-new`.

## Fix

Replace `os.getenv()` with `get_env_value()` (reads both process env and `.env` file) for **all** terminal config lookups in `run_doctor()`:

- `TERMINAL_ENV` — determines which backend section doctor enters
- `TERMINAL_SSH_HOST/USER/PORT/KEY` — SSH connection details
- `TERMINAL_VERCEL_RUNTIME` — Vercel runtime validation
- `TERMINAL_CONTAINER_DISK` / `TERMINAL_CONTAINER_PERSISTENT`

Also add `StrictHostKeyChecking=accept-new` to match runtime SSH backend.

## Tests

1. `test_doctor_ssh_probe_uses_strict_host_checking` — SSH probe includes correct host-key policy
2. `test_doctor_ssh_reads_env_file` — SSH config read from `.env` when not in process env
3. `test_doctor_terminal_env_from_env_file` — `TERMINAL_ENV` read from `.env` (root cause)

Fixes #29481