### PR TITLE
fix(gateway): offload evaluate_after_turn to thread executor

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10636,7 +10636,15 @@ class GatewayRunner:
         if not mgr.is_active():
             return
 
-        decision = mgr.evaluate_after_turn(final_response or "", user_initiated=True)
+        # evaluate_after_turn calls judge_goal() which makes a synchronous
+        # HTTP request to the auxiliary LLM.  Running it on the event-loop
+        # thread would block Discord heartbeats for 10-40 s and cause
+        # connection flaps, so we offload it to the default thread-pool executor.
+        loop = asyncio.get_event_loop()
+        decision = await loop.run_in_executor(
+            None,
+            lambda: mgr.evaluate_after_turn(final_response or "", user_initiated=True),
+        )
         msg = decision.get("message") or ""
 
         # Defer the status line until after the adapter has delivered the


### PR DESCRIPTION
## Problem

`evaluate_after_turn()` calls `judge_goal()` which makes a **synchronous** HTTP request to the auxiliary LLM. Because this runs directly on the event-loop thread inside an `async` method, it blocks the entire event loop for 10–40 seconds per evaluation.

This causes **Discord heartbeat timeouts** — the gateway cannot respond to Discord heartbeats while blocked, leading to connection flaps and gateway instability.

## Fix

Offload `evaluate_after_turn()` to the default thread-pool executor via `loop.run_in_executor()`, keeping the event loop responsive during evaluation.

```python
# Before
decision = mgr.evaluate_after_turn(final_response or "", user_initiated=True)

# After
loop = asyncio.get_event_loop()
decision = await loop.run_in_executor(
    None,
    lambda: mgr.evaluate_after_turn(final_response or "", user_initiated=True),
)
```

## Testing

- Patch has been running on a production gateway for ~24h with zero Discord connection flaps (previously saw multiple per day)
- All other platform adapters (Telegram, API server) unaffected
- No functional change — same return value, just non-blocking

## Files Changed

- `gateway/run.py` — 1 method, 9 lines added, 1 removed