### PR TITLE
fix(auth): recognize the "openai" provider alias in resolve_provider

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -1404,6 +1404,10 @@ def resolve_provider(
 
     # Normalize provider aliases
     _PROVIDER_ALIASES = {
+        # Bare "openai" → the generic OpenAI-compatible runtime. Mirrors the
+        # ALIASES table in providers.py; without it here, a config or request
+        # with provider "openai" is rejected as "Unknown provider 'openai'".
+        "openai": "openrouter",
         "glm": "zai", "z-ai": "zai", "z.ai": "zai", "zhipu": "zai",
         "google": "gemini", "google-gemini": "gemini", "google-ai-studio": "gemini",
         "x-ai": "xai", "x.ai": "xai", "grok": "xai",


### PR DESCRIPTION
## Summary

`resolve_provider()` in `hermes_cli/auth.py` builds a `_PROVIDER_ALIASES` table to normalize provider names, but it does not include `"openai"`. A config or request with `provider: openai` therefore falls through to the "Unknown provider 'openai'" error path — even though `hermes_cli/providers.py`'s module-level `ALIASES` table already maps `"openai" → "openrouter"`.

The two alias tables disagree, and `resolve_provider` is the one that gates the error.

## Fix

Add `"openai": "openrouter"` to `_PROVIDER_ALIASES`, so `resolve_provider` agrees with `providers.py`'s `ALIASES` and a bare `openai` provider resolves to the generic OpenAI-compatible runtime instead of being rejected.

One line (plus a comment). Fully backwards compatible — it only adds a previously-unhandled alias.

## Context

Surfaced by an API client that wrote `model.provider: openai` after the user configured an OpenAI key; the gateway then refused to start with `Unknown provider 'openai'`.