### PR TITLE
fix(runtime): preserve named user provider identity

### DIFF
--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -469,6 +469,7 @@ def _try_resolve_from_custom_pool(
             "api_key": pool_api_key,
             "source": f"pool:{pool_key}",
             "credential_pool": pool,
+            "custom_provider": True,
         }
     except Exception:
         return None
@@ -682,6 +683,7 @@ def _resolve_named_custom_runtime(
             "api_key": api_key,
             "source": "direct-alias",
             "requested_provider": requested_provider,
+            "custom_provider": True,
         }
 
     custom_provider = _get_named_custom_provider(requested_provider)
@@ -708,6 +710,7 @@ def _resolve_named_custom_runtime(
     # Check if a credential pool exists for this custom endpoint
     pool_result = _try_resolve_from_custom_pool(base_url, runtime_provider, custom_provider.get("api_mode"), provider_name=custom_provider.get("name"))
     if pool_result:
+        pool_result["custom_provider"] = True
         if provider_key:
             pool_result["provider_key"] = provider_key
         # Propagate the model name even when using pooled credentials —
@@ -747,6 +750,7 @@ def _resolve_named_custom_runtime(
         "base_url": base_url,
         "api_key": api_key or "no-key-required",
         "source": f"custom_provider:{custom_provider.get('name', requested_provider)}",
+        "custom_provider": True,
     }
     if provider_key:
         result["provider_key"] = provider_key

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -523,6 +523,7 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
                 base_url = entry.get("api") or entry.get("url") or entry.get("base_url") or ""
                 if base_url:
                     result = {
+                        "provider_key": ep_name,
                         "name": entry.get("name", ep_name),
                         "base_url": base_url.strip(),
                         "api_key": resolved_api_key,
@@ -551,6 +552,7 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
                     base_url = entry.get("api") or entry.get("url") or entry.get("base_url") or ""
                     if base_url:
                         result = {
+                            "provider_key": ep_name,
                             "name": display_name,
                             "base_url": base_url.strip(),
                             "api_key": resolved_api_key,
@@ -691,8 +693,17 @@ def _resolve_named_custom_runtime(
     if not base_url:
         return None
 
+    # New-style `providers:` entries are first-class named providers in the
+    # rest of the runtime (model switching, capability lookup, logs, aux
+    # vision routing).  Preserve their provider key instead of collapsing them
+    # to bare "custom".  Legacy `custom_providers:` entries intentionally keep
+    # the old "custom" label unless they were migrated with a provider_key.
+    runtime_provider = str(
+        custom_provider.get("provider_key") or "custom"
+    ).strip() or "custom"
+
     # Check if a credential pool exists for this custom endpoint
-    pool_result = _try_resolve_from_custom_pool(base_url, "custom", custom_provider.get("api_mode"), provider_name=custom_provider.get("name"))
+    pool_result = _try_resolve_from_custom_pool(base_url, runtime_provider, custom_provider.get("api_mode"), provider_name=custom_provider.get("name"))
     if pool_result:
         # Propagate the model name even when using pooled credentials —
         # the pool doesn't know about the custom_providers model field.
@@ -724,7 +735,7 @@ def _resolve_named_custom_runtime(
     api_key = next((candidate for candidate in api_key_candidates if has_usable_secret(candidate)), "")
 
     result = {
-        "provider": "custom",
+        "provider": runtime_provider,
         "api_mode": custom_provider.get("api_mode")
         or _detect_api_mode_for_url(base_url)
         or "chat_completions",

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -522,9 +522,10 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
                 # Found match by provider key
                 base_url = entry.get("api") or entry.get("url") or entry.get("base_url") or ""
                 if base_url:
+                    provider_key = str(ep_name).strip()
                     result = {
-                        "provider_key": ep_name,
-                        "name": entry.get("name", ep_name),
+                        "provider_key": provider_key,
+                        "name": entry.get("name", provider_key),
                         "base_url": base_url.strip(),
                         "api_key": resolved_api_key,
                         "model": entry.get("default_model", ""),
@@ -551,8 +552,9 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
                     # Found match by display name
                     base_url = entry.get("api") or entry.get("url") or entry.get("base_url") or ""
                     if base_url:
+                        provider_key = str(ep_name).strip()
                         result = {
-                            "provider_key": ep_name,
+                            "provider_key": provider_key,
                             "name": display_name,
                             "base_url": base_url.strip(),
                             "api_key": resolved_api_key,
@@ -701,10 +703,13 @@ def _resolve_named_custom_runtime(
     runtime_provider = str(
         custom_provider.get("provider_key") or "custom"
     ).strip() or "custom"
+    provider_key = str(custom_provider.get("provider_key") or "").strip()
 
     # Check if a credential pool exists for this custom endpoint
     pool_result = _try_resolve_from_custom_pool(base_url, runtime_provider, custom_provider.get("api_mode"), provider_name=custom_provider.get("name"))
     if pool_result:
+        if provider_key:
+            pool_result["provider_key"] = provider_key
         # Propagate the model name even when using pooled credentials —
         # the pool doesn't know about the custom_providers model field.
         model_name = custom_provider.get("model")
@@ -743,6 +748,8 @@ def _resolve_named_custom_runtime(
         "api_key": api_key or "no-key-required",
         "source": f"custom_provider:{custom_provider.get('name', requested_provider)}",
     }
+    if provider_key:
+        result["provider_key"] = provider_key
     # Propagate the model name so callers can override self.model when the
     # provider name differs from the actual model string the API expects.
     if custom_provider.get("model"):

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -744,7 +744,7 @@ def test_named_custom_provider_uses_providers_dict_when_list_missing(monkeypatch
 
     resolved = rp.resolve_runtime_provider(requested="openai-direct-primary")
 
-    assert resolved["provider"] == "custom"
+    assert resolved["provider"] == "openai-direct-primary"
     assert resolved["api_mode"] == "codex_responses"
     assert resolved["base_url"] == "https://api.openai.com/v1"
     assert resolved["api_key"] == "dir-key"
@@ -784,7 +784,7 @@ def test_named_custom_provider_uses_key_env_from_providers_dict(monkeypatch):
 
     resolved = rp.resolve_runtime_provider(requested="mycorp-proxy")
 
-    assert resolved["provider"] == "custom"
+    assert resolved["provider"] == "mycorp-proxy"
     assert resolved["api_mode"] == "chat_completions"
     assert resolved["base_url"] == "https://proxy.example.com/v1"
     assert resolved["api_key"] == "env-secret"

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -745,6 +745,7 @@ def test_named_custom_provider_uses_providers_dict_when_list_missing(monkeypatch
     resolved = rp.resolve_runtime_provider(requested="openai-direct-primary")
 
     assert resolved["provider"] == "openai-direct-primary"
+    assert resolved["provider_key"] == "openai-direct-primary"
     assert resolved["api_mode"] == "codex_responses"
     assert resolved["base_url"] == "https://api.openai.com/v1"
     assert resolved["api_key"] == "dir-key"
@@ -785,6 +786,7 @@ def test_named_custom_provider_uses_key_env_from_providers_dict(monkeypatch):
     resolved = rp.resolve_runtime_provider(requested="mycorp-proxy")
 
     assert resolved["provider"] == "mycorp-proxy"
+    assert resolved["provider_key"] == "mycorp-proxy"
     assert resolved["api_mode"] == "chat_completions"
     assert resolved["base_url"] == "https://proxy.example.com/v1"
     assert resolved["api_key"] == "env-secret"
@@ -824,6 +826,43 @@ def test_named_custom_provider_falls_back_to_openai_api_key(monkeypatch):
     # localhost is not openai.com — OPENAI_API_KEY must not leak to local endpoints (#28660)
     assert resolved["api_key"] == "no-key-required"
     assert resolved["requested_provider"] == "custom:local-llm"
+    assert resolved["provider"] == "custom"
+    assert "provider_key" not in resolved
+
+
+def test_providers_dict_provider_key_is_normalized(monkeypatch):
+    """Store provider_key without accidental YAML key whitespace."""
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.setattr(
+        rp,
+        "load_config",
+        lambda: {
+            "providers": {
+                "  mycorp-proxy  ": {
+                    "base_url": "https://proxy.example.com/v1",
+                    "api_key": "direct-secret",
+                    "default_model": "acme-large",
+                    "name": "MyCorp Proxy",
+                }
+            }
+        },
+    )
+    monkeypatch.setattr(
+        rp,
+        "resolve_provider",
+        lambda *a, **k: (_ for _ in ()).throw(
+            AssertionError(
+                "resolve_provider should not be called for named custom providers"
+            )
+        ),
+    )
+
+    resolved = rp.resolve_runtime_provider(requested="mycorp-proxy")
+
+    assert resolved["provider"] == "mycorp-proxy"
+    assert resolved["provider_key"] == "mycorp-proxy"
+    assert resolved["source"] == "custom_provider:MyCorp Proxy"
 
 
 def test_named_custom_provider_does_not_shadow_builtin_provider(monkeypatch):

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -710,6 +710,7 @@ def test_named_custom_provider_uses_saved_credentials(monkeypatch):
     assert resolved["api_key"] == "local-provider-key"
     assert resolved["requested_provider"] == "local"
     assert resolved["source"] == "custom_provider:Local"
+    assert resolved["custom_provider"] is True
 
 
 def test_named_custom_provider_uses_providers_dict_when_list_missing(monkeypatch):
@@ -746,6 +747,7 @@ def test_named_custom_provider_uses_providers_dict_when_list_missing(monkeypatch
 
     assert resolved["provider"] == "openai-direct-primary"
     assert resolved["provider_key"] == "openai-direct-primary"
+    assert resolved["custom_provider"] is True
     assert resolved["api_mode"] == "codex_responses"
     assert resolved["base_url"] == "https://api.openai.com/v1"
     assert resolved["api_key"] == "dir-key"
@@ -787,6 +789,7 @@ def test_named_custom_provider_uses_key_env_from_providers_dict(monkeypatch):
 
     assert resolved["provider"] == "mycorp-proxy"
     assert resolved["provider_key"] == "mycorp-proxy"
+    assert resolved["custom_provider"] is True
     assert resolved["api_mode"] == "chat_completions"
     assert resolved["base_url"] == "https://proxy.example.com/v1"
     assert resolved["api_key"] == "env-secret"
@@ -828,6 +831,7 @@ def test_named_custom_provider_falls_back_to_openai_api_key(monkeypatch):
     assert resolved["requested_provider"] == "custom:local-llm"
     assert resolved["provider"] == "custom"
     assert "provider_key" not in resolved
+    assert resolved["custom_provider"] is True
 
 
 def test_providers_dict_provider_key_is_normalized(monkeypatch):
@@ -1660,6 +1664,7 @@ def test_named_custom_runtime_propagates_model_pool_path(monkeypatch):
         rp, "_get_named_custom_provider",
         lambda p: {
             "name": "my-server",
+            "provider_key": "my-server",
             "base_url": "http://localhost:8000/v1",
             "api_key": "test-key",
             "model": "qwen3.6-plus",
@@ -1681,6 +1686,9 @@ def test_named_custom_runtime_propagates_model_pool_path(monkeypatch):
     assert resolved["model"] == "qwen3.6-plus", (
         "model must be injected into pool result"
     )
+    assert resolved["provider"] == "custom"
+    assert resolved["provider_key"] == "my-server"
+    assert resolved["custom_provider"] is True
     assert resolved["api_key"] == "pool-key", "pool credentials should be used"
 
 


### PR DESCRIPTION
## Summary
- preserve the `providers.<name>` key when resolving new-style named custom providers at runtime
- keep legacy `custom_providers` entries on the existing `provider=custom` path
- update runtime-provider regression expectations so `providers:` entries remain first-class provider IDs

## Why
Gateway cold start resolves `model.provider` through `resolve_runtime_provider()`. For new-style `providers:` entries, `_get_named_custom_provider()` found the entry but `_resolve_named_custom_runtime()` returned `provider=custom`, so logs and downstream routing lost the named provider identity.

That differs from `/model --provider <name>`, which stores a session override with the named provider and therefore works until the gateway restarts. Preserving the provider key keeps cold-start behavior aligned with model-switch behavior and lets capability/vision routing see the configured provider name.

## Related work
- #26544 preserves `custom:<name>` in auxiliary/vision normalization, but does not fix runtime provider resolution for `providers.<name>` during gateway startup.
- #18804 improves named custom provider credential selection, but still returns `provider=custom` from the runtime path.

## Test plan
- [x] `.venv/bin/python -m pytest tests/hermes_cli/test_runtime_provider_resolution.py -q -o 'addopts='`
- [x] `.venv/bin/python -m pytest tests/hermes_cli/test_user_providers_model_switch.py tests/hermes_cli/test_custom_provider_model_switch.py tests/gateway/test_model_switch_persistence.py -q -o 'addopts='`

