### PR TITLE
i18n: add background_review + memory/skill tool messages to locale system

### DIFF
--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -24,6 +24,8 @@ import logging
 import os
 from typing import Any, Dict, List, Optional
 
+from agent.i18n import t
+
 logger = logging.getLogger(__name__)
 
 
@@ -280,14 +282,14 @@ def summarize_background_review_actions(
         elif "updated" in message.lower():
             actions.append(message)
         elif "added" in message.lower() or (target and "add" in message.lower()):
-            label = "Memory" if target == "memory" else "User profile" if target == "user" else target
-            actions.append(f"{label} updated")
+            label = t("background_review.memory_label") if target == "memory" else t("background_review.user_profile_label") if target == "user" else target
+            actions.append(t("background_review.memory_updated") if target == "memory" else t("background_review.user_profile_updated"))
         elif "Entry added" in message:
-            label = "Memory" if target == "memory" else "User profile" if target == "user" else target
-            actions.append(f"{label} updated")
+            label = t("background_review.memory_label") if target == "memory" else t("background_review.user_profile_label") if target == "user" else target
+            actions.append(t("background_review.memory_updated") if target == "memory" else t("background_review.user_profile_updated"))
         elif "removed" in message.lower() or "replaced" in message.lower():
-            label = "Memory" if target == "memory" else "User profile" if target == "user" else target
-            actions.append(f"{label} updated")
+            label = t("background_review.memory_label") if target == "memory" else t("background_review.user_profile_label") if target == "user" else target
+            actions.append(t("background_review.memory_updated") if target == "memory" else t("background_review.user_profile_updated"))
     return actions
 
 
@@ -501,13 +503,13 @@ def _run_review_in_thread(
         if actions:
             summary = " · ".join(dict.fromkeys(actions))
             agent._safe_print(
-                f"  💾 Self-improvement review: {summary}"
+                f"  {t('background_review.self_improvement', summary=summary)}"
             )
             _bg_cb = agent.background_review_callback
             if _bg_cb:
                 try:
                     _bg_cb(
-                        f"💾 Self-improvement review: {summary}"
+                        t("background_review.self_improvement", summary=summary)
                     )
                 except Exception:
                     pass

--- a/locales/af.yaml
+++ b/locales/af.yaml
@@ -349,3 +349,22 @@ gateway:
     session_db_unavailable_prefix: "Sessie-databasis is nie beskikbaar"
     session_not_found:           "Sessie nie in databasis gevind nie."
     warn_passthrough:            "⚠️ {error}"
+
+background_review:
+  self_improvement:     "💾 Self-improvement review: {summary}"
+  memory_label:         "Memory"
+  user_profile_label:   "User profile"
+  memory_updated:       "Memory updated"
+  user_profile_updated: "User profile updated"
+
+tools:
+  memory:
+    entry_added:     "Entry added."
+    entry_replaced:  "Entry replaced."
+    entry_removed:   "Entry removed."
+    entry_duplicate: "Entry already exists (no duplicate added)."
+  skills:
+    created:      "Skill '{name}' created."
+    updated:      "Skill '{name}' updated."
+    deleted:      "Skill '{name}' deleted."
+    file_removed: "File '{file_path}' removed from skill '{name}'."

--- a/locales/de.yaml
+++ b/locales/de.yaml
@@ -349,3 +349,22 @@ gateway:
     session_db_unavailable_prefix: "Session-Datenbank nicht verfügbar"
     session_not_found:           "Session nicht in der Datenbank gefunden."
     warn_passthrough:            "⚠️ {error}"
+
+background_review:
+  self_improvement:     "💾 Self-improvement review: {summary}"
+  memory_label:         "Memory"
+  user_profile_label:   "User profile"
+  memory_updated:       "Memory updated"
+  user_profile_updated: "User profile updated"
+
+tools:
+  memory:
+    entry_added:     "Entry added."
+    entry_replaced:  "Entry replaced."
+    entry_removed:   "Entry removed."
+    entry_duplicate: "Entry already exists (no duplicate added)."
+  skills:
+    created:      "Skill '{name}' created."
+    updated:      "Skill '{name}' updated."
+    deleted:      "Skill '{name}' deleted."
+    file_removed: "File '{file_path}' removed from skill '{name}'."

--- a/locales/en.yaml
+++ b/locales/en.yaml
@@ -364,3 +364,22 @@ gateway:
     session_db_unavailable_prefix: "Session database not available"
     session_not_found:           "Session not found in database."
     warn_passthrough:            "⚠️ {error}"
+
+background_review:
+  self_improvement:     "💾 Self-improvement review: {summary}"
+  memory_label:         "Memory"
+  user_profile_label:   "User profile"
+  memory_updated:       "Memory updated"
+  user_profile_updated: "User profile updated"
+
+tools:
+  memory:
+    entry_added:     "Entry added."
+    entry_replaced:  "Entry replaced."
+    entry_removed:   "Entry removed."
+    entry_duplicate: "Entry already exists (no duplicate added)."
+  skills:
+    created:      "Skill '{name}' created."
+    updated:      "Skill '{name}' updated."
+    deleted:      "Skill '{name}' deleted."
+    file_removed: "File '{file_path}' removed from skill '{name}'."

--- a/locales/es.yaml
+++ b/locales/es.yaml
@@ -349,3 +349,22 @@ gateway:
     session_db_unavailable_prefix: "Base de datos de sesiones no disponible"
     session_not_found:           "Sesión no encontrada en la base de datos."
     warn_passthrough:            "⚠️ {error}"
+
+background_review:
+  self_improvement:     "💾 Self-improvement review: {summary}"
+  memory_label:         "Memory"
+  user_profile_label:   "User profile"
+  memory_updated:       "Memory updated"
+  user_profile_updated: "User profile updated"
+
+tools:
+  memory:
+    entry_added:     "Entry added."
+    entry_replaced:  "Entry replaced."
+    entry_removed:   "Entry removed."
+    entry_duplicate: "Entry already exists (no duplicate added)."
+  skills:
+    created:      "Skill '{name}' created."
+    updated:      "Skill '{name}' updated."
+    deleted:      "Skill '{name}' deleted."
+    file_removed: "File '{file_path}' removed from skill '{name}'."

--- a/locales/fr.yaml
+++ b/locales/fr.yaml
@@ -349,3 +349,22 @@ gateway:
     session_db_unavailable_prefix: "Base de données de sessions indisponible"
     session_not_found:           "Session introuvable dans la base de données."
     warn_passthrough:            "⚠️ {error}"
+
+background_review:
+  self_improvement:     "💾 Self-improvement review: {summary}"
+  memory_label:         "Memory"
+  user_profile_label:   "User profile"
+  memory_updated:       "Memory updated"
+  user_profile_updated: "User profile updated"
+
+tools:
+  memory:
+    entry_added:     "Entry added."
+    entry_replaced:  "Entry replaced."
+    entry_removed:   "Entry removed."
+    entry_duplicate: "Entry already exists (no duplicate added)."
+  skills:
+    created:      "Skill '{name}' created."
+    updated:      "Skill '{name}' updated."
+    deleted:      "Skill '{name}' deleted."
+    file_removed: "File '{file_path}' removed from skill '{name}'."

--- a/locales/ga.yaml
+++ b/locales/ga.yaml
@@ -353,3 +353,22 @@ gateway:
     session_db_unavailable_prefix: "Níl bunachar sonraí na seisiún ar fáil"
     session_not_found:           "Seisiún gan a aimsiú sa bhunachar sonraí."
     warn_passthrough:            "⚠️ {error}"
+
+background_review:
+  self_improvement:     "💾 Self-improvement review: {summary}"
+  memory_label:         "Memory"
+  user_profile_label:   "User profile"
+  memory_updated:       "Memory updated"
+  user_profile_updated: "User profile updated"
+
+tools:
+  memory:
+    entry_added:     "Entry added."
+    entry_replaced:  "Entry replaced."
+    entry_removed:   "Entry removed."
+    entry_duplicate: "Entry already exists (no duplicate added)."
+  skills:
+    created:      "Skill '{name}' created."
+    updated:      "Skill '{name}' updated."
+    deleted:      "Skill '{name}' deleted."
+    file_removed: "File '{file_path}' removed from skill '{name}'."

--- a/locales/hu.yaml
+++ b/locales/hu.yaml
@@ -349,3 +349,22 @@ gateway:
     session_db_unavailable_prefix: "A munkamenet-adatbázis nem érhető el"
     session_not_found:           "A munkamenet nem található az adatbázisban."
     warn_passthrough:            "⚠️ {error}"
+
+background_review:
+  self_improvement:     "💾 Self-improvement review: {summary}"
+  memory_label:         "Memory"
+  user_profile_label:   "User profile"
+  memory_updated:       "Memory updated"
+  user_profile_updated: "User profile updated"
+
+tools:
+  memory:
+    entry_added:     "Entry added."
+    entry_replaced:  "Entry replaced."
+    entry_removed:   "Entry removed."
+    entry_duplicate: "Entry already exists (no duplicate added)."
+  skills:
+    created:      "Skill '{name}' created."
+    updated:      "Skill '{name}' updated."
+    deleted:      "Skill '{name}' deleted."
+    file_removed: "File '{file_path}' removed from skill '{name}'."

--- a/locales/it.yaml
+++ b/locales/it.yaml
@@ -349,3 +349,22 @@ gateway:
     session_db_unavailable_prefix: "Database delle sessioni non disponibile"
     session_not_found:           "Sessione non trovata nel database."
     warn_passthrough:            "⚠️ {error}"
+
+background_review:
+  self_improvement:     "💾 Self-improvement review: {summary}"
+  memory_label:         "Memory"
+  user_profile_label:   "User profile"
+  memory_updated:       "Memory updated"
+  user_profile_updated: "User profile updated"
+
+tools:
+  memory:
+    entry_added:     "Entry added."
+    entry_replaced:  "Entry replaced."
+    entry_removed:   "Entry removed."
+    entry_duplicate: "Entry already exists (no duplicate added)."
+  skills:
+    created:      "Skill '{name}' created."
+    updated:      "Skill '{name}' updated."
+    deleted:      "Skill '{name}' deleted."
+    file_removed: "File '{file_path}' removed from skill '{name}'."

--- a/locales/ja.yaml
+++ b/locales/ja.yaml
@@ -349,3 +349,22 @@ gateway:
     session_db_unavailable_prefix: "セッションデータベースが利用できません"
     session_not_found:           "データベースにセッションが見つかりません。"
     warn_passthrough:            "⚠️ {error}"
+
+background_review:
+  self_improvement:     "💾 Self-improvement review: {summary}"
+  memory_label:         "Memory"
+  user_profile_label:   "User profile"
+  memory_updated:       "Memory updated"
+  user_profile_updated: "User profile updated"
+
+tools:
+  memory:
+    entry_added:     "Entry added."
+    entry_replaced:  "Entry replaced."
+    entry_removed:   "Entry removed."
+    entry_duplicate: "Entry already exists (no duplicate added)."
+  skills:
+    created:      "Skill '{name}' created."
+    updated:      "Skill '{name}' updated."
+    deleted:      "Skill '{name}' deleted."
+    file_removed: "File '{file_path}' removed from skill '{name}'."

--- a/locales/ko.yaml
+++ b/locales/ko.yaml
@@ -349,3 +349,22 @@ gateway:
     session_db_unavailable_prefix: "세션 데이터베이스를 사용할 수 없습니다"
     session_not_found:           "데이터베이스에서 세션을 찾을 수 없습니다."
     warn_passthrough:            "⚠️ {error}"
+
+background_review:
+  self_improvement:     "💾 Self-improvement review: {summary}"
+  memory_label:         "Memory"
+  user_profile_label:   "User profile"
+  memory_updated:       "Memory updated"
+  user_profile_updated: "User profile updated"
+
+tools:
+  memory:
+    entry_added:     "Entry added."
+    entry_replaced:  "Entry replaced."
+    entry_removed:   "Entry removed."
+    entry_duplicate: "Entry already exists (no duplicate added)."
+  skills:
+    created:      "Skill '{name}' created."
+    updated:      "Skill '{name}' updated."
+    deleted:      "Skill '{name}' deleted."
+    file_removed: "File '{file_path}' removed from skill '{name}'."

--- a/locales/pt.yaml
+++ b/locales/pt.yaml
@@ -349,3 +349,22 @@ gateway:
     session_db_unavailable_prefix: "Base de dados de sessões indisponível"
     session_not_found:           "Sessão não encontrada na base de dados."
     warn_passthrough:            "⚠️ {error}"
+
+background_review:
+  self_improvement:     "💾 Self-improvement review: {summary}"
+  memory_label:         "Memory"
+  user_profile_label:   "User profile"
+  memory_updated:       "Memory updated"
+  user_profile_updated: "User profile updated"
+
+tools:
+  memory:
+    entry_added:     "Entry added."
+    entry_replaced:  "Entry replaced."
+    entry_removed:   "Entry removed."
+    entry_duplicate: "Entry already exists (no duplicate added)."
+  skills:
+    created:      "Skill '{name}' created."
+    updated:      "Skill '{name}' updated."
+    deleted:      "Skill '{name}' deleted."
+    file_removed: "File '{file_path}' removed from skill '{name}'."

--- a/locales/ru.yaml
+++ b/locales/ru.yaml
@@ -349,3 +349,22 @@ gateway:
     session_db_unavailable_prefix: "База данных сеансов недоступна"
     session_not_found:           "Сеанс не найден в базе данных."
     warn_passthrough:            "⚠️ {error}"
+
+background_review:
+  self_improvement:     "💾 Self-improvement review: {summary}"
+  memory_label:         "Memory"
+  user_profile_label:   "User profile"
+  memory_updated:       "Memory updated"
+  user_profile_updated: "User profile updated"
+
+tools:
+  memory:
+    entry_added:     "Entry added."
+    entry_replaced:  "Entry replaced."
+    entry_removed:   "Entry removed."
+    entry_duplicate: "Entry already exists (no duplicate added)."
+  skills:
+    created:      "Skill '{name}' created."
+    updated:      "Skill '{name}' updated."
+    deleted:      "Skill '{name}' deleted."
+    file_removed: "File '{file_path}' removed from skill '{name}'."

--- a/locales/tr.yaml
+++ b/locales/tr.yaml
@@ -349,3 +349,22 @@ gateway:
     session_db_unavailable_prefix: "Oturum veritabanı kullanılamıyor"
     session_not_found:           "Oturum veritabanında bulunamadı."
     warn_passthrough:            "⚠️ {error}"
+
+background_review:
+  self_improvement:     "💾 Self-improvement review: {summary}"
+  memory_label:         "Memory"
+  user_profile_label:   "User profile"
+  memory_updated:       "Memory updated"
+  user_profile_updated: "User profile updated"
+
+tools:
+  memory:
+    entry_added:     "Entry added."
+    entry_replaced:  "Entry replaced."
+    entry_removed:   "Entry removed."
+    entry_duplicate: "Entry already exists (no duplicate added)."
+  skills:
+    created:      "Skill '{name}' created."
+    updated:      "Skill '{name}' updated."
+    deleted:      "Skill '{name}' deleted."
+    file_removed: "File '{file_path}' removed from skill '{name}'."

--- a/locales/uk.yaml
+++ b/locales/uk.yaml
@@ -349,3 +349,22 @@ gateway:
     session_db_unavailable_prefix: "База даних сеансів недоступна"
     session_not_found:           "Сеанс не знайдено в базі даних."
     warn_passthrough:            "⚠️ {error}"
+
+background_review:
+  self_improvement:     "💾 Self-improvement review: {summary}"
+  memory_label:         "Memory"
+  user_profile_label:   "User profile"
+  memory_updated:       "Memory updated"
+  user_profile_updated: "User profile updated"
+
+tools:
+  memory:
+    entry_added:     "Entry added."
+    entry_replaced:  "Entry replaced."
+    entry_removed:   "Entry removed."
+    entry_duplicate: "Entry already exists (no duplicate added)."
+  skills:
+    created:      "Skill '{name}' created."
+    updated:      "Skill '{name}' updated."
+    deleted:      "Skill '{name}' deleted."
+    file_removed: "File '{file_path}' removed from skill '{name}'."

--- a/locales/zh-hant.yaml
+++ b/locales/zh-hant.yaml
@@ -349,3 +349,22 @@ gateway:
     session_db_unavailable_prefix: "工作階段資料庫無法使用"
     session_not_found:           "資料庫中找不到此工作階段。"
     warn_passthrough:            "⚠️ {error}"
+
+background_review:
+  self_improvement:     "💾 Self-improvement review: {summary}"
+  memory_label:         "Memory"
+  user_profile_label:   "User profile"
+  memory_updated:       "Memory updated"
+  user_profile_updated: "User profile updated"
+
+tools:
+  memory:
+    entry_added:     "Entry added."
+    entry_replaced:  "Entry replaced."
+    entry_removed:   "Entry removed."
+    entry_duplicate: "Entry already exists (no duplicate added)."
+  skills:
+    created:      "Skill '{name}' created."
+    updated:      "Skill '{name}' updated."
+    deleted:      "Skill '{name}' deleted."
+    file_removed: "File '{file_path}' removed from skill '{name}'."

--- a/locales/zh.yaml
+++ b/locales/zh.yaml
@@ -349,3 +349,22 @@ gateway:
     session_db_unavailable_prefix: "会话数据库不可用"
     session_not_found:           "数据库中未找到该会话。"
     warn_passthrough:            "⚠️ {error}"
+
+background_review:
+  self_improvement:     "💾 自我改进：{summary}"
+  memory_label:         "记忆"
+  user_profile_label:   "用户档案"
+  memory_updated:       "记忆 已更新"
+  user_profile_updated: "用户档案 已更新"
+
+tools:
+  memory:
+    entry_added:     "条目已添加。"
+    entry_replaced:  "条目已替换。"
+    entry_removed:   "条目已移除。"
+    entry_duplicate: "条目已存在（未重复添加）。"
+  skills:
+    created:      "技能 '{name}' 已创建。"
+    updated:      "技能 '{name}' 已更新。"
+    deleted:      "技能 '{name}' 已删除。"
+    file_removed: "文件 '{file_path}' 已从技能 '{name}' 移除。"

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -35,6 +35,8 @@ from typing import Dict, Any, List, Optional
 
 from utils import atomic_replace
 
+from agent.i18n import t
+
 # fcntl is Unix-only; on Windows use msvcrt for file locking
 msvcrt = None
 try:
@@ -241,7 +243,7 @@ class MemoryStore:
 
             # Reject exact duplicates
             if content in entries:
-                return self._success_response(target, "Entry already exists (no duplicate added).")
+                return self._success_response(target, t("tools.memory.entry_duplicate"))
 
             # Calculate what the new total would be
             new_entries = entries + [content]
@@ -264,7 +266,7 @@ class MemoryStore:
             self._set_entries(target, entries)
             self.save_to_disk(target)
 
-        return self._success_response(target, "Entry added.")
+        return self._success_response(target, t("tools.memory.entry_added"))
 
     def replace(self, target: str, old_text: str, new_content: str) -> Dict[str, Any]:
         """Find entry containing old_text substring, replace it with new_content."""
@@ -322,7 +324,7 @@ class MemoryStore:
             self._set_entries(target, entries)
             self.save_to_disk(target)
 
-        return self._success_response(target, "Entry replaced.")
+        return self._success_response(target, t("tools.memory.entry_replaced"))
 
     def remove(self, target: str, old_text: str) -> Dict[str, Any]:
         """Remove the entry containing old_text substring."""
@@ -356,7 +358,7 @@ class MemoryStore:
             self._set_entries(target, entries)
             self.save_to_disk(target)
 
-        return self._success_response(target, "Entry removed.")
+        return self._success_response(target, t("tools.memory.entry_removed"))
 
     def format_for_system_prompt(self, target: str) -> Optional[str]:
         """

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -45,6 +45,8 @@ from typing import Dict, Any, Optional, Tuple
 from utils import atomic_replace, is_truthy_value
 from hermes_cli.config import cfg_get
 
+from agent.i18n import t
+
 logger = logging.getLogger(__name__)
 
 # Import security scanner — external hub installs always get scanned;
@@ -414,7 +416,7 @@ def _create_skill(name: str, content: str, category: str = None) -> Dict[str, An
 
     result = {
         "success": True,
-        "message": f"Skill '{name}' created.",
+        "message": t("tools.skills.created", name=name),
         "path": str(skill_dir.relative_to(SKILLS_DIR)),
         "skill_md": str(skill_md),
     }
@@ -455,7 +457,7 @@ def _edit_skill(name: str, content: str) -> Dict[str, Any]:
 
     return {
         "success": True,
-        "message": f"Skill '{name}' updated.",
+        "message": t("tools.skills.updated", name=name),
         "path": str(existing["path"]),
     }
 
@@ -601,7 +603,7 @@ def _delete_skill(name: str, absorbed_into: Optional[str] = None) -> Dict[str, A
     if parent != skills_root and parent.exists() and not any(parent.iterdir()):
         parent.rmdir()
 
-    message = f"Skill '{name}' deleted."
+    message = t("tools.skills.deleted", name=name)
     if absorbed_into is not None and isinstance(absorbed_into, str) and absorbed_into.strip():
         message += f" Content absorbed into '{absorbed_into.strip()}'."
 
@@ -702,7 +704,7 @@ def _remove_file(name: str, file_path: str) -> Dict[str, Any]:
 
     return {
         "success": True,
-        "message": f"File '{file_path}' removed from skill '{name}'.",
+        "message": t("tools.skills.file_removed", name=name, file_path=file_path),
     }
 
 


### PR DESCRIPTION
Add i18n support via existing `agent.i18n.t()` for:

- **background_review.py**: Self-improvement review header, Memory/User-profile labels
- **memory_tool.py**: entry added/replaced/removed/duplicate messages
- **skill_manager_tool.py**: skill created/updated/deleted, file_removed messages

Adds `background_review` and `tools` sections to all locale YAML files.
zh.yaml has full Chinese translations; other locales use English fallback.

Tested: `pytest tests/agent/test_i18n.py` — 43 passed.