### PR TITLE
fix(config): fall back when ruamel is unavailable

### DIFF
--- a/tests/test_atomic_roundtrip_yaml_update.py
+++ b/tests/test_atomic_roundtrip_yaml_update.py
@@ -1,0 +1,57 @@
+"""Regression tests for dotted YAML config updates."""
+
+from __future__ import annotations
+
+import builtins
+import stat
+
+import yaml
+
+from utils import atomic_roundtrip_yaml_update
+
+
+def _block_ruamel_import(monkeypatch):
+    real_import = builtins.__import__
+
+    def block_ruamel(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "ruamel" or name.startswith("ruamel."):
+            raise ModuleNotFoundError("No module named 'ruamel'", name="ruamel")
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", block_ruamel)
+
+
+def test_atomic_roundtrip_yaml_update_falls_back_when_ruamel_missing(monkeypatch, tmp_path):
+    """Slash-command config toggles should still save without ruamel.yaml."""
+    _block_ruamel_import(monkeypatch)
+
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text("model:\n  default: test-model\n", encoding="utf-8")
+
+    atomic_roundtrip_yaml_update(config_path, "display.runtime_footer.enabled", True)
+
+    config = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    assert config["model"]["default"] == "test-model"
+    assert config["display"]["runtime_footer"]["enabled"] is True
+
+
+def test_atomic_roundtrip_yaml_update_fallback_creates_missing_file(monkeypatch, tmp_path):
+    _block_ruamel_import(monkeypatch)
+
+    config_path = tmp_path / "config.yaml"
+    atomic_roundtrip_yaml_update(config_path, "display.runtime_footer.enabled", True)
+
+    config = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    assert config == {"display": {"runtime_footer": {"enabled": True}}}
+
+
+def test_atomic_roundtrip_yaml_update_fallback_preserves_file_mode(monkeypatch, tmp_path):
+    _block_ruamel_import(monkeypatch)
+
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text("display:\n  skin: ares\n", encoding="utf-8")
+    config_path.chmod(0o640)
+
+    atomic_roundtrip_yaml_update(config_path, "display.runtime_footer.enabled", True)
+
+    assert stat.S_IMODE(config_path.stat().st_mode) == 0o640

--- a/utils.py
+++ b/utils.py
@@ -193,18 +193,47 @@ def atomic_roundtrip_yaml_update(
     key_path: str,
     value: Any,
 ) -> None:
-    """Update one dotted YAML key while preserving comments and readable text.
+    """Update one dotted YAML key while preserving comments when possible.
 
     This is intentionally narrower than :func:`atomic_yaml_write`: it is for
     user-edited config files where comments, ordering, quoting, and Unicode
     should survive a single setting mutation.  Writes still use the same temp
     file + fsync + atomic replace pattern.
-    """
-    from ruamel.yaml import YAML
-    from ruamel.yaml.comments import CommentedMap
 
+    ``ruamel.yaml`` is the preferred backend because it preserves comments, but
+    config persistence is too important to fail completely when a partial or
+    editable install is missing that dependency.  In that case, fall back to a
+    PyYAML update that still preserves existing keys, uses the same atomic-write
+    path, and leaves users with a working slash-command/config toggle.
+    """
     path = Path(path)
     path.parent.mkdir(parents=True, exist_ok=True)
+
+    try:
+        from ruamel.yaml import YAML  # type: ignore[import-not-found]
+        from ruamel.yaml.comments import CommentedMap  # type: ignore[import-not-found]
+    except ModuleNotFoundError as exc:
+        if exc.name and not exc.name.startswith("ruamel"):
+            raise
+        config: Any = {}
+        if path.exists():
+            with path.open("r", encoding="utf-8") as f:
+                config = yaml.safe_load(f) or {}
+        if not isinstance(config, dict):
+            config = dict(config)
+
+        current = config
+        keys = key_path.split(".")
+        for key in keys[:-1]:
+            next_value = current.get(key)
+            if not isinstance(next_value, dict):
+                next_value = {}
+                current[key] = next_value
+            current = next_value
+        current[keys[-1]] = value
+
+        atomic_yaml_write(path, config, default_flow_style=False, sort_keys=False)
+        return
 
     yaml_rt = YAML(typ="rt")
     yaml_rt.preserve_quotes = True


### PR DESCRIPTION
## Summary

- Adds a safe PyYAML fallback for `utils.atomic_roundtrip_yaml_update()` when `ruamel.yaml` is missing from the active runtime.
- Keeps the preferred `ruamel.yaml` path for comment/quote-preserving config edits.
- Preserves existing config keys and file mode in the fallback path, and still writes through the existing atomic YAML writer.
- Adds regression tests for the missing-`ruamel.yaml` case that affects slash-command config toggles such as `/footer on`.

## Context

This is a real config-persistence failure, not just a local typo. On current `main`, if `ruamel.yaml` is unavailable in the runtime, `save_config_value("display.runtime_footer.enabled", True)` returns `False` and `/footer on` reports that it failed to save.

There is already related upstream tracking for the same missing-dependency root cause in destructive slash-command persistence:

- Related: #27660
- Complements: #27679

This PR takes the fallback route: keep comment-preserving `ruamel.yaml` when available, but do not make core config toggles fail entirely if a partial/editable install is missing that dependency.

## Test plan

- Reproduced on current `main` in a source checkout where `ruamel.yaml` is missing:
  - `save_config_value("display.runtime_footer.enabled", True)` returned `False`
  - config remained unchanged
- Verified after this change:
  - `save_config_value("display.runtime_footer.enabled", True)` returned `True`
  - config gained `display.runtime_footer.enabled: true`
- Ran targeted regression tests:

```bash
HOME=/home/hehehe0803 scripts/run_tests.sh tests/test_atomic_roundtrip_yaml_update.py tests/gateway/test_runtime_footer.py -q
```

Result:

```text
28 passed in 1.20s
```

## Privacy / safety

- No secrets or local machine identifiers are included in the diff.
- The fallback uses `yaml.safe_load()` and the existing atomic write helper.
- The fallback intentionally does not preserve YAML comments; the preferred `ruamel.yaml` path still does that when available.
