### PR TITLE
fix(feishu): render markdown tables via post+tag:md instead of plain text

### DIFF
--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -155,8 +155,7 @@ _MARKDOWN_HINT_RE = re.compile(
     r"(^#{1,6}\s)|(^\s*[-*]\s)|(^\s*\d+\.\s)|(^\s*---+\s*$)|(```)|(`[^`\n]+`)|(\*\*[^*\n].+?\*\*)|(~~[^~\n].+?~~)|(<u>.+?</u>)|(\*[^*\n]+\*)|(\[[^\]]+\]\([^)]+\))|(^>\s)",
     re.MULTILINE,
 )
-# Detect markdown tables: a line starting with | followed by a separator line.
-# Feishu post-type 'md' elements do not render tables, so we force text mode.
+# Detect markdown tables so outbound payloads can route them through post/md.
 _MARKDOWN_TABLE_RE = re.compile(r"^\|.*\|\n\|[-|: ]+\|", re.MULTILINE)
 _MARKDOWN_LINK_RE = re.compile(r"\[([^\]]+)\]\(([^)]+)\)")
 _MARKDOWN_FENCE_OPEN_RE = re.compile(r"^```([^\n`]*)\s*$")
@@ -4526,12 +4525,9 @@ class FeishuAdapter(BasePlatformAdapter):
     # =========================================================================
 
     def _build_outbound_payload(self, content: str) -> tuple[str, str]:
-        # Feishu post-type 'md' elements do not render markdown tables; sending
-        # table content as post causes the message to appear blank on the client.
-        # Force plain text for anything that looks like a markdown table.
+        # _MARKDOWN_HINT_RE does not match tables, so route them explicitly.
         if _MARKDOWN_TABLE_RE.search(content):
-            text_payload = {"text": content}
-            return "text", json.dumps(text_payload, ensure_ascii=False)
+            return "post", _build_markdown_post_payload(content)
         if _MARKDOWN_HINT_RE.search(content):
             return "post", _build_markdown_post_payload(content)
         text_payload = {"text": content}

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -49,6 +49,7 @@ AUTHOR_MAP = {
     "changhyun.min@gmail.com": "minchang",  # PR #42231 salvage (providers: add Upstage Solar)
     "neo@neodeMac-mini.local": "neo-claw-bot",  # PR #58465 salvage (moa: drop empty user turns from advisory view)
     "2024104039@mails.szu.edu.cn": "pixel4039",  # PR #64420 salvage (streaming: retry zero-chunk streams)
+    "hanqshih@gmail.com": "M1racleShih",  # PR #29552 (Feishu table rendering)
     "m.guttmann@journaway.com": "mguttmann",  # PR #63738 salvage (Anthropic setup-token pool auth normalization)
     "VrtxOmega@pm.me": "VrtxOmega",  # PR #43809 salvage (desktop: WSL folder-picker path bridge)
     "gn00742754@gmail.com": "SemonCat",  # PR #56786 salvage (Slack Agent View manifests and Assistant APIs)

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -2691,6 +2691,23 @@ class TestAdapterBehavior(unittest.TestCase):
         )
 
     @patch.dict(os.environ, {}, clear=True)
+    def test_build_outbound_payload_uses_post_for_markdown_table(self):
+        from gateway.config import PlatformConfig
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        content = "| Name | Score |\n| --- | ---: |\n| Ada | 10 |"
+
+        msg_type, raw_payload = adapter._build_outbound_payload(content)
+
+        self.assertEqual(msg_type, "post")
+        payload = json.loads(raw_payload)
+        self.assertEqual(
+            payload["zh_cn"]["content"],
+            [[{"tag": "md", "text": content}]],
+        )
+
+    @patch.dict(os.environ, {}, clear=True)
     def test_send_uses_post_for_inline_markdown(self):
         from gateway.config import PlatformConfig
         from plugins.platforms.feishu.adapter import FeishuAdapter


### PR DESCRIPTION
## What does this PR do?

This fixes Markdown table rendering in the active Feishu adapter at `plugins/platforms/feishu/adapter.py`.

Table-shaped Markdown is now sent through the existing `post` + `md` payload builder instead of plain `text`. The explicit branch is needed because `_MARKDOWN_HINT_RE` does not match tables.

Feishu's current [message-content documentation](https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/im-v1/message/create_json) documents GFM table support in `post` message `md` elements. The behavior was also verified in the Feishu desktop environment below. This does not claim support across every Feishu or Lark client version.

## Related Issue

Fixes #27529

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `plugins/platforms/feishu/adapter.py`
  - Routes Markdown tables through `_build_markdown_post_payload()`.
  - Updates the stale table-routing comments.
- `tests/gateway/test_feishu.py`
  - Adds `test_build_outbound_payload_uses_post_for_markdown_table`.
  - Directly asserts the `post` type and decoded `md` payload.
- `scripts/release.py`
  - Maps the contributor's existing commit email to `M1racleShih`.

The existing invalid-post plain-text fallback in the send and edit paths is unchanged.

Scope is limited to this routing fix and its regression test. There are no parser, regex, post-row builder, configuration, dependency, CardKit, chunking, streaming, inbound parsing, media, or unrelated Feishu changes.

## How to Test

```bash
scripts/run_tests.sh tests/gateway/test_feishu.py \
  -k build_outbound_payload_uses_post_for_markdown_table -q
scripts/run_tests.sh tests/gateway/test_feishu.py -q
ruff check .
python scripts/check-windows-footguns.py --all
uv lock --check
git diff --check
```

### TDD evidence

RED on clean `upstream/main@0d3ad193d6cc235213489f509e26760ccb3722a1`:

```text
AssertionError: 'text' != 'post'
1 failed
```

The test showed that `_build_outbound_payload()` returned `text`.

GREEN after the minimal implementation on the same base:

```text
1 passed
```

### Final validation

Rebased onto `upstream/main@569b912d7d0931c7256e9f5fb326609e9deda377`.

Head: `add6f01aa0ffabdebabfc20b988132d26b7e0778`.

```text
Targeted regression test: 1 passed
Complete Feishu test file: 211 passed
ruff check .: passed; only the pre-existing invalid-noqa warning was emitted
Windows footgun check: no footguns found (762 files scanned)
uv lock --check: passed
git diff --check: clean
```

<details>
<summary>Full-suite baseline/environment failures</summary>

The full suite is not claimed as passing.

The same eight-file diagnostic set was run against clean latest `main` and the PR worktree:

```bash
scripts/run_tests.sh \
  tests/agent/lsp/test_service.py \
  tests/agent/lsp/test_broken_set.py \
  tests/agent/lsp/test_workspace.py \
  tests/agent/lsp/test_install_and_lint_fixes.py \
  tests/agent/test_coding_context.py \
  tests/agent/test_verification_stop.py \
  tests/agent/test_verification_evidence.py \
  tests/agent/test_model_metadata_ssl.py -q
```

```text
Clean upstream/main: 138 passed, 31 failed
PR worktree:        129 passed, 31 failed, 1 collection error
```

The same 31 failures come from the sandbox-injected `/tmp/.git` path affecting workspace detection and are unrelated to the Feishu diff. The additional PR-worktree collection error comes from the local shared-venv overlay shadowing the source `agent` package while collecting `test_model_metadata_ssl.py`.

</details>

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass — baseline/environment failures are documented above
- [x] I've added tests for my changes
- [x] I've tested on Ubuntu 24.04.3 LTS with Feishu desktop 7.66.11-0

### Documentation & Housekeeping

- [x] Relevant documentation update — N/A
- [x] `cli-config.yaml.example` update — N/A; no configuration changed
- [x] `CONTRIBUTING.md` or `AGENTS.md` update — N/A
- [x] Cross-platform impact considered; Windows footgun check passed
- [x] Tool descriptions/schemas update — N/A

## Screenshots / Logs

### Feishu desktop evidence

- Test date: 2026-07-14, Asia/Shanghai
- Product: Feishu desktop, China region
- Package version: `bytedance-feishu-stable 7.66.11-0`
- OS: Ubuntu 24.04.3 LTS, KDE/X11
- Hermes setting: `FEISHU_DOMAIN=feishu`
- API base: `https://open.feishu.cn`
- Target: configured Feishu home channel, redacted as `oc_2291…6466`
- Mobile and international Lark clients were not tested

Test message:

```markdown
## Service status

| Service | State |
| --- | --- |
| API | **Healthy** |
| Worker | `Degraded` |

After-table text with a [link](https://example.com).
```

Baseline, clean `upstream/main@0d3ad193d6cc235213489f509e26760ccb3722a1`:

- API success: `om_x100…94bd0`
- The client displayed literal table pipes, heading markers, bold markers, and backticks.

Modified implementation on the same base:

- API success: `om_x100…c38b4`
- The client displayed a bordered table, heading, bold text, inline code, trailing text, and link.
- The message was not blank and did not visibly use the plain-text fallback.

<img width="389" height="452" alt="pr29552-feishu-ab-private" src="https://github.com/user-attachments/assets/b914e1f9-63f6-4d64-b2c5-7a89f4c9f62d" />

The privacy-checked A/B image contains only the two labeled test messages. No sidebar, unrelated conversation, avatar, account information, or composer is visible.
