### PR TITLE
fix(kanban): close decompose sqlite connections

### DIFF
--- a/hermes_cli/kanban_decompose.py
+++ b/hermes_cli/kanban_decompose.py
@@ -38,6 +38,7 @@ from __future__ import annotations
 
 import json
 import logging
+from contextlib import closing
 import os
 import re
 from dataclasses import dataclass
@@ -281,7 +282,7 @@ def decompose_task(
     configured, API error, malformed response, decomposer returned
     fanout=true with empty task list) — those surface via ``ok=False``.
     """
-    with kb.connect() as conn:
+    with closing(kb.connect()) as conn, conn:
         task = kb.get_task(conn, task_id)
     if task is None:
         return DecomposeOutcome(task_id, False, "unknown task id")
@@ -370,7 +371,7 @@ def decompose_task(
             return DecomposeOutcome(
                 task_id, False, "decomposer returned fanout=false with no title/body",
             )
-        with kb.connect() as conn:
+        with closing(kb.connect()) as conn, conn:
             ok = kb.specify_triage_task(
                 conn,
                 task_id,
@@ -439,7 +440,7 @@ def decompose_task(
         })
 
     try:
-        with kb.connect() as conn:
+        with closing(kb.connect()) as conn, conn:
             child_ids = kb.decompose_triage_task(
                 conn,
                 task_id,
@@ -467,7 +468,7 @@ def decompose_task(
 
 def list_triage_ids(*, tenant: Optional[str] = None) -> list[str]:
     """Return task ids currently in the triage column."""
-    with kb.connect() as conn:
+    with closing(kb.connect()) as conn, conn:
         rows = kb.list_tasks(
             conn,
             status="triage",

--- a/tests/hermes_cli/test_kanban_decompose.py
+++ b/tests/hermes_cli/test_kanban_decompose.py
@@ -76,6 +76,46 @@ def _patch_list_profiles(names: list[str]):
     ]
 
 
+class _ConnWithoutResourceClosing:
+    """sqlite3.Connection context managers do not close the FD."""
+
+    def __init__(self):
+        self.closed = False
+        self.exited = False
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        self.exited = True
+        return False
+
+    def close(self):
+        self.closed = True
+
+
+def test_decompose_closes_connection_when_task_is_unknown(monkeypatch):
+    conn = _ConnWithoutResourceClosing()
+    monkeypatch.setattr(decomp.kb, "connect", lambda: conn)
+    monkeypatch.setattr(decomp.kb, "get_task", lambda _conn, _task_id: None)
+
+    outcome = decomp.decompose_task("missing")
+
+    assert outcome.ok is False
+    assert conn.exited is True
+    assert conn.closed is True
+
+
+def test_list_triage_ids_closes_connection(monkeypatch):
+    conn = _ConnWithoutResourceClosing()
+    monkeypatch.setattr(decomp.kb, "connect", lambda: conn)
+    monkeypatch.setattr(decomp.kb, "list_tasks", lambda _conn, **_kwargs: [])
+
+    assert decomp.list_triage_ids() == []
+    assert conn.exited is True
+    assert conn.closed is True
+
+
 def test_decompose_with_fanout_creates_children(kanban_home):
     with kb.connect() as conn:
         tid = kb.create_task(conn, title="ship a feature", triage=True)


### PR DESCRIPTION
## Summary
- Close SQLite connections opened by `hermes_cli.kanban_decompose` after preserving sqlite3 transaction context-manager semantics
- Add regression coverage proving decomposer/list-triage paths close connections instead of relying on `sqlite3.Connection.__exit__`

## Why
`sqlite3.Connection` context managers commit/rollback but do not close the underlying connection. In a long-lived gateway process, the kanban auto-decompose loop can repeatedly open kanban DB handles and leak file descriptors until unrelated session/state writes fail with `OSError: [Errno 24] Too many open files`.

## Test Plan
- [x] Verified new regression tests fail against the previous `with kb.connect() as conn:` implementation
- [x] `PYTHONPATH=/tmp/hermes-kanban-fd-pr /Users/luisramirez/Code/hermes-agent-upstream-staged-2026-05-19/.venv/bin/python -m pytest tests/hermes_cli/test_kanban_decompose.py tests/hermes_cli/test_kanban_decompose_db.py -q -o addopts= --tb=short` — 19 passed
- [x] `PYTHONPATH=/tmp/hermes-kanban-fd-pr /Users/luisramirez/Code/hermes-agent-upstream-staged-2026-05-19/.venv/bin/python -m py_compile hermes_cli/kanban_decompose.py`
