### PR TITLE
fix(compress): retry summary on connection error and preserve recent turns on fallback (#29559)

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -587,6 +587,10 @@ class ContextCompressor(ContextEngine):
         self._ineffective_compression_count: int = 0
         self._summary_failure_cooldown_until: float = 0.0
         self._last_summary_error: Optional[str] = None
+        # One-shot retry guard for transient connection errors when no
+        # cross-model fallback is available (or already used).  Reset at the
+        # start of every compress() call.  See issue #29559.
+        self._summary_connection_retried: bool = False
         # When summary generation fails and a static fallback is inserted,
         # record how many turns were unrecoverably dropped so callers
         # (gateway hygiene, /compress) can surface a visible warning.
@@ -1082,6 +1086,7 @@ The user has requested that this compaction PRIORITISE preserving all informatio
             self._summary_failure_cooldown_until = 0.0
             self._summary_model_fallen_back = False
             self._last_summary_error = None
+            self._summary_connection_retried = False
             return self._with_summary_prefix(summary)
         except RuntimeError:
             # No provider configured — long cooldown, unlikely to self-resolve
@@ -1172,6 +1177,26 @@ The user has requested that this compaction PRIORITISE preserving all informatio
                 and not getattr(self, "_summary_model_fallen_back", False)
             ):
                 self._fallback_to_main_for_compression(e, "failed")
+                return self._generate_summary(turns_to_summarize, focus_topic=focus_topic)
+
+            # Transient connection error and no cross-model fallback is
+            # available (no aux summary_model, or aux already fell back to
+            # main): instead of immediately entering cooldown — which causes
+            # the legacy fallback to drop the entire compress window with a
+            # static placeholder (issue #29559) — attempt exactly one
+            # same-model retry after a brief delay.
+            if (
+                _is_streaming_closed
+                and not getattr(self, "_summary_connection_retried", False)
+            ):
+                self._summary_connection_retried = True
+                logger.info(
+                    "Context compression: transient connection error from "
+                    "summary LLM (%s). Retrying once on the same model "
+                    "after a brief delay before falling back.",
+                    e.__class__.__name__,
+                )
+                time.sleep(1.0)
                 return self._generate_summary(turns_to_summarize, focus_topic=focus_topic)
 
             # Transient errors (timeout, rate limit, network, JSON decode,
@@ -1522,6 +1547,7 @@ The user has requested that this compaction PRIORITISE preserving all informatio
         self._last_aux_model_failure_error = None
         self._last_aux_model_failure_model = None
         self._last_compress_aborted = False
+        self._summary_connection_retried = False
 
         # Manual /compress (force=True) bypasses the failure cooldown so the
         # user can retry immediately after an auto-compress abort.  Without
@@ -1646,19 +1672,48 @@ The user has requested that this compaction PRIORITISE preserving all informatio
         # Legacy fallback path: LLM summary failed and abort_on_summary_failure
         # is False (the default).  Insert a static placeholder so the model
         # knows context was lost rather than silently dropping everything.
+        # When the failure looks transient (connection error → we already
+        # tried a same-model retry), preserve additional recent turns from
+        # the compress window so the user retains usable context. (#29559)
         if not summary:
             if not self.quiet_mode:
                 logger.warning("Summary generation failed — inserting static fallback context marker")
-            n_dropped = compress_end - compress_start
+            window_len = compress_end - compress_start
+            _is_transient = bool(getattr(self, "_summary_connection_retried", False))
+            if _is_transient and window_len > 0:
+                _preserve_tail = min(20, window_len)
+                # Preserve the last _preserve_tail raw turns from the
+                # compress window by shrinking the dropped range.
+                _new_compress_end = compress_end - _preserve_tail
+            else:
+                _preserve_tail = 0
+                _new_compress_end = compress_end
+            n_dropped = _new_compress_end - compress_start
             self._last_summary_dropped_count = n_dropped
             self._last_summary_fallback_used = True
-            summary = (
-                f"{SUMMARY_PREFIX}\n"
-                f"Summary generation was unavailable. {n_dropped} message(s) were "
-                f"removed to free context space but could not be summarized. The removed "
-                f"messages contained earlier work in this session. Continue based on the "
-                f"recent messages below and the current state of any files or resources."
-            )
+            if _preserve_tail > 0:
+                summary = (
+                    f"{SUMMARY_PREFIX}\n"
+                    f"WARNING: Summary generation was unavailable due to a transient "
+                    f"error. {n_dropped} earlier message(s) were removed without a "
+                    f"summary; the {_preserve_tail} most recent message(s) from that "
+                    f"window are preserved below for continuity. You may need to ask "
+                    f"the user to clarify recent state — do not assume the dropped "
+                    f"messages are recoverable."
+                )
+            else:
+                summary = (
+                    f"{SUMMARY_PREFIX}\n"
+                    f"WARNING: Summary generation was unavailable. {n_dropped} "
+                    f"message(s) were removed to free context space but could not "
+                    f"be summarized. The removed messages contained earlier work in "
+                    f"this session. Continue based on the recent messages below and "
+                    f"the current state of any files or resources — you may need to "
+                    f"ask the user to clarify recent state."
+                )
+            # Shrink the dropped window so the preserved tail messages are
+            # re-emitted into the final compressed output below.
+            compress_end = _new_compress_end
 
         _merge_summary_into_tail = False
         last_head_role = messages[compress_start - 1].get("role", "user") if compress_start > 0 else "user"

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -631,6 +631,128 @@ class TestStreamingClosedFallback:
         assert c._summary_failure_cooldown_until == 1060.0
 
 
+class TestConnectionErrorSameModelRetry:
+    """Issue #29559: when a transient connection error occurs and no
+    cross-model fallback is available (either no aux summary_model, or aux
+    has already fallen back to main), _generate_summary must do exactly one
+    same-model retry before entering cooldown.  When that retry also fails,
+    the legacy fallback path must preserve recent tail messages from the
+    compress window instead of dropping the entire window."""
+
+    def _msgs(self):
+        return [
+            {"role": "user", "content": "do something"},
+            {"role": "assistant", "content": "ok"},
+        ]
+
+    def test_connection_error_triggers_one_same_model_retry_then_succeeds(self):
+        """ConnectionError on main model → one retry → success, no placeholder."""
+        mock_ok = MagicMock()
+        mock_ok.choices = [MagicMock()]
+        mock_ok.choices[0].message.content = "recovered summary"
+
+        err = Exception("RemoteProtocolError: peer closed connection")
+
+        with patch("agent.context_compressor.get_model_context_length", return_value=100000):
+            c = ContextCompressor(model="main-model", quiet_mode=True)
+
+        with patch(
+            "agent.context_compressor.call_llm",
+            side_effect=[err, mock_ok],
+        ) as mock_call, patch(
+            "agent.context_compressor._is_connection_error",
+            return_value=True,
+        ), patch("agent.context_compressor.time.sleep"):
+            result = c._generate_summary(self._msgs())
+
+        assert mock_call.call_count == 2
+        # Both calls hit the same (main) model — no model kwarg switch.
+        assert "model" not in mock_call.call_args_list[0].kwargs
+        assert "model" not in mock_call.call_args_list[1].kwargs
+        assert result is not None
+        assert "recovered summary" in result
+        assert c._summary_failure_cooldown_until == 0.0
+
+    def test_only_one_retry_per_compress_call(self):
+        """A second connection error after the retry must NOT loop — it falls
+        through to the cooldown branch."""
+        err = Exception("RemoteProtocolError: peer closed connection")
+
+        with patch("agent.context_compressor.get_model_context_length", return_value=100000):
+            c = ContextCompressor(model="main-model", quiet_mode=True)
+
+        with patch(
+            "agent.context_compressor.call_llm",
+            side_effect=err,
+        ) as mock_call, patch(
+            "agent.context_compressor._is_connection_error",
+            return_value=True,
+        ), patch("agent.context_compressor.time.sleep"), patch(
+            "agent.context_compressor.time.monotonic", return_value=1000.0
+        ):
+            result = c._generate_summary(self._msgs())
+
+        assert result is None
+        # Exactly two calls: original + one retry.
+        assert mock_call.call_count == 2
+        # 30s short cooldown for streaming-closed.
+        assert c._summary_failure_cooldown_until == 1030.0
+
+    def test_compress_preserves_recent_tail_when_retry_also_fails(self):
+        """When the connection-error retry also fails, the legacy fallback
+        path must keep recent tail messages of the compress window rather
+        than dropping the entire window with a static placeholder."""
+        err = Exception("RemoteProtocolError: peer closed connection")
+
+        with patch("agent.context_compressor.get_model_context_length", return_value=100000):
+            c = ContextCompressor(
+                model="main-model",
+                quiet_mode=True,
+                protect_first_n=2,
+                protect_last_n=2,
+            )
+
+        # Build a longer message list so the compress window has > 20 turns
+        # and we can verify the preserved-tail behavior.
+        msgs = [{"role": "system", "content": "sys"}]
+        for i in range(40):
+            role = "user" if i % 2 == 0 else "assistant"
+            msgs.append({"role": role, "content": f"middle-{i}"})
+        msgs.append({"role": "user", "content": "tail-protected-1"})
+        msgs.append({"role": "assistant", "content": "tail-protected-2"})
+
+        with patch(
+            "agent.context_compressor.call_llm",
+            side_effect=err,
+        ), patch(
+            "agent.context_compressor._is_connection_error",
+            return_value=True,
+        ), patch("agent.context_compressor.time.sleep"):
+            result = c.compress(msgs)
+
+        assert c._last_summary_fallback_used is True
+        # Some of the latest "middle-*" messages from the compress window
+        # must survive (the preserved tail).
+        contents = [m.get("content") for m in result if isinstance(m.get("content"), str)]
+        preserved_middle = [c2 for c2 in contents if c2 and c2.startswith("middle-")]
+        assert len(preserved_middle) > 0, (
+            "Expected recent compress-window messages to be preserved when "
+            "summary failed due to a transient connection error."
+        )
+        # The placeholder must be present and use the new WARNING prefix.
+        assert any(
+            isinstance(m.get("content"), str)
+            and "WARNING" in m["content"]
+            and "Summary generation was unavailable" in m["content"]
+            for m in result
+        )
+        # Dropped count should reflect the shrunk window, not the full window.
+        full_window = 40 + 1 - 2  # 40 middle + system - protect_first_n=2
+        # (we only assert it's less than full window since exact count depends
+        # on boundary alignment internals)
+        assert 0 < c._last_summary_dropped_count < full_window
+
+
 class TestAuxModelFallbackSurfacedToCallers:
     """When summary_model fails but retry-on-main succeeds, compress() must
     expose the aux-model failure via _last_aux_model_failure_{model,error}


### PR DESCRIPTION
## Summary

Fixes #29559.

When context compression runs and the summary LLM hits a transient connection error with no cross-model fallback available (no aux `summary_model`, or aux already fell back to main), the previous behavior was to immediately enter a 60s cooldown and return `None`. The legacy fallback path in `compress_messages` then replaced the entire compress window with a static "Summary generation was unavailable" placeholder, silently dropping every middle message — catastrophic for long multi-turn sessions where a single network blip wipes 100+ turns.

Reproducing log from the issue:
```
agent.conversation_compression: context compression started: messages=124 tokens=~100,157
root: Failed to generate context summary: Connection error.. Further summary attempts paused for 30 seconds.
agent.conversation_compression: context compression done: messages=124->15 tokens=~28,865
```

## Changes

1. **One-shot same-model retry on connection error** (`_generate_summary`)
   When `_is_connection_error(e)` is true and the aux-fallback paths don't apply, sleep ~1s, log at INFO, and retry once on the same model. Guarded by `self._summary_connection_retried`, reset at the start of every `compress()` call and cleared on success. Prevents infinite recursion; second failure proceeds to the existing transient-cooldown branch.

2. **Preserve recent turns on transient-failure fallback** (`compress_messages`)
   When the static fallback path fires AND the retry guard fired (i.e. transient cause), preserve the last `min(20, window_len)` raw turns from the compress window by shrinking `compress_end` before the assembly phase. `_last_summary_dropped_count` is updated to reflect the actual loss so gateway hygiene still surfaces the correct warning.

3. **More prominent placeholder text**
   Now starts with `WARNING:` and explicitly tells the model it may need to ask the user to clarify recent state. The existing `"Summary generation was unavailable"` substring is retained so older test assertions still pass.

## Testing

```
pytest tests/agent/test_context_compressor.py
# 86 passed in 28.07s
```

New tests in `TestConnectionErrorSameModelRetry`:
- Connection error → one same-model retry → success (no placeholder, no cooldown).
- Retry also fails → exactly two LLM calls, then 30s cooldown (no infinite loop).
- End-to-end `compress()` preserves recent middle messages on transient-failure fallback.

## Risk

Surgical change in one file plus tests. Non-transient failure paths (404, 503, timeout, JSON decode, no provider configured) are unchanged. The placeholder text update keeps the old substring so existing assertions continue to hold.
