### PR TITLE
fix(approval): make smart approval token budget configurable

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1917,6 +1917,8 @@ DEFAULT_CONFIG = {
         "mode": "manual",
         "timeout": 60,
         "cron_mode": "deny",
+        # Token budget for smart approval LLM; reasoning models need >64.
+        "smart_max_tokens": 128,
         # When true, /reload-mcp asks the user to confirm before rebuilding
         # the MCP tool set for the active session.  Reloading invalidates
         # the provider prompt cache (tool schemas are baked into the system

--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -35,14 +35,46 @@ class TestSmartApproval:
         response = SimpleNamespace(
             choices=[SimpleNamespace(message=SimpleNamespace(content="APPROVE"))]
         )
-        with mock_patch("agent.auxiliary_client.call_llm", return_value=response) as mock_call:
+        with (
+            mock_patch("hermes_cli.config.load_config", return_value={"approvals": {}}),
+            mock_patch("agent.auxiliary_client.call_llm", return_value=response) as mock_call,
+        ):
             result = _smart_approve("python -c \"print('hello')\"", "script execution via -c flag")
 
         assert result == "approve"
         mock_call.assert_called_once()
         assert mock_call.call_args.kwargs["task"] == "approval"
         assert mock_call.call_args.kwargs["temperature"] == 0
-        assert mock_call.call_args.kwargs["max_tokens"] == 16
+        assert mock_call.call_args.kwargs["max_tokens"] == 128
+
+    def test_smart_approval_reads_max_tokens_from_config(self):
+        response = SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content="APPROVE"))]
+        )
+        config = {"approvals": {"smart_max_tokens": 256}}
+        with (
+            mock_patch("hermes_cli.config.load_config", return_value=config),
+            mock_patch("agent.auxiliary_client.call_llm", return_value=response) as mock_call,
+        ):
+            _smart_approve("python -c \"print('hi')\"", "script execution via -c flag")
+
+        assert mock_call.call_args.kwargs["max_tokens"] == 256
+
+    def test_smart_approval_falls_back_on_invalid_max_tokens(self):
+        """Non-integer or sub-1 values in config fall back to the default budget."""
+        response = SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content="APPROVE"))]
+        )
+        for bad_value in ("not-an-int", 0, -5):
+            config = {"approvals": {"smart_max_tokens": bad_value}}
+            with (
+                mock_patch("hermes_cli.config.load_config", return_value=config),
+                mock_patch("agent.auxiliary_client.call_llm", return_value=response) as mock_call,
+            ):
+                _smart_approve("python -c \"print('hi')\"", "script execution via -c flag")
+            assert mock_call.call_args.kwargs["max_tokens"] == 128, (
+                f"expected fallback to 128 for {bad_value!r}, got {mock_call.call_args.kwargs['max_tokens']}"
+            )
 
 
 class TestDetectDangerousRm:

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -940,6 +940,9 @@ def _get_cron_approval_mode() -> str:
         return "deny"
 
 
+_SMART_APPROVE_DEFAULT_MAX_TOKENS = 128
+
+
 def _smart_approve(command: str, description: str) -> str:
     """Use the auxiliary LLM to assess risk and decide approval.
 
@@ -951,6 +954,15 @@ def _smart_approve(command: str, description: str) -> str:
     """
     try:
         from agent.auxiliary_client import call_llm
+
+        try:
+            smart_max_tokens = int(
+                _get_approval_config().get("smart_max_tokens", _SMART_APPROVE_DEFAULT_MAX_TOKENS)
+            )
+            if smart_max_tokens < 1:
+                smart_max_tokens = _SMART_APPROVE_DEFAULT_MAX_TOKENS
+        except (ValueError, TypeError):
+            smart_max_tokens = _SMART_APPROVE_DEFAULT_MAX_TOKENS
 
         prompt = f"""You are a security reviewer for an AI coding agent. A terminal command was flagged by pattern matching as potentially dangerous.
 
@@ -970,7 +982,7 @@ Respond with exactly one word: APPROVE, DENY, or ESCALATE"""
             task="approval",
             messages=[{"role": "user", "content": prompt}],
             temperature=0,
-            max_tokens=16,
+            max_tokens=smart_max_tokens,
         )
 
         answer = (response.choices[0].message.content or "").strip().upper()


### PR DESCRIPTION
## What does this PR do?

Fixes a silent failure in smart approval mode where every flagged command falls back to manual approval when the auxiliary model is a reasoning model. `tools.approval._smart_approve` hard-codes `max_tokens=16`, which is sufficient for non-reasoning models (`APPROVE` ≈ 1 token) but is fully consumed by `reasoning_content` for reasoning models (e.g. `deepseek-v4-flash` via OpenCode Go), leaving `message.content` empty and the verdict silently treated as `escalate`. This PR replaces the hard-coded value with a config-driven `approvals.smart_max_tokens` (default 128, configurable per auxiliary model).

## Related Issue

Fixes #
<!-- No existing issue tracks this. Happy to open one if preferred. -->

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/approval.py` — introduce `_SMART_APPROVE_DEFAULT_MAX_TOKENS = 128` module constant; read `approvals.smart_max_tokens` from config instead of the hard-coded `max_tokens=16`; defensive `try/except` for non-integer or sub-1 values falls back to the default
- `hermes_cli/config.py` — add `smart_max_tokens: 128` to `DEFAULT_CONFIG["approvals"]` with inline comment
- `tests/tools/test_approval.py` — update `test_smart_approval_uses_call_llm` to assert the new default (128) via mocked `load_config`; add `test_smart_approval_reads_max_tokens_from_config` (override path) and `test_smart_approval_falls_back_on_invalid_max_tokens` (string/0/negative → fallback to 128)

## Problem

`tools.approval._smart_approve` hard-codes `max_tokens=16` on the auxiliary LLM call. Reasoning models emit an internal chain-of-thought into `response.reasoning_content` before producing the verdict in `message.content`. With a 16-token budget the reasoning consumes the entire allowance and `content` stays empty. Empty content is interpreted as "uncertain" → silent fallback to a manual approval prompt for every flagged command, defeating smart mode.

## Reproducer

`config.yaml`:
```yaml
approvals:
  mode: smart
auxiliary:
  approval:
    provider: opencode-go
    model: deepseek-v4-flash
```

> Note: `tirith_enabled: false` is needed to invoke `_smart_approve` — when tirith is enabled it preempts pattern-flagged commands before the auxiliary LLM is consulted.

In a hermes session, ask the agent to run a benign script:
```
> run python3 -c "print('hello')"
```

The agent calls `terminal_tool`, which routes through approval. Pattern matching flags `-c` script execution as dangerous → `_smart_approve` is invoked.

Before: manual approval popup (smart_approve returns `escalate` due to empty `content`)
After: auto-approved (smart_approve returns `approve`)

## Root cause — empirical (deepseek-v4-flash via OpenCode Go)

| max_tokens | content     | reasoning_content                                       |
|------------|-------------|---------------------------------------------------------|
| 16         | `''`        | `We are given a command: python3 -c "print('hello')".`  |
| 32         | `''`        | `...flagged as potentially dangerous...`                |
| 48         | `''`        | `...There is no damage. So`                             |
| 64         | `''`        | `...clearly safe. So we should approve.`                |
| 80         | `'APPROVE'` | `...completely harmless. So the answer is APPROVE.`     |

Non-reasoning models (GPT-4o, Claude Haiku) emit `APPROVE` into `content` in 1–2 tokens, which is why 16 worked historically.

## Why the reasoning step matters

Smart approval distinguishes false positives (`python3 -c "print('hi')"`) from real threats (`rm -rf /`) — the same flagged pattern can be safe or catastrophic depending on context. The internal CoT (e.g. `"flagged as -c script execution, but only prints a string → APPROVE"`) is exactly the work we want the model to do for a security decision. A model that emits `APPROVE` in 1 token without reasoning would be less reliable, not more.

Cutting the budget at 16 forces the model to skip the verdict and fall through with an empty answer. Giving it room to think (128 default) has no cost impact for non-reasoning models — providers bill on tokens generated, not on the budget allowed. GPT-4o, Claude Haiku, etc. still emit `APPROVE` in 1–2 tokens and pay for those; the wider budget only matters for reasoning models that actually consume it.

Exposing `smart_max_tokens` as a config key lets operators tune the budget per auxiliary model: higher for verbose reasoning models (DeepSeek R-series, Claude extended thinking, GPT-5 thinking), lower for direct-response models (GPT-4o-mini, Claude Haiku) where a tight budget still works. Future-proofs the call site without needing another PR when the next reasoning model lands.

## Fix

Read `approvals.smart_max_tokens` from config; default 128 (margin above the 80-token empirical floor for future reasoning models). Non-reasoning models keep working — they only consume the tokens they need regardless of the budget cap.

## How to Test

**Automated:**
```
pytest tests/tools/test_approval.py::TestSmartApproval -q
```

The new/updated tests assert:
- Default behavior reads `approvals.smart_max_tokens` with fallback to 128 (`test_smart_approval_uses_call_llm`)
- Config override is honored (`test_smart_approval_reads_max_tokens_from_config` sets `{"smart_max_tokens": 256}` → `call_llm` invoked with `max_tokens=256`)
- Adjacent approval suites unaffected: `pytest tests/tools/test_approval*.py -q` → 212 passed locally

**Manual** (hermes session with deepseek-v4-flash, `approvals.mode=smart`, `tirith_enabled=false`):
- `python3 -c "print('hi')"` → auto-approved (was: manual popup before fix)
- `hermes config set approvals.smart_max_tokens 256` → written to `config.yaml`
- `rm -rf /` (flagged as destructive) → `_smart_approve` returns `DENY` (safety preserved)

## Future work

Read `reasoning_content` when `content` is empty instead of relying on a wider budget. Provider-specific field names (`reasoning_content`, Anthropic thinking blocks, etc.) and free-text parsing make it a larger refactor — out of scope here.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(approval):`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run `pytest tests/tools/test_approval*.py -q` and all 212 tests pass
- [x] I've added tests for my changes (default 128 + config override)
- [x] I've tested on my platform: macOS 26 (Apple Silicon, M4 Pro), Hermes Agent v0.14.0

### Documentation & Housekeeping

- [x] N/A — no user-facing docs reference approval config keys
- [x] N/A — `cli-config.yaml.example` does not currently include the `approvals` section (other approval keys like `mode`, `timeout`, `cron_mode` are also absent there); following existing precedent
- [x] N/A — no architectural or workflow changes
- [x] Cross-platform: pure config read + integer comparison, no platform-specific behavior
- [x] N/A — no tool descriptions/schemas changed
