### PR TITLE
fix(gateway): normalize legacy bool reply_to_mode so 'false' truly means 'off' (#29623)

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -277,6 +277,55 @@ class SessionResetPolicy:
         )
 
 
+REPLY_TO_MODES: tuple[str, ...] = ("off", "first", "all")
+DEFAULT_REPLY_TO_MODE: str = "first"
+
+
+def normalize_reply_to_mode(value: Any, *, default: str = DEFAULT_REPLY_TO_MODE) -> str:
+    """Coerce a ``reply_to_mode`` value to one of ``REPLY_TO_MODES`` (#29623).
+
+    Older configs (and operators copying examples from chat) can hand us
+    anything from a YAML 1.1 boolean ``false`` (parsed from ``off``)
+    through a string ``"OFF"`` to a stray ``None``. The Discord and
+    Telegram adapters historically did
+    ``getattr(config, 'reply_to_mode', 'first') or 'first'`` which
+    silently mapped boolean ``False`` to ``"first"`` — exactly the
+    opposite of what the user asked for. Normalize at the config layer
+    so every adapter consumer gets a canonical string.
+
+    Rules:
+
+    * ``False`` / ``"false"`` / ``"no"`` / ``"0"`` / ``"off"`` → ``"off"``
+    * ``True`` / ``"true"`` / ``"yes"`` / ``"1"`` → ``default``
+      (boolean ``true`` historically meant "yes please reply", i.e.
+      the project default behaviour).
+    * ``None`` / missing / empty / unknown → ``default``.
+    * ``"first"`` / ``"FIRST"`` / ``"  first  "`` → ``"first"``
+    * ``"all"`` / ``"ALL"`` → ``"all"``
+    """
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        # Must precede the ``int`` branch because ``bool`` is an ``int``
+        # subclass in Python and would otherwise stringify to ``"0"``/``"1"``.
+        return "off" if value is False else default
+    if isinstance(value, (int, float)):
+        # YAML / env interop: tolerate numeric 0/1 the same way the legacy
+        # adapter would have if it were boolean-aware.
+        return "off" if value == 0 else default
+    if isinstance(value, str):
+        lowered = value.strip().lower()
+        if not lowered:
+            return default
+        if lowered in REPLY_TO_MODES:
+            return lowered
+        if lowered in {"false", "no", "0"}:
+            return "off"
+        if lowered in {"true", "yes", "1"}:
+            return default
+    return default
+
+
 @dataclass
 class PlatformConfig:
     """Configuration for a single messaging platform."""
@@ -289,7 +338,7 @@ class PlatformConfig:
     # - "off": Never thread replies to original message
     # - "first": Only first chunk threads to user's message (default)
     # - "all": All chunks in multi-part replies thread to user's message
-    reply_to_mode: str = "first"
+    reply_to_mode: str = DEFAULT_REPLY_TO_MODE
 
     # Whether the gateway is allowed to send "♻️ Gateway online" /
     # "♻ Gateway restarted" lifecycle notifications on this platform.
@@ -300,6 +349,13 @@ class PlatformConfig:
 
     # Platform-specific settings
     extra: Dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        # Single point of truth for ``reply_to_mode`` shape (#29623).
+        # Applies to every construction path — direct ``PlatformConfig(…)``
+        # in tests, ``from_dict`` from YAML, env-var overrides further
+        # down, etc.
+        self.reply_to_mode = normalize_reply_to_mode(self.reply_to_mode)
 
     def to_dict(self) -> Dict[str, Any]:
         result = {
@@ -335,7 +391,9 @@ class PlatformConfig:
             token=data.get("token"),
             api_key=data.get("api_key"),
             home_channel=home_channel,
-            reply_to_mode=data.get("reply_to_mode", "first"),
+            # ``__post_init__`` normalises this; the explicit call here
+            # is redundant but documents the contract at the boundary.
+            reply_to_mode=normalize_reply_to_mode(data.get("reply_to_mode")),
             gateway_restart_notification=_coerce_bool(_grn, True),
             extra=data.get("extra", {}),
         )

--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -588,7 +588,15 @@ class DiscordAdapter(BasePlatformAdapter):
         self._dedup = MessageDeduplicator()
         # Reply threading mode: "off" (no replies), "first" (reply on first
         # chunk only, default), "all" (reply-reference on every chunk).
-        self._reply_to_mode: str = getattr(config, 'reply_to_mode', 'first') or 'first'
+        # ``PlatformConfig.__post_init__`` already normalises this — the
+        # explicit call here is defence in depth for the rare path that
+        # bypasses the dataclass (e.g. a hand-rolled stub config in a
+        # downstream embedder), and matches the contract documented in
+        # ``gateway.config.normalize_reply_to_mode`` (#29623).
+        from gateway.config import normalize_reply_to_mode
+        self._reply_to_mode: str = normalize_reply_to_mode(
+            getattr(config, 'reply_to_mode', None)
+        )
         self._slash_commands: bool = self.config.extra.get("slash_commands", True)
         # In-memory cache of the bot's last message ID per channel, used by
         # history backfill to skip the full scan on hot paths.  Falls back to

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -393,7 +393,13 @@ class TelegramAdapter(BasePlatformAdapter):
         self._bot: Optional[Bot] = None
         self._webhook_mode: bool = False
         self._mention_patterns = self._compile_mention_patterns()
-        self._reply_to_mode: str = getattr(config, 'reply_to_mode', 'first') or 'first'
+        # Defensive normalisation — see ``DiscordAdapter.__init__`` /
+        # ``gateway.config.normalize_reply_to_mode`` (#29623). Catches any
+        # stub config that bypasses ``PlatformConfig.__post_init__``.
+        from gateway.config import normalize_reply_to_mode
+        self._reply_to_mode: str = normalize_reply_to_mode(
+            getattr(config, 'reply_to_mode', None)
+        )
         self._disable_link_previews: bool = self._coerce_bool_extra("disable_link_previews", False)
         # Buffer rapid/album photo updates so Telegram image bursts are handled
         # as a single MessageEvent instead of self-interrupting multiple turns.

--- a/tests/gateway/test_discord_reply_mode.py
+++ b/tests/gateway/test_discord_reply_mode.py
@@ -84,10 +84,12 @@ class TestReplyToModeConfig:
         adapter = adapter_factory(reply_to_mode="all")
         assert adapter._reply_to_mode == "all"
 
-    def test_invalid_mode_stored_as_is(self, adapter_factory):
-        """Invalid modes are stored but send() handles them gracefully."""
+    def test_invalid_mode_normalised_to_default(self, adapter_factory):
+        """Garbage values now resolve to ``"first"`` at the config layer
+        (#29623). The old "store as-is and hope ``send()`` notices"
+        contract silently mishandled boolean ``False`` from legacy YAML."""
         adapter = adapter_factory(reply_to_mode="invalid")
-        assert adapter._reply_to_mode == "invalid"
+        assert adapter._reply_to_mode == "first"
 
     def test_none_mode_defaults_to_first(self):
         config = PlatformConfig(enabled=True, token="test-token")

--- a/tests/gateway/test_reply_to_mode_normalization.py
+++ b/tests/gateway/test_reply_to_mode_normalization.py
@@ -1,0 +1,329 @@
+"""Regression coverage for #29623 — legacy ``reply_to_mode: false`` in
+Discord/Telegram configs silently regressed to ``"first"`` instead of
+being treated as ``"off"``.
+
+The fix introduces ``gateway.config.normalize_reply_to_mode`` and wires
+it into both ``PlatformConfig.__post_init__`` and the Discord/Telegram
+adapter constructors. These tests pin the full contract end-to-end:
+
+* Reporter's exact repro (``PlatformConfig.from_dict({'reply_to_mode': False})``).
+* Every construction path — ``from_dict``, direct dataclass, env-var
+  bridge — lands on a canonical ``"off"`` / ``"first"`` / ``"all"``.
+* Both adapter constructors absorb any leftover non-canonical value
+  through the defensive normalisation layer.
+"""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+from gateway.config import (
+    DEFAULT_REPLY_TO_MODE,
+    REPLY_TO_MODES,
+    PlatformConfig,
+    Platform,
+    load_gateway_config,
+    normalize_reply_to_mode,
+)
+
+
+# ---------------------------------------------------------------------------
+# normalize_reply_to_mode — the helper's pure contract
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeReplyToModeHelper:
+    @pytest.mark.parametrize(
+        "value,expected",
+        [
+            # The whole point of #29623 — boolean False must become "off".
+            (False, "off"),
+            # True historically meant "yes please reply (default behaviour)".
+            (True, "first"),
+            # Missing / blank → default
+            (None, "first"),
+            ("", "first"),
+            ("   ", "first"),
+            ("\t\n", "first"),
+            # Canonical strings round-trip.
+            ("off", "off"),
+            ("first", "first"),
+            ("all", "all"),
+            # Case + whitespace insensitive.
+            ("OFF", "off"),
+            ("Off", "off"),
+            ("  off  ", "off"),
+            ("FIRST", "first"),
+            ("ALL", "all"),
+            # Bool-shaped strings (env-var bridge can hand us these).
+            ("true", "first"),
+            ("false", "off"),
+            ("yes", "first"),
+            ("no", "off"),
+            ("1", "first"),
+            ("0", "off"),
+            ("TRUE", "first"),
+            ("False", "off"),
+            # Numeric 0/1 (YAML can parse to int)
+            (0, "off"),
+            (1, "first"),
+            # Garbage falls back to the default rather than leaking into
+            # the adapter where it would silently mean "first" anyway.
+            ("banana", "first"),
+            ("on", "first"),  # ambiguous historically, "on" is not a mode
+            ("forever", "first"),
+            (42, "first"),
+            (object(), "first"),
+        ],
+    )
+    def test_canonicalises_inputs(self, value, expected):
+        assert normalize_reply_to_mode(value) == expected
+
+    def test_custom_default_is_honoured(self):
+        """Adapters that want a different fallback (e.g. legacy ``"all"``
+        on a forum-bridge bot) can pass ``default=``. ``True`` and
+        garbage both resolve to that default."""
+        assert normalize_reply_to_mode(True, default="all") == "all"
+        assert normalize_reply_to_mode(None, default="all") == "all"
+        assert normalize_reply_to_mode("banana", default="all") == "all"
+        # ``False`` is still ``"off"`` — that's the explicit user intent
+        # the default-override should NOT subvert.
+        assert normalize_reply_to_mode(False, default="all") == "off"
+
+    def test_output_is_always_in_REPLY_TO_MODES(self):
+        """Defensive: every code path through the helper must return a
+        value in the public tuple — adapters branch on those exact
+        strings."""
+        inputs = [
+            None, True, False, 0, 1, 42, "",
+            "off", "first", "all", "OFF", "FIRST", "ALL",
+            "true", "false", "yes", "no",
+            "banana", "on", "forever",
+            object(), [], {}, (1, 2),
+        ]
+        for value in inputs:
+            assert normalize_reply_to_mode(value) in REPLY_TO_MODES, (
+                f"{value!r} produced an out-of-range mode"
+            )
+
+    def test_default_constant_is_in_modes(self):
+        """Catch the silly typo case where someone changes the default
+        to e.g. ``"frist"`` and breaks every adapter at once."""
+        assert DEFAULT_REPLY_TO_MODE in REPLY_TO_MODES
+
+
+# ---------------------------------------------------------------------------
+# Reporter's exact repro
+# ---------------------------------------------------------------------------
+
+
+class TestReporterRepro29623:
+    """Exact transcript from
+    https://github.com/NousResearch/hermes-agent/issues/29623."""
+
+    def test_from_dict_false_resolves_to_off(self):
+        """Before the fix: ``False -> False``. After: ``False -> "off"``."""
+        cfg = PlatformConfig.from_dict({"enabled": True, "reply_to_mode": False})
+        assert cfg.reply_to_mode == "off"
+
+    def test_from_dict_off_string_resolves_to_off(self):
+        cfg = PlatformConfig.from_dict({"enabled": True, "reply_to_mode": "off"})
+        assert cfg.reply_to_mode == "off"
+
+    def test_from_dict_missing_resolves_to_first(self):
+        cfg = PlatformConfig.from_dict({"enabled": True})
+        assert cfg.reply_to_mode == "first"
+
+    def test_from_dict_all_three_match_reporter_table(self):
+        """The reporter pasted a three-row table — assert all three
+        rows agree on the new canonical output."""
+        results = {
+            "False": PlatformConfig.from_dict({"enabled": True, "reply_to_mode": False}).reply_to_mode,
+            "off": PlatformConfig.from_dict({"enabled": True, "reply_to_mode": "off"}).reply_to_mode,
+            "missing": PlatformConfig.from_dict({"enabled": True}).reply_to_mode,
+        }
+        assert results == {"False": "off", "off": "off", "missing": "first"}
+
+
+# ---------------------------------------------------------------------------
+# PlatformConfig construction paths
+# ---------------------------------------------------------------------------
+
+
+class TestPlatformConfigPostInit:
+    """``__post_init__`` is the single point of truth — every
+    construction style (direct, ``from_dict``, env-var override) ends
+    up with a normalised value."""
+
+    @pytest.mark.parametrize(
+        "value,expected",
+        [
+            (False, "off"),
+            (True, "first"),
+            (None, "first"),
+            ("", "first"),
+            ("off", "off"),
+            ("OFF", "off"),
+            ("  off  ", "off"),
+            ("all", "all"),
+            ("ALL", "all"),
+            ("false", "off"),
+            ("true", "first"),
+            ("banana", "first"),
+        ],
+    )
+    def test_direct_construction_normalises(self, value, expected):
+        cfg = PlatformConfig(enabled=True, reply_to_mode=value)
+        assert cfg.reply_to_mode == expected
+
+    def test_default_is_first(self):
+        """No-arg construction respects the dataclass default."""
+        cfg = PlatformConfig(enabled=True)
+        assert cfg.reply_to_mode == "first"
+
+    def test_to_dict_round_trip_preserves_off(self):
+        """The bad path was: legacy YAML stores ``false`` → from_dict
+        keeps ``False`` → to_dict serialises ``False`` → next reload
+        repeats the cycle. After normalisation, to_dict always
+        serialises a canonical string."""
+        cfg = PlatformConfig.from_dict({"enabled": True, "reply_to_mode": False})
+        serialised = cfg.to_dict()
+        assert serialised["reply_to_mode"] == "off"
+        # And reloading is idempotent.
+        cfg2 = PlatformConfig.from_dict(serialised)
+        assert cfg2.reply_to_mode == "off"
+
+    def test_post_init_runs_on_every_construction(self):
+        """Sanity: if ``__post_init__`` were silently dropped (e.g. by
+        a future ``__init__`` override) every input would round-trip
+        as-is. Pin the contract here."""
+        cfg = PlatformConfig(enabled=True, reply_to_mode="banana")
+        assert cfg.reply_to_mode == "first", (
+            "PlatformConfig.__post_init__ should normalise reply_to_mode"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Env-var bridge (load_gateway_config)
+# ---------------------------------------------------------------------------
+
+
+class TestEnvVarBridgeNormalises:
+    """The env-var path (``DISCORD_REPLY_TO_MODE`` /
+    ``TELEGRAM_REPLY_TO_MODE``) already filters non-canonical strings,
+    but after the fix the ``PlatformConfig`` it constructs goes through
+    ``__post_init__`` regardless, so even a hypothetical garbage value
+    can't leak into the adapter."""
+
+    def test_discord_env_off_lands_as_off(self, monkeypatch):
+        for var in (
+            "DISCORD_REPLY_TO_MODE",
+            "TELEGRAM_REPLY_TO_MODE",
+            "DISCORD_BOT_TOKEN",
+        ):
+            monkeypatch.delenv(var, raising=False)
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "x")
+        monkeypatch.setenv("DISCORD_REPLY_TO_MODE", "off")
+
+        cfg = load_gateway_config()
+        assert cfg.platforms[Platform.DISCORD].reply_to_mode == "off"
+
+    def test_discord_env_first_lands_as_first(self, monkeypatch):
+        for var in ("DISCORD_REPLY_TO_MODE", "DISCORD_BOT_TOKEN"):
+            monkeypatch.delenv(var, raising=False)
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "x")
+        monkeypatch.setenv("DISCORD_REPLY_TO_MODE", "first")
+
+        cfg = load_gateway_config()
+        assert cfg.platforms[Platform.DISCORD].reply_to_mode == "first"
+
+
+# ---------------------------------------------------------------------------
+# Adapter defence-in-depth — stub configs that bypass __post_init__
+# ---------------------------------------------------------------------------
+
+
+class _StubConfig:
+    """A config-shaped duck that does NOT inherit ``PlatformConfig``.
+
+    Mirrors what a downstream embedder might do if they hand-roll a
+    config object instead of going through the dataclass. The adapter
+    constructor reads ``reply_to_mode`` via ``getattr``, so this is
+    the realistic worst-case escape hatch.
+    """
+
+    def __init__(self, **kw):
+        self.enabled = True
+        self.token = "stub"
+        self.extra = {}
+        self.home_channel = None
+        # Anything callers want to set, e.g. ``reply_to_mode=False``.
+        for k, v in kw.items():
+            setattr(self, k, v)
+
+
+class TestAdapterDefensiveNormalisation:
+    """Even if a stub config slips a ``False`` past
+    ``PlatformConfig.__post_init__``, the adapter constructor must
+    still produce a canonical mode."""
+
+    def test_discord_adapter_normalises_stub_false(self):
+        from gateway.platforms.discord import DiscordAdapter
+
+        adapter = DiscordAdapter(_StubConfig(reply_to_mode=False))
+        assert adapter._reply_to_mode == "off"
+
+    def test_discord_adapter_normalises_stub_garbage(self):
+        from gateway.platforms.discord import DiscordAdapter
+
+        adapter = DiscordAdapter(_StubConfig(reply_to_mode="banana"))
+        assert adapter._reply_to_mode == "first"
+
+    def test_discord_adapter_normalises_stub_missing_attr(self):
+        from gateway.platforms.discord import DiscordAdapter
+
+        stub = _StubConfig()
+        # Force-remove the attribute so ``getattr(config, 'reply_to_mode',
+        # None)`` actually returns ``None``.
+        if hasattr(stub, "reply_to_mode"):
+            delattr(stub, "reply_to_mode")
+        adapter = DiscordAdapter(stub)
+        assert adapter._reply_to_mode == "first"
+
+    def test_telegram_adapter_normalises_stub_false(self):
+        try:
+            from gateway.platforms.telegram import TelegramAdapter
+        except Exception:
+            pytest.skip("telegram adapter dependencies not installed")
+
+        # We can't instantiate the full TelegramAdapter without a token
+        # exchange, so directly exercise the normalisation contract via
+        # the helper the adapter delegates to.
+        assert normalize_reply_to_mode(False) == "off"
+        # And confirm the stub config (which IS what would be passed)
+        # produces ``False`` so the adapter clearly needs a defender.
+        stub = _StubConfig(reply_to_mode=False)
+        assert stub.reply_to_mode is False
+        assert normalize_reply_to_mode(getattr(stub, "reply_to_mode", None)) == "off"
+
+
+# ---------------------------------------------------------------------------
+# Whole-config round-trip — pin that ``PlatformConfig.to_dict ->
+# from_dict`` is idempotent for legacy bool input.
+# ---------------------------------------------------------------------------
+
+
+class TestLegacyBoolRoundTrip:
+    """If an operator's on-disk config has ``reply_to_mode: false``,
+    Hermes should load it, treat it as ``"off"``, and (if it ever
+    rewrites the file) save back a canonical string — never silently
+    re-emit the bool that started the bug."""
+
+    @pytest.mark.parametrize("raw", [False, "off", "OFF", "false", "no", "0", 0])
+    def test_legacy_off_inputs_all_serialise_to_off(self, raw):
+        cfg = PlatformConfig.from_dict({"enabled": True, "reply_to_mode": raw})
+        assert cfg.reply_to_mode == "off"
+        assert cfg.to_dict()["reply_to_mode"] == "off"

--- a/tests/gateway/test_telegram_reply_mode.py
+++ b/tests/gateway/test_telegram_reply_mode.py
@@ -62,10 +62,12 @@ class TestReplyToModeConfig:
         adapter = adapter_factory(reply_to_mode="all")
         assert adapter._reply_to_mode == "all"
 
-    def test_invalid_mode_stored_as_is(self, adapter_factory):
-        """Invalid modes are stored but _should_thread_reply handles them."""
+    def test_invalid_mode_normalised_to_default(self, adapter_factory):
+        """Garbage values now resolve to ``"first"`` at the config layer
+        (#29623). The old "store as-is" contract silently mishandled
+        boolean ``False`` from legacy YAML configs."""
         adapter = adapter_factory(reply_to_mode="invalid")
-        assert adapter._reply_to_mode == "invalid"
+        assert adapter._reply_to_mode == "first"
 
     def test_none_mode_defaults_to_first(self):
         config = PlatformConfig(enabled=True, token="test-token")


### PR DESCRIPTION
## What does this PR do?

Fixes [#29623](https://github.com/NousResearch/hermes-agent/issues/29623) — Discord (and Telegram) configs that carry the legacy boolean `reply_to_mode: false` were silently regressing to `"first"` on the current runtime, so the bot kept replying to the triggering message instead of sending it standalone.

**Root cause.**
`PlatformConfig.from_dict` did:

```python
reply_to_mode=data.get("reply_to_mode", "first"),
```

— no normalisation, so `False` was stored verbatim. The Discord and Telegram adapter constructors then did:

```python
self._reply_to_mode = getattr(config, 'reply_to_mode', 'first') or 'first'
```

`False or 'first'` evaluates to `'first'`, which is exactly the opposite of what the user asked for. The YAML→env bridge in `load_gateway_config` already coerced `False → "off"` for top-level `discord:` / `telegram:` sections, but the `from_dict` path (used by `display.platforms.discord:` and `platforms.discord:` blocks) bypassed that bridge entirely.

**Fix.**
- New `gateway.config.normalize_reply_to_mode(value, *, default=…)` is the single source of truth: `False`/`"false"`/`"no"`/`"0"`/`0` → `"off"`, `True`/`"true"`/`"yes"`/`"1"`/`1` → default, `None`/missing/garbage → default, case- and whitespace-insensitive `off`/`first`/`all` round-trip canonically.
- `PlatformConfig.__post_init__` runs the normaliser, so **every** construction path (`from_dict`, env-var bridge, direct `PlatformConfig(reply_to_mode=…)` in tests and embedders) lands on a canonical string.
- `DiscordAdapter.__init__` and `TelegramAdapter.__init__` apply the same normaliser defensively, so the rare stub-config path that bypasses the dataclass (downstream embedders that hand-roll a duck-typed config object) still produces a canonical mode.

The reporter's exact repro now prints `False -> off` instead of `False -> False`.

## Related Issue

Closes #29623 — *Discord `reply_to_mode: false` regresses to `first` on current runtime*.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [x] ♻️ Refactor (no behavior change) — centralises the previously scattered `or 'first'` / `_rtm_str = "off" if … is False else …` logic into one helper
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/config.py`
  - New module-level constants: `REPLY_TO_MODES = ("off", "first", "all")` and `DEFAULT_REPLY_TO_MODE = "first"` — both used as the public contract surface for tests and adapter code.
  - New `normalize_reply_to_mode(value, *, default=DEFAULT_REPLY_TO_MODE) -> str` helper with the full rule table (see fix description above).
  - `PlatformConfig.reply_to_mode` default switched to `DEFAULT_REPLY_TO_MODE` (same string, semantically labelled).
  - New `PlatformConfig.__post_init__` that runs every constructed config through the normaliser — the single point of truth.
  - `PlatformConfig.from_dict` now calls the normaliser explicitly at the boundary (redundant with `__post_init__` but documents the contract).

- `gateway/platforms/discord.py` — `DiscordAdapter.__init__` swaps the brittle `getattr(config, 'reply_to_mode', 'first') or 'first'` for the new normaliser, with a comment that points at `gateway.config.normalize_reply_to_mode` and #29623.

- `gateway/platforms/telegram.py` — same defensive normalisation pattern in `TelegramAdapter.__init__`.

- `tests/gateway/test_discord_reply_mode.py` and `tests/gateway/test_telegram_reply_mode.py` — flip the two `test_invalid_mode_stored_as_is` assertions to `test_invalid_mode_normalised_to_default` so they pin the improved contract instead of the bug surface they used to lock in.

- `tests/gateway/test_reply_to_mode_normalization.py` (new, +329 lines, **64 cases** across six classes):
  - `TestNormalizeReplyToModeHelper` — pure-helper contract (parametrised over ~30 inputs, plus `test_custom_default_is_honoured`, `test_output_is_always_in_REPLY_TO_MODES`, `test_default_constant_is_in_modes`).
  - `TestReporterRepro29623` — the exact transcript pasted in the issue body, asserted as four separate tests.
  - `TestPlatformConfigPostInit` — every direct `PlatformConfig(reply_to_mode=…)` is normalised, `to_dict` no longer re-emits the legacy bool, and a guardrail catches a future `__init__` that silently drops `__post_init__`.
  - `TestEnvVarBridgeNormalises` — the env-var path through `load_gateway_config` also lands on canonical values.
  - `TestAdapterDefensiveNormalisation` — duck-typed stub configs (downstream embedders) still get a canonical mode out of `DiscordAdapter` / via the `normalize_reply_to_mode(getattr(stub, 'reply_to_mode', None))` helper used in `TelegramAdapter`.
  - `TestLegacyBoolRoundTrip` — every legacy `off`-ish input survives `from_dict → to_dict → from_dict` as `"off"`, so a config written by an older Hermes can't reanimate the bug on the next save.

## How to Test

1. Check out the branch and activate the venv:
   ```
   git fetch origin fix/29623-discord-reply-to-mode-false-normalize
   git checkout fix/29623-discord-reply-to-mode-false-normalize
   source .venv/bin/activate   # or: python3 -m venv .venv && source .venv/bin/activate && pip install -e ".[all,dev]"
   ```
2. Run the new regression file on its own:
   ```
   scripts/run_tests.sh tests/gateway/test_reply_to_mode_normalization.py -v
   ```
   Expected: **64 passed**.
3. Run the combined reply-mode suite (covers the updated existing tests too):
   ```
   scripts/run_tests.sh tests/gateway/test_reply_to_mode_normalization.py tests/gateway/test_discord_reply_mode.py tests/gateway/test_telegram_reply_mode.py
   ```
   Expected: **137 passed**.
4. Run the broader gateway-config suite to confirm no cross-file regressions:
   ```
   scripts/run_tests.sh tests/gateway/test_config.py tests/gateway/test_config_cwd_bridge.py tests/gateway/test_display_config.py tests/gateway/test_runtime_env_reload_config_authority.py tests/gateway/test_config_env_bridge_authority.py
   ```
   Expected: **111 passed**.
5. Reporter's exact one-liner:
   ```
   python -c "from gateway.config import PlatformConfig; print(PlatformConfig.from_dict({'enabled': True, 'reply_to_mode': False}).reply_to_mode)"
   ```
   Expected: `off` (before this PR: `False`).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(gateway): …` and `test(gateway): …`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run `scripts/run_tests.sh tests/gateway/test_reply_to_mode_normalization.py tests/gateway/test_discord_reply_mode.py tests/gateway/test_telegram_reply_mode.py` and all 137 tests pass
- [x] I've added tests for my changes (64 new regression cases across six classes + updated two existing assertions to reflect the improved contract)
- [x] I've tested on my platform: macOS 15.2 (Darwin 24.6.0), Python 3.12

### Documentation & Housekeeping

- [x] I've updated relevant documentation — the inline docstring on `normalize_reply_to_mode` documents the full rule table; no user-facing docs change is needed (the YAML key + accepted string values are unchanged — legacy bool values just now resolve correctly)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no new config keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure config-shape change, no OS-specific code paths
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

```
$ scripts/run_tests.sh tests/gateway/test_reply_to_mode_normalization.py -v
4 workers [64 items]
............................................................... [100%]
============================== 64 passed in 1.23s ==============================

$ scripts/run_tests.sh tests/gateway/test_reply_to_mode_normalization.py tests/gateway/test_discord_reply_mode.py tests/gateway/test_telegram_reply_mode.py
4 workers [137 items]
============================== 137 passed in 1.40s ==============================

$ python -c "from gateway.config import PlatformConfig; print(PlatformConfig.from_dict({'enabled': True, 'reply_to_mode': False}).reply_to_mode)"
off
```
