### PR TITLE
feat: add workflow guardrails and local sampling defaults

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -49,6 +49,10 @@ from agent.tool_guardrails import (
     ToolCallGuardrailController,
     ToolGuardrailDecision,
 )
+from agent.workflow_guardrails import (
+    WorkflowGuardrailConfig,
+    WorkflowGuardrailController,
+)
 from hermes_cli.config import cfg_get
 from hermes_cli.timeouts import get_provider_request_timeout
 from hermes_constants import get_hermes_home
@@ -342,6 +346,7 @@ def init_agent(
     # even when stream consumers are registered (no tokens streaming then)
     agent._executing_tools = False
     agent._tool_guardrails = ToolCallGuardrailController()
+    agent._workflow_guardrails = WorkflowGuardrailController()
     agent._tool_guardrail_halt_decision: ToolGuardrailDecision | None = None
 
     # Interrupt mechanism for breaking out of tool loops
@@ -949,6 +954,14 @@ def init_agent(
         )
     except Exception as _tlg_err:
         _ra().logger.warning("Tool loop guardrail config ignored: %s", _tlg_err)
+    try:
+        agent._workflow_guardrails = WorkflowGuardrailController(
+            WorkflowGuardrailConfig.from_mapping(
+                _agent_cfg.get("workflow_guardrails", {})
+            )
+        )
+    except Exception as _wfg_err:
+        _ra().logger.warning("Workflow guardrail config ignored: %s", _wfg_err)
     # Cache only the derived auxiliary compression context override that is
     # needed later by the startup feasibility check.  Avoid exposing a
     # broad pseudo-public config object on the agent instance.

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -3267,6 +3267,35 @@ def resolve_provider_client(
         return (_to_async_client(client, final_model, is_vision=is_vision) if async_mode
                 else (client, final_model))
 
+    # ── Google Gemini CLI / Code Assist OAuth ────────────────────────
+    if provider == "google-gemini-cli":
+        # This provider is not OpenAI-compatible at the URL layer; use the
+        # Cloud Code Assist facade. Main-agent fallback calls this resolver
+        # with raw_codex=True, so resolving it here is required for Codex →
+        # Gemini fallback chains to work instead of silently exhausting the
+        # chain as "provider not configured".
+        try:
+            from hermes_cli.auth import resolve_gemini_oauth_runtime_credentials
+            from agent.gemini_cloudcode_adapter import GeminiCloudCodeClient
+
+            creds = resolve_gemini_oauth_runtime_credentials()
+            final_model = _normalize_resolved_model(
+                model or "gemini-3.1-pro-preview", provider
+            )
+            client = GeminiCloudCodeClient(
+                api_key=creds.get("api_key") or "google-oauth",
+                base_url=creds.get("base_url") or explicit_base_url or "cloudcode-pa://google",
+                project_id=creds.get("project_id", ""),
+            )
+            return (_to_async_client(client, final_model, is_vision=is_vision) if async_mode
+                    else (client, final_model))
+        except Exception as exc:
+            logger.warning(
+                "resolve_provider_client: google-gemini-cli requested but OAuth "
+                "credentials are unavailable or invalid: %s", exc,
+            )
+            return None, None
+
     # ── Custom endpoint (OPENAI_BASE_URL + OPENAI_API_KEY) ───────────
     if provider == "custom":
         if explicit_base_url:

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -341,6 +341,15 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
     )
     _is_tokenhub = base_url_host_matches(agent._base_url_lower, "tokenhub.tencentmaas.com")
     _is_lmstudio = (agent.provider or "").strip().lower() == "lmstudio"
+    try:
+        from agent.model_sampling_registry import resolve_sampling_profile
+        _sampling_profile = resolve_sampling_profile(
+            provider=agent.provider,
+            base_url=agent.base_url,
+            model=agent.model,
+        )
+    except Exception:
+        _sampling_profile = None
 
     # Temperature: _fixed_temperature_for_model may return OMIT_TEMPERATURE
     # sentinel (temperature omitted entirely), a numeric override, or None.
@@ -404,7 +413,7 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
         # registered providers with profiles were bypassing the strip.
         api_messages = agent._prepare_messages_for_non_vision_model(api_messages)
 
-        return _ct.build_kwargs(
+        _kwargs = _ct.build_kwargs(
             model=agent.model,
             messages=api_messages,
             tools=tools_for_api,
@@ -425,6 +434,13 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
             supports_reasoning=agent._supports_reasoning_extra_body(),
             qwen_session_metadata=_qwen_meta,
         )
+        if not agent.request_overrides:
+            try:
+                from agent.model_sampling_registry import apply_sampling_defaults
+                _kwargs = apply_sampling_defaults(_kwargs, _sampling_profile)
+            except Exception:
+                pass
+        return _kwargs
 
     # ── Legacy flag path ────────────────────────────────────────────
     # Reached only when get_provider_profile() returns None — i.e. a
@@ -436,7 +452,7 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
     # Strip image parts for non-vision models (no-op when vision-capable).
     _msgs_for_chat = agent._prepare_messages_for_non_vision_model(api_messages)
 
-    return _ct.build_kwargs(
+    _kwargs = _ct.build_kwargs(
         model=agent.model,
         messages=_msgs_for_chat,
         tools=tools_for_api,
@@ -472,6 +488,13 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
         anthropic_max_output=_ant_max,
         provider_name=agent.provider,
     )
+    if not agent.request_overrides:
+        try:
+            from agent.model_sampling_registry import apply_sampling_defaults
+            _kwargs = apply_sampling_defaults(_kwargs, _sampling_profile)
+        except Exception:
+            pass
+    return _kwargs
 
 
 

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -1012,6 +1012,14 @@ Be specific with file paths, commands, line numbers, and results.]
 ## Critical Context
 [Any specific values, error messages, configuration details, or data that would be lost without explicit preservation. NEVER include API keys, tokens, passwords, or credentials — write [REDACTED] instead.]
 
+## Guardrail & Verification Evidence
+[Preserve workflow-critical evidence that should survive compaction:
+- Required workflow steps completed or still missing
+- Test/build/lint/smoke commands and outcomes
+- User approvals/denials and exact gated phrases
+- Tool guardrail warnings/blocks that affected the task
+- Final artifact paths and verification status]
+
 Target ~{summary_budget} tokens. Be CONCRETE — include file paths, command outputs, error messages, line numbers, and specific values. Avoid vague descriptions like "made some changes" — say exactly what changed.
 
 Write only the summary body. Do not include any preamble or prefix."""

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -64,6 +64,11 @@ from agent.prompt_caching import apply_anthropic_cache_control
 from agent.retry_utils import jittered_backoff
 from agent.trajectory import has_incomplete_scratchpad
 from agent.usage_pricing import estimate_usage_cost, normalize_usage
+from agent.workflow_guardrails import (
+    append_workflow_advisory,
+    workflow_block_response,
+    workflow_nudge_message,
+)
 from hermes_constants import display_hermes_home as _dhh_fn
 from hermes_logging import set_session_context
 from tools.schema_sanitizer import strip_pattern_and_format
@@ -380,6 +385,11 @@ def run_conversation(
 
     # Preserve the original user message (no nudge injection).
     original_user_message = persist_user_message if persist_user_message is not None else user_message
+    try:
+        _wf_turn_msg = original_user_message if isinstance(original_user_message, str) else ""
+        agent._workflow_guardrails.reset_for_turn(_wf_turn_msg)
+    except Exception:
+        pass
 
     # Track memory nudge trigger (turn-based, checked here).
     # Skill trigger is checked AFTER the agent loop completes, based on
@@ -3723,8 +3733,32 @@ def run_conversation(
                     length_continue_retries = 0
                 
                 final_response = agent._strip_think_blocks(final_response).strip()
+
+                try:
+                    _wf_decision = agent._workflow_guardrails.evaluate_final_response(final_response)
+                except Exception:
+                    _wf_decision = None
+                if _wf_decision is not None and _wf_decision.action == "nudge":
+                    nudge_msg = agent._build_assistant_message(assistant_message, finish_reason)
+                    nudge_msg["_workflow_guardrail_nudge"] = True
+                    messages.append(nudge_msg)
+                    messages.append(workflow_nudge_message(_wf_decision))
+                    agent._emit_status(
+                        f"⚠️ Workflow guardrail nudged: {_wf_decision.workflow_key}"
+                    )
+                    continue
+                if _wf_decision is not None and _wf_decision.action == "block":
+                    final_response = workflow_block_response(_wf_decision)
+                    messages.append({"role": "assistant", "content": final_response})
+                    _turn_exit_reason = f"workflow_guardrail_block({_wf_decision.workflow_key})"
+                    break
+                if _wf_decision is not None and _wf_decision.action == "advisory":
+                    final_response = append_workflow_advisory(final_response, _wf_decision)
+                    _turn_exit_reason = f"workflow_guardrail_advisory({_wf_decision.workflow_key})"
                 
                 final_msg = agent._build_assistant_message(assistant_message, finish_reason)
+                if _wf_decision is not None and _wf_decision.action == "advisory":
+                    final_msg["content"] = final_response
 
                 # Pop thinking-only prefill and empty-response retry
                 # scaffolding before appending the final response.  These
@@ -3743,7 +3777,8 @@ def run_conversation(
 
                 messages.append(final_msg)
                 
-                _turn_exit_reason = f"text_response(finish_reason={finish_reason})"
+                if not (_wf_decision is not None and _wf_decision.action == "advisory"):
+                    _turn_exit_reason = f"text_response(finish_reason={finish_reason})"
                 if not agent.quiet_mode:
                     agent._safe_print(f"🎉 Conversation completed after {api_call_count} OpenAI-compatible API call(s)")
                 break
@@ -4024,6 +4059,14 @@ def run_conversation(
     }
     if agent._tool_guardrail_halt_decision is not None:
         result["guardrail"] = agent._tool_guardrail_halt_decision.to_metadata()
+    try:
+        _wf_active = getattr(agent._workflow_guardrails, "active_workflows", ())
+        if _wf_active:
+            result["workflow_guardrail"] = {
+                "active": [wf.key for wf in _wf_active],
+            }
+    except Exception:
+        pass
     # If a /steer landed after the final assistant turn (no more tool
     # batches to drain into), hand it back to the caller so it can be
     # delivered as the next user turn instead of being silently lost.

--- a/agent/model_sampling_registry.py
+++ b/agent/model_sampling_registry.py
@@ -1,0 +1,84 @@
+"""Model/backend sampling defaults inspired by Forge backend registries.
+
+The registry is deliberately conservative: it only supplies request fields when
+there is a known local/CLI backend pattern and the caller has not already set
+that field. Cloud/provider profiles and explicit request_overrides keep priority.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+
+@dataclass(frozen=True)
+class SamplingProfile:
+    name: str
+    match_providers: tuple[str, ...] = ()
+    match_base_url_contains: tuple[str, ...] = ()
+    match_model_contains: tuple[str, ...] = ()
+    request_defaults: Mapping[str, Any] | None = None
+    extra_body_defaults: Mapping[str, Any] | None = None
+
+
+DEFAULT_SAMPLING_PROFILES: tuple[SamplingProfile, ...] = (
+    SamplingProfile(
+        name="ollama_tool_stable",
+        match_providers=("ollama",),
+        match_base_url_contains=("localhost:11434", "127.0.0.1:11434"),
+        request_defaults={"temperature": 0.2},
+        extra_body_defaults={"top_p": 0.9},
+    ),
+    SamplingProfile(
+        name="llama_cpp_tool_stable",
+        match_providers=("llama-cpp", "llamacpp", "llama.cpp"),
+        match_base_url_contains=("localhost:8080", "127.0.0.1:8080"),
+        request_defaults={"temperature": 0.1},
+        extra_body_defaults={"top_p": 0.9},
+    ),
+    SamplingProfile(
+        name="lmstudio_tool_stable",
+        match_providers=("lmstudio",),
+        match_base_url_contains=("localhost:1234", "127.0.0.1:1234"),
+        request_defaults={"temperature": 0.2},
+        extra_body_defaults={"top_p": 0.9},
+    ),
+)
+
+
+def resolve_sampling_profile(
+    *,
+    provider: str | None,
+    base_url: str | None,
+    model: str | None,
+    profiles: tuple[SamplingProfile, ...] = DEFAULT_SAMPLING_PROFILES,
+) -> SamplingProfile | None:
+    provider_l = (provider or "").strip().lower()
+    base_l = (base_url or "").strip().lower()
+    model_l = (model or "").strip().lower()
+    for profile in profiles:
+        if profile.match_providers and provider_l in {p.lower() for p in profile.match_providers}:
+            return profile
+        if profile.match_base_url_contains and any(part.lower() in base_l for part in profile.match_base_url_contains):
+            return profile
+        if profile.match_model_contains and any(part.lower() in model_l for part in profile.match_model_contains):
+            return profile
+    return None
+
+
+def apply_sampling_defaults(api_kwargs: dict[str, Any], profile: SamplingProfile | None) -> dict[str, Any]:
+    """Apply sampling defaults without overriding explicit caller fields."""
+    if profile is None:
+        return api_kwargs
+    for key, value in (profile.request_defaults or {}).items():
+        api_kwargs.setdefault(key, value)
+    extra_defaults = dict(profile.extra_body_defaults or {})
+    if extra_defaults:
+        existing = api_kwargs.get("extra_body")
+        if isinstance(existing, dict):
+            merged = dict(extra_defaults)
+            merged.update(existing)
+            api_kwargs["extra_body"] = merged
+        else:
+            api_kwargs["extra_body"] = extra_defaults
+    return api_kwargs

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -29,7 +29,7 @@ from agent.display import (
     get_tool_emoji as _get_tool_emoji,
     _detect_tool_failure,
 )
-from agent.tool_guardrails import ToolGuardrailDecision
+from agent.tool_guardrails import ToolGuardrailDecision, append_toolguard_guidance
 from agent.tool_dispatch_helpers import (
     _is_destructive_command,
     _is_multimodal_tool_result,
@@ -124,6 +124,7 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
 
         block_result = None
         blocked_by_guardrail = False
+        pre_execution_decision: ToolGuardrailDecision | None = None
         try:
             from hermes_cli.plugins import get_pre_tool_call_block_message
             block_message = get_pre_tool_call_block_message(
@@ -139,14 +140,16 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
             if not guardrail_decision.allows_execution:
                 block_result = agent._guardrail_block_result(guardrail_decision)
                 blocked_by_guardrail = True
+            elif guardrail_decision.action == "warn":
+                pre_execution_decision = guardrail_decision
 
-        parsed_calls.append((tool_call, function_name, function_args, block_result, blocked_by_guardrail))
+        parsed_calls.append((tool_call, function_name, function_args, block_result, blocked_by_guardrail, pre_execution_decision))
 
     # ── Logging / callbacks ──────────────────────────────────────────
-    tool_names_str = ", ".join(name for _, name, _, _, _ in parsed_calls)
+    tool_names_str = ", ".join(name for _, name, _, _, _, _ in parsed_calls)
     if not agent.quiet_mode:
         print(f"  ⚡ Concurrent: {num_tools} tool calls — {tool_names_str}")
-        for i, (tc, name, args, block_result, blocked_by_guardrail) in enumerate(parsed_calls, 1):
+        for i, (tc, name, args, block_result, blocked_by_guardrail, pre_execution_decision) in enumerate(parsed_calls, 1):
             args_str = json.dumps(args, ensure_ascii=False)
             if agent.verbose_logging:
                 print(f"  📞 Tool {i}: {name}({list(args.keys())})")
@@ -155,7 +158,7 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
                 args_preview = args_str[:agent.log_prefix_chars] + "..." if len(args_str) > agent.log_prefix_chars else args_str
                 print(f"  📞 Tool {i}: {name}({list(args.keys())}) - {args_preview}")
 
-    for tc, name, args, block_result, blocked_by_guardrail in parsed_calls:
+    for tc, name, args, block_result, blocked_by_guardrail, pre_execution_decision in parsed_calls:
         if block_result is not None:
             continue
         if agent.tool_progress_callback:
@@ -165,7 +168,7 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
             except Exception as cb_err:
                 logging.debug(f"Tool progress callback error: {cb_err}")
 
-    for tc, name, args, block_result, blocked_by_guardrail in parsed_calls:
+    for tc, name, args, block_result, blocked_by_guardrail, pre_execution_decision in parsed_calls:
         if block_result is not None:
             continue
         if agent.tool_start_callback:
@@ -177,7 +180,7 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
     # ── Concurrent execution ─────────────────────────────────────────
     # Each slot holds (function_name, function_args, function_result, duration, error_flag, blocked_flag)
     results = [None] * num_tools
-    for i, (tc, name, args, block_result, blocked_by_guardrail) in enumerate(parsed_calls):
+    for i, (tc, name, args, block_result, blocked_by_guardrail, pre_execution_decision) in enumerate(parsed_calls):
         if block_result is not None:
             results[i] = (name, args, block_result, 0.0, True, True)
 
@@ -279,7 +282,7 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
     try:
         runnable_calls = [
             (i, tc, name, args)
-            for i, (tc, name, args, block_result, blocked_by_guardrail) in enumerate(parsed_calls)
+            for i, (tc, name, args, block_result, blocked_by_guardrail, pre_execution_decision) in enumerate(parsed_calls)
             if block_result is None
         ]
         futures = []
@@ -346,7 +349,7 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
             spinner.stop(f"⚡ {completed}/{num_tools} tools completed in {total_dur:.1f}s total")
 
     # ── Post-execution: display per-tool results ─────────────────────
-    for i, (tc, name, args, block_result, blocked_by_guardrail) in enumerate(parsed_calls):
+    for i, (tc, name, args, block_result, blocked_by_guardrail, pre_execution_decision) in enumerate(parsed_calls):
         r = results[i]
         blocked = False
         if r is None:
@@ -366,6 +369,11 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
                     function_result,
                     failed=is_error,
                 )
+                if pre_execution_decision is not None:
+                    function_result = append_toolguard_guidance(
+                        function_result,
+                        pre_execution_decision,
+                    )
 
             if is_error:
                 _err_text = _multimodal_text_summary(function_result)
@@ -376,6 +384,13 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
             # `blocked` calls never actually ran — don't let a guardrail
             # block count as either a failure or a success.
             if not blocked:
+                try:
+                    agent._workflow_guardrails.record_tool_result(
+                        function_name,
+                        failed=is_error,
+                    )
+                except Exception:
+                    pass
                 try:
                     agent._record_file_mutation_result(
                         function_name, function_args, function_result, is_error,
@@ -507,10 +522,13 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
             pass
 
         _guardrail_block_decision: ToolGuardrailDecision | None = None
+        _guardrail_warn_decision: ToolGuardrailDecision | None = None
         if _block_msg is None:
             guardrail_decision = agent._tool_guardrails.before_call(function_name, function_args)
             if not guardrail_decision.allows_execution:
                 _guardrail_block_decision = guardrail_decision
+            elif guardrail_decision.action == "warn":
+                _guardrail_warn_decision = guardrail_decision
 
         _execution_blocked = _block_msg is not None or _guardrail_block_decision is not None
 
@@ -797,6 +815,11 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                 function_result,
                 failed=_is_error_result,
             )
+            if _guardrail_warn_decision is not None:
+                function_result = append_toolguard_guidance(
+                    function_result,
+                    _guardrail_warn_decision,
+                )
             result_preview = function_result if agent.verbose_logging else (
                 function_result[:200] if len(function_result) > 200 else function_result
             )
@@ -810,6 +833,13 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
         # the same state so the footer reflects every tool call in the
         # turn, not just the parallel ones.
         if not _execution_blocked:
+            try:
+                agent._workflow_guardrails.record_tool_result(
+                    function_name,
+                    failed=_is_error_result,
+                )
+            except Exception:
+                pass
             try:
                 agent._record_file_mutation_result(
                     function_name, function_args, function_result, _is_error_result,

--- a/agent/tool_guardrails.py
+++ b/agent/tool_guardrails.py
@@ -61,6 +61,55 @@ MUTATING_TOOL_NAMES = frozenset(
 
 
 @dataclass(frozen=True)
+class ToolPrerequisiteRule:
+    """A lightweight Forge-style prerequisite for tool calls.
+
+    Rules are intentionally coarse and advisory by default. They nudge the
+    model toward proven tool order without breaking existing sessions that
+    legitimately carry prerequisite context from a previous user turn.
+    """
+
+    required_any: tuple[str, ...]
+    message: str
+
+
+DEFAULT_PREREQUISITE_RULES: dict[str, ToolPrerequisiteRule] = {
+    "browser_back": ToolPrerequisiteRule(
+        required_any=("browser_navigate",),
+        message="Call browser_navigate before browser_back so there is browser history to go back through.",
+    ),
+    "browser_click": ToolPrerequisiteRule(
+        required_any=("browser_navigate", "browser_snapshot", "browser_vision"),
+        message="Get a fresh browser snapshot or navigate first so element refs are valid before clicking.",
+    ),
+    "browser_type": ToolPrerequisiteRule(
+        required_any=("browser_navigate", "browser_snapshot", "browser_vision"),
+        message="Get a fresh browser snapshot or navigate first so the input ref is valid before typing.",
+    ),
+    "browser_press": ToolPrerequisiteRule(
+        required_any=("browser_navigate", "browser_snapshot", "browser_vision"),
+        message="Navigate or inspect the page before sending keyboard input.",
+    ),
+    "browser_scroll": ToolPrerequisiteRule(
+        required_any=("browser_navigate", "browser_snapshot", "browser_vision"),
+        message="Navigate or inspect the page before scrolling it.",
+    ),
+    "browser_console": ToolPrerequisiteRule(
+        required_any=("browser_navigate",),
+        message="Open a browser page with browser_navigate before reading console output.",
+    ),
+    "browser_get_images": ToolPrerequisiteRule(
+        required_any=("browser_navigate",),
+        message="Open a browser page with browser_navigate before listing images.",
+    ),
+    "patch": ToolPrerequisiteRule(
+        required_any=("read_file", "search_files"),
+        message="Inspect the target with read_file or search_files before patching so the edit is grounded.",
+    ),
+}
+
+
+@dataclass(frozen=True)
 class ToolCallGuardrailConfig:
     """Thresholds for per-turn tool-call loop detection.
 
@@ -71,6 +120,8 @@ class ToolCallGuardrailConfig:
 
     warnings_enabled: bool = True
     hard_stop_enabled: bool = False
+    prerequisite_checks_enabled: bool = True
+    prerequisite_hard_stop_enabled: bool = False
     exact_failure_warn_after: int = 2
     exact_failure_block_after: int = 5
     same_tool_failure_warn_after: int = 3
@@ -97,6 +148,14 @@ class ToolCallGuardrailConfig:
         return cls(
             warnings_enabled=_as_bool(data.get("warnings_enabled"), defaults.warnings_enabled),
             hard_stop_enabled=_as_bool(data.get("hard_stop_enabled"), defaults.hard_stop_enabled),
+            prerequisite_checks_enabled=_as_bool(
+                data.get("prerequisite_checks_enabled"),
+                defaults.prerequisite_checks_enabled,
+            ),
+            prerequisite_hard_stop_enabled=_as_bool(
+                data.get("prerequisite_hard_stop_enabled"),
+                defaults.prerequisite_hard_stop_enabled,
+            ),
             exact_failure_warn_after=_positive_int(
                 warn_after.get("exact_failure", data.get("exact_failure_warn_after")),
                 defaults.exact_failure_warn_after,
@@ -232,6 +291,8 @@ class ToolCallGuardrailController:
         self._exact_failure_counts: dict[ToolCallSignature, int] = {}
         self._same_tool_failure_counts: dict[str, int] = {}
         self._no_progress: dict[ToolCallSignature, tuple[str, int]] = {}
+        self._successful_tools: set[str] = set()
+        self._successful_tool_actions: set[tuple[str, str]] = set()
         self._halt_decision: ToolGuardrailDecision | None = None
 
     @property
@@ -239,46 +300,55 @@ class ToolCallGuardrailController:
         return self._halt_decision
 
     def before_call(self, tool_name: str, args: Mapping[str, Any] | None) -> ToolGuardrailDecision:
-        signature = ToolCallSignature.from_call(tool_name, _coerce_args(args))
-        if not self.config.hard_stop_enabled:
-            return ToolGuardrailDecision(tool_name=tool_name, signature=signature)
+        args = _coerce_args(args)
+        signature = ToolCallSignature.from_call(tool_name, args)
+        prereq_decision = self._check_prerequisite(tool_name, args, signature)
 
-        exact_count = self._exact_failure_counts.get(signature, 0)
-        if exact_count >= self.config.exact_failure_block_after:
-            decision = ToolGuardrailDecision(
-                action="block",
-                code="repeated_exact_failure_block",
-                message=(
-                    f"Blocked {tool_name}: the same tool call failed {exact_count} "
-                    "times with identical arguments. Stop retrying it unchanged; "
-                    "change strategy or explain the blocker."
-                ),
-                tool_name=tool_name,
-                count=exact_count,
-                signature=signature,
-            )
-            self._halt_decision = decision
-            return decision
+        # Existing hard-stop loop breakers must keep priority over new soft
+        # prerequisite nudges. Otherwise a missing-prerequisite warning could
+        # mask a repeated exact-failure block for the same call.
+        if self.config.hard_stop_enabled:
+            exact_count = self._exact_failure_counts.get(signature, 0)
+            if exact_count >= self.config.exact_failure_block_after:
+                decision = ToolGuardrailDecision(
+                    action="block",
+                    code="repeated_exact_failure_block",
+                    message=(
+                        f"Blocked {tool_name}: the same tool call failed {exact_count} "
+                        "times with identical arguments. Stop retrying it unchanged; "
+                        "change strategy or explain the blocker."
+                    ),
+                    tool_name=tool_name,
+                    count=exact_count,
+                    signature=signature,
+                )
+                self._halt_decision = decision
+                return decision
 
-        if self._is_idempotent(tool_name):
-            record = self._no_progress.get(signature)
-            if record is not None:
-                _result_hash, repeat_count = record
-                if repeat_count >= self.config.no_progress_block_after:
-                    decision = ToolGuardrailDecision(
-                        action="block",
-                        code="idempotent_no_progress_block",
-                        message=(
-                            f"Blocked {tool_name}: this read-only call returned the same "
-                            f"result {repeat_count} times. Stop repeating it unchanged; "
-                            "use the result already provided or try a different query."
-                        ),
-                        tool_name=tool_name,
-                        count=repeat_count,
-                        signature=signature,
-                    )
-                    self._halt_decision = decision
-                    return decision
+            if self._is_idempotent(tool_name):
+                record = self._no_progress.get(signature)
+                if record is not None:
+                    _result_hash, repeat_count = record
+                    if repeat_count >= self.config.no_progress_block_after:
+                        decision = ToolGuardrailDecision(
+                            action="block",
+                            code="idempotent_no_progress_block",
+                            message=(
+                                f"Blocked {tool_name}: this read-only call returned the same "
+                                f"result {repeat_count} times. Stop repeating it unchanged; "
+                                "use the result already provided or try a different query."
+                            ),
+                            tool_name=tool_name,
+                            count=repeat_count,
+                            signature=signature,
+                        )
+                        self._halt_decision = decision
+                        return decision
+
+        if prereq_decision is not None:
+            if prereq_decision.should_halt:
+                self._halt_decision = prereq_decision
+            return prereq_decision
 
         return ToolGuardrailDecision(tool_name=tool_name, signature=signature)
 
@@ -344,6 +414,7 @@ class ToolCallGuardrailController:
 
             return ToolGuardrailDecision(tool_name=tool_name, count=exact_count, signature=signature)
 
+        self._record_success(tool_name, args)
         self._exact_failure_counts.pop(signature, None)
         self._same_tool_failure_counts.pop(tool_name, None)
 
@@ -379,6 +450,95 @@ class ToolCallGuardrailController:
             return False
         return tool_name in self.config.idempotent_tools
 
+    def _check_prerequisite(
+        self,
+        tool_name: str,
+        args: Mapping[str, Any],
+        signature: ToolCallSignature,
+    ) -> ToolGuardrailDecision | None:
+        if not self.config.prerequisite_checks_enabled:
+            return None
+
+        if not self.config.prerequisite_hard_stop_enabled and not self.config.warnings_enabled:
+            return None
+
+        rule = _dynamic_prerequisite_rule(tool_name, args) or DEFAULT_PREREQUISITE_RULES.get(tool_name)
+        if rule is None:
+            return None
+        if any(self._has_successful_requirement(required) for required in rule.required_any):
+            return None
+
+        action = "block" if self.config.prerequisite_hard_stop_enabled else "warn"
+        code = (
+            "missing_tool_prerequisite_block"
+            if self.config.prerequisite_hard_stop_enabled
+            else "missing_tool_prerequisite_warning"
+        )
+        required = ", ".join(rule.required_any)
+        return ToolGuardrailDecision(
+            action=action,
+            code=code,
+            message=(
+                f"{tool_name} is being called before its recommended prerequisite "
+                f"tool(s): {required}. {rule.message} If the prerequisite was "
+                "already satisfied in earlier conversation context, proceed carefully; "
+                "otherwise call the prerequisite first."
+            ),
+            tool_name=tool_name,
+            count=0,
+            signature=signature,
+        )
+
+    def _record_success(self, tool_name: str, args: Mapping[str, Any]) -> None:
+        self._successful_tools.add(tool_name)
+        action = args.get("action")
+        if isinstance(action, str) and action:
+            self._successful_tool_actions.add((tool_name, action))
+
+    def _has_successful_requirement(self, requirement: str) -> bool:
+        if ":" not in requirement:
+            return requirement in self._successful_tools
+        tool_name, action = requirement.split(":", 1)
+        return (tool_name, action) in self._successful_tool_actions
+
+
+def _dynamic_prerequisite_rule(
+    tool_name: str,
+    args: Mapping[str, Any],
+) -> ToolPrerequisiteRule | None:
+    """Return argument-sensitive prerequisite rules.
+
+    These capture Hermes-specific workflow contracts from the tool docs without
+    needing a separate workflow engine.
+    """
+    if tool_name == "send_message":
+        action = str(args.get("action") or "send")
+        target = str(args.get("target") or "")
+        named_target = ":" in target or "#" in target
+        if action == "send" and named_target:
+            return ToolPrerequisiteRule(
+                required_any=("send_message:list",),
+                message="Use send_message(action='list') before sending to a named channel/person so the target is verified.",
+            )
+
+    if tool_name == "cronjob":
+        action = str(args.get("action") or "")
+        if action in {"update", "pause", "resume", "remove", "run"}:
+            return ToolPrerequisiteRule(
+                required_any=("cronjob:list",),
+                message="Use cronjob(action='list') before managing an existing job so the job_id is verified.",
+            )
+
+    if tool_name == "process":
+        action = str(args.get("action") or "")
+        if action and action != "list":
+            return ToolPrerequisiteRule(
+                required_any=("terminal", "process"),
+                message="Use process(action='list') or start/observe a terminal background process before acting on a process session_id.",
+            )
+
+    return None
+
 
 def toolguard_synthetic_result(decision: ToolGuardrailDecision) -> str:
     """Build a synthetic role=tool content string for a blocked tool call."""
@@ -391,9 +551,15 @@ def toolguard_synthetic_result(decision: ToolGuardrailDecision) -> str:
     )
 
 
-def append_toolguard_guidance(result: str, decision: ToolGuardrailDecision) -> str:
-    """Append runtime guidance to the current tool result content."""
+def append_toolguard_guidance(result: Any, decision: ToolGuardrailDecision) -> Any:
+    """Append runtime guidance to the current tool result content.
+
+    Most tool results are strings. Multimodal results may be dict/list payloads;
+    leave them unchanged rather than corrupting the structured content.
+    """
     if decision.action not in {"warn", "halt"} or not decision.message:
+        return result
+    if not isinstance(result, str):
         return result
     label = "Tool loop hard stop" if decision.action == "halt" else "Tool loop warning"
     suffix = (

--- a/agent/tool_guardrails.py
+++ b/agent/tool_guardrails.py
@@ -582,6 +582,12 @@ def _tool_failure_recovery_hint(tool_name: str, count: int) -> str:
             "in the same tool, then try an absolute path, a simpler command, a different "
             "working directory, or a different tool such as read_file/write_file/patch."
         )
+    if tool_name == "patch":
+        return common + (
+            "For repeated patch failures, stop trying the same old_string. Re-read the "
+            "target with read_file/search_files, choose a smaller exact context, or switch "
+            "to write_file only when replacing the whole file is safer and scoped."
+        )
     return common + (
         "Try different arguments, a narrower query/path, an absolute path when relevant, "
         "or a different tool that can make progress. If the blocker is external, report "

--- a/agent/workflow_guardrails.py
+++ b/agent/workflow_guardrails.py
@@ -1,0 +1,285 @@
+"""Forge-style workflow guardrail primitives for Hermes.
+
+This module is intentionally side-effect free. Runtime code tells the
+controller which user turn started, which tools succeeded, and what final
+response the model wants to return; the controller returns advisory/gate
+decisions. Default config is compatibility-first: missing workflow steps are
+reported as a footer, not blocked.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Iterable, Mapping
+
+
+@dataclass(frozen=True)
+class WorkflowStep:
+    """A required workflow step satisfied by one of several tool names."""
+
+    key: str
+    label: str
+    required_any: tuple[str, ...] = ()
+    description: str = ""
+
+
+@dataclass(frozen=True)
+class WorkflowSpec:
+    """Workflow-level required step specification."""
+
+    key: str
+    label: str
+    triggers_any: tuple[str, ...]
+    steps: tuple[WorkflowStep, ...]
+
+
+@dataclass(frozen=True)
+class WorkflowGuardrailConfig:
+    """Config for workflow-level final gates.
+
+    final_gate_mode:
+      - off:      disable workflow final evaluation entirely
+      - advisory: append/report missing-step advisory but allow final response
+      - nudge:    ask the model to continue once before allowing final response
+      - block:    return a controlled missing-step response instead of final
+    """
+
+    enabled: bool = False
+    final_gate_mode: str = "off"
+    max_nudges: int = 1
+
+    @classmethod
+    def from_mapping(cls, data: Mapping[str, Any] | None) -> "WorkflowGuardrailConfig":
+        if not isinstance(data, Mapping):
+            return cls()
+        defaults = cls()
+        mode = str(data.get("final_gate_mode", defaults.final_gate_mode) or "").strip().lower()
+        if mode not in {"off", "advisory", "nudge", "block"}:
+            mode = defaults.final_gate_mode
+        return cls(
+            enabled=_as_bool(data.get("enabled"), defaults.enabled),
+            final_gate_mode=mode,
+            max_nudges=_positive_int(data.get("max_nudges"), defaults.max_nudges),
+        )
+
+
+@dataclass(frozen=True)
+class WorkflowGuardrailDecision:
+    """Decision returned when a final response is evaluated."""
+
+    action: str = "allow"  # allow | advisory | nudge | block
+    workflow_key: str = ""
+    workflow_label: str = ""
+    missing_steps: tuple[WorkflowStep, ...] = ()
+    message: str = ""
+
+    @property
+    def allows_final_response(self) -> bool:
+        return self.action in {"allow", "advisory"}
+
+    def to_metadata(self) -> dict[str, Any]:
+        return {
+            "action": self.action,
+            "workflow_key": self.workflow_key,
+            "workflow_label": self.workflow_label,
+            "missing_steps": [step.key for step in self.missing_steps],
+            "message": self.message,
+        }
+
+
+DEFAULT_WORKFLOWS: tuple[WorkflowSpec, ...] = (
+    WorkflowSpec(
+        key="repo_review",
+        label="Repository review",
+        triggers_any=("repo", "repository", "github.com", "레포", "레포지토리", "검토", "review"),
+        steps=(
+            WorkflowStep("inspect_metadata", "Inspect repo metadata", ("terminal",), "branch/status/remote or package metadata"),
+            WorkflowStep("inspect_docs", "Inspect docs", ("read_file", "search_files"), "README/docs/config discovery"),
+            WorkflowStep("inspect_core", "Inspect core code", ("read_file", "search_files"), "source implementation review"),
+            WorkflowStep("verify", "Run tests or smoke checks", ("terminal", "execute_code"), "tests, import smoke, or explicit unavailable reason"),
+        ),
+    ),
+    WorkflowSpec(
+        key="devflow",
+        label="Code implementation workflow",
+        triggers_any=("implement", "fix", "build", "refactor", "구현", "수정", "고쳐", "개발"),
+        steps=(
+            WorkflowStep("inspect", "Inspect relevant files", ("read_file", "search_files"), "read/search before editing"),
+            WorkflowStep("mutate", "Apply scoped changes", ("patch", "write_file"), "code/config/doc changes"),
+            WorkflowStep("verify", "Run targeted checks", ("terminal", "execute_code"), "tests, py_compile, lint, smoke, or explicit blocker"),
+        ),
+    ),
+    WorkflowSpec(
+        key="weekly_report",
+        label="Weekly report workflow",
+        triggers_any=("weekly report", "주간보고", "주간 보고"),
+        steps=(
+            WorkflowStep("collect", "Collect source material", ("session_search", "read_file", "search_files"), "verified source collection"),
+            WorkflowStep("preview", "Preview draft before sending", ("send_message",), "Telegram/user preview before delivery"),
+        ),
+    ),
+    WorkflowSpec(
+        key="ppt_workflow",
+        label="PPT/deck workflow",
+        triggers_any=("ppt", "powerpoint", "deck", "슬라이드", "발표자료"),
+        steps=(
+            WorkflowStep("read_context", "Read source/context", ("read_file", "search_files"), "source/context inspection"),
+            WorkflowStep("create_artifact", "Create or edit deck artifact", ("write_file", "patch", "terminal", "execute_code"), "deck/artifact generation"),
+            WorkflowStep("visual_or_file_qa", "Run QA", ("terminal", "execute_code", "vision_analyze", "browser_vision"), "layout/file validation"),
+        ),
+    ),
+)
+
+
+class WorkflowGuardrailController:
+    """Per-turn required-step tracker inspired by Forge workflows."""
+
+    def __init__(self, config: WorkflowGuardrailConfig | None = None, workflows: Iterable[WorkflowSpec] | None = None):
+        self.config = config or WorkflowGuardrailConfig()
+        self.workflows = tuple(workflows or DEFAULT_WORKFLOWS)
+        self.reset_for_turn()
+
+    def reset_for_turn(self, user_message: str | None = None) -> None:
+        self._user_message = user_message or ""
+        self._tool_successes: set[str] = set()
+        self._nudges_sent: dict[str, int] = {}
+        self._active_workflows = self._classify_workflows(self._user_message)
+
+    @property
+    def active_workflows(self) -> tuple[WorkflowSpec, ...]:
+        return self._active_workflows
+
+    def record_tool_result(self, tool_name: str, *, failed: bool = False) -> None:
+        if not failed and tool_name:
+            self._tool_successes.add(tool_name)
+
+    def evaluate_final_response(self, final_response: str | None) -> WorkflowGuardrailDecision:
+        if not self.config.enabled or self.config.final_gate_mode == "off":
+            return WorkflowGuardrailDecision()
+        if not final_response or not self._active_workflows:
+            return WorkflowGuardrailDecision()
+
+        workflow = self._active_workflows[0]
+        missing = tuple(
+            step for step in workflow.steps
+            if not any(tool in self._tool_successes for tool in step.required_any)
+        )
+        if not missing:
+            return WorkflowGuardrailDecision(workflow_key=workflow.key, workflow_label=workflow.label)
+
+        message = _format_missing_steps_message(workflow, missing)
+        if self.config.final_gate_mode == "advisory":
+            return WorkflowGuardrailDecision(
+                action="advisory",
+                workflow_key=workflow.key,
+                workflow_label=workflow.label,
+                missing_steps=missing,
+                message=message,
+            )
+        if self.config.final_gate_mode == "nudge":
+            sent = self._nudges_sent.get(workflow.key, 0)
+            if sent < self.config.max_nudges:
+                self._nudges_sent[workflow.key] = sent + 1
+                return WorkflowGuardrailDecision(
+                    action="nudge",
+                    workflow_key=workflow.key,
+                    workflow_label=workflow.label,
+                    missing_steps=missing,
+                    message=message,
+                )
+            return WorkflowGuardrailDecision(
+                action="advisory",
+                workflow_key=workflow.key,
+                workflow_label=workflow.label,
+                missing_steps=missing,
+                message=message,
+            )
+        if self.config.final_gate_mode == "block":
+            return WorkflowGuardrailDecision(
+                action="block",
+                workflow_key=workflow.key,
+                workflow_label=workflow.label,
+                missing_steps=missing,
+                message=message,
+            )
+        return WorkflowGuardrailDecision()
+
+    def _classify_workflows(self, user_message: str) -> tuple[WorkflowSpec, ...]:
+        lowered = (user_message or "").lower()
+        if not lowered:
+            return ()
+        matches = []
+        for workflow in self.workflows:
+            hits = sum(1 for token in workflow.triggers_any if token.lower() in lowered)
+            # Repo review is intentionally stricter: avoid treating every Korean
+            # "검토" as a repository review unless repo/GitHub context is present.
+            if workflow.key == "repo_review":
+                has_repo = any(token in lowered for token in ("repo", "repository", "github.com", "레포", "레포지토리"))
+                has_review = any(token in lowered for token in ("review", "검토"))
+                if has_repo and has_review:
+                    matches.append((10 + hits, workflow))
+                continue
+            if hits:
+                matches.append((hits, workflow))
+        matches.sort(key=lambda item: item[0], reverse=True)
+        return tuple(workflow for _score, workflow in matches[:1])
+
+
+def append_workflow_advisory(response: str, decision: WorkflowGuardrailDecision) -> str:
+    """Append a concise workflow advisory footer to a string response."""
+    if decision.action != "advisory" or not decision.message:
+        return response
+    return response.rstrip() + "\n\n[Workflow guardrail advisory: " + decision.message + "]"
+
+
+def workflow_block_response(decision: WorkflowGuardrailDecision) -> str:
+    return (
+        "I stopped before finalizing because the active workflow is missing "
+        f"required step evidence. {decision.message}"
+    )
+
+
+def workflow_nudge_message(decision: WorkflowGuardrailDecision) -> dict[str, str]:
+    return {
+        "role": "user",
+        "content": (
+            "[System workflow guardrail] You are about to give a final response, "
+            "but required workflow evidence is missing. Complete the missing steps "
+            "with tools if possible, or explicitly state a blocker if a step cannot "
+            f"be performed. Missing: {decision.message}"
+        ),
+    }
+
+
+def _format_missing_steps_message(workflow: WorkflowSpec, missing: tuple[WorkflowStep, ...]) -> str:
+    parts = []
+    for step in missing:
+        tools = "/".join(step.required_any) if step.required_any else "manual evidence"
+        parts.append(f"{step.label} ({tools})")
+    return f"{workflow.label} missing required step evidence: " + "; ".join(parts)
+
+
+def _as_bool(value: Any, default: bool) -> bool:
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return bool(value)
+    if isinstance(value, str):
+        lowered = value.strip().lower()
+        if lowered in {"1", "true", "yes", "on", "enabled"}:
+            return True
+        if lowered in {"0", "false", "no", "off", "disabled"}:
+            return False
+    return default
+
+
+def _positive_int(value: Any, default: int) -> int:
+    if value is None:
+        return default
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return default
+    return parsed if parsed >= 0 else default

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -326,6 +326,11 @@ browser:
 tool_loop_guardrails:
   warnings_enabled: true
   hard_stop_enabled: false
+  # Forge-style prerequisite nudges warn when a tool is called before its
+  # recommended discovery/list/snapshot step. Keep hard-stop mode off unless
+  # you want autonomous sessions to block such calls instead of warning.
+  prerequisite_checks_enabled: true
+  prerequisite_hard_stop_enabled: false
   warn_after:
     exact_failure: 2
     same_tool_failure: 3
@@ -334,6 +339,17 @@ tool_loop_guardrails:
     exact_failure: 5
     same_tool_failure: 8
     idempotent_no_progress: 5
+
+# =============================================================================
+# Workflow Guardrails
+# =============================================================================
+# Forge-style required-step awareness above the raw tool loop. Default is
+# opt-in/off to preserve legacy final-response text exactly. Set
+# final_gate_mode to advisory, nudge, or block for stricter autonomous sessions.
+workflow_guardrails:
+  enabled: false
+  final_gate_mode: off  # off | advisory | nudge | block
+  max_nudges: 1
 
 # =============================================================================
 # Context Compression (Auto-shrinks long conversations)

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -173,6 +173,13 @@ terminal:
   lifetime_seconds: 300
   # sudo_password: "hunter2"  # Optional: pipe a sudo password via sudo -S. SECURITY WARNING: plaintext.
   # sudo_password: ""         # Explicit empty password: try empty and never open the interactive sudo prompt.
+  # Optional RTK-inspired terminal output optimizer. Default off to preserve legacy behavior.
+  output_optimizer:
+    enabled: false
+    min_chars: 4000
+    target_chars: 12000
+    raw_output: preserve  # preserve | off
+    storage_dir: /tmp/hermes-terminal-raw
 
 # -----------------------------------------------------------------------------
 # OPTION 2: SSH remote execution

--- a/cli.py
+++ b/cli.py
@@ -10671,42 +10671,188 @@ class HermesCLI:
         import time as _time
 
         with self._approval_lock:
-            timeout = int(CLI_CONFIG.get("approvals", {}).get("timeout", 60))
+            try:
+                from hermes_cli.config import load_config as _load_full_config
+                _approvals_cfg = (_load_full_config().get("approvals") or {})
+            except Exception:
+                _approvals_cfg = {}
+            try:
+                timeout = int(_approvals_cfg.get("timeout", 60) or 60)
+            except (TypeError, ValueError):
+                timeout = 60
+            notify_target = str(_approvals_cfg.get("notify_target", "") or "").strip()
             response_queue = queue.Queue()
 
+            choices = self._approval_choices(command, allow_permanent=allow_permanent)
             self._approval_state = {
                 "command": command,
                 "description": description,
-                "choices": self._approval_choices(command, allow_permanent=allow_permanent),
+                "choices": choices,
                 "selected": 0,
                 "response_queue": response_queue,
             }
             self._approval_deadline = _time.monotonic() + timeout
 
+            broker_request_id = None
+            try:
+                from tools.shared_approval_broker import register_cli_approval
+
+                title = self._resolve_approval_session_title()
+                try:
+                    cwd = os.getcwd()
+                except Exception:
+                    cwd = "unknown"
+                broker_request_id = register_cli_approval(
+                    {
+                        "session_key": f"cli:{getattr(self, 'session_id', '') or os.getpid()}",
+                        "session_id": str(getattr(self, "session_id", "") or "unknown"),
+                        "title": title,
+                        "cwd": cwd,
+                        "pid": os.getpid(),
+                        "command": command,
+                        "description": description,
+                        "allow_permanent": allow_permanent,
+                        "notify_target": notify_target,
+                    },
+                    ttl_seconds=timeout,
+                )
+            except Exception as exc:
+                logger.debug("Failed to register shared CLI approval: %s", exc)
+
             self._invalidate()
+            if notify_target:
+                self._send_approval_notification(notify_target, command, description, timeout)
 
             _last_countdown_refresh = _time.monotonic()
-            while True:
-                try:
-                    result = response_queue.get(timeout=1)
-                    self._approval_state = None
-                    self._approval_deadline = 0
-                    self._invalidate()
-                    return result
-                except queue.Empty:
-                    remaining = self._approval_deadline - _time.monotonic()
-                    if remaining <= 0:
-                        break
-                    now = _time.monotonic()
-                    if now - _last_countdown_refresh >= 5.0:
-                        _last_countdown_refresh = now
+            try:
+                while True:
+                    try:
+                        result = response_queue.get(timeout=1)
+                        self._approval_state = None
+                        self._approval_deadline = 0
                         self._invalidate()
+                        return result
+                    except queue.Empty:
+                        if broker_request_id:
+                            try:
+                                from tools.shared_approval_broker import wait_for_cli_approval
+
+                                remote_choice = wait_for_cli_approval(
+                                    broker_request_id,
+                                    timeout_seconds=0,
+                                    poll_interval=0.01,
+                                )
+                            except Exception as exc:
+                                logger.debug("Failed to poll shared CLI approval: %s", exc)
+                                remote_choice = None
+                            if remote_choice:
+                                if remote_choice == "always" and not allow_permanent:
+                                    remote_choice = "session"
+                                self._approval_state = None
+                                self._approval_deadline = 0
+                                self._invalidate()
+                                _cprint(f"\n{_DIM}  ✓ Remote approval received: {remote_choice}{_RST}")
+                                return remote_choice
+                        remaining = self._approval_deadline - _time.monotonic()
+                        if remaining <= 0:
+                            break
+                        now = _time.monotonic()
+                        if now - _last_countdown_refresh >= 5.0:
+                            _last_countdown_refresh = now
+                            self._invalidate()
+            finally:
+                if broker_request_id:
+                    try:
+                        from tools.shared_approval_broker import clear_cli_approval
+
+                        clear_cli_approval(broker_request_id)
+                    except Exception:
+                        pass
 
             self._approval_state = None
             self._approval_deadline = 0
             self._invalidate()
             _cprint(f"\n{_DIM}  ⏱ Timeout — denying command{_RST}")
             return "deny"
+
+    def _resolve_approval_session_title(self) -> str:
+        """Return a human-readable title for approval notifications."""
+        session_id = str(getattr(self, "session_id", "") or "unknown")
+        title = str(getattr(self, "_pending_title", "") or "").strip()
+        session_db = getattr(self, "_session_db", None)
+        if not title and session_db is not None:
+            try:
+                session_meta = session_db.get_session(session_id) or {}
+                title = str(session_meta.get("title") or "").strip()
+            except Exception:
+                title = ""
+        return title or "제목 없음"
+
+    def _build_approval_notification_message(self, command: str, description: str, timeout: int, notify_target: str = "") -> str:
+        """Build the out-of-band CLI approval notification body."""
+        cmd = command.strip().replace("\n", " ")
+        if len(cmd) > 900:
+            cmd = cmd[:900] + "…"
+        desc = (description or "권한 승인이 필요합니다.").strip()
+        if len(desc) > 500:
+            desc = desc[:500] + "…"
+
+        session_id = str(getattr(self, "session_id", "") or "unknown")
+        title = self._resolve_approval_session_title()
+
+        try:
+            cwd = os.getcwd()
+        except Exception:
+            cwd = "unknown"
+
+        try:
+            pid = os.getpid()
+        except Exception:
+            pid = "unknown"
+
+        remote_line = (
+            "원격 승인: Telegram/Gateway에서 /approve, /approve session, /approve always 또는 /deny를 보내면 이 CLI 대기가 해제됩니다."
+            if ":" in str(notify_target or "")
+            else "원격 승인: notify_target이 특정 채팅으로 지정된 경우에만 /approve 또는 /deny로 이 CLI 대기를 해제할 수 있습니다."
+        )
+
+        return textwrap.dedent(f"""\
+        Hermes CLI 권한 승인 요청
+
+        세션: {title}
+        세션 ID: {session_id}
+        작업 위치: {cwd}
+        프로세스: {pid}
+
+        설명: {desc}
+        명령: {cmd}
+        제한시간: {timeout}초
+
+        {remote_line}
+        터미널에서도 기존처럼 once/session/always/deny를 직접 선택할 수 있습니다.
+        """).strip()
+
+    def _send_approval_notification(self, target: str, command: str, description: str, timeout: int) -> None:
+        """Best-effort out-of-band notification for dangerous-command approvals.
+
+        This notifies the user that the terminal is waiting for approval.  The
+        CLI also registers the pending request in the shared broker, so an
+        authenticated gateway /approve or /deny can resolve it remotely.
+        """
+        def _worker() -> None:
+            try:
+                from tools.send_message_tool import send_message_tool as _send_message_tool
+
+                message = self._build_approval_notification_message(command, description, timeout, target)
+                _send_message_tool({"action": "send", "target": target, "message": message})
+            except Exception:
+                pass
+
+        try:
+            import threading as _threading
+            _threading.Thread(target=_worker, name="hermes-approval-notify", daemon=True).start()
+        except Exception:
+            pass
 
     def _approval_choices(self, command: str, *, allow_permanent: bool = True) -> list[str]:
         """Return approval choices for a dangerous command prompt."""

--- a/cli.py
+++ b/cli.py
@@ -7468,6 +7468,17 @@ class HermesCLI:
             return
         self._handle_project_mode_command("office", arg)
 
+    def _handle_commute_command(self):
+        """Print commute-mode usage help in CLI."""
+        try:
+            from gateway.project_sessions import commute_help_text
+            text = commute_help_text()
+        except Exception as exc:
+            _cprint(f"  {_ERR}퇴근모드 도움말 조회 실패: {exc}{_RST}")
+            return
+        for line in text.splitlines():
+            _cprint(f"  {line}")
+
     def _output_console(self):
         """Use prompt_toolkit-safe Rich rendering once the TUI is live."""
         if getattr(self, "_app", None):
@@ -8278,6 +8289,8 @@ class HermesCLI:
             self._handle_afterwork_command(cmd_original)
         elif canonical == "office":
             self._handle_office_command(cmd_original)
+        elif canonical == "commute":
+            self._handle_commute_command()
         elif canonical in self._WORKFLOW_SKILL_WRAPPER_COMMANDS:
             self._handle_workflow_skill_command(cmd_original, canonical)
         elif canonical == "background":

--- a/cli.py
+++ b/cli.py
@@ -2509,6 +2509,7 @@ from agent.skill_commands import (
     get_skill_commands,
     build_skill_invocation_message,
     build_preloaded_skills_prompt,
+    resolve_skill_command_key,
 )
 from agent.skill_bundles import (
     get_skill_bundles,
@@ -7890,6 +7891,42 @@ class HermesCLI:
             print(f"    2. Or configure settings in {display_hermes_home()}/config.yaml")
             print()
     
+    _WORKFLOW_SKILL_WRAPPER_COMMANDS = frozenset({
+        "autopilot",
+        "ralplan",
+        "deep-interview",
+        "verify",
+        "ultraqa",
+        "trace",
+        "deepsearch",
+        "devflow",
+        "tdd",
+    })
+
+    def _handle_workflow_skill_command(self, cmd_original: str, canonical: str) -> None:
+        """Load a workflow skill from a built-in slash-command wrapper."""
+        user_instruction = cmd_original.split(None, 1)[1].strip() if len(cmd_original.split(None, 1)) > 1 else ""
+        skill_cmds = get_skill_commands()
+        cmd_key = resolve_skill_command_key(canonical)
+        if cmd_key is None:
+            ChatConsole().print(
+                f"[bold red]Workflow skill '/{canonical}' is not installed or is disabled.[/]"
+            )
+            ChatConsole().print("[dim]Run /reload-skills after installing or enabling skills.[/]")
+            return
+        msg = build_skill_invocation_message(
+            cmd_key,
+            user_instruction,
+            task_id=self.session_id,
+        )
+        if msg:
+            skill_name = skill_cmds.get(cmd_key, {}).get("name", canonical)
+            print(f"\n⚡ Loading skill: {skill_name}")
+            if hasattr(self, '_pending_input'):
+                self._pending_input.put(msg)
+        else:
+            ChatConsole().print(f"[bold red]Failed to load skill for /{canonical}[/]")
+
     def process_command(self, command: str) -> bool:
         """
         Process a slash command.
@@ -8199,6 +8236,8 @@ class HermesCLI:
             self._handle_agents_command()
         elif canonical == "afterwork":
             self._handle_afterwork_command(cmd_original)
+        elif canonical in self._WORKFLOW_SKILL_WRAPPER_COMMANDS:
+            self._handle_workflow_skill_command(cmd_original, canonical)
         elif canonical == "background":
             self._handle_background_command(cmd_original)
         elif canonical == "queue":

--- a/cli.py
+++ b/cli.py
@@ -7346,6 +7346,87 @@ class HermesCLI:
         except Exception:
             return False
 
+    @staticmethod
+    def _looks_like_afterwork_plaintext(text: str) -> bool:
+        """Return True for exact Korean/plaintext away-mode commands.
+
+        These phrases are intentionally exact-match only so normal Korean chat
+        does not accidentally become a control-plane command. The Enter handler
+        rewrites them to /afterwork before busy-input routing, which prevents
+        the default interrupt mode from killing the current run.
+        """
+        normalized = (text or "").strip().lower()
+        return normalized in {"퇴근", "퇴근모드", "퇴근 모드", "afterwork", "awaymode"}
+
+    def _should_handle_afterwork_command_inline(self, text: str, has_images: bool = False) -> bool:
+        """Return True when away mode should be handled as a command now.
+
+        /afterwork is a control-plane command. If Hermes is busy, routing it
+        through the normal pending/interrupt path is exactly the bug away mode
+        is meant to avoid. Dispatch it on the UI thread like /steer.
+        """
+        if not text or has_images:
+            return False
+        if self._looks_like_afterwork_plaintext(text):
+            return True
+        if not _looks_like_slash_command(text):
+            return False
+        try:
+            from hermes_cli.commands import resolve_command
+            base = text.split(None, 1)[0].lower().lstrip('/')
+            cmd = resolve_command(base)
+            return bool(cmd and cmd.name == "afterwork")
+        except Exception:
+            return False
+
+    def _afterwork_prompt(self) -> tuple[str, Path]:
+        """Build the local away-mode instruction and handoff path."""
+        try:
+            workdir = Path(getattr(self, "cwd", None) or os.getcwd())
+        except Exception:
+            workdir = Path.cwd()
+        handoff = workdir / ".hermes" / "handoff" / "current.md"
+        prompt = (
+            "퇴근모드로 전환해. 현재 진행 중인 작업은 중단하지 말고 계속 진행해. "
+            "먼저 현재 상태, 완료/진행/대기 항목, 다음 계획, 사용자 확인이 필요한 결정을 간단히 정리해. "
+            "가능하면 프로젝트 handoff 파일을 업데이트해: "
+            f"{handoff}. "
+            "막히면 Telegram 알림으로 결정이 필요한 사항만 짧게 보고해."
+        )
+        return prompt, handoff
+
+    def _handle_afterwork_command(self, cmd: str):
+        """Handle /afterwork, /awaymode, /퇴근, /퇴근모드 in the local CLI.
+
+        This is deliberately non-interrupting: when an agent is running, prefer
+        agent.steer() so the instruction lands after the next tool call; if
+        steering is unavailable, queue it for the next turn instead.
+        """
+        prompt, handoff = self._afterwork_prompt()
+        try:
+            handoff.parent.mkdir(parents=True, exist_ok=True)
+        except Exception:
+            pass
+
+        if self._agent_running and self.agent is not None and hasattr(self.agent, "steer"):
+            try:
+                if self.agent.steer(prompt):
+                    _cprint(f"  {_ACCENT}퇴근모드 전환 요청을 현재 작업에 주입했습니다. 작업은 중단하지 않습니다.{_RST}")
+                    _cprint(f"  {_DIM}handoff: {handoff}{_RST}")
+                    return
+            except Exception as exc:
+                _cprint(f"  {_DIM}Steer failed ({exc}) — queued for next turn.{_RST}")
+
+        if hasattr(self, "_pending_input"):
+            self._pending_input.put(prompt)
+            if self._agent_running:
+                _cprint(f"  {_ACCENT}퇴근모드 요청을 다음 턴으로 큐잉했습니다. 현재 작업은 interrupt하지 않습니다.{_RST}")
+            else:
+                _cprint(f"  {_ACCENT}퇴근모드 요청을 시작합니다.{_RST}")
+            _cprint(f"  {_DIM}handoff: {handoff}{_RST}")
+        else:
+            _cprint("  (._.) Cannot enter away mode: input queue is unavailable.")
+
     def _output_console(self):
         """Use prompt_toolkit-safe Rich rendering once the TUI is live."""
         if getattr(self, "_app", None):
@@ -8116,6 +8197,8 @@ class HermesCLI:
             self._handle_stop_command()
         elif canonical == "agents":
             self._handle_agents_command()
+        elif canonical == "afterwork":
+            self._handle_afterwork_command(cmd_original)
         elif canonical == "background":
             self._handle_background_command(cmd_original)
         elif canonical == "queue":
@@ -12333,6 +12416,16 @@ class HermesCLI:
                 # agent.steer() is thread-safe (holds _pending_steer_lock).
                 if self._should_handle_steer_command_inline(text, has_images=has_images):
                     self.process_command(text)
+                    event.app.current_buffer.reset(append_to_history=True)
+                    return
+
+                # Handle away-mode commands before busy-input routing. Plain
+                # Korean commands like "퇴근모드" must not be treated as a
+                # normal busy message, because the default busy mode interrupts
+                # the running task.
+                if self._should_handle_afterwork_command_inline(text, has_images=has_images):
+                    command_text = "/afterwork" if self._looks_like_afterwork_plaintext(text) else text
+                    self.process_command(command_text)
                     event.app.current_buffer.reset(append_to_history=True)
                     return
 

--- a/cli.py
+++ b/cli.py
@@ -10805,32 +10805,54 @@ class HermesCLI:
         except Exception:
             cwd = "unknown"
 
+        if cwd and cwd != "unknown":
+            project = os.path.basename(cwd.rstrip(os.sep)) or cwd
+        else:
+            project = "unknown"
+
         try:
             pid = os.getpid()
         except Exception:
             pid = "unknown"
 
-        remote_line = (
-            "원격 승인: Telegram/Gateway에서 /approve, /approve session, /approve always 또는 /deny를 보내면 이 CLI 대기가 해제됩니다."
-            if ":" in str(notify_target or "")
-            else "원격 승인: notify_target이 특정 채팅으로 지정된 경우에만 /approve 또는 /deny로 이 CLI 대기를 해제할 수 있습니다."
-        )
+        remote_enabled = ":" in str(notify_target or "")
+        if remote_enabled:
+            answer_lines = textwrap.dedent("""\
+            답변 방법:
+            - 이번 1회만 승인: /approve
+            - 이 세션 동안 같은 유형 승인: /approve session
+            - 항상 승인 규칙 저장: /approve always
+            - 거절: /deny
+            """).strip()
+        else:
+            answer_lines = textwrap.dedent("""\
+            답변 방법:
+            - 이 알림은 확인용입니다.
+            - 승인/거절은 현재 열려 있는 Hermes 터미널에서 선택해야 합니다.
+            - 원격 승인을 쓰려면 approvals.notify_target을 telegram:<chat_id>처럼 특정 채팅으로 지정하세요.
+            """).strip()
 
-        return textwrap.dedent(f"""\
-        Hermes CLI 권한 승인 요청
-
-        세션: {title}
-        세션 ID: {session_id}
-        작업 위치: {cwd}
-        프로세스: {pid}
-
-        설명: {desc}
-        명령: {cmd}
-        제한시간: {timeout}초
-
-        {remote_line}
-        터미널에서도 기존처럼 once/session/always/deny를 직접 선택할 수 있습니다.
-        """).strip()
+        return "\n".join([
+            "[Hermes 승인 요청]",
+            "",
+            "무엇을 승인하나요?",
+            f"- 안건: {desc}",
+            f"- 실행 명령: {cmd}",
+            f"- 제한시간: {timeout}초",
+            "",
+            "어디서 요청했나요?",
+            f"- 프로젝트: {project}",
+            f"- 작업 위치: {cwd}",
+            f"- 세션: {title}",
+            f"- 세션 ID: {session_id}",
+            f"- 프로세스: {pid}",
+            "",
+            answer_lines,
+            "",
+            "참고:",
+            "- 자연어 '승인'은 명령이 아닙니다. 위 slash command로 답하세요.",
+            "- 터미널에서도 기존처럼 once/session/always/deny를 직접 선택할 수 있습니다.",
+        ]).strip()
 
     def _send_approval_notification(self, target: str, command: str, description: str, timeout: int) -> None:
         """Best-effort out-of-band notification for dangerous-command approvals.

--- a/cli.py
+++ b/cli.py
@@ -7359,6 +7359,12 @@ class HermesCLI:
         normalized = (text or "").strip().lower()
         return normalized in {"퇴근", "퇴근모드", "퇴근 모드", "afterwork", "awaymode"}
 
+    @staticmethod
+    def _looks_like_office_plaintext(text: str) -> bool:
+        """Return True for exact Korean/plaintext office-mode commands."""
+        normalized = (text or "").strip().lower()
+        return normalized in {"출근", "출근모드", "출근 모드", "office", "morning"}
+
     def _should_handle_afterwork_command_inline(self, text: str, has_images: bool = False) -> bool:
         """Return True when away mode should be handled as a command now.
 
@@ -7368,7 +7374,7 @@ class HermesCLI:
         """
         if not text or has_images:
             return False
-        if self._looks_like_afterwork_plaintext(text):
+        if self._looks_like_afterwork_plaintext(text) or self._looks_like_office_plaintext(text):
             return True
         if not _looks_like_slash_command(text):
             return False
@@ -7376,7 +7382,7 @@ class HermesCLI:
             from hermes_cli.commands import resolve_command
             base = text.split(None, 1)[0].lower().lstrip('/')
             cmd = resolve_command(base)
-            return bool(cmd and cmd.name == "afterwork")
+            return bool(cmd and cmd.name in {"afterwork", "office"})
         except Exception:
             return False
 
@@ -7396,13 +7402,38 @@ class HermesCLI:
         )
         return prompt, handoff
 
+    def _handle_project_mode_command(self, mode: str, target: str = "all") -> bool:
+        """Handle global tmux project away/office mode from the local CLI."""
+        try:
+            from types import SimpleNamespace
+            from gateway.project_sessions import set_mode
+            source = SimpleNamespace(
+                platform=SimpleNamespace(value="local"),
+                chat_id="cli",
+                user_id=None,
+                thread_id=None,
+            )
+            message = set_mode(source, mode, target or "all")
+        except Exception as exc:
+            _cprint(f"  {_ERR}프로젝트 모드 전환 실패: {exc}{_RST}")
+            return False
+        for line in str(message).splitlines():
+            _cprint(f"  {line}")
+        return True
+
     def _handle_afterwork_command(self, cmd: str):
         """Handle /afterwork, /awaymode, /퇴근, /퇴근모드 in the local CLI.
 
-        This is deliberately non-interrupting: when an agent is running, prefer
-        agent.steer() so the instruction lands after the next tool call; if
-        steering is unavailable, queue it for the next turn instead.
+        `/afterwork all|current` is the global tmux project-session away mode.
+        Bare `/afterwork` keeps the local-session compatibility path.
+        Plain Korean `퇴근모드` is rewritten to `/afterwork all` before this
+        handler, so the user's natural command acts as the global commute flow.
         """
+        parts = (cmd or "").split(maxsplit=1)
+        arg = parts[1].strip().lower() if len(parts) > 1 else ""
+        if arg in {"all", "current"}:
+            self._handle_project_mode_command("away", arg)
+            return
         prompt, handoff = self._afterwork_prompt()
         try:
             handoff.parent.mkdir(parents=True, exist_ok=True)
@@ -7427,6 +7458,15 @@ class HermesCLI:
             _cprint(f"  {_DIM}handoff: {handoff}{_RST}")
         else:
             _cprint("  (._.) Cannot enter away mode: input queue is unavailable.")
+
+    def _handle_office_command(self, cmd: str):
+        """Handle /office, /morning, /출근, /출근모드 in the local CLI."""
+        parts = (cmd or "").split(maxsplit=1)
+        arg = parts[1].strip().lower() if len(parts) > 1 else "all"
+        if arg not in {"all", "current"}:
+            _cprint("  사용: /office [all|current]")
+            return
+        self._handle_project_mode_command("office", arg)
 
     def _output_console(self):
         """Use prompt_toolkit-safe Rich rendering once the TUI is live."""
@@ -8236,6 +8276,8 @@ class HermesCLI:
             self._handle_agents_command()
         elif canonical == "afterwork":
             self._handle_afterwork_command(cmd_original)
+        elif canonical == "office":
+            self._handle_office_command(cmd_original)
         elif canonical in self._WORKFLOW_SKILL_WRAPPER_COMMANDS:
             self._handle_workflow_skill_command(cmd_original, canonical)
         elif canonical == "background":
@@ -12463,7 +12505,12 @@ class HermesCLI:
                 # normal busy message, because the default busy mode interrupts
                 # the running task.
                 if self._should_handle_afterwork_command_inline(text, has_images=has_images):
-                    command_text = "/afterwork" if self._looks_like_afterwork_plaintext(text) else text
+                    if self._looks_like_afterwork_plaintext(text):
+                        command_text = "/afterwork all"
+                    elif self._looks_like_office_plaintext(text):
+                        command_text = "/office all"
+                    else:
+                        command_text = text
                     self.process_command(command_text)
                     event.app.current_buffer.reset(append_to_history=True)
                     return

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1029,6 +1029,10 @@ _PLAINTEXT_GATEWAY_RESTART_PATTERNS: tuple[re.Pattern[str], ...] = (
     re.compile(r"^(?:please\s+)?restart\s+hermes[.!?\s]*$", re.IGNORECASE),
 )
 
+_PLAINTEXT_AFTERWORK_COMMANDS: frozenset[str] = frozenset(
+    {"퇴근", "퇴근모드", "퇴근 모드", "afterwork", "awaymode"}
+)
+
 
 def coerce_plaintext_gateway_command(event: "MessageEvent") -> None:
     """Rewrite a tiny set of DM plaintext admin phrases into slash commands.
@@ -1046,6 +1050,9 @@ def coerce_plaintext_gateway_command(event: "MessageEvent") -> None:
             return
         text = (event.text or "").strip()
         if not text or text.startswith("/"):
+            return
+        if text.lower() in _PLAINTEXT_AFTERWORK_COMMANDS:
+            event.text = "/afterwork"
             return
         source = getattr(event, "source", None)
         if getattr(source, "chat_type", None) != "dm":

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1033,6 +1033,10 @@ _PLAINTEXT_AFTERWORK_COMMANDS: frozenset[str] = frozenset(
     {"퇴근", "퇴근모드", "퇴근 모드", "afterwork", "awaymode"}
 )
 
+_PLAINTEXT_OFFICE_COMMANDS: frozenset[str] = frozenset(
+    {"출근", "출근모드", "출근 모드", "office", "morning"}
+)
+
 
 def coerce_plaintext_gateway_command(event: "MessageEvent") -> None:
     """Rewrite a tiny set of DM plaintext admin phrases into slash commands.
@@ -1051,11 +1055,14 @@ def coerce_plaintext_gateway_command(event: "MessageEvent") -> None:
         text = (event.text or "").strip()
         if not text or text.startswith("/"):
             return
-        if text.lower() in _PLAINTEXT_AFTERWORK_COMMANDS:
-            event.text = "/afterwork"
-            return
         source = getattr(event, "source", None)
         if getattr(source, "chat_type", None) != "dm":
+            return
+        if text.lower() in _PLAINTEXT_AFTERWORK_COMMANDS:
+            event.text = "/afterwork all"
+            return
+        if text.lower() in _PLAINTEXT_OFFICE_COMMANDS:
+            event.text = "/office all"
             return
         for pattern in _PLAINTEXT_GATEWAY_RESTART_PATTERNS:
             if pattern.match(text):

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -2948,10 +2948,28 @@ class TelegramAdapter(BasePlatformAdapter):
                     await query.answer(text="⛔ You are not authorized to approve commands.")
                     return
 
-                session_key = self._approval_state.pop(approval_id, None)
+                session_key = self._approval_state.get(approval_id)
                 if not session_key:
                     await query.answer(text="This approval has already been resolved.")
                     return
+
+                # Resolve the approval first.  The same pending command can also
+                # be resolved by typed /approve or /deny; in that case the button
+                # state may still exist, but resolve_gateway_approval() returns 0.
+                try:
+                    from tools.approval import resolve_gateway_approval
+                    count = resolve_gateway_approval(session_key, choice)
+                except Exception as exc:
+                    logger.error("Failed to resolve gateway approval from Telegram button: %s", exc)
+                    await query.answer(text="Failed to resolve approval.")
+                    return
+
+                if not count:
+                    self._approval_state.pop(approval_id, None)
+                    await query.answer(text="This approval has already been resolved.")
+                    return
+
+                self._approval_state.pop(approval_id, None)
 
                 # Map choice to human-readable label
                 label_map = {
@@ -2975,24 +2993,17 @@ class TelegramAdapter(BasePlatformAdapter):
                 except Exception:
                     pass  # non-fatal if edit fails
 
-                # Resolve the approval — unblocks the agent thread
-                try:
-                    from tools.approval import resolve_gateway_approval
-                    count = resolve_gateway_approval(session_key, choice)
-                    logger.info(
-                        "Telegram button resolved %d approval(s) for session %s (choice=%s, user=%s)",
-                        count, session_key, choice, user_display,
-                    )
-                except Exception as exc:
-                    logger.error("Failed to resolve gateway approval from Telegram button: %s", exc)
-                    count = 0
+                logger.info(
+                    "Telegram button resolved %d approval(s) for session %s (choice=%s, user=%s)",
+                    count, session_key, choice, user_display,
+                )
 
                 # Resume the typing indicator — paused when the approval was
                 # sent (gateway/run.py).  The text /approve and /deny paths
                 # call resume_typing_for_chat here too; without it, typing
                 # stays paused for the rest of the turn after an inline
                 # button click.
-                if count and query_chat_id is not None:
+                if query_chat_id is not None:
                     self.resume_typing_for_chat(str(query_chat_id))
             return
 

--- a/gateway/project_sessions.py
+++ b/gateway/project_sessions.py
@@ -192,6 +192,42 @@ def find_project(state: ProjectRoutingState, label_or_alias: str) -> ProjectSess
     return None
 
 
+def commute_help_text() -> str:
+    return """[퇴근모드/출근모드 도움말]
+
+개념:
+- 퇴근모드: tmux의 프로젝트 Hermes 세션은 계속 터미널에서 돌고, Telegram으로도 결과/막힘/결정 필요 사항을 받는 모드
+- 출근모드: Telegram relay를 끄고 다시 tmux 터미널 중심으로 보는 모드
+- 승인 요청은 별도입니다. 작업 지시는 [label] 형식, 승인은 /approve 또는 /deny를 사용하세요.
+
+기본 순서:
+1. /projects
+   - 감지된 프로젝트 label 확인
+2. /switch <번호|label>
+   - Telegram의 현재 대상 프로젝트 선택
+3. /current
+   - 현재 선택 확인
+4. /afterwork current
+   - 선택한 프로젝트만 퇴근모드
+   또는 /afterwork all
+   - 감지된 모든 프로젝트 퇴근모드
+5. [label] <지시>
+   - 퇴근모드 중 특정 프로젝트에 지시 전달
+   예: [llm-eval-pipeline] 다음 작업 진행해줘
+6. /office current 또는 /office all
+   - 출근모드로 복귀
+
+자연어 단축:
+- Telegram DM: 퇴근모드 → /afterwork all, 출근모드 → /office all
+- tmux CLI: 퇴근모드 → /afterwork all, 출근모드 → /office all
+
+주의:
+- /afterwork all은 work/personal을 포함해 감지된 모든 tmux 프로젝트에 /steer를 보낼 수 있습니다.
+- 처음에는 /afterwork current로 한 프로젝트만 테스트하는 것을 권장합니다.
+- 긴 로그 확인은 tmux/Termius가 적합하고, Telegram은 요약/결정/짧은 지시용입니다.
+""".strip()
+
+
 def format_projects(state: ProjectRoutingState, source: Any | None = None) -> str:
     if not state.projects:
         return "[프로젝트 세션]\n등록/감지된 tmux 프로젝트 세션이 없습니다. 프로젝트 디렉토리에서 Hermes를 실행한 뒤 다시 시도하세요."

--- a/gateway/project_sessions.py
+++ b/gateway/project_sessions.py
@@ -22,6 +22,8 @@ STATE_VERSION = 1
 STATE_FILENAME = "project_sessions.json"
 _PROJECT_PREFIX_RE = re.compile(r"^\s*\[([^\]\n]{1,80})\]\s*(.+?)\s*$", re.DOTALL)
 _BROAD_ROOT_NAMES = {"", "/", "~", "home", "work", "workspace", "desktop", "documents", "downloads"}
+_HERMES_COMMAND_RE = re.compile(r"^(?:hermes(?:\.exe)?|python(?:\d+(?:\.\d+)*)?|pythonw)$", re.IGNORECASE)
+_SHELL_COMMANDS = {"sh", "bash", "zsh", "fish", "pwsh", "powershell", "cmd", "nu"}
 
 
 @dataclass
@@ -34,6 +36,9 @@ class ProjectSession:
     status: str = "active"
     notify: bool = False
     last_seen_at: float = field(default_factory=time.time)
+    command: str = ""
+    routable: bool = False
+    last_away_snapshot_path: str | None = None
 
 
 @dataclass
@@ -80,7 +85,14 @@ def load_state(path: Path | None = None) -> ProjectRoutingState:
             try:
                 projects[label] = ProjectSession(**item)
             except TypeError:
-                continue
+                # Older records may have unknown keys in future/downgrade paths;
+                # keep the known fields instead of discarding the project.
+                known = {f.name for f in ProjectSession.__dataclass_fields__.values()}
+                filtered = {k: v for k, v in item.items() if k in known}
+                try:
+                    projects[label] = ProjectSession(**filtered)
+                except TypeError:
+                    continue
     return ProjectRoutingState(
         version=int(raw.get("version") or STATE_VERSION),
         mode=str(raw.get("mode") or "office"),
@@ -119,6 +131,43 @@ def _looks_like_project_dir(path: Path) -> bool:
     return any(marker.exists() for marker in markers)
 
 
+def _looks_like_hermes_pane(command: str) -> bool:
+    """Return whether a tmux pane is safe to receive Hermes /steer input.
+
+    tmux exposes only the current foreground command, not the full argv.  Hermes
+    normally appears as ``hermes`` or as the Python interpreter that launched the
+    installed CLI.  Shell/editor/server panes are intentionally not routable even
+    if their cwd is a valid project directory.
+    """
+    name = Path((command or "").strip()).name.lower()
+    if not name or name in _SHELL_COMMANDS:
+        return False
+    return bool(_HERMES_COMMAND_RE.match(name))
+
+
+def _status_for(command: str, *, discovered: bool = True) -> str:
+    if not discovered:
+        return "stale"
+    return "ready" if _looks_like_hermes_pane(command) else "shell-only"
+
+
+def _status_label(project: ProjectSession) -> str:
+    if project.status == "ready" and project.routable:
+        return "READY"
+    if project.status == "stale":
+        return "STALE"
+    return "SHELL-ONLY"
+
+
+def _non_routable_reason(project: ProjectSession) -> str | None:
+    if project.status == "stale":
+        return "tmux target이 현재 감지되지 않는 STALE 프로젝트입니다. /projects로 목록을 갱신한 뒤 다시 선택하세요."
+    if not project.routable:
+        command = project.command or "unknown"
+        return f"현재 tmux pane은 Hermes 세션이 아닙니다(command={command}). tmux에서 Hermes를 실행한 뒤 다시 시도하세요."
+    return None
+
+
 def _default_label(session: str, window: str, cwd: Path, used: set[str]) -> str:
     # Prefer tmux window names when they look human-meaningful; otherwise use the
     # project directory name. Deduplicate deterministically.
@@ -153,6 +202,7 @@ def discover_tmux_projects() -> list[ProjectSession]:
         tmux_target = f"{session}:{window_index}.{pane_index}"
         handoff = cwd / ".hermes" / "handoff" / "current.md"
         aliases = [] if cwd.name == label else [cwd.name]
+        status = _status_for(command)
         sessions.append(
             ProjectSession(
                 label=label,
@@ -160,8 +210,10 @@ def discover_tmux_projects() -> list[ProjectSession]:
                 workdir=str(cwd),
                 aliases=aliases,
                 handoff_path=str(handoff),
-                status="active",
+                status=status,
                 notify=False,
+                command=command,
+                routable=status == "ready",
             )
         )
     return sessions
@@ -169,19 +221,33 @@ def discover_tmux_projects() -> list[ProjectSession]:
 
 def refresh_from_tmux(state: ProjectRoutingState | None = None) -> ProjectRoutingState:
     state = state or load_state()
-    for discovered in discover_tmux_projects():
-        existing = state.projects.get(discovered.label)
+    discovered = {project.label: project for project in discover_tmux_projects()}
+    seen: set[str] = set()
+    for label, project in discovered.items():
+        seen.add(label)
+        existing = state.projects.get(label)
         if existing:
-            existing.tmux_target = discovered.tmux_target
-            existing.workdir = discovered.workdir
-            existing.handoff_path = discovered.handoff_path
-            existing.status = "active"
+            existing.tmux_target = project.tmux_target
+            existing.workdir = project.workdir
+            existing.handoff_path = project.handoff_path
+            existing.status = project.status
+            existing.command = project.command
+            existing.routable = project.routable
             existing.last_seen_at = time.time()
-            for alias in discovered.aliases:
+            # A shell-only/stale pane must not keep a previous away-mode relay.
+            if not existing.routable:
+                existing.notify = False
+            for alias in project.aliases:
                 if alias not in existing.aliases:
                     existing.aliases.append(alias)
         else:
-            state.projects[discovered.label] = discovered
+            state.projects[label] = project
+    for label, project in state.projects.items():
+        if label in seen:
+            continue
+        project.status = "stale"
+        project.routable = False
+        project.notify = False
     return state
 
 
@@ -206,35 +272,35 @@ def commute_help_text() -> str:
     return """[퇴근모드/출근모드 도움말]
 
 개념:
-- 퇴근모드: tmux의 프로젝트 Hermes 세션은 계속 터미널에서 돌고, Telegram으로도 결과/막힘/결정 필요 사항을 받는 모드
+- 퇴근모드: tmux의 READY Hermes 프로젝트 세션은 계속 터미널에서 돌고, Telegram으로도 결과/막힘/결정 필요 사항을 받는 모드
 - 출근모드: Telegram relay를 끄고 다시 tmux 터미널 중심으로 보는 모드
 - 승인 요청은 별도입니다. 작업 지시는 [label] 형식, 승인은 /approve 또는 /deny를 사용하세요.
 
 기본 순서:
 1. /projects
-   - 감지된 프로젝트 label 확인
+   - 감지된 프로젝트 label과 READY/SHELL-ONLY/STALE 상태 확인
 2. 퇴근모드 또는 /afterwork all
-   - 감지된 모든 프로젝트를 퇴근모드로 전환
+   - READY 프로젝트만 퇴근모드로 전환하고, SHELL-ONLY/STALE 프로젝트는 제외
 3. [label] <지시>
-   - 퇴근모드 중 특정 프로젝트에 지시 전달
+   - 퇴근모드 중 READY 프로젝트에 지시 전달
    예: [llm-eval-pipeline] 다음 작업 진행해줘
 4. 출근모드 또는 /office all
-   - 모든 프로젝트를 출근모드로 복귀
+   - READY 프로젝트를 출근모드로 복귀
 
 현재 프로젝트에만 지시:
 - /switch <번호|label> 후 /psend <지시>
-- /psend는 선택된 프로젝트 tmux pane에 /steer로 전달합니다.
+- /psend는 선택된 READY 프로젝트 tmux pane에 /steer로 전달합니다.
 
 고급/테스트 옵션:
-- /afterwork current: 선택한 프로젝트만 퇴근모드
-- /office current: 선택한 프로젝트만 출근모드
+- /afterwork current: 선택한 READY 프로젝트만 퇴근모드
+- /office current: 선택한 READY 프로젝트만 출근모드
 
 자연어 단축:
 - Telegram DM: 퇴근모드 → /afterwork all, 출근모드 → /office all
 - tmux CLI: 퇴근모드 → /afterwork all, 출근모드 → /office all
 
 주의:
-- /afterwork all은 work/personal을 포함해 감지된 모든 tmux 프로젝트에 /steer를 보낼 수 있습니다.
+- SHELL-ONLY는 프로젝트 디렉토리의 일반 shell pane입니다. Hermes 세션이 아니므로 /psend와 퇴근모드 전달 대상에서 제외됩니다.
 - 긴 로그 확인은 tmux/Termius가 적합하고, Telegram은 요약/결정/짧은 지시용입니다.
 """.strip()
 
@@ -247,12 +313,19 @@ def format_projects(state: ProjectRoutingState, source: Any | None = None) -> st
     for i, project in enumerate(sorted(state.projects.values(), key=lambda p: p.label.lower()), 1):
         marker = " *active*" if active and project.label == active else ""
         aliases = f" / aliases: {', '.join(project.aliases)}" if project.aliases else ""
+        state_label = _status_label(project)
         lines.extend([
-            f"{i}. [{project.label}]{marker}{aliases}",
+            f"{i}. [{project.label}] {state_label}{marker}{aliases}",
             f"   - tmux: {project.tmux_target}",
+            f"   - command: {project.command or '-'}",
             f"   - cwd: {project.workdir}",
             f"   - notify: {'on' if project.notify else 'off'}",
         ])
+        reason = _non_routable_reason(project)
+        if reason:
+            lines.append(f"   - Telegram 지시: 불가 — {reason}")
+        else:
+            lines.append("   - Telegram 지시: 가능")
     lines.extend(["", "사용:", " /switch <번호|label>", " /psend <지시>", " [label] <지시>"])
     return "\n".join(lines)
 
@@ -265,7 +338,17 @@ def switch_project(source: Any, target: str, *, path: Path | None = None) -> str
         return f"프로젝트 `{target}`를 찾지 못했습니다.\n\n{format_projects(state, source)}"
     state.active_by_chat[_source_key(source)] = project.label
     save_state(state, path)
-    return f"[전환 완료]\n현재 Telegram 대상: [{project.label}]\n- tmux: {project.tmux_target}\n- cwd: {project.workdir}"
+    reason = _non_routable_reason(project)
+    if reason:
+        return (
+            f"[전환 완료: 주의]\n현재 Telegram 대상: [{project.label}]\n"
+            f"- 상태: {_status_label(project)}\n- tmux: {project.tmux_target}\n"
+            f"- command: {project.command or '-'}\n- cwd: {project.workdir}\n\n주의: {reason}"
+        )
+    return (
+        f"[전환 완료]\n현재 Telegram 대상: [{project.label}]\n"
+        f"- 상태: READY\n- tmux: {project.tmux_target}\n- cwd: {project.workdir}"
+    )
 
 
 def current_project(source: Any, *, path: Path | None = None) -> str:
@@ -275,7 +358,19 @@ def current_project(source: Any, *, path: Path | None = None) -> str:
     save_state(state, path)
     if not project:
         return "현재 선택된 프로젝트가 없습니다. /projects 후 /switch <번호|label>을 사용하세요."
-    return f"[현재 프로젝트]\n[{project.label}]\n- tmux: {project.tmux_target}\n- cwd: {project.workdir}\n- handoff: {project.handoff_path or '-'}\n- notify: {'on' if project.notify else 'off'}"
+    reason = _non_routable_reason(project)
+    lines = [
+        "[현재 프로젝트]",
+        f"[{project.label}] {_status_label(project)}",
+        f"- tmux: {project.tmux_target}",
+        f"- command: {project.command or '-'}",
+        f"- cwd: {project.workdir}",
+        f"- handoff: {project.handoff_path or '-'}",
+        f"- notify: {'on' if project.notify else 'off'}",
+    ]
+    if reason:
+        lines.extend(["", f"주의: {reason}"])
+    return "\n".join(lines)
 
 
 def parse_project_prefix(text: str) -> tuple[str, str] | None:
@@ -294,6 +389,42 @@ def _send_to_tmux(project: ProjectSession, prompt: str) -> None:
         timeout=5,
         check=True,
     )
+
+
+def _capture_pane(project: ProjectSession, lines: int = 80) -> str:
+    if not project.tmux_target:
+        return ""
+    output = _run_tmux(["capture-pane", "-p", "-t", project.tmux_target, "-S", f"-{lines}"])
+    return output.strip()[-4000:]
+
+
+def _write_away_snapshot(project: ProjectSession, *, mode: str, sent: bool, error: str | None = None) -> str | None:
+    try:
+        root = Path(project.workdir).expanduser()
+        snapshot = root / ".hermes" / "handoff" / "telegram-away-snapshot.md"
+        snapshot.parent.mkdir(parents=True, exist_ok=True)
+        pane = _capture_pane(project)
+        now = time.strftime("%Y-%m-%dT%H:%M:%S%z")
+        snapshot.write_text(
+            "# Telegram away-mode snapshot\n\n"
+            f"- updated_at: {now}\n"
+            f"- project: {project.label}\n"
+            f"- mode: {mode}\n"
+            f"- status: {_status_label(project)}\n"
+            f"- routable: {project.routable}\n"
+            f"- tmux_target: {project.tmux_target}\n"
+            f"- command: {project.command or '-'}\n"
+            f"- workdir: {project.workdir}\n"
+            f"- steer_sent: {sent}\n"
+            f"- error: {error or '-'}\n\n"
+            "## Recent tmux output\n\n"
+            f"```text\n{pane}\n```\n",
+            encoding="utf-8",
+        )
+        project.last_away_snapshot_path = str(snapshot)
+        return str(snapshot)
+    except Exception:
+        return None
 
 
 def _away_instruction(project: ProjectSession) -> str:
@@ -318,6 +449,10 @@ def send_prompt_to_project(source: Any, message: str, *, explicit_label: str | N
     if not project:
         save_state(state, path)
         return "대상 프로젝트가 없습니다. `[label] 지시` 형식으로 보내거나 /projects 후 /switch를 먼저 사용하세요."
+    reason = _non_routable_reason(project)
+    if reason:
+        save_state(state, path)
+        return f"[차단]\n[{project.label}] Telegram 지시를 보낼 수 없습니다.\n- 상태: {_status_label(project)}\n- tmux: {project.tmux_target}\n- command: {project.command or '-'}\n\n{reason}"
     safe_message = (message or "").strip()
     if not safe_message:
         return "전달할 지시가 비어 있습니다. 예: [dev-1] 다음 작업 진행해줘"
@@ -365,8 +500,16 @@ def set_mode(source: Any, mode: str, target: str = "all", *, path: Path | None =
         projects = sorted(state.projects.values(), key=lambda p: p.label.lower())
     changed: list[ProjectSession] = []
     failures: list[str] = []
+    excluded: list[str] = []
     for project in projects:
         if not project:
+            continue
+        reason = _non_routable_reason(project)
+        if reason:
+            project.notify = False
+            if mode == "away":
+                _write_away_snapshot(project, mode=mode, sent=False, error=reason)
+            excluded.append(f"[{project.label}] {_status_label(project)} — {reason}")
             continue
         old_notify = project.notify
         instruction = _away_instruction(project) if mode == "away" else _office_instruction(project)
@@ -374,9 +517,13 @@ def set_mode(source: Any, mode: str, target: str = "all", *, path: Path | None =
             _send_to_tmux(project, f"/steer {instruction}")
         except Exception as exc:
             project.notify = old_notify
+            if mode == "away":
+                _write_away_snapshot(project, mode=mode, sent=False, error=str(exc))
             failures.append(f"[{project.label}] {exc}")
             continue
         project.notify = mode == "away"
+        if mode == "away":
+            _write_away_snapshot(project, mode=mode, sent=True)
         changed.append(project)
     if changed:
         state.mode = mode
@@ -386,9 +533,12 @@ def set_mode(source: Any, mode: str, target: str = "all", *, path: Path | None =
     if changed:
         lines.append("대상:")
         for p in changed:
-            lines.append(f"- [{p.label}] tmux={p.tmux_target} notify={'on' if p.notify else 'off'}")
+            extra = f" snapshot={p.last_away_snapshot_path}" if mode == "away" and p.last_away_snapshot_path else ""
+            lines.append(f"- [{p.label}] tmux={p.tmux_target} notify={'on' if p.notify else 'off'}{extra}")
     else:
-        lines.append("대상 프로젝트가 없습니다. /projects 후 /switch 하거나 프로젝트 tmux 세션을 확인하세요.")
+        lines.append("전환된 READY 프로젝트가 없습니다. /projects로 상태를 확인하거나 프로젝트 tmux pane에서 Hermes를 실행하세요.")
+    if excluded:
+        lines.extend(["", "제외:", *excluded])
     if mode == "away":
         lines.extend(["", "회신 형식:", "[label] 다음 작업 진행해줘", "[label] 멈추고 handoff 정리해줘"])
     if failures:

--- a/gateway/project_sessions.py
+++ b/gateway/project_sessions.py
@@ -64,6 +64,16 @@ def load_state(path: Path | None = None) -> ProjectRoutingState:
         raw = json.loads(path.read_text(encoding="utf-8"))
     except Exception:
         return ProjectRoutingState()
+    # Older builds stored project routing as:
+    # {"active_by_user": {"858...": "label"}, "pinned": {...}}.
+    # Keep reading that file instead of treating it as empty so a user's first
+    # /projects or /current after upgrading does not silently discard intent.
+    legacy_active = raw.get("active_by_user") if isinstance(raw, dict) else None
+    legacy_active_by_chat: dict[str, str] = {}
+    if isinstance(legacy_active, dict) and not raw.get("active_by_chat"):
+        for user_id, label in legacy_active.items():
+            if user_id and label and str(label).strip().lower() not in _BROAD_ROOT_NAMES:
+                legacy_active_by_chat[f"telegram:{user_id}"] = str(label)
     projects: dict[str, ProjectSession] = {}
     for label, item in (raw.get("projects") or {}).items():
         if isinstance(item, dict):
@@ -74,7 +84,7 @@ def load_state(path: Path | None = None) -> ProjectRoutingState:
     return ProjectRoutingState(
         version=int(raw.get("version") or STATE_VERSION),
         mode=str(raw.get("mode") or "office"),
-        active_by_chat=dict(raw.get("active_by_chat") or {}),
+        active_by_chat=dict(raw.get("active_by_chat") or legacy_active_by_chat),
         projects=projects,
         updated_at=float(raw.get("updated_at") or time.time()),
     )
@@ -203,19 +213,21 @@ def commute_help_text() -> str:
 기본 순서:
 1. /projects
    - 감지된 프로젝트 label 확인
-2. /switch <번호|label>
-   - Telegram의 현재 대상 프로젝트 선택
-3. /current
-   - 현재 선택 확인
-4. /afterwork current
-   - 선택한 프로젝트만 퇴근모드
-   또는 /afterwork all
-   - 감지된 모든 프로젝트 퇴근모드
-5. [label] <지시>
+2. 퇴근모드 또는 /afterwork all
+   - 감지된 모든 프로젝트를 퇴근모드로 전환
+3. [label] <지시>
    - 퇴근모드 중 특정 프로젝트에 지시 전달
    예: [llm-eval-pipeline] 다음 작업 진행해줘
-6. /office current 또는 /office all
-   - 출근모드로 복귀
+4. 출근모드 또는 /office all
+   - 모든 프로젝트를 출근모드로 복귀
+
+현재 프로젝트에만 지시:
+- /switch <번호|label> 후 /psend <지시>
+- /psend는 선택된 프로젝트 tmux pane에 /steer로 전달합니다.
+
+고급/테스트 옵션:
+- /afterwork current: 선택한 프로젝트만 퇴근모드
+- /office current: 선택한 프로젝트만 출근모드
 
 자연어 단축:
 - Telegram DM: 퇴근모드 → /afterwork all, 출근모드 → /office all
@@ -223,7 +235,6 @@ def commute_help_text() -> str:
 
 주의:
 - /afterwork all은 work/personal을 포함해 감지된 모든 tmux 프로젝트에 /steer를 보낼 수 있습니다.
-- 처음에는 /afterwork current로 한 프로젝트만 테스트하는 것을 권장합니다.
 - 긴 로그 확인은 tmux/Termius가 적합하고, Telegram은 요약/결정/짧은 지시용입니다.
 """.strip()
 

--- a/gateway/project_sessions.py
+++ b/gateway/project_sessions.py
@@ -1,0 +1,349 @@
+"""Telegram/tmux project-session routing helpers.
+
+This module intentionally keeps the routing layer small and deterministic:
+Gateway commands discover/register tmux panes, store a lightweight profile-local
+registry, and send user prompts to the selected Hermes CLI pane via /steer.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import time
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any, Iterable
+
+from hermes_constants import get_hermes_home
+
+STATE_VERSION = 1
+STATE_FILENAME = "project_sessions.json"
+_PROJECT_PREFIX_RE = re.compile(r"^\s*\[([^\]\n]{1,80})\]\s*(.+?)\s*$", re.DOTALL)
+_BROAD_ROOT_NAMES = {"", "/", "~", "home", "work", "workspace", "desktop", "documents", "downloads"}
+
+
+@dataclass
+class ProjectSession:
+    label: str
+    tmux_target: str
+    workdir: str
+    aliases: list[str] = field(default_factory=list)
+    handoff_path: str | None = None
+    status: str = "active"
+    notify: bool = False
+    last_seen_at: float = field(default_factory=time.time)
+
+
+@dataclass
+class ProjectRoutingState:
+    version: int = STATE_VERSION
+    mode: str = "office"
+    active_by_chat: dict[str, str] = field(default_factory=dict)
+    projects: dict[str, ProjectSession] = field(default_factory=dict)
+    updated_at: float = field(default_factory=time.time)
+
+
+def state_path() -> Path:
+    return get_hermes_home() / STATE_FILENAME
+
+
+def _source_key(source: Any) -> str:
+    platform = getattr(getattr(source, "platform", None), "value", None) or getattr(source, "platform", None) or "unknown"
+    chat_id = getattr(source, "chat_id", None) or getattr(source, "user_id", None) or "unknown"
+    thread_id = getattr(source, "thread_id", None)
+    return f"{platform}:{chat_id}:{thread_id}" if thread_id else f"{platform}:{chat_id}"
+
+
+def load_state(path: Path | None = None) -> ProjectRoutingState:
+    path = path or state_path()
+    if not path.exists():
+        return ProjectRoutingState()
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return ProjectRoutingState()
+    projects: dict[str, ProjectSession] = {}
+    for label, item in (raw.get("projects") or {}).items():
+        if isinstance(item, dict):
+            try:
+                projects[label] = ProjectSession(**item)
+            except TypeError:
+                continue
+    return ProjectRoutingState(
+        version=int(raw.get("version") or STATE_VERSION),
+        mode=str(raw.get("mode") or "office"),
+        active_by_chat=dict(raw.get("active_by_chat") or {}),
+        projects=projects,
+        updated_at=float(raw.get("updated_at") or time.time()),
+    )
+
+
+def save_state(state: ProjectRoutingState, path: Path | None = None) -> None:
+    path = path or state_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    state.updated_at = time.time()
+    payload = asdict(state)
+    tmp = path.with_suffix(path.suffix + f".{os.getpid()}.tmp")
+    tmp.write_text(json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True), encoding="utf-8")
+    os.replace(tmp, path)
+
+
+def _run_tmux(args: list[str]) -> str:
+    proc = subprocess.run(["tmux", *args], text=True, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, timeout=5)
+    if proc.returncode != 0:
+        return ""
+    return proc.stdout
+
+
+def _looks_like_project_dir(path: Path) -> bool:
+    try:
+        resolved = path.expanduser().resolve()
+    except Exception:
+        resolved = path
+    name = resolved.name.lower()
+    if name in _BROAD_ROOT_NAMES:
+        return False
+    markers = [resolved / ".git", resolved / ".hermes", resolved / "AGENTS.md", resolved / "CLAUDE.md"]
+    return any(marker.exists() for marker in markers)
+
+
+def _default_label(session: str, window: str, cwd: Path, used: set[str]) -> str:
+    # Prefer tmux window names when they look human-meaningful; otherwise use the
+    # project directory name. Deduplicate deterministically.
+    base = re.sub(r"[^A-Za-z0-9_.-]+", "-", (window or cwd.name or session).strip()).strip("-._")
+    if not base or base in {"zsh", "bash", "python", "python3", "-"}:
+        base = re.sub(r"[^A-Za-z0-9_.-]+", "-", (cwd.name or session).strip()).strip("-._") or "project"
+    label = base
+    i = 2
+    while label in used:
+        label = f"{base}-{i}"
+        i += 1
+    used.add(label)
+    return label
+
+
+def discover_tmux_projects() -> list[ProjectSession]:
+    fmt = "#{session_name}\t#{window_index}\t#{window_name}\t#{pane_index}\t#{pane_current_path}\t#{pane_current_command}"
+    output = _run_tmux(["list-panes", "-a", "-F", fmt])
+    if not output.strip():
+        return []
+    sessions: list[ProjectSession] = []
+    used: set[str] = set()
+    for line in output.splitlines():
+        parts = line.split("\t")
+        if len(parts) < 6:
+            continue
+        session, window_index, window_name, pane_index, cwd_s, command = parts[:6]
+        cwd = Path(cwd_s).expanduser()
+        if not _looks_like_project_dir(cwd):
+            continue
+        label = _default_label(session, window_name, cwd, used)
+        tmux_target = f"{session}:{window_index}.{pane_index}"
+        handoff = cwd / ".hermes" / "handoff" / "current.md"
+        aliases = [] if cwd.name == label else [cwd.name]
+        sessions.append(
+            ProjectSession(
+                label=label,
+                tmux_target=tmux_target,
+                workdir=str(cwd),
+                aliases=aliases,
+                handoff_path=str(handoff),
+                status="active",
+                notify=False,
+            )
+        )
+    return sessions
+
+
+def refresh_from_tmux(state: ProjectRoutingState | None = None) -> ProjectRoutingState:
+    state = state or load_state()
+    for discovered in discover_tmux_projects():
+        existing = state.projects.get(discovered.label)
+        if existing:
+            existing.tmux_target = discovered.tmux_target
+            existing.workdir = discovered.workdir
+            existing.handoff_path = discovered.handoff_path
+            existing.status = "active"
+            existing.last_seen_at = time.time()
+            for alias in discovered.aliases:
+                if alias not in existing.aliases:
+                    existing.aliases.append(alias)
+        else:
+            state.projects[discovered.label] = discovered
+    return state
+
+
+def find_project(state: ProjectRoutingState, label_or_alias: str) -> ProjectSession | None:
+    needle = (label_or_alias or "").strip().lower()
+    if not needle:
+        return None
+    for label, project in state.projects.items():
+        names = [label, project.label, *project.aliases]
+        if any(needle == str(name).strip().lower() for name in names):
+            return project
+    # Allow numeric selection in current sorted display order.
+    if needle.isdigit():
+        idx = int(needle) - 1
+        values = sorted(state.projects.values(), key=lambda p: p.label.lower())
+        if 0 <= idx < len(values):
+            return values[idx]
+    return None
+
+
+def format_projects(state: ProjectRoutingState, source: Any | None = None) -> str:
+    if not state.projects:
+        return "[프로젝트 세션]\n등록/감지된 tmux 프로젝트 세션이 없습니다. 프로젝트 디렉토리에서 Hermes를 실행한 뒤 다시 시도하세요."
+    active = state.active_by_chat.get(_source_key(source)) if source is not None else None
+    lines = ["[프로젝트 세션]", f"mode: {state.mode}", ""]
+    for i, project in enumerate(sorted(state.projects.values(), key=lambda p: p.label.lower()), 1):
+        marker = " *active*" if active and project.label == active else ""
+        aliases = f" / aliases: {', '.join(project.aliases)}" if project.aliases else ""
+        lines.extend([
+            f"{i}. [{project.label}]{marker}{aliases}",
+            f"   - tmux: {project.tmux_target}",
+            f"   - cwd: {project.workdir}",
+            f"   - notify: {'on' if project.notify else 'off'}",
+        ])
+    lines.extend(["", "사용:", " /switch <번호|label>", " /psend <지시>", " [label] <지시>"])
+    return "\n".join(lines)
+
+
+def switch_project(source: Any, target: str, *, path: Path | None = None) -> str:
+    state = refresh_from_tmux(load_state(path))
+    project = find_project(state, target)
+    if not project:
+        save_state(state, path)
+        return f"프로젝트 `{target}`를 찾지 못했습니다.\n\n{format_projects(state, source)}"
+    state.active_by_chat[_source_key(source)] = project.label
+    save_state(state, path)
+    return f"[전환 완료]\n현재 Telegram 대상: [{project.label}]\n- tmux: {project.tmux_target}\n- cwd: {project.workdir}"
+
+
+def current_project(source: Any, *, path: Path | None = None) -> str:
+    state = refresh_from_tmux(load_state(path))
+    label = state.active_by_chat.get(_source_key(source))
+    project = find_project(state, label or "") if label else None
+    save_state(state, path)
+    if not project:
+        return "현재 선택된 프로젝트가 없습니다. /projects 후 /switch <번호|label>을 사용하세요."
+    return f"[현재 프로젝트]\n[{project.label}]\n- tmux: {project.tmux_target}\n- cwd: {project.workdir}\n- handoff: {project.handoff_path or '-'}\n- notify: {'on' if project.notify else 'off'}"
+
+
+def parse_project_prefix(text: str) -> tuple[str, str] | None:
+    m = _PROJECT_PREFIX_RE.match(text or "")
+    if not m:
+        return None
+    return m.group(1).strip(), m.group(2).strip()
+
+
+def _send_to_tmux(project: ProjectSession, prompt: str) -> None:
+    subprocess.run(
+        ["tmux", "send-keys", "-t", project.tmux_target, prompt, "Enter"],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.PIPE,
+        text=True,
+        timeout=5,
+        check=True,
+    )
+
+
+def _away_instruction(project: ProjectSession) -> str:
+    return (
+        "퇴근모드로 전환합니다. 현재 작업을 중단하지 말고, 완료/막힘/결정 필요 시 "
+        f"Telegram에 프로젝트 prefix [{project.label}]를 붙여 짧게 보고하세요. "
+        "긴 로그는 요약하고, 다음 사용자가 답할 수 있는 선택지를 포함하세요."
+    )
+
+
+def _office_instruction(project: ProjectSession) -> str:
+    return (
+        "출근모드로 전환합니다. 이후 proactive Telegram 결과 보고는 중지하고, "
+        "응답은 현재 tmux 터미널 중심으로 남기세요. 필요한 handoff만 최신화하세요."
+    )
+
+
+def send_prompt_to_project(source: Any, message: str, *, explicit_label: str | None = None, path: Path | None = None) -> str:
+    state = refresh_from_tmux(load_state(path))
+    label = explicit_label or state.active_by_chat.get(_source_key(source))
+    project = find_project(state, label or "") if label else None
+    if not project:
+        save_state(state, path)
+        return "대상 프로젝트가 없습니다. `[label] 지시` 형식으로 보내거나 /projects 후 /switch를 먼저 사용하세요."
+    safe_message = (message or "").strip()
+    if not safe_message:
+        return "전달할 지시가 비어 있습니다. 예: [dev-1] 다음 작업 진행해줘"
+    prompt = f"/steer {safe_message}"
+    try:
+        _send_to_tmux(project, prompt)
+    except Exception as exc:
+        save_state(state, path)
+        return f"[{project.label}] 전달 실패 — tmux target 확인 필요: {exc}"
+    state.active_by_chat[_source_key(source)] = project.label
+    save_state(state, path)
+    return f"[{project.label}] 전달 완료\n- tmux: {project.tmux_target}\n- 방식: /steer"
+
+
+def handle_prefixed_message(source: Any, text: str, *, path: Path | None = None) -> str | None:
+    parsed = parse_project_prefix(text)
+    if not parsed:
+        return None
+    label, message = parsed
+    state = refresh_from_tmux(load_state(path))
+    project = find_project(state, label)
+    if not project:
+        save_state(state, path)
+        return f"프로젝트 prefix `{label}`를 찾지 못했습니다.\n\n{format_projects(state, source)}"
+    if state.mode != "away" or not project.notify:
+        return None
+    # Avoid hijacking approval command payloads; approval routing is separate.
+    if message.strip().lower().startswith(("/approve", "/deny")):
+        return None
+    return send_prompt_to_project(source, message, explicit_label=project.label, path=path)
+
+
+def set_mode(source: Any, mode: str, target: str = "all", *, path: Path | None = None) -> str:
+    state = refresh_from_tmux(load_state(path))
+    mode = "away" if mode == "away" else "office"
+    scope = (target or "all").strip().lower() or "all"
+    if scope not in {"all", "current"}:
+        return "사용: /afterwork [all|current] 또는 /office [all|current]"
+    projects: Iterable[ProjectSession]
+    if scope == "current":
+        label = state.active_by_chat.get(_source_key(source))
+        project = find_project(state, label or "") if label else None
+        projects = [project] if project else []
+    else:
+        projects = sorted(state.projects.values(), key=lambda p: p.label.lower())
+    changed: list[ProjectSession] = []
+    failures: list[str] = []
+    for project in projects:
+        if not project:
+            continue
+        old_notify = project.notify
+        instruction = _away_instruction(project) if mode == "away" else _office_instruction(project)
+        try:
+            _send_to_tmux(project, f"/steer {instruction}")
+        except Exception as exc:
+            project.notify = old_notify
+            failures.append(f"[{project.label}] {exc}")
+            continue
+        project.notify = mode == "away"
+        changed.append(project)
+    if changed:
+        state.mode = mode
+    save_state(state, path)
+    title = "퇴근모드 시작" if mode == "away" else "출근모드 전환 완료"
+    lines = [f"[{title}]", ""]
+    if changed:
+        lines.append("대상:")
+        for p in changed:
+            lines.append(f"- [{p.label}] tmux={p.tmux_target} notify={'on' if p.notify else 'off'}")
+    else:
+        lines.append("대상 프로젝트가 없습니다. /projects 후 /switch 하거나 프로젝트 tmux 세션을 확인하세요.")
+    if mode == "away":
+        lines.extend(["", "회신 형식:", "[label] 다음 작업 진행해줘", "[label] 멈추고 handoff 정리해줘"])
+    if failures:
+        lines.extend(["", "전달 실패:", *failures])
+    return "\n".join(lines)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -13421,12 +13421,6 @@ class GatewayRunner:
             resolve_gateway_approval, has_blocking_approval,
         )
 
-        if not has_blocking_approval(session_key):
-            if session_key in self._pending_approvals:
-                self._pending_approvals.pop(session_key)
-                return t("gateway.approval_expired")
-            return t("gateway.approve.no_pending")
-
         # Parse args: support "all", "all session", "all always", "session", "always"
         args = event.get_command_args().strip().lower().split()
         resolve_all = "all" in args
@@ -13438,6 +13432,27 @@ class GatewayRunner:
             choice = "session"
         else:
             choice = "once"
+
+        if not has_blocking_approval(session_key):
+            if session_key in self._pending_approvals:
+                self._pending_approvals.pop(session_key)
+                return t("gateway.approval_expired")
+            try:
+                from tools.shared_approval_broker import resolve_oldest_cli_approval
+                cli_count = resolve_oldest_cli_approval(
+                    choice,
+                    resolve_all=resolve_all,
+                    source=source.to_dict() if source else None,
+                )
+            except Exception as exc:
+                logger.debug("Shared CLI approval resolve failed: %s", exc)
+                cli_count = 0
+            if cli_count:
+                logger.info("User approved %d CLI approval(s) via /approve (%s)", cli_count, choice)
+                if cli_count > 1:
+                    return f"✅ Approved {cli_count} CLI approval requests remotely. Return to the terminal to continue."
+                return "✅ Approved CLI approval request remotely. Return to the terminal to continue."
+            return t("gateway.approve.no_pending")
 
         count = resolve_gateway_approval(session_key, choice, resolve_all=resolve_all)
         if not count:
@@ -13467,14 +13482,29 @@ class GatewayRunner:
             resolve_gateway_approval, has_blocking_approval,
         )
 
+        args = event.get_command_args().strip().lower()
+        resolve_all = "all" in args
+
         if not has_blocking_approval(session_key):
             if session_key in self._pending_approvals:
                 self._pending_approvals.pop(session_key)
                 return t("gateway.deny.stale")
+            try:
+                from tools.shared_approval_broker import resolve_oldest_cli_approval
+                cli_count = resolve_oldest_cli_approval(
+                    "deny",
+                    resolve_all=resolve_all,
+                    source=source.to_dict() if source else None,
+                )
+            except Exception as exc:
+                logger.debug("Shared CLI approval deny failed: %s", exc)
+                cli_count = 0
+            if cli_count:
+                logger.info("User denied %d CLI approval(s) via /deny", cli_count)
+                if cli_count > 1:
+                    return f"🚫 Denied {cli_count} CLI approval requests remotely."
+                return "🚫 Denied CLI approval request remotely."
             return t("gateway.deny.no_pending")
-
-        args = event.get_command_args().strip().lower()
-        resolve_all = "all" in args
 
         count = resolve_gateway_approval(session_key, "deny", resolve_all=resolve_all)
         if not count:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7344,6 +7344,45 @@ class GatewayRunner:
         if canonical == "voice":
             return await self._handle_voice_command(event)
 
+        if canonical in {
+            "autopilot",
+            "ralplan",
+            "deep-interview",
+            "verify",
+            "ultraqa",
+            "trace",
+            "deepsearch",
+            "devflow",
+            "tdd",
+        }:
+            try:
+                from agent.skill_commands import (
+                    build_skill_invocation_message,
+                    get_skill_commands,
+                    resolve_skill_command_key,
+                )
+                skill_cmds = get_skill_commands()
+                cmd_key = resolve_skill_command_key(canonical)
+                if cmd_key is None:
+                    return (
+                        f"Workflow skill `/{canonical}` is not installed or is disabled. "
+                        "Run `/reload-skills` after installing or enabling skills."
+                    )
+                msg = build_skill_invocation_message(
+                    cmd_key,
+                    event.get_command_args().strip(),
+                    task_id=_quick_key,
+                )
+                if msg:
+                    event.text = msg
+                    command = None
+                else:
+                    skill_name = skill_cmds.get(cmd_key, {}).get("name", canonical)
+                    return f"Failed to load workflow skill `{skill_name}`."
+            except Exception as e:
+                logger.debug("Workflow skill wrapper failed (non-fatal): %s", e)
+                return f"Workflow skill `/{canonical}` could not be loaded."
+
         if self._draining:
             return f"⏳ Gateway is {self._status_action_gerund()} and is not accepting new work right now."
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6894,6 +6894,38 @@ class GatewayRunner:
             if _cmd_def_inner and _cmd_def_inner.name == "background":
                 return await self._handle_background_command(event)
 
+            # /afterwork is a project-session control command. It must be safe
+            # while an agent is running: dispatch the command hook directly so
+            # the project/tmux router can send a non-interrupting /steer to the
+            # target pane instead of rejecting it or treating it as follow-up
+            # text that interrupts the current run.
+            if _cmd_def_inner and _cmd_def_inner.name == "afterwork":
+                raw_args = event.get_command_args().strip()
+                hook_ctx = {
+                    "platform": source.platform.value if source.platform else "",
+                    "user_id": source.user_id,
+                    "command": "afterwork",
+                    "raw_command": _evt_cmd,
+                    "args": raw_args,
+                    "raw_args": raw_args,
+                }
+                try:
+                    hook_results = await self.hooks.emit_collect("command:afterwork", hook_ctx)
+                except Exception as _hook_err:
+                    logger.debug("command:afterwork hook dispatch failed (non-fatal): %s", _hook_err)
+                    hook_results = []
+                for hook_result in hook_results:
+                    if not isinstance(hook_result, dict):
+                        continue
+                    decision = str(hook_result.get("decision", "")).strip().lower()
+                    if decision == "handled":
+                        message = hook_result.get("message")
+                        return message if isinstance(message, str) and message else None
+                    if decision == "deny":
+                        message = hook_result.get("message")
+                        return message if isinstance(message, str) and message else "Command `/afterwork` was blocked by a hook."
+                return "퇴근모드 hook이 설정되어 있지 않습니다. 터미널에서는 /afterwork 또는 퇴근모드를 사용하세요."
+
             # /kanban must bypass the guard. It writes to a profile-agnostic
             # DB (kanban.db), not to the running agent's state. In fact
             # /kanban unblock is often the only way to free a worker that

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7214,6 +7214,9 @@ class GatewayRunner:
         if canonical == "office":
             return await self._handle_office_project_command(event)
 
+        if canonical == "commute":
+            return await self._handle_commute_command(event)
+
         if canonical == "agents":
             return await self._handle_agents_command(event)
 
@@ -9484,6 +9487,15 @@ class GatewayRunner:
         except Exception as e:
             logger.debug("/office project routing failed: %s", e)
             return f"출근모드 전환 실패: {e}"
+
+    async def _handle_commute_command(self, event: MessageEvent) -> str:
+        """Show commute-mode usage help."""
+        try:
+            from gateway.project_sessions import commute_help_text
+            return commute_help_text()
+        except Exception as e:
+            logger.debug("/commute failed: %s", e)
+            return f"퇴근모드 도움말 조회 실패: {e}"
 
     async def _handle_status_command(self, event: MessageEvent) -> str:
         """Handle /status command."""

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6894,37 +6894,14 @@ class GatewayRunner:
             if _cmd_def_inner and _cmd_def_inner.name == "background":
                 return await self._handle_background_command(event)
 
-            # /afterwork is a project-session control command. It must be safe
-            # while an agent is running: dispatch the command hook directly so
-            # the project/tmux router can send a non-interrupting /steer to the
-            # target pane instead of rejecting it or treating it as follow-up
-            # text that interrupts the current run.
-            if _cmd_def_inner and _cmd_def_inner.name == "afterwork":
-                raw_args = event.get_command_args().strip()
-                hook_ctx = {
-                    "platform": source.platform.value if source.platform else "",
-                    "user_id": source.user_id,
-                    "command": "afterwork",
-                    "raw_command": _evt_cmd,
-                    "args": raw_args,
-                    "raw_args": raw_args,
-                }
-                try:
-                    hook_results = await self.hooks.emit_collect("command:afterwork", hook_ctx)
-                except Exception as _hook_err:
-                    logger.debug("command:afterwork hook dispatch failed (non-fatal): %s", _hook_err)
-                    hook_results = []
-                for hook_result in hook_results:
-                    if not isinstance(hook_result, dict):
-                        continue
-                    decision = str(hook_result.get("decision", "")).strip().lower()
-                    if decision == "handled":
-                        message = hook_result.get("message")
-                        return message if isinstance(message, str) and message else None
-                    if decision == "deny":
-                        message = hook_result.get("message")
-                        return message if isinstance(message, str) and message else "Command `/afterwork` was blocked by a hook."
-                return "퇴근모드 hook이 설정되어 있지 않습니다. 터미널에서는 /afterwork 또는 퇴근모드를 사용하세요."
+            # /afterwork and /office are project-session control commands. They
+            # must be safe while an agent is running: dispatch directly so the
+            # project/tmux router sends a non-interrupting /steer to target panes
+            # instead of treating the text as a follow-up that interrupts.
+            if _cmd_def_inner and _cmd_def_inner.name in {"afterwork", "office"}:
+                if _cmd_def_inner.name == "afterwork":
+                    return await self._handle_afterwork_project_command(event)
+                return await self._handle_office_project_command(event)
 
             # /kanban must bypass the guard. It writes to a profile-agnostic
             # DB (kanban.db), not to the running agent's state. In fact
@@ -7218,6 +7195,24 @@ class GatewayRunner:
 
         if canonical == "status":
             return await self._handle_status_command(event)
+
+        if canonical == "projects":
+            return await self._handle_projects_command(event)
+
+        if canonical == "switch":
+            return await self._handle_switch_project_command(event)
+
+        if canonical == "current":
+            return await self._handle_current_project_command(event)
+
+        if canonical == "psend":
+            return await self._handle_psend_command(event)
+
+        if canonical == "afterwork":
+            return await self._handle_afterwork_project_command(event)
+
+        if canonical == "office":
+            return await self._handle_office_project_command(event)
 
         if canonical == "agents":
             return await self._handle_agents_command(event)
@@ -7550,6 +7545,19 @@ class GatewayRunner:
         # Pending exec approvals are handled by /approve and /deny commands above.
         # No bare text matching — "yes" in normal conversation must not trigger
         # execution of a dangerous command.
+
+        # Project-session prefix routing: in away mode, messages like
+        # `[dev-1] 다음 작업 진행해줘` should steer the matching tmux/Hermes
+        # pane instead of becoming a new Gateway agent turn. Approval commands
+        # remain handled by their dedicated /approve and /deny paths above.
+        if not command:
+            try:
+                from gateway.project_sessions import handle_prefixed_message
+                routed = await asyncio.to_thread(handle_prefixed_message, source, event.text)
+                if routed is not None:
+                    return routed
+            except Exception as e:
+                logger.debug("Project-session prefix routing failed (non-fatal): %s", e)
 
         if self._is_telegram_topic_root_lobby(source):
             # Debounce the lobby reminder so a user who forgets about
@@ -9412,6 +9420,70 @@ class GatewayRunner:
         if len(output) > 3800:
             output = output[:3800] + "\n" + t("gateway.kanban.truncated_suffix")
         return output or t("gateway.kanban.no_output")
+
+    async def _handle_projects_command(self, event: MessageEvent) -> str:
+        """List Telegram-routable tmux/project sessions."""
+        try:
+            from gateway.project_sessions import format_projects, load_state, refresh_from_tmux, save_state
+            state = await asyncio.to_thread(lambda: refresh_from_tmux(load_state()))
+            await asyncio.to_thread(save_state, state)
+            return format_projects(state, event.source)
+        except Exception as e:
+            logger.debug("/projects failed: %s", e)
+            return f"프로젝트 세션 조회 실패: {e}"
+
+    async def _handle_switch_project_command(self, event: MessageEvent) -> str:
+        """Switch the active Telegram project session."""
+        target = event.get_command_args().strip()
+        if not target:
+            return "사용: /switch <번호|label>"
+        try:
+            from gateway.project_sessions import switch_project
+            return await asyncio.to_thread(switch_project, event.source, target)
+        except Exception as e:
+            logger.debug("/switch failed: %s", e)
+            return f"프로젝트 전환 실패: {e}"
+
+    async def _handle_current_project_command(self, event: MessageEvent) -> str:
+        """Show the active Telegram project session."""
+        try:
+            from gateway.project_sessions import current_project
+            return await asyncio.to_thread(current_project, event.source)
+        except Exception as e:
+            logger.debug("/current failed: %s", e)
+            return f"현재 프로젝트 조회 실패: {e}"
+
+    async def _handle_psend_command(self, event: MessageEvent) -> str:
+        """Send a prompt to the active Telegram project tmux pane."""
+        message = event.get_command_args().strip()
+        if not message:
+            return "사용: /psend <지시>  또는 [label] <지시>"
+        try:
+            from gateway.project_sessions import send_prompt_to_project
+            return await asyncio.to_thread(send_prompt_to_project, event.source, message)
+        except Exception as e:
+            logger.debug("/psend failed: %s", e)
+            return f"프로젝트 지시 전달 실패: {e}"
+
+    async def _handle_afterwork_project_command(self, event: MessageEvent) -> str:
+        """Turn on away-mode relay instructions for project sessions."""
+        target = event.get_command_args().strip() or "all"
+        try:
+            from gateway.project_sessions import set_mode
+            return await asyncio.to_thread(set_mode, event.source, "away", target)
+        except Exception as e:
+            logger.debug("/afterwork project routing failed: %s", e)
+            return f"퇴근모드 전환 실패: {e}"
+
+    async def _handle_office_project_command(self, event: MessageEvent) -> str:
+        """Turn off away-mode relay instructions for project sessions."""
+        target = event.get_command_args().strip() or "all"
+        try:
+            from gateway.project_sessions import set_mode
+            return await asyncio.to_thread(set_mode, event.source, "office", target)
+        except Exception as e:
+            logger.debug("/office project routing failed: %s", e)
+            return f"출근모드 전환 실패: {e}"
 
     async def _handle_status_command(self, event: MessageEvent) -> str:
         """Handle /status command."""

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -2093,7 +2093,9 @@ def get_gemini_oauth_auth_status() -> Dict[str, Any]:
         "logged_in": True,
         "auth_file": str(auth_path),
         "source": "google-oauth",
-        "api_key": creds.access_token,
+        # Do not expose bearer tokens in status/auth-list payloads. Runtime
+        # resolution returns the token via resolve_gemini_oauth_runtime_credentials().
+        "api_key_present": bool(creds.access_token),
         "expires_at_ms": creds.expires_ms,
         "email": creds.email,
         "project_id": creds.project_id,

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -124,6 +124,26 @@ COMMAND_REGISTRY: list[CommandDef] = [
     CommandDef("afterwork", "Put current/all project sessions into away mode", "Session",
                aliases=("awaymode", "퇴근", "퇴근모드"), args_hint="[current|all]"),
 
+    # Workflow skill wrappers
+    CommandDef("autopilot", "Run the autopilot goal-completion workflow skill", "Workflow",
+               args_hint="<instruction>"),
+    CommandDef("ralplan", "Create a rigorous action/implementation plan", "Workflow",
+               args_hint="<topic>"),
+    CommandDef("deep-interview", "Run a structured requirements interview", "Workflow",
+               aliases=("deepinterview",), args_hint="<topic>"),
+    CommandDef("verify", "Verify completion against acceptance criteria", "Workflow",
+               args_hint="<target>"),
+    CommandDef("ultraqa", "Iterate on tests/build/lint/typecheck until clean or blocked", "Workflow",
+               args_hint="<target>"),
+    CommandDef("trace", "Trace a bug, request path, or data/control flow", "Workflow",
+               args_hint="<target>"),
+    CommandDef("deepsearch", "Run a deep source-grounded research workflow", "Workflow",
+               args_hint="<question>"),
+    CommandDef("devflow", "Run plan/verify -> develop -> verify workflow", "Workflow",
+               args_hint="<task>"),
+    CommandDef("tdd", "Run strict RED-GREEN-REFACTOR development workflow", "Workflow",
+               args_hint="<task>"),
+
     # Configuration
     CommandDef("sessions", "Browse and resume previous sessions", "Session"),
 
@@ -503,6 +523,8 @@ def telegram_bot_commands() -> list[tuple[str, str]]:
     menu_excluded = {"afterwork"}
     for cmd in COMMAND_REGISTRY:
         if not _is_gateway_available(cmd, overrides):
+            continue
+        if cmd.category == "Workflow":
             continue
         if cmd.name in menu_excluded:
             # Control-plane commands that are mainly typed via aliases/hooks do
@@ -1029,7 +1051,7 @@ def slack_native_slashes() -> list[tuple[str, str, str]]:
     for cmd in COMMAND_REGISTRY:
         if not _is_gateway_available(cmd, overrides):
             continue
-        if cmd.name in menu_excluded:
+        if cmd.category == "Workflow" or cmd.name in menu_excluded:
             continue
         for alias in cmd.aliases:
             if alias in priority_aliases:
@@ -1040,7 +1062,7 @@ def slack_native_slashes() -> list[tuple[str, str, str]]:
     for cmd in COMMAND_REGISTRY:
         if not _is_gateway_available(cmd, overrides):
             continue
-        if cmd.name in menu_excluded:
+        if cmd.category == "Workflow" or cmd.name in menu_excluded:
             continue
         _add(cmd.name, cmd.description, cmd.args_hint or "")
 
@@ -1048,7 +1070,7 @@ def slack_native_slashes() -> list[tuple[str, str, str]]:
     for cmd in COMMAND_REGISTRY:
         if not _is_gateway_available(cmd, overrides):
             continue
-        if cmd.name in menu_excluded:
+        if cmd.category == "Workflow" or cmd.name in menu_excluded:
             continue
         for alias in cmd.aliases:
             # Skip aliases that only differ from canonical by case/punctuation

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -524,7 +524,7 @@ def telegram_bot_commands() -> list[tuple[str, str]]:
     """
     overrides = _resolve_config_gates()
     result: list[tuple[str, str]] = []
-    menu_excluded = {"afterwork", "debug", "platform", "update"}
+    menu_excluded = {"debug", "insights", "platform", "update"}
     for cmd in COMMAND_REGISTRY:
         if not _is_gateway_available(cmd, overrides):
             continue
@@ -1028,7 +1028,7 @@ def slack_native_slashes() -> list[tuple[str, str, str]]:
     gets dropped by the clamp or for free-form questions.
     """
     overrides = _resolve_config_gates()
-    menu_excluded = {"afterwork"}
+    menu_excluded: set[str] = set()
     entries: list[tuple[str, str, str]] = []
     seen: set[str] = set()
 

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -113,6 +113,16 @@ COMMAND_REGISTRY: list[CommandDef] = [
                gateway_only=True, aliases=("set-home",)),
     CommandDef("resume", "Resume a previously-named session", "Session",
                args_hint="[name]"),
+    CommandDef("projects", "List Telegram-routable tmux/project sessions", "Session",
+               gateway_only=True),
+    CommandDef("switch", "Switch the active Telegram project session", "Session",
+               gateway_only=True, args_hint="<number|name>"),
+    CommandDef("current", "Show the active Telegram project session", "Session",
+               gateway_only=True),
+    CommandDef("psend", "Send a prompt to the active Telegram project tmux pane", "Session",
+               gateway_only=True, args_hint="<prompt>"),
+    CommandDef("afterwork", "Put current/all Telegram project sessions into away mode", "Session",
+               gateway_only=True, aliases=("awaymode",), args_hint="[current|all]"),
 
     # Configuration
     CommandDef("sessions", "Browse and resume previous sessions", "Session"),

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -125,6 +125,8 @@ COMMAND_REGISTRY: list[CommandDef] = [
                aliases=("awaymode", "퇴근", "퇴근모드"), args_hint="[current|all]"),
     CommandDef("office", "Return project sessions to terminal-only office mode", "Session",
                aliases=("morning", "출근", "출근모드"), args_hint="[current|all]"),
+    CommandDef("commute", "Show 퇴근모드/출근모드 remote-control help", "Session",
+               aliases=("away-help", "commute-help", "퇴근도움말")),
 
     # Workflow skill wrappers
     CommandDef("autopilot", "Run the autopilot goal-completion workflow skill", "Workflow",

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -121,8 +121,8 @@ COMMAND_REGISTRY: list[CommandDef] = [
                gateway_only=True),
     CommandDef("psend", "Send a prompt to the active Telegram project tmux pane", "Session",
                gateway_only=True, args_hint="<prompt>"),
-    CommandDef("afterwork", "Put current/all Telegram project sessions into away mode", "Session",
-               gateway_only=True, aliases=("awaymode",), args_hint="[current|all]"),
+    CommandDef("afterwork", "Put current/all project sessions into away mode", "Session",
+               aliases=("awaymode", "퇴근", "퇴근모드"), args_hint="[current|all]"),
 
     # Configuration
     CommandDef("sessions", "Browse and resume previous sessions", "Session"),
@@ -500,8 +500,14 @@ def telegram_bot_commands() -> list[tuple[str, str]]:
     """
     overrides = _resolve_config_gates()
     result: list[tuple[str, str]] = []
+    menu_excluded = {"afterwork"}
     for cmd in COMMAND_REGISTRY:
         if not _is_gateway_available(cmd, overrides):
+            continue
+        if cmd.name in menu_excluded:
+            # Control-plane commands that are mainly typed via aliases/hooks do
+            # not need a Telegram menu slot, and keeping them out preserves
+            # Slack parity under Slack's 50-command cap.
             continue
         # Built-in arg-taking commands are included — their handlers show
         # usage text when invoked without arguments, and hiding them from
@@ -996,6 +1002,7 @@ def slack_native_slashes() -> list[tuple[str, str, str]]:
     gets dropped by the clamp or for free-form questions.
     """
     overrides = _resolve_config_gates()
+    menu_excluded = {"afterwork"}
     entries: list[tuple[str, str, str]] = []
     seen: set[str] = set()
 
@@ -1015,15 +1022,33 @@ def slack_native_slashes() -> list[tuple[str, str, str]]:
         entries.append((slack_name, desc[:140], hint[:100]))
         seen.add(slack_name)
 
-    # First pass: canonical names (so they win slots if we hit the cap).
+    # Preserve compact high-value aliases before the generic canonical pass so
+    # Slack's 50-command cap cannot silently evict them when new gateway
+    # commands are added.
+    priority_aliases = {"btw", "bg", "q", "reset"}
     for cmd in COMMAND_REGISTRY:
         if not _is_gateway_available(cmd, overrides):
             continue
-        _add(cmd.name, cmd.description, cmd.args_hint or "")
+        if cmd.name in menu_excluded:
+            continue
+        for alias in cmd.aliases:
+            if alias in priority_aliases:
+                _add(alias, f"Alias for /{cmd.name} — {cmd.description}", cmd.args_hint or "")
 
-    # Second pass: aliases.
+    # First pass: canonical names (so they win slots after the reserved aliases
+    # above if we hit the cap).
     for cmd in COMMAND_REGISTRY:
         if not _is_gateway_available(cmd, overrides):
+            continue
+        if cmd.name in menu_excluded:
+            continue
+        _add(cmd.name, cmd.description, cmd.args_hint or "")
+
+    # Second pass: remaining aliases.
+    for cmd in COMMAND_REGISTRY:
+        if not _is_gateway_available(cmd, overrides):
+            continue
+        if cmd.name in menu_excluded:
             continue
         for alias in cmd.aliases:
             # Skip aliases that only differ from canonical by case/punctuation

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -524,7 +524,7 @@ def telegram_bot_commands() -> list[tuple[str, str]]:
     """
     overrides = _resolve_config_gates()
     result: list[tuple[str, str]] = []
-    menu_excluded = {"afterwork"}
+    menu_excluded = {"afterwork", "debug", "update"}
     for cmd in COMMAND_REGISTRY:
         if not _is_gateway_available(cmd, overrides):
             continue

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -123,6 +123,8 @@ COMMAND_REGISTRY: list[CommandDef] = [
                gateway_only=True, args_hint="<prompt>"),
     CommandDef("afterwork", "Put current/all project sessions into away mode", "Session",
                aliases=("awaymode", "퇴근", "퇴근모드"), args_hint="[current|all]"),
+    CommandDef("office", "Return project sessions to terminal-only office mode", "Session",
+               aliases=("morning", "출근", "출근모드"), args_hint="[current|all]"),
 
     # Workflow skill wrappers
     CommandDef("autopilot", "Run the autopilot goal-completion workflow skill", "Workflow",

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -524,7 +524,7 @@ def telegram_bot_commands() -> list[tuple[str, str]]:
     """
     overrides = _resolve_config_gates()
     result: list[tuple[str, str]] = []
-    menu_excluded = {"afterwork", "debug", "update"}
+    menu_excluded = {"afterwork", "debug", "platform", "update"}
     for cmd in COMMAND_REGISTRY:
         if not _is_gateway_available(cmd, overrides):
             continue

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -779,6 +779,11 @@ DEFAULT_CONFIG = {
     "tool_loop_guardrails": {
         "warnings_enabled": True,
         "hard_stop_enabled": False,
+        # Forge-style prerequisite nudges warn when a tool is called before
+        # its recommended discovery/list/snapshot step. Hard-stop mode is
+        # separate and off by default to preserve legacy cross-turn workflows.
+        "prerequisite_checks_enabled": True,
+        "prerequisite_hard_stop_enabled": False,
         "warn_after": {
             "exact_failure": 2,
             "same_tool_failure": 3,
@@ -789,6 +794,16 @@ DEFAULT_CONFIG = {
             "same_tool_failure": 8,
             "idempotent_no_progress": 5,
         },
+    },
+
+    # Workflow guardrails add Forge-style required-step awareness above the
+    # raw tool loop. Default is opt-in/off to preserve legacy final-response
+    # text exactly. Set final_gate_mode to 'advisory', 'nudge', or 'block'
+    # for stricter autonomous/workflow sessions.
+    "workflow_guardrails": {
+        "enabled": False,
+        "final_gate_mode": "off",  # off | advisory | nudge | block
+        "max_nudges": 1,
     },
 
     "compression": {

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -667,6 +667,17 @@ DEFAULT_CONFIG = {
         # Enabled by default for non-local backends (SSH); local is always opt-in
         # via TERMINAL_LOCAL_PERSISTENT env var.
         "persistent_shell": True,
+        # RTK-inspired terminal output optimizer. Default off to preserve legacy
+        # behavior exactly. When enabled, Hermes may compact noisy foreground
+        # terminal output after ANSI stripping/secret redaction while preserving
+        # a sanitized raw-output file for recovery.
+        "output_optimizer": {
+            "enabled": False,
+            "min_chars": 4000,
+            "target_chars": 12000,
+            "raw_output": "preserve",  # preserve | off
+            "storage_dir": "/tmp/hermes-terminal-raw",
+        },
     },
 
     "web": {

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1311,6 +1311,19 @@ def list_authenticated_providers(
                     has_creds = True
             except Exception as exc:
                 logger.debug("Auth store check failed for %s: %s", pid, exc)
+        # Google Gemini CLI / Code Assist can be configured from the official
+        # Gemini CLI OAuth store even when Hermes auth.json has no provider or
+        # credential-pool row. The runtime resolver is the source of truth for
+        # whether Hermes can actually use this provider, so mirror that here for
+        # model-picker discovery.
+        if not has_creds and hermes_slug == "google-gemini-cli":
+            try:
+                from hermes_cli.auth import resolve_gemini_oauth_runtime_credentials
+                creds = resolve_gemini_oauth_runtime_credentials(force_refresh=False)
+                if creds.get("api_key"):
+                    has_creds = True
+            except Exception as exc:
+                logger.debug("Google Gemini CLI OAuth check failed: %s", exc)
         # Fallback: check the credential pool with full auto-seeding.
         # This catches credentials that exist in external stores (e.g.
         # Codex CLI ~/.codex/auth.json) which _seed_from_singletons()

--- a/scripts/workflow_guardrail_eval.py
+++ b/scripts/workflow_guardrail_eval.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Deterministic workflow-guardrail scenario harness.
+
+This is a low-cost Forge-style regression harness: no provider calls, no tools
+executed. It feeds synthetic turns/tool successes into the pure workflow
+controller and verifies expected final-gate decisions.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from dataclasses import asdict
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from agent.workflow_guardrails import (  # noqa: E402
+    WorkflowGuardrailConfig,
+    WorkflowGuardrailController,
+)
+
+
+SCENARIOS = [
+    {
+        "name": "repo_review_missing_tests_advisory",
+        "message": "다음 GitHub 레포지토리를 검토해줘 https://github.com/example/repo",
+        "tools": ["read_file", "search_files"],
+        "mode": "advisory",
+        "expected_action": "advisory",
+        "expected_missing": ["inspect_metadata", "verify"],
+    },
+    {
+        "name": "devflow_complete_allows_final",
+        "message": "이 버그를 수정하고 테스트까지 해줘",
+        "tools": ["read_file", "patch", "terminal"],
+        "mode": "advisory",
+        "expected_action": "allow",
+        "expected_missing": [],
+    },
+    {
+        "name": "devflow_missing_verify_nudges_when_configured",
+        "message": "구현 진행해서 완료해",
+        "tools": ["search_files", "patch"],
+        "mode": "nudge",
+        "expected_action": "nudge",
+        "expected_missing": ["verify"],
+    },
+    {
+        "name": "disabled_mode_allows_final",
+        "message": "구현 진행해서 완료해",
+        "tools": [],
+        "mode": "off",
+        "expected_action": "allow",
+        "expected_missing": [],
+    },
+]
+
+
+def run_scenario(scenario: dict) -> dict:
+    controller = WorkflowGuardrailController(
+        WorkflowGuardrailConfig(enabled=True, final_gate_mode=scenario["mode"])
+    )
+    controller.reset_for_turn(scenario["message"])
+    for tool in scenario["tools"]:
+        controller.record_tool_result(tool, failed=False)
+    decision = controller.evaluate_final_response("done")
+    missing = [step.key for step in decision.missing_steps]
+    passed = decision.action == scenario["expected_action"] and missing == scenario["expected_missing"]
+    return {
+        "name": scenario["name"],
+        "passed": passed,
+        "expected_action": scenario["expected_action"],
+        "actual_action": decision.action,
+        "expected_missing": scenario["expected_missing"],
+        "actual_missing": missing,
+        "decision": decision.to_metadata(),
+    }
+
+
+def main() -> int:
+    results = [run_scenario(s) for s in SCENARIOS]
+    print(json.dumps({"results": results}, ensure_ascii=False, indent=2))
+    return 0 if all(r["passed"] for r in results) else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/software-development/devflow/SKILL.md
+++ b/skills/software-development/devflow/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: devflow
+description: "Plan/verify -> develop -> verify workflow for scoped implementation tasks."
+version: 1.0.0
+author: Hermes Agent
+license: MIT
+metadata:
+  hermes:
+    tags: [development, planning, verification, workflow, qa]
+    related_skills: [plan, verify, ultraqa, tdd, trace, requesting-code-review]
+    created_by: agent
+---
+
+# Devflow
+
+Use this skill when the user invokes `/devflow ...` or asks for a full development workflow that first plans and verifies the plan, then implements and verifies completion.
+
+## Purpose
+
+Make Hermes own the development loop:
+
+1. understand the task,
+2. create a concrete plan,
+3. verify the plan against live repo/context,
+4. implement only the approved/inferred scope,
+5. verify with evidence,
+6. update handoff or report clearly.
+
+Other agents and tools may be used, but only as bounded helpers, implementers, or reviewers. Do not hand over overall orchestration to another harness unless the user explicitly asks.
+
+## Workflow
+
+### 1. Scope discovery
+
+- Inspect current repo/config/handoff as needed before designing changes.
+- Identify unrelated dirty files and preserve them.
+- Infer acceptance criteria from the user's request. If ambiguity would change what files or systems you touch, ask a concise clarifying question. Otherwise proceed with a clearly stated assumption.
+
+### 2. Plan
+
+Create a short, actionable plan. For code changes include:
+
+- goal,
+- files likely to change,
+- implementation approach,
+- tests/validation commands,
+- risks and rollback notes.
+
+If the user asked to execute immediately, the plan may be saved as a checkpoint under `.hermes/plans/` and then execution should continue in the same turn.
+
+### 3. Verify the plan before coding
+
+Before editing, check that the plan is feasible:
+
+- the target files/commands exist,
+- the existing code has the expected extension points,
+- planned tests are available,
+- no obvious conflict with repo instructions or user preferences exists.
+
+If the plan is wrong, revise it before coding.
+
+### 4. Develop
+
+- Make the smallest scoped edits needed.
+- Prefer targeted patches over broad rewrites.
+- Keep behavior in skills/docs when implementing workflow policy; keep code wrappers thin.
+- Do not commit, push, deploy, or run destructive cleanup unless explicitly requested.
+
+### 5. Verify implementation
+
+Run fresh checks. Minimum expected evidence:
+
+- targeted unit/integration tests for changed behavior,
+- syntax/lint/format checks when available and relevant,
+- `git diff --check` for touched files,
+- direct inspection that acceptance criteria are represented in code/docs.
+
+If a check fails, diagnose and iterate within scope. If blocked by environment, report BLOCKED with evidence and the exact remaining action.
+
+### 6. Optional independent review gate
+
+For material code changes, security-sensitive changes, or high-risk workflow changes, consider a bounded independent review. For this user, Claude Code Opus review should be constrained and exact when used:
+
+```bash
+claude -p 'Review only. Do not edit files.' --model claude-opus-4-6 --allowedTools 'Read' --max-turns 1
+```
+
+Use the review as input; Hermes still decides what to apply and verifies again.
+
+### 7. Handoff and final report
+
+When the repo uses `.hermes/handoff/current.md`, update it with:
+
+- what changed,
+- files touched,
+- tests/checks run and exit codes,
+- known caveats,
+- next pickup prompt if relevant.
+
+Final response should be concise and evidence-based:
+
+1. Plan checkpoint
+2. Changes made
+3. Verification results with commands/exit codes
+4. Final status: PASS / FAIL / BLOCKED
+5. Any restart/reload needed
+
+## Acceptance criteria template
+
+Use or adapt this checklist:
+
+- Plan was created and verified before implementation.
+- Implementation changed only scoped files.
+- Tests/checks relevant to changed behavior pass.
+- `git diff --check` passes for touched files.
+- Handoff/final summary records evidence and caveats.
+
+## Pitfalls
+
+- Do not confuse plan-only mode with devflow. Devflow continues after plan verification unless blocked.
+- Do not claim broad quality gates passed unless they were actually run.
+- Do not let a spawned agent or Claude Code session become the primary orchestrator by accident.
+- Do not overwrite unrelated user changes in a dirty repo.

--- a/tests/agent/test_model_sampling_registry.py
+++ b/tests/agent/test_model_sampling_registry.py
@@ -1,0 +1,32 @@
+"""Tests for local/backend sampling registry."""
+
+from agent.model_sampling_registry import apply_sampling_defaults, resolve_sampling_profile
+
+
+def test_resolve_sampling_profile_matches_ollama_provider_or_url():
+    by_provider = resolve_sampling_profile(provider="ollama", base_url="", model="qwen")
+    by_url = resolve_sampling_profile(provider="custom", base_url="http://127.0.0.1:11434/v1", model="qwen")
+
+    assert by_provider is not None
+    assert by_provider.name == "ollama_tool_stable"
+    assert by_url is not None
+    assert by_url.name == "ollama_tool_stable"
+
+
+def test_apply_sampling_defaults_never_overrides_explicit_request_values():
+    profile = resolve_sampling_profile(provider="ollama", base_url="", model="qwen")
+    kwargs = {"model": "qwen", "temperature": 0.7, "extra_body": {"top_p": 0.5, "num_ctx": 8192}}
+
+    out = apply_sampling_defaults(kwargs, profile)
+
+    assert out["temperature"] == 0.7
+    assert out["extra_body"]["top_p"] == 0.5
+    assert out["extra_body"]["num_ctx"] == 8192
+
+
+def test_apply_sampling_defaults_adds_conservative_values_when_absent():
+    profile = resolve_sampling_profile(provider="lmstudio", base_url="", model="local")
+    out = apply_sampling_defaults({"model": "local"}, profile)
+
+    assert out["temperature"] == 0.2
+    assert out["extra_body"]["top_p"] == 0.9

--- a/tests/agent/test_tool_guardrails.py
+++ b/tests/agent/test_tool_guardrails.py
@@ -38,6 +38,8 @@ def test_default_config_is_soft_warning_only_with_hard_stop_disabled():
 
     assert cfg.warnings_enabled is True
     assert cfg.hard_stop_enabled is False
+    assert cfg.prerequisite_checks_enabled is True
+    assert cfg.prerequisite_hard_stop_enabled is False
     assert cfg.exact_failure_warn_after == 2
     assert cfg.same_tool_failure_warn_after == 3
     assert cfg.no_progress_warn_after == 2
@@ -51,6 +53,8 @@ def test_config_parses_nested_warn_and_hard_stop_thresholds():
         {
             "warnings_enabled": False,
             "hard_stop_enabled": True,
+            "prerequisite_checks_enabled": False,
+            "prerequisite_hard_stop_enabled": True,
             "warn_after": {
                 "exact_failure": 3,
                 "same_tool_failure": 4,
@@ -66,12 +70,109 @@ def test_config_parses_nested_warn_and_hard_stop_thresholds():
 
     assert cfg.warnings_enabled is False
     assert cfg.hard_stop_enabled is True
+    assert cfg.prerequisite_checks_enabled is False
+    assert cfg.prerequisite_hard_stop_enabled is True
     assert cfg.exact_failure_warn_after == 3
     assert cfg.same_tool_failure_warn_after == 4
     assert cfg.no_progress_warn_after == 5
     assert cfg.exact_failure_block_after == 6
     assert cfg.same_tool_failure_halt_after == 7
     assert cfg.no_progress_block_after == 8
+
+
+def test_missing_prerequisite_warns_by_default_without_blocking_execution():
+    controller = ToolCallGuardrailController()
+
+    decision = controller.before_call("patch", {"path": "a.py", "old_string": "x", "new_string": "y"})
+
+    assert decision.action == "warn"
+    assert decision.code == "missing_tool_prerequisite_warning"
+    assert "read_file" in decision.message
+    assert "search_files" in decision.message
+    assert decision.allows_execution is True
+
+
+def test_successful_prerequisite_satisfies_later_tool_call():
+    controller = ToolCallGuardrailController()
+
+    controller.after_call("read_file", {"path": "a.py"}, "contents", failed=False)
+
+    decision = controller.before_call("patch", {"path": "a.py", "old_string": "x", "new_string": "y"})
+    assert decision.action == "allow"
+
+
+def test_prerequisite_hard_stop_blocks_before_execution_when_explicitly_enabled():
+    controller = ToolCallGuardrailController(
+        ToolCallGuardrailConfig(prerequisite_hard_stop_enabled=True)
+    )
+
+    decision = controller.before_call("browser_click", {"ref": "@e1"})
+
+    assert decision.action == "block"
+    assert decision.code == "missing_tool_prerequisite_block"
+    assert "browser_snapshot" in decision.message
+    assert decision.should_halt is True
+    assert controller.halt_decision == decision
+
+
+def test_argument_sensitive_prerequisites_require_list_actions():
+    controller = ToolCallGuardrailController()
+
+    named_send = controller.before_call("send_message", {"action": "send", "target": "discord:#ops"})
+    assert named_send.action == "warn"
+    assert "send_message:list" in named_send.message
+
+    controller.after_call("send_message", {"action": "list"}, '{"targets": []}', failed=False)
+    assert controller.before_call("send_message", {"action": "send", "target": "discord:#ops"}).action == "allow"
+
+    cron = ToolCallGuardrailController()
+    assert cron.before_call("cronjob", {"action": "remove", "job_id": "abc"}).action == "warn"
+    cron.after_call("cronjob", {"action": "list"}, '{"jobs": []}', failed=False)
+    assert cron.before_call("cronjob", {"action": "remove", "job_id": "abc"}).action == "allow"
+
+
+def test_prerequisite_checks_can_be_disabled_for_legacy_sessions():
+    controller = ToolCallGuardrailController(
+        ToolCallGuardrailConfig(prerequisite_checks_enabled=False)
+    )
+
+    assert controller.before_call("patch", {"path": "a.py"}).action == "allow"
+
+
+def test_warnings_disabled_suppresses_soft_prerequisite_warnings():
+    controller = ToolCallGuardrailController(
+        ToolCallGuardrailConfig(warnings_enabled=False)
+    )
+
+    assert controller.before_call("patch", {"path": "a.py"}).action == "allow"
+
+
+def test_prerequisite_warning_does_not_mask_existing_hard_stop_block():
+    controller = ToolCallGuardrailController(
+        ToolCallGuardrailConfig(
+            hard_stop_enabled=True,
+            exact_failure_block_after=2,
+            prerequisite_hard_stop_enabled=False,
+        )
+    )
+    args = {"path": "a.py", "old_string": "x", "new_string": "y"}
+    controller.after_call("patch", args, '{"error":"boom"}', failed=True)
+    controller.after_call("patch", args, '{"error":"boom"}', failed=True)
+
+    decision = controller.before_call("patch", args)
+
+    assert decision.action == "block"
+    assert decision.code == "repeated_exact_failure_block"
+
+
+def test_append_toolguard_guidance_leaves_non_string_results_unchanged():
+    controller = ToolCallGuardrailController()
+    decision = controller.before_call("patch", {"path": "a.py"})
+    result = {"_multimodal": True, "content": [{"type": "text", "text": "ok"}]}
+
+    from agent.tool_guardrails import append_toolguard_guidance
+
+    assert append_toolguard_guidance(result, decision) is result
 
 
 def test_default_repeated_identical_failed_call_warns_without_blocking():

--- a/tests/agent/test_tool_guardrails.py
+++ b/tests/agent/test_tool_guardrails.py
@@ -268,6 +268,21 @@ def test_same_tool_varying_args_warns_by_default_without_halting():
     assert controller.halt_decision is None
 
 
+def test_patch_failure_warning_recommends_reread_and_smaller_context():
+    controller = ToolCallGuardrailController(
+        ToolCallGuardrailConfig(same_tool_failure_warn_after=2, same_tool_failure_halt_after=99)
+    )
+
+    controller.after_call("patch", {"path": "a.py", "old_string": "x1", "new_string": "y"}, '{"error":"not found"}', failed=True)
+    decision = controller.after_call("patch", {"path": "a.py", "old_string": "x2", "new_string": "y"}, '{"error":"not found"}', failed=True)
+
+    assert decision.action == "warn"
+    assert decision.code == "same_tool_failure_warning"
+    assert "Re-read" in decision.message
+    assert "smaller exact context" in decision.message
+    assert "write_file only" in decision.message
+
+
 def test_hard_stop_enabled_halts_same_tool_varying_args_failure_streak():
     controller = ToolCallGuardrailController(
         ToolCallGuardrailConfig(

--- a/tests/agent/test_workflow_guardrails.py
+++ b/tests/agent/test_workflow_guardrails.py
@@ -1,0 +1,183 @@
+"""Tests for Forge-style workflow guardrails."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from agent.workflow_guardrails import (
+    WorkflowGuardrailConfig,
+    WorkflowGuardrailController,
+    append_workflow_advisory,
+)
+from run_agent import AIAgent
+
+
+def _mock_response(content="done", finish_reason="stop", tool_calls=None):
+    msg = SimpleNamespace(content=content, tool_calls=tool_calls)
+    choice = SimpleNamespace(message=msg, finish_reason=finish_reason)
+    return SimpleNamespace(choices=[choice], model="test/model", usage=None)
+
+
+def _make_agent(config: dict | None = None, max_iterations: int = 5) -> AIAgent:
+    with (
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("hermes_cli.config.load_config", return_value=config or {}),
+        patch("run_agent.OpenAI"),
+    ):
+        agent = AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://openrouter.ai/api/v1",
+            max_iterations=max_iterations,
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+    agent.client = MagicMock()
+    agent._cached_system_prompt = "You are helpful."
+    agent._use_prompt_caching = False
+    agent.compression_enabled = False
+    agent.save_trajectories = False
+    return agent
+
+
+def test_workflow_config_defaults_to_legacy_safe_off():
+    cfg = WorkflowGuardrailConfig()
+
+    assert cfg.enabled is False
+    assert cfg.final_gate_mode == "off"
+    assert cfg.max_nudges == 1
+
+
+def test_workflow_config_parses_modes_and_invalid_values():
+    cfg = WorkflowGuardrailConfig.from_mapping({"enabled": False, "final_gate_mode": "nudge", "max_nudges": 2})
+    assert cfg.enabled is False
+    assert cfg.final_gate_mode == "nudge"
+    assert cfg.max_nudges == 2
+
+    fallback = WorkflowGuardrailConfig.from_mapping({"enabled": True, "final_gate_mode": "explode"})
+    assert fallback.final_gate_mode == "off"
+
+
+def test_repo_review_missing_verify_returns_advisory():
+    controller = WorkflowGuardrailController(
+        WorkflowGuardrailConfig(enabled=True, final_gate_mode="advisory")
+    )
+    controller.reset_for_turn("다음 GitHub 레포지토리를 검토해줘 https://github.com/example/repo")
+    controller.record_tool_result("read_file")
+    controller.record_tool_result("search_files")
+
+    decision = controller.evaluate_final_response("review done")
+
+    assert decision.action == "advisory"
+    assert decision.workflow_key == "repo_review"
+    assert [step.key for step in decision.missing_steps] == ["inspect_metadata", "verify"]
+    assert "Run tests or smoke checks" in decision.message
+
+
+def test_devflow_all_required_steps_allow_final():
+    controller = WorkflowGuardrailController()
+    controller.reset_for_turn("구현 진행해서 완료해")
+    for tool in ["read_file", "patch", "terminal"]:
+        controller.record_tool_result(tool)
+
+    decision = controller.evaluate_final_response("done")
+
+    assert decision.action == "allow"
+    assert decision.missing_steps == ()
+
+
+def test_nudge_mode_nudges_once_then_advises():
+    controller = WorkflowGuardrailController(
+        WorkflowGuardrailConfig(enabled=True, final_gate_mode="nudge", max_nudges=1)
+    )
+    controller.reset_for_turn("구현 진행해서 완료해")
+    controller.record_tool_result("read_file")
+    controller.record_tool_result("patch")
+
+    first = controller.evaluate_final_response("done")
+    second = controller.evaluate_final_response("done")
+
+    assert first.action == "nudge"
+    assert second.action == "advisory"
+
+
+def test_append_workflow_advisory_adds_footer_only_for_advisory():
+    controller = WorkflowGuardrailController(
+        WorkflowGuardrailConfig(enabled=True, final_gate_mode="advisory")
+    )
+    controller.reset_for_turn("구현 진행해서 완료해")
+    decision = controller.evaluate_final_response("done")
+
+    text = append_workflow_advisory("done", decision)
+
+    assert text.startswith("done")
+    assert "Workflow guardrail advisory" in text
+
+
+def test_runtime_default_workflow_guardrail_is_off_for_legacy_compatibility():
+    agent = _make_agent()
+    agent.client.chat.completions.create.return_value = _mock_response("done")
+
+    with (
+        patch.object(agent, "_persist_session"),
+        patch.object(agent, "_save_trajectory"),
+        patch.object(agent, "_cleanup_task_resources"),
+    ):
+        result = agent.run_conversation("구현 진행해서 완료해")
+
+    assert result["final_response"] == "done"
+    assert "Workflow guardrail advisory" not in result["final_response"]
+    assert result["turn_exit_reason"] == "text_response(finish_reason=stop)"
+
+
+def test_runtime_opt_in_workflow_advisory_preserves_final_response_and_metadata():
+    config = {"workflow_guardrails": {"enabled": True, "final_gate_mode": "advisory"}}
+    agent = _make_agent(config=config)
+    agent.client.chat.completions.create.return_value = _mock_response("done")
+
+    with (
+        patch.object(agent, "_persist_session"),
+        patch.object(agent, "_save_trajectory"),
+        patch.object(agent, "_cleanup_task_resources"),
+    ):
+        result = agent.run_conversation("구현 진행해서 완료해")
+
+    assert result["final_response"].startswith("done")
+    assert "Workflow guardrail advisory" in result["final_response"]
+    assert result["turn_exit_reason"] == "workflow_guardrail_advisory(devflow)"
+    assert result["workflow_guardrail"]["active"] == ["devflow"]
+
+
+def test_runtime_workflow_nudge_continues_then_allows_after_tool_evidence():
+    config = {"workflow_guardrails": {"enabled": True, "final_gate_mode": "nudge", "max_nudges": 1}}
+    agent = _make_agent(config=config, max_iterations=4)
+    agent.client.chat.completions.create.side_effect = [
+        _mock_response("premature final"),
+        _mock_response("done"),
+    ]
+    # Simulate the missing tool evidence being supplied between iterations by
+    # the runtime/tool layer. This keeps the test deterministic and focused on
+    # final-gate role sequencing.
+    original_eval = agent._workflow_guardrails.evaluate_final_response
+    calls = {"n": 0}
+
+    def eval_with_evidence(text):
+        calls["n"] += 1
+        if calls["n"] == 2:
+            for tool in ["read_file", "patch", "terminal"]:
+                agent._workflow_guardrails.record_tool_result(tool)
+        return original_eval(text)
+
+    agent._workflow_guardrails.evaluate_final_response = eval_with_evidence
+
+    with (
+        patch.object(agent, "_persist_session"),
+        patch.object(agent, "_save_trajectory"),
+        patch.object(agent, "_cleanup_task_resources"),
+    ):
+        result = agent.run_conversation("구현 진행해서 완료해")
+
+    assert result["final_response"] == "done"
+    roles = [m["role"] for m in result["messages"]]
+    assert roles[-3:] == ["assistant", "user", "assistant"]
+    assert result["completed"] is True

--- a/tests/cli/test_busy_input_mode_command.py
+++ b/tests/cli/test_busy_input_mode_command.py
@@ -160,6 +160,18 @@ class TestAfterworkCommand(unittest.TestCase):
 
         self.assertEqual(calls, [("away", "all")])
 
+    def test_commute_command_prints_help(self):
+        cli_mod = _import_cli()
+        printed = []
+
+        with patch.object(cli_mod, "_cprint", lambda msg: printed.append(str(msg))):
+            cli_mod.HermesCLI._handle_commute_command(SimpleNamespace())
+
+        text = "\n".join(printed)
+        self.assertIn("/projects", text)
+        self.assertIn("/afterwork current", text)
+        self.assertIn("/office current", text)
+
     def test_afterwork_steers_running_agent_without_interrupt_queue(self):
         cli_mod = _import_cli()
 

--- a/tests/cli/test_busy_input_mode_command.py
+++ b/tests/cli/test_busy_input_mode_command.py
@@ -1,6 +1,7 @@
 """Tests for the /busy CLI command and busy-input-mode config handling."""
 
 import unittest
+from queue import Queue
 from types import SimpleNamespace
 from unittest.mock import patch
 
@@ -121,3 +122,61 @@ class TestBusyCommandRegistry(unittest.TestCase):
         busy = next(c for c in COMMAND_REGISTRY if c.name == "busy")
         assert busy.args_hint == "[queue|steer|interrupt|status]"
         assert busy.category == "Configuration"
+
+
+class TestAfterworkCommand(unittest.TestCase):
+    def test_plaintext_afterwork_phrases_are_recognized(self):
+        cli_mod = _import_cli()
+
+        for text in ("퇴근", "퇴근모드", "퇴근 모드", "afterwork", "awaymode"):
+            self.assertTrue(cli_mod.HermesCLI._looks_like_afterwork_plaintext(text))
+
+        self.assertFalse(cli_mod.HermesCLI._looks_like_afterwork_plaintext("그냥 퇴근할까?"))
+
+    def test_afterwork_steers_running_agent_without_interrupt_queue(self):
+        cli_mod = _import_cli()
+
+        class FakeAgent:
+            def __init__(self):
+                self.payloads = []
+
+            def steer(self, text):
+                self.payloads.append(text)
+                return True
+
+        agent = FakeAgent()
+        pending = Queue()
+        stub = SimpleNamespace(
+            _agent_running=True,
+            agent=agent,
+            _pending_input=pending,
+            cwd="/tmp/example-project",
+        )
+        stub._afterwork_prompt = lambda: cli_mod.HermesCLI._afterwork_prompt(stub)
+
+        with patch.object(cli_mod, "_cprint"):
+            cli_mod.HermesCLI._handle_afterwork_command(stub, "/afterwork")
+
+        self.assertEqual(pending.qsize(), 0)
+        self.assertEqual(len(agent.payloads), 1)
+        self.assertIn("퇴근모드로 전환", agent.payloads[0])
+        self.assertIn("중단하지 말고", agent.payloads[0])
+
+    def test_afterwork_queues_when_steer_unavailable(self):
+        cli_mod = _import_cli()
+        pending = Queue()
+        stub = SimpleNamespace(
+            _agent_running=True,
+            agent=None,
+            _pending_input=pending,
+            cwd="/tmp/example-project",
+        )
+        stub._afterwork_prompt = lambda: cli_mod.HermesCLI._afterwork_prompt(stub)
+
+        with patch.object(cli_mod, "_cprint"):
+            cli_mod.HermesCLI._handle_afterwork_command(stub, "퇴근모드")
+
+        self.assertEqual(pending.qsize(), 1)
+        queued = pending.get_nowait()
+        self.assertIn("퇴근모드로 전환", queued)
+        self.assertIn("중단하지 말고", queued)

--- a/tests/cli/test_busy_input_mode_command.py
+++ b/tests/cli/test_busy_input_mode_command.py
@@ -133,6 +133,33 @@ class TestAfterworkCommand(unittest.TestCase):
 
         self.assertFalse(cli_mod.HermesCLI._looks_like_afterwork_plaintext("그냥 퇴근할까?"))
 
+    def test_plaintext_office_phrases_are_recognized(self):
+        cli_mod = _import_cli()
+
+        for text in ("출근", "출근모드", "출근 모드", "office", "morning"):
+            self.assertTrue(cli_mod.HermesCLI._looks_like_office_plaintext(text))
+            self.assertTrue(cli_mod.HermesCLI._should_handle_afterwork_command_inline(cli_mod.HermesCLI, text))
+
+        self.assertFalse(cli_mod.HermesCLI._looks_like_office_plaintext("내일 출근하면"))
+
+    def test_office_command_uses_project_mode_router(self):
+        cli_mod = _import_cli()
+        calls = []
+        stub = SimpleNamespace(_handle_project_mode_command=lambda mode, target: calls.append((mode, target)))
+
+        cli_mod.HermesCLI._handle_office_command(stub, "/office current")
+
+        self.assertEqual(calls, [("office", "current")])
+
+    def test_afterwork_all_uses_project_mode_router(self):
+        cli_mod = _import_cli()
+        calls = []
+        stub = SimpleNamespace(_handle_project_mode_command=lambda mode, target: calls.append((mode, target)))
+
+        cli_mod.HermesCLI._handle_afterwork_command(stub, "/afterwork all")
+
+        self.assertEqual(calls, [("away", "all")])
+
     def test_afterwork_steers_running_agent_without_interrupt_queue(self):
         cli_mod = _import_cli()
 

--- a/tests/cli/test_cli_approval_ui.py
+++ b/tests/cli/test_cli_approval_ui.py
@@ -96,6 +96,28 @@ class TestCliApprovalUi:
         assert cli._app.current_buffer.text == "draft command"
         assert cli._app.current_buffer.cursor_position == 5
 
+    def test_approval_notification_identifies_cli_session_and_terminal_only_flow(self):
+        cli = _make_cli_stub()
+        cli.session_id = "20260512_151213_8a0a60"
+        cli._pending_title = "업무 환경 상황 파악"
+        cli._session_db = None
+
+        with patch("os.getcwd", return_value="/tmp/hermes-work"):
+            message = cli._build_approval_notification_message(
+                "rm -rf /tmp/demo",
+                "recursive delete",
+                600,
+            )
+
+        assert "Hermes CLI 권한 승인 요청" in message
+        assert "세션: 업무 환경 상황 파악" in message
+        assert "세션 ID: 20260512_151213_8a0a60" in message
+        assert "작업 위치: /tmp/hermes-work" in message
+        assert "원격 승인" in message
+        assert "/approve" in message
+        assert "터미널에서도" in message
+        assert "rm -rf /tmp/demo" in message
+
     def test_approval_callback_includes_view_for_long_commands(self):
         cli = _make_cli_stub()
         command = "sudo dd if=/tmp/githubcli-keyring.gpg of=/usr/share/keyrings/githubcli-archive-keyring.gpg bs=4M status=progress"
@@ -117,6 +139,49 @@ class TestCliApprovalUi:
         cli._approval_state["response_queue"].put("deny")
         thread.join(timeout=2)
         assert result["value"] == "deny"
+
+    def test_approval_callback_accepts_shared_broker_resolution(self):
+        cli = _make_cli_stub()
+        cli.session_id = "sid-remote-approval"
+        cli._pending_title = "Remote approval test"
+        cli._session_db = None
+        result = {}
+
+        def _run_callback():
+            result["value"] = cli._approval_callback("rm -rf /tmp/demo", "delete demo")
+
+        with patch.object(cli_module, "_cprint"), patch(
+            "hermes_cli.config.load_config",
+            return_value={"approvals": {"timeout": 60, "notify_target": "telegram:chat-1"}},
+        ):
+            thread = threading.Thread(target=_run_callback, daemon=True)
+            thread.start()
+
+            deadline = time.time() + 2
+            while cli._approval_state is None and time.time() < deadline:
+                time.sleep(0.01)
+
+            assert cli._approval_state is not None
+
+            from tools import shared_approval_broker as broker
+
+            deadline = time.time() + 2
+            while (
+                not broker.list_resolvable_cli_approvals(
+                    {"platform": "telegram", "chat_id": "chat-1"}
+                )
+                and time.time() < deadline
+            ):
+                time.sleep(0.01)
+
+            assert broker.resolve_oldest_cli_approval(
+                "session",
+                source={"platform": "telegram", "chat_id": "chat-1"},
+            ) == 1
+            thread.join(timeout=3)
+
+        assert not thread.is_alive()
+        assert result["value"] == "session"
 
     def test_handle_approval_selection_view_expands_in_place(self):
         cli = _make_cli_stub()

--- a/tests/cli/test_cli_approval_ui.py
+++ b/tests/cli/test_cli_approval_ui.py
@@ -109,14 +109,40 @@ class TestCliApprovalUi:
                 600,
             )
 
-        assert "Hermes CLI 권한 승인 요청" in message
-        assert "세션: 업무 환경 상황 파악" in message
-        assert "세션 ID: 20260512_151213_8a0a60" in message
-        assert "작업 위치: /tmp/hermes-work" in message
-        assert "원격 승인" in message
-        assert "/approve" in message
-        assert "터미널에서도" in message
+        assert "[Hermes 승인 요청]" in message
+        assert "무엇을 승인하나요?" in message
+        assert "어디서 요청했나요?" in message
+        assert "- 안건: recursive delete" in message
+        assert "- 프로젝트: hermes-work" in message
+        assert "- 세션: 업무 환경 상황 파악" in message
+        assert "- 세션 ID: 20260512_151213_8a0a60" in message
+        assert "- 작업 위치: /tmp/hermes-work" in message
+        assert "승인/거절은 현재 열려 있는 Hermes 터미널" in message
+        assert "telegram:<chat_id>" in message
         assert "rm -rf /tmp/demo" in message
+
+    def test_approval_notification_lists_remote_telegram_reply_commands(self):
+        cli = _make_cli_stub()
+        cli.session_id = "20260512_151213_8a0a60"
+        cli._pending_title = "llm-eval-pipeline"
+        cli._session_db = None
+
+        with patch("os.getcwd", return_value="/workspace/work/llm-eval-pipeline"):
+            message = cli._build_approval_notification_message(
+                "python run_benchmark.py --target demo",
+                "benchmark execution",
+                600,
+                "telegram:8584626899",
+            )
+
+        assert "- 프로젝트: llm-eval-pipeline" in message
+        assert "- 세션: llm-eval-pipeline" in message
+        assert "- 안건: benchmark execution" in message
+        assert "- 이번 1회만 승인: /approve" in message
+        assert "- 이 세션 동안 같은 유형 승인: /approve session" in message
+        assert "- 항상 승인 규칙 저장: /approve always" in message
+        assert "- 거절: /deny" in message
+        assert "자연어 '승인'은 명령이 아닙니다" in message
 
     def test_approval_callback_includes_view_for_long_commands(self):
         cli = _make_cli_stub()

--- a/tests/cli/test_workflow_skill_wrappers.py
+++ b/tests/cli/test_workflow_skill_wrappers.py
@@ -1,0 +1,88 @@
+"""Tests for built-in workflow slash commands that wrap skills."""
+
+from queue import Queue
+
+import cli as cli_mod
+from cli import HermesCLI
+
+
+def test_cli_workflow_wrapper_queues_skill_invocation(monkeypatch):
+    instance = object.__new__(HermesCLI)
+    instance.session_id = "test-session"
+    instance._pending_input = Queue()
+
+    monkeypatch.setattr(
+        cli_mod,
+        "get_skill_commands",
+        lambda: {"/autopilot": {"name": "autopilot"}},
+    )
+    monkeypatch.setattr(cli_mod, "resolve_skill_command_key", lambda name: f"/{name}")
+
+    calls = {}
+
+    def fake_build(cmd_key, user_instruction, task_id=None):
+        calls["cmd_key"] = cmd_key
+        calls["user_instruction"] = user_instruction
+        calls["task_id"] = task_id
+        return "LOADED AUTOPILOT"
+
+    monkeypatch.setattr(cli_mod, "build_skill_invocation_message", fake_build)
+
+    instance.process_command("/autopilot finish the goal")
+
+    assert calls == {
+        "cmd_key": "/autopilot",
+        "user_instruction": "finish the goal",
+        "task_id": "test-session",
+    }
+    assert instance._pending_input.get_nowait() == "LOADED AUTOPILOT"
+
+
+def test_cli_deepinterview_alias_uses_canonical_skill(monkeypatch):
+    instance = object.__new__(HermesCLI)
+    instance.session_id = "test-session"
+    instance._pending_input = Queue()
+
+    monkeypatch.setattr(
+        cli_mod,
+        "get_skill_commands",
+        lambda: {"/deep-interview": {"name": "deep-interview"}},
+    )
+    monkeypatch.setattr(
+        cli_mod,
+        "resolve_skill_command_key",
+        lambda name: "/deep-interview" if name == "deep-interview" else None,
+    )
+    monkeypatch.setattr(
+        cli_mod,
+        "build_skill_invocation_message",
+        lambda cmd_key, user_instruction, task_id=None: f"{cmd_key}:{user_instruction}:{task_id}",
+    )
+
+    instance.process_command("/deepinterview requirements")
+
+    assert instance._pending_input.get_nowait() == "/deep-interview:requirements:test-session"
+
+
+def test_cli_devflow_wrapper_queues_skill_invocation(monkeypatch):
+    instance = object.__new__(HermesCLI)
+    instance.session_id = "test-session"
+    instance._pending_input = Queue()
+
+    monkeypatch.setattr(
+        cli_mod,
+        "get_skill_commands",
+        lambda: {"/devflow": {"name": "devflow"}},
+    )
+    monkeypatch.setattr(cli_mod, "resolve_skill_command_key", lambda name: f"/{name}")
+    monkeypatch.setattr(
+        cli_mod,
+        "build_skill_invocation_message",
+        lambda cmd_key, user_instruction, task_id=None: f"{cmd_key}:{user_instruction}:{task_id}",
+    )
+
+    instance.process_command("/devflow implement the reviewed workflow")
+
+    assert instance._pending_input.get_nowait() == (
+        "/devflow:implement the reviewed workflow:test-session"
+    )

--- a/tests/gateway/test_approve_deny_commands.py
+++ b/tests/gateway/test_approve_deny_commands.py
@@ -262,6 +262,32 @@ class TestApproveCommand:
         assert "No pending command" in result
 
     @pytest.mark.asyncio
+    async def test_approve_falls_back_to_shared_cli_broker(self):
+        """When no gateway-thread approval is pending, /approve can resolve CLI prompts."""
+        from tools import shared_approval_broker as broker
+
+        runner = _make_runner()
+        request_id = broker.register_cli_approval(
+            {
+                "session_key": "cli-session-for-gateway",
+                "session_id": "sid-cli",
+                "title": "CLI session",
+                "cwd": "/tmp",
+                "pid": os.getpid(),
+                "command": "rm -rf /tmp/demo",
+                "description": "delete demo",
+                "notify_target": "telegram:c1",
+            },
+            ttl_seconds=600,
+        )
+
+        result = await runner._handle_approve_command(_make_event("/approve session"))
+
+        assert "CLI" in result or "remote" in result.lower()
+        assert broker.get_cli_approval(request_id)["choice"] == "session"
+
+
+    @pytest.mark.asyncio
     async def test_approve_stale_old_style_pending(self):
         """Old-style _pending_approvals without blocking event reports expired."""
         runner = _make_runner()
@@ -324,6 +350,31 @@ class TestDenyCommand:
         runner = _make_runner()
         result = await runner._handle_deny_command(_make_event("/deny"))
         assert "No pending command" in result
+
+    @pytest.mark.asyncio
+    async def test_deny_falls_back_to_shared_cli_broker(self):
+        """When no gateway-thread approval is pending, /deny can resolve CLI prompts."""
+        from tools import shared_approval_broker as broker
+
+        runner = _make_runner()
+        request_id = broker.register_cli_approval(
+            {
+                "session_key": "cli-session-for-gateway-deny",
+                "session_id": "sid-cli-deny",
+                "title": "CLI session",
+                "cwd": "/tmp",
+                "pid": os.getpid(),
+                "command": "git reset --hard",
+                "description": "reset tree",
+                "notify_target": "telegram:c1",
+            },
+            ttl_seconds=600,
+        )
+
+        result = await runner._handle_deny_command(_make_event("/deny"))
+
+        assert "CLI" in result or "remote" in result.lower()
+        assert broker.get_cli_approval(request_id)["choice"] == "deny"
 
 
 # ------------------------------------------------------------------

--- a/tests/gateway/test_command_bypass_active_session.py
+++ b/tests/gateway/test_command_bypass_active_session.py
@@ -300,6 +300,9 @@ class TestAllResolvableCommandsBypassGuard:
             ("/usage", "usage"),
             ("/reload-mcp", "reload-mcp"),
             ("/sethome", "sethome"),
+            ("/afterwork", "afterwork"),
+            ("/퇴근", "afterwork"),
+            ("/퇴근모드", "afterwork"),
         ],
     )
     @pytest.mark.asyncio
@@ -319,6 +322,30 @@ class TestAllResolvableCommandsBypassGuard:
             "not silently discarded"
         )
 
+    @pytest.mark.asyncio
+    async def test_afterwork_plaintext_is_coerced_and_bypasses_guard(self):
+        """Plain Korean away-mode text must not interrupt/queue as normal chat."""
+        adapter = _make_adapter()
+        sk = _session_key()
+        adapter._active_sessions[sk] = asyncio.Event()
+
+        await adapter.handle_message(_make_event("퇴근모드"))
+
+        assert sk not in adapter._pending_messages
+        assert any("handled:afterwork" in r for r in adapter.sent_responses)
+
+    @pytest.mark.asyncio
+    async def test_afterwork_natural_sentence_stays_normal_text(self):
+        """Only exact away-mode phrases become commands."""
+        adapter = _make_adapter()
+        sk = _session_key()
+        adapter._active_sessions[sk] = asyncio.Event()
+
+        await adapter.handle_message(_make_event("그냥 퇴근할까?"))
+
+        assert sk in adapter._pending_messages
+        assert len(adapter.sent_responses) == 0
+
     def test_should_bypass_returns_true_for_every_registered_command(self):
         """Spot-check: the commands previously-broken on Discord all bypass."""
         from hermes_cli.commands import should_bypass_active_session
@@ -326,7 +353,7 @@ class TestAllResolvableCommandsBypassGuard:
         for cmd in (
             "model", "reasoning", "personality", "voice", "insights", "title",
             "resume", "retry", "undo", "compress", "usage",
-            "reload-mcp", "sethome", "reset",
+            "reload-mcp", "sethome", "reset", "afterwork", "퇴근", "퇴근모드",
         ):
             assert should_bypass_active_session(cmd) is True, (
                 f"/{cmd} must bypass the active-session guard"

--- a/tests/gateway/test_project_sessions.py
+++ b/tests/gateway/test_project_sessions.py
@@ -84,7 +84,22 @@ def test_switch_and_current_project_with_alias(monkeypatch, tmp_path):
 
 
 def test_handle_prefixed_message_routes_via_steer(monkeypatch, tmp_path):
-    monkeypatch.setattr(ps, "discover_tmux_projects", lambda: [])
+    monkeypatch.setattr(
+        ps,
+        "discover_tmux_projects",
+        lambda: [
+            ps.ProjectSession(
+                label="dev-1",
+                tmux_target="dev:1.0",
+                workdir=str(tmp_path),
+                aliases=["HUD"],
+                notify=True,
+                status="ready",
+                command="python3.11",
+                routable=True,
+            )
+        ],
+    )
     sent = []
     monkeypatch.setattr(ps, "_send_to_tmux", lambda project, prompt: sent.append((project.label, prompt)))
     state = ps.ProjectRoutingState(
@@ -96,6 +111,9 @@ def test_handle_prefixed_message_routes_via_steer(monkeypatch, tmp_path):
                 workdir=str(tmp_path),
                 aliases=["HUD"],
                 notify=True,
+                status="ready",
+                command="python3.11",
+                routable=True,
             )
         }
     )
@@ -134,13 +152,20 @@ def test_handle_prefixed_message_ignores_office_mode(monkeypatch, tmp_path):
 
 
 def test_set_mode_toggles_notify_and_sends_instructions(monkeypatch, tmp_path):
-    monkeypatch.setattr(ps, "discover_tmux_projects", lambda: [])
+    monkeypatch.setattr(
+        ps,
+        "discover_tmux_projects",
+        lambda: [
+            ps.ProjectSession(label="dev-1", tmux_target="dev:1.0", workdir=str(tmp_path), status="ready", command="python3.11", routable=True),
+            ps.ProjectSession(label="dev-2", tmux_target="dev:2.0", workdir=str(tmp_path), status="ready", command="hermes", routable=True),
+        ],
+    )
     sent = []
     monkeypatch.setattr(ps, "_send_to_tmux", lambda project, prompt: sent.append((project.label, prompt)))
     state = ps.ProjectRoutingState(
         projects={
-            "dev-1": ps.ProjectSession(label="dev-1", tmux_target="dev:1.0", workdir=str(tmp_path)),
-            "dev-2": ps.ProjectSession(label="dev-2", tmux_target="dev:2.0", workdir=str(tmp_path)),
+            "dev-1": ps.ProjectSession(label="dev-1", tmux_target="dev:1.0", workdir=str(tmp_path), status="ready", command="python3.11", routable=True),
+            "dev-2": ps.ProjectSession(label="dev-2", tmux_target="dev:2.0", workdir=str(tmp_path), status="ready", command="hermes", routable=True),
         }
     )
     path = tmp_path / "project_sessions.json"
@@ -179,14 +204,18 @@ def test_set_mode_rejects_invalid_scope(monkeypatch, tmp_path):
 
 
 def test_set_mode_does_not_mark_failed_project_notify(monkeypatch, tmp_path):
-    monkeypatch.setattr(ps, "discover_tmux_projects", lambda: [])
+    monkeypatch.setattr(
+        ps,
+        "discover_tmux_projects",
+        lambda: [ps.ProjectSession(label="dev-1", tmux_target="dev:1.0", workdir=str(tmp_path), status="ready", command="python3.11", routable=True)],
+    )
 
     def fail(project, prompt):
         raise RuntimeError("tmux missing")
 
     monkeypatch.setattr(ps, "_send_to_tmux", fail)
     state = ps.ProjectRoutingState(
-        projects={"dev-1": ps.ProjectSession(label="dev-1", tmux_target="dev:1.0", workdir=str(tmp_path))}
+        projects={"dev-1": ps.ProjectSession(label="dev-1", tmux_target="dev:1.0", workdir=str(tmp_path), status="ready", command="python3.11", routable=True)}
     )
     path = tmp_path / "project_sessions.json"
     ps.save_state(state, path)
@@ -214,3 +243,79 @@ def test_discover_tmux_projects_filters_broad_roots(monkeypatch, tmp_path):
 
     assert [p.label for p in projects] == ["HUD"]
     assert projects[0].tmux_target == "dev:1.0"
+
+
+
+def test_shell_only_project_is_listed_but_not_routable(monkeypatch, tmp_path):
+    project = tmp_path / "shell-project"
+    project.mkdir()
+    (project / ".hermes").mkdir()
+    output = "dev\t1\tshell-project\t0\t{}\tzsh\n".format(project)
+    monkeypatch.setattr(ps, "_run_tmux", lambda args: output)
+    sent = []
+    monkeypatch.setattr(ps, "_send_to_tmux", lambda project, prompt: sent.append((project.label, prompt)))
+    path = tmp_path / "project_sessions.json"
+    state = ps.refresh_from_tmux(ps.load_state(path))
+    ps.save_state(state, path)
+
+    listing = ps.format_projects(state, _source())
+    assert "SHELL-ONLY" in listing
+    assert "Telegram 지시: 불가" in listing
+
+    switch = ps.switch_project(_source(), "shell-project", path=path)
+    assert "전환 완료: 주의" in switch
+    blocked = ps.send_prompt_to_project(_source(), "상태 요약", path=path)
+    assert "[차단]" in blocked
+    assert "Hermes 세션이 아닙니다" in blocked
+    assert sent == []
+
+
+def test_afterwork_all_excludes_shell_only_and_stale_projects(monkeypatch, tmp_path):
+    sent = []
+    monkeypatch.setattr(ps, "_send_to_tmux", lambda project, prompt: sent.append((project.label, prompt)))
+    monkeypatch.setattr(ps, "_capture_pane", lambda project, lines=80: "recent output")
+    monkeypatch.setattr(
+        ps,
+        "discover_tmux_projects",
+        lambda: [
+            ps.ProjectSession(label="ready", tmux_target="dev:1.0", workdir=str(tmp_path / "ready"), status="ready", command="python3.11", routable=True),
+            ps.ProjectSession(label="shell", tmux_target="dev:2.0", workdir=str(tmp_path / "shell"), status="shell-only", command="zsh", routable=False),
+        ],
+    )
+    (tmp_path / "ready").mkdir()
+    (tmp_path / "shell").mkdir()
+    state = ps.ProjectRoutingState(
+        projects={
+            "ready": ps.ProjectSession(label="ready", tmux_target="dev:1.0", workdir=str(tmp_path / "ready"), status="ready", command="python3.11", routable=True),
+            "stale": ps.ProjectSession(label="stale", tmux_target="old:1.0", workdir=str(tmp_path / "stale"), status="ready", command="python3.11", routable=True),
+        }
+    )
+    path = tmp_path / "project_sessions.json"
+    ps.save_state(state, path)
+
+    msg = ps.set_mode(_source(), "away", "all", path=path)
+
+    assert "[ready]" in msg
+    assert "[shell] SHELL-ONLY" in msg
+    assert "[stale] STALE" in msg
+    assert sent == [("ready", sent[0][1])]
+    reloaded = ps.load_state(path)
+    assert reloaded.projects["ready"].notify is True
+    assert reloaded.projects["shell"].notify is False
+    assert reloaded.projects["stale"].notify is False
+    snapshot = Path(reloaded.projects["ready"].last_away_snapshot_path)
+    assert snapshot.exists()
+    assert "steer_sent: True" in snapshot.read_text(encoding="utf-8")
+
+
+def test_refresh_marks_missing_projects_stale(monkeypatch, tmp_path):
+    monkeypatch.setattr(ps, "discover_tmux_projects", lambda: [])
+    state = ps.ProjectRoutingState(
+        projects={"old": ps.ProjectSession(label="old", tmux_target="old:1.0", workdir=str(tmp_path), status="ready", command="python3.11", routable=True, notify=True)}
+    )
+
+    refreshed = ps.refresh_from_tmux(state)
+
+    assert refreshed.projects["old"].status == "stale"
+    assert refreshed.projects["old"].routable is False
+    assert refreshed.projects["old"].notify is False

--- a/tests/gateway/test_project_sessions.py
+++ b/tests/gateway/test_project_sessions.py
@@ -37,10 +37,27 @@ def test_parse_project_prefix():
 def test_commute_help_text_includes_core_commands():
     text = ps.commute_help_text()
     assert "/projects" in text
+    assert "퇴근모드 또는 /afterwork all" in text
+    assert "출근모드 또는 /office all" in text
     assert "/afterwork current" in text
-    assert "/office current" in text
+    assert "고급/테스트 옵션" in text
+    assert "/psend" in text
     assert "[label]" in text
     assert "/approve" in text
+
+
+def test_load_state_migrates_legacy_active_by_user(tmp_path):
+    path = tmp_path / "project_sessions.json"
+    path.write_text(
+        '{"active_by_user": {"8584626899": "HUD", "test": "work", "old": "home"}, "pinned": {}}',
+        encoding="utf-8",
+    )
+
+    state = ps.load_state(path)
+
+    assert state.mode == "office"
+    assert state.active_by_chat == {"telegram:8584626899": "HUD"}
+    assert state.projects == {}
 
 
 def test_switch_and_current_project_with_alias(monkeypatch, tmp_path):

--- a/tests/gateway/test_project_sessions.py
+++ b/tests/gateway/test_project_sessions.py
@@ -34,6 +34,15 @@ def test_parse_project_prefix():
     assert ps.parse_project_prefix("일반 메시지") is None
 
 
+def test_commute_help_text_includes_core_commands():
+    text = ps.commute_help_text()
+    assert "/projects" in text
+    assert "/afterwork current" in text
+    assert "/office current" in text
+    assert "[label]" in text
+    assert "/approve" in text
+
+
 def test_switch_and_current_project_with_alias(monkeypatch, tmp_path):
     monkeypatch.setattr(ps, "discover_tmux_projects", lambda: [])
     state = ps.ProjectRoutingState(

--- a/tests/gateway/test_project_sessions.py
+++ b/tests/gateway/test_project_sessions.py
@@ -1,0 +1,190 @@
+from pathlib import Path
+from types import SimpleNamespace
+
+from gateway import project_sessions as ps
+from gateway.config import Platform
+from gateway.platforms.base import MessageEvent, MessageType, coerce_plaintext_gateway_command
+from gateway.session import SessionSource
+
+
+def _source(chat_id="chat1"):
+    return SimpleNamespace(platform=SimpleNamespace(value="telegram"), chat_id=chat_id, user_id="u1", thread_id=None)
+
+
+def test_plaintext_commute_commands_are_dm_only():
+    dm = MessageEvent(
+        text="출근모드",
+        message_type=MessageType.TEXT,
+        source=SessionSource(platform=Platform.TELEGRAM, chat_id="c1", chat_type="dm", user_id="u1"),
+    )
+    coerce_plaintext_gateway_command(dm)
+    assert dm.text == "/office all"
+
+    group = MessageEvent(
+        text="출근모드",
+        message_type=MessageType.TEXT,
+        source=SessionSource(platform=Platform.TELEGRAM, chat_id="g1", chat_type="group", user_id="u1"),
+    )
+    coerce_plaintext_gateway_command(group)
+    assert group.text == "출근모드"
+
+
+def test_parse_project_prefix():
+    assert ps.parse_project_prefix("[dev-1] 다음 작업 진행해줘") == ("dev-1", "다음 작업 진행해줘")
+    assert ps.parse_project_prefix("일반 메시지") is None
+
+
+def test_switch_and_current_project_with_alias(monkeypatch, tmp_path):
+    monkeypatch.setattr(ps, "discover_tmux_projects", lambda: [])
+    state = ps.ProjectRoutingState(
+        projects={
+            "dev-1": ps.ProjectSession(
+                label="dev-1",
+                tmux_target="dev:1.0",
+                workdir=str(tmp_path),
+                aliases=["HUD"],
+            )
+        }
+    )
+    path = tmp_path / "project_sessions.json"
+    ps.save_state(state, path)
+
+    msg = ps.switch_project(_source(), "HUD", path=path)
+    assert "[dev-1]" in msg
+
+    current = ps.current_project(_source(), path=path)
+    assert "[dev-1]" in current
+    assert "dev:1.0" in current
+
+
+def test_handle_prefixed_message_routes_via_steer(monkeypatch, tmp_path):
+    monkeypatch.setattr(ps, "discover_tmux_projects", lambda: [])
+    sent = []
+    monkeypatch.setattr(ps, "_send_to_tmux", lambda project, prompt: sent.append((project.label, prompt)))
+    state = ps.ProjectRoutingState(
+        mode="away",
+        projects={
+            "dev-1": ps.ProjectSession(
+                label="dev-1",
+                tmux_target="dev:1.0",
+                workdir=str(tmp_path),
+                aliases=["HUD"],
+                notify=True,
+            )
+        }
+    )
+    path = tmp_path / "project_sessions.json"
+    ps.save_state(state, path)
+
+    result = ps.handle_prefixed_message(_source(), "[HUD] 다음 작업 진행해줘", path=path)
+
+    assert "[dev-1] 전달 완료" in result
+    assert sent == [("dev-1", "/steer 다음 작업 진행해줘")]
+
+
+def test_handle_prefixed_message_ignores_office_mode(monkeypatch, tmp_path):
+    monkeypatch.setattr(ps, "discover_tmux_projects", lambda: [])
+    sent = []
+    monkeypatch.setattr(ps, "_send_to_tmux", lambda project, prompt: sent.append((project.label, prompt)))
+    state = ps.ProjectRoutingState(
+        mode="office",
+        projects={
+            "dev-1": ps.ProjectSession(
+                label="dev-1",
+                tmux_target="dev:1.0",
+                workdir=str(tmp_path),
+                aliases=["HUD"],
+                notify=False,
+            )
+        },
+    )
+    path = tmp_path / "project_sessions.json"
+    ps.save_state(state, path)
+
+    result = ps.handle_prefixed_message(_source(), "[HUD] 다음 작업 진행해줘", path=path)
+
+    assert result is None
+    assert sent == []
+
+
+def test_set_mode_toggles_notify_and_sends_instructions(monkeypatch, tmp_path):
+    monkeypatch.setattr(ps, "discover_tmux_projects", lambda: [])
+    sent = []
+    monkeypatch.setattr(ps, "_send_to_tmux", lambda project, prompt: sent.append((project.label, prompt)))
+    state = ps.ProjectRoutingState(
+        projects={
+            "dev-1": ps.ProjectSession(label="dev-1", tmux_target="dev:1.0", workdir=str(tmp_path)),
+            "dev-2": ps.ProjectSession(label="dev-2", tmux_target="dev:2.0", workdir=str(tmp_path)),
+        }
+    )
+    path = tmp_path / "project_sessions.json"
+    ps.save_state(state, path)
+
+    away = ps.set_mode(_source(), "away", "all", path=path)
+    assert "[퇴근모드 시작]" in away
+    assert len(sent) == 2
+    reloaded = ps.load_state(path)
+    assert reloaded.mode == "away"
+    assert all(p.notify for p in reloaded.projects.values())
+
+    sent.clear()
+    office = ps.set_mode(_source(), "office", "all", path=path)
+    assert "[출근모드 전환 완료]" in office
+    reloaded = ps.load_state(path)
+    assert reloaded.mode == "office"
+    assert not any(p.notify for p in reloaded.projects.values())
+
+
+def test_set_mode_rejects_invalid_scope(monkeypatch, tmp_path):
+    monkeypatch.setattr(ps, "discover_tmux_projects", lambda: [])
+    sent = []
+    monkeypatch.setattr(ps, "_send_to_tmux", lambda project, prompt: sent.append((project.label, prompt)))
+    state = ps.ProjectRoutingState(
+        projects={"dev-1": ps.ProjectSession(label="dev-1", tmux_target="dev:1.0", workdir=str(tmp_path))}
+    )
+    path = tmp_path / "project_sessions.json"
+    ps.save_state(state, path)
+
+    msg = ps.set_mode(_source(), "away", "curent", path=path)
+
+    assert "사용: /afterwork" in msg
+    assert sent == []
+    assert ps.load_state(path).mode == "office"
+
+
+def test_set_mode_does_not_mark_failed_project_notify(monkeypatch, tmp_path):
+    monkeypatch.setattr(ps, "discover_tmux_projects", lambda: [])
+
+    def fail(project, prompt):
+        raise RuntimeError("tmux missing")
+
+    monkeypatch.setattr(ps, "_send_to_tmux", fail)
+    state = ps.ProjectRoutingState(
+        projects={"dev-1": ps.ProjectSession(label="dev-1", tmux_target="dev:1.0", workdir=str(tmp_path))}
+    )
+    path = tmp_path / "project_sessions.json"
+    ps.save_state(state, path)
+
+    msg = ps.set_mode(_source(), "away", "all", path=path)
+
+    assert "전달 실패" in msg
+    reloaded = ps.load_state(path)
+    assert reloaded.mode == "office"
+    assert reloaded.projects["dev-1"].notify is False
+
+
+def test_discover_tmux_projects_filters_broad_roots(monkeypatch, tmp_path):
+    project = tmp_path / "real-project"
+    project.mkdir()
+    (project / ".hermes").mkdir()
+    broad = tmp_path / "work"
+    broad.mkdir()
+    (broad / "AGENTS.md").write_text("x", encoding="utf-8")
+    output = "dev\t1\tHUD\t0\t{}\tpython\n".format(project)
+    output += "dev\t2\twork\t0\t{}\tzsh\n".format(broad)
+    monkeypatch.setattr(ps, "_run_tmux", lambda args: output)
+
+    projects = ps.discover_tmux_projects()
+
+    assert [p.label for p in projects] == ["HUD"]
+    assert projects[0].tmux_target == "dev:1.0"

--- a/tests/gateway/test_telegram_approval_buttons.py
+++ b/tests/gateway/test_telegram_approval_buttons.py
@@ -451,6 +451,63 @@ class TestTelegramApprovalCallback:
         assert "already been resolved" in query.answer.call_args[1]["text"]
 
     @pytest.mark.asyncio
+    async def test_button_state_stale_after_text_approve_does_not_edit_as_success(self):
+        adapter = _make_adapter()
+        adapter._approval_state[3] = "some-session"
+
+        query = AsyncMock()
+        query.data = "ea:deny:3"
+        query.message = MagicMock()
+        query.message.chat_id = 12345
+        query.from_user = MagicMock()
+        query.from_user.id = "12345"
+        query.from_user.first_name = "Alice"
+        query.answer = AsyncMock()
+        query.edit_message_text = AsyncMock()
+
+        update = MagicMock()
+        update.callback_query = query
+        context = MagicMock()
+
+        with patch.dict(os.environ, {"TELEGRAM_ALLOWED_USERS": "*"}, clear=False):
+            with patch("tools.approval.resolve_gateway_approval", return_value=0) as mock_resolve:
+                await adapter._handle_callback_query(update, context)
+
+        mock_resolve.assert_called_once_with("some-session", "deny")
+        query.answer.assert_called_once()
+        assert "already been resolved" in query.answer.call_args[1]["text"]
+        query.edit_message_text.assert_not_called()
+        assert 3 not in adapter._approval_state
+
+    @pytest.mark.asyncio
+    async def test_button_resolve_failure_keeps_state_for_retry(self):
+        adapter = _make_adapter()
+        adapter._approval_state[4] = "some-session"
+
+        query = AsyncMock()
+        query.data = "ea:once:4"
+        query.message = MagicMock()
+        query.message.chat_id = 12345
+        query.from_user = MagicMock()
+        query.from_user.id = "12345"
+        query.from_user.first_name = "Alice"
+        query.answer = AsyncMock()
+        query.edit_message_text = AsyncMock()
+
+        update = MagicMock()
+        update.callback_query = query
+        context = MagicMock()
+
+        with patch.dict(os.environ, {"TELEGRAM_ALLOWED_USERS": "*"}, clear=False):
+            with patch("tools.approval.resolve_gateway_approval", side_effect=RuntimeError("boom")):
+                await adapter._handle_callback_query(update, context)
+
+        query.answer.assert_called_once()
+        assert "failed" in query.answer.call_args[1]["text"].lower()
+        query.edit_message_text.assert_not_called()
+        assert adapter._approval_state[4] == "some-session"
+
+    @pytest.mark.asyncio
     async def test_model_picker_callback_not_affected(self):
         """Ensure model picker callbacks still route correctly."""
         adapter = _make_adapter()

--- a/tests/gateway/test_telegram_approval_buttons.py
+++ b/tests/gateway/test_telegram_approval_buttons.py
@@ -550,11 +550,10 @@ class TestTelegramApprovalCallback:
 
         with patch("tools.approval.resolve_gateway_approval") as mock_resolve:
             with patch("hermes_constants.get_hermes_home", return_value=tmp_path):
-                # Allow the caller — the new fail-closed allowlist gate
-                # (#24457) rejects empty TELEGRAM_ALLOWED_USERS, but this
-                # test isn't exercising that gate; it's verifying the
-                # update_prompt callback still writes the response.
-                with patch.dict(os.environ, {"TELEGRAM_ALLOWED_USERS": "*"}):
+                # Allow the caller — the fail-closed allowlist gate rejects
+                # missing/empty TELEGRAM_ALLOWED_USERS, but this test is about
+                # update_prompt callback routing rather than authorization.
+                with patch.dict(os.environ, {"TELEGRAM_ALLOWED_USERS": "123"}):
                     await adapter._handle_callback_query(update, context)
 
         # Should NOT have triggered approval resolution

--- a/tests/gateway/test_workflow_skill_wrappers.py
+++ b/tests/gateway/test_workflow_skill_wrappers.py
@@ -1,0 +1,105 @@
+"""Gateway dispatch tests for workflow skill slash-command wrappers."""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from tests.gateway.test_reload_skills_command import _make_event, _make_runner
+
+
+@pytest.mark.asyncio
+async def test_gateway_workflow_wrapper_rewrites_to_skill_message(monkeypatch):
+    import agent.skill_commands as skill_commands_mod
+    import gateway.run as gateway_run
+
+    runner = _make_runner()
+    runner._draining = False
+    runner._running_agents_ts = {}
+    runner._begin_session_run_generation = lambda _key: 1
+    runner._handle_message_with_agent = AsyncMock(return_value="agent result")
+    runner._telegram_topic_root_lobby_message = lambda: "lobby"
+    runner._is_telegram_topic_root_lobby = lambda _source: False
+    runner._should_send_telegram_lobby_reminder = lambda _source: False
+
+    monkeypatch.setattr(
+        gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"}
+    )
+    monkeypatch.setattr(
+        skill_commands_mod,
+        "get_skill_commands",
+        lambda: {"/verify": {"name": "verify"}},
+    )
+    monkeypatch.setattr(
+        skill_commands_mod,
+        "resolve_skill_command_key",
+        lambda name: "/verify" if name == "verify" else None,
+    )
+
+    calls = {}
+
+    def fake_build(cmd_key, user_instruction, task_id=None):
+        calls["cmd_key"] = cmd_key
+        calls["user_instruction"] = user_instruction
+        calls["task_id"] = task_id
+        return "LOADED VERIFY"
+
+    monkeypatch.setattr(skill_commands_mod, "build_skill_invocation_message", fake_build)
+
+    event = _make_event("/verify acceptance criteria")
+    result = await runner._handle_message(event)
+
+    assert result == "agent result"
+    assert event.text == "LOADED VERIFY"
+    assert calls["cmd_key"] == "/verify"
+    assert calls["user_instruction"] == "acceptance criteria"
+    assert calls["task_id"] == "agent:main:telegram:dm:c1"
+    runner._handle_message_with_agent.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_gateway_devflow_wrapper_rewrites_to_skill_message(monkeypatch):
+    import agent.skill_commands as skill_commands_mod
+    import gateway.run as gateway_run
+
+    runner = _make_runner()
+    runner._draining = False
+    runner._running_agents_ts = {}
+    runner._begin_session_run_generation = lambda _key: 1
+    runner._handle_message_with_agent = AsyncMock(return_value="agent result")
+    runner._telegram_topic_root_lobby_message = lambda: "lobby"
+    runner._is_telegram_topic_root_lobby = lambda _source: False
+    runner._should_send_telegram_lobby_reminder = lambda _source: False
+
+    monkeypatch.setattr(
+        gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"}
+    )
+    monkeypatch.setattr(
+        skill_commands_mod,
+        "get_skill_commands",
+        lambda: {"/devflow": {"name": "devflow"}},
+    )
+    monkeypatch.setattr(
+        skill_commands_mod,
+        "resolve_skill_command_key",
+        lambda name: "/devflow" if name == "devflow" else None,
+    )
+
+    calls = {}
+
+    def fake_build(cmd_key, user_instruction, task_id=None):
+        calls["cmd_key"] = cmd_key
+        calls["user_instruction"] = user_instruction
+        calls["task_id"] = task_id
+        return "LOADED DEVFLOW"
+
+    monkeypatch.setattr(skill_commands_mod, "build_skill_invocation_message", fake_build)
+
+    event = _make_event("/devflow implement workflow gates")
+    result = await runner._handle_message(event)
+
+    assert result == "agent result"
+    assert event.text == "LOADED DEVFLOW"
+    assert calls["cmd_key"] == "/devflow"
+    assert calls["user_instruction"] == "implement workflow gates"
+    assert calls["task_id"] == "agent:main:telegram:dm:c1"
+    runner._handle_message_with_agent.assert_awaited_once()

--- a/tests/hermes_cli/test_commands.py
+++ b/tests/hermes_cli/test_commands.py
@@ -119,6 +119,11 @@ class TestResolveCommand:
         assert "퇴근" in GATEWAY_KNOWN_COMMANDS
         assert "퇴근모드" in GATEWAY_KNOWN_COMMANDS
 
+    def test_afterwork_visible_in_telegram_menu(self):
+        names = {name for name, _ in telegram_bot_commands()}
+
+        assert "afterwork" in names
+
     def test_workflow_skill_wrappers_are_registered_for_cli_and_gateway(self):
         workflow_names = {
             "autopilot",

--- a/tests/hermes_cli/test_commands.py
+++ b/tests/hermes_cli/test_commands.py
@@ -110,6 +110,15 @@ class TestResolveCommand:
         assert resolve_command("codex_runtime").name == "codex-runtime"
         assert resolve_command("tasks").name == "agents"
 
+    def test_afterwork_available_in_cli_and_gateway(self):
+        afterwork = next(cmd for cmd in COMMAND_REGISTRY if cmd.name == "afterwork")
+
+        assert not afterwork.cli_only
+        assert not afterwork.gateway_only
+        assert "afterwork" in GATEWAY_KNOWN_COMMANDS
+        assert "퇴근" in GATEWAY_KNOWN_COMMANDS
+        assert "퇴근모드" in GATEWAY_KNOWN_COMMANDS
+
     def test_topic_is_gateway_command(self):
         topic = resolve_command("topic")
         assert topic is not None

--- a/tests/hermes_cli/test_commands.py
+++ b/tests/hermes_cli/test_commands.py
@@ -67,7 +67,7 @@ class TestCommandRegistry:
                         f"Alias '{alias}' of '{cmd.name}' shadows canonical '{target.name}'"
 
     def test_every_entry_has_valid_category(self):
-        valid_categories = {"Session", "Configuration", "Tools & Skills", "Info", "Exit"}
+        valid_categories = {"Session", "Configuration", "Tools & Skills", "Info", "Exit", "Workflow"}
         for cmd in COMMAND_REGISTRY:
             assert cmd.category in valid_categories, f"{cmd.name} has invalid category '{cmd.category}'"
 
@@ -118,6 +118,29 @@ class TestResolveCommand:
         assert "afterwork" in GATEWAY_KNOWN_COMMANDS
         assert "퇴근" in GATEWAY_KNOWN_COMMANDS
         assert "퇴근모드" in GATEWAY_KNOWN_COMMANDS
+
+    def test_workflow_skill_wrappers_are_registered_for_cli_and_gateway(self):
+        workflow_names = {
+            "autopilot",
+            "ralplan",
+            "deep-interview",
+            "verify",
+            "ultraqa",
+            "trace",
+            "deepsearch",
+            "devflow",
+            "tdd",
+        }
+        registry = {cmd.name: cmd for cmd in COMMAND_REGISTRY}
+        for name in workflow_names:
+            cmd = registry[name]
+            assert cmd.category == "Workflow"
+            assert not cmd.cli_only
+            assert not cmd.gateway_only
+            assert f"/{name}" in COMMANDS
+            assert name in GATEWAY_KNOWN_COMMANDS
+            assert resolve_command(name).name == name
+        assert resolve_command("deepinterview").name == "deep-interview"
 
     def test_topic_is_gateway_command(self):
         topic = resolve_command("topic")

--- a/tests/hermes_cli/test_google_gemini_cli_in_model_list.py
+++ b/tests/hermes_cli/test_google_gemini_cli_in_model_list.py
@@ -1,0 +1,41 @@
+from unittest.mock import patch
+
+from hermes_cli.model_switch import list_authenticated_providers
+
+
+def test_google_gemini_cli_appears_when_runtime_oauth_resolves():
+    """Model picker discovery should mirror Gemini CLI runtime auth.
+
+    Hermes can use google-gemini-cli via the official ~/.gemini OAuth store
+    even when ~/.hermes/auth.json has no provider or credential-pool row for
+    google-gemini-cli.  The picker should therefore ask the runtime resolver
+    before hiding the provider.
+    """
+    with patch(
+        "hermes_cli.auth.resolve_gemini_oauth_runtime_credentials",
+        return_value={"api_key": "google-oauth-token", "provider": "google-gemini-cli"},
+    ), patch("agent.credential_pool.load_pool") as load_pool:
+        load_pool.return_value.has_credentials.return_value = False
+        load_pool.return_value.has_available.return_value = False
+        providers = list_authenticated_providers(
+            current_provider="google-gemini-cli",
+            current_model="gemini-3.1-pro-preview",
+            max_models=50,
+        )
+
+    gemini_cli = next((p for p in providers if p["slug"] == "google-gemini-cli"), None)
+    assert gemini_cli is not None
+    assert gemini_cli["is_current"] is True
+    assert "gemini-3.1-pro-preview" in gemini_cli["models"]
+
+
+def test_google_gemini_cli_hidden_when_runtime_oauth_missing():
+    with patch(
+        "hermes_cli.auth.resolve_gemini_oauth_runtime_credentials",
+        side_effect=RuntimeError("not logged in"),
+    ), patch("agent.credential_pool.load_pool") as load_pool:
+        load_pool.return_value.has_credentials.return_value = False
+        load_pool.return_value.has_available.return_value = False
+        providers = list_authenticated_providers(current_provider="openrouter", max_models=50)
+
+    assert all(p["slug"] != "google-gemini-cli" for p in providers)

--- a/tests/run_agent/test_tool_call_guardrail_runtime.py
+++ b/tests/run_agent/test_tool_call_guardrail_runtime.py
@@ -136,6 +136,40 @@ def test_config_enabled_hard_stop_blocks_repeated_exact_failure_before_execution
     assert "repeated_exact_failure_block" in messages[0]["content"]
 
 
+def test_default_sequential_path_appends_missing_prerequisite_warning_but_executes_tool():
+    agent = _make_agent("patch")
+    args = {"path": "a.py", "old_string": "x", "new_string": "y"}
+    tc = _mock_tool_call("patch", json.dumps(args), "c-prereq")
+    msg = SimpleNamespace(content="", tool_calls=[tc])
+    messages = []
+
+    with patch("run_agent.handle_function_call", return_value=json.dumps({"success": True})) as mock_hfc:
+        agent._execute_tool_calls_sequential(msg, messages, "task-1")
+
+    mock_hfc.assert_called_once()
+    assert len(messages) == 1
+    assert messages[0]["tool_call_id"] == "c-prereq"
+    assert "missing_tool_prerequisite_warning" in messages[0]["content"]
+    assert "read_file" in messages[0]["content"]
+
+
+def test_config_enabled_prerequisite_hard_stop_blocks_without_execution():
+    config = _hard_stop_config(prerequisite_hard_stop_enabled=True)
+    agent = _make_agent("browser_click", config=config)
+    tc = _mock_tool_call("browser_click", json.dumps({"ref": "@e1"}), "c-prereq-block")
+    msg = SimpleNamespace(content="", tool_calls=[tc])
+    messages = []
+
+    with patch("run_agent.handle_function_call", return_value="SHOULD_NOT_RUN") as mock_hfc:
+        agent._execute_tool_calls_sequential(msg, messages, "task-1")
+
+    mock_hfc.assert_not_called()
+    assert len(messages) == 1
+    assert messages[0]["tool_call_id"] == "c-prereq-block"
+    assert "missing_tool_prerequisite_block" in messages[0]["content"]
+    assert "browser_snapshot" in messages[0]["content"]
+
+
 def test_sequential_after_call_appends_guidance_to_tool_result_without_extra_messages():
     agent = _make_agent("web_search")
     args = {"query": "same"}

--- a/tests/tools/test_approval_heartbeat.py
+++ b/tests/tools/test_approval_heartbeat.py
@@ -59,5 +59,45 @@ class TestApprovalHeartbeat:
                 os.environ[k] = v
         _clear_approval_state()
 
+    def test_gateway_timeout_zero_waits_until_explicit_resolution(self):
+        """gateway_timeout=0 means no approval timeout, not immediate deny."""
+        from tools import approval as mod
+
+        notified = threading.Event()
+        result_box = {}
+
+        def notify(_approval_data):
+            notified.set()
+
+        def worker():
+            result_box["result"] = mod.check_all_command_guards(
+                "git reset --hard",
+                "local",
+            )
+
+        mod.register_gateway_notify(self.SESSION_KEY, notify)
+        with patch.object(
+            mod,
+            "_get_approval_config",
+            return_value={"mode": "manual", "gateway_timeout": 0},
+        ):
+            thread = threading.Thread(target=worker)
+            thread.start()
+            try:
+                assert notified.wait(2), "approval prompt was not registered"
+                # Old behavior treated 0 as an already-expired deadline and
+                # returned BLOCKED immediately.  Give that regression a chance
+                # to happen before resolving.
+                time.sleep(0.05)
+                assert thread.is_alive()
+                assert mod.resolve_gateway_approval(self.SESSION_KEY, "once") == 1
+                thread.join(2)
+            finally:
+                if thread.is_alive():
+                    mod.resolve_gateway_approval(self.SESSION_KEY, "deny", resolve_all=True)
+                    thread.join(2)
+
+        assert not thread.is_alive()
+        assert result_box["result"]["approved"] is True
 
 

--- a/tests/tools/test_shared_approval_broker.py
+++ b/tests/tools/test_shared_approval_broker.py
@@ -1,0 +1,185 @@
+"""Tests for the file-backed CLI/Gateway approval broker.
+
+The existing gateway approval queue is process-local.  CLI/TUI approvals live in
+another process, so Telegram /approve cannot see them unless the CLI publishes a
+pending request through a shared broker under HERMES_HOME.
+"""
+
+import importlib
+import os
+import stat
+import threading
+import time
+
+
+def test_cli_approval_request_persists_across_imports():
+    """A CLI approval request is visible to a fresh importer/process."""
+    from hermes_constants import get_hermes_home
+    from tools import shared_approval_broker as broker
+
+    request_id = broker.register_cli_approval(
+        {
+            "session_key": "cli-session-1",
+            "session_id": "20260512_151213_8a0a60",
+            "title": "업무 환경 상황 파악",
+            "cwd": "/tmp/hermes-work",
+            "pid": 12345,
+            "command": "rm -rf /tmp/demo",
+            "description": "recursive delete",
+        },
+        ttl_seconds=600,
+    )
+
+    approval_file = get_hermes_home() / "approvals" / "cli" / f"{request_id}.json"
+    assert approval_file.exists()
+
+    # Simulate the gateway importing the broker in another process after the CLI
+    # has already registered the request.  The pending request must be read from
+    # disk, not from module globals.
+    fresh_broker = importlib.reload(broker)
+    pending = fresh_broker.list_pending_cli_approvals()
+
+    assert [item["request_id"] for item in pending] == [request_id]
+    assert pending[0]["session_key"] == "cli-session-1"
+    assert pending[0]["command"] == "rm -rf /tmp/demo"
+    assert pending[0]["status"] == "pending"
+
+    if os.name == "posix":
+        assert stat.S_IMODE(approval_file.parent.stat().st_mode) == 0o700
+        assert stat.S_IMODE(approval_file.stat().st_mode) == 0o600
+
+
+def test_gateway_resolution_is_scoped_to_notified_target():
+    """A /approve from a different platform/chat must not resolve CLI prompts."""
+    from tools import shared_approval_broker as broker
+
+    broker.register_cli_approval(
+        {
+            "session_key": "cli-session-scoped",
+            "session_id": "sid-scoped",
+            "title": "scoped approval",
+            "cwd": "/tmp",
+            "pid": os.getpid(),
+            "command": "rm -rf /tmp/scoped",
+            "description": "delete scoped dir",
+            "notify_target": "telegram:chat-1",
+        },
+        ttl_seconds=600,
+    )
+
+    assert broker.resolve_oldest_cli_approval(
+        "once",
+        source={"platform": "discord", "chat_id": "chat-1"},
+    ) == 0
+    assert broker.resolve_oldest_cli_approval(
+        "once",
+        source={"platform": "telegram", "chat_id": "chat-2"},
+    ) == 0
+    assert broker.resolve_oldest_cli_approval(
+        "once",
+        source={"platform": "telegram", "chat_id": "chat-1"},
+    ) == 1
+
+
+def test_platform_only_target_is_not_remotely_resolvable():
+    """Bare platform notify targets are not specific enough for /approve."""
+    from tools import shared_approval_broker as broker
+
+    broker.register_cli_approval(
+        {
+            "session_key": "cli-session-platform-wide",
+            "session_id": "sid-platform-wide",
+            "title": "platform-wide approval",
+            "cwd": "/tmp",
+            "pid": os.getpid(),
+            "command": "rm -rf /tmp/platform-wide",
+            "description": "delete platform-wide dir",
+            "notify_target": "telegram",
+        },
+        ttl_seconds=600,
+    )
+
+    assert broker.resolve_oldest_cli_approval(
+        "once",
+        source={"platform": "telegram", "chat_id": "chat-1"},
+    ) == 0
+
+
+def test_gateway_resolve_oldest_unblocks_cli_waiter():
+    """Gateway-side resolution is observed by the CLI polling waiter."""
+    from tools import shared_approval_broker as broker
+
+    request_id = broker.register_cli_approval(
+        {
+            "session_key": "cli-session-2",
+            "session_id": "sid-2",
+            "title": "approval test",
+            "cwd": "/tmp",
+            "pid": os.getpid(),
+            "command": "git reset --hard",
+            "description": "reset working tree",
+            "notify_target": "telegram:chat-1",
+        },
+        ttl_seconds=600,
+    )
+
+    result_box = {}
+
+    def waiter():
+        result_box["choice"] = broker.wait_for_cli_approval(
+            request_id,
+            timeout_seconds=2,
+            poll_interval=0.01,
+        )
+
+    thread = threading.Thread(target=waiter)
+    thread.start()
+    try:
+        time.sleep(0.05)
+        resolved = broker.resolve_oldest_cli_approval(
+            "session",
+            source={"platform": "telegram", "chat_id": "chat-1"},
+        )
+        assert resolved == 1
+        thread.join(2)
+    finally:
+        if thread.is_alive():
+            broker.resolve_cli_approval(request_id, "deny")
+            thread.join(2)
+
+    assert not thread.is_alive()
+    assert result_box["choice"] == "session"
+    assert broker.get_cli_approval(request_id)["status"] == "resolved"
+    assert broker.get_cli_approval(request_id)["choice"] == "session"
+
+
+def test_expired_cli_approval_is_not_resolved():
+    """Gateway /approve must not approve stale CLI prompts."""
+    from tools import shared_approval_broker as broker
+
+    request_id = broker.register_cli_approval(
+        {
+            "session_key": "cli-session-3",
+            "session_id": "sid-3",
+            "title": "expired approval",
+            "cwd": "/tmp",
+            "pid": os.getpid(),
+            "command": "rm -rf /tmp/old",
+            "description": "delete old dir",
+            "notify_target": "telegram:chat-1",
+        },
+        ttl_seconds=0.01,
+    )
+
+    time.sleep(0.05)
+
+    assert broker.resolve_oldest_cli_approval(
+        "once",
+        source={"platform": "telegram", "chat_id": "chat-1"},
+    ) == 0
+    assert broker.wait_for_cli_approval(
+        request_id,
+        timeout_seconds=0,
+        poll_interval=0.01,
+    ) is None
+    assert broker.list_pending_cli_approvals() == []

--- a/tests/tools/test_terminal_output_optimizer.py
+++ b/tests/tools/test_terminal_output_optimizer.py
@@ -1,0 +1,118 @@
+from pathlib import Path
+
+from tools.terminal_output_optimizer import classify_command, optimize_terminal_output
+
+
+class FakeEnv:
+    def __init__(self, tmp_path: Path):
+        self.tmp_path = tmp_path
+        self.writes = {}
+
+    def execute(self, command, timeout=30, stdin_data=None):
+        assert stdin_data is not None
+        assert "umask 077" in command
+        assert "cat >" in command
+        # The production path writes through shell quoting. For these tests,
+        # it is enough to prove the optimizer requested a permission-restricted
+        # sandbox write.
+        self.writes[command] = stdin_data
+        return {"returncode": 0, "output": ""}
+
+
+def test_disabled_mode_is_exact_passthrough():
+    output = "line\n" * 2000
+    result = optimize_terminal_output(
+        command="pytest -q",
+        output=output,
+        returncode=0,
+        config={"enabled": False, "min_chars": 10},
+    )
+    assert result.output == output
+    assert result.optimized is False
+    assert result.reason == "disabled"
+
+
+def test_below_min_chars_is_passthrough():
+    result = optimize_terminal_output(
+        command="git status",
+        output="short output",
+        config={"enabled": True, "min_chars": 1000},
+    )
+    assert result.output == "short output"
+    assert result.optimized is False
+    assert result.reason == "below_min_chars"
+
+
+def test_classify_common_commands():
+    assert classify_command("git status --short") == "git_status"
+    assert classify_command("cd repo && git diff") == "git_diff"
+    assert classify_command("pytest -q") == "test"
+    assert classify_command("pnpm test") == "test"
+    assert classify_command("rg pattern .") == "search"
+
+
+def test_generic_repeated_output_collapses_with_raw_preservation(tmp_path):
+    output = ("same noisy line\n" * 600) + ("tail detail\n" * 100)
+    result = optimize_terminal_output(
+        command="some noisy command",
+        output=output,
+        returncode=0,
+        config={
+            "enabled": True,
+            "min_chars": 100,
+            "target_chars": 1000,
+            "raw_output": "preserve",
+            "storage_dir": str(tmp_path),
+        },
+    )
+    assert result.optimized is True
+    assert "<terminal-output-optimized>" in result.output
+    assert "raw_sanitized_output:" in result.output
+    assert "repeated" in result.output
+    assert len(result.output) < len(output)
+    raw_path = Path(result.raw_path)
+    assert raw_path.read_text() == output
+    assert oct(raw_path.stat().st_mode & 0o777) == "0o600"
+    assert oct(tmp_path.stat().st_mode & 0o777) == "0o700"
+
+
+def test_raw_preserve_failure_fails_open():
+    class FailingEnv:
+        def execute(self, *args, **kwargs):
+            return {"returncode": 1, "output": "nope"}
+
+    output = "line\n" * 1000
+    result = optimize_terminal_output(
+        command="pytest -q",
+        output=output,
+        env=FailingEnv(),
+        config={"enabled": True, "min_chars": 10, "target_chars": 1000, "raw_output": "preserve"},
+    )
+    assert result.output == output
+    assert result.optimized is False
+    assert result.reason == "raw_preserve_failed"
+
+
+def test_test_output_preserves_failures_and_summary(tmp_path):
+    output = "\n".join(
+        [f"progress {i}" for i in range(500)]
+        + ["FAILED tests/test_x.py::test_case - AssertionError", "short test summary info", "1 failed, 20 passed"]
+        + [f"tail {i}" for i in range(100)]
+    )
+    result = optimize_terminal_output(
+        command="pytest -q",
+        output=output,
+        returncode=1,
+        config={
+            "enabled": True,
+            "min_chars": 100,
+            "target_chars": 1000,
+            "raw_output": "preserve",
+            "storage_dir": str(tmp_path),
+        },
+    )
+    assert result.optimized is True
+    assert "FAILED tests/test_x.py::test_case" in result.output
+    assert "short test summary" in result.output
+    assert "1 failed" in result.output
+    assert "exit_code: 1" in result.output

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -1253,13 +1253,21 @@ def check_all_command_guards(command: str, env_type: str,
                 touch_activity_if_due = None
 
             _now = time.monotonic()
-            _deadline = _now + max(timeout, 0)
+            # gateway_timeout <= 0 means wait indefinitely.  This mirrors the
+            # agent inactivity timeout semantics (0 == unlimited) and is useful
+            # for out-of-band approval surfaces where the user may respond much
+            # later than a fixed 5-minute window.  We still poll in 1s slices so
+            # activity heartbeats keep the gateway run alive while waiting.
+            _deadline = None if timeout <= 0 else _now + timeout
             _activity_state = {"last_touch": _now, "start": _now}
             resolved = False
             while True:
-                _remaining = _deadline - time.monotonic()
-                if _remaining <= 0:
-                    break
+                if _deadline is None:
+                    _remaining = 1.0
+                else:
+                    _remaining = _deadline - time.monotonic()
+                    if _remaining <= 0:
+                        break
                 # 1s poll slice — the event is set immediately when the
                 # user responds, so slice length only controls heartbeat
                 # cadence, not user-visible responsiveness.

--- a/tools/shared_approval_broker.py
+++ b/tools/shared_approval_broker.py
@@ -1,0 +1,301 @@
+"""File-backed approval broker shared by CLI and Gateway processes.
+
+Gateway dangerous-command approvals are normally in-memory because the waiting
+agent thread and /approve handler live in the same process.  CLI/TUI approvals
+are different: the CLI process owns the prompt while Telegram /approve arrives
+in the gateway process.  This module bridges that gap with small JSON records
+under HERMES_HOME.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import threading
+import time
+import uuid
+from pathlib import Path
+from typing import Any, Optional
+
+from hermes_constants import get_hermes_home
+
+_VALID_CHOICES = {"once", "session", "always", "deny"}
+_LOCK = threading.RLock()
+
+
+def _approval_dir() -> Path:
+    return get_hermes_home() / "approvals" / "cli"
+
+
+def _ensure_private_dir(path: Path) -> None:
+    """Create the broker directory with owner-only permissions when possible."""
+    path.mkdir(parents=True, exist_ok=True, mode=0o700)
+    try:
+        os.chmod(path, 0o700)
+    except OSError:
+        pass
+
+
+def _request_path(request_id: str) -> Path:
+    safe = "".join(ch for ch in str(request_id) if ch.isalnum() or ch in ("-", "_"))
+    if not safe:
+        raise ValueError("request_id is empty")
+    return _approval_dir() / f"{safe}.json"
+
+
+def _now() -> float:
+    return time.time()
+
+
+def _atomic_write(path: Path, data: dict[str, Any]) -> None:
+    _ensure_private_dir(path.parent)
+    tmp = path.with_name(f".{path.name}.{os.getpid()}.{threading.get_ident()}.tmp")
+    encoded = json.dumps(data, ensure_ascii=False, sort_keys=True, indent=2).encode("utf-8")
+    fd = os.open(tmp, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    try:
+        with os.fdopen(fd, "wb") as handle:
+            handle.write(encoded)
+    except Exception:
+        try:
+            os.close(fd)
+        except OSError:
+            pass
+        raise
+    os.replace(tmp, path)
+    try:
+        os.chmod(path, 0o600)
+    except OSError:
+        pass
+
+
+def _normalize_platform(value: Any) -> str:
+    raw = getattr(value, "value", value)
+    return str(raw or "").strip().lower()
+
+
+def _source_matches_target(source: Optional[dict[str, Any]], notify_target: str) -> bool:
+    """Return whether a gateway source is allowed to resolve a CLI request.
+
+    CLI approvals are only remotely resolvable from the platform/chat that was
+    notified. This avoids a generic gateway /approve in one channel resolving a
+    dangerous command prompt that was announced somewhere else.
+    """
+    if not source:
+        return False
+    target = str(notify_target or "").strip().lower()
+    if not target:
+        return False
+
+    platform = _normalize_platform(source.get("platform"))
+    chat_id = str(source.get("chat_id") or "").strip().lower()
+    thread_id = str(source.get("thread_id") or "").strip().lower()
+    parent_chat_id = str(source.get("parent_chat_id") or "").strip().lower()
+    # send_message targets are commonly: "telegram:<chat>" or
+    # "telegram:<chat>:<thread>".  Broker resolution requires a concrete
+    # chat/thread target; a bare platform target such as "telegram" is only a
+    # notification destination alias and is not specific enough to authorize a
+    # remote dangerous-command approval.
+    if target == platform:
+        return False
+    prefix = f"{platform}:"
+    if not target.startswith(prefix):
+        return False
+    remainder = target[len(prefix):]
+    parts = [part for part in remainder.split(":") if part]
+    if not parts:
+        return False
+    if parts[0] not in {chat_id, parent_chat_id}:
+        return False
+    if len(parts) >= 2 and parts[1] != thread_id:
+        return False
+    return True
+
+
+def _matches_resolver(data: dict[str, Any], source: Optional[dict[str, Any]]) -> bool:
+    return _source_matches_target(source, str(data.get("notify_target") or ""))
+
+
+def _read_request(path: Path) -> Optional[dict[str, Any]]:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError, UnicodeDecodeError):
+        return None
+    if not isinstance(data, dict):
+        return None
+    return data
+
+
+def _is_expired(data: dict[str, Any], *, now: Optional[float] = None) -> bool:
+    if data.get("status") != "pending":
+        return False
+    try:
+        expires_at = float(data.get("expires_at", 0) or 0)
+    except (TypeError, ValueError):
+        expires_at = 0
+    return expires_at > 0 and (now if now is not None else _now()) >= expires_at
+
+
+def _mark_expired(path: Path, data: dict[str, Any], *, now: Optional[float] = None) -> None:
+    data = dict(data)
+    data["status"] = "expired"
+    data["resolved_at"] = now if now is not None else _now()
+    data.setdefault("choice", None)
+    try:
+        _atomic_write(path, data)
+    except OSError:
+        pass
+
+
+def register_cli_approval(payload: dict[str, Any], ttl_seconds: int | float = 60) -> str:
+    """Register a pending CLI approval and return its request id.
+
+    ``payload`` should include session/cwd/pid/command details, but this helper
+    is intentionally schema-light so older/newer CLI versions can coexist with
+    the gateway.  The broker adds request_id/status/timestamps.
+    """
+    if not isinstance(payload, dict):
+        raise TypeError("payload must be a dict")
+    request_id = str(payload.get("request_id") or uuid.uuid4().hex)
+    now = _now()
+    try:
+        ttl = float(ttl_seconds)
+    except (TypeError, ValueError):
+        ttl = 60.0
+    expires_at = 0 if ttl <= 0 else now + ttl
+    data = dict(payload)
+    data.update(
+        {
+            "request_id": request_id,
+            "status": "pending",
+            "choice": None,
+            "created_at": now,
+            "updated_at": now,
+            "expires_at": expires_at,
+        }
+    )
+    with _LOCK:
+        _atomic_write(_request_path(request_id), data)
+    return request_id
+
+
+def get_cli_approval(request_id: str) -> Optional[dict[str, Any]]:
+    """Return one CLI approval record, marking expired pending records."""
+    path = _request_path(request_id)
+    with _LOCK:
+        data = _read_request(path)
+        if data is None:
+            return None
+        if _is_expired(data):
+            _mark_expired(path, data)
+            data = _read_request(path) or data
+        return data
+
+
+def list_pending_cli_approvals() -> list[dict[str, Any]]:
+    """List non-expired pending CLI approvals, oldest first."""
+    base = _approval_dir()
+    if not base.exists():
+        return []
+    pending: list[dict[str, Any]] = []
+    now = _now()
+    with _LOCK:
+        for path in sorted(base.glob("*.json")):
+            data = _read_request(path)
+            if not data or data.get("status") != "pending":
+                continue
+            if _is_expired(data, now=now):
+                _mark_expired(path, data, now=now)
+                continue
+            pending.append(data)
+    pending.sort(key=lambda item: float(item.get("created_at", 0) or 0))
+    return pending
+
+
+def list_resolvable_cli_approvals(source: Optional[dict[str, Any]]) -> list[dict[str, Any]]:
+    """List pending CLI approvals that the given gateway source may resolve."""
+    return [item for item in list_pending_cli_approvals() if _matches_resolver(item, source)]
+
+
+def resolve_cli_approval(request_id: str, choice: str) -> bool:
+    """Resolve a specific pending CLI approval."""
+    normalized = (choice or "").strip().lower()
+    if normalized not in _VALID_CHOICES:
+        raise ValueError(f"invalid approval choice: {choice!r}")
+    path = _request_path(request_id)
+    with _LOCK:
+        data = _read_request(path)
+        if not data or data.get("status") != "pending" or _is_expired(data):
+            if data and _is_expired(data):
+                _mark_expired(path, data)
+            return False
+        data = dict(data)
+        data["status"] = "resolved"
+        data["choice"] = normalized
+        data["resolved_at"] = _now()
+        data["updated_at"] = data["resolved_at"]
+        _atomic_write(path, data)
+    return True
+
+
+def resolve_oldest_cli_approval(
+    choice: str,
+    *,
+    resolve_all: bool = False,
+    source: Optional[dict[str, Any]] = None,
+) -> int:
+    """Resolve the oldest pending CLI approval(s) visible to the gateway."""
+    pending = list_resolvable_cli_approvals(source)
+    if not pending:
+        return 0
+    targets = pending if resolve_all else pending[:1]
+    count = 0
+    for item in targets:
+        if resolve_cli_approval(str(item.get("request_id", "")), choice):
+            count += 1
+    return count
+
+
+def wait_for_cli_approval(
+    request_id: str,
+    *,
+    timeout_seconds: int | float = 60,
+    poll_interval: int | float = 0.25,
+) -> Optional[str]:
+    """Poll until a CLI approval is resolved, expired, missing, or timed out."""
+    try:
+        timeout = float(timeout_seconds)
+    except (TypeError, ValueError):
+        timeout = 60.0
+    try:
+        interval = max(float(poll_interval), 0.01)
+    except (TypeError, ValueError):
+        interval = 0.25
+    deadline = None if timeout <= 0 else time.monotonic() + timeout
+    while True:
+        data = get_cli_approval(request_id)
+        if not data:
+            return None
+        status = data.get("status")
+        if status == "resolved":
+            choice = data.get("choice")
+            return str(choice) if choice else None
+        if status in ("expired", "cancelled"):
+            return None
+        if deadline is not None:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return None
+            time.sleep(min(interval, remaining))
+        else:
+            # Non-blocking check for callers that pass timeout_seconds=0.
+            return None
+
+
+def clear_cli_approval(request_id: str) -> None:
+    """Remove one CLI approval file; best-effort cleanup for CLI finally blocks."""
+    try:
+        _request_path(request_id).unlink()
+    except FileNotFoundError:
+        pass
+    except OSError:
+        pass

--- a/tools/terminal_output_optimizer.py
+++ b/tools/terminal_output_optimizer.py
@@ -1,0 +1,321 @@
+"""Optional terminal output optimization inspired by RTK.
+
+This module is intentionally conservative:
+- disabled by default via config,
+- never rewrites or re-executes commands,
+- never changes exit codes/errors,
+- fails open to the original output,
+- preserves the sanitized raw output before returning a compact view.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import re
+import shlex
+import stat
+from dataclasses import dataclass
+from typing import Any
+
+
+DEFAULT_CONFIG = {
+    "enabled": False,
+    "min_chars": 4000,
+    "target_chars": 12000,
+    "raw_output": "preserve",  # preserve | off
+    "storage_dir": "/tmp/hermes-terminal-raw",
+}
+
+
+@dataclass(frozen=True)
+class OptimizationResult:
+    output: str
+    optimized: bool
+    reason: str = ""
+    raw_path: str = ""
+    original_chars: int = 0
+    optimized_chars: int = 0
+    command_class: str = "generic"
+
+
+def _load_optimizer_config(config_override: dict[str, Any] | None = None) -> dict[str, Any]:
+    if config_override is not None:
+        cfg = dict(DEFAULT_CONFIG)
+        cfg.update(config_override or {})
+        return cfg
+    try:
+        from hermes_cli.config import load_config
+
+        root = load_config() or {}
+        user_cfg = (((root.get("terminal") or {}).get("output_optimizer")) or {})
+    except Exception:
+        user_cfg = {}
+    cfg = dict(DEFAULT_CONFIG)
+    if isinstance(user_cfg, dict):
+        cfg.update(user_cfg)
+    return cfg
+
+
+def _as_bool(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "on"}
+    return bool(value)
+
+
+def _as_int(value: Any, default: int, *, minimum: int = 0) -> int:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return default
+    return max(minimum, parsed)
+
+
+def classify_command(command: str) -> str:
+    """Return a coarse command class for output filtering only.
+
+    This is not a shell parser and must not be used for approval or command
+    rewrite decisions. It only selects a reducer after the command has already
+    run.
+    """
+    text = (command or "").strip()
+    if not text:
+        return "generic"
+    # Lightweight segment scan for compound commands. This remains output-only
+    # classification, not a rewrite/safety parser.
+    if re.search(r"(^|[;&|()\s])git\s+status(\s|$)", text):
+        return "git_status"
+    if re.search(r"(^|[;&|()\s])git\s+(diff|show)(\s|$)", text):
+        return "git_diff"
+    if re.search(r"(^|[;&|()\s])git\s+log(\s|$)", text):
+        return "git_log"
+    if re.search(r"(^|[;&|()\s])(pytest|py\.test|vitest|jest)(\s|$)", text) or re.search(r"(^|[;&|()\s])(npm|pnpm|yarn|bun|cargo|go)\s+test(\s|$)", text):
+        return "test"
+    try:
+        tokens = shlex.split(text, posix=True)
+    except ValueError:
+        tokens = text.split()
+    if not tokens:
+        return "generic"
+
+    # Skip leading environment assignments and common wrappers.
+    i = 0
+    while i < len(tokens) and re.match(r"^[A-Za-z_][A-Za-z0-9_]*=", tokens[i]):
+        i += 1
+    while i < len(tokens) and tokens[i] in {"sudo", "env", "command", "time"}:
+        i += 1
+    if i >= len(tokens):
+        return "generic"
+
+    cmd = os.path.basename(tokens[i])
+    rest = tokens[i + 1 :]
+    joined = " ".join([cmd] + rest)
+
+    if cmd == "git":
+        if "status" in rest:
+            return "git_status"
+        if "diff" in rest or "show" in rest:
+            return "git_diff"
+        if "log" in rest:
+            return "git_log"
+        return "git"
+    if cmd in {"pytest", "py.test"} or "pytest" in joined:
+        return "test"
+    if cmd == "cargo" and "test" in rest:
+        return "test"
+    if cmd in {"npm", "pnpm", "yarn", "bun"} and any(t in rest for t in {"test", "vitest", "jest"}):
+        return "test"
+    if cmd in {"vitest", "jest", "go"} and (cmd != "go" or "test" in rest):
+        return "test"
+    if cmd in {"rg", "grep"}:
+        return "search"
+    return "generic"
+
+
+def _collapse_repeated_lines(lines: list[str], max_repeats: int = 3) -> list[str]:
+    if not lines:
+        return lines
+    out: list[str] = []
+    prev = None
+    count = 0
+    for line in lines:
+        if line == prev:
+            count += 1
+            if count <= max_repeats:
+                out.append(line)
+            continue
+        if prev is not None and count > max_repeats:
+            out.append(f"[... repeated {count - max_repeats} more times ...]")
+        prev = line
+        count = 1
+        out.append(line)
+    if prev is not None and count > max_repeats:
+        out.append(f"[... repeated {count - max_repeats} more times ...]")
+    return out
+
+
+def _head_tail(lines: list[str], *, head: int, tail: int) -> str:
+    if len(lines) <= head + tail:
+        return "\n".join(lines)
+    omitted = len(lines) - head - tail
+    return "\n".join(lines[:head] + [f"... [{omitted} lines omitted] ..."] + lines[-tail:])
+
+
+def _reduce_generic(output: str, target_chars: int) -> str:
+    lines = _collapse_repeated_lines(output.splitlines())
+    if len("\n".join(lines)) <= target_chars:
+        return "\n".join(lines)
+    head = max(20, target_chars // 220)
+    tail = max(40, target_chars // 140)
+    return _head_tail(lines, head=head, tail=tail)
+
+
+def _reduce_git_status(output: str, target_chars: int) -> str:
+    lines = output.splitlines()
+    if len(output) <= target_chars:
+        return output
+    important = [ln for ln in lines if ln.startswith(("##", " M", "M ", " A", "A ", " D", "D ", " R", "R ", " C", "C ", "??", "UU"))]
+    if important:
+        body = _head_tail(important, head=80, tail=80)
+        return "[git status compact view]\n" + body
+    return _reduce_generic(output, target_chars)
+
+
+def _reduce_git_log(output: str, target_chars: int) -> str:
+    lines = output.splitlines()
+    return _head_tail(lines, head=120, tail=20) if len(output) > target_chars else output
+
+
+def _reduce_git_diff(output: str, target_chars: int) -> str:
+    if len(output) <= target_chars:
+        return output
+    kept: list[str] = []
+    for line in output.splitlines():
+        if line.startswith(("diff --git", "+++ ", "--- ", "@@", "+", "-")):
+            kept.append(line)
+    compact = _head_tail(kept, head=160, tail=120) if kept else _reduce_generic(output, target_chars)
+    return "[git diff compact view: headers/hunks preserved, context reduced]\n" + compact
+
+
+def _reduce_test_output(output: str, target_chars: int) -> str:
+    if len(output) <= target_chars:
+        return output
+    lines = output.splitlines()
+    patterns = re.compile(
+        r"(FAILED|FAILURES|ERROR|Error|Traceback|AssertionError|E\s+|F\s+|=+.*(failed|error|passed)|short test summary|FAIL|panic|thread '.*' panicked)",
+        re.IGNORECASE,
+    )
+    important = [ln for ln in lines if patterns.search(ln)]
+    if important:
+        body = _head_tail(important, head=120, tail=120)
+        tail = "\n".join(lines[-40:])
+        return "[test output compact view: failures/errors/summary preserved]\n" + body + "\n\n[tail]\n" + tail
+    return _head_tail(lines, head=80, tail=80)
+
+
+def _reduce_output(command_class: str, output: str, target_chars: int) -> str:
+    if command_class == "git_status":
+        return _reduce_git_status(output, target_chars)
+    if command_class == "git_log":
+        return _reduce_git_log(output, target_chars)
+    if command_class == "git_diff":
+        return _reduce_git_diff(output, target_chars)
+    if command_class == "test":
+        return _reduce_test_output(output, target_chars)
+    return _reduce_generic(output, target_chars)
+
+
+def _write_raw_output(output: str, command: str, env, storage_dir: str) -> str:
+    digest = hashlib.sha256((command + "\0" + output).encode("utf-8", errors="replace")).hexdigest()[:16]
+    remote_path = f"{storage_dir.rstrip('/')}/terminal-{digest}.txt"
+    if env is None:
+        os.makedirs(storage_dir, mode=0o700, exist_ok=True)
+        try:
+            os.chmod(storage_dir, 0o700)
+        except OSError:
+            pass
+        flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC
+        fd = os.open(remote_path, flags, 0o600)
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                f.write(output)
+        finally:
+            try:
+                os.chmod(remote_path, stat.S_IRUSR | stat.S_IWUSR)
+            except OSError:
+                pass
+        return remote_path
+    try:
+        storage = shlex.quote(storage_dir.rstrip("/"))
+        target = shlex.quote(remote_path)
+        cmd = f"umask 077 && mkdir -p {storage} && chmod 700 {storage} && cat > {target} && chmod 600 {target}"
+        result = env.execute(cmd, timeout=30, stdin_data=output)
+        if result.get("returncode", 1) == 0:
+            return remote_path
+    except Exception:
+        return ""
+    return ""
+
+
+def optimize_terminal_output(
+    *,
+    command: str,
+    output: str,
+    returncode: int = 0,
+    env=None,
+    config: dict[str, Any] | None = None,
+) -> OptimizationResult:
+    """Return optimized output when enabled and safe, else original output."""
+    cfg = _load_optimizer_config(config)
+    if not _as_bool(cfg.get("enabled")):
+        return OptimizationResult(output=output, optimized=False, reason="disabled")
+    if not output:
+        return OptimizationResult(output=output, optimized=False, reason="empty")
+
+    min_chars = _as_int(cfg.get("min_chars"), DEFAULT_CONFIG["min_chars"], minimum=0)
+    target_chars = _as_int(cfg.get("target_chars"), DEFAULT_CONFIG["target_chars"], minimum=1000)
+    if len(output) < min_chars:
+        return OptimizationResult(output=output, optimized=False, reason="below_min_chars")
+
+    command_class = classify_command(command)
+    try:
+        compact = _reduce_output(command_class, output, target_chars)
+    except Exception:
+        return OptimizationResult(output=output, optimized=False, reason="reducer_error")
+
+    # Do not add metadata or raw files when the reducer did not materially help.
+    if len(compact) >= len(output) * 0.95 and len(compact) <= len(output):
+        return OptimizationResult(output=output, optimized=False, reason="not_beneficial")
+    if len(compact) >= len(output):
+        return OptimizationResult(output=output, optimized=False, reason="expanded")
+
+    raw_path = ""
+    if str(cfg.get("raw_output", "preserve")).lower() == "preserve":
+        raw_path = _write_raw_output(output, command, env, str(cfg.get("storage_dir") or DEFAULT_CONFIG["storage_dir"]))
+        if not raw_path:
+            return OptimizationResult(output=output, optimized=False, reason="raw_preserve_failed")
+
+    saved = len(output) - len(compact)
+    metadata = [
+        "<terminal-output-optimized>",
+        f"command_class: {command_class}",
+        f"exit_code: {returncode}",
+        f"original_chars: {len(output)}",
+        f"optimized_chars: {len(compact)}",
+        f"saved_chars: {saved}",
+    ]
+    if raw_path:
+        metadata.append(f"raw_sanitized_output: {raw_path}")
+    metadata.append("Raw file contains the complete post-ANSI-strip, post-secret-redaction output before optimization.")
+    metadata.append("</terminal-output-optimized>")
+    final = "\n".join(metadata) + "\n" + compact
+    return OptimizationResult(
+        output=final,
+        optimized=True,
+        raw_path=raw_path,
+        original_chars=len(output),
+        optimized_chars=len(final),
+        command_class=command_class,
+    )

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -2099,7 +2099,38 @@ def terminal_tool(
             except Exception:
                 pass
             
-            # Truncate output if too long, keeping both head and tail
+            # Strip ANSI escape sequences before any optimizer/raw preservation
+            # so saved terminal artifacts never contain control codes.
+            from tools.ansi_strip import strip_ansi
+            output = strip_ansi(output)
+
+            # Redact secrets from command output (catches env/printenv leaking keys)
+            # before optional raw preservation. This is intentionally before the
+            # legacy head/tail cap so the optimizer can preserve complete
+            # sanitized output instead of an already-truncated fragment.
+            from agent.redact import redact_sensitive_text
+            output = redact_sensitive_text(output.strip()) if output else ""
+
+            # Optional RTK-inspired terminal output optimization. This runs only
+            # after ANSI stripping and secret redaction, never changes the
+            # command/exit code/error fields, and fails open to the original
+            # sanitized output when raw preservation is unavailable.
+            try:
+                from tools.terminal_output_optimizer import optimize_terminal_output
+
+                output = optimize_terminal_output(
+                    command=command,
+                    output=output,
+                    returncode=returncode,
+                    env=locals().get("env"),
+                ).output
+            except Exception:
+                pass
+
+            # Legacy terminal output cap remains after optional optimization as
+            # a final safety net. If optimization is disabled or not beneficial,
+            # behavior is still bounded; if optimization succeeds, this should
+            # normally be a no-op because target_chars is below max_bytes.
             from tools.tool_output_limits import get_max_bytes
             MAX_OUTPUT_CHARS = get_max_bytes()
             if len(output) > MAX_OUTPUT_CHARS:
@@ -2111,15 +2142,6 @@ def terminal_tool(
                     f"out of {len(output)} total] ...\n\n"
                 )
                 output = output[:head_chars] + truncated_notice + output[-tail_chars:]
-
-            # Strip ANSI escape sequences so the model never sees terminal
-            # formatting — prevents it from copying escapes into file writes.
-            from tools.ansi_strip import strip_ansi
-            output = strip_ansi(output)
-
-            # Redact secrets from command output (catches env/printenv leaking keys)
-            from agent.redact import redact_sensitive_text
-            output = redact_sensitive_text(output.strip()) if output else ""
 
             # Interpret non-zero exit codes that aren't real errors
             # (e.g. grep=1 means "no matches", diff=1 means "files differ")


### PR DESCRIPTION
## Summary
- Add opt-in workflow-level guardrails with final-answer advisory/nudge/block modes
- Add deterministic workflow guardrail eval harness and tests
- Add conservative local backend sampling defaults for Ollama, llama.cpp, and LM Studio
- Expand compaction guidance for guardrail and verification evidence

## Verification
- venv/bin/python -m pytest tests/agent/test_workflow_guardrails.py tests/agent/test_model_sampling_registry.py tests/agent/test_tool_guardrails.py tests/run_agent/test_tool_call_guardrail_runtime.py tests/run_agent/test_tool_executor_contextvar_propagation.py -q -o 'addopts='
- venv/bin/python scripts/workflow_guardrail_eval.py

## Notes
- Runtime defaults remain opt-in/off in repository config examples; local user config can enable advisory mode.
- Direct push to upstream origin was denied, so this PR is opened from the fork.