### PR TITLE
Fix Slack thread replies in send_message

### DIFF
--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -28,6 +28,7 @@ from tools.send_message_tool import (
     _send_discord,
     _send_matrix_via_adapter,
     _send_signal,
+    _send_slack,
     _send_telegram,
     _send_to_platform,
     send_message_tool,
@@ -476,7 +477,80 @@ class TestSendToPlatformChunking:
             "***",
             "C123",
             "*hello* from <https://example.com|Hermes>",
+            thread_id=None,
         )
+
+    def test_slack_thread_id_is_forwarded_to_sender(self, monkeypatch):
+        _ensure_slack_mock(monkeypatch)
+
+        import gateway.platforms.slack as slack_mod
+
+        monkeypatch.setattr(slack_mod, "SLACK_AVAILABLE", True)
+        send = AsyncMock(return_value={"success": True, "message_id": "1"})
+
+        with patch("tools.send_message_tool._send_slack", send):
+            result = asyncio.run(
+                _send_to_platform(
+                    Platform.SLACK,
+                    SimpleNamespace(enabled=True, token="***", extra={}),
+                    "C123",
+                    "thread reply",
+                    thread_id="1779324848.822579",
+                )
+            )
+
+        assert result["success"] is True
+        send.assert_awaited_once_with(
+            "***",
+            "C123",
+            "thread reply",
+            thread_id="1779324848.822579",
+        )
+
+    def test_send_slack_includes_thread_ts_when_thread_id_present(self, monkeypatch):
+        captured_payload = {}
+
+        class FakeResponse:
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc, tb):
+                return False
+
+            async def json(self):
+                return {"ok": True, "ts": "1779325000.000001"}
+
+        class FakeSession:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc, tb):
+                return False
+
+            def post(self, _url, *, json, **_kwargs):
+                captured_payload.update(json)
+                return FakeResponse()
+
+        fake_aiohttp = SimpleNamespace(
+            ClientSession=FakeSession,
+            ClientTimeout=lambda total: SimpleNamespace(total=total),
+        )
+        monkeypatch.setitem(sys.modules, "aiohttp", fake_aiohttp)
+
+        result = asyncio.run(
+            _send_slack(
+                "xoxb-token",
+                "C123",
+                "thread reply",
+                thread_id="1779324848.822579",
+            )
+        )
+
+        assert result["success"] is True
+        assert captured_payload["thread_ts"] == "1779324848.822579"
 
     def test_slack_bold_italic_formatted_before_send(self, monkeypatch):
         """Bold+italic ***text*** survives tool-layer formatting."""
@@ -2569,4 +2643,3 @@ class TestSendTelegramThreadNotFoundRetry:
         finally:
             if media_path and os.path.exists(media_path):
                 os.unlink(media_path)
-

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -742,7 +742,7 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
     last_result = None
     for chunk in chunks:
         if platform == Platform.SLACK:
-            result = await _send_slack(pconfig.token, chat_id, chunk)
+            result = await _send_slack(pconfig.token, chat_id, chunk, thread_id=thread_id)
         elif platform == Platform.WHATSAPP:
             result = await _send_whatsapp(pconfig.extra, chat_id, chunk)
         elif platform == Platform.SIGNAL:
@@ -1247,7 +1247,7 @@ async def _send_discord(token, chat_id, message, thread_id=None, media_files=Non
         return _error(f"Discord send failed: {e}")
 
 
-async def _send_slack(token, chat_id, message):
+async def _send_slack(token, chat_id, message, thread_id=None):
     """Send via Slack Web API."""
     try:
         import aiohttp
@@ -1261,6 +1261,8 @@ async def _send_slack(token, chat_id, message):
         headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
         async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=30), **_sess_kw) as session:
             payload = {"channel": chat_id, "text": message, "mrkdwn": True}
+            if thread_id:
+                payload["thread_ts"] = thread_id
             async with session.post(url, headers=headers, json=payload, **_req_kw) as resp:
                 data = await resp.json()
                 if data.get("ok"):


### PR DESCRIPTION
## Summary
- pass Slack thread IDs through the standalone `send_message` dispatch path
- include `thread_ts` in Slack Web API payloads when a thread target is supplied
- add regression coverage for forwarding and payload generation

## Tests
- `uv run --extra dev --extra messaging pytest tests/tools/test_send_message_tool.py -q`
- `uv run --extra dev ruff check tools/send_message_tool.py tests/tools/test_send_message_tool.py`
- `uv run python -m py_compile tools/send_message_tool.py`
