### PR TITLE
fix(test): clean HERMES_CRON_SESSION in approval isolation test

### DIFF
--- a/tests/acp/test_approval_isolation.py
+++ b/tests/acp/test_approval_isolation.py
@@ -213,6 +213,7 @@ class TestAcpExecAskGate:
         monkeypatch.delenv("HERMES_GATEWAY_SESSION", raising=False)
         monkeypatch.delenv("HERMES_EXEC_ASK", raising=False)
         monkeypatch.delenv("HERMES_YOLO_MODE", raising=False)
+        monkeypatch.delenv("HERMES_CRON_SESSION", raising=False)
 
         from tools.approval import check_all_command_guards
 


### PR DESCRIPTION
## Summary

The `test_interactive_env_var_routes_to_callback` test in `tests/acp/test_approval_isolation.py` fails when `HERMES_CRON_SESSION=1` is set in the parent process environment (e.g., during cron runs or cron-spawned sessions).

## Root Cause

The test cleans up `HERMES_INTERACTIVE`, `HERMES_GATEWAY_SESSION`, `HERMES_EXEC_ASK`, and `HERMES_YOLO_MODE` but not `HERMES_CRON_SESSION`. When the parent process has `HERMES_CRON_SESSION=1`:

1. The command `rm -rf /tmp/test-exec-ask` is flagged as dangerous ("delete in root path")
2. The cron deny mode in `tools/approval.py` (line 1090-1104) blocks the command
3. The test expects `approved=True` but gets `approved=False`

## Fix

Add `monkeypatch.delenv("HERMES_CRON_SESSION", raising=False)` to the test's environment cleanup.

## Testing

- `pytest tests/acp/test_approval_isolation.py -v` passes (all 7 tests)
- Verified the test fails without the fix when `HERMES_CRON_SESSION=1`

Closes #29625