### PR TITLE
fix(cron): preserve existing jobs.json mode across writes (#29660)

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -22,7 +22,7 @@ from typing import Optional, Dict, List, Any, Union
 logger = logging.getLogger(__name__)
 
 from hermes_time import now as _hermes_now
-from utils import atomic_replace
+from utils import atomic_json_write, atomic_replace
 
 try:
     from croniter import croniter
@@ -453,22 +453,28 @@ def load_jobs() -> List[Dict[str, Any]]:
 
 
 def save_jobs(jobs: List[Dict[str, Any]]):
-    """Save all jobs to storage."""
+    """Save all jobs to storage.
+
+    Uses utils.atomic_json_write so that existing file permissions are
+    preserved across rewrites. This matters for shared-volume deployments
+    (e.g. WebUI + gateway containers running as different UIDs/GIDs sharing
+    the Hermes home) where the operator has intentionally set group-readable
+    permissions like 0o664. Previously save_jobs() always forced 0o600 via
+    _secure_file(), which clobbered the deployment's chosen mode on every
+    write and broke shared access (issue #29660).
+
+    For brand-new files (no existing jobs.json yet) we still default to
+    0o600 to preserve the original security posture for single-user installs.
+    """
     ensure_dirs()
-    fd, tmp_path = tempfile.mkstemp(dir=str(JOBS_FILE.parent), suffix='.tmp', prefix='.jobs_')
-    try:
-        with os.fdopen(fd, 'w', encoding='utf-8') as f:
-            json.dump({"jobs": jobs, "updated_at": _hermes_now().isoformat()}, f, indent=2)
-            f.flush()
-            os.fsync(f.fileno())
-        atomic_replace(tmp_path, JOBS_FILE)
+    existed = JOBS_FILE.exists()
+    atomic_json_write(
+        JOBS_FILE,
+        {"jobs": jobs, "updated_at": _hermes_now().isoformat()},
+        indent=2,
+    )
+    if not existed:
         _secure_file(JOBS_FILE)
-    except BaseException:
-        try:
-            os.unlink(tmp_path)
-        except OSError:
-            pass
-        raise
 
 
 def _normalize_workdir(workdir: Optional[str]) -> Optional[str]:

--- a/tests/cron/test_file_permissions.py
+++ b/tests/cron/test_file_permissions.py
@@ -57,6 +57,35 @@ class TestCronFilePermissions(unittest.TestCase):
             file_mode = stat.S_IMODE(os.stat(jobs_file).st_mode)
             self.assertEqual(file_mode, 0o600)
 
+    @unittest.skipIf(os.name == 'nt', 'POSIX file modes not applicable on Windows')
+    def test_save_jobs_preserves_existing_mode(self):
+        """Regression test for #29660.
+
+        Shared-volume deployments (e.g. WebUI + gateway containers under
+        different UIDs) intentionally set group-readable modes like 0o664
+        on jobs.json. save_jobs() must not clobber those on every write.
+        """
+        cron_dir = Path(self.tmpdir) / 'cron'
+        output_dir = cron_dir / 'output'
+        jobs_file = cron_dir / 'jobs.json'
+
+        with patch('cron.jobs.CRON_DIR', cron_dir), \
+             patch('cron.jobs.OUTPUT_DIR', output_dir), \
+             patch('cron.jobs.JOBS_FILE', jobs_file):
+            from cron.jobs import save_jobs
+            # First save creates the file with default secure mode (0o600).
+            save_jobs([{'id': 'a', 'prompt': 'hi'}])
+            self.assertEqual(stat.S_IMODE(os.stat(jobs_file).st_mode), 0o600)
+
+            # Deployment relaxes the permission to allow a sibling UID/GID
+            # to read/write the shared jobs file.
+            os.chmod(jobs_file, 0o664)
+
+            # Subsequent save must preserve the operator's chosen mode.
+            save_jobs([{'id': 'b', 'prompt': 'again'}])
+            file_mode = stat.S_IMODE(os.stat(jobs_file).st_mode)
+            self.assertEqual(file_mode, 0o664)
+
     def test_save_job_output_sets_0600(self):
         output_dir = Path(self.tmpdir) / "output"
         with patch("cron.jobs.OUTPUT_DIR", output_dir), \


### PR DESCRIPTION
## Summary

Fixes #29660.

`cron/jobs.py::save_jobs()` previously called `_secure_file()` unconditionally after every atomic write, hard-resetting `~/.hermes/cron/jobs.json` to `0o600`. This breaks shared-volume deployments (e.g. WebUI + gateway containers running as different UIDs/GIDs sharing the Hermes home, with the operator-chosen mode `0o664`): every cron save reverted the file, locking out the sibling process until manual chmod.

## Fix

Switch `save_jobs()` to the existing `utils.atomic_json_write()` helper, which already preserves an existing file's mode across the temp-file → atomic replace cycle via `_preserve_file_mode` / `_restore_file_mode`.

For brand-new files (no prior `jobs.json`) we still call `_secure_file()` so single-user / fresh installs keep the `0o600` default — only existing operator-chosen modes are preserved.

Net effect:
- First-ever `save_jobs()` on a fresh install → `0o600` (unchanged).
- Subsequent `save_jobs()` calls → preserve whatever mode is currently on disk (e.g. `0o664` set by deployment).
- Drop-in: no public API change, no config flag needed.

The other `_secure_file()` use (per-job output files at `cron/jobs.py:1078`) is unchanged — different concern.

## Testing

New regression test `tests/cron/test_file_permissions.py::test_save_jobs_preserves_existing_mode`:
- first save → asserts `0o600` (preserves fresh-install default)
- operator `chmod 0o664`
- second save → asserts mode is **still** `0o664`
- skipped on Windows (no POSIX modes)

```
$ python -m pytest tests/cron/test_file_permissions.py -q
.........                                                                [100%]
9 passed in 1.86s

$ python -m pytest tests/cron/ -q --deselect tests/cron/test_cron_script.py::TestRunJobScript::test_script_timeout
373 passed, 1 deselected in 9.46s
```
(The deselected `test_script_timeout` failure is unrelated — pre-existing message-string mismatch on `main`.)

## Risk

Low. `atomic_json_write` is already used elsewhere in the repo (`utils.py`). The only behavior change is: existing files keep their on-disk mode instead of being forced back to `0o600`. New files still get `0o600`.
