### PR TITLE
fix: require auth for exposed Feishu webhooks

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -1642,6 +1642,12 @@ class FeishuAdapter(BasePlatformAdapter):
                 self._connection_mode,
             )
             return False
+        if self._connection_mode == "webhook" and self._webhook_requires_secret() and not self._has_webhook_secret():
+            logger.error(
+                "[Feishu] Refusing to start network-accessible webhook listener without "
+                "FEISHU_VERIFICATION_TOKEN or FEISHU_ENCRYPT_KEY"
+            )
+            return False
 
         try:
             self._app_lock_identity = self._app_id
@@ -3229,11 +3235,6 @@ class FeishuAdapter(BasePlatformAdapter):
             self._record_webhook_anomaly(remote_ip, "400")
             return web.json_response({"code": 400, "msg": "invalid json"}, status=400)
 
-        # URL verification challenge — respond before other checks so that Feishu's
-        # subscription setup works even before encrypt_key is wired.
-        if payload.get("type") == "url_verification":
-            return web.json_response({"challenge": payload.get("challenge", "")})
-
         # Verification token check — second layer of defence beyond signature (matches openclaw).
         if self._verification_token:
             header = payload.get("header") or {}
@@ -3242,6 +3243,12 @@ class FeishuAdapter(BasePlatformAdapter):
                 logger.warning("[Feishu] Webhook rejected: invalid verification token from %s", remote_ip)
                 self._record_webhook_anomaly(remote_ip, "401-token")
                 return web.Response(status=401, text="Invalid verification token")
+
+        # URL verification challenge — Feishu includes the verification token in
+        # challenge requests. Validate it before reflecting the challenge so an
+        # unauthenticated remote request cannot prove endpoint control.
+        if payload.get("type") == "url_verification":
+            return web.json_response({"challenge": payload.get("challenge", "")})
 
         # Timing-safe signature verification (only enforced when encrypt_key is set).
         if self._encrypt_key and not self._is_webhook_signature_valid(request.headers, body_bytes):
@@ -3296,6 +3303,13 @@ class FeishuAdapter(BasePlatformAdapter):
         except Exception:
             logger.debug("[Feishu] Signature verification raised an exception", exc_info=True)
             return False
+
+    def _has_webhook_secret(self) -> bool:
+        return bool(self._verification_token or self._encrypt_key)
+
+    def _webhook_requires_secret(self) -> bool:
+        host = (self._webhook_host or "").strip().lower()
+        return host in {"0.0.0.0", "::", ""}
 
     def _check_webhook_rate_limit(self, rate_key: str) -> bool:
         """Return False when the composite rate_key has exceeded _FEISHU_WEBHOOK_RATE_LIMIT_MAX.

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -1538,6 +1538,44 @@ class TestAdapterBehavior(unittest.TestCase):
         self.assertEqual(response.status, 200)
         adapter._on_message_event.assert_called_once()
 
+    @patch.dict(os.environ, {"FEISHU_VERIFICATION_TOKEN": "expected-token"}, clear=True)
+    def test_url_verification_requires_configured_verification_token(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        body = json.dumps({
+            "type": "url_verification",
+            "token": "wrong-token",
+            "challenge": "attacker-controlled-challenge",
+        }).encode("utf-8")
+        request = SimpleNamespace(
+            remote="203.0.113.10",
+            content_length=None,
+            headers={},
+            read=AsyncMock(return_value=body),
+        )
+
+        response = asyncio.run(adapter._handle_webhook_request(request))
+
+        self.assertEqual(response.status, 401)
+
+    @patch.dict(os.environ, {"FEISHU_CONNECTION_MODE": "webhook"}, clear=True)
+    def test_network_webhook_refuses_to_start_without_verification_secret(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(
+            PlatformConfig(
+                extra={
+                    "webhook_host": "0.0.0.0",
+                    "connection_mode": "webhook",
+                }
+            )
+        )
+
+        self.assertFalse(asyncio.run(adapter.connect()))
+
     @patch.dict(os.environ, {}, clear=True)
     def test_process_inbound_message_uses_event_sender_identity_only(self):
         from gateway.config import PlatformConfig

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -337,8 +337,8 @@ For cloud sandbox backends, persistence is filesystem-oriented. `TERMINAL_LIFETI
 | `FEISHU_APP_SECRET` | Feishu/Lark bot App Secret |
 | `FEISHU_DOMAIN` | `feishu` (China) or `lark` (international). Default: `feishu` |
 | `FEISHU_CONNECTION_MODE` | `websocket` (recommended) or `webhook`. Default: `websocket` |
-| `FEISHU_ENCRYPT_KEY` | Optional encryption key for webhook mode |
-| `FEISHU_VERIFICATION_TOKEN` | Optional verification token for webhook mode |
+| `FEISHU_ENCRYPT_KEY` | Optional encryption key for webhook mode. Required with `FEISHU_VERIFICATION_TOKEN` absent when binding webhook mode to a network-accessible address. |
+| `FEISHU_VERIFICATION_TOKEN` | Optional verification token for webhook mode. Required with `FEISHU_ENCRYPT_KEY` absent when binding webhook mode to a network-accessible address. |
 | `FEISHU_ALLOWED_USERS` | Comma-separated Feishu user IDs allowed to message the bot |
 | `FEISHU_ALLOW_BOTS` | `none` (default) / `mentions` / `all` — accept inbound messages from other bots. See [bot-to-bot messaging](../user-guide/messaging/feishu.md#bot-to-bot-messaging) |
 | `FEISHU_REQUIRE_MENTION` | `true` (default) / `false` — whether group messages must @mention the bot. Override per-chat via `group_rules.<chat_id>.require_mention`. |

--- a/website/docs/user-guide/messaging/feishu.md
+++ b/website/docs/user-guide/messaging/feishu.md
@@ -93,7 +93,7 @@ FEISHU_WEBHOOK_PORT=8765         # default: 8765
 FEISHU_WEBHOOK_PATH=/feishu/webhook  # default: /feishu/webhook
 ```
 
-When Feishu sends a URL verification challenge (`type: url_verification`), the webhook responds automatically so you can complete the subscription setup in the Feishu developer console.
+When Feishu sends a URL verification challenge (`type: url_verification`), the webhook responds automatically so you can complete the subscription setup in the Feishu developer console. If you bind the webhook server to a network-accessible address such as `0.0.0.0`, configure `FEISHU_VERIFICATION_TOKEN` or `FEISHU_ENCRYPT_KEY`; Hermes refuses to start a public Feishu webhook listener without one of these webhook secrets.
 
 ## Step 3: Configure Hermes
 
@@ -172,7 +172,7 @@ SHA256(timestamp + nonce + encrypt_key + body)
 The computed hash is compared against the `x-lark-signature` header using timing-safe comparison. Requests with invalid or missing signatures are rejected with HTTP 401.
 
 :::tip
-In WebSocket mode, signature verification is handled by the SDK itself, so `FEISHU_ENCRYPT_KEY` is optional. In webhook mode, it is strongly recommended for production.
+In WebSocket mode, signature verification is handled by the SDK itself, so `FEISHU_ENCRYPT_KEY` is optional. In webhook mode, set either `FEISHU_ENCRYPT_KEY` or `FEISHU_VERIFICATION_TOKEN` before exposing the listener beyond localhost.
 :::
 
 ### Verification Token
@@ -183,7 +183,7 @@ An additional layer of authentication that checks the `token` field inside webho
 FEISHU_VERIFICATION_TOKEN=your-verification-token
 ```
 
-This token is also found in the **Event Subscriptions** section of your Feishu app. When set, every inbound webhook payload must contain a matching `token` in its `header` object. Mismatched tokens are rejected with HTTP 401.
+This token is also found in the **Event Subscriptions** section of your Feishu app. When set, every inbound webhook payload, including URL verification challenges, must contain a matching `token` in its `header` object or top-level `token` field. Mismatched tokens are rejected with HTTP 401.
 
 Both `FEISHU_ENCRYPT_KEY` and `FEISHU_VERIFICATION_TOKEN` can be used together for defense in depth.
 


### PR DESCRIPTION
Summary

This PR hardens Feishu/Lark webhook handling so network-accessible webhook listeners require a configured verification secret before accepting challenge traffic.

Changes

- Require `FEISHU_VERIFICATION_TOKEN` or `FEISHU_ENCRYPT_KEY` before starting webhook mode on network-accessible bind addresses.
- Validate configured verification tokens before responding to `url_verification` challenges.
- Add regression coverage for challenge handling and startup fail-closed behavior.
- Clarify the Feishu webhook secret requirement in user/reference docs.

Testing

- `python -m pytest -n 0 tests/gateway/test_feishu.py -q`

Notes

This is a defensive hardening change and avoids including sensitive vulnerability details.
