### PR TITLE
fix(gateway): name macOS launchd gateways by profile

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -7,13 +7,19 @@ Handles: hermes gateway [run|start|stop|restart|status|install|uninstall|setup]
 import asyncio
 import logging
 import os
+import plistlib
+import shlex
 import shutil
 import signal
+import stat
 import subprocess
 import sys
+import tempfile
 import textwrap
 from dataclasses import dataclass
 from pathlib import Path
+from xml.sax.saxutils import escape as _xml_escape
+from xml.sax.saxutils import unescape as _xml_unescape
 
 PROJECT_ROOT = Path(__file__).parent.parent.resolve()
 
@@ -2105,7 +2111,7 @@ def _hermes_home_for_target_user(target_home_dir: str) -> str:
         return str(current_hermes)
 
 
-def _build_service_path_dirs(project_root: Path | None = None) -> list[str]:
+def _build_service_path_dirs(project_root: Path | None = None, hermes_home: Path | None = None) -> list[str]:
     """Build PATH directory list for service units, excluding non-existent dirs."""
     if project_root is None:
         project_root = PROJECT_ROOT
@@ -2128,7 +2134,7 @@ def _build_service_path_dirs(project_root: Path | None = None) -> list[str]:
     if _is_dir(node_bin):
         candidates.append(str(node_bin))
 
-    hermes_home = get_hermes_home()
+    hermes_home = hermes_home or get_hermes_home()
     hermes_node = hermes_home / "node" / "bin"
     if _is_dir(hermes_node):
         candidates.append(str(hermes_node))
@@ -2250,20 +2256,38 @@ def _normalize_service_definition(text: str) -> str:
     return "\n".join(line.rstrip() for line in text.strip().splitlines())
 
 
+def _launchd_path_dirs_for_comparison() -> list[str]:
+    path_dirs = _build_service_path_dirs(hermes_home=get_hermes_home().resolve())
+    resolved_node = shutil.which("node")
+    if resolved_node:
+        resolved_node_dir = str(Path(resolved_node).resolve().parent)
+        if resolved_node_dir not in path_dirs:
+            path_dirs.append(resolved_node_dir)
+    return path_dirs
+
+
+def _normalize_launchd_path_for_comparison(path_text: str) -> str:
+    deterministic_entries = _launchd_path_dirs_for_comparison()
+    path_entries = _xml_unescape(path_text).split(":")
+    deterministic_prefix = path_entries[: len(deterministic_entries)]
+    return ":".join(deterministic_prefix)
+
+
 def _normalize_launchd_plist_for_comparison(text: str) -> str:
     """Normalize launchd plist text for staleness checks.
 
     The generated plist intentionally captures a broad PATH assembled from the
     invoking shell so user-installed tools remain reachable under launchd.
-    That makes raw text comparison unstable across shells, so ignore the PATH
-    payload when deciding whether the installed plist is stale.
+    That makes raw text comparison unstable across shells, so compare only the
+    deterministic Hermes-controlled PATH entries and ignore the volatile shell
+    tail.
     """
     import re
 
     normalized = _normalize_service_definition(text)
     return re.sub(
         r'(<key>PATH</key>\s*<string>)(.*?)(</string>)',
-        r'\1__HERMES_PATH__\3',
+        lambda match: f"{match.group(1)}{_xml_escape(_normalize_launchd_path_for_comparison(match.group(2)))}{match.group(3)}",
         normalized,
         flags=re.S,
     )
@@ -2780,12 +2804,901 @@ def _launchd_domain() -> str:
     return f"gui/{os.getuid()}"  # windows-footgun: ok — POSIX launchd (macOS) helper, never invoked on Windows
 
 
-def generate_launchd_plist() -> str:
+_LAUNCHD_WRAPPER_FALLBACK_ENV = "HERMES_LAUNCHD_WRAPPER_FALLBACK"
+
+
+def _plist_string(value: object) -> str:
+    return f"<string>{_xml_escape(str(value))}</string>"
+
+
+def _launchd_gateway_wrapper_path() -> Path:
+    return get_hermes_home().resolve() / "bin" / get_service_name()
+
+
+def _launchd_path_owner_is_trusted(path_stat: os.stat_result) -> bool:
+    return path_stat.st_uid in {0, os.getuid()}  # windows-footgun: ok — POSIX launchd helper, never invoked on Windows
+
+
+def _launchd_path_mode_is_safe(path_stat: os.stat_result) -> bool:
+    mode = stat.S_IMODE(path_stat.st_mode)
+    return mode & 0o022 == 0 or (path_stat.st_uid == 0 and bool(mode & stat.S_ISVTX))
+
+
+def _launchd_directory_path_is_safe(path: Path, *, missing_ok: bool = False) -> bool:
+    current = Path(path.anchor)
+    for part in path.parts[1:]:
+        current = current / part
+        try:
+            path_stat = current.lstat()
+        except FileNotFoundError:
+            return missing_ok
+        if stat.S_ISLNK(path_stat.st_mode) and path_stat.st_uid == 0:
+            continue
+        if stat.S_ISLNK(path_stat.st_mode) or not stat.S_ISDIR(path_stat.st_mode):
+            raise RuntimeError(f"Refusing to use unsafe launchd directory: {current}")
+        if not _launchd_path_owner_is_trusted(path_stat) or not _launchd_path_mode_is_safe(path_stat):
+            raise RuntimeError(f"Refusing to use insecure launchd directory: {current}")
+    return True
+
+
+def _launchd_gateway_wrapper_ancestors_are_safe(parent: Path) -> bool:
+    hermes_home = get_hermes_home().resolve()
+    try:
+        resolved_parent = parent.resolve()
+        relative_parts = resolved_parent.relative_to(hermes_home).parts
+    except ValueError:
+        logger.warning("Refusing launchd gateway wrapper outside Hermes home: %s", parent)
+        return False
+
+    try:
+        return _launchd_directory_path_is_safe(resolved_parent, missing_ok=False)
+    except RuntimeError as exc:
+        logger.warning("%s", exc)
+        return False
+
+
+def _launchd_gateway_wrapper_parent_is_safe(parent: Path, *, create: bool, missing_ok: bool = False) -> bool:
+    try:
+        if create and not _launchd_gateway_wrapper_ancestors_are_safe(parent.parent):
+            return False
+        if create:
+            parent.mkdir(mode=0o755, parents=True, exist_ok=True)
+        current_stat = parent.lstat()
+    except FileNotFoundError:
+        return missing_ok and _launchd_gateway_wrapper_ancestors_are_safe(parent.parent)
+    except OSError as exc:
+        logger.warning("Could not prepare launchd gateway wrapper directory at %s: %s", parent, exc)
+        return False
+
+    if stat.S_ISLNK(current_stat.st_mode) or not stat.S_ISDIR(current_stat.st_mode):
+        logger.warning("Refusing to use unsafe launchd gateway wrapper directory: %s", parent)
+        return False
+
+    hermes_home = get_hermes_home().resolve()
+    ancestor_boundary = parent if parent == hermes_home else parent.parent
+    if not _launchd_gateway_wrapper_ancestors_are_safe(ancestor_boundary):
+        return False
+    if not _launchd_path_owner_is_trusted(current_stat):
+        logger.warning("Refusing to use untrusted launchd gateway wrapper directory: %s", parent)
+        return False
+
+    current_mode = stat.S_IMODE(current_stat.st_mode)
+    safe_mode = current_mode & ~0o022
+    if safe_mode != current_mode:
+        try:
+            parent.chmod(safe_mode)
+        except OSError as exc:
+            logger.warning("Could not secure launchd gateway wrapper directory at %s: %s", parent, exc)
+            return False
+    return True
+
+
+def _launchd_gateway_wrapper_parent_is_safe_readonly(parent: Path, *, missing_ok: bool = False) -> bool:
+    try:
+        current_stat = parent.lstat()
+    except FileNotFoundError:
+        return missing_ok and _launchd_gateway_wrapper_ancestors_are_safe(parent.parent)
+    except OSError as exc:
+        logger.warning("Could not inspect launchd gateway wrapper directory at %s: %s", parent, exc)
+        return False
+    if stat.S_ISLNK(current_stat.st_mode) or not stat.S_ISDIR(current_stat.st_mode):
+        logger.warning("Refusing to use unsafe launchd gateway wrapper directory: %s", parent)
+        return False
+    hermes_home = get_hermes_home().resolve()
+    ancestor_boundary = parent if parent == hermes_home else parent.parent
+    if not _launchd_gateway_wrapper_ancestors_are_safe(ancestor_boundary):
+        return False
+    if not _launchd_path_owner_is_trusted(current_stat):
+        logger.warning("Refusing to use untrusted launchd gateway wrapper directory: %s", parent)
+        return False
+    return stat.S_IMODE(current_stat.st_mode) & 0o022 == 0
+
+
+def _launchd_gateway_wrapper_script(python_path: str) -> bytes:
+    return f"#!/bin/sh\nexec {shlex.quote(python_path)} -m hermes_cli.main \"$@\"\n".encode("utf-8")
+
+
+def _launchd_gateway_wrapper_for_plist(python_path: str, *, prepare_paths: bool) -> Path | None:
+    if prepare_paths:
+        return _ensure_launchd_gateway_wrapper(python_path)
+
+    wrapper_path = _launchd_gateway_wrapper_path()
+    if not _launchd_gateway_wrapper_parent_is_safe_readonly(wrapper_path.parent, missing_ok=True):
+        return None
+    try:
+        current_stat = wrapper_path.lstat()
+    except FileNotFoundError:
+        return wrapper_path
+    if stat.S_ISLNK(current_stat.st_mode) or not stat.S_ISREG(current_stat.st_mode):
+        return None
+    return wrapper_path
+
+
+def _launchd_gateway_wrapper_can_be_prepared_without_writing(python_path: str) -> bool:
+    wrapper_path = _launchd_gateway_wrapper_path()
+    parent = wrapper_path.parent
+    if not _launchd_gateway_wrapper_parent_is_safe_readonly(parent, missing_ok=True):
+        return False
+    if parent.exists():
+        writable_parent = os.access(parent, os.W_OK | os.X_OK)
+    else:
+        nearest = parent.parent
+        while not nearest.exists() and nearest != nearest.parent:
+            nearest = nearest.parent
+        writable_parent = os.access(nearest, os.W_OK | os.X_OK)
+    try:
+        current_stat = wrapper_path.lstat()
+    except FileNotFoundError:
+        return writable_parent
+    if stat.S_ISLNK(current_stat.st_mode) or not stat.S_ISREG(current_stat.st_mode):
+        return False
+    current = _read_regular_no_follow(wrapper_path)
+    if current is None:
+        return False
+    if current.content == _launchd_gateway_wrapper_script(python_path) and current.mode == 0o755:
+        return True
+    if not (
+        current.content.startswith(b"#!/bin/sh\nexec ")
+        and current.content.endswith(b' -m hermes_cli.main "$@"\n')
+    ):
+        return False
+    return writable_parent
+
+
+@dataclass(frozen=True)
+class LaunchdWrapperSnapshot:
+    path: Path
+    content: bytes | None
+    mode: int = 0
+    existed: bool = True
+    reload_safe: bool = True
+
+
+@dataclass(frozen=True)
+class LaunchdWrapperParentSnapshot:
+    path: Path
+    mode: int = 0
+    secured_mode: int | None = None
+    device: int | None = None
+    inode: int | None = None
+    existed: bool = True
+
+
+@dataclass(frozen=True)
+class LaunchdPlistSnapshot:
+    path: Path
+    content: bytes | None
+    mode: int = 0
+    device: int | None = None
+    inode: int | None = None
+
+    def text(self) -> str | None:
+        if self.content is None:
+            return None
+        try:
+            return self.content.decode("utf-8")
+        except UnicodeDecodeError:
+            return None
+
+
+@dataclass(frozen=True)
+class LaunchdRefreshRollback:
+    plist_path: Path
+    plist_snapshot: LaunchdPlistSnapshot | None
+    wrapper_snapshot: LaunchdWrapperSnapshot | None
+    wrapper_parent_snapshot: LaunchdWrapperParentSnapshot | None
+    reload_previous: bool
+
+
+@dataclass(frozen=True)
+class LaunchdRefreshResult:
+    refreshed: bool
+    rollback: LaunchdRefreshRollback | None = None
+
+
+@dataclass
+class LaunchdBootstrapRecoveryState:
+    unloaded_stale_registration: bool = False
+
+
+@dataclass(frozen=True)
+class LaunchdRegularFileRead:
+    content: bytes
+    mode: int
+    device: int
+    inode: int
+
+
+@dataclass(frozen=True)
+class LaunchdPlistRemovalCandidate:
+    path: Path
+    content: LaunchdPlistSnapshot | None = None
+    path_stat: os.stat_result | None = None
+
+
+@dataclass(frozen=True)
+class LaunchdWrapperRemovalCandidate:
+    path: Path
+    content: LaunchdRegularFileRead
+
+
+_LaunchdWrittenArtifact = tuple[int, int, int, bytes]
+
+_launchd_written_plist_artifacts: dict[Path, _LaunchdWrittenArtifact] = {}
+_launchd_written_wrapper_artifacts: dict[Path, _LaunchdWrittenArtifact] = {}
+
+
+def _launchd_file_state_tuple(
+    state: LaunchdRegularFileRead | LaunchdPlistSnapshot | None,
+) -> _LaunchdWrittenArtifact | None:
+    if state is None or state.content is None or state.device is None or state.inode is None:
+        return None
+    return (state.device, state.inode, state.mode, state.content)
+
+
+def _launchd_file_state_matches(
+    current: LaunchdRegularFileRead | LaunchdPlistSnapshot | None,
+    expected: LaunchdRegularFileRead | LaunchdPlistSnapshot,
+) -> bool:
+    return _launchd_file_state_tuple(current) == _launchd_file_state_tuple(expected)
+
+
+def _launchd_stat_identity(path_stat: os.stat_result) -> tuple[int, int, int]:
+    return (path_stat.st_dev, path_stat.st_ino, path_stat.st_mode)
+
+
+def _launchd_unlinked_temp_path(path: Path, *, prefix: str) -> Path:
+    fd, temp_name = tempfile.mkstemp(prefix=prefix, dir=str(path.parent))
+    os.close(fd)
+    os.unlink(temp_name)
+    return Path(temp_name)
+
+
+def _quarantine_launchd_path(path: Path) -> Path:
+    quarantine_path = _launchd_unlinked_temp_path(
+        path,
+        prefix=f".{path.name}.quarantine.",
+    )
+    os.replace(path, quarantine_path)
+    return quarantine_path
+
+
+def _restore_launchd_quarantined_path(path: Path, quarantine_path: Path, description: str) -> bool:
+    try:
+        quarantine_stat = quarantine_path.lstat()
+        if stat.S_ISLNK(quarantine_stat.st_mode):
+            os.symlink(os.readlink(quarantine_path), path)
+        elif stat.S_ISDIR(quarantine_stat.st_mode):
+            try:
+                path.lstat()
+            except FileNotFoundError:
+                os.rename(quarantine_path, path)
+            else:
+                raise FileExistsError
+        else:
+            os.link(quarantine_path, path)
+    except FileExistsError:
+        logger.warning(
+            "Leaving quarantined %s at %s because %s already exists",
+            description,
+            quarantine_path,
+            path,
+        )
+        return False
+    except OSError as exc:
+        logger.warning("Could not restore quarantined %s from %s to %s: %s", description, quarantine_path, path, exc)
+        return False
+    try:
+        os.unlink(quarantine_path)
+    except FileNotFoundError:
+        pass
+    return True
+
+
+def _write_launchd_file_if_absent(path: Path, content: bytes, mode: int) -> None:
+    temp_name = None
+    fd = None
+    try:
+        fd, temp_name = tempfile.mkstemp(
+            prefix=f".{path.name}.",
+            dir=str(path.parent),
+        )
+        with os.fdopen(fd, "wb") as fh:
+            fd = None
+            fh.write(content)
+            fh.flush()
+            os.fchmod(fh.fileno(), mode)
+        os.link(temp_name, path)
+    finally:
+        if fd is not None:
+            os.close(fd)
+        if temp_name is not None:
+            try:
+                os.unlink(temp_name)
+            except FileNotFoundError:
+                pass
+
+
+def _remove_launchd_file_if_current(path: Path, expected: LaunchdRegularFileRead | LaunchdPlistSnapshot, read_current, description: str) -> bool:
+    try:
+        quarantine_path = _quarantine_launchd_path(path)
+    except FileNotFoundError:
+        return False
+    try:
+        current = read_current(quarantine_path)
+    except (OSError, RuntimeError) as exc:
+        _restore_launchd_quarantined_path(path, quarantine_path, description)
+        logger.warning("Skipping %s removal because %s changed before removal: %s", description, path, exc)
+        return False
+    if not _launchd_file_state_matches(current, expected):
+        _restore_launchd_quarantined_path(path, quarantine_path, description)
+        logger.warning("Skipping %s removal because %s changed before removal", description, path)
+        return False
+    os.unlink(quarantine_path)
+    return True
+
+
+def _remove_launchd_path_if_lstat_matches(path: Path, expected_stat: os.stat_result, description: str) -> bool:
+    try:
+        quarantine_path = _quarantine_launchd_path(path)
+    except FileNotFoundError:
+        return False
+    try:
+        quarantine_stat = quarantine_path.lstat()
+    except FileNotFoundError:
+        logger.warning("Skipping %s removal because %s changed before removal", description, path)
+        return False
+    if _launchd_stat_identity(quarantine_stat) != _launchd_stat_identity(expected_stat):
+        _restore_launchd_quarantined_path(path, quarantine_path, description)
+        logger.warning("Skipping %s removal because %s changed before removal", description, path)
+        return False
+    os.unlink(quarantine_path)
+    return True
+
+
+def _replace_launchd_file_if_current(
+    path: Path,
+    content: bytes,
+    mode: int,
+    expected: LaunchdRegularFileRead | LaunchdPlistSnapshot,
+    read_current,
+    description: str,
+) -> bool:
+    try:
+        quarantine_path = _quarantine_launchd_path(path)
+    except FileNotFoundError:
+        logger.warning("Skipping %s replacement because %s disappeared before replacement", description, path)
+        return False
+    try:
+        current = read_current(quarantine_path)
+    except (OSError, RuntimeError) as exc:
+        _restore_launchd_quarantined_path(path, quarantine_path, description)
+        logger.warning("Skipping %s replacement because %s changed before replacement: %s", description, path, exc)
+        return False
+    if not _launchd_file_state_matches(current, expected):
+        _restore_launchd_quarantined_path(path, quarantine_path, description)
+        logger.warning("Skipping %s replacement because %s changed before replacement", description, path)
+        return False
+    try:
+        _write_launchd_file_if_absent(path, content, mode)
+    except FileExistsError:
+        _restore_launchd_quarantined_path(path, quarantine_path, description)
+        logger.warning("Skipping %s replacement because %s changed during replacement", description, path)
+        return False
+    except OSError:
+        _restore_launchd_quarantined_path(path, quarantine_path, description)
+        raise
+    try:
+        os.unlink(quarantine_path)
+    except FileNotFoundError:
+        pass
+    return True
+
+
+def _remember_launchd_written_artifact(
+    registry: dict[Path, _LaunchdWrittenArtifact],
+    path: Path,
+    content: bytes,
+) -> None:
+    try:
+        current_stat = path.lstat()
+    except OSError:
+        return
+    registry[path] = (
+        current_stat.st_dev,
+        current_stat.st_ino,
+        stat.S_IMODE(current_stat.st_mode),
+        content,
+    )
+
+
+def _launchd_current_artifact_matches(
+    registry: dict[Path, _LaunchdWrittenArtifact],
+    path: Path,
+    device: int | None,
+    inode: int | None,
+    mode: int,
+    current_content: bytes,
+) -> bool:
+    if device is None or inode is None:
+        return False
+    remembered = registry.get(path)
+    return remembered == (device, inode, mode, current_content)
+
+
+def _read_regular_no_follow(path: Path) -> LaunchdRegularFileRead | None:
+    try:
+        current_stat = path.lstat()
+    except FileNotFoundError:
+        return None
+    if stat.S_ISLNK(current_stat.st_mode) or not stat.S_ISREG(current_stat.st_mode):
+        return None
+    if not _launchd_path_owner_is_trusted(current_stat):
+        return None
+    flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+    try:
+        fd = os.open(path, flags)
+    except OSError:
+        return None
+    try:
+        opened_stat = os.fstat(fd)
+        if (opened_stat.st_dev, opened_stat.st_ino) != (current_stat.st_dev, current_stat.st_ino):
+            return None
+        if stat.S_ISLNK(opened_stat.st_mode) or not stat.S_ISREG(opened_stat.st_mode):
+            return None
+        if not _launchd_path_owner_is_trusted(opened_stat):
+            return None
+        with os.fdopen(fd, "rb") as fh:
+            fd = None
+            content = fh.read()
+    finally:
+        if fd is not None:
+            os.close(fd)
+    return LaunchdRegularFileRead(
+        content=content,
+        mode=stat.S_IMODE(opened_stat.st_mode),
+        device=opened_stat.st_dev,
+        inode=opened_stat.st_ino,
+    )
+
+
+def _launchd_gateway_wrapper_is_current(python_path: str) -> bool:
+    wrapper_path = _launchd_gateway_wrapper_path()
+    if not _launchd_gateway_wrapper_parent_is_safe_readonly(wrapper_path.parent):
+        return False
+    current = _read_regular_no_follow(wrapper_path)
+    if current is None:
+        return False
+    return current.content == _launchd_gateway_wrapper_script(python_path) and current.mode == 0o755
+
+
+def _launchd_gateway_wrapper_is_hermes_generated() -> bool:
+    wrapper_path = _launchd_gateway_wrapper_path()
+    if not _launchd_gateway_wrapper_parent_is_safe_readonly(wrapper_path.parent):
+        return False
+    current = _read_regular_no_follow(wrapper_path)
+    if current is None:
+        return False
+    return current.content.startswith(b"#!/bin/sh\nexec ") and current.content.endswith(
+        b' -m hermes_cli.main "$@"\n'
+    )
+
+
+def _launchd_gateway_wrapper_removal_candidate(python_path: str) -> LaunchdWrapperRemovalCandidate | None:
+    wrapper_path = _launchd_gateway_wrapper_path()
+    if not _launchd_gateway_wrapper_parent_is_safe_readonly(wrapper_path.parent):
+        return None
+    current = _read_regular_no_follow(wrapper_path)
+    if current is None:
+        return None
+    if current.content == _launchd_gateway_wrapper_script(python_path) and current.mode == 0o755:
+        return LaunchdWrapperRemovalCandidate(path=wrapper_path, content=current)
+    if current.content.startswith(b"#!/bin/sh\nexec ") and current.content.endswith(
+        b' -m hermes_cli.main "$@"\n'
+    ):
+        return LaunchdWrapperRemovalCandidate(path=wrapper_path, content=current)
+    return None
+
+
+def _remove_launchd_gateway_wrapper_candidate(candidate: LaunchdWrapperRemovalCandidate | None) -> bool:
+    if candidate is None:
+        return False
+    current = _read_regular_no_follow(candidate.path)
+    if (
+        current is None
+        or (current.device, current.inode, current.mode, current.content)
+        != (candidate.content.device, candidate.content.inode, candidate.content.mode, candidate.content.content)
+    ):
+        logger.warning("Skipping launchd gateway wrapper removal because %s changed before uninstall", candidate.path)
+        return False
+    return _remove_launchd_file_if_current(
+        candidate.path,
+        current,
+        _read_regular_no_follow,
+        "launchd gateway wrapper",
+    )
+
+
+def _remove_launchd_gateway_wrapper_if_generated(python_path: str) -> bool:
+    return _remove_launchd_gateway_wrapper_candidate(_launchd_gateway_wrapper_removal_candidate(python_path))
+
+
+def _snapshot_launchd_gateway_wrapper_parent() -> LaunchdWrapperParentSnapshot | None:
+    parent = _launchd_gateway_wrapper_path().parent
+    try:
+        current_stat = parent.lstat()
+    except FileNotFoundError:
+        if _launchd_gateway_wrapper_ancestors_are_safe(parent.parent):
+            return LaunchdWrapperParentSnapshot(path=parent, existed=False)
+        return None
+    except OSError as exc:
+        logger.warning("Could not inspect launchd gateway wrapper directory at %s: %s", parent, exc)
+        return None
+
+    if stat.S_ISLNK(current_stat.st_mode) or not stat.S_ISDIR(current_stat.st_mode):
+        logger.warning("Refusing to snapshot unsafe launchd gateway wrapper directory: %s", parent)
+        return None
+    if not _launchd_path_owner_is_trusted(current_stat):
+        logger.warning("Refusing to snapshot untrusted launchd gateway wrapper directory: %s", parent)
+        return None
+    if not _launchd_gateway_wrapper_ancestors_are_safe(parent.parent):
+        return None
+    return LaunchdWrapperParentSnapshot(
+        path=parent,
+        mode=stat.S_IMODE(current_stat.st_mode),
+        secured_mode=stat.S_IMODE(current_stat.st_mode) & ~0o022,
+        device=current_stat.st_dev,
+        inode=current_stat.st_ino,
+    )
+
+
+def _restore_launchd_gateway_wrapper_parent(snapshot: LaunchdWrapperParentSnapshot | None) -> bool:
+    if snapshot is None or not snapshot.existed:
+        return True
+    try:
+        current_stat = snapshot.path.lstat()
+    except FileNotFoundError:
+        logger.warning("Skipping launchd gateway wrapper directory mode restore because %s no longer exists", snapshot.path)
+        return False
+    if stat.S_ISLNK(current_stat.st_mode) or not stat.S_ISDIR(current_stat.st_mode):
+        logger.warning("Skipping launchd gateway wrapper directory mode restore because %s changed after snapshot", snapshot.path)
+        return False
+    if (current_stat.st_dev, current_stat.st_ino) != (snapshot.device, snapshot.inode):
+        logger.warning("Skipping launchd gateway wrapper directory mode restore because %s changed after snapshot", snapshot.path)
+        return False
+    current_mode = stat.S_IMODE(current_stat.st_mode)
+    if current_mode == snapshot.mode:
+        return True
+    if snapshot.secured_mode is None or current_mode != snapshot.secured_mode:
+        logger.warning("Skipping launchd gateway wrapper directory mode restore because %s changed after snapshot", snapshot.path)
+        return False
+    try:
+        snapshot.path.chmod(snapshot.mode)
+    except OSError as exc:
+        logger.warning("Could not restore launchd gateway wrapper directory mode at %s: %s", snapshot.path, exc)
+        return False
+    return True
+
+
+def _snapshot_launchd_gateway_wrapper() -> LaunchdWrapperSnapshot | None:
+    wrapper_path = _launchd_gateway_wrapper_path()
+    parent_is_reload_safe = _launchd_gateway_wrapper_parent_is_safe_readonly(wrapper_path.parent, missing_ok=True)
+    if not parent_is_reload_safe and _snapshot_launchd_gateway_wrapper_parent() is None:
+        return None
+    current = _read_regular_no_follow(wrapper_path)
+    if current is None:
+        try:
+            current_stat = wrapper_path.lstat()
+        except FileNotFoundError:
+            return LaunchdWrapperSnapshot(path=wrapper_path, content=None, existed=False, reload_safe=parent_is_reload_safe)
+        if stat.S_ISLNK(current_stat.st_mode) or not stat.S_ISREG(current_stat.st_mode):
+            return None
+        return None
+    return LaunchdWrapperSnapshot(
+        path=wrapper_path,
+        content=current.content,
+        mode=current.mode,
+        reload_safe=parent_is_reload_safe,
+    )
+
+
+def _restore_launchd_gateway_wrapper(snapshot: LaunchdWrapperSnapshot | None) -> bool:
+    if snapshot is None:
+        return True
+    if not _launchd_gateway_wrapper_parent_is_safe(
+        snapshot.path.parent,
+        create=snapshot.content is not None,
+        missing_ok=snapshot.content is None and not snapshot.existed,
+    ):
+        return False
+    if snapshot.content is None:
+        try:
+            current_stat = snapshot.path.lstat()
+        except FileNotFoundError:
+            return not snapshot.existed
+        if stat.S_ISREG(current_stat.st_mode) and not stat.S_ISLNK(current_stat.st_mode):
+            current = _read_regular_no_follow(snapshot.path)
+            if current is not None and _launchd_current_artifact_matches(
+                _launchd_written_wrapper_artifacts,
+                snapshot.path,
+                current.device,
+                current.inode,
+                current.mode,
+                current.content,
+            ):
+                removed = _remove_launchd_file_if_current(
+                    snapshot.path,
+                    current,
+                    _read_regular_no_follow,
+                    "launchd gateway wrapper",
+                )
+                _launchd_written_wrapper_artifacts.pop(snapshot.path, None)
+                if not removed:
+                    return False
+            else:
+                _launchd_written_wrapper_artifacts.pop(snapshot.path, None)
+                logger.warning("Skipping launchd gateway wrapper removal because %s changed after snapshot", snapshot.path)
+                return False
+        else:
+            _launchd_written_wrapper_artifacts.pop(snapshot.path, None)
+            logger.warning("Skipping launchd gateway wrapper removal because %s changed after snapshot", snapshot.path)
+            return False
+        return not snapshot.existed
+
+    current = _read_regular_no_follow(snapshot.path)
+    if current is not None and current.content == snapshot.content and current.mode == snapshot.mode:
+        _launchd_written_wrapper_artifacts.pop(snapshot.path, None)
+        return True
+    if not (
+        current is not None
+        and _launchd_current_artifact_matches(
+            _launchd_written_wrapper_artifacts,
+            snapshot.path,
+            current.device,
+            current.inode,
+            current.mode,
+            current.content,
+        )
+    ):
+        _launchd_written_wrapper_artifacts.pop(snapshot.path, None)
+        logger.warning("Skipping launchd gateway wrapper restore because %s changed after snapshot", snapshot.path)
+        return False
+
+    snapshot.path.parent.mkdir(parents=True, exist_ok=True)
+    restored = _replace_launchd_file_if_current(
+        snapshot.path,
+        snapshot.content,
+        snapshot.mode,
+        current,
+        _read_regular_no_follow,
+        "launchd gateway wrapper",
+    )
+    _launchd_written_wrapper_artifacts.pop(snapshot.path, None)
+    return restored
+
+
+def _ensure_launchd_gateway_wrapper(python_path: str) -> Path | None:
+    """Create the profile-scoped executable that launchd shows in macOS Login Items."""
+    wrapper_path = _launchd_gateway_wrapper_path()
+    script_bytes = _launchd_gateway_wrapper_script(python_path)
+    current = None
+    try:
+        if not _launchd_gateway_wrapper_parent_is_safe(wrapper_path.parent, create=True):
+            return None
+        try:
+            current_stat = wrapper_path.lstat()
+        except FileNotFoundError:
+            current_stat = None
+        if current_stat is not None:
+            if stat.S_ISLNK(current_stat.st_mode) or not stat.S_ISREG(current_stat.st_mode):
+                logger.warning("Refusing to replace unsafe launchd gateway wrapper path: %s", wrapper_path)
+                return None
+            if not _launchd_path_owner_is_trusted(current_stat):
+                logger.warning("Refusing to replace untrusted launchd gateway wrapper path: %s", wrapper_path)
+                return None
+            current = _read_regular_no_follow(wrapper_path)
+            if current is None:
+                logger.warning("Could not read existing launchd gateway wrapper at %s", wrapper_path)
+                return None
+            if current.content == script_bytes and current.mode == 0o755:
+                return wrapper_path
+            if not (
+                current.content.startswith(b"#!/bin/sh\nexec ")
+                and current.content.endswith(b' -m hermes_cli.main "$@"\n')
+            ):
+                logger.warning("Refusing to replace custom launchd gateway wrapper at %s", wrapper_path)
+                return None
+
+        if current is None:
+            _write_launchd_file_if_absent(wrapper_path, script_bytes, 0o755)
+        elif not _replace_launchd_file_if_current(
+            wrapper_path,
+            script_bytes,
+            0o755,
+            current,
+            _read_regular_no_follow,
+            "launchd gateway wrapper",
+        ):
+            return None
+        _remember_launchd_written_artifact(
+            _launchd_written_wrapper_artifacts,
+            wrapper_path,
+            script_bytes,
+        )
+        return wrapper_path
+    except OSError as exc:
+        logger.warning("Could not prepare launchd gateway wrapper at %s: %s", wrapper_path, exc)
+        return None
+
+
+def _validate_launchd_plist_path(plist_path: Path, current_stat: os.stat_result | None) -> None:
+    if current_stat is not None:
+        if stat.S_ISLNK(current_stat.st_mode) or not stat.S_ISREG(current_stat.st_mode):
+            raise RuntimeError(f"Refusing to replace unsafe launchd plist path: {plist_path}")
+        if not _launchd_path_owner_is_trusted(current_stat):
+            raise RuntimeError(f"Refusing to use untrusted launchd plist path: {plist_path}")
+        if stat.S_IMODE(current_stat.st_mode) & 0o022:
+            raise RuntimeError(f"Refusing to use insecure launchd plist path: {plist_path}")
+
+
+def _validate_launchd_plist_parent(plist_path: Path, *, create: bool, missing_ok: bool = False) -> bool:
+    parent = plist_path.parent
+    if create:
+        _launchd_directory_path_is_safe(parent.parent, missing_ok=False)
+    else:
+        return _launchd_directory_path_is_safe(parent, missing_ok=missing_ok)
+    try:
+        if create:
+            parent.mkdir(mode=0o755, exist_ok=True)
+        parent_stat = parent.lstat()
+    except FileNotFoundError:
+        if missing_ok:
+            return False
+        raise
+
+    if stat.S_ISLNK(parent_stat.st_mode) or not stat.S_ISDIR(parent_stat.st_mode):
+        raise RuntimeError(f"Refusing to use unsafe launchd plist directory: {parent}")
+    if not _launchd_path_owner_is_trusted(parent_stat):
+        raise RuntimeError(f"Refusing to use untrusted launchd plist directory: {parent}")
+
+    current_mode = stat.S_IMODE(parent_stat.st_mode)
+    safe_mode = current_mode & ~0o022
+    if safe_mode != current_mode:
+        parent.chmod(safe_mode)
+    return True
+
+
+def _read_launchd_plist(plist_path: Path) -> str | None:
+    snapshot = _snapshot_launchd_plist(plist_path)
+    return None if snapshot is None else snapshot.text()
+
+
+def _snapshot_launchd_plist(plist_path: Path) -> LaunchdPlistSnapshot | None:
+    if not _validate_launchd_plist_parent(plist_path, create=False, missing_ok=True):
+        return LaunchdPlistSnapshot(path=plist_path, content=None)
+    try:
+        current_stat = plist_path.lstat()
+    except FileNotFoundError:
+        return LaunchdPlistSnapshot(path=plist_path, content=None)
+    _validate_launchd_plist_path(plist_path, current_stat)
+    flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+    fd = None
+    try:
+        fd = os.open(plist_path, flags)
+        opened_stat = os.fstat(fd)
+        if (opened_stat.st_dev, opened_stat.st_ino) != (current_stat.st_dev, current_stat.st_ino):
+            raise RuntimeError(f"Refusing to use launchd plist path that changed while opening: {plist_path}")
+        _validate_launchd_plist_path(plist_path, opened_stat)
+        with os.fdopen(fd, "rb") as fh:
+            fd = None
+            content = fh.read()
+    finally:
+        if fd is not None:
+            os.close(fd)
+    return LaunchdPlistSnapshot(
+        path=plist_path,
+        content=content,
+        mode=stat.S_IMODE(opened_stat.st_mode),
+        device=opened_stat.st_dev,
+        inode=opened_stat.st_ino,
+    )
+
+
+def _launchd_plist_missing(plist_path: Path) -> bool:
+    if not _validate_launchd_plist_parent(plist_path, create=False, missing_ok=True):
+        return True
+    try:
+        current_stat = plist_path.lstat()
+    except FileNotFoundError:
+        return True
+    _validate_launchd_plist_path(plist_path, current_stat)
+    return False
+
+
+def _launchd_plist_removal_candidate(plist_path: Path) -> LaunchdPlistRemovalCandidate | None:
+    if not _validate_launchd_plist_parent(plist_path, create=False, missing_ok=True):
+        return None
+    try:
+        current_stat = plist_path.lstat()
+    except FileNotFoundError:
+        return None
+    if stat.S_ISREG(current_stat.st_mode):
+        current = _snapshot_launchd_plist(plist_path)
+        if current is None or current.content is None:
+            return None
+        return LaunchdPlistRemovalCandidate(path=plist_path, content=current)
+    if stat.S_ISLNK(current_stat.st_mode):
+        return LaunchdPlistRemovalCandidate(path=plist_path, path_stat=current_stat)
+    raise RuntimeError(f"Refusing to remove unsafe launchd plist path: {plist_path}")
+
+
+def _remove_launchd_plist_candidate(candidate: LaunchdPlistRemovalCandidate) -> bool:
+    if candidate.content is not None:
+        return _remove_launchd_file_if_current(
+            candidate.path,
+            candidate.content,
+            _snapshot_launchd_plist,
+            "launchd plist",
+        )
+    if candidate.path_stat is not None:
+        return _remove_launchd_path_if_lstat_matches(candidate.path, candidate.path_stat, "launchd plist")
+    return False
+
+
+def _write_launchd_plist(plist_path: Path, content: str) -> None:
+    """Atomically write a launchd plist without following unsafe existing paths."""
+    _validate_launchd_plist_parent(plist_path, create=True)
+    current = _snapshot_launchd_plist(plist_path)
+    content_bytes = content.encode("utf-8")
+    if current is None or current.content is None:
+        try:
+            _write_launchd_file_if_absent(plist_path, content_bytes, 0o644)
+        except FileExistsError as exc:
+            raise RuntimeError(f"Refusing to replace launchd plist path that changed while writing: {plist_path}") from exc
+    elif not _replace_launchd_file_if_current(
+        plist_path,
+        content_bytes,
+        0o644,
+        current,
+        _snapshot_launchd_plist,
+        "launchd plist",
+    ):
+        raise RuntimeError(f"Refusing to replace launchd plist path that changed while writing: {plist_path}")
+    _remember_launchd_written_artifact(
+        _launchd_written_plist_artifacts,
+        plist_path,
+        content_bytes,
+    )
+
+
+def generate_launchd_plist(*, prepare_paths: bool = True, force_python: bool = False) -> str:
     python_path = get_python_path()
     working_dir = str(PROJECT_ROOT)
-    hermes_home = str(get_hermes_home().resolve())
-    log_dir = get_hermes_home() / "logs"
-    log_dir.mkdir(parents=True, exist_ok=True)
+    hermes_home_path = get_hermes_home().resolve()
+    hermes_home = str(hermes_home_path)
+    log_dir = hermes_home_path / "logs"
+    if prepare_paths:
+        log_dir.mkdir(parents=True, exist_ok=True)
     label = get_launchd_label()
     profile_arg = _profile_arg(hermes_home)
     # Build a sane PATH for the launchd plist.  launchd provides only a
@@ -2797,7 +3710,7 @@ def generate_launchd_plist() -> str:
     venv_dir = str(detected_venv) if detected_venv else str(PROJECT_ROOT / "venv")
     # Resolve the directory containing the node binary (e.g. Homebrew, nvm)
     # so it's explicitly in PATH even if the user's shell PATH changes later.
-    priority_dirs = _build_service_path_dirs()
+    priority_dirs = _build_service_path_dirs(hermes_home=hermes_home_path)
     resolved_node = shutil.which("node")
     if resolved_node:
         resolved_node_dir = str(Path(resolved_node).resolve().parent)
@@ -2807,28 +3720,45 @@ def generate_launchd_plist() -> str:
         dict.fromkeys(priority_dirs + [p for p in os.environ.get("PATH", "").split(":") if p])
     )
 
-    # Build ProgramArguments array, including --profile when using a named profile
-    prog_args = [
-        f"<string>{python_path}</string>",
-        "<string>-m</string>",
-        "<string>hermes_cli.main</string>",
-    ]
+    # Build ProgramArguments array, including --profile when using a named profile.
+    #
+    # macOS Background Task Management uses basename(ProgramArguments[0]) as
+    # the Login Items display name. A profile-scoped wrapper lets multiple
+    # gateway services show distinct names instead of all appearing as Python.
+    gateway_wrapper = None if force_python else _launchd_gateway_wrapper_for_plist(
+        python_path,
+        prepare_paths=prepare_paths,
+    )
+    using_wrapper_fallback = gateway_wrapper is None
+    if gateway_wrapper is not None:
+        prog_args = [_plist_string(gateway_wrapper)]
+    else:
+        prog_args = [
+            _plist_string(python_path),
+            _plist_string("-m"),
+            _plist_string("hermes_cli.main"),
+        ]
     if profile_arg:
         for part in profile_arg.split():
-            prog_args.append(f"<string>{part}</string>")
+            prog_args.append(_plist_string(part))
     prog_args.extend([
-        "<string>gateway</string>",
-        "<string>run</string>",
-        "<string>--replace</string>",
+        _plist_string("gateway"),
+        _plist_string("run"),
+        _plist_string("--replace"),
     ])
     prog_args_xml = "\n        ".join(prog_args)
+    fallback_env_xml = ""
+    if using_wrapper_fallback:
+        fallback_env_xml = f"""
+        <key>{_LAUNCHD_WRAPPER_FALLBACK_ENV}</key>
+        {_plist_string("1")}"""
 
     return f"""<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
     <key>Label</key>
-    <string>{label}</string>
+    {_plist_string(label)}
 
     <key>ProgramArguments</key>
     <array>
@@ -2836,16 +3766,17 @@ def generate_launchd_plist() -> str:
     </array>
     
     <key>WorkingDirectory</key>
-    <string>{working_dir}</string>
+    {_plist_string(working_dir)}
     
     <key>EnvironmentVariables</key>
     <dict>
         <key>PATH</key>
-        <string>{sane_path}</string>
+        {_plist_string(sane_path)}
         <key>VIRTUAL_ENV</key>
-        <string>{venv_dir}</string>
+        {_plist_string(venv_dir)}
         <key>HERMES_HOME</key>
-        <string>{hermes_home}</string>
+        {_plist_string(hermes_home)}
+        {fallback_env_xml}
     </dict>
     
     <key>RunAtLoad</key>
@@ -2858,10 +3789,10 @@ def generate_launchd_plist() -> str:
     </dict>
     
     <key>StandardOutPath</key>
-    <string>{log_dir}/gateway.log</string>
+    {_plist_string(log_dir / "gateway.log")}
     
     <key>StandardErrorPath</key>
-    <string>{log_dir}/gateway.error.log</string>
+    {_plist_string(log_dir / "gateway.error.log")}
 </dict>
 </plist>
 """
@@ -2869,15 +3800,289 @@ def generate_launchd_plist() -> str:
 def launchd_plist_is_current() -> bool:
     """Check if the installed launchd plist matches the currently generated one."""
     plist_path = get_launchd_plist_path()
-    if not plist_path.exists():
+    installed = _read_launchd_plist(plist_path)
+    if installed is None:
         return False
 
-    installed = plist_path.read_text(encoding="utf-8")
-    expected = generate_launchd_plist()
-    return _normalize_launchd_plist_for_comparison(installed) == _normalize_launchd_plist_for_comparison(expected)
+    python_path = get_python_path()
+    gateway_wrapper = _launchd_gateway_wrapper_for_plist(python_path, prepare_paths=False)
+    expected = generate_launchd_plist(prepare_paths=False)
+    if _normalize_launchd_plist_for_comparison(installed) != _normalize_launchd_plist_for_comparison(expected):
+        fallback_expected = generate_launchd_plist(prepare_paths=False, force_python=True)
+        fallback_current = _launchd_plist_text_has_current_fallback(
+            installed,
+            gateway_wrapper,
+            python_path,
+        )
+        return fallback_current and _normalize_launchd_plist_for_comparison(installed) == _normalize_launchd_plist_for_comparison(
+            fallback_expected
+        )
+    return gateway_wrapper is None or _launchd_gateway_wrapper_is_current(python_path)
 
 
-def refresh_launchd_plist_if_needed() -> bool:
+def _restore_launchd_plist(snapshot: LaunchdPlistSnapshot | None) -> bool:
+    if snapshot is None:
+        return True
+    parent_exists = _validate_launchd_plist_parent(
+        snapshot.path,
+        create=snapshot.content is not None,
+        missing_ok=snapshot.content is None,
+    )
+    if snapshot.content is None:
+        if not parent_exists:
+            return True
+        try:
+            current_stat = snapshot.path.lstat()
+        except FileNotFoundError:
+            return True
+        if stat.S_ISREG(current_stat.st_mode) and not stat.S_ISLNK(current_stat.st_mode):
+            current = _snapshot_launchd_plist(snapshot.path)
+            if (
+                current is not None
+                and current.content is not None
+                and _launchd_current_artifact_matches(
+                    _launchd_written_plist_artifacts,
+                    snapshot.path,
+                    current.device,
+                    current.inode,
+                    current.mode,
+                    current.content,
+                )
+            ):
+                removed = _remove_launchd_file_if_current(
+                    snapshot.path,
+                    current,
+                    _snapshot_launchd_plist,
+                    "launchd plist",
+                )
+                _launchd_written_plist_artifacts.pop(snapshot.path, None)
+                if not removed:
+                    return False
+            else:
+                _launchd_written_plist_artifacts.pop(snapshot.path, None)
+                logger.warning("Skipping launchd plist removal because %s changed after snapshot", snapshot.path)
+                return False
+        return True
+
+    current = _snapshot_launchd_plist(snapshot.path)
+    if current is not None and current.content == snapshot.content and current.mode == snapshot.mode:
+        _launchd_written_plist_artifacts.pop(snapshot.path, None)
+        return True
+    if not (
+        current is not None
+        and current.content is not None
+        and _launchd_current_artifact_matches(
+            _launchd_written_plist_artifacts,
+            snapshot.path,
+            current.device,
+            current.inode,
+            current.mode,
+            current.content,
+        )
+    ):
+        _launchd_written_plist_artifacts.pop(snapshot.path, None)
+        logger.warning("Skipping launchd plist restore because %s changed after snapshot", snapshot.path)
+        return False
+
+    restored = _replace_launchd_file_if_current(
+        snapshot.path,
+        snapshot.content,
+        snapshot.mode,
+        current,
+        _snapshot_launchd_plist,
+        "launchd plist",
+    )
+    _launchd_written_plist_artifacts.pop(snapshot.path, None)
+    return restored
+
+
+def _bootout_launchd_if_loaded(label: str) -> bool:
+    try:
+        subprocess.run(["launchctl", "bootout", f"{_launchd_domain()}/{label}"], check=True, timeout=90)
+        return True
+    except subprocess.CalledProcessError as exc:
+        if exc.returncode in {3, 113}:
+            return False
+        raise
+
+
+def _rollback_launchd_definition(
+    plist_path: Path,
+    plist_snapshot: LaunchdPlistSnapshot | None,
+    wrapper_snapshot: LaunchdWrapperSnapshot | None,
+    wrapper_parent_snapshot: LaunchdWrapperParentSnapshot | None,
+    *,
+    unload_failed: bool,
+    reload_previous: bool,
+) -> None:
+    if unload_failed:
+        try:
+            _bootout_launchd_if_loaded(get_launchd_label())
+        except (OSError, subprocess.SubprocessError) as rollback_exc:
+            logger.warning("Could not unload failed launchd service definition before rollback: %s", rollback_exc)
+    wrapper_restored = True
+    wrapper_reloadable = True
+    previous_uses_wrapper = _launchd_plist_snapshot_uses_wrapper(plist_snapshot)
+    previous_wrapper_missing = (
+        previous_uses_wrapper
+        and wrapper_snapshot is not None
+        and wrapper_snapshot.content is None
+    )
+    if previous_uses_wrapper and wrapper_snapshot is None:
+        wrapper_restored = False
+        wrapper_reloadable = False
+    elif previous_uses_wrapper and wrapper_snapshot is not None and not wrapper_snapshot.reload_safe:
+        wrapper_reloadable = False
+    try:
+        if wrapper_snapshot is not None and _launchd_gateway_wrapper_parent_is_safe_readonly(
+            wrapper_snapshot.path.parent,
+            missing_ok=wrapper_snapshot.content is None and not wrapper_snapshot.existed,
+        ):
+            wrapper_restored = _restore_launchd_gateway_wrapper(wrapper_snapshot)
+        elif wrapper_snapshot is not None:
+            wrapper_restored = False
+    except OSError as rollback_exc:
+        wrapper_restored = False
+        logger.warning("Could not restore previous launchd gateway wrapper: %s", rollback_exc)
+    if previous_wrapper_missing and wrapper_restored:
+        wrapper_restored = False
+    plist_restored = False
+    try:
+        plist_restored = _restore_launchd_plist(plist_snapshot)
+    except (OSError, RuntimeError) as rollback_exc:
+        logger.warning("Could not restore previous launchd plist at %s: %s", plist_path, rollback_exc)
+    if (
+        reload_previous
+        and wrapper_restored
+        and wrapper_reloadable
+        and plist_restored
+        and plist_snapshot is not None
+        and plist_snapshot.content is not None
+    ):
+        try:
+            _bootstrap_launchd_service_with_stale_registration_recovery(plist_path, get_launchd_label())
+        except (OSError, subprocess.SubprocessError) as rollback_exc:
+            logger.warning("Could not reload previous launchd service definition: %s", rollback_exc)
+    elif reload_previous and not wrapper_restored:
+        logger.warning("Skipping previous launchd service reload because the previous wrapper could not be restored")
+    elif reload_previous and not wrapper_reloadable:
+        logger.warning("Skipping previous launchd service reload because the previous wrapper directory was not safe")
+    elif reload_previous and not plist_restored:
+        logger.warning("Skipping previous launchd service reload because the previous plist could not be restored")
+    _restore_launchd_gateway_wrapper_parent(wrapper_parent_snapshot)
+
+
+def _launchd_plist_snapshot_uses_wrapper(snapshot: LaunchdPlistSnapshot | None) -> bool:
+    if snapshot is None or snapshot.content is None:
+        return False
+    try:
+        parsed = plistlib.loads(snapshot.content)
+    except (plistlib.InvalidFileException, ValueError, TypeError, OSError, UnicodeDecodeError):
+        text = snapshot.text()
+        return (
+            text is not None
+            and _LAUNCHD_WRAPPER_FALLBACK_ENV not in text
+            and str(_launchd_gateway_wrapper_path()) in text
+        )
+    program_arguments = parsed.get("ProgramArguments") if isinstance(parsed, dict) else None
+    environment = parsed.get("EnvironmentVariables") if isinstance(parsed, dict) else None
+    if isinstance(environment, dict) and environment.get(_LAUNCHD_WRAPPER_FALLBACK_ENV) == "1":
+        return False
+    return (
+        isinstance(program_arguments, list)
+        and bool(program_arguments)
+        and program_arguments[0] == str(_launchd_gateway_wrapper_path())
+    )
+
+
+def _launchd_plist_text_has_fallback_marker(plist_text: str) -> bool:
+    try:
+        parsed = plistlib.loads(plist_text.encode("utf-8"))
+    except (plistlib.InvalidFileException, ValueError, TypeError, OSError, UnicodeDecodeError):
+        return _LAUNCHD_WRAPPER_FALLBACK_ENV in plist_text
+    environment = parsed.get("EnvironmentVariables") if isinstance(parsed, dict) else None
+    return isinstance(environment, dict) and environment.get(_LAUNCHD_WRAPPER_FALLBACK_ENV) == "1"
+
+
+def _launchd_plist_text_has_current_fallback(
+    plist_text: str,
+    gateway_wrapper: Path | None,
+    python_path: str,
+) -> bool:
+    if not _launchd_plist_text_has_fallback_marker(plist_text):
+        return False
+    if gateway_wrapper is None:
+        return True
+    return not _launchd_gateway_wrapper_can_be_prepared_without_writing(python_path)
+
+
+def _bootstrap_launchd_service(plist_path: Path) -> None:
+    subprocess.run(
+        ["launchctl", "bootstrap", _launchd_domain(), str(plist_path)],
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+
+def _launchd_bootstrap_error_indicates_stale_registration(exc: subprocess.CalledProcessError) -> bool:
+    text = " ".join(str(part or "") for part in (getattr(exc, "stderr", ""), getattr(exc, "stdout", ""), exc)).lower()
+    return "already loaded" in text or (
+        exc.returncode == 5 and "bootstrap failed" in text and "input/output error" in text
+    )
+
+
+def _bootstrap_launchd_service_with_stale_registration_recovery(
+    plist_path: Path,
+    label: str,
+    recovery_state: LaunchdBootstrapRecoveryState | None = None,
+) -> None:
+    try:
+        _bootstrap_launchd_service(plist_path)
+    except subprocess.CalledProcessError as exc:
+        if not _launchd_bootstrap_error_indicates_stale_registration(exc):
+            raise
+        if not _bootout_launchd_if_loaded(label):
+            raise
+        if recovery_state is not None:
+            recovery_state.unloaded_stale_registration = True
+        _bootstrap_launchd_service(plist_path)
+
+
+def _kickstart_launchd_service(target: str, *, kill_existing: bool = False, timeout: int = 30) -> None:
+    cmd = ["launchctl", "kickstart"]
+    if kill_existing:
+        cmd.append("-k")
+    cmd.append(target)
+    subprocess.run(cmd, check=True, timeout=timeout)
+
+
+def _bootstrap_then_kickstart_launchd(plist_path: Path, target: str) -> None:
+    loaded_by_attempt = False
+    label = get_launchd_label()
+    recovery_state = LaunchdBootstrapRecoveryState()
+    try:
+        try:
+            _bootstrap_launchd_service_with_stale_registration_recovery(plist_path, label, recovery_state)
+        except subprocess.TimeoutExpired:
+            loaded_by_attempt = True
+            raise
+        except (OSError, subprocess.SubprocessError):
+            loaded_by_attempt = recovery_state.unloaded_stale_registration
+            raise
+        loaded_by_attempt = True
+        _kickstart_launchd_service(target)
+    except (OSError, subprocess.SubprocessError):
+        if loaded_by_attempt:
+            try:
+                _bootout_launchd_if_loaded(label)
+            except (OSError, subprocess.SubprocessError) as cleanup_exc:
+                logger.warning("Could not unload failed launchd recovery job: %s", cleanup_exc)
+        raise
+
+
+def _refresh_launchd_plist_if_needed() -> LaunchdRefreshResult:
     """Rewrite the installed launchd plist when the generated definition has changed.
 
     Unlike systemd, launchd picks up plist changes on the next ``launchctl kill``/
@@ -2885,22 +4090,121 @@ def refresh_launchd_plist_if_needed() -> bool:
     bootstrap to make launchd re-read the updated plist immediately.
     """
     plist_path = get_launchd_plist_path()
-    if not plist_path.exists() or launchd_plist_is_current():
-        return False
+    plist_snapshot = _snapshot_launchd_plist(plist_path)
+    if plist_snapshot is None or plist_snapshot.content is None:
+        return LaunchdRefreshResult(False)
+    installed = plist_snapshot.text()
 
-    plist_path.write_text(generate_launchd_plist(), encoding="utf-8")
+    python_path = get_python_path()
+    gateway_wrapper = _launchd_gateway_wrapper_for_plist(python_path, prepare_paths=False)
+    expected = generate_launchd_plist(prepare_paths=False)
+    fallback_expected = generate_launchd_plist(prepare_paths=False, force_python=True)
+    if installed is not None:
+        if (
+            _normalize_launchd_plist_for_comparison(installed) == _normalize_launchd_plist_for_comparison(expected)
+            and (gateway_wrapper is None or _launchd_gateway_wrapper_is_current(python_path))
+        ) or (
+            _launchd_plist_text_has_current_fallback(
+                installed,
+                gateway_wrapper,
+                python_path,
+            )
+            and _normalize_launchd_plist_for_comparison(installed) == _normalize_launchd_plist_for_comparison(
+                fallback_expected
+            )
+        ):
+            return LaunchdRefreshResult(False)
+
+    wrapper_parent_snapshot = _snapshot_launchd_gateway_wrapper_parent()
+    wrapper_snapshot = _snapshot_launchd_gateway_wrapper()
+    expected = generate_launchd_plist()
+    if installed is not None and _normalize_launchd_plist_for_comparison(
+        installed
+    ) == _normalize_launchd_plist_for_comparison(expected):
+        return LaunchdRefreshResult(False)
+
     label = get_launchd_label()
-    # Bootout/bootstrap so launchd picks up the new definition
-    subprocess.run(["launchctl", "bootout", f"{_launchd_domain()}/{label}"], check=False, timeout=90)
-    subprocess.run(["launchctl", "bootstrap", _launchd_domain(), str(plist_path)], check=False, timeout=30)
+    # Bootout/bootstrap so launchd picks up the new definition. Keep the old
+    # plist and wrapper on disk if bootout fails so the refresh stays retryable.
+    try:
+        was_loaded = _bootout_launchd_if_loaded(label)
+    except subprocess.TimeoutExpired:
+        _rollback_launchd_definition(
+            plist_path,
+            plist_snapshot,
+            wrapper_snapshot,
+            wrapper_parent_snapshot,
+            unload_failed=False,
+            reload_previous=True,
+        )
+        raise
+    except (OSError, subprocess.SubprocessError):
+        _rollback_launchd_definition(
+            plist_path,
+            plist_snapshot,
+            wrapper_snapshot,
+            wrapper_parent_snapshot,
+            unload_failed=False,
+            reload_previous=False,
+        )
+        raise
+    loaded_by_attempt = False
+    recovery_state = LaunchdBootstrapRecoveryState()
+    try:
+        _write_launchd_plist(plist_path, expected)
+        try:
+            _bootstrap_launchd_service_with_stale_registration_recovery(plist_path, label, recovery_state)
+        except subprocess.TimeoutExpired:
+            loaded_by_attempt = True
+            raise
+        except (OSError, subprocess.SubprocessError):
+            loaded_by_attempt = recovery_state.unloaded_stale_registration
+            raise
+    except (OSError, RuntimeError, subprocess.SubprocessError):
+        _rollback_launchd_definition(
+            plist_path,
+            plist_snapshot,
+            wrapper_snapshot,
+            wrapper_parent_snapshot,
+            unload_failed=loaded_by_attempt,
+            reload_previous=was_loaded or recovery_state.unloaded_stale_registration,
+        )
+        raise
     print("↻ Updated gateway launchd service definition to match the current Hermes install")
-    return True
+    return LaunchdRefreshResult(
+        True,
+        LaunchdRefreshRollback(
+            plist_path=plist_path,
+            plist_snapshot=plist_snapshot,
+            wrapper_snapshot=wrapper_snapshot,
+            wrapper_parent_snapshot=wrapper_parent_snapshot,
+            reload_previous=was_loaded or recovery_state.unloaded_stale_registration,
+        ),
+    )
+
+
+def refresh_launchd_plist_if_needed() -> bool:
+    return _refresh_launchd_plist_if_needed().refreshed
+
+
+def _rollback_launchd_refresh_after_followup_failure(refresh: LaunchdRefreshResult) -> None:
+    if refresh.rollback is None:
+        return
+    _rollback_launchd_definition(
+        refresh.rollback.plist_path,
+        refresh.rollback.plist_snapshot,
+        refresh.rollback.wrapper_snapshot,
+        refresh.rollback.wrapper_parent_snapshot,
+        unload_failed=True,
+        reload_previous=refresh.rollback.reload_previous,
+    )
 
 
 def launchd_install(force: bool = False):
     plist_path = get_launchd_plist_path()
+    plist_missing = _launchd_plist_missing(plist_path)
     
-    if plist_path.exists() and not force:
+    if not plist_missing and not force:
         if not launchd_plist_is_current():
             print(f"↻ Repairing outdated launchd service at: {plist_path}")
             refresh_launchd_plist_if_needed()
@@ -2910,11 +4214,54 @@ def launchd_install(force: bool = False):
         print("Use --force to reinstall")
         return
     
-    plist_path.parent.mkdir(parents=True, exist_ok=True)
     print(f"Installing launchd service to: {plist_path}")
-    plist_path.write_text(generate_launchd_plist())
-    
-    subprocess.run(["launchctl", "bootstrap", _launchd_domain(), str(plist_path)], check=True, timeout=30)
+    plist_snapshot = (
+        LaunchdPlistSnapshot(path=plist_path, content=None)
+        if plist_missing
+        else _snapshot_launchd_plist(plist_path)
+    )
+    wrapper_parent_snapshot = _snapshot_launchd_gateway_wrapper_parent()
+    wrapper_snapshot = _snapshot_launchd_gateway_wrapper()
+    was_loaded = False
+    if plist_snapshot is not None and plist_snapshot.content is not None:
+        try:
+            was_loaded = _bootout_launchd_if_loaded(get_launchd_label())
+        except subprocess.TimeoutExpired:
+            _rollback_launchd_definition(
+                plist_path,
+                plist_snapshot,
+                wrapper_snapshot,
+                wrapper_parent_snapshot,
+                unload_failed=False,
+                reload_previous=True,
+            )
+            raise
+    loaded_by_attempt = False
+    recovery_state = LaunchdBootstrapRecoveryState()
+    try:
+        _write_launchd_plist(plist_path, generate_launchd_plist())
+        try:
+            _bootstrap_launchd_service_with_stale_registration_recovery(
+                plist_path,
+                get_launchd_label(),
+                recovery_state,
+            )
+        except subprocess.TimeoutExpired:
+            loaded_by_attempt = True
+            raise
+        except (OSError, subprocess.SubprocessError):
+            loaded_by_attempt = recovery_state.unloaded_stale_registration
+            raise
+    except (OSError, RuntimeError, subprocess.SubprocessError):
+        _rollback_launchd_definition(
+            plist_path,
+            plist_snapshot,
+            wrapper_snapshot,
+            wrapper_parent_snapshot,
+            unload_failed=loaded_by_attempt,
+            reload_previous=was_loaded or recovery_state.unloaded_stale_registration,
+        )
+        raise
     
     print()
     print("✓ Service installed and loaded!")
@@ -2927,11 +4274,18 @@ def launchd_install(force: bool = False):
 def launchd_uninstall():
     plist_path = get_launchd_plist_path()
     label = get_launchd_label()
-    subprocess.run(["launchctl", "bootout", f"{_launchd_domain()}/{label}"], check=False, timeout=90)
+    plist_removal_candidate = _launchd_plist_removal_candidate(plist_path)
+    python_path = get_python_path()
+    wrapper_removal_candidate = _launchd_gateway_wrapper_removal_candidate(python_path)
+    result = subprocess.run(["launchctl", "bootout", f"{_launchd_domain()}/{label}"], check=False, timeout=90)
+    if result.returncode not in {0, 3, 113}:
+        raise subprocess.CalledProcessError(result.returncode, ["launchctl", "bootout", f"{_launchd_domain()}/{label}"])
     
-    if plist_path.exists():
-        plist_path.unlink()
+    if plist_removal_candidate is not None and _remove_launchd_plist_candidate(plist_removal_candidate):
         print(f"✓ Removed {plist_path}")
+
+    if _remove_launchd_gateway_wrapper_candidate(wrapper_removal_candidate):
+        print(f"✓ Removed {_launchd_gateway_wrapper_path()}")
     
     print("✓ Service uninstalled")
 
@@ -2940,24 +4294,53 @@ def launchd_start():
     label = get_launchd_label()
 
     # Self-heal if the plist is missing entirely (e.g., manual cleanup, failed upgrade)
-    if not plist_path.exists():
+    if _launchd_plist_missing(plist_path):
         print("↻ launchd plist missing; regenerating service definition")
-        plist_path.parent.mkdir(parents=True, exist_ok=True)
-        plist_path.write_text(generate_launchd_plist(), encoding="utf-8")
-        subprocess.run(["launchctl", "bootstrap", _launchd_domain(), str(plist_path)], check=True, timeout=30)
-        subprocess.run(["launchctl", "kickstart", f"{_launchd_domain()}/{label}"], check=True, timeout=30)
+        wrapper_parent_snapshot = _snapshot_launchd_gateway_wrapper_parent()
+        wrapper_snapshot = _snapshot_launchd_gateway_wrapper()
+        loaded_by_attempt = False
+        recovery_state = LaunchdBootstrapRecoveryState()
+        try:
+            _write_launchd_plist(plist_path, generate_launchd_plist())
+            try:
+                _bootstrap_launchd_service_with_stale_registration_recovery(plist_path, label, recovery_state)
+            except subprocess.TimeoutExpired:
+                loaded_by_attempt = True
+                raise
+            except (OSError, subprocess.SubprocessError):
+                loaded_by_attempt = recovery_state.unloaded_stale_registration
+                raise
+            loaded_by_attempt = True
+            _kickstart_launchd_service(f"{_launchd_domain()}/{label}")
+        except (OSError, RuntimeError, subprocess.SubprocessError):
+            _rollback_launchd_definition(
+                plist_path,
+                LaunchdPlistSnapshot(path=plist_path, content=None),
+                wrapper_snapshot,
+                wrapper_parent_snapshot,
+                unload_failed=loaded_by_attempt,
+                reload_previous=False,
+            )
+            raise
         print("✓ Service started")
         return
 
-    refresh_launchd_plist_if_needed()
+    refresh = _refresh_launchd_plist_if_needed()
     try:
         subprocess.run(["launchctl", "kickstart", f"{_launchd_domain()}/{label}"], check=True, timeout=30)
     except subprocess.CalledProcessError as e:
         if e.returncode not in {3, 113}:
+            _rollback_launchd_refresh_after_followup_failure(refresh)
             raise
         print("↻ launchd job was unloaded; reloading service definition")
-        subprocess.run(["launchctl", "bootstrap", _launchd_domain(), str(plist_path)], check=True, timeout=30)
-        subprocess.run(["launchctl", "kickstart", f"{_launchd_domain()}/{label}"], check=True, timeout=30)
+        try:
+            _bootstrap_then_kickstart_launchd(plist_path, f"{_launchd_domain()}/{label}")
+        except (OSError, subprocess.SubprocessError):
+            _rollback_launchd_refresh_after_followup_failure(refresh)
+            raise
+    except (OSError, subprocess.SubprocessError):
+        _rollback_launchd_refresh_after_followup_failure(refresh)
+        raise
     print("✓ Service started")
 
 def launchd_stop():
@@ -3032,9 +4415,12 @@ def launchd_restart():
     drain_timeout = _get_restart_drain_timeout()
     from gateway.status import get_running_pid
 
+    refresh = LaunchdRefreshResult(False)
     try:
+        refresh = _refresh_launchd_plist_if_needed()
+        refreshed = refresh.refreshed
         pid = get_running_pid()
-        if pid is not None and _request_gateway_self_restart(pid):
+        if pid is not None and not refreshed and _request_gateway_self_restart(pid):
             print("✓ Service restart requested")
             return
         if pid is not None:
@@ -3050,13 +4436,20 @@ def launchd_restart():
         print("✓ Service restarted")
     except subprocess.CalledProcessError as e:
         if e.returncode not in {3, 113}:
+            _rollback_launchd_refresh_after_followup_failure(refresh)
             raise
         # Job not loaded — bootstrap and start fresh
         print("↻ launchd job was unloaded; reloading")
         plist_path = get_launchd_plist_path()
-        subprocess.run(["launchctl", "bootstrap", _launchd_domain(), str(plist_path)], check=True, timeout=30)
-        subprocess.run(["launchctl", "kickstart", target], check=True, timeout=30)
+        try:
+            _bootstrap_then_kickstart_launchd(plist_path, target)
+        except (OSError, subprocess.SubprocessError):
+            _rollback_launchd_refresh_after_followup_failure(refresh)
+            raise
         print("✓ Service restarted")
+    except (OSError, subprocess.SubprocessError):
+        _rollback_launchd_refresh_after_followup_failure(refresh)
+        raise
 
 def launchd_status(deep: bool = False):
     plist_path = get_launchd_plist_path()

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -1,6 +1,8 @@
 """Tests for gateway service management helpers."""
 
 import os
+import plistlib
+import stat
 import subprocess
 from pathlib import Path
 from types import SimpleNamespace
@@ -38,6 +40,10 @@ class TestUserSystemdPrivateSocketPreflight:
 
 
 class TestSystemdServiceRefresh:
+    @pytest.fixture(autouse=True)
+    def _skip_user_systemd_preflight(self, monkeypatch):
+        monkeypatch.setattr(gateway_cli, "_preflight_user_systemd", lambda *args, **kwargs: None)
+
     def test_systemd_install_repairs_outdated_unit_without_force(self, tmp_path, monkeypatch):
         unit_path = tmp_path / "hermes-gateway.service"
         unit_path.write_text("old unit\n", encoding="utf-8")
@@ -450,6 +456,14 @@ class TestGatewayStopCleanup:
 
 
 class TestLaunchdServiceRecovery:
+    @pytest.fixture(autouse=True)
+    def _sandbox_launchd_home(self, tmp_path, monkeypatch):
+        profile_dir = tmp_path / ".hermes" / "profiles" / "launchd-test"
+        profile_dir.mkdir(parents=True)
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(profile_dir))
+        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: profile_dir)
+
     def test_get_restart_drain_timeout_prefers_env_then_config_then_default(self, monkeypatch):
         monkeypatch.delenv("HERMES_RESTART_DRAIN_TIMEOUT", raising=False)
         monkeypatch.setattr(gateway_cli, "read_raw_config", lambda: {})
@@ -554,10 +568,1459 @@ class TestLaunchdServiceRecovery:
             ["launchctl", "kickstart", target],
         ]
 
+    def test_launchd_start_recovery_boots_out_after_final_kickstart_failure(self, tmp_path, monkeypatch):
+        plist_path = tmp_path / "ai.hermes.gateway.plist"
+        plist_path.write_text(gateway_cli.generate_launchd_plist(), encoding="utf-8")
+        label = gateway_cli.get_launchd_label()
+        calls = []
+        domain = gateway_cli._launchd_domain()
+        target = f"{domain}/{label}"
+
+        def fake_run(cmd, check=False, **kwargs):
+            if cmd and cmd[0] == "launchctl":
+                calls.append(cmd)
+            if cmd == ["launchctl", "kickstart", target] and calls.count(cmd) == 1:
+                raise gateway_cli.subprocess.CalledProcessError(113, cmd, stderr="Could not find service")
+            if cmd == ["launchctl", "kickstart", target] and calls.count(cmd) == 2:
+                raise gateway_cli.subprocess.CalledProcessError(5, cmd, stderr="kickstart failed")
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        with pytest.raises(gateway_cli.subprocess.CalledProcessError):
+            gateway_cli.launchd_start()
+
+        assert calls == [
+            ["launchctl", "kickstart", target],
+            ["launchctl", "bootstrap", domain, str(plist_path)],
+            ["launchctl", "kickstart", target],
+            ["launchctl", "bootout", target],
+        ]
+
+    def test_launchd_refresh_rewrites_old_python_plist_to_profile_wrapper(self, tmp_path, monkeypatch):
+        profile_dir = tmp_path / ".hermes" / "profiles" / "mybot"
+        profile_dir.mkdir(parents=True)
+        python_path = tmp_path / "venv" / "bin" / "python"
+        python_path.parent.mkdir(parents=True)
+        python_path.write_text("")
+        plist_path = tmp_path / "ai.hermes.gateway-mybot.plist"
+        plist_path.write_text(
+            f"""
+<plist version="1.0">
+<dict>
+    <key>ProgramArguments</key>
+    <array>
+        <string>{python_path}</string>
+        <string>-m</string>
+        <string>hermes_cli.main</string>
+        <string>--profile</string>
+        <string>mybot</string>
+        <string>gateway</string>
+        <string>run</string>
+        <string>--replace</string>
+    </array>
+</dict>
+</plist>
+""",
+            encoding="utf-8",
+        )
+        calls = []
+
+        def fake_run(cmd, check=False, **kwargs):
+            calls.append(cmd)
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(profile_dir))
+        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: profile_dir)
+        monkeypatch.setattr(gateway_cli, "get_python_path", lambda: str(python_path))
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        assert gateway_cli.refresh_launchd_plist_if_needed() is True
+
+        wrapper = profile_dir / "bin" / "hermes-gateway-mybot"
+        updated = plist_path.read_text(encoding="utf-8")
+        assert f"<string>{wrapper}</string>" in updated
+        assert f"<string>{python_path}</string>" not in updated
+        assert "<string>-m</string>" not in updated
+        assert "<string>hermes_cli.main</string>" not in updated
+        assert calls == [
+            ["launchctl", "bootout", f"{gateway_cli._launchd_domain()}/{gateway_cli.get_launchd_label()}"],
+            ["launchctl", "bootstrap", gateway_cli._launchd_domain(), str(plist_path)],
+        ]
+
+    def test_launchd_old_python_plist_is_not_current_when_wrapper_available(self, tmp_path, monkeypatch):
+        profile_dir = tmp_path / ".hermes" / "profiles" / "mybot"
+        profile_dir.mkdir(parents=True)
+        python_path = tmp_path / "venv" / "bin" / "python"
+        python_path.parent.mkdir(parents=True)
+        python_path.write_text("")
+        plist_path = tmp_path / "ai.hermes.gateway-mybot.plist"
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(profile_dir))
+        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: profile_dir)
+        monkeypatch.setattr(gateway_cli, "get_python_path", lambda: str(python_path))
+        old_python_plist = gateway_cli.generate_launchd_plist(prepare_paths=False, force_python=True).replace(
+            """
+        <key>HERMES_LAUNCHD_WRAPPER_FALLBACK</key>
+        <string>1</string>""",
+            "",
+        )
+        plist_path.write_text(old_python_plist, encoding="utf-8")
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+
+        assert gateway_cli.launchd_plist_is_current() is False
+
+    def test_launchd_refresh_refuses_symlinked_plist_path(self, tmp_path, monkeypatch):
+        profile_dir = tmp_path / ".hermes" / "profiles" / "mybot"
+        profile_dir.mkdir(parents=True)
+        target = tmp_path / "target.plist"
+        target.write_text("<plist>old content</plist>", encoding="utf-8")
+        plist_path = tmp_path / "ai.hermes.gateway-mybot.plist"
+        plist_path.symlink_to(target)
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(profile_dir))
+        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: profile_dir)
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+        monkeypatch.setattr(
+            gateway_cli.subprocess,
+            "run",
+            lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("launchctl should not run")),
+        )
+
+        with pytest.raises(RuntimeError, match="Refusing to replace unsafe launchd plist path"):
+            gateway_cli.refresh_launchd_plist_if_needed()
+
+        assert plist_path.is_symlink()
+        assert target.read_text(encoding="utf-8") == "<plist>old content</plist>"
+
+    def test_launchd_plist_current_refuses_current_symlinked_plist_path(self, tmp_path, monkeypatch):
+        profile_dir = tmp_path / ".hermes" / "profiles" / "mybot"
+        profile_dir.mkdir(parents=True)
+        python_path = tmp_path / "venv" / "bin" / "python"
+        python_path.parent.mkdir(parents=True)
+        python_path.write_text("")
+        target = tmp_path / "target.plist"
+        plist_path = tmp_path / "ai.hermes.gateway-mybot.plist"
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(profile_dir))
+        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: profile_dir)
+        monkeypatch.setattr(gateway_cli, "get_python_path", lambda: str(python_path))
+        target.write_text(gateway_cli.generate_launchd_plist(), encoding="utf-8")
+        plist_path.symlink_to(target)
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+
+        with pytest.raises(RuntimeError, match="Refusing to replace unsafe launchd plist path"):
+            gateway_cli.launchd_plist_is_current()
+
+    def test_launchd_refresh_keeps_old_plist_retryable_when_bootout_fails(self, tmp_path, monkeypatch):
+        plist_path = tmp_path / "ai.hermes.gateway.plist"
+        old_content = "<plist>old content</plist>"
+        plist_path.write_text(old_content, encoding="utf-8")
+        calls = []
+
+        def fake_run(cmd, check=False, **kwargs):
+            calls.append(cmd)
+            raise gateway_cli.subprocess.CalledProcessError(5, cmd, stderr="bootout failed")
+
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        with pytest.raises(gateway_cli.subprocess.CalledProcessError):
+            gateway_cli.refresh_launchd_plist_if_needed()
+
+        assert plist_path.read_text(encoding="utf-8") == old_content
+        assert calls == [
+            ["launchctl", "bootout", f"{gateway_cli._launchd_domain()}/{gateway_cli.get_launchd_label()}"],
+        ]
+
+    def test_launchd_refresh_restores_wrapper_when_bootout_fails_after_generation(self, tmp_path, monkeypatch):
+        profile_dir = tmp_path / ".hermes" / "profiles" / "mybot"
+        (profile_dir / "node" / "bin").mkdir(parents=True)
+        plist_path = tmp_path / "ai.hermes.gateway.plist"
+        old_python_path = tmp_path / "old-venv" / "bin" / "python"
+        old_python_path.parent.mkdir(parents=True)
+        old_python_path.write_text("")
+        new_python_path = tmp_path / "new-venv" / "bin" / "python"
+        new_python_path.parent.mkdir(parents=True)
+        new_python_path.write_text("")
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(profile_dir))
+        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: profile_dir)
+        monkeypatch.setattr(gateway_cli, "get_python_path", lambda: str(old_python_path))
+        old_plist = gateway_cli.generate_launchd_plist()
+        parsed = plistlib.loads(old_plist.encode("utf-8"))
+        required_path = str((profile_dir / "node" / "bin").resolve())
+        path_entries = parsed["EnvironmentVariables"]["PATH"].split(":")
+        assert required_path in path_entries
+        old_path = parsed["EnvironmentVariables"]["PATH"]
+        stale_path = ":".join(path for path in path_entries if path != required_path)
+        old_plist = old_plist.replace(
+            gateway_cli._plist_string(old_path),
+            gateway_cli._plist_string(stale_path),
+            1,
+        )
+        plist_path.write_text(old_plist, encoding="utf-8")
+        wrapper = profile_dir / "bin" / "hermes-gateway-mybot"
+        old_wrapper = wrapper.read_bytes()
+        old_mode = stat.S_IMODE(wrapper.stat().st_mode)
+        calls = []
+
+        def fake_run(cmd, check=False, **kwargs):
+            calls.append(cmd)
+            if cmd[1] == "bootout":
+                raise gateway_cli.subprocess.CalledProcessError(5, cmd, stderr="bootout failed")
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(gateway_cli, "get_python_path", lambda: str(new_python_path))
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        with pytest.raises(gateway_cli.subprocess.CalledProcessError):
+            gateway_cli.refresh_launchd_plist_if_needed()
+
+        assert plist_path.read_text(encoding="utf-8") == old_plist
+        assert wrapper.read_bytes() == old_wrapper
+        assert stat.S_IMODE(wrapper.stat().st_mode) == old_mode
+        assert calls == [
+            ["launchctl", "bootout", f"{gateway_cli._launchd_domain()}/{gateway_cli.get_launchd_label()}"],
+        ]
+
+    def test_launchd_refresh_restores_wrapper_parent_mode_when_bootout_fails(self, tmp_path, monkeypatch):
+        profile_dir = tmp_path / ".hermes" / "profiles" / "mybot"
+        profile_dir.mkdir(parents=True)
+        wrapper_parent = profile_dir / "bin"
+        wrapper_parent.mkdir()
+        wrapper_parent.chmod(0o777)
+        plist_path = tmp_path / "ai.hermes.gateway.plist"
+        plist_path.write_text("<plist>old content</plist>", encoding="utf-8")
+        python_path = tmp_path / "venv" / "bin" / "python"
+        python_path.parent.mkdir(parents=True)
+        python_path.write_text("")
+
+        def fake_run(cmd, check=False, **kwargs):
+            if cmd[1] == "bootout":
+                raise gateway_cli.subprocess.CalledProcessError(5, cmd, stderr="bootout failed")
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(profile_dir))
+        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: profile_dir)
+        monkeypatch.setattr(gateway_cli, "get_python_path", lambda: str(python_path))
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        try:
+            with pytest.raises(gateway_cli.subprocess.CalledProcessError):
+                gateway_cli.refresh_launchd_plist_if_needed()
+
+            assert stat.S_IMODE(wrapper_parent.stat().st_mode) == 0o777
+            assert not (wrapper_parent / "hermes-gateway-mybot").exists()
+        finally:
+            wrapper_parent.chmod(0o755)
+
+    def test_launchd_refresh_preserves_wrapper_parent_mode_changed_after_secure_step(self, tmp_path, monkeypatch):
+        profile_dir = tmp_path / ".hermes" / "profiles" / "mybot"
+        profile_dir.mkdir(parents=True)
+        wrapper_parent = profile_dir / "bin"
+        wrapper_parent.mkdir()
+        wrapper_parent.chmod(0o777)
+        plist_path = tmp_path / "ai.hermes.gateway.plist"
+        plist_path.write_text("<plist>old content</plist>", encoding="utf-8")
+        python_path = tmp_path / "venv" / "bin" / "python"
+        python_path.parent.mkdir(parents=True)
+        python_path.write_text("")
+
+        def fake_run(cmd, check=False, **kwargs):
+            if cmd[1] == "bootout":
+                wrapper_parent.chmod(0o700)
+                raise gateway_cli.subprocess.CalledProcessError(5, cmd, stderr="bootout failed")
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(profile_dir))
+        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: profile_dir)
+        monkeypatch.setattr(gateway_cli, "get_python_path", lambda: str(python_path))
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        try:
+            with pytest.raises(gateway_cli.subprocess.CalledProcessError):
+                gateway_cli.refresh_launchd_plist_if_needed()
+
+            assert stat.S_IMODE(wrapper_parent.stat().st_mode) == 0o700
+        finally:
+            wrapper_parent.chmod(0o755)
+
+    def test_launchd_refresh_preserves_group_writable_wrapper_parent_changed_after_secure_step(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        profile_dir = tmp_path / ".hermes" / "profiles" / "mybot"
+        profile_dir.mkdir(parents=True)
+        wrapper_parent = profile_dir / "bin"
+        wrapper_parent.mkdir()
+        wrapper_parent.chmod(0o777)
+        plist_path = tmp_path / "ai.hermes.gateway.plist"
+        plist_path.write_text("<plist>old content</plist>", encoding="utf-8")
+        python_path = tmp_path / "venv" / "bin" / "python"
+        python_path.parent.mkdir(parents=True)
+        python_path.write_text("")
+
+        def fake_run(cmd, check=False, **kwargs):
+            if cmd[1] == "bootout":
+                wrapper_parent.chmod(0o775)
+                raise gateway_cli.subprocess.CalledProcessError(5, cmd, stderr="bootout failed")
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(profile_dir))
+        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: profile_dir)
+        monkeypatch.setattr(gateway_cli, "get_python_path", lambda: str(python_path))
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        try:
+            with pytest.raises(gateway_cli.subprocess.CalledProcessError):
+                gateway_cli.refresh_launchd_plist_if_needed()
+
+            assert stat.S_IMODE(wrapper_parent.stat().st_mode) == 0o775
+        finally:
+            wrapper_parent.chmod(0o755)
+
+    def test_launchd_refresh_reloads_previous_plist_when_bootout_times_out(self, tmp_path, monkeypatch):
+        plist_path = tmp_path / "ai.hermes.gateway.plist"
+        old_content = "<plist>old content</plist>"
+        plist_path.write_text(old_content, encoding="utf-8")
+        calls = []
+
+        def fake_run(cmd, check=False, **kwargs):
+            calls.append((cmd, check))
+            if cmd[1] == "bootout":
+                raise gateway_cli.subprocess.TimeoutExpired(cmd, timeout=90)
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        with pytest.raises(gateway_cli.subprocess.TimeoutExpired):
+            gateway_cli.refresh_launchd_plist_if_needed()
+
+        assert plist_path.read_text(encoding="utf-8") == old_content
+        assert calls == [
+            (["launchctl", "bootout", f"{gateway_cli._launchd_domain()}/{gateway_cli.get_launchd_label()}"], True),
+            (["launchctl", "bootstrap", gateway_cli._launchd_domain(), str(plist_path)], True),
+        ]
+
+    def test_launchd_refresh_rolls_back_when_bootstrap_fails(self, tmp_path, monkeypatch):
+        profile_dir = tmp_path / ".hermes" / "profiles" / "mybot"
+        profile_dir.mkdir(parents=True)
+        plist_path = tmp_path / "ai.hermes.gateway.plist"
+        old_content = "<plist>old content</plist>"
+        plist_path.write_text(old_content, encoding="utf-8")
+        wrapper = profile_dir / "bin" / "hermes-gateway-mybot"
+        wrapper.parent.mkdir()
+        old_wrapper = b"#!/bin/sh\nexec /old/python -m hermes_cli.main \"$@\"\n"
+        wrapper.write_bytes(old_wrapper)
+        wrapper.chmod(0o700)
+        python_path = tmp_path / "venv" / "bin" / "python"
+        python_path.parent.mkdir(parents=True)
+        python_path.write_text("")
+        calls = []
+
+        def fake_run(cmd, check=False, **kwargs):
+            calls.append((cmd, check))
+            if cmd[1] == "bootstrap" and check:
+                raise gateway_cli.subprocess.CalledProcessError(5, cmd, stderr="bootstrap failed")
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(profile_dir))
+        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: profile_dir)
+        monkeypatch.setattr(gateway_cli, "get_python_path", lambda: str(python_path))
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        with pytest.raises(gateway_cli.subprocess.CalledProcessError):
+            gateway_cli.refresh_launchd_plist_if_needed()
+
+        assert plist_path.read_text(encoding="utf-8") == old_content
+        assert wrapper.read_bytes() == old_wrapper
+        assert stat.S_IMODE(wrapper.stat().st_mode) == 0o700
+        assert calls == [
+            (["launchctl", "bootout", f"{gateway_cli._launchd_domain()}/{gateway_cli.get_launchd_label()}"], True),
+            (["launchctl", "bootstrap", gateway_cli._launchd_domain(), str(plist_path)], True),
+            (["launchctl", "bootstrap", gateway_cli._launchd_domain(), str(plist_path)], True),
+        ]
+
+    def test_launchd_refresh_warns_when_previous_reload_fails(self, tmp_path, monkeypatch, caplog):
+        profile_dir = tmp_path / ".hermes" / "profiles" / "mybot"
+        profile_dir.mkdir(parents=True)
+        plist_path = tmp_path / "ai.hermes.gateway.plist"
+        old_content = "<plist>old content</plist>"
+        plist_path.write_text(old_content, encoding="utf-8")
+        python_path = tmp_path / "venv" / "bin" / "python"
+        python_path.parent.mkdir(parents=True)
+        python_path.write_text("")
+        calls = []
+
+        def fake_run(cmd, check=False, **kwargs):
+            calls.append((cmd, check))
+            if cmd[1] == "bootstrap" and check:
+                raise gateway_cli.subprocess.CalledProcessError(5, cmd, stderr="bootstrap failed")
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(profile_dir))
+        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: profile_dir)
+        monkeypatch.setattr(gateway_cli, "get_python_path", lambda: str(python_path))
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        with caplog.at_level("WARNING", logger=gateway_cli.logger.name):
+            with pytest.raises(gateway_cli.subprocess.CalledProcessError):
+                gateway_cli.refresh_launchd_plist_if_needed()
+
+        assert plist_path.read_text(encoding="utf-8") == old_content
+        assert calls == [
+            (["launchctl", "bootout", f"{gateway_cli._launchd_domain()}/{gateway_cli.get_launchd_label()}"], True),
+            (["launchctl", "bootstrap", gateway_cli._launchd_domain(), str(plist_path)], True),
+            (["launchctl", "bootstrap", gateway_cli._launchd_domain(), str(plist_path)], True),
+        ]
+        assert "Could not reload previous launchd service definition" in caplog.text
+
+    def test_launchd_refresh_does_not_reload_previous_when_plist_changed_after_write(
+        self,
+        tmp_path,
+        monkeypatch,
+        caplog,
+    ):
+        profile_dir = tmp_path / ".hermes" / "profiles" / "mybot"
+        profile_dir.mkdir(parents=True)
+        plist_path = tmp_path / "ai.hermes.gateway.plist"
+        old_content = "<plist>old content</plist>"
+        user_content = "<plist>user content</plist>"
+        plist_path.write_text(old_content, encoding="utf-8")
+        python_path = tmp_path / "venv" / "bin" / "python"
+        python_path.parent.mkdir(parents=True)
+        python_path.write_text("")
+        calls = []
+        bootstrap_attempts = 0
+
+        def fake_run(cmd, check=False, **kwargs):
+            nonlocal bootstrap_attempts
+            calls.append((cmd, check))
+            if cmd[1] == "bootstrap" and check:
+                bootstrap_attempts += 1
+                if bootstrap_attempts == 1:
+                    plist_path.write_text(user_content, encoding="utf-8")
+                    raise gateway_cli.subprocess.CalledProcessError(5, cmd, stderr="bootstrap failed")
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(profile_dir))
+        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: profile_dir)
+        monkeypatch.setattr(gateway_cli, "get_python_path", lambda: str(python_path))
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        with caplog.at_level("WARNING", logger=gateway_cli.logger.name):
+            with pytest.raises(gateway_cli.subprocess.CalledProcessError):
+                gateway_cli.refresh_launchd_plist_if_needed()
+
+        assert plist_path.read_text(encoding="utf-8") == user_content
+        assert calls == [
+            (["launchctl", "bootout", f"{gateway_cli._launchd_domain()}/{gateway_cli.get_launchd_label()}"], True),
+            (["launchctl", "bootstrap", gateway_cli._launchd_domain(), str(plist_path)], True),
+        ]
+        assert "Skipping previous launchd service reload because the previous plist could not be restored" in caplog.text
+
+    def test_launchd_refresh_does_not_reload_previous_when_plist_replaced_during_restore(
+        self,
+        tmp_path,
+        monkeypatch,
+        caplog,
+    ):
+        profile_dir = tmp_path / ".hermes" / "profiles" / "mybot"
+        profile_dir.mkdir(parents=True)
+        plist_path = tmp_path / "ai.hermes.gateway.plist"
+        old_content = "<plist>old content</plist>"
+        user_content = "<plist>user content</plist>"
+        plist_path.write_text(old_content, encoding="utf-8")
+        python_path = tmp_path / "venv" / "bin" / "python"
+        python_path.parent.mkdir(parents=True)
+        python_path.write_text("")
+        calls = []
+        bootstrap_attempts = 0
+        race_during_restore = {"enabled": False}
+        real_replace = gateway_cli.os.replace
+
+        def replace_plist_before_quarantine(src, dst):
+            if race_during_restore["enabled"] and (Path(src) == plist_path or Path(dst) == plist_path):
+                race_during_restore["enabled"] = False
+                plist_path.write_text(user_content, encoding="utf-8")
+            real_replace(src, dst)
+
+        def fake_run(cmd, check=False, **kwargs):
+            nonlocal bootstrap_attempts
+            calls.append((cmd, check))
+            if cmd[1] == "bootstrap" and check:
+                bootstrap_attempts += 1
+                if bootstrap_attempts == 1:
+                    race_during_restore["enabled"] = True
+                    raise gateway_cli.subprocess.CalledProcessError(5, cmd, stderr="bootstrap failed")
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(profile_dir))
+        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: profile_dir)
+        monkeypatch.setattr(gateway_cli, "get_python_path", lambda: str(python_path))
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+        monkeypatch.setattr(gateway_cli.os, "replace", replace_plist_before_quarantine)
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        with caplog.at_level("WARNING", logger=gateway_cli.logger.name):
+            with pytest.raises(gateway_cli.subprocess.CalledProcessError):
+                gateway_cli.refresh_launchd_plist_if_needed()
+
+        assert plist_path.read_text(encoding="utf-8") == user_content
+        assert calls == [
+            (["launchctl", "bootout", f"{gateway_cli._launchd_domain()}/{gateway_cli.get_launchd_label()}"], True),
+            (["launchctl", "bootstrap", gateway_cli._launchd_domain(), str(plist_path)], True),
+        ]
+        assert "Skipping previous launchd service reload because the previous plist could not be restored" in caplog.text
+
+    def test_launchd_refresh_uses_stale_registration_recovery_when_reloading_previous(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        profile_dir = tmp_path / ".hermes" / "profiles" / "mybot"
+        profile_dir.mkdir(parents=True)
+        plist_path = tmp_path / "ai.hermes.gateway.plist"
+        old_content = "<plist>old content</plist>"
+        plist_path.write_text(old_content, encoding="utf-8")
+        python_path = tmp_path / "venv" / "bin" / "python"
+        python_path.parent.mkdir(parents=True)
+        python_path.write_text("")
+        calls = []
+        bootstrap_attempts = 0
+
+        def fake_run(cmd, check=False, **kwargs):
+            nonlocal bootstrap_attempts
+            calls.append((cmd, check))
+            if cmd[1] == "bootstrap" and check:
+                bootstrap_attempts += 1
+                if bootstrap_attempts == 1:
+                    raise gateway_cli.subprocess.CalledProcessError(5, cmd, stderr="bootstrap failed")
+                if bootstrap_attempts == 2:
+                    raise gateway_cli.subprocess.CalledProcessError(
+                        5,
+                        cmd,
+                        stderr="Bootstrap failed: 5: Input/output error",
+                    )
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(profile_dir))
+        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: profile_dir)
+        monkeypatch.setattr(gateway_cli, "get_python_path", lambda: str(python_path))
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        with pytest.raises(gateway_cli.subprocess.CalledProcessError):
+            gateway_cli.refresh_launchd_plist_if_needed()
+
+        assert plist_path.read_text(encoding="utf-8") == old_content
+        assert calls == [
+            (["launchctl", "bootout", f"{gateway_cli._launchd_domain()}/{gateway_cli.get_launchd_label()}"], True),
+            (["launchctl", "bootstrap", gateway_cli._launchd_domain(), str(plist_path)], True),
+            (["launchctl", "bootstrap", gateway_cli._launchd_domain(), str(plist_path)], True),
+            (["launchctl", "bootout", f"{gateway_cli._launchd_domain()}/{gateway_cli.get_launchd_label()}"], True),
+            (["launchctl", "bootstrap", gateway_cli._launchd_domain(), str(plist_path)], True),
+        ]
+
+    def test_launchd_refresh_rolls_back_when_bootstrap_times_out(self, tmp_path, monkeypatch):
+        profile_dir = tmp_path / ".hermes" / "profiles" / "mybot"
+        profile_dir.mkdir(parents=True)
+        plist_path = tmp_path / "ai.hermes.gateway.plist"
+        old_content = "<plist>old content</plist>"
+        plist_path.write_text(old_content, encoding="utf-8")
+        wrapper = profile_dir / "bin" / "hermes-gateway-mybot"
+        wrapper.parent.mkdir()
+        old_wrapper = b"#!/bin/sh\nexec /old/python -m hermes_cli.main \"$@\"\n"
+        wrapper.write_bytes(old_wrapper)
+        python_path = tmp_path / "venv" / "bin" / "python"
+        python_path.parent.mkdir(parents=True)
+        python_path.write_text("")
+        calls = []
+
+        def fake_run(cmd, check=False, **kwargs):
+            calls.append((cmd, check))
+            if cmd[1] == "bootstrap" and check:
+                raise gateway_cli.subprocess.TimeoutExpired(cmd, timeout=30)
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(profile_dir))
+        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: profile_dir)
+        monkeypatch.setattr(gateway_cli, "get_python_path", lambda: str(python_path))
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        with pytest.raises(gateway_cli.subprocess.TimeoutExpired):
+            gateway_cli.refresh_launchd_plist_if_needed()
+
+        assert plist_path.read_text(encoding="utf-8") == old_content
+        assert wrapper.read_bytes() == old_wrapper
+        assert calls == [
+            (["launchctl", "bootout", f"{gateway_cli._launchd_domain()}/{gateway_cli.get_launchd_label()}"], True),
+            (["launchctl", "bootstrap", gateway_cli._launchd_domain(), str(plist_path)], True),
+            (["launchctl", "bootout", f"{gateway_cli._launchd_domain()}/{gateway_cli.get_launchd_label()}"], True),
+            (["launchctl", "bootstrap", gateway_cli._launchd_domain(), str(plist_path)], True),
+        ]
+
+    def test_launchd_refresh_snapshots_wrapper_before_bootout(self, tmp_path, monkeypatch):
+        plist_path = tmp_path / "ai.hermes.gateway.plist"
+        plist_path.write_text("<plist>old content</plist>", encoding="utf-8")
+        calls = []
+
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+        monkeypatch.setattr(
+            gateway_cli,
+            "_snapshot_launchd_gateway_wrapper",
+            lambda: (_ for _ in ()).throw(PermissionError("unreadable wrapper")),
+        )
+        monkeypatch.setattr(gateway_cli.subprocess, "run", lambda cmd, **kwargs: calls.append(cmd))
+
+        with pytest.raises(PermissionError):
+            gateway_cli.refresh_launchd_plist_if_needed()
+
+        assert calls == []
+
+    def test_launchd_refresh_removes_new_wrapper_when_bootstrap_fails_without_prior_wrapper(self, tmp_path, monkeypatch):
+        profile_dir = tmp_path / ".hermes" / "profiles" / "mybot"
+        profile_dir.mkdir(parents=True)
+        plist_path = tmp_path / "ai.hermes.gateway.plist"
+        plist_path.write_text("<plist>old content</plist>", encoding="utf-8")
+        python_path = tmp_path / "venv" / "bin" / "python"
+        python_path.parent.mkdir(parents=True)
+        python_path.write_text("")
+
+        def fake_run(cmd, check=False, **kwargs):
+            if cmd[1] == "bootstrap" and check:
+                raise gateway_cli.subprocess.CalledProcessError(5, cmd, stderr="bootstrap failed")
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(profile_dir))
+        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: profile_dir)
+        monkeypatch.setattr(gateway_cli, "get_python_path", lambda: str(python_path))
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        with pytest.raises(gateway_cli.subprocess.CalledProcessError):
+            gateway_cli.refresh_launchd_plist_if_needed()
+
+        assert not (profile_dir / "bin" / "hermes-gateway-mybot").exists()
+
+    def test_launchd_refresh_does_not_reload_previous_when_prior_wrapper_was_missing(
+        self,
+        tmp_path,
+        monkeypatch,
+        caplog,
+    ):
+        profile_dir = tmp_path / ".hermes" / "profiles" / "mybot"
+        profile_dir.mkdir(parents=True)
+        wrapper = profile_dir / "bin" / "hermes-gateway-mybot"
+        old_plist = f"<plist><dict><key>ProgramArguments</key><array><string>{wrapper}</string></array></dict></plist>"
+        plist_path = tmp_path / "ai.hermes.gateway-mybot.plist"
+        plist_path.write_text(old_plist, encoding="utf-8")
+        python_path = tmp_path / "venv" / "bin" / "python"
+        python_path.parent.mkdir(parents=True)
+        python_path.write_text("")
+        calls = []
+        bootstrap_attempts = 0
+
+        def fake_run(cmd, check=False, **kwargs):
+            nonlocal bootstrap_attempts
+            calls.append((cmd, check))
+            if cmd[1] == "bootstrap" and check:
+                bootstrap_attempts += 1
+                if bootstrap_attempts == 1:
+                    raise gateway_cli.subprocess.CalledProcessError(5, cmd, stderr="bootstrap failed")
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(profile_dir))
+        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: profile_dir)
+        monkeypatch.setattr(gateway_cli, "get_python_path", lambda: str(python_path))
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        with caplog.at_level("WARNING", logger=gateway_cli.logger.name):
+            with pytest.raises(gateway_cli.subprocess.CalledProcessError):
+                gateway_cli.refresh_launchd_plist_if_needed()
+
+        assert plist_path.read_text(encoding="utf-8") == old_plist
+        assert not wrapper.exists()
+        assert calls == [
+            (["launchctl", "bootout", f"{gateway_cli._launchd_domain()}/{gateway_cli.get_launchd_label()}"], True),
+            (["launchctl", "bootstrap", gateway_cli._launchd_domain(), str(plist_path)], True),
+        ]
+        assert "Skipping previous launchd service reload because the previous wrapper could not be restored" in caplog.text
+
+    def test_launchd_force_install_rolls_back_when_bootstrap_fails(self, tmp_path, monkeypatch):
+        profile_dir = tmp_path / ".hermes" / "profiles" / "mybot"
+        profile_dir.mkdir(parents=True)
+        plist_path = tmp_path / "ai.hermes.gateway.plist"
+        old_content = "<plist>old content</plist>"
+        plist_path.write_text(old_content, encoding="utf-8")
+        wrapper = profile_dir / "bin" / "hermes-gateway-mybot"
+        wrapper.parent.mkdir()
+        old_wrapper = b"#!/bin/sh\nexec /old/python -m hermes_cli.main \"$@\"\n"
+        wrapper.write_bytes(old_wrapper)
+        python_path = tmp_path / "venv" / "bin" / "python"
+        python_path.parent.mkdir(parents=True)
+        python_path.write_text("")
+
+        def fake_run(cmd, check=False, **kwargs):
+            if cmd[1] == "bootstrap" and check:
+                raise gateway_cli.subprocess.CalledProcessError(5, cmd, stderr="bootstrap failed")
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(profile_dir))
+        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: profile_dir)
+        monkeypatch.setattr(gateway_cli, "get_python_path", lambda: str(python_path))
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        with pytest.raises(gateway_cli.subprocess.CalledProcessError):
+            gateway_cli.launchd_install(force=True)
+
+        assert plist_path.read_text(encoding="utf-8") == old_content
+        assert wrapper.read_bytes() == old_wrapper
+
+    def test_launchd_force_install_reloads_previous_plist_when_bootout_times_out(self, tmp_path, monkeypatch):
+        plist_path = tmp_path / "ai.hermes.gateway.plist"
+        old_content = "<plist>old content</plist>"
+        plist_path.write_text(old_content, encoding="utf-8")
+        calls = []
+
+        def fake_run(cmd, check=False, **kwargs):
+            calls.append((cmd, check))
+            if cmd[1] == "bootout":
+                raise gateway_cli.subprocess.TimeoutExpired(cmd, timeout=90)
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        with pytest.raises(gateway_cli.subprocess.TimeoutExpired):
+            gateway_cli.launchd_install(force=True)
+
+        assert plist_path.read_text(encoding="utf-8") == old_content
+        assert calls == [
+            (["launchctl", "bootout", f"{gateway_cli._launchd_domain()}/{gateway_cli.get_launchd_label()}"], True),
+            (["launchctl", "bootstrap", gateway_cli._launchd_domain(), str(plist_path)], True),
+        ]
+
+    def test_launchd_force_install_replaces_binary_existing_plist(self, tmp_path, monkeypatch):
+        profile_dir = tmp_path / ".hermes" / "profiles" / "mybot"
+        profile_dir.mkdir(parents=True)
+        plist_path = tmp_path / "ai.hermes.gateway.plist"
+        plist_path.write_bytes(b"\xff\xfe")
+        python_path = tmp_path / "venv" / "bin" / "python"
+        python_path.parent.mkdir(parents=True)
+        python_path.write_text("")
+        calls = []
+
+        def fake_run(cmd, check=False, **kwargs):
+            calls.append(cmd)
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(profile_dir))
+        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: profile_dir)
+        monkeypatch.setattr(gateway_cli, "get_python_path", lambda: str(python_path))
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        gateway_cli.launchd_install(force=True)
+
+        assert plist_path.read_text(encoding="utf-8").startswith("<?xml")
+        assert calls == [
+            ["launchctl", "bootout", f"{gateway_cli._launchd_domain()}/{gateway_cli.get_launchd_label()}"],
+            ["launchctl", "bootstrap", gateway_cli._launchd_domain(), str(plist_path)],
+        ]
+
+    def test_launchd_install_repairs_binary_existing_plist_without_force(self, tmp_path, monkeypatch):
+        profile_dir = tmp_path / ".hermes" / "profiles" / "mybot"
+        profile_dir.mkdir(parents=True)
+        plist_path = tmp_path / "ai.hermes.gateway.plist"
+        plist_path.write_bytes(b"\xff\xfe")
+        python_path = tmp_path / "venv" / "bin" / "python"
+        python_path.parent.mkdir(parents=True)
+        python_path.write_text("")
+        calls = []
+
+        def fake_run(cmd, check=False, **kwargs):
+            calls.append(cmd)
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(profile_dir))
+        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: profile_dir)
+        monkeypatch.setattr(gateway_cli, "get_python_path", lambda: str(python_path))
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        gateway_cli.launchd_install()
+
+        assert plist_path.read_text(encoding="utf-8").startswith("<?xml")
+        assert calls == [
+            ["launchctl", "bootout", f"{gateway_cli._launchd_domain()}/{gateway_cli.get_launchd_label()}"],
+            ["launchctl", "bootstrap", gateway_cli._launchd_domain(), str(plist_path)],
+        ]
+
+    def test_launchd_install_recovers_missing_plist_stale_registration(self, tmp_path, monkeypatch):
+        profile_dir = tmp_path / ".hermes" / "profiles" / "mybot"
+        profile_dir.mkdir(parents=True)
+        plist_path = tmp_path / "ai.hermes.gateway.plist"
+        python_path = tmp_path / "venv" / "bin" / "python"
+        python_path.parent.mkdir(parents=True)
+        python_path.write_text("")
+        calls = []
+        bootstrap_kwargs = []
+        bootstrap_attempts = 0
+
+        def fake_run(cmd, check=False, **kwargs):
+            nonlocal bootstrap_attempts
+            calls.append((cmd, check))
+            if cmd[1] == "bootstrap":
+                bootstrap_kwargs.append(kwargs)
+                bootstrap_attempts += 1
+                if bootstrap_attempts == 1:
+                    raise gateway_cli.subprocess.CalledProcessError(5, cmd, stderr="service already loaded")
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(profile_dir))
+        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: profile_dir)
+        monkeypatch.setattr(gateway_cli, "get_python_path", lambda: str(python_path))
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        gateway_cli.launchd_install()
+
+        assert plist_path.exists()
+        assert (profile_dir / "bin" / "hermes-gateway-mybot").exists()
+        assert calls == [
+            (["launchctl", "bootstrap", gateway_cli._launchd_domain(), str(plist_path)], True),
+            (["launchctl", "bootout", f"{gateway_cli._launchd_domain()}/{gateway_cli.get_launchd_label()}"], True),
+            (["launchctl", "bootstrap", gateway_cli._launchd_domain(), str(plist_path)], True),
+        ]
+        assert bootstrap_kwargs == [
+            {"capture_output": True, "text": True, "timeout": 30},
+            {"capture_output": True, "text": True, "timeout": 30},
+        ]
+
+    def test_launchd_force_install_reloads_previous_after_stale_registration_retry_fails(self, tmp_path, monkeypatch):
+        profile_dir = tmp_path / ".hermes" / "profiles" / "mybot"
+        profile_dir.mkdir(parents=True)
+        plist_path = tmp_path / "ai.hermes.gateway.plist"
+        old_plist = "<plist>old content</plist>"
+        plist_path.write_text(old_plist, encoding="utf-8")
+        python_path = tmp_path / "venv" / "bin" / "python"
+        python_path.parent.mkdir(parents=True)
+        python_path.write_text("")
+        calls = []
+        bootout_attempts = 0
+        bootstrap_attempts = 0
+
+        def fake_run(cmd, check=False, **kwargs):
+            nonlocal bootout_attempts, bootstrap_attempts
+            calls.append((cmd, check))
+            if cmd[1] == "bootout":
+                bootout_attempts += 1
+                if bootout_attempts == 1:
+                    raise gateway_cli.subprocess.CalledProcessError(113, cmd, stderr="not loaded")
+            if cmd[1] == "bootstrap" and check:
+                bootstrap_attempts += 1
+                if bootstrap_attempts == 1:
+                    raise gateway_cli.subprocess.CalledProcessError(5, cmd, stderr="service already loaded")
+                raise gateway_cli.subprocess.CalledProcessError(5, cmd, stderr="bootstrap failed")
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(profile_dir))
+        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: profile_dir)
+        monkeypatch.setattr(gateway_cli, "get_python_path", lambda: str(python_path))
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        with pytest.raises(gateway_cli.subprocess.CalledProcessError):
+            gateway_cli.launchd_install(force=True)
+
+        assert plist_path.read_text(encoding="utf-8") == old_plist
+        assert calls == [
+            (["launchctl", "bootout", f"{gateway_cli._launchd_domain()}/{gateway_cli.get_launchd_label()}"], True),
+            (["launchctl", "bootstrap", gateway_cli._launchd_domain(), str(plist_path)], True),
+            (["launchctl", "bootout", f"{gateway_cli._launchd_domain()}/{gateway_cli.get_launchd_label()}"], True),
+            (["launchctl", "bootstrap", gateway_cli._launchd_domain(), str(plist_path)], True),
+            (["launchctl", "bootout", f"{gateway_cli._launchd_domain()}/{gateway_cli.get_launchd_label()}"], True),
+            (["launchctl", "bootstrap", gateway_cli._launchd_domain(), str(plist_path)], True),
+        ]
+
+    def test_launchd_install_does_not_bootout_on_already_exists_bootstrap_failure(self, tmp_path, monkeypatch):
+        profile_dir = tmp_path / ".hermes" / "profiles" / "mybot"
+        profile_dir.mkdir(parents=True)
+        plist_path = tmp_path / "ai.hermes.gateway.plist"
+        python_path = tmp_path / "venv" / "bin" / "python"
+        python_path.parent.mkdir(parents=True)
+        python_path.write_text("")
+        calls = []
+
+        def fake_run(cmd, check=False, **kwargs):
+            calls.append((cmd, check))
+            if cmd[1] == "bootstrap":
+                raise gateway_cli.subprocess.CalledProcessError(5, cmd, stderr="file already exists")
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(profile_dir))
+        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: profile_dir)
+        monkeypatch.setattr(gateway_cli, "get_python_path", lambda: str(python_path))
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        with pytest.raises(gateway_cli.subprocess.CalledProcessError):
+            gateway_cli.launchd_install()
+
+        assert not plist_path.exists()
+        assert calls == [
+            (["launchctl", "bootstrap", gateway_cli._launchd_domain(), str(plist_path)], True),
+        ]
+
+    def test_launchd_fresh_install_rolls_back_when_bootstrap_fails(self, tmp_path, monkeypatch):
+        profile_dir = tmp_path / ".hermes" / "profiles" / "mybot"
+        profile_dir.mkdir(parents=True)
+        plist_path = tmp_path / "ai.hermes.gateway.plist"
+        python_path = tmp_path / "venv" / "bin" / "python"
+        python_path.parent.mkdir(parents=True)
+        python_path.write_text("")
+
+        def fake_run(cmd, check=False, **kwargs):
+            if cmd[1] == "bootstrap" and check:
+                raise gateway_cli.subprocess.CalledProcessError(5, cmd, stderr="bootstrap failed")
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(profile_dir))
+        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: profile_dir)
+        monkeypatch.setattr(gateway_cli, "get_python_path", lambda: str(python_path))
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        with pytest.raises(gateway_cli.subprocess.CalledProcessError):
+            gateway_cli.launchd_install()
+
+        assert not plist_path.exists()
+        assert not (profile_dir / "bin" / "hermes-gateway-mybot").exists()
+
+    def test_launchd_fresh_install_preserves_files_created_after_snapshot_on_rollback(self, tmp_path, monkeypatch):
+        profile_dir = tmp_path / ".hermes" / "profiles" / "mybot"
+        profile_dir.mkdir(parents=True)
+        plist_path = tmp_path / "ai.hermes.gateway.plist"
+        python_path = tmp_path / "venv" / "bin" / "python"
+        python_path.parent.mkdir(parents=True)
+        python_path.write_text("")
+        wrapper = profile_dir / "bin" / "hermes-gateway-mybot"
+
+        def fake_run(cmd, check=False, **kwargs):
+            if cmd[1] == "bootstrap" and check:
+                plist_path.write_text("user plist", encoding="utf-8")
+                wrapper.write_bytes(b"#!/bin/sh\nexec /custom/python -m hermes_cli.main \"$@\"\n")
+                raise gateway_cli.subprocess.CalledProcessError(5, cmd, stderr="bootstrap failed")
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(profile_dir))
+        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: profile_dir)
+        monkeypatch.setattr(gateway_cli, "get_python_path", lambda: str(python_path))
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        with pytest.raises(gateway_cli.subprocess.CalledProcessError):
+            gateway_cli.launchd_install()
+
+        assert plist_path.read_text(encoding="utf-8") == "user plist"
+        assert wrapper.read_bytes() == b"#!/bin/sh\nexec /custom/python -m hermes_cli.main \"$@\"\n"
+
+    def test_launchd_fresh_install_preserves_path_only_plist_changes_on_rollback(self, tmp_path, monkeypatch):
+        profile_dir = tmp_path / ".hermes" / "profiles" / "mybot"
+        profile_dir.mkdir(parents=True)
+        plist_path = tmp_path / "ai.hermes.gateway.plist"
+        python_path = tmp_path / "venv" / "bin" / "python"
+        python_path.parent.mkdir(parents=True)
+        python_path.write_text("")
+        expected_plist = {"content": None}
+
+        def fake_run(cmd, check=False, **kwargs):
+            if cmd[1] == "bootstrap" and check:
+                original = plist_path.read_text(encoding="utf-8")
+                parsed = plistlib.loads(original.encode("utf-8"))
+                original_path = parsed["EnvironmentVariables"]["PATH"]
+                updated = original.replace(
+                    gateway_cli._plist_string(original_path),
+                    gateway_cli._plist_string(f"{original_path}:/custom/bin"),
+                    1,
+                )
+                assert gateway_cli._normalize_launchd_plist_for_comparison(
+                    updated
+                ) == gateway_cli._normalize_launchd_plist_for_comparison(original)
+                plist_path.write_text(updated, encoding="utf-8")
+                expected_plist["content"] = updated
+                raise gateway_cli.subprocess.CalledProcessError(5, cmd, stderr="bootstrap failed")
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(profile_dir))
+        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: profile_dir)
+        monkeypatch.setattr(gateway_cli, "get_python_path", lambda: str(python_path))
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        with pytest.raises(gateway_cli.subprocess.CalledProcessError):
+            gateway_cli.launchd_install()
+
+        assert plist_path.read_text(encoding="utf-8") == expected_plist["content"]
+        assert not (profile_dir / "bin" / "hermes-gateway-mybot").exists()
+
+    def test_launchd_fresh_install_preserves_chmodded_wrapper_created_after_snapshot_on_rollback(self, tmp_path, monkeypatch):
+        profile_dir = tmp_path / ".hermes" / "profiles" / "mybot"
+        profile_dir.mkdir(parents=True)
+        plist_path = tmp_path / "ai.hermes.gateway.plist"
+        python_path = tmp_path / "venv" / "bin" / "python"
+        python_path.parent.mkdir(parents=True)
+        python_path.write_text("")
+        wrapper = profile_dir / "bin" / "hermes-gateway-mybot"
+        expected_wrapper = {"content": None}
+
+        def fake_run(cmd, check=False, **kwargs):
+            if cmd[1] == "bootstrap" and check:
+                expected_wrapper["content"] = wrapper.read_bytes()
+                wrapper.chmod(0o700)
+                raise gateway_cli.subprocess.CalledProcessError(5, cmd, stderr="bootstrap failed")
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(profile_dir))
+        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: profile_dir)
+        monkeypatch.setattr(gateway_cli, "get_python_path", lambda: str(python_path))
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        with pytest.raises(gateway_cli.subprocess.CalledProcessError):
+            gateway_cli.launchd_install()
+
+        assert not plist_path.exists()
+        assert wrapper.read_bytes() == expected_wrapper["content"]
+        assert stat.S_IMODE(wrapper.stat().st_mode) == 0o700
+
+    def test_launchd_install_preserves_existing_files_modified_after_write_on_rollback(self, tmp_path, monkeypatch):
+        profile_dir = tmp_path / ".hermes" / "profiles" / "mybot"
+        profile_dir.mkdir(parents=True)
+        wrapper = profile_dir / "bin" / "hermes-gateway-mybot"
+        wrapper.parent.mkdir()
+        old_wrapper = b"#!/bin/sh\nexec /old/python -m hermes_cli.main \"$@\"\n"
+        user_wrapper = b"#!/bin/sh\nexec /user/python -m hermes_cli.main \"$@\"\n"
+        wrapper.write_bytes(old_wrapper)
+        wrapper.chmod(0o700)
+        plist_path = tmp_path / "ai.hermes.gateway.plist"
+        old_plist = "<plist>old content</plist>"
+        user_plist = "<plist>user content</plist>"
+        plist_path.write_text(old_plist, encoding="utf-8")
+        python_path = tmp_path / "venv" / "bin" / "python"
+        python_path.parent.mkdir(parents=True)
+        python_path.write_text("")
+
+        def fake_run(cmd, check=False, **kwargs):
+            if cmd[1] == "bootstrap" and check:
+                plist_path.write_text(user_plist, encoding="utf-8")
+                wrapper.write_bytes(user_wrapper)
+                wrapper.chmod(0o600)
+                raise gateway_cli.subprocess.CalledProcessError(5, cmd, stderr="bootstrap failed")
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(profile_dir))
+        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: profile_dir)
+        monkeypatch.setattr(gateway_cli, "get_python_path", lambda: str(python_path))
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        with pytest.raises(gateway_cli.subprocess.CalledProcessError):
+            gateway_cli.launchd_install(force=True)
+
+        assert plist_path.read_text(encoding="utf-8") == user_plist
+        assert wrapper.read_bytes() == user_wrapper
+        assert stat.S_IMODE(wrapper.stat().st_mode) == 0o600
+
+    def test_launchd_fresh_install_boots_out_uncertain_bootstrap_before_rollback(self, tmp_path, monkeypatch):
+        profile_dir = tmp_path / ".hermes" / "profiles" / "mybot"
+        profile_dir.mkdir(parents=True)
+        plist_path = tmp_path / "ai.hermes.gateway.plist"
+        python_path = tmp_path / "venv" / "bin" / "python"
+        python_path.parent.mkdir(parents=True)
+        python_path.write_text("")
+        calls = []
+
+        def fake_run(cmd, check=False, **kwargs):
+            calls.append((cmd, check))
+            if cmd[1] == "bootstrap" and check:
+                raise gateway_cli.subprocess.TimeoutExpired(cmd, timeout=30)
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(profile_dir))
+        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: profile_dir)
+        monkeypatch.setattr(gateway_cli, "get_python_path", lambda: str(python_path))
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        with pytest.raises(gateway_cli.subprocess.TimeoutExpired):
+            gateway_cli.launchd_install()
+
+        assert not plist_path.exists()
+        assert not (profile_dir / "bin" / "hermes-gateway-mybot").exists()
+        assert calls == [
+            (["launchctl", "bootstrap", gateway_cli._launchd_domain(), str(plist_path)], True),
+            (["launchctl", "bootout", f"{gateway_cli._launchd_domain()}/{gateway_cli.get_launchd_label()}"], True),
+        ]
+
+    def test_launchd_install_refuses_broken_plist_symlink_without_bootout(self, tmp_path, monkeypatch):
+        plist_path = tmp_path / "ai.hermes.gateway.plist"
+        plist_path.symlink_to(tmp_path / "missing.plist")
+        calls = []
+
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+        monkeypatch.setattr(gateway_cli.subprocess, "run", lambda cmd, **kwargs: calls.append(cmd))
+
+        with pytest.raises(RuntimeError, match="Refusing to replace unsafe launchd plist path"):
+            gateway_cli.launchd_install(force=True)
+
+        assert calls == []
+
+    def test_launchd_install_refuses_symlinked_plist_parent_without_writing(self, tmp_path, monkeypatch):
+        launch_agents = tmp_path / "LaunchAgents"
+        redirected = tmp_path / "redirected"
+        redirected.mkdir()
+        launch_agents.symlink_to(redirected, target_is_directory=True)
+        plist_path = launch_agents / "ai.hermes.gateway.plist"
+        calls = []
+
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+        monkeypatch.setattr(gateway_cli.subprocess, "run", lambda cmd, **kwargs: calls.append(cmd))
+
+        with pytest.raises(RuntimeError, match="Refusing to use unsafe launchd"):
+            gateway_cli.launchd_install()
+
+        assert not (redirected / "ai.hermes.gateway.plist").exists()
+        assert calls == []
+
+    def test_launchd_install_refuses_symlinked_plist_ancestor_without_writing(self, tmp_path, monkeypatch):
+        home = tmp_path / "home"
+        home.mkdir()
+        redirected = tmp_path / "redirected"
+        redirected.mkdir()
+        (home / "Library").symlink_to(redirected, target_is_directory=True)
+        plist_path = home / "Library" / "LaunchAgents" / "ai.hermes.gateway.plist"
+        calls = []
+
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+        monkeypatch.setattr(gateway_cli.subprocess, "run", lambda cmd, **kwargs: calls.append(cmd))
+
+        with pytest.raises(RuntimeError, match="Refusing to use unsafe launchd directory"):
+            gateway_cli.launchd_install()
+
+        assert not (redirected / "LaunchAgents" / "ai.hermes.gateway.plist").exists()
+        assert calls == []
+
+    def test_launchd_start_refuses_group_writable_plist_without_bootstrap(self, tmp_path, monkeypatch):
+        profile_dir = tmp_path / ".hermes" / "profiles" / "mybot"
+        profile_dir.mkdir(parents=True)
+        python_path = tmp_path / "venv" / "bin" / "python"
+        python_path.parent.mkdir(parents=True)
+        python_path.write_text("")
+        plist_path = tmp_path / "ai.hermes.gateway-mybot.plist"
+        calls = []
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(profile_dir))
+        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: profile_dir)
+        monkeypatch.setattr(gateway_cli, "get_python_path", lambda: str(python_path))
+        plist_path.write_text(gateway_cli.generate_launchd_plist(), encoding="utf-8")
+        plist_path.chmod(0o664)
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+        monkeypatch.setattr(gateway_cli.subprocess, "run", lambda cmd, **kwargs: calls.append(cmd))
+
+        try:
+            with pytest.raises(RuntimeError, match="Refusing to use insecure launchd plist path"):
+                gateway_cli.launchd_start()
+        finally:
+            plist_path.chmod(0o644)
+
+        assert calls == []
+
+    def test_launchd_start_missing_plist_rolls_back_when_bootstrap_fails(self, tmp_path, monkeypatch):
+        profile_dir = tmp_path / ".hermes" / "profiles" / "mybot"
+        profile_dir.mkdir(parents=True)
+        plist_path = tmp_path / "ai.hermes.gateway.plist"
+        python_path = tmp_path / "venv" / "bin" / "python"
+        python_path.parent.mkdir(parents=True)
+        python_path.write_text("")
+
+        def fake_run(cmd, check=False, **kwargs):
+            if cmd[1] == "bootstrap" and check:
+                raise gateway_cli.subprocess.CalledProcessError(5, cmd, stderr="bootstrap failed")
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(profile_dir))
+        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: profile_dir)
+        monkeypatch.setattr(gateway_cli, "get_python_path", lambda: str(python_path))
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        with pytest.raises(gateway_cli.subprocess.CalledProcessError):
+            gateway_cli.launchd_start()
+
+        assert not plist_path.exists()
+        assert not (profile_dir / "bin" / "hermes-gateway-mybot").exists()
+
+    def test_launchd_start_missing_plist_boots_out_after_kickstart_failure(self, tmp_path, monkeypatch):
+        profile_dir = tmp_path / ".hermes" / "profiles" / "mybot"
+        profile_dir.mkdir(parents=True)
+        plist_path = tmp_path / "ai.hermes.gateway.plist"
+        python_path = tmp_path / "venv" / "bin" / "python"
+        python_path.parent.mkdir(parents=True)
+        python_path.write_text("")
+        calls = []
+
+        def fake_run(cmd, check=False, **kwargs):
+            calls.append((cmd, check))
+            if cmd[1] == "kickstart":
+                raise gateway_cli.subprocess.CalledProcessError(5, cmd, stderr="kickstart failed")
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(profile_dir))
+        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: profile_dir)
+        monkeypatch.setattr(gateway_cli, "get_python_path", lambda: str(python_path))
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        with pytest.raises(gateway_cli.subprocess.CalledProcessError):
+            gateway_cli.launchd_start()
+
+        assert not plist_path.exists()
+        assert not (profile_dir / "bin" / "hermes-gateway-mybot").exists()
+        assert calls == [
+            (["launchctl", "bootstrap", gateway_cli._launchd_domain(), str(plist_path)], True),
+            (["launchctl", "kickstart", f"{gateway_cli._launchd_domain()}/{gateway_cli.get_launchd_label()}"], True),
+            (["launchctl", "bootout", f"{gateway_cli._launchd_domain()}/{gateway_cli.get_launchd_label()}"], True),
+        ]
+
+    @pytest.mark.parametrize(
+        "bootstrap_stderr",
+        [
+            "service already loaded",
+            "Bootstrap failed: 5: Input/output error",
+        ],
+    )
+    def test_launchd_start_missing_plist_recovers_stale_registration(self, tmp_path, monkeypatch, bootstrap_stderr):
+        profile_dir = tmp_path / ".hermes" / "profiles" / "mybot"
+        profile_dir.mkdir(parents=True)
+        plist_path = tmp_path / "ai.hermes.gateway.plist"
+        python_path = tmp_path / "venv" / "bin" / "python"
+        python_path.parent.mkdir(parents=True)
+        python_path.write_text("")
+        calls = []
+        bootstrap_attempts = 0
+
+        def fake_run(cmd, check=False, **kwargs):
+            nonlocal bootstrap_attempts
+            calls.append((cmd, check))
+            if cmd[1] == "bootstrap":
+                bootstrap_attempts += 1
+                if bootstrap_attempts == 1:
+                    raise gateway_cli.subprocess.CalledProcessError(5, cmd, stderr=bootstrap_stderr)
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(profile_dir))
+        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: profile_dir)
+        monkeypatch.setattr(gateway_cli, "get_python_path", lambda: str(python_path))
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        gateway_cli.launchd_start()
+
+        assert plist_path.exists()
+        assert (profile_dir / "bin" / "hermes-gateway-mybot").exists()
+        assert calls == [
+            (["launchctl", "bootstrap", gateway_cli._launchd_domain(), str(plist_path)], True),
+            (["launchctl", "bootout", f"{gateway_cli._launchd_domain()}/{gateway_cli.get_launchd_label()}"], True),
+            (["launchctl", "bootstrap", gateway_cli._launchd_domain(), str(plist_path)], True),
+            (["launchctl", "kickstart", f"{gateway_cli._launchd_domain()}/{gateway_cli.get_launchd_label()}"], True),
+        ]
+
+    def test_launchd_start_refuses_broken_plist_symlink_without_bootout(self, tmp_path, monkeypatch):
+        plist_path = tmp_path / "ai.hermes.gateway.plist"
+        plist_path.symlink_to(tmp_path / "missing.plist")
+        calls = []
+
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+        monkeypatch.setattr(gateway_cli.subprocess, "run", lambda cmd, **kwargs: calls.append(cmd))
+
+        with pytest.raises(RuntimeError, match="Refusing to replace unsafe launchd plist path"):
+            gateway_cli.launchd_start()
+
+        assert calls == []
+
+    def test_launchd_start_rolls_back_refresh_when_kickstart_fails(self, tmp_path, monkeypatch):
+        profile_dir = tmp_path / ".hermes" / "profiles" / "mybot"
+        profile_dir.mkdir(parents=True)
+        plist_path = tmp_path / "ai.hermes.gateway.plist"
+        old_plist = "<plist>old content</plist>"
+        plist_path.write_text(old_plist, encoding="utf-8")
+        python_path = tmp_path / "venv" / "bin" / "python"
+        python_path.parent.mkdir(parents=True)
+        python_path.write_text("")
+        calls = []
+
+        def fake_run(cmd, check=False, **kwargs):
+            calls.append((cmd, check))
+            if cmd[1] == "kickstart":
+                raise gateway_cli.subprocess.CalledProcessError(5, cmd, stderr="kickstart failed")
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(profile_dir))
+        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: profile_dir)
+        monkeypatch.setattr(gateway_cli, "get_python_path", lambda: str(python_path))
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        with pytest.raises(gateway_cli.subprocess.CalledProcessError):
+            gateway_cli.launchd_start()
+
+        assert plist_path.read_text(encoding="utf-8") == old_plist
+        assert not (profile_dir / "bin" / "hermes-gateway-mybot").exists()
+        assert calls == [
+            (["launchctl", "bootout", f"{gateway_cli._launchd_domain()}/{gateway_cli.get_launchd_label()}"], True),
+            (["launchctl", "bootstrap", gateway_cli._launchd_domain(), str(plist_path)], True),
+            (["launchctl", "kickstart", f"{gateway_cli._launchd_domain()}/{gateway_cli.get_launchd_label()}"], True),
+            (["launchctl", "bootout", f"{gateway_cli._launchd_domain()}/{gateway_cli.get_launchd_label()}"], True),
+            (["launchctl", "bootstrap", gateway_cli._launchd_domain(), str(plist_path)], True),
+        ]
+
+    def test_launchd_start_rolls_back_refresh_when_kickstart_oserror(self, tmp_path, monkeypatch):
+        profile_dir = tmp_path / ".hermes" / "profiles" / "mybot"
+        profile_dir.mkdir(parents=True)
+        plist_path = tmp_path / "ai.hermes.gateway.plist"
+        old_plist = "<plist>old content</plist>"
+        plist_path.write_text(old_plist, encoding="utf-8")
+        python_path = tmp_path / "venv" / "bin" / "python"
+        python_path.parent.mkdir(parents=True)
+        python_path.write_text("")
+        calls = []
+
+        def fake_run(cmd, check=False, **kwargs):
+            calls.append((cmd, check))
+            if cmd[1] == "kickstart":
+                raise OSError("launchctl unavailable")
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(profile_dir))
+        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: profile_dir)
+        monkeypatch.setattr(gateway_cli, "get_python_path", lambda: str(python_path))
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        with pytest.raises(OSError):
+            gateway_cli.launchd_start()
+
+        assert plist_path.read_text(encoding="utf-8") == old_plist
+        assert not (profile_dir / "bin" / "hermes-gateway-mybot").exists()
+        assert calls == [
+            (["launchctl", "bootout", f"{gateway_cli._launchd_domain()}/{gateway_cli.get_launchd_label()}"], True),
+            (["launchctl", "bootstrap", gateway_cli._launchd_domain(), str(plist_path)], True),
+            (["launchctl", "kickstart", f"{gateway_cli._launchd_domain()}/{gateway_cli.get_launchd_label()}"], True),
+            (["launchctl", "bootout", f"{gateway_cli._launchd_domain()}/{gateway_cli.get_launchd_label()}"], True),
+            (["launchctl", "bootstrap", gateway_cli._launchd_domain(), str(plist_path)], True),
+        ]
+
+    def test_launchd_start_rolls_back_refresh_when_recovery_kickstart_fails(self, tmp_path, monkeypatch):
+        profile_dir = tmp_path / ".hermes" / "profiles" / "mybot"
+        profile_dir.mkdir(parents=True)
+        plist_path = tmp_path / "ai.hermes.gateway.plist"
+        old_plist = "<plist>old content</plist>"
+        plist_path.write_text(old_plist, encoding="utf-8")
+        python_path = tmp_path / "venv" / "bin" / "python"
+        python_path.parent.mkdir(parents=True)
+        python_path.write_text("")
+        calls = []
+        kickstart_attempts = 0
+
+        def fake_run(cmd, check=False, **kwargs):
+            nonlocal kickstart_attempts
+            calls.append((cmd, check))
+            if cmd[1] == "kickstart":
+                kickstart_attempts += 1
+                returncode = 113 if kickstart_attempts == 1 else 5
+                raise gateway_cli.subprocess.CalledProcessError(returncode, cmd, stderr="kickstart failed")
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(profile_dir))
+        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: profile_dir)
+        monkeypatch.setattr(gateway_cli, "get_python_path", lambda: str(python_path))
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        with pytest.raises(gateway_cli.subprocess.CalledProcessError):
+            gateway_cli.launchd_start()
+
+        target = f"{gateway_cli._launchd_domain()}/{gateway_cli.get_launchd_label()}"
+        assert plist_path.read_text(encoding="utf-8") == old_plist
+        assert not (profile_dir / "bin" / "hermes-gateway-mybot").exists()
+        assert calls == [
+            (["launchctl", "bootout", target], True),
+            (["launchctl", "bootstrap", gateway_cli._launchd_domain(), str(plist_path)], True),
+            (["launchctl", "kickstart", target], True),
+            (["launchctl", "bootstrap", gateway_cli._launchd_domain(), str(plist_path)], True),
+            (["launchctl", "kickstart", target], True),
+            (["launchctl", "bootout", target], True),
+            (["launchctl", "bootout", target], True),
+            (["launchctl", "bootstrap", gateway_cli._launchd_domain(), str(plist_path)], True),
+        ]
+
     def test_launchd_restart_drains_running_gateway_before_kickstart(self, monkeypatch):
         calls = []
         target = f"{gateway_cli._launchd_domain()}/{gateway_cli.get_launchd_label()}"
 
+        monkeypatch.setattr(gateway_cli, "_refresh_launchd_plist_if_needed", lambda: gateway_cli.LaunchdRefreshResult(False))
         monkeypatch.setattr(gateway_cli, "_get_restart_drain_timeout", lambda: 12.0)
         monkeypatch.setattr(gateway_cli, "_request_gateway_self_restart", lambda pid: False)
         monkeypatch.setattr(gateway_cli, "_wait_for_gateway_exit", lambda timeout, force_after=None: True)
@@ -580,9 +2043,155 @@ class TestLaunchdServiceRecovery:
             ["launchctl", "kickstart", "-k", target],
         ]
 
+    def test_launchd_restart_refreshes_stale_plist_before_kickstart(self, monkeypatch):
+        calls = []
+        target = f"{gateway_cli._launchd_domain()}/{gateway_cli.get_launchd_label()}"
+
+        monkeypatch.setattr(
+            gateway_cli,
+            "_refresh_launchd_plist_if_needed",
+            lambda: calls.append("refresh") or gateway_cli.LaunchdRefreshResult(True),
+        )
+        monkeypatch.setattr(gateway_cli, "_get_restart_drain_timeout", lambda: 12.0)
+        monkeypatch.setattr(
+            gateway_cli,
+            "_request_gateway_self_restart",
+            lambda pid: (_ for _ in ()).throw(AssertionError("stale plist should use launchctl restart")),
+        )
+        monkeypatch.setattr("gateway.status.get_running_pid", lambda: None)
+
+        def fake_run(cmd, check=False, **kwargs):
+            calls.append(cmd)
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        gateway_cli.launchd_restart()
+
+        assert calls == ["refresh", ["launchctl", "kickstart", "-k", target]]
+
+    def test_launchd_restart_refreshes_stale_plist_for_running_gateway(self, monkeypatch):
+        calls = []
+        target = f"{gateway_cli._launchd_domain()}/{gateway_cli.get_launchd_label()}"
+
+        monkeypatch.setattr(
+            gateway_cli,
+            "_refresh_launchd_plist_if_needed",
+            lambda: calls.append("refresh") or gateway_cli.LaunchdRefreshResult(True),
+        )
+        monkeypatch.setattr(gateway_cli, "_get_restart_drain_timeout", lambda: 12.0)
+        monkeypatch.setattr(
+            gateway_cli,
+            "_request_gateway_self_restart",
+            lambda pid: (_ for _ in ()).throw(AssertionError("stale plist should not use self restart")),
+        )
+        monkeypatch.setattr(gateway_cli, "terminate_pid", lambda pid, force=False: calls.append(("term", pid, force)))
+        monkeypatch.setattr(gateway_cli, "_wait_for_gateway_exit", lambda timeout, force_after=None: True)
+        monkeypatch.setattr("gateway.status.get_running_pid", lambda: 321)
+
+        def fake_run(cmd, check=False, **kwargs):
+            calls.append(cmd)
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        gateway_cli.launchd_restart()
+
+        assert calls == ["refresh", ("term", 321, False), ["launchctl", "kickstart", "-k", target]]
+
+    def test_launchd_restart_rolls_back_refresh_when_kickstart_fails(self, tmp_path, monkeypatch):
+        profile_dir = tmp_path / ".hermes" / "profiles" / "mybot"
+        profile_dir.mkdir(parents=True)
+        plist_path = tmp_path / "ai.hermes.gateway.plist"
+        old_plist = "<plist>old content</plist>"
+        plist_path.write_text(old_plist, encoding="utf-8")
+        python_path = tmp_path / "venv" / "bin" / "python"
+        python_path.parent.mkdir(parents=True)
+        python_path.write_text("")
+        calls = []
+
+        def fake_run(cmd, check=False, **kwargs):
+            calls.append((cmd, check))
+            if cmd[:3] == ["launchctl", "kickstart", "-k"]:
+                raise gateway_cli.subprocess.CalledProcessError(5, cmd, stderr="kickstart failed")
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(profile_dir))
+        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: profile_dir)
+        monkeypatch.setattr(gateway_cli, "get_python_path", lambda: str(python_path))
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+        monkeypatch.setattr(gateway_cli, "_get_restart_drain_timeout", lambda: 12.0)
+        monkeypatch.setattr("gateway.status.get_running_pid", lambda: None)
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        with pytest.raises(gateway_cli.subprocess.CalledProcessError):
+            gateway_cli.launchd_restart()
+
+        target = f"{gateway_cli._launchd_domain()}/{gateway_cli.get_launchd_label()}"
+        assert plist_path.read_text(encoding="utf-8") == old_plist
+        assert not (profile_dir / "bin" / "hermes-gateway-mybot").exists()
+        assert calls == [
+            (["launchctl", "bootout", f"{gateway_cli._launchd_domain()}/{gateway_cli.get_launchd_label()}"], True),
+            (["launchctl", "bootstrap", gateway_cli._launchd_domain(), str(plist_path)], True),
+            (["launchctl", "kickstart", "-k", target], True),
+            (["launchctl", "bootout", f"{gateway_cli._launchd_domain()}/{gateway_cli.get_launchd_label()}"], True),
+            (["launchctl", "bootstrap", gateway_cli._launchd_domain(), str(plist_path)], True),
+        ]
+
+    def test_launchd_restart_rolls_back_refresh_when_recovery_kickstart_fails(self, tmp_path, monkeypatch):
+        profile_dir = tmp_path / ".hermes" / "profiles" / "mybot"
+        profile_dir.mkdir(parents=True)
+        plist_path = tmp_path / "ai.hermes.gateway.plist"
+        old_plist = "<plist>old content</plist>"
+        plist_path.write_text(old_plist, encoding="utf-8")
+        python_path = tmp_path / "venv" / "bin" / "python"
+        python_path.parent.mkdir(parents=True)
+        python_path.write_text("")
+        calls = []
+        kickstart_attempts = 0
+
+        def fake_run(cmd, check=False, **kwargs):
+            nonlocal kickstart_attempts
+            calls.append((cmd, check))
+            if cmd[:3] == ["launchctl", "kickstart", "-k"]:
+                raise gateway_cli.subprocess.CalledProcessError(113, cmd, stderr="not loaded")
+            if cmd[1] == "kickstart":
+                kickstart_attempts += 1
+                raise gateway_cli.subprocess.CalledProcessError(5, cmd, stderr="kickstart failed")
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(profile_dir))
+        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: profile_dir)
+        monkeypatch.setattr(gateway_cli, "get_python_path", lambda: str(python_path))
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+        monkeypatch.setattr(gateway_cli, "_get_restart_drain_timeout", lambda: 12.0)
+        monkeypatch.setattr("gateway.status.get_running_pid", lambda: None)
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        with pytest.raises(gateway_cli.subprocess.CalledProcessError):
+            gateway_cli.launchd_restart()
+
+        target = f"{gateway_cli._launchd_domain()}/{gateway_cli.get_launchd_label()}"
+        assert kickstart_attempts == 1
+        assert plist_path.read_text(encoding="utf-8") == old_plist
+        assert not (profile_dir / "bin" / "hermes-gateway-mybot").exists()
+        assert calls == [
+            (["launchctl", "bootout", target], True),
+            (["launchctl", "bootstrap", gateway_cli._launchd_domain(), str(plist_path)], True),
+            (["launchctl", "kickstart", "-k", target], True),
+            (["launchctl", "bootstrap", gateway_cli._launchd_domain(), str(plist_path)], True),
+            (["launchctl", "kickstart", target], True),
+            (["launchctl", "bootout", target], True),
+            (["launchctl", "bootout", target], True),
+            (["launchctl", "bootstrap", gateway_cli._launchd_domain(), str(plist_path)], True),
+        ]
+
     def test_launchd_restart_self_requests_graceful_restart_without_kickstart(self, monkeypatch, capsys):
         calls = []
 
+        monkeypatch.setattr(gateway_cli, "_refresh_launchd_plist_if_needed", lambda: gateway_cli.LaunchdRefreshResult(False))
         monkeypatch.setattr(
             "gateway.status.get_running_pid",
             lambda: 321,
@@ -603,6 +2212,38 @@ class TestLaunchdServiceRecovery:
         assert calls == [("self", 321)]
         assert "restart requested" in capsys.readouterr().out.lower()
 
+    def test_launchd_restart_recovery_boots_out_after_final_kickstart_failure(self, tmp_path, monkeypatch):
+        plist_path = tmp_path / "ai.hermes.gateway.plist"
+        plist_path.write_text(gateway_cli.generate_launchd_plist(), encoding="utf-8")
+        calls = []
+        domain = gateway_cli._launchd_domain()
+        target = f"{domain}/{gateway_cli.get_launchd_label()}"
+
+        monkeypatch.setattr(gateway_cli, "_refresh_launchd_plist_if_needed", lambda: gateway_cli.LaunchdRefreshResult(False))
+        monkeypatch.setattr(gateway_cli, "_get_restart_drain_timeout", lambda: 12.0)
+        monkeypatch.setattr("gateway.status.get_running_pid", lambda: None)
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+
+        def fake_run(cmd, check=False, **kwargs):
+            calls.append(cmd)
+            if cmd == ["launchctl", "kickstart", "-k", target]:
+                raise gateway_cli.subprocess.CalledProcessError(113, cmd, stderr="Could not find service")
+            if cmd == ["launchctl", "kickstart", target]:
+                raise gateway_cli.subprocess.CalledProcessError(5, cmd, stderr="kickstart failed")
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        with pytest.raises(gateway_cli.subprocess.CalledProcessError):
+            gateway_cli.launchd_restart()
+
+        assert calls == [
+            ["launchctl", "kickstart", "-k", target],
+            ["launchctl", "bootstrap", domain, str(plist_path)],
+            ["launchctl", "kickstart", target],
+            ["launchctl", "bootout", target],
+        ]
+
     def test_launchd_stop_uses_bootout_not_kill(self, monkeypatch):
         """launchd_stop must bootout the service so KeepAlive doesn't respawn it."""
         label = gateway_cli.get_launchd_label()
@@ -621,6 +2262,379 @@ class TestLaunchdServiceRecovery:
         gateway_cli.launchd_stop()
 
         assert calls == [["launchctl", "bootout", target]]
+
+    def test_launchd_uninstall_removes_matching_wrapper_and_broken_plist_symlink(self, tmp_path, monkeypatch):
+        profile_dir = tmp_path / ".hermes" / "profiles" / "mybot"
+        profile_dir.mkdir(parents=True)
+        python_path = tmp_path / "venv" / "bin" / "python"
+        python_path.parent.mkdir(parents=True)
+        python_path.write_text("")
+        plist_path = tmp_path / "ai.hermes.gateway-mybot.plist"
+        plist_path.symlink_to(tmp_path / "missing.plist")
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(profile_dir))
+        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: profile_dir)
+        monkeypatch.setattr(gateway_cli, "get_python_path", lambda: str(python_path))
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+        monkeypatch.setattr(
+            gateway_cli.subprocess,
+            "run",
+            lambda *args, **kwargs: SimpleNamespace(returncode=0, stdout="", stderr=""),
+        )
+        gateway_cli.generate_launchd_plist()
+        wrapper = profile_dir / "bin" / "hermes-gateway-mybot"
+
+        gateway_cli.launchd_uninstall()
+
+        assert not plist_path.is_symlink()
+        assert not wrapper.exists()
+
+    def test_launchd_uninstall_removes_stale_hermes_wrapper(self, tmp_path, monkeypatch):
+        profile_dir = tmp_path / ".hermes" / "profiles" / "mybot"
+        profile_dir.mkdir(parents=True)
+        wrapper = profile_dir / "bin" / "hermes-gateway-mybot"
+        wrapper.parent.mkdir()
+        wrapper.write_bytes(b"#!/bin/sh\nexec /old/python -m hermes_cli.main \"$@\"\n")
+        plist_path = tmp_path / "ai.hermes.gateway-mybot.plist"
+        plist_path.write_text("<plist/>", encoding="utf-8")
+        python_path = tmp_path / "venv" / "bin" / "python"
+        python_path.parent.mkdir(parents=True)
+        python_path.write_text("")
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(profile_dir))
+        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: profile_dir)
+        monkeypatch.setattr(gateway_cli, "get_python_path", lambda: str(python_path))
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+        monkeypatch.setattr(
+            gateway_cli.subprocess,
+            "run",
+            lambda *args, **kwargs: SimpleNamespace(returncode=0, stdout="", stderr=""),
+        )
+
+        gateway_cli.launchd_uninstall()
+
+        assert not wrapper.exists()
+
+    def test_launchd_uninstall_preserves_wrapper_replaced_after_validation(self, tmp_path, monkeypatch):
+        profile_dir = tmp_path / ".hermes" / "profiles" / "mybot"
+        profile_dir.mkdir(parents=True)
+        wrapper = profile_dir / "bin" / "hermes-gateway-mybot"
+        wrapper.parent.mkdir()
+        python_path = tmp_path / "venv" / "bin" / "python"
+        python_path.parent.mkdir(parents=True)
+        python_path.write_text("")
+        wrapper.write_bytes(gateway_cli._launchd_gateway_wrapper_script(str(python_path)))
+        custom_wrapper = b"custom wrapper"
+        plist_path = tmp_path / "ai.hermes.gateway-mybot.plist"
+        plist_path.write_text("<plist/>", encoding="utf-8")
+        read_count = {"wrapper": 0}
+        real_read = gateway_cli._read_regular_no_follow
+
+        def replace_after_first_wrapper_read(path):
+            result = real_read(path)
+            if Path(path) == wrapper and read_count["wrapper"] == 0:
+                read_count["wrapper"] += 1
+                wrapper.write_bytes(custom_wrapper)
+            return result
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(profile_dir))
+        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: profile_dir)
+        monkeypatch.setattr(gateway_cli, "get_python_path", lambda: str(python_path))
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+        monkeypatch.setattr(gateway_cli, "_read_regular_no_follow", replace_after_first_wrapper_read)
+        monkeypatch.setattr(
+            gateway_cli.subprocess,
+            "run",
+            lambda *args, **kwargs: SimpleNamespace(returncode=0, stdout="", stderr=""),
+        )
+
+        gateway_cli.launchd_uninstall()
+
+        assert wrapper.read_bytes() == custom_wrapper
+
+    def test_launchd_uninstall_preserves_wrapper_replaced_during_final_removal(self, tmp_path, monkeypatch):
+        profile_dir = tmp_path / ".hermes" / "profiles" / "mybot"
+        profile_dir.mkdir(parents=True)
+        wrapper = profile_dir / "bin" / "hermes-gateway-mybot"
+        wrapper.parent.mkdir()
+        python_path = tmp_path / "venv" / "bin" / "python"
+        python_path.parent.mkdir(parents=True)
+        python_path.write_text("")
+        wrapper.write_bytes(gateway_cli._launchd_gateway_wrapper_script(str(python_path)))
+        wrapper.chmod(0o755)
+        custom_wrapper = b"custom wrapper"
+        plist_path = tmp_path / "ai.hermes.gateway-mybot.plist"
+        plist_path.write_text("<plist/>", encoding="utf-8")
+        real_unlink = Path.unlink
+        real_replace = gateway_cli.os.replace
+
+        def replace_wrapper_before_unlink(path, *args, **kwargs):
+            if Path(path) == wrapper:
+                wrapper.write_bytes(custom_wrapper)
+            return real_unlink(path, *args, **kwargs)
+
+        def replace_wrapper_before_quarantine(src, dst):
+            if Path(src) == wrapper:
+                wrapper.write_bytes(custom_wrapper)
+            real_replace(src, dst)
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(profile_dir))
+        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: profile_dir)
+        monkeypatch.setattr(gateway_cli, "get_python_path", lambda: str(python_path))
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+        monkeypatch.setattr(Path, "unlink", replace_wrapper_before_unlink)
+        monkeypatch.setattr(gateway_cli.os, "replace", replace_wrapper_before_quarantine)
+        monkeypatch.setattr(
+            gateway_cli.subprocess,
+            "run",
+            lambda *args, **kwargs: SimpleNamespace(returncode=0, stdout="", stderr=""),
+        )
+
+        gateway_cli.launchd_uninstall()
+
+        assert wrapper.read_bytes() == custom_wrapper
+
+    def test_launchd_uninstall_preserves_wrapper_recreated_after_bootout(self, tmp_path, monkeypatch):
+        profile_dir = tmp_path / ".hermes" / "profiles" / "mybot"
+        profile_dir.mkdir(parents=True)
+        wrapper = profile_dir / "bin" / "hermes-gateway-mybot"
+        wrapper.parent.mkdir()
+        python_path = tmp_path / "venv" / "bin" / "python"
+        python_path.parent.mkdir(parents=True)
+        python_path.write_text("")
+        plist_path = tmp_path / "ai.hermes.gateway-mybot.plist"
+        plist_path.write_text("<plist/>", encoding="utf-8")
+        recreated_wrapper = gateway_cli._launchd_gateway_wrapper_script(str(python_path))
+
+        def fake_run(cmd, check=False, **kwargs):
+            if cmd[1] == "bootout":
+                wrapper.write_bytes(recreated_wrapper)
+                wrapper.chmod(0o755)
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(profile_dir))
+        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: profile_dir)
+        monkeypatch.setattr(gateway_cli, "get_python_path", lambda: str(python_path))
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        gateway_cli.launchd_uninstall()
+
+        assert wrapper.read_bytes() == recreated_wrapper
+
+    def test_launchd_uninstall_preserves_wrapper_directory_replaced_during_final_removal(self, tmp_path, monkeypatch):
+        profile_dir = tmp_path / ".hermes" / "profiles" / "mybot"
+        profile_dir.mkdir(parents=True)
+        wrapper = profile_dir / "bin" / "hermes-gateway-mybot"
+        wrapper.parent.mkdir()
+        python_path = tmp_path / "venv" / "bin" / "python"
+        python_path.parent.mkdir(parents=True)
+        python_path.write_text("")
+        wrapper.write_bytes(gateway_cli._launchd_gateway_wrapper_script(str(python_path)))
+        wrapper.chmod(0o755)
+        plist_path = tmp_path / "ai.hermes.gateway-mybot.plist"
+        plist_path.write_text("<plist/>", encoding="utf-8")
+        real_replace = gateway_cli.os.replace
+
+        def replace_wrapper_with_directory_before_quarantine(src, dst):
+            if Path(src) == wrapper:
+                wrapper.unlink()
+                wrapper.mkdir()
+            real_replace(src, dst)
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(profile_dir))
+        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: profile_dir)
+        monkeypatch.setattr(gateway_cli, "get_python_path", lambda: str(python_path))
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+        monkeypatch.setattr(gateway_cli.os, "replace", replace_wrapper_with_directory_before_quarantine)
+        monkeypatch.setattr(
+            gateway_cli.subprocess,
+            "run",
+            lambda *args, **kwargs: SimpleNamespace(returncode=0, stdout="", stderr=""),
+        )
+
+        gateway_cli.launchd_uninstall()
+
+        assert wrapper.is_dir()
+        assert not list(wrapper.iterdir())
+
+    def test_launchd_uninstall_preserves_plist_replaced_during_final_removal(self, tmp_path, monkeypatch):
+        profile_dir = tmp_path / ".hermes" / "profiles" / "mybot"
+        profile_dir.mkdir(parents=True)
+        plist_path = tmp_path / "ai.hermes.gateway-mybot.plist"
+        plist_path.write_text("<plist/>", encoding="utf-8")
+        user_content = "<plist>user content</plist>"
+        real_unlink = Path.unlink
+        real_replace = gateway_cli.os.replace
+
+        def replace_plist_before_unlink(path, *args, **kwargs):
+            if Path(path) == plist_path:
+                plist_path.write_text(user_content, encoding="utf-8")
+            return real_unlink(path, *args, **kwargs)
+
+        def replace_plist_before_quarantine(src, dst):
+            if Path(src) == plist_path:
+                plist_path.write_text(user_content, encoding="utf-8")
+            real_replace(src, dst)
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(profile_dir))
+        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: profile_dir)
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+        monkeypatch.setattr(Path, "unlink", replace_plist_before_unlink)
+        monkeypatch.setattr(gateway_cli.os, "replace", replace_plist_before_quarantine)
+        monkeypatch.setattr(
+            gateway_cli.subprocess,
+            "run",
+            lambda *args, **kwargs: SimpleNamespace(returncode=0, stdout="", stderr=""),
+        )
+
+        gateway_cli.launchd_uninstall()
+
+        assert plist_path.read_text(encoding="utf-8") == user_content
+
+    def test_launchd_uninstall_preserves_plist_directory_replaced_during_final_removal(self, tmp_path, monkeypatch):
+        profile_dir = tmp_path / ".hermes" / "profiles" / "mybot"
+        profile_dir.mkdir(parents=True)
+        plist_path = tmp_path / "ai.hermes.gateway-mybot.plist"
+        plist_path.write_text("<plist/>", encoding="utf-8")
+        real_replace = gateway_cli.os.replace
+
+        def replace_plist_with_directory_before_quarantine(src, dst):
+            if Path(src) == plist_path:
+                plist_path.unlink()
+                plist_path.mkdir()
+            real_replace(src, dst)
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(profile_dir))
+        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: profile_dir)
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+        monkeypatch.setattr(gateway_cli.os, "replace", replace_plist_with_directory_before_quarantine)
+        monkeypatch.setattr(
+            gateway_cli.subprocess,
+            "run",
+            lambda *args, **kwargs: SimpleNamespace(returncode=0, stdout="", stderr=""),
+        )
+
+        gateway_cli.launchd_uninstall()
+
+        assert plist_path.is_dir()
+        assert not list(plist_path.iterdir())
+
+    def test_launchd_uninstall_preserves_plist_replaced_after_bootout(self, tmp_path, monkeypatch):
+        profile_dir = tmp_path / ".hermes" / "profiles" / "mybot"
+        profile_dir.mkdir(parents=True)
+        plist_path = tmp_path / "ai.hermes.gateway-mybot.plist"
+        plist_path.write_text("<plist/>", encoding="utf-8")
+        user_content = "<plist>user content</plist>"
+
+        def fake_run(cmd, check=False, **kwargs):
+            if cmd[1] == "bootout":
+                plist_path.write_text(user_content, encoding="utf-8")
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(profile_dir))
+        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: profile_dir)
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        gateway_cli.launchd_uninstall()
+
+        assert plist_path.read_text(encoding="utf-8") == user_content
+
+    def test_launchd_uninstall_refuses_wrapper_parent_symlink(self, tmp_path, monkeypatch):
+        profile_dir = tmp_path / ".hermes" / "profiles" / "mybot"
+        profile_dir.mkdir(parents=True)
+        redirected = tmp_path / "redirected"
+        redirected.mkdir()
+        (profile_dir / "bin").symlink_to(redirected, target_is_directory=True)
+        redirected_wrapper = redirected / "hermes-gateway-mybot"
+        redirected_wrapper.write_bytes(b"#!/bin/sh\nexec /old/python -m hermes_cli.main \"$@\"\n")
+        plist_path = tmp_path / "ai.hermes.gateway-mybot.plist"
+        python_path = tmp_path / "venv" / "bin" / "python"
+        python_path.parent.mkdir(parents=True)
+        python_path.write_text("")
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(profile_dir))
+        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: profile_dir)
+        monkeypatch.setattr(gateway_cli, "get_python_path", lambda: str(python_path))
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+        monkeypatch.setattr(
+            gateway_cli.subprocess,
+            "run",
+            lambda *args, **kwargs: SimpleNamespace(returncode=0, stdout="", stderr=""),
+        )
+
+        gateway_cli.launchd_uninstall()
+
+        assert redirected_wrapper.exists()
+
+    def test_launchd_uninstall_keeps_files_when_bootout_fails(self, tmp_path, monkeypatch):
+        profile_dir = tmp_path / ".hermes" / "profiles" / "mybot"
+        profile_dir.mkdir(parents=True)
+        python_path = tmp_path / "venv" / "bin" / "python"
+        python_path.parent.mkdir(parents=True)
+        python_path.write_text("")
+        plist_path = tmp_path / "ai.hermes.gateway-mybot.plist"
+        plist_path.write_text("<plist/>", encoding="utf-8")
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(profile_dir))
+        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: profile_dir)
+        monkeypatch.setattr(gateway_cli, "get_python_path", lambda: str(python_path))
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+        gateway_cli.generate_launchd_plist()
+        wrapper = profile_dir / "bin" / "hermes-gateway-mybot"
+        monkeypatch.setattr(
+            gateway_cli.subprocess,
+            "run",
+            lambda *args, **kwargs: SimpleNamespace(returncode=5, stdout="", stderr="bootout failed"),
+        )
+
+        with pytest.raises(gateway_cli.subprocess.CalledProcessError):
+            gateway_cli.launchd_uninstall()
+
+        assert plist_path.exists()
+        assert wrapper.exists()
+
+    def test_launchd_uninstall_refuses_symlinked_plist_parent(self, tmp_path, monkeypatch):
+        profile_dir = tmp_path / ".hermes" / "profiles" / "mybot"
+        profile_dir.mkdir(parents=True)
+        launch_agents = tmp_path / "LaunchAgents"
+        redirected = tmp_path / "redirected"
+        redirected.mkdir()
+        launch_agents.symlink_to(redirected, target_is_directory=True)
+        redirected_plist = redirected / "ai.hermes.gateway-mybot.plist"
+        redirected_plist.write_text("<plist/>", encoding="utf-8")
+        plist_path = launch_agents / "ai.hermes.gateway-mybot.plist"
+        python_path = tmp_path / "venv" / "bin" / "python"
+        python_path.parent.mkdir(parents=True)
+        python_path.write_text("")
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(profile_dir))
+        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: profile_dir)
+        monkeypatch.setattr(gateway_cli, "get_python_path", lambda: str(python_path))
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+        monkeypatch.setattr(
+            gateway_cli.subprocess,
+            "run",
+            lambda *args, **kwargs: SimpleNamespace(returncode=0, stdout="", stderr=""),
+        )
+
+        with pytest.raises(RuntimeError, match="Refusing to use unsafe launchd"):
+            gateway_cli.launchd_uninstall()
+
+        assert redirected_plist.exists()
 
     def test_launchd_stop_tolerates_already_unloaded(self, monkeypatch, capsys):
         """launchd_stop silently handles exit codes 3/113 (job not loaded)."""
@@ -737,6 +2751,10 @@ class TestGatewayServiceDetection:
         assert gateway_cli._is_service_running() is False
 
 class TestGatewaySystemServiceRouting:
+    @pytest.fixture(autouse=True)
+    def _skip_user_systemd_preflight(self, monkeypatch):
+        monkeypatch.setattr(gateway_cli, "_preflight_user_systemd", lambda *args, **kwargs: None)
+
     def test_systemd_restart_gracefully_restarts_running_service_and_waits(self, monkeypatch, capsys):
         calls = []
 
@@ -1630,6 +3648,896 @@ class TestProfileArg:
         plist = gateway_cli.generate_launchd_plist()
         assert "<string>--profile</string>" in plist
         assert "<string>mybot</string>" in plist
+
+    def test_launchd_plist_uses_profile_named_gateway_wrapper(self, tmp_path, monkeypatch):
+        """Named profile services should show a profile-specific name in macOS Login Items."""
+        profile_dir = tmp_path / ".hermes" / "profiles" / "mybot"
+        profile_dir.mkdir(parents=True)
+        venv = tmp_path / "venv"
+        venv_bin = venv / "bin"
+        venv_bin.mkdir(parents=True)
+        python_path = venv_bin / "python"
+        python_path.write_text("")
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(profile_dir))
+        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: profile_dir)
+        monkeypatch.setattr(gateway_cli, "_detect_venv_dir", lambda: venv)
+        monkeypatch.setattr(gateway_cli, "get_python_path", lambda: str(python_path))
+
+        plist = gateway_cli.generate_launchd_plist()
+        wrapper = profile_dir / "bin" / "hermes-gateway-mybot"
+
+        assert f"<string>{wrapper}</string>" in plist
+        assert wrapper.exists()
+        assert os.access(wrapper, os.X_OK)
+        assert f"exec {python_path}" in wrapper.read_text(encoding="utf-8")
+        assert stat.S_IMODE(wrapper.stat().st_mode) == 0o755
+        assert "<string>-m</string>" not in plist
+        assert "<string>hermes_cli.main</string>" not in plist
+        assert "<string>--profile</string>" in plist
+        assert "<string>mybot</string>" in plist
+
+    def test_launchd_plist_uses_resolved_home_for_relative_wrapper_path(self, tmp_path, monkeypatch):
+        """Relative HERMES_HOME should not leak a relative executable path into launchd."""
+        profile_dir = Path(".hermes") / "profiles" / "mybot"
+        (tmp_path / profile_dir).mkdir(parents=True)
+        (tmp_path / profile_dir / "node" / "bin").mkdir(parents=True)
+        (tmp_path / profile_dir / "node_modules" / ".bin").mkdir(parents=True)
+        python_path = tmp_path / "venv" / "bin" / "python"
+        python_path.parent.mkdir(parents=True)
+        python_path.write_text("")
+
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(profile_dir))
+        monkeypatch.setattr(gateway_cli, "get_python_path", lambda: str(python_path))
+
+        plist = gateway_cli.generate_launchd_plist()
+        resolved_profile = (tmp_path / profile_dir).resolve()
+        wrapper = resolved_profile / "bin" / "hermes-gateway-mybot"
+        parsed = plistlib.loads(plist.encode("utf-8"))
+        path_entries = parsed["EnvironmentVariables"]["PATH"].split(":")
+
+        assert f"<string>{wrapper}</string>" in plist
+        assert f"<string>{resolved_profile}</string>" in plist
+        assert wrapper.exists()
+        assert "<string>.hermes/profiles/mybot/bin/hermes-gateway-mybot</string>" not in plist
+        assert str(resolved_profile / "node" / "bin") in path_entries
+        assert str(resolved_profile / "node_modules" / ".bin") in path_entries
+        assert ".hermes/profiles/mybot/node/bin" not in path_entries
+
+    def test_launchd_plist_current_reports_stale_without_creating_gateway_wrapper(self, tmp_path, monkeypatch):
+        profile_dir = tmp_path / ".hermes" / "profiles" / "mybot"
+        profile_dir.mkdir(parents=True)
+        python_path = tmp_path / "venv" / "bin" / "python"
+        python_path.parent.mkdir(parents=True)
+        python_path.write_text("")
+        plist_path = tmp_path / "ai.hermes.gateway-mybot.plist"
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(profile_dir))
+        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: profile_dir)
+        monkeypatch.setattr(gateway_cli, "get_python_path", lambda: str(python_path))
+        plist_path.write_text(gateway_cli.generate_launchd_plist(prepare_paths=False), encoding="utf-8")
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+
+        wrapper = profile_dir / "bin" / "hermes-gateway-mybot"
+        assert not wrapper.exists()
+        assert gateway_cli.launchd_plist_is_current() is False
+        assert not wrapper.exists()
+
+        gateway_cli.generate_launchd_plist()
+        assert gateway_cli.launchd_plist_is_current() is True
+
+    def test_launchd_plist_current_reports_stale_when_required_path_entry_is_missing(self, tmp_path, monkeypatch):
+        profile_dir = tmp_path / ".hermes" / "profiles" / "mybot"
+        (profile_dir / "node" / "bin").mkdir(parents=True)
+        python_path = tmp_path / "venv" / "bin" / "python"
+        python_path.parent.mkdir(parents=True)
+        python_path.write_text("")
+        plist_path = tmp_path / "ai.hermes.gateway-mybot.plist"
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(profile_dir))
+        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: profile_dir)
+        monkeypatch.setattr(gateway_cli, "get_python_path", lambda: str(python_path))
+        plist = gateway_cli.generate_launchd_plist()
+        parsed = plistlib.loads(plist.encode("utf-8"))
+        required_entry = str((profile_dir / "node" / "bin").resolve())
+        path_entries = parsed["EnvironmentVariables"]["PATH"].split(":")
+        assert required_entry in path_entries
+        original_path = parsed["EnvironmentVariables"]["PATH"]
+        stale_path = ":".join(path for path in path_entries if path != required_entry)
+        plist_path.write_text(
+            plist.replace(
+                gateway_cli._plist_string(original_path),
+                gateway_cli._plist_string(stale_path),
+                1,
+            ),
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+
+        assert gateway_cli.launchd_plist_is_current() is False
+
+    def test_launchd_plist_current_ignores_shell_path_tail_changes(self, tmp_path, monkeypatch):
+        profile_dir = tmp_path / ".hermes" / "profiles" / "mybot"
+        (profile_dir / "node" / "bin").mkdir(parents=True)
+        python_path = tmp_path / "venv" / "bin" / "python"
+        python_path.parent.mkdir(parents=True)
+        python_path.write_text("")
+        plist_path = tmp_path / "ai.hermes.gateway-mybot.plist"
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(profile_dir))
+        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: profile_dir)
+        monkeypatch.setattr(gateway_cli, "get_python_path", lambda: str(python_path))
+        plist = gateway_cli.generate_launchd_plist()
+        parsed = plistlib.loads(plist.encode("utf-8"))
+        original_path = parsed["EnvironmentVariables"]["PATH"]
+        plist_path.write_text(
+            plist.replace(
+                gateway_cli._plist_string(original_path),
+                gateway_cli._plist_string(f"{original_path}:/custom/shell/bin"),
+                1,
+            ),
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+
+        assert gateway_cli.launchd_plist_is_current() is True
+
+    def test_launchd_plist_current_reports_stale_when_required_path_order_changes(self, tmp_path, monkeypatch):
+        profile_dir = tmp_path / ".hermes" / "profiles" / "mybot"
+        (profile_dir / "node" / "bin").mkdir(parents=True)
+        (profile_dir / "node_modules" / ".bin").mkdir(parents=True)
+        python_path = tmp_path / "venv" / "bin" / "python"
+        python_path.parent.mkdir(parents=True)
+        python_path.write_text("")
+        plist_path = tmp_path / "ai.hermes.gateway-mybot.plist"
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(profile_dir))
+        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: profile_dir)
+        monkeypatch.setattr(gateway_cli, "get_python_path", lambda: str(python_path))
+        plist = gateway_cli.generate_launchd_plist()
+        parsed = plistlib.loads(plist.encode("utf-8"))
+        first = str((profile_dir / "node" / "bin").resolve())
+        second = str((profile_dir / "node_modules" / ".bin").resolve())
+        path_entries = parsed["EnvironmentVariables"]["PATH"].split(":")
+        assert path_entries.index(first) < path_entries.index(second)
+        reordered_entries = path_entries[:]
+        first_index = reordered_entries.index(first)
+        second_index = reordered_entries.index(second)
+        reordered_entries[first_index], reordered_entries[second_index] = (
+            reordered_entries[second_index],
+            reordered_entries[first_index],
+        )
+        original_path = parsed["EnvironmentVariables"]["PATH"]
+        plist_path.write_text(
+            plist.replace(
+                gateway_cli._plist_string(original_path),
+                gateway_cli._plist_string(":".join(reordered_entries)),
+                1,
+            ),
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+
+        assert gateway_cli.launchd_plist_is_current() is False
+
+    def test_launchd_plist_current_reports_stale_when_shell_path_precedes_required_entries(self, tmp_path, monkeypatch):
+        profile_dir = tmp_path / ".hermes" / "profiles" / "mybot"
+        (profile_dir / "node" / "bin").mkdir(parents=True)
+        python_path = tmp_path / "venv" / "bin" / "python"
+        python_path.parent.mkdir(parents=True)
+        python_path.write_text("")
+        plist_path = tmp_path / "ai.hermes.gateway-mybot.plist"
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(profile_dir))
+        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: profile_dir)
+        monkeypatch.setattr(gateway_cli, "get_python_path", lambda: str(python_path))
+        plist = gateway_cli.generate_launchd_plist()
+        parsed = plistlib.loads(plist.encode("utf-8"))
+        original_path = parsed["EnvironmentVariables"]["PATH"]
+        plist_path.write_text(
+            plist.replace(
+                gateway_cli._plist_string(original_path),
+                gateway_cli._plist_string(f"/shadow/bin:{original_path}"),
+                1,
+            ),
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+
+        assert gateway_cli.launchd_plist_is_current() is False
+
+    def test_launchd_plist_current_refuses_group_writable_plist(self, tmp_path, monkeypatch):
+        profile_dir = tmp_path / ".hermes" / "profiles" / "mybot"
+        profile_dir.mkdir(parents=True)
+        python_path = tmp_path / "venv" / "bin" / "python"
+        python_path.parent.mkdir(parents=True)
+        python_path.write_text("")
+        plist_path = tmp_path / "ai.hermes.gateway-mybot.plist"
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(profile_dir))
+        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: profile_dir)
+        monkeypatch.setattr(gateway_cli, "get_python_path", lambda: str(python_path))
+        plist_path.write_text(gateway_cli.generate_launchd_plist(), encoding="utf-8")
+        plist_path.chmod(0o666)
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+
+        try:
+            with pytest.raises(RuntimeError, match="Refusing to use insecure launchd plist path"):
+                gateway_cli.launchd_plist_is_current()
+        finally:
+            plist_path.chmod(0o644)
+
+    def test_launchd_plist_escapes_xml_special_chars(self, tmp_path, monkeypatch):
+        machine_home = tmp_path / "home&space"
+        profile_dir = machine_home / ".hermes" / "profiles" / "mybot"
+        profile_dir.mkdir(parents=True)
+        python_path = tmp_path / "venv & tools" / "bin" / "python"
+        python_path.parent.mkdir(parents=True)
+        python_path.write_text("")
+
+        monkeypatch.setattr(Path, "home", lambda: machine_home)
+        monkeypatch.setenv("HERMES_HOME", str(profile_dir))
+        monkeypatch.setattr(gateway_cli, "get_python_path", lambda: str(python_path))
+
+        plist = gateway_cli.generate_launchd_plist()
+        parsed = plistlib.loads(plist.encode("utf-8"))
+        wrapper = profile_dir.resolve() / "bin" / "hermes-gateway-mybot"
+
+        assert parsed["ProgramArguments"][0] == str(wrapper)
+        assert parsed["EnvironmentVariables"]["HERMES_HOME"] == str(profile_dir.resolve())
+        assert parsed["StandardOutPath"] == str(profile_dir.resolve() / "logs" / "gateway.log")
+
+    def test_launchd_gateway_wrapper_preserves_custom_existing_wrapper(self, tmp_path, monkeypatch):
+        profile_dir = tmp_path / ".hermes" / "profiles" / "mybot"
+        profile_dir.mkdir(parents=True)
+        wrapper = profile_dir / "bin" / "hermes-gateway-mybot"
+        wrapper.parent.mkdir()
+        custom_wrapper = "#!/bin/sh\nexit 1\n"
+        wrapper.write_text(custom_wrapper, encoding="utf-8")
+        wrapper.chmod(0o777)
+        python_path = tmp_path / "venv" / "bin" / "python"
+        python_path.parent.mkdir(parents=True)
+        python_path.write_text("")
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(profile_dir))
+        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: profile_dir)
+        monkeypatch.setattr(gateway_cli, "get_python_path", lambda: str(python_path))
+
+        plist = gateway_cli.generate_launchd_plist()
+
+        assert wrapper.read_text(encoding="utf-8") == custom_wrapper
+        assert stat.S_IMODE(wrapper.stat().st_mode) == 0o777
+        assert f"<string>{python_path}</string>" in plist
+        assert "<string>-m</string>" in plist
+        assert "<string>hermes_cli.main</string>" in plist
+
+    def test_launchd_gateway_wrapper_tightens_existing_hermes_generated_permissions(self, tmp_path, monkeypatch):
+        profile_dir = tmp_path / ".hermes" / "profiles" / "mybot"
+        profile_dir.mkdir(parents=True)
+        wrapper = profile_dir / "bin" / "hermes-gateway-mybot"
+        wrapper.parent.mkdir()
+        python_path = tmp_path / "venv" / "bin" / "python"
+        python_path.parent.mkdir(parents=True)
+        python_path.write_text("")
+        wrapper.write_bytes(gateway_cli._launchd_gateway_wrapper_script(str(python_path)))
+        wrapper.chmod(0o777)
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(profile_dir))
+        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: profile_dir)
+        monkeypatch.setattr(gateway_cli, "get_python_path", lambda: str(python_path))
+
+        plist = gateway_cli.generate_launchd_plist()
+
+        assert stat.S_IMODE(wrapper.stat().st_mode) == 0o755
+        assert f"<string>{wrapper}</string>" in plist
+
+    def test_launchd_gateway_wrapper_rechecks_mode_after_opening_current_wrapper(self, tmp_path, monkeypatch):
+        profile_dir = tmp_path / ".hermes" / "profiles" / "mybot"
+        profile_dir.mkdir(parents=True)
+        wrapper = profile_dir / "bin" / "hermes-gateway-mybot"
+        wrapper.parent.mkdir()
+        python_path = tmp_path / "venv" / "bin" / "python"
+        python_path.parent.mkdir(parents=True)
+        python_path.write_text("")
+        wrapper.write_bytes(gateway_cli._launchd_gateway_wrapper_script(str(python_path)))
+        wrapper.chmod(0o755)
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(profile_dir))
+        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: profile_dir)
+        monkeypatch.setattr(gateway_cli, "get_python_path", lambda: str(python_path))
+
+        real_open = gateway_cli.os.open
+
+        def chmod_before_open(path, flags, *args, **kwargs):
+            if Path(path) == wrapper:
+                wrapper.chmod(0o777)
+            return real_open(path, flags, *args, **kwargs)
+
+        monkeypatch.setattr(gateway_cli.os, "open", chmod_before_open)
+
+        plist = gateway_cli.generate_launchd_plist()
+
+        assert stat.S_IMODE(wrapper.stat().st_mode) == 0o755
+        assert f"<string>{wrapper}</string>" in plist
+
+    def test_launchd_gateway_wrapper_preserves_non_utf8_content(self, tmp_path, monkeypatch):
+        profile_dir = tmp_path / ".hermes" / "profiles" / "mybot"
+        profile_dir.mkdir(parents=True)
+        wrapper = profile_dir / "bin" / "hermes-gateway-mybot"
+        wrapper.parent.mkdir()
+        custom_wrapper = b"\xff\xfe"
+        wrapper.write_bytes(custom_wrapper)
+        python_path = tmp_path / "venv" / "bin" / "python"
+        python_path.parent.mkdir(parents=True)
+        python_path.write_text("")
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(profile_dir))
+        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: profile_dir)
+        monkeypatch.setattr(gateway_cli, "get_python_path", lambda: str(python_path))
+
+        plist = gateway_cli.generate_launchd_plist()
+
+        assert wrapper.read_bytes() == custom_wrapper
+        assert f"<string>{python_path}</string>" in plist
+        assert "<string>-m</string>" in plist
+        assert "<string>hermes_cli.main</string>" in plist
+
+    def test_launchd_plist_current_reports_stale_for_unreadable_wrapper(self, tmp_path, monkeypatch):
+        profile_dir = tmp_path / ".hermes" / "profiles" / "mybot"
+        profile_dir.mkdir(parents=True)
+        python_path = tmp_path / "venv" / "bin" / "python"
+        python_path.parent.mkdir(parents=True)
+        python_path.write_text("")
+        plist_path = tmp_path / "ai.hermes.gateway-mybot.plist"
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(profile_dir))
+        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: profile_dir)
+        monkeypatch.setattr(gateway_cli, "get_python_path", lambda: str(python_path))
+        plist_path.write_text(gateway_cli.generate_launchd_plist(), encoding="utf-8")
+        wrapper = profile_dir / "bin" / "hermes-gateway-mybot"
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+
+        real_open = gateway_cli.os.open
+
+        def fake_open(path, flags, *args, **kwargs):
+            if Path(path) == wrapper:
+                raise PermissionError("unreadable wrapper")
+            return real_open(path, flags, *args, **kwargs)
+
+        monkeypatch.setattr(gateway_cli.os, "open", fake_open)
+
+        assert gateway_cli.launchd_plist_is_current() is False
+
+    def test_launchd_refresh_falls_back_without_overwriting_unreadable_regular_wrapper(self, tmp_path, monkeypatch):
+        profile_dir = tmp_path / ".hermes" / "profiles" / "mybot"
+        profile_dir.mkdir(parents=True)
+        python_path = tmp_path / "venv" / "bin" / "python"
+        python_path.parent.mkdir(parents=True)
+        python_path.write_text("")
+        plist_path = tmp_path / "ai.hermes.gateway-mybot.plist"
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(profile_dir))
+        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: profile_dir)
+        monkeypatch.setattr(gateway_cli, "get_python_path", lambda: str(python_path))
+        plist_path.write_text(gateway_cli.generate_launchd_plist(), encoding="utf-8")
+        wrapper = profile_dir / "bin" / "hermes-gateway-mybot"
+        wrapper.write_text("custom wrapper", encoding="utf-8")
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+        monkeypatch.setattr(
+            gateway_cli.subprocess,
+            "run",
+            lambda *args, **kwargs: SimpleNamespace(returncode=0, stdout="", stderr=""),
+        )
+
+        real_open = gateway_cli.os.open
+
+        def fake_open(path, flags, *args, **kwargs):
+            if Path(path) == wrapper:
+                raise PermissionError("unreadable wrapper")
+            return real_open(path, flags, *args, **kwargs)
+
+        monkeypatch.setattr(gateway_cli.os, "open", fake_open)
+
+        assert gateway_cli.refresh_launchd_plist_if_needed() is True
+        assert wrapper.read_text(encoding="utf-8") == "custom wrapper"
+        plist = plist_path.read_text(encoding="utf-8")
+        assert f"<string>{python_path}</string>" in plist
+        assert "<string>-m</string>" in plist
+        assert "<string>hermes_cli.main</string>" in plist
+        assert gateway_cli.launchd_plist_is_current() is True
+
+    def test_launchd_refresh_falls_back_without_overwriting_custom_readable_wrapper(self, tmp_path, monkeypatch):
+        profile_dir = tmp_path / ".hermes" / "profiles" / "mybot"
+        profile_dir.mkdir(parents=True)
+        python_path = tmp_path / "venv" / "bin" / "python"
+        python_path.parent.mkdir(parents=True)
+        python_path.write_text("")
+        plist_path = tmp_path / "ai.hermes.gateway-mybot.plist"
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(profile_dir))
+        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: profile_dir)
+        monkeypatch.setattr(gateway_cli, "get_python_path", lambda: str(python_path))
+        plist_path.write_text(gateway_cli.generate_launchd_plist(), encoding="utf-8")
+        wrapper = profile_dir / "bin" / "hermes-gateway-mybot"
+        wrapper.write_text("custom wrapper", encoding="utf-8")
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+        monkeypatch.setattr(
+            gateway_cli.subprocess,
+            "run",
+            lambda *args, **kwargs: SimpleNamespace(returncode=0, stdout="", stderr=""),
+        )
+
+        assert gateway_cli.refresh_launchd_plist_if_needed() is True
+        assert wrapper.read_text(encoding="utf-8") == "custom wrapper"
+        plist = plist_path.read_text(encoding="utf-8")
+        assert f"<string>{python_path}</string>" in plist
+        assert "<string>-m</string>" in plist
+        assert "<string>hermes_cli.main</string>" in plist
+        assert gateway_cli.launchd_plist_is_current() is True
+
+    def test_launchd_fallback_plist_is_current_with_custom_readable_wrapper(self, tmp_path, monkeypatch):
+        profile_dir = tmp_path / ".hermes" / "profiles" / "mybot"
+        profile_dir.mkdir(parents=True)
+        wrapper = profile_dir / "bin" / "hermes-gateway-mybot"
+        wrapper.parent.mkdir()
+        wrapper.write_text("custom wrapper", encoding="utf-8")
+        python_path = tmp_path / "venv" / "bin" / "python"
+        python_path.parent.mkdir(parents=True)
+        python_path.write_text("")
+        plist_path = tmp_path / "ai.hermes.gateway-mybot.plist"
+        calls = []
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(profile_dir))
+        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: profile_dir)
+        monkeypatch.setattr(gateway_cli, "get_python_path", lambda: str(python_path))
+        plist_path.write_text(gateway_cli.generate_launchd_plist(), encoding="utf-8")
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+        monkeypatch.setattr(
+            gateway_cli.subprocess,
+            "run",
+            lambda cmd, **kwargs: calls.append(cmd) or SimpleNamespace(returncode=0, stdout="", stderr=""),
+        )
+
+        assert gateway_cli.launchd_plist_is_current() is True
+        assert gateway_cli.refresh_launchd_plist_if_needed() is False
+        assert wrapper.read_text(encoding="utf-8") == "custom wrapper"
+        assert calls == []
+
+    def test_launchd_refresh_does_not_reload_previous_when_unreadable_wrapper_cannot_restore(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        profile_dir = tmp_path / ".hermes" / "profiles" / "mybot"
+        profile_dir.mkdir(parents=True)
+        python_path = tmp_path / "venv" / "bin" / "python"
+        python_path.parent.mkdir(parents=True)
+        python_path.write_text("")
+        plist_path = tmp_path / "ai.hermes.gateway-mybot.plist"
+        wrapper = profile_dir / "bin" / "hermes-gateway-mybot"
+        wrapper.parent.mkdir()
+        wrapper.write_text("old wrapper", encoding="utf-8")
+        old_plist = plistlib.dumps({"ProgramArguments": [str(wrapper)]}).decode("utf-8")
+        plist_path.write_text(old_plist, encoding="utf-8")
+        calls = []
+
+        def fake_run(cmd, check=False, **kwargs):
+            calls.append((cmd, check))
+            if cmd[1] == "bootstrap":
+                raise gateway_cli.subprocess.CalledProcessError(5, cmd, stderr="bootstrap failed")
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        real_open = gateway_cli.os.open
+
+        def fake_open(path, flags, *args, **kwargs):
+            if Path(path) == wrapper:
+                raise PermissionError("unreadable wrapper")
+            return real_open(path, flags, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(profile_dir))
+        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: profile_dir)
+        monkeypatch.setattr(gateway_cli, "get_python_path", lambda: str(python_path))
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+        monkeypatch.setattr(gateway_cli.os, "open", fake_open)
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        with pytest.raises(gateway_cli.subprocess.CalledProcessError):
+            gateway_cli.refresh_launchd_plist_if_needed()
+
+        assert plist_path.read_text(encoding="utf-8") == old_plist
+        assert wrapper.exists()
+        assert calls == [
+            (["launchctl", "bootout", f"{gateway_cli._launchd_domain()}/{gateway_cli.get_launchd_label()}"], True),
+            (["launchctl", "bootstrap", gateway_cli._launchd_domain(), str(plist_path)], True),
+        ]
+
+    def test_launchd_refresh_does_not_reload_previous_when_wrapper_path_becomes_unsafe(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        profile_dir = tmp_path / ".hermes" / "profiles" / "mybot"
+        profile_dir.mkdir(parents=True)
+        python_path = tmp_path / "venv" / "bin" / "python"
+        python_path.parent.mkdir(parents=True)
+        python_path.write_text("")
+        wrapper = profile_dir / "bin" / "hermes-gateway-mybot"
+        old_plist = f"<plist><dict><key>ProgramArguments</key><array><string>{wrapper}</string></array></dict></plist>"
+        plist_path = tmp_path / "ai.hermes.gateway-mybot.plist"
+        plist_path.write_text(old_plist, encoding="utf-8")
+        redirected = tmp_path / "redirected"
+        redirected.mkdir()
+        wrapper.parent.symlink_to(redirected, target_is_directory=True)
+        calls = []
+
+        def fake_run(cmd, check=False, **kwargs):
+            calls.append((cmd, check))
+            if cmd[1] == "bootstrap" and check:
+                raise gateway_cli.subprocess.CalledProcessError(5, cmd, stderr="bootstrap failed")
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(profile_dir))
+        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: profile_dir)
+        monkeypatch.setattr(gateway_cli, "get_python_path", lambda: str(python_path))
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        with pytest.raises(gateway_cli.subprocess.CalledProcessError):
+            gateway_cli.refresh_launchd_plist_if_needed()
+
+        assert plist_path.read_text(encoding="utf-8") == old_plist
+        assert calls == [
+            (["launchctl", "bootout", f"{gateway_cli._launchd_domain()}/{gateway_cli.get_launchd_label()}"], True),
+            (["launchctl", "bootstrap", gateway_cli._launchd_domain(), str(plist_path)], True),
+        ]
+
+    def test_launchd_refresh_does_not_reload_previous_when_missing_wrapper_becomes_symlink(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        profile_dir = tmp_path / ".hermes" / "profiles" / "mybot"
+        profile_dir.mkdir(parents=True)
+        python_path = tmp_path / "venv" / "bin" / "python"
+        python_path.parent.mkdir(parents=True)
+        python_path.write_text("")
+        wrapper = profile_dir / "bin" / "hermes-gateway-mybot"
+        old_plist = f"<plist><dict><key>ProgramArguments</key><array><string>{wrapper}</string></array></dict></plist>"
+        plist_path = tmp_path / "ai.hermes.gateway-mybot.plist"
+        plist_path.write_text(old_plist, encoding="utf-8")
+        redirected = tmp_path / "redirected-wrapper"
+        redirected.write_text("custom wrapper", encoding="utf-8")
+        calls = []
+        bootstrap_attempts = 0
+
+        def fake_run(cmd, check=False, **kwargs):
+            nonlocal bootstrap_attempts
+            calls.append((cmd, check))
+            if cmd[1] == "bootstrap" and check:
+                bootstrap_attempts += 1
+                if bootstrap_attempts == 1:
+                    wrapper.unlink()
+                    wrapper.symlink_to(redirected)
+                    raise gateway_cli.subprocess.CalledProcessError(5, cmd, stderr="bootstrap failed")
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(profile_dir))
+        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: profile_dir)
+        monkeypatch.setattr(gateway_cli, "get_python_path", lambda: str(python_path))
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        with pytest.raises(gateway_cli.subprocess.CalledProcessError):
+            gateway_cli.refresh_launchd_plist_if_needed()
+
+        assert plist_path.read_text(encoding="utf-8") == old_plist
+        assert wrapper.is_symlink()
+        assert calls == [
+            (["launchctl", "bootout", f"{gateway_cli._launchd_domain()}/{gateway_cli.get_launchd_label()}"], True),
+            (["launchctl", "bootstrap", gateway_cli._launchd_domain(), str(plist_path)], True),
+        ]
+
+    def test_launchd_plist_falls_back_to_python_when_wrapper_creation_fails(self, tmp_path, monkeypatch):
+        profile_dir = tmp_path / ".hermes" / "profiles" / "mybot"
+        profile_dir.mkdir(parents=True)
+        python_path = tmp_path / "venv" / "bin" / "python"
+        python_path.parent.mkdir(parents=True)
+        python_path.write_text("")
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(profile_dir))
+        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: profile_dir)
+        monkeypatch.setattr(gateway_cli, "get_python_path", lambda: str(python_path))
+        monkeypatch.setattr(gateway_cli, "_ensure_launchd_gateway_wrapper", lambda _python_path: None)
+
+        plist = gateway_cli.generate_launchd_plist()
+
+        assert f"<string>{python_path}</string>" in plist
+        assert "<string>-m</string>" in plist
+        assert "<string>hermes_cli.main</string>" in plist
+
+    def test_launchd_fallback_refresh_is_noop_while_wrapper_creation_keeps_failing(self, tmp_path, monkeypatch):
+        profile_dir = tmp_path / ".hermes" / "profiles" / "mybot"
+        profile_dir.mkdir(parents=True)
+        python_path = tmp_path / "venv" / "bin" / "python"
+        python_path.parent.mkdir(parents=True)
+        python_path.write_text("")
+        plist_path = tmp_path / "ai.hermes.gateway-mybot.plist"
+        calls = []
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(profile_dir))
+        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: profile_dir)
+        monkeypatch.setattr(gateway_cli, "get_python_path", lambda: str(python_path))
+        monkeypatch.setattr(gateway_cli, "_ensure_launchd_gateway_wrapper", lambda _python_path: None)
+        plist_path.write_text(gateway_cli.generate_launchd_plist(), encoding="utf-8")
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+        monkeypatch.setattr(
+            gateway_cli.subprocess,
+            "run",
+            lambda cmd, **kwargs: calls.append(cmd) or SimpleNamespace(returncode=0, stdout="", stderr=""),
+        )
+
+        assert gateway_cli.launchd_plist_is_current() is False
+        assert not (profile_dir / "bin" / "hermes-gateway-mybot").exists()
+        assert gateway_cli.refresh_launchd_plist_if_needed() is False
+        assert calls == []
+
+    def test_launchd_fallback_plist_self_heals_after_wrapper_failure_is_cleared(self, tmp_path, monkeypatch):
+        profile_dir = tmp_path / ".hermes" / "profiles" / "mybot"
+        profile_dir.mkdir(parents=True)
+        python_path = tmp_path / "venv" / "bin" / "python"
+        python_path.parent.mkdir(parents=True)
+        python_path.write_text("")
+        plist_path = tmp_path / "ai.hermes.gateway-mybot.plist"
+        calls = []
+        ensure_wrapper = gateway_cli._ensure_launchd_gateway_wrapper
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(profile_dir))
+        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: profile_dir)
+        monkeypatch.setattr(gateway_cli, "get_python_path", lambda: str(python_path))
+        monkeypatch.setattr(gateway_cli, "_ensure_launchd_gateway_wrapper", lambda _python_path: None)
+        plist_path.write_text(gateway_cli.generate_launchd_plist(), encoding="utf-8")
+        monkeypatch.setattr(gateway_cli, "_ensure_launchd_gateway_wrapper", ensure_wrapper)
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+        monkeypatch.setattr(
+            gateway_cli.subprocess,
+            "run",
+            lambda cmd, **kwargs: calls.append(cmd) or SimpleNamespace(returncode=0, stdout="", stderr=""),
+        )
+
+        assert gateway_cli.launchd_plist_is_current() is False
+        assert not (profile_dir / "bin" / "hermes-gateway-mybot").exists()
+        assert gateway_cli.refresh_launchd_plist_if_needed() is True
+        assert (profile_dir / "bin" / "hermes-gateway-mybot").exists()
+
+    def test_launchd_fallback_plist_self_heals_when_wrapper_becomes_available(self, tmp_path, monkeypatch):
+        profile_dir = tmp_path / ".hermes" / "profiles" / "mybot"
+        profile_dir.mkdir(parents=True)
+        python_path = tmp_path / "venv" / "bin" / "python"
+        python_path.parent.mkdir(parents=True)
+        python_path.write_text("")
+        plist_path = tmp_path / "ai.hermes.gateway-mybot.plist"
+        calls = []
+        ensure_wrapper = gateway_cli._ensure_launchd_gateway_wrapper
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(profile_dir))
+        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: profile_dir)
+        monkeypatch.setattr(gateway_cli, "get_python_path", lambda: str(python_path))
+        monkeypatch.setattr(gateway_cli, "_ensure_launchd_gateway_wrapper", lambda _python_path: None)
+        plist_path.write_text(gateway_cli.generate_launchd_plist(), encoding="utf-8")
+        monkeypatch.setattr(gateway_cli, "_ensure_launchd_gateway_wrapper", ensure_wrapper)
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+        monkeypatch.setattr(
+            gateway_cli.subprocess,
+            "run",
+            lambda cmd, **kwargs: calls.append(cmd) or SimpleNamespace(returncode=0, stdout="", stderr=""),
+        )
+
+        assert not (profile_dir / "bin" / "hermes-gateway-mybot").exists()
+        assert gateway_cli.launchd_plist_is_current() is False
+        assert not (profile_dir / "bin" / "hermes-gateway-mybot").exists()
+        assert gateway_cli.refresh_launchd_plist_if_needed() is True
+        assert (profile_dir / "bin" / "hermes-gateway-mybot").exists()
+        assert gateway_cli.launchd_plist_is_current() is True
+
+    def test_launchd_fallback_currentness_does_not_chmod_wrapper_parent(self, tmp_path, monkeypatch):
+        profile_dir = tmp_path / ".hermes" / "profiles" / "mybot"
+        profile_dir.mkdir(parents=True)
+        wrapper_parent = profile_dir / "bin"
+        wrapper_parent.mkdir()
+        wrapper_parent.chmod(0o777)
+        python_path = tmp_path / "venv" / "bin" / "python"
+        python_path.parent.mkdir(parents=True)
+        python_path.write_text("")
+        plist_path = tmp_path / "ai.hermes.gateway-mybot.plist"
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(profile_dir))
+        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: profile_dir)
+        monkeypatch.setattr(gateway_cli, "get_python_path", lambda: str(python_path))
+        monkeypatch.setattr(gateway_cli, "_ensure_launchd_gateway_wrapper", lambda _python_path: None)
+        plist_path.write_text(gateway_cli.generate_launchd_plist(), encoding="utf-8")
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+
+        try:
+            assert gateway_cli.launchd_plist_is_current() is True
+            assert stat.S_IMODE(wrapper_parent.stat().st_mode) == 0o777
+        finally:
+            wrapper_parent.chmod(0o755)
+
+    def test_launchd_fallback_plist_is_current_when_wrapper_path_is_unsafe(self, tmp_path, monkeypatch):
+        profile_dir = tmp_path / ".hermes" / "profiles" / "mybot"
+        profile_dir.mkdir(parents=True)
+        wrapper = profile_dir / "bin" / "hermes-gateway-mybot"
+        wrapper.parent.mkdir()
+        wrapper.symlink_to(tmp_path / "unsafe-target")
+        python_path = tmp_path / "venv" / "bin" / "python"
+        python_path.parent.mkdir(parents=True)
+        python_path.write_text("")
+        plist_path = tmp_path / "ai.hermes.gateway-mybot.plist"
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(profile_dir))
+        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: profile_dir)
+        monkeypatch.setattr(gateway_cli, "get_python_path", lambda: str(python_path))
+        plist_path.write_text(gateway_cli.generate_launchd_plist(), encoding="utf-8")
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+
+        assert gateway_cli.launchd_plist_is_current() is True
+
+    def test_launchd_plist_falls_back_when_wrapper_path_is_symlink(self, tmp_path, monkeypatch):
+        profile_dir = tmp_path / ".hermes" / "profiles" / "mybot"
+        profile_dir.mkdir(parents=True)
+        wrapper = profile_dir / "bin" / "hermes-gateway-mybot"
+        wrapper.parent.mkdir()
+        symlink_target = tmp_path / "do-not-touch"
+        symlink_target.write_text("keep me", encoding="utf-8")
+        wrapper.symlink_to(symlink_target)
+        python_path = tmp_path / "venv" / "bin" / "python"
+        python_path.parent.mkdir(parents=True)
+        python_path.write_text("")
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(profile_dir))
+        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: profile_dir)
+        monkeypatch.setattr(gateway_cli, "get_python_path", lambda: str(python_path))
+
+        plist = gateway_cli.generate_launchd_plist()
+
+        assert wrapper.is_symlink()
+        assert symlink_target.read_text(encoding="utf-8") == "keep me"
+        assert f"<string>{python_path}</string>" in plist
+        assert "<string>-m</string>" in plist
+        assert "<string>hermes_cli.main</string>" in plist
+
+    def test_launchd_plist_falls_back_when_wrapper_parent_is_symlink(self, tmp_path, monkeypatch):
+        profile_dir = tmp_path / ".hermes" / "profiles" / "mybot"
+        profile_dir.mkdir(parents=True)
+        redirected = tmp_path / "redirected"
+        redirected.mkdir()
+        (profile_dir / "bin").symlink_to(redirected, target_is_directory=True)
+        python_path = tmp_path / "venv" / "bin" / "python"
+        python_path.parent.mkdir(parents=True)
+        python_path.write_text("")
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(profile_dir))
+        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: profile_dir)
+        monkeypatch.setattr(gateway_cli, "get_python_path", lambda: str(python_path))
+
+        plist = gateway_cli.generate_launchd_plist()
+
+        assert not (redirected / "hermes-gateway-mybot").exists()
+        assert f"<string>{python_path}</string>" in plist
+        assert "<string>-m</string>" in plist
+        assert "<string>hermes_cli.main</string>" in plist
+
+    def test_launchd_plist_falls_back_when_hermes_home_is_group_writable(self, tmp_path, monkeypatch):
+        profile_dir = tmp_path / ".hermes" / "profiles" / "mybot"
+        profile_dir.mkdir(parents=True)
+        profile_dir.chmod(0o775)
+        python_path = tmp_path / "venv" / "bin" / "python"
+        python_path.parent.mkdir(parents=True)
+        python_path.write_text("")
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(profile_dir))
+        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: profile_dir)
+        monkeypatch.setattr(gateway_cli, "get_python_path", lambda: str(python_path))
+
+        try:
+            plist = gateway_cli.generate_launchd_plist()
+        finally:
+            profile_dir.chmod(0o755)
+
+        assert not (profile_dir / "bin" / "hermes-gateway-mybot").exists()
+        assert f"<string>{python_path}</string>" in plist
+        assert "<string>-m</string>" in plist
+        assert "<string>hermes_cli.main</string>" in plist
+
+    def test_launchd_plist_falls_back_when_profile_parent_is_group_writable(self, tmp_path, monkeypatch):
+        profiles_dir = tmp_path / ".hermes" / "profiles"
+        profile_dir = profiles_dir / "mybot"
+        profile_dir.mkdir(parents=True)
+        profiles_dir.chmod(0o775)
+        python_path = tmp_path / "venv" / "bin" / "python"
+        python_path.parent.mkdir(parents=True)
+        python_path.write_text("")
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(profile_dir))
+        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: profile_dir)
+        monkeypatch.setattr(gateway_cli, "get_python_path", lambda: str(python_path))
+
+        try:
+            plist = gateway_cli.generate_launchd_plist()
+        finally:
+            profiles_dir.chmod(0o755)
+
+        assert not (profile_dir / "bin" / "hermes-gateway-mybot").exists()
+        assert f"<string>{python_path}</string>" in plist
+        assert "<string>-m</string>" in plist
+        assert "<string>hermes_cli.main</string>" in plist
+
+    def test_launchd_gateway_wrapper_secures_parent_directory_permissions(self, tmp_path, monkeypatch):
+        profile_dir = tmp_path / ".hermes" / "profiles" / "mybot"
+        profile_dir.mkdir(parents=True)
+        wrapper_parent = profile_dir / "bin"
+        wrapper_parent.mkdir()
+        wrapper_parent.chmod(0o777)
+        python_path = tmp_path / "venv" / "bin" / "python"
+        python_path.parent.mkdir(parents=True)
+        python_path.write_text("")
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(profile_dir))
+        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: profile_dir)
+        monkeypatch.setattr(gateway_cli, "get_python_path", lambda: str(python_path))
+
+        gateway_cli.generate_launchd_plist()
+
+        assert stat.S_IMODE(wrapper_parent.stat().st_mode) == 0o755
+
+    def test_launchd_gateway_wrapper_restore_refuses_symlinked_parent(self, tmp_path):
+        profile_dir = tmp_path / ".hermes" / "profiles" / "mybot"
+        profile_dir.mkdir(parents=True)
+        redirected = tmp_path / "redirected"
+        redirected.mkdir()
+        (profile_dir / "bin").symlink_to(redirected, target_is_directory=True)
+        redirected_wrapper = redirected / "hermes-gateway-mybot"
+        redirected_wrapper.write_text("keep me", encoding="utf-8")
+        snapshot = gateway_cli.LaunchdWrapperSnapshot(
+            path=profile_dir / "bin" / "hermes-gateway-mybot",
+            content=b"new content",
+            mode=0o755,
+        )
+
+        gateway_cli._restore_launchd_gateway_wrapper(snapshot)
+
+        assert redirected_wrapper.read_text(encoding="utf-8") == "keep me"
 
     def test_launchd_plist_path_uses_real_user_home_not_profile_home(self, tmp_path, monkeypatch):
         profile_dir = tmp_path / ".hermes" / "profiles" / "orcha"


### PR DESCRIPTION
## What does this PR do?

macOS Background Items currently shows Hermes launchd gateways by the basename of `ProgramArguments[0]`. When the plist launches `.../venv/bin/python -m hermes_cli.main`, multiple profile gateways all appear as `python`, which makes entries hard to distinguish.

This changes macOS launchd plist generation to create a service-scoped wrapper at `HERMES_HOME/bin/<service-name>` and use that wrapper as `ProgramArguments[0]`. The wrapper still execs the same Python interpreter with `-m hermes_cli.main`, so runtime behavior stays the same while macOS displays names like `hermes-gateway-kb-insurance-ai-projects` or `hermes-gateway-tennis-court-checker`.

This is related to #15640, but intentionally keeps the service name profile-aware. Using `venv/bin/hermes` would improve the single-service case from `python` to `hermes`, but two active profile gateways would still be indistinguishable from each other.

## Related Issue

Related to #15636
Related to #15640

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/gateway.py`: generate a service-scoped macOS launchd wrapper under `HERMES_HOME/bin/<service-name>` and point `ProgramArguments[0]` at it, falling back to the previous Python module invocation if wrapper creation fails.
- `hermes_cli/gateway.py`: refresh stale launchd plists during `hermes gateway restart` so existing services pick up the new wrapper executable path.
- `hermes_cli/gateway.py`: write wrapper files through a temp file and `os.replace()`, reset permissions to `0755`, reject unsafe symlink/non-regular wrapper paths, and tolerate stale/corrupt wrapper contents.
- `tests/hermes_cli/test_gateway_service.py`: cover named-profile launchd plist generation, wrapper creation, executable permissions, non-UTF-8 replacement, symlink fallback, Python fallback behavior, restart-time plist refresh, and real old Python plist rewrite.

## How to Test

1. `uv run --extra dev pytest tests/hermes_cli/test_gateway_service.py::TestProfileArg tests/hermes_cli/test_gateway_service.py::TestLaunchdServiceRecovery -q -n 0`
2. `uv run --extra dev pytest tests/hermes_cli/test_gateway_service.py -k 'launchd_plist or launchd_install_repairs_outdated_plist_without_force or launchd_refresh_rewrites_old_python_plist_to_profile_wrapper' -q -n 0`
3. `python scripts/check-windows-footguns.py hermes_cli/gateway.py tests/hermes_cli/test_gateway_service.py`
4. `git diff --check`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.3.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A

## Screenshots / Logs

Automated verification output is summarized in **How to Test**.
