### PR TITLE
chore(models): drop retired grok-4-1-fast from metadata, tests, and provider docs

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -210,9 +210,8 @@ DEFAULT_CONTEXT_LENGTHS = {
     # Keys use substring matching (longest-first), so e.g. "grok-4.20"
     # matches "grok-4.20-0309-reasoning" / "-non-reasoning" / "-multi-agent-0309".
     "grok-code-fast": 256000,   # grok-code-fast-1
-    "grok-4-1-fast": 2000000,   # grok-4-1-fast-(non-)reasoning
     "grok-2-vision": 8192,      # grok-2-vision, -1212, -latest
-    "grok-4-fast": 2000000,     # grok-4-fast-(non-)reasoning
+    "grok-4-fast": 2000000,     # grok-4-fast-(non-)reasoning, also matches -reasoning
     "grok-4.20": 2000000,       # grok-4.20-0309-(non-)reasoning, -multi-agent-0309
     "grok-4.3": 1000000,        # grok-4.3, grok-4.3-latest — 1M context per docs.x.ai
     "grok-4": 256000,           # grok-4, grok-4-0709

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -161,7 +161,6 @@ class TestDefaultContextLengths:
         # Values sourced from models.dev (2026-04).
         expected = {
             "grok-4.20": 2000000,
-            "grok-4-1-fast": 2000000,
             "grok-4-fast": 2000000,
             "grok-4": 256000,
             "grok-code-fast": 256000,
@@ -189,8 +188,6 @@ class TestDefaultContextLengths:
                 ("grok-4.20-0309-reasoning", 2000000),
                 ("grok-4.20-0309-non-reasoning", 2000000),
                 ("grok-4.20-multi-agent-0309", 2000000),
-                ("grok-4-1-fast-reasoning", 2000000),
-                ("grok-4-1-fast-non-reasoning", 2000000),
                 ("grok-4-fast-reasoning", 2000000),
                 ("grok-4-fast-non-reasoning", 2000000),
                 ("grok-4", 256000),

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -345,7 +345,7 @@ When using the Z.AI / GLM provider, Hermes automatically probes multiple endpoin
 
 ### xAI (Grok) — Responses API + Prompt Caching
 
-xAI is wired through the Responses API (`codex_responses` transport) for automatic reasoning support on Grok 4 models — no `reasoning_effort` parameter needed, the server reasons by default. Set `XAI_API_KEY` in `~/.hermes/.env` and pick xAI in `hermes model`, or drop `grok` as a shortcut into `/model grok-4-1-fast-reasoning`.
+xAI is wired through the Responses API (`codex_responses` transport) for automatic reasoning support on Grok 4 models — no `reasoning_effort` parameter needed, the server reasons by default. Set `XAI_API_KEY` in `~/.hermes/.env` and pick xAI in `hermes model`, or drop `grok` as a shortcut into `/model grok-4-fast-reasoning`.
 
 SuperGrok and X Premium+ subscribers can sign in with browser OAuth instead of using an API key — pick **xAI Grok OAuth (SuperGrok Subscription)** in `hermes model`, or run `hermes auth add xai-oauth`. The same OAuth bearer token is automatically reused by direct-to-xAI tools (TTS, image gen, video gen, transcription). See the [xAI Grok OAuth guide](../guides/xai-grok-oauth.md) for the full flow — and if Hermes runs on a remote host, also see [OAuth over SSH / Remote Hosts](../guides/oauth-over-ssh.md) for the required `ssh -L` tunnel.
 


### PR DESCRIPTION
## Summary

`grok-4-1-fast` was retired by xAI. `hermes_cli/models.py` already removed it from the static fallback in an earlier commit, but three other places still reference the retired ID by name — context-length metadata, the tests pinning those values, and the xAI provider documentation. This sweeps them up so the retired model stops surfacing in user-facing lists, error messages, and docs.

## Changes

**`agent/model_metadata.py`** — drop the `"grok-4-1-fast": 2000000` entry from `DEFAULT_CONTEXT_LENGTHS`. The existing `"grok-4-fast"` entry (also 2M context) covers the live successor; updated its inline comment to note it now also catches `-reasoning` variants via longest-prefix substring matching.

**`tests/agent/test_model_metadata.py`** — remove `grok-4-1-fast` assertions from `test_grok_models_context_lengths` and `grok-4-1-fast-reasoning` / `-non-reasoning` cases from `test_grok_substring_matching`. The remaining cases still exercise the substring-matching path on live IDs (`grok-4-fast-reasoning`, `grok-4-fast-non-reasoning`, etc.).

**`website/docs/integrations/providers.md`** — `/model grok-4-1-fast-reasoning` → `/model grok-4-fast-reasoning` in the xAI Grok section.

Net diff: **3 files, +2/-6 lines**.

## Testing

- `pytest tests/agent/test_model_metadata.py` → **101/101 pass**

## Notes for reviewers

- **`hermes_cli/models.py` was deliberately omitted from this PR**: an earlier version of this cleanup also touched the `_XAI_STATIC_FALLBACK` list there, but #23291 (`fix(xai): drop models being retired May 15, 2026 from pickers`, commit 594209389) had already collapsed that list down to `grok-4.20-*` and `grok-4.3` variants. Re-adding `grok-4-fast` / `grok-4-fast-reasoning` to that list would actively regress the upstream retirement. This PR strictly targets the three remaining stragglers that the upstream sweep missed.
- The `grok-4-fast` entry in `DEFAULT_CONTEXT_LENGTHS` is retained because the substring matcher uses it (longest-prefix-first) to resolve `grok-4-fast-*` IDs to the correct 2M context without falling through to the 128K probe-down. Removing it would silently downgrade context length for users on direct-xAI endpoints that still expose the model.
- Pure metadata/docs cleanup — no runtime behavior change for any non-retired model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)