### PR TITLE
feat(memory): add evidence repair governance workflow

### DIFF
--- a/agent/memory_evidence_repair_apply_preview.py
+++ b/agent/memory_evidence_repair_apply_preview.py
@@ -1,0 +1,355 @@
+"""Read-only apply previews for memory evidence repair candidates.
+
+The preview layer shows the exact evidence metadata patch that would be applied
+after a user confirms a repair candidate. It never writes to durable memory.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Mapping, Sequence
+
+
+PATCH_OPERATION = "merge_evidence_metadata"
+PREVIEW_STATUS_AWAITING_CONFIRMATION = "awaiting_user_confirmation"
+PREVIEW_STATUS_READY_FOR_MANUAL_APPLY = "ready_for_manual_apply"
+PREVIEW_STATUS_BLOCKED_MISSING_EVIDENCE = "blocked_missing_evidence"
+PENDING_VALUE = "<pending>"
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairApplyPreview:
+    """One read-only evidence repair patch preview."""
+
+    id: str
+    candidate_id: str
+    status: str
+    provider: str
+    priority: str
+    repair_action: str
+    operation: str
+    target: dict[str, Any]
+    evidence_patch: dict[str, Any]
+    memory_patch_preview: dict[str, Any]
+    would_update_fields: tuple[str, ...]
+    missing_evidence: tuple[str, ...]
+    preconditions: tuple[str, ...]
+    content_preview: str
+    source: str
+    reason: str
+    safety_note: str
+    source_candidate: dict[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "candidate_id": self.candidate_id,
+            "status": self.status,
+            "provider": self.provider,
+            "priority": self.priority,
+            "repair_action": self.repair_action,
+            "operation": self.operation,
+            "target": dict(self.target),
+            "evidence_patch": dict(self.evidence_patch),
+            "memory_patch_preview": dict(self.memory_patch_preview),
+            "would_update_fields": list(self.would_update_fields),
+            "missing_evidence": list(self.missing_evidence),
+            "preconditions": list(self.preconditions),
+            "content_preview": self.content_preview,
+            "source": self.source,
+            "reason": self.reason,
+            "safety_note": self.safety_note,
+            "source_candidate": dict(self.source_candidate),
+        }
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairApplyPreviewReport:
+    """Read-only evidence repair apply preview report."""
+
+    generated_at: str
+    previews: tuple[MemoryEvidenceRepairApplyPreview, ...]
+
+    @property
+    def summary(self) -> dict[str, Any]:
+        by_status: dict[str, int] = {}
+        by_provider: dict[str, int] = {}
+        by_repair_action: dict[str, int] = {}
+        missing_evidence_count = 0
+        ready_count = 0
+        awaiting_confirmation_count = 0
+        for preview in self.previews:
+            by_status[preview.status] = by_status.get(preview.status, 0) + 1
+            by_repair_action[preview.repair_action] = (
+                by_repair_action.get(preview.repair_action, 0) + 1
+            )
+            if preview.provider:
+                by_provider[preview.provider] = by_provider.get(preview.provider, 0) + 1
+            if preview.missing_evidence:
+                missing_evidence_count += 1
+            if preview.status == PREVIEW_STATUS_READY_FOR_MANUAL_APPLY:
+                ready_count += 1
+            if preview.status == PREVIEW_STATUS_AWAITING_CONFIRMATION:
+                awaiting_confirmation_count += 1
+        return {
+            "preview_count": len(self.previews),
+            "ready_count": ready_count,
+            "awaiting_confirmation_count": awaiting_confirmation_count,
+            "missing_evidence_count": missing_evidence_count,
+            "by_status": by_status,
+            "by_provider": by_provider,
+            "by_repair_action": by_repair_action,
+            "requires_user_confirmation": awaiting_confirmation_count > 0,
+            "has_previews": bool(self.previews),
+        }
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "generated_at": self.generated_at,
+            "summary": self.summary,
+            "previews": [preview.to_dict() for preview in self.previews],
+            "read_only": True,
+            "read_only_memory": True,
+            "would_mutate_memory": False,
+        }
+
+
+def build_evidence_repair_apply_preview(
+    *,
+    approval: Mapping[str, Any] | None = None,
+    candidates: Sequence[Mapping[str, Any]] | None = None,
+    approved_candidate_ids: Sequence[str] | None = None,
+    proposed_evidence: Mapping[str, Any] | None = None,
+) -> MemoryEvidenceRepairApplyPreviewReport:
+    """Build read-only patch previews from evidence repair approval candidates."""
+
+    approval = approval if isinstance(approval, Mapping) else {}
+    proposed_evidence = (
+        proposed_evidence if isinstance(proposed_evidence, Mapping) else {}
+    )
+    candidate_rows = _candidate_rows(approval=approval, candidates=candidates)
+    approved_ids = _string_set(approved_candidate_ids)
+    filter_to_approved = approved_candidate_ids is not None
+
+    previews: list[MemoryEvidenceRepairApplyPreview] = []
+    for candidate in candidate_rows:
+        if not isinstance(candidate, Mapping):
+            continue
+        candidate_id = _str(candidate.get("id"))
+        if filter_to_approved and candidate_id not in approved_ids:
+            continue
+        preview = _preview_from_candidate(
+            candidate,
+            approved_ids=approved_ids,
+            approval_filter_enabled=filter_to_approved,
+            proposed_evidence=proposed_evidence,
+        )
+        if preview is not None:
+            previews.append(preview)
+
+    return MemoryEvidenceRepairApplyPreviewReport(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        previews=tuple(_dedupe_previews(previews)),
+    )
+
+
+def empty_evidence_repair_apply_preview() -> MemoryEvidenceRepairApplyPreviewReport:
+    """Return an empty read-only apply preview report."""
+
+    return MemoryEvidenceRepairApplyPreviewReport(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        previews=(),
+    )
+
+
+def _preview_from_candidate(
+    candidate: Mapping[str, Any],
+    *,
+    approved_ids: set[str],
+    approval_filter_enabled: bool,
+    proposed_evidence: Mapping[str, Any],
+) -> MemoryEvidenceRepairApplyPreview | None:
+    candidate_id = _str(candidate.get("id"))
+    repair_action = _str(candidate.get("repair_action") or candidate.get("action"))
+    reason = _str(candidate.get("reason"))
+    if not candidate_id and not repair_action and not reason:
+        return None
+
+    if not candidate_id:
+        candidate_id = _stable_preview_source_id(candidate)
+    provider = _str(candidate.get("provider")) or "memory"
+    priority = _str(candidate.get("priority")) or "medium"
+    source = _str(candidate.get("source")) or "memory_evidence_repair_approval"
+    required_evidence = _required_evidence(candidate)
+    evidence_patch = _evidence_patch(
+        candidate_id=candidate_id,
+        required_evidence=required_evidence,
+        candidate=candidate,
+        proposed_evidence=proposed_evidence,
+    )
+    missing_evidence = tuple(
+        field for field in required_evidence if _is_missing(evidence_patch.get(field))
+    )
+    status = _preview_status(
+        candidate_id=candidate_id,
+        approved_ids=approved_ids,
+        approval_filter_enabled=approval_filter_enabled,
+        missing_evidence=missing_evidence,
+    )
+    target = {
+        "candidate_id": candidate_id,
+        "provider": provider,
+        "source": source,
+    }
+    memory_patch = {
+        "operation": PATCH_OPERATION,
+        "target": target,
+        "set": {
+            "evidence": evidence_patch,
+            "evidence_repair": {
+                "candidate_id": candidate_id,
+                "repair_action": repair_action,
+                "reason": reason,
+                "source": source,
+            },
+        },
+    }
+    return MemoryEvidenceRepairApplyPreview(
+        id=_stable_preview_id(candidate_id, evidence_patch),
+        candidate_id=candidate_id,
+        status=status,
+        provider=provider,
+        priority=priority,
+        repair_action=repair_action or "attach_provenance",
+        operation=PATCH_OPERATION,
+        target=target,
+        evidence_patch=evidence_patch,
+        memory_patch_preview=memory_patch,
+        would_update_fields=tuple(evidence_patch.keys()),
+        missing_evidence=missing_evidence,
+        preconditions=_preconditions(status, missing_evidence),
+        content_preview=_str(candidate.get("content_preview"))[:280],
+        source=source,
+        reason=reason or "Evidence repair apply preview needs review.",
+        safety_note=(
+            "Preview only. This patch must not be applied to durable memory "
+            "until the user explicitly confirms it."
+        ),
+        source_candidate=dict(candidate),
+    )
+
+
+def _candidate_rows(
+    *,
+    approval: Mapping[str, Any],
+    candidates: Sequence[Mapping[str, Any]] | None,
+) -> list[Any]:
+    if candidates is not None:
+        return list(candidates)
+    value = approval.get("candidates")
+    return value if isinstance(value, list) else []
+
+
+def _evidence_patch(
+    *,
+    candidate_id: str,
+    required_evidence: tuple[str, ...],
+    candidate: Mapping[str, Any],
+    proposed_evidence: Mapping[str, Any],
+) -> dict[str, Any]:
+    candidate_patch = candidate.get("proposed_evidence_patch")
+    candidate_patch = candidate_patch if isinstance(candidate_patch, Mapping) else {}
+    scoped_patch = proposed_evidence.get(candidate_id)
+    scoped_patch = scoped_patch if isinstance(scoped_patch, Mapping) else {}
+    patch: dict[str, Any] = {}
+    for field in required_evidence:
+        if field in scoped_patch and not _is_missing(scoped_patch[field]):
+            patch[field] = scoped_patch[field]
+        elif field in proposed_evidence and not _is_missing(proposed_evidence[field]):
+            patch[field] = proposed_evidence[field]
+        elif field in candidate_patch:
+            patch[field] = candidate_patch[field]
+        else:
+            patch[field] = PENDING_VALUE
+    return patch
+
+
+def _preview_status(
+    *,
+    candidate_id: str,
+    approved_ids: set[str],
+    approval_filter_enabled: bool,
+    missing_evidence: tuple[str, ...],
+) -> str:
+    if missing_evidence:
+        return PREVIEW_STATUS_BLOCKED_MISSING_EVIDENCE
+    if approval_filter_enabled and candidate_id in approved_ids:
+        return PREVIEW_STATUS_READY_FOR_MANUAL_APPLY
+    return PREVIEW_STATUS_AWAITING_CONFIRMATION
+
+
+def _preconditions(status: str, missing_evidence: tuple[str, ...]) -> tuple[str, ...]:
+    preconditions = ["explicit_user_confirmation"]
+    if missing_evidence:
+        preconditions.append("complete_required_evidence")
+    if status == PREVIEW_STATUS_READY_FOR_MANUAL_APPLY:
+        preconditions.append("manual_apply_only")
+    return tuple(preconditions)
+
+
+def _required_evidence(candidate: Mapping[str, Any]) -> tuple[str, ...]:
+    required = candidate.get("required_evidence")
+    if isinstance(required, (list, tuple)):
+        fields = tuple(_str(item) for item in required if _str(item))
+        if fields:
+            return fields
+    patch = candidate.get("proposed_evidence_patch")
+    if isinstance(patch, Mapping) and patch:
+        return tuple(_str(field) for field in patch.keys() if _str(field))
+    return ("source_url", "observed_at", "verification_signal")
+
+
+def _dedupe_previews(
+    previews: list[MemoryEvidenceRepairApplyPreview],
+) -> list[MemoryEvidenceRepairApplyPreview]:
+    seen: set[str] = set()
+    deduped: list[MemoryEvidenceRepairApplyPreview] = []
+    for preview in previews:
+        if preview.id in seen:
+            continue
+        seen.add(preview.id)
+        deduped.append(preview)
+    return deduped
+
+
+def _stable_preview_id(candidate_id: str, evidence_patch: Mapping[str, Any]) -> str:
+    raw = json.dumps(
+        {"candidate_id": candidate_id, "evidence_patch": dict(evidence_patch)},
+        sort_keys=True,
+        ensure_ascii=False,
+    )
+    digest = hashlib.sha256(raw.encode("utf-8")).hexdigest()[:16]
+    return f"preview-{digest}"
+
+
+def _stable_preview_source_id(candidate: Mapping[str, Any]) -> str:
+    raw = json.dumps(dict(candidate), sort_keys=True, ensure_ascii=False, default=str)
+    digest = hashlib.sha256(raw.encode("utf-8")).hexdigest()[:16]
+    return f"repair-{digest}"
+
+
+def _string_set(value: Sequence[str] | None) -> set[str]:
+    if value is None:
+        return set()
+    return {_str(item) for item in value if _str(item)}
+
+
+def _is_missing(value: Any) -> bool:
+    return value in (None, "", PENDING_VALUE)
+
+
+def _str(value: Any) -> str:
+    return str(value or "").strip()

--- a/agent/memory_evidence_repair_approval.py
+++ b/agent/memory_evidence_repair_approval.py
@@ -1,0 +1,246 @@
+"""Read-only approval candidates for memory evidence repair.
+
+This layer converts an evidence repair plan into human-confirmable candidate
+records. It never writes to durable memory stores.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Mapping
+
+
+CANDIDATE_TYPE = "memory_evidence_repair"
+STATUS_NEEDS_CONFIRMATION = "needs_user_confirmation"
+PENDING_VALUE = "<pending>"
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairApprovalCandidate:
+    """One read-only repair candidate that needs user confirmation."""
+
+    id: str
+    candidate_type: str
+    status: str
+    provider: str
+    priority: str
+    repair_action: str
+    source: str
+    reason: str
+    content_preview: str
+    required_evidence: tuple[str, ...]
+    proposed_evidence_patch: dict[str, Any]
+    confirmation_question: str
+    safety_note: str
+    source_repair: dict[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "candidate_type": self.candidate_type,
+            "status": self.status,
+            "provider": self.provider,
+            "priority": self.priority,
+            "repair_action": self.repair_action,
+            "source": self.source,
+            "reason": self.reason,
+            "content_preview": self.content_preview,
+            "required_evidence": list(self.required_evidence),
+            "proposed_evidence_patch": dict(self.proposed_evidence_patch),
+            "confirmation_question": self.confirmation_question,
+            "safety_note": self.safety_note,
+            "source_repair": dict(self.source_repair),
+        }
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairApprovalReport:
+    """Read-only approval candidate report."""
+
+    generated_at: str
+    candidates: tuple[MemoryEvidenceRepairApprovalCandidate, ...]
+
+    @property
+    def summary(self) -> dict[str, Any]:
+        by_priority: dict[str, int] = {}
+        by_provider: dict[str, int] = {}
+        by_repair_action: dict[str, int] = {}
+        for candidate in self.candidates:
+            by_priority[candidate.priority] = by_priority.get(candidate.priority, 0) + 1
+            by_repair_action[candidate.repair_action] = (
+                by_repair_action.get(candidate.repair_action, 0) + 1
+            )
+            if candidate.provider:
+                by_provider[candidate.provider] = by_provider.get(candidate.provider, 0) + 1
+        return {
+            "candidate_count": len(self.candidates),
+            "by_priority": by_priority,
+            "by_provider": by_provider,
+            "by_repair_action": by_repair_action,
+            "requires_user_confirmation": bool(self.candidates),
+            "has_candidates": bool(self.candidates),
+        }
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "generated_at": self.generated_at,
+            "summary": self.summary,
+            "candidates": [candidate.to_dict() for candidate in self.candidates],
+            "read_only": True,
+            "read_only_memory": True,
+        }
+
+
+def build_evidence_repair_approval_candidates(
+    *,
+    plan: Mapping[str, Any] | None = None,
+    proposed_evidence: Mapping[str, Any] | None = None,
+) -> MemoryEvidenceRepairApprovalReport:
+    """Build read-only approval candidates from an evidence repair plan."""
+
+    plan = plan if isinstance(plan, Mapping) else {}
+    proposed_evidence = (
+        proposed_evidence if isinstance(proposed_evidence, Mapping) else {}
+    )
+    candidates: list[MemoryEvidenceRepairApprovalCandidate] = []
+    for repair in _list(plan.get("repairs")):
+        if not isinstance(repair, Mapping):
+            continue
+        candidate = _candidate_from_repair(repair, proposed_evidence)
+        if candidate is not None:
+            candidates.append(candidate)
+
+    return MemoryEvidenceRepairApprovalReport(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        candidates=tuple(_dedupe_candidates(candidates)),
+    )
+
+
+def empty_evidence_repair_approval_candidates() -> MemoryEvidenceRepairApprovalReport:
+    """Return an empty read-only approval candidate report."""
+
+    return MemoryEvidenceRepairApprovalReport(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        candidates=(),
+    )
+
+
+def _candidate_from_repair(
+    repair: Mapping[str, Any],
+    proposed_evidence: Mapping[str, Any],
+) -> MemoryEvidenceRepairApprovalCandidate | None:
+    action = _str(repair.get("action") or repair.get("repair_action"))
+    reason = _str(repair.get("reason"))
+    if not action and not reason:
+        return None
+
+    provider = _str(repair.get("provider")) or "memory"
+    priority = _str(repair.get("priority")) or "medium"
+    source = _str(repair.get("source")) or "memory_evidence_repair_plan"
+    content_preview = _content_preview(repair)
+    required_evidence = _required_evidence(repair.get("required_evidence"))
+    candidate_id = _stable_candidate_id(
+        provider=provider,
+        action=action,
+        source=source,
+        reason=reason,
+        content_preview=content_preview,
+    )
+    proposed_patch = {
+        field: _proposed_value(field, proposed_evidence) for field in required_evidence
+    }
+    return MemoryEvidenceRepairApprovalCandidate(
+        id=candidate_id,
+        candidate_type=CANDIDATE_TYPE,
+        status=STATUS_NEEDS_CONFIRMATION,
+        provider=provider,
+        priority=priority,
+        repair_action=action,
+        source=source,
+        reason=reason or "Evidence repair needs user confirmation.",
+        content_preview=content_preview,
+        required_evidence=required_evidence,
+        proposed_evidence_patch=proposed_patch,
+        confirmation_question=_confirmation_question(action, required_evidence),
+        safety_note=(
+            "Read-only candidate. Do not write this repair to memory until the "
+            "user explicitly confirms the evidence patch."
+        ),
+        source_repair=dict(repair),
+    )
+
+
+def _dedupe_candidates(
+    candidates: list[MemoryEvidenceRepairApprovalCandidate],
+) -> list[MemoryEvidenceRepairApprovalCandidate]:
+    seen: set[str] = set()
+    deduped: list[MemoryEvidenceRepairApprovalCandidate] = []
+    for candidate in candidates:
+        if candidate.id in seen:
+            continue
+        seen.add(candidate.id)
+        deduped.append(candidate)
+    return deduped
+
+
+def _stable_candidate_id(
+    *,
+    provider: str,
+    action: str,
+    source: str,
+    reason: str,
+    content_preview: str,
+) -> str:
+    raw = json.dumps(
+        {
+            "provider": provider,
+            "action": action,
+            "source": source,
+            "reason": reason,
+            "content_preview": content_preview,
+        },
+        sort_keys=True,
+        ensure_ascii=False,
+    )
+    digest = hashlib.sha256(raw.encode("utf-8")).hexdigest()[:16]
+    return f"repair-{digest}"
+
+
+def _required_evidence(value: Any) -> tuple[str, ...]:
+    if not isinstance(value, (list, tuple)):
+        return ("source_url", "observed_at", "verification_signal")
+    fields = tuple(_str(item) for item in value if _str(item))
+    return fields or ("source_url", "observed_at", "verification_signal")
+
+
+def _proposed_value(field: str, proposed_evidence: Mapping[str, Any]) -> Any:
+    if field in proposed_evidence and proposed_evidence[field] not in (None, ""):
+        return proposed_evidence[field]
+    return PENDING_VALUE
+
+
+def _confirmation_question(action: str, required_evidence: tuple[str, ...]) -> str:
+    evidence_list = ", ".join(required_evidence) or "the required evidence"
+    if action == "refresh_observation":
+        return f"Can you confirm the refreshed {evidence_list} for this memory?"
+    if action == "review_conflict":
+        return f"Can you confirm the conflict resolution and {evidence_list}?"
+    return f"Can you confirm {evidence_list} for this memory evidence repair?"
+
+
+def _content_preview(repair: Mapping[str, Any]) -> str:
+    preview = _str(repair.get("content_preview"))
+    if not preview:
+        preview = _str(repair.get("evidence"))
+    return preview[:280]
+
+
+def _list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _str(value: Any) -> str:
+    return str(value or "").strip()

--- a/agent/memory_evidence_repair_approval_token_gate.py
+++ b/agent/memory_evidence_repair_approval_token_gate.py
@@ -1,0 +1,617 @@
+"""Read-only approval token verification gate for memory evidence repair.
+
+The gate verifies a drafted human approval token against the current dry-run,
+confirmation text, expiry window, and one-time-use hints. It never writes to
+durable memory stores.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Any, Mapping, Sequence
+
+from agent.memory_evidence_repair_human_approval_token import (
+    APPROVAL_TOKEN_SCOPE,
+    APPROVAL_TOKEN_TYPE,
+    TOKEN_STATUS_DRAFT_READY,
+    TOKEN_STATUS_NO_ACTION_NEEDED,
+)
+from agent.memory_evidence_repair_manual_commit_dry_run import (
+    CHECK_STATUS_FAIL,
+    CHECK_STATUS_PASS,
+    DRY_RUN_STATUS_NO_ACTION_NEEDED,
+    DRY_RUN_STATUS_READY_FOR_MANUAL_COMMIT,
+)
+
+
+TOKEN_GATE_STATUS_VERIFIED = "verified_for_manual_commit"
+TOKEN_GATE_STATUS_BLOCKED = "blocked"
+TOKEN_GATE_STATUS_NO_ACTION_NEEDED = "no_action_needed"
+
+CHECK_TOKEN_SHAPE = "token_shape"
+CHECK_CONFIRMATION_TEXT = "confirmation_text"
+CHECK_TOKEN_DIGEST = "token_digest"
+CHECK_DRY_RUN_DIGEST = "dry_run_digest"
+CHECK_PATCH_DIGESTS = "patch_digests"
+CHECK_EXPIRY = "expiry"
+CHECK_ONE_TIME_CONSTRAINTS = "one_time_constraints"
+CHECK_REUSE = "reuse"
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairApprovalTokenGateCheck:
+    """One read-only approval token verification check."""
+
+    id: str
+    status: str
+    reason: str
+    required_actions: tuple[str, ...]
+    details: dict[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "status": self.status,
+            "reason": self.reason,
+            "required_actions": list(self.required_actions),
+            "details": dict(self.details),
+        }
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairApprovalTokenGateReport:
+    """Read-only approval token gate report."""
+
+    generated_at: str
+    status: str
+    token_id: str
+    dry_run_status: str
+    checks: tuple[MemoryEvidenceRepairApprovalTokenGateCheck, ...]
+    blocking_reasons: tuple[str, ...]
+    required_actions: tuple[str, ...]
+    verified_operation_ids: tuple[str, ...]
+    verified_candidate_ids: tuple[str, ...]
+    verified_patch_digests: tuple[str, ...]
+    source_token: dict[str, Any]
+    source_dry_run: dict[str, Any]
+
+    @property
+    def summary(self) -> dict[str, Any]:
+        by_check_status: dict[str, int] = {}
+        for check in self.checks:
+            by_check_status[check.status] = by_check_status.get(check.status, 0) + 1
+        return {
+            "status": self.status,
+            "token_id": self.token_id,
+            "check_count": len(self.checks),
+            "pass_count": by_check_status.get(CHECK_STATUS_PASS, 0),
+            "fail_count": by_check_status.get(CHECK_STATUS_FAIL, 0),
+            "blocking_reason_count": len(self.blocking_reasons),
+            "required_action_count": len(self.required_actions),
+            "verified_operation_count": len(self.verified_operation_ids),
+            "manual_commit_verified": self.status == TOKEN_GATE_STATUS_VERIFIED,
+            "has_blocks": self.status == TOKEN_GATE_STATUS_BLOCKED,
+            "requires_followup": bool(self.required_actions),
+            "by_check_status": by_check_status,
+        }
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "generated_at": self.generated_at,
+            "status": self.status,
+            "summary": self.summary,
+            "token_id": self.token_id,
+            "dry_run_status": self.dry_run_status,
+            "checks": [check.to_dict() for check in self.checks],
+            "blocking_reasons": list(self.blocking_reasons),
+            "required_actions": list(self.required_actions),
+            "verified_operation_ids": list(self.verified_operation_ids),
+            "verified_candidate_ids": list(self.verified_candidate_ids),
+            "verified_patch_digests": list(self.verified_patch_digests),
+            "source_token": dict(self.source_token),
+            "source_dry_run": dict(self.source_dry_run),
+            "read_only": True,
+            "read_only_memory": True,
+            "would_mutate_memory": False,
+        }
+
+
+def build_evidence_repair_approval_token_gate(
+    *,
+    approval_token: Mapping[str, Any] | None = None,
+    dry_run: Mapping[str, Any] | None = None,
+    confirmation_text: str = "",
+    used_token_ids: Sequence[str] | None = None,
+    current_time: str | datetime | None = None,
+) -> MemoryEvidenceRepairApprovalTokenGateReport:
+    """Verify a human approval token without mutating memory."""
+
+    token, issued_at = _extract_token_and_issued_at(approval_token)
+    explicit_dry_run = dry_run if isinstance(dry_run, Mapping) else {}
+    token_dry_run = token.get("source_dry_run") if isinstance(token, Mapping) else {}
+    current_dry_run = explicit_dry_run or (
+        token_dry_run if isinstance(token_dry_run, Mapping) else {}
+    )
+    current_dry_run = current_dry_run if isinstance(current_dry_run, Mapping) else {}
+
+    approval_token_status = (
+        _str(approval_token.get("status")) if isinstance(approval_token, Mapping) else ""
+    )
+    if not token:
+        dry_run_status = _str(current_dry_run.get("status"))
+        if (
+            approval_token_status == TOKEN_STATUS_NO_ACTION_NEEDED
+            or dry_run_status == DRY_RUN_STATUS_NO_ACTION_NEEDED
+            or (not current_dry_run and not approval_token_status)
+        ):
+            return _empty_report(dry_run=current_dry_run)
+        source_blocking = _list(approval_token.get("blocking_reasons")) if isinstance(approval_token, Mapping) else []
+        source_actions = _list(approval_token.get("required_actions")) if isinstance(approval_token, Mapping) else []
+        return _blocked_report(
+            token_id="",
+            dry_run=current_dry_run,
+            checks=(
+                _fail(
+                    CHECK_TOKEN_SHAPE,
+                    "No approval token was supplied."
+                    if not source_blocking
+                    else "; ".join(_str(item) for item in source_blocking if _str(item)),
+                    tuple(_str(item) for item in source_actions if _str(item))
+                    or ("draft_human_approval_token",),
+                    {"approval_token_status": approval_token_status},
+                ),
+            ),
+        )
+
+    checks = tuple(
+        check
+        for check in (
+            _token_shape_check(token),
+            _confirmation_check(token, confirmation_text),
+            _token_digest_check(token),
+            _dry_run_digest_check(token, current_dry_run),
+            _patch_digest_check(token, current_dry_run),
+            _expiry_check(token, issued_at, current_time),
+            _one_time_constraint_check(token),
+            _reuse_check(token, used_token_ids),
+        )
+        if check is not None
+    )
+    blocking_reasons = tuple(
+        _dedupe_strings(check.reason for check in checks if check.status == CHECK_STATUS_FAIL)
+    )
+    required_actions = tuple(
+        _dedupe_strings(
+            action
+            for check in checks
+            if check.status == CHECK_STATUS_FAIL
+            for action in check.required_actions
+        )
+    )
+    status = (
+        TOKEN_GATE_STATUS_VERIFIED
+        if checks and not blocking_reasons
+        else TOKEN_GATE_STATUS_BLOCKED
+    )
+    operations = _operation_rows(current_dry_run)
+    return MemoryEvidenceRepairApprovalTokenGateReport(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        status=status,
+        token_id=_str(token.get("id")),
+        dry_run_status=_str(current_dry_run.get("status")),
+        checks=checks,
+        blocking_reasons=blocking_reasons,
+        required_actions=required_actions,
+        verified_operation_ids=tuple(_str(operation.get("id")) for operation in operations),
+        verified_candidate_ids=tuple(_str(operation.get("candidate_id")) for operation in operations),
+        verified_patch_digests=tuple(_str(operation.get("patch_digest")) for operation in operations),
+        source_token=dict(token),
+        source_dry_run=dict(current_dry_run),
+    )
+
+
+def empty_evidence_repair_approval_token_gate() -> MemoryEvidenceRepairApprovalTokenGateReport:
+    """Return an empty read-only approval token gate report."""
+
+    return _empty_report(dry_run={})
+
+
+def _empty_report(*, dry_run: Mapping[str, Any]) -> MemoryEvidenceRepairApprovalTokenGateReport:
+    return MemoryEvidenceRepairApprovalTokenGateReport(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        status=TOKEN_GATE_STATUS_NO_ACTION_NEEDED,
+        token_id="",
+        dry_run_status=_str(dry_run.get("status")),
+        checks=(),
+        blocking_reasons=(),
+        required_actions=(),
+        verified_operation_ids=(),
+        verified_candidate_ids=(),
+        verified_patch_digests=(),
+        source_token={},
+        source_dry_run=dict(dry_run),
+    )
+
+
+def _blocked_report(
+    *,
+    token_id: str,
+    dry_run: Mapping[str, Any],
+    checks: tuple[MemoryEvidenceRepairApprovalTokenGateCheck, ...],
+) -> MemoryEvidenceRepairApprovalTokenGateReport:
+    blocking_reasons = tuple(
+        _dedupe_strings(check.reason for check in checks if check.status == CHECK_STATUS_FAIL)
+    )
+    required_actions = tuple(
+        _dedupe_strings(
+            action
+            for check in checks
+            if check.status == CHECK_STATUS_FAIL
+            for action in check.required_actions
+        )
+    )
+    return MemoryEvidenceRepairApprovalTokenGateReport(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        status=TOKEN_GATE_STATUS_BLOCKED,
+        token_id=token_id,
+        dry_run_status=_str(dry_run.get("status")),
+        checks=checks,
+        blocking_reasons=blocking_reasons,
+        required_actions=required_actions,
+        verified_operation_ids=(),
+        verified_candidate_ids=(),
+        verified_patch_digests=(),
+        source_token={},
+        source_dry_run=dict(dry_run),
+    )
+
+
+def _extract_token_and_issued_at(
+    approval_token: Mapping[str, Any] | None,
+) -> tuple[dict[str, Any], str]:
+    if not isinstance(approval_token, Mapping):
+        return {}, ""
+    report_issued_at = _str(approval_token.get("generated_at"))
+    token: Mapping[str, Any] | None = None
+    tokens = approval_token.get("tokens")
+    if isinstance(tokens, list):
+        token = next((item for item in tokens if isinstance(item, Mapping)), None)
+    elif _str(approval_token.get("id")):
+        token = approval_token
+    if not isinstance(token, Mapping):
+        return {}, report_issued_at
+    issued_at = (
+        _str(token.get("issued_at"))
+        or _str(token.get("generated_at"))
+        or report_issued_at
+    )
+    return dict(token), issued_at
+
+
+def _token_shape_check(
+    token: Mapping[str, Any],
+) -> MemoryEvidenceRepairApprovalTokenGateCheck:
+    reasons: list[str] = []
+    if not _str(token.get("id")).startswith("approval-token-"):
+        reasons.append("Token id is missing or invalid.")
+    if _str(token.get("token_type")) != APPROVAL_TOKEN_TYPE:
+        reasons.append("Token type is not a memory evidence repair human approval token.")
+    if _str(token.get("scope")) != APPROVAL_TOKEN_SCOPE:
+        reasons.append("Token scope does not match manual memory evidence repair commit.")
+    if _str(token.get("status")) != TOKEN_STATUS_DRAFT_READY:
+        reasons.append("Token is not a ready approval draft.")
+    if reasons:
+        return _fail(
+            CHECK_TOKEN_SHAPE,
+            " ".join(reasons),
+            ("regenerate_human_approval_token",),
+            {"token_id": _str(token.get("id"))},
+        )
+    return _pass(
+        CHECK_TOKEN_SHAPE,
+        "Approval token shape is valid.",
+        {"token_id": _str(token.get("id"))},
+    )
+
+
+def _confirmation_check(
+    token: Mapping[str, Any],
+    confirmation_text: str,
+) -> MemoryEvidenceRepairApprovalTokenGateCheck:
+    expected = _str(token.get("required_confirmation_text"))
+    actual = _str(confirmation_text)
+    constraints = _dict(token.get("one_time_constraints"))
+    constraint_expected = _str(constraints.get("requires_exact_confirmation_text"))
+    expected_values = {item for item in (expected, constraint_expected) if item}
+    if not actual or actual not in expected_values:
+        return _fail(
+            CHECK_CONFIRMATION_TEXT,
+            "Confirmation text does not exactly match the approval token.",
+            ("provide_exact_confirmation_text",),
+            {"expected_confirmation_text": expected or constraint_expected, "provided": actual},
+        )
+    return _pass(
+        CHECK_CONFIRMATION_TEXT,
+        "Confirmation text matches the approval token.",
+        {"provided": actual},
+    )
+
+
+def _token_digest_check(
+    token: Mapping[str, Any],
+) -> MemoryEvidenceRepairApprovalTokenGateCheck:
+    expected_digest = _expected_token_digest(token)
+    actual_digest = _str(token.get("token_digest"))
+    expected_id = f"approval-token-{expected_digest[:16]}" if expected_digest else ""
+    if actual_digest != expected_digest or _str(token.get("id")) != expected_id:
+        return _fail(
+            CHECK_TOKEN_DIGEST,
+            "Approval token digest or id does not match its declared payload.",
+            ("regenerate_human_approval_token",),
+            {
+                "expected_token_digest": expected_digest,
+                "actual_token_digest": actual_digest,
+                "expected_token_id": expected_id,
+                "actual_token_id": _str(token.get("id")),
+            },
+        )
+    return _pass(
+        CHECK_TOKEN_DIGEST,
+        "Approval token digest matches its declared payload.",
+        {"token_digest": actual_digest, "token_id": expected_id},
+    )
+
+
+def _dry_run_digest_check(
+    token: Mapping[str, Any],
+    dry_run: Mapping[str, Any],
+) -> MemoryEvidenceRepairApprovalTokenGateCheck:
+    if _str(dry_run.get("status")) != DRY_RUN_STATUS_READY_FOR_MANUAL_COMMIT:
+        return _fail(
+            CHECK_DRY_RUN_DIGEST,
+            "Current dry-run is not ready for manual commit.",
+            ("produce_ready_manual_commit_dry_run",),
+            {"dry_run_status": _str(dry_run.get("status"))},
+        )
+    actual = _dry_run_digest(dry_run)
+    expected = _str(token.get("dry_run_digest"))
+    if not expected or actual != expected:
+        return _fail(
+            CHECK_DRY_RUN_DIGEST,
+            "Current dry-run digest does not match the approval token.",
+            ("regenerate_human_approval_token_for_current_dry_run",),
+            {"expected_dry_run_digest": expected, "actual_dry_run_digest": actual},
+        )
+    return _pass(
+        CHECK_DRY_RUN_DIGEST,
+        "Current dry-run digest matches the approval token.",
+        {"dry_run_digest": actual},
+    )
+
+
+def _patch_digest_check(
+    token: Mapping[str, Any],
+    dry_run: Mapping[str, Any],
+) -> MemoryEvidenceRepairApprovalTokenGateCheck:
+    expected = _str_list(token.get("patch_digests"))
+    actual = [_str(operation.get("patch_digest")) for operation in _operation_rows(dry_run)]
+    constraints = _dict(token.get("one_time_constraints"))
+    constraint_expected = _str_list(constraints.get("requires_same_patch_digests"))
+    if expected != actual or (constraint_expected and constraint_expected != actual):
+        return _fail(
+            CHECK_PATCH_DIGESTS,
+            "Current dry-run patch digests do not match the approval token.",
+            ("regenerate_human_approval_token_for_current_patch_set",),
+            {
+                "expected_patch_digests": expected,
+                "constraint_patch_digests": constraint_expected,
+                "actual_patch_digests": actual,
+            },
+        )
+    return _pass(
+        CHECK_PATCH_DIGESTS,
+        "Current dry-run patch digests match the approval token.",
+        {"patch_digests": actual},
+    )
+
+
+def _expiry_check(
+    token: Mapping[str, Any],
+    issued_at: str,
+    current_time: str | datetime | None,
+) -> MemoryEvidenceRepairApprovalTokenGateCheck:
+    issued = _parse_datetime(issued_at)
+    now = _parse_datetime(current_time) or datetime.now(timezone.utc)
+    expires_in_minutes = _positive_int(token.get("expires_in_minutes")) or 30
+    if issued is None:
+        return _fail(
+            CHECK_EXPIRY,
+            "Approval token issue time is missing or invalid.",
+            ("provide_token_generated_at_or_regenerate_token",),
+            {"issued_at": issued_at},
+        )
+    expires_at = issued + timedelta(minutes=expires_in_minutes)
+    if now > expires_at:
+        return _fail(
+            CHECK_EXPIRY,
+            "Approval token has expired.",
+            ("regenerate_human_approval_token",),
+            {
+                "issued_at": issued.isoformat(),
+                "expires_at": expires_at.isoformat(),
+                "current_time": now.isoformat(),
+            },
+        )
+    return _pass(
+        CHECK_EXPIRY,
+        "Approval token is within its expiry window.",
+        {
+            "issued_at": issued.isoformat(),
+            "expires_at": expires_at.isoformat(),
+            "current_time": now.isoformat(),
+        },
+    )
+
+
+def _one_time_constraint_check(
+    token: Mapping[str, Any],
+) -> MemoryEvidenceRepairApprovalTokenGateCheck:
+    constraints = _dict(token.get("one_time_constraints"))
+    if constraints.get("one_time_use") is not True:
+        return _fail(
+            CHECK_ONE_TIME_CONSTRAINTS,
+            "Approval token does not declare one-time-use constraints.",
+            ("regenerate_human_approval_token",),
+            {"one_time_constraints": constraints},
+        )
+    expected_dry_run = _str(constraints.get("requires_exact_dry_run_digest"))
+    if expected_dry_run != _str(token.get("dry_run_digest")):
+        return _fail(
+            CHECK_ONE_TIME_CONSTRAINTS,
+            "Approval token dry-run constraint does not match its digest.",
+            ("regenerate_human_approval_token",),
+            {"one_time_constraints": constraints},
+        )
+    return _pass(
+        CHECK_ONE_TIME_CONSTRAINTS,
+        "Approval token one-time constraints are declared.",
+        {"one_time_constraints": constraints},
+    )
+
+
+def _reuse_check(
+    token: Mapping[str, Any],
+    used_token_ids: Sequence[str] | None,
+) -> MemoryEvidenceRepairApprovalTokenGateCheck:
+    token_id = _str(token.get("id"))
+    used = {_str(item) for item in used_token_ids or [] if _str(item)}
+    if token_id and token_id in used:
+        return _fail(
+            CHECK_REUSE,
+            "Approval token is already marked as used.",
+            ("regenerate_human_approval_token",),
+            {"token_id": token_id},
+        )
+    return _pass(
+        CHECK_REUSE,
+        "Approval token is not marked as used in the supplied read-only ledger.",
+        {"token_id": token_id, "used_token_id_count": len(used)},
+    )
+
+
+def _expected_token_digest(token: Mapping[str, Any]) -> str:
+    token_seed = {
+        "token_type": APPROVAL_TOKEN_TYPE,
+        "scope": APPROVAL_TOKEN_SCOPE,
+        "approver": _str(token.get("approver")) or "human",
+        "approval_reason": _str(token.get("approval_reason")),
+        "dry_run_digest": _str(token.get("dry_run_digest")),
+        "operation_ids": _str_list(token.get("operation_ids")),
+        "ledger_entry_ids": _str_list(token.get("ledger_entry_ids")),
+        "candidate_ids": _str_list(token.get("candidate_ids")),
+        "patch_digests": _str_list(token.get("patch_digests")),
+        "expires_in_minutes": _positive_int(token.get("expires_in_minutes")) or 30,
+    }
+    return _digest(token_seed)
+
+
+def _dry_run_digest(dry_run: Mapping[str, Any]) -> str:
+    return _digest(
+        {
+            "status": dry_run.get("status"),
+            "operations": _operation_rows(dry_run),
+            "checks": dry_run.get("checks"),
+        }
+    )
+
+
+def _operation_rows(dry_run: Mapping[str, Any]) -> list[Mapping[str, Any]]:
+    return [
+        operation
+        for operation in _list(dry_run.get("operations"))
+        if isinstance(operation, Mapping)
+    ]
+
+
+def _pass(
+    check_id: str,
+    reason: str,
+    details: Mapping[str, Any],
+) -> MemoryEvidenceRepairApprovalTokenGateCheck:
+    return MemoryEvidenceRepairApprovalTokenGateCheck(
+        id=check_id,
+        status=CHECK_STATUS_PASS,
+        reason=reason,
+        required_actions=(),
+        details=dict(details),
+    )
+
+
+def _fail(
+    check_id: str,
+    reason: str,
+    required_actions: Sequence[str],
+    details: Mapping[str, Any],
+) -> MemoryEvidenceRepairApprovalTokenGateCheck:
+    return MemoryEvidenceRepairApprovalTokenGateCheck(
+        id=check_id,
+        status=CHECK_STATUS_FAIL,
+        reason=reason,
+        required_actions=tuple(required_actions),
+        details=dict(details),
+    )
+
+
+def _parse_datetime(value: str | datetime | None) -> datetime | None:
+    if isinstance(value, datetime):
+        return value if value.tzinfo else value.replace(tzinfo=timezone.utc)
+    if not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    return parsed if parsed.tzinfo else parsed.replace(tzinfo=timezone.utc)
+
+
+def _positive_int(value: Any) -> int | None:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed if parsed > 0 else None
+
+
+def _digest(value: Any) -> str:
+    raw = json.dumps(value, sort_keys=True, ensure_ascii=False, default=str)
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def _dict(value: Any) -> dict[str, Any]:
+    return dict(value) if isinstance(value, Mapping) else {}
+
+
+def _list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _str_list(value: Any) -> list[str]:
+    return [_str(item) for item in value] if isinstance(value, list) else []
+
+
+def _dedupe_strings(values: Sequence[str] | Any) -> list[str]:
+    seen: set[str] = set()
+    result: list[str] = []
+    for value in values:
+        text = _str(value)
+        if text and text not in seen:
+            seen.add(text)
+            result.append(text)
+    return result
+
+
+def _str(value: Any) -> str:
+    return str(value or "").strip()

--- a/agent/memory_evidence_repair_commit_gate.py
+++ b/agent/memory_evidence_repair_commit_gate.py
@@ -1,0 +1,354 @@
+"""Read-only commit gate for memory evidence repair previews.
+
+The gate decides whether a repair preview is ready for a later manual write.
+It never writes to durable memory stores.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Mapping, Sequence
+
+from agent.memory_evidence_repair_apply_preview import (
+    PATCH_OPERATION,
+    PREVIEW_STATUS_READY_FOR_MANUAL_APPLY,
+)
+
+
+DECISION_ALLOW_MANUAL_COMMIT = "allow_manual_commit"
+DECISION_BLOCK_COMMIT = "block_commit"
+DECISION_NEEDS_USER_CONFIRMATION = "needs_user_confirmation"
+
+REASON_MISSING_EVIDENCE = "missing_evidence"
+REASON_MISSING_CONFIRMATION = "missing_user_confirmation"
+REASON_PREVIEW_NOT_READY = "preview_not_ready"
+REASON_UNSAFE_OPERATION = "unsafe_operation"
+REASON_PATCH_SHAPE_INVALID = "patch_shape_invalid"
+REASON_CONFLICT_REQUIRES_REVIEW = "conflict_requires_review"
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairCommitGateDecision:
+    """One read-only commit gate decision for a repair preview."""
+
+    id: str
+    preview_id: str
+    candidate_id: str
+    decision: str
+    provider: str
+    priority: str
+    repair_action: str
+    reasons: tuple[str, ...]
+    required_actions: tuple[str, ...]
+    target: dict[str, Any]
+    evidence_patch: dict[str, Any]
+    memory_patch_preview: dict[str, Any]
+    conflict_risk: str
+    safety_note: str
+    source_preview: dict[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "preview_id": self.preview_id,
+            "candidate_id": self.candidate_id,
+            "decision": self.decision,
+            "provider": self.provider,
+            "priority": self.priority,
+            "repair_action": self.repair_action,
+            "reasons": list(self.reasons),
+            "required_actions": list(self.required_actions),
+            "target": dict(self.target),
+            "evidence_patch": dict(self.evidence_patch),
+            "memory_patch_preview": dict(self.memory_patch_preview),
+            "conflict_risk": self.conflict_risk,
+            "safety_note": self.safety_note,
+            "source_preview": dict(self.source_preview),
+        }
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairCommitGateReport:
+    """Read-only commit gate report."""
+
+    generated_at: str
+    decisions: tuple[MemoryEvidenceRepairCommitGateDecision, ...]
+
+    @property
+    def summary(self) -> dict[str, Any]:
+        by_decision: dict[str, int] = {}
+        by_provider: dict[str, int] = {}
+        by_repair_action: dict[str, int] = {}
+        allow_count = 0
+        blocked_count = 0
+        needs_confirmation_count = 0
+        for decision in self.decisions:
+            by_decision[decision.decision] = by_decision.get(decision.decision, 0) + 1
+            by_repair_action[decision.repair_action] = (
+                by_repair_action.get(decision.repair_action, 0) + 1
+            )
+            if decision.provider:
+                by_provider[decision.provider] = by_provider.get(decision.provider, 0) + 1
+            if decision.decision == DECISION_ALLOW_MANUAL_COMMIT:
+                allow_count += 1
+            elif decision.decision == DECISION_NEEDS_USER_CONFIRMATION:
+                needs_confirmation_count += 1
+            elif decision.decision == DECISION_BLOCK_COMMIT:
+                blocked_count += 1
+        return {
+            "decision_count": len(self.decisions),
+            "allow_count": allow_count,
+            "blocked_count": blocked_count,
+            "needs_confirmation_count": needs_confirmation_count,
+            "by_decision": by_decision,
+            "by_provider": by_provider,
+            "by_repair_action": by_repair_action,
+            "has_allowances": allow_count > 0,
+            "has_blocks": blocked_count > 0,
+            "requires_user_confirmation": needs_confirmation_count > 0,
+        }
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "generated_at": self.generated_at,
+            "summary": self.summary,
+            "decisions": [decision.to_dict() for decision in self.decisions],
+            "read_only": True,
+            "read_only_memory": True,
+            "would_mutate_memory": False,
+        }
+
+
+def build_evidence_repair_commit_gate(
+    *,
+    preview: Mapping[str, Any] | None = None,
+    previews: Sequence[Mapping[str, Any]] | None = None,
+    confirmed_preview_ids: Sequence[str] | None = None,
+    user_confirmed: bool = False,
+) -> MemoryEvidenceRepairCommitGateReport:
+    """Build read-only commit gate decisions from apply previews."""
+
+    preview = preview if isinstance(preview, Mapping) else {}
+    preview_rows = _preview_rows(preview=preview, previews=previews)
+    confirmed_ids = _string_set(confirmed_preview_ids)
+    decisions: list[MemoryEvidenceRepairCommitGateDecision] = []
+    for row in preview_rows:
+        if not isinstance(row, Mapping):
+            continue
+        decision = _decision_from_preview(
+            row,
+            confirmed_preview_ids=confirmed_ids,
+            user_confirmed=user_confirmed,
+        )
+        if decision is not None:
+            decisions.append(decision)
+
+    return MemoryEvidenceRepairCommitGateReport(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        decisions=tuple(_dedupe_decisions(decisions)),
+    )
+
+
+def empty_evidence_repair_commit_gate() -> MemoryEvidenceRepairCommitGateReport:
+    """Return an empty read-only commit gate report."""
+
+    return MemoryEvidenceRepairCommitGateReport(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        decisions=(),
+    )
+
+
+def _decision_from_preview(
+    preview: Mapping[str, Any],
+    *,
+    confirmed_preview_ids: set[str],
+    user_confirmed: bool,
+) -> MemoryEvidenceRepairCommitGateDecision | None:
+    preview_id = _str(preview.get("id"))
+    candidate_id = _str(preview.get("candidate_id"))
+    repair_action = _str(preview.get("repair_action"))
+    if not preview_id and not candidate_id and not repair_action:
+        return None
+
+    provider = _str(preview.get("provider")) or "memory"
+    priority = _str(preview.get("priority")) or "medium"
+    target = preview.get("target") if isinstance(preview.get("target"), Mapping) else {}
+    evidence_patch = (
+        preview.get("evidence_patch")
+        if isinstance(preview.get("evidence_patch"), Mapping)
+        else {}
+    )
+    memory_patch_preview = (
+        preview.get("memory_patch_preview")
+        if isinstance(preview.get("memory_patch_preview"), Mapping)
+        else {}
+    )
+    reasons, required_actions = _evaluate_reasons(
+        preview=preview,
+        preview_id=preview_id,
+        confirmed_preview_ids=confirmed_preview_ids,
+        user_confirmed=user_confirmed,
+        evidence_patch=evidence_patch,
+        memory_patch_preview=memory_patch_preview,
+    )
+    decision = _decision_for_reasons(reasons)
+    return MemoryEvidenceRepairCommitGateDecision(
+        id=f"gate-{preview_id or candidate_id}",
+        preview_id=preview_id,
+        candidate_id=candidate_id,
+        decision=decision,
+        provider=provider,
+        priority=priority,
+        repair_action=repair_action or "attach_provenance",
+        reasons=tuple(reasons),
+        required_actions=tuple(required_actions),
+        target=dict(target),
+        evidence_patch=dict(evidence_patch),
+        memory_patch_preview=dict(memory_patch_preview),
+        conflict_risk=_conflict_risk(preview),
+        safety_note=(
+            "Read-only gate. An allow decision means this preview is eligible "
+            "for a later manual write; this gate never writes memory."
+        ),
+        source_preview=dict(preview),
+    )
+
+
+def _evaluate_reasons(
+    *,
+    preview: Mapping[str, Any],
+    preview_id: str,
+    confirmed_preview_ids: set[str],
+    user_confirmed: bool,
+    evidence_patch: Mapping[str, Any],
+    memory_patch_preview: Mapping[str, Any],
+) -> tuple[list[str], list[str]]:
+    reasons: list[str] = []
+    required_actions: list[str] = []
+
+    missing_evidence = _list_of_str(preview.get("missing_evidence"))
+    if missing_evidence:
+        reasons.append(REASON_MISSING_EVIDENCE)
+        required_actions.append("complete_required_evidence")
+    if _str(preview.get("status")) != PREVIEW_STATUS_READY_FOR_MANUAL_APPLY:
+        reasons.append(REASON_PREVIEW_NOT_READY)
+        required_actions.append("regenerate_ready_apply_preview")
+    if not _is_preview_confirmed(
+        preview_id=preview_id,
+        confirmed_preview_ids=confirmed_preview_ids,
+        user_confirmed=user_confirmed,
+    ):
+        reasons.append(REASON_MISSING_CONFIRMATION)
+        required_actions.append("obtain_explicit_user_confirmation")
+    if _str(preview.get("operation")) != PATCH_OPERATION:
+        reasons.append(REASON_UNSAFE_OPERATION)
+        required_actions.append("use_evidence_metadata_merge_operation")
+    if _str(memory_patch_preview.get("operation")) != PATCH_OPERATION:
+        reasons.append(REASON_PATCH_SHAPE_INVALID)
+        required_actions.append("repair_memory_patch_preview_shape")
+    if not evidence_patch:
+        reasons.append(REASON_PATCH_SHAPE_INVALID)
+        required_actions.append("provide_non_empty_evidence_patch")
+    if _conflict_risk(preview) == "high":
+        evidence_resolution = _str(evidence_patch.get("conflict_resolution"))
+        if not evidence_resolution:
+            reasons.append(REASON_CONFLICT_REQUIRES_REVIEW)
+            required_actions.append("provide_conflict_resolution")
+
+    return _dedupe_strings(reasons), _dedupe_strings(required_actions)
+
+
+def _decision_for_reasons(reasons: list[str]) -> str:
+    if not reasons:
+        return DECISION_ALLOW_MANUAL_COMMIT
+    if reasons == [REASON_MISSING_CONFIRMATION]:
+        return DECISION_NEEDS_USER_CONFIRMATION
+    if (
+        REASON_MISSING_CONFIRMATION in reasons
+        and all(reason == REASON_MISSING_CONFIRMATION for reason in reasons)
+    ):
+        return DECISION_NEEDS_USER_CONFIRMATION
+    return DECISION_BLOCK_COMMIT
+
+
+def _is_preview_confirmed(
+    *,
+    preview_id: str,
+    confirmed_preview_ids: set[str],
+    user_confirmed: bool,
+) -> bool:
+    if confirmed_preview_ids:
+        return preview_id in confirmed_preview_ids
+    return bool(user_confirmed)
+
+
+def _conflict_risk(preview: Mapping[str, Any]) -> str:
+    repair_action = _str(preview.get("repair_action"))
+    if repair_action == "review_conflict":
+        return "high"
+    source_candidate = preview.get("source_candidate")
+    if isinstance(source_candidate, Mapping):
+        source_repair = source_candidate.get("source_repair")
+        if isinstance(source_repair, Mapping):
+            source = f"{source_repair.get('action', '')} {source_repair.get('reason', '')}"
+            if "conflict" in source.lower():
+                return "high"
+        reason = _str(source_candidate.get("reason"))
+        if "conflict" in reason.lower():
+            return "medium"
+    reason = _str(preview.get("reason"))
+    if "conflict" in reason.lower():
+        return "medium"
+    return "low"
+
+
+def _preview_rows(
+    *,
+    preview: Mapping[str, Any],
+    previews: Sequence[Mapping[str, Any]] | None,
+) -> list[Any]:
+    if previews is not None:
+        return list(previews)
+    if "id" in preview:
+        return [preview]
+    value = preview.get("previews")
+    return value if isinstance(value, list) else []
+
+
+def _dedupe_decisions(
+    decisions: list[MemoryEvidenceRepairCommitGateDecision],
+) -> list[MemoryEvidenceRepairCommitGateDecision]:
+    seen: set[str] = set()
+    deduped: list[MemoryEvidenceRepairCommitGateDecision] = []
+    for decision in decisions:
+        if decision.id in seen:
+            continue
+        seen.add(decision.id)
+        deduped.append(decision)
+    return deduped
+
+
+def _dedupe_strings(values: list[str]) -> list[str]:
+    seen: set[str] = set()
+    deduped: list[str] = []
+    for value in values:
+        if value in seen:
+            continue
+        seen.add(value)
+        deduped.append(value)
+    return deduped
+
+
+def _string_set(value: Sequence[str] | None) -> set[str]:
+    if value is None:
+        return set()
+    return {_str(item) for item in value if _str(item)}
+
+
+def _list_of_str(value: Any) -> list[str]:
+    return [_str(item) for item in value] if isinstance(value, list) else []
+
+
+def _str(value: Any) -> str:
+    return str(value or "").strip()

--- a/agent/memory_evidence_repair_commit_ledger.py
+++ b/agent/memory_evidence_repair_commit_ledger.py
@@ -1,0 +1,338 @@
+"""Read-only commit ledger draft for memory evidence repair decisions.
+
+The ledger turns commit gate decisions into audit-ready records. It never
+writes to durable memory stores.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Mapping, Sequence
+
+from agent.memory_evidence_repair_commit_gate import (
+    DECISION_ALLOW_MANUAL_COMMIT,
+    DECISION_BLOCK_COMMIT,
+    DECISION_NEEDS_USER_CONFIRMATION,
+)
+
+
+LEDGER_EVENT_TYPE = "memory_evidence_repair_commit_gate_decision"
+LEDGER_STATUS_DRAFT = "draft"
+OUTCOME_ALLOWED = "allowed_for_manual_commit"
+OUTCOME_BLOCKED = "blocked"
+OUTCOME_NEEDS_CONFIRMATION = "needs_user_confirmation"
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairCommitLedgerEntry:
+    """One read-only audit ledger entry draft."""
+
+    id: str
+    sequence: int
+    event_type: str
+    status: str
+    outcome: str
+    decision_id: str
+    preview_id: str
+    candidate_id: str
+    provider: str
+    priority: str
+    repair_action: str
+    decision: str
+    reasons: tuple[str, ...]
+    required_actions: tuple[str, ...]
+    evidence_fields: tuple[str, ...]
+    patch_digest: str
+    manual_commit_allowed: bool
+    blocked: bool
+    requires_followup: bool
+    target: dict[str, Any]
+    metadata: dict[str, Any]
+    safety_note: str
+    source_decision: dict[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "sequence": self.sequence,
+            "event_type": self.event_type,
+            "status": self.status,
+            "outcome": self.outcome,
+            "decision_id": self.decision_id,
+            "preview_id": self.preview_id,
+            "candidate_id": self.candidate_id,
+            "provider": self.provider,
+            "priority": self.priority,
+            "repair_action": self.repair_action,
+            "decision": self.decision,
+            "reasons": list(self.reasons),
+            "required_actions": list(self.required_actions),
+            "evidence_fields": list(self.evidence_fields),
+            "patch_digest": self.patch_digest,
+            "manual_commit_allowed": self.manual_commit_allowed,
+            "blocked": self.blocked,
+            "requires_followup": self.requires_followup,
+            "target": dict(self.target),
+            "metadata": dict(self.metadata),
+            "safety_note": self.safety_note,
+            "source_decision": dict(self.source_decision),
+        }
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairCommitLedgerDraft:
+    """Read-only commit ledger draft."""
+
+    generated_at: str
+    entries: tuple[MemoryEvidenceRepairCommitLedgerEntry, ...]
+
+    @property
+    def summary(self) -> dict[str, Any]:
+        by_decision: dict[str, int] = {}
+        by_outcome: dict[str, int] = {}
+        by_provider: dict[str, int] = {}
+        by_repair_action: dict[str, int] = {}
+        allow_count = 0
+        blocked_count = 0
+        followup_count = 0
+        for entry in self.entries:
+            by_decision[entry.decision] = by_decision.get(entry.decision, 0) + 1
+            by_outcome[entry.outcome] = by_outcome.get(entry.outcome, 0) + 1
+            by_repair_action[entry.repair_action] = (
+                by_repair_action.get(entry.repair_action, 0) + 1
+            )
+            if entry.provider:
+                by_provider[entry.provider] = by_provider.get(entry.provider, 0) + 1
+            if entry.manual_commit_allowed:
+                allow_count += 1
+            if entry.blocked:
+                blocked_count += 1
+            if entry.requires_followup:
+                followup_count += 1
+        return {
+            "entry_count": len(self.entries),
+            "allow_count": allow_count,
+            "blocked_count": blocked_count,
+            "followup_count": followup_count,
+            "by_decision": by_decision,
+            "by_outcome": by_outcome,
+            "by_provider": by_provider,
+            "by_repair_action": by_repair_action,
+            "has_allowances": allow_count > 0,
+            "has_blocks": blocked_count > 0,
+            "requires_followup": followup_count > 0,
+        }
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "generated_at": self.generated_at,
+            "summary": self.summary,
+            "entries": [entry.to_dict() for entry in self.entries],
+            "read_only": True,
+            "read_only_memory": True,
+            "would_mutate_memory": False,
+        }
+
+
+def build_evidence_repair_commit_ledger(
+    *,
+    commit_gate: Mapping[str, Any] | None = None,
+    decisions: Sequence[Mapping[str, Any]] | None = None,
+    ledger_actor: str = "hermes",
+    ledger_reason: str = "",
+) -> MemoryEvidenceRepairCommitLedgerDraft:
+    """Build a read-only audit ledger draft from commit gate decisions."""
+
+    commit_gate = commit_gate if isinstance(commit_gate, Mapping) else {}
+    rows = _decision_rows(commit_gate=commit_gate, decisions=decisions)
+    entries: list[MemoryEvidenceRepairCommitLedgerEntry] = []
+    for index, row in enumerate(rows, start=1):
+        if not isinstance(row, Mapping):
+            continue
+        entry = _entry_from_decision(
+            row,
+            sequence=index,
+            ledger_actor=ledger_actor,
+            ledger_reason=ledger_reason,
+        )
+        if entry is not None:
+            entries.append(entry)
+
+    return MemoryEvidenceRepairCommitLedgerDraft(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        entries=tuple(_dedupe_entries(entries)),
+    )
+
+
+def empty_evidence_repair_commit_ledger() -> MemoryEvidenceRepairCommitLedgerDraft:
+    """Return an empty read-only commit ledger draft."""
+
+    return MemoryEvidenceRepairCommitLedgerDraft(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        entries=(),
+    )
+
+
+def _entry_from_decision(
+    decision: Mapping[str, Any],
+    *,
+    sequence: int,
+    ledger_actor: str,
+    ledger_reason: str,
+) -> MemoryEvidenceRepairCommitLedgerEntry | None:
+    decision_id = _str(decision.get("id"))
+    preview_id = _str(decision.get("preview_id"))
+    candidate_id = _str(decision.get("candidate_id"))
+    decision_value = _str(decision.get("decision"))
+    if not decision_id and not preview_id and not candidate_id and not decision_value:
+        return None
+
+    evidence_patch = (
+        decision.get("evidence_patch")
+        if isinstance(decision.get("evidence_patch"), Mapping)
+        else {}
+    )
+    memory_patch_preview = (
+        decision.get("memory_patch_preview")
+        if isinstance(decision.get("memory_patch_preview"), Mapping)
+        else {}
+    )
+    reasons = tuple(_list_of_str(decision.get("reasons")))
+    required_actions = tuple(_list_of_str(decision.get("required_actions")))
+    outcome = _outcome(decision_value)
+    patch_digest = _patch_digest(
+        evidence_patch=evidence_patch,
+        memory_patch_preview=memory_patch_preview,
+    )
+    entry_id = _stable_entry_id(
+        decision_id=decision_id,
+        preview_id=preview_id,
+        candidate_id=candidate_id,
+        decision=decision_value,
+        patch_digest=patch_digest,
+        reasons=reasons,
+    )
+    return MemoryEvidenceRepairCommitLedgerEntry(
+        id=entry_id,
+        sequence=sequence,
+        event_type=LEDGER_EVENT_TYPE,
+        status=LEDGER_STATUS_DRAFT,
+        outcome=outcome,
+        decision_id=decision_id,
+        preview_id=preview_id,
+        candidate_id=candidate_id,
+        provider=_str(decision.get("provider")) or "memory",
+        priority=_str(decision.get("priority")) or "medium",
+        repair_action=_str(decision.get("repair_action")) or "attach_provenance",
+        decision=decision_value,
+        reasons=reasons,
+        required_actions=required_actions,
+        evidence_fields=tuple(str(field) for field in evidence_patch.keys()),
+        patch_digest=patch_digest,
+        manual_commit_allowed=decision_value == DECISION_ALLOW_MANUAL_COMMIT,
+        blocked=decision_value == DECISION_BLOCK_COMMIT,
+        requires_followup=bool(required_actions)
+        or decision_value == DECISION_NEEDS_USER_CONFIRMATION,
+        target=_dict(decision.get("target")),
+        metadata={
+            "ledger_actor": _str(ledger_actor) or "hermes",
+            "ledger_reason": _str(ledger_reason),
+            "conflict_risk": _str(decision.get("conflict_risk")) or "unknown",
+        },
+        safety_note=(
+            "Read-only ledger draft. This record is for audit and planning only; "
+            "it does not commit or mutate durable memory."
+        ),
+        source_decision=dict(decision),
+    )
+
+
+def _decision_rows(
+    *,
+    commit_gate: Mapping[str, Any],
+    decisions: Sequence[Mapping[str, Any]] | None,
+) -> list[Any]:
+    if decisions is not None:
+        return list(decisions)
+    if "decision" in commit_gate:
+        return [commit_gate]
+    value = commit_gate.get("decisions")
+    return value if isinstance(value, list) else []
+
+
+def _outcome(decision: str) -> str:
+    if decision == DECISION_ALLOW_MANUAL_COMMIT:
+        return OUTCOME_ALLOWED
+    if decision == DECISION_NEEDS_USER_CONFIRMATION:
+        return OUTCOME_NEEDS_CONFIRMATION
+    return OUTCOME_BLOCKED
+
+
+def _patch_digest(
+    *,
+    evidence_patch: Mapping[str, Any],
+    memory_patch_preview: Mapping[str, Any],
+) -> str:
+    raw = json.dumps(
+        {
+            "evidence_patch": dict(evidence_patch),
+            "memory_patch_preview": dict(memory_patch_preview),
+        },
+        sort_keys=True,
+        ensure_ascii=False,
+        default=str,
+    )
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def _stable_entry_id(
+    *,
+    decision_id: str,
+    preview_id: str,
+    candidate_id: str,
+    decision: str,
+    patch_digest: str,
+    reasons: tuple[str, ...],
+) -> str:
+    raw = json.dumps(
+        {
+            "decision_id": decision_id,
+            "preview_id": preview_id,
+            "candidate_id": candidate_id,
+            "decision": decision,
+            "patch_digest": patch_digest,
+            "reasons": list(reasons),
+        },
+        sort_keys=True,
+        ensure_ascii=False,
+    )
+    digest = hashlib.sha256(raw.encode("utf-8")).hexdigest()[:16]
+    return f"ledger-{digest}"
+
+
+def _dedupe_entries(
+    entries: list[MemoryEvidenceRepairCommitLedgerEntry],
+) -> list[MemoryEvidenceRepairCommitLedgerEntry]:
+    seen: set[str] = set()
+    deduped: list[MemoryEvidenceRepairCommitLedgerEntry] = []
+    for entry in entries:
+        if entry.id in seen:
+            continue
+        seen.add(entry.id)
+        deduped.append(entry)
+    return deduped
+
+
+def _dict(value: Any) -> dict[str, Any]:
+    return dict(value) if isinstance(value, Mapping) else {}
+
+
+def _list_of_str(value: Any) -> list[str]:
+    return [_str(item) for item in value] if isinstance(value, list) else []
+
+
+def _str(value: Any) -> str:
+    return str(value or "").strip()

--- a/agent/memory_evidence_repair_commit_receipt.py
+++ b/agent/memory_evidence_repair_commit_receipt.py
@@ -1,0 +1,365 @@
+"""Read-only manual commit receipt ledger for memory evidence repair.
+
+The receipt layer turns a verified approval-token gate into a durable-looking
+receipt draft and a used-token ledger view. It never writes to durable memory
+stores; it only describes what a later manual commit would record.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Mapping, Sequence
+
+from agent.memory_evidence_repair_approval_token_gate import (
+    TOKEN_GATE_STATUS_BLOCKED,
+    TOKEN_GATE_STATUS_NO_ACTION_NEEDED,
+    TOKEN_GATE_STATUS_VERIFIED,
+)
+
+
+RECEIPT_TYPE = "memory_evidence_repair_manual_commit_receipt"
+RECEIPT_SCOPE = "manual_memory_evidence_repair_commit"
+RECEIPT_STATUS_READY = "receipt_ready_for_manual_commit"
+RECEIPT_STATUS_BLOCKED = "blocked"
+RECEIPT_STATUS_NO_ACTION_NEEDED = "no_action_needed"
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairCommitReceipt:
+    """One read-only manual commit receipt draft."""
+
+    id: str
+    receipt_type: str
+    status: str
+    scope: str
+    actor: str
+    commit_reason: str
+    token_id: str
+    token_digest: str
+    dry_run_digest: str
+    gate_status: str
+    receipt_digest: str
+    receipt_preview: str
+    operation_ids: tuple[str, ...]
+    ledger_entry_ids: tuple[str, ...]
+    candidate_ids: tuple[str, ...]
+    patch_digests: tuple[str, ...]
+    used_token_id: str
+    would_record_receipt: bool
+    would_mark_token_used: bool
+    safety_note: str
+    source_gate: dict[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "receipt_type": self.receipt_type,
+            "status": self.status,
+            "scope": self.scope,
+            "actor": self.actor,
+            "commit_reason": self.commit_reason,
+            "token_id": self.token_id,
+            "token_digest": self.token_digest,
+            "dry_run_digest": self.dry_run_digest,
+            "gate_status": self.gate_status,
+            "receipt_digest": self.receipt_digest,
+            "receipt_preview": self.receipt_preview,
+            "operation_ids": list(self.operation_ids),
+            "ledger_entry_ids": list(self.ledger_entry_ids),
+            "candidate_ids": list(self.candidate_ids),
+            "patch_digests": list(self.patch_digests),
+            "used_token_id": self.used_token_id,
+            "would_record_receipt": self.would_record_receipt,
+            "would_mark_token_used": self.would_mark_token_used,
+            "safety_note": self.safety_note,
+            "source_gate": dict(self.source_gate),
+        }
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairCommitReceiptReport:
+    """Read-only manual commit receipt report."""
+
+    generated_at: str
+    status: str
+    receipts: tuple[MemoryEvidenceRepairCommitReceipt, ...]
+    used_token_ids: tuple[str, ...]
+    blocking_reasons: tuple[str, ...]
+    required_actions: tuple[str, ...]
+    source_gate: dict[str, Any]
+
+    @property
+    def summary(self) -> dict[str, Any]:
+        return {
+            "status": self.status,
+            "receipt_count": len(self.receipts),
+            "used_token_count": len(self.used_token_ids),
+            "blocking_reason_count": len(self.blocking_reasons),
+            "required_action_count": len(self.required_actions),
+            "commit_receipt_available": bool(self.receipts),
+            "would_record_receipt_count": sum(
+                1 for receipt in self.receipts if receipt.would_record_receipt
+            ),
+            "would_mark_token_used_count": sum(
+                1 for receipt in self.receipts if receipt.would_mark_token_used
+            ),
+            "has_blocks": self.status == RECEIPT_STATUS_BLOCKED,
+            "requires_followup": bool(self.required_actions),
+        }
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "generated_at": self.generated_at,
+            "status": self.status,
+            "summary": self.summary,
+            "receipts": [receipt.to_dict() for receipt in self.receipts],
+            "used_token_ids": list(self.used_token_ids),
+            "blocking_reasons": list(self.blocking_reasons),
+            "required_actions": list(self.required_actions),
+            "source_gate": dict(self.source_gate),
+            "read_only": True,
+            "read_only_memory": True,
+            "would_mutate_memory": False,
+        }
+
+
+def build_evidence_repair_commit_receipt(
+    *,
+    token_gate: Mapping[str, Any] | None = None,
+    existing_receipts: Sequence[Mapping[str, Any]] | Mapping[str, Any] | None = None,
+    used_token_ids: Sequence[str] | None = None,
+    actor: str = "human",
+    commit_reason: str = "",
+) -> MemoryEvidenceRepairCommitReceiptReport:
+    """Build a read-only receipt draft from a verified approval-token gate."""
+
+    token_gate = token_gate if isinstance(token_gate, Mapping) else {}
+    gate_status = _str(token_gate.get("status"))
+    existing_used = _used_token_ids(existing_receipts, used_token_ids)
+
+    if not token_gate or gate_status == TOKEN_GATE_STATUS_NO_ACTION_NEEDED:
+        return _empty_report(
+            token_gate=token_gate,
+            used_token_ids=existing_used,
+        )
+
+    if gate_status != TOKEN_GATE_STATUS_VERIFIED:
+        blocking_reasons = tuple(_list_of_str(token_gate.get("blocking_reasons")))
+        required_actions = tuple(_list_of_str(token_gate.get("required_actions")))
+        if not blocking_reasons:
+            blocking_reasons = ("Approval token gate is not verified.",)
+        if not required_actions:
+            required_actions = ("verify_approval_token_gate",)
+        return _blocked_report(
+            token_gate=token_gate,
+            used_token_ids=existing_used,
+            blocking_reasons=blocking_reasons,
+            required_actions=required_actions,
+        )
+
+    token_id = _str(token_gate.get("token_id"))
+    operation_ids = tuple(_list_of_str(token_gate.get("verified_operation_ids")))
+    if not token_id or not operation_ids:
+        return _blocked_report(
+            token_gate=token_gate,
+            used_token_ids=existing_used,
+            blocking_reasons=(
+                "Verified approval token gate is missing token id or operations.",
+            ),
+            required_actions=("regenerate_approval_token_gate",),
+        )
+    if token_id in set(existing_used):
+        return _blocked_report(
+            token_gate=token_gate,
+            used_token_ids=existing_used,
+            blocking_reasons=("Approval token is already present in the used-token ledger.",),
+            required_actions=("regenerate_human_approval_token",),
+        )
+
+    receipt = _receipt_from_gate(
+        token_gate=token_gate,
+        actor=actor,
+        commit_reason=commit_reason,
+    )
+    return MemoryEvidenceRepairCommitReceiptReport(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        status=RECEIPT_STATUS_READY,
+        receipts=(receipt,),
+        used_token_ids=tuple(_dedupe_strings([*existing_used, receipt.used_token_id])),
+        blocking_reasons=(),
+        required_actions=(),
+        source_gate=dict(token_gate),
+    )
+
+
+def empty_evidence_repair_commit_receipt() -> MemoryEvidenceRepairCommitReceiptReport:
+    """Return an empty read-only manual commit receipt report."""
+
+    return _empty_report(token_gate={}, used_token_ids=())
+
+
+def _receipt_from_gate(
+    *,
+    token_gate: Mapping[str, Any],
+    actor: str,
+    commit_reason: str,
+) -> MemoryEvidenceRepairCommitReceipt:
+    source_token = _dict(token_gate.get("source_token"))
+    source_dry_run = _dict(token_gate.get("source_dry_run"))
+    operations = _operation_rows(source_dry_run)
+    token_id = _str(token_gate.get("token_id"))
+    operation_ids = tuple(_list_of_str(token_gate.get("verified_operation_ids")))
+    candidate_ids = tuple(_list_of_str(token_gate.get("verified_candidate_ids")))
+    patch_digests = tuple(_list_of_str(token_gate.get("verified_patch_digests")))
+    ledger_entry_ids = tuple(_str(operation.get("ledger_entry_id")) for operation in operations)
+    token_digest = _str(source_token.get("token_digest"))
+    dry_run_digest = _str(source_token.get("dry_run_digest"))
+    receipt_seed = {
+        "receipt_type": RECEIPT_TYPE,
+        "scope": RECEIPT_SCOPE,
+        "actor": _str(actor) or "human",
+        "commit_reason": _str(commit_reason),
+        "token_id": token_id,
+        "token_digest": token_digest,
+        "dry_run_digest": dry_run_digest,
+        "gate_status": _str(token_gate.get("status")),
+        "operation_ids": operation_ids,
+        "ledger_entry_ids": ledger_entry_ids,
+        "candidate_ids": candidate_ids,
+        "patch_digests": patch_digests,
+    }
+    receipt_digest = _digest(receipt_seed)
+    receipt_id = f"commit-receipt-{receipt_digest[:16]}"
+    return MemoryEvidenceRepairCommitReceipt(
+        id=receipt_id,
+        receipt_type=RECEIPT_TYPE,
+        status=RECEIPT_STATUS_READY,
+        scope=RECEIPT_SCOPE,
+        actor=_str(actor) or "human",
+        commit_reason=_str(commit_reason),
+        token_id=token_id,
+        token_digest=token_digest,
+        dry_run_digest=dry_run_digest,
+        gate_status=_str(token_gate.get("status")),
+        receipt_digest=receipt_digest,
+        receipt_preview=f"{receipt_id}:{receipt_digest[:12]}",
+        operation_ids=operation_ids,
+        ledger_entry_ids=ledger_entry_ids,
+        candidate_ids=candidate_ids,
+        patch_digests=patch_digests,
+        used_token_id=token_id,
+        would_record_receipt=True,
+        would_mark_token_used=True,
+        safety_note=(
+            "Read-only receipt draft. It previews a future commit receipt and "
+            "used-token ledger update, but does not persist either."
+        ),
+        source_gate=dict(token_gate),
+    )
+
+
+def _empty_report(
+    *,
+    token_gate: Mapping[str, Any],
+    used_token_ids: Sequence[str],
+) -> MemoryEvidenceRepairCommitReceiptReport:
+    return MemoryEvidenceRepairCommitReceiptReport(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        status=RECEIPT_STATUS_NO_ACTION_NEEDED,
+        receipts=(),
+        used_token_ids=tuple(_dedupe_strings(used_token_ids)),
+        blocking_reasons=(),
+        required_actions=(),
+        source_gate=dict(token_gate),
+    )
+
+
+def _blocked_report(
+    *,
+    token_gate: Mapping[str, Any],
+    used_token_ids: Sequence[str],
+    blocking_reasons: Sequence[str],
+    required_actions: Sequence[str],
+) -> MemoryEvidenceRepairCommitReceiptReport:
+    return MemoryEvidenceRepairCommitReceiptReport(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        status=RECEIPT_STATUS_BLOCKED,
+        receipts=(),
+        used_token_ids=tuple(_dedupe_strings(used_token_ids)),
+        blocking_reasons=tuple(_dedupe_strings(blocking_reasons)),
+        required_actions=tuple(_dedupe_strings(required_actions)),
+        source_gate=dict(token_gate),
+    )
+
+
+def _used_token_ids(
+    existing_receipts: Sequence[Mapping[str, Any]] | Mapping[str, Any] | None,
+    explicit_used_token_ids: Sequence[str] | None,
+) -> tuple[str, ...]:
+    candidates: list[str] = _list_of_str(explicit_used_token_ids)
+    if isinstance(existing_receipts, Mapping):
+        candidates.extend(_list_of_str(existing_receipts.get("used_token_ids")))
+        receipt_rows = existing_receipts.get("receipts")
+        if isinstance(receipt_rows, list):
+            candidates.extend(_token_ids_from_receipts(receipt_rows))
+        elif _str(existing_receipts.get("token_id")):
+            candidates.append(_str(existing_receipts.get("token_id")))
+        elif _str(existing_receipts.get("used_token_id")):
+            candidates.append(_str(existing_receipts.get("used_token_id")))
+    elif isinstance(existing_receipts, list):
+        candidates.extend(_token_ids_from_receipts(existing_receipts))
+    return tuple(_dedupe_strings(candidates))
+
+
+def _token_ids_from_receipts(receipts: Sequence[Any]) -> list[str]:
+    token_ids: list[str] = []
+    for receipt in receipts:
+        if not isinstance(receipt, Mapping):
+            continue
+        token_id = _str(receipt.get("used_token_id")) or _str(receipt.get("token_id"))
+        if token_id:
+            token_ids.append(token_id)
+    return token_ids
+
+
+def _operation_rows(dry_run: Mapping[str, Any]) -> list[Mapping[str, Any]]:
+    return [
+        operation
+        for operation in _list(dry_run.get("operations"))
+        if isinstance(operation, Mapping)
+    ]
+
+
+def _digest(value: Any) -> str:
+    raw = json.dumps(value, sort_keys=True, ensure_ascii=False, default=str)
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def _dict(value: Any) -> dict[str, Any]:
+    return dict(value) if isinstance(value, Mapping) else {}
+
+
+def _list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _list_of_str(value: Any) -> list[str]:
+    return [_str(item) for item in value] if isinstance(value, list) else []
+
+
+def _dedupe_strings(values: Sequence[str] | Any) -> list[str]:
+    seen: set[str] = set()
+    result: list[str] = []
+    for value in values:
+        text = _str(value)
+        if text and text not in seen:
+            seen.add(text)
+            result.append(text)
+    return result
+
+
+def _str(value: Any) -> str:
+    return str(value or "").strip()

--- a/agent/memory_evidence_repair_executor_preview.py
+++ b/agent/memory_evidence_repair_executor_preview.py
@@ -1,0 +1,754 @@
+"""Read-only manual commit executor preview for memory evidence repair.
+
+The executor preview turns a verified write-lock gate into an ordered execution
+plan for a later manual memory repair commit. It never writes to durable memory
+stores and never acquires or releases a real lock.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Mapping, Sequence
+
+from agent.memory_evidence_repair_commit_receipt import RECEIPT_SCOPE
+from agent.memory_evidence_repair_manual_commit_dry_run import (
+    CHECK_STATUS_FAIL,
+    CHECK_STATUS_PASS,
+)
+from agent.memory_evidence_repair_write_lock_gate import (
+    LOCK_DRAFT_STATUS_READY,
+    WRITE_LOCK_STATUS_BLOCKED,
+    WRITE_LOCK_STATUS_NO_ACTION_NEEDED,
+    WRITE_LOCK_STATUS_READY,
+    WRITE_LOCK_TYPE,
+)
+
+
+EXECUTOR_PREVIEW_STATUS_READY = "executor_preview_ready_for_manual_commit"
+EXECUTOR_PREVIEW_STATUS_BLOCKED = "blocked"
+EXECUTOR_PREVIEW_STATUS_NO_ACTION_NEEDED = "no_action_needed"
+
+CHECK_WRITE_LOCK_READY = "write_lock_ready"
+CHECK_WRITE_LOCK_INTEGRITY = "write_lock_integrity"
+CHECK_WRITE_LOCK_EXPIRY = "write_lock_expiry"
+CHECK_EXECUTION_OPERATIONS = "execution_operations"
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairExecutorPreviewCheck:
+    """One read-only executor preview readiness check."""
+
+    id: str
+    status: str
+    reason: str
+    required_actions: tuple[str, ...]
+    details: dict[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "status": self.status,
+            "reason": self.reason,
+            "required_actions": list(self.required_actions),
+            "details": dict(self.details),
+        }
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairExecutorStep:
+    """One future executor step preview."""
+
+    id: str
+    sequence: int
+    phase: str
+    action: str
+    description: str
+    operation_id: str
+    candidate_id: str
+    ledger_entry_id: str
+    patch_digest: str
+    target: dict[str, Any]
+    evidence_fields: tuple[str, ...]
+    source_operation: dict[str, Any]
+    future_would_write_memory: bool
+    stop_on_failure: bool
+    rollback_hint: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "sequence": self.sequence,
+            "phase": self.phase,
+            "action": self.action,
+            "description": self.description,
+            "operation_id": self.operation_id,
+            "candidate_id": self.candidate_id,
+            "ledger_entry_id": self.ledger_entry_id,
+            "patch_digest": self.patch_digest,
+            "target": dict(self.target),
+            "evidence_fields": list(self.evidence_fields),
+            "source_operation": dict(self.source_operation),
+            "future_would_write_memory": self.future_would_write_memory,
+            "stop_on_failure": self.stop_on_failure,
+            "rollback_hint": self.rollback_hint,
+        }
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairExecutorPreview:
+    """One read-only executor preview."""
+
+    id: str
+    status: str
+    lock_id: str
+    receipt_id: str
+    token_id: str
+    operation_ids: tuple[str, ...]
+    candidate_ids: tuple[str, ...]
+    patch_digests: tuple[str, ...]
+    step_ids: tuple[str, ...]
+    preview_digest: str
+    preview_preview: str
+    execution_mode: str
+    failure_policy: str
+    steps: tuple[MemoryEvidenceRepairExecutorStep, ...]
+    would_apply_memory_patches: bool
+    would_record_receipt: bool
+    would_mark_token_used: bool
+    would_release_write_lock: bool
+    safety_note: str
+    source_lock: dict[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "status": self.status,
+            "lock_id": self.lock_id,
+            "receipt_id": self.receipt_id,
+            "token_id": self.token_id,
+            "operation_ids": list(self.operation_ids),
+            "candidate_ids": list(self.candidate_ids),
+            "patch_digests": list(self.patch_digests),
+            "step_ids": list(self.step_ids),
+            "preview_digest": self.preview_digest,
+            "preview_preview": self.preview_preview,
+            "execution_mode": self.execution_mode,
+            "failure_policy": self.failure_policy,
+            "steps": [step.to_dict() for step in self.steps],
+            "would_apply_memory_patches": self.would_apply_memory_patches,
+            "would_record_receipt": self.would_record_receipt,
+            "would_mark_token_used": self.would_mark_token_used,
+            "would_release_write_lock": self.would_release_write_lock,
+            "safety_note": self.safety_note,
+            "source_lock": dict(self.source_lock),
+        }
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairExecutorPreviewReport:
+    """Read-only manual commit executor preview report."""
+
+    generated_at: str
+    status: str
+    checks: tuple[MemoryEvidenceRepairExecutorPreviewCheck, ...]
+    previews: tuple[MemoryEvidenceRepairExecutorPreview, ...]
+    blocking_reasons: tuple[str, ...]
+    required_actions: tuple[str, ...]
+    source_write_lock_gate: dict[str, Any]
+
+    @property
+    def summary(self) -> dict[str, Any]:
+        by_check_status: dict[str, int] = {}
+        for check in self.checks:
+            by_check_status[check.status] = by_check_status.get(check.status, 0) + 1
+        step_count = sum(len(preview.steps) for preview in self.previews)
+        future_write_step_count = sum(
+            1
+            for preview in self.previews
+            for step in preview.steps
+            if step.future_would_write_memory
+        )
+        return {
+            "status": self.status,
+            "check_count": len(self.checks),
+            "pass_count": by_check_status.get(CHECK_STATUS_PASS, 0),
+            "fail_count": by_check_status.get(CHECK_STATUS_FAIL, 0),
+            "preview_count": len(self.previews),
+            "step_count": step_count,
+            "future_write_step_count": future_write_step_count,
+            "blocking_reason_count": len(self.blocking_reasons),
+            "required_action_count": len(self.required_actions),
+            "executor_preview_available": bool(self.previews),
+            "manual_executor_preview_ready": self.status == EXECUTOR_PREVIEW_STATUS_READY,
+            "has_blocks": self.status == EXECUTOR_PREVIEW_STATUS_BLOCKED,
+            "requires_followup": bool(self.required_actions),
+            "by_check_status": by_check_status,
+        }
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "generated_at": self.generated_at,
+            "status": self.status,
+            "summary": self.summary,
+            "checks": [check.to_dict() for check in self.checks],
+            "previews": [preview.to_dict() for preview in self.previews],
+            "blocking_reasons": list(self.blocking_reasons),
+            "required_actions": list(self.required_actions),
+            "source_write_lock_gate": dict(self.source_write_lock_gate),
+            "read_only": True,
+            "read_only_memory": True,
+            "would_mutate_memory": False,
+        }
+
+
+def build_evidence_repair_executor_preview(
+    *,
+    write_lock_gate: Mapping[str, Any] | None = None,
+    current_time: str | datetime | None = None,
+) -> MemoryEvidenceRepairExecutorPreviewReport:
+    """Build a read-only executor preview from a write-lock gate."""
+
+    write_lock_gate = write_lock_gate if isinstance(write_lock_gate, Mapping) else {}
+    gate_status = _str(write_lock_gate.get("status"))
+    lock = _extract_lock(write_lock_gate)
+    now = _parse_datetime(current_time) or datetime.now(timezone.utc)
+
+    if not lock:
+        if not write_lock_gate or gate_status == WRITE_LOCK_STATUS_NO_ACTION_NEEDED:
+            return _empty_report(write_lock_gate=write_lock_gate)
+        source_blocking = tuple(_list_of_str(write_lock_gate.get("blocking_reasons")))
+        source_actions = tuple(_list_of_str(write_lock_gate.get("required_actions")))
+        return _blocked_report(
+            write_lock_gate=write_lock_gate,
+            checks=(
+                _fail(
+                    CHECK_WRITE_LOCK_READY,
+                    "No write-lock draft was supplied."
+                    if not source_blocking
+                    else "; ".join(source_blocking),
+                    source_actions or ("produce_write_lock_gate",),
+                    {"write_lock_gate_status": gate_status},
+                ),
+            ),
+        )
+
+    operations = tuple(_operations_from_lock(lock))
+    checks = (
+        _write_lock_ready_check(write_lock_gate, lock),
+        _write_lock_integrity_check(lock),
+        _write_lock_expiry_check(lock, now),
+        _execution_operations_check(lock, operations),
+    )
+    blocking_reasons = tuple(
+        _dedupe_strings(check.reason for check in checks if check.status == CHECK_STATUS_FAIL)
+    )
+    required_actions = tuple(
+        _dedupe_strings(
+            action
+            for check in checks
+            if check.status == CHECK_STATUS_FAIL
+            for action in check.required_actions
+        )
+    )
+    if blocking_reasons:
+        return MemoryEvidenceRepairExecutorPreviewReport(
+            generated_at=datetime.now(timezone.utc).isoformat(),
+            status=EXECUTOR_PREVIEW_STATUS_BLOCKED,
+            checks=checks,
+            previews=(),
+            blocking_reasons=blocking_reasons,
+            required_actions=required_actions,
+            source_write_lock_gate=dict(write_lock_gate),
+        )
+
+    preview = _preview_from_lock(lock=lock, operations=operations)
+    return MemoryEvidenceRepairExecutorPreviewReport(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        status=EXECUTOR_PREVIEW_STATUS_READY,
+        checks=checks,
+        previews=(preview,),
+        blocking_reasons=(),
+        required_actions=(),
+        source_write_lock_gate=dict(write_lock_gate),
+    )
+
+
+def empty_evidence_repair_executor_preview() -> MemoryEvidenceRepairExecutorPreviewReport:
+    """Return an empty read-only manual commit executor preview."""
+
+    return _empty_report(write_lock_gate={})
+
+
+def _extract_lock(write_lock_gate: Mapping[str, Any]) -> dict[str, Any]:
+    locks = write_lock_gate.get("locks")
+    if isinstance(locks, list):
+        for lock in locks:
+            if isinstance(lock, Mapping):
+                return dict(lock)
+    if _str(write_lock_gate.get("id")).startswith("write-lock-"):
+        return dict(write_lock_gate)
+    return {}
+
+
+def _write_lock_ready_check(
+    write_lock_gate: Mapping[str, Any],
+    lock: Mapping[str, Any],
+) -> MemoryEvidenceRepairExecutorPreviewCheck:
+    gate_status = _str(write_lock_gate.get("status"))
+    lock_status = _str(lock.get("status"))
+    if gate_status and gate_status != WRITE_LOCK_STATUS_READY:
+        return _fail(
+            CHECK_WRITE_LOCK_READY,
+            "Write-lock gate is not ready for manual commit execution.",
+            tuple(_list_of_str(write_lock_gate.get("required_actions")))
+            or ("produce_ready_write_lock_gate",),
+            {"write_lock_gate_status": gate_status, "lock_status": lock_status},
+        )
+    if lock_status != LOCK_DRAFT_STATUS_READY:
+        return _fail(
+            CHECK_WRITE_LOCK_READY,
+            "Write-lock draft is not ready.",
+            ("produce_ready_write_lock_gate",),
+            {"write_lock_gate_status": gate_status, "lock_status": lock_status},
+        )
+    return _pass(
+        CHECK_WRITE_LOCK_READY,
+        "Write-lock gate and draft are ready.",
+        {"lock_id": _str(lock.get("id"))},
+    )
+
+
+def _write_lock_integrity_check(
+    lock: Mapping[str, Any],
+) -> MemoryEvidenceRepairExecutorPreviewCheck:
+    expected_digest = _expected_lock_digest(lock)
+    actual_digest = _str(lock.get("lock_digest"))
+    expected_id = f"write-lock-{expected_digest[:16]}" if expected_digest else ""
+    missing_fields: list[str] = []
+    for field_name in ("receipt_id", "token_id", "operation_ids", "patch_digests"):
+        value = lock.get(field_name)
+        if isinstance(value, list) and not value:
+            missing_fields.append(field_name)
+        elif not isinstance(value, list) and not _str(value):
+            missing_fields.append(field_name)
+    if (
+        missing_fields
+        or actual_digest != expected_digest
+        or _str(lock.get("id")) != expected_id
+        or _str(lock.get("lock_type")) != WRITE_LOCK_TYPE
+        or _str(lock.get("scope")) != RECEIPT_SCOPE
+    ):
+        return _fail(
+            CHECK_WRITE_LOCK_INTEGRITY,
+            "Write-lock digest, id, type, scope, or required fields are invalid.",
+            ("regenerate_write_lock_gate",),
+            {
+                "expected_lock_digest": expected_digest,
+                "actual_lock_digest": actual_digest,
+                "expected_lock_id": expected_id,
+                "actual_lock_id": _str(lock.get("id")),
+                "missing_fields": missing_fields,
+            },
+        )
+    return _pass(
+        CHECK_WRITE_LOCK_INTEGRITY,
+        "Write-lock integrity checks pass.",
+        {"lock_id": expected_id, "lock_digest": actual_digest},
+    )
+
+
+def _write_lock_expiry_check(
+    lock: Mapping[str, Any],
+    now: datetime,
+) -> MemoryEvidenceRepairExecutorPreviewCheck:
+    expires_at = _parse_datetime(lock.get("expires_at"))
+    if expires_at is None:
+        return _fail(
+            CHECK_WRITE_LOCK_EXPIRY,
+            "Write-lock expiry is missing or invalid.",
+            ("regenerate_write_lock_gate",),
+            {"expires_at": _str(lock.get("expires_at"))},
+        )
+    if expires_at <= now:
+        return _fail(
+            CHECK_WRITE_LOCK_EXPIRY,
+            "Write-lock draft has expired.",
+            ("regenerate_write_lock_gate",),
+            {"expires_at": expires_at.isoformat(), "current_time": now.isoformat()},
+        )
+    return _pass(
+        CHECK_WRITE_LOCK_EXPIRY,
+        "Write-lock draft is within its expiry window.",
+        {"expires_at": expires_at.isoformat(), "current_time": now.isoformat()},
+    )
+
+
+def _execution_operations_check(
+    lock: Mapping[str, Any],
+    operations: Sequence[Mapping[str, Any]],
+) -> MemoryEvidenceRepairExecutorPreviewCheck:
+    lock_operation_ids = _list_of_str(lock.get("operation_ids"))
+    operation_ids = [_str(operation.get("id")) for operation in operations]
+    lock_patch_digests = _list_of_str(lock.get("patch_digests"))
+    operation_patch_digests = [_str(operation.get("patch_digest")) for operation in operations]
+    if not operations:
+        return _fail(
+            CHECK_EXECUTION_OPERATIONS,
+            "No executable dry-run operations were found in the write-lock source receipt.",
+            ("regenerate_commit_receipt_with_source_operations",),
+            {"lock_operation_ids": lock_operation_ids},
+        )
+    if lock_operation_ids != operation_ids or lock_patch_digests != operation_patch_digests:
+        return _fail(
+            CHECK_EXECUTION_OPERATIONS,
+            "Write-lock operation ids or patch digests do not match source operations.",
+            ("regenerate_write_lock_gate",),
+            {
+                "lock_operation_ids": lock_operation_ids,
+                "operation_ids": operation_ids,
+                "lock_patch_digests": lock_patch_digests,
+                "operation_patch_digests": operation_patch_digests,
+            },
+        )
+    return _pass(
+        CHECK_EXECUTION_OPERATIONS,
+        "Executable operations match the write-lock draft.",
+        {"operation_count": len(operations), "operation_ids": operation_ids},
+    )
+
+
+def _preview_from_lock(
+    *,
+    lock: Mapping[str, Any],
+    operations: Sequence[Mapping[str, Any]],
+) -> MemoryEvidenceRepairExecutorPreview:
+    steps = tuple(_steps_from_lock(lock=lock, operations=operations))
+    step_ids = tuple(step.id for step in steps)
+    operation_ids = tuple(_list_of_str(lock.get("operation_ids")))
+    candidate_ids = tuple(_list_of_str(lock.get("candidate_ids")))
+    patch_digests = tuple(_list_of_str(lock.get("patch_digests")))
+    preview_seed = {
+        "lock_id": _str(lock.get("id")),
+        "receipt_id": _str(lock.get("receipt_id")),
+        "token_id": _str(lock.get("token_id")),
+        "operation_ids": operation_ids,
+        "candidate_ids": candidate_ids,
+        "patch_digests": patch_digests,
+        "step_ids": step_ids,
+        "execution_mode": "manual_ordered_commit",
+        "failure_policy": "stop_on_first_write_failure_then_release_lock",
+    }
+    preview_digest = _digest(preview_seed)
+    preview_id = f"executor-preview-{preview_digest[:16]}"
+    return MemoryEvidenceRepairExecutorPreview(
+        id=preview_id,
+        status=EXECUTOR_PREVIEW_STATUS_READY,
+        lock_id=_str(lock.get("id")),
+        receipt_id=_str(lock.get("receipt_id")),
+        token_id=_str(lock.get("token_id")),
+        operation_ids=operation_ids,
+        candidate_ids=candidate_ids,
+        patch_digests=patch_digests,
+        step_ids=step_ids,
+        preview_digest=preview_digest,
+        preview_preview=f"{preview_id}:{preview_digest[:12]}",
+        execution_mode="manual_ordered_commit",
+        failure_policy="stop_on_first_write_failure_then_release_lock",
+        steps=steps,
+        would_apply_memory_patches=True,
+        would_record_receipt=True,
+        would_mark_token_used=True,
+        would_release_write_lock=True,
+        safety_note=(
+            "Read-only executor preview. It describes a future ordered manual "
+            "commit and does not write memory, acquire locks, or mark tokens used."
+        ),
+        source_lock=dict(lock),
+    )
+
+
+def _steps_from_lock(
+    *,
+    lock: Mapping[str, Any],
+    operations: Sequence[Mapping[str, Any]],
+) -> list[MemoryEvidenceRepairExecutorStep]:
+    steps: list[MemoryEvidenceRepairExecutorStep] = []
+    steps.append(
+        _step(
+            sequence=1,
+            phase="preflight",
+            action="verify_write_lock_and_receipt",
+            description="Verify write-lock, commit receipt, token, and operation digests.",
+            lock=lock,
+        )
+    )
+    sequence = 2
+    for operation in operations:
+        steps.append(
+            _operation_step(
+                sequence=sequence,
+                operation=operation,
+            )
+        )
+        sequence += 1
+    steps.append(
+        _step(
+            sequence=sequence,
+            phase="audit",
+            action="record_commit_receipt",
+            description="Record the manual commit receipt after all memory patch steps succeed.",
+            lock=lock,
+            future_would_write_memory=False,
+            rollback_hint="skip_receipt_recording_if_any_write_step_fails",
+        )
+    )
+    sequence += 1
+    steps.append(
+        _step(
+            sequence=sequence,
+            phase="audit",
+            action="mark_approval_token_used",
+            description="Mark the approval token as used only after receipt recording is ready.",
+            lock=lock,
+            future_would_write_memory=False,
+            rollback_hint="do_not_mark_token_used_if_receipt_recording_fails",
+        )
+    )
+    sequence += 1
+    steps.append(
+        _step(
+            sequence=sequence,
+            phase="cleanup",
+            action="release_write_lock",
+            description="Release the write lock regardless of success or failure.",
+            lock=lock,
+            future_would_write_memory=False,
+            stop_on_failure=False,
+            rollback_hint="release_lock_in_finally_block",
+        )
+    )
+    return steps
+
+
+def _operation_step(
+    *,
+    sequence: int,
+    operation: Mapping[str, Any],
+) -> MemoryEvidenceRepairExecutorStep:
+    operation_id = _str(operation.get("id"))
+    return MemoryEvidenceRepairExecutorStep(
+        id=f"executor-step-{sequence}-{operation_id or 'operation'}",
+        sequence=sequence,
+        phase="write",
+        action="apply_evidence_metadata_patch",
+        description="Apply the approved evidence metadata patch for one dry-run operation.",
+        operation_id=operation_id,
+        candidate_id=_str(operation.get("candidate_id")),
+        ledger_entry_id=_str(operation.get("ledger_entry_id")),
+        patch_digest=_str(operation.get("patch_digest")),
+        target=_dict(operation.get("target")),
+        evidence_fields=tuple(_list_of_str(operation.get("evidence_fields"))),
+        source_operation=dict(operation),
+        future_would_write_memory=True,
+        stop_on_failure=True,
+        rollback_hint="stop_executor_and_use_pre_commit_snapshot_or_rollback_plan",
+    )
+
+
+def _step(
+    *,
+    sequence: int,
+    phase: str,
+    action: str,
+    description: str,
+    lock: Mapping[str, Any],
+    future_would_write_memory: bool = False,
+    stop_on_failure: bool = True,
+    rollback_hint: str = "stop_executor_before_memory_write",
+) -> MemoryEvidenceRepairExecutorStep:
+    return MemoryEvidenceRepairExecutorStep(
+        id=f"executor-step-{sequence}-{action}",
+        sequence=sequence,
+        phase=phase,
+        action=action,
+        description=description,
+        operation_id="",
+        candidate_id="",
+        ledger_entry_id="",
+        patch_digest="",
+        target={
+            "lock_id": _str(lock.get("id")),
+            "receipt_id": _str(lock.get("receipt_id")),
+            "token_id": _str(lock.get("token_id")),
+        },
+        evidence_fields=(),
+        source_operation={},
+        future_would_write_memory=future_would_write_memory,
+        stop_on_failure=stop_on_failure,
+        rollback_hint=rollback_hint,
+    )
+
+
+def _operations_from_lock(lock: Mapping[str, Any]) -> list[Mapping[str, Any]]:
+    receipt = _dict(lock.get("source_receipt"))
+    source_gate = _dict(receipt.get("source_gate"))
+    dry_run = _dict(source_gate.get("source_dry_run"))
+    operations = [
+        operation
+        for operation in _list(dry_run.get("operations"))
+        if isinstance(operation, Mapping)
+    ]
+    if operations:
+        return operations
+    operation_ids = _list_of_str(lock.get("operation_ids"))
+    candidate_ids = _list_of_str(lock.get("candidate_ids"))
+    patch_digests = _list_of_str(lock.get("patch_digests"))
+    return [
+        {
+            "id": operation_id,
+            "candidate_id": candidate_ids[index] if index < len(candidate_ids) else "",
+            "patch_digest": patch_digests[index] if index < len(patch_digests) else "",
+            "target": {},
+            "evidence_fields": [],
+        }
+        for index, operation_id in enumerate(operation_ids)
+    ]
+
+
+def _expected_lock_digest(lock: Mapping[str, Any]) -> str:
+    seed = {
+        "lock_type": WRITE_LOCK_TYPE,
+        "scope": RECEIPT_SCOPE,
+        "owner": _str(lock.get("owner")) or "human",
+        "receipt_id": _str(lock.get("receipt_id")),
+        "token_id": _str(lock.get("token_id")),
+        "operation_ids": tuple(_list_of_str(lock.get("operation_ids"))),
+        "candidate_ids": tuple(_list_of_str(lock.get("candidate_ids"))),
+        "patch_digests": tuple(_list_of_str(lock.get("patch_digests"))),
+        "expires_in_minutes": _positive_int(lock.get("expires_in_minutes")) or 10,
+    }
+    return _digest(seed)
+
+
+def _empty_report(
+    *,
+    write_lock_gate: Mapping[str, Any],
+) -> MemoryEvidenceRepairExecutorPreviewReport:
+    return MemoryEvidenceRepairExecutorPreviewReport(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        status=EXECUTOR_PREVIEW_STATUS_NO_ACTION_NEEDED,
+        checks=(),
+        previews=(),
+        blocking_reasons=(),
+        required_actions=(),
+        source_write_lock_gate=dict(write_lock_gate),
+    )
+
+
+def _blocked_report(
+    *,
+    write_lock_gate: Mapping[str, Any],
+    checks: tuple[MemoryEvidenceRepairExecutorPreviewCheck, ...],
+) -> MemoryEvidenceRepairExecutorPreviewReport:
+    return MemoryEvidenceRepairExecutorPreviewReport(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        status=EXECUTOR_PREVIEW_STATUS_BLOCKED,
+        checks=checks,
+        previews=(),
+        blocking_reasons=tuple(
+            _dedupe_strings(check.reason for check in checks if check.status == CHECK_STATUS_FAIL)
+        ),
+        required_actions=tuple(
+            _dedupe_strings(
+                action
+                for check in checks
+                if check.status == CHECK_STATUS_FAIL
+                for action in check.required_actions
+            )
+        ),
+        source_write_lock_gate=dict(write_lock_gate),
+    )
+
+
+def _pass(
+    check_id: str,
+    reason: str,
+    details: Mapping[str, Any],
+) -> MemoryEvidenceRepairExecutorPreviewCheck:
+    return MemoryEvidenceRepairExecutorPreviewCheck(
+        id=check_id,
+        status=CHECK_STATUS_PASS,
+        reason=reason,
+        required_actions=(),
+        details=dict(details),
+    )
+
+
+def _fail(
+    check_id: str,
+    reason: str,
+    required_actions: Sequence[str],
+    details: Mapping[str, Any],
+) -> MemoryEvidenceRepairExecutorPreviewCheck:
+    return MemoryEvidenceRepairExecutorPreviewCheck(
+        id=check_id,
+        status=CHECK_STATUS_FAIL,
+        reason=reason,
+        required_actions=tuple(required_actions),
+        details=dict(details),
+    )
+
+
+def _parse_datetime(value: str | datetime | Any) -> datetime | None:
+    if isinstance(value, datetime):
+        return value if value.tzinfo else value.replace(tzinfo=timezone.utc)
+    if not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    return parsed if parsed.tzinfo else parsed.replace(tzinfo=timezone.utc)
+
+
+def _positive_int(value: Any) -> int | None:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed if parsed > 0 else None
+
+
+def _digest(value: Any) -> str:
+    raw = json.dumps(value, sort_keys=True, ensure_ascii=False, default=str)
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def _dict(value: Any) -> dict[str, Any]:
+    return dict(value) if isinstance(value, Mapping) else {}
+
+
+def _list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _list_of_str(value: Any) -> list[str]:
+    return [_str(item) for item in value] if isinstance(value, list) else []
+
+
+def _dedupe_strings(values: Sequence[str] | Any) -> list[str]:
+    seen: set[str] = set()
+    result: list[str] = []
+    for value in values:
+        text = _str(value)
+        if text and text not in seen:
+            seen.add(text)
+            result.append(text)
+    return result
+
+
+def _str(value: Any) -> str:
+    return str(value or "").strip()

--- a/agent/memory_evidence_repair_human_approval_token.py
+++ b/agent/memory_evidence_repair_human_approval_token.py
@@ -1,0 +1,277 @@
+"""Read-only human approval token draft for memory evidence repair.
+
+The token layer creates an approval-token draft only after a manual commit
+dry-run is ready. It never writes to durable memory stores.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Mapping
+
+from agent.memory_evidence_repair_manual_commit_dry_run import (
+    DRY_RUN_STATUS_BLOCKED,
+    DRY_RUN_STATUS_NO_ACTION_NEEDED,
+    DRY_RUN_STATUS_READY_FOR_MANUAL_COMMIT,
+)
+
+
+APPROVAL_TOKEN_TYPE = "memory_evidence_repair_human_approval"
+APPROVAL_TOKEN_SCOPE = "manual_memory_evidence_repair_commit"
+TOKEN_STATUS_DRAFT_READY = "draft_ready_for_human_approval"
+TOKEN_STATUS_BLOCKED = "blocked"
+TOKEN_STATUS_NO_ACTION_NEEDED = "no_action_needed"
+DEFAULT_EXPIRES_IN_MINUTES = 30
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairHumanApprovalToken:
+    """One read-only human approval token draft."""
+
+    id: str
+    token_type: str
+    status: str
+    scope: str
+    approver: str
+    approval_reason: str
+    dry_run_status: str
+    dry_run_digest: str
+    token_digest: str
+    token_preview: str
+    expires_in_minutes: int
+    operation_ids: tuple[str, ...]
+    ledger_entry_ids: tuple[str, ...]
+    candidate_ids: tuple[str, ...]
+    patch_digests: tuple[str, ...]
+    required_confirmation_text: str
+    one_time_constraints: dict[str, Any]
+    safety_note: str
+    source_dry_run: dict[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "token_type": self.token_type,
+            "status": self.status,
+            "scope": self.scope,
+            "approver": self.approver,
+            "approval_reason": self.approval_reason,
+            "dry_run_status": self.dry_run_status,
+            "dry_run_digest": self.dry_run_digest,
+            "token_digest": self.token_digest,
+            "token_preview": self.token_preview,
+            "expires_in_minutes": self.expires_in_minutes,
+            "operation_ids": list(self.operation_ids),
+            "ledger_entry_ids": list(self.ledger_entry_ids),
+            "candidate_ids": list(self.candidate_ids),
+            "patch_digests": list(self.patch_digests),
+            "required_confirmation_text": self.required_confirmation_text,
+            "one_time_constraints": dict(self.one_time_constraints),
+            "safety_note": self.safety_note,
+            "source_dry_run": dict(self.source_dry_run),
+        }
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairHumanApprovalTokenReport:
+    """Read-only human approval token draft report."""
+
+    generated_at: str
+    status: str
+    tokens: tuple[MemoryEvidenceRepairHumanApprovalToken, ...]
+    blocking_reasons: tuple[str, ...]
+    required_actions: tuple[str, ...]
+
+    @property
+    def summary(self) -> dict[str, Any]:
+        return {
+            "status": self.status,
+            "token_count": len(self.tokens),
+            "ready_count": 1 if self.status == TOKEN_STATUS_DRAFT_READY else 0,
+            "blocked_count": 1 if self.status == TOKEN_STATUS_BLOCKED else 0,
+            "no_action_count": 1 if self.status == TOKEN_STATUS_NO_ACTION_NEEDED else 0,
+            "blocking_reason_count": len(self.blocking_reasons),
+            "required_action_count": len(self.required_actions),
+            "human_approval_token_available": bool(self.tokens),
+            "requires_followup": bool(self.required_actions),
+        }
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "generated_at": self.generated_at,
+            "status": self.status,
+            "summary": self.summary,
+            "tokens": [token.to_dict() for token in self.tokens],
+            "blocking_reasons": list(self.blocking_reasons),
+            "required_actions": list(self.required_actions),
+            "read_only": True,
+            "read_only_memory": True,
+            "would_mutate_memory": False,
+        }
+
+
+def build_evidence_repair_human_approval_token(
+    *,
+    dry_run: Mapping[str, Any] | None = None,
+    approver: str = "human",
+    approval_reason: str = "",
+    expires_in_minutes: int = DEFAULT_EXPIRES_IN_MINUTES,
+) -> MemoryEvidenceRepairHumanApprovalTokenReport:
+    """Build a read-only human approval token draft from a dry-run."""
+
+    dry_run = dry_run if isinstance(dry_run, Mapping) else {}
+    dry_run_status = _str(dry_run.get("status"))
+    operations = _operation_rows(dry_run)
+    if dry_run_status == DRY_RUN_STATUS_READY_FOR_MANUAL_COMMIT and operations:
+        token = _token_from_dry_run(
+            dry_run=dry_run,
+            approver=approver,
+            approval_reason=approval_reason,
+            expires_in_minutes=expires_in_minutes,
+        )
+        return MemoryEvidenceRepairHumanApprovalTokenReport(
+            generated_at=datetime.now(timezone.utc).isoformat(),
+            status=TOKEN_STATUS_DRAFT_READY,
+            tokens=(token,),
+            blocking_reasons=(),
+            required_actions=(),
+        )
+
+    blocking_reasons = tuple(_list_of_str(dry_run.get("blocking_reasons")))
+    required_actions = tuple(_list_of_str(dry_run.get("required_actions")))
+    if dry_run_status == DRY_RUN_STATUS_BLOCKED:
+        status = TOKEN_STATUS_BLOCKED
+        if not blocking_reasons:
+            blocking_reasons = ("Manual commit dry-run is blocked.",)
+        if not required_actions:
+            required_actions = ("resolve_manual_commit_dry_run_blocks",)
+    elif dry_run_status == DRY_RUN_STATUS_NO_ACTION_NEEDED or not operations:
+        status = TOKEN_STATUS_NO_ACTION_NEEDED
+    else:
+        status = TOKEN_STATUS_BLOCKED
+        blocking_reasons = blocking_reasons or ("Manual commit dry-run is not ready.",)
+        required_actions = required_actions or ("produce_ready_manual_commit_dry_run",)
+
+    return MemoryEvidenceRepairHumanApprovalTokenReport(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        status=status,
+        tokens=(),
+        blocking_reasons=blocking_reasons,
+        required_actions=required_actions,
+    )
+
+
+def empty_evidence_repair_human_approval_token() -> MemoryEvidenceRepairHumanApprovalTokenReport:
+    """Return an empty read-only human approval token report."""
+
+    return MemoryEvidenceRepairHumanApprovalTokenReport(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        status=TOKEN_STATUS_NO_ACTION_NEEDED,
+        tokens=(),
+        blocking_reasons=(),
+        required_actions=(),
+    )
+
+
+def _token_from_dry_run(
+    *,
+    dry_run: Mapping[str, Any],
+    approver: str,
+    approval_reason: str,
+    expires_in_minutes: int,
+) -> MemoryEvidenceRepairHumanApprovalToken:
+    operations = _operation_rows(dry_run)
+    dry_run_digest = _digest(
+        {
+            "status": dry_run.get("status"),
+            "operations": operations,
+            "checks": dry_run.get("checks"),
+        }
+    )
+    operation_ids = tuple(_str(operation.get("id")) for operation in operations)
+    ledger_entry_ids = tuple(_str(operation.get("ledger_entry_id")) for operation in operations)
+    candidate_ids = tuple(_str(operation.get("candidate_id")) for operation in operations)
+    patch_digests = tuple(_str(operation.get("patch_digest")) for operation in operations)
+    token_seed = {
+        "token_type": APPROVAL_TOKEN_TYPE,
+        "scope": APPROVAL_TOKEN_SCOPE,
+        "approver": _str(approver) or "human",
+        "approval_reason": _str(approval_reason),
+        "dry_run_digest": dry_run_digest,
+        "operation_ids": operation_ids,
+        "ledger_entry_ids": ledger_entry_ids,
+        "candidate_ids": candidate_ids,
+        "patch_digests": patch_digests,
+        "expires_in_minutes": _expires_in_minutes(expires_in_minutes),
+    }
+    token_digest = _digest(token_seed)
+    token_id = f"approval-token-{token_digest[:16]}"
+    required_confirmation_text = (
+        f"APPROVE {APPROVAL_TOKEN_SCOPE} {token_id}"
+    )
+    return MemoryEvidenceRepairHumanApprovalToken(
+        id=token_id,
+        token_type=APPROVAL_TOKEN_TYPE,
+        status=TOKEN_STATUS_DRAFT_READY,
+        scope=APPROVAL_TOKEN_SCOPE,
+        approver=_str(approver) or "human",
+        approval_reason=_str(approval_reason),
+        dry_run_status=_str(dry_run.get("status")),
+        dry_run_digest=dry_run_digest,
+        token_digest=token_digest,
+        token_preview=f"{token_id}:{token_digest[:12]}",
+        expires_in_minutes=_expires_in_minutes(expires_in_minutes),
+        operation_ids=operation_ids,
+        ledger_entry_ids=ledger_entry_ids,
+        candidate_ids=candidate_ids,
+        patch_digests=patch_digests,
+        required_confirmation_text=required_confirmation_text,
+        one_time_constraints={
+            "one_time_use": True,
+            "requires_exact_dry_run_digest": dry_run_digest,
+            "requires_exact_confirmation_text": required_confirmation_text,
+            "requires_same_patch_digests": list(patch_digests),
+            "expires_in_minutes": _expires_in_minutes(expires_in_minutes),
+        },
+        safety_note=(
+            "Read-only approval token draft. This is not a persisted credential "
+            "and does not authorize or mutate durable memory by itself."
+        ),
+        source_dry_run=dict(dry_run),
+    )
+
+
+def _operation_rows(dry_run: Mapping[str, Any]) -> list[Mapping[str, Any]]:
+    return [
+        operation
+        for operation in _list(dry_run.get("operations"))
+        if isinstance(operation, Mapping)
+    ]
+
+
+def _expires_in_minutes(value: Any) -> int:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        parsed = DEFAULT_EXPIRES_IN_MINUTES
+    return parsed if parsed > 0 else DEFAULT_EXPIRES_IN_MINUTES
+
+
+def _digest(value: Any) -> str:
+    raw = json.dumps(value, sort_keys=True, ensure_ascii=False, default=str)
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def _list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _list_of_str(value: Any) -> list[str]:
+    return [_str(item) for item in value] if isinstance(value, list) else []
+
+
+def _str(value: Any) -> str:
+    return str(value or "").strip()

--- a/agent/memory_evidence_repair_manual_commit_dry_run.py
+++ b/agent/memory_evidence_repair_manual_commit_dry_run.py
@@ -1,0 +1,428 @@
+"""Read-only manual commit dry-run for memory evidence repair.
+
+The dry-run layer summarizes whether a future manual evidence repair write is
+ready after commit gate, ledger, rollback, and snapshot checks. It never writes
+to durable memory stores.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Mapping
+
+
+DRY_RUN_STATUS_READY_FOR_MANUAL_COMMIT = "ready_for_manual_commit"
+DRY_RUN_STATUS_BLOCKED = "blocked"
+DRY_RUN_STATUS_NO_ACTION_NEEDED = "no_action_needed"
+
+CHECK_STATUS_PASS = "pass"
+CHECK_STATUS_FAIL = "fail"
+CHECK_STATUS_SKIPPED = "skipped"
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairDryRunCheck:
+    """One readiness check in the manual commit dry-run."""
+
+    id: str
+    status: str
+    reason: str
+    required_actions: tuple[str, ...]
+    details: dict[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "status": self.status,
+            "reason": self.reason,
+            "required_actions": list(self.required_actions),
+            "details": dict(self.details),
+        }
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairDryRunOperation:
+    """One future manual commit operation preview."""
+
+    id: str
+    ledger_entry_id: str
+    candidate_id: str
+    preview_id: str
+    provider: str
+    repair_action: str
+    patch_digest: str
+    target: dict[str, Any]
+    evidence_fields: tuple[str, ...]
+    source_entry: dict[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "ledger_entry_id": self.ledger_entry_id,
+            "candidate_id": self.candidate_id,
+            "preview_id": self.preview_id,
+            "provider": self.provider,
+            "repair_action": self.repair_action,
+            "patch_digest": self.patch_digest,
+            "target": dict(self.target),
+            "evidence_fields": list(self.evidence_fields),
+            "source_entry": dict(self.source_entry),
+        }
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairManualCommitDryRun:
+    """Read-only manual commit dry-run report."""
+
+    generated_at: str
+    status: str
+    checks: tuple[MemoryEvidenceRepairDryRunCheck, ...]
+    operations: tuple[MemoryEvidenceRepairDryRunOperation, ...]
+    blocking_reasons: tuple[str, ...]
+    required_actions: tuple[str, ...]
+
+    @property
+    def summary(self) -> dict[str, Any]:
+        by_check_status: dict[str, int] = {}
+        for check in self.checks:
+            by_check_status[check.status] = by_check_status.get(check.status, 0) + 1
+        return {
+            "status": self.status,
+            "check_count": len(self.checks),
+            "operation_count": len(self.operations),
+            "blocking_reason_count": len(self.blocking_reasons),
+            "required_action_count": len(self.required_actions),
+            "by_check_status": by_check_status,
+            "manual_commit_allowed": self.status == DRY_RUN_STATUS_READY_FOR_MANUAL_COMMIT,
+            "has_blocks": self.status == DRY_RUN_STATUS_BLOCKED,
+            "requires_followup": bool(self.required_actions),
+        }
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "generated_at": self.generated_at,
+            "status": self.status,
+            "summary": self.summary,
+            "checks": [check.to_dict() for check in self.checks],
+            "operations": [operation.to_dict() for operation in self.operations],
+            "blocking_reasons": list(self.blocking_reasons),
+            "required_actions": list(self.required_actions),
+            "read_only": True,
+            "read_only_memory": True,
+            "would_mutate_memory": False,
+        }
+
+
+def build_evidence_repair_manual_commit_dry_run(
+    *,
+    snapshot_plan: Mapping[str, Any] | None = None,
+    commit_gate: Mapping[str, Any] | None = None,
+    ledger: Mapping[str, Any] | None = None,
+    rollback_plan: Mapping[str, Any] | None = None,
+) -> MemoryEvidenceRepairManualCommitDryRun:
+    """Build a read-only final dry-run before any manual repair write."""
+
+    snapshot_plan = snapshot_plan if isinstance(snapshot_plan, Mapping) else {}
+    commit_gate = commit_gate if isinstance(commit_gate, Mapping) else {}
+    ledger = ledger if isinstance(ledger, Mapping) else {}
+    rollback_plan = rollback_plan if isinstance(rollback_plan, Mapping) else {}
+
+    checks = (
+        _commit_gate_check(commit_gate),
+        _ledger_check(ledger),
+        _rollback_check(rollback_plan),
+        _snapshot_check(snapshot_plan),
+    )
+    operations = tuple(_operations_from_ledger(ledger))
+    blocking_reasons = tuple(
+        _dedupe_strings(
+            reason
+            for check in checks
+            if check.status == CHECK_STATUS_FAIL
+            for reason in [check.reason]
+            if reason
+        )
+    )
+    required_actions = tuple(
+        _dedupe_strings(
+            action
+            for check in checks
+            if check.status == CHECK_STATUS_FAIL
+            for action in check.required_actions
+        )
+    )
+    status = _dry_run_status(checks=checks, operations=operations)
+    return MemoryEvidenceRepairManualCommitDryRun(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        status=status,
+        checks=checks,
+        operations=operations,
+        blocking_reasons=blocking_reasons,
+        required_actions=required_actions,
+    )
+
+
+def empty_evidence_repair_manual_commit_dry_run() -> MemoryEvidenceRepairManualCommitDryRun:
+    """Return an empty read-only manual commit dry-run."""
+
+    return MemoryEvidenceRepairManualCommitDryRun(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        status=DRY_RUN_STATUS_NO_ACTION_NEEDED,
+        checks=(),
+        operations=(),
+        blocking_reasons=(),
+        required_actions=(),
+    )
+
+
+def _commit_gate_check(commit_gate: Mapping[str, Any]) -> MemoryEvidenceRepairDryRunCheck:
+    summary = _dict(commit_gate.get("summary"))
+    decision_count = _int(summary.get("decision_count"))
+    if decision_count == 0:
+        return _check(
+            "commit_gate",
+            CHECK_STATUS_SKIPPED,
+            "No commit gate decisions were supplied.",
+            (),
+            summary,
+        )
+    blocked_count = _int(summary.get("blocked_count"))
+    needs_confirmation_count = _int(summary.get("needs_confirmation_count"))
+    allow_count = _int(summary.get("allow_count"))
+    if blocked_count or needs_confirmation_count or allow_count == 0:
+        actions: list[str] = []
+        if blocked_count:
+            actions.append("resolve_commit_gate_blocks")
+        if needs_confirmation_count:
+            actions.append("obtain_explicit_user_confirmation")
+        if allow_count == 0:
+            actions.append("produce_allowed_commit_gate_decision")
+        return _check(
+            "commit_gate",
+            CHECK_STATUS_FAIL,
+            "Commit gate is not allowing manual commit.",
+            tuple(actions),
+            summary,
+        )
+    return _check(
+        "commit_gate",
+        CHECK_STATUS_PASS,
+        "Commit gate allows manual commit.",
+        (),
+        summary,
+    )
+
+
+def _ledger_check(ledger: Mapping[str, Any]) -> MemoryEvidenceRepairDryRunCheck:
+    summary = _dict(ledger.get("summary"))
+    entry_count = _int(summary.get("entry_count"))
+    if entry_count == 0:
+        return _check(
+            "commit_ledger",
+            CHECK_STATUS_SKIPPED,
+            "No commit ledger entries were supplied.",
+            (),
+            summary,
+        )
+    allow_count = _int(summary.get("allow_count"))
+    blocked_count = _int(summary.get("blocked_count"))
+    followup_count = _int(summary.get("followup_count"))
+    if blocked_count or followup_count or allow_count == 0:
+        actions: list[str] = []
+        if blocked_count:
+            actions.append("resolve_blocked_ledger_entries")
+        if followup_count:
+            actions.append("complete_ledger_followups")
+        if allow_count == 0:
+            actions.append("produce_allowed_ledger_entry")
+        return _check(
+            "commit_ledger",
+            CHECK_STATUS_FAIL,
+            "Commit ledger is not clean for manual commit.",
+            tuple(actions),
+            summary,
+        )
+    return _check(
+        "commit_ledger",
+        CHECK_STATUS_PASS,
+        "Commit ledger contains allowed entries with no follow-up.",
+        (),
+        summary,
+    )
+
+
+def _rollback_check(rollback_plan: Mapping[str, Any]) -> MemoryEvidenceRepairDryRunCheck:
+    summary = _dict(rollback_plan.get("summary"))
+    step_count = _int(summary.get("rollback_step_count"))
+    if step_count == 0:
+        return _check(
+            "rollback_plan",
+            CHECK_STATUS_SKIPPED,
+            "No rollback steps were supplied.",
+            (),
+            summary,
+        )
+    snapshot_required_count = _int(summary.get("snapshot_required_count"))
+    ready_count = _int(summary.get("ready_count"))
+    if snapshot_required_count or ready_count == 0:
+        actions: list[str] = []
+        if snapshot_required_count:
+            actions.append("capture_pre_commit_snapshots")
+        if ready_count == 0:
+            actions.append("produce_ready_rollback_plan")
+        return _check(
+            "rollback_plan",
+            CHECK_STATUS_FAIL,
+            "Rollback plan is not ready for manual rollback.",
+            tuple(actions),
+            summary,
+        )
+    return _check(
+        "rollback_plan",
+        CHECK_STATUS_PASS,
+        "Rollback plan is ready.",
+        (),
+        summary,
+    )
+
+
+def _snapshot_check(snapshot_plan: Mapping[str, Any]) -> MemoryEvidenceRepairDryRunCheck:
+    summary = _dict(snapshot_plan.get("summary"))
+    request_count = _int(summary.get("snapshot_request_count"))
+    if request_count == 0:
+        return _check(
+            "snapshot_plan",
+            CHECK_STATUS_SKIPPED,
+            "No snapshot requests were supplied.",
+            (),
+            summary,
+        )
+    capture_required_count = _int(summary.get("capture_required_count"))
+    blocking_count = _int(summary.get("blocking_count"))
+    if capture_required_count or blocking_count:
+        return _check(
+            "snapshot_plan",
+            CHECK_STATUS_FAIL,
+            "Pre-commit snapshots are still required.",
+            ("capture_pre_commit_snapshots",),
+            summary,
+        )
+    return _check(
+        "snapshot_plan",
+        CHECK_STATUS_PASS,
+        "Pre-commit snapshots are available or not needed.",
+        (),
+        summary,
+    )
+
+
+def _operations_from_ledger(
+    ledger: Mapping[str, Any],
+) -> list[MemoryEvidenceRepairDryRunOperation]:
+    operations: list[MemoryEvidenceRepairDryRunOperation] = []
+    for entry in _list(ledger.get("entries")):
+        if not isinstance(entry, Mapping):
+            continue
+        if not bool(entry.get("manual_commit_allowed")):
+            continue
+        entry_id = _str(entry.get("id"))
+        patch_digest = _str(entry.get("patch_digest"))
+        operations.append(
+            MemoryEvidenceRepairDryRunOperation(
+                id=_stable_operation_id(entry_id=entry_id, patch_digest=patch_digest),
+                ledger_entry_id=entry_id,
+                candidate_id=_str(entry.get("candidate_id")),
+                preview_id=_str(entry.get("preview_id")),
+                provider=_str(entry.get("provider")) or "memory",
+                repair_action=_str(entry.get("repair_action")) or "attach_provenance",
+                patch_digest=patch_digest,
+                target=_dict(entry.get("target")),
+                evidence_fields=tuple(_str(field) for field in _list(entry.get("evidence_fields")) if _str(field)),
+                source_entry=dict(entry),
+            )
+        )
+    return _dedupe_operations(operations)
+
+
+def _dry_run_status(
+    *,
+    checks: tuple[MemoryEvidenceRepairDryRunCheck, ...],
+    operations: tuple[MemoryEvidenceRepairDryRunOperation, ...],
+) -> str:
+    if any(check.status == CHECK_STATUS_FAIL for check in checks):
+        return DRY_RUN_STATUS_BLOCKED
+    if not operations:
+        return DRY_RUN_STATUS_NO_ACTION_NEEDED
+    return DRY_RUN_STATUS_READY_FOR_MANUAL_COMMIT
+
+
+def _check(
+    check_id: str,
+    status: str,
+    reason: str,
+    required_actions: tuple[str, ...],
+    details: Mapping[str, Any],
+) -> MemoryEvidenceRepairDryRunCheck:
+    return MemoryEvidenceRepairDryRunCheck(
+        id=check_id,
+        status=status,
+        reason=reason,
+        required_actions=required_actions,
+        details=dict(details),
+    )
+
+
+def _stable_operation_id(*, entry_id: str, patch_digest: str) -> str:
+    raw = json.dumps(
+        {"entry_id": entry_id, "patch_digest": patch_digest},
+        sort_keys=True,
+        ensure_ascii=False,
+    )
+    digest = hashlib.sha256(raw.encode("utf-8")).hexdigest()[:16]
+    return f"dryrun-op-{digest}"
+
+
+def _dedupe_operations(
+    operations: list[MemoryEvidenceRepairDryRunOperation],
+) -> list[MemoryEvidenceRepairDryRunOperation]:
+    seen: set[str] = set()
+    deduped: list[MemoryEvidenceRepairDryRunOperation] = []
+    for operation in operations:
+        if operation.id in seen:
+            continue
+        seen.add(operation.id)
+        deduped.append(operation)
+    return deduped
+
+
+def _dedupe_strings(values) -> list[str]:
+    seen: set[str] = set()
+    deduped: list[str] = []
+    for value in values:
+        if value in seen:
+            continue
+        seen.add(value)
+        deduped.append(value)
+    return deduped
+
+
+def _dict(value: Any) -> dict[str, Any]:
+    return dict(value) if isinstance(value, Mapping) else {}
+
+
+def _list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _int(value: Any) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _str(value: Any) -> str:
+    return str(value or "").strip()

--- a/agent/memory_evidence_repair_planner.py
+++ b/agent/memory_evidence_repair_planner.py
@@ -1,0 +1,319 @@
+"""Read-only planner for repairing weak memory provenance.
+
+The planner converts gate/audit/diagnostic/policy signals into repair
+candidates. It never writes to durable memory stores.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Mapping
+
+
+ACTION_ATTACH_PROVENANCE = "attach_provenance"
+ACTION_VERIFY_SOURCE = "verify_source"
+ACTION_REFRESH_OBSERVATION = "refresh_observation"
+ACTION_REVIEW_CONFLICT = "review_conflict"
+
+REQUIRE_PROVENANCE = "require_provenance_before_reuse"
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairItem:
+    """One read-only evidence repair candidate."""
+
+    provider: str
+    priority: str
+    action: str
+    reason: str
+    source: str
+    evidence: str = ""
+    content_preview: str = ""
+    blocked_by_gate: bool = False
+    required_evidence: tuple[str, ...] = ()
+    recommended_next_step: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "provider": self.provider,
+            "priority": self.priority,
+            "action": self.action,
+            "source": self.source,
+            "reason": self.reason,
+            "evidence": self.evidence,
+            "content_preview": self.content_preview,
+            "blocked_by_gate": self.blocked_by_gate,
+            "required_evidence": list(self.required_evidence),
+            "recommended_next_step": self.recommended_next_step,
+        }
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairPlan:
+    """Read-only evidence repair plan."""
+
+    generated_at: str
+    repairs: tuple[MemoryEvidenceRepairItem, ...]
+
+    @property
+    def summary(self) -> dict[str, Any]:
+        by_priority: dict[str, int] = {}
+        by_provider: dict[str, int] = {}
+        by_action: dict[str, int] = {}
+        blocked_count = 0
+        for repair in self.repairs:
+            by_priority[repair.priority] = by_priority.get(repair.priority, 0) + 1
+            by_action[repair.action] = by_action.get(repair.action, 0) + 1
+            if repair.provider:
+                by_provider[repair.provider] = by_provider.get(repair.provider, 0) + 1
+            if repair.blocked_by_gate:
+                blocked_count += 1
+        return {
+            "repair_count": len(self.repairs),
+            "blocked_count": blocked_count,
+            "by_priority": by_priority,
+            "by_provider": by_provider,
+            "by_action": by_action,
+            "has_repairs": bool(self.repairs),
+        }
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "generated_at": self.generated_at,
+            "summary": self.summary,
+            "repairs": [repair.to_dict() for repair in self.repairs],
+            "read_only": True,
+        }
+
+
+def build_evidence_repair_plan(
+    *,
+    gate: Mapping[str, Any] | None = None,
+    audit: Mapping[str, Any] | None = None,
+    diagnostics: Mapping[str, Any] | None = None,
+    policy: Mapping[str, Any] | None = None,
+) -> MemoryEvidenceRepairPlan:
+    """Build a read-only evidence repair plan from memory quality signals."""
+
+    repairs: list[MemoryEvidenceRepairItem] = []
+    gate = gate if isinstance(gate, Mapping) else {}
+    audit = audit if isinstance(audit, Mapping) else {}
+    diagnostics = diagnostics if isinstance(diagnostics, Mapping) else {}
+    policy = policy if isinstance(policy, Mapping) else {}
+
+    repairs.extend(_repairs_from_gate(gate))
+    repairs.extend(_repairs_from_diagnostics(diagnostics))
+    repairs.extend(_repairs_from_policy(policy))
+    repairs.extend(_repairs_from_audit(audit))
+
+    return MemoryEvidenceRepairPlan(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        repairs=tuple(_dedupe_repairs(repairs)),
+    )
+
+
+def empty_evidence_repair_plan() -> MemoryEvidenceRepairPlan:
+    """Return an empty read-only evidence repair plan."""
+
+    return MemoryEvidenceRepairPlan(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        repairs=(),
+    )
+
+
+def _repairs_from_gate(gate: Mapping[str, Any]) -> list[MemoryEvidenceRepairItem]:
+    rows = _list(gate.get("provider_results")) or _list(gate.get("decisions"))
+    repairs: list[MemoryEvidenceRepairItem] = []
+    for row in rows:
+        if not isinstance(row, Mapping):
+            continue
+        action = str(row.get("action", "") or "")
+        effect = str(row.get("effect", "") or "")
+        reason = str(row.get("reason", "") or "")
+        if action != REQUIRE_PROVENANCE and "provenance" not in reason.lower():
+            continue
+        repairs.append(
+            MemoryEvidenceRepairItem(
+                provider=str(row.get("provider", "") or ""),
+                priority="high" if effect == "filtered" else "medium",
+                action=ACTION_ATTACH_PROVENANCE,
+                source="policy_gate",
+                reason=reason or "Memory recall needs explicit provenance before reuse.",
+                evidence=str(row.get("evidence", "") or ""),
+                blocked_by_gate=effect == "filtered",
+                required_evidence=_default_required_evidence(),
+                recommended_next_step=(
+                    "Attach source_url, observed_at, and a verification signal before "
+                    "allowing this memory back into recall."
+                ),
+            )
+        )
+    return repairs
+
+
+def _repairs_from_diagnostics(
+    diagnostics: Mapping[str, Any],
+) -> list[MemoryEvidenceRepairItem]:
+    repairs: list[MemoryEvidenceRepairItem] = []
+    for issue in _list(diagnostics.get("issues")):
+        if not isinstance(issue, Mapping):
+            continue
+        code = str(issue.get("code", "") or "")
+        if code == "collect_evidence_before_reuse":
+            repairs.append(
+                MemoryEvidenceRepairItem(
+                    provider=str(issue.get("provider", "") or ""),
+                    priority="high",
+                    action=ACTION_ATTACH_PROVENANCE,
+                    source="diagnostics",
+                    reason=str(issue.get("reason", "") or "Recall has weak evidence."),
+                    evidence=str(issue.get("evidence", "") or ""),
+                    required_evidence=_default_required_evidence(),
+                    recommended_next_step=str(
+                        issue.get("recommended_next_step", "")
+                        or "Attach provenance before reuse."
+                    ),
+                )
+            )
+        elif code == "refresh_stale_recall":
+            repairs.append(
+                MemoryEvidenceRepairItem(
+                    provider=str(issue.get("provider", "") or ""),
+                    priority="medium",
+                    action=ACTION_REFRESH_OBSERVATION,
+                    source="diagnostics",
+                    reason=str(issue.get("reason", "") or "Recall may be stale."),
+                    evidence=str(issue.get("evidence", "") or ""),
+                    required_evidence=("observed_at", "freshness_check"),
+                    recommended_next_step=str(
+                        issue.get("recommended_next_step", "")
+                        or "Refresh observed_at and confirm the memory still applies."
+                    ),
+                )
+            )
+        elif code == "review_conflicting_recall":
+            repairs.append(
+                MemoryEvidenceRepairItem(
+                    provider=str(issue.get("provider", "") or ""),
+                    priority="high",
+                    action=ACTION_REVIEW_CONFLICT,
+                    source="diagnostics",
+                    reason=str(issue.get("reason", "") or "Recall may conflict."),
+                    evidence=str(issue.get("evidence", "") or ""),
+                    required_evidence=("conflict_resolution", "source_url"),
+                    recommended_next_step=str(
+                        issue.get("recommended_next_step", "")
+                        or "Resolve conflict before this memory is reused."
+                    ),
+                )
+            )
+    return repairs
+
+
+def _repairs_from_policy(policy: Mapping[str, Any]) -> list[MemoryEvidenceRepairItem]:
+    repairs: list[MemoryEvidenceRepairItem] = []
+    for decision in _list(policy.get("decisions")):
+        if not isinstance(decision, Mapping):
+            continue
+        if str(decision.get("action", "") or "") != REQUIRE_PROVENANCE:
+            continue
+        repairs.append(
+            MemoryEvidenceRepairItem(
+                provider=str(decision.get("provider", "") or ""),
+                priority="high" if decision.get("provider") else "medium",
+                action=ACTION_ATTACH_PROVENANCE,
+                source="auto_policy",
+                reason=str(
+                    decision.get("reason", "")
+                    or "Auto-policy requires provenance before memory reuse."
+                ),
+                evidence=str(decision.get("evidence", "") or ""),
+                required_evidence=_default_required_evidence(),
+                recommended_next_step=str(
+                    decision.get("recommended_next_step", "")
+                    or "Repair provenance before reusing this memory."
+                ),
+            )
+        )
+    return repairs
+
+
+def _repairs_from_audit(audit: Mapping[str, Any]) -> list[MemoryEvidenceRepairItem]:
+    repairs: list[MemoryEvidenceRepairItem] = []
+    for entry in _list(audit.get("entries")):
+        if not isinstance(entry, Mapping):
+            continue
+        recommendation = str(entry.get("recommendation", "") or "")
+        dimensions = (
+            entry.get("dimensions") if isinstance(entry.get("dimensions"), Mapping) else {}
+        )
+        weak_source = _float(dimensions.get("source_strength")) < 0.5
+        weak_evidence = _float(dimensions.get("evidence_strength")) < 0.5
+        if recommendation != "needs_evidence" and not (weak_source or weak_evidence):
+            continue
+        decision = str(entry.get("decision", "") or "")
+        repairs.append(
+            MemoryEvidenceRepairItem(
+                provider=str(entry.get("provider", "") or ""),
+                priority="high" if decision in {"injected", "fallback_injected"} else "medium",
+                action=ACTION_ATTACH_PROVENANCE,
+                source="recall_audit",
+                reason=str(
+                    entry.get("reason", "")
+                    or "Recall audit found weak source or evidence strength."
+                ),
+                evidence=f"source_strength={dimensions.get('source_strength', 'n/a')}; "
+                f"evidence_strength={dimensions.get('evidence_strength', 'n/a')}",
+                content_preview=str(entry.get("content_preview", "") or ""),
+                required_evidence=_default_required_evidence(),
+                recommended_next_step=(
+                    "Attach source_url, observed_at, and verification before trusting "
+                    "this recall again."
+                ),
+            )
+        )
+    return repairs
+
+
+def _dedupe_repairs(
+    repairs: list[MemoryEvidenceRepairItem],
+) -> list[MemoryEvidenceRepairItem]:
+    seen: set[tuple[str, str, str, str]] = set()
+    deduped: list[MemoryEvidenceRepairItem] = []
+    priority_rank = {"critical": 0, "high": 1, "medium": 2, "low": 3}
+    repairs.sort(
+        key=lambda item: (
+            priority_rank.get(item.priority, 9),
+            item.provider,
+            item.action,
+            item.source,
+        )
+    )
+    for repair in repairs:
+        key = (
+            repair.provider,
+            repair.action,
+            repair.reason,
+            repair.content_preview,
+        )
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append(repair)
+    return deduped
+
+
+def _default_required_evidence() -> tuple[str, ...]:
+    return ("source_url", "observed_at", "verification_signal")
+
+
+def _list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _float(value: Any) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return 0.0

--- a/agent/memory_evidence_repair_post_commit_audit_preview.py
+++ b/agent/memory_evidence_repair_post_commit_audit_preview.py
@@ -1,0 +1,789 @@
+"""Read-only post-commit audit preview for memory evidence repair.
+
+The post-commit audit preview turns an executor preview into an ordered
+verification plan for after a future manual commit. It can also validate
+optional observed post-commit state. It never writes to durable memory stores.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Mapping, Sequence
+
+from agent.memory_evidence_repair_executor_preview import (
+    EXECUTOR_PREVIEW_STATUS_BLOCKED,
+    EXECUTOR_PREVIEW_STATUS_NO_ACTION_NEEDED,
+    EXECUTOR_PREVIEW_STATUS_READY,
+)
+from agent.memory_evidence_repair_manual_commit_dry_run import (
+    CHECK_STATUS_FAIL,
+    CHECK_STATUS_PASS,
+)
+
+
+POST_COMMIT_AUDIT_STATUS_READY = "post_commit_audit_preview_ready"
+POST_COMMIT_AUDIT_STATUS_BLOCKED = "blocked"
+POST_COMMIT_AUDIT_STATUS_NO_ACTION_NEEDED = "no_action_needed"
+
+AUDIT_STEP_STATUS_PLANNED = "planned"
+AUDIT_STEP_STATUS_PASS = "pass"
+AUDIT_STEP_STATUS_FAIL = "fail"
+
+CHECK_EXECUTOR_PREVIEW_READY = "executor_preview_ready"
+CHECK_EXECUTOR_PREVIEW_INTEGRITY = "executor_preview_integrity"
+CHECK_AUDIT_REQUIREMENTS = "audit_requirements"
+CHECK_OBSERVED_POST_STATE = "observed_post_state"
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairPostCommitAuditCheck:
+    """One read-only post-commit audit preview check."""
+
+    id: str
+    status: str
+    reason: str
+    required_actions: tuple[str, ...]
+    details: dict[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "status": self.status,
+            "reason": self.reason,
+            "required_actions": list(self.required_actions),
+            "details": dict(self.details),
+        }
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairPostCommitAuditStep:
+    """One future post-commit audit step preview."""
+
+    id: str
+    sequence: int
+    category: str
+    assertion: str
+    operation_id: str
+    receipt_id: str
+    token_id: str
+    lock_id: str
+    expected_signal: dict[str, Any]
+    observed_signal: dict[str, Any]
+    status: str
+    required_action_on_fail: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "sequence": self.sequence,
+            "category": self.category,
+            "assertion": self.assertion,
+            "operation_id": self.operation_id,
+            "receipt_id": self.receipt_id,
+            "token_id": self.token_id,
+            "lock_id": self.lock_id,
+            "expected_signal": dict(self.expected_signal),
+            "observed_signal": dict(self.observed_signal),
+            "status": self.status,
+            "required_action_on_fail": self.required_action_on_fail,
+        }
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairPostCommitAuditPreview:
+    """One read-only post-commit audit preview."""
+
+    id: str
+    status: str
+    executor_preview_id: str
+    lock_id: str
+    receipt_id: str
+    token_id: str
+    operation_ids: tuple[str, ...]
+    patch_digests: tuple[str, ...]
+    audit_step_ids: tuple[str, ...]
+    audit_digest: str
+    audit_preview: str
+    audit_steps: tuple[MemoryEvidenceRepairPostCommitAuditStep, ...]
+    observed_state_supplied: bool
+    would_verify_memory_patches: bool
+    would_verify_receipt_recorded: bool
+    would_verify_token_used: bool
+    would_verify_lock_released: bool
+    would_verify_rollback_available: bool
+    safety_note: str
+    source_executor_preview: dict[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "status": self.status,
+            "executor_preview_id": self.executor_preview_id,
+            "lock_id": self.lock_id,
+            "receipt_id": self.receipt_id,
+            "token_id": self.token_id,
+            "operation_ids": list(self.operation_ids),
+            "patch_digests": list(self.patch_digests),
+            "audit_step_ids": list(self.audit_step_ids),
+            "audit_digest": self.audit_digest,
+            "audit_preview": self.audit_preview,
+            "audit_steps": [step.to_dict() for step in self.audit_steps],
+            "observed_state_supplied": self.observed_state_supplied,
+            "would_verify_memory_patches": self.would_verify_memory_patches,
+            "would_verify_receipt_recorded": self.would_verify_receipt_recorded,
+            "would_verify_token_used": self.would_verify_token_used,
+            "would_verify_lock_released": self.would_verify_lock_released,
+            "would_verify_rollback_available": self.would_verify_rollback_available,
+            "safety_note": self.safety_note,
+            "source_executor_preview": dict(self.source_executor_preview),
+        }
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairPostCommitAuditPreviewReport:
+    """Read-only post-commit audit preview report."""
+
+    generated_at: str
+    status: str
+    checks: tuple[MemoryEvidenceRepairPostCommitAuditCheck, ...]
+    previews: tuple[MemoryEvidenceRepairPostCommitAuditPreview, ...]
+    blocking_reasons: tuple[str, ...]
+    required_actions: tuple[str, ...]
+    source_executor_preview_report: dict[str, Any]
+
+    @property
+    def summary(self) -> dict[str, Any]:
+        by_check_status: dict[str, int] = {}
+        by_audit_step_status: dict[str, int] = {}
+        for check in self.checks:
+            by_check_status[check.status] = by_check_status.get(check.status, 0) + 1
+        for preview in self.previews:
+            for step in preview.audit_steps:
+                by_audit_step_status[step.status] = (
+                    by_audit_step_status.get(step.status, 0) + 1
+                )
+        return {
+            "status": self.status,
+            "check_count": len(self.checks),
+            "pass_count": by_check_status.get(CHECK_STATUS_PASS, 0),
+            "fail_count": by_check_status.get(CHECK_STATUS_FAIL, 0),
+            "preview_count": len(self.previews),
+            "audit_step_count": sum(len(preview.audit_steps) for preview in self.previews),
+            "planned_audit_step_count": by_audit_step_status.get(AUDIT_STEP_STATUS_PLANNED, 0),
+            "observed_pass_step_count": by_audit_step_status.get(AUDIT_STEP_STATUS_PASS, 0),
+            "observed_fail_step_count": by_audit_step_status.get(AUDIT_STEP_STATUS_FAIL, 0),
+            "blocking_reason_count": len(self.blocking_reasons),
+            "required_action_count": len(self.required_actions),
+            "post_commit_audit_preview_available": bool(self.previews),
+            "post_commit_audit_ready": self.status == POST_COMMIT_AUDIT_STATUS_READY,
+            "has_blocks": self.status == POST_COMMIT_AUDIT_STATUS_BLOCKED,
+            "requires_followup": bool(self.required_actions),
+            "by_check_status": by_check_status,
+            "by_audit_step_status": by_audit_step_status,
+        }
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "generated_at": self.generated_at,
+            "status": self.status,
+            "summary": self.summary,
+            "checks": [check.to_dict() for check in self.checks],
+            "previews": [preview.to_dict() for preview in self.previews],
+            "blocking_reasons": list(self.blocking_reasons),
+            "required_actions": list(self.required_actions),
+            "source_executor_preview_report": dict(self.source_executor_preview_report),
+            "read_only": True,
+            "read_only_memory": True,
+            "would_mutate_memory": False,
+        }
+
+
+def build_evidence_repair_post_commit_audit_preview(
+    *,
+    executor_preview: Mapping[str, Any] | None = None,
+    observed_memory_patches: Mapping[str, Any] | None = None,
+    recorded_receipts: Sequence[Mapping[str, Any]] | Mapping[str, Any] | None = None,
+    used_token_ids: Sequence[str] | None = None,
+    released_lock_ids: Sequence[str] | None = None,
+    rollback_status: Mapping[str, Any] | None = None,
+) -> MemoryEvidenceRepairPostCommitAuditPreviewReport:
+    """Build a read-only post-commit audit preview from an executor preview."""
+
+    executor_preview = executor_preview if isinstance(executor_preview, Mapping) else {}
+    report_status = _str(executor_preview.get("status"))
+    preview = _extract_preview(executor_preview)
+    observed = _observed_context(
+        observed_memory_patches=observed_memory_patches,
+        recorded_receipts=recorded_receipts,
+        used_token_ids=used_token_ids,
+        released_lock_ids=released_lock_ids,
+        rollback_status=rollback_status,
+    )
+
+    if not preview:
+        if not executor_preview or report_status == EXECUTOR_PREVIEW_STATUS_NO_ACTION_NEEDED:
+            return _empty_report(executor_preview=executor_preview)
+        source_blocking = tuple(_list_of_str(executor_preview.get("blocking_reasons")))
+        source_actions = tuple(_list_of_str(executor_preview.get("required_actions")))
+        return _blocked_report(
+            executor_preview=executor_preview,
+            checks=(
+                _fail(
+                    CHECK_EXECUTOR_PREVIEW_READY,
+                    "No executor preview was supplied."
+                    if not source_blocking
+                    else "; ".join(source_blocking),
+                    source_actions or ("produce_executor_preview",),
+                    {"executor_preview_status": report_status},
+                ),
+            ),
+        )
+
+    audit_steps = tuple(_audit_steps_from_preview(preview, observed))
+    checks = (
+        _executor_preview_ready_check(executor_preview, preview),
+        _executor_preview_integrity_check(preview),
+        _audit_requirements_check(preview, audit_steps),
+        _observed_post_state_check(observed, audit_steps),
+    )
+    blocking_reasons = tuple(
+        _dedupe_strings(check.reason for check in checks if check.status == CHECK_STATUS_FAIL)
+    )
+    required_actions = tuple(
+        _dedupe_strings(
+            action
+            for check in checks
+            if check.status == CHECK_STATUS_FAIL
+            for action in check.required_actions
+        )
+    )
+    if blocking_reasons:
+        return MemoryEvidenceRepairPostCommitAuditPreviewReport(
+            generated_at=datetime.now(timezone.utc).isoformat(),
+            status=POST_COMMIT_AUDIT_STATUS_BLOCKED,
+            checks=checks,
+            previews=(),
+            blocking_reasons=blocking_reasons,
+            required_actions=required_actions,
+            source_executor_preview_report=dict(executor_preview),
+        )
+
+    post_preview = _preview_from_executor_preview(
+        preview=preview,
+        audit_steps=audit_steps,
+        observed_state_supplied=observed["supplied"],
+    )
+    return MemoryEvidenceRepairPostCommitAuditPreviewReport(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        status=POST_COMMIT_AUDIT_STATUS_READY,
+        checks=checks,
+        previews=(post_preview,),
+        blocking_reasons=(),
+        required_actions=(),
+        source_executor_preview_report=dict(executor_preview),
+    )
+
+
+def empty_evidence_repair_post_commit_audit_preview() -> MemoryEvidenceRepairPostCommitAuditPreviewReport:
+    """Return an empty read-only post-commit audit preview."""
+
+    return _empty_report(executor_preview={})
+
+
+def _extract_preview(executor_preview: Mapping[str, Any]) -> dict[str, Any]:
+    previews = executor_preview.get("previews")
+    if isinstance(previews, list):
+        for preview in previews:
+            if isinstance(preview, Mapping):
+                return dict(preview)
+    if _str(executor_preview.get("id")).startswith("executor-preview-"):
+        return dict(executor_preview)
+    return {}
+
+
+def _executor_preview_ready_check(
+    executor_preview: Mapping[str, Any],
+    preview: Mapping[str, Any],
+) -> MemoryEvidenceRepairPostCommitAuditCheck:
+    report_status = _str(executor_preview.get("status"))
+    preview_status = _str(preview.get("status"))
+    if report_status and report_status != EXECUTOR_PREVIEW_STATUS_READY:
+        return _fail(
+            CHECK_EXECUTOR_PREVIEW_READY,
+            "Executor preview report is not ready for post-commit audit planning.",
+            tuple(_list_of_str(executor_preview.get("required_actions")))
+            or ("produce_ready_executor_preview",),
+            {"report_status": report_status, "preview_status": preview_status},
+        )
+    if preview_status != EXECUTOR_PREVIEW_STATUS_READY:
+        return _fail(
+            CHECK_EXECUTOR_PREVIEW_READY,
+            "Executor preview entry is not ready.",
+            ("produce_ready_executor_preview",),
+            {"report_status": report_status, "preview_status": preview_status},
+        )
+    return _pass(
+        CHECK_EXECUTOR_PREVIEW_READY,
+        "Executor preview is ready for post-commit audit planning.",
+        {"executor_preview_id": _str(preview.get("id"))},
+    )
+
+
+def _executor_preview_integrity_check(
+    preview: Mapping[str, Any],
+) -> MemoryEvidenceRepairPostCommitAuditCheck:
+    expected_digest = _expected_executor_preview_digest(preview)
+    actual_digest = _str(preview.get("preview_digest"))
+    expected_id = f"executor-preview-{expected_digest[:16]}" if expected_digest else ""
+    missing_fields: list[str] = []
+    for field_name in ("lock_id", "receipt_id", "token_id", "operation_ids"):
+        value = preview.get(field_name)
+        if isinstance(value, list) and not value:
+            missing_fields.append(field_name)
+        elif not isinstance(value, list) and not _str(value):
+            missing_fields.append(field_name)
+    if missing_fields or actual_digest != expected_digest or _str(preview.get("id")) != expected_id:
+        return _fail(
+            CHECK_EXECUTOR_PREVIEW_INTEGRITY,
+            "Executor preview digest, id, or required fields are invalid.",
+            ("regenerate_executor_preview",),
+            {
+                "expected_preview_digest": expected_digest,
+                "actual_preview_digest": actual_digest,
+                "expected_preview_id": expected_id,
+                "actual_preview_id": _str(preview.get("id")),
+                "missing_fields": missing_fields,
+            },
+        )
+    return _pass(
+        CHECK_EXECUTOR_PREVIEW_INTEGRITY,
+        "Executor preview integrity checks pass.",
+        {"executor_preview_id": expected_id, "preview_digest": actual_digest},
+    )
+
+
+def _audit_requirements_check(
+    preview: Mapping[str, Any],
+    audit_steps: Sequence[MemoryEvidenceRepairPostCommitAuditStep],
+) -> MemoryEvidenceRepairPostCommitAuditCheck:
+    categories = {step.category for step in audit_steps}
+    required = {"memory_patch", "receipt", "token", "lock", "rollback"}
+    missing = sorted(required - categories)
+    write_steps = [
+        step
+        for step in _list(preview.get("steps"))
+        if isinstance(step, Mapping) and step.get("future_would_write_memory") is True
+    ]
+    if missing or not write_steps:
+        return _fail(
+            CHECK_AUDIT_REQUIREMENTS,
+            "Post-commit audit requirements are incomplete.",
+            ("regenerate_executor_preview_with_audit_requirements",),
+            {"missing_categories": missing, "future_write_step_count": len(write_steps)},
+        )
+    return _pass(
+        CHECK_AUDIT_REQUIREMENTS,
+        "Post-commit audit requirements cover memory patch, receipt, token, lock, and rollback checks.",
+        {"audit_step_count": len(audit_steps), "future_write_step_count": len(write_steps)},
+    )
+
+
+def _observed_post_state_check(
+    observed: Mapping[str, Any],
+    audit_steps: Sequence[MemoryEvidenceRepairPostCommitAuditStep],
+) -> MemoryEvidenceRepairPostCommitAuditCheck:
+    if not observed.get("supplied"):
+        return _pass(
+            CHECK_OBSERVED_POST_STATE,
+            "No observed post-commit state supplied; audit remains a planned preview.",
+            {"observed_state_supplied": False},
+        )
+    failures = [step.to_dict() for step in audit_steps if step.status == AUDIT_STEP_STATUS_FAIL]
+    if failures:
+        return _fail(
+            CHECK_OBSERVED_POST_STATE,
+            "Observed post-commit state does not satisfy the audit preview.",
+            ("investigate_post_commit_audit_failures",),
+            {"observed_state_supplied": True, "failures": failures},
+        )
+    return _pass(
+        CHECK_OBSERVED_POST_STATE,
+        "Observed post-commit state satisfies the audit preview.",
+        {"observed_state_supplied": True},
+    )
+
+
+def _preview_from_executor_preview(
+    *,
+    preview: Mapping[str, Any],
+    audit_steps: Sequence[MemoryEvidenceRepairPostCommitAuditStep],
+    observed_state_supplied: bool,
+) -> MemoryEvidenceRepairPostCommitAuditPreview:
+    audit_step_ids = tuple(step.id for step in audit_steps)
+    operation_ids = tuple(_list_of_str(preview.get("operation_ids")))
+    patch_digests = tuple(_list_of_str(preview.get("patch_digests")))
+    audit_seed = {
+        "executor_preview_id": _str(preview.get("id")),
+        "lock_id": _str(preview.get("lock_id")),
+        "receipt_id": _str(preview.get("receipt_id")),
+        "token_id": _str(preview.get("token_id")),
+        "operation_ids": operation_ids,
+        "patch_digests": patch_digests,
+        "audit_step_ids": audit_step_ids,
+        "observed_state_supplied": observed_state_supplied,
+    }
+    audit_digest = _digest(audit_seed)
+    audit_id = f"post-commit-audit-{audit_digest[:16]}"
+    return MemoryEvidenceRepairPostCommitAuditPreview(
+        id=audit_id,
+        status=POST_COMMIT_AUDIT_STATUS_READY,
+        executor_preview_id=_str(preview.get("id")),
+        lock_id=_str(preview.get("lock_id")),
+        receipt_id=_str(preview.get("receipt_id")),
+        token_id=_str(preview.get("token_id")),
+        operation_ids=operation_ids,
+        patch_digests=patch_digests,
+        audit_step_ids=audit_step_ids,
+        audit_digest=audit_digest,
+        audit_preview=f"{audit_id}:{audit_digest[:12]}",
+        audit_steps=tuple(audit_steps),
+        observed_state_supplied=observed_state_supplied,
+        would_verify_memory_patches=True,
+        would_verify_receipt_recorded=True,
+        would_verify_token_used=True,
+        would_verify_lock_released=True,
+        would_verify_rollback_available=True,
+        safety_note=(
+            "Read-only post-commit audit preview. It plans or checks future "
+            "verification signals but does not read or write durable memory."
+        ),
+        source_executor_preview=dict(preview),
+    )
+
+
+def _audit_steps_from_preview(
+    preview: Mapping[str, Any],
+    observed: Mapping[str, Any],
+) -> list[MemoryEvidenceRepairPostCommitAuditStep]:
+    steps: list[MemoryEvidenceRepairPostCommitAuditStep] = []
+    observed_patches = _dict(observed.get("memory_patches"))
+    for sequence, write_step in enumerate(_write_steps(preview), start=1):
+        operation_id = _str(write_step.get("operation_id"))
+        expected = {
+            "operation_id": operation_id,
+            "patch_digest": _str(write_step.get("patch_digest")),
+            "target": _dict(write_step.get("target")),
+            "evidence_fields": _list_of_str(write_step.get("evidence_fields")),
+        }
+        observed_signal = _dict(observed_patches.get(operation_id))
+        steps.append(
+            _audit_step(
+                sequence=sequence,
+                category="memory_patch",
+                assertion="memory_patch_applied_with_expected_digest",
+                preview=preview,
+                operation_id=operation_id,
+                expected_signal=expected,
+                observed_signal=observed_signal,
+                status=_observed_patch_status(expected, observed_signal, observed["supplied"]),
+                required_action_on_fail="inspect_memory_patch_and_rollback_if_needed",
+            )
+        )
+    sequence = len(steps) + 1
+    steps.append(
+        _audit_step(
+            sequence=sequence,
+            category="receipt",
+            assertion="commit_receipt_recorded",
+            preview=preview,
+            expected_signal={"receipt_id": _str(preview.get("receipt_id"))},
+            observed_signal={"recorded": _receipt_recorded(preview, observed)},
+            status=_boolean_status(_receipt_recorded(preview, observed), observed["supplied"]),
+            required_action_on_fail="record_or_recover_commit_receipt",
+        )
+    )
+    sequence += 1
+    steps.append(
+        _audit_step(
+            sequence=sequence,
+            category="token",
+            assertion="approval_token_marked_used",
+            preview=preview,
+            expected_signal={"token_id": _str(preview.get("token_id"))},
+            observed_signal={"used": _token_used(preview, observed)},
+            status=_boolean_status(_token_used(preview, observed), observed["supplied"]),
+            required_action_on_fail="mark_token_used_or_block_reuse",
+        )
+    )
+    sequence += 1
+    steps.append(
+        _audit_step(
+            sequence=sequence,
+            category="lock",
+            assertion="write_lock_released",
+            preview=preview,
+            expected_signal={"lock_id": _str(preview.get("lock_id"))},
+            observed_signal={"released": _lock_released(preview, observed)},
+            status=_boolean_status(_lock_released(preview, observed), observed["supplied"]),
+            required_action_on_fail="release_write_lock_or_mark_lock_expired",
+        )
+    )
+    sequence += 1
+    rollback_ready = _rollback_available(observed)
+    steps.append(
+        _audit_step(
+            sequence=sequence,
+            category="rollback",
+            assertion="rollback_or_snapshot_reference_available",
+            preview=preview,
+            expected_signal={"rollback_reference_required": True},
+            observed_signal={"rollback_available": rollback_ready},
+            status=_boolean_status(rollback_ready, observed["supplied"]),
+            required_action_on_fail="verify_rollback_plan_or_pre_commit_snapshot",
+        )
+    )
+    return steps
+
+
+def _audit_step(
+    *,
+    sequence: int,
+    category: str,
+    assertion: str,
+    preview: Mapping[str, Any],
+    expected_signal: Mapping[str, Any],
+    observed_signal: Mapping[str, Any],
+    status: str,
+    required_action_on_fail: str,
+    operation_id: str = "",
+) -> MemoryEvidenceRepairPostCommitAuditStep:
+    return MemoryEvidenceRepairPostCommitAuditStep(
+        id=f"post-commit-audit-step-{sequence}-{category}",
+        sequence=sequence,
+        category=category,
+        assertion=assertion,
+        operation_id=operation_id,
+        receipt_id=_str(preview.get("receipt_id")),
+        token_id=_str(preview.get("token_id")),
+        lock_id=_str(preview.get("lock_id")),
+        expected_signal=dict(expected_signal),
+        observed_signal=dict(observed_signal),
+        status=status,
+        required_action_on_fail=required_action_on_fail,
+    )
+
+
+def _observed_context(
+    *,
+    observed_memory_patches: Mapping[str, Any] | None,
+    recorded_receipts: Sequence[Mapping[str, Any]] | Mapping[str, Any] | None,
+    used_token_ids: Sequence[str] | None,
+    released_lock_ids: Sequence[str] | None,
+    rollback_status: Mapping[str, Any] | None,
+) -> dict[str, Any]:
+    memory_patches = _dict(observed_memory_patches)
+    receipt_ids = _receipt_ids(recorded_receipts)
+    used_tokens = tuple(_list_of_str(used_token_ids))
+    released_locks = tuple(_list_of_str(released_lock_ids))
+    rollback = _dict(rollback_status)
+    supplied = bool(memory_patches or receipt_ids or used_tokens or released_locks or rollback)
+    return {
+        "supplied": supplied,
+        "memory_patches": memory_patches,
+        "receipt_ids": receipt_ids,
+        "used_token_ids": used_tokens,
+        "released_lock_ids": released_locks,
+        "rollback_status": rollback,
+    }
+
+
+def _observed_patch_status(
+    expected: Mapping[str, Any],
+    observed: Mapping[str, Any],
+    observed_supplied: bool,
+) -> str:
+    if not observed_supplied:
+        return AUDIT_STEP_STATUS_PLANNED
+    if (
+        observed.get("applied") is True
+        and _str(observed.get("patch_digest")) == _str(expected.get("patch_digest"))
+    ):
+        return AUDIT_STEP_STATUS_PASS
+    return AUDIT_STEP_STATUS_FAIL
+
+
+def _boolean_status(value: bool, observed_supplied: bool) -> str:
+    if not observed_supplied:
+        return AUDIT_STEP_STATUS_PLANNED
+    return AUDIT_STEP_STATUS_PASS if value else AUDIT_STEP_STATUS_FAIL
+
+
+def _receipt_recorded(preview: Mapping[str, Any], observed: Mapping[str, Any]) -> bool:
+    return _str(preview.get("receipt_id")) in set(observed.get("receipt_ids") or ())
+
+
+def _token_used(preview: Mapping[str, Any], observed: Mapping[str, Any]) -> bool:
+    return _str(preview.get("token_id")) in set(observed.get("used_token_ids") or ())
+
+
+def _lock_released(preview: Mapping[str, Any], observed: Mapping[str, Any]) -> bool:
+    return _str(preview.get("lock_id")) in set(observed.get("released_lock_ids") or ())
+
+
+def _rollback_available(observed: Mapping[str, Any]) -> bool:
+    rollback = _dict(observed.get("rollback_status"))
+    status = _str(rollback.get("status"))
+    if not rollback:
+        return False
+    return status in {
+        "ready",
+        "available",
+        "verified",
+        "rollback_ready",
+        "snapshot_available",
+    }
+
+
+def _write_steps(preview: Mapping[str, Any]) -> list[Mapping[str, Any]]:
+    return [
+        step
+        for step in _list(preview.get("steps"))
+        if isinstance(step, Mapping) and step.get("future_would_write_memory") is True
+    ]
+
+
+def _receipt_ids(recorded_receipts: Sequence[Mapping[str, Any]] | Mapping[str, Any] | None) -> tuple[str, ...]:
+    ids: list[str] = []
+    if isinstance(recorded_receipts, Mapping):
+        ids.extend(_list_of_str(recorded_receipts.get("receipt_ids")))
+        rows = recorded_receipts.get("receipts")
+        if isinstance(rows, list):
+            ids.extend(_receipt_ids(rows))
+        if _str(recorded_receipts.get("id")):
+            ids.append(_str(recorded_receipts.get("id")))
+        if _str(recorded_receipts.get("receipt_id")):
+            ids.append(_str(recorded_receipts.get("receipt_id")))
+    elif isinstance(recorded_receipts, list):
+        for receipt in recorded_receipts:
+            if isinstance(receipt, Mapping):
+                ids.append(_str(receipt.get("id")) or _str(receipt.get("receipt_id")))
+    return tuple(_dedupe_strings(ids))
+
+
+def _expected_executor_preview_digest(preview: Mapping[str, Any]) -> str:
+    seed = {
+        "lock_id": _str(preview.get("lock_id")),
+        "receipt_id": _str(preview.get("receipt_id")),
+        "token_id": _str(preview.get("token_id")),
+        "operation_ids": tuple(_list_of_str(preview.get("operation_ids"))),
+        "candidate_ids": tuple(_list_of_str(preview.get("candidate_ids"))),
+        "patch_digests": tuple(_list_of_str(preview.get("patch_digests"))),
+        "step_ids": tuple(_list_of_str(preview.get("step_ids"))),
+        "execution_mode": "manual_ordered_commit",
+        "failure_policy": "stop_on_first_write_failure_then_release_lock",
+    }
+    return _digest(seed)
+
+
+def _empty_report(
+    *,
+    executor_preview: Mapping[str, Any],
+) -> MemoryEvidenceRepairPostCommitAuditPreviewReport:
+    return MemoryEvidenceRepairPostCommitAuditPreviewReport(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        status=POST_COMMIT_AUDIT_STATUS_NO_ACTION_NEEDED,
+        checks=(),
+        previews=(),
+        blocking_reasons=(),
+        required_actions=(),
+        source_executor_preview_report=dict(executor_preview),
+    )
+
+
+def _blocked_report(
+    *,
+    executor_preview: Mapping[str, Any],
+    checks: tuple[MemoryEvidenceRepairPostCommitAuditCheck, ...],
+) -> MemoryEvidenceRepairPostCommitAuditPreviewReport:
+    return MemoryEvidenceRepairPostCommitAuditPreviewReport(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        status=POST_COMMIT_AUDIT_STATUS_BLOCKED,
+        checks=checks,
+        previews=(),
+        blocking_reasons=tuple(
+            _dedupe_strings(check.reason for check in checks if check.status == CHECK_STATUS_FAIL)
+        ),
+        required_actions=tuple(
+            _dedupe_strings(
+                action
+                for check in checks
+                if check.status == CHECK_STATUS_FAIL
+                for action in check.required_actions
+            )
+        ),
+        source_executor_preview_report=dict(executor_preview),
+    )
+
+
+def _pass(
+    check_id: str,
+    reason: str,
+    details: Mapping[str, Any],
+) -> MemoryEvidenceRepairPostCommitAuditCheck:
+    return MemoryEvidenceRepairPostCommitAuditCheck(
+        id=check_id,
+        status=CHECK_STATUS_PASS,
+        reason=reason,
+        required_actions=(),
+        details=dict(details),
+    )
+
+
+def _fail(
+    check_id: str,
+    reason: str,
+    required_actions: Sequence[str],
+    details: Mapping[str, Any],
+) -> MemoryEvidenceRepairPostCommitAuditCheck:
+    return MemoryEvidenceRepairPostCommitAuditCheck(
+        id=check_id,
+        status=CHECK_STATUS_FAIL,
+        reason=reason,
+        required_actions=tuple(required_actions),
+        details=dict(details),
+    )
+
+
+def _digest(value: Any) -> str:
+    raw = json.dumps(value, sort_keys=True, ensure_ascii=False, default=str)
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def _dict(value: Any) -> dict[str, Any]:
+    return dict(value) if isinstance(value, Mapping) else {}
+
+
+def _list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _list_of_str(value: Any) -> list[str]:
+    return [_str(item) for item in value] if isinstance(value, list) else []
+
+
+def _dedupe_strings(values: Sequence[str] | Any) -> list[str]:
+    seen: set[str] = set()
+    result: list[str] = []
+    for value in values:
+        text = _str(value)
+        if text and text not in seen:
+            seen.add(text)
+            result.append(text)
+    return result
+
+
+def _str(value: Any) -> str:
+    return str(value or "").strip()

--- a/agent/memory_evidence_repair_recovery_approval_token_gate.py
+++ b/agent/memory_evidence_repair_recovery_approval_token_gate.py
@@ -1,0 +1,670 @@
+"""Read-only recovery approval token verification gate.
+
+The gate verifies a drafted recovery human approval token against the current
+recovery execution preview, confirmation text, expiry window, and one-time-use
+hints. It never writes to durable memory stores.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Any, Mapping, Sequence
+
+from agent.memory_evidence_repair_manual_commit_dry_run import (
+    CHECK_STATUS_FAIL,
+    CHECK_STATUS_PASS,
+)
+from agent.memory_evidence_repair_recovery_execution_preview import (
+    RECOVERY_EXECUTION_STATUS_NO_ACTION_NEEDED,
+    RECOVERY_EXECUTION_STATUS_READY,
+)
+from agent.memory_evidence_repair_recovery_human_approval_token import (
+    RECOVERY_APPROVAL_TOKEN_SCOPE,
+    RECOVERY_APPROVAL_TOKEN_TYPE,
+    RECOVERY_TOKEN_STATUS_DRAFT_READY,
+    RECOVERY_TOKEN_STATUS_NO_ACTION_NEEDED,
+)
+
+
+RECOVERY_TOKEN_GATE_STATUS_VERIFIED = "verified_for_manual_recovery"
+RECOVERY_TOKEN_GATE_STATUS_BLOCKED = "blocked"
+RECOVERY_TOKEN_GATE_STATUS_NO_ACTION_NEEDED = "no_action_needed"
+
+CHECK_RECOVERY_TOKEN_SHAPE = "recovery_token_shape"
+CHECK_RECOVERY_CONFIRMATION_TEXT = "recovery_confirmation_text"
+CHECK_RECOVERY_TOKEN_DIGEST = "recovery_token_digest"
+CHECK_EXECUTION_PREVIEW_DIGEST = "execution_preview_digest"
+CHECK_FUTURE_MUTATION_STEPS = "future_mutation_steps"
+CHECK_RECOVERY_EXPIRY = "recovery_expiry"
+CHECK_RECOVERY_ONE_TIME_CONSTRAINTS = "recovery_one_time_constraints"
+CHECK_RECOVERY_REUSE = "recovery_reuse"
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairRecoveryApprovalTokenGateCheck:
+    """One read-only recovery approval token verification check."""
+
+    id: str
+    status: str
+    reason: str
+    required_actions: tuple[str, ...]
+    details: dict[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "status": self.status,
+            "reason": self.reason,
+            "required_actions": list(self.required_actions),
+            "details": dict(self.details),
+        }
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairRecoveryApprovalTokenGateReport:
+    """Read-only recovery approval token gate report."""
+
+    generated_at: str
+    status: str
+    token_id: str
+    execution_preview_status: str
+    checks: tuple[MemoryEvidenceRepairRecoveryApprovalTokenGateCheck, ...]
+    blocking_reasons: tuple[str, ...]
+    required_actions: tuple[str, ...]
+    verified_operation_ids: tuple[str, ...]
+    verified_step_ids: tuple[str, ...]
+    verified_future_mutation_step_ids: tuple[str, ...]
+    source_token: dict[str, Any]
+    source_recovery_execution_preview: dict[str, Any]
+
+    @property
+    def summary(self) -> dict[str, Any]:
+        by_check_status: dict[str, int] = {}
+        for check in self.checks:
+            by_check_status[check.status] = by_check_status.get(check.status, 0) + 1
+        return {
+            "status": self.status,
+            "token_id": self.token_id,
+            "check_count": len(self.checks),
+            "pass_count": by_check_status.get(CHECK_STATUS_PASS, 0),
+            "fail_count": by_check_status.get(CHECK_STATUS_FAIL, 0),
+            "blocking_reason_count": len(self.blocking_reasons),
+            "required_action_count": len(self.required_actions),
+            "verified_operation_count": len(self.verified_operation_ids),
+            "verified_step_count": len(self.verified_step_ids),
+            "verified_future_mutation_step_count": len(
+                self.verified_future_mutation_step_ids
+            ),
+            "manual_recovery_verified": self.status == RECOVERY_TOKEN_GATE_STATUS_VERIFIED,
+            "has_blocks": self.status == RECOVERY_TOKEN_GATE_STATUS_BLOCKED,
+            "requires_followup": bool(self.required_actions),
+            "by_check_status": by_check_status,
+        }
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "generated_at": self.generated_at,
+            "status": self.status,
+            "summary": self.summary,
+            "token_id": self.token_id,
+            "execution_preview_status": self.execution_preview_status,
+            "checks": [check.to_dict() for check in self.checks],
+            "blocking_reasons": list(self.blocking_reasons),
+            "required_actions": list(self.required_actions),
+            "verified_operation_ids": list(self.verified_operation_ids),
+            "verified_step_ids": list(self.verified_step_ids),
+            "verified_future_mutation_step_ids": list(
+                self.verified_future_mutation_step_ids
+            ),
+            "source_token": dict(self.source_token),
+            "source_recovery_execution_preview": dict(
+                self.source_recovery_execution_preview
+            ),
+            "read_only": True,
+            "read_only_memory": True,
+            "would_mutate_memory": False,
+        }
+
+
+def build_evidence_repair_recovery_approval_token_gate(
+    *,
+    recovery_approval_token: Mapping[str, Any] | None = None,
+    recovery_execution: Mapping[str, Any] | None = None,
+    confirmation_text: str = "",
+    used_token_ids: Sequence[str] | None = None,
+    current_time: str | datetime | None = None,
+) -> MemoryEvidenceRepairRecoveryApprovalTokenGateReport:
+    """Verify a recovery human approval token without mutating memory."""
+
+    token, issued_at = _extract_token_and_issued_at(recovery_approval_token)
+    explicit_execution = (
+        recovery_execution if isinstance(recovery_execution, Mapping) else {}
+    )
+    token_execution = token.get("source_execution_preview") if isinstance(token, Mapping) else {}
+    current_execution = explicit_execution or (
+        token_execution if isinstance(token_execution, Mapping) else {}
+    )
+    current_execution = current_execution if isinstance(current_execution, Mapping) else {}
+
+    token_report_status = (
+        _str(recovery_approval_token.get("status"))
+        if isinstance(recovery_approval_token, Mapping)
+        else ""
+    )
+    if not token:
+        execution_status = _str(current_execution.get("status"))
+        if (
+            token_report_status == RECOVERY_TOKEN_STATUS_NO_ACTION_NEEDED
+            or execution_status == RECOVERY_EXECUTION_STATUS_NO_ACTION_NEEDED
+            or (not current_execution and not token_report_status)
+        ):
+            return _empty_report(recovery_execution=current_execution)
+        source_blocking = (
+            _list(recovery_approval_token.get("blocking_reasons"))
+            if isinstance(recovery_approval_token, Mapping)
+            else []
+        )
+        source_actions = (
+            _list(recovery_approval_token.get("required_actions"))
+            if isinstance(recovery_approval_token, Mapping)
+            else []
+        )
+        return _blocked_report(
+            token_id="",
+            recovery_execution=current_execution,
+            checks=(
+                _fail(
+                    CHECK_RECOVERY_TOKEN_SHAPE,
+                    "No recovery approval token was supplied."
+                    if not source_blocking
+                    else "; ".join(_str(item) for item in source_blocking if _str(item)),
+                    tuple(_str(item) for item in source_actions if _str(item))
+                    or ("draft_recovery_human_approval_token",),
+                    {"recovery_approval_token_status": token_report_status},
+                ),
+            ),
+        )
+
+    checks = tuple(
+        check
+        for check in (
+            _token_shape_check(token),
+            _confirmation_check(token, confirmation_text),
+            _token_digest_check(token),
+            _execution_preview_digest_check(token, current_execution),
+            _future_mutation_step_check(token, current_execution),
+            _expiry_check(token, issued_at, current_time),
+            _one_time_constraint_check(token),
+            _reuse_check(token, used_token_ids),
+        )
+        if check is not None
+    )
+    blocking_reasons = tuple(
+        _dedupe_strings(check.reason for check in checks if check.status == CHECK_STATUS_FAIL)
+    )
+    required_actions = tuple(
+        _dedupe_strings(
+            action
+            for check in checks
+            if check.status == CHECK_STATUS_FAIL
+            for action in check.required_actions
+        )
+    )
+    status = (
+        RECOVERY_TOKEN_GATE_STATUS_VERIFIED
+        if checks and not blocking_reasons
+        else RECOVERY_TOKEN_GATE_STATUS_BLOCKED
+    )
+    return MemoryEvidenceRepairRecoveryApprovalTokenGateReport(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        status=status,
+        token_id=_str(token.get("id")),
+        execution_preview_status=_str(current_execution.get("status")),
+        checks=checks,
+        blocking_reasons=blocking_reasons,
+        required_actions=required_actions,
+        verified_operation_ids=tuple(_list_of_str(current_execution.get("operation_ids"))),
+        verified_step_ids=tuple(_list_of_str(current_execution.get("step_ids"))),
+        verified_future_mutation_step_ids=tuple(_future_mutation_step_ids(current_execution)),
+        source_token=dict(token),
+        source_recovery_execution_preview=dict(current_execution),
+    )
+
+
+def empty_evidence_repair_recovery_approval_token_gate() -> MemoryEvidenceRepairRecoveryApprovalTokenGateReport:
+    """Return an empty read-only recovery approval token gate report."""
+
+    return _empty_report(recovery_execution={})
+
+
+def _empty_report(
+    *,
+    recovery_execution: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryApprovalTokenGateReport:
+    return MemoryEvidenceRepairRecoveryApprovalTokenGateReport(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        status=RECOVERY_TOKEN_GATE_STATUS_NO_ACTION_NEEDED,
+        token_id="",
+        execution_preview_status=_str(recovery_execution.get("status")),
+        checks=(),
+        blocking_reasons=(),
+        required_actions=(),
+        verified_operation_ids=(),
+        verified_step_ids=(),
+        verified_future_mutation_step_ids=(),
+        source_token={},
+        source_recovery_execution_preview=dict(recovery_execution),
+    )
+
+
+def _blocked_report(
+    *,
+    token_id: str,
+    recovery_execution: Mapping[str, Any],
+    checks: tuple[MemoryEvidenceRepairRecoveryApprovalTokenGateCheck, ...],
+) -> MemoryEvidenceRepairRecoveryApprovalTokenGateReport:
+    blocking_reasons = tuple(
+        _dedupe_strings(check.reason for check in checks if check.status == CHECK_STATUS_FAIL)
+    )
+    required_actions = tuple(
+        _dedupe_strings(
+            action
+            for check in checks
+            if check.status == CHECK_STATUS_FAIL
+            for action in check.required_actions
+        )
+    )
+    return MemoryEvidenceRepairRecoveryApprovalTokenGateReport(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        status=RECOVERY_TOKEN_GATE_STATUS_BLOCKED,
+        token_id=token_id,
+        execution_preview_status=_str(recovery_execution.get("status")),
+        checks=checks,
+        blocking_reasons=blocking_reasons,
+        required_actions=required_actions,
+        verified_operation_ids=(),
+        verified_step_ids=(),
+        verified_future_mutation_step_ids=(),
+        source_token={},
+        source_recovery_execution_preview=dict(recovery_execution),
+    )
+
+
+def _extract_token_and_issued_at(
+    recovery_approval_token: Mapping[str, Any] | None,
+) -> tuple[dict[str, Any], str]:
+    if not isinstance(recovery_approval_token, Mapping):
+        return {}, ""
+    report_issued_at = _str(recovery_approval_token.get("generated_at"))
+    token: Mapping[str, Any] | None = None
+    tokens = recovery_approval_token.get("tokens")
+    if isinstance(tokens, list):
+        token = next((item for item in tokens if isinstance(item, Mapping)), None)
+    elif _str(recovery_approval_token.get("id")):
+        token = recovery_approval_token
+    if not isinstance(token, Mapping):
+        return {}, report_issued_at
+    issued_at = (
+        _str(token.get("issued_at"))
+        or _str(token.get("generated_at"))
+        or report_issued_at
+    )
+    return dict(token), issued_at
+
+
+def _token_shape_check(
+    token: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryApprovalTokenGateCheck:
+    reasons: list[str] = []
+    if not _str(token.get("id")).startswith("recovery-approval-token-"):
+        reasons.append("Recovery token id is missing or invalid.")
+    if _str(token.get("token_type")) != RECOVERY_APPROVAL_TOKEN_TYPE:
+        reasons.append("Token type is not a memory evidence repair recovery token.")
+    if _str(token.get("scope")) != RECOVERY_APPROVAL_TOKEN_SCOPE:
+        reasons.append("Token scope does not match manual memory evidence repair recovery.")
+    if _str(token.get("status")) != RECOVERY_TOKEN_STATUS_DRAFT_READY:
+        reasons.append("Recovery token is not a ready approval draft.")
+    if reasons:
+        return _fail(
+            CHECK_RECOVERY_TOKEN_SHAPE,
+            " ".join(reasons),
+            ("regenerate_recovery_human_approval_token",),
+            {"token_id": _str(token.get("id"))},
+        )
+    return _pass(
+        CHECK_RECOVERY_TOKEN_SHAPE,
+        "Recovery approval token shape is valid.",
+        {"token_id": _str(token.get("id"))},
+    )
+
+
+def _confirmation_check(
+    token: Mapping[str, Any],
+    confirmation_text: str,
+) -> MemoryEvidenceRepairRecoveryApprovalTokenGateCheck:
+    expected = _str(token.get("required_confirmation_text"))
+    actual = _str(confirmation_text)
+    constraints = _dict(token.get("one_time_constraints"))
+    constraint_expected = _str(constraints.get("requires_exact_confirmation_text"))
+    expected_values = {item for item in (expected, constraint_expected) if item}
+    if not actual or actual not in expected_values:
+        return _fail(
+            CHECK_RECOVERY_CONFIRMATION_TEXT,
+            "Confirmation text does not exactly match the recovery approval token.",
+            ("provide_exact_recovery_confirmation_text",),
+            {"expected_confirmation_text": expected or constraint_expected, "provided": actual},
+        )
+    return _pass(
+        CHECK_RECOVERY_CONFIRMATION_TEXT,
+        "Confirmation text matches the recovery approval token.",
+        {"provided": actual},
+    )
+
+
+def _token_digest_check(
+    token: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryApprovalTokenGateCheck:
+    expected_digest = _expected_token_digest(token)
+    actual_digest = _str(token.get("token_digest"))
+    expected_id = f"recovery-approval-token-{expected_digest[:16]}" if expected_digest else ""
+    if actual_digest != expected_digest or _str(token.get("id")) != expected_id:
+        return _fail(
+            CHECK_RECOVERY_TOKEN_DIGEST,
+            "Recovery approval token digest or id does not match its declared payload.",
+            ("regenerate_recovery_human_approval_token",),
+            {
+                "expected_token_digest": expected_digest,
+                "actual_token_digest": actual_digest,
+                "expected_token_id": expected_id,
+                "actual_token_id": _str(token.get("id")),
+            },
+        )
+    return _pass(
+        CHECK_RECOVERY_TOKEN_DIGEST,
+        "Recovery approval token digest matches its declared payload.",
+        {"token_digest": actual_digest, "token_id": expected_id},
+    )
+
+
+def _execution_preview_digest_check(
+    token: Mapping[str, Any],
+    recovery_execution: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryApprovalTokenGateCheck:
+    if _str(recovery_execution.get("status")) != RECOVERY_EXECUTION_STATUS_READY:
+        return _fail(
+            CHECK_EXECUTION_PREVIEW_DIGEST,
+            "Current recovery execution preview is not ready.",
+            ("produce_ready_recovery_execution_preview",),
+            {"recovery_execution_status": _str(recovery_execution.get("status"))},
+        )
+    actual = _execution_preview_digest(recovery_execution)
+    expected = _str(token.get("execution_preview_digest"))
+    if not expected or actual != expected:
+        return _fail(
+            CHECK_EXECUTION_PREVIEW_DIGEST,
+            "Current recovery execution preview digest does not match the token.",
+            ("regenerate_recovery_human_approval_token_for_current_execution_preview",),
+            {
+                "expected_execution_preview_digest": expected,
+                "actual_execution_preview_digest": actual,
+            },
+        )
+    return _pass(
+        CHECK_EXECUTION_PREVIEW_DIGEST,
+        "Current recovery execution preview digest matches the token.",
+        {"execution_preview_digest": actual},
+    )
+
+
+def _future_mutation_step_check(
+    token: Mapping[str, Any],
+    recovery_execution: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryApprovalTokenGateCheck:
+    expected = _str_list(token.get("future_mutation_step_ids"))
+    actual = _future_mutation_step_ids(recovery_execution)
+    constraints = _dict(token.get("one_time_constraints"))
+    constraint_expected = _str_list(
+        constraints.get("requires_same_future_mutation_step_ids")
+    )
+    if expected != actual or (constraint_expected and constraint_expected != actual):
+        return _fail(
+            CHECK_FUTURE_MUTATION_STEPS,
+            "Current future mutation steps do not match the recovery approval token.",
+            ("regenerate_recovery_human_approval_token_for_current_execution_preview",),
+            {
+                "expected_future_mutation_step_ids": expected,
+                "constraint_future_mutation_step_ids": constraint_expected,
+                "actual_future_mutation_step_ids": actual,
+            },
+        )
+    return _pass(
+        CHECK_FUTURE_MUTATION_STEPS,
+        "Current future mutation steps match the recovery approval token.",
+        {"future_mutation_step_ids": actual},
+    )
+
+
+def _expiry_check(
+    token: Mapping[str, Any],
+    issued_at: str,
+    current_time: str | datetime | None,
+) -> MemoryEvidenceRepairRecoveryApprovalTokenGateCheck:
+    issued = _parse_datetime(issued_at)
+    now = _parse_datetime(current_time) or datetime.now(timezone.utc)
+    expires_in_minutes = _positive_int(token.get("expires_in_minutes")) or 15
+    if issued is None:
+        return _fail(
+            CHECK_RECOVERY_EXPIRY,
+            "Recovery approval token issue time is missing or invalid.",
+            ("provide_recovery_token_generated_at_or_regenerate_token",),
+            {"issued_at": issued_at},
+        )
+    expires_at = issued + timedelta(minutes=expires_in_minutes)
+    if now > expires_at:
+        return _fail(
+            CHECK_RECOVERY_EXPIRY,
+            "Recovery approval token has expired.",
+            ("regenerate_recovery_human_approval_token",),
+            {
+                "issued_at": issued.isoformat(),
+                "expires_at": expires_at.isoformat(),
+                "current_time": now.isoformat(),
+            },
+        )
+    return _pass(
+        CHECK_RECOVERY_EXPIRY,
+        "Recovery approval token is within its expiry window.",
+        {
+            "issued_at": issued.isoformat(),
+            "expires_at": expires_at.isoformat(),
+            "current_time": now.isoformat(),
+        },
+    )
+
+
+def _one_time_constraint_check(
+    token: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryApprovalTokenGateCheck:
+    constraints = _dict(token.get("one_time_constraints"))
+    if constraints.get("one_time_use") is not True:
+        return _fail(
+            CHECK_RECOVERY_ONE_TIME_CONSTRAINTS,
+            "Recovery approval token does not declare one-time-use constraints.",
+            ("regenerate_recovery_human_approval_token",),
+            {"one_time_constraints": constraints},
+        )
+    expected_execution = _str(
+        constraints.get("requires_exact_execution_preview_digest")
+    )
+    if expected_execution != _str(token.get("execution_preview_digest")):
+        return _fail(
+            CHECK_RECOVERY_ONE_TIME_CONSTRAINTS,
+            "Recovery token execution-preview constraint does not match its digest.",
+            ("regenerate_recovery_human_approval_token",),
+            {"one_time_constraints": constraints},
+        )
+    if _str(constraints.get("requires_exact_decision_id")) != _str(token.get("decision_id")):
+        return _fail(
+            CHECK_RECOVERY_ONE_TIME_CONSTRAINTS,
+            "Recovery token decision constraint does not match its decision id.",
+            ("regenerate_recovery_human_approval_token",),
+            {"one_time_constraints": constraints},
+        )
+    return _pass(
+        CHECK_RECOVERY_ONE_TIME_CONSTRAINTS,
+        "Recovery approval token one-time constraints are declared.",
+        {"one_time_constraints": constraints},
+    )
+
+
+def _reuse_check(
+    token: Mapping[str, Any],
+    used_token_ids: Sequence[str] | None,
+) -> MemoryEvidenceRepairRecoveryApprovalTokenGateCheck:
+    token_id = _str(token.get("id"))
+    used = {_str(item) for item in used_token_ids or [] if _str(item)}
+    if token_id and token_id in used:
+        return _fail(
+            CHECK_RECOVERY_REUSE,
+            "Recovery approval token is already marked as used.",
+            ("regenerate_recovery_human_approval_token",),
+            {"token_id": token_id},
+        )
+    return _pass(
+        CHECK_RECOVERY_REUSE,
+        "Recovery approval token is not marked as used in the supplied read-only ledger.",
+        {"token_id": token_id, "used_token_id_count": len(used)},
+    )
+
+
+def _expected_token_digest(token: Mapping[str, Any]) -> str:
+    token_seed = {
+        "token_type": RECOVERY_APPROVAL_TOKEN_TYPE,
+        "scope": RECOVERY_APPROVAL_TOKEN_SCOPE,
+        "approver": _str(token.get("approver")) or "human",
+        "approval_reason": _str(token.get("approval_reason")),
+        "execution_preview_digest": _str(token.get("execution_preview_digest")),
+        "execution_preview_id": _str(token.get("execution_preview_id")),
+        "decision_id": _str(token.get("decision_id")),
+        "route": _str(token.get("route")),
+        "operation_ids": _str_list(token.get("operation_ids")),
+        "failed_audit_step_ids": _str_list(token.get("failed_audit_step_ids")),
+        "step_ids": _str_list(token.get("step_ids")),
+        "future_mutation_step_ids": _str_list(token.get("future_mutation_step_ids")),
+        "expires_in_minutes": _positive_int(token.get("expires_in_minutes")) or 15,
+    }
+    return _digest(token_seed)
+
+
+def _execution_preview_digest(recovery_execution: Mapping[str, Any]) -> str:
+    existing = _str(recovery_execution.get("preview_digest"))
+    if existing:
+        return existing
+    return _digest(
+        {
+            "id": _str(recovery_execution.get("id")),
+            "route": _str(recovery_execution.get("route")),
+            "decision_id": _str(recovery_execution.get("decision_id")),
+            "operation_ids": tuple(_list_of_str(recovery_execution.get("operation_ids"))),
+            "failed_audit_step_ids": tuple(
+                _list_of_str(recovery_execution.get("failed_audit_step_ids"))
+            ),
+            "step_ids": tuple(_list_of_str(recovery_execution.get("step_ids"))),
+        }
+    )
+
+
+def _future_mutation_step_ids(recovery_execution: Mapping[str, Any]) -> list[str]:
+    return [
+        _str(step.get("id"))
+        for step in _list(recovery_execution.get("steps"))
+        if isinstance(step, Mapping) and step.get("future_would_mutate_memory") is True
+    ]
+
+
+def _pass(
+    check_id: str,
+    reason: str,
+    details: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryApprovalTokenGateCheck:
+    return MemoryEvidenceRepairRecoveryApprovalTokenGateCheck(
+        id=check_id,
+        status=CHECK_STATUS_PASS,
+        reason=reason,
+        required_actions=(),
+        details=dict(details),
+    )
+
+
+def _fail(
+    check_id: str,
+    reason: str,
+    required_actions: Sequence[str],
+    details: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryApprovalTokenGateCheck:
+    return MemoryEvidenceRepairRecoveryApprovalTokenGateCheck(
+        id=check_id,
+        status=CHECK_STATUS_FAIL,
+        reason=reason,
+        required_actions=tuple(required_actions),
+        details=dict(details),
+    )
+
+
+def _parse_datetime(value: str | datetime | None) -> datetime | None:
+    if isinstance(value, datetime):
+        return value if value.tzinfo else value.replace(tzinfo=timezone.utc)
+    if not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    return parsed if parsed.tzinfo else parsed.replace(tzinfo=timezone.utc)
+
+
+def _positive_int(value: Any) -> int | None:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed if parsed > 0 else None
+
+
+def _digest(value: Any) -> str:
+    raw = json.dumps(value, sort_keys=True, ensure_ascii=False, default=str)
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def _dict(value: Any) -> dict[str, Any]:
+    return dict(value) if isinstance(value, Mapping) else {}
+
+
+def _list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _list_of_str(value: Any) -> list[str]:
+    return [_str(item) for item in value] if isinstance(value, list) else []
+
+
+def _str_list(value: Any) -> list[str]:
+    return [_str(item) for item in value] if isinstance(value, list) else []
+
+
+def _dedupe_strings(values: Sequence[str] | Any) -> list[str]:
+    seen: set[str] = set()
+    result: list[str] = []
+    for value in values:
+        text = _str(value)
+        if text and text not in seen:
+            seen.add(text)
+            result.append(text)
+    return result
+
+
+def _str(value: Any) -> str:
+    return str(value or "").strip()

--- a/agent/memory_evidence_repair_recovery_closure_finalization_readiness_audit_preview.py
+++ b/agent/memory_evidence_repair_recovery_closure_finalization_readiness_audit_preview.py
@@ -1,0 +1,1123 @@
+"""Read-only recovery closure finalization readiness audit preview.
+
+This layer audits a recovery closure finalization readiness draft so a later
+manual finalization path can trust the gate that would allow closure. It never
+writes durable memory, records a real audit, or finalizes a recovery.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Mapping, Sequence
+
+from agent.memory_evidence_repair_manual_commit_dry_run import (
+    CHECK_STATUS_FAIL,
+    CHECK_STATUS_PASS,
+)
+from agent.memory_evidence_repair_recovery_closure_finalization_readiness_preview import (
+    RECOVERY_CLOSURE_FINALIZATION_DECISION,
+    RECOVERY_CLOSURE_FINALIZATION_DRAFT_STATUS_READY,
+    RECOVERY_CLOSURE_FINALIZATION_SCOPE,
+    RECOVERY_CLOSURE_FINALIZATION_STATUS_NO_ACTION_NEEDED,
+    RECOVERY_CLOSURE_FINALIZATION_STATUS_READY,
+    RECOVERY_CLOSURE_FINALIZATION_TYPE,
+)
+from agent.memory_evidence_repair_recovery_closure_governance_seal_audit_preview import (
+    GOVERNANCE_SEAL_AUDIT_STEP_STATUS_PASS,
+    RECOVERY_CLOSURE_GOVERNANCE_SEAL_AUDIT_PREVIEW_STATUS_READY,
+)
+from agent.memory_evidence_repair_recovery_closure_governance_seal_preview import (
+    RECOVERY_CLOSURE_GOVERNANCE_SEAL_DRAFT_STATUS_READY,
+)
+from agent.memory_evidence_repair_recovery_closure_ledger_audit_preview import (
+    LEDGER_AUDIT_STEP_STATUS_PASS,
+    RECOVERY_CLOSURE_LEDGER_AUDIT_PREVIEW_STATUS_READY,
+)
+from agent.memory_evidence_repair_recovery_closure_ledger_preview import (
+    RECOVERY_CLOSURE_LEDGER_ENTRY_STATUS_READY,
+)
+
+
+RECOVERY_CLOSURE_FINALIZATION_READINESS_AUDIT_STATUS_READY = (
+    "recovery_closure_finalization_readiness_audit_preview_ready"
+)
+RECOVERY_CLOSURE_FINALIZATION_READINESS_AUDIT_STATUS_BLOCKED = "blocked"
+RECOVERY_CLOSURE_FINALIZATION_READINESS_AUDIT_STATUS_NO_ACTION_NEEDED = (
+    "no_action_needed"
+)
+RECOVERY_CLOSURE_FINALIZATION_READINESS_AUDIT_PREVIEW_STATUS_READY = (
+    "recovery_closure_finalization_readiness_audit_ready"
+)
+
+FINALIZATION_READINESS_AUDIT_STEP_STATUS_PASS = "pass"
+FINALIZATION_READINESS_AUDIT_STEP_STATUS_FAIL = "fail"
+
+CHECK_RECOVERY_FINALIZATION_READINESS_READY = "recovery_finalization_readiness_ready"
+CHECK_RECOVERY_FINALIZATION_READINESS_INTEGRITY = (
+    "recovery_finalization_readiness_integrity"
+)
+CHECK_RECOVERY_FINALIZATION_READINESS_SOURCE_CHAIN = (
+    "recovery_finalization_readiness_source_chain"
+)
+CHECK_RECOVERY_FINALIZATION_READINESS_AUDIT_REQUIREMENTS = (
+    "recovery_finalization_readiness_audit_requirements"
+)
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairRecoveryClosureFinalizationReadinessAuditCheck:
+    """One read-only finalization readiness audit check."""
+
+    id: str
+    status: str
+    reason: str
+    required_actions: tuple[str, ...]
+    details: dict[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "status": self.status,
+            "reason": self.reason,
+            "required_actions": list(self.required_actions),
+            "details": dict(self.details),
+        }
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairRecoveryClosureFinalizationReadinessAuditStep:
+    """One structural audit step for a future finalization readiness draft."""
+
+    id: str
+    sequence: int
+    category: str
+    assertion: str
+    finalization_readiness_id: str
+    reference_id: str
+    expected_signal: dict[str, Any]
+    observed_signal: dict[str, Any]
+    status: str
+    required_action_on_fail: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "sequence": self.sequence,
+            "category": self.category,
+            "assertion": self.assertion,
+            "finalization_readiness_id": self.finalization_readiness_id,
+            "reference_id": self.reference_id,
+            "expected_signal": dict(self.expected_signal),
+            "observed_signal": dict(self.observed_signal),
+            "status": self.status,
+            "required_action_on_fail": self.required_action_on_fail,
+        }
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairRecoveryClosureFinalizationReadinessAuditPreview:
+    """One read-only recovery closure finalization readiness audit preview."""
+
+    id: str
+    status: str
+    finalization_readiness_id: str
+    seal_audit_preview_id: str
+    seal_id: str
+    ledger_audit_preview_id: str
+    ledger_entry_id: str
+    closure_id: str
+    audit_preview_id: str
+    receipt_id: str
+    executor_preview_id: str
+    decision_id: str
+    execution_preview_id: str
+    token_id: str
+    lock_id: str
+    route: str
+    operation_ids: tuple[str, ...]
+    recovery_step_ids: tuple[str, ...]
+    future_mutation_step_ids: tuple[str, ...]
+    completion_audit_step_ids: tuple[str, ...]
+    milestone_ids: tuple[str, ...]
+    ledger_audit_step_ids: tuple[str, ...]
+    seal_audit_step_ids: tuple[str, ...]
+    readiness_audit_step_ids: tuple[str, ...]
+    finalization_digest: str
+    seal_audit_digest: str
+    seal_digest: str
+    ledger_audit_digest: str
+    ledger_entry_digest: str
+    closure_digest: str
+    audit_digest: str
+    audit_preview: str
+    audit_steps: tuple[
+        MemoryEvidenceRepairRecoveryClosureFinalizationReadinessAuditStep, ...
+    ]
+    would_verify_finalization_integrity: bool
+    would_verify_manual_handoff: bool
+    would_verify_source_governance_chain: bool
+    would_verify_read_only_constraints: bool
+    safety_note: str
+    source_recovery_closure_finalization_readiness: dict[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "status": self.status,
+            "finalization_readiness_id": self.finalization_readiness_id,
+            "seal_audit_preview_id": self.seal_audit_preview_id,
+            "seal_id": self.seal_id,
+            "ledger_audit_preview_id": self.ledger_audit_preview_id,
+            "ledger_entry_id": self.ledger_entry_id,
+            "closure_id": self.closure_id,
+            "audit_preview_id": self.audit_preview_id,
+            "receipt_id": self.receipt_id,
+            "executor_preview_id": self.executor_preview_id,
+            "decision_id": self.decision_id,
+            "execution_preview_id": self.execution_preview_id,
+            "token_id": self.token_id,
+            "lock_id": self.lock_id,
+            "route": self.route,
+            "operation_ids": list(self.operation_ids),
+            "recovery_step_ids": list(self.recovery_step_ids),
+            "future_mutation_step_ids": list(self.future_mutation_step_ids),
+            "completion_audit_step_ids": list(self.completion_audit_step_ids),
+            "milestone_ids": list(self.milestone_ids),
+            "ledger_audit_step_ids": list(self.ledger_audit_step_ids),
+            "seal_audit_step_ids": list(self.seal_audit_step_ids),
+            "readiness_audit_step_ids": list(self.readiness_audit_step_ids),
+            "finalization_digest": self.finalization_digest,
+            "seal_audit_digest": self.seal_audit_digest,
+            "seal_digest": self.seal_digest,
+            "ledger_audit_digest": self.ledger_audit_digest,
+            "ledger_entry_digest": self.ledger_entry_digest,
+            "closure_digest": self.closure_digest,
+            "audit_digest": self.audit_digest,
+            "audit_preview": self.audit_preview,
+            "audit_steps": [step.to_dict() for step in self.audit_steps],
+            "would_verify_finalization_integrity": (
+                self.would_verify_finalization_integrity
+            ),
+            "would_verify_manual_handoff": self.would_verify_manual_handoff,
+            "would_verify_source_governance_chain": (
+                self.would_verify_source_governance_chain
+            ),
+            "would_verify_read_only_constraints": (
+                self.would_verify_read_only_constraints
+            ),
+            "safety_note": self.safety_note,
+            "source_recovery_closure_finalization_readiness": dict(
+                self.source_recovery_closure_finalization_readiness
+            ),
+        }
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairRecoveryClosureFinalizationReadinessAuditPreviewReport:
+    """Read-only finalization readiness audit preview report."""
+
+    generated_at: str
+    status: str
+    checks: tuple[
+        MemoryEvidenceRepairRecoveryClosureFinalizationReadinessAuditCheck, ...
+    ]
+    previews: tuple[
+        MemoryEvidenceRepairRecoveryClosureFinalizationReadinessAuditPreview, ...
+    ]
+    blocking_reasons: tuple[str, ...]
+    required_actions: tuple[str, ...]
+    source_recovery_closure_finalization_readiness_report: dict[str, Any]
+
+    @property
+    def summary(self) -> dict[str, Any]:
+        by_check_status: dict[str, int] = {}
+        by_audit_step_status: dict[str, int] = {}
+        for check in self.checks:
+            by_check_status[check.status] = by_check_status.get(check.status, 0) + 1
+        for preview in self.previews:
+            for step in preview.audit_steps:
+                by_audit_step_status[step.status] = (
+                    by_audit_step_status.get(step.status, 0) + 1
+                )
+        return {
+            "status": self.status,
+            "check_count": len(self.checks),
+            "pass_count": by_check_status.get(CHECK_STATUS_PASS, 0),
+            "fail_count": by_check_status.get(CHECK_STATUS_FAIL, 0),
+            "preview_count": len(self.previews),
+            "audit_step_count": sum(len(preview.audit_steps) for preview in self.previews),
+            "observed_pass_step_count": by_audit_step_status.get(
+                FINALIZATION_READINESS_AUDIT_STEP_STATUS_PASS,
+                0,
+            ),
+            "observed_fail_step_count": by_audit_step_status.get(
+                FINALIZATION_READINESS_AUDIT_STEP_STATUS_FAIL,
+                0,
+            ),
+            "blocking_reason_count": len(self.blocking_reasons),
+            "required_action_count": len(self.required_actions),
+            "recovery_closure_finalization_readiness_audit_preview_available": bool(
+                self.previews
+            ),
+            "recovery_closure_finalization_readiness_audit_ready": (
+                self.status
+                == RECOVERY_CLOSURE_FINALIZATION_READINESS_AUDIT_STATUS_READY
+            ),
+            "has_blocks": (
+                self.status
+                == RECOVERY_CLOSURE_FINALIZATION_READINESS_AUDIT_STATUS_BLOCKED
+            ),
+            "requires_followup": bool(self.required_actions),
+            "by_check_status": by_check_status,
+            "by_audit_step_status": by_audit_step_status,
+        }
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "generated_at": self.generated_at,
+            "status": self.status,
+            "summary": self.summary,
+            "checks": [check.to_dict() for check in self.checks],
+            "previews": [preview.to_dict() for preview in self.previews],
+            "blocking_reasons": list(self.blocking_reasons),
+            "required_actions": list(self.required_actions),
+            "source_recovery_closure_finalization_readiness_report": dict(
+                self.source_recovery_closure_finalization_readiness_report
+            ),
+            "read_only": True,
+            "read_only_memory": True,
+            "would_mutate_memory": False,
+        }
+
+
+def build_evidence_repair_recovery_closure_finalization_readiness_audit_preview(
+    *,
+    recovery_closure_finalization_readiness: Mapping[str, Any] | None = None,
+) -> MemoryEvidenceRepairRecoveryClosureFinalizationReadinessAuditPreviewReport:
+    """Build a read-only audit preview from a finalization readiness report."""
+
+    recovery_closure_finalization_readiness = (
+        recovery_closure_finalization_readiness
+        if isinstance(recovery_closure_finalization_readiness, Mapping)
+        else {}
+    )
+    report_status = _str(recovery_closure_finalization_readiness.get("status"))
+    readiness = _extract_readiness(recovery_closure_finalization_readiness)
+
+    if not readiness:
+        if (
+            not recovery_closure_finalization_readiness
+            or report_status == RECOVERY_CLOSURE_FINALIZATION_STATUS_NO_ACTION_NEEDED
+        ):
+            return _empty_report(
+                recovery_closure_finalization_readiness=(
+                    recovery_closure_finalization_readiness
+                )
+            )
+        source_blocking = tuple(
+            _list_of_str(
+                recovery_closure_finalization_readiness.get("blocking_reasons")
+            )
+        )
+        source_actions = tuple(
+            _list_of_str(
+                recovery_closure_finalization_readiness.get("required_actions")
+            )
+        )
+        return _blocked_report(
+            recovery_closure_finalization_readiness=(
+                recovery_closure_finalization_readiness
+            ),
+            checks=(
+                _fail(
+                    CHECK_RECOVERY_FINALIZATION_READINESS_READY,
+                    "No recovery closure finalization readiness draft was supplied."
+                    if not source_blocking
+                    else "; ".join(source_blocking),
+                    source_actions
+                    or ("produce_recovery_closure_finalization_readiness_preview",),
+                    {
+                        "recovery_closure_finalization_readiness_status": (
+                            report_status
+                        )
+                    },
+                ),
+            ),
+        )
+
+    checks = (
+        _readiness_ready_check(recovery_closure_finalization_readiness, readiness),
+        _readiness_integrity_check(readiness),
+        _readiness_source_chain_check(readiness),
+        _audit_requirements_check(readiness),
+    )
+    blocking_reasons = tuple(
+        _dedupe_strings(
+            check.reason for check in checks if check.status == CHECK_STATUS_FAIL
+        )
+    )
+    required_actions = tuple(
+        _dedupe_strings(
+            action
+            for check in checks
+            if check.status == CHECK_STATUS_FAIL
+            for action in check.required_actions
+        )
+    )
+    if blocking_reasons:
+        return MemoryEvidenceRepairRecoveryClosureFinalizationReadinessAuditPreviewReport(
+            generated_at=datetime.now(timezone.utc).isoformat(),
+            status=RECOVERY_CLOSURE_FINALIZATION_READINESS_AUDIT_STATUS_BLOCKED,
+            checks=checks,
+            previews=(),
+            blocking_reasons=blocking_reasons,
+            required_actions=required_actions,
+            source_recovery_closure_finalization_readiness_report=dict(
+                recovery_closure_finalization_readiness
+            ),
+        )
+
+    preview = _preview_from_readiness(readiness)
+    return MemoryEvidenceRepairRecoveryClosureFinalizationReadinessAuditPreviewReport(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        status=RECOVERY_CLOSURE_FINALIZATION_READINESS_AUDIT_STATUS_READY,
+        checks=checks,
+        previews=(preview,),
+        blocking_reasons=(),
+        required_actions=(),
+        source_recovery_closure_finalization_readiness_report=dict(
+            recovery_closure_finalization_readiness
+        ),
+    )
+
+
+def empty_evidence_repair_recovery_closure_finalization_readiness_audit_preview() -> MemoryEvidenceRepairRecoveryClosureFinalizationReadinessAuditPreviewReport:
+    """Return an empty read-only finalization readiness audit preview."""
+
+    return _empty_report(recovery_closure_finalization_readiness={})
+
+
+def _extract_readiness(
+    recovery_closure_finalization_readiness: Mapping[str, Any],
+) -> dict[str, Any]:
+    readiness = recovery_closure_finalization_readiness.get("readiness")
+    if isinstance(readiness, list):
+        for item in readiness:
+            if isinstance(item, Mapping):
+                return dict(item)
+    if _str(recovery_closure_finalization_readiness.get("id")).startswith(
+        "recovery-closure-finalization-readiness-"
+    ):
+        return dict(recovery_closure_finalization_readiness)
+    return {}
+
+
+def _readiness_ready_check(
+    recovery_closure_finalization_readiness: Mapping[str, Any],
+    readiness: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryClosureFinalizationReadinessAuditCheck:
+    report_status = _str(recovery_closure_finalization_readiness.get("status"))
+    readiness_status = _str(readiness.get("status"))
+    if report_status and report_status != RECOVERY_CLOSURE_FINALIZATION_STATUS_READY:
+        return _fail(
+            CHECK_RECOVERY_FINALIZATION_READINESS_READY,
+            "Recovery closure finalization readiness report is not ready for audit preview.",
+            tuple(
+                _list_of_str(
+                    recovery_closure_finalization_readiness.get("required_actions")
+                )
+            )
+            or ("produce_ready_recovery_closure_finalization_readiness_preview",),
+            {"report_status": report_status, "readiness_status": readiness_status},
+        )
+    if readiness_status != RECOVERY_CLOSURE_FINALIZATION_DRAFT_STATUS_READY:
+        return _fail(
+            CHECK_RECOVERY_FINALIZATION_READINESS_READY,
+            "Recovery closure finalization readiness draft is not ready for audit preview.",
+            ("regenerate_recovery_closure_finalization_readiness_preview",),
+            {"report_status": report_status, "readiness_status": readiness_status},
+        )
+    return _pass(
+        CHECK_RECOVERY_FINALIZATION_READINESS_READY,
+        "Recovery closure finalization readiness draft is ready for audit preview.",
+        {"finalization_readiness_id": _str(readiness.get("id"))},
+    )
+
+
+def _readiness_integrity_check(
+    readiness: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryClosureFinalizationReadinessAuditCheck:
+    expected_digest = _expected_finalization_digest(readiness)
+    actual_digest = _str(readiness.get("finalization_digest"))
+    expected_id = (
+        f"recovery-closure-finalization-readiness-{expected_digest[:16]}"
+        if expected_digest
+        else ""
+    )
+    missing_fields: list[str] = []
+    for field_name in (
+        "id",
+        "finalization_type",
+        "status",
+        "finalization_decision",
+        "finalization_scope",
+        "seal_audit_preview_id",
+        "seal_id",
+        "ledger_audit_preview_id",
+        "ledger_entry_id",
+        "closure_id",
+        "audit_preview_id",
+        "receipt_id",
+        "executor_preview_id",
+        "decision_id",
+        "execution_preview_id",
+        "token_id",
+        "lock_id",
+        "route",
+        "operation_ids",
+        "recovery_step_ids",
+        "future_mutation_step_ids",
+        "completion_audit_step_ids",
+        "milestone_ids",
+        "ledger_audit_step_ids",
+        "seal_audit_step_ids",
+        "seal_digest",
+        "seal_audit_digest",
+        "ledger_audit_digest",
+        "ledger_entry_digest",
+        "closure_digest",
+        "finalization_digest",
+        "source_recovery_closure_governance_seal_audit_preview",
+    ):
+        value = readiness.get(field_name)
+        if isinstance(value, list) and not value:
+            missing_fields.append(field_name)
+        elif isinstance(value, Mapping) and not value:
+            missing_fields.append(field_name)
+        elif not isinstance(value, (list, Mapping)) and not _str(value):
+            missing_fields.append(field_name)
+    if (
+        missing_fields
+        or actual_digest != expected_digest
+        or _str(readiness.get("id")) != expected_id
+        or _str(readiness.get("finalization_type"))
+        != RECOVERY_CLOSURE_FINALIZATION_TYPE
+        or _str(readiness.get("finalization_decision"))
+        != RECOVERY_CLOSURE_FINALIZATION_DECISION
+        or _str(readiness.get("finalization_scope"))
+        != RECOVERY_CLOSURE_FINALIZATION_SCOPE
+    ):
+        return _fail(
+            CHECK_RECOVERY_FINALIZATION_READINESS_INTEGRITY,
+            "Recovery closure finalization readiness digest, id, type, scope, or required fields are invalid.",
+            ("regenerate_recovery_closure_finalization_readiness_preview",),
+            {
+                "expected_finalization_digest": expected_digest,
+                "actual_finalization_digest": actual_digest,
+                "expected_finalization_readiness_id": expected_id,
+                "actual_finalization_readiness_id": _str(readiness.get("id")),
+                "missing_fields": missing_fields,
+            },
+        )
+    return _pass(
+        CHECK_RECOVERY_FINALIZATION_READINESS_INTEGRITY,
+        "Recovery closure finalization readiness integrity checks pass.",
+        {
+            "finalization_readiness_id": expected_id,
+            "finalization_digest": actual_digest,
+        },
+    )
+
+
+def _readiness_source_chain_check(
+    readiness: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryClosureFinalizationReadinessAuditCheck:
+    seal_audit = _dict(
+        readiness.get("source_recovery_closure_governance_seal_audit_preview")
+    )
+    seal = _dict(seal_audit.get("source_recovery_closure_governance_seal"))
+    ledger_audit = _dict(seal.get("source_recovery_closure_ledger_audit_preview"))
+    entry = _dict(ledger_audit.get("source_recovery_closure_ledger_entry"))
+    missing_sources = [
+        name
+        for name, source in (
+            ("source_recovery_closure_governance_seal_audit_preview", seal_audit),
+            ("source_recovery_closure_governance_seal", seal),
+            ("source_recovery_closure_ledger_audit_preview", ledger_audit),
+            ("source_recovery_closure_ledger_entry", entry),
+        )
+        if not source
+    ]
+    mismatches: list[dict[str, str]] = []
+    for field_name in (
+        "seal_audit_preview_id",
+        "seal_id",
+        "ledger_audit_preview_id",
+        "ledger_entry_id",
+        "closure_id",
+        "audit_preview_id",
+        "receipt_id",
+        "executor_preview_id",
+        "decision_id",
+        "execution_preview_id",
+        "token_id",
+        "lock_id",
+        "route",
+        "seal_digest",
+        "seal_audit_digest",
+        "ledger_audit_digest",
+        "ledger_entry_digest",
+        "closure_digest",
+    ):
+        source_key = "id" if field_name == "seal_audit_preview_id" else field_name
+        if field_name == "seal_audit_digest":
+            source_key = "audit_digest"
+        _compare(mismatches, field_name, readiness, field_name, seal_audit, source_key)
+    if _str(readiness.get("seal_id")) != _str(seal.get("id")):
+        mismatches.append(
+            {
+                "field": "seal_id",
+                "left": _str(readiness.get("seal_id")),
+                "right": _str(seal.get("id")),
+                "right_key": "source_recovery_closure_governance_seal.id",
+            }
+        )
+    if _str(readiness.get("ledger_audit_preview_id")) != _str(ledger_audit.get("id")):
+        mismatches.append(
+            {
+                "field": "ledger_audit_preview_id",
+                "left": _str(readiness.get("ledger_audit_preview_id")),
+                "right": _str(ledger_audit.get("id")),
+                "right_key": "source_recovery_closure_ledger_audit_preview.id",
+            }
+        )
+    if _str(readiness.get("ledger_entry_id")) != _str(entry.get("id")):
+        mismatches.append(
+            {
+                "field": "ledger_entry_id",
+                "left": _str(readiness.get("ledger_entry_id")),
+                "right": _str(entry.get("id")),
+                "right_key": "source_recovery_closure_ledger_entry.id",
+            }
+        )
+    seal_audit_steps = _audit_steps(seal_audit)
+    ledger_audit_steps = _audit_steps(ledger_audit)
+    non_pass_seal_audit_steps = [
+        _str(step.get("id")) or f"seal-audit-step-{index}"
+        for index, step in enumerate(seal_audit_steps, start=1)
+        if _str(step.get("status")) != GOVERNANCE_SEAL_AUDIT_STEP_STATUS_PASS
+    ]
+    non_pass_ledger_audit_steps = [
+        _str(step.get("id")) or f"ledger-audit-step-{index}"
+        for index, step in enumerate(ledger_audit_steps, start=1)
+        if _str(step.get("status")) != LEDGER_AUDIT_STEP_STATUS_PASS
+    ]
+    if (
+        missing_sources
+        or mismatches
+        or _str(seal_audit.get("status"))
+        != RECOVERY_CLOSURE_GOVERNANCE_SEAL_AUDIT_PREVIEW_STATUS_READY
+        or _str(seal.get("status")) != RECOVERY_CLOSURE_GOVERNANCE_SEAL_DRAFT_STATUS_READY
+        or _str(ledger_audit.get("status"))
+        != RECOVERY_CLOSURE_LEDGER_AUDIT_PREVIEW_STATUS_READY
+        or _str(entry.get("status")) != RECOVERY_CLOSURE_LEDGER_ENTRY_STATUS_READY
+        or non_pass_seal_audit_steps
+        or non_pass_ledger_audit_steps
+    ):
+        return _fail(
+            CHECK_RECOVERY_FINALIZATION_READINESS_SOURCE_CHAIN,
+            "Recovery closure finalization readiness source chain is incomplete or inconsistent.",
+            ("regenerate_recovery_closure_finalization_readiness_preview",),
+            {
+                "missing_sources": missing_sources,
+                "mismatches": mismatches,
+                "seal_audit_status": _str(seal_audit.get("status")),
+                "seal_status": _str(seal.get("status")),
+                "ledger_audit_status": _str(ledger_audit.get("status")),
+                "entry_status": _str(entry.get("status")),
+                "non_pass_seal_audit_step_ids": non_pass_seal_audit_steps,
+                "non_pass_ledger_audit_step_ids": non_pass_ledger_audit_steps,
+            },
+        )
+    return _pass(
+        CHECK_RECOVERY_FINALIZATION_READINESS_SOURCE_CHAIN,
+        "Recovery closure finalization readiness source chain preserves finalization, seal audit, seal, ledger audit, and ledger evidence.",
+        {
+            "finalization_readiness_id": _str(readiness.get("id")),
+            "seal_audit_preview_id": _str(readiness.get("seal_audit_preview_id")),
+            "seal_id": _str(readiness.get("seal_id")),
+            "ledger_audit_preview_id": _str(readiness.get("ledger_audit_preview_id")),
+            "seal_audit_step_count": len(seal_audit_steps),
+            "ledger_audit_step_count": len(ledger_audit_steps),
+        },
+    )
+
+
+def _audit_requirements_check(
+    readiness: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryClosureFinalizationReadinessAuditCheck:
+    required_readiness_flags = (
+        "would_allow_final_closure",
+        "would_preserve_full_governance_chain",
+        "would_require_human_finalization",
+        "would_keep_read_only_until_manual_commit",
+    )
+    missing_readiness_flags = [
+        field_name
+        for field_name in required_readiness_flags
+        if readiness.get(field_name) is not True
+    ]
+    missing_lists = [
+        field_name
+        for field_name in (
+            "operation_ids",
+            "recovery_step_ids",
+            "future_mutation_step_ids",
+            "completion_audit_step_ids",
+            "milestone_ids",
+            "ledger_audit_step_ids",
+            "seal_audit_step_ids",
+        )
+        if not _list_of_str(readiness.get(field_name))
+    ]
+    seal_audit = _dict(
+        readiness.get("source_recovery_closure_governance_seal_audit_preview")
+    )
+    source_flags = (
+        "would_verify_seal_integrity",
+        "would_verify_governance_handoff",
+        "would_verify_source_audit_evidence",
+        "would_verify_read_only_constraints",
+    )
+    missing_source_flags = [
+        field_name
+        for field_name in source_flags
+        if seal_audit.get(field_name) is not True
+    ]
+    categories = {_str(step.get("category")) for step in _audit_steps(seal_audit)}
+    required_categories = {
+        "seal_integrity",
+        "ledger_audit_source",
+        "ledger_entry_source",
+        "closure_trace",
+        "governance_controls",
+        "read_only",
+    }
+    missing_categories = sorted(required_categories - categories)
+    if (
+        missing_readiness_flags
+        or missing_lists
+        or missing_source_flags
+        or missing_categories
+    ):
+        return _fail(
+            CHECK_RECOVERY_FINALIZATION_READINESS_AUDIT_REQUIREMENTS,
+            "Recovery closure finalization readiness audit requirements are incomplete.",
+            ("regenerate_recovery_closure_finalization_readiness_preview",),
+            {
+                "missing_readiness_flags": missing_readiness_flags,
+                "missing_lists": missing_lists,
+                "missing_source_flags": missing_source_flags,
+                "missing_categories": missing_categories,
+            },
+        )
+    return _pass(
+        CHECK_RECOVERY_FINALIZATION_READINESS_AUDIT_REQUIREMENTS,
+        "Recovery closure finalization readiness audit can verify integrity, manual handoff, source governance chain, and read-only constraints.",
+        {
+            "seal_audit_step_count": len(_audit_steps(seal_audit)),
+            "milestone_count": len(_list_of_str(readiness.get("milestone_ids"))),
+        },
+    )
+
+
+def _preview_from_readiness(
+    readiness: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryClosureFinalizationReadinessAuditPreview:
+    audit_steps = tuple(_audit_steps_from_readiness(readiness))
+    readiness_audit_step_ids = tuple(step.id for step in audit_steps)
+    operation_ids = tuple(_list_of_str(readiness.get("operation_ids")))
+    recovery_step_ids = tuple(_list_of_str(readiness.get("recovery_step_ids")))
+    future_mutation_step_ids = tuple(
+        _list_of_str(readiness.get("future_mutation_step_ids"))
+    )
+    completion_audit_step_ids = tuple(
+        _list_of_str(readiness.get("completion_audit_step_ids"))
+    )
+    milestone_ids = tuple(_list_of_str(readiness.get("milestone_ids")))
+    ledger_audit_step_ids = tuple(_list_of_str(readiness.get("ledger_audit_step_ids")))
+    seal_audit_step_ids = tuple(_list_of_str(readiness.get("seal_audit_step_ids")))
+    audit_seed = {
+        "finalization_readiness_id": _str(readiness.get("id")),
+        "seal_audit_preview_id": _str(readiness.get("seal_audit_preview_id")),
+        "seal_id": _str(readiness.get("seal_id")),
+        "ledger_audit_preview_id": _str(readiness.get("ledger_audit_preview_id")),
+        "ledger_entry_id": _str(readiness.get("ledger_entry_id")),
+        "closure_id": _str(readiness.get("closure_id")),
+        "audit_preview_id": _str(readiness.get("audit_preview_id")),
+        "receipt_id": _str(readiness.get("receipt_id")),
+        "executor_preview_id": _str(readiness.get("executor_preview_id")),
+        "decision_id": _str(readiness.get("decision_id")),
+        "execution_preview_id": _str(readiness.get("execution_preview_id")),
+        "token_id": _str(readiness.get("token_id")),
+        "lock_id": _str(readiness.get("lock_id")),
+        "route": _str(readiness.get("route")),
+        "operation_ids": operation_ids,
+        "recovery_step_ids": recovery_step_ids,
+        "future_mutation_step_ids": future_mutation_step_ids,
+        "completion_audit_step_ids": completion_audit_step_ids,
+        "milestone_ids": milestone_ids,
+        "ledger_audit_step_ids": ledger_audit_step_ids,
+        "seal_audit_step_ids": seal_audit_step_ids,
+        "readiness_audit_step_ids": readiness_audit_step_ids,
+        "finalization_digest": _str(readiness.get("finalization_digest")),
+        "seal_audit_digest": _str(readiness.get("seal_audit_digest")),
+        "seal_digest": _str(readiness.get("seal_digest")),
+        "ledger_audit_digest": _str(readiness.get("ledger_audit_digest")),
+        "ledger_entry_digest": _str(readiness.get("ledger_entry_digest")),
+        "closure_digest": _str(readiness.get("closure_digest")),
+    }
+    audit_digest = _digest(audit_seed)
+    audit_id = f"recovery-closure-finalization-readiness-audit-{audit_digest[:16]}"
+    return MemoryEvidenceRepairRecoveryClosureFinalizationReadinessAuditPreview(
+        id=audit_id,
+        status=RECOVERY_CLOSURE_FINALIZATION_READINESS_AUDIT_PREVIEW_STATUS_READY,
+        finalization_readiness_id=_str(readiness.get("id")),
+        seal_audit_preview_id=_str(readiness.get("seal_audit_preview_id")),
+        seal_id=_str(readiness.get("seal_id")),
+        ledger_audit_preview_id=_str(readiness.get("ledger_audit_preview_id")),
+        ledger_entry_id=_str(readiness.get("ledger_entry_id")),
+        closure_id=_str(readiness.get("closure_id")),
+        audit_preview_id=_str(readiness.get("audit_preview_id")),
+        receipt_id=_str(readiness.get("receipt_id")),
+        executor_preview_id=_str(readiness.get("executor_preview_id")),
+        decision_id=_str(readiness.get("decision_id")),
+        execution_preview_id=_str(readiness.get("execution_preview_id")),
+        token_id=_str(readiness.get("token_id")),
+        lock_id=_str(readiness.get("lock_id")),
+        route=_str(readiness.get("route")),
+        operation_ids=operation_ids,
+        recovery_step_ids=recovery_step_ids,
+        future_mutation_step_ids=future_mutation_step_ids,
+        completion_audit_step_ids=completion_audit_step_ids,
+        milestone_ids=milestone_ids,
+        ledger_audit_step_ids=ledger_audit_step_ids,
+        seal_audit_step_ids=seal_audit_step_ids,
+        readiness_audit_step_ids=readiness_audit_step_ids,
+        finalization_digest=_str(readiness.get("finalization_digest")),
+        seal_audit_digest=_str(readiness.get("seal_audit_digest")),
+        seal_digest=_str(readiness.get("seal_digest")),
+        ledger_audit_digest=_str(readiness.get("ledger_audit_digest")),
+        ledger_entry_digest=_str(readiness.get("ledger_entry_digest")),
+        closure_digest=_str(readiness.get("closure_digest")),
+        audit_digest=audit_digest,
+        audit_preview=f"{audit_id}:{audit_digest[:12]}",
+        audit_steps=audit_steps,
+        would_verify_finalization_integrity=True,
+        would_verify_manual_handoff=True,
+        would_verify_source_governance_chain=True,
+        would_verify_read_only_constraints=True,
+        safety_note=(
+            "Read-only recovery closure finalization readiness audit preview. "
+            "It verifies that a future manual finalization gate is traceable "
+            "and guarded, but does not record an audit or mutate durable memory."
+        ),
+        source_recovery_closure_finalization_readiness=dict(readiness),
+    )
+
+
+def _audit_steps_from_readiness(
+    readiness: Mapping[str, Any],
+) -> list[MemoryEvidenceRepairRecoveryClosureFinalizationReadinessAuditStep]:
+    seal_audit = _dict(
+        readiness.get("source_recovery_closure_governance_seal_audit_preview")
+    )
+    rows = (
+        (
+            "finalization_integrity",
+            "finalization_digest_valid",
+            _str(readiness.get("id")),
+            {"expected_finalization_digest": _expected_finalization_digest(readiness)},
+            {"actual_finalization_digest": _str(readiness.get("finalization_digest"))},
+        ),
+        (
+            "seal_audit_source",
+            "seal_audit_digest_consistent",
+            _str(readiness.get("seal_audit_preview_id")),
+            {"seal_audit_digest": _str(readiness.get("seal_audit_digest"))},
+            {"source_seal_audit_digest": _str(seal_audit.get("audit_digest"))},
+        ),
+        (
+            "governance_seal_source",
+            "governance_seal_digest_consistent",
+            _str(readiness.get("seal_id")),
+            {"seal_digest": _str(readiness.get("seal_digest"))},
+            {"source_seal_digest": _str(seal_audit.get("seal_digest"))},
+        ),
+        (
+            "ledger_audit_source",
+            "ledger_audit_digest_consistent",
+            _str(readiness.get("ledger_audit_preview_id")),
+            {"ledger_audit_digest": _str(readiness.get("ledger_audit_digest"))},
+            {"source_ledger_audit_digest": _str(seal_audit.get("ledger_audit_digest"))},
+        ),
+        (
+            "manual_handoff",
+            "human_finalization_required",
+            _str(readiness.get("id")),
+            {"would_require_human_finalization": True},
+            {
+                "would_require_human_finalization": readiness.get(
+                    "would_require_human_finalization"
+                )
+                is True
+            },
+        ),
+        (
+            "read_only",
+            "finalization_readiness_is_preview_only",
+            _str(readiness.get("id")),
+            {"would_keep_read_only_until_manual_commit": True},
+            {
+                "would_keep_read_only_until_manual_commit": readiness.get(
+                    "would_keep_read_only_until_manual_commit"
+                )
+                is True
+            },
+        ),
+    )
+    return [
+        _audit_step(
+            sequence=index,
+            category=category,
+            assertion=assertion,
+            readiness=readiness,
+            reference_id=reference_id,
+            expected_signal=expected_signal,
+            observed_signal=observed_signal,
+        )
+        for index, (
+            category,
+            assertion,
+            reference_id,
+            expected_signal,
+            observed_signal,
+        ) in enumerate(rows, start=1)
+    ]
+
+
+def _audit_step(
+    *,
+    sequence: int,
+    category: str,
+    assertion: str,
+    readiness: Mapping[str, Any],
+    reference_id: str,
+    expected_signal: Mapping[str, Any],
+    observed_signal: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryClosureFinalizationReadinessAuditStep:
+    step_seed = {
+        "sequence": sequence,
+        "category": category,
+        "assertion": assertion,
+        "finalization_readiness_id": _str(readiness.get("id")),
+        "reference_id": _str(reference_id),
+    }
+    step_id = f"recovery-closure-finalization-readiness-audit-step-{_digest(step_seed)[:16]}"
+    return MemoryEvidenceRepairRecoveryClosureFinalizationReadinessAuditStep(
+        id=step_id,
+        sequence=sequence,
+        category=category,
+        assertion=assertion,
+        finalization_readiness_id=_str(readiness.get("id")),
+        reference_id=_str(reference_id),
+        expected_signal=dict(expected_signal),
+        observed_signal=dict(observed_signal),
+        status=FINALIZATION_READINESS_AUDIT_STEP_STATUS_PASS,
+        required_action_on_fail=(
+            "regenerate_recovery_closure_finalization_readiness_preview"
+        ),
+    )
+
+
+def _expected_finalization_digest(readiness: Mapping[str, Any]) -> str:
+    seed = {
+        "finalization_type": RECOVERY_CLOSURE_FINALIZATION_TYPE,
+        "finalization_decision": RECOVERY_CLOSURE_FINALIZATION_DECISION,
+        "finalization_scope": RECOVERY_CLOSURE_FINALIZATION_SCOPE,
+        "seal_audit_preview_id": _str(readiness.get("seal_audit_preview_id")),
+        "seal_id": _str(readiness.get("seal_id")),
+        "ledger_audit_preview_id": _str(readiness.get("ledger_audit_preview_id")),
+        "ledger_entry_id": _str(readiness.get("ledger_entry_id")),
+        "closure_id": _str(readiness.get("closure_id")),
+        "audit_preview_id": _str(readiness.get("audit_preview_id")),
+        "receipt_id": _str(readiness.get("receipt_id")),
+        "executor_preview_id": _str(readiness.get("executor_preview_id")),
+        "decision_id": _str(readiness.get("decision_id")),
+        "execution_preview_id": _str(readiness.get("execution_preview_id")),
+        "token_id": _str(readiness.get("token_id")),
+        "lock_id": _str(readiness.get("lock_id")),
+        "route": _str(readiness.get("route")),
+        "operation_ids": tuple(_list_of_str(readiness.get("operation_ids"))),
+        "recovery_step_ids": tuple(_list_of_str(readiness.get("recovery_step_ids"))),
+        "future_mutation_step_ids": tuple(
+            _list_of_str(readiness.get("future_mutation_step_ids"))
+        ),
+        "completion_audit_step_ids": tuple(
+            _list_of_str(readiness.get("completion_audit_step_ids"))
+        ),
+        "milestone_ids": tuple(_list_of_str(readiness.get("milestone_ids"))),
+        "ledger_audit_step_ids": tuple(
+            _list_of_str(readiness.get("ledger_audit_step_ids"))
+        ),
+        "seal_audit_step_ids": tuple(
+            _list_of_str(readiness.get("seal_audit_step_ids"))
+        ),
+        "seal_digest": _str(readiness.get("seal_digest")),
+        "seal_audit_digest": _str(readiness.get("seal_audit_digest")),
+        "ledger_audit_digest": _str(readiness.get("ledger_audit_digest")),
+        "ledger_entry_digest": _str(readiness.get("ledger_entry_digest")),
+        "closure_digest": _str(readiness.get("closure_digest")),
+    }
+    return _digest(seed)
+
+
+def _audit_steps(preview: Mapping[str, Any]) -> list[Mapping[str, Any]]:
+    return [
+        step
+        for step in _list(preview.get("audit_steps"))
+        if isinstance(step, Mapping)
+    ]
+
+
+def _compare(
+    mismatches: list[dict[str, str]],
+    label: str,
+    left: Mapping[str, Any],
+    left_key: str,
+    right: Mapping[str, Any],
+    right_key: str,
+) -> None:
+    left_value = _str(left.get(left_key))
+    right_value = _str(right.get(right_key))
+    if left_value != right_value:
+        mismatches.append(
+            {
+                "field": label,
+                "left": left_value,
+                "right": right_value,
+                "right_key": right_key,
+            }
+        )
+
+
+def _empty_report(
+    *,
+    recovery_closure_finalization_readiness: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryClosureFinalizationReadinessAuditPreviewReport:
+    return MemoryEvidenceRepairRecoveryClosureFinalizationReadinessAuditPreviewReport(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        status=RECOVERY_CLOSURE_FINALIZATION_READINESS_AUDIT_STATUS_NO_ACTION_NEEDED,
+        checks=(),
+        previews=(),
+        blocking_reasons=(),
+        required_actions=(),
+        source_recovery_closure_finalization_readiness_report=dict(
+            recovery_closure_finalization_readiness
+        ),
+    )
+
+
+def _blocked_report(
+    *,
+    recovery_closure_finalization_readiness: Mapping[str, Any],
+    checks: tuple[
+        MemoryEvidenceRepairRecoveryClosureFinalizationReadinessAuditCheck, ...
+    ],
+) -> MemoryEvidenceRepairRecoveryClosureFinalizationReadinessAuditPreviewReport:
+    return MemoryEvidenceRepairRecoveryClosureFinalizationReadinessAuditPreviewReport(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        status=RECOVERY_CLOSURE_FINALIZATION_READINESS_AUDIT_STATUS_BLOCKED,
+        checks=checks,
+        previews=(),
+        blocking_reasons=tuple(
+            _dedupe_strings(
+                check.reason for check in checks if check.status == CHECK_STATUS_FAIL
+            )
+        ),
+        required_actions=tuple(
+            _dedupe_strings(
+                action
+                for check in checks
+                if check.status == CHECK_STATUS_FAIL
+                for action in check.required_actions
+            )
+        ),
+        source_recovery_closure_finalization_readiness_report=dict(
+            recovery_closure_finalization_readiness
+        ),
+    )
+
+
+def _pass(
+    check_id: str,
+    reason: str,
+    details: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryClosureFinalizationReadinessAuditCheck:
+    return MemoryEvidenceRepairRecoveryClosureFinalizationReadinessAuditCheck(
+        id=check_id,
+        status=CHECK_STATUS_PASS,
+        reason=reason,
+        required_actions=(),
+        details=dict(details),
+    )
+
+
+def _fail(
+    check_id: str,
+    reason: str,
+    required_actions: Sequence[str],
+    details: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryClosureFinalizationReadinessAuditCheck:
+    return MemoryEvidenceRepairRecoveryClosureFinalizationReadinessAuditCheck(
+        id=check_id,
+        status=CHECK_STATUS_FAIL,
+        reason=reason,
+        required_actions=tuple(required_actions),
+        details=dict(details),
+    )
+
+
+def _digest(value: Any) -> str:
+    raw = json.dumps(value, sort_keys=True, ensure_ascii=False, default=str)
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def _dict(value: Any) -> dict[str, Any]:
+    return dict(value) if isinstance(value, Mapping) else {}
+
+
+def _list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _list_of_str(value: Any) -> list[str]:
+    return [_str(item) for item in value] if isinstance(value, list) else []
+
+
+def _dedupe_strings(values: Sequence[str] | Any) -> list[str]:
+    seen: set[str] = set()
+    result: list[str] = []
+    for value in values:
+        text = _str(value)
+        if text and text not in seen:
+            seen.add(text)
+            result.append(text)
+    return result
+
+
+def _str(value: Any) -> str:
+    return str(value or "").strip()

--- a/agent/memory_evidence_repair_recovery_closure_finalization_readiness_preview.py
+++ b/agent/memory_evidence_repair_recovery_closure_finalization_readiness_preview.py
@@ -1,0 +1,938 @@
+"""Read-only recovery closure finalization readiness preview.
+
+This layer aggregates the closure, ledger, ledger audit, governance seal, and
+seal audit into a final readiness gate for a future manual closure. It never
+finalizes a recovery, writes durable memory, or freezes real state.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Mapping, Sequence
+
+from agent.memory_evidence_repair_manual_commit_dry_run import (
+    CHECK_STATUS_FAIL,
+    CHECK_STATUS_PASS,
+)
+from agent.memory_evidence_repair_recovery_closure_governance_seal_audit_preview import (
+    GOVERNANCE_SEAL_AUDIT_STEP_STATUS_PASS,
+    RECOVERY_CLOSURE_GOVERNANCE_SEAL_AUDIT_PREVIEW_STATUS_READY,
+    RECOVERY_CLOSURE_GOVERNANCE_SEAL_AUDIT_STATUS_NO_ACTION_NEEDED,
+    RECOVERY_CLOSURE_GOVERNANCE_SEAL_AUDIT_STATUS_READY,
+)
+from agent.memory_evidence_repair_recovery_closure_governance_seal_preview import (
+    RECOVERY_CLOSURE_GOVERNANCE_SEAL_DRAFT_STATUS_READY,
+)
+from agent.memory_evidence_repair_recovery_closure_ledger_audit_preview import (
+    LEDGER_AUDIT_STEP_STATUS_PASS,
+    RECOVERY_CLOSURE_LEDGER_AUDIT_PREVIEW_STATUS_READY,
+)
+from agent.memory_evidence_repair_recovery_closure_ledger_preview import (
+    RECOVERY_CLOSURE_LEDGER_ENTRY_STATUS_READY,
+)
+
+
+RECOVERY_CLOSURE_FINALIZATION_STATUS_READY = (
+    "recovery_closure_finalization_readiness_preview_ready"
+)
+RECOVERY_CLOSURE_FINALIZATION_STATUS_BLOCKED = "blocked"
+RECOVERY_CLOSURE_FINALIZATION_STATUS_NO_ACTION_NEEDED = "no_action_needed"
+RECOVERY_CLOSURE_FINALIZATION_DRAFT_STATUS_READY = (
+    "recovery_closure_finalization_readiness_ready"
+)
+RECOVERY_CLOSURE_FINALIZATION_TYPE = (
+    "memory_evidence_repair_recovery_closure_finalization_readiness"
+)
+RECOVERY_CLOSURE_FINALIZATION_DECISION = "ready_for_final_closure"
+RECOVERY_CLOSURE_FINALIZATION_SCOPE = (
+    "manual_memory_evidence_repair_recovery_finalization"
+)
+
+CHECK_RECOVERY_GOVERNANCE_SEAL_AUDIT_READY = (
+    "recovery_governance_seal_audit_ready"
+)
+CHECK_RECOVERY_GOVERNANCE_SEAL_AUDIT_INTEGRITY = (
+    "recovery_governance_seal_audit_integrity"
+)
+CHECK_RECOVERY_FINALIZATION_SOURCE_CHAIN = "recovery_finalization_source_chain"
+CHECK_RECOVERY_FINALIZATION_REQUIREMENTS = "recovery_finalization_requirements"
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairRecoveryClosureFinalizationReadinessCheck:
+    """One read-only finalization readiness check."""
+
+    id: str
+    status: str
+    reason: str
+    required_actions: tuple[str, ...]
+    details: dict[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "status": self.status,
+            "reason": self.reason,
+            "required_actions": list(self.required_actions),
+            "details": dict(self.details),
+        }
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairRecoveryClosureFinalizationReadinessPreview:
+    """One read-only future finalization readiness draft."""
+
+    id: str
+    finalization_type: str
+    status: str
+    finalization_decision: str
+    finalization_scope: str
+    seal_audit_preview_id: str
+    seal_id: str
+    ledger_audit_preview_id: str
+    ledger_entry_id: str
+    closure_id: str
+    audit_preview_id: str
+    receipt_id: str
+    executor_preview_id: str
+    decision_id: str
+    execution_preview_id: str
+    token_id: str
+    lock_id: str
+    route: str
+    operation_ids: tuple[str, ...]
+    recovery_step_ids: tuple[str, ...]
+    future_mutation_step_ids: tuple[str, ...]
+    completion_audit_step_ids: tuple[str, ...]
+    milestone_ids: tuple[str, ...]
+    ledger_audit_step_ids: tuple[str, ...]
+    seal_audit_step_ids: tuple[str, ...]
+    seal_digest: str
+    seal_audit_digest: str
+    ledger_audit_digest: str
+    ledger_entry_digest: str
+    closure_digest: str
+    finalization_digest: str
+    finalization_preview: str
+    would_allow_final_closure: bool
+    would_preserve_full_governance_chain: bool
+    would_require_human_finalization: bool
+    would_keep_read_only_until_manual_commit: bool
+    safety_note: str
+    source_recovery_closure_governance_seal_audit_preview: dict[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "finalization_type": self.finalization_type,
+            "status": self.status,
+            "finalization_decision": self.finalization_decision,
+            "finalization_scope": self.finalization_scope,
+            "seal_audit_preview_id": self.seal_audit_preview_id,
+            "seal_id": self.seal_id,
+            "ledger_audit_preview_id": self.ledger_audit_preview_id,
+            "ledger_entry_id": self.ledger_entry_id,
+            "closure_id": self.closure_id,
+            "audit_preview_id": self.audit_preview_id,
+            "receipt_id": self.receipt_id,
+            "executor_preview_id": self.executor_preview_id,
+            "decision_id": self.decision_id,
+            "execution_preview_id": self.execution_preview_id,
+            "token_id": self.token_id,
+            "lock_id": self.lock_id,
+            "route": self.route,
+            "operation_ids": list(self.operation_ids),
+            "recovery_step_ids": list(self.recovery_step_ids),
+            "future_mutation_step_ids": list(self.future_mutation_step_ids),
+            "completion_audit_step_ids": list(self.completion_audit_step_ids),
+            "milestone_ids": list(self.milestone_ids),
+            "ledger_audit_step_ids": list(self.ledger_audit_step_ids),
+            "seal_audit_step_ids": list(self.seal_audit_step_ids),
+            "seal_digest": self.seal_digest,
+            "seal_audit_digest": self.seal_audit_digest,
+            "ledger_audit_digest": self.ledger_audit_digest,
+            "ledger_entry_digest": self.ledger_entry_digest,
+            "closure_digest": self.closure_digest,
+            "finalization_digest": self.finalization_digest,
+            "finalization_preview": self.finalization_preview,
+            "would_allow_final_closure": self.would_allow_final_closure,
+            "would_preserve_full_governance_chain": (
+                self.would_preserve_full_governance_chain
+            ),
+            "would_require_human_finalization": self.would_require_human_finalization,
+            "would_keep_read_only_until_manual_commit": (
+                self.would_keep_read_only_until_manual_commit
+            ),
+            "safety_note": self.safety_note,
+            "source_recovery_closure_governance_seal_audit_preview": dict(
+                self.source_recovery_closure_governance_seal_audit_preview
+            ),
+        }
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairRecoveryClosureFinalizationReadinessPreviewReport:
+    """Read-only finalization readiness preview report."""
+
+    generated_at: str
+    status: str
+    checks: tuple[MemoryEvidenceRepairRecoveryClosureFinalizationReadinessCheck, ...]
+    readiness: tuple[
+        MemoryEvidenceRepairRecoveryClosureFinalizationReadinessPreview, ...
+    ]
+    blocking_reasons: tuple[str, ...]
+    required_actions: tuple[str, ...]
+    source_recovery_closure_governance_seal_audit_report: dict[str, Any]
+
+    @property
+    def summary(self) -> dict[str, Any]:
+        by_check_status: dict[str, int] = {}
+        for check in self.checks:
+            by_check_status[check.status] = by_check_status.get(check.status, 0) + 1
+        return {
+            "status": self.status,
+            "check_count": len(self.checks),
+            "pass_count": by_check_status.get(CHECK_STATUS_PASS, 0),
+            "fail_count": by_check_status.get(CHECK_STATUS_FAIL, 0),
+            "readiness_count": len(self.readiness),
+            "blocking_reason_count": len(self.blocking_reasons),
+            "required_action_count": len(self.required_actions),
+            "recovery_closure_finalization_readiness_available": bool(
+                self.readiness
+            ),
+            "recovery_closure_finalization_ready": (
+                self.status == RECOVERY_CLOSURE_FINALIZATION_STATUS_READY
+            ),
+            "would_allow_final_closure_count": sum(
+                1 for item in self.readiness if item.would_allow_final_closure
+            ),
+            "would_preserve_full_governance_chain_count": sum(
+                1
+                for item in self.readiness
+                if item.would_preserve_full_governance_chain
+            ),
+            "would_require_human_finalization_count": sum(
+                1 for item in self.readiness if item.would_require_human_finalization
+            ),
+            "would_keep_read_only_until_manual_commit_count": sum(
+                1
+                for item in self.readiness
+                if item.would_keep_read_only_until_manual_commit
+            ),
+            "has_blocks": (
+                self.status == RECOVERY_CLOSURE_FINALIZATION_STATUS_BLOCKED
+            ),
+            "requires_followup": bool(self.required_actions),
+            "by_check_status": by_check_status,
+        }
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "generated_at": self.generated_at,
+            "status": self.status,
+            "summary": self.summary,
+            "checks": [check.to_dict() for check in self.checks],
+            "readiness": [item.to_dict() for item in self.readiness],
+            "blocking_reasons": list(self.blocking_reasons),
+            "required_actions": list(self.required_actions),
+            "source_recovery_closure_governance_seal_audit_report": dict(
+                self.source_recovery_closure_governance_seal_audit_report
+            ),
+            "read_only": True,
+            "read_only_memory": True,
+            "would_mutate_memory": False,
+        }
+
+
+def build_evidence_repair_recovery_closure_finalization_readiness_preview(
+    *,
+    recovery_closure_governance_seal_audit: Mapping[str, Any] | None = None,
+) -> MemoryEvidenceRepairRecoveryClosureFinalizationReadinessPreviewReport:
+    """Build a read-only finalization readiness preview from a seal audit."""
+
+    recovery_closure_governance_seal_audit = (
+        recovery_closure_governance_seal_audit
+        if isinstance(recovery_closure_governance_seal_audit, Mapping)
+        else {}
+    )
+    report_status = _str(recovery_closure_governance_seal_audit.get("status"))
+    preview = _extract_preview(recovery_closure_governance_seal_audit)
+
+    if not preview:
+        if (
+            not recovery_closure_governance_seal_audit
+            or report_status
+            == RECOVERY_CLOSURE_GOVERNANCE_SEAL_AUDIT_STATUS_NO_ACTION_NEEDED
+        ):
+            return _empty_report(
+                recovery_closure_governance_seal_audit=(
+                    recovery_closure_governance_seal_audit
+                )
+            )
+        source_blocking = tuple(
+            _list_of_str(
+                recovery_closure_governance_seal_audit.get("blocking_reasons")
+            )
+        )
+        source_actions = tuple(
+            _list_of_str(recovery_closure_governance_seal_audit.get("required_actions"))
+        )
+        return _blocked_report(
+            recovery_closure_governance_seal_audit=(
+                recovery_closure_governance_seal_audit
+            ),
+            checks=(
+                _fail(
+                    CHECK_RECOVERY_GOVERNANCE_SEAL_AUDIT_READY,
+                    "No recovery closure governance seal audit preview was supplied."
+                    if not source_blocking
+                    else "; ".join(source_blocking),
+                    source_actions
+                    or (
+                        "produce_recovery_closure_governance_seal_audit_preview",
+                    ),
+                    {
+                        "recovery_closure_governance_seal_audit_status": (
+                            report_status
+                        )
+                    },
+                ),
+            ),
+        )
+
+    checks = (
+        _seal_audit_ready_check(recovery_closure_governance_seal_audit, preview),
+        _seal_audit_integrity_check(preview),
+        _source_chain_check(preview),
+        _finalization_requirements_check(preview),
+    )
+    blocking_reasons = tuple(
+        _dedupe_strings(
+            check.reason for check in checks if check.status == CHECK_STATUS_FAIL
+        )
+    )
+    required_actions = tuple(
+        _dedupe_strings(
+            action
+            for check in checks
+            if check.status == CHECK_STATUS_FAIL
+            for action in check.required_actions
+        )
+    )
+    if blocking_reasons:
+        return MemoryEvidenceRepairRecoveryClosureFinalizationReadinessPreviewReport(
+            generated_at=datetime.now(timezone.utc).isoformat(),
+            status=RECOVERY_CLOSURE_FINALIZATION_STATUS_BLOCKED,
+            checks=checks,
+            readiness=(),
+            blocking_reasons=blocking_reasons,
+            required_actions=required_actions,
+            source_recovery_closure_governance_seal_audit_report=dict(
+                recovery_closure_governance_seal_audit
+            ),
+        )
+
+    readiness = _readiness_from_seal_audit(preview)
+    return MemoryEvidenceRepairRecoveryClosureFinalizationReadinessPreviewReport(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        status=RECOVERY_CLOSURE_FINALIZATION_STATUS_READY,
+        checks=checks,
+        readiness=(readiness,),
+        blocking_reasons=(),
+        required_actions=(),
+        source_recovery_closure_governance_seal_audit_report=dict(
+            recovery_closure_governance_seal_audit
+        ),
+    )
+
+
+def empty_evidence_repair_recovery_closure_finalization_readiness_preview() -> MemoryEvidenceRepairRecoveryClosureFinalizationReadinessPreviewReport:
+    """Return an empty read-only finalization readiness preview."""
+
+    return _empty_report(recovery_closure_governance_seal_audit={})
+
+
+def _extract_preview(
+    recovery_closure_governance_seal_audit: Mapping[str, Any],
+) -> dict[str, Any]:
+    previews = recovery_closure_governance_seal_audit.get("previews")
+    if isinstance(previews, list):
+        for preview in previews:
+            if isinstance(preview, Mapping):
+                return dict(preview)
+    if _str(recovery_closure_governance_seal_audit.get("id")).startswith(
+        "recovery-closure-governance-seal-audit-"
+    ):
+        return dict(recovery_closure_governance_seal_audit)
+    return {}
+
+
+def _seal_audit_ready_check(
+    recovery_closure_governance_seal_audit: Mapping[str, Any],
+    preview: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryClosureFinalizationReadinessCheck:
+    report_status = _str(recovery_closure_governance_seal_audit.get("status"))
+    preview_status = _str(preview.get("status"))
+    if (
+        report_status
+        and report_status != RECOVERY_CLOSURE_GOVERNANCE_SEAL_AUDIT_STATUS_READY
+    ):
+        return _fail(
+            CHECK_RECOVERY_GOVERNANCE_SEAL_AUDIT_READY,
+            "Recovery closure governance seal audit report is not ready for finalization readiness preview.",
+            tuple(
+                _list_of_str(
+                    recovery_closure_governance_seal_audit.get("required_actions")
+                )
+            )
+            or ("produce_ready_recovery_closure_governance_seal_audit_preview",),
+            {"report_status": report_status, "preview_status": preview_status},
+        )
+    if preview_status != RECOVERY_CLOSURE_GOVERNANCE_SEAL_AUDIT_PREVIEW_STATUS_READY:
+        return _fail(
+            CHECK_RECOVERY_GOVERNANCE_SEAL_AUDIT_READY,
+            "Recovery closure governance seal audit preview is not ready for finalization readiness preview.",
+            ("regenerate_recovery_closure_governance_seal_audit_preview",),
+            {"report_status": report_status, "preview_status": preview_status},
+        )
+    return _pass(
+        CHECK_RECOVERY_GOVERNANCE_SEAL_AUDIT_READY,
+        "Recovery closure governance seal audit preview is ready for finalization readiness preview.",
+        {"seal_audit_preview_id": _str(preview.get("id"))},
+    )
+
+
+def _seal_audit_integrity_check(
+    preview: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryClosureFinalizationReadinessCheck:
+    expected_digest = _expected_seal_audit_digest(preview)
+    actual_digest = _str(preview.get("audit_digest"))
+    expected_id = (
+        f"recovery-closure-governance-seal-audit-{expected_digest[:16]}"
+        if expected_digest
+        else ""
+    )
+    missing_fields: list[str] = []
+    for field_name in (
+        "id",
+        "status",
+        "seal_id",
+        "ledger_audit_preview_id",
+        "ledger_entry_id",
+        "closure_id",
+        "audit_preview_id",
+        "receipt_id",
+        "executor_preview_id",
+        "decision_id",
+        "execution_preview_id",
+        "token_id",
+        "lock_id",
+        "route",
+        "operation_ids",
+        "recovery_step_ids",
+        "future_mutation_step_ids",
+        "completion_audit_step_ids",
+        "milestone_ids",
+        "ledger_audit_step_ids",
+        "seal_audit_step_ids",
+        "seal_digest",
+        "ledger_audit_digest",
+        "ledger_entry_digest",
+        "closure_digest",
+        "audit_digest",
+        "audit_steps",
+        "source_recovery_closure_governance_seal",
+    ):
+        value = preview.get(field_name)
+        if isinstance(value, list) and not value:
+            missing_fields.append(field_name)
+        elif isinstance(value, Mapping) and not value:
+            missing_fields.append(field_name)
+        elif not isinstance(value, (list, Mapping)) and not _str(value):
+            missing_fields.append(field_name)
+    if (
+        missing_fields
+        or actual_digest != expected_digest
+        or _str(preview.get("id")) != expected_id
+    ):
+        return _fail(
+            CHECK_RECOVERY_GOVERNANCE_SEAL_AUDIT_INTEGRITY,
+            "Recovery closure governance seal audit digest, id, or required fields are invalid.",
+            ("regenerate_recovery_closure_governance_seal_audit_preview",),
+            {
+                "expected_seal_audit_digest": expected_digest,
+                "actual_seal_audit_digest": actual_digest,
+                "expected_seal_audit_id": expected_id,
+                "actual_seal_audit_id": _str(preview.get("id")),
+                "missing_fields": missing_fields,
+            },
+        )
+    return _pass(
+        CHECK_RECOVERY_GOVERNANCE_SEAL_AUDIT_INTEGRITY,
+        "Recovery closure governance seal audit integrity checks pass.",
+        {"seal_audit_preview_id": expected_id, "audit_digest": actual_digest},
+    )
+
+
+def _source_chain_check(
+    preview: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryClosureFinalizationReadinessCheck:
+    seal = _dict(preview.get("source_recovery_closure_governance_seal"))
+    ledger_audit = _dict(seal.get("source_recovery_closure_ledger_audit_preview"))
+    entry = _dict(ledger_audit.get("source_recovery_closure_ledger_entry"))
+    missing_sources = [
+        name
+        for name, source in (
+            ("source_recovery_closure_governance_seal", seal),
+            ("source_recovery_closure_ledger_audit_preview", ledger_audit),
+            ("source_recovery_closure_ledger_entry", entry),
+        )
+        if not source
+    ]
+    mismatches: list[dict[str, str]] = []
+    for field_name in (
+        "seal_id",
+        "ledger_audit_preview_id",
+        "ledger_entry_id",
+        "closure_id",
+        "audit_preview_id",
+        "receipt_id",
+        "executor_preview_id",
+        "decision_id",
+        "execution_preview_id",
+        "token_id",
+        "lock_id",
+        "route",
+        "seal_digest",
+        "ledger_audit_digest",
+        "ledger_entry_digest",
+        "closure_digest",
+    ):
+        seal_key = "id" if field_name == "seal_id" else field_name
+        _compare(mismatches, field_name, preview, field_name, seal, seal_key)
+
+    for field_name in (
+        "ledger_audit_preview_id",
+        "ledger_entry_id",
+        "closure_id",
+        "audit_preview_id",
+        "receipt_id",
+        "executor_preview_id",
+        "decision_id",
+        "execution_preview_id",
+        "token_id",
+        "lock_id",
+        "route",
+        "ledger_entry_digest",
+        "closure_digest",
+    ):
+        ledger_key = "id" if field_name == "ledger_audit_preview_id" else field_name
+        _compare(mismatches, field_name, preview, field_name, ledger_audit, ledger_key)
+    if _str(preview.get("ledger_audit_digest")) != _str(
+        ledger_audit.get("audit_digest")
+    ):
+        mismatches.append(
+            {
+                "field": "ledger_audit_digest",
+                "left": _str(preview.get("ledger_audit_digest")),
+                "right": _str(ledger_audit.get("audit_digest")),
+                "right_key": "source_recovery_closure_ledger_audit_preview.audit_digest",
+            }
+        )
+    _compare(mismatches, "ledger_entry_id", preview, "ledger_entry_id", entry, "id")
+    _compare(mismatches, "closure_id", preview, "closure_id", entry, "closure_id")
+    if _str(preview.get("ledger_entry_digest")) != _str(entry.get("entry_digest")):
+        mismatches.append(
+            {
+                "field": "ledger_entry_digest",
+                "left": _str(preview.get("ledger_entry_digest")),
+                "right": _str(entry.get("entry_digest")),
+                "right_key": "source_recovery_closure_ledger_entry.entry_digest",
+            }
+        )
+    seal_audit_steps = _audit_steps(preview)
+    ledger_audit_steps = _audit_steps(ledger_audit)
+    non_pass_seal_audit_steps = [
+        _str(step.get("id")) or f"seal-audit-step-{index}"
+        for index, step in enumerate(seal_audit_steps, start=1)
+        if _str(step.get("status")) != GOVERNANCE_SEAL_AUDIT_STEP_STATUS_PASS
+    ]
+    non_pass_ledger_audit_steps = [
+        _str(step.get("id")) or f"ledger-audit-step-{index}"
+        for index, step in enumerate(ledger_audit_steps, start=1)
+        if _str(step.get("status")) != LEDGER_AUDIT_STEP_STATUS_PASS
+    ]
+    if (
+        missing_sources
+        or mismatches
+        or _str(seal.get("status")) != RECOVERY_CLOSURE_GOVERNANCE_SEAL_DRAFT_STATUS_READY
+        or _str(ledger_audit.get("status"))
+        != RECOVERY_CLOSURE_LEDGER_AUDIT_PREVIEW_STATUS_READY
+        or _str(entry.get("status")) != RECOVERY_CLOSURE_LEDGER_ENTRY_STATUS_READY
+        or non_pass_seal_audit_steps
+        or non_pass_ledger_audit_steps
+    ):
+        return _fail(
+            CHECK_RECOVERY_FINALIZATION_SOURCE_CHAIN,
+            "Recovery closure finalization source chain is incomplete or inconsistent.",
+            ("regenerate_recovery_closure_governance_seal_audit_preview",),
+            {
+                "missing_sources": missing_sources,
+                "mismatches": mismatches,
+                "seal_status": _str(seal.get("status")),
+                "ledger_audit_status": _str(ledger_audit.get("status")),
+                "entry_status": _str(entry.get("status")),
+                "non_pass_seal_audit_step_ids": non_pass_seal_audit_steps,
+                "non_pass_ledger_audit_step_ids": non_pass_ledger_audit_steps,
+            },
+        )
+    return _pass(
+        CHECK_RECOVERY_FINALIZATION_SOURCE_CHAIN,
+        "Recovery closure finalization source chain preserves seal, ledger audit, ledger entry, and closure evidence.",
+        {
+            "seal_audit_preview_id": _str(preview.get("id")),
+            "seal_id": _str(preview.get("seal_id")),
+            "ledger_audit_preview_id": _str(preview.get("ledger_audit_preview_id")),
+            "ledger_entry_id": _str(preview.get("ledger_entry_id")),
+            "seal_audit_step_count": len(seal_audit_steps),
+            "ledger_audit_step_count": len(ledger_audit_steps),
+        },
+    )
+
+
+def _finalization_requirements_check(
+    preview: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryClosureFinalizationReadinessCheck:
+    required_preview_flags = (
+        "would_verify_seal_integrity",
+        "would_verify_governance_handoff",
+        "would_verify_source_audit_evidence",
+        "would_verify_read_only_constraints",
+    )
+    missing_preview_flags = [
+        field_name
+        for field_name in required_preview_flags
+        if preview.get(field_name) is not True
+    ]
+    missing_lists = [
+        field_name
+        for field_name in (
+            "operation_ids",
+            "recovery_step_ids",
+            "future_mutation_step_ids",
+            "completion_audit_step_ids",
+            "milestone_ids",
+            "ledger_audit_step_ids",
+            "seal_audit_step_ids",
+        )
+        if not _list_of_str(preview.get(field_name))
+    ]
+    seal = _dict(preview.get("source_recovery_closure_governance_seal"))
+    required_seal_flags = (
+        "would_freeze_recovery_closure",
+        "would_preserve_audit_evidence",
+        "would_enable_governed_handoff",
+        "would_block_unreviewed_mutation",
+    )
+    missing_seal_flags = [
+        field_name for field_name in required_seal_flags if seal.get(field_name) is not True
+    ]
+    categories = {_str(step.get("category")) for step in _audit_steps(preview)}
+    required_categories = {
+        "seal_integrity",
+        "ledger_audit_source",
+        "ledger_entry_source",
+        "closure_trace",
+        "governance_controls",
+        "read_only",
+    }
+    missing_categories = sorted(required_categories - categories)
+    if missing_preview_flags or missing_lists or missing_seal_flags or missing_categories:
+        return _fail(
+            CHECK_RECOVERY_FINALIZATION_REQUIREMENTS,
+            "Recovery closure finalization readiness requirements are incomplete.",
+            ("regenerate_recovery_closure_governance_seal_audit_preview",),
+            {
+                "missing_preview_flags": missing_preview_flags,
+                "missing_lists": missing_lists,
+                "missing_seal_flags": missing_seal_flags,
+                "missing_categories": missing_categories,
+            },
+        )
+    return _pass(
+        CHECK_RECOVERY_FINALIZATION_REQUIREMENTS,
+        "Recovery closure finalization readiness covers integrity, handoff, source evidence, and read-only constraints.",
+        {
+            "seal_audit_step_count": len(_audit_steps(preview)),
+            "milestone_count": len(_list_of_str(preview.get("milestone_ids"))),
+        },
+    )
+
+
+def _readiness_from_seal_audit(
+    preview: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryClosureFinalizationReadinessPreview:
+    operation_ids = tuple(_list_of_str(preview.get("operation_ids")))
+    recovery_step_ids = tuple(_list_of_str(preview.get("recovery_step_ids")))
+    future_mutation_step_ids = tuple(_list_of_str(preview.get("future_mutation_step_ids")))
+    completion_audit_step_ids = tuple(
+        _list_of_str(preview.get("completion_audit_step_ids"))
+    )
+    milestone_ids = tuple(_list_of_str(preview.get("milestone_ids")))
+    ledger_audit_step_ids = tuple(_list_of_str(preview.get("ledger_audit_step_ids")))
+    seal_audit_step_ids = tuple(_list_of_str(preview.get("seal_audit_step_ids")))
+    finalization_seed = {
+        "finalization_type": RECOVERY_CLOSURE_FINALIZATION_TYPE,
+        "finalization_decision": RECOVERY_CLOSURE_FINALIZATION_DECISION,
+        "finalization_scope": RECOVERY_CLOSURE_FINALIZATION_SCOPE,
+        "seal_audit_preview_id": _str(preview.get("id")),
+        "seal_id": _str(preview.get("seal_id")),
+        "ledger_audit_preview_id": _str(preview.get("ledger_audit_preview_id")),
+        "ledger_entry_id": _str(preview.get("ledger_entry_id")),
+        "closure_id": _str(preview.get("closure_id")),
+        "audit_preview_id": _str(preview.get("audit_preview_id")),
+        "receipt_id": _str(preview.get("receipt_id")),
+        "executor_preview_id": _str(preview.get("executor_preview_id")),
+        "decision_id": _str(preview.get("decision_id")),
+        "execution_preview_id": _str(preview.get("execution_preview_id")),
+        "token_id": _str(preview.get("token_id")),
+        "lock_id": _str(preview.get("lock_id")),
+        "route": _str(preview.get("route")),
+        "operation_ids": operation_ids,
+        "recovery_step_ids": recovery_step_ids,
+        "future_mutation_step_ids": future_mutation_step_ids,
+        "completion_audit_step_ids": completion_audit_step_ids,
+        "milestone_ids": milestone_ids,
+        "ledger_audit_step_ids": ledger_audit_step_ids,
+        "seal_audit_step_ids": seal_audit_step_ids,
+        "seal_digest": _str(preview.get("seal_digest")),
+        "seal_audit_digest": _str(preview.get("audit_digest")),
+        "ledger_audit_digest": _str(preview.get("ledger_audit_digest")),
+        "ledger_entry_digest": _str(preview.get("ledger_entry_digest")),
+        "closure_digest": _str(preview.get("closure_digest")),
+    }
+    finalization_digest = _digest(finalization_seed)
+    finalization_id = (
+        f"recovery-closure-finalization-readiness-{finalization_digest[:16]}"
+    )
+    return MemoryEvidenceRepairRecoveryClosureFinalizationReadinessPreview(
+        id=finalization_id,
+        finalization_type=RECOVERY_CLOSURE_FINALIZATION_TYPE,
+        status=RECOVERY_CLOSURE_FINALIZATION_DRAFT_STATUS_READY,
+        finalization_decision=RECOVERY_CLOSURE_FINALIZATION_DECISION,
+        finalization_scope=RECOVERY_CLOSURE_FINALIZATION_SCOPE,
+        seal_audit_preview_id=_str(preview.get("id")),
+        seal_id=_str(preview.get("seal_id")),
+        ledger_audit_preview_id=_str(preview.get("ledger_audit_preview_id")),
+        ledger_entry_id=_str(preview.get("ledger_entry_id")),
+        closure_id=_str(preview.get("closure_id")),
+        audit_preview_id=_str(preview.get("audit_preview_id")),
+        receipt_id=_str(preview.get("receipt_id")),
+        executor_preview_id=_str(preview.get("executor_preview_id")),
+        decision_id=_str(preview.get("decision_id")),
+        execution_preview_id=_str(preview.get("execution_preview_id")),
+        token_id=_str(preview.get("token_id")),
+        lock_id=_str(preview.get("lock_id")),
+        route=_str(preview.get("route")),
+        operation_ids=operation_ids,
+        recovery_step_ids=recovery_step_ids,
+        future_mutation_step_ids=future_mutation_step_ids,
+        completion_audit_step_ids=completion_audit_step_ids,
+        milestone_ids=milestone_ids,
+        ledger_audit_step_ids=ledger_audit_step_ids,
+        seal_audit_step_ids=seal_audit_step_ids,
+        seal_digest=_str(preview.get("seal_digest")),
+        seal_audit_digest=_str(preview.get("audit_digest")),
+        ledger_audit_digest=_str(preview.get("ledger_audit_digest")),
+        ledger_entry_digest=_str(preview.get("ledger_entry_digest")),
+        closure_digest=_str(preview.get("closure_digest")),
+        finalization_digest=finalization_digest,
+        finalization_preview=f"{finalization_id}:{finalization_digest[:12]}",
+        would_allow_final_closure=True,
+        would_preserve_full_governance_chain=True,
+        would_require_human_finalization=True,
+        would_keep_read_only_until_manual_commit=True,
+        safety_note=(
+            "Read-only recovery closure finalization readiness preview. It "
+            "allows a later human-governed final closure only if the complete "
+            "seal and audit chain remains intact; it does not finalize or "
+            "mutate durable memory."
+        ),
+        source_recovery_closure_governance_seal_audit_preview=dict(preview),
+    )
+
+
+def _expected_seal_audit_digest(preview: Mapping[str, Any]) -> str:
+    seed = {
+        "seal_id": _str(preview.get("seal_id")),
+        "ledger_audit_preview_id": _str(preview.get("ledger_audit_preview_id")),
+        "ledger_entry_id": _str(preview.get("ledger_entry_id")),
+        "closure_id": _str(preview.get("closure_id")),
+        "audit_preview_id": _str(preview.get("audit_preview_id")),
+        "receipt_id": _str(preview.get("receipt_id")),
+        "executor_preview_id": _str(preview.get("executor_preview_id")),
+        "decision_id": _str(preview.get("decision_id")),
+        "execution_preview_id": _str(preview.get("execution_preview_id")),
+        "token_id": _str(preview.get("token_id")),
+        "lock_id": _str(preview.get("lock_id")),
+        "route": _str(preview.get("route")),
+        "operation_ids": tuple(_list_of_str(preview.get("operation_ids"))),
+        "recovery_step_ids": tuple(_list_of_str(preview.get("recovery_step_ids"))),
+        "future_mutation_step_ids": tuple(
+            _list_of_str(preview.get("future_mutation_step_ids"))
+        ),
+        "completion_audit_step_ids": tuple(
+            _list_of_str(preview.get("completion_audit_step_ids"))
+        ),
+        "milestone_ids": tuple(_list_of_str(preview.get("milestone_ids"))),
+        "ledger_audit_step_ids": tuple(
+            _list_of_str(preview.get("ledger_audit_step_ids"))
+        ),
+        "seal_audit_step_ids": tuple(_list_of_str(preview.get("seal_audit_step_ids"))),
+        "seal_digest": _str(preview.get("seal_digest")),
+        "ledger_audit_digest": _str(preview.get("ledger_audit_digest")),
+        "ledger_entry_digest": _str(preview.get("ledger_entry_digest")),
+        "closure_digest": _str(preview.get("closure_digest")),
+    }
+    return _digest(seed)
+
+
+def _audit_steps(preview: Mapping[str, Any]) -> list[Mapping[str, Any]]:
+    return [
+        step
+        for step in _list(preview.get("audit_steps"))
+        if isinstance(step, Mapping)
+    ]
+
+
+def _compare(
+    mismatches: list[dict[str, str]],
+    label: str,
+    left: Mapping[str, Any],
+    left_key: str,
+    right: Mapping[str, Any],
+    right_key: str,
+) -> None:
+    left_value = _str(left.get(left_key))
+    right_value = _str(right.get(right_key))
+    if left_value != right_value:
+        mismatches.append(
+            {
+                "field": label,
+                "left": left_value,
+                "right": right_value,
+                "right_key": right_key,
+            }
+        )
+
+
+def _empty_report(
+    *,
+    recovery_closure_governance_seal_audit: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryClosureFinalizationReadinessPreviewReport:
+    return MemoryEvidenceRepairRecoveryClosureFinalizationReadinessPreviewReport(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        status=RECOVERY_CLOSURE_FINALIZATION_STATUS_NO_ACTION_NEEDED,
+        checks=(),
+        readiness=(),
+        blocking_reasons=(),
+        required_actions=(),
+        source_recovery_closure_governance_seal_audit_report=dict(
+            recovery_closure_governance_seal_audit
+        ),
+    )
+
+
+def _blocked_report(
+    *,
+    recovery_closure_governance_seal_audit: Mapping[str, Any],
+    checks: tuple[
+        MemoryEvidenceRepairRecoveryClosureFinalizationReadinessCheck, ...
+    ],
+) -> MemoryEvidenceRepairRecoveryClosureFinalizationReadinessPreviewReport:
+    return MemoryEvidenceRepairRecoveryClosureFinalizationReadinessPreviewReport(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        status=RECOVERY_CLOSURE_FINALIZATION_STATUS_BLOCKED,
+        checks=checks,
+        readiness=(),
+        blocking_reasons=tuple(
+            _dedupe_strings(
+                check.reason for check in checks if check.status == CHECK_STATUS_FAIL
+            )
+        ),
+        required_actions=tuple(
+            _dedupe_strings(
+                action
+                for check in checks
+                if check.status == CHECK_STATUS_FAIL
+                for action in check.required_actions
+            )
+        ),
+        source_recovery_closure_governance_seal_audit_report=dict(
+            recovery_closure_governance_seal_audit
+        ),
+    )
+
+
+def _pass(
+    check_id: str,
+    reason: str,
+    details: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryClosureFinalizationReadinessCheck:
+    return MemoryEvidenceRepairRecoveryClosureFinalizationReadinessCheck(
+        id=check_id,
+        status=CHECK_STATUS_PASS,
+        reason=reason,
+        required_actions=(),
+        details=dict(details),
+    )
+
+
+def _fail(
+    check_id: str,
+    reason: str,
+    required_actions: Sequence[str],
+    details: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryClosureFinalizationReadinessCheck:
+    return MemoryEvidenceRepairRecoveryClosureFinalizationReadinessCheck(
+        id=check_id,
+        status=CHECK_STATUS_FAIL,
+        reason=reason,
+        required_actions=tuple(required_actions),
+        details=dict(details),
+    )
+
+
+def _digest(value: Any) -> str:
+    raw = json.dumps(value, sort_keys=True, ensure_ascii=False, default=str)
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def _dict(value: Any) -> dict[str, Any]:
+    return dict(value) if isinstance(value, Mapping) else {}
+
+
+def _list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _list_of_str(value: Any) -> list[str]:
+    return [_str(item) for item in value] if isinstance(value, list) else []
+
+
+def _dedupe_strings(values: Sequence[str] | Any) -> list[str]:
+    seen: set[str] = set()
+    result: list[str] = []
+    for value in values:
+        text = _str(value)
+        if text and text not in seen:
+            seen.add(text)
+            result.append(text)
+    return result
+
+
+def _str(value: Any) -> str:
+    return str(value or "").strip()

--- a/agent/memory_evidence_repair_recovery_closure_gate.py
+++ b/agent/memory_evidence_repair_recovery_closure_gate.py
@@ -1,0 +1,616 @@
+"""Read-only recovery closure gate for memory evidence repair.
+
+The recovery closure gate verifies a recovery completion audit preview and only
+allows a future closure draft when observed recovery-completion state has been
+supplied and every audit step passes. It never writes durable memory and never
+marks recovery as closed.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Mapping, Sequence
+
+from agent.memory_evidence_repair_manual_commit_dry_run import (
+    CHECK_STATUS_FAIL,
+    CHECK_STATUS_PASS,
+)
+from agent.memory_evidence_repair_recovery_completion_audit_preview import (
+    RECOVERY_AUDIT_STEP_STATUS_FAIL,
+    RECOVERY_AUDIT_STEP_STATUS_PASS,
+    RECOVERY_AUDIT_STEP_STATUS_PLANNED,
+    RECOVERY_COMPLETION_AUDIT_STATUS_NO_ACTION_NEEDED,
+    RECOVERY_COMPLETION_AUDIT_STATUS_READY,
+)
+
+
+RECOVERY_CLOSURE_STATUS_READY = "recovery_closure_ready"
+RECOVERY_CLOSURE_STATUS_BLOCKED = "blocked"
+RECOVERY_CLOSURE_STATUS_NO_ACTION_NEEDED = "no_action_needed"
+RECOVERY_CLOSURE_DRAFT_STATUS_READY = "recovery_closure_draft_ready"
+
+CHECK_RECOVERY_COMPLETION_AUDIT_READY = "recovery_completion_audit_ready"
+CHECK_RECOVERY_COMPLETION_AUDIT_INTEGRITY = "recovery_completion_audit_integrity"
+CHECK_RECOVERY_COMPLETION_AUDIT_OBSERVED_PASS = "recovery_completion_audit_observed_pass"
+CHECK_RECOVERY_CLOSURE_REQUIREMENTS = "recovery_closure_requirements"
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairRecoveryClosureCheck:
+    """One read-only recovery closure gate check."""
+
+    id: str
+    status: str
+    reason: str
+    required_actions: tuple[str, ...]
+    details: dict[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "status": self.status,
+            "reason": self.reason,
+            "required_actions": list(self.required_actions),
+            "details": dict(self.details),
+        }
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairRecoveryClosureDraft:
+    """One read-only future recovery closure draft."""
+
+    id: str
+    status: str
+    closure_type: str
+    closure_decision: str
+    audit_preview_id: str
+    receipt_id: str
+    executor_preview_id: str
+    decision_id: str
+    execution_preview_id: str
+    token_id: str
+    lock_id: str
+    route: str
+    operation_ids: tuple[str, ...]
+    recovery_step_ids: tuple[str, ...]
+    future_mutation_step_ids: tuple[str, ...]
+    audit_step_ids: tuple[str, ...]
+    closure_digest: str
+    closure_preview: str
+    would_close_recovery_loop: bool
+    would_mark_recovery_resolved: bool
+    would_preserve_audit_evidence: bool
+    safety_note: str
+    source_recovery_completion_audit_preview: dict[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "status": self.status,
+            "closure_type": self.closure_type,
+            "closure_decision": self.closure_decision,
+            "audit_preview_id": self.audit_preview_id,
+            "receipt_id": self.receipt_id,
+            "executor_preview_id": self.executor_preview_id,
+            "decision_id": self.decision_id,
+            "execution_preview_id": self.execution_preview_id,
+            "token_id": self.token_id,
+            "lock_id": self.lock_id,
+            "route": self.route,
+            "operation_ids": list(self.operation_ids),
+            "recovery_step_ids": list(self.recovery_step_ids),
+            "future_mutation_step_ids": list(self.future_mutation_step_ids),
+            "audit_step_ids": list(self.audit_step_ids),
+            "closure_digest": self.closure_digest,
+            "closure_preview": self.closure_preview,
+            "would_close_recovery_loop": self.would_close_recovery_loop,
+            "would_mark_recovery_resolved": self.would_mark_recovery_resolved,
+            "would_preserve_audit_evidence": self.would_preserve_audit_evidence,
+            "safety_note": self.safety_note,
+            "source_recovery_completion_audit_preview": dict(
+                self.source_recovery_completion_audit_preview
+            ),
+        }
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairRecoveryClosureGateReport:
+    """Read-only recovery closure gate report."""
+
+    generated_at: str
+    status: str
+    checks: tuple[MemoryEvidenceRepairRecoveryClosureCheck, ...]
+    closures: tuple[MemoryEvidenceRepairRecoveryClosureDraft, ...]
+    blocking_reasons: tuple[str, ...]
+    required_actions: tuple[str, ...]
+    source_recovery_completion_audit_report: dict[str, Any]
+
+    @property
+    def summary(self) -> dict[str, Any]:
+        by_check_status: dict[str, int] = {}
+        for check in self.checks:
+            by_check_status[check.status] = by_check_status.get(check.status, 0) + 1
+        return {
+            "status": self.status,
+            "check_count": len(self.checks),
+            "pass_count": by_check_status.get(CHECK_STATUS_PASS, 0),
+            "fail_count": by_check_status.get(CHECK_STATUS_FAIL, 0),
+            "closure_count": len(self.closures),
+            "blocking_reason_count": len(self.blocking_reasons),
+            "required_action_count": len(self.required_actions),
+            "recovery_closure_available": bool(self.closures),
+            "recovery_closure_ready": self.status == RECOVERY_CLOSURE_STATUS_READY,
+            "would_close_recovery_loop_count": sum(
+                1 for closure in self.closures if closure.would_close_recovery_loop
+            ),
+            "has_blocks": self.status == RECOVERY_CLOSURE_STATUS_BLOCKED,
+            "requires_followup": bool(self.required_actions),
+            "by_check_status": by_check_status,
+        }
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "generated_at": self.generated_at,
+            "status": self.status,
+            "summary": self.summary,
+            "checks": [check.to_dict() for check in self.checks],
+            "closures": [closure.to_dict() for closure in self.closures],
+            "blocking_reasons": list(self.blocking_reasons),
+            "required_actions": list(self.required_actions),
+            "source_recovery_completion_audit_report": dict(
+                self.source_recovery_completion_audit_report
+            ),
+            "read_only": True,
+            "read_only_memory": True,
+            "would_mutate_memory": False,
+        }
+
+
+def build_evidence_repair_recovery_closure_gate(
+    *,
+    recovery_completion_audit: Mapping[str, Any] | None = None,
+) -> MemoryEvidenceRepairRecoveryClosureGateReport:
+    """Build a read-only recovery closure gate from a completion audit."""
+
+    recovery_completion_audit = (
+        recovery_completion_audit if isinstance(recovery_completion_audit, Mapping) else {}
+    )
+    report_status = _str(recovery_completion_audit.get("status"))
+    preview = _extract_preview(recovery_completion_audit)
+
+    if not preview:
+        if (
+            not recovery_completion_audit
+            or report_status == RECOVERY_COMPLETION_AUDIT_STATUS_NO_ACTION_NEEDED
+        ):
+            return _empty_report(recovery_completion_audit=recovery_completion_audit)
+        source_blocking = tuple(_list_of_str(recovery_completion_audit.get("blocking_reasons")))
+        source_actions = tuple(_list_of_str(recovery_completion_audit.get("required_actions")))
+        return _blocked_report(
+            recovery_completion_audit=recovery_completion_audit,
+            checks=(
+                _fail(
+                    CHECK_RECOVERY_COMPLETION_AUDIT_READY,
+                    "No recovery completion audit preview was supplied."
+                    if not source_blocking
+                    else "; ".join(source_blocking),
+                    source_actions or ("produce_recovery_completion_audit_preview",),
+                    {"recovery_completion_audit_status": report_status},
+                ),
+            ),
+        )
+
+    checks = (
+        _audit_ready_check(recovery_completion_audit, preview),
+        _audit_integrity_check(preview),
+        _audit_observed_pass_check(preview),
+        _closure_requirements_check(preview),
+    )
+    blocking_reasons = tuple(
+        _dedupe_strings(check.reason for check in checks if check.status == CHECK_STATUS_FAIL)
+    )
+    required_actions = tuple(
+        _dedupe_strings(
+            action
+            for check in checks
+            if check.status == CHECK_STATUS_FAIL
+            for action in check.required_actions
+        )
+    )
+    if blocking_reasons:
+        return MemoryEvidenceRepairRecoveryClosureGateReport(
+            generated_at=datetime.now(timezone.utc).isoformat(),
+            status=RECOVERY_CLOSURE_STATUS_BLOCKED,
+            checks=checks,
+            closures=(),
+            blocking_reasons=blocking_reasons,
+            required_actions=required_actions,
+            source_recovery_completion_audit_report=dict(recovery_completion_audit),
+        )
+
+    closure = _closure_from_audit(preview)
+    return MemoryEvidenceRepairRecoveryClosureGateReport(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        status=RECOVERY_CLOSURE_STATUS_READY,
+        checks=checks,
+        closures=(closure,),
+        blocking_reasons=(),
+        required_actions=(),
+        source_recovery_completion_audit_report=dict(recovery_completion_audit),
+    )
+
+
+def empty_evidence_repair_recovery_closure_gate() -> MemoryEvidenceRepairRecoveryClosureGateReport:
+    """Return an empty read-only recovery closure gate report."""
+
+    return _empty_report(recovery_completion_audit={})
+
+
+def _extract_preview(recovery_completion_audit: Mapping[str, Any]) -> dict[str, Any]:
+    previews = recovery_completion_audit.get("previews")
+    if isinstance(previews, list):
+        for preview in previews:
+            if isinstance(preview, Mapping):
+                return dict(preview)
+    if _str(recovery_completion_audit.get("id")).startswith("recovery-completion-audit-"):
+        return dict(recovery_completion_audit)
+    return {}
+
+
+def _audit_ready_check(
+    recovery_completion_audit: Mapping[str, Any],
+    preview: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryClosureCheck:
+    report_status = _str(recovery_completion_audit.get("status"))
+    preview_status = _str(preview.get("status"))
+    if report_status and report_status != RECOVERY_COMPLETION_AUDIT_STATUS_READY:
+        return _fail(
+            CHECK_RECOVERY_COMPLETION_AUDIT_READY,
+            "Recovery completion audit report is not ready for closure.",
+            tuple(_list_of_str(recovery_completion_audit.get("required_actions")))
+            or ("produce_ready_recovery_completion_audit_preview",),
+            {"report_status": report_status, "preview_status": preview_status},
+        )
+    if preview_status != RECOVERY_COMPLETION_AUDIT_STATUS_READY:
+        return _fail(
+            CHECK_RECOVERY_COMPLETION_AUDIT_READY,
+            "Recovery completion audit preview entry is not ready.",
+            ("produce_ready_recovery_completion_audit_preview",),
+            {"report_status": report_status, "preview_status": preview_status},
+        )
+    return _pass(
+        CHECK_RECOVERY_COMPLETION_AUDIT_READY,
+        "Recovery completion audit preview is ready for closure gating.",
+        {"audit_preview_id": _str(preview.get("id"))},
+    )
+
+
+def _audit_integrity_check(
+    preview: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryClosureCheck:
+    expected_digest = _expected_audit_digest(preview)
+    actual_digest = _str(preview.get("audit_digest"))
+    expected_id = f"recovery-completion-audit-{expected_digest[:16]}" if expected_digest else ""
+    missing_fields: list[str] = []
+    for field_name in (
+        "id",
+        "receipt_id",
+        "executor_preview_id",
+        "decision_id",
+        "execution_preview_id",
+        "lock_id",
+        "token_id",
+        "operation_ids",
+        "recovery_step_ids",
+        "future_mutation_step_ids",
+        "audit_step_ids",
+        "audit_steps",
+    ):
+        value = preview.get(field_name)
+        if isinstance(value, list) and not value:
+            missing_fields.append(field_name)
+        elif not isinstance(value, list) and not _str(value):
+            missing_fields.append(field_name)
+    if (
+        missing_fields
+        or actual_digest != expected_digest
+        or _str(preview.get("id")) != expected_id
+    ):
+        return _fail(
+            CHECK_RECOVERY_COMPLETION_AUDIT_INTEGRITY,
+            "Recovery completion audit digest, id, or required fields are invalid.",
+            ("regenerate_recovery_completion_audit_preview",),
+            {
+                "expected_audit_digest": expected_digest,
+                "actual_audit_digest": actual_digest,
+                "expected_audit_id": expected_id,
+                "actual_audit_id": _str(preview.get("id")),
+                "missing_fields": missing_fields,
+            },
+        )
+    return _pass(
+        CHECK_RECOVERY_COMPLETION_AUDIT_INTEGRITY,
+        "Recovery completion audit integrity checks pass.",
+        {"audit_preview_id": expected_id, "audit_digest": actual_digest},
+    )
+
+
+def _audit_observed_pass_check(
+    preview: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryClosureCheck:
+    audit_steps = _audit_steps(preview)
+    statuses = [_str(step.get("status")) for step in audit_steps]
+    planned = [step for step in audit_steps if _str(step.get("status")) == RECOVERY_AUDIT_STEP_STATUS_PLANNED]
+    failed = [step for step in audit_steps if _str(step.get("status")) == RECOVERY_AUDIT_STEP_STATUS_FAIL]
+    passed = [step for step in audit_steps if _str(step.get("status")) == RECOVERY_AUDIT_STEP_STATUS_PASS]
+    if preview.get("observed_state_supplied") is not True:
+        return _fail(
+            CHECK_RECOVERY_COMPLETION_AUDIT_OBSERVED_PASS,
+            "Recovery closure requires observed recovery-completion state; planned audit is not enough.",
+            ("provide_observed_recovery_completion_state",),
+            {"observed_state_supplied": bool(preview.get("observed_state_supplied"))},
+        )
+    if planned or failed or len(passed) != len(audit_steps):
+        return _fail(
+            CHECK_RECOVERY_COMPLETION_AUDIT_OBSERVED_PASS,
+            "Recovery closure requires every completion audit step to pass.",
+            ("investigate_recovery_completion_audit_failures",),
+            {
+                "audit_step_count": len(audit_steps),
+                "pass_count": len(passed),
+                "planned_count": len(planned),
+                "fail_count": len(failed),
+                "statuses": statuses,
+            },
+        )
+    return _pass(
+        CHECK_RECOVERY_COMPLETION_AUDIT_OBSERVED_PASS,
+        "Observed recovery-completion audit has passed every step.",
+        {"audit_step_count": len(audit_steps), "pass_count": len(passed)},
+    )
+
+
+def _closure_requirements_check(
+    preview: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryClosureCheck:
+    flags = {
+        "would_verify_completion_receipt_recorded": preview.get(
+            "would_verify_completion_receipt_recorded"
+        )
+        is True,
+        "would_verify_recovery_token_used": preview.get("would_verify_recovery_token_used")
+        is True,
+        "would_verify_recovery_lock_released": preview.get(
+            "would_verify_recovery_lock_released"
+        )
+        is True,
+        "would_verify_recovery_steps_completed": preview.get(
+            "would_verify_recovery_steps_completed"
+        )
+        is True,
+        "would_verify_post_recovery_audit_clear": preview.get(
+            "would_verify_post_recovery_audit_clear"
+        )
+        is True,
+        "would_verify_no_secondary_memory_contamination": preview.get(
+            "would_verify_no_secondary_memory_contamination"
+        )
+        is True,
+    }
+    missing = [name for name, ok in flags.items() if not ok]
+    required_categories = {
+        "completion_receipt",
+        "token",
+        "lock",
+        "recovery_step",
+        "post_recovery_audit",
+        "contamination_guard",
+    }
+    categories = {_str(step.get("category")) for step in _audit_steps(preview)}
+    missing_categories = sorted(required_categories - categories)
+    if missing or missing_categories or not _list_of_str(preview.get("future_mutation_step_ids")):
+        return _fail(
+            CHECK_RECOVERY_CLOSURE_REQUIREMENTS,
+            "Recovery closure requirements are incomplete.",
+            ("regenerate_recovery_completion_audit_preview",),
+            {
+                "missing_flags": missing,
+                "missing_categories": missing_categories,
+                "future_mutation_step_count": len(
+                    _list_of_str(preview.get("future_mutation_step_ids"))
+                ),
+            },
+        )
+    return _pass(
+        CHECK_RECOVERY_CLOSURE_REQUIREMENTS,
+        "Recovery closure requirements cover receipt, token, lock, steps, audit, and contamination guard.",
+        {
+            "category_count": len(categories),
+            "future_mutation_step_count": len(
+                _list_of_str(preview.get("future_mutation_step_ids"))
+            ),
+        },
+    )
+
+
+def _closure_from_audit(
+    preview: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryClosureDraft:
+    operation_ids = tuple(_list_of_str(preview.get("operation_ids")))
+    recovery_step_ids = tuple(_list_of_str(preview.get("recovery_step_ids")))
+    future_mutation_step_ids = tuple(_list_of_str(preview.get("future_mutation_step_ids")))
+    audit_step_ids = tuple(_list_of_str(preview.get("audit_step_ids")))
+    seed = {
+        "closure_type": "memory_evidence_repair_recovery_closure",
+        "closure_decision": "close_recovery_loop",
+        "audit_preview_id": _str(preview.get("id")),
+        "receipt_id": _str(preview.get("receipt_id")),
+        "executor_preview_id": _str(preview.get("executor_preview_id")),
+        "decision_id": _str(preview.get("decision_id")),
+        "execution_preview_id": _str(preview.get("execution_preview_id")),
+        "token_id": _str(preview.get("token_id")),
+        "lock_id": _str(preview.get("lock_id")),
+        "route": _str(preview.get("route")),
+        "operation_ids": operation_ids,
+        "recovery_step_ids": recovery_step_ids,
+        "future_mutation_step_ids": future_mutation_step_ids,
+        "audit_step_ids": audit_step_ids,
+    }
+    closure_digest = _digest(seed)
+    closure_id = f"recovery-closure-{closure_digest[:16]}"
+    return MemoryEvidenceRepairRecoveryClosureDraft(
+        id=closure_id,
+        status=RECOVERY_CLOSURE_DRAFT_STATUS_READY,
+        closure_type="memory_evidence_repair_recovery_closure",
+        closure_decision="close_recovery_loop",
+        audit_preview_id=_str(preview.get("id")),
+        receipt_id=_str(preview.get("receipt_id")),
+        executor_preview_id=_str(preview.get("executor_preview_id")),
+        decision_id=_str(preview.get("decision_id")),
+        execution_preview_id=_str(preview.get("execution_preview_id")),
+        token_id=_str(preview.get("token_id")),
+        lock_id=_str(preview.get("lock_id")),
+        route=_str(preview.get("route")),
+        operation_ids=operation_ids,
+        recovery_step_ids=recovery_step_ids,
+        future_mutation_step_ids=future_mutation_step_ids,
+        audit_step_ids=audit_step_ids,
+        closure_digest=closure_digest,
+        closure_preview=f"{closure_id}:{closure_digest[:12]}",
+        would_close_recovery_loop=True,
+        would_mark_recovery_resolved=True,
+        would_preserve_audit_evidence=True,
+        safety_note=(
+            "Read-only recovery closure draft. It states that a future closure "
+            "would be allowed, but does not persist closure state or mutate memory."
+        ),
+        source_recovery_completion_audit_preview=dict(preview),
+    )
+
+
+def _expected_audit_digest(preview: Mapping[str, Any]) -> str:
+    seed = {
+        "receipt_id": _str(preview.get("receipt_id")),
+        "executor_preview_id": _str(preview.get("executor_preview_id")),
+        "decision_id": _str(preview.get("decision_id")),
+        "execution_preview_id": _str(preview.get("execution_preview_id")),
+        "lock_id": _str(preview.get("lock_id")),
+        "token_id": _str(preview.get("token_id")),
+        "route": _str(preview.get("route")),
+        "operation_ids": tuple(_list_of_str(preview.get("operation_ids"))),
+        "recovery_step_ids": tuple(_list_of_str(preview.get("recovery_step_ids"))),
+        "future_mutation_step_ids": tuple(
+            _list_of_str(preview.get("future_mutation_step_ids"))
+        ),
+        "audit_step_ids": tuple(_list_of_str(preview.get("audit_step_ids"))),
+        "observed_state_supplied": preview.get("observed_state_supplied") is True,
+    }
+    return _digest(seed)
+
+
+def _audit_steps(preview: Mapping[str, Any]) -> list[Mapping[str, Any]]:
+    return [
+        step
+        for step in _list(preview.get("audit_steps"))
+        if isinstance(step, Mapping)
+    ]
+
+
+def _empty_report(
+    *,
+    recovery_completion_audit: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryClosureGateReport:
+    return MemoryEvidenceRepairRecoveryClosureGateReport(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        status=RECOVERY_CLOSURE_STATUS_NO_ACTION_NEEDED,
+        checks=(),
+        closures=(),
+        blocking_reasons=(),
+        required_actions=(),
+        source_recovery_completion_audit_report=dict(recovery_completion_audit),
+    )
+
+
+def _blocked_report(
+    *,
+    recovery_completion_audit: Mapping[str, Any],
+    checks: tuple[MemoryEvidenceRepairRecoveryClosureCheck, ...],
+) -> MemoryEvidenceRepairRecoveryClosureGateReport:
+    return MemoryEvidenceRepairRecoveryClosureGateReport(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        status=RECOVERY_CLOSURE_STATUS_BLOCKED,
+        checks=checks,
+        closures=(),
+        blocking_reasons=tuple(
+            _dedupe_strings(check.reason for check in checks if check.status == CHECK_STATUS_FAIL)
+        ),
+        required_actions=tuple(
+            _dedupe_strings(
+                action
+                for check in checks
+                if check.status == CHECK_STATUS_FAIL
+                for action in check.required_actions
+            )
+        ),
+        source_recovery_completion_audit_report=dict(recovery_completion_audit),
+    )
+
+
+def _pass(
+    check_id: str,
+    reason: str,
+    details: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryClosureCheck:
+    return MemoryEvidenceRepairRecoveryClosureCheck(
+        id=check_id,
+        status=CHECK_STATUS_PASS,
+        reason=reason,
+        required_actions=(),
+        details=dict(details),
+    )
+
+
+def _fail(
+    check_id: str,
+    reason: str,
+    required_actions: Sequence[str],
+    details: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryClosureCheck:
+    return MemoryEvidenceRepairRecoveryClosureCheck(
+        id=check_id,
+        status=CHECK_STATUS_FAIL,
+        reason=reason,
+        required_actions=tuple(required_actions),
+        details=dict(details),
+    )
+
+
+def _digest(value: Any) -> str:
+    raw = json.dumps(value, sort_keys=True, ensure_ascii=False, default=str)
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def _list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _list_of_str(value: Any) -> list[str]:
+    return [_str(item) for item in value] if isinstance(value, list) else []
+
+
+def _dedupe_strings(values: Sequence[str] | Any) -> list[str]:
+    seen: set[str] = set()
+    result: list[str] = []
+    for value in values:
+        text = _str(value)
+        if text and text not in seen:
+            seen.add(text)
+            result.append(text)
+    return result
+
+
+def _str(value: Any) -> str:
+    return str(value or "").strip()

--- a/agent/memory_evidence_repair_recovery_closure_governance_seal_audit_preview.py
+++ b/agent/memory_evidence_repair_recovery_closure_governance_seal_audit_preview.py
@@ -1,0 +1,992 @@
+"""Read-only recovery closure governance seal audit preview.
+
+This layer audits a recovery closure governance seal draft so later governance
+layers can verify the seal itself before any future handoff or freeze. It never
+writes durable memory, records a real audit, or mutates a real seal.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Mapping, Sequence
+
+from agent.memory_evidence_repair_manual_commit_dry_run import (
+    CHECK_STATUS_FAIL,
+    CHECK_STATUS_PASS,
+)
+from agent.memory_evidence_repair_recovery_closure_governance_seal_preview import (
+    RECOVERY_CLOSURE_GOVERNANCE_DECISION,
+    RECOVERY_CLOSURE_GOVERNANCE_SCOPE,
+    RECOVERY_CLOSURE_GOVERNANCE_SEAL_DRAFT_STATUS_READY,
+    RECOVERY_CLOSURE_GOVERNANCE_SEAL_STATUS_NO_ACTION_NEEDED,
+    RECOVERY_CLOSURE_GOVERNANCE_SEAL_STATUS_READY,
+    RECOVERY_CLOSURE_GOVERNANCE_SEAL_TYPE,
+)
+from agent.memory_evidence_repair_recovery_closure_ledger_audit_preview import (
+    LEDGER_AUDIT_STEP_STATUS_PASS,
+    RECOVERY_CLOSURE_LEDGER_AUDIT_PREVIEW_STATUS_READY,
+)
+from agent.memory_evidence_repair_recovery_closure_ledger_preview import (
+    RECOVERY_CLOSURE_LEDGER_ENTRY_STATUS_READY,
+)
+
+
+RECOVERY_CLOSURE_GOVERNANCE_SEAL_AUDIT_STATUS_READY = (
+    "recovery_closure_governance_seal_audit_preview_ready"
+)
+RECOVERY_CLOSURE_GOVERNANCE_SEAL_AUDIT_STATUS_BLOCKED = "blocked"
+RECOVERY_CLOSURE_GOVERNANCE_SEAL_AUDIT_STATUS_NO_ACTION_NEEDED = "no_action_needed"
+RECOVERY_CLOSURE_GOVERNANCE_SEAL_AUDIT_PREVIEW_STATUS_READY = (
+    "recovery_closure_governance_seal_audit_ready"
+)
+
+GOVERNANCE_SEAL_AUDIT_STEP_STATUS_PASS = "pass"
+GOVERNANCE_SEAL_AUDIT_STEP_STATUS_FAIL = "fail"
+
+CHECK_RECOVERY_GOVERNANCE_SEAL_READY = "recovery_governance_seal_ready"
+CHECK_RECOVERY_GOVERNANCE_SEAL_INTEGRITY = "recovery_governance_seal_integrity"
+CHECK_RECOVERY_GOVERNANCE_SEAL_AUDIT_SOURCE_CHAIN = (
+    "recovery_governance_seal_audit_source_chain"
+)
+CHECK_RECOVERY_GOVERNANCE_SEAL_AUDIT_REQUIREMENTS = (
+    "recovery_governance_seal_audit_requirements"
+)
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairRecoveryClosureGovernanceSealAuditCheck:
+    """One read-only governance seal audit readiness check."""
+
+    id: str
+    status: str
+    reason: str
+    required_actions: tuple[str, ...]
+    details: dict[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "status": self.status,
+            "reason": self.reason,
+            "required_actions": list(self.required_actions),
+            "details": dict(self.details),
+        }
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairRecoveryClosureGovernanceSealAuditStep:
+    """One structural audit step for a future governance seal."""
+
+    id: str
+    sequence: int
+    category: str
+    assertion: str
+    seal_id: str
+    reference_id: str
+    expected_signal: dict[str, Any]
+    observed_signal: dict[str, Any]
+    status: str
+    required_action_on_fail: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "sequence": self.sequence,
+            "category": self.category,
+            "assertion": self.assertion,
+            "seal_id": self.seal_id,
+            "reference_id": self.reference_id,
+            "expected_signal": dict(self.expected_signal),
+            "observed_signal": dict(self.observed_signal),
+            "status": self.status,
+            "required_action_on_fail": self.required_action_on_fail,
+        }
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairRecoveryClosureGovernanceSealAuditPreview:
+    """One read-only recovery closure governance seal audit preview."""
+
+    id: str
+    status: str
+    seal_id: str
+    ledger_audit_preview_id: str
+    ledger_entry_id: str
+    closure_id: str
+    audit_preview_id: str
+    receipt_id: str
+    executor_preview_id: str
+    decision_id: str
+    execution_preview_id: str
+    token_id: str
+    lock_id: str
+    route: str
+    operation_ids: tuple[str, ...]
+    recovery_step_ids: tuple[str, ...]
+    future_mutation_step_ids: tuple[str, ...]
+    completion_audit_step_ids: tuple[str, ...]
+    milestone_ids: tuple[str, ...]
+    ledger_audit_step_ids: tuple[str, ...]
+    seal_audit_step_ids: tuple[str, ...]
+    seal_digest: str
+    ledger_audit_digest: str
+    ledger_entry_digest: str
+    closure_digest: str
+    audit_digest: str
+    audit_preview: str
+    audit_steps: tuple[MemoryEvidenceRepairRecoveryClosureGovernanceSealAuditStep, ...]
+    would_verify_seal_integrity: bool
+    would_verify_governance_handoff: bool
+    would_verify_source_audit_evidence: bool
+    would_verify_read_only_constraints: bool
+    safety_note: str
+    source_recovery_closure_governance_seal: dict[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "status": self.status,
+            "seal_id": self.seal_id,
+            "ledger_audit_preview_id": self.ledger_audit_preview_id,
+            "ledger_entry_id": self.ledger_entry_id,
+            "closure_id": self.closure_id,
+            "audit_preview_id": self.audit_preview_id,
+            "receipt_id": self.receipt_id,
+            "executor_preview_id": self.executor_preview_id,
+            "decision_id": self.decision_id,
+            "execution_preview_id": self.execution_preview_id,
+            "token_id": self.token_id,
+            "lock_id": self.lock_id,
+            "route": self.route,
+            "operation_ids": list(self.operation_ids),
+            "recovery_step_ids": list(self.recovery_step_ids),
+            "future_mutation_step_ids": list(self.future_mutation_step_ids),
+            "completion_audit_step_ids": list(self.completion_audit_step_ids),
+            "milestone_ids": list(self.milestone_ids),
+            "ledger_audit_step_ids": list(self.ledger_audit_step_ids),
+            "seal_audit_step_ids": list(self.seal_audit_step_ids),
+            "seal_digest": self.seal_digest,
+            "ledger_audit_digest": self.ledger_audit_digest,
+            "ledger_entry_digest": self.ledger_entry_digest,
+            "closure_digest": self.closure_digest,
+            "audit_digest": self.audit_digest,
+            "audit_preview": self.audit_preview,
+            "audit_steps": [step.to_dict() for step in self.audit_steps],
+            "would_verify_seal_integrity": self.would_verify_seal_integrity,
+            "would_verify_governance_handoff": self.would_verify_governance_handoff,
+            "would_verify_source_audit_evidence": self.would_verify_source_audit_evidence,
+            "would_verify_read_only_constraints": self.would_verify_read_only_constraints,
+            "safety_note": self.safety_note,
+            "source_recovery_closure_governance_seal": dict(
+                self.source_recovery_closure_governance_seal
+            ),
+        }
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairRecoveryClosureGovernanceSealAuditPreviewReport:
+    """Read-only recovery closure governance seal audit preview report."""
+
+    generated_at: str
+    status: str
+    checks: tuple[MemoryEvidenceRepairRecoveryClosureGovernanceSealAuditCheck, ...]
+    previews: tuple[MemoryEvidenceRepairRecoveryClosureGovernanceSealAuditPreview, ...]
+    blocking_reasons: tuple[str, ...]
+    required_actions: tuple[str, ...]
+    source_recovery_closure_governance_seal_report: dict[str, Any]
+
+    @property
+    def summary(self) -> dict[str, Any]:
+        by_check_status: dict[str, int] = {}
+        by_audit_step_status: dict[str, int] = {}
+        for check in self.checks:
+            by_check_status[check.status] = by_check_status.get(check.status, 0) + 1
+        for preview in self.previews:
+            for step in preview.audit_steps:
+                by_audit_step_status[step.status] = (
+                    by_audit_step_status.get(step.status, 0) + 1
+                )
+        return {
+            "status": self.status,
+            "check_count": len(self.checks),
+            "pass_count": by_check_status.get(CHECK_STATUS_PASS, 0),
+            "fail_count": by_check_status.get(CHECK_STATUS_FAIL, 0),
+            "preview_count": len(self.previews),
+            "audit_step_count": sum(len(preview.audit_steps) for preview in self.previews),
+            "observed_pass_step_count": by_audit_step_status.get(
+                GOVERNANCE_SEAL_AUDIT_STEP_STATUS_PASS,
+                0,
+            ),
+            "observed_fail_step_count": by_audit_step_status.get(
+                GOVERNANCE_SEAL_AUDIT_STEP_STATUS_FAIL,
+                0,
+            ),
+            "blocking_reason_count": len(self.blocking_reasons),
+            "required_action_count": len(self.required_actions),
+            "recovery_closure_governance_seal_audit_preview_available": bool(
+                self.previews
+            ),
+            "recovery_closure_governance_seal_audit_ready": (
+                self.status == RECOVERY_CLOSURE_GOVERNANCE_SEAL_AUDIT_STATUS_READY
+            ),
+            "has_blocks": (
+                self.status == RECOVERY_CLOSURE_GOVERNANCE_SEAL_AUDIT_STATUS_BLOCKED
+            ),
+            "requires_followup": bool(self.required_actions),
+            "by_check_status": by_check_status,
+            "by_audit_step_status": by_audit_step_status,
+        }
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "generated_at": self.generated_at,
+            "status": self.status,
+            "summary": self.summary,
+            "checks": [check.to_dict() for check in self.checks],
+            "previews": [preview.to_dict() for preview in self.previews],
+            "blocking_reasons": list(self.blocking_reasons),
+            "required_actions": list(self.required_actions),
+            "source_recovery_closure_governance_seal_report": dict(
+                self.source_recovery_closure_governance_seal_report
+            ),
+            "read_only": True,
+            "read_only_memory": True,
+            "would_mutate_memory": False,
+        }
+
+
+def build_evidence_repair_recovery_closure_governance_seal_audit_preview(
+    *,
+    recovery_closure_governance_seal: Mapping[str, Any] | None = None,
+) -> MemoryEvidenceRepairRecoveryClosureGovernanceSealAuditPreviewReport:
+    """Build a read-only audit preview from a recovery governance seal report."""
+
+    recovery_closure_governance_seal = (
+        recovery_closure_governance_seal
+        if isinstance(recovery_closure_governance_seal, Mapping)
+        else {}
+    )
+    report_status = _str(recovery_closure_governance_seal.get("status"))
+    seal = _extract_seal(recovery_closure_governance_seal)
+
+    if not seal:
+        if (
+            not recovery_closure_governance_seal
+            or report_status == RECOVERY_CLOSURE_GOVERNANCE_SEAL_STATUS_NO_ACTION_NEEDED
+        ):
+            return _empty_report(
+                recovery_closure_governance_seal=recovery_closure_governance_seal
+            )
+        source_blocking = tuple(
+            _list_of_str(recovery_closure_governance_seal.get("blocking_reasons"))
+        )
+        source_actions = tuple(
+            _list_of_str(recovery_closure_governance_seal.get("required_actions"))
+        )
+        return _blocked_report(
+            recovery_closure_governance_seal=recovery_closure_governance_seal,
+            checks=(
+                _fail(
+                    CHECK_RECOVERY_GOVERNANCE_SEAL_READY,
+                    "No recovery closure governance seal draft was supplied."
+                    if not source_blocking
+                    else "; ".join(source_blocking),
+                    source_actions
+                    or ("produce_recovery_closure_governance_seal_preview",),
+                    {"recovery_closure_governance_seal_status": report_status},
+                ),
+            ),
+        )
+
+    checks = (
+        _seal_ready_check(recovery_closure_governance_seal, seal),
+        _seal_integrity_check(seal),
+        _seal_source_chain_check(seal),
+        _audit_requirements_check(seal),
+    )
+    blocking_reasons = tuple(
+        _dedupe_strings(check.reason for check in checks if check.status == CHECK_STATUS_FAIL)
+    )
+    required_actions = tuple(
+        _dedupe_strings(
+            action
+            for check in checks
+            if check.status == CHECK_STATUS_FAIL
+            for action in check.required_actions
+        )
+    )
+    if blocking_reasons:
+        return MemoryEvidenceRepairRecoveryClosureGovernanceSealAuditPreviewReport(
+            generated_at=datetime.now(timezone.utc).isoformat(),
+            status=RECOVERY_CLOSURE_GOVERNANCE_SEAL_AUDIT_STATUS_BLOCKED,
+            checks=checks,
+            previews=(),
+            blocking_reasons=blocking_reasons,
+            required_actions=required_actions,
+            source_recovery_closure_governance_seal_report=dict(
+                recovery_closure_governance_seal
+            ),
+        )
+
+    preview = _preview_from_seal(seal)
+    return MemoryEvidenceRepairRecoveryClosureGovernanceSealAuditPreviewReport(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        status=RECOVERY_CLOSURE_GOVERNANCE_SEAL_AUDIT_STATUS_READY,
+        checks=checks,
+        previews=(preview,),
+        blocking_reasons=(),
+        required_actions=(),
+        source_recovery_closure_governance_seal_report=dict(
+            recovery_closure_governance_seal
+        ),
+    )
+
+
+def empty_evidence_repair_recovery_closure_governance_seal_audit_preview() -> MemoryEvidenceRepairRecoveryClosureGovernanceSealAuditPreviewReport:
+    """Return an empty read-only recovery closure governance seal audit preview."""
+
+    return _empty_report(recovery_closure_governance_seal={})
+
+
+def _extract_seal(recovery_closure_governance_seal: Mapping[str, Any]) -> dict[str, Any]:
+    seals = recovery_closure_governance_seal.get("seals")
+    if isinstance(seals, list):
+        for seal in seals:
+            if isinstance(seal, Mapping):
+                return dict(seal)
+    if _str(recovery_closure_governance_seal.get("id")).startswith(
+        "recovery-closure-governance-seal-"
+    ):
+        return dict(recovery_closure_governance_seal)
+    return {}
+
+
+def _seal_ready_check(
+    recovery_closure_governance_seal: Mapping[str, Any],
+    seal: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryClosureGovernanceSealAuditCheck:
+    report_status = _str(recovery_closure_governance_seal.get("status"))
+    seal_status = _str(seal.get("status"))
+    if report_status and report_status != RECOVERY_CLOSURE_GOVERNANCE_SEAL_STATUS_READY:
+        return _fail(
+            CHECK_RECOVERY_GOVERNANCE_SEAL_READY,
+            "Recovery closure governance seal report is not ready for audit preview.",
+            tuple(_list_of_str(recovery_closure_governance_seal.get("required_actions")))
+            or ("produce_ready_recovery_closure_governance_seal_preview",),
+            {"report_status": report_status, "seal_status": seal_status},
+        )
+    if seal_status != RECOVERY_CLOSURE_GOVERNANCE_SEAL_DRAFT_STATUS_READY:
+        return _fail(
+            CHECK_RECOVERY_GOVERNANCE_SEAL_READY,
+            "Recovery closure governance seal draft is not ready for audit preview.",
+            ("regenerate_recovery_closure_governance_seal_preview",),
+            {"report_status": report_status, "seal_status": seal_status},
+        )
+    return _pass(
+        CHECK_RECOVERY_GOVERNANCE_SEAL_READY,
+        "Recovery closure governance seal draft is ready for audit preview.",
+        {"seal_id": _str(seal.get("id"))},
+    )
+
+
+def _seal_integrity_check(
+    seal: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryClosureGovernanceSealAuditCheck:
+    expected_digest = _expected_seal_digest(seal)
+    actual_digest = _str(seal.get("seal_digest"))
+    expected_id = (
+        f"recovery-closure-governance-seal-{expected_digest[:16]}"
+        if expected_digest
+        else ""
+    )
+    missing_fields: list[str] = []
+    for field_name in (
+        "id",
+        "seal_type",
+        "status",
+        "governance_decision",
+        "governance_scope",
+        "ledger_audit_preview_id",
+        "ledger_entry_id",
+        "closure_id",
+        "audit_preview_id",
+        "receipt_id",
+        "executor_preview_id",
+        "decision_id",
+        "execution_preview_id",
+        "token_id",
+        "lock_id",
+        "route",
+        "operation_ids",
+        "recovery_step_ids",
+        "future_mutation_step_ids",
+        "completion_audit_step_ids",
+        "milestone_ids",
+        "ledger_audit_step_ids",
+        "ledger_entry_digest",
+        "closure_digest",
+        "ledger_audit_digest",
+        "seal_digest",
+        "source_recovery_closure_ledger_audit_preview",
+    ):
+        value = seal.get(field_name)
+        if isinstance(value, list) and not value:
+            missing_fields.append(field_name)
+        elif isinstance(value, Mapping) and not value:
+            missing_fields.append(field_name)
+        elif not isinstance(value, (list, Mapping)) and not _str(value):
+            missing_fields.append(field_name)
+    if (
+        missing_fields
+        or actual_digest != expected_digest
+        or _str(seal.get("id")) != expected_id
+        or _str(seal.get("seal_type")) != RECOVERY_CLOSURE_GOVERNANCE_SEAL_TYPE
+        or _str(seal.get("governance_decision"))
+        != RECOVERY_CLOSURE_GOVERNANCE_DECISION
+        or _str(seal.get("governance_scope")) != RECOVERY_CLOSURE_GOVERNANCE_SCOPE
+    ):
+        return _fail(
+            CHECK_RECOVERY_GOVERNANCE_SEAL_INTEGRITY,
+            "Recovery closure governance seal digest, id, type, scope, or required fields are invalid.",
+            ("regenerate_recovery_closure_governance_seal_preview",),
+            {
+                "expected_seal_digest": expected_digest,
+                "actual_seal_digest": actual_digest,
+                "expected_seal_id": expected_id,
+                "actual_seal_id": _str(seal.get("id")),
+                "missing_fields": missing_fields,
+            },
+        )
+    return _pass(
+        CHECK_RECOVERY_GOVERNANCE_SEAL_INTEGRITY,
+        "Recovery closure governance seal integrity checks pass.",
+        {"seal_id": expected_id, "seal_digest": actual_digest},
+    )
+
+
+def _seal_source_chain_check(
+    seal: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryClosureGovernanceSealAuditCheck:
+    ledger_audit = _dict(seal.get("source_recovery_closure_ledger_audit_preview"))
+    entry = _dict(ledger_audit.get("source_recovery_closure_ledger_entry"))
+    mismatches: list[dict[str, str]] = []
+    for field_name in (
+        "ledger_audit_preview_id",
+        "ledger_entry_id",
+        "closure_id",
+        "audit_preview_id",
+        "receipt_id",
+        "executor_preview_id",
+        "decision_id",
+        "execution_preview_id",
+        "token_id",
+        "lock_id",
+        "route",
+        "ledger_entry_digest",
+        "closure_digest",
+    ):
+        audit_key = "id" if field_name == "ledger_audit_preview_id" else field_name
+        if field_name == "ledger_audit_digest":
+            audit_key = "audit_digest"
+        _compare(mismatches, field_name, seal, field_name, ledger_audit, audit_key)
+    if _str(seal.get("ledger_audit_digest")) != _str(ledger_audit.get("audit_digest")):
+        mismatches.append(
+            {
+                "field": "ledger_audit_digest",
+                "left": _str(seal.get("ledger_audit_digest")),
+                "right": _str(ledger_audit.get("audit_digest")),
+                "right_key": "source_recovery_closure_ledger_audit_preview.audit_digest",
+            }
+        )
+    audit_steps = _audit_steps(ledger_audit)
+    non_pass_steps = [
+        _str(step.get("id")) or f"ledger-audit-step-{index}"
+        for index, step in enumerate(audit_steps, start=1)
+        if _str(step.get("status")) != LEDGER_AUDIT_STEP_STATUS_PASS
+    ]
+    missing_sources = [
+        name
+        for name, source in (
+            ("source_recovery_closure_ledger_audit_preview", ledger_audit),
+            ("source_recovery_closure_ledger_entry", entry),
+        )
+        if not source
+    ]
+    if (
+        missing_sources
+        or mismatches
+        or _str(ledger_audit.get("status"))
+        != RECOVERY_CLOSURE_LEDGER_AUDIT_PREVIEW_STATUS_READY
+        or _str(entry.get("status")) != RECOVERY_CLOSURE_LEDGER_ENTRY_STATUS_READY
+        or non_pass_steps
+    ):
+        return _fail(
+            CHECK_RECOVERY_GOVERNANCE_SEAL_AUDIT_SOURCE_CHAIN,
+            "Recovery closure governance seal source chain is incomplete or inconsistent.",
+            ("regenerate_recovery_closure_governance_seal_preview",),
+            {
+                "missing_sources": missing_sources,
+                "mismatches": mismatches,
+                "ledger_audit_status": _str(ledger_audit.get("status")),
+                "entry_status": _str(entry.get("status")),
+                "non_pass_ledger_audit_step_ids": non_pass_steps,
+            },
+        )
+    return _pass(
+        CHECK_RECOVERY_GOVERNANCE_SEAL_AUDIT_SOURCE_CHAIN,
+        "Recovery closure governance seal source chain is internally consistent.",
+        {
+            "seal_id": _str(seal.get("id")),
+            "ledger_audit_preview_id": _str(seal.get("ledger_audit_preview_id")),
+            "ledger_entry_id": _str(seal.get("ledger_entry_id")),
+            "ledger_audit_step_count": len(audit_steps),
+        },
+    )
+
+
+def _audit_requirements_check(
+    seal: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryClosureGovernanceSealAuditCheck:
+    required_flags = (
+        "would_freeze_recovery_closure",
+        "would_preserve_audit_evidence",
+        "would_enable_governed_handoff",
+        "would_block_unreviewed_mutation",
+    )
+    missing_flags = [field_name for field_name in required_flags if seal.get(field_name) is not True]
+    missing_lists = [
+        field_name
+        for field_name in (
+            "operation_ids",
+            "recovery_step_ids",
+            "future_mutation_step_ids",
+            "completion_audit_step_ids",
+            "milestone_ids",
+            "ledger_audit_step_ids",
+        )
+        if not _list_of_str(seal.get(field_name))
+    ]
+    ledger_audit = _dict(seal.get("source_recovery_closure_ledger_audit_preview"))
+    source_flags = (
+        "would_verify_ledger_entry_integrity",
+        "would_verify_closure_source_integrity",
+        "would_verify_lifecycle_milestones",
+        "would_verify_completion_audit_evidence",
+    )
+    missing_source_flags = [
+        field_name for field_name in source_flags if ledger_audit.get(field_name) is not True
+    ]
+    if missing_flags or missing_lists or missing_source_flags:
+        return _fail(
+            CHECK_RECOVERY_GOVERNANCE_SEAL_AUDIT_REQUIREMENTS,
+            "Recovery closure governance seal audit requirements are incomplete.",
+            ("regenerate_recovery_closure_governance_seal_preview",),
+            {
+                "missing_flags": missing_flags,
+                "missing_lists": missing_lists,
+                "missing_source_flags": missing_source_flags,
+            },
+        )
+    return _pass(
+        CHECK_RECOVERY_GOVERNANCE_SEAL_AUDIT_REQUIREMENTS,
+        "Recovery closure governance seal audit can verify integrity, handoff, source evidence, and read-only constraints.",
+        {
+            "ledger_audit_step_count": len(_audit_steps(ledger_audit)),
+            "milestone_count": len(_list_of_str(seal.get("milestone_ids"))),
+        },
+    )
+
+
+def _preview_from_seal(
+    seal: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryClosureGovernanceSealAuditPreview:
+    audit_steps = tuple(_audit_steps_from_seal(seal))
+    seal_audit_step_ids = tuple(step.id for step in audit_steps)
+    operation_ids = tuple(_list_of_str(seal.get("operation_ids")))
+    recovery_step_ids = tuple(_list_of_str(seal.get("recovery_step_ids")))
+    future_mutation_step_ids = tuple(_list_of_str(seal.get("future_mutation_step_ids")))
+    completion_audit_step_ids = tuple(_list_of_str(seal.get("completion_audit_step_ids")))
+    milestone_ids = tuple(_list_of_str(seal.get("milestone_ids")))
+    ledger_audit_step_ids = tuple(_list_of_str(seal.get("ledger_audit_step_ids")))
+    audit_seed = {
+        "seal_id": _str(seal.get("id")),
+        "ledger_audit_preview_id": _str(seal.get("ledger_audit_preview_id")),
+        "ledger_entry_id": _str(seal.get("ledger_entry_id")),
+        "closure_id": _str(seal.get("closure_id")),
+        "audit_preview_id": _str(seal.get("audit_preview_id")),
+        "receipt_id": _str(seal.get("receipt_id")),
+        "executor_preview_id": _str(seal.get("executor_preview_id")),
+        "decision_id": _str(seal.get("decision_id")),
+        "execution_preview_id": _str(seal.get("execution_preview_id")),
+        "token_id": _str(seal.get("token_id")),
+        "lock_id": _str(seal.get("lock_id")),
+        "route": _str(seal.get("route")),
+        "operation_ids": operation_ids,
+        "recovery_step_ids": recovery_step_ids,
+        "future_mutation_step_ids": future_mutation_step_ids,
+        "completion_audit_step_ids": completion_audit_step_ids,
+        "milestone_ids": milestone_ids,
+        "ledger_audit_step_ids": ledger_audit_step_ids,
+        "seal_audit_step_ids": seal_audit_step_ids,
+        "seal_digest": _str(seal.get("seal_digest")),
+        "ledger_audit_digest": _str(seal.get("ledger_audit_digest")),
+        "ledger_entry_digest": _str(seal.get("ledger_entry_digest")),
+        "closure_digest": _str(seal.get("closure_digest")),
+    }
+    audit_digest = _digest(audit_seed)
+    audit_id = f"recovery-closure-governance-seal-audit-{audit_digest[:16]}"
+    return MemoryEvidenceRepairRecoveryClosureGovernanceSealAuditPreview(
+        id=audit_id,
+        status=RECOVERY_CLOSURE_GOVERNANCE_SEAL_AUDIT_PREVIEW_STATUS_READY,
+        seal_id=_str(seal.get("id")),
+        ledger_audit_preview_id=_str(seal.get("ledger_audit_preview_id")),
+        ledger_entry_id=_str(seal.get("ledger_entry_id")),
+        closure_id=_str(seal.get("closure_id")),
+        audit_preview_id=_str(seal.get("audit_preview_id")),
+        receipt_id=_str(seal.get("receipt_id")),
+        executor_preview_id=_str(seal.get("executor_preview_id")),
+        decision_id=_str(seal.get("decision_id")),
+        execution_preview_id=_str(seal.get("execution_preview_id")),
+        token_id=_str(seal.get("token_id")),
+        lock_id=_str(seal.get("lock_id")),
+        route=_str(seal.get("route")),
+        operation_ids=operation_ids,
+        recovery_step_ids=recovery_step_ids,
+        future_mutation_step_ids=future_mutation_step_ids,
+        completion_audit_step_ids=completion_audit_step_ids,
+        milestone_ids=milestone_ids,
+        ledger_audit_step_ids=ledger_audit_step_ids,
+        seal_audit_step_ids=seal_audit_step_ids,
+        seal_digest=_str(seal.get("seal_digest")),
+        ledger_audit_digest=_str(seal.get("ledger_audit_digest")),
+        ledger_entry_digest=_str(seal.get("ledger_entry_digest")),
+        closure_digest=_str(seal.get("closure_digest")),
+        audit_digest=audit_digest,
+        audit_preview=f"{audit_id}:{audit_digest[:12]}",
+        audit_steps=audit_steps,
+        would_verify_seal_integrity=True,
+        would_verify_governance_handoff=True,
+        would_verify_source_audit_evidence=True,
+        would_verify_read_only_constraints=True,
+        safety_note=(
+            "Read-only recovery closure governance seal audit preview. It checks "
+            "a future governance seal's traceability and handoff controls, but "
+            "does not record an audit or mutate durable memory."
+        ),
+        source_recovery_closure_governance_seal=dict(seal),
+    )
+
+
+def _audit_steps_from_seal(
+    seal: Mapping[str, Any],
+) -> list[MemoryEvidenceRepairRecoveryClosureGovernanceSealAuditStep]:
+    ledger_audit = _dict(seal.get("source_recovery_closure_ledger_audit_preview"))
+    rows = (
+        (
+            "seal_integrity",
+            "seal_digest_valid",
+            _str(seal.get("id")),
+            {"expected_seal_digest": _expected_seal_digest(seal)},
+            {"actual_seal_digest": _str(seal.get("seal_digest"))},
+        ),
+        (
+            "ledger_audit_source",
+            "ledger_audit_digest_valid",
+            _str(seal.get("ledger_audit_preview_id")),
+            {"expected_ledger_audit_digest": _expected_ledger_audit_digest(ledger_audit)},
+            {"actual_ledger_audit_digest": _str(seal.get("ledger_audit_digest"))},
+        ),
+        (
+            "ledger_entry_source",
+            "ledger_entry_reference_consistent",
+            _str(seal.get("ledger_entry_id")),
+            {"ledger_entry_id": _str(seal.get("ledger_entry_id"))},
+            {"source_ledger_entry_id": _str(ledger_audit.get("ledger_entry_id"))},
+        ),
+        (
+            "closure_trace",
+            "closure_reference_consistent",
+            _str(seal.get("closure_id")),
+            {"closure_id": _str(seal.get("closure_id"))},
+            {"source_closure_id": _str(ledger_audit.get("closure_id"))},
+        ),
+        (
+            "governance_controls",
+            "governance_handoff_controls_present",
+            _str(seal.get("id")),
+            {
+                "would_freeze_recovery_closure": True,
+                "would_enable_governed_handoff": True,
+            },
+            {
+                "would_freeze_recovery_closure": seal.get("would_freeze_recovery_closure")
+                is True,
+                "would_enable_governed_handoff": seal.get("would_enable_governed_handoff")
+                is True,
+            },
+        ),
+        (
+            "read_only",
+            "seal_is_preview_only",
+            _str(seal.get("id")),
+            {"would_block_unreviewed_mutation": True},
+            {
+                "would_block_unreviewed_mutation": seal.get(
+                    "would_block_unreviewed_mutation"
+                )
+                is True
+            },
+        ),
+    )
+    return [
+        _audit_step(
+            sequence=index,
+            category=category,
+            assertion=assertion,
+            seal=seal,
+            reference_id=reference_id,
+            expected_signal=expected_signal,
+            observed_signal=observed_signal,
+        )
+        for index, (
+            category,
+            assertion,
+            reference_id,
+            expected_signal,
+            observed_signal,
+        ) in enumerate(rows, start=1)
+    ]
+
+
+def _audit_step(
+    *,
+    sequence: int,
+    category: str,
+    assertion: str,
+    seal: Mapping[str, Any],
+    reference_id: str,
+    expected_signal: Mapping[str, Any],
+    observed_signal: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryClosureGovernanceSealAuditStep:
+    step_seed = {
+        "sequence": sequence,
+        "category": category,
+        "assertion": assertion,
+        "seal_id": _str(seal.get("id")),
+        "reference_id": _str(reference_id),
+    }
+    step_id = f"recovery-closure-governance-seal-audit-step-{_digest(step_seed)[:16]}"
+    return MemoryEvidenceRepairRecoveryClosureGovernanceSealAuditStep(
+        id=step_id,
+        sequence=sequence,
+        category=category,
+        assertion=assertion,
+        seal_id=_str(seal.get("id")),
+        reference_id=_str(reference_id),
+        expected_signal=dict(expected_signal),
+        observed_signal=dict(observed_signal),
+        status=GOVERNANCE_SEAL_AUDIT_STEP_STATUS_PASS,
+        required_action_on_fail="regenerate_recovery_closure_governance_seal_preview",
+    )
+
+
+def _expected_seal_digest(seal: Mapping[str, Any]) -> str:
+    seed = {
+        "seal_type": RECOVERY_CLOSURE_GOVERNANCE_SEAL_TYPE,
+        "governance_decision": RECOVERY_CLOSURE_GOVERNANCE_DECISION,
+        "governance_scope": RECOVERY_CLOSURE_GOVERNANCE_SCOPE,
+        "ledger_audit_preview_id": _str(seal.get("ledger_audit_preview_id")),
+        "ledger_entry_id": _str(seal.get("ledger_entry_id")),
+        "closure_id": _str(seal.get("closure_id")),
+        "audit_preview_id": _str(seal.get("audit_preview_id")),
+        "receipt_id": _str(seal.get("receipt_id")),
+        "executor_preview_id": _str(seal.get("executor_preview_id")),
+        "decision_id": _str(seal.get("decision_id")),
+        "execution_preview_id": _str(seal.get("execution_preview_id")),
+        "token_id": _str(seal.get("token_id")),
+        "lock_id": _str(seal.get("lock_id")),
+        "route": _str(seal.get("route")),
+        "operation_ids": tuple(_list_of_str(seal.get("operation_ids"))),
+        "recovery_step_ids": tuple(_list_of_str(seal.get("recovery_step_ids"))),
+        "future_mutation_step_ids": tuple(
+            _list_of_str(seal.get("future_mutation_step_ids"))
+        ),
+        "completion_audit_step_ids": tuple(
+            _list_of_str(seal.get("completion_audit_step_ids"))
+        ),
+        "milestone_ids": tuple(_list_of_str(seal.get("milestone_ids"))),
+        "ledger_audit_step_ids": tuple(
+            _list_of_str(seal.get("ledger_audit_step_ids"))
+        ),
+        "ledger_entry_digest": _str(seal.get("ledger_entry_digest")),
+        "closure_digest": _str(seal.get("closure_digest")),
+        "ledger_audit_digest": _str(seal.get("ledger_audit_digest")),
+    }
+    return _digest(seed)
+
+
+def _expected_ledger_audit_digest(preview: Mapping[str, Any]) -> str:
+    seed = {
+        "ledger_entry_id": _str(preview.get("ledger_entry_id")),
+        "closure_id": _str(preview.get("closure_id")),
+        "audit_preview_id": _str(preview.get("audit_preview_id")),
+        "receipt_id": _str(preview.get("receipt_id")),
+        "executor_preview_id": _str(preview.get("executor_preview_id")),
+        "decision_id": _str(preview.get("decision_id")),
+        "execution_preview_id": _str(preview.get("execution_preview_id")),
+        "token_id": _str(preview.get("token_id")),
+        "lock_id": _str(preview.get("lock_id")),
+        "route": _str(preview.get("route")),
+        "operation_ids": tuple(_list_of_str(preview.get("operation_ids"))),
+        "recovery_step_ids": tuple(_list_of_str(preview.get("recovery_step_ids"))),
+        "future_mutation_step_ids": tuple(
+            _list_of_str(preview.get("future_mutation_step_ids"))
+        ),
+        "completion_audit_step_ids": tuple(
+            _list_of_str(preview.get("completion_audit_step_ids"))
+        ),
+        "milestone_ids": tuple(_list_of_str(preview.get("milestone_ids"))),
+        "ledger_audit_step_ids": tuple(
+            _list_of_str(preview.get("ledger_audit_step_ids"))
+        ),
+        "entry_digest": _str(preview.get("ledger_entry_digest")),
+        "closure_digest": _str(preview.get("closure_digest")),
+    }
+    return _digest(seed)
+
+
+def _audit_steps(preview: Mapping[str, Any]) -> list[Mapping[str, Any]]:
+    return [
+        step
+        for step in _list(preview.get("audit_steps"))
+        if isinstance(step, Mapping)
+    ]
+
+
+def _compare(
+    mismatches: list[dict[str, str]],
+    label: str,
+    left: Mapping[str, Any],
+    left_key: str,
+    right: Mapping[str, Any],
+    right_key: str,
+) -> None:
+    left_value = _str(left.get(left_key))
+    right_value = _str(right.get(right_key))
+    if left_value != right_value:
+        mismatches.append(
+            {
+                "field": label,
+                "left": left_value,
+                "right": right_value,
+                "right_key": right_key,
+            }
+        )
+
+
+def _empty_report(
+    *,
+    recovery_closure_governance_seal: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryClosureGovernanceSealAuditPreviewReport:
+    return MemoryEvidenceRepairRecoveryClosureGovernanceSealAuditPreviewReport(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        status=RECOVERY_CLOSURE_GOVERNANCE_SEAL_AUDIT_STATUS_NO_ACTION_NEEDED,
+        checks=(),
+        previews=(),
+        blocking_reasons=(),
+        required_actions=(),
+        source_recovery_closure_governance_seal_report=dict(
+            recovery_closure_governance_seal
+        ),
+    )
+
+
+def _blocked_report(
+    *,
+    recovery_closure_governance_seal: Mapping[str, Any],
+    checks: tuple[MemoryEvidenceRepairRecoveryClosureGovernanceSealAuditCheck, ...],
+) -> MemoryEvidenceRepairRecoveryClosureGovernanceSealAuditPreviewReport:
+    return MemoryEvidenceRepairRecoveryClosureGovernanceSealAuditPreviewReport(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        status=RECOVERY_CLOSURE_GOVERNANCE_SEAL_AUDIT_STATUS_BLOCKED,
+        checks=checks,
+        previews=(),
+        blocking_reasons=tuple(
+            _dedupe_strings(check.reason for check in checks if check.status == CHECK_STATUS_FAIL)
+        ),
+        required_actions=tuple(
+            _dedupe_strings(
+                action
+                for check in checks
+                if check.status == CHECK_STATUS_FAIL
+                for action in check.required_actions
+            )
+        ),
+        source_recovery_closure_governance_seal_report=dict(
+            recovery_closure_governance_seal
+        ),
+    )
+
+
+def _pass(
+    check_id: str,
+    reason: str,
+    details: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryClosureGovernanceSealAuditCheck:
+    return MemoryEvidenceRepairRecoveryClosureGovernanceSealAuditCheck(
+        id=check_id,
+        status=CHECK_STATUS_PASS,
+        reason=reason,
+        required_actions=(),
+        details=dict(details),
+    )
+
+
+def _fail(
+    check_id: str,
+    reason: str,
+    required_actions: Sequence[str],
+    details: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryClosureGovernanceSealAuditCheck:
+    return MemoryEvidenceRepairRecoveryClosureGovernanceSealAuditCheck(
+        id=check_id,
+        status=CHECK_STATUS_FAIL,
+        reason=reason,
+        required_actions=tuple(required_actions),
+        details=dict(details),
+    )
+
+
+def _digest(value: Any) -> str:
+    raw = json.dumps(value, sort_keys=True, ensure_ascii=False, default=str)
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def _dict(value: Any) -> dict[str, Any]:
+    return dict(value) if isinstance(value, Mapping) else {}
+
+
+def _list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _list_of_str(value: Any) -> list[str]:
+    return [_str(item) for item in value] if isinstance(value, list) else []
+
+
+def _dedupe_strings(values: Sequence[str] | Any) -> list[str]:
+    seen: set[str] = set()
+    result: list[str] = []
+    for value in values:
+        text = _str(value)
+        if text and text not in seen:
+            seen.add(text)
+            result.append(text)
+    return result
+
+
+def _str(value: Any) -> str:
+    return str(value or "").strip()

--- a/agent/memory_evidence_repair_recovery_closure_governance_seal_preview.py
+++ b/agent/memory_evidence_repair_recovery_closure_governance_seal_preview.py
@@ -1,0 +1,770 @@
+"""Read-only recovery closure governance seal preview for memory evidence repair.
+
+The governance seal preview turns a ready recovery closure ledger audit into a
+final governance seal draft. It never writes durable memory, records a real
+seal, or freezes a real recovery closure.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Mapping, Sequence
+
+from agent.memory_evidence_repair_manual_commit_dry_run import (
+    CHECK_STATUS_FAIL,
+    CHECK_STATUS_PASS,
+)
+from agent.memory_evidence_repair_recovery_closure_ledger_audit_preview import (
+    LEDGER_AUDIT_STEP_STATUS_PASS,
+    RECOVERY_CLOSURE_LEDGER_AUDIT_PREVIEW_STATUS_READY,
+    RECOVERY_CLOSURE_LEDGER_AUDIT_STATUS_NO_ACTION_NEEDED,
+    RECOVERY_CLOSURE_LEDGER_AUDIT_STATUS_READY,
+)
+from agent.memory_evidence_repair_recovery_closure_ledger_preview import (
+    RECOVERY_CLOSURE_LEDGER_ENTRY_STATUS_READY,
+)
+
+
+RECOVERY_CLOSURE_GOVERNANCE_SEAL_STATUS_READY = (
+    "recovery_closure_governance_seal_preview_ready"
+)
+RECOVERY_CLOSURE_GOVERNANCE_SEAL_STATUS_BLOCKED = "blocked"
+RECOVERY_CLOSURE_GOVERNANCE_SEAL_STATUS_NO_ACTION_NEEDED = "no_action_needed"
+RECOVERY_CLOSURE_GOVERNANCE_SEAL_DRAFT_STATUS_READY = (
+    "recovery_closure_governance_seal_draft_ready"
+)
+RECOVERY_CLOSURE_GOVERNANCE_SEAL_TYPE = (
+    "memory_evidence_repair_recovery_closure_governance_seal"
+)
+RECOVERY_CLOSURE_GOVERNANCE_DECISION = "seal_recovery_closure"
+RECOVERY_CLOSURE_GOVERNANCE_SCOPE = "manual_memory_evidence_repair_recovery_closure"
+
+CHECK_RECOVERY_CLOSURE_LEDGER_AUDIT_READY = "recovery_closure_ledger_audit_ready"
+CHECK_RECOVERY_CLOSURE_LEDGER_AUDIT_INTEGRITY = (
+    "recovery_closure_ledger_audit_integrity"
+)
+CHECK_RECOVERY_GOVERNANCE_SEAL_SOURCE_CHAIN = (
+    "recovery_governance_seal_source_chain"
+)
+CHECK_RECOVERY_GOVERNANCE_SEAL_REQUIREMENTS = (
+    "recovery_governance_seal_requirements"
+)
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairRecoveryClosureGovernanceSealCheck:
+    """One read-only recovery closure governance seal check."""
+
+    id: str
+    status: str
+    reason: str
+    required_actions: tuple[str, ...]
+    details: dict[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "status": self.status,
+            "reason": self.reason,
+            "required_actions": list(self.required_actions),
+            "details": dict(self.details),
+        }
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairRecoveryClosureGovernanceSealDraft:
+    """One read-only future recovery closure governance seal draft."""
+
+    id: str
+    seal_type: str
+    status: str
+    governance_decision: str
+    governance_scope: str
+    ledger_audit_preview_id: str
+    ledger_entry_id: str
+    closure_id: str
+    audit_preview_id: str
+    receipt_id: str
+    executor_preview_id: str
+    decision_id: str
+    execution_preview_id: str
+    token_id: str
+    lock_id: str
+    route: str
+    operation_ids: tuple[str, ...]
+    recovery_step_ids: tuple[str, ...]
+    future_mutation_step_ids: tuple[str, ...]
+    completion_audit_step_ids: tuple[str, ...]
+    milestone_ids: tuple[str, ...]
+    ledger_audit_step_ids: tuple[str, ...]
+    ledger_entry_digest: str
+    closure_digest: str
+    ledger_audit_digest: str
+    seal_digest: str
+    seal_preview: str
+    would_freeze_recovery_closure: bool
+    would_preserve_audit_evidence: bool
+    would_enable_governed_handoff: bool
+    would_block_unreviewed_mutation: bool
+    safety_note: str
+    source_recovery_closure_ledger_audit_preview: dict[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "seal_type": self.seal_type,
+            "status": self.status,
+            "governance_decision": self.governance_decision,
+            "governance_scope": self.governance_scope,
+            "ledger_audit_preview_id": self.ledger_audit_preview_id,
+            "ledger_entry_id": self.ledger_entry_id,
+            "closure_id": self.closure_id,
+            "audit_preview_id": self.audit_preview_id,
+            "receipt_id": self.receipt_id,
+            "executor_preview_id": self.executor_preview_id,
+            "decision_id": self.decision_id,
+            "execution_preview_id": self.execution_preview_id,
+            "token_id": self.token_id,
+            "lock_id": self.lock_id,
+            "route": self.route,
+            "operation_ids": list(self.operation_ids),
+            "recovery_step_ids": list(self.recovery_step_ids),
+            "future_mutation_step_ids": list(self.future_mutation_step_ids),
+            "completion_audit_step_ids": list(self.completion_audit_step_ids),
+            "milestone_ids": list(self.milestone_ids),
+            "ledger_audit_step_ids": list(self.ledger_audit_step_ids),
+            "ledger_entry_digest": self.ledger_entry_digest,
+            "closure_digest": self.closure_digest,
+            "ledger_audit_digest": self.ledger_audit_digest,
+            "seal_digest": self.seal_digest,
+            "seal_preview": self.seal_preview,
+            "would_freeze_recovery_closure": self.would_freeze_recovery_closure,
+            "would_preserve_audit_evidence": self.would_preserve_audit_evidence,
+            "would_enable_governed_handoff": self.would_enable_governed_handoff,
+            "would_block_unreviewed_mutation": self.would_block_unreviewed_mutation,
+            "safety_note": self.safety_note,
+            "source_recovery_closure_ledger_audit_preview": dict(
+                self.source_recovery_closure_ledger_audit_preview
+            ),
+        }
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairRecoveryClosureGovernanceSealPreviewReport:
+    """Read-only recovery closure governance seal preview report."""
+
+    generated_at: str
+    status: str
+    checks: tuple[MemoryEvidenceRepairRecoveryClosureGovernanceSealCheck, ...]
+    seals: tuple[MemoryEvidenceRepairRecoveryClosureGovernanceSealDraft, ...]
+    blocking_reasons: tuple[str, ...]
+    required_actions: tuple[str, ...]
+    source_recovery_closure_ledger_audit_report: dict[str, Any]
+
+    @property
+    def summary(self) -> dict[str, Any]:
+        by_check_status: dict[str, int] = {}
+        for check in self.checks:
+            by_check_status[check.status] = by_check_status.get(check.status, 0) + 1
+        return {
+            "status": self.status,
+            "check_count": len(self.checks),
+            "pass_count": by_check_status.get(CHECK_STATUS_PASS, 0),
+            "fail_count": by_check_status.get(CHECK_STATUS_FAIL, 0),
+            "seal_count": len(self.seals),
+            "blocking_reason_count": len(self.blocking_reasons),
+            "required_action_count": len(self.required_actions),
+            "recovery_closure_governance_seal_available": bool(self.seals),
+            "recovery_closure_governance_seal_ready": (
+                self.status == RECOVERY_CLOSURE_GOVERNANCE_SEAL_STATUS_READY
+            ),
+            "would_freeze_recovery_closure_count": sum(
+                1 for seal in self.seals if seal.would_freeze_recovery_closure
+            ),
+            "would_enable_governed_handoff_count": sum(
+                1 for seal in self.seals if seal.would_enable_governed_handoff
+            ),
+            "has_blocks": self.status == RECOVERY_CLOSURE_GOVERNANCE_SEAL_STATUS_BLOCKED,
+            "requires_followup": bool(self.required_actions),
+            "by_check_status": by_check_status,
+        }
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "generated_at": self.generated_at,
+            "status": self.status,
+            "summary": self.summary,
+            "checks": [check.to_dict() for check in self.checks],
+            "seals": [seal.to_dict() for seal in self.seals],
+            "blocking_reasons": list(self.blocking_reasons),
+            "required_actions": list(self.required_actions),
+            "source_recovery_closure_ledger_audit_report": dict(
+                self.source_recovery_closure_ledger_audit_report
+            ),
+            "read_only": True,
+            "read_only_memory": True,
+            "would_mutate_memory": False,
+        }
+
+
+def build_evidence_repair_recovery_closure_governance_seal_preview(
+    *,
+    recovery_closure_ledger_audit: Mapping[str, Any] | None = None,
+) -> MemoryEvidenceRepairRecoveryClosureGovernanceSealPreviewReport:
+    """Build a read-only governance seal from a ready closure ledger audit."""
+
+    recovery_closure_ledger_audit = (
+        recovery_closure_ledger_audit
+        if isinstance(recovery_closure_ledger_audit, Mapping)
+        else {}
+    )
+    report_status = _str(recovery_closure_ledger_audit.get("status"))
+    preview = _extract_preview(recovery_closure_ledger_audit)
+
+    if not preview:
+        if (
+            not recovery_closure_ledger_audit
+            or report_status == RECOVERY_CLOSURE_LEDGER_AUDIT_STATUS_NO_ACTION_NEEDED
+        ):
+            return _empty_report(
+                recovery_closure_ledger_audit=recovery_closure_ledger_audit
+            )
+        source_blocking = tuple(
+            _list_of_str(recovery_closure_ledger_audit.get("blocking_reasons"))
+        )
+        source_actions = tuple(
+            _list_of_str(recovery_closure_ledger_audit.get("required_actions"))
+        )
+        return _blocked_report(
+            recovery_closure_ledger_audit=recovery_closure_ledger_audit,
+            checks=(
+                _fail(
+                    CHECK_RECOVERY_CLOSURE_LEDGER_AUDIT_READY,
+                    "No recovery closure ledger audit preview was supplied."
+                    if not source_blocking
+                    else "; ".join(source_blocking),
+                    source_actions
+                    or ("produce_recovery_closure_ledger_audit_preview",),
+                    {"recovery_closure_ledger_audit_status": report_status},
+                ),
+            ),
+        )
+
+    checks = (
+        _ledger_audit_ready_check(recovery_closure_ledger_audit, preview),
+        _ledger_audit_integrity_check(preview),
+        _seal_source_chain_check(preview),
+        _seal_requirements_check(preview),
+    )
+    blocking_reasons = tuple(
+        _dedupe_strings(check.reason for check in checks if check.status == CHECK_STATUS_FAIL)
+    )
+    required_actions = tuple(
+        _dedupe_strings(
+            action
+            for check in checks
+            if check.status == CHECK_STATUS_FAIL
+            for action in check.required_actions
+        )
+    )
+    if blocking_reasons:
+        return MemoryEvidenceRepairRecoveryClosureGovernanceSealPreviewReport(
+            generated_at=datetime.now(timezone.utc).isoformat(),
+            status=RECOVERY_CLOSURE_GOVERNANCE_SEAL_STATUS_BLOCKED,
+            checks=checks,
+            seals=(),
+            blocking_reasons=blocking_reasons,
+            required_actions=required_actions,
+            source_recovery_closure_ledger_audit_report=dict(
+                recovery_closure_ledger_audit
+            ),
+        )
+
+    seal = _seal_from_ledger_audit(preview)
+    return MemoryEvidenceRepairRecoveryClosureGovernanceSealPreviewReport(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        status=RECOVERY_CLOSURE_GOVERNANCE_SEAL_STATUS_READY,
+        checks=checks,
+        seals=(seal,),
+        blocking_reasons=(),
+        required_actions=(),
+        source_recovery_closure_ledger_audit_report=dict(recovery_closure_ledger_audit),
+    )
+
+
+def empty_evidence_repair_recovery_closure_governance_seal_preview() -> MemoryEvidenceRepairRecoveryClosureGovernanceSealPreviewReport:
+    """Return an empty read-only recovery closure governance seal preview."""
+
+    return _empty_report(recovery_closure_ledger_audit={})
+
+
+def _extract_preview(recovery_closure_ledger_audit: Mapping[str, Any]) -> dict[str, Any]:
+    previews = recovery_closure_ledger_audit.get("previews")
+    if isinstance(previews, list):
+        for preview in previews:
+            if isinstance(preview, Mapping):
+                return dict(preview)
+    if _str(recovery_closure_ledger_audit.get("id")).startswith(
+        "recovery-closure-ledger-audit-"
+    ):
+        return dict(recovery_closure_ledger_audit)
+    return {}
+
+
+def _ledger_audit_ready_check(
+    recovery_closure_ledger_audit: Mapping[str, Any],
+    preview: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryClosureGovernanceSealCheck:
+    report_status = _str(recovery_closure_ledger_audit.get("status"))
+    preview_status = _str(preview.get("status"))
+    if report_status and report_status != RECOVERY_CLOSURE_LEDGER_AUDIT_STATUS_READY:
+        return _fail(
+            CHECK_RECOVERY_CLOSURE_LEDGER_AUDIT_READY,
+            "Recovery closure ledger audit report is not ready for governance sealing.",
+            tuple(_list_of_str(recovery_closure_ledger_audit.get("required_actions")))
+            or ("produce_ready_recovery_closure_ledger_audit_preview",),
+            {"report_status": report_status, "preview_status": preview_status},
+        )
+    if preview_status != RECOVERY_CLOSURE_LEDGER_AUDIT_PREVIEW_STATUS_READY:
+        return _fail(
+            CHECK_RECOVERY_CLOSURE_LEDGER_AUDIT_READY,
+            "Recovery closure ledger audit preview is not ready for governance sealing.",
+            ("regenerate_recovery_closure_ledger_audit_preview",),
+            {"report_status": report_status, "preview_status": preview_status},
+        )
+    return _pass(
+        CHECK_RECOVERY_CLOSURE_LEDGER_AUDIT_READY,
+        "Recovery closure ledger audit preview is ready for governance sealing.",
+        {"ledger_audit_preview_id": _str(preview.get("id"))},
+    )
+
+
+def _ledger_audit_integrity_check(
+    preview: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryClosureGovernanceSealCheck:
+    expected_digest = _expected_ledger_audit_digest(preview)
+    actual_digest = _str(preview.get("audit_digest"))
+    expected_id = (
+        f"recovery-closure-ledger-audit-{expected_digest[:16]}"
+        if expected_digest
+        else ""
+    )
+    missing_fields: list[str] = []
+    for field_name in (
+        "id",
+        "status",
+        "ledger_entry_id",
+        "closure_id",
+        "audit_preview_id",
+        "receipt_id",
+        "executor_preview_id",
+        "decision_id",
+        "execution_preview_id",
+        "token_id",
+        "lock_id",
+        "route",
+        "operation_ids",
+        "recovery_step_ids",
+        "future_mutation_step_ids",
+        "completion_audit_step_ids",
+        "milestone_ids",
+        "ledger_audit_step_ids",
+        "ledger_entry_digest",
+        "closure_digest",
+        "audit_digest",
+        "audit_steps",
+        "source_recovery_closure_ledger_entry",
+    ):
+        value = preview.get(field_name)
+        if isinstance(value, list) and not value:
+            missing_fields.append(field_name)
+        elif isinstance(value, Mapping) and not value:
+            missing_fields.append(field_name)
+        elif not isinstance(value, (list, Mapping)) and not _str(value):
+            missing_fields.append(field_name)
+    if (
+        missing_fields
+        or actual_digest != expected_digest
+        or _str(preview.get("id")) != expected_id
+    ):
+        return _fail(
+            CHECK_RECOVERY_CLOSURE_LEDGER_AUDIT_INTEGRITY,
+            "Recovery closure ledger audit digest, id, or required fields are invalid.",
+            ("regenerate_recovery_closure_ledger_audit_preview",),
+            {
+                "expected_audit_digest": expected_digest,
+                "actual_audit_digest": actual_digest,
+                "expected_audit_id": expected_id,
+                "actual_audit_id": _str(preview.get("id")),
+                "missing_fields": missing_fields,
+            },
+        )
+    return _pass(
+        CHECK_RECOVERY_CLOSURE_LEDGER_AUDIT_INTEGRITY,
+        "Recovery closure ledger audit integrity checks pass.",
+        {"ledger_audit_preview_id": expected_id, "audit_digest": actual_digest},
+    )
+
+
+def _seal_source_chain_check(
+    preview: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryClosureGovernanceSealCheck:
+    entry = _dict(preview.get("source_recovery_closure_ledger_entry"))
+    mismatches: list[dict[str, str]] = []
+    for field_name in (
+        "ledger_entry_id",
+        "closure_id",
+        "audit_preview_id",
+        "receipt_id",
+        "executor_preview_id",
+        "decision_id",
+        "execution_preview_id",
+        "token_id",
+        "lock_id",
+        "route",
+        "closure_digest",
+    ):
+        entry_key = "id" if field_name == "ledger_entry_id" else field_name
+        _compare(mismatches, field_name, preview, field_name, entry, entry_key)
+    if _str(entry.get("entry_digest")) != _str(preview.get("ledger_entry_digest")):
+        mismatches.append(
+            {
+                "field": "ledger_entry_digest",
+                "left": _str(preview.get("ledger_entry_digest")),
+                "right": _str(entry.get("entry_digest")),
+                "right_key": "source_recovery_closure_ledger_entry.entry_digest",
+            }
+        )
+    audit_steps = _audit_steps(preview)
+    non_pass_steps = [
+        _str(step.get("id")) or f"ledger-audit-step-{index}"
+        for index, step in enumerate(audit_steps, start=1)
+        if _str(step.get("status")) != LEDGER_AUDIT_STEP_STATUS_PASS
+    ]
+    if (
+        not entry
+        or mismatches
+        or _str(entry.get("status")) != RECOVERY_CLOSURE_LEDGER_ENTRY_STATUS_READY
+        or non_pass_steps
+    ):
+        return _fail(
+            CHECK_RECOVERY_GOVERNANCE_SEAL_SOURCE_CHAIN,
+            "Recovery closure governance seal source chain is incomplete or inconsistent.",
+            ("regenerate_recovery_closure_ledger_audit_preview",),
+            {
+                "missing_sources": [
+                    "source_recovery_closure_ledger_entry"
+                ]
+                if not entry
+                else [],
+                "mismatches": mismatches,
+                "entry_status": _str(entry.get("status")),
+                "non_pass_ledger_audit_step_ids": non_pass_steps,
+            },
+        )
+    return _pass(
+        CHECK_RECOVERY_GOVERNANCE_SEAL_SOURCE_CHAIN,
+        "Recovery closure governance seal source chain is internally consistent.",
+        {
+            "ledger_entry_id": _str(preview.get("ledger_entry_id")),
+            "closure_id": _str(preview.get("closure_id")),
+            "ledger_audit_step_count": len(audit_steps),
+        },
+    )
+
+
+def _seal_requirements_check(
+    preview: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryClosureGovernanceSealCheck:
+    required_flags = (
+        "would_verify_ledger_entry_integrity",
+        "would_verify_closure_source_integrity",
+        "would_verify_lifecycle_milestones",
+        "would_verify_completion_audit_evidence",
+    )
+    missing_flags = [field_name for field_name in required_flags if preview.get(field_name) is not True]
+    missing_lists = [
+        field_name
+        for field_name in (
+            "operation_ids",
+            "recovery_step_ids",
+            "future_mutation_step_ids",
+            "completion_audit_step_ids",
+            "milestone_ids",
+            "ledger_audit_step_ids",
+        )
+        if not _list_of_str(preview.get(field_name))
+    ]
+    categories = {_str(step.get("category")) for step in _audit_steps(preview)}
+    required_categories = {
+        "ledger_entry",
+        "closure_source",
+        "milestones",
+        "source_chain",
+        "completion_audit",
+        "read_only",
+    }
+    missing_categories = sorted(required_categories - categories)
+    if missing_flags or missing_lists or missing_categories:
+        return _fail(
+            CHECK_RECOVERY_GOVERNANCE_SEAL_REQUIREMENTS,
+            "Recovery closure governance seal requirements are incomplete.",
+            ("regenerate_recovery_closure_ledger_audit_preview",),
+            {
+                "missing_flags": missing_flags,
+                "missing_lists": missing_lists,
+                "missing_categories": missing_categories,
+            },
+        )
+    return _pass(
+        CHECK_RECOVERY_GOVERNANCE_SEAL_REQUIREMENTS,
+        "Recovery closure governance seal requirements cover integrity, lifecycle, audit, and read-only guarantees.",
+        {
+            "ledger_audit_step_count": len(_audit_steps(preview)),
+            "milestone_count": len(_list_of_str(preview.get("milestone_ids"))),
+        },
+    )
+
+
+def _seal_from_ledger_audit(
+    preview: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryClosureGovernanceSealDraft:
+    operation_ids = tuple(_list_of_str(preview.get("operation_ids")))
+    recovery_step_ids = tuple(_list_of_str(preview.get("recovery_step_ids")))
+    future_mutation_step_ids = tuple(_list_of_str(preview.get("future_mutation_step_ids")))
+    completion_audit_step_ids = tuple(_list_of_str(preview.get("completion_audit_step_ids")))
+    milestone_ids = tuple(_list_of_str(preview.get("milestone_ids")))
+    ledger_audit_step_ids = tuple(_list_of_str(preview.get("ledger_audit_step_ids")))
+    seal_seed = {
+        "seal_type": RECOVERY_CLOSURE_GOVERNANCE_SEAL_TYPE,
+        "governance_decision": RECOVERY_CLOSURE_GOVERNANCE_DECISION,
+        "governance_scope": RECOVERY_CLOSURE_GOVERNANCE_SCOPE,
+        "ledger_audit_preview_id": _str(preview.get("id")),
+        "ledger_entry_id": _str(preview.get("ledger_entry_id")),
+        "closure_id": _str(preview.get("closure_id")),
+        "audit_preview_id": _str(preview.get("audit_preview_id")),
+        "receipt_id": _str(preview.get("receipt_id")),
+        "executor_preview_id": _str(preview.get("executor_preview_id")),
+        "decision_id": _str(preview.get("decision_id")),
+        "execution_preview_id": _str(preview.get("execution_preview_id")),
+        "token_id": _str(preview.get("token_id")),
+        "lock_id": _str(preview.get("lock_id")),
+        "route": _str(preview.get("route")),
+        "operation_ids": operation_ids,
+        "recovery_step_ids": recovery_step_ids,
+        "future_mutation_step_ids": future_mutation_step_ids,
+        "completion_audit_step_ids": completion_audit_step_ids,
+        "milestone_ids": milestone_ids,
+        "ledger_audit_step_ids": ledger_audit_step_ids,
+        "ledger_entry_digest": _str(preview.get("ledger_entry_digest")),
+        "closure_digest": _str(preview.get("closure_digest")),
+        "ledger_audit_digest": _str(preview.get("audit_digest")),
+    }
+    seal_digest = _digest(seal_seed)
+    seal_id = f"recovery-closure-governance-seal-{seal_digest[:16]}"
+    return MemoryEvidenceRepairRecoveryClosureGovernanceSealDraft(
+        id=seal_id,
+        seal_type=RECOVERY_CLOSURE_GOVERNANCE_SEAL_TYPE,
+        status=RECOVERY_CLOSURE_GOVERNANCE_SEAL_DRAFT_STATUS_READY,
+        governance_decision=RECOVERY_CLOSURE_GOVERNANCE_DECISION,
+        governance_scope=RECOVERY_CLOSURE_GOVERNANCE_SCOPE,
+        ledger_audit_preview_id=_str(preview.get("id")),
+        ledger_entry_id=_str(preview.get("ledger_entry_id")),
+        closure_id=_str(preview.get("closure_id")),
+        audit_preview_id=_str(preview.get("audit_preview_id")),
+        receipt_id=_str(preview.get("receipt_id")),
+        executor_preview_id=_str(preview.get("executor_preview_id")),
+        decision_id=_str(preview.get("decision_id")),
+        execution_preview_id=_str(preview.get("execution_preview_id")),
+        token_id=_str(preview.get("token_id")),
+        lock_id=_str(preview.get("lock_id")),
+        route=_str(preview.get("route")),
+        operation_ids=operation_ids,
+        recovery_step_ids=recovery_step_ids,
+        future_mutation_step_ids=future_mutation_step_ids,
+        completion_audit_step_ids=completion_audit_step_ids,
+        milestone_ids=milestone_ids,
+        ledger_audit_step_ids=ledger_audit_step_ids,
+        ledger_entry_digest=_str(preview.get("ledger_entry_digest")),
+        closure_digest=_str(preview.get("closure_digest")),
+        ledger_audit_digest=_str(preview.get("audit_digest")),
+        seal_digest=seal_digest,
+        seal_preview=f"{seal_id}:{seal_digest[:12]}",
+        would_freeze_recovery_closure=True,
+        would_preserve_audit_evidence=True,
+        would_enable_governed_handoff=True,
+        would_block_unreviewed_mutation=True,
+        safety_note=(
+            "Read-only recovery closure governance seal draft. It previews a "
+            "future governance seal for handoff and accountability, but does "
+            "not freeze, persist, or mutate durable memory."
+        ),
+        source_recovery_closure_ledger_audit_preview=dict(preview),
+    )
+
+
+def _expected_ledger_audit_digest(preview: Mapping[str, Any]) -> str:
+    seed = {
+        "ledger_entry_id": _str(preview.get("ledger_entry_id")),
+        "closure_id": _str(preview.get("closure_id")),
+        "audit_preview_id": _str(preview.get("audit_preview_id")),
+        "receipt_id": _str(preview.get("receipt_id")),
+        "executor_preview_id": _str(preview.get("executor_preview_id")),
+        "decision_id": _str(preview.get("decision_id")),
+        "execution_preview_id": _str(preview.get("execution_preview_id")),
+        "token_id": _str(preview.get("token_id")),
+        "lock_id": _str(preview.get("lock_id")),
+        "route": _str(preview.get("route")),
+        "operation_ids": tuple(_list_of_str(preview.get("operation_ids"))),
+        "recovery_step_ids": tuple(_list_of_str(preview.get("recovery_step_ids"))),
+        "future_mutation_step_ids": tuple(
+            _list_of_str(preview.get("future_mutation_step_ids"))
+        ),
+        "completion_audit_step_ids": tuple(
+            _list_of_str(preview.get("completion_audit_step_ids"))
+        ),
+        "milestone_ids": tuple(_list_of_str(preview.get("milestone_ids"))),
+        "ledger_audit_step_ids": tuple(
+            _list_of_str(preview.get("ledger_audit_step_ids"))
+        ),
+        "entry_digest": _str(preview.get("ledger_entry_digest")),
+        "closure_digest": _str(preview.get("closure_digest")),
+    }
+    return _digest(seed)
+
+
+def _audit_steps(preview: Mapping[str, Any]) -> list[Mapping[str, Any]]:
+    return [
+        step
+        for step in _list(preview.get("audit_steps"))
+        if isinstance(step, Mapping)
+    ]
+
+
+def _compare(
+    mismatches: list[dict[str, str]],
+    label: str,
+    left: Mapping[str, Any],
+    left_key: str,
+    right: Mapping[str, Any],
+    right_key: str,
+) -> None:
+    left_value = _str(left.get(left_key))
+    right_value = _str(right.get(right_key))
+    if left_value != right_value:
+        mismatches.append(
+            {
+                "field": label,
+                "left": left_value,
+                "right": right_value,
+                "right_key": right_key,
+            }
+        )
+
+
+def _empty_report(
+    *,
+    recovery_closure_ledger_audit: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryClosureGovernanceSealPreviewReport:
+    return MemoryEvidenceRepairRecoveryClosureGovernanceSealPreviewReport(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        status=RECOVERY_CLOSURE_GOVERNANCE_SEAL_STATUS_NO_ACTION_NEEDED,
+        checks=(),
+        seals=(),
+        blocking_reasons=(),
+        required_actions=(),
+        source_recovery_closure_ledger_audit_report=dict(
+            recovery_closure_ledger_audit
+        ),
+    )
+
+
+def _blocked_report(
+    *,
+    recovery_closure_ledger_audit: Mapping[str, Any],
+    checks: tuple[MemoryEvidenceRepairRecoveryClosureGovernanceSealCheck, ...],
+) -> MemoryEvidenceRepairRecoveryClosureGovernanceSealPreviewReport:
+    return MemoryEvidenceRepairRecoveryClosureGovernanceSealPreviewReport(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        status=RECOVERY_CLOSURE_GOVERNANCE_SEAL_STATUS_BLOCKED,
+        checks=checks,
+        seals=(),
+        blocking_reasons=tuple(
+            _dedupe_strings(check.reason for check in checks if check.status == CHECK_STATUS_FAIL)
+        ),
+        required_actions=tuple(
+            _dedupe_strings(
+                action
+                for check in checks
+                if check.status == CHECK_STATUS_FAIL
+                for action in check.required_actions
+            )
+        ),
+        source_recovery_closure_ledger_audit_report=dict(
+            recovery_closure_ledger_audit
+        ),
+    )
+
+
+def _pass(
+    check_id: str,
+    reason: str,
+    details: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryClosureGovernanceSealCheck:
+    return MemoryEvidenceRepairRecoveryClosureGovernanceSealCheck(
+        id=check_id,
+        status=CHECK_STATUS_PASS,
+        reason=reason,
+        required_actions=(),
+        details=dict(details),
+    )
+
+
+def _fail(
+    check_id: str,
+    reason: str,
+    required_actions: Sequence[str],
+    details: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryClosureGovernanceSealCheck:
+    return MemoryEvidenceRepairRecoveryClosureGovernanceSealCheck(
+        id=check_id,
+        status=CHECK_STATUS_FAIL,
+        reason=reason,
+        required_actions=tuple(required_actions),
+        details=dict(details),
+    )
+
+
+def _digest(value: Any) -> str:
+    raw = json.dumps(value, sort_keys=True, ensure_ascii=False, default=str)
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def _dict(value: Any) -> dict[str, Any]:
+    return dict(value) if isinstance(value, Mapping) else {}
+
+
+def _list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _list_of_str(value: Any) -> list[str]:
+    return [_str(item) for item in value] if isinstance(value, list) else []
+
+
+def _dedupe_strings(values: Sequence[str] | Any) -> list[str]:
+    seen: set[str] = set()
+    result: list[str] = []
+    for value in values:
+        text = _str(value)
+        if text and text not in seen:
+            seen.add(text)
+            result.append(text)
+    return result
+
+
+def _str(value: Any) -> str:
+    return str(value or "").strip()

--- a/agent/memory_evidence_repair_recovery_closure_ledger_audit_preview.py
+++ b/agent/memory_evidence_repair_recovery_closure_ledger_audit_preview.py
@@ -1,0 +1,1024 @@
+"""Read-only recovery closure ledger audit preview for memory evidence repair.
+
+The ledger audit preview verifies that a recovery closure ledger entry can be
+trusted by later governance layers. It never writes durable memory, records a
+real audit, or marks a recovery closed.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Mapping, Sequence
+
+from agent.memory_evidence_repair_manual_commit_dry_run import (
+    CHECK_STATUS_FAIL,
+    CHECK_STATUS_PASS,
+)
+from agent.memory_evidence_repair_recovery_closure_gate import (
+    RECOVERY_CLOSURE_DRAFT_STATUS_READY,
+)
+from agent.memory_evidence_repair_recovery_closure_ledger_preview import (
+    RECOVERY_CLOSURE_DECISION,
+    RECOVERY_CLOSURE_LEDGER_ENTRY_STATUS_READY,
+    RECOVERY_CLOSURE_LEDGER_ENTRY_TYPE,
+    RECOVERY_CLOSURE_LEDGER_STATUS_NO_ACTION_NEEDED,
+    RECOVERY_CLOSURE_LEDGER_STATUS_READY,
+    RECOVERY_CLOSURE_TYPE,
+)
+from agent.memory_evidence_repair_recovery_completion_audit_preview import (
+    RECOVERY_AUDIT_STEP_STATUS_PASS,
+    RECOVERY_COMPLETION_AUDIT_STATUS_READY,
+)
+
+
+RECOVERY_CLOSURE_LEDGER_AUDIT_STATUS_READY = (
+    "recovery_closure_ledger_audit_preview_ready"
+)
+RECOVERY_CLOSURE_LEDGER_AUDIT_STATUS_BLOCKED = "blocked"
+RECOVERY_CLOSURE_LEDGER_AUDIT_STATUS_NO_ACTION_NEEDED = "no_action_needed"
+RECOVERY_CLOSURE_LEDGER_AUDIT_PREVIEW_STATUS_READY = (
+    "recovery_closure_ledger_audit_ready"
+)
+
+LEDGER_AUDIT_STEP_STATUS_PASS = "pass"
+LEDGER_AUDIT_STEP_STATUS_FAIL = "fail"
+
+CHECK_RECOVERY_CLOSURE_LEDGER_READY = "recovery_closure_ledger_ready"
+CHECK_RECOVERY_CLOSURE_LEDGER_INTEGRITY = "recovery_closure_ledger_integrity"
+CHECK_RECOVERY_CLOSURE_LEDGER_SOURCE_CHAIN = "recovery_closure_ledger_source_chain"
+CHECK_RECOVERY_CLOSURE_LEDGER_AUDIT_REQUIREMENTS = (
+    "recovery_closure_ledger_audit_requirements"
+)
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairRecoveryClosureLedgerAuditCheck:
+    """One read-only recovery closure ledger audit check."""
+
+    id: str
+    status: str
+    reason: str
+    required_actions: tuple[str, ...]
+    details: dict[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "status": self.status,
+            "reason": self.reason,
+            "required_actions": list(self.required_actions),
+            "details": dict(self.details),
+        }
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairRecoveryClosureLedgerAuditStep:
+    """One structural audit step for a future closure ledger entry."""
+
+    id: str
+    sequence: int
+    category: str
+    assertion: str
+    ledger_entry_id: str
+    reference_id: str
+    expected_signal: dict[str, Any]
+    observed_signal: dict[str, Any]
+    status: str
+    required_action_on_fail: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "sequence": self.sequence,
+            "category": self.category,
+            "assertion": self.assertion,
+            "ledger_entry_id": self.ledger_entry_id,
+            "reference_id": self.reference_id,
+            "expected_signal": dict(self.expected_signal),
+            "observed_signal": dict(self.observed_signal),
+            "status": self.status,
+            "required_action_on_fail": self.required_action_on_fail,
+        }
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairRecoveryClosureLedgerAuditPreview:
+    """One read-only recovery closure ledger audit preview."""
+
+    id: str
+    status: str
+    ledger_entry_id: str
+    closure_id: str
+    audit_preview_id: str
+    receipt_id: str
+    executor_preview_id: str
+    decision_id: str
+    execution_preview_id: str
+    token_id: str
+    lock_id: str
+    route: str
+    operation_ids: tuple[str, ...]
+    recovery_step_ids: tuple[str, ...]
+    future_mutation_step_ids: tuple[str, ...]
+    completion_audit_step_ids: tuple[str, ...]
+    milestone_ids: tuple[str, ...]
+    ledger_audit_step_ids: tuple[str, ...]
+    ledger_entry_digest: str
+    closure_digest: str
+    audit_digest: str
+    audit_preview: str
+    audit_steps: tuple[MemoryEvidenceRepairRecoveryClosureLedgerAuditStep, ...]
+    would_verify_ledger_entry_integrity: bool
+    would_verify_closure_source_integrity: bool
+    would_verify_lifecycle_milestones: bool
+    would_verify_completion_audit_evidence: bool
+    safety_note: str
+    source_recovery_closure_ledger_entry: dict[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "status": self.status,
+            "ledger_entry_id": self.ledger_entry_id,
+            "closure_id": self.closure_id,
+            "audit_preview_id": self.audit_preview_id,
+            "receipt_id": self.receipt_id,
+            "executor_preview_id": self.executor_preview_id,
+            "decision_id": self.decision_id,
+            "execution_preview_id": self.execution_preview_id,
+            "token_id": self.token_id,
+            "lock_id": self.lock_id,
+            "route": self.route,
+            "operation_ids": list(self.operation_ids),
+            "recovery_step_ids": list(self.recovery_step_ids),
+            "future_mutation_step_ids": list(self.future_mutation_step_ids),
+            "completion_audit_step_ids": list(self.completion_audit_step_ids),
+            "milestone_ids": list(self.milestone_ids),
+            "ledger_audit_step_ids": list(self.ledger_audit_step_ids),
+            "ledger_entry_digest": self.ledger_entry_digest,
+            "closure_digest": self.closure_digest,
+            "audit_digest": self.audit_digest,
+            "audit_preview": self.audit_preview,
+            "audit_steps": [step.to_dict() for step in self.audit_steps],
+            "would_verify_ledger_entry_integrity": (
+                self.would_verify_ledger_entry_integrity
+            ),
+            "would_verify_closure_source_integrity": (
+                self.would_verify_closure_source_integrity
+            ),
+            "would_verify_lifecycle_milestones": self.would_verify_lifecycle_milestones,
+            "would_verify_completion_audit_evidence": (
+                self.would_verify_completion_audit_evidence
+            ),
+            "safety_note": self.safety_note,
+            "source_recovery_closure_ledger_entry": dict(
+                self.source_recovery_closure_ledger_entry
+            ),
+        }
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairRecoveryClosureLedgerAuditPreviewReport:
+    """Read-only recovery closure ledger audit preview report."""
+
+    generated_at: str
+    status: str
+    checks: tuple[MemoryEvidenceRepairRecoveryClosureLedgerAuditCheck, ...]
+    previews: tuple[MemoryEvidenceRepairRecoveryClosureLedgerAuditPreview, ...]
+    blocking_reasons: tuple[str, ...]
+    required_actions: tuple[str, ...]
+    source_recovery_closure_ledger_report: dict[str, Any]
+
+    @property
+    def summary(self) -> dict[str, Any]:
+        by_check_status: dict[str, int] = {}
+        by_audit_step_status: dict[str, int] = {}
+        for check in self.checks:
+            by_check_status[check.status] = by_check_status.get(check.status, 0) + 1
+        for preview in self.previews:
+            for step in preview.audit_steps:
+                by_audit_step_status[step.status] = (
+                    by_audit_step_status.get(step.status, 0) + 1
+                )
+        return {
+            "status": self.status,
+            "check_count": len(self.checks),
+            "pass_count": by_check_status.get(CHECK_STATUS_PASS, 0),
+            "fail_count": by_check_status.get(CHECK_STATUS_FAIL, 0),
+            "preview_count": len(self.previews),
+            "audit_step_count": sum(len(preview.audit_steps) for preview in self.previews),
+            "observed_pass_step_count": by_audit_step_status.get(
+                LEDGER_AUDIT_STEP_STATUS_PASS,
+                0,
+            ),
+            "observed_fail_step_count": by_audit_step_status.get(
+                LEDGER_AUDIT_STEP_STATUS_FAIL,
+                0,
+            ),
+            "blocking_reason_count": len(self.blocking_reasons),
+            "required_action_count": len(self.required_actions),
+            "recovery_closure_ledger_audit_preview_available": bool(self.previews),
+            "recovery_closure_ledger_audit_ready": (
+                self.status == RECOVERY_CLOSURE_LEDGER_AUDIT_STATUS_READY
+            ),
+            "has_blocks": self.status == RECOVERY_CLOSURE_LEDGER_AUDIT_STATUS_BLOCKED,
+            "requires_followup": bool(self.required_actions),
+            "by_check_status": by_check_status,
+            "by_audit_step_status": by_audit_step_status,
+        }
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "generated_at": self.generated_at,
+            "status": self.status,
+            "summary": self.summary,
+            "checks": [check.to_dict() for check in self.checks],
+            "previews": [preview.to_dict() for preview in self.previews],
+            "blocking_reasons": list(self.blocking_reasons),
+            "required_actions": list(self.required_actions),
+            "source_recovery_closure_ledger_report": dict(
+                self.source_recovery_closure_ledger_report
+            ),
+            "read_only": True,
+            "read_only_memory": True,
+            "would_mutate_memory": False,
+        }
+
+
+def build_evidence_repair_recovery_closure_ledger_audit_preview(
+    *,
+    recovery_closure_ledger: Mapping[str, Any] | None = None,
+) -> MemoryEvidenceRepairRecoveryClosureLedgerAuditPreviewReport:
+    """Build a read-only audit preview from a recovery closure ledger report."""
+
+    recovery_closure_ledger = (
+        recovery_closure_ledger if isinstance(recovery_closure_ledger, Mapping) else {}
+    )
+    report_status = _str(recovery_closure_ledger.get("status"))
+    entry = _extract_entry(recovery_closure_ledger)
+
+    if not entry:
+        if (
+            not recovery_closure_ledger
+            or report_status == RECOVERY_CLOSURE_LEDGER_STATUS_NO_ACTION_NEEDED
+        ):
+            return _empty_report(recovery_closure_ledger=recovery_closure_ledger)
+        source_blocking = tuple(
+            _list_of_str(recovery_closure_ledger.get("blocking_reasons"))
+        )
+        source_actions = tuple(_list_of_str(recovery_closure_ledger.get("required_actions")))
+        return _blocked_report(
+            recovery_closure_ledger=recovery_closure_ledger,
+            checks=(
+                _fail(
+                    CHECK_RECOVERY_CLOSURE_LEDGER_READY,
+                    "No recovery closure ledger entry was supplied."
+                    if not source_blocking
+                    else "; ".join(source_blocking),
+                    source_actions
+                    or ("produce_recovery_closure_ledger_preview",),
+                    {"recovery_closure_ledger_status": report_status},
+                ),
+            ),
+        )
+
+    checks = (
+        _ledger_ready_check(recovery_closure_ledger, entry),
+        _ledger_integrity_check(entry),
+        _source_chain_check(entry),
+        _audit_requirements_check(entry),
+    )
+    blocking_reasons = tuple(
+        _dedupe_strings(check.reason for check in checks if check.status == CHECK_STATUS_FAIL)
+    )
+    required_actions = tuple(
+        _dedupe_strings(
+            action
+            for check in checks
+            if check.status == CHECK_STATUS_FAIL
+            for action in check.required_actions
+        )
+    )
+    if blocking_reasons:
+        return MemoryEvidenceRepairRecoveryClosureLedgerAuditPreviewReport(
+            generated_at=datetime.now(timezone.utc).isoformat(),
+            status=RECOVERY_CLOSURE_LEDGER_AUDIT_STATUS_BLOCKED,
+            checks=checks,
+            previews=(),
+            blocking_reasons=blocking_reasons,
+            required_actions=required_actions,
+            source_recovery_closure_ledger_report=dict(recovery_closure_ledger),
+        )
+
+    preview = _preview_from_entry(entry)
+    return MemoryEvidenceRepairRecoveryClosureLedgerAuditPreviewReport(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        status=RECOVERY_CLOSURE_LEDGER_AUDIT_STATUS_READY,
+        checks=checks,
+        previews=(preview,),
+        blocking_reasons=(),
+        required_actions=(),
+        source_recovery_closure_ledger_report=dict(recovery_closure_ledger),
+    )
+
+
+def empty_evidence_repair_recovery_closure_ledger_audit_preview() -> MemoryEvidenceRepairRecoveryClosureLedgerAuditPreviewReport:
+    """Return an empty read-only recovery closure ledger audit preview."""
+
+    return _empty_report(recovery_closure_ledger={})
+
+
+def _extract_entry(recovery_closure_ledger: Mapping[str, Any]) -> dict[str, Any]:
+    entries = recovery_closure_ledger.get("entries")
+    if isinstance(entries, list):
+        for entry in entries:
+            if isinstance(entry, Mapping):
+                return dict(entry)
+    if _str(recovery_closure_ledger.get("id")).startswith("recovery-closure-ledger-"):
+        return dict(recovery_closure_ledger)
+    return {}
+
+
+def _ledger_ready_check(
+    recovery_closure_ledger: Mapping[str, Any],
+    entry: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryClosureLedgerAuditCheck:
+    report_status = _str(recovery_closure_ledger.get("status"))
+    entry_status = _str(entry.get("status"))
+    if report_status and report_status != RECOVERY_CLOSURE_LEDGER_STATUS_READY:
+        return _fail(
+            CHECK_RECOVERY_CLOSURE_LEDGER_READY,
+            "Recovery closure ledger report is not ready for audit preview.",
+            tuple(_list_of_str(recovery_closure_ledger.get("required_actions")))
+            or ("produce_ready_recovery_closure_ledger_preview",),
+            {"report_status": report_status, "entry_status": entry_status},
+        )
+    if entry_status != RECOVERY_CLOSURE_LEDGER_ENTRY_STATUS_READY:
+        return _fail(
+            CHECK_RECOVERY_CLOSURE_LEDGER_READY,
+            "Recovery closure ledger entry is not ready for audit preview.",
+            ("regenerate_recovery_closure_ledger_preview",),
+            {"report_status": report_status, "entry_status": entry_status},
+        )
+    return _pass(
+        CHECK_RECOVERY_CLOSURE_LEDGER_READY,
+        "Recovery closure ledger entry is ready for audit preview.",
+        {"ledger_entry_id": _str(entry.get("id"))},
+    )
+
+
+def _ledger_integrity_check(
+    entry: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryClosureLedgerAuditCheck:
+    expected_digest = _expected_entry_digest(entry)
+    actual_digest = _str(entry.get("entry_digest"))
+    expected_id = (
+        f"recovery-closure-ledger-{expected_digest[:16]}" if expected_digest else ""
+    )
+    missing_fields: list[str] = []
+    for field_name in (
+        "id",
+        "entry_type",
+        "status",
+        "closure_id",
+        "closure_decision",
+        "audit_preview_id",
+        "receipt_id",
+        "executor_preview_id",
+        "decision_id",
+        "execution_preview_id",
+        "token_id",
+        "lock_id",
+        "route",
+        "operation_ids",
+        "recovery_step_ids",
+        "future_mutation_step_ids",
+        "audit_step_ids",
+        "closure_digest",
+        "entry_digest",
+        "milestones",
+        "source_recovery_closure",
+    ):
+        value = entry.get(field_name)
+        if isinstance(value, list) and not value:
+            missing_fields.append(field_name)
+        elif isinstance(value, Mapping) and not value:
+            missing_fields.append(field_name)
+        elif not isinstance(value, (list, Mapping)) and not _str(value):
+            missing_fields.append(field_name)
+    if (
+        missing_fields
+        or actual_digest != expected_digest
+        or _str(entry.get("id")) != expected_id
+        or _str(entry.get("entry_type")) != RECOVERY_CLOSURE_LEDGER_ENTRY_TYPE
+        or _str(entry.get("status")) != RECOVERY_CLOSURE_LEDGER_ENTRY_STATUS_READY
+    ):
+        return _fail(
+            CHECK_RECOVERY_CLOSURE_LEDGER_INTEGRITY,
+            "Recovery closure ledger entry digest, id, type, status, or required fields are invalid.",
+            ("regenerate_recovery_closure_ledger_preview",),
+            {
+                "expected_entry_digest": expected_digest,
+                "actual_entry_digest": actual_digest,
+                "expected_entry_id": expected_id,
+                "actual_entry_id": _str(entry.get("id")),
+                "missing_fields": missing_fields,
+            },
+        )
+    return _pass(
+        CHECK_RECOVERY_CLOSURE_LEDGER_INTEGRITY,
+        "Recovery closure ledger entry integrity checks pass.",
+        {"ledger_entry_id": expected_id, "entry_digest": actual_digest},
+    )
+
+
+def _source_chain_check(
+    entry: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryClosureLedgerAuditCheck:
+    closure = _dict(entry.get("source_recovery_closure"))
+    audit = _dict(closure.get("source_recovery_completion_audit_preview"))
+    receipt = _dict(audit.get("source_recovery_completion_receipt"))
+    executor = _dict(receipt.get("source_recovery_executor_preview"))
+    expected_closure_digest = _expected_closure_digest(closure)
+    audit_steps = _audit_steps(audit)
+    non_pass_audit_steps = [
+        _str(step.get("id")) or f"audit-step-{index}"
+        for index, step in enumerate(audit_steps, start=1)
+        if _str(step.get("status")) != RECOVERY_AUDIT_STEP_STATUS_PASS
+    ]
+    mismatches: list[dict[str, str]] = []
+    for field_name in (
+        "closure_id",
+        "closure_decision",
+        "audit_preview_id",
+        "receipt_id",
+        "executor_preview_id",
+        "decision_id",
+        "execution_preview_id",
+        "token_id",
+        "lock_id",
+        "route",
+        "closure_digest",
+    ):
+        closure_key = "id" if field_name == "closure_id" else field_name
+        _compare(mismatches, field_name, entry, field_name, closure, closure_key)
+    if _str(audit.get("id")) != _str(entry.get("audit_preview_id")):
+        mismatches.append(
+            {
+                "field": "audit_preview_id",
+                "left": _str(entry.get("audit_preview_id")),
+                "right": _str(audit.get("id")),
+                "right_key": "source_recovery_completion_audit_preview.id",
+            }
+        )
+    if _str(receipt.get("id")) != _str(entry.get("receipt_id")):
+        mismatches.append(
+            {
+                "field": "receipt_id",
+                "left": _str(entry.get("receipt_id")),
+                "right": _str(receipt.get("id")),
+                "right_key": "source_recovery_completion_receipt.id",
+            }
+        )
+    if _str(executor.get("id")) != _str(entry.get("executor_preview_id")):
+        mismatches.append(
+            {
+                "field": "executor_preview_id",
+                "left": _str(entry.get("executor_preview_id")),
+                "right": _str(executor.get("id")),
+                "right_key": "source_recovery_executor_preview.id",
+            }
+        )
+    missing_sources = [
+        name
+        for name, source in (
+            ("source_recovery_closure", closure),
+            ("source_recovery_completion_audit_preview", audit),
+            ("source_recovery_completion_receipt", receipt),
+            ("source_recovery_executor_preview", executor),
+        )
+        if not source
+    ]
+    if (
+        missing_sources
+        or mismatches
+        or _str(closure.get("status")) != RECOVERY_CLOSURE_DRAFT_STATUS_READY
+        or _str(entry.get("closure_digest")) != expected_closure_digest
+        or _str(audit.get("status")) != RECOVERY_COMPLETION_AUDIT_STATUS_READY
+        or audit.get("observed_state_supplied") is not True
+        or non_pass_audit_steps
+    ):
+        return _fail(
+            CHECK_RECOVERY_CLOSURE_LEDGER_SOURCE_CHAIN,
+            "Recovery closure ledger source chain is incomplete or inconsistent.",
+            ("regenerate_recovery_closure_ledger_preview",),
+            {
+                "missing_sources": missing_sources,
+                "mismatches": mismatches,
+                "closure_status": _str(closure.get("status")),
+                "expected_closure_digest": expected_closure_digest,
+                "actual_closure_digest": _str(entry.get("closure_digest")),
+                "audit_status": _str(audit.get("status")),
+                "observed_state_supplied": audit.get("observed_state_supplied") is True,
+                "non_pass_audit_step_ids": non_pass_audit_steps,
+            },
+        )
+    return _pass(
+        CHECK_RECOVERY_CLOSURE_LEDGER_SOURCE_CHAIN,
+        "Recovery closure ledger source chain is internally consistent.",
+        {
+            "closure_id": _str(entry.get("closure_id")),
+            "audit_preview_id": _str(entry.get("audit_preview_id")),
+            "receipt_id": _str(entry.get("receipt_id")),
+            "executor_preview_id": _str(entry.get("executor_preview_id")),
+            "audit_step_count": len(audit_steps),
+        },
+    )
+
+
+def _audit_requirements_check(
+    entry: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryClosureLedgerAuditCheck:
+    milestones = _milestones(entry)
+    missing_lists = [
+        field_name
+        for field_name in (
+            "operation_ids",
+            "recovery_step_ids",
+            "future_mutation_step_ids",
+            "audit_step_ids",
+        )
+        if not _list_of_str(entry.get(field_name))
+    ]
+    missing_flags = [
+        field_name
+        for field_name in (
+            "would_record_ledger_entry",
+            "would_preserve_recovery_evidence",
+        )
+        if entry.get(field_name) is not True
+    ]
+    milestone_errors = _milestone_errors(entry)
+    if missing_lists or missing_flags or milestone_errors:
+        return _fail(
+            CHECK_RECOVERY_CLOSURE_LEDGER_AUDIT_REQUIREMENTS,
+            "Recovery closure ledger audit requirements are incomplete.",
+            ("regenerate_recovery_closure_ledger_preview",),
+            {
+                "missing_lists": missing_lists,
+                "missing_flags": missing_flags,
+                "milestone_errors": milestone_errors,
+                "milestone_count": len(milestones),
+            },
+        )
+    return _pass(
+        CHECK_RECOVERY_CLOSURE_LEDGER_AUDIT_REQUIREMENTS,
+        "Recovery closure ledger audit has all structural evidence needed.",
+        {
+            "milestone_count": len(milestones),
+            "operation_count": len(_list_of_str(entry.get("operation_ids"))),
+            "recovery_step_count": len(_list_of_str(entry.get("recovery_step_ids"))),
+            "completion_audit_step_count": len(_list_of_str(entry.get("audit_step_ids"))),
+        },
+    )
+
+
+def _preview_from_entry(
+    entry: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryClosureLedgerAuditPreview:
+    audit_steps = tuple(_audit_steps_from_entry(entry))
+    ledger_audit_step_ids = tuple(step.id for step in audit_steps)
+    operation_ids = tuple(_list_of_str(entry.get("operation_ids")))
+    recovery_step_ids = tuple(_list_of_str(entry.get("recovery_step_ids")))
+    future_mutation_step_ids = tuple(_list_of_str(entry.get("future_mutation_step_ids")))
+    completion_audit_step_ids = tuple(_list_of_str(entry.get("audit_step_ids")))
+    milestone_ids = tuple(_str(milestone.get("id")) for milestone in _milestones(entry))
+    audit_seed = {
+        "ledger_entry_id": _str(entry.get("id")),
+        "closure_id": _str(entry.get("closure_id")),
+        "audit_preview_id": _str(entry.get("audit_preview_id")),
+        "receipt_id": _str(entry.get("receipt_id")),
+        "executor_preview_id": _str(entry.get("executor_preview_id")),
+        "decision_id": _str(entry.get("decision_id")),
+        "execution_preview_id": _str(entry.get("execution_preview_id")),
+        "token_id": _str(entry.get("token_id")),
+        "lock_id": _str(entry.get("lock_id")),
+        "route": _str(entry.get("route")),
+        "operation_ids": operation_ids,
+        "recovery_step_ids": recovery_step_ids,
+        "future_mutation_step_ids": future_mutation_step_ids,
+        "completion_audit_step_ids": completion_audit_step_ids,
+        "milestone_ids": milestone_ids,
+        "ledger_audit_step_ids": ledger_audit_step_ids,
+        "entry_digest": _str(entry.get("entry_digest")),
+        "closure_digest": _str(entry.get("closure_digest")),
+    }
+    audit_digest = _digest(audit_seed)
+    audit_id = f"recovery-closure-ledger-audit-{audit_digest[:16]}"
+    return MemoryEvidenceRepairRecoveryClosureLedgerAuditPreview(
+        id=audit_id,
+        status=RECOVERY_CLOSURE_LEDGER_AUDIT_PREVIEW_STATUS_READY,
+        ledger_entry_id=_str(entry.get("id")),
+        closure_id=_str(entry.get("closure_id")),
+        audit_preview_id=_str(entry.get("audit_preview_id")),
+        receipt_id=_str(entry.get("receipt_id")),
+        executor_preview_id=_str(entry.get("executor_preview_id")),
+        decision_id=_str(entry.get("decision_id")),
+        execution_preview_id=_str(entry.get("execution_preview_id")),
+        token_id=_str(entry.get("token_id")),
+        lock_id=_str(entry.get("lock_id")),
+        route=_str(entry.get("route")),
+        operation_ids=operation_ids,
+        recovery_step_ids=recovery_step_ids,
+        future_mutation_step_ids=future_mutation_step_ids,
+        completion_audit_step_ids=completion_audit_step_ids,
+        milestone_ids=milestone_ids,
+        ledger_audit_step_ids=ledger_audit_step_ids,
+        ledger_entry_digest=_str(entry.get("entry_digest")),
+        closure_digest=_str(entry.get("closure_digest")),
+        audit_digest=audit_digest,
+        audit_preview=f"{audit_id}:{audit_digest[:12]}",
+        audit_steps=audit_steps,
+        would_verify_ledger_entry_integrity=True,
+        would_verify_closure_source_integrity=True,
+        would_verify_lifecycle_milestones=True,
+        would_verify_completion_audit_evidence=True,
+        safety_note=(
+            "Read-only recovery closure ledger audit preview. It checks whether "
+            "a future closure ledger entry is structurally trustworthy, but does "
+            "not record the audit or mutate durable memory."
+        ),
+        source_recovery_closure_ledger_entry=dict(entry),
+    )
+
+
+def _audit_steps_from_entry(
+    entry: Mapping[str, Any],
+) -> list[MemoryEvidenceRepairRecoveryClosureLedgerAuditStep]:
+    rows = (
+        (
+            "ledger_entry",
+            "ledger_entry_digest_valid",
+            _str(entry.get("id")),
+            {"expected_entry_digest": _expected_entry_digest(entry)},
+            {"actual_entry_digest": _str(entry.get("entry_digest"))},
+        ),
+        (
+            "closure_source",
+            "closure_source_digest_valid",
+            _str(entry.get("closure_id")),
+            {
+                "expected_closure_digest": _expected_closure_digest(
+                    _dict(entry.get("source_recovery_closure"))
+                )
+            },
+            {"actual_closure_digest": _str(entry.get("closure_digest"))},
+        ),
+        (
+            "milestones",
+            "lifecycle_milestones_ordered",
+            _str(entry.get("id")),
+            {"required_stages": list(_required_milestone_stages())},
+            {"stages": [_str(milestone.get("stage")) for milestone in _milestones(entry)]},
+        ),
+        (
+            "source_chain",
+            "source_chain_consistent",
+            _str(entry.get("closure_id")),
+            {"closure_id": _str(entry.get("closure_id"))},
+            {"source_closure_id": _str(_dict(entry.get("source_recovery_closure")).get("id"))},
+        ),
+        (
+            "completion_audit",
+            "completion_audit_observed_pass",
+            _str(entry.get("audit_preview_id")),
+            {"observed_state_supplied": True},
+            {
+                "observed_state_supplied": _dict(
+                    _dict(entry.get("source_recovery_closure")).get(
+                        "source_recovery_completion_audit_preview"
+                    )
+                ).get("observed_state_supplied")
+                is True
+            },
+        ),
+        (
+            "read_only",
+            "ledger_entry_is_preview_only",
+            _str(entry.get("id")),
+            {"would_record_ledger_entry": True},
+            {"would_record_ledger_entry": entry.get("would_record_ledger_entry") is True},
+        ),
+    )
+    return [
+        _audit_step(
+            sequence=index,
+            category=category,
+            assertion=assertion,
+            entry=entry,
+            reference_id=reference_id,
+            expected_signal=expected_signal,
+            observed_signal=observed_signal,
+        )
+        for index, (
+            category,
+            assertion,
+            reference_id,
+            expected_signal,
+            observed_signal,
+        ) in enumerate(rows, start=1)
+    ]
+
+
+def _audit_step(
+    *,
+    sequence: int,
+    category: str,
+    assertion: str,
+    entry: Mapping[str, Any],
+    reference_id: str,
+    expected_signal: Mapping[str, Any],
+    observed_signal: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryClosureLedgerAuditStep:
+    step_seed = {
+        "sequence": sequence,
+        "category": category,
+        "assertion": assertion,
+        "ledger_entry_id": _str(entry.get("id")),
+        "reference_id": _str(reference_id),
+    }
+    step_id = f"recovery-closure-ledger-audit-step-{_digest(step_seed)[:16]}"
+    return MemoryEvidenceRepairRecoveryClosureLedgerAuditStep(
+        id=step_id,
+        sequence=sequence,
+        category=category,
+        assertion=assertion,
+        ledger_entry_id=_str(entry.get("id")),
+        reference_id=_str(reference_id),
+        expected_signal=dict(expected_signal),
+        observed_signal=dict(observed_signal),
+        status=LEDGER_AUDIT_STEP_STATUS_PASS,
+        required_action_on_fail="regenerate_recovery_closure_ledger_preview",
+    )
+
+
+def _expected_entry_digest(entry: Mapping[str, Any]) -> str:
+    seed = {
+        "entry_type": RECOVERY_CLOSURE_LEDGER_ENTRY_TYPE,
+        "closure_id": _str(entry.get("closure_id")),
+        "closure_digest": _str(entry.get("closure_digest")),
+        "audit_preview_id": _str(entry.get("audit_preview_id")),
+        "receipt_id": _str(entry.get("receipt_id")),
+        "executor_preview_id": _str(entry.get("executor_preview_id")),
+        "decision_id": _str(entry.get("decision_id")),
+        "execution_preview_id": _str(entry.get("execution_preview_id")),
+        "token_id": _str(entry.get("token_id")),
+        "lock_id": _str(entry.get("lock_id")),
+        "route": _str(entry.get("route")),
+        "operation_ids": tuple(_list_of_str(entry.get("operation_ids"))),
+        "recovery_step_ids": tuple(_list_of_str(entry.get("recovery_step_ids"))),
+        "future_mutation_step_ids": tuple(
+            _list_of_str(entry.get("future_mutation_step_ids"))
+        ),
+        "audit_step_ids": tuple(_list_of_str(entry.get("audit_step_ids"))),
+        "milestone_ids": tuple(_str(milestone.get("id")) for milestone in _milestones(entry)),
+    }
+    return _digest(seed)
+
+
+def _expected_closure_digest(closure: Mapping[str, Any]) -> str:
+    seed = {
+        "closure_type": RECOVERY_CLOSURE_TYPE,
+        "closure_decision": RECOVERY_CLOSURE_DECISION,
+        "audit_preview_id": _str(closure.get("audit_preview_id")),
+        "receipt_id": _str(closure.get("receipt_id")),
+        "executor_preview_id": _str(closure.get("executor_preview_id")),
+        "decision_id": _str(closure.get("decision_id")),
+        "execution_preview_id": _str(closure.get("execution_preview_id")),
+        "token_id": _str(closure.get("token_id")),
+        "lock_id": _str(closure.get("lock_id")),
+        "route": _str(closure.get("route")),
+        "operation_ids": tuple(_list_of_str(closure.get("operation_ids"))),
+        "recovery_step_ids": tuple(_list_of_str(closure.get("recovery_step_ids"))),
+        "future_mutation_step_ids": tuple(
+            _list_of_str(closure.get("future_mutation_step_ids"))
+        ),
+        "audit_step_ids": tuple(_list_of_str(closure.get("audit_step_ids"))),
+    }
+    return _digest(seed)
+
+
+def _milestone_errors(entry: Mapping[str, Any]) -> list[dict[str, Any]]:
+    milestones = _milestones(entry)
+    errors: list[dict[str, Any]] = []
+    expected_reference_ids = {
+        "recovery_decision": _str(entry.get("decision_id")),
+        "recovery_execution_preview": _str(entry.get("execution_preview_id")),
+        "recovery_approval_token": _str(entry.get("token_id")),
+        "recovery_write_lock": _str(entry.get("lock_id")),
+        "recovery_executor_preview": _str(entry.get("executor_preview_id")),
+        "recovery_completion_receipt": _str(entry.get("receipt_id")),
+        "recovery_completion_audit": _str(entry.get("audit_preview_id")),
+        "recovery_closure": _str(entry.get("closure_id")),
+    }
+    stages = [_str(milestone.get("stage")) for milestone in milestones]
+    if tuple(stages) != _required_milestone_stages():
+        errors.append(
+            {
+                "type": "stage_order",
+                "expected": list(_required_milestone_stages()),
+                "actual": stages,
+            }
+        )
+    for expected_sequence, milestone in enumerate(milestones, start=1):
+        stage = _str(milestone.get("stage"))
+        reference_id = _str(milestone.get("reference_id"))
+        expected_reference_id = expected_reference_ids.get(stage, "")
+        expected_id = _milestone_id(stage, expected_reference_id, expected_sequence)
+        if int(milestone.get("sequence") or 0) != expected_sequence:
+            errors.append(
+                {
+                    "type": "sequence",
+                    "stage": stage,
+                    "expected": expected_sequence,
+                    "actual": milestone.get("sequence"),
+                }
+            )
+        if reference_id != expected_reference_id:
+            errors.append(
+                {
+                    "type": "reference_id",
+                    "stage": stage,
+                    "expected": expected_reference_id,
+                    "actual": reference_id,
+                }
+            )
+        if _str(milestone.get("id")) != expected_id:
+            errors.append(
+                {
+                    "type": "milestone_id",
+                    "stage": stage,
+                    "expected": expected_id,
+                    "actual": _str(milestone.get("id")),
+                }
+            )
+    return errors
+
+
+def _milestones(entry: Mapping[str, Any]) -> list[Mapping[str, Any]]:
+    return [
+        milestone
+        for milestone in _list(entry.get("milestones"))
+        if isinstance(milestone, Mapping)
+    ]
+
+
+def _required_milestone_stages() -> tuple[str, ...]:
+    return (
+        "recovery_decision",
+        "recovery_execution_preview",
+        "recovery_approval_token",
+        "recovery_write_lock",
+        "recovery_executor_preview",
+        "recovery_completion_receipt",
+        "recovery_completion_audit",
+        "recovery_closure",
+    )
+
+
+def _milestone_id(stage: str, reference_id: str, sequence: int) -> str:
+    digest = _digest({"stage": stage, "reference_id": reference_id, "sequence": sequence})
+    return f"recovery-closure-milestone-{digest[:16]}"
+
+
+def _audit_steps(audit: Mapping[str, Any]) -> list[Mapping[str, Any]]:
+    return [
+        step
+        for step in _list(audit.get("audit_steps"))
+        if isinstance(step, Mapping)
+    ]
+
+
+def _compare(
+    mismatches: list[dict[str, str]],
+    label: str,
+    left: Mapping[str, Any],
+    left_key: str,
+    right: Mapping[str, Any],
+    right_key: str,
+) -> None:
+    left_value = _str(left.get(left_key))
+    right_value = _str(right.get(right_key))
+    if left_value != right_value:
+        mismatches.append(
+            {
+                "field": label,
+                "left": left_value,
+                "right": right_value,
+                "right_key": right_key,
+            }
+        )
+
+
+def _empty_report(
+    *,
+    recovery_closure_ledger: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryClosureLedgerAuditPreviewReport:
+    return MemoryEvidenceRepairRecoveryClosureLedgerAuditPreviewReport(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        status=RECOVERY_CLOSURE_LEDGER_AUDIT_STATUS_NO_ACTION_NEEDED,
+        checks=(),
+        previews=(),
+        blocking_reasons=(),
+        required_actions=(),
+        source_recovery_closure_ledger_report=dict(recovery_closure_ledger),
+    )
+
+
+def _blocked_report(
+    *,
+    recovery_closure_ledger: Mapping[str, Any],
+    checks: tuple[MemoryEvidenceRepairRecoveryClosureLedgerAuditCheck, ...],
+) -> MemoryEvidenceRepairRecoveryClosureLedgerAuditPreviewReport:
+    return MemoryEvidenceRepairRecoveryClosureLedgerAuditPreviewReport(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        status=RECOVERY_CLOSURE_LEDGER_AUDIT_STATUS_BLOCKED,
+        checks=checks,
+        previews=(),
+        blocking_reasons=tuple(
+            _dedupe_strings(check.reason for check in checks if check.status == CHECK_STATUS_FAIL)
+        ),
+        required_actions=tuple(
+            _dedupe_strings(
+                action
+                for check in checks
+                if check.status == CHECK_STATUS_FAIL
+                for action in check.required_actions
+            )
+        ),
+        source_recovery_closure_ledger_report=dict(recovery_closure_ledger),
+    )
+
+
+def _pass(
+    check_id: str,
+    reason: str,
+    details: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryClosureLedgerAuditCheck:
+    return MemoryEvidenceRepairRecoveryClosureLedgerAuditCheck(
+        id=check_id,
+        status=CHECK_STATUS_PASS,
+        reason=reason,
+        required_actions=(),
+        details=dict(details),
+    )
+
+
+def _fail(
+    check_id: str,
+    reason: str,
+    required_actions: Sequence[str],
+    details: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryClosureLedgerAuditCheck:
+    return MemoryEvidenceRepairRecoveryClosureLedgerAuditCheck(
+        id=check_id,
+        status=CHECK_STATUS_FAIL,
+        reason=reason,
+        required_actions=tuple(required_actions),
+        details=dict(details),
+    )
+
+
+def _digest(value: Any) -> str:
+    raw = json.dumps(value, sort_keys=True, ensure_ascii=False, default=str)
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def _dict(value: Any) -> dict[str, Any]:
+    return dict(value) if isinstance(value, Mapping) else {}
+
+
+def _list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _list_of_str(value: Any) -> list[str]:
+    return [_str(item) for item in value] if isinstance(value, list) else []
+
+
+def _dedupe_strings(values: Sequence[str] | Any) -> list[str]:
+    seen: set[str] = set()
+    result: list[str] = []
+    for value in values:
+        text = _str(value)
+        if text and text not in seen:
+            seen.add(text)
+            result.append(text)
+    return result
+
+
+def _str(value: Any) -> str:
+    return str(value or "").strip()

--- a/agent/memory_evidence_repair_recovery_closure_ledger_preview.py
+++ b/agent/memory_evidence_repair_recovery_closure_ledger_preview.py
@@ -1,0 +1,822 @@
+"""Read-only recovery closure ledger preview for memory evidence repair.
+
+This layer turns a ready recovery closure draft into an audit-style lifecycle
+ledger entry. It never writes durable memory and never marks a recovery closed.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Mapping, Sequence
+
+from agent.memory_evidence_repair_manual_commit_dry_run import (
+    CHECK_STATUS_FAIL,
+    CHECK_STATUS_PASS,
+)
+from agent.memory_evidence_repair_recovery_closure_gate import (
+    RECOVERY_CLOSURE_DRAFT_STATUS_READY,
+    RECOVERY_CLOSURE_STATUS_NO_ACTION_NEEDED,
+    RECOVERY_CLOSURE_STATUS_READY,
+)
+from agent.memory_evidence_repair_recovery_completion_audit_preview import (
+    RECOVERY_AUDIT_STEP_STATUS_PASS,
+    RECOVERY_COMPLETION_AUDIT_STATUS_READY,
+)
+
+
+RECOVERY_CLOSURE_LEDGER_STATUS_READY = "recovery_closure_ledger_preview_ready"
+RECOVERY_CLOSURE_LEDGER_STATUS_BLOCKED = "blocked"
+RECOVERY_CLOSURE_LEDGER_STATUS_NO_ACTION_NEEDED = "no_action_needed"
+RECOVERY_CLOSURE_LEDGER_ENTRY_STATUS_READY = "recovery_closure_ledger_entry_ready"
+RECOVERY_CLOSURE_LEDGER_ENTRY_TYPE = (
+    "memory_evidence_repair_recovery_closure_ledger_entry"
+)
+
+CHECK_RECOVERY_CLOSURE_READY = "recovery_closure_ready"
+CHECK_RECOVERY_CLOSURE_INTEGRITY = "recovery_closure_integrity"
+CHECK_RECOVERY_LIFECYCLE_CHAIN = "recovery_lifecycle_chain"
+CHECK_RECOVERY_LEDGER_REQUIREMENTS = "recovery_ledger_requirements"
+
+RECOVERY_CLOSURE_TYPE = "memory_evidence_repair_recovery_closure"
+RECOVERY_CLOSURE_DECISION = "close_recovery_loop"
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairRecoveryClosureLedgerCheck:
+    """One read-only recovery closure ledger check."""
+
+    id: str
+    status: str
+    reason: str
+    required_actions: tuple[str, ...]
+    details: dict[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "status": self.status,
+            "reason": self.reason,
+            "required_actions": list(self.required_actions),
+            "details": dict(self.details),
+        }
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairRecoveryClosureLedgerMilestone:
+    """One lifecycle milestone inside a future recovery closure ledger entry."""
+
+    id: str
+    sequence: int
+    stage: str
+    reference_id: str
+    status: str
+    summary: str
+    source: dict[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "sequence": self.sequence,
+            "stage": self.stage,
+            "reference_id": self.reference_id,
+            "status": self.status,
+            "summary": self.summary,
+            "source": dict(self.source),
+        }
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairRecoveryClosureLedgerEntry:
+    """One read-only future recovery closure ledger entry preview."""
+
+    id: str
+    entry_type: str
+    status: str
+    closure_id: str
+    closure_decision: str
+    audit_preview_id: str
+    receipt_id: str
+    executor_preview_id: str
+    decision_id: str
+    execution_preview_id: str
+    token_id: str
+    lock_id: str
+    route: str
+    operation_ids: tuple[str, ...]
+    recovery_step_ids: tuple[str, ...]
+    future_mutation_step_ids: tuple[str, ...]
+    audit_step_ids: tuple[str, ...]
+    closure_digest: str
+    entry_digest: str
+    entry_preview: str
+    milestones: tuple[MemoryEvidenceRepairRecoveryClosureLedgerMilestone, ...]
+    would_record_ledger_entry: bool
+    would_preserve_recovery_evidence: bool
+    safety_note: str
+    source_recovery_closure: dict[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "entry_type": self.entry_type,
+            "status": self.status,
+            "closure_id": self.closure_id,
+            "closure_decision": self.closure_decision,
+            "audit_preview_id": self.audit_preview_id,
+            "receipt_id": self.receipt_id,
+            "executor_preview_id": self.executor_preview_id,
+            "decision_id": self.decision_id,
+            "execution_preview_id": self.execution_preview_id,
+            "token_id": self.token_id,
+            "lock_id": self.lock_id,
+            "route": self.route,
+            "operation_ids": list(self.operation_ids),
+            "recovery_step_ids": list(self.recovery_step_ids),
+            "future_mutation_step_ids": list(self.future_mutation_step_ids),
+            "audit_step_ids": list(self.audit_step_ids),
+            "closure_digest": self.closure_digest,
+            "entry_digest": self.entry_digest,
+            "entry_preview": self.entry_preview,
+            "milestones": [milestone.to_dict() for milestone in self.milestones],
+            "would_record_ledger_entry": self.would_record_ledger_entry,
+            "would_preserve_recovery_evidence": self.would_preserve_recovery_evidence,
+            "safety_note": self.safety_note,
+            "source_recovery_closure": dict(self.source_recovery_closure),
+        }
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairRecoveryClosureLedgerPreviewReport:
+    """Read-only recovery closure ledger preview report."""
+
+    generated_at: str
+    status: str
+    checks: tuple[MemoryEvidenceRepairRecoveryClosureLedgerCheck, ...]
+    entries: tuple[MemoryEvidenceRepairRecoveryClosureLedgerEntry, ...]
+    blocking_reasons: tuple[str, ...]
+    required_actions: tuple[str, ...]
+    source_recovery_closure_gate: dict[str, Any]
+
+    @property
+    def summary(self) -> dict[str, Any]:
+        by_check_status: dict[str, int] = {}
+        milestone_count = 0
+        for check in self.checks:
+            by_check_status[check.status] = by_check_status.get(check.status, 0) + 1
+        for entry in self.entries:
+            milestone_count += len(entry.milestones)
+        return {
+            "status": self.status,
+            "check_count": len(self.checks),
+            "pass_count": by_check_status.get(CHECK_STATUS_PASS, 0),
+            "fail_count": by_check_status.get(CHECK_STATUS_FAIL, 0),
+            "entry_count": len(self.entries),
+            "milestone_count": milestone_count,
+            "blocking_reason_count": len(self.blocking_reasons),
+            "required_action_count": len(self.required_actions),
+            "recovery_closure_ledger_preview_available": bool(self.entries),
+            "recovery_closure_ledger_ready": (
+                self.status == RECOVERY_CLOSURE_LEDGER_STATUS_READY
+            ),
+            "would_record_ledger_entry_count": sum(
+                1 for entry in self.entries if entry.would_record_ledger_entry
+            ),
+            "would_preserve_recovery_evidence_count": sum(
+                1 for entry in self.entries if entry.would_preserve_recovery_evidence
+            ),
+            "has_blocks": self.status == RECOVERY_CLOSURE_LEDGER_STATUS_BLOCKED,
+            "requires_followup": bool(self.required_actions),
+            "by_check_status": by_check_status,
+        }
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "generated_at": self.generated_at,
+            "status": self.status,
+            "summary": self.summary,
+            "checks": [check.to_dict() for check in self.checks],
+            "entries": [entry.to_dict() for entry in self.entries],
+            "blocking_reasons": list(self.blocking_reasons),
+            "required_actions": list(self.required_actions),
+            "source_recovery_closure_gate": dict(self.source_recovery_closure_gate),
+            "read_only": True,
+            "read_only_memory": True,
+            "would_mutate_memory": False,
+        }
+
+
+def build_evidence_repair_recovery_closure_ledger_preview(
+    *,
+    recovery_closure_gate: Mapping[str, Any] | None = None,
+) -> MemoryEvidenceRepairRecoveryClosureLedgerPreviewReport:
+    """Build a read-only lifecycle ledger preview from a recovery closure gate."""
+
+    recovery_closure_gate = (
+        recovery_closure_gate if isinstance(recovery_closure_gate, Mapping) else {}
+    )
+    report_status = _str(recovery_closure_gate.get("status"))
+    closure = _extract_closure(recovery_closure_gate)
+
+    if not closure:
+        if (
+            not recovery_closure_gate
+            or report_status == RECOVERY_CLOSURE_STATUS_NO_ACTION_NEEDED
+        ):
+            return _empty_report(recovery_closure_gate=recovery_closure_gate)
+        source_blocking = tuple(_list_of_str(recovery_closure_gate.get("blocking_reasons")))
+        source_actions = tuple(_list_of_str(recovery_closure_gate.get("required_actions")))
+        return _blocked_report(
+            recovery_closure_gate=recovery_closure_gate,
+            checks=(
+                _fail(
+                    CHECK_RECOVERY_CLOSURE_READY,
+                    "No recovery closure draft was supplied."
+                    if not source_blocking
+                    else "; ".join(source_blocking),
+                    source_actions or ("produce_ready_recovery_closure_gate",),
+                    {"recovery_closure_gate_status": report_status},
+                ),
+            ),
+        )
+
+    checks = (
+        _closure_ready_check(recovery_closure_gate, closure),
+        _closure_integrity_check(closure),
+        _lifecycle_chain_check(closure),
+        _ledger_requirements_check(closure),
+    )
+    blocking_reasons = tuple(
+        _dedupe_strings(check.reason for check in checks if check.status == CHECK_STATUS_FAIL)
+    )
+    required_actions = tuple(
+        _dedupe_strings(
+            action
+            for check in checks
+            if check.status == CHECK_STATUS_FAIL
+            for action in check.required_actions
+        )
+    )
+    if blocking_reasons:
+        return MemoryEvidenceRepairRecoveryClosureLedgerPreviewReport(
+            generated_at=datetime.now(timezone.utc).isoformat(),
+            status=RECOVERY_CLOSURE_LEDGER_STATUS_BLOCKED,
+            checks=checks,
+            entries=(),
+            blocking_reasons=blocking_reasons,
+            required_actions=required_actions,
+            source_recovery_closure_gate=dict(recovery_closure_gate),
+        )
+
+    entry = _entry_from_closure(closure)
+    return MemoryEvidenceRepairRecoveryClosureLedgerPreviewReport(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        status=RECOVERY_CLOSURE_LEDGER_STATUS_READY,
+        checks=checks,
+        entries=(entry,),
+        blocking_reasons=(),
+        required_actions=(),
+        source_recovery_closure_gate=dict(recovery_closure_gate),
+    )
+
+
+def empty_evidence_repair_recovery_closure_ledger_preview() -> MemoryEvidenceRepairRecoveryClosureLedgerPreviewReport:
+    """Return an empty read-only recovery closure ledger preview."""
+
+    return _empty_report(recovery_closure_gate={})
+
+
+def _extract_closure(recovery_closure_gate: Mapping[str, Any]) -> dict[str, Any]:
+    closures = recovery_closure_gate.get("closures")
+    if isinstance(closures, list):
+        for closure in closures:
+            if isinstance(closure, Mapping):
+                return dict(closure)
+    if _str(recovery_closure_gate.get("id")).startswith("recovery-closure-"):
+        return dict(recovery_closure_gate)
+    return {}
+
+
+def _closure_ready_check(
+    recovery_closure_gate: Mapping[str, Any],
+    closure: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryClosureLedgerCheck:
+    report_status = _str(recovery_closure_gate.get("status"))
+    closure_status = _str(closure.get("status"))
+    if report_status and report_status != RECOVERY_CLOSURE_STATUS_READY:
+        return _fail(
+            CHECK_RECOVERY_CLOSURE_READY,
+            "Recovery closure gate report is not ready for ledger preview.",
+            tuple(_list_of_str(recovery_closure_gate.get("required_actions")))
+            or ("produce_ready_recovery_closure_gate",),
+            {"report_status": report_status, "closure_status": closure_status},
+        )
+    if closure_status != RECOVERY_CLOSURE_DRAFT_STATUS_READY:
+        return _fail(
+            CHECK_RECOVERY_CLOSURE_READY,
+            "Recovery closure draft is not ready for ledger preview.",
+            ("regenerate_recovery_closure_gate",),
+            {"report_status": report_status, "closure_status": closure_status},
+        )
+    return _pass(
+        CHECK_RECOVERY_CLOSURE_READY,
+        "Recovery closure draft is ready for ledger preview.",
+        {"closure_id": _str(closure.get("id"))},
+    )
+
+
+def _closure_integrity_check(
+    closure: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryClosureLedgerCheck:
+    expected_digest = _expected_closure_digest(closure)
+    actual_digest = _str(closure.get("closure_digest"))
+    expected_id = f"recovery-closure-{expected_digest[:16]}" if expected_digest else ""
+    missing_fields: list[str] = []
+    for field_name in (
+        "id",
+        "status",
+        "closure_type",
+        "closure_decision",
+        "audit_preview_id",
+        "receipt_id",
+        "executor_preview_id",
+        "decision_id",
+        "execution_preview_id",
+        "token_id",
+        "lock_id",
+        "route",
+        "operation_ids",
+        "recovery_step_ids",
+        "future_mutation_step_ids",
+        "audit_step_ids",
+        "source_recovery_completion_audit_preview",
+    ):
+        value = closure.get(field_name)
+        if isinstance(value, list) and not value:
+            missing_fields.append(field_name)
+        elif isinstance(value, Mapping) and not value:
+            missing_fields.append(field_name)
+        elif not isinstance(value, (list, Mapping)) and not _str(value):
+            missing_fields.append(field_name)
+    if (
+        missing_fields
+        or actual_digest != expected_digest
+        or _str(closure.get("id")) != expected_id
+        or _str(closure.get("closure_type")) != RECOVERY_CLOSURE_TYPE
+        or _str(closure.get("closure_decision")) != RECOVERY_CLOSURE_DECISION
+    ):
+        return _fail(
+            CHECK_RECOVERY_CLOSURE_INTEGRITY,
+            "Recovery closure digest, id, type, decision, or required fields are invalid.",
+            ("regenerate_recovery_closure_gate",),
+            {
+                "expected_closure_digest": expected_digest,
+                "actual_closure_digest": actual_digest,
+                "expected_closure_id": expected_id,
+                "actual_closure_id": _str(closure.get("id")),
+                "missing_fields": missing_fields,
+            },
+        )
+    return _pass(
+        CHECK_RECOVERY_CLOSURE_INTEGRITY,
+        "Recovery closure integrity checks pass.",
+        {"closure_id": expected_id, "closure_digest": actual_digest},
+    )
+
+
+def _lifecycle_chain_check(
+    closure: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryClosureLedgerCheck:
+    audit = _dict(closure.get("source_recovery_completion_audit_preview"))
+    receipt = _dict(audit.get("source_recovery_completion_receipt"))
+    executor = _dict(receipt.get("source_recovery_executor_preview"))
+    mismatches: list[dict[str, str]] = []
+
+    _compare(mismatches, "audit_preview_id", closure, "audit_preview_id", audit, "id")
+    _compare(mismatches, "receipt_id", closure, "receipt_id", audit, "receipt_id")
+    _compare(mismatches, "receipt_id", closure, "receipt_id", receipt, "id")
+    _compare(
+        mismatches,
+        "executor_preview_id",
+        closure,
+        "executor_preview_id",
+        audit,
+        "executor_preview_id",
+    )
+    _compare(
+        mismatches,
+        "executor_preview_id",
+        closure,
+        "executor_preview_id",
+        receipt,
+        "executor_preview_id",
+    )
+    _compare(mismatches, "executor_preview_id", closure, "executor_preview_id", executor, "id")
+    for field_name in ("decision_id", "execution_preview_id", "token_id", "lock_id", "route"):
+        _compare(mismatches, field_name, closure, field_name, audit, field_name)
+        _compare(mismatches, field_name, closure, field_name, receipt, field_name)
+        _compare(mismatches, field_name, closure, field_name, executor, field_name)
+
+    audit_steps = _audit_steps(audit)
+    non_pass_steps = [
+        _str(step.get("id")) or f"step-{index}"
+        for index, step in enumerate(audit_steps, start=1)
+        if _str(step.get("status")) != RECOVERY_AUDIT_STEP_STATUS_PASS
+    ]
+    missing_sources = [
+        name
+        for name, source in (
+            ("source_recovery_completion_audit_preview", audit),
+            ("source_recovery_completion_receipt", receipt),
+            ("source_recovery_executor_preview", executor),
+        )
+        if not source
+    ]
+    if (
+        missing_sources
+        or mismatches
+        or _str(audit.get("status")) != RECOVERY_COMPLETION_AUDIT_STATUS_READY
+        or audit.get("observed_state_supplied") is not True
+        or non_pass_steps
+    ):
+        return _fail(
+            CHECK_RECOVERY_LIFECYCLE_CHAIN,
+            "Recovery closure lifecycle chain is incomplete or inconsistent.",
+            ("regenerate_recovery_closure_gate",),
+            {
+                "missing_sources": missing_sources,
+                "mismatches": mismatches,
+                "audit_status": _str(audit.get("status")),
+                "observed_state_supplied": audit.get("observed_state_supplied") is True,
+                "non_pass_audit_step_ids": non_pass_steps,
+            },
+        )
+    return _pass(
+        CHECK_RECOVERY_LIFECYCLE_CHAIN,
+        "Recovery closure lifecycle chain is internally consistent.",
+        {
+            "closure_id": _str(closure.get("id")),
+            "audit_preview_id": _str(audit.get("id")),
+            "receipt_id": _str(receipt.get("id")),
+            "executor_preview_id": _str(executor.get("id")),
+            "audit_step_count": len(audit_steps),
+        },
+    )
+
+
+def _ledger_requirements_check(
+    closure: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryClosureLedgerCheck:
+    milestones = _milestones(closure)
+    missing_stages = [
+        stage
+        for stage in _required_milestone_stages()
+        if not any(
+            milestone.stage == stage and milestone.reference_id for milestone in milestones
+        )
+    ]
+    missing_lists = [
+        field_name
+        for field_name in (
+            "operation_ids",
+            "recovery_step_ids",
+            "future_mutation_step_ids",
+            "audit_step_ids",
+        )
+        if not _list_of_str(closure.get(field_name))
+    ]
+    missing_flags = [
+        field_name
+        for field_name in (
+            "would_close_recovery_loop",
+            "would_mark_recovery_resolved",
+            "would_preserve_audit_evidence",
+        )
+        if closure.get(field_name) is not True
+    ]
+    if missing_stages or missing_lists or missing_flags:
+        return _fail(
+            CHECK_RECOVERY_LEDGER_REQUIREMENTS,
+            "Recovery closure ledger requirements are incomplete.",
+            ("regenerate_recovery_closure_gate",),
+            {
+                "missing_stages": missing_stages,
+                "missing_lists": missing_lists,
+                "missing_flags": missing_flags,
+                "milestone_count": len(milestones),
+            },
+        )
+    return _pass(
+        CHECK_RECOVERY_LEDGER_REQUIREMENTS,
+        "Recovery closure ledger has all lifecycle milestones and evidence ids.",
+        {
+            "milestone_count": len(milestones),
+            "operation_count": len(_list_of_str(closure.get("operation_ids"))),
+            "recovery_step_count": len(_list_of_str(closure.get("recovery_step_ids"))),
+            "audit_step_count": len(_list_of_str(closure.get("audit_step_ids"))),
+        },
+    )
+
+
+def _entry_from_closure(
+    closure: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryClosureLedgerEntry:
+    operation_ids = tuple(_list_of_str(closure.get("operation_ids")))
+    recovery_step_ids = tuple(_list_of_str(closure.get("recovery_step_ids")))
+    future_mutation_step_ids = tuple(_list_of_str(closure.get("future_mutation_step_ids")))
+    audit_step_ids = tuple(_list_of_str(closure.get("audit_step_ids")))
+    milestones = tuple(_milestones(closure))
+    entry_seed = {
+        "entry_type": RECOVERY_CLOSURE_LEDGER_ENTRY_TYPE,
+        "closure_id": _str(closure.get("id")),
+        "closure_digest": _str(closure.get("closure_digest")),
+        "audit_preview_id": _str(closure.get("audit_preview_id")),
+        "receipt_id": _str(closure.get("receipt_id")),
+        "executor_preview_id": _str(closure.get("executor_preview_id")),
+        "decision_id": _str(closure.get("decision_id")),
+        "execution_preview_id": _str(closure.get("execution_preview_id")),
+        "token_id": _str(closure.get("token_id")),
+        "lock_id": _str(closure.get("lock_id")),
+        "route": _str(closure.get("route")),
+        "operation_ids": operation_ids,
+        "recovery_step_ids": recovery_step_ids,
+        "future_mutation_step_ids": future_mutation_step_ids,
+        "audit_step_ids": audit_step_ids,
+        "milestone_ids": tuple(milestone.id for milestone in milestones),
+    }
+    entry_digest = _digest(entry_seed)
+    entry_id = f"recovery-closure-ledger-{entry_digest[:16]}"
+    return MemoryEvidenceRepairRecoveryClosureLedgerEntry(
+        id=entry_id,
+        entry_type=RECOVERY_CLOSURE_LEDGER_ENTRY_TYPE,
+        status=RECOVERY_CLOSURE_LEDGER_ENTRY_STATUS_READY,
+        closure_id=_str(closure.get("id")),
+        closure_decision=_str(closure.get("closure_decision")),
+        audit_preview_id=_str(closure.get("audit_preview_id")),
+        receipt_id=_str(closure.get("receipt_id")),
+        executor_preview_id=_str(closure.get("executor_preview_id")),
+        decision_id=_str(closure.get("decision_id")),
+        execution_preview_id=_str(closure.get("execution_preview_id")),
+        token_id=_str(closure.get("token_id")),
+        lock_id=_str(closure.get("lock_id")),
+        route=_str(closure.get("route")),
+        operation_ids=operation_ids,
+        recovery_step_ids=recovery_step_ids,
+        future_mutation_step_ids=future_mutation_step_ids,
+        audit_step_ids=audit_step_ids,
+        closure_digest=_str(closure.get("closure_digest")),
+        entry_digest=entry_digest,
+        entry_preview=f"{entry_id}:{entry_digest[:12]}",
+        milestones=milestones,
+        would_record_ledger_entry=True,
+        would_preserve_recovery_evidence=True,
+        safety_note=(
+            "Read-only recovery closure ledger preview. It records the intended "
+            "audit trail for a future closure, but does not persist a ledger "
+            "entry or mutate durable memory."
+        ),
+        source_recovery_closure=dict(closure),
+    )
+
+
+def _milestones(
+    closure: Mapping[str, Any],
+) -> list[MemoryEvidenceRepairRecoveryClosureLedgerMilestone]:
+    audit = _dict(closure.get("source_recovery_completion_audit_preview"))
+    receipt = _dict(audit.get("source_recovery_completion_receipt"))
+    executor = _dict(receipt.get("source_recovery_executor_preview"))
+    lock = _dict(executor.get("source_lock"))
+    token_gate = _dict(lock.get("source_recovery_token_gate"))
+    execution = _dict(token_gate.get("source_recovery_execution_preview"))
+    decision = _dict(execution.get("source_recovery_decision"))
+    sources = {
+        "recovery_decision": decision,
+        "recovery_execution_preview": execution,
+        "recovery_approval_token": _dict(token_gate.get("source_token")),
+        "recovery_write_lock": lock,
+        "recovery_executor_preview": executor,
+        "recovery_completion_receipt": receipt,
+        "recovery_completion_audit": audit,
+        "recovery_closure": dict(closure),
+    }
+    fallback_ids = {
+        "recovery_decision": _str(closure.get("decision_id")),
+        "recovery_execution_preview": _str(closure.get("execution_preview_id")),
+        "recovery_approval_token": _str(closure.get("token_id")),
+        "recovery_write_lock": _str(closure.get("lock_id")),
+        "recovery_executor_preview": _str(closure.get("executor_preview_id")),
+        "recovery_completion_receipt": _str(closure.get("receipt_id")),
+        "recovery_completion_audit": _str(closure.get("audit_preview_id")),
+        "recovery_closure": _str(closure.get("id")),
+    }
+    summaries = {
+        "recovery_decision": "Recovery route decision selected.",
+        "recovery_execution_preview": "Manual recovery execution preview prepared.",
+        "recovery_approval_token": "Recovery human approval token verified.",
+        "recovery_write_lock": "Recovery write lock drafted for the manual window.",
+        "recovery_executor_preview": "Recovery executor preview completed.",
+        "recovery_completion_receipt": "Recovery completion receipt drafted.",
+        "recovery_completion_audit": "Observed recovery completion audit passed.",
+        "recovery_closure": "Recovery closure draft is ready to close the loop.",
+    }
+    milestones: list[MemoryEvidenceRepairRecoveryClosureLedgerMilestone] = []
+    for sequence, stage in enumerate(_required_milestone_stages(), start=1):
+        source = sources.get(stage, {})
+        reference_id = _str(source.get("id")) or fallback_ids.get(stage, "")
+        status = _str(source.get("status")) or _str(closure.get("status"))
+        milestone_id = _milestone_id(stage, reference_id, sequence)
+        milestones.append(
+            MemoryEvidenceRepairRecoveryClosureLedgerMilestone(
+                id=milestone_id,
+                sequence=sequence,
+                stage=stage,
+                reference_id=reference_id,
+                status=status,
+                summary=summaries[stage],
+                source=_source_summary(source, fallback_id=reference_id),
+            )
+        )
+    return milestones
+
+
+def _required_milestone_stages() -> tuple[str, ...]:
+    return (
+        "recovery_decision",
+        "recovery_execution_preview",
+        "recovery_approval_token",
+        "recovery_write_lock",
+        "recovery_executor_preview",
+        "recovery_completion_receipt",
+        "recovery_completion_audit",
+        "recovery_closure",
+    )
+
+
+def _source_summary(source: Mapping[str, Any], *, fallback_id: str) -> dict[str, Any]:
+    return {
+        "id": _str(source.get("id")) or fallback_id,
+        "status": _str(source.get("status")),
+        "route": _str(source.get("route")),
+        "type": _str(source.get("closure_type"))
+        or _str(source.get("receipt_type"))
+        or _str(source.get("lock_type")),
+    }
+
+
+def _milestone_id(stage: str, reference_id: str, sequence: int) -> str:
+    digest = _digest({"stage": stage, "reference_id": reference_id, "sequence": sequence})
+    return f"recovery-closure-milestone-{digest[:16]}"
+
+
+def _expected_closure_digest(closure: Mapping[str, Any]) -> str:
+    seed = {
+        "closure_type": RECOVERY_CLOSURE_TYPE,
+        "closure_decision": RECOVERY_CLOSURE_DECISION,
+        "audit_preview_id": _str(closure.get("audit_preview_id")),
+        "receipt_id": _str(closure.get("receipt_id")),
+        "executor_preview_id": _str(closure.get("executor_preview_id")),
+        "decision_id": _str(closure.get("decision_id")),
+        "execution_preview_id": _str(closure.get("execution_preview_id")),
+        "token_id": _str(closure.get("token_id")),
+        "lock_id": _str(closure.get("lock_id")),
+        "route": _str(closure.get("route")),
+        "operation_ids": tuple(_list_of_str(closure.get("operation_ids"))),
+        "recovery_step_ids": tuple(_list_of_str(closure.get("recovery_step_ids"))),
+        "future_mutation_step_ids": tuple(
+            _list_of_str(closure.get("future_mutation_step_ids"))
+        ),
+        "audit_step_ids": tuple(_list_of_str(closure.get("audit_step_ids"))),
+    }
+    return _digest(seed)
+
+
+def _audit_steps(audit: Mapping[str, Any]) -> list[Mapping[str, Any]]:
+    return [
+        step
+        for step in _list(audit.get("audit_steps"))
+        if isinstance(step, Mapping)
+    ]
+
+
+def _compare(
+    mismatches: list[dict[str, str]],
+    label: str,
+    left: Mapping[str, Any],
+    left_key: str,
+    right: Mapping[str, Any],
+    right_key: str,
+) -> None:
+    left_value = _str(left.get(left_key))
+    right_value = _str(right.get(right_key))
+    if left_value != right_value:
+        mismatches.append(
+            {
+                "field": label,
+                "left": left_value,
+                "right": right_value,
+                "right_key": right_key,
+            }
+        )
+
+
+def _empty_report(
+    *,
+    recovery_closure_gate: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryClosureLedgerPreviewReport:
+    return MemoryEvidenceRepairRecoveryClosureLedgerPreviewReport(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        status=RECOVERY_CLOSURE_LEDGER_STATUS_NO_ACTION_NEEDED,
+        checks=(),
+        entries=(),
+        blocking_reasons=(),
+        required_actions=(),
+        source_recovery_closure_gate=dict(recovery_closure_gate),
+    )
+
+
+def _blocked_report(
+    *,
+    recovery_closure_gate: Mapping[str, Any],
+    checks: tuple[MemoryEvidenceRepairRecoveryClosureLedgerCheck, ...],
+) -> MemoryEvidenceRepairRecoveryClosureLedgerPreviewReport:
+    return MemoryEvidenceRepairRecoveryClosureLedgerPreviewReport(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        status=RECOVERY_CLOSURE_LEDGER_STATUS_BLOCKED,
+        checks=checks,
+        entries=(),
+        blocking_reasons=tuple(
+            _dedupe_strings(check.reason for check in checks if check.status == CHECK_STATUS_FAIL)
+        ),
+        required_actions=tuple(
+            _dedupe_strings(
+                action
+                for check in checks
+                if check.status == CHECK_STATUS_FAIL
+                for action in check.required_actions
+            )
+        ),
+        source_recovery_closure_gate=dict(recovery_closure_gate),
+    )
+
+
+def _pass(
+    check_id: str,
+    reason: str,
+    details: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryClosureLedgerCheck:
+    return MemoryEvidenceRepairRecoveryClosureLedgerCheck(
+        id=check_id,
+        status=CHECK_STATUS_PASS,
+        reason=reason,
+        required_actions=(),
+        details=dict(details),
+    )
+
+
+def _fail(
+    check_id: str,
+    reason: str,
+    required_actions: Sequence[str],
+    details: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryClosureLedgerCheck:
+    return MemoryEvidenceRepairRecoveryClosureLedgerCheck(
+        id=check_id,
+        status=CHECK_STATUS_FAIL,
+        reason=reason,
+        required_actions=tuple(required_actions),
+        details=dict(details),
+    )
+
+
+def _digest(value: Any) -> str:
+    raw = json.dumps(value, sort_keys=True, ensure_ascii=False, default=str)
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def _dict(value: Any) -> dict[str, Any]:
+    return dict(value) if isinstance(value, Mapping) else {}
+
+
+def _list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _list_of_str(value: Any) -> list[str]:
+    return [_str(item) for item in value] if isinstance(value, list) else []
+
+
+def _dedupe_strings(values: Sequence[str] | Any) -> list[str]:
+    seen: set[str] = set()
+    result: list[str] = []
+    for value in values:
+        text = _str(value)
+        if text and text not in seen:
+            seen.add(text)
+            result.append(text)
+    return result
+
+
+def _str(value: Any) -> str:
+    return str(value or "").strip()

--- a/agent/memory_evidence_repair_recovery_completion_audit_preview.py
+++ b/agent/memory_evidence_repair_recovery_completion_audit_preview.py
@@ -1,0 +1,916 @@
+"""Read-only recovery completion audit preview for memory evidence repair.
+
+The recovery completion audit preview turns a recovery completion receipt into
+an ordered verification plan for after a future manual recovery. It can also
+validate optional observed recovery-completion state. It never writes to durable
+memory stores.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Mapping, Sequence
+
+from agent.memory_evidence_repair_manual_commit_dry_run import (
+    CHECK_STATUS_FAIL,
+    CHECK_STATUS_PASS,
+)
+from agent.memory_evidence_repair_recovery_completion_receipt import (
+    RECOVERY_COMPLETION_RECEIPT_SCOPE,
+    RECOVERY_COMPLETION_RECEIPT_STATUS_NO_ACTION_NEEDED,
+    RECOVERY_COMPLETION_RECEIPT_STATUS_READY,
+    RECOVERY_COMPLETION_RECEIPT_TYPE,
+)
+
+
+RECOVERY_COMPLETION_AUDIT_STATUS_READY = "recovery_completion_audit_preview_ready"
+RECOVERY_COMPLETION_AUDIT_STATUS_BLOCKED = "blocked"
+RECOVERY_COMPLETION_AUDIT_STATUS_NO_ACTION_NEEDED = "no_action_needed"
+
+RECOVERY_AUDIT_STEP_STATUS_PLANNED = "planned"
+RECOVERY_AUDIT_STEP_STATUS_PASS = "pass"
+RECOVERY_AUDIT_STEP_STATUS_FAIL = "fail"
+
+CHECK_RECOVERY_COMPLETION_RECEIPT_READY = "recovery_completion_receipt_ready"
+CHECK_RECOVERY_COMPLETION_RECEIPT_INTEGRITY = "recovery_completion_receipt_integrity"
+CHECK_RECOVERY_COMPLETION_AUDIT_REQUIREMENTS = "recovery_completion_audit_requirements"
+CHECK_OBSERVED_RECOVERY_COMPLETION_STATE = "observed_recovery_completion_state"
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairRecoveryCompletionAuditCheck:
+    """One read-only recovery completion audit readiness check."""
+
+    id: str
+    status: str
+    reason: str
+    required_actions: tuple[str, ...]
+    details: dict[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "status": self.status,
+            "reason": self.reason,
+            "required_actions": list(self.required_actions),
+            "details": dict(self.details),
+        }
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairRecoveryCompletionAuditStep:
+    """One future recovery completion audit step preview."""
+
+    id: str
+    sequence: int
+    category: str
+    assertion: str
+    operation_id: str
+    recovery_step_id: str
+    receipt_id: str
+    token_id: str
+    lock_id: str
+    expected_signal: dict[str, Any]
+    observed_signal: dict[str, Any]
+    status: str
+    required_action_on_fail: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "sequence": self.sequence,
+            "category": self.category,
+            "assertion": self.assertion,
+            "operation_id": self.operation_id,
+            "recovery_step_id": self.recovery_step_id,
+            "receipt_id": self.receipt_id,
+            "token_id": self.token_id,
+            "lock_id": self.lock_id,
+            "expected_signal": dict(self.expected_signal),
+            "observed_signal": dict(self.observed_signal),
+            "status": self.status,
+            "required_action_on_fail": self.required_action_on_fail,
+        }
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairRecoveryCompletionAuditPreview:
+    """One read-only recovery completion audit preview."""
+
+    id: str
+    status: str
+    receipt_id: str
+    executor_preview_id: str
+    decision_id: str
+    execution_preview_id: str
+    lock_id: str
+    token_id: str
+    route: str
+    operation_ids: tuple[str, ...]
+    recovery_step_ids: tuple[str, ...]
+    future_mutation_step_ids: tuple[str, ...]
+    audit_step_ids: tuple[str, ...]
+    audit_digest: str
+    audit_preview: str
+    audit_steps: tuple[MemoryEvidenceRepairRecoveryCompletionAuditStep, ...]
+    observed_state_supplied: bool
+    would_verify_completion_receipt_recorded: bool
+    would_verify_recovery_token_used: bool
+    would_verify_recovery_lock_released: bool
+    would_verify_recovery_steps_completed: bool
+    would_verify_post_recovery_audit_clear: bool
+    would_verify_no_secondary_memory_contamination: bool
+    safety_note: str
+    source_recovery_completion_receipt: dict[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "status": self.status,
+            "receipt_id": self.receipt_id,
+            "executor_preview_id": self.executor_preview_id,
+            "decision_id": self.decision_id,
+            "execution_preview_id": self.execution_preview_id,
+            "lock_id": self.lock_id,
+            "token_id": self.token_id,
+            "route": self.route,
+            "operation_ids": list(self.operation_ids),
+            "recovery_step_ids": list(self.recovery_step_ids),
+            "future_mutation_step_ids": list(self.future_mutation_step_ids),
+            "audit_step_ids": list(self.audit_step_ids),
+            "audit_digest": self.audit_digest,
+            "audit_preview": self.audit_preview,
+            "audit_steps": [step.to_dict() for step in self.audit_steps],
+            "observed_state_supplied": self.observed_state_supplied,
+            "would_verify_completion_receipt_recorded": (
+                self.would_verify_completion_receipt_recorded
+            ),
+            "would_verify_recovery_token_used": self.would_verify_recovery_token_used,
+            "would_verify_recovery_lock_released": self.would_verify_recovery_lock_released,
+            "would_verify_recovery_steps_completed": (
+                self.would_verify_recovery_steps_completed
+            ),
+            "would_verify_post_recovery_audit_clear": (
+                self.would_verify_post_recovery_audit_clear
+            ),
+            "would_verify_no_secondary_memory_contamination": (
+                self.would_verify_no_secondary_memory_contamination
+            ),
+            "safety_note": self.safety_note,
+            "source_recovery_completion_receipt": dict(
+                self.source_recovery_completion_receipt
+            ),
+        }
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairRecoveryCompletionAuditPreviewReport:
+    """Read-only recovery completion audit preview report."""
+
+    generated_at: str
+    status: str
+    checks: tuple[MemoryEvidenceRepairRecoveryCompletionAuditCheck, ...]
+    previews: tuple[MemoryEvidenceRepairRecoveryCompletionAuditPreview, ...]
+    blocking_reasons: tuple[str, ...]
+    required_actions: tuple[str, ...]
+    source_recovery_completion_receipt_report: dict[str, Any]
+
+    @property
+    def summary(self) -> dict[str, Any]:
+        by_check_status: dict[str, int] = {}
+        by_audit_step_status: dict[str, int] = {}
+        for check in self.checks:
+            by_check_status[check.status] = by_check_status.get(check.status, 0) + 1
+        for preview in self.previews:
+            for step in preview.audit_steps:
+                by_audit_step_status[step.status] = (
+                    by_audit_step_status.get(step.status, 0) + 1
+                )
+        return {
+            "status": self.status,
+            "check_count": len(self.checks),
+            "pass_count": by_check_status.get(CHECK_STATUS_PASS, 0),
+            "fail_count": by_check_status.get(CHECK_STATUS_FAIL, 0),
+            "preview_count": len(self.previews),
+            "audit_step_count": sum(len(preview.audit_steps) for preview in self.previews),
+            "planned_audit_step_count": by_audit_step_status.get(
+                RECOVERY_AUDIT_STEP_STATUS_PLANNED,
+                0,
+            ),
+            "observed_pass_step_count": by_audit_step_status.get(
+                RECOVERY_AUDIT_STEP_STATUS_PASS,
+                0,
+            ),
+            "observed_fail_step_count": by_audit_step_status.get(
+                RECOVERY_AUDIT_STEP_STATUS_FAIL,
+                0,
+            ),
+            "blocking_reason_count": len(self.blocking_reasons),
+            "required_action_count": len(self.required_actions),
+            "recovery_completion_audit_preview_available": bool(self.previews),
+            "recovery_completion_audit_ready": (
+                self.status == RECOVERY_COMPLETION_AUDIT_STATUS_READY
+            ),
+            "has_blocks": self.status == RECOVERY_COMPLETION_AUDIT_STATUS_BLOCKED,
+            "requires_followup": bool(self.required_actions),
+            "by_check_status": by_check_status,
+            "by_audit_step_status": by_audit_step_status,
+        }
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "generated_at": self.generated_at,
+            "status": self.status,
+            "summary": self.summary,
+            "checks": [check.to_dict() for check in self.checks],
+            "previews": [preview.to_dict() for preview in self.previews],
+            "blocking_reasons": list(self.blocking_reasons),
+            "required_actions": list(self.required_actions),
+            "source_recovery_completion_receipt_report": dict(
+                self.source_recovery_completion_receipt_report
+            ),
+            "read_only": True,
+            "read_only_memory": True,
+            "would_mutate_memory": False,
+        }
+
+
+def build_evidence_repair_recovery_completion_audit_preview(
+    *,
+    recovery_completion_receipt: Mapping[str, Any] | None = None,
+    observed_recovery_steps: Mapping[str, Any] | None = None,
+    recorded_receipts: Sequence[Mapping[str, Any]] | Mapping[str, Any] | None = None,
+    used_token_ids: Sequence[str] | None = None,
+    released_lock_ids: Sequence[str] | None = None,
+    post_recovery_audit_status: Mapping[str, Any] | None = None,
+    contamination_status: Mapping[str, Any] | None = None,
+) -> MemoryEvidenceRepairRecoveryCompletionAuditPreviewReport:
+    """Build a read-only recovery completion audit preview from a receipt."""
+
+    recovery_completion_receipt = (
+        recovery_completion_receipt
+        if isinstance(recovery_completion_receipt, Mapping)
+        else {}
+    )
+    report_status = _str(recovery_completion_receipt.get("status"))
+    receipt = _extract_receipt(recovery_completion_receipt)
+    observed = _observed_context(
+        observed_recovery_steps=observed_recovery_steps,
+        recorded_receipts=recorded_receipts,
+        used_token_ids=used_token_ids,
+        released_lock_ids=released_lock_ids,
+        post_recovery_audit_status=post_recovery_audit_status,
+        contamination_status=contamination_status,
+    )
+
+    if not receipt:
+        if (
+            not recovery_completion_receipt
+            or report_status == RECOVERY_COMPLETION_RECEIPT_STATUS_NO_ACTION_NEEDED
+        ):
+            return _empty_report(recovery_completion_receipt=recovery_completion_receipt)
+        source_blocking = tuple(_list_of_str(recovery_completion_receipt.get("blocking_reasons")))
+        source_actions = tuple(_list_of_str(recovery_completion_receipt.get("required_actions")))
+        return _blocked_report(
+            recovery_completion_receipt=recovery_completion_receipt,
+            checks=(
+                _fail(
+                    CHECK_RECOVERY_COMPLETION_RECEIPT_READY,
+                    "No recovery completion receipt was supplied."
+                    if not source_blocking
+                    else "; ".join(source_blocking),
+                    source_actions or ("produce_recovery_completion_receipt",),
+                    {"recovery_completion_receipt_status": report_status},
+                ),
+            ),
+        )
+
+    audit_steps = tuple(_audit_steps_from_receipt(receipt, observed))
+    checks = (
+        _receipt_ready_check(recovery_completion_receipt, receipt),
+        _receipt_integrity_check(receipt),
+        _audit_requirements_check(receipt, audit_steps),
+        _observed_recovery_completion_state_check(observed, audit_steps),
+    )
+    blocking_reasons = tuple(
+        _dedupe_strings(check.reason for check in checks if check.status == CHECK_STATUS_FAIL)
+    )
+    required_actions = tuple(
+        _dedupe_strings(
+            action
+            for check in checks
+            if check.status == CHECK_STATUS_FAIL
+            for action in check.required_actions
+        )
+    )
+    if blocking_reasons:
+        return MemoryEvidenceRepairRecoveryCompletionAuditPreviewReport(
+            generated_at=datetime.now(timezone.utc).isoformat(),
+            status=RECOVERY_COMPLETION_AUDIT_STATUS_BLOCKED,
+            checks=checks,
+            previews=(),
+            blocking_reasons=blocking_reasons,
+            required_actions=required_actions,
+            source_recovery_completion_receipt_report=dict(recovery_completion_receipt),
+        )
+
+    preview = _preview_from_receipt(
+        receipt=receipt,
+        audit_steps=audit_steps,
+        observed_state_supplied=observed["supplied"],
+    )
+    return MemoryEvidenceRepairRecoveryCompletionAuditPreviewReport(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        status=RECOVERY_COMPLETION_AUDIT_STATUS_READY,
+        checks=checks,
+        previews=(preview,),
+        blocking_reasons=(),
+        required_actions=(),
+        source_recovery_completion_receipt_report=dict(recovery_completion_receipt),
+    )
+
+
+def empty_evidence_repair_recovery_completion_audit_preview() -> MemoryEvidenceRepairRecoveryCompletionAuditPreviewReport:
+    """Return an empty read-only recovery completion audit preview."""
+
+    return _empty_report(recovery_completion_receipt={})
+
+
+def _extract_receipt(recovery_completion_receipt: Mapping[str, Any]) -> dict[str, Any]:
+    receipts = recovery_completion_receipt.get("receipts")
+    if isinstance(receipts, list):
+        for receipt in receipts:
+            if isinstance(receipt, Mapping):
+                return dict(receipt)
+    if _str(recovery_completion_receipt.get("id")).startswith(
+        "recovery-completion-receipt-"
+    ):
+        return dict(recovery_completion_receipt)
+    return {}
+
+
+def _receipt_ready_check(
+    recovery_completion_receipt: Mapping[str, Any],
+    receipt: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryCompletionAuditCheck:
+    report_status = _str(recovery_completion_receipt.get("status"))
+    receipt_status = _str(receipt.get("status"))
+    if report_status and report_status != RECOVERY_COMPLETION_RECEIPT_STATUS_READY:
+        return _fail(
+            CHECK_RECOVERY_COMPLETION_RECEIPT_READY,
+            "Recovery completion receipt report is not ready for audit planning.",
+            tuple(_list_of_str(recovery_completion_receipt.get("required_actions")))
+            or ("produce_ready_recovery_completion_receipt",),
+            {"report_status": report_status, "receipt_status": receipt_status},
+        )
+    if receipt_status != RECOVERY_COMPLETION_RECEIPT_STATUS_READY:
+        return _fail(
+            CHECK_RECOVERY_COMPLETION_RECEIPT_READY,
+            "Recovery completion receipt entry is not ready.",
+            ("produce_ready_recovery_completion_receipt",),
+            {"report_status": report_status, "receipt_status": receipt_status},
+        )
+    return _pass(
+        CHECK_RECOVERY_COMPLETION_RECEIPT_READY,
+        "Recovery completion receipt is ready for audit planning.",
+        {"receipt_id": _str(receipt.get("id"))},
+    )
+
+
+def _receipt_integrity_check(
+    receipt: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryCompletionAuditCheck:
+    expected_digest = _expected_receipt_digest(receipt)
+    actual_digest = _str(receipt.get("receipt_digest"))
+    expected_id = (
+        f"recovery-completion-receipt-{expected_digest[:16]}"
+        if expected_digest
+        else ""
+    )
+    missing_fields: list[str] = []
+    for field_name in (
+        "id",
+        "token_id",
+        "lock_id",
+        "decision_id",
+        "execution_preview_id",
+        "executor_preview_id",
+        "operation_ids",
+        "recovery_step_ids",
+        "future_mutation_step_ids",
+        "executor_step_ids",
+        "executor_preview_digest",
+    ):
+        value = receipt.get(field_name)
+        if isinstance(value, list) and not value:
+            missing_fields.append(field_name)
+        elif not isinstance(value, list) and not _str(value):
+            missing_fields.append(field_name)
+    if (
+        missing_fields
+        or actual_digest != expected_digest
+        or _str(receipt.get("id")) != expected_id
+        or _str(receipt.get("receipt_type")) != RECOVERY_COMPLETION_RECEIPT_TYPE
+        or _str(receipt.get("scope")) != RECOVERY_COMPLETION_RECEIPT_SCOPE
+    ):
+        return _fail(
+            CHECK_RECOVERY_COMPLETION_RECEIPT_INTEGRITY,
+            "Recovery completion receipt digest, id, type, scope, or required fields are invalid.",
+            ("regenerate_recovery_completion_receipt",),
+            {
+                "expected_receipt_digest": expected_digest,
+                "actual_receipt_digest": actual_digest,
+                "expected_receipt_id": expected_id,
+                "actual_receipt_id": _str(receipt.get("id")),
+                "missing_fields": missing_fields,
+            },
+        )
+    return _pass(
+        CHECK_RECOVERY_COMPLETION_RECEIPT_INTEGRITY,
+        "Recovery completion receipt integrity checks pass.",
+        {"receipt_id": expected_id, "receipt_digest": actual_digest},
+    )
+
+
+def _audit_requirements_check(
+    receipt: Mapping[str, Any],
+    audit_steps: Sequence[MemoryEvidenceRepairRecoveryCompletionAuditStep],
+) -> MemoryEvidenceRepairRecoveryCompletionAuditCheck:
+    categories = {step.category for step in audit_steps}
+    required = {
+        "completion_receipt",
+        "token",
+        "lock",
+        "recovery_step",
+        "post_recovery_audit",
+        "contamination_guard",
+    }
+    missing = sorted(required - categories)
+    if missing or not _list_of_str(receipt.get("future_mutation_step_ids")):
+        return _fail(
+            CHECK_RECOVERY_COMPLETION_AUDIT_REQUIREMENTS,
+            "Recovery completion audit requirements are incomplete.",
+            ("regenerate_recovery_completion_receipt_with_audit_requirements",),
+            {
+                "missing_categories": missing,
+                "future_mutation_step_count": len(
+                    _list_of_str(receipt.get("future_mutation_step_ids"))
+                ),
+            },
+        )
+    return _pass(
+        CHECK_RECOVERY_COMPLETION_AUDIT_REQUIREMENTS,
+        "Recovery completion audit covers receipt, token, lock, recovery steps, post-audit, and contamination guard checks.",
+        {
+            "audit_step_count": len(audit_steps),
+            "future_mutation_step_count": len(
+                _list_of_str(receipt.get("future_mutation_step_ids"))
+            ),
+        },
+    )
+
+
+def _observed_recovery_completion_state_check(
+    observed: Mapping[str, Any],
+    audit_steps: Sequence[MemoryEvidenceRepairRecoveryCompletionAuditStep],
+) -> MemoryEvidenceRepairRecoveryCompletionAuditCheck:
+    if not observed.get("supplied"):
+        return _pass(
+            CHECK_OBSERVED_RECOVERY_COMPLETION_STATE,
+            "No observed recovery-completion state supplied; audit remains a planned preview.",
+            {"observed_state_supplied": False},
+        )
+    failures = [
+        step.to_dict()
+        for step in audit_steps
+        if step.status == RECOVERY_AUDIT_STEP_STATUS_FAIL
+    ]
+    if failures:
+        return _fail(
+            CHECK_OBSERVED_RECOVERY_COMPLETION_STATE,
+            "Observed recovery-completion state does not satisfy the audit preview.",
+            ("investigate_recovery_completion_audit_failures",),
+            {"observed_state_supplied": True, "failures": failures},
+        )
+    return _pass(
+        CHECK_OBSERVED_RECOVERY_COMPLETION_STATE,
+        "Observed recovery-completion state satisfies the audit preview.",
+        {"observed_state_supplied": True},
+    )
+
+
+def _preview_from_receipt(
+    *,
+    receipt: Mapping[str, Any],
+    audit_steps: Sequence[MemoryEvidenceRepairRecoveryCompletionAuditStep],
+    observed_state_supplied: bool,
+) -> MemoryEvidenceRepairRecoveryCompletionAuditPreview:
+    audit_step_ids = tuple(step.id for step in audit_steps)
+    operation_ids = tuple(_list_of_str(receipt.get("operation_ids")))
+    recovery_step_ids = tuple(_list_of_str(receipt.get("recovery_step_ids")))
+    future_mutation_step_ids = tuple(
+        _list_of_str(receipt.get("future_mutation_step_ids"))
+    )
+    audit_seed = {
+        "receipt_id": _str(receipt.get("id")),
+        "executor_preview_id": _str(receipt.get("executor_preview_id")),
+        "decision_id": _str(receipt.get("decision_id")),
+        "execution_preview_id": _str(receipt.get("execution_preview_id")),
+        "lock_id": _str(receipt.get("lock_id")),
+        "token_id": _str(receipt.get("token_id")),
+        "route": _str(receipt.get("route")),
+        "operation_ids": operation_ids,
+        "recovery_step_ids": recovery_step_ids,
+        "future_mutation_step_ids": future_mutation_step_ids,
+        "audit_step_ids": audit_step_ids,
+        "observed_state_supplied": observed_state_supplied,
+    }
+    audit_digest = _digest(audit_seed)
+    audit_id = f"recovery-completion-audit-{audit_digest[:16]}"
+    return MemoryEvidenceRepairRecoveryCompletionAuditPreview(
+        id=audit_id,
+        status=RECOVERY_COMPLETION_AUDIT_STATUS_READY,
+        receipt_id=_str(receipt.get("id")),
+        executor_preview_id=_str(receipt.get("executor_preview_id")),
+        decision_id=_str(receipt.get("decision_id")),
+        execution_preview_id=_str(receipt.get("execution_preview_id")),
+        lock_id=_str(receipt.get("lock_id")),
+        token_id=_str(receipt.get("token_id")),
+        route=_str(receipt.get("route")),
+        operation_ids=operation_ids,
+        recovery_step_ids=recovery_step_ids,
+        future_mutation_step_ids=future_mutation_step_ids,
+        audit_step_ids=audit_step_ids,
+        audit_digest=audit_digest,
+        audit_preview=f"{audit_id}:{audit_digest[:12]}",
+        audit_steps=tuple(audit_steps),
+        observed_state_supplied=observed_state_supplied,
+        would_verify_completion_receipt_recorded=True,
+        would_verify_recovery_token_used=True,
+        would_verify_recovery_lock_released=True,
+        would_verify_recovery_steps_completed=True,
+        would_verify_post_recovery_audit_clear=True,
+        would_verify_no_secondary_memory_contamination=True,
+        safety_note=(
+            "Read-only recovery completion audit preview. It plans or checks "
+            "future recovery verification signals but does not read or write "
+            "durable memory."
+        ),
+        source_recovery_completion_receipt=dict(receipt),
+    )
+
+
+def _audit_steps_from_receipt(
+    receipt: Mapping[str, Any],
+    observed: Mapping[str, Any],
+) -> list[MemoryEvidenceRepairRecoveryCompletionAuditStep]:
+    steps: list[MemoryEvidenceRepairRecoveryCompletionAuditStep] = []
+    steps.append(
+        _audit_step(
+            sequence=1,
+            category="completion_receipt",
+            assertion="recovery_completion_receipt_recorded",
+            receipt=receipt,
+            expected_signal={"receipt_id": _str(receipt.get("id"))},
+            observed_signal={"recorded": _receipt_recorded(receipt, observed)},
+            status=_boolean_status(_receipt_recorded(receipt, observed), observed["supplied"]),
+            required_action_on_fail="record_or_recover_recovery_completion_receipt",
+        )
+    )
+    steps.append(
+        _audit_step(
+            sequence=2,
+            category="token",
+            assertion="recovery_approval_token_marked_used",
+            receipt=receipt,
+            expected_signal={"token_id": _str(receipt.get("token_id"))},
+            observed_signal={"used": _token_used(receipt, observed)},
+            status=_boolean_status(_token_used(receipt, observed), observed["supplied"]),
+            required_action_on_fail="mark_recovery_token_used_or_block_reuse",
+        )
+    )
+    steps.append(
+        _audit_step(
+            sequence=3,
+            category="lock",
+            assertion="recovery_write_lock_released",
+            receipt=receipt,
+            expected_signal={"lock_id": _str(receipt.get("lock_id"))},
+            observed_signal={"released": _lock_released(receipt, observed)},
+            status=_boolean_status(_lock_released(receipt, observed), observed["supplied"]),
+            required_action_on_fail="release_recovery_write_lock_or_mark_expired",
+        )
+    )
+    sequence = 4
+    observed_steps = _dict(observed.get("recovery_steps"))
+    for recovery_step_id in _list_of_str(receipt.get("recovery_step_ids")):
+        observed_signal = _dict(observed_steps.get(recovery_step_id))
+        completed = _recovery_step_completed(observed_signal)
+        steps.append(
+            _audit_step(
+                sequence=sequence,
+                category="recovery_step",
+                assertion="recovery_step_completed",
+                receipt=receipt,
+                recovery_step_id=recovery_step_id,
+                expected_signal={"recovery_step_id": recovery_step_id, "completed": True},
+                observed_signal=observed_signal,
+                status=_boolean_status(completed, observed["supplied"]),
+                required_action_on_fail="inspect_recovery_step_or_reopen_recovery_plan",
+            )
+        )
+        sequence += 1
+    post_status = _post_recovery_audit_clear(observed)
+    steps.append(
+        _audit_step(
+            sequence=sequence,
+            category="post_recovery_audit",
+            assertion="post_recovery_audit_clear",
+            receipt=receipt,
+            expected_signal={"post_recovery_audit_clear": True},
+            observed_signal=_dict(observed.get("post_recovery_audit_status")),
+            status=_boolean_status(post_status, observed["supplied"]),
+            required_action_on_fail="rerun_or_investigate_post_recovery_audit",
+        )
+    )
+    sequence += 1
+    contamination_clear = _contamination_clear(observed)
+    steps.append(
+        _audit_step(
+            sequence=sequence,
+            category="contamination_guard",
+            assertion="no_secondary_memory_contamination",
+            receipt=receipt,
+            expected_signal={"secondary_memory_contamination": False},
+            observed_signal=_dict(observed.get("contamination_status")),
+            status=_boolean_status(contamination_clear, observed["supplied"]),
+            required_action_on_fail="isolate_secondary_memory_contamination",
+        )
+    )
+    return steps
+
+
+def _audit_step(
+    *,
+    sequence: int,
+    category: str,
+    assertion: str,
+    receipt: Mapping[str, Any],
+    expected_signal: Mapping[str, Any],
+    observed_signal: Mapping[str, Any],
+    status: str,
+    required_action_on_fail: str,
+    recovery_step_id: str = "",
+    operation_id: str = "",
+) -> MemoryEvidenceRepairRecoveryCompletionAuditStep:
+    return MemoryEvidenceRepairRecoveryCompletionAuditStep(
+        id=f"recovery-completion-audit-step-{sequence}-{category}",
+        sequence=sequence,
+        category=category,
+        assertion=assertion,
+        operation_id=operation_id,
+        recovery_step_id=recovery_step_id,
+        receipt_id=_str(receipt.get("id")),
+        token_id=_str(receipt.get("token_id")),
+        lock_id=_str(receipt.get("lock_id")),
+        expected_signal=dict(expected_signal),
+        observed_signal=dict(observed_signal),
+        status=status,
+        required_action_on_fail=required_action_on_fail,
+    )
+
+
+def _observed_context(
+    *,
+    observed_recovery_steps: Mapping[str, Any] | None,
+    recorded_receipts: Sequence[Mapping[str, Any]] | Mapping[str, Any] | None,
+    used_token_ids: Sequence[str] | None,
+    released_lock_ids: Sequence[str] | None,
+    post_recovery_audit_status: Mapping[str, Any] | None,
+    contamination_status: Mapping[str, Any] | None,
+) -> dict[str, Any]:
+    recovery_steps = _dict(observed_recovery_steps)
+    receipt_ids = _receipt_ids(recorded_receipts)
+    used_tokens = tuple(_list_of_str(used_token_ids))
+    released_locks = tuple(_list_of_str(released_lock_ids))
+    post_audit = _dict(post_recovery_audit_status)
+    contamination = _dict(contamination_status)
+    supplied = bool(
+        recovery_steps
+        or receipt_ids
+        or used_tokens
+        or released_locks
+        or post_audit
+        or contamination
+    )
+    return {
+        "supplied": supplied,
+        "recovery_steps": recovery_steps,
+        "receipt_ids": receipt_ids,
+        "used_token_ids": used_tokens,
+        "released_lock_ids": released_locks,
+        "post_recovery_audit_status": post_audit,
+        "contamination_status": contamination,
+    }
+
+
+def _boolean_status(value: bool, observed_supplied: bool) -> str:
+    if not observed_supplied:
+        return RECOVERY_AUDIT_STEP_STATUS_PLANNED
+    return RECOVERY_AUDIT_STEP_STATUS_PASS if value else RECOVERY_AUDIT_STEP_STATUS_FAIL
+
+
+def _receipt_recorded(receipt: Mapping[str, Any], observed: Mapping[str, Any]) -> bool:
+    return _str(receipt.get("id")) in set(observed.get("receipt_ids") or ())
+
+
+def _token_used(receipt: Mapping[str, Any], observed: Mapping[str, Any]) -> bool:
+    return _str(receipt.get("token_id")) in set(observed.get("used_token_ids") or ())
+
+
+def _lock_released(receipt: Mapping[str, Any], observed: Mapping[str, Any]) -> bool:
+    return _str(receipt.get("lock_id")) in set(observed.get("released_lock_ids") or ())
+
+
+def _recovery_step_completed(observed_signal: Mapping[str, Any]) -> bool:
+    if not observed_signal:
+        return False
+    status = _str(observed_signal.get("status")).lower()
+    return observed_signal.get("completed") is True or status in {
+        "complete",
+        "completed",
+        "success",
+        "succeeded",
+        "pass",
+        "passed",
+        "verified",
+    }
+
+
+def _post_recovery_audit_clear(observed: Mapping[str, Any]) -> bool:
+    post_audit = _dict(observed.get("post_recovery_audit_status"))
+    if not post_audit:
+        return False
+    status = _str(post_audit.get("status")).lower()
+    return post_audit.get("clear") is True or status in {
+        "clear",
+        "clean",
+        "pass",
+        "passed",
+        "success",
+        "verified",
+        "no_issues",
+    }
+
+
+def _contamination_clear(observed: Mapping[str, Any]) -> bool:
+    contamination = _dict(observed.get("contamination_status"))
+    if not contamination:
+        return False
+    status = _str(contamination.get("status")).lower()
+    if contamination.get("contaminated") is False:
+        return True
+    return status in {"clear", "clean", "no_contamination", "verified", "pass"}
+
+
+def _receipt_ids(recorded_receipts: Sequence[Mapping[str, Any]] | Mapping[str, Any] | None) -> tuple[str, ...]:
+    ids: list[str] = []
+    if isinstance(recorded_receipts, Mapping):
+        ids.extend(_list_of_str(recorded_receipts.get("receipt_ids")))
+        rows = recorded_receipts.get("receipts")
+        if isinstance(rows, list):
+            ids.extend(_receipt_ids(rows))
+        if _str(recorded_receipts.get("id")):
+            ids.append(_str(recorded_receipts.get("id")))
+        if _str(recorded_receipts.get("receipt_id")):
+            ids.append(_str(recorded_receipts.get("receipt_id")))
+    elif isinstance(recorded_receipts, list):
+        for receipt in recorded_receipts:
+            if isinstance(receipt, Mapping):
+                ids.append(_str(receipt.get("id")) or _str(receipt.get("receipt_id")))
+    return tuple(_dedupe_strings(ids))
+
+
+def _expected_receipt_digest(receipt: Mapping[str, Any]) -> str:
+    source_preview = _dict(receipt.get("source_recovery_executor_preview"))
+    seed = {
+        "receipt_type": RECOVERY_COMPLETION_RECEIPT_TYPE,
+        "scope": RECOVERY_COMPLETION_RECEIPT_SCOPE,
+        "actor": _str(receipt.get("actor")) or "human",
+        "recovery_reason": _str(receipt.get("recovery_reason")),
+        "token_id": _str(receipt.get("token_id")),
+        "lock_id": _str(receipt.get("lock_id")),
+        "decision_id": _str(receipt.get("decision_id")),
+        "execution_preview_id": _str(receipt.get("execution_preview_id")),
+        "executor_preview_id": _str(receipt.get("executor_preview_id")),
+        "route": _str(receipt.get("route")),
+        "operation_ids": tuple(_list_of_str(receipt.get("operation_ids"))),
+        "recovery_step_ids": tuple(_list_of_str(receipt.get("recovery_step_ids"))),
+        "future_mutation_step_ids": tuple(
+            _list_of_str(receipt.get("future_mutation_step_ids"))
+        ),
+        "executor_step_ids": tuple(_list_of_str(receipt.get("executor_step_ids"))),
+        "executor_preview_digest": _str(receipt.get("executor_preview_digest")),
+        "preview_status": _str(source_preview.get("status")),
+    }
+    return _digest(seed)
+
+
+def _empty_report(
+    *,
+    recovery_completion_receipt: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryCompletionAuditPreviewReport:
+    return MemoryEvidenceRepairRecoveryCompletionAuditPreviewReport(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        status=RECOVERY_COMPLETION_AUDIT_STATUS_NO_ACTION_NEEDED,
+        checks=(),
+        previews=(),
+        blocking_reasons=(),
+        required_actions=(),
+        source_recovery_completion_receipt_report=dict(recovery_completion_receipt),
+    )
+
+
+def _blocked_report(
+    *,
+    recovery_completion_receipt: Mapping[str, Any],
+    checks: tuple[MemoryEvidenceRepairRecoveryCompletionAuditCheck, ...],
+) -> MemoryEvidenceRepairRecoveryCompletionAuditPreviewReport:
+    return MemoryEvidenceRepairRecoveryCompletionAuditPreviewReport(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        status=RECOVERY_COMPLETION_AUDIT_STATUS_BLOCKED,
+        checks=checks,
+        previews=(),
+        blocking_reasons=tuple(
+            _dedupe_strings(check.reason for check in checks if check.status == CHECK_STATUS_FAIL)
+        ),
+        required_actions=tuple(
+            _dedupe_strings(
+                action
+                for check in checks
+                if check.status == CHECK_STATUS_FAIL
+                for action in check.required_actions
+            )
+        ),
+        source_recovery_completion_receipt_report=dict(recovery_completion_receipt),
+    )
+
+
+def _pass(
+    check_id: str,
+    reason: str,
+    details: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryCompletionAuditCheck:
+    return MemoryEvidenceRepairRecoveryCompletionAuditCheck(
+        id=check_id,
+        status=CHECK_STATUS_PASS,
+        reason=reason,
+        required_actions=(),
+        details=dict(details),
+    )
+
+
+def _fail(
+    check_id: str,
+    reason: str,
+    required_actions: Sequence[str],
+    details: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryCompletionAuditCheck:
+    return MemoryEvidenceRepairRecoveryCompletionAuditCheck(
+        id=check_id,
+        status=CHECK_STATUS_FAIL,
+        reason=reason,
+        required_actions=tuple(required_actions),
+        details=dict(details),
+    )
+
+
+def _digest(value: Any) -> str:
+    raw = json.dumps(value, sort_keys=True, ensure_ascii=False, default=str)
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def _dict(value: Any) -> dict[str, Any]:
+    return dict(value) if isinstance(value, Mapping) else {}
+
+
+def _list_of_str(value: Any) -> list[str]:
+    return [_str(item) for item in value] if isinstance(value, list) else []
+
+
+def _dedupe_strings(values: Sequence[str] | Any) -> list[str]:
+    seen: set[str] = set()
+    result: list[str] = []
+    for value in values:
+        text = _str(value)
+        if text and text not in seen:
+            seen.add(text)
+            result.append(text)
+    return result
+
+
+def _str(value: Any) -> str:
+    return str(value or "").strip()

--- a/agent/memory_evidence_repair_recovery_completion_receipt.py
+++ b/agent/memory_evidence_repair_recovery_completion_receipt.py
@@ -1,0 +1,527 @@
+"""Read-only recovery completion receipt draft for memory evidence repair.
+
+The recovery completion receipt layer turns a ready recovery executor preview
+into a durable-looking receipt draft and token/lock ledger view. It never writes
+to durable memory stores; it only describes what a later manual recovery would
+record after successful completion.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Mapping, Sequence
+
+from agent.memory_evidence_repair_recovery_executor_preview import (
+    RECOVERY_EXECUTOR_PREVIEW_STATUS_NO_ACTION_NEEDED,
+    RECOVERY_EXECUTOR_PREVIEW_STATUS_READY,
+)
+from agent.memory_evidence_repair_recovery_write_lock_gate import (
+    RECOVERY_WRITE_LOCK_SCOPE,
+)
+
+
+RECOVERY_COMPLETION_RECEIPT_TYPE = "memory_evidence_repair_recovery_completion_receipt"
+RECOVERY_COMPLETION_RECEIPT_SCOPE = RECOVERY_WRITE_LOCK_SCOPE
+RECOVERY_COMPLETION_RECEIPT_STATUS_READY = "recovery_completion_receipt_ready"
+RECOVERY_COMPLETION_RECEIPT_STATUS_BLOCKED = "blocked"
+RECOVERY_COMPLETION_RECEIPT_STATUS_NO_ACTION_NEEDED = "no_action_needed"
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairRecoveryCompletionReceipt:
+    """One read-only recovery completion receipt draft."""
+
+    id: str
+    receipt_type: str
+    status: str
+    scope: str
+    actor: str
+    recovery_reason: str
+    token_id: str
+    lock_id: str
+    decision_id: str
+    execution_preview_id: str
+    executor_preview_id: str
+    route: str
+    executor_preview_digest: str
+    receipt_digest: str
+    receipt_preview: str
+    operation_ids: tuple[str, ...]
+    recovery_step_ids: tuple[str, ...]
+    future_mutation_step_ids: tuple[str, ...]
+    executor_step_ids: tuple[str, ...]
+    used_recovery_token_id: str
+    released_recovery_lock_id: str
+    would_record_receipt: bool
+    would_mark_recovery_token_used: bool
+    would_release_recovery_write_lock: bool
+    would_trigger_recovery_audit: bool
+    safety_note: str
+    source_recovery_executor_preview: dict[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "receipt_type": self.receipt_type,
+            "status": self.status,
+            "scope": self.scope,
+            "actor": self.actor,
+            "recovery_reason": self.recovery_reason,
+            "token_id": self.token_id,
+            "lock_id": self.lock_id,
+            "decision_id": self.decision_id,
+            "execution_preview_id": self.execution_preview_id,
+            "executor_preview_id": self.executor_preview_id,
+            "route": self.route,
+            "executor_preview_digest": self.executor_preview_digest,
+            "receipt_digest": self.receipt_digest,
+            "receipt_preview": self.receipt_preview,
+            "operation_ids": list(self.operation_ids),
+            "recovery_step_ids": list(self.recovery_step_ids),
+            "future_mutation_step_ids": list(self.future_mutation_step_ids),
+            "executor_step_ids": list(self.executor_step_ids),
+            "used_recovery_token_id": self.used_recovery_token_id,
+            "released_recovery_lock_id": self.released_recovery_lock_id,
+            "would_record_receipt": self.would_record_receipt,
+            "would_mark_recovery_token_used": self.would_mark_recovery_token_used,
+            "would_release_recovery_write_lock": self.would_release_recovery_write_lock,
+            "would_trigger_recovery_audit": self.would_trigger_recovery_audit,
+            "safety_note": self.safety_note,
+            "source_recovery_executor_preview": dict(self.source_recovery_executor_preview),
+        }
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairRecoveryCompletionReceiptReport:
+    """Read-only recovery completion receipt report."""
+
+    generated_at: str
+    status: str
+    receipts: tuple[MemoryEvidenceRepairRecoveryCompletionReceipt, ...]
+    used_recovery_token_ids: tuple[str, ...]
+    released_recovery_lock_ids: tuple[str, ...]
+    blocking_reasons: tuple[str, ...]
+    required_actions: tuple[str, ...]
+    source_recovery_executor_preview_report: dict[str, Any]
+
+    @property
+    def summary(self) -> dict[str, Any]:
+        return {
+            "status": self.status,
+            "receipt_count": len(self.receipts),
+            "used_recovery_token_count": len(self.used_recovery_token_ids),
+            "released_recovery_lock_count": len(self.released_recovery_lock_ids),
+            "blocking_reason_count": len(self.blocking_reasons),
+            "required_action_count": len(self.required_actions),
+            "recovery_completion_receipt_available": bool(self.receipts),
+            "would_record_receipt_count": sum(
+                1 for receipt in self.receipts if receipt.would_record_receipt
+            ),
+            "would_mark_recovery_token_used_count": sum(
+                1 for receipt in self.receipts if receipt.would_mark_recovery_token_used
+            ),
+            "would_release_recovery_write_lock_count": sum(
+                1 for receipt in self.receipts if receipt.would_release_recovery_write_lock
+            ),
+            "would_trigger_recovery_audit_count": sum(
+                1 for receipt in self.receipts if receipt.would_trigger_recovery_audit
+            ),
+            "has_blocks": self.status == RECOVERY_COMPLETION_RECEIPT_STATUS_BLOCKED,
+            "requires_followup": bool(self.required_actions),
+        }
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "generated_at": self.generated_at,
+            "status": self.status,
+            "summary": self.summary,
+            "receipts": [receipt.to_dict() for receipt in self.receipts],
+            "used_recovery_token_ids": list(self.used_recovery_token_ids),
+            "released_recovery_lock_ids": list(self.released_recovery_lock_ids),
+            "blocking_reasons": list(self.blocking_reasons),
+            "required_actions": list(self.required_actions),
+            "source_recovery_executor_preview_report": dict(
+                self.source_recovery_executor_preview_report
+            ),
+            "read_only": True,
+            "read_only_memory": True,
+            "would_mutate_memory": False,
+        }
+
+
+def build_evidence_repair_recovery_completion_receipt(
+    *,
+    recovery_executor_preview: Mapping[str, Any] | None = None,
+    existing_receipts: Sequence[Mapping[str, Any]] | Mapping[str, Any] | None = None,
+    used_token_ids: Sequence[str] | None = None,
+    released_lock_ids: Sequence[str] | None = None,
+    actor: str = "human",
+    recovery_reason: str = "",
+) -> MemoryEvidenceRepairRecoveryCompletionReceiptReport:
+    """Build a read-only recovery completion receipt from an executor preview."""
+
+    recovery_executor_preview = (
+        recovery_executor_preview if isinstance(recovery_executor_preview, Mapping) else {}
+    )
+    report_status = _str(recovery_executor_preview.get("status"))
+    preview = _extract_preview(recovery_executor_preview)
+    existing_used = _used_recovery_token_ids(existing_receipts, used_token_ids)
+    existing_released = _released_recovery_lock_ids(existing_receipts, released_lock_ids)
+
+    if not preview:
+        if (
+            not recovery_executor_preview
+            or report_status == RECOVERY_EXECUTOR_PREVIEW_STATUS_NO_ACTION_NEEDED
+        ):
+            return _empty_report(
+                recovery_executor_preview=recovery_executor_preview,
+                used_recovery_token_ids=existing_used,
+                released_recovery_lock_ids=existing_released,
+            )
+        source_blocking = tuple(_list_of_str(recovery_executor_preview.get("blocking_reasons")))
+        source_actions = tuple(_list_of_str(recovery_executor_preview.get("required_actions")))
+        return _blocked_report(
+            recovery_executor_preview=recovery_executor_preview,
+            used_recovery_token_ids=existing_used,
+            released_recovery_lock_ids=existing_released,
+            blocking_reasons=source_blocking
+            or ("Recovery executor preview is not ready for completion receipt.",),
+            required_actions=source_actions or ("produce_recovery_executor_preview",),
+        )
+
+    validation_error = _preview_validation_error(recovery_executor_preview, preview)
+    if validation_error is not None:
+        return _blocked_report(
+            recovery_executor_preview=recovery_executor_preview,
+            used_recovery_token_ids=existing_used,
+            released_recovery_lock_ids=existing_released,
+            blocking_reasons=(validation_error,),
+            required_actions=("regenerate_recovery_executor_preview",),
+        )
+
+    token_id = _str(preview.get("token_id"))
+    lock_id = _str(preview.get("lock_id"))
+    if token_id in set(existing_used):
+        return _blocked_report(
+            recovery_executor_preview=recovery_executor_preview,
+            used_recovery_token_ids=existing_used,
+            released_recovery_lock_ids=existing_released,
+            blocking_reasons=(
+                "Recovery approval token is already present in the used-token ledger.",
+            ),
+            required_actions=("regenerate_recovery_human_approval_token",),
+        )
+    if lock_id in set(existing_released):
+        return _blocked_report(
+            recovery_executor_preview=recovery_executor_preview,
+            used_recovery_token_ids=existing_used,
+            released_recovery_lock_ids=existing_released,
+            blocking_reasons=(
+                "Recovery write lock is already present in the released-lock ledger.",
+            ),
+            required_actions=("regenerate_recovery_write_lock_gate",),
+        )
+
+    receipt = _receipt_from_preview(
+        preview=preview,
+        actor=actor,
+        recovery_reason=recovery_reason,
+    )
+    return MemoryEvidenceRepairRecoveryCompletionReceiptReport(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        status=RECOVERY_COMPLETION_RECEIPT_STATUS_READY,
+        receipts=(receipt,),
+        used_recovery_token_ids=tuple(
+            _dedupe_strings([*existing_used, receipt.used_recovery_token_id])
+        ),
+        released_recovery_lock_ids=tuple(
+            _dedupe_strings([*existing_released, receipt.released_recovery_lock_id])
+        ),
+        blocking_reasons=(),
+        required_actions=(),
+        source_recovery_executor_preview_report=dict(recovery_executor_preview),
+    )
+
+
+def empty_evidence_repair_recovery_completion_receipt() -> MemoryEvidenceRepairRecoveryCompletionReceiptReport:
+    """Return an empty read-only recovery completion receipt report."""
+
+    return _empty_report(
+        recovery_executor_preview={},
+        used_recovery_token_ids=(),
+        released_recovery_lock_ids=(),
+    )
+
+
+def _receipt_from_preview(
+    *,
+    preview: Mapping[str, Any],
+    actor: str,
+    recovery_reason: str,
+) -> MemoryEvidenceRepairRecoveryCompletionReceipt:
+    operation_ids = tuple(_list_of_str(preview.get("operation_ids")))
+    recovery_step_ids = tuple(_list_of_str(preview.get("step_ids")))
+    future_mutation_step_ids = tuple(_list_of_str(preview.get("future_mutation_step_ids")))
+    executor_step_ids = tuple(_list_of_str(preview.get("executor_step_ids")))
+    token_id = _str(preview.get("token_id"))
+    lock_id = _str(preview.get("lock_id"))
+    receipt_seed = {
+        "receipt_type": RECOVERY_COMPLETION_RECEIPT_TYPE,
+        "scope": RECOVERY_COMPLETION_RECEIPT_SCOPE,
+        "actor": _str(actor) or "human",
+        "recovery_reason": _str(recovery_reason),
+        "token_id": token_id,
+        "lock_id": lock_id,
+        "decision_id": _str(preview.get("decision_id")),
+        "execution_preview_id": _str(preview.get("execution_preview_id")),
+        "executor_preview_id": _str(preview.get("id")),
+        "route": _str(preview.get("route")),
+        "operation_ids": operation_ids,
+        "recovery_step_ids": recovery_step_ids,
+        "future_mutation_step_ids": future_mutation_step_ids,
+        "executor_step_ids": executor_step_ids,
+        "executor_preview_digest": _str(preview.get("preview_digest")),
+        "preview_status": _str(preview.get("status")),
+    }
+    receipt_digest = _digest(receipt_seed)
+    receipt_id = f"recovery-completion-receipt-{receipt_digest[:16]}"
+    return MemoryEvidenceRepairRecoveryCompletionReceipt(
+        id=receipt_id,
+        receipt_type=RECOVERY_COMPLETION_RECEIPT_TYPE,
+        status=RECOVERY_COMPLETION_RECEIPT_STATUS_READY,
+        scope=RECOVERY_COMPLETION_RECEIPT_SCOPE,
+        actor=_str(actor) or "human",
+        recovery_reason=_str(recovery_reason),
+        token_id=token_id,
+        lock_id=lock_id,
+        decision_id=_str(preview.get("decision_id")),
+        execution_preview_id=_str(preview.get("execution_preview_id")),
+        executor_preview_id=_str(preview.get("id")),
+        route=_str(preview.get("route")),
+        executor_preview_digest=_str(preview.get("preview_digest")),
+        receipt_digest=receipt_digest,
+        receipt_preview=f"{receipt_id}:{receipt_digest[:12]}",
+        operation_ids=operation_ids,
+        recovery_step_ids=recovery_step_ids,
+        future_mutation_step_ids=future_mutation_step_ids,
+        executor_step_ids=executor_step_ids,
+        used_recovery_token_id=token_id,
+        released_recovery_lock_id=lock_id,
+        would_record_receipt=True,
+        would_mark_recovery_token_used=True,
+        would_release_recovery_write_lock=True,
+        would_trigger_recovery_audit=True,
+        safety_note=(
+            "Read-only recovery completion receipt draft. It previews a future "
+            "completion receipt, used-token mark, released-lock mark, and audit "
+            "trigger, but does not persist any of them."
+        ),
+        source_recovery_executor_preview=dict(preview),
+    )
+
+
+def _preview_validation_error(
+    recovery_executor_preview: Mapping[str, Any],
+    preview: Mapping[str, Any],
+) -> str | None:
+    report_status = _str(recovery_executor_preview.get("status"))
+    preview_status = _str(preview.get("status"))
+    if report_status and report_status != RECOVERY_EXECUTOR_PREVIEW_STATUS_READY:
+        blocking = _list_of_str(recovery_executor_preview.get("blocking_reasons"))
+        return (
+            "; ".join(blocking)
+            if blocking
+            else "Recovery executor preview report is not ready."
+        )
+    if preview_status != RECOVERY_EXECUTOR_PREVIEW_STATUS_READY:
+        return "Recovery executor preview entry is not ready."
+
+    missing_fields: list[str] = []
+    for field_name in (
+        "id",
+        "lock_id",
+        "token_id",
+        "decision_id",
+        "execution_preview_id",
+        "operation_ids",
+        "step_ids",
+        "future_mutation_step_ids",
+        "executor_step_ids",
+        "preview_digest",
+    ):
+        value = preview.get(field_name)
+        if isinstance(value, list) and not value:
+            missing_fields.append(field_name)
+        elif not isinstance(value, list) and not _str(value):
+            missing_fields.append(field_name)
+    expected_digest = _expected_executor_preview_digest(preview)
+    actual_digest = _str(preview.get("preview_digest"))
+    expected_id = f"recovery-executor-preview-{expected_digest[:16]}" if expected_digest else ""
+    if missing_fields:
+        return (
+            "Recovery executor preview is missing required fields: "
+            + ", ".join(missing_fields)
+        )
+    if actual_digest != expected_digest or _str(preview.get("id")) != expected_id:
+        return "Recovery executor preview digest or id is invalid."
+    if not preview.get("would_execute_manual_recovery"):
+        return "Recovery executor preview does not indicate future manual recovery execution."
+    if not preview.get("would_release_recovery_write_lock"):
+        return "Recovery executor preview does not release the future recovery write lock."
+    if not preview.get("would_mark_recovery_token_used"):
+        return "Recovery executor preview does not mark the future recovery token used."
+    return None
+
+
+def _expected_executor_preview_digest(preview: Mapping[str, Any]) -> str:
+    seed = {
+        "lock_id": _str(preview.get("lock_id")),
+        "token_id": _str(preview.get("token_id")),
+        "decision_id": _str(preview.get("decision_id")),
+        "execution_preview_id": _str(preview.get("execution_preview_id")),
+        "operation_ids": tuple(_list_of_str(preview.get("operation_ids"))),
+        "step_ids": tuple(_list_of_str(preview.get("step_ids"))),
+        "future_mutation_step_ids": tuple(_list_of_str(preview.get("future_mutation_step_ids"))),
+        "executor_step_ids": tuple(_list_of_str(preview.get("executor_step_ids"))),
+        "execution_mode": _str(preview.get("execution_mode")),
+        "failure_policy": _str(preview.get("failure_policy")),
+    }
+    return _digest(seed)
+
+
+def _extract_preview(recovery_executor_preview: Mapping[str, Any]) -> dict[str, Any]:
+    previews = recovery_executor_preview.get("previews")
+    if isinstance(previews, list):
+        for preview in previews:
+            if isinstance(preview, Mapping):
+                return dict(preview)
+    if _str(recovery_executor_preview.get("id")).startswith("recovery-executor-preview-"):
+        return dict(recovery_executor_preview)
+    return {}
+
+
+def _empty_report(
+    *,
+    recovery_executor_preview: Mapping[str, Any],
+    used_recovery_token_ids: Sequence[str],
+    released_recovery_lock_ids: Sequence[str],
+) -> MemoryEvidenceRepairRecoveryCompletionReceiptReport:
+    return MemoryEvidenceRepairRecoveryCompletionReceiptReport(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        status=RECOVERY_COMPLETION_RECEIPT_STATUS_NO_ACTION_NEEDED,
+        receipts=(),
+        used_recovery_token_ids=tuple(_dedupe_strings(used_recovery_token_ids)),
+        released_recovery_lock_ids=tuple(_dedupe_strings(released_recovery_lock_ids)),
+        blocking_reasons=(),
+        required_actions=(),
+        source_recovery_executor_preview_report=dict(recovery_executor_preview),
+    )
+
+
+def _blocked_report(
+    *,
+    recovery_executor_preview: Mapping[str, Any],
+    used_recovery_token_ids: Sequence[str],
+    released_recovery_lock_ids: Sequence[str],
+    blocking_reasons: Sequence[str],
+    required_actions: Sequence[str],
+) -> MemoryEvidenceRepairRecoveryCompletionReceiptReport:
+    return MemoryEvidenceRepairRecoveryCompletionReceiptReport(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        status=RECOVERY_COMPLETION_RECEIPT_STATUS_BLOCKED,
+        receipts=(),
+        used_recovery_token_ids=tuple(_dedupe_strings(used_recovery_token_ids)),
+        released_recovery_lock_ids=tuple(_dedupe_strings(released_recovery_lock_ids)),
+        blocking_reasons=tuple(_dedupe_strings(blocking_reasons)),
+        required_actions=tuple(_dedupe_strings(required_actions)),
+        source_recovery_executor_preview_report=dict(recovery_executor_preview),
+    )
+
+
+def _used_recovery_token_ids(
+    existing_receipts: Sequence[Mapping[str, Any]] | Mapping[str, Any] | None,
+    explicit_used_token_ids: Sequence[str] | None,
+) -> tuple[str, ...]:
+    candidates: list[str] = _list_of_str(explicit_used_token_ids)
+    if isinstance(existing_receipts, Mapping):
+        candidates.extend(_list_of_str(existing_receipts.get("used_recovery_token_ids")))
+        candidates.extend(_list_of_str(existing_receipts.get("used_token_ids")))
+        receipt_rows = existing_receipts.get("receipts")
+        if isinstance(receipt_rows, list):
+            candidates.extend(_token_ids_from_receipts(receipt_rows))
+        else:
+            candidates.extend(_token_ids_from_receipts([existing_receipts]))
+    elif isinstance(existing_receipts, list):
+        candidates.extend(_token_ids_from_receipts(existing_receipts))
+    return tuple(_dedupe_strings(candidates))
+
+
+def _released_recovery_lock_ids(
+    existing_receipts: Sequence[Mapping[str, Any]] | Mapping[str, Any] | None,
+    explicit_released_lock_ids: Sequence[str] | None,
+) -> tuple[str, ...]:
+    candidates: list[str] = _list_of_str(explicit_released_lock_ids)
+    if isinstance(existing_receipts, Mapping):
+        candidates.extend(_list_of_str(existing_receipts.get("released_recovery_lock_ids")))
+        candidates.extend(_list_of_str(existing_receipts.get("released_lock_ids")))
+        receipt_rows = existing_receipts.get("receipts")
+        if isinstance(receipt_rows, list):
+            candidates.extend(_lock_ids_from_receipts(receipt_rows))
+        else:
+            candidates.extend(_lock_ids_from_receipts([existing_receipts]))
+    elif isinstance(existing_receipts, list):
+        candidates.extend(_lock_ids_from_receipts(existing_receipts))
+    return tuple(_dedupe_strings(candidates))
+
+
+def _token_ids_from_receipts(receipts: Sequence[Any]) -> list[str]:
+    token_ids: list[str] = []
+    for receipt in receipts:
+        if not isinstance(receipt, Mapping):
+            continue
+        token_id = (
+            _str(receipt.get("used_recovery_token_id"))
+            or _str(receipt.get("used_token_id"))
+            or _str(receipt.get("token_id"))
+        )
+        if token_id:
+            token_ids.append(token_id)
+    return token_ids
+
+
+def _lock_ids_from_receipts(receipts: Sequence[Any]) -> list[str]:
+    lock_ids: list[str] = []
+    for receipt in receipts:
+        if not isinstance(receipt, Mapping):
+            continue
+        lock_id = _str(receipt.get("released_recovery_lock_id")) or _str(receipt.get("lock_id"))
+        if lock_id:
+            lock_ids.append(lock_id)
+    return lock_ids
+
+
+def _digest(value: Any) -> str:
+    raw = json.dumps(value, sort_keys=True, ensure_ascii=False, default=str)
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def _list_of_str(value: Any) -> list[str]:
+    return [_str(item) for item in value] if isinstance(value, list) else []
+
+
+def _dedupe_strings(values: Sequence[str] | Any) -> list[str]:
+    seen: set[str] = set()
+    result: list[str] = []
+    for value in values:
+        text = _str(value)
+        if text and text not in seen:
+            seen.add(text)
+            result.append(text)
+    return result
+
+
+def _str(value: Any) -> str:
+    return str(value or "").strip()

--- a/agent/memory_evidence_repair_recovery_decision_gate.py
+++ b/agent/memory_evidence_repair_recovery_decision_gate.py
@@ -1,0 +1,595 @@
+"""Read-only recovery decision gate for memory evidence repair.
+
+The recovery decision gate turns a rollback drill preview into a controlled
+decision about the next recovery route. It never performs rollback, never
+mutates durable memory, and never changes receipt, token, or lock state.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Mapping, Sequence
+
+from agent.memory_evidence_repair_manual_commit_dry_run import (
+    CHECK_STATUS_FAIL,
+    CHECK_STATUS_PASS,
+)
+from agent.memory_evidence_repair_rollback_drill_preview import (
+    DRILL_STEP_STATUS_PLANNED,
+    ROLLBACK_DRILL_STATUS_BLOCKED,
+    ROLLBACK_DRILL_STATUS_NO_ACTION_NEEDED,
+    ROLLBACK_DRILL_STATUS_READY,
+    ROLLBACK_DRILL_TRIGGER_AUDIT_FAILURE,
+    ROLLBACK_DRILL_TRIGGER_PREPAREDNESS,
+)
+
+
+RECOVERY_DECISION_STATUS_READY = "recovery_decision_gate_ready"
+RECOVERY_DECISION_STATUS_BLOCKED = "blocked"
+RECOVERY_DECISION_STATUS_NO_ACTION_NEEDED = "no_action_needed"
+
+RECOVERY_ROUTE_PREPAREDNESS_ONLY = "preparedness_review_only"
+RECOVERY_ROUTE_ISOLATE_AND_REVIEW = "isolate_and_review"
+RECOVERY_ROUTE_MANUAL_ROLLBACK = "manual_rollback_required"
+RECOVERY_ROUTE_RERUN_AUDIT = "rerun_post_commit_audit"
+
+CHECK_ROLLBACK_DRILL_READY = "rollback_drill_ready"
+CHECK_ROLLBACK_DRILL_INTEGRITY = "rollback_drill_integrity"
+CHECK_OPERATOR_CONTROLS = "operator_controls"
+
+DECISION_STATUS_PLANNED = "planned"
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairRecoveryDecisionCheck:
+    """One read-only recovery decision readiness check."""
+
+    id: str
+    status: str
+    reason: str
+    required_actions: tuple[str, ...]
+    details: dict[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "status": self.status,
+            "reason": self.reason,
+            "required_actions": list(self.required_actions),
+            "details": dict(self.details),
+        }
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairRecoveryDecision:
+    """One read-only recovery route decision."""
+
+    id: str
+    status: str
+    route: str
+    priority: str
+    reason: str
+    rollback_drill_id: str
+    trigger: str
+    operation_ids: tuple[str, ...]
+    failed_audit_step_ids: tuple[str, ...]
+    receipt_id: str
+    token_id: str
+    lock_id: str
+    recommended_actions: tuple[str, ...]
+    required_preconditions: tuple[str, ...]
+    blocked_actions: tuple[str, ...]
+    next_tool_hint: str
+    decision_digest: str
+    source_rollback_drill: dict[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "status": self.status,
+            "route": self.route,
+            "priority": self.priority,
+            "reason": self.reason,
+            "rollback_drill_id": self.rollback_drill_id,
+            "trigger": self.trigger,
+            "operation_ids": list(self.operation_ids),
+            "failed_audit_step_ids": list(self.failed_audit_step_ids),
+            "receipt_id": self.receipt_id,
+            "token_id": self.token_id,
+            "lock_id": self.lock_id,
+            "recommended_actions": list(self.recommended_actions),
+            "required_preconditions": list(self.required_preconditions),
+            "blocked_actions": list(self.blocked_actions),
+            "next_tool_hint": self.next_tool_hint,
+            "decision_digest": self.decision_digest,
+            "source_rollback_drill": dict(self.source_rollback_drill),
+            "future_would_mutate_memory": False,
+        }
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairRecoveryDecisionGateReport:
+    """Read-only recovery decision gate report."""
+
+    generated_at: str
+    status: str
+    checks: tuple[MemoryEvidenceRepairRecoveryDecisionCheck, ...]
+    decisions: tuple[MemoryEvidenceRepairRecoveryDecision, ...]
+    blocking_reasons: tuple[str, ...]
+    required_actions: tuple[str, ...]
+    source_rollback_drill_report: dict[str, Any]
+
+    @property
+    def summary(self) -> dict[str, Any]:
+        by_check_status: dict[str, int] = {}
+        by_route: dict[str, int] = {}
+        for check in self.checks:
+            by_check_status[check.status] = by_check_status.get(check.status, 0) + 1
+        for decision in self.decisions:
+            by_route[decision.route] = by_route.get(decision.route, 0) + 1
+        return {
+            "status": self.status,
+            "check_count": len(self.checks),
+            "pass_count": by_check_status.get(CHECK_STATUS_PASS, 0),
+            "fail_count": by_check_status.get(CHECK_STATUS_FAIL, 0),
+            "decision_count": len(self.decisions),
+            "manual_rollback_required_count": by_route.get(
+                RECOVERY_ROUTE_MANUAL_ROLLBACK,
+                0,
+            ),
+            "isolate_and_review_count": by_route.get(
+                RECOVERY_ROUTE_ISOLATE_AND_REVIEW,
+                0,
+            ),
+            "preparedness_review_count": by_route.get(
+                RECOVERY_ROUTE_PREPAREDNESS_ONLY,
+                0,
+            ),
+            "rerun_audit_count": by_route.get(RECOVERY_ROUTE_RERUN_AUDIT, 0),
+            "blocking_reason_count": len(self.blocking_reasons),
+            "required_action_count": len(self.required_actions),
+            "recovery_decision_available": bool(self.decisions),
+            "recovery_decision_ready": self.status == RECOVERY_DECISION_STATUS_READY,
+            "has_blocks": self.status == RECOVERY_DECISION_STATUS_BLOCKED,
+            "requires_followup": bool(self.required_actions),
+            "by_check_status": by_check_status,
+            "by_route": by_route,
+        }
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "generated_at": self.generated_at,
+            "status": self.status,
+            "summary": self.summary,
+            "checks": [check.to_dict() for check in self.checks],
+            "decisions": [decision.to_dict() for decision in self.decisions],
+            "blocking_reasons": list(self.blocking_reasons),
+            "required_actions": list(self.required_actions),
+            "source_rollback_drill_report": dict(self.source_rollback_drill_report),
+            "read_only": True,
+            "read_only_memory": True,
+            "would_mutate_memory": False,
+        }
+
+
+def build_evidence_repair_recovery_decision_gate(
+    *,
+    rollback_drill: Mapping[str, Any] | None = None,
+) -> MemoryEvidenceRepairRecoveryDecisionGateReport:
+    """Build a read-only recovery decision gate from a rollback drill preview."""
+
+    rollback_drill = rollback_drill if isinstance(rollback_drill, Mapping) else {}
+    drill_status = _str(rollback_drill.get("status"))
+    drill_preview = _extract_drill_preview(rollback_drill)
+
+    if not rollback_drill or drill_status == ROLLBACK_DRILL_STATUS_NO_ACTION_NEEDED:
+        return _empty_report(rollback_drill=rollback_drill)
+
+    if drill_status == ROLLBACK_DRILL_STATUS_BLOCKED and not drill_preview:
+        return _blocked_report(
+            rollback_drill=rollback_drill,
+            checks=(
+                _fail(
+                    CHECK_ROLLBACK_DRILL_READY,
+                    "Rollback drill preview is blocked and cannot drive a recovery decision.",
+                    tuple(_list_of_str(rollback_drill.get("required_actions")))
+                    or ("produce_ready_rollback_drill_preview",),
+                    {"rollback_drill_status": drill_status},
+                ),
+            ),
+        )
+
+    if not drill_preview:
+        return _blocked_report(
+            rollback_drill=rollback_drill,
+            checks=(
+                _fail(
+                    CHECK_ROLLBACK_DRILL_READY,
+                    "No rollback drill preview was supplied.",
+                    ("produce_rollback_drill_preview",),
+                    {"rollback_drill_status": drill_status},
+                ),
+            ),
+        )
+
+    checks = (
+        _rollback_drill_ready_check(rollback_drill=rollback_drill, drill_preview=drill_preview),
+        _rollback_drill_integrity_check(drill_preview),
+        _operator_controls_check(drill_preview),
+    )
+    blocking_reasons = tuple(
+        _dedupe_strings(check.reason for check in checks if check.status == CHECK_STATUS_FAIL)
+    )
+    required_actions = tuple(
+        _dedupe_strings(
+            action
+            for check in checks
+            if check.status == CHECK_STATUS_FAIL
+            for action in check.required_actions
+        )
+    )
+    if blocking_reasons:
+        return MemoryEvidenceRepairRecoveryDecisionGateReport(
+            generated_at=datetime.now(timezone.utc).isoformat(),
+            status=RECOVERY_DECISION_STATUS_BLOCKED,
+            checks=checks,
+            decisions=(),
+            blocking_reasons=blocking_reasons,
+            required_actions=required_actions,
+            source_rollback_drill_report=dict(rollback_drill),
+        )
+
+    decision = _decision_from_drill(drill_preview)
+    return MemoryEvidenceRepairRecoveryDecisionGateReport(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        status=RECOVERY_DECISION_STATUS_READY,
+        checks=checks,
+        decisions=(decision,),
+        blocking_reasons=(),
+        required_actions=(),
+        source_rollback_drill_report=dict(rollback_drill),
+    )
+
+
+def empty_evidence_repair_recovery_decision_gate() -> MemoryEvidenceRepairRecoveryDecisionGateReport:
+    """Return an empty read-only recovery decision gate."""
+
+    return _empty_report(rollback_drill={})
+
+
+def _rollback_drill_ready_check(
+    *,
+    rollback_drill: Mapping[str, Any],
+    drill_preview: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryDecisionCheck:
+    report_status = _str(rollback_drill.get("status"))
+    preview_status = _str(drill_preview.get("status"))
+    if report_status and report_status != ROLLBACK_DRILL_STATUS_READY:
+        return _fail(
+            CHECK_ROLLBACK_DRILL_READY,
+            "Rollback drill report is not ready for recovery decision planning.",
+            tuple(_list_of_str(rollback_drill.get("required_actions")))
+            or ("produce_ready_rollback_drill_preview",),
+            {"report_status": report_status, "preview_status": preview_status},
+        )
+    if preview_status != ROLLBACK_DRILL_STATUS_READY:
+        return _fail(
+            CHECK_ROLLBACK_DRILL_READY,
+            "Rollback drill preview entry is not ready.",
+            ("produce_ready_rollback_drill_preview",),
+            {"report_status": report_status, "preview_status": preview_status},
+        )
+    return _pass(
+        CHECK_ROLLBACK_DRILL_READY,
+        "Rollback drill preview is ready for recovery decision planning.",
+        {"rollback_drill_id": _str(drill_preview.get("id"))},
+    )
+
+
+def _rollback_drill_integrity_check(
+    drill_preview: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryDecisionCheck:
+    missing_fields: list[str] = []
+    for field_name in ("id", "trigger", "rollback_mode", "steps"):
+        value = drill_preview.get(field_name)
+        if isinstance(value, list) and not value:
+            missing_fields.append(field_name)
+        elif not isinstance(value, list) and not _str(value):
+            missing_fields.append(field_name)
+    step_statuses = [
+        _str(step.get("status"))
+        for step in _list(drill_preview.get("steps"))
+        if isinstance(step, Mapping)
+    ]
+    non_planned = [status for status in step_statuses if status != DRILL_STEP_STATUS_PLANNED]
+    if missing_fields or non_planned:
+        return _fail(
+            CHECK_ROLLBACK_DRILL_INTEGRITY,
+            "Rollback drill preview has missing fields or non-planned steps.",
+            ("regenerate_rollback_drill_preview",),
+            {
+                "missing_fields": missing_fields,
+                "non_planned_step_statuses": non_planned,
+            },
+        )
+    return _pass(
+        CHECK_ROLLBACK_DRILL_INTEGRITY,
+        "Rollback drill preview structure is usable for decision planning.",
+        {"rollback_drill_id": _str(drill_preview.get("id")), "step_count": len(step_statuses)},
+    )
+
+
+def _operator_controls_check(
+    drill_preview: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryDecisionCheck:
+    return _pass(
+        CHECK_OPERATOR_CONTROLS,
+        "Future recovery execution remains gated by explicit human approval.",
+        {
+            "rollback_drill_id": _str(drill_preview.get("id")),
+            "requires_human_approval_before_execution": True,
+            "read_only_gate": True,
+        },
+    )
+
+
+def _decision_from_drill(
+    drill_preview: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryDecision:
+    route = _route_for_drill(drill_preview)
+    recommended_actions = tuple(_recommended_actions(route))
+    required_preconditions = tuple(_required_preconditions(route))
+    blocked_actions = tuple(_blocked_actions(route))
+    operation_ids = tuple(_list_of_str(drill_preview.get("operation_ids")))
+    failed_step_ids = tuple(_list_of_str(drill_preview.get("failed_audit_step_ids")))
+    trigger = _str(drill_preview.get("trigger"))
+    seed = {
+        "route": route,
+        "rollback_drill_id": _str(drill_preview.get("id")),
+        "trigger": trigger,
+        "operation_ids": operation_ids,
+        "failed_audit_step_ids": failed_step_ids,
+        "recommended_actions": recommended_actions,
+        "required_preconditions": required_preconditions,
+    }
+    decision_digest = _digest(seed)
+    return MemoryEvidenceRepairRecoveryDecision(
+        id=f"recovery-decision-{decision_digest[:16]}",
+        status=DECISION_STATUS_PLANNED,
+        route=route,
+        priority=_priority(route),
+        reason=_reason(route, drill_preview),
+        rollback_drill_id=_str(drill_preview.get("id")),
+        trigger=trigger,
+        operation_ids=operation_ids,
+        failed_audit_step_ids=failed_step_ids,
+        receipt_id=_str(drill_preview.get("receipt_id")),
+        token_id=_str(drill_preview.get("token_id")),
+        lock_id=_str(drill_preview.get("lock_id")),
+        recommended_actions=recommended_actions,
+        required_preconditions=required_preconditions,
+        blocked_actions=blocked_actions,
+        next_tool_hint=_next_tool_hint(route),
+        decision_digest=decision_digest,
+        source_rollback_drill=dict(drill_preview),
+    )
+
+
+def _route_for_drill(drill_preview: Mapping[str, Any]) -> str:
+    trigger = _str(drill_preview.get("trigger"))
+    future_restore_steps = [
+        step
+        for step in _list(drill_preview.get("steps"))
+        if isinstance(step, Mapping) and step.get("future_would_restore_memory") is True
+    ]
+    failed_steps = _list_of_str(drill_preview.get("failed_audit_step_ids"))
+    if trigger == ROLLBACK_DRILL_TRIGGER_PREPAREDNESS:
+        return RECOVERY_ROUTE_PREPAREDNESS_ONLY
+    if trigger == ROLLBACK_DRILL_TRIGGER_AUDIT_FAILURE and future_restore_steps:
+        return RECOVERY_ROUTE_MANUAL_ROLLBACK
+    if trigger == ROLLBACK_DRILL_TRIGGER_AUDIT_FAILURE or failed_steps:
+        return RECOVERY_ROUTE_ISOLATE_AND_REVIEW
+    return RECOVERY_ROUTE_RERUN_AUDIT
+
+
+def _recommended_actions(route: str) -> list[str]:
+    if route == RECOVERY_ROUTE_MANUAL_ROLLBACK:
+        return [
+            "preserve_failed_audit_context",
+            "isolate_impacted_memory_records",
+            "verify_pre_commit_snapshot_or_rollback_plan",
+            "request_explicit_human_recovery_approval",
+            "rerun_post_commit_audit_after_manual_recovery",
+        ]
+    if route == RECOVERY_ROUTE_ISOLATE_AND_REVIEW:
+        return [
+            "preserve_failed_audit_context",
+            "isolate_impacted_memory_records",
+            "inspect_failed_audit_signals",
+            "choose_manual_rollback_or_patch_regeneration",
+        ]
+    if route == RECOVERY_ROUTE_PREPAREDNESS_ONLY:
+        return [
+            "keep_rollback_drill_available",
+            "verify_pre_commit_snapshot_or_rollback_plan_before_future_commit",
+            "rerun_post_commit_audit_after_future_commit",
+        ]
+    return ["rerun_post_commit_audit"]
+
+
+def _required_preconditions(route: str) -> list[str]:
+    common = [
+        "no_automatic_memory_mutation",
+        "explicit_human_approval_before_recovery_execution",
+    ]
+    if route == RECOVERY_ROUTE_MANUAL_ROLLBACK:
+        return [
+            *common,
+            "failed_audit_context_preserved",
+            "impacted_records_isolated",
+            "snapshot_or_rollback_plan_verified",
+        ]
+    if route == RECOVERY_ROUTE_ISOLATE_AND_REVIEW:
+        return [
+            *common,
+            "failed_audit_context_preserved",
+            "impacted_records_isolated",
+        ]
+    if route == RECOVERY_ROUTE_PREPAREDNESS_ONLY:
+        return [
+            "no_automatic_memory_mutation",
+            "rollback_drill_kept_read_only",
+        ]
+    return common
+
+
+def _blocked_actions(route: str) -> list[str]:
+    blocked = [
+        "automatic_memory_rollback",
+        "automatic_receipt_rewrite",
+        "automatic_token_state_change",
+        "automatic_lock_state_change",
+    ]
+    if route in {RECOVERY_ROUTE_MANUAL_ROLLBACK, RECOVERY_ROUTE_ISOLATE_AND_REVIEW}:
+        blocked.append("future_memory_write_until_human_review")
+    return blocked
+
+
+def _next_tool_hint(route: str) -> str:
+    if route == RECOVERY_ROUTE_MANUAL_ROLLBACK:
+        return "memory_evidence_repair_recovery_execution_preview"
+    if route == RECOVERY_ROUTE_ISOLATE_AND_REVIEW:
+        return "memory_evidence_repair_post_commit_audit_preview"
+    if route == RECOVERY_ROUTE_PREPAREDNESS_ONLY:
+        return "memory_evidence_repair_post_commit_audit_preview"
+    return "memory_evidence_repair_post_commit_audit_preview"
+
+
+def _priority(route: str) -> str:
+    if route == RECOVERY_ROUTE_MANUAL_ROLLBACK:
+        return "p0"
+    if route == RECOVERY_ROUTE_ISOLATE_AND_REVIEW:
+        return "p1"
+    return "p2"
+
+
+def _reason(route: str, drill_preview: Mapping[str, Any]) -> str:
+    failed_count = len(_list_of_str(drill_preview.get("failed_audit_step_ids")))
+    if route == RECOVERY_ROUTE_MANUAL_ROLLBACK:
+        return f"{failed_count} failed audit step(s) require isolated manual rollback planning."
+    if route == RECOVERY_ROUTE_ISOLATE_AND_REVIEW:
+        return f"{failed_count} failed audit step(s) require isolation and human review."
+    if route == RECOVERY_ROUTE_PREPAREDNESS_ONLY:
+        return "No observed audit failure; keep the rollback drill as preparedness coverage."
+    return "Recovery can proceed by rerunning the post-commit audit."
+
+
+def _extract_drill_preview(rollback_drill: Mapping[str, Any]) -> dict[str, Any]:
+    previews = rollback_drill.get("previews")
+    if isinstance(previews, list):
+        for preview in previews:
+            if isinstance(preview, Mapping):
+                return dict(preview)
+    if _str(rollback_drill.get("id")).startswith("rollback-drill-"):
+        return dict(rollback_drill)
+    return {}
+
+
+def _empty_report(
+    *,
+    rollback_drill: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryDecisionGateReport:
+    return MemoryEvidenceRepairRecoveryDecisionGateReport(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        status=RECOVERY_DECISION_STATUS_NO_ACTION_NEEDED,
+        checks=(),
+        decisions=(),
+        blocking_reasons=(),
+        required_actions=(),
+        source_rollback_drill_report=dict(rollback_drill),
+    )
+
+
+def _blocked_report(
+    *,
+    rollback_drill: Mapping[str, Any],
+    checks: tuple[MemoryEvidenceRepairRecoveryDecisionCheck, ...],
+) -> MemoryEvidenceRepairRecoveryDecisionGateReport:
+    return MemoryEvidenceRepairRecoveryDecisionGateReport(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        status=RECOVERY_DECISION_STATUS_BLOCKED,
+        checks=checks,
+        decisions=(),
+        blocking_reasons=tuple(
+            _dedupe_strings(check.reason for check in checks if check.status == CHECK_STATUS_FAIL)
+        ),
+        required_actions=tuple(
+            _dedupe_strings(
+                action
+                for check in checks
+                if check.status == CHECK_STATUS_FAIL
+                for action in check.required_actions
+            )
+        ),
+        source_rollback_drill_report=dict(rollback_drill),
+    )
+
+
+def _pass(
+    check_id: str,
+    reason: str,
+    details: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryDecisionCheck:
+    return MemoryEvidenceRepairRecoveryDecisionCheck(
+        id=check_id,
+        status=CHECK_STATUS_PASS,
+        reason=reason,
+        required_actions=(),
+        details=dict(details),
+    )
+
+
+def _fail(
+    check_id: str,
+    reason: str,
+    required_actions: Sequence[str],
+    details: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryDecisionCheck:
+    return MemoryEvidenceRepairRecoveryDecisionCheck(
+        id=check_id,
+        status=CHECK_STATUS_FAIL,
+        reason=reason,
+        required_actions=tuple(required_actions),
+        details=dict(details),
+    )
+
+
+def _digest(value: Any) -> str:
+    raw = json.dumps(value, sort_keys=True, ensure_ascii=False, default=str)
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def _list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _list_of_str(value: Any) -> list[str]:
+    return [_str(item) for item in value] if isinstance(value, list) else []
+
+
+def _dedupe_strings(values: Sequence[str] | Any) -> list[str]:
+    seen: set[str] = set()
+    result: list[str] = []
+    for value in values:
+        text = _str(value)
+        if text and text not in seen:
+            seen.add(text)
+            result.append(text)
+    return result
+
+
+def _str(value: Any) -> str:
+    return str(value or "").strip()

--- a/agent/memory_evidence_repair_recovery_execution_preview.py
+++ b/agent/memory_evidence_repair_recovery_execution_preview.py
@@ -1,0 +1,679 @@
+"""Read-only recovery execution preview for memory evidence repair.
+
+The recovery execution preview expands a recovery decision into an ordered
+manual execution plan. It never executes rollback, never mutates durable
+memory, and never changes receipt, token, or lock state.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Mapping, Sequence
+
+from agent.memory_evidence_repair_manual_commit_dry_run import (
+    CHECK_STATUS_FAIL,
+    CHECK_STATUS_PASS,
+)
+from agent.memory_evidence_repair_recovery_decision_gate import (
+    DECISION_STATUS_PLANNED,
+    RECOVERY_DECISION_STATUS_BLOCKED,
+    RECOVERY_DECISION_STATUS_NO_ACTION_NEEDED,
+    RECOVERY_DECISION_STATUS_READY,
+    RECOVERY_ROUTE_ISOLATE_AND_REVIEW,
+    RECOVERY_ROUTE_MANUAL_ROLLBACK,
+    RECOVERY_ROUTE_PREPAREDNESS_ONLY,
+    RECOVERY_ROUTE_RERUN_AUDIT,
+)
+
+
+RECOVERY_EXECUTION_STATUS_READY = "recovery_execution_preview_ready"
+RECOVERY_EXECUTION_STATUS_BLOCKED = "blocked"
+RECOVERY_EXECUTION_STATUS_NO_ACTION_NEEDED = "no_action_needed"
+
+CHECK_RECOVERY_DECISION_READY = "recovery_decision_ready"
+CHECK_RECOVERY_DECISION_INTEGRITY = "recovery_decision_integrity"
+CHECK_EXECUTION_CONTROLS = "execution_controls"
+
+EXECUTION_STEP_STATUS_PLANNED = "planned"
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairRecoveryExecutionCheck:
+    """One read-only recovery execution preview check."""
+
+    id: str
+    status: str
+    reason: str
+    required_actions: tuple[str, ...]
+    details: dict[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "status": self.status,
+            "reason": self.reason,
+            "required_actions": list(self.required_actions),
+            "details": dict(self.details),
+        }
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairRecoveryExecutionStep:
+    """One future manual recovery execution step preview."""
+
+    id: str
+    sequence: int
+    phase: str
+    action: str
+    description: str
+    status: str
+    route: str
+    operation_id: str
+    receipt_id: str
+    token_id: str
+    lock_id: str
+    required_precondition: str
+    expected_result: str
+    source_decision_id: str
+    human_approval_required: bool
+    future_would_mutate_memory: bool
+    rollback_safe_point: bool
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "sequence": self.sequence,
+            "phase": self.phase,
+            "action": self.action,
+            "description": self.description,
+            "status": self.status,
+            "route": self.route,
+            "operation_id": self.operation_id,
+            "receipt_id": self.receipt_id,
+            "token_id": self.token_id,
+            "lock_id": self.lock_id,
+            "required_precondition": self.required_precondition,
+            "expected_result": self.expected_result,
+            "source_decision_id": self.source_decision_id,
+            "human_approval_required": self.human_approval_required,
+            "future_would_mutate_memory": self.future_would_mutate_memory,
+            "rollback_safe_point": self.rollback_safe_point,
+        }
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairRecoveryExecutionPreview:
+    """One read-only recovery execution preview."""
+
+    id: str
+    status: str
+    route: str
+    priority: str
+    decision_id: str
+    operation_ids: tuple[str, ...]
+    failed_audit_step_ids: tuple[str, ...]
+    receipt_id: str
+    token_id: str
+    lock_id: str
+    step_ids: tuple[str, ...]
+    preview_digest: str
+    execution_preview: str
+    steps: tuple[MemoryEvidenceRepairRecoveryExecutionStep, ...]
+    future_would_mutate_memory: bool
+    human_approval_required: bool
+    blocked_actions: tuple[str, ...]
+    safety_note: str
+    source_recovery_decision: dict[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "status": self.status,
+            "route": self.route,
+            "priority": self.priority,
+            "decision_id": self.decision_id,
+            "operation_ids": list(self.operation_ids),
+            "failed_audit_step_ids": list(self.failed_audit_step_ids),
+            "receipt_id": self.receipt_id,
+            "token_id": self.token_id,
+            "lock_id": self.lock_id,
+            "step_ids": list(self.step_ids),
+            "preview_digest": self.preview_digest,
+            "execution_preview": self.execution_preview,
+            "steps": [step.to_dict() for step in self.steps],
+            "future_would_mutate_memory": self.future_would_mutate_memory,
+            "human_approval_required": self.human_approval_required,
+            "blocked_actions": list(self.blocked_actions),
+            "safety_note": self.safety_note,
+            "source_recovery_decision": dict(self.source_recovery_decision),
+        }
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairRecoveryExecutionPreviewReport:
+    """Read-only recovery execution preview report."""
+
+    generated_at: str
+    status: str
+    checks: tuple[MemoryEvidenceRepairRecoveryExecutionCheck, ...]
+    previews: tuple[MemoryEvidenceRepairRecoveryExecutionPreview, ...]
+    blocking_reasons: tuple[str, ...]
+    required_actions: tuple[str, ...]
+    source_recovery_decision_gate_report: dict[str, Any]
+
+    @property
+    def summary(self) -> dict[str, Any]:
+        by_check_status: dict[str, int] = {}
+        by_route: dict[str, int] = {}
+        future_mutation_count = 0
+        for check in self.checks:
+            by_check_status[check.status] = by_check_status.get(check.status, 0) + 1
+        for preview in self.previews:
+            by_route[preview.route] = by_route.get(preview.route, 0) + 1
+            future_mutation_count += sum(
+                1 for step in preview.steps if step.future_would_mutate_memory
+            )
+        step_count = sum(len(preview.steps) for preview in self.previews)
+        return {
+            "status": self.status,
+            "check_count": len(self.checks),
+            "pass_count": by_check_status.get(CHECK_STATUS_PASS, 0),
+            "fail_count": by_check_status.get(CHECK_STATUS_FAIL, 0),
+            "preview_count": len(self.previews),
+            "execution_step_count": step_count,
+            "future_mutation_step_count": future_mutation_count,
+            "manual_rollback_preview_count": by_route.get(
+                RECOVERY_ROUTE_MANUAL_ROLLBACK,
+                0,
+            ),
+            "preparedness_preview_count": by_route.get(
+                RECOVERY_ROUTE_PREPAREDNESS_ONLY,
+                0,
+            ),
+            "isolation_review_preview_count": by_route.get(
+                RECOVERY_ROUTE_ISOLATE_AND_REVIEW,
+                0,
+            ),
+            "rerun_audit_preview_count": by_route.get(RECOVERY_ROUTE_RERUN_AUDIT, 0),
+            "blocking_reason_count": len(self.blocking_reasons),
+            "required_action_count": len(self.required_actions),
+            "recovery_execution_preview_available": bool(self.previews),
+            "recovery_execution_ready": self.status == RECOVERY_EXECUTION_STATUS_READY,
+            "has_blocks": self.status == RECOVERY_EXECUTION_STATUS_BLOCKED,
+            "requires_followup": bool(self.required_actions),
+            "by_check_status": by_check_status,
+            "by_route": by_route,
+        }
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "generated_at": self.generated_at,
+            "status": self.status,
+            "summary": self.summary,
+            "checks": [check.to_dict() for check in self.checks],
+            "previews": [preview.to_dict() for preview in self.previews],
+            "blocking_reasons": list(self.blocking_reasons),
+            "required_actions": list(self.required_actions),
+            "source_recovery_decision_gate_report": dict(
+                self.source_recovery_decision_gate_report
+            ),
+            "read_only": True,
+            "read_only_memory": True,
+            "would_mutate_memory": False,
+        }
+
+
+def build_evidence_repair_recovery_execution_preview(
+    *,
+    recovery_decision: Mapping[str, Any] | None = None,
+) -> MemoryEvidenceRepairRecoveryExecutionPreviewReport:
+    """Build a read-only recovery execution preview from a decision gate."""
+
+    recovery_decision = recovery_decision if isinstance(recovery_decision, Mapping) else {}
+    decision_status = _str(recovery_decision.get("status"))
+    decision = _extract_decision(recovery_decision)
+
+    if not recovery_decision or decision_status == RECOVERY_DECISION_STATUS_NO_ACTION_NEEDED:
+        return _empty_report(recovery_decision=recovery_decision)
+
+    if decision_status == RECOVERY_DECISION_STATUS_BLOCKED and not decision:
+        return _blocked_report(
+            recovery_decision=recovery_decision,
+            checks=(
+                _fail(
+                    CHECK_RECOVERY_DECISION_READY,
+                    "Recovery decision gate is blocked and cannot drive execution preview.",
+                    tuple(_list_of_str(recovery_decision.get("required_actions")))
+                    or ("produce_ready_recovery_decision_gate",),
+                    {"recovery_decision_status": decision_status},
+                ),
+            ),
+        )
+
+    if not decision:
+        return _blocked_report(
+            recovery_decision=recovery_decision,
+            checks=(
+                _fail(
+                    CHECK_RECOVERY_DECISION_READY,
+                    "No recovery decision was supplied.",
+                    ("produce_recovery_decision_gate",),
+                    {"recovery_decision_status": decision_status},
+                ),
+            ),
+        )
+
+    checks = (
+        _recovery_decision_ready_check(
+            recovery_decision=recovery_decision,
+            decision=decision,
+        ),
+        _recovery_decision_integrity_check(decision),
+        _execution_controls_check(decision),
+    )
+    blocking_reasons = tuple(
+        _dedupe_strings(check.reason for check in checks if check.status == CHECK_STATUS_FAIL)
+    )
+    required_actions = tuple(
+        _dedupe_strings(
+            action
+            for check in checks
+            if check.status == CHECK_STATUS_FAIL
+            for action in check.required_actions
+        )
+    )
+    if blocking_reasons:
+        return MemoryEvidenceRepairRecoveryExecutionPreviewReport(
+            generated_at=datetime.now(timezone.utc).isoformat(),
+            status=RECOVERY_EXECUTION_STATUS_BLOCKED,
+            checks=checks,
+            previews=(),
+            blocking_reasons=blocking_reasons,
+            required_actions=required_actions,
+            source_recovery_decision_gate_report=dict(recovery_decision),
+        )
+
+    preview = _preview_from_decision(decision)
+    return MemoryEvidenceRepairRecoveryExecutionPreviewReport(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        status=RECOVERY_EXECUTION_STATUS_READY,
+        checks=checks,
+        previews=(preview,),
+        blocking_reasons=(),
+        required_actions=(),
+        source_recovery_decision_gate_report=dict(recovery_decision),
+    )
+
+
+def empty_evidence_repair_recovery_execution_preview() -> MemoryEvidenceRepairRecoveryExecutionPreviewReport:
+    """Return an empty read-only recovery execution preview."""
+
+    return _empty_report(recovery_decision={})
+
+
+def _recovery_decision_ready_check(
+    *,
+    recovery_decision: Mapping[str, Any],
+    decision: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryExecutionCheck:
+    report_status = _str(recovery_decision.get("status"))
+    decision_status = _str(decision.get("status"))
+    if report_status and report_status != RECOVERY_DECISION_STATUS_READY:
+        return _fail(
+            CHECK_RECOVERY_DECISION_READY,
+            "Recovery decision gate report is not ready for execution preview.",
+            tuple(_list_of_str(recovery_decision.get("required_actions")))
+            or ("produce_ready_recovery_decision_gate",),
+            {"report_status": report_status, "decision_status": decision_status},
+        )
+    if decision_status != DECISION_STATUS_PLANNED:
+        return _fail(
+            CHECK_RECOVERY_DECISION_READY,
+            "Recovery decision entry is not planned.",
+            ("regenerate_recovery_decision_gate",),
+            {"report_status": report_status, "decision_status": decision_status},
+        )
+    return _pass(
+        CHECK_RECOVERY_DECISION_READY,
+        "Recovery decision is ready for execution preview planning.",
+        {"decision_id": _str(decision.get("id"))},
+    )
+
+
+def _recovery_decision_integrity_check(
+    decision: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryExecutionCheck:
+    route = _str(decision.get("route"))
+    missing_fields: list[str] = []
+    for field_name in ("id", "route", "priority", "recommended_actions", "blocked_actions"):
+        value = decision.get(field_name)
+        if isinstance(value, list) and not value:
+            missing_fields.append(field_name)
+        elif not isinstance(value, list) and not _str(value):
+            missing_fields.append(field_name)
+    if route not in _known_routes() or missing_fields:
+        return _fail(
+            CHECK_RECOVERY_DECISION_INTEGRITY,
+            "Recovery decision route or required fields are invalid.",
+            ("regenerate_recovery_decision_gate",),
+            {"route": route, "missing_fields": missing_fields},
+        )
+    return _pass(
+        CHECK_RECOVERY_DECISION_INTEGRITY,
+        "Recovery decision structure is usable for execution preview planning.",
+        {"decision_id": _str(decision.get("id")), "route": route},
+    )
+
+
+def _execution_controls_check(
+    decision: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryExecutionCheck:
+    preconditions = set(_list_of_str(decision.get("required_preconditions")))
+    blocked = set(_list_of_str(decision.get("blocked_actions")))
+    missing: list[str] = []
+    if "no_automatic_memory_mutation" not in preconditions:
+        missing.append("no_automatic_memory_mutation")
+    if "automatic_memory_rollback" not in blocked:
+        missing.append("automatic_memory_rollback_block")
+    if missing:
+        return _fail(
+            CHECK_EXECUTION_CONTROLS,
+            "Recovery decision does not preserve read-only execution controls.",
+            ("regenerate_recovery_decision_gate_with_controls",),
+            {"missing_controls": missing},
+        )
+    return _pass(
+        CHECK_EXECUTION_CONTROLS,
+        "Execution preview remains read-only and automatic recovery is blocked.",
+        {
+            "decision_id": _str(decision.get("id")),
+            "automatic_memory_rollback_blocked": True,
+        },
+    )
+
+
+def _preview_from_decision(
+    decision: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryExecutionPreview:
+    route = _str(decision.get("route"))
+    steps = tuple(_steps_for_decision(decision))
+    step_ids = tuple(step.id for step in steps)
+    operation_ids = tuple(_list_of_str(decision.get("operation_ids")))
+    failed_step_ids = tuple(_list_of_str(decision.get("failed_audit_step_ids")))
+    seed = {
+        "decision_id": _str(decision.get("id")),
+        "route": route,
+        "priority": _str(decision.get("priority")),
+        "operation_ids": operation_ids,
+        "failed_audit_step_ids": failed_step_ids,
+        "step_ids": step_ids,
+    }
+    preview_digest = _digest(seed)
+    preview_id = f"recovery-execution-preview-{preview_digest[:16]}"
+    return MemoryEvidenceRepairRecoveryExecutionPreview(
+        id=preview_id,
+        status=RECOVERY_EXECUTION_STATUS_READY,
+        route=route,
+        priority=_str(decision.get("priority")),
+        decision_id=_str(decision.get("id")),
+        operation_ids=operation_ids,
+        failed_audit_step_ids=failed_step_ids,
+        receipt_id=_str(decision.get("receipt_id")),
+        token_id=_str(decision.get("token_id")),
+        lock_id=_str(decision.get("lock_id")),
+        step_ids=step_ids,
+        preview_digest=preview_digest,
+        execution_preview=f"{preview_id}:{preview_digest[:12]}",
+        steps=steps,
+        future_would_mutate_memory=any(step.future_would_mutate_memory for step in steps),
+        human_approval_required=any(step.human_approval_required for step in steps),
+        blocked_actions=tuple(_list_of_str(decision.get("blocked_actions"))),
+        safety_note=(
+            "Read-only recovery execution preview. It orders future manual "
+            "recovery actions but does not execute rollback or mutate durable memory."
+        ),
+        source_recovery_decision=dict(decision),
+    )
+
+
+def _steps_for_decision(
+    decision: Mapping[str, Any],
+) -> list[MemoryEvidenceRepairRecoveryExecutionStep]:
+    route = _str(decision.get("route"))
+    if route == RECOVERY_ROUTE_MANUAL_ROLLBACK:
+        actions = (
+            ("preflight", "verify_recovery_decision_gate", "decision_gate_ready"),
+            ("preserve", "preserve_failed_audit_context", "failed_audit_context_preserved"),
+            ("isolate", "isolate_impacted_memory_records", "impacted_records_isolated"),
+            ("verify", "verify_snapshot_or_rollback_plan", "snapshot_or_rollback_plan_verified"),
+            ("restore", "apply_manual_rollback_restore", "pre_commit_state_restored"),
+            ("reconcile", "reconcile_receipt_token_lock_state", "receipt_token_lock_state_consistent"),
+            ("audit", "rerun_post_commit_audit", "post_commit_audit_passes_after_recovery"),
+        )
+    elif route == RECOVERY_ROUTE_ISOLATE_AND_REVIEW:
+        actions = (
+            ("preflight", "verify_recovery_decision_gate", "decision_gate_ready"),
+            ("preserve", "preserve_failed_audit_context", "failed_audit_context_preserved"),
+            ("isolate", "isolate_impacted_memory_records", "impacted_records_isolated"),
+            ("review", "inspect_failed_audit_signals", "human_review_route_chosen"),
+            ("audit", "rerun_post_commit_audit_if_needed", "post_commit_audit_rechecked"),
+        )
+    elif route == RECOVERY_ROUTE_PREPAREDNESS_ONLY:
+        actions = (
+            ("preflight", "verify_recovery_decision_gate", "decision_gate_ready"),
+            ("prepare", "keep_rollback_drill_available", "rollback_drill_available"),
+            ("verify", "verify_snapshot_or_rollback_plan_before_future_commit", "future_rollback_source_verified"),
+            ("audit", "rerun_post_commit_audit_after_future_commit", "future_audit_plan_ready"),
+        )
+    else:
+        actions = (
+            ("preflight", "verify_recovery_decision_gate", "decision_gate_ready"),
+            ("audit", "rerun_post_commit_audit", "post_commit_audit_rechecked"),
+        )
+
+    operation_ids = _list_of_str(decision.get("operation_ids"))
+    operation_text = ",".join(operation_ids)
+    return [
+        _step(
+            sequence=index,
+            phase=phase,
+            action=action,
+            expected_result=expected,
+            decision=decision,
+            operation_id=operation_text if action in _operation_scoped_actions() else "",
+            future_would_mutate_memory=action == "apply_manual_rollback_restore",
+            rollback_safe_point=phase in {"preflight", "preserve", "verify", "audit"},
+        )
+        for index, (phase, action, expected) in enumerate(actions, start=1)
+    ]
+
+
+def _step(
+    *,
+    sequence: int,
+    phase: str,
+    action: str,
+    expected_result: str,
+    decision: Mapping[str, Any],
+    operation_id: str,
+    future_would_mutate_memory: bool,
+    rollback_safe_point: bool,
+) -> MemoryEvidenceRepairRecoveryExecutionStep:
+    route = _str(decision.get("route"))
+    human_approval_required = future_would_mutate_memory or route in {
+        RECOVERY_ROUTE_MANUAL_ROLLBACK,
+        RECOVERY_ROUTE_ISOLATE_AND_REVIEW,
+    }
+    return MemoryEvidenceRepairRecoveryExecutionStep(
+        id=f"recovery-execution-step-{sequence}-{action}",
+        sequence=sequence,
+        phase=phase,
+        action=action,
+        description=_description(action),
+        status=EXECUTION_STEP_STATUS_PLANNED,
+        route=route,
+        operation_id=operation_id,
+        receipt_id=_str(decision.get("receipt_id")),
+        token_id=_str(decision.get("token_id")),
+        lock_id=_str(decision.get("lock_id")),
+        required_precondition=_required_precondition(action, decision),
+        expected_result=expected_result,
+        source_decision_id=_str(decision.get("id")),
+        human_approval_required=human_approval_required,
+        future_would_mutate_memory=future_would_mutate_memory,
+        rollback_safe_point=rollback_safe_point,
+    )
+
+
+def _description(action: str) -> str:
+    descriptions = {
+        "verify_recovery_decision_gate": "Verify the recovery decision gate, route, priority, and blocked actions.",
+        "preserve_failed_audit_context": "Preserve failed audit evidence before any future manual recovery work.",
+        "isolate_impacted_memory_records": "Mark impacted records for human review before further writes.",
+        "verify_snapshot_or_rollback_plan": "Verify a pre-commit snapshot or rollback plan before restore.",
+        "apply_manual_rollback_restore": "Manually restore impacted evidence from the verified rollback source.",
+        "reconcile_receipt_token_lock_state": "Reconcile receipt, approval-token, and write-lock state after recovery.",
+        "rerun_post_commit_audit": "Rerun post-commit audit after recovery handling.",
+        "inspect_failed_audit_signals": "Inspect failed audit signals before choosing the final recovery route.",
+        "rerun_post_commit_audit_if_needed": "Rerun post-commit audit if human review finds recoverable state.",
+        "keep_rollback_drill_available": "Keep the rollback drill available as preparedness coverage.",
+        "verify_snapshot_or_rollback_plan_before_future_commit": "Verify rollback sources before a future commit.",
+        "rerun_post_commit_audit_after_future_commit": "Run post-commit audit after the future commit occurs.",
+    }
+    return descriptions.get(action, "Preview the future manual recovery action.")
+
+
+def _required_precondition(action: str, decision: Mapping[str, Any]) -> str:
+    if action == "apply_manual_rollback_restore":
+        return "explicit_human_approval_before_recovery_execution"
+    if action == "verify_snapshot_or_rollback_plan":
+        return "snapshot_or_rollback_plan_verified"
+    if action == "isolate_impacted_memory_records":
+        return "failed_audit_context_preserved"
+    preconditions = _list_of_str(decision.get("required_preconditions"))
+    return preconditions[0] if preconditions else "no_automatic_memory_mutation"
+
+
+def _operation_scoped_actions() -> set[str]:
+    return {
+        "isolate_impacted_memory_records",
+        "verify_snapshot_or_rollback_plan",
+        "apply_manual_rollback_restore",
+        "verify_snapshot_or_rollback_plan_before_future_commit",
+    }
+
+
+def _extract_decision(recovery_decision: Mapping[str, Any]) -> dict[str, Any]:
+    decisions = recovery_decision.get("decisions")
+    if isinstance(decisions, list):
+        for decision in decisions:
+            if isinstance(decision, Mapping):
+                return dict(decision)
+    if _str(recovery_decision.get("id")).startswith("recovery-decision-"):
+        return dict(recovery_decision)
+    return {}
+
+
+def _known_routes() -> set[str]:
+    return {
+        RECOVERY_ROUTE_MANUAL_ROLLBACK,
+        RECOVERY_ROUTE_ISOLATE_AND_REVIEW,
+        RECOVERY_ROUTE_PREPAREDNESS_ONLY,
+        RECOVERY_ROUTE_RERUN_AUDIT,
+    }
+
+
+def _empty_report(
+    *,
+    recovery_decision: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryExecutionPreviewReport:
+    return MemoryEvidenceRepairRecoveryExecutionPreviewReport(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        status=RECOVERY_EXECUTION_STATUS_NO_ACTION_NEEDED,
+        checks=(),
+        previews=(),
+        blocking_reasons=(),
+        required_actions=(),
+        source_recovery_decision_gate_report=dict(recovery_decision),
+    )
+
+
+def _blocked_report(
+    *,
+    recovery_decision: Mapping[str, Any],
+    checks: tuple[MemoryEvidenceRepairRecoveryExecutionCheck, ...],
+) -> MemoryEvidenceRepairRecoveryExecutionPreviewReport:
+    return MemoryEvidenceRepairRecoveryExecutionPreviewReport(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        status=RECOVERY_EXECUTION_STATUS_BLOCKED,
+        checks=checks,
+        previews=(),
+        blocking_reasons=tuple(
+            _dedupe_strings(check.reason for check in checks if check.status == CHECK_STATUS_FAIL)
+        ),
+        required_actions=tuple(
+            _dedupe_strings(
+                action
+                for check in checks
+                if check.status == CHECK_STATUS_FAIL
+                for action in check.required_actions
+            )
+        ),
+        source_recovery_decision_gate_report=dict(recovery_decision),
+    )
+
+
+def _pass(
+    check_id: str,
+    reason: str,
+    details: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryExecutionCheck:
+    return MemoryEvidenceRepairRecoveryExecutionCheck(
+        id=check_id,
+        status=CHECK_STATUS_PASS,
+        reason=reason,
+        required_actions=(),
+        details=dict(details),
+    )
+
+
+def _fail(
+    check_id: str,
+    reason: str,
+    required_actions: Sequence[str],
+    details: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryExecutionCheck:
+    return MemoryEvidenceRepairRecoveryExecutionCheck(
+        id=check_id,
+        status=CHECK_STATUS_FAIL,
+        reason=reason,
+        required_actions=tuple(required_actions),
+        details=dict(details),
+    )
+
+
+def _digest(value: Any) -> str:
+    raw = json.dumps(value, sort_keys=True, ensure_ascii=False, default=str)
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def _list_of_str(value: Any) -> list[str]:
+    return [_str(item) for item in value] if isinstance(value, list) else []
+
+
+def _dedupe_strings(values: Sequence[str] | Any) -> list[str]:
+    seen: set[str] = set()
+    result: list[str] = []
+    for value in values:
+        text = _str(value)
+        if text and text not in seen:
+            seen.add(text)
+            result.append(text)
+    return result
+
+
+def _str(value: Any) -> str:
+    return str(value or "").strip()

--- a/agent/memory_evidence_repair_recovery_executor_preview.py
+++ b/agent/memory_evidence_repair_recovery_executor_preview.py
@@ -1,0 +1,812 @@
+"""Read-only recovery executor preview for memory evidence repair.
+
+The recovery executor preview turns a verified recovery write-lock gate into
+an ordered manual recovery execution plan. It never executes rollback, never
+mutates durable memory, and never acquires, releases, or records a real lock.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Mapping, Sequence
+
+from agent.memory_evidence_repair_manual_commit_dry_run import (
+    CHECK_STATUS_FAIL,
+    CHECK_STATUS_PASS,
+)
+from agent.memory_evidence_repair_recovery_execution_preview import (
+    RECOVERY_EXECUTION_STATUS_READY,
+)
+from agent.memory_evidence_repair_recovery_write_lock_gate import (
+    DEFAULT_RECOVERY_LOCK_TTL_MINUTES,
+    RECOVERY_LOCK_DRAFT_STATUS_READY,
+    RECOVERY_WRITE_LOCK_SCOPE,
+    RECOVERY_WRITE_LOCK_STATUS_NO_ACTION_NEEDED,
+    RECOVERY_WRITE_LOCK_STATUS_READY,
+    RECOVERY_WRITE_LOCK_TYPE,
+)
+
+
+RECOVERY_EXECUTOR_PREVIEW_STATUS_READY = "recovery_executor_preview_ready_for_manual_recovery"
+RECOVERY_EXECUTOR_PREVIEW_STATUS_BLOCKED = "blocked"
+RECOVERY_EXECUTOR_PREVIEW_STATUS_NO_ACTION_NEEDED = "no_action_needed"
+
+CHECK_RECOVERY_WRITE_LOCK_READY = "recovery_write_lock_ready"
+CHECK_RECOVERY_WRITE_LOCK_INTEGRITY = "recovery_write_lock_integrity"
+CHECK_RECOVERY_WRITE_LOCK_EXPIRY = "recovery_write_lock_expiry"
+CHECK_RECOVERY_EXECUTION_STEPS = "recovery_execution_steps"
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairRecoveryExecutorPreviewCheck:
+    """One read-only recovery executor readiness check."""
+
+    id: str
+    status: str
+    reason: str
+    required_actions: tuple[str, ...]
+    details: dict[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "status": self.status,
+            "reason": self.reason,
+            "required_actions": list(self.required_actions),
+            "details": dict(self.details),
+        }
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairRecoveryExecutorStep:
+    """One future manual recovery executor step preview."""
+
+    id: str
+    sequence: int
+    phase: str
+    action: str
+    description: str
+    recovery_execution_step_id: str
+    operation_id: str
+    decision_id: str
+    execution_preview_id: str
+    receipt_id: str
+    token_id: str
+    lock_id: str
+    route: str
+    required_precondition: str
+    expected_result: str
+    source_recovery_execution_step: dict[str, Any]
+    future_would_mutate_memory: bool
+    stop_on_failure: bool
+    rollback_hint: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "sequence": self.sequence,
+            "phase": self.phase,
+            "action": self.action,
+            "description": self.description,
+            "recovery_execution_step_id": self.recovery_execution_step_id,
+            "operation_id": self.operation_id,
+            "decision_id": self.decision_id,
+            "execution_preview_id": self.execution_preview_id,
+            "receipt_id": self.receipt_id,
+            "token_id": self.token_id,
+            "lock_id": self.lock_id,
+            "route": self.route,
+            "required_precondition": self.required_precondition,
+            "expected_result": self.expected_result,
+            "source_recovery_execution_step": dict(self.source_recovery_execution_step),
+            "future_would_mutate_memory": self.future_would_mutate_memory,
+            "stop_on_failure": self.stop_on_failure,
+            "rollback_hint": self.rollback_hint,
+        }
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairRecoveryExecutorPreview:
+    """One read-only recovery executor preview."""
+
+    id: str
+    status: str
+    lock_id: str
+    token_id: str
+    decision_id: str
+    execution_preview_id: str
+    route: str
+    operation_ids: tuple[str, ...]
+    step_ids: tuple[str, ...]
+    future_mutation_step_ids: tuple[str, ...]
+    executor_step_ids: tuple[str, ...]
+    preview_digest: str
+    preview_preview: str
+    execution_mode: str
+    failure_policy: str
+    steps: tuple[MemoryEvidenceRepairRecoveryExecutorStep, ...]
+    would_execute_manual_recovery: bool
+    would_apply_memory_recovery: bool
+    would_mark_recovery_token_used: bool
+    would_release_recovery_write_lock: bool
+    would_rerun_post_commit_audit: bool
+    safety_note: str
+    source_lock: dict[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "status": self.status,
+            "lock_id": self.lock_id,
+            "token_id": self.token_id,
+            "decision_id": self.decision_id,
+            "execution_preview_id": self.execution_preview_id,
+            "route": self.route,
+            "operation_ids": list(self.operation_ids),
+            "step_ids": list(self.step_ids),
+            "future_mutation_step_ids": list(self.future_mutation_step_ids),
+            "executor_step_ids": list(self.executor_step_ids),
+            "preview_digest": self.preview_digest,
+            "preview_preview": self.preview_preview,
+            "execution_mode": self.execution_mode,
+            "failure_policy": self.failure_policy,
+            "steps": [step.to_dict() for step in self.steps],
+            "would_execute_manual_recovery": self.would_execute_manual_recovery,
+            "would_apply_memory_recovery": self.would_apply_memory_recovery,
+            "would_mark_recovery_token_used": self.would_mark_recovery_token_used,
+            "would_release_recovery_write_lock": self.would_release_recovery_write_lock,
+            "would_rerun_post_commit_audit": self.would_rerun_post_commit_audit,
+            "safety_note": self.safety_note,
+            "source_lock": dict(self.source_lock),
+        }
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairRecoveryExecutorPreviewReport:
+    """Read-only recovery executor preview report."""
+
+    generated_at: str
+    status: str
+    checks: tuple[MemoryEvidenceRepairRecoveryExecutorPreviewCheck, ...]
+    previews: tuple[MemoryEvidenceRepairRecoveryExecutorPreview, ...]
+    blocking_reasons: tuple[str, ...]
+    required_actions: tuple[str, ...]
+    source_recovery_write_lock_gate: dict[str, Any]
+
+    @property
+    def summary(self) -> dict[str, Any]:
+        by_check_status: dict[str, int] = {}
+        for check in self.checks:
+            by_check_status[check.status] = by_check_status.get(check.status, 0) + 1
+        step_count = sum(len(preview.steps) for preview in self.previews)
+        future_mutation_step_count = sum(
+            1
+            for preview in self.previews
+            for step in preview.steps
+            if step.future_would_mutate_memory
+        )
+        return {
+            "status": self.status,
+            "check_count": len(self.checks),
+            "pass_count": by_check_status.get(CHECK_STATUS_PASS, 0),
+            "fail_count": by_check_status.get(CHECK_STATUS_FAIL, 0),
+            "preview_count": len(self.previews),
+            "step_count": step_count,
+            "future_mutation_step_count": future_mutation_step_count,
+            "blocking_reason_count": len(self.blocking_reasons),
+            "required_action_count": len(self.required_actions),
+            "recovery_executor_preview_available": bool(self.previews),
+            "manual_recovery_executor_preview_ready": (
+                self.status == RECOVERY_EXECUTOR_PREVIEW_STATUS_READY
+            ),
+            "would_apply_memory_recovery_count": sum(
+                1 for preview in self.previews if preview.would_apply_memory_recovery
+            ),
+            "has_blocks": self.status == RECOVERY_EXECUTOR_PREVIEW_STATUS_BLOCKED,
+            "requires_followup": bool(self.required_actions),
+            "by_check_status": by_check_status,
+        }
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "generated_at": self.generated_at,
+            "status": self.status,
+            "summary": self.summary,
+            "checks": [check.to_dict() for check in self.checks],
+            "previews": [preview.to_dict() for preview in self.previews],
+            "blocking_reasons": list(self.blocking_reasons),
+            "required_actions": list(self.required_actions),
+            "source_recovery_write_lock_gate": dict(self.source_recovery_write_lock_gate),
+            "read_only": True,
+            "read_only_memory": True,
+            "would_mutate_memory": False,
+        }
+
+
+def build_evidence_repair_recovery_executor_preview(
+    *,
+    recovery_write_lock_gate: Mapping[str, Any] | None = None,
+    current_time: str | datetime | None = None,
+) -> MemoryEvidenceRepairRecoveryExecutorPreviewReport:
+    """Build a read-only recovery executor preview from a recovery write lock."""
+
+    recovery_write_lock_gate = (
+        recovery_write_lock_gate if isinstance(recovery_write_lock_gate, Mapping) else {}
+    )
+    gate_status = _str(recovery_write_lock_gate.get("status"))
+    lock = _extract_lock(recovery_write_lock_gate)
+    now = _parse_datetime(current_time) or datetime.now(timezone.utc)
+
+    if not lock:
+        if not recovery_write_lock_gate or gate_status == RECOVERY_WRITE_LOCK_STATUS_NO_ACTION_NEEDED:
+            return _empty_report(recovery_write_lock_gate=recovery_write_lock_gate)
+        source_blocking = tuple(_list_of_str(recovery_write_lock_gate.get("blocking_reasons")))
+        source_actions = tuple(_list_of_str(recovery_write_lock_gate.get("required_actions")))
+        return _blocked_report(
+            recovery_write_lock_gate=recovery_write_lock_gate,
+            checks=(
+                _fail(
+                    CHECK_RECOVERY_WRITE_LOCK_READY,
+                    "No recovery write-lock draft was supplied."
+                    if not source_blocking
+                    else "; ".join(source_blocking),
+                    source_actions or ("produce_recovery_write_lock_gate",),
+                    {"recovery_write_lock_gate_status": gate_status},
+                ),
+            ),
+        )
+
+    execution = _execution_from_lock(lock)
+    checks = (
+        _recovery_write_lock_ready_check(recovery_write_lock_gate, lock),
+        _recovery_write_lock_integrity_check(lock),
+        _recovery_write_lock_expiry_check(lock, now),
+        _recovery_execution_steps_check(lock, execution),
+    )
+    blocking_reasons = tuple(
+        _dedupe_strings(check.reason for check in checks if check.status == CHECK_STATUS_FAIL)
+    )
+    required_actions = tuple(
+        _dedupe_strings(
+            action
+            for check in checks
+            if check.status == CHECK_STATUS_FAIL
+            for action in check.required_actions
+        )
+    )
+    if blocking_reasons:
+        return MemoryEvidenceRepairRecoveryExecutorPreviewReport(
+            generated_at=datetime.now(timezone.utc).isoformat(),
+            status=RECOVERY_EXECUTOR_PREVIEW_STATUS_BLOCKED,
+            checks=checks,
+            previews=(),
+            blocking_reasons=blocking_reasons,
+            required_actions=required_actions,
+            source_recovery_write_lock_gate=dict(recovery_write_lock_gate),
+        )
+
+    preview = _preview_from_lock(lock=lock, execution=execution)
+    return MemoryEvidenceRepairRecoveryExecutorPreviewReport(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        status=RECOVERY_EXECUTOR_PREVIEW_STATUS_READY,
+        checks=checks,
+        previews=(preview,),
+        blocking_reasons=(),
+        required_actions=(),
+        source_recovery_write_lock_gate=dict(recovery_write_lock_gate),
+    )
+
+
+def empty_evidence_repair_recovery_executor_preview() -> MemoryEvidenceRepairRecoveryExecutorPreviewReport:
+    """Return an empty read-only recovery executor preview report."""
+
+    return _empty_report(recovery_write_lock_gate={})
+
+
+def _extract_lock(recovery_write_lock_gate: Mapping[str, Any]) -> dict[str, Any]:
+    locks = recovery_write_lock_gate.get("locks")
+    if isinstance(locks, list):
+        for lock in locks:
+            if isinstance(lock, Mapping):
+                return dict(lock)
+    if _str(recovery_write_lock_gate.get("id")).startswith("recovery-write-lock-"):
+        return dict(recovery_write_lock_gate)
+    return {}
+
+
+def _recovery_write_lock_ready_check(
+    recovery_write_lock_gate: Mapping[str, Any],
+    lock: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryExecutorPreviewCheck:
+    gate_status = _str(recovery_write_lock_gate.get("status"))
+    lock_status = _str(lock.get("status"))
+    if gate_status and gate_status != RECOVERY_WRITE_LOCK_STATUS_READY:
+        return _fail(
+            CHECK_RECOVERY_WRITE_LOCK_READY,
+            "Recovery write-lock gate is not ready for manual recovery execution.",
+            tuple(_list_of_str(recovery_write_lock_gate.get("required_actions")))
+            or ("produce_ready_recovery_write_lock_gate",),
+            {"recovery_write_lock_gate_status": gate_status, "lock_status": lock_status},
+        )
+    if lock_status != RECOVERY_LOCK_DRAFT_STATUS_READY:
+        return _fail(
+            CHECK_RECOVERY_WRITE_LOCK_READY,
+            "Recovery write-lock draft is not ready.",
+            ("produce_ready_recovery_write_lock_gate",),
+            {"recovery_write_lock_gate_status": gate_status, "lock_status": lock_status},
+        )
+    return _pass(
+        CHECK_RECOVERY_WRITE_LOCK_READY,
+        "Recovery write-lock gate and draft are ready.",
+        {"lock_id": _str(lock.get("id"))},
+    )
+
+
+def _recovery_write_lock_integrity_check(
+    lock: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryExecutorPreviewCheck:
+    expected_digest = _expected_lock_digest(lock)
+    actual_digest = _str(lock.get("lock_digest"))
+    expected_id = f"recovery-write-lock-{expected_digest[:16]}" if expected_digest else ""
+    missing_fields: list[str] = []
+    for field_name in (
+        "token_id",
+        "decision_id",
+        "execution_preview_id",
+        "operation_ids",
+        "step_ids",
+        "future_mutation_step_ids",
+    ):
+        value = lock.get(field_name)
+        if isinstance(value, list) and not value:
+            missing_fields.append(field_name)
+        elif not isinstance(value, list) and not _str(value):
+            missing_fields.append(field_name)
+    if (
+        missing_fields
+        or actual_digest != expected_digest
+        or _str(lock.get("id")) != expected_id
+        or _str(lock.get("lock_type")) != RECOVERY_WRITE_LOCK_TYPE
+        or _str(lock.get("scope")) != RECOVERY_WRITE_LOCK_SCOPE
+    ):
+        return _fail(
+            CHECK_RECOVERY_WRITE_LOCK_INTEGRITY,
+            "Recovery write-lock digest, id, type, scope, or required fields are invalid.",
+            ("regenerate_recovery_write_lock_gate",),
+            {
+                "expected_lock_digest": expected_digest,
+                "actual_lock_digest": actual_digest,
+                "expected_lock_id": expected_id,
+                "actual_lock_id": _str(lock.get("id")),
+                "missing_fields": missing_fields,
+            },
+        )
+    return _pass(
+        CHECK_RECOVERY_WRITE_LOCK_INTEGRITY,
+        "Recovery write-lock integrity checks pass.",
+        {"lock_id": expected_id, "lock_digest": actual_digest},
+    )
+
+
+def _recovery_write_lock_expiry_check(
+    lock: Mapping[str, Any],
+    now: datetime,
+) -> MemoryEvidenceRepairRecoveryExecutorPreviewCheck:
+    expires_at = _parse_datetime(lock.get("expires_at"))
+    if expires_at is None:
+        return _fail(
+            CHECK_RECOVERY_WRITE_LOCK_EXPIRY,
+            "Recovery write-lock expiry is missing or invalid.",
+            ("regenerate_recovery_write_lock_gate",),
+            {"expires_at": _str(lock.get("expires_at"))},
+        )
+    if expires_at <= now:
+        return _fail(
+            CHECK_RECOVERY_WRITE_LOCK_EXPIRY,
+            "Recovery write-lock draft has expired.",
+            ("regenerate_recovery_write_lock_gate",),
+            {"expires_at": expires_at.isoformat(), "current_time": now.isoformat()},
+        )
+    return _pass(
+        CHECK_RECOVERY_WRITE_LOCK_EXPIRY,
+        "Recovery write-lock draft is within its expiry window.",
+        {"expires_at": expires_at.isoformat(), "current_time": now.isoformat()},
+    )
+
+
+def _recovery_execution_steps_check(
+    lock: Mapping[str, Any],
+    execution: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryExecutorPreviewCheck:
+    steps = _execution_steps(execution)
+    execution_step_ids = [_str(step.get("id")) for step in steps]
+    execution_future_mutation_step_ids = _future_mutation_step_ids(execution)
+    lock_step_ids = _list_of_str(lock.get("step_ids"))
+    lock_future_mutation_step_ids = _list_of_str(lock.get("future_mutation_step_ids"))
+    missing_fields: list[str] = []
+    if not execution:
+        missing_fields.append("source_recovery_execution_preview")
+    if not steps:
+        missing_fields.append("source_recovery_execution_preview.steps")
+    if (
+        missing_fields
+        or _str(execution.get("status")) != RECOVERY_EXECUTION_STATUS_READY
+        or _str(execution.get("id")) != _str(lock.get("execution_preview_id"))
+        or _str(execution.get("decision_id")) != _str(lock.get("decision_id"))
+        or _list_of_str(execution.get("operation_ids")) != _list_of_str(lock.get("operation_ids"))
+        or execution_step_ids != lock_step_ids
+        or execution_future_mutation_step_ids != lock_future_mutation_step_ids
+    ):
+        return _fail(
+            CHECK_RECOVERY_EXECUTION_STEPS,
+            "Recovery execution preview does not match the recovery write-lock draft.",
+            ("regenerate_recovery_write_lock_gate",),
+            {
+                "missing_fields": missing_fields,
+                "execution_preview_id": _str(execution.get("id")),
+                "lock_execution_preview_id": _str(lock.get("execution_preview_id")),
+                "execution_step_ids": execution_step_ids,
+                "lock_step_ids": lock_step_ids,
+                "execution_future_mutation_step_ids": execution_future_mutation_step_ids,
+                "lock_future_mutation_step_ids": lock_future_mutation_step_ids,
+            },
+        )
+    return _pass(
+        CHECK_RECOVERY_EXECUTION_STEPS,
+        "Recovery execution steps match the recovery write-lock draft.",
+        {
+            "execution_preview_id": _str(execution.get("id")),
+            "step_count": len(steps),
+            "future_mutation_step_count": len(execution_future_mutation_step_ids),
+        },
+    )
+
+
+def _preview_from_lock(
+    *,
+    lock: Mapping[str, Any],
+    execution: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryExecutorPreview:
+    steps = tuple(_steps_from_lock(lock=lock, execution=execution))
+    executor_step_ids = tuple(step.id for step in steps)
+    step_ids = tuple(_list_of_str(lock.get("step_ids")))
+    operation_ids = tuple(_list_of_str(lock.get("operation_ids")))
+    future_mutation_step_ids = tuple(_list_of_str(lock.get("future_mutation_step_ids")))
+    preview_seed = {
+        "lock_id": _str(lock.get("id")),
+        "token_id": _str(lock.get("token_id")),
+        "decision_id": _str(lock.get("decision_id")),
+        "execution_preview_id": _str(lock.get("execution_preview_id")),
+        "operation_ids": operation_ids,
+        "step_ids": step_ids,
+        "future_mutation_step_ids": future_mutation_step_ids,
+        "executor_step_ids": executor_step_ids,
+        "execution_mode": "manual_ordered_recovery",
+        "failure_policy": "stop_on_first_recovery_failure_then_release_lock",
+    }
+    preview_digest = _digest(preview_seed)
+    preview_id = f"recovery-executor-preview-{preview_digest[:16]}"
+    return MemoryEvidenceRepairRecoveryExecutorPreview(
+        id=preview_id,
+        status=RECOVERY_EXECUTOR_PREVIEW_STATUS_READY,
+        lock_id=_str(lock.get("id")),
+        token_id=_str(lock.get("token_id")),
+        decision_id=_str(lock.get("decision_id")),
+        execution_preview_id=_str(lock.get("execution_preview_id")),
+        route=_str(execution.get("route")),
+        operation_ids=operation_ids,
+        step_ids=step_ids,
+        future_mutation_step_ids=future_mutation_step_ids,
+        executor_step_ids=executor_step_ids,
+        preview_digest=preview_digest,
+        preview_preview=f"{preview_id}:{preview_digest[:12]}",
+        execution_mode="manual_ordered_recovery",
+        failure_policy="stop_on_first_recovery_failure_then_release_lock",
+        steps=steps,
+        would_execute_manual_recovery=True,
+        would_apply_memory_recovery=bool(future_mutation_step_ids),
+        would_mark_recovery_token_used=True,
+        would_release_recovery_write_lock=True,
+        would_rerun_post_commit_audit=any(
+            step.action.startswith("rerun_post_commit_audit") for step in steps
+        ),
+        safety_note=(
+            "Read-only recovery executor preview. It describes a future ordered "
+            "manual recovery and does not execute rollback, write memory, mark "
+            "tokens used, or release a real lock."
+        ),
+        source_lock=dict(lock),
+    )
+
+
+def _steps_from_lock(
+    *,
+    lock: Mapping[str, Any],
+    execution: Mapping[str, Any],
+) -> list[MemoryEvidenceRepairRecoveryExecutorStep]:
+    steps: list[MemoryEvidenceRepairRecoveryExecutorStep] = [
+        _control_step(
+            sequence=1,
+            phase="preflight",
+            action="verify_recovery_write_lock_token_and_execution",
+            description="Verify recovery write-lock, token gate, execution preview, and step ids.",
+            lock=lock,
+            execution=execution,
+        )
+    ]
+    sequence = 2
+    for source_step in _execution_steps(execution):
+        steps.append(
+            _source_step(
+                sequence=sequence,
+                source_step=source_step,
+                lock=lock,
+                execution=execution,
+            )
+        )
+        sequence += 1
+    steps.append(
+        _control_step(
+            sequence=sequence,
+            phase="audit",
+            action="mark_recovery_token_used",
+            description="Mark the recovery approval token as used only after manual recovery succeeds.",
+            lock=lock,
+            execution=execution,
+            rollback_hint="do_not_mark_recovery_token_used_if_recovery_steps_fail",
+        )
+    )
+    sequence += 1
+    steps.append(
+        _control_step(
+            sequence=sequence,
+            phase="cleanup",
+            action="release_recovery_write_lock",
+            description="Release the recovery write lock regardless of success or failure.",
+            lock=lock,
+            execution=execution,
+            stop_on_failure=False,
+            rollback_hint="release_recovery_lock_in_finally_block",
+        )
+    )
+    return steps
+
+
+def _source_step(
+    *,
+    sequence: int,
+    source_step: Mapping[str, Any],
+    lock: Mapping[str, Any],
+    execution: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryExecutorStep:
+    action = _str(source_step.get("action")) or "recovery_step"
+    future_mutation = source_step.get("future_would_mutate_memory") is True
+    return MemoryEvidenceRepairRecoveryExecutorStep(
+        id=f"recovery-executor-step-{sequence}-{action}",
+        sequence=sequence,
+        phase=_str(source_step.get("phase")) or "recovery",
+        action=action,
+        description=_str(source_step.get("description")) or "Preview the future manual recovery step.",
+        recovery_execution_step_id=_str(source_step.get("id")),
+        operation_id=_str(source_step.get("operation_id")),
+        decision_id=_str(source_step.get("source_decision_id")) or _str(lock.get("decision_id")),
+        execution_preview_id=_str(execution.get("id")),
+        receipt_id=_str(source_step.get("receipt_id")),
+        token_id=_str(lock.get("token_id")),
+        lock_id=_str(lock.get("id")),
+        route=_str(source_step.get("route")) or _str(execution.get("route")),
+        required_precondition=_str(source_step.get("required_precondition")),
+        expected_result=_str(source_step.get("expected_result")),
+        source_recovery_execution_step=dict(source_step),
+        future_would_mutate_memory=future_mutation,
+        stop_on_failure=True,
+        rollback_hint=_rollback_hint(action, future_mutation),
+    )
+
+
+def _control_step(
+    *,
+    sequence: int,
+    phase: str,
+    action: str,
+    description: str,
+    lock: Mapping[str, Any],
+    execution: Mapping[str, Any],
+    future_would_mutate_memory: bool = False,
+    stop_on_failure: bool = True,
+    rollback_hint: str = "stop_executor_before_recovery_mutation",
+) -> MemoryEvidenceRepairRecoveryExecutorStep:
+    return MemoryEvidenceRepairRecoveryExecutorStep(
+        id=f"recovery-executor-step-{sequence}-{action}",
+        sequence=sequence,
+        phase=phase,
+        action=action,
+        description=description,
+        recovery_execution_step_id="",
+        operation_id="",
+        decision_id=_str(lock.get("decision_id")),
+        execution_preview_id=_str(execution.get("id")),
+        receipt_id=_str(execution.get("receipt_id")),
+        token_id=_str(lock.get("token_id")),
+        lock_id=_str(lock.get("id")),
+        route=_str(execution.get("route")),
+        required_precondition="verified_recovery_write_lock",
+        expected_result=f"{action}_complete",
+        source_recovery_execution_step={},
+        future_would_mutate_memory=future_would_mutate_memory,
+        stop_on_failure=stop_on_failure,
+        rollback_hint=rollback_hint,
+    )
+
+
+def _rollback_hint(action: str, future_mutation: bool) -> str:
+    if future_mutation:
+        return "stop_recovery_executor_and_use_verified_snapshot_or_rollback_plan"
+    if action.startswith("rerun_post_commit_audit"):
+        return "preserve_recovery_context_if_audit_still_fails"
+    return "stop_recovery_executor_before_next_manual_step"
+
+
+def _execution_from_lock(lock: Mapping[str, Any]) -> dict[str, Any]:
+    token_gate = _dict(lock.get("source_recovery_token_gate"))
+    execution = _dict(token_gate.get("source_recovery_execution_preview"))
+    return execution
+
+
+def _execution_steps(execution: Mapping[str, Any]) -> list[Mapping[str, Any]]:
+    return [
+        step
+        for step in _list(execution.get("steps"))
+        if isinstance(step, Mapping)
+    ]
+
+
+def _future_mutation_step_ids(execution: Mapping[str, Any]) -> list[str]:
+    return [
+        _str(step.get("id"))
+        for step in _execution_steps(execution)
+        if step.get("future_would_mutate_memory") is True
+    ]
+
+
+def _expected_lock_digest(lock: Mapping[str, Any]) -> str:
+    seed = {
+        "lock_type": RECOVERY_WRITE_LOCK_TYPE,
+        "scope": RECOVERY_WRITE_LOCK_SCOPE,
+        "owner": _str(lock.get("owner")) or "human",
+        "token_id": _str(lock.get("token_id")),
+        "decision_id": _str(lock.get("decision_id")),
+        "execution_preview_id": _str(lock.get("execution_preview_id")),
+        "operation_ids": tuple(_list_of_str(lock.get("operation_ids"))),
+        "step_ids": tuple(_list_of_str(lock.get("step_ids"))),
+        "future_mutation_step_ids": tuple(_list_of_str(lock.get("future_mutation_step_ids"))),
+        "expires_in_minutes": (
+            _positive_int(lock.get("expires_in_minutes"))
+            or DEFAULT_RECOVERY_LOCK_TTL_MINUTES
+        ),
+    }
+    return _digest(seed)
+
+
+def _empty_report(
+    *,
+    recovery_write_lock_gate: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryExecutorPreviewReport:
+    return MemoryEvidenceRepairRecoveryExecutorPreviewReport(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        status=RECOVERY_EXECUTOR_PREVIEW_STATUS_NO_ACTION_NEEDED,
+        checks=(),
+        previews=(),
+        blocking_reasons=(),
+        required_actions=(),
+        source_recovery_write_lock_gate=dict(recovery_write_lock_gate),
+    )
+
+
+def _blocked_report(
+    *,
+    recovery_write_lock_gate: Mapping[str, Any],
+    checks: tuple[MemoryEvidenceRepairRecoveryExecutorPreviewCheck, ...],
+) -> MemoryEvidenceRepairRecoveryExecutorPreviewReport:
+    return MemoryEvidenceRepairRecoveryExecutorPreviewReport(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        status=RECOVERY_EXECUTOR_PREVIEW_STATUS_BLOCKED,
+        checks=checks,
+        previews=(),
+        blocking_reasons=tuple(
+            _dedupe_strings(check.reason for check in checks if check.status == CHECK_STATUS_FAIL)
+        ),
+        required_actions=tuple(
+            _dedupe_strings(
+                action
+                for check in checks
+                if check.status == CHECK_STATUS_FAIL
+                for action in check.required_actions
+            )
+        ),
+        source_recovery_write_lock_gate=dict(recovery_write_lock_gate),
+    )
+
+
+def _pass(
+    check_id: str,
+    reason: str,
+    details: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryExecutorPreviewCheck:
+    return MemoryEvidenceRepairRecoveryExecutorPreviewCheck(
+        id=check_id,
+        status=CHECK_STATUS_PASS,
+        reason=reason,
+        required_actions=(),
+        details=dict(details),
+    )
+
+
+def _fail(
+    check_id: str,
+    reason: str,
+    required_actions: Sequence[str],
+    details: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryExecutorPreviewCheck:
+    return MemoryEvidenceRepairRecoveryExecutorPreviewCheck(
+        id=check_id,
+        status=CHECK_STATUS_FAIL,
+        reason=reason,
+        required_actions=tuple(required_actions),
+        details=dict(details),
+    )
+
+
+def _parse_datetime(value: str | datetime | Any) -> datetime | None:
+    if isinstance(value, datetime):
+        return value if value.tzinfo else value.replace(tzinfo=timezone.utc)
+    if not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    return parsed if parsed.tzinfo else parsed.replace(tzinfo=timezone.utc)
+
+
+def _positive_int(value: Any) -> int | None:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed if parsed > 0 else None
+
+
+def _digest(value: Any) -> str:
+    raw = json.dumps(value, sort_keys=True, ensure_ascii=False, default=str)
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def _dict(value: Any) -> dict[str, Any]:
+    return dict(value) if isinstance(value, Mapping) else {}
+
+
+def _list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _list_of_str(value: Any) -> list[str]:
+    return [_str(item) for item in value] if isinstance(value, list) else []
+
+
+def _dedupe_strings(values: Sequence[str] | Any) -> list[str]:
+    seen: set[str] = set()
+    result: list[str] = []
+    for value in values:
+        text = _str(value)
+        if text and text not in seen:
+            seen.add(text)
+            result.append(text)
+    return result
+
+
+def _str(value: Any) -> str:
+    return str(value or "").strip()

--- a/agent/memory_evidence_repair_recovery_human_approval_token.py
+++ b/agent/memory_evidence_repair_recovery_human_approval_token.py
@@ -1,0 +1,347 @@
+"""Read-only human approval token draft for memory recovery execution.
+
+The recovery token layer creates a dedicated approval-token draft only after
+a recovery execution preview is ready and requires human approval. It never
+writes to durable memory stores.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Mapping
+
+from agent.memory_evidence_repair_recovery_execution_preview import (
+    RECOVERY_EXECUTION_STATUS_BLOCKED,
+    RECOVERY_EXECUTION_STATUS_NO_ACTION_NEEDED,
+    RECOVERY_EXECUTION_STATUS_READY,
+)
+
+
+RECOVERY_APPROVAL_TOKEN_TYPE = "memory_evidence_repair_recovery_human_approval"
+RECOVERY_APPROVAL_TOKEN_SCOPE = "manual_memory_evidence_repair_recovery"
+RECOVERY_TOKEN_STATUS_DRAFT_READY = "draft_ready_for_recovery_human_approval"
+RECOVERY_TOKEN_STATUS_BLOCKED = "blocked"
+RECOVERY_TOKEN_STATUS_NO_ACTION_NEEDED = "no_action_needed"
+DEFAULT_EXPIRES_IN_MINUTES = 15
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairRecoveryHumanApprovalToken:
+    """One read-only recovery human approval token draft."""
+
+    id: str
+    token_type: str
+    status: str
+    scope: str
+    approver: str
+    approval_reason: str
+    execution_preview_status: str
+    execution_preview_id: str
+    execution_preview_digest: str
+    decision_id: str
+    route: str
+    priority: str
+    token_digest: str
+    token_preview: str
+    expires_in_minutes: int
+    operation_ids: tuple[str, ...]
+    failed_audit_step_ids: tuple[str, ...]
+    step_ids: tuple[str, ...]
+    future_mutation_step_ids: tuple[str, ...]
+    required_confirmation_text: str
+    one_time_constraints: dict[str, Any]
+    safety_note: str
+    source_execution_preview: dict[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "token_type": self.token_type,
+            "status": self.status,
+            "scope": self.scope,
+            "approver": self.approver,
+            "approval_reason": self.approval_reason,
+            "execution_preview_status": self.execution_preview_status,
+            "execution_preview_id": self.execution_preview_id,
+            "execution_preview_digest": self.execution_preview_digest,
+            "decision_id": self.decision_id,
+            "route": self.route,
+            "priority": self.priority,
+            "token_digest": self.token_digest,
+            "token_preview": self.token_preview,
+            "expires_in_minutes": self.expires_in_minutes,
+            "operation_ids": list(self.operation_ids),
+            "failed_audit_step_ids": list(self.failed_audit_step_ids),
+            "step_ids": list(self.step_ids),
+            "future_mutation_step_ids": list(self.future_mutation_step_ids),
+            "required_confirmation_text": self.required_confirmation_text,
+            "one_time_constraints": dict(self.one_time_constraints),
+            "safety_note": self.safety_note,
+            "source_execution_preview": dict(self.source_execution_preview),
+        }
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairRecoveryHumanApprovalTokenReport:
+    """Read-only recovery human approval token draft report."""
+
+    generated_at: str
+    status: str
+    tokens: tuple[MemoryEvidenceRepairRecoveryHumanApprovalToken, ...]
+    blocking_reasons: tuple[str, ...]
+    required_actions: tuple[str, ...]
+    source_recovery_execution_preview_report: dict[str, Any]
+
+    @property
+    def summary(self) -> dict[str, Any]:
+        return {
+            "status": self.status,
+            "token_count": len(self.tokens),
+            "ready_count": 1 if self.status == RECOVERY_TOKEN_STATUS_DRAFT_READY else 0,
+            "blocked_count": 1 if self.status == RECOVERY_TOKEN_STATUS_BLOCKED else 0,
+            "no_action_count": 1 if self.status == RECOVERY_TOKEN_STATUS_NO_ACTION_NEEDED else 0,
+            "blocking_reason_count": len(self.blocking_reasons),
+            "required_action_count": len(self.required_actions),
+            "recovery_human_approval_token_available": bool(self.tokens),
+            "requires_followup": bool(self.required_actions),
+        }
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "generated_at": self.generated_at,
+            "status": self.status,
+            "summary": self.summary,
+            "tokens": [token.to_dict() for token in self.tokens],
+            "blocking_reasons": list(self.blocking_reasons),
+            "required_actions": list(self.required_actions),
+            "source_recovery_execution_preview_report": dict(
+                self.source_recovery_execution_preview_report
+            ),
+            "read_only": True,
+            "read_only_memory": True,
+            "would_mutate_memory": False,
+        }
+
+
+def build_evidence_repair_recovery_human_approval_token(
+    *,
+    recovery_execution: Mapping[str, Any] | None = None,
+    approver: str = "human",
+    approval_reason: str = "",
+    expires_in_minutes: int = DEFAULT_EXPIRES_IN_MINUTES,
+) -> MemoryEvidenceRepairRecoveryHumanApprovalTokenReport:
+    """Build a read-only recovery approval token draft from an execution preview."""
+
+    recovery_execution = (
+        recovery_execution if isinstance(recovery_execution, Mapping) else {}
+    )
+    execution_status = _str(recovery_execution.get("status"))
+    preview = _extract_execution_preview(recovery_execution)
+
+    if not recovery_execution or execution_status == RECOVERY_EXECUTION_STATUS_NO_ACTION_NEEDED:
+        return _empty_report(recovery_execution=recovery_execution)
+
+    if execution_status == RECOVERY_EXECUTION_STATUS_BLOCKED and not preview:
+        blocking_reasons = tuple(_list_of_str(recovery_execution.get("blocking_reasons")))
+        required_actions = tuple(_list_of_str(recovery_execution.get("required_actions")))
+        return MemoryEvidenceRepairRecoveryHumanApprovalTokenReport(
+            generated_at=datetime.now(timezone.utc).isoformat(),
+            status=RECOVERY_TOKEN_STATUS_BLOCKED,
+            tokens=(),
+            blocking_reasons=blocking_reasons
+            or ("Recovery execution preview is blocked.",),
+            required_actions=required_actions
+            or ("produce_ready_recovery_execution_preview",),
+            source_recovery_execution_preview_report=dict(recovery_execution),
+        )
+
+    if execution_status != RECOVERY_EXECUTION_STATUS_READY or not preview:
+        return MemoryEvidenceRepairRecoveryHumanApprovalTokenReport(
+            generated_at=datetime.now(timezone.utc).isoformat(),
+            status=RECOVERY_TOKEN_STATUS_BLOCKED,
+            tokens=(),
+            blocking_reasons=("Recovery execution preview is not ready.",),
+            required_actions=("produce_ready_recovery_execution_preview",),
+            source_recovery_execution_preview_report=dict(recovery_execution),
+        )
+
+    if not _requires_recovery_approval(preview):
+        return MemoryEvidenceRepairRecoveryHumanApprovalTokenReport(
+            generated_at=datetime.now(timezone.utc).isoformat(),
+            status=RECOVERY_TOKEN_STATUS_NO_ACTION_NEEDED,
+            tokens=(),
+            blocking_reasons=(),
+            required_actions=(),
+            source_recovery_execution_preview_report=dict(recovery_execution),
+        )
+
+    token = _token_from_execution_preview(
+        preview=preview,
+        approver=approver,
+        approval_reason=approval_reason,
+        expires_in_minutes=expires_in_minutes,
+    )
+    return MemoryEvidenceRepairRecoveryHumanApprovalTokenReport(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        status=RECOVERY_TOKEN_STATUS_DRAFT_READY,
+        tokens=(token,),
+        blocking_reasons=(),
+        required_actions=(),
+        source_recovery_execution_preview_report=dict(recovery_execution),
+    )
+
+
+def empty_evidence_repair_recovery_human_approval_token() -> MemoryEvidenceRepairRecoveryHumanApprovalTokenReport:
+    """Return an empty read-only recovery human approval token report."""
+
+    return _empty_report(recovery_execution={})
+
+
+def _token_from_execution_preview(
+    *,
+    preview: Mapping[str, Any],
+    approver: str,
+    approval_reason: str,
+    expires_in_minutes: int,
+) -> MemoryEvidenceRepairRecoveryHumanApprovalToken:
+    execution_preview_digest = _execution_preview_digest(preview)
+    step_ids = tuple(_list_of_str(preview.get("step_ids")))
+    future_mutation_step_ids = tuple(
+        _str(step.get("id"))
+        for step in _list(preview.get("steps"))
+        if isinstance(step, Mapping) and step.get("future_would_mutate_memory") is True
+    )
+    operation_ids = tuple(_list_of_str(preview.get("operation_ids")))
+    failed_step_ids = tuple(_list_of_str(preview.get("failed_audit_step_ids")))
+    token_seed = {
+        "token_type": RECOVERY_APPROVAL_TOKEN_TYPE,
+        "scope": RECOVERY_APPROVAL_TOKEN_SCOPE,
+        "approver": _str(approver) or "human",
+        "approval_reason": _str(approval_reason),
+        "execution_preview_digest": execution_preview_digest,
+        "execution_preview_id": _str(preview.get("id")),
+        "decision_id": _str(preview.get("decision_id")),
+        "route": _str(preview.get("route")),
+        "operation_ids": operation_ids,
+        "failed_audit_step_ids": failed_step_ids,
+        "step_ids": step_ids,
+        "future_mutation_step_ids": future_mutation_step_ids,
+        "expires_in_minutes": _expires_in_minutes(expires_in_minutes),
+    }
+    token_digest = _digest(token_seed)
+    token_id = f"recovery-approval-token-{token_digest[:16]}"
+    required_confirmation_text = (
+        f"APPROVE {RECOVERY_APPROVAL_TOKEN_SCOPE} {token_id}"
+    )
+    return MemoryEvidenceRepairRecoveryHumanApprovalToken(
+        id=token_id,
+        token_type=RECOVERY_APPROVAL_TOKEN_TYPE,
+        status=RECOVERY_TOKEN_STATUS_DRAFT_READY,
+        scope=RECOVERY_APPROVAL_TOKEN_SCOPE,
+        approver=_str(approver) or "human",
+        approval_reason=_str(approval_reason),
+        execution_preview_status=_str(preview.get("status")),
+        execution_preview_id=_str(preview.get("id")),
+        execution_preview_digest=execution_preview_digest,
+        decision_id=_str(preview.get("decision_id")),
+        route=_str(preview.get("route")),
+        priority=_str(preview.get("priority")),
+        token_digest=token_digest,
+        token_preview=f"{token_id}:{token_digest[:12]}",
+        expires_in_minutes=_expires_in_minutes(expires_in_minutes),
+        operation_ids=operation_ids,
+        failed_audit_step_ids=failed_step_ids,
+        step_ids=step_ids,
+        future_mutation_step_ids=future_mutation_step_ids,
+        required_confirmation_text=required_confirmation_text,
+        one_time_constraints={
+            "one_time_use": True,
+            "requires_exact_execution_preview_digest": execution_preview_digest,
+            "requires_exact_execution_preview_id": _str(preview.get("id")),
+            "requires_exact_decision_id": _str(preview.get("decision_id")),
+            "requires_exact_route": _str(preview.get("route")),
+            "requires_exact_confirmation_text": required_confirmation_text,
+            "requires_same_future_mutation_step_ids": list(future_mutation_step_ids),
+            "expires_in_minutes": _expires_in_minutes(expires_in_minutes),
+        },
+        safety_note=(
+            "Read-only recovery approval token draft. This is not a persisted "
+            "credential and does not execute recovery or mutate durable memory by itself."
+        ),
+        source_execution_preview=dict(preview),
+    )
+
+
+def _extract_execution_preview(recovery_execution: Mapping[str, Any]) -> dict[str, Any]:
+    previews = recovery_execution.get("previews")
+    if isinstance(previews, list):
+        for preview in previews:
+            if isinstance(preview, Mapping):
+                return dict(preview)
+    if _str(recovery_execution.get("id")).startswith("recovery-execution-preview-"):
+        return dict(recovery_execution)
+    return {}
+
+
+def _requires_recovery_approval(preview: Mapping[str, Any]) -> bool:
+    if preview.get("future_would_mutate_memory") is True:
+        return True
+    return preview.get("human_approval_required") is True
+
+
+def _execution_preview_digest(preview: Mapping[str, Any]) -> str:
+    existing = _str(preview.get("preview_digest"))
+    if existing:
+        return existing
+    return _digest(
+        {
+            "id": _str(preview.get("id")),
+            "route": _str(preview.get("route")),
+            "decision_id": _str(preview.get("decision_id")),
+            "operation_ids": tuple(_list_of_str(preview.get("operation_ids"))),
+            "failed_audit_step_ids": tuple(_list_of_str(preview.get("failed_audit_step_ids"))),
+            "step_ids": tuple(_list_of_str(preview.get("step_ids"))),
+        }
+    )
+
+
+def _empty_report(
+    *,
+    recovery_execution: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryHumanApprovalTokenReport:
+    return MemoryEvidenceRepairRecoveryHumanApprovalTokenReport(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        status=RECOVERY_TOKEN_STATUS_NO_ACTION_NEEDED,
+        tokens=(),
+        blocking_reasons=(),
+        required_actions=(),
+        source_recovery_execution_preview_report=dict(recovery_execution),
+    )
+
+
+def _expires_in_minutes(value: Any) -> int:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        parsed = DEFAULT_EXPIRES_IN_MINUTES
+    return parsed if parsed > 0 else DEFAULT_EXPIRES_IN_MINUTES
+
+
+def _digest(value: Any) -> str:
+    raw = json.dumps(value, sort_keys=True, ensure_ascii=False, default=str)
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def _list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _list_of_str(value: Any) -> list[str]:
+    return [_str(item) for item in value] if isinstance(value, list) else []
+
+
+def _str(value: Any) -> str:
+    return str(value or "").strip()

--- a/agent/memory_evidence_repair_recovery_write_lock_gate.py
+++ b/agent/memory_evidence_repair_recovery_write_lock_gate.py
@@ -1,0 +1,634 @@
+"""Read-only write-lock gate for memory evidence repair recovery.
+
+The recovery write-lock gate verifies a recovery approval token gate, checks
+supplied active locks and used-token ids, then drafts a future recovery write
+lock. It never writes to durable memory stores and never acquires a real lock.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Any, Mapping, Sequence
+
+from agent.memory_evidence_repair_manual_commit_dry_run import (
+    CHECK_STATUS_FAIL,
+    CHECK_STATUS_PASS,
+)
+from agent.memory_evidence_repair_recovery_approval_token_gate import (
+    RECOVERY_TOKEN_GATE_STATUS_BLOCKED,
+    RECOVERY_TOKEN_GATE_STATUS_NO_ACTION_NEEDED,
+    RECOVERY_TOKEN_GATE_STATUS_VERIFIED,
+)
+from agent.memory_evidence_repair_recovery_execution_preview import (
+    RECOVERY_EXECUTION_STATUS_READY,
+)
+
+
+RECOVERY_WRITE_LOCK_TYPE = "memory_evidence_repair_recovery_write_lock"
+RECOVERY_WRITE_LOCK_SCOPE = "manual_memory_evidence_repair_recovery"
+RECOVERY_WRITE_LOCK_STATUS_READY = "recovery_write_lock_ready_for_manual_recovery"
+RECOVERY_WRITE_LOCK_STATUS_BLOCKED = "blocked"
+RECOVERY_WRITE_LOCK_STATUS_NO_ACTION_NEEDED = "no_action_needed"
+RECOVERY_LOCK_DRAFT_STATUS_READY = "recovery_write_lock_draft_ready"
+DEFAULT_RECOVERY_LOCK_TTL_MINUTES = 10
+
+CHECK_RECOVERY_TOKEN_GATE_READY = "recovery_token_gate_ready"
+CHECK_RECOVERY_TOKEN_GATE_INTEGRITY = "recovery_token_gate_integrity"
+CHECK_RECOVERY_TOKEN_REUSE = "recovery_token_reuse"
+CHECK_RECOVERY_ACTIVE_LOCKS = "recovery_active_locks"
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairRecoveryWriteLockCheck:
+    """One read-only recovery write-lock readiness check."""
+
+    id: str
+    status: str
+    reason: str
+    required_actions: tuple[str, ...]
+    details: dict[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "status": self.status,
+            "reason": self.reason,
+            "required_actions": list(self.required_actions),
+            "details": dict(self.details),
+        }
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairRecoveryWriteLockDraft:
+    """One read-only future recovery write-lock draft."""
+
+    id: str
+    lock_type: str
+    status: str
+    scope: str
+    owner: str
+    token_id: str
+    decision_id: str
+    execution_preview_id: str
+    operation_ids: tuple[str, ...]
+    step_ids: tuple[str, ...]
+    future_mutation_step_ids: tuple[str, ...]
+    lock_digest: str
+    lock_preview: str
+    issued_at: str
+    expires_at: str
+    expires_in_minutes: int
+    would_acquire_write_lock: bool
+    would_release_after_recovery: bool
+    safety_note: str
+    source_recovery_token_gate: dict[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "lock_type": self.lock_type,
+            "status": self.status,
+            "scope": self.scope,
+            "owner": self.owner,
+            "token_id": self.token_id,
+            "decision_id": self.decision_id,
+            "execution_preview_id": self.execution_preview_id,
+            "operation_ids": list(self.operation_ids),
+            "step_ids": list(self.step_ids),
+            "future_mutation_step_ids": list(self.future_mutation_step_ids),
+            "lock_digest": self.lock_digest,
+            "lock_preview": self.lock_preview,
+            "issued_at": self.issued_at,
+            "expires_at": self.expires_at,
+            "expires_in_minutes": self.expires_in_minutes,
+            "would_acquire_write_lock": self.would_acquire_write_lock,
+            "would_release_after_recovery": self.would_release_after_recovery,
+            "safety_note": self.safety_note,
+            "source_recovery_token_gate": dict(self.source_recovery_token_gate),
+        }
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairRecoveryWriteLockGateReport:
+    """Read-only recovery write-lock gate report."""
+
+    generated_at: str
+    status: str
+    checks: tuple[MemoryEvidenceRepairRecoveryWriteLockCheck, ...]
+    locks: tuple[MemoryEvidenceRepairRecoveryWriteLockDraft, ...]
+    blocking_reasons: tuple[str, ...]
+    required_actions: tuple[str, ...]
+    active_lock_conflicts: tuple[dict[str, Any], ...]
+    source_recovery_token_gate: dict[str, Any]
+
+    @property
+    def summary(self) -> dict[str, Any]:
+        by_check_status: dict[str, int] = {}
+        for check in self.checks:
+            by_check_status[check.status] = by_check_status.get(check.status, 0) + 1
+        return {
+            "status": self.status,
+            "check_count": len(self.checks),
+            "pass_count": by_check_status.get(CHECK_STATUS_PASS, 0),
+            "fail_count": by_check_status.get(CHECK_STATUS_FAIL, 0),
+            "lock_count": len(self.locks),
+            "active_lock_conflict_count": len(self.active_lock_conflicts),
+            "blocking_reason_count": len(self.blocking_reasons),
+            "required_action_count": len(self.required_actions),
+            "recovery_write_lock_available": bool(self.locks),
+            "recovery_executor_preview_allowed": self.status == RECOVERY_WRITE_LOCK_STATUS_READY,
+            "would_acquire_write_lock_count": sum(
+                1 for lock in self.locks if lock.would_acquire_write_lock
+            ),
+            "has_blocks": self.status == RECOVERY_WRITE_LOCK_STATUS_BLOCKED,
+            "requires_followup": bool(self.required_actions),
+            "by_check_status": by_check_status,
+        }
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "generated_at": self.generated_at,
+            "status": self.status,
+            "summary": self.summary,
+            "checks": [check.to_dict() for check in self.checks],
+            "locks": [lock.to_dict() for lock in self.locks],
+            "blocking_reasons": list(self.blocking_reasons),
+            "required_actions": list(self.required_actions),
+            "active_lock_conflicts": [dict(conflict) for conflict in self.active_lock_conflicts],
+            "source_recovery_token_gate": dict(self.source_recovery_token_gate),
+            "read_only": True,
+            "read_only_memory": True,
+            "would_mutate_memory": False,
+        }
+
+
+def build_evidence_repair_recovery_write_lock_gate(
+    *,
+    recovery_token_gate: Mapping[str, Any] | None = None,
+    active_locks: Sequence[Mapping[str, Any]] | None = None,
+    already_used_token_ids: Sequence[str] | None = None,
+    lock_owner: str = "human",
+    lock_ttl_minutes: int = DEFAULT_RECOVERY_LOCK_TTL_MINUTES,
+    current_time: str | datetime | None = None,
+) -> MemoryEvidenceRepairRecoveryWriteLockGateReport:
+    """Build a read-only recovery write-lock gate from a verified token gate."""
+
+    recovery_token_gate = recovery_token_gate if isinstance(recovery_token_gate, Mapping) else {}
+    gate_status = _str(recovery_token_gate.get("status"))
+    now = _parse_datetime(current_time) or datetime.now(timezone.utc)
+
+    if not recovery_token_gate or gate_status == RECOVERY_TOKEN_GATE_STATUS_NO_ACTION_NEEDED:
+        return _empty_report(recovery_token_gate=recovery_token_gate)
+
+    if gate_status == RECOVERY_TOKEN_GATE_STATUS_BLOCKED:
+        return _blocked_report(
+            recovery_token_gate=recovery_token_gate,
+            checks=(
+                _fail(
+                    CHECK_RECOVERY_TOKEN_GATE_READY,
+                    "; ".join(_list_of_str(recovery_token_gate.get("blocking_reasons")))
+                    or "Recovery approval token gate is blocked.",
+                    tuple(_list_of_str(recovery_token_gate.get("required_actions")))
+                    or ("produce_verified_recovery_approval_token_gate",),
+                    {"recovery_token_gate_status": gate_status},
+                ),
+            ),
+            conflicts=(),
+        )
+
+    checks: list[MemoryEvidenceRepairRecoveryWriteLockCheck] = [
+        _token_gate_ready_check(recovery_token_gate),
+        _token_gate_integrity_check(recovery_token_gate),
+        _token_reuse_check(recovery_token_gate, already_used_token_ids),
+    ]
+    conflicts = tuple(_active_lock_conflicts(recovery_token_gate, active_locks, now))
+    checks.append(_active_lock_check(conflicts))
+
+    blocking_reasons = tuple(
+        _dedupe_strings(check.reason for check in checks if check.status == CHECK_STATUS_FAIL)
+    )
+    required_actions = tuple(
+        _dedupe_strings(
+            action
+            for check in checks
+            if check.status == CHECK_STATUS_FAIL
+            for action in check.required_actions
+        )
+    )
+    if blocking_reasons:
+        return MemoryEvidenceRepairRecoveryWriteLockGateReport(
+            generated_at=datetime.now(timezone.utc).isoformat(),
+            status=RECOVERY_WRITE_LOCK_STATUS_BLOCKED,
+            checks=tuple(checks),
+            locks=(),
+            blocking_reasons=blocking_reasons,
+            required_actions=required_actions,
+            active_lock_conflicts=conflicts,
+            source_recovery_token_gate=dict(recovery_token_gate),
+        )
+
+    lock = _lock_from_gate(
+        recovery_token_gate=recovery_token_gate,
+        lock_owner=lock_owner,
+        lock_ttl_minutes=lock_ttl_minutes,
+        issued_at=now,
+    )
+    return MemoryEvidenceRepairRecoveryWriteLockGateReport(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        status=RECOVERY_WRITE_LOCK_STATUS_READY,
+        checks=tuple(checks),
+        locks=(lock,),
+        blocking_reasons=(),
+        required_actions=(),
+        active_lock_conflicts=(),
+        source_recovery_token_gate=dict(recovery_token_gate),
+    )
+
+
+def empty_evidence_repair_recovery_write_lock_gate() -> MemoryEvidenceRepairRecoveryWriteLockGateReport:
+    """Return an empty read-only recovery write-lock gate report."""
+
+    return _empty_report(recovery_token_gate={})
+
+
+def _token_gate_ready_check(
+    recovery_token_gate: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryWriteLockCheck:
+    status = _str(recovery_token_gate.get("status"))
+    if status != RECOVERY_TOKEN_GATE_STATUS_VERIFIED:
+        return _fail(
+            CHECK_RECOVERY_TOKEN_GATE_READY,
+            "Recovery approval token gate is not verified for manual recovery.",
+            tuple(_list_of_str(recovery_token_gate.get("required_actions")))
+            or ("produce_verified_recovery_approval_token_gate",),
+            {"recovery_token_gate_status": status},
+        )
+    return _pass(
+        CHECK_RECOVERY_TOKEN_GATE_READY,
+        "Recovery approval token gate is verified for manual recovery.",
+        {"token_id": _str(recovery_token_gate.get("token_id"))},
+    )
+
+
+def _token_gate_integrity_check(
+    recovery_token_gate: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryWriteLockCheck:
+    token = _dict(recovery_token_gate.get("source_token"))
+    execution = _dict(recovery_token_gate.get("source_recovery_execution_preview"))
+    future_mutation_step_ids = _list_of_str(
+        recovery_token_gate.get("verified_future_mutation_step_ids")
+    )
+    missing_fields: list[str] = []
+    for field_name in ("token_id", "verified_operation_ids", "verified_step_ids"):
+        value = recovery_token_gate.get(field_name)
+        if isinstance(value, list) and not value:
+            missing_fields.append(field_name)
+        elif not isinstance(value, list) and not _str(value):
+            missing_fields.append(field_name)
+    if not future_mutation_step_ids:
+        missing_fields.append("verified_future_mutation_step_ids")
+    if not _str(execution.get("id")):
+        missing_fields.append("source_recovery_execution_preview.id")
+    if not _str(execution.get("decision_id")):
+        missing_fields.append("source_recovery_execution_preview.decision_id")
+    if (
+        missing_fields
+        or _str(token.get("id")) != _str(recovery_token_gate.get("token_id"))
+        or _str(execution.get("status")) != RECOVERY_EXECUTION_STATUS_READY
+        or _list_of_str(execution.get("operation_ids"))
+        != _list_of_str(recovery_token_gate.get("verified_operation_ids"))
+        or _list_of_str(execution.get("step_ids"))
+        != _list_of_str(recovery_token_gate.get("verified_step_ids"))
+        or _future_mutation_step_ids(execution) != future_mutation_step_ids
+    ):
+        return _fail(
+            CHECK_RECOVERY_TOKEN_GATE_INTEGRITY,
+            "Recovery token gate source token, execution preview, or verified ids are invalid.",
+            ("regenerate_recovery_approval_token_gate",),
+            {
+                "missing_fields": missing_fields,
+                "token_id": _str(recovery_token_gate.get("token_id")),
+                "source_token_id": _str(token.get("id")),
+                "execution_preview_status": _str(execution.get("status")),
+            },
+        )
+    return _pass(
+        CHECK_RECOVERY_TOKEN_GATE_INTEGRITY,
+        "Recovery token gate integrity checks pass.",
+        {
+            "token_id": _str(recovery_token_gate.get("token_id")),
+            "future_mutation_step_count": len(future_mutation_step_ids),
+        },
+    )
+
+
+def _token_reuse_check(
+    recovery_token_gate: Mapping[str, Any],
+    already_used_token_ids: Sequence[str] | None,
+) -> MemoryEvidenceRepairRecoveryWriteLockCheck:
+    token_id = _str(recovery_token_gate.get("token_id"))
+    used = {_str(item) for item in already_used_token_ids or [] if _str(item)}
+    if token_id and token_id in used:
+        return _fail(
+            CHECK_RECOVERY_TOKEN_REUSE,
+            "Recovery approval token is already present in the external used-token ledger.",
+            ("regenerate_recovery_human_approval_token",),
+            {"token_id": token_id, "already_used_token_count": len(used)},
+        )
+    return _pass(
+        CHECK_RECOVERY_TOKEN_REUSE,
+        "Recovery approval token is not present in the external used-token ledger.",
+        {"token_id": token_id, "already_used_token_count": len(used)},
+    )
+
+
+def _active_lock_check(
+    conflicts: Sequence[Mapping[str, Any]],
+) -> MemoryEvidenceRepairRecoveryWriteLockCheck:
+    if conflicts:
+        return _fail(
+            CHECK_RECOVERY_ACTIVE_LOCKS,
+            "Active recovery write locks conflict with the planned memory evidence repair recovery.",
+            ("wait_for_recovery_write_lock_release", "retry_recovery_write_lock_gate"),
+            {"conflict_count": len(conflicts), "conflicts": list(conflicts)},
+        )
+    return _pass(
+        CHECK_RECOVERY_ACTIVE_LOCKS,
+        "No active recovery write-lock conflicts were supplied.",
+        {"conflict_count": 0},
+    )
+
+
+def _lock_from_gate(
+    *,
+    recovery_token_gate: Mapping[str, Any],
+    lock_owner: str,
+    lock_ttl_minutes: int,
+    issued_at: datetime,
+) -> MemoryEvidenceRepairRecoveryWriteLockDraft:
+    ttl = _positive_int(lock_ttl_minutes) or DEFAULT_RECOVERY_LOCK_TTL_MINUTES
+    expires_at = issued_at + timedelta(minutes=ttl)
+    execution = _dict(recovery_token_gate.get("source_recovery_execution_preview"))
+    operation_ids = tuple(_list_of_str(recovery_token_gate.get("verified_operation_ids")))
+    step_ids = tuple(_list_of_str(recovery_token_gate.get("verified_step_ids")))
+    future_mutation_step_ids = tuple(
+        _list_of_str(recovery_token_gate.get("verified_future_mutation_step_ids"))
+    )
+    seed = {
+        "lock_type": RECOVERY_WRITE_LOCK_TYPE,
+        "scope": RECOVERY_WRITE_LOCK_SCOPE,
+        "owner": _str(lock_owner) or "human",
+        "token_id": _str(recovery_token_gate.get("token_id")),
+        "decision_id": _str(execution.get("decision_id")),
+        "execution_preview_id": _str(execution.get("id")),
+        "operation_ids": operation_ids,
+        "step_ids": step_ids,
+        "future_mutation_step_ids": future_mutation_step_ids,
+        "expires_in_minutes": ttl,
+    }
+    lock_digest = _digest(seed)
+    lock_id = f"recovery-write-lock-{lock_digest[:16]}"
+    return MemoryEvidenceRepairRecoveryWriteLockDraft(
+        id=lock_id,
+        lock_type=RECOVERY_WRITE_LOCK_TYPE,
+        status=RECOVERY_LOCK_DRAFT_STATUS_READY,
+        scope=RECOVERY_WRITE_LOCK_SCOPE,
+        owner=_str(lock_owner) or "human",
+        token_id=_str(recovery_token_gate.get("token_id")),
+        decision_id=_str(execution.get("decision_id")),
+        execution_preview_id=_str(execution.get("id")),
+        operation_ids=operation_ids,
+        step_ids=step_ids,
+        future_mutation_step_ids=future_mutation_step_ids,
+        lock_digest=lock_digest,
+        lock_preview=f"{lock_id}:{lock_digest[:12]}",
+        issued_at=issued_at.isoformat(),
+        expires_at=expires_at.isoformat(),
+        expires_in_minutes=ttl,
+        would_acquire_write_lock=True,
+        would_release_after_recovery=True,
+        safety_note=(
+            "Read-only recovery write-lock draft. This does not acquire a real "
+            "lock and does not mutate durable memory."
+        ),
+        source_recovery_token_gate=dict(recovery_token_gate),
+    )
+
+
+def _active_lock_conflicts(
+    recovery_token_gate: Mapping[str, Any],
+    active_locks: Sequence[Mapping[str, Any]] | None,
+    now: datetime,
+) -> list[dict[str, Any]]:
+    conflicts: list[dict[str, Any]] = []
+    for lock in active_locks or []:
+        if not isinstance(lock, Mapping) or not _is_active_lock(lock, now):
+            continue
+        if _lock_conflicts_with_gate(lock, recovery_token_gate):
+            conflicts.append(
+                {
+                    "lock_id": _str(lock.get("id")),
+                    "owner": _str(lock.get("owner")),
+                    "scope": _str(lock.get("scope")),
+                    "expires_at": _str(lock.get("expires_at")),
+                    "reason": _conflict_reason(lock, recovery_token_gate),
+                }
+            )
+    return conflicts
+
+
+def _is_active_lock(lock: Mapping[str, Any], now: datetime) -> bool:
+    status = _str(lock.get("status")).lower()
+    if status in {"released", "expired", "cancelled", "canceled", "inactive"}:
+        return False
+    expires_at = _parse_datetime(lock.get("expires_at"))
+    if expires_at is not None and expires_at <= now:
+        return False
+    return status in {"", "active", "recovery_write_lock_active", RECOVERY_LOCK_DRAFT_STATUS_READY}
+
+
+def _lock_conflicts_with_gate(
+    lock: Mapping[str, Any],
+    recovery_token_gate: Mapping[str, Any],
+) -> bool:
+    lock_scope = _str(lock.get("scope"))
+    if lock_scope and lock_scope != RECOVERY_WRITE_LOCK_SCOPE:
+        return False
+    execution = _dict(recovery_token_gate.get("source_recovery_execution_preview"))
+    if _str(lock.get("token_id")) and _str(lock.get("token_id")) == _str(recovery_token_gate.get("token_id")):
+        return True
+    if _str(lock.get("decision_id")) and _str(lock.get("decision_id")) == _str(execution.get("decision_id")):
+        return True
+    if _str(lock.get("execution_preview_id")) and _str(lock.get("execution_preview_id")) == _str(execution.get("id")):
+        return True
+    if _intersects(_list_of_str(lock.get("operation_ids")), _list_of_str(recovery_token_gate.get("verified_operation_ids"))):
+        return True
+    if _intersects(_list_of_str(lock.get("step_ids")), _list_of_str(recovery_token_gate.get("verified_step_ids"))):
+        return True
+    if _intersects(_list_of_str(lock.get("future_mutation_step_ids")), _list_of_str(recovery_token_gate.get("verified_future_mutation_step_ids"))):
+        return True
+    identifiers = (
+        _str(lock.get("token_id")),
+        _str(lock.get("decision_id")),
+        _str(lock.get("execution_preview_id")),
+        *_list_of_str(lock.get("operation_ids")),
+        *_list_of_str(lock.get("step_ids")),
+        *_list_of_str(lock.get("future_mutation_step_ids")),
+    )
+    return not any(identifiers)
+
+
+def _conflict_reason(lock: Mapping[str, Any], recovery_token_gate: Mapping[str, Any]) -> str:
+    execution = _dict(recovery_token_gate.get("source_recovery_execution_preview"))
+    if _str(lock.get("token_id")) == _str(recovery_token_gate.get("token_id")):
+        return "same_token_id"
+    if _str(lock.get("decision_id")) == _str(execution.get("decision_id")):
+        return "same_decision_id"
+    if _str(lock.get("execution_preview_id")) == _str(execution.get("id")):
+        return "same_execution_preview_id"
+    if _intersects(_list_of_str(lock.get("operation_ids")), _list_of_str(recovery_token_gate.get("verified_operation_ids"))):
+        return "overlapping_operation_ids"
+    if _intersects(_list_of_str(lock.get("step_ids")), _list_of_str(recovery_token_gate.get("verified_step_ids"))):
+        return "overlapping_step_ids"
+    if _intersects(_list_of_str(lock.get("future_mutation_step_ids")), _list_of_str(recovery_token_gate.get("verified_future_mutation_step_ids"))):
+        return "overlapping_future_mutation_step_ids"
+    return "global_scope_lock"
+
+
+def _future_mutation_step_ids(recovery_execution: Mapping[str, Any]) -> list[str]:
+    return [
+        _str(step.get("id"))
+        for step in _list(recovery_execution.get("steps"))
+        if isinstance(step, Mapping) and step.get("future_would_mutate_memory") is True
+    ]
+
+
+def _empty_report(
+    *,
+    recovery_token_gate: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryWriteLockGateReport:
+    return MemoryEvidenceRepairRecoveryWriteLockGateReport(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        status=RECOVERY_WRITE_LOCK_STATUS_NO_ACTION_NEEDED,
+        checks=(),
+        locks=(),
+        blocking_reasons=(),
+        required_actions=(),
+        active_lock_conflicts=(),
+        source_recovery_token_gate=dict(recovery_token_gate),
+    )
+
+
+def _blocked_report(
+    *,
+    recovery_token_gate: Mapping[str, Any],
+    checks: tuple[MemoryEvidenceRepairRecoveryWriteLockCheck, ...],
+    conflicts: Sequence[Mapping[str, Any]],
+) -> MemoryEvidenceRepairRecoveryWriteLockGateReport:
+    return MemoryEvidenceRepairRecoveryWriteLockGateReport(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        status=RECOVERY_WRITE_LOCK_STATUS_BLOCKED,
+        checks=checks,
+        locks=(),
+        blocking_reasons=tuple(
+            _dedupe_strings(check.reason for check in checks if check.status == CHECK_STATUS_FAIL)
+        ),
+        required_actions=tuple(
+            _dedupe_strings(
+                action
+                for check in checks
+                if check.status == CHECK_STATUS_FAIL
+                for action in check.required_actions
+            )
+        ),
+        active_lock_conflicts=tuple(dict(conflict) for conflict in conflicts),
+        source_recovery_token_gate=dict(recovery_token_gate),
+    )
+
+
+def _pass(
+    check_id: str,
+    reason: str,
+    details: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryWriteLockCheck:
+    return MemoryEvidenceRepairRecoveryWriteLockCheck(
+        id=check_id,
+        status=CHECK_STATUS_PASS,
+        reason=reason,
+        required_actions=(),
+        details=dict(details),
+    )
+
+
+def _fail(
+    check_id: str,
+    reason: str,
+    required_actions: Sequence[str],
+    details: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryWriteLockCheck:
+    return MemoryEvidenceRepairRecoveryWriteLockCheck(
+        id=check_id,
+        status=CHECK_STATUS_FAIL,
+        reason=reason,
+        required_actions=tuple(required_actions),
+        details=dict(details),
+    )
+
+
+def _parse_datetime(value: str | datetime | Any) -> datetime | None:
+    if isinstance(value, datetime):
+        return value if value.tzinfo else value.replace(tzinfo=timezone.utc)
+    if not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    return parsed if parsed.tzinfo else parsed.replace(tzinfo=timezone.utc)
+
+
+def _positive_int(value: Any) -> int | None:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed if parsed > 0 else None
+
+
+def _intersects(left: Sequence[str], right: Sequence[str]) -> bool:
+    return bool(set(left).intersection(set(right)))
+
+
+def _digest(value: Any) -> str:
+    raw = json.dumps(value, sort_keys=True, ensure_ascii=False, default=str)
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def _dict(value: Any) -> dict[str, Any]:
+    return dict(value) if isinstance(value, Mapping) else {}
+
+
+def _list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _list_of_str(value: Any) -> list[str]:
+    return [_str(item) for item in value] if isinstance(value, list) else []
+
+
+def _dedupe_strings(values: Sequence[str] | Any) -> list[str]:
+    seen: set[str] = set()
+    result: list[str] = []
+    for value in values:
+        text = _str(value)
+        if text and text not in seen:
+            seen.add(text)
+            result.append(text)
+    return result
+
+
+def _str(value: Any) -> str:
+    return str(value or "").strip()

--- a/agent/memory_evidence_repair_rollback_drill_preview.py
+++ b/agent/memory_evidence_repair_rollback_drill_preview.py
@@ -1,0 +1,971 @@
+"""Read-only rollback drill preview for memory evidence repair audits.
+
+The rollback drill preview turns a post-commit audit preview or observed
+post-commit audit failure into a rehearsal plan. It never rolls back durable
+memory and never mutates receipts, approval tokens, or write locks.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Mapping, Sequence
+
+from agent.memory_evidence_repair_manual_commit_dry_run import (
+    CHECK_STATUS_FAIL,
+    CHECK_STATUS_PASS,
+)
+from agent.memory_evidence_repair_post_commit_audit_preview import (
+    AUDIT_STEP_STATUS_FAIL,
+    POST_COMMIT_AUDIT_STATUS_BLOCKED,
+    POST_COMMIT_AUDIT_STATUS_NO_ACTION_NEEDED,
+    POST_COMMIT_AUDIT_STATUS_READY,
+)
+
+
+ROLLBACK_DRILL_STATUS_READY = "rollback_drill_preview_ready"
+ROLLBACK_DRILL_STATUS_BLOCKED = "blocked"
+ROLLBACK_DRILL_STATUS_NO_ACTION_NEEDED = "no_action_needed"
+
+ROLLBACK_DRILL_TRIGGER_AUDIT_FAILURE = "post_commit_audit_failure"
+ROLLBACK_DRILL_TRIGGER_PREPAREDNESS = "post_commit_audit_preparedness"
+
+DRILL_STEP_STATUS_PLANNED = "planned"
+
+CHECK_POST_COMMIT_AUDIT_AVAILABLE = "post_commit_audit_available"
+CHECK_AUDIT_FAILURE_CONTEXT = "audit_failure_context"
+CHECK_ROLLBACK_DRILL_SOURCES = "rollback_drill_sources"
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairRollbackDrillCheck:
+    """One read-only rollback drill readiness check."""
+
+    id: str
+    status: str
+    reason: str
+    required_actions: tuple[str, ...]
+    details: dict[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "status": self.status,
+            "reason": self.reason,
+            "required_actions": list(self.required_actions),
+            "details": dict(self.details),
+        }
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairRollbackDrillStep:
+    """One future rollback drill step preview."""
+
+    id: str
+    sequence: int
+    phase: str
+    action: str
+    description: str
+    status: str
+    operation_id: str
+    audit_step_id: str
+    audit_category: str
+    receipt_id: str
+    token_id: str
+    lock_id: str
+    patch_digest: str
+    rollback_source: str
+    expected_result: str
+    required_operator_action: str
+    source_audit_step: dict[str, Any]
+    future_would_restore_memory: bool
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "sequence": self.sequence,
+            "phase": self.phase,
+            "action": self.action,
+            "description": self.description,
+            "status": self.status,
+            "operation_id": self.operation_id,
+            "audit_step_id": self.audit_step_id,
+            "audit_category": self.audit_category,
+            "receipt_id": self.receipt_id,
+            "token_id": self.token_id,
+            "lock_id": self.lock_id,
+            "patch_digest": self.patch_digest,
+            "rollback_source": self.rollback_source,
+            "expected_result": self.expected_result,
+            "required_operator_action": self.required_operator_action,
+            "source_audit_step": dict(self.source_audit_step),
+            "future_would_restore_memory": self.future_would_restore_memory,
+        }
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairRollbackDrillPreview:
+    """One read-only rollback drill preview."""
+
+    id: str
+    status: str
+    trigger: str
+    rollback_mode: str
+    post_commit_audit_id: str
+    executor_preview_id: str
+    receipt_id: str
+    token_id: str
+    lock_id: str
+    operation_ids: tuple[str, ...]
+    patch_digests: tuple[str, ...]
+    failed_audit_step_ids: tuple[str, ...]
+    drill_step_ids: tuple[str, ...]
+    drill_digest: str
+    drill_preview: str
+    steps: tuple[MemoryEvidenceRepairRollbackDrillStep, ...]
+    would_preserve_failed_audit_evidence: bool
+    would_isolate_failed_memory: bool
+    would_restore_snapshots: bool
+    would_reconcile_receipt_token_lock: bool
+    would_rerun_post_commit_audit: bool
+    safety_note: str
+    source_post_commit_audit: dict[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "status": self.status,
+            "trigger": self.trigger,
+            "rollback_mode": self.rollback_mode,
+            "post_commit_audit_id": self.post_commit_audit_id,
+            "executor_preview_id": self.executor_preview_id,
+            "receipt_id": self.receipt_id,
+            "token_id": self.token_id,
+            "lock_id": self.lock_id,
+            "operation_ids": list(self.operation_ids),
+            "patch_digests": list(self.patch_digests),
+            "failed_audit_step_ids": list(self.failed_audit_step_ids),
+            "drill_step_ids": list(self.drill_step_ids),
+            "drill_digest": self.drill_digest,
+            "drill_preview": self.drill_preview,
+            "steps": [step.to_dict() for step in self.steps],
+            "would_preserve_failed_audit_evidence": self.would_preserve_failed_audit_evidence,
+            "would_isolate_failed_memory": self.would_isolate_failed_memory,
+            "would_restore_snapshots": self.would_restore_snapshots,
+            "would_reconcile_receipt_token_lock": self.would_reconcile_receipt_token_lock,
+            "would_rerun_post_commit_audit": self.would_rerun_post_commit_audit,
+            "safety_note": self.safety_note,
+            "source_post_commit_audit": dict(self.source_post_commit_audit),
+        }
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairRollbackDrillPreviewReport:
+    """Read-only rollback drill preview report."""
+
+    generated_at: str
+    status: str
+    checks: tuple[MemoryEvidenceRepairRollbackDrillCheck, ...]
+    previews: tuple[MemoryEvidenceRepairRollbackDrillPreview, ...]
+    blocking_reasons: tuple[str, ...]
+    required_actions: tuple[str, ...]
+    source_post_commit_audit_report: dict[str, Any]
+
+    @property
+    def summary(self) -> dict[str, Any]:
+        by_check_status: dict[str, int] = {}
+        by_trigger: dict[str, int] = {}
+        future_restore_count = 0
+        for check in self.checks:
+            by_check_status[check.status] = by_check_status.get(check.status, 0) + 1
+        for preview in self.previews:
+            by_trigger[preview.trigger] = by_trigger.get(preview.trigger, 0) + 1
+            future_restore_count += sum(
+                1 for step in preview.steps if step.future_would_restore_memory
+            )
+        drill_step_count = sum(len(preview.steps) for preview in self.previews)
+        failed_step_count = sum(
+            len(preview.failed_audit_step_ids) for preview in self.previews
+        )
+        return {
+            "status": self.status,
+            "check_count": len(self.checks),
+            "pass_count": by_check_status.get(CHECK_STATUS_PASS, 0),
+            "fail_count": by_check_status.get(CHECK_STATUS_FAIL, 0),
+            "preview_count": len(self.previews),
+            "drill_step_count": drill_step_count,
+            "failed_audit_step_count": failed_step_count,
+            "future_restore_step_count": future_restore_count,
+            "blocking_reason_count": len(self.blocking_reasons),
+            "required_action_count": len(self.required_actions),
+            "rollback_drill_preview_available": bool(self.previews),
+            "rollback_drill_ready": self.status == ROLLBACK_DRILL_STATUS_READY,
+            "has_blocks": self.status == ROLLBACK_DRILL_STATUS_BLOCKED,
+            "requires_followup": bool(self.required_actions),
+            "by_check_status": by_check_status,
+            "by_trigger": by_trigger,
+        }
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "generated_at": self.generated_at,
+            "status": self.status,
+            "summary": self.summary,
+            "checks": [check.to_dict() for check in self.checks],
+            "previews": [preview.to_dict() for preview in self.previews],
+            "blocking_reasons": list(self.blocking_reasons),
+            "required_actions": list(self.required_actions),
+            "source_post_commit_audit_report": dict(self.source_post_commit_audit_report),
+            "read_only": True,
+            "read_only_memory": True,
+            "would_mutate_memory": False,
+        }
+
+
+def build_evidence_repair_rollback_drill_preview(
+    *,
+    post_commit_audit: Mapping[str, Any] | None = None,
+    rollback_plan: Mapping[str, Any] | None = None,
+    snapshot_plan: Mapping[str, Any] | None = None,
+) -> MemoryEvidenceRepairRollbackDrillPreviewReport:
+    """Build a read-only rollback drill from a post-commit audit report."""
+
+    post_commit_audit = post_commit_audit if isinstance(post_commit_audit, Mapping) else {}
+    rollback_plan = rollback_plan if isinstance(rollback_plan, Mapping) else {}
+    snapshot_plan = snapshot_plan if isinstance(snapshot_plan, Mapping) else {}
+    audit_status = _str(post_commit_audit.get("status"))
+    audit_preview = _extract_audit_preview(post_commit_audit)
+    failed_steps = tuple(_failed_audit_steps(post_commit_audit, audit_preview))
+    executor_preview = _extract_executor_preview(post_commit_audit, audit_preview)
+
+    if not post_commit_audit or audit_status == POST_COMMIT_AUDIT_STATUS_NO_ACTION_NEEDED:
+        return _empty_report(post_commit_audit=post_commit_audit)
+
+    if not audit_preview and not failed_steps:
+        return _blocked_report(
+            post_commit_audit=post_commit_audit,
+            checks=(
+                _fail(
+                    CHECK_POST_COMMIT_AUDIT_AVAILABLE,
+                    "No usable post-commit audit preview or observed audit failure was supplied.",
+                    tuple(_list_of_str(post_commit_audit.get("required_actions")))
+                    or ("produce_post_commit_audit_preview",),
+                    {"post_commit_audit_status": audit_status},
+                ),
+            ),
+        )
+
+    if (
+        audit_status
+        and audit_status not in {POST_COMMIT_AUDIT_STATUS_READY, POST_COMMIT_AUDIT_STATUS_BLOCKED}
+        and not audit_preview
+    ):
+        return _blocked_report(
+            post_commit_audit=post_commit_audit,
+            checks=(
+                _fail(
+                    CHECK_POST_COMMIT_AUDIT_AVAILABLE,
+                    "Post-commit audit status is not ready for rollback drill planning.",
+                    ("produce_ready_or_failed_post_commit_audit",),
+                    {"post_commit_audit_status": audit_status},
+                ),
+            ),
+        )
+
+    checks = (
+        _post_commit_audit_available_check(
+            post_commit_audit=post_commit_audit,
+            audit_preview=audit_preview,
+            failed_steps=failed_steps,
+        ),
+        _audit_failure_context_check(failed_steps=failed_steps, audit_preview=audit_preview),
+        _rollback_drill_sources_check(
+            rollback_plan=rollback_plan,
+            snapshot_plan=snapshot_plan,
+            audit_preview=audit_preview,
+            executor_preview=executor_preview,
+        ),
+    )
+    blocking_reasons = tuple(
+        _dedupe_strings(check.reason for check in checks if check.status == CHECK_STATUS_FAIL)
+    )
+    required_actions = tuple(
+        _dedupe_strings(
+            action
+            for check in checks
+            if check.status == CHECK_STATUS_FAIL
+            for action in check.required_actions
+        )
+    )
+    if blocking_reasons:
+        return MemoryEvidenceRepairRollbackDrillPreviewReport(
+            generated_at=datetime.now(timezone.utc).isoformat(),
+            status=ROLLBACK_DRILL_STATUS_BLOCKED,
+            checks=checks,
+            previews=(),
+            blocking_reasons=blocking_reasons,
+            required_actions=required_actions,
+            source_post_commit_audit_report=dict(post_commit_audit),
+        )
+
+    preview = _preview_from_audit(
+        post_commit_audit=post_commit_audit,
+        audit_preview=audit_preview,
+        failed_steps=failed_steps,
+        executor_preview=executor_preview,
+        rollback_plan=rollback_plan,
+        snapshot_plan=snapshot_plan,
+    )
+    return MemoryEvidenceRepairRollbackDrillPreviewReport(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        status=ROLLBACK_DRILL_STATUS_READY,
+        checks=checks,
+        previews=(preview,),
+        blocking_reasons=(),
+        required_actions=(),
+        source_post_commit_audit_report=dict(post_commit_audit),
+    )
+
+
+def empty_evidence_repair_rollback_drill_preview() -> MemoryEvidenceRepairRollbackDrillPreviewReport:
+    """Return an empty read-only rollback drill preview."""
+
+    return _empty_report(post_commit_audit={})
+
+
+def _post_commit_audit_available_check(
+    *,
+    post_commit_audit: Mapping[str, Any],
+    audit_preview: Mapping[str, Any],
+    failed_steps: Sequence[Mapping[str, Any]],
+) -> MemoryEvidenceRepairRollbackDrillCheck:
+    audit_status = _str(post_commit_audit.get("status"))
+    if audit_preview or failed_steps:
+        return _pass(
+            CHECK_POST_COMMIT_AUDIT_AVAILABLE,
+            "Post-commit audit context is available for rollback drill planning.",
+            {
+                "post_commit_audit_status": audit_status,
+                "audit_preview_id": _str(audit_preview.get("id")),
+                "failed_audit_step_count": len(failed_steps),
+            },
+        )
+    return _fail(
+        CHECK_POST_COMMIT_AUDIT_AVAILABLE,
+        "No post-commit audit preview or failure context is available.",
+        ("produce_post_commit_audit_preview",),
+        {"post_commit_audit_status": audit_status},
+    )
+
+
+def _audit_failure_context_check(
+    *,
+    failed_steps: Sequence[Mapping[str, Any]],
+    audit_preview: Mapping[str, Any],
+) -> MemoryEvidenceRepairRollbackDrillCheck:
+    if failed_steps:
+        return _pass(
+            CHECK_AUDIT_FAILURE_CONTEXT,
+            "Observed audit failures can drive a rollback drill.",
+            {"failed_audit_step_ids": [_str(step.get("id")) for step in failed_steps]},
+        )
+    return _pass(
+        CHECK_AUDIT_FAILURE_CONTEXT,
+        "No observed audit failure supplied; rollback drill remains a preparedness rehearsal.",
+        {
+            "audit_preview_id": _str(audit_preview.get("id")),
+            "trigger": ROLLBACK_DRILL_TRIGGER_PREPAREDNESS,
+        },
+    )
+
+
+def _rollback_drill_sources_check(
+    *,
+    rollback_plan: Mapping[str, Any],
+    snapshot_plan: Mapping[str, Any],
+    audit_preview: Mapping[str, Any],
+    executor_preview: Mapping[str, Any],
+) -> MemoryEvidenceRepairRollbackDrillCheck:
+    sources = _rollback_sources(
+        rollback_plan=rollback_plan,
+        snapshot_plan=snapshot_plan,
+        audit_preview=audit_preview,
+        executor_preview=executor_preview,
+    )
+    return _pass(
+        CHECK_ROLLBACK_DRILL_SOURCES,
+        "Rollback drill source references are captured for future human verification.",
+        {"sources": sources},
+    )
+
+
+def _preview_from_audit(
+    *,
+    post_commit_audit: Mapping[str, Any],
+    audit_preview: Mapping[str, Any],
+    failed_steps: Sequence[Mapping[str, Any]],
+    executor_preview: Mapping[str, Any],
+    rollback_plan: Mapping[str, Any],
+    snapshot_plan: Mapping[str, Any],
+) -> MemoryEvidenceRepairRollbackDrillPreview:
+    trigger = (
+        ROLLBACK_DRILL_TRIGGER_AUDIT_FAILURE
+        if failed_steps
+        else ROLLBACK_DRILL_TRIGGER_PREPAREDNESS
+    )
+    operation_ids = tuple(
+        _operation_ids(
+            audit_preview=audit_preview,
+            executor_preview=executor_preview,
+            failed_steps=failed_steps,
+        )
+    )
+    patch_digests = tuple(
+        _patch_digests(
+            audit_preview=audit_preview,
+            executor_preview=executor_preview,
+            operation_ids=operation_ids,
+        )
+    )
+    receipt_id = _first_nonempty(
+        _str(audit_preview.get("receipt_id")),
+        _str(executor_preview.get("receipt_id")),
+        _first_from_steps(failed_steps, "receipt_id"),
+    )
+    token_id = _first_nonempty(
+        _str(audit_preview.get("token_id")),
+        _str(executor_preview.get("token_id")),
+        _first_from_steps(failed_steps, "token_id"),
+    )
+    lock_id = _first_nonempty(
+        _str(audit_preview.get("lock_id")),
+        _str(executor_preview.get("lock_id")),
+        _first_from_steps(failed_steps, "lock_id"),
+    )
+    steps = tuple(
+        _drill_steps(
+            trigger=trigger,
+            operation_ids=operation_ids,
+            patch_digests=patch_digests,
+            failed_steps=failed_steps,
+            receipt_id=receipt_id,
+            token_id=token_id,
+            lock_id=lock_id,
+            rollback_plan=rollback_plan,
+            snapshot_plan=snapshot_plan,
+            executor_preview=executor_preview,
+        )
+    )
+    drill_step_ids = tuple(step.id for step in steps)
+    failed_step_ids = tuple(
+        _dedupe_strings(_str(step.get("id")) for step in failed_steps)
+    )
+    drill_seed = {
+        "trigger": trigger,
+        "post_commit_audit_id": _str(audit_preview.get("id")),
+        "executor_preview_id": _str(executor_preview.get("id")),
+        "receipt_id": receipt_id,
+        "token_id": token_id,
+        "lock_id": lock_id,
+        "operation_ids": operation_ids,
+        "patch_digests": patch_digests,
+        "failed_audit_step_ids": failed_step_ids,
+        "drill_step_ids": drill_step_ids,
+    }
+    drill_digest = _digest(drill_seed)
+    drill_id = f"rollback-drill-{drill_digest[:16]}"
+    return MemoryEvidenceRepairRollbackDrillPreview(
+        id=drill_id,
+        status=ROLLBACK_DRILL_STATUS_READY,
+        trigger=trigger,
+        rollback_mode="failure_response" if failed_steps else "preparedness_rehearsal",
+        post_commit_audit_id=_str(audit_preview.get("id")),
+        executor_preview_id=_str(executor_preview.get("id")),
+        receipt_id=receipt_id,
+        token_id=token_id,
+        lock_id=lock_id,
+        operation_ids=operation_ids,
+        patch_digests=patch_digests,
+        failed_audit_step_ids=failed_step_ids,
+        drill_step_ids=drill_step_ids,
+        drill_digest=drill_digest,
+        drill_preview=f"{drill_id}:{drill_digest[:12]}",
+        steps=steps,
+        would_preserve_failed_audit_evidence=True,
+        would_isolate_failed_memory=True,
+        would_restore_snapshots=True,
+        would_reconcile_receipt_token_lock=True,
+        would_rerun_post_commit_audit=True,
+        safety_note=(
+            "Read-only rollback drill preview. It rehearses future isolation, "
+            "snapshot restoration, reconciliation, and re-audit steps but does "
+            "not mutate durable memory."
+        ),
+        source_post_commit_audit=dict(post_commit_audit),
+    )
+
+
+def _drill_steps(
+    *,
+    trigger: str,
+    operation_ids: Sequence[str],
+    patch_digests: Sequence[str],
+    failed_steps: Sequence[Mapping[str, Any]],
+    receipt_id: str,
+    token_id: str,
+    lock_id: str,
+    rollback_plan: Mapping[str, Any],
+    snapshot_plan: Mapping[str, Any],
+    executor_preview: Mapping[str, Any],
+) -> list[MemoryEvidenceRepairRollbackDrillStep]:
+    steps: list[MemoryEvidenceRepairRollbackDrillStep] = []
+    failure_mode = trigger == ROLLBACK_DRILL_TRIGGER_AUDIT_FAILURE
+    source_step = failed_steps[0] if failed_steps else {}
+    steps.append(
+        _step(
+            sequence=1,
+            phase="preserve",
+            action=(
+                "preserve_failed_audit_context"
+                if failure_mode
+                else "prepare_rollback_context"
+            ),
+            description=(
+                "Preserve the failed post-commit audit report, executor preview, and observed signals."
+                if failure_mode
+                else "Prepare the audit, executor, receipt, token, and lock context for a future rollback rehearsal."
+            ),
+            operation_id="",
+            source_step=source_step,
+            receipt_id=receipt_id,
+            token_id=token_id,
+            lock_id=lock_id,
+            expected_result="rollback_drill_context_preserved",
+            required_operator_action="archive_audit_report_executor_preview_and_observed_signals",
+        )
+    )
+    steps.append(
+        _step(
+            sequence=2,
+            phase="isolation",
+            action=(
+                "isolate_impacted_memory_records"
+                if failure_mode
+                else "define_impacted_operation_isolation"
+            ),
+            description=(
+                "Identify and isolate memory records touched by failed audit steps before any manual rollback."
+                if failure_mode
+                else "Define which memory records would be isolated if the post-commit audit later fails."
+            ),
+            operation_id=",".join(operation_ids),
+            source_step=source_step,
+            receipt_id=receipt_id,
+            token_id=token_id,
+            lock_id=lock_id,
+            expected_result="impacted_operations_isolated_for_review",
+            required_operator_action="mark_impacted_operations_read_only_until_review_completes",
+        )
+    )
+    next_sequence = 3
+    restore_targets = list(operation_ids) or [""]
+    for index, operation_id in enumerate(restore_targets):
+        patch_digest = patch_digests[index] if index < len(patch_digests) else ""
+        steps.append(
+            _step(
+                sequence=next_sequence,
+                phase="restore",
+                action=(
+                    "restore_from_pre_commit_snapshot_or_rollback_plan"
+                    if failure_mode
+                    else "verify_pre_commit_snapshot_or_rollback_plan"
+                ),
+                description=(
+                    "Restore the impacted operation from its pre-commit snapshot or approved rollback plan."
+                    if failure_mode
+                    else "Verify a pre-commit snapshot or rollback plan exists for the operation before any future write."
+                ),
+                operation_id=operation_id,
+                source_step=_failed_step_for_operation(failed_steps, operation_id),
+                receipt_id=receipt_id,
+                token_id=token_id,
+                lock_id=lock_id,
+                patch_digest=patch_digest,
+                rollback_source=_rollback_source_for_operation(
+                    operation_id=operation_id,
+                    patch_digest=patch_digest,
+                    rollback_plan=rollback_plan,
+                    snapshot_plan=snapshot_plan,
+                    executor_preview=executor_preview,
+                ),
+                expected_result="pre_commit_state_restored_or_verified",
+                required_operator_action="verify_snapshot_digest_then_restore_manually",
+                future_would_restore_memory=failure_mode,
+            )
+        )
+        next_sequence += 1
+    steps.append(
+        _step(
+            sequence=next_sequence,
+            phase="reconcile",
+            action="reconcile_commit_receipt_token_and_lock",
+            description="Reconcile receipt, approval-token, and write-lock state after rollback handling.",
+            operation_id="",
+            source_step=source_step,
+            receipt_id=receipt_id,
+            token_id=token_id,
+            lock_id=lock_id,
+            expected_result="receipt_token_lock_state_consistent",
+            required_operator_action="verify_receipt_token_and_lock_state_before_unlocking_future_writes",
+        )
+    )
+    next_sequence += 1
+    steps.append(
+        _step(
+            sequence=next_sequence,
+            phase="audit",
+            action="rerun_post_commit_audit",
+            description="Rerun the post-commit audit after rollback or preparedness checks complete.",
+            operation_id="",
+            source_step=source_step,
+            receipt_id=receipt_id,
+            token_id=token_id,
+            lock_id=lock_id,
+            expected_result="post_commit_audit_passes_after_rollback_drill",
+            required_operator_action="rerun_memory_evidence_repair_post_commit_audit_preview",
+        )
+    )
+    return steps
+
+
+def _step(
+    *,
+    sequence: int,
+    phase: str,
+    action: str,
+    description: str,
+    operation_id: str,
+    source_step: Mapping[str, Any],
+    receipt_id: str,
+    token_id: str,
+    lock_id: str,
+    expected_result: str,
+    required_operator_action: str,
+    patch_digest: str = "",
+    rollback_source: str = "",
+    future_would_restore_memory: bool = False,
+) -> MemoryEvidenceRepairRollbackDrillStep:
+    audit_step_id = _str(source_step.get("id"))
+    audit_category = _str(source_step.get("category"))
+    if not patch_digest:
+        patch_digest = _patch_digest_from_audit_step(source_step)
+    if not rollback_source:
+        rollback_source = "pre_commit_snapshot_or_rollback_plan_required"
+    return MemoryEvidenceRepairRollbackDrillStep(
+        id=f"rollback-drill-step-{sequence}-{action}",
+        sequence=sequence,
+        phase=phase,
+        action=action,
+        description=description,
+        status=DRILL_STEP_STATUS_PLANNED,
+        operation_id=operation_id,
+        audit_step_id=audit_step_id,
+        audit_category=audit_category,
+        receipt_id=receipt_id or _str(source_step.get("receipt_id")),
+        token_id=token_id or _str(source_step.get("token_id")),
+        lock_id=lock_id or _str(source_step.get("lock_id")),
+        patch_digest=patch_digest,
+        rollback_source=rollback_source,
+        expected_result=expected_result,
+        required_operator_action=required_operator_action,
+        source_audit_step=dict(source_step),
+        future_would_restore_memory=future_would_restore_memory,
+    )
+
+
+def _extract_audit_preview(post_commit_audit: Mapping[str, Any]) -> dict[str, Any]:
+    previews = post_commit_audit.get("previews")
+    if isinstance(previews, list):
+        for preview in previews:
+            if isinstance(preview, Mapping):
+                return dict(preview)
+    if _str(post_commit_audit.get("id")).startswith("post-commit-audit-"):
+        return dict(post_commit_audit)
+    return {}
+
+
+def _failed_audit_steps(
+    post_commit_audit: Mapping[str, Any],
+    audit_preview: Mapping[str, Any],
+) -> list[Mapping[str, Any]]:
+    steps: list[Mapping[str, Any]] = []
+    for step in _list(audit_preview.get("audit_steps")):
+        if isinstance(step, Mapping) and _str(step.get("status")) == AUDIT_STEP_STATUS_FAIL:
+            steps.append(dict(step))
+    for check in _list(post_commit_audit.get("checks")):
+        if not isinstance(check, Mapping):
+            continue
+        details = _dict(check.get("details"))
+        for failure in _list(details.get("failures")):
+            if isinstance(failure, Mapping):
+                steps.append(dict(failure))
+    return _dedupe_steps(steps)
+
+
+def _extract_executor_preview(
+    post_commit_audit: Mapping[str, Any],
+    audit_preview: Mapping[str, Any],
+) -> dict[str, Any]:
+    source = audit_preview.get("source_executor_preview")
+    if isinstance(source, Mapping):
+        return dict(source)
+    source_report = post_commit_audit.get("source_executor_preview_report")
+    if isinstance(source_report, Mapping):
+        previews = source_report.get("previews")
+        if isinstance(previews, list):
+            for preview in previews:
+                if isinstance(preview, Mapping):
+                    return dict(preview)
+        if _str(source_report.get("id")).startswith("executor-preview-"):
+            return dict(source_report)
+    return {}
+
+
+def _operation_ids(
+    *,
+    audit_preview: Mapping[str, Any],
+    executor_preview: Mapping[str, Any],
+    failed_steps: Sequence[Mapping[str, Any]],
+) -> list[str]:
+    ids: list[str] = []
+    ids.extend(_list_of_str(audit_preview.get("operation_ids")))
+    ids.extend(_list_of_str(executor_preview.get("operation_ids")))
+    ids.extend(_str(step.get("operation_id")) for step in failed_steps)
+    if not ids and failed_steps:
+        ids.extend(_list_of_str(executor_preview.get("operation_ids")))
+    return _dedupe_strings(ids)
+
+
+def _patch_digests(
+    *,
+    audit_preview: Mapping[str, Any],
+    executor_preview: Mapping[str, Any],
+    operation_ids: Sequence[str],
+) -> list[str]:
+    digests = _list_of_str(audit_preview.get("patch_digests"))
+    if digests:
+        return digests
+    digests = _list_of_str(executor_preview.get("patch_digests"))
+    if digests:
+        return digests
+    steps = [
+        step
+        for step in _list(executor_preview.get("steps"))
+        if isinstance(step, Mapping) and step.get("future_would_write_memory") is True
+    ]
+    by_operation = {_str(step.get("operation_id")): _str(step.get("patch_digest")) for step in steps}
+    return [by_operation.get(operation_id, "") for operation_id in operation_ids]
+
+
+def _rollback_sources(
+    *,
+    rollback_plan: Mapping[str, Any],
+    snapshot_plan: Mapping[str, Any],
+    audit_preview: Mapping[str, Any],
+    executor_preview: Mapping[str, Any],
+) -> list[str]:
+    sources: list[str] = []
+    if rollback_plan:
+        sources.append("rollback_plan")
+    if snapshot_plan:
+        sources.append("snapshot_plan")
+    if audit_preview:
+        sources.append("post_commit_audit_preview")
+    if executor_preview:
+        sources.append("executor_preview")
+    if not sources:
+        sources.append("operator_supplied_pre_commit_snapshot_required")
+    return _dedupe_strings(sources)
+
+
+def _rollback_source_for_operation(
+    *,
+    operation_id: str,
+    patch_digest: str,
+    rollback_plan: Mapping[str, Any],
+    snapshot_plan: Mapping[str, Any],
+    executor_preview: Mapping[str, Any],
+) -> str:
+    if _matches_plan(rollback_plan, operation_id=operation_id, patch_digest=patch_digest):
+        return "provided_rollback_plan"
+    if _matches_plan(snapshot_plan, operation_id=operation_id, patch_digest=patch_digest):
+        return "provided_snapshot_plan"
+    if executor_preview:
+        return "executor_preview_rollback_hint"
+    return "pre_commit_snapshot_or_rollback_plan_required"
+
+
+def _matches_plan(plan: Mapping[str, Any], *, operation_id: str, patch_digest: str) -> bool:
+    if not plan:
+        return False
+    rows = []
+    for key in ("steps", "plans", "snapshots", "previews"):
+        rows.extend(item for item in _list(plan.get(key)) if isinstance(item, Mapping))
+    if not rows and plan:
+        rows.append(plan)
+    for row in rows:
+        if operation_id and operation_id in {
+            _str(row.get("operation_id")),
+            _str(row.get("id")),
+            _str(row.get("source_operation_id")),
+            _str(row.get("ledger_entry_id")),
+        }:
+            return True
+        if patch_digest and patch_digest == _str(row.get("patch_digest")):
+            return True
+    return False
+
+
+def _failed_step_for_operation(
+    failed_steps: Sequence[Mapping[str, Any]],
+    operation_id: str,
+) -> Mapping[str, Any]:
+    for step in failed_steps:
+        if _str(step.get("operation_id")) == operation_id:
+            return step
+    return failed_steps[0] if failed_steps else {}
+
+
+def _patch_digest_from_audit_step(step: Mapping[str, Any]) -> str:
+    expected = _dict(step.get("expected_signal"))
+    return _str(expected.get("patch_digest"))
+
+
+def _first_from_steps(steps: Sequence[Mapping[str, Any]], field_name: str) -> str:
+    for step in steps:
+        value = _str(step.get(field_name))
+        if value:
+            return value
+    return ""
+
+
+def _first_nonempty(*values: str) -> str:
+    for value in values:
+        if value:
+            return value
+    return ""
+
+
+def _empty_report(
+    *,
+    post_commit_audit: Mapping[str, Any],
+) -> MemoryEvidenceRepairRollbackDrillPreviewReport:
+    return MemoryEvidenceRepairRollbackDrillPreviewReport(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        status=ROLLBACK_DRILL_STATUS_NO_ACTION_NEEDED,
+        checks=(),
+        previews=(),
+        blocking_reasons=(),
+        required_actions=(),
+        source_post_commit_audit_report=dict(post_commit_audit),
+    )
+
+
+def _blocked_report(
+    *,
+    post_commit_audit: Mapping[str, Any],
+    checks: tuple[MemoryEvidenceRepairRollbackDrillCheck, ...],
+) -> MemoryEvidenceRepairRollbackDrillPreviewReport:
+    return MemoryEvidenceRepairRollbackDrillPreviewReport(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        status=ROLLBACK_DRILL_STATUS_BLOCKED,
+        checks=checks,
+        previews=(),
+        blocking_reasons=tuple(
+            _dedupe_strings(check.reason for check in checks if check.status == CHECK_STATUS_FAIL)
+        ),
+        required_actions=tuple(
+            _dedupe_strings(
+                action
+                for check in checks
+                if check.status == CHECK_STATUS_FAIL
+                for action in check.required_actions
+            )
+        ),
+        source_post_commit_audit_report=dict(post_commit_audit),
+    )
+
+
+def _pass(
+    check_id: str,
+    reason: str,
+    details: Mapping[str, Any],
+) -> MemoryEvidenceRepairRollbackDrillCheck:
+    return MemoryEvidenceRepairRollbackDrillCheck(
+        id=check_id,
+        status=CHECK_STATUS_PASS,
+        reason=reason,
+        required_actions=(),
+        details=dict(details),
+    )
+
+
+def _fail(
+    check_id: str,
+    reason: str,
+    required_actions: Sequence[str],
+    details: Mapping[str, Any],
+) -> MemoryEvidenceRepairRollbackDrillCheck:
+    return MemoryEvidenceRepairRollbackDrillCheck(
+        id=check_id,
+        status=CHECK_STATUS_FAIL,
+        reason=reason,
+        required_actions=tuple(required_actions),
+        details=dict(details),
+    )
+
+
+def _dedupe_steps(steps: Sequence[Mapping[str, Any]]) -> list[Mapping[str, Any]]:
+    seen: set[str] = set()
+    result: list[Mapping[str, Any]] = []
+    for step in steps:
+        key = _str(step.get("id")) or _digest(step)
+        if key in seen:
+            continue
+        seen.add(key)
+        result.append(step)
+    return result
+
+
+def _digest(value: Any) -> str:
+    raw = json.dumps(value, sort_keys=True, ensure_ascii=False, default=str)
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def _dict(value: Any) -> dict[str, Any]:
+    return dict(value) if isinstance(value, Mapping) else {}
+
+
+def _list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _list_of_str(value: Any) -> list[str]:
+    return [_str(item) for item in value] if isinstance(value, list) else []
+
+
+def _dedupe_strings(values: Sequence[str] | Any) -> list[str]:
+    seen: set[str] = set()
+    result: list[str] = []
+    for value in values:
+        text = _str(value)
+        if text and text not in seen:
+            seen.add(text)
+            result.append(text)
+    return result
+
+
+def _str(value: Any) -> str:
+    return str(value or "").strip()

--- a/agent/memory_evidence_repair_rollback_plan.py
+++ b/agent/memory_evidence_repair_rollback_plan.py
@@ -1,0 +1,370 @@
+"""Read-only rollback plans for memory evidence repair ledger entries.
+
+The rollback layer drafts how to undo a future manual evidence repair write.
+It never writes to durable memory stores.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Mapping, Sequence
+
+from agent.memory_evidence_repair_commit_ledger import OUTCOME_ALLOWED
+
+
+ROLLBACK_ACTION_RESTORE_EVIDENCE_METADATA = "restore_evidence_metadata"
+ROLLBACK_ACTION_NOOP = "no_rollback_required"
+ROLLBACK_STATUS_READY_FOR_MANUAL_ROLLBACK = "ready_for_manual_rollback"
+ROLLBACK_STATUS_SNAPSHOT_REQUIRED = "snapshot_required"
+ROLLBACK_STATUS_NO_ACTION_NEEDED = "no_action_needed"
+SNAPSHOT_REQUIRED_VALUE = "<requires_pre_commit_snapshot>"
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairRollbackStep:
+    """One read-only rollback step draft."""
+
+    id: str
+    ledger_entry_id: str
+    sequence: int
+    status: str
+    rollback_action: str
+    outcome: str
+    provider: str
+    repair_action: str
+    candidate_id: str
+    preview_id: str
+    patch_digest: str
+    evidence_fields: tuple[str, ...]
+    target: dict[str, Any]
+    inverse_patch_preview: dict[str, Any]
+    required_preconditions: tuple[str, ...]
+    verification_steps: tuple[str, ...]
+    reason: str
+    safety_note: str
+    source_entry: dict[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "ledger_entry_id": self.ledger_entry_id,
+            "sequence": self.sequence,
+            "status": self.status,
+            "rollback_action": self.rollback_action,
+            "outcome": self.outcome,
+            "provider": self.provider,
+            "repair_action": self.repair_action,
+            "candidate_id": self.candidate_id,
+            "preview_id": self.preview_id,
+            "patch_digest": self.patch_digest,
+            "evidence_fields": list(self.evidence_fields),
+            "target": dict(self.target),
+            "inverse_patch_preview": dict(self.inverse_patch_preview),
+            "required_preconditions": list(self.required_preconditions),
+            "verification_steps": list(self.verification_steps),
+            "reason": self.reason,
+            "safety_note": self.safety_note,
+            "source_entry": dict(self.source_entry),
+        }
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairRollbackPlan:
+    """Read-only rollback plan draft."""
+
+    generated_at: str
+    steps: tuple[MemoryEvidenceRepairRollbackStep, ...]
+
+    @property
+    def summary(self) -> dict[str, Any]:
+        by_status: dict[str, int] = {}
+        by_provider: dict[str, int] = {}
+        by_repair_action: dict[str, int] = {}
+        ready_count = 0
+        snapshot_required_count = 0
+        no_action_count = 0
+        for step in self.steps:
+            by_status[step.status] = by_status.get(step.status, 0) + 1
+            by_repair_action[step.repair_action] = (
+                by_repair_action.get(step.repair_action, 0) + 1
+            )
+            if step.provider:
+                by_provider[step.provider] = by_provider.get(step.provider, 0) + 1
+            if step.status == ROLLBACK_STATUS_READY_FOR_MANUAL_ROLLBACK:
+                ready_count += 1
+            elif step.status == ROLLBACK_STATUS_SNAPSHOT_REQUIRED:
+                snapshot_required_count += 1
+            elif step.status == ROLLBACK_STATUS_NO_ACTION_NEEDED:
+                no_action_count += 1
+        return {
+            "rollback_step_count": len(self.steps),
+            "ready_count": ready_count,
+            "snapshot_required_count": snapshot_required_count,
+            "no_action_count": no_action_count,
+            "by_status": by_status,
+            "by_provider": by_provider,
+            "by_repair_action": by_repair_action,
+            "requires_snapshot": snapshot_required_count > 0,
+            "has_ready_rollbacks": ready_count > 0,
+        }
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "generated_at": self.generated_at,
+            "summary": self.summary,
+            "steps": [step.to_dict() for step in self.steps],
+            "read_only": True,
+            "read_only_memory": True,
+            "would_mutate_memory": False,
+        }
+
+
+def build_evidence_repair_rollback_plan(
+    *,
+    ledger: Mapping[str, Any] | None = None,
+    entries: Sequence[Mapping[str, Any]] | None = None,
+    pre_commit_snapshots: Mapping[str, Any] | None = None,
+) -> MemoryEvidenceRepairRollbackPlan:
+    """Build a read-only rollback plan from commit ledger entries."""
+
+    ledger = ledger if isinstance(ledger, Mapping) else {}
+    pre_commit_snapshots = (
+        pre_commit_snapshots if isinstance(pre_commit_snapshots, Mapping) else {}
+    )
+    rows = _entry_rows(ledger=ledger, entries=entries)
+    steps: list[MemoryEvidenceRepairRollbackStep] = []
+    for index, row in enumerate(rows, start=1):
+        if not isinstance(row, Mapping):
+            continue
+        step = _step_from_entry(
+            row,
+            sequence=index,
+            pre_commit_snapshots=pre_commit_snapshots,
+        )
+        if step is not None:
+            steps.append(step)
+
+    return MemoryEvidenceRepairRollbackPlan(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        steps=tuple(_dedupe_steps(steps)),
+    )
+
+
+def empty_evidence_repair_rollback_plan() -> MemoryEvidenceRepairRollbackPlan:
+    """Return an empty read-only rollback plan."""
+
+    return MemoryEvidenceRepairRollbackPlan(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        steps=(),
+    )
+
+
+def _step_from_entry(
+    entry: Mapping[str, Any],
+    *,
+    sequence: int,
+    pre_commit_snapshots: Mapping[str, Any],
+) -> MemoryEvidenceRepairRollbackStep | None:
+    entry_id = _str(entry.get("id"))
+    outcome = _str(entry.get("outcome"))
+    candidate_id = _str(entry.get("candidate_id"))
+    preview_id = _str(entry.get("preview_id"))
+    if not entry_id and not outcome and not candidate_id and not preview_id:
+        return None
+
+    evidence_fields = _evidence_fields(entry)
+    snapshot = _snapshot_for_entry(entry, pre_commit_snapshots, evidence_fields)
+    allowed = _is_allowed(entry)
+    status = _status_for_entry(allowed=allowed, snapshot=snapshot)
+    rollback_action = (
+        ROLLBACK_ACTION_RESTORE_EVIDENCE_METADATA
+        if allowed
+        else ROLLBACK_ACTION_NOOP
+    )
+    inverse_patch = _inverse_patch_preview(
+        entry=entry,
+        allowed=allowed,
+        snapshot=snapshot,
+    )
+    return MemoryEvidenceRepairRollbackStep(
+        id=_stable_step_id(entry_id=entry_id, patch_digest=_str(entry.get("patch_digest"))),
+        ledger_entry_id=entry_id,
+        sequence=sequence,
+        status=status,
+        rollback_action=rollback_action,
+        outcome=outcome,
+        provider=_str(entry.get("provider")) or "memory",
+        repair_action=_str(entry.get("repair_action")) or "attach_provenance",
+        candidate_id=candidate_id,
+        preview_id=preview_id,
+        patch_digest=_str(entry.get("patch_digest")),
+        evidence_fields=evidence_fields,
+        target=_dict(entry.get("target")),
+        inverse_patch_preview=inverse_patch,
+        required_preconditions=_required_preconditions(status),
+        verification_steps=_verification_steps(status),
+        reason=_reason(status, outcome),
+        safety_note=(
+            "Read-only rollback plan. This step describes a future manual "
+            "rollback path and does not mutate durable memory."
+        ),
+        source_entry=dict(entry),
+    )
+
+
+def _entry_rows(
+    *,
+    ledger: Mapping[str, Any],
+    entries: Sequence[Mapping[str, Any]] | None,
+) -> list[Any]:
+    if entries is not None:
+        return list(entries)
+    if "outcome" in ledger:
+        return [ledger]
+    value = ledger.get("entries")
+    return value if isinstance(value, list) else []
+
+
+def _is_allowed(entry: Mapping[str, Any]) -> bool:
+    return bool(entry.get("manual_commit_allowed")) or _str(entry.get("outcome")) == OUTCOME_ALLOWED
+
+
+def _status_for_entry(*, allowed: bool, snapshot: dict[str, Any] | None) -> str:
+    if not allowed:
+        return ROLLBACK_STATUS_NO_ACTION_NEEDED
+    if snapshot is None:
+        return ROLLBACK_STATUS_SNAPSHOT_REQUIRED
+    return ROLLBACK_STATUS_READY_FOR_MANUAL_ROLLBACK
+
+
+def _inverse_patch_preview(
+    *,
+    entry: Mapping[str, Any],
+    allowed: bool,
+    snapshot: dict[str, Any] | None,
+) -> dict[str, Any]:
+    if not allowed:
+        return {
+            "operation": ROLLBACK_ACTION_NOOP,
+            "reason": "Ledger entry was not allowed for manual commit.",
+        }
+    return {
+        "operation": ROLLBACK_ACTION_RESTORE_EVIDENCE_METADATA,
+        "target": _dict(entry.get("target")),
+        "set": {
+            "evidence": snapshot if snapshot is not None else SNAPSHOT_REQUIRED_VALUE,
+        },
+        "verify_patch_digest": _str(entry.get("patch_digest")),
+        "source_ledger_entry_id": _str(entry.get("id")),
+    }
+
+
+def _required_preconditions(status: str) -> tuple[str, ...]:
+    if status == ROLLBACK_STATUS_NO_ACTION_NEEDED:
+        return ()
+    preconditions = ["explicit_user_confirmation", "verify_patch_digest_matches_ledger"]
+    if status == ROLLBACK_STATUS_SNAPSHOT_REQUIRED:
+        preconditions.append("capture_pre_commit_snapshot_before_apply")
+    if status == ROLLBACK_STATUS_READY_FOR_MANUAL_ROLLBACK:
+        preconditions.append("manual_rollback_only")
+    return tuple(preconditions)
+
+
+def _verification_steps(status: str) -> tuple[str, ...]:
+    if status == ROLLBACK_STATUS_NO_ACTION_NEEDED:
+        return ("verify_no_manual_commit_occurred",)
+    steps = [
+        "verify_target_matches_ledger_entry",
+        "verify_patch_digest_matches_ledger",
+        "manual_review_before_rollback",
+    ]
+    if status == ROLLBACK_STATUS_READY_FOR_MANUAL_ROLLBACK:
+        steps.append("restore_previous_evidence_metadata")
+    else:
+        steps.append("capture_pre_commit_snapshot_before_apply")
+    return tuple(steps)
+
+
+def _reason(status: str, outcome: str) -> str:
+    if status == ROLLBACK_STATUS_NO_ACTION_NEEDED:
+        return f"Ledger outcome {outcome or 'unknown'} does not require rollback."
+    if status == ROLLBACK_STATUS_SNAPSHOT_REQUIRED:
+        return "Allowed entry needs a pre-commit evidence snapshot before rollback can be ready."
+    return "Allowed entry has a pre-commit evidence snapshot and can be manually rolled back."
+
+
+def _snapshot_for_entry(
+    entry: Mapping[str, Any],
+    pre_commit_snapshots: Mapping[str, Any],
+    evidence_fields: tuple[str, ...],
+) -> dict[str, Any] | None:
+    keys = (
+        _str(entry.get("id")),
+        _str(entry.get("candidate_id")),
+        _str(entry.get("preview_id")),
+        _str(entry.get("decision_id")),
+        _str(entry.get("patch_digest")),
+    )
+    for key in keys:
+        if key and key in pre_commit_snapshots:
+            return _snapshot_evidence(pre_commit_snapshots.get(key))
+    if evidence_fields and any(field in pre_commit_snapshots for field in evidence_fields):
+        return {field: pre_commit_snapshots.get(field) for field in evidence_fields}
+    return None
+
+
+def _snapshot_evidence(value: Any) -> dict[str, Any] | None:
+    if not isinstance(value, Mapping):
+        return None
+    evidence = value.get("evidence")
+    if isinstance(evidence, Mapping):
+        return dict(evidence)
+    return dict(value)
+
+
+def _evidence_fields(entry: Mapping[str, Any]) -> tuple[str, ...]:
+    fields = entry.get("evidence_fields")
+    if isinstance(fields, list):
+        parsed = tuple(_str(field) for field in fields if _str(field))
+        if parsed:
+            return parsed
+    source_decision = entry.get("source_decision")
+    if isinstance(source_decision, Mapping):
+        evidence_patch = source_decision.get("evidence_patch")
+        if isinstance(evidence_patch, Mapping):
+            return tuple(str(field) for field in evidence_patch.keys())
+    return ()
+
+
+def _stable_step_id(*, entry_id: str, patch_digest: str) -> str:
+    raw = json.dumps(
+        {"entry_id": entry_id, "patch_digest": patch_digest},
+        sort_keys=True,
+        ensure_ascii=False,
+    )
+    digest = hashlib.sha256(raw.encode("utf-8")).hexdigest()[:16]
+    return f"rollback-{digest}"
+
+
+def _dedupe_steps(
+    steps: list[MemoryEvidenceRepairRollbackStep],
+) -> list[MemoryEvidenceRepairRollbackStep]:
+    seen: set[str] = set()
+    deduped: list[MemoryEvidenceRepairRollbackStep] = []
+    for step in steps:
+        if step.id in seen:
+            continue
+        seen.add(step.id)
+        deduped.append(step)
+    return deduped
+
+
+def _dict(value: Any) -> dict[str, Any]:
+    return dict(value) if isinstance(value, Mapping) else {}
+
+
+def _str(value: Any) -> str:
+    return str(value or "").strip()

--- a/agent/memory_evidence_repair_snapshot_planner.py
+++ b/agent/memory_evidence_repair_snapshot_planner.py
@@ -1,0 +1,385 @@
+"""Read-only pre-commit snapshot planner for memory evidence repair.
+
+The snapshot planner identifies which existing evidence fields must be captured
+before a future manual repair write. It never writes to durable memory stores.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Mapping, Sequence
+
+from agent.memory_evidence_repair_rollback_plan import (
+    ROLLBACK_ACTION_NOOP,
+    ROLLBACK_STATUS_NO_ACTION_NEEDED,
+    ROLLBACK_STATUS_READY_FOR_MANUAL_ROLLBACK,
+    ROLLBACK_STATUS_SNAPSHOT_REQUIRED,
+    build_evidence_repair_rollback_plan,
+)
+
+
+SNAPSHOT_ACTION_CAPTURE_EVIDENCE_METADATA = "capture_evidence_metadata"
+SNAPSHOT_ACTION_VERIFY_EXISTING_SNAPSHOT = "verify_existing_snapshot"
+SNAPSHOT_ACTION_NOOP = "no_snapshot_required"
+SNAPSHOT_STATUS_CAPTURE_REQUIRED = "capture_required"
+SNAPSHOT_STATUS_ALREADY_AVAILABLE = "already_available"
+SNAPSHOT_STATUS_NO_ACTION_NEEDED = "no_action_needed"
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairSnapshotRequest:
+    """One read-only pre-commit snapshot request."""
+
+    id: str
+    sequence: int
+    status: str
+    snapshot_action: str
+    ledger_entry_id: str
+    rollback_step_id: str
+    candidate_id: str
+    preview_id: str
+    provider: str
+    repair_action: str
+    patch_digest: str
+    target: dict[str, Any]
+    evidence_fields: tuple[str, ...]
+    snapshot_key_candidates: tuple[str, ...]
+    snapshot_payload_preview: dict[str, Any]
+    required_before: str
+    blocks_manual_commit: bool
+    reason: str
+    verification_steps: tuple[str, ...]
+    safety_note: str
+    source_step: dict[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "sequence": self.sequence,
+            "status": self.status,
+            "snapshot_action": self.snapshot_action,
+            "ledger_entry_id": self.ledger_entry_id,
+            "rollback_step_id": self.rollback_step_id,
+            "candidate_id": self.candidate_id,
+            "preview_id": self.preview_id,
+            "provider": self.provider,
+            "repair_action": self.repair_action,
+            "patch_digest": self.patch_digest,
+            "target": dict(self.target),
+            "evidence_fields": list(self.evidence_fields),
+            "snapshot_key_candidates": list(self.snapshot_key_candidates),
+            "snapshot_payload_preview": dict(self.snapshot_payload_preview),
+            "required_before": self.required_before,
+            "blocks_manual_commit": self.blocks_manual_commit,
+            "reason": self.reason,
+            "verification_steps": list(self.verification_steps),
+            "safety_note": self.safety_note,
+            "source_step": dict(self.source_step),
+        }
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairSnapshotPlan:
+    """Read-only pre-commit snapshot plan."""
+
+    generated_at: str
+    requests: tuple[MemoryEvidenceRepairSnapshotRequest, ...]
+
+    @property
+    def summary(self) -> dict[str, Any]:
+        by_status: dict[str, int] = {}
+        by_provider: dict[str, int] = {}
+        by_repair_action: dict[str, int] = {}
+        capture_required_count = 0
+        already_available_count = 0
+        no_action_count = 0
+        blocking_count = 0
+        for request in self.requests:
+            by_status[request.status] = by_status.get(request.status, 0) + 1
+            by_repair_action[request.repair_action] = (
+                by_repair_action.get(request.repair_action, 0) + 1
+            )
+            if request.provider:
+                by_provider[request.provider] = by_provider.get(request.provider, 0) + 1
+            if request.status == SNAPSHOT_STATUS_CAPTURE_REQUIRED:
+                capture_required_count += 1
+            elif request.status == SNAPSHOT_STATUS_ALREADY_AVAILABLE:
+                already_available_count += 1
+            elif request.status == SNAPSHOT_STATUS_NO_ACTION_NEEDED:
+                no_action_count += 1
+            if request.blocks_manual_commit:
+                blocking_count += 1
+        return {
+            "snapshot_request_count": len(self.requests),
+            "capture_required_count": capture_required_count,
+            "already_available_count": already_available_count,
+            "no_action_count": no_action_count,
+            "blocking_count": blocking_count,
+            "by_status": by_status,
+            "by_provider": by_provider,
+            "by_repair_action": by_repair_action,
+            "requires_capture": capture_required_count > 0,
+            "blocks_manual_commit": blocking_count > 0,
+        }
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "generated_at": self.generated_at,
+            "summary": self.summary,
+            "requests": [request.to_dict() for request in self.requests],
+            "read_only": True,
+            "read_only_memory": True,
+            "would_mutate_memory": False,
+        }
+
+
+def build_evidence_repair_snapshot_plan(
+    *,
+    rollback_plan: Mapping[str, Any] | None = None,
+    steps: Sequence[Mapping[str, Any]] | None = None,
+    ledger: Mapping[str, Any] | None = None,
+    entries: Sequence[Mapping[str, Any]] | None = None,
+    existing_snapshots: Mapping[str, Any] | None = None,
+) -> MemoryEvidenceRepairSnapshotPlan:
+    """Build a read-only pre-commit snapshot plan."""
+
+    rollback_plan = rollback_plan if isinstance(rollback_plan, Mapping) else {}
+    existing_snapshots = (
+        existing_snapshots if isinstance(existing_snapshots, Mapping) else {}
+    )
+    rows = _step_rows(rollback_plan=rollback_plan, steps=steps)
+    if not rows and (ledger or entries is not None):
+        rows = build_evidence_repair_rollback_plan(
+            ledger=ledger if isinstance(ledger, Mapping) else {},
+            entries=entries,
+            pre_commit_snapshots=existing_snapshots,
+        ).to_dict().get("steps", [])
+
+    requests: list[MemoryEvidenceRepairSnapshotRequest] = []
+    for index, row in enumerate(rows, start=1):
+        if not isinstance(row, Mapping):
+            continue
+        request = _request_from_step(row, sequence=index)
+        if request is not None:
+            requests.append(request)
+
+    return MemoryEvidenceRepairSnapshotPlan(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        requests=tuple(_dedupe_requests(requests)),
+    )
+
+
+def empty_evidence_repair_snapshot_plan() -> MemoryEvidenceRepairSnapshotPlan:
+    """Return an empty read-only pre-commit snapshot plan."""
+
+    return MemoryEvidenceRepairSnapshotPlan(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        requests=(),
+    )
+
+
+def _request_from_step(
+    step: Mapping[str, Any],
+    *,
+    sequence: int,
+) -> MemoryEvidenceRepairSnapshotRequest | None:
+    step_id = _str(step.get("id"))
+    ledger_entry_id = _str(step.get("ledger_entry_id"))
+    candidate_id = _str(step.get("candidate_id"))
+    preview_id = _str(step.get("preview_id"))
+    status = _str(step.get("status"))
+    if not step_id and not ledger_entry_id and not candidate_id and not status:
+        return None
+
+    snapshot_status = _snapshot_status(step)
+    evidence_fields = _evidence_fields(step)
+    key_candidates = _snapshot_key_candidates(step)
+    request_id = _stable_request_id(
+        ledger_entry_id=ledger_entry_id,
+        rollback_step_id=step_id,
+        patch_digest=_str(step.get("patch_digest")),
+        evidence_fields=evidence_fields,
+    )
+    return MemoryEvidenceRepairSnapshotRequest(
+        id=request_id,
+        sequence=sequence,
+        status=snapshot_status,
+        snapshot_action=_snapshot_action(snapshot_status),
+        ledger_entry_id=ledger_entry_id,
+        rollback_step_id=step_id,
+        candidate_id=candidate_id,
+        preview_id=preview_id,
+        provider=_str(step.get("provider")) or "memory",
+        repair_action=_str(step.get("repair_action")) or "attach_provenance",
+        patch_digest=_str(step.get("patch_digest")),
+        target=_dict(step.get("target")),
+        evidence_fields=evidence_fields,
+        snapshot_key_candidates=key_candidates,
+        snapshot_payload_preview=_snapshot_payload_preview(
+            step=step,
+            snapshot_status=snapshot_status,
+            evidence_fields=evidence_fields,
+            key_candidates=key_candidates,
+        ),
+        required_before="manual_commit",
+        blocks_manual_commit=snapshot_status == SNAPSHOT_STATUS_CAPTURE_REQUIRED,
+        reason=_reason(snapshot_status),
+        verification_steps=_verification_steps(snapshot_status),
+        safety_note=(
+            "Read-only snapshot plan. Capture requests describe evidence that "
+            "must be saved before a future manual write; this plan writes nothing."
+        ),
+        source_step=dict(step),
+    )
+
+
+def _snapshot_status(step: Mapping[str, Any]) -> str:
+    rollback_status = _str(step.get("status"))
+    rollback_action = _str(step.get("rollback_action"))
+    if rollback_status == ROLLBACK_STATUS_NO_ACTION_NEEDED or rollback_action == ROLLBACK_ACTION_NOOP:
+        return SNAPSHOT_STATUS_NO_ACTION_NEEDED
+    if rollback_status == ROLLBACK_STATUS_READY_FOR_MANUAL_ROLLBACK:
+        return SNAPSHOT_STATUS_ALREADY_AVAILABLE
+    if rollback_status == ROLLBACK_STATUS_SNAPSHOT_REQUIRED:
+        return SNAPSHOT_STATUS_CAPTURE_REQUIRED
+    return SNAPSHOT_STATUS_CAPTURE_REQUIRED
+
+
+def _snapshot_action(snapshot_status: str) -> str:
+    if snapshot_status == SNAPSHOT_STATUS_CAPTURE_REQUIRED:
+        return SNAPSHOT_ACTION_CAPTURE_EVIDENCE_METADATA
+    if snapshot_status == SNAPSHOT_STATUS_ALREADY_AVAILABLE:
+        return SNAPSHOT_ACTION_VERIFY_EXISTING_SNAPSHOT
+    return SNAPSHOT_ACTION_NOOP
+
+
+def _snapshot_payload_preview(
+    *,
+    step: Mapping[str, Any],
+    snapshot_status: str,
+    evidence_fields: tuple[str, ...],
+    key_candidates: tuple[str, ...],
+) -> dict[str, Any]:
+    if snapshot_status == SNAPSHOT_STATUS_NO_ACTION_NEEDED:
+        return {
+            "operation": SNAPSHOT_ACTION_NOOP,
+            "reason": "Rollback step does not correspond to an allowed manual commit.",
+        }
+    return {
+        "operation": SNAPSHOT_ACTION_CAPTURE_EVIDENCE_METADATA,
+        "target": _dict(step.get("target")),
+        "capture": {
+            "evidence_fields": list(evidence_fields),
+            "snapshot_key": key_candidates[0] if key_candidates else "",
+            "snapshot_key_candidates": list(key_candidates),
+            "format": "pre_commit_evidence_snapshot",
+        },
+        "required_before": "manual_commit",
+        "source_rollback_step_id": _str(step.get("id")),
+    }
+
+
+def _reason(snapshot_status: str) -> str:
+    if snapshot_status == SNAPSHOT_STATUS_CAPTURE_REQUIRED:
+        return "Capture current evidence metadata before applying this manual repair."
+    if snapshot_status == SNAPSHOT_STATUS_ALREADY_AVAILABLE:
+        return "A pre-commit snapshot is already available; verify it before commit."
+    return "No snapshot is required because this entry is not eligible for manual commit."
+
+
+def _verification_steps(snapshot_status: str) -> tuple[str, ...]:
+    if snapshot_status == SNAPSHOT_STATUS_NO_ACTION_NEEDED:
+        return ("verify_no_manual_commit_is_planned",)
+    steps = [
+        "verify_target_matches_ledger_entry",
+        "read_current_evidence_metadata",
+        "verify_snapshot_contains_requested_fields",
+    ]
+    if snapshot_status == SNAPSHOT_STATUS_CAPTURE_REQUIRED:
+        steps.append("store_snapshot_before_manual_commit")
+    else:
+        steps.append("verify_existing_snapshot_before_manual_commit")
+    return tuple(steps)
+
+
+def _step_rows(
+    *,
+    rollback_plan: Mapping[str, Any],
+    steps: Sequence[Mapping[str, Any]] | None,
+) -> list[Any]:
+    if steps is not None:
+        return list(steps)
+    if "rollback_action" in rollback_plan:
+        return [rollback_plan]
+    value = rollback_plan.get("steps")
+    return value if isinstance(value, list) else []
+
+
+def _evidence_fields(step: Mapping[str, Any]) -> tuple[str, ...]:
+    fields = step.get("evidence_fields")
+    if isinstance(fields, list):
+        parsed = tuple(_str(field) for field in fields if _str(field))
+        if parsed:
+            return parsed
+    source_entry = step.get("source_entry")
+    if isinstance(source_entry, Mapping):
+        fields = source_entry.get("evidence_fields")
+        if isinstance(fields, list):
+            return tuple(_str(field) for field in fields if _str(field))
+    return ()
+
+
+def _snapshot_key_candidates(step: Mapping[str, Any]) -> tuple[str, ...]:
+    keys = (
+        _str(step.get("ledger_entry_id")),
+        _str(step.get("candidate_id")),
+        _str(step.get("preview_id")),
+        _str(step.get("patch_digest")),
+        _str(step.get("id")),
+    )
+    return tuple(key for key in keys if key)
+
+
+def _stable_request_id(
+    *,
+    ledger_entry_id: str,
+    rollback_step_id: str,
+    patch_digest: str,
+    evidence_fields: tuple[str, ...],
+) -> str:
+    raw = json.dumps(
+        {
+            "ledger_entry_id": ledger_entry_id,
+            "rollback_step_id": rollback_step_id,
+            "patch_digest": patch_digest,
+            "evidence_fields": list(evidence_fields),
+        },
+        sort_keys=True,
+        ensure_ascii=False,
+    )
+    digest = hashlib.sha256(raw.encode("utf-8")).hexdigest()[:16]
+    return f"snapshot-{digest}"
+
+
+def _dedupe_requests(
+    requests: list[MemoryEvidenceRepairSnapshotRequest],
+) -> list[MemoryEvidenceRepairSnapshotRequest]:
+    seen: set[str] = set()
+    deduped: list[MemoryEvidenceRepairSnapshotRequest] = []
+    for request in requests:
+        if request.id in seen:
+            continue
+        seen.add(request.id)
+        deduped.append(request)
+    return deduped
+
+
+def _dict(value: Any) -> dict[str, Any]:
+    return dict(value) if isinstance(value, Mapping) else {}
+
+
+def _str(value: Any) -> str:
+    return str(value or "").strip()

--- a/agent/memory_evidence_repair_write_lock_gate.py
+++ b/agent/memory_evidence_repair_write_lock_gate.py
@@ -1,0 +1,623 @@
+"""Read-only write-lock gate for memory evidence repair manual commits.
+
+The write-lock gate verifies a commit receipt, checks supplied active locks and
+used-token ids, then drafts a future write lock. It never writes to durable
+memory stores and never acquires a real lock.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Any, Mapping, Sequence
+
+from agent.memory_evidence_repair_commit_receipt import (
+    RECEIPT_SCOPE,
+    RECEIPT_STATUS_BLOCKED,
+    RECEIPT_STATUS_NO_ACTION_NEEDED,
+    RECEIPT_STATUS_READY,
+    RECEIPT_TYPE,
+)
+from agent.memory_evidence_repair_manual_commit_dry_run import (
+    CHECK_STATUS_FAIL,
+    CHECK_STATUS_PASS,
+)
+
+
+WRITE_LOCK_TYPE = "memory_evidence_repair_write_lock"
+WRITE_LOCK_STATUS_READY = "write_lock_ready_for_manual_commit"
+WRITE_LOCK_STATUS_BLOCKED = "blocked"
+WRITE_LOCK_STATUS_NO_ACTION_NEEDED = "no_action_needed"
+LOCK_DRAFT_STATUS_READY = "write_lock_draft_ready"
+DEFAULT_LOCK_TTL_MINUTES = 10
+
+CHECK_RECEIPT_READY = "receipt_ready"
+CHECK_RECEIPT_INTEGRITY = "receipt_integrity"
+CHECK_TOKEN_REUSE = "token_reuse"
+CHECK_ACTIVE_LOCKS = "active_locks"
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairWriteLockCheck:
+    """One read-only write-lock readiness check."""
+
+    id: str
+    status: str
+    reason: str
+    required_actions: tuple[str, ...]
+    details: dict[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "status": self.status,
+            "reason": self.reason,
+            "required_actions": list(self.required_actions),
+            "details": dict(self.details),
+        }
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairWriteLockDraft:
+    """One read-only future write-lock draft."""
+
+    id: str
+    lock_type: str
+    status: str
+    scope: str
+    owner: str
+    receipt_id: str
+    token_id: str
+    operation_ids: tuple[str, ...]
+    candidate_ids: tuple[str, ...]
+    patch_digests: tuple[str, ...]
+    lock_digest: str
+    lock_preview: str
+    issued_at: str
+    expires_at: str
+    expires_in_minutes: int
+    would_acquire_write_lock: bool
+    would_release_after_commit: bool
+    safety_note: str
+    source_receipt: dict[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "lock_type": self.lock_type,
+            "status": self.status,
+            "scope": self.scope,
+            "owner": self.owner,
+            "receipt_id": self.receipt_id,
+            "token_id": self.token_id,
+            "operation_ids": list(self.operation_ids),
+            "candidate_ids": list(self.candidate_ids),
+            "patch_digests": list(self.patch_digests),
+            "lock_digest": self.lock_digest,
+            "lock_preview": self.lock_preview,
+            "issued_at": self.issued_at,
+            "expires_at": self.expires_at,
+            "expires_in_minutes": self.expires_in_minutes,
+            "would_acquire_write_lock": self.would_acquire_write_lock,
+            "would_release_after_commit": self.would_release_after_commit,
+            "safety_note": self.safety_note,
+            "source_receipt": dict(self.source_receipt),
+        }
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairWriteLockGateReport:
+    """Read-only write-lock gate report."""
+
+    generated_at: str
+    status: str
+    checks: tuple[MemoryEvidenceRepairWriteLockCheck, ...]
+    locks: tuple[MemoryEvidenceRepairWriteLockDraft, ...]
+    blocking_reasons: tuple[str, ...]
+    required_actions: tuple[str, ...]
+    active_lock_conflicts: tuple[dict[str, Any], ...]
+    source_receipt: dict[str, Any]
+
+    @property
+    def summary(self) -> dict[str, Any]:
+        by_check_status: dict[str, int] = {}
+        for check in self.checks:
+            by_check_status[check.status] = by_check_status.get(check.status, 0) + 1
+        return {
+            "status": self.status,
+            "check_count": len(self.checks),
+            "pass_count": by_check_status.get(CHECK_STATUS_PASS, 0),
+            "fail_count": by_check_status.get(CHECK_STATUS_FAIL, 0),
+            "lock_count": len(self.locks),
+            "active_lock_conflict_count": len(self.active_lock_conflicts),
+            "blocking_reason_count": len(self.blocking_reasons),
+            "required_action_count": len(self.required_actions),
+            "write_lock_available": bool(self.locks),
+            "executor_dry_run_allowed": self.status == WRITE_LOCK_STATUS_READY,
+            "would_acquire_write_lock_count": sum(
+                1 for lock in self.locks if lock.would_acquire_write_lock
+            ),
+            "has_blocks": self.status == WRITE_LOCK_STATUS_BLOCKED,
+            "requires_followup": bool(self.required_actions),
+            "by_check_status": by_check_status,
+        }
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "generated_at": self.generated_at,
+            "status": self.status,
+            "summary": self.summary,
+            "checks": [check.to_dict() for check in self.checks],
+            "locks": [lock.to_dict() for lock in self.locks],
+            "blocking_reasons": list(self.blocking_reasons),
+            "required_actions": list(self.required_actions),
+            "active_lock_conflicts": [dict(conflict) for conflict in self.active_lock_conflicts],
+            "source_receipt": dict(self.source_receipt),
+            "read_only": True,
+            "read_only_memory": True,
+            "would_mutate_memory": False,
+        }
+
+
+def build_evidence_repair_write_lock_gate(
+    *,
+    commit_receipt: Mapping[str, Any] | None = None,
+    active_locks: Sequence[Mapping[str, Any]] | None = None,
+    already_used_token_ids: Sequence[str] | None = None,
+    lock_owner: str = "human",
+    lock_ttl_minutes: int = DEFAULT_LOCK_TTL_MINUTES,
+    current_time: str | datetime | None = None,
+) -> MemoryEvidenceRepairWriteLockGateReport:
+    """Build a read-only write-lock gate from a commit receipt report."""
+
+    commit_receipt = commit_receipt if isinstance(commit_receipt, Mapping) else {}
+    receipt = _extract_receipt(commit_receipt)
+    receipt_status = _str(commit_receipt.get("status")) or _str(receipt.get("status"))
+    now = _parse_datetime(current_time) or datetime.now(timezone.utc)
+
+    if not receipt:
+        if not commit_receipt or receipt_status == RECEIPT_STATUS_NO_ACTION_NEEDED:
+            return _empty_report(commit_receipt=commit_receipt)
+        source_blocking = tuple(_list_of_str(commit_receipt.get("blocking_reasons")))
+        source_actions = tuple(_list_of_str(commit_receipt.get("required_actions")))
+        return _blocked_report(
+            commit_receipt=commit_receipt,
+            checks=(
+                _fail(
+                    CHECK_RECEIPT_READY,
+                    "No commit receipt was supplied."
+                    if not source_blocking
+                    else "; ".join(source_blocking),
+                    source_actions or ("produce_commit_receipt",),
+                    {"receipt_status": receipt_status},
+                ),
+            ),
+            conflicts=(),
+        )
+
+    checks: list[MemoryEvidenceRepairWriteLockCheck] = [
+        _receipt_ready_check(commit_receipt, receipt),
+        _receipt_integrity_check(receipt),
+        _token_reuse_check(receipt, already_used_token_ids),
+    ]
+    conflicts = tuple(_active_lock_conflicts(receipt, active_locks, now))
+    checks.append(_active_lock_check(conflicts))
+
+    blocking_reasons = tuple(
+        _dedupe_strings(check.reason for check in checks if check.status == CHECK_STATUS_FAIL)
+    )
+    required_actions = tuple(
+        _dedupe_strings(
+            action
+            for check in checks
+            if check.status == CHECK_STATUS_FAIL
+            for action in check.required_actions
+        )
+    )
+    if blocking_reasons:
+        return MemoryEvidenceRepairWriteLockGateReport(
+            generated_at=datetime.now(timezone.utc).isoformat(),
+            status=WRITE_LOCK_STATUS_BLOCKED,
+            checks=tuple(checks),
+            locks=(),
+            blocking_reasons=blocking_reasons,
+            required_actions=required_actions,
+            active_lock_conflicts=conflicts,
+            source_receipt=dict(commit_receipt),
+        )
+
+    lock = _lock_from_receipt(
+        receipt=receipt,
+        lock_owner=lock_owner,
+        lock_ttl_minutes=lock_ttl_minutes,
+        issued_at=now,
+    )
+    return MemoryEvidenceRepairWriteLockGateReport(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        status=WRITE_LOCK_STATUS_READY,
+        checks=tuple(checks),
+        locks=(lock,),
+        blocking_reasons=(),
+        required_actions=(),
+        active_lock_conflicts=(),
+        source_receipt=dict(commit_receipt),
+    )
+
+
+def empty_evidence_repair_write_lock_gate() -> MemoryEvidenceRepairWriteLockGateReport:
+    """Return an empty read-only write-lock gate report."""
+
+    return _empty_report(commit_receipt={})
+
+
+def _extract_receipt(commit_receipt: Mapping[str, Any]) -> dict[str, Any]:
+    receipts = commit_receipt.get("receipts")
+    if isinstance(receipts, list):
+        for receipt in receipts:
+            if isinstance(receipt, Mapping):
+                return dict(receipt)
+    if _str(commit_receipt.get("id")).startswith("commit-receipt-"):
+        return dict(commit_receipt)
+    return {}
+
+
+def _receipt_ready_check(
+    commit_receipt: Mapping[str, Any],
+    receipt: Mapping[str, Any],
+) -> MemoryEvidenceRepairWriteLockCheck:
+    report_status = _str(commit_receipt.get("status"))
+    receipt_status = _str(receipt.get("status"))
+    if report_status and report_status != RECEIPT_STATUS_READY:
+        return _fail(
+            CHECK_RECEIPT_READY,
+            "Commit receipt report is not ready for manual commit.",
+            tuple(_list_of_str(commit_receipt.get("required_actions")))
+            or ("produce_ready_commit_receipt",),
+            {"report_status": report_status, "receipt_status": receipt_status},
+        )
+    if receipt_status != RECEIPT_STATUS_READY:
+        return _fail(
+            CHECK_RECEIPT_READY,
+            "Commit receipt entry is not ready for manual commit.",
+            ("produce_ready_commit_receipt",),
+            {"report_status": report_status, "receipt_status": receipt_status},
+        )
+    return _pass(
+        CHECK_RECEIPT_READY,
+        "Commit receipt is ready for manual commit.",
+        {"receipt_id": _str(receipt.get("id"))},
+    )
+
+
+def _receipt_integrity_check(
+    receipt: Mapping[str, Any],
+) -> MemoryEvidenceRepairWriteLockCheck:
+    expected_digest = _expected_receipt_digest(receipt)
+    actual_digest = _str(receipt.get("receipt_digest"))
+    expected_id = f"commit-receipt-{expected_digest[:16]}" if expected_digest else ""
+    missing_fields: list[str] = []
+    for field_name in ("token_id", "operation_ids", "patch_digests"):
+        value = receipt.get(field_name)
+        if isinstance(value, list) and not value:
+            missing_fields.append(field_name)
+        elif not isinstance(value, list) and not _str(value):
+            missing_fields.append(field_name)
+    if (
+        missing_fields
+        or actual_digest != expected_digest
+        or _str(receipt.get("id")) != expected_id
+        or _str(receipt.get("receipt_type")) != RECEIPT_TYPE
+        or _str(receipt.get("scope")) != RECEIPT_SCOPE
+    ):
+        return _fail(
+            CHECK_RECEIPT_INTEGRITY,
+            "Commit receipt digest, id, type, scope, or required fields are invalid.",
+            ("regenerate_commit_receipt",),
+            {
+                "expected_receipt_digest": expected_digest,
+                "actual_receipt_digest": actual_digest,
+                "expected_receipt_id": expected_id,
+                "actual_receipt_id": _str(receipt.get("id")),
+                "missing_fields": missing_fields,
+            },
+        )
+    return _pass(
+        CHECK_RECEIPT_INTEGRITY,
+        "Commit receipt integrity checks pass.",
+        {"receipt_id": expected_id, "receipt_digest": actual_digest},
+    )
+
+
+def _token_reuse_check(
+    receipt: Mapping[str, Any],
+    already_used_token_ids: Sequence[str] | None,
+) -> MemoryEvidenceRepairWriteLockCheck:
+    token_id = _str(receipt.get("token_id"))
+    used = {_str(item) for item in already_used_token_ids or [] if _str(item)}
+    if token_id and token_id in used:
+        return _fail(
+            CHECK_TOKEN_REUSE,
+            "Approval token is already present in the external used-token ledger.",
+            ("regenerate_human_approval_token",),
+            {"token_id": token_id, "already_used_token_count": len(used)},
+        )
+    return _pass(
+        CHECK_TOKEN_REUSE,
+        "Approval token is not present in the external used-token ledger.",
+        {"token_id": token_id, "already_used_token_count": len(used)},
+    )
+
+
+def _active_lock_check(
+    conflicts: Sequence[Mapping[str, Any]],
+) -> MemoryEvidenceRepairWriteLockCheck:
+    if conflicts:
+        return _fail(
+            CHECK_ACTIVE_LOCKS,
+            "Active write locks conflict with the planned memory evidence repair commit.",
+            ("wait_for_write_lock_release", "retry_write_lock_gate"),
+            {"conflict_count": len(conflicts), "conflicts": list(conflicts)},
+        )
+    return _pass(
+        CHECK_ACTIVE_LOCKS,
+        "No active write-lock conflicts were supplied.",
+        {"conflict_count": 0},
+    )
+
+
+def _lock_from_receipt(
+    *,
+    receipt: Mapping[str, Any],
+    lock_owner: str,
+    lock_ttl_minutes: int,
+    issued_at: datetime,
+) -> MemoryEvidenceRepairWriteLockDraft:
+    ttl = _positive_int(lock_ttl_minutes) or DEFAULT_LOCK_TTL_MINUTES
+    expires_at = issued_at + timedelta(minutes=ttl)
+    operation_ids = tuple(_list_of_str(receipt.get("operation_ids")))
+    candidate_ids = tuple(_list_of_str(receipt.get("candidate_ids")))
+    patch_digests = tuple(_list_of_str(receipt.get("patch_digests")))
+    seed = {
+        "lock_type": WRITE_LOCK_TYPE,
+        "scope": RECEIPT_SCOPE,
+        "owner": _str(lock_owner) or "human",
+        "receipt_id": _str(receipt.get("id")),
+        "token_id": _str(receipt.get("token_id")),
+        "operation_ids": operation_ids,
+        "candidate_ids": candidate_ids,
+        "patch_digests": patch_digests,
+        "expires_in_minutes": ttl,
+    }
+    lock_digest = _digest(seed)
+    lock_id = f"write-lock-{lock_digest[:16]}"
+    return MemoryEvidenceRepairWriteLockDraft(
+        id=lock_id,
+        lock_type=WRITE_LOCK_TYPE,
+        status=LOCK_DRAFT_STATUS_READY,
+        scope=RECEIPT_SCOPE,
+        owner=_str(lock_owner) or "human",
+        receipt_id=_str(receipt.get("id")),
+        token_id=_str(receipt.get("token_id")),
+        operation_ids=operation_ids,
+        candidate_ids=candidate_ids,
+        patch_digests=patch_digests,
+        lock_digest=lock_digest,
+        lock_preview=f"{lock_id}:{lock_digest[:12]}",
+        issued_at=issued_at.isoformat(),
+        expires_at=expires_at.isoformat(),
+        expires_in_minutes=ttl,
+        would_acquire_write_lock=True,
+        would_release_after_commit=True,
+        safety_note=(
+            "Read-only write-lock draft. This does not acquire a real lock and "
+            "does not mutate durable memory."
+        ),
+        source_receipt=dict(receipt),
+    )
+
+
+def _active_lock_conflicts(
+    receipt: Mapping[str, Any],
+    active_locks: Sequence[Mapping[str, Any]] | None,
+    now: datetime,
+) -> list[dict[str, Any]]:
+    conflicts: list[dict[str, Any]] = []
+    for lock in active_locks or []:
+        if not isinstance(lock, Mapping) or not _is_active_lock(lock, now):
+            continue
+        if _lock_conflicts_with_receipt(lock, receipt):
+            conflicts.append(
+                {
+                    "lock_id": _str(lock.get("id")),
+                    "owner": _str(lock.get("owner")),
+                    "scope": _str(lock.get("scope")),
+                    "expires_at": _str(lock.get("expires_at")),
+                    "reason": _conflict_reason(lock, receipt),
+                }
+            )
+    return conflicts
+
+
+def _is_active_lock(lock: Mapping[str, Any], now: datetime) -> bool:
+    status = _str(lock.get("status")).lower()
+    if status in {"released", "expired", "cancelled", "canceled", "inactive"}:
+        return False
+    expires_at = _parse_datetime(lock.get("expires_at"))
+    if expires_at is not None and expires_at <= now:
+        return False
+    return status in {"", "active", "write_lock_active", LOCK_DRAFT_STATUS_READY}
+
+
+def _lock_conflicts_with_receipt(lock: Mapping[str, Any], receipt: Mapping[str, Any]) -> bool:
+    lock_scope = _str(lock.get("scope"))
+    if lock_scope and lock_scope != RECEIPT_SCOPE:
+        return False
+    if _str(lock.get("token_id")) and _str(lock.get("token_id")) == _str(receipt.get("token_id")):
+        return True
+    if _str(lock.get("receipt_id")) and _str(lock.get("receipt_id")) == _str(receipt.get("id")):
+        return True
+    if _intersects(_list_of_str(lock.get("operation_ids")), _list_of_str(receipt.get("operation_ids"))):
+        return True
+    if _intersects(_list_of_str(lock.get("candidate_ids")), _list_of_str(receipt.get("candidate_ids"))):
+        return True
+    if _intersects(_list_of_str(lock.get("patch_digests")), _list_of_str(receipt.get("patch_digests"))):
+        return True
+    identifiers = (
+        _str(lock.get("token_id")),
+        _str(lock.get("receipt_id")),
+        *_list_of_str(lock.get("operation_ids")),
+        *_list_of_str(lock.get("candidate_ids")),
+        *_list_of_str(lock.get("patch_digests")),
+    )
+    return not any(identifiers)
+
+
+def _conflict_reason(lock: Mapping[str, Any], receipt: Mapping[str, Any]) -> str:
+    if _str(lock.get("token_id")) == _str(receipt.get("token_id")):
+        return "same_token_id"
+    if _str(lock.get("receipt_id")) == _str(receipt.get("id")):
+        return "same_receipt_id"
+    if _intersects(_list_of_str(lock.get("operation_ids")), _list_of_str(receipt.get("operation_ids"))):
+        return "overlapping_operation_ids"
+    if _intersects(_list_of_str(lock.get("candidate_ids")), _list_of_str(receipt.get("candidate_ids"))):
+        return "overlapping_candidate_ids"
+    if _intersects(_list_of_str(lock.get("patch_digests")), _list_of_str(receipt.get("patch_digests"))):
+        return "overlapping_patch_digests"
+    return "global_scope_lock"
+
+
+def _expected_receipt_digest(receipt: Mapping[str, Any]) -> str:
+    seed = {
+        "receipt_type": RECEIPT_TYPE,
+        "scope": RECEIPT_SCOPE,
+        "actor": _str(receipt.get("actor")) or "human",
+        "commit_reason": _str(receipt.get("commit_reason")),
+        "token_id": _str(receipt.get("token_id")),
+        "token_digest": _str(receipt.get("token_digest")),
+        "dry_run_digest": _str(receipt.get("dry_run_digest")),
+        "gate_status": _str(receipt.get("gate_status")),
+        "operation_ids": _list_of_str(receipt.get("operation_ids")),
+        "ledger_entry_ids": _list_of_str(receipt.get("ledger_entry_ids")),
+        "candidate_ids": _list_of_str(receipt.get("candidate_ids")),
+        "patch_digests": _list_of_str(receipt.get("patch_digests")),
+    }
+    return _digest(seed)
+
+
+def _empty_report(*, commit_receipt: Mapping[str, Any]) -> MemoryEvidenceRepairWriteLockGateReport:
+    return MemoryEvidenceRepairWriteLockGateReport(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        status=WRITE_LOCK_STATUS_NO_ACTION_NEEDED,
+        checks=(),
+        locks=(),
+        blocking_reasons=(),
+        required_actions=(),
+        active_lock_conflicts=(),
+        source_receipt=dict(commit_receipt),
+    )
+
+
+def _blocked_report(
+    *,
+    commit_receipt: Mapping[str, Any],
+    checks: tuple[MemoryEvidenceRepairWriteLockCheck, ...],
+    conflicts: Sequence[Mapping[str, Any]],
+) -> MemoryEvidenceRepairWriteLockGateReport:
+    return MemoryEvidenceRepairWriteLockGateReport(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        status=WRITE_LOCK_STATUS_BLOCKED,
+        checks=checks,
+        locks=(),
+        blocking_reasons=tuple(
+            _dedupe_strings(check.reason for check in checks if check.status == CHECK_STATUS_FAIL)
+        ),
+        required_actions=tuple(
+            _dedupe_strings(
+                action
+                for check in checks
+                if check.status == CHECK_STATUS_FAIL
+                for action in check.required_actions
+            )
+        ),
+        active_lock_conflicts=tuple(dict(conflict) for conflict in conflicts),
+        source_receipt=dict(commit_receipt),
+    )
+
+
+def _pass(
+    check_id: str,
+    reason: str,
+    details: Mapping[str, Any],
+) -> MemoryEvidenceRepairWriteLockCheck:
+    return MemoryEvidenceRepairWriteLockCheck(
+        id=check_id,
+        status=CHECK_STATUS_PASS,
+        reason=reason,
+        required_actions=(),
+        details=dict(details),
+    )
+
+
+def _fail(
+    check_id: str,
+    reason: str,
+    required_actions: Sequence[str],
+    details: Mapping[str, Any],
+) -> MemoryEvidenceRepairWriteLockCheck:
+    return MemoryEvidenceRepairWriteLockCheck(
+        id=check_id,
+        status=CHECK_STATUS_FAIL,
+        reason=reason,
+        required_actions=tuple(required_actions),
+        details=dict(details),
+    )
+
+
+def _parse_datetime(value: str | datetime | Any) -> datetime | None:
+    if isinstance(value, datetime):
+        return value if value.tzinfo else value.replace(tzinfo=timezone.utc)
+    if not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    return parsed if parsed.tzinfo else parsed.replace(tzinfo=timezone.utc)
+
+
+def _positive_int(value: Any) -> int | None:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed if parsed > 0 else None
+
+
+def _intersects(left: Sequence[str], right: Sequence[str]) -> bool:
+    return bool(set(left).intersection(set(right)))
+
+
+def _digest(value: Any) -> str:
+    raw = json.dumps(value, sort_keys=True, ensure_ascii=False, default=str)
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def _list_of_str(value: Any) -> list[str]:
+    return [_str(item) for item in value] if isinstance(value, list) else []
+
+
+def _dedupe_strings(values: Sequence[str] | Any) -> list[str]:
+    seen: set[str] = set()
+    result: list[str] = []
+    for value in values:
+        text = _str(value)
+        if text and text not in seen:
+            seen.add(text)
+            result.append(text)
+    return result
+
+
+def _str(value: Any) -> str:
+    return str(value or "").strip()

--- a/tests/agent/test_memory_evidence_repair_apply_preview.py
+++ b/tests/agent/test_memory_evidence_repair_apply_preview.py
@@ -1,0 +1,137 @@
+from agent.memory_evidence_repair_apply_preview import (
+    PATCH_OPERATION,
+    PREVIEW_STATUS_AWAITING_CONFIRMATION,
+    PREVIEW_STATUS_BLOCKED_MISSING_EVIDENCE,
+    PREVIEW_STATUS_READY_FOR_MANUAL_APPLY,
+    build_evidence_repair_apply_preview,
+    empty_evidence_repair_apply_preview,
+)
+
+
+def test_builds_ready_apply_preview_for_approved_candidate():
+    report = build_evidence_repair_apply_preview(
+        candidates=[
+            {
+                "id": "repair-123",
+                "provider": "builtin",
+                "priority": "high",
+                "repair_action": "attach_provenance",
+                "source": "policy_gate",
+                "reason": "Missing explicit provenance.",
+                "required_evidence": [
+                    "source_url",
+                    "observed_at",
+                    "verification_signal",
+                ],
+                "proposed_evidence_patch": {
+                    "source_url": "https://example.com/source",
+                    "observed_at": "2026-05-11T00:00:00Z",
+                    "verification_signal": "manual_verified",
+                },
+            }
+        ],
+        approved_candidate_ids=["repair-123"],
+    )
+
+    payload = report.to_dict()
+    preview = payload["previews"][0]
+    assert payload["read_only"] is True
+    assert payload["read_only_memory"] is True
+    assert payload["would_mutate_memory"] is False
+    assert payload["summary"]["ready_count"] == 1
+    assert preview["id"].startswith("preview-")
+    assert preview["candidate_id"] == "repair-123"
+    assert preview["status"] == PREVIEW_STATUS_READY_FOR_MANUAL_APPLY
+    assert preview["operation"] == PATCH_OPERATION
+    assert preview["would_update_fields"] == [
+        "source_url",
+        "observed_at",
+        "verification_signal",
+    ]
+    assert preview["missing_evidence"] == []
+    assert preview["memory_patch_preview"]["operation"] == PATCH_OPERATION
+
+
+def test_preview_blocks_missing_evidence_until_completed():
+    report = build_evidence_repair_apply_preview(
+        candidates=[
+            {
+                "id": "repair-456",
+                "provider": "graph",
+                "priority": "medium",
+                "repair_action": "refresh_observation",
+                "required_evidence": ["observed_at", "freshness_check"],
+                "proposed_evidence_patch": {
+                    "observed_at": "<pending>",
+                    "freshness_check": "confirmed_current",
+                },
+            }
+        ],
+        approved_candidate_ids=["repair-456"],
+    )
+
+    payload = report.to_dict()
+    preview = payload["previews"][0]
+    assert preview["status"] == PREVIEW_STATUS_BLOCKED_MISSING_EVIDENCE
+    assert preview["missing_evidence"] == ["observed_at"]
+    assert payload["summary"]["missing_evidence_count"] == 1
+    assert payload["summary"]["ready_count"] == 0
+
+
+def test_preview_awaits_confirmation_when_not_approved():
+    report = build_evidence_repair_apply_preview(
+        candidates=[
+            {
+                "id": "repair-789",
+                "provider": "builtin",
+                "repair_action": "attach_provenance",
+                "required_evidence": ["source_url"],
+                "proposed_evidence_patch": {"source_url": "https://example.com"},
+            }
+        ],
+    )
+
+    payload = report.to_dict()
+    assert payload["previews"][0]["status"] == PREVIEW_STATUS_AWAITING_CONFIRMATION
+    assert payload["summary"]["requires_user_confirmation"] is True
+
+
+def test_proposed_evidence_can_fill_candidate_patch():
+    report = build_evidence_repair_apply_preview(
+        candidates=[
+            {
+                "id": "repair-abc",
+                "provider": "builtin",
+                "repair_action": "attach_provenance",
+                "required_evidence": ["source_url", "observed_at"],
+                "proposed_evidence_patch": {
+                    "source_url": "<pending>",
+                    "observed_at": "<pending>",
+                },
+            }
+        ],
+        approved_candidate_ids=["repair-abc"],
+        proposed_evidence={
+            "repair-abc": {
+                "source_url": "https://example.com/source",
+                "observed_at": "2026-05-11T00:00:00Z",
+            }
+        },
+    )
+
+    preview = report.to_dict()["previews"][0]
+    assert preview["status"] == PREVIEW_STATUS_READY_FOR_MANUAL_APPLY
+    assert preview["evidence_patch"] == {
+        "source_url": "https://example.com/source",
+        "observed_at": "2026-05-11T00:00:00Z",
+    }
+
+
+def test_empty_apply_preview_is_read_only():
+    payload = empty_evidence_repair_apply_preview().to_dict()
+
+    assert payload["read_only"] is True
+    assert payload["read_only_memory"] is True
+    assert payload["would_mutate_memory"] is False
+    assert payload["summary"]["preview_count"] == 0
+    assert payload["previews"] == []

--- a/tests/agent/test_memory_evidence_repair_approval.py
+++ b/tests/agent/test_memory_evidence_repair_approval.py
@@ -1,0 +1,101 @@
+from agent.memory_evidence_repair_approval import (
+    CANDIDATE_TYPE,
+    PENDING_VALUE,
+    STATUS_NEEDS_CONFIRMATION,
+    build_evidence_repair_approval_candidates,
+    empty_evidence_repair_approval_candidates,
+)
+
+
+def test_builds_approval_candidate_from_repair_plan():
+    report = build_evidence_repair_approval_candidates(
+        plan={
+            "repairs": [
+                {
+                    "provider": "builtin",
+                    "priority": "high",
+                    "action": "attach_provenance",
+                    "source": "policy_gate",
+                    "reason": "Missing explicit provenance.",
+                    "content_preview": "Weak memory content.",
+                    "required_evidence": [
+                        "source_url",
+                        "observed_at",
+                        "verification_signal",
+                    ],
+                }
+            ],
+            "read_only": True,
+        }
+    )
+
+    payload = report.to_dict()
+    candidate = payload["candidates"][0]
+    assert payload["read_only"] is True
+    assert payload["read_only_memory"] is True
+    assert payload["summary"]["candidate_count"] == 1
+    assert payload["summary"]["requires_user_confirmation"] is True
+    assert candidate["id"].startswith("repair-")
+    assert candidate["candidate_type"] == CANDIDATE_TYPE
+    assert candidate["status"] == STATUS_NEEDS_CONFIRMATION
+    assert candidate["provider"] == "builtin"
+    assert candidate["required_evidence"] == [
+        "source_url",
+        "observed_at",
+        "verification_signal",
+    ]
+    assert candidate["proposed_evidence_patch"] == {
+        "source_url": PENDING_VALUE,
+        "observed_at": PENDING_VALUE,
+        "verification_signal": PENDING_VALUE,
+    }
+
+
+def test_candidate_id_is_stable_and_proposed_evidence_fills_patch():
+    plan = {
+        "repairs": [
+            {
+                "provider": "graph",
+                "priority": "medium",
+                "action": "refresh_observation",
+                "source": "diagnostics",
+                "reason": "Recall may be stale.",
+                "required_evidence": ["observed_at", "freshness_check"],
+            }
+        ]
+    }
+
+    first = build_evidence_repair_approval_candidates(
+        plan=plan,
+        proposed_evidence={
+            "observed_at": "2026-05-11T00:00:00Z",
+            "freshness_check": "confirmed_current",
+        },
+    ).to_dict()
+    second = build_evidence_repair_approval_candidates(
+        plan=plan,
+        proposed_evidence={
+            "observed_at": "2026-05-11T00:00:00Z",
+            "freshness_check": "confirmed_current",
+        },
+    ).to_dict()
+
+    first_candidate = first["candidates"][0]
+    second_candidate = second["candidates"][0]
+    assert first_candidate["id"] == second_candidate["id"]
+    assert first_candidate["proposed_evidence_patch"] == {
+        "observed_at": "2026-05-11T00:00:00Z",
+        "freshness_check": "confirmed_current",
+    }
+    assert first["summary"]["by_provider"] == {"graph": 1}
+    assert first["summary"]["by_repair_action"] == {"refresh_observation": 1}
+
+
+def test_empty_approval_report_is_read_only():
+    payload = empty_evidence_repair_approval_candidates().to_dict()
+
+    assert payload["read_only"] is True
+    assert payload["read_only_memory"] is True
+    assert payload["summary"]["candidate_count"] == 0
+    assert payload["summary"]["requires_user_confirmation"] is False
+    assert payload["candidates"] == []

--- a/tests/agent/test_memory_evidence_repair_approval_token_gate.py
+++ b/tests/agent/test_memory_evidence_repair_approval_token_gate.py
@@ -1,0 +1,148 @@
+from agent.memory_evidence_repair_approval_token_gate import (
+    CHECK_CONFIRMATION_TEXT,
+    CHECK_EXPIRY,
+    CHECK_PATCH_DIGESTS,
+    CHECK_REUSE,
+    TOKEN_GATE_STATUS_BLOCKED,
+    TOKEN_GATE_STATUS_NO_ACTION_NEEDED,
+    TOKEN_GATE_STATUS_VERIFIED,
+    build_evidence_repair_approval_token_gate,
+    empty_evidence_repair_approval_token_gate,
+)
+from agent.memory_evidence_repair_human_approval_token import (
+    build_evidence_repair_human_approval_token,
+)
+
+
+def _ready_dry_run():
+    return {
+        "status": "ready_for_manual_commit",
+        "summary": {
+            "manual_commit_allowed": True,
+            "operation_count": 1,
+            "has_blocks": False,
+        },
+        "checks": [{"id": "commit_gate", "status": "pass"}],
+        "operations": [
+            {
+                "id": "dryrun-op-123",
+                "ledger_entry_id": "ledger-123",
+                "candidate_id": "repair-123",
+                "preview_id": "preview-123",
+                "provider": "builtin",
+                "repair_action": "attach_provenance",
+                "patch_digest": "a" * 64,
+                "target": {"candidate_id": "repair-123"},
+                "evidence_fields": ["source_url"],
+            }
+        ],
+        "blocking_reasons": [],
+        "required_actions": [],
+    }
+
+
+def _token_report():
+    payload = build_evidence_repair_human_approval_token(
+        dry_run=_ready_dry_run(),
+        approver="han",
+        approval_reason="final manual approval",
+        expires_in_minutes=30,
+    ).to_dict()
+    payload["generated_at"] = "2026-05-11T00:00:00+00:00"
+    return payload
+
+
+def test_exact_confirmation_verifies_token_gate():
+    token_report = _token_report()
+    confirmation_text = token_report["tokens"][0]["required_confirmation_text"]
+
+    payload = build_evidence_repair_approval_token_gate(
+        approval_token=token_report,
+        confirmation_text=confirmation_text,
+        current_time="2026-05-11T00:10:00+00:00",
+    ).to_dict()
+
+    assert payload["status"] == TOKEN_GATE_STATUS_VERIFIED
+    assert payload["summary"]["manual_commit_verified"] is True
+    assert payload["summary"]["fail_count"] == 0
+    assert payload["verified_operation_ids"] == ["dryrun-op-123"]
+    assert payload["verified_candidate_ids"] == ["repair-123"]
+    assert payload["read_only"] is True
+    assert payload["read_only_memory"] is True
+    assert payload["would_mutate_memory"] is False
+
+
+def test_wrong_confirmation_blocks_token_gate():
+    payload = build_evidence_repair_approval_token_gate(
+        approval_token=_token_report(),
+        confirmation_text="APPROVE the wrong thing",
+        current_time="2026-05-11T00:10:00+00:00",
+    ).to_dict()
+
+    failed_checks = {check["id"] for check in payload["checks"] if check["status"] == "fail"}
+    assert payload["status"] == TOKEN_GATE_STATUS_BLOCKED
+    assert CHECK_CONFIRMATION_TEXT in failed_checks
+    assert "provide_exact_confirmation_text" in payload["required_actions"]
+
+
+def test_changed_patch_digest_blocks_token_gate():
+    token_report = _token_report()
+    dry_run = _ready_dry_run()
+    dry_run["operations"][0]["patch_digest"] = "b" * 64
+    confirmation_text = token_report["tokens"][0]["required_confirmation_text"]
+
+    payload = build_evidence_repair_approval_token_gate(
+        approval_token=token_report,
+        dry_run=dry_run,
+        confirmation_text=confirmation_text,
+        current_time="2026-05-11T00:10:00+00:00",
+    ).to_dict()
+
+    failed_checks = {check["id"] for check in payload["checks"] if check["status"] == "fail"}
+    assert payload["status"] == TOKEN_GATE_STATUS_BLOCKED
+    assert CHECK_PATCH_DIGESTS in failed_checks
+    assert "regenerate_human_approval_token_for_current_patch_set" in payload["required_actions"]
+
+
+def test_expired_token_blocks_token_gate():
+    token_report = _token_report()
+    confirmation_text = token_report["tokens"][0]["required_confirmation_text"]
+
+    payload = build_evidence_repair_approval_token_gate(
+        approval_token=token_report,
+        confirmation_text=confirmation_text,
+        current_time="2026-05-11T00:31:00+00:00",
+    ).to_dict()
+
+    failed_checks = {check["id"] for check in payload["checks"] if check["status"] == "fail"}
+    assert payload["status"] == TOKEN_GATE_STATUS_BLOCKED
+    assert CHECK_EXPIRY in failed_checks
+    assert "Approval token has expired." in payload["blocking_reasons"]
+
+
+def test_used_token_id_blocks_token_gate():
+    token_report = _token_report()
+    token_id = token_report["tokens"][0]["id"]
+    confirmation_text = token_report["tokens"][0]["required_confirmation_text"]
+
+    payload = build_evidence_repair_approval_token_gate(
+        approval_token=token_report,
+        confirmation_text=confirmation_text,
+        used_token_ids=[token_id],
+        current_time="2026-05-11T00:10:00+00:00",
+    ).to_dict()
+
+    failed_checks = {check["id"] for check in payload["checks"] if check["status"] == "fail"}
+    assert payload["status"] == TOKEN_GATE_STATUS_BLOCKED
+    assert CHECK_REUSE in failed_checks
+    assert "Approval token is already marked as used." in payload["blocking_reasons"]
+
+
+def test_empty_token_gate_is_read_only():
+    payload = empty_evidence_repair_approval_token_gate().to_dict()
+
+    assert payload["status"] == TOKEN_GATE_STATUS_NO_ACTION_NEEDED
+    assert payload["read_only"] is True
+    assert payload["read_only_memory"] is True
+    assert payload["would_mutate_memory"] is False
+    assert payload["checks"] == []

--- a/tests/agent/test_memory_evidence_repair_commit_gate.py
+++ b/tests/agent/test_memory_evidence_repair_commit_gate.py
@@ -1,0 +1,118 @@
+from agent.memory_evidence_repair_commit_gate import (
+    DECISION_ALLOW_MANUAL_COMMIT,
+    DECISION_BLOCK_COMMIT,
+    DECISION_NEEDS_USER_CONFIRMATION,
+    REASON_MISSING_CONFIRMATION,
+    REASON_MISSING_EVIDENCE,
+    REASON_UNSAFE_OPERATION,
+    build_evidence_repair_commit_gate,
+    empty_evidence_repair_commit_gate,
+)
+
+
+def _ready_preview():
+    return {
+        "id": "preview-123",
+        "candidate_id": "repair-123",
+        "status": "ready_for_manual_apply",
+        "provider": "builtin",
+        "priority": "high",
+        "repair_action": "attach_provenance",
+        "operation": "merge_evidence_metadata",
+        "target": {"candidate_id": "repair-123", "provider": "builtin"},
+        "evidence_patch": {
+            "source_url": "https://example.com/source",
+            "observed_at": "2026-05-11T00:00:00Z",
+            "verification_signal": "manual_verified",
+        },
+        "memory_patch_preview": {
+            "operation": "merge_evidence_metadata",
+            "target": {"candidate_id": "repair-123", "provider": "builtin"},
+            "set": {"evidence": {}},
+        },
+        "missing_evidence": [],
+    }
+
+
+def test_gate_allows_ready_preview_with_explicit_confirmation():
+    report = build_evidence_repair_commit_gate(
+        previews=[_ready_preview()],
+        confirmed_preview_ids=["preview-123"],
+    )
+
+    payload = report.to_dict()
+    decision = payload["decisions"][0]
+    assert payload["read_only"] is True
+    assert payload["read_only_memory"] is True
+    assert payload["would_mutate_memory"] is False
+    assert payload["summary"]["allow_count"] == 1
+    assert decision["decision"] == DECISION_ALLOW_MANUAL_COMMIT
+    assert decision["reasons"] == []
+    assert decision["required_actions"] == []
+    assert decision["preview_id"] == "preview-123"
+
+
+def test_gate_needs_confirmation_for_ready_unconfirmed_preview():
+    report = build_evidence_repair_commit_gate(previews=[_ready_preview()])
+
+    payload = report.to_dict()
+    decision = payload["decisions"][0]
+    assert decision["decision"] == DECISION_NEEDS_USER_CONFIRMATION
+    assert decision["reasons"] == [REASON_MISSING_CONFIRMATION]
+    assert "obtain_explicit_user_confirmation" in decision["required_actions"]
+    assert payload["summary"]["requires_user_confirmation"] is True
+
+
+def test_gate_blocks_missing_evidence_even_when_confirmed():
+    preview = _ready_preview()
+    preview["missing_evidence"] = ["source_url"]
+
+    report = build_evidence_repair_commit_gate(
+        previews=[preview],
+        confirmed_preview_ids=["preview-123"],
+    )
+
+    payload = report.to_dict()
+    decision = payload["decisions"][0]
+    assert decision["decision"] == DECISION_BLOCK_COMMIT
+    assert REASON_MISSING_EVIDENCE in decision["reasons"]
+    assert payload["summary"]["blocked_count"] == 1
+
+
+def test_gate_blocks_unsafe_operation():
+    preview = _ready_preview()
+    preview["operation"] = "replace_memory_content"
+
+    report = build_evidence_repair_commit_gate(
+        previews=[preview],
+        confirmed_preview_ids=["preview-123"],
+    )
+
+    decision = report.to_dict()["decisions"][0]
+    assert decision["decision"] == DECISION_BLOCK_COMMIT
+    assert REASON_UNSAFE_OPERATION in decision["reasons"]
+
+
+def test_conflict_preview_requires_resolution():
+    preview = _ready_preview()
+    preview["repair_action"] = "review_conflict"
+
+    report = build_evidence_repair_commit_gate(
+        previews=[preview],
+        confirmed_preview_ids=["preview-123"],
+    )
+
+    decision = report.to_dict()["decisions"][0]
+    assert decision["decision"] == DECISION_BLOCK_COMMIT
+    assert decision["conflict_risk"] == "high"
+    assert "provide_conflict_resolution" in decision["required_actions"]
+
+
+def test_empty_commit_gate_is_read_only():
+    payload = empty_evidence_repair_commit_gate().to_dict()
+
+    assert payload["read_only"] is True
+    assert payload["read_only_memory"] is True
+    assert payload["would_mutate_memory"] is False
+    assert payload["summary"]["decision_count"] == 0
+    assert payload["decisions"] == []

--- a/tests/agent/test_memory_evidence_repair_commit_ledger.py
+++ b/tests/agent/test_memory_evidence_repair_commit_ledger.py
@@ -1,0 +1,110 @@
+from agent.memory_evidence_repair_commit_ledger import (
+    LEDGER_EVENT_TYPE,
+    LEDGER_STATUS_DRAFT,
+    OUTCOME_ALLOWED,
+    OUTCOME_BLOCKED,
+    OUTCOME_NEEDS_CONFIRMATION,
+    build_evidence_repair_commit_ledger,
+    empty_evidence_repair_commit_ledger,
+)
+
+
+def _allow_decision():
+    return {
+        "id": "gate-preview-123",
+        "preview_id": "preview-123",
+        "candidate_id": "repair-123",
+        "decision": "allow_manual_commit",
+        "provider": "builtin",
+        "priority": "high",
+        "repair_action": "attach_provenance",
+        "reasons": [],
+        "required_actions": [],
+        "target": {"candidate_id": "repair-123", "provider": "builtin"},
+        "evidence_patch": {
+            "source_url": "https://example.com/source",
+            "observed_at": "2026-05-11T00:00:00Z",
+            "verification_signal": "manual_verified",
+        },
+        "memory_patch_preview": {
+            "operation": "merge_evidence_metadata",
+            "set": {"evidence": {}},
+        },
+        "conflict_risk": "low",
+    }
+
+
+def test_ledger_entry_from_allow_decision():
+    draft = build_evidence_repair_commit_ledger(
+        decisions=[_allow_decision()],
+        ledger_actor="tester",
+        ledger_reason="audit before manual memory write",
+    )
+
+    payload = draft.to_dict()
+    entry = payload["entries"][0]
+    assert payload["read_only"] is True
+    assert payload["read_only_memory"] is True
+    assert payload["would_mutate_memory"] is False
+    assert payload["summary"]["allow_count"] == 1
+    assert entry["id"].startswith("ledger-")
+    assert entry["event_type"] == LEDGER_EVENT_TYPE
+    assert entry["status"] == LEDGER_STATUS_DRAFT
+    assert entry["outcome"] == OUTCOME_ALLOWED
+    assert entry["manual_commit_allowed"] is True
+    assert entry["blocked"] is False
+    assert entry["requires_followup"] is False
+    assert entry["evidence_fields"] == [
+        "source_url",
+        "observed_at",
+        "verification_signal",
+    ]
+    assert len(entry["patch_digest"]) == 64
+    assert entry["metadata"]["ledger_actor"] == "tester"
+
+
+def test_ledger_entry_from_blocked_decision_requires_followup():
+    decision = _allow_decision()
+    decision["decision"] = "block_commit"
+    decision["reasons"] = ["missing_evidence"]
+    decision["required_actions"] = ["complete_required_evidence"]
+
+    payload = build_evidence_repair_commit_ledger(decisions=[decision]).to_dict()
+    entry = payload["entries"][0]
+    assert entry["outcome"] == OUTCOME_BLOCKED
+    assert entry["manual_commit_allowed"] is False
+    assert entry["blocked"] is True
+    assert entry["requires_followup"] is True
+    assert payload["summary"]["blocked_count"] == 1
+    assert payload["summary"]["followup_count"] == 1
+
+
+def test_ledger_entry_from_needs_confirmation_decision():
+    decision = _allow_decision()
+    decision["decision"] = "needs_user_confirmation"
+    decision["reasons"] = ["missing_user_confirmation"]
+    decision["required_actions"] = ["obtain_explicit_user_confirmation"]
+
+    payload = build_evidence_repair_commit_ledger(decisions=[decision]).to_dict()
+    entry = payload["entries"][0]
+    assert entry["outcome"] == OUTCOME_NEEDS_CONFIRMATION
+    assert entry["requires_followup"] is True
+    assert payload["summary"]["by_outcome"] == {OUTCOME_NEEDS_CONFIRMATION: 1}
+
+
+def test_ledger_entry_id_and_patch_digest_are_stable():
+    first = build_evidence_repair_commit_ledger(decisions=[_allow_decision()]).to_dict()
+    second = build_evidence_repair_commit_ledger(decisions=[_allow_decision()]).to_dict()
+
+    assert first["entries"][0]["id"] == second["entries"][0]["id"]
+    assert first["entries"][0]["patch_digest"] == second["entries"][0]["patch_digest"]
+
+
+def test_empty_ledger_is_read_only():
+    payload = empty_evidence_repair_commit_ledger().to_dict()
+
+    assert payload["read_only"] is True
+    assert payload["read_only_memory"] is True
+    assert payload["would_mutate_memory"] is False
+    assert payload["summary"]["entry_count"] == 0
+    assert payload["entries"] == []

--- a/tests/agent/test_memory_evidence_repair_commit_receipt.py
+++ b/tests/agent/test_memory_evidence_repair_commit_receipt.py
@@ -1,0 +1,150 @@
+from agent.memory_evidence_repair_approval_token_gate import (
+    build_evidence_repair_approval_token_gate,
+)
+from agent.memory_evidence_repair_commit_receipt import (
+    RECEIPT_STATUS_BLOCKED,
+    RECEIPT_STATUS_NO_ACTION_NEEDED,
+    RECEIPT_STATUS_READY,
+    RECEIPT_TYPE,
+    build_evidence_repair_commit_receipt,
+    empty_evidence_repair_commit_receipt,
+)
+from agent.memory_evidence_repair_human_approval_token import (
+    build_evidence_repair_human_approval_token,
+)
+
+
+def _ready_dry_run():
+    return {
+        "status": "ready_for_manual_commit",
+        "summary": {
+            "manual_commit_allowed": True,
+            "operation_count": 1,
+            "has_blocks": False,
+        },
+        "checks": [{"id": "commit_gate", "status": "pass"}],
+        "operations": [
+            {
+                "id": "dryrun-op-123",
+                "ledger_entry_id": "ledger-123",
+                "candidate_id": "repair-123",
+                "preview_id": "preview-123",
+                "provider": "builtin",
+                "repair_action": "attach_provenance",
+                "patch_digest": "a" * 64,
+                "target": {"candidate_id": "repair-123"},
+                "evidence_fields": ["source_url"],
+            }
+        ],
+        "blocking_reasons": [],
+        "required_actions": [],
+    }
+
+
+def _token_report():
+    payload = build_evidence_repair_human_approval_token(
+        dry_run=_ready_dry_run(),
+        approver="han",
+        approval_reason="final manual approval",
+        expires_in_minutes=30,
+    ).to_dict()
+    payload["generated_at"] = "2026-05-11T00:00:00+00:00"
+    return payload
+
+
+def _verified_gate():
+    token_report = _token_report()
+    return build_evidence_repair_approval_token_gate(
+        approval_token=token_report,
+        confirmation_text=token_report["tokens"][0]["required_confirmation_text"],
+        current_time="2026-05-11T00:10:00+00:00",
+    ).to_dict()
+
+
+def test_verified_gate_creates_read_only_commit_receipt():
+    payload = build_evidence_repair_commit_receipt(
+        token_gate=_verified_gate(),
+        actor="han",
+        commit_reason="manual memory evidence repair",
+    ).to_dict()
+
+    receipt = payload["receipts"][0]
+    assert payload["status"] == RECEIPT_STATUS_READY
+    assert payload["summary"]["commit_receipt_available"] is True
+    assert payload["summary"]["would_mark_token_used_count"] == 1
+    assert payload["read_only"] is True
+    assert payload["read_only_memory"] is True
+    assert payload["would_mutate_memory"] is False
+    assert receipt["id"].startswith("commit-receipt-")
+    assert receipt["receipt_type"] == RECEIPT_TYPE
+    assert receipt["actor"] == "han"
+    assert receipt["operation_ids"] == ["dryrun-op-123"]
+    assert receipt["ledger_entry_ids"] == ["ledger-123"]
+    assert receipt["candidate_ids"] == ["repair-123"]
+    assert receipt["used_token_id"] in payload["used_token_ids"]
+
+
+def test_blocked_gate_does_not_create_receipt():
+    gate = _verified_gate()
+    gate["status"] = "blocked"
+    gate["blocking_reasons"] = ["Approval token has expired."]
+    gate["required_actions"] = ["regenerate_human_approval_token"]
+
+    payload = build_evidence_repair_commit_receipt(token_gate=gate).to_dict()
+
+    assert payload["status"] == RECEIPT_STATUS_BLOCKED
+    assert payload["receipts"] == []
+    assert payload["blocking_reasons"] == ["Approval token has expired."]
+    assert payload["required_actions"] == ["regenerate_human_approval_token"]
+
+
+def test_existing_used_token_blocks_receipt():
+    gate = _verified_gate()
+    token_id = gate["token_id"]
+
+    payload = build_evidence_repair_commit_receipt(
+        token_gate=gate,
+        existing_receipts={"used_token_ids": [token_id]},
+    ).to_dict()
+
+    assert payload["status"] == RECEIPT_STATUS_BLOCKED
+    assert payload["receipts"] == []
+    assert "Approval token is already present in the used-token ledger." in payload["blocking_reasons"]
+    assert token_id in payload["used_token_ids"]
+
+
+def test_receipt_id_and_digest_are_stable():
+    gate = _verified_gate()
+    first = build_evidence_repair_commit_receipt(
+        token_gate=gate,
+        actor="han",
+        commit_reason="manual memory evidence repair",
+    ).to_dict()
+    second = build_evidence_repair_commit_receipt(
+        token_gate=gate,
+        actor="han",
+        commit_reason="manual memory evidence repair",
+    ).to_dict()
+
+    assert first["receipts"][0]["id"] == second["receipts"][0]["id"]
+    assert first["receipts"][0]["receipt_digest"] == second["receipts"][0]["receipt_digest"]
+
+
+def test_no_action_gate_does_not_create_receipt():
+    payload = build_evidence_repair_commit_receipt(
+        token_gate={"status": "no_action_needed"}
+    ).to_dict()
+
+    assert payload["status"] == RECEIPT_STATUS_NO_ACTION_NEEDED
+    assert payload["receipts"] == []
+    assert payload["summary"]["commit_receipt_available"] is False
+
+
+def test_empty_receipt_report_is_read_only():
+    payload = empty_evidence_repair_commit_receipt().to_dict()
+
+    assert payload["status"] == RECEIPT_STATUS_NO_ACTION_NEEDED
+    assert payload["read_only"] is True
+    assert payload["read_only_memory"] is True
+    assert payload["would_mutate_memory"] is False
+    assert payload["receipts"] == []

--- a/tests/agent/test_memory_evidence_repair_executor_preview.py
+++ b/tests/agent/test_memory_evidence_repair_executor_preview.py
@@ -1,0 +1,168 @@
+from agent.memory_evidence_repair_approval_token_gate import (
+    build_evidence_repair_approval_token_gate,
+)
+from agent.memory_evidence_repair_commit_receipt import (
+    build_evidence_repair_commit_receipt,
+)
+from agent.memory_evidence_repair_executor_preview import (
+    CHECK_EXECUTION_OPERATIONS,
+    CHECK_WRITE_LOCK_EXPIRY,
+    CHECK_WRITE_LOCK_INTEGRITY,
+    EXECUTOR_PREVIEW_STATUS_BLOCKED,
+    EXECUTOR_PREVIEW_STATUS_NO_ACTION_NEEDED,
+    EXECUTOR_PREVIEW_STATUS_READY,
+    build_evidence_repair_executor_preview,
+    empty_evidence_repair_executor_preview,
+)
+from agent.memory_evidence_repair_human_approval_token import (
+    build_evidence_repair_human_approval_token,
+)
+from agent.memory_evidence_repair_write_lock_gate import (
+    build_evidence_repair_write_lock_gate,
+)
+
+
+def _ready_dry_run():
+    return {
+        "status": "ready_for_manual_commit",
+        "summary": {
+            "manual_commit_allowed": True,
+            "operation_count": 1,
+            "has_blocks": False,
+        },
+        "checks": [{"id": "commit_gate", "status": "pass"}],
+        "operations": [
+            {
+                "id": "dryrun-op-123",
+                "ledger_entry_id": "ledger-123",
+                "candidate_id": "repair-123",
+                "preview_id": "preview-123",
+                "provider": "builtin",
+                "repair_action": "attach_provenance",
+                "patch_digest": "a" * 64,
+                "target": {"candidate_id": "repair-123"},
+                "evidence_fields": ["source_url"],
+            }
+        ],
+        "blocking_reasons": [],
+        "required_actions": [],
+    }
+
+
+def _write_lock_gate():
+    token_report = build_evidence_repair_human_approval_token(
+        dry_run=_ready_dry_run(),
+        approver="han",
+        approval_reason="final manual approval",
+        expires_in_minutes=30,
+    ).to_dict()
+    token_report["generated_at"] = "2026-05-11T00:00:00+00:00"
+    token_gate = build_evidence_repair_approval_token_gate(
+        approval_token=token_report,
+        confirmation_text=token_report["tokens"][0]["required_confirmation_text"],
+        current_time="2026-05-11T00:10:00+00:00",
+    ).to_dict()
+    receipt = build_evidence_repair_commit_receipt(
+        token_gate=token_gate,
+        actor="han",
+        commit_reason="manual memory evidence repair",
+    ).to_dict()
+    return build_evidence_repair_write_lock_gate(
+        commit_receipt=receipt,
+        lock_owner="han",
+        lock_ttl_minutes=15,
+        current_time="2026-05-11T00:20:00+00:00",
+    ).to_dict()
+
+
+def test_ready_write_lock_creates_executor_preview_steps():
+    payload = build_evidence_repair_executor_preview(
+        write_lock_gate=_write_lock_gate(),
+        current_time="2026-05-11T00:25:00+00:00",
+    ).to_dict()
+
+    preview = payload["previews"][0]
+    steps = preview["steps"]
+    assert payload["status"] == EXECUTOR_PREVIEW_STATUS_READY
+    assert payload["summary"]["manual_executor_preview_ready"] is True
+    assert payload["summary"]["future_write_step_count"] == 1
+    assert payload["read_only"] is True
+    assert payload["read_only_memory"] is True
+    assert payload["would_mutate_memory"] is False
+    assert preview["id"].startswith("executor-preview-")
+    assert preview["would_apply_memory_patches"] is True
+    assert preview["would_release_write_lock"] is True
+    assert [step["action"] for step in steps] == [
+        "verify_write_lock_and_receipt",
+        "apply_evidence_metadata_patch",
+        "record_commit_receipt",
+        "mark_approval_token_used",
+        "release_write_lock",
+    ]
+    assert steps[1]["operation_id"] == "dryrun-op-123"
+    assert steps[1]["future_would_write_memory"] is True
+    assert steps[-1]["stop_on_failure"] is False
+
+
+def test_expired_write_lock_blocks_executor_preview():
+    payload = build_evidence_repair_executor_preview(
+        write_lock_gate=_write_lock_gate(),
+        current_time="2026-05-11T00:36:00+00:00",
+    ).to_dict()
+
+    failed_checks = {check["id"] for check in payload["checks"] if check["status"] == "fail"}
+    assert payload["status"] == EXECUTOR_PREVIEW_STATUS_BLOCKED
+    assert CHECK_WRITE_LOCK_EXPIRY in failed_checks
+    assert "regenerate_write_lock_gate" in payload["required_actions"]
+
+
+def test_tampered_write_lock_digest_blocks_executor_preview():
+    gate = _write_lock_gate()
+    gate["locks"][0]["lock_digest"] = "bad"
+
+    payload = build_evidence_repair_executor_preview(
+        write_lock_gate=gate,
+        current_time="2026-05-11T00:25:00+00:00",
+    ).to_dict()
+
+    failed_checks = {check["id"] for check in payload["checks"] if check["status"] == "fail"}
+    assert payload["status"] == EXECUTOR_PREVIEW_STATUS_BLOCKED
+    assert CHECK_WRITE_LOCK_INTEGRITY in failed_checks
+    assert "regenerate_write_lock_gate" in payload["required_actions"]
+
+
+def test_mismatched_operation_patch_blocks_executor_preview():
+    gate = _write_lock_gate()
+    source_operation = (
+        gate["locks"][0]["source_receipt"]["source_gate"]["source_dry_run"]["operations"][0]
+    )
+    source_operation["patch_digest"] = "b" * 64
+
+    payload = build_evidence_repair_executor_preview(
+        write_lock_gate=gate,
+        current_time="2026-05-11T00:25:00+00:00",
+    ).to_dict()
+
+    failed_checks = {check["id"] for check in payload["checks"] if check["status"] == "fail"}
+    assert payload["status"] == EXECUTOR_PREVIEW_STATUS_BLOCKED
+    assert CHECK_EXECUTION_OPERATIONS in failed_checks
+
+
+def test_no_action_write_lock_gate_does_not_create_preview():
+    payload = build_evidence_repair_executor_preview(
+        write_lock_gate={"status": "no_action_needed"}
+    ).to_dict()
+
+    assert payload["status"] == EXECUTOR_PREVIEW_STATUS_NO_ACTION_NEEDED
+    assert payload["previews"] == []
+    assert payload["summary"]["executor_preview_available"] is False
+
+
+def test_empty_executor_preview_is_read_only():
+    payload = empty_evidence_repair_executor_preview().to_dict()
+
+    assert payload["status"] == EXECUTOR_PREVIEW_STATUS_NO_ACTION_NEEDED
+    assert payload["read_only"] is True
+    assert payload["read_only_memory"] is True
+    assert payload["would_mutate_memory"] is False
+    assert payload["previews"] == []

--- a/tests/agent/test_memory_evidence_repair_human_approval_token.py
+++ b/tests/agent/test_memory_evidence_repair_human_approval_token.py
@@ -1,0 +1,113 @@
+from agent.memory_evidence_repair_human_approval_token import (
+    APPROVAL_TOKEN_SCOPE,
+    APPROVAL_TOKEN_TYPE,
+    TOKEN_STATUS_BLOCKED,
+    TOKEN_STATUS_DRAFT_READY,
+    TOKEN_STATUS_NO_ACTION_NEEDED,
+    build_evidence_repair_human_approval_token,
+    empty_evidence_repair_human_approval_token,
+)
+
+
+def _ready_dry_run():
+    return {
+        "status": "ready_for_manual_commit",
+        "summary": {
+            "manual_commit_allowed": True,
+            "operation_count": 1,
+            "has_blocks": False,
+        },
+        "checks": [{"id": "commit_gate", "status": "pass"}],
+        "operations": [
+            {
+                "id": "dryrun-op-123",
+                "ledger_entry_id": "ledger-123",
+                "candidate_id": "repair-123",
+                "preview_id": "preview-123",
+                "provider": "builtin",
+                "repair_action": "attach_provenance",
+                "patch_digest": "a" * 64,
+                "target": {"candidate_id": "repair-123"},
+                "evidence_fields": ["source_url"],
+            }
+        ],
+        "blocking_reasons": [],
+        "required_actions": [],
+    }
+
+
+def test_ready_dry_run_creates_token_draft():
+    payload = build_evidence_repair_human_approval_token(
+        dry_run=_ready_dry_run(),
+        approver="han",
+        approval_reason="final manual approval",
+        expires_in_minutes=45,
+    ).to_dict()
+
+    token = payload["tokens"][0]
+    assert payload["status"] == TOKEN_STATUS_DRAFT_READY
+    assert payload["summary"]["token_count"] == 1
+    assert payload["read_only"] is True
+    assert payload["read_only_memory"] is True
+    assert payload["would_mutate_memory"] is False
+    assert token["id"].startswith("approval-token-")
+    assert token["token_type"] == APPROVAL_TOKEN_TYPE
+    assert token["scope"] == APPROVAL_TOKEN_SCOPE
+    assert token["approver"] == "han"
+    assert token["expires_in_minutes"] == 45
+    assert token["operation_ids"] == ["dryrun-op-123"]
+    assert token["ledger_entry_ids"] == ["ledger-123"]
+    assert token["candidate_ids"] == ["repair-123"]
+    assert len(token["token_digest"]) == 64
+    assert token["one_time_constraints"]["one_time_use"] is True
+    assert token["required_confirmation_text"].startswith("APPROVE ")
+
+
+def test_blocked_dry_run_does_not_create_token():
+    dry_run = _ready_dry_run()
+    dry_run["status"] = "blocked"
+    dry_run["blocking_reasons"] = ["Pre-commit snapshots are still required."]
+    dry_run["required_actions"] = ["capture_pre_commit_snapshots"]
+
+    payload = build_evidence_repair_human_approval_token(dry_run=dry_run).to_dict()
+
+    assert payload["status"] == TOKEN_STATUS_BLOCKED
+    assert payload["tokens"] == []
+    assert payload["blocking_reasons"] == ["Pre-commit snapshots are still required."]
+    assert payload["required_actions"] == ["capture_pre_commit_snapshots"]
+
+
+def test_no_action_dry_run_does_not_create_token():
+    payload = build_evidence_repair_human_approval_token(
+        dry_run={"status": "no_action_needed", "operations": []}
+    ).to_dict()
+
+    assert payload["status"] == TOKEN_STATUS_NO_ACTION_NEEDED
+    assert payload["tokens"] == []
+    assert payload["summary"]["no_action_count"] == 1
+
+
+def test_token_id_and_digest_are_stable():
+    first = build_evidence_repair_human_approval_token(
+        dry_run=_ready_dry_run(),
+        approver="han",
+        approval_reason="final manual approval",
+    ).to_dict()
+    second = build_evidence_repair_human_approval_token(
+        dry_run=_ready_dry_run(),
+        approver="han",
+        approval_reason="final manual approval",
+    ).to_dict()
+
+    assert first["tokens"][0]["id"] == second["tokens"][0]["id"]
+    assert first["tokens"][0]["token_digest"] == second["tokens"][0]["token_digest"]
+
+
+def test_empty_token_report_is_read_only():
+    payload = empty_evidence_repair_human_approval_token().to_dict()
+
+    assert payload["status"] == TOKEN_STATUS_NO_ACTION_NEEDED
+    assert payload["read_only"] is True
+    assert payload["read_only_memory"] is True
+    assert payload["would_mutate_memory"] is False
+    assert payload["tokens"] == []

--- a/tests/agent/test_memory_evidence_repair_manual_commit_dry_run.py
+++ b/tests/agent/test_memory_evidence_repair_manual_commit_dry_run.py
@@ -1,0 +1,150 @@
+from agent.memory_evidence_repair_manual_commit_dry_run import (
+    CHECK_STATUS_FAIL,
+    CHECK_STATUS_PASS,
+    DRY_RUN_STATUS_BLOCKED,
+    DRY_RUN_STATUS_NO_ACTION_NEEDED,
+    DRY_RUN_STATUS_READY_FOR_MANUAL_COMMIT,
+    build_evidence_repair_manual_commit_dry_run,
+    empty_evidence_repair_manual_commit_dry_run,
+)
+
+
+def _commit_gate_allow():
+    return {
+        "summary": {
+            "decision_count": 1,
+            "allow_count": 1,
+            "blocked_count": 0,
+            "needs_confirmation_count": 0,
+        },
+        "decisions": [{"decision": "allow_manual_commit"}],
+    }
+
+
+def _ledger_allow():
+    return {
+        "summary": {
+            "entry_count": 1,
+            "allow_count": 1,
+            "blocked_count": 0,
+            "followup_count": 0,
+        },
+        "entries": [
+            {
+                "id": "ledger-123",
+                "manual_commit_allowed": True,
+                "candidate_id": "repair-123",
+                "preview_id": "preview-123",
+                "provider": "builtin",
+                "repair_action": "attach_provenance",
+                "patch_digest": "a" * 64,
+                "target": {"candidate_id": "repair-123"},
+                "evidence_fields": [
+                    "source_url",
+                    "observed_at",
+                    "verification_signal",
+                ],
+            }
+        ],
+    }
+
+
+def _rollback_ready():
+    return {
+        "summary": {
+            "rollback_step_count": 1,
+            "ready_count": 1,
+            "snapshot_required_count": 0,
+        },
+        "steps": [{"status": "ready_for_manual_rollback"}],
+    }
+
+
+def _snapshot_available():
+    return {
+        "summary": {
+            "snapshot_request_count": 1,
+            "capture_required_count": 0,
+            "blocking_count": 0,
+        },
+        "requests": [{"status": "already_available"}],
+    }
+
+
+def test_ready_dry_run_allows_manual_commit_without_mutation():
+    payload = build_evidence_repair_manual_commit_dry_run(
+        snapshot_plan=_snapshot_available(),
+        commit_gate=_commit_gate_allow(),
+        ledger=_ledger_allow(),
+        rollback_plan=_rollback_ready(),
+    ).to_dict()
+
+    assert payload["status"] == DRY_RUN_STATUS_READY_FOR_MANUAL_COMMIT
+    assert payload["read_only"] is True
+    assert payload["read_only_memory"] is True
+    assert payload["would_mutate_memory"] is False
+    assert payload["summary"]["manual_commit_allowed"] is True
+    assert payload["summary"]["operation_count"] == 1
+    assert payload["operations"][0]["id"].startswith("dryrun-op-")
+    assert payload["blocking_reasons"] == []
+    assert {check["status"] for check in payload["checks"]} == {CHECK_STATUS_PASS}
+
+
+def test_dry_run_blocks_when_snapshot_capture_is_required():
+    snapshot_plan = _snapshot_available()
+    snapshot_plan["summary"]["capture_required_count"] = 1
+    snapshot_plan["summary"]["blocking_count"] = 1
+
+    payload = build_evidence_repair_manual_commit_dry_run(
+        snapshot_plan=snapshot_plan,
+        commit_gate=_commit_gate_allow(),
+        ledger=_ledger_allow(),
+        rollback_plan=_rollback_ready(),
+    ).to_dict()
+
+    assert payload["status"] == DRY_RUN_STATUS_BLOCKED
+    assert payload["summary"]["has_blocks"] is True
+    assert "Pre-commit snapshots are still required." in payload["blocking_reasons"]
+    assert "capture_pre_commit_snapshots" in payload["required_actions"]
+
+
+def test_dry_run_blocks_when_commit_gate_is_not_clean():
+    commit_gate = _commit_gate_allow()
+    commit_gate["summary"]["blocked_count"] = 1
+    commit_gate["summary"]["allow_count"] = 0
+
+    payload = build_evidence_repair_manual_commit_dry_run(
+        snapshot_plan=_snapshot_available(),
+        commit_gate=commit_gate,
+        ledger=_ledger_allow(),
+        rollback_plan=_rollback_ready(),
+    ).to_dict()
+
+    gate_check = next(check for check in payload["checks"] if check["id"] == "commit_gate")
+    assert payload["status"] == DRY_RUN_STATUS_BLOCKED
+    assert gate_check["status"] == CHECK_STATUS_FAIL
+    assert "resolve_commit_gate_blocks" in gate_check["required_actions"]
+
+
+def test_dry_run_has_no_action_without_operations():
+    payload = build_evidence_repair_manual_commit_dry_run(
+        snapshot_plan={},
+        commit_gate={},
+        ledger={},
+        rollback_plan={},
+    ).to_dict()
+
+    assert payload["status"] == DRY_RUN_STATUS_NO_ACTION_NEEDED
+    assert payload["summary"]["operation_count"] == 0
+    assert payload["summary"]["manual_commit_allowed"] is False
+
+
+def test_empty_dry_run_is_read_only():
+    payload = empty_evidence_repair_manual_commit_dry_run().to_dict()
+
+    assert payload["status"] == DRY_RUN_STATUS_NO_ACTION_NEEDED
+    assert payload["read_only"] is True
+    assert payload["read_only_memory"] is True
+    assert payload["would_mutate_memory"] is False
+    assert payload["checks"] == []
+    assert payload["operations"] == []

--- a/tests/agent/test_memory_evidence_repair_planner.py
+++ b/tests/agent/test_memory_evidence_repair_planner.py
@@ -1,0 +1,75 @@
+from agent.memory_evidence_repair_planner import (
+    ACTION_ATTACH_PROVENANCE,
+    ACTION_REFRESH_OBSERVATION,
+    build_evidence_repair_plan,
+    empty_evidence_repair_plan,
+)
+
+
+def test_plan_from_policy_gate_filters_requires_provenance():
+    plan = build_evidence_repair_plan(
+        gate={
+            "provider_results": [
+                {
+                    "provider": "builtin",
+                    "action": "require_provenance_before_reuse",
+                    "effect": "filtered",
+                    "reason": "Recall candidate lacks explicit provenance required by policy.",
+                },
+                {
+                    "provider": "graph",
+                    "action": "allow_memory_recall",
+                    "effect": "allowed",
+                    "reason": "No restriction.",
+                },
+            ]
+        }
+    )
+
+    payload = plan.to_dict()
+    assert payload["read_only"] is True
+    assert payload["summary"]["repair_count"] == 1
+    assert payload["summary"]["blocked_count"] == 1
+    assert payload["repairs"][0]["provider"] == "builtin"
+    assert payload["repairs"][0]["action"] == ACTION_ATTACH_PROVENANCE
+    assert "source_url" in payload["repairs"][0]["required_evidence"]
+
+
+def test_plan_from_diagnostics_and_audit():
+    plan = build_evidence_repair_plan(
+        diagnostics={
+            "issues": [
+                {
+                    "provider": "graph",
+                    "code": "refresh_stale_recall",
+                    "reason": "Recall may be stale.",
+                    "evidence": "staleness=0.7",
+                }
+            ]
+        },
+        audit={
+            "entries": [
+                {
+                    "provider": "builtin",
+                    "decision": "injected",
+                    "recommendation": "needs_evidence",
+                    "dimensions": {"source_strength": 0.2, "evidence_strength": 0.3},
+                    "content_preview": "Remember a weakly sourced fact.",
+                }
+            ]
+        },
+    )
+
+    payload = plan.to_dict()
+    actions = {repair["action"] for repair in payload["repairs"]}
+    assert ACTION_ATTACH_PROVENANCE in actions
+    assert ACTION_REFRESH_OBSERVATION in actions
+    assert payload["summary"]["by_provider"] == {"builtin": 1, "graph": 1}
+
+
+def test_empty_plan_is_read_only():
+    payload = empty_evidence_repair_plan().to_dict()
+
+    assert payload["read_only"] is True
+    assert payload["summary"]["repair_count"] == 0
+    assert payload["repairs"] == []

--- a/tests/agent/test_memory_evidence_repair_post_commit_audit_preview.py
+++ b/tests/agent/test_memory_evidence_repair_post_commit_audit_preview.py
@@ -1,0 +1,174 @@
+from agent.memory_evidence_repair_approval_token_gate import (
+    build_evidence_repair_approval_token_gate,
+)
+from agent.memory_evidence_repair_commit_receipt import (
+    build_evidence_repair_commit_receipt,
+)
+from agent.memory_evidence_repair_executor_preview import (
+    build_evidence_repair_executor_preview,
+)
+from agent.memory_evidence_repair_human_approval_token import (
+    build_evidence_repair_human_approval_token,
+)
+from agent.memory_evidence_repair_post_commit_audit_preview import (
+    CHECK_EXECUTOR_PREVIEW_INTEGRITY,
+    CHECK_OBSERVED_POST_STATE,
+    POST_COMMIT_AUDIT_STATUS_BLOCKED,
+    POST_COMMIT_AUDIT_STATUS_NO_ACTION_NEEDED,
+    POST_COMMIT_AUDIT_STATUS_READY,
+    build_evidence_repair_post_commit_audit_preview,
+    empty_evidence_repair_post_commit_audit_preview,
+)
+from agent.memory_evidence_repair_write_lock_gate import (
+    build_evidence_repair_write_lock_gate,
+)
+
+
+def _ready_dry_run():
+    return {
+        "status": "ready_for_manual_commit",
+        "summary": {
+            "manual_commit_allowed": True,
+            "operation_count": 1,
+            "has_blocks": False,
+        },
+        "checks": [{"id": "commit_gate", "status": "pass"}],
+        "operations": [
+            {
+                "id": "dryrun-op-123",
+                "ledger_entry_id": "ledger-123",
+                "candidate_id": "repair-123",
+                "preview_id": "preview-123",
+                "provider": "builtin",
+                "repair_action": "attach_provenance",
+                "patch_digest": "a" * 64,
+                "target": {"candidate_id": "repair-123"},
+                "evidence_fields": ["source_url"],
+            }
+        ],
+        "blocking_reasons": [],
+        "required_actions": [],
+    }
+
+
+def _executor_preview():
+    token_report = build_evidence_repair_human_approval_token(
+        dry_run=_ready_dry_run(),
+        approver="han",
+        approval_reason="final manual approval",
+        expires_in_minutes=30,
+    ).to_dict()
+    token_report["generated_at"] = "2026-05-11T00:00:00+00:00"
+    token_gate = build_evidence_repair_approval_token_gate(
+        approval_token=token_report,
+        confirmation_text=token_report["tokens"][0]["required_confirmation_text"],
+        current_time="2026-05-11T00:10:00+00:00",
+    ).to_dict()
+    receipt = build_evidence_repair_commit_receipt(
+        token_gate=token_gate,
+        actor="han",
+        commit_reason="manual memory evidence repair",
+    ).to_dict()
+    write_lock = build_evidence_repair_write_lock_gate(
+        commit_receipt=receipt,
+        lock_owner="han",
+        lock_ttl_minutes=15,
+        current_time="2026-05-11T00:20:00+00:00",
+    ).to_dict()
+    return build_evidence_repair_executor_preview(
+        write_lock_gate=write_lock,
+        current_time="2026-05-11T00:25:00+00:00",
+    ).to_dict()
+
+
+def test_ready_executor_preview_creates_planned_post_commit_audit():
+    payload = build_evidence_repair_post_commit_audit_preview(
+        executor_preview=_executor_preview()
+    ).to_dict()
+
+    audit = payload["previews"][0]
+    categories = {step["category"] for step in audit["audit_steps"]}
+    assert payload["status"] == POST_COMMIT_AUDIT_STATUS_READY
+    assert payload["summary"]["post_commit_audit_ready"] is True
+    assert payload["summary"]["planned_audit_step_count"] == 5
+    assert payload["read_only"] is True
+    assert payload["read_only_memory"] is True
+    assert payload["would_mutate_memory"] is False
+    assert audit["id"].startswith("post-commit-audit-")
+    assert categories == {"memory_patch", "receipt", "token", "lock", "rollback"}
+
+
+def test_observed_post_commit_state_can_pass():
+    executor = _executor_preview()
+    preview = executor["previews"][0]
+
+    payload = build_evidence_repair_post_commit_audit_preview(
+        executor_preview=executor,
+        observed_memory_patches={
+            "dryrun-op-123": {"applied": True, "patch_digest": "a" * 64}
+        },
+        recorded_receipts=[{"id": preview["receipt_id"]}],
+        used_token_ids=[preview["token_id"]],
+        released_lock_ids=[preview["lock_id"]],
+        rollback_status={"status": "snapshot_available"},
+    ).to_dict()
+
+    assert payload["status"] == POST_COMMIT_AUDIT_STATUS_READY
+    assert payload["summary"]["observed_pass_step_count"] == 5
+    assert payload["summary"]["observed_fail_step_count"] == 0
+    assert payload["previews"][0]["observed_state_supplied"] is True
+
+
+def test_observed_missing_token_blocks_audit():
+    executor = _executor_preview()
+    preview = executor["previews"][0]
+
+    payload = build_evidence_repair_post_commit_audit_preview(
+        executor_preview=executor,
+        observed_memory_patches={
+            "dryrun-op-123": {"applied": True, "patch_digest": "a" * 64}
+        },
+        recorded_receipts=[{"id": preview["receipt_id"]}],
+        used_token_ids=[],
+        released_lock_ids=[preview["lock_id"]],
+        rollback_status={"status": "snapshot_available"},
+    ).to_dict()
+
+    failed_checks = {check["id"] for check in payload["checks"] if check["status"] == "fail"}
+    assert payload["status"] == POST_COMMIT_AUDIT_STATUS_BLOCKED
+    assert CHECK_OBSERVED_POST_STATE in failed_checks
+    assert "investigate_post_commit_audit_failures" in payload["required_actions"]
+
+
+def test_tampered_executor_preview_blocks_audit():
+    executor = _executor_preview()
+    executor["previews"][0]["preview_digest"] = "bad"
+
+    payload = build_evidence_repair_post_commit_audit_preview(
+        executor_preview=executor
+    ).to_dict()
+
+    failed_checks = {check["id"] for check in payload["checks"] if check["status"] == "fail"}
+    assert payload["status"] == POST_COMMIT_AUDIT_STATUS_BLOCKED
+    assert CHECK_EXECUTOR_PREVIEW_INTEGRITY in failed_checks
+    assert "regenerate_executor_preview" in payload["required_actions"]
+
+
+def test_no_action_executor_preview_does_not_create_audit():
+    payload = build_evidence_repair_post_commit_audit_preview(
+        executor_preview={"status": "no_action_needed"}
+    ).to_dict()
+
+    assert payload["status"] == POST_COMMIT_AUDIT_STATUS_NO_ACTION_NEEDED
+    assert payload["previews"] == []
+    assert payload["summary"]["post_commit_audit_preview_available"] is False
+
+
+def test_empty_post_commit_audit_preview_is_read_only():
+    payload = empty_evidence_repair_post_commit_audit_preview().to_dict()
+
+    assert payload["status"] == POST_COMMIT_AUDIT_STATUS_NO_ACTION_NEEDED
+    assert payload["read_only"] is True
+    assert payload["read_only_memory"] is True
+    assert payload["would_mutate_memory"] is False
+    assert payload["previews"] == []

--- a/tests/agent/test_memory_evidence_repair_recovery_approval_token_gate.py
+++ b/tests/agent/test_memory_evidence_repair_recovery_approval_token_gate.py
@@ -1,0 +1,137 @@
+from agent.memory_evidence_repair_recovery_approval_token_gate import (
+    CHECK_EXECUTION_PREVIEW_DIGEST,
+    CHECK_RECOVERY_CONFIRMATION_TEXT,
+    CHECK_RECOVERY_EXPIRY,
+    CHECK_RECOVERY_REUSE,
+    RECOVERY_TOKEN_GATE_STATUS_BLOCKED,
+    RECOVERY_TOKEN_GATE_STATUS_NO_ACTION_NEEDED,
+    RECOVERY_TOKEN_GATE_STATUS_VERIFIED,
+    build_evidence_repair_recovery_approval_token_gate,
+    empty_evidence_repair_recovery_approval_token_gate,
+)
+from agent.memory_evidence_repair_recovery_human_approval_token import (
+    build_evidence_repair_recovery_human_approval_token,
+)
+from tests.agent.test_memory_evidence_repair_recovery_human_approval_token import (
+    _manual_rollback_execution,
+    _preparedness_execution,
+)
+
+
+def _recovery_token_report():
+    payload = build_evidence_repair_recovery_human_approval_token(
+        recovery_execution=_manual_rollback_execution(),
+        approver="han",
+        approval_reason="manual recovery approval",
+        expires_in_minutes=20,
+    ).to_dict()
+    payload["generated_at"] = "2026-05-11T00:00:00+00:00"
+    return payload
+
+
+def test_valid_recovery_token_and_confirmation_are_verified():
+    token_report = _recovery_token_report()
+    token = token_report["tokens"][0]
+
+    payload = build_evidence_repair_recovery_approval_token_gate(
+        recovery_approval_token=token_report,
+        confirmation_text=token["required_confirmation_text"],
+        current_time="2026-05-11T00:10:00+00:00",
+    ).to_dict()
+
+    assert payload["status"] == RECOVERY_TOKEN_GATE_STATUS_VERIFIED
+    assert payload["summary"]["manual_recovery_verified"] is True
+    assert payload["summary"]["verified_operation_count"] == 1
+    assert payload["summary"]["verified_future_mutation_step_count"] == 1
+    assert payload["read_only"] is True
+    assert payload["read_only_memory"] is True
+    assert payload["would_mutate_memory"] is False
+    assert payload["token_id"] == token["id"]
+    assert payload["verified_operation_ids"] == ["dryrun-op-123"]
+
+
+def test_wrong_confirmation_blocks_recovery_gate():
+    token_report = _recovery_token_report()
+
+    payload = build_evidence_repair_recovery_approval_token_gate(
+        recovery_approval_token=token_report,
+        confirmation_text="wrong confirmation",
+        current_time="2026-05-11T00:10:00+00:00",
+    ).to_dict()
+
+    failed_checks = {check["id"] for check in payload["checks"] if check["status"] == "fail"}
+    assert payload["status"] == RECOVERY_TOKEN_GATE_STATUS_BLOCKED
+    assert CHECK_RECOVERY_CONFIRMATION_TEXT in failed_checks
+    assert "provide_exact_recovery_confirmation_text" in payload["required_actions"]
+
+
+def test_expired_recovery_token_blocks_gate():
+    token_report = _recovery_token_report()
+    token = token_report["tokens"][0]
+
+    payload = build_evidence_repair_recovery_approval_token_gate(
+        recovery_approval_token=token_report,
+        confirmation_text=token["required_confirmation_text"],
+        current_time="2026-05-11T00:25:00+00:00",
+    ).to_dict()
+
+    failed_checks = {check["id"] for check in payload["checks"] if check["status"] == "fail"}
+    assert payload["status"] == RECOVERY_TOKEN_GATE_STATUS_BLOCKED
+    assert CHECK_RECOVERY_EXPIRY in failed_checks
+    assert "regenerate_recovery_human_approval_token" in payload["required_actions"]
+
+
+def test_used_recovery_token_blocks_gate():
+    token_report = _recovery_token_report()
+    token = token_report["tokens"][0]
+
+    payload = build_evidence_repair_recovery_approval_token_gate(
+        recovery_approval_token=token_report,
+        confirmation_text=token["required_confirmation_text"],
+        used_token_ids=[token["id"]],
+        current_time="2026-05-11T00:10:00+00:00",
+    ).to_dict()
+
+    failed_checks = {check["id"] for check in payload["checks"] if check["status"] == "fail"}
+    assert payload["status"] == RECOVERY_TOKEN_GATE_STATUS_BLOCKED
+    assert CHECK_RECOVERY_REUSE in failed_checks
+
+
+def test_mismatched_execution_preview_blocks_gate():
+    token_report = _recovery_token_report()
+    token = token_report["tokens"][0]
+    execution = _manual_rollback_execution()["previews"][0]
+    execution["preview_digest"] = "bad"
+
+    payload = build_evidence_repair_recovery_approval_token_gate(
+        recovery_approval_token=token_report,
+        recovery_execution=execution,
+        confirmation_text=token["required_confirmation_text"],
+        current_time="2026-05-11T00:10:00+00:00",
+    ).to_dict()
+
+    failed_checks = {check["id"] for check in payload["checks"] if check["status"] == "fail"}
+    assert payload["status"] == RECOVERY_TOKEN_GATE_STATUS_BLOCKED
+    assert CHECK_EXECUTION_PREVIEW_DIGEST in failed_checks
+
+
+def test_no_action_recovery_token_report_does_not_create_gate():
+    token_report = build_evidence_repair_recovery_human_approval_token(
+        recovery_execution=_preparedness_execution()
+    ).to_dict()
+
+    payload = build_evidence_repair_recovery_approval_token_gate(
+        recovery_approval_token=token_report
+    ).to_dict()
+
+    assert payload["status"] == RECOVERY_TOKEN_GATE_STATUS_NO_ACTION_NEEDED
+    assert payload["checks"] == []
+
+
+def test_empty_recovery_token_gate_is_read_only():
+    payload = empty_evidence_repair_recovery_approval_token_gate().to_dict()
+
+    assert payload["status"] == RECOVERY_TOKEN_GATE_STATUS_NO_ACTION_NEEDED
+    assert payload["read_only"] is True
+    assert payload["read_only_memory"] is True
+    assert payload["would_mutate_memory"] is False

--- a/tests/agent/test_memory_evidence_repair_recovery_closure_finalization_readiness_preview.py
+++ b/tests/agent/test_memory_evidence_repair_recovery_closure_finalization_readiness_preview.py
@@ -1,0 +1,152 @@
+from copy import deepcopy
+
+from agent.memory_evidence_repair_recovery_closure_finalization_readiness_preview import (
+    CHECK_RECOVERY_FINALIZATION_REQUIREMENTS,
+    CHECK_RECOVERY_FINALIZATION_SOURCE_CHAIN,
+    CHECK_RECOVERY_GOVERNANCE_SEAL_AUDIT_INTEGRITY,
+    RECOVERY_CLOSURE_FINALIZATION_DRAFT_STATUS_READY,
+    RECOVERY_CLOSURE_FINALIZATION_STATUS_BLOCKED,
+    RECOVERY_CLOSURE_FINALIZATION_STATUS_NO_ACTION_NEEDED,
+    RECOVERY_CLOSURE_FINALIZATION_STATUS_READY,
+    build_evidence_repair_recovery_closure_finalization_readiness_preview,
+    empty_evidence_repair_recovery_closure_finalization_readiness_preview,
+)
+from agent.memory_evidence_repair_recovery_closure_governance_seal_audit_preview import (
+    build_evidence_repair_recovery_closure_governance_seal_audit_preview,
+)
+from tests.agent.test_memory_evidence_repair_recovery_closure_governance_seal_audit_preview import (
+    _ready_governance_seal,
+)
+
+
+def _ready_seal_audit():
+    return build_evidence_repair_recovery_closure_governance_seal_audit_preview(
+        recovery_closure_governance_seal=_ready_governance_seal()
+    ).to_dict()
+
+
+def test_ready_seal_audit_creates_finalization_readiness():
+    payload = build_evidence_repair_recovery_closure_finalization_readiness_preview(
+        recovery_closure_governance_seal_audit=_ready_seal_audit()
+    ).to_dict()
+
+    readiness = payload["readiness"][0]
+    assert payload["status"] == RECOVERY_CLOSURE_FINALIZATION_STATUS_READY
+    assert payload["summary"]["recovery_closure_finalization_ready"] is True
+    assert payload["summary"]["readiness_count"] == 1
+    assert payload["summary"]["would_allow_final_closure_count"] == 1
+    assert payload["read_only"] is True
+    assert payload["read_only_memory"] is True
+    assert payload["would_mutate_memory"] is False
+    assert readiness["id"].startswith("recovery-closure-finalization-readiness-")
+    assert readiness["status"] == RECOVERY_CLOSURE_FINALIZATION_DRAFT_STATUS_READY
+    assert readiness["seal_audit_preview_id"].startswith(
+        "recovery-closure-governance-seal-audit-"
+    )
+    assert readiness["operation_ids"] == ["dryrun-op-123"]
+    assert readiness["would_allow_final_closure"] is True
+    assert readiness["would_preserve_full_governance_chain"] is True
+    assert readiness["would_require_human_finalization"] is True
+    assert readiness["would_keep_read_only_until_manual_commit"] is True
+
+
+def test_blocked_seal_audit_blocks_finalization_readiness():
+    payload = build_evidence_repair_recovery_closure_finalization_readiness_preview(
+        recovery_closure_governance_seal_audit={
+            "status": "blocked",
+            "blocking_reasons": ["seal audit blocked"],
+            "required_actions": ["fix_seal_audit"],
+        }
+    ).to_dict()
+
+    assert payload["status"] == RECOVERY_CLOSURE_FINALIZATION_STATUS_BLOCKED
+    assert payload["readiness"] == []
+    assert "fix_seal_audit" in payload["required_actions"]
+
+
+def test_tampered_seal_audit_digest_blocks_finalization_readiness():
+    seal_audit = _ready_seal_audit()
+    seal_audit["previews"][0]["audit_digest"] = "bad"
+
+    payload = build_evidence_repair_recovery_closure_finalization_readiness_preview(
+        recovery_closure_governance_seal_audit=seal_audit
+    ).to_dict()
+
+    failed_checks = {check["id"] for check in payload["checks"] if check["status"] == "fail"}
+    assert payload["status"] == RECOVERY_CLOSURE_FINALIZATION_STATUS_BLOCKED
+    assert CHECK_RECOVERY_GOVERNANCE_SEAL_AUDIT_INTEGRITY in failed_checks
+    assert (
+        "regenerate_recovery_closure_governance_seal_audit_preview"
+        in payload["required_actions"]
+    )
+
+
+def test_tampered_source_seal_blocks_finalization_source_chain():
+    seal_audit = deepcopy(_ready_seal_audit())
+    seal_audit["previews"][0]["source_recovery_closure_governance_seal"][
+        "seal_digest"
+    ] = "bad"
+
+    payload = build_evidence_repair_recovery_closure_finalization_readiness_preview(
+        recovery_closure_governance_seal_audit=seal_audit
+    ).to_dict()
+
+    failed_checks = {check["id"] for check in payload["checks"] if check["status"] == "fail"}
+    assert payload["status"] == RECOVERY_CLOSURE_FINALIZATION_STATUS_BLOCKED
+    assert CHECK_RECOVERY_FINALIZATION_SOURCE_CHAIN in failed_checks
+
+
+def test_missing_governance_handoff_flag_blocks_finalization_requirements():
+    seal_audit = deepcopy(_ready_seal_audit())
+    seal_audit["previews"][0]["would_verify_governance_handoff"] = False
+
+    payload = build_evidence_repair_recovery_closure_finalization_readiness_preview(
+        recovery_closure_governance_seal_audit=seal_audit
+    ).to_dict()
+
+    failed_checks = {check["id"] for check in payload["checks"] if check["status"] == "fail"}
+    assert payload["status"] == RECOVERY_CLOSURE_FINALIZATION_STATUS_BLOCKED
+    assert CHECK_RECOVERY_FINALIZATION_REQUIREMENTS in failed_checks
+
+
+def test_no_action_seal_audit_does_not_create_finalization_readiness():
+    payload = build_evidence_repair_recovery_closure_finalization_readiness_preview(
+        recovery_closure_governance_seal_audit={"status": "no_action_needed"}
+    ).to_dict()
+
+    assert payload["status"] == RECOVERY_CLOSURE_FINALIZATION_STATUS_NO_ACTION_NEEDED
+    assert payload["readiness"] == []
+    assert (
+        payload["summary"]["recovery_closure_finalization_readiness_available"]
+        is False
+    )
+
+
+def test_empty_finalization_readiness_preview_is_read_only():
+    payload = (
+        empty_evidence_repair_recovery_closure_finalization_readiness_preview()
+        .to_dict()
+    )
+
+    assert payload["status"] == RECOVERY_CLOSURE_FINALIZATION_STATUS_NO_ACTION_NEEDED
+    assert payload["read_only"] is True
+    assert payload["read_only_memory"] is True
+    assert payload["would_mutate_memory"] is False
+    assert payload["readiness"] == []
+
+
+def test_finalization_readiness_id_is_stable():
+    seal_audit = _ready_seal_audit()
+
+    first = build_evidence_repair_recovery_closure_finalization_readiness_preview(
+        recovery_closure_governance_seal_audit=seal_audit
+    ).to_dict()
+    second = build_evidence_repair_recovery_closure_finalization_readiness_preview(
+        recovery_closure_governance_seal_audit=seal_audit
+    ).to_dict()
+
+    assert first["readiness"][0]["id"] == second["readiness"][0]["id"]
+    assert (
+        first["readiness"][0]["finalization_digest"]
+        == second["readiness"][0]["finalization_digest"]
+    )

--- a/tests/agent/test_memory_evidence_repair_recovery_closure_gate.py
+++ b/tests/agent/test_memory_evidence_repair_recovery_closure_gate.py
@@ -1,0 +1,118 @@
+from agent.memory_evidence_repair_recovery_closure_gate import (
+    CHECK_RECOVERY_COMPLETION_AUDIT_INTEGRITY,
+    CHECK_RECOVERY_COMPLETION_AUDIT_OBSERVED_PASS,
+    RECOVERY_CLOSURE_DRAFT_STATUS_READY,
+    RECOVERY_CLOSURE_STATUS_BLOCKED,
+    RECOVERY_CLOSURE_STATUS_NO_ACTION_NEEDED,
+    RECOVERY_CLOSURE_STATUS_READY,
+    build_evidence_repair_recovery_closure_gate,
+    empty_evidence_repair_recovery_closure_gate,
+)
+from agent.memory_evidence_repair_recovery_completion_audit_preview import (
+    build_evidence_repair_recovery_completion_audit_preview,
+)
+from tests.agent.test_memory_evidence_repair_recovery_completion_audit_preview import (
+    _observed_recovery_steps,
+    _recovery_completion_receipt,
+)
+
+
+def _passing_completion_audit():
+    receipt = _recovery_completion_receipt()
+    row = receipt["receipts"][0]
+    return build_evidence_repair_recovery_completion_audit_preview(
+        recovery_completion_receipt=receipt,
+        observed_recovery_steps=_observed_recovery_steps(receipt),
+        recorded_receipts=[{"id": row["id"]}],
+        used_token_ids=[row["token_id"]],
+        released_lock_ids=[row["lock_id"]],
+        post_recovery_audit_status={"status": "pass"},
+        contamination_status={"contaminated": False},
+    ).to_dict()
+
+
+def _planned_completion_audit():
+    return build_evidence_repair_recovery_completion_audit_preview(
+        recovery_completion_receipt=_recovery_completion_receipt()
+    ).to_dict()
+
+
+def test_passing_completion_audit_creates_recovery_closure_draft():
+    payload = build_evidence_repair_recovery_closure_gate(
+        recovery_completion_audit=_passing_completion_audit()
+    ).to_dict()
+
+    closure = payload["closures"][0]
+    assert payload["status"] == RECOVERY_CLOSURE_STATUS_READY
+    assert payload["summary"]["recovery_closure_ready"] is True
+    assert payload["summary"]["would_close_recovery_loop_count"] == 1
+    assert payload["read_only"] is True
+    assert payload["read_only_memory"] is True
+    assert payload["would_mutate_memory"] is False
+    assert closure["id"].startswith("recovery-closure-")
+    assert closure["status"] == RECOVERY_CLOSURE_DRAFT_STATUS_READY
+    assert closure["closure_decision"] == "close_recovery_loop"
+    assert closure["operation_ids"] == ["dryrun-op-123"]
+    assert closure["would_close_recovery_loop"] is True
+    assert closure["would_mark_recovery_resolved"] is True
+    assert closure["would_preserve_audit_evidence"] is True
+
+
+def test_planned_completion_audit_blocks_recovery_closure():
+    payload = build_evidence_repair_recovery_closure_gate(
+        recovery_completion_audit=_planned_completion_audit()
+    ).to_dict()
+
+    failed_checks = {check["id"] for check in payload["checks"] if check["status"] == "fail"}
+    assert payload["status"] == RECOVERY_CLOSURE_STATUS_BLOCKED
+    assert CHECK_RECOVERY_COMPLETION_AUDIT_OBSERVED_PASS in failed_checks
+    assert "provide_observed_recovery_completion_state" in payload["required_actions"]
+    assert payload["closures"] == []
+
+
+def test_failed_completion_audit_step_blocks_recovery_closure():
+    audit = _passing_completion_audit()
+    audit["previews"][0]["audit_steps"][0]["status"] = "fail"
+
+    payload = build_evidence_repair_recovery_closure_gate(
+        recovery_completion_audit=audit
+    ).to_dict()
+
+    failed_checks = {check["id"] for check in payload["checks"] if check["status"] == "fail"}
+    assert payload["status"] == RECOVERY_CLOSURE_STATUS_BLOCKED
+    assert CHECK_RECOVERY_COMPLETION_AUDIT_OBSERVED_PASS in failed_checks
+    assert "investigate_recovery_completion_audit_failures" in payload["required_actions"]
+
+
+def test_tampered_completion_audit_digest_blocks_recovery_closure():
+    audit = _passing_completion_audit()
+    audit["previews"][0]["audit_digest"] = "bad"
+
+    payload = build_evidence_repair_recovery_closure_gate(
+        recovery_completion_audit=audit
+    ).to_dict()
+
+    failed_checks = {check["id"] for check in payload["checks"] if check["status"] == "fail"}
+    assert payload["status"] == RECOVERY_CLOSURE_STATUS_BLOCKED
+    assert CHECK_RECOVERY_COMPLETION_AUDIT_INTEGRITY in failed_checks
+    assert "regenerate_recovery_completion_audit_preview" in payload["required_actions"]
+
+
+def test_no_action_completion_audit_does_not_create_closure():
+    payload = build_evidence_repair_recovery_closure_gate(
+        recovery_completion_audit={"status": "no_action_needed"}
+    ).to_dict()
+
+    assert payload["status"] == RECOVERY_CLOSURE_STATUS_NO_ACTION_NEEDED
+    assert payload["closures"] == []
+    assert payload["summary"]["recovery_closure_available"] is False
+
+
+def test_empty_recovery_closure_gate_is_read_only():
+    payload = empty_evidence_repair_recovery_closure_gate().to_dict()
+
+    assert payload["status"] == RECOVERY_CLOSURE_STATUS_NO_ACTION_NEEDED
+    assert payload["read_only"] is True
+    assert payload["read_only_memory"] is True
+    assert payload["would_mutate_memory"] is False
+    assert payload["closures"] == []

--- a/tests/agent/test_memory_evidence_repair_recovery_closure_governance_seal_audit_preview.py
+++ b/tests/agent/test_memory_evidence_repair_recovery_closure_governance_seal_audit_preview.py
@@ -1,0 +1,142 @@
+from copy import deepcopy
+
+from agent.memory_evidence_repair_recovery_closure_governance_seal_audit_preview import (
+    CHECK_RECOVERY_GOVERNANCE_SEAL_AUDIT_REQUIREMENTS,
+    CHECK_RECOVERY_GOVERNANCE_SEAL_AUDIT_SOURCE_CHAIN,
+    CHECK_RECOVERY_GOVERNANCE_SEAL_INTEGRITY,
+    RECOVERY_CLOSURE_GOVERNANCE_SEAL_AUDIT_PREVIEW_STATUS_READY,
+    RECOVERY_CLOSURE_GOVERNANCE_SEAL_AUDIT_STATUS_BLOCKED,
+    RECOVERY_CLOSURE_GOVERNANCE_SEAL_AUDIT_STATUS_NO_ACTION_NEEDED,
+    RECOVERY_CLOSURE_GOVERNANCE_SEAL_AUDIT_STATUS_READY,
+    build_evidence_repair_recovery_closure_governance_seal_audit_preview,
+    empty_evidence_repair_recovery_closure_governance_seal_audit_preview,
+)
+from agent.memory_evidence_repair_recovery_closure_governance_seal_preview import (
+    build_evidence_repair_recovery_closure_governance_seal_preview,
+)
+from tests.agent.test_memory_evidence_repair_recovery_closure_governance_seal_preview import (
+    _ready_ledger_audit,
+)
+
+
+def _ready_governance_seal():
+    return build_evidence_repair_recovery_closure_governance_seal_preview(
+        recovery_closure_ledger_audit=_ready_ledger_audit()
+    ).to_dict()
+
+
+def test_ready_governance_seal_creates_audit_preview():
+    payload = build_evidence_repair_recovery_closure_governance_seal_audit_preview(
+        recovery_closure_governance_seal=_ready_governance_seal()
+    ).to_dict()
+
+    preview = payload["previews"][0]
+    assert payload["status"] == RECOVERY_CLOSURE_GOVERNANCE_SEAL_AUDIT_STATUS_READY
+    assert payload["summary"]["recovery_closure_governance_seal_audit_ready"] is True
+    assert payload["summary"]["preview_count"] == 1
+    assert payload["summary"]["audit_step_count"] == 6
+    assert payload["summary"]["observed_pass_step_count"] == 6
+    assert payload["read_only"] is True
+    assert payload["read_only_memory"] is True
+    assert payload["would_mutate_memory"] is False
+    assert preview["id"].startswith("recovery-closure-governance-seal-audit-")
+    assert preview["status"] == RECOVERY_CLOSURE_GOVERNANCE_SEAL_AUDIT_PREVIEW_STATUS_READY
+    assert preview["seal_id"].startswith("recovery-closure-governance-seal-")
+    assert preview["operation_ids"] == ["dryrun-op-123"]
+    assert preview["would_verify_seal_integrity"] is True
+    assert preview["would_verify_governance_handoff"] is True
+    assert preview["would_verify_source_audit_evidence"] is True
+    assert preview["would_verify_read_only_constraints"] is True
+
+
+def test_blocked_governance_seal_blocks_audit_preview():
+    payload = build_evidence_repair_recovery_closure_governance_seal_audit_preview(
+        recovery_closure_governance_seal={
+            "status": "blocked",
+            "blocking_reasons": ["governance seal blocked"],
+            "required_actions": ["fix_governance_seal"],
+        }
+    ).to_dict()
+
+    assert payload["status"] == RECOVERY_CLOSURE_GOVERNANCE_SEAL_AUDIT_STATUS_BLOCKED
+    assert payload["previews"] == []
+    assert "fix_governance_seal" in payload["required_actions"]
+
+
+def test_tampered_seal_digest_blocks_audit_preview():
+    seal_report = _ready_governance_seal()
+    seal_report["seals"][0]["seal_digest"] = "bad"
+
+    payload = build_evidence_repair_recovery_closure_governance_seal_audit_preview(
+        recovery_closure_governance_seal=seal_report
+    ).to_dict()
+
+    failed_checks = {check["id"] for check in payload["checks"] if check["status"] == "fail"}
+    assert payload["status"] == RECOVERY_CLOSURE_GOVERNANCE_SEAL_AUDIT_STATUS_BLOCKED
+    assert CHECK_RECOVERY_GOVERNANCE_SEAL_INTEGRITY in failed_checks
+    assert "regenerate_recovery_closure_governance_seal_preview" in payload["required_actions"]
+
+
+def test_tampered_source_ledger_audit_blocks_source_chain():
+    seal_report = deepcopy(_ready_governance_seal())
+    seal_report["seals"][0]["source_recovery_closure_ledger_audit_preview"][
+        "audit_digest"
+    ] = "bad"
+
+    payload = build_evidence_repair_recovery_closure_governance_seal_audit_preview(
+        recovery_closure_governance_seal=seal_report
+    ).to_dict()
+
+    failed_checks = {check["id"] for check in payload["checks"] if check["status"] == "fail"}
+    assert payload["status"] == RECOVERY_CLOSURE_GOVERNANCE_SEAL_AUDIT_STATUS_BLOCKED
+    assert CHECK_RECOVERY_GOVERNANCE_SEAL_AUDIT_SOURCE_CHAIN in failed_checks
+
+
+def test_missing_governance_handoff_flag_blocks_audit_requirements():
+    seal_report = deepcopy(_ready_governance_seal())
+    seal_report["seals"][0]["would_enable_governed_handoff"] = False
+
+    payload = build_evidence_repair_recovery_closure_governance_seal_audit_preview(
+        recovery_closure_governance_seal=seal_report
+    ).to_dict()
+
+    failed_checks = {check["id"] for check in payload["checks"] if check["status"] == "fail"}
+    assert payload["status"] == RECOVERY_CLOSURE_GOVERNANCE_SEAL_AUDIT_STATUS_BLOCKED
+    assert CHECK_RECOVERY_GOVERNANCE_SEAL_AUDIT_REQUIREMENTS in failed_checks
+
+
+def test_no_action_governance_seal_does_not_create_audit_preview():
+    payload = build_evidence_repair_recovery_closure_governance_seal_audit_preview(
+        recovery_closure_governance_seal={"status": "no_action_needed"}
+    ).to_dict()
+
+    assert payload["status"] == RECOVERY_CLOSURE_GOVERNANCE_SEAL_AUDIT_STATUS_NO_ACTION_NEEDED
+    assert payload["previews"] == []
+    assert (
+        payload["summary"]["recovery_closure_governance_seal_audit_preview_available"]
+        is False
+    )
+
+
+def test_empty_governance_seal_audit_preview_is_read_only():
+    payload = empty_evidence_repair_recovery_closure_governance_seal_audit_preview().to_dict()
+
+    assert payload["status"] == RECOVERY_CLOSURE_GOVERNANCE_SEAL_AUDIT_STATUS_NO_ACTION_NEEDED
+    assert payload["read_only"] is True
+    assert payload["read_only_memory"] is True
+    assert payload["would_mutate_memory"] is False
+    assert payload["previews"] == []
+
+
+def test_governance_seal_audit_preview_id_is_stable():
+    seal_report = _ready_governance_seal()
+
+    first = build_evidence_repair_recovery_closure_governance_seal_audit_preview(
+        recovery_closure_governance_seal=seal_report
+    ).to_dict()
+    second = build_evidence_repair_recovery_closure_governance_seal_audit_preview(
+        recovery_closure_governance_seal=seal_report
+    ).to_dict()
+
+    assert first["previews"][0]["id"] == second["previews"][0]["id"]
+    assert first["previews"][0]["audit_digest"] == second["previews"][0]["audit_digest"]

--- a/tests/agent/test_memory_evidence_repair_recovery_closure_governance_seal_preview.py
+++ b/tests/agent/test_memory_evidence_repair_recovery_closure_governance_seal_preview.py
@@ -1,0 +1,151 @@
+from copy import deepcopy
+
+from agent.memory_evidence_repair_recovery_closure_governance_seal_preview import (
+    CHECK_RECOVERY_CLOSURE_LEDGER_AUDIT_INTEGRITY,
+    CHECK_RECOVERY_GOVERNANCE_SEAL_REQUIREMENTS,
+    CHECK_RECOVERY_GOVERNANCE_SEAL_SOURCE_CHAIN,
+    RECOVERY_CLOSURE_GOVERNANCE_SEAL_DRAFT_STATUS_READY,
+    RECOVERY_CLOSURE_GOVERNANCE_SEAL_STATUS_BLOCKED,
+    RECOVERY_CLOSURE_GOVERNANCE_SEAL_STATUS_NO_ACTION_NEEDED,
+    RECOVERY_CLOSURE_GOVERNANCE_SEAL_STATUS_READY,
+    RECOVERY_CLOSURE_GOVERNANCE_SEAL_TYPE,
+    build_evidence_repair_recovery_closure_governance_seal_preview,
+    empty_evidence_repair_recovery_closure_governance_seal_preview,
+)
+from agent.memory_evidence_repair_recovery_closure_ledger_audit_preview import (
+    build_evidence_repair_recovery_closure_ledger_audit_preview,
+)
+from tests.agent.test_memory_evidence_repair_recovery_closure_ledger_audit_preview import (
+    _ready_ledger_preview,
+)
+
+
+def _ready_ledger_audit():
+    return build_evidence_repair_recovery_closure_ledger_audit_preview(
+        recovery_closure_ledger=_ready_ledger_preview()
+    ).to_dict()
+
+
+def test_ready_recovery_closure_ledger_audit_creates_governance_seal():
+    payload = build_evidence_repair_recovery_closure_governance_seal_preview(
+        recovery_closure_ledger_audit=_ready_ledger_audit()
+    ).to_dict()
+
+    seal = payload["seals"][0]
+    assert payload["status"] == RECOVERY_CLOSURE_GOVERNANCE_SEAL_STATUS_READY
+    assert payload["summary"]["recovery_closure_governance_seal_ready"] is True
+    assert payload["summary"]["seal_count"] == 1
+    assert payload["read_only"] is True
+    assert payload["read_only_memory"] is True
+    assert payload["would_mutate_memory"] is False
+    assert seal["id"].startswith("recovery-closure-governance-seal-")
+    assert seal["seal_type"] == RECOVERY_CLOSURE_GOVERNANCE_SEAL_TYPE
+    assert seal["status"] == RECOVERY_CLOSURE_GOVERNANCE_SEAL_DRAFT_STATUS_READY
+    assert seal["operation_ids"] == ["dryrun-op-123"]
+    assert seal["would_freeze_recovery_closure"] is True
+    assert seal["would_preserve_audit_evidence"] is True
+    assert seal["would_enable_governed_handoff"] is True
+    assert seal["would_block_unreviewed_mutation"] is True
+
+
+def test_blocked_ledger_audit_blocks_governance_seal():
+    payload = build_evidence_repair_recovery_closure_governance_seal_preview(
+        recovery_closure_ledger_audit={
+            "status": "blocked",
+            "blocking_reasons": ["ledger audit blocked"],
+            "required_actions": ["fix_ledger_audit"],
+        }
+    ).to_dict()
+
+    assert payload["status"] == RECOVERY_CLOSURE_GOVERNANCE_SEAL_STATUS_BLOCKED
+    assert payload["seals"] == []
+    assert "fix_ledger_audit" in payload["required_actions"]
+
+
+def test_tampered_ledger_audit_digest_blocks_governance_seal():
+    ledger_audit = _ready_ledger_audit()
+    ledger_audit["previews"][0]["audit_digest"] = "bad"
+
+    payload = build_evidence_repair_recovery_closure_governance_seal_preview(
+        recovery_closure_ledger_audit=ledger_audit
+    ).to_dict()
+
+    failed_checks = {check["id"] for check in payload["checks"] if check["status"] == "fail"}
+    assert payload["status"] == RECOVERY_CLOSURE_GOVERNANCE_SEAL_STATUS_BLOCKED
+    assert CHECK_RECOVERY_CLOSURE_LEDGER_AUDIT_INTEGRITY in failed_checks
+    assert "regenerate_recovery_closure_ledger_audit_preview" in payload["required_actions"]
+
+
+def test_tampered_source_ledger_entry_blocks_governance_seal_source_chain():
+    ledger_audit = deepcopy(_ready_ledger_audit())
+    ledger_audit["previews"][0]["source_recovery_closure_ledger_entry"][
+        "entry_digest"
+    ] = "bad"
+
+    payload = build_evidence_repair_recovery_closure_governance_seal_preview(
+        recovery_closure_ledger_audit=ledger_audit
+    ).to_dict()
+
+    failed_checks = {check["id"] for check in payload["checks"] if check["status"] == "fail"}
+    assert payload["status"] == RECOVERY_CLOSURE_GOVERNANCE_SEAL_STATUS_BLOCKED
+    assert CHECK_RECOVERY_GOVERNANCE_SEAL_SOURCE_CHAIN in failed_checks
+
+
+def test_failed_ledger_audit_step_blocks_governance_seal_requirements():
+    ledger_audit = deepcopy(_ready_ledger_audit())
+    ledger_audit["previews"][0]["audit_steps"][0]["status"] = "fail"
+
+    payload = build_evidence_repair_recovery_closure_governance_seal_preview(
+        recovery_closure_ledger_audit=ledger_audit
+    ).to_dict()
+
+    failed_checks = {check["id"] for check in payload["checks"] if check["status"] == "fail"}
+    assert payload["status"] == RECOVERY_CLOSURE_GOVERNANCE_SEAL_STATUS_BLOCKED
+    assert CHECK_RECOVERY_GOVERNANCE_SEAL_SOURCE_CHAIN in failed_checks
+
+
+def test_missing_governance_flag_blocks_governance_seal_requirements():
+    ledger_audit = deepcopy(_ready_ledger_audit())
+    ledger_audit["previews"][0]["would_verify_lifecycle_milestones"] = False
+
+    payload = build_evidence_repair_recovery_closure_governance_seal_preview(
+        recovery_closure_ledger_audit=ledger_audit
+    ).to_dict()
+
+    failed_checks = {check["id"] for check in payload["checks"] if check["status"] == "fail"}
+    assert payload["status"] == RECOVERY_CLOSURE_GOVERNANCE_SEAL_STATUS_BLOCKED
+    assert CHECK_RECOVERY_GOVERNANCE_SEAL_REQUIREMENTS in failed_checks
+
+
+def test_no_action_ledger_audit_does_not_create_governance_seal():
+    payload = build_evidence_repair_recovery_closure_governance_seal_preview(
+        recovery_closure_ledger_audit={"status": "no_action_needed"}
+    ).to_dict()
+
+    assert payload["status"] == RECOVERY_CLOSURE_GOVERNANCE_SEAL_STATUS_NO_ACTION_NEEDED
+    assert payload["seals"] == []
+    assert payload["summary"]["recovery_closure_governance_seal_available"] is False
+
+
+def test_empty_governance_seal_preview_is_read_only():
+    payload = empty_evidence_repair_recovery_closure_governance_seal_preview().to_dict()
+
+    assert payload["status"] == RECOVERY_CLOSURE_GOVERNANCE_SEAL_STATUS_NO_ACTION_NEEDED
+    assert payload["read_only"] is True
+    assert payload["read_only_memory"] is True
+    assert payload["would_mutate_memory"] is False
+    assert payload["seals"] == []
+
+
+def test_governance_seal_id_is_stable():
+    ledger_audit = _ready_ledger_audit()
+
+    first = build_evidence_repair_recovery_closure_governance_seal_preview(
+        recovery_closure_ledger_audit=ledger_audit
+    ).to_dict()
+    second = build_evidence_repair_recovery_closure_governance_seal_preview(
+        recovery_closure_ledger_audit=ledger_audit
+    ).to_dict()
+
+    assert first["seals"][0]["id"] == second["seals"][0]["id"]
+    assert first["seals"][0]["seal_digest"] == second["seals"][0]["seal_digest"]

--- a/tests/agent/test_memory_evidence_repair_recovery_closure_ledger_audit_preview.py
+++ b/tests/agent/test_memory_evidence_repair_recovery_closure_ledger_audit_preview.py
@@ -1,0 +1,138 @@
+from copy import deepcopy
+
+from agent.memory_evidence_repair_recovery_closure_ledger_audit_preview import (
+    CHECK_RECOVERY_CLOSURE_LEDGER_AUDIT_REQUIREMENTS,
+    CHECK_RECOVERY_CLOSURE_LEDGER_INTEGRITY,
+    CHECK_RECOVERY_CLOSURE_LEDGER_SOURCE_CHAIN,
+    RECOVERY_CLOSURE_LEDGER_AUDIT_PREVIEW_STATUS_READY,
+    RECOVERY_CLOSURE_LEDGER_AUDIT_STATUS_BLOCKED,
+    RECOVERY_CLOSURE_LEDGER_AUDIT_STATUS_NO_ACTION_NEEDED,
+    RECOVERY_CLOSURE_LEDGER_AUDIT_STATUS_READY,
+    build_evidence_repair_recovery_closure_ledger_audit_preview,
+    empty_evidence_repair_recovery_closure_ledger_audit_preview,
+)
+from agent.memory_evidence_repair_recovery_closure_ledger_preview import (
+    build_evidence_repair_recovery_closure_ledger_preview,
+)
+from tests.agent.test_memory_evidence_repair_recovery_closure_ledger_preview import (
+    _ready_closure_gate,
+)
+
+
+def _ready_ledger_preview():
+    return build_evidence_repair_recovery_closure_ledger_preview(
+        recovery_closure_gate=_ready_closure_gate()
+    ).to_dict()
+
+
+def test_ready_recovery_closure_ledger_creates_audit_preview():
+    payload = build_evidence_repair_recovery_closure_ledger_audit_preview(
+        recovery_closure_ledger=_ready_ledger_preview()
+    ).to_dict()
+
+    preview = payload["previews"][0]
+    assert payload["status"] == RECOVERY_CLOSURE_LEDGER_AUDIT_STATUS_READY
+    assert payload["summary"]["recovery_closure_ledger_audit_ready"] is True
+    assert payload["summary"]["preview_count"] == 1
+    assert payload["summary"]["audit_step_count"] == 6
+    assert payload["summary"]["observed_pass_step_count"] == 6
+    assert payload["read_only"] is True
+    assert payload["read_only_memory"] is True
+    assert payload["would_mutate_memory"] is False
+    assert preview["id"].startswith("recovery-closure-ledger-audit-")
+    assert preview["status"] == RECOVERY_CLOSURE_LEDGER_AUDIT_PREVIEW_STATUS_READY
+    assert preview["ledger_entry_id"].startswith("recovery-closure-ledger-")
+    assert preview["closure_id"].startswith("recovery-closure-")
+    assert preview["operation_ids"] == ["dryrun-op-123"]
+    assert preview["would_verify_ledger_entry_integrity"] is True
+    assert preview["would_verify_completion_audit_evidence"] is True
+
+
+def test_blocked_recovery_closure_ledger_blocks_audit_preview():
+    payload = build_evidence_repair_recovery_closure_ledger_audit_preview(
+        recovery_closure_ledger={
+            "status": "blocked",
+            "blocking_reasons": ["upstream ledger blocked"],
+            "required_actions": ["fix_upstream_ledger"],
+        }
+    ).to_dict()
+
+    assert payload["status"] == RECOVERY_CLOSURE_LEDGER_AUDIT_STATUS_BLOCKED
+    assert payload["previews"] == []
+    assert "fix_upstream_ledger" in payload["required_actions"]
+
+
+def test_tampered_ledger_entry_digest_blocks_audit_preview():
+    ledger = _ready_ledger_preview()
+    ledger["entries"][0]["entry_digest"] = "bad"
+
+    payload = build_evidence_repair_recovery_closure_ledger_audit_preview(
+        recovery_closure_ledger=ledger
+    ).to_dict()
+
+    failed_checks = {check["id"] for check in payload["checks"] if check["status"] == "fail"}
+    assert payload["status"] == RECOVERY_CLOSURE_LEDGER_AUDIT_STATUS_BLOCKED
+    assert CHECK_RECOVERY_CLOSURE_LEDGER_INTEGRITY in failed_checks
+    assert "regenerate_recovery_closure_ledger_preview" in payload["required_actions"]
+
+
+def test_tampered_source_completion_audit_blocks_source_chain():
+    ledger = deepcopy(_ready_ledger_preview())
+    ledger["entries"][0]["source_recovery_closure"][
+        "source_recovery_completion_audit_preview"
+    ]["observed_state_supplied"] = False
+
+    payload = build_evidence_repair_recovery_closure_ledger_audit_preview(
+        recovery_closure_ledger=ledger
+    ).to_dict()
+
+    failed_checks = {check["id"] for check in payload["checks"] if check["status"] == "fail"}
+    assert payload["status"] == RECOVERY_CLOSURE_LEDGER_AUDIT_STATUS_BLOCKED
+    assert CHECK_RECOVERY_CLOSURE_LEDGER_SOURCE_CHAIN in failed_checks
+
+
+def test_tampered_milestone_reference_blocks_audit_requirements():
+    ledger = deepcopy(_ready_ledger_preview())
+    ledger["entries"][0]["milestones"][0]["reference_id"] = "wrong-decision"
+
+    payload = build_evidence_repair_recovery_closure_ledger_audit_preview(
+        recovery_closure_ledger=ledger
+    ).to_dict()
+
+    failed_checks = {check["id"] for check in payload["checks"] if check["status"] == "fail"}
+    assert payload["status"] == RECOVERY_CLOSURE_LEDGER_AUDIT_STATUS_BLOCKED
+    assert CHECK_RECOVERY_CLOSURE_LEDGER_AUDIT_REQUIREMENTS in failed_checks
+
+
+def test_no_action_recovery_closure_ledger_does_not_create_audit_preview():
+    payload = build_evidence_repair_recovery_closure_ledger_audit_preview(
+        recovery_closure_ledger={"status": "no_action_needed"}
+    ).to_dict()
+
+    assert payload["status"] == RECOVERY_CLOSURE_LEDGER_AUDIT_STATUS_NO_ACTION_NEEDED
+    assert payload["previews"] == []
+    assert payload["summary"]["recovery_closure_ledger_audit_preview_available"] is False
+
+
+def test_empty_recovery_closure_ledger_audit_preview_is_read_only():
+    payload = empty_evidence_repair_recovery_closure_ledger_audit_preview().to_dict()
+
+    assert payload["status"] == RECOVERY_CLOSURE_LEDGER_AUDIT_STATUS_NO_ACTION_NEEDED
+    assert payload["read_only"] is True
+    assert payload["read_only_memory"] is True
+    assert payload["would_mutate_memory"] is False
+    assert payload["previews"] == []
+
+
+def test_recovery_closure_ledger_audit_preview_id_is_stable():
+    ledger = _ready_ledger_preview()
+
+    first = build_evidence_repair_recovery_closure_ledger_audit_preview(
+        recovery_closure_ledger=ledger
+    ).to_dict()
+    second = build_evidence_repair_recovery_closure_ledger_audit_preview(
+        recovery_closure_ledger=ledger
+    ).to_dict()
+
+    assert first["previews"][0]["id"] == second["previews"][0]["id"]
+    assert first["previews"][0]["audit_digest"] == second["previews"][0]["audit_digest"]

--- a/tests/agent/test_memory_evidence_repair_recovery_closure_ledger_preview.py
+++ b/tests/agent/test_memory_evidence_repair_recovery_closure_ledger_preview.py
@@ -1,0 +1,137 @@
+from copy import deepcopy
+
+from agent.memory_evidence_repair_recovery_closure_gate import (
+    build_evidence_repair_recovery_closure_gate,
+)
+from agent.memory_evidence_repair_recovery_closure_ledger_preview import (
+    CHECK_RECOVERY_CLOSURE_INTEGRITY,
+    CHECK_RECOVERY_LIFECYCLE_CHAIN,
+    RECOVERY_CLOSURE_LEDGER_ENTRY_STATUS_READY,
+    RECOVERY_CLOSURE_LEDGER_ENTRY_TYPE,
+    RECOVERY_CLOSURE_LEDGER_STATUS_BLOCKED,
+    RECOVERY_CLOSURE_LEDGER_STATUS_NO_ACTION_NEEDED,
+    RECOVERY_CLOSURE_LEDGER_STATUS_READY,
+    build_evidence_repair_recovery_closure_ledger_preview,
+    empty_evidence_repair_recovery_closure_ledger_preview,
+)
+from tests.agent.test_memory_evidence_repair_recovery_closure_gate import (
+    _passing_completion_audit,
+    _planned_completion_audit,
+)
+
+
+def _ready_closure_gate():
+    return build_evidence_repair_recovery_closure_gate(
+        recovery_completion_audit=_passing_completion_audit()
+    ).to_dict()
+
+
+def test_ready_recovery_closure_creates_ledger_entry_preview():
+    payload = build_evidence_repair_recovery_closure_ledger_preview(
+        recovery_closure_gate=_ready_closure_gate()
+    ).to_dict()
+
+    entry = payload["entries"][0]
+    stages = {milestone["stage"] for milestone in entry["milestones"]}
+    assert payload["status"] == RECOVERY_CLOSURE_LEDGER_STATUS_READY
+    assert payload["summary"]["recovery_closure_ledger_ready"] is True
+    assert payload["summary"]["entry_count"] == 1
+    assert payload["summary"]["milestone_count"] == 8
+    assert payload["read_only"] is True
+    assert payload["read_only_memory"] is True
+    assert payload["would_mutate_memory"] is False
+    assert entry["id"].startswith("recovery-closure-ledger-")
+    assert entry["entry_type"] == RECOVERY_CLOSURE_LEDGER_ENTRY_TYPE
+    assert entry["status"] == RECOVERY_CLOSURE_LEDGER_ENTRY_STATUS_READY
+    assert entry["closure_id"].startswith("recovery-closure-")
+    assert entry["operation_ids"] == ["dryrun-op-123"]
+    assert entry["would_record_ledger_entry"] is True
+    assert entry["would_preserve_recovery_evidence"] is True
+    assert stages == {
+        "recovery_decision",
+        "recovery_execution_preview",
+        "recovery_approval_token",
+        "recovery_write_lock",
+        "recovery_executor_preview",
+        "recovery_completion_receipt",
+        "recovery_completion_audit",
+        "recovery_closure",
+    }
+
+
+def test_planned_recovery_closure_gate_blocks_ledger_preview():
+    closure_gate = build_evidence_repair_recovery_closure_gate(
+        recovery_completion_audit=_planned_completion_audit()
+    ).to_dict()
+
+    payload = build_evidence_repair_recovery_closure_ledger_preview(
+        recovery_closure_gate=closure_gate
+    ).to_dict()
+
+    assert payload["status"] == RECOVERY_CLOSURE_LEDGER_STATUS_BLOCKED
+    assert payload["entries"] == []
+    assert "provide_observed_recovery_completion_state" in payload["required_actions"]
+
+
+def test_tampered_recovery_closure_digest_blocks_ledger_preview():
+    closure_gate = _ready_closure_gate()
+    closure_gate["closures"][0]["closure_digest"] = "bad"
+
+    payload = build_evidence_repair_recovery_closure_ledger_preview(
+        recovery_closure_gate=closure_gate
+    ).to_dict()
+
+    failed_checks = {check["id"] for check in payload["checks"] if check["status"] == "fail"}
+    assert payload["status"] == RECOVERY_CLOSURE_LEDGER_STATUS_BLOCKED
+    assert CHECK_RECOVERY_CLOSURE_INTEGRITY in failed_checks
+    assert "regenerate_recovery_closure_gate" in payload["required_actions"]
+
+
+def test_unobserved_source_audit_blocks_lifecycle_chain():
+    closure_gate = deepcopy(_ready_closure_gate())
+    closure_gate["closures"][0]["source_recovery_completion_audit_preview"][
+        "observed_state_supplied"
+    ] = False
+
+    payload = build_evidence_repair_recovery_closure_ledger_preview(
+        recovery_closure_gate=closure_gate
+    ).to_dict()
+
+    failed_checks = {check["id"] for check in payload["checks"] if check["status"] == "fail"}
+    assert payload["status"] == RECOVERY_CLOSURE_LEDGER_STATUS_BLOCKED
+    assert CHECK_RECOVERY_LIFECYCLE_CHAIN in failed_checks
+    assert "regenerate_recovery_closure_gate" in payload["required_actions"]
+
+
+def test_no_action_recovery_closure_gate_does_not_create_ledger_entry():
+    payload = build_evidence_repair_recovery_closure_ledger_preview(
+        recovery_closure_gate={"status": "no_action_needed"}
+    ).to_dict()
+
+    assert payload["status"] == RECOVERY_CLOSURE_LEDGER_STATUS_NO_ACTION_NEEDED
+    assert payload["entries"] == []
+    assert payload["summary"]["recovery_closure_ledger_preview_available"] is False
+
+
+def test_empty_recovery_closure_ledger_preview_is_read_only():
+    payload = empty_evidence_repair_recovery_closure_ledger_preview().to_dict()
+
+    assert payload["status"] == RECOVERY_CLOSURE_LEDGER_STATUS_NO_ACTION_NEEDED
+    assert payload["read_only"] is True
+    assert payload["read_only_memory"] is True
+    assert payload["would_mutate_memory"] is False
+    assert payload["entries"] == []
+
+
+def test_recovery_closure_ledger_entry_id_is_stable():
+    closure_gate = _ready_closure_gate()
+
+    first = build_evidence_repair_recovery_closure_ledger_preview(
+        recovery_closure_gate=closure_gate
+    ).to_dict()
+    second = build_evidence_repair_recovery_closure_ledger_preview(
+        recovery_closure_gate=closure_gate
+    ).to_dict()
+
+    assert first["entries"][0]["id"] == second["entries"][0]["id"]
+    assert first["entries"][0]["entry_digest"] == second["entries"][0]["entry_digest"]

--- a/tests/agent/test_memory_evidence_repair_recovery_completion_audit_preview.py
+++ b/tests/agent/test_memory_evidence_repair_recovery_completion_audit_preview.py
@@ -1,0 +1,149 @@
+from agent.memory_evidence_repair_recovery_completion_audit_preview import (
+    CHECK_OBSERVED_RECOVERY_COMPLETION_STATE,
+    CHECK_RECOVERY_COMPLETION_RECEIPT_INTEGRITY,
+    RECOVERY_COMPLETION_AUDIT_STATUS_BLOCKED,
+    RECOVERY_COMPLETION_AUDIT_STATUS_NO_ACTION_NEEDED,
+    RECOVERY_COMPLETION_AUDIT_STATUS_READY,
+    build_evidence_repair_recovery_completion_audit_preview,
+    empty_evidence_repair_recovery_completion_audit_preview,
+)
+from agent.memory_evidence_repair_recovery_completion_receipt import (
+    build_evidence_repair_recovery_completion_receipt,
+)
+from tests.agent.test_memory_evidence_repair_recovery_completion_receipt import (
+    _recovery_executor_preview,
+)
+
+
+def _recovery_completion_receipt():
+    return build_evidence_repair_recovery_completion_receipt(
+        recovery_executor_preview=_recovery_executor_preview(),
+        actor="han",
+        recovery_reason="manual post-audit recovery complete",
+    ).to_dict()
+
+
+def _observed_recovery_steps(receipt):
+    return {
+        step_id: {"status": "completed"}
+        for step_id in receipt["receipts"][0]["recovery_step_ids"]
+    }
+
+
+def test_ready_recovery_completion_receipt_creates_planned_audit():
+    payload = build_evidence_repair_recovery_completion_audit_preview(
+        recovery_completion_receipt=_recovery_completion_receipt()
+    ).to_dict()
+
+    audit = payload["previews"][0]
+    categories = {step["category"] for step in audit["audit_steps"]}
+    assert payload["status"] == RECOVERY_COMPLETION_AUDIT_STATUS_READY
+    assert payload["summary"]["recovery_completion_audit_ready"] is True
+    assert payload["summary"]["planned_audit_step_count"] == 12
+    assert payload["read_only"] is True
+    assert payload["read_only_memory"] is True
+    assert payload["would_mutate_memory"] is False
+    assert audit["id"].startswith("recovery-completion-audit-")
+    assert categories == {
+        "completion_receipt",
+        "token",
+        "lock",
+        "recovery_step",
+        "post_recovery_audit",
+        "contamination_guard",
+    }
+    assert audit["would_verify_completion_receipt_recorded"] is True
+    assert audit["would_verify_no_secondary_memory_contamination"] is True
+
+
+def test_observed_recovery_completion_state_can_pass():
+    receipt = _recovery_completion_receipt()
+    row = receipt["receipts"][0]
+
+    payload = build_evidence_repair_recovery_completion_audit_preview(
+        recovery_completion_receipt=receipt,
+        observed_recovery_steps=_observed_recovery_steps(receipt),
+        recorded_receipts=[{"id": row["id"]}],
+        used_token_ids=[row["token_id"]],
+        released_lock_ids=[row["lock_id"]],
+        post_recovery_audit_status={"status": "pass"},
+        contamination_status={"contaminated": False},
+    ).to_dict()
+
+    assert payload["status"] == RECOVERY_COMPLETION_AUDIT_STATUS_READY
+    assert payload["summary"]["observed_pass_step_count"] == 12
+    assert payload["summary"]["observed_fail_step_count"] == 0
+    assert payload["previews"][0]["observed_state_supplied"] is True
+
+
+def test_observed_missing_recovery_token_blocks_audit():
+    receipt = _recovery_completion_receipt()
+    row = receipt["receipts"][0]
+
+    payload = build_evidence_repair_recovery_completion_audit_preview(
+        recovery_completion_receipt=receipt,
+        observed_recovery_steps=_observed_recovery_steps(receipt),
+        recorded_receipts=[{"id": row["id"]}],
+        used_token_ids=[],
+        released_lock_ids=[row["lock_id"]],
+        post_recovery_audit_status={"status": "pass"},
+        contamination_status={"contaminated": False},
+    ).to_dict()
+
+    failed_checks = {check["id"] for check in payload["checks"] if check["status"] == "fail"}
+    assert payload["status"] == RECOVERY_COMPLETION_AUDIT_STATUS_BLOCKED
+    assert CHECK_OBSERVED_RECOVERY_COMPLETION_STATE in failed_checks
+    assert "investigate_recovery_completion_audit_failures" in payload["required_actions"]
+
+
+def test_observed_contamination_blocks_audit():
+    receipt = _recovery_completion_receipt()
+    row = receipt["receipts"][0]
+
+    payload = build_evidence_repair_recovery_completion_audit_preview(
+        recovery_completion_receipt=receipt,
+        observed_recovery_steps=_observed_recovery_steps(receipt),
+        recorded_receipts=[{"id": row["id"]}],
+        used_token_ids=[row["token_id"]],
+        released_lock_ids=[row["lock_id"]],
+        post_recovery_audit_status={"status": "pass"},
+        contamination_status={"contaminated": True},
+    ).to_dict()
+
+    failed_checks = {check["id"] for check in payload["checks"] if check["status"] == "fail"}
+    assert payload["status"] == RECOVERY_COMPLETION_AUDIT_STATUS_BLOCKED
+    assert CHECK_OBSERVED_RECOVERY_COMPLETION_STATE in failed_checks
+
+
+def test_tampered_recovery_completion_receipt_blocks_audit():
+    receipt = _recovery_completion_receipt()
+    receipt["receipts"][0]["receipt_digest"] = "bad"
+
+    payload = build_evidence_repair_recovery_completion_audit_preview(
+        recovery_completion_receipt=receipt
+    ).to_dict()
+
+    failed_checks = {check["id"] for check in payload["checks"] if check["status"] == "fail"}
+    assert payload["status"] == RECOVERY_COMPLETION_AUDIT_STATUS_BLOCKED
+    assert CHECK_RECOVERY_COMPLETION_RECEIPT_INTEGRITY in failed_checks
+    assert "regenerate_recovery_completion_receipt" in payload["required_actions"]
+
+
+def test_no_action_recovery_completion_receipt_does_not_create_audit():
+    payload = build_evidence_repair_recovery_completion_audit_preview(
+        recovery_completion_receipt={"status": "no_action_needed"}
+    ).to_dict()
+
+    assert payload["status"] == RECOVERY_COMPLETION_AUDIT_STATUS_NO_ACTION_NEEDED
+    assert payload["previews"] == []
+    assert payload["summary"]["recovery_completion_audit_preview_available"] is False
+
+
+def test_empty_recovery_completion_audit_preview_is_read_only():
+    payload = empty_evidence_repair_recovery_completion_audit_preview().to_dict()
+
+    assert payload["status"] == RECOVERY_COMPLETION_AUDIT_STATUS_NO_ACTION_NEEDED
+    assert payload["read_only"] is True
+    assert payload["read_only_memory"] is True
+    assert payload["would_mutate_memory"] is False
+    assert payload["previews"] == []

--- a/tests/agent/test_memory_evidence_repair_recovery_completion_receipt.py
+++ b/tests/agent/test_memory_evidence_repair_recovery_completion_receipt.py
@@ -1,0 +1,147 @@
+from agent.memory_evidence_repair_recovery_completion_receipt import (
+    RECOVERY_COMPLETION_RECEIPT_STATUS_BLOCKED,
+    RECOVERY_COMPLETION_RECEIPT_STATUS_NO_ACTION_NEEDED,
+    RECOVERY_COMPLETION_RECEIPT_STATUS_READY,
+    RECOVERY_COMPLETION_RECEIPT_TYPE,
+    build_evidence_repair_recovery_completion_receipt,
+    empty_evidence_repair_recovery_completion_receipt,
+)
+from agent.memory_evidence_repair_recovery_executor_preview import (
+    build_evidence_repair_recovery_executor_preview,
+)
+from tests.agent.test_memory_evidence_repair_recovery_executor_preview import (
+    _recovery_write_lock_gate,
+)
+
+
+def _recovery_executor_preview():
+    return build_evidence_repair_recovery_executor_preview(
+        recovery_write_lock_gate=_recovery_write_lock_gate(),
+        current_time="2026-05-11T00:12:00+00:00",
+    ).to_dict()
+
+
+def test_ready_recovery_executor_preview_creates_completion_receipt():
+    payload = build_evidence_repair_recovery_completion_receipt(
+        recovery_executor_preview=_recovery_executor_preview(),
+        actor="han",
+        recovery_reason="manual post-audit recovery complete",
+    ).to_dict()
+
+    receipt = payload["receipts"][0]
+    assert payload["status"] == RECOVERY_COMPLETION_RECEIPT_STATUS_READY
+    assert payload["summary"]["recovery_completion_receipt_available"] is True
+    assert payload["summary"]["would_record_receipt_count"] == 1
+    assert payload["summary"]["would_mark_recovery_token_used_count"] == 1
+    assert payload["summary"]["would_release_recovery_write_lock_count"] == 1
+    assert payload["summary"]["would_trigger_recovery_audit_count"] == 1
+    assert payload["read_only"] is True
+    assert payload["read_only_memory"] is True
+    assert payload["would_mutate_memory"] is False
+    assert receipt["id"].startswith("recovery-completion-receipt-")
+    assert receipt["receipt_type"] == RECOVERY_COMPLETION_RECEIPT_TYPE
+    assert receipt["actor"] == "han"
+    assert receipt["recovery_reason"] == "manual post-audit recovery complete"
+    assert receipt["operation_ids"] == ["dryrun-op-123"]
+    assert receipt["future_mutation_step_ids"] == [
+        "recovery-execution-step-5-apply_manual_rollback_restore"
+    ]
+    assert receipt["used_recovery_token_id"] in payload["used_recovery_token_ids"]
+    assert receipt["released_recovery_lock_id"] in payload["released_recovery_lock_ids"]
+    assert receipt["would_trigger_recovery_audit"] is True
+
+
+def test_blocked_recovery_executor_preview_does_not_create_receipt():
+    executor_preview = _recovery_executor_preview()
+    executor_preview["status"] = "blocked"
+    executor_preview["blocking_reasons"] = ["Recovery write lock expired."]
+    executor_preview["required_actions"] = ["regenerate_recovery_write_lock_gate"]
+
+    payload = build_evidence_repair_recovery_completion_receipt(
+        recovery_executor_preview=executor_preview
+    ).to_dict()
+
+    assert payload["status"] == RECOVERY_COMPLETION_RECEIPT_STATUS_BLOCKED
+    assert payload["receipts"] == []
+    assert payload["blocking_reasons"] == ["Recovery write lock expired."]
+    assert payload["required_actions"] == ["regenerate_recovery_executor_preview"]
+
+
+def test_existing_used_recovery_token_blocks_completion_receipt():
+    executor_preview = _recovery_executor_preview()
+    token_id = executor_preview["previews"][0]["token_id"]
+
+    payload = build_evidence_repair_recovery_completion_receipt(
+        recovery_executor_preview=executor_preview,
+        used_token_ids=[token_id],
+    ).to_dict()
+
+    assert payload["status"] == RECOVERY_COMPLETION_RECEIPT_STATUS_BLOCKED
+    assert payload["receipts"] == []
+    assert "regenerate_recovery_human_approval_token" in payload["required_actions"]
+    assert token_id in payload["used_recovery_token_ids"]
+
+
+def test_existing_released_recovery_lock_blocks_completion_receipt():
+    executor_preview = _recovery_executor_preview()
+    lock_id = executor_preview["previews"][0]["lock_id"]
+
+    payload = build_evidence_repair_recovery_completion_receipt(
+        recovery_executor_preview=executor_preview,
+        released_lock_ids=[lock_id],
+    ).to_dict()
+
+    assert payload["status"] == RECOVERY_COMPLETION_RECEIPT_STATUS_BLOCKED
+    assert payload["receipts"] == []
+    assert "regenerate_recovery_write_lock_gate" in payload["required_actions"]
+    assert lock_id in payload["released_recovery_lock_ids"]
+
+
+def test_tampered_recovery_executor_preview_digest_blocks_completion_receipt():
+    executor_preview = _recovery_executor_preview()
+    executor_preview["previews"][0]["preview_digest"] = "bad"
+
+    payload = build_evidence_repair_recovery_completion_receipt(
+        recovery_executor_preview=executor_preview
+    ).to_dict()
+
+    assert payload["status"] == RECOVERY_COMPLETION_RECEIPT_STATUS_BLOCKED
+    assert payload["receipts"] == []
+    assert "regenerate_recovery_executor_preview" in payload["required_actions"]
+
+
+def test_recovery_completion_receipt_id_and_digest_are_stable():
+    executor_preview = _recovery_executor_preview()
+    first = build_evidence_repair_recovery_completion_receipt(
+        recovery_executor_preview=executor_preview,
+        actor="han",
+        recovery_reason="manual post-audit recovery complete",
+    ).to_dict()
+    second = build_evidence_repair_recovery_completion_receipt(
+        recovery_executor_preview=executor_preview,
+        actor="han",
+        recovery_reason="manual post-audit recovery complete",
+    ).to_dict()
+
+    assert first["receipts"][0]["id"] == second["receipts"][0]["id"]
+    assert first["receipts"][0]["receipt_digest"] == second["receipts"][0]["receipt_digest"]
+
+
+def test_no_action_recovery_executor_preview_does_not_create_receipt():
+    payload = build_evidence_repair_recovery_completion_receipt(
+        recovery_executor_preview={"status": "no_action_needed"}
+    ).to_dict()
+
+    assert payload["status"] == RECOVERY_COMPLETION_RECEIPT_STATUS_NO_ACTION_NEEDED
+    assert payload["receipts"] == []
+    assert payload["summary"]["recovery_completion_receipt_available"] is False
+
+
+def test_empty_recovery_completion_receipt_is_read_only():
+    payload = empty_evidence_repair_recovery_completion_receipt().to_dict()
+
+    assert payload["status"] == RECOVERY_COMPLETION_RECEIPT_STATUS_NO_ACTION_NEEDED
+    assert payload["read_only"] is True
+    assert payload["read_only_memory"] is True
+    assert payload["would_mutate_memory"] is False
+    assert payload["receipts"] == []

--- a/tests/agent/test_memory_evidence_repair_recovery_decision_gate.py
+++ b/tests/agent/test_memory_evidence_repair_recovery_decision_gate.py
@@ -1,0 +1,110 @@
+from agent.memory_evidence_repair_recovery_decision_gate import (
+    RECOVERY_DECISION_STATUS_BLOCKED,
+    RECOVERY_DECISION_STATUS_NO_ACTION_NEEDED,
+    RECOVERY_DECISION_STATUS_READY,
+    RECOVERY_ROUTE_MANUAL_ROLLBACK,
+    RECOVERY_ROUTE_PREPAREDNESS_ONLY,
+    build_evidence_repair_recovery_decision_gate,
+    empty_evidence_repair_recovery_decision_gate,
+)
+from agent.memory_evidence_repair_rollback_drill_preview import (
+    build_evidence_repair_rollback_drill_preview,
+)
+from tests.agent.test_memory_evidence_repair_rollback_drill_preview import (
+    _failed_post_commit_audit,
+    _planned_post_commit_audit,
+)
+
+
+def _preparedness_drill():
+    return build_evidence_repair_rollback_drill_preview(
+        post_commit_audit=_planned_post_commit_audit()
+    ).to_dict()
+
+
+def _failure_drill():
+    return build_evidence_repair_rollback_drill_preview(
+        post_commit_audit=_failed_post_commit_audit()
+    ).to_dict()
+
+
+def test_preparedness_drill_creates_preparedness_decision():
+    payload = build_evidence_repair_recovery_decision_gate(
+        rollback_drill=_preparedness_drill()
+    ).to_dict()
+
+    decision = payload["decisions"][0]
+    assert payload["status"] == RECOVERY_DECISION_STATUS_READY
+    assert payload["summary"]["recovery_decision_ready"] is True
+    assert payload["summary"]["preparedness_review_count"] == 1
+    assert payload["summary"]["manual_rollback_required_count"] == 0
+    assert payload["read_only"] is True
+    assert payload["read_only_memory"] is True
+    assert payload["would_mutate_memory"] is False
+    assert decision["route"] == RECOVERY_ROUTE_PREPAREDNESS_ONLY
+    assert decision["priority"] == "p2"
+    assert decision["future_would_mutate_memory"] is False
+    assert "rollback_drill_kept_read_only" in decision["required_preconditions"]
+
+
+def test_failure_drill_creates_manual_rollback_decision():
+    payload = build_evidence_repair_recovery_decision_gate(
+        rollback_drill=_failure_drill()
+    ).to_dict()
+
+    decision = payload["decisions"][0]
+    assert payload["status"] == RECOVERY_DECISION_STATUS_READY
+    assert payload["summary"]["manual_rollback_required_count"] == 1
+    assert decision["route"] == RECOVERY_ROUTE_MANUAL_ROLLBACK
+    assert decision["priority"] == "p0"
+    assert decision["operation_ids"] == ["dryrun-op-123"]
+    assert "request_explicit_human_recovery_approval" in decision["recommended_actions"]
+    assert "snapshot_or_rollback_plan_verified" in decision["required_preconditions"]
+    assert "automatic_memory_rollback" in decision["blocked_actions"]
+
+
+def test_tampered_drill_with_non_planned_step_blocks_decision():
+    drill = _failure_drill()
+    drill["previews"][0]["steps"][0]["status"] = "done"
+
+    payload = build_evidence_repair_recovery_decision_gate(
+        rollback_drill=drill
+    ).to_dict()
+
+    assert payload["status"] == RECOVERY_DECISION_STATUS_BLOCKED
+    assert payload["decisions"] == []
+    assert "regenerate_rollback_drill_preview" in payload["required_actions"]
+
+
+def test_blocked_drill_blocks_decision_gate():
+    payload = build_evidence_repair_recovery_decision_gate(
+        rollback_drill={
+            "status": "blocked",
+            "blocking_reasons": ["post commit audit unavailable"],
+            "required_actions": ["produce_post_commit_audit_preview"],
+        }
+    ).to_dict()
+
+    assert payload["status"] == RECOVERY_DECISION_STATUS_BLOCKED
+    assert payload["decisions"] == []
+    assert "produce_post_commit_audit_preview" in payload["required_actions"]
+
+
+def test_no_action_drill_does_not_create_decision():
+    payload = build_evidence_repair_recovery_decision_gate(
+        rollback_drill={"status": "no_action_needed"}
+    ).to_dict()
+
+    assert payload["status"] == RECOVERY_DECISION_STATUS_NO_ACTION_NEEDED
+    assert payload["decisions"] == []
+    assert payload["summary"]["recovery_decision_available"] is False
+
+
+def test_empty_recovery_decision_gate_is_read_only():
+    payload = empty_evidence_repair_recovery_decision_gate().to_dict()
+
+    assert payload["status"] == RECOVERY_DECISION_STATUS_NO_ACTION_NEEDED
+    assert payload["read_only"] is True
+    assert payload["read_only_memory"] is True
+    assert payload["would_mutate_memory"] is False
+    assert payload["decisions"] == []

--- a/tests/agent/test_memory_evidence_repair_recovery_execution_preview.py
+++ b/tests/agent/test_memory_evidence_repair_recovery_execution_preview.py
@@ -1,0 +1,123 @@
+from agent.memory_evidence_repair_recovery_decision_gate import (
+    build_evidence_repair_recovery_decision_gate,
+)
+from agent.memory_evidence_repair_recovery_execution_preview import (
+    RECOVERY_EXECUTION_STATUS_BLOCKED,
+    RECOVERY_EXECUTION_STATUS_NO_ACTION_NEEDED,
+    RECOVERY_EXECUTION_STATUS_READY,
+    build_evidence_repair_recovery_execution_preview,
+    empty_evidence_repair_recovery_execution_preview,
+)
+from tests.agent.test_memory_evidence_repair_recovery_decision_gate import (
+    _failure_drill,
+    _preparedness_drill,
+)
+
+
+def _preparedness_decision():
+    return build_evidence_repair_recovery_decision_gate(
+        rollback_drill=_preparedness_drill()
+    ).to_dict()
+
+
+def _manual_rollback_decision():
+    return build_evidence_repair_recovery_decision_gate(
+        rollback_drill=_failure_drill()
+    ).to_dict()
+
+
+def test_preparedness_decision_creates_non_mutating_execution_preview():
+    payload = build_evidence_repair_recovery_execution_preview(
+        recovery_decision=_preparedness_decision()
+    ).to_dict()
+
+    preview = payload["previews"][0]
+    actions = {step["action"] for step in preview["steps"]}
+    assert payload["status"] == RECOVERY_EXECUTION_STATUS_READY
+    assert payload["summary"]["recovery_execution_ready"] is True
+    assert payload["summary"]["preparedness_preview_count"] == 1
+    assert payload["summary"]["future_mutation_step_count"] == 0
+    assert payload["read_only"] is True
+    assert payload["read_only_memory"] is True
+    assert payload["would_mutate_memory"] is False
+    assert preview["future_would_mutate_memory"] is False
+    assert preview["route"] == "preparedness_review_only"
+    assert "keep_rollback_drill_available" in actions
+    assert "rerun_post_commit_audit_after_future_commit" in actions
+
+
+def test_manual_rollback_decision_creates_ordered_execution_preview():
+    payload = build_evidence_repair_recovery_execution_preview(
+        recovery_decision=_manual_rollback_decision()
+    ).to_dict()
+
+    preview = payload["previews"][0]
+    actions = [step["action"] for step in preview["steps"]]
+    restore_steps = [
+        step for step in preview["steps"] if step["action"] == "apply_manual_rollback_restore"
+    ]
+    assert payload["status"] == RECOVERY_EXECUTION_STATUS_READY
+    assert payload["summary"]["manual_rollback_preview_count"] == 1
+    assert payload["summary"]["future_mutation_step_count"] == 1
+    assert preview["future_would_mutate_memory"] is True
+    assert preview["human_approval_required"] is True
+    assert preview["operation_ids"] == ["dryrun-op-123"]
+    assert actions == [
+        "verify_recovery_decision_gate",
+        "preserve_failed_audit_context",
+        "isolate_impacted_memory_records",
+        "verify_snapshot_or_rollback_plan",
+        "apply_manual_rollback_restore",
+        "reconcile_receipt_token_lock_state",
+        "rerun_post_commit_audit",
+    ]
+    assert restore_steps
+    assert restore_steps[0]["future_would_mutate_memory"] is True
+    assert restore_steps[0]["human_approval_required"] is True
+
+
+def test_tampered_decision_without_controls_blocks_execution_preview():
+    decision = _manual_rollback_decision()
+    decision["decisions"][0]["blocked_actions"] = []
+
+    payload = build_evidence_repair_recovery_execution_preview(
+        recovery_decision=decision
+    ).to_dict()
+
+    assert payload["status"] == RECOVERY_EXECUTION_STATUS_BLOCKED
+    assert payload["previews"] == []
+    assert "regenerate_recovery_decision_gate" in payload["required_actions"]
+
+
+def test_blocked_decision_gate_blocks_execution_preview():
+    payload = build_evidence_repair_recovery_execution_preview(
+        recovery_decision={
+            "status": "blocked",
+            "blocking_reasons": ["rollback drill unavailable"],
+            "required_actions": ["produce_ready_rollback_drill_preview"],
+        }
+    ).to_dict()
+
+    assert payload["status"] == RECOVERY_EXECUTION_STATUS_BLOCKED
+    assert payload["previews"] == []
+    assert "produce_ready_rollback_drill_preview" in payload["required_actions"]
+
+
+def test_no_action_decision_does_not_create_execution_preview():
+    payload = build_evidence_repair_recovery_execution_preview(
+        recovery_decision={"status": "no_action_needed"}
+    ).to_dict()
+
+    assert payload["status"] == RECOVERY_EXECUTION_STATUS_NO_ACTION_NEEDED
+    assert payload["previews"] == []
+    assert payload["summary"]["recovery_execution_preview_available"] is False
+
+
+def test_empty_recovery_execution_preview_is_read_only():
+    payload = empty_evidence_repair_recovery_execution_preview().to_dict()
+
+    assert payload["status"] == RECOVERY_EXECUTION_STATUS_NO_ACTION_NEEDED
+    assert payload["read_only"] is True
+    assert payload["read_only_memory"] is True
+    assert payload["would_mutate_memory"] is False
+    assert payload["previews"] == []

--- a/tests/agent/test_memory_evidence_repair_recovery_executor_preview.py
+++ b/tests/agent/test_memory_evidence_repair_recovery_executor_preview.py
@@ -1,0 +1,139 @@
+from agent.memory_evidence_repair_recovery_approval_token_gate import (
+    build_evidence_repair_recovery_approval_token_gate,
+)
+from agent.memory_evidence_repair_recovery_executor_preview import (
+    CHECK_RECOVERY_EXECUTION_STEPS,
+    CHECK_RECOVERY_WRITE_LOCK_EXPIRY,
+    CHECK_RECOVERY_WRITE_LOCK_INTEGRITY,
+    RECOVERY_EXECUTOR_PREVIEW_STATUS_BLOCKED,
+    RECOVERY_EXECUTOR_PREVIEW_STATUS_NO_ACTION_NEEDED,
+    RECOVERY_EXECUTOR_PREVIEW_STATUS_READY,
+    build_evidence_repair_recovery_executor_preview,
+    empty_evidence_repair_recovery_executor_preview,
+)
+from agent.memory_evidence_repair_recovery_human_approval_token import (
+    build_evidence_repair_recovery_human_approval_token,
+)
+from agent.memory_evidence_repair_recovery_write_lock_gate import (
+    build_evidence_repair_recovery_write_lock_gate,
+)
+from tests.agent.test_memory_evidence_repair_recovery_human_approval_token import (
+    _manual_rollback_execution,
+)
+
+
+def _recovery_write_lock_gate():
+    token_report = build_evidence_repair_recovery_human_approval_token(
+        recovery_execution=_manual_rollback_execution(),
+        approver="han",
+        approval_reason="manual recovery approval",
+        expires_in_minutes=20,
+    ).to_dict()
+    token_report["generated_at"] = "2026-05-11T00:00:00+00:00"
+    token = token_report["tokens"][0]
+    token_gate = build_evidence_repair_recovery_approval_token_gate(
+        recovery_approval_token=token_report,
+        confirmation_text=token["required_confirmation_text"],
+        current_time="2026-05-11T00:10:00+00:00",
+    ).to_dict()
+    return build_evidence_repair_recovery_write_lock_gate(
+        recovery_token_gate=token_gate,
+        lock_owner="han",
+        lock_ttl_minutes=15,
+        current_time="2026-05-11T00:10:00+00:00",
+    ).to_dict()
+
+
+def test_ready_recovery_write_lock_creates_recovery_executor_preview_steps():
+    payload = build_evidence_repair_recovery_executor_preview(
+        recovery_write_lock_gate=_recovery_write_lock_gate(),
+        current_time="2026-05-11T00:12:00+00:00",
+    ).to_dict()
+
+    preview = payload["previews"][0]
+    actions = [step["action"] for step in preview["steps"]]
+    assert payload["status"] == RECOVERY_EXECUTOR_PREVIEW_STATUS_READY
+    assert payload["summary"]["manual_recovery_executor_preview_ready"] is True
+    assert payload["summary"]["future_mutation_step_count"] == 1
+    assert payload["read_only"] is True
+    assert payload["read_only_memory"] is True
+    assert payload["would_mutate_memory"] is False
+    assert preview["id"].startswith("recovery-executor-preview-")
+    assert preview["would_execute_manual_recovery"] is True
+    assert preview["would_apply_memory_recovery"] is True
+    assert preview["would_mark_recovery_token_used"] is True
+    assert preview["would_release_recovery_write_lock"] is True
+    assert preview["would_rerun_post_commit_audit"] is True
+    assert actions[0] == "verify_recovery_write_lock_token_and_execution"
+    assert "apply_manual_rollback_restore" in actions
+    assert actions[-2:] == ["mark_recovery_token_used", "release_recovery_write_lock"]
+    mutation_steps = [
+        step for step in preview["steps"] if step["future_would_mutate_memory"]
+    ]
+    assert mutation_steps[0]["action"] == "apply_manual_rollback_restore"
+    assert preview["steps"][-1]["stop_on_failure"] is False
+
+
+def test_expired_recovery_write_lock_blocks_recovery_executor_preview():
+    payload = build_evidence_repair_recovery_executor_preview(
+        recovery_write_lock_gate=_recovery_write_lock_gate(),
+        current_time="2026-05-11T00:26:00+00:00",
+    ).to_dict()
+
+    failed_checks = {check["id"] for check in payload["checks"] if check["status"] == "fail"}
+    assert payload["status"] == RECOVERY_EXECUTOR_PREVIEW_STATUS_BLOCKED
+    assert CHECK_RECOVERY_WRITE_LOCK_EXPIRY in failed_checks
+    assert "regenerate_recovery_write_lock_gate" in payload["required_actions"]
+
+
+def test_tampered_recovery_write_lock_digest_blocks_recovery_executor_preview():
+    gate = _recovery_write_lock_gate()
+    gate["locks"][0]["lock_digest"] = "bad"
+
+    payload = build_evidence_repair_recovery_executor_preview(
+        recovery_write_lock_gate=gate,
+        current_time="2026-05-11T00:12:00+00:00",
+    ).to_dict()
+
+    failed_checks = {check["id"] for check in payload["checks"] if check["status"] == "fail"}
+    assert payload["status"] == RECOVERY_EXECUTOR_PREVIEW_STATUS_BLOCKED
+    assert CHECK_RECOVERY_WRITE_LOCK_INTEGRITY in failed_checks
+
+
+def test_mismatched_recovery_execution_steps_block_recovery_executor_preview():
+    gate = _recovery_write_lock_gate()
+    execution = (
+        gate["locks"][0]["source_recovery_token_gate"][
+            "source_recovery_execution_preview"
+        ]
+    )
+    execution["steps"][0]["id"] = "tampered-step-id"
+
+    payload = build_evidence_repair_recovery_executor_preview(
+        recovery_write_lock_gate=gate,
+        current_time="2026-05-11T00:12:00+00:00",
+    ).to_dict()
+
+    failed_checks = {check["id"] for check in payload["checks"] if check["status"] == "fail"}
+    assert payload["status"] == RECOVERY_EXECUTOR_PREVIEW_STATUS_BLOCKED
+    assert CHECK_RECOVERY_EXECUTION_STEPS in failed_checks
+
+
+def test_no_action_recovery_write_lock_gate_does_not_create_preview():
+    payload = build_evidence_repair_recovery_executor_preview(
+        recovery_write_lock_gate={"status": "no_action_needed"}
+    ).to_dict()
+
+    assert payload["status"] == RECOVERY_EXECUTOR_PREVIEW_STATUS_NO_ACTION_NEEDED
+    assert payload["previews"] == []
+    assert payload["summary"]["recovery_executor_preview_available"] is False
+
+
+def test_empty_recovery_executor_preview_is_read_only():
+    payload = empty_evidence_repair_recovery_executor_preview().to_dict()
+
+    assert payload["status"] == RECOVERY_EXECUTOR_PREVIEW_STATUS_NO_ACTION_NEEDED
+    assert payload["read_only"] is True
+    assert payload["read_only_memory"] is True
+    assert payload["would_mutate_memory"] is False
+    assert payload["previews"] == []

--- a/tests/agent/test_memory_evidence_repair_recovery_human_approval_token.py
+++ b/tests/agent/test_memory_evidence_repair_recovery_human_approval_token.py
@@ -1,0 +1,108 @@
+from agent.memory_evidence_repair_recovery_execution_preview import (
+    build_evidence_repair_recovery_execution_preview,
+)
+from agent.memory_evidence_repair_recovery_human_approval_token import (
+    RECOVERY_APPROVAL_TOKEN_SCOPE,
+    RECOVERY_APPROVAL_TOKEN_TYPE,
+    RECOVERY_TOKEN_STATUS_BLOCKED,
+    RECOVERY_TOKEN_STATUS_DRAFT_READY,
+    RECOVERY_TOKEN_STATUS_NO_ACTION_NEEDED,
+    build_evidence_repair_recovery_human_approval_token,
+    empty_evidence_repair_recovery_human_approval_token,
+)
+from tests.agent.test_memory_evidence_repair_recovery_execution_preview import (
+    _manual_rollback_decision,
+    _preparedness_decision,
+)
+
+
+def _manual_rollback_execution():
+    return build_evidence_repair_recovery_execution_preview(
+        recovery_decision=_manual_rollback_decision()
+    ).to_dict()
+
+
+def _preparedness_execution():
+    return build_evidence_repair_recovery_execution_preview(
+        recovery_decision=_preparedness_decision()
+    ).to_dict()
+
+
+def test_manual_rollback_execution_creates_recovery_token_draft():
+    payload = build_evidence_repair_recovery_human_approval_token(
+        recovery_execution=_manual_rollback_execution(),
+        approver="han",
+        approval_reason="manual recovery approval",
+        expires_in_minutes=20,
+    ).to_dict()
+
+    token = payload["tokens"][0]
+    assert payload["status"] == RECOVERY_TOKEN_STATUS_DRAFT_READY
+    assert payload["summary"]["token_count"] == 1
+    assert payload["read_only"] is True
+    assert payload["read_only_memory"] is True
+    assert payload["would_mutate_memory"] is False
+    assert token["id"].startswith("recovery-approval-token-")
+    assert token["token_type"] == RECOVERY_APPROVAL_TOKEN_TYPE
+    assert token["scope"] == RECOVERY_APPROVAL_TOKEN_SCOPE
+    assert token["approver"] == "han"
+    assert token["approval_reason"] == "manual recovery approval"
+    assert token["expires_in_minutes"] == 20
+    assert token["operation_ids"] == ["dryrun-op-123"]
+    assert token["future_mutation_step_ids"] == [
+        "recovery-execution-step-5-apply_manual_rollback_restore"
+    ]
+    assert len(token["token_digest"]) == 64
+    assert token["one_time_constraints"]["one_time_use"] is True
+    assert token["required_confirmation_text"].startswith("APPROVE ")
+
+
+def test_preparedness_execution_does_not_need_recovery_token():
+    payload = build_evidence_repair_recovery_human_approval_token(
+        recovery_execution=_preparedness_execution()
+    ).to_dict()
+
+    assert payload["status"] == RECOVERY_TOKEN_STATUS_NO_ACTION_NEEDED
+    assert payload["tokens"] == []
+    assert payload["summary"]["no_action_count"] == 1
+
+
+def test_blocked_execution_preview_does_not_create_token():
+    payload = build_evidence_repair_recovery_human_approval_token(
+        recovery_execution={
+            "status": "blocked",
+            "blocking_reasons": ["recovery decision missing"],
+            "required_actions": ["produce_recovery_decision_gate"],
+        }
+    ).to_dict()
+
+    assert payload["status"] == RECOVERY_TOKEN_STATUS_BLOCKED
+    assert payload["tokens"] == []
+    assert payload["blocking_reasons"] == ["recovery decision missing"]
+    assert payload["required_actions"] == ["produce_recovery_decision_gate"]
+
+
+def test_recovery_token_id_and_digest_are_stable():
+    first = build_evidence_repair_recovery_human_approval_token(
+        recovery_execution=_manual_rollback_execution(),
+        approver="han",
+        approval_reason="manual recovery approval",
+    ).to_dict()
+    second = build_evidence_repair_recovery_human_approval_token(
+        recovery_execution=_manual_rollback_execution(),
+        approver="han",
+        approval_reason="manual recovery approval",
+    ).to_dict()
+
+    assert first["tokens"][0]["id"] == second["tokens"][0]["id"]
+    assert first["tokens"][0]["token_digest"] == second["tokens"][0]["token_digest"]
+
+
+def test_empty_recovery_token_report_is_read_only():
+    payload = empty_evidence_repair_recovery_human_approval_token().to_dict()
+
+    assert payload["status"] == RECOVERY_TOKEN_STATUS_NO_ACTION_NEEDED
+    assert payload["read_only"] is True
+    assert payload["read_only_memory"] is True
+    assert payload["would_mutate_memory"] is False
+    assert payload["tokens"] == []

--- a/tests/agent/test_memory_evidence_repair_recovery_write_lock_gate.py
+++ b/tests/agent/test_memory_evidence_repair_recovery_write_lock_gate.py
@@ -1,0 +1,175 @@
+from agent.memory_evidence_repair_recovery_approval_token_gate import (
+    build_evidence_repair_recovery_approval_token_gate,
+)
+from agent.memory_evidence_repair_recovery_human_approval_token import (
+    build_evidence_repair_recovery_human_approval_token,
+)
+from agent.memory_evidence_repair_recovery_write_lock_gate import (
+    CHECK_RECOVERY_ACTIVE_LOCKS,
+    CHECK_RECOVERY_TOKEN_GATE_INTEGRITY,
+    CHECK_RECOVERY_TOKEN_REUSE,
+    RECOVERY_LOCK_DRAFT_STATUS_READY,
+    RECOVERY_WRITE_LOCK_SCOPE,
+    RECOVERY_WRITE_LOCK_STATUS_BLOCKED,
+    RECOVERY_WRITE_LOCK_STATUS_NO_ACTION_NEEDED,
+    RECOVERY_WRITE_LOCK_STATUS_READY,
+    RECOVERY_WRITE_LOCK_TYPE,
+    build_evidence_repair_recovery_write_lock_gate,
+    empty_evidence_repair_recovery_write_lock_gate,
+)
+from tests.agent.test_memory_evidence_repair_recovery_human_approval_token import (
+    _manual_rollback_execution,
+    _preparedness_execution,
+)
+
+
+def _verified_recovery_token_gate():
+    token_report = build_evidence_repair_recovery_human_approval_token(
+        recovery_execution=_manual_rollback_execution(),
+        approver="han",
+        approval_reason="manual recovery approval",
+        expires_in_minutes=20,
+    ).to_dict()
+    token_report["generated_at"] = "2026-05-11T00:00:00+00:00"
+    token = token_report["tokens"][0]
+    return build_evidence_repair_recovery_approval_token_gate(
+        recovery_approval_token=token_report,
+        confirmation_text=token["required_confirmation_text"],
+        current_time="2026-05-11T00:10:00+00:00",
+    ).to_dict()
+
+
+def test_verified_recovery_token_gate_creates_recovery_write_lock_draft():
+    token_gate = _verified_recovery_token_gate()
+
+    payload = build_evidence_repair_recovery_write_lock_gate(
+        recovery_token_gate=token_gate,
+        lock_owner="han",
+        lock_ttl_minutes=15,
+        current_time="2026-05-11T00:10:00+00:00",
+    ).to_dict()
+
+    lock = payload["locks"][0]
+    assert payload["status"] == RECOVERY_WRITE_LOCK_STATUS_READY
+    assert payload["summary"]["recovery_executor_preview_allowed"] is True
+    assert payload["summary"]["recovery_write_lock_available"] is True
+    assert payload["read_only"] is True
+    assert payload["read_only_memory"] is True
+    assert payload["would_mutate_memory"] is False
+    assert lock["id"].startswith("recovery-write-lock-")
+    assert lock["lock_type"] == RECOVERY_WRITE_LOCK_TYPE
+    assert lock["status"] == RECOVERY_LOCK_DRAFT_STATUS_READY
+    assert lock["scope"] == RECOVERY_WRITE_LOCK_SCOPE
+    assert lock["owner"] == "han"
+    assert lock["token_id"] == token_gate["token_id"]
+    assert lock["operation_ids"] == ["dryrun-op-123"]
+    assert lock["future_mutation_step_ids"] == [
+        "recovery-execution-step-5-apply_manual_rollback_restore"
+    ]
+    assert lock["would_acquire_write_lock"] is True
+    assert lock["would_release_after_recovery"] is True
+    assert lock["expires_at"] == "2026-05-11T00:25:00+00:00"
+
+
+def test_active_recovery_lock_conflict_blocks_gate():
+    token_gate = _verified_recovery_token_gate()
+
+    payload = build_evidence_repair_recovery_write_lock_gate(
+        recovery_token_gate=token_gate,
+        active_locks=[
+            {
+                "id": "recovery-lock-active",
+                "status": "active",
+                "scope": RECOVERY_WRITE_LOCK_SCOPE,
+                "owner": "han",
+                "operation_ids": ["dryrun-op-123"],
+                "expires_at": "2026-05-11T00:20:00+00:00",
+            }
+        ],
+        current_time="2026-05-11T00:10:00+00:00",
+    ).to_dict()
+
+    failed_checks = {check["id"] for check in payload["checks"] if check["status"] == "fail"}
+    assert payload["status"] == RECOVERY_WRITE_LOCK_STATUS_BLOCKED
+    assert CHECK_RECOVERY_ACTIVE_LOCKS in failed_checks
+    assert payload["active_lock_conflicts"][0]["reason"] == "overlapping_operation_ids"
+    assert payload["locks"] == []
+
+
+def test_expired_recovery_lock_does_not_block_gate():
+    token_gate = _verified_recovery_token_gate()
+
+    payload = build_evidence_repair_recovery_write_lock_gate(
+        recovery_token_gate=token_gate,
+        active_locks=[
+            {
+                "id": "recovery-lock-expired",
+                "status": "active",
+                "scope": RECOVERY_WRITE_LOCK_SCOPE,
+                "operation_ids": ["dryrun-op-123"],
+                "expires_at": "2026-05-11T00:09:00+00:00",
+            }
+        ],
+        current_time="2026-05-11T00:10:00+00:00",
+    ).to_dict()
+
+    assert payload["status"] == RECOVERY_WRITE_LOCK_STATUS_READY
+    assert payload["active_lock_conflicts"] == []
+    assert len(payload["locks"]) == 1
+
+
+def test_used_recovery_token_blocks_write_lock_gate():
+    token_gate = _verified_recovery_token_gate()
+
+    payload = build_evidence_repair_recovery_write_lock_gate(
+        recovery_token_gate=token_gate,
+        already_used_token_ids=[token_gate["token_id"]],
+        current_time="2026-05-11T00:10:00+00:00",
+    ).to_dict()
+
+    failed_checks = {check["id"] for check in payload["checks"] if check["status"] == "fail"}
+    assert payload["status"] == RECOVERY_WRITE_LOCK_STATUS_BLOCKED
+    assert CHECK_RECOVERY_TOKEN_REUSE in failed_checks
+    assert "regenerate_recovery_human_approval_token" in payload["required_actions"]
+
+
+def test_tampered_recovery_token_gate_integrity_blocks_gate():
+    token_gate = _verified_recovery_token_gate()
+    token_gate["verified_future_mutation_step_ids"] = []
+
+    payload = build_evidence_repair_recovery_write_lock_gate(
+        recovery_token_gate=token_gate,
+        current_time="2026-05-11T00:10:00+00:00",
+    ).to_dict()
+
+    failed_checks = {check["id"] for check in payload["checks"] if check["status"] == "fail"}
+    assert payload["status"] == RECOVERY_WRITE_LOCK_STATUS_BLOCKED
+    assert CHECK_RECOVERY_TOKEN_GATE_INTEGRITY in failed_checks
+    assert "regenerate_recovery_approval_token_gate" in payload["required_actions"]
+
+
+def test_no_action_recovery_token_gate_does_not_create_lock():
+    token_report = build_evidence_repair_recovery_human_approval_token(
+        recovery_execution=_preparedness_execution()
+    ).to_dict()
+    token_gate = build_evidence_repair_recovery_approval_token_gate(
+        recovery_approval_token=token_report
+    ).to_dict()
+
+    payload = build_evidence_repair_recovery_write_lock_gate(
+        recovery_token_gate=token_gate
+    ).to_dict()
+
+    assert payload["status"] == RECOVERY_WRITE_LOCK_STATUS_NO_ACTION_NEEDED
+    assert payload["locks"] == []
+    assert payload["checks"] == []
+
+
+def test_empty_recovery_write_lock_gate_is_read_only():
+    payload = empty_evidence_repair_recovery_write_lock_gate().to_dict()
+
+    assert payload["status"] == RECOVERY_WRITE_LOCK_STATUS_NO_ACTION_NEEDED
+    assert payload["read_only"] is True
+    assert payload["read_only_memory"] is True
+    assert payload["would_mutate_memory"] is False
+    assert payload["locks"] == []

--- a/tests/agent/test_memory_evidence_repair_rollback_drill_preview.py
+++ b/tests/agent/test_memory_evidence_repair_rollback_drill_preview.py
@@ -1,0 +1,130 @@
+from agent.memory_evidence_repair_post_commit_audit_preview import (
+    build_evidence_repair_post_commit_audit_preview,
+)
+from agent.memory_evidence_repair_rollback_drill_preview import (
+    ROLLBACK_DRILL_STATUS_BLOCKED,
+    ROLLBACK_DRILL_STATUS_NO_ACTION_NEEDED,
+    ROLLBACK_DRILL_STATUS_READY,
+    ROLLBACK_DRILL_TRIGGER_AUDIT_FAILURE,
+    ROLLBACK_DRILL_TRIGGER_PREPAREDNESS,
+    build_evidence_repair_rollback_drill_preview,
+    empty_evidence_repair_rollback_drill_preview,
+)
+from tests.agent.test_memory_evidence_repair_post_commit_audit_preview import (
+    _executor_preview,
+)
+
+
+def _planned_post_commit_audit():
+    return build_evidence_repair_post_commit_audit_preview(
+        executor_preview=_executor_preview()
+    ).to_dict()
+
+
+def _failed_post_commit_audit():
+    executor = _executor_preview()
+    preview = executor["previews"][0]
+    return build_evidence_repair_post_commit_audit_preview(
+        executor_preview=executor,
+        observed_memory_patches={
+            "dryrun-op-123": {"applied": True, "patch_digest": "a" * 64}
+        },
+        recorded_receipts=[{"id": preview["receipt_id"]}],
+        used_token_ids=[],
+        released_lock_ids=[preview["lock_id"]],
+        rollback_status={"status": "snapshot_available"},
+    ).to_dict()
+
+
+def test_planned_post_commit_audit_creates_preparedness_drill():
+    payload = build_evidence_repair_rollback_drill_preview(
+        post_commit_audit=_planned_post_commit_audit()
+    ).to_dict()
+
+    drill = payload["previews"][0]
+    actions = {step["action"] for step in drill["steps"]}
+    assert payload["status"] == ROLLBACK_DRILL_STATUS_READY
+    assert payload["summary"]["rollback_drill_ready"] is True
+    assert payload["summary"]["failed_audit_step_count"] == 0
+    assert payload["summary"]["future_restore_step_count"] == 0
+    assert payload["read_only"] is True
+    assert payload["read_only_memory"] is True
+    assert payload["would_mutate_memory"] is False
+    assert drill["trigger"] == ROLLBACK_DRILL_TRIGGER_PREPAREDNESS
+    assert drill["rollback_mode"] == "preparedness_rehearsal"
+    assert drill["id"].startswith("rollback-drill-")
+    assert "verify_pre_commit_snapshot_or_rollback_plan" in actions
+    assert "rerun_post_commit_audit" in actions
+
+
+def test_failed_post_commit_audit_creates_failure_response_drill():
+    payload = build_evidence_repair_rollback_drill_preview(
+        post_commit_audit=_failed_post_commit_audit()
+    ).to_dict()
+
+    drill = payload["previews"][0]
+    actions = [step["action"] for step in drill["steps"]]
+    assert payload["status"] == ROLLBACK_DRILL_STATUS_READY
+    assert payload["summary"]["failed_audit_step_count"] >= 1
+    assert payload["summary"]["future_restore_step_count"] == 1
+    assert drill["trigger"] == ROLLBACK_DRILL_TRIGGER_AUDIT_FAILURE
+    assert drill["rollback_mode"] == "failure_response"
+    assert drill["operation_ids"] == ["dryrun-op-123"]
+    assert "isolate_impacted_memory_records" in actions
+    assert "restore_from_pre_commit_snapshot_or_rollback_plan" in actions
+
+
+def test_rollback_plan_can_be_used_as_drill_source():
+    payload = build_evidence_repair_rollback_drill_preview(
+        post_commit_audit=_failed_post_commit_audit(),
+        rollback_plan={
+            "steps": [
+                {
+                    "operation_id": "dryrun-op-123",
+                    "patch_digest": "a" * 64,
+                }
+            ]
+        },
+    ).to_dict()
+
+    restore_steps = [
+        step
+        for step in payload["previews"][0]["steps"]
+        if step["action"] == "restore_from_pre_commit_snapshot_or_rollback_plan"
+    ]
+    assert restore_steps
+    assert restore_steps[0]["rollback_source"] == "provided_rollback_plan"
+
+
+def test_blocked_audit_without_failure_context_blocks_drill():
+    payload = build_evidence_repair_rollback_drill_preview(
+        post_commit_audit={
+            "status": "blocked",
+            "blocking_reasons": ["executor preview is invalid"],
+            "required_actions": ["regenerate_executor_preview"],
+        }
+    ).to_dict()
+
+    assert payload["status"] == ROLLBACK_DRILL_STATUS_BLOCKED
+    assert payload["previews"] == []
+    assert "regenerate_executor_preview" in payload["required_actions"]
+
+
+def test_no_action_post_commit_audit_does_not_create_drill():
+    payload = build_evidence_repair_rollback_drill_preview(
+        post_commit_audit={"status": "no_action_needed"}
+    ).to_dict()
+
+    assert payload["status"] == ROLLBACK_DRILL_STATUS_NO_ACTION_NEEDED
+    assert payload["previews"] == []
+    assert payload["summary"]["rollback_drill_preview_available"] is False
+
+
+def test_empty_rollback_drill_preview_is_read_only():
+    payload = empty_evidence_repair_rollback_drill_preview().to_dict()
+
+    assert payload["status"] == ROLLBACK_DRILL_STATUS_NO_ACTION_NEEDED
+    assert payload["read_only"] is True
+    assert payload["read_only_memory"] is True
+    assert payload["would_mutate_memory"] is False
+    assert payload["previews"] == []

--- a/tests/agent/test_memory_evidence_repair_rollback_plan.py
+++ b/tests/agent/test_memory_evidence_repair_rollback_plan.py
@@ -1,0 +1,103 @@
+from agent.memory_evidence_repair_rollback_plan import (
+    ROLLBACK_ACTION_NOOP,
+    ROLLBACK_ACTION_RESTORE_EVIDENCE_METADATA,
+    ROLLBACK_STATUS_NO_ACTION_NEEDED,
+    ROLLBACK_STATUS_READY_FOR_MANUAL_ROLLBACK,
+    ROLLBACK_STATUS_SNAPSHOT_REQUIRED,
+    SNAPSHOT_REQUIRED_VALUE,
+    build_evidence_repair_rollback_plan,
+    empty_evidence_repair_rollback_plan,
+)
+
+
+def _allowed_entry():
+    return {
+        "id": "ledger-123",
+        "sequence": 1,
+        "outcome": "allowed_for_manual_commit",
+        "decision_id": "gate-preview-123",
+        "preview_id": "preview-123",
+        "candidate_id": "repair-123",
+        "provider": "builtin",
+        "priority": "high",
+        "repair_action": "attach_provenance",
+        "evidence_fields": ["source_url", "observed_at", "verification_signal"],
+        "patch_digest": "a" * 64,
+        "manual_commit_allowed": True,
+        "blocked": False,
+        "target": {"candidate_id": "repair-123", "provider": "builtin"},
+    }
+
+
+def test_ready_rollback_plan_from_allowed_entry_with_snapshot():
+    plan = build_evidence_repair_rollback_plan(
+        entries=[_allowed_entry()],
+        pre_commit_snapshots={
+            "ledger-123": {
+                "evidence": {
+                    "source_url": "https://old.example.com/source",
+                    "observed_at": "2026-05-01T00:00:00Z",
+                    "verification_signal": "previous_manual_verified",
+                }
+            }
+        },
+    )
+
+    payload = plan.to_dict()
+    step = payload["steps"][0]
+    assert payload["read_only"] is True
+    assert payload["read_only_memory"] is True
+    assert payload["would_mutate_memory"] is False
+    assert payload["summary"]["ready_count"] == 1
+    assert step["id"].startswith("rollback-")
+    assert step["status"] == ROLLBACK_STATUS_READY_FOR_MANUAL_ROLLBACK
+    assert step["rollback_action"] == ROLLBACK_ACTION_RESTORE_EVIDENCE_METADATA
+    assert step["inverse_patch_preview"]["set"]["evidence"] == {
+        "source_url": "https://old.example.com/source",
+        "observed_at": "2026-05-01T00:00:00Z",
+        "verification_signal": "previous_manual_verified",
+    }
+    assert "manual_rollback_only" in step["required_preconditions"]
+
+
+def test_allowed_entry_requires_snapshot_before_rollback_ready():
+    plan = build_evidence_repair_rollback_plan(entries=[_allowed_entry()])
+
+    payload = plan.to_dict()
+    step = payload["steps"][0]
+    assert step["status"] == ROLLBACK_STATUS_SNAPSHOT_REQUIRED
+    assert step["inverse_patch_preview"]["set"]["evidence"] == SNAPSHOT_REQUIRED_VALUE
+    assert "capture_pre_commit_snapshot_before_apply" in step["required_preconditions"]
+    assert payload["summary"]["snapshot_required_count"] == 1
+    assert payload["summary"]["requires_snapshot"] is True
+
+
+def test_blocked_entry_has_no_rollback_action():
+    entry = _allowed_entry()
+    entry["outcome"] = "blocked"
+    entry["manual_commit_allowed"] = False
+    entry["blocked"] = True
+
+    payload = build_evidence_repair_rollback_plan(entries=[entry]).to_dict()
+    step = payload["steps"][0]
+    assert step["status"] == ROLLBACK_STATUS_NO_ACTION_NEEDED
+    assert step["rollback_action"] == ROLLBACK_ACTION_NOOP
+    assert step["inverse_patch_preview"]["operation"] == ROLLBACK_ACTION_NOOP
+    assert payload["summary"]["no_action_count"] == 1
+
+
+def test_rollback_step_id_is_stable():
+    first = build_evidence_repair_rollback_plan(entries=[_allowed_entry()]).to_dict()
+    second = build_evidence_repair_rollback_plan(entries=[_allowed_entry()]).to_dict()
+
+    assert first["steps"][0]["id"] == second["steps"][0]["id"]
+
+
+def test_empty_rollback_plan_is_read_only():
+    payload = empty_evidence_repair_rollback_plan().to_dict()
+
+    assert payload["read_only"] is True
+    assert payload["read_only_memory"] is True
+    assert payload["would_mutate_memory"] is False
+    assert payload["summary"]["rollback_step_count"] == 0
+    assert payload["steps"] == []

--- a/tests/agent/test_memory_evidence_repair_snapshot_planner.py
+++ b/tests/agent/test_memory_evidence_repair_snapshot_planner.py
@@ -1,0 +1,118 @@
+from agent.memory_evidence_repair_snapshot_planner import (
+    SNAPSHOT_ACTION_CAPTURE_EVIDENCE_METADATA,
+    SNAPSHOT_ACTION_NOOP,
+    SNAPSHOT_ACTION_VERIFY_EXISTING_SNAPSHOT,
+    SNAPSHOT_STATUS_ALREADY_AVAILABLE,
+    SNAPSHOT_STATUS_CAPTURE_REQUIRED,
+    SNAPSHOT_STATUS_NO_ACTION_NEEDED,
+    build_evidence_repair_snapshot_plan,
+    empty_evidence_repair_snapshot_plan,
+)
+
+
+def _snapshot_required_step():
+    return {
+        "id": "rollback-123",
+        "ledger_entry_id": "ledger-123",
+        "sequence": 1,
+        "status": "snapshot_required",
+        "rollback_action": "restore_evidence_metadata",
+        "provider": "builtin",
+        "repair_action": "attach_provenance",
+        "candidate_id": "repair-123",
+        "preview_id": "preview-123",
+        "patch_digest": "a" * 64,
+        "target": {"candidate_id": "repair-123", "provider": "builtin"},
+        "evidence_fields": ["source_url", "observed_at", "verification_signal"],
+    }
+
+
+def test_snapshot_plan_requires_capture_for_snapshot_required_step():
+    plan = build_evidence_repair_snapshot_plan(steps=[_snapshot_required_step()])
+
+    payload = plan.to_dict()
+    request = payload["requests"][0]
+    assert payload["read_only"] is True
+    assert payload["read_only_memory"] is True
+    assert payload["would_mutate_memory"] is False
+    assert payload["summary"]["capture_required_count"] == 1
+    assert payload["summary"]["blocks_manual_commit"] is True
+    assert request["id"].startswith("snapshot-")
+    assert request["status"] == SNAPSHOT_STATUS_CAPTURE_REQUIRED
+    assert request["snapshot_action"] == SNAPSHOT_ACTION_CAPTURE_EVIDENCE_METADATA
+    assert request["blocks_manual_commit"] is True
+    assert request["evidence_fields"] == [
+        "source_url",
+        "observed_at",
+        "verification_signal",
+    ]
+    assert request["snapshot_payload_preview"]["capture"]["snapshot_key"] == "ledger-123"
+
+
+def test_snapshot_plan_detects_existing_snapshot_from_ready_rollback_step():
+    step = _snapshot_required_step()
+    step["status"] = "ready_for_manual_rollback"
+
+    payload = build_evidence_repair_snapshot_plan(steps=[step]).to_dict()
+    request = payload["requests"][0]
+    assert request["status"] == SNAPSHOT_STATUS_ALREADY_AVAILABLE
+    assert request["snapshot_action"] == SNAPSHOT_ACTION_VERIFY_EXISTING_SNAPSHOT
+    assert request["blocks_manual_commit"] is False
+    assert payload["summary"]["already_available_count"] == 1
+
+
+def test_snapshot_plan_noops_for_non_committed_entry():
+    step = _snapshot_required_step()
+    step["status"] = "no_action_needed"
+    step["rollback_action"] = "no_rollback_required"
+
+    payload = build_evidence_repair_snapshot_plan(steps=[step]).to_dict()
+    request = payload["requests"][0]
+    assert request["status"] == SNAPSHOT_STATUS_NO_ACTION_NEEDED
+    assert request["snapshot_action"] == SNAPSHOT_ACTION_NOOP
+    assert request["blocks_manual_commit"] is False
+    assert payload["summary"]["no_action_count"] == 1
+
+
+def test_snapshot_plan_can_build_from_ledger_and_existing_snapshot():
+    entry = {
+        "id": "ledger-123",
+        "outcome": "allowed_for_manual_commit",
+        "manual_commit_allowed": True,
+        "provider": "builtin",
+        "repair_action": "attach_provenance",
+        "candidate_id": "repair-123",
+        "preview_id": "preview-123",
+        "patch_digest": "a" * 64,
+        "target": {"candidate_id": "repair-123", "provider": "builtin"},
+        "evidence_fields": ["source_url"],
+    }
+
+    payload = build_evidence_repair_snapshot_plan(
+        entries=[entry],
+        existing_snapshots={"ledger-123": {"evidence": {"source_url": "old"}}},
+    ).to_dict()
+
+    assert payload["requests"][0]["status"] == SNAPSHOT_STATUS_ALREADY_AVAILABLE
+    assert payload["summary"]["already_available_count"] == 1
+
+
+def test_snapshot_request_id_is_stable():
+    first = build_evidence_repair_snapshot_plan(
+        steps=[_snapshot_required_step()]
+    ).to_dict()
+    second = build_evidence_repair_snapshot_plan(
+        steps=[_snapshot_required_step()]
+    ).to_dict()
+
+    assert first["requests"][0]["id"] == second["requests"][0]["id"]
+
+
+def test_empty_snapshot_plan_is_read_only():
+    payload = empty_evidence_repair_snapshot_plan().to_dict()
+
+    assert payload["read_only"] is True
+    assert payload["read_only_memory"] is True
+    assert payload["would_mutate_memory"] is False
+    assert payload["summary"]["snapshot_request_count"] == 0
+    assert payload["requests"] == []

--- a/tests/agent/test_memory_evidence_repair_write_lock_gate.py
+++ b/tests/agent/test_memory_evidence_repair_write_lock_gate.py
@@ -1,0 +1,190 @@
+from agent.memory_evidence_repair_approval_token_gate import (
+    build_evidence_repair_approval_token_gate,
+)
+from agent.memory_evidence_repair_commit_receipt import (
+    build_evidence_repair_commit_receipt,
+)
+from agent.memory_evidence_repair_human_approval_token import (
+    build_evidence_repair_human_approval_token,
+)
+from agent.memory_evidence_repair_write_lock_gate import (
+    CHECK_ACTIVE_LOCKS,
+    CHECK_RECEIPT_INTEGRITY,
+    CHECK_TOKEN_REUSE,
+    WRITE_LOCK_STATUS_BLOCKED,
+    WRITE_LOCK_STATUS_NO_ACTION_NEEDED,
+    WRITE_LOCK_STATUS_READY,
+    WRITE_LOCK_TYPE,
+    build_evidence_repair_write_lock_gate,
+    empty_evidence_repair_write_lock_gate,
+)
+
+
+def _ready_dry_run():
+    return {
+        "status": "ready_for_manual_commit",
+        "summary": {
+            "manual_commit_allowed": True,
+            "operation_count": 1,
+            "has_blocks": False,
+        },
+        "checks": [{"id": "commit_gate", "status": "pass"}],
+        "operations": [
+            {
+                "id": "dryrun-op-123",
+                "ledger_entry_id": "ledger-123",
+                "candidate_id": "repair-123",
+                "preview_id": "preview-123",
+                "provider": "builtin",
+                "repair_action": "attach_provenance",
+                "patch_digest": "a" * 64,
+                "target": {"candidate_id": "repair-123"},
+                "evidence_fields": ["source_url"],
+            }
+        ],
+        "blocking_reasons": [],
+        "required_actions": [],
+    }
+
+
+def _verified_gate():
+    token_report = build_evidence_repair_human_approval_token(
+        dry_run=_ready_dry_run(),
+        approver="han",
+        approval_reason="final manual approval",
+        expires_in_minutes=30,
+    ).to_dict()
+    token_report["generated_at"] = "2026-05-11T00:00:00+00:00"
+    return build_evidence_repair_approval_token_gate(
+        approval_token=token_report,
+        confirmation_text=token_report["tokens"][0]["required_confirmation_text"],
+        current_time="2026-05-11T00:10:00+00:00",
+    ).to_dict()
+
+
+def _commit_receipt():
+    return build_evidence_repair_commit_receipt(
+        token_gate=_verified_gate(),
+        actor="han",
+        commit_reason="manual memory evidence repair",
+    ).to_dict()
+
+
+def test_ready_receipt_creates_write_lock_draft():
+    payload = build_evidence_repair_write_lock_gate(
+        commit_receipt=_commit_receipt(),
+        lock_owner="han",
+        lock_ttl_minutes=15,
+        current_time="2026-05-11T00:20:00+00:00",
+    ).to_dict()
+
+    lock = payload["locks"][0]
+    assert payload["status"] == WRITE_LOCK_STATUS_READY
+    assert payload["summary"]["executor_dry_run_allowed"] is True
+    assert payload["summary"]["fail_count"] == 0
+    assert payload["read_only"] is True
+    assert payload["read_only_memory"] is True
+    assert payload["would_mutate_memory"] is False
+    assert lock["id"].startswith("write-lock-")
+    assert lock["lock_type"] == WRITE_LOCK_TYPE
+    assert lock["owner"] == "han"
+    assert lock["operation_ids"] == ["dryrun-op-123"]
+    assert lock["would_acquire_write_lock"] is True
+    assert lock["would_release_after_commit"] is True
+    assert lock["expires_at"] == "2026-05-11T00:35:00+00:00"
+
+
+def test_active_lock_conflict_blocks_write_lock():
+    receipt = _commit_receipt()
+
+    payload = build_evidence_repair_write_lock_gate(
+        commit_receipt=receipt,
+        active_locks=[
+            {
+                "id": "write-lock-existing",
+                "status": "active",
+                "scope": "manual_memory_evidence_repair_commit",
+                "owner": "other",
+                "operation_ids": ["dryrun-op-123"],
+                "expires_at": "2026-05-11T00:40:00+00:00",
+            }
+        ],
+        current_time="2026-05-11T00:20:00+00:00",
+    ).to_dict()
+
+    failed_checks = {check["id"] for check in payload["checks"] if check["status"] == "fail"}
+    assert payload["status"] == WRITE_LOCK_STATUS_BLOCKED
+    assert CHECK_ACTIVE_LOCKS in failed_checks
+    assert payload["summary"]["active_lock_conflict_count"] == 1
+    assert payload["active_lock_conflicts"][0]["reason"] == "overlapping_operation_ids"
+
+
+def test_expired_active_lock_does_not_block_write_lock():
+    payload = build_evidence_repair_write_lock_gate(
+        commit_receipt=_commit_receipt(),
+        active_locks=[
+            {
+                "id": "write-lock-expired",
+                "status": "active",
+                "scope": "manual_memory_evidence_repair_commit",
+                "operation_ids": ["dryrun-op-123"],
+                "expires_at": "2026-05-11T00:10:00+00:00",
+            }
+        ],
+        current_time="2026-05-11T00:20:00+00:00",
+    ).to_dict()
+
+    assert payload["status"] == WRITE_LOCK_STATUS_READY
+    assert payload["summary"]["active_lock_conflict_count"] == 0
+    assert payload["locks"]
+
+
+def test_already_used_token_blocks_write_lock():
+    receipt = _commit_receipt()
+    token_id = receipt["receipts"][0]["token_id"]
+
+    payload = build_evidence_repair_write_lock_gate(
+        commit_receipt=receipt,
+        already_used_token_ids=[token_id],
+        current_time="2026-05-11T00:20:00+00:00",
+    ).to_dict()
+
+    failed_checks = {check["id"] for check in payload["checks"] if check["status"] == "fail"}
+    assert payload["status"] == WRITE_LOCK_STATUS_BLOCKED
+    assert CHECK_TOKEN_REUSE in failed_checks
+    assert "regenerate_human_approval_token" in payload["required_actions"]
+
+
+def test_tampered_receipt_digest_blocks_write_lock():
+    receipt = _commit_receipt()
+    receipt["receipts"][0]["receipt_digest"] = "bad"
+
+    payload = build_evidence_repair_write_lock_gate(
+        commit_receipt=receipt,
+        current_time="2026-05-11T00:20:00+00:00",
+    ).to_dict()
+
+    failed_checks = {check["id"] for check in payload["checks"] if check["status"] == "fail"}
+    assert payload["status"] == WRITE_LOCK_STATUS_BLOCKED
+    assert CHECK_RECEIPT_INTEGRITY in failed_checks
+    assert "regenerate_commit_receipt" in payload["required_actions"]
+
+
+def test_no_action_receipt_does_not_create_write_lock():
+    payload = build_evidence_repair_write_lock_gate(
+        commit_receipt={"status": "no_action_needed"}
+    ).to_dict()
+
+    assert payload["status"] == WRITE_LOCK_STATUS_NO_ACTION_NEEDED
+    assert payload["locks"] == []
+    assert payload["summary"]["write_lock_available"] is False
+
+
+def test_empty_write_lock_gate_is_read_only():
+    payload = empty_evidence_repair_write_lock_gate().to_dict()
+
+    assert payload["status"] == WRITE_LOCK_STATUS_NO_ACTION_NEEDED
+    assert payload["read_only"] is True
+    assert payload["read_only_memory"] is True
+    assert payload["would_mutate_memory"] is False
+    assert payload["locks"] == []

--- a/tests/tools/test_memory_evidence_repair_apply_preview_tool.py
+++ b/tests/tools/test_memory_evidence_repair_apply_preview_tool.py
@@ -1,0 +1,142 @@
+import json
+
+from tools.memory_evidence_repair_apply_preview_tool import (
+    memory_evidence_repair_apply_preview_tool,
+)
+from tools.registry import registry
+
+
+class FakeMemoryManager:
+    def last_memory_policy_gate(self):
+        return {
+            "summary": {"input_count": 1, "output_count": 0},
+            "provider_results": [
+                {
+                    "provider": "builtin",
+                    "action": "require_provenance_before_reuse",
+                    "effect": "filtered",
+                    "reason": "Recall candidate lacks explicit provenance required by policy.",
+                }
+            ],
+            "read_only": True,
+        }
+
+    def last_recall_audit(self):
+        return {"entries": [], "read_only": True}
+
+    def last_recall_diagnostics(self):
+        return {"issues": [], "read_only": True}
+
+    def last_memory_auto_policy(self):
+        return {"decisions": [], "read_only": True}
+
+
+def test_tool_uses_latest_manager_state_read_only_markdown():
+    result = json.loads(
+        memory_evidence_repair_apply_preview_tool(
+            {"format": "markdown"},
+            memory_manager=FakeMemoryManager(),
+        )
+    )
+
+    assert result["success"] is True
+    assert result["read_only"] is True
+    assert result["read_only_memory"] is True
+    assert result["would_mutate_memory"] is False
+    assert result["summary"]["preview_count"] == 1
+    assert result["summary"]["missing_evidence_count"] == 1
+    assert "Memory Evidence Repair Apply Preview" in result["markdown"]
+
+
+def test_tool_accepts_explicit_candidates_and_approved_ids():
+    result = json.loads(
+        memory_evidence_repair_apply_preview_tool(
+            {
+                "candidates": [
+                    {
+                        "id": "repair-123",
+                        "provider": "builtin",
+                        "priority": "high",
+                        "repair_action": "attach_provenance",
+                        "required_evidence": [
+                            "source_url",
+                            "observed_at",
+                            "verification_signal",
+                        ],
+                        "proposed_evidence_patch": {
+                            "source_url": "<pending>",
+                            "observed_at": "<pending>",
+                            "verification_signal": "<pending>",
+                        },
+                    }
+                ],
+                "approved_candidate_ids": ["repair-123"],
+                "proposed_evidence": {
+                    "source_url": "https://example.com/source",
+                    "observed_at": "2026-05-11T00:00:00Z",
+                    "verification_signal": "manual_verified",
+                },
+            }
+        )
+    )
+
+    assert result["summary"]["ready_count"] == 1
+    assert result["previews"][0]["status"] == "ready_for_manual_apply"
+    assert result["previews"][0]["evidence_patch"] == {
+        "source_url": "https://example.com/source",
+        "observed_at": "2026-05-11T00:00:00Z",
+        "verification_signal": "manual_verified",
+    }
+
+
+def test_tool_accepts_repairs_and_limits_previews():
+    result = json.loads(
+        memory_evidence_repair_apply_preview_tool(
+            {
+                "limit": 1,
+                "repairs": [
+                    {
+                        "provider": "builtin",
+                        "priority": "high",
+                        "action": "attach_provenance",
+                        "source": "policy_gate",
+                        "reason": "Missing provenance.",
+                    },
+                    {
+                        "provider": "graph",
+                        "priority": "medium",
+                        "action": "refresh_observation",
+                        "source": "diagnostics",
+                        "reason": "Stale recall.",
+                    },
+                ],
+            }
+        )
+    )
+
+    assert result["limited_to"] == 1
+    assert result["summary"]["preview_count"] == 1
+    assert len(result["previews"]) == 1
+
+
+def test_tool_rejects_invalid_input_shape():
+    result = json.loads(memory_evidence_repair_apply_preview_tool({"approval": "bad"}))
+
+    assert result["success"] is False
+    assert "approval must be an object" in result["error"]
+
+
+def test_tool_without_manager_returns_empty_preview():
+    result = json.loads(memory_evidence_repair_apply_preview_tool({}))
+
+    assert result["success"] is True
+    assert result["read_only"] is True
+    assert result["summary"]["preview_count"] == 0
+    assert result["previews"] == []
+
+
+def test_tool_is_registered_under_memory_toolset():
+    entry = registry.get_entry("memory_evidence_repair_apply_preview")
+
+    assert entry is not None
+    assert entry.toolset == "memory"

--- a/tests/tools/test_memory_evidence_repair_approval_candidates_tool.py
+++ b/tests/tools/test_memory_evidence_repair_approval_candidates_tool.py
@@ -1,0 +1,134 @@
+import json
+
+from tools.memory_evidence_repair_approval_candidates_tool import (
+    memory_evidence_repair_approval_candidates_tool,
+)
+from tools.registry import registry
+
+
+class FakeMemoryManager:
+    def last_memory_policy_gate(self):
+        return {
+            "summary": {"input_count": 1, "output_count": 0},
+            "provider_results": [
+                {
+                    "provider": "builtin",
+                    "action": "require_provenance_before_reuse",
+                    "effect": "filtered",
+                    "reason": "Recall candidate lacks explicit provenance required by policy.",
+                }
+            ],
+            "read_only": True,
+        }
+
+    def last_recall_audit(self):
+        return {"entries": [], "read_only": True}
+
+    def last_recall_diagnostics(self):
+        return {"issues": [], "read_only": True}
+
+    def last_memory_auto_policy(self):
+        return {"decisions": [], "read_only": True}
+
+
+def test_tool_uses_latest_manager_state_read_only_markdown():
+    result = json.loads(
+        memory_evidence_repair_approval_candidates_tool(
+            {"format": "markdown"},
+            memory_manager=FakeMemoryManager(),
+        )
+    )
+
+    assert result["success"] is True
+    assert result["read_only"] is True
+    assert result["read_only_memory"] is True
+    assert result["summary"]["candidate_count"] == 1
+    assert result["summary"]["requires_user_confirmation"] is True
+    assert "Memory Evidence Repair Approval Candidates" in result["markdown"]
+
+
+def test_tool_accepts_explicit_repairs_and_limits_candidates():
+    result = json.loads(
+        memory_evidence_repair_approval_candidates_tool(
+            {
+                "limit": 1,
+                "repairs": [
+                    {
+                        "provider": "builtin",
+                        "priority": "high",
+                        "action": "attach_provenance",
+                        "source": "policy_gate",
+                        "reason": "Missing provenance.",
+                    },
+                    {
+                        "provider": "graph",
+                        "priority": "medium",
+                        "action": "refresh_observation",
+                        "source": "diagnostics",
+                        "reason": "Stale recall.",
+                    },
+                ],
+            }
+        )
+    )
+
+    assert result["limited_to"] == 1
+    assert result["summary"]["candidate_count"] == 1
+    assert len(result["candidates"]) == 1
+    assert result["candidates"][0]["priority"] == "high"
+
+
+def test_tool_accepts_explicit_plan_and_proposed_evidence():
+    result = json.loads(
+        memory_evidence_repair_approval_candidates_tool(
+            {
+                "plan": {
+                    "repairs": [
+                        {
+                            "provider": "graph",
+                            "priority": "medium",
+                            "action": "refresh_observation",
+                            "source": "diagnostics",
+                            "reason": "Recall may be stale.",
+                            "required_evidence": ["observed_at", "freshness_check"],
+                        }
+                    ]
+                },
+                "proposed_evidence": {
+                    "observed_at": "2026-05-11T00:00:00Z",
+                    "freshness_check": "confirmed_current",
+                },
+            }
+        )
+    )
+
+    assert result["summary"]["candidate_count"] == 1
+    assert result["candidates"][0]["proposed_evidence_patch"] == {
+        "observed_at": "2026-05-11T00:00:00Z",
+        "freshness_check": "confirmed_current",
+    }
+
+
+def test_tool_rejects_invalid_input_shape():
+    result = json.loads(
+        memory_evidence_repair_approval_candidates_tool({"plan": "bad"})
+    )
+
+    assert result["success"] is False
+    assert "plan must be an object" in result["error"]
+
+
+def test_tool_without_manager_returns_empty_candidates():
+    result = json.loads(memory_evidence_repair_approval_candidates_tool({}))
+
+    assert result["success"] is True
+    assert result["read_only"] is True
+    assert result["summary"]["candidate_count"] == 0
+    assert result["candidates"] == []
+
+
+def test_tool_is_registered_under_memory_toolset():
+    entry = registry.get_entry("memory_evidence_repair_approval_candidates")
+
+    assert entry is not None
+    assert entry.toolset == "memory"

--- a/tests/tools/test_memory_evidence_repair_approval_token_gate_tool.py
+++ b/tests/tools/test_memory_evidence_repair_approval_token_gate_tool.py
@@ -1,0 +1,197 @@
+import json
+
+from tools.memory_evidence_repair_approval_token_gate_tool import (
+    memory_evidence_repair_approval_token_gate_tool,
+)
+from tools.memory_evidence_repair_human_approval_token_tool import (
+    memory_evidence_repair_human_approval_token_tool,
+)
+from tools.registry import registry
+
+
+class FakeMemoryManager:
+    def last_memory_policy_gate(self):
+        return {
+            "summary": {"input_count": 1, "output_count": 0},
+            "provider_results": [
+                {
+                    "provider": "builtin",
+                    "action": "require_provenance_before_reuse",
+                    "effect": "filtered",
+                    "reason": "Recall candidate lacks explicit provenance required by policy.",
+                }
+            ],
+            "read_only": True,
+        }
+
+    def last_recall_audit(self):
+        return {"entries": [], "read_only": True}
+
+    def last_recall_diagnostics(self):
+        return {"issues": [], "read_only": True}
+
+    def last_memory_auto_policy(self):
+        return {"decisions": [], "read_only": True}
+
+
+def _ready_dry_run():
+    return {
+        "status": "ready_for_manual_commit",
+        "summary": {"manual_commit_allowed": True, "operation_count": 1},
+        "checks": [{"id": "commit_gate", "status": "pass"}],
+        "operations": [
+            {
+                "id": "dryrun-op-123",
+                "ledger_entry_id": "ledger-123",
+                "candidate_id": "repair-123",
+                "preview_id": "preview-123",
+                "provider": "builtin",
+                "repair_action": "attach_provenance",
+                "patch_digest": "a" * 64,
+                "target": {"candidate_id": "repair-123"},
+                "evidence_fields": ["source_url"],
+            }
+        ],
+        "blocking_reasons": [],
+        "required_actions": [],
+    }
+
+
+def _token_report():
+    result = json.loads(
+        memory_evidence_repair_human_approval_token_tool(
+            {
+                "dry_run": _ready_dry_run(),
+                "approver": "han",
+                "approval_reason": "final manual approval",
+                "expires_in_minutes": 30,
+            }
+        )
+    )
+    result["generated_at"] = "2026-05-11T00:00:00+00:00"
+    return result
+
+
+def _candidate_args():
+    return {
+        "candidates": [
+            {
+                "id": "repair-123",
+                "provider": "builtin",
+                "priority": "high",
+                "repair_action": "attach_provenance",
+                "required_evidence": [
+                    "source_url",
+                    "observed_at",
+                    "verification_signal",
+                ],
+                "proposed_evidence_patch": {
+                    "source_url": "https://example.com/source",
+                    "observed_at": "2026-05-11T00:00:00Z",
+                    "verification_signal": "manual_verified",
+                },
+            }
+        ],
+        "approved_candidate_ids": ["repair-123"],
+        "user_confirmed": True,
+        "existing_snapshots": {
+            "source_url": "https://old.example.com/source",
+            "observed_at": "2026-05-01T00:00:00Z",
+            "verification_signal": "previous_manual_verified",
+        },
+        "approver": "han",
+    }
+
+
+def test_tool_accepts_explicit_token_report_markdown():
+    token_report = _token_report()
+    confirmation_text = token_report["tokens"][0]["required_confirmation_text"]
+
+    result = json.loads(
+        memory_evidence_repair_approval_token_gate_tool(
+            {
+                "approval_token": token_report,
+                "confirmation_text": confirmation_text,
+                "current_time": "2026-05-11T00:10:00+00:00",
+                "format": "markdown",
+            }
+        )
+    )
+
+    assert result["success"] is True
+    assert result["read_only"] is True
+    assert result["read_only_memory"] is True
+    assert result["would_mutate_memory"] is False
+    assert result["status"] == "verified_for_manual_commit"
+    assert result["summary"]["manual_commit_verified"] is True
+    assert result["summary"]["fail_count"] == 0
+    assert "Memory Evidence Repair Approval Token Gate" in result["markdown"]
+
+
+def test_tool_blocks_wrong_confirmation():
+    token_report = _token_report()
+
+    result = json.loads(
+        memory_evidence_repair_approval_token_gate_tool(
+            {
+                "approval_token": token_report,
+                "confirmation_text": "APPROVE not-this-token",
+                "current_time": "2026-05-11T00:10:00+00:00",
+            }
+        )
+    )
+
+    assert result["status"] == "blocked"
+    assert result["summary"]["manual_commit_verified"] is False
+    assert "provide_exact_confirmation_text" in result["required_actions"]
+
+
+def test_tool_generates_token_from_candidates_and_verifies():
+    token = json.loads(memory_evidence_repair_human_approval_token_tool(_candidate_args()))
+    confirmation_text = token["tokens"][0]["required_confirmation_text"]
+    args = _candidate_args()
+    args["confirmation_text"] = confirmation_text
+
+    result = json.loads(memory_evidence_repair_approval_token_gate_tool(args))
+
+    assert result["status"] == "verified_for_manual_commit"
+    assert result["summary"]["manual_commit_verified"] is True
+    assert result["verified_operation_ids"]
+
+
+def test_tool_uses_latest_manager_state_and_blocks_when_no_token_available():
+    result = json.loads(
+        memory_evidence_repair_approval_token_gate_tool(
+            {"format": "markdown"},
+            memory_manager=FakeMemoryManager(),
+        )
+    )
+
+    assert result["success"] is True
+    assert result["status"] == "blocked"
+    assert result["summary"]["manual_commit_verified"] is False
+    assert result["blocking_reasons"]
+
+
+def test_tool_rejects_invalid_input_shape():
+    result = json.loads(
+        memory_evidence_repair_approval_token_gate_tool({"approval_token": "bad"})
+    )
+
+    assert result["success"] is False
+    assert "approval_token must be an object" in result["error"]
+
+
+def test_tool_without_manager_returns_no_action():
+    result = json.loads(memory_evidence_repair_approval_token_gate_tool({}))
+
+    assert result["success"] is True
+    assert result["status"] == "no_action_needed"
+    assert result["summary"]["check_count"] == 0
+
+
+def test_tool_is_registered_under_memory_toolset():
+    entry = registry.get_entry("memory_evidence_repair_approval_token_gate")
+
+    assert entry is not None
+    assert entry.toolset == "memory"

--- a/tests/tools/test_memory_evidence_repair_commit_gate_tool.py
+++ b/tests/tools/test_memory_evidence_repair_commit_gate_tool.py
@@ -1,0 +1,158 @@
+import json
+
+from tools.memory_evidence_repair_commit_gate_tool import (
+    memory_evidence_repair_commit_gate_tool,
+)
+from tools.registry import registry
+
+
+class FakeMemoryManager:
+    def last_memory_policy_gate(self):
+        return {
+            "summary": {"input_count": 1, "output_count": 0},
+            "provider_results": [
+                {
+                    "provider": "builtin",
+                    "action": "require_provenance_before_reuse",
+                    "effect": "filtered",
+                    "reason": "Recall candidate lacks explicit provenance required by policy.",
+                }
+            ],
+            "read_only": True,
+        }
+
+    def last_recall_audit(self):
+        return {"entries": [], "read_only": True}
+
+    def last_recall_diagnostics(self):
+        return {"issues": [], "read_only": True}
+
+    def last_memory_auto_policy(self):
+        return {"decisions": [], "read_only": True}
+
+
+def _ready_preview():
+    return {
+        "id": "preview-123",
+        "candidate_id": "repair-123",
+        "status": "ready_for_manual_apply",
+        "provider": "builtin",
+        "priority": "high",
+        "repair_action": "attach_provenance",
+        "operation": "merge_evidence_metadata",
+        "target": {"candidate_id": "repair-123", "provider": "builtin"},
+        "evidence_patch": {
+            "source_url": "https://example.com/source",
+            "observed_at": "2026-05-11T00:00:00Z",
+            "verification_signal": "manual_verified",
+        },
+        "memory_patch_preview": {
+            "operation": "merge_evidence_metadata",
+            "target": {"candidate_id": "repair-123", "provider": "builtin"},
+            "set": {"evidence": {}},
+        },
+        "missing_evidence": [],
+    }
+
+
+def test_tool_uses_latest_manager_state_read_only_markdown():
+    result = json.loads(
+        memory_evidence_repair_commit_gate_tool(
+            {"format": "markdown"},
+            memory_manager=FakeMemoryManager(),
+        )
+    )
+
+    assert result["success"] is True
+    assert result["read_only"] is True
+    assert result["read_only_memory"] is True
+    assert result["would_mutate_memory"] is False
+    assert result["summary"]["decision_count"] == 1
+    assert result["summary"]["blocked_count"] == 1
+    assert "Memory Evidence Repair Commit Gate" in result["markdown"]
+
+
+def test_tool_accepts_explicit_preview_and_confirmation():
+    result = json.loads(
+        memory_evidence_repair_commit_gate_tool(
+            {
+                "preview": _ready_preview(),
+                "confirmed_preview_ids": ["preview-123"],
+            }
+        )
+    )
+
+    assert result["summary"]["allow_count"] == 1
+    assert result["decisions"][0]["decision"] == "allow_manual_commit"
+    assert result["decisions"][0]["reasons"] == []
+
+
+def test_tool_accepts_candidates_and_builds_gate():
+    result = json.loads(
+        memory_evidence_repair_commit_gate_tool(
+            {
+                "candidates": [
+                    {
+                        "id": "repair-123",
+                        "provider": "builtin",
+                        "priority": "high",
+                        "repair_action": "attach_provenance",
+                        "required_evidence": [
+                            "source_url",
+                            "observed_at",
+                            "verification_signal",
+                        ],
+                        "proposed_evidence_patch": {
+                            "source_url": "https://example.com/source",
+                            "observed_at": "2026-05-11T00:00:00Z",
+                            "verification_signal": "manual_verified",
+                        },
+                    }
+                ],
+                "approved_candidate_ids": ["repair-123"],
+                "user_confirmed": True,
+            }
+        )
+    )
+
+    assert result["summary"]["allow_count"] == 1
+    assert result["decisions"][0]["decision"] == "allow_manual_commit"
+
+
+def test_tool_accepts_previews_and_limits_decisions():
+    result = json.loads(
+        memory_evidence_repair_commit_gate_tool(
+            {
+                "limit": 1,
+                "previews": [_ready_preview(), _ready_preview()],
+                "confirmed_preview_ids": ["preview-123"],
+            }
+        )
+    )
+
+    assert result["limited_to"] == 1
+    assert result["summary"]["decision_count"] == 1
+    assert len(result["decisions"]) == 1
+
+
+def test_tool_rejects_invalid_input_shape():
+    result = json.loads(memory_evidence_repair_commit_gate_tool({"preview": "bad"}))
+
+    assert result["success"] is False
+    assert "preview must be an object" in result["error"]
+
+
+def test_tool_without_manager_returns_empty_gate():
+    result = json.loads(memory_evidence_repair_commit_gate_tool({}))
+
+    assert result["success"] is True
+    assert result["read_only"] is True
+    assert result["summary"]["decision_count"] == 0
+    assert result["decisions"] == []
+
+
+def test_tool_is_registered_under_memory_toolset():
+    entry = registry.get_entry("memory_evidence_repair_commit_gate")
+
+    assert entry is not None
+    assert entry.toolset == "memory"

--- a/tests/tools/test_memory_evidence_repair_commit_ledger_tool.py
+++ b/tests/tools/test_memory_evidence_repair_commit_ledger_tool.py
@@ -1,0 +1,167 @@
+import json
+
+from tools.memory_evidence_repair_commit_ledger_tool import (
+    memory_evidence_repair_commit_ledger_tool,
+)
+from tools.registry import registry
+
+
+class FakeMemoryManager:
+    def last_memory_policy_gate(self):
+        return {
+            "summary": {"input_count": 1, "output_count": 0},
+            "provider_results": [
+                {
+                    "provider": "builtin",
+                    "action": "require_provenance_before_reuse",
+                    "effect": "filtered",
+                    "reason": "Recall candidate lacks explicit provenance required by policy.",
+                }
+            ],
+            "read_only": True,
+        }
+
+    def last_recall_audit(self):
+        return {"entries": [], "read_only": True}
+
+    def last_recall_diagnostics(self):
+        return {"issues": [], "read_only": True}
+
+    def last_memory_auto_policy(self):
+        return {"decisions": [], "read_only": True}
+
+
+def _allow_decision():
+    return {
+        "id": "gate-preview-123",
+        "preview_id": "preview-123",
+        "candidate_id": "repair-123",
+        "decision": "allow_manual_commit",
+        "provider": "builtin",
+        "priority": "high",
+        "repair_action": "attach_provenance",
+        "reasons": [],
+        "required_actions": [],
+        "target": {"candidate_id": "repair-123", "provider": "builtin"},
+        "evidence_patch": {
+            "source_url": "https://example.com/source",
+            "observed_at": "2026-05-11T00:00:00Z",
+            "verification_signal": "manual_verified",
+        },
+        "memory_patch_preview": {
+            "operation": "merge_evidence_metadata",
+            "set": {"evidence": {}},
+        },
+        "conflict_risk": "low",
+    }
+
+
+def test_tool_uses_latest_manager_state_read_only_markdown():
+    result = json.loads(
+        memory_evidence_repair_commit_ledger_tool(
+            {"format": "markdown"},
+            memory_manager=FakeMemoryManager(),
+        )
+    )
+
+    assert result["success"] is True
+    assert result["read_only"] is True
+    assert result["read_only_memory"] is True
+    assert result["would_mutate_memory"] is False
+    assert result["summary"]["entry_count"] == 1
+    assert result["summary"]["blocked_count"] == 1
+    assert "Memory Evidence Repair Commit Ledger" in result["markdown"]
+
+
+def test_tool_accepts_explicit_decisions_and_ledger_metadata():
+    result = json.loads(
+        memory_evidence_repair_commit_ledger_tool(
+            {
+                "decisions": [_allow_decision()],
+                "ledger_actor": "tester",
+                "ledger_reason": "audit before manual memory write",
+            }
+        )
+    )
+
+    assert result["summary"]["allow_count"] == 1
+    assert result["entries"][0]["outcome"] == "allowed_for_manual_commit"
+    assert result["entries"][0]["metadata"]["ledger_actor"] == "tester"
+    assert result["entries"][0]["metadata"]["ledger_reason"] == (
+        "audit before manual memory write"
+    )
+
+
+def test_tool_accepts_candidates_and_builds_full_pipeline():
+    result = json.loads(
+        memory_evidence_repair_commit_ledger_tool(
+            {
+                "candidates": [
+                    {
+                        "id": "repair-123",
+                        "provider": "builtin",
+                        "priority": "high",
+                        "repair_action": "attach_provenance",
+                        "required_evidence": [
+                            "source_url",
+                            "observed_at",
+                            "verification_signal",
+                        ],
+                        "proposed_evidence_patch": {
+                            "source_url": "https://example.com/source",
+                            "observed_at": "2026-05-11T00:00:00Z",
+                            "verification_signal": "manual_verified",
+                        },
+                    }
+                ],
+                "approved_candidate_ids": ["repair-123"],
+                "user_confirmed": True,
+            }
+        )
+    )
+
+    assert result["summary"]["allow_count"] == 1
+    assert result["entries"][0]["manual_commit_allowed"] is True
+
+
+def test_tool_accepts_commit_gate_and_limits_entries():
+    result = json.loads(
+        memory_evidence_repair_commit_ledger_tool(
+            {
+                "limit": 1,
+                "commit_gate": {
+                    "decisions": [_allow_decision(), _allow_decision()],
+                    "read_only": True,
+                },
+            }
+        )
+    )
+
+    assert result["limited_to"] == 1
+    assert result["summary"]["entry_count"] == 1
+    assert len(result["entries"]) == 1
+
+
+def test_tool_rejects_invalid_input_shape():
+    result = json.loads(
+        memory_evidence_repair_commit_ledger_tool({"commit_gate": "bad"})
+    )
+
+    assert result["success"] is False
+    assert "commit_gate must be an object" in result["error"]
+
+
+def test_tool_without_manager_returns_empty_ledger():
+    result = json.loads(memory_evidence_repair_commit_ledger_tool({}))
+
+    assert result["success"] is True
+    assert result["read_only"] is True
+    assert result["summary"]["entry_count"] == 0
+    assert result["entries"] == []
+
+
+def test_tool_is_registered_under_memory_toolset():
+    entry = registry.get_entry("memory_evidence_repair_commit_ledger")
+
+    assert entry is not None
+    assert entry.toolset == "memory"

--- a/tests/tools/test_memory_evidence_repair_commit_receipt_tool.py
+++ b/tests/tools/test_memory_evidence_repair_commit_receipt_tool.py
@@ -1,0 +1,231 @@
+import json
+
+from tools.memory_evidence_repair_approval_token_gate_tool import (
+    memory_evidence_repair_approval_token_gate_tool,
+)
+from tools.memory_evidence_repair_commit_receipt_tool import (
+    memory_evidence_repair_commit_receipt_tool,
+)
+from tools.memory_evidence_repair_human_approval_token_tool import (
+    memory_evidence_repair_human_approval_token_tool,
+)
+from tools.registry import registry
+
+
+class FakeMemoryManager:
+    def last_memory_policy_gate(self):
+        return {
+            "summary": {"input_count": 1, "output_count": 0},
+            "provider_results": [
+                {
+                    "provider": "builtin",
+                    "action": "require_provenance_before_reuse",
+                    "effect": "filtered",
+                    "reason": "Recall candidate lacks explicit provenance required by policy.",
+                }
+            ],
+            "read_only": True,
+        }
+
+    def last_recall_audit(self):
+        return {"entries": [], "read_only": True}
+
+    def last_recall_diagnostics(self):
+        return {"issues": [], "read_only": True}
+
+    def last_memory_auto_policy(self):
+        return {"decisions": [], "read_only": True}
+
+
+def _ready_dry_run():
+    return {
+        "status": "ready_for_manual_commit",
+        "summary": {"manual_commit_allowed": True, "operation_count": 1},
+        "checks": [{"id": "commit_gate", "status": "pass"}],
+        "operations": [
+            {
+                "id": "dryrun-op-123",
+                "ledger_entry_id": "ledger-123",
+                "candidate_id": "repair-123",
+                "preview_id": "preview-123",
+                "provider": "builtin",
+                "repair_action": "attach_provenance",
+                "patch_digest": "a" * 64,
+                "target": {"candidate_id": "repair-123"},
+                "evidence_fields": ["source_url"],
+            }
+        ],
+        "blocking_reasons": [],
+        "required_actions": [],
+    }
+
+
+def _token_report():
+    result = json.loads(
+        memory_evidence_repair_human_approval_token_tool(
+            {
+                "dry_run": _ready_dry_run(),
+                "approver": "han",
+                "approval_reason": "final manual approval",
+                "expires_in_minutes": 30,
+            }
+        )
+    )
+    result["generated_at"] = "2026-05-11T00:00:00+00:00"
+    return result
+
+
+def _verified_gate():
+    token_report = _token_report()
+    return json.loads(
+        memory_evidence_repair_approval_token_gate_tool(
+            {
+                "approval_token": token_report,
+                "confirmation_text": token_report["tokens"][0]["required_confirmation_text"],
+                "current_time": "2026-05-11T00:10:00+00:00",
+            }
+        )
+    )
+
+
+def _candidate_args():
+    return {
+        "candidates": [
+            {
+                "id": "repair-123",
+                "provider": "builtin",
+                "priority": "high",
+                "repair_action": "attach_provenance",
+                "required_evidence": [
+                    "source_url",
+                    "observed_at",
+                    "verification_signal",
+                ],
+                "proposed_evidence_patch": {
+                    "source_url": "https://example.com/source",
+                    "observed_at": "2026-05-11T00:00:00Z",
+                    "verification_signal": "manual_verified",
+                },
+            }
+        ],
+        "approved_candidate_ids": ["repair-123"],
+        "user_confirmed": True,
+        "existing_snapshots": {
+            "source_url": "https://old.example.com/source",
+            "observed_at": "2026-05-01T00:00:00Z",
+            "verification_signal": "previous_manual_verified",
+        },
+        "approver": "han",
+    }
+
+
+def test_tool_accepts_explicit_verified_gate_markdown():
+    result = json.loads(
+        memory_evidence_repair_commit_receipt_tool(
+            {
+                "token_gate": _verified_gate(),
+                "actor": "han",
+                "commit_reason": "manual memory evidence repair",
+                "format": "markdown",
+            }
+        )
+    )
+
+    assert result["success"] is True
+    assert result["read_only"] is True
+    assert result["read_only_memory"] is True
+    assert result["would_mutate_memory"] is False
+    assert result["status"] == "receipt_ready_for_manual_commit"
+    assert result["summary"]["commit_receipt_available"] is True
+    assert result["receipts"][0]["actor"] == "han"
+    assert "Memory Evidence Repair Commit Receipt" in result["markdown"]
+
+
+def test_tool_blocks_when_token_already_used():
+    gate = _verified_gate()
+
+    result = json.loads(
+        memory_evidence_repair_commit_receipt_tool(
+            {
+                "token_gate": gate,
+                "used_token_ids": [gate["token_id"]],
+            }
+        )
+    )
+
+    assert result["status"] == "blocked"
+    assert result["receipts"] == []
+    assert "regenerate_human_approval_token" in result["required_actions"]
+
+
+def test_tool_generates_gate_from_token_and_creates_receipt():
+    token_report = _token_report()
+    result = json.loads(
+        memory_evidence_repair_commit_receipt_tool(
+            {
+                "approval_token": token_report,
+                "confirmation_text": token_report["tokens"][0]["required_confirmation_text"],
+                "current_time": "2026-05-11T00:10:00+00:00",
+                "actor": "han",
+            }
+        )
+    )
+
+    assert result["status"] == "receipt_ready_for_manual_commit"
+    assert result["summary"]["would_record_receipt_count"] == 1
+    assert result["receipts"][0]["token_id"] == token_report["tokens"][0]["id"]
+
+
+def test_tool_blocks_when_generated_gate_is_not_verified():
+    token_report = _token_report()
+    result = json.loads(
+        memory_evidence_repair_commit_receipt_tool(
+            {
+                "approval_token": token_report,
+                "confirmation_text": "wrong confirmation",
+                "current_time": "2026-05-11T00:10:00+00:00",
+            }
+        )
+    )
+
+    assert result["status"] == "blocked"
+    assert result["receipts"] == []
+    assert "provide_exact_confirmation_text" in result["required_actions"]
+
+
+def test_tool_uses_latest_manager_state_and_blocks_when_no_gate_available():
+    result = json.loads(
+        memory_evidence_repair_commit_receipt_tool(
+            {"format": "markdown"},
+            memory_manager=FakeMemoryManager(),
+        )
+    )
+
+    assert result["success"] is True
+    assert result["status"] == "blocked"
+    assert result["receipts"] == []
+    assert result["blocking_reasons"]
+
+
+def test_tool_rejects_invalid_input_shape():
+    result = json.loads(
+        memory_evidence_repair_commit_receipt_tool({"token_gate": "bad"})
+    )
+
+    assert result["success"] is False
+    assert "token_gate must be an object" in result["error"]
+
+
+def test_tool_without_manager_returns_no_action():
+    result = json.loads(memory_evidence_repair_commit_receipt_tool({}))
+
+    assert result["success"] is True
+    assert result["status"] == "no_action_needed"
+    assert result["summary"]["receipt_count"] == 0
+
+
+def test_tool_is_registered_under_memory_toolset():
+    entry = registry.get_entry("memory_evidence_repair_commit_receipt")
+
+    assert entry is not None
+    assert entry.toolset == "memory"

--- a/tests/tools/test_memory_evidence_repair_executor_preview_tool.py
+++ b/tests/tools/test_memory_evidence_repair_executor_preview_tool.py
@@ -1,0 +1,234 @@
+import json
+
+from tools.memory_evidence_repair_executor_preview_tool import (
+    memory_evidence_repair_executor_preview_tool,
+)
+from tools.memory_evidence_repair_human_approval_token_tool import (
+    memory_evidence_repair_human_approval_token_tool,
+)
+from tools.memory_evidence_repair_write_lock_gate_tool import (
+    memory_evidence_repair_write_lock_gate_tool,
+)
+from tools.registry import registry
+
+
+class FakeMemoryManager:
+    def last_memory_policy_gate(self):
+        return {
+            "summary": {"input_count": 1, "output_count": 0},
+            "provider_results": [
+                {
+                    "provider": "builtin",
+                    "action": "require_provenance_before_reuse",
+                    "effect": "filtered",
+                    "reason": "Recall candidate lacks explicit provenance required by policy.",
+                }
+            ],
+            "read_only": True,
+        }
+
+    def last_recall_audit(self):
+        return {"entries": [], "read_only": True}
+
+    def last_recall_diagnostics(self):
+        return {"issues": [], "read_only": True}
+
+    def last_memory_auto_policy(self):
+        return {"decisions": [], "read_only": True}
+
+
+def _ready_dry_run():
+    return {
+        "status": "ready_for_manual_commit",
+        "summary": {"manual_commit_allowed": True, "operation_count": 1},
+        "checks": [{"id": "commit_gate", "status": "pass"}],
+        "operations": [
+            {
+                "id": "dryrun-op-123",
+                "ledger_entry_id": "ledger-123",
+                "candidate_id": "repair-123",
+                "preview_id": "preview-123",
+                "provider": "builtin",
+                "repair_action": "attach_provenance",
+                "patch_digest": "a" * 64,
+                "target": {"candidate_id": "repair-123"},
+                "evidence_fields": ["source_url"],
+            }
+        ],
+        "blocking_reasons": [],
+        "required_actions": [],
+    }
+
+
+def _token_report():
+    result = json.loads(
+        memory_evidence_repair_human_approval_token_tool(
+            {
+                "dry_run": _ready_dry_run(),
+                "approver": "han",
+                "approval_reason": "final manual approval",
+                "expires_in_minutes": 30,
+            }
+        )
+    )
+    result["generated_at"] = "2026-05-11T00:00:00+00:00"
+    return result
+
+
+def _write_lock_gate():
+    token_report = _token_report()
+    return json.loads(
+        memory_evidence_repair_write_lock_gate_tool(
+            {
+                "approval_token": token_report,
+                "confirmation_text": token_report["tokens"][0]["required_confirmation_text"],
+                "current_time": "2026-05-11T00:10:00+00:00",
+                "actor": "han",
+                "commit_reason": "manual memory evidence repair",
+                "lock_owner": "han",
+                "lock_ttl_minutes": 15,
+            }
+        )
+    )
+
+
+def _candidate_args():
+    return {
+        "candidates": [
+            {
+                "id": "repair-123",
+                "provider": "builtin",
+                "priority": "high",
+                "repair_action": "attach_provenance",
+                "required_evidence": [
+                    "source_url",
+                    "observed_at",
+                    "verification_signal",
+                ],
+                "proposed_evidence_patch": {
+                    "source_url": "https://example.com/source",
+                    "observed_at": "2026-05-11T00:00:00Z",
+                    "verification_signal": "manual_verified",
+                },
+            }
+        ],
+        "approved_candidate_ids": ["repair-123"],
+        "user_confirmed": True,
+        "existing_snapshots": {
+            "source_url": "https://old.example.com/source",
+            "observed_at": "2026-05-01T00:00:00Z",
+            "verification_signal": "previous_manual_verified",
+        },
+        "approver": "han",
+    }
+
+
+def test_tool_accepts_explicit_write_lock_gate_markdown():
+    result = json.loads(
+        memory_evidence_repair_executor_preview_tool(
+            {
+                "write_lock_gate": _write_lock_gate(),
+                "current_time": "2026-05-11T00:12:00+00:00",
+                "format": "markdown",
+            }
+        )
+    )
+
+    assert result["success"] is True
+    assert result["read_only"] is True
+    assert result["read_only_memory"] is True
+    assert result["would_mutate_memory"] is False
+    assert result["status"] == "executor_preview_ready_for_manual_commit"
+    assert result["summary"]["manual_executor_preview_ready"] is True
+    assert result["summary"]["future_write_step_count"] == 1
+    assert result["previews"][0]["steps"][1]["action"] == "apply_evidence_metadata_patch"
+    assert "Memory Evidence Repair Executor Preview" in result["markdown"]
+
+
+def test_tool_blocks_expired_write_lock_gate():
+    result = json.loads(
+        memory_evidence_repair_executor_preview_tool(
+            {
+                "write_lock_gate": _write_lock_gate(),
+                "current_time": "2026-05-11T00:26:00+00:00",
+            }
+        )
+    )
+
+    assert result["status"] == "blocked"
+    assert result["previews"] == []
+    assert "regenerate_write_lock_gate" in result["required_actions"]
+
+
+def test_tool_generates_write_lock_gate_from_token_and_creates_preview():
+    token_report = _token_report()
+    result = json.loads(
+        memory_evidence_repair_executor_preview_tool(
+            {
+                "approval_token": token_report,
+                "confirmation_text": token_report["tokens"][0]["required_confirmation_text"],
+                "current_time": "2026-05-11T00:10:00+00:00",
+                "actor": "han",
+                "lock_owner": "han",
+            }
+        )
+    )
+
+    assert result["status"] == "executor_preview_ready_for_manual_commit"
+    assert result["summary"]["executor_preview_available"] is True
+    assert result["previews"][0]["operation_ids"] == ["dryrun-op-123"]
+
+
+def test_tool_blocks_when_generated_write_lock_gate_is_not_ready():
+    token_report = _token_report()
+    result = json.loads(
+        memory_evidence_repair_executor_preview_tool(
+            {
+                "approval_token": token_report,
+                "confirmation_text": "wrong confirmation",
+                "current_time": "2026-05-11T00:10:00+00:00",
+            }
+        )
+    )
+
+    assert result["status"] == "blocked"
+    assert result["previews"] == []
+    assert "provide_exact_confirmation_text" in result["required_actions"]
+
+
+def test_tool_uses_latest_manager_state_and_blocks_when_no_lock_available():
+    result = json.loads(
+        memory_evidence_repair_executor_preview_tool(
+            {"format": "markdown"},
+            memory_manager=FakeMemoryManager(),
+        )
+    )
+
+    assert result["success"] is True
+    assert result["status"] == "blocked"
+    assert result["previews"] == []
+    assert result["blocking_reasons"]
+
+
+def test_tool_rejects_invalid_input_shape():
+    result = json.loads(
+        memory_evidence_repair_executor_preview_tool({"write_lock_gate": "bad"})
+    )
+
+    assert result["success"] is False
+    assert "write_lock_gate must be an object" in result["error"]
+
+
+def test_tool_without_manager_returns_no_action():
+    result = json.loads(memory_evidence_repair_executor_preview_tool({}))
+
+    assert result["success"] is True
+    assert result["status"] == "no_action_needed"
+    assert result["summary"]["preview_count"] == 0
+
+
+def test_tool_is_registered_under_memory_toolset():
+    entry = registry.get_entry("memory_evidence_repair_executor_preview")
+
+    assert entry is not None
+    assert entry.toolset == "memory"

--- a/tests/tools/test_memory_evidence_repair_human_approval_token_tool.py
+++ b/tests/tools/test_memory_evidence_repair_human_approval_token_tool.py
@@ -1,0 +1,158 @@
+import json
+
+from tools.memory_evidence_repair_human_approval_token_tool import (
+    memory_evidence_repair_human_approval_token_tool,
+)
+from tools.registry import registry
+
+
+class FakeMemoryManager:
+    def last_memory_policy_gate(self):
+        return {
+            "summary": {"input_count": 1, "output_count": 0},
+            "provider_results": [
+                {
+                    "provider": "builtin",
+                    "action": "require_provenance_before_reuse",
+                    "effect": "filtered",
+                    "reason": "Recall candidate lacks explicit provenance required by policy.",
+                }
+            ],
+            "read_only": True,
+        }
+
+    def last_recall_audit(self):
+        return {"entries": [], "read_only": True}
+
+    def last_recall_diagnostics(self):
+        return {"issues": [], "read_only": True}
+
+    def last_memory_auto_policy(self):
+        return {"decisions": [], "read_only": True}
+
+
+def _ready_dry_run():
+    return {
+        "status": "ready_for_manual_commit",
+        "summary": {"manual_commit_allowed": True, "operation_count": 1},
+        "checks": [{"id": "commit_gate", "status": "pass"}],
+        "operations": [
+            {
+                "id": "dryrun-op-123",
+                "ledger_entry_id": "ledger-123",
+                "candidate_id": "repair-123",
+                "preview_id": "preview-123",
+                "provider": "builtin",
+                "repair_action": "attach_provenance",
+                "patch_digest": "a" * 64,
+                "target": {"candidate_id": "repair-123"},
+                "evidence_fields": ["source_url"],
+            }
+        ],
+        "blocking_reasons": [],
+        "required_actions": [],
+    }
+
+
+def test_tool_accepts_explicit_ready_dry_run_markdown():
+    result = json.loads(
+        memory_evidence_repair_human_approval_token_tool(
+            {
+                "dry_run": _ready_dry_run(),
+                "approver": "han",
+                "approval_reason": "final manual approval",
+                "expires_in_minutes": 45,
+                "format": "markdown",
+            }
+        )
+    )
+
+    assert result["success"] is True
+    assert result["read_only"] is True
+    assert result["read_only_memory"] is True
+    assert result["would_mutate_memory"] is False
+    assert result["status"] == "draft_ready_for_human_approval"
+    assert result["summary"]["token_count"] == 1
+    assert result["tokens"][0]["approver"] == "han"
+    assert result["tokens"][0]["expires_in_minutes"] == 45
+    assert "Memory Evidence Repair Human Approval Token" in result["markdown"]
+
+
+def test_tool_uses_latest_manager_state_and_blocks_when_dry_run_blocked():
+    result = json.loads(
+        memory_evidence_repair_human_approval_token_tool(
+            {"format": "markdown"},
+            memory_manager=FakeMemoryManager(),
+        )
+    )
+
+    assert result["success"] is True
+    assert result["status"] == "blocked"
+    assert result["summary"]["token_count"] == 0
+    assert result["tokens"] == []
+    assert result["blocking_reasons"]
+
+
+def test_tool_accepts_candidates_and_existing_snapshots_for_token():
+    result = json.loads(
+        memory_evidence_repair_human_approval_token_tool(
+            {
+                "candidates": [
+                    {
+                        "id": "repair-123",
+                        "provider": "builtin",
+                        "priority": "high",
+                        "repair_action": "attach_provenance",
+                        "required_evidence": [
+                            "source_url",
+                            "observed_at",
+                            "verification_signal",
+                        ],
+                        "proposed_evidence_patch": {
+                            "source_url": "https://example.com/source",
+                            "observed_at": "2026-05-11T00:00:00Z",
+                            "verification_signal": "manual_verified",
+                        },
+                    }
+                ],
+                "approved_candidate_ids": ["repair-123"],
+                "user_confirmed": True,
+                "existing_snapshots": {
+                    "source_url": "https://old.example.com/source",
+                    "observed_at": "2026-05-01T00:00:00Z",
+                    "verification_signal": "previous_manual_verified",
+                },
+                "approver": "han",
+            }
+        )
+    )
+
+    assert result["status"] == "draft_ready_for_human_approval"
+    assert result["summary"]["human_approval_token_available"] is True
+    assert result["tokens"][0]["approver"] == "han"
+    assert result["tokens"][0]["operation_ids"]
+
+
+def test_tool_rejects_invalid_input_shape():
+    result = json.loads(
+        memory_evidence_repair_human_approval_token_tool({"dry_run": "bad"})
+    )
+
+    assert result["success"] is False
+    assert "dry_run must be an object" in result["error"]
+
+
+def test_tool_without_manager_returns_no_action():
+    result = json.loads(memory_evidence_repair_human_approval_token_tool({}))
+
+    assert result["success"] is True
+    assert result["status"] == "no_action_needed"
+    assert result["summary"]["token_count"] == 0
+    assert result["tokens"] == []
+
+
+def test_tool_is_registered_under_memory_toolset():
+    entry = registry.get_entry("memory_evidence_repair_human_approval_token")
+
+    assert entry is not None
+    assert entry.toolset == "memory"

--- a/tests/tools/test_memory_evidence_repair_manual_commit_dry_run_tool.py
+++ b/tests/tools/test_memory_evidence_repair_manual_commit_dry_run_tool.py
@@ -1,0 +1,216 @@
+import json
+
+from tools.memory_evidence_repair_manual_commit_dry_run_tool import (
+    memory_evidence_repair_manual_commit_dry_run_tool,
+)
+from tools.registry import registry
+
+
+class FakeMemoryManager:
+    def last_memory_policy_gate(self):
+        return {
+            "summary": {"input_count": 1, "output_count": 0},
+            "provider_results": [
+                {
+                    "provider": "builtin",
+                    "action": "require_provenance_before_reuse",
+                    "effect": "filtered",
+                    "reason": "Recall candidate lacks explicit provenance required by policy.",
+                }
+            ],
+            "read_only": True,
+        }
+
+    def last_recall_audit(self):
+        return {"entries": [], "read_only": True}
+
+    def last_recall_diagnostics(self):
+        return {"issues": [], "read_only": True}
+
+    def last_memory_auto_policy(self):
+        return {"decisions": [], "read_only": True}
+
+
+def test_tool_uses_latest_manager_state_read_only_markdown():
+    result = json.loads(
+        memory_evidence_repair_manual_commit_dry_run_tool(
+            {"format": "markdown"},
+            memory_manager=FakeMemoryManager(),
+        )
+    )
+
+    assert result["success"] is True
+    assert result["read_only"] is True
+    assert result["read_only_memory"] is True
+    assert result["would_mutate_memory"] is False
+    assert result["status"] == "blocked"
+    assert result["summary"]["has_blocks"] is True
+    assert "Memory Evidence Repair Manual Commit Dry-Run" in result["markdown"]
+
+
+def test_tool_accepts_candidates_and_existing_snapshots_for_ready_dry_run():
+    result = json.loads(
+        memory_evidence_repair_manual_commit_dry_run_tool(
+            {
+                "candidates": [
+                    {
+                        "id": "repair-123",
+                        "provider": "builtin",
+                        "priority": "high",
+                        "repair_action": "attach_provenance",
+                        "required_evidence": [
+                            "source_url",
+                            "observed_at",
+                            "verification_signal",
+                        ],
+                        "proposed_evidence_patch": {
+                            "source_url": "https://example.com/source",
+                            "observed_at": "2026-05-11T00:00:00Z",
+                            "verification_signal": "manual_verified",
+                        },
+                    }
+                ],
+                "approved_candidate_ids": ["repair-123"],
+                "user_confirmed": True,
+                "existing_snapshots": {
+                    "source_url": "https://old.example.com/source",
+                    "observed_at": "2026-05-01T00:00:00Z",
+                    "verification_signal": "previous_manual_verified",
+                },
+            }
+        )
+    )
+
+    assert result["status"] == "ready_for_manual_commit"
+    assert result["summary"]["manual_commit_allowed"] is True
+    assert result["summary"]["operation_count"] == 1
+    assert result["blocking_reasons"] == []
+
+
+def test_tool_blocks_when_snapshot_plan_requires_capture():
+    result = json.loads(
+        memory_evidence_repair_manual_commit_dry_run_tool(
+            {
+                "snapshot_plan": {
+                    "summary": {
+                        "snapshot_request_count": 1,
+                        "capture_required_count": 1,
+                        "blocking_count": 1,
+                    },
+                    "requests": [{"status": "capture_required"}],
+                },
+                "commit_gate": {
+                    "summary": {
+                        "decision_count": 1,
+                        "allow_count": 1,
+                        "blocked_count": 0,
+                        "needs_confirmation_count": 0,
+                    },
+                    "decisions": [{"decision": "allow_manual_commit"}],
+                },
+                "ledger": {
+                    "summary": {
+                        "entry_count": 1,
+                        "allow_count": 1,
+                        "blocked_count": 0,
+                        "followup_count": 0,
+                    },
+                    "entries": [
+                        {
+                            "id": "ledger-123",
+                            "manual_commit_allowed": True,
+                            "patch_digest": "a" * 64,
+                            "evidence_fields": ["source_url"],
+                        }
+                    ],
+                },
+                "rollback_plan": {
+                    "summary": {
+                        "rollback_step_count": 1,
+                        "ready_count": 1,
+                        "snapshot_required_count": 0,
+                    },
+                    "steps": [{"status": "ready_for_manual_rollback"}],
+                },
+            }
+        )
+    )
+
+    assert result["status"] == "blocked"
+    assert "capture_pre_commit_snapshots" in result["required_actions"]
+
+
+def test_tool_accepts_limit_for_operations():
+    result = json.loads(
+        memory_evidence_repair_manual_commit_dry_run_tool(
+            {
+                "limit": 1,
+                "snapshot_plan": {
+                    "summary": {
+                        "snapshot_request_count": 1,
+                        "capture_required_count": 0,
+                        "blocking_count": 0,
+                    },
+                    "requests": [{"status": "already_available"}],
+                },
+                "commit_gate": {
+                    "summary": {
+                        "decision_count": 1,
+                        "allow_count": 1,
+                        "blocked_count": 0,
+                        "needs_confirmation_count": 0,
+                    },
+                    "decisions": [{"decision": "allow_manual_commit"}],
+                },
+                "ledger": {
+                    "summary": {
+                        "entry_count": 2,
+                        "allow_count": 2,
+                        "blocked_count": 0,
+                        "followup_count": 0,
+                    },
+                    "entries": [
+                        {"id": "ledger-1", "manual_commit_allowed": True},
+                        {"id": "ledger-2", "manual_commit_allowed": True},
+                    ],
+                },
+                "rollback_plan": {
+                    "summary": {
+                        "rollback_step_count": 1,
+                        "ready_count": 1,
+                        "snapshot_required_count": 0,
+                    },
+                    "steps": [{"status": "ready_for_manual_rollback"}],
+                },
+            }
+        )
+    )
+
+    assert result["limited_to"] == 1
+    assert result["summary"]["operation_count"] == 1
+    assert len(result["operations"]) == 1
+
+
+def test_tool_rejects_invalid_input_shape():
+    result = json.loads(
+        memory_evidence_repair_manual_commit_dry_run_tool({"snapshot_plan": "bad"})
+    )
+
+    assert result["success"] is False
+    assert "snapshot_plan must be an object" in result["error"]
+
+
+def test_tool_without_manager_returns_no_action():
+    result = json.loads(memory_evidence_repair_manual_commit_dry_run_tool({}))
+
+    assert result["success"] is True
+    assert result["read_only"] is True
+    assert result["status"] == "no_action_needed"
+    assert result["summary"]["operation_count"] == 0
+
+
+def test_tool_is_registered_under_memory_toolset():
+    entry = registry.get_entry("memory_evidence_repair_manual_commit_dry_run")
+
+    assert entry is not None
+    assert entry.toolset == "memory"

--- a/tests/tools/test_memory_evidence_repair_planner_tool.py
+++ b/tests/tools/test_memory_evidence_repair_planner_tool.py
@@ -1,0 +1,103 @@
+import json
+
+from tools.memory_evidence_repair_planner_tool import (
+    memory_evidence_repair_planner_tool,
+)
+from tools.registry import registry
+
+
+class FakeMemoryManager:
+    def last_memory_policy_gate(self):
+        return {
+            "summary": {"input_count": 1, "output_count": 0},
+            "provider_results": [
+                {
+                    "provider": "builtin",
+                    "action": "require_provenance_before_reuse",
+                    "effect": "filtered",
+                    "reason": "Recall candidate lacks explicit provenance required by policy.",
+                }
+            ],
+            "read_only": True,
+        }
+
+    def last_recall_audit(self):
+        return {"entries": [], "read_only": True}
+
+    def last_recall_diagnostics(self):
+        return {"issues": [], "read_only": True}
+
+    def last_memory_auto_policy(self):
+        return {"decisions": [], "read_only": True}
+
+
+def test_tool_uses_latest_manager_state_read_only_markdown():
+    result = json.loads(
+        memory_evidence_repair_planner_tool(
+            {"format": "markdown"},
+            memory_manager=FakeMemoryManager(),
+        )
+    )
+
+    assert result["success"] is True
+    assert result["read_only"] is True
+    assert result["read_only_memory"] is True
+    assert result["summary"]["repair_count"] == 1
+    assert result["summary"]["blocked_count"] == 1
+    assert "Memory Evidence Repair Planner" in result["markdown"]
+
+
+def test_tool_accepts_explicit_payloads_and_limits_repairs():
+    result = json.loads(
+        memory_evidence_repair_planner_tool(
+            {
+                "limit": 1,
+                "gate": {
+                    "provider_results": [
+                        {
+                            "provider": "builtin",
+                            "action": "require_provenance_before_reuse",
+                            "effect": "filtered",
+                            "reason": "Missing provenance.",
+                        }
+                    ]
+                },
+                "diagnostics": {
+                    "issues": [
+                        {
+                            "provider": "graph",
+                            "code": "refresh_stale_recall",
+                            "reason": "Recall may be stale.",
+                        }
+                    ]
+                },
+            }
+        )
+    )
+
+    assert result["limited_to"] == 1
+    assert len(result["repairs"]) == 1
+    assert result["repairs"][0]["priority"] == "high"
+
+
+def test_tool_rejects_invalid_input_shape():
+    result = json.loads(memory_evidence_repair_planner_tool({"gate": "bad"}))
+
+    assert result["success"] is False
+    assert "gate must be an object" in result["error"]
+
+
+def test_tool_without_manager_returns_empty_plan():
+    result = json.loads(memory_evidence_repair_planner_tool({}))
+
+    assert result["success"] is True
+    assert result["read_only"] is True
+    assert result["summary"]["repair_count"] == 0
+    assert result["repairs"] == []
+
+
+def test_tool_is_registered_under_memory_toolset():
+    entry = registry.get_entry("memory_evidence_repair_planner")
+
+    assert entry is not None
+    assert entry.toolset == "memory"

--- a/tests/tools/test_memory_evidence_repair_post_commit_audit_preview_tool.py
+++ b/tests/tools/test_memory_evidence_repair_post_commit_audit_preview_tool.py
@@ -1,0 +1,231 @@
+import json
+
+from tools.memory_evidence_repair_executor_preview_tool import (
+    memory_evidence_repair_executor_preview_tool,
+)
+from tools.memory_evidence_repair_human_approval_token_tool import (
+    memory_evidence_repair_human_approval_token_tool,
+)
+from tools.memory_evidence_repair_post_commit_audit_preview_tool import (
+    memory_evidence_repair_post_commit_audit_preview_tool,
+)
+from tools.registry import registry
+
+
+class FakeMemoryManager:
+    def last_memory_policy_gate(self):
+        return {
+            "summary": {"input_count": 1, "output_count": 0},
+            "provider_results": [
+                {
+                    "provider": "builtin",
+                    "action": "require_provenance_before_reuse",
+                    "effect": "filtered",
+                    "reason": "Recall candidate lacks explicit provenance required by policy.",
+                }
+            ],
+            "read_only": True,
+        }
+
+    def last_recall_audit(self):
+        return {"entries": [], "read_only": True}
+
+    def last_recall_diagnostics(self):
+        return {"issues": [], "read_only": True}
+
+    def last_memory_auto_policy(self):
+        return {"decisions": [], "read_only": True}
+
+
+def _ready_dry_run():
+    return {
+        "status": "ready_for_manual_commit",
+        "summary": {"manual_commit_allowed": True, "operation_count": 1},
+        "checks": [{"id": "commit_gate", "status": "pass"}],
+        "operations": [
+            {
+                "id": "dryrun-op-123",
+                "ledger_entry_id": "ledger-123",
+                "candidate_id": "repair-123",
+                "preview_id": "preview-123",
+                "provider": "builtin",
+                "repair_action": "attach_provenance",
+                "patch_digest": "a" * 64,
+                "target": {"candidate_id": "repair-123"},
+                "evidence_fields": ["source_url"],
+            }
+        ],
+        "blocking_reasons": [],
+        "required_actions": [],
+    }
+
+
+def _token_report():
+    result = json.loads(
+        memory_evidence_repair_human_approval_token_tool(
+            {
+                "dry_run": _ready_dry_run(),
+                "approver": "han",
+                "approval_reason": "final manual approval",
+                "expires_in_minutes": 30,
+            }
+        )
+    )
+    result["generated_at"] = "2026-05-11T00:00:00+00:00"
+    return result
+
+
+def _executor_preview():
+    token_report = _token_report()
+    return json.loads(
+        memory_evidence_repair_executor_preview_tool(
+            {
+                "approval_token": token_report,
+                "confirmation_text": token_report["tokens"][0]["required_confirmation_text"],
+                "current_time": "2026-05-11T00:10:00+00:00",
+                "actor": "han",
+                "commit_reason": "manual memory evidence repair",
+                "lock_owner": "han",
+            }
+        )
+    )
+
+
+def test_tool_accepts_explicit_executor_preview_markdown():
+    result = json.loads(
+        memory_evidence_repair_post_commit_audit_preview_tool(
+            {
+                "executor_preview": _executor_preview(),
+                "format": "markdown",
+            }
+        )
+    )
+
+    assert result["success"] is True
+    assert result["read_only"] is True
+    assert result["read_only_memory"] is True
+    assert result["would_mutate_memory"] is False
+    assert result["status"] == "post_commit_audit_preview_ready"
+    assert result["summary"]["planned_audit_step_count"] == 5
+    assert "Memory Evidence Repair Post-Commit Audit Preview" in result["markdown"]
+
+
+def test_tool_accepts_observed_state_and_passes():
+    executor = _executor_preview()
+    preview = executor["previews"][0]
+    result = json.loads(
+        memory_evidence_repair_post_commit_audit_preview_tool(
+            {
+                "executor_preview": executor,
+                "observed_memory_patches": {
+                    "dryrun-op-123": {"applied": True, "patch_digest": "a" * 64}
+                },
+                "recorded_receipts": [{"id": preview["receipt_id"]}],
+                "used_token_ids": [preview["token_id"]],
+                "released_lock_ids": [preview["lock_id"]],
+                "rollback_status": {"status": "snapshot_available"},
+            }
+        )
+    )
+
+    assert result["status"] == "post_commit_audit_preview_ready"
+    assert result["summary"]["observed_pass_step_count"] == 5
+    assert result["summary"]["observed_fail_step_count"] == 0
+
+
+def test_tool_blocks_bad_observed_patch_digest():
+    executor = _executor_preview()
+    preview = executor["previews"][0]
+    result = json.loads(
+        memory_evidence_repair_post_commit_audit_preview_tool(
+            {
+                "executor_preview": executor,
+                "observed_memory_patches": {
+                    "dryrun-op-123": {"applied": True, "patch_digest": "b" * 64}
+                },
+                "recorded_receipts": [{"id": preview["receipt_id"]}],
+                "used_token_ids": [preview["token_id"]],
+                "released_lock_ids": [preview["lock_id"]],
+                "rollback_status": {"status": "snapshot_available"},
+            }
+        )
+    )
+
+    assert result["status"] == "blocked"
+    assert result["previews"] == []
+    assert "investigate_post_commit_audit_failures" in result["required_actions"]
+
+
+def test_tool_generates_executor_preview_from_token():
+    token_report = _token_report()
+    result = json.loads(
+        memory_evidence_repair_post_commit_audit_preview_tool(
+            {
+                "approval_token": token_report,
+                "confirmation_text": token_report["tokens"][0]["required_confirmation_text"],
+                "current_time": "2026-05-11T00:10:00+00:00",
+                "actor": "han",
+                "lock_owner": "han",
+            }
+        )
+    )
+
+    assert result["status"] == "post_commit_audit_preview_ready"
+    assert result["summary"]["post_commit_audit_preview_available"] is True
+
+
+def test_tool_blocks_when_generated_executor_preview_is_not_ready():
+    token_report = _token_report()
+    result = json.loads(
+        memory_evidence_repair_post_commit_audit_preview_tool(
+            {
+                "approval_token": token_report,
+                "confirmation_text": "wrong confirmation",
+                "current_time": "2026-05-11T00:10:00+00:00",
+            }
+        )
+    )
+
+    assert result["status"] == "blocked"
+    assert result["previews"] == []
+    assert "provide_exact_confirmation_text" in result["required_actions"]
+
+
+def test_tool_uses_latest_manager_state_and_blocks_when_no_executor_available():
+    result = json.loads(
+        memory_evidence_repair_post_commit_audit_preview_tool(
+            {"format": "markdown"},
+            memory_manager=FakeMemoryManager(),
+        )
+    )
+
+    assert result["success"] is True
+    assert result["status"] == "blocked"
+    assert result["previews"] == []
+    assert result["blocking_reasons"]
+
+
+def test_tool_rejects_invalid_input_shape():
+    result = json.loads(
+        memory_evidence_repair_post_commit_audit_preview_tool(
+            {"executor_preview": "bad"}
+        )
+    )
+
+    assert result["success"] is False
+    assert "executor_preview must be an object" in result["error"]
+
+
+def test_tool_without_manager_returns_no_action():
+    result = json.loads(memory_evidence_repair_post_commit_audit_preview_tool({}))
+
+    assert result["success"] is True
+    assert result["status"] == "no_action_needed"
+    assert result["summary"]["preview_count"] == 0
+
+
+def test_tool_is_registered_under_memory_toolset():
+    entry = registry.get_entry("memory_evidence_repair_post_commit_audit_preview")
+
+    assert entry is not None
+    assert entry.toolset == "memory"

--- a/tests/tools/test_memory_evidence_repair_recovery_approval_token_gate_tool.py
+++ b/tests/tools/test_memory_evidence_repair_recovery_approval_token_gate_tool.py
@@ -1,0 +1,162 @@
+import json
+
+from tools.memory_evidence_repair_recovery_approval_token_gate_tool import (
+    memory_evidence_repair_recovery_approval_token_gate_tool,
+)
+from tools.memory_evidence_repair_recovery_human_approval_token_tool import (
+    memory_evidence_repair_recovery_human_approval_token_tool,
+)
+from tools.registry import registry
+from tests.tools.test_memory_evidence_repair_post_commit_audit_preview_tool import (
+    FakeMemoryManager,
+)
+from tests.tools.test_memory_evidence_repair_recovery_human_approval_token_tool import (
+    _manual_rollback_execution,
+    _preparedness_execution,
+)
+
+
+def _recovery_token_report():
+    payload = json.loads(
+        memory_evidence_repair_recovery_human_approval_token_tool(
+            {
+                "recovery_execution": _manual_rollback_execution(),
+                "approver": "han",
+                "approval_reason": "manual recovery approval",
+                "expires_in_minutes": 20,
+            }
+        )
+    )
+    payload["generated_at"] = "2026-05-11T00:00:00+00:00"
+    return payload
+
+
+def test_tool_accepts_explicit_recovery_token_markdown():
+    token_report = _recovery_token_report()
+    token = token_report["tokens"][0]
+
+    result = json.loads(
+        memory_evidence_repair_recovery_approval_token_gate_tool(
+            {
+                "recovery_approval_token": token_report,
+                "confirmation_text": token["required_confirmation_text"],
+                "current_time": "2026-05-11T00:10:00+00:00",
+                "format": "markdown",
+            }
+        )
+    )
+
+    assert result["success"] is True
+    assert result["read_only"] is True
+    assert result["read_only_memory"] is True
+    assert result["would_mutate_memory"] is False
+    assert result["status"] == "verified_for_manual_recovery"
+    assert result["summary"]["manual_recovery_verified"] is True
+    assert "Memory Evidence Repair Recovery Approval Token Gate" in result["markdown"]
+
+
+def test_tool_blocks_wrong_confirmation():
+    token_report = _recovery_token_report()
+
+    result = json.loads(
+        memory_evidence_repair_recovery_approval_token_gate_tool(
+            {
+                "recovery_approval_token": token_report,
+                "confirmation_text": "wrong confirmation",
+                "current_time": "2026-05-11T00:10:00+00:00",
+            }
+        )
+    )
+
+    assert result["status"] == "blocked"
+    assert "provide_exact_recovery_confirmation_text" in result["required_actions"]
+
+
+def test_tool_blocks_used_token():
+    token_report = _recovery_token_report()
+    token = token_report["tokens"][0]
+
+    result = json.loads(
+        memory_evidence_repair_recovery_approval_token_gate_tool(
+            {
+                "recovery_approval_token": token_report,
+                "confirmation_text": token["required_confirmation_text"],
+                "used_token_ids": [token["id"]],
+                "current_time": "2026-05-11T00:10:00+00:00",
+            }
+        )
+    )
+
+    assert result["status"] == "blocked"
+    assert "regenerate_recovery_human_approval_token" in result["required_actions"]
+
+
+def test_tool_returns_no_action_for_non_mutating_recovery_token_report():
+    token_report = json.loads(
+        memory_evidence_repair_recovery_human_approval_token_tool(
+            {"recovery_execution": _preparedness_execution()}
+        )
+    )
+
+    result = json.loads(
+        memory_evidence_repair_recovery_approval_token_gate_tool(
+            {"recovery_approval_token": token_report}
+        )
+    )
+
+    assert result["status"] == "no_action_needed"
+    assert result["checks"] == []
+
+
+def test_tool_blocks_when_generated_token_is_not_confirmed():
+    result = json.loads(
+        memory_evidence_repair_recovery_approval_token_gate_tool(
+            {
+                "recovery_execution": _manual_rollback_execution(),
+                "confirmation_text": "wrong confirmation",
+                "current_time": "2026-05-11T00:10:00+00:00",
+            }
+        )
+    )
+
+    assert result["status"] == "blocked"
+    assert "provide_exact_recovery_confirmation_text" in result["required_actions"]
+
+
+def test_tool_uses_latest_manager_state_and_blocks_when_no_token_available():
+    result = json.loads(
+        memory_evidence_repair_recovery_approval_token_gate_tool(
+            {"format": "markdown"},
+            memory_manager=FakeMemoryManager(),
+        )
+    )
+
+    assert result["success"] is True
+    assert result["status"] == "blocked"
+    assert result["blocking_reasons"]
+
+
+def test_tool_rejects_invalid_input_shape():
+    result = json.loads(
+        memory_evidence_repair_recovery_approval_token_gate_tool(
+            {"recovery_approval_token": "bad"}
+        )
+    )
+
+    assert result["success"] is False
+    assert "recovery_approval_token must be an object" in result["error"]
+
+
+def test_tool_without_manager_returns_no_action():
+    result = json.loads(memory_evidence_repair_recovery_approval_token_gate_tool({}))
+
+    assert result["success"] is True
+    assert result["status"] == "no_action_needed"
+    assert result["summary"]["check_count"] == 0
+
+
+def test_tool_is_registered_under_memory_toolset():
+    entry = registry.get_entry("memory_evidence_repair_recovery_approval_token_gate")
+
+    assert entry is not None
+    assert entry.toolset == "memory"

--- a/tests/tools/test_memory_evidence_repair_recovery_closure_finalization_readiness_preview_tool.py
+++ b/tests/tools/test_memory_evidence_repair_recovery_closure_finalization_readiness_preview_tool.py
@@ -1,0 +1,180 @@
+import json
+
+from tools.memory_evidence_repair_recovery_closure_finalization_readiness_preview_tool import (
+    memory_evidence_repair_recovery_closure_finalization_readiness_preview_tool,
+)
+from tools.memory_evidence_repair_recovery_closure_governance_seal_audit_preview_tool import (
+    memory_evidence_repair_recovery_closure_governance_seal_audit_preview_tool,
+)
+from tools.memory_evidence_repair_recovery_completion_receipt_tool import (
+    memory_evidence_repair_recovery_completion_receipt_tool,
+)
+from tools.registry import registry
+from tests.tools.test_memory_evidence_repair_post_commit_audit_preview_tool import (
+    FakeMemoryManager,
+)
+from tests.tools.test_memory_evidence_repair_recovery_approval_token_gate_tool import (
+    _recovery_token_report,
+)
+from tests.tools.test_memory_evidence_repair_recovery_closure_governance_seal_audit_preview_tool import (
+    _ready_governance_seal,
+)
+from tests.tools.test_memory_evidence_repair_recovery_completion_audit_preview_tool import (
+    _observed_recovery_steps,
+)
+
+
+def _ready_seal_audit():
+    return json.loads(
+        memory_evidence_repair_recovery_closure_governance_seal_audit_preview_tool(
+            {"recovery_closure_governance_seal": _ready_governance_seal()}
+        )
+    )
+
+
+def test_tool_accepts_explicit_seal_audit_markdown():
+    result = json.loads(
+        memory_evidence_repair_recovery_closure_finalization_readiness_preview_tool(
+            {
+                "recovery_closure_governance_seal_audit": _ready_seal_audit(),
+                "format": "markdown",
+            }
+        )
+    )
+
+    assert result["success"] is True
+    assert result["read_only"] is True
+    assert result["read_only_memory"] is True
+    assert result["would_mutate_memory"] is False
+    assert result["status"] == "recovery_closure_finalization_readiness_preview_ready"
+    assert result["summary"]["recovery_closure_finalization_ready"] is True
+    assert result["readiness"][0]["seal_audit_preview_id"].startswith(
+        "recovery-closure-governance-seal-audit-"
+    )
+    assert (
+        "Memory Evidence Repair Recovery Closure Finalization Readiness Preview"
+        in result["markdown"]
+    )
+
+
+def test_tool_accepts_explicit_single_seal_audit_preview():
+    seal_audit = _ready_seal_audit()["previews"][0]
+
+    result = json.loads(
+        memory_evidence_repair_recovery_closure_finalization_readiness_preview_tool(
+            {"seal_audit": seal_audit}
+        )
+    )
+
+    assert result["status"] == "recovery_closure_finalization_readiness_preview_ready"
+    assert result["readiness"][0]["seal_audit_preview_id"] == seal_audit["id"]
+    assert result["readiness"][0]["operation_ids"] == ["dryrun-op-123"]
+
+
+def test_tool_generates_full_chain_from_token_and_creates_finalization_readiness():
+    token_report = _recovery_token_report()
+    token = token_report["tokens"][0]
+    receipt = json.loads(
+        memory_evidence_repair_recovery_completion_receipt_tool(
+            {
+                "recovery_approval_token": token_report,
+                "confirmation_text": token["required_confirmation_text"],
+                "lock_owner": "han",
+                "current_time": "2026-05-11T00:10:00+00:00",
+                "actor": "han",
+                "recovery_reason": "manual post-audit recovery complete",
+            }
+        )
+    )
+    row = receipt["receipts"][0]
+
+    result = json.loads(
+        memory_evidence_repair_recovery_closure_finalization_readiness_preview_tool(
+            {
+                "recovery_approval_token": token_report,
+                "confirmation_text": token["required_confirmation_text"],
+                "lock_owner": "han",
+                "current_time": "2026-05-11T00:10:00+00:00",
+                "actor": "han",
+                "recovery_reason": "manual post-audit recovery complete",
+                "observed_recovery_steps": _observed_recovery_steps(receipt),
+                "recorded_receipts": [{"id": row["id"]}],
+                "used_token_ids": [row["token_id"]],
+                "released_lock_ids": [row["lock_id"]],
+                "post_recovery_audit_status": {"status": "pass"},
+                "contamination_status": {"contaminated": False},
+            }
+        )
+    )
+
+    assert result["status"] == "recovery_closure_finalization_readiness_preview_ready"
+    assert result["summary"]["readiness_count"] == 1
+    assert result["readiness"][0]["operation_ids"] == ["dryrun-op-123"]
+    assert result["readiness"][0]["would_allow_final_closure"] is True
+
+
+def test_tool_blocks_when_generated_seal_audit_is_not_ready():
+    token_report = _recovery_token_report()
+
+    result = json.loads(
+        memory_evidence_repair_recovery_closure_finalization_readiness_preview_tool(
+            {
+                "recovery_approval_token": token_report,
+                "confirmation_text": "wrong confirmation",
+                "current_time": "2026-05-11T00:10:00+00:00",
+            }
+        )
+    )
+
+    assert result["status"] == "blocked"
+    assert result["readiness"] == []
+    assert "provide_exact_recovery_confirmation_text" in result["required_actions"]
+
+
+def test_tool_uses_latest_manager_state_and_blocks_when_no_audit_available():
+    result = json.loads(
+        memory_evidence_repair_recovery_closure_finalization_readiness_preview_tool(
+            {"format": "markdown"},
+            memory_manager=FakeMemoryManager(),
+        )
+    )
+
+    assert result["success"] is True
+    assert result["status"] == "blocked"
+    assert result["readiness"] == []
+    assert result["blocking_reasons"]
+
+
+def test_tool_rejects_invalid_input_shape():
+    result = json.loads(
+        memory_evidence_repair_recovery_closure_finalization_readiness_preview_tool(
+            {"recovery_closure_governance_seal_audit": "bad"}
+        )
+    )
+
+    assert result["success"] is False
+    assert (
+        "recovery_closure_governance_seal_audit must be an object"
+        in result["error"]
+    )
+
+
+def test_tool_without_manager_returns_no_action():
+    result = json.loads(
+        memory_evidence_repair_recovery_closure_finalization_readiness_preview_tool(
+            {}
+        )
+    )
+
+    assert result["success"] is True
+    assert result["status"] == "no_action_needed"
+    assert result["summary"]["readiness_count"] == 0
+
+
+def test_tool_is_registered_under_memory_toolset():
+    entry = registry.get_entry(
+        "memory_evidence_repair_recovery_closure_finalization_readiness_preview"
+    )
+
+    assert entry is not None
+    assert entry.toolset == "memory"

--- a/tests/tools/test_memory_evidence_repair_recovery_closure_gate_tool.py
+++ b/tests/tools/test_memory_evidence_repair_recovery_closure_gate_tool.py
@@ -1,0 +1,178 @@
+import json
+
+from tools.memory_evidence_repair_recovery_closure_gate_tool import (
+    memory_evidence_repair_recovery_closure_gate_tool,
+)
+from tools.memory_evidence_repair_recovery_completion_audit_preview_tool import (
+    memory_evidence_repair_recovery_completion_audit_preview_tool,
+)
+from tools.memory_evidence_repair_recovery_completion_receipt_tool import (
+    memory_evidence_repair_recovery_completion_receipt_tool,
+)
+from tools.registry import registry
+from tests.tools.test_memory_evidence_repair_post_commit_audit_preview_tool import (
+    FakeMemoryManager,
+)
+from tests.tools.test_memory_evidence_repair_recovery_approval_token_gate_tool import (
+    _recovery_token_report,
+)
+from tests.tools.test_memory_evidence_repair_recovery_completion_audit_preview_tool import (
+    _observed_recovery_steps,
+    _recovery_completion_receipt,
+)
+
+
+def _passing_completion_audit():
+    receipt = _recovery_completion_receipt()
+    row = receipt["receipts"][0]
+    return json.loads(
+        memory_evidence_repair_recovery_completion_audit_preview_tool(
+            {
+                "recovery_completion_receipt": receipt,
+                "observed_recovery_steps": _observed_recovery_steps(receipt),
+                "recorded_receipts": [{"id": row["id"]}],
+                "used_token_ids": [row["token_id"]],
+                "released_lock_ids": [row["lock_id"]],
+                "post_recovery_audit_status": {"status": "pass"},
+                "contamination_status": {"contaminated": False},
+            }
+        )
+    )
+
+
+def test_tool_accepts_explicit_passing_completion_audit_markdown():
+    result = json.loads(
+        memory_evidence_repair_recovery_closure_gate_tool(
+            {
+                "recovery_completion_audit": _passing_completion_audit(),
+                "format": "markdown",
+            }
+        )
+    )
+
+    assert result["success"] is True
+    assert result["read_only"] is True
+    assert result["read_only_memory"] is True
+    assert result["would_mutate_memory"] is False
+    assert result["status"] == "recovery_closure_ready"
+    assert result["summary"]["recovery_closure_ready"] is True
+    assert result["closures"][0]["closure_decision"] == "close_recovery_loop"
+    assert "Memory Evidence Repair Recovery Closure Gate" in result["markdown"]
+
+
+def test_tool_blocks_planned_completion_audit_without_observed_state():
+    receipt = _recovery_completion_receipt()
+    planned = json.loads(
+        memory_evidence_repair_recovery_completion_audit_preview_tool(
+            {"recovery_completion_receipt": receipt}
+        )
+    )
+
+    result = json.loads(
+        memory_evidence_repair_recovery_closure_gate_tool(
+            {"recovery_completion_audit": planned}
+        )
+    )
+
+    assert result["status"] == "blocked"
+    assert result["closures"] == []
+    assert "provide_observed_recovery_completion_state" in result["required_actions"]
+
+
+def test_tool_generates_completion_audit_from_token_and_creates_closure():
+    token_report = _recovery_token_report()
+    token = token_report["tokens"][0]
+    receipt = json.loads(
+        memory_evidence_repair_recovery_completion_receipt_tool(
+            {
+                "recovery_approval_token": token_report,
+                "confirmation_text": token["required_confirmation_text"],
+                "lock_owner": "han",
+                "current_time": "2026-05-11T00:10:00+00:00",
+                "actor": "han",
+                "recovery_reason": "manual post-audit recovery complete",
+            }
+        )
+    )
+    row = receipt["receipts"][0]
+
+    result = json.loads(
+        memory_evidence_repair_recovery_closure_gate_tool(
+            {
+                "recovery_approval_token": token_report,
+                "confirmation_text": token["required_confirmation_text"],
+                "lock_owner": "han",
+                "current_time": "2026-05-11T00:10:00+00:00",
+                "actor": "han",
+                "recovery_reason": "manual post-audit recovery complete",
+                "observed_recovery_steps": _observed_recovery_steps(receipt),
+                "recorded_receipts": [{"id": row["id"]}],
+                "used_token_ids": [row["token_id"]],
+                "released_lock_ids": [row["lock_id"]],
+                "post_recovery_audit_status": {"status": "pass"},
+                "contamination_status": {"contaminated": False},
+            }
+        )
+    )
+
+    assert result["status"] == "recovery_closure_ready"
+    assert result["summary"]["recovery_closure_available"] is True
+    assert result["closures"][0]["operation_ids"] == ["dryrun-op-123"]
+
+
+def test_tool_blocks_when_generated_completion_audit_is_not_ready():
+    token_report = _recovery_token_report()
+
+    result = json.loads(
+        memory_evidence_repair_recovery_closure_gate_tool(
+            {
+                "recovery_approval_token": token_report,
+                "confirmation_text": "wrong confirmation",
+                "current_time": "2026-05-11T00:10:00+00:00",
+            }
+        )
+    )
+
+    assert result["status"] == "blocked"
+    assert result["closures"] == []
+    assert "provide_exact_recovery_confirmation_text" in result["required_actions"]
+
+
+def test_tool_uses_latest_manager_state_and_blocks_when_no_audit_available():
+    result = json.loads(
+        memory_evidence_repair_recovery_closure_gate_tool(
+            {"format": "markdown"},
+            memory_manager=FakeMemoryManager(),
+        )
+    )
+
+    assert result["success"] is True
+    assert result["status"] == "blocked"
+    assert result["closures"] == []
+    assert result["blocking_reasons"]
+
+
+def test_tool_rejects_invalid_input_shape():
+    result = json.loads(
+        memory_evidence_repair_recovery_closure_gate_tool(
+            {"recovery_completion_audit": "bad"}
+        )
+    )
+
+    assert result["success"] is False
+    assert "recovery_completion_audit must be an object" in result["error"]
+
+
+def test_tool_without_manager_returns_no_action():
+    result = json.loads(memory_evidence_repair_recovery_closure_gate_tool({}))
+
+    assert result["success"] is True
+    assert result["status"] == "no_action_needed"
+    assert result["summary"]["closure_count"] == 0
+
+
+def test_tool_is_registered_under_memory_toolset():
+    entry = registry.get_entry("memory_evidence_repair_recovery_closure_gate")
+
+    assert entry is not None
+    assert entry.toolset == "memory"

--- a/tests/tools/test_memory_evidence_repair_recovery_closure_governance_seal_audit_preview_tool.py
+++ b/tests/tools/test_memory_evidence_repair_recovery_closure_governance_seal_audit_preview_tool.py
@@ -1,0 +1,174 @@
+import json
+
+from tools.memory_evidence_repair_recovery_closure_governance_seal_audit_preview_tool import (
+    memory_evidence_repair_recovery_closure_governance_seal_audit_preview_tool,
+)
+from tools.memory_evidence_repair_recovery_closure_governance_seal_preview_tool import (
+    memory_evidence_repair_recovery_closure_governance_seal_preview_tool,
+)
+from tools.memory_evidence_repair_recovery_completion_receipt_tool import (
+    memory_evidence_repair_recovery_completion_receipt_tool,
+)
+from tools.registry import registry
+from tests.tools.test_memory_evidence_repair_post_commit_audit_preview_tool import (
+    FakeMemoryManager,
+)
+from tests.tools.test_memory_evidence_repair_recovery_approval_token_gate_tool import (
+    _recovery_token_report,
+)
+from tests.tools.test_memory_evidence_repair_recovery_closure_governance_seal_preview_tool import (
+    _ready_ledger_audit,
+)
+from tests.tools.test_memory_evidence_repair_recovery_completion_audit_preview_tool import (
+    _observed_recovery_steps,
+)
+
+
+def _ready_governance_seal():
+    return json.loads(
+        memory_evidence_repair_recovery_closure_governance_seal_preview_tool(
+            {"recovery_closure_ledger_audit": _ready_ledger_audit()}
+        )
+    )
+
+
+def test_tool_accepts_explicit_governance_seal_markdown():
+    result = json.loads(
+        memory_evidence_repair_recovery_closure_governance_seal_audit_preview_tool(
+            {
+                "recovery_closure_governance_seal": _ready_governance_seal(),
+                "format": "markdown",
+            }
+        )
+    )
+
+    assert result["success"] is True
+    assert result["read_only"] is True
+    assert result["read_only_memory"] is True
+    assert result["would_mutate_memory"] is False
+    assert result["status"] == "recovery_closure_governance_seal_audit_preview_ready"
+    assert result["summary"]["recovery_closure_governance_seal_audit_ready"] is True
+    assert result["previews"][0]["seal_id"].startswith(
+        "recovery-closure-governance-seal-"
+    )
+    assert "Memory Evidence Repair Recovery Closure Governance Seal Audit Preview" in result[
+        "markdown"
+    ]
+
+
+def test_tool_accepts_explicit_single_seal():
+    seal = _ready_governance_seal()["seals"][0]
+
+    result = json.loads(
+        memory_evidence_repair_recovery_closure_governance_seal_audit_preview_tool(
+            {"seal": seal}
+        )
+    )
+
+    assert result["status"] == "recovery_closure_governance_seal_audit_preview_ready"
+    assert result["previews"][0]["seal_id"] == seal["id"]
+    assert result["previews"][0]["operation_ids"] == ["dryrun-op-123"]
+
+
+def test_tool_generates_full_chain_from_token_and_creates_seal_audit():
+    token_report = _recovery_token_report()
+    token = token_report["tokens"][0]
+    receipt = json.loads(
+        memory_evidence_repair_recovery_completion_receipt_tool(
+            {
+                "recovery_approval_token": token_report,
+                "confirmation_text": token["required_confirmation_text"],
+                "lock_owner": "han",
+                "current_time": "2026-05-11T00:10:00+00:00",
+                "actor": "han",
+                "recovery_reason": "manual post-audit recovery complete",
+            }
+        )
+    )
+    row = receipt["receipts"][0]
+
+    result = json.loads(
+        memory_evidence_repair_recovery_closure_governance_seal_audit_preview_tool(
+            {
+                "recovery_approval_token": token_report,
+                "confirmation_text": token["required_confirmation_text"],
+                "lock_owner": "han",
+                "current_time": "2026-05-11T00:10:00+00:00",
+                "actor": "han",
+                "recovery_reason": "manual post-audit recovery complete",
+                "observed_recovery_steps": _observed_recovery_steps(receipt),
+                "recorded_receipts": [{"id": row["id"]}],
+                "used_token_ids": [row["token_id"]],
+                "released_lock_ids": [row["lock_id"]],
+                "post_recovery_audit_status": {"status": "pass"},
+                "contamination_status": {"contaminated": False},
+            }
+        )
+    )
+
+    assert result["status"] == "recovery_closure_governance_seal_audit_preview_ready"
+    assert result["summary"]["preview_count"] == 1
+    assert result["previews"][0]["operation_ids"] == ["dryrun-op-123"]
+    assert result["previews"][0]["would_verify_governance_handoff"] is True
+
+
+def test_tool_blocks_when_generated_governance_seal_is_not_ready():
+    token_report = _recovery_token_report()
+
+    result = json.loads(
+        memory_evidence_repair_recovery_closure_governance_seal_audit_preview_tool(
+            {
+                "recovery_approval_token": token_report,
+                "confirmation_text": "wrong confirmation",
+                "current_time": "2026-05-11T00:10:00+00:00",
+            }
+        )
+    )
+
+    assert result["status"] == "blocked"
+    assert result["previews"] == []
+    assert "provide_exact_recovery_confirmation_text" in result["required_actions"]
+
+
+def test_tool_uses_latest_manager_state_and_blocks_when_no_audit_available():
+    result = json.loads(
+        memory_evidence_repair_recovery_closure_governance_seal_audit_preview_tool(
+            {"format": "markdown"},
+            memory_manager=FakeMemoryManager(),
+        )
+    )
+
+    assert result["success"] is True
+    assert result["status"] == "blocked"
+    assert result["previews"] == []
+    assert result["blocking_reasons"]
+
+
+def test_tool_rejects_invalid_input_shape():
+    result = json.loads(
+        memory_evidence_repair_recovery_closure_governance_seal_audit_preview_tool(
+            {"recovery_closure_governance_seal": "bad"}
+        )
+    )
+
+    assert result["success"] is False
+    assert "recovery_closure_governance_seal must be an object" in result["error"]
+
+
+def test_tool_without_manager_returns_no_action():
+    result = json.loads(
+        memory_evidence_repair_recovery_closure_governance_seal_audit_preview_tool({})
+    )
+
+    assert result["success"] is True
+    assert result["status"] == "no_action_needed"
+    assert result["summary"]["preview_count"] == 0
+
+
+def test_tool_is_registered_under_memory_toolset():
+    entry = registry.get_entry(
+        "memory_evidence_repair_recovery_closure_governance_seal_audit_preview"
+    )
+
+    assert entry is not None
+    assert entry.toolset == "memory"

--- a/tests/tools/test_memory_evidence_repair_recovery_closure_governance_seal_preview_tool.py
+++ b/tests/tools/test_memory_evidence_repair_recovery_closure_governance_seal_preview_tool.py
@@ -1,0 +1,174 @@
+import json
+
+from tools.memory_evidence_repair_recovery_closure_governance_seal_preview_tool import (
+    memory_evidence_repair_recovery_closure_governance_seal_preview_tool,
+)
+from tools.memory_evidence_repair_recovery_closure_ledger_audit_preview_tool import (
+    memory_evidence_repair_recovery_closure_ledger_audit_preview_tool,
+)
+from tools.memory_evidence_repair_recovery_completion_receipt_tool import (
+    memory_evidence_repair_recovery_completion_receipt_tool,
+)
+from tools.registry import registry
+from tests.tools.test_memory_evidence_repair_post_commit_audit_preview_tool import (
+    FakeMemoryManager,
+)
+from tests.tools.test_memory_evidence_repair_recovery_approval_token_gate_tool import (
+    _recovery_token_report,
+)
+from tests.tools.test_memory_evidence_repair_recovery_closure_ledger_audit_preview_tool import (
+    _ready_ledger_preview,
+)
+from tests.tools.test_memory_evidence_repair_recovery_completion_audit_preview_tool import (
+    _observed_recovery_steps,
+)
+
+
+def _ready_ledger_audit():
+    return json.loads(
+        memory_evidence_repair_recovery_closure_ledger_audit_preview_tool(
+            {"recovery_closure_ledger": _ready_ledger_preview()}
+        )
+    )
+
+
+def test_tool_accepts_explicit_ledger_audit_markdown():
+    result = json.loads(
+        memory_evidence_repair_recovery_closure_governance_seal_preview_tool(
+            {
+                "recovery_closure_ledger_audit": _ready_ledger_audit(),
+                "format": "markdown",
+            }
+        )
+    )
+
+    assert result["success"] is True
+    assert result["read_only"] is True
+    assert result["read_only_memory"] is True
+    assert result["would_mutate_memory"] is False
+    assert result["status"] == "recovery_closure_governance_seal_preview_ready"
+    assert result["summary"]["recovery_closure_governance_seal_ready"] is True
+    assert result["seals"][0]["seal_type"] == (
+        "memory_evidence_repair_recovery_closure_governance_seal"
+    )
+    assert "Memory Evidence Repair Recovery Closure Governance Seal Preview" in result[
+        "markdown"
+    ]
+
+
+def test_tool_accepts_explicit_ledger_audit_preview():
+    preview = _ready_ledger_audit()["previews"][0]
+
+    result = json.loads(
+        memory_evidence_repair_recovery_closure_governance_seal_preview_tool(
+            {"ledger_audit_preview": preview}
+        )
+    )
+
+    assert result["status"] == "recovery_closure_governance_seal_preview_ready"
+    assert result["seals"][0]["ledger_audit_preview_id"] == preview["id"]
+    assert result["seals"][0]["operation_ids"] == ["dryrun-op-123"]
+
+
+def test_tool_generates_full_chain_from_token_and_creates_governance_seal():
+    token_report = _recovery_token_report()
+    token = token_report["tokens"][0]
+    receipt = json.loads(
+        memory_evidence_repair_recovery_completion_receipt_tool(
+            {
+                "recovery_approval_token": token_report,
+                "confirmation_text": token["required_confirmation_text"],
+                "lock_owner": "han",
+                "current_time": "2026-05-11T00:10:00+00:00",
+                "actor": "han",
+                "recovery_reason": "manual post-audit recovery complete",
+            }
+        )
+    )
+    row = receipt["receipts"][0]
+
+    result = json.loads(
+        memory_evidence_repair_recovery_closure_governance_seal_preview_tool(
+            {
+                "recovery_approval_token": token_report,
+                "confirmation_text": token["required_confirmation_text"],
+                "lock_owner": "han",
+                "current_time": "2026-05-11T00:10:00+00:00",
+                "actor": "han",
+                "recovery_reason": "manual post-audit recovery complete",
+                "observed_recovery_steps": _observed_recovery_steps(receipt),
+                "recorded_receipts": [{"id": row["id"]}],
+                "used_token_ids": [row["token_id"]],
+                "released_lock_ids": [row["lock_id"]],
+                "post_recovery_audit_status": {"status": "pass"},
+                "contamination_status": {"contaminated": False},
+            }
+        )
+    )
+
+    assert result["status"] == "recovery_closure_governance_seal_preview_ready"
+    assert result["summary"]["seal_count"] == 1
+    assert result["seals"][0]["operation_ids"] == ["dryrun-op-123"]
+    assert result["seals"][0]["would_enable_governed_handoff"] is True
+
+
+def test_tool_blocks_when_generated_ledger_audit_is_not_ready():
+    token_report = _recovery_token_report()
+
+    result = json.loads(
+        memory_evidence_repair_recovery_closure_governance_seal_preview_tool(
+            {
+                "recovery_approval_token": token_report,
+                "confirmation_text": "wrong confirmation",
+                "current_time": "2026-05-11T00:10:00+00:00",
+            }
+        )
+    )
+
+    assert result["status"] == "blocked"
+    assert result["seals"] == []
+    assert "provide_exact_recovery_confirmation_text" in result["required_actions"]
+
+
+def test_tool_uses_latest_manager_state_and_blocks_when_no_seal_available():
+    result = json.loads(
+        memory_evidence_repair_recovery_closure_governance_seal_preview_tool(
+            {"format": "markdown"},
+            memory_manager=FakeMemoryManager(),
+        )
+    )
+
+    assert result["success"] is True
+    assert result["status"] == "blocked"
+    assert result["seals"] == []
+    assert result["blocking_reasons"]
+
+
+def test_tool_rejects_invalid_input_shape():
+    result = json.loads(
+        memory_evidence_repair_recovery_closure_governance_seal_preview_tool(
+            {"recovery_closure_ledger_audit": "bad"}
+        )
+    )
+
+    assert result["success"] is False
+    assert "recovery_closure_ledger_audit must be an object" in result["error"]
+
+
+def test_tool_without_manager_returns_no_action():
+    result = json.loads(
+        memory_evidence_repair_recovery_closure_governance_seal_preview_tool({})
+    )
+
+    assert result["success"] is True
+    assert result["status"] == "no_action_needed"
+    assert result["summary"]["seal_count"] == 0
+
+
+def test_tool_is_registered_under_memory_toolset():
+    entry = registry.get_entry(
+        "memory_evidence_repair_recovery_closure_governance_seal_preview"
+    )
+
+    assert entry is not None
+    assert entry.toolset == "memory"

--- a/tests/tools/test_memory_evidence_repair_recovery_closure_ledger_audit_preview_tool.py
+++ b/tests/tools/test_memory_evidence_repair_recovery_closure_ledger_audit_preview_tool.py
@@ -1,0 +1,172 @@
+import json
+
+from tools.memory_evidence_repair_recovery_closure_ledger_audit_preview_tool import (
+    memory_evidence_repair_recovery_closure_ledger_audit_preview_tool,
+)
+from tools.memory_evidence_repair_recovery_closure_ledger_preview_tool import (
+    memory_evidence_repair_recovery_closure_ledger_preview_tool,
+)
+from tools.memory_evidence_repair_recovery_completion_receipt_tool import (
+    memory_evidence_repair_recovery_completion_receipt_tool,
+)
+from tools.registry import registry
+from tests.tools.test_memory_evidence_repair_post_commit_audit_preview_tool import (
+    FakeMemoryManager,
+)
+from tests.tools.test_memory_evidence_repair_recovery_approval_token_gate_tool import (
+    _recovery_token_report,
+)
+from tests.tools.test_memory_evidence_repair_recovery_closure_ledger_preview_tool import (
+    _ready_closure_gate,
+)
+from tests.tools.test_memory_evidence_repair_recovery_completion_audit_preview_tool import (
+    _observed_recovery_steps,
+)
+
+
+def _ready_ledger_preview():
+    return json.loads(
+        memory_evidence_repair_recovery_closure_ledger_preview_tool(
+            {"recovery_closure_gate": _ready_closure_gate()}
+        )
+    )
+
+
+def test_tool_accepts_explicit_recovery_closure_ledger_markdown():
+    result = json.loads(
+        memory_evidence_repair_recovery_closure_ledger_audit_preview_tool(
+            {
+                "recovery_closure_ledger": _ready_ledger_preview(),
+                "format": "markdown",
+            }
+        )
+    )
+
+    assert result["success"] is True
+    assert result["read_only"] is True
+    assert result["read_only_memory"] is True
+    assert result["would_mutate_memory"] is False
+    assert result["status"] == "recovery_closure_ledger_audit_preview_ready"
+    assert result["summary"]["recovery_closure_ledger_audit_ready"] is True
+    assert result["previews"][0]["ledger_entry_id"].startswith(
+        "recovery-closure-ledger-"
+    )
+    assert "Memory Evidence Repair Recovery Closure Ledger Audit Preview" in result[
+        "markdown"
+    ]
+
+
+def test_tool_accepts_explicit_recovery_closure_ledger_entry():
+    entry = _ready_ledger_preview()["entries"][0]
+
+    result = json.loads(
+        memory_evidence_repair_recovery_closure_ledger_audit_preview_tool(
+            {"recovery_closure_ledger_entry": entry}
+        )
+    )
+
+    assert result["status"] == "recovery_closure_ledger_audit_preview_ready"
+    assert result["previews"][0]["ledger_entry_id"] == entry["id"]
+    assert result["previews"][0]["operation_ids"] == ["dryrun-op-123"]
+
+
+def test_tool_generates_ledger_chain_from_token_and_creates_audit_preview():
+    token_report = _recovery_token_report()
+    token = token_report["tokens"][0]
+    receipt = json.loads(
+        memory_evidence_repair_recovery_completion_receipt_tool(
+            {
+                "recovery_approval_token": token_report,
+                "confirmation_text": token["required_confirmation_text"],
+                "lock_owner": "han",
+                "current_time": "2026-05-11T00:10:00+00:00",
+                "actor": "han",
+                "recovery_reason": "manual post-audit recovery complete",
+            }
+        )
+    )
+    row = receipt["receipts"][0]
+
+    result = json.loads(
+        memory_evidence_repair_recovery_closure_ledger_audit_preview_tool(
+            {
+                "recovery_approval_token": token_report,
+                "confirmation_text": token["required_confirmation_text"],
+                "lock_owner": "han",
+                "current_time": "2026-05-11T00:10:00+00:00",
+                "actor": "han",
+                "recovery_reason": "manual post-audit recovery complete",
+                "observed_recovery_steps": _observed_recovery_steps(receipt),
+                "recorded_receipts": [{"id": row["id"]}],
+                "used_token_ids": [row["token_id"]],
+                "released_lock_ids": [row["lock_id"]],
+                "post_recovery_audit_status": {"status": "pass"},
+                "contamination_status": {"contaminated": False},
+            }
+        )
+    )
+
+    assert result["status"] == "recovery_closure_ledger_audit_preview_ready"
+    assert result["summary"]["preview_count"] == 1
+    assert result["previews"][0]["operation_ids"] == ["dryrun-op-123"]
+    assert result["previews"][0]["would_verify_lifecycle_milestones"] is True
+
+
+def test_tool_blocks_when_generated_ledger_preview_is_not_ready():
+    token_report = _recovery_token_report()
+
+    result = json.loads(
+        memory_evidence_repair_recovery_closure_ledger_audit_preview_tool(
+            {
+                "recovery_approval_token": token_report,
+                "confirmation_text": "wrong confirmation",
+                "current_time": "2026-05-11T00:10:00+00:00",
+            }
+        )
+    )
+
+    assert result["status"] == "blocked"
+    assert result["previews"] == []
+    assert "provide_exact_recovery_confirmation_text" in result["required_actions"]
+
+
+def test_tool_uses_latest_manager_state_and_blocks_when_no_ledger_available():
+    result = json.loads(
+        memory_evidence_repair_recovery_closure_ledger_audit_preview_tool(
+            {"format": "markdown"},
+            memory_manager=FakeMemoryManager(),
+        )
+    )
+
+    assert result["success"] is True
+    assert result["status"] == "blocked"
+    assert result["previews"] == []
+    assert result["blocking_reasons"]
+
+
+def test_tool_rejects_invalid_input_shape():
+    result = json.loads(
+        memory_evidence_repair_recovery_closure_ledger_audit_preview_tool(
+            {"recovery_closure_ledger": "bad"}
+        )
+    )
+
+    assert result["success"] is False
+    assert "recovery_closure_ledger must be an object" in result["error"]
+
+
+def test_tool_without_manager_returns_no_action():
+    result = json.loads(
+        memory_evidence_repair_recovery_closure_ledger_audit_preview_tool({})
+    )
+
+    assert result["success"] is True
+    assert result["status"] == "no_action_needed"
+    assert result["summary"]["preview_count"] == 0
+
+
+def test_tool_is_registered_under_memory_toolset():
+    entry = registry.get_entry("memory_evidence_repair_recovery_closure_ledger_audit_preview")
+
+    assert entry is not None
+    assert entry.toolset == "memory"

--- a/tests/tools/test_memory_evidence_repair_recovery_closure_ledger_preview_tool.py
+++ b/tests/tools/test_memory_evidence_repair_recovery_closure_ledger_preview_tool.py
@@ -1,0 +1,168 @@
+import json
+
+from tools.memory_evidence_repair_recovery_closure_gate_tool import (
+    memory_evidence_repair_recovery_closure_gate_tool,
+)
+from tools.memory_evidence_repair_recovery_closure_ledger_preview_tool import (
+    memory_evidence_repair_recovery_closure_ledger_preview_tool,
+)
+from tools.memory_evidence_repair_recovery_completion_receipt_tool import (
+    memory_evidence_repair_recovery_completion_receipt_tool,
+)
+from tools.registry import registry
+from tests.tools.test_memory_evidence_repair_post_commit_audit_preview_tool import (
+    FakeMemoryManager,
+)
+from tests.tools.test_memory_evidence_repair_recovery_approval_token_gate_tool import (
+    _recovery_token_report,
+)
+from tests.tools.test_memory_evidence_repair_recovery_closure_gate_tool import (
+    _passing_completion_audit,
+)
+from tests.tools.test_memory_evidence_repair_recovery_completion_audit_preview_tool import (
+    _observed_recovery_steps,
+)
+
+
+def _ready_closure_gate():
+    return json.loads(
+        memory_evidence_repair_recovery_closure_gate_tool(
+            {"recovery_completion_audit": _passing_completion_audit()}
+        )
+    )
+
+
+def test_tool_accepts_explicit_recovery_closure_gate_markdown():
+    result = json.loads(
+        memory_evidence_repair_recovery_closure_ledger_preview_tool(
+            {
+                "recovery_closure_gate": _ready_closure_gate(),
+                "format": "markdown",
+            }
+        )
+    )
+
+    assert result["success"] is True
+    assert result["read_only"] is True
+    assert result["read_only_memory"] is True
+    assert result["would_mutate_memory"] is False
+    assert result["status"] == "recovery_closure_ledger_preview_ready"
+    assert result["summary"]["recovery_closure_ledger_ready"] is True
+    assert result["entries"][0]["entry_type"] == (
+        "memory_evidence_repair_recovery_closure_ledger_entry"
+    )
+    assert "Memory Evidence Repair Recovery Closure Ledger Preview" in result["markdown"]
+
+
+def test_tool_accepts_explicit_recovery_closure_draft():
+    closure = _ready_closure_gate()["closures"][0]
+
+    result = json.loads(
+        memory_evidence_repair_recovery_closure_ledger_preview_tool(
+            {"recovery_closure": closure}
+        )
+    )
+
+    assert result["status"] == "recovery_closure_ledger_preview_ready"
+    assert result["entries"][0]["closure_id"] == closure["id"]
+    assert result["entries"][0]["operation_ids"] == ["dryrun-op-123"]
+
+
+def test_tool_generates_closure_chain_from_token_and_creates_ledger_entry():
+    token_report = _recovery_token_report()
+    token = token_report["tokens"][0]
+    receipt = json.loads(
+        memory_evidence_repair_recovery_completion_receipt_tool(
+            {
+                "recovery_approval_token": token_report,
+                "confirmation_text": token["required_confirmation_text"],
+                "lock_owner": "han",
+                "current_time": "2026-05-11T00:10:00+00:00",
+                "actor": "han",
+                "recovery_reason": "manual post-audit recovery complete",
+            }
+        )
+    )
+    row = receipt["receipts"][0]
+
+    result = json.loads(
+        memory_evidence_repair_recovery_closure_ledger_preview_tool(
+            {
+                "recovery_approval_token": token_report,
+                "confirmation_text": token["required_confirmation_text"],
+                "lock_owner": "han",
+                "current_time": "2026-05-11T00:10:00+00:00",
+                "actor": "han",
+                "recovery_reason": "manual post-audit recovery complete",
+                "observed_recovery_steps": _observed_recovery_steps(receipt),
+                "recorded_receipts": [{"id": row["id"]}],
+                "used_token_ids": [row["token_id"]],
+                "released_lock_ids": [row["lock_id"]],
+                "post_recovery_audit_status": {"status": "pass"},
+                "contamination_status": {"contaminated": False},
+            }
+        )
+    )
+
+    assert result["status"] == "recovery_closure_ledger_preview_ready"
+    assert result["summary"]["entry_count"] == 1
+    assert result["entries"][0]["operation_ids"] == ["dryrun-op-123"]
+    assert result["entries"][0]["would_record_ledger_entry"] is True
+
+
+def test_tool_blocks_when_generated_closure_gate_is_not_ready():
+    token_report = _recovery_token_report()
+
+    result = json.loads(
+        memory_evidence_repair_recovery_closure_ledger_preview_tool(
+            {
+                "recovery_approval_token": token_report,
+                "confirmation_text": "wrong confirmation",
+                "current_time": "2026-05-11T00:10:00+00:00",
+            }
+        )
+    )
+
+    assert result["status"] == "blocked"
+    assert result["entries"] == []
+    assert "provide_exact_recovery_confirmation_text" in result["required_actions"]
+
+
+def test_tool_uses_latest_manager_state_and_blocks_when_no_closure_available():
+    result = json.loads(
+        memory_evidence_repair_recovery_closure_ledger_preview_tool(
+            {"format": "markdown"},
+            memory_manager=FakeMemoryManager(),
+        )
+    )
+
+    assert result["success"] is True
+    assert result["status"] == "blocked"
+    assert result["entries"] == []
+    assert result["blocking_reasons"]
+
+
+def test_tool_rejects_invalid_input_shape():
+    result = json.loads(
+        memory_evidence_repair_recovery_closure_ledger_preview_tool(
+            {"recovery_closure_gate": "bad"}
+        )
+    )
+
+    assert result["success"] is False
+    assert "recovery_closure_gate must be an object" in result["error"]
+
+
+def test_tool_without_manager_returns_no_action():
+    result = json.loads(memory_evidence_repair_recovery_closure_ledger_preview_tool({}))
+
+    assert result["success"] is True
+    assert result["status"] == "no_action_needed"
+    assert result["summary"]["entry_count"] == 0
+
+
+def test_tool_is_registered_under_memory_toolset():
+    entry = registry.get_entry("memory_evidence_repair_recovery_closure_ledger_preview")
+
+    assert entry is not None
+    assert entry.toolset == "memory"

--- a/tests/tools/test_memory_evidence_repair_recovery_completion_audit_preview_tool.py
+++ b/tests/tools/test_memory_evidence_repair_recovery_completion_audit_preview_tool.py
@@ -1,0 +1,182 @@
+import json
+
+from tools.memory_evidence_repair_recovery_completion_audit_preview_tool import (
+    memory_evidence_repair_recovery_completion_audit_preview_tool,
+)
+from tools.memory_evidence_repair_recovery_completion_receipt_tool import (
+    memory_evidence_repair_recovery_completion_receipt_tool,
+)
+from tools.registry import registry
+from tests.tools.test_memory_evidence_repair_post_commit_audit_preview_tool import (
+    FakeMemoryManager,
+)
+from tests.tools.test_memory_evidence_repair_recovery_approval_token_gate_tool import (
+    _recovery_token_report,
+)
+from tests.tools.test_memory_evidence_repair_recovery_completion_receipt_tool import (
+    _recovery_executor_preview,
+)
+
+
+def _recovery_completion_receipt():
+    return json.loads(
+        memory_evidence_repair_recovery_completion_receipt_tool(
+            {
+                "recovery_executor_preview": _recovery_executor_preview(),
+                "actor": "han",
+                "recovery_reason": "manual post-audit recovery complete",
+            }
+        )
+    )
+
+
+def _observed_recovery_steps(receipt):
+    return {
+        step_id: {"status": "completed"}
+        for step_id in receipt["receipts"][0]["recovery_step_ids"]
+    }
+
+
+def test_tool_accepts_explicit_recovery_completion_receipt_markdown():
+    result = json.loads(
+        memory_evidence_repair_recovery_completion_audit_preview_tool(
+            {
+                "recovery_completion_receipt": _recovery_completion_receipt(),
+                "format": "markdown",
+            }
+        )
+    )
+
+    assert result["success"] is True
+    assert result["read_only"] is True
+    assert result["read_only_memory"] is True
+    assert result["would_mutate_memory"] is False
+    assert result["status"] == "recovery_completion_audit_preview_ready"
+    assert result["summary"]["planned_audit_step_count"] == 12
+    assert "Memory Evidence Repair Recovery Completion Audit Preview" in result["markdown"]
+
+
+def test_tool_accepts_observed_recovery_completion_state_and_passes():
+    receipt = _recovery_completion_receipt()
+    row = receipt["receipts"][0]
+
+    result = json.loads(
+        memory_evidence_repair_recovery_completion_audit_preview_tool(
+            {
+                "recovery_completion_receipt": receipt,
+                "observed_recovery_steps": _observed_recovery_steps(receipt),
+                "recorded_receipts": [{"id": row["id"]}],
+                "used_token_ids": [row["token_id"]],
+                "released_lock_ids": [row["lock_id"]],
+                "post_recovery_audit_status": {"status": "pass"},
+                "contamination_status": {"contaminated": False},
+            }
+        )
+    )
+
+    assert result["status"] == "recovery_completion_audit_preview_ready"
+    assert result["summary"]["observed_pass_step_count"] == 12
+    assert result["summary"]["observed_fail_step_count"] == 0
+
+
+def test_tool_blocks_bad_observed_contamination_status():
+    receipt = _recovery_completion_receipt()
+    row = receipt["receipts"][0]
+
+    result = json.loads(
+        memory_evidence_repair_recovery_completion_audit_preview_tool(
+            {
+                "recovery_completion_receipt": receipt,
+                "observed_recovery_steps": _observed_recovery_steps(receipt),
+                "recorded_receipts": [{"id": row["id"]}],
+                "used_token_ids": [row["token_id"]],
+                "released_lock_ids": [row["lock_id"]],
+                "post_recovery_audit_status": {"status": "pass"},
+                "contamination_status": {"contaminated": True},
+            }
+        )
+    )
+
+    assert result["status"] == "blocked"
+    assert result["previews"] == []
+    assert "investigate_recovery_completion_audit_failures" in result["required_actions"]
+
+
+def test_tool_generates_recovery_completion_receipt_from_token():
+    token_report = _recovery_token_report()
+    token = token_report["tokens"][0]
+
+    result = json.loads(
+        memory_evidence_repair_recovery_completion_audit_preview_tool(
+            {
+                "recovery_approval_token": token_report,
+                "confirmation_text": token["required_confirmation_text"],
+                "lock_owner": "han",
+                "current_time": "2026-05-11T00:10:00+00:00",
+                "actor": "han",
+            }
+        )
+    )
+
+    assert result["status"] == "recovery_completion_audit_preview_ready"
+    assert result["summary"]["recovery_completion_audit_preview_available"] is True
+
+
+def test_tool_blocks_when_generated_recovery_completion_receipt_is_not_ready():
+    token_report = _recovery_token_report()
+
+    result = json.loads(
+        memory_evidence_repair_recovery_completion_audit_preview_tool(
+            {
+                "recovery_approval_token": token_report,
+                "confirmation_text": "wrong confirmation",
+                "current_time": "2026-05-11T00:10:00+00:00",
+            }
+        )
+    )
+
+    assert result["status"] == "blocked"
+    assert result["previews"] == []
+    assert "provide_exact_recovery_confirmation_text" in result["required_actions"]
+
+
+def test_tool_uses_latest_manager_state_and_blocks_when_no_receipt_available():
+    result = json.loads(
+        memory_evidence_repair_recovery_completion_audit_preview_tool(
+            {"format": "markdown"},
+            memory_manager=FakeMemoryManager(),
+        )
+    )
+
+    assert result["success"] is True
+    assert result["status"] == "blocked"
+    assert result["previews"] == []
+    assert result["blocking_reasons"]
+
+
+def test_tool_rejects_invalid_input_shape():
+    result = json.loads(
+        memory_evidence_repair_recovery_completion_audit_preview_tool(
+            {"recovery_completion_receipt": "bad"}
+        )
+    )
+
+    assert result["success"] is False
+    assert "recovery_completion_receipt must be an object" in result["error"]
+
+
+def test_tool_without_manager_returns_no_action():
+    result = json.loads(
+        memory_evidence_repair_recovery_completion_audit_preview_tool({})
+    )
+
+    assert result["success"] is True
+    assert result["status"] == "no_action_needed"
+    assert result["summary"]["preview_count"] == 0
+
+
+def test_tool_is_registered_under_memory_toolset():
+    entry = registry.get_entry("memory_evidence_repair_recovery_completion_audit_preview")
+
+    assert entry is not None
+    assert entry.toolset == "memory"

--- a/tests/tools/test_memory_evidence_repair_recovery_completion_receipt_tool.py
+++ b/tests/tools/test_memory_evidence_repair_recovery_completion_receipt_tool.py
@@ -1,0 +1,167 @@
+import json
+
+from tools.memory_evidence_repair_recovery_completion_receipt_tool import (
+    memory_evidence_repair_recovery_completion_receipt_tool,
+)
+from tools.memory_evidence_repair_recovery_executor_preview_tool import (
+    memory_evidence_repair_recovery_executor_preview_tool,
+)
+from tools.registry import registry
+from tests.tools.test_memory_evidence_repair_post_commit_audit_preview_tool import (
+    FakeMemoryManager,
+)
+from tests.tools.test_memory_evidence_repair_recovery_approval_token_gate_tool import (
+    _recovery_token_report,
+)
+from tests.tools.test_memory_evidence_repair_recovery_executor_preview_tool import (
+    _recovery_write_lock_gate,
+)
+
+
+def _recovery_executor_preview():
+    return json.loads(
+        memory_evidence_repair_recovery_executor_preview_tool(
+            {
+                "recovery_write_lock_gate": _recovery_write_lock_gate(),
+                "current_time": "2026-05-11T00:12:00+00:00",
+            }
+        )
+    )
+
+
+def test_tool_accepts_explicit_recovery_executor_preview_markdown():
+    result = json.loads(
+        memory_evidence_repair_recovery_completion_receipt_tool(
+            {
+                "recovery_executor_preview": _recovery_executor_preview(),
+                "actor": "han",
+                "recovery_reason": "manual post-audit recovery complete",
+                "format": "markdown",
+            }
+        )
+    )
+
+    assert result["success"] is True
+    assert result["read_only"] is True
+    assert result["read_only_memory"] is True
+    assert result["would_mutate_memory"] is False
+    assert result["status"] == "recovery_completion_receipt_ready"
+    assert result["summary"]["recovery_completion_receipt_available"] is True
+    assert result["receipts"][0]["actor"] == "han"
+    assert result["receipts"][0]["operation_ids"] == ["dryrun-op-123"]
+    assert "Memory Evidence Repair Recovery Completion Receipt" in result["markdown"]
+
+
+def test_tool_blocks_when_recovery_token_already_used():
+    executor_preview = _recovery_executor_preview()
+    token_id = executor_preview["previews"][0]["token_id"]
+
+    result = json.loads(
+        memory_evidence_repair_recovery_completion_receipt_tool(
+            {
+                "recovery_executor_preview": executor_preview,
+                "used_token_ids": [token_id],
+            }
+        )
+    )
+
+    assert result["status"] == "blocked"
+    assert result["receipts"] == []
+    assert "regenerate_recovery_human_approval_token" in result["required_actions"]
+
+
+def test_tool_blocks_when_recovery_lock_already_released():
+    executor_preview = _recovery_executor_preview()
+    lock_id = executor_preview["previews"][0]["lock_id"]
+
+    result = json.loads(
+        memory_evidence_repair_recovery_completion_receipt_tool(
+            {
+                "recovery_executor_preview": executor_preview,
+                "released_lock_ids": [lock_id],
+            }
+        )
+    )
+
+    assert result["status"] == "blocked"
+    assert result["receipts"] == []
+    assert "regenerate_recovery_write_lock_gate" in result["required_actions"]
+
+
+def test_tool_generates_recovery_executor_preview_from_token_and_creates_receipt():
+    token_report = _recovery_token_report()
+    token = token_report["tokens"][0]
+
+    result = json.loads(
+        memory_evidence_repair_recovery_completion_receipt_tool(
+            {
+                "recovery_approval_token": token_report,
+                "confirmation_text": token["required_confirmation_text"],
+                "lock_owner": "han",
+                "current_time": "2026-05-11T00:10:00+00:00",
+                "actor": "han",
+            }
+        )
+    )
+
+    assert result["status"] == "recovery_completion_receipt_ready"
+    assert result["summary"]["would_record_receipt_count"] == 1
+    assert result["receipts"][0]["token_id"] == token["id"]
+
+
+def test_tool_blocks_when_generated_recovery_executor_preview_is_not_ready():
+    token_report = _recovery_token_report()
+
+    result = json.loads(
+        memory_evidence_repair_recovery_completion_receipt_tool(
+            {
+                "recovery_approval_token": token_report,
+                "confirmation_text": "wrong confirmation",
+                "current_time": "2026-05-11T00:10:00+00:00",
+            }
+        )
+    )
+
+    assert result["status"] == "blocked"
+    assert result["receipts"] == []
+    assert "provide_exact_recovery_confirmation_text" in result["required_actions"]
+
+
+def test_tool_uses_latest_manager_state_and_blocks_when_no_executor_available():
+    result = json.loads(
+        memory_evidence_repair_recovery_completion_receipt_tool(
+            {"format": "markdown"},
+            memory_manager=FakeMemoryManager(),
+        )
+    )
+
+    assert result["success"] is True
+    assert result["status"] == "blocked"
+    assert result["receipts"] == []
+    assert result["blocking_reasons"]
+
+
+def test_tool_rejects_invalid_input_shape():
+    result = json.loads(
+        memory_evidence_repair_recovery_completion_receipt_tool(
+            {"recovery_executor_preview": "bad"}
+        )
+    )
+
+    assert result["success"] is False
+    assert "recovery_executor_preview must be an object" in result["error"]
+
+
+def test_tool_without_manager_returns_no_action():
+    result = json.loads(memory_evidence_repair_recovery_completion_receipt_tool({}))
+
+    assert result["success"] is True
+    assert result["status"] == "no_action_needed"
+    assert result["summary"]["receipt_count"] == 0
+
+
+def test_tool_is_registered_under_memory_toolset():
+    entry = registry.get_entry("memory_evidence_repair_recovery_completion_receipt")
+
+    assert entry is not None
+    assert entry.toolset == "memory"

--- a/tests/tools/test_memory_evidence_repair_recovery_decision_gate_tool.py
+++ b/tests/tools/test_memory_evidence_repair_recovery_decision_gate_tool.py
@@ -1,0 +1,145 @@
+import json
+
+from tools.memory_evidence_repair_recovery_decision_gate_tool import (
+    memory_evidence_repair_recovery_decision_gate_tool,
+)
+from tools.memory_evidence_repair_rollback_drill_preview_tool import (
+    memory_evidence_repair_rollback_drill_preview_tool,
+)
+from tools.registry import registry
+from tests.tools.test_memory_evidence_repair_post_commit_audit_preview_tool import (
+    FakeMemoryManager,
+    _executor_preview,
+    _token_report,
+)
+from tests.tools.test_memory_evidence_repair_rollback_drill_preview_tool import (
+    _failed_post_commit_audit,
+)
+
+
+def _preparedness_drill():
+    return json.loads(
+        memory_evidence_repair_rollback_drill_preview_tool(
+            {
+                "executor_preview": _executor_preview(),
+            }
+        )
+    )
+
+
+def _failure_drill():
+    return json.loads(
+        memory_evidence_repair_rollback_drill_preview_tool(
+            {
+                "post_commit_audit": _failed_post_commit_audit(),
+            }
+        )
+    )
+
+
+def test_tool_accepts_explicit_rollback_drill_markdown():
+    result = json.loads(
+        memory_evidence_repair_recovery_decision_gate_tool(
+            {
+                "rollback_drill": _preparedness_drill(),
+                "format": "markdown",
+            }
+        )
+    )
+
+    assert result["success"] is True
+    assert result["read_only"] is True
+    assert result["read_only_memory"] is True
+    assert result["would_mutate_memory"] is False
+    assert result["status"] == "recovery_decision_gate_ready"
+    assert result["decisions"][0]["route"] == "preparedness_review_only"
+    assert "Memory Evidence Repair Recovery Decision Gate" in result["markdown"]
+
+
+def test_tool_accepts_failed_drill_and_requires_manual_rollback():
+    result = json.loads(
+        memory_evidence_repair_recovery_decision_gate_tool(
+            {
+                "rollback_drill": _failure_drill(),
+            }
+        )
+    )
+
+    assert result["status"] == "recovery_decision_gate_ready"
+    assert result["summary"]["manual_rollback_required_count"] == 1
+    assert result["decisions"][0]["route"] == "manual_rollback_required"
+
+
+def test_tool_generates_rollback_drill_from_token():
+    token_report = _token_report()
+    result = json.loads(
+        memory_evidence_repair_recovery_decision_gate_tool(
+            {
+                "approval_token": token_report,
+                "confirmation_text": token_report["tokens"][0]["required_confirmation_text"],
+                "current_time": "2026-05-11T00:10:00+00:00",
+                "actor": "han",
+                "lock_owner": "han",
+            }
+        )
+    )
+
+    assert result["status"] == "recovery_decision_gate_ready"
+    assert result["summary"]["recovery_decision_available"] is True
+
+
+def test_tool_blocks_when_generated_drill_is_not_usable():
+    token_report = _token_report()
+    result = json.loads(
+        memory_evidence_repair_recovery_decision_gate_tool(
+            {
+                "approval_token": token_report,
+                "confirmation_text": "wrong confirmation",
+                "current_time": "2026-05-11T00:10:00+00:00",
+            }
+        )
+    )
+
+    assert result["status"] == "blocked"
+    assert result["decisions"] == []
+    assert "provide_exact_confirmation_text" in result["required_actions"]
+
+
+def test_tool_uses_latest_manager_state_and_blocks_when_no_drill_available():
+    result = json.loads(
+        memory_evidence_repair_recovery_decision_gate_tool(
+            {"format": "markdown"},
+            memory_manager=FakeMemoryManager(),
+        )
+    )
+
+    assert result["success"] is True
+    assert result["status"] == "blocked"
+    assert result["decisions"] == []
+    assert result["blocking_reasons"]
+
+
+def test_tool_rejects_invalid_input_shape():
+    result = json.loads(
+        memory_evidence_repair_recovery_decision_gate_tool(
+            {"rollback_drill": "bad"}
+        )
+    )
+
+    assert result["success"] is False
+    assert "rollback_drill must be an object" in result["error"]
+
+
+def test_tool_without_manager_returns_no_action():
+    result = json.loads(memory_evidence_repair_recovery_decision_gate_tool({}))
+
+    assert result["success"] is True
+    assert result["status"] == "no_action_needed"
+    assert result["summary"]["decision_count"] == 0
+
+
+def test_tool_is_registered_under_memory_toolset():
+    entry = registry.get_entry("memory_evidence_repair_recovery_decision_gate")
+
+    assert entry is not None
+    assert entry.toolset == "memory"

--- a/tests/tools/test_memory_evidence_repair_recovery_execution_preview_tool.py
+++ b/tests/tools/test_memory_evidence_repair_recovery_execution_preview_tool.py
@@ -1,0 +1,146 @@
+import json
+
+from tools.memory_evidence_repair_recovery_decision_gate_tool import (
+    memory_evidence_repair_recovery_decision_gate_tool,
+)
+from tools.memory_evidence_repair_recovery_execution_preview_tool import (
+    memory_evidence_repair_recovery_execution_preview_tool,
+)
+from tools.registry import registry
+from tests.tools.test_memory_evidence_repair_post_commit_audit_preview_tool import (
+    FakeMemoryManager,
+    _executor_preview,
+    _token_report,
+)
+from tests.tools.test_memory_evidence_repair_recovery_decision_gate_tool import (
+    _failure_drill,
+)
+
+
+def _preparedness_decision():
+    return json.loads(
+        memory_evidence_repair_recovery_decision_gate_tool(
+            {
+                "executor_preview": _executor_preview(),
+            }
+        )
+    )
+
+
+def _manual_rollback_decision():
+    return json.loads(
+        memory_evidence_repair_recovery_decision_gate_tool(
+            {
+                "rollback_drill": _failure_drill(),
+            }
+        )
+    )
+
+
+def test_tool_accepts_explicit_recovery_decision_markdown():
+    result = json.loads(
+        memory_evidence_repair_recovery_execution_preview_tool(
+            {
+                "recovery_decision": _preparedness_decision(),
+                "format": "markdown",
+            }
+        )
+    )
+
+    assert result["success"] is True
+    assert result["read_only"] is True
+    assert result["read_only_memory"] is True
+    assert result["would_mutate_memory"] is False
+    assert result["status"] == "recovery_execution_preview_ready"
+    assert result["previews"][0]["route"] == "preparedness_review_only"
+    assert "Memory Evidence Repair Recovery Execution Preview" in result["markdown"]
+
+
+def test_tool_accepts_manual_rollback_decision():
+    result = json.loads(
+        memory_evidence_repair_recovery_execution_preview_tool(
+            {
+                "recovery_decision": _manual_rollback_decision(),
+            }
+        )
+    )
+
+    assert result["status"] == "recovery_execution_preview_ready"
+    assert result["summary"]["manual_rollback_preview_count"] == 1
+    assert result["summary"]["future_mutation_step_count"] == 1
+    assert result["previews"][0]["future_would_mutate_memory"] is True
+
+
+def test_tool_generates_recovery_decision_from_token():
+    token_report = _token_report()
+    result = json.loads(
+        memory_evidence_repair_recovery_execution_preview_tool(
+            {
+                "approval_token": token_report,
+                "confirmation_text": token_report["tokens"][0]["required_confirmation_text"],
+                "current_time": "2026-05-11T00:10:00+00:00",
+                "actor": "han",
+                "lock_owner": "han",
+            }
+        )
+    )
+
+    assert result["status"] == "recovery_execution_preview_ready"
+    assert result["summary"]["recovery_execution_preview_available"] is True
+
+
+def test_tool_blocks_when_generated_decision_is_not_usable():
+    token_report = _token_report()
+    result = json.loads(
+        memory_evidence_repair_recovery_execution_preview_tool(
+            {
+                "approval_token": token_report,
+                "confirmation_text": "wrong confirmation",
+                "current_time": "2026-05-11T00:10:00+00:00",
+            }
+        )
+    )
+
+    assert result["status"] == "blocked"
+    assert result["previews"] == []
+    assert "provide_exact_confirmation_text" in result["required_actions"]
+
+
+def test_tool_uses_latest_manager_state_and_blocks_when_no_decision_available():
+    result = json.loads(
+        memory_evidence_repair_recovery_execution_preview_tool(
+            {"format": "markdown"},
+            memory_manager=FakeMemoryManager(),
+        )
+    )
+
+    assert result["success"] is True
+    assert result["status"] == "blocked"
+    assert result["previews"] == []
+    assert result["blocking_reasons"]
+
+
+def test_tool_rejects_invalid_input_shape():
+    result = json.loads(
+        memory_evidence_repair_recovery_execution_preview_tool(
+            {"recovery_decision": "bad"}
+        )
+    )
+
+    assert result["success"] is False
+    assert "recovery_decision must be an object" in result["error"]
+
+
+def test_tool_without_manager_returns_no_action():
+    result = json.loads(memory_evidence_repair_recovery_execution_preview_tool({}))
+
+    assert result["success"] is True
+    assert result["status"] == "no_action_needed"
+    assert result["summary"]["preview_count"] == 0
+
+
+def test_tool_is_registered_under_memory_toolset():
+    entry = registry.get_entry("memory_evidence_repair_recovery_execution_preview")
+
+    assert entry is not None
+    assert entry.toolset == "memory"

--- a/tests/tools/test_memory_evidence_repair_recovery_executor_preview_tool.py
+++ b/tests/tools/test_memory_evidence_repair_recovery_executor_preview_tool.py
@@ -1,0 +1,165 @@
+import json
+
+from tools.memory_evidence_repair_recovery_executor_preview_tool import (
+    memory_evidence_repair_recovery_executor_preview_tool,
+)
+from tools.memory_evidence_repair_recovery_write_lock_gate_tool import (
+    memory_evidence_repair_recovery_write_lock_gate_tool,
+)
+from tools.registry import registry
+from tests.tools.test_memory_evidence_repair_post_commit_audit_preview_tool import (
+    FakeMemoryManager,
+)
+from tests.tools.test_memory_evidence_repair_recovery_approval_token_gate_tool import (
+    _recovery_token_report,
+)
+from tests.tools.test_memory_evidence_repair_recovery_human_approval_token_tool import (
+    _preparedness_execution,
+)
+
+
+def _recovery_write_lock_gate():
+    token_report = _recovery_token_report()
+    token = token_report["tokens"][0]
+    return json.loads(
+        memory_evidence_repair_recovery_write_lock_gate_tool(
+            {
+                "recovery_approval_token": token_report,
+                "confirmation_text": token["required_confirmation_text"],
+                "lock_owner": "han",
+                "lock_ttl_minutes": 15,
+                "current_time": "2026-05-11T00:10:00+00:00",
+            }
+        )
+    )
+
+
+def test_tool_accepts_explicit_recovery_write_lock_gate_markdown():
+    result = json.loads(
+        memory_evidence_repair_recovery_executor_preview_tool(
+            {
+                "recovery_write_lock_gate": _recovery_write_lock_gate(),
+                "current_time": "2026-05-11T00:12:00+00:00",
+                "format": "markdown",
+            }
+        )
+    )
+
+    assert result["success"] is True
+    assert result["read_only"] is True
+    assert result["read_only_memory"] is True
+    assert result["would_mutate_memory"] is False
+    assert result["status"] == "recovery_executor_preview_ready_for_manual_recovery"
+    assert result["summary"]["manual_recovery_executor_preview_ready"] is True
+    assert result["summary"]["future_mutation_step_count"] == 1
+    assert result["previews"][0]["steps"][0]["action"] == (
+        "verify_recovery_write_lock_token_and_execution"
+    )
+    assert "Memory Evidence Repair Recovery Executor Preview" in result["markdown"]
+
+
+def test_tool_blocks_expired_recovery_write_lock_gate():
+    result = json.loads(
+        memory_evidence_repair_recovery_executor_preview_tool(
+            {
+                "recovery_write_lock_gate": _recovery_write_lock_gate(),
+                "current_time": "2026-05-11T00:26:00+00:00",
+            }
+        )
+    )
+
+    assert result["status"] == "blocked"
+    assert result["previews"] == []
+    assert "regenerate_recovery_write_lock_gate" in result["required_actions"]
+
+
+def test_tool_generates_recovery_write_lock_gate_from_token_and_creates_preview():
+    token_report = _recovery_token_report()
+    token = token_report["tokens"][0]
+
+    result = json.loads(
+        memory_evidence_repair_recovery_executor_preview_tool(
+            {
+                "recovery_approval_token": token_report,
+                "confirmation_text": token["required_confirmation_text"],
+                "lock_owner": "han",
+                "current_time": "2026-05-11T00:10:00+00:00",
+            }
+        )
+    )
+
+    assert result["status"] == "recovery_executor_preview_ready_for_manual_recovery"
+    assert result["summary"]["recovery_executor_preview_available"] is True
+    assert result["previews"][0]["operation_ids"] == ["dryrun-op-123"]
+
+
+def test_tool_blocks_when_generated_recovery_write_lock_gate_is_not_ready():
+    token_report = _recovery_token_report()
+
+    result = json.loads(
+        memory_evidence_repair_recovery_executor_preview_tool(
+            {
+                "recovery_approval_token": token_report,
+                "confirmation_text": "wrong confirmation",
+                "current_time": "2026-05-11T00:10:00+00:00",
+            }
+        )
+    )
+
+    assert result["status"] == "blocked"
+    assert result["previews"] == []
+    assert "provide_exact_recovery_confirmation_text" in result["required_actions"]
+
+
+def test_tool_uses_latest_manager_state_and_blocks_when_no_lock_available():
+    result = json.loads(
+        memory_evidence_repair_recovery_executor_preview_tool(
+            {"format": "markdown"},
+            memory_manager=FakeMemoryManager(),
+        )
+    )
+
+    assert result["success"] is True
+    assert result["status"] == "blocked"
+    assert result["previews"] == []
+    assert result["blocking_reasons"]
+
+
+def test_tool_returns_no_action_for_non_mutating_recovery_path():
+    result = json.loads(
+        memory_evidence_repair_recovery_executor_preview_tool(
+            {
+                "recovery_execution": _preparedness_execution(),
+            }
+        )
+    )
+
+    assert result["success"] is True
+    assert result["status"] == "no_action_needed"
+    assert result["previews"] == []
+
+
+def test_tool_rejects_invalid_input_shape():
+    result = json.loads(
+        memory_evidence_repair_recovery_executor_preview_tool(
+            {"recovery_write_lock_gate": "bad"}
+        )
+    )
+
+    assert result["success"] is False
+    assert "recovery_write_lock_gate must be an object" in result["error"]
+
+
+def test_tool_without_manager_returns_no_action():
+    result = json.loads(memory_evidence_repair_recovery_executor_preview_tool({}))
+
+    assert result["success"] is True
+    assert result["status"] == "no_action_needed"
+    assert result["summary"]["preview_count"] == 0
+
+
+def test_tool_is_registered_under_memory_toolset():
+    entry = registry.get_entry("memory_evidence_repair_recovery_executor_preview")
+
+    assert entry is not None
+    assert entry.toolset == "memory"

--- a/tests/tools/test_memory_evidence_repair_recovery_human_approval_token_tool.py
+++ b/tests/tools/test_memory_evidence_repair_recovery_human_approval_token_tool.py
@@ -1,0 +1,147 @@
+import json
+
+from tools.memory_evidence_repair_recovery_execution_preview_tool import (
+    memory_evidence_repair_recovery_execution_preview_tool,
+)
+from tools.memory_evidence_repair_recovery_human_approval_token_tool import (
+    memory_evidence_repair_recovery_human_approval_token_tool,
+)
+from tools.registry import registry
+from tests.tools.test_memory_evidence_repair_post_commit_audit_preview_tool import (
+    FakeMemoryManager,
+    _token_report,
+)
+from tests.tools.test_memory_evidence_repair_recovery_execution_preview_tool import (
+    _manual_rollback_decision,
+    _preparedness_decision,
+)
+
+
+def _manual_rollback_execution():
+    return json.loads(
+        memory_evidence_repair_recovery_execution_preview_tool(
+            {
+                "recovery_decision": _manual_rollback_decision(),
+            }
+        )
+    )
+
+
+def _preparedness_execution():
+    return json.loads(
+        memory_evidence_repair_recovery_execution_preview_tool(
+            {
+                "recovery_decision": _preparedness_decision(),
+            }
+        )
+    )
+
+
+def test_tool_accepts_explicit_recovery_execution_markdown():
+    result = json.loads(
+        memory_evidence_repair_recovery_human_approval_token_tool(
+            {
+                "recovery_execution": _manual_rollback_execution(),
+                "approver": "han",
+                "approval_reason": "manual recovery approval",
+                "expires_in_minutes": 20,
+                "format": "markdown",
+            }
+        )
+    )
+
+    assert result["success"] is True
+    assert result["read_only"] is True
+    assert result["read_only_memory"] is True
+    assert result["would_mutate_memory"] is False
+    assert result["status"] == "draft_ready_for_recovery_human_approval"
+    assert result["summary"]["token_count"] == 1
+    assert result["tokens"][0]["approver"] == "han"
+    assert result["tokens"][0]["expires_in_minutes"] == 20
+    assert "Memory Evidence Repair Recovery Human Approval Token" in result["markdown"]
+
+
+def test_tool_returns_no_action_for_non_mutating_preparedness_execution():
+    result = json.loads(
+        memory_evidence_repair_recovery_human_approval_token_tool(
+            {
+                "recovery_execution": _preparedness_execution(),
+            }
+        )
+    )
+
+    assert result["status"] == "no_action_needed"
+    assert result["tokens"] == []
+
+
+def test_tool_generates_recovery_execution_from_failed_audit_path():
+    result = json.loads(
+        memory_evidence_repair_recovery_human_approval_token_tool(
+            {
+                "recovery_decision": _manual_rollback_decision(),
+                "approver": "han",
+            }
+        )
+    )
+
+    assert result["status"] == "draft_ready_for_recovery_human_approval"
+    assert result["summary"]["recovery_human_approval_token_available"] is True
+    assert result["tokens"][0]["operation_ids"] == ["dryrun-op-123"]
+
+
+def test_tool_blocks_when_generated_execution_is_not_usable():
+    token_report = _token_report()
+    result = json.loads(
+        memory_evidence_repair_recovery_human_approval_token_tool(
+            {
+                "approval_token": token_report,
+                "confirmation_text": "wrong confirmation",
+                "current_time": "2026-05-11T00:10:00+00:00",
+            }
+        )
+    )
+
+    assert result["status"] == "blocked"
+    assert result["tokens"] == []
+    assert "provide_exact_confirmation_text" in result["required_actions"]
+
+
+def test_tool_uses_latest_manager_state_and_blocks_when_no_execution_available():
+    result = json.loads(
+        memory_evidence_repair_recovery_human_approval_token_tool(
+            {"format": "markdown"},
+            memory_manager=FakeMemoryManager(),
+        )
+    )
+
+    assert result["success"] is True
+    assert result["status"] == "blocked"
+    assert result["tokens"] == []
+    assert result["blocking_reasons"]
+
+
+def test_tool_rejects_invalid_input_shape():
+    result = json.loads(
+        memory_evidence_repair_recovery_human_approval_token_tool(
+            {"recovery_execution": "bad"}
+        )
+    )
+
+    assert result["success"] is False
+    assert "recovery_execution must be an object" in result["error"]
+
+
+def test_tool_without_manager_returns_no_action():
+    result = json.loads(memory_evidence_repair_recovery_human_approval_token_tool({}))
+
+    assert result["success"] is True
+    assert result["status"] == "no_action_needed"
+    assert result["summary"]["token_count"] == 0
+    assert result["tokens"] == []
+
+
+def test_tool_is_registered_under_memory_toolset():
+    entry = registry.get_entry("memory_evidence_repair_recovery_human_approval_token")
+
+    assert entry is not None
+    assert entry.toolset == "memory"

--- a/tests/tools/test_memory_evidence_repair_recovery_write_lock_gate_tool.py
+++ b/tests/tools/test_memory_evidence_repair_recovery_write_lock_gate_tool.py
@@ -1,0 +1,175 @@
+import json
+
+from tools.memory_evidence_repair_recovery_approval_token_gate_tool import (
+    memory_evidence_repair_recovery_approval_token_gate_tool,
+)
+from tools.memory_evidence_repair_recovery_write_lock_gate_tool import (
+    memory_evidence_repair_recovery_write_lock_gate_tool,
+)
+from tools.registry import registry
+from tests.tools.test_memory_evidence_repair_post_commit_audit_preview_tool import (
+    FakeMemoryManager,
+)
+from tests.tools.test_memory_evidence_repair_recovery_approval_token_gate_tool import (
+    _recovery_token_report,
+)
+from tests.tools.test_memory_evidence_repair_recovery_human_approval_token_tool import (
+    _preparedness_execution,
+)
+
+
+def _verified_recovery_token_gate():
+    token_report = _recovery_token_report()
+    token = token_report["tokens"][0]
+    return json.loads(
+        memory_evidence_repair_recovery_approval_token_gate_tool(
+            {
+                "recovery_approval_token": token_report,
+                "confirmation_text": token["required_confirmation_text"],
+                "current_time": "2026-05-11T00:10:00+00:00",
+            }
+        )
+    )
+
+
+def test_tool_accepts_explicit_recovery_token_gate_markdown():
+    token_gate = _verified_recovery_token_gate()
+
+    result = json.loads(
+        memory_evidence_repair_recovery_write_lock_gate_tool(
+            {
+                "recovery_token_gate": token_gate,
+                "lock_owner": "han",
+                "lock_ttl_minutes": 15,
+                "current_time": "2026-05-11T00:10:00+00:00",
+                "format": "markdown",
+            }
+        )
+    )
+
+    assert result["success"] is True
+    assert result["read_only"] is True
+    assert result["read_only_memory"] is True
+    assert result["would_mutate_memory"] is False
+    assert result["status"] == "recovery_write_lock_ready_for_manual_recovery"
+    assert result["summary"]["recovery_executor_preview_allowed"] is True
+    assert result["locks"][0]["owner"] == "han"
+    assert result["locks"][0]["expires_at"] == "2026-05-11T00:25:00+00:00"
+    assert "Memory Evidence Repair Recovery Write Lock Gate" in result["markdown"]
+
+
+def test_tool_blocks_on_active_recovery_lock_conflict():
+    token_gate = _verified_recovery_token_gate()
+
+    result = json.loads(
+        memory_evidence_repair_recovery_write_lock_gate_tool(
+            {
+                "recovery_token_gate": token_gate,
+                "active_locks": [
+                    {
+                        "id": "recovery-lock-active",
+                        "status": "active",
+                        "scope": "manual_memory_evidence_repair_recovery",
+                        "operation_ids": ["dryrun-op-123"],
+                        "expires_at": "2026-05-11T00:20:00+00:00",
+                    }
+                ],
+                "current_time": "2026-05-11T00:10:00+00:00",
+            }
+        )
+    )
+
+    assert result["status"] == "blocked"
+    assert result["summary"]["active_lock_conflict_count"] == 1
+    assert result["active_lock_conflicts"][0]["reason"] == "overlapping_operation_ids"
+
+
+def test_tool_generates_token_gate_from_recovery_approval_token():
+    token_report = _recovery_token_report()
+    token = token_report["tokens"][0]
+
+    result = json.loads(
+        memory_evidence_repair_recovery_write_lock_gate_tool(
+            {
+                "recovery_approval_token": token_report,
+                "confirmation_text": token["required_confirmation_text"],
+                "lock_owner": "han",
+                "current_time": "2026-05-11T00:10:00+00:00",
+            }
+        )
+    )
+
+    assert result["success"] is True
+    assert result["status"] == "recovery_write_lock_ready_for_manual_recovery"
+    assert result["summary"]["recovery_write_lock_available"] is True
+    assert result["locks"][0]["token_id"] == token["id"]
+
+
+def test_tool_blocks_when_generated_token_gate_is_not_verified():
+    token_report = _recovery_token_report()
+
+    result = json.loads(
+        memory_evidence_repair_recovery_write_lock_gate_tool(
+            {
+                "recovery_approval_token": token_report,
+                "confirmation_text": "wrong confirmation",
+                "current_time": "2026-05-11T00:10:00+00:00",
+            }
+        )
+    )
+
+    assert result["status"] == "blocked"
+    assert "provide_exact_recovery_confirmation_text" in result["required_actions"]
+
+
+def test_tool_uses_latest_manager_state_and_blocks_when_no_token_gate_available():
+    result = json.loads(
+        memory_evidence_repair_recovery_write_lock_gate_tool(
+            {"format": "markdown"},
+            memory_manager=FakeMemoryManager(),
+        )
+    )
+
+    assert result["success"] is True
+    assert result["status"] == "blocked"
+    assert result["blocking_reasons"]
+
+
+def test_tool_returns_no_action_for_non_mutating_recovery_path():
+    result = json.loads(
+        memory_evidence_repair_recovery_write_lock_gate_tool(
+            {
+                "recovery_execution": _preparedness_execution(),
+            }
+        )
+    )
+
+    assert result["success"] is True
+    assert result["status"] == "no_action_needed"
+    assert result["locks"] == []
+
+
+def test_tool_rejects_invalid_input_shape():
+    result = json.loads(
+        memory_evidence_repair_recovery_write_lock_gate_tool(
+            {"recovery_token_gate": "bad"}
+        )
+    )
+
+    assert result["success"] is False
+    assert "recovery_token_gate must be an object" in result["error"]
+
+
+def test_tool_without_manager_returns_no_action():
+    result = json.loads(memory_evidence_repair_recovery_write_lock_gate_tool({}))
+
+    assert result["success"] is True
+    assert result["status"] == "no_action_needed"
+    assert result["summary"]["lock_count"] == 0
+
+
+def test_tool_is_registered_under_memory_toolset():
+    entry = registry.get_entry("memory_evidence_repair_recovery_write_lock_gate")
+
+    assert entry is not None
+    assert entry.toolset == "memory"

--- a/tests/tools/test_memory_evidence_repair_rollback_drill_preview_tool.py
+++ b/tests/tools/test_memory_evidence_repair_rollback_drill_preview_tool.py
@@ -1,0 +1,158 @@
+import json
+
+from tools.memory_evidence_repair_post_commit_audit_preview_tool import (
+    memory_evidence_repair_post_commit_audit_preview_tool,
+)
+from tools.memory_evidence_repair_rollback_drill_preview_tool import (
+    memory_evidence_repair_rollback_drill_preview_tool,
+)
+from tools.registry import registry
+from tests.tools.test_memory_evidence_repair_post_commit_audit_preview_tool import (
+    FakeMemoryManager,
+    _executor_preview,
+    _token_report,
+)
+
+
+def _planned_post_commit_audit():
+    return json.loads(
+        memory_evidence_repair_post_commit_audit_preview_tool(
+            {"executor_preview": _executor_preview()}
+        )
+    )
+
+
+def _failed_post_commit_audit():
+    executor = _executor_preview()
+    preview = executor["previews"][0]
+    return json.loads(
+        memory_evidence_repair_post_commit_audit_preview_tool(
+            {
+                "executor_preview": executor,
+                "observed_memory_patches": {
+                    "dryrun-op-123": {"applied": True, "patch_digest": "a" * 64}
+                },
+                "recorded_receipts": [{"id": preview["receipt_id"]}],
+                "used_token_ids": [],
+                "released_lock_ids": [preview["lock_id"]],
+                "rollback_status": {"status": "snapshot_available"},
+            }
+        )
+    )
+
+
+def test_tool_accepts_explicit_post_commit_audit_markdown():
+    result = json.loads(
+        memory_evidence_repair_rollback_drill_preview_tool(
+            {
+                "post_commit_audit": _planned_post_commit_audit(),
+                "format": "markdown",
+            }
+        )
+    )
+
+    assert result["success"] is True
+    assert result["read_only"] is True
+    assert result["read_only_memory"] is True
+    assert result["would_mutate_memory"] is False
+    assert result["status"] == "rollback_drill_preview_ready"
+    assert result["previews"][0]["trigger"] == "post_commit_audit_preparedness"
+    assert "Memory Evidence Repair Rollback Drill Preview" in result["markdown"]
+
+
+def test_tool_accepts_failed_audit_and_creates_failure_drill():
+    result = json.loads(
+        memory_evidence_repair_rollback_drill_preview_tool(
+            {
+                "post_commit_audit": _failed_post_commit_audit(),
+                "rollback_plan": {
+                    "steps": [
+                        {
+                            "operation_id": "dryrun-op-123",
+                            "patch_digest": "a" * 64,
+                        }
+                    ]
+                },
+            }
+        )
+    )
+
+    assert result["status"] == "rollback_drill_preview_ready"
+    assert result["summary"]["failed_audit_step_count"] >= 1
+    assert result["summary"]["future_restore_step_count"] == 1
+    assert result["previews"][0]["trigger"] == "post_commit_audit_failure"
+
+
+def test_tool_generates_post_commit_audit_from_token():
+    token_report = _token_report()
+    result = json.loads(
+        memory_evidence_repair_rollback_drill_preview_tool(
+            {
+                "approval_token": token_report,
+                "confirmation_text": token_report["tokens"][0]["required_confirmation_text"],
+                "current_time": "2026-05-11T00:10:00+00:00",
+                "actor": "han",
+                "lock_owner": "han",
+            }
+        )
+    )
+
+    assert result["status"] == "rollback_drill_preview_ready"
+    assert result["summary"]["rollback_drill_preview_available"] is True
+
+
+def test_tool_blocks_when_generated_post_commit_audit_is_not_usable():
+    token_report = _token_report()
+    result = json.loads(
+        memory_evidence_repair_rollback_drill_preview_tool(
+            {
+                "approval_token": token_report,
+                "confirmation_text": "wrong confirmation",
+                "current_time": "2026-05-11T00:10:00+00:00",
+            }
+        )
+    )
+
+    assert result["status"] == "blocked"
+    assert result["previews"] == []
+    assert "provide_exact_confirmation_text" in result["required_actions"]
+
+
+def test_tool_uses_latest_manager_state_and_blocks_when_no_audit_available():
+    result = json.loads(
+        memory_evidence_repair_rollback_drill_preview_tool(
+            {"format": "markdown"},
+            memory_manager=FakeMemoryManager(),
+        )
+    )
+
+    assert result["success"] is True
+    assert result["status"] == "blocked"
+    assert result["previews"] == []
+    assert result["blocking_reasons"]
+
+
+def test_tool_rejects_invalid_input_shape():
+    result = json.loads(
+        memory_evidence_repair_rollback_drill_preview_tool(
+            {"post_commit_audit": "bad"}
+        )
+    )
+
+    assert result["success"] is False
+    assert "post_commit_audit must be an object" in result["error"]
+
+
+def test_tool_without_manager_returns_no_action():
+    result = json.loads(memory_evidence_repair_rollback_drill_preview_tool({}))
+
+    assert result["success"] is True
+    assert result["status"] == "no_action_needed"
+    assert result["summary"]["preview_count"] == 0
+
+
+def test_tool_is_registered_under_memory_toolset():
+    entry = registry.get_entry("memory_evidence_repair_rollback_drill_preview")
+
+    assert entry is not None
+    assert entry.toolset == "memory"

--- a/tests/tools/test_memory_evidence_repair_rollback_plan_tool.py
+++ b/tests/tools/test_memory_evidence_repair_rollback_plan_tool.py
@@ -1,0 +1,164 @@
+import json
+
+from tools.memory_evidence_repair_rollback_plan_tool import (
+    memory_evidence_repair_rollback_plan_tool,
+)
+from tools.registry import registry
+
+
+class FakeMemoryManager:
+    def last_memory_policy_gate(self):
+        return {
+            "summary": {"input_count": 1, "output_count": 0},
+            "provider_results": [
+                {
+                    "provider": "builtin",
+                    "action": "require_provenance_before_reuse",
+                    "effect": "filtered",
+                    "reason": "Recall candidate lacks explicit provenance required by policy.",
+                }
+            ],
+            "read_only": True,
+        }
+
+    def last_recall_audit(self):
+        return {"entries": [], "read_only": True}
+
+    def last_recall_diagnostics(self):
+        return {"issues": [], "read_only": True}
+
+    def last_memory_auto_policy(self):
+        return {"decisions": [], "read_only": True}
+
+
+def _allowed_entry():
+    return {
+        "id": "ledger-123",
+        "sequence": 1,
+        "outcome": "allowed_for_manual_commit",
+        "decision_id": "gate-preview-123",
+        "preview_id": "preview-123",
+        "candidate_id": "repair-123",
+        "provider": "builtin",
+        "priority": "high",
+        "repair_action": "attach_provenance",
+        "evidence_fields": ["source_url", "observed_at", "verification_signal"],
+        "patch_digest": "a" * 64,
+        "manual_commit_allowed": True,
+        "blocked": False,
+        "target": {"candidate_id": "repair-123", "provider": "builtin"},
+    }
+
+
+def test_tool_uses_latest_manager_state_read_only_markdown():
+    result = json.loads(
+        memory_evidence_repair_rollback_plan_tool(
+            {"format": "markdown"},
+            memory_manager=FakeMemoryManager(),
+        )
+    )
+
+    assert result["success"] is True
+    assert result["read_only"] is True
+    assert result["read_only_memory"] is True
+    assert result["would_mutate_memory"] is False
+    assert result["summary"]["rollback_step_count"] == 1
+    assert result["summary"]["no_action_count"] == 1
+    assert "Memory Evidence Repair Rollback Plan" in result["markdown"]
+
+
+def test_tool_accepts_explicit_entries_and_snapshots():
+    result = json.loads(
+        memory_evidence_repair_rollback_plan_tool(
+            {
+                "entries": [_allowed_entry()],
+                "pre_commit_snapshots": {
+                    "ledger-123": {
+                        "evidence": {
+                            "source_url": "https://old.example.com/source",
+                            "observed_at": "2026-05-01T00:00:00Z",
+                            "verification_signal": "previous_manual_verified",
+                        }
+                    }
+                },
+            }
+        )
+    )
+
+    assert result["summary"]["ready_count"] == 1
+    assert result["steps"][0]["status"] == "ready_for_manual_rollback"
+    assert result["steps"][0]["inverse_patch_preview"]["set"]["evidence"] == {
+        "source_url": "https://old.example.com/source",
+        "observed_at": "2026-05-01T00:00:00Z",
+        "verification_signal": "previous_manual_verified",
+    }
+
+
+def test_tool_accepts_candidates_and_builds_full_pipeline():
+    result = json.loads(
+        memory_evidence_repair_rollback_plan_tool(
+            {
+                "candidates": [
+                    {
+                        "id": "repair-123",
+                        "provider": "builtin",
+                        "priority": "high",
+                        "repair_action": "attach_provenance",
+                        "required_evidence": [
+                            "source_url",
+                            "observed_at",
+                            "verification_signal",
+                        ],
+                        "proposed_evidence_patch": {
+                            "source_url": "https://example.com/source",
+                            "observed_at": "2026-05-11T00:00:00Z",
+                            "verification_signal": "manual_verified",
+                        },
+                    }
+                ],
+                "approved_candidate_ids": ["repair-123"],
+                "user_confirmed": True,
+            }
+        )
+    )
+
+    assert result["summary"]["snapshot_required_count"] == 1
+    assert result["steps"][0]["status"] == "snapshot_required"
+
+
+def test_tool_accepts_ledger_and_limits_steps():
+    result = json.loads(
+        memory_evidence_repair_rollback_plan_tool(
+            {
+                "limit": 1,
+                "ledger": {"entries": [_allowed_entry(), _allowed_entry()]},
+            }
+        )
+    )
+
+    assert result["limited_to"] == 1
+    assert result["summary"]["rollback_step_count"] == 1
+    assert len(result["steps"]) == 1
+
+
+def test_tool_rejects_invalid_input_shape():
+    result = json.loads(memory_evidence_repair_rollback_plan_tool({"ledger": "bad"}))
+
+    assert result["success"] is False
+    assert "ledger must be an object" in result["error"]
+
+
+def test_tool_without_manager_returns_empty_plan():
+    result = json.loads(memory_evidence_repair_rollback_plan_tool({}))
+
+    assert result["success"] is True
+    assert result["read_only"] is True
+    assert result["summary"]["rollback_step_count"] == 0
+    assert result["steps"] == []
+
+
+def test_tool_is_registered_under_memory_toolset():
+    entry = registry.get_entry("memory_evidence_repair_rollback_plan")
+
+    assert entry is not None
+    assert entry.toolset == "memory"

--- a/tests/tools/test_memory_evidence_repair_snapshot_planner_tool.py
+++ b/tests/tools/test_memory_evidence_repair_snapshot_planner_tool.py
@@ -1,0 +1,168 @@
+import json
+
+from tools.memory_evidence_repair_snapshot_planner_tool import (
+    memory_evidence_repair_snapshot_planner_tool,
+)
+from tools.registry import registry
+
+
+class FakeMemoryManager:
+    def last_memory_policy_gate(self):
+        return {
+            "summary": {"input_count": 1, "output_count": 0},
+            "provider_results": [
+                {
+                    "provider": "builtin",
+                    "action": "require_provenance_before_reuse",
+                    "effect": "filtered",
+                    "reason": "Recall candidate lacks explicit provenance required by policy.",
+                }
+            ],
+            "read_only": True,
+        }
+
+    def last_recall_audit(self):
+        return {"entries": [], "read_only": True}
+
+    def last_recall_diagnostics(self):
+        return {"issues": [], "read_only": True}
+
+    def last_memory_auto_policy(self):
+        return {"decisions": [], "read_only": True}
+
+
+def _snapshot_required_step():
+    return {
+        "id": "rollback-123",
+        "ledger_entry_id": "ledger-123",
+        "sequence": 1,
+        "status": "snapshot_required",
+        "rollback_action": "restore_evidence_metadata",
+        "provider": "builtin",
+        "repair_action": "attach_provenance",
+        "candidate_id": "repair-123",
+        "preview_id": "preview-123",
+        "patch_digest": "a" * 64,
+        "target": {"candidate_id": "repair-123", "provider": "builtin"},
+        "evidence_fields": ["source_url", "observed_at", "verification_signal"],
+    }
+
+
+def test_tool_uses_latest_manager_state_read_only_markdown():
+    result = json.loads(
+        memory_evidence_repair_snapshot_planner_tool(
+            {"format": "markdown"},
+            memory_manager=FakeMemoryManager(),
+        )
+    )
+
+    assert result["success"] is True
+    assert result["read_only"] is True
+    assert result["read_only_memory"] is True
+    assert result["would_mutate_memory"] is False
+    assert result["summary"]["snapshot_request_count"] == 1
+    assert result["summary"]["no_action_count"] == 1
+    assert "Memory Evidence Repair Snapshot Planner" in result["markdown"]
+
+
+def test_tool_accepts_explicit_steps_and_limits_requests():
+    result = json.loads(
+        memory_evidence_repair_snapshot_planner_tool(
+            {
+                "limit": 1,
+                "steps": [_snapshot_required_step(), _snapshot_required_step()],
+            }
+        )
+    )
+
+    assert result["limited_to"] == 1
+    assert result["summary"]["snapshot_request_count"] == 1
+    assert result["requests"][0]["status"] == "capture_required"
+    assert result["requests"][0]["blocks_manual_commit"] is True
+
+
+def test_tool_accepts_entries_and_existing_snapshots():
+    result = json.loads(
+        memory_evidence_repair_snapshot_planner_tool(
+            {
+                "entries": [
+                    {
+                        "id": "ledger-123",
+                        "outcome": "allowed_for_manual_commit",
+                        "manual_commit_allowed": True,
+                        "provider": "builtin",
+                        "repair_action": "attach_provenance",
+                        "candidate_id": "repair-123",
+                        "preview_id": "preview-123",
+                        "patch_digest": "a" * 64,
+                        "target": {"candidate_id": "repair-123", "provider": "builtin"},
+                        "evidence_fields": ["source_url"],
+                    }
+                ],
+                "existing_snapshots": {
+                    "ledger-123": {"evidence": {"source_url": "https://old.example.com"}}
+                },
+            }
+        )
+    )
+
+    assert result["summary"]["already_available_count"] == 1
+    assert result["requests"][0]["status"] == "already_available"
+
+
+def test_tool_accepts_candidates_and_builds_full_pipeline():
+    result = json.loads(
+        memory_evidence_repair_snapshot_planner_tool(
+            {
+                "candidates": [
+                    {
+                        "id": "repair-123",
+                        "provider": "builtin",
+                        "priority": "high",
+                        "repair_action": "attach_provenance",
+                        "required_evidence": [
+                            "source_url",
+                            "observed_at",
+                            "verification_signal",
+                        ],
+                        "proposed_evidence_patch": {
+                            "source_url": "https://example.com/source",
+                            "observed_at": "2026-05-11T00:00:00Z",
+                            "verification_signal": "manual_verified",
+                        },
+                    }
+                ],
+                "approved_candidate_ids": ["repair-123"],
+                "user_confirmed": True,
+            }
+        )
+    )
+
+    assert result["summary"]["capture_required_count"] == 1
+    assert result["summary"]["blocks_manual_commit"] is True
+    assert result["requests"][0]["status"] == "capture_required"
+
+
+def test_tool_rejects_invalid_input_shape():
+    result = json.loads(
+        memory_evidence_repair_snapshot_planner_tool({"rollback_plan": "bad"})
+    )
+
+    assert result["success"] is False
+    assert "rollback_plan must be an object" in result["error"]
+
+
+def test_tool_without_manager_returns_empty_plan():
+    result = json.loads(memory_evidence_repair_snapshot_planner_tool({}))
+
+    assert result["success"] is True
+    assert result["read_only"] is True
+    assert result["summary"]["snapshot_request_count"] == 0
+    assert result["requests"] == []
+
+
+def test_tool_is_registered_under_memory_toolset():
+    entry = registry.get_entry("memory_evidence_repair_snapshot_planner")
+
+    assert entry is not None
+    assert entry.toolset == "memory"

--- a/tests/tools/test_memory_evidence_repair_write_lock_gate_tool.py
+++ b/tests/tools/test_memory_evidence_repair_write_lock_gate_tool.py
@@ -1,0 +1,243 @@
+import json
+
+from tools.memory_evidence_repair_commit_receipt_tool import (
+    memory_evidence_repair_commit_receipt_tool,
+)
+from tools.memory_evidence_repair_human_approval_token_tool import (
+    memory_evidence_repair_human_approval_token_tool,
+)
+from tools.memory_evidence_repair_write_lock_gate_tool import (
+    memory_evidence_repair_write_lock_gate_tool,
+)
+from tools.registry import registry
+
+
+class FakeMemoryManager:
+    def last_memory_policy_gate(self):
+        return {
+            "summary": {"input_count": 1, "output_count": 0},
+            "provider_results": [
+                {
+                    "provider": "builtin",
+                    "action": "require_provenance_before_reuse",
+                    "effect": "filtered",
+                    "reason": "Recall candidate lacks explicit provenance required by policy.",
+                }
+            ],
+            "read_only": True,
+        }
+
+    def last_recall_audit(self):
+        return {"entries": [], "read_only": True}
+
+    def last_recall_diagnostics(self):
+        return {"issues": [], "read_only": True}
+
+    def last_memory_auto_policy(self):
+        return {"decisions": [], "read_only": True}
+
+
+def _ready_dry_run():
+    return {
+        "status": "ready_for_manual_commit",
+        "summary": {"manual_commit_allowed": True, "operation_count": 1},
+        "checks": [{"id": "commit_gate", "status": "pass"}],
+        "operations": [
+            {
+                "id": "dryrun-op-123",
+                "ledger_entry_id": "ledger-123",
+                "candidate_id": "repair-123",
+                "preview_id": "preview-123",
+                "provider": "builtin",
+                "repair_action": "attach_provenance",
+                "patch_digest": "a" * 64,
+                "target": {"candidate_id": "repair-123"},
+                "evidence_fields": ["source_url"],
+            }
+        ],
+        "blocking_reasons": [],
+        "required_actions": [],
+    }
+
+
+def _token_report():
+    result = json.loads(
+        memory_evidence_repair_human_approval_token_tool(
+            {
+                "dry_run": _ready_dry_run(),
+                "approver": "han",
+                "approval_reason": "final manual approval",
+                "expires_in_minutes": 30,
+            }
+        )
+    )
+    result["generated_at"] = "2026-05-11T00:00:00+00:00"
+    return result
+
+
+def _commit_receipt():
+    token_report = _token_report()
+    return json.loads(
+        memory_evidence_repair_commit_receipt_tool(
+            {
+                "approval_token": token_report,
+                "confirmation_text": token_report["tokens"][0]["required_confirmation_text"],
+                "current_time": "2026-05-11T00:10:00+00:00",
+                "actor": "han",
+                "commit_reason": "manual memory evidence repair",
+            }
+        )
+    )
+
+
+def _candidate_args():
+    return {
+        "candidates": [
+            {
+                "id": "repair-123",
+                "provider": "builtin",
+                "priority": "high",
+                "repair_action": "attach_provenance",
+                "required_evidence": [
+                    "source_url",
+                    "observed_at",
+                    "verification_signal",
+                ],
+                "proposed_evidence_patch": {
+                    "source_url": "https://example.com/source",
+                    "observed_at": "2026-05-11T00:00:00Z",
+                    "verification_signal": "manual_verified",
+                },
+            }
+        ],
+        "approved_candidate_ids": ["repair-123"],
+        "user_confirmed": True,
+        "existing_snapshots": {
+            "source_url": "https://old.example.com/source",
+            "observed_at": "2026-05-01T00:00:00Z",
+            "verification_signal": "previous_manual_verified",
+        },
+        "approver": "han",
+    }
+
+
+def test_tool_accepts_explicit_commit_receipt_markdown():
+    result = json.loads(
+        memory_evidence_repair_write_lock_gate_tool(
+            {
+                "commit_receipt": _commit_receipt(),
+                "lock_owner": "han",
+                "lock_ttl_minutes": 15,
+                "current_time": "2026-05-11T00:20:00+00:00",
+                "format": "markdown",
+            }
+        )
+    )
+
+    assert result["success"] is True
+    assert result["read_only"] is True
+    assert result["read_only_memory"] is True
+    assert result["would_mutate_memory"] is False
+    assert result["status"] == "write_lock_ready_for_manual_commit"
+    assert result["summary"]["executor_dry_run_allowed"] is True
+    assert result["locks"][0]["owner"] == "han"
+    assert "Memory Evidence Repair Write Lock Gate" in result["markdown"]
+
+
+def test_tool_blocks_on_active_lock_conflict():
+    result = json.loads(
+        memory_evidence_repair_write_lock_gate_tool(
+            {
+                "commit_receipt": _commit_receipt(),
+                "active_locks": [
+                    {
+                        "id": "write-lock-existing",
+                        "status": "active",
+                        "scope": "manual_memory_evidence_repair_commit",
+                        "operation_ids": ["dryrun-op-123"],
+                        "expires_at": "2026-05-11T00:40:00+00:00",
+                    }
+                ],
+                "current_time": "2026-05-11T00:20:00+00:00",
+            }
+        )
+    )
+
+    assert result["status"] == "blocked"
+    assert result["locks"] == []
+    assert result["summary"]["active_lock_conflict_count"] == 1
+    assert "wait_for_write_lock_release" in result["required_actions"]
+
+
+def test_tool_generates_receipt_from_token_and_creates_write_lock():
+    token_report = _token_report()
+    result = json.loads(
+        memory_evidence_repair_write_lock_gate_tool(
+            {
+                "approval_token": token_report,
+                "confirmation_text": token_report["tokens"][0]["required_confirmation_text"],
+                "current_time": "2026-05-11T00:10:00+00:00",
+                "actor": "han",
+                "lock_owner": "han",
+            }
+        )
+    )
+
+    assert result["status"] == "write_lock_ready_for_manual_commit"
+    assert result["summary"]["write_lock_available"] is True
+    assert result["locks"][0]["token_id"] == token_report["tokens"][0]["id"]
+
+
+def test_tool_blocks_when_generated_receipt_is_not_ready():
+    token_report = _token_report()
+    result = json.loads(
+        memory_evidence_repair_write_lock_gate_tool(
+            {
+                "approval_token": token_report,
+                "confirmation_text": "wrong confirmation",
+                "current_time": "2026-05-11T00:10:00+00:00",
+            }
+        )
+    )
+
+    assert result["status"] == "blocked"
+    assert result["locks"] == []
+    assert "provide_exact_confirmation_text" in result["required_actions"]
+
+
+def test_tool_uses_latest_manager_state_and_blocks_when_no_receipt_available():
+    result = json.loads(
+        memory_evidence_repair_write_lock_gate_tool(
+            {"format": "markdown"},
+            memory_manager=FakeMemoryManager(),
+        )
+    )
+
+    assert result["success"] is True
+    assert result["status"] == "blocked"
+    assert result["locks"] == []
+    assert result["blocking_reasons"]
+
+
+def test_tool_rejects_invalid_input_shape():
+    result = json.loads(
+        memory_evidence_repair_write_lock_gate_tool({"commit_receipt": "bad"})
+    )
+
+    assert result["success"] is False
+    assert "commit_receipt must be an object" in result["error"]
+
+
+def test_tool_without_manager_returns_no_action():
+    result = json.loads(memory_evidence_repair_write_lock_gate_tool({}))
+
+    assert result["success"] is True
+    assert result["status"] == "no_action_needed"
+    assert result["summary"]["lock_count"] == 0
+
+
+def test_tool_is_registered_under_memory_toolset():
+    entry = registry.get_entry("memory_evidence_repair_write_lock_gate")
+
+    assert entry is not None
+    assert entry.toolset == "memory"

--- a/tools/memory_evidence_repair_apply_preview_tool.py
+++ b/tools/memory_evidence_repair_apply_preview_tool.py
@@ -1,0 +1,283 @@
+"""Read-only Memory Evidence Repair Apply Preview tool."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from agent.memory_evidence_repair_apply_preview import (
+    MemoryEvidenceRepairApplyPreviewReport,
+    build_evidence_repair_apply_preview,
+)
+from agent.memory_evidence_repair_approval import (
+    build_evidence_repair_approval_candidates,
+)
+from agent.memory_evidence_repair_planner import build_evidence_repair_plan
+from tools.registry import registry, tool_error
+
+
+MEMORY_EVIDENCE_REPAIR_APPLY_PREVIEW_SCHEMA = {
+    "name": "memory_evidence_repair_apply_preview",
+    "description": (
+        "Read-only preview of the memory evidence metadata patch that would be "
+        "applied after user confirmation. It never mutates durable memory."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "approval": {
+                "type": "object",
+                "description": "Optional approval candidate report payload.",
+                "additionalProperties": True,
+            },
+            "candidates": {
+                "type": "array",
+                "description": "Optional approval candidates to preview.",
+                "items": {"type": "object", "additionalProperties": True},
+            },
+            "approved_candidate_ids": {
+                "type": "array",
+                "description": "Optional candidate ids the user has confirmed for preview.",
+                "items": {"type": "string"},
+            },
+            "plan": {
+                "type": "object",
+                "description": "Optional evidence repair plan payload.",
+                "additionalProperties": True,
+            },
+            "repairs": {
+                "type": "array",
+                "description": "Optional repair items to wrap as a plan.",
+                "items": {"type": "object", "additionalProperties": True},
+            },
+            "gate": {
+                "type": "object",
+                "description": "Optional memory policy gate payload.",
+                "additionalProperties": True,
+            },
+            "audit": {
+                "type": "object",
+                "description": "Optional memory recall audit payload.",
+                "additionalProperties": True,
+            },
+            "diagnostics": {
+                "type": "object",
+                "description": "Optional memory recall diagnostics payload.",
+                "additionalProperties": True,
+            },
+            "policy": {
+                "type": "object",
+                "description": "Optional memory auto-policy payload.",
+                "additionalProperties": True,
+            },
+            "proposed_evidence": {
+                "type": "object",
+                "description": "Optional proposed evidence values keyed globally or by candidate id.",
+                "additionalProperties": True,
+            },
+            "format": {
+                "type": "string",
+                "enum": ["json", "markdown"],
+                "description": "Optional response format helper. JSON is always returned; markdown adds a readable summary field.",
+            },
+            "limit": {
+                "type": "integer",
+                "description": "Maximum apply previews to include. Defaults to all previews.",
+            },
+        },
+    },
+}
+
+
+def memory_evidence_repair_apply_preview_tool(
+    args: dict[str, Any],
+    **kwargs,
+) -> str:
+    if not isinstance(args, dict):
+        return tool_error("args must be an object.", success=False)
+
+    validated = _validate_args(args)
+    if validated is not None:
+        return validated
+
+    approval = _resolve_approval(args, kwargs.get("memory_manager"))
+    if isinstance(approval, str):
+        return approval
+
+    approved_candidate_ids = args.get("approved_candidate_ids")
+    proposed_evidence = args.get("proposed_evidence")
+    report = build_evidence_repair_apply_preview(
+        approval=approval,
+        approved_candidate_ids=(
+            approved_candidate_ids if isinstance(approved_candidate_ids, list) else None
+        ),
+        proposed_evidence=proposed_evidence if isinstance(proposed_evidence, dict) else {},
+    )
+
+    limit = _positive_int(args.get("limit"))
+    if limit is not None:
+        report = MemoryEvidenceRepairApplyPreviewReport(
+            generated_at=report.generated_at,
+            previews=report.previews[:limit],
+        )
+
+    payload = report.to_dict()
+    if limit is not None:
+        payload["limited_to"] = limit
+    payload["success"] = True
+    payload["read_only"] = True
+    payload["read_only_memory"] = True
+    payload["would_mutate_memory"] = False
+    if str(args.get("format", "")).lower() == "markdown":
+        payload["markdown"] = _render_markdown(payload)
+    return json.dumps(payload, ensure_ascii=False)
+
+
+def _validate_args(args: dict[str, Any]) -> str | None:
+    object_fields = (
+        "approval",
+        "plan",
+        "gate",
+        "audit",
+        "diagnostics",
+        "policy",
+        "proposed_evidence",
+    )
+    array_fields = ("candidates", "approved_candidate_ids", "repairs")
+    for field_name in object_fields:
+        value = args.get(field_name)
+        if value is not None and not isinstance(value, dict):
+            return tool_error(f"{field_name} must be an object when provided.", success=False)
+    for field_name in array_fields:
+        value = args.get(field_name)
+        if value is not None and not isinstance(value, list):
+            return tool_error(f"{field_name} must be an array when provided.", success=False)
+    return None
+
+
+def _resolve_approval(args: dict[str, Any], memory_manager: Any) -> dict[str, Any] | str:
+    explicit_approval = args.get("approval")
+    explicit_candidates = args.get("candidates")
+    if isinstance(explicit_approval, dict):
+        return explicit_approval
+    if isinstance(explicit_candidates, list):
+        return {
+            "summary": {"candidate_count": len(explicit_candidates)},
+            "candidates": explicit_candidates,
+            "read_only": True,
+            "read_only_memory": True,
+        }
+
+    plan = _resolve_plan(args, memory_manager)
+    if isinstance(plan, str):
+        return plan
+    proposed_evidence = args.get("proposed_evidence")
+    return build_evidence_repair_approval_candidates(
+        plan=plan,
+        proposed_evidence=proposed_evidence if isinstance(proposed_evidence, dict) else {},
+    ).to_dict()
+
+
+def _resolve_plan(args: dict[str, Any], memory_manager: Any) -> dict[str, Any] | str:
+    explicit_plan = args.get("plan")
+    explicit_repairs = args.get("repairs")
+    if isinstance(explicit_plan, dict):
+        return explicit_plan
+    if isinstance(explicit_repairs, list):
+        return {
+            "summary": {"repair_count": len(explicit_repairs)},
+            "repairs": explicit_repairs,
+            "read_only": True,
+        }
+
+    raw_inputs = _resolve_raw_inputs(args, memory_manager)
+    if isinstance(raw_inputs, str):
+        return raw_inputs
+    gate, audit, diagnostics, policy = raw_inputs
+    return build_evidence_repair_plan(
+        gate=gate,
+        audit=audit,
+        diagnostics=diagnostics,
+        policy=policy,
+    ).to_dict()
+
+
+def _resolve_raw_inputs(
+    args: dict[str, Any],
+    memory_manager: Any,
+) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any], dict[str, Any]] | str:
+    gate = args.get("gate") if isinstance(args.get("gate"), dict) else _manager_dict(
+        memory_manager,
+        "last_memory_policy_gate",
+    )
+    audit = args.get("audit") if isinstance(args.get("audit"), dict) else _manager_dict(
+        memory_manager,
+        "last_recall_audit",
+    )
+    diagnostics = (
+        args.get("diagnostics")
+        if isinstance(args.get("diagnostics"), dict)
+        else _manager_dict(memory_manager, "last_recall_diagnostics")
+    )
+    policy = args.get("policy") if isinstance(args.get("policy"), dict) else _manager_dict(
+        memory_manager,
+        "last_memory_auto_policy",
+    )
+    return gate, audit, diagnostics, policy
+
+
+def _manager_dict(memory_manager: Any, method_name: str) -> dict[str, Any]:
+    if memory_manager is None or not hasattr(memory_manager, method_name):
+        return {}
+    try:
+        value = getattr(memory_manager, method_name)()
+    except Exception:
+        return {}
+    return dict(value) if isinstance(value, dict) else {}
+
+
+def _positive_int(value: Any) -> int | None:
+    if value is None:
+        return None
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed if parsed > 0 else None
+
+
+def _render_markdown(payload: dict[str, Any]) -> str:
+    summary = payload.get("summary", {})
+    lines = [
+        "### Memory Evidence Repair Apply Preview",
+        f"- Previews: {summary.get('preview_count', 0)}",
+        f"- Ready: {summary.get('ready_count', 0)}",
+        f"- Missing evidence: {summary.get('missing_evidence_count', 0)}",
+    ]
+    for index, preview in enumerate(payload.get("previews", []), start=1):
+        provider = preview.get("provider") or "memory"
+        lines.append(
+            f"{index}. [{preview.get('status')}] "
+            f"{preview.get('repair_action')} provider={provider}"
+        )
+        fields = preview.get("would_update_fields") or []
+        if fields:
+            lines.append(f"   Would update: {', '.join(str(item) for item in fields)}")
+        missing = preview.get("missing_evidence") or []
+        if missing:
+            lines.append(f"   Missing: {', '.join(str(item) for item in missing)}")
+    return "\n".join(lines)
+
+
+def check_memory_evidence_repair_apply_preview_requirements() -> bool:
+    return True
+
+
+registry.register(
+    name="memory_evidence_repair_apply_preview",
+    toolset="memory",
+    schema=MEMORY_EVIDENCE_REPAIR_APPLY_PREVIEW_SCHEMA,
+    handler=memory_evidence_repair_apply_preview_tool,
+    check_fn=check_memory_evidence_repair_apply_preview_requirements,
+    emoji="🧠",
+)

--- a/tools/memory_evidence_repair_approval_candidates_tool.py
+++ b/tools/memory_evidence_repair_approval_candidates_tool.py
@@ -1,0 +1,233 @@
+"""Read-only Memory Evidence Repair Approval Candidates tool."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from agent.memory_evidence_repair_approval import (
+    MemoryEvidenceRepairApprovalReport,
+    build_evidence_repair_approval_candidates,
+)
+from agent.memory_evidence_repair_planner import build_evidence_repair_plan
+from tools.registry import registry, tool_error
+
+
+MEMORY_EVIDENCE_REPAIR_APPROVAL_CANDIDATES_SCHEMA = {
+    "name": "memory_evidence_repair_approval_candidates",
+    "description": (
+        "Read-only planner that turns memory evidence repair plans into "
+        "human-confirmable approval candidates. It never mutates durable memory."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "plan": {
+                "type": "object",
+                "description": "Optional evidence repair plan payload.",
+                "additionalProperties": True,
+            },
+            "repairs": {
+                "type": "array",
+                "description": "Optional repair items to wrap as a plan.",
+                "items": {"type": "object", "additionalProperties": True},
+            },
+            "gate": {
+                "type": "object",
+                "description": "Optional memory policy gate payload.",
+                "additionalProperties": True,
+            },
+            "audit": {
+                "type": "object",
+                "description": "Optional memory recall audit payload.",
+                "additionalProperties": True,
+            },
+            "diagnostics": {
+                "type": "object",
+                "description": "Optional memory recall diagnostics payload.",
+                "additionalProperties": True,
+            },
+            "policy": {
+                "type": "object",
+                "description": "Optional memory auto-policy payload.",
+                "additionalProperties": True,
+            },
+            "proposed_evidence": {
+                "type": "object",
+                "description": "Optional proposed evidence values keyed by required field.",
+                "additionalProperties": True,
+            },
+            "format": {
+                "type": "string",
+                "enum": ["json", "markdown"],
+                "description": "Optional response format helper. JSON is always returned; markdown adds a readable summary field.",
+            },
+            "limit": {
+                "type": "integer",
+                "description": "Maximum approval candidates to include. Defaults to all candidates.",
+            },
+        },
+    },
+}
+
+
+def memory_evidence_repair_approval_candidates_tool(
+    args: dict[str, Any],
+    **kwargs,
+) -> str:
+    if not isinstance(args, dict):
+        return tool_error("args must be an object.", success=False)
+
+    resolved_plan = _resolve_plan(args, kwargs.get("memory_manager"))
+    if isinstance(resolved_plan, str):
+        return resolved_plan
+
+    proposed_evidence = args.get("proposed_evidence")
+    if proposed_evidence is not None and not isinstance(proposed_evidence, dict):
+        return tool_error(
+            "proposed_evidence must be an object when provided.",
+            success=False,
+        )
+
+    report = build_evidence_repair_approval_candidates(
+        plan=resolved_plan,
+        proposed_evidence=proposed_evidence if isinstance(proposed_evidence, dict) else {},
+    )
+    limit = _positive_int(args.get("limit"))
+    if limit is not None:
+        report = MemoryEvidenceRepairApprovalReport(
+            generated_at=report.generated_at,
+            candidates=report.candidates[:limit],
+        )
+
+    payload = report.to_dict()
+    if limit is not None:
+        payload["limited_to"] = limit
+    payload["success"] = True
+    payload["read_only"] = True
+    payload["read_only_memory"] = True
+    if str(args.get("format", "")).lower() == "markdown":
+        payload["markdown"] = _render_markdown(payload)
+    return json.dumps(payload, ensure_ascii=False)
+
+
+def _resolve_plan(args: dict[str, Any], memory_manager: Any) -> dict[str, Any] | str:
+    explicit_plan = args.get("plan")
+    explicit_repairs = args.get("repairs")
+    if explicit_plan is not None:
+        if not isinstance(explicit_plan, dict):
+            return tool_error("plan must be an object when provided.", success=False)
+        return explicit_plan
+    if explicit_repairs is not None:
+        if not isinstance(explicit_repairs, list):
+            return tool_error("repairs must be an array when provided.", success=False)
+        return {
+            "summary": {"repair_count": len(explicit_repairs)},
+            "repairs": explicit_repairs,
+            "read_only": True,
+        }
+
+    raw_inputs = _resolve_raw_inputs(args, memory_manager)
+    if isinstance(raw_inputs, str):
+        return raw_inputs
+    gate, audit, diagnostics, policy = raw_inputs
+    return build_evidence_repair_plan(
+        gate=gate,
+        audit=audit,
+        diagnostics=diagnostics,
+        policy=policy,
+    ).to_dict()
+
+
+def _resolve_raw_inputs(
+    args: dict[str, Any],
+    memory_manager: Any,
+) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any], dict[str, Any]] | str:
+    explicit_gate = args.get("gate")
+    explicit_audit = args.get("audit")
+    explicit_diagnostics = args.get("diagnostics")
+    explicit_policy = args.get("policy")
+    for field_name, value in (
+        ("gate", explicit_gate),
+        ("audit", explicit_audit),
+        ("diagnostics", explicit_diagnostics),
+        ("policy", explicit_policy),
+    ):
+        if value is not None and not isinstance(value, dict):
+            return tool_error(f"{field_name} must be an object when provided.", success=False)
+
+    gate = explicit_gate if isinstance(explicit_gate, dict) else _manager_dict(
+        memory_manager,
+        "last_memory_policy_gate",
+    )
+    audit = explicit_audit if isinstance(explicit_audit, dict) else _manager_dict(
+        memory_manager,
+        "last_recall_audit",
+    )
+    diagnostics = (
+        explicit_diagnostics
+        if isinstance(explicit_diagnostics, dict)
+        else _manager_dict(memory_manager, "last_recall_diagnostics")
+    )
+    policy = explicit_policy if isinstance(explicit_policy, dict) else _manager_dict(
+        memory_manager,
+        "last_memory_auto_policy",
+    )
+    return gate, audit, diagnostics, policy
+
+
+def _manager_dict(memory_manager: Any, method_name: str) -> dict[str, Any]:
+    if memory_manager is None or not hasattr(memory_manager, method_name):
+        return {}
+    try:
+        value = getattr(memory_manager, method_name)()
+    except Exception:
+        return {}
+    return dict(value) if isinstance(value, dict) else {}
+
+
+def _positive_int(value: Any) -> int | None:
+    if value is None:
+        return None
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed if parsed > 0 else None
+
+
+def _render_markdown(payload: dict[str, Any]) -> str:
+    summary = payload.get("summary", {})
+    lines = [
+        "### Memory Evidence Repair Approval Candidates",
+        f"- Candidates: {summary.get('candidate_count', 0)}",
+        f"- Requires confirmation: {summary.get('requires_user_confirmation', False)}",
+        f"- By priority: {summary.get('by_priority', {})}",
+    ]
+    for index, candidate in enumerate(payload.get("candidates", []), start=1):
+        provider = candidate.get("provider") or "memory"
+        lines.append(
+            f"{index}. [{candidate.get('priority')}] "
+            f"{candidate.get('repair_action')} provider={provider}"
+        )
+        question = candidate.get("confirmation_question")
+        if question:
+            lines.append(f"   Confirm: {question}")
+        required = candidate.get("required_evidence") or []
+        if required:
+            lines.append(f"   Required: {', '.join(str(item) for item in required)}")
+    return "\n".join(lines)
+
+
+def check_memory_evidence_repair_approval_candidates_requirements() -> bool:
+    return True
+
+
+registry.register(
+    name="memory_evidence_repair_approval_candidates",
+    toolset="memory",
+    schema=MEMORY_EVIDENCE_REPAIR_APPROVAL_CANDIDATES_SCHEMA,
+    handler=memory_evidence_repair_approval_candidates_tool,
+    check_fn=check_memory_evidence_repair_approval_candidates_requirements,
+    emoji="🧠",
+)

--- a/tools/memory_evidence_repair_approval_token_gate_tool.py
+++ b/tools/memory_evidence_repair_approval_token_gate_tool.py
@@ -1,0 +1,262 @@
+"""Read-only Memory Evidence Repair Approval Token Gate tool."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from agent.memory_evidence_repair_approval_token_gate import (
+    build_evidence_repair_approval_token_gate,
+)
+from tools.memory_evidence_repair_human_approval_token_tool import (
+    MEMORY_EVIDENCE_REPAIR_HUMAN_APPROVAL_TOKEN_SCHEMA,
+    memory_evidence_repair_human_approval_token_tool,
+)
+from tools.registry import registry, tool_error
+
+
+_UPSTREAM_PROPERTIES = dict(
+    MEMORY_EVIDENCE_REPAIR_HUMAN_APPROVAL_TOKEN_SCHEMA["parameters"]["properties"]
+)
+_UPSTREAM_PROPERTIES.pop("format", None)
+
+MEMORY_EVIDENCE_REPAIR_APPROVAL_TOKEN_GATE_SCHEMA = {
+    "name": "memory_evidence_repair_approval_token_gate",
+    "description": (
+        "Read-only gate that verifies a human approval token before any later "
+        "manual memory evidence repair commit. It never mutates durable memory."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "approval_token": {
+                "type": "object",
+                "description": "Optional approval token report payload.",
+                "additionalProperties": True,
+            },
+            "token": {
+                "type": "object",
+                "description": "Optional single approval token payload.",
+                "additionalProperties": True,
+            },
+            "tokens": {
+                "type": "array",
+                "description": "Optional approval token list.",
+                "items": {"type": "object", "additionalProperties": True},
+            },
+            "confirmation_text": {
+                "type": "string",
+                "description": "Exact human confirmation text required by the token.",
+            },
+            "used_token_ids": {
+                "type": "array",
+                "description": "Read-only ids already marked as used by an external ledger.",
+                "items": {"type": "string"},
+            },
+            "token_generated_at": {
+                "type": "string",
+                "description": "Issue time for bare token payloads.",
+            },
+            "current_time": {
+                "type": "string",
+                "description": "Optional current time override for deterministic verification.",
+            },
+            "format": {
+                "type": "string",
+                "enum": ["json", "markdown"],
+                "description": "Optional response format helper. JSON is always returned; markdown adds a readable summary field.",
+            },
+            **_UPSTREAM_PROPERTIES,
+        },
+    },
+}
+
+
+def memory_evidence_repair_approval_token_gate_tool(
+    args: dict[str, Any],
+    **kwargs,
+) -> str:
+    if not isinstance(args, dict):
+        return tool_error("args must be an object.", success=False)
+
+    validated = _validate_args(args)
+    if validated is not None:
+        return validated
+
+    approval_token = _resolve_approval_token(args, kwargs.get("memory_manager"))
+    if isinstance(approval_token, str):
+        return approval_token
+
+    dry_run = _resolve_dry_run(args, approval_token)
+    payload = build_evidence_repair_approval_token_gate(
+        approval_token=approval_token,
+        dry_run=dry_run,
+        confirmation_text=str(args.get("confirmation_text") or ""),
+        used_token_ids=(
+            args.get("used_token_ids")
+            if isinstance(args.get("used_token_ids"), list)
+            else None
+        ),
+        current_time=args.get("current_time"),
+    ).to_dict()
+    payload["success"] = True
+    payload["read_only"] = True
+    payload["read_only_memory"] = True
+    payload["would_mutate_memory"] = False
+    if str(args.get("format", "")).lower() == "markdown":
+        payload["markdown"] = _render_markdown(payload)
+    return json.dumps(payload, ensure_ascii=False)
+
+
+def _validate_args(args: dict[str, Any]) -> str | None:
+    object_fields = (
+        "approval_token",
+        "token",
+        "dry_run",
+        "snapshot_plan",
+        "rollback_plan",
+        "existing_snapshots",
+        "pre_commit_snapshots",
+        "ledger",
+        "commit_gate",
+        "preview",
+        "approval",
+        "plan",
+        "gate",
+        "audit",
+        "diagnostics",
+        "policy",
+        "proposed_evidence",
+    )
+    array_fields = (
+        "tokens",
+        "used_token_ids",
+        "requests",
+        "steps",
+        "entries",
+        "decisions",
+        "previews",
+        "confirmed_preview_ids",
+        "candidates",
+        "approved_candidate_ids",
+        "repairs",
+    )
+    for field_name in object_fields:
+        value = args.get(field_name)
+        if value is not None and not isinstance(value, dict):
+            return tool_error(f"{field_name} must be an object when provided.", success=False)
+    for field_name in array_fields:
+        value = args.get(field_name)
+        if value is not None and not isinstance(value, list):
+            return tool_error(f"{field_name} must be an array when provided.", success=False)
+    return None
+
+
+def _resolve_approval_token(
+    args: dict[str, Any],
+    memory_manager: Any,
+) -> dict[str, Any] | str:
+    explicit_report = args.get("approval_token")
+    if isinstance(explicit_report, dict):
+        if "generated_at" not in explicit_report and args.get("token_generated_at"):
+            explicit_report = dict(explicit_report)
+            explicit_report["generated_at"] = str(args.get("token_generated_at") or "")
+        return explicit_report
+
+    explicit_token = args.get("token")
+    if isinstance(explicit_token, dict):
+        return {
+            "generated_at": str(args.get("token_generated_at") or ""),
+            "tokens": [explicit_token],
+            "read_only": True,
+            "read_only_memory": True,
+            "would_mutate_memory": False,
+        }
+
+    explicit_tokens = args.get("tokens")
+    if isinstance(explicit_tokens, list):
+        return {
+            "generated_at": str(args.get("token_generated_at") or ""),
+            "tokens": explicit_tokens,
+            "read_only": True,
+            "read_only_memory": True,
+            "would_mutate_memory": False,
+        }
+
+    token_args = dict(args)
+    for field_name in (
+        "approval_token",
+        "token",
+        "tokens",
+        "confirmation_text",
+        "used_token_ids",
+        "token_generated_at",
+        "current_time",
+        "format",
+    ):
+        token_args.pop(field_name, None)
+    result = memory_evidence_repair_human_approval_token_tool(
+        token_args,
+        memory_manager=memory_manager,
+    )
+    try:
+        payload = json.loads(result)
+    except json.JSONDecodeError:
+        return tool_error("human approval token tool returned invalid JSON.", success=False)
+    if not isinstance(payload, dict):
+        return tool_error("human approval token tool returned a non-object payload.", success=False)
+    if payload.get("success") is False:
+        return json.dumps(payload, ensure_ascii=False)
+    return payload
+
+
+def _resolve_dry_run(args: dict[str, Any], approval_token: dict[str, Any]) -> dict[str, Any]:
+    explicit = args.get("dry_run")
+    if isinstance(explicit, dict):
+        return explicit
+    token = _first_token(approval_token)
+    source_dry_run = token.get("source_dry_run") if isinstance(token, dict) else {}
+    return dict(source_dry_run) if isinstance(source_dry_run, dict) else {}
+
+
+def _first_token(approval_token: dict[str, Any]) -> dict[str, Any]:
+    tokens = approval_token.get("tokens")
+    if isinstance(tokens, list):
+        for token in tokens:
+            if isinstance(token, dict):
+                return token
+    if isinstance(approval_token, dict) and approval_token.get("id"):
+        return approval_token
+    return {}
+
+
+def _render_markdown(payload: dict[str, Any]) -> str:
+    summary = payload.get("summary", {})
+    lines = [
+        "### Memory Evidence Repair Approval Token Gate",
+        f"- Status: {payload.get('status')}",
+        f"- Token: {payload.get('token_id') or 'none'}",
+        f"- Checks: {summary.get('check_count', 0)}",
+        f"- Passed: {summary.get('pass_count', 0)}",
+        f"- Failed: {summary.get('fail_count', 0)}",
+        f"- Manual commit verified: {summary.get('manual_commit_verified', False)}",
+    ]
+    for reason in payload.get("blocking_reasons", []):
+        lines.append(f"- Blocked: {reason}")
+    for action in payload.get("required_actions", []):
+        lines.append(f"- Required: {action}")
+    return "\n".join(lines)
+
+
+def check_memory_evidence_repair_approval_token_gate_requirements() -> bool:
+    return True
+
+
+registry.register(
+    name="memory_evidence_repair_approval_token_gate",
+    toolset="memory",
+    schema=MEMORY_EVIDENCE_REPAIR_APPROVAL_TOKEN_GATE_SCHEMA,
+    handler=memory_evidence_repair_approval_token_gate_tool,
+    check_fn=check_memory_evidence_repair_approval_token_gate_requirements,
+    emoji="🧠",
+)

--- a/tools/memory_evidence_repair_commit_gate_tool.py
+++ b/tools/memory_evidence_repair_commit_gate_tool.py
@@ -1,0 +1,345 @@
+"""Read-only Memory Evidence Repair Commit Gate tool."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from agent.memory_evidence_repair_apply_preview import (
+    build_evidence_repair_apply_preview,
+)
+from agent.memory_evidence_repair_approval import (
+    build_evidence_repair_approval_candidates,
+)
+from agent.memory_evidence_repair_commit_gate import (
+    MemoryEvidenceRepairCommitGateReport,
+    build_evidence_repair_commit_gate,
+)
+from agent.memory_evidence_repair_planner import build_evidence_repair_plan
+from tools.registry import registry, tool_error
+
+
+MEMORY_EVIDENCE_REPAIR_COMMIT_GATE_SCHEMA = {
+    "name": "memory_evidence_repair_commit_gate",
+    "description": (
+        "Read-only gate that decides whether an evidence repair apply preview "
+        "is eligible for a later manual memory write. It never mutates durable memory."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "preview": {
+                "type": "object",
+                "description": "Optional apply preview report payload.",
+                "additionalProperties": True,
+            },
+            "previews": {
+                "type": "array",
+                "description": "Optional apply previews to gate.",
+                "items": {"type": "object", "additionalProperties": True},
+            },
+            "confirmed_preview_ids": {
+                "type": "array",
+                "description": "Optional preview ids explicitly confirmed by the user.",
+                "items": {"type": "string"},
+            },
+            "user_confirmed": {
+                "type": "boolean",
+                "description": "Whether the user explicitly confirmed these previews.",
+            },
+            "approval": {
+                "type": "object",
+                "description": "Optional approval candidate report payload.",
+                "additionalProperties": True,
+            },
+            "candidates": {
+                "type": "array",
+                "description": "Optional approval candidates used to build previews.",
+                "items": {"type": "object", "additionalProperties": True},
+            },
+            "approved_candidate_ids": {
+                "type": "array",
+                "description": "Optional candidate ids confirmed for apply preview generation.",
+                "items": {"type": "string"},
+            },
+            "plan": {
+                "type": "object",
+                "description": "Optional evidence repair plan payload.",
+                "additionalProperties": True,
+            },
+            "repairs": {
+                "type": "array",
+                "description": "Optional repair items used to build candidates.",
+                "items": {"type": "object", "additionalProperties": True},
+            },
+            "gate": {
+                "type": "object",
+                "description": "Optional memory policy gate payload.",
+                "additionalProperties": True,
+            },
+            "audit": {
+                "type": "object",
+                "description": "Optional memory recall audit payload.",
+                "additionalProperties": True,
+            },
+            "diagnostics": {
+                "type": "object",
+                "description": "Optional memory recall diagnostics payload.",
+                "additionalProperties": True,
+            },
+            "policy": {
+                "type": "object",
+                "description": "Optional memory auto-policy payload.",
+                "additionalProperties": True,
+            },
+            "proposed_evidence": {
+                "type": "object",
+                "description": "Optional proposed evidence values keyed globally or by candidate id.",
+                "additionalProperties": True,
+            },
+            "format": {
+                "type": "string",
+                "enum": ["json", "markdown"],
+                "description": "Optional response format helper. JSON is always returned; markdown adds a readable summary field.",
+            },
+            "limit": {
+                "type": "integer",
+                "description": "Maximum gate decisions to include. Defaults to all decisions.",
+            },
+        },
+    },
+}
+
+
+def memory_evidence_repair_commit_gate_tool(
+    args: dict[str, Any],
+    **kwargs,
+) -> str:
+    if not isinstance(args, dict):
+        return tool_error("args must be an object.", success=False)
+
+    validated = _validate_args(args)
+    if validated is not None:
+        return validated
+
+    preview = _resolve_preview(args, kwargs.get("memory_manager"))
+    if isinstance(preview, str):
+        return preview
+
+    report = build_evidence_repair_commit_gate(
+        preview=preview,
+        confirmed_preview_ids=(
+            args.get("confirmed_preview_ids")
+            if isinstance(args.get("confirmed_preview_ids"), list)
+            else None
+        ),
+        user_confirmed=bool(args.get("user_confirmed")),
+    )
+
+    limit = _positive_int(args.get("limit"))
+    if limit is not None:
+        report = MemoryEvidenceRepairCommitGateReport(
+            generated_at=report.generated_at,
+            decisions=report.decisions[:limit],
+        )
+
+    payload = report.to_dict()
+    if limit is not None:
+        payload["limited_to"] = limit
+    payload["success"] = True
+    payload["read_only"] = True
+    payload["read_only_memory"] = True
+    payload["would_mutate_memory"] = False
+    if str(args.get("format", "")).lower() == "markdown":
+        payload["markdown"] = _render_markdown(payload)
+    return json.dumps(payload, ensure_ascii=False)
+
+
+def _validate_args(args: dict[str, Any]) -> str | None:
+    object_fields = (
+        "preview",
+        "approval",
+        "plan",
+        "gate",
+        "audit",
+        "diagnostics",
+        "policy",
+        "proposed_evidence",
+    )
+    array_fields = (
+        "previews",
+        "confirmed_preview_ids",
+        "candidates",
+        "approved_candidate_ids",
+        "repairs",
+    )
+    for field_name in object_fields:
+        value = args.get(field_name)
+        if value is not None and not isinstance(value, dict):
+            return tool_error(f"{field_name} must be an object when provided.", success=False)
+    for field_name in array_fields:
+        value = args.get(field_name)
+        if value is not None and not isinstance(value, list):
+            return tool_error(f"{field_name} must be an array when provided.", success=False)
+    return None
+
+
+def _resolve_preview(args: dict[str, Any], memory_manager: Any) -> dict[str, Any] | str:
+    explicit_preview = args.get("preview")
+    explicit_previews = args.get("previews")
+    if isinstance(explicit_preview, dict):
+        if "previews" in explicit_preview:
+            return explicit_preview
+        return {
+            "summary": {"preview_count": 1},
+            "previews": [explicit_preview],
+            "read_only": True,
+            "read_only_memory": True,
+            "would_mutate_memory": False,
+        }
+    if isinstance(explicit_previews, list):
+        return {
+            "summary": {"preview_count": len(explicit_previews)},
+            "previews": explicit_previews,
+            "read_only": True,
+            "read_only_memory": True,
+            "would_mutate_memory": False,
+        }
+
+    approval = _resolve_approval(args, memory_manager)
+    if isinstance(approval, str):
+        return approval
+    return build_evidence_repair_apply_preview(
+        approval=approval,
+        approved_candidate_ids=(
+            args.get("approved_candidate_ids")
+            if isinstance(args.get("approved_candidate_ids"), list)
+            else None
+        ),
+        proposed_evidence=(
+            args.get("proposed_evidence")
+            if isinstance(args.get("proposed_evidence"), dict)
+            else {}
+        ),
+    ).to_dict()
+
+
+def _resolve_approval(args: dict[str, Any], memory_manager: Any) -> dict[str, Any] | str:
+    explicit_approval = args.get("approval")
+    explicit_candidates = args.get("candidates")
+    if isinstance(explicit_approval, dict):
+        return explicit_approval
+    if isinstance(explicit_candidates, list):
+        return {
+            "summary": {"candidate_count": len(explicit_candidates)},
+            "candidates": explicit_candidates,
+            "read_only": True,
+            "read_only_memory": True,
+        }
+
+    plan = _resolve_plan(args, memory_manager)
+    if isinstance(plan, str):
+        return plan
+    return build_evidence_repair_approval_candidates(
+        plan=plan,
+        proposed_evidence=(
+            args.get("proposed_evidence")
+            if isinstance(args.get("proposed_evidence"), dict)
+            else {}
+        ),
+    ).to_dict()
+
+
+def _resolve_plan(args: dict[str, Any], memory_manager: Any) -> dict[str, Any] | str:
+    explicit_plan = args.get("plan")
+    explicit_repairs = args.get("repairs")
+    if isinstance(explicit_plan, dict):
+        return explicit_plan
+    if isinstance(explicit_repairs, list):
+        return {
+            "summary": {"repair_count": len(explicit_repairs)},
+            "repairs": explicit_repairs,
+            "read_only": True,
+        }
+
+    gate = args.get("gate") if isinstance(args.get("gate"), dict) else _manager_dict(
+        memory_manager,
+        "last_memory_policy_gate",
+    )
+    audit = args.get("audit") if isinstance(args.get("audit"), dict) else _manager_dict(
+        memory_manager,
+        "last_recall_audit",
+    )
+    diagnostics = (
+        args.get("diagnostics")
+        if isinstance(args.get("diagnostics"), dict)
+        else _manager_dict(memory_manager, "last_recall_diagnostics")
+    )
+    policy = args.get("policy") if isinstance(args.get("policy"), dict) else _manager_dict(
+        memory_manager,
+        "last_memory_auto_policy",
+    )
+    return build_evidence_repair_plan(
+        gate=gate,
+        audit=audit,
+        diagnostics=diagnostics,
+        policy=policy,
+    ).to_dict()
+
+
+def _manager_dict(memory_manager: Any, method_name: str) -> dict[str, Any]:
+    if memory_manager is None or not hasattr(memory_manager, method_name):
+        return {}
+    try:
+        value = getattr(memory_manager, method_name)()
+    except Exception:
+        return {}
+    return dict(value) if isinstance(value, dict) else {}
+
+
+def _positive_int(value: Any) -> int | None:
+    if value is None:
+        return None
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed if parsed > 0 else None
+
+
+def _render_markdown(payload: dict[str, Any]) -> str:
+    summary = payload.get("summary", {})
+    lines = [
+        "### Memory Evidence Repair Commit Gate",
+        f"- Decisions: {summary.get('decision_count', 0)}",
+        f"- Allow: {summary.get('allow_count', 0)}",
+        f"- Blocked: {summary.get('blocked_count', 0)}",
+        f"- Needs confirmation: {summary.get('needs_confirmation_count', 0)}",
+    ]
+    for index, decision in enumerate(payload.get("decisions", []), start=1):
+        provider = decision.get("provider") or "memory"
+        lines.append(
+            f"{index}. [{decision.get('decision')}] "
+            f"{decision.get('repair_action')} provider={provider}"
+        )
+        reasons = decision.get("reasons") or []
+        if reasons:
+            lines.append(f"   Reasons: {', '.join(str(item) for item in reasons)}")
+        required = decision.get("required_actions") or []
+        if required:
+            lines.append(f"   Required: {', '.join(str(item) for item in required)}")
+    return "\n".join(lines)
+
+
+def check_memory_evidence_repair_commit_gate_requirements() -> bool:
+    return True
+
+
+registry.register(
+    name="memory_evidence_repair_commit_gate",
+    toolset="memory",
+    schema=MEMORY_EVIDENCE_REPAIR_COMMIT_GATE_SCHEMA,
+    handler=memory_evidence_repair_commit_gate_tool,
+    check_fn=check_memory_evidence_repair_commit_gate_requirements,
+    emoji="🧠",
+)

--- a/tools/memory_evidence_repair_commit_ledger_tool.py
+++ b/tools/memory_evidence_repair_commit_ledger_tool.py
@@ -1,0 +1,403 @@
+"""Read-only Memory Evidence Repair Commit Ledger tool."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from agent.memory_evidence_repair_apply_preview import (
+    build_evidence_repair_apply_preview,
+)
+from agent.memory_evidence_repair_approval import (
+    build_evidence_repair_approval_candidates,
+)
+from agent.memory_evidence_repair_commit_gate import (
+    build_evidence_repair_commit_gate,
+)
+from agent.memory_evidence_repair_commit_ledger import (
+    MemoryEvidenceRepairCommitLedgerDraft,
+    build_evidence_repair_commit_ledger,
+)
+from agent.memory_evidence_repair_planner import build_evidence_repair_plan
+from tools.registry import registry, tool_error
+
+
+MEMORY_EVIDENCE_REPAIR_COMMIT_LEDGER_SCHEMA = {
+    "name": "memory_evidence_repair_commit_ledger",
+    "description": (
+        "Read-only audit ledger draft for memory evidence repair commit gate "
+        "decisions. It never mutates durable memory."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "commit_gate": {
+                "type": "object",
+                "description": "Optional commit gate report payload.",
+                "additionalProperties": True,
+            },
+            "decisions": {
+                "type": "array",
+                "description": "Optional commit gate decisions to ledger.",
+                "items": {"type": "object", "additionalProperties": True},
+            },
+            "ledger_actor": {
+                "type": "string",
+                "description": "Optional actor label for the ledger draft.",
+            },
+            "ledger_reason": {
+                "type": "string",
+                "description": "Optional reason for creating the ledger draft.",
+            },
+            "preview": {
+                "type": "object",
+                "description": "Optional apply preview report payload.",
+                "additionalProperties": True,
+            },
+            "previews": {
+                "type": "array",
+                "description": "Optional apply previews used to build a commit gate.",
+                "items": {"type": "object", "additionalProperties": True},
+            },
+            "confirmed_preview_ids": {
+                "type": "array",
+                "description": "Optional preview ids explicitly confirmed by the user.",
+                "items": {"type": "string"},
+            },
+            "user_confirmed": {
+                "type": "boolean",
+                "description": "Whether the user explicitly confirmed these previews.",
+            },
+            "approval": {
+                "type": "object",
+                "description": "Optional approval candidate report payload.",
+                "additionalProperties": True,
+            },
+            "candidates": {
+                "type": "array",
+                "description": "Optional approval candidates used to build previews.",
+                "items": {"type": "object", "additionalProperties": True},
+            },
+            "approved_candidate_ids": {
+                "type": "array",
+                "description": "Optional candidate ids confirmed for apply preview generation.",
+                "items": {"type": "string"},
+            },
+            "plan": {
+                "type": "object",
+                "description": "Optional evidence repair plan payload.",
+                "additionalProperties": True,
+            },
+            "repairs": {
+                "type": "array",
+                "description": "Optional repair items used to build candidates.",
+                "items": {"type": "object", "additionalProperties": True},
+            },
+            "gate": {
+                "type": "object",
+                "description": "Optional memory policy gate payload.",
+                "additionalProperties": True,
+            },
+            "audit": {
+                "type": "object",
+                "description": "Optional memory recall audit payload.",
+                "additionalProperties": True,
+            },
+            "diagnostics": {
+                "type": "object",
+                "description": "Optional memory recall diagnostics payload.",
+                "additionalProperties": True,
+            },
+            "policy": {
+                "type": "object",
+                "description": "Optional memory auto-policy payload.",
+                "additionalProperties": True,
+            },
+            "proposed_evidence": {
+                "type": "object",
+                "description": "Optional proposed evidence values keyed globally or by candidate id.",
+                "additionalProperties": True,
+            },
+            "format": {
+                "type": "string",
+                "enum": ["json", "markdown"],
+                "description": "Optional response format helper. JSON is always returned; markdown adds a readable summary field.",
+            },
+            "limit": {
+                "type": "integer",
+                "description": "Maximum ledger entries to include. Defaults to all entries.",
+            },
+        },
+    },
+}
+
+
+def memory_evidence_repair_commit_ledger_tool(
+    args: dict[str, Any],
+    **kwargs,
+) -> str:
+    if not isinstance(args, dict):
+        return tool_error("args must be an object.", success=False)
+
+    validated = _validate_args(args)
+    if validated is not None:
+        return validated
+
+    commit_gate = _resolve_commit_gate(args, kwargs.get("memory_manager"))
+    if isinstance(commit_gate, str):
+        return commit_gate
+
+    report = build_evidence_repair_commit_ledger(
+        commit_gate=commit_gate,
+        ledger_actor=str(args.get("ledger_actor") or "hermes"),
+        ledger_reason=str(args.get("ledger_reason") or ""),
+    )
+
+    limit = _positive_int(args.get("limit"))
+    if limit is not None:
+        report = MemoryEvidenceRepairCommitLedgerDraft(
+            generated_at=report.generated_at,
+            entries=report.entries[:limit],
+        )
+
+    payload = report.to_dict()
+    if limit is not None:
+        payload["limited_to"] = limit
+    payload["success"] = True
+    payload["read_only"] = True
+    payload["read_only_memory"] = True
+    payload["would_mutate_memory"] = False
+    if str(args.get("format", "")).lower() == "markdown":
+        payload["markdown"] = _render_markdown(payload)
+    return json.dumps(payload, ensure_ascii=False)
+
+
+def _validate_args(args: dict[str, Any]) -> str | None:
+    object_fields = (
+        "commit_gate",
+        "preview",
+        "approval",
+        "plan",
+        "gate",
+        "audit",
+        "diagnostics",
+        "policy",
+        "proposed_evidence",
+    )
+    array_fields = (
+        "decisions",
+        "previews",
+        "confirmed_preview_ids",
+        "candidates",
+        "approved_candidate_ids",
+        "repairs",
+    )
+    for field_name in object_fields:
+        value = args.get(field_name)
+        if value is not None and not isinstance(value, dict):
+            return tool_error(f"{field_name} must be an object when provided.", success=False)
+    for field_name in array_fields:
+        value = args.get(field_name)
+        if value is not None and not isinstance(value, list):
+            return tool_error(f"{field_name} must be an array when provided.", success=False)
+    return None
+
+
+def _resolve_commit_gate(
+    args: dict[str, Any],
+    memory_manager: Any,
+) -> dict[str, Any] | str:
+    explicit_gate = args.get("commit_gate")
+    explicit_decisions = args.get("decisions")
+    if isinstance(explicit_gate, dict):
+        if "decisions" in explicit_gate:
+            return explicit_gate
+        return {
+            "summary": {"decision_count": 1},
+            "decisions": [explicit_gate],
+            "read_only": True,
+            "read_only_memory": True,
+            "would_mutate_memory": False,
+        }
+    if isinstance(explicit_decisions, list):
+        return {
+            "summary": {"decision_count": len(explicit_decisions)},
+            "decisions": explicit_decisions,
+            "read_only": True,
+            "read_only_memory": True,
+            "would_mutate_memory": False,
+        }
+
+    preview = _resolve_preview(args, memory_manager)
+    if isinstance(preview, str):
+        return preview
+    return build_evidence_repair_commit_gate(
+        preview=preview,
+        confirmed_preview_ids=(
+            args.get("confirmed_preview_ids")
+            if isinstance(args.get("confirmed_preview_ids"), list)
+            else None
+        ),
+        user_confirmed=bool(args.get("user_confirmed")),
+    ).to_dict()
+
+
+def _resolve_preview(args: dict[str, Any], memory_manager: Any) -> dict[str, Any] | str:
+    explicit_preview = args.get("preview")
+    explicit_previews = args.get("previews")
+    if isinstance(explicit_preview, dict):
+        if "previews" in explicit_preview:
+            return explicit_preview
+        return {
+            "summary": {"preview_count": 1},
+            "previews": [explicit_preview],
+            "read_only": True,
+            "read_only_memory": True,
+            "would_mutate_memory": False,
+        }
+    if isinstance(explicit_previews, list):
+        return {
+            "summary": {"preview_count": len(explicit_previews)},
+            "previews": explicit_previews,
+            "read_only": True,
+            "read_only_memory": True,
+            "would_mutate_memory": False,
+        }
+
+    approval = _resolve_approval(args, memory_manager)
+    if isinstance(approval, str):
+        return approval
+    return build_evidence_repair_apply_preview(
+        approval=approval,
+        approved_candidate_ids=(
+            args.get("approved_candidate_ids")
+            if isinstance(args.get("approved_candidate_ids"), list)
+            else None
+        ),
+        proposed_evidence=(
+            args.get("proposed_evidence")
+            if isinstance(args.get("proposed_evidence"), dict)
+            else {}
+        ),
+    ).to_dict()
+
+
+def _resolve_approval(args: dict[str, Any], memory_manager: Any) -> dict[str, Any] | str:
+    explicit_approval = args.get("approval")
+    explicit_candidates = args.get("candidates")
+    if isinstance(explicit_approval, dict):
+        return explicit_approval
+    if isinstance(explicit_candidates, list):
+        return {
+            "summary": {"candidate_count": len(explicit_candidates)},
+            "candidates": explicit_candidates,
+            "read_only": True,
+            "read_only_memory": True,
+        }
+
+    plan = _resolve_plan(args, memory_manager)
+    if isinstance(plan, str):
+        return plan
+    return build_evidence_repair_approval_candidates(
+        plan=plan,
+        proposed_evidence=(
+            args.get("proposed_evidence")
+            if isinstance(args.get("proposed_evidence"), dict)
+            else {}
+        ),
+    ).to_dict()
+
+
+def _resolve_plan(args: dict[str, Any], memory_manager: Any) -> dict[str, Any] | str:
+    explicit_plan = args.get("plan")
+    explicit_repairs = args.get("repairs")
+    if isinstance(explicit_plan, dict):
+        return explicit_plan
+    if isinstance(explicit_repairs, list):
+        return {
+            "summary": {"repair_count": len(explicit_repairs)},
+            "repairs": explicit_repairs,
+            "read_only": True,
+        }
+
+    gate = args.get("gate") if isinstance(args.get("gate"), dict) else _manager_dict(
+        memory_manager,
+        "last_memory_policy_gate",
+    )
+    audit = args.get("audit") if isinstance(args.get("audit"), dict) else _manager_dict(
+        memory_manager,
+        "last_recall_audit",
+    )
+    diagnostics = (
+        args.get("diagnostics")
+        if isinstance(args.get("diagnostics"), dict)
+        else _manager_dict(memory_manager, "last_recall_diagnostics")
+    )
+    policy = args.get("policy") if isinstance(args.get("policy"), dict) else _manager_dict(
+        memory_manager,
+        "last_memory_auto_policy",
+    )
+    return build_evidence_repair_plan(
+        gate=gate,
+        audit=audit,
+        diagnostics=diagnostics,
+        policy=policy,
+    ).to_dict()
+
+
+def _manager_dict(memory_manager: Any, method_name: str) -> dict[str, Any]:
+    if memory_manager is None or not hasattr(memory_manager, method_name):
+        return {}
+    try:
+        value = getattr(memory_manager, method_name)()
+    except Exception:
+        return {}
+    return dict(value) if isinstance(value, dict) else {}
+
+
+def _positive_int(value: Any) -> int | None:
+    if value is None:
+        return None
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed if parsed > 0 else None
+
+
+def _render_markdown(payload: dict[str, Any]) -> str:
+    summary = payload.get("summary", {})
+    lines = [
+        "### Memory Evidence Repair Commit Ledger",
+        f"- Entries: {summary.get('entry_count', 0)}",
+        f"- Allowed: {summary.get('allow_count', 0)}",
+        f"- Blocked: {summary.get('blocked_count', 0)}",
+        f"- Follow-up: {summary.get('followup_count', 0)}",
+    ]
+    for index, entry in enumerate(payload.get("entries", []), start=1):
+        provider = entry.get("provider") or "memory"
+        lines.append(
+            f"{index}. [{entry.get('outcome')}] "
+            f"{entry.get('repair_action')} provider={provider}"
+        )
+        digest = entry.get("patch_digest", "")
+        if digest:
+            lines.append(f"   Patch digest: {digest[:12]}")
+        required = entry.get("required_actions") or []
+        if required:
+            lines.append(f"   Required: {', '.join(str(item) for item in required)}")
+    return "\n".join(lines)
+
+
+def check_memory_evidence_repair_commit_ledger_requirements() -> bool:
+    return True
+
+
+registry.register(
+    name="memory_evidence_repair_commit_ledger",
+    toolset="memory",
+    schema=MEMORY_EVIDENCE_REPAIR_COMMIT_LEDGER_SCHEMA,
+    handler=memory_evidence_repair_commit_ledger_tool,
+    check_fn=check_memory_evidence_repair_commit_ledger_requirements,
+    emoji="🧠",
+)

--- a/tools/memory_evidence_repair_commit_receipt_tool.py
+++ b/tools/memory_evidence_repair_commit_receipt_tool.py
@@ -1,0 +1,241 @@
+"""Read-only Memory Evidence Repair Manual Commit Receipt tool."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from agent.memory_evidence_repair_commit_receipt import (
+    build_evidence_repair_commit_receipt,
+)
+from tools.memory_evidence_repair_approval_token_gate_tool import (
+    MEMORY_EVIDENCE_REPAIR_APPROVAL_TOKEN_GATE_SCHEMA,
+    memory_evidence_repair_approval_token_gate_tool,
+)
+from tools.registry import registry, tool_error
+
+
+_UPSTREAM_PROPERTIES = dict(
+    MEMORY_EVIDENCE_REPAIR_APPROVAL_TOKEN_GATE_SCHEMA["parameters"]["properties"]
+)
+_UPSTREAM_PROPERTIES.pop("format", None)
+
+MEMORY_EVIDENCE_REPAIR_COMMIT_RECEIPT_SCHEMA = {
+    "name": "memory_evidence_repair_commit_receipt",
+    "description": (
+        "Read-only receipt draft and used-token ledger view for a verified "
+        "memory evidence repair manual commit. It never mutates durable memory."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "token_gate": {
+                "type": "object",
+                "description": "Optional approval token gate payload.",
+                "additionalProperties": True,
+            },
+            "approval_token_gate": {
+                "type": "object",
+                "description": "Alias for token_gate.",
+                "additionalProperties": True,
+            },
+            "existing_receipts": {
+                "description": "Optional existing receipt report or receipt list.",
+                "oneOf": [
+                    {"type": "object", "additionalProperties": True},
+                    {
+                        "type": "array",
+                        "items": {"type": "object", "additionalProperties": True},
+                    },
+                ],
+            },
+            "receipts": {
+                "type": "array",
+                "description": "Optional existing receipt list.",
+                "items": {"type": "object", "additionalProperties": True},
+            },
+            "actor": {
+                "type": "string",
+                "description": "Human actor label for the future receipt.",
+            },
+            "commit_reason": {
+                "type": "string",
+                "description": "Reason for the future manual memory evidence repair commit.",
+            },
+            "format": {
+                "type": "string",
+                "enum": ["json", "markdown"],
+                "description": "Optional response format helper. JSON is always returned; markdown adds a readable summary field.",
+            },
+            **_UPSTREAM_PROPERTIES,
+        },
+    },
+}
+
+
+def memory_evidence_repair_commit_receipt_tool(
+    args: dict[str, Any],
+    **kwargs,
+) -> str:
+    if not isinstance(args, dict):
+        return tool_error("args must be an object.", success=False)
+
+    validated = _validate_args(args)
+    if validated is not None:
+        return validated
+
+    token_gate = _resolve_token_gate(args, kwargs.get("memory_manager"))
+    if isinstance(token_gate, str):
+        return token_gate
+
+    payload = build_evidence_repair_commit_receipt(
+        token_gate=token_gate,
+        existing_receipts=_existing_receipts(args),
+        used_token_ids=(
+            args.get("used_token_ids")
+            if isinstance(args.get("used_token_ids"), list)
+            else None
+        ),
+        actor=str(args.get("actor") or "human"),
+        commit_reason=str(args.get("commit_reason") or ""),
+    ).to_dict()
+    payload["success"] = True
+    payload["read_only"] = True
+    payload["read_only_memory"] = True
+    payload["would_mutate_memory"] = False
+    if str(args.get("format", "")).lower() == "markdown":
+        payload["markdown"] = _render_markdown(payload)
+    return json.dumps(payload, ensure_ascii=False)
+
+
+def _validate_args(args: dict[str, Any]) -> str | None:
+    object_fields = (
+        "token_gate",
+        "approval_token_gate",
+        "approval_token",
+        "token",
+        "dry_run",
+        "snapshot_plan",
+        "rollback_plan",
+        "existing_snapshots",
+        "pre_commit_snapshots",
+        "ledger",
+        "commit_gate",
+        "preview",
+        "approval",
+        "plan",
+        "gate",
+        "audit",
+        "diagnostics",
+        "policy",
+        "proposed_evidence",
+    )
+    array_fields = (
+        "tokens",
+        "used_token_ids",
+        "receipts",
+        "requests",
+        "steps",
+        "entries",
+        "decisions",
+        "previews",
+        "confirmed_preview_ids",
+        "candidates",
+        "approved_candidate_ids",
+        "repairs",
+    )
+    for field_name in object_fields:
+        value = args.get(field_name)
+        if value is not None and not isinstance(value, dict):
+            return tool_error(f"{field_name} must be an object when provided.", success=False)
+    existing_receipts = args.get("existing_receipts")
+    if existing_receipts is not None and not isinstance(existing_receipts, (dict, list)):
+        return tool_error(
+            "existing_receipts must be an object or array when provided.",
+            success=False,
+        )
+    for field_name in array_fields:
+        value = args.get(field_name)
+        if value is not None and not isinstance(value, list):
+            return tool_error(f"{field_name} must be an array when provided.", success=False)
+    return None
+
+
+def _resolve_token_gate(
+    args: dict[str, Any],
+    memory_manager: Any,
+) -> dict[str, Any] | str:
+    explicit_gate = args.get("token_gate")
+    if isinstance(explicit_gate, dict):
+        return explicit_gate
+    explicit_gate = args.get("approval_token_gate")
+    if isinstance(explicit_gate, dict):
+        return explicit_gate
+
+    gate_args = dict(args)
+    for field_name in (
+        "token_gate",
+        "approval_token_gate",
+        "existing_receipts",
+        "receipts",
+        "actor",
+        "commit_reason",
+        "format",
+    ):
+        gate_args.pop(field_name, None)
+    result = memory_evidence_repair_approval_token_gate_tool(
+        gate_args,
+        memory_manager=memory_manager,
+    )
+    try:
+        payload = json.loads(result)
+    except json.JSONDecodeError:
+        return tool_error("approval token gate returned invalid JSON.", success=False)
+    if not isinstance(payload, dict):
+        return tool_error("approval token gate returned a non-object payload.", success=False)
+    if payload.get("success") is False:
+        return json.dumps(payload, ensure_ascii=False)
+    return payload
+
+
+def _existing_receipts(args: dict[str, Any]) -> dict[str, Any] | list[dict[str, Any]] | None:
+    explicit = args.get("existing_receipts")
+    if isinstance(explicit, (dict, list)):
+        return explicit
+    receipts = args.get("receipts")
+    if isinstance(receipts, list):
+        return receipts
+    return None
+
+
+def _render_markdown(payload: dict[str, Any]) -> str:
+    summary = payload.get("summary", {})
+    lines = [
+        "### Memory Evidence Repair Commit Receipt",
+        f"- Status: {payload.get('status')}",
+        f"- Receipts: {summary.get('receipt_count', 0)}",
+        f"- Used tokens: {summary.get('used_token_count', 0)}",
+        f"- Blocks: {summary.get('blocking_reason_count', 0)}",
+        f"- Required actions: {summary.get('required_action_count', 0)}",
+    ]
+    for receipt in payload.get("receipts", []):
+        lines.append(f"- Receipt: {receipt.get('id')}")
+        lines.append(f"  Token: {receipt.get('token_id')}")
+        lines.append(f"  Operations: {len(receipt.get('operation_ids') or [])}")
+    for reason in payload.get("blocking_reasons", []):
+        lines.append(f"- Blocked: {reason}")
+    return "\n".join(lines)
+
+
+def check_memory_evidence_repair_commit_receipt_requirements() -> bool:
+    return True
+
+
+registry.register(
+    name="memory_evidence_repair_commit_receipt",
+    toolset="memory",
+    schema=MEMORY_EVIDENCE_REPAIR_COMMIT_RECEIPT_SCHEMA,
+    handler=memory_evidence_repair_commit_receipt_tool,
+    check_fn=check_memory_evidence_repair_commit_receipt_requirements,
+    emoji="🧠",
+)

--- a/tools/memory_evidence_repair_executor_preview_tool.py
+++ b/tools/memory_evidence_repair_executor_preview_tool.py
@@ -1,0 +1,224 @@
+"""Read-only Memory Evidence Repair Manual Commit Executor Preview tool."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from agent.memory_evidence_repair_executor_preview import (
+    build_evidence_repair_executor_preview,
+)
+from tools.memory_evidence_repair_write_lock_gate_tool import (
+    MEMORY_EVIDENCE_REPAIR_WRITE_LOCK_GATE_SCHEMA,
+    memory_evidence_repair_write_lock_gate_tool,
+)
+from tools.registry import registry, tool_error
+
+
+_UPSTREAM_PROPERTIES = dict(
+    MEMORY_EVIDENCE_REPAIR_WRITE_LOCK_GATE_SCHEMA["parameters"]["properties"]
+)
+_UPSTREAM_PROPERTIES.pop("format", None)
+
+MEMORY_EVIDENCE_REPAIR_EXECUTOR_PREVIEW_SCHEMA = {
+    "name": "memory_evidence_repair_executor_preview",
+    "description": (
+        "Read-only ordered executor preview for a future memory evidence repair "
+        "manual commit. It never mutates durable memory."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "write_lock_gate": {
+                "type": "object",
+                "description": "Optional write-lock gate payload.",
+                "additionalProperties": True,
+            },
+            "executor_lock_gate": {
+                "type": "object",
+                "description": "Alias for write_lock_gate.",
+                "additionalProperties": True,
+            },
+            "write_lock": {
+                "type": "object",
+                "description": "Optional single write-lock draft payload.",
+                "additionalProperties": True,
+            },
+            "format": {
+                "type": "string",
+                "enum": ["json", "markdown"],
+                "description": "Optional response format helper. JSON is always returned; markdown adds a readable summary field.",
+            },
+            **_UPSTREAM_PROPERTIES,
+        },
+    },
+}
+
+
+def memory_evidence_repair_executor_preview_tool(
+    args: dict[str, Any],
+    **kwargs,
+) -> str:
+    if not isinstance(args, dict):
+        return tool_error("args must be an object.", success=False)
+
+    validated = _validate_args(args)
+    if validated is not None:
+        return validated
+
+    write_lock_gate = _resolve_write_lock_gate(args, kwargs.get("memory_manager"))
+    if isinstance(write_lock_gate, str):
+        return write_lock_gate
+
+    payload = build_evidence_repair_executor_preview(
+        write_lock_gate=write_lock_gate,
+        current_time=args.get("current_time"),
+    ).to_dict()
+    payload["success"] = True
+    payload["read_only"] = True
+    payload["read_only_memory"] = True
+    payload["would_mutate_memory"] = False
+    if str(args.get("format", "")).lower() == "markdown":
+        payload["markdown"] = _render_markdown(payload)
+    return json.dumps(payload, ensure_ascii=False)
+
+
+def _validate_args(args: dict[str, Any]) -> str | None:
+    object_fields = (
+        "write_lock_gate",
+        "executor_lock_gate",
+        "write_lock",
+        "commit_receipt",
+        "receipt",
+        "token_gate",
+        "approval_token_gate",
+        "approval_token",
+        "token",
+        "dry_run",
+        "snapshot_plan",
+        "rollback_plan",
+        "existing_snapshots",
+        "pre_commit_snapshots",
+        "ledger",
+        "commit_gate",
+        "preview",
+        "approval",
+        "plan",
+        "gate",
+        "audit",
+        "diagnostics",
+        "policy",
+        "proposed_evidence",
+    )
+    array_fields = (
+        "active_locks",
+        "locks",
+        "already_used_token_ids",
+        "tokens",
+        "used_token_ids",
+        "receipts",
+        "requests",
+        "steps",
+        "entries",
+        "decisions",
+        "previews",
+        "confirmed_preview_ids",
+        "candidates",
+        "approved_candidate_ids",
+        "repairs",
+    )
+    for field_name in object_fields:
+        value = args.get(field_name)
+        if value is not None and not isinstance(value, dict):
+            return tool_error(f"{field_name} must be an object when provided.", success=False)
+    existing_receipts = args.get("existing_receipts")
+    if existing_receipts is not None and not isinstance(existing_receipts, (dict, list)):
+        return tool_error(
+            "existing_receipts must be an object or array when provided.",
+            success=False,
+        )
+    for field_name in array_fields:
+        value = args.get(field_name)
+        if value is not None and not isinstance(value, list):
+            return tool_error(f"{field_name} must be an array when provided.", success=False)
+    return None
+
+
+def _resolve_write_lock_gate(
+    args: dict[str, Any],
+    memory_manager: Any,
+) -> dict[str, Any] | str:
+    explicit_gate = args.get("write_lock_gate")
+    if isinstance(explicit_gate, dict):
+        return explicit_gate
+    explicit_gate = args.get("executor_lock_gate")
+    if isinstance(explicit_gate, dict):
+        return explicit_gate
+
+    explicit_lock = args.get("write_lock")
+    if isinstance(explicit_lock, dict):
+        return {
+            "status": "write_lock_ready_for_manual_commit",
+            "summary": {"lock_count": 1},
+            "locks": [explicit_lock],
+            "read_only": True,
+            "read_only_memory": True,
+            "would_mutate_memory": False,
+        }
+
+    gate_args = dict(args)
+    for field_name in (
+        "write_lock_gate",
+        "executor_lock_gate",
+        "write_lock",
+        "format",
+    ):
+        gate_args.pop(field_name, None)
+    result = memory_evidence_repair_write_lock_gate_tool(
+        gate_args,
+        memory_manager=memory_manager,
+    )
+    try:
+        payload = json.loads(result)
+    except json.JSONDecodeError:
+        return tool_error("write-lock gate returned invalid JSON.", success=False)
+    if not isinstance(payload, dict):
+        return tool_error("write-lock gate returned a non-object payload.", success=False)
+    if payload.get("success") is False:
+        return json.dumps(payload, ensure_ascii=False)
+    return payload
+
+
+def _render_markdown(payload: dict[str, Any]) -> str:
+    summary = payload.get("summary", {})
+    lines = [
+        "### Memory Evidence Repair Executor Preview",
+        f"- Status: {payload.get('status')}",
+        f"- Previews: {summary.get('preview_count', 0)}",
+        f"- Steps: {summary.get('step_count', 0)}",
+        f"- Future write steps: {summary.get('future_write_step_count', 0)}",
+        f"- Ready: {summary.get('manual_executor_preview_ready', False)}",
+    ]
+    for preview in payload.get("previews", []):
+        lines.append(f"- Preview: {preview.get('id')}")
+        lines.append(f"  Lock: {preview.get('lock_id')}")
+        lines.append(f"  Failure policy: {preview.get('failure_policy')}")
+    for reason in payload.get("blocking_reasons", []):
+        lines.append(f"- Blocked: {reason}")
+    for action in payload.get("required_actions", []):
+        lines.append(f"- Required: {action}")
+    return "\n".join(lines)
+
+
+def check_memory_evidence_repair_executor_preview_requirements() -> bool:
+    return True
+
+
+registry.register(
+    name="memory_evidence_repair_executor_preview",
+    toolset="memory",
+    schema=MEMORY_EVIDENCE_REPAIR_EXECUTOR_PREVIEW_SCHEMA,
+    handler=memory_evidence_repair_executor_preview_tool,
+    check_fn=check_memory_evidence_repair_executor_preview_requirements,
+    emoji="🧠",
+)

--- a/tools/memory_evidence_repair_human_approval_token_tool.py
+++ b/tools/memory_evidence_repair_human_approval_token_tool.py
@@ -1,0 +1,303 @@
+"""Read-only Memory Evidence Repair Human Approval Token tool."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from agent.memory_evidence_repair_human_approval_token import (
+    build_evidence_repair_human_approval_token,
+)
+from tools.memory_evidence_repair_manual_commit_dry_run_tool import (
+    memory_evidence_repair_manual_commit_dry_run_tool,
+)
+from tools.registry import registry, tool_error
+
+
+MEMORY_EVIDENCE_REPAIR_HUMAN_APPROVAL_TOKEN_SCHEMA = {
+    "name": "memory_evidence_repair_human_approval_token",
+    "description": (
+        "Read-only human approval token draft for a ready memory evidence "
+        "repair manual commit dry-run. It never mutates durable memory."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "dry_run": {
+                "type": "object",
+                "description": "Optional manual commit dry-run payload.",
+                "additionalProperties": True,
+            },
+            "approver": {
+                "type": "string",
+                "description": "Human approver label for the token draft.",
+            },
+            "approval_reason": {
+                "type": "string",
+                "description": "Reason for drafting the approval token.",
+            },
+            "expires_in_minutes": {
+                "type": "integer",
+                "description": "Draft token expiry window in minutes. Defaults to 30.",
+            },
+            "snapshot_plan": {
+                "type": "object",
+                "description": "Optional snapshot planner payload.",
+                "additionalProperties": True,
+            },
+            "requests": {
+                "type": "array",
+                "description": "Optional snapshot requests.",
+                "items": {"type": "object", "additionalProperties": True},
+            },
+            "rollback_plan": {
+                "type": "object",
+                "description": "Optional rollback plan payload.",
+                "additionalProperties": True,
+            },
+            "steps": {
+                "type": "array",
+                "description": "Optional rollback steps.",
+                "items": {"type": "object", "additionalProperties": True},
+            },
+            "existing_snapshots": {
+                "type": "object",
+                "description": "Optional existing pre-commit snapshots.",
+                "additionalProperties": True,
+            },
+            "pre_commit_snapshots": {
+                "type": "object",
+                "description": "Alias for existing_snapshots.",
+                "additionalProperties": True,
+            },
+            "ledger": {
+                "type": "object",
+                "description": "Optional commit ledger draft payload.",
+                "additionalProperties": True,
+            },
+            "entries": {
+                "type": "array",
+                "description": "Optional commit ledger entries.",
+                "items": {"type": "object", "additionalProperties": True},
+            },
+            "commit_gate": {
+                "type": "object",
+                "description": "Optional commit gate report payload.",
+                "additionalProperties": True,
+            },
+            "decisions": {
+                "type": "array",
+                "description": "Optional commit gate decisions.",
+                "items": {"type": "object", "additionalProperties": True},
+            },
+            "ledger_actor": {
+                "type": "string",
+                "description": "Optional actor label for generated ledger entries.",
+            },
+            "ledger_reason": {
+                "type": "string",
+                "description": "Optional reason for generated ledger entries.",
+            },
+            "preview": {
+                "type": "object",
+                "description": "Optional apply preview report payload.",
+                "additionalProperties": True,
+            },
+            "previews": {
+                "type": "array",
+                "description": "Optional apply previews.",
+                "items": {"type": "object", "additionalProperties": True},
+            },
+            "confirmed_preview_ids": {
+                "type": "array",
+                "description": "Optional preview ids explicitly confirmed by the user.",
+                "items": {"type": "string"},
+            },
+            "user_confirmed": {
+                "type": "boolean",
+                "description": "Whether the user explicitly confirmed these previews.",
+            },
+            "approval": {
+                "type": "object",
+                "description": "Optional approval candidate report payload.",
+                "additionalProperties": True,
+            },
+            "candidates": {
+                "type": "array",
+                "description": "Optional approval candidates.",
+                "items": {"type": "object", "additionalProperties": True},
+            },
+            "approved_candidate_ids": {
+                "type": "array",
+                "description": "Optional candidate ids confirmed for apply preview generation.",
+                "items": {"type": "string"},
+            },
+            "plan": {
+                "type": "object",
+                "description": "Optional evidence repair plan payload.",
+                "additionalProperties": True,
+            },
+            "repairs": {
+                "type": "array",
+                "description": "Optional evidence repair items.",
+                "items": {"type": "object", "additionalProperties": True},
+            },
+            "gate": {
+                "type": "object",
+                "description": "Optional memory policy gate payload.",
+                "additionalProperties": True,
+            },
+            "audit": {
+                "type": "object",
+                "description": "Optional memory recall audit payload.",
+                "additionalProperties": True,
+            },
+            "diagnostics": {
+                "type": "object",
+                "description": "Optional memory recall diagnostics payload.",
+                "additionalProperties": True,
+            },
+            "policy": {
+                "type": "object",
+                "description": "Optional memory auto-policy payload.",
+                "additionalProperties": True,
+            },
+            "proposed_evidence": {
+                "type": "object",
+                "description": "Optional proposed evidence values keyed globally or by candidate id.",
+                "additionalProperties": True,
+            },
+            "format": {
+                "type": "string",
+                "enum": ["json", "markdown"],
+                "description": "Optional response format helper. JSON is always returned; markdown adds a readable summary field.",
+            },
+        },
+    },
+}
+
+
+def memory_evidence_repair_human_approval_token_tool(
+    args: dict[str, Any],
+    **kwargs,
+) -> str:
+    if not isinstance(args, dict):
+        return tool_error("args must be an object.", success=False)
+
+    validated = _validate_args(args)
+    if validated is not None:
+        return validated
+
+    dry_run = _resolve_dry_run(args, kwargs.get("memory_manager"))
+    if isinstance(dry_run, str):
+        return dry_run
+
+    payload = build_evidence_repair_human_approval_token(
+        dry_run=dry_run,
+        approver=str(args.get("approver") or "human"),
+        approval_reason=str(args.get("approval_reason") or ""),
+        expires_in_minutes=args.get("expires_in_minutes") or 30,
+    ).to_dict()
+    payload["success"] = True
+    payload["read_only"] = True
+    payload["read_only_memory"] = True
+    payload["would_mutate_memory"] = False
+    if str(args.get("format", "")).lower() == "markdown":
+        payload["markdown"] = _render_markdown(payload)
+    return json.dumps(payload, ensure_ascii=False)
+
+
+def _validate_args(args: dict[str, Any]) -> str | None:
+    object_fields = (
+        "dry_run",
+        "snapshot_plan",
+        "rollback_plan",
+        "existing_snapshots",
+        "pre_commit_snapshots",
+        "ledger",
+        "commit_gate",
+        "preview",
+        "approval",
+        "plan",
+        "gate",
+        "audit",
+        "diagnostics",
+        "policy",
+        "proposed_evidence",
+    )
+    array_fields = (
+        "requests",
+        "steps",
+        "entries",
+        "decisions",
+        "previews",
+        "confirmed_preview_ids",
+        "candidates",
+        "approved_candidate_ids",
+        "repairs",
+    )
+    for field_name in object_fields:
+        value = args.get(field_name)
+        if value is not None and not isinstance(value, dict):
+            return tool_error(f"{field_name} must be an object when provided.", success=False)
+    for field_name in array_fields:
+        value = args.get(field_name)
+        if value is not None and not isinstance(value, list):
+            return tool_error(f"{field_name} must be an array when provided.", success=False)
+    return None
+
+
+def _resolve_dry_run(args: dict[str, Any], memory_manager: Any) -> dict[str, Any] | str:
+    explicit = args.get("dry_run")
+    if isinstance(explicit, dict):
+        return explicit
+
+    dry_run_args = dict(args)
+    dry_run_args.pop("dry_run", None)
+    dry_run_args.pop("approver", None)
+    dry_run_args.pop("approval_reason", None)
+    dry_run_args.pop("expires_in_minutes", None)
+    result = memory_evidence_repair_manual_commit_dry_run_tool(
+        dry_run_args,
+        memory_manager=memory_manager,
+    )
+    try:
+        payload = json.loads(result)
+    except json.JSONDecodeError:
+        return tool_error("manual commit dry-run returned invalid JSON.", success=False)
+    if not isinstance(payload, dict):
+        return tool_error("manual commit dry-run returned a non-object payload.", success=False)
+    if payload.get("success") is False:
+        return json.dumps(payload, ensure_ascii=False)
+    return payload
+
+
+def _render_markdown(payload: dict[str, Any]) -> str:
+    summary = payload.get("summary", {})
+    lines = [
+        "### Memory Evidence Repair Human Approval Token",
+        f"- Status: {payload.get('status')}",
+        f"- Tokens: {summary.get('token_count', 0)}",
+        f"- Blocks: {summary.get('blocking_reason_count', 0)}",
+        f"- Required actions: {summary.get('required_action_count', 0)}",
+    ]
+    for token in payload.get("tokens", []):
+        lines.append(f"- Token: {token.get('id')}")
+        lines.append(f"  Confirm: {token.get('required_confirmation_text')}")
+    for reason in payload.get("blocking_reasons", []):
+        lines.append(f"- Blocked: {reason}")
+    return "\n".join(lines)
+
+
+def check_memory_evidence_repair_human_approval_token_requirements() -> bool:
+    return True
+
+
+registry.register(
+    name="memory_evidence_repair_human_approval_token",
+    toolset="memory",
+    schema=MEMORY_EVIDENCE_REPAIR_HUMAN_APPROVAL_TOKEN_SCHEMA,
+    handler=memory_evidence_repair_human_approval_token_tool,
+    check_fn=check_memory_evidence_repair_human_approval_token_requirements,
+    emoji="🧠",
+)

--- a/tools/memory_evidence_repair_manual_commit_dry_run_tool.py
+++ b/tools/memory_evidence_repair_manual_commit_dry_run_tool.py
@@ -1,0 +1,583 @@
+"""Read-only Memory Evidence Repair Manual Commit Dry-Run tool."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from agent.memory_evidence_repair_apply_preview import (
+    build_evidence_repair_apply_preview,
+)
+from agent.memory_evidence_repair_approval import (
+    build_evidence_repair_approval_candidates,
+)
+from agent.memory_evidence_repair_commit_gate import (
+    build_evidence_repair_commit_gate,
+)
+from agent.memory_evidence_repair_commit_ledger import (
+    build_evidence_repair_commit_ledger,
+)
+from agent.memory_evidence_repair_manual_commit_dry_run import (
+    build_evidence_repair_manual_commit_dry_run,
+)
+from agent.memory_evidence_repair_planner import build_evidence_repair_plan
+from agent.memory_evidence_repair_rollback_plan import (
+    build_evidence_repair_rollback_plan,
+)
+from agent.memory_evidence_repair_snapshot_planner import (
+    build_evidence_repair_snapshot_plan,
+)
+from tools.registry import registry, tool_error
+
+
+MEMORY_EVIDENCE_REPAIR_MANUAL_COMMIT_DRY_RUN_SCHEMA = {
+    "name": "memory_evidence_repair_manual_commit_dry_run",
+    "description": (
+        "Read-only final dry-run before a future manual memory evidence repair "
+        "commit. It summarizes gate, ledger, rollback, and snapshot readiness."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "snapshot_plan": {
+                "type": "object",
+                "description": "Optional snapshot planner payload.",
+                "additionalProperties": True,
+            },
+            "requests": {
+                "type": "array",
+                "description": "Optional snapshot requests.",
+                "items": {"type": "object", "additionalProperties": True},
+            },
+            "rollback_plan": {
+                "type": "object",
+                "description": "Optional rollback plan payload.",
+                "additionalProperties": True,
+            },
+            "steps": {
+                "type": "array",
+                "description": "Optional rollback steps.",
+                "items": {"type": "object", "additionalProperties": True},
+            },
+            "existing_snapshots": {
+                "type": "object",
+                "description": "Optional existing pre-commit snapshots.",
+                "additionalProperties": True,
+            },
+            "pre_commit_snapshots": {
+                "type": "object",
+                "description": "Alias for existing_snapshots.",
+                "additionalProperties": True,
+            },
+            "ledger": {
+                "type": "object",
+                "description": "Optional commit ledger draft payload.",
+                "additionalProperties": True,
+            },
+            "entries": {
+                "type": "array",
+                "description": "Optional commit ledger entries.",
+                "items": {"type": "object", "additionalProperties": True},
+            },
+            "commit_gate": {
+                "type": "object",
+                "description": "Optional commit gate report payload.",
+                "additionalProperties": True,
+            },
+            "decisions": {
+                "type": "array",
+                "description": "Optional commit gate decisions.",
+                "items": {"type": "object", "additionalProperties": True},
+            },
+            "ledger_actor": {
+                "type": "string",
+                "description": "Optional actor label for generated ledger entries.",
+            },
+            "ledger_reason": {
+                "type": "string",
+                "description": "Optional reason for generated ledger entries.",
+            },
+            "preview": {
+                "type": "object",
+                "description": "Optional apply preview report payload.",
+                "additionalProperties": True,
+            },
+            "previews": {
+                "type": "array",
+                "description": "Optional apply previews.",
+                "items": {"type": "object", "additionalProperties": True},
+            },
+            "confirmed_preview_ids": {
+                "type": "array",
+                "description": "Optional preview ids explicitly confirmed by the user.",
+                "items": {"type": "string"},
+            },
+            "user_confirmed": {
+                "type": "boolean",
+                "description": "Whether the user explicitly confirmed these previews.",
+            },
+            "approval": {
+                "type": "object",
+                "description": "Optional approval candidate report payload.",
+                "additionalProperties": True,
+            },
+            "candidates": {
+                "type": "array",
+                "description": "Optional approval candidates.",
+                "items": {"type": "object", "additionalProperties": True},
+            },
+            "approved_candidate_ids": {
+                "type": "array",
+                "description": "Optional candidate ids confirmed for apply preview generation.",
+                "items": {"type": "string"},
+            },
+            "plan": {
+                "type": "object",
+                "description": "Optional evidence repair plan payload.",
+                "additionalProperties": True,
+            },
+            "repairs": {
+                "type": "array",
+                "description": "Optional evidence repair items.",
+                "items": {"type": "object", "additionalProperties": True},
+            },
+            "gate": {
+                "type": "object",
+                "description": "Optional memory policy gate payload.",
+                "additionalProperties": True,
+            },
+            "audit": {
+                "type": "object",
+                "description": "Optional memory recall audit payload.",
+                "additionalProperties": True,
+            },
+            "diagnostics": {
+                "type": "object",
+                "description": "Optional memory recall diagnostics payload.",
+                "additionalProperties": True,
+            },
+            "policy": {
+                "type": "object",
+                "description": "Optional memory auto-policy payload.",
+                "additionalProperties": True,
+            },
+            "proposed_evidence": {
+                "type": "object",
+                "description": "Optional proposed evidence values keyed globally or by candidate id.",
+                "additionalProperties": True,
+            },
+            "format": {
+                "type": "string",
+                "enum": ["json", "markdown"],
+                "description": "Optional response format helper. JSON is always returned; markdown adds a readable summary field.",
+            },
+            "limit": {
+                "type": "integer",
+                "description": "Maximum dry-run operations to include. Defaults to all operations.",
+            },
+        },
+    },
+}
+
+
+def memory_evidence_repair_manual_commit_dry_run_tool(
+    args: dict[str, Any],
+    **kwargs,
+) -> str:
+    if not isinstance(args, dict):
+        return tool_error("args must be an object.", success=False)
+
+    validated = _validate_args(args)
+    if validated is not None:
+        return validated
+
+    context = _resolve_context(args, kwargs.get("memory_manager"))
+    if isinstance(context, str):
+        return context
+    snapshot_plan, commit_gate, ledger, rollback_plan = context
+
+    report = build_evidence_repair_manual_commit_dry_run(
+        snapshot_plan=snapshot_plan,
+        commit_gate=commit_gate,
+        ledger=ledger,
+        rollback_plan=rollback_plan,
+    )
+
+    payload = report.to_dict()
+    limit = _positive_int(args.get("limit"))
+    if limit is not None:
+        payload["operations"] = list(payload.get("operations", []))[:limit]
+        payload["summary"]["operation_count"] = len(payload["operations"])
+        payload["limited_to"] = limit
+    payload["success"] = True
+    payload["read_only"] = True
+    payload["read_only_memory"] = True
+    payload["would_mutate_memory"] = False
+    if str(args.get("format", "")).lower() == "markdown":
+        payload["markdown"] = _render_markdown(payload)
+    return json.dumps(payload, ensure_ascii=False)
+
+
+def _validate_args(args: dict[str, Any]) -> str | None:
+    object_fields = (
+        "snapshot_plan",
+        "rollback_plan",
+        "existing_snapshots",
+        "pre_commit_snapshots",
+        "ledger",
+        "commit_gate",
+        "preview",
+        "approval",
+        "plan",
+        "gate",
+        "audit",
+        "diagnostics",
+        "policy",
+        "proposed_evidence",
+    )
+    array_fields = (
+        "requests",
+        "steps",
+        "entries",
+        "decisions",
+        "previews",
+        "confirmed_preview_ids",
+        "candidates",
+        "approved_candidate_ids",
+        "repairs",
+    )
+    for field_name in object_fields:
+        value = args.get(field_name)
+        if value is not None and not isinstance(value, dict):
+            return tool_error(f"{field_name} must be an object when provided.", success=False)
+    for field_name in array_fields:
+        value = args.get(field_name)
+        if value is not None and not isinstance(value, list):
+            return tool_error(f"{field_name} must be an array when provided.", success=False)
+    return None
+
+
+def _resolve_context(
+    args: dict[str, Any],
+    memory_manager: Any,
+) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any], dict[str, Any]] | str:
+    commit_gate = _resolve_commit_gate(args, memory_manager)
+    if isinstance(commit_gate, str):
+        return commit_gate
+    ledger = _resolve_ledger(args, memory_manager, commit_gate)
+    if isinstance(ledger, str):
+        return ledger
+    rollback_plan = _resolve_rollback_plan(args, memory_manager, ledger)
+    if isinstance(rollback_plan, str):
+        return rollback_plan
+    snapshot_plan = _resolve_snapshot_plan(args, memory_manager, rollback_plan)
+    if isinstance(snapshot_plan, str):
+        return snapshot_plan
+    return snapshot_plan, commit_gate, ledger, rollback_plan
+
+
+def _resolve_snapshot_plan(
+    args: dict[str, Any],
+    memory_manager: Any,
+    fallback_rollback_plan: dict[str, Any],
+) -> dict[str, Any] | str:
+    explicit_plan = args.get("snapshot_plan")
+    explicit_requests = args.get("requests")
+    if isinstance(explicit_plan, dict):
+        if "requests" in explicit_plan:
+            return explicit_plan
+        return {
+            "summary": {"snapshot_request_count": 1},
+            "requests": [explicit_plan],
+            "read_only": True,
+            "read_only_memory": True,
+            "would_mutate_memory": False,
+        }
+    if isinstance(explicit_requests, list):
+        return {
+            "summary": {"snapshot_request_count": len(explicit_requests)},
+            "requests": explicit_requests,
+            "read_only": True,
+            "read_only_memory": True,
+            "would_mutate_memory": False,
+        }
+    rollback_plan = _resolve_rollback_plan(args, memory_manager, None)
+    if isinstance(rollback_plan, str):
+        return rollback_plan
+    if not rollback_plan.get("steps"):
+        rollback_plan = fallback_rollback_plan
+    return build_evidence_repair_snapshot_plan(
+        rollback_plan=rollback_plan,
+        existing_snapshots=_existing_snapshots(args),
+    ).to_dict()
+
+
+def _resolve_rollback_plan(
+    args: dict[str, Any],
+    memory_manager: Any,
+    fallback_ledger: dict[str, Any] | None,
+) -> dict[str, Any] | str:
+    explicit_plan = args.get("rollback_plan")
+    explicit_steps = args.get("steps")
+    if isinstance(explicit_plan, dict):
+        if "steps" in explicit_plan:
+            return explicit_plan
+        return {
+            "summary": {"rollback_step_count": 1},
+            "steps": [explicit_plan],
+            "read_only": True,
+            "read_only_memory": True,
+            "would_mutate_memory": False,
+        }
+    if isinstance(explicit_steps, list):
+        return {
+            "summary": {"rollback_step_count": len(explicit_steps)},
+            "steps": explicit_steps,
+            "read_only": True,
+            "read_only_memory": True,
+            "would_mutate_memory": False,
+        }
+    ledger = _resolve_ledger(args, memory_manager, None)
+    if isinstance(ledger, str):
+        return ledger
+    if not ledger.get("entries") and fallback_ledger is not None:
+        ledger = fallback_ledger
+    return build_evidence_repair_rollback_plan(
+        ledger=ledger,
+        pre_commit_snapshots=_existing_snapshots(args),
+    ).to_dict()
+
+
+def _resolve_ledger(
+    args: dict[str, Any],
+    memory_manager: Any,
+    fallback_commit_gate: dict[str, Any] | None,
+) -> dict[str, Any] | str:
+    explicit_ledger = args.get("ledger")
+    explicit_entries = args.get("entries")
+    if isinstance(explicit_ledger, dict):
+        if "entries" in explicit_ledger:
+            return explicit_ledger
+        return {
+            "summary": {"entry_count": 1},
+            "entries": [explicit_ledger],
+            "read_only": True,
+            "read_only_memory": True,
+            "would_mutate_memory": False,
+        }
+    if isinstance(explicit_entries, list):
+        return {
+            "summary": {"entry_count": len(explicit_entries)},
+            "entries": explicit_entries,
+            "read_only": True,
+            "read_only_memory": True,
+            "would_mutate_memory": False,
+        }
+    commit_gate = _resolve_commit_gate(args, memory_manager)
+    if isinstance(commit_gate, str):
+        return commit_gate
+    if not commit_gate.get("decisions") and fallback_commit_gate is not None:
+        commit_gate = fallback_commit_gate
+    return build_evidence_repair_commit_ledger(
+        commit_gate=commit_gate,
+        ledger_actor=str(args.get("ledger_actor") or "hermes"),
+        ledger_reason=str(args.get("ledger_reason") or ""),
+    ).to_dict()
+
+
+def _resolve_commit_gate(args: dict[str, Any], memory_manager: Any) -> dict[str, Any] | str:
+    explicit_gate = args.get("commit_gate")
+    explicit_decisions = args.get("decisions")
+    if isinstance(explicit_gate, dict):
+        if "decisions" in explicit_gate:
+            return explicit_gate
+        return {
+            "summary": {"decision_count": 1},
+            "decisions": [explicit_gate],
+            "read_only": True,
+            "read_only_memory": True,
+            "would_mutate_memory": False,
+        }
+    if isinstance(explicit_decisions, list):
+        return {
+            "summary": {"decision_count": len(explicit_decisions)},
+            "decisions": explicit_decisions,
+            "read_only": True,
+            "read_only_memory": True,
+            "would_mutate_memory": False,
+        }
+
+    preview = _resolve_preview(args, memory_manager)
+    if isinstance(preview, str):
+        return preview
+    return build_evidence_repair_commit_gate(
+        preview=preview,
+        confirmed_preview_ids=(
+            args.get("confirmed_preview_ids")
+            if isinstance(args.get("confirmed_preview_ids"), list)
+            else None
+        ),
+        user_confirmed=bool(args.get("user_confirmed")),
+    ).to_dict()
+
+
+def _resolve_preview(args: dict[str, Any], memory_manager: Any) -> dict[str, Any] | str:
+    explicit_preview = args.get("preview")
+    explicit_previews = args.get("previews")
+    if isinstance(explicit_preview, dict):
+        if "previews" in explicit_preview:
+            return explicit_preview
+        return {
+            "summary": {"preview_count": 1},
+            "previews": [explicit_preview],
+            "read_only": True,
+            "read_only_memory": True,
+            "would_mutate_memory": False,
+        }
+    if isinstance(explicit_previews, list):
+        return {
+            "summary": {"preview_count": len(explicit_previews)},
+            "previews": explicit_previews,
+            "read_only": True,
+            "read_only_memory": True,
+            "would_mutate_memory": False,
+        }
+
+    approval = _resolve_approval(args, memory_manager)
+    if isinstance(approval, str):
+        return approval
+    return build_evidence_repair_apply_preview(
+        approval=approval,
+        approved_candidate_ids=(
+            args.get("approved_candidate_ids")
+            if isinstance(args.get("approved_candidate_ids"), list)
+            else None
+        ),
+        proposed_evidence=(
+            args.get("proposed_evidence")
+            if isinstance(args.get("proposed_evidence"), dict)
+            else {}
+        ),
+    ).to_dict()
+
+
+def _resolve_approval(args: dict[str, Any], memory_manager: Any) -> dict[str, Any] | str:
+    explicit_approval = args.get("approval")
+    explicit_candidates = args.get("candidates")
+    if isinstance(explicit_approval, dict):
+        return explicit_approval
+    if isinstance(explicit_candidates, list):
+        return {
+            "summary": {"candidate_count": len(explicit_candidates)},
+            "candidates": explicit_candidates,
+            "read_only": True,
+            "read_only_memory": True,
+        }
+
+    plan = _resolve_plan(args, memory_manager)
+    if isinstance(plan, str):
+        return plan
+    return build_evidence_repair_approval_candidates(
+        plan=plan,
+        proposed_evidence=(
+            args.get("proposed_evidence")
+            if isinstance(args.get("proposed_evidence"), dict)
+            else {}
+        ),
+    ).to_dict()
+
+
+def _resolve_plan(args: dict[str, Any], memory_manager: Any) -> dict[str, Any] | str:
+    explicit_plan = args.get("plan")
+    explicit_repairs = args.get("repairs")
+    if isinstance(explicit_plan, dict):
+        return explicit_plan
+    if isinstance(explicit_repairs, list):
+        return {
+            "summary": {"repair_count": len(explicit_repairs)},
+            "repairs": explicit_repairs,
+            "read_only": True,
+        }
+
+    gate = args.get("gate") if isinstance(args.get("gate"), dict) else _manager_dict(
+        memory_manager,
+        "last_memory_policy_gate",
+    )
+    audit = args.get("audit") if isinstance(args.get("audit"), dict) else _manager_dict(
+        memory_manager,
+        "last_recall_audit",
+    )
+    diagnostics = (
+        args.get("diagnostics")
+        if isinstance(args.get("diagnostics"), dict)
+        else _manager_dict(memory_manager, "last_recall_diagnostics")
+    )
+    policy = args.get("policy") if isinstance(args.get("policy"), dict) else _manager_dict(
+        memory_manager,
+        "last_memory_auto_policy",
+    )
+    return build_evidence_repair_plan(
+        gate=gate,
+        audit=audit,
+        diagnostics=diagnostics,
+        policy=policy,
+    ).to_dict()
+
+
+def _existing_snapshots(args: dict[str, Any]) -> dict[str, Any]:
+    if isinstance(args.get("existing_snapshots"), dict):
+        return args["existing_snapshots"]
+    if isinstance(args.get("pre_commit_snapshots"), dict):
+        return args["pre_commit_snapshots"]
+    return {}
+
+
+def _manager_dict(memory_manager: Any, method_name: str) -> dict[str, Any]:
+    if memory_manager is None or not hasattr(memory_manager, method_name):
+        return {}
+    try:
+        value = getattr(memory_manager, method_name)()
+    except Exception:
+        return {}
+    return dict(value) if isinstance(value, dict) else {}
+
+
+def _positive_int(value: Any) -> int | None:
+    if value is None:
+        return None
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed if parsed > 0 else None
+
+
+def _render_markdown(payload: dict[str, Any]) -> str:
+    summary = payload.get("summary", {})
+    lines = [
+        "### Memory Evidence Repair Manual Commit Dry-Run",
+        f"- Status: {payload.get('status')}",
+        f"- Operations: {summary.get('operation_count', 0)}",
+        f"- Blocks: {summary.get('blocking_reason_count', 0)}",
+        f"- Required actions: {summary.get('required_action_count', 0)}",
+    ]
+    for check in payload.get("checks", []):
+        lines.append(f"- {check.get('id')}: {check.get('status')}")
+        actions = check.get("required_actions") or []
+        if actions:
+            lines.append(f"  Required: {', '.join(str(item) for item in actions)}")
+    return "\n".join(lines)
+
+
+def check_memory_evidence_repair_manual_commit_dry_run_requirements() -> bool:
+    return True
+
+
+registry.register(
+    name="memory_evidence_repair_manual_commit_dry_run",
+    toolset="memory",
+    schema=MEMORY_EVIDENCE_REPAIR_MANUAL_COMMIT_DRY_RUN_SCHEMA,
+    handler=memory_evidence_repair_manual_commit_dry_run_tool,
+    check_fn=check_memory_evidence_repair_manual_commit_dry_run_requirements,
+    emoji="🧠",
+)

--- a/tools/memory_evidence_repair_planner_tool.py
+++ b/tools/memory_evidence_repair_planner_tool.py
@@ -1,0 +1,175 @@
+"""Read-only Memory Evidence Repair Planner tool."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from agent.memory_evidence_repair_planner import (
+    build_evidence_repair_plan,
+    empty_evidence_repair_plan,
+)
+from tools.registry import registry, tool_error
+
+
+MEMORY_EVIDENCE_REPAIR_PLANNER_SCHEMA = {
+    "name": "memory_evidence_repair_planner",
+    "description": (
+        "Read-only planner for memory evidence repair. It turns policy gate, "
+        "recall audit, diagnostics, and auto-policy signals into provenance "
+        "repair candidates. The tool never mutates durable memory."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "gate": {
+                "type": "object",
+                "description": "Optional memory policy gate payload.",
+                "additionalProperties": True,
+            },
+            "audit": {
+                "type": "object",
+                "description": "Optional memory recall audit payload.",
+                "additionalProperties": True,
+            },
+            "diagnostics": {
+                "type": "object",
+                "description": "Optional memory recall diagnostics payload.",
+                "additionalProperties": True,
+            },
+            "policy": {
+                "type": "object",
+                "description": "Optional memory auto-policy payload.",
+                "additionalProperties": True,
+            },
+            "format": {
+                "type": "string",
+                "enum": ["json", "markdown"],
+                "description": "Optional response format helper. JSON is always returned; markdown adds a readable summary field.",
+            },
+            "limit": {
+                "type": "integer",
+                "description": "Maximum repair candidates to include. Defaults to all repairs.",
+            },
+        },
+    },
+}
+
+
+def memory_evidence_repair_planner_tool(args: dict[str, Any], **kwargs) -> str:
+    resolved = _resolve_inputs(args, kwargs.get("memory_manager"))
+    if isinstance(resolved, str):
+        return resolved
+    gate, audit, diagnostics, policy = resolved
+    payload = build_evidence_repair_plan(
+        gate=gate,
+        audit=audit,
+        diagnostics=diagnostics,
+        policy=policy,
+    ).to_dict()
+
+    limit = _positive_int(args.get("limit"))
+    if limit is not None:
+        payload["repairs"] = list(payload.get("repairs", []))[:limit]
+        payload["limited_to"] = limit
+
+    payload["success"] = True
+    payload["read_only"] = True
+    payload["read_only_memory"] = True
+    if str(args.get("format", "")).lower() == "markdown":
+        payload["markdown"] = _render_markdown(payload)
+    return json.dumps(payload, ensure_ascii=False)
+
+
+def _resolve_inputs(
+    args: dict[str, Any],
+    memory_manager: Any,
+) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any], dict[str, Any]] | str:
+    explicit_gate = args.get("gate")
+    explicit_audit = args.get("audit")
+    explicit_diagnostics = args.get("diagnostics")
+    explicit_policy = args.get("policy")
+    for field_name, value in (
+        ("gate", explicit_gate),
+        ("audit", explicit_audit),
+        ("diagnostics", explicit_diagnostics),
+        ("policy", explicit_policy),
+    ):
+        if value is not None and not isinstance(value, dict):
+            return tool_error(f"{field_name} must be an object when provided.", success=False)
+
+    gate = explicit_gate if isinstance(explicit_gate, dict) else _manager_dict(
+        memory_manager,
+        "last_memory_policy_gate",
+    )
+    audit = explicit_audit if isinstance(explicit_audit, dict) else _manager_dict(
+        memory_manager,
+        "last_recall_audit",
+    )
+    diagnostics = (
+        explicit_diagnostics
+        if isinstance(explicit_diagnostics, dict)
+        else _manager_dict(memory_manager, "last_recall_diagnostics")
+    )
+    policy = explicit_policy if isinstance(explicit_policy, dict) else _manager_dict(
+        memory_manager,
+        "last_memory_auto_policy",
+    )
+    return gate, audit, diagnostics, policy
+
+
+def _manager_dict(memory_manager: Any, method_name: str) -> dict[str, Any]:
+    if memory_manager is None or not hasattr(memory_manager, method_name):
+        return {}
+    try:
+        value = getattr(memory_manager, method_name)()
+    except Exception:
+        return {}
+    return dict(value) if isinstance(value, dict) else {}
+
+
+def _positive_int(value: Any) -> int | None:
+    if value is None:
+        return None
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed if parsed > 0 else None
+
+
+def _render_markdown(payload: dict[str, Any]) -> str:
+    summary = payload.get("summary", {})
+    lines = [
+        "### Memory Evidence Repair Planner",
+        f"- Repairs: {summary.get('repair_count', 0)}",
+        f"- Blocked by gate: {summary.get('blocked_count', 0)}",
+        f"- By priority: {summary.get('by_priority', {})}",
+    ]
+    for index, repair in enumerate(payload.get("repairs", []), start=1):
+        provider = repair.get("provider") or "memory"
+        lines.append(
+            f"{index}. [{repair.get('priority')}] {repair.get('action')} "
+            f"provider={provider}"
+        )
+        reason = repair.get("reason")
+        if reason:
+            lines.append(f"   Reason: {reason}")
+        required = repair.get("required_evidence") or []
+        if required:
+            lines.append(f"   Required: {', '.join(str(item) for item in required)}")
+    return "\n".join(lines)
+
+
+def check_memory_evidence_repair_planner_requirements() -> bool:
+    return True
+
+
+registry.register(
+    name="memory_evidence_repair_planner",
+    toolset="memory",
+    schema=MEMORY_EVIDENCE_REPAIR_PLANNER_SCHEMA,
+    handler=memory_evidence_repair_planner_tool,
+    check_fn=check_memory_evidence_repair_planner_requirements,
+    emoji="🧠",
+)

--- a/tools/memory_evidence_repair_post_commit_audit_preview_tool.py
+++ b/tools/memory_evidence_repair_post_commit_audit_preview_tool.py
@@ -1,0 +1,269 @@
+"""Read-only Memory Evidence Repair Post-Commit Audit Preview tool."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from agent.memory_evidence_repair_post_commit_audit_preview import (
+    build_evidence_repair_post_commit_audit_preview,
+)
+from tools.memory_evidence_repair_executor_preview_tool import (
+    MEMORY_EVIDENCE_REPAIR_EXECUTOR_PREVIEW_SCHEMA,
+    memory_evidence_repair_executor_preview_tool,
+)
+from tools.registry import registry, tool_error
+
+
+_UPSTREAM_PROPERTIES = dict(
+    MEMORY_EVIDENCE_REPAIR_EXECUTOR_PREVIEW_SCHEMA["parameters"]["properties"]
+)
+_UPSTREAM_PROPERTIES.pop("format", None)
+
+MEMORY_EVIDENCE_REPAIR_POST_COMMIT_AUDIT_PREVIEW_SCHEMA = {
+    "name": "memory_evidence_repair_post_commit_audit_preview",
+    "description": (
+        "Read-only post-commit audit preview for future memory evidence repair "
+        "manual commits. It never mutates durable memory."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "executor_preview": {
+                "type": "object",
+                "description": "Optional executor preview report payload.",
+                "additionalProperties": True,
+            },
+            "executor": {
+                "type": "object",
+                "description": "Alias for executor_preview.",
+                "additionalProperties": True,
+            },
+            "observed_memory_patches": {
+                "type": "object",
+                "description": "Optional observed post-commit patch signals keyed by operation id.",
+                "additionalProperties": True,
+            },
+            "recorded_receipts": {
+                "description": "Optional recorded receipt report or receipt list.",
+                "oneOf": [
+                    {"type": "object", "additionalProperties": True},
+                    {
+                        "type": "array",
+                        "items": {"type": "object", "additionalProperties": True},
+                    },
+                ],
+            },
+            "released_lock_ids": {
+                "type": "array",
+                "description": "Optional write-lock ids observed as released after commit.",
+                "items": {"type": "string"},
+            },
+            "rollback_status": {
+                "type": "object",
+                "description": "Optional observed rollback or snapshot readiness signal.",
+                "additionalProperties": True,
+            },
+            "format": {
+                "type": "string",
+                "enum": ["json", "markdown"],
+                "description": "Optional response format helper. JSON is always returned; markdown adds a readable summary field.",
+            },
+            **_UPSTREAM_PROPERTIES,
+        },
+    },
+}
+
+
+def memory_evidence_repair_post_commit_audit_preview_tool(
+    args: dict[str, Any],
+    **kwargs,
+) -> str:
+    if not isinstance(args, dict):
+        return tool_error("args must be an object.", success=False)
+
+    validated = _validate_args(args)
+    if validated is not None:
+        return validated
+
+    executor_preview = _resolve_executor_preview(args, kwargs.get("memory_manager"))
+    if isinstance(executor_preview, str):
+        return executor_preview
+
+    payload = build_evidence_repair_post_commit_audit_preview(
+        executor_preview=executor_preview,
+        observed_memory_patches=(
+            args.get("observed_memory_patches")
+            if isinstance(args.get("observed_memory_patches"), dict)
+            else None
+        ),
+        recorded_receipts=_recorded_receipts(args),
+        used_token_ids=(
+            args.get("used_token_ids")
+            if isinstance(args.get("used_token_ids"), list)
+            else None
+        ),
+        released_lock_ids=(
+            args.get("released_lock_ids")
+            if isinstance(args.get("released_lock_ids"), list)
+            else None
+        ),
+        rollback_status=(
+            args.get("rollback_status")
+            if isinstance(args.get("rollback_status"), dict)
+            else None
+        ),
+    ).to_dict()
+    payload["success"] = True
+    payload["read_only"] = True
+    payload["read_only_memory"] = True
+    payload["would_mutate_memory"] = False
+    if str(args.get("format", "")).lower() == "markdown":
+        payload["markdown"] = _render_markdown(payload)
+    return json.dumps(payload, ensure_ascii=False)
+
+
+def _validate_args(args: dict[str, Any]) -> str | None:
+    object_fields = (
+        "executor_preview",
+        "executor",
+        "observed_memory_patches",
+        "rollback_status",
+        "write_lock_gate",
+        "executor_lock_gate",
+        "write_lock",
+        "commit_receipt",
+        "receipt",
+        "token_gate",
+        "approval_token_gate",
+        "approval_token",
+        "token",
+        "dry_run",
+        "snapshot_plan",
+        "rollback_plan",
+        "existing_snapshots",
+        "pre_commit_snapshots",
+        "ledger",
+        "commit_gate",
+        "preview",
+        "approval",
+        "plan",
+        "gate",
+        "audit",
+        "diagnostics",
+        "policy",
+        "proposed_evidence",
+    )
+    array_fields = (
+        "released_lock_ids",
+        "active_locks",
+        "locks",
+        "already_used_token_ids",
+        "tokens",
+        "used_token_ids",
+        "receipts",
+        "requests",
+        "steps",
+        "entries",
+        "decisions",
+        "previews",
+        "confirmed_preview_ids",
+        "candidates",
+        "approved_candidate_ids",
+        "repairs",
+    )
+    for field_name in object_fields:
+        value = args.get(field_name)
+        if value is not None and not isinstance(value, dict):
+            return tool_error(f"{field_name} must be an object when provided.", success=False)
+    for field_name in ("existing_receipts", "recorded_receipts"):
+        value = args.get(field_name)
+        if value is not None and not isinstance(value, (dict, list)):
+            return tool_error(
+                f"{field_name} must be an object or array when provided.",
+                success=False,
+            )
+    for field_name in array_fields:
+        value = args.get(field_name)
+        if value is not None and not isinstance(value, list):
+            return tool_error(f"{field_name} must be an array when provided.", success=False)
+    return None
+
+
+def _resolve_executor_preview(
+    args: dict[str, Any],
+    memory_manager: Any,
+) -> dict[str, Any] | str:
+    explicit_preview = args.get("executor_preview")
+    if isinstance(explicit_preview, dict):
+        return explicit_preview
+    explicit_preview = args.get("executor")
+    if isinstance(explicit_preview, dict):
+        return explicit_preview
+
+    executor_args = dict(args)
+    for field_name in (
+        "executor_preview",
+        "executor",
+        "observed_memory_patches",
+        "recorded_receipts",
+        "released_lock_ids",
+        "rollback_status",
+        "format",
+    ):
+        executor_args.pop(field_name, None)
+    result = memory_evidence_repair_executor_preview_tool(
+        executor_args,
+        memory_manager=memory_manager,
+    )
+    try:
+        payload = json.loads(result)
+    except json.JSONDecodeError:
+        return tool_error("executor preview tool returned invalid JSON.", success=False)
+    if not isinstance(payload, dict):
+        return tool_error("executor preview tool returned a non-object payload.", success=False)
+    if payload.get("success") is False:
+        return json.dumps(payload, ensure_ascii=False)
+    return payload
+
+
+def _recorded_receipts(args: dict[str, Any]) -> dict[str, Any] | list[dict[str, Any]] | None:
+    explicit = args.get("recorded_receipts")
+    if isinstance(explicit, (dict, list)):
+        return explicit
+    return None
+
+
+def _render_markdown(payload: dict[str, Any]) -> str:
+    summary = payload.get("summary", {})
+    lines = [
+        "### Memory Evidence Repair Post-Commit Audit Preview",
+        f"- Status: {payload.get('status')}",
+        f"- Previews: {summary.get('preview_count', 0)}",
+        f"- Audit steps: {summary.get('audit_step_count', 0)}",
+        f"- Planned: {summary.get('planned_audit_step_count', 0)}",
+        f"- Observed pass: {summary.get('observed_pass_step_count', 0)}",
+        f"- Observed fail: {summary.get('observed_fail_step_count', 0)}",
+    ]
+    for preview in payload.get("previews", []):
+        lines.append(f"- Audit: {preview.get('id')}")
+        lines.append(f"  Executor: {preview.get('executor_preview_id')}")
+    for reason in payload.get("blocking_reasons", []):
+        lines.append(f"- Blocked: {reason}")
+    for action in payload.get("required_actions", []):
+        lines.append(f"- Required: {action}")
+    return "\n".join(lines)
+
+
+def check_memory_evidence_repair_post_commit_audit_preview_requirements() -> bool:
+    return True
+
+
+registry.register(
+    name="memory_evidence_repair_post_commit_audit_preview",
+    toolset="memory",
+    schema=MEMORY_EVIDENCE_REPAIR_POST_COMMIT_AUDIT_PREVIEW_SCHEMA,
+    handler=memory_evidence_repair_post_commit_audit_preview_tool,
+    check_fn=check_memory_evidence_repair_post_commit_audit_preview_requirements,
+    emoji="🧠",
+)

--- a/tools/memory_evidence_repair_recovery_approval_token_gate_tool.py
+++ b/tools/memory_evidence_repair_recovery_approval_token_gate_tool.py
@@ -1,0 +1,331 @@
+"""Read-only Memory Evidence Repair Recovery Approval Token Gate tool."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from agent.memory_evidence_repair_recovery_approval_token_gate import (
+    build_evidence_repair_recovery_approval_token_gate,
+)
+from tools.memory_evidence_repair_recovery_human_approval_token_tool import (
+    MEMORY_EVIDENCE_REPAIR_RECOVERY_HUMAN_APPROVAL_TOKEN_SCHEMA,
+    memory_evidence_repair_recovery_human_approval_token_tool,
+)
+from tools.registry import registry, tool_error
+
+
+_UPSTREAM_PROPERTIES = dict(
+    MEMORY_EVIDENCE_REPAIR_RECOVERY_HUMAN_APPROVAL_TOKEN_SCHEMA["parameters"]["properties"]
+)
+_UPSTREAM_PROPERTIES.pop("format", None)
+
+MEMORY_EVIDENCE_REPAIR_RECOVERY_APPROVAL_TOKEN_GATE_SCHEMA = {
+    "name": "memory_evidence_repair_recovery_approval_token_gate",
+    "description": (
+        "Read-only gate that verifies a recovery human approval token before "
+        "any later manual memory evidence repair recovery. It never mutates durable memory."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "recovery_approval_token": {
+                "type": "object",
+                "description": "Optional recovery approval token report payload.",
+                "additionalProperties": True,
+            },
+            "recovery_human_approval_token": {
+                "type": "object",
+                "description": "Alias for recovery_approval_token.",
+                "additionalProperties": True,
+            },
+            "recovery_token": {
+                "type": "object",
+                "description": "Optional single recovery approval token payload.",
+                "additionalProperties": True,
+            },
+            "token": {
+                "type": "object",
+                "description": "Optional single recovery approval token payload.",
+                "additionalProperties": True,
+            },
+            "tokens": {
+                "type": "array",
+                "description": "Optional recovery approval token list.",
+                "items": {"type": "object", "additionalProperties": True},
+            },
+            "confirmation_text": {
+                "type": "string",
+                "description": "Exact human confirmation text required by the recovery token.",
+            },
+            "used_token_ids": {
+                "type": "array",
+                "description": "Read-only ids already marked as used by an external ledger.",
+                "items": {"type": "string"},
+            },
+            "token_generated_at": {
+                "type": "string",
+                "description": "Issue time for bare token payloads.",
+            },
+            "current_time": {
+                "type": "string",
+                "description": "Optional current time override for deterministic verification.",
+            },
+            "format": {
+                "type": "string",
+                "enum": ["json", "markdown"],
+                "description": "Optional response format helper. JSON is always returned; markdown adds a readable summary field.",
+            },
+            **_UPSTREAM_PROPERTIES,
+        },
+    },
+}
+
+
+def memory_evidence_repair_recovery_approval_token_gate_tool(
+    args: dict[str, Any],
+    **kwargs,
+) -> str:
+    if not isinstance(args, dict):
+        return tool_error("args must be an object.", success=False)
+
+    validated = _validate_args(args)
+    if validated is not None:
+        return validated
+
+    recovery_approval_token = _resolve_recovery_approval_token(
+        args,
+        kwargs.get("memory_manager"),
+    )
+    if isinstance(recovery_approval_token, str):
+        return recovery_approval_token
+
+    recovery_execution = _resolve_recovery_execution(args, recovery_approval_token)
+    payload = build_evidence_repair_recovery_approval_token_gate(
+        recovery_approval_token=recovery_approval_token,
+        recovery_execution=recovery_execution,
+        confirmation_text=str(args.get("confirmation_text") or ""),
+        used_token_ids=(
+            args.get("used_token_ids")
+            if isinstance(args.get("used_token_ids"), list)
+            else None
+        ),
+        current_time=args.get("current_time"),
+    ).to_dict()
+    payload["success"] = True
+    payload["read_only"] = True
+    payload["read_only_memory"] = True
+    payload["would_mutate_memory"] = False
+    if str(args.get("format", "")).lower() == "markdown":
+        payload["markdown"] = _render_markdown(payload)
+    return json.dumps(payload, ensure_ascii=False)
+
+
+def _validate_args(args: dict[str, Any]) -> str | None:
+    object_fields = (
+        "recovery_approval_token",
+        "recovery_human_approval_token",
+        "recovery_token",
+        "token",
+        "recovery_execution",
+        "recovery_execution_preview",
+        "recovery_execution_report",
+        "recovery_decision",
+        "recovery_decision_gate",
+        "recovery_decision_report",
+        "rollback_drill",
+        "rollback_drill_preview",
+        "rollback_drill_report",
+        "post_commit_audit",
+        "post_commit_audit_preview",
+        "post_commit_audit_report",
+        "executor_preview",
+        "executor",
+        "observed_memory_patches",
+        "rollback_status",
+        "write_lock_gate",
+        "executor_lock_gate",
+        "write_lock",
+        "commit_receipt",
+        "receipt",
+        "token_gate",
+        "approval_token_gate",
+        "approval_token",
+        "dry_run",
+        "snapshot_plan",
+        "rollback_plan",
+        "existing_snapshots",
+        "pre_commit_snapshots",
+        "ledger",
+        "commit_gate",
+        "preview",
+        "approval",
+        "plan",
+        "gate",
+        "audit",
+        "diagnostics",
+        "policy",
+        "proposed_evidence",
+    )
+    array_fields = (
+        "tokens",
+        "used_token_ids",
+        "released_lock_ids",
+        "active_locks",
+        "locks",
+        "already_used_token_ids",
+        "receipts",
+        "requests",
+        "steps",
+        "entries",
+        "decisions",
+        "previews",
+        "confirmed_preview_ids",
+        "candidates",
+        "approved_candidate_ids",
+        "repairs",
+    )
+    for field_name in object_fields:
+        value = args.get(field_name)
+        if value is not None and not isinstance(value, dict):
+            return tool_error(f"{field_name} must be an object when provided.", success=False)
+    for field_name in ("existing_receipts", "recorded_receipts"):
+        value = args.get(field_name)
+        if value is not None and not isinstance(value, (dict, list)):
+            return tool_error(
+                f"{field_name} must be an object or array when provided.",
+                success=False,
+            )
+    for field_name in array_fields:
+        value = args.get(field_name)
+        if value is not None and not isinstance(value, list):
+            return tool_error(f"{field_name} must be an array when provided.", success=False)
+    return None
+
+
+def _resolve_recovery_approval_token(
+    args: dict[str, Any],
+    memory_manager: Any,
+) -> dict[str, Any] | str:
+    for field_name in ("recovery_approval_token", "recovery_human_approval_token"):
+        explicit_report = args.get(field_name)
+        if isinstance(explicit_report, dict):
+            if "generated_at" not in explicit_report and args.get("token_generated_at"):
+                explicit_report = dict(explicit_report)
+                explicit_report["generated_at"] = str(args.get("token_generated_at") or "")
+            return explicit_report
+
+    for field_name in ("recovery_token", "token"):
+        explicit_token = args.get(field_name)
+        if isinstance(explicit_token, dict):
+            return {
+                "generated_at": str(args.get("token_generated_at") or ""),
+                "tokens": [explicit_token],
+                "read_only": True,
+                "read_only_memory": True,
+                "would_mutate_memory": False,
+            }
+
+    explicit_tokens = args.get("tokens")
+    if isinstance(explicit_tokens, list):
+        return {
+            "generated_at": str(args.get("token_generated_at") or ""),
+            "tokens": explicit_tokens,
+            "read_only": True,
+            "read_only_memory": True,
+            "would_mutate_memory": False,
+        }
+
+    token_args = dict(args)
+    for field_name in (
+        "recovery_approval_token",
+        "recovery_human_approval_token",
+        "recovery_token",
+        "token",
+        "tokens",
+        "confirmation_text",
+        "used_token_ids",
+        "token_generated_at",
+        "current_time",
+        "format",
+    ):
+        token_args.pop(field_name, None)
+    result = memory_evidence_repair_recovery_human_approval_token_tool(
+        token_args,
+        memory_manager=memory_manager,
+    )
+    try:
+        payload = json.loads(result)
+    except json.JSONDecodeError:
+        return tool_error(
+            "recovery human approval token tool returned invalid JSON.",
+            success=False,
+        )
+    if not isinstance(payload, dict):
+        return tool_error(
+            "recovery human approval token tool returned a non-object payload.",
+            success=False,
+        )
+    if payload.get("success") is False:
+        return json.dumps(payload, ensure_ascii=False)
+    return payload
+
+
+def _resolve_recovery_execution(
+    args: dict[str, Any],
+    recovery_approval_token: dict[str, Any],
+) -> dict[str, Any]:
+    for field_name in (
+        "recovery_execution",
+        "recovery_execution_preview",
+        "recovery_execution_report",
+    ):
+        explicit = args.get(field_name)
+        if isinstance(explicit, dict):
+            return explicit
+    token = _first_token(recovery_approval_token)
+    source = token.get("source_execution_preview") if isinstance(token, dict) else {}
+    return dict(source) if isinstance(source, dict) else {}
+
+
+def _first_token(recovery_approval_token: dict[str, Any]) -> dict[str, Any]:
+    tokens = recovery_approval_token.get("tokens")
+    if isinstance(tokens, list):
+        for token in tokens:
+            if isinstance(token, dict):
+                return token
+    if isinstance(recovery_approval_token, dict) and recovery_approval_token.get("id"):
+        return recovery_approval_token
+    return {}
+
+
+def _render_markdown(payload: dict[str, Any]) -> str:
+    summary = payload.get("summary", {})
+    lines = [
+        "### Memory Evidence Repair Recovery Approval Token Gate",
+        f"- Status: {payload.get('status')}",
+        f"- Token: {payload.get('token_id') or 'none'}",
+        f"- Checks: {summary.get('check_count', 0)}",
+        f"- Passed: {summary.get('pass_count', 0)}",
+        f"- Failed: {summary.get('fail_count', 0)}",
+        f"- Manual recovery verified: {summary.get('manual_recovery_verified', False)}",
+    ]
+    for reason in payload.get("blocking_reasons", []):
+        lines.append(f"- Blocked: {reason}")
+    for action in payload.get("required_actions", []):
+        lines.append(f"- Required: {action}")
+    return "\n".join(lines)
+
+
+def check_memory_evidence_repair_recovery_approval_token_gate_requirements() -> bool:
+    return True
+
+
+registry.register(
+    name="memory_evidence_repair_recovery_approval_token_gate",
+    toolset="memory",
+    schema=MEMORY_EVIDENCE_REPAIR_RECOVERY_APPROVAL_TOKEN_GATE_SCHEMA,
+    handler=memory_evidence_repair_recovery_approval_token_gate_tool,
+    check_fn=check_memory_evidence_repair_recovery_approval_token_gate_requirements,
+    emoji="🧠",
+)

--- a/tools/memory_evidence_repair_recovery_closure_finalization_readiness_audit_preview_tool.py
+++ b/tools/memory_evidence_repair_recovery_closure_finalization_readiness_audit_preview_tool.py
@@ -1,0 +1,354 @@
+"""Read-only Memory Evidence Repair Recovery Closure Finalization Readiness Audit Preview tool."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from agent.memory_evidence_repair_recovery_closure_finalization_readiness_audit_preview import (
+    build_evidence_repair_recovery_closure_finalization_readiness_audit_preview,
+)
+from tools.memory_evidence_repair_recovery_closure_finalization_readiness_preview_tool import (
+    MEMORY_EVIDENCE_REPAIR_RECOVERY_CLOSURE_FINALIZATION_READINESS_PREVIEW_SCHEMA,
+    memory_evidence_repair_recovery_closure_finalization_readiness_preview_tool,
+)
+from tools.registry import registry, tool_error
+
+
+_UPSTREAM_PROPERTIES = dict(
+    MEMORY_EVIDENCE_REPAIR_RECOVERY_CLOSURE_FINALIZATION_READINESS_PREVIEW_SCHEMA[
+        "parameters"
+    ]["properties"]
+)
+_UPSTREAM_PROPERTIES.pop("format", None)
+
+MEMORY_EVIDENCE_REPAIR_RECOVERY_CLOSURE_FINALIZATION_READINESS_AUDIT_PREVIEW_SCHEMA = {
+    "name": "memory_evidence_repair_recovery_closure_finalization_readiness_audit_preview",
+    "description": (
+        "Read-only audit preview for memory evidence repair recovery closure "
+        "finalization readiness. It verifies the finalization gate without "
+        "recording an audit or mutating durable memory."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "recovery_closure_finalization_readiness": {
+                "type": "object",
+                "description": "Optional recovery closure finalization readiness preview report payload.",
+                "additionalProperties": True,
+            },
+            "recovery_closure_finalization_readiness_preview": {
+                "type": "object",
+                "description": "Alias for recovery_closure_finalization_readiness.",
+                "additionalProperties": True,
+            },
+            "recovery_closure_finalization_readiness_report": {
+                "type": "object",
+                "description": "Alias for recovery_closure_finalization_readiness.",
+                "additionalProperties": True,
+            },
+            "finalization_readiness": {
+                "type": "object",
+                "description": "Optional single recovery closure finalization readiness draft.",
+                "additionalProperties": True,
+            },
+            "finalization_readiness_preview": {
+                "type": "object",
+                "description": "Alias for finalization_readiness.",
+                "additionalProperties": True,
+            },
+            "finalization_readiness_draft": {
+                "type": "object",
+                "description": "Alias for finalization_readiness.",
+                "additionalProperties": True,
+            },
+            "format": {
+                "type": "string",
+                "enum": ["json", "markdown"],
+                "description": "Optional response format helper. JSON is always returned; markdown adds a readable summary field.",
+            },
+            **_UPSTREAM_PROPERTIES,
+        },
+    },
+}
+
+
+def memory_evidence_repair_recovery_closure_finalization_readiness_audit_preview_tool(
+    args: dict[str, Any],
+    **kwargs,
+) -> str:
+    if not isinstance(args, dict):
+        return tool_error("args must be an object.", success=False)
+
+    validated = _validate_args(args)
+    if validated is not None:
+        return validated
+
+    recovery_closure_finalization_readiness = (
+        _resolve_recovery_closure_finalization_readiness(
+            args,
+            kwargs.get("memory_manager"),
+        )
+    )
+    if isinstance(recovery_closure_finalization_readiness, str):
+        return recovery_closure_finalization_readiness
+
+    payload = (
+        build_evidence_repair_recovery_closure_finalization_readiness_audit_preview(
+            recovery_closure_finalization_readiness=(
+                recovery_closure_finalization_readiness
+            ),
+        ).to_dict()
+    )
+    payload["success"] = True
+    payload["read_only"] = True
+    payload["read_only_memory"] = True
+    payload["would_mutate_memory"] = False
+    if str(args.get("format", "")).lower() == "markdown":
+        payload["markdown"] = _render_markdown(payload)
+    return json.dumps(payload, ensure_ascii=False)
+
+
+def _validate_args(args: dict[str, Any]) -> str | None:
+    object_fields = (
+        "recovery_closure_finalization_readiness",
+        "recovery_closure_finalization_readiness_preview",
+        "recovery_closure_finalization_readiness_report",
+        "finalization_readiness",
+        "finalization_readiness_preview",
+        "finalization_readiness_draft",
+        "recovery_closure_governance_seal_audit",
+        "recovery_closure_governance_seal_audit_preview",
+        "recovery_closure_governance_seal_audit_report",
+        "governance_seal_audit",
+        "governance_seal_audit_preview",
+        "seal_audit",
+        "seal_audit_preview",
+        "recovery_closure_governance_seal",
+        "recovery_closure_governance_seal_preview",
+        "recovery_closure_governance_seal_report",
+        "governance_seal",
+        "governance_seal_preview",
+        "seal",
+        "recovery_closure_ledger_audit",
+        "recovery_closure_ledger_audit_preview",
+        "recovery_closure_ledger_audit_report",
+        "ledger_audit",
+        "ledger_audit_preview",
+        "recovery_closure_ledger",
+        "recovery_closure_ledger_preview",
+        "recovery_closure_ledger_report",
+        "ledger_preview",
+        "recovery_closure_ledger_entry",
+        "ledger_entry",
+        "entry",
+        "recovery_closure_gate",
+        "recovery_closure_gate_report",
+        "closure_gate",
+        "recovery_closure",
+        "closure",
+        "recovery_completion_audit",
+        "recovery_completion_audit_preview",
+        "recovery_completion_audit_report",
+        "recovery_completion_receipt",
+        "recovery_completion_receipt_report",
+        "completion_receipt",
+        "observed_recovery_steps",
+        "post_recovery_audit_status",
+        "contamination_status",
+        "recovery_executor_preview",
+        "recovery_executor_preview_report",
+        "recovery_executor",
+        "recovery_write_lock_gate",
+        "recovery_executor_lock_gate",
+        "recovery_write_lock",
+        "recovery_token_gate",
+        "recovery_approval_token_gate",
+        "token_gate",
+        "recovery_approval_token",
+        "recovery_human_approval_token",
+        "recovery_token",
+        "token",
+        "recovery_execution",
+        "recovery_execution_preview",
+        "recovery_execution_report",
+        "recovery_decision",
+        "recovery_decision_gate",
+        "recovery_decision_report",
+        "rollback_drill",
+        "rollback_drill_preview",
+        "rollback_drill_report",
+        "post_commit_audit",
+        "post_commit_audit_preview",
+        "post_commit_audit_report",
+        "executor_preview",
+        "executor",
+        "observed_memory_patches",
+        "rollback_status",
+        "write_lock_gate",
+        "executor_lock_gate",
+        "write_lock",
+        "commit_receipt",
+        "receipt",
+        "approval_token_gate",
+        "approval_token",
+        "dry_run",
+        "snapshot_plan",
+        "rollback_plan",
+        "existing_snapshots",
+        "pre_commit_snapshots",
+        "ledger",
+        "commit_gate",
+        "preview",
+        "approval",
+        "plan",
+        "gate",
+        "audit",
+        "diagnostics",
+        "policy",
+        "proposed_evidence",
+    )
+    array_fields = (
+        "active_locks",
+        "locks",
+        "already_used_token_ids",
+        "tokens",
+        "used_token_ids",
+        "released_lock_ids",
+        "receipts",
+        "requests",
+        "steps",
+        "entries",
+        "decisions",
+        "previews",
+        "readiness",
+        "confirmed_preview_ids",
+        "candidates",
+        "approved_candidate_ids",
+        "repairs",
+    )
+    for field_name in object_fields:
+        value = args.get(field_name)
+        if value is not None and not isinstance(value, dict):
+            return tool_error(
+                f"{field_name} must be an object when provided.",
+                success=False,
+            )
+    for field_name in ("existing_receipts", "recorded_receipts"):
+        value = args.get(field_name)
+        if value is not None and not isinstance(value, (dict, list)):
+            return tool_error(
+                f"{field_name} must be an object or array when provided.",
+                success=False,
+            )
+    for field_name in array_fields:
+        value = args.get(field_name)
+        if value is not None and not isinstance(value, list):
+            return tool_error(f"{field_name} must be an array when provided.", success=False)
+    return None
+
+
+def _resolve_recovery_closure_finalization_readiness(
+    args: dict[str, Any],
+    memory_manager: Any,
+) -> dict[str, Any] | str:
+    for field_name in (
+        "recovery_closure_finalization_readiness",
+        "recovery_closure_finalization_readiness_preview",
+        "recovery_closure_finalization_readiness_report",
+    ):
+        explicit = args.get(field_name)
+        if isinstance(explicit, dict):
+            if str(explicit.get("id") or "").startswith(
+                "recovery-closure-finalization-readiness-"
+            ):
+                return _readiness_report(explicit)
+            return explicit
+
+    for field_name in (
+        "finalization_readiness",
+        "finalization_readiness_preview",
+        "finalization_readiness_draft",
+    ):
+        explicit = args.get(field_name)
+        if isinstance(explicit, dict):
+            return _readiness_report(explicit)
+
+    readiness_args = dict(args)
+    for field_name in (
+        "recovery_closure_finalization_readiness",
+        "recovery_closure_finalization_readiness_preview",
+        "recovery_closure_finalization_readiness_report",
+        "finalization_readiness",
+        "finalization_readiness_preview",
+        "finalization_readiness_draft",
+        "format",
+    ):
+        readiness_args.pop(field_name, None)
+    result = memory_evidence_repair_recovery_closure_finalization_readiness_preview_tool(
+        readiness_args,
+        memory_manager=memory_manager,
+    )
+    try:
+        payload = json.loads(result)
+    except json.JSONDecodeError:
+        return tool_error(
+            "recovery closure finalization readiness preview tool returned invalid JSON.",
+            success=False,
+        )
+    if not isinstance(payload, dict):
+        return tool_error(
+            "recovery closure finalization readiness preview tool returned a non-object payload.",
+            success=False,
+        )
+    if payload.get("success") is False:
+        return json.dumps(payload, ensure_ascii=False)
+    return payload
+
+
+def _readiness_report(readiness: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "status": "recovery_closure_finalization_readiness_preview_ready",
+        "summary": {"readiness_count": 1},
+        "readiness": [readiness],
+        "read_only": True,
+        "read_only_memory": True,
+        "would_mutate_memory": False,
+    }
+
+
+def _render_markdown(payload: dict[str, Any]) -> str:
+    summary = payload.get("summary", {})
+    lines = [
+        "### Memory Evidence Repair Recovery Closure Finalization Readiness Audit Preview",
+        f"- Status: {payload.get('status')}",
+        f"- Checks: {summary.get('check_count', 0)}",
+        f"- Previews: {summary.get('preview_count', 0)}",
+        f"- Audit steps: {summary.get('audit_step_count', 0)}",
+        f"- Ready: {summary.get('recovery_closure_finalization_readiness_audit_ready', False)}",
+    ]
+    for preview in payload.get("previews", []):
+        lines.append(f"- Audit preview: {preview.get('id')}")
+        lines.append(
+            f"  Finalization readiness: {preview.get('finalization_readiness_id')}"
+        )
+        lines.append(f"  Seal audit: {preview.get('seal_audit_preview_id')}")
+    for reason in payload.get("blocking_reasons", []):
+        lines.append(f"- Blocked: {reason}")
+    for action in payload.get("required_actions", []):
+        lines.append(f"- Required: {action}")
+    return "\n".join(lines)
+
+
+def check_memory_evidence_repair_recovery_closure_finalization_readiness_audit_preview_requirements() -> bool:
+    return True
+
+
+registry.register(
+    name="memory_evidence_repair_recovery_closure_finalization_readiness_audit_preview",
+    toolset="memory",
+    schema=MEMORY_EVIDENCE_REPAIR_RECOVERY_CLOSURE_FINALIZATION_READINESS_AUDIT_PREVIEW_SCHEMA,
+    handler=memory_evidence_repair_recovery_closure_finalization_readiness_audit_preview_tool,
+    check_fn=check_memory_evidence_repair_recovery_closure_finalization_readiness_audit_preview_requirements,
+    emoji="🧠",
+)

--- a/tools/memory_evidence_repair_recovery_closure_finalization_readiness_preview_tool.py
+++ b/tools/memory_evidence_repair_recovery_closure_finalization_readiness_preview_tool.py
@@ -1,0 +1,347 @@
+"""Read-only Memory Evidence Repair Recovery Closure Finalization Readiness Preview tool."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from agent.memory_evidence_repair_recovery_closure_finalization_readiness_preview import (
+    build_evidence_repair_recovery_closure_finalization_readiness_preview,
+)
+from tools.memory_evidence_repair_recovery_closure_governance_seal_audit_preview_tool import (
+    MEMORY_EVIDENCE_REPAIR_RECOVERY_CLOSURE_GOVERNANCE_SEAL_AUDIT_PREVIEW_SCHEMA,
+    memory_evidence_repair_recovery_closure_governance_seal_audit_preview_tool,
+)
+from tools.registry import registry, tool_error
+
+
+_UPSTREAM_PROPERTIES = dict(
+    MEMORY_EVIDENCE_REPAIR_RECOVERY_CLOSURE_GOVERNANCE_SEAL_AUDIT_PREVIEW_SCHEMA[
+        "parameters"
+    ]["properties"]
+)
+_UPSTREAM_PROPERTIES.pop("format", None)
+
+MEMORY_EVIDENCE_REPAIR_RECOVERY_CLOSURE_FINALIZATION_READINESS_PREVIEW_SCHEMA = {
+    "name": "memory_evidence_repair_recovery_closure_finalization_readiness_preview",
+    "description": (
+        "Read-only finalization readiness preview for memory evidence repair "
+        "recovery closure. It checks whether the full closure governance chain "
+        "is ready for a future manual finalization, without mutating memory."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "recovery_closure_governance_seal_audit": {
+                "type": "object",
+                "description": "Optional recovery closure governance seal audit preview report payload.",
+                "additionalProperties": True,
+            },
+            "recovery_closure_governance_seal_audit_preview": {
+                "type": "object",
+                "description": "Alias for recovery_closure_governance_seal_audit.",
+                "additionalProperties": True,
+            },
+            "recovery_closure_governance_seal_audit_report": {
+                "type": "object",
+                "description": "Alias for recovery_closure_governance_seal_audit.",
+                "additionalProperties": True,
+            },
+            "governance_seal_audit": {
+                "type": "object",
+                "description": "Alias for recovery_closure_governance_seal_audit.",
+                "additionalProperties": True,
+            },
+            "governance_seal_audit_preview": {
+                "type": "object",
+                "description": "Alias for recovery_closure_governance_seal_audit.",
+                "additionalProperties": True,
+            },
+            "seal_audit": {
+                "type": "object",
+                "description": "Optional single recovery closure governance seal audit preview.",
+                "additionalProperties": True,
+            },
+            "seal_audit_preview": {
+                "type": "object",
+                "description": "Alias for seal_audit.",
+                "additionalProperties": True,
+            },
+            "format": {
+                "type": "string",
+                "enum": ["json", "markdown"],
+                "description": "Optional response format helper. JSON is always returned; markdown adds a readable summary field.",
+            },
+            **_UPSTREAM_PROPERTIES,
+        },
+    },
+}
+
+
+def memory_evidence_repair_recovery_closure_finalization_readiness_preview_tool(
+    args: dict[str, Any],
+    **kwargs,
+) -> str:
+    if not isinstance(args, dict):
+        return tool_error("args must be an object.", success=False)
+
+    validated = _validate_args(args)
+    if validated is not None:
+        return validated
+
+    recovery_closure_governance_seal_audit = (
+        _resolve_recovery_closure_governance_seal_audit(
+            args,
+            kwargs.get("memory_manager"),
+        )
+    )
+    if isinstance(recovery_closure_governance_seal_audit, str):
+        return recovery_closure_governance_seal_audit
+
+    payload = build_evidence_repair_recovery_closure_finalization_readiness_preview(
+        recovery_closure_governance_seal_audit=recovery_closure_governance_seal_audit,
+    ).to_dict()
+    payload["success"] = True
+    payload["read_only"] = True
+    payload["read_only_memory"] = True
+    payload["would_mutate_memory"] = False
+    if str(args.get("format", "")).lower() == "markdown":
+        payload["markdown"] = _render_markdown(payload)
+    return json.dumps(payload, ensure_ascii=False)
+
+
+def _validate_args(args: dict[str, Any]) -> str | None:
+    object_fields = (
+        "recovery_closure_governance_seal_audit",
+        "recovery_closure_governance_seal_audit_preview",
+        "recovery_closure_governance_seal_audit_report",
+        "governance_seal_audit",
+        "governance_seal_audit_preview",
+        "seal_audit",
+        "seal_audit_preview",
+        "recovery_closure_governance_seal",
+        "recovery_closure_governance_seal_preview",
+        "recovery_closure_governance_seal_report",
+        "governance_seal",
+        "governance_seal_preview",
+        "seal",
+        "recovery_closure_ledger_audit",
+        "recovery_closure_ledger_audit_preview",
+        "recovery_closure_ledger_audit_report",
+        "ledger_audit",
+        "ledger_audit_preview",
+        "recovery_closure_ledger",
+        "recovery_closure_ledger_preview",
+        "recovery_closure_ledger_report",
+        "ledger_preview",
+        "recovery_closure_ledger_entry",
+        "ledger_entry",
+        "entry",
+        "recovery_closure_gate",
+        "recovery_closure_gate_report",
+        "closure_gate",
+        "recovery_closure",
+        "closure",
+        "recovery_completion_audit",
+        "recovery_completion_audit_preview",
+        "recovery_completion_audit_report",
+        "recovery_completion_receipt",
+        "recovery_completion_receipt_report",
+        "completion_receipt",
+        "observed_recovery_steps",
+        "post_recovery_audit_status",
+        "contamination_status",
+        "recovery_executor_preview",
+        "recovery_executor_preview_report",
+        "recovery_executor",
+        "recovery_write_lock_gate",
+        "recovery_executor_lock_gate",
+        "recovery_write_lock",
+        "recovery_token_gate",
+        "recovery_approval_token_gate",
+        "token_gate",
+        "recovery_approval_token",
+        "recovery_human_approval_token",
+        "recovery_token",
+        "token",
+        "recovery_execution",
+        "recovery_execution_preview",
+        "recovery_execution_report",
+        "recovery_decision",
+        "recovery_decision_gate",
+        "recovery_decision_report",
+        "rollback_drill",
+        "rollback_drill_preview",
+        "rollback_drill_report",
+        "post_commit_audit",
+        "post_commit_audit_preview",
+        "post_commit_audit_report",
+        "executor_preview",
+        "executor",
+        "observed_memory_patches",
+        "rollback_status",
+        "write_lock_gate",
+        "executor_lock_gate",
+        "write_lock",
+        "commit_receipt",
+        "receipt",
+        "approval_token_gate",
+        "approval_token",
+        "dry_run",
+        "snapshot_plan",
+        "rollback_plan",
+        "existing_snapshots",
+        "pre_commit_snapshots",
+        "ledger",
+        "commit_gate",
+        "preview",
+        "approval",
+        "plan",
+        "gate",
+        "audit",
+        "diagnostics",
+        "policy",
+        "proposed_evidence",
+    )
+    array_fields = (
+        "active_locks",
+        "locks",
+        "already_used_token_ids",
+        "tokens",
+        "used_token_ids",
+        "released_lock_ids",
+        "receipts",
+        "requests",
+        "steps",
+        "entries",
+        "decisions",
+        "previews",
+        "readiness",
+        "confirmed_preview_ids",
+        "candidates",
+        "approved_candidate_ids",
+        "repairs",
+    )
+    for field_name in object_fields:
+        value = args.get(field_name)
+        if value is not None and not isinstance(value, dict):
+            return tool_error(
+                f"{field_name} must be an object when provided.",
+                success=False,
+            )
+    for field_name in ("existing_receipts", "recorded_receipts"):
+        value = args.get(field_name)
+        if value is not None and not isinstance(value, (dict, list)):
+            return tool_error(
+                f"{field_name} must be an object or array when provided.",
+                success=False,
+            )
+    for field_name in array_fields:
+        value = args.get(field_name)
+        if value is not None and not isinstance(value, list):
+            return tool_error(f"{field_name} must be an array when provided.", success=False)
+    return None
+
+
+def _resolve_recovery_closure_governance_seal_audit(
+    args: dict[str, Any],
+    memory_manager: Any,
+) -> dict[str, Any] | str:
+    for field_name in (
+        "recovery_closure_governance_seal_audit",
+        "recovery_closure_governance_seal_audit_preview",
+        "recovery_closure_governance_seal_audit_report",
+        "governance_seal_audit",
+        "governance_seal_audit_preview",
+    ):
+        explicit = args.get(field_name)
+        if isinstance(explicit, dict):
+            if str(explicit.get("id") or "").startswith(
+                "recovery-closure-governance-seal-audit-"
+            ):
+                return _seal_audit_report(explicit)
+            return explicit
+
+    for field_name in ("seal_audit", "seal_audit_preview"):
+        explicit = args.get(field_name)
+        if isinstance(explicit, dict):
+            return _seal_audit_report(explicit)
+
+    seal_audit_args = dict(args)
+    for field_name in (
+        "recovery_closure_governance_seal_audit",
+        "recovery_closure_governance_seal_audit_preview",
+        "recovery_closure_governance_seal_audit_report",
+        "governance_seal_audit",
+        "governance_seal_audit_preview",
+        "seal_audit",
+        "seal_audit_preview",
+        "format",
+    ):
+        seal_audit_args.pop(field_name, None)
+    result = memory_evidence_repair_recovery_closure_governance_seal_audit_preview_tool(
+        seal_audit_args,
+        memory_manager=memory_manager,
+    )
+    try:
+        payload = json.loads(result)
+    except json.JSONDecodeError:
+        return tool_error(
+            "recovery closure governance seal audit preview tool returned invalid JSON.",
+            success=False,
+        )
+    if not isinstance(payload, dict):
+        return tool_error(
+            "recovery closure governance seal audit preview tool returned a non-object payload.",
+            success=False,
+        )
+    if payload.get("success") is False:
+        return json.dumps(payload, ensure_ascii=False)
+    return payload
+
+
+def _seal_audit_report(seal_audit: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "status": "recovery_closure_governance_seal_audit_preview_ready",
+        "summary": {"preview_count": 1},
+        "previews": [seal_audit],
+        "read_only": True,
+        "read_only_memory": True,
+        "would_mutate_memory": False,
+    }
+
+
+def _render_markdown(payload: dict[str, Any]) -> str:
+    summary = payload.get("summary", {})
+    lines = [
+        "### Memory Evidence Repair Recovery Closure Finalization Readiness Preview",
+        f"- Status: {payload.get('status')}",
+        f"- Checks: {summary.get('check_count', 0)}",
+        f"- Readiness drafts: {summary.get('readiness_count', 0)}",
+        f"- Ready: {summary.get('recovery_closure_finalization_ready', False)}",
+        f"- Would allow final closure: {summary.get('would_allow_final_closure_count', 0)}",
+    ]
+    for item in payload.get("readiness", []):
+        lines.append(f"- Finalization readiness: {item.get('id')}")
+        lines.append(f"  Seal audit: {item.get('seal_audit_preview_id')}")
+        lines.append(f"  Seal: {item.get('seal_id')}")
+        lines.append(f"  Ledger audit: {item.get('ledger_audit_preview_id')}")
+    for reason in payload.get("blocking_reasons", []):
+        lines.append(f"- Blocked: {reason}")
+    for action in payload.get("required_actions", []):
+        lines.append(f"- Required: {action}")
+    return "\n".join(lines)
+
+
+def check_memory_evidence_repair_recovery_closure_finalization_readiness_preview_requirements() -> bool:
+    return True
+
+
+registry.register(
+    name="memory_evidence_repair_recovery_closure_finalization_readiness_preview",
+    toolset="memory",
+    schema=MEMORY_EVIDENCE_REPAIR_RECOVERY_CLOSURE_FINALIZATION_READINESS_PREVIEW_SCHEMA,
+    handler=memory_evidence_repair_recovery_closure_finalization_readiness_preview_tool,
+    check_fn=check_memory_evidence_repair_recovery_closure_finalization_readiness_preview_requirements,
+    emoji="🧠",
+)

--- a/tools/memory_evidence_repair_recovery_closure_gate_tool.py
+++ b/tools/memory_evidence_repair_recovery_closure_gate_tool.py
@@ -1,0 +1,261 @@
+"""Read-only Memory Evidence Repair Recovery Closure Gate tool."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from agent.memory_evidence_repair_recovery_closure_gate import (
+    build_evidence_repair_recovery_closure_gate,
+)
+from tools.memory_evidence_repair_recovery_completion_audit_preview_tool import (
+    MEMORY_EVIDENCE_REPAIR_RECOVERY_COMPLETION_AUDIT_PREVIEW_SCHEMA,
+    memory_evidence_repair_recovery_completion_audit_preview_tool,
+)
+from tools.registry import registry, tool_error
+
+
+_UPSTREAM_PROPERTIES = dict(
+    MEMORY_EVIDENCE_REPAIR_RECOVERY_COMPLETION_AUDIT_PREVIEW_SCHEMA["parameters"][
+        "properties"
+    ]
+)
+_UPSTREAM_PROPERTIES.pop("format", None)
+
+MEMORY_EVIDENCE_REPAIR_RECOVERY_CLOSURE_GATE_SCHEMA = {
+    "name": "memory_evidence_repair_recovery_closure_gate",
+    "description": (
+        "Read-only final closure gate for memory evidence repair recovery. "
+        "It only drafts closure when observed completion audit steps all pass."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "recovery_completion_audit": {
+                "type": "object",
+                "description": "Optional recovery completion audit preview report payload.",
+                "additionalProperties": True,
+            },
+            "recovery_completion_audit_preview": {
+                "type": "object",
+                "description": "Alias for recovery_completion_audit.",
+                "additionalProperties": True,
+            },
+            "recovery_completion_audit_report": {
+                "type": "object",
+                "description": "Alias for recovery_completion_audit.",
+                "additionalProperties": True,
+            },
+            "format": {
+                "type": "string",
+                "enum": ["json", "markdown"],
+                "description": "Optional response format helper. JSON is always returned; markdown adds a readable summary field.",
+            },
+            **_UPSTREAM_PROPERTIES,
+        },
+    },
+}
+
+
+def memory_evidence_repair_recovery_closure_gate_tool(
+    args: dict[str, Any],
+    **kwargs,
+) -> str:
+    if not isinstance(args, dict):
+        return tool_error("args must be an object.", success=False)
+
+    validated = _validate_args(args)
+    if validated is not None:
+        return validated
+
+    recovery_completion_audit = _resolve_recovery_completion_audit(
+        args,
+        kwargs.get("memory_manager"),
+    )
+    if isinstance(recovery_completion_audit, str):
+        return recovery_completion_audit
+
+    payload = build_evidence_repair_recovery_closure_gate(
+        recovery_completion_audit=recovery_completion_audit,
+    ).to_dict()
+    payload["success"] = True
+    payload["read_only"] = True
+    payload["read_only_memory"] = True
+    payload["would_mutate_memory"] = False
+    if str(args.get("format", "")).lower() == "markdown":
+        payload["markdown"] = _render_markdown(payload)
+    return json.dumps(payload, ensure_ascii=False)
+
+
+def _validate_args(args: dict[str, Any]) -> str | None:
+    object_fields = (
+        "recovery_completion_audit",
+        "recovery_completion_audit_preview",
+        "recovery_completion_audit_report",
+        "recovery_completion_receipt",
+        "recovery_completion_receipt_report",
+        "completion_receipt",
+        "observed_recovery_steps",
+        "post_recovery_audit_status",
+        "contamination_status",
+        "recovery_executor_preview",
+        "recovery_executor_preview_report",
+        "recovery_executor",
+        "recovery_write_lock_gate",
+        "recovery_executor_lock_gate",
+        "recovery_write_lock",
+        "recovery_token_gate",
+        "recovery_approval_token_gate",
+        "token_gate",
+        "recovery_approval_token",
+        "recovery_human_approval_token",
+        "recovery_token",
+        "token",
+        "recovery_execution",
+        "recovery_execution_preview",
+        "recovery_execution_report",
+        "recovery_decision",
+        "recovery_decision_gate",
+        "recovery_decision_report",
+        "rollback_drill",
+        "rollback_drill_preview",
+        "rollback_drill_report",
+        "post_commit_audit",
+        "post_commit_audit_preview",
+        "post_commit_audit_report",
+        "executor_preview",
+        "executor",
+        "observed_memory_patches",
+        "rollback_status",
+        "write_lock_gate",
+        "executor_lock_gate",
+        "write_lock",
+        "commit_receipt",
+        "receipt",
+        "approval_token_gate",
+        "approval_token",
+        "dry_run",
+        "snapshot_plan",
+        "rollback_plan",
+        "existing_snapshots",
+        "pre_commit_snapshots",
+        "ledger",
+        "commit_gate",
+        "preview",
+        "approval",
+        "plan",
+        "gate",
+        "audit",
+        "diagnostics",
+        "policy",
+        "proposed_evidence",
+    )
+    array_fields = (
+        "active_locks",
+        "locks",
+        "already_used_token_ids",
+        "tokens",
+        "used_token_ids",
+        "released_lock_ids",
+        "receipts",
+        "requests",
+        "steps",
+        "entries",
+        "decisions",
+        "previews",
+        "confirmed_preview_ids",
+        "candidates",
+        "approved_candidate_ids",
+        "repairs",
+    )
+    for field_name in object_fields:
+        value = args.get(field_name)
+        if value is not None and not isinstance(value, dict):
+            return tool_error(f"{field_name} must be an object when provided.", success=False)
+    for field_name in ("existing_receipts", "recorded_receipts"):
+        value = args.get(field_name)
+        if value is not None and not isinstance(value, (dict, list)):
+            return tool_error(
+                f"{field_name} must be an object or array when provided.",
+                success=False,
+            )
+    for field_name in array_fields:
+        value = args.get(field_name)
+        if value is not None and not isinstance(value, list):
+            return tool_error(f"{field_name} must be an array when provided.", success=False)
+    return None
+
+
+def _resolve_recovery_completion_audit(
+    args: dict[str, Any],
+    memory_manager: Any,
+) -> dict[str, Any] | str:
+    for field_name in (
+        "recovery_completion_audit",
+        "recovery_completion_audit_preview",
+        "recovery_completion_audit_report",
+    ):
+        explicit = args.get(field_name)
+        if isinstance(explicit, dict):
+            return explicit
+
+    audit_args = dict(args)
+    for field_name in (
+        "recovery_completion_audit",
+        "recovery_completion_audit_preview",
+        "recovery_completion_audit_report",
+        "format",
+    ):
+        audit_args.pop(field_name, None)
+    result = memory_evidence_repair_recovery_completion_audit_preview_tool(
+        audit_args,
+        memory_manager=memory_manager,
+    )
+    try:
+        payload = json.loads(result)
+    except json.JSONDecodeError:
+        return tool_error(
+            "recovery completion audit preview tool returned invalid JSON.",
+            success=False,
+        )
+    if not isinstance(payload, dict):
+        return tool_error(
+            "recovery completion audit preview tool returned a non-object payload.",
+            success=False,
+        )
+    if payload.get("success") is False:
+        return json.dumps(payload, ensure_ascii=False)
+    return payload
+
+
+def _render_markdown(payload: dict[str, Any]) -> str:
+    summary = payload.get("summary", {})
+    lines = [
+        "### Memory Evidence Repair Recovery Closure Gate",
+        f"- Status: {payload.get('status')}",
+        f"- Checks: {summary.get('check_count', 0)}",
+        f"- Closures: {summary.get('closure_count', 0)}",
+        f"- Ready: {summary.get('recovery_closure_ready', False)}",
+    ]
+    for closure in payload.get("closures", []):
+        lines.append(f"- Closure: {closure.get('id')}")
+        lines.append(f"  Audit: {closure.get('audit_preview_id')}")
+    for reason in payload.get("blocking_reasons", []):
+        lines.append(f"- Blocked: {reason}")
+    for action in payload.get("required_actions", []):
+        lines.append(f"- Required: {action}")
+    return "\n".join(lines)
+
+
+def check_memory_evidence_repair_recovery_closure_gate_requirements() -> bool:
+    return True
+
+
+registry.register(
+    name="memory_evidence_repair_recovery_closure_gate",
+    toolset="memory",
+    schema=MEMORY_EVIDENCE_REPAIR_RECOVERY_CLOSURE_GATE_SCHEMA,
+    handler=memory_evidence_repair_recovery_closure_gate_tool,
+    check_fn=check_memory_evidence_repair_recovery_closure_gate_requirements,
+    emoji="🧠",
+)

--- a/tools/memory_evidence_repair_recovery_closure_governance_seal_audit_preview_tool.py
+++ b/tools/memory_evidence_repair_recovery_closure_governance_seal_audit_preview_tool.py
@@ -1,0 +1,325 @@
+"""Read-only Memory Evidence Repair Recovery Closure Governance Seal Audit Preview tool."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from agent.memory_evidence_repair_recovery_closure_governance_seal_audit_preview import (
+    build_evidence_repair_recovery_closure_governance_seal_audit_preview,
+)
+from tools.memory_evidence_repair_recovery_closure_governance_seal_preview_tool import (
+    MEMORY_EVIDENCE_REPAIR_RECOVERY_CLOSURE_GOVERNANCE_SEAL_PREVIEW_SCHEMA,
+    memory_evidence_repair_recovery_closure_governance_seal_preview_tool,
+)
+from tools.registry import registry, tool_error
+
+
+_UPSTREAM_PROPERTIES = dict(
+    MEMORY_EVIDENCE_REPAIR_RECOVERY_CLOSURE_GOVERNANCE_SEAL_PREVIEW_SCHEMA[
+        "parameters"
+    ]["properties"]
+)
+_UPSTREAM_PROPERTIES.pop("format", None)
+
+MEMORY_EVIDENCE_REPAIR_RECOVERY_CLOSURE_GOVERNANCE_SEAL_AUDIT_PREVIEW_SCHEMA = {
+    "name": "memory_evidence_repair_recovery_closure_governance_seal_audit_preview",
+    "description": (
+        "Read-only audit preview for a memory evidence repair recovery closure "
+        "governance seal. It never records an audit or mutates durable memory."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "recovery_closure_governance_seal": {
+                "type": "object",
+                "description": "Optional recovery closure governance seal preview report payload.",
+                "additionalProperties": True,
+            },
+            "recovery_closure_governance_seal_preview": {
+                "type": "object",
+                "description": "Alias for recovery_closure_governance_seal.",
+                "additionalProperties": True,
+            },
+            "recovery_closure_governance_seal_report": {
+                "type": "object",
+                "description": "Alias for recovery_closure_governance_seal.",
+                "additionalProperties": True,
+            },
+            "governance_seal": {
+                "type": "object",
+                "description": "Alias for recovery_closure_governance_seal.",
+                "additionalProperties": True,
+            },
+            "governance_seal_preview": {
+                "type": "object",
+                "description": "Alias for recovery_closure_governance_seal.",
+                "additionalProperties": True,
+            },
+            "seal": {
+                "type": "object",
+                "description": "Optional single recovery closure governance seal draft.",
+                "additionalProperties": True,
+            },
+            "format": {
+                "type": "string",
+                "enum": ["json", "markdown"],
+                "description": "Optional response format helper. JSON is always returned; markdown adds a readable summary field.",
+            },
+            **_UPSTREAM_PROPERTIES,
+        },
+    },
+}
+
+
+def memory_evidence_repair_recovery_closure_governance_seal_audit_preview_tool(
+    args: dict[str, Any],
+    **kwargs,
+) -> str:
+    if not isinstance(args, dict):
+        return tool_error("args must be an object.", success=False)
+
+    validated = _validate_args(args)
+    if validated is not None:
+        return validated
+
+    recovery_closure_governance_seal = _resolve_recovery_closure_governance_seal(
+        args,
+        kwargs.get("memory_manager"),
+    )
+    if isinstance(recovery_closure_governance_seal, str):
+        return recovery_closure_governance_seal
+
+    payload = build_evidence_repair_recovery_closure_governance_seal_audit_preview(
+        recovery_closure_governance_seal=recovery_closure_governance_seal,
+    ).to_dict()
+    payload["success"] = True
+    payload["read_only"] = True
+    payload["read_only_memory"] = True
+    payload["would_mutate_memory"] = False
+    if str(args.get("format", "")).lower() == "markdown":
+        payload["markdown"] = _render_markdown(payload)
+    return json.dumps(payload, ensure_ascii=False)
+
+
+def _validate_args(args: dict[str, Any]) -> str | None:
+    object_fields = (
+        "recovery_closure_governance_seal",
+        "recovery_closure_governance_seal_preview",
+        "recovery_closure_governance_seal_report",
+        "governance_seal",
+        "governance_seal_preview",
+        "seal",
+        "recovery_closure_ledger_audit",
+        "recovery_closure_ledger_audit_preview",
+        "recovery_closure_ledger_audit_report",
+        "ledger_audit",
+        "ledger_audit_preview",
+        "recovery_closure_ledger",
+        "recovery_closure_ledger_preview",
+        "recovery_closure_ledger_report",
+        "ledger_preview",
+        "recovery_closure_ledger_entry",
+        "ledger_entry",
+        "entry",
+        "recovery_closure_gate",
+        "recovery_closure_gate_report",
+        "closure_gate",
+        "recovery_closure",
+        "closure",
+        "recovery_completion_audit",
+        "recovery_completion_audit_preview",
+        "recovery_completion_audit_report",
+        "recovery_completion_receipt",
+        "recovery_completion_receipt_report",
+        "completion_receipt",
+        "observed_recovery_steps",
+        "post_recovery_audit_status",
+        "contamination_status",
+        "recovery_executor_preview",
+        "recovery_executor_preview_report",
+        "recovery_executor",
+        "recovery_write_lock_gate",
+        "recovery_executor_lock_gate",
+        "recovery_write_lock",
+        "recovery_token_gate",
+        "recovery_approval_token_gate",
+        "token_gate",
+        "recovery_approval_token",
+        "recovery_human_approval_token",
+        "recovery_token",
+        "token",
+        "recovery_execution",
+        "recovery_execution_preview",
+        "recovery_execution_report",
+        "recovery_decision",
+        "recovery_decision_gate",
+        "recovery_decision_report",
+        "rollback_drill",
+        "rollback_drill_preview",
+        "rollback_drill_report",
+        "post_commit_audit",
+        "post_commit_audit_preview",
+        "post_commit_audit_report",
+        "executor_preview",
+        "executor",
+        "observed_memory_patches",
+        "rollback_status",
+        "write_lock_gate",
+        "executor_lock_gate",
+        "write_lock",
+        "commit_receipt",
+        "receipt",
+        "approval_token_gate",
+        "approval_token",
+        "dry_run",
+        "snapshot_plan",
+        "rollback_plan",
+        "existing_snapshots",
+        "pre_commit_snapshots",
+        "ledger",
+        "commit_gate",
+        "preview",
+        "approval",
+        "plan",
+        "gate",
+        "audit",
+        "diagnostics",
+        "policy",
+        "proposed_evidence",
+    )
+    array_fields = (
+        "active_locks",
+        "locks",
+        "already_used_token_ids",
+        "tokens",
+        "used_token_ids",
+        "released_lock_ids",
+        "receipts",
+        "requests",
+        "steps",
+        "entries",
+        "decisions",
+        "previews",
+        "confirmed_preview_ids",
+        "candidates",
+        "approved_candidate_ids",
+        "repairs",
+    )
+    for field_name in object_fields:
+        value = args.get(field_name)
+        if value is not None and not isinstance(value, dict):
+            return tool_error(f"{field_name} must be an object when provided.", success=False)
+    for field_name in ("existing_receipts", "recorded_receipts"):
+        value = args.get(field_name)
+        if value is not None and not isinstance(value, (dict, list)):
+            return tool_error(
+                f"{field_name} must be an object or array when provided.",
+                success=False,
+            )
+    for field_name in array_fields:
+        value = args.get(field_name)
+        if value is not None and not isinstance(value, list):
+            return tool_error(f"{field_name} must be an array when provided.", success=False)
+    return None
+
+
+def _resolve_recovery_closure_governance_seal(
+    args: dict[str, Any],
+    memory_manager: Any,
+) -> dict[str, Any] | str:
+    for field_name in (
+        "recovery_closure_governance_seal",
+        "recovery_closure_governance_seal_preview",
+        "recovery_closure_governance_seal_report",
+        "governance_seal",
+        "governance_seal_preview",
+    ):
+        explicit = args.get(field_name)
+        if isinstance(explicit, dict):
+            if str(explicit.get("id") or "").startswith(
+                "recovery-closure-governance-seal-"
+            ):
+                return _seal_report(explicit)
+            return explicit
+
+    explicit_seal = args.get("seal")
+    if isinstance(explicit_seal, dict):
+        return _seal_report(explicit_seal)
+
+    seal_args = dict(args)
+    for field_name in (
+        "recovery_closure_governance_seal",
+        "recovery_closure_governance_seal_preview",
+        "recovery_closure_governance_seal_report",
+        "governance_seal",
+        "governance_seal_preview",
+        "seal",
+        "format",
+    ):
+        seal_args.pop(field_name, None)
+    result = memory_evidence_repair_recovery_closure_governance_seal_preview_tool(
+        seal_args,
+        memory_manager=memory_manager,
+    )
+    try:
+        payload = json.loads(result)
+    except json.JSONDecodeError:
+        return tool_error(
+            "recovery closure governance seal preview tool returned invalid JSON.",
+            success=False,
+        )
+    if not isinstance(payload, dict):
+        return tool_error(
+            "recovery closure governance seal preview tool returned a non-object payload.",
+            success=False,
+        )
+    if payload.get("success") is False:
+        return json.dumps(payload, ensure_ascii=False)
+    return payload
+
+
+def _seal_report(seal: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "status": "recovery_closure_governance_seal_preview_ready",
+        "summary": {"seal_count": 1},
+        "seals": [seal],
+        "read_only": True,
+        "read_only_memory": True,
+        "would_mutate_memory": False,
+    }
+
+
+def _render_markdown(payload: dict[str, Any]) -> str:
+    summary = payload.get("summary", {})
+    lines = [
+        "### Memory Evidence Repair Recovery Closure Governance Seal Audit Preview",
+        f"- Status: {payload.get('status')}",
+        f"- Checks: {summary.get('check_count', 0)}",
+        f"- Previews: {summary.get('preview_count', 0)}",
+        f"- Audit steps: {summary.get('audit_step_count', 0)}",
+        f"- Ready: {summary.get('recovery_closure_governance_seal_audit_ready', False)}",
+    ]
+    for preview in payload.get("previews", []):
+        lines.append(f"- Audit preview: {preview.get('id')}")
+        lines.append(f"  Seal: {preview.get('seal_id')}")
+        lines.append(f"  Ledger audit: {preview.get('ledger_audit_preview_id')}")
+    for reason in payload.get("blocking_reasons", []):
+        lines.append(f"- Blocked: {reason}")
+    for action in payload.get("required_actions", []):
+        lines.append(f"- Required: {action}")
+    return "\n".join(lines)
+
+
+def check_memory_evidence_repair_recovery_closure_governance_seal_audit_preview_requirements() -> bool:
+    return True
+
+
+registry.register(
+    name="memory_evidence_repair_recovery_closure_governance_seal_audit_preview",
+    toolset="memory",
+    schema=MEMORY_EVIDENCE_REPAIR_RECOVERY_CLOSURE_GOVERNANCE_SEAL_AUDIT_PREVIEW_SCHEMA,
+    handler=memory_evidence_repair_recovery_closure_governance_seal_audit_preview_tool,
+    check_fn=check_memory_evidence_repair_recovery_closure_governance_seal_audit_preview_requirements,
+    emoji="🧠",
+)

--- a/tools/memory_evidence_repair_recovery_closure_governance_seal_preview_tool.py
+++ b/tools/memory_evidence_repair_recovery_closure_governance_seal_preview_tool.py
@@ -1,0 +1,304 @@
+"""Read-only Memory Evidence Repair Recovery Closure Governance Seal Preview tool."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from agent.memory_evidence_repair_recovery_closure_governance_seal_preview import (
+    build_evidence_repair_recovery_closure_governance_seal_preview,
+)
+from tools.memory_evidence_repair_recovery_closure_ledger_audit_preview_tool import (
+    MEMORY_EVIDENCE_REPAIR_RECOVERY_CLOSURE_LEDGER_AUDIT_PREVIEW_SCHEMA,
+    memory_evidence_repair_recovery_closure_ledger_audit_preview_tool,
+)
+from tools.registry import registry, tool_error
+
+
+_UPSTREAM_PROPERTIES = dict(
+    MEMORY_EVIDENCE_REPAIR_RECOVERY_CLOSURE_LEDGER_AUDIT_PREVIEW_SCHEMA[
+        "parameters"
+    ]["properties"]
+)
+_UPSTREAM_PROPERTIES.pop("format", None)
+
+MEMORY_EVIDENCE_REPAIR_RECOVERY_CLOSURE_GOVERNANCE_SEAL_PREVIEW_SCHEMA = {
+    "name": "memory_evidence_repair_recovery_closure_governance_seal_preview",
+    "description": (
+        "Read-only governance seal draft for an audited memory evidence repair "
+        "recovery closure. It never records a seal or mutates durable memory."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "recovery_closure_ledger_audit": {
+                "type": "object",
+                "description": "Optional recovery closure ledger audit preview report payload.",
+                "additionalProperties": True,
+            },
+            "recovery_closure_ledger_audit_preview": {
+                "type": "object",
+                "description": "Alias for recovery_closure_ledger_audit.",
+                "additionalProperties": True,
+            },
+            "recovery_closure_ledger_audit_report": {
+                "type": "object",
+                "description": "Alias for recovery_closure_ledger_audit.",
+                "additionalProperties": True,
+            },
+            "ledger_audit": {
+                "type": "object",
+                "description": "Alias for recovery_closure_ledger_audit.",
+                "additionalProperties": True,
+            },
+            "ledger_audit_preview": {
+                "type": "object",
+                "description": "Alias for recovery_closure_ledger_audit.",
+                "additionalProperties": True,
+            },
+            "format": {
+                "type": "string",
+                "enum": ["json", "markdown"],
+                "description": "Optional response format helper. JSON is always returned; markdown adds a readable summary field.",
+            },
+            **_UPSTREAM_PROPERTIES,
+        },
+    },
+}
+
+
+def memory_evidence_repair_recovery_closure_governance_seal_preview_tool(
+    args: dict[str, Any],
+    **kwargs,
+) -> str:
+    if not isinstance(args, dict):
+        return tool_error("args must be an object.", success=False)
+
+    validated = _validate_args(args)
+    if validated is not None:
+        return validated
+
+    recovery_closure_ledger_audit = _resolve_recovery_closure_ledger_audit(
+        args,
+        kwargs.get("memory_manager"),
+    )
+    if isinstance(recovery_closure_ledger_audit, str):
+        return recovery_closure_ledger_audit
+
+    payload = build_evidence_repair_recovery_closure_governance_seal_preview(
+        recovery_closure_ledger_audit=recovery_closure_ledger_audit,
+    ).to_dict()
+    payload["success"] = True
+    payload["read_only"] = True
+    payload["read_only_memory"] = True
+    payload["would_mutate_memory"] = False
+    if str(args.get("format", "")).lower() == "markdown":
+        payload["markdown"] = _render_markdown(payload)
+    return json.dumps(payload, ensure_ascii=False)
+
+
+def _validate_args(args: dict[str, Any]) -> str | None:
+    object_fields = (
+        "recovery_closure_ledger_audit",
+        "recovery_closure_ledger_audit_preview",
+        "recovery_closure_ledger_audit_report",
+        "ledger_audit",
+        "ledger_audit_preview",
+        "recovery_closure_ledger",
+        "recovery_closure_ledger_preview",
+        "recovery_closure_ledger_report",
+        "ledger_preview",
+        "recovery_closure_ledger_entry",
+        "ledger_entry",
+        "entry",
+        "recovery_closure_gate",
+        "recovery_closure_gate_report",
+        "closure_gate",
+        "recovery_closure",
+        "closure",
+        "recovery_completion_audit",
+        "recovery_completion_audit_preview",
+        "recovery_completion_audit_report",
+        "recovery_completion_receipt",
+        "recovery_completion_receipt_report",
+        "completion_receipt",
+        "observed_recovery_steps",
+        "post_recovery_audit_status",
+        "contamination_status",
+        "recovery_executor_preview",
+        "recovery_executor_preview_report",
+        "recovery_executor",
+        "recovery_write_lock_gate",
+        "recovery_executor_lock_gate",
+        "recovery_write_lock",
+        "recovery_token_gate",
+        "recovery_approval_token_gate",
+        "token_gate",
+        "recovery_approval_token",
+        "recovery_human_approval_token",
+        "recovery_token",
+        "token",
+        "recovery_execution",
+        "recovery_execution_preview",
+        "recovery_execution_report",
+        "recovery_decision",
+        "recovery_decision_gate",
+        "recovery_decision_report",
+        "rollback_drill",
+        "rollback_drill_preview",
+        "rollback_drill_report",
+        "post_commit_audit",
+        "post_commit_audit_preview",
+        "post_commit_audit_report",
+        "executor_preview",
+        "executor",
+        "observed_memory_patches",
+        "rollback_status",
+        "write_lock_gate",
+        "executor_lock_gate",
+        "write_lock",
+        "commit_receipt",
+        "receipt",
+        "approval_token_gate",
+        "approval_token",
+        "dry_run",
+        "snapshot_plan",
+        "rollback_plan",
+        "existing_snapshots",
+        "pre_commit_snapshots",
+        "ledger",
+        "commit_gate",
+        "preview",
+        "approval",
+        "plan",
+        "gate",
+        "audit",
+        "diagnostics",
+        "policy",
+        "proposed_evidence",
+    )
+    array_fields = (
+        "active_locks",
+        "locks",
+        "already_used_token_ids",
+        "tokens",
+        "used_token_ids",
+        "released_lock_ids",
+        "receipts",
+        "requests",
+        "steps",
+        "entries",
+        "decisions",
+        "previews",
+        "confirmed_preview_ids",
+        "candidates",
+        "approved_candidate_ids",
+        "repairs",
+    )
+    for field_name in object_fields:
+        value = args.get(field_name)
+        if value is not None and not isinstance(value, dict):
+            return tool_error(f"{field_name} must be an object when provided.", success=False)
+    for field_name in ("existing_receipts", "recorded_receipts"):
+        value = args.get(field_name)
+        if value is not None and not isinstance(value, (dict, list)):
+            return tool_error(
+                f"{field_name} must be an object or array when provided.",
+                success=False,
+            )
+    for field_name in array_fields:
+        value = args.get(field_name)
+        if value is not None and not isinstance(value, list):
+            return tool_error(f"{field_name} must be an array when provided.", success=False)
+    return None
+
+
+def _resolve_recovery_closure_ledger_audit(
+    args: dict[str, Any],
+    memory_manager: Any,
+) -> dict[str, Any] | str:
+    for field_name in (
+        "recovery_closure_ledger_audit",
+        "recovery_closure_ledger_audit_preview",
+        "recovery_closure_ledger_audit_report",
+        "ledger_audit",
+        "ledger_audit_preview",
+    ):
+        explicit = args.get(field_name)
+        if isinstance(explicit, dict):
+            if str(explicit.get("id") or "").startswith(
+                "recovery-closure-ledger-audit-"
+            ):
+                return {
+                    "status": "recovery_closure_ledger_audit_preview_ready",
+                    "summary": {"preview_count": 1},
+                    "previews": [explicit],
+                    "read_only": True,
+                    "read_only_memory": True,
+                    "would_mutate_memory": False,
+                }
+            return explicit
+
+    audit_args = dict(args)
+    for field_name in (
+        "recovery_closure_ledger_audit",
+        "recovery_closure_ledger_audit_preview",
+        "recovery_closure_ledger_audit_report",
+        "ledger_audit",
+        "ledger_audit_preview",
+        "format",
+    ):
+        audit_args.pop(field_name, None)
+    result = memory_evidence_repair_recovery_closure_ledger_audit_preview_tool(
+        audit_args,
+        memory_manager=memory_manager,
+    )
+    try:
+        payload = json.loads(result)
+    except json.JSONDecodeError:
+        return tool_error(
+            "recovery closure ledger audit preview tool returned invalid JSON.",
+            success=False,
+        )
+    if not isinstance(payload, dict):
+        return tool_error(
+            "recovery closure ledger audit preview tool returned a non-object payload.",
+            success=False,
+        )
+    if payload.get("success") is False:
+        return json.dumps(payload, ensure_ascii=False)
+    return payload
+
+
+def _render_markdown(payload: dict[str, Any]) -> str:
+    summary = payload.get("summary", {})
+    lines = [
+        "### Memory Evidence Repair Recovery Closure Governance Seal Preview",
+        f"- Status: {payload.get('status')}",
+        f"- Checks: {summary.get('check_count', 0)}",
+        f"- Seals: {summary.get('seal_count', 0)}",
+        f"- Ready: {summary.get('recovery_closure_governance_seal_ready', False)}",
+    ]
+    for seal in payload.get("seals", []):
+        lines.append(f"- Seal: {seal.get('id')}")
+        lines.append(f"  Ledger audit: {seal.get('ledger_audit_preview_id')}")
+        lines.append(f"  Closure: {seal.get('closure_id')}")
+    for reason in payload.get("blocking_reasons", []):
+        lines.append(f"- Blocked: {reason}")
+    for action in payload.get("required_actions", []):
+        lines.append(f"- Required: {action}")
+    return "\n".join(lines)
+
+
+def check_memory_evidence_repair_recovery_closure_governance_seal_preview_requirements() -> bool:
+    return True
+
+
+registry.register(
+    name="memory_evidence_repair_recovery_closure_governance_seal_preview",
+    toolset="memory",
+    schema=MEMORY_EVIDENCE_REPAIR_RECOVERY_CLOSURE_GOVERNANCE_SEAL_PREVIEW_SCHEMA,
+    handler=memory_evidence_repair_recovery_closure_governance_seal_preview_tool,
+    check_fn=check_memory_evidence_repair_recovery_closure_governance_seal_preview_requirements,
+    emoji="🧠",
+)

--- a/tools/memory_evidence_repair_recovery_closure_ledger_audit_preview_tool.py
+++ b/tools/memory_evidence_repair_recovery_closure_ledger_audit_preview_tool.py
@@ -1,0 +1,312 @@
+"""Read-only Memory Evidence Repair Recovery Closure Ledger Audit Preview tool."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from agent.memory_evidence_repair_recovery_closure_ledger_audit_preview import (
+    build_evidence_repair_recovery_closure_ledger_audit_preview,
+)
+from tools.memory_evidence_repair_recovery_closure_ledger_preview_tool import (
+    MEMORY_EVIDENCE_REPAIR_RECOVERY_CLOSURE_LEDGER_PREVIEW_SCHEMA,
+    memory_evidence_repair_recovery_closure_ledger_preview_tool,
+)
+from tools.registry import registry, tool_error
+
+
+_UPSTREAM_PROPERTIES = dict(
+    MEMORY_EVIDENCE_REPAIR_RECOVERY_CLOSURE_LEDGER_PREVIEW_SCHEMA["parameters"][
+        "properties"
+    ]
+)
+_UPSTREAM_PROPERTIES.pop("format", None)
+
+MEMORY_EVIDENCE_REPAIR_RECOVERY_CLOSURE_LEDGER_AUDIT_PREVIEW_SCHEMA = {
+    "name": "memory_evidence_repair_recovery_closure_ledger_audit_preview",
+    "description": (
+        "Read-only audit preview for a memory evidence repair recovery closure "
+        "ledger entry. It never records an audit or mutates durable memory."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "recovery_closure_ledger": {
+                "type": "object",
+                "description": "Optional recovery closure ledger preview report payload.",
+                "additionalProperties": True,
+            },
+            "recovery_closure_ledger_preview": {
+                "type": "object",
+                "description": "Alias for recovery_closure_ledger.",
+                "additionalProperties": True,
+            },
+            "recovery_closure_ledger_report": {
+                "type": "object",
+                "description": "Alias for recovery_closure_ledger.",
+                "additionalProperties": True,
+            },
+            "ledger_preview": {
+                "type": "object",
+                "description": "Alias for recovery_closure_ledger.",
+                "additionalProperties": True,
+            },
+            "recovery_closure_ledger_entry": {
+                "type": "object",
+                "description": "Optional single recovery closure ledger entry payload.",
+                "additionalProperties": True,
+            },
+            "ledger_entry": {
+                "type": "object",
+                "description": "Alias for recovery_closure_ledger_entry.",
+                "additionalProperties": True,
+            },
+            "entry": {
+                "type": "object",
+                "description": "Alias for recovery_closure_ledger_entry.",
+                "additionalProperties": True,
+            },
+            "format": {
+                "type": "string",
+                "enum": ["json", "markdown"],
+                "description": "Optional response format helper. JSON is always returned; markdown adds a readable summary field.",
+            },
+            **_UPSTREAM_PROPERTIES,
+        },
+    },
+}
+
+
+def memory_evidence_repair_recovery_closure_ledger_audit_preview_tool(
+    args: dict[str, Any],
+    **kwargs,
+) -> str:
+    if not isinstance(args, dict):
+        return tool_error("args must be an object.", success=False)
+
+    validated = _validate_args(args)
+    if validated is not None:
+        return validated
+
+    recovery_closure_ledger = _resolve_recovery_closure_ledger(
+        args,
+        kwargs.get("memory_manager"),
+    )
+    if isinstance(recovery_closure_ledger, str):
+        return recovery_closure_ledger
+
+    payload = build_evidence_repair_recovery_closure_ledger_audit_preview(
+        recovery_closure_ledger=recovery_closure_ledger,
+    ).to_dict()
+    payload["success"] = True
+    payload["read_only"] = True
+    payload["read_only_memory"] = True
+    payload["would_mutate_memory"] = False
+    if str(args.get("format", "")).lower() == "markdown":
+        payload["markdown"] = _render_markdown(payload)
+    return json.dumps(payload, ensure_ascii=False)
+
+
+def _validate_args(args: dict[str, Any]) -> str | None:
+    object_fields = (
+        "recovery_closure_ledger",
+        "recovery_closure_ledger_preview",
+        "recovery_closure_ledger_report",
+        "ledger_preview",
+        "recovery_closure_ledger_entry",
+        "ledger_entry",
+        "entry",
+        "recovery_closure_gate",
+        "recovery_closure_gate_report",
+        "closure_gate",
+        "recovery_closure",
+        "closure",
+        "recovery_completion_audit",
+        "recovery_completion_audit_preview",
+        "recovery_completion_audit_report",
+        "recovery_completion_receipt",
+        "recovery_completion_receipt_report",
+        "completion_receipt",
+        "observed_recovery_steps",
+        "post_recovery_audit_status",
+        "contamination_status",
+        "recovery_executor_preview",
+        "recovery_executor_preview_report",
+        "recovery_executor",
+        "recovery_write_lock_gate",
+        "recovery_executor_lock_gate",
+        "recovery_write_lock",
+        "recovery_token_gate",
+        "recovery_approval_token_gate",
+        "token_gate",
+        "recovery_approval_token",
+        "recovery_human_approval_token",
+        "recovery_token",
+        "token",
+        "recovery_execution",
+        "recovery_execution_preview",
+        "recovery_execution_report",
+        "recovery_decision",
+        "recovery_decision_gate",
+        "recovery_decision_report",
+        "rollback_drill",
+        "rollback_drill_preview",
+        "rollback_drill_report",
+        "post_commit_audit",
+        "post_commit_audit_preview",
+        "post_commit_audit_report",
+        "executor_preview",
+        "executor",
+        "observed_memory_patches",
+        "rollback_status",
+        "write_lock_gate",
+        "executor_lock_gate",
+        "write_lock",
+        "commit_receipt",
+        "receipt",
+        "approval_token_gate",
+        "approval_token",
+        "dry_run",
+        "snapshot_plan",
+        "rollback_plan",
+        "existing_snapshots",
+        "pre_commit_snapshots",
+        "ledger",
+        "commit_gate",
+        "preview",
+        "approval",
+        "plan",
+        "gate",
+        "audit",
+        "diagnostics",
+        "policy",
+        "proposed_evidence",
+    )
+    array_fields = (
+        "active_locks",
+        "locks",
+        "already_used_token_ids",
+        "tokens",
+        "used_token_ids",
+        "released_lock_ids",
+        "receipts",
+        "requests",
+        "steps",
+        "entries",
+        "decisions",
+        "previews",
+        "confirmed_preview_ids",
+        "candidates",
+        "approved_candidate_ids",
+        "repairs",
+    )
+    for field_name in object_fields:
+        value = args.get(field_name)
+        if value is not None and not isinstance(value, dict):
+            return tool_error(f"{field_name} must be an object when provided.", success=False)
+    for field_name in ("existing_receipts", "recorded_receipts"):
+        value = args.get(field_name)
+        if value is not None and not isinstance(value, (dict, list)):
+            return tool_error(
+                f"{field_name} must be an object or array when provided.",
+                success=False,
+            )
+    for field_name in array_fields:
+        value = args.get(field_name)
+        if value is not None and not isinstance(value, list):
+            return tool_error(f"{field_name} must be an array when provided.", success=False)
+    return None
+
+
+def _resolve_recovery_closure_ledger(
+    args: dict[str, Any],
+    memory_manager: Any,
+) -> dict[str, Any] | str:
+    for field_name in (
+        "recovery_closure_ledger",
+        "recovery_closure_ledger_preview",
+        "recovery_closure_ledger_report",
+        "ledger_preview",
+    ):
+        explicit = args.get(field_name)
+        if isinstance(explicit, dict):
+            return explicit
+
+    for field_name in ("recovery_closure_ledger_entry", "ledger_entry", "entry"):
+        explicit_entry = args.get(field_name)
+        if isinstance(explicit_entry, dict):
+            return {
+                "status": "recovery_closure_ledger_preview_ready",
+                "summary": {"entry_count": 1},
+                "entries": [explicit_entry],
+                "read_only": True,
+                "read_only_memory": True,
+                "would_mutate_memory": False,
+            }
+
+    ledger_args = dict(args)
+    for field_name in (
+        "recovery_closure_ledger",
+        "recovery_closure_ledger_preview",
+        "recovery_closure_ledger_report",
+        "ledger_preview",
+        "recovery_closure_ledger_entry",
+        "ledger_entry",
+        "entry",
+        "format",
+    ):
+        ledger_args.pop(field_name, None)
+    result = memory_evidence_repair_recovery_closure_ledger_preview_tool(
+        ledger_args,
+        memory_manager=memory_manager,
+    )
+    try:
+        payload = json.loads(result)
+    except json.JSONDecodeError:
+        return tool_error(
+            "recovery closure ledger preview tool returned invalid JSON.",
+            success=False,
+        )
+    if not isinstance(payload, dict):
+        return tool_error(
+            "recovery closure ledger preview tool returned a non-object payload.",
+            success=False,
+        )
+    if payload.get("success") is False:
+        return json.dumps(payload, ensure_ascii=False)
+    return payload
+
+
+def _render_markdown(payload: dict[str, Any]) -> str:
+    summary = payload.get("summary", {})
+    lines = [
+        "### Memory Evidence Repair Recovery Closure Ledger Audit Preview",
+        f"- Status: {payload.get('status')}",
+        f"- Checks: {summary.get('check_count', 0)}",
+        f"- Previews: {summary.get('preview_count', 0)}",
+        f"- Audit steps: {summary.get('audit_step_count', 0)}",
+        f"- Ready: {summary.get('recovery_closure_ledger_audit_ready', False)}",
+    ]
+    for preview in payload.get("previews", []):
+        lines.append(f"- Audit preview: {preview.get('id')}")
+        lines.append(f"  Ledger entry: {preview.get('ledger_entry_id')}")
+        lines.append(f"  Closure: {preview.get('closure_id')}")
+    for reason in payload.get("blocking_reasons", []):
+        lines.append(f"- Blocked: {reason}")
+    for action in payload.get("required_actions", []):
+        lines.append(f"- Required: {action}")
+    return "\n".join(lines)
+
+
+def check_memory_evidence_repair_recovery_closure_ledger_audit_preview_requirements() -> bool:
+    return True
+
+
+registry.register(
+    name="memory_evidence_repair_recovery_closure_ledger_audit_preview",
+    toolset="memory",
+    schema=MEMORY_EVIDENCE_REPAIR_RECOVERY_CLOSURE_LEDGER_AUDIT_PREVIEW_SCHEMA,
+    handler=memory_evidence_repair_recovery_closure_ledger_audit_preview_tool,
+    check_fn=check_memory_evidence_repair_recovery_closure_ledger_audit_preview_requirements,
+    emoji="🧠",
+)

--- a/tools/memory_evidence_repair_recovery_closure_ledger_preview_tool.py
+++ b/tools/memory_evidence_repair_recovery_closure_ledger_preview_tool.py
@@ -1,0 +1,287 @@
+"""Read-only Memory Evidence Repair Recovery Closure Ledger Preview tool."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from agent.memory_evidence_repair_recovery_closure_ledger_preview import (
+    build_evidence_repair_recovery_closure_ledger_preview,
+)
+from tools.memory_evidence_repair_recovery_closure_gate_tool import (
+    MEMORY_EVIDENCE_REPAIR_RECOVERY_CLOSURE_GATE_SCHEMA,
+    memory_evidence_repair_recovery_closure_gate_tool,
+)
+from tools.registry import registry, tool_error
+
+
+_UPSTREAM_PROPERTIES = dict(
+    MEMORY_EVIDENCE_REPAIR_RECOVERY_CLOSURE_GATE_SCHEMA["parameters"]["properties"]
+)
+_UPSTREAM_PROPERTIES.pop("format", None)
+
+MEMORY_EVIDENCE_REPAIR_RECOVERY_CLOSURE_LEDGER_PREVIEW_SCHEMA = {
+    "name": "memory_evidence_repair_recovery_closure_ledger_preview",
+    "description": (
+        "Read-only lifecycle ledger preview for a memory evidence repair recovery "
+        "closure. It never records a ledger entry or mutates durable memory."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "recovery_closure_gate": {
+                "type": "object",
+                "description": "Optional recovery closure gate report payload.",
+                "additionalProperties": True,
+            },
+            "recovery_closure_gate_report": {
+                "type": "object",
+                "description": "Alias for recovery_closure_gate.",
+                "additionalProperties": True,
+            },
+            "closure_gate": {
+                "type": "object",
+                "description": "Alias for recovery_closure_gate.",
+                "additionalProperties": True,
+            },
+            "recovery_closure": {
+                "type": "object",
+                "description": "Optional single recovery closure draft payload.",
+                "additionalProperties": True,
+            },
+            "closure": {
+                "type": "object",
+                "description": "Alias for recovery_closure.",
+                "additionalProperties": True,
+            },
+            "format": {
+                "type": "string",
+                "enum": ["json", "markdown"],
+                "description": "Optional response format helper. JSON is always returned; markdown adds a readable summary field.",
+            },
+            **_UPSTREAM_PROPERTIES,
+        },
+    },
+}
+
+
+def memory_evidence_repair_recovery_closure_ledger_preview_tool(
+    args: dict[str, Any],
+    **kwargs,
+) -> str:
+    if not isinstance(args, dict):
+        return tool_error("args must be an object.", success=False)
+
+    validated = _validate_args(args)
+    if validated is not None:
+        return validated
+
+    recovery_closure_gate = _resolve_recovery_closure_gate(
+        args,
+        kwargs.get("memory_manager"),
+    )
+    if isinstance(recovery_closure_gate, str):
+        return recovery_closure_gate
+
+    payload = build_evidence_repair_recovery_closure_ledger_preview(
+        recovery_closure_gate=recovery_closure_gate,
+    ).to_dict()
+    payload["success"] = True
+    payload["read_only"] = True
+    payload["read_only_memory"] = True
+    payload["would_mutate_memory"] = False
+    if str(args.get("format", "")).lower() == "markdown":
+        payload["markdown"] = _render_markdown(payload)
+    return json.dumps(payload, ensure_ascii=False)
+
+
+def _validate_args(args: dict[str, Any]) -> str | None:
+    object_fields = (
+        "recovery_closure_gate",
+        "recovery_closure_gate_report",
+        "closure_gate",
+        "recovery_closure",
+        "closure",
+        "recovery_completion_audit",
+        "recovery_completion_audit_preview",
+        "recovery_completion_audit_report",
+        "recovery_completion_receipt",
+        "recovery_completion_receipt_report",
+        "completion_receipt",
+        "observed_recovery_steps",
+        "post_recovery_audit_status",
+        "contamination_status",
+        "recovery_executor_preview",
+        "recovery_executor_preview_report",
+        "recovery_executor",
+        "recovery_write_lock_gate",
+        "recovery_executor_lock_gate",
+        "recovery_write_lock",
+        "recovery_token_gate",
+        "recovery_approval_token_gate",
+        "token_gate",
+        "recovery_approval_token",
+        "recovery_human_approval_token",
+        "recovery_token",
+        "token",
+        "recovery_execution",
+        "recovery_execution_preview",
+        "recovery_execution_report",
+        "recovery_decision",
+        "recovery_decision_gate",
+        "recovery_decision_report",
+        "rollback_drill",
+        "rollback_drill_preview",
+        "rollback_drill_report",
+        "post_commit_audit",
+        "post_commit_audit_preview",
+        "post_commit_audit_report",
+        "executor_preview",
+        "executor",
+        "observed_memory_patches",
+        "rollback_status",
+        "write_lock_gate",
+        "executor_lock_gate",
+        "write_lock",
+        "commit_receipt",
+        "receipt",
+        "approval_token_gate",
+        "approval_token",
+        "dry_run",
+        "snapshot_plan",
+        "rollback_plan",
+        "existing_snapshots",
+        "pre_commit_snapshots",
+        "ledger",
+        "commit_gate",
+        "preview",
+        "approval",
+        "plan",
+        "gate",
+        "audit",
+        "diagnostics",
+        "policy",
+        "proposed_evidence",
+    )
+    array_fields = (
+        "active_locks",
+        "locks",
+        "already_used_token_ids",
+        "tokens",
+        "used_token_ids",
+        "released_lock_ids",
+        "receipts",
+        "requests",
+        "steps",
+        "entries",
+        "decisions",
+        "previews",
+        "confirmed_preview_ids",
+        "candidates",
+        "approved_candidate_ids",
+        "repairs",
+    )
+    for field_name in object_fields:
+        value = args.get(field_name)
+        if value is not None and not isinstance(value, dict):
+            return tool_error(f"{field_name} must be an object when provided.", success=False)
+    for field_name in ("existing_receipts", "recorded_receipts"):
+        value = args.get(field_name)
+        if value is not None and not isinstance(value, (dict, list)):
+            return tool_error(
+                f"{field_name} must be an object or array when provided.",
+                success=False,
+            )
+    for field_name in array_fields:
+        value = args.get(field_name)
+        if value is not None and not isinstance(value, list):
+            return tool_error(f"{field_name} must be an array when provided.", success=False)
+    return None
+
+
+def _resolve_recovery_closure_gate(
+    args: dict[str, Any],
+    memory_manager: Any,
+) -> dict[str, Any] | str:
+    for field_name in (
+        "recovery_closure_gate",
+        "recovery_closure_gate_report",
+        "closure_gate",
+    ):
+        explicit = args.get(field_name)
+        if isinstance(explicit, dict):
+            return explicit
+
+    for field_name in ("recovery_closure", "closure"):
+        explicit_closure = args.get(field_name)
+        if isinstance(explicit_closure, dict):
+            return {
+                "status": "recovery_closure_ready",
+                "summary": {"closure_count": 1},
+                "closures": [explicit_closure],
+                "read_only": True,
+                "read_only_memory": True,
+                "would_mutate_memory": False,
+            }
+
+    gate_args = dict(args)
+    for field_name in (
+        "recovery_closure_gate",
+        "recovery_closure_gate_report",
+        "closure_gate",
+        "recovery_closure",
+        "closure",
+        "format",
+    ):
+        gate_args.pop(field_name, None)
+    result = memory_evidence_repair_recovery_closure_gate_tool(
+        gate_args,
+        memory_manager=memory_manager,
+    )
+    try:
+        payload = json.loads(result)
+    except json.JSONDecodeError:
+        return tool_error("recovery closure gate tool returned invalid JSON.", success=False)
+    if not isinstance(payload, dict):
+        return tool_error(
+            "recovery closure gate tool returned a non-object payload.",
+            success=False,
+        )
+    if payload.get("success") is False:
+        return json.dumps(payload, ensure_ascii=False)
+    return payload
+
+
+def _render_markdown(payload: dict[str, Any]) -> str:
+    summary = payload.get("summary", {})
+    lines = [
+        "### Memory Evidence Repair Recovery Closure Ledger Preview",
+        f"- Status: {payload.get('status')}",
+        f"- Checks: {summary.get('check_count', 0)}",
+        f"- Entries: {summary.get('entry_count', 0)}",
+        f"- Milestones: {summary.get('milestone_count', 0)}",
+        f"- Ready: {summary.get('recovery_closure_ledger_ready', False)}",
+    ]
+    for entry in payload.get("entries", []):
+        lines.append(f"- Ledger entry: {entry.get('id')}")
+        lines.append(f"  Closure: {entry.get('closure_id')}")
+        lines.append(f"  Audit: {entry.get('audit_preview_id')}")
+    for reason in payload.get("blocking_reasons", []):
+        lines.append(f"- Blocked: {reason}")
+    for action in payload.get("required_actions", []):
+        lines.append(f"- Required: {action}")
+    return "\n".join(lines)
+
+
+def check_memory_evidence_repair_recovery_closure_ledger_preview_requirements() -> bool:
+    return True
+
+
+registry.register(
+    name="memory_evidence_repair_recovery_closure_ledger_preview",
+    toolset="memory",
+    schema=MEMORY_EVIDENCE_REPAIR_RECOVERY_CLOSURE_LEDGER_PREVIEW_SCHEMA,
+    handler=memory_evidence_repair_recovery_closure_ledger_preview_tool,
+    check_fn=check_memory_evidence_repair_recovery_closure_ledger_preview_requirements,
+    emoji="🧠",
+)

--- a/tools/memory_evidence_repair_recovery_completion_audit_preview_tool.py
+++ b/tools/memory_evidence_repair_recovery_completion_audit_preview_tool.py
@@ -1,0 +1,327 @@
+"""Read-only Memory Evidence Repair Recovery Completion Audit Preview tool."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from agent.memory_evidence_repair_recovery_completion_audit_preview import (
+    build_evidence_repair_recovery_completion_audit_preview,
+)
+from tools.memory_evidence_repair_recovery_completion_receipt_tool import (
+    MEMORY_EVIDENCE_REPAIR_RECOVERY_COMPLETION_RECEIPT_SCHEMA,
+    memory_evidence_repair_recovery_completion_receipt_tool,
+)
+from tools.registry import registry, tool_error
+
+
+_UPSTREAM_PROPERTIES = dict(
+    MEMORY_EVIDENCE_REPAIR_RECOVERY_COMPLETION_RECEIPT_SCHEMA["parameters"]["properties"]
+)
+_UPSTREAM_PROPERTIES.pop("format", None)
+
+MEMORY_EVIDENCE_REPAIR_RECOVERY_COMPLETION_AUDIT_PREVIEW_SCHEMA = {
+    "name": "memory_evidence_repair_recovery_completion_audit_preview",
+    "description": (
+        "Read-only recovery completion audit preview for future memory evidence "
+        "repair manual recoveries. It never mutates durable memory."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "recovery_completion_receipt": {
+                "type": "object",
+                "description": "Optional recovery completion receipt report payload.",
+                "additionalProperties": True,
+            },
+            "recovery_completion_receipt_report": {
+                "type": "object",
+                "description": "Alias for recovery_completion_receipt.",
+                "additionalProperties": True,
+            },
+            "completion_receipt": {
+                "type": "object",
+                "description": "Alias for recovery_completion_receipt.",
+                "additionalProperties": True,
+            },
+            "observed_recovery_steps": {
+                "type": "object",
+                "description": "Optional observed recovery step signals keyed by recovery step id.",
+                "additionalProperties": True,
+            },
+            "recorded_receipts": {
+                "description": "Optional recorded recovery completion receipt report or receipt list.",
+                "oneOf": [
+                    {"type": "object", "additionalProperties": True},
+                    {
+                        "type": "array",
+                        "items": {"type": "object", "additionalProperties": True},
+                    },
+                ],
+            },
+            "released_lock_ids": {
+                "type": "array",
+                "description": "Optional recovery write-lock ids observed as released.",
+                "items": {"type": "string"},
+            },
+            "post_recovery_audit_status": {
+                "type": "object",
+                "description": "Optional observed post-recovery audit status.",
+                "additionalProperties": True,
+            },
+            "contamination_status": {
+                "type": "object",
+                "description": "Optional observed secondary-memory-contamination status.",
+                "additionalProperties": True,
+            },
+            "format": {
+                "type": "string",
+                "enum": ["json", "markdown"],
+                "description": "Optional response format helper. JSON is always returned; markdown adds a readable summary field.",
+            },
+            **_UPSTREAM_PROPERTIES,
+        },
+    },
+}
+
+
+def memory_evidence_repair_recovery_completion_audit_preview_tool(
+    args: dict[str, Any],
+    **kwargs,
+) -> str:
+    if not isinstance(args, dict):
+        return tool_error("args must be an object.", success=False)
+
+    validated = _validate_args(args)
+    if validated is not None:
+        return validated
+
+    recovery_completion_receipt = _resolve_recovery_completion_receipt(
+        args,
+        kwargs.get("memory_manager"),
+    )
+    if isinstance(recovery_completion_receipt, str):
+        return recovery_completion_receipt
+
+    payload = build_evidence_repair_recovery_completion_audit_preview(
+        recovery_completion_receipt=recovery_completion_receipt,
+        observed_recovery_steps=(
+            args.get("observed_recovery_steps")
+            if isinstance(args.get("observed_recovery_steps"), dict)
+            else None
+        ),
+        recorded_receipts=_recorded_receipts(args),
+        used_token_ids=(
+            args.get("used_token_ids")
+            if isinstance(args.get("used_token_ids"), list)
+            else None
+        ),
+        released_lock_ids=(
+            args.get("released_lock_ids")
+            if isinstance(args.get("released_lock_ids"), list)
+            else None
+        ),
+        post_recovery_audit_status=(
+            args.get("post_recovery_audit_status")
+            if isinstance(args.get("post_recovery_audit_status"), dict)
+            else None
+        ),
+        contamination_status=(
+            args.get("contamination_status")
+            if isinstance(args.get("contamination_status"), dict)
+            else None
+        ),
+    ).to_dict()
+    payload["success"] = True
+    payload["read_only"] = True
+    payload["read_only_memory"] = True
+    payload["would_mutate_memory"] = False
+    if str(args.get("format", "")).lower() == "markdown":
+        payload["markdown"] = _render_markdown(payload)
+    return json.dumps(payload, ensure_ascii=False)
+
+
+def _validate_args(args: dict[str, Any]) -> str | None:
+    object_fields = (
+        "recovery_completion_receipt",
+        "recovery_completion_receipt_report",
+        "completion_receipt",
+        "observed_recovery_steps",
+        "post_recovery_audit_status",
+        "contamination_status",
+        "recovery_executor_preview",
+        "recovery_executor_preview_report",
+        "recovery_executor",
+        "recovery_write_lock_gate",
+        "recovery_executor_lock_gate",
+        "recovery_write_lock",
+        "recovery_token_gate",
+        "recovery_approval_token_gate",
+        "token_gate",
+        "recovery_approval_token",
+        "recovery_human_approval_token",
+        "recovery_token",
+        "token",
+        "recovery_execution",
+        "recovery_execution_preview",
+        "recovery_execution_report",
+        "recovery_decision",
+        "recovery_decision_gate",
+        "recovery_decision_report",
+        "rollback_drill",
+        "rollback_drill_preview",
+        "rollback_drill_report",
+        "post_commit_audit",
+        "post_commit_audit_preview",
+        "post_commit_audit_report",
+        "executor_preview",
+        "executor",
+        "observed_memory_patches",
+        "rollback_status",
+        "write_lock_gate",
+        "executor_lock_gate",
+        "write_lock",
+        "commit_receipt",
+        "receipt",
+        "approval_token_gate",
+        "approval_token",
+        "dry_run",
+        "snapshot_plan",
+        "rollback_plan",
+        "existing_snapshots",
+        "pre_commit_snapshots",
+        "ledger",
+        "commit_gate",
+        "preview",
+        "approval",
+        "plan",
+        "gate",
+        "audit",
+        "diagnostics",
+        "policy",
+        "proposed_evidence",
+    )
+    array_fields = (
+        "active_locks",
+        "locks",
+        "already_used_token_ids",
+        "tokens",
+        "used_token_ids",
+        "released_lock_ids",
+        "receipts",
+        "requests",
+        "steps",
+        "entries",
+        "decisions",
+        "previews",
+        "confirmed_preview_ids",
+        "candidates",
+        "approved_candidate_ids",
+        "repairs",
+    )
+    for field_name in object_fields:
+        value = args.get(field_name)
+        if value is not None and not isinstance(value, dict):
+            return tool_error(f"{field_name} must be an object when provided.", success=False)
+    for field_name in ("existing_receipts", "recorded_receipts"):
+        value = args.get(field_name)
+        if value is not None and not isinstance(value, (dict, list)):
+            return tool_error(
+                f"{field_name} must be an object or array when provided.",
+                success=False,
+            )
+    for field_name in array_fields:
+        value = args.get(field_name)
+        if value is not None and not isinstance(value, list):
+            return tool_error(f"{field_name} must be an array when provided.", success=False)
+    return None
+
+
+def _resolve_recovery_completion_receipt(
+    args: dict[str, Any],
+    memory_manager: Any,
+) -> dict[str, Any] | str:
+    for field_name in (
+        "recovery_completion_receipt",
+        "recovery_completion_receipt_report",
+        "completion_receipt",
+    ):
+        explicit = args.get(field_name)
+        if isinstance(explicit, dict):
+            return explicit
+
+    receipt_args = dict(args)
+    for field_name in (
+        "recovery_completion_receipt",
+        "recovery_completion_receipt_report",
+        "completion_receipt",
+        "observed_recovery_steps",
+        "recorded_receipts",
+        "used_token_ids",
+        "released_lock_ids",
+        "post_recovery_audit_status",
+        "contamination_status",
+        "format",
+    ):
+        receipt_args.pop(field_name, None)
+    result = memory_evidence_repair_recovery_completion_receipt_tool(
+        receipt_args,
+        memory_manager=memory_manager,
+    )
+    try:
+        payload = json.loads(result)
+    except json.JSONDecodeError:
+        return tool_error(
+            "recovery completion receipt tool returned invalid JSON.",
+            success=False,
+        )
+    if not isinstance(payload, dict):
+        return tool_error(
+            "recovery completion receipt tool returned a non-object payload.",
+            success=False,
+        )
+    if payload.get("success") is False:
+        return json.dumps(payload, ensure_ascii=False)
+    return payload
+
+
+def _recorded_receipts(args: dict[str, Any]) -> dict[str, Any] | list[dict[str, Any]] | None:
+    explicit = args.get("recorded_receipts")
+    if isinstance(explicit, (dict, list)):
+        return explicit
+    return None
+
+
+def _render_markdown(payload: dict[str, Any]) -> str:
+    summary = payload.get("summary", {})
+    lines = [
+        "### Memory Evidence Repair Recovery Completion Audit Preview",
+        f"- Status: {payload.get('status')}",
+        f"- Previews: {summary.get('preview_count', 0)}",
+        f"- Audit steps: {summary.get('audit_step_count', 0)}",
+        f"- Planned: {summary.get('planned_audit_step_count', 0)}",
+        f"- Observed pass: {summary.get('observed_pass_step_count', 0)}",
+        f"- Observed fail: {summary.get('observed_fail_step_count', 0)}",
+    ]
+    for preview in payload.get("previews", []):
+        lines.append(f"- Audit: {preview.get('id')}")
+        lines.append(f"  Receipt: {preview.get('receipt_id')}")
+    for reason in payload.get("blocking_reasons", []):
+        lines.append(f"- Blocked: {reason}")
+    for action in payload.get("required_actions", []):
+        lines.append(f"- Required: {action}")
+    return "\n".join(lines)
+
+
+def check_memory_evidence_repair_recovery_completion_audit_preview_requirements() -> bool:
+    return True
+
+
+registry.register(
+    name="memory_evidence_repair_recovery_completion_audit_preview",
+    toolset="memory",
+    schema=MEMORY_EVIDENCE_REPAIR_RECOVERY_COMPLETION_AUDIT_PREVIEW_SCHEMA,
+    handler=memory_evidence_repair_recovery_completion_audit_preview_tool,
+    check_fn=check_memory_evidence_repair_recovery_completion_audit_preview_requirements,
+    emoji="🧠",
+)

--- a/tools/memory_evidence_repair_recovery_completion_receipt_tool.py
+++ b/tools/memory_evidence_repair_recovery_completion_receipt_tool.py
@@ -1,0 +1,314 @@
+"""Read-only Memory Evidence Repair Recovery Completion Receipt tool."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from agent.memory_evidence_repair_recovery_completion_receipt import (
+    build_evidence_repair_recovery_completion_receipt,
+)
+from tools.memory_evidence_repair_recovery_executor_preview_tool import (
+    MEMORY_EVIDENCE_REPAIR_RECOVERY_EXECUTOR_PREVIEW_SCHEMA,
+    memory_evidence_repair_recovery_executor_preview_tool,
+)
+from tools.registry import registry, tool_error
+
+
+_UPSTREAM_PROPERTIES = dict(
+    MEMORY_EVIDENCE_REPAIR_RECOVERY_EXECUTOR_PREVIEW_SCHEMA["parameters"]["properties"]
+)
+_UPSTREAM_PROPERTIES.pop("format", None)
+
+MEMORY_EVIDENCE_REPAIR_RECOVERY_COMPLETION_RECEIPT_SCHEMA = {
+    "name": "memory_evidence_repair_recovery_completion_receipt",
+    "description": (
+        "Read-only completion receipt draft and token/lock ledger view for a "
+        "future memory evidence repair manual recovery. It never mutates durable memory."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "recovery_executor_preview": {
+                "type": "object",
+                "description": "Optional recovery executor preview report payload.",
+                "additionalProperties": True,
+            },
+            "recovery_executor_preview_report": {
+                "type": "object",
+                "description": "Alias for recovery_executor_preview.",
+                "additionalProperties": True,
+            },
+            "recovery_executor": {
+                "type": "object",
+                "description": "Alias for recovery_executor_preview.",
+                "additionalProperties": True,
+            },
+            "existing_receipts": {
+                "description": "Optional existing recovery completion receipt report or receipt list.",
+                "oneOf": [
+                    {"type": "object", "additionalProperties": True},
+                    {
+                        "type": "array",
+                        "items": {"type": "object", "additionalProperties": True},
+                    },
+                ],
+            },
+            "receipts": {
+                "type": "array",
+                "description": "Optional existing recovery completion receipt list.",
+                "items": {"type": "object", "additionalProperties": True},
+            },
+            "used_token_ids": {
+                "type": "array",
+                "description": "Optional used recovery approval token ids.",
+                "items": {"type": "string"},
+            },
+            "released_lock_ids": {
+                "type": "array",
+                "description": "Optional released recovery write-lock ids.",
+                "items": {"type": "string"},
+            },
+            "actor": {
+                "type": "string",
+                "description": "Human actor label for the future recovery completion receipt.",
+            },
+            "recovery_reason": {
+                "type": "string",
+                "description": "Reason for the future manual recovery completion.",
+            },
+            "format": {
+                "type": "string",
+                "enum": ["json", "markdown"],
+                "description": "Optional response format helper. JSON is always returned; markdown adds a readable summary field.",
+            },
+            **_UPSTREAM_PROPERTIES,
+        },
+    },
+}
+
+
+def memory_evidence_repair_recovery_completion_receipt_tool(
+    args: dict[str, Any],
+    **kwargs,
+) -> str:
+    if not isinstance(args, dict):
+        return tool_error("args must be an object.", success=False)
+
+    validated = _validate_args(args)
+    if validated is not None:
+        return validated
+
+    recovery_executor_preview = _resolve_recovery_executor_preview(
+        args,
+        kwargs.get("memory_manager"),
+    )
+    if isinstance(recovery_executor_preview, str):
+        return recovery_executor_preview
+
+    payload = build_evidence_repair_recovery_completion_receipt(
+        recovery_executor_preview=recovery_executor_preview,
+        existing_receipts=_existing_receipts(args),
+        used_token_ids=(
+            args.get("used_token_ids")
+            if isinstance(args.get("used_token_ids"), list)
+            else None
+        ),
+        released_lock_ids=(
+            args.get("released_lock_ids")
+            if isinstance(args.get("released_lock_ids"), list)
+            else None
+        ),
+        actor=str(args.get("actor") or "human"),
+        recovery_reason=str(args.get("recovery_reason") or ""),
+    ).to_dict()
+    payload["success"] = True
+    payload["read_only"] = True
+    payload["read_only_memory"] = True
+    payload["would_mutate_memory"] = False
+    if str(args.get("format", "")).lower() == "markdown":
+        payload["markdown"] = _render_markdown(payload)
+    return json.dumps(payload, ensure_ascii=False)
+
+
+def _validate_args(args: dict[str, Any]) -> str | None:
+    object_fields = (
+        "recovery_executor_preview",
+        "recovery_executor_preview_report",
+        "recovery_executor",
+        "recovery_write_lock_gate",
+        "recovery_executor_lock_gate",
+        "recovery_write_lock",
+        "recovery_token_gate",
+        "recovery_approval_token_gate",
+        "token_gate",
+        "recovery_approval_token",
+        "recovery_human_approval_token",
+        "recovery_token",
+        "token",
+        "recovery_execution",
+        "recovery_execution_preview",
+        "recovery_execution_report",
+        "recovery_decision",
+        "recovery_decision_gate",
+        "recovery_decision_report",
+        "rollback_drill",
+        "rollback_drill_preview",
+        "rollback_drill_report",
+        "post_commit_audit",
+        "post_commit_audit_preview",
+        "post_commit_audit_report",
+        "executor_preview",
+        "executor",
+        "observed_memory_patches",
+        "rollback_status",
+        "write_lock_gate",
+        "executor_lock_gate",
+        "write_lock",
+        "commit_receipt",
+        "receipt",
+        "approval_token_gate",
+        "approval_token",
+        "dry_run",
+        "snapshot_plan",
+        "rollback_plan",
+        "existing_snapshots",
+        "pre_commit_snapshots",
+        "ledger",
+        "commit_gate",
+        "preview",
+        "approval",
+        "plan",
+        "gate",
+        "audit",
+        "diagnostics",
+        "policy",
+        "proposed_evidence",
+    )
+    array_fields = (
+        "active_locks",
+        "locks",
+        "already_used_token_ids",
+        "tokens",
+        "used_token_ids",
+        "released_lock_ids",
+        "receipts",
+        "requests",
+        "steps",
+        "entries",
+        "decisions",
+        "previews",
+        "confirmed_preview_ids",
+        "candidates",
+        "approved_candidate_ids",
+        "repairs",
+    )
+    for field_name in object_fields:
+        value = args.get(field_name)
+        if value is not None and not isinstance(value, dict):
+            return tool_error(f"{field_name} must be an object when provided.", success=False)
+    for field_name in ("existing_receipts", "recorded_receipts"):
+        value = args.get(field_name)
+        if value is not None and not isinstance(value, (dict, list)):
+            return tool_error(
+                f"{field_name} must be an object or array when provided.",
+                success=False,
+            )
+    for field_name in array_fields:
+        value = args.get(field_name)
+        if value is not None and not isinstance(value, list):
+            return tool_error(f"{field_name} must be an array when provided.", success=False)
+    return None
+
+
+def _resolve_recovery_executor_preview(
+    args: dict[str, Any],
+    memory_manager: Any,
+) -> dict[str, Any] | str:
+    for field_name in (
+        "recovery_executor_preview",
+        "recovery_executor_preview_report",
+        "recovery_executor",
+    ):
+        explicit = args.get(field_name)
+        if isinstance(explicit, dict):
+            return explicit
+
+    executor_args = dict(args)
+    for field_name in (
+        "recovery_executor_preview",
+        "recovery_executor_preview_report",
+        "recovery_executor",
+        "existing_receipts",
+        "receipts",
+        "used_token_ids",
+        "released_lock_ids",
+        "actor",
+        "recovery_reason",
+        "format",
+    ):
+        executor_args.pop(field_name, None)
+    result = memory_evidence_repair_recovery_executor_preview_tool(
+        executor_args,
+        memory_manager=memory_manager,
+    )
+    try:
+        payload = json.loads(result)
+    except json.JSONDecodeError:
+        return tool_error(
+            "recovery executor preview tool returned invalid JSON.",
+            success=False,
+        )
+    if not isinstance(payload, dict):
+        return tool_error(
+            "recovery executor preview tool returned a non-object payload.",
+            success=False,
+        )
+    if payload.get("success") is False:
+        return json.dumps(payload, ensure_ascii=False)
+    return payload
+
+
+def _existing_receipts(args: dict[str, Any]) -> dict[str, Any] | list[dict[str, Any]] | None:
+    explicit = args.get("existing_receipts")
+    if isinstance(explicit, (dict, list)):
+        return explicit
+    receipts = args.get("receipts")
+    if isinstance(receipts, list):
+        return receipts
+    return None
+
+
+def _render_markdown(payload: dict[str, Any]) -> str:
+    summary = payload.get("summary", {})
+    lines = [
+        "### Memory Evidence Repair Recovery Completion Receipt",
+        f"- Status: {payload.get('status')}",
+        f"- Receipts: {summary.get('receipt_count', 0)}",
+        f"- Used recovery tokens: {summary.get('used_recovery_token_count', 0)}",
+        f"- Released recovery locks: {summary.get('released_recovery_lock_count', 0)}",
+        f"- Blocks: {summary.get('blocking_reason_count', 0)}",
+    ]
+    for receipt in payload.get("receipts", []):
+        lines.append(f"- Receipt: {receipt.get('id')}")
+        lines.append(f"  Token: {receipt.get('token_id')}")
+        lines.append(f"  Lock: {receipt.get('lock_id')}")
+    for reason in payload.get("blocking_reasons", []):
+        lines.append(f"- Blocked: {reason}")
+    for action in payload.get("required_actions", []):
+        lines.append(f"- Required: {action}")
+    return "\n".join(lines)
+
+
+def check_memory_evidence_repair_recovery_completion_receipt_requirements() -> bool:
+    return True
+
+
+registry.register(
+    name="memory_evidence_repair_recovery_completion_receipt",
+    toolset="memory",
+    schema=MEMORY_EVIDENCE_REPAIR_RECOVERY_COMPLETION_RECEIPT_SCHEMA,
+    handler=memory_evidence_repair_recovery_completion_receipt_tool,
+    check_fn=check_memory_evidence_repair_recovery_completion_receipt_requirements,
+    emoji="🧠",
+)

--- a/tools/memory_evidence_repair_recovery_decision_gate_tool.py
+++ b/tools/memory_evidence_repair_recovery_decision_gate_tool.py
@@ -1,0 +1,230 @@
+"""Read-only Memory Evidence Repair Recovery Decision Gate tool."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from agent.memory_evidence_repair_recovery_decision_gate import (
+    build_evidence_repair_recovery_decision_gate,
+)
+from tools.memory_evidence_repair_rollback_drill_preview_tool import (
+    MEMORY_EVIDENCE_REPAIR_ROLLBACK_DRILL_PREVIEW_SCHEMA,
+    memory_evidence_repair_rollback_drill_preview_tool,
+)
+from tools.registry import registry, tool_error
+
+
+_UPSTREAM_PROPERTIES = dict(
+    MEMORY_EVIDENCE_REPAIR_ROLLBACK_DRILL_PREVIEW_SCHEMA["parameters"]["properties"]
+)
+_UPSTREAM_PROPERTIES.pop("format", None)
+
+MEMORY_EVIDENCE_REPAIR_RECOVERY_DECISION_GATE_SCHEMA = {
+    "name": "memory_evidence_repair_recovery_decision_gate",
+    "description": (
+        "Read-only recovery decision gate for memory evidence repair rollback "
+        "drills. It chooses the next recovery route without mutating durable "
+        "memory."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "rollback_drill": {
+                "type": "object",
+                "description": "Optional rollback drill preview report payload.",
+                "additionalProperties": True,
+            },
+            "rollback_drill_preview": {
+                "type": "object",
+                "description": "Alias for rollback_drill.",
+                "additionalProperties": True,
+            },
+            "rollback_drill_report": {
+                "type": "object",
+                "description": "Alias for rollback_drill.",
+                "additionalProperties": True,
+            },
+            "format": {
+                "type": "string",
+                "enum": ["json", "markdown"],
+                "description": "Optional response format helper. JSON is always returned; markdown adds a readable summary field.",
+            },
+            **_UPSTREAM_PROPERTIES,
+        },
+    },
+}
+
+
+def memory_evidence_repair_recovery_decision_gate_tool(
+    args: dict[str, Any],
+    **kwargs,
+) -> str:
+    if not isinstance(args, dict):
+        return tool_error("args must be an object.", success=False)
+
+    validated = _validate_args(args)
+    if validated is not None:
+        return validated
+
+    rollback_drill = _resolve_rollback_drill(args, kwargs.get("memory_manager"))
+    if isinstance(rollback_drill, str):
+        return rollback_drill
+
+    payload = build_evidence_repair_recovery_decision_gate(
+        rollback_drill=rollback_drill,
+    ).to_dict()
+    payload["success"] = True
+    payload["read_only"] = True
+    payload["read_only_memory"] = True
+    payload["would_mutate_memory"] = False
+    if str(args.get("format", "")).lower() == "markdown":
+        payload["markdown"] = _render_markdown(payload)
+    return json.dumps(payload, ensure_ascii=False)
+
+
+def _validate_args(args: dict[str, Any]) -> str | None:
+    object_fields = (
+        "rollback_drill",
+        "rollback_drill_preview",
+        "rollback_drill_report",
+        "post_commit_audit",
+        "post_commit_audit_preview",
+        "post_commit_audit_report",
+        "executor_preview",
+        "executor",
+        "observed_memory_patches",
+        "rollback_status",
+        "write_lock_gate",
+        "executor_lock_gate",
+        "write_lock",
+        "commit_receipt",
+        "receipt",
+        "token_gate",
+        "approval_token_gate",
+        "approval_token",
+        "token",
+        "dry_run",
+        "snapshot_plan",
+        "rollback_plan",
+        "existing_snapshots",
+        "pre_commit_snapshots",
+        "ledger",
+        "commit_gate",
+        "preview",
+        "approval",
+        "plan",
+        "gate",
+        "audit",
+        "diagnostics",
+        "policy",
+        "proposed_evidence",
+    )
+    array_fields = (
+        "released_lock_ids",
+        "active_locks",
+        "locks",
+        "already_used_token_ids",
+        "tokens",
+        "used_token_ids",
+        "receipts",
+        "requests",
+        "steps",
+        "entries",
+        "decisions",
+        "previews",
+        "confirmed_preview_ids",
+        "candidates",
+        "approved_candidate_ids",
+        "repairs",
+    )
+    for field_name in object_fields:
+        value = args.get(field_name)
+        if value is not None and not isinstance(value, dict):
+            return tool_error(f"{field_name} must be an object when provided.", success=False)
+    for field_name in ("existing_receipts", "recorded_receipts"):
+        value = args.get(field_name)
+        if value is not None and not isinstance(value, (dict, list)):
+            return tool_error(
+                f"{field_name} must be an object or array when provided.",
+                success=False,
+            )
+    for field_name in array_fields:
+        value = args.get(field_name)
+        if value is not None and not isinstance(value, list):
+            return tool_error(f"{field_name} must be an array when provided.", success=False)
+    return None
+
+
+def _resolve_rollback_drill(
+    args: dict[str, Any],
+    memory_manager: Any,
+) -> dict[str, Any] | str:
+    for field_name in (
+        "rollback_drill",
+        "rollback_drill_preview",
+        "rollback_drill_report",
+    ):
+        explicit = args.get(field_name)
+        if isinstance(explicit, dict):
+            return explicit
+
+    drill_args = dict(args)
+    for field_name in (
+        "rollback_drill",
+        "rollback_drill_preview",
+        "rollback_drill_report",
+        "format",
+    ):
+        drill_args.pop(field_name, None)
+    result = memory_evidence_repair_rollback_drill_preview_tool(
+        drill_args,
+        memory_manager=memory_manager,
+    )
+    try:
+        payload = json.loads(result)
+    except json.JSONDecodeError:
+        return tool_error("rollback drill preview tool returned invalid JSON.", success=False)
+    if not isinstance(payload, dict):
+        return tool_error(
+            "rollback drill preview tool returned a non-object payload.",
+            success=False,
+        )
+    if payload.get("success") is False:
+        return json.dumps(payload, ensure_ascii=False)
+    return payload
+
+
+def _render_markdown(payload: dict[str, Any]) -> str:
+    summary = payload.get("summary", {})
+    lines = [
+        "### Memory Evidence Repair Recovery Decision Gate",
+        f"- Status: {payload.get('status')}",
+        f"- Decisions: {summary.get('decision_count', 0)}",
+        f"- Manual rollback: {summary.get('manual_rollback_required_count', 0)}",
+        f"- Isolation review: {summary.get('isolate_and_review_count', 0)}",
+        f"- Preparedness review: {summary.get('preparedness_review_count', 0)}",
+    ]
+    for decision in payload.get("decisions", []):
+        lines.append(f"- Decision: {decision.get('id')}")
+        lines.append(f"  Route: {decision.get('route')}")
+        lines.append(f"  Priority: {decision.get('priority')}")
+    for reason in payload.get("blocking_reasons", []):
+        lines.append(f"- Blocked: {reason}")
+    for action in payload.get("required_actions", []):
+        lines.append(f"- Required: {action}")
+    return "\n".join(lines)
+
+
+def check_memory_evidence_repair_recovery_decision_gate_requirements() -> bool:
+    return True
+
+
+registry.register(
+    name="memory_evidence_repair_recovery_decision_gate",
+    toolset="memory",
+    schema=MEMORY_EVIDENCE_REPAIR_RECOVERY_DECISION_GATE_SCHEMA,
+    handler=memory_evidence_repair_recovery_decision_gate_tool,
+    check_fn=check_memory_evidence_repair_recovery_decision_gate_requirements,
+    emoji="🧠",
+)

--- a/tools/memory_evidence_repair_recovery_execution_preview_tool.py
+++ b/tools/memory_evidence_repair_recovery_execution_preview_tool.py
@@ -1,0 +1,232 @@
+"""Read-only Memory Evidence Repair Recovery Execution Preview tool."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from agent.memory_evidence_repair_recovery_execution_preview import (
+    build_evidence_repair_recovery_execution_preview,
+)
+from tools.memory_evidence_repair_recovery_decision_gate_tool import (
+    MEMORY_EVIDENCE_REPAIR_RECOVERY_DECISION_GATE_SCHEMA,
+    memory_evidence_repair_recovery_decision_gate_tool,
+)
+from tools.registry import registry, tool_error
+
+
+_UPSTREAM_PROPERTIES = dict(
+    MEMORY_EVIDENCE_REPAIR_RECOVERY_DECISION_GATE_SCHEMA["parameters"]["properties"]
+)
+_UPSTREAM_PROPERTIES.pop("format", None)
+
+MEMORY_EVIDENCE_REPAIR_RECOVERY_EXECUTION_PREVIEW_SCHEMA = {
+    "name": "memory_evidence_repair_recovery_execution_preview",
+    "description": (
+        "Read-only recovery execution preview for memory evidence repair. "
+        "It orders future manual recovery actions without mutating durable memory."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "recovery_decision": {
+                "type": "object",
+                "description": "Optional recovery decision gate report payload.",
+                "additionalProperties": True,
+            },
+            "recovery_decision_gate": {
+                "type": "object",
+                "description": "Alias for recovery_decision.",
+                "additionalProperties": True,
+            },
+            "recovery_decision_report": {
+                "type": "object",
+                "description": "Alias for recovery_decision.",
+                "additionalProperties": True,
+            },
+            "format": {
+                "type": "string",
+                "enum": ["json", "markdown"],
+                "description": "Optional response format helper. JSON is always returned; markdown adds a readable summary field.",
+            },
+            **_UPSTREAM_PROPERTIES,
+        },
+    },
+}
+
+
+def memory_evidence_repair_recovery_execution_preview_tool(
+    args: dict[str, Any],
+    **kwargs,
+) -> str:
+    if not isinstance(args, dict):
+        return tool_error("args must be an object.", success=False)
+
+    validated = _validate_args(args)
+    if validated is not None:
+        return validated
+
+    recovery_decision = _resolve_recovery_decision(args, kwargs.get("memory_manager"))
+    if isinstance(recovery_decision, str):
+        return recovery_decision
+
+    payload = build_evidence_repair_recovery_execution_preview(
+        recovery_decision=recovery_decision,
+    ).to_dict()
+    payload["success"] = True
+    payload["read_only"] = True
+    payload["read_only_memory"] = True
+    payload["would_mutate_memory"] = False
+    if str(args.get("format", "")).lower() == "markdown":
+        payload["markdown"] = _render_markdown(payload)
+    return json.dumps(payload, ensure_ascii=False)
+
+
+def _validate_args(args: dict[str, Any]) -> str | None:
+    object_fields = (
+        "recovery_decision",
+        "recovery_decision_gate",
+        "recovery_decision_report",
+        "rollback_drill",
+        "rollback_drill_preview",
+        "rollback_drill_report",
+        "post_commit_audit",
+        "post_commit_audit_preview",
+        "post_commit_audit_report",
+        "executor_preview",
+        "executor",
+        "observed_memory_patches",
+        "rollback_status",
+        "write_lock_gate",
+        "executor_lock_gate",
+        "write_lock",
+        "commit_receipt",
+        "receipt",
+        "token_gate",
+        "approval_token_gate",
+        "approval_token",
+        "token",
+        "dry_run",
+        "snapshot_plan",
+        "rollback_plan",
+        "existing_snapshots",
+        "pre_commit_snapshots",
+        "ledger",
+        "commit_gate",
+        "preview",
+        "approval",
+        "plan",
+        "gate",
+        "audit",
+        "diagnostics",
+        "policy",
+        "proposed_evidence",
+    )
+    array_fields = (
+        "released_lock_ids",
+        "active_locks",
+        "locks",
+        "already_used_token_ids",
+        "tokens",
+        "used_token_ids",
+        "receipts",
+        "requests",
+        "steps",
+        "entries",
+        "decisions",
+        "previews",
+        "confirmed_preview_ids",
+        "candidates",
+        "approved_candidate_ids",
+        "repairs",
+    )
+    for field_name in object_fields:
+        value = args.get(field_name)
+        if value is not None and not isinstance(value, dict):
+            return tool_error(f"{field_name} must be an object when provided.", success=False)
+    for field_name in ("existing_receipts", "recorded_receipts"):
+        value = args.get(field_name)
+        if value is not None and not isinstance(value, (dict, list)):
+            return tool_error(
+                f"{field_name} must be an object or array when provided.",
+                success=False,
+            )
+    for field_name in array_fields:
+        value = args.get(field_name)
+        if value is not None and not isinstance(value, list):
+            return tool_error(f"{field_name} must be an array when provided.", success=False)
+    return None
+
+
+def _resolve_recovery_decision(
+    args: dict[str, Any],
+    memory_manager: Any,
+) -> dict[str, Any] | str:
+    for field_name in (
+        "recovery_decision",
+        "recovery_decision_gate",
+        "recovery_decision_report",
+    ):
+        explicit = args.get(field_name)
+        if isinstance(explicit, dict):
+            return explicit
+
+    decision_args = dict(args)
+    for field_name in (
+        "recovery_decision",
+        "recovery_decision_gate",
+        "recovery_decision_report",
+        "format",
+    ):
+        decision_args.pop(field_name, None)
+    result = memory_evidence_repair_recovery_decision_gate_tool(
+        decision_args,
+        memory_manager=memory_manager,
+    )
+    try:
+        payload = json.loads(result)
+    except json.JSONDecodeError:
+        return tool_error("recovery decision gate tool returned invalid JSON.", success=False)
+    if not isinstance(payload, dict):
+        return tool_error(
+            "recovery decision gate tool returned a non-object payload.",
+            success=False,
+        )
+    if payload.get("success") is False:
+        return json.dumps(payload, ensure_ascii=False)
+    return payload
+
+
+def _render_markdown(payload: dict[str, Any]) -> str:
+    summary = payload.get("summary", {})
+    lines = [
+        "### Memory Evidence Repair Recovery Execution Preview",
+        f"- Status: {payload.get('status')}",
+        f"- Previews: {summary.get('preview_count', 0)}",
+        f"- Execution steps: {summary.get('execution_step_count', 0)}",
+        f"- Future mutation steps: {summary.get('future_mutation_step_count', 0)}",
+        f"- Manual rollback previews: {summary.get('manual_rollback_preview_count', 0)}",
+    ]
+    for preview in payload.get("previews", []):
+        lines.append(f"- Preview: {preview.get('id')}")
+        lines.append(f"  Route: {preview.get('route')}")
+        lines.append(f"  Decision: {preview.get('decision_id')}")
+    for reason in payload.get("blocking_reasons", []):
+        lines.append(f"- Blocked: {reason}")
+    for action in payload.get("required_actions", []):
+        lines.append(f"- Required: {action}")
+    return "\n".join(lines)
+
+
+def check_memory_evidence_repair_recovery_execution_preview_requirements() -> bool:
+    return True
+
+
+registry.register(
+    name="memory_evidence_repair_recovery_execution_preview",
+    toolset="memory",
+    schema=MEMORY_EVIDENCE_REPAIR_RECOVERY_EXECUTION_PREVIEW_SCHEMA,
+    handler=memory_evidence_repair_recovery_execution_preview_tool,
+    check_fn=check_memory_evidence_repair_recovery_execution_preview_requirements,
+    emoji="🧠",
+)

--- a/tools/memory_evidence_repair_recovery_executor_preview_tool.py
+++ b/tools/memory_evidence_repair_recovery_executor_preview_tool.py
@@ -1,0 +1,257 @@
+"""Read-only Memory Evidence Repair Recovery Executor Preview tool."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from agent.memory_evidence_repair_recovery_executor_preview import (
+    build_evidence_repair_recovery_executor_preview,
+)
+from tools.memory_evidence_repair_recovery_write_lock_gate_tool import (
+    MEMORY_EVIDENCE_REPAIR_RECOVERY_WRITE_LOCK_GATE_SCHEMA,
+    memory_evidence_repair_recovery_write_lock_gate_tool,
+)
+from tools.registry import registry, tool_error
+
+
+_UPSTREAM_PROPERTIES = dict(
+    MEMORY_EVIDENCE_REPAIR_RECOVERY_WRITE_LOCK_GATE_SCHEMA["parameters"]["properties"]
+)
+_UPSTREAM_PROPERTIES.pop("format", None)
+
+MEMORY_EVIDENCE_REPAIR_RECOVERY_EXECUTOR_PREVIEW_SCHEMA = {
+    "name": "memory_evidence_repair_recovery_executor_preview",
+    "description": (
+        "Read-only ordered executor preview for a future memory evidence repair "
+        "manual recovery. It never mutates durable memory."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "recovery_write_lock_gate": {
+                "type": "object",
+                "description": "Optional recovery write-lock gate payload.",
+                "additionalProperties": True,
+            },
+            "recovery_executor_lock_gate": {
+                "type": "object",
+                "description": "Alias for recovery_write_lock_gate.",
+                "additionalProperties": True,
+            },
+            "recovery_write_lock": {
+                "type": "object",
+                "description": "Optional single recovery write-lock draft payload.",
+                "additionalProperties": True,
+            },
+            "format": {
+                "type": "string",
+                "enum": ["json", "markdown"],
+                "description": "Optional response format helper. JSON is always returned; markdown adds a readable summary field.",
+            },
+            **_UPSTREAM_PROPERTIES,
+        },
+    },
+}
+
+
+def memory_evidence_repair_recovery_executor_preview_tool(
+    args: dict[str, Any],
+    **kwargs,
+) -> str:
+    if not isinstance(args, dict):
+        return tool_error("args must be an object.", success=False)
+
+    validated = _validate_args(args)
+    if validated is not None:
+        return validated
+
+    recovery_write_lock_gate = _resolve_recovery_write_lock_gate(
+        args,
+        kwargs.get("memory_manager"),
+    )
+    if isinstance(recovery_write_lock_gate, str):
+        return recovery_write_lock_gate
+
+    payload = build_evidence_repair_recovery_executor_preview(
+        recovery_write_lock_gate=recovery_write_lock_gate,
+        current_time=args.get("current_time"),
+    ).to_dict()
+    payload["success"] = True
+    payload["read_only"] = True
+    payload["read_only_memory"] = True
+    payload["would_mutate_memory"] = False
+    if str(args.get("format", "")).lower() == "markdown":
+        payload["markdown"] = _render_markdown(payload)
+    return json.dumps(payload, ensure_ascii=False)
+
+
+def _validate_args(args: dict[str, Any]) -> str | None:
+    object_fields = (
+        "recovery_write_lock_gate",
+        "recovery_executor_lock_gate",
+        "recovery_write_lock",
+        "recovery_token_gate",
+        "recovery_approval_token_gate",
+        "token_gate",
+        "recovery_approval_token",
+        "recovery_human_approval_token",
+        "recovery_token",
+        "token",
+        "recovery_execution",
+        "recovery_execution_preview",
+        "recovery_execution_report",
+        "recovery_decision",
+        "recovery_decision_gate",
+        "recovery_decision_report",
+        "rollback_drill",
+        "rollback_drill_preview",
+        "rollback_drill_report",
+        "post_commit_audit",
+        "post_commit_audit_preview",
+        "post_commit_audit_report",
+        "executor_preview",
+        "executor",
+        "observed_memory_patches",
+        "rollback_status",
+        "write_lock_gate",
+        "executor_lock_gate",
+        "write_lock",
+        "commit_receipt",
+        "receipt",
+        "approval_token_gate",
+        "approval_token",
+        "dry_run",
+        "snapshot_plan",
+        "rollback_plan",
+        "existing_snapshots",
+        "pre_commit_snapshots",
+        "ledger",
+        "commit_gate",
+        "preview",
+        "approval",
+        "plan",
+        "gate",
+        "audit",
+        "diagnostics",
+        "policy",
+        "proposed_evidence",
+    )
+    array_fields = (
+        "active_locks",
+        "locks",
+        "already_used_token_ids",
+        "tokens",
+        "used_token_ids",
+        "released_lock_ids",
+        "receipts",
+        "requests",
+        "steps",
+        "entries",
+        "decisions",
+        "previews",
+        "confirmed_preview_ids",
+        "candidates",
+        "approved_candidate_ids",
+        "repairs",
+    )
+    for field_name in object_fields:
+        value = args.get(field_name)
+        if value is not None and not isinstance(value, dict):
+            return tool_error(f"{field_name} must be an object when provided.", success=False)
+    for field_name in ("existing_receipts", "recorded_receipts"):
+        value = args.get(field_name)
+        if value is not None and not isinstance(value, (dict, list)):
+            return tool_error(
+                f"{field_name} must be an object or array when provided.",
+                success=False,
+            )
+    for field_name in array_fields:
+        value = args.get(field_name)
+        if value is not None and not isinstance(value, list):
+            return tool_error(f"{field_name} must be an array when provided.", success=False)
+    return None
+
+
+def _resolve_recovery_write_lock_gate(
+    args: dict[str, Any],
+    memory_manager: Any,
+) -> dict[str, Any] | str:
+    for field_name in (
+        "recovery_write_lock_gate",
+        "recovery_executor_lock_gate",
+    ):
+        explicit_gate = args.get(field_name)
+        if isinstance(explicit_gate, dict):
+            return explicit_gate
+
+    explicit_lock = args.get("recovery_write_lock")
+    if isinstance(explicit_lock, dict):
+        return {
+            "status": "recovery_write_lock_ready_for_manual_recovery",
+            "summary": {"lock_count": 1},
+            "locks": [explicit_lock],
+            "read_only": True,
+            "read_only_memory": True,
+            "would_mutate_memory": False,
+        }
+
+    gate_args = dict(args)
+    for field_name in (
+        "recovery_write_lock_gate",
+        "recovery_executor_lock_gate",
+        "recovery_write_lock",
+        "format",
+    ):
+        gate_args.pop(field_name, None)
+    result = memory_evidence_repair_recovery_write_lock_gate_tool(
+        gate_args,
+        memory_manager=memory_manager,
+    )
+    try:
+        payload = json.loads(result)
+    except json.JSONDecodeError:
+        return tool_error("recovery write-lock gate returned invalid JSON.", success=False)
+    if not isinstance(payload, dict):
+        return tool_error(
+            "recovery write-lock gate returned a non-object payload.",
+            success=False,
+        )
+    if payload.get("success") is False:
+        return json.dumps(payload, ensure_ascii=False)
+    return payload
+
+
+def _render_markdown(payload: dict[str, Any]) -> str:
+    summary = payload.get("summary", {})
+    lines = [
+        "### Memory Evidence Repair Recovery Executor Preview",
+        f"- Status: {payload.get('status')}",
+        f"- Previews: {summary.get('preview_count', 0)}",
+        f"- Steps: {summary.get('step_count', 0)}",
+        f"- Future mutation steps: {summary.get('future_mutation_step_count', 0)}",
+        f"- Ready: {summary.get('manual_recovery_executor_preview_ready', False)}",
+    ]
+    for preview in payload.get("previews", []):
+        lines.append(f"- Preview: {preview.get('id')}")
+        lines.append(f"  Lock: {preview.get('lock_id')}")
+        lines.append(f"  Failure policy: {preview.get('failure_policy')}")
+    for reason in payload.get("blocking_reasons", []):
+        lines.append(f"- Blocked: {reason}")
+    for action in payload.get("required_actions", []):
+        lines.append(f"- Required: {action}")
+    return "\n".join(lines)
+
+
+def check_memory_evidence_repair_recovery_executor_preview_requirements() -> bool:
+    return True
+
+
+registry.register(
+    name="memory_evidence_repair_recovery_executor_preview",
+    toolset="memory",
+    schema=MEMORY_EVIDENCE_REPAIR_RECOVERY_EXECUTOR_PREVIEW_SCHEMA,
+    handler=memory_evidence_repair_recovery_executor_preview_tool,
+    check_fn=check_memory_evidence_repair_recovery_executor_preview_requirements,
+    emoji="🧠",
+)

--- a/tools/memory_evidence_repair_recovery_human_approval_token_tool.py
+++ b/tools/memory_evidence_repair_recovery_human_approval_token_tool.py
@@ -1,0 +1,256 @@
+"""Read-only Memory Evidence Repair Recovery Human Approval Token tool."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from agent.memory_evidence_repair_recovery_human_approval_token import (
+    build_evidence_repair_recovery_human_approval_token,
+)
+from tools.memory_evidence_repair_recovery_execution_preview_tool import (
+    MEMORY_EVIDENCE_REPAIR_RECOVERY_EXECUTION_PREVIEW_SCHEMA,
+    memory_evidence_repair_recovery_execution_preview_tool,
+)
+from tools.registry import registry, tool_error
+
+
+_UPSTREAM_PROPERTIES = dict(
+    MEMORY_EVIDENCE_REPAIR_RECOVERY_EXECUTION_PREVIEW_SCHEMA["parameters"]["properties"]
+)
+_UPSTREAM_PROPERTIES.pop("format", None)
+_UPSTREAM_PROPERTIES.pop("expires_in_minutes", None)
+
+MEMORY_EVIDENCE_REPAIR_RECOVERY_HUMAN_APPROVAL_TOKEN_SCHEMA = {
+    "name": "memory_evidence_repair_recovery_human_approval_token",
+    "description": (
+        "Read-only recovery human approval token draft for a ready memory "
+        "evidence repair recovery execution preview. It never mutates durable memory."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "recovery_execution": {
+                "type": "object",
+                "description": "Optional recovery execution preview report payload.",
+                "additionalProperties": True,
+            },
+            "recovery_execution_preview": {
+                "type": "object",
+                "description": "Alias for recovery_execution.",
+                "additionalProperties": True,
+            },
+            "recovery_execution_report": {
+                "type": "object",
+                "description": "Alias for recovery_execution.",
+                "additionalProperties": True,
+            },
+            "approver": {
+                "type": "string",
+                "description": "Human approver label for the recovery token draft.",
+            },
+            "approval_reason": {
+                "type": "string",
+                "description": "Reason for drafting the recovery approval token.",
+            },
+            "expires_in_minutes": {
+                "type": "integer",
+                "description": "Draft recovery token expiry window in minutes. Defaults to 15.",
+            },
+            "format": {
+                "type": "string",
+                "enum": ["json", "markdown"],
+                "description": "Optional response format helper. JSON is always returned; markdown adds a readable summary field.",
+            },
+            **_UPSTREAM_PROPERTIES,
+        },
+    },
+}
+
+
+def memory_evidence_repair_recovery_human_approval_token_tool(
+    args: dict[str, Any],
+    **kwargs,
+) -> str:
+    if not isinstance(args, dict):
+        return tool_error("args must be an object.", success=False)
+
+    validated = _validate_args(args)
+    if validated is not None:
+        return validated
+
+    recovery_execution = _resolve_recovery_execution(
+        args,
+        kwargs.get("memory_manager"),
+    )
+    if isinstance(recovery_execution, str):
+        return recovery_execution
+
+    payload = build_evidence_repair_recovery_human_approval_token(
+        recovery_execution=recovery_execution,
+        approver=str(args.get("approver") or "human"),
+        approval_reason=str(args.get("approval_reason") or ""),
+        expires_in_minutes=args.get("expires_in_minutes") or 15,
+    ).to_dict()
+    payload["success"] = True
+    payload["read_only"] = True
+    payload["read_only_memory"] = True
+    payload["would_mutate_memory"] = False
+    if str(args.get("format", "")).lower() == "markdown":
+        payload["markdown"] = _render_markdown(payload)
+    return json.dumps(payload, ensure_ascii=False)
+
+
+def _validate_args(args: dict[str, Any]) -> str | None:
+    object_fields = (
+        "recovery_execution",
+        "recovery_execution_preview",
+        "recovery_execution_report",
+        "recovery_decision",
+        "recovery_decision_gate",
+        "recovery_decision_report",
+        "rollback_drill",
+        "rollback_drill_preview",
+        "rollback_drill_report",
+        "post_commit_audit",
+        "post_commit_audit_preview",
+        "post_commit_audit_report",
+        "executor_preview",
+        "executor",
+        "observed_memory_patches",
+        "rollback_status",
+        "write_lock_gate",
+        "executor_lock_gate",
+        "write_lock",
+        "commit_receipt",
+        "receipt",
+        "token_gate",
+        "approval_token_gate",
+        "approval_token",
+        "token",
+        "dry_run",
+        "snapshot_plan",
+        "rollback_plan",
+        "existing_snapshots",
+        "pre_commit_snapshots",
+        "ledger",
+        "commit_gate",
+        "preview",
+        "approval",
+        "plan",
+        "gate",
+        "audit",
+        "diagnostics",
+        "policy",
+        "proposed_evidence",
+    )
+    array_fields = (
+        "released_lock_ids",
+        "active_locks",
+        "locks",
+        "already_used_token_ids",
+        "tokens",
+        "used_token_ids",
+        "receipts",
+        "requests",
+        "steps",
+        "entries",
+        "decisions",
+        "previews",
+        "confirmed_preview_ids",
+        "candidates",
+        "approved_candidate_ids",
+        "repairs",
+    )
+    for field_name in object_fields:
+        value = args.get(field_name)
+        if value is not None and not isinstance(value, dict):
+            return tool_error(f"{field_name} must be an object when provided.", success=False)
+    for field_name in ("existing_receipts", "recorded_receipts"):
+        value = args.get(field_name)
+        if value is not None and not isinstance(value, (dict, list)):
+            return tool_error(
+                f"{field_name} must be an object or array when provided.",
+                success=False,
+            )
+    for field_name in array_fields:
+        value = args.get(field_name)
+        if value is not None and not isinstance(value, list):
+            return tool_error(f"{field_name} must be an array when provided.", success=False)
+    return None
+
+
+def _resolve_recovery_execution(
+    args: dict[str, Any],
+    memory_manager: Any,
+) -> dict[str, Any] | str:
+    for field_name in (
+        "recovery_execution",
+        "recovery_execution_preview",
+        "recovery_execution_report",
+    ):
+        explicit = args.get(field_name)
+        if isinstance(explicit, dict):
+            return explicit
+
+    execution_args = dict(args)
+    for field_name in (
+        "recovery_execution",
+        "recovery_execution_preview",
+        "recovery_execution_report",
+        "approver",
+        "approval_reason",
+        "expires_in_minutes",
+        "format",
+    ):
+        execution_args.pop(field_name, None)
+    result = memory_evidence_repair_recovery_execution_preview_tool(
+        execution_args,
+        memory_manager=memory_manager,
+    )
+    try:
+        payload = json.loads(result)
+    except json.JSONDecodeError:
+        return tool_error(
+            "recovery execution preview tool returned invalid JSON.",
+            success=False,
+        )
+    if not isinstance(payload, dict):
+        return tool_error(
+            "recovery execution preview tool returned a non-object payload.",
+            success=False,
+        )
+    if payload.get("success") is False:
+        return json.dumps(payload, ensure_ascii=False)
+    return payload
+
+
+def _render_markdown(payload: dict[str, Any]) -> str:
+    summary = payload.get("summary", {})
+    lines = [
+        "### Memory Evidence Repair Recovery Human Approval Token",
+        f"- Status: {payload.get('status')}",
+        f"- Tokens: {summary.get('token_count', 0)}",
+        f"- Blocks: {summary.get('blocking_reason_count', 0)}",
+        f"- Required actions: {summary.get('required_action_count', 0)}",
+    ]
+    for token in payload.get("tokens", []):
+        lines.append(f"- Token: {token.get('id')}")
+        lines.append(f"  Confirm: {token.get('required_confirmation_text')}")
+    for reason in payload.get("blocking_reasons", []):
+        lines.append(f"- Blocked: {reason}")
+    return "\n".join(lines)
+
+
+def check_memory_evidence_repair_recovery_human_approval_token_requirements() -> bool:
+    return True
+
+
+registry.register(
+    name="memory_evidence_repair_recovery_human_approval_token",
+    toolset="memory",
+    schema=MEMORY_EVIDENCE_REPAIR_RECOVERY_HUMAN_APPROVAL_TOKEN_SCHEMA,
+    handler=memory_evidence_repair_recovery_human_approval_token_tool,
+    check_fn=check_memory_evidence_repair_recovery_human_approval_token_requirements,
+    emoji="🧠",
+)

--- a/tools/memory_evidence_repair_recovery_write_lock_gate_tool.py
+++ b/tools/memory_evidence_repair_recovery_write_lock_gate_tool.py
@@ -1,0 +1,287 @@
+"""Read-only Memory Evidence Repair Recovery Write Lock Gate tool."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from agent.memory_evidence_repair_recovery_write_lock_gate import (
+    build_evidence_repair_recovery_write_lock_gate,
+)
+from tools.memory_evidence_repair_recovery_approval_token_gate_tool import (
+    MEMORY_EVIDENCE_REPAIR_RECOVERY_APPROVAL_TOKEN_GATE_SCHEMA,
+    memory_evidence_repair_recovery_approval_token_gate_tool,
+)
+from tools.registry import registry, tool_error
+
+
+_UPSTREAM_PROPERTIES = dict(
+    MEMORY_EVIDENCE_REPAIR_RECOVERY_APPROVAL_TOKEN_GATE_SCHEMA["parameters"]["properties"]
+)
+_UPSTREAM_PROPERTIES.pop("format", None)
+
+MEMORY_EVIDENCE_REPAIR_RECOVERY_WRITE_LOCK_GATE_SCHEMA = {
+    "name": "memory_evidence_repair_recovery_write_lock_gate",
+    "description": (
+        "Read-only recovery write-lock gate for memory evidence repair recovery. "
+        "It drafts a future recovery write lock without mutating durable memory."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "recovery_token_gate": {
+                "type": "object",
+                "description": "Optional recovery approval token gate report payload.",
+                "additionalProperties": True,
+            },
+            "recovery_approval_token_gate": {
+                "type": "object",
+                "description": "Alias for recovery_token_gate.",
+                "additionalProperties": True,
+            },
+            "token_gate": {
+                "type": "object",
+                "description": "Alias for recovery_token_gate.",
+                "additionalProperties": True,
+            },
+            "active_locks": {
+                "type": "array",
+                "description": "Optional active recovery write-lock records to check for conflicts.",
+                "items": {"type": "object", "additionalProperties": True},
+            },
+            "locks": {
+                "type": "array",
+                "description": "Alias for active_locks.",
+                "items": {"type": "object", "additionalProperties": True},
+            },
+            "already_used_token_ids": {
+                "type": "array",
+                "description": "External used-token ids to check before drafting a recovery write lock.",
+                "items": {"type": "string"},
+            },
+            "lock_owner": {
+                "type": "string",
+                "description": "Owner label for the future recovery write-lock draft.",
+            },
+            "lock_ttl_minutes": {
+                "type": "integer",
+                "description": "Recovery write-lock draft TTL in minutes. Defaults to 10.",
+            },
+            "format": {
+                "type": "string",
+                "enum": ["json", "markdown"],
+                "description": "Optional response format helper. JSON is always returned; markdown adds a readable summary field.",
+            },
+            **_UPSTREAM_PROPERTIES,
+        },
+    },
+}
+
+
+def memory_evidence_repair_recovery_write_lock_gate_tool(
+    args: dict[str, Any],
+    **kwargs,
+) -> str:
+    if not isinstance(args, dict):
+        return tool_error("args must be an object.", success=False)
+
+    validated = _validate_args(args)
+    if validated is not None:
+        return validated
+
+    recovery_token_gate = _resolve_recovery_token_gate(
+        args,
+        kwargs.get("memory_manager"),
+    )
+    if isinstance(recovery_token_gate, str):
+        return recovery_token_gate
+
+    payload = build_evidence_repair_recovery_write_lock_gate(
+        recovery_token_gate=recovery_token_gate,
+        active_locks=_active_locks(args),
+        already_used_token_ids=(
+            args.get("already_used_token_ids")
+            if isinstance(args.get("already_used_token_ids"), list)
+            else None
+        ),
+        lock_owner=str(args.get("lock_owner") or args.get("actor") or "human"),
+        lock_ttl_minutes=args.get("lock_ttl_minutes") or 10,
+        current_time=args.get("current_time"),
+    ).to_dict()
+    payload["success"] = True
+    payload["read_only"] = True
+    payload["read_only_memory"] = True
+    payload["would_mutate_memory"] = False
+    if str(args.get("format", "")).lower() == "markdown":
+        payload["markdown"] = _render_markdown(payload)
+    return json.dumps(payload, ensure_ascii=False)
+
+
+def _validate_args(args: dict[str, Any]) -> str | None:
+    object_fields = (
+        "recovery_token_gate",
+        "recovery_approval_token_gate",
+        "token_gate",
+        "recovery_approval_token",
+        "recovery_human_approval_token",
+        "recovery_token",
+        "token",
+        "recovery_execution",
+        "recovery_execution_preview",
+        "recovery_execution_report",
+        "recovery_decision",
+        "recovery_decision_gate",
+        "recovery_decision_report",
+        "rollback_drill",
+        "rollback_drill_preview",
+        "rollback_drill_report",
+        "post_commit_audit",
+        "post_commit_audit_preview",
+        "post_commit_audit_report",
+        "executor_preview",
+        "executor",
+        "observed_memory_patches",
+        "rollback_status",
+        "write_lock_gate",
+        "executor_lock_gate",
+        "write_lock",
+        "commit_receipt",
+        "receipt",
+        "approval_token_gate",
+        "approval_token",
+        "dry_run",
+        "snapshot_plan",
+        "rollback_plan",
+        "existing_snapshots",
+        "pre_commit_snapshots",
+        "ledger",
+        "commit_gate",
+        "preview",
+        "approval",
+        "plan",
+        "gate",
+        "audit",
+        "diagnostics",
+        "policy",
+        "proposed_evidence",
+    )
+    array_fields = (
+        "active_locks",
+        "locks",
+        "already_used_token_ids",
+        "tokens",
+        "used_token_ids",
+        "released_lock_ids",
+        "receipts",
+        "requests",
+        "steps",
+        "entries",
+        "decisions",
+        "previews",
+        "confirmed_preview_ids",
+        "candidates",
+        "approved_candidate_ids",
+        "repairs",
+    )
+    for field_name in object_fields:
+        value = args.get(field_name)
+        if value is not None and not isinstance(value, dict):
+            return tool_error(f"{field_name} must be an object when provided.", success=False)
+    for field_name in ("existing_receipts", "recorded_receipts"):
+        value = args.get(field_name)
+        if value is not None and not isinstance(value, (dict, list)):
+            return tool_error(
+                f"{field_name} must be an object or array when provided.",
+                success=False,
+            )
+    for field_name in array_fields:
+        value = args.get(field_name)
+        if value is not None and not isinstance(value, list):
+            return tool_error(f"{field_name} must be an array when provided.", success=False)
+    return None
+
+
+def _resolve_recovery_token_gate(
+    args: dict[str, Any],
+    memory_manager: Any,
+) -> dict[str, Any] | str:
+    for field_name in ("recovery_token_gate", "recovery_approval_token_gate", "token_gate"):
+        explicit = args.get(field_name)
+        if isinstance(explicit, dict):
+            return explicit
+
+    gate_args = dict(args)
+    for field_name in (
+        "recovery_token_gate",
+        "recovery_approval_token_gate",
+        "token_gate",
+        "active_locks",
+        "locks",
+        "already_used_token_ids",
+        "lock_owner",
+        "lock_ttl_minutes",
+        "format",
+    ):
+        gate_args.pop(field_name, None)
+    result = memory_evidence_repair_recovery_approval_token_gate_tool(
+        gate_args,
+        memory_manager=memory_manager,
+    )
+    try:
+        payload = json.loads(result)
+    except json.JSONDecodeError:
+        return tool_error(
+            "recovery approval token gate tool returned invalid JSON.",
+            success=False,
+        )
+    if not isinstance(payload, dict):
+        return tool_error(
+            "recovery approval token gate tool returned a non-object payload.",
+            success=False,
+        )
+    if payload.get("success") is False:
+        return json.dumps(payload, ensure_ascii=False)
+    return payload
+
+
+def _active_locks(args: dict[str, Any]) -> list[dict[str, Any]]:
+    if isinstance(args.get("active_locks"), list):
+        return args["active_locks"]
+    if isinstance(args.get("locks"), list):
+        return args["locks"]
+    return []
+
+
+def _render_markdown(payload: dict[str, Any]) -> str:
+    summary = payload.get("summary", {})
+    lines = [
+        "### Memory Evidence Repair Recovery Write Lock Gate",
+        f"- Status: {payload.get('status')}",
+        f"- Checks: {summary.get('check_count', 0)}",
+        f"- Locks: {summary.get('lock_count', 0)}",
+        f"- Conflicts: {summary.get('active_lock_conflict_count', 0)}",
+        f"- Recovery executor preview allowed: {summary.get('recovery_executor_preview_allowed', False)}",
+    ]
+    for lock in payload.get("locks", []):
+        lines.append(f"- Lock: {lock.get('id')}")
+        lines.append(f"  Token: {lock.get('token_id')}")
+        lines.append(f"  Expires: {lock.get('expires_at')}")
+    for reason in payload.get("blocking_reasons", []):
+        lines.append(f"- Blocked: {reason}")
+    for action in payload.get("required_actions", []):
+        lines.append(f"- Required: {action}")
+    return "\n".join(lines)
+
+
+def check_memory_evidence_repair_recovery_write_lock_gate_requirements() -> bool:
+    return True
+
+
+registry.register(
+    name="memory_evidence_repair_recovery_write_lock_gate",
+    toolset="memory",
+    schema=MEMORY_EVIDENCE_REPAIR_RECOVERY_WRITE_LOCK_GATE_SCHEMA,
+    handler=memory_evidence_repair_recovery_write_lock_gate_tool,
+    check_fn=check_memory_evidence_repair_recovery_write_lock_gate_requirements,
+    emoji="🧠",
+)

--- a/tools/memory_evidence_repair_rollback_drill_preview_tool.py
+++ b/tools/memory_evidence_repair_rollback_drill_preview_tool.py
@@ -1,0 +1,249 @@
+"""Read-only Memory Evidence Repair Rollback Drill Preview tool."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from agent.memory_evidence_repair_rollback_drill_preview import (
+    build_evidence_repair_rollback_drill_preview,
+)
+from tools.memory_evidence_repair_post_commit_audit_preview_tool import (
+    MEMORY_EVIDENCE_REPAIR_POST_COMMIT_AUDIT_PREVIEW_SCHEMA,
+    memory_evidence_repair_post_commit_audit_preview_tool,
+)
+from tools.registry import registry, tool_error
+
+
+_UPSTREAM_PROPERTIES = dict(
+    MEMORY_EVIDENCE_REPAIR_POST_COMMIT_AUDIT_PREVIEW_SCHEMA["parameters"]["properties"]
+)
+_UPSTREAM_PROPERTIES.pop("format", None)
+
+MEMORY_EVIDENCE_REPAIR_ROLLBACK_DRILL_PREVIEW_SCHEMA = {
+    "name": "memory_evidence_repair_rollback_drill_preview",
+    "description": (
+        "Read-only rollback drill preview for memory evidence repair audit "
+        "failures. It rehearses isolation, restoration, reconciliation, and "
+        "re-audit steps without mutating durable memory."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "post_commit_audit": {
+                "type": "object",
+                "description": "Optional post-commit audit report payload.",
+                "additionalProperties": True,
+            },
+            "post_commit_audit_preview": {
+                "type": "object",
+                "description": "Alias for post_commit_audit.",
+                "additionalProperties": True,
+            },
+            "post_commit_audit_report": {
+                "type": "object",
+                "description": "Alias for post_commit_audit.",
+                "additionalProperties": True,
+            },
+            "rollback_plan": {
+                "type": "object",
+                "description": "Optional rollback plan reference for drill source matching.",
+                "additionalProperties": True,
+            },
+            "snapshot_plan": {
+                "type": "object",
+                "description": "Optional snapshot plan reference for drill source matching.",
+                "additionalProperties": True,
+            },
+            "format": {
+                "type": "string",
+                "enum": ["json", "markdown"],
+                "description": "Optional response format helper. JSON is always returned; markdown adds a readable summary field.",
+            },
+            **_UPSTREAM_PROPERTIES,
+        },
+    },
+}
+
+
+def memory_evidence_repair_rollback_drill_preview_tool(
+    args: dict[str, Any],
+    **kwargs,
+) -> str:
+    if not isinstance(args, dict):
+        return tool_error("args must be an object.", success=False)
+
+    validated = _validate_args(args)
+    if validated is not None:
+        return validated
+
+    post_commit_audit = _resolve_post_commit_audit(args, kwargs.get("memory_manager"))
+    if isinstance(post_commit_audit, str):
+        return post_commit_audit
+
+    payload = build_evidence_repair_rollback_drill_preview(
+        post_commit_audit=post_commit_audit,
+        rollback_plan=(
+            args.get("rollback_plan")
+            if isinstance(args.get("rollback_plan"), dict)
+            else None
+        ),
+        snapshot_plan=(
+            args.get("snapshot_plan")
+            if isinstance(args.get("snapshot_plan"), dict)
+            else None
+        ),
+    ).to_dict()
+    payload["success"] = True
+    payload["read_only"] = True
+    payload["read_only_memory"] = True
+    payload["would_mutate_memory"] = False
+    if str(args.get("format", "")).lower() == "markdown":
+        payload["markdown"] = _render_markdown(payload)
+    return json.dumps(payload, ensure_ascii=False)
+
+
+def _validate_args(args: dict[str, Any]) -> str | None:
+    object_fields = (
+        "post_commit_audit",
+        "post_commit_audit_preview",
+        "post_commit_audit_report",
+        "executor_preview",
+        "executor",
+        "observed_memory_patches",
+        "rollback_status",
+        "write_lock_gate",
+        "executor_lock_gate",
+        "write_lock",
+        "commit_receipt",
+        "receipt",
+        "token_gate",
+        "approval_token_gate",
+        "approval_token",
+        "token",
+        "dry_run",
+        "snapshot_plan",
+        "rollback_plan",
+        "existing_snapshots",
+        "pre_commit_snapshots",
+        "ledger",
+        "commit_gate",
+        "preview",
+        "approval",
+        "plan",
+        "gate",
+        "audit",
+        "diagnostics",
+        "policy",
+        "proposed_evidence",
+    )
+    array_fields = (
+        "released_lock_ids",
+        "active_locks",
+        "locks",
+        "already_used_token_ids",
+        "tokens",
+        "used_token_ids",
+        "receipts",
+        "requests",
+        "steps",
+        "entries",
+        "decisions",
+        "previews",
+        "confirmed_preview_ids",
+        "candidates",
+        "approved_candidate_ids",
+        "repairs",
+    )
+    for field_name in object_fields:
+        value = args.get(field_name)
+        if value is not None and not isinstance(value, dict):
+            return tool_error(f"{field_name} must be an object when provided.", success=False)
+    for field_name in ("existing_receipts", "recorded_receipts"):
+        value = args.get(field_name)
+        if value is not None and not isinstance(value, (dict, list)):
+            return tool_error(
+                f"{field_name} must be an object or array when provided.",
+                success=False,
+            )
+    for field_name in array_fields:
+        value = args.get(field_name)
+        if value is not None and not isinstance(value, list):
+            return tool_error(f"{field_name} must be an array when provided.", success=False)
+    return None
+
+
+def _resolve_post_commit_audit(
+    args: dict[str, Any],
+    memory_manager: Any,
+) -> dict[str, Any] | str:
+    for field_name in (
+        "post_commit_audit",
+        "post_commit_audit_preview",
+        "post_commit_audit_report",
+    ):
+        explicit = args.get(field_name)
+        if isinstance(explicit, dict):
+            return explicit
+
+    audit_args = dict(args)
+    for field_name in (
+        "post_commit_audit",
+        "post_commit_audit_preview",
+        "post_commit_audit_report",
+        "rollback_plan",
+        "snapshot_plan",
+        "format",
+    ):
+        audit_args.pop(field_name, None)
+    result = memory_evidence_repair_post_commit_audit_preview_tool(
+        audit_args,
+        memory_manager=memory_manager,
+    )
+    try:
+        payload = json.loads(result)
+    except json.JSONDecodeError:
+        return tool_error("post-commit audit preview tool returned invalid JSON.", success=False)
+    if not isinstance(payload, dict):
+        return tool_error(
+            "post-commit audit preview tool returned a non-object payload.",
+            success=False,
+        )
+    if payload.get("success") is False:
+        return json.dumps(payload, ensure_ascii=False)
+    return payload
+
+
+def _render_markdown(payload: dict[str, Any]) -> str:
+    summary = payload.get("summary", {})
+    lines = [
+        "### Memory Evidence Repair Rollback Drill Preview",
+        f"- Status: {payload.get('status')}",
+        f"- Previews: {summary.get('preview_count', 0)}",
+        f"- Drill steps: {summary.get('drill_step_count', 0)}",
+        f"- Failed audit steps: {summary.get('failed_audit_step_count', 0)}",
+        f"- Future restore steps: {summary.get('future_restore_step_count', 0)}",
+    ]
+    for preview in payload.get("previews", []):
+        lines.append(f"- Drill: {preview.get('id')}")
+        lines.append(f"  Trigger: {preview.get('trigger')}")
+        lines.append(f"  Audit: {preview.get('post_commit_audit_id')}")
+    for reason in payload.get("blocking_reasons", []):
+        lines.append(f"- Blocked: {reason}")
+    for action in payload.get("required_actions", []):
+        lines.append(f"- Required: {action}")
+    return "\n".join(lines)
+
+
+def check_memory_evidence_repair_rollback_drill_preview_requirements() -> bool:
+    return True
+
+
+registry.register(
+    name="memory_evidence_repair_rollback_drill_preview",
+    toolset="memory",
+    schema=MEMORY_EVIDENCE_REPAIR_ROLLBACK_DRILL_PREVIEW_SCHEMA,
+    handler=memory_evidence_repair_rollback_drill_preview_tool,
+    check_fn=check_memory_evidence_repair_rollback_drill_preview_requirements,
+    emoji="🧠",
+)

--- a/tools/memory_evidence_repair_rollback_plan_tool.py
+++ b/tools/memory_evidence_repair_rollback_plan_tool.py
@@ -1,0 +1,459 @@
+"""Read-only Memory Evidence Repair Rollback Plan tool."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from agent.memory_evidence_repair_apply_preview import (
+    build_evidence_repair_apply_preview,
+)
+from agent.memory_evidence_repair_approval import (
+    build_evidence_repair_approval_candidates,
+)
+from agent.memory_evidence_repair_commit_gate import (
+    build_evidence_repair_commit_gate,
+)
+from agent.memory_evidence_repair_commit_ledger import (
+    build_evidence_repair_commit_ledger,
+)
+from agent.memory_evidence_repair_planner import build_evidence_repair_plan
+from agent.memory_evidence_repair_rollback_plan import (
+    MemoryEvidenceRepairRollbackPlan,
+    build_evidence_repair_rollback_plan,
+)
+from tools.registry import registry, tool_error
+
+
+MEMORY_EVIDENCE_REPAIR_ROLLBACK_PLAN_SCHEMA = {
+    "name": "memory_evidence_repair_rollback_plan",
+    "description": (
+        "Read-only rollback plan for future memory evidence repair writes. "
+        "It drafts inverse patch steps and never mutates durable memory."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "ledger": {
+                "type": "object",
+                "description": "Optional commit ledger draft payload.",
+                "additionalProperties": True,
+            },
+            "entries": {
+                "type": "array",
+                "description": "Optional commit ledger entries to turn into rollback steps.",
+                "items": {"type": "object", "additionalProperties": True},
+            },
+            "pre_commit_snapshots": {
+                "type": "object",
+                "description": "Optional previous evidence snapshots keyed by ledger, candidate, preview, decision, or patch digest id.",
+                "additionalProperties": True,
+            },
+            "commit_gate": {
+                "type": "object",
+                "description": "Optional commit gate report payload.",
+                "additionalProperties": True,
+            },
+            "decisions": {
+                "type": "array",
+                "description": "Optional commit gate decisions used to build a ledger.",
+                "items": {"type": "object", "additionalProperties": True},
+            },
+            "ledger_actor": {
+                "type": "string",
+                "description": "Optional actor label for generated ledger entries.",
+            },
+            "ledger_reason": {
+                "type": "string",
+                "description": "Optional reason for generated ledger entries.",
+            },
+            "preview": {
+                "type": "object",
+                "description": "Optional apply preview report payload.",
+                "additionalProperties": True,
+            },
+            "previews": {
+                "type": "array",
+                "description": "Optional apply previews used to build a commit gate.",
+                "items": {"type": "object", "additionalProperties": True},
+            },
+            "confirmed_preview_ids": {
+                "type": "array",
+                "description": "Optional preview ids explicitly confirmed by the user.",
+                "items": {"type": "string"},
+            },
+            "user_confirmed": {
+                "type": "boolean",
+                "description": "Whether the user explicitly confirmed these previews.",
+            },
+            "approval": {
+                "type": "object",
+                "description": "Optional approval candidate report payload.",
+                "additionalProperties": True,
+            },
+            "candidates": {
+                "type": "array",
+                "description": "Optional approval candidates used to build previews.",
+                "items": {"type": "object", "additionalProperties": True},
+            },
+            "approved_candidate_ids": {
+                "type": "array",
+                "description": "Optional candidate ids confirmed for apply preview generation.",
+                "items": {"type": "string"},
+            },
+            "plan": {
+                "type": "object",
+                "description": "Optional evidence repair plan payload.",
+                "additionalProperties": True,
+            },
+            "repairs": {
+                "type": "array",
+                "description": "Optional repair items used to build candidates.",
+                "items": {"type": "object", "additionalProperties": True},
+            },
+            "gate": {
+                "type": "object",
+                "description": "Optional memory policy gate payload.",
+                "additionalProperties": True,
+            },
+            "audit": {
+                "type": "object",
+                "description": "Optional memory recall audit payload.",
+                "additionalProperties": True,
+            },
+            "diagnostics": {
+                "type": "object",
+                "description": "Optional memory recall diagnostics payload.",
+                "additionalProperties": True,
+            },
+            "policy": {
+                "type": "object",
+                "description": "Optional memory auto-policy payload.",
+                "additionalProperties": True,
+            },
+            "proposed_evidence": {
+                "type": "object",
+                "description": "Optional proposed evidence values keyed globally or by candidate id.",
+                "additionalProperties": True,
+            },
+            "format": {
+                "type": "string",
+                "enum": ["json", "markdown"],
+                "description": "Optional response format helper. JSON is always returned; markdown adds a readable summary field.",
+            },
+            "limit": {
+                "type": "integer",
+                "description": "Maximum rollback steps to include. Defaults to all steps.",
+            },
+        },
+    },
+}
+
+
+def memory_evidence_repair_rollback_plan_tool(
+    args: dict[str, Any],
+    **kwargs,
+) -> str:
+    if not isinstance(args, dict):
+        return tool_error("args must be an object.", success=False)
+
+    validated = _validate_args(args)
+    if validated is not None:
+        return validated
+
+    ledger = _resolve_ledger(args, kwargs.get("memory_manager"))
+    if isinstance(ledger, str):
+        return ledger
+
+    report = build_evidence_repair_rollback_plan(
+        ledger=ledger,
+        pre_commit_snapshots=(
+            args.get("pre_commit_snapshots")
+            if isinstance(args.get("pre_commit_snapshots"), dict)
+            else {}
+        ),
+    )
+
+    limit = _positive_int(args.get("limit"))
+    if limit is not None:
+        report = MemoryEvidenceRepairRollbackPlan(
+            generated_at=report.generated_at,
+            steps=report.steps[:limit],
+        )
+
+    payload = report.to_dict()
+    if limit is not None:
+        payload["limited_to"] = limit
+    payload["success"] = True
+    payload["read_only"] = True
+    payload["read_only_memory"] = True
+    payload["would_mutate_memory"] = False
+    if str(args.get("format", "")).lower() == "markdown":
+        payload["markdown"] = _render_markdown(payload)
+    return json.dumps(payload, ensure_ascii=False)
+
+
+def _validate_args(args: dict[str, Any]) -> str | None:
+    object_fields = (
+        "ledger",
+        "pre_commit_snapshots",
+        "commit_gate",
+        "preview",
+        "approval",
+        "plan",
+        "gate",
+        "audit",
+        "diagnostics",
+        "policy",
+        "proposed_evidence",
+    )
+    array_fields = (
+        "entries",
+        "decisions",
+        "previews",
+        "confirmed_preview_ids",
+        "candidates",
+        "approved_candidate_ids",
+        "repairs",
+    )
+    for field_name in object_fields:
+        value = args.get(field_name)
+        if value is not None and not isinstance(value, dict):
+            return tool_error(f"{field_name} must be an object when provided.", success=False)
+    for field_name in array_fields:
+        value = args.get(field_name)
+        if value is not None and not isinstance(value, list):
+            return tool_error(f"{field_name} must be an array when provided.", success=False)
+    return None
+
+
+def _resolve_ledger(args: dict[str, Any], memory_manager: Any) -> dict[str, Any] | str:
+    explicit_ledger = args.get("ledger")
+    explicit_entries = args.get("entries")
+    if isinstance(explicit_ledger, dict):
+        if "entries" in explicit_ledger:
+            return explicit_ledger
+        return {
+            "summary": {"entry_count": 1},
+            "entries": [explicit_ledger],
+            "read_only": True,
+            "read_only_memory": True,
+            "would_mutate_memory": False,
+        }
+    if isinstance(explicit_entries, list):
+        return {
+            "summary": {"entry_count": len(explicit_entries)},
+            "entries": explicit_entries,
+            "read_only": True,
+            "read_only_memory": True,
+            "would_mutate_memory": False,
+        }
+
+    commit_gate = _resolve_commit_gate(args, memory_manager)
+    if isinstance(commit_gate, str):
+        return commit_gate
+    return build_evidence_repair_commit_ledger(
+        commit_gate=commit_gate,
+        ledger_actor=str(args.get("ledger_actor") or "hermes"),
+        ledger_reason=str(args.get("ledger_reason") or ""),
+    ).to_dict()
+
+
+def _resolve_commit_gate(
+    args: dict[str, Any],
+    memory_manager: Any,
+) -> dict[str, Any] | str:
+    explicit_gate = args.get("commit_gate")
+    explicit_decisions = args.get("decisions")
+    if isinstance(explicit_gate, dict):
+        if "decisions" in explicit_gate:
+            return explicit_gate
+        return {
+            "summary": {"decision_count": 1},
+            "decisions": [explicit_gate],
+            "read_only": True,
+            "read_only_memory": True,
+            "would_mutate_memory": False,
+        }
+    if isinstance(explicit_decisions, list):
+        return {
+            "summary": {"decision_count": len(explicit_decisions)},
+            "decisions": explicit_decisions,
+            "read_only": True,
+            "read_only_memory": True,
+            "would_mutate_memory": False,
+        }
+
+    preview = _resolve_preview(args, memory_manager)
+    if isinstance(preview, str):
+        return preview
+    return build_evidence_repair_commit_gate(
+        preview=preview,
+        confirmed_preview_ids=(
+            args.get("confirmed_preview_ids")
+            if isinstance(args.get("confirmed_preview_ids"), list)
+            else None
+        ),
+        user_confirmed=bool(args.get("user_confirmed")),
+    ).to_dict()
+
+
+def _resolve_preview(args: dict[str, Any], memory_manager: Any) -> dict[str, Any] | str:
+    explicit_preview = args.get("preview")
+    explicit_previews = args.get("previews")
+    if isinstance(explicit_preview, dict):
+        if "previews" in explicit_preview:
+            return explicit_preview
+        return {
+            "summary": {"preview_count": 1},
+            "previews": [explicit_preview],
+            "read_only": True,
+            "read_only_memory": True,
+            "would_mutate_memory": False,
+        }
+    if isinstance(explicit_previews, list):
+        return {
+            "summary": {"preview_count": len(explicit_previews)},
+            "previews": explicit_previews,
+            "read_only": True,
+            "read_only_memory": True,
+            "would_mutate_memory": False,
+        }
+
+    approval = _resolve_approval(args, memory_manager)
+    if isinstance(approval, str):
+        return approval
+    return build_evidence_repair_apply_preview(
+        approval=approval,
+        approved_candidate_ids=(
+            args.get("approved_candidate_ids")
+            if isinstance(args.get("approved_candidate_ids"), list)
+            else None
+        ),
+        proposed_evidence=(
+            args.get("proposed_evidence")
+            if isinstance(args.get("proposed_evidence"), dict)
+            else {}
+        ),
+    ).to_dict()
+
+
+def _resolve_approval(args: dict[str, Any], memory_manager: Any) -> dict[str, Any] | str:
+    explicit_approval = args.get("approval")
+    explicit_candidates = args.get("candidates")
+    if isinstance(explicit_approval, dict):
+        return explicit_approval
+    if isinstance(explicit_candidates, list):
+        return {
+            "summary": {"candidate_count": len(explicit_candidates)},
+            "candidates": explicit_candidates,
+            "read_only": True,
+            "read_only_memory": True,
+        }
+
+    plan = _resolve_plan(args, memory_manager)
+    if isinstance(plan, str):
+        return plan
+    return build_evidence_repair_approval_candidates(
+        plan=plan,
+        proposed_evidence=(
+            args.get("proposed_evidence")
+            if isinstance(args.get("proposed_evidence"), dict)
+            else {}
+        ),
+    ).to_dict()
+
+
+def _resolve_plan(args: dict[str, Any], memory_manager: Any) -> dict[str, Any] | str:
+    explicit_plan = args.get("plan")
+    explicit_repairs = args.get("repairs")
+    if isinstance(explicit_plan, dict):
+        return explicit_plan
+    if isinstance(explicit_repairs, list):
+        return {
+            "summary": {"repair_count": len(explicit_repairs)},
+            "repairs": explicit_repairs,
+            "read_only": True,
+        }
+
+    gate = args.get("gate") if isinstance(args.get("gate"), dict) else _manager_dict(
+        memory_manager,
+        "last_memory_policy_gate",
+    )
+    audit = args.get("audit") if isinstance(args.get("audit"), dict) else _manager_dict(
+        memory_manager,
+        "last_recall_audit",
+    )
+    diagnostics = (
+        args.get("diagnostics")
+        if isinstance(args.get("diagnostics"), dict)
+        else _manager_dict(memory_manager, "last_recall_diagnostics")
+    )
+    policy = args.get("policy") if isinstance(args.get("policy"), dict) else _manager_dict(
+        memory_manager,
+        "last_memory_auto_policy",
+    )
+    return build_evidence_repair_plan(
+        gate=gate,
+        audit=audit,
+        diagnostics=diagnostics,
+        policy=policy,
+    ).to_dict()
+
+
+def _manager_dict(memory_manager: Any, method_name: str) -> dict[str, Any]:
+    if memory_manager is None or not hasattr(memory_manager, method_name):
+        return {}
+    try:
+        value = getattr(memory_manager, method_name)()
+    except Exception:
+        return {}
+    return dict(value) if isinstance(value, dict) else {}
+
+
+def _positive_int(value: Any) -> int | None:
+    if value is None:
+        return None
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed if parsed > 0 else None
+
+
+def _render_markdown(payload: dict[str, Any]) -> str:
+    summary = payload.get("summary", {})
+    lines = [
+        "### Memory Evidence Repair Rollback Plan",
+        f"- Steps: {summary.get('rollback_step_count', 0)}",
+        f"- Ready: {summary.get('ready_count', 0)}",
+        f"- Snapshot required: {summary.get('snapshot_required_count', 0)}",
+        f"- No action: {summary.get('no_action_count', 0)}",
+    ]
+    for index, step in enumerate(payload.get("steps", []), start=1):
+        provider = step.get("provider") or "memory"
+        lines.append(
+            f"{index}. [{step.get('status')}] "
+            f"{step.get('rollback_action')} provider={provider}"
+        )
+        required = step.get("required_preconditions") or []
+        if required:
+            lines.append(f"   Preconditions: {', '.join(str(item) for item in required)}")
+        verify = step.get("verification_steps") or []
+        if verify:
+            lines.append(f"   Verify: {', '.join(str(item) for item in verify)}")
+    return "\n".join(lines)
+
+
+def check_memory_evidence_repair_rollback_plan_requirements() -> bool:
+    return True
+
+
+registry.register(
+    name="memory_evidence_repair_rollback_plan",
+    toolset="memory",
+    schema=MEMORY_EVIDENCE_REPAIR_ROLLBACK_PLAN_SCHEMA,
+    handler=memory_evidence_repair_rollback_plan_tool,
+    check_fn=check_memory_evidence_repair_rollback_plan_requirements,
+    emoji="🧠",
+)

--- a/tools/memory_evidence_repair_snapshot_planner_tool.py
+++ b/tools/memory_evidence_repair_snapshot_planner_tool.py
@@ -1,0 +1,519 @@
+"""Read-only Memory Evidence Repair Snapshot Planner tool."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from agent.memory_evidence_repair_apply_preview import (
+    build_evidence_repair_apply_preview,
+)
+from agent.memory_evidence_repair_approval import (
+    build_evidence_repair_approval_candidates,
+)
+from agent.memory_evidence_repair_commit_gate import (
+    build_evidence_repair_commit_gate,
+)
+from agent.memory_evidence_repair_commit_ledger import (
+    build_evidence_repair_commit_ledger,
+)
+from agent.memory_evidence_repair_planner import build_evidence_repair_plan
+from agent.memory_evidence_repair_rollback_plan import (
+    build_evidence_repair_rollback_plan,
+)
+from agent.memory_evidence_repair_snapshot_planner import (
+    MemoryEvidenceRepairSnapshotPlan,
+    build_evidence_repair_snapshot_plan,
+)
+from tools.registry import registry, tool_error
+
+
+MEMORY_EVIDENCE_REPAIR_SNAPSHOT_PLANNER_SCHEMA = {
+    "name": "memory_evidence_repair_snapshot_planner",
+    "description": (
+        "Read-only pre-commit snapshot planner for memory evidence repair. "
+        "It identifies evidence fields to capture before a future manual write."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "rollback_plan": {
+                "type": "object",
+                "description": "Optional rollback plan payload.",
+                "additionalProperties": True,
+            },
+            "steps": {
+                "type": "array",
+                "description": "Optional rollback steps to turn into snapshot requests.",
+                "items": {"type": "object", "additionalProperties": True},
+            },
+            "existing_snapshots": {
+                "type": "object",
+                "description": "Optional existing pre-commit snapshots keyed by ledger, candidate, preview, decision, or patch digest id.",
+                "additionalProperties": True,
+            },
+            "pre_commit_snapshots": {
+                "type": "object",
+                "description": "Alias for existing_snapshots.",
+                "additionalProperties": True,
+            },
+            "ledger": {
+                "type": "object",
+                "description": "Optional commit ledger draft payload.",
+                "additionalProperties": True,
+            },
+            "entries": {
+                "type": "array",
+                "description": "Optional commit ledger entries used to build rollback steps.",
+                "items": {"type": "object", "additionalProperties": True},
+            },
+            "commit_gate": {
+                "type": "object",
+                "description": "Optional commit gate report payload.",
+                "additionalProperties": True,
+            },
+            "decisions": {
+                "type": "array",
+                "description": "Optional commit gate decisions used to build a ledger.",
+                "items": {"type": "object", "additionalProperties": True},
+            },
+            "ledger_actor": {
+                "type": "string",
+                "description": "Optional actor label for generated ledger entries.",
+            },
+            "ledger_reason": {
+                "type": "string",
+                "description": "Optional reason for generated ledger entries.",
+            },
+            "preview": {
+                "type": "object",
+                "description": "Optional apply preview report payload.",
+                "additionalProperties": True,
+            },
+            "previews": {
+                "type": "array",
+                "description": "Optional apply previews used to build a commit gate.",
+                "items": {"type": "object", "additionalProperties": True},
+            },
+            "confirmed_preview_ids": {
+                "type": "array",
+                "description": "Optional preview ids explicitly confirmed by the user.",
+                "items": {"type": "string"},
+            },
+            "user_confirmed": {
+                "type": "boolean",
+                "description": "Whether the user explicitly confirmed these previews.",
+            },
+            "approval": {
+                "type": "object",
+                "description": "Optional approval candidate report payload.",
+                "additionalProperties": True,
+            },
+            "candidates": {
+                "type": "array",
+                "description": "Optional approval candidates used to build previews.",
+                "items": {"type": "object", "additionalProperties": True},
+            },
+            "approved_candidate_ids": {
+                "type": "array",
+                "description": "Optional candidate ids confirmed for apply preview generation.",
+                "items": {"type": "string"},
+            },
+            "plan": {
+                "type": "object",
+                "description": "Optional evidence repair plan payload.",
+                "additionalProperties": True,
+            },
+            "repairs": {
+                "type": "array",
+                "description": "Optional repair items used to build candidates.",
+                "items": {"type": "object", "additionalProperties": True},
+            },
+            "gate": {
+                "type": "object",
+                "description": "Optional memory policy gate payload.",
+                "additionalProperties": True,
+            },
+            "audit": {
+                "type": "object",
+                "description": "Optional memory recall audit payload.",
+                "additionalProperties": True,
+            },
+            "diagnostics": {
+                "type": "object",
+                "description": "Optional memory recall diagnostics payload.",
+                "additionalProperties": True,
+            },
+            "policy": {
+                "type": "object",
+                "description": "Optional memory auto-policy payload.",
+                "additionalProperties": True,
+            },
+            "proposed_evidence": {
+                "type": "object",
+                "description": "Optional proposed evidence values keyed globally or by candidate id.",
+                "additionalProperties": True,
+            },
+            "format": {
+                "type": "string",
+                "enum": ["json", "markdown"],
+                "description": "Optional response format helper. JSON is always returned; markdown adds a readable summary field.",
+            },
+            "limit": {
+                "type": "integer",
+                "description": "Maximum snapshot requests to include. Defaults to all requests.",
+            },
+        },
+    },
+}
+
+
+def memory_evidence_repair_snapshot_planner_tool(
+    args: dict[str, Any],
+    **kwargs,
+) -> str:
+    if not isinstance(args, dict):
+        return tool_error("args must be an object.", success=False)
+
+    validated = _validate_args(args)
+    if validated is not None:
+        return validated
+
+    existing_snapshots = _existing_snapshots(args)
+    rollback_plan = _resolve_rollback_plan(args, kwargs.get("memory_manager"))
+    if isinstance(rollback_plan, str):
+        return rollback_plan
+
+    report = build_evidence_repair_snapshot_plan(
+        rollback_plan=rollback_plan,
+        existing_snapshots=existing_snapshots,
+    )
+
+    limit = _positive_int(args.get("limit"))
+    if limit is not None:
+        report = MemoryEvidenceRepairSnapshotPlan(
+            generated_at=report.generated_at,
+            requests=report.requests[:limit],
+        )
+
+    payload = report.to_dict()
+    if limit is not None:
+        payload["limited_to"] = limit
+    payload["success"] = True
+    payload["read_only"] = True
+    payload["read_only_memory"] = True
+    payload["would_mutate_memory"] = False
+    if str(args.get("format", "")).lower() == "markdown":
+        payload["markdown"] = _render_markdown(payload)
+    return json.dumps(payload, ensure_ascii=False)
+
+
+def _validate_args(args: dict[str, Any]) -> str | None:
+    object_fields = (
+        "rollback_plan",
+        "existing_snapshots",
+        "pre_commit_snapshots",
+        "ledger",
+        "commit_gate",
+        "preview",
+        "approval",
+        "plan",
+        "gate",
+        "audit",
+        "diagnostics",
+        "policy",
+        "proposed_evidence",
+    )
+    array_fields = (
+        "steps",
+        "entries",
+        "decisions",
+        "previews",
+        "confirmed_preview_ids",
+        "candidates",
+        "approved_candidate_ids",
+        "repairs",
+    )
+    for field_name in object_fields:
+        value = args.get(field_name)
+        if value is not None and not isinstance(value, dict):
+            return tool_error(f"{field_name} must be an object when provided.", success=False)
+    for field_name in array_fields:
+        value = args.get(field_name)
+        if value is not None and not isinstance(value, list):
+            return tool_error(f"{field_name} must be an array when provided.", success=False)
+    return None
+
+
+def _existing_snapshots(args: dict[str, Any]) -> dict[str, Any]:
+    if isinstance(args.get("existing_snapshots"), dict):
+        return args["existing_snapshots"]
+    if isinstance(args.get("pre_commit_snapshots"), dict):
+        return args["pre_commit_snapshots"]
+    return {}
+
+
+def _resolve_rollback_plan(
+    args: dict[str, Any],
+    memory_manager: Any,
+) -> dict[str, Any] | str:
+    explicit_plan = args.get("rollback_plan")
+    explicit_steps = args.get("steps")
+    if isinstance(explicit_plan, dict):
+        if "steps" in explicit_plan:
+            return explicit_plan
+        return {
+            "summary": {"rollback_step_count": 1},
+            "steps": [explicit_plan],
+            "read_only": True,
+            "read_only_memory": True,
+            "would_mutate_memory": False,
+        }
+    if isinstance(explicit_steps, list):
+        return {
+            "summary": {"rollback_step_count": len(explicit_steps)},
+            "steps": explicit_steps,
+            "read_only": True,
+            "read_only_memory": True,
+            "would_mutate_memory": False,
+        }
+
+    ledger = _resolve_ledger(args, memory_manager)
+    if isinstance(ledger, str):
+        return ledger
+    return build_evidence_repair_rollback_plan(
+        ledger=ledger,
+        pre_commit_snapshots=_existing_snapshots(args),
+    ).to_dict()
+
+
+def _resolve_ledger(args: dict[str, Any], memory_manager: Any) -> dict[str, Any] | str:
+    explicit_ledger = args.get("ledger")
+    explicit_entries = args.get("entries")
+    if isinstance(explicit_ledger, dict):
+        if "entries" in explicit_ledger:
+            return explicit_ledger
+        return {
+            "summary": {"entry_count": 1},
+            "entries": [explicit_ledger],
+            "read_only": True,
+            "read_only_memory": True,
+            "would_mutate_memory": False,
+        }
+    if isinstance(explicit_entries, list):
+        return {
+            "summary": {"entry_count": len(explicit_entries)},
+            "entries": explicit_entries,
+            "read_only": True,
+            "read_only_memory": True,
+            "would_mutate_memory": False,
+        }
+
+    commit_gate = _resolve_commit_gate(args, memory_manager)
+    if isinstance(commit_gate, str):
+        return commit_gate
+    return build_evidence_repair_commit_ledger(
+        commit_gate=commit_gate,
+        ledger_actor=str(args.get("ledger_actor") or "hermes"),
+        ledger_reason=str(args.get("ledger_reason") or ""),
+    ).to_dict()
+
+
+def _resolve_commit_gate(
+    args: dict[str, Any],
+    memory_manager: Any,
+) -> dict[str, Any] | str:
+    explicit_gate = args.get("commit_gate")
+    explicit_decisions = args.get("decisions")
+    if isinstance(explicit_gate, dict):
+        if "decisions" in explicit_gate:
+            return explicit_gate
+        return {
+            "summary": {"decision_count": 1},
+            "decisions": [explicit_gate],
+            "read_only": True,
+            "read_only_memory": True,
+            "would_mutate_memory": False,
+        }
+    if isinstance(explicit_decisions, list):
+        return {
+            "summary": {"decision_count": len(explicit_decisions)},
+            "decisions": explicit_decisions,
+            "read_only": True,
+            "read_only_memory": True,
+            "would_mutate_memory": False,
+        }
+
+    preview = _resolve_preview(args, memory_manager)
+    if isinstance(preview, str):
+        return preview
+    return build_evidence_repair_commit_gate(
+        preview=preview,
+        confirmed_preview_ids=(
+            args.get("confirmed_preview_ids")
+            if isinstance(args.get("confirmed_preview_ids"), list)
+            else None
+        ),
+        user_confirmed=bool(args.get("user_confirmed")),
+    ).to_dict()
+
+
+def _resolve_preview(args: dict[str, Any], memory_manager: Any) -> dict[str, Any] | str:
+    explicit_preview = args.get("preview")
+    explicit_previews = args.get("previews")
+    if isinstance(explicit_preview, dict):
+        if "previews" in explicit_preview:
+            return explicit_preview
+        return {
+            "summary": {"preview_count": 1},
+            "previews": [explicit_preview],
+            "read_only": True,
+            "read_only_memory": True,
+            "would_mutate_memory": False,
+        }
+    if isinstance(explicit_previews, list):
+        return {
+            "summary": {"preview_count": len(explicit_previews)},
+            "previews": explicit_previews,
+            "read_only": True,
+            "read_only_memory": True,
+            "would_mutate_memory": False,
+        }
+
+    approval = _resolve_approval(args, memory_manager)
+    if isinstance(approval, str):
+        return approval
+    return build_evidence_repair_apply_preview(
+        approval=approval,
+        approved_candidate_ids=(
+            args.get("approved_candidate_ids")
+            if isinstance(args.get("approved_candidate_ids"), list)
+            else None
+        ),
+        proposed_evidence=(
+            args.get("proposed_evidence")
+            if isinstance(args.get("proposed_evidence"), dict)
+            else {}
+        ),
+    ).to_dict()
+
+
+def _resolve_approval(args: dict[str, Any], memory_manager: Any) -> dict[str, Any] | str:
+    explicit_approval = args.get("approval")
+    explicit_candidates = args.get("candidates")
+    if isinstance(explicit_approval, dict):
+        return explicit_approval
+    if isinstance(explicit_candidates, list):
+        return {
+            "summary": {"candidate_count": len(explicit_candidates)},
+            "candidates": explicit_candidates,
+            "read_only": True,
+            "read_only_memory": True,
+        }
+
+    plan = _resolve_plan(args, memory_manager)
+    if isinstance(plan, str):
+        return plan
+    return build_evidence_repair_approval_candidates(
+        plan=plan,
+        proposed_evidence=(
+            args.get("proposed_evidence")
+            if isinstance(args.get("proposed_evidence"), dict)
+            else {}
+        ),
+    ).to_dict()
+
+
+def _resolve_plan(args: dict[str, Any], memory_manager: Any) -> dict[str, Any] | str:
+    explicit_plan = args.get("plan")
+    explicit_repairs = args.get("repairs")
+    if isinstance(explicit_plan, dict):
+        return explicit_plan
+    if isinstance(explicit_repairs, list):
+        return {
+            "summary": {"repair_count": len(explicit_repairs)},
+            "repairs": explicit_repairs,
+            "read_only": True,
+        }
+
+    gate = args.get("gate") if isinstance(args.get("gate"), dict) else _manager_dict(
+        memory_manager,
+        "last_memory_policy_gate",
+    )
+    audit = args.get("audit") if isinstance(args.get("audit"), dict) else _manager_dict(
+        memory_manager,
+        "last_recall_audit",
+    )
+    diagnostics = (
+        args.get("diagnostics")
+        if isinstance(args.get("diagnostics"), dict)
+        else _manager_dict(memory_manager, "last_recall_diagnostics")
+    )
+    policy = args.get("policy") if isinstance(args.get("policy"), dict) else _manager_dict(
+        memory_manager,
+        "last_memory_auto_policy",
+    )
+    return build_evidence_repair_plan(
+        gate=gate,
+        audit=audit,
+        diagnostics=diagnostics,
+        policy=policy,
+    ).to_dict()
+
+
+def _manager_dict(memory_manager: Any, method_name: str) -> dict[str, Any]:
+    if memory_manager is None or not hasattr(memory_manager, method_name):
+        return {}
+    try:
+        value = getattr(memory_manager, method_name)()
+    except Exception:
+        return {}
+    return dict(value) if isinstance(value, dict) else {}
+
+
+def _positive_int(value: Any) -> int | None:
+    if value is None:
+        return None
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed if parsed > 0 else None
+
+
+def _render_markdown(payload: dict[str, Any]) -> str:
+    summary = payload.get("summary", {})
+    lines = [
+        "### Memory Evidence Repair Snapshot Planner",
+        f"- Requests: {summary.get('snapshot_request_count', 0)}",
+        f"- Capture required: {summary.get('capture_required_count', 0)}",
+        f"- Already available: {summary.get('already_available_count', 0)}",
+        f"- Blocking: {summary.get('blocking_count', 0)}",
+    ]
+    for index, request in enumerate(payload.get("requests", []), start=1):
+        provider = request.get("provider") or "memory"
+        lines.append(
+            f"{index}. [{request.get('status')}] "
+            f"{request.get('snapshot_action')} provider={provider}"
+        )
+        fields = request.get("evidence_fields") or []
+        if fields:
+            lines.append(f"   Capture: {', '.join(str(item) for item in fields)}")
+        verify = request.get("verification_steps") or []
+        if verify:
+            lines.append(f"   Verify: {', '.join(str(item) for item in verify)}")
+    return "\n".join(lines)
+
+
+def check_memory_evidence_repair_snapshot_planner_requirements() -> bool:
+    return True
+
+
+registry.register(
+    name="memory_evidence_repair_snapshot_planner",
+    toolset="memory",
+    schema=MEMORY_EVIDENCE_REPAIR_SNAPSHOT_PLANNER_SCHEMA,
+    handler=memory_evidence_repair_snapshot_planner_tool,
+    check_fn=check_memory_evidence_repair_snapshot_planner_requirements,
+    emoji="🧠",
+)

--- a/tools/memory_evidence_repair_write_lock_gate_tool.py
+++ b/tools/memory_evidence_repair_write_lock_gate_tool.py
@@ -1,0 +1,256 @@
+"""Read-only Memory Evidence Repair Write Lock Gate tool."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from agent.memory_evidence_repair_write_lock_gate import (
+    build_evidence_repair_write_lock_gate,
+)
+from tools.memory_evidence_repair_commit_receipt_tool import (
+    MEMORY_EVIDENCE_REPAIR_COMMIT_RECEIPT_SCHEMA,
+    memory_evidence_repair_commit_receipt_tool,
+)
+from tools.registry import registry, tool_error
+
+
+_UPSTREAM_PROPERTIES = dict(
+    MEMORY_EVIDENCE_REPAIR_COMMIT_RECEIPT_SCHEMA["parameters"]["properties"]
+)
+_UPSTREAM_PROPERTIES.pop("format", None)
+
+MEMORY_EVIDENCE_REPAIR_WRITE_LOCK_GATE_SCHEMA = {
+    "name": "memory_evidence_repair_write_lock_gate",
+    "description": (
+        "Read-only write-lock and executor dry-run gate for memory evidence "
+        "repair manual commits. It never mutates durable memory."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "commit_receipt": {
+                "type": "object",
+                "description": "Optional commit receipt report payload.",
+                "additionalProperties": True,
+            },
+            "receipt": {
+                "type": "object",
+                "description": "Optional single commit receipt payload.",
+                "additionalProperties": True,
+            },
+            "active_locks": {
+                "type": "array",
+                "description": "Optional active write-lock records to check for conflicts.",
+                "items": {"type": "object", "additionalProperties": True},
+            },
+            "locks": {
+                "type": "array",
+                "description": "Alias for active_locks.",
+                "items": {"type": "object", "additionalProperties": True},
+            },
+            "already_used_token_ids": {
+                "type": "array",
+                "description": "External used-token ids to check before drafting a write lock.",
+                "items": {"type": "string"},
+            },
+            "lock_owner": {
+                "type": "string",
+                "description": "Owner label for the future write-lock draft.",
+            },
+            "lock_ttl_minutes": {
+                "type": "integer",
+                "description": "Write-lock draft TTL in minutes. Defaults to 10.",
+            },
+            "format": {
+                "type": "string",
+                "enum": ["json", "markdown"],
+                "description": "Optional response format helper. JSON is always returned; markdown adds a readable summary field.",
+            },
+            **_UPSTREAM_PROPERTIES,
+        },
+    },
+}
+
+
+def memory_evidence_repair_write_lock_gate_tool(
+    args: dict[str, Any],
+    **kwargs,
+) -> str:
+    if not isinstance(args, dict):
+        return tool_error("args must be an object.", success=False)
+
+    validated = _validate_args(args)
+    if validated is not None:
+        return validated
+
+    commit_receipt = _resolve_commit_receipt(args, kwargs.get("memory_manager"))
+    if isinstance(commit_receipt, str):
+        return commit_receipt
+
+    payload = build_evidence_repair_write_lock_gate(
+        commit_receipt=commit_receipt,
+        active_locks=_active_locks(args),
+        already_used_token_ids=(
+            args.get("already_used_token_ids")
+            if isinstance(args.get("already_used_token_ids"), list)
+            else None
+        ),
+        lock_owner=str(args.get("lock_owner") or args.get("actor") or "human"),
+        lock_ttl_minutes=args.get("lock_ttl_minutes") or 10,
+        current_time=args.get("current_time"),
+    ).to_dict()
+    payload["success"] = True
+    payload["read_only"] = True
+    payload["read_only_memory"] = True
+    payload["would_mutate_memory"] = False
+    if str(args.get("format", "")).lower() == "markdown":
+        payload["markdown"] = _render_markdown(payload)
+    return json.dumps(payload, ensure_ascii=False)
+
+
+def _validate_args(args: dict[str, Any]) -> str | None:
+    object_fields = (
+        "commit_receipt",
+        "receipt",
+        "token_gate",
+        "approval_token_gate",
+        "approval_token",
+        "token",
+        "dry_run",
+        "snapshot_plan",
+        "rollback_plan",
+        "existing_snapshots",
+        "pre_commit_snapshots",
+        "ledger",
+        "commit_gate",
+        "preview",
+        "approval",
+        "plan",
+        "gate",
+        "audit",
+        "diagnostics",
+        "policy",
+        "proposed_evidence",
+    )
+    array_fields = (
+        "active_locks",
+        "locks",
+        "already_used_token_ids",
+        "tokens",
+        "used_token_ids",
+        "receipts",
+        "requests",
+        "steps",
+        "entries",
+        "decisions",
+        "previews",
+        "confirmed_preview_ids",
+        "candidates",
+        "approved_candidate_ids",
+        "repairs",
+    )
+    for field_name in object_fields:
+        value = args.get(field_name)
+        if value is not None and not isinstance(value, dict):
+            return tool_error(f"{field_name} must be an object when provided.", success=False)
+    existing_receipts = args.get("existing_receipts")
+    if existing_receipts is not None and not isinstance(existing_receipts, (dict, list)):
+        return tool_error(
+            "existing_receipts must be an object or array when provided.",
+            success=False,
+        )
+    for field_name in array_fields:
+        value = args.get(field_name)
+        if value is not None and not isinstance(value, list):
+            return tool_error(f"{field_name} must be an array when provided.", success=False)
+    return None
+
+
+def _resolve_commit_receipt(
+    args: dict[str, Any],
+    memory_manager: Any,
+) -> dict[str, Any] | str:
+    explicit_report = args.get("commit_receipt")
+    if isinstance(explicit_report, dict):
+        return explicit_report
+
+    explicit_receipt = args.get("receipt")
+    if isinstance(explicit_receipt, dict):
+        return {
+            "status": explicit_receipt.get("status"),
+            "summary": {"receipt_count": 1},
+            "receipts": [explicit_receipt],
+            "read_only": True,
+            "read_only_memory": True,
+            "would_mutate_memory": False,
+        }
+
+    receipt_args = dict(args)
+    for field_name in (
+        "commit_receipt",
+        "receipt",
+        "active_locks",
+        "locks",
+        "already_used_token_ids",
+        "lock_owner",
+        "lock_ttl_minutes",
+        "format",
+    ):
+        receipt_args.pop(field_name, None)
+    result = memory_evidence_repair_commit_receipt_tool(
+        receipt_args,
+        memory_manager=memory_manager,
+    )
+    try:
+        payload = json.loads(result)
+    except json.JSONDecodeError:
+        return tool_error("commit receipt tool returned invalid JSON.", success=False)
+    if not isinstance(payload, dict):
+        return tool_error("commit receipt tool returned a non-object payload.", success=False)
+    if payload.get("success") is False:
+        return json.dumps(payload, ensure_ascii=False)
+    return payload
+
+
+def _active_locks(args: dict[str, Any]) -> list[dict[str, Any]]:
+    if isinstance(args.get("active_locks"), list):
+        return args["active_locks"]
+    if isinstance(args.get("locks"), list):
+        return args["locks"]
+    return []
+
+
+def _render_markdown(payload: dict[str, Any]) -> str:
+    summary = payload.get("summary", {})
+    lines = [
+        "### Memory Evidence Repair Write Lock Gate",
+        f"- Status: {payload.get('status')}",
+        f"- Checks: {summary.get('check_count', 0)}",
+        f"- Locks: {summary.get('lock_count', 0)}",
+        f"- Conflicts: {summary.get('active_lock_conflict_count', 0)}",
+        f"- Executor dry-run allowed: {summary.get('executor_dry_run_allowed', False)}",
+    ]
+    for lock in payload.get("locks", []):
+        lines.append(f"- Lock: {lock.get('id')}")
+        lines.append(f"  Receipt: {lock.get('receipt_id')}")
+        lines.append(f"  Expires: {lock.get('expires_at')}")
+    for reason in payload.get("blocking_reasons", []):
+        lines.append(f"- Blocked: {reason}")
+    for action in payload.get("required_actions", []):
+        lines.append(f"- Required: {action}")
+    return "\n".join(lines)
+
+
+def check_memory_evidence_repair_write_lock_gate_requirements() -> bool:
+    return True
+
+
+registry.register(
+    name="memory_evidence_repair_write_lock_gate",
+    toolset="memory",
+    schema=MEMORY_EVIDENCE_REPAIR_WRITE_LOCK_GATE_SCHEMA,
+    handler=memory_evidence_repair_write_lock_gate_tool,
+    check_fn=check_memory_evidence_repair_write_lock_gate_requirements,
+    emoji="🧠",
+)


### PR DESCRIPTION
## Summary
- Adds the Memory Evidence Repair governance workflow on a clean branch based on `origin/main`.
- Introduces read-only/preview-first repair planning, approval token gates, commit receipts, write-lock gates, recovery execution previews, closure ledgers, governance seals, and finalization readiness previews.
- Adds tool wrappers and focused tests for the full evidence repair governance chain.

## Relation to previous work
- This clean PR is based on `origin/main` instead of the stacked branch.
- The stacked draft PR remains available at johns25chen/hermes-agent#1 for comparison.
- PR #29362 is still related policy-governance work, but this branch cherry-picks only the evidence repair commit onto current main.

## Test Plan
- `.venv/bin/python -m py_compile agent/memory_evidence_repair*.py tools/memory_evidence_repair*.py tests/agent/test_memory_evidence_repair*.py tests/tools/test_memory_evidence_repair*.py`
- `.venv/bin/python -m pytest tests/agent/test_memory_evidence_repair*.py tests/tools/test_memory_evidence_repair*.py -q -o 'addopts=' --tb=short`

Result: 401 passed in 3.80s.

## Governance / safety notes
- Does not write real Memory Graph data.
- Does not modify config.
- Keeps `website/docs/guides/share-hermes-memory-with-codex-openclaw.md` out of this PR.
