### PR TITLE
fix(auxiliary): prevent URL double-rewrite for custom anthropic_messages endpoints

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -3270,22 +3270,58 @@ def resolve_provider_client(
     # ── Custom endpoint (OPENAI_BASE_URL + OPENAI_API_KEY) ───────────
     if provider == "custom":
         if explicit_base_url:
-            custom_base = _to_openai_base_url(explicit_base_url).strip()
             custom_key = (
                 (explicit_api_key or "").strip()
                 or os.getenv("OPENAI_API_KEY", "").strip()
                 or "no-key-required"  # local servers don't need auth
             )
+            final_model = _normalize_resolved_model(
+                model or (main_runtime.get("model") if main_runtime else None) or "gpt-4o-mini",
+                provider,
+            )
+
+            # When api_mode is anthropic_messages, the endpoint speaks the
+            # Anthropic Messages protocol — build an Anthropic client directly
+            # using the *original* URL (e.g. /api/anthropic).  Rewriting it to
+            # an OpenAI-wire URL via _to_openai_base_url and then wrapping in
+            # AnthropicAuxiliaryClient causes a double-rewrite: the Anthropic
+            # SDK appends /v1/messages to the already-rewritten /paas/v4 path,
+            # producing /v4/v1/messages → 404.
+            if api_mode == "anthropic_messages":
+                try:
+                    from agent.anthropic_adapter import build_anthropic_client
+                    real_client = build_anthropic_client(custom_key, explicit_base_url.strip())
+                    client = AnthropicAuxiliaryClient(
+                        real_client, final_model, custom_key,
+                        explicit_base_url.strip(), is_oauth=False,
+                    )
+                    logger.debug(
+                        "resolve_provider_client: custom anthropic_messages "
+                        "endpoint %s (model=%s)",
+                        explicit_base_url.strip()[:60], final_model,
+                    )
+                    return (_to_async_client(client, final_model, is_vision=is_vision) if async_mode
+                            else (client, final_model))
+                except ImportError:
+                    logger.warning(
+                        "Custom endpoint declares api_mode=anthropic_messages but "
+                        "the anthropic SDK is not installed — falling back to "
+                        "OpenAI-wire transport."
+                    )
+                except Exception as exc:
+                    logger.warning(
+                        "Failed to build Anthropic client for custom endpoint %s "
+                        "(%s) — falling back to OpenAI-wire.",
+                        explicit_base_url.strip()[:60], exc,
+                    )
+
+            custom_base = _to_openai_base_url(explicit_base_url).strip()
             if not custom_base:
                 logger.warning(
                     "resolve_provider_client: explicit custom endpoint requested "
                     "but base_url is empty"
                 )
                 return None, None
-            final_model = _normalize_resolved_model(
-                model or (main_runtime.get("model") if main_runtime else None) or "gpt-4o-mini",
-                provider,
-            )
             extra = {}
             _clean_base, _dq = _extract_url_query_params(custom_base)
             if _dq:


### PR DESCRIPTION
markdown
    Bug Description

    Auxiliary tasks (title generation, vision, compression, etc.) fail with HTTP 404 when using a custom provider with api_mode: anthropic_messages (e.g. Zhipu GLM via https://open.bigmodel.cn/api/anthropic).

    Error:

    Auxiliary title generation failed: HTTP 404: Error code: 404 - {'status': 404, 'error': 'Not Found', 'path': '/v4/v1/messages'}


    Root Cause

    In resolve_provider_client()'s custom + explicit_base_url branch, the URL passes through two contradictory rewrites:

    1. _to_openai_base_url() rewrites /api/anthropic → /api/paas/v4 (OpenAI-wire format), because the auxiliary client historically uses the OpenAI SDK.
    2. _maybe_wrap_anthropic() detects api_mode=anthropic_messages and builds an AnthropicAuxiliaryClient on the already-rewritten URL.
    3. The Anthropic SDK appends /v1/messages to /api/paas/v4, producing /v4/v1/messages → 404.

    The two steps assume mutually exclusive transports: step 1 assumes OpenAI SDK, step 2 assumes Anthropic SDK. When both fire, the URL is mangled.

    Fix

    When api_mode == "anthropic_messages", bypass _to_openai_base_url() entirely and build an AnthropicAuxiliaryClient directly from the original explicit_base_url (e.g. https://open.bigmodel.cn/api/anthropic). This mirrors the approach already used in _try_custom_endpoint() (the Step-2 fallback path), which correctly handles anthropic_messages by building the Anthropic client first.

    On ImportError (anthropic SDK not installed) or other exceptions, falls back to the existing OpenAI-wire path.

    How to Verify

    1. Configure a custom provider with Anthropic-compatible endpoint:
       yaml
       model:
         default: glm-5.1
         provider: custom
         base_url: https://open.bigmodel.cn/api/anthropic
         api_mode: anthropic_messages
         api_key: <your-key>

    2. Start a new session with hermes
    3. Send any message — previously this would log Auxiliary title generation failed: HTTP 404
    4. After the fix, title generation succeeds and the session gets a proper title
    5. Verify with a unit test:
       python
       from agent.auxiliary_client import resolve_provider_client
       client, model = resolve_provider_client(
           'custom', 'glm-5.1',
           explicit_base_url='https://open.bigmodel.cn/api/anthropic',
           explicit_api_key='test-key',
           api_mode='anthropic_messages',
       )
       assert type(client).name == 'AnthropicAuxiliaryClient'
       assert str(getattr(client, 'base_url', '')).endswith('/api/anthropic')


    Test Plan

    - [x] Manual verification with Zhipu GLM Anthropic-compatible endpoint
    - [x] Module import succeeds (import agent.auxiliary_client)
    - [x] resolve_provider_client returns correct AnthropicAuxiliaryClient with unrewritten URL
    - [ ] Existing tests still pass
    - [ ] Regression test added

    Risk Assessment

    Low — The fix adds an early-return branch that only triggers when api_mode == "anthropic_messages". All other code paths (OpenAI-wire custom endpoints, named providers, auto-detection without explicit api_mode) are unchanged. The fallback on ImportError ensures no regression if the anthropic SDK is missing.