### PR TITLE
fix(config): preserve api_key during provider migration for unauthenticated servers

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3617,7 +3617,7 @@ def migrate_config(interactive: bool = True, quiet: bool = False) -> Dict[str, A
                 new_entry = {"api": old_url}
                 if old_name:
                     new_entry["name"] = old_name
-                if old_key and old_key not in {"no-key", "no-key-required", ""}:
+                if old_key and old_key not in {"",}:
                     new_entry["api_key"] = old_key
 
                 # Carry over model and api_mode if present


### PR DESCRIPTION
## Summary

- The v11→v12 config migration (`custom_providers` list → `providers` dict) stripped `api_key` values matching `"no-key"` or `"no-key-required"` from migrated entries
- These are legitimate values used by self-hosted backends (llama.cpp, Ollama, vLLM, custom proxies) that expose `/v1/models` but don't require authentication
- Without the `api_key`, model discovery is skipped entirely (see `model_switch.py` Section 3), causing the `/model` picker to only show `default_model` instead of the full catalog
- Users who add a placeholder `api_key` to work around this **lose it on every config migration triggered by an update**

## Problem

A user adds a placeholder `api_key` to enable model discovery for their local server:

```yaml
providers:
  loader:
    base_url: http://10.1.1.20:1234/v1
    name: loader
    api_key: no-key-required
    default_model: Qwen_V3.6_27B_dflash_c256_g0_bee
```

This works — the `/model` picker shows all models from `/v1/models`. But the next `hermes update` triggers a config migration that runs:

```python
if old_key and old_key not in {"no-key", "no-key-required", ""}:
    new_entry["api_key"] = old_key
```

The `api_key` is silently stripped. After restart, the picker reverts to showing only `default_model`.

## Fix

Stop filtering out `"no-key"` and `"no-key-required"`. Only skip empty strings:

```python
if old_key and old_key not in {"",}:
    new_entry["api_key"] = old_key
```

If a user explicitly configured an `api_key` — even a placeholder — the migration should preserve it.

## Relationship to #29575

This PR addresses the same underlying problem from a different angle. [#29575](https://github.com/NousResearch/hermes-agent/pull/29575) fixes the discovery logic so providers without an `api_key` can still be probed. This PR fixes the migration so placeholder keys aren't silently stripped. Both fixes are independently valid; together they fully resolve the issue.

## Test plan

- [x] Add `api_key: no-key-required` to a provider entry
- [ ] Run config migration — verify the `api_key` is preserved in the migrated `providers:` dict entry
- [ ] Verify providers with real API keys are still migrated correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)