### PR TITLE
fix(kanban): reject relative board default_workdir before dispatch

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -458,7 +458,12 @@ def write_board_metadata(
     if archived is not None:
         meta["archived"] = bool(archived)
     if default_workdir is not None:
-        meta["default_workdir"] = str(default_workdir) if default_workdir else None
+        default_workdir_str = str(default_workdir).strip() if default_workdir else ""
+        if default_workdir_str and not os.path.isabs(default_workdir_str):
+            raise ValueError(
+                f"default_workdir must be an absolute path, got: {default_workdir_str!r}"
+            )
+        meta["default_workdir"] = default_workdir_str or None
     if not meta.get("created_at"):
         meta["created_at"] = int(time.time())
     path = board_metadata_path(slug)
@@ -1471,6 +1476,11 @@ def create_task(
         board_meta = read_board_metadata(board_slug)
         board_default = board_meta.get("default_workdir")
         if board_default:
+            if not os.path.isabs(str(board_default)):
+                raise ValueError(
+                    f"Board '{board_slug}' has non-absolute default_workdir: {board_default!r}. "
+                    f"Fix with: hermes kanban board set-default-workdir {board_slug} <absolute-path>"
+                )
             workspace_path = str(board_default)
 
     # Retry once on the extremely unlikely id collision.


### PR DESCRIPTION
A board-level `default_workdir` could be saved as a relative path, then copied into newly created tasks and only fail later during workspace resolution/dispatch.

- Validate `default_workdir` is absolute when writing board metadata
- Guard `create_task()` against legacy board metadata with relative paths
- Surface clear error messages with fix instructions

Fixes #29145