### PR TITLE
fix: always redact API keys in status output

### DIFF
--- a/hermes_cli/status.py
+++ b/hermes_cli/status.py
@@ -163,12 +163,15 @@ def show_status(args):
             continue
         value = _resolve_env(env_ref)
         has_key = bool(value)
-        display = redact_key(value) if not show_all else value
+        # Never print raw API keys, even with --all. The --all flag expands
+        # status coverage; it must not turn a diagnostic command into a
+        # credential disclosure path.
+        display = redact_key(value)
         print(f"  {name:<12}  {check_mark(has_key)} {display}")
 
     from hermes_cli.auth import get_anthropic_key
     anthropic_value = get_anthropic_key()
-    anthropic_display = redact_key(anthropic_value) if not show_all else anthropic_value
+    anthropic_display = redact_key(anthropic_value)
     print(f"  {'Anthropic':<12}  {check_mark(bool(anthropic_value))} {anthropic_display}")
 
     # =========================================================================

--- a/tests/hermes_cli/test_status.py
+++ b/tests/hermes_cli/test_status.py
@@ -14,6 +14,25 @@ def test_show_status_includes_tavily_key(monkeypatch, capsys, tmp_path):
     assert "tvly...cdef" in output
 
 
+def test_show_status_all_redacts_api_keys(monkeypatch, capsys, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    nvidia_key = "nvapi-secret-value-that-must-not-leak-123456"
+    openai_key = "openai-status-test-token-abcdef"
+    monkeypatch.setenv("NVIDIA_API_KEY", nvidia_key)
+    monkeypatch.setenv("OPENAI_API_KEY", openai_key)
+
+    show_status(SimpleNamespace(all=True, deep=False))
+
+    output = capsys.readouterr().out
+    assert "NVIDIA NIM" in output
+    assert "OpenAI" in output
+    assert nvidia_key not in output
+    assert openai_key not in output
+    assert "nvap...3456" in output
+    assert "open...cdef" in output
+
+
+
 def test_show_status_termux_gateway_section_skips_systemctl(monkeypatch, capsys, tmp_path):
     from hermes_cli import status as status_mod
     import hermes_cli.auth as auth_mod


### PR DESCRIPTION
## Summary
- Always redact API key values in `hermes status`, including `--all` mode
- Keep `--all` useful for diagnostics without turning it into a credential disclosure path
- Add regression coverage for NVIDIA/OpenAI-style API keys

## Security
`hermes status --all` previously printed raw API key values from configured environment variables. This PR does not include any real secrets.

## Tests
- `uv run --python 3.13 pytest tests/hermes_cli/test_status.py -v --tb=short -o 'addopts='`