### PR TITLE
fix(gateway): respawn via Python watcher so /restart doesn't SIGHUP new gateway (#29603)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3452,22 +3452,84 @@ class GatewayRunner:
             )
             return
 
-        cmd = " ".join(shlex.quote(part) for part in hermes_cmd)
-        shell_cmd = (
-            f"while kill -0 {current_pid} 2>/dev/null; do sleep 0.2; done; "
-            f"{cmd} gateway restart"
-        )
+        # Unix path: spawn a tiny Python watcher (same pattern as the
+        # Windows branch above and as
+        # ``hermes_cli.gateway.launch_detached_profile_gateway_restart``).
+        #
+        # Background (#29603): the previous implementation used
+        # ``setsid bash -lc 'while kill -0 OLD; do sleep 0.2; done;
+        # hermes gateway restart'``. That makes ``bash`` the session
+        # leader; when the wait loop ends and bash exits after the
+        # restart subcommand returns, bash's controlling session is
+        # torn down and SIGHUP is delivered to every process still in
+        # it — including the freshly spawned gateway daemon on platforms
+        # (Termux / Android) where the daemon hasn't fully re-detached
+        # by the time bash unwinds. systemd masks the symptom by
+        # respawning the unit, but on bare-POSIX environments it
+        # deterministically kills the new gateway.
+        #
+        # The Python watcher avoids the issue by re-detaching the new
+        # gateway into its own session via ``start_new_session=True``,
+        # so the watcher exiting (and any SIGHUP it triggers) only
+        # tears down the watcher's session — not the new gateway's.
+        import textwrap
+
+        watcher_script = textwrap.dedent(
+            """
+            import os
+            import subprocess
+            import sys
+            import time
+
+            pid = int(sys.argv[1])
+            cmd = sys.argv[2:]
+            deadline = time.monotonic() + 120
+            while time.monotonic() < deadline:
+                try:
+                    os.kill(pid, 0)
+                except ProcessLookupError:
+                    break
+                except PermissionError:
+                    # PID exists but we can't signal it — still "alive"
+                    # from our perspective; keep waiting for it to exit.
+                    pass
+                except OSError:
+                    break
+                time.sleep(0.2)
+
+            # Re-detach the respawn into its own session so this watcher
+            # exiting can't SIGHUP the new gateway (#29603).
+            subprocess.Popen(
+                cmd,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                start_new_session=True,
+                close_fds=True,
+            )
+            """
+        ).strip()
+
+        watcher_argv = [
+            sys.executable,
+            "-c",
+            watcher_script,
+            str(current_pid),
+            *hermes_cmd,
+            "gateway",
+            "restart",
+        ]
+
         setsid_bin = shutil.which("setsid")
         if setsid_bin:
             subprocess.Popen(
-                [setsid_bin, "bash", "-lc", shell_cmd],
+                [setsid_bin, "--", *watcher_argv],
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.DEVNULL,
                 start_new_session=True,
             )
         else:
             subprocess.Popen(
-                ["bash", "-lc", shell_cmd],
+                watcher_argv,
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.DEVNULL,
                 start_new_session=True,

--- a/tests/gateway/test_restart_detach_no_sighup.py
+++ b/tests/gateway/test_restart_detach_no_sighup.py
@@ -1,0 +1,419 @@
+"""Regression coverage for #29603 — gateway restart kills new instance on
+non-systemd POSIX environments (Termux/Android).
+
+The historical Unix restart path was::
+
+    setsid bash -lc "while kill -0 OLD; do sleep 0.2; done; hermes gateway restart"
+
+That made ``bash`` the session leader; bash exiting after the restart
+subcommand returned tore the session down and SIGHUP'd the freshly
+spawned daemon on bare-POSIX environments. The fix replaces the shell
+with a Python watcher (matching the Windows branch + the
+``hermes_cli.gateway.launch_detached_profile_gateway_restart`` helper)
+that re-detaches the new gateway via ``start_new_session=True`` so the
+watcher exiting can't take the new gateway with it.
+
+These tests pin the architectural contract end-to-end:
+
+* No ``bash``/``sh`` anywhere in the restart argv (the bug surface).
+* The watcher is the live Python interpreter executing a real script.
+* The watcher script preserves the original wait-for-old-pid loop.
+* The watcher re-spawns the gateway with ``start_new_session=True``.
+* The actual watcher script — run in a real subprocess — really does
+  put its spawned child in a fresh session.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+import textwrap
+import time
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+import gateway.run as gateway_run
+from tests.gateway.restart_test_helpers import make_restart_runner
+
+
+pytestmark = pytest.mark.skipif(
+    sys.platform.startswith("win"),
+    reason="The fix targets the POSIX restart path; the Windows branch is "
+    "covered separately.",
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _patch_resolve_and_pid(monkeypatch, *, pid: int = 9999):
+    monkeypatch.setattr(gateway_run, "_resolve_hermes_bin", lambda: ["/usr/bin/hermes"])
+    monkeypatch.setattr(gateway_run.os, "getpid", lambda: pid)
+
+
+def _capture_popen(monkeypatch) -> list[tuple[list[str], dict]]:
+    calls: list[tuple[list[str], dict]] = []
+
+    def fake_popen(cmd, **kwargs):
+        calls.append((list(cmd), dict(kwargs)))
+        return MagicMock()
+
+    monkeypatch.setattr(subprocess, "Popen", fake_popen)
+    return calls
+
+
+def _extract_watcher_script(argv: list[str]) -> str:
+    """Pull the Python source out of a ``[..., python, "-c", <script>, …]`` argv."""
+    for idx in range(len(argv) - 1):
+        if argv[idx] == "-c":
+            return argv[idx + 1]
+    raise AssertionError(f"watcher argv missing '-c <script>': {argv!r}")
+
+
+# ---------------------------------------------------------------------------
+# Argv-shape regression tests
+# ---------------------------------------------------------------------------
+
+
+class TestRestartArgvShape:
+    """The restart command never goes through bash again (#29603)."""
+
+    @pytest.mark.asyncio
+    async def test_no_bash_anywhere_in_restart_argv(self, monkeypatch):
+        """Direct guardrail: ``bash -lc`` was the bug. Anything that
+        reintroduces a shell wrapper should fail loudly here."""
+        runner, _ = make_restart_runner()
+        _patch_resolve_and_pid(monkeypatch)
+        # Force the setsid-available branch — the more-common path.
+        monkeypatch.setattr(
+            shutil, "which",
+            lambda cmd: "/usr/bin/setsid" if cmd == "setsid" else None,
+        )
+        calls = _capture_popen(monkeypatch)
+
+        await runner._launch_detached_restart_command()
+
+        assert len(calls) == 1
+        argv, _kwargs = calls[0]
+        flat = " ".join(argv)
+        for needle in (" bash ", "bash ", " sh ", "/bin/sh", "-lc", "-c '", "-c \""):
+            # ``-c`` on its own is fine (it follows ``sys.executable``);
+            # but ``bash`` / ``sh`` / shell-quoted ``-c`` strings are not.
+            pass
+        assert not any(part in {"bash", "sh", "/bin/bash", "/bin/sh"} for part in argv), (
+            f"shell wrapper reappeared in restart argv: {argv!r}"
+        )
+        assert "-lc" not in argv, f"login-shell flag reintroduced: {argv!r}"
+
+    @pytest.mark.asyncio
+    async def test_setsid_branch_uses_python_watcher(self, monkeypatch):
+        runner, _ = make_restart_runner()
+        _patch_resolve_and_pid(monkeypatch, pid=4242)
+        monkeypatch.setattr(
+            shutil, "which",
+            lambda cmd: "/usr/bin/setsid" if cmd == "setsid" else None,
+        )
+        calls = _capture_popen(monkeypatch)
+
+        await runner._launch_detached_restart_command()
+
+        argv, kwargs = calls[0]
+        # ``setsid --`` then the live interpreter ``-c <script>``.
+        assert argv[0] == "/usr/bin/setsid"
+        assert argv[1] == "--"
+        assert argv[2] == sys.executable
+        assert argv[3] == "-c"
+        # PID + restart subcommand passed as argv to the watcher.
+        tail = argv[5:]
+        assert "4242" in tail
+        assert "/usr/bin/hermes" in tail
+        assert tail[-2:] == ["gateway", "restart"]
+        # Top-level Popen is itself in a new session — defence in depth.
+        assert kwargs["start_new_session"] is True
+        assert kwargs["stdout"] is subprocess.DEVNULL
+        assert kwargs["stderr"] is subprocess.DEVNULL
+
+    @pytest.mark.asyncio
+    async def test_no_setsid_branch_still_uses_python_watcher(self, monkeypatch):
+        """Termux is exactly the environment where ``setsid`` is often
+        absent. The watcher contract must hold without it."""
+        runner, _ = make_restart_runner()
+        _patch_resolve_and_pid(monkeypatch, pid=4242)
+        monkeypatch.setattr(shutil, "which", lambda cmd: None)
+        calls = _capture_popen(monkeypatch)
+
+        await runner._launch_detached_restart_command()
+
+        argv, kwargs = calls[0]
+        assert argv[0] == sys.executable
+        assert argv[1] == "-c"
+        # No setsid prefix at all.
+        assert "setsid" not in argv[0]
+        # PID + restart subcommand still threaded through.
+        tail = argv[3:]
+        assert "4242" in tail
+        assert tail[-2:] == ["gateway", "restart"]
+        assert kwargs["start_new_session"] is True
+
+    @pytest.mark.asyncio
+    async def test_resolve_failure_short_circuits(self, monkeypatch, caplog):
+        """If we can't find the hermes binary, refuse to spawn anything
+        — we'd just spin a watcher waiting to run a nonexistent command."""
+        runner, _ = make_restart_runner()
+        monkeypatch.setattr(gateway_run, "_resolve_hermes_bin", lambda: None)
+        calls = _capture_popen(monkeypatch)
+
+        with caplog.at_level("ERROR", logger="gateway.run"):
+            await runner._launch_detached_restart_command()
+
+        assert calls == []
+        assert any("hermes binary" in rec.message for rec in caplog.records)
+
+    @pytest.mark.asyncio
+    async def test_hermes_cmd_with_multiple_parts_threaded_unquoted(self, monkeypatch):
+        """When ``_resolve_hermes_bin`` returns a multi-part argv (e.g.
+        ``[python, /path/to/hermes-cli]``), the watcher must receive
+        each part as a separate argv entry — never re-joined into a
+        shell-quoted string the way the old ``shlex.join`` path did.
+        """
+        runner, _ = make_restart_runner()
+        monkeypatch.setattr(
+            gateway_run, "_resolve_hermes_bin",
+            lambda: ["/usr/bin/python3", "/opt/hermes/cli.py", "--profile=prod"],
+        )
+        monkeypatch.setattr(gateway_run.os, "getpid", lambda: 7777)
+        monkeypatch.setattr(shutil, "which", lambda cmd: None)
+        calls = _capture_popen(monkeypatch)
+
+        await runner._launch_detached_restart_command()
+
+        argv, _ = calls[0]
+        # Each component appears as its own argv entry; no quoting at all.
+        assert "/usr/bin/python3" in argv
+        assert "/opt/hermes/cli.py" in argv
+        assert "--profile=prod" in argv
+        # The old code did ``shlex.join(hermes_cmd) + " gateway restart"``
+        # which would smush these three into a single shell-joined entry
+        # like ``"/usr/bin/python3 /opt/hermes/cli.py --profile=prod"``.
+        # That string is what we must NEVER see in the new argv.
+        shell_joined = "/usr/bin/python3 /opt/hermes/cli.py --profile=prod"
+        assert shell_joined not in argv, (
+            f"shell-quoted hermes_cmd reappeared in argv: {argv!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Watcher-script content tests
+# ---------------------------------------------------------------------------
+
+
+class TestWatcherScriptContent:
+    """The embedded watcher script must preserve the wait-for-old-pid
+    behaviour and the new ``start_new_session=True`` re-detach."""
+
+    @pytest.mark.asyncio
+    async def test_script_polls_old_pid_with_os_kill(self, monkeypatch):
+        runner, _ = make_restart_runner()
+        _patch_resolve_and_pid(monkeypatch)
+        monkeypatch.setattr(shutil, "which", lambda cmd: None)
+        calls = _capture_popen(monkeypatch)
+
+        await runner._launch_detached_restart_command()
+
+        script = _extract_watcher_script(calls[0][0])
+        assert "os.kill(pid, 0)" in script
+        assert "ProcessLookupError" in script
+        # The 120 s bound matches the Windows branch — keeps the watcher
+        # from running forever if the old gateway never exits.
+        assert "120" in script
+
+    @pytest.mark.asyncio
+    async def test_script_uses_start_new_session_true_for_respawn(self, monkeypatch):
+        """The whole point of #29603: the watcher's child must be in
+        its own session so SIGHUP from the watcher exit doesn't reach
+        it."""
+        runner, _ = make_restart_runner()
+        _patch_resolve_and_pid(monkeypatch)
+        monkeypatch.setattr(shutil, "which", lambda cmd: None)
+        calls = _capture_popen(monkeypatch)
+
+        await runner._launch_detached_restart_command()
+
+        script = _extract_watcher_script(calls[0][0])
+        assert "start_new_session=True" in script
+        # Belt-and-suspenders: also closes the parent's fds so the new
+        # gateway can't accidentally inherit a writable stdio handle.
+        assert "close_fds=True" in script
+
+    @pytest.mark.asyncio
+    async def test_script_routes_child_stdio_to_devnull(self, monkeypatch):
+        runner, _ = make_restart_runner()
+        _patch_resolve_and_pid(monkeypatch)
+        monkeypatch.setattr(shutil, "which", lambda cmd: None)
+        calls = _capture_popen(monkeypatch)
+
+        await runner._launch_detached_restart_command()
+
+        script = _extract_watcher_script(calls[0][0])
+        assert "subprocess.DEVNULL" in script
+        assert "stdout=subprocess.DEVNULL" in script
+        assert "stderr=subprocess.DEVNULL" in script
+
+    @pytest.mark.asyncio
+    async def test_script_is_byte_compilable(self, monkeypatch):
+        """The watcher is interpreted by a fresh ``python -c``, so a
+        SyntaxError in the embedded script would silently kill /restart
+        in production. Compile it here to catch that at test time."""
+        runner, _ = make_restart_runner()
+        _patch_resolve_and_pid(monkeypatch)
+        monkeypatch.setattr(shutil, "which", lambda cmd: None)
+        calls = _capture_popen(monkeypatch)
+
+        await runner._launch_detached_restart_command()
+
+        script = _extract_watcher_script(calls[0][0])
+        compile(script, "<watcher>", "exec")
+
+
+# ---------------------------------------------------------------------------
+# End-to-end functional test
+# ---------------------------------------------------------------------------
+
+
+class TestWatcherRespawnReallyDetaches:
+    """Run the actual embedded watcher script in a real subprocess and
+    confirm its child ends up in a brand-new session — the property
+    #29603 was missing."""
+
+    def _build_e2e_script(
+        self,
+        *,
+        watcher_script: str,
+        target_pid: int,
+        sentinel_path: Path,
+        python: str,
+    ) -> list[str]:
+        """Wrap the embedded watcher so its "respawn" is a tiny Python
+        program that records its session id (sid), pgid, pid, and ppid
+        into ``sentinel_path`` — that's how we'll prove the new session.
+        """
+        child_program = textwrap.dedent(
+            f"""
+            import os
+            import time
+
+            sid = os.getsid(0)
+            pgid = os.getpgrp()
+            pid = os.getpid()
+            ppid = os.getppid()
+            with open({str(sentinel_path)!r}, "w") as f:
+                f.write(f"sid={{sid}}\\npgid={{pgid}}\\npid={{pid}}\\nppid={{ppid}}\\n")
+            # Stay alive briefly so the watcher exits first, exercising
+            # the SIGHUP path #29603 cared about.
+            time.sleep(1.5)
+            """
+        ).strip()
+        return [
+            python,
+            "-c",
+            watcher_script,
+            str(target_pid),
+            python,
+            "-c",
+            child_program,
+        ]
+
+    @pytest.mark.asyncio
+    async def test_watcher_child_lands_in_new_session(self, monkeypatch, tmp_path):
+        runner, _ = make_restart_runner()
+        _patch_resolve_and_pid(monkeypatch)
+        monkeypatch.setattr(shutil, "which", lambda cmd: None)
+        calls = _capture_popen(monkeypatch)
+
+        await runner._launch_detached_restart_command()
+        watcher_script = _extract_watcher_script(calls[0][0])
+
+        # Restore the real ``subprocess.Popen`` — the rest of this test
+        # needs to spawn the watcher (and a fake old gateway) for real.
+        monkeypatch.undo()
+
+        sentinel = tmp_path / "child.txt"
+
+        # Real "old gateway" so the watcher's wait loop has a PID to
+        # poll. We deliberately reap it BEFORE letting the watcher run
+        # so ``os.kill(old_pid, 0)`` returns ESRCH right away — a
+        # zombie process still answers signal 0 with success, which
+        # would stall the wait loop for the full 120 s deadline.
+        old_gateway = subprocess.Popen(
+            [sys.executable, "-c", "raise SystemExit(0)"],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        old_pid = old_gateway.pid
+        old_gateway.wait(timeout=5.0)
+
+        watcher_argv = self._build_e2e_script(
+            watcher_script=watcher_script,
+            target_pid=old_pid,
+            sentinel_path=sentinel,
+            python=sys.executable,
+        )
+
+        # The watcher itself runs in a brand-new session — exactly how
+        # production invokes it via the top-level Popen.
+        watcher = subprocess.Popen(
+            watcher_argv,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            start_new_session=True,
+        )
+
+        data: dict[str, str] = {}
+        try:
+            deadline = time.monotonic() + 10.0
+            while time.monotonic() < deadline and not sentinel.exists():
+                time.sleep(0.05)
+            assert sentinel.exists(), "watcher never spawned the child"
+
+            data = dict(
+                line.split("=", 1) for line in sentinel.read_text().splitlines() if "=" in line
+            )
+            child_sid = int(data["sid"])
+            child_pgid = int(data["pgid"])
+            child_pid = int(data["pid"])
+
+            # The fix's invariant: the spawned child is the leader of
+            # its own session, so when the watcher's own session is
+            # torn down SIGHUP does NOT reach the new gateway.
+            assert child_sid == child_pid, (
+                f"child should be session leader (sid={child_sid}, pid={child_pid}) — "
+                "start_new_session=True did not take effect"
+            )
+            assert child_pgid == child_pid, (
+                f"child should be process group leader (pgid={child_pgid}, pid={child_pid})"
+            )
+            assert child_sid != os.getsid(0), (
+                "child should NOT share a session with the test runner"
+            )
+        finally:
+            if watcher.poll() is None:
+                watcher.terminate()
+                try:
+                    watcher.wait(timeout=2.0)
+                except subprocess.TimeoutExpired:
+                    watcher.kill()
+                    watcher.wait(timeout=2.0)
+            # The watcher's child is now an orphan adopted by init;
+            # kill it directly via the PID we captured.
+            child_pid_str = data.get("pid")
+            if child_pid_str:
+                try:
+                    os.kill(int(child_pid_str), 9)
+                except (ProcessLookupError, OSError):
+                    pass

--- a/tests/gateway/test_restart_drain.py
+++ b/tests/gateway/test_restart_drain.py
@@ -161,6 +161,12 @@ async def test_request_restart_is_idempotent():
 
 @pytest.mark.asyncio
 async def test_launch_detached_restart_command_uses_setsid(monkeypatch):
+    """The Unix restart path spawns the watcher under setsid (when
+    available), with the watcher exec'd via ``sys.executable -c …``
+    rather than ``bash -lc`` (#29603 — bash-as-session-leader SIGHUPs
+    the new gateway on non-systemd POSIX environments)."""
+    import sys
+
     runner, _adapter = make_restart_runner()
     popen_calls = []
 
@@ -178,9 +184,20 @@ async def test_launch_detached_restart_command_uses_setsid(monkeypatch):
 
     assert len(popen_calls) == 1
     cmd, kwargs = popen_calls[0]
-    assert cmd[:2] == ["/usr/bin/setsid", "bash"]
-    assert "gateway restart" in cmd[-1]
-    assert "kill -0 321" in cmd[-1]
+    # setsid wraps a Python watcher (no shell, no bash -lc).
+    assert cmd[:3] == ["/usr/bin/setsid", "--", sys.executable]
+    assert cmd[3] == "-c"
+    watcher_script = cmd[4]
+    # Watcher is the Python source, not a shell snippet.
+    assert "import subprocess" in watcher_script
+    assert "start_new_session=True" in watcher_script
+    # No bash anywhere in the argv — the old shell-based command was the bug.
+    assert not any(part == "bash" or part == "-lc" for part in cmd)
+    # Old PID + restart subcommand are passed as argv to the watcher,
+    # not interpolated into a shell string.
+    assert "321" in cmd[5:]
+    assert "gateway" in cmd[5:]
+    assert "restart" in cmd[5:]
     assert kwargs["start_new_session"] is True
     assert kwargs["stdout"] is subprocess.DEVNULL
     assert kwargs["stderr"] is subprocess.DEVNULL


### PR DESCRIPTION
## What does this PR do?

Fixes [#29603](https://github.com/NousResearch/hermes-agent/issues/29603) — `hermes gateway restart` (and `/restart` from a chat platform) kills the *new* gateway instance on non-systemd POSIX environments (Termux/Android), leaving the QQ/Telegram adapters offline until someone restarts manually.

**Root cause.** `_launch_detached_restart_command` (in `gateway/run.py`) used:

```
setsid bash -lc "while kill -0 OLD; do sleep 0.2; done; hermes gateway restart"
```

That makes `bash` the session leader. When the wait loop ends and bash exits after the restart subcommand returns, bash's controlling session is torn down and `SIGHUP` is delivered to every process still in it — including the freshly spawned gateway daemon on platforms (Termux / Android) where the daemon hasn't fully re-detached by the time bash unwinds. `systemd` masks the symptom by respawning the unit; bare-POSIX environments deterministically lose the gateway.

**Fix.** Replace the shell with a small Python watcher — exactly the same pattern already used by the Windows branch right above it and by `hermes_cli.gateway.launch_detached_profile_gateway_restart`. The watcher polls the old PID, then re-detaches `hermes gateway restart` into its own session via `start_new_session=True`, so the watcher exiting can't take the new gateway with it. Both the `setsid`-available and `setsid`-missing branches go through the same watcher (Termux is exactly the environment that often ships without `setsid`).

The fix preserves the original 120 s wait-for-old-pid loop and doesn't change the Windows or systemd code paths.

## Related Issue

Closes #29603 — *gateway restart kills new instance on non-systemd environments (Termux/Android)*.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [x] ♻️ Refactor (no behavior change) — aligns the Unix detach pattern with the existing Windows / profile-restart watchers
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/run.py` — `_launch_detached_restart_command` (Unix branch only):
  - Removes the `setsid bash -lc "while kill -0 …; hermes gateway restart"` shell pipeline.
  - Replaces it with a Python watcher script (mirrors the existing Windows branch + `hermes_cli.gateway.launch_detached_profile_gateway_restart`) executed via `sys.executable -c <script>`.
  - The watcher preserves the 120 s wait-for-old-pid loop (`os.kill(pid, 0)`), handles `ProcessLookupError` / `PermissionError` / `OSError` explicitly, then `Popen`s `hermes gateway restart` with `start_new_session=True, close_fds=True` so the new gateway is the leader of its own session.
  - The watcher itself is still launched under `setsid --` when available, for defence in depth.
  - Inline comment cites #29603 and spells out *why* the bash wrapper had to go (so a future "let's just shell it out, it's simpler" patch trips the reviewer).

- `tests/gateway/test_restart_drain.py` — updates the existing `test_launch_detached_restart_command_uses_setsid` to assert on the new argv shape (`[setsid, --, sys.executable, -c, <watcher_script>, …]` instead of `[setsid, bash, -lc, <shell_cmd>]`) and explicitly rejects any reappearance of `bash`/`-lc` in the argv.

- `tests/gateway/test_restart_detach_no_sighup.py` (new file, +419 lines, 10 cases across three classes):
  - `TestRestartArgvShape` (5 cases): top-level guardrails — no `bash`/`-lc`/`/bin/sh` anywhere; the `setsid`-available *and* `setsid`-missing branches both use the Python watcher; `_resolve_hermes_bin` failure short-circuits without spawning anything; a multi-part `hermes_cmd` is threaded as separate argv entries (no `shlex.join` shell-quoting reappearing).
  - `TestWatcherScriptContent` (4 cases): the embedded watcher script preserves `os.kill(pid, 0)` polling with the 120 s bound, uses `start_new_session=True` + `close_fds=True` for the respawn, routes child stdio to `DEVNULL`, and is byte-compilable (a `SyntaxError` in the embedded string would silently break `/restart` in production).
  - `TestWatcherRespawnReallyDetaches` (1 e2e case): runs the actual watcher script in a real subprocess with a real (already-reaped) fake old-gateway PID, has it spawn a recorder child that writes its `sid` / `pgid` / `pid` to a sentinel file, and asserts the recorder ends up as the leader of a brand-new session — the property #29603 was missing.

## How to Test

1. Check out the branch and activate the venv:
   ```
   git fetch origin fix/29603-gateway-restart-termux-sighup
   git checkout fix/29603-gateway-restart-termux-sighup
   source .venv/bin/activate   # or: python3 -m venv .venv && source .venv/bin/activate && pip install -e ".[all,dev]"
   ```
2. Run the new regression file on its own:
   ```
   scripts/run_tests.sh tests/gateway/test_restart_detach_no_sighup.py -v
   ```
   Expected: **10 passed**.
3. Run both restart test files together (covers the updated existing test):
   ```
   scripts/run_tests.sh tests/gateway/test_restart_detach_no_sighup.py tests/gateway/test_restart_drain.py
   ```
   Expected: **26 passed**.
4. Manual smoke test on a non-systemd POSIX host (Termux / plain Linux without `--user` systemd):
   - Start the gateway: `hermes gateway run` in a foreground shell.
   - From a chat platform send `/restart`, or run `hermes gateway restart` from another shell.
   - Before this PR: the new gateway dies seconds after the old one exits; `hermes gateway status` reports no gateway running and the messenger adapters stay offline.
   - With this PR: the new gateway survives, adapters reconnect within seconds, and `hermes gateway status` shows the new PID.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(gateway): …` and `test(gateway): …`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run `scripts/run_tests.sh tests/gateway/test_restart_detach_no_sighup.py tests/gateway/test_restart_drain.py` and all 26 tests pass
- [x] I've added tests for my changes (10 new regression cases across three classes + updated existing argv-shape test)
- [x] I've tested on my platform: macOS 15.2 (Darwin 24.6.0), Python 3.12

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (no user-visible config / behaviour surface change; the fix is invisible to users on platforms that previously worked)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — the Windows branch is untouched (same Python-watcher pattern as before), the Unix branch now mirrors it, and the test file is `skipif(sys.platform.startswith("win"))` to keep CI clean
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

```
$ scripts/run_tests.sh tests/gateway/test_restart_detach_no_sighup.py -v
4 workers [10 items]
==============================
TestRestartArgvShape::test_no_bash_anywhere_in_restart_argv             PASSED
TestRestartArgvShape::test_setsid_branch_uses_python_watcher            PASSED
TestRestartArgvShape::test_no_setsid_branch_still_uses_python_watcher   PASSED
TestRestartArgvShape::test_resolve_failure_short_circuits               PASSED
TestRestartArgvShape::test_hermes_cmd_with_multiple_parts_threaded_…    PASSED
TestWatcherScriptContent::test_script_polls_old_pid_with_os_kill        PASSED
TestWatcherScriptContent::test_script_uses_start_new_session_true_…    PASSED
TestWatcherScriptContent::test_script_routes_child_stdio_to_devnull     PASSED
TestWatcherScriptContent::test_script_is_byte_compilable                PASSED
TestWatcherRespawnReallyDetaches::test_watcher_child_lands_in_new_…    PASSED
============================== 10 passed in 1.14s ==============================

$ scripts/run_tests.sh tests/gateway/test_restart_detach_no_sighup.py tests/gateway/test_restart_drain.py
4 workers [26 items]
..........................                                               [100%]
============================== 26 passed in 1.22s ==============================
```
