### PR TITLE
fix(skills-hub): expose stable identifier in browse API and TUI outputs

### DIFF
--- a/hermes_cli/skills_hub.py
+++ b/hermes_cli/skills_hub.py
@@ -715,7 +715,7 @@ def browse_skills(page: int = 1, page_size: int = 20, source: str = "all") -> di
     page_items = deduped[start : min(start + page_size, total)]
     return {
         "items": [{"name": r.name, "description": r.description, "source": r.source,
-                    "trust": r.trust_level} for r in page_items],
+                    "trust": r.trust_level, "identifier": r.identifier} for r in page_items],
         "page": page,
         "total_pages": total_pages,
         "total": total,

--- a/tests/hermes_cli/test_skills_hub.py
+++ b/tests/hermes_cli/test_skills_hub.py
@@ -565,3 +565,7 @@ def test_browse_skills_dedup_uses_identifier_not_name(monkeypatch):
         "browse_skills() must not deduplicate browse-sh skills with the same name "
         "but different identifiers"
     )
+    assert {item["identifier"] for item in result["items"]} == {
+        "browse-sh/airbnb.com/search-listings-ddgioa",
+        "browse-sh/booking.com/search-listings-xyzab",
+    }

--- a/ui-tui/src/__tests__/createSlashHandler.test.ts
+++ b/ui-tui/src/__tests__/createSlashHandler.test.ts
@@ -201,6 +201,54 @@ describe('createSlashHandler', () => {
     })
   })
 
+  it('shows Skills Hub browse identifiers returned by the gateway', async () => {
+    const rpc = vi.fn(() =>
+      Promise.resolve({
+        items: [
+          {
+            description: 'Airbnb search',
+            identifier: 'browse-sh/airbnb.com/search-listings-ddgioa',
+            name: 'search-listings',
+            trust: 'community'
+          },
+          {
+            description: 'Booking search',
+            identifier: 'browse-sh/booking.com/search-listings-xyzab',
+            name: 'search-listings',
+            trust: 'community'
+          }
+        ],
+        page: 1,
+        total: 2,
+        total_pages: 1
+      })
+    )
+
+    const ctx = buildCtx({ gateway: { ...buildGateway(), rpc } })
+
+    expect(createSlashHandler(ctx)('/skills browse')).toBe(true)
+
+    await vi.waitFor(() => {
+      expect(ctx.transcript.panel).toHaveBeenCalledWith(
+        'Browse Skills',
+        expect.arrayContaining([
+          expect.objectContaining({
+            rows: [
+              [
+                'search-listings · community',
+                'browse-sh/airbnb.com/search-listings-ddgioa - Airbnb search'
+              ],
+              [
+                'search-listings · community',
+                'browse-sh/booking.com/search-listings-xyzab - Booking search'
+              ]
+            ]
+          })
+        ])
+      )
+    })
+  })
+
   it('delegates non-native /skills subcommands to slash.exec', () => {
     const ctx = buildCtx()
 

--- a/ui-tui/src/app/slash/commands/ops.ts
+++ b/ui-tui/src/app/slash/commands/ops.ts
@@ -45,6 +45,7 @@ interface SkillsInstallResponse {
 
 interface SkillsBrowseItem {
   description?: string
+  identifier?: string
   name: string
   source?: string
   trust?: string
@@ -618,10 +619,12 @@ export const opsCommands: SlashCommand[] = [
                 return sys(`no skills on page ${pageNum}${r.total ? ` (total ${r.total})` : ''}`)
               }
 
-              const rows: [string, string][] = items.map(s => [
-                s.trust ? `${s.name} · ${s.trust}` : s.name,
-                String(s.description ?? '').slice(0, 160)
-              ])
+              const rows: [string, string][] = items.map(s => {
+                const description = String(s.description ?? '').slice(0, 160)
+                const details = s.identifier ? `${s.identifier} - ${description}` : description
+
+                return [s.trust ? `${s.name} · ${s.trust}` : s.name, details]
+              })
 
               const footer: string[] = []
 


### PR DESCRIPTION
## Summary

Fixes the Skills Hub browse API/TUI path so duplicate-name skills remain actionable by exposing their stable identifiers.

`browse_skills()` already deduplicates by `identifier`, not `name`, but the programmatic response did not include that identifier. As a result, TUI `/skills browse` could preserve duplicate-name results while still hiding the exact identifier users need for inspect/install.

## Changes

- Add `identifier` to each `browse_skills()` item.
- Show the identifier in TUI `/skills browse` output.
- Extend the existing duplicate-name browse regression test to assert returned identifiers.
- Add a TUI slash-handler regression test for rendering browse identifiers.

## Why

Skills Hub identity is based on stable identifiers. This completes the earlier dedupe-by-identifier fix by carrying the same identity through the user-facing browse response.

## Tests

- `uv --cache-dir .uv-cache run --extra dev pytest -o addopts= tests/hermes_cli/test_skills_hub.py -q`
  - `23 passed`
- `npm.cmd test -- src/__tests__/createSlashHandler.test.ts`
  - `54 passed`
- `git diff --check`
  - passed
- `npm.cmd exec eslint -- src/app/slash/commands/ops.ts src/__tests__/createSlashHandler.test.ts`
  - 0 errors
  - existing padding warnings remain

