### PR TITLE
fix(compression): persist rotated session snapshot immediately

### DIFF
--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -406,6 +406,13 @@ def compress_context(
             agent._session_db.update_system_prompt(agent.session_id, new_system_prompt)
             # Reset flush cursor — new session starts with no messages written
             agent._last_flushed_db_idx = 0
+            # Persist the compressed snapshot immediately so any session-list /
+            # transcript refetch that notices the rotated session_id can load
+            # the latest assistant turn without waiting for the outer
+            # end-of-turn _persist_session() call.
+            agent._session_messages = compressed
+            agent._save_session_log(compressed)
+            agent._flush_messages_to_session_db(compressed, None)
         except Exception as e:
             logger.warning("Session DB compression split failed — new session will NOT be indexed: %s", e)
 

--- a/tests/run_agent/test_compression_boundary_hook.py
+++ b/tests/run_agent/test_compression_boundary_hook.py
@@ -160,3 +160,54 @@ class TestCompressionBoundaryHook:
             )
             assert compressed
             assert agent.session_id != original_sid
+
+    def test_compression_split_immediately_persists_new_session_snapshot(self):
+        """The rotated session should already contain the compressed transcript."""
+        from hermes_state import SessionDB
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db = SessionDB(db_path=Path(tmpdir) / "test.db")
+            hermes_home = Path(tmpdir) / "hermes-home"
+            hermes_home.mkdir()
+            with patch.dict(
+                os.environ,
+                {
+                    "OPENROUTER_API_KEY": "test-key",
+                    "HERMES_HOME": str(hermes_home),
+                },
+            ):
+                agent = self._make_agent(db)
+
+            db.create_session(session_id=agent.session_id, source="test")
+            original_sid = agent.session_id
+
+            compressor = MagicMock()
+            compressor.compress.return_value = [
+                {"role": "user", "content": "[CONTEXT COMPACTION] summary"},
+                {"role": "assistant", "content": "just-finished answer"},
+            ]
+            compressor.compression_count = 1
+            compressor.last_prompt_tokens = 0
+            compressor.last_completion_tokens = 0
+            compressor._last_summary_error = None
+            compressor._last_compress_aborted = False
+            compressor._last_aux_model_failure_model = None
+            compressor._last_aux_model_failure_error = None
+            agent.context_compressor = compressor
+
+            compressed, _prompt = agent._compress_context(
+                [{"role": "user", "content": "older question"}],
+                "sys",
+                approx_tokens=100,
+            )
+
+            assert agent.session_id != original_sid
+            assert agent._last_flushed_db_idx == len(compressed)
+
+            rows = db.get_messages(agent.session_id)
+            assert [row["role"] for row in rows] == ["user", "assistant"]
+            assert [row["content"] for row in rows] == [
+                "[CONTEXT COMPACTION] summary",
+                "just-finished answer",
+            ]
+            assert agent._session_messages == compressed


### PR DESCRIPTION
## Summary
- persist the compressed transcript immediately after a compression-driven session split
- advance the new session flush cursor so later end-of-turn persistence does not duplicate writes
- add a regression test that reads the rotated session immediately and verifies the latest assistant turn is already present

## Testing
- uv run --frozen pytest -q -o addopts= tests/run_agent/test_compression_boundary_hook.py tests/run_agent/test_compression_persistence.py
- uv run --frozen ruff check agent/conversation_compression.py tests/run_agent/test_compression_boundary_hook.py
- git diff --check

Fixes #29522