### PR TITLE
fix: fail closed for webhook routes without secrets

### DIFF
--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -351,9 +351,21 @@ class WebhookAdapter(BasePlatformAdapter):
             logger.error("[webhook] Failed to read body: %s", e)
             return web.json_response({"error": "Bad request"}, status=400)
 
-        # Validate HMAC signature FIRST (skip for INSECURE_NO_AUTH testing mode)
+        # Validate HMAC signature FIRST (skip only for the explicit local-test
+        # INSECURE_NO_AUTH mode). Missing/empty secrets must fail closed here,
+        # not only during connect(), so direct handler reuse cannot turn a
+        # network webhook route into an unauthenticated agent-dispatch surface.
         secret = route_config.get("secret", self._global_secret)
-        if secret and secret != _INSECURE_NO_AUTH:
+        if not secret:
+            logger.error(
+                "[webhook] Route %s has no HMAC secret; refusing request",
+                route_name,
+            )
+            return web.json_response(
+                {"error": "Webhook route is missing an HMAC secret"},
+                status=500,
+            )
+        if secret != _INSECURE_NO_AUTH:
             if not self._validate_signature(request, raw_body, secret):
                 logger.warning(
                     "[webhook] Invalid signature for route %s", route_name

--- a/tests/gateway/test_webhook_adapter.py
+++ b/tests/gateway/test_webhook_adapter.py
@@ -337,6 +337,22 @@ class TestHTTPHandling:
             assert data["route"] == "test"
 
     @pytest.mark.asyncio
+    async def test_route_without_secret_rejects_unsigned_request(self):
+        """Missing HMAC secret must fail closed even if connect() was bypassed."""
+        routes = {"test": {"prompt": "hi"}}
+        adapter = _make_adapter(routes=routes, secret="")
+        adapter.handle_message = AsyncMock()
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post("/webhooks/test", json={"data": "value"})
+            assert resp.status == 500
+            data = await resp.json()
+            assert data["error"] == "Webhook route is missing an HMAC secret"
+
+        adapter.handle_message.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_health_endpoint(self):
         """GET /health returns 200 with status=ok."""
         adapter = _make_adapter()


### PR DESCRIPTION
Security hardening patch prepared for private advisory GHSA-27g9-x3x6-4m35.

Summary:
- Fails closed in the webhook request handler when a route has no effective HMAC secret.
- Keeps INSECURE_NO_AUTH as the explicit testing bypass.
- Adds regression coverage that direct handler access with a no-secret route rejects and does not dispatch.

Validation:
python -m pytest tests/gateway/test_webhook_adapter.py::TestHTTPHandling::test_route_without_secret_rejects_unsigned_request tests/gateway/test_webhook_adapter.py::TestHTTPHandling::test_webhook_handler_returns_202 tests/gateway/test_webhook_signature_rate_limit.py -q -o 'addopts='

Result:
5 passed

Branch:
m0n3r0:security/webhook-missing-secret-fail-closed

Note:
This PR is intentionally minimal and tied to the private GHSA. It avoids additional exploit detail in the public PR body.
