### PR TITLE
fix(auth): config.yaml model.provider takes precedence over auth.json…

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -1471,14 +1471,45 @@ def resolve_provider(
     if explicit_api_key or explicit_base_url:
         return "openrouter"
 
-    # Check auth store for an active OAuth provider
+    # Check model.provider from config.yaml before auth.json active_provider
+    # so explicitly configured providers always take precedence over stale
+    # OAuth login state (e.g. after token exhaustion).  See #29285.
+    try:
+        from hermes_cli.config import load_config
+        _cfg = load_config()
+        _model_cfg = _cfg.get("model")
+        if isinstance(_model_cfg, dict):
+            _cfg_provider = (_model_cfg.get("provider") or "").strip().lower()
+            if _cfg_provider and _cfg_provider in PROVIDER_REGISTRY:
+                return _cfg_provider
+    except Exception:
+        pass
+
+    # Check auth store for an active OAuth provider.  Only return it when
+    # the credential pool has at least one non-exhausted entry — otherwise
+    # a stale active_provider with exhausted tokens hijacks inference even
+    # though every retry will fail with 429.  See #29285.
     try:
         auth_store = _load_auth_store()
         active = auth_store.get("active_provider")
         if active and active in PROVIDER_REGISTRY:
             status = get_auth_status(active)
             if status.get("logged_in"):
-                return active
+                try:
+                    from agent.credential_pool import load_pool
+                    pool = load_pool(active)
+                    if pool and pool.has_credentials():
+                        _non_exhausted = False
+                        for _entry in pool.entries():
+                            if getattr(_entry, "last_status", None) != "exhausted":
+                                _non_exhausted = True
+                                break
+                        if _non_exhausted:
+                            return active
+                    else:
+                        return active
+                except Exception:
+                    return active
     except Exception as e:
         logger.debug("Could not detect active auth provider: %s", e)
 


### PR DESCRIPTION
## What does this PR do?

Fixes two bugs in `resolve_provider()`'s auto-selection path that cause `auth.json`'s `active_provider` to silently override `config.yaml`'s `model.provider`:

**Bug 1 — Config ignored after stale login.** When `model.provider` is set in `config.yaml` but `resolve_provider("auto")` runs (because `resolve_requested_provider()` returned "auto" due to malformed YAML, or the config wasn't read yet), the function checked `active_provider` from `auth.json` first. A user who ran `hermes login --provider openai-codex` months ago but later switched to `model.provider: minimax` in `config.yaml` would silently get `openai-codex` (or whatever `active_provider` was) instead of `minimax`.

**Fix 1 — Config.yaml check inserted before auth.json check.** `resolve_provider()` now reads `model.provider` from `config.yaml` before consulting `auth.json.active_provider`. If the config specifies a valid provider in `PROVIDER_REGISTRY`, it is returned immediately. This makes `config.yaml` the authoritative source for provider selection, matching user expectations.

**Bug 2 — Exhausted credentials still selected.** Even when `active_provider` was correct, if the provider's credential pool had only exhausted entries (e.g. Codex tokens depleted with 429 usage_limit_reached), `resolve_provider("auto")` still returned that provider because it only checked `status.get("logged_in")` — which returns `True` regardless of exhaustion. Every subsequent inference call would fail with 429, with only an `agent.log` entry visible to users who actively monitor logs.

**Fix 2 — Exhaustion check on pool entries.** Before returning `active_provider`, the function now loads the credential pool and verifies at least one entry has `last_status != "exhausted"`. If all entries are exhausted, it falls through to the next resolution priority (env var keys, then `"openrouter"`). This prevents silent failure loops.

## Related Issue
Fixes #29285

## Type of Change
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
## Changes Made
- `hermes_cli/auth.py:1474-1514` — `resolve_provider()` auto path: insert config.yaml `model.provider` check before `active_provider`, and add credential-pool exhaustion gating

## How to Test
1. Set `model.provider: minimax` (or any non-OAuth provider) in `config.yaml` while `auth.json` has `active_provider: openai-codex`
2. Run `hermes` — verify `minimax` is used, not `openai-codex`
3. Exhaust Codex tokens (or mock pool entries with `last_status: "exhausted"`)
4. Run `hermes` — verify auto-selection falls through to env-var keys or `"openrouter"` instead of returning the exhausted provider

## Checklist
### Code
- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
### Documentation & Housekeeping
- [x] I've considered cross-platform impact (Windows, macOS) — N/A (config/auth store logic is platform-agnostic)