### PR TITLE
fix(openviking): bypass broken extraction pipeline in viking_remember

### DIFF
--- a/plugins/memory/openviking/__init__.py
+++ b/plugins/memory/openviking/__init__.py
@@ -858,24 +858,47 @@ class OpenVikingMemoryProvider(MemoryProvider):
         if not content:
             return tool_error("content is required")
 
-        # Store as a session message that will be extracted during commit.
-        # The category hint helps OpenViking's extraction classify correctly.
         category = args.get("category", "")
-        text = f"[Remember] {content}"
-        if category:
-            text = f"[Remember — {category}] {content}"
 
-        self._client.post(f"/api/v1/sessions/{self._session_id}/messages", {
-            "role": "user",
-            "parts": [
-                {"type": "text", "text": text},
-            ],
-        })
+        # Map category to viking:// subdirectory
+        subdir_map = {
+            "preference": "preferences",
+            "entity": "entities",
+            "event": "events",
+            "case": "patterns",
+            "pattern": "patterns",
+        }
+        subdir = subdir_map.get(category, "preferences")
 
-        return json.dumps({
-            "status": "stored",
-            "message": "Memory recorded. Will be extracted and indexed on session commit.",
-        })
+        # Build a deterministic URI with UUID to avoid collisions
+        usr = self._user
+        slug = uuid.uuid4().hex[:12]
+        uri = f"viking://user/{usr}/memories/{subdir}/mem_{slug}.md"
+
+        # Write directly via content/write API — bypasses broken extraction pipeline
+        try:
+            result = self._client.post("/api/v1/content/write", {
+                "uri": uri,
+                "content": content,
+                "mode": "create",
+            })
+            written = result.get("result", {}).get("written_bytes", 0)
+            return json.dumps({
+                "status": "stored",
+                "message": f"Memory stored ({written}b) and queued for vector indexing.",
+            })
+        except Exception as e:
+            logger.warning("OpenViking direct write failed, falling back to session message: %s", e)
+            # Fall back to session message (original behavior)
+            text = f"[Remember{f' — {category}' if category else ''}] {content}"
+            self._client.post(f"/api/v1/sessions/{self._session_id}/messages", {
+                "role": "user",
+                "parts": [{"type": "text", "text": text}],
+            })
+            return json.dumps({
+                "status": "stored",
+                "message": "Memory recorded. Will be extracted and indexed on session commit.",
+            })
 
     def _tool_add_resource(self, args: dict) -> str:
         url = args.get("url", "")


### PR DESCRIPTION
## What

The `_tool_remember` method in the OpenViking memory provider was posting memories as session messages that rely on the commit extraction pipeline. That pipeline is broken upstream (OpenViking issues #1410/#1541) — messages are written to the session but never extracted or indexed on commit, causing all `viking_remember` calls to silently lose data.

## How

Replace the session-message pipeline with a direct `POST /api/v1/content/write?mode=create` call, which creates the file, writes content, and queues vector indexing in a single API call.

### Changes in `_tool_remember`:

| Before (broken) | After |
|---|---|
| POST to session messages → wait for commit extraction → never indexed | POST to `content/write?mode=create` → immediately queued for indexing |
| Category only decorates message text | Category maps to proper `viking://` subdirectory (preferences, entities, events, patterns) |
| Returns "Will be extracted on session commit" (never happened) | Returns actual byte count + "queued for vector indexing" |
| No fallback | Graceful fallback to original session-message approach if direct write fails |

### Safety

- No new dependencies (uses stdlib `uuid`)
- Fallback preserved: if `content/write` errors, falls back to the original session-message approach
- Other tools (`viking_search`, `viking_read`, `viking_browse`, `viking_add_resource`) are untouched
- Tested with real OpenViking instance and confirmed: `viking_remember → viking_search → viking_read` pipeline works end-to-end

## Related

- Closes #17998
- Upstream OpenViking issues: #1410 (extraction not writing content), #1541 (LLM returning plain text instead of JSON)

## Checklist

- [x] Single logical change (only `_tool_remember` modified)
- [x] Conventional commit format
- [x] Tests verified locally via manual end-to-end testing
- [x] Backward compatible — fallback to original behavior preserved
