### PR TITLE
feat(skills): validate Obsidian vault path on load

### DIFF
--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -210,7 +210,7 @@ def _build_skill_message(
                 f"[Skill setup note: {loaded_skill['gateway_setup_hint']}]",
             ]
         )
-    elif loaded_skill.get("setup_needed") and loaded_skill.get("setup_note"):
+    elif loaded_skill.get("setup_note"):
         parts.extend(
             [
                 "",

--- a/skills/note-taking/obsidian/SKILL.md
+++ b/skills/note-taking/obsidian/SKILL.md
@@ -2,6 +2,13 @@
 name: obsidian
 description: Read, search, create, and edit notes in the Obsidian vault.
 platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    path_validations:
+      - name: Obsidian vault
+        env_var: OBSIDIAN_VAULT_PATH
+        default: ~/Documents/Obsidian Vault
+        type: directory
 ---
 
 # Obsidian Vault
@@ -10,13 +17,21 @@ Use this skill for filesystem-first Obsidian vault work: reading notes, listing 
 
 ## Vault path
 
-Use a known or resolved vault path before calling file tools.
+Before any vault operation, resolve and verify the vault path. Do not read,
+search, write, or patch notes until the path is concrete and accessible.
 
 The documented vault-path convention is the `OBSIDIAN_VAULT_PATH` environment variable, for example from `~/.hermes/.env`. If it is unset, use `~/Documents/Obsidian Vault`.
 
 File tools do not expand shell variables. Do not pass paths containing `$OBSIDIAN_VAULT_PATH` to `read_file`, `write_file`, `patch`, or `search_files`; resolve the vault path first and pass a concrete absolute path. Vault paths may contain spaces, which is another reason to prefer file tools over shell commands.
 
-If the vault path is unknown, `terminal` is acceptable for resolving `OBSIDIAN_VAULT_PATH` or checking whether the fallback path exists. Once the path is known, switch back to file tools.
+If the vault path is unknown, use `terminal` to read `OBSIDIAN_VAULT_PATH` or
+check whether the fallback path exists. Once the path is known, switch back to
+file tools.
+
+When the resolved path exists, state which vault path you are using before the
+first note operation. When neither `OBSIDIAN_VAULT_PATH` nor the fallback path
+resolves to an accessible directory, stop and ask the user to set
+`OBSIDIAN_VAULT_PATH` instead of guessing or searching unrelated folders.
 
 ## Read a note
 

--- a/tests/agent/test_skill_commands.py
+++ b/tests/agent/test_skill_commands.py
@@ -8,6 +8,7 @@ import pytest
 
 import tools.skills_tool as skills_tool_module
 from agent.skill_commands import (
+    _build_skill_message,
     build_preloaded_skills_prompt,
     build_skill_invocation_message,
     resolve_skill_command_key,
@@ -36,6 +37,20 @@ description: Description for {name}.
 """
     (skill_dir / "SKILL.md").write_text(content)
     return skill_dir
+
+
+def test_build_skill_message_includes_available_setup_note(tmp_path):
+    message = _build_skill_message(
+        {
+            "content": "# Obsidian\n\nUse the vault.",
+            "setup_needed": False,
+            "setup_note": "Verified skill path: Obsidian vault: /tmp/vault.",
+        },
+        tmp_path,
+        "Loaded obsidian.",
+    )
+
+    assert "[Skill setup note: Verified skill path: Obsidian vault: /tmp/vault.]" in message
 
 
 def _symlink_category(skills_dir: Path, linked_root: Path, category: str) -> Path:

--- a/tests/tools/test_skills_tool.py
+++ b/tests/tools/test_skills_tool.py
@@ -895,6 +895,91 @@ class TestSkillViewPrerequisites:
         assert result["setup_needed"] is False
         assert result["required_environment_variables"] == []
 
+    def test_path_validation_uses_existing_env_path(self, tmp_path, monkeypatch):
+        vault = tmp_path / "vault"
+        vault.mkdir()
+        monkeypatch.setenv("OBSIDIAN_VAULT_PATH", str(vault))
+        monkeypatch.setattr(skills_tool_module, "load_env", lambda: {})
+
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(
+                tmp_path,
+                "obsidian",
+                frontmatter_extra=(
+                    "metadata:\n"
+                    "  hermes:\n"
+                    "    path_validations:\n"
+                    "      - name: Obsidian vault\n"
+                    "        env_var: OBSIDIAN_VAULT_PATH\n"
+                    "        default: ~/Documents/Obsidian Vault\n"
+                    "        type: directory\n"
+                ),
+            )
+            raw = skill_view("obsidian")
+
+        result = json.loads(raw)
+        assert result["success"] is True
+        assert result["setup_needed"] is False
+        assert result["path_validations"][0]["readiness_status"] == "available"
+        assert result["path_validations"][0]["path"] == str(vault.resolve())
+        assert "Verified skill path: Obsidian vault" in result["setup_note"]
+
+    def test_path_validation_uses_existing_default_path(self, tmp_path, monkeypatch):
+        vault = tmp_path / "default-vault"
+        vault.mkdir()
+        monkeypatch.delenv("OBSIDIAN_VAULT_PATH", raising=False)
+        monkeypatch.setattr(skills_tool_module, "load_env", lambda: {})
+
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(
+                tmp_path,
+                "obsidian",
+                frontmatter_extra=(
+                    "metadata:\n"
+                    "  hermes:\n"
+                    "    path_validations:\n"
+                    "      - name: Obsidian vault\n"
+                    "        env_var: OBSIDIAN_VAULT_PATH\n"
+                    f"        default: \"{vault.as_posix()}\"\n"
+                    "        type: directory\n"
+                ),
+            )
+            raw = skill_view("obsidian")
+
+        result = json.loads(raw)
+        assert result["success"] is True
+        assert result["setup_needed"] is False
+        assert result["path_validations"][0]["source"] == "default"
+        assert result["path_validations"][0]["path"] == str(vault.resolve())
+
+    def test_path_validation_reports_missing_directory(self, tmp_path, monkeypatch):
+        missing_vault = tmp_path / "missing-vault"
+        monkeypatch.delenv("OBSIDIAN_VAULT_PATH", raising=False)
+        monkeypatch.setattr(skills_tool_module, "load_env", lambda: {})
+
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(
+                tmp_path,
+                "obsidian",
+                frontmatter_extra=(
+                    "metadata:\n"
+                    "  hermes:\n"
+                    "    path_validations:\n"
+                    "      - name: Obsidian vault\n"
+                    "        env_var: OBSIDIAN_VAULT_PATH\n"
+                    f"        default: \"{missing_vault.as_posix()}\"\n"
+                    "        type: directory\n"
+                ),
+            )
+            raw = skill_view("obsidian")
+
+        result = json.loads(raw)
+        assert result["success"] is True
+        assert result["setup_needed"] is True
+        assert result["missing_required_paths"] == ["Obsidian vault"]
+        assert result["path_validations"][0]["readiness_status"] == "setup_needed"
+        assert "Path setup needed: Obsidian vault does not exist" in result["setup_note"]
+
     def test_skill_view_treats_backend_only_env_as_setup_needed(
         self, tmp_path, monkeypatch
     ):

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -43,6 +43,11 @@ SKILL.md Format (YAML Frontmatter, agentskills.io compatible):
       hermes:
         tags: [fine-tuning, llm]
         related_skills: [peft, lora]
+        path_validations:         # Optional runtime path checks on skill load
+          - name: Local vault
+            env_var: VAULT_PATH
+            default: ~/Documents/Vault
+            type: directory
     ---
 
     # Skill Title
@@ -404,6 +409,175 @@ def _remaining_required_environment_names(
         if name in missing_names or not _is_env_var_persisted(name, env_snapshot):
             remaining.append(name)
     return remaining
+
+
+def _get_hermes_skill_metadata(frontmatter: Dict[str, Any]) -> Dict[str, Any]:
+    metadata = frontmatter.get("metadata")
+    if not isinstance(metadata, dict):
+        return {}
+    hermes_meta = metadata.get("hermes")
+    if not isinstance(hermes_meta, dict):
+        return {}
+    return hermes_meta
+
+
+def _normalize_path_validation_entries(
+    frontmatter: Dict[str, Any],
+) -> List[Dict[str, Any]]:
+    raw = _get_hermes_skill_metadata(frontmatter).get("path_validations")
+    if isinstance(raw, dict):
+        raw = [raw]
+    if not isinstance(raw, list):
+        return []
+
+    entries: List[Dict[str, Any]] = []
+    for item in raw:
+        if not isinstance(item, dict):
+            continue
+        env_var = str(item.get("env_var") or "").strip()
+        default = str(item.get("default") or "").strip()
+        if not env_var and not default:
+            continue
+        kind = str(item.get("type") or item.get("kind") or "directory").strip().lower()
+        if kind not in {"directory", "file", "path"}:
+            kind = "directory"
+        name = str(item.get("name") or item.get("label") or env_var or default).strip()
+        entries.append(
+            {
+                "name": name,
+                "env_var": env_var or None,
+                "default": default or None,
+                "type": kind,
+                "optional": bool(item.get("optional", False)),
+            }
+        )
+    return entries
+
+
+def _expand_skill_path(raw_path: str) -> Path:
+    expanded = os.path.expandvars(os.path.expanduser(raw_path))
+    return Path(expanded).resolve(strict=False)
+
+
+def _validate_skill_paths(
+    frontmatter: Dict[str, Any],
+    env_snapshot: Dict[str, str] | None = None,
+) -> List[Dict[str, Any]]:
+    if env_snapshot is None:
+        env_snapshot = load_env()
+
+    results: List[Dict[str, Any]] = []
+    for entry in _normalize_path_validation_entries(frontmatter):
+        env_var = entry.get("env_var")
+        configured = ""
+        source = ""
+        if env_var:
+            configured = str(env_snapshot.get(env_var) or os.getenv(env_var) or "").strip()
+            if configured:
+                source = f"env ${env_var}"
+
+        if not configured and entry.get("default"):
+            configured = str(entry["default"]).strip()
+            source = "default"
+
+        base_result = {
+            "name": entry["name"],
+            "env_var": env_var,
+            "type": entry["type"],
+            "source": source or None,
+            "optional": entry["optional"],
+        }
+
+        if not configured:
+            results.append(
+                {
+                    **base_result,
+                    "readiness_status": SkillReadinessStatus.SETUP_NEEDED.value,
+                    "error": f"{entry['name']} is not configured",
+                }
+            )
+            continue
+
+        try:
+            resolved_path = _expand_skill_path(configured)
+        except Exception as exc:
+            results.append(
+                {
+                    **base_result,
+                    "configured": configured,
+                    "readiness_status": SkillReadinessStatus.SETUP_NEEDED.value,
+                    "error": f"{entry['name']} could not be resolved: {exc}",
+                }
+            )
+            continue
+
+        kind = entry["type"]
+        exists = resolved_path.exists()
+        valid_kind = (
+            exists
+            if kind == "path"
+            else resolved_path.is_dir()
+            if kind == "directory"
+            else resolved_path.is_file()
+        )
+        readable = os.access(resolved_path, os.R_OK) if exists else False
+
+        if valid_kind and readable:
+            results.append(
+                {
+                    **base_result,
+                    "configured": configured,
+                    "path": str(resolved_path),
+                    "readiness_status": SkillReadinessStatus.AVAILABLE.value,
+                }
+            )
+            continue
+
+        if not exists:
+            error = f"{entry['name']} does not exist: {resolved_path}"
+        elif kind == "directory" and not resolved_path.is_dir():
+            error = f"{entry['name']} is not a directory: {resolved_path}"
+        elif kind == "file" and not resolved_path.is_file():
+            error = f"{entry['name']} is not a file: {resolved_path}"
+        else:
+            error = f"{entry['name']} is not readable: {resolved_path}"
+
+        results.append(
+            {
+                **base_result,
+                "configured": configured,
+                "path": str(resolved_path),
+                "readiness_status": SkillReadinessStatus.SETUP_NEEDED.value,
+                "error": error,
+            }
+        )
+
+    return results
+
+
+def _build_path_validation_note(path_validations: List[Dict[str, Any]]) -> str | None:
+    if not path_validations:
+        return None
+
+    verified = [
+        f"{item['name']}: {item['path']}"
+        for item in path_validations
+        if item.get("readiness_status") == SkillReadinessStatus.AVAILABLE.value
+        and item.get("path")
+    ]
+    blocked = [
+        item.get("error") or f"{item['name']} is not available"
+        for item in path_validations
+        if item.get("readiness_status") == SkillReadinessStatus.SETUP_NEEDED.value
+        and not item.get("optional")
+    ]
+
+    parts = []
+    if verified:
+        parts.append("Verified skill path: " + "; ".join(verified) + ".")
+    if blocked:
+        parts.append("Path setup needed: " + "; ".join(blocked) + ".")
+    return " ".join(parts) if parts else None
 
 
 def _gateway_setup_hint() -> str:
@@ -1269,10 +1443,8 @@ def skill_view(
 
         # Read tags/related_skills with backward compat:
         # Check metadata.hermes.* first (agentskills.io convention), fall back to top-level
-        hermes_meta = {}
         metadata = frontmatter.get("metadata")
-        if isinstance(metadata, dict):
-            hermes_meta = metadata.get("hermes", {}) or {}
+        hermes_meta = _get_hermes_skill_metadata(frontmatter)
 
         tags = _parse_tags(hermes_meta.get("tags") or frontmatter.get("tags", ""))
         related_skills = _parse_tags(
@@ -1322,6 +1494,15 @@ def skill_view(
             env_snapshot=env_snapshot,
         )
         setup_needed = bool(remaining_missing_required_envs)
+        path_validations = _validate_skill_paths(frontmatter, env_snapshot)
+        missing_required_paths = [
+            item
+            for item in path_validations
+            if item.get("readiness_status") == SkillReadinessStatus.SETUP_NEEDED.value
+            and not item.get("optional")
+        ]
+        if missing_required_paths:
+            setup_needed = True
 
         # Register available skill env vars so they pass through to sandboxed
         # execution environments (execute_code, terminal).  Only vars that are
@@ -1416,16 +1597,31 @@ def skill_view(
                 f"env ${env_name}" for env_name in remaining_missing_required_envs
             ] + [
                 f"file {path}" for path in missing_cred_files
+            ] + [
+                f"path {item['name']}" for item in missing_required_paths
             ]
             setup_note = _build_setup_note(
                 SkillReadinessStatus.SETUP_NEEDED,
                 missing_items,
                 setup_help,
             )
+            path_note = _build_path_validation_note(path_validations)
+            if path_note:
+                setup_note = f"{setup_note} {path_note}" if setup_note else path_note
             if backend in _REMOTE_ENV_BACKENDS and setup_note:
                 setup_note = f"{setup_note} {backend.upper()}-backed skills need these requirements available inside the remote environment as well."
             if setup_note:
                 result["setup_note"] = setup_note
+        else:
+            path_note = _build_path_validation_note(path_validations)
+            if path_note:
+                result["setup_note"] = path_note
+
+        if path_validations:
+            result["path_validations"] = path_validations
+            result["missing_required_paths"] = [
+                item["name"] for item in missing_required_paths
+            ]
 
         # Surface agentskills.io optional fields when present
         if frontmatter.get("compatibility"):

--- a/website/docs/user-guide/skills/bundled/note-taking/note-taking-obsidian.md
+++ b/website/docs/user-guide/skills/bundled/note-taking/note-taking-obsidian.md
@@ -30,13 +30,21 @@ Use this skill for filesystem-first Obsidian vault work: reading notes, listing 
 
 ## Vault path
 
-Use a known or resolved vault path before calling file tools.
+Before any vault operation, resolve and verify the vault path. Do not read,
+search, write, or patch notes until the path is concrete and accessible.
 
 The documented vault-path convention is the `OBSIDIAN_VAULT_PATH` environment variable, for example from `~/.hermes/.env`. If it is unset, use `~/Documents/Obsidian Vault`.
 
 File tools do not expand shell variables. Do not pass paths containing `$OBSIDIAN_VAULT_PATH` to `read_file`, `write_file`, `patch`, or `search_files`; resolve the vault path first and pass a concrete absolute path. Vault paths may contain spaces, which is another reason to prefer file tools over shell commands.
 
-If the vault path is unknown, `terminal` is acceptable for resolving `OBSIDIAN_VAULT_PATH` or checking whether the fallback path exists. Once the path is known, switch back to file tools.
+If the vault path is unknown, use `terminal` to read `OBSIDIAN_VAULT_PATH` or
+check whether the fallback path exists. Once the path is known, switch back to
+file tools.
+
+When the resolved path exists, state which vault path you are using before the
+first note operation. When neither `OBSIDIAN_VAULT_PATH` nor the fallback path
+resolves to an accessible directory, stop and ask the user to set
+`OBSIDIAN_VAULT_PATH` instead of guessing or searching unrelated folders.
 
 ## Read a note
 


### PR DESCRIPTION
## What does this PR do?

Adds declarative skill path validation and uses it for the bundled Obsidian skill so Hermes can report whether the configured vault path is ready before note-taking commands run.

## Root cause

The Obsidian skill documents `OBSIDIAN_VAULT_PATH`, but loading the skill did not validate the concrete path that note operations would use. A missing or unreadable vault could remain hidden until a later tool call failed.

## Fix

- Adds `metadata.hermes.path_validations` support to skill metadata loading.
- Resolves configured environment paths and fallback directories during `skill_view()`.
- Surfaces readiness through `path_validations`, `missing_required_paths`, `setup_needed`, and `setup_note`.
- Declares Obsidian vault validation in the bundled skill metadata and refreshes the matching docs.
- Adds focused regression coverage for env paths, fallback paths, missing paths, and setup-note injection.

## Why this shape

This keeps the validation generic enough for other skills while only enabling it for Obsidian in this PR. The note-taking behavior stays unchanged; the new path check only improves setup feedback before the skill is used.

## Tests

- `python -m pytest tests/tools/test_skills_tool.py tests/agent/test_skill_commands.py -q -k "path_validation or build_skill_message_includes_available_setup_note" -o addopts= -p no:xdist` — 4 passed, 127 deselected.
- `python -m py_compile tools/skills_tool.py agent/skill_commands.py`
- `python -m ruff check tools/skills_tool.py agent/skill_commands.py tests/tools/test_skills_tool.py tests/agent/test_skill_commands.py` — passed.

## Related PRs / issues

- Related to #29224. - Related to #29469.

<details>
<summary>Original body</summary>

﻿## What does this PR do?

Adds declarative skill path validation and uses it for the bundled Obsidian skill so Hermes can report whether the configured vault path is ready before note-taking commands run.

## Problem

The Obsidian skill documents `OBSIDIAN_VAULT_PATH`, but loading the skill did not validate the concrete path that note operations would use. A missing or unreadable vault could remain hidden until a later tool call failed.

## What this changes

- Adds `metadata.hermes.path_validations` support to skill metadata loading.
- Resolves configured environment paths and fallback directories during `skill_view()`.
- Surfaces readiness through `path_validations`, `missing_required_paths`, `setup_needed`, and `setup_note`.
- Declares Obsidian vault validation in the bundled skill metadata and refreshes the matching docs.
- Adds focused regression coverage for env paths, fallback paths, missing paths, and setup-note injection.

## Why this shape

This keeps the validation generic enough for other skills while only enabling it for Obsidian in this PR. The note-taking behavior stays unchanged; the new path check only improves setup feedback before the skill is used.

## Tests

- `python -m pytest tests/tools/test_skills_tool.py tests/agent/test_skill_commands.py -q -k "path_validation or build_skill_message_includes_available_setup_note" -o addopts= -p no:xdist` — 4 passed, 127 deselected.
- `python -m py_compile tools/skills_tool.py agent/skill_commands.py`
- `python -m ruff check tools/skills_tool.py agent/skill_commands.py tests/tools/test_skills_tool.py tests/agent/test_skill_commands.py` — passed.

## CI note

The current full `test` job failure is outside this diff and matches baseline drift already covered by #29224.

Closes #29469

</details>

---

_Generated by Hermes Turbo_