### PR TITLE
docs(simplex): fix contact discovery command

### DIFF
--- a/website/docs/user-guide/messaging/simplex.md
+++ b/website/docs/user-guide/messaging/simplex.md
@@ -62,7 +62,13 @@ SIMPLEX_HOME_CHANNEL=<contact-id>
 
 ## Find your contact ID or display name
 
-After starting the daemon, open a conversation with your agent contact. The numeric `contactId` appears in session logs or via `hermes send_message action=list`. If you'd rather use the display name shown in the SimpleX UI, that works too — `SIMPLEX_ALLOWED_USERS` accepts either form.
+After starting the daemon, open a conversation with your agent contact. The numeric `contactId` appears in session logs or in the discovered messaging targets:
+
+```bash
+hermes send --list simplex
+```
+
+If you'd rather use the display name shown in the SimpleX UI, that works too — `SIMPLEX_ALLOWED_USERS` accepts either form.
 
 ## Authorization
 


### PR DESCRIPTION
## What does this PR do?

Updates the SimpleX setup docs to show the real CLI command for listing discovered SimpleX messaging targets.

The previous text told users to run `hermes send_message action=list`, which is the internal tool-call shape, not the shell CLI command. The documented user-facing command is now `hermes send --list simplex`.

## Related Issue

No issue filed. Found while handling a Discord support thread for SimpleX contact ID discovery.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `website/docs/user-guide/messaging/simplex.md`: replace the internal `send_message(action='list')`-style wording with the actual `hermes send --list simplex` CLI command.

## How to Test

1. Read the SimpleX docs page section `Find your contact ID`.
2. Confirm it now shows `hermes send --list simplex` as the CLI command for discovered SimpleX targets.
3. Confirm the command matches `hermes send --help`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass (not run; docs-only command correction)
- [ ] I've added tests for my changes (not applicable; docs-only command correction)
- [x] I've tested on my platform: Linux / WSL shell command verification

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Not applicable; docs-only correction.