### PR TITLE
fix(gateway): normalize false reply mode at config boundary

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -36,6 +36,19 @@ def _coerce_bool(value: Any, default: bool = True) -> bool:
     return is_truthy_value(value, default=default)
 
 
+def _normalize_reply_to_mode(value: Any) -> str:
+    """Normalize reply threading mode from YAML and legacy config values."""
+    if value is False:
+        return "off"
+    if isinstance(value, str):
+        mode = value.strip().lower()
+        if mode in {"off", "false"}:
+            return "off"
+        if mode in {"first", "all"}:
+            return mode
+    return "first"
+
+
 def _coerce_float(value: Any, default: float) -> float:
     """Coerce numeric config values, falling back on malformed input."""
     if value is None:
@@ -335,7 +348,7 @@ class PlatformConfig:
             token=data.get("token"),
             api_key=data.get("api_key"),
             home_channel=home_channel,
-            reply_to_mode=data.get("reply_to_mode", "first"),
+            reply_to_mode=_normalize_reply_to_mode(data.get("reply_to_mode")),
             gateway_restart_notification=_coerce_bool(_grn, True),
             extra=data.get("extra", {}),
         )

--- a/tests/gateway/test_discord_reply_mode.py
+++ b/tests/gateway/test_discord_reply_mode.py
@@ -233,6 +233,14 @@ class TestConfigSerialization:
         config = PlatformConfig.from_dict(data)
         assert config.reply_to_mode == "off"
 
+    def test_from_dict_normalizes_legacy_false_reply_to_mode(self):
+        data = {"enabled": True, "token": "***", "reply_to_mode": False}
+        config = PlatformConfig.from_dict(data)
+        adapter = DiscordAdapter(config)
+
+        assert config.reply_to_mode == "off"
+        assert adapter._reply_to_mode == "off"
+
     def test_from_dict_defaults_to_first(self):
         data = {"enabled": True, "token": "***"}
         config = PlatformConfig.from_dict(data)


### PR DESCRIPTION
## What does this PR do?

Normalizes legacy `reply_to_mode: false` gateway config values to the explicit reply mode `off` before Discord adapter initialization.

## Root cause

`PlatformConfig.from_dict()` preserved boolean `False` for `reply_to_mode`. `DiscordAdapter` then treated that falsy value as missing and fell back to `first`, which made Discord replies reference the triggering message again.

## Fix

- Adds a shared reply-mode normalizer in gateway config loading.
- Maps boolean `False` and string `"false"` to `"off"` for backward compatibility.
- Preserves the existing `"first"` default for missing or unsupported values.
- Adds a Discord regression test proving `PlatformConfig.from_dict()` passes `off` through to the adapter.

## Why this shape

This is the narrow config-boundary patch: it normalizes the legacy value where `PlatformConfig.from_dict()` accepts external configuration and keeps the Discord adapter receiving an explicit string mode.

PR #29639 is the broader/superset fix for the same issue because it also adds defensive normalization in Discord and Telegram adapters. If maintainers prefer that broader shape, this PR should be closed in favor of #29639 rather than merged as a competing duplicate.

## Tests

- `git diff --check -- gateway/config.py tests/gateway/test_discord_reply_mode.py`
- `python -m py_compile gateway\config.py`
- `python -m pytest tests/gateway/test_discord_reply_mode.py tests/gateway/test_config.py -q -o addopts= -p no:xdist` — 82 passed.
- `python -m ruff check gateway\config.py tests\gateway\test_discord_reply_mode.py`

## Related PRs / issues

- Related to #29623.
- Superset/competing context: #29639 covers the same issue with broader adapter-level defensive normalization.