### PR TITLE
feat(openai): support Responses text verbosity

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -629,6 +629,7 @@ def init_agent(
     agent.max_tokens = max_tokens  # None = use model default
     agent.reasoning_config = reasoning_config  # None = use default (medium for OpenRouter)
     agent.service_tier = service_tier
+    agent.text_verbosity = None
     agent.request_overrides = dict(request_overrides or {})
     agent.prefill_messages = prefill_messages or []  # Prefilled conversation turns
     agent._force_ascii_payload = False
@@ -1530,6 +1531,19 @@ def init_agent(
     if not isinstance(_agent_section, dict):
         _agent_section = {}
     agent._tool_use_enforcement = _agent_section.get("tool_use_enforcement", "auto")
+    _config_text_verbosity = _agent_section.get("text_verbosity")
+    if _config_text_verbosity is not None:
+        from agent.text_verbosity import parse_text_verbosity
+
+        agent.text_verbosity = parse_text_verbosity(_config_text_verbosity)
+        if str(_config_text_verbosity or "").strip() and agent.text_verbosity is None:
+            _ra().logger.warning(
+                "Invalid agent.text_verbosity in config.yaml: %r; "
+                "must be one of: low, medium, high. "
+                "Falling back to provider default.",
+                _config_text_verbosity,
+            )
+    agent._session_init_model_config["text_verbosity"] = agent.text_verbosity
 
     # Intent-ack continuation config: "auto" (default — codex_responses only,
     # the historical gate), true (all api_modes), false (never), or a list of

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1035,6 +1035,8 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
         is_xai_responses = agent.provider in {"xai", "xai-oauth"} or agent._base_url_hostname == "api.x.ai"
         _msgs_for_codex = agent._prepare_messages_for_non_vision_model(api_messages)
 
+        from agent.text_verbosity import supports_openai_text_verbosity
+
         # xAI's /responses endpoint rejects ``pattern`` and ``format`` keywords
         # in tool schemas (HTTP 400 "Invalid arguments passed to the model").
         # Most commonly hit when MCP-derived tools carry JSON Schema validation
@@ -1076,6 +1078,13 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
             max_tokens=agent.max_tokens,
             timeout=agent._resolved_api_call_timeout(),
             request_overrides=agent.request_overrides,
+            text_verbosity=getattr(agent, "text_verbosity", None),
+            base_url=getattr(agent, "base_url", None),
+            supports_text_verbosity=supports_openai_text_verbosity(
+                agent.model,
+                base_url_hostname=agent._base_url_hostname,
+                is_codex_backend=is_codex_backend,
+            ),
             is_github_responses=is_github_responses,
             is_codex_backend=is_codex_backend,
             is_xai_responses=is_xai_responses,

--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -913,7 +913,7 @@ def _preflight_codex_api_kwargs(
         "model", "instructions", "input", "tools", "store",
         "reasoning", "include", "max_output_tokens", "temperature",
         "tool_choice", "parallel_tool_calls", "prompt_cache_key", "service_tier",
-        "extra_headers", "extra_body", "timeout",
+        "text", "extra_headers", "extra_body", "timeout",
     }
     normalized: Dict[str, Any] = {
         "model": model,
@@ -934,6 +934,30 @@ def _preflight_codex_api_kwargs(
     service_tier = api_kwargs.get("service_tier")
     if isinstance(service_tier, str) and service_tier.strip():
         normalized["service_tier"] = service_tier.strip()
+    text = api_kwargs.get("text")
+    if text is not None:
+        if not isinstance(text, dict):
+            raise ValueError("Codex Responses request 'text' must be an object.")
+        normalized_text: Dict[str, Any] = {}
+        for key, value in text.items():
+            if not isinstance(key, str) or not key.strip():
+                raise ValueError("Codex Responses request 'text' keys must be non-empty strings.")
+            normalized_key = key.strip()
+            if normalized_key == "verbosity":
+                if value is None:
+                    continue
+                from agent.text_verbosity import parse_text_verbosity
+
+                verbosity = parse_text_verbosity(value)
+                if verbosity is None:
+                    raise ValueError(
+                        "Codex Responses request 'text.verbosity' must be low, medium, or high."
+                    )
+                normalized_text["verbosity"] = verbosity
+            else:
+                normalized_text[normalized_key] = value
+        if normalized_text:
+            normalized["text"] = normalized_text
 
     # Pass through max_output_tokens and temperature
     max_output_tokens = api_kwargs.get("max_output_tokens")

--- a/agent/text_verbosity.py
+++ b/agent/text_verbosity.py
@@ -1,0 +1,36 @@
+"""OpenAI Responses API text verbosity helpers."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+VALID_TEXT_VERBOSITIES = {"low", "medium", "high"}
+
+
+def parse_text_verbosity(raw: Any) -> str | None:
+    """Return a normalized Responses API text verbosity value, or None."""
+    value = str(raw or "").strip().lower()
+    if not value:
+        return None
+    if value in VALID_TEXT_VERBOSITIES:
+        return value
+    return None
+
+
+def supports_openai_text_verbosity(
+    model: Any,
+    *,
+    base_url_hostname: str = "",
+    is_codex_backend: bool = False,
+) -> bool:
+    """Return whether the resolved target supports GPT-5 text verbosity."""
+    model_id = str(model or "").strip().lower().rsplit("/", 1)[-1]
+    is_gpt5 = (
+        model_id == "gpt-5"
+        or model_id.startswith("gpt-5.")
+        or model_id.startswith("gpt-5-")
+    )
+    if not is_gpt5:
+        return False
+    return is_codex_backend or base_url_hostname.strip().lower() == "api.openai.com"

--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -128,9 +128,9 @@ class ResponsesApiTransport(ProviderTransport):
             max_tokens: int | None — max_output_tokens
             timeout: float | None — per-request timeout forwarded to the SDK
             request_overrides: dict | None — extra kwargs merged in
-            provider: str | None — provider name for backend-specific logic
+            text_verbosity: str | None — OpenAI Responses text.verbosity
+            supports_text_verbosity: bool — resolved target capability
             base_url: str | None — endpoint URL
-            base_url_hostname: str | None — hostname for backend detection
             is_github_responses: bool — Copilot/GitHub models backend
             is_codex_backend: bool — chatgpt.com/backend-api/codex
             is_xai_responses: bool — xAI/Grok backend
@@ -317,6 +317,20 @@ class ResponsesApiTransport(ProviderTransport):
         request_overrides = params.get("request_overrides")
         if request_overrides:
             kwargs.update(request_overrides)
+
+        text_verbosity = params.get("text_verbosity")
+        if text_verbosity and params.get("supports_text_verbosity") is True:
+            from agent.text_verbosity import parse_text_verbosity
+
+            verbosity = parse_text_verbosity(text_verbosity)
+            if verbosity:
+                override_text = kwargs.get("text")
+                if override_text is None:
+                    kwargs["text"] = {"verbosity": verbosity}
+                elif isinstance(override_text, dict):
+                    merged_text = dict(override_text)
+                    merged_text.setdefault("verbosity", verbosity)
+                    kwargs["text"] = merged_text
 
         if "prompt_cache_key" in kwargs:
             bounded_cache_key = _bounded_prompt_cache_key(kwargs["prompt_cache_key"])

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -757,6 +757,12 @@ agent:
   # Controls how much "thinking" the model does before responding.
   # Options: "xhigh" (max), "high", "medium", "low", "minimal", "none" (disable)
   reasoning_effort: "medium"
+
+  # OpenAI Responses API final-answer verbosity.
+  # Empty/unset = provider default. Options: "low", "medium", "high".
+  # Automatically applied only to GPT-5 models on Codex OAuth or the exact
+  # api.openai.com host, not xAI/Grok, GitHub Models, or custom endpoints.
+  text_verbosity: ""
   
   # Per-model reasoning effort overrides (optional dict)
   # Key: any sensible model spelling works (exact, dots↔dashes interchangeable,

--- a/cli.py
+++ b/cli.py
@@ -430,6 +430,7 @@ def load_cli_config() -> Dict[str, Any]:
             "prefill_messages_file": "",
             "reasoning_effort": "",
             "service_tier": "",
+            "text_verbosity": "",
             "personalities": {
                 "helpful": "You are a helpful, friendly AI assistant.",
                 "concise": "You are a concise assistant. Keep responses brief and to the point.",

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -17198,6 +17198,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         ("compression", "codex_app_server_auto"),
         ("compression", "target_ratio"),
         ("compression", "protect_last_n"),
+        ("agent", "text_verbosity"),
         ("agent", "disabled_toolsets"),
         ("memory", "provider"),
     )

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1041,6 +1041,9 @@ DEFAULT_CONFIG = {
         # provider hiccups on a single provider.
         "api_max_retries": 3,
         "service_tier": "",
+        # OpenAI Responses API final-answer verbosity. Empty/unset preserves
+        # the provider default. Valid values: "low", "medium", "high".
+        "text_verbosity": "",
         # Tool-use enforcement: injects system prompt guidance that tells the
         # model to actually call tools instead of describing intended actions.
         # Values: "auto" (default — applies to gpt/codex models), true/false

--- a/tests/agent/transports/test_codex_transport.py
+++ b/tests/agent/transports/test_codex_transport.py
@@ -4,6 +4,11 @@ import json
 import pytest
 from types import SimpleNamespace
 
+from agent.codex_responses_adapter import _preflight_codex_api_kwargs
+from agent.text_verbosity import (
+    parse_text_verbosity,
+    supports_openai_text_verbosity,
+)
 from agent.transports import get_transport
 from agent.transports.types import NormalizedResponse
 
@@ -53,6 +58,57 @@ class TestCodexBuildKwargs:
         assert kw["instructions"] == "You are helpful."
         assert "input" in kw
         assert kw["store"] is False
+
+    def test_text_verbosity_adds_top_level_text_for_supported_target(self, transport):
+        messages = [{"role": "user", "content": "Hi"}]
+        kw = transport.build_kwargs(
+            model="gpt-5.5",
+            messages=messages,
+            tools=[],
+            text_verbosity=" LOW ",
+            supports_text_verbosity=True,
+        )
+        assert kw.get("text") == {"verbosity": "low"}
+
+    def test_text_verbosity_skips_unsupported_target(self, transport):
+        messages = [{"role": "user", "content": "Hi"}]
+        kw = transport.build_kwargs(
+            model="gpt-5.5",
+            messages=messages,
+            tools=[],
+            text_verbosity="low",
+            supports_text_verbosity=False,
+        )
+        assert "text" not in kw
+
+    def test_text_verbosity_merges_with_request_override_text(self, transport):
+        messages = [{"role": "user", "content": "Hi"}]
+        request_overrides = {"text": {"format": {"type": "text"}}}
+        kw = transport.build_kwargs(
+            model="gpt-5.5",
+            messages=messages,
+            tools=[],
+            text_verbosity="low",
+            supports_text_verbosity=True,
+            request_overrides=request_overrides,
+        )
+        assert kw.get("text") == {
+            "format": {"type": "text"},
+            "verbosity": "low",
+        }
+        assert request_overrides == {"text": {"format": {"type": "text"}}}
+
+    def test_text_verbosity_request_override_verbosity_wins(self, transport):
+        messages = [{"role": "user", "content": "Hi"}]
+        kw = transport.build_kwargs(
+            model="gpt-5.5",
+            messages=messages,
+            tools=[],
+            text_verbosity="low",
+            supports_text_verbosity=True,
+            request_overrides={"text": {"verbosity": "high"}},
+        )
+        assert kw.get("text") == {"verbosity": "high"}
 
     def test_system_extracted_from_messages(self, transport):
         messages = [
@@ -947,6 +1003,70 @@ class TestCodexTransportTimeout:
         assert kw.get("timeout") == 450.0
 
 
+class TestCodexTextVerbosityPreflight:
+
+    @pytest.mark.parametrize(
+        ("model", "hostname", "is_codex_backend", "expected"),
+        [
+            ("gpt-5.6-sol", "api.openai.com", False, True),
+            ("openai/gpt-5.5", "", True, True),
+            ("o3", "api.openai.com", False, False),
+            ("grok-4.5", "api.x.ai", False, False),
+            ("gpt-5.5", "models.github.ai", False, False),
+            ("gpt-5.5", "proxy.example", False, False),
+        ],
+    )
+    def test_text_verbosity_capability_boundary(
+        self, model, hostname, is_codex_backend, expected
+    ):
+        assert (
+            supports_openai_text_verbosity(
+                model,
+                base_url_hostname=hostname,
+                is_codex_backend=is_codex_backend,
+            )
+            is expected
+        )
+
+    def test_parse_text_verbosity_accepts_openai_values_only(self):
+        assert parse_text_verbosity("") is None
+        assert parse_text_verbosity(" LOW ") == "low"
+        assert parse_text_verbosity("medium") == "medium"
+        assert parse_text_verbosity("high") == "high"
+        assert parse_text_verbosity("verbose") is None
+
+    def test_preflight_allows_text_verbosity_with_timeout_and_extra_body(self):
+        payload = _preflight_codex_api_kwargs(
+            {
+                "model": "gpt-5.5",
+                "instructions": "system",
+                "input": [{"role": "user", "content": "hi"}],
+                "store": False,
+                "timeout": 600,
+                "extra_body": {"prompt_cache_key": "conv-1"},
+                "text": {"verbosity": "HIGH", "format": {"type": "text"}},
+            }
+        )
+        assert payload["timeout"] == 600.0
+        assert payload["extra_body"] == {"prompt_cache_key": "conv-1"}
+        assert payload["text"] == {
+            "verbosity": "high",
+            "format": {"type": "text"},
+        }
+
+    def test_preflight_rejects_invalid_text_verbosity(self):
+        with pytest.raises(ValueError, match="text.verbosity"):
+            _preflight_codex_api_kwargs(
+                {
+                    "model": "gpt-5.5",
+                    "instructions": "system",
+                    "input": [{"role": "user", "content": "hi"}],
+                    "store": False,
+                    "text": {"verbosity": "verbose"},
+                }
+            )
+
+
 class TestCodexTransportXaiServiceTierStrip:
     """xAI Responses API rejects ``service_tier`` (#28490).
 
@@ -1047,7 +1167,6 @@ class TestPreflightSlashEnumStrip:
     def test_grok_model_strips_slash_enum_values(self):
         """When the model name is Grok-family, slash-containing enum
         values are stripped so xAI doesn't 400 on the tool schema."""
-        from agent.codex_responses_adapter import _preflight_codex_api_kwargs
         kwargs = self._make_kwargs(
             "grok-4.3",
             ["Qwen/Qwen3.5-0.8B", "openai/gpt-oss-20b", "plain-id"],
@@ -1063,7 +1182,6 @@ class TestPreflightSlashEnumStrip:
 
     def test_aggregator_prefixed_grok_also_strips(self):
         """Aggregator-prefixed (x-ai/grok-*) names hit the same path."""
-        from agent.codex_responses_adapter import _preflight_codex_api_kwargs
         kwargs = self._make_kwargs(
             "x-ai/grok-4.3",
             ["Qwen/Qwen3.5-0.8B"],
@@ -1076,7 +1194,6 @@ class TestPreflightSlashEnumStrip:
         enums.  The safety-net must NOT strip there or we silently
         degrade tool-schema constraints on every codex_responses
         provider that isn't xAI."""
-        from agent.codex_responses_adapter import _preflight_codex_api_kwargs
         kwargs = self._make_kwargs(
             "gpt-5.5",
             ["Qwen/Qwen3.5-0.8B", "plain-id"],

--- a/tests/gateway/test_agent_cache.py
+++ b/tests/gateway/test_agent_cache.py
@@ -243,6 +243,14 @@ class TestExtractCacheBustingConfig:
         assert out["compression.protect_last_n"] == 25
         assert out["compression.codex_app_server_auto"] == "hermes"
 
+    def test_reads_agent_text_verbosity(self):
+        from gateway.run import GatewayRunner
+
+        out = GatewayRunner._extract_cache_busting_config(
+            {"agent": {"text_verbosity": "low", "some_other_key": "ignored"}}
+        )
+        assert out["agent.text_verbosity"] == "low"
+
     def test_missing_keys_yield_none(self):
         """Absent config keys must produce None values (still contribute to signature)."""
         from gateway.run import GatewayRunner
@@ -414,6 +422,20 @@ class TestExtractCacheBustingConfig:
             "Editing compression.threshold in config.yaml must bust the "
             "gateway's cached agent so the new threshold takes effect."
         )
+
+    def test_text_verbosity_change_busts_cache(self):
+        from gateway.run import GatewayRunner
+
+        runtime = {"api_key": "k", "base_url": "u", "provider": "p"}
+        sig_before = GatewayRunner._agent_config_signature(
+            "m", runtime, [], "",
+            cache_keys={"agent.text_verbosity": "low"},
+        )
+        sig_after = GatewayRunner._agent_config_signature(
+            "m", runtime, [], "",
+            cache_keys={"agent.text_verbosity": "high"},
+        )
+        assert sig_before != sig_after
 
 
 class TestAgentCacheLifecycle:

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -1110,6 +1110,88 @@ class TestInit:
         assert a.max_tokens == 4096
         assert kwargs["max_tokens"] == 4096
 
+    def test_text_verbosity_from_config_populates_responses_request(self):
+        """agent.text_verbosity config populates OpenAI Responses text.verbosity."""
+        with (
+            patch("run_agent.get_tool_definitions", return_value=[]),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+            patch(
+                "hermes_cli.config.load_config",
+                return_value={"agent": {"text_verbosity": "low"}},
+            ),
+        ):
+            a = AIAgent(
+                api_key="test-k...7890",
+                provider="openai-api",
+                model="gpt-5.5",
+                base_url="https://api.openai.com/v1",
+                api_mode="codex_responses",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+            )
+
+            kwargs = a._build_api_kwargs([{"role": "user", "content": "Hi"}])
+
+        assert a.text_verbosity == "low"
+        assert kwargs["text"] == {"verbosity": "low"}
+
+    def test_text_verbosity_skips_custom_responses_endpoint(self):
+        with (
+            patch("run_agent.get_tool_definitions", return_value=[]),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+            patch(
+                "hermes_cli.config.load_config",
+                return_value={"agent": {"text_verbosity": "low"}},
+            ),
+        ):
+            a = AIAgent(
+                api_key="test-k...7890",
+                provider="custom",
+                model="gpt-5.5",
+                base_url="https://proxy.example/v1",
+                api_mode="codex_responses",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+            )
+
+            kwargs = a._build_api_kwargs([{"role": "user", "content": "Hi"}])
+
+        assert a.text_verbosity == "low"
+        assert "text" not in kwargs
+
+    def test_invalid_text_verbosity_config_falls_back(self, caplog):
+        """Invalid agent.text_verbosity warns and preserves provider default."""
+        with (
+            caplog.at_level(logging.WARNING),
+            patch("run_agent.get_tool_definitions", return_value=[]),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+            patch(
+                "hermes_cli.config.load_config",
+                return_value={"agent": {"text_verbosity": "verbose"}},
+            ),
+        ):
+            a = AIAgent(
+                api_key="test-k...7890",
+                provider="openai-api",
+                model="gpt-5.5",
+                base_url="https://api.openai.com/v1",
+                api_mode="codex_responses",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+            )
+
+            kwargs = a._build_api_kwargs([{"role": "user", "content": "Hi"}])
+
+        assert a.text_verbosity is None
+        assert "text" not in kwargs
+        assert "Invalid agent.text_verbosity" in caplog.text
+
     def test_constructor_max_tokens_wins_over_config(self):
         """Explicit constructor max_tokens keeps programmatic callers stable."""
         with (

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1361,6 +1361,17 @@ There is no `hermes config set` support for `reasoning_overrides` keys — edit 
 
 The override applies automatically everywhere: CLI startup, messaging gateway, Desktop/TUI, cron jobs, `/model` mid-session switches, and fallback model activation.
 
+## Text Verbosity
+
+Control OpenAI Responses API final-answer length without changing reasoning effort:
+
+```yaml
+agent:
+  text_verbosity: ""   # empty = provider default. Options: low, medium, high
+```
+
+Hermes automatically sends this as top-level `text: {"verbosity": ...}` only for GPT-5 models on the Codex OAuth backend or the exact `api.openai.com` host. It is not injected for xAI/Grok, GitHub Models, Anthropic, or arbitrary custom endpoints.
+
 ## Tool-Use Enforcement
 
 Some models occasionally describe intended actions as text instead of making tool calls ("I would run the tests..." instead of actually calling the terminal). Tool-use enforcement injects system prompt guidance that steers the model back to actually calling tools.


### PR DESCRIPTION
## Summary
- add `agent.text_verbosity` config parsing for OpenAI Responses output verbosity
- automatically inject `text.verbosity` only for GPT-5 models on Codex OAuth or the exact `api.openai.com` host; xAI, GitHub Models, and arbitrary custom endpoints fail closed
- merge configured verbosity into `request_overrides.text` without dropping `text.format` or replacing an explicit verbosity override
- validate `text` in the Responses preflight, document the option, and invalidate cached gateway agents when it changes

## Context
Closes #20203.

#20258 also proposes this feature. This PR keeps the implementation at the existing agent-to-Responses transport boundary and does not add a generic capability framework or custom-proxy opt-in.

## Tests
- `scripts/run_tests.sh tests/agent/transports/test_codex_transport.py tests/run_agent/test_run_agent.py tests/gateway/test_agent_cache.py` (`581 passed`)
- `ruff check` on all changed Python files
- `python -m compileall` on all changed Python files
- `git diff --check`
