### PR TITLE
fix(kanban): close decomposer SQLite connections to stop fd leak

### DIFF
--- a/hermes_cli/kanban_decompose.py
+++ b/hermes_cli/kanban_decompose.py
@@ -36,6 +36,7 @@ Design notes
 
 from __future__ import annotations
 
+import contextlib
 import json
 import logging
 import os
@@ -281,7 +282,7 @@ def decompose_task(
     configured, API error, malformed response, decomposer returned
     fanout=true with empty task list) — those surface via ``ok=False``.
     """
-    with kb.connect() as conn:
+    with contextlib.closing(kb.connect()) as conn:
         task = kb.get_task(conn, task_id)
     if task is None:
         return DecomposeOutcome(task_id, False, "unknown task id")
@@ -370,7 +371,7 @@ def decompose_task(
             return DecomposeOutcome(
                 task_id, False, "decomposer returned fanout=false with no title/body",
             )
-        with kb.connect() as conn:
+        with contextlib.closing(kb.connect()) as conn:
             ok = kb.specify_triage_task(
                 conn,
                 task_id,
@@ -439,7 +440,7 @@ def decompose_task(
         })
 
     try:
-        with kb.connect() as conn:
+        with contextlib.closing(kb.connect()) as conn:
             child_ids = kb.decompose_triage_task(
                 conn,
                 task_id,
@@ -467,7 +468,7 @@ def decompose_task(
 
 def list_triage_ids(*, tenant: Optional[str] = None) -> list[str]:
     """Return task ids currently in the triage column."""
-    with kb.connect() as conn:
+    with contextlib.closing(kb.connect()) as conn:
         rows = kb.list_tasks(
             conn,
             status="triage",


### PR DESCRIPTION
## Summary

`hermes_cli/kanban_decompose.py` opened SQLite connections with `with kb.connect() as conn:`. Python's `sqlite3` connection context manager **commits/rolls back the transaction but does not close the connection** — so the underlying file descriptors (main DB + WAL) are only released on garbage collection, and connections held by reference cycles linger.

`list_triage_ids()` is called on **every gateway dispatcher tick, for every board** (via the auto-decompose loop in `gateway/run.py`), so this leaked ~1 connection (2 fds) per tick per board.

### Impact (observed in production)

On a long-running gateway this exhausted the process's open-file limit (default soft `RLIMIT_NOFILE` of 1024) in ~5 hours. Once the fd table was full:

- the Slack Socket Mode client could no longer open sockets and every reconnect failed with `ClientConnectorDNSError: Cannot connect to host slack.com:443 ssl:default [Invalid argument]` (EINVAL) — the agent went silent on Slack while the process stayed "active";
- the kanban DB itself started throwing `sqlite3.OperationalError: unable to open database file`.

Host DNS/TLS to Slack was fine throughout — it was purely fd starvation. `/proc/<pid>/fd` showed ~993 of 1024 fds held open against `kanban.db` / `kanban.db-wal` across boards.

## Fix

Wrap all four `kb.connect()` sites in `kanban_decompose.py` with `contextlib.closing()` so the connection is deterministically closed when the block exits. Verified on a live gateway: kanban fds dropped from ~993 to 0 and stay flat across ticks; Slack reconnects immediately.

## Note for maintainers

The same `with kb.connect() as conn:` pattern appears in other modules that are **not** on the gateway hot path (`hermes_cli/kanban_specify.py` has an identical `list_triage_ids`, and there are ~34 sites in `hermes_cli/kanban.py`). They're latent leaks rather than active ones, so I've kept this PR scoped to the proven culprit. Happy to follow up with a sweep of the rest if you'd prefer them fixed in one go.

## Test plan

- [ ] CI green
- [x] Manual: ran a live gateway with the patch — `ls /proc/<pid>/fd | grep -c kanban` stays at 0 across many dispatcher ticks (previously climbed ~1/tick/board to the 1024 ceiling)
- [x] Manual: Slack Socket Mode reconnects and stays connected (`ss -tnp` shows an ESTABLISHED websocket to `wss-primary.slack.com`)