### PR TITLE
fix(tools): honor --platform scope for MCP tool exclusions

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -798,11 +798,26 @@ def init_agent(
             print(f"🔄 Fallback chain ({len(agent._fallback_chain)} providers): " +
                   " → ".join(f"{f['model']} ({f['provider']})" for f in agent._fallback_chain))
 
+    # Resolve per-platform MCP tool exclusions. ``platform`` is threaded into
+    # every agent-construction path (cli, gateway background tasks, cron), so
+    # this is the single chokepoint where the runtime platform is known and
+    # config is available. Excludes the heavy MCP servers an operator has
+    # scoped out of this platform (e.g. OpenBB dropped from cron jobs that
+    # don't need it, while cli keeps it) — see hermes_cli/tools_config.py.
+    _mcp_excludes = None
+    try:
+        from hermes_cli.config import load_config as _load_mcp_excl_cfg
+        from hermes_cli.tools_config import resolve_mcp_excludes as _resolve_mcp_excludes
+        _mcp_excludes = _resolve_mcp_excludes(_load_mcp_excl_cfg(), platform or "cli")
+    except Exception as _mcp_excl_err:
+        _ra().logger.debug("MCP exclude resolution skipped: %s", _mcp_excl_err)
+
     # Get available tools with filtering
     agent.tools = _ra().get_tool_definitions(
         enabled_toolsets=enabled_toolsets,
         disabled_toolsets=disabled_toolsets,
         quiet_mode=agent.quiet_mode,
+        mcp_excludes=_mcp_excludes,
     )
     
     # Show tool configuration and store valid tool names for validation

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -666,6 +666,30 @@ platform_toolsets:
   teams: [hermes-teams]
   google_chat: [hermes-google_chat]
 
+# ─────────────────────────────────────────────────────────────────────────────
+# Per-platform MCP tool exclusions
+#
+# Exclude specific MCP server tools from a single platform without disabling
+# them everywhere. Useful for keeping heavy MCP servers (OpenBB, Alpaca, etc.)
+# available for interactive use while excluding them from cron jobs whose tool
+# schema would otherwise overflow the model's context window.
+#
+# Keyed by platform, then by MCP server name; the value is a list of tool
+# names (or ['*'] to exclude every tool from that server).
+#
+# A tool is excluded for a platform if EITHER this map OR the global
+# mcp_servers.<name>.tools.exclude list matches it.
+#
+# Manage interactively with:
+#   hermes tools disable --platform cron openbb:*
+#   hermes tools enable  --platform cron openbb:*
+#
+# platform_mcp_excludes:
+#   cron:
+#     openbb: ['*']             # exclude all OpenBB tools from cron jobs
+#     alpaca: [place_order]     # exclude one Alpaca tool from cron jobs
+# ─────────────────────────────────────────────────────────────────────────────
+
 # =============================================================================
 # Gateway Platform Settings
 # =============================================================================

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -1281,6 +1281,54 @@ def _get_platform_tools(
     return enabled_toolsets
 
 
+# Sentinel platform meaning "every platform". When ``hermes tools disable`` is
+# invoked without ``--platform`` (or with the default ``cli``), MCP exclusions
+# are written globally under ``mcp_servers.<name>.tools.exclude`` so they apply
+# everywhere — that GLOBAL behavior predates per-platform scoping and is kept.
+_MCP_EXCLUDE_GLOBAL_PLATFORM = "cli"
+
+
+def resolve_mcp_excludes(config: dict, platform: str) -> Dict[str, Set[str]]:
+    """Resolve the effective MCP tool exclusions for *platform*.
+
+    Merges two sources, both of which exclude a tool when they match:
+
+      * GLOBAL — ``mcp_servers.<server>.tools.exclude`` (applies to every
+        platform; this is the long-standing behavior).
+      * PLATFORM-SCOPED — ``platform_mcp_excludes.<platform>.<server>``
+        (applies only to the named platform).
+
+    Returns ``{server_name: {tool_name, ...}}``. A ``"*"`` entry in a server's
+    set means every tool from that server is excluded.
+    """
+    merged: Dict[str, Set[str]] = {}
+
+    # Global server-level excludes — apply to all platforms.
+    mcp_servers = config.get("mcp_servers") or {}
+    for server_name, server_cfg in mcp_servers.items():
+        if not isinstance(server_cfg, dict):
+            continue
+        tools_cfg = server_cfg.get("tools") or {}
+        exclude = tools_cfg.get("exclude") or []
+        if isinstance(exclude, str):
+            exclude = [exclude]
+        if exclude:
+            merged.setdefault(str(server_name), set()).update(str(t) for t in exclude)
+
+    # Platform-scoped excludes — apply only to this platform.
+    platform_excludes = config.get("platform_mcp_excludes") or {}
+    scoped = platform_excludes.get(platform) or {}
+    if isinstance(scoped, dict):
+        for server_name, tool_list in scoped.items():
+            if isinstance(tool_list, str):
+                tool_list = [tool_list]
+            if not tool_list:
+                continue
+            merged.setdefault(str(server_name), set()).update(str(t) for t in tool_list)
+
+    return merged
+
+
 def _save_platform_tools(config: dict, platform: str, enabled_toolset_keys: Set[str]):
     """Save the selected toolset keys for a platform to config.
 
@@ -3074,32 +3122,67 @@ def _apply_toolset_change(config: dict, platform: str, toolset_names: List[str],
     _save_platform_tools(config, platform, updated)
 
 
-def _apply_mcp_change(config: dict, targets: List[str], action: str) -> Set[str]:
-    """Add or remove specific MCP tools from a server's exclude list.
+def _apply_mcp_change(
+    config: dict, targets: List[str], action: str, platform: str = _MCP_EXCLUDE_GLOBAL_PLATFORM
+) -> Set[str]:
+    """Add or remove specific MCP tools from an exclude list.
 
     Returns the set of server names that were not found in config.
+
+    When *platform* is the global default (``cli``), changes are written to the
+    GLOBAL ``mcp_servers.<server>.tools.exclude`` list, which applies to every
+    platform — preserving the long-standing behavior. When *platform* is any
+    other platform, changes are written to the PLATFORM-SCOPED
+    ``platform_mcp_excludes.<platform>.<server>`` list, so a heavy MCP server
+    can be excluded from (say) cron jobs while staying available for ``cli``.
     """
     failed_servers: Set[str] = set()
     mcp_servers = config.get("mcp_servers") or {}
+    is_global = platform == _MCP_EXCLUDE_GLOBAL_PLATFORM
 
     for target in targets:
         server_name, tool_name = target.split(":", 1)
         if server_name not in mcp_servers:
             failed_servers.add(server_name)
             continue
-        tools_cfg = mcp_servers[server_name].setdefault("tools", {})
-        exclude = list(tools_cfg.get("exclude") or [])
-        if action == "disable":
-            if tool_name not in exclude:
-                exclude.append(tool_name)
+        if is_global:
+            tools_cfg = mcp_servers[server_name].setdefault("tools", {})
+            exclude = list(tools_cfg.get("exclude") or [])
+            if action == "disable":
+                if tool_name not in exclude:
+                    exclude.append(tool_name)
+            else:
+                exclude = [t for t in exclude if t != tool_name]
+            tools_cfg["exclude"] = exclude
         else:
-            exclude = [t for t in exclude if t != tool_name]
-        tools_cfg["exclude"] = exclude
+            platform_excludes = config.setdefault("platform_mcp_excludes", {})
+            scoped = platform_excludes.setdefault(platform, {})
+            exclude = list(scoped.get(server_name) or [])
+            if action == "disable":
+                if tool_name not in exclude:
+                    exclude.append(tool_name)
+            else:
+                exclude = [t for t in exclude if t != tool_name]
+            if exclude:
+                scoped[server_name] = exclude
+            else:
+                # Drop empty leaves so ``hermes tools enable`` fully reverts
+                # the config rather than leaving dangling empty containers.
+                scoped.pop(server_name, None)
+                if not scoped:
+                    platform_excludes.pop(platform, None)
+                if not platform_excludes:
+                    config.pop("platform_mcp_excludes", None)
 
     return failed_servers
 
 
-def _print_tools_list(enabled_toolsets: set, mcp_servers: dict, platform: str = "cli"):
+def _print_tools_list(
+    enabled_toolsets: set,
+    mcp_servers: dict,
+    platform: str = "cli",
+    config: Optional[dict] = None,
+):
     """Print a summary of enabled/disabled toolsets and MCP tool filters."""
     effective_all = _get_effective_configurable_toolsets()
     effective = [
@@ -3127,18 +3210,38 @@ def _print_tools_list(enabled_toolsets: set, mcp_servers: dict, platform: str = 
             print(f"  {status}  {ts_key}  {color(label, Colors.DIM)}")
 
     if mcp_servers:
+        # Platform-scoped MCP excludes (separate from the global server-level
+        # exclude list). Shown alongside so `hermes tools list --platform cron`
+        # accurately reflects what cron sees, not just the global config.
+        scoped_excludes: Dict[str, List[str]] = {}
+        if config:
+            platform_excludes = config.get("platform_mcp_excludes") or {}
+            raw_scoped = platform_excludes.get(platform) or {}
+            if isinstance(raw_scoped, dict):
+                for srv, tool_list in raw_scoped.items():
+                    if isinstance(tool_list, str):
+                        tool_list = [tool_list]
+                    if tool_list:
+                        scoped_excludes[str(srv)] = [str(t) for t in tool_list]
+
         print()
         print("MCP servers:")
         for srv_name, srv_cfg in mcp_servers.items():
             tools_cfg = srv_cfg.get("tools") or {}
             exclude = tools_cfg.get("exclude") or []
             include = tools_cfg.get("include") or []
+            scoped = scoped_excludes.get(str(srv_name)) or []
             if include:
                 _print_info(f"{srv_name}  [include only: {', '.join(include)}]")
             elif exclude:
                 _print_info(f"{srv_name}  [excluded: {color(', '.join(exclude), Colors.YELLOW)}]")
             else:
                 _print_info(f"{srv_name}  {color('all tools enabled', Colors.DIM)}")
+            if scoped:
+                _print_info(
+                    f"  └ {platform}-only excluded: "
+                    f"{color(', '.join(scoped), Colors.YELLOW)}"
+                )
 
 
 def tools_disable_enable_command(args):
@@ -3157,7 +3260,7 @@ def tools_disable_enable_command(args):
 
     if action == "list":
         _print_tools_list(_get_platform_tools(config, platform, include_default_mcp_servers=False),
-                          config.get("mcp_servers") or {}, platform)
+                          config.get("mcp_servers") or {}, platform, config)
         return
 
     targets: List[str] = args.names
@@ -3190,7 +3293,7 @@ def tools_disable_enable_command(args):
 
     failed_servers: Set[str] = set()
     if mcp_targets:
-        failed_servers = _apply_mcp_change(config, mcp_targets, action)
+        failed_servers = _apply_mcp_change(config, mcp_targets, action, platform)
         for srv in failed_servers:
             _print_error(f"MCP server '{srv}' not found in config")
 

--- a/model_tools.py
+++ b/model_tools.py
@@ -264,6 +264,7 @@ def get_tool_definitions(
     enabled_toolsets: List[str] = None,
     disabled_toolsets: List[str] = None,
     quiet_mode: bool = False,
+    mcp_excludes: Dict[str, set] = None,
 ) -> List[Dict[str, Any]]:
     """
     Get tool definitions for model API calls with toolset-based filtering.
@@ -274,6 +275,11 @@ def get_tool_definitions(
         enabled_toolsets: Only include tools from these toolsets.
         disabled_toolsets: Exclude tools from these toolsets (if enabled_toolsets is None).
         quiet_mode: Suppress status prints.
+        mcp_excludes: Optional ``{server_name: {tool_name_or_"*"}}`` map of
+            MCP tools to exclude. Applied after toolset resolution so heavy
+            MCP servers can be scoped out per-platform (e.g. dropped from cron
+            jobs while staying available for cli). Resolve via
+            ``hermes_cli.tools_config.resolve_mcp_excludes(config, platform)``.
 
     Returns:
         Filtered list of OpenAI-format tool definitions.
@@ -294,11 +300,20 @@ def get_tool_definitions(
             cfg_fp = (cfg_stat.st_mtime_ns, cfg_stat.st_size)
         except (FileNotFoundError, OSError, ImportError):
             cfg_fp = None
+        # MCP excludes are a dict-of-sets — flatten to a hashable, order-stable
+        # form so the same exclusion config always hits the same cache entry.
+        if mcp_excludes:
+            mcp_excludes_key = frozenset(
+                (srv, frozenset(tools)) for srv, tools in mcp_excludes.items()
+            )
+        else:
+            mcp_excludes_key = None
         cache_key = (
             frozenset(enabled_toolsets) if enabled_toolsets is not None else None,
             frozenset(disabled_toolsets) if disabled_toolsets else None,
             registry._generation,
             cfg_fp,
+            mcp_excludes_key,
         )
         cached = _tool_defs_cache.get(cache_key)
         if cached is not None:
@@ -310,7 +325,7 @@ def get_tool_definitions(
             # schemas are treated as read-only by all known callers.
             return list(cached)
 
-    result = _compute_tool_definitions(enabled_toolsets, disabled_toolsets, quiet_mode)
+    result = _compute_tool_definitions(enabled_toolsets, disabled_toolsets, quiet_mode, mcp_excludes)
     if quiet_mode:
         # Cache the freshly-computed list, but hand callers a shallow copy so
         # downstream mutations (e.g. run_agent appending memory/LCM tool
@@ -328,6 +343,7 @@ def _compute_tool_definitions(
     enabled_toolsets: List[str] = None,
     disabled_toolsets: List[str] = None,
     quiet_mode: bool = False,
+    mcp_excludes: Dict[str, set] = None,
 ) -> List[Dict[str, Any]]:
     """Uncached implementation of :func:`get_tool_definitions`."""
     # Determine which tool names the caller wants
@@ -371,6 +387,40 @@ def _compute_tool_definitions(
                     print(f"🚫 Disabled legacy toolset '{toolset_name}': {', '.join(legacy_tools)}")
             elif not quiet_mode:
                 print(f"⚠️  Unknown toolset: {toolset_name}")
+
+    # Apply per-platform MCP tool exclusions. Toolset resolution above works
+    # at the server level (the ``mcp-<server>`` alias resolves to ALL of a
+    # server's tools), so individual-tool and wildcard exclusions can't be
+    # expressed as toolset names — they must be subtracted here, by mapping
+    # each candidate MCP tool back to its (server, raw_tool_name) origin.
+    # The global ``mcp_servers.<name>.tools.exclude`` list is already honored
+    # at MCP registration time; this step layers the platform-scoped excludes
+    # (``platform_mcp_excludes``) on top so e.g. cron jobs can drop a heavy
+    # server that cli keeps. ``"*"`` in a server's set excludes every tool.
+    if mcp_excludes:
+        try:
+            from tools.mcp_tool import get_mcp_tool_origin
+        except Exception:
+            get_mcp_tool_origin = None
+        if get_mcp_tool_origin is not None:
+            excluded_mcp_tools = set()
+            for tool_name in tools_to_include:
+                origin = get_mcp_tool_origin(tool_name)
+                if origin is None:
+                    continue
+                server_name, raw_tool_name = origin
+                server_excludes = mcp_excludes.get(server_name)
+                if not server_excludes:
+                    continue
+                if "*" in server_excludes or raw_tool_name in server_excludes:
+                    excluded_mcp_tools.add(tool_name)
+            if excluded_mcp_tools:
+                tools_to_include.difference_update(excluded_mcp_tools)
+                if not quiet_mode:
+                    print(
+                        f"🚫 Excluded {len(excluded_mcp_tools)} MCP tool(s) "
+                        f"by platform scope: {', '.join(sorted(excluded_mcp_tools))}"
+                    )
 
     # Plugin-registered tools are now resolved through the normal toolset
     # path — validate_toolset() / resolve_toolset() / get_all_toolsets()

--- a/tests/hermes_cli/test_tools_disable_enable.py
+++ b/tests/hermes_cli/test_tools_disable_enable.py
@@ -2,7 +2,7 @@
 from argparse import Namespace
 from unittest.mock import patch
 
-from hermes_cli.tools_config import tools_disable_enable_command
+from hermes_cli.tools_config import resolve_mcp_excludes, tools_disable_enable_command
 
 
 # ── Built-in toolset disable ────────────────────────────────────────────────
@@ -113,6 +113,109 @@ class TestToolsEnableMcp:
         assert "delete_branch" in saved["mcp_servers"]["github"]["tools"]["exclude"]
 
 
+# ── Platform-scoped MCP tool disable (--platform <non-cli>) ──────────────────
+
+
+class TestToolsDisableMcpPlatformScoped:
+    """Bug 1: `hermes tools disable --platform cron openbb:*` must write a
+    platform-scoped exclusion, NOT a global one."""
+
+    def test_disable_with_platform_writes_scoped_not_global(self):
+        config = {"mcp_servers": {"openbb": {"command": "uvx"}}}
+        with patch("hermes_cli.tools_config.load_config", return_value=config), \
+             patch("hermes_cli.tools_config.save_config") as mock_save:
+            tools_disable_enable_command(
+                Namespace(tools_action="disable", names=["openbb:get_quote"], platform="cron")
+            )
+        saved = mock_save.call_args[0][0]
+        # Scoped exclusion written under platform_mcp_excludes.
+        assert saved["platform_mcp_excludes"]["cron"]["openbb"] == ["get_quote"]
+        # Global exclude list NOT touched.
+        assert "tools" not in saved["mcp_servers"]["openbb"] or \
+               not saved["mcp_servers"]["openbb"].get("tools", {}).get("exclude")
+
+    def test_disable_wildcard_with_platform_scoped(self):
+        config = {"mcp_servers": {"openbb": {"command": "uvx"}}}
+        with patch("hermes_cli.tools_config.load_config", return_value=config), \
+             patch("hermes_cli.tools_config.save_config") as mock_save:
+            tools_disable_enable_command(
+                Namespace(tools_action="disable", names=["openbb:*"], platform="cron")
+            )
+        saved = mock_save.call_args[0][0]
+        assert saved["platform_mcp_excludes"]["cron"]["openbb"] == ["*"]
+
+    def test_disable_default_platform_still_writes_global(self):
+        """Backward compat: no --platform (default cli) writes the GLOBAL list."""
+        config = {"mcp_servers": {"openbb": {"command": "uvx"}}}
+        with patch("hermes_cli.tools_config.load_config", return_value=config), \
+             patch("hermes_cli.tools_config.save_config") as mock_save:
+            tools_disable_enable_command(
+                Namespace(tools_action="disable", names=["openbb:get_quote"], platform="cli")
+            )
+        saved = mock_save.call_args[0][0]
+        assert "get_quote" in saved["mcp_servers"]["openbb"]["tools"]["exclude"]
+        assert "platform_mcp_excludes" not in saved
+
+    def test_disable_scoped_unknown_server_prints_error(self, capsys):
+        config = {"mcp_servers": {}}
+        with patch("hermes_cli.tools_config.load_config", return_value=config), \
+             patch("hermes_cli.tools_config.save_config"):
+            tools_disable_enable_command(
+                Namespace(tools_action="disable", names=["ghost:tool"], platform="cron")
+            )
+        out = capsys.readouterr().out
+        assert "MCP server 'ghost' not found in config" in out
+
+
+class TestToolsEnableMcpPlatformScoped:
+    """Inverse path: `hermes tools enable --platform cron` must remove a
+    platform-scoped exclusion."""
+
+    def test_enable_removes_scoped_exclusion(self):
+        config = {
+            "mcp_servers": {"openbb": {"command": "uvx"}},
+            "platform_mcp_excludes": {"cron": {"openbb": ["get_quote", "get_news"]}},
+        }
+        with patch("hermes_cli.tools_config.load_config", return_value=config), \
+             patch("hermes_cli.tools_config.save_config") as mock_save:
+            tools_disable_enable_command(
+                Namespace(tools_action="enable", names=["openbb:get_quote"], platform="cron")
+            )
+        saved = mock_save.call_args[0][0]
+        assert saved["platform_mcp_excludes"]["cron"]["openbb"] == ["get_news"]
+
+    def test_enable_last_scoped_exclusion_prunes_empty_containers(self):
+        config = {
+            "mcp_servers": {"openbb": {"command": "uvx"}},
+            "platform_mcp_excludes": {"cron": {"openbb": ["get_quote"]}},
+        }
+        with patch("hermes_cli.tools_config.load_config", return_value=config), \
+             patch("hermes_cli.tools_config.save_config") as mock_save:
+            tools_disable_enable_command(
+                Namespace(tools_action="enable", names=["openbb:get_quote"], platform="cron")
+            )
+        saved = mock_save.call_args[0][0]
+        # Empty leaves are pruned so the config fully reverts.
+        assert "platform_mcp_excludes" not in saved
+
+    def test_enable_scoped_leaves_other_platforms_untouched(self):
+        config = {
+            "mcp_servers": {"openbb": {"command": "uvx"}},
+            "platform_mcp_excludes": {
+                "cron": {"openbb": ["get_quote"]},
+                "telegram": {"openbb": ["get_quote"]},
+            },
+        }
+        with patch("hermes_cli.tools_config.load_config", return_value=config), \
+             patch("hermes_cli.tools_config.save_config") as mock_save:
+            tools_disable_enable_command(
+                Namespace(tools_action="enable", names=["openbb:get_quote"], platform="cron")
+            )
+        saved = mock_save.call_args[0][0]
+        assert "cron" not in saved["platform_mcp_excludes"]
+        assert saved["platform_mcp_excludes"]["telegram"]["openbb"] == ["get_quote"]
+
+
 # ── Mixed targets ────────────────────────────────────────────────────────────
 
 
@@ -174,6 +277,70 @@ class TestToolsList:
         out = capsys.readouterr().out
         assert "github" in out
         assert "create_issue" in out
+
+    def test_list_shows_platform_scoped_mcp_excludes(self, capsys):
+        """Bug 3: `hermes tools list --platform cron` must reflect the
+        platform-scoped exclusion, not just the global config."""
+        config = {
+            "mcp_servers": {"openbb": {"command": "uvx"}},
+            "platform_mcp_excludes": {"cron": {"openbb": ["get_quote"]}},
+        }
+        with patch("hermes_cli.tools_config.load_config", return_value=config):
+            tools_disable_enable_command(Namespace(tools_action="list", platform="cron"))
+        out = capsys.readouterr().out
+        assert "openbb" in out
+        assert "cron-only excluded" in out
+        assert "get_quote" in out
+
+    def test_list_cli_does_not_show_other_platform_scoped_excludes(self, capsys):
+        config = {
+            "mcp_servers": {"openbb": {"command": "uvx"}},
+            "platform_mcp_excludes": {"cron": {"openbb": ["get_quote"]}},
+        }
+        with patch("hermes_cli.tools_config.load_config", return_value=config):
+            tools_disable_enable_command(Namespace(tools_action="list", platform="cli"))
+        out = capsys.readouterr().out
+        assert "cron-only excluded" not in out
+
+
+# ── resolve_mcp_excludes (runtime resolver helper) ──────────────────────────
+
+
+class TestResolveMcpExcludes:
+
+    def test_global_exclude_applies_to_all_platforms(self):
+        config = {"mcp_servers": {"openbb": {"tools": {"exclude": ["get_quote"]}}}}
+        for platform in ("cli", "cron", "telegram"):
+            resolved = resolve_mcp_excludes(config, platform)
+            assert resolved == {"openbb": {"get_quote"}}
+
+    def test_scoped_exclude_applies_only_to_named_platform(self):
+        config = {
+            "mcp_servers": {"openbb": {"command": "uvx"}},
+            "platform_mcp_excludes": {"cron": {"openbb": ["get_quote"]}},
+        }
+        assert resolve_mcp_excludes(config, "cron") == {"openbb": {"get_quote"}}
+        assert resolve_mcp_excludes(config, "cli") == {}
+
+    def test_global_and_scoped_are_unioned(self):
+        config = {
+            "mcp_servers": {"openbb": {"tools": {"exclude": ["get_news"]}}},
+            "platform_mcp_excludes": {"cron": {"openbb": ["get_quote"]}},
+        }
+        assert resolve_mcp_excludes(config, "cron") == {"openbb": {"get_news", "get_quote"}}
+        # cli still sees only the global exclude.
+        assert resolve_mcp_excludes(config, "cli") == {"openbb": {"get_news"}}
+
+    def test_wildcard_preserved(self):
+        config = {"platform_mcp_excludes": {"cron": {"openbb": ["*"]}}}
+        assert resolve_mcp_excludes(config, "cron") == {"openbb": {"*"}}
+
+    def test_empty_config_returns_empty(self):
+        assert resolve_mcp_excludes({}, "cron") == {}
+
+    def test_string_exclude_value_normalized_to_set(self):
+        config = {"mcp_servers": {"openbb": {"tools": {"exclude": "get_quote"}}}}
+        assert resolve_mcp_excludes(config, "cli") == {"openbb": {"get_quote"}}
 
 
 # ── Validation ───────────────────────────────────────────────────────────────

--- a/tests/tools/test_mcp_platform_exclude.py
+++ b/tests/tools/test_mcp_platform_exclude.py
@@ -1,0 +1,179 @@
+"""Tests for per-platform MCP tool exclusion at runtime.
+
+Covers the read-path half of the fix: ``get_tool_definitions`` must drop MCP
+tools that a platform has scoped out via ``mcp_excludes`` (resolved from
+``platform_mcp_excludes`` in config), while keeping them for platforms that
+have not. The write-path half is covered in
+``tests/hermes_cli/test_tools_disable_enable.py``.
+
+All tests use mocks -- no real MCP servers or subprocesses are started.
+"""
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+import model_tools
+from tools.registry import ToolRegistry
+from tools.mcp_tool import (
+    _discover_and_register_server,
+    _mcp_tool_origins,
+    _servers,
+    get_mcp_tool_origin,
+)
+
+
+def _make_mcp_tool(name):
+    """Create a fake MCP Tool object matching the SDK interface."""
+    return SimpleNamespace(
+        name=name,
+        description=name,
+        inputSchema={"type": "object", "properties": {}},
+    )
+
+
+@pytest.fixture
+def mcp_env():
+    """Register fake MCP servers, exposing a builder, and tear them down.
+
+    Server names are unique per test instance so concurrent xdist workers
+    never collide on the module-global ``_servers`` / ``_mcp_tool_origins``.
+    """
+    registry = ToolRegistry()
+    spawned = []  # (server_name, [registered_tool_names])
+
+    def register(server_name, tool_names):
+        server_tools = [_make_mcp_tool(n) for n in tool_names]
+
+        async def fake_connect(_name, _config):
+            from tools.mcp_tool import MCPServerTask
+            server = MCPServerTask(_name)
+            server.session = SimpleNamespace()
+            server._tools = server_tools
+            return server
+
+        async def run():
+            with patch("tools.mcp_tool._connect_server", side_effect=fake_connect), \
+                 patch("tools.registry.registry", registry):
+                return await _discover_and_register_server(server_name, {"url": "https://x"})
+
+        registered = asyncio.run(run())
+        spawned.append((server_name, registered))
+        return registered
+
+    def tool_names(enabled_toolsets, mcp_excludes=None, clear_cache=True):
+        if clear_cache:
+            model_tools._tool_defs_cache.clear()
+        with patch("model_tools.registry", registry), \
+             patch("tools.registry.registry", registry):
+            defs = model_tools.get_tool_definitions(
+                enabled_toolsets=enabled_toolsets,
+                quiet_mode=True,
+                mcp_excludes=mcp_excludes,
+            )
+        return {d["function"]["name"] for d in defs}
+
+    env = SimpleNamespace(registry=registry, register=register, tool_names=tool_names)
+    try:
+        yield env
+    finally:
+        model_tools._tool_defs_cache.clear()
+        for server_name, registered in spawned:
+            _servers.pop(server_name, None)
+            for n in registered:
+                _mcp_tool_origins.pop(n, None)
+
+
+class TestMcpToolOriginTracking:
+    """Registration must record the (server, raw_tool_name) provenance the
+    runtime resolver needs for ``server:tool`` matching."""
+
+    def test_origin_captured_on_registration(self, mcp_env):
+        mcp_env.register("originsrv", ["get_quote", "get_news"])
+        assert get_mcp_tool_origin("mcp_originsrv_get_quote") == ("originsrv", "get_quote")
+        assert get_mcp_tool_origin("mcp_originsrv_get_news") == ("originsrv", "get_news")
+
+    def test_origin_none_for_unknown_tool(self):
+        assert get_mcp_tool_origin("totally_not_a_tool") is None
+
+
+class TestRuntimeMcpExclusion:
+    """get_tool_definitions must honor the resolved mcp_excludes map."""
+
+    def test_no_excludes_keeps_all_mcp_tools(self, mcp_env):
+        mcp_env.register("noex", ["get_quote", "get_news"])
+        names = mcp_env.tool_names(["noex"], mcp_excludes=None)
+        assert "mcp_noex_get_quote" in names
+        assert "mcp_noex_get_news" in names
+
+    def test_scoped_exclude_drops_only_listed_tool(self, mcp_env):
+        mcp_env.register("scopedex", ["get_quote", "get_news"])
+        names = mcp_env.tool_names(["scopedex"], mcp_excludes={"scopedex": {"get_quote"}})
+        assert "mcp_scopedex_get_quote" not in names
+        assert "mcp_scopedex_get_news" in names
+
+    def test_wildcard_exclude_drops_entire_server(self, mcp_env):
+        mcp_env.register("wildex", ["get_quote", "get_news", "get_chart"])
+        names = mcp_env.tool_names(["wildex"], mcp_excludes={"wildex": {"*"}})
+        assert not any(n.startswith("mcp_wildex_") for n in names)
+
+    def test_exclude_for_one_server_leaves_others_intact(self, mcp_env):
+        mcp_env.register("exca", ["get_quote"])
+        mcp_env.register("excb", ["place_order"])
+        names = mcp_env.tool_names(["exca", "excb"], mcp_excludes={"exca": {"*"}})
+        assert "mcp_exca_get_quote" not in names
+        assert "mcp_excb_place_order" in names
+
+    def test_cron_excludes_server_but_cli_keeps_it(self, mcp_env):
+        """End-to-end of the production fix: a server scoped out of cron is
+        absent for cron but present for cli."""
+        from hermes_cli.tools_config import resolve_mcp_excludes
+
+        config = {
+            "mcp_servers": {"croncli": {"url": "https://x"}},
+            "platform_mcp_excludes": {"cron": {"croncli": ["*"]}},
+        }
+        mcp_env.register("croncli", ["get_quote", "get_news"])
+        cron_names = mcp_env.tool_names(
+            ["croncli"], mcp_excludes=resolve_mcp_excludes(config, "cron")
+        )
+        cli_names = mcp_env.tool_names(
+            ["croncli"], mcp_excludes=resolve_mcp_excludes(config, "cli")
+        )
+        assert not any(n.startswith("mcp_croncli_") for n in cron_names)
+        assert "mcp_croncli_get_quote" in cli_names
+        assert "mcp_croncli_get_news" in cli_names
+
+    def test_global_exclude_applies_to_every_platform(self, mcp_env):
+        """Backward compat: a global mcp_servers.<name>.tools.exclude resolves
+        for all platforms (cron AND cli)."""
+        from hermes_cli.tools_config import resolve_mcp_excludes
+
+        config = {
+            "mcp_servers": {
+                "globex": {"url": "https://x", "tools": {"exclude": ["get_quote"]}}
+            },
+        }
+        mcp_env.register("globex", ["get_quote", "get_news"])
+        for platform in ("cron", "cli", "telegram"):
+            names = mcp_env.tool_names(
+                ["globex"], mcp_excludes=resolve_mcp_excludes(config, platform)
+            )
+            assert "mcp_globex_get_quote" not in names, platform
+            assert "mcp_globex_get_news" in names, platform
+
+    def test_cache_key_distinguishes_excludes(self, mcp_env):
+        """The quiet_mode memo must key on mcp_excludes — without it, a cron
+        call would get a stale cli result cached under the same key."""
+        mcp_env.register("cachekey", ["get_quote"])
+        model_tools._tool_defs_cache.clear()
+        # First call (no excludes) populates the cache.
+        cli_names = mcp_env.tool_names(["cachekey"], mcp_excludes=None, clear_cache=False)
+        # Second call with a different exclude map must NOT hit the cli entry.
+        cron_names = mcp_env.tool_names(
+            ["cachekey"], mcp_excludes={"cachekey": {"*"}}, clear_cache=False
+        )
+        assert "mcp_cachekey_get_quote" in cli_names
+        assert "mcp_cachekey_get_quote" not in cron_names

--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -3279,6 +3279,23 @@ class TestMCPSelectiveToolLoading:
             "mcp_ink_exclude_list_services",
         ]
 
+    def test_exclude_wildcard_registers_no_tools(self):
+        """Bug 2: a global ``exclude: ['*']`` must drop EVERY tool from the
+        server — previously the literal-match filter only excluded a tool
+        actually named ``*``, so all tools survived."""
+        config = {
+            "url": "https://mcp.example.com",
+            "tools": {"exclude": ["*"]},
+        }
+        registered, mock_registry = self._run_discover(
+            "ink_wild",
+            ["create_service", "delete_service", "list_services"],
+            config,
+            session=SimpleNamespace(),
+        )
+        assert registered == []
+        assert mock_registry.get_all_tool_names() == []
+
     def test_include_filter_skips_utility_tools_without_capabilities(self):
         config = {
             "url": "https://mcp.example.com",

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -2076,6 +2076,12 @@ _parallel_safe_servers: set = set()
 # guessing.
 _mcp_tool_server_names: Dict[str, str] = {}
 
+# Parallel map: prefixed tool name → (raw_server_name, raw_tool_name) as they
+# appear in config. Sanitization for the prefixed name is lossy, so platform-
+# scoped exclusion matching (``server:tool``) needs the un-sanitized strings
+# captured at registration time.
+_mcp_tool_origins: Dict[str, tuple] = {}
+
 # Dedicated event loop running in a background daemon thread.
 _mcp_loop: Optional[asyncio.AbstractEventLoop] = None
 _mcp_thread: Optional[threading.Thread] = None
@@ -2964,17 +2970,33 @@ _UTILITY_CAPABILITY_ATTRS = {
 }
 
 
-def _track_mcp_tool_server(tool_name: str, server_name: str) -> None:
-    """Remember the exact MCP server that registered *tool_name*."""
+def _track_mcp_tool_server(tool_name: str, server_name: str, raw_tool_name: str = "") -> None:
+    """Remember the exact MCP server that registered *tool_name*.
+
+    ``raw_tool_name`` is the un-sanitized tool name from the server (used for
+    platform-scoped ``server:tool`` exclusion matching). Defaults to empty for
+    callers that don't carry it (e.g. utility tools, whose names are stable).
+    """
     safe_server_name = sanitize_mcp_name_component(server_name)
     with _lock:
         _mcp_tool_server_names[tool_name] = safe_server_name
+        _mcp_tool_origins[tool_name] = (server_name, raw_tool_name)
 
 
 def _forget_mcp_tool_server(tool_name: str) -> None:
     """Forget MCP server provenance for a deregistered tool."""
     with _lock:
         _mcp_tool_server_names.pop(tool_name, None)
+        _mcp_tool_origins.pop(tool_name, None)
+
+
+def get_mcp_tool_origin(tool_name: str) -> Optional[tuple]:
+    """Return ``(raw_server_name, raw_tool_name)`` for a registered MCP tool.
+
+    Returns None for non-MCP tools or tools whose provenance was not tracked.
+    """
+    with _lock:
+        return _mcp_tool_origins.get(tool_name)
 
 
 def _select_utility_schemas(server_name: str, server: MCPServerTask, config: dict) -> List[dict]:
@@ -3078,6 +3100,10 @@ def _register_server_tools(name: str, server: MCPServerTask, config: dict) -> Li
         if include_set:
             return tool_name in include_set
         if exclude_set:
+            # ``*`` is a wildcard meaning "exclude every tool from this
+            # server" — used by ``hermes tools disable <server>:*``.
+            if "*" in exclude_set:
+                return False
             return tool_name not in exclude_set
         return True
 
@@ -3111,7 +3137,7 @@ def _register_server_tools(name: str, server: MCPServerTask, config: dict) -> Li
             is_async=False,
             description=schema["description"],
         )
-        _track_mcp_tool_server(tool_name_prefixed, name)
+        _track_mcp_tool_server(tool_name_prefixed, name, raw_tool_name=mcp_tool.name)
         registered_names.append(tool_name_prefixed)
 
     # Register MCP Resources & Prompts utility tools, filtered by config and

--- a/website/docs/user-guide/features/mcp.md
+++ b/website/docs/user-guide/features/mcp.md
@@ -207,7 +207,54 @@ mcp_servers:
       exclude: [delete_customer]
 ```
 
-All server tools are registered except the excluded ones.
+All server tools are registered except the excluded ones. Use `exclude: ['*']`
+to exclude **every** tool from a server while keeping it connected.
+
+This `exclude` list is **global** — it applies to every platform (cli,
+telegram, cron, etc.). To exclude a server's tools from only some platforms,
+see [Per-platform tool exclusions](#per-platform-tool-exclusions) below.
+
+### Per-platform tool exclusions
+
+Heavy MCP servers (e.g. OpenBB's ~189 tools, Alpaca's ~66) can balloon the
+tool schema sent on every LLM call. That's usually fine for interactive use,
+but it can overflow the context window of scheduled **cron** jobs that don't
+need those tools — failing the run before it starts.
+
+Use `hermes tools disable --platform <platform>` to exclude MCP tools for a
+specific platform only:
+
+```bash
+# Drop ALL OpenBB tools from cron jobs — but keep them for cli/telegram
+hermes tools disable --platform cron openbb:*
+
+# Drop a single tool from cron
+hermes tools disable --platform cron alpaca:place_order
+
+# Re-enable (removes the platform-scoped exclusion)
+hermes tools enable --platform cron openbb:*
+```
+
+Platform-scoped exclusions are stored under `platform_mcp_excludes` in
+`~/.hermes/config.yaml`, keyed by platform then by server:
+
+```yaml
+platform_mcp_excludes:
+  cron:
+    openbb: ['*']            # exclude every OpenBB tool from cron
+    alpaca: [place_order]    # exclude one Alpaca tool from cron
+```
+
+Without `--platform` (or with the default `--platform cli`), `hermes tools
+disable <server>:<tool>` writes to the **global** `mcp_servers.<name>.tools.exclude`
+list instead — applying to every platform, as before.
+
+**Precedence:** a tool is excluded for a platform if **either** the global
+`exclude` list **or** that platform's `platform_mcp_excludes` entry matches it.
+The `*` wildcard works in both.
+
+`hermes tools list --platform cron` shows both the global and the
+cron-specific exclusions so you can see exactly what each platform receives.
 
 ### Precedence rule
 

--- a/website/docs/user-guide/features/tools.md
+++ b/website/docs/user-guide/features/tools.md
@@ -47,11 +47,18 @@ hermes tools
 
 # Configure tools per platform (interactive)
 hermes tools
+
+# Disable / enable toolsets or MCP tools for a specific platform
+hermes tools disable --platform cron openbb:*
+hermes tools enable  --platform cron openbb:*
+hermes tools list    --platform cron
 ```
 
 Common toolsets include `web`, `search`, `terminal`, `file`, `browser`, `vision`, `image_gen`, `moa`, `skills`, `tts`, `todo`, `memory`, `session_search`, `cronjob`, `code_execution`, `delegation`, `clarify`, `homeassistant`, `messaging`, `spotify`, `discord`, `discord_admin`, `debugging`, `safe`, and `rl`.
 
 See [Toolsets Reference](/docs/reference/toolsets-reference) for the full set, including platform presets such as `hermes-cli`, `hermes-telegram`, and dynamic MCP toolsets like `mcp-<server>`.
+
+`hermes tools disable --platform <platform> <server>:<tool>` scopes an MCP tool exclusion to one platform — for example, dropping a heavy MCP server from cron jobs while keeping it for interactive use. See [MCP → Per-platform tool exclusions](mcp.md#per-platform-tool-exclusions).
 
 ## Terminal Backends
 


### PR DESCRIPTION
## Summary

`hermes tools disable --platform <platform> <server>:<tool>` is documented to scope MCP tool exclusions per platform, but it didn't work for MCP servers. This PR fixes two distinct bugs and adds the missing per-platform storage.

### The bugs

**Bug 1 — write path ignores `--platform`.** `tools_disable_enable_command` captured `platform` and passed it to `_apply_toolset_change` for built-in toolsets, but for MCP targets it called `_apply_mcp_change(config, targets, action)` — which had no `platform` parameter and always wrote a **global** exclusion to `mcp_servers.<server>.tools.exclude`. So `hermes tools disable --platform cron openbb:*` silently behaved identically to a global disable; the `--platform cron` scope was dropped.

**Bug 2 — read path ignores the exclusion at runtime.** Two sub-issues:
- `_should_register` in `tools/mcp_tool.py` did literal tool-name matching only — it had **no `*` wildcard support**, so a global `exclude: ['*']` excluded nothing (it only matched a tool literally named `*`).
- MCP tools are registered into a single global registry (`mcp-<server>` toolset alias) once at gateway startup, with **no platform awareness**. The per-platform tool resolver (`_get_platform_tools` → `get_tool_definitions`) works at the toolset-name level, so it could never express or apply an individual-tool / per-platform MCP exclusion.

### The production incident

After OpenBB (189 tools) and Alpaca (66 tools) MCP servers were added, the serialized `tools:` array ballooned to ~561 KB. Scheduled **cron** jobs — which don't need those tools — started failing with `RuntimeError: Context length exceeded: max compression attempts (3) reached`: the tool schema alone overflowed the model's context window. There was no working way to exclude the heavy servers from cron while keeping them for interactive use.

## Fix design

- **New config key `platform_mcp_excludes`** — a top-level `{platform: {server: [tool|"*"]}}` map, mirroring the existing top-level `platform_toolsets` map. Chosen over nesting MCP tool lists inside `platform_toolsets` (whose schema is a flat list of toolset names) so each structure stays single-purpose and consistent with the established schema convention.
- **`_apply_mcp_change` now takes a `platform` arg.** Default `cli` (or no `--platform`) keeps writing the **global** `mcp_servers.<name>.tools.exclude` list — preserving the long-standing global-exclude feature for backward compatibility. Any other platform writes to `platform_mcp_excludes`. The `enable` (inverse) path prunes empty leaves so a config fully reverts.
- **`resolve_mcp_excludes(config, platform)`** unions the global exclude list and the platform-scoped map into `{server: {tool|"*"}}`. Precedence: a tool is excluded for a platform if **either** source matches.
- **Runtime read path** — `get_tool_definitions` / `_compute_tool_definitions` accept an `mcp_excludes` map and subtract matching MCP tools, mapping each tool back to its `(server, raw_tool_name)` origin (now tracked at registration via `_mcp_tool_origins` + `get_mcp_tool_origin`). The quiet-mode memo cache key includes the exclude map. The map is resolved in `init_agent` — the single chokepoint where the runtime platform and config are both cleanly available (cli, gateway background tasks, and cron all construct the agent through it).
- **`_should_register`** now honors `*`, so a global `exclude: ['*']` correctly drops every tool from a server.
- **`hermes tools list --platform <p>`** now reflects platform-scoped exclusions, not just the global config.

This lets operators keep heavy MCP servers (OpenBB, Alpaca, etc.) available for interactive cli/telegram use while excluding them from cron jobs that don't need them — e.g. `hermes tools disable --platform cron openbb:*`.

## Test coverage

25 new tests:
- `_apply_mcp_change` — global vs platform-scoped writes; wildcard; default-platform backward compat; scoped `enable` (inverse) removes exclusions and prunes empty containers; other platforms left untouched.
- `resolve_mcp_excludes` — global applies to all platforms; scoped applies only to its platform; global+scoped unioned; wildcard preserved; string-value normalization.
- Runtime resolver (`get_tool_definitions` + `mcp_excludes`) — a server excluded for `cron` is absent from the cron tool list but present for `cli`; per-tool and wildcard exclusion; one server's exclusion doesn't affect another; global exclude applies to every platform; cache key distinguishes exclude maps.
- `_should_register` wildcard — global `exclude: ['*']` registers zero tools.
- `_print_tools_list` — `--platform cron` shows scoped exclusions; `--platform cli` doesn't show other platforms' scoped exclusions.

All 495 tests across the affected suites (`test_mcp_tool`, `test_mcp_platform_exclude`, `test_tools_disable_enable`, `test_tools_config`, `test_model_tools`, `test_toolsets`, `test_cli_tools_command`, `test_get_tool_definitions_cache_isolation`, `test_scheduler`) pass. The handful of unrelated failures in `tests/agent/` (anthropic token resolution, local stream timeouts) are pre-existing and environmental — verified by re-running them on the base commit.

## Test plan

- [ ] `hermes tools disable --platform cron openbb:*` writes `platform_mcp_excludes`, leaves the global `mcp_servers.openbb.tools.exclude` untouched.
- [ ] `hermes tools disable openbb:get_quote` (no `--platform`) still writes the global exclude list.
- [ ] A cron job no longer receives a server scoped out for `cron`, while a cli session still does.
- [ ] A global `mcp_servers.<name>.tools.exclude` (incl. `['*']`) still applies to every platform.
- [ ] `hermes tools enable --platform cron openbb:*` removes the platform-scoped exclusion.
- [ ] `hermes tools list --platform cron` shows the scoped exclusion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)