### PR TITLE
fix(gateway/telegram): resolve gmail triage scripts via active hermes home

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -3240,8 +3240,8 @@ class TelegramAdapter(BasePlatformAdapter):
             logger.error("Failed to write update response from callback: %s", exc)
 
     # Maps `gt:<verb>` -> (script-name, extra-args, success-label, is_state).
-    # Scripts live in ~/.hermes/scripts/gmail-triage/. `arg` from the callback
-    # data is always passed as the first positional arg.
+    # Scripts live in the active HERMES_HOME under scripts/gmail-triage/.
+    # `arg` from the callback data is always passed as the first positional arg.
     # is_state=True means the verb is a sticky sender-rule change (mute, trust,
     # vip) that should leave the keyboard tappable for follow-on actions.
     # is_state=False is a per-email one-shot (send, archive, draft, spam) that
@@ -3293,7 +3293,8 @@ class TelegramAdapter(BasePlatformAdapter):
             return
         script_name, extra_args, success_label, is_state_verb = entry
 
-        script_path = _Path.home() / ".hermes" / "scripts" / "gmail-triage" / script_name
+        from hermes_constants import get_hermes_home
+        script_path = get_hermes_home() / "scripts" / "gmail-triage" / script_name
         if not script_path.exists():
             await query.answer(text=f"❌ {script_name} missing")
             logger.error("[%s] gmail-triage script missing: %s", self.name, script_path)

--- a/tests/gateway/test_telegram_approval_buttons.py
+++ b/tests/gateway/test_telegram_approval_buttons.py
@@ -589,3 +589,55 @@ class TestTelegramApprovalCallback:
         query.answer.assert_called_once()
         query.edit_message_text.assert_called_once()
         assert (tmp_path / ".update_response").read_text() == "n"
+
+    @pytest.mark.asyncio
+    async def test_gmail_triage_callback_uses_active_hermes_home(self, tmp_path, monkeypatch):
+        """Gmail triage scripts must resolve under the active profile home."""
+        adapter = _make_adapter()
+        real_home = tmp_path / "real-home"
+        profile_home = tmp_path / "profile-home"
+        script_dir = profile_home / "scripts" / "gmail-triage"
+        script_dir.mkdir(parents=True)
+        script_path = script_dir / "archive.sh"
+        script_path.write_text("#!/bin/sh\n", encoding="utf-8")
+
+        monkeypatch.setattr(Path, "home", lambda: real_home)
+
+        query = AsyncMock()
+        query.from_user = MagicMock()
+        query.from_user.id = 111
+        query.from_user.first_name = "Alice"
+        query.message = MagicMock()
+        query.message.text = "Email summary"
+        query.answer = AsyncMock()
+        query.edit_message_text = AsyncMock()
+
+        calls = []
+
+        async def fake_create_subprocess_exec(*cmd, **kwargs):
+            calls.append((cmd, kwargs))
+            proc = AsyncMock()
+            proc.returncode = 0
+            proc.communicate = AsyncMock(return_value=(b"", b""))
+            return proc
+
+        with patch("hermes_constants.get_hermes_home", return_value=profile_home):
+            with patch.dict(os.environ, {"TELEGRAM_ALLOWED_USERS": "111"}):
+                with patch(
+                    "gateway.platforms.telegram.asyncio.create_subprocess_exec",
+                    side_effect=fake_create_subprocess_exec,
+                ):
+                    await adapter._handle_gmail_triage_callback(
+                        query,
+                        "gt:archive:msg-123",
+                        query_chat_id=12345,
+                        query_chat_type="private",
+                        query_thread_id=None,
+                        query_user_name="Alice",
+                    )
+
+        assert calls
+        assert calls[0][0][0] == str(script_path)
+        assert calls[0][0][1:] == ("msg-123",)
+        query.answer.assert_called_once_with(text=adapter._GT_VERB_DISPATCH["archive"][2])
+        query.edit_message_text.assert_called_once()


### PR DESCRIPTION
## Summary

Fix Telegram Gmail triage callback script resolution to use the active Hermes home instead of hardcoding the default user home.

This keeps callback behavior consistent with Hermes profile-aware path handling.

## Problem

Gmail triage callbacks resolved action scripts from the default home directory. That bypassed active Hermes home/profile resolution, so callbacks could fail to find scripts when Hermes was running with a profile-specific home.

## Fix

Resolve Gmail triage action scripts from the active Hermes home.

## Tests

```text
tests/gateway/test_telegram_approval_buttons.py - 21 passed in 0.91s