### PR TITLE
test(plugins): add xai to bundled web search plugin test suite

### DIFF
--- a/tests/plugins/web/test_web_search_provider_plugins.py
+++ b/tests/plugins/web/test_web_search_provider_plugins.py
@@ -2,8 +2,8 @@
 
 Covers:
 
-- All seven bundled plugins (brave-free, ddgs, searxng, exa, parallel,
-  tavily, firecrawl) instantiate and self-report the expected
+- All eight bundled plugins (brave-free, ddgs, searxng, exa, parallel,
+  tavily, firecrawl, xai) instantiate and self-report the expected
   capabilities + ABC-derived defaults.
 - Each plugin's ``is_available()`` correctly reflects env-var presence.
 - The web_search_registry resolves an active provider in the documented
@@ -47,6 +47,7 @@ def _clear_web_env(monkeypatch: pytest.MonkeyPatch) -> None:
         "FIRECRAWL_GATEWAY_URL",
         "TOOL_GATEWAY_DOMAIN",
         "TOOL_GATEWAY_USER_TOKEN",
+        "XAI_API_KEY",
     ):
         monkeypatch.delenv(k, raising=False)
 
@@ -70,9 +71,9 @@ def _isolate_env(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 class TestBundledPluginsRegister:
-    """All seven bundled web plugins discover and register correctly."""
+    """All eight bundled web plugins discover and register correctly."""
 
-    def test_all_seven_plugins_present_in_registry(self) -> None:
+    def test_all_eight_plugins_present_in_registry(self) -> None:
         _ensure_plugins_loaded()
         from agent.web_search_registry import list_providers
 
@@ -85,6 +86,7 @@ class TestBundledPluginsRegister:
             "parallel",
             "searxng",
             "tavily",
+            "xai",
         ]
 
     @pytest.mark.parametrize(
@@ -100,6 +102,9 @@ class TestBundledPluginsRegister:
             # disabled in the migration (fell through to a legacy inline
             # path); the follow-up commit enabled it natively.
             ("firecrawl", True, True, True),
+            # xai: Grok-backed agentic web search. Server-side web_search
+            # returns LLM-summarized result rows; no extract/crawl surface.
+            ("xai", True, False, False),
         ],
     )
     def test_capability_flags_match_spec(
@@ -120,7 +125,7 @@ class TestBundledPluginsRegister:
 
     @pytest.mark.parametrize(
         "plugin_name",
-        ["brave-free", "ddgs", "searxng", "exa", "parallel", "tavily", "firecrawl"],
+        ["brave-free", "ddgs", "searxng", "exa", "parallel", "tavily", "firecrawl", "xai"],
     )
     def test_each_plugin_has_name_and_display_name(self, plugin_name: str) -> None:
         _ensure_plugins_loaded()
@@ -133,7 +138,7 @@ class TestBundledPluginsRegister:
 
     @pytest.mark.parametrize(
         "plugin_name",
-        ["brave-free", "ddgs", "searxng", "exa", "parallel", "tavily", "firecrawl"],
+        ["brave-free", "ddgs", "searxng", "exa", "parallel", "tavily", "firecrawl", "xai"],
     )
     def test_each_plugin_has_setup_schema(self, plugin_name: str) -> None:
         """``get_setup_schema()`` returns a dict the picker can consume."""
@@ -221,6 +226,32 @@ class TestIsAvailable:
         assert p.is_available() is True
         monkeypatch.delenv("FIRECRAWL_API_KEY", raising=False)
         monkeypatch.setenv("FIRECRAWL_API_URL", "http://localhost:3002")
+        assert p.is_available() is True
+
+    def test_xai_requires_api_key_or_oauth(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path
+    ) -> None:
+        """xai is_available() lights up on XAI_API_KEY or auth.json OAuth tokens.
+
+        Isolates HERMES_HOME so a developer's real ~/.hermes/auth.json
+        doesn't leak OAuth credentials into the assert-False half of the
+        test. has_xai_credentials() reads auth.json directly, so the
+        env-clear alone is not sufficient.
+        """
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        # Nuke any cached home path the config module may hold.
+        import hermes_cli.config as _cfg
+        if hasattr(_cfg, "_HERMES_HOME_CACHE"):
+            _cfg._HERMES_HOME_CACHE = None  # type: ignore[attr-defined]
+
+        _ensure_plugins_loaded()
+        from agent.web_search_registry import get_provider
+
+        p = get_provider("xai")
+        assert p is not None
+        # Clean HERMES_HOME has no auth.json + fixture cleared XAI_API_KEY.
+        assert p.is_available() is False
+        monkeypatch.setenv("XAI_API_KEY", "real")
         assert p.is_available() is True
 
     def test_ddgs_always_available_when_package_importable(self) -> None:

--- a/tests/plugins/web/test_web_search_provider_plugins.py
+++ b/tests/plugins/web/test_web_search_provider_plugins.py
@@ -239,10 +239,13 @@ class TestIsAvailable:
         env-clear alone is not sufficient.
         """
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
-        # Nuke any cached home path the config module may hold.
+        # Reset any cached home path the config module may hold; using
+        # monkeypatch.setattr (rather than direct assignment) so pytest
+        # restores the original cache value on teardown and the test can't
+        # leak a None into subsequent tests' resolve path.
         import hermes_cli.config as _cfg
         if hasattr(_cfg, "_HERMES_HOME_CACHE"):
-            _cfg._HERMES_HOME_CACHE = None  # type: ignore[attr-defined]
+            monkeypatch.setattr(_cfg, "_HERMES_HOME_CACHE", None, raising=False)
 
         _ensure_plugins_loaded()
         from agent.web_search_registry import get_provider


### PR DESCRIPTION
## What does this PR do?

The xAI Web Search provider plugin landed on `origin/main` as commit `a0c031299 feat(web): add xAI Web Search provider plugin` on 2026-05-19, bringing the bundled web-search plugin count from 7 to 8. The fixture in `tests/plugins/web/test_web_search_provider_plugins.py` was not updated to match, so the `Tests` workflow has been red on every push to `main` and on every open PR ever since (`24563 passed, 2 failed`):

```
FAILED tests/plugins/web/test_web_search_provider_plugins.py::TestBundledPluginsRegister::test_all_seven_plugins_present_in_registry
  AssertionError: Left contains one more item: 'xai'
```

This PR aligns the test file to the new 8-plugin reality. No production-code change — the production plugin and its registry wiring are already correct on `main`; only the test fixture needed to follow.

The second baseline failure (`tests/hermes_cli/test_update_hangup_protection.py::TestInstallHangupProtection::test_wraps_stdout_and_stderr_with_mirror`) looks like a separate test-isolation issue around `_UpdateOutputStream` identity and is intentionally out of scope here — a one-line `xai`-addition PR shouldn't be bundled with a deeper test-isolation investigation.

## Related Issue

N/A — pure CI baseline fix following a production change.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tests/plugins/web/test_web_search_provider_plugins.py` — rename `test_all_seven_plugins_present_in_registry` → `test_all_eight_plugins_present_in_registry` and include `xai` in the sorted-name assertion; extend the `test_capability_flags_match_spec`, `test_each_plugin_has_name_and_display_name`, and `test_each_plugin_has_setup_schema` parametrize lists with `xai`; add `XAI_API_KEY` to `_clear_web_env()`; add `TestIsAvailable::test_xai_requires_api_key_or_oauth` (isolates `HERMES_HOME` to a tmp_path so a developer's real `~/.hermes/auth.json` doesn't leak OAuth tokens into the assert-False half — `has_xai_credentials()` reads auth.json directly, so the env-clear alone isn't sufficient); update the module docstring header (`seven` → `eight`, `firecrawl)` → `firecrawl, xai)`).

## How to Test

1. Reproduce the failure on clean `origin/main`:
   ```
   uv run --with pytest --with pytest-xdist --with pytest-asyncio --with pytest-timeout \
     python3 -m pytest tests/plugins/web/test_web_search_provider_plugins.py -v
   ```
   → 1 failed (`test_all_seven_plugins_present_in_registry`), 36 passed.
2. Apply this PR and re-run the same command.
   → `49 passed in 1.37s` (12 new parametrized cases + 1 new `test_xai_requires_api_key_or_oauth`).
3. Spot-check the production plugin still self-reports correctly:
   ```python
   from hermes_cli.plugins import _ensure_plugins_discovered
   from agent.web_search_registry import get_provider
   _ensure_plugins_discovered()
   p = get_provider(\"xai\")
   assert p.name == \"xai\" and p.supports_search() and not p.supports_extract() and not p.supports_crawl()
   ```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`test(plugins): …`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run focused tests for the touched code and all pass (49/49)
- [x] I've added tests for my changes (1 new is_available test for xai)
- [x] I've tested on my platform: macOS 15.x

### Documentation & Housekeeping

- [x] I've updated relevant documentation (module-header docstring) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no config changes)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — the new `test_xai_requires_api_key_or_oauth` is platform-agnostic (pure env-var + tmp_path)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

> Audited siblings: confirmed no other bundled-plugin-count assertions exist outside `tests/plugins/web/test_web_search_provider_plugins.py` (verified via `grep -rn 'seven\\|7.plugin' tests/plugins/web/` and `grep -rn 'list_providers' tests/`). No widening needed.