### PR TITLE
fix(skills): use HERMES_HOME in maps script path

### DIFF
--- a/skills/productivity/maps/SKILL.md
+++ b/skills/productivity/maps/SKILL.md
@@ -39,12 +39,12 @@ functionality is covered by the `nearby` command below, with the same
 
 Python 3.8+ (stdlib only — no pip installs needed).
 
-Script path: `~/.hermes/skills/maps/scripts/maps_client.py`
+Script path: `$HERMES_HOME/skills/productivity/maps/scripts/maps_client.py`
 
 ## Commands
 
 ```bash
-MAPS=~/.hermes/skills/maps/scripts/maps_client.py
+MAPS=$HERMES_HOME/skills/productivity/maps/scripts/maps_client.py
 ```
 
 ### search — Geocode a place name
@@ -187,9 +187,9 @@ current.
 ## Verification
 
 ```bash
-python3 ~/.hermes/skills/maps/scripts/maps_client.py search "Statue of Liberty"
+python3 "$HERMES_HOME/skills/productivity/maps/scripts/maps_client.py" search "Statue of Liberty"
 # Should return lat ~40.689, lon ~-74.044
 
-python3 ~/.hermes/skills/maps/scripts/maps_client.py nearby --near "Times Square" --category restaurant --limit 3
+python3 "$HERMES_HOME/skills/productivity/maps/scripts/maps_client.py" nearby --near "Times Square" --category restaurant --limit 3
 # Should return a list of restaurants within ~500m of Times Square
 ```


### PR DESCRIPTION
## Summary
- replace the broken `~/.hermes/skills/maps/...` references in the bundled `productivity/maps` skill
- point examples at `$HERMES_HOME/skills/productivity/maps/scripts/maps_client.py`, which keeps the category prefix and survives profile HOME isolation
- update the verification examples to use the same profile-safe path

## Testing
- tmp=$(mktemp -d); mkdir -p "$tmp/skills/productivity" "$tmp/profiles/test/home"; cp -R skills/productivity/maps "$tmp/skills/productivity/"; HOME="$tmp/profiles/test/home" HERMES_HOME="$tmp" bash -lc 'MAPS="$HERMES_HOME/skills/productivity/maps/scripts/maps_client.py"; test -f "$MAPS"; python3 "$MAPS" --help >/dev/null'; HOME="$tmp/profiles/test/home" HERMES_HOME="$tmp" bash -lc 'MAPS=~/.hermes/skills/maps/scripts/maps_client.py; test ! -f "$MAPS"'
- git diff --check

Fixes #29584
