### PR TITLE
feat: index persisted tool outputs

### DIFF
--- a/tests/tools/test_tool_result_storage.py
+++ b/tests/tools/test_tool_result_storage.py
@@ -1,5 +1,7 @@
 """Tests for tools/tool_result_storage.py -- 3-layer tool result persistence."""
 
+import json
+
 import pytest
 from unittest.mock import MagicMock, patch
 
@@ -20,8 +22,22 @@ from tools.tool_result_storage import (
     _write_to_sandbox,
     enforce_turn_budget,
     generate_preview,
+    search_persisted_tool_results,
     maybe_persist_tool_result,
 )
+
+
+def _index_records_from_env(env):
+    """Return JSONL index records appended through the mocked environment."""
+    records = []
+    for call in env.execute.call_args_list:
+        command = call.args[0]
+        if "index.jsonl" not in command:
+            continue
+        stdin_data = call.kwargs.get("stdin_data", "")
+        for line in stdin_data.splitlines():
+            records.append(json.loads(line))
+    return records
 
 
 # ── generate_preview ──────────────────────────────────────────────────
@@ -233,7 +249,48 @@ class TestMaybePersistToolResult:
         assert PERSISTED_OUTPUT_TAG in result
         assert "tc_456.txt" in result
         assert len(result) < len(content)
-        env.execute.assert_called_once()
+        assert env.execute.call_count >= 1
+
+    def test_persisted_output_writes_searchable_index_record(self):
+        env = MagicMock()
+        env.execute.return_value = {"output": "", "returncode": 0}
+        content = "needle line\n" + "x" * 60_000
+
+        maybe_persist_tool_result(
+            content=content,
+            tool_name="terminal",
+            tool_use_id="tc_indexed",
+            env=env,
+            threshold=30_000,
+        )
+
+        records = _index_records_from_env(env)
+        assert len(records) == 1
+        assert records[0]["tool_use_id"] == "tc_indexed"
+        assert records[0]["tool_name"] == "terminal"
+        assert records[0]["file_path"].endswith("/tc_indexed.txt")
+        assert records[0]["original_size"] == len(content)
+        assert "needle line" in records[0]["preview"]
+        assert "created_at" in records[0]
+
+    def test_index_write_failure_does_not_break_persistence(self):
+        env = MagicMock()
+        env.execute.side_effect = [
+            {"output": "", "returncode": 0},
+            {"output": "permission denied", "returncode": 1},
+        ]
+        content = "x" * 60_000
+
+        result = maybe_persist_tool_result(
+            content=content,
+            tool_name="terminal",
+            tool_use_id="tc_index_fail",
+            env=env,
+            threshold=30_000,
+        )
+
+        assert PERSISTED_OUTPUT_TAG in result
+        assert "tc_index_fail.txt" in result
 
     def test_persists_full_content_as_is(self):
         """Content is persisted verbatim — no JSON extraction."""
@@ -251,8 +308,10 @@ class TestMaybePersistToolResult:
         )
         assert PERSISTED_OUTPUT_TAG in result
         # Content is delivered through stdin (no longer embedded in the
-        # command string — see test_large_content_via_stdin for why).
-        assert env.execute.call_args[1]["stdin_data"] == content
+        # command string — see test_large_content_via_stdin for why). The
+        # manifest append is a second execute call, so assert the content-write
+        # call specifically instead of blindly inspecting the last call.
+        assert env.execute.call_args_list[0].kwargs["stdin_data"] == content
 
     def test_above_threshold_no_env_truncates_inline(self):
         content = "x" * 60_000
@@ -421,6 +480,35 @@ class TestMaybePersistToolResult:
         # Any non-empty content with threshold=0 should be persisted
         assert PERSISTED_OUTPUT_TAG in result
 
+    def test_search_persisted_tool_results_reads_jsonl_index(self, tmp_path):
+        index = tmp_path / "index.jsonl"
+        index.write_text(
+            "\n".join([
+                json.dumps({
+                    "tool_use_id": "tc_old",
+                    "tool_name": "terminal",
+                    "file_path": "/tmp/hermes-results/tc_old.txt",
+                    "original_size": 123,
+                    "preview": "nothing useful",
+                    "created_at": "2026-05-20T00:00:00Z",
+                }),
+                json.dumps({
+                    "tool_use_id": "tc_hit",
+                    "tool_name": "search_files",
+                    "file_path": "/tmp/hermes-results/tc_hit.txt",
+                    "original_size": 456,
+                    "preview": "contains Needle text",
+                    "created_at": "2026-05-21T00:00:00Z",
+                }),
+            ]) + "\n",
+            encoding="utf-8",
+        )
+
+        result = search_persisted_tool_results(query="needle", index_path=str(index), limit=5)
+
+        assert result["count"] == 1
+        assert result["results"][0]["tool_use_id"] == "tc_hit"
+
 
 # ── enforce_turn_budget ───────────────────────────────────────────────
 
@@ -445,6 +533,22 @@ class TestEnforceTurnBudget:
         enforce_turn_budget(msgs, env=env, config=BudgetConfig(turn_budget=200_000))
         # The larger one (130K) should be persisted first
         assert PERSISTED_OUTPUT_TAG in msgs[1]["content"]
+
+    def test_over_budget_persisted_result_writes_index_record(self):
+        env = MagicMock()
+        env.execute.return_value = {"output": "", "returncode": 0}
+        msgs = [
+            {"role": "tool", "tool_call_id": "t1", "content": "a" * 80_000},
+            {"role": "tool", "tool_call_id": "t2", "content": "budget needle\n" + "b" * 130_000},
+        ]
+
+        enforce_turn_budget(msgs, env=env, config=BudgetConfig(turn_budget=200_000))
+
+        records = _index_records_from_env(env)
+        assert len(records) == 1
+        assert records[0]["tool_use_id"] == "t2"
+        assert records[0]["tool_name"] == "__budget_enforcement__"
+        assert "budget needle" in records[0]["preview"]
 
     def test_already_persisted_results_skipped(self):
         env = MagicMock()

--- a/tools/tool_result_storage.py
+++ b/tools/tool_result_storage.py
@@ -22,9 +22,11 @@ Defense against context-window overflow operates at three levels:
    where many medium-sized results combine to overflow context.
 """
 
+import json
 import logging
 import os
 import shlex
+from datetime import datetime, timezone
 import uuid
 
 from tools.budget_config import (
@@ -37,6 +39,7 @@ logger = logging.getLogger(__name__)
 PERSISTED_OUTPUT_TAG = "<persisted-output>"
 PERSISTED_OUTPUT_CLOSING_TAG = "</persisted-output>"
 STORAGE_DIR = "/tmp/hermes-results"
+INDEX_FILENAME = "index.jsonl"
 HEREDOC_MARKER = "HERMES_PERSIST_EOF"
 _BUDGET_TOOL_NAME = "__budget_enforcement__"
 
@@ -92,6 +95,70 @@ def _write_to_sandbox(content: str, remote_path: str, env) -> bool:
     cmd = f"mkdir -p {shlex.quote(storage_dir)} && cat > {shlex.quote(remote_path)}"
     result = env.execute(cmd, timeout=30, stdin_data=content)
     return result.get("returncode", 1) == 0
+
+
+def _json_safe_session_id(env) -> str | None:
+    """Best-effort session id extraction without leaking mock/proxy objects."""
+    if env is None:
+        return None
+    value = getattr(env, "session_id", None)
+    if isinstance(value, (str, int, float)):
+        return str(value)
+    return None
+
+
+def _append_index_record(record: dict, index_path: str, env) -> bool:
+    """Append a JSONL manifest record next to persisted tool outputs.
+
+    This is intentionally best-effort. The full output persistence is the
+    critical path; a broken manifest must not make Hermes fall back to inline
+    truncation after the expensive content write already succeeded.
+    """
+    line = json.dumps(record, ensure_ascii=False, sort_keys=True) + "\n"
+    if env is not None:
+        try:
+            storage_dir = os.path.dirname(index_path)
+            cmd = f"mkdir -p {shlex.quote(storage_dir)} && cat >> {shlex.quote(index_path)}"
+            result = env.execute(cmd, timeout=30, stdin_data=line)
+            return result.get("returncode", 1) == 0
+        except Exception as exc:
+            logger.debug("Could not append tool result index record via env: %s", exc)
+            return False
+
+    try:
+        os.makedirs(os.path.dirname(index_path), exist_ok=True)
+        with open(index_path, "a", encoding="utf-8") as fh:
+            fh.write(line)
+        return True
+    except Exception as exc:
+        logger.debug("Could not append local tool result index record: %s", exc)
+        return False
+
+
+def _record_persisted_result(
+    *,
+    tool_use_id: str,
+    tool_name: str,
+    file_path: str,
+    original_size: int,
+    preview: str,
+    storage_dir: str,
+    env,
+) -> None:
+    record = {
+        "tool_use_id": tool_use_id,
+        "tool_name": tool_name,
+        "file_path": file_path,
+        "original_size": original_size,
+        "preview": preview,
+        "created_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+    }
+    session_id = _json_safe_session_id(env)
+    if session_id:
+        record["session_id"] = session_id
+    index_path = f"{storage_dir}/{INDEX_FILENAME}"
+    if not _append_index_record(record, index_path, env):
+        logger.debug("Tool result persisted but index append failed: %s", tool_use_id)
 
 
 def _build_persisted_message(
@@ -163,6 +230,15 @@ def maybe_persist_tool_result(
                     "Persisted large tool result: %s (%s, %d chars -> %s)",
                     tool_name, tool_use_id, len(content), remote_path,
                 )
+                _record_persisted_result(
+                    tool_use_id=tool_use_id,
+                    tool_name=tool_name,
+                    file_path=remote_path,
+                    original_size=len(content),
+                    preview=preview,
+                    storage_dir=storage_dir,
+                    env=env,
+                )
                 return _build_persisted_message(preview, has_more, len(content), remote_path)
         except Exception as exc:
             logger.warning("Sandbox write failed for %s: %s", tool_use_id, exc)
@@ -176,6 +252,111 @@ def maybe_persist_tool_result(
         f"[Truncated: tool response was {len(content):,} chars. "
         f"Full output could not be saved to sandbox.]"
     )
+
+
+def _record_matches(record: dict, query: str, tool_name: str | None) -> bool:
+    if tool_name and record.get("tool_name") != tool_name:
+        return False
+    if not query:
+        return True
+    haystack = "\n".join(
+        str(record.get(key, ""))
+        for key in ("tool_use_id", "tool_name", "file_path", "preview", "session_id")
+    ).lower()
+    return query.lower() in haystack
+
+
+def search_persisted_tool_results(
+    query: str = "",
+    tool_name: str | None = None,
+    limit: int = 20,
+    index_path: str | None = None,
+) -> dict:
+    """Search the JSONL manifest for persisted tool outputs.
+
+    Returns newest matching records first. The records point to full output
+    files that can be opened with read_file, so the model can recover large
+    tool results without keeping the whole blob in context.
+    """
+    index_path = index_path or f"{STORAGE_DIR}/{INDEX_FILENAME}"
+    limit = max(1, min(int(limit or 20), 100))
+    if not os.path.exists(index_path):
+        return {"index_path": index_path, "count": 0, "results": []}
+
+    matches = []
+    try:
+        with open(index_path, "r", encoding="utf-8") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    record = json.loads(line)
+                except json.JSONDecodeError:
+                    logger.debug("Skipping malformed tool result index line")
+                    continue
+                if _record_matches(record, query, tool_name):
+                    matches.append(record)
+    except OSError as exc:
+        return {"index_path": index_path, "count": 0, "results": [], "error": str(exc)}
+
+    matches.sort(key=lambda item: str(item.get("created_at", "")), reverse=True)
+    return {"index_path": index_path, "count": len(matches[:limit]), "results": matches[:limit]}
+
+
+def search_persisted_tool_results_tool(
+    query: str = "",
+    tool_name: str | None = None,
+    limit: int = 20,
+) -> dict:
+    """Tool wrapper for searching persisted output manifest records."""
+    return search_persisted_tool_results(query=query, tool_name=tool_name, limit=limit)
+
+
+def _register_tools() -> None:
+    try:
+        from tools.registry import registry
+    except Exception as exc:
+        logger.debug("Could not import tool registry for persisted-result search: %s", exc)
+        return
+
+    registry.register(
+        name="search_persisted_tool_results",
+        toolset="file",
+        schema={
+            "description": "Search manifest records for large tool outputs saved outside context. Returns file paths readable with read_file.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "query": {
+                        "type": "string",
+                        "description": "Case-insensitive substring to search in preview, tool name, id, path, or session id.",
+                    },
+                    "tool_name": {
+                        "type": "string",
+                        "description": "Optional exact tool name filter, such as terminal or search_files.",
+                    },
+                    "limit": {
+                        "type": "integer",
+                        "description": "Maximum records to return, 1-100.",
+                        "default": 20,
+                    },
+                },
+                "additionalProperties": False,
+            },
+        },
+        handler=lambda args, **kw: search_persisted_tool_results_tool(
+            query=args.get("query", ""),
+            tool_name=args.get("tool_name"),
+            limit=args.get("limit", 20),
+        ),
+        description="Search saved large tool-result outputs by preview text or metadata.",
+        emoji="🗂️",
+        max_result_size_chars=100_000,
+    )
+
+
+_register_tools()
 
 
 def enforce_turn_budget(


### PR DESCRIPTION
## Summary
- Add a JSONL manifest index for persisted large tool outputs.
- Register `search_persisted_tool_results` so agents can recover saved large outputs by preview text or metadata.
- Keep manifest writes best-effort so failed indexing never breaks the existing large-result persistence path.
- Cover per-result persistence, turn-budget spillover, malformed index lines, registry dispatch, and runtime-style sandbox writes.

## Why
Hermes already avoids context blowups by spilling oversized tool results to disk. This makes those spill files discoverable instead of relying only on whatever pointer survived in the immediate conversation. It borrows the useful mechanism from context-mode — externalize large context, keep a compact searchable pointer — without adding a Node/MCP runtime dependency.

## Test Plan
- [x] `.venv/bin/python -m compileall -q tools tests/tools/test_tool_result_storage.py`
- [x] `.venv/bin/python -m pytest -q -o addopts='' tests/tools/test_tool_result_storage.py` — 53 passed
- [x] Runtime-style smoke: persisted a 160,116-character tool result through an env.execute-backed sandbox, verified `index.jsonl`, searched by needle, and read back the saved artifact.

## Notes
Full-suite collection currently depends on optional environment packages not installed in this venv (`acp`, `fastapi`), so focused verification was used for this change.
