### PR TITLE
feat: project kanban runtime receipts

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4220,11 +4220,12 @@ class GatewayRunner:
             return "default"
 
     async def _kanban_notifier_watcher(self, interval: float = 5.0) -> None:
-        """Poll ``kanban_notify_subs`` and deliver terminal events to users.
+        """Poll ``kanban_notify_subs`` and deliver lightweight receipts to users.
 
         For each subscription row, fetches ``task_events`` newer than the
-        stored cursor with kind in the terminal set (``completed``,
-        ``blocked``, ``gave_up``, ``crashed``, ``timed_out``). Sends one
+        stored cursor with kind in the receipt set (``created``, ``assigned``,
+        ``spawned``, ``heartbeat``, ``completed``, ``blocked``, ``gave_up``,
+        ``crashed``, ``timed_out``). Sends one lightweight text/emoji receipt
         message per new event to ``(platform, chat_id, thread_id)``,
         then advances the cursor. When a task reaches a terminal state
         (``completed`` / ``archived``), the subscription is removed.
@@ -4245,7 +4246,17 @@ class GatewayRunner:
             logger.warning("kanban notifier: kanban_db not importable; notifier disabled")
             return
 
-        TERMINAL_KINDS = ("completed", "blocked", "gave_up", "crashed", "timed_out")
+        RECEIPT_KINDS = (
+            "created",
+            "assigned",
+            "spawned",
+            "heartbeat",
+            "completed",
+            "blocked",
+            "gave_up",
+            "crashed",
+            "timed_out",
+        )
         # Subscriptions are removed only when the task reaches a truly final
         # status (done / archived). We used to also unsub on any terminal
         # event kind (gave_up / crashed / timed_out / blocked), but that
@@ -4353,7 +4364,7 @@ class GatewayRunner:
                                     platform=sub["platform"],
                                     chat_id=sub["chat_id"],
                                     thread_id=sub.get("thread_id") or "",
-                                    kinds=TERMINAL_KINDS,
+                                    kinds=RECEIPT_KINDS,
                                 )
                                 if not events:
                                     continue
@@ -4406,56 +4417,163 @@ class GatewayRunner:
                     title = (task.title if task else sub["task_id"])[:120]
                     for ev in d["events"]:
                         kind = ev.kind
-                        # Identity prefix: attribute terminal pings to the
-                        # worker that did the work. Makes fleets (where one
-                        # chat subscribes to many tasks) legible at a glance.
+                        # Runtime-owned identity: attribute receipts to the
+                        # task assignee/runtime. Routine Kanban lifecycle
+                        # events stay lightweight text/emoji; image Feed is
+                        # reserved for milestone/blocker/evidence gates.
                         who = (task.assignee if task and task.assignee else None)
-                        tag = f"@{who} " if who else ""
-                        if kind == "completed":
+                        owner = f"@{who}" if who else "@agent"
+                        if kind == "created":
+                            assignee = None
+                            status = None
+                            if ev.payload:
+                                assignee = ev.payload.get("assignee")
+                                status = ev.payload.get("status")
+                            event_owner = f"@{assignee}" if assignee else owner
+                            state = f" · {status}" if status else ""
+                            msg = (
+                                f"📌 Kanban 已派单\n\n"
+                                f"任务：{sub['task_id']} · {event_owner}{state}\n"
+                                f"范围：{title}\n"
+                                f"下一步：等待 runtime 开始执行"
+                            )
+                        elif kind == "assigned":
+                            assignee = None
+                            if ev.payload:
+                                assignee = ev.payload.get("assignee")
+                            event_owner = f"@{assignee}" if assignee else owner
+                            msg = (
+                                f"📌 Kanban 已分配\n\n"
+                                f"任务：{sub['task_id']} · {event_owner}\n"
+                                f"范围：{title}\n"
+                                f"下一步：等待 runtime 开始执行"
+                            )
+                        elif kind == "spawned":
+                            pid_text = ""
+                            if ev.payload and ev.payload.get("pid"):
+                                pid_text = f"\n运行：pid {ev.payload['pid']}"
+                            msg = (
+                                f"▶️ Runtime 已开始\n\n"
+                                f"任务：{sub['task_id']} · {owner}\n"
+                                f"范围：{title}{pid_text}\n"
+                                f"下一步：执行中，有阻塞/完成会继续回报"
+                            )
+                        elif kind == "heartbeat":
+                            note = "执行中"
+                            if ev.payload and ev.payload.get("note"):
+                                note = str(ev.payload["note"]).strip().splitlines()[0][:160]
+                            msg = (
+                                f"🔄 Runtime 进展\n\n"
+                                f"任务：{sub['task_id']} · {owner}\n"
+                                f"范围：{title}\n"
+                                f"进展：{note}"
+                            )
+                        elif kind == "completed":
                             # Prefer the run's summary (the worker's
                             # intentional human-facing handoff, carried
                             # in the event payload), then fall back to
                             # task.result for legacy rows written before
-                            # runs shipped.
-                            handoff = ""
+                            # runs shipped. Telegram-facing cards are kept
+                            # short and Chinese; verbose worker handoffs stay
+                            # in Kanban comments/logs for audit.
                             payload_summary = None
                             if ev.payload and ev.payload.get("summary"):
                                 payload_summary = str(ev.payload["summary"])
                             if payload_summary:
-                                h = payload_summary.strip().splitlines()[0][:200]
-                                handoff = f"\n{h}"
+                                result = payload_summary.strip().splitlines()[0][:180]
                             elif task and task.result:
-                                r = task.result.strip().splitlines()[0][:160]
-                                handoff = f"\n{r}"
+                                result = task.result.strip().splitlines()[0][:160]
+                            else:
+                                result = "已完成"
+                            evidence_text = "\n".join(
+                                str(part or "")
+                                for part in (
+                                    title,
+                                    getattr(task, "body", None) if task else None,
+                                    getattr(task, "result", None) if task else None,
+                                    payload_summary,
+                                )
+                            )
+                            issue_nums = []
+                            for _match in re.finditer(r"(?:Issue\s*)?#(\d+)\b", evidence_text, re.I):
+                                num = _match.group(1)
+                                if num not in issue_nums:
+                                    issue_nums.append(num)
+                            pr_nums = []
+                            for _match in re.finditer(r"PR\s*#(\d+)\b", evidence_text, re.I):
+                                num = _match.group(1)
+                                if num not in pr_nums:
+                                    pr_nums.append(num)
+                            refs = []
+                            if issue_nums:
+                                refs.append("Issue " + ", ".join(f"#{n}" for n in issue_nums[:3]) + " 已完成")
+                            if pr_nums:
+                                refs.append("PR " + ", ".join(f"#{n}" for n in pr_nums[:3]))
+                            refs_line = "\n" + f"关联：{' / '.join(refs)}" if refs else ""
                             msg = (
-                                f"✔ {tag}Kanban {sub['task_id']} done"
-                                f" — {title}{handoff}"
+                                f"✅ Issue/任务完成\n\n"
+                                f"任务：{sub['task_id']} · {owner}\n"
+                                f"范围：{title}{refs_line}\n"
+                                f"结果：{result}\n"
+                                f"下一步：Kopa/PM 验证 PR/Issue/milestone"
                             )
                         elif kind == "blocked":
-                            reason = ""
+                            raw_reason = ""
                             if ev.payload and ev.payload.get("reason"):
-                                reason = f": {str(ev.payload['reason'])[:160]}"
-                            msg = f"⏸ {tag}Kanban {sub['task_id']} blocked{reason}"
+                                raw_reason = str(ev.payload["reason"])
+                            pr_match = re.search(r"PR\s*#(\d+)", raw_reason, re.I)
+                            issue_match = re.search(r"Issue\s*#(\d+)", raw_reason, re.I)
+                            if not issue_match:
+                                issue_match = re.search(r"\bfor\s+#(\d+)", raw_reason, re.I)
+                            pr_issue = []
+                            if pr_match:
+                                pr_issue.append(f"PR #{pr_match.group(1)}")
+                            if issue_match:
+                                issue_num = issue_match.group(1)
+                                pr_issue.append(f"Issue #{issue_num}")
+                            refs = " / ".join(pr_issue) if pr_issue else "待补充"
+                            tests = "passed" if re.search(r"tests?\s+passed|passed", raw_reason, re.I) else "待确认"
+                            if "review-required" in raw_reason:
+                                header = "⏸ Kanban 阻塞 · 等待 Review"
+                                next_step = "Founder/reviewer 批准后 merge"
+                            else:
+                                header = "⏸ Kanban 阻塞 · 需处理"
+                                next_step = raw_reason[:120] if raw_reason else "查看 Kanban 日志"
+                            msg = (
+                                f"{header}\n\n"
+                                f"任务：{sub['task_id']} · {owner}\n"
+                                f"{refs}\n"
+                                f"范围：{title}\n"
+                                f"测试：{tests}\n"
+                                f"下一步：{next_step}"
+                            )
                         elif kind == "gave_up":
                             err = ""
                             if ev.payload and ev.payload.get("error"):
-                                err = f"\n{str(ev.payload['error'])[:200]}"
+                                err = f"\n错误：{str(ev.payload['error'])[:180]}"
                             msg = (
-                                f"✖ {tag}Kanban {sub['task_id']} gave up "
-                                f"after repeated spawn failures{err}"
+                                f"✖ Kanban 失败 · 多次启动失败\n\n"
+                                f"任务：{sub['task_id']} · {owner}\n"
+                                f"范围：{title}{err}\n"
+                                f"下一步：Kopa/PM 诊断 profile/token/worker"
                             )
                         elif kind == "crashed":
                             msg = (
-                                f"✖ {tag}Kanban {sub['task_id']} worker crashed "
-                                f"(pid gone); dispatcher will retry"
+                                f"✖ Kanban 崩溃 · Worker 退出\n\n"
+                                f"任务：{sub['task_id']} · {owner}\n"
+                                f"范围：{title}\n"
+                                f"下一步：dispatcher 将重试，若重复失败需恢复"
                             )
                         elif kind == "timed_out":
                             limit = 0
                             if ev.payload and ev.payload.get("limit_seconds"):
                                 limit = int(ev.payload["limit_seconds"])
                             msg = (
-                                f"⏱ {tag}Kanban {sub['task_id']} timed out "
-                                f"(max_runtime={limit}s); will retry"
+                                f"⏱ Kanban 超时 · 将重试\n\n"
+                                f"任务：{sub['task_id']} · {owner}\n"
+                                f"范围：{title}\n"
+                                f"限制：{limit}s\n"
+                                f"下一步：观察重试或拆小任务"
                             )
                         else:
                             continue

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4585,13 +4585,40 @@ class GatewayRunner:
                             sub["chat_id"], sub.get("thread_id") or "",
                         )
                         try:
-                            await adapter.send(
+                            send_result = await adapter.send(
                                 sub["chat_id"], msg, metadata=metadata,
                             )
                             logger.debug(
                                 "kanban notifier: delivered %s event for %s to %s/%s on board %s",
                                 kind, sub["task_id"], platform_str, sub["chat_id"], board_slug,
                             )
+                            evidence_payload = {
+                                "work_item_id": sub["task_id"],
+                                "task_id": sub["task_id"],
+                                "runtime_profile": who,
+                                "assignee": who,
+                                "notifier_profile": notifier_profile,
+                                "platform": platform_str,
+                                "chat_id": sub["chat_id"],
+                                "thread_id": sub.get("thread_id") or "",
+                                "message_id": self._kanban_send_message_id(send_result),
+                                "source_event_id": ev.id,
+                                "source_event_kind": kind,
+                                "board": board_slug,
+                            }
+                            try:
+                                await asyncio.to_thread(
+                                    self._kanban_record_delivery_evidence,
+                                    sub,
+                                    evidence_payload,
+                                    ev.run_id,
+                                    board_slug,
+                                )
+                            except Exception as evidence_exc:
+                                logger.warning(
+                                    "kanban notifier: delivery evidence record failed for %s event %s on board %s: %s",
+                                    sub["task_id"], ev.id, board_slug, evidence_exc,
+                                )
                             # Reset the failure counter on success.
                             sub_fail_counts.pop(sub_key, None)
                         except Exception as exc:
@@ -4705,6 +4732,36 @@ class GatewayRunner:
                 thread_id=sub.get("thread_id") or "",
                 claimed_cursor=claimed_cursor,
                 old_cursor=old_cursor,
+            )
+        finally:
+            conn.close()
+
+    @staticmethod
+    def _kanban_send_message_id(send_result: Any) -> Optional[str]:
+        """Extract a platform message id from adapter.send() results."""
+        if send_result is None:
+            return None
+        msg_id = getattr(send_result, "message_id", None)
+        if msg_id is None and isinstance(send_result, dict):
+            msg_id = send_result.get("message_id")
+        return str(msg_id) if msg_id is not None else None
+
+    def _kanban_record_delivery_evidence(
+        self,
+        sub: dict,
+        payload: dict,
+        run_id: Optional[int] = None,
+        board: Optional[str] = None,
+    ) -> None:
+        """Sync helper: append a kanban notification delivery evidence event."""
+        from hermes_cli import kanban_db as _kb
+        conn = _kb.connect(board=board)
+        try:
+            _kb.record_notify_delivery_evidence(
+                conn,
+                sub["task_id"],
+                payload,
+                run_id=run_id,
             )
         finally:
             conn.close()

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4588,6 +4588,10 @@ class GatewayRunner:
                             send_result = await adapter.send(
                                 sub["chat_id"], msg, metadata=metadata,
                             )
+                            if self._kanban_send_result_failed(send_result):
+                                raise RuntimeError(
+                                    self._kanban_send_failure_error(send_result)
+                                )
                             logger.debug(
                                 "kanban notifier: delivered %s event for %s to %s/%s on board %s",
                                 kind, sub["task_id"], platform_str, sub["chat_id"], board_slug,
@@ -4735,6 +4739,24 @@ class GatewayRunner:
             )
         finally:
             conn.close()
+
+    @staticmethod
+    def _kanban_send_result_failed(send_result: Any) -> bool:
+        """Return True when adapter.send() explicitly reports non-delivery."""
+        if send_result is None:
+            return False
+        if isinstance(send_result, dict):
+            return send_result.get("success") is False
+        return getattr(send_result, "success", None) is False
+
+    @staticmethod
+    def _kanban_send_failure_error(send_result: Any) -> str:
+        """Extract a short adapter error from an explicit send failure result."""
+        if isinstance(send_result, dict):
+            error = send_result.get("error")
+        else:
+            error = getattr(send_result, "error", None)
+        return str(error or "adapter returned success=False")
 
     @staticmethod
     def _kanban_send_message_id(send_result: Any) -> Optional[str]:

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -4564,6 +4564,30 @@ def rewind_notify_cursor(
     return cur.rowcount > 0
 
 
+def record_notify_delivery_evidence(
+    conn: sqlite3.Connection,
+    task_id: str,
+    payload: dict,
+    *,
+    run_id: Optional[int] = None,
+) -> None:
+    """Persist gateway delivery evidence for a kanban notification receipt.
+
+    The gateway notifier uses this as an audit ledger for routine lifecycle
+    receipts. It intentionally writes a distinct event kind that is *not* in
+    the notifier's receipt set, so recording the evidence cannot recursively
+    trigger another outbound notification.
+    """
+    with write_txn(conn):
+        _append_event(
+            conn,
+            task_id,
+            "notify_delivery_evidence",
+            dict(payload or {}),
+            run_id=run_id,
+        )
+
+
 # ---------------------------------------------------------------------------
 # Retention + garbage collection
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_kanban_notifier.py
+++ b/tests/gateway/test_kanban_notifier.py
@@ -84,9 +84,10 @@ def test_kanban_notifier_dedupes_board_slugs_pointing_to_same_db(tmp_path, monke
 
     asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
 
-    assert len(adapter.sent) == 1
-    assert "Kanban" in adapter.sent[0]["text"]
-    assert tid in adapter.sent[0]["text"]
+    assert len(adapter.sent) == 2
+    assert "Kanban 已派单" in adapter.sent[0]["text"]
+    assert "Issue/任务完成" in adapter.sent[1]["text"]
+    assert all(tid in item["text"] for item in adapter.sent)
 
 
 def test_kanban_notifier_claim_prevents_second_watcher_send(tmp_path, monkeypatch):
@@ -102,7 +103,7 @@ def test_kanban_notifier_claim_prevents_second_watcher_send(tmp_path, monkeypatc
     asyncio.run(_run_one_notifier_tick(monkeypatch, _make_runner(adapter1)))
     asyncio.run(_run_one_notifier_tick(monkeypatch, _make_runner(adapter2)))
 
-    assert len(adapter1.sent) == 1
+    assert len(adapter1.sent) == 2
     assert adapter2.sent == []
 
 
@@ -203,9 +204,10 @@ def test_notifier_redelivers_same_kind_on_dispatch_cycle(tmp_path, monkeypatch):
     runner = _make_runner(adapter)
     asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
 
-    # First crash delivered.
-    assert len(adapter.sent) == 1
-    assert "crashed" in adapter.sent[0]["text"].lower()
+    # Initial assignment and first crash delivered.
+    assert len(adapter.sent) == 2
+    assert "Kanban 已派单" in adapter.sent[0]["text"]
+    assert "崩溃" in adapter.sent[1]["text"]
 
     # Subscription survives — the cursor advanced past event #1, but the
     # row is still there.
@@ -229,8 +231,39 @@ def test_notifier_redelivers_same_kind_on_dispatch_cycle(tmp_path, monkeypatch):
     runner = _make_runner(adapter)
     asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
 
-    assert len(adapter.sent) == 2, (
+    assert len(adapter.sent) == 3, (
         f"Second crashed event should also notify; got {len(adapter.sent)} "
         f"deliveries (texts: {[d['text'] for d in adapter.sent]})"
     )
-    assert "crashed" in adapter.sent[1]["text"].lower()
+    assert "崩溃" in adapter.sent[2]["text"]
+
+
+def test_kanban_notifier_sends_runtime_lifecycle_receipts(tmp_path, monkeypatch):
+    db_path = tmp_path / "runtime-lifecycle.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    kb.init_db()
+
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="runtime receipts", assignee="coder")
+        kb.add_notify_sub(conn, task_id=tid, platform="telegram", chat_id="chat-1")
+        kb.assign_task(conn, tid, "reviewer")
+        kb._append_event(conn, tid, "spawned", {"pid": 12345})
+        kb._append_event(conn, tid, "heartbeat", {"note": "halfway done"})
+        kb.complete_task(conn, tid, summary="finished handoff")
+    finally:
+        conn.close()
+
+    adapter = RecordingAdapter()
+    asyncio.run(_run_one_notifier_tick(monkeypatch, _make_runner(adapter)))
+
+    texts = [item["text"] for item in adapter.sent]
+    assert [text.splitlines()[0] for text in texts] == [
+        "📌 Kanban 已派单",
+        "📌 Kanban 已分配",
+        "▶️ Runtime 已开始",
+        "🔄 Runtime 进展",
+        "✅ Issue/任务完成",
+    ]
+    assert "@reviewer" in texts[-1]
+    assert "halfway done" in texts[3]

--- a/tests/gateway/test_kanban_notifier.py
+++ b/tests/gateway/test_kanban_notifier.py
@@ -1,9 +1,11 @@
 import asyncio
+import json
 from pathlib import Path
 
 import pytest
 
 from gateway.config import Platform
+from gateway.platforms.base import SendResult
 from gateway.run import GatewayRunner
 from hermes_cli import kanban_db as kb
 
@@ -14,6 +16,7 @@ class RecordingAdapter:
 
     async def send(self, chat_id, text, metadata=None):
         self.sent.append({"chat_id": chat_id, "text": text, "metadata": metadata or {}})
+        return SendResult(success=True, message_id=f"msg-{len(self.sent)}")
 
 
 class DisconnectedAdapters(dict):
@@ -267,3 +270,26 @@ def test_kanban_notifier_sends_runtime_lifecycle_receipts(tmp_path, monkeypatch)
     ]
     assert "@reviewer" in texts[-1]
     assert "halfway done" in texts[3]
+
+    conn = kb.connect()
+    try:
+        rows = conn.execute(
+            "SELECT payload FROM task_events "
+            "WHERE task_id = ? AND kind = 'notify_delivery_evidence' "
+            "ORDER BY id ASC",
+            (tid,),
+        ).fetchall()
+    finally:
+        conn.close()
+
+    assert len(rows) == 5
+    payloads = [json.loads(row["payload"]) for row in rows]
+    assert payloads[-1]["work_item_id"] == tid
+    assert payloads[-1]["task_id"] == tid
+    assert payloads[-1]["runtime_profile"] == "reviewer"
+    assert payloads[-1]["assignee"] == "reviewer"
+    assert payloads[-1]["notifier_profile"] == "default"
+    assert payloads[-1]["chat_id"] == "chat-1"
+    assert payloads[-1]["thread_id"] == ""
+    assert payloads[-1]["message_id"] == "msg-5"
+    assert payloads[-1]["source_event_kind"] == "completed"

--- a/tests/gateway/test_kanban_notifier.py
+++ b/tests/gateway/test_kanban_notifier.py
@@ -153,6 +153,17 @@ class FailingAdapter:
         raise RuntimeError("simulated send failure")
 
 
+class FailedResultAdapter:
+    """Adapter whose send() returns an explicit non-delivery result."""
+
+    def __init__(self):
+        self.attempts = 0
+
+    async def send(self, chat_id, text, metadata=None):
+        self.attempts += 1
+        return SendResult(success=False, error="simulated non-delivery")
+
+
 def test_kanban_notifier_rewinds_claim_on_send_exception(tmp_path, monkeypatch):
     """A raising adapter rewinds the claim so the next tick can retry.
 
@@ -176,6 +187,37 @@ def test_kanban_notifier_rewinds_claim_on_send_exception(tmp_path, monkeypatch):
     # still returns the event for retry on the next tick.
     assert adapter.attempts >= 1, "send should have been attempted at least once"
     assert [ev.kind for ev in _unseen_terminal_events(tid)] == ["completed"]
+
+
+def test_kanban_notifier_treats_failed_send_result_as_failed_delivery(tmp_path, monkeypatch):
+    """SendResult(success=False) must not ledger or advance as delivered."""
+    db_path = tmp_path / "failed-result.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    kb.init_db()
+    tid = _create_completed_subscription()
+
+    adapter = FailedResultAdapter()
+    runner = _make_runner(adapter)
+
+    asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
+
+    assert adapter.attempts >= 1, "send should have been attempted at least once"
+    assert [ev.kind for ev in _unseen_terminal_events(tid)] == ["completed"]
+
+    conn = kb.connect()
+    try:
+        evidence_rows = conn.execute(
+            "SELECT 1 FROM task_events "
+            "WHERE task_id = ? AND kind = 'notify_delivery_evidence'",
+            (tid,),
+        ).fetchall()
+        subs = kb.list_notify_subs(conn, tid)
+    finally:
+        conn.close()
+
+    assert evidence_rows == []
+    assert len(subs) == 1, "terminal subscription must not be removed on failed send"
+    assert runner._kanban_sub_fail_counts[(tid, "telegram", "chat-1", "")] == 1
 
 
 def test_notifier_redelivers_same_kind_on_dispatch_cycle(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- expands Kanban notifier subscriptions from terminal-only events to lightweight lifecycle receipts
- projects created/assigned/spawned/heartbeat/completed/blocked/crashed/timed_out into short runtime-owned Telegram messages
- adds coverage for runtime lifecycle receipt ordering and updates existing notifier expectations

## Test plan
- `python -m pytest tests/gateway/test_kanban_notifier.py tests/gateway/test_telegram_reactions.py -q -o 'addopts='`
- `git diff --check -- gateway/run.py tests/gateway/test_kanban_notifier.py`
- `python -m py_compile gateway/run.py tests/gateway/test_kanban_notifier.py`

KopaOS M15 reference: AZ80066/kopa-os#264
