### PR TITLE
docs(mcp): add iFlow Search server example

### DIFF
--- a/website/docs/guides/use-mcp-with-hermes.md
+++ b/website/docs/guides/use-mcp-with-hermes.md
@@ -334,6 +334,35 @@ List available MCP resources from the docs server, then read the onboarding guid
 List prompts exposed by the docs server and tell me which ones would help with incident response.
 ```
 
+### Example: iFlow Search over MCP
+
+iFlow Search publishes a stdio MCP server as `@iflow-ai/search-mcp`. Use it when you want web search, image search, and web fetch through Hermes without writing a native Hermes tool.
+
+```yaml
+mcp_servers:
+  iflow-search:
+    command: "npx"
+    args: ["-y", "@iflow-ai/search-mcp@next"]
+    env:
+      IFLOW_API_KEY: "YOUR_IFLOW_API_KEY"
+    tools:
+      include: [iflow_web_search, iflow_image_search, iflow_web_fetch]
+      resources: false
+      prompts: false
+```
+
+Verify the server before using it in a session:
+
+```bash
+hermes mcp test iflow-search
+```
+
+Notes:
+- Keep the real `IFLOW_API_KEY` out of version control; Hermes only passes it because it is explicitly listed in the server `env` block.
+- The package currently exposes `iflow_web_search`, `iflow_image_search`, and `iflow_web_fetch`.
+- With the server name above, Hermes registers those tools as `mcp_iflow_search_iflow_web_search`, `mcp_iflow_search_iflow_image_search`, and `mcp_iflow_search_iflow_web_fetch`.
+- Prefer `@next` or a pinned version in shared config so package upgrades stay intentional.
+
 ## Tutorial: end-to-end setup with filtering
 
 Here is a practical progression.


### PR DESCRIPTION
## What does this PR do?

Adds a copy-ready iFlow Search MCP server example to the Hermes MCP guide.

## Root cause

Issue #29250 asked for a concrete Hermes configuration example for iFlow Search. Without a documented snippet, users have to infer the command shape, environment variable placement, and tool names from the upstream package themselves.

## Fix

- Adds an iFlow Search entry to the practical MCP examples.
- Uses the published `@iflow-ai/search-mcp@next` stdio server through `npx -y`.
- Keeps the API key in the server `env` block instead of in the command string.
- Disables unused resource and prompt wrappers for a narrower tool surface.
- Documents the expected Hermes tool names and a simple verification command.

## Why this shape

This is docs-only because the MCP server is already published and does not require Hermes runtime changes. The example stays narrow: one server, one env var, and the registered search tool names users need to verify setup.

## Tests

- `npm view @iflow-ai/search-mcp@next name version bin repository dist-tags --json`
- `git diff --check -- website/docs/guides/use-mcp-with-hermes.md`
- `npm --prefix website run build -- --locale en`

Closes #29250

## Related PRs / issues

- Related to #29250.

<details>
<summary>Original body</summary>

﻿## What does this PR do?

Adds a copy-ready iFlow Search MCP server example to the Hermes MCP guide.

## Problem

Issue #29250 asked for a concrete Hermes configuration example for iFlow Search. Without a documented snippet, users have to infer the command shape, environment variable placement, and tool names from the upstream package themselves.

## What this changes

- Adds an iFlow Search entry to the practical MCP examples.
- Uses the published `@iflow-ai/search-mcp@next` stdio server through `npx -y`.
- Keeps the API key in the server `env` block instead of in the command string.
- Disables unused resource and prompt wrappers for a narrower tool surface.
- Documents the expected Hermes tool names and a simple verification command.

## Why this shape

This is docs-only because the MCP server is already published and does not require Hermes runtime changes. The example stays narrow: one server, one env var, and the registered search tool names users need to verify setup.

## Tests

- `npm view @iflow-ai/search-mcp@next name version bin repository dist-tags --json`
- `git diff --check -- website/docs/guides/use-mcp-with-hermes.md`
- `npm --prefix website run build -- --locale en`

Closes #29250

</details>

---

_Generated by Hermes Turbo_