### PR TITLE
fix(model-switch): probe /v1/models for providers without api_key

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1515,10 +1515,15 @@ def list_authenticated_providers(
                     if fb:
                         models_list = list(fb)
 
-            # Prefer the endpoint's live /models list when credentials are
-            # available, unless the provider explicitly opts out via
-            # discover_models: false (e.g. dedicated endpoints that expose
-            # the entire aggregator catalog via /models).
+            # Prefer the endpoint's live /models list when discoverable,
+            # unless the provider explicitly opts out via discover_models: false.
+            # Policy mirrors Section 4's should_probe logic:
+            # - With an api_key: always probe (user opted into the endpoint).
+            # - Without an api_key but with explicit models: skip — the user
+            #   is narrowing a public endpoint to a specific subset.
+            # - Without an api_key AND no explicit models: probe anyway so
+            #   bare-endpoint providers (local llama.cpp / Ollama servers)
+            #   still show their full model catalog.
             api_key = str(ep_cfg.get("api_key", "") or "").strip()
             if not api_key:
                 key_env = str(ep_cfg.get("key_env", "") or "").strip()
@@ -1526,7 +1531,11 @@ def list_authenticated_providers(
             discover = ep_cfg.get("discover_models", True)
             if isinstance(discover, str):
                 discover = discover.lower() not in {"false", "no", "0"}
-            if api_url and api_key and discover:
+            has_explicit_models = bool(models_list)
+            should_probe = bool(api_url) and discover and (
+                bool(api_key) or not has_explicit_models
+            )
+            if should_probe:
                 try:
                     from hermes_cli.models import fetch_api_models
                     live_models = fetch_api_models(api_key, api_url)


### PR DESCRIPTION
## Summary

- Section 3 of `list_authenticated_providers` (user-defined endpoints from the `providers:` config section) required an `api_key` before probing `/v1/models` for live model discovery
- This broke local self-hosted backends (llama.cpp, Ollama, vLLM, custom proxies, etc.) that don't require authentication — they would only ever show the single `default_model` from config instead of the full model catalog
- Section 4 (`custom_providers` list) already handled this correctly with the policy: probe when `api_key` is set **OR** when no explicit models are configured
- This PR applies the same logic to Section 3 so local backends get full model discovery without requiring a placeholder `api_key` workaround

## Problem

A user configures a local inference server (e.g. llama.cpp with load_and_proxy) as a provider:

```yaml
providers:
  loader:
    base_url: http://10.1.1.20:1234/v1
    name: loader
    default_model: Qwen_V3.6_27B_dflash_c256_g0_bee
```

The server exposes 100+ models via `/v1/models` and requires no authentication. But the `/model` picker only shows 1 model because the discovery condition at line 1529 was:

```python
if api_url and api_key and discover:
```

There's no `api_key` → no probe → only `default_model` shown.

## Fix

Mirror Section 4's `should_probe` logic:

```python
should_probe = bool(api_url) and discover and (
    bool(api_key) or not has_explicit_models
)
```

- **With api_key**: always probe (user opted into the endpoint)
- **Without api_key + no explicit models**: probe anyway (bare-endpoint providers like local llama.cpp/Ollama)
- **Without api_key + explicit models list**: skip (user is narrowing a public endpoint to a subset)

## Test plan

- [x] Configure a local llama.cpp/vLLM server in `providers:` without an `api_key`
- [x] Verify `/model` shows the full catalog from `/v1/models` instead of just `default_model`
- [ ] Verify providers with explicit `models:` list still skip discovery as before
- [ ] Verify providers with `discover_models: false` still skip discovery as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)