### PR TITLE
fix(terminal): preserve gh auth with profile home isolation

### DIFF
--- a/tests/test_subprocess_home_isolation.py
+++ b/tests/test_subprocess_home_isolation.py
@@ -179,6 +179,47 @@ class TestMakeRunEnvHomeInjection:
         assert result["HERMES_HOME"] == str(profile)
         assert result["HOME"] == str(profile / "home")
 
+    def test_preserves_host_gh_config_when_profile_home_hides_it(self, tmp_path, monkeypatch):
+        account_home = tmp_path / "account"
+        hermes_home = tmp_path / "hermes"
+        account_gh = account_home / ".config" / "gh"
+        profile_home = hermes_home / "home"
+        account_gh.mkdir(parents=True)
+        profile_home.mkdir(parents=True)
+        (account_gh / "hosts.yml").write_text("github.com: {}\n")
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv("HOME", str(account_home))
+        monkeypatch.delenv("GH_CONFIG_DIR", raising=False)
+        monkeypatch.setenv("PATH", "/usr/bin:/bin")
+
+        from tools.environments.local import _make_run_env
+
+        result = _make_run_env({})
+
+        assert result["HOME"] == str(profile_home)
+        assert result["GH_CONFIG_DIR"] == str(account_gh)
+
+    def test_profile_gh_config_wins_without_gh_config_dir(self, tmp_path, monkeypatch):
+        account_home = tmp_path / "account"
+        hermes_home = tmp_path / "hermes"
+        profile_gh = hermes_home / "home" / ".config" / "gh"
+        account_gh = account_home / ".config" / "gh"
+        profile_gh.mkdir(parents=True)
+        account_gh.mkdir(parents=True)
+        (profile_gh / "hosts.yml").write_text("github.com: {}\n")
+        (account_gh / "hosts.yml").write_text("github.com: {}\n")
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv("HOME", str(account_home))
+        monkeypatch.delenv("GH_CONFIG_DIR", raising=False)
+        monkeypatch.setenv("PATH", "/usr/bin:/bin")
+
+        from tools.environments.local import _make_run_env
+
+        result = _make_run_env({})
+
+        assert result["HOME"] == str(hermes_home / "home")
+        assert "GH_CONFIG_DIR" not in result
+
 
 # ---------------------------------------------------------------------------
 # _sanitize_subprocess_env() injection
@@ -230,6 +271,25 @@ class TestSanitizeSubprocessEnvHomeInjection:
 
         assert result["HERMES_HOME"] == str(profile)
         assert result["HOME"] == str(profile / "home")
+
+    def test_preserves_host_gh_config_for_background_env(self, tmp_path, monkeypatch):
+        account_home = tmp_path / "account"
+        hermes_home = tmp_path / "hermes"
+        account_gh = account_home / ".config" / "gh"
+        profile_home = hermes_home / "home"
+        account_gh.mkdir(parents=True)
+        profile_home.mkdir(parents=True)
+        (account_gh / "hosts.yml").write_text("github.com: {}\n")
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.delenv("GH_CONFIG_DIR", raising=False)
+
+        base_env = {"HOME": str(account_home), "PATH": "/usr/bin"}
+        from tools.environments.local import _sanitize_subprocess_env
+
+        result = _sanitize_subprocess_env(base_env)
+
+        assert result["HOME"] == str(profile_home)
+        assert result["GH_CONFIG_DIR"] == str(account_gh)
 
 
 # ---------------------------------------------------------------------------

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -3,6 +3,7 @@
 import logging
 import os
 import platform
+import pwd
 import re
 import shutil
 import signal
@@ -183,6 +184,35 @@ def _inject_context_hermes_home(env: dict) -> None:
         pass
 
 
+def _preserve_github_cli_config(env: dict, *, next_home: str | None) -> None:
+    """Expose host-level gh auth when profile HOME isolation hides it."""
+    if env.get("GH_CONFIG_DIR") or not next_home or _IS_WINDOWS:
+        return
+
+    profile_gh_hosts = Path(next_home).expanduser() / ".config" / "gh" / "hosts.yml"
+    if profile_gh_hosts.exists():
+        return
+
+    candidates: list[Path] = []
+    current_home = env.get("HOME")
+    if current_home:
+        candidates.append(Path(current_home).expanduser() / ".config" / "gh")
+    try:
+        candidates.append(Path(pwd.getpwuid(os.getuid()).pw_dir) / ".config" / "gh")
+    except Exception:
+        pass
+
+    seen: set[Path] = set()
+    for candidate in candidates:
+        resolved = candidate.resolve(strict=False)
+        if resolved in seen:
+            continue
+        seen.add(resolved)
+        if (candidate / "hosts.yml").is_file():
+            env["GH_CONFIG_DIR"] = str(candidate)
+            return
+
+
 def _sanitize_subprocess_env(base_env: dict | None, extra_env: dict | None = None) -> dict:
     """Filter Hermes-managed secrets from a subprocess environment."""
     try:
@@ -211,6 +241,7 @@ def _sanitize_subprocess_env(base_env: dict | None, extra_env: dict | None = Non
     from hermes_constants import get_subprocess_home
     _profile_home = get_subprocess_home()
     if _profile_home:
+        _preserve_github_cli_config(sanitized, next_home=_profile_home)
         sanitized["HOME"] = _profile_home
 
     return sanitized
@@ -315,6 +346,7 @@ def _make_run_env(env: dict) -> dict:
     from hermes_constants import get_subprocess_home
     _profile_home = get_subprocess_home()
     if _profile_home:
+        _preserve_github_cli_config(run_env, next_home=_profile_home)
         run_env["HOME"] = _profile_home
 
     # Inject ContextVar-based session vars into subprocess env.


### PR DESCRIPTION
## Summary
- preserve host-level GitHub CLI auth when Hermes profile HOME isolation rewrites subprocess `HOME`
- set `GH_CONFIG_DIR` only when the profiled `home/` has no `gh` config but the account-level config does
- apply the same fallback to both foreground and background local terminal environments

Fixes #29529.

## Proof
- `uv run --frozen pytest -q -o addopts= tests/tools/test_local_env_blocklist.py tests/tools/test_env_passthrough.py tests/test_subprocess_home_isolation.py`
- `uv run --frozen ruff check tools/environments/local.py tests/test_subprocess_home_isolation.py`
- `git diff --check`

## Notes
- The targeted pytest suite is green at `423b255482704ffcf8344f9b43cf6f6c959e63f5`.
- The repeated `PytestUnhandledThreadExceptionWarning` lines from `tests/tools/test_local_env_blocklist.py` are preexisting unrelated warning noise from that test family; they are not introduced by this diff.
