### PR TITLE
fix(weixin): make iLink timeouts configurable

### DIFF
--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -83,10 +83,35 @@ EP_GET_UPLOAD_URL = "ilink/bot/getuploadurl"
 EP_GET_BOT_QR = "ilink/bot/get_bot_qrcode"
 EP_GET_QR_STATUS = "ilink/bot/get_qrcode_status"
 
-LONG_POLL_TIMEOUT_MS = 35_000
-API_TIMEOUT_MS = 15_000
-CONFIG_TIMEOUT_MS = 10_000
-QR_TIMEOUT_MS = 35_000
+
+def _env_int(name: str, default: int) -> int:
+    """Return a positive integer from the environment, or a safe default."""
+    raw = os.getenv(name)
+    if not raw:
+        return default
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        logger.warning("Invalid %s=%r; using default %s", name, raw, default)
+        return default
+    if value <= 0:
+        logger.warning("Invalid %s=%r; using default %s", name, raw, default)
+        return default
+    return value
+
+
+LONG_POLL_TIMEOUT_MS = _env_int("WEIXIN_LONG_POLL_TIMEOUT_MS", 35_000)
+API_TIMEOUT_MS = _env_int("WEIXIN_API_TIMEOUT_MS", 15_000)
+CONFIG_TIMEOUT_MS = _env_int("WEIXIN_CONFIG_TIMEOUT_MS", 10_000)
+QR_TIMEOUT_MS = _env_int("WEIXIN_QR_TIMEOUT_MS", 35_000)
+
+
+def _bounded_long_poll_timeout_ms(suggested_timeout: Any, current_timeout_ms: int) -> int:
+    """Apply iLink's suggested timeout without exceeding the local safety cap."""
+    if isinstance(suggested_timeout, int) and suggested_timeout > 0:
+        return min(suggested_timeout, LONG_POLL_TIMEOUT_MS)
+    return current_timeout_ms
+
 
 MAX_CONSECUTIVE_FAILURES = 3
 RETRY_DELAY_SECONDS = 2
@@ -1326,8 +1351,7 @@ class WeixinAdapter(BasePlatformAdapter):
                     timeout_ms=timeout_ms,
                 )
                 suggested_timeout = response.get("longpolling_timeout_ms")
-                if isinstance(suggested_timeout, int) and suggested_timeout > 0:
-                    timeout_ms = suggested_timeout
+                timeout_ms = _bounded_long_poll_timeout_ms(suggested_timeout, timeout_ms)
 
                 ret = response.get("ret", 0)
                 errcode = response.get("errcode", 0)

--- a/tests/gateway/test_weixin.py
+++ b/tests/gateway/test_weixin.py
@@ -27,6 +27,25 @@ def _make_adapter() -> WeixinAdapter:
     )
 
 
+class TestWeixinTimeoutConfig:
+    def test_env_int_reads_positive_integer(self, monkeypatch):
+        monkeypatch.setenv("WEIXIN_LONG_POLL_TIMEOUT_MS", "12000")
+
+        assert weixin._env_int("WEIXIN_LONG_POLL_TIMEOUT_MS", 35_000) == 12_000
+
+    def test_env_int_falls_back_for_invalid_values(self, monkeypatch):
+        monkeypatch.setenv("WEIXIN_LONG_POLL_TIMEOUT_MS", "not-an-int")
+
+        assert weixin._env_int("WEIXIN_LONG_POLL_TIMEOUT_MS", 35_000) == 35_000
+
+    def test_long_poll_suggestion_is_capped_by_local_timeout(self, monkeypatch):
+        monkeypatch.setattr(weixin, "LONG_POLL_TIMEOUT_MS", 12_000)
+
+        assert weixin._bounded_long_poll_timeout_ms(60_000, 12_000) == 12_000
+        assert weixin._bounded_long_poll_timeout_ms(5_000, 12_000) == 5_000
+        assert weixin._bounded_long_poll_timeout_ms("60000", 12_000) == 12_000
+
+
 class TestWeixinFormatting:
     def test_format_message_preserves_markdown(self):
         adapter = _make_adapter()


### PR DESCRIPTION
## Summary
- Make the Weixin/iLink long-poll, API, config, and QR timeout constants configurable via environment variables.
- Keep the current hard-coded defaults as safe fallbacks.
- Treat `WEIXIN_LONG_POLL_TIMEOUT_MS` as a local safety cap even if iLink later suggests a larger `longpolling_timeout_ms`, avoiding Cloudflare/iLink 522/524 noise on hosts that time out before the previous 35s poll window.
- Add regression coverage for env parsing and long-poll timeout capping.

## Context
Some iLink hosts return gateway/Cloudflare errors before the previous hard-coded 35s long-poll timeout. Local operators may already set `WEIXIN_LONG_POLL_TIMEOUT_MS=12000`, but the adapter previously ignored that env var and could later follow server-suggested timeout values above the local safety cap.

## Test plan
- `python -m pytest tests/gateway/test_weixin.py::TestWeixinTimeoutConfig -o 'addopts=' -q`
- `python -m pytest tests/gateway/test_weixin.py -o 'addopts=' -q`
