### PR TITLE
fix(gateway/slack): enforce allow_from restrictions on block kit interactive callbacks

### DIFF
--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -349,6 +349,31 @@ class SlackAdapter(BasePlatformAdapter):
         # Each value: {"response_url": str, "ts": float}
         self._slash_command_contexts: Dict[Tuple[str, str], Dict[str, Any]] = {}
 
+    @staticmethod
+    def _coerce_user_allowlist(raw: Any) -> set:
+        """Normalize Slack user allowlist config/env values."""
+        if raw is None:
+            return set()
+        if isinstance(raw, (list, tuple, set, frozenset)):
+            items = raw
+        else:
+            items = str(raw).split(",")
+        return {str(uid).strip() for uid in items if str(uid).strip()}
+
+    def _is_interactive_user_authorized(self, user_id: str) -> bool:
+        """Return whether a Slack interactive button caller is allowed."""
+        normalized_user_id = str(user_id or "").strip()
+        allowed_ids = self._coerce_user_allowlist(
+            os.getenv("SLACK_ALLOWED_USERS", "").strip()
+        )
+        if not allowed_ids:
+            allowed_ids = self._coerce_user_allowlist(
+                getattr(self.config, "extra", {}).get("allow_from")
+            )
+        if not allowed_ids:
+            return True
+        return "*" in allowed_ids or normalized_user_id in allowed_ids
+
     def _describe_slack_api_error(self, response: Any, *, file_obj: Optional[Dict[str, Any]] = None) -> Optional[str]:
         """Convert Slack API auth/permission failures into actionable user-facing text."""
         if response is None or not hasattr(response, "get"):
@@ -2396,15 +2421,12 @@ class SlackAdapter(BasePlatformAdapter):
         user_id = body.get("user", {}).get("id", "")
 
         # Authorization — reuse the exec-approval allowlist.
-        allowed_csv = os.getenv("SLACK_ALLOWED_USERS", "").strip()
-        if allowed_csv:
-            allowed_ids = {uid.strip() for uid in allowed_csv.split(",") if uid.strip()}
-            if "*" not in allowed_ids and user_id not in allowed_ids:
-                logger.warning(
-                    "[Slack] Unauthorized slash-confirm click by %s (%s) — ignoring",
-                    user_name, user_id,
-                )
-                return
+        if not self._is_interactive_user_authorized(user_id):
+            logger.warning(
+                "[Slack] Unauthorized slash-confirm click by %s (%s) - ignoring",
+                user_name, user_id,
+            )
+            return
 
         # Parse session_key|confirm_id back out
         if "|" not in value:
@@ -2496,15 +2518,12 @@ class SlackAdapter(BasePlatformAdapter):
         # Only authorized users may click approval buttons.  Button clicks
         # bypass the normal message auth flow in gateway/run.py, so we must
         # check here as well.
-        allowed_csv = os.getenv("SLACK_ALLOWED_USERS", "").strip()
-        if allowed_csv:
-            allowed_ids = {uid.strip() for uid in allowed_csv.split(",") if uid.strip()}
-            if "*" not in allowed_ids and user_id not in allowed_ids:
-                logger.warning(
-                    "[Slack] Unauthorized approval click by %s (%s) — ignoring",
-                    user_name, user_id,
-                )
-                return
+        if not self._is_interactive_user_authorized(user_id):
+            logger.warning(
+                "[Slack] Unauthorized approval click by %s (%s) - ignoring",
+                user_name, user_id,
+            )
+            return
 
         # Map action_id to approval choice
         choice_map = {

--- a/tests/gateway/test_slack_approval_buttons.py
+++ b/tests/gateway/test_slack_approval_buttons.py
@@ -236,6 +236,83 @@ class TestSlackApprovalAction:
         update_kwargs = mock_client.chat_update.call_args[1]
         assert "Denied by alice" in update_kwargs["text"]
 
+    @pytest.mark.asyncio
+    async def test_approval_action_honors_config_allow_from(self):
+        adapter = _make_adapter()
+        adapter.config.extra["allow_from"] = ["U_ALLOWED"]
+        adapter._approval_resolved["2.3"] = False
+
+        ack = AsyncMock()
+        body = {
+            "message": {"ts": "2.3", "blocks": []},
+            "channel": {"id": "C1"},
+            "user": {"id": "U_DENIED", "name": "mallory"},
+        }
+        action = {"action_id": "hermes_approve_once", "value": "session-key"}
+
+        mock_client = adapter._team_clients["T1"]
+        mock_client.chat_update = AsyncMock()
+
+        with patch.dict(os.environ, {"SLACK_ALLOWED_USERS": ""}), \
+             patch("tools.approval.resolve_gateway_approval") as mock_resolve:
+            await adapter._handle_approval_action(ack, body, action)
+
+        ack.assert_called_once()
+        mock_resolve.assert_not_called()
+        mock_client.chat_update.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_approval_action_allows_config_allow_from_user(self):
+        adapter = _make_adapter()
+        adapter.config.extra["allow_from"] = ["U_ALLOWED"]
+        adapter._approval_resolved["2.4"] = False
+
+        ack = AsyncMock()
+        body = {
+            "message": {"ts": "2.4", "blocks": []},
+            "channel": {"id": "C1"},
+            "user": {"id": "U_ALLOWED", "name": "alice"},
+        }
+        action = {"action_id": "hermes_approve_once", "value": "session-key"}
+
+        mock_client = adapter._team_clients["T1"]
+        mock_client.chat_update = AsyncMock()
+
+        with patch.dict(os.environ, {"SLACK_ALLOWED_USERS": ""}), \
+             patch("tools.approval.resolve_gateway_approval", return_value=1) as mock_resolve:
+            await adapter._handle_approval_action(ack, body, action)
+
+        mock_resolve.assert_called_once_with("session-key", "once")
+        mock_client.chat_update.assert_called_once()
+
+
+class TestSlackSlashConfirmAction:
+    """Test slash-confirm Block Kit authorization."""
+
+    @pytest.mark.asyncio
+    async def test_slash_confirm_action_honors_config_allow_from(self):
+        adapter = _make_adapter()
+        adapter.config.extra["allow_from"] = ["U_ALLOWED"]
+
+        ack = AsyncMock()
+        body = {
+            "message": {"ts": "3.4", "blocks": []},
+            "channel": {"id": "C1"},
+            "user": {"id": "U_DENIED", "name": "mallory"},
+        }
+        action = {"action_id": "hermes_confirm_once", "value": "session-key|confirm-id"}
+
+        mock_client = adapter._team_clients["T1"]
+        mock_client.chat_update = AsyncMock()
+
+        with patch.dict(os.environ, {"SLACK_ALLOWED_USERS": ""}), \
+             patch("tools.slash_confirm.resolve", new_callable=AsyncMock) as mock_resolve:
+            await adapter._handle_slash_confirm_action(ack, body, action)
+
+        ack.assert_called_once()
+        mock_resolve.assert_not_called()
+        mock_client.chat_update.assert_not_called()
+
 
 # ===========================================================================
 # _fetch_thread_context


### PR DESCRIPTION
## Summary

This PR hardens Slack Block Kit interactive callback authorization for approval and slash-confirm buttons.

Previously, these callback paths only checked `SLACK_ALLOWED_USERS`. Deployments using Slack adapter config such as `extra.allow_from` for normal inbound authorization could have approval/slash-confirm button clicks ignore that configured allowlist when `SLACK_ALLOWED_USERS` was unset.

This change adds a shared Slack interactive authorization helper that:

- preserves `SLACK_ALLOWED_USERS` precedence and wildcard support
- falls back to `config.extra["allow_from"]` when the env allowlist is unset
- preserves existing permissive behavior when no allowlist is configured

## Why

Slack button callbacks bypass the normal gateway message authorization flow, so they need to enforce the same configured user allowlist locally. This keeps approval and slash-confirm actions aligned with the adapter’s existing auth configuration.

## Tests

```bash
scripts/run_tests.sh tests/gateway/test_slack_approval_buttons.py -q
```

Result: passed, exit code `0`.

`git diff --check` also passed. 