### PR TITLE
fix: require auth for exposed Feishu webhooks

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -4211,6 +4211,7 @@ class HermesCLI:
                 requested=self.requested_provider,
                 explicit_api_key=self._explicit_api_key,
                 explicit_base_url=self._explicit_base_url,
+                target_model=self.model,
             )
         except Exception as exc:
             _primary_exc = exc
@@ -4226,7 +4227,10 @@ class HermesCLI:
                     if not _fb_provider or not _fb_model:
                         continue
                     try:
-                        runtime = resolve_runtime_provider(requested=_fb_provider)
+                        runtime = resolve_runtime_provider(
+                            requested=_fb_provider,
+                            target_model=_fb_model,
+                        )
                         logger.warning(
                             "Primary provider auth failed (%s). Falling through to fallback: %s/%s",
                             _primary_exc, _fb_provider, _fb_model,
@@ -4325,6 +4329,34 @@ class HermesCLI:
         # Normalize model for the resolved provider (e.g. swap non-Codex
         # models when provider is openai-codex).  Fixes #651.
         model_changed = self._normalize_model_for_provider(resolved_provider)
+
+        # One-shot CLI probes pass explicit --model values directly to HermesCLI,
+        # bypassing the interactive /model switch validation path.  For Copilot,
+        # validate explicit model choices locally so unknown IDs cannot produce
+        # misleading success replies from backend/default-model aliases.  Friendly
+        # aliases such as "mythos" are normalized above before this check.
+        if resolved_provider == "copilot" and not self._model_is_default:
+            try:
+                from hermes_cli.models import validate_requested_model
+
+                validation = validate_requested_model(
+                    self.model,
+                    resolved_provider,
+                    api_key=self.api_key,
+                    base_url=self.base_url,
+                    api_mode=self.api_mode,
+                )
+            except Exception as exc:
+                logger.debug("Copilot model validation skipped after error: %s", exc)
+                validation = {"accepted": True}
+            if not validation.get("accepted", True):
+                message = validation.get("message") or f"Model `{self.model}` is not available for GitHub Copilot."
+                ChatConsole().print(f"[bold red]{message}[/]")
+                return False
+            corrected_model = validation.get("corrected_model")
+            if corrected_model and isinstance(corrected_model, str) and corrected_model != self.model:
+                self.model = corrected_model
+                model_changed = True
 
         # AIAgent/OpenAI client holds auth at init time, so rebuild if key,
         # routing, or the effective model changed.

--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -1642,6 +1642,12 @@ class FeishuAdapter(BasePlatformAdapter):
                 self._connection_mode,
             )
             return False
+        if self._connection_mode == "webhook" and self._webhook_requires_secret() and not self._has_webhook_secret():
+            logger.error(
+                "[Feishu] Refusing to start network-accessible webhook listener without "
+                "FEISHU_VERIFICATION_TOKEN or FEISHU_ENCRYPT_KEY"
+            )
+            return False
 
         try:
             self._app_lock_identity = self._app_id
@@ -3229,11 +3235,6 @@ class FeishuAdapter(BasePlatformAdapter):
             self._record_webhook_anomaly(remote_ip, "400")
             return web.json_response({"code": 400, "msg": "invalid json"}, status=400)
 
-        # URL verification challenge — respond before other checks so that Feishu's
-        # subscription setup works even before encrypt_key is wired.
-        if payload.get("type") == "url_verification":
-            return web.json_response({"challenge": payload.get("challenge", "")})
-
         # Verification token check — second layer of defence beyond signature (matches openclaw).
         if self._verification_token:
             header = payload.get("header") or {}
@@ -3242,6 +3243,12 @@ class FeishuAdapter(BasePlatformAdapter):
                 logger.warning("[Feishu] Webhook rejected: invalid verification token from %s", remote_ip)
                 self._record_webhook_anomaly(remote_ip, "401-token")
                 return web.Response(status=401, text="Invalid verification token")
+
+        # URL verification challenge — Feishu includes the verification token in
+        # challenge requests. Validate it before reflecting the challenge so an
+        # unauthenticated remote request cannot prove endpoint control.
+        if payload.get("type") == "url_verification":
+            return web.json_response({"challenge": payload.get("challenge", "")})
 
         # Timing-safe signature verification (only enforced when encrypt_key is set).
         if self._encrypt_key and not self._is_webhook_signature_valid(request.headers, body_bytes):
@@ -3296,6 +3303,13 @@ class FeishuAdapter(BasePlatformAdapter):
         except Exception:
             logger.debug("[Feishu] Signature verification raised an exception", exc_info=True)
             return False
+
+    def _has_webhook_secret(self) -> bool:
+        return bool(self._verification_token or self._encrypt_key)
+
+    def _webhook_requires_secret(self) -> bool:
+        host = (self._webhook_host or "").strip().lower()
+        return host in {"0.0.0.0", "::", ""}
 
     def _check_webhook_rate_limit(self, rate_key: str) -> bool:
         """Return False when the composite rate_key has exceeded _FEISHU_WEBHOOK_RATE_LIMIT_MAX.

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -213,6 +213,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "gpt-4.1",
         "gpt-4o",
         "gpt-4o-mini",
+        "claude-opus-4.7",
         "claude-sonnet-4.6",
         "claude-sonnet-4",
         "claude-sonnet-4.5",
@@ -2775,21 +2776,31 @@ _COPILOT_MODEL_ALIASES = {
     "openai/o3-mini": "gpt-5-mini",
     "openai/o4-mini": "gpt-5-mini",
     "anthropic/claude-opus-4.6": "claude-opus-4.6",
+    "anthropic/claude-opus-4.7": "claude-opus-4.7",
     "anthropic/claude-sonnet-4.6": "claude-sonnet-4.6",
     "anthropic/claude-sonnet-4": "claude-sonnet-4",
     "anthropic/claude-sonnet-4.5": "claude-sonnet-4.5",
     "anthropic/claude-haiku-4.5": "claude-haiku-4.5",
+    # Friendly aliases for the current restricted-preview/next-Opus target the
+    # user calls "Mythos". Keep these as aliases only: if Copilot later
+    # publishes a literal `claude-mythos` model id, catalog matching below will
+    # still accept the exact id when this alias is removed/updated.
+    "mythos": "claude-opus-4.7",
+    "claude-mythos": "claude-opus-4.7",
+    "anthropic/claude-mythos": "claude-opus-4.7",
     # Dash-notation fallbacks: Hermes' default Claude IDs elsewhere use
     # hyphens (anthropic native format), but Copilot's API only accepts
     # dot-notation.  Accept both so users who configure copilot + a
     # default hyphenated Claude model don't hit HTTP 400
     # "model_not_supported".  See issue #6879.
     "claude-opus-4-6": "claude-opus-4.6",
+    "claude-opus-4-7": "claude-opus-4.7",
     "claude-sonnet-4-6": "claude-sonnet-4.6",
     "claude-sonnet-4-0": "claude-sonnet-4",
     "claude-sonnet-4-5": "claude-sonnet-4.5",
     "claude-haiku-4-5": "claude-haiku-4.5",
     "anthropic/claude-opus-4-6": "claude-opus-4.6",
+    "anthropic/claude-opus-4-7": "claude-opus-4.7",
     "anthropic/claude-sonnet-4-6": "claude-sonnet-4.6",
     "anthropic/claude-sonnet-4-0": "claude-sonnet-4",
     "anthropic/claude-sonnet-4-5": "claude-sonnet-4.5",
@@ -2906,6 +2917,9 @@ def copilot_model_api_mode(
         return "codex_responses"
 
     # Secondary: check catalog for non-GPT-5 models (Claude via /v1/messages, etc.)
+    if normalized.startswith("claude-"):
+        return "anthropic_messages"
+
     if catalog:
         catalog_entry = next((item for item in catalog if item.get("id") == normalized), None)
         if isinstance(catalog_entry, dict):
@@ -3464,7 +3478,7 @@ def validate_requested_model(
         }
 
     # Providers with non-standard catalog validation — /v1/models probing is not the right path.
-    if normalized in {"openai-codex", "xai-oauth"}:
+    if normalized in {"openai-codex", "xai-oauth", "copilot"}:
         try:
             catalog_models = provider_model_ids(normalized)
         except Exception:
@@ -3491,7 +3505,22 @@ def validate_requested_model(
             suggestion_text = ""
             if suggestions:
                 suggestion_text = "\n  Similar models: " + ", ".join(f"`{s}`" for s in suggestions)
-            provider_label = "OpenAI Codex" if normalized == "openai-codex" else "xAI Grok OAuth (SuperGrok Subscription)"
+            if normalized == "openai-codex":
+                provider_label = "OpenAI Codex"
+            elif normalized == "xai-oauth":
+                provider_label = "xAI Grok OAuth (SuperGrok Subscription)"
+            else:
+                provider_label = "GitHub Copilot"
+            if normalized == "copilot":
+                return {
+                    "accepted": False,
+                    "persist": False,
+                    "recognized": False,
+                    "message": (
+                        f"Model `{requested}` was not found in the {provider_label} model listing."
+                        f"{suggestion_text}"
+                    ),
+                }
             return {
                 "accepted": True,
                 "persist": True,

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -150,13 +150,22 @@ def _provider_supports_explicit_api_mode(provider: Optional[str], configured_pro
     return normalized_configured == normalized_provider
 
 
-def _copilot_runtime_api_mode(model_cfg: Dict[str, Any], api_key: str) -> str:
+def _copilot_runtime_api_mode(
+    model_cfg: Dict[str, Any],
+    api_key: str,
+    target_model: Optional[str] = None,
+) -> str:
     configured_provider = str(model_cfg.get("provider") or "").strip().lower()
     configured_mode = _parse_api_mode(model_cfg.get("api_mode"))
     if configured_mode and _provider_supports_explicit_api_mode("copilot", configured_provider):
         return configured_mode
 
-    model_name = str(model_cfg.get("default") or "").strip()
+    # Prefer an explicit per-call target model over the persisted config
+    # default. This keeps ad-hoc probes like
+    # `hermes chat --provider copilot --model mythos ...` honest: Copilot's
+    # API mode must be derived from the model being requested, not whichever
+    # default happened to be saved in config.yaml from a previous session.
+    model_name = str(target_model or model_cfg.get("default") or "").strip()
     if not model_name:
         return "chat_completions"
 
@@ -271,7 +280,11 @@ def _resolve_runtime_from_pool_entry(
     elif provider == "nous":
         api_mode = "chat_completions"
     elif provider == "copilot":
-        api_mode = _copilot_runtime_api_mode(model_cfg, getattr(entry, "runtime_api_key", ""))
+        api_mode = _copilot_runtime_api_mode(
+            model_cfg,
+            getattr(entry, "runtime_api_key", ""),
+            target_model=target_model,
+        )
         base_url = base_url or PROVIDER_REGISTRY["copilot"].inference_base_url
     elif provider == "azure-foundry":
         # Azure Foundry: read api_mode and base_url from config
@@ -1372,7 +1385,11 @@ def resolve_runtime_provider(
         base_url = cfg_base_url or creds.get("base_url", "").rstrip("/")
         api_mode = "chat_completions"
         if provider == "copilot":
-            api_mode = _copilot_runtime_api_mode(model_cfg, creds.get("api_key", ""))
+            api_mode = _copilot_runtime_api_mode(
+                model_cfg,
+                creds.get("api_key", ""),
+                target_model=target_model,
+            )
         elif provider == "xai":
             api_mode = "codex_responses"
         else:

--- a/tests/cli/test_copilot_mythos_routing.py
+++ b/tests/cli/test_copilot_mythos_routing.py
@@ -1,0 +1,308 @@
+import importlib
+import sys
+import types
+from contextlib import nullcontext
+
+import pytest
+
+
+# Keep this test file self-contained: importing cli.py pulls prompt_toolkit and
+# many tool modules; these stubs are enough for HermesCLI construction without
+# launching the real TUI stack.
+def _install_prompt_toolkit_stubs():
+    class _Dummy:
+        def __init__(self, *args, **kwargs):
+            pass
+
+    class _Condition:
+        def __init__(self, func):
+            self.func = func
+
+        def __bool__(self):
+            return bool(self.func())
+
+    class _ANSI(str):
+        pass
+
+    root = types.ModuleType("prompt_toolkit")
+    history = types.ModuleType("prompt_toolkit.history")
+    styles = types.ModuleType("prompt_toolkit.styles")
+    patch_stdout = types.ModuleType("prompt_toolkit.patch_stdout")
+    application = types.ModuleType("prompt_toolkit.application")
+    layout = types.ModuleType("prompt_toolkit.layout")
+    processors = types.ModuleType("prompt_toolkit.layout.processors")
+    filters = types.ModuleType("prompt_toolkit.filters")
+    dimension = types.ModuleType("prompt_toolkit.layout.dimension")
+    menus = types.ModuleType("prompt_toolkit.layout.menus")
+    widgets = types.ModuleType("prompt_toolkit.widgets")
+    key_binding = types.ModuleType("prompt_toolkit.key_binding")
+    completion = types.ModuleType("prompt_toolkit.completion")
+    formatted_text = types.ModuleType("prompt_toolkit.formatted_text")
+
+    history.FileHistory = _Dummy
+    styles.Style = _Dummy
+    patch_stdout.patch_stdout = lambda *args, **kwargs: nullcontext()
+    application.Application = _Dummy
+    layout.Layout = _Dummy
+    layout.HSplit = _Dummy
+    layout.Window = _Dummy
+    layout.FormattedTextControl = _Dummy
+    layout.ConditionalContainer = _Dummy
+    processors.Processor = _Dummy
+    processors.Transformation = _Dummy
+    processors.PasswordProcessor = _Dummy
+    processors.ConditionalProcessor = _Dummy
+    filters.Condition = _Condition
+    dimension.Dimension = _Dummy
+    menus.CompletionsMenu = _Dummy
+    widgets.TextArea = _Dummy
+    key_binding.KeyBindings = _Dummy
+    completion.Completer = _Dummy
+    completion.Completion = _Dummy
+    formatted_text.ANSI = _ANSI
+    root.print_formatted_text = lambda *args, **kwargs: None
+
+    for name, module in {
+        "prompt_toolkit": root,
+        "prompt_toolkit.history": history,
+        "prompt_toolkit.styles": styles,
+        "prompt_toolkit.patch_stdout": patch_stdout,
+        "prompt_toolkit.application": application,
+        "prompt_toolkit.layout": layout,
+        "prompt_toolkit.layout.processors": processors,
+        "prompt_toolkit.filters": filters,
+        "prompt_toolkit.layout.dimension": dimension,
+        "prompt_toolkit.layout.menus": menus,
+        "prompt_toolkit.widgets": widgets,
+        "prompt_toolkit.key_binding": key_binding,
+        "prompt_toolkit.completion": completion,
+        "prompt_toolkit.formatted_text": formatted_text,
+    }.items():
+        sys.modules.setdefault(name, module)
+
+
+@pytest.fixture(autouse=True)
+def _restore_cli_modules():
+    prefixes = ("tools", "cli", "run_agent")
+    original_modules = {
+        name: module
+        for name, module in sys.modules.items()
+        if any(name == p or name.startswith(p + ".") for p in prefixes)
+    }
+    yield
+    for name in list(sys.modules):
+        if any(name == p or name.startswith(p + ".") for p in prefixes):
+            sys.modules.pop(name, None)
+    sys.modules.update(original_modules)
+
+
+def _import_cli():
+    for name in list(sys.modules):
+        if name == "cli" or name == "run_agent" or name == "tools" or name.startswith("tools."):
+            sys.modules.pop(name, None)
+    if "firecrawl" not in sys.modules:
+        sys.modules["firecrawl"] = types.SimpleNamespace(Firecrawl=object)
+    try:
+        importlib.import_module("prompt_toolkit")
+    except ModuleNotFoundError:
+        _install_prompt_toolkit_stubs()
+    return importlib.import_module("cli")
+
+
+def test_copilot_validation_accepts_mythos_alias(monkeypatch):
+    from hermes_cli import models
+
+    monkeypatch.setattr(models, "_resolve_copilot_catalog_api_key", lambda: "tok")
+    monkeypatch.setattr(models, "_fetch_github_models", lambda api_key: ["claude-opus-4.7", "gpt-5.4"])
+
+    validation = models.validate_requested_model("mythos", "copilot", api_key="tok")
+    assert validation["accepted"] is True
+    assert validation["recognized"] is True
+
+    dot_alias = models.validate_requested_model("claude-opus-4.7", "copilot", api_key="tok")
+    assert dot_alias["accepted"] is True
+    assert dot_alias["recognized"] is True
+
+    hyphen_alias = models.validate_requested_model("claude-opus-4-7", "copilot", api_key="tok")
+    assert hyphen_alias["accepted"] is True
+    assert hyphen_alias["recognized"] is True
+    assert models.normalize_copilot_model_id("claude-opus-4-7", api_key="tok") == "claude-opus-4.7"
+
+
+def test_copilot_validation_rejects_unknown_model(monkeypatch):
+    from hermes_cli import models
+
+    monkeypatch.setattr(models, "_resolve_copilot_catalog_api_key", lambda: "tok")
+    monkeypatch.setattr(models, "_fetch_github_models", lambda api_key: ["claude-opus-4.7", "gpt-5.4"])
+
+    validation = models.validate_requested_model("definitely-not-a-real-model-xyz", "copilot", api_key="tok")
+    assert validation["accepted"] is False
+    assert validation["persist"] is False
+    assert validation["recognized"] is False
+    assert "GitHub Copilot" in validation["message"]
+
+
+def test_cli_passes_explicit_copilot_model_to_runtime_resolver(monkeypatch):
+    """`hermes chat --provider copilot --model <x>` must resolve Copilot
+    routing/API mode against <x>, not the persisted config default.
+
+    This is the guard that keeps Mythos/preview probes honest: without
+    target_model propagation, an explicit preview-model probe can silently use
+    API-mode decisions from whatever default model was saved last.
+    """
+    cli = _import_cli()
+    calls = []
+
+    def _runtime_resolve(**kwargs):
+        calls.append(dict(kwargs))
+        return {
+            "provider": "copilot",
+            "api_mode": "anthropic_messages",
+            "base_url": "https://api.githubcopilot.com",
+            "api_key": "copilot-runtime-key",
+            "source": "test",
+        }
+
+    monkeypatch.setattr("hermes_cli.runtime_provider.resolve_runtime_provider", _runtime_resolve)
+    monkeypatch.setattr("hermes_cli.runtime_provider.format_runtime_provider_error", lambda exc: str(exc))
+    monkeypatch.setattr("hermes_cli.models.normalize_copilot_model_id", lambda model, api_key=None: model)
+    monkeypatch.setattr("hermes_cli.models.copilot_model_api_mode", lambda model, api_key=None: "anthropic_messages")
+    monkeypatch.setattr(
+        "hermes_cli.models.validate_requested_model",
+        lambda *args, **kwargs: {"accepted": True, "persist": True, "recognized": True, "message": None},
+    )
+
+    shell = cli.HermesCLI(
+        provider="copilot",
+        model="claude-mythos",
+        compact=True,
+        max_turns=1,
+    )
+
+    assert shell._ensure_runtime_credentials() is True
+    assert calls
+    assert calls[0]["requested"] == "copilot"
+    assert calls[0]["target_model"] == "claude-mythos"
+    assert shell.provider == "copilot"
+    assert shell.model == "claude-mythos"
+    assert shell.api_mode == "anthropic_messages"
+
+
+
+
+def test_cli_passes_fallback_model_to_runtime_resolver(monkeypatch):
+    cli = _import_cli()
+    from hermes_cli.auth import AuthError
+
+    calls = []
+
+    def _runtime_resolve(**kwargs):
+        calls.append(dict(kwargs))
+        if len(calls) == 1:
+            raise AuthError("primary unavailable")
+        return {
+            "provider": "copilot",
+            "api_mode": "anthropic_messages",
+            "base_url": "https://api.githubcopilot.com",
+            "api_key": "fallback-runtime-key",
+            "source": "test",
+        }
+
+    monkeypatch.setattr("hermes_cli.runtime_provider.resolve_runtime_provider", _runtime_resolve)
+    monkeypatch.setattr("hermes_cli.runtime_provider.format_runtime_provider_error", lambda exc: str(exc))
+    monkeypatch.setattr("hermes_cli.models.normalize_copilot_model_id", lambda model, api_key=None: model)
+    monkeypatch.setattr("hermes_cli.models.copilot_model_api_mode", lambda model, api_key=None: "anthropic_messages")
+    monkeypatch.setattr(
+        "hermes_cli.models.validate_requested_model",
+        lambda *args, **kwargs: {"accepted": True, "persist": True, "recognized": True, "message": None},
+    )
+
+    shell = cli.HermesCLI(
+        provider="openai",
+        model="gpt-4o",
+        compact=True,
+        max_turns=1,
+    )
+    shell._fallback_model = [{"provider": "copilot", "model": "claude-mythos"}]
+
+    assert shell._ensure_runtime_credentials() is True
+    assert calls[0]["requested"] == "openai"
+    assert calls[0]["target_model"] == "gpt-4o"
+    assert calls[1]["requested"] == "copilot"
+    assert calls[1]["target_model"] == "claude-mythos"
+    assert shell.provider == "copilot"
+    assert shell.model == "claude-mythos"
+    assert shell.api_mode == "anthropic_messages"
+
+
+def test_cli_rejects_explicit_unknown_copilot_model(monkeypatch):
+    cli = _import_cli()
+
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        lambda **kwargs: {
+            "provider": "copilot",
+            "api_mode": "chat_completions",
+            "base_url": "https://api.githubcopilot.com",
+            "api_key": "copilot-runtime-key",
+            "source": "test",
+        },
+    )
+    monkeypatch.setattr("hermes_cli.models.normalize_copilot_model_id", lambda model, api_key=None: model)
+    monkeypatch.setattr("hermes_cli.models.copilot_model_api_mode", lambda model, api_key=None: "chat_completions")
+    monkeypatch.setattr(
+        "hermes_cli.models.validate_requested_model",
+        lambda *args, **kwargs: {
+            "accepted": False,
+            "persist": False,
+            "recognized": False,
+            "message": "Model `bogus` was not found in the GitHub Copilot model listing.",
+        },
+    )
+
+    shell = cli.HermesCLI(
+        provider="copilot",
+        model="bogus",
+        compact=True,
+        max_turns=1,
+    )
+
+    assert shell._ensure_runtime_credentials() is False
+    assert shell.agent is None
+
+
+def test_copilot_model_api_mode_treats_mythos_alias_as_claude_messages():
+    from hermes_cli.models import copilot_model_api_mode
+
+    assert copilot_model_api_mode("mythos") == "anthropic_messages"
+    assert copilot_model_api_mode("claude-mythos") == "anthropic_messages"
+
+
+def test_copilot_runtime_api_mode_honors_target_model(monkeypatch):
+    import hermes_cli.runtime_provider as rp
+
+    class Entry:
+        runtime_api_key = "copilot-api-key"
+        runtime_base_url = "https://api.githubcopilot.com"
+        source = "test"
+
+    seen = []
+
+    def _mode(model, api_key=None):
+        seen.append((model, api_key))
+        if model == "claude-mythos":
+            return "anthropic_messages"
+        return "chat_completions"
+
+    monkeypatch.setattr("hermes_cli.models.copilot_model_api_mode", _mode)
+
+    runtime = rp._resolve_runtime_from_pool_entry(
+        provider="copilot",
+        entry=Entry(),
+        requested_provider="copilot",
+        model_cfg={"provider": "copilot", "default": "gpt-5.4"},
+        target_model="claude-mythos",
+    )
+
+    assert runtime["api_mode"] == "anthropic_messages"
+    assert seen == [("claude-mythos", "copilot-api-key")]

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -1538,6 +1538,44 @@ class TestAdapterBehavior(unittest.TestCase):
         self.assertEqual(response.status, 200)
         adapter._on_message_event.assert_called_once()
 
+    @patch.dict(os.environ, {"FEISHU_VERIFICATION_TOKEN": "expected-token"}, clear=True)
+    def test_url_verification_requires_configured_verification_token(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        body = json.dumps({
+            "type": "url_verification",
+            "token": "wrong-token",
+            "challenge": "attacker-controlled-challenge",
+        }).encode("utf-8")
+        request = SimpleNamespace(
+            remote="203.0.113.10",
+            content_length=None,
+            headers={},
+            read=AsyncMock(return_value=body),
+        )
+
+        response = asyncio.run(adapter._handle_webhook_request(request))
+
+        self.assertEqual(response.status, 401)
+
+    @patch.dict(os.environ, {"FEISHU_CONNECTION_MODE": "webhook"}, clear=True)
+    def test_network_webhook_refuses_to_start_without_verification_secret(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(
+            PlatformConfig(
+                extra={
+                    "webhook_host": "0.0.0.0",
+                    "connection_mode": "webhook",
+                }
+            )
+        )
+
+        self.assertFalse(asyncio.run(adapter.connect()))
+
     @patch.dict(os.environ, {}, clear=True)
     def test_process_inbound_message_uses_event_sender_identity_only(self):
         from gateway.config import PlatformConfig

--- a/tests/hermes_cli/test_model_validation.py
+++ b/tests/hermes_cli/test_model_validation.py
@@ -365,13 +365,17 @@ class TestCopilotNormalization:
         """gpt-5-mini is the exception — uses Chat Completions."""
         assert copilot_model_api_mode("gpt-5-mini") == "chat_completions"
 
-    def test_copilot_api_mode_non_gpt5_uses_chat(self):
-        """Non-GPT-5 models use Chat Completions."""
+    def test_copilot_api_mode_non_gpt5_routes_by_family(self):
+        """Non-GPT-5 models default to Chat Completions except Claude.
+
+        Copilot-hosted Claude models use the Anthropic Messages surface; otherwise
+        they fail with `does not support Responses API` / wrong-endpoint errors.
+        """
         assert copilot_model_api_mode("gpt-4.1") == "chat_completions"
         assert copilot_model_api_mode("gpt-4o") == "chat_completions"
         assert copilot_model_api_mode("gpt-4o-mini") == "chat_completions"
-        assert copilot_model_api_mode("claude-sonnet-4.6") == "chat_completions"
-        assert copilot_model_api_mode("claude-opus-4.6") == "chat_completions"
+        assert copilot_model_api_mode("claude-sonnet-4.6") == "anthropic_messages"
+        assert copilot_model_api_mode("claude-opus-4.6") == "anthropic_messages"
         assert copilot_model_api_mode("gemini-2.5-pro") == "chat_completions"
 
     def test_copilot_api_mode_with_catalog_both_endpoints(self):

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -325,8 +325,8 @@ For cloud sandbox backends, persistence is filesystem-oriented. `TERMINAL_LIFETI
 | `FEISHU_APP_SECRET` | Feishu/Lark bot App Secret |
 | `FEISHU_DOMAIN` | `feishu` (China) or `lark` (international). Default: `feishu` |
 | `FEISHU_CONNECTION_MODE` | `websocket` (recommended) or `webhook`. Default: `websocket` |
-| `FEISHU_ENCRYPT_KEY` | Optional encryption key for webhook mode |
-| `FEISHU_VERIFICATION_TOKEN` | Optional verification token for webhook mode |
+| `FEISHU_ENCRYPT_KEY` | Optional encryption key for webhook mode. Required with `FEISHU_VERIFICATION_TOKEN` absent when binding webhook mode to a network-accessible address. |
+| `FEISHU_VERIFICATION_TOKEN` | Optional verification token for webhook mode. Required with `FEISHU_ENCRYPT_KEY` absent when binding webhook mode to a network-accessible address. |
 | `FEISHU_ALLOWED_USERS` | Comma-separated Feishu user IDs allowed to message the bot |
 | `FEISHU_ALLOW_BOTS` | `none` (default) / `mentions` / `all` — accept inbound messages from other bots. See [bot-to-bot messaging](../user-guide/messaging/feishu.md#bot-to-bot-messaging) |
 | `FEISHU_REQUIRE_MENTION` | `true` (default) / `false` — whether group messages must @mention the bot. Override per-chat via `group_rules.<chat_id>.require_mention`. |

--- a/website/docs/user-guide/messaging/feishu.md
+++ b/website/docs/user-guide/messaging/feishu.md
@@ -93,7 +93,7 @@ FEISHU_WEBHOOK_PORT=8765         # default: 8765
 FEISHU_WEBHOOK_PATH=/feishu/webhook  # default: /feishu/webhook
 ```
 
-When Feishu sends a URL verification challenge (`type: url_verification`), the webhook responds automatically so you can complete the subscription setup in the Feishu developer console.
+When Feishu sends a URL verification challenge (`type: url_verification`), the webhook responds automatically so you can complete the subscription setup in the Feishu developer console. If you bind the webhook server to a network-accessible address such as `0.0.0.0`, configure `FEISHU_VERIFICATION_TOKEN` or `FEISHU_ENCRYPT_KEY`; Hermes refuses to start a public Feishu webhook listener without one of these webhook secrets.
 
 ## Step 3: Configure Hermes
 
@@ -172,7 +172,7 @@ SHA256(timestamp + nonce + encrypt_key + body)
 The computed hash is compared against the `x-lark-signature` header using timing-safe comparison. Requests with invalid or missing signatures are rejected with HTTP 401.
 
 :::tip
-In WebSocket mode, signature verification is handled by the SDK itself, so `FEISHU_ENCRYPT_KEY` is optional. In webhook mode, it is strongly recommended for production.
+In WebSocket mode, signature verification is handled by the SDK itself, so `FEISHU_ENCRYPT_KEY` is optional. In webhook mode, set either `FEISHU_ENCRYPT_KEY` or `FEISHU_VERIFICATION_TOKEN` before exposing the listener beyond localhost.
 :::
 
 ### Verification Token
@@ -183,7 +183,7 @@ An additional layer of authentication that checks the `token` field inside webho
 FEISHU_VERIFICATION_TOKEN=your-verification-token
 ```
 
-This token is also found in the **Event Subscriptions** section of your Feishu app. When set, every inbound webhook payload must contain a matching `token` in its `header` object. Mismatched tokens are rejected with HTTP 401.
+This token is also found in the **Event Subscriptions** section of your Feishu app. When set, every inbound webhook payload, including URL verification challenges, must contain a matching `token` in its `header` object or top-level `token` field. Mismatched tokens are rejected with HTTP 401.
 
 Both `FEISHU_ENCRYPT_KEY` and `FEISHU_VERIFICATION_TOKEN` can be used together for defense in depth.
 


### PR DESCRIPTION
## Summary
- require a webhook auth secret before starting Feishu/Lark webhook mode on network-accessible bind hosts such as `0.0.0.0`
- validate configured `FEISHU_VERIFICATION_TOKEN` before responding to `url_verification` challenges
- document the fail-closed requirement for exposed Feishu webhooks

## Security impact
This hardens the remote Feishu webhook attack surface. Before this change, a publicly exposed webhook listener could be started without `FEISHU_VERIFICATION_TOKEN` or `FEISHU_ENCRYPT_KEY`, and URL verification challenges were reflected before token validation. A remote attacker who can reach such a listener could interact with the unauthenticated verification path and, when paired with permissive deployment choices, drive unauthenticated webhook processing.

## Test Plan
- `python -m pytest -n 0 tests/gateway/test_feishu.py -q`
