### PR TITLE
fix: honor DeepSeek config api_key

### DIFF
--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -1496,6 +1496,13 @@ def resolve_runtime_provider(
         if cfg_provider == provider:
             cfg_base_url = (model_cfg.get("base_url") or "").strip().rstrip("/")
         base_url = cfg_base_url or creds.get("base_url", "").rstrip("/")
+        api_key = creds.get("api_key", "")
+        source = creds.get("source", "env")
+        if provider == "deepseek" and not api_key and cfg_provider == "deepseek":
+            cfg_api_key = str(model_cfg.get("api_key") or "").strip()
+            if cfg_api_key:
+                api_key = cfg_api_key
+                source = "config:model.api_key"
         api_mode = "chat_completions"
         if provider == "copilot":
             api_mode = _copilot_runtime_api_mode(model_cfg, creds.get("api_key", ""))
@@ -1533,8 +1540,8 @@ def resolve_runtime_provider(
             "provider": provider,
             "api_mode": api_mode,
             "base_url": base_url,
-            "api_key": creds.get("api_key", ""),
-            "source": creds.get("source", "env"),
+            "api_key": api_key,
+            "source": source,
             "requested_provider": requested_provider,
         }
 

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -199,6 +199,62 @@ def test_resolve_runtime_provider_uses_qwen_pool_entry(monkeypatch):
     assert resolved["source"] == "manual:qwen_cli"
 
 
+def test_resolve_runtime_provider_deepseek_uses_config_api_key_when_auth_empty(monkeypatch):
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "deepseek")
+    monkeypatch.setattr(
+        rp,
+        "_get_model_config",
+        lambda: {
+            "provider": "deepseek",
+            "api_key": "config-deepseek-token",
+            "base_url": "https://api.deepseek.com/v1",
+            "default": "deepseek/deepseek-chat",
+        },
+    )
+    monkeypatch.setattr(
+        rp,
+        "resolve_api_key_provider_credentials",
+        lambda provider: {
+            "provider": provider,
+            "api_key": "",
+            "base_url": "https://api.deepseek.com/v1",
+            "source": "default",
+        },
+    )
+    monkeypatch.delenv("DEEPSEEK_API_KEY", raising=False)
+    monkeypatch.delenv("DEEPSEEK_BASE_URL", raising=False)
+
+    resolved = rp.resolve_runtime_provider(requested="deepseek")
+
+    assert resolved["provider"] == "deepseek"
+    assert resolved["api_key"] == "config-deepseek-token"
+    assert resolved["source"] == "config:model.api_key"
+    assert resolved["base_url"] == "https://api.deepseek.com/v1"
+
+
+def test_resolve_runtime_provider_deepseek_config_api_key_is_ignored_for_other_provider(monkeypatch):
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "anthropic")
+    monkeypatch.setattr(
+        rp,
+        "_get_model_config",
+        lambda: {
+            "provider": "anthropic",
+            "api_key": "config-deepseek-token",
+            "base_url": "https://api.anthropic.com",
+        },
+    )
+    monkeypatch.setattr(
+        "agent.anthropic_adapter.resolve_anthropic_token",
+        lambda: "anthropic-token",
+    )
+
+    resolved = rp.resolve_runtime_provider(requested="anthropic")
+
+    assert resolved["provider"] == "anthropic"
+    assert resolved["api_key"] == "anthropic-token"
+    assert resolved["base_url"] == "https://api.anthropic.com"
+
+
 def test_resolve_provider_alias_qwen(monkeypatch):
     monkeypatch.setattr(rp.auth_mod, "_load_auth_store", lambda: {})
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)


### PR DESCRIPTION
## Summary
Allow built-in DeepSeek to use `config.yaml` `model.api_key` when no runtime or env API key is available.

This keeps the behavior scoped to the DeepSeek built-in provider and leaves auth/provider-detection logic alone.

## Verification
- `python -m pytest tests/hermes_cli/test_runtime_provider_resolution.py -q -k 'deepseek or qwen_pool_entry'`
- `git diff --check`

## Notes
- Adds regression coverage for the DeepSeek fallback path and the non-DeepSeek ignore path.
- No `auth.py` or provider-detection changes.