### PR TITLE
fix: keep approval prompts out of terminal tool errors

### DIFF
--- a/tests/tools/test_terminal_approval_contract.py
+++ b/tests/tools/test_terminal_approval_contract.py
@@ -1,0 +1,82 @@
+import json
+from unittest.mock import MagicMock
+
+
+def _make_env_config(tmp_path):
+    return {
+        "env_type": "local",
+        "timeout": 30,
+        "cwd": str(tmp_path),
+        "host_cwd": None,
+        "modal_mode": "auto",
+        "docker_image": "",
+        "singularity_image": "",
+        "modal_image": "",
+        "daytona_image": "",
+    }
+
+
+def _run_terminal(monkeypatch, tmp_path, approval):
+    import tools.terminal_tool as terminal_tool_module
+
+    mock_env = MagicMock()
+
+    monkeypatch.setattr(
+        terminal_tool_module, "_get_env_config", lambda: _make_env_config(tmp_path)
+    )
+    monkeypatch.setattr(terminal_tool_module, "_start_cleanup_thread", lambda: None)
+    monkeypatch.setattr(
+        terminal_tool_module,
+        "_check_all_guards",
+        lambda *_args, **_kwargs: approval,
+    )
+    monkeypatch.setitem(terminal_tool_module._active_environments, "default", mock_env)
+    monkeypatch.setitem(terminal_tool_module._last_activity, "default", 0.0)
+
+    result = json.loads(terminal_tool_module.terminal_tool(command="rm -rf /tmp/demo"))
+    return result, mock_env
+
+
+def test_pending_approval_uses_short_error_and_preserves_human_prompt(monkeypatch, tmp_path):
+    approval = {
+        "approved": False,
+        "status": "pending_approval",
+        "command": "rm -rf /tmp/demo",
+        "description": "dangerous deletion",
+        "pattern_key": "dangerous:rm_rf",
+        "message": "WARNING: Asking the user for approval.\n\nrm -rf /tmp/demo",
+    }
+
+    result, mock_env = _run_terminal(monkeypatch, tmp_path, approval)
+
+    assert result["status"] == "pending_approval"
+    assert result["approval_pending"] is True
+    assert result["error"] == "Command blocked pending user approval."
+    assert "Asking the user for approval" not in result["error"]
+    assert result["approval_message"] == approval["message"]
+    assert result["description"] == "dangerous deletion"
+    assert result["pattern_key"] == "dangerous:rm_rf"
+    mock_env.execute.assert_not_called()
+
+
+def test_blocked_approval_keeps_structure_without_leaking_warning_text(monkeypatch, tmp_path):
+    approval = {
+        "approved": False,
+        "status": "blocked",
+        "description": "dangerous deletion",
+        "pattern_key": "dangerous:rm_rf",
+        "message": "BLOCKED: Command denied by user. Do NOT retry this command.",
+    }
+
+    result, mock_env = _run_terminal(monkeypatch, tmp_path, approval)
+
+    assert result["status"] == "blocked"
+    assert result["error"] == (
+        "Command denied: dangerous deletion. "
+        "Use the approval prompt to allow it, or rephrase the command."
+    )
+    assert result["approval_message"] == approval["message"]
+    assert result["description"] == "dangerous deletion"
+    assert result["pattern_key"] == "dangerous:rm_rf"
+    assert "Do NOT retry this command" not in result["error"]
+    mock_env.execute.assert_not_called()

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1862,29 +1862,37 @@ def terminal_tool(
         if not force:
             approval = _check_all_guards(command, env_type)
             if not approval["approved"]:
-                # Check if this is an approval_required (gateway ask mode)
-                if approval.get("status") == "pending_approval":
+                approval_status = approval.get("status")
+                approval_message = approval.get("message")
+                approval_description = approval.get("description", "command flagged")
+                approval_pattern_key = approval.get("pattern_key", "")
+                # Keep the model-facing error terse and typed; the verbose
+                # human approval prompt stays in approval_message.
+                if approval_status in {"approval_required", "pending_approval"}:
                     return json.dumps({
                         "output": "",
                         "exit_code": -1,
-                        "error": "",
+                        "error": "Command blocked pending user approval.",
                         "status": "pending_approval",
                         "approval_pending": True,
                         "command": approval.get("command", command),
-                        "description": approval.get("description", "command flagged"),
-                        "pattern_key": approval.get("pattern_key", ""),
+                        "description": approval_description,
+                        "pattern_key": approval_pattern_key,
+                        "approval_message": approval_message,
                     }, ensure_ascii=False)
                 # Command was blocked
-                desc = approval.get("description", "command flagged")
                 fallback_msg = (
-                    f"Command denied: {desc}. "
+                    f"Command denied: {approval_description}. "
                     "Use the approval prompt to allow it, or rephrase the command."
                 )
                 return json.dumps({
                     "output": "",
                     "exit_code": -1,
-                    "error": approval.get("message", fallback_msg),
-                    "status": "blocked"
+                    "error": fallback_msg,
+                    "status": "blocked",
+                    "description": approval_description,
+                    "pattern_key": approval_pattern_key,
+                    "approval_message": approval_message,
                 }, ensure_ascii=False)
             # Track whether approval was explicitly granted by the user
             if approval.get("user_approved"):


### PR DESCRIPTION
## Summary
- keep terminal-tool approval failures model-safe by returning a short typed error for pending approvals
- preserve the verbose human-facing approval prompt separately as `approval_message`
- keep blocked approval responses structured with `description` and `pattern_key` instead of leaking the warning text into `error`
- add a regression test covering both pending and blocked approval contracts

Fixes #29511.

## Test
- uv run --frozen pytest -q -o addopts= tests/tools/test_terminal_approval_contract.py tests/gateway/test_approve_deny_commands.py
- uv run --frozen ruff check tools/terminal_tool.py tests/tools/test_terminal_approval_contract.py
- git diff --check