### PR TITLE
fix(gateway): sync MEDIA regex extension allowlist with SUPPORTED_DOCUMENT_TYPES

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2158,9 +2158,24 @@ class BasePlatformAdapter(ABC):
         
         # Extract MEDIA:<path> tags, allowing optional whitespace after the colon
         # and quoted/backticked paths for LLM-formatted outputs.
-        media_pattern = re.compile(
-            r'''[`"']?MEDIA:\s*(?P<path>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|(?:~/|/)\S+(?:[^\S\n]+\S+)*?\.(?:png|jpe?g|gif|webp|mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|flac|epub|pdf|zip|rar|7z|docx?|xlsx?|pptx?|txt|csv|apk|ipa)(?=[\s`"',;:)\]}]|$))[`"']?'''
+        # Build extension list from SUPPORTED_DOCUMENT_TYPES + known media types
+        # so the two stay in sync automatically.
+        _media_exts = set()
+        for ext in SUPPORTED_DOCUMENT_TYPES:
+            _media_exts.add(ext.lstrip("."))
+        _media_exts.update({"png", "jpg", "jpeg", "gif", "webp",
+                            "mp4", "mov", "avi", "mkv", "webm",
+                            "ogg", "opus", "mp3", "wav", "m4a", "flac",
+                            "epub", "rar", "7z", "apk", "ipa", "markdown"})
+        _ext_list = sorted(_media_exts, key=lambda x: (-len(x), x))
+        _ext_pattern = "|".join(_ext_list)
+        _MEDIA_RE_STR = (
+            r'''[`"']?MEDIA:\s*(?P<path>'''
+            r'''`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|'''
+            r'''(?:~/|/)\S+(?:[^\S\n]+\S+)*?\.(?:'''
+            + _ext_pattern + r''')(?=[\s`"',;:)\]}]|$))[`"']?'''
         )
+        media_pattern = re.compile(_MEDIA_RE_STR)
         for match in media_pattern.finditer(content):
             path = match.group("path").strip()
             if len(path) >= 2 and path[0] == path[-1] and path[0] in "`\"'":


### PR DESCRIPTION
## Problem

After commit `ea49b3862` tightened the MEDIA extraction regex by removing the greedy `\S+` fallback, the hardcoded extension allowlist in `extract_media()` fell out of sync with `SUPPORTED_DOCUMENT_TYPES` defined in the same file (line 817).

This caused valid file attachments with extensions like `.md`, `.json`, `.xml`, `.yaml`, `.yml`, `.toml`, `.py`, `.ts`, `.sh`, `.log`, `.ini`, `.cfg`, `.html`, `.htm` to be **silently ignored** when sent via `MEDIA:<path>`.

## Fix

Instead of maintaining two separate extension lists (the regex and `SUPPORTED_DOCUMENT_TYPES`), the regex now **derives its extension set dynamically** from `SUPPORTED_DOCUMENT_TYPES` + known media types (image/video/audio/archive).

### Before
```python
# Hardcoded extension list — out of sync with SUPPORTED_DOCUMENT_TYPES
media_pattern = re.compile(
    r'''...\.(?:png|jpe?g|gif|...|txt|csv|apk|ipa)...'''
)
```

### After
```python
# Extension list derived from SUPPORTED_DOCUMENT_TYPES automatically
_media_exts = set()
for ext in SUPPORTED_DOCUMENT_TYPES:
    _media_exts.add(ext.lstrip("."))
_media_exts.update({"png", "jpg", ..., "markdown"})
_ext_pattern = "|".join(sorted(_media_exts, key=lambda x: (-len(x), x)))
# regex built from _ext_pattern dynamically
```

## Benefits

- ✅ Single source of truth — no more desync
- ✅ Future additions to `SUPPORTED_DOCUMENT_TYPES` automatically work with `MEDIA:`
- ✅ Existing tests pass: **92 passed** in `tests/gateway/test_platform_base.py`
- ✅ 1 file changed, +17 / -2 lines

## Related

- Closes #29582 (`.html` files not sent via WeChat)
- Follow-up to commit `ea49b3862`

## Checklist

- [x] Tests pass (`tests/gateway/test_platform_base.py`)
- [x] Code review
- [ ] CI (pending)