### PR TITLE
fix(update): sync fork from upstream before fetch/pull

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -8443,6 +8443,10 @@ def _cmd_update_impl(args, gateway_mode: bool):
         print(f"  {origin_url}")
         print()
 
+        # Sync fork from upstream before fetching — ensures origin (fork)
+        # is current so the fetch/pull below gets real upstream updates.
+        _sync_with_upstream_if_needed(git_cmd, PROJECT_ROOT)
+
     if use_zip_update:
         # ZIP-based update for Windows when git is broken
         _update_via_zip(args)
@@ -8671,10 +8675,6 @@ def _cmd_update_impl(args, gateway_mode: bool):
             print(
                 f"  ✓ Cleared {removed} stale __pycache__ director{'y' if removed == 1 else 'ies'}"
             )
-
-        # Fork upstream sync logic (only for main branch on forks)
-        if is_fork and branch == "main":
-            _sync_with_upstream_if_needed(git_cmd, PROJECT_ROOT)
 
         # Reinstall Python dependencies. Prefer .[all], but if one optional extra
         # breaks on this machine, keep base deps and reinstall the remaining extras


### PR DESCRIPTION
## What does this PR do?

Fixes the `hermes update` fork path where the upstream sync (`_sync_with_upstream_if_needed`) ran AFTER the fetch/pull from origin — too late to prevent stale-fork scenarios.

The fix moves the upstream sync to BEFORE the fetch/pull step, so:
- Both code paths (early-return and full pull) operate against a current fork
- The post-pull duplicate sync call is removed

## Related Issue

Fixes #26172

## Related PRs

- #26249 (LeonSGP43) patches the early-return path only — this PR takes the broader approach of fixing the ordering so both paths work.
- #19696 fixed `hermes update --check` but not the actual update path.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- Moved `_sync_with_upstream_if_needed()` call from after the pull/pip-install (line ~8677) to before the fetch/pull section (line ~8445)
- Removed the now-redundant post-pull sync call
- Net: same number of sync calls, but at the right time

## How to Test

1. Set up a fork of hermes-agent where origin/main is behind upstream/main by N commits
2. Run `hermes update`
3. Confirm upstream sync runs BEFORE "Fetching updates..."
4. Confirm the update pulls current upstream code, not stale fork code