### PR TITLE
fix(kanban): convert PR web URL to API URL in _fetch_pr_state

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -3676,6 +3676,60 @@ _RESPAWN_GUARD_PR_URL_RE = re.compile(
     re.IGNORECASE,
 )
 
+# In-process cache: pr_url -> (is_open: bool, fetched_at: float)
+_GITHUB_PR_STATE_CACHE: dict[str, tuple[bool, float]] = {}
+_GITHUB_PR_CACHE_TTL = 300  # 5 minutes
+
+
+def _fetch_pr_state(pr_url: str) -> bool | None:
+    """Return True if the PR is open, False if merged/closed, None if unresolved.
+
+    Queries the GitHub REST API (public repos, no token required for state).
+    Results are cached for _GITHUB_PR_CACHE_TTL seconds to avoid repeated
+    network calls during a single dispatch pass.
+    """
+    import urllib.request
+
+    # Convert web URL (https://github.com/owner/repo/pull/N) to API URL.
+    # _RESPAWN_GUARD_PR_URL_RE guarantees the URL matches this pattern.
+    try:
+        api_url = re.sub(
+            r"^https?://github\\.com/([^/]+)/([^/]+)/pull/(\\d+)$",
+            lambda m: f"https://api.github.com/repos/{m.group(1)}/{m.group(2)}/pulls/{m.group(3)}",
+            pr_url,
+        )
+    except Exception:
+        return None
+
+    now = time.time()
+    cache_key = pr_url  # cache by original web URL for lookups from comment text
+    if cache_key in _GITHUB_PR_STATE_CACHE:
+        _, fetched_at = _GITHUB_PR_STATE_CACHE[cache_key]
+        if now - fetched_at < _GITHUB_PR_CACHE_TTL:
+            return _GITHUB_PR_STATE_CACHE[cache_key][0]
+
+    # Lazy import to avoid hard-blocking on httpx/stdlib availability.
+    # Use stdlib urllib so this works without any extra packages.
+    try:
+        headers = {"Accept": "application/vnd.github+json"}
+        token = os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")
+        if token:
+            headers["Authorization"] = f"Bearer {token}"
+
+        req = urllib.request.Request(api_url, headers=headers)
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            data = json.loads(resp.read())
+            # PR state: "open", "closed", "merged"
+            state = data.get("state", "").lower()
+            is_open = state == "open"
+            _GITHUB_PR_STATE_CACHE[cache_key] = (is_open, now)
+            return is_open
+    except Exception:
+        # Network error, rate limit, private repo, missing token, etc.
+        # Fall back to URL-only heuristic (legacy behaviour) rather than
+        # silently allowing a task that genuinely has an active PR.
+        return None
+
 
 @dataclass
 class DispatchResult:
@@ -4636,8 +4690,16 @@ def check_respawn_guard(conn: sqlite3.Connection, task_id: str) -> Optional[str]
         "SELECT body FROM task_comments WHERE task_id = ? AND created_at >= ?",
         (task_id, pr_cutoff),
     ).fetchall():
-        if c["body"] and _RESPAWN_GUARD_PR_URL_RE.search(c["body"]):
-            return "active_pr"
+        if c["body"]:
+            for match in _RESPAWN_GUARD_PR_URL_RE.findall(c["body"]):
+                pr_state = _fetch_pr_state(match)
+                # pr_state is True (open)  -> definitely guard
+                # pr_state is False (merged/closed) -> not an active PR, skip URL
+                # pr_state is None (error/no-token)  -> fall back to legacy
+                #   URL-only behaviour (block to be safe)
+                if pr_state is False:
+                    continue
+                return "active_pr"
 
     return None
 

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -1278,6 +1278,65 @@ def test_respawn_guard_old_pr_comment_not_guarded(kanban_home):
     assert reason is None
 
 
+def test_respawn_guard_merged_pr_not_guarded(kanban_home, monkeypatch):
+    """A merged PR URL does NOT trigger active_pr — guard now checks GitHub state."""
+    # Prime the cache so _fetch_pr_state returns False (merged).
+    kb._GITHUB_PR_STATE_CACHE.clear()
+    monkeypatch.setenv("GITHUB_TOKEN", "")
+
+    def fake_fetch(url):
+        return False  # merged/closed
+
+    with monkeypatch.context() as m:
+        m.setattr(kb, "_fetch_pr_state", fake_fetch)
+        with kb.connect() as conn:
+            t = kb.create_task(conn, title="merged-pr", assignee="alice")
+            kb.add_comment(
+                conn, t, "worker",
+                "PR merged: https://github.com/example-org/example-repo/pull/61",
+            )
+            reason = kb.check_respawn_guard(conn, t)
+        assert reason is None, f"Expected None for merged PR, got {reason!r}"
+
+
+def test_respawn_guard_open_pr_still_guarded(kanban_home, monkeypatch):
+    """An open PR URL still triggers active_pr — _fetch_pr_state returns True."""
+    def fake_fetch(url):
+        return True  # open
+
+    with monkeypatch.context() as m:
+        m.setattr(kb, "_fetch_pr_state", fake_fetch)
+        with kb.connect() as conn:
+            t = kb.create_task(conn, title="open-pr", assignee="alice")
+            kb.add_comment(
+                conn, t, "worker",
+                "PR opened: https://github.com/example-org/example-repo/pull/99",
+            )
+            reason = kb.check_respawn_guard(conn, t)
+        assert reason == "active_pr"
+
+
+def test_respawn_guard_network_error_falls_back_to_guarding(kanban_home, monkeypatch):
+    """When _fetch_pr_state returns None (network error / no token), guard anyway.
+
+    This preserves the legacy safe-by-default behaviour: a task with a PR URL
+    that we can't verify is treated as potentially having an active PR.
+    """
+    def fake_fetch(url):
+        return None  # unresolved
+
+    with monkeypatch.context() as m:
+        m.setattr(kb, "_fetch_pr_state", fake_fetch)
+        with kb.connect() as conn:
+            t = kb.create_task(conn, title="unresolved-pr", assignee="alice")
+            kb.add_comment(
+                conn, t, "worker",
+                "PR: https://github.com/example-org/example-repo/pull/100",
+            )
+            reason = kb.check_respawn_guard(conn, t)
+        assert reason == "active_pr"
+
+
 def test_dispatch_respawn_guard_defers_auth_error_without_auto_block(
     kanban_home, all_assignees_spawnable
 ):


### PR DESCRIPTION
## What

The original `_fetch_pr_state` implementation passed the GitHub web URL (`https://github.com/owner/repo/pull/N`) directly to `urllib.urlopen`, which 404s because that is not a REST API endpoint.

This converts the web URL to the GitHub REST API URL (`https://api.github.com/repos/owner/repo/pulls/N`) before querying, so the PR state check can distinguish open PRs from closed/merged PRs.

## Testing

- `python3 -m pytest tests/hermes_cli/test_kanban_db.py -k 'respawn_guard_merged_pr_not_guarded or respawn_guard_open_pr_still_guarded or respawn_guard_network_error_falls_back_to_guarding' -q -o 'addopts='`
