### PR TITLE
feat(cli): show fast service tier in status bar

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -2041,13 +2041,18 @@ class HermesCLI:
             percent = snapshot["context_percent"]
             percent_label = f"{percent}%" if percent is not None else "--"
             duration_label = snapshot["duration"]
+            fast_active = getattr(self, "service_tier", None) == "priority"
 
             if width < 52:
                 text = f"⚕ {snapshot['model_short']} · {duration_label}"
+                if fast_active:
+                    text += " · ⚡ FAST"
                 return self._trim_status_bar_text(text, width)
             if width < 76:
                 parts = [f"⚕ {snapshot['model_short']}", percent_label]
                 parts.append(duration_label)
+                if fast_active:
+                    parts.append("⚡ FAST")
                 return self._trim_status_bar_text(" · ".join(parts), width)
 
             if snapshot["context_length"]:
@@ -2059,6 +2064,8 @@ class HermesCLI:
 
             parts = [f"⚕ {snapshot['model_short']}", context_label, percent_label]
             parts.append(duration_label)
+            if fast_active:
+                parts.append("⚡ FAST")
             return self._trim_status_bar_text(" │ ".join(parts), width)
         except Exception:
             return f"⚕ {self.model if getattr(self, 'model', None) else 'Hermes'}"
@@ -2075,6 +2082,7 @@ class HermesCLI:
             # line and produce duplicated status bar rows over long sessions.
             width = self._get_tui_terminal_width()
             duration_label = snapshot["duration"]
+            fast_active = getattr(self, "service_tier", None) == "priority"
 
             if width < 52:
                 frags = [
@@ -2082,8 +2090,11 @@ class HermesCLI:
                     ("class:status-bar-strong", snapshot["model_short"]),
                     ("class:status-bar-dim", " · "),
                     ("class:status-bar-dim", duration_label),
-                    ("class:status-bar", " "),
                 ]
+                if fast_active:
+                    frags.append(("class:status-bar-dim", " · "))
+                    frags.append(("class:status-bar-fast", "⚡ FAST"))
+                frags.append(("class:status-bar", " "))
             else:
                 percent = snapshot["context_percent"]
                 percent_label = f"{percent}%" if percent is not None else "--"
@@ -2095,8 +2106,11 @@ class HermesCLI:
                         (self._status_bar_context_style(percent), percent_label),
                         ("class:status-bar-dim", " · "),
                         ("class:status-bar-dim", duration_label),
-                        ("class:status-bar", " "),
                     ]
+                    if fast_active:
+                        frags.append(("class:status-bar-dim", " · "))
+                        frags.append(("class:status-bar-fast", "⚡ FAST"))
+                    frags.append(("class:status-bar", " "))
                 else:
                     if snapshot["context_length"]:
                         ctx_total = _format_context_length(snapshot["context_length"])
@@ -2117,8 +2131,11 @@ class HermesCLI:
                         (bar_style, percent_label),
                         ("class:status-bar-dim", " │ "),
                         ("class:status-bar-dim", duration_label),
-                        ("class:status-bar", " "),
                     ]
+                    if fast_active:
+                        frags.append(("class:status-bar-dim", " │ "))
+                        frags.append(("class:status-bar-fast", "⚡ FAST"))
+                    frags.append(("class:status-bar", " "))
 
             total_width = sum(self._status_bar_display_width(text) for _, text in frags)
             if total_width > width:
@@ -9370,6 +9387,7 @@ class HermesCLI:
             'status-bar-warn': 'bg:#1a1a2e #FFD700 bold',
             'status-bar-bad': 'bg:#1a1a2e #FF8C00 bold',
             'status-bar-critical': 'bg:#1a1a2e #FF6B6B bold',
+            'status-bar-fast': 'bg:#1a1a2e #00D7FF bold',
             # Bronze horizontal rules around the input area
             'input-rule': '#CD7F32',
             # Clipboard image attachment badges

--- a/tests/cli/test_cli_status_bar.py
+++ b/tests/cli/test_cli_status_bar.py
@@ -80,6 +80,47 @@ class TestCLIStatusBar:
         assert "$0.06" not in text  # cost hidden by default
         assert "15m" in text
 
+    def test_build_status_bar_text_shows_fast_mode_when_enabled(self):
+        cli_obj = _attach_agent(
+            _make_cli(),
+            prompt_tokens=10_230,
+            completion_tokens=2_220,
+            total_tokens=12_450,
+            api_calls=7,
+            context_tokens=12_450,
+            context_length=200_000,
+        )
+        cli_obj.service_tier = "priority"
+
+        wide = cli_obj._build_status_bar_text(width=120)
+        medium = cli_obj._build_status_bar_text(width=60)
+        narrow = cli_obj._build_status_bar_text(width=50)
+
+        assert "⚡ FAST" in wide
+        assert "⚡ FAST" in medium
+        assert "⚡ FAST" in narrow
+
+    def test_fast_mode_in_wide_fragments(self):
+        cli_obj = _attach_agent(
+            _make_cli(),
+            prompt_tokens=10_230,
+            completion_tokens=2_220,
+            total_tokens=12_450,
+            api_calls=7,
+            context_tokens=12_450,
+            context_length=200_000,
+        )
+        cli_obj._status_bar_visible = True
+        cli_obj.service_tier = "priority"
+
+        mock_app = MagicMock()
+        mock_app.output.get_size.return_value = MagicMock(columns=160)
+        with patch("prompt_toolkit.application.get_app", return_value=mock_app):
+            frags = cli_obj._get_status_bar_fragments()
+        frag_styles = {text: style for style, text in frags}
+
+        assert frag_styles["⚡ FAST"] == "class:status-bar-fast"
+
     def test_input_height_counts_wide_characters_using_cell_width(self):
         cli_obj = _make_cli()
 


### PR DESCRIPTION
## Summary
- Show `⚡ FAST` in the CLI status bar when `service_tier` is `priority`
- Render the indicator in narrow, medium, and wide status bar layouts
- Add a dedicated prompt_toolkit style for the fast indicator

## Test Plan
- `venv/bin/python -m pytest tests/cli/test_cli_status_bar.py -q`