### PR TITLE
fix(ci): isolate PR lockfile fixes from secrets

### DIFF
--- a/.github/workflows/nix-lockfile-fix.yml
+++ b/.github/workflows/nix-lockfile-fix.yml
@@ -18,8 +18,8 @@ on:
     types: [edited]
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
+  pull-requests: read
 
 concurrency:
   group: nix-lockfile-fix-${{ github.event.issue.number || github.event.inputs.pr_number || github.ref }}
@@ -41,10 +41,15 @@ jobs:
   #      always operates on the latest branch state.
   #   4. Uses a GitHub App token (not GITHUB_TOKEN) so the fix commit
   #      triggers downstream nix.yml verification.
+  #   5. Nix setup uses pinned third-party actions rather than repository-local
+  #      action code, so setup cannot be changed by this workflow's own commit.
   auto-fix-main:
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
     timeout-minutes: 25
+    permissions:
+      contents: write
+      pull-requests: read
     concurrency:
       group: auto-fix-main
       cancel-in-progress: true
@@ -61,9 +66,15 @@ jobs:
           ref: main
           token: ${{ steps.app-token.outputs.token }}
 
-      - uses: ./.github/actions/nix-setup
+      - name: Install Nix from trusted pinned action
+        uses: cachix/install-nix-action@08dcb3a5e62fa31e2da3d490afc4176ef55ecd72 # v30
+
+      - name: Configure Cachix authenticated cache
+        uses: cachix/cachix-action@1eb2ef646ac0255473d23a5907ad7b04ce94065c # v17
         with:
-          cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          name: hermes-agent
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+        continue-on-error: true
 
       - name: Apply lockfile hashes
         id: apply
@@ -121,10 +132,12 @@ jobs:
           echo "::error::Failed to push after 3 rebase attempts"
           exit 1
 
-  # ── PR fix (manual / checkbox) ─────────────────────────────────────
-  # Existing behavior: run on manual dispatch OR when a task-list
-  # checkbox in the sticky lockfile-check comment flips from [ ] to [x].
-  fix:
+  # ── PR/manual fix resolution ────────────────────────────────────────
+  # Manual/checkbox PR fixes are split across a no-secret generation job
+  # and a trusted write job. The PR branch is allowed to execute only in
+  # the generation job, which has read-only permissions, no persisted git
+  # credentials, no Cachix auth token, and no repository write token.
+  resolve_pr_fix:
     if: |
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'issue_comment'
@@ -132,15 +145,27 @@ jobs:
        && contains(github.event.comment.body, '[x] **Apply lockfile fix**')
        && !contains(github.event.changes.body.from, '[x] **Apply lockfile fix**'))
     runs-on: ubuntu-latest
-    timeout-minutes: 25
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+    outputs:
+      target_owner: ${{ steps.resolve.outputs.target_owner }}
+      target_repo: ${{ steps.resolve.outputs.target_repo }}
+      target_ref: ${{ steps.resolve.outputs.target_ref }}
+      target_sha: ${{ steps.resolve.outputs.target_sha }}
+      can_push: ${{ steps.resolve.outputs.can_push }}
+      pr: ${{ steps.resolve.outputs.pr }}
     steps:
-      - name: Authorize & resolve PR
+      - name: Authorize & resolve target
         id: resolve
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea  # v7.0.1
         with:
           script: |
-            // 1. Verify the actor has write access — applies to both checkbox
-            //    clicks and manual dispatch.
+            // Verify the actor has write access — applies to both checkbox
+            // clicks and manual dispatch. This authorizes requesting the fix;
+            // it does not make PR code trusted.
             const { data: perm } =
               await github.rest.repos.getCollaboratorPermissionLevel({
                 owner: context.repo.owner,
@@ -154,7 +179,6 @@ jobs:
               return;
             }
 
-            // 2. Resolve which ref to check out.
             let prNumber = '';
             if (context.eventName === 'issue_comment') {
               prNumber = String(context.payload.issue.number);
@@ -162,10 +186,23 @@ jobs:
               prNumber = context.payload.inputs.pr_number || '';
             }
 
+            const assertSafeRef = (ref) => {
+              if (!/^[A-Za-z0-9._\/-]+$/.test(ref) ||
+                  ref.includes('..') || ref.includes('@{') ||
+                  ref.startsWith('-') || ref.startsWith('/') ||
+                  ref.endsWith('/') || ref.endsWith('.')) {
+                throw new Error(`Unsafe target ref: ${ref}`);
+              }
+            };
+
             if (!prNumber) {
-              core.setOutput('ref', context.ref.replace(/^refs\/heads\//, ''));
-              core.setOutput('repo', context.repo.repo);
-              core.setOutput('owner', context.repo.owner);
+              const ref = context.ref.replace(/^refs\/heads\//, '');
+              assertSafeRef(ref);
+              core.setOutput('target_owner', context.repo.owner);
+              core.setOutput('target_repo', context.repo.repo);
+              core.setOutput('target_ref', ref);
+              core.setOutput('target_sha', context.sha);
+              core.setOutput('can_push', 'true');
               core.setOutput('pr', '');
               return;
             }
@@ -175,14 +212,15 @@ jobs:
               repo: context.repo.repo,
               pull_number: Number(prNumber),
             });
-            core.setOutput('ref', pr.head.ref);
-            core.setOutput('repo', pr.head.repo.name);
-            core.setOutput('owner', pr.head.repo.owner.login);
+            const baseFullName = `${context.repo.owner}/${context.repo.repo}`;
+            assertSafeRef(pr.head.ref);
+            core.setOutput('target_owner', pr.head.repo.owner.login);
+            core.setOutput('target_repo', pr.head.repo.name);
+            core.setOutput('target_ref', pr.head.ref);
+            core.setOutput('target_sha', pr.head.sha);
+            core.setOutput('can_push', pr.head.repo.full_name === baseFullName ? 'true' : 'false');
             core.setOutput('pr', String(pr.number));
 
-      # Wipe the sticky lockfile-check comment to a "running" state as soon
-      # as the job is authorized, so the user sees their click was picked up
-      # before the ~minute of nix build work.
       - name: Mark sticky as running
         if: steps.resolve.outputs.pr != ''
         uses: marocchino/sticky-pull-request-comment@52423e01640425a022ef5fd42c6fb5f633a02728  # v2.9.1
@@ -194,60 +232,295 @@ jobs:
 
             Triggered by @${{ github.actor }} — [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}).
 
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+  generate_pr_fix_patch:
+    needs: resolve_pr_fix
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      changed: ${{ steps.patch.outputs.changed }}
+    steps:
+      - name: Checkout target without credentials
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
-          repository: ${{ steps.resolve.outputs.owner }}/${{ steps.resolve.outputs.repo }}
-          ref: ${{ steps.resolve.outputs.ref }}
-          token: ${{ secrets.GITHUB_TOKEN }}
-          fetch-depth: 0
+          repository: ${{ needs.resolve_pr_fix.outputs.target_owner }}/${{ needs.resolve_pr_fix.outputs.target_repo }}
+          ref: ${{ needs.resolve_pr_fix.outputs.target_sha }}
+          persist-credentials: false
+          fetch-depth: 1
 
-      - uses: ./.github/actions/nix-setup
+      - name: Install Nix from trusted pinned action
+        uses: cachix/install-nix-action@08dcb3a5e62fa31e2da3d490afc4176ef55ecd72 # v30
+
+      - name: Configure Cachix read-only cache
+        uses: cachix/cachix-action@1eb2ef646ac0255473d23a5907ad7b04ce94065c # v17
         with:
-          cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          name: hermes-agent
+        continue-on-error: true
 
-      - name: Apply lockfile hashes
+      - name: Apply lockfile hashes without secrets
         id: apply
-        run: nix run .#fix-lockfiles
+        env:
+          LINK_SHA: ${{ needs.resolve_pr_fix.outputs.target_sha }}
+        run: nix run .#fix-lockfiles -- --apply
 
-      - name: Commit & push
-        if: steps.apply.outputs.changed == 'true'
+      - name: Validate and create patch artifact
+        id: patch
         shell: bash
         run: |
           set -euo pipefail
+          modified="$(git diff --name-only)"
+          if [ -z "$modified" ]; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          unexpected="$(printf '%s\n' "$modified" | grep -Ev '^nix/(tui|web)\.nix$' || true)"
+          if [ -n "$unexpected" ]; then
+            echo "::error::Unexpected modified files: $unexpected"
+            exit 1
+          fi
+
+          git diff -- nix/tui.nix nix/web.nix > lockfile-fix.patch
+          test -s lockfile-fix.patch
+          python3 - <<'PY'
+          import re
+          from pathlib import Path
+
+          ALLOWED_PATHS = {'nix/tui.nix', 'nix/web.nix'}
+          HASH_LINE = re.compile(r'^[+-]\s*hash = "sha256-[A-Za-z0-9+/=._-]+";$')
+          INDEX_LINE = re.compile(r'^index [0-9a-f]+\.\.[0-9a-f]+ 100644$')
+          REJECT_PREFIXES = (
+              'old mode ', 'new mode ', 'deleted file mode ', 'new file mode ',
+              'rename from ', 'rename to ', 'copy from ', 'copy to ',
+              'similarity index ', 'dissimilarity index ', 'Binary files ',
+              'GIT binary patch',
+          )
+
+          def patch_path(token):
+              if token == '/dev/null':
+                  return None
+              if not (token.startswith('a/') or token.startswith('b/')):
+                  return 'INVALID'
+              return token[2:]
+
+          bad = []
+          for line in Path('lockfile-fix.patch').read_text().splitlines():
+              if line.startswith('diff --git '):
+                  parts = line.split()
+                  paths = [patch_path(part) for part in parts[2:4]] if len(parts) == 4 else ['INVALID']
+                  if len(paths) != 2 or any(path not in ALLOWED_PATHS for path in paths):
+                      bad.append(line)
+                  continue
+              if line.startswith(('--- ', '+++ ')):
+                  path = patch_path(line.split(maxsplit=1)[1])
+                  if path not in ALLOWED_PATHS:
+                      bad.append(line)
+                  continue
+              if line.startswith('index '):
+                  if not INDEX_LINE.fullmatch(line):
+                      bad.append(line)
+                  continue
+              if line.startswith(REJECT_PREFIXES):
+                  bad.append(line)
+                  continue
+              if line.startswith('@@') or not line.startswith(('+', '-')):
+                  continue
+              if not HASH_LINE.fullmatch(line.strip()):
+                  bad.append(line)
+          if bad:
+              print('::error::Patch changes non-hash content or unsafe metadata:')
+              for line in bad[:20]:
+                  print(line)
+              raise SystemExit(1)
+          PY
+          echo "changed=true" >> "$GITHUB_OUTPUT"
+
+      - name: Upload lockfile patch
+        if: steps.patch.outputs.changed == 'true'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        with:
+          name: lockfile-fix-patch
+          path: lockfile-fix.patch
+          if-no-files-found: error
+
+  apply_pr_fix:
+    needs: [resolve_pr_fix, generate_pr_fix_patch]
+    if: needs.generate_pr_fix_patch.outputs.changed == 'true' && needs.resolve_pr_fix.outputs.can_push == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Checkout target branch for patch application
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          repository: ${{ github.repository }}
+          ref: ${{ needs.resolve_pr_fix.outputs.target_ref }}
+          fetch-depth: 0
+
+      - name: Download generated patch
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
+        with:
+          name: lockfile-fix-patch
+          path: patch
+
+      - name: Validate patch touches only lockfile hash files
+        shell: bash
+        run: |
+          set -euo pipefail
+          files="$(git apply --numstat patch/lockfile-fix.patch | awk '{print $3}')"
+          bad="$(printf '%s\n' "$files" | grep -Ev '^nix/(tui|web)\.nix$' || true)"
+          if [ -n "$bad" ]; then
+            echo "::error::Patch touches non-lockfile hash paths: $bad"
+            exit 1
+          fi
+          python3 - <<'PY'
+          import re
+          from pathlib import Path
+
+          ALLOWED_PATHS = {'nix/tui.nix', 'nix/web.nix'}
+          HASH_LINE = re.compile(r'^[+-]\s*hash = "sha256-[A-Za-z0-9+/=._-]+";$')
+          INDEX_LINE = re.compile(r'^index [0-9a-f]+\.\.[0-9a-f]+ 100644$')
+          REJECT_PREFIXES = (
+              'old mode ', 'new mode ', 'deleted file mode ', 'new file mode ',
+              'rename from ', 'rename to ', 'copy from ', 'copy to ',
+              'similarity index ', 'dissimilarity index ', 'Binary files ',
+              'GIT binary patch',
+          )
+
+          def patch_path(token):
+              if token == '/dev/null':
+                  return None
+              if not (token.startswith('a/') or token.startswith('b/')):
+                  return 'INVALID'
+              return token[2:]
+
+          bad = []
+          for line in Path('patch/lockfile-fix.patch').read_text().splitlines():
+              if line.startswith('diff --git '):
+                  parts = line.split()
+                  paths = [patch_path(part) for part in parts[2:4]] if len(parts) == 4 else ['INVALID']
+                  if len(paths) != 2 or any(path not in ALLOWED_PATHS for path in paths):
+                      bad.append(line)
+                  continue
+              if line.startswith(('--- ', '+++ ')):
+                  path = patch_path(line.split(maxsplit=1)[1])
+                  if path not in ALLOWED_PATHS:
+                      bad.append(line)
+                  continue
+              if line.startswith('index '):
+                  if not INDEX_LINE.fullmatch(line):
+                      bad.append(line)
+                  continue
+              if line.startswith(REJECT_PREFIXES):
+                  bad.append(line)
+                  continue
+              if line.startswith('@@') or not line.startswith(('+', '-')):
+                  continue
+              if not HASH_LINE.fullmatch(line.strip()):
+                  bad.append(line)
+          if bad:
+              print('::error::Patch changes non-hash content or unsafe metadata:')
+              for line in bad[:20]:
+                  print(line)
+              raise SystemExit(1)
+          PY
+
+      - name: Apply validated patch
+        shell: bash
+        run: git apply patch/lockfile-fix.patch
+
+      - name: Commit & push
+        shell: bash
+        env:
+          TARGET_REF: ${{ needs.resolve_pr_fix.outputs.target_ref }}
+        run: |
+          set -euo pipefail
+          if [[ ! "$TARGET_REF" =~ ^[A-Za-z0-9._/-]+$ ||
+                "$TARGET_REF" == -* || "$TARGET_REF" == /* ||
+                "$TARGET_REF" == */ || "$TARGET_REF" == *. ||
+                "$TARGET_REF" == *..* || "$TARGET_REF" == *@{* ]]; then
+            echo "::error::Unsafe target ref: $TARGET_REF"
+            exit 1
+          fi
+          git check-ref-format --branch "$TARGET_REF" >/dev/null
           git config user.name 'github-actions[bot]'
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
           git add nix/tui.nix nix/web.nix
           git commit -m "fix(nix): refresh npm lockfile hashes"
-          git push
+          git push origin "HEAD:${TARGET_REF}"
 
       - name: Update sticky (applied)
-        if: steps.apply.outputs.changed == 'true' && steps.resolve.outputs.pr != ''
+        if: needs.resolve_pr_fix.outputs.pr != ''
         uses: marocchino/sticky-pull-request-comment@52423e01640425a022ef5fd42c6fb5f633a02728  # v2.9.1
         with:
           header: nix-lockfile-check
-          number: ${{ steps.resolve.outputs.pr }}
+          number: ${{ needs.resolve_pr_fix.outputs.pr }}
           message: |
             ### ✅ Lockfile fix applied
 
             Pushed a commit refreshing the npm lockfile hashes — [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}).
 
-      - name: Update sticky (already current)
-        if: steps.apply.outputs.changed == 'false' && steps.resolve.outputs.pr != ''
+  comment_pr_patch_available:
+    needs: [resolve_pr_fix, generate_pr_fix_patch]
+    if: needs.generate_pr_fix_patch.outputs.changed == 'true' && needs.resolve_pr_fix.outputs.can_push != 'true' && needs.resolve_pr_fix.outputs.pr != ''
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: read
+    steps:
+      - name: Update sticky (patch available)
         uses: marocchino/sticky-pull-request-comment@52423e01640425a022ef5fd42c6fb5f633a02728  # v2.9.1
         with:
           header: nix-lockfile-check
-          number: ${{ steps.resolve.outputs.pr }}
+          number: ${{ needs.resolve_pr_fix.outputs.pr }}
+          message: |
+            ### ⚠️ Lockfile patch generated, but not pushed
+
+            This PR comes from a fork, so the workflow will not push with repository write credentials. Download the `lockfile-fix-patch` artifact from the [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) and apply it from a trusted checkout.
+
+  update_sticky_current:
+    needs: [resolve_pr_fix, generate_pr_fix_patch]
+    if: needs.generate_pr_fix_patch.outputs.changed == 'false' && needs.resolve_pr_fix.outputs.pr != ''
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: read
+    steps:
+      - name: Update sticky (already current)
+        uses: marocchino/sticky-pull-request-comment@52423e01640425a022ef5fd42c6fb5f633a02728  # v2.9.1
+        with:
+          header: nix-lockfile-check
+          number: ${{ needs.resolve_pr_fix.outputs.pr }}
           message: |
             ### ✅ Lockfile hashes already current
 
             Nothing to commit — [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}).
 
+  update_sticky_failed:
+    needs: [resolve_pr_fix, generate_pr_fix_patch, apply_pr_fix, comment_pr_patch_available, update_sticky_current]
+    if: |
+      always() &&
+      needs.resolve_pr_fix.outputs.pr != '' &&
+      (needs.resolve_pr_fix.result == 'failure' ||
+       needs.generate_pr_fix_patch.result == 'failure' ||
+       needs.apply_pr_fix.result == 'failure' ||
+       needs.comment_pr_patch_available.result == 'failure' ||
+       needs.update_sticky_current.result == 'failure')
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: read
+    steps:
       - name: Update sticky (failed)
-        if: failure() && steps.resolve.outputs.pr != ''
         uses: marocchino/sticky-pull-request-comment@52423e01640425a022ef5fd42c6fb5f633a02728  # v2.9.1
         with:
           header: nix-lockfile-check
-          number: ${{ steps.resolve.outputs.pr }}
+          number: ${{ needs.resolve_pr_fix.outputs.pr }}
           message: |
             ### ❌ Lockfile fix failed
 

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -22,9 +22,26 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: ./.github/actions/nix-setup
         with:
-          cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          persist-credentials: false
+
+      - name: Install Nix from trusted pinned action
+        uses: cachix/install-nix-action@08dcb3a5e62fa31e2da3d490afc4176ef55ecd72 # v30
+
+      - name: Configure Cachix authenticated cache on trusted pushes
+        if: github.event_name == 'push'
+        uses: cachix/cachix-action@1eb2ef646ac0255473d23a5907ad7b04ce94065c # v17
+        with:
+          name: hermes-agent
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+        continue-on-error: true
+
+      - name: Configure Cachix read-only cache on PRs
+        if: github.event_name == 'pull_request'
+        uses: cachix/cachix-action@1eb2ef646ac0255473d23a5907ad7b04ce94065c # v17
+        with:
+          name: hermes-agent
+        continue-on-error: true
 
       - name: Resolve head SHA
         if: github.event_name == 'pull_request'

--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -29,8 +29,14 @@ on:
       - 'package-lock.json'
       - 'ui-tui/package.json'
       - 'ui-tui/package-lock.json'
+      - 'ui-tui/packages/hermes-ink/package.json'
+      - 'ui-tui/packages/hermes-ink/package-lock.json'
+      - 'web/package.json'
+      - 'web/package-lock.json'
       - 'website/package.json'
       - 'website/package-lock.json'
+      - 'scripts/whatsapp-bridge/package.json'
+      - 'scripts/whatsapp-bridge/package-lock.json'
       - '.github/workflows/osv-scanner.yml'
   push:
     branches: [main]
@@ -40,7 +46,10 @@ on:
       - 'package.json'
       - 'package-lock.json'
       - 'ui-tui/package-lock.json'
+      - 'ui-tui/packages/hermes-ink/package-lock.json'
+      - 'web/package-lock.json'
       - 'website/package-lock.json'
+      - 'scripts/whatsapp-bridge/package-lock.json'
   schedule:
     # Weekly scan against main — catches CVEs published after merge for
     # deps that haven't changed since.
@@ -58,10 +67,14 @@ jobs:
     name: Scan lockfiles
     uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@9a498708959aeaef5ef730655706c5a1df1edbc2  # v2.3.8
     with:
-      # Scan explicit lockfiles rather than recursing, so we only look at
-      # the three sources of truth and skip vendored / test / worktree dirs.
+      # Scan explicit lockfiles rather than recursing, so we cover the tracked
+      # dependency roots while skipping vendored / test / worktree dirs.
       scan-args: |-
         --lockfile=uv.lock
+        --lockfile=package-lock.json
         --lockfile=ui-tui/package-lock.json
+        --lockfile=ui-tui/packages/hermes-ink/package-lock.json
+        --lockfile=web/package-lock.json
         --lockfile=website/package-lock.json
+        --lockfile=scripts/whatsapp-bridge/package-lock.json
       fail-on-vuln: false

--- a/tests/security/test_ci_security_workflows.py
+++ b/tests/security/test_ci_security_workflows.py
@@ -1,0 +1,105 @@
+import subprocess
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+LOCKFILE_FIX = ROOT / ".github" / "workflows" / "nix-lockfile-fix.yml"
+NIX_WORKFLOW = ROOT / ".github" / "workflows" / "nix.yml"
+OSV_WORKFLOW = ROOT / ".github" / "workflows" / "osv-scanner.yml"
+
+
+def _job_section(text: str, job_name: str) -> str:
+    marker = f"\n  {job_name}:\n"
+    start = text.index(marker)
+    next_job = text.find("\n  ", start + len(marker))
+    while next_job != -1:
+        line_end = text.find("\n", next_job + 1)
+        line = text[next_job + 1 : line_end if line_end != -1 else len(text)]
+        if line.startswith("  ") and not line.startswith("    ") and line.rstrip().endswith(":"):
+            return text[start:next_job]
+        next_job = text.find("\n  ", next_job + 1)
+    return text[start:]
+
+
+def test_pr_lockfile_generation_runs_without_secrets_or_write_credentials():
+    text = LOCKFILE_FIX.read_text()
+    generate = _job_section(text, "generate_pr_fix_patch")
+
+    assert "permissions:\n      contents: read\n      pull-requests: read" in generate
+    assert "persist-credentials: false" in generate
+    assert "secrets.CACHIX_AUTH_TOKEN" not in generate
+    assert "./.github/actions/nix-setup" not in generate
+    assert "nix run .#fix-lockfiles" in generate
+    assert "HASH_LINE = re.compile" in generate
+
+
+def test_pr_lockfile_write_job_does_not_execute_pr_controlled_code():
+    text = LOCKFILE_FIX.read_text()
+    apply = _job_section(text, "apply_pr_fix")
+
+    assert "permissions:\n      contents: write" in apply
+    assert "nix run .#fix-lockfiles" not in apply
+    assert "./.github/actions/nix-setup" not in apply
+    assert "CACHIX_AUTH_TOKEN" not in apply
+    assert "git apply patch/lockfile-fix.patch" in apply
+    assert "HASH_LINE = re.compile" in apply
+    assert "TARGET_REF: ${{ needs.resolve_pr_fix.outputs.target_ref }}" in apply
+    assert 'git push origin "HEAD:${TARGET_REF}"' in apply
+    assert "git push origin HEAD:${{ needs.resolve_pr_fix.outputs.target_ref }}" not in apply
+
+
+def test_pr_lockfile_fork_prs_do_not_receive_write_token_pushes():
+    text = LOCKFILE_FIX.read_text()
+
+    assert "can_push" in _job_section(text, "resolve_pr_fix")
+    assert "assertSafeRef(pr.head.ref)" in text
+    assert "ref.startsWith('-')" in text
+    assert "pr.head.repo.full_name === baseFullName ? 'true' : 'false'" in text
+    assert "needs.resolve_pr_fix.outputs.can_push == 'true'" in _job_section(text, "apply_pr_fix")
+    assert "needs.resolve_pr_fix.outputs.can_push != 'true'" in _job_section(text, "comment_pr_patch_available")
+
+
+def test_lockfile_patch_validation_rejects_metadata_changes():
+    text = LOCKFILE_FIX.read_text()
+    generate = _job_section(text, "generate_pr_fix_patch")
+    apply = _job_section(text, "apply_pr_fix")
+
+    for section in (generate, apply):
+        assert "old mode " in section
+        assert "new mode " in section
+        assert "GIT binary patch" in section
+        assert "Patch changes non-hash content or unsafe metadata" in section
+        assert "INDEX_LINE" in section
+
+
+def test_nix_pr_checks_do_not_load_local_actions_or_cachix_secret():
+    text = NIX_WORKFLOW.read_text()
+
+    assert "./.github/actions/nix-setup" not in text
+    assert "persist-credentials: false" in text
+    assert "github.event_name == 'push'" in text
+    assert "authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}" in text
+    assert "github.event_name == 'pull_request'" in text
+
+
+def test_nix_setup_uses_pinned_external_action_in_ci():
+    for workflow in (LOCKFILE_FIX, NIX_WORKFLOW):
+        text = workflow.read_text()
+        assert "cachix/install-nix-action@08dcb3a5e62fa31e2da3d490afc4176ef55ecd72 # v30" in text
+        assert "./.github/actions/nix-setup" not in text
+
+
+def test_osv_scanner_covers_all_tracked_lockfiles():
+    text = OSV_WORKFLOW.read_text()
+    tracked = subprocess.run(
+        ["git", "ls-files", "uv.lock", "*package-lock.json"],
+        cwd=ROOT,
+        check=True,
+        text=True,
+        capture_output=True,
+    ).stdout.splitlines()
+
+    # OSV only supports lockfile inputs here; every tracked uv/package lockfile
+    # should be listed explicitly so new dependency roots are not silently missed.
+    for lockfile in tracked:
+        assert f"--lockfile={lockfile}" in text

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@docusaurus/core": "3.9.2",
         "@docusaurus/preset-classic": "3.9.2",
-        "@docusaurus/theme-mermaid": "^3.9.2",
+        "@docusaurus/theme-mermaid": "3.9.2",
         "@easyops-cn/docusaurus-search-local": "^0.55.1",
         "@mdx-js/react": "^3.0.0",
         "clsx": "^2.0.0",
@@ -7109,9 +7109,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -9907,9 +9907,9 @@
       "license": "MIT"
     },
     "node_modules/express/node_modules/path-to-regexp": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
-      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
       "license": "MIT"
     },
     "node_modules/express/node_modules/range-parser": {
@@ -12565,16 +12565,16 @@
       }
     },
     "node_modules/mermaid/node_modules/uuid": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/esm/bin/uuid"
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/methods": {
@@ -14525,9 +14525,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "funding": [
         {
           "type": "github",
@@ -15164,9 +15164,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -15235,9 +15235,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
       "funding": [
         {
           "type": "opencollective",
@@ -15254,7 +15254,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -16895,15 +16895,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "^5.1.0"
-      }
-    },
     "node_modules/range-parser": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
@@ -17044,9 +17035,9 @@
       }
     },
     "node_modules/react-loadable-ssr-addon-v5-slorber": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/react-loadable-ssr-addon-v5-slorber/-/react-loadable-ssr-addon-v5-slorber-1.0.1.tgz",
-      "integrity": "sha512-lq3Lyw1lGku8zUEJPDxsNm1AfYHBrO9Y1+olAYwpUJ2IGFBskM0DMKok97A6LWUpHm+o7IvQBOWu9MLenp9Z+A==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/react-loadable-ssr-addon-v5-slorber/-/react-loadable-ssr-addon-v5-slorber-1.0.3.tgz",
+      "integrity": "sha512-GXfh9VLwB5ERaCsU6RULh7tkemeX15aNh6wuMEBtfdyMa7fFG8TXrhXlx1SoEK2Ty/l6XIkzzYIQmyaWW3JgdQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.10.3"
@@ -17921,12 +17912,12 @@
       }
     },
     "node_modules/serialize-javascript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.5.tgz",
+      "integrity": "sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==",
       "license": "BSD-3-Clause",
-      "dependencies": {
-        "randombytes": "^2.1.0"
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/serve-handler": {
@@ -18968,9 +18959,9 @@
       "license": "MIT"
     },
     "node_modules/undici": {
-      "version": "7.23.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.23.0.tgz",
-      "integrity": "sha512-HVMxHKZKi+eL2mrUZDzDkKW3XvCjynhbtpSq20xQp4ePDFeSFuAfnvM0GIwZIv8fiKHjXFQ5WjxhCt15KRNj+g==",
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"
@@ -19736,9 +19727,9 @@
       }
     },
     "node_modules/webpack-dev-server/node_modules/ws": {
-      "version": "8.19.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
-      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/website/package.json
+++ b/website/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "@docusaurus/core": "3.9.2",
     "@docusaurus/preset-classic": "3.9.2",
-    "@docusaurus/theme-mermaid": "^3.9.2",
+    "@docusaurus/theme-mermaid": "3.9.2",
     "@easyops-cn/docusaurus-search-local": "^0.55.1",
     "@mdx-js/react": "^3.0.0",
     "clsx": "^2.0.0",
@@ -48,5 +48,8 @@
   },
   "engines": {
     "node": ">=20.0"
+  },
+  "overrides": {
+    "serialize-javascript": "7.0.5"
   }
 }


### PR DESCRIPTION
## Summary
- Isolates PR-controlled Nix lockfile fix generation from secrets and write tokens.
- Replaces repository-local Nix setup actions with SHA-pinned trusted third-party actions.
- Adds strict patch validation for lockfile fixes: allowed paths only, hash-line changes only, no mode/rename/copy/binary metadata, safe target refs only.
- Expands OSV lockfile coverage and fixes website high-severity npm advisories.

## Verification
- `uv run --extra dev pytest tests/security/test_ci_security_workflows.py -q` → 7 passed
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 .github/workflows/nix-lockfile-fix.yml .github/workflows/nix.yml .github/workflows/osv-scanner.yml` → clean
- YAML parse for changed workflows → clean
- `git diff --check origin/main...HEAD` → clean
- `npm audit --omit=dev --audit-level=high` → 0 vulnerabilities across root, web, ui-tui, website, ui-tui/packages/hermes-ink, scripts/whatsapp-bridge
- `cd website && npm ci && npm run build` → success; existing docs broken-link warnings only
- Independent pre-landing security review after blocker fixes → NO BLOCKERS

## CI status
Fork PR workflow runs are stuck at `action_required`; repository admin approval is required before GitHub Actions will execute them. Local verification above is complete.
