### PR TITLE
fix: new Telegram DM topics from All Messages reroute to previous session

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -5278,8 +5278,45 @@ class TelegramAdapter(BasePlatformAdapter):
         if thread_id_raw is not None:
             if chat_type == "group" and (is_topic_message or is_forum_group):
                 thread_id_str = str(thread_id_raw)
-            elif chat_type == "dm" and is_topic_message:
-                thread_id_str = str(thread_id_raw)
+            elif chat_type == "dm":
+                if is_topic_message:
+                    thread_id_str = str(thread_id_raw)
+                else:
+                    # Telegram doesn't always set is_topic_message on the
+                    # very first message of a freshly-created DM topic.
+                    # When topic mode is enabled and this thread_id is
+                    # NOT already bound to a session (genuinely new),
+                    # preserve it so the new topic gets its own lane.
+                    # If the thread_id IS already known, this is likely a
+                    # cross-topic Reply leak — strip it and let the
+                    # recovery function handle routing.
+                    runner = getattr(
+                        getattr(self, "_message_handler", None), "__self__", None
+                    )
+                    if runner is None:
+                        pass
+                    elif not getattr(runner, "_telegram_topic_mode_enabled", lambda _s: False)(
+                        type("_Probe", (), {
+                            "platform": Platform.TELEGRAM,
+                            "chat_type": "dm",
+                            "chat_id": str(chat.id),
+                            "user_id": str(user.id) if user else "",
+                            "thread_id": str(thread_id_raw),
+                        })()
+                    ):
+                        pass
+                    else:
+                        try:
+                            session_db = getattr(runner, "_session_db", None)
+                            if session_db is not None:
+                                bindings = session_db.list_telegram_topic_bindings_for_chat(
+                                    chat_id=str(chat.id)
+                                )
+                                known = {int(b.get("thread_id") or 0) for b in (bindings or [])}
+                                if int(thread_id_raw) not in known:
+                                    thread_id_str = str(thread_id_raw)
+                        except Exception:
+                            pass
         # For forum groups without an explicit topic, default to the
         # General-topic id so the gateway routes back to the General topic
         # rather than dropping into the bot's main channel (#22423).

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2077,6 +2077,15 @@ class GatewayRunner:
         known = {str(b.get("thread_id") or "") for b in bindings}
         if not is_lobby and inbound in known:
             return None
+        # A non-lobby, non-General thread_id that is NOT in known bindings
+        # is a genuinely new topic (e.g. user just created it via "All
+        # Messages").  Don't recover — let it get its own session lane.
+        # Only recover when the inbound id is lobby/General or unknown
+        # (cross-topic Reply leak).
+        if not is_lobby or not known:
+            return None
+        # Lobby/General thread_id with known bindings: recover to the
+        # user's most recent topic binding.
         user_id = str(source.user_id)
         for b in bindings:  # newest-first
             if str(b.get("user_id") or "") == user_id:

--- a/tests/gateway/test_telegram_topic_mode.py
+++ b/tests/gateway/test_telegram_topic_mode.py
@@ -1175,13 +1175,39 @@ def test_recover_returns_none_for_known_topic(tmp_path):
     assert runner._recover_telegram_topic_thread_id(_make_source(thread_id="222")) is None
 
 
-def test_recover_rewrites_unknown_thread_id_to_most_recent(tmp_path):
-    # Cross-topic Reply leak: inbound thread_id is a Telegram-only id we never bound.
+def test_recover_leaves_unknown_topic_alone(tmp_path):
+    # A brand-new topic from "All Messages" — its thread_id exists
+    # in Telegram but we've never bound it yet.  It should be treated
+    # as a genuinely new topic lane, not redirected to an old one.
     db = SessionDB(db_path=tmp_path / "state.db")
     _seed_two_topic_bindings(db)
     runner = _make_runner(session_db=db)
 
-    assert runner._recover_telegram_topic_thread_id(_make_source(thread_id="9999")) == "222"
+    assert runner._recover_telegram_topic_thread_id(_make_source(thread_id="9999")) is None
+
+
+def test_recover_redirects_cross_topic_reply_to_known_topic(tmp_path):
+    # A reply that landed in a known (different) topic due to
+    # Telegram's cross-topic Reply leak: thread_id=111 (known).
+    # Should NOT be recovered — it's already in a valid lane.
+    db = SessionDB(db_path=tmp_path / "state.db")
+    _seed_two_topic_bindings(db)
+    runner = _make_runner(session_db=db)
+
+    # 111 is a known topic → not lobby, inbound in known → returns None
+    assert runner._recover_telegram_topic_thread_id(_make_source(thread_id="111")) is None
+
+
+def test_recover_rewrites_cross_topic_reply_to_unknown_topic(tmp_path):
+    # A cross-topic Reply that landed in an unknown foreign topic:
+    # thread_id=9999 (not bound).  Should NOT be recovered —
+    # treat it like a new topic lane.
+    db = SessionDB(db_path=tmp_path / "state.db")
+    _seed_two_topic_bindings(db)
+    runner = _make_runner(session_db=db)
+
+    # 9999 is unknown non-lobby → not lobby, not in known → returns None
+    assert runner._recover_telegram_topic_thread_id(_make_source(thread_id="9999")) is None
 
 
 def test_recover_rewrites_lobby_thread_id_to_most_recent(tmp_path):


### PR DESCRIPTION
## Summary

When topic mode is enabled and a user creates a new topic from Telegram's "All Messages" view, the first message in that topic often arrives without `is_topic_message=True`. This caused `_build_message_event` to strip the `message_thread_id`, and `_recover_telegram_topic_thread_id` redirected the resulting lobby thread_id to the user's most recent binding — making the brand-new topic inherit the previous topic's session.

## Changes

### 1. `gateway/platforms/telegram.py` — `_build_message_event`
When `is_topic_message` is `False` for a DM that has a `message_thread_id`:
- Check if topic mode is enabled
- Check if the thread_id is **not yet bound** to any session (genuinely new topic)
- If both true, preserve the thread_id so the topic gets its own session lane
- If the thread_id IS already known (cross-topic Reply leak), strip it and let the recovery function handle routing

### 2. `gateway/run.py` — `_recover_telegram_topic_thread_id`
Only recover from the lobby/General topic (`thread_id=None` / `""` / `"1"`) where routing intent is truly ambiguous. Non-lobby unknown thread_ids are treated as genuinely new topic lanes and left alone.

### 3. `tests/gateway/test_telegram_topic_mode.py` — updated tests
- Replaced `test_recover_rewrites_unknown_thread_id_to_most_recent` with `test_recover_leaves_unknown_topic_alone` (the old test codified the buggy behavior)
- Added `test_recover_redirects_cross_topic_reply_to_known_topic` (known topic stays put)
- Added `test_recover_rewrites_cross_topic_reply_to_unknown_topic` (unknown non-lobby returns None)

## Testing
- All 44 tests in `test_telegram_topic_mode.py` pass
- Verified working in production: creating a new topic from All Messages now correctly gets its own Hermes session