### PR TITLE
fix(background_review): inherit parent's toolset config to keep tools[] cache-stable (~50% fewer cache-write tokens on long sessions)

### DIFF
--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -390,24 +390,9 @@ def _run_review_in_thread(
             # parent below so memory(action="add") writes from
             # the review still land on disk; the review just
             # has zero side effects on external providers.
-            # Inherit the parent's toolset configuration so the review
-            # fork's outbound request body has byte-identical ``tools[]``
-            # with the parent's last main-turn request. Without this,
-            # ``enabled_toolsets=None`` defaults to "all registered tools"
-            # and the fork transmits every tool descriptor (including any
-            # the user has disabled via ``hermes tools disable``), while
-            # the parent transmits only its narrower configured set —
-            # making the two requests diverge in ``tools[]`` even though
-            # they share ``messages[0..N]`` and ``system`` byte-for-byte.
-            # Anthropic's prompt-cache key includes ``tools[]``, so any
-            # divergence forks the cache lineage and forces a full
-            # prefix rewrite (~100-200K tokens per turn for long convs).
-            # The post-construction whitelist (``set_thread_tool_whitelist``
-            # below) still restricts which tools the model is allowed
-            # to dispatch — this change only aligns what the request
-            # body transmits, not what the review is allowed to do.
-            # This extends the byte-stability invariant established by
-            # PR #17276 (which fixed ``system``) to ``tools[]``.
+            # Match parent's toolset config so ``tools[]`` is byte-identical
+            # in the request body — Anthropic's cache key includes it.
+            # (The runtime whitelist below still restricts dispatch.)
             review_agent = AIAgent(
                 model=agent.model,
                 max_iterations=16,

--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -390,6 +390,24 @@ def _run_review_in_thread(
             # parent below so memory(action="add") writes from
             # the review still land on disk; the review just
             # has zero side effects on external providers.
+            # Inherit the parent's toolset configuration so the review
+            # fork's outbound request body has byte-identical ``tools[]``
+            # with the parent's last main-turn request. Without this,
+            # ``enabled_toolsets=None`` defaults to "all registered tools"
+            # and the fork transmits every tool descriptor (including any
+            # the user has disabled via ``hermes tools disable``), while
+            # the parent transmits only its narrower configured set —
+            # making the two requests diverge in ``tools[]`` even though
+            # they share ``messages[0..N]`` and ``system`` byte-for-byte.
+            # Anthropic's prompt-cache key includes ``tools[]``, so any
+            # divergence forks the cache lineage and forces a full
+            # prefix rewrite (~100-200K tokens per turn for long convs).
+            # The post-construction whitelist (``set_thread_tool_whitelist``
+            # below) still restricts which tools the model is allowed
+            # to dispatch — this change only aligns what the request
+            # body transmits, not what the review is allowed to do.
+            # This extends the byte-stability invariant established by
+            # PR #17276 (which fixed ``system``) to ``tools[]``.
             review_agent = AIAgent(
                 model=agent.model,
                 max_iterations=16,
@@ -401,6 +419,8 @@ def _run_review_in_thread(
                 api_key=_parent_runtime.get("api_key") or None,
                 credential_pool=getattr(agent, "_credential_pool", None),
                 parent_session_id=agent.session_id,
+                enabled_toolsets=getattr(agent, "enabled_toolsets", None),
+                disabled_toolsets=getattr(agent, "disabled_toolsets", None),
                 skip_memory=True,
             )
             review_agent._memory_write_origin = "background_review"

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -713,6 +713,7 @@ AUTHOR_MAP = {
     "9219265+cresslank@users.noreply.github.com": "cresslank",
     "trevmanthony@gmail.com": "trevthefoolish",
     "ziliangpeng@users.noreply.github.com": "ziliangpeng",
+    "ziliangdotme@gmail.com": "ziliangpeng",
     "centripetal-star@users.noreply.github.com": "centripetal-star",
     "LeonSGP43@users.noreply.github.com": "LeonSGP43",
     "154585401+LeonSGP43@users.noreply.github.com": "LeonSGP43",

--- a/tests/run_agent/test_background_review_cache_parity.py
+++ b/tests/run_agent/test_background_review_cache_parity.py
@@ -38,11 +38,7 @@ def _make_agent_stub(agent_cls):
     agent._MEMORY_REVIEW_PROMPT = "review memory"
     agent._SKILL_REVIEW_PROMPT = "review skills"
     agent._COMBINED_REVIEW_PROMPT = "review both"
-    # Parent's toolset configuration — must be propagated to the review
-    # fork so ``tools[]`` matches byte-for-byte. Without these set on the
-    # stub, ``getattr(agent, ..., None)`` would return None on both sides
-    # and the test wouldn't catch a regression where the fork is built
-    # without the kwargs at all.
+    # Non-None so the test catches a missing-kwarg regression.
     agent.enabled_toolsets = ["memory", "skills", "terminal"]
     agent.disabled_toolsets = ["spotify", "feishu_doc"]
     return agent
@@ -193,21 +189,7 @@ def test_review_fork_pins_session_start_and_session_id():
 
 
 def test_review_fork_inherits_parent_toolset_config():
-    """The review fork must receive ``enabled_toolsets`` / ``disabled_toolsets``
-    from the parent so the outbound request body's ``tools[]`` field matches
-    byte-for-byte.
-
-    Without this, ``enabled_toolsets=None`` defaults to "all registered tools"
-    and the fork sends every tool descriptor (e.g. Spotify, Feishu, video)
-    even when the parent disabled them via ``hermes tools disable``. Anthropic's
-    prompt cache keys on the byte-exact ``tools[]`` array, so divergence here
-    forks the cache lineage and forces a full prefix rewrite per nudge
-    (~100-200 K cache-write tokens for long conversations).
-
-    This is the same byte-stability invariant as
-    ``test_review_fork_inherits_parent_cached_system_prompt`` but for the
-    ``tools[]`` slot of the request body, not the ``system`` slot.
-    """
+    """``tools[]`` byte-stability: fork must inherit parent's toolset config."""
     import run_agent
 
     agent = _make_agent_stub(run_agent.AIAgent)
@@ -218,7 +200,6 @@ def test_review_fork_inherits_parent_toolset_config():
         def __init__(self, *args, **kwargs):
             captured["enabled_toolsets"] = kwargs.get("enabled_toolsets")
             captured["disabled_toolsets"] = kwargs.get("disabled_toolsets")
-            # Minimal post-init attrs the surrounding code touches.
             self._cached_system_prompt = None
             self._memory_write_origin = None
             self._memory_write_context = None
@@ -249,14 +230,10 @@ def test_review_fork_inherits_parent_toolset_config():
         )
 
     assert captured.get("enabled_toolsets") == agent.enabled_toolsets, (
-        f"Review fork did not receive parent's enabled_toolsets. "
-        f"Got {captured.get('enabled_toolsets')!r}, expected {agent.enabled_toolsets!r}. "
-        "This causes ``tools[]`` to diverge between main turns and review nudges, "
-        "breaking Anthropic prompt-cache parity."
+        f"enabled_toolsets mismatch: {captured.get('enabled_toolsets')!r} "
+        f"vs expected {agent.enabled_toolsets!r}"
     )
     assert captured.get("disabled_toolsets") == agent.disabled_toolsets, (
-        f"Review fork did not receive parent's disabled_toolsets. "
-        f"Got {captured.get('disabled_toolsets')!r}, expected {agent.disabled_toolsets!r}. "
-        "This causes ``tools[]`` to diverge between main turns and review nudges, "
-        "breaking Anthropic prompt-cache parity."
+        f"disabled_toolsets mismatch: {captured.get('disabled_toolsets')!r} "
+        f"vs expected {agent.disabled_toolsets!r}"
     )

--- a/tests/run_agent/test_background_review_cache_parity.py
+++ b/tests/run_agent/test_background_review_cache_parity.py
@@ -38,6 +38,13 @@ def _make_agent_stub(agent_cls):
     agent._MEMORY_REVIEW_PROMPT = "review memory"
     agent._SKILL_REVIEW_PROMPT = "review skills"
     agent._COMBINED_REVIEW_PROMPT = "review both"
+    # Parent's toolset configuration — must be propagated to the review
+    # fork so ``tools[]`` matches byte-for-byte. Without these set on the
+    # stub, ``getattr(agent, ..., None)`` would return None on both sides
+    # and the test wouldn't catch a regression where the fork is built
+    # without the kwargs at all.
+    agent.enabled_toolsets = ["memory", "skills", "terminal"]
+    agent.disabled_toolsets = ["spotify", "feishu_doc"]
     return agent
 
 
@@ -182,4 +189,74 @@ def test_review_fork_pins_session_start_and_session_id():
     assert captured.get("session_id") == agent.session_id, (
         "Review fork did not inherit parent's session_id — "
         "system-prompt rebuild paths would diverge."
+    )
+
+
+def test_review_fork_inherits_parent_toolset_config():
+    """The review fork must receive ``enabled_toolsets`` / ``disabled_toolsets``
+    from the parent so the outbound request body's ``tools[]`` field matches
+    byte-for-byte.
+
+    Without this, ``enabled_toolsets=None`` defaults to "all registered tools"
+    and the fork sends every tool descriptor (e.g. Spotify, Feishu, video)
+    even when the parent disabled them via ``hermes tools disable``. Anthropic's
+    prompt cache keys on the byte-exact ``tools[]`` array, so divergence here
+    forks the cache lineage and forces a full prefix rewrite per nudge
+    (~100-200 K cache-write tokens for long conversations).
+
+    This is the same byte-stability invariant as
+    ``test_review_fork_inherits_parent_cached_system_prompt`` but for the
+    ``tools[]`` slot of the request body, not the ``system`` slot.
+    """
+    import run_agent
+
+    agent = _make_agent_stub(run_agent.AIAgent)
+
+    captured = {}
+
+    class _Recorder:
+        def __init__(self, *args, **kwargs):
+            captured["enabled_toolsets"] = kwargs.get("enabled_toolsets")
+            captured["disabled_toolsets"] = kwargs.get("disabled_toolsets")
+            # Minimal post-init attrs the surrounding code touches.
+            self._cached_system_prompt = None
+            self._memory_write_origin = None
+            self._memory_write_context = None
+            self._memory_store = None
+            self._memory_enabled = None
+            self._user_profile_enabled = None
+            self._memory_nudge_interval = None
+            self._skill_nudge_interval = None
+            self.suppress_status_output = None
+            self.session_start = None
+            self.session_id = None
+
+        def run_conversation(self, *args, **kwargs):
+            raise RuntimeError("stop after recording — don't actually call the API")
+
+        def shutdown_memory_provider(self):
+            pass
+
+        def close(self):
+            pass
+
+    with patch.object(run_agent, "AIAgent", _Recorder), \
+         patch("threading.Thread", _SyncThread):
+        agent._spawn_background_review(
+            messages_snapshot=[],
+            review_memory=True,
+            review_skills=False,
+        )
+
+    assert captured.get("enabled_toolsets") == agent.enabled_toolsets, (
+        f"Review fork did not receive parent's enabled_toolsets. "
+        f"Got {captured.get('enabled_toolsets')!r}, expected {agent.enabled_toolsets!r}. "
+        "This causes ``tools[]`` to diverge between main turns and review nudges, "
+        "breaking Anthropic prompt-cache parity."
+    )
+    assert captured.get("disabled_toolsets") == agent.disabled_toolsets, (
+        f"Review fork did not receive parent's disabled_toolsets. "
+        f"Got {captured.get('disabled_toolsets')!r}, expected {agent.disabled_toolsets!r}. "
+        "This causes ``tools[]`` to diverge between main turns and review nudges, "
+        "breaking Anthropic prompt-cache parity."
     )

--- a/tests/run_agent/test_background_review_toolset_restriction.py
+++ b/tests/run_agent/test_background_review_toolset_restriction.py
@@ -38,11 +38,7 @@ def _make_agent_stub(agent_cls):
     agent._MEMORY_REVIEW_PROMPT = "review memory"
     agent._SKILL_REVIEW_PROMPT = "review skills"
     agent._COMBINED_REVIEW_PROMPT = "review both"
-    # Parent's toolset configuration must propagate to the review fork
-    # so the request body's ``tools[]`` array is byte-identical. Without
-    # propagation, ``enabled_toolsets=None`` expands to "all registered
-    # tools" — which diverges from a parent that narrowed its set via
-    # ``hermes tools disable`` or config.
+    # Non-None so the test catches a missing-kwarg regression.
     agent.enabled_toolsets = ["memory", "skills", "terminal"]
     agent.disabled_toolsets = ["spotify", "feishu_doc"]
     return agent
@@ -60,25 +56,7 @@ class _SyncThread:
 
 
 def test_background_review_matches_parent_toolset_config():
-    """The review fork must propagate the parent's ``enabled_toolsets`` to AIAgent.
-
-    Earlier guidance (the old "do NOT pass enabled_toolsets" rule) assumed the
-    parent always ran with the registry default. In practice the parent is
-    often narrowed via ``hermes tools disable`` or ``config.yaml``, and
-    leaving ``enabled_toolsets=None`` on the fork makes it expand to ALL
-    registered tools — which is what *diverges* from the parent and breaks
-    Anthropic's prefix cache key on ``tools[]``.
-
-    The correct rule is symmetric: whatever the parent has, the fork
-    must have the same. When the parent's value is ``None``, the fork's
-    must also be ``None`` (and they'll both expand identically). When
-    the parent narrows, the fork inherits the narrowed set verbatim.
-
-    (Schema-level alignment with the parent + post-construction runtime
-    whitelist remain the safety contract for #15204 — the whitelist
-    blocks dispatch of non-memory/skill tools regardless of what schemas
-    are sent over the wire.)
-    """
+    """Fork must receive parent's toolset config so ``tools[]`` cache key matches."""
     import run_agent
 
     agent = _make_agent_stub(run_agent.AIAgent)
@@ -98,18 +76,13 @@ def test_background_review_matches_parent_toolset_config():
         )
 
     assert "enabled_toolsets" in captured, "AIAgent.__init__ was not called"
-    # The kwargs must equal the parent's so the ``tools[]`` request-body
-    # bytes match the parent's last main-turn request.
     assert captured["enabled_toolsets"] == agent.enabled_toolsets, (
-        f"Review fork did not propagate parent's enabled_toolsets "
-        f"(got {captured['enabled_toolsets']!r}, expected {agent.enabled_toolsets!r}). "
-        "This causes ``tools[]`` to diverge from the parent — Anthropic's "
-        "prompt-cache key includes ``tools[]``, so divergence forks the "
-        "cache lineage and forces a full prefix rewrite per nudge."
+        f"enabled_toolsets mismatch: {captured['enabled_toolsets']!r} "
+        f"vs expected {agent.enabled_toolsets!r}"
     )
     assert captured["disabled_toolsets"] == agent.disabled_toolsets, (
-        f"Review fork did not propagate parent's disabled_toolsets "
-        f"(got {captured['disabled_toolsets']!r}, expected {agent.disabled_toolsets!r})."
+        f"disabled_toolsets mismatch: {captured['disabled_toolsets']!r} "
+        f"vs expected {agent.disabled_toolsets!r}"
     )
 
 

--- a/tests/run_agent/test_background_review_toolset_restriction.py
+++ b/tests/run_agent/test_background_review_toolset_restriction.py
@@ -38,6 +38,13 @@ def _make_agent_stub(agent_cls):
     agent._MEMORY_REVIEW_PROMPT = "review memory"
     agent._SKILL_REVIEW_PROMPT = "review skills"
     agent._COMBINED_REVIEW_PROMPT = "review both"
+    # Parent's toolset configuration must propagate to the review fork
+    # so the request body's ``tools[]`` array is byte-identical. Without
+    # propagation, ``enabled_toolsets=None`` expands to "all registered
+    # tools" — which diverges from a parent that narrowed its set via
+    # ``hermes tools disable`` or config.
+    agent.enabled_toolsets = ["memory", "skills", "terminal"]
+    agent.disabled_toolsets = ["spotify", "feishu_doc"]
     return agent
 
 
@@ -52,12 +59,25 @@ class _SyncThread:
             self._target()
 
 
-def test_background_review_does_not_narrow_toolset_schema():
-    """The review fork must NOT pass enabled_toolsets to AIAgent.
+def test_background_review_matches_parent_toolset_config():
+    """The review fork must propagate the parent's ``enabled_toolsets`` to AIAgent.
 
-    Narrowing the schema diverges the ``tools`` cache key from the parent's,
-    which sits above ``system`` in Anthropic's cache hierarchy and forces a
-    full prefix-cache miss on every review (see #25322, PR #17276).
+    Earlier guidance (the old "do NOT pass enabled_toolsets" rule) assumed the
+    parent always ran with the registry default. In practice the parent is
+    often narrowed via ``hermes tools disable`` or ``config.yaml``, and
+    leaving ``enabled_toolsets=None`` on the fork makes it expand to ALL
+    registered tools — which is what *diverges* from the parent and breaks
+    Anthropic's prefix cache key on ``tools[]``.
+
+    The correct rule is symmetric: whatever the parent has, the fork
+    must have the same. When the parent's value is ``None``, the fork's
+    must also be ``None`` (and they'll both expand identically). When
+    the parent narrows, the fork inherits the narrowed set verbatim.
+
+    (Schema-level alignment with the parent + post-construction runtime
+    whitelist remain the safety contract for #15204 — the whitelist
+    blocks dispatch of non-memory/skill tools regardless of what schemas
+    are sent over the wire.)
     """
     import run_agent
 
@@ -66,6 +86,7 @@ def test_background_review_does_not_narrow_toolset_schema():
 
     def _capture_init(self, *args, **kwargs):
         captured["enabled_toolsets"] = kwargs.get("enabled_toolsets", "UNSET")
+        captured["disabled_toolsets"] = kwargs.get("disabled_toolsets", "UNSET")
         raise RuntimeError("stop after capturing init args")
 
     with patch.object(run_agent.AIAgent, "__init__", _capture_init), \
@@ -77,11 +98,18 @@ def test_background_review_does_not_narrow_toolset_schema():
         )
 
     assert "enabled_toolsets" in captured, "AIAgent.__init__ was not called"
-    # The kwarg must be absent — letting AIAgent inherit the default full
-    # toolset so the schema bytes match the parent's.
-    assert captured["enabled_toolsets"] == "UNSET", (
-        f"Review fork narrowed the toolset schema (got {captured['enabled_toolsets']!r}), "
-        "which breaks prefix-cache parity with the parent."
+    # The kwargs must equal the parent's so the ``tools[]`` request-body
+    # bytes match the parent's last main-turn request.
+    assert captured["enabled_toolsets"] == agent.enabled_toolsets, (
+        f"Review fork did not propagate parent's enabled_toolsets "
+        f"(got {captured['enabled_toolsets']!r}, expected {agent.enabled_toolsets!r}). "
+        "This causes ``tools[]`` to diverge from the parent — Anthropic's "
+        "prompt-cache key includes ``tools[]``, so divergence forks the "
+        "cache lineage and forces a full prefix rewrite per nudge."
+    )
+    assert captured["disabled_toolsets"] == agent.disabled_toolsets, (
+        f"Review fork did not propagate parent's disabled_toolsets "
+        f"(got {captured['disabled_toolsets']!r}, expected {agent.disabled_toolsets!r})."
     )
 
 


### PR DESCRIPTION
# fix(background_review): inherit parent's toolset config to keep `tools[]` cache-stable

## Summary

Fixes #29567. The background skill/memory-review fork (`agent/background_review.py`) constructs its child `AIAgent` without propagating `enabled_toolsets` / `disabled_toolsets` from the parent. When the parent's toolset is narrowed from the registry default (e.g. via `hermes tools disable` or `config.yaml`), the fork's default `enabled_toolsets=None` expands to "all registered tools" and the fork's outbound `tools[]` becomes a strict superset of the parent's. Anthropic's prompt-cache key includes the `tools[]` array byte-for-byte, so the divergence forks the cache lineage and forces a full prefix rewrite on every review nudge.

This PR adds the two missing kwargs and aligns the review fork's `tools[]` with the parent's, extending PR #17276's `system`-bytes invariant one slot up the cache hierarchy.

## Goal

Eliminate cache-write overhead on the background review path. On a captured ~5 hour Sonnet-class session, review-fork requests account for ~51 % of the session's total `cache_creation_input_tokens` even though they share `messages[0..N]` and `system` with the parent byte-for-byte — the divergence in `tools[]` alone is enough to push every fork req into a cache miss. After the fix, fork requests read from the parent's warmed cache instead of rewriting.

The safety contract from #15204 (the review fork must not dispatch terminal / send_message / delegate_task) is preserved: it is enforced by the post-construction `set_thread_tool_whitelist({memory, skills, …})` call a few lines below, which gates *dispatch*, not what the request body *transmits*.

## Implementation

`agent/background_review.py` — two added kwargs in the `AIAgent(...)` call inside `_spawn_background_review`:

```python
enabled_toolsets=getattr(agent, "enabled_toolsets", None),
disabled_toolsets=getattr(agent, "disabled_toolsets", None),
```

Plus an explanatory block comment that calls out the cache-key dependency and the relationship to PR #17276.

Symmetric inheritance: when the parent's value is `None`, the fork's is also `None` and both expand to the registry default identically; when the parent narrows, the fork inherits the narrowed set verbatim.

## Testing

Two test files updated:

- `tests/run_agent/test_background_review_cache_parity.py` — new positive assertion `test_review_fork_inherits_parent_toolset_config` confirms both kwargs reach the constructor with the parent's values.
- `tests/run_agent/test_background_review_toolset_restriction.py` — the existing `test_background_review_does_not_narrow_toolset_schema` was renamed to `test_background_review_matches_parent_toolset_config` and inverted. Its prior invariant ("the fork must NOT pass `enabled_toolsets`") was built on the implicit assumption that the parent always runs with the registry default; when the parent narrows, leaving the fork at `None` is what *causes* divergence. The corrected invariant is symmetric inheritance.

Sanity check: the new positive test fails without the fix and passes with it.

```bash
python -m pytest tests/run_agent/test_background_review.py \
                 tests/run_agent/test_background_review_summary.py \
                 tests/run_agent/test_background_review_toolset_restriction.py \
                 tests/run_agent/test_background_review_cache_parity.py -q
```

**Output:**

```
18 passed in 1.85s
```

End-to-end verification (capturing real `/v1/messages` traffic via a local HTTP proxy):

| Window | Total reqs | Review-fork reqs | Distinct `tools[]` hashes per conv |
|---|---:|---:|---:|
| Pre-fix (~5 h session) | 411 | 87 (30 fork spawns) | **2** (main vs fork) |
| Post-fix (~15 min, after first fork spawn) | 32 | 4 (1 spawn) | **1** (identical) |

The post-fix fork retains its other identifiers (the `_SKILL_REVIEW_PROMPT` text on the last user message, the absence of `output_config` / `thinking` at the top level — those flow through the secondary completion adapter), but its `tools[]` array now hashes identically to the parent's.

## Scope

- `agent/background_review.py`: two added kwargs + explanatory comment.
- Two test files updated as described above.
- No production code paths outside the review fork.
- No schema, public-API, or runtime-whitelist changes.
- No new dependencies.

Related: extends PR #17276 / #25322 (which fixed `system`-bytes inheritance) to the `tools[]` slot.
