### PR TITLE
fix(dashboard): bump chat scrollback so long sessions don't truncate (#29562)

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -90,6 +90,33 @@ _SESSION_HEADER_NAME = "X-Hermes-Session-Token"
 # or HERMES_DASHBOARD_TUI=1.  Set from :func:`start_server`.
 _DASHBOARD_EMBEDDED_CHAT_ENABLED = False
 
+# Upper bound for the dashboard-chat xterm.js scrollback override below.
+# Mirrors ``DASHBOARD_CHAT_SCROLLBACK_CEILING`` in
+# ``web/src/pages/ChatPage.tsx`` — a typo with an extra zero shouldn't be
+# allowed to OOM the browser tab.
+_DASHBOARD_CHAT_SCROLLBACK_CEILING = 500_000
+
+
+def _dashboard_chat_scrollback_js() -> str:
+    """Render the ``window.__HERMES_DASHBOARD_CHAT_SCROLLBACK__`` payload.
+
+    Returns a JS literal — either a clamped positive integer when the
+    operator set ``HERMES_DASHBOARD_CHAT_SCROLLBACK`` to a valid number,
+    or the literal ``null`` so the frontend falls back to
+    ``DASHBOARD_CHAT_SCROLLBACK_DEFAULT``. Anything malformed (negative,
+    non-numeric, blank) also resolves to ``null`` — see #29562.
+    """
+    raw = os.environ.get("HERMES_DASHBOARD_CHAT_SCROLLBACK")
+    if not raw or not raw.strip():
+        return "null"
+    try:
+        value = int(raw.strip())
+    except ValueError:
+        return "null"
+    if value <= 0:
+        return "null"
+    return str(min(value, _DASHBOARD_CHAT_SCROLLBACK_CEILING))
+
 # Simple rate limiter for the reveal endpoint
 _reveal_timestamps: List[float] = []
 _REVEAL_MAX_PER_WINDOW = 5
@@ -3681,9 +3708,11 @@ def mount_spa(application: FastAPI):
         """
         html = _index_path.read_text()
         chat_js = "true" if _DASHBOARD_EMBEDDED_CHAT_ENABLED else "false"
+        scrollback_js = _dashboard_chat_scrollback_js()
         token_script = (
             f'<script>window.__HERMES_SESSION_TOKEN__="{_SESSION_TOKEN}";'
             f"window.__HERMES_DASHBOARD_EMBEDDED_CHAT__={chat_js};"
+            f"window.__HERMES_DASHBOARD_CHAT_SCROLLBACK__={scrollback_js};"
             f'window.__HERMES_BASE_PATH__="{prefix}";</script>'
         )
         if prefix:

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -2339,3 +2339,250 @@ class TestPtyWebSocket:
             ):
                 pass
         assert exc.value.code == 4400
+
+
+# ---------------------------------------------------------------------------
+# Dashboard chat scrollback override (#29562)
+#
+# Regression coverage for the long-session truncation bug introduced by
+# afffb8d9a. The inline-mode browser chat scrolls through xterm.js's own
+# scrollback buffer, so the buffer needs to be large enough to hold a real
+# session's worth of output. Operators can tune the cap without rebuilding
+# the SPA via ``HERMES_DASHBOARD_CHAT_SCROLLBACK``; this section pins both
+# the parser contract and the frontend source-level guardrail.
+# ---------------------------------------------------------------------------
+
+
+class TestDashboardChatScrollbackJs:
+    """Unit coverage for ``_dashboard_chat_scrollback_js``.
+
+    Returns either a positive integer literal (clamped at the ceiling) or
+    the literal ``null`` for the frontend to fall back to its built-in
+    default. Anything malformed resolves to ``null`` — never raises, never
+    returns something xterm.js would interpret as ``0``.
+    """
+
+    @pytest.fixture
+    def helper(self):
+        import hermes_cli.web_server as ws
+
+        return ws._dashboard_chat_scrollback_js, ws._DASHBOARD_CHAT_SCROLLBACK_CEILING
+
+    def test_unset_env_returns_null(self, helper, monkeypatch):
+        fn, _ceiling = helper
+        monkeypatch.delenv("HERMES_DASHBOARD_CHAT_SCROLLBACK", raising=False)
+        assert fn() == "null"
+
+    @pytest.mark.parametrize("value", ["", "   ", "\t", "\n"])
+    def test_blank_returns_null(self, helper, monkeypatch, value):
+        fn, _ = helper
+        monkeypatch.setenv("HERMES_DASHBOARD_CHAT_SCROLLBACK", value)
+        assert fn() == "null"
+
+    @pytest.mark.parametrize(
+        "value", ["abc", "1.5", "7e3", "100 lines", "infinity", "NaN"]
+    )
+    def test_non_integer_returns_null(self, helper, monkeypatch, value):
+        fn, _ = helper
+        monkeypatch.setenv("HERMES_DASHBOARD_CHAT_SCROLLBACK", value)
+        assert fn() == "null"
+
+    def test_underscore_separator_is_accepted(self, helper, monkeypatch):
+        """Python's ``int`` accepts PEP 515 separators (``50_000``); we
+        accept the same form so config-as-code that already uses it
+        keeps working without surprise."""
+        fn, _ = helper
+        monkeypatch.setenv("HERMES_DASHBOARD_CHAT_SCROLLBACK", "50_000")
+        assert fn() == "50000"
+
+    @pytest.mark.parametrize("value", ["0", "-1", "-50000"])
+    def test_non_positive_returns_null(self, helper, monkeypatch, value):
+        fn, _ = helper
+        monkeypatch.setenv("HERMES_DASHBOARD_CHAT_SCROLLBACK", value)
+        assert fn() == "null"
+
+    @pytest.mark.parametrize(
+        "value,expected",
+        [("1", "1"), ("100", "100"), ("50000", "50000"), ("200000", "200000")],
+    )
+    def test_valid_value_passes_through(self, helper, monkeypatch, value, expected):
+        fn, _ = helper
+        monkeypatch.setenv("HERMES_DASHBOARD_CHAT_SCROLLBACK", value)
+        assert fn() == expected
+
+    def test_value_above_ceiling_is_clamped(self, helper, monkeypatch):
+        fn, ceiling = helper
+        monkeypatch.setenv(
+            "HERMES_DASHBOARD_CHAT_SCROLLBACK", str(ceiling * 100)
+        )
+        assert fn() == str(ceiling)
+
+    def test_value_at_ceiling_is_preserved(self, helper, monkeypatch):
+        fn, ceiling = helper
+        monkeypatch.setenv("HERMES_DASHBOARD_CHAT_SCROLLBACK", str(ceiling))
+        assert fn() == str(ceiling)
+
+    def test_value_with_surrounding_whitespace_is_stripped(self, helper, monkeypatch):
+        fn, _ = helper
+        monkeypatch.setenv("HERMES_DASHBOARD_CHAT_SCROLLBACK", "  12345  ")
+        assert fn() == "12345"
+
+    def test_returned_token_is_a_safe_js_literal(self, helper, monkeypatch):
+        """The helper output is interpolated into a <script> tag, so it
+        must only ever be a bare JS literal — never user-controllable
+        text. Reject any value that could break out of the literal.
+        """
+        fn, _ = helper
+        for value in ["</script>", "alert(1)", '";evil', "\\n", "0x1F"]:
+            monkeypatch.setenv("HERMES_DASHBOARD_CHAT_SCROLLBACK", value)
+            result = fn()
+            assert result == "null" or result.isdigit()
+
+
+class TestServeIndexInjectsChatScrollback:
+    """``mount_spa`` threads the override through the existing token script.
+
+    Tests assert on the injected ``<script>`` contents — the most direct
+    surface that ChatPage.tsx reads from. The default (unset env) must
+    inject ``null`` so the frontend falls back to its own default; a
+    valid value must round-trip through unchanged.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _setup(self, tmp_path, monkeypatch):
+        from fastapi import FastAPI
+        from starlette.testclient import TestClient
+
+        import hermes_cli.web_server as ws
+
+        web_dist = tmp_path / "web_dist"
+        web_dist.mkdir()
+        (web_dist / "index.html").write_text(
+            "<!doctype html><html><head><title>Hermes</title></head>"
+            "<body><div id='root'></div></body></html>"
+        )
+        (web_dist / "assets").mkdir()
+
+        monkeypatch.setattr(ws, "WEB_DIST", web_dist)
+        # mount_spa registers a catch-all route on the module-level ``app``
+        # — use a throwaway FastAPI instance so we don't pollute the
+        # shared singleton and break neighbouring tests.
+        application = FastAPI()
+        ws.mount_spa(application)
+        self.client = TestClient(application)
+
+    def test_default_injects_null_for_chat_scrollback(self, monkeypatch):
+        monkeypatch.delenv("HERMES_DASHBOARD_CHAT_SCROLLBACK", raising=False)
+        resp = self.client.get("/")
+        assert resp.status_code == 200
+        assert "window.__HERMES_DASHBOARD_CHAT_SCROLLBACK__=null;" in resp.text
+
+    def test_env_override_round_trips_into_script(self, monkeypatch):
+        monkeypatch.setenv("HERMES_DASHBOARD_CHAT_SCROLLBACK", "75000")
+        resp = self.client.get("/")
+        assert resp.status_code == 200
+        assert (
+            "window.__HERMES_DASHBOARD_CHAT_SCROLLBACK__=75000;" in resp.text
+        )
+
+    def test_malformed_env_falls_back_to_null(self, monkeypatch):
+        monkeypatch.setenv("HERMES_DASHBOARD_CHAT_SCROLLBACK", "lots-of-lines")
+        resp = self.client.get("/")
+        assert resp.status_code == 200
+        assert "window.__HERMES_DASHBOARD_CHAT_SCROLLBACK__=null;" in resp.text
+
+    def test_above_ceiling_is_clamped_in_script(self, monkeypatch):
+        import hermes_cli.web_server as ws
+
+        monkeypatch.setenv(
+            "HERMES_DASHBOARD_CHAT_SCROLLBACK",
+            str(ws._DASHBOARD_CHAT_SCROLLBACK_CEILING * 10),
+        )
+        resp = self.client.get("/")
+        assert resp.status_code == 200
+        assert (
+            f"window.__HERMES_DASHBOARD_CHAT_SCROLLBACK__={ws._DASHBOARD_CHAT_SCROLLBACK_CEILING};"
+            in resp.text
+        )
+
+    def test_other_globals_still_present(self, monkeypatch):
+        """Sanity: the new global must not have displaced the existing ones."""
+        monkeypatch.delenv("HERMES_DASHBOARD_CHAT_SCROLLBACK", raising=False)
+        resp = self.client.get("/")
+        body = resp.text
+        assert "window.__HERMES_SESSION_TOKEN__=" in body
+        assert "window.__HERMES_DASHBOARD_EMBEDDED_CHAT__=" in body
+        assert 'window.__HERMES_BASE_PATH__=""' in body
+
+
+class TestChatPageScrollbackSource:
+    """Static guardrails on ``web/src/pages/ChatPage.tsx`` (#29562).
+
+    Without a JS test runner in the repo, the most reliable way to keep
+    the frontend honest is to pin the documented contract on the source
+    file directly. If the constants below ever change, this test forces
+    the docs + server defaults to be updated in lockstep.
+    """
+
+    @pytest.fixture
+    def source(self):
+        repo_root = Path(__file__).resolve().parents[2]
+        path = repo_root / "web" / "src" / "pages" / "ChatPage.tsx"
+        assert path.is_file(), f"ChatPage.tsx not found at {path}"
+        return path.read_text()
+
+    def test_default_scrollback_is_at_least_50k(self, source):
+        """The pre-#29562 cap of 5,000 was too small; the new default
+        must be high enough to hold a long session without truncating.
+        """
+        import re
+
+        m = re.search(
+            r"DASHBOARD_CHAT_SCROLLBACK_DEFAULT\s*=\s*(\d+)", source
+        )
+        assert m, "DASHBOARD_CHAT_SCROLLBACK_DEFAULT constant missing"
+        assert int(m.group(1)) >= 50000
+
+    def test_ceiling_matches_server_side(self, source):
+        """Browser-side ceiling and server-side ceiling must agree —
+        otherwise the server could happily forward a value the browser
+        will silently clamp (or vice-versa)."""
+        import re
+
+        import hermes_cli.web_server as ws
+
+        m = re.search(
+            r"DASHBOARD_CHAT_SCROLLBACK_CEILING\s*=\s*(\d+)", source
+        )
+        assert m, "DASHBOARD_CHAT_SCROLLBACK_CEILING constant missing"
+        assert int(m.group(1)) == ws._DASHBOARD_CHAT_SCROLLBACK_CEILING
+
+    def test_reads_window_global(self, source):
+        """The runtime must honour the operator override even after a
+        build, so the constant must be a function call (not inlined)."""
+        assert "dashboardChatScrollback()" in source
+        assert "window.__HERMES_DASHBOARD_CHAT_SCROLLBACK__" in source
+
+    def test_global_is_declared(self, source):
+        assert "__HERMES_DASHBOARD_CHAT_SCROLLBACK__?:" in source
+
+    def test_old_5000_literal_is_gone(self, source):
+        """Guard against accidentally re-introducing the truncating cap."""
+        assert "scrollback: 5000" not in source
+
+    def test_invalid_global_falls_back_to_default(self, source):
+        """The browser-side helper must defensively handle bad globals
+        (string ``"abc"``, ``NaN``, negatives, zero) — those should
+        resolve to the default so a malformed inject never breaks the
+        chat tab."""
+        assert "Number.isFinite" in source
+        assert "DASHBOARD_CHAT_SCROLLBACK_DEFAULT" in source
+
+    def test_inline_mode_rationale_documented(self, source):
+        """The scrollback comment must spell out *why* the cap matters —
+        otherwise a future "just bump it back to 5k to save memory"
+        commit will undo the fix without realising it. Pinning the
+        #29562 reference here keeps the rationale linkable from blame.
+        """
+        assert "#29562" in source
+        assert "HERMES_DASHBOARD_CHAT_SCROLLBACK" in source

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -104,6 +104,23 @@ function terminalLineHeightForWidth(layoutWidthPx: number): number {
   return layoutWidthPx < 1024 ? 1.02 : 1.15;
 }
 
+// Default xterm.js scrollback for the dashboard chat — see the comment at
+// the call site below. Keep in sync with
+// ``website/docs/reference/environment-variables.md``.
+const DASHBOARD_CHAT_SCROLLBACK_DEFAULT = 50000;
+// Hard upper bound on operator overrides so a typo (e.g. an extra zero)
+// can't OOM the browser tab.
+const DASHBOARD_CHAT_SCROLLBACK_CEILING = 500000;
+
+function dashboardChatScrollback(): number {
+  if (typeof window === "undefined") return DASHBOARD_CHAT_SCROLLBACK_DEFAULT;
+  const raw = window.__HERMES_DASHBOARD_CHAT_SCROLLBACK__;
+  if (raw === undefined || raw === null) return DASHBOARD_CHAT_SCROLLBACK_DEFAULT;
+  const n = typeof raw === "number" ? raw : Number(raw);
+  if (!Number.isFinite(n) || n <= 0) return DASHBOARD_CHAT_SCROLLBACK_DEFAULT;
+  return Math.min(Math.floor(n), DASHBOARD_CHAT_SCROLLBACK_CEILING);
+}
+
 export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
   const hostRef = useRef<HTMLDivElement | null>(null);
   const termRef = useRef<Terminal | null>(null);
@@ -298,9 +315,20 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
       // is false; enabling it gives users a single-action selection
       // path on top of the modifier-based bypass above.
       rightClickSelectsWord: true,
-      // Browser-embedded chat runs the TUI in inline mode. Keep transcript
-      // history in xterm.js so the browser wheel can scroll it directly.
-      scrollback: 5000,
+      // Browser-embedded chat runs the TUI in inline mode (see
+      // ``HERMES_TUI_INLINE`` in the PTY env), so the only transcript
+      // history the wheel handler below can scroll through is xterm.js's
+      // own scrollback buffer — the inline TUI does not retain a separate
+      // scrollback of its own. The previous 5,000-line cap was easy to
+      // exhaust on long sessions (a few hundred messages × tool calls /
+      // code blocks ≈ tens of thousands of rows), which surfaced as
+      // "scroll-up hits a wall and older messages are missing"
+      // (#29562 on v0.14.0). 50,000 lines is roughly enough for
+      // ~1.5–3k typical chat messages at a memory budget of ~60–90 MB
+      // worst case (xterm.js stores ~12 B/cell × cols × rows); operators
+      // who need more can set ``HERMES_DASHBOARD_CHAT_SCROLLBACK`` which
+      // the server forwards into the ``window`` global below.
+      scrollback: dashboardChatScrollback(),
       theme: TERMINAL_THEME,
     });
     termRef.current = term;
@@ -861,5 +889,12 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
 declare global {
   interface Window {
     __HERMES_SESSION_TOKEN__?: string;
+    /**
+     * Operator override for the dashboard chat's xterm.js scrollback
+     * cap (#29562). Injected by ``hermes_cli/web_server.py`` from the
+     * ``HERMES_DASHBOARD_CHAT_SCROLLBACK`` env var; defaults to
+     * ``DASHBOARD_CHAT_SCROLLBACK_DEFAULT`` when unset / invalid.
+     */
+    __HERMES_DASHBOARD_CHAT_SCROLLBACK__?: number | string;
   }
 }

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -572,6 +572,7 @@ Advanced per-platform knobs for throttling the outbound message batcher. Most us
 | `HERMES_TUI_RESUME` | Resume a specific TUI session by ID on launch. When set, `hermes --tui` skips forging a fresh session and picks up the named session instead — useful for re-attaching after a disconnect or terminal crash. |
 | `HERMES_TUI_THEME` | Force the TUI color theme: `light`, `dark`, or a raw 6-character background hex (e.g. `ffffff` or `1a1a2e`). When unset, Hermes auto-detects using `COLORFGBG` and terminal background queries; this variable overrides detection on terminals (Ghostty, Warp, iTerm2, etc.) that don't set `COLORFGBG`. |
 | `HERMES_INFERENCE_MODEL` | Force the model for `hermes -z` / `hermes chat` without mutating `config.yaml`. Pairs with `HERMES_INFERENCE_PROVIDER`. Useful for scripted callers (sweeper, CI, batch runners) that need to override the default model per run. |
+| `HERMES_DASHBOARD_CHAT_SCROLLBACK` | Maximum number of rows the dashboard "Chat" tab retains in its xterm.js scrollback buffer. Default is 50,000 (≈60–90 MB worst case), which is enough for a few thousand typical messages. Bump this if you run very long sessions and `scroll up` hits a wall before reaching the start of the transcript (see [#29562](https://github.com/NousResearch/hermes-agent/issues/29562)). Clamped to 500,000 to keep a typo from OOM-ing the browser tab; invalid or non-positive values fall back to the default. No rebuild of the SPA required. |
 
 ## Session Settings
 


### PR DESCRIPTION
## What does this PR do?

Fixes [#29562](https://github.com/NousResearch/hermes-agent/issues/29562) — the v0.14.0 Dashboard "Chat" tab silently truncates long sessions: scroll up past ~5,000 rows and you hit a wall, with the start of the conversation simply missing from the buffer.

Root cause (introduced by [`afffb8d9a`](https://github.com/NousResearch/hermes-agent/commit/afffb8d9a)): the inline-mode browser chat now routes the mouse wheel through xterm.js's own scrollback buffer instead of forwarding `Shift+Up` keystrokes into the TUI. That was the right call for smooth wheel UX, but the `scrollback: 5000` cap is small enough to be exhausted by a few hundred messages × tool calls / code blocks (tens of thousands of rows). Once the buffer overflows, older rows are dropped — they're not "missing from the DOM", they're gone from the buffer entirely, and there's no other scroll path back to them in inline mode.

This PR raises the default cap to a level that comfortably covers long-running sessions, and exposes an operator-facing override so power users can tune it without rebuilding the SPA.

- Browser default raised from **5,000 → 50,000 lines** (~60–90 MB worst case; covers ~1.5k–3k typical messages).
- New `HERMES_DASHBOARD_CHAT_SCROLLBACK` env var lets operators bump it further (clamped to 500,000 so a typo can't OOM the tab).
- Server forwards the value into the existing `window.__HERMES_*` token script, so the override is honoured at runtime — **no `npm run build` required**.
- Invalid / blank / non-positive values silently fall back to the default (the helper's output is interpolated straight into a `<script>` tag, so it can only ever be `null` or a clamped integer literal).

## Related Issue

Closes #29562 — *Dashboard TUI scroll regression in v0.14.0 — long sessions truncated / missing history*.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `web/src/pages/ChatPage.tsx`
  - New constants `DASHBOARD_CHAT_SCROLLBACK_DEFAULT = 50000` and `DASHBOARD_CHAT_SCROLLBACK_CEILING = 500000`.
  - New `dashboardChatScrollback()` helper: reads `window.__HERMES_DASHBOARD_CHAT_SCROLLBACK__`, defensively falls back to the default on `null` / `NaN` / non-positive / non-finite, clamps to the ceiling.
  - Replaces the inline `scrollback: 5000` literal with `scrollback: dashboardChatScrollback()`.
  - Adds the `__HERMES_DASHBOARD_CHAT_SCROLLBACK__?: number | string` typing on the `Window` interface so the global is properly typed.
  - Expands the inline comment to explain *why* the cap matters (inline TUI has no separate scrollback to fall back on) and links to #29562.

- `hermes_cli/web_server.py`
  - New module-level `_DASHBOARD_CHAT_SCROLLBACK_CEILING = 500_000` (kept in lockstep with the browser-side constant via a test guardrail).
  - New `_dashboard_chat_scrollback_js()` helper that reads `HERMES_DASHBOARD_CHAT_SCROLLBACK` and returns either `"null"` or a clamped integer literal. Blank / non-integer / non-positive resolve to `"null"`.
  - `_serve_index()` now injects `window.__HERMES_DASHBOARD_CHAT_SCROLLBACK__=…` into the existing `<script>` block next to the session token / base path / embedded-chat globals.

- `tests/hermes_cli/test_web_server.py` (+248 lines, 35 new test cases):
  - `TestDashboardChatScrollbackJs` (15 cases) — parser contract: unset/blank/non-numeric/non-positive all resolve to `"null"`; valid values pass through; ceiling clamps; PEP 515 separators are accepted; output is always a safe JS literal (no `<script>` injection surface).
  - `TestServeIndexInjectsChatScrollback` (5 cases) — integration: `mount_spa` actually threads the value into the `<script>` block, malformed env falls back to `null`, the new global doesn't displace the existing `__HERMES_*` globals.
  - `TestChatPageScrollbackSource` (7 cases) — static guardrails on `web/src/pages/ChatPage.tsx`: pins the default ≥ 50k, pins the browser ceiling to the server ceiling, refuses to re-introduce the old `scrollback: 5000` literal, requires the #29562 reference + env-var name + defensive `Number.isFinite` check to stay in the source.

- `website/docs/reference/environment-variables.md` — documents `HERMES_DASHBOARD_CHAT_SCROLLBACK` in the **Interface** section next to the other `HERMES_TUI_*` knobs, including the default, the ceiling, the fallback contract, and a link to #29562.

## How to Test

1. Check out the branch and activate the venv:
   ```
   git fetch origin fix/29562-dashboard-chat-history-truncation
   git checkout fix/29562-dashboard-chat-history-truncation
   source .venv/bin/activate   # or: python3 -m venv .venv && source .venv/bin/activate && pip install -e ".[all,dev]"
   ```
2. Run the new regression tests on their own:
   ```
   scripts/run_tests.sh tests/hermes_cli/test_web_server.py -k "DashboardChatScrollback or ServeIndexInjectsChatScrollback or ChatPageScrollbackSource" -v
   ```
   Expected: **35 passed**.
3. Run the full `test_web_server.py` suite to confirm no regressions in the broader dashboard/PTY surface:
   ```
   scripts/run_tests.sh tests/hermes_cli/test_web_server.py
   ```
   Expected: **180 passed**.
4. End-to-end manual smoke test:
   - Rebuild the SPA: `cd web && npm install && npm run build`.
   - Launch `hermes dashboard --tui`, open a long session (several hundred messages), and scroll up with the mouse wheel — older messages should now stay reachable.
   - Re-launch with `HERMES_DASHBOARD_CHAT_SCROLLBACK=200000 hermes dashboard --tui`, open DevTools, and confirm `window.__HERMES_DASHBOARD_CHAT_SCROLLBACK__` is `200000` and the `<script>` tag in the served `index.html` reflects the override.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(dashboard): …` and `test(dashboard): …`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run `scripts/run_tests.sh tests/hermes_cli/test_web_server.py` and all tests pass
- [x] I've added tests for my changes (35 new test cases across three classes)
- [x] I've tested on my platform: macOS 15.2 (Darwin 24.6.0), Python 3.12

### Documentation & Housekeeping

- [x] I've updated relevant documentation — `website/docs/reference/environment-variables.md` covers the new `HERMES_DASHBOARD_CHAT_SCROLLBACK` knob
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (env-var-only, no YAML schema change)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — the helper is pure Python `os.environ` lookup + a frontend `window` global read; no OS-specific paths
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

```
$ scripts/run_tests.sh tests/hermes_cli/test_web_server.py -k "DashboardChatScrollback or ServeIndexInjectsChatScrollback or ChatPageScrollbackSource"
4 workers [35 items]

...................................                                      [100%]
============================== 35 passed in 1.49s ==============================

$ scripts/run_tests.sh tests/hermes_cli/test_web_server.py
======================= 180 passed, 5 warnings in 4.24s ========================
```
