### PR TITLE
fix: type guard in mask_api_key, remove dead skill ref, explicit utf-8 encoding

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -14702,7 +14702,7 @@ class GatewayRunner:
         # (e.g. "eyJhbGci"), which can cause false cache hits across auth
         # switches if only the first few characters are considered.
         _api_key = str(runtime.get("api_key", "") or "")
-        _api_key_fingerprint = hashlib.sha256(_api_key.encode()).hexdigest() if _api_key else ""
+        _api_key_fingerprint = hashlib.sha256(_api_key.encode("utf-8")).hexdigest() if _api_key else ""
 
         _cache_keys_sorted = sorted((cache_keys or {}).items())
 
@@ -14722,7 +14722,7 @@ class GatewayRunner:
             sort_keys=True,
             default=str,
         )
-        return hashlib.sha256(blob.encode()).hexdigest()[:16]
+        return hashlib.sha256(blob.encode("utf-8")).hexdigest()[:16]
 
     def _apply_session_model_override(
         self, session_key: str, model: str, runtime_kwargs: dict

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -698,7 +698,7 @@ def _resolve_zai_base_url(api_key: str, default_url: str, env_override: str) -> 
     cached = state.get("detected_endpoint")
     if isinstance(cached, dict) and cached.get("base_url"):
         key_hash = cached.get("key_hash", "")
-        if key_hash == hashlib.sha256(api_key.encode()).hexdigest()[:16]:
+        if key_hash == hashlib.sha256(api_key.encode("utf-8")).hexdigest()[:16]:
             logger.debug("Z.AI: using cached endpoint %s", cached["base_url"])
             return cached["base_url"]
 
@@ -706,7 +706,7 @@ def _resolve_zai_base_url(api_key: str, default_url: str, env_override: str) -> 
     detected = detect_zai_endpoint(api_key)
     if detected and detected.get("base_url"):
         # Persist the detection result keyed on the API key hash.
-        key_hash = hashlib.sha256(api_key.encode()).hexdigest()[:16]
+        key_hash = hashlib.sha256(api_key.encode("utf-8")).hexdigest()[:16]
         state["detected_endpoint"] = {
             "base_url": detected["base_url"],
             "endpoint_id": detected.get("id", ""),
@@ -6771,7 +6771,7 @@ def _minimax_pkce_pair() -> tuple:
     import secrets
     verifier = secrets.token_urlsafe(64)[:96]
     challenge = base64.urlsafe_b64encode(
-        hashlib.sha256(verifier.encode()).digest()
+        hashlib.sha256(verifier.encode("utf-8")).digest()
     ).decode().rstrip("=")
     state = secrets.token_urlsafe(16)
     return verifier, challenge, state

--- a/hermes_cli/kanban_swarm.py
+++ b/hermes_cli/kanban_swarm.py
@@ -209,7 +209,7 @@ def create_swarm(
         priority=priority,
         workspace_kind=workspace_kind,
         workspace_path=workspace_path,
-        skills=["avoid-ai-writing"],
+        skills=[],
     )
 
     created = SwarmCreated(root, worker_ids, verifier, synthesizer)

--- a/hermes_cli/webhook.py
+++ b/hermes_cli/webhook.py
@@ -250,7 +250,7 @@ def _cmd_test(args):
     import hmac
     import hashlib
     sig = "sha256=" + hmac.new(
-        secret.encode(), payload.encode(), hashlib.sha256
+        secret.encode("utf-8"), payload.encode("utf-8"), hashlib.sha256
     ).hexdigest()
 
     print(f"  Sending test POST to {url}")
@@ -258,7 +258,7 @@ def _cmd_test(args):
         import urllib.request
         req = urllib.request.Request(
             url,
-            data=payload.encode(),
+            data=payload.encode("utf-8"),
             headers={
                 "Content-Type": "application/json",
                 "X-Hub-Signature-256": sig,

--- a/run_agent.py
+++ b/run_agent.py
@@ -1443,6 +1443,8 @@ class AIAgent:
             return "<entra-id-bearer>"
         if not key:
             return None
+        if not isinstance(key, str):
+            return repr(key)[:12]
         if len(key) <= 12:
             return "***"
         return f"{key[:8]}...{key[-4:]}"


### PR DESCRIPTION
## Summary

Fixes 3 classes of bugs:

### 1. Type guard in `_mask_api_key_for_logs` (run_agent.py)

The method accepts `key: Any` but calls `len(key)` without checking if `key` is a string. A non-string truthy value (e.g. `int`) would crash with `TypeError: object of type 'int' has no len()`.

**Fix:** Add `if not isinstance(key, str): return repr(key)[:12]` after the callable/None checks.

### 2. Dead skill reference in kanban_swarm.py

`skills=["avoid-ai-writing"]` references a skill that was removed in v0.14.0, causing crash loops when synthesizer tries to load it.

**Fix:** Changed to `skills=[]`.

### 3. Explicit `encoding="utf-8"` in security-sensitive `.encode()` calls

~100 `.encode()` calls across the codebase rely on the default UTF-8 encoding. While correct in Python 3, explicit encoding is best practice for security-sensitive code (HMAC, SHA256 hashing) to prevent cross-platform surprises.

**Fix:** Added `encoding="utf-8"` to:
- `hermes_cli/webhook.py`: HMAC signature computation + payload encoding
- `hermes_cli/auth.py`: Z.AI key hash (2 locations) + MiniMax PKCE challenge
- `gateway/run.py`: API key fingerprint + session fingerprint

## Test Plan
- [x] All 5 modified files pass `py_compile`
- [ ] CI tests pass