### PR TITLE
feat: add dashboard native auth moon ops

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -1120,6 +1120,11 @@ def load_gateway_config() -> GatewayConfig:
                     if isinstance(ac, list):
                         ac = ",".join(str(v) for v in ac)
                     os.environ["MATTERMOST_ALLOWED_CHANNELS"] = str(ac)
+                ntc = mattermost_cfg.get("no_thread_channels")
+                if ntc is not None and not os.getenv("MATTERMOST_NO_THREAD_CHANNELS"):
+                    if isinstance(ntc, list):
+                        ntc = ",".join(str(v) for v in ntc)
+                    os.environ["MATTERMOST_NO_THREAD_CHANNELS"] = str(ntc)
 
             # Matrix settings → env vars (env vars take precedence)
             matrix_cfg = yaml_cfg.get("matrix", {})
@@ -1377,6 +1382,13 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
         config.platforms[Platform.MATTERMOST].enabled = True
         config.platforms[Platform.MATTERMOST].token = mattermost_token
         config.platforms[Platform.MATTERMOST].extra["url"] = mattermost_url
+        for env_key, extra_key in (
+            ("MATTERMOST_REPLY_MODE", "reply_mode"),
+            ("MATTERMOST_NO_THREAD_CHANNELS", "no_thread_channels"),
+        ):
+            env_value = os.getenv(env_key)
+            if env_value:
+                config.platforms[Platform.MATTERMOST].extra[extra_key] = env_value
     mattermost_home = os.getenv("MATTERMOST_HOME_CHANNEL")
     if mattermost_home and Platform.MATTERMOST in config.platforms:
         config.platforms[Platform.MATTERMOST].home_channel = HomeChannel(

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -81,6 +81,11 @@ def _reply_anchor_for_event(event) -> str | None:
         return getattr(event, "message_id", None) or getattr(event, "reply_to_message_id", None)
     if platform == "telegram" and thread_id:
         return None
+    if platform == "mattermost" and thread_id:
+        # Mattermost posts require root_id to point at the thread root. For a
+        # user's reply inside an existing thread, event.message_id is the child
+        # post; using it as root_id can fork replies into the channel/new lane.
+        return str(thread_id)
     if platform == "feishu" and thread_id and getattr(event, "reply_to_message_id", None):
         return getattr(event, "reply_to_message_id", None)
     return getattr(event, "message_id", None)

--- a/gateway/platforms/mattermost.py
+++ b/gateway/platforms/mattermost.py
@@ -95,6 +95,15 @@ class MattermostAdapter(BasePlatformAdapter):
             config.extra.get("reply_mode", "")
             or os.getenv("MATTERMOST_REPLY_MODE", "off")
         ).lower()
+        no_thread_raw = config.extra.get("no_thread_channels") or []
+        if isinstance(no_thread_raw, str):
+            no_thread_values = no_thread_raw.split(",")
+        else:
+            no_thread_values = list(no_thread_raw)
+        env_no_thread = os.getenv("MATTERMOST_NO_THREAD_CHANNELS", "")
+        if env_no_thread:
+            no_thread_values.extend(env_no_thread.split(","))
+        self._no_thread_channels = {str(v).strip() for v in no_thread_values if str(v).strip()}
 
         # Dedup cache (prevent reprocessing)
         self._dedup = MessageDeduplicator()
@@ -270,7 +279,7 @@ class MattermostAdapter(BasePlatformAdapter):
                 "message": chunk,
             }
             # Thread support: reply_to is the root post ID.
-            if reply_to and self._reply_mode == "thread":
+            if reply_to and self._should_thread_reply(chat_id):
                 payload["root_id"] = reply_to
 
             data = await self._api_post("posts", payload)
@@ -279,6 +288,10 @@ class MattermostAdapter(BasePlatformAdapter):
             last_id = data["id"]
 
         return SendResult(success=True, message_id=last_id)
+
+    def _should_thread_reply(self, chat_id: str) -> bool:
+        """Return whether replies in this channel should be nested in a Mattermost thread."""
+        return self._reply_mode == "thread" and chat_id not in self._no_thread_channels
 
     async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
         """Return channel name and type."""
@@ -450,7 +463,7 @@ class MattermostAdapter(BasePlatformAdapter):
             "message": caption or "",
             "file_ids": [file_id],
         }
-        if reply_to and self._reply_mode == "thread":
+        if reply_to and self._should_thread_reply(chat_id):
             payload["root_id"] = reply_to
 
         data = await self._api_post("posts", payload)
@@ -488,7 +501,7 @@ class MattermostAdapter(BasePlatformAdapter):
             "message": caption or "",
             "file_ids": [file_id],
         }
-        if reply_to and self._reply_mode == "thread":
+        if reply_to and self._should_thread_reply(chat_id):
             payload["root_id"] = reply_to
 
         data = await self._api_post("posts", payload)

--- a/gateway/platforms/mattermost.py
+++ b/gateway/platforms/mattermost.py
@@ -107,6 +107,19 @@ class MattermostAdapter(BasePlatformAdapter):
             no_thread_values.extend(env_no_thread.split(","))
         self._no_thread_channels = {str(v).strip() for v in no_thread_values if str(v).strip()}
 
+        auto_thread_raw = (
+            config.extra.get("auto_thread_channels", "")
+            or os.getenv("MATTERMOST_AUTO_THREAD_CHANNELS", "")
+        )
+        if isinstance(auto_thread_raw, (list, tuple, set)):
+            self._auto_thread_channels = {
+                str(channel).strip() for channel in auto_thread_raw if str(channel).strip()
+            }
+        else:
+            self._auto_thread_channels = {
+                channel.strip() for channel in str(auto_thread_raw).split(",") if channel.strip()
+            }
+
         # Dedup cache (prevent reprocessing)
         self._dedup = MessageDeduplicator()
 
@@ -280,9 +293,9 @@ class MattermostAdapter(BasePlatformAdapter):
                 "channel_id": chat_id,
                 "message": chunk,
             }
-            # Thread support: reply_to is the root post ID.
-            if reply_to and self._should_thread_reply(chat_id):
-                payload["root_id"] = reply_to
+            root_id = self._root_id_from_send_context(chat_id, reply_to, metadata)
+            if root_id:
+                payload["root_id"] = root_id
 
             data = await self._api_post("posts", payload)
             if not data or "id" not in data:
@@ -294,6 +307,27 @@ class MattermostAdapter(BasePlatformAdapter):
     def _should_thread_reply(self, chat_id: str) -> bool:
         """Return whether replies in this channel should be nested in a Mattermost thread."""
         return self._reply_mode == "thread" and chat_id not in self._no_thread_channels
+
+    def _root_id_from_send_context(
+        self,
+        chat_id: str,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> Optional[str]:
+        """Resolve the Mattermost thread root for an outbound post.
+
+        Gateway progress, streaming, approval, and background notifications
+        often carry the canonical thread root in metadata and leave reply_to
+        empty. For Mattermost, root_id must be the root post id; child post ids
+        are rejected with Invalid RootId.
+        """
+        if not self._should_thread_reply(chat_id):
+            return None
+        root_id = None
+        if metadata:
+            root_id = metadata.get("mattermost_root_id") or metadata.get("thread_id")
+        root_id = root_id or reply_to
+        return str(root_id) if root_id else None
 
     async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
         """Return channel name and type."""
@@ -347,7 +381,7 @@ class MattermostAdapter(BasePlatformAdapter):
     ) -> SendResult:
         """Download an image and upload it as a file attachment."""
         return await self._send_url_as_file(
-            chat_id, image_url, caption, reply_to, "image"
+            chat_id, image_url, caption, reply_to, metadata=metadata, kind="image"
         )
 
     async def send_image_file(
@@ -360,7 +394,7 @@ class MattermostAdapter(BasePlatformAdapter):
     ) -> SendResult:
         """Upload a local image file."""
         return await self._send_local_file(
-            chat_id, image_path, caption, reply_to
+            chat_id, image_path, caption, reply_to, metadata=metadata
         )
 
     async def send_document(
@@ -374,7 +408,7 @@ class MattermostAdapter(BasePlatformAdapter):
     ) -> SendResult:
         """Upload a local file as a document."""
         return await self._send_local_file(
-            chat_id, file_path, caption, reply_to, file_name
+            chat_id, file_path, caption, reply_to, file_name, metadata=metadata
         )
 
     async def send_voice(
@@ -387,7 +421,7 @@ class MattermostAdapter(BasePlatformAdapter):
     ) -> SendResult:
         """Upload an audio file."""
         return await self._send_local_file(
-            chat_id, audio_path, caption, reply_to
+            chat_id, audio_path, caption, reply_to, metadata=metadata
         )
 
     async def send_video(
@@ -400,7 +434,7 @@ class MattermostAdapter(BasePlatformAdapter):
     ) -> SendResult:
         """Upload a video file."""
         return await self._send_local_file(
-            chat_id, video_path, caption, reply_to
+            chat_id, video_path, caption, reply_to, metadata=metadata
         )
 
     def format_message(self, content: str) -> str:
@@ -423,13 +457,14 @@ class MattermostAdapter(BasePlatformAdapter):
         url: str,
         caption: Optional[str],
         reply_to: Optional[str],
+        metadata: Optional[Dict[str, Any]] = None,
         kind: str = "file",
     ) -> SendResult:
         """Download a URL and upload it as a file attachment."""
         from tools.url_safety import is_safe_url
         if not is_safe_url(url):
             logger.warning("Mattermost: blocked unsafe URL (SSRF protection)")
-            return await self.send(chat_id, f"{caption or ''}\n{url}".strip(), reply_to)
+            return await self.send(chat_id, f"{caption or ''}\n{url}".strip(), reply_to, metadata=metadata)
 
         import aiohttp
 
@@ -447,7 +482,7 @@ class MattermostAdapter(BasePlatformAdapter):
                             await asyncio.sleep(1.5 * (attempt + 1))
                             continue
                     if resp.status >= 400:
-                        return await self.send(chat_id, f"{caption or ''}\n{url}".strip(), reply_to)
+                        return await self.send(chat_id, f"{caption or ''}\n{url}".strip(), reply_to, metadata=metadata)
                     file_data = await resp.read()
                     ct = resp.content_type or "application/octet-stream"
                     break
@@ -456,23 +491,24 @@ class MattermostAdapter(BasePlatformAdapter):
                     await asyncio.sleep(1.5 * (attempt + 1))
                     continue
                 logger.warning("Mattermost: failed to download %s after %d attempts: %s", url, attempt + 1, exc)
-                return await self.send(chat_id, f"{caption or ''}\n{url}".strip(), reply_to)
+                return await self.send(chat_id, f"{caption or ''}\n{url}".strip(), reply_to, metadata=metadata)
 
         if file_data is None:
             logger.warning("Mattermost: download returned no data for %s", url)
-            return await self.send(chat_id, f"{caption or ''}\n{url}".strip(), reply_to)
+            return await self.send(chat_id, f"{caption or ''}\n{url}".strip(), reply_to, metadata=metadata)
 
         file_id = await self._upload_file(chat_id, file_data, fname, ct)
         if not file_id:
-            return await self.send(chat_id, f"{caption or ''}\n{url}".strip(), reply_to)
+            return await self.send(chat_id, f"{caption or ''}\n{url}".strip(), reply_to, metadata=metadata)
 
         payload: Dict[str, Any] = {
             "channel_id": chat_id,
             "message": caption or "",
             "file_ids": [file_id],
         }
-        if reply_to and self._should_thread_reply(chat_id):
-            payload["root_id"] = reply_to
+        root_id = self._root_id_from_send_context(chat_id, reply_to, metadata)
+        if root_id:
+            payload["root_id"] = root_id
 
         data = await self._api_post("posts", payload)
         if not data or "id" not in data:
@@ -486,6 +522,7 @@ class MattermostAdapter(BasePlatformAdapter):
         caption: Optional[str],
         reply_to: Optional[str],
         file_name: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
         """Upload a local file and attach it to a post."""
         import mimetypes
@@ -493,7 +530,7 @@ class MattermostAdapter(BasePlatformAdapter):
         p = Path(file_path)
         if not p.exists():
             return await self.send(
-                chat_id, f"{caption or ''}\n(file not found: {file_path})", reply_to
+                chat_id, f"{caption or ''}\n(file not found: {file_path})", reply_to, metadata=metadata
             )
 
         fname = file_name or p.name
@@ -509,8 +546,9 @@ class MattermostAdapter(BasePlatformAdapter):
             "message": caption or "",
             "file_ids": [file_id],
         }
-        if reply_to and self._should_thread_reply(chat_id):
-            payload["root_id"] = reply_to
+        root_id = self._root_id_from_send_context(chat_id, reply_to, metadata)
+        if root_id:
+            payload["root_id"] = root_id
 
         data = await self._api_post("posts", payload)
         if not data or "id" not in data:
@@ -596,6 +634,9 @@ class MattermostAdapter(BasePlatformAdapter):
                     "message": "\n".join(caption_parts),
                     "file_ids": file_ids,
                 }
+                root_id = self._root_id_from_send_context(chat_id, metadata=metadata)
+                if root_id:
+                    payload["root_id"] = root_id
                 logger.info(
                     "Mattermost: sending %d image(s) as single post (chunk %d/%d)",
                     len(file_ids), chunk_idx + 1, len(chunks),
@@ -725,6 +766,8 @@ class MattermostAdapter(BasePlatformAdapter):
 
         # For DMs, user_id is sufficient.  For channels, check for @mention.
         message_text = post.get("message", "")
+        sender_id = post.get("user_id", "")
+        sender_name = data.get("sender_name", "").lstrip("@") or sender_id
 
         # Mention-gating for non-DM channels.
         # Config (config.yaml `mattermost.*` with env-var fallback):
@@ -749,6 +792,21 @@ class MattermostAdapter(BasePlatformAdapter):
                     "Mattermost: ignoring message in non-allowed channel: %s",
                     channel_id,
                 )
+                return
+
+            # Moon delivery approvals are intentionally plain replies like
+            # "go" inside coding threads. They must be recognized before the
+            # generic @mention gate, but the helper still fail-closes on
+            # configured channel, thread root, exact approval phrase, plan
+            # readiness, and approved sender allowlist.
+            if await self._maybe_enqueue_moon_delivery_goal(
+                post=post,
+                data=data,
+                message_text=message_text,
+                channel_id=channel_id,
+                sender_id=sender_id,
+                sender_name=sender_name,
+            ):
                 return
 
             require_mention = os.getenv(
@@ -781,13 +839,12 @@ class MattermostAdapter(BasePlatformAdapter):
                     message_text = re.sub(
                         re.escape(pattern), "", message_text, flags=re.IGNORECASE
                     ).strip()
-
-        # Resolve sender info.
-        sender_id = post.get("user_id", "")
-        sender_name = data.get("sender_name", "").lstrip("@") or sender_id
-
-        # Thread support: if the post is in a thread, use root_id.
+        # Thread support: if the post is in a thread, use root_id. For
+        # configured coding/work channels, a top-level post is the thread root
+        # so each task gets a siloed session and all bot replies stay nested.
         thread_id = post.get("root_id") or None
+        if not thread_id and channel_id in self._auto_thread_channels and channel_type_raw != "D":
+            thread_id = post_id or None
 
         # Determine message type.
         file_ids = post.get("file_ids") or []
@@ -849,6 +906,7 @@ class MattermostAdapter(BasePlatformAdapter):
             user_id=sender_id,
             user_name=sender_name,
             thread_id=thread_id,
+            message_id=post_id,
         )
 
         # Per-channel ephemeral prompt
@@ -869,5 +927,294 @@ class MattermostAdapter(BasePlatformAdapter):
         )
 
         await self.handle_message(msg_event)
+
+    async def _maybe_enqueue_moon_delivery_goal(
+        self,
+        *,
+        post: Dict[str, Any],
+        data: Dict[str, Any],
+        message_text: str,
+        channel_id: str,
+        sender_id: str,
+        sender_name: str,
+    ) -> bool:
+        """Turn approved Moon coding threads into durable Kanban work.
+
+        The human-facing flow stays natural: a top-level post gets a plan in
+        its Mattermost thread; when Mauri/Aaron replies with an approval phrase,
+        the gateway creates exactly one Kanban task for that Mattermost thread
+        and lets the embedded dispatcher spawn the worker.  This keeps feature
+        delivery durable instead of relying on a long interactive agent run.
+        """
+        cfg = self._moon_delivery_goal_config()
+        if not cfg.get("enabled"):
+            return False
+        channels = {str(ch).strip() for ch in (cfg.get("channels") or []) if str(ch).strip()}
+        if channel_id not in channels:
+            return False
+
+        root_id = str(post.get("root_id") or "").strip()
+        require_thread = bool(cfg.get("require_thread", True))
+        if require_thread and not root_id:
+            return False
+
+        text = (message_text or "").strip().lower()
+        if not text:
+            return False
+        approvals = {str(p).strip().lower() for p in (cfg.get("approval_phrases") or []) if str(p).strip()}
+        if text not in approvals:
+            return False
+
+        allowed_sender_ids = {str(s).strip() for s in (cfg.get("approved_sender_ids") or []) if str(s).strip()}
+        allowed_senders = {str(s).strip().lower().lstrip("@") for s in (cfg.get("approved_senders") or []) if str(s).strip()}
+        sender_key = str(sender_name or "").strip().lower().lstrip("@")
+        sender_id_key = str(sender_id or "").strip()
+        sender_allowed = bool(allowed_sender_ids and sender_id_key in allowed_sender_ids)
+        # Name fallback is only used while bootstrapping, when immutable IDs are
+        # not configured yet. Once approved_sender_ids exists, IDs are the sole
+        # authority. If neither allowlist exists, fail closed; approval phrases
+        # must never become "anyone in channel can launch autonomous work".
+        if not allowed_sender_ids and allowed_senders:
+            sender_allowed = sender_key in allowed_senders
+        if not sender_allowed:
+            logger.info(
+                "Mattermost: consuming denied Moon delivery approval from non-approved sender %s/%s in %s",
+                sender_name,
+                sender_id,
+                channel_id,
+            )
+            await self.send(
+                channel_id,
+                "I saw an approval phrase, but that account is not allowed to launch Moon delivery tasks.",
+                reply_to=root_id or post.get("id"),
+            )
+            return True
+
+        task_root_id = root_id or post.get("id", "")
+        thread_transcript = await asyncio.to_thread(self._fetch_thread_transcript_sync, task_root_id)
+        if not self._thread_looks_ready_for_moon_delivery(thread_transcript):
+            logger.info(
+                "Mattermost: consuming approval phrase in %s/%s because thread does not look like an approved Moon delivery plan",
+                channel_id,
+                task_root_id,
+            )
+            await self.send(
+                channel_id,
+                "I saw the approval phrase, but I don't see a complete Moon delivery plan in this thread yet. Post/approve the plan with risk, verification, and release impact first.",
+                reply_to=task_root_id,
+            )
+            return True
+
+        task_id = await asyncio.to_thread(
+            self._create_moon_delivery_task_sync,
+            cfg,
+            post,
+            data,
+            channel_id,
+            task_root_id,
+            sender_name,
+            thread_transcript,
+        )
+        if not task_id:
+            await self.send(
+                channel_id,
+                "I saw the approval, but couldn't create the Kanban task. Check gateway logs — the conveyor belt jammed before worker dispatch.",
+                reply_to=root_id or post.get("id"),
+            )
+            return True
+
+        board = str(cfg.get("board") or "moon")
+        assignee = str(cfg.get("assignee") or cfg.get("default_assignee") or "mooncoder")
+        await self.send(
+            channel_id,
+            f"Approved plan captured. Kanban task `{task_id}` is queued on `{board}` for `{assignee}`; the dispatcher will pick it up autonomously.",
+            reply_to=root_id or post.get("id"),
+        )
+        return True
+
+    def _moon_delivery_goal_config(self) -> Dict[str, Any]:
+        try:
+            from hermes_cli.config import load_config
+            cfg = load_config()
+            section = cfg.get("moon_delivery_goal", {}) if isinstance(cfg, dict) else {}
+            return section if isinstance(section, dict) else {}
+        except Exception as exc:
+            logger.warning("Mattermost: failed to load moon_delivery_goal config: %s", exc)
+            return {}
+
+    def _create_moon_delivery_task_sync(
+        self,
+        cfg: Dict[str, Any],
+        post: Dict[str, Any],
+        data: Dict[str, Any],
+        channel_id: str,
+        root_id: str,
+        sender_name: str,
+        thread_transcript: str,
+    ) -> Optional[str]:
+        try:
+            from hermes_cli import kanban_db as kb
+
+            board = str(cfg.get("board") or "moon")
+            assignee = str(cfg.get("assignee") or cfg.get("default_assignee") or "mooncoder")
+            tenant = str(cfg.get("tenant") or "moon")
+            thread_url = self._mattermost_thread_url(data, channel_id, root_id)
+            body = self._moon_delivery_task_body(cfg, channel_id, root_id, thread_url, sender_name, thread_transcript)
+            title = self._moon_delivery_task_title(body)
+            metadata = {
+                "source": "mattermost_moon_delivery_goal",
+                "platform": "mattermost",
+                "channel_id": channel_id,
+                "thread_id": root_id,
+                "thread_url": thread_url,
+                "approved_by": sender_name,
+                "repo": str(cfg.get("repo") or "/Users/mauri/app"),
+                "release_train": [
+                    "scope_and_plan_approved",
+                    "branch_or_worktree",
+                    "implement",
+                    "self_review_diff",
+                    "automated_tests",
+                    "simulator_or_emulator_if_available",
+                    "physical_device_when_required",
+                    "ota_store_or_backend_gate",
+                    "final_report",
+                ],
+            }
+            with kb.connect(board=board) as conn:
+                return kb.create_task(
+                    conn,
+                    title=title,
+                    body=body,
+                    assignee=assignee,
+                    created_by=f"mattermost:{sender_name}",
+                    workspace_kind=str(cfg.get("workspace") or "worktree"),
+                    tenant=tenant,
+                    priority=int(cfg.get("priority", 10) or 10),
+                    idempotency_key=f"mattermost:{channel_id}:{root_id}:moon-delivery-goal",
+                    max_runtime_seconds=int(cfg.get("max_runtime_seconds", 7200) or 7200),
+                    skills=["expo-eas-mobile-release", "github-pr-workflow", "requesting-code-review"],
+                    metadata=metadata,
+                )
+        except Exception as exc:
+            logger.error("Mattermost: failed to create Moon delivery Kanban task: %s", exc, exc_info=True)
+            return None
+
+    def _mattermost_thread_url(self, data: Dict[str, Any], channel_id: str, root_id: str) -> str:
+        team = data.get("team_name") or data.get("team_id") or ""
+        if self._base_url and team and root_id:
+            return f"{self._base_url}/{team}/pl/{root_id}"
+        if self._base_url and root_id:
+            return f"{self._base_url}/_redirect/pl/{root_id}"
+        return f"mattermost:{channel_id}:{root_id}"
+
+    def _moon_delivery_task_body(
+        self,
+        cfg: Dict[str, Any],
+        channel_id: str,
+        root_id: str,
+        thread_url: str,
+        sender_name: str,
+        thread_transcript: str,
+    ) -> str:
+        thread_text = self._redact_mattermost_transcript(thread_transcript)
+        template = str(cfg.get("goal_template") or "Implement the approved Moon task from this Mattermost thread.")
+        repo = str(cfg.get("repo") or "/Users/mauri/app")
+        return (
+            f"{template}\n\n"
+            f"Approved by: {sender_name}\n"
+            f"Source: {thread_url}\n"
+            f"Repo: {repo}\n\n"
+            "Mandatory workflow:\n"
+            "1. Work in an isolated branch/worktree; do not touch unrelated dirty files.\n"
+            "2. Implement the approved plan from the transcript below.\n"
+            "3. Run targeted tests plus ./scripts/moon-verify-branch.sh when available.\n"
+            "4. Test simulator/emulator/physical-device paths when the environment supports them; if tooling is missing, report the blocker explicitly.\n"
+            "5. Review every diff before commit.\n"
+            "6. Push/merge only low/medium-risk app-only work when green. Ask before production Supabase/backend deploys, EAS credit-spending builds, store submission, Stripe/billing, destructive data work, or unclear high-risk rollback.\n\n"
+            "Mattermost thread transcript:\n"
+            f"{thread_text}"
+        )
+
+    def _fetch_thread_transcript_sync(self, root_id: str) -> str:
+        # Called from an asyncio.to_thread context; use the REST API with urllib
+        # instead of trying to await the adapter's aiohttp session from a worker thread.
+        if not root_id or not self._base_url or not self._token:
+            return "[thread transcript unavailable]"
+        try:
+            import urllib.request
+            from urllib.parse import urlsplit
+
+            base_host = urlsplit(self._base_url).netloc
+            if not base_host or urlsplit(self._base_url).scheme not in {"http", "https"}:
+                return "[thread transcript unavailable]"
+
+            class _NoRedirect(urllib.request.HTTPRedirectHandler):
+                def redirect_request(self, req, fp, code, msg, headers, newurl):  # type: ignore[override]
+                    return None
+
+            req = urllib.request.Request(
+                f"{self._base_url}/api/v4/posts/{root_id}/thread",
+                headers={"Authorization": f"Bearer {self._token}"},
+            )
+            opener = urllib.request.build_opener(_NoRedirect)
+            with opener.open(req, timeout=30) as resp:  # nosec B310: configured Mattermost base URL, redirects disabled
+                final_host = urlsplit(resp.geturl()).netloc
+                if final_host and final_host != base_host:
+                    return "[thread transcript unavailable]"
+                payload = json.loads(resp.read().decode("utf-8"))
+            order = payload.get("order") or []
+            posts = payload.get("posts") or {}
+            lines: List[str] = []
+            for pid in order:
+                p = posts.get(pid) or {}
+                msg = str(p.get("message") or "").strip()
+                if not msg:
+                    continue
+                user = p.get("props", {}).get("from_webhook") or p.get("user_id") or "unknown"
+                lines.append(f"[{user}] {msg}")
+            return "\n\n".join(lines) if lines else "[thread transcript empty]"
+        except Exception as exc:
+            logger.warning("Mattermost: failed to fetch thread transcript for %s: %s", root_id, exc)
+            return "[thread transcript unavailable]"
+
+    def _thread_looks_ready_for_moon_delivery(self, transcript: str) -> bool:
+        text = (transcript or "").lower()
+        if not text or text.startswith("[thread transcript unavailable]"):
+            return False
+        # The channel prompts require the plan to cover these exact concepts.
+        # Requiring them makes casual replies like "go" in a random thread fall
+        # through to normal agent handling instead of launching a worker.
+        has_plan_shape = all(marker in text for marker in ("risk", "verification", "release"))
+        # Use token/word-aware matching so generic words like "release" do not
+        # accidentally satisfy the EAS marker via the substring "eas".
+        has_moon_context = bool(re.search(r"\b(?:moon|mooninv|mooncus|supabase|eas|ota)\b", text))
+        return has_plan_shape and has_moon_context
+
+    def _redact_mattermost_transcript(self, transcript: str) -> str:
+        redacted = transcript or "[thread transcript unavailable]"
+        patterns = (
+            r'(?i)(api[_-]?key|secret|password|passwd|token|service[_-]?role[_-]?key)\s*[:=]\s*[^\s`\'\"]+',
+            r'(?i)(bearer\s+)[a-z0-9._~+/=-]{12,}',
+            r'(?i)(sk|rk|pk)_[a-z0-9_\-]{16,}',
+            r'postgres(?:ql)?://[^\s`\'\"]+',
+        )
+        for pattern in patterns:
+            redacted = re.sub(pattern, lambda m: m.group(1) + "[REDACTED]" if m.lastindex else "[REDACTED]", redacted)
+        return redacted
+
+    def _moon_delivery_task_title(self, body: str) -> str:
+        in_transcript = False
+        for line in body.splitlines():
+            stripped = line.strip()
+            if stripped == "Mattermost thread transcript:":
+                in_transcript = True
+                continue
+            if not in_transcript or not stripped:
+                continue
+            if "]" in stripped:
+                stripped = stripped.split("]", 1)[1].strip()
+            return stripped[:120] or "Approved Moon delivery task"
+        return "Approved Moon delivery task"
 
 

--- a/gateway/platforms/mattermost.py
+++ b/gateway/platforms/mattermost.py
@@ -91,9 +91,11 @@ class MattermostAdapter(BasePlatformAdapter):
         self._closing = False
 
         # Reply mode: "thread" to nest replies, "off" for flat messages.
+        # Mattermost is noisy without threads; make the safe/default behavior
+        # stay in the triggering post's thread unless explicitly disabled.
         self._reply_mode: str = (
             config.extra.get("reply_mode", "")
-            or os.getenv("MATTERMOST_REPLY_MODE", "off")
+            or os.getenv("MATTERMOST_REPLY_MODE", "thread")
         ).lower()
         no_thread_raw = config.extra.get("no_thread_channels") or []
         if isinstance(no_thread_raw, str):
@@ -310,10 +312,16 @@ class MattermostAdapter(BasePlatformAdapter):
     async def send_typing(
         self, chat_id: str, metadata: Optional[Dict[str, Any]] = None
     ) -> None:
-        """Send a typing indicator."""
+        """Send a typing indicator, scoped to a thread when Mattermost supports it."""
+        payload = {"channel_id": chat_id}
+        thread_id = None
+        if metadata:
+            thread_id = metadata.get("thread_id") or metadata.get("mattermost_root_id")
+        if thread_id:
+            payload["parent_id"] = str(thread_id)
         await self._api_post(
             f"users/{self._bot_user_id}/typing",
-            {"channel_id": chat_id},
+            payload,
         )
 
     async def edit_message(

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1050,6 +1050,13 @@ DEFAULT_CONFIG = {
         # Set this to True to re-enable the surfaces with the understanding
         # that the numbers are a local lower-bound estimate, not billing.
         "show_token_analytics": False,
+        "auth": {
+            "enabled": False,
+            "username": "",
+            # Generate with:
+            #   python -c "from hermes_cli.web_server import hash_dashboard_password; print(hash_dashboard_password('your-password'))"
+            "password_hash": "",
+        },
     },
 
     # Privacy settings

--- a/hermes_cli/dashboard_auth.py
+++ b/hermes_cli/dashboard_auth.py
@@ -1,0 +1,63 @@
+"""Helpers for configuring native dashboard authentication."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from hermes_cli.config import load_config, save_config
+from hermes_cli.web_server import hash_dashboard_password
+
+
+def _dashboard_auth_from_config(config: dict[str, Any]) -> dict[str, Any]:
+    dashboard = config.setdefault("dashboard", {})
+    if not isinstance(dashboard, dict):
+        dashboard = {}
+        config["dashboard"] = dashboard
+    auth = dashboard.setdefault("auth", {})
+    if not isinstance(auth, dict):
+        auth = {}
+        dashboard["auth"] = auth
+    return auth
+
+
+def configure_dashboard_auth(*, username: str, password: str) -> dict[str, Any]:
+    """Enable native dashboard auth and store a PBKDF2 password hash."""
+    username = (username or "").strip()
+    if not username:
+        raise ValueError("dashboard auth username must not be empty")
+    if not password:
+        raise ValueError("dashboard auth password must not be empty")
+
+    config = load_config()
+    auth = _dashboard_auth_from_config(config)
+    auth["enabled"] = True
+    auth["username"] = username
+    auth["password_hash"] = hash_dashboard_password(password)
+    save_config(config)
+    return dict(auth)
+
+
+def disable_dashboard_auth() -> dict[str, Any]:
+    """Disable native dashboard auth and clear the password hash."""
+    config = load_config()
+    auth = _dashboard_auth_from_config(config)
+    auth["enabled"] = False
+    auth["username"] = str(auth.get("username") or "")
+    auth["password_hash"] = ""
+    save_config(config)
+    return dict(auth)
+
+
+def dashboard_auth_status() -> dict[str, Any]:
+    """Return safe dashboard auth status without exposing the password hash."""
+    config = load_config()
+    dashboard = config.get("dashboard", {})
+    auth = dashboard.get("auth", {}) if isinstance(dashboard, dict) else {}
+    auth = auth if isinstance(auth, dict) else {}
+    username = str(auth.get("username") or "")
+    password_hash = str(auth.get("password_hash") or "")
+    return {
+        "enabled": bool(auth.get("enabled")),
+        "configured": bool(username and password_hash),
+        "username": username,
+    }

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -71,7 +71,19 @@ def _task_to_dict(t: kb.Task) -> dict[str, Any]:
         "result": t.result,
         "skills": list(t.skills) if t.skills else [],
         "max_retries": t.max_retries,
+        "metadata": t.metadata or {},
     }
+
+def _parse_json_object(value: Optional[str], *, label: str) -> Optional[dict[str, Any]]:
+    if value is None:
+        return None
+    try:
+        parsed = json.loads(value)
+    except json.JSONDecodeError as exc:
+        raise argparse.ArgumentTypeError(f"{label} must be valid JSON: {exc.msg}") from exc
+    if not isinstance(parsed, dict):
+        raise argparse.ArgumentTypeError(f"{label} must be a JSON object")
+    return parsed
 
 
 def _parse_workspace_flag(value: str) -> tuple[str, Optional[str]]:
@@ -285,6 +297,8 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
                                "(repeatable). Appended to the built-in "
                                "kanban-worker skill. Example: "
                                "--skill translation --skill github-code-review")
+    p_create.add_argument("--metadata", default=None,
+                          help='JSON object of durable task metadata, e.g. \'{"app":"mooninv"}\'')
     p_create.add_argument("--max-retries", type=int, default=None,
                           metavar="N",
                           help="Per-task override for the consecutive-failure "
@@ -312,6 +326,18 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
     p_show = sub.add_parser("show", help="Show a task with comments + events")
     p_show.add_argument("task_id")
     p_show.add_argument("--json", action="store_true")
+
+
+    # --- metadata ---
+    p_meta = sub.add_parser("metadata", aliases=["meta"], help="Set or merge durable task metadata")
+    p_meta.add_argument("task_id")
+    p_meta.add_argument("--set", required=True, dest="metadata_json",
+                        help="JSON object to merge into task metadata")
+    p_meta.add_argument("--replace", action="store_true",
+                        help="Replace metadata instead of merging")
+    p_meta.add_argument("--author", default=None,
+                        help="Author recorded on the metadata_updated event")
+    p_meta.add_argument("--json", action="store_true")
 
     # --- assign ---
     p_assign = sub.add_parser("assign", help="Assign or reassign a task")
@@ -749,6 +775,8 @@ def kanban_command(args: argparse.Namespace) -> int:
         "list":     _cmd_list,
         "ls":       _cmd_list,
         "show":     _cmd_show,
+        "metadata": _cmd_metadata,
+        "meta":     _cmd_metadata,
         "assign":   _cmd_assign,
         "reclaim":  _cmd_reclaim,
         "reassign": _cmd_reassign,
@@ -1098,6 +1126,11 @@ def _cmd_create(args: argparse.Namespace) -> int:
             file=sys.stderr,
         )
         return 2
+    try:
+        metadata = _parse_json_object(getattr(args, "metadata", None), label="--metadata")
+    except argparse.ArgumentTypeError as exc:
+        print(f"kanban: {exc}", file=sys.stderr)
+        return 2
     with kb.connect() as conn:
         task_id = kb.create_task(
             conn,
@@ -1115,6 +1148,7 @@ def _cmd_create(args: argparse.Namespace) -> int:
             max_runtime_seconds=max_runtime,
             skills=getattr(args, "skills", None) or None,
             max_retries=max_retries,
+            metadata=metadata,
         )
         task = kb.get_task(conn, task_id)
     if getattr(args, "json", False):
@@ -1242,6 +1276,8 @@ def _cmd_show(args: argparse.Namespace) -> int:
           (f" @ {task.workspace_path}" if task.workspace_path else ""))
     if task.skills:
         print(f"  skills:    {', '.join(task.skills)}")
+    if task.metadata:
+        print(f"  metadata:  {json.dumps(task.metadata, ensure_ascii=False, sort_keys=True)}")
     # Effective retry threshold. Show the per-task override if set,
     # otherwise the dispatcher's resolved value from config (or the
     # default if config doesn't set it either). Helps operators see
@@ -1335,6 +1371,32 @@ def _cmd_show(args: argparse.Namespace) -> int:
                 print(f"        → {r.summary.splitlines()[0][:160]}")
             if r.error:
                 print(f"        ! {r.error.splitlines()[0][:160]}")
+    return 0
+
+
+def _cmd_metadata(args: argparse.Namespace) -> int:
+    try:
+        metadata = _parse_json_object(args.metadata_json, label="--set")
+    except argparse.ArgumentTypeError as exc:
+        print(f"kanban: {exc}", file=sys.stderr)
+        return 2
+    with kb.connect() as conn:
+        try:
+            merged = kb.update_task_metadata(
+                conn,
+                args.task_id,
+                metadata or {},
+                merge=not bool(getattr(args, "replace", False)),
+                author=args.author or _profile_author(),
+            )
+            task = kb.get_task(conn, args.task_id)
+        except ValueError as exc:
+            print(str(exc), file=sys.stderr)
+            return 1
+    if getattr(args, "json", False):
+        print(json.dumps(_task_to_dict(task), indent=2, ensure_ascii=False))
+    else:
+        print(f"Updated metadata for {args.task_id}: {json.dumps(merged, ensure_ascii=False, sort_keys=True)}")
     return 0
 
 

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -575,6 +575,7 @@ class Task:
     claim_lock: Optional[str]
     claim_expires: Optional[int]
     tenant: Optional[str]
+    metadata: Optional[dict[str, Any]] = None
     result: Optional[str] = None
     idempotency_key: Optional[str] = None
     # Unified non-success counter. Incremented on any of:
@@ -611,6 +612,15 @@ class Task:
     @classmethod
     def from_row(cls, row: sqlite3.Row) -> "Task":
         keys = set(row.keys())
+        metadata_value: Optional[dict[str, Any]] = None
+        if "metadata" in keys and row["metadata"]:
+            try:
+                parsed_meta = json.loads(row["metadata"])
+                if isinstance(parsed_meta, dict):
+                    metadata_value = parsed_meta
+            except Exception:
+                metadata_value = None
+
         # Parse skills JSON blob if present
         skills_value: Optional[list] = None
         if "skills" in keys and row["skills"]:
@@ -636,6 +646,7 @@ class Task:
             claim_lock=row["claim_lock"],
             claim_expires=row["claim_expires"],
             tenant=row["tenant"] if "tenant" in keys else None,
+            metadata=metadata_value,
             result=row["result"] if "result" in keys else None,
             idempotency_key=row["idempotency_key"] if "idempotency_key" in keys else None,
             consecutive_failures=(
@@ -769,6 +780,7 @@ CREATE TABLE IF NOT EXISTS tasks (
     claim_expires        INTEGER,
     tenant               TEXT,
     result               TEXT,
+    metadata             TEXT,
     idempotency_key      TEXT,
     -- Unified consecutive-failure counter. Incremented on spawn
     -- failure, timeout, or crash; reset only on successful completion.
@@ -997,6 +1009,8 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
         _add_column_if_missing(conn, "tasks", "tenant", "tenant TEXT")
     if "result" not in cols:
         _add_column_if_missing(conn, "tasks", "result", "result TEXT")
+    if "metadata" not in cols:
+        _add_column_if_missing(conn, "tasks", "metadata", "metadata TEXT")
     if "idempotency_key" not in cols:
         _add_column_if_missing(
             conn, "tasks", "idempotency_key", "idempotency_key TEXT"
@@ -1245,6 +1259,7 @@ def create_task(
     max_runtime_seconds: Optional[int] = None,
     skills: Optional[Iterable[str]] = None,
     max_retries: Optional[int] = None,
+    metadata: Optional[dict[str, Any]] = None,
 ) -> str:
     """Create a new task and optionally link it under parent tasks.
 
@@ -1279,6 +1294,8 @@ def create_task(
             f"got {workspace_kind!r}"
         )
     parents = tuple(p for p in parents if p)
+    if metadata is not None and not isinstance(metadata, dict):
+        raise ValueError("metadata must be a JSON object")
 
     # Normalise + validate skills: strip whitespace, drop empties, dedupe
     # (preserving order). Refuse commas inside a single name so we don't
@@ -1377,9 +1394,9 @@ def create_task(
                     INSERT INTO tasks (
                         id, title, body, assignee, status, priority,
                         created_by, created_at, workspace_kind, workspace_path,
-                        tenant, idempotency_key, max_runtime_seconds, skills,
+                        tenant, metadata, idempotency_key, max_runtime_seconds, skills,
                         max_retries
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     """,
                     (
                         task_id,
@@ -1393,6 +1410,7 @@ def create_task(
                         workspace_kind,
                         workspace_path,
                         tenant,
+                        json.dumps(metadata, ensure_ascii=False, sort_keys=True) if metadata is not None else None,
                         idempotency_key,
                         int(max_runtime_seconds) if max_runtime_seconds else None,
                         json.dumps(skills_list) if skills_list is not None else None,
@@ -1413,6 +1431,7 @@ def create_task(
                         "status": initial_status,
                         "parents": list(parents),
                         "tenant": tenant,
+                        "metadata": metadata,
                         "skills": list(skills_list) if skills_list else None,
                     },
                 )
@@ -1424,6 +1443,36 @@ def create_task(
             continue
     raise RuntimeError("unreachable")
 
+
+
+def update_task_metadata(
+    conn: sqlite3.Connection,
+    task_id: str,
+    metadata: dict[str, Any],
+    *,
+    merge: bool = True,
+    author: Optional[str] = None,
+) -> dict[str, Any]:
+    """Set or merge durable task metadata; return the resulting object."""
+    if not isinstance(metadata, dict):
+        raise ValueError("metadata must be a JSON object")
+    with write_txn(conn):
+        task = get_task(conn, task_id)
+        if not task:
+            raise ValueError(f"no such task: {task_id}")
+        current = task.metadata or {}
+        new_meta = {**current, **metadata} if merge else dict(metadata)
+        conn.execute(
+            "UPDATE tasks SET metadata = ? WHERE id = ?",
+            (json.dumps(new_meta, ensure_ascii=False, sort_keys=True), task_id),
+        )
+        _append_event(
+            conn,
+            task_id,
+            "metadata_updated",
+            {"author": author, "merge": merge, "metadata": new_meta},
+        )
+    return new_meta
 
 def _find_missing_parents(conn: sqlite3.Connection, parents: Iterable[str]) -> list[str]:
     parents = list(parents)
@@ -4327,6 +4376,11 @@ def build_worker_context(conn: sqlite3.Connection, task_id: str) -> str:
     if task.body and task.body.strip():
         lines.append("## Body")
         lines.append(_cap(task.body, _CTX_MAX_BODY_BYTES))
+        lines.append("")
+
+    if task.metadata:
+        lines.append("## Metadata")
+        lines.append(_cap(json.dumps(task.metadata, ensure_ascii=False, sort_keys=True)))
         lines.append("")
 
     # Prior attempts — show closed runs so a retrying worker sees the

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -9602,8 +9602,60 @@ def _report_dashboard_status() -> int:
     return len(pids)
 
 
+def _cmd_dashboard_auth(args):
+    """Manage native dashboard authentication."""
+    import getpass
+
+    from hermes_cli.dashboard_auth import (
+        configure_dashboard_auth,
+        dashboard_auth_status,
+        disable_dashboard_auth,
+    )
+
+    action = getattr(args, "auth_action", None)
+    if action == "status":
+        status = dashboard_auth_status()
+        state = "enabled" if status["enabled"] else "disabled"
+        configured = "yes" if status["configured"] else "no"
+        print(f"Dashboard native auth: {state}")
+        print(f"Configured: {configured}")
+        if status.get("username"):
+            print(f"Username: {status['username']}")
+        return
+
+    if action == "disable":
+        disable_dashboard_auth()
+        print("Dashboard native auth disabled; password hash cleared.")
+        return
+
+    if action == "setup":
+        username = (getattr(args, "username", None) or "").strip()
+        while not username:
+            username = input("Dashboard username: ").strip()
+        password_env = getattr(args, "password_env", None)
+        if password_env:
+            password = os.environ.get(password_env, "")
+            if not password:
+                raise SystemExit(f"Environment variable {password_env!r} is empty or not set")
+        else:
+            password = getpass.getpass("Dashboard password: ")
+            confirm = getpass.getpass("Confirm dashboard password: ")
+            if password != confirm:
+                raise SystemExit("Dashboard passwords did not match")
+        configure_dashboard_auth(username=username, password=password)
+        print(f"Dashboard native auth enabled for user {username!r}.")
+        print("Restart any running dashboard process for the change to apply.")
+        return
+
+    raise SystemExit("Expected dashboard auth action: setup, status, or disable")
+
+
 def cmd_dashboard(args):
     """Start the web UI server, or (with --stop/--status) manage running ones."""
+    if getattr(args, "auth_action", None):
+        _cmd_dashboard_auth(args)
+        return
+
     # --status: report running dashboards and exit, no deps needed.
     if getattr(args, "status", False):
         count = _report_dashboard_status()
@@ -12342,6 +12394,41 @@ Examples:
         "--status",
         action="store_true",
         help="List running hermes dashboard processes and exit",
+    )
+    dashboard_auth_parser = dashboard_parser.add_subparsers(
+        dest="auth_action",
+        metavar="auth_action",
+        help="Manage native dashboard authentication",
+    )
+    dashboard_auth_setup_parser = dashboard_auth_parser.add_parser(
+        "auth",
+        help="Manage native dashboard authentication",
+        description="Enable, disable, or inspect native dashboard Basic Auth",
+    )
+    dashboard_auth_subparsers = dashboard_auth_setup_parser.add_subparsers(
+        dest="auth_action",
+        metavar="action",
+        required=True,
+    )
+    dashboard_auth_enable = dashboard_auth_subparsers.add_parser(
+        "setup",
+        help="Enable or rotate native dashboard auth",
+    )
+    dashboard_auth_enable.add_argument("--username", help="Dashboard username")
+    dashboard_auth_enable.add_argument(
+        "--password-env",
+        help=(
+            "Read the password from this environment variable instead of prompting. "
+            "Useful for automation without putting secrets in shell history."
+        ),
+    )
+    dashboard_auth_subparsers.add_parser(
+        "status",
+        help="Show native dashboard auth status without exposing the hash",
+    )
+    dashboard_auth_subparsers.add_parser(
+        "disable",
+        help="Disable native dashboard auth and clear the hash",
     )
     dashboard_parser.set_defaults(func=cmd_dashboard)
 

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -10,6 +10,8 @@ Usage:
 """
 
 import asyncio
+import base64
+import hashlib
 import hmac
 import importlib.util
 import json
@@ -85,6 +87,9 @@ app = FastAPI(title="Hermes Agent", version=__version__)
 # ---------------------------------------------------------------------------
 _SESSION_TOKEN = secrets.token_urlsafe(32)
 _SESSION_HEADER_NAME = "X-Hermes-Session-Token"
+_DASHBOARD_AUTH_REALM = "Hermes Dashboard"
+_DASHBOARD_PBKDF2_PREFIX = "pbkdf2_sha256"
+_DASHBOARD_PBKDF2_DEFAULT_ITERATIONS = 260_000
 
 # In-browser Chat tab (/chat, /api/pty, …).  Off unless ``hermes dashboard --tui``
 # or HERMES_DASHBOARD_TUI=1.  Set from :func:`start_server`.
@@ -146,6 +151,113 @@ def _require_token(request: Request) -> None:
     """Validate the ephemeral session token.  Raises 401 on mismatch."""
     if not _has_valid_session_token(request):
         raise HTTPException(status_code=401, detail="Unauthorized")
+
+
+def hash_dashboard_password(password: str, *, salt: Optional[str] = None, iterations: int = _DASHBOARD_PBKDF2_DEFAULT_ITERATIONS) -> str:
+    """Return a config-safe PBKDF2-SHA256 hash for dashboard Basic Auth.
+
+    Format: ``pbkdf2_sha256$iterations$salt_b64$digest_b64``.  This keeps
+    native dashboard auth dependency-free while still avoiding plaintext
+    passwords in config.yaml.
+    """
+    if not password:
+        raise ValueError("dashboard auth password must not be empty")
+    if iterations < 100_000:
+        raise ValueError("dashboard auth password hash iterations must be >= 100000")
+    salt_bytes = _b64decode_nopad(salt) if salt else secrets.token_bytes(16)
+    digest = hashlib.pbkdf2_hmac("sha256", password.encode(), salt_bytes, iterations)
+    salt_b64 = base64.urlsafe_b64encode(salt_bytes).decode().rstrip("=")
+    digest_b64 = base64.urlsafe_b64encode(digest).decode().rstrip("=")
+    return f"{_DASHBOARD_PBKDF2_PREFIX}${iterations}${salt_b64}${digest_b64}"
+
+
+def _b64decode_nopad(value: str) -> bytes:
+    return base64.urlsafe_b64decode(value + "=" * (-len(value) % 4))
+
+
+def _verify_dashboard_password(password: str, password_hash: str) -> bool:
+    """Verify a password against the dashboard auth hash format."""
+    try:
+        prefix, iterations_s, salt_b64, digest_b64 = password_hash.split("$", 3)
+        if prefix != _DASHBOARD_PBKDF2_PREFIX:
+            return False
+        iterations = int(iterations_s)
+        if iterations < 100_000:
+            return False
+        salt_bytes = _b64decode_nopad(salt_b64)
+        expected = _b64decode_nopad(digest_b64)
+        actual = hashlib.pbkdf2_hmac("sha256", password.encode(), salt_bytes, iterations)
+    except Exception:
+        return False
+    return hmac.compare_digest(actual, expected)
+
+
+def _dashboard_auth_config() -> Dict[str, Any]:
+    dashboard = load_config().get("dashboard", {})
+    auth = dashboard.get("auth", {}) if isinstance(dashboard, dict) else {}
+    return auth if isinstance(auth, dict) else {}
+
+
+def _dashboard_native_auth_enabled() -> bool:
+    auth = _dashboard_auth_config()
+    return bool(auth.get("enabled"))
+
+
+def _parse_basic_auth_header(header_value: str) -> Optional[Tuple[str, str]]:
+    if not header_value.lower().startswith("basic "):
+        return None
+    encoded = header_value.split(" ", 1)[1].strip()
+    try:
+        decoded = base64.b64decode(encoded, validate=True).decode("utf-8")
+    except Exception:
+        return None
+    if ":" not in decoded:
+        return None
+    username, password = decoded.split(":", 1)
+    return username, password
+
+
+def _has_valid_dashboard_basic_auth_header(header_value: str) -> bool:
+    auth = _dashboard_auth_config()
+    expected_username = str(auth.get("username") or "")
+    expected_hash = str(auth.get("password_hash") or "")
+    parsed = _parse_basic_auth_header(header_value or "")
+    if not expected_username or not expected_hash or not parsed:
+        return False
+    username, password = parsed
+    if not hmac.compare_digest(username.encode(), expected_username.encode()):
+        return False
+    return _verify_dashboard_password(password, expected_hash)
+
+
+def _basic_auth_challenge() -> JSONResponse:
+    return JSONResponse(
+        status_code=401,
+        content={"detail": "Dashboard authentication required"},
+        headers={"WWW-Authenticate": f'Basic realm="{_DASHBOARD_AUTH_REALM}", charset="UTF-8"'},
+    )
+
+
+def _ws_client_is_loopback(ws: "WebSocket") -> bool:
+    client_host = ws.client.host if ws.client else ""
+    return not client_host or client_host in _LOOPBACK_HOSTS
+
+
+def _websocket_has_dashboard_auth(ws: "WebSocket", *, allow_loopback_token_only: bool = False) -> bool:
+    if not _dashboard_native_auth_enabled():
+        return True
+    auth_header = ws.headers.get("authorization", "")
+    if _has_valid_dashboard_basic_auth_header(auth_header):
+        return True
+    # Narrow exception for the PTY sidecar publisher: it is an internal process
+    # that cannot attach browser-cached Basic credentials, only the injected
+    # session token. Do not apply this to browser-facing sockets.
+    token = ws.query_params.get("token", "")
+    return bool(
+        allow_loopback_token_only
+        and _ws_client_is_loopback(ws)
+        and hmac.compare_digest(token.encode(), _SESSION_TOKEN.encode())
+    )
 
 
 # Accepted Host header values for loopback binds. DNS rebinding attacks
@@ -230,6 +342,22 @@ async def host_header_middleware(request: Request, call_next):
                     ),
                 },
             )
+    return await call_next(request)
+
+
+@app.middleware("http")
+async def dashboard_native_auth_middleware(request: Request, call_next):
+    """Optional native dashboard Basic Auth for the whole web surface.
+
+    The existing ephemeral session token protects REST calls from arbitrary
+    websites, but it is injected into index.html.  When ``dashboard.auth`` is
+    enabled, guard the HTML/static surface too so remote dashboard deployments
+    do not leak that token to unauthenticated clients.
+    """
+    if request.method == "OPTIONS" or not _dashboard_native_auth_enabled():
+        return await call_next(request)
+    if not _has_valid_dashboard_basic_auth_header(request.headers.get("authorization", "")):
+        return _basic_auth_challenge()
     return await call_next(request)
 
 
@@ -3291,6 +3419,10 @@ async def pty_ws(ws: WebSocket) -> None:
         return
 
     # --- auth + loopback check (before accept so we can close cleanly) ---
+    if not _websocket_has_dashboard_auth(ws):
+        await ws.close(code=4401)
+        return
+
     token = ws.query_params.get("token", "")
     expected = _SESSION_TOKEN
     if not hmac.compare_digest(token.encode(), expected.encode()):
@@ -3411,6 +3543,10 @@ async def gateway_ws(ws: WebSocket) -> None:
         await ws.close(code=4403)
         return
 
+    if not _websocket_has_dashboard_auth(ws):
+        await ws.close(code=4401)
+        return
+
     token = ws.query_params.get("token", "")
     if not hmac.compare_digest(token.encode(), _SESSION_TOKEN.encode()):
         await ws.close(code=4401)
@@ -3443,6 +3579,10 @@ async def pub_ws(ws: WebSocket) -> None:
         await ws.close(code=4403)
         return
 
+    if not _websocket_has_dashboard_auth(ws, allow_loopback_token_only=True):
+        await ws.close(code=4401)
+        return
+
     token = ws.query_params.get("token", "")
     if not hmac.compare_digest(token.encode(), _SESSION_TOKEN.encode()):
         await ws.close(code=4401)
@@ -3470,6 +3610,10 @@ async def pub_ws(ws: WebSocket) -> None:
 async def events_ws(ws: WebSocket) -> None:
     if not _DASHBOARD_EMBEDDED_CHAT_ENABLED:
         await ws.close(code=4403)
+        return
+
+    if not _websocket_has_dashboard_auth(ws):
+        await ws.close(code=4401)
         return
 
     token = ws.query_params.get("token", "")

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -21,16 +21,16 @@ random per-process ``_SESSION_TOKEN`` printed at startup; the dashboard's
 own pages inject it via ``window.__HERMES_SESSION_TOKEN__`` so logged-in
 browsers don't have to handle it manually.
 
-For the ``/events`` WebSocket we still require the session token as a
-``?token=`` query parameter (browsers cannot set the ``Authorization``
-header on an upgrade request), matching the established pattern used by
-the in-browser PTY bridge in ``hermes_cli/web_server.py``.
+For the ``/events`` WebSocket we require the dashboard session token as a
+``?token=`` query parameter. When native dashboard Basic Auth is enabled,
+the WebSocket also delegates to ``hermes_cli.web_server`` so plugin sockets
+honor the same auth gate as core dashboard sockets.
 
-This means ``hermes dashboard --host 0.0.0.0`` is safe to run on a LAN:
-plugin routes are no longer an unauthenticated exception. The auth still
-isn't multi-user — anyone who can read the printed URL+token gets full
-dashboard access — but they can't ride along just because they can reach
-the port.
+This means plugin routes are no longer an unauthenticated exception. The
+session token still is not multi-user — anyone who can read the printed
+URL+token gets dashboard access unless native auth or an external access
+proxy is enabled — so public exposure should stay behind a trusted tunnel
+or reverse proxy.
 """
 
 from __future__ import annotations
@@ -56,9 +56,25 @@ router = APIRouter()
 
 
 # ---------------------------------------------------------------------------
-# Auth helper — WebSocket only (HTTP routes live behind the dashboard's
-# existing plugin-bypass; this is documented above).
+# Auth helpers — WebSocket only (HTTP routes live behind the dashboard's
+# normal API middleware; this is documented above).
 # ---------------------------------------------------------------------------
+
+def _check_ws_native_auth(ws: WebSocket) -> bool:
+    """Apply optional native dashboard auth to plugin WebSockets.
+
+    HTTP middleware does not run for WebSocket upgrades, so plugin sockets
+    must explicitly delegate to the dashboard's WebSocket auth helper.
+    """
+    try:
+        from hermes_cli import web_server as _ws
+    except Exception:
+        return True
+    checker = getattr(_ws, "_websocket_has_dashboard_auth", None)
+    if checker is None:
+        return True
+    return bool(checker(ws))
+
 
 def _check_ws_token(provided: Optional[str]) -> bool:
     """Constant-time compare against the dashboard session token.
@@ -1813,6 +1829,10 @@ async def stream_events(ws: WebSocket):
     # Enforce the dashboard session token as a query param — browsers can't
     # set Authorization on a WS upgrade. This matches how the PTY bridge
     # authenticates in hermes_cli/web_server.py.
+    if not _check_ws_native_auth(ws):
+        await ws.close(code=http_status.WS_1008_POLICY_VIOLATION)
+        return
+
     token = ws.query_params.get("token")
     if not _check_ws_token(token):
         await ws.close(code=http_status.WS_1008_POLICY_VIOLATION)

--- a/tests/gateway/test_mattermost.py
+++ b/tests/gateway/test_mattermost.py
@@ -225,6 +225,38 @@ class TestMattermostSend:
         payload = self.adapter._session.post.call_args[1]["json"]
         assert "root_id" not in payload
 
+
+    @pytest.mark.asyncio
+    async def test_send_no_thread_channel_overrides_thread_mode(self):
+        """Configured no-thread channels should stay flat even when reply_mode is thread."""
+        self.adapter._reply_mode = "thread"
+        self.adapter._no_thread_channels = {"channel_1"}
+
+        mock_resp = AsyncMock()
+        mock_resp.status = 200
+        mock_resp.json = AsyncMock(return_value={"id": "post_no_thread"})
+        mock_resp.text = AsyncMock(return_value="")
+        mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
+        mock_resp.__aexit__ = AsyncMock(return_value=False)
+
+        self.adapter._session.post = MagicMock(return_value=mock_resp)
+
+        result = await self.adapter.send("channel_1", "Flat reply!", reply_to="root_post")
+
+        assert result.success is True
+        payload = self.adapter._session.post.call_args[1]["json"]
+        assert "root_id" not in payload
+
+    def test_no_thread_channels_from_config_and_env(self, monkeypatch):
+        from gateway.platforms.mattermost import MattermostAdapter
+        monkeypatch.setenv("MATTERMOST_NO_THREAD_CHANNELS", "env_chan, other_chan")
+        adapter = MattermostAdapter(PlatformConfig(
+            enabled=True,
+            token="test-token",
+            extra={"url": "https://mm.example.com", "no_thread_channels": ["config_chan"]},
+        ))
+        assert adapter._no_thread_channels == {"config_chan", "env_chan", "other_chan"}
+
     @pytest.mark.asyncio
     async def test_send_api_failure(self):
         """When API returns error, send should return failure."""

--- a/tests/gateway/test_mattermost.py
+++ b/tests/gateway/test_mattermost.py
@@ -257,6 +257,25 @@ class TestMattermostSend:
         ))
         assert adapter._no_thread_channels == {"config_chan", "env_chan", "other_chan"}
 
+    def test_auto_thread_channels_from_config_and_env(self, monkeypatch):
+        from gateway.platforms.mattermost import MattermostAdapter
+        monkeypatch.setenv("MATTERMOST_AUTO_THREAD_CHANNELS", "env_coding, other_coding")
+        adapter = MattermostAdapter(PlatformConfig(
+            enabled=True,
+            token="test-token",
+            extra={"url": "https://mm.example.com", "auto_thread_channels": ["config_coding"]},
+        ))
+        # Explicit config wins over env for deterministic workspace channels.
+        assert adapter._auto_thread_channels == {"config_coding"}
+
+    def test_root_id_prefers_metadata_thread_root(self):
+        self.adapter._reply_mode = "thread"
+        assert self.adapter._root_id_from_send_context(
+            "channel_1",
+            reply_to="child_post",
+            metadata={"mattermost_root_id": "root_post"},
+        ) == "root_post"
+
     @pytest.mark.asyncio
     async def test_send_api_failure(self):
         """When API returns error, send should return failure."""
@@ -272,6 +291,223 @@ class TestMattermostSend:
         result = await self.adapter.send("channel_1", "Hello!")
 
         assert result.success is False
+
+
+class TestMattermostMoonDeliveryGoal:
+    def setup_method(self):
+        self.adapter = _make_adapter()
+        self.adapter.send = AsyncMock()
+
+    def _cfg(self, **overrides):
+        cfg = {
+            "enabled": True,
+            "channels": ["coding_channel"],
+            "require_thread": True,
+            "approved_sender_ids": ["mauri_user"],
+            "approval_phrases": ["go", "approved"],
+            "board": "moon-test",
+            "assignee": "mooncoder",
+            "tenant": "moon",
+            "workspace": "worktree",
+            "priority": 10,
+            "max_runtime_seconds": 7200,
+            "repo": "/Users/mauri/app",
+        }
+        cfg.update(overrides)
+        return cfg
+
+    def test_thread_ready_requires_plan_verification_release_and_moon_context(self):
+        assert self.adapter._thread_looks_ready_for_moon_delivery(
+            "Plan for mooninv. Risk: low. Verification: run tests. Release: OTA only."
+        )
+        assert not self.adapter._thread_looks_ready_for_moon_delivery(
+            "Plan for mooninv. Risk: low. Verification: run tests."
+        )
+        assert not self.adapter._thread_looks_ready_for_moon_delivery(
+            "Risk: low. Verification: tests. Release: none."
+        )
+
+    def test_redacts_secrets_from_transcript(self):
+        redacted = self.adapter._redact_mattermost_transcript(
+            "token=abc123456789 bearer abc123456789012345 postgres://user:pass@example/db"
+        )
+        assert "abc123456789" not in redacted
+        assert "postgres://" not in redacted
+        assert "[REDACTED]" in redacted
+
+    @pytest.mark.asyncio
+    async def test_approval_creates_exactly_one_kanban_task_and_consumes_event(self):
+        self.adapter._moon_delivery_goal_config = MagicMock(return_value=self._cfg())
+        self.adapter._fetch_thread_transcript_sync = MagicMock(
+            return_value="[mauri] Build mooninv feature\n[bot] Risk: low. Verification: tests. Release: OTA."
+        )
+        self.adapter._create_moon_delivery_task_sync = MagicMock(return_value="t_delivery123")
+
+        consumed = await self.adapter._maybe_enqueue_moon_delivery_goal(
+            post={"id": "approval_post", "root_id": "root_post"},
+            data={"team_name": "moon"},
+            message_text="go",
+            channel_id="coding_channel",
+            sender_id="mauri_user",
+            sender_name="mauric",
+        )
+
+        assert consumed is True
+        self.adapter._create_moon_delivery_task_sync.assert_called_once()
+        self.adapter.send.assert_awaited_once()
+        assert "t_delivery123" in self.adapter.send.await_args.args[1]
+
+    @pytest.mark.asyncio
+    async def test_approval_blocks_when_thread_lacks_complete_plan(self):
+        self.adapter._moon_delivery_goal_config = MagicMock(return_value=self._cfg())
+        self.adapter._fetch_thread_transcript_sync = MagicMock(return_value="[mauri] just chatting about mooninv")
+        self.adapter._create_moon_delivery_task_sync = MagicMock(return_value="should-not-run")
+
+        consumed = await self.adapter._maybe_enqueue_moon_delivery_goal(
+            post={"id": "approval_post", "root_id": "root_post"},
+            data={"team_name": "moon"},
+            message_text="go",
+            channel_id="coding_channel",
+            sender_id="mauri_user",
+            sender_name="mauric",
+        )
+
+        assert consumed is True
+        self.adapter._create_moon_delivery_task_sync.assert_not_called()
+        assert "complete Moon delivery plan" in self.adapter.send.await_args.args[1]
+
+    @pytest.mark.asyncio
+    async def test_approval_blocks_unapproved_sender(self):
+        self.adapter._moon_delivery_goal_config = MagicMock(return_value=self._cfg())
+        self.adapter._create_moon_delivery_task_sync = MagicMock(return_value="should-not-run")
+
+        consumed = await self.adapter._maybe_enqueue_moon_delivery_goal(
+            post={"id": "approval_post", "root_id": "root_post"},
+            data={"team_name": "moon"},
+            message_text="go",
+            channel_id="coding_channel",
+            sender_id="random_user",
+            sender_name="random",
+        )
+
+        assert consumed is True
+        self.adapter._create_moon_delivery_task_sync.assert_not_called()
+        assert "not allowed" in self.adapter.send.await_args.args[1]
+
+    @pytest.mark.asyncio
+    async def test_approval_fails_closed_without_allowlist(self):
+        self.adapter._moon_delivery_goal_config = MagicMock(
+            return_value=self._cfg(approved_sender_ids=[], approved_senders=[])
+        )
+        self.adapter._create_moon_delivery_task_sync = MagicMock(return_value="should-not-run")
+
+        consumed = await self.adapter._maybe_enqueue_moon_delivery_goal(
+            post={"id": "approval_post", "root_id": "root_post"},
+            data={"team_name": "moon"},
+            message_text="go",
+            channel_id="coding_channel",
+            sender_id="mauri_user",
+            sender_name="mauric",
+        )
+
+        assert consumed is True
+        self.adapter._create_moon_delivery_task_sync.assert_not_called()
+        assert "not allowed" in self.adapter.send.await_args.args[1]
+
+    @pytest.mark.asyncio
+    async def test_handle_ws_plain_approval_bypasses_mention_gate(self, monkeypatch):
+        monkeypatch.delenv("MATTERMOST_REQUIRE_MENTION", raising=False)
+        monkeypatch.delenv("MATTERMOST_FREE_RESPONSE_CHANNELS", raising=False)
+        self.adapter._bot_user_id = "bot_user_id"
+        self.adapter._bot_username = "hermes-bot"
+        self.adapter.handle_message = AsyncMock()
+        self.adapter._moon_delivery_goal_config = MagicMock(return_value=self._cfg())
+        self.adapter._fetch_thread_transcript_sync = MagicMock(
+            return_value="[mauri] Build mooninv feature\n[bot] Risk: low. Verification: tests. Release: OTA."
+        )
+        self.adapter._create_moon_delivery_task_sync = MagicMock(return_value="t_delivery123")
+
+        event = {
+            "event": "posted",
+            "data": {
+                "post": json.dumps({
+                    "id": "approval_post",
+                    "user_id": "mauri_user",
+                    "channel_id": "coding_channel",
+                    "message": "go",
+                    "root_id": "root_post",
+                }),
+                "channel_type": "O",
+                "sender_name": "mauric",
+                "team_name": "moon",
+            },
+        }
+
+        await self.adapter._handle_ws_event(event)
+
+        self.adapter._create_moon_delivery_task_sync.assert_called_once()
+        self.adapter.send.assert_awaited_once()
+        self.adapter.handle_message.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_handle_ws_nonapproval_without_mention_still_skips(self, monkeypatch):
+        monkeypatch.delenv("MATTERMOST_REQUIRE_MENTION", raising=False)
+        monkeypatch.delenv("MATTERMOST_FREE_RESPONSE_CHANNELS", raising=False)
+        self.adapter._bot_user_id = "bot_user_id"
+        self.adapter._bot_username = "hermes-bot"
+        self.adapter.handle_message = AsyncMock()
+        self.adapter._moon_delivery_goal_config = MagicMock(return_value=self._cfg())
+        self.adapter._create_moon_delivery_task_sync = MagicMock(return_value="should-not-run")
+
+        event = {
+            "event": "posted",
+            "data": {
+                "post": json.dumps({
+                    "id": "plain_post",
+                    "user_id": "mauri_user",
+                    "channel_id": "coding_channel",
+                    "message": "not an approval",
+                    "root_id": "root_post",
+                }),
+                "channel_type": "O",
+                "sender_name": "mauric",
+            },
+        }
+
+        await self.adapter._handle_ws_event(event)
+
+        self.adapter._create_moon_delivery_task_sync.assert_not_called()
+        self.adapter.handle_message.assert_not_called()
+
+    def test_create_task_body_carries_release_train_metadata(self, tmp_path):
+        from hermes_cli import kanban_db as kb
+
+        db_path = tmp_path / "kanban.db"
+        original_connect = kb.connect
+
+        def connect_temp(*args, **kwargs):
+            return original_connect(db_path)
+
+        with patch.object(kb, "connect", side_effect=connect_temp):
+            task_id = self.adapter._create_moon_delivery_task_sync(
+                self._cfg(board="unused-test-board"),
+                post={"id": "approval_post", "root_id": "root_post"},
+                data={"team_name": "moon"},
+                channel_id="coding_channel",
+                root_id="root_post",
+                sender_name="mauric",
+                thread_transcript="[mauri] Build mooninv thing\n[bot] Risk: low. Verification: tests. Release: OTA.",
+            )
+
+        assert task_id
+        with kb.connect(db_path) as conn:
+            row = conn.execute("SELECT * FROM tasks WHERE id = ?", (task_id,)).fetchone()
+        assert row["assignee"] == "mooncoder"
+        assert row["status"] == "ready"
+        metadata = json.loads(row["metadata"])
+        assert metadata["source"] == "mattermost_moon_delivery_goal"
+        assert metadata["repo"] == "/Users/mauri/app"
+        assert "ota_store_or_backend_gate" in metadata["release_train"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_mattermost_threading.py
+++ b/tests/gateway/test_mattermost_threading.py
@@ -1,0 +1,52 @@
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import MessageEvent, MessageType, _reply_anchor_for_event
+from gateway.platforms.mattermost import MattermostAdapter
+from gateway.session import SessionSource
+
+
+def test_mattermost_defaults_to_threaded_replies(monkeypatch):
+    monkeypatch.delenv("MATTERMOST_REPLY_MODE", raising=False)
+
+    adapter = MattermostAdapter(
+        PlatformConfig(
+            token="token",
+            extra={"url": "https://mattermost.example.test"},
+        )
+    )
+
+    assert adapter._reply_mode == "thread"
+    assert adapter._should_thread_reply("channel-id") is True
+
+
+def test_mattermost_existing_thread_replies_anchor_to_root_post():
+    source = SessionSource(
+        platform=Platform.MATTERMOST,
+        chat_id="channel-id",
+        chat_type="channel",
+        thread_id="root-post-id",
+    )
+    event = MessageEvent(
+        text="reply in existing thread",
+        message_type=MessageType.TEXT,
+        source=source,
+        message_id="child-post-id",
+    )
+
+    assert _reply_anchor_for_event(event) == "root-post-id"
+
+
+def test_mattermost_top_level_post_replies_anchor_to_triggering_post():
+    source = SessionSource(
+        platform=Platform.MATTERMOST,
+        chat_id="channel-id",
+        chat_type="channel",
+        thread_id=None,
+    )
+    event = MessageEvent(
+        text="top-level mention",
+        message_type=MessageType.TEXT,
+        source=source,
+        message_id="top-level-post-id",
+    )
+
+    assert _reply_anchor_for_event(event) == "top-level-post-id"

--- a/tests/hermes_cli/test_dashboard_auth_cli.py
+++ b/tests/hermes_cli/test_dashboard_auth_cli.py
@@ -1,0 +1,119 @@
+"""Tests for dashboard native auth CLI helpers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+
+def test_configure_dashboard_auth_writes_hash_not_plaintext(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+    from hermes_cli.config import load_config
+    from hermes_cli.dashboard_auth import configure_dashboard_auth
+    from hermes_cli.web_server import _verify_dashboard_password
+
+    result = configure_dashboard_auth(username="mauri", password="moon-secret")
+
+    assert result["enabled"] is True
+    assert result["username"] == "mauri"
+    assert result["password_hash"].startswith("pbkdf2_sha256$")
+    assert "moon-secret" not in result["password_hash"]
+    assert _verify_dashboard_password("moon-secret", result["password_hash"])
+
+    cfg = load_config()
+    assert cfg["dashboard"]["auth"]["enabled"] is True
+    assert cfg["dashboard"]["auth"]["username"] == "mauri"
+    assert cfg["dashboard"]["auth"]["password_hash"] == result["password_hash"]
+
+
+def test_disable_dashboard_auth_preserves_username_and_clears_hash(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+    from hermes_cli.dashboard_auth import configure_dashboard_auth, disable_dashboard_auth, dashboard_auth_status
+
+    configure_dashboard_auth(username="mauri", password="moon-secret")
+    disabled = disable_dashboard_auth()
+
+    assert disabled["enabled"] is False
+    assert disabled["username"] == "mauri"
+    assert disabled["password_hash"] == ""
+
+    status = dashboard_auth_status()
+    assert status == {"enabled": False, "configured": False, "username": "mauri"}
+
+
+def test_dashboard_auth_status_reports_enabled_and_configured(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+    from hermes_cli.dashboard_auth import configure_dashboard_auth, dashboard_auth_status
+
+    configure_dashboard_auth(username="mauri", password="moon-secret")
+
+    assert dashboard_auth_status() == {
+        "enabled": True,
+        "configured": True,
+        "username": "mauri",
+    }
+
+
+def test_configure_dashboard_auth_rejects_empty_username_or_password(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+    from hermes_cli.dashboard_auth import configure_dashboard_auth
+
+    for username, password in [("", "moon-secret"), ("mauri", "")]:
+        try:
+            configure_dashboard_auth(username=username, password=password)
+        except ValueError as exc:
+            assert "dashboard auth" in str(exc)
+        else:
+            raise AssertionError("expected ValueError")
+
+
+def test_cmd_dashboard_auth_status_prints_safe_state(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+    from hermes_cli.dashboard_auth import configure_dashboard_auth
+    from hermes_cli.main import cmd_dashboard
+
+    configure_dashboard_auth(username="mauri", password="moon-secret")
+
+    cmd_dashboard(SimpleNamespace(auth_action="status"))
+
+    out = capsys.readouterr().out
+    assert "Dashboard native auth: enabled" in out
+    assert "Username: mauri" in out
+    assert "moon-secret" not in out
+    assert "pbkdf2_sha256" not in out
+
+
+def test_cmd_dashboard_auth_setup_reads_password_env(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    monkeypatch.setenv("HERMES_DASHBOARD_PASSWORD", "moon-secret")
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+    from hermes_cli.config import load_config
+    from hermes_cli.main import cmd_dashboard
+    from hermes_cli.web_server import _verify_dashboard_password
+
+    cmd_dashboard(
+        SimpleNamespace(
+            auth_action="setup",
+            username="mauri",
+            password_env="HERMES_DASHBOARD_PASSWORD",
+        )
+    )
+
+    out = capsys.readouterr().out
+    assert "Dashboard native auth enabled" in out
+    cfg = load_config()
+    auth = cfg["dashboard"]["auth"]
+    assert auth["enabled"] is True
+    assert auth["username"] == "mauri"
+    assert _verify_dashboard_password("moon-secret", auth["password_hash"])

--- a/tests/hermes_cli/test_kanban_cli.py
+++ b/tests/hermes_cli/test_kanban_cli.py
@@ -119,6 +119,37 @@ def test_run_slash_json_output(kanban_home):
     assert payload["status"] == "ready"
 
 
+
+
+def test_run_slash_create_with_metadata_json(kanban_home):
+    out = kc.run_slash('create "moon card" --metadata \'{"app":"mooninv","risk":"low"}\' --json')
+    payload = json.loads(out)
+    assert payload["metadata"] == {"app": "mooninv", "risk": "low"}
+
+
+def test_run_slash_metadata_update_merges_fields(kanban_home):
+    out = kc.run_slash('create "moon card" --metadata \'{"app":"mooninv","risk":"low"}\' --json')
+    tid = json.loads(out)["id"]
+
+    updated = json.loads(kc.run_slash(f'metadata {tid} --set \'{{"branch":"feat/x","risk":"medium"}}\' --json'))
+    assert updated["metadata"] == {
+        "app": "mooninv",
+        "risk": "medium",
+        "branch": "feat/x",
+    }
+
+    shown = json.loads(kc.run_slash(f"show {tid} --json"))
+    assert shown["task"]["metadata"]["branch"] == "feat/x"
+    plain = kc.run_slash(f"show {tid}")
+    assert "metadata:" in plain
+    assert "feat/x" in plain
+
+    with kb.connect() as conn:
+        ctx = kb.build_worker_context(conn, tid)
+    assert "## Metadata" in ctx
+    assert "feat/x" in ctx
+
+
 def test_run_slash_dispatch_dry_run_counts(kanban_home):
     kc.run_slash("create 'a' --assignee alice")
     kc.run_slash("create 'b' --assignee bob")

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -1,9 +1,11 @@
 """Tests for hermes_cli.web_server and related config utilities."""
 
 import os
+import base64
 import json
 import tempfile
 from pathlib import Path
+from typing import Any, cast
 from unittest.mock import patch, MagicMock
 
 import pytest
@@ -15,6 +17,11 @@ from hermes_cli.config import (
     _EXTRA_ENV_KEYS,
     OPTIONAL_ENV_VARS,
 )
+
+
+def _basic(username: str, password: str) -> str:
+    token = base64.b64encode(f"{username}:{password}".encode()).decode()
+    return f"Basic {token}"
 
 
 # ---------------------------------------------------------------------------
@@ -256,6 +263,106 @@ class TestWebServerEndpoints:
             json={"key": "TEST_REVEAL_NOAUTH"},
         )
         assert resp.status_code == 401
+
+    def test_dashboard_password_hash_verification(self):
+        """Dashboard auth stores PBKDF2 hashes, not plaintext passwords."""
+        from hermes_cli.web_server import hash_dashboard_password, _verify_dashboard_password
+
+        password_hash = hash_dashboard_password("correct horse battery staple")
+
+        assert password_hash.startswith("pbkdf2_sha256$")
+        assert _verify_dashboard_password("correct horse battery staple", password_hash)
+        assert not _verify_dashboard_password("wrong", password_hash)
+
+    def test_native_dashboard_auth_protects_spa_and_api(self, monkeypatch):
+        """When dashboard.auth is enabled, index.html and APIs require Basic Auth."""
+        from starlette.testclient import TestClient
+        import hermes_cli.web_server as web_server
+
+        password_hash = web_server.hash_dashboard_password("moon-secret")
+        monkeypatch.setattr(
+            web_server,
+            "load_config",
+            lambda: {
+                "dashboard": {
+                    "auth": {
+                        "enabled": True,
+                        "username": "mauri",
+                        "password_hash": password_hash,
+                    }
+                }
+            },
+        )
+
+        client = TestClient(web_server.app)
+
+        unauth = client.get("/api/status")
+        assert unauth.status_code == 401
+        assert "Basic" in unauth.headers.get("www-authenticate", "")
+
+        session_only = client.get(
+            "/api/env",
+            headers={web_server._SESSION_HEADER_NAME: web_server._SESSION_TOKEN},
+        )
+        assert session_only.status_code == 401
+        assert "Basic" in session_only.headers.get("www-authenticate", "")
+
+        basic_only = client.get("/api/env", headers={"Authorization": _basic("mauri", "moon-secret")})
+        assert basic_only.status_code == 401
+
+        bad = client.get("/api/status", headers={"Authorization": _basic("mauri", "wrong")})
+        assert bad.status_code == 401
+
+        ok = client.get("/api/status", headers={"Authorization": _basic("mauri", "moon-secret")})
+        assert ok.status_code == 200
+
+        protected_ok = client.get(
+            "/api/env",
+            headers={
+                "Authorization": _basic("mauri", "moon-secret"),
+                web_server._SESSION_HEADER_NAME: web_server._SESSION_TOKEN,
+            },
+        )
+        assert protected_ok.status_code == 200
+
+    def test_native_dashboard_auth_websocket_requires_basic_except_loopback_pub(self, monkeypatch):
+        """Browser-facing WebSockets cannot bypass native auth with only the session token."""
+        import hermes_cli.web_server as web_server
+
+        password_hash = web_server.hash_dashboard_password("moon-secret")
+        monkeypatch.setattr(
+            web_server,
+            "load_config",
+            lambda: {
+                "dashboard": {
+                    "auth": {
+                        "enabled": True,
+                        "username": "mauri",
+                        "password_hash": password_hash,
+                    }
+                }
+            },
+        )
+
+        class _Client:
+            host = "127.0.0.1"
+
+        class _WS:
+            client = _Client()
+
+            def __init__(self, *, auth: str = "", token: str = ""):
+                self.headers = {"authorization": auth} if auth else {}
+                self.query_params = {"token": token} if token else {}
+
+        token_only = cast(Any, _WS(token=web_server._SESSION_TOKEN))
+        assert not web_server._websocket_has_dashboard_auth(token_only)
+        assert web_server._websocket_has_dashboard_auth(token_only, allow_loopback_token_only=True)
+
+        good_basic = cast(Any, _WS(auth=_basic("mauri", "moon-secret"), token=web_server._SESSION_TOKEN))
+        assert web_server._websocket_has_dashboard_auth(good_basic)
+
+        bad_basic = cast(Any, _WS(auth=_basic("mauri", "wrong"), token=web_server._SESSION_TOKEN))
+        assert not web_server._websocket_has_dashboard_auth(bad_basic)
 
     def test_reveal_env_var_bad_token(self, tmp_path):
         """POST /api/env/reveal with wrong token should return 401."""

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -7,6 +7,7 @@ REST surface without spinning up the whole dashboard.
 
 from __future__ import annotations
 
+import base64
 import importlib.util
 import os
 import sys
@@ -18,6 +19,11 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from hermes_cli import kanban_db as kb
+
+
+def _basic(username: str, password: str) -> str:
+    token = base64.b64encode(f"{username}:{password}".encode()).decode()
+    return f"Basic {token}"
 
 
 # ---------------------------------------------------------------------------
@@ -565,7 +571,10 @@ def test_ws_events_rejects_when_token_required(tmp_path, monkeypatch):
     # Stub web_server so _check_ws_token has a token to compare against.
     import hermes_cli
     import types
-    stub = types.SimpleNamespace(_SESSION_TOKEN="secret-xyz")
+    stub = types.SimpleNamespace(
+        _SESSION_TOKEN="secret-xyz",
+        _websocket_has_dashboard_auth=lambda ws: True,
+    )
     monkeypatch.setitem(sys.modules, "hermes_cli.web_server", stub)
     monkeypatch.setattr(hermes_cli, "web_server", stub, raising=False)
 
@@ -591,6 +600,61 @@ def test_ws_events_rejects_when_token_required(tmp_path, monkeypatch):
         "/api/plugins/kanban/events?token=secret-xyz"
     ) as ws:
         assert ws is not None  # handshake succeeded
+
+
+def test_ws_events_honors_native_dashboard_auth(tmp_path, monkeypatch):
+    """Kanban plugin WebSocket must not bypass native dashboard auth."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+
+    import hermes_cli.web_server as web_server
+
+    password_hash = web_server.hash_dashboard_password("moon-secret")
+    monkeypatch.setattr(
+        web_server,
+        "load_config",
+        lambda: {
+            "dashboard": {
+                "auth": {
+                    "enabled": True,
+                    "username": "mauri",
+                    "password_hash": password_hash,
+                }
+            }
+        },
+    )
+    monkeypatch.setattr(web_server, "_SESSION_TOKEN", "secret-xyz")
+
+    app = FastAPI()
+    app.include_router(_load_plugin_router(), prefix="/api/plugins/kanban")
+    c = TestClient(app)
+
+    from starlette.websockets import WebSocketDisconnect
+
+    # Session token alone is not enough when native auth is enabled.
+    with pytest.raises(WebSocketDisconnect) as exc:
+        with c.websocket_connect("/api/plugins/kanban/events?token=secret-xyz"):
+            pass
+    assert exc.value.code == 1008
+
+    # Basic Auth plus the session token succeeds.
+    with c.websocket_connect(
+        "/api/plugins/kanban/events?token=secret-xyz",
+        headers={"Authorization": _basic("mauri", "moon-secret")},
+    ) as ws:
+        assert ws is not None
+
+    # Wrong Basic Auth remains rejected even with the session token.
+    with pytest.raises(WebSocketDisconnect) as exc:
+        with c.websocket_connect(
+            "/api/plugins/kanban/events?token=secret-xyz",
+            headers={"Authorization": _basic("mauri", "wrong")},
+        ):
+            pass
+    assert exc.value.code == 1008
 
 
 def test_ws_events_swallows_cancellation_on_shutdown(tmp_path, monkeypatch):

--- a/website/docs/user-guide/features/web-dashboard.md
+++ b/website/docs/user-guide/features/web-dashboard.md
@@ -194,10 +194,29 @@ dashboard:
     password_hash: "pbkdf2_sha256$..."
 ```
 
-Generate the hash with:
+Generate the hash manually with:
 
 ```bash
 python -c "from hermes_cli.web_server import hash_dashboard_password; print(hash_dashboard_password('your-password'))"
+```
+
+Or let Hermes prompt securely and write the hash for you:
+
+```bash
+hermes dashboard auth setup --username mauri
+hermes dashboard auth status
+hermes dashboard auth disable
+```
+
+For automation, avoid putting the password directly in shell history:
+
+```bash
+read -rs HERMES_DASHBOARD_PASSWORD
+export HERMES_DASHBOARD_PASSWORD
+hermes dashboard auth setup \
+  --username mauri \
+  --password-env HERMES_DASHBOARD_PASSWORD
+unset HERMES_DASHBOARD_PASSWORD
 ```
 
 Native dashboard auth protects the SPA, REST API, and dashboard WebSockets, but direct `0.0.0.0` exposure is still not the recommended deployment pattern. Use it as defense-in-depth behind Cloudflare Access, Tailscale, Caddy, or another trusted edge.

--- a/website/docs/user-guide/features/web-dashboard.md
+++ b/website/docs/user-guide/features/web-dashboard.md
@@ -30,8 +30,8 @@ This starts a local web server and opens `http://127.0.0.1:9119` in your browser
 # Custom port
 hermes dashboard --port 8080
 
-# Bind to all interfaces (use with caution on shared networks)
-hermes dashboard --host 0.0.0.0
+# Bind to all interfaces (requires --insecure; prefer a private tunnel instead)
+hermes dashboard --host 0.0.0.0 --insecure
 
 # Start without opening browser
 hermes dashboard --no-open
@@ -182,7 +182,25 @@ Browse, search, and toggle skills and toolsets. Skills are loaded from `~/.herme
 - **Toolsets** — a separate section shows built-in toolsets (file operations, web browsing, etc.) with their active/inactive status, setup requirements, and list of included tools
 
 :::warning Security
-The web dashboard reads and writes your `.env` file, which contains API keys and secrets. It binds to `127.0.0.1` by default — only accessible from your local machine. If you bind to `0.0.0.0`, anyone on your network can view and modify your credentials. The dashboard has no authentication of its own.
+The web dashboard reads and writes your `.env` file, which contains API keys and secrets. It binds to `127.0.0.1` by default — only accessible from your local machine.
+
+For anywhere-access, keep the dashboard bound to localhost and put an authenticated tunnel/reverse proxy in front of it (for example Cloudflare Tunnel + Cloudflare Access). Hermes also supports an optional native Basic Auth guard:
+
+```yaml
+dashboard:
+  auth:
+    enabled: true
+    username: mauri
+    password_hash: "pbkdf2_sha256$..."
+```
+
+Generate the hash with:
+
+```bash
+python -c "from hermes_cli.web_server import hash_dashboard_password; print(hash_dashboard_password('your-password'))"
+```
+
+Native dashboard auth protects the SPA, REST API, and dashboard WebSockets, but direct `0.0.0.0` exposure is still not the recommended deployment pattern. Use it as defense-in-depth behind Cloudflare Access, Tailscale, Caddy, or another trusted edge.
 :::
 
 ## `/reload` Slash Command


### PR DESCRIPTION
## Summary
- add native dashboard auth support
- add dashboard auth CLI
- add kanban task metadata
- support flat Mattermost work channels and preserve thread replies

## Notes
Opened from Mauri's fork because mauriskabelund currently has READ access on NousResearch/hermes-agent. For long-term direct pushes, add mauriskabelund with Write permission to the upstream repo.