### PR TITLE
fix(vision): honor auxiliary.vision.max_tokens from config in vision_tools

### DIFF
--- a/tests/tools/test_vision_tools.py
+++ b/tests/tools/test_vision_tools.py
@@ -424,6 +424,43 @@ class TestVisionConfig:
         assert result["success"] is True
         assert mock_llm.await_args.kwargs["temperature"] == 0.1
         assert mock_llm.await_args.kwargs["timeout"] == 120.0
+        # When config omits max_tokens, fall back to the 2000-token default.
+        assert mock_llm.await_args.kwargs["max_tokens"] == 2000
+
+    @pytest.mark.asyncio
+    async def test_vision_honors_max_tokens_from_config(self, tmp_path):
+        """auxiliary.vision.max_tokens in config.yaml should override the 2000 default.
+
+        Regression test for hermes-agent#29590: reasoning models (e.g. Kimi)
+        would stall for 9+ minutes generating 2000-token essays because the
+        hardcoded cap could not be lowered via config.
+        """
+        img = tmp_path / "test.png"
+        img.write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 8)
+
+        mock_response = MagicMock()
+        mock_choice = MagicMock()
+        mock_choice.message.content = "Brief analysis"
+        mock_response.choices = [mock_choice]
+
+        with (
+            patch("hermes_cli.config.load_config", return_value={
+                "auxiliary": {"vision": {"max_tokens": 256}}
+            }),
+            patch(
+                "tools.vision_tools._image_to_base64_data_url",
+                return_value="data:image/png;base64,abc",
+            ),
+            patch(
+                "tools.vision_tools.async_call_llm",
+                new_callable=AsyncMock,
+                return_value=mock_response,
+            ) as mock_llm,
+        ):
+            result = json.loads(await vision_analyze_tool(str(img), "describe this", "test/model"))
+
+        assert result["success"] is True
+        assert mock_llm.await_args.kwargs["max_tokens"] == 256
 
 
 class TestVisionSafetyGuards:

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -784,6 +784,7 @@ async def vision_analyze_tool(
         # Local vision models (llama.cpp, ollama) can take well over 30s.
         vision_timeout = 120.0
         vision_temperature = 0.1
+        vision_max_tokens = 2000
         try:
             from hermes_cli.config import cfg_get, load_config
             _cfg = load_config()
@@ -794,13 +795,16 @@ async def vision_analyze_tool(
             _vtemp = _vision_cfg.get("temperature")
             if _vtemp is not None:
                 vision_temperature = float(_vtemp)
+            _vmax = _vision_cfg.get("max_tokens")
+            if _vmax is not None:
+                vision_max_tokens = int(_vmax)
         except Exception:
             pass
         call_kwargs = {
             "task": "vision",
             "messages": messages,
             "temperature": vision_temperature,
-            "max_tokens": 2000,
+            "max_tokens": vision_max_tokens,
             "timeout": vision_timeout,
         }
         if model:
@@ -1281,6 +1285,7 @@ async def video_analyze_tool(
 
         vision_timeout = 180.0
         vision_temperature = 0.1
+        vision_max_tokens = 4000
         try:
             from hermes_cli.config import cfg_get, load_config
             _cfg = load_config()
@@ -1291,6 +1296,9 @@ async def video_analyze_tool(
             _vtemp = _vision_cfg.get("temperature")
             if _vtemp is not None:
                 vision_temperature = float(_vtemp)
+            _vmax = _vision_cfg.get("max_tokens")
+            if _vmax is not None:
+                vision_max_tokens = int(_vmax)
         except Exception:
             pass
 
@@ -1298,7 +1306,7 @@ async def video_analyze_tool(
             "task": "vision",
             "messages": messages,
             "temperature": vision_temperature,
-            "max_tokens": 4000,
+            "max_tokens": vision_max_tokens,
             "timeout": vision_timeout,
         }
         if model:


### PR DESCRIPTION
## Summary

Closes #29590.

`tools/vision_tools.py` hardcoded `max_tokens=2000` for image analysis (and `4000` for video) when calling the auxiliary vision LLM, ignoring `auxiliary.vision.max_tokens` in `config.yaml`. Users routing vision to reasoning models (e.g. Kimi K2.6) reported 9+ minute latency on a single screenshot because the model was being asked to produce up to 2000 tokens of reasoning+answer with no way to cap it via config.

## Root cause

In both `vision_analyze_tool` (image path, ~L783) and the video analysis path (~L1272), the code reads `auxiliary.vision.timeout` and `auxiliary.vision.temperature` from `_vision_cfg` but skips `max_tokens`, then hardcodes the value in `call_kwargs`:

```python
call_kwargs = {
    ...
    "max_tokens": 2000,  # hardcoded — ignores config
}
```

## Fix

Read `auxiliary.vision.max_tokens` from the same `_vision_cfg` block (mirroring the existing `timeout`/`temperature` pattern) and feed it into `call_kwargs`. Defaults fall back to the prior 2000 (image) / 4000 (video) values, so behavior is unchanged for configs that don't set `max_tokens`.

## Tests

`tests/tools/test_vision_tools.py`:
- New `test_vision_honors_max_tokens_from_config` — sets `auxiliary.vision.max_tokens: 256` and asserts the value is forwarded to `async_call_llm`.
- Extended `test_vision_defaults_temperature_when_config_omits_it` to pin the `2000` fallback when `max_tokens` is unset.

```
$ python -m pytest tests/tools/test_vision_tools.py -q
65 passed, 6 skipped in 5.78s
```

## Scope

- `tools/vision_tools.py` — 12 lines (2 sites)
- `tests/tools/test_vision_tools.py` — +37 lines

## Risk

Low. Backward compatible (defaults preserved); follows the exact pattern already used for sibling `timeout`/`temperature` config keys two lines above each call site.