### PR TITLE
fix: include cache_read_tokens and cache_write_tokens in API Server SSE usage events

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1324,6 +1324,8 @@ class APIServerAdapter(BasePlatformAdapter):
                 "prompt_tokens": usage.get("input_tokens", 0),
                 "completion_tokens": usage.get("output_tokens", 0),
                 "total_tokens": usage.get("total_tokens", 0),
+                "cache_read_tokens": usage.get("cache_read_tokens", 0),
+                "cache_write_tokens": usage.get("cache_write_tokens", 0),
             },
         }
         if is_partial or is_failed or not completed:
@@ -1453,6 +1455,8 @@ class APIServerAdapter(BasePlatformAdapter):
                     "prompt_tokens": usage.get("input_tokens", 0),
                     "completion_tokens": usage.get("output_tokens", 0),
                     "total_tokens": usage.get("total_tokens", 0),
+                    "cache_read_tokens": usage.get("cache_read_tokens", 0),
+                    "cache_write_tokens": usage.get("cache_write_tokens", 0),
                 },
             }
             await response.write(f"data: {json.dumps(finish_chunk)}\n\n".encode())
@@ -1645,6 +1649,8 @@ class APIServerAdapter(BasePlatformAdapter):
                 "input_tokens": usage.get("input_tokens", 0),
                 "output_tokens": usage.get("output_tokens", 0),
                 "total_tokens": usage.get("total_tokens", 0),
+                "cache_read_tokens": usage.get("cache_read_tokens", 0),
+                "cache_write_tokens": usage.get("cache_write_tokens", 0),
             }
             incomplete_history = list(conversation_history)
             incomplete_history.append({"role": "user", "content": user_message})
@@ -1988,6 +1994,8 @@ class APIServerAdapter(BasePlatformAdapter):
                     "input_tokens": usage.get("input_tokens", 0),
                     "output_tokens": usage.get("output_tokens", 0),
                     "total_tokens": usage.get("total_tokens", 0),
+                    "cache_read_tokens": usage.get("cache_read_tokens", 0),
+                    "cache_write_tokens": usage.get("cache_write_tokens", 0),
                 }
                 _failed_history = list(conversation_history)
                 _failed_history.append({"role": "user", "content": user_message})
@@ -2012,6 +2020,8 @@ class APIServerAdapter(BasePlatformAdapter):
                     "input_tokens": usage.get("input_tokens", 0),
                     "output_tokens": usage.get("output_tokens", 0),
                     "total_tokens": usage.get("total_tokens", 0),
+                    "cache_read_tokens": usage.get("cache_read_tokens", 0),
+                    "cache_write_tokens": usage.get("cache_write_tokens", 0),
                 }
                 full_history = self._build_response_conversation_history(
                     conversation_history,
@@ -2078,6 +2088,8 @@ class APIServerAdapter(BasePlatformAdapter):
                     "input_tokens": usage.get("input_tokens", 0),
                     "output_tokens": usage.get("output_tokens", 0),
                     "total_tokens": usage.get("total_tokens", 0),
+                    "cache_read_tokens": usage.get("cache_read_tokens", 0),
+                    "cache_write_tokens": usage.get("cache_write_tokens", 0),
                 }
                 await _write_event("response.failed", {
                     "type": "response.failed",
@@ -2348,6 +2360,8 @@ class APIServerAdapter(BasePlatformAdapter):
                 "input_tokens": usage.get("input_tokens", 0),
                 "output_tokens": usage.get("output_tokens", 0),
                 "total_tokens": usage.get("total_tokens", 0),
+                "cache_read_tokens": usage.get("cache_read_tokens", 0),
+                "cache_write_tokens": usage.get("cache_write_tokens", 0),
             },
         }
 


### PR DESCRIPTION
## Summary

The agent internally tracks `cache_read_tokens` and `cache_write_tokens` (stored in `Session` objects and SQLite `state.db`), but these fields are **not included** in the `usage` object of SSE responses from the API Server. This causes downstream consumers to always report `cache_read_tokens = 0` and `cache_hit_rate = 0%`, even when prompt caching is actively working.

## Changes

Added `cache_read_tokens` and `cache_write_tokens` to all 7 `usage` dict constructions in `gateway/platforms/api_server.py`:

1. Chat completions streaming finish chunk
2. Chat completions non-streaming response
3. Responses API incomplete event
4. Responses API failed event
5. Responses API completed event
6. Responses API failed event (streaming)
7. Responses API non-streaming completed response

Each change follows the same pattern:

```python
"usage": {
    "input_tokens": usage.get("input_tokens", 0),
    "output_tokens": usage.get("output_tokens", 0),
    "total_tokens": usage.get("total_tokens", 0),
    "cache_read_tokens": usage.get("cache_read_tokens", 0),   # ← added
    "cache_write_tokens": usage.get("cache_write_tokens", 0), # ← added
}
```

## Why This Matters

- **Cost tracking**: Prompt caching can reduce costs by 90% for repeated contexts. Without cache token reporting, users cannot verify or quantify their savings.
- **Dashboard accuracy**: The built-in usage dashboard always shows `cache_hit_rate = 0%`, which is misleading.
- **Third-party integrations**: WebUIs and monitoring tools that consume the SSE API cannot display cache metrics.

## Testing

- Verified that `usage.get("cache_read_tokens", 0)` returns the correct value from the agent's internal `Session` tracking
- The change is purely additive — existing consumers that don't use these fields are unaffected
- Default value of `0` maintains backward compatibility

## Related Issue

Closes #29553
