### PR TITLE
fix(memory): forward on_pre_compress return value to compress() as pr…

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -910,7 +910,7 @@ class ContextCompressor(ContextEngine):
         self.summary_model = ""  # empty = use main model
         self._summary_failure_cooldown_until = 0.0  # no cooldown — retry immediately
 
-    def _generate_summary(self, turns_to_summarize: List[Dict[str, Any]], focus_topic: str = None) -> Optional[str]:
+    def _generate_summary(self, turns_to_summarize: List[Dict[str, Any]], focus_topic: str = None, provider_context: str = "") -> Optional[str]:
         """Generate a structured summary of conversation turns.
 
         Uses a structured template (Goal, Progress, Decisions, Resolved/Pending
@@ -1052,6 +1052,15 @@ Use this exact structure:
 FOCUS TOPIC: "{focus_topic}"
 The user has requested that this compaction PRIORITISE preserving all information related to the focus topic above. For content related to "{focus_topic}", include full detail — exact values, file paths, command outputs, error messages, and decisions. For content NOT related to the focus topic, summarise more aggressively (brief one-liners or omit if truly irrelevant). The focus topic sections should receive roughly 60-70% of the summary token budget. Even for the focus topic, NEVER preserve API keys, tokens, passwords, or credentials — use [REDACTED]."""
 
+        if provider_context and provider_context.strip():
+            prompt += (
+                "\n\nMEMORY PROVIDER CONTEXT:\n"
+                "The following information was surfaced by the active memory provider "
+                "before compression. Ensure the summary preserves context related to "
+                "these insights so they are not lost:\n"
+                + provider_context.strip()
+            )
+
         try:
             call_kwargs = {
                 "task": "compression",
@@ -1154,7 +1163,7 @@ The user has requested that this compaction PRIORITISE preserving all informatio
                 else:
                     _reason = "timed out"
                 self._fallback_to_main_for_compression(e, _reason)
-                return self._generate_summary(turns_to_summarize, focus_topic=focus_topic)  # retry immediately
+                return self._generate_summary(turns_to_summarize, focus_topic=focus_topic, provider_context=provider_context)  # retry immediately
 
             # Unknown-error best-effort retry on main model.  Losing N turns of
             # context is almost always worse than one extra summary attempt, so
@@ -1171,7 +1180,7 @@ The user has requested that this compaction PRIORITISE preserving all informatio
                 and not getattr(self, "_summary_model_fallen_back", False)
             ):
                 self._fallback_to_main_for_compression(e, "failed")
-                return self._generate_summary(turns_to_summarize, focus_topic=focus_topic)
+                return self._generate_summary(turns_to_summarize, focus_topic=focus_topic, provider_context=provider_context)
 
             # Transient errors (timeout, rate limit, network, JSON decode,
             # streaming premature-close) — shorter cooldown for JSON decode and
@@ -1491,7 +1500,7 @@ The user has requested that this compaction PRIORITISE preserving all informatio
     # Main compression entry point
     # ------------------------------------------------------------------
 
-    def compress(self, messages: List[Dict[str, Any]], current_tokens: int = None, focus_topic: str = None, force: bool = False) -> List[Dict[str, Any]]:
+    def compress(self, messages: List[Dict[str, Any]], current_tokens: int = None, focus_topic: str = None, force: bool = False, provider_context: str = "") -> List[Dict[str, Any]]:
         """Compress conversation messages by summarizing middle turns.
 
         Algorithm:
@@ -1600,7 +1609,7 @@ The user has requested that this compaction PRIORITISE preserving all informatio
             )
 
         # Phase 3: Generate structured summary
-        summary = self._generate_summary(turns_to_summarize, focus_topic=focus_topic)
+        summary = self._generate_summary(turns_to_summarize, focus_topic=focus_topic, provider_context=provider_context)
 
         # If summary generation failed, behavior splits on
         # ``abort_on_summary_failure`` (config: compression.abort_on_summary_failure):

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -305,18 +305,27 @@ def compress_context(
         "🗜️ Compacting context — summarizing earlier conversation so I can continue..."
     )
 
-    # Notify external memory provider before compression discards context
+    # Notify external memory provider before compression discards context.
+    # Capture the returned hint text (if any) to inject into the compression
+    # prompt so the summarisation LLM knows which facts to preserve.
+    _provider_context = ""
     if agent._memory_manager:
         try:
-            agent._memory_manager.on_pre_compress(messages)
+            _provider_context = agent._memory_manager.on_pre_compress(messages) or ""
         except Exception:
             pass
 
     try:
-        compressed = agent.context_compressor.compress(messages, current_tokens=approx_tokens, focus_topic=focus_topic, force=force)
+        compressed = agent.context_compressor.compress(
+            messages,
+            current_tokens=approx_tokens,
+            focus_topic=focus_topic,
+            force=force,
+            provider_context=_provider_context,
+        )
     except TypeError:
         # Plugin context engine with strict signature that doesn't accept
-        # focus_topic / force — fall back to calling without them.
+        # focus_topic / force / provider_context — fall back to calling without them.
         compressed = agent.context_compressor.compress(messages, current_tokens=approx_tokens)
 
     # If compression aborted (aux LLM failed to produce a usable summary)

--- a/plugins/memory/holographic/__init__.py
+++ b/plugins/memory/holographic/__init__.py
@@ -250,6 +250,32 @@ class HolographicMemoryProvider(MemoryProvider):
             except Exception as e:
                 logger.debug("Holographic memory_write mirror failed: %s", e)
 
+    def on_pre_compress(self, messages: List[Dict[str, Any]]) -> str:
+        """Return top-trust stored facts as compression hints.
+
+        Tells the compressor which facts are already persisted in the
+        holographic memory bank so it can preserve surrounding conversation
+        context that led to or elaborates on those facts.
+        """
+        if not self._store:
+            return ""
+        try:
+            rows = self._store.list_facts(
+                min_trust=self._min_trust,
+                limit=15,
+            )
+            if not rows:
+                return ""
+            lines = "\n".join(f"- {r['content']}" for r in rows)
+            return (
+                "The following facts are stored in the holographic memory bank "
+                "(highest trust first). Preserve conversation context related to "
+                "these facts and any updates or corrections to them:\n" + lines
+            )
+        except Exception as e:
+            logger.debug("Holographic on_pre_compress failed: %s", e)
+            return ""
+
     def shutdown(self) -> None:
         self._store = None
         self._retriever = None

--- a/tests/agent/test_compress_focus.py
+++ b/tests/agent/test_compress_focus.py
@@ -142,3 +142,123 @@ def test_compress_none_focus_by_default():
     compressor.compress(messages, current_tokens=100000)
 
     assert received_kwargs.get("focus_topic") is None
+
+
+# ---------------------------------------------------------------------------
+# provider_context injection tests (issue #23367)
+# ---------------------------------------------------------------------------
+
+
+def test_provider_context_injected_into_summary_prompt():
+    """When provider_context is provided, the LLM prompt includes the memory block."""
+    compressor = _make_compressor()
+    turns = [
+        {"role": "user", "content": "Set up the database"},
+        {"role": "assistant", "content": "Done, using PostgreSQL 15."},
+    ]
+
+    captured_prompt = {}
+
+    def mock_call_llm(**kwargs):
+        captured_prompt["messages"] = kwargs["messages"]
+        resp = MagicMock()
+        resp.choices = [MagicMock()]
+        resp.choices[0].message.content = "## Goal\nDB setup."
+        return resp
+
+    with patch("agent.context_compressor.call_llm", mock_call_llm):
+        compressor._generate_summary(
+            turns,
+            provider_context="User prefers PostgreSQL over MySQL",
+        )
+
+    text = captured_prompt["messages"][0]["content"]
+    assert "MEMORY PROVIDER CONTEXT" in text
+    assert "User prefers PostgreSQL over MySQL" in text
+
+
+def test_empty_provider_context_not_injected():
+    """Empty provider_context must not add the block to the prompt."""
+    compressor = _make_compressor()
+    turns = [
+        {"role": "user", "content": "Hello"},
+        {"role": "assistant", "content": "Hi there"},
+    ]
+
+    captured_prompt = {}
+
+    def mock_call_llm(**kwargs):
+        captured_prompt["messages"] = kwargs["messages"]
+        resp = MagicMock()
+        resp.choices = [MagicMock()]
+        resp.choices[0].message.content = "## Goal\nGreeting."
+        return resp
+
+    with patch("agent.context_compressor.call_llm", mock_call_llm):
+        compressor._generate_summary(turns, provider_context="")
+
+    text = captured_prompt["messages"][0]["content"]
+    assert "MEMORY PROVIDER CONTEXT" not in text
+
+
+def test_provider_context_and_focus_topic_coexist():
+    """provider_context and focus_topic can both appear in the same prompt."""
+    compressor = _make_compressor()
+    turns = [
+        {"role": "user", "content": "fix the auth bug"},
+        {"role": "assistant", "content": "Fixed JWT expiry check."},
+    ]
+
+    captured_prompt = {}
+
+    def mock_call_llm(**kwargs):
+        captured_prompt["messages"] = kwargs["messages"]
+        resp = MagicMock()
+        resp.choices = [MagicMock()]
+        resp.choices[0].message.content = "## Goal\nAuth fix."
+        return resp
+
+    with patch("agent.context_compressor.call_llm", mock_call_llm):
+        compressor._generate_summary(
+            turns,
+            focus_topic="authentication",
+            provider_context="User uses JWT tokens with 1h expiry",
+        )
+
+    text = captured_prompt["messages"][0]["content"]
+    assert 'FOCUS TOPIC: "authentication"' in text
+    assert "MEMORY PROVIDER CONTEXT" in text
+    assert "JWT" in text
+
+
+def test_compress_passes_provider_context_to_generate_summary():
+    """compress() passes provider_context through to _generate_summary."""
+    compressor = _make_compressor()
+
+    received_kwargs = {}
+
+    def tracking_generate(turns, **kwargs):
+        received_kwargs.update(kwargs)
+        return "## Goal\nTest."
+
+    compressor._generate_summary = tracking_generate
+
+    messages = [
+        {"role": "system", "content": "System prompt"},
+        {"role": "user", "content": "first"},
+        {"role": "assistant", "content": "reply1"},
+        {"role": "user", "content": "second"},
+        {"role": "assistant", "content": "reply2"},
+        {"role": "user", "content": "third"},
+        {"role": "assistant", "content": "reply3"},
+        {"role": "user", "content": "fourth"},
+        {"role": "assistant", "content": "reply4"},
+    ]
+
+    compressor.compress(
+        messages,
+        current_tokens=100000,
+        provider_context="User fact: prefers dark mode",
+    )
+
+    assert received_kwargs.get("provider_context") == "User fact: prefers dark mode"

--- a/tests/agent/test_memory_provider.py
+++ b/tests/agent/test_memory_provider.py
@@ -326,6 +326,45 @@ class TestMemoryManager:
         mgr.on_pre_compress([{"role": "user", "content": "old"}])
         assert p.pre_compress_called
 
+    def test_on_pre_compress_returns_combined_text(self):
+        """MemoryManager.on_pre_compress returns joined hint text from providers."""
+        mgr = MemoryManager()
+
+        class HintProvider(FakeMemoryProvider):
+            def on_pre_compress(self, messages):
+                self.pre_compress_called = True
+                return "important fact from provider"
+
+        p = HintProvider("ext")
+        mgr.add_provider(p)
+
+        result = mgr.on_pre_compress([{"role": "user", "content": "msg"}])
+        assert result == "important fact from provider"
+        assert p.pre_compress_called
+
+    def test_on_pre_compress_empty_provider_returns_empty(self):
+        """MemoryManager.on_pre_compress returns empty string when provider returns nothing."""
+        mgr = MemoryManager()
+        p = FakeMemoryProvider("ext")  # base returns ""
+        mgr.add_provider(p)
+
+        result = mgr.on_pre_compress([{"role": "user", "content": "msg"}])
+        assert result == ""
+
+    def test_on_pre_compress_whitespace_only_skipped(self):
+        """MemoryManager skips providers whose on_pre_compress returns only whitespace."""
+        mgr = MemoryManager()
+
+        class WhitespaceProvider(FakeMemoryProvider):
+            def on_pre_compress(self, messages):
+                return "   \n  "
+
+        p = WhitespaceProvider("ext")
+        mgr.add_provider(p)
+
+        result = mgr.on_pre_compress([])
+        assert result == ""
+
     def test_shutdown_all_reverse_order(self):
         mgr = MemoryManager()
         order = []

--- a/tests/run_agent/test_compression_boundary_hook.py
+++ b/tests/run_agent/test_compression_boundary_hook.py
@@ -1,4 +1,9 @@
-"""Test: the context engine is notified of a compression-boundary rollover.
+"""Tests: compression boundary hook and memory provider context chain.
+
+Tests that:
+1. The context engine is notified of a compression-boundary rollover.
+2. on_pre_compress return value is forwarded to compress() as provider_context
+   (issue #23367 — the chain was broken: return value was discarded).
 
 When _compress_context rotates session_id (compression split), the active
 context engine receives on_session_start(new_sid, boundary_reason="compression",
@@ -160,3 +165,123 @@ class TestCompressionBoundaryHook:
             )
             assert compressed
             assert agent.session_id != original_sid
+
+
+class TestMemoryProviderContextChain:
+    """Regression tests for issue #23367.
+
+    on_pre_compress() return value was silently discarded in
+    conversation_compression.py — it was never forwarded to compress() as
+    provider_context, so memory providers could never guide the compressor.
+    """
+
+    def _make_agent(self):
+        with patch.dict(os.environ, {"OPENROUTER_API_KEY": "test-key"}):
+            from run_agent import AIAgent
+            return AIAgent(
+                api_key="test-key",
+                base_url="https://openrouter.ai/api/v1",
+                model="test/model",
+                quiet_mode=True,
+                session_db=None,
+                session_id="test-session",
+                skip_context_files=True,
+                skip_memory=True,
+            )
+
+    def test_on_pre_compress_return_value_forwarded_to_compress(self):
+        """provider_context from on_pre_compress must reach compress()."""
+        agent = self._make_agent()
+
+        # Inject a mock memory manager whose on_pre_compress returns a hint
+        mock_mgr = MagicMock()
+        mock_mgr.on_pre_compress.return_value = "User prefers PostgreSQL over MySQL"
+        mock_mgr.build_system_prompt.return_value = ""
+        agent._memory_manager = mock_mgr
+
+        # Intercept compress() to capture what provider_context it receives
+        received = {}
+        compressor = MagicMock()
+
+        def capture_compress(messages, **kwargs):
+            received["provider_context"] = kwargs.get("provider_context", "")
+            return [{"role": "user", "content": "summary"}]
+
+        compressor.compress.side_effect = capture_compress
+        compressor.compression_count = 1
+        compressor.last_prompt_tokens = 0
+        compressor.last_completion_tokens = 0
+        compressor._last_summary_error = None
+        compressor._last_compress_aborted = False
+        agent.context_compressor = compressor
+
+        agent._compress_context(
+            [{"role": "user", "content": "msg"}], "sys", approx_tokens=100
+        )
+
+        assert received.get("provider_context") == "User prefers PostgreSQL over MySQL", (
+            "provider_context from on_pre_compress was not forwarded to compress(). "
+            f"Got: {received.get('provider_context')!r}"
+        )
+
+    def test_empty_on_pre_compress_forwards_empty_string(self):
+        """When on_pre_compress returns empty, compress() receives empty string."""
+        agent = self._make_agent()
+
+        mock_mgr = MagicMock()
+        mock_mgr.on_pre_compress.return_value = ""
+        mock_mgr.build_system_prompt.return_value = ""
+        agent._memory_manager = mock_mgr
+
+        received = {}
+        compressor = MagicMock()
+
+        def capture_compress(messages, **kwargs):
+            received["provider_context"] = kwargs.get("provider_context", "MISSING")
+            return [{"role": "user", "content": "summary"}]
+
+        compressor.compress.side_effect = capture_compress
+        compressor.compression_count = 1
+        compressor.last_prompt_tokens = 0
+        compressor.last_completion_tokens = 0
+        compressor._last_summary_error = None
+        compressor._last_compress_aborted = False
+        agent.context_compressor = compressor
+
+        agent._compress_context(
+            [{"role": "user", "content": "msg"}], "sys", approx_tokens=100
+        )
+
+        assert received.get("provider_context") == "", (
+            f"Expected empty string, got: {received.get('provider_context')!r}"
+        )
+
+    def test_no_memory_manager_still_compresses(self):
+        """Without a memory manager, compress() is still called normally."""
+        agent = self._make_agent()
+        agent._memory_manager = None
+
+        received = {}
+        compressor = MagicMock()
+
+        def capture_compress(messages, **kwargs):
+            received["called"] = True
+            received["provider_context"] = kwargs.get("provider_context", "MISSING")
+            return [{"role": "user", "content": "summary"}]
+
+        compressor.compress.side_effect = capture_compress
+        compressor.compression_count = 1
+        compressor.last_prompt_tokens = 0
+        compressor.last_completion_tokens = 0
+        compressor._last_summary_error = None
+        compressor._last_compress_aborted = False
+        agent.context_compressor = compressor
+
+        agent._compress_context(
+            [{"role": "user", "content": "msg"}], "sys", approx_tokens=100
+        )
+
+        assert received.get("called"), "compress() was never called"
+        assert received.get("provider_context") == "", (
+            f"Expected empty string without memory manager, got: {received.get('provider_context')!r}"
+        )


### PR DESCRIPTION
 **Problem**                                                                                                                                
                                                                                                                                             
  Fixes #23367.                                                                                                                              
                                                                                                                                             
  `MemoryProvider.on_pre_compress()` lets external memory backends return a hint string telling the summarisation LLM which facts to preserve
   during compression. The return value was silently discarded — every provider implementing this hook was being ignored.                    
                                                                                                                                             
  **Root Cause**                                                                                                                             
                                                                                                                                           
  `conversation_compression.py` called `on_pre_compress()` but threw away the return value. `ContextCompressor.compress()` had no            
  `provider_context` parameter, so the hint had nowhere to go even if captured.                                                            

  **Solution**                                                                                                                               
   
  - `conversation_compression.py`: capture `on_pre_compress()` return value, forward to `compress()`                                         
  - `context_compressor.py`: add `provider_context` param to `compress()` / `_generate_summary()`; inject as `MEMORY PROVIDER CONTEXT` block
  in the LLM summarisation prompt             
  - `holographic` plugin: add reference `on_pre_compress()` returning top-trust stored facts

  **Tests**                                                                                                                                  
   
  10 new tests, all pass. Mutation-verified.                                                                                                 
                                                                                                                                           
  - `tests/agent/test_compress_focus.py` (4): `provider_context` injected into LLM prompt, empty string skipped, coexists with `focus_topic`,
   forwarded through `compress()`         
  - `tests/agent/test_memory_provider.py` (3): hint text passes through `MemoryManager`, empty and whitespace-only returns handled correctly
  - `tests/run_agent/test_compression_boundary_hook.py` (3): end-to-end integration — hint flows from `on_pre_compress()` into               
  `compress(provider_context=...)` via real `AIAgent


**Tested on:** Linux (Ubuntu 24.04, Python 3.13)