### PR TITLE
fix(status): redact API keys when using --all

### DIFF
--- a/hermes_cli/status.py
+++ b/hermes_cli/status.py
@@ -163,12 +163,12 @@ def show_status(args):
             continue
         value = _resolve_env(env_ref)
         has_key = bool(value)
-        display = redact_key(value) if not show_all else value
+        display = redact_key(value)
         print(f"  {name:<12}  {check_mark(has_key)} {display}")
 
     from hermes_cli.auth import get_anthropic_key
     anthropic_value = get_anthropic_key()
-    anthropic_display = redact_key(anthropic_value) if not show_all else anthropic_value
+    anthropic_display = redact_key(anthropic_value)
     print(f"  {'Anthropic':<12}  {check_mark(bool(anthropic_value))} {anthropic_display}")
 
     # =========================================================================

--- a/tests/hermes_cli/test_status.py
+++ b/tests/hermes_cli/test_status.py
@@ -14,6 +14,20 @@ def test_show_status_includes_tavily_key(monkeypatch, capsys, tmp_path):
     assert "tvly...cdef" in output
 
 
+def test_show_status_all_redacts_api_keys(monkeypatch, capsys, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("OPENROUTER_API_KEY", "openrouter-test-secret-1234567890")
+    monkeypatch.setenv("TAVILY_API_KEY", "tavily-test-secret-1234567890")
+
+    show_status(SimpleNamespace(all=True, deep=False))
+
+    output = capsys.readouterr().out
+    assert "open...7890" in output
+    assert "tavi...7890" in output
+    assert "openrouter-test-secret-1234567890" not in output
+    assert "tavily-test-secret-1234567890" not in output
+
+
 def test_show_status_termux_gateway_section_skips_systemctl(monkeypatch, capsys, tmp_path):
     from hermes_cli import status as status_mod
     import hermes_cli.auth as auth_mod


### PR DESCRIPTION
## Summary
- keep API-key rows redacted in `hermes status --all`
- add regression coverage for expanded status output

## Why
`--all` expands diagnostic detail, but it should not reveal configured API key values. The status command already has `redact_key(...)`; this keeps that redaction in place for API-key rows even when `--all` is used.

## Test plan
- `PYTHONDONTWRITEBYTECODE=1 /home/shawn/.hermes/hermes-agent/venv/bin/python -m pytest tests/hermes_cli/test_status.py tests/hermes_cli/test_status_model_provider.py -q -o 'addopts='`
