### PR TITLE
feat: add local-first Graphiti brain workflow

### DIFF
--- a/docs/plans/2026-05-21-local-first-brain-methodology.md
+++ b/docs/plans/2026-05-21-local-first-brain-methodology.md
@@ -1,0 +1,72 @@
+# Local-First Brain + Methodology Implementation Plan
+
+> **For Hermes:** Use subagent-driven-development skill to implement this plan task-by-task.
+
+**Goal:** Add a practical local-first development methodology layer and a user-installed Graphiti memory provider for Hermes.
+
+**Architecture:** Keep upstream-safe methodology assets in the Hermes repo as built-in skills. Keep Graphiti as a user-installed memory provider under `$HERMES_HOME/plugins/graphiti` because `CONTRIBUTING.md` says new memory backends must not be added under `plugins/memory/` in-tree. Use local Ollama embeddings (`qwen3-embedding:4b`) and local Kuzu graph storage; use OpenRouter only for LLM extraction.
+
+**Tech Stack:** Hermes SKILL.md, MemoryProvider plugin API, Graphiti Core, Kuzu, Ollama embeddings, OpenRouter-compatible chat completions.
+
+---
+
+### Task 1: Add methodology router skill
+
+**Objective:** Add a built-in Hermes skill that chooses the right workflow size: quick edit, bugfix, spec-driven feature, product/SDLC mode, or brain-memory work.
+
+**Files:**
+- Create: `skills/software-development/methodology-router/SKILL.md`
+
+**Verification:** Validate SKILL.md frontmatter and ensure it references existing peer skills.
+
+### Task 2: Add spec-driven development skill
+
+**Objective:** Add a Spec Kit-inspired skill that defines Hermes artifact flow from constitution/spec/plan/tasks/implementation.
+
+**Files:**
+- Create: `skills/software-development/spec-driven-development/SKILL.md`
+
+**Verification:** Validate frontmatter and artifact paths.
+
+### Task 3: Add brain protocol skill
+
+**Objective:** Add a skill describing how Hermes should treat durable memory layers: working, episodic, semantic, procedural, knowledge, reflective.
+
+**Files:**
+- Create: `skills/software-development/agent-brain-protocol/SKILL.md`
+
+**Verification:** Validate frontmatter and integration notes for Graphiti, Mem0, Cognee/LightRAG, and Obsidian mirror.
+
+### Task 4: Create user-installed Graphiti memory provider
+
+**Objective:** Create a local plugin in `$HERMES_HOME/plugins/graphiti` that Hermes can load via `memory.provider: graphiti`.
+
+**Files:**
+- Create: `/home/kairo/.hermes/plugins/graphiti/__init__.py`
+- Create: `/home/kairo/.hermes/plugins/graphiti/plugin.yaml`
+- Create: `/home/kairo/.hermes/plugins/graphiti/README.md`
+- Create: `/home/kairo/.hermes/plugins/graphiti/requirements.txt`
+
+**Verification:** Import via `plugins.memory.load_memory_provider("graphiti")`, assert `is_available()` with local config/deps, and check tool schemas.
+
+### Task 5: Configure local-first defaults
+
+**Objective:** Set up non-secret Graphiti config with Kuzu local graph path, Ollama embedding model, OpenRouter base URL/model, and no key disclosure.
+
+**Files:**
+- Create/update: `/home/kairo/.hermes/graphiti.json`
+- Update Hermes config: `memory.provider=graphiti`
+
+**Verification:** `ollama ps` shows GPU use for `qwen3-embedding:4b`; provider loads without reading or printing OpenRouter secret.
+
+### Task 6: Validate repo changes and commit
+
+**Objective:** Run targeted validation, commit repo skill additions, push branch, open PR.
+
+**Commands:**
+- `venv/bin/python -m pytest tests/agent/test_memory_provider.py -q`
+- SKILL.md validation script
+- `git status --short`
+- `git add ... && git commit -m "feat: add local-first brain methodology skills"`
+- `git push -u origin HEAD`
+- `gh pr create ...`

--- a/plugins/memory/graphiti/README.md
+++ b/plugins/memory/graphiti/README.md
@@ -1,0 +1,78 @@
+# Hermes Graphiti Memory Provider
+
+Local-first temporal graph memory provider for Hermes.
+
+## Defaults
+
+- Graph store: local Kuzu database at `$HERMES_HOME/graphiti/graph.kuzu`
+- Embeddings: Ollama `qwen3-embedding:4b`
+- LLM extraction: OpenRouter via `OPENROUTER_API_KEY`
+- Default LLM model: `deepseek/deepseek-v4-flash`
+
+## Install dependencies
+
+Bundled install / repo checkout:
+
+```bash
+uv pip install --python ~/.hermes/hermes-agent/venv/bin/python 'hermes-agent[graphiti]'
+```
+
+Standalone user-plugin install:
+
+```bash
+uv pip install --python ~/.hermes/hermes-agent/venv/bin/python -r ~/.hermes/plugins/graphiti/requirements.txt
+```
+
+## Configure
+
+`$HERMES_HOME/graphiti.json`:
+
+```json
+{
+  "backend": "kuzu",
+  "kuzu_path": "~/.hermes/graphiti/graph.kuzu",
+  "ollama_base_url": "http://127.0.0.1:11434",
+  "embedding_model": "qwen3-embedding:4b",
+  "embedding_dim": 2560,
+  "llm_base_url": "https://openrouter.ai/api/v1",
+  "llm_model": "deepseek/deepseek-v4-flash",
+  "llm_small_model": "deepseek/deepseek-v4-flash",
+  "sync_turns": true,
+  "prefetch_top_k": 5,
+  "group_id": ""
+}
+```
+
+Secrets stay in env. Do not put `OPENROUTER_API_KEY` in this JSON.
+
+Enable provider:
+
+```bash
+hermes config set memory.provider graphiti
+```
+
+Restart Hermes after changing memory provider.
+
+## Tools
+
+- `graphiti_search` — search temporal graph memory.
+- `graphiti_remember` — store an explicit durable fact/event without waiting for turn sync.
+- `graphiti_status` — report backend/model config without printing secrets.
+
+## Privacy Controls
+
+Graph storage and embeddings are local-first, but Graphiti extraction uses the configured OpenRouter-compatible LLM endpoint by default. This means automatically synced turns are sent to that LLM endpoint for entity/relation extraction.
+
+To disable automatic turn ingestion while keeping explicit memory tools available:
+
+```json
+{
+  "sync_turns": false
+}
+```
+
+With `sync_turns=false`, use `graphiti_remember` only when the user explicitly wants durable memory.
+
+## Notes
+
+This provider is bundled under `plugins/memory/graphiti` in this branch and can also be installed as a standalone user plugin under `$HERMES_HOME/plugins/graphiti` for local experimentation.

--- a/plugins/memory/graphiti/__init__.py
+++ b/plugins/memory/graphiti/__init__.py
@@ -1,0 +1,551 @@
+"""Graphiti memory provider for Hermes.
+
+Local-first defaults:
+- Kuzu graph database under $HERMES_HOME/graphiti/graph.kuzu
+- Ollama embeddings, default qwen3-embedding:4b
+- OpenRouter-compatible LLM extraction, default deepseek/deepseek-v4-flash
+
+Secrets are read from environment variables only. This provider never prints
+API keys in status/tool output.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import re
+import threading
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Iterable, List
+
+from agent.memory_provider import MemoryProvider
+from tools.registry import tool_error
+
+try:  # Optional plugin deps; is_available() reports false when missing.
+    from graphiti_core.embedder.client import EmbedderClient
+    from graphiti_core.cross_encoder.client import CrossEncoderClient
+    from graphiti_core.llm_client.client import LLMClient, ModelSize
+    from graphiti_core.llm_client.config import LLMConfig
+except Exception:  # pragma: no cover - exercised when deps are absent on user machines
+    EmbedderClient = object  # type: ignore
+    CrossEncoderClient = object  # type: ignore
+    LLMClient = object  # type: ignore
+    ModelSize = None  # type: ignore
+    LLMConfig = None  # type: ignore
+
+logger = logging.getLogger(__name__)
+
+_BREAKER_THRESHOLD = 5
+_BREAKER_COOLDOWN_SECS = 120
+
+
+def _expand_path(value: str, hermes_home: str) -> str:
+    if not value:
+        return str(Path(hermes_home) / "graphiti" / "graph.kuzu")
+    value = value.replace("$HERMES_HOME", hermes_home)
+    return str(Path(value).expanduser())
+
+
+def _load_config(hermes_home: str | None = None) -> dict:
+    if hermes_home is None:
+        from hermes_constants import get_hermes_home
+
+        hermes_home = str(get_hermes_home())
+
+    try:
+        from hermes_cli.env_loader import load_hermes_dotenv
+
+        load_hermes_dotenv(hermes_home=Path(hermes_home))
+    except Exception:
+        # The agent runtime normally loads .env before plugins initialize. This
+        # fallback keeps standalone plugin tests usable without exposing secrets.
+        pass
+
+    cfg = {
+        "backend": os.environ.get("GRAPHITI_BACKEND", "kuzu"),
+        "kuzu_path": os.environ.get("GRAPHITI_KUZU_PATH", str(Path(hermes_home) / "graphiti" / "graph.kuzu")),
+        "ollama_base_url": os.environ.get("OLLAMA_BASE_URL", "http://127.0.0.1:11434"),
+        "embedding_model": os.environ.get("GRAPHITI_EMBEDDING_MODEL", "qwen3-embedding:4b"),
+        "embedding_dim": int(os.environ.get("GRAPHITI_EMBEDDING_DIM", "2560")),
+        "llm_base_url": os.environ.get("GRAPHITI_LLM_BASE_URL", "https://openrouter.ai/api/v1"),
+        "llm_model": os.environ.get("GRAPHITI_LLM_MODEL", "deepseek/deepseek-v4-flash"),
+        "llm_small_model": os.environ.get("GRAPHITI_LLM_SMALL_MODEL", "deepseek/deepseek-v4-flash"),
+        "llm_temperature": float(os.environ.get("GRAPHITI_LLM_TEMPERATURE", "0")),
+        "group_id": os.environ.get("GRAPHITI_GROUP_ID", "hermes-default"),
+        "sync_turns": os.environ.get("GRAPHITI_SYNC_TURNS", "true").lower() not in {"0", "false", "no"},
+        "prefetch_top_k": int(os.environ.get("GRAPHITI_PREFETCH_TOP_K", "5")),
+    }
+
+    config_path = Path(hermes_home) / "graphiti.json"
+    if config_path.exists():
+        try:
+            file_cfg = json.loads(config_path.read_text(encoding="utf-8"))
+            for k, v in file_cfg.items():
+                if v is None:
+                    continue
+                if v == "" and k != "group_id":
+                    continue
+                cfg[k] = v
+        except Exception as exc:
+            logger.warning("Failed to read graphiti.json: %s", exc)
+
+    cfg["kuzu_path"] = _expand_path(str(cfg.get("kuzu_path", "")), hermes_home)
+    cfg["embedding_dim"] = int(cfg.get("embedding_dim") or 2560)
+    cfg["prefetch_top_k"] = int(cfg.get("prefetch_top_k") or 5)
+    return cfg
+
+
+class OllamaEmbedder(EmbedderClient):
+    """Graphiti EmbedderClient-compatible wrapper for Ollama embeddings."""
+
+    def __init__(self, *, model: str, base_url: str, embedding_dim: int):
+        self.model = model
+        self.base_url = base_url.rstrip("/")
+        self.embedding_dim = embedding_dim
+
+    async def create(self, input_data: str | list[str] | Iterable[int] | Iterable[Iterable[int]]) -> list[float]:
+        texts = input_data if isinstance(input_data, list) else [str(input_data)]
+        embeddings = await self.create_batch([str(t) for t in texts])
+        return embeddings[0]
+
+    async def create_batch(self, input_data_list: list[str]) -> list[list[float]]:
+        import httpx
+
+        async with httpx.AsyncClient(timeout=60.0) as client:
+            response = await client.post(
+                f"{self.base_url}/api/embed",
+                json={"model": self.model, "input": input_data_list},
+            )
+            response.raise_for_status()
+            payload = response.json()
+        vectors = payload.get("embeddings") or []
+        if not vectors:
+            raise RuntimeError("Ollama returned no embeddings")
+        return [list(map(float, vector[: self.embedding_dim])) for vector in vectors]
+
+
+class OpenRouterJSONClient(LLMClient):
+    """Minimal Graphiti LLMClient-compatible JSON client using chat completions.
+
+    Graphiti's bundled OpenAI client uses the OpenAI Responses parse API for
+    structured outputs. OpenRouter is OpenAI-compatible for chat completions, so
+    this client asks the model for strict JSON and validates with Pydantic.
+    """
+
+    def __init__(self, *, api_key: str, base_url: str, model: str, small_model: str, temperature: float = 0.0):
+        if LLMConfig is None:
+            raise RuntimeError("graphiti-core is not installed")
+        super().__init__(LLMConfig(api_key=api_key, model=model, small_model=small_model, base_url=base_url, temperature=temperature), cache=False)
+        self.api_key = api_key
+        self.base_url = base_url
+
+    async def _generate_response(self, messages, response_model=None, max_tokens=None, model_size=None):
+        return await self.generate_response(messages, response_model=response_model, max_tokens=max_tokens, model_size=model_size)
+
+    async def generate_response(self, messages, response_model=None, max_tokens=None, model_size=None, group_id=None, prompt_name=None):
+        from openai import AsyncOpenAI
+
+        selected_model = self.small_model if ModelSize is not None and model_size == ModelSize.small else self.model
+        openai_messages = []
+        for msg in messages:
+            role = "system" if getattr(msg, "role", "user") == "system" else "user"
+            openai_messages.append({"role": role, "content": getattr(msg, "content", str(msg))})
+
+        if response_model is not None:
+            schema = response_model.model_json_schema()
+            openai_messages.append({
+                "role": "user",
+                "content": (
+                    "Return ONLY valid JSON matching this JSON Schema. "
+                    "No markdown, no commentary.\n"
+                    + json.dumps(schema, ensure_ascii=False)
+                ),
+            })
+        else:
+            openai_messages.append({"role": "user", "content": "Return ONLY valid JSON."})
+
+        client = AsyncOpenAI(api_key=self.api_key, base_url=self.base_url)
+        response = await client.chat.completions.create(
+            model=selected_model,
+            messages=openai_messages,
+            temperature=self.temperature,
+            max_tokens=max_tokens or self.max_tokens or 4096,
+            response_format={"type": "json_object"},
+        )
+        text = response.choices[0].message.content or "{}"
+        data = _extract_json(text)
+        if response_model is not None:
+            return response_model.model_validate(data).model_dump()
+        return data
+
+
+def _extract_json(text: str) -> dict:
+    text = text.strip()
+    if text.startswith("```"):
+        text = re.sub(r"^```(?:json)?\s*", "", text)
+        text = re.sub(r"\s*```$", "", text)
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        match = re.search(r"\{.*\}", text, flags=re.S)
+        if match:
+            return json.loads(match.group(0))
+        raise
+
+
+class PassthroughCrossEncoder(CrossEncoderClient):
+    """Graphiti CrossEncoderClient-compatible no-op reranker.
+
+    Keeps retrieval local-first and avoids a hidden OpenAI reranker dependency.
+    """
+
+    async def rank(self, query: str, passages: list[str]) -> list[tuple[str, float]]:
+        if not passages:
+            return []
+        # Preserve upstream order with a gentle descending score.
+        total = max(len(passages), 1)
+        return [(passage, (total - idx) / total) for idx, passage in enumerate(passages)]
+
+
+SEARCH_SCHEMA = {
+    "name": "graphiti_search",
+    "description": "Search Graphiti temporal graph memory for relevant facts, relationships, and prior events.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "query": {"type": "string", "description": "Memory query."},
+            "top_k": {"type": "integer", "description": "Maximum results, default 5, max 20."},
+        },
+        "required": ["query"],
+    },
+}
+
+REMEMBER_SCHEMA = {
+    "name": "graphiti_remember",
+    "description": "Store an explicit durable fact or event in Graphiti memory. Use only for stable, useful memory.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "content": {"type": "string", "description": "Fact/event to remember."},
+            "name": {"type": "string", "description": "Optional short episode name."},
+        },
+        "required": ["content"],
+    },
+}
+
+STATUS_SCHEMA = {
+    "name": "graphiti_status",
+    "description": "Show Graphiti provider status and non-secret configuration.",
+    "parameters": {"type": "object", "properties": {}, "required": []},
+}
+
+
+class GraphitiMemoryProvider(MemoryProvider):
+    def __init__(self):
+        self._cfg: dict[str, Any] = {}
+        self._hermes_home = ""
+        self._session_id = ""
+        self._user_id = "hermes-user"
+        self._group_id = "hermes-default"
+        self._graphiti = None
+        self._lock = threading.Lock()
+        self._prefetch_result = ""
+        self._prefetch_thread: threading.Thread | None = None
+        self._sync_thread: threading.Thread | None = None
+        self._consecutive_failures = 0
+        self._breaker_open_until = 0.0
+        self._initialized = False
+
+    @property
+    def name(self) -> str:
+        return "graphiti"
+
+    def is_available(self) -> bool:
+        if not self._cfg:
+            try:
+                self._cfg = _load_config(self._hermes_home or None)
+            except Exception:
+                pass
+        if not (os.environ.get("OPENROUTER_API_KEY") or os.environ.get("GRAPHITI_LLM_API_KEY")):
+            return False
+        try:
+            import graphiti_core  # noqa: F401
+            import kuzu  # noqa: F401
+            import openai  # noqa: F401
+        except Exception:
+            return False
+        return True
+
+    def get_config_schema(self):
+        return [
+            {"key": "llm_api_key", "description": "OpenRouter or OpenAI-compatible API key", "secret": True, "required": True, "env_var": "OPENROUTER_API_KEY", "url": "https://openrouter.ai/keys"},
+            {"key": "llm_model", "description": "OpenRouter model id", "default": "deepseek/deepseek-v4-flash"},
+            {"key": "embedding_model", "description": "Ollama embedding model", "default": "qwen3-embedding:4b"},
+            {"key": "kuzu_path", "description": "Local Kuzu graph path", "default": "$HERMES_HOME/graphiti/graph.kuzu"},
+        ]
+
+    def save_config(self, values, hermes_home):
+        path = Path(hermes_home) / "graphiti.json"
+        existing = {}
+        if path.exists():
+            try:
+                existing = json.loads(path.read_text(encoding="utf-8"))
+            except Exception:
+                existing = {}
+        existing.update(values)
+        existing.pop("llm_api_key", None)
+        path.write_text(json.dumps(existing, indent=2), encoding="utf-8")
+
+    def initialize(self, session_id: str, **kwargs) -> None:
+        self._hermes_home = str(kwargs.get("hermes_home") or Path.home() / ".hermes")
+        self._session_id = session_id
+        self._user_id = str(kwargs.get("user_id") or "hermes-user")
+        self._cfg = _load_config(self._hermes_home)
+        self._group_id = self._cfg.get("group_id") or None
+        Path(self._cfg["kuzu_path"]).parent.mkdir(parents=True, exist_ok=True)
+        self._initialized = True
+
+    def _is_breaker_open(self) -> bool:
+        if self._consecutive_failures < _BREAKER_THRESHOLD:
+            return False
+        if time.monotonic() >= self._breaker_open_until:
+            self._consecutive_failures = 0
+            return False
+        return True
+
+    def _record_success(self):
+        self._consecutive_failures = 0
+
+    def _record_failure(self):
+        self._consecutive_failures += 1
+        if self._consecutive_failures >= _BREAKER_THRESHOLD:
+            self._breaker_open_until = time.monotonic() + _BREAKER_COOLDOWN_SECS
+
+    async def _get_graphiti(self):
+        if self._graphiti is not None:
+            return self._graphiti
+        from graphiti_core import Graphiti
+        from graphiti_core.driver.kuzu_driver import KuzuDriver
+
+        api_key = os.environ.get("GRAPHITI_LLM_API_KEY") or os.environ.get("OPENROUTER_API_KEY")
+        if not api_key:
+            raise RuntimeError("OPENROUTER_API_KEY or GRAPHITI_LLM_API_KEY is required")
+
+        driver = KuzuDriver(db=self._cfg["kuzu_path"])
+        embedder = OllamaEmbedder(
+            model=self._cfg["embedding_model"],
+            base_url=self._cfg["ollama_base_url"],
+            embedding_dim=int(self._cfg["embedding_dim"]),
+        )
+        llm_client = OpenRouterJSONClient(
+            api_key=api_key,
+            base_url=self._cfg["llm_base_url"],
+            model=self._cfg["llm_model"],
+            small_model=self._cfg["llm_small_model"],
+            temperature=float(self._cfg.get("llm_temperature", 0)),
+        )
+        self._graphiti = Graphiti(graph_driver=driver, llm_client=llm_client, embedder=embedder, cross_encoder=PassthroughCrossEncoder())
+        await self._graphiti.build_indices_and_constraints()
+        await self._ensure_kuzu_fulltext_indices(driver)
+        return self._graphiti
+
+    async def _ensure_kuzu_fulltext_indices(self, driver) -> None:
+        """Create Kuzu FTS indices that current graphiti-core's driver no-op can miss."""
+        try:
+            from graphiti_core.driver.driver import GraphProvider
+            from graphiti_core.graph_queries import get_fulltext_indices
+
+            for query in get_fulltext_indices(GraphProvider.KUZU):
+                try:
+                    await driver.client.execute(query)
+                except Exception as exc:
+                    # Kuzu may report if an index already exists or an installed
+                    # binary lacks FTS support. Let actual search/add expose hard
+                    # failures; don't prevent provider initialization.
+                    logger.debug("Graphiti Kuzu FTS index query skipped: %s", exc)
+        except Exception as exc:
+            logger.debug("Graphiti Kuzu FTS index setup unavailable: %s", exc)
+
+    def system_prompt_block(self) -> str:
+        model = self._cfg.get("llm_model", "deepseek/deepseek-v4-flash")
+        embed = self._cfg.get("embedding_model", "qwen3-embedding:4b")
+        return (
+            "# Graphiti Temporal Memory\n"
+            f"Active local-first memory. Graph backend: Kuzu. Embeddings: Ollama {embed}. LLM extraction: {model}.\n"
+            "Use graphiti_search for durable recall and graphiti_remember only for stable facts/events."
+        )
+
+    def prefetch(self, query: str, *, session_id: str = "") -> str:
+        if self._prefetch_thread and self._prefetch_thread.is_alive():
+            self._prefetch_thread.join(timeout=3.0)
+        with self._lock:
+            result = self._prefetch_result
+            self._prefetch_result = ""
+        return f"## Graphiti Memory\n{result}" if result else ""
+
+    def queue_prefetch(self, query: str, *, session_id: str = "") -> None:
+        if self._is_breaker_open() or not query:
+            return
+
+        def _run():
+            try:
+                result = asyncio.run(self._search(query, int(self._cfg.get("prefetch_top_k", 5))))
+                if result:
+                    with self._lock:
+                        self._prefetch_result = result
+                self._record_success()
+            except Exception as exc:
+                self._record_failure()
+                logger.debug("Graphiti prefetch failed: %s", exc)
+
+        self._prefetch_thread = threading.Thread(target=_run, daemon=True, name="graphiti-prefetch")
+        self._prefetch_thread.start()
+
+    def sync_turn(self, user_content: str, assistant_content: str, *, session_id: str = "") -> None:
+        if self._is_breaker_open() or not self._cfg.get("sync_turns", True):
+            return
+        body = f"User: {user_content}\nAssistant: {assistant_content}"
+
+        def _run():
+            try:
+                asyncio.run(self._add_episode(body, name=f"turn-{session_id or self._session_id}"))
+                self._record_success()
+            except Exception as exc:
+                self._record_failure()
+                logger.warning("Graphiti sync failed: %s", exc)
+
+        if self._sync_thread and self._sync_thread.is_alive():
+            self._sync_thread.join(timeout=5.0)
+        self._sync_thread = threading.Thread(target=_run, daemon=True, name="graphiti-sync")
+        self._sync_thread.start()
+
+    async def _add_episode(self, content: str, *, name: str = "manual-memory") -> None:
+        from graphiti_core.nodes import EpisodeType
+
+        graphiti = await self._get_graphiti()
+        await graphiti.add_episode(
+            name=name[:120],
+            episode_body=content,
+            source_description="Hermes Agent memory provider",
+            reference_time=datetime.now(timezone.utc),
+            source=EpisodeType.message,
+            group_id=self._group_id,
+        )
+
+    async def _search(self, query: str, top_k: int) -> str:
+        graphiti = await self._get_graphiti()
+        kwargs = {"num_results": max(1, min(top_k, 20))}
+        if self._group_id:
+            kwargs["group_ids"] = [self._group_id]
+        results = await graphiti.search(query, **kwargs)
+        lines = []
+        for item in results:
+            fact = getattr(item, "fact", None) or getattr(item, "name", None) or str(item)
+            score = getattr(item, "score", None)
+            if score is not None:
+                lines.append(f"- {fact} (score={score:.3f})")
+            else:
+                lines.append(f"- {fact}")
+        if not lines:
+            lines = await self._fallback_kuzu_search(query, top_k)
+        return "\n".join(lines)
+
+    async def _fallback_kuzu_search(self, query: str, top_k: int) -> list[str]:
+        """Simple local fallback over Kuzu episode/entity text.
+
+        Graphiti's edge search can be empty when no relationships were extracted
+        yet. Hermes still needs recall from stored episodes and entity summaries.
+        """
+        if self._graphiti is None:
+            return []
+        query_terms = [t.casefold() for t in re.findall(r"[\w-]{3,}", query)][:12]
+        if not query_terms:
+            return []
+        records: list[tuple[str, str]] = []
+        searches = [
+            ("episode", "MATCH (n:Episodic) RETURN n.name AS name, n.content AS text LIMIT 100"),
+            ("entity", "MATCH (n:Entity) RETURN n.name AS name, n.summary AS text LIMIT 100"),
+        ]
+        for label, cypher in searches:
+            try:
+                rows, _, _ = await self._graphiti.driver.execute_query(cypher)
+            except Exception as exc:
+                logger.debug("Graphiti fallback %s search failed: %s", label, exc)
+                continue
+            for row in rows:
+                text = str(row.get("text") or "")
+                name = str(row.get("name") or label)
+                haystack = f"{name} {text}".casefold()
+                score = sum(1 for term in query_terms if term in haystack)
+                if score:
+                    records.append((f"- [{label}] {name}: {text}", score))
+        records.sort(key=lambda item: item[1], reverse=True)
+        return [line for line, _ in records[: max(1, min(top_k, 20))]]
+
+    def get_tool_schemas(self) -> List[Dict[str, Any]]:
+        return [SEARCH_SCHEMA, REMEMBER_SCHEMA, STATUS_SCHEMA]
+
+    def handle_tool_call(self, tool_name: str, args: Dict[str, Any], **kwargs) -> str:
+        if tool_name == "graphiti_status":
+            return json.dumps({
+                "provider": "graphiti",
+                "available": self.is_available(),
+                "initialized": self._initialized,
+                "backend": self._cfg.get("backend", "kuzu"),
+                "kuzu_path": self._cfg.get("kuzu_path", ""),
+                "embedding_model": self._cfg.get("embedding_model", "qwen3-embedding:4b"),
+                "embedding_dim": self._cfg.get("embedding_dim", 2560),
+                "llm_base_url": self._cfg.get("llm_base_url", "https://openrouter.ai/api/v1"),
+                "llm_model": self._cfg.get("llm_model", "deepseek/deepseek-v4-flash"),
+                "has_llm_key": bool(os.environ.get("OPENROUTER_API_KEY") or os.environ.get("GRAPHITI_LLM_API_KEY")),
+            })
+
+        if self._is_breaker_open():
+            return tool_error("Graphiti temporarily unavailable after repeated failures; retry later.")
+
+        if tool_name == "graphiti_search":
+            query = args.get("query", "")
+            if not query:
+                return tool_error("Missing required parameter: query")
+            try:
+                top_k = int(args.get("top_k", 5) or 5)
+                result = asyncio.run(self._search(query, top_k))
+                self._record_success()
+                return json.dumps({"result": result or "No relevant Graphiti memories found."})
+            except Exception as exc:
+                self._record_failure()
+                return tool_error(f"Graphiti search failed: {exc}")
+
+        if tool_name == "graphiti_remember":
+            content = args.get("content", "")
+            if not content:
+                return tool_error("Missing required parameter: content")
+            name = args.get("name") or "manual-memory"
+            try:
+                asyncio.run(self._add_episode(content, name=name))
+                self._record_success()
+                return json.dumps({"result": "Stored in Graphiti memory."})
+            except Exception as exc:
+                self._record_failure()
+                return tool_error(f"Graphiti remember failed: {exc}")
+
+        return tool_error(f"Unknown tool: {tool_name}")
+
+    def shutdown(self) -> None:
+        for thread in (self._prefetch_thread, self._sync_thread):
+            if thread and thread.is_alive():
+                thread.join(timeout=5.0)
+        if self._graphiti is not None:
+            try:
+                asyncio.run(self._graphiti.close())
+            except Exception:
+                pass
+            self._graphiti = None
+
+
+def register(ctx) -> None:
+    ctx.register_memory_provider(GraphitiMemoryProvider())

--- a/plugins/memory/graphiti/plugin.yaml
+++ b/plugins/memory/graphiti/plugin.yaml
@@ -1,0 +1,3 @@
+name: graphiti
+description: Local-first Graphiti temporal knowledge graph memory for Hermes using Kuzu, Ollama embeddings, and OpenRouter-compatible LLM extraction.
+version: 0.1.0

--- a/plugins/memory/graphiti/requirements.txt
+++ b/plugins/memory/graphiti/requirements.txt
@@ -1,0 +1,4 @@
+graphiti-core>=0.29.0
+kuzu>=0.11.3
+ollama>=0.6.2
+openai>=2.0.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,6 +103,7 @@ pty = [
   "pywinpty==2.0.15; sys_platform == 'win32'",
 ]
 honcho = ["honcho-ai==2.0.1"]
+graphiti = ["graphiti-core==0.29.0", "kuzu==0.11.3", "ollama==0.6.2"]
 mcp = ["mcp==1.26.0"]
 homeassistant = ["aiohttp==3.13.3"]
 sms = ["aiohttp==3.13.3"]

--- a/skills/software-development/agent-brain-protocol/SKILL.md
+++ b/skills/software-development/agent-brain-protocol/SKILL.md
@@ -1,0 +1,223 @@
+---
+name: agent-brain-protocol
+description: "Use when designing, configuring, or changing Hermes memory/brain systems: temporal graph memory, semantic facts, procedural skills, knowledge RAG, and human-readable mirrors."
+version: 1.0.0
+author: Hermes Agent
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [memory, brain, graphiti, zep, mem0, rag, skills, protocol]
+    related_skills: [methodology-router, hermes-agent, native-mcp, obsidian]
+---
+
+# Agent Brain Protocol
+
+## Overview
+
+A serious agent brain is not a dump of chat logs. It is a layered memory system with clear write policies, retrieval policies, provenance, and cleanup.
+
+Use this skill when changing Hermes memory, adding a memory provider, designing project knowledge, or deciding what should become a skill versus durable memory.
+
+## When to Use
+
+Use when:
+- Configuring memory providers such as Graphiti/Zep, Mem0, Honcho, Hindsight, Holographic, or similar.
+- Designing local-first memory with Ollama embeddings or graph storage.
+- Adding project brain artifacts under `.hermes/`.
+- Deciding whether a fact belongs in memory, a skill, a spec, or session history.
+- Integrating RAG/knowledge systems such as Cognee, LightRAG, GraphRAG, or Obsidian.
+
+Don't use for:
+- Temporary task progress.
+- One-off summaries that will be stale soon.
+- Secrets, raw credentials, or sensitive data without explicit user approval and storage policy.
+
+## Memory Layers
+
+### Layer 0 — Working Memory
+
+Current conversation, active tool results, and temporary scratchpad.
+
+Storage:
+- Model context.
+- `todo` tool.
+- Current session state.
+
+Write policy:
+- Do not persist by default.
+- Summarize only if it creates durable value.
+
+### Layer 1 — Episodic Memory
+
+Timestamped events and interactions.
+
+Examples:
+- Conversation episodes.
+- Tool execution summaries.
+- Delegation outcomes.
+- Major project decisions with time context.
+
+Recommended backend:
+- Graphiti/Zep temporal episodes.
+- Session database remains the source for raw transcripts.
+
+Write policy:
+- Store concise event summaries, not full noisy logs.
+- Include source, timestamp, actor, project/session scope.
+
+### Layer 2 — Semantic Memory
+
+Stable facts.
+
+Examples:
+- User preferences.
+- Environment facts likely to remain true.
+- Project conventions.
+- Architecture decisions.
+- API quirks.
+
+Recommended backend:
+- Graphiti/Zep entity nodes and edges.
+- Mem0 if using a simpler memory layer.
+- Built-in Hermes memory for compact high-value facts.
+
+Write policy:
+- Store declarative facts, not commands to the assistant.
+- Avoid facts likely to become stale within a week.
+- Include confidence/provenance when supported.
+
+### Layer 3 — Procedural Memory
+
+Reusable workflows.
+
+Examples:
+- How to debug a specific class of failures.
+- How to deploy a project.
+- How to perform a recurring review.
+
+Recommended backend:
+- Hermes skills, not normal memory.
+- Skill metadata can be referenced by graph memory, but the procedure itself belongs in `SKILL.md`.
+
+Write policy:
+- Create or patch a skill after a difficult/iterative workflow succeeds.
+- Keep procedures actionable: triggers, steps, commands, pitfalls, verification.
+
+### Layer 4 — Knowledge Memory
+
+Documents, codebases, APIs, PDFs, websites, and skill catalogs.
+
+Recommended backend:
+- Cognee, LightRAG, GraphRAG, or another corpus RAG system.
+- Keep separate from user/personal memory.
+
+Write policy:
+- Index documents by source and version.
+- Do not mix large document chunks into personal memory.
+- Prefer citations/file paths in retrieval output.
+
+### Layer 5 — Reflective / Consolidation Memory
+
+Background maintenance that improves memory quality.
+
+Examples:
+- Deduplication.
+- Conflict detection.
+- Confidence updates.
+- Stale fact review.
+- Link/backlink creation.
+- Skill suggestions after repeated patterns.
+
+Recommended inspiration:
+- A-MEM / Zettelkasten-style linked notes.
+- LangMem-style background managers.
+- Graphiti/Zep temporal invalidation.
+
+Write policy:
+- Consolidation jobs should be conservative.
+- Never silently overwrite explicit user preferences without evidence.
+
+## Recommended Hermes Brain Stack
+
+### Local-First Default
+
+Use when privacy/control matters:
+
+- **Graph backend:** Graphiti with local Kuzu database.
+- **Embeddings:** Ollama local embedding model, preferably GPU-loaded.
+- **LLM extraction:** OpenRouter allowed when the user permits cloud LLM calls.
+- **Knowledge corpus:** local Cognee/LightRAG later if needed.
+- **Mirror:** optional Obsidian/Markdown export for auditability.
+
+### Cloud-Pragmatic Default
+
+Use when setup speed and managed reliability matter:
+
+- **Memory:** Zep Cloud or Mem0 Cloud.
+- **Embeddings/LLM:** managed provider.
+- **Mirror:** optional Markdown export.
+
+### Hybrid Default
+
+Use for most power users:
+
+- Local embeddings and graph storage for private/project memory.
+- Cloud LLM for high-quality extraction/reasoning.
+- Separate local RAG for large docs/code.
+
+## Write Decision Tree
+
+Before saving anything, ask:
+
+1. **Will this still matter later?** If no, keep it in session only.
+2. **Is it a stable fact?** If yes, semantic memory.
+3. **Is it an event with time/order?** If yes, episodic memory.
+4. **Is it a reusable procedure?** If yes, skill.
+5. **Is it external/document knowledge?** If yes, knowledge RAG.
+6. **Is it sensitive?** If yes, require explicit policy and avoid logs.
+
+## Retrieval Policy
+
+- Retrieve narrowly by task, project, user, and timeframe.
+- Prefer graph/semantic results for decisions.
+- Prefer session search for exact previous conversation details.
+- Prefer knowledge RAG for docs/code/API facts.
+- Keep injected memory compact; long memory blocks degrade reasoning.
+
+## Hermes Integration Points
+
+Least invasive order:
+
+1. **Skills:** add or patch `SKILL.md` for reusable workflows.
+2. **Config:** set `memory.provider`, MCP servers, or skill external dirs.
+3. **User-installed memory plugin:** `$HERMES_HOME/plugins/<provider>/` implementing `MemoryProvider`.
+4. **MCP server:** expose external memory or RAG tools through `mcp_servers`.
+5. **Core changes:** only when the provider lifecycle or prompt assembly truly needs new primitives.
+
+For Hermes memory providers:
+
+- Implement `MemoryProvider`.
+- Keep `is_available()` cheap and non-networked.
+- Use `initialize()` for connections/resources.
+- Use non-blocking `sync_turn()`.
+- Use `queue_prefetch()` and `prefetch()` for compact recall.
+- Expose only high-value tools to avoid schema bloat.
+
+## Common Pitfalls
+
+1. **Vector dump brain.** Embeddings alone are not memory governance.
+2. **Mixing layers.** User preferences, repo docs, and task logs need different stores.
+3. **Overwriting user truth.** Temporal memory should preserve changes over time, not hide conflicts.
+4. **No provenance.** Memories without source/time are harder to trust.
+5. **No deletion path.** Users need a way to remove wrong or sensitive memory.
+6. **Saving stale artifacts.** PR numbers, commit SHAs, and issue status usually do not belong in durable memory.
+
+## Verification Checklist
+
+- [ ] Memory layers are separated.
+- [ ] Backend choice matches privacy/budget/latency requirements.
+- [ ] Embedding and graph storage are configured without exposing secrets.
+- [ ] Retrieval output is compact and scoped.
+- [ ] Write policy prevents stale/noisy memory.
+- [ ] User can inspect, correct, or disable the system.

--- a/skills/software-development/methodology-router/SKILL.md
+++ b/skills/software-development/methodology-router/SKILL.md
@@ -1,0 +1,177 @@
+---
+name: methodology-router
+description: "Use when choosing the right software-development workflow depth for Hermes: quick edit, bugfix, spec-driven feature, product/SDLC work, or memory/brain changes. Routes to the proper skills and gates."
+version: 1.0.0
+author: Hermes Agent
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [methodology, workflow, routing, software-development, skills]
+    related_skills: [spec-driven-development, writing-plans, subagent-driven-development, test-driven-development, systematic-debugging, requesting-code-review]
+---
+
+# Methodology Router
+
+## Overview
+
+Use this skill to select the minimum effective development methodology before changing code or project state. The goal is not ceremony. The goal is leverage: choose the workflow that prevents avoidable mistakes while staying proportional to task size.
+
+Hermes already has strong primitives — tools, skills, memory, session search, delegation, kanban, cron, and MCP. This router turns those primitives into a consistent development operating system.
+
+## When to Use
+
+Use when:
+- The user asks for implementation, architecture, refactoring, debugging, or repository changes.
+- The task may need planning, testing, review, subagents, or durable memory.
+- You are unsure whether to use quick execution, TDD, spec-driven development, or SDLC/product planning.
+
+Don't use for:
+- Pure factual Q&A.
+- One-line edits with obvious verification.
+- Tasks where the user explicitly asks for no process and the risk is low.
+
+## Workflow Tiers
+
+### Tier 0 — Direct Answer
+
+Use for questions and tiny non-code clarifications.
+
+Signals:
+- No repo/file changes.
+- No external side effects.
+- Answer can be grounded in existing context or one lookup.
+
+Action:
+- Answer directly.
+- Use tools if the answer depends on current facts, files, git, system state, or arithmetic.
+
+### Tier 1 — Quick Edit
+
+Use for very small, low-risk repo changes.
+
+Signals:
+- One or two files.
+- No new architecture.
+- Existing test coverage is obvious.
+
+Action:
+1. Inspect target files.
+2. Make minimal patch.
+3. Run targeted test/lint if available.
+4. Summarize changed paths and verification.
+
+Gate: targeted verification passes.
+
+### Tier 2 — TDD Bugfix or Behavior Change
+
+Use for bugs, regressions, and behavior changes.
+
+Signals:
+- Something is broken.
+- The correct behavior can be expressed in a test.
+- Existing code has unclear failure mode.
+
+Action:
+1. Load `systematic-debugging` for root cause work.
+2. Load `test-driven-development`.
+3. Write/identify a failing regression test first.
+4. Fix minimally.
+5. Run targeted + relevant broader tests.
+
+Gate: failing test fails for the expected reason before the fix, then passes after.
+
+### Tier 3 — Spec-Driven Feature
+
+Use for medium/large features or anything that affects multiple components.
+
+Signals:
+- Multiple files/modules.
+- New user-visible behavior.
+- Needs acceptance criteria.
+- Ambiguity would materially change implementation.
+
+Action:
+1. Load `spec-driven-development`.
+2. Create/update `.hermes/specs/<feature>/spec.md` or repo-approved equivalent.
+3. Create plan and task breakdown.
+4. Execute with `subagent-driven-development` when tasks are independent or review quality matters.
+5. Use TDD for behavior-producing tasks.
+
+Gates:
+- Spec gate: requirements and non-goals are explicit.
+- Plan gate: implementation tasks are concrete and ordered.
+- Verification gate: tests/checks prove the feature.
+
+### Tier 4 — Product / SDLC Mode
+
+Use for greenfield products, large brownfield initiatives, roadmap work, or cross-functional planning.
+
+Signals:
+- PRD, architecture, UX, epics, stories, milestones, or rollout is needed.
+- Multiple agents/profiles would materially improve speed/quality.
+- Work spans days or persistent kanban tasks.
+
+Action:
+1. Use BMAD-inspired roles selectively: analyst, PM, architect, developer, reviewer.
+2. Convert strategy into artifacts: PRD, architecture, epics/stories, implementation plan.
+3. Use Hermes kanban for durable multi-agent execution.
+4. Keep human approval gates for destructive, security, deployment, or cost-bearing actions.
+
+Gate: stakeholder/user approval before irreversible execution.
+
+### Tier 5 — Brain / Memory Architecture Work
+
+Use when changing durable memory, skills, agent behavior, MCP, or project knowledge systems.
+
+Signals:
+- Memory provider, skillpack, agent protocol, or long-running behavior is involved.
+- Bad design would pollute future sessions.
+
+Action:
+1. Load `agent-brain-protocol`.
+2. Separate memory classes: user facts, project facts, procedural skills, episodic events, knowledge corpus.
+3. Prefer plugin/config/skill changes before core prompt changes.
+4. Add validation and rollback path.
+
+Gate: memory writes are scoped, auditable, and not stale task logs.
+
+## Default Stack
+
+Use this default unless the user says otherwise:
+
+1. **AGENTS.md / CLAUDE.md / .hermes/** — project-local instructions and artifacts.
+2. **Spec-driven development** — for medium/large feature lifecycle.
+3. **Superpowers-style execution discipline** — TDD, systematic debugging, subagent reviews, verification.
+4. **Kanban** — for durable multi-agent execution.
+5. **Graph/semantic memory** — only for durable facts and relationships, not raw noisy logs.
+
+## Escalation Rules
+
+Escalate one tier when:
+- The change touches more files than expected.
+- Requirements are ambiguous.
+- Tests reveal hidden coupling.
+- The task has security, privacy, deployment, or cost impact.
+- A subagent/reviewer finds spec gaps.
+
+De-escalate when:
+- The task is smaller than expected.
+- Existing tests/docs fully constrain the change.
+- User asks for speed and risk is low.
+
+## Common Pitfalls
+
+1. **Over-process.** Do not use full SDLC for a typo.
+2. **Under-spec.** Do not code multi-file features from vibes.
+3. **Skipping RED.** Bug fixes need a failing test or equivalent reproduction first.
+4. **Memory pollution.** Do not save PR numbers, transient task state, or stale logs as durable memory.
+5. **Core edits before extension points.** Prefer skills, MCP, plugins, config, and user-local providers before changing core prompts/runtime.
+
+## Verification Checklist
+
+- [ ] Chosen tier matches risk and scope.
+- [ ] Required related skills were loaded.
+- [ ] Tests or verification commands were run when code changed.
+- [ ] Durable memory/skills only store reusable or stable facts.
+- [ ] Final answer reports concrete changes and verification, not intentions.

--- a/skills/software-development/spec-driven-development/SKILL.md
+++ b/skills/software-development/spec-driven-development/SKILL.md
@@ -1,0 +1,220 @@
+---
+name: spec-driven-development
+description: "Use when implementing medium or large features with a spec-first lifecycle: constitution, specification, plan, tasks, implementation, and validation. Inspired by GitHub Spec Kit, adapted for Hermes."
+version: 1.0.0
+author: Hermes Agent
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [specs, planning, implementation, spec-driven-development, quality-gates]
+    related_skills: [methodology-router, writing-plans, subagent-driven-development, test-driven-development, requesting-code-review]
+---
+
+# Spec-Driven Development
+
+## Overview
+
+Spec-driven development makes the specification the source of truth. Code is the implementation of an explicit contract, not the place where requirements are discovered accidentally.
+
+This skill adapts the GitHub Spec Kit style for Hermes. Use it when a task is too important or too broad for a direct edit.
+
+## When to Use
+
+Use when:
+- A feature affects multiple files or components.
+- The user asks for a new capability, integration, protocol, or architecture.
+- Acceptance criteria matter.
+- Several implementation paths are possible.
+- Work may be delegated to subagents or kanban workers.
+
+Don't use when:
+- The change is a trivial typo/config tweak.
+- A failing test already defines the bug clearly and the fix is local.
+- The user explicitly asks for a spike/prototype; use `spike` first, then come back to this skill if building for real.
+
+## Artifact Layout
+
+Prefer project-local artifacts under `.hermes/` when no repo convention exists:
+
+```text
+.hermes/
+  constitution.md              # standing engineering principles for this repo/project
+  specs/
+    <feature-slug>/
+      spec.md                  # what and why
+      plan.md                  # how
+      tasks.md                 # bite-sized execution list
+      validation.md            # test plan, checks, acceptance evidence
+```
+
+If the repo already has `docs/specs/`, `docs/plans/`, `AGENTS.md`, or another convention, follow the repo convention and cross-link from `.hermes/` only when useful.
+
+## Process
+
+### 1. Constitution Gate
+
+Check for durable project rules:
+
+- `AGENTS.md`
+- `CLAUDE.md`
+- `.hermes/constitution.md`
+- existing architecture docs
+- package/test/CI conventions
+
+If missing and the feature is large, create a minimal constitution:
+
+```markdown
+# Project Constitution
+
+## Principles
+- Keep changes testable and reversible.
+- Prefer extension points over core rewrites.
+- Separate personal memory, project memory, and knowledge-corpus retrieval.
+
+## Quality Gates
+- Targeted tests for touched behavior.
+- Full relevant suite before merge.
+- No secrets in logs, commits, or docs.
+```
+
+Gate passes when project constraints are known enough to prevent avoidable design drift.
+
+### 2. Specify Gate
+
+Write `spec.md` before implementation.
+
+Required sections:
+
+```markdown
+# <Feature> Specification
+
+## Goal
+One paragraph describing the outcome.
+
+## Users / Actors
+Who uses this and in what context.
+
+## Requirements
+- R1: Observable behavior.
+- R2: Integration behavior.
+- R3: Failure/edge behavior.
+
+## Non-Goals
+- Explicitly excluded scope.
+
+## Acceptance Criteria
+- [ ] User-visible or testable outcome.
+- [ ] Verification command or manual check.
+
+## Risks
+- Security, privacy, cost, compatibility, migration, performance.
+```
+
+Gate passes when requirements and non-goals are explicit.
+
+### 3. Plan Gate
+
+Write `plan.md` using `writing-plans` discipline.
+
+Required sections:
+
+```markdown
+# <Feature> Implementation Plan
+
+## Architecture
+Explain the chosen design and rejected alternatives.
+
+## Files to Change
+- Create/modify exact paths.
+
+## Dependency / Config Changes
+- New packages, env vars, config keys, migrations.
+
+## Test Strategy
+- Unit tests.
+- Integration tests.
+- Manual verification.
+
+## Rollback Plan
+How to disable/revert safely.
+```
+
+Gate passes when a competent subagent could implement without guessing.
+
+### 4. Tasks Gate
+
+Write `tasks.md` as small ordered tasks.
+
+Each task should include:
+
+- Objective.
+- Exact files.
+- RED test or verification-first step.
+- GREEN implementation step.
+- Refactor/cleanup step if needed.
+- Command to verify.
+- Commit message suggestion.
+
+Use `subagent-driven-development` when tasks are independent or benefit from fresh context and review.
+
+Gate passes when every task is 2–15 minutes and independently verifiable.
+
+### 5. Implement Gate
+
+Execution rules:
+
+1. Do not implement before spec and plan gates pass unless the user explicitly requests a spike.
+2. Use TDD for behavior-producing code.
+3. Use `delegate_task` for independent research/review/implementation chunks when it improves quality or speed.
+4. Run targeted verification after each meaningful task.
+5. Keep commits coherent.
+
+Gate passes when all acceptance criteria have evidence.
+
+### 6. Validation Gate
+
+Write or update `validation.md` with actual evidence:
+
+```markdown
+# Validation
+
+## Commands Run
+- `pytest tests/foo/test_bar.py -q` — passed
+- `python scripts/check_config.py` — passed
+
+## Acceptance Criteria Evidence
+- [x] R1 proven by test X.
+- [x] R2 proven by command Y.
+
+## Known Gaps
+- Any limitation or follow-up.
+```
+
+Gate passes when final claims are backed by tests, tool outputs, docs, or explicit assumptions.
+
+## Hermes Integration Notes
+
+- Use `todo` for in-session task control.
+- Use `session_search` when prior decisions may exist.
+- Use `skill_view` for related methodology skills before execution.
+- Use `delegate_task` for parallel research, implementation, or review.
+- Use kanban for durable multi-worker execution beyond the current turn.
+- Use memory only for stable facts and reusable lessons; do not store task-progress logs.
+
+## Common Pitfalls
+
+1. **Spec as afterthought.** A spec written after code is documentation, not a contract.
+2. **No non-goals.** Missing non-goals causes scope creep.
+3. **Tasks too large.** If a task needs multiple unrelated files and cannot be verified alone, split it.
+4. **No rollback path.** Every integration should have disable/revert instructions.
+5. **Validation theater.** Listing planned commands is not evidence. Record actual commands run and outcomes.
+
+## Verification Checklist
+
+- [ ] Constitution/project rules checked.
+- [ ] `spec.md` has requirements, non-goals, acceptance criteria, risks.
+- [ ] `plan.md` has architecture, file list, dependencies, tests, rollback.
+- [ ] `tasks.md` is ordered and bite-sized.
+- [ ] Implementation followed TDD where applicable.
+- [ ] Validation records actual evidence.

--- a/tests/plugins/memory/test_graphiti_provider.py
+++ b/tests/plugins/memory/test_graphiti_provider.py
@@ -1,0 +1,101 @@
+import asyncio
+import json
+
+from plugins.memory.graphiti import (
+    GraphitiMemoryProvider,
+    _extract_json,
+    _load_config,
+)
+
+
+class FakeDriver:
+    def __init__(self):
+        self.queries = []
+
+    async def execute_query(self, query):
+        self.queries.append(query)
+        if "Episodic" in query:
+            return ([
+                {"name": "episode-1", "text": "Hermes Graphiti provider uses local Kuzu with Ollama qwen3 embeddings."},
+                {"name": "episode-2", "text": "Unrelated memory."},
+            ], None, None)
+        if "Entity" in query:
+            return ([
+                {"name": "Ollama qwen3 embeddings", "text": "Local embedding model used by Graphiti provider."},
+            ], None, None)
+        return ([], None, None)
+
+
+class FakeGraphiti:
+    def __init__(self):
+        self.driver = FakeDriver()
+
+
+def test_extract_json_accepts_markdown_fenced_json():
+    assert _extract_json('```json\n{"ok": true}\n```') == {"ok": True}
+
+
+def test_load_config_reads_file_but_keeps_group_id_empty(tmp_path, monkeypatch):
+    monkeypatch.delenv("GRAPHITI_GROUP_ID", raising=False)
+    (tmp_path / "graphiti.json").write_text(
+        json.dumps({"group_id": "", "kuzu_path": "$HERMES_HOME/custom.kuzu"}),
+        encoding="utf-8",
+    )
+
+    cfg = _load_config(str(tmp_path))
+
+    assert cfg["group_id"] == ""
+    assert cfg["kuzu_path"] == str(tmp_path / "custom.kuzu")
+
+
+def test_save_config_drops_secret_key(tmp_path):
+    provider = GraphitiMemoryProvider()
+    provider.save_config({"llm_api_key": "secret-value", "llm_model": "qwen/qwen3.6-plus"}, str(tmp_path))
+
+    stored = json.loads((tmp_path / "graphiti.json").read_text(encoding="utf-8"))
+
+    assert "llm_api_key" not in stored
+    assert stored["llm_model"] == "qwen/qwen3.6-plus"
+
+
+def test_status_reports_key_presence_without_secret(tmp_path, monkeypatch):
+    monkeypatch.setenv("OPENROUTER_API_KEY", "secret-value")
+    provider = GraphitiMemoryProvider()
+    provider.initialize("session-1", hermes_home=str(tmp_path), user_id="zidane")
+
+    status = json.loads(provider.handle_tool_call("graphiti_status", {}))
+
+    assert status["provider"] == "graphiti"
+    assert status["has_llm_key"] is True
+    assert "secret-value" not in json.dumps(status)
+
+
+def test_fallback_kuzu_search_reads_episode_and_entity_text(tmp_path):
+    provider = GraphitiMemoryProvider()
+    provider.initialize("session-1", hermes_home=str(tmp_path), user_id="zidane")
+    object.__setattr__(provider, "_graphiti", FakeGraphiti())
+
+    result = asyncio.run(provider._fallback_kuzu_search("Graphiti Ollama qwen3", 5))
+
+    joined = "\n".join(result)
+    assert "episode-1" in joined
+    assert "Ollama qwen3 embeddings" in joined
+    assert "Unrelated memory" not in joined
+
+
+def test_tool_schema_exposes_search_remember_and_status():
+    provider = GraphitiMemoryProvider()
+
+    names = {schema["name"] for schema in provider.get_tool_schemas()}
+
+    assert names == {"graphiti_search", "graphiti_remember", "graphiti_status"}
+
+
+def test_search_tool_handles_malformed_top_k_without_raising(tmp_path):
+    provider = GraphitiMemoryProvider()
+    provider.initialize("session-1", hermes_home=str(tmp_path), user_id="zidane")
+
+    result = json.loads(provider.handle_tool_call("graphiti_search", {"query": "Graphiti", "top_k": "not-an-int"}))
+
+    assert "error" in result
+    assert "invalid literal" in result["error"]

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -118,6 +118,7 @@ LAZY_DEPS: dict[str, tuple[str, ...]] = {
     # ─── Memory providers ──────────────────────────────────────────────────
     "memory.honcho": ("honcho-ai==2.0.1",),
     "memory.hindsight": ("hindsight-client==0.6.1",),
+    "memory.graphiti": ("graphiti-core==0.29.0", "kuzu==0.11.3", "ollama==0.6.2"),
 
     # ─── Messaging platforms (lazy-installable on demand) ──────────────────
     "platform.telegram": ("python-telegram-bot[webhooks]==22.6",),

--- a/uv.lock
+++ b/uv.lock
@@ -530,6 +530,15 @@ wheels = [
 ]
 
 [[package]]
+name = "backoff"
+version = "2.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/d7/5bbeb12c44d7c4f2fb5b56abce497eb5ed9f34d85701de869acedd602619/backoff-2.2.1.tar.gz", hash = "sha256:03f829f5bb1923180821643f8753b0502c3b682293992485b0eef2807afa5cba", size = 17001, upload-time = "2022-10-05T19:19:32.061Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/73/b6e24bd22e6720ca8ee9a85a0c4a2971af8497d8f3193fa05390cbd46e09/backoff-2.2.1-py3-none-any.whl", hash = "sha256:63579f9a0628e06278f7e47b7d7d5b6ce20dc65c5e96a6f3ca99a6adca0396e8", size = 15148, upload-time = "2022-10-05T19:19:30.546Z" },
+]
+
+[[package]]
 name = "base58"
 version = "2.1.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1562,6 +1571,24 @@ wheels = [
 ]
 
 [[package]]
+name = "graphiti-core"
+version = "0.29.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "neo4j" },
+    { name = "numpy" },
+    { name = "openai" },
+    { name = "posthog" },
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "tenacity" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a5/95/c6e05d3cae650f6e236ed4b6cf2201f480e7dea38d9c947553e16424cef3/graphiti_core-0.29.0.tar.gz", hash = "sha256:00bdc148901a0f1c3952e0ed12f704f179221065a31b3d1edad0777a46b03c09", size = 6896765, upload-time = "2026-04-27T15:55:07.575Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/0c/54cebaa2e668d1a89d934a924ccefa752a9f7c6e8d93eddcd93372832bd7/graphiti_core-0.29.0-py3-none-any.whl", hash = "sha256:6b94e1c3e66b35216f1ad51e9a2274e52f92ef5ec872e647d6c1e4af51390996", size = 342037, upload-time = "2026-04-27T15:55:05.589Z" },
+]
+
+[[package]]
 name = "grpclib"
 version = "0.4.9"
 source = { registry = "https://pypi.org/simple" }
@@ -1700,6 +1727,11 @@ google = [
     { name = "google-auth-httplib2" },
     { name = "google-auth-oauthlib" },
 ]
+graphiti = [
+    { name = "graphiti-core" },
+    { name = "kuzu" },
+    { name = "ollama" },
+]
 hindsight = [
     { name = "hindsight-client" },
 ]
@@ -1820,6 +1852,7 @@ requires-dist = [
     { name = "google-api-python-client", marker = "extra == 'google'", specifier = "==2.194.0" },
     { name = "google-auth-httplib2", marker = "extra == 'google'", specifier = "==0.3.1" },
     { name = "google-auth-oauthlib", marker = "extra == 'google'", specifier = "==1.3.1" },
+    { name = "graphiti-core", marker = "extra == 'graphiti'", specifier = "==0.29.0" },
     { name = "hermes-agent", extras = ["acp"], marker = "extra == 'all'" },
     { name = "hermes-agent", extras = ["acp"], marker = "extra == 'termux'" },
     { name = "hermes-agent", extras = ["cli"], marker = "extra == 'all'" },
@@ -1846,6 +1879,7 @@ requires-dist = [
     { name = "honcho-ai", marker = "extra == 'honcho'", specifier = "==2.0.1" },
     { name = "httpx", extras = ["socks"], specifier = "==0.28.1" },
     { name = "jinja2", specifier = "==3.1.6" },
+    { name = "kuzu", marker = "extra == 'graphiti'", specifier = "==0.11.3" },
     { name = "lark-oapi", marker = "extra == 'feishu'", specifier = "==1.5.3" },
     { name = "markdown", marker = "extra == 'matrix'", specifier = "==3.10.2" },
     { name = "mautrix", extras = ["encryption"], marker = "extra == 'matrix'", specifier = "==0.21.0" },
@@ -1854,6 +1888,7 @@ requires-dist = [
     { name = "mcp", marker = "extra == 'mcp'", specifier = "==1.26.0" },
     { name = "modal", marker = "extra == 'modal'", specifier = "==1.3.4" },
     { name = "numpy", marker = "extra == 'voice'", specifier = "==2.4.3" },
+    { name = "ollama", marker = "extra == 'graphiti'", specifier = "==0.6.2" },
     { name = "openai", specifier = "==2.24.0" },
     { name = "parallel-web", marker = "extra == 'parallel-web'", specifier = "==0.4.2" },
     { name = "prompt-toolkit", specifier = "==3.0.52" },
@@ -1891,7 +1926,7 @@ requires-dist = [
     { name = "vercel", marker = "extra == 'vercel'", specifier = "==0.5.7" },
     { name = "youtube-transcript-api", marker = "extra == 'youtube'", specifier = "==1.2.4" },
 ]
-provides-extras = ["anthropic", "exa", "firecrawl", "parallel-web", "fal", "edge-tts", "modal", "daytona", "vercel", "hindsight", "dev", "messaging", "cron", "slack", "matrix", "cli", "tts-premium", "voice", "pty", "honcho", "mcp", "homeassistant", "sms", "computer-use", "acp", "bedrock", "azure-identity", "termux", "termux-all", "dingtalk", "feishu", "google", "youtube", "web", "all"]
+provides-extras = ["anthropic", "exa", "firecrawl", "parallel-web", "fal", "edge-tts", "modal", "daytona", "vercel", "hindsight", "dev", "messaging", "cron", "slack", "matrix", "cli", "tts-premium", "voice", "pty", "honcho", "graphiti", "mcp", "homeassistant", "sms", "computer-use", "acp", "bedrock", "azure-identity", "termux", "termux-all", "dingtalk", "feishu", "google", "youtube", "web", "all"]
 
 [[package]]
 name = "hf-xet"
@@ -2246,6 +2281,35 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe", size = 18437, upload-time = "2025-09-08T01:34:57.871Z" },
+]
+
+[[package]]
+name = "kuzu"
+version = "0.11.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/96/0c/f141a81485729a072dc527b474e7580d5632309c68ad1a5aa6ed9ac45387/kuzu-0.11.3.tar.gz", hash = "sha256:e7bea3ca30c4bb462792eedcaa7f2125c800b243bb4a872e1eedc16917c1967a", size = 19430620, upload-time = "2025-10-10T13:36:54.984Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/46/1b/65d3974551f10d100ca4682b1e4beff23a9c5b7555c6ea552a3855555cc0/kuzu-0.11.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:836739dced9f61912a80bb7ad1df2159cef456c5b5cfe92f15394b9c51a785cb", size = 4094223, upload-time = "2025-10-10T13:35:56.023Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/e8/0efbc4812796468ca47273fc53c21c63706bc5f7bc4fa3459918d323ced8/kuzu-0.11.3-cp311-cp311-macosx_11_0_x86_64.whl", hash = "sha256:8d4f0e4085d3a85b0e7a8e337082bec6a3cf8c92c9a35209ffe53b2ed212ab08", size = 4519024, upload-time = "2025-10-10T13:35:57.665Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/b2/07e81d9f1858a592d1ddc1f02a483718cdfac3315bbca019b13b2ddd8c3e/kuzu-0.11.3-cp311-cp311-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1419ada227d15107c2b2536c66ae715c59876585d434b1918c17598956dcd5f7", size = 6796096, upload-time = "2025-10-10T13:35:59.174Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/e0/8ea0d289ef6840fbd00e642657ed07d03690a97a01676e2b79d5c3e9ddf8/kuzu-0.11.3-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ef094001d319804fcc8eb72775a184f1119d84af1bace29581a003bd806c36cd", size = 7616892, upload-time = "2025-10-10T13:36:00.866Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/d6/9ea65a74c9140e13d7f68dd9d8f95f42b55b9d7750e7a20df3d9b2f09734/kuzu-0.11.3-cp311-cp311-win_amd64.whl", hash = "sha256:eb0858ec8084b10badeae37e730fbe0c3b2846dfe3508001d123087de262efbb", size = 4712696, upload-time = "2025-10-10T13:36:02.607Z" },
+    { url = "https://files.pythonhosted.org/packages/64/88/ed193fd0ddfdbdde6c79e96b96df3b760fe48b2626e7151d81a1ed90fd9f/kuzu-0.11.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:d865ca31506867cf1ccf50c094c44de96de94bc77ffb350bfcaca0e4c5e469da", size = 4093637, upload-time = "2025-10-10T13:36:04.206Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/6d/06e02828b78297d6d99ff3dfb0ab7b5ec5d075053aae33b53189437bbb66/kuzu-0.11.3-cp312-cp312-macosx_11_0_x86_64.whl", hash = "sha256:109372bc16ce6724f88e0312bc686e34145e330d69b163b22ba92f4d3d96b48f", size = 4520482, upload-time = "2025-10-10T13:36:06.302Z" },
+    { url = "https://files.pythonhosted.org/packages/72/d5/0939a953860a8b373bef7b8a66a4571b27ff9faeb22672d2cd2cf3b6ba15/kuzu-0.11.3-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d6274da6c470c001b7d332ec78a076395b009c2f267914640884fd6fa78bf47d", size = 6795398, upload-time = "2025-10-10T13:36:08Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/5d/8e3dfb89aa3f70f63aa283c523f2dd2ac90a1b3ed990643e3a89909236f9/kuzu-0.11.3-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1bb3b833ca2d1d919423cb3e0150592c2587562ab85259277f622e6f06e0b487", size = 7615389, upload-time = "2025-10-10T13:36:09.809Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/19/c8e93185d6142f01b2e6daec4ad537dfd32afd1f69894889769b725b08c1/kuzu-0.11.3-cp312-cp312-win_amd64.whl", hash = "sha256:605909f744763775b8647014a03526d7f928a7b5a62a8b8c1d1e7bbdaf9dbb6c", size = 4714355, upload-time = "2025-10-10T13:36:11.527Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/e4/2c0e222a9b0605745234fec2774a25dd2e472699931f683f15d28ab8c076/kuzu-0.11.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e20ab3e3b20ccf75219872feb86582f959e313eeb59f51131adf4c91ebfabe30", size = 4093664, upload-time = "2025-10-10T13:36:13.116Z" },
+    { url = "https://files.pythonhosted.org/packages/88/05/3020ed9a0a7b492597f211f805233b77ef37266a23c27efc40bb7cb37402/kuzu-0.11.3-cp313-cp313-macosx_11_0_x86_64.whl", hash = "sha256:054479d3ce71410b8af2f5fa6aa37883db7fea5b25606af8d3bd7cf717aa5395", size = 4520498, upload-time = "2025-10-10T13:36:14.933Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/66/1a502700a7f2863f8f60621a412a7074d7eda9e92f18fd1d8d86905aa4d3/kuzu-0.11.3-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:143a37f1ae38b6b4337ccfcf42fa4f779a897223fff9c6c29f1a5a5a86911300", size = 6795804, upload-time = "2025-10-10T13:36:16.55Z" },
+    { url = "https://files.pythonhosted.org/packages/79/c2/1ea8cdc05946cb5906a7ebb451d7268e501ebb51ebecc0437969f8c07450/kuzu-0.11.3-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:548bfb3045d89bce1fbe89f4a890d636789671abfa80cbde2054c671e6069133", size = 7615668, upload-time = "2025-10-10T13:36:18.882Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/c3/336d6181f8f50126cf3d7186b3c5479f9f49d973145f79bed45cf87a9bb7/kuzu-0.11.3-cp313-cp313-win_amd64.whl", hash = "sha256:87bf6c369f182a59e5b8a38b3ca288b90fab2827577d9b0d2170a202c42bc8f5", size = 4714372, upload-time = "2025-10-10T13:36:20.877Z" },
+    { url = "https://files.pythonhosted.org/packages/94/db/e7e6cada6dc924eb8939bd35c5f724f5de4fc430a64d6d9e71b75cd0c271/kuzu-0.11.3-cp313-cp313t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:eb5c165bc5838059e498e8325939fc6bac075e1941157e8df6ebdd710135d43b", size = 6798556, upload-time = "2025-10-10T13:36:22.472Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/68/a0fa02134cb255c80b5ed5bb5f6130fbbc75a8ae8be4fd6ea6eb6bc8014b/kuzu-0.11.3-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:88c73dfd3d6a1fb374031050b725236fa9dd9a95424b09b20086a3d274bed51f", size = 7620378, upload-time = "2025-10-10T13:36:24.453Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/b7/2a4569984995f09476dbf1ef2e0a7298aa9fdb8896f2e8195d80e11786f4/kuzu-0.11.3-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9d2752a9e37adda6aef3bf041932ae3a1cf74ca7e893bbbacdd5e62b3ac6f8c2", size = 6795649, upload-time = "2025-10-10T13:36:26.15Z" },
+    { url = "https://files.pythonhosted.org/packages/77/13/df6e06a7d7506743c3a6cfbe50ee3f9d3fc58228e2a2fcbe7e74e7c17b00/kuzu-0.11.3-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:86be7d113e4e2c6761b1701079af8aeffc04c6981517f2d6aa393e883cc46036", size = 7615882, upload-time = "2025-10-10T13:36:28.215Z" },
+    { url = "https://files.pythonhosted.org/packages/32/85/c52c3b167edcc67da3b8788a20a2fb5b4f045060cbe1aed6121ce3ce83d3/kuzu-0.11.3-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d72ebd88e231b562e7a60ff88d200825d53e78a681bddd7f8d77b78126a5060c", size = 6798657, upload-time = "2025-10-10T13:36:29.935Z" },
+    { url = "https://files.pythonhosted.org/packages/06/be/5b4ff168718165c2ff5848ab79e22ecce72ad00522afee6820d390cb0753/kuzu-0.11.3-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:64c7ec822906bdee154eb38d93e64f184d8f94b30bbeaceaa252725f2b9efab3", size = 7620394, upload-time = "2025-10-10T13:36:31.69Z" },
 ]
 
 [[package]]
@@ -2654,6 +2718,18 @@ wheels = [
 ]
 
 [[package]]
+name = "neo4j"
+version = "6.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytz" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ce/f4/aaa4ac19adae4b01bc742b63afd2672a77e7351566f02721e713e4b863ee/neo4j-6.2.0.tar.gz", hash = "sha256:e1e246b65b572bd8ea97f9e0e721b7d40a5ce53e53d0007c29aef63e4f9124d9", size = 241459, upload-time = "2026-05-04T07:35:41.428Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e6/cf/1c3795866cefaac6e648d4e98c373cafd97810f6e317c307371007ab4abb/neo4j-6.2.0-py3-none-any.whl", hash = "sha256:b87abdd13a5cc2e3bd51026926c2f20ac38fa3febe98c340520dce19e97388d0", size = 327824, upload-time = "2026-05-04T07:35:39.604Z" },
+]
+
+[[package]]
 name = "nest-asyncio"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2810,6 +2886,19 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/7f/74/3269a3a58347e0b019742d888612c4b765293c9c75efa44e144b1e884c0d/obstore-0.8.2-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:329038c9645d6d1741e77fe1a53e28a14b1a5c1461cfe4086082ad39ebabf981", size = 3687307, upload-time = "2025-09-16T15:34:14.501Z" },
     { url = "https://files.pythonhosted.org/packages/01/f9/4fd4819ad6a49d2f462a45be453561f4caebded0dc40112deeffc34b89b1/obstore-0.8.2-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:1e4df99b369790c97c752d126b286dc86484ea49bff5782843a265221406566f", size = 3776076, upload-time = "2025-09-16T15:34:16.207Z" },
     { url = "https://files.pythonhosted.org/packages/14/dd/7c4f958fa0b9fc4778fb3d232e38b37db8c6b260f641022fbba48b049d7e/obstore-0.8.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:9e1c65c65e20cc990414a8a9af88209b1bbc0dd9521b5f6b0293c60e19439bb7", size = 3947445, upload-time = "2025-09-16T15:34:17.423Z" },
+]
+
+[[package]]
+name = "ollama"
+version = "0.6.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+    { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fc/72/5f12423b6b39ca8430fbe56f77fcf4ef60f63067c7c4a2e30e200ed9ec16/ollama-0.6.2.tar.gz", hash = "sha256:936d55daa684f474364c098611c933626f8d6c7d67065c5b7ae0c477b508b07f", size = 53145, upload-time = "2026-04-29T21:21:15.018Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c4/ab/d6722beeb2d10f7a3b9ff49375708904fde18f82b5609a0bc4aeb5996a4d/ollama-0.6.2-py3-none-any.whl", hash = "sha256:3ad7daab28e5a973445c36a73882a3ef698c2ebb00e21e308652741577509f7d", size = 15115, upload-time = "2026-04-29T21:21:13.794Z" },
 ]
 
 [[package]]
@@ -3024,6 +3113,21 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "posthog"
+version = "7.15.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "backoff" },
+    { name = "distro" },
+    { name = "requests" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a1/98/e4f414fd390bba6242be37f0a899325abba5ab22e3e83213cbb20253f807/posthog-7.15.0.tar.gz", hash = "sha256:22270215d7b062cd66badee3dfbe957e3f05e29b1b0e8c125a214ebc50bc77c8", size = 212310, upload-time = "2026-05-19T12:57:03.506Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b0/4a/7b50a53e9a557c7e78deb36811eb6b0d05f40f20c3b633e379e206426e37/posthog-7.15.0-py3-none-any.whl", hash = "sha256:0ada8fe94c7fb9b7ad507180eed308fea3b45063ddb4088cc8eaddb9cdea15c4", size = 248461, upload-time = "2026-05-19T12:57:01.575Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Adds a local-first software-development methodology + brain upgrade for Hermes:

- Adds methodology skills:
  - `methodology-router`
  - `spec-driven-development`
  - `agent-brain-protocol`
- Adds a Graphiti memory provider scaffold:
  - local Kuzu graph backend
  - Ollama embedding default: `qwen3-embedding:4b`
  - OpenRouter-compatible LLM extraction default: `deepseek/deepseek-v4-flash`
  - tools: `graphiti_search`, `graphiti_remember`, `graphiti_status`
- Adds docs/planning notes and Graphiti provider README.
- Adds lazy dependency + optional extra entries for Graphiti.
- Adds provider unit tests for config, secret handling, fallback search, schemas, and malformed args.

## Privacy / Security

- Secrets are read from environment variables only.
- `save_config()` intentionally drops `llm_api_key`.
- `graphiti_status` reports only key presence, not key values.
- Storage and embeddings are local-first.
- LLM extraction uses configured OpenRouter-compatible endpoint by default; README documents `sync_turns=false` to disable automatic turn ingestion while keeping explicit `graphiti_remember` available.

## Validation

Passed after rebasing on current `origin/main`:

```bash
venv/bin/python -m pytest tests/plugins/memory/test_graphiti_provider.py tests/tools/test_memory_tool_schema.py tests/agent/test_memory_provider.py -q
# 72 passed, 12 warnings

venv/bin/python -m ruff check plugins/memory/graphiti tests/plugins/memory/test_graphiti_provider.py tools/lazy_deps.py pyproject.toml
# All checks passed

uv lock --check
# Resolved 224 packages
```

Also smoke-tested local provider discovery/status/search with Hermes plugin loading.

## Full-suite note

A full `venv/bin/python -m pytest -q` run was attempted before final rebase. It completed with many existing environment/config-dependent failures unrelated to this diff, including Discord tests, custom model provider picker tests affected by local Ollama config, web plugin registry expectations, and one MCP event bridge test. Targeted memory/provider tests pass.
