### PR TITLE
fix(kanban): sort priority-desc from highest priority first

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1590,7 +1590,7 @@ VALID_SORT_ORDERS: dict[str, str] = {
     "created": "created_at ASC, id ASC",
     "created-desc": "created_at DESC, id DESC",
     "priority": "priority DESC, created_at ASC",
-    "priority-desc": "priority ASC, created_at ASC",
+    "priority-desc": "priority DESC, created_at ASC",
     "status": "status ASC, created_at ASC",
     "assignee": "assignee ASC, created_at ASC",
     "title": "title ASC, id ASC",


### PR DESCRIPTION
Fixes `hermes kanban list --sort priority-desc` so it sorts tasks by priority descending, matching the sort name.

Previously, `priority-desc` mapped to `priority ASC`, which put lower-priority tasks before higher-priority tasks — contradicting the sort name.

Fixes #29167