### PR TITLE
fix(agent): recover write_file path from malformed content JSON

### DIFF
--- a/agent/message_sanitization.py
+++ b/agent/message_sanitization.py
@@ -271,6 +271,31 @@ def _repair_tool_call_arguments(raw_args: str, tool_name: str = "?") -> str:
 
     # Last resort: replace with empty object so the API request doesn't
     # crash the entire session.
+    #
+    # write_file-specific recovery: when the generic repairs above all fail
+    # (typically because the model emitted unescaped triple-double-quotes
+    # inside the "content" value), try to salvage at least the "path" field.
+    # File paths are always simple strings — no quoting issues — so a narrow
+    # regex reliably extracts them even when the surrounding JSON is broken.
+    #
+    # Without this, _handle_write_file receives {} and returns a generic
+    # "path missing" error that the model cannot act on, causing a retry
+    # loop with the same malformed JSON.  With the path recovered, the model
+    # instead receives the "content missing" error which explicitly suggests
+    # using execute_code — a path the model can follow to break the loop.
+    if tool_name == "write_file":
+        path_match = re.search(r'"path"\s*:\s*"([^"]+)"', raw_stripped)
+        if path_match:
+            recovered = json.dumps({"path": path_match.group(1)})
+            logger.warning(
+                "Unrepairable tool_call arguments for %s — "
+                "recovered path only (content JSON was malformed, likely "
+                "unescaped quotes in Python/code content). "
+                "path=%r (was: %s)",
+                tool_name, path_match.group(1), raw_stripped[:80],
+            )
+            return recovered
+
     logger.warning(
         "Unrepairable tool_call arguments for %s — "
         "replaced with empty object (was: %s)",

--- a/tests/run_agent/test_repair_tool_call_arguments.py
+++ b/tests/run_agent/test_repair_tool_call_arguments.py
@@ -141,3 +141,25 @@ class TestRepairToolCallArguments:
         parsed = json.loads(result)
         assert "line" in parsed["msg"]
 
+    # -- Stage 7: write_file path recovery from malformed content JSON --
+
+    def test_write_file_recovers_path_from_malformed_content(self):
+        """When a model emits unescaped triple-double-quotes inside the
+        content field, the JSON is unrecoverable — but the path field
+        should still be extracted so the model gets the actionable
+        'content missing' error instead of a generic 'path missing' error
+        that causes a retry loop."""
+        malformed = (
+            '{"path": "foo.py", "content": "def f():\\n    '
+            '"""Docstring."""\\n    pass"}'
+        )
+        result = _repair_tool_call_arguments(malformed, "write_file")
+        parsed = json.loads(result)
+        assert parsed.get("path") == "foo.py"
+        assert "content" not in parsed
+
+    def test_write_file_path_absent_still_returns_empty(self):
+        """If the JSON is malformed AND no path field is present, the
+        generic {} fallback is still returned — no special recovery."""
+        assert _repair_tool_call_arguments("garbage", "write_file") == "{}"
+


### PR DESCRIPTION
## Summary

Fixes a bug where `write_file` silently fails and the agent gets stuck in a retry loop when a model emits unescaped triple-double-quotes (`"""`) inside the `"content"` value of a JSON tool call argument.

## Root Cause

In `_repair_tool_call_arguments()`, when the model emits:

```json
{"path": "foo.py", "content": "def f():\n    """Docstring."""\n    pass"}
```

…the inner quotes terminate the JSON string early. The repair pipeline correctly identifies this as unrepairable, but previously returned `{}` — discarding the `path` along with the broken `content`. Without a `path`, `_handle_write_file` returned a generic "path missing" error that the model could not act on, so it retried with the same malformed JSON → stuck loop.

## Fix

Adds a `write_file`-specific recovery pass just before the final `return "{}"` fallback. A narrow regex extracts the `"path"` value from the malformed JSON string (file paths are always simple quoted strings, no quoting edge cases). The recovered `{"path": "<extracted>"}` triggers the existing "content missing" error path in `_handle_write_file`, which already suggests `execute_code` as an alternative — breaking the retry loop.

## Changes

- **`agent/message_sanitization.py`**: +25 lines — write_file-specific path recovery with WARNING log
- **`tests/run_agent/test_repair_tool_call_arguments.py`**: +22 lines — two new test cases

## Testing

- Existing 21 repair tests: all pass (no regressions)
- New test: `test_write_file_recovers_path_from_malformed_content` — verifies path is extracted, content is absent
- New test: `test_write_file_path_absent_still_returns_empty` — verifies generic fallback still works when no path is present
- End-to-end: confirmed on hermes v0.14.0 with 9/9 selftest checks, 35/35 pytest suite

Closes #29597