### PR TITLE
docs(gateway): clarify multi-profile setup

### DIFF
--- a/website/docs/user-guide/messaging/index.md
+++ b/website/docs/user-guide/messaging/index.md
@@ -111,6 +111,14 @@ hermes gateway setup        # Interactive setup for all messaging platforms
 
 This walks you through configuring each platform with arrow-key selection, shows which platforms are already configured, and offers to start/restart the gateway when done.
 
+You do not need a separate Hermes profile for every platform. One gateway
+process can connect all platforms configured in the active profile, so a single
+agent can answer from Telegram, Feishu/Lark, Weixin, Discord, Slack, and other
+enabled adapters at the same time. Create separate profiles only when you want
+separate agents with different models, memories, personalities, bot tokens, or
+service names. See [Profiles: Running Multiple Agents](../profiles.md) for the
+multi-agent setup pattern.
+
 ## Gateway Commands
 
 ```bash

--- a/website/docs/user-guide/profiles.md
+++ b/website/docs/user-guide/profiles.md
@@ -22,6 +22,40 @@ coder chat                        # start chatting
 
 That's it. `coder` is now its own Hermes profile with its own config, memory, and state.
 
+## One agent on many platforms vs many agents
+
+Hermes can connect one agent to multiple messaging platforms at the same time.
+If you want the same assistant, memory, model, and sessions to answer from
+Telegram, Feishu/Lark, Weixin, and other gateway adapters, keep one profile,
+configure every platform in that profile, and start that profile's gateway:
+
+```bash
+hermes gateway setup
+hermes gateway start
+```
+
+Use additional profiles only when you want separate agents: different API keys,
+models, memories, personalities, allowed users, bot tokens, or service names.
+Each profile owns its own `.env`, `config.yaml`, `SOUL.md`, sessions, and gateway
+state.
+
+For example, to run two independent gateway agents on the same machine:
+
+```bash
+hermes profile create support --clone
+hermes profile create research --clone
+
+support gateway setup
+research gateway setup
+
+support gateway start
+research gateway start
+```
+
+Use different bot credentials for each profile. If two profiles try to start the
+same supported bot token, Hermes blocks the second gateway with a token-lock
+error so the two agents do not race on the same account.
+
 ## Creating a profile
 
 ### Blank profile


### PR DESCRIPTION
## What does this PR do?

Clarifies the gateway setup boundary between one agent on many messaging platforms and many independent agents on one machine.

## Root cause

Issue #9129 asks how to use Telegram, Feishu/Lark, Weixin, and other gateways at the same time while also asking about “more agents.” The existing docs explain profiles and gateway setup separately, but they do not make the choice explicit.

## Fix

- Adds a profiles guide section explaining that one active profile can connect multiple gateway platforms at once.
- Shows when to create additional profiles: separate model, memory, personality, credentials, allowed users, bot tokens, or service name.
- Adds concrete `support` / `research` profile commands for running two independent gateway agents.
- Links the messaging gateway overview back to the profiles guide so users find the multi-agent setup path from gateway docs.

## Why this shape

This is docs-only because the gateway already supports one configured profile serving multiple platforms. The change reduces setup confusion without changing runtime behavior or platform adapters.

## Tests

- `git diff --check -- website/docs/user-guide/profiles.md website/docs/user-guide/messaging/index.md`
- `node scripts/prebuild.mjs`
- `docusaurus build --locale en`

The docs build completed successfully; remaining Docusaurus warnings are pre-existing unrelated links or anchors.

Closes #9129

## Related PRs / issues

- Related to #9129.

<details>
<summary>Original body</summary>

﻿## What does this PR do?

Clarifies the gateway setup boundary between one agent on many messaging platforms and many independent agents on one machine.

## Problem

Issue #9129 asks how to use Telegram, Feishu/Lark, Weixin, and other gateways at the same time while also asking about “more agents.” The existing docs explain profiles and gateway setup separately, but they do not make the choice explicit.

## What this changes

- Adds a profiles guide section explaining that one active profile can connect multiple gateway platforms at once.
- Shows when to create additional profiles: separate model, memory, personality, credentials, allowed users, bot tokens, or service name.
- Adds concrete `support` / `research` profile commands for running two independent gateway agents.
- Links the messaging gateway overview back to the profiles guide so users find the multi-agent setup path from gateway docs.

## Why this shape

This is docs-only because the gateway already supports one configured profile serving multiple platforms. The change reduces setup confusion without changing runtime behavior or platform adapters.

## Tests

- `git diff --check -- website/docs/user-guide/profiles.md website/docs/user-guide/messaging/index.md`
- `node scripts/prebuild.mjs`
- `docusaurus build --locale en`

The docs build completed successfully; remaining Docusaurus warnings are pre-existing unrelated links or anchors.

Closes #9129

</details>

---

_Generated by Hermes Turbo_