### PR TITLE
fix(acp): add "Allow for session" option to edit approval prompts

### DIFF
--- a/acp_adapter/edit_approval.py
+++ b/acp_adapter/edit_approval.py
@@ -240,6 +240,12 @@ def make_acp_edit_approval_requester(
 ) -> EditApprovalRequester:
     """Return a sync requester that bridges edit proposals to ACP permissions."""
 
+    # Closure-scoped flag flipped on by an interactive "Allow for session"
+    # selection. Mirrors the server-side ``AUTO_APPROVE_SESSION`` policy
+    # (see ``should_auto_approve_edit``): sensitive paths still prompt even
+    # after the user opts in for the session.
+    session_state = {"allow_for_session": False}
+
     def _requester(proposal: EditProposal) -> bool:
         from acp.schema import PermissionOption
         from agent.async_utils import safe_schedule_threadsafe
@@ -253,8 +259,20 @@ def make_acp_edit_approval_requester(
             except Exception:
                 logger.debug("ACP edit auto-approval policy check failed", exc_info=True)
 
+        if session_state["allow_for_session"] and not _is_sensitive_auto_approve_path(proposal.path):
+            logger.info("Auto-approved ACP edit under interactive session opt-in: %s", proposal.path)
+            return True
+
         options = [
             PermissionOption(option_id="allow_once", kind="allow_once", name="Allow edit"),
+            PermissionOption(
+                option_id="allow_session",
+                # ACP has no session-scoped kind, so use the closest persistent
+                # hint while keeping Hermes semantics in the option id. Matches
+                # the terminal command bridge in ``permissions.py``.
+                kind="allow_always",
+                name="Allow edits for session",
+            ),
             PermissionOption(option_id="deny", kind="reject_once", name="Deny"),
         ]
         tool_call = build_acp_edit_tool_call(proposal)
@@ -278,9 +296,12 @@ def make_acp_edit_approval_requester(
             logger.warning("Edit approval request timed out or failed: %s", exc)
             return False
         outcome = getattr(response, "outcome", None)
-        return (
-            getattr(outcome, "outcome", None) == "selected"
-            and getattr(outcome, "option_id", None) == "allow_once"
-        )
+        if getattr(outcome, "outcome", None) != "selected":
+            return False
+        option_id = getattr(outcome, "option_id", None)
+        if option_id == "allow_session":
+            session_state["allow_for_session"] = True
+            return True
+        return option_id == "allow_once"
 
     return _requester

--- a/tests/acp/test_edit_approval.py
+++ b/tests/acp/test_edit_approval.py
@@ -2,14 +2,20 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 import tempfile
+from concurrent.futures import Future
 from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from acp.schema import AllowedOutcome, RequestPermissionResponse
 
 from acp_adapter.edit_approval import (
     EditProposal,
     build_acp_edit_tool_call,
     clear_edit_approval_requester,
+    make_acp_edit_approval_requester,
     set_edit_approval_requester,
     should_auto_approve_edit,
 )
@@ -180,6 +186,135 @@ def test_patch_replace_approval_request_includes_full_file_diff(tmp_path):
     assert proposals[0].tool_name == "patch"
     assert proposals[0].old_text == "alpha\nbeta\n"
     assert proposals[0].new_text == "alpha\ngamma\n"
+
+
+def _build_requester_with_responses(responses):
+    """Build a requester whose underlying ACP permission call returns the
+    given outcomes in order, one per call. Returns ``(requester, call_log)``.
+
+    ``call_log`` is a list of the option-id lists offered to each request,
+    so tests can assert that ``allow_session`` is surfaced and that
+    subsequent edits skip the prompt entirely (call_log shorter than the
+    number of edits proposed).
+    """
+
+    loop = MagicMock(spec=asyncio.AbstractEventLoop)
+    request_permission = AsyncMock(name="request_permission")
+    call_log: list[list[str]] = []
+
+    response_iter = iter(responses)
+
+    def _schedule(coro, passed_loop):
+        coro.close()
+        fut = MagicMock(spec=Future)
+        fut.result.return_value = RequestPermissionResponse(outcome=next(response_iter))
+        return fut
+
+    patcher = patch(
+        "agent.async_utils.asyncio.run_coroutine_threadsafe",
+        side_effect=_schedule,
+    )
+    patcher.start()
+    try:
+        requester = make_acp_edit_approval_requester(
+            request_permission, loop, session_id="s1", timeout=1.0,
+        )
+    finally:
+        # Keep the patch active for the lifetime of the requester so that
+        # repeated calls within a test exercise the same _schedule shim.
+        pass
+
+    original = requester
+
+    def wrapped(proposal):
+        result = original(proposal)
+        # Record which options were offered on this call (empty if the
+        # session opt-in short-circuited before scheduling the permission
+        # request).
+        if request_permission.call_args is not None:
+            kwargs = request_permission.call_args.kwargs
+            call_log.append([opt.option_id for opt in kwargs.get("options", [])])
+            request_permission.reset_mock()
+        else:
+            call_log.append([])
+        return result
+
+    wrapped._patcher = patcher  # so callers can stop it
+    return wrapped, call_log
+
+
+def test_edit_approval_options_include_allow_session(tmp_path):
+    proposal = EditProposal("write_file", str(tmp_path / "x.py"), None, "x", {})
+    requester, call_log = _build_requester_with_responses(
+        [AllowedOutcome(option_id="allow_once", outcome="selected")]
+    )
+    try:
+        assert requester(proposal) is True
+        assert call_log == [["allow_once", "allow_session", "deny"]]
+    finally:
+        requester._patcher.stop()
+
+
+def test_edit_approval_allow_session_skips_subsequent_prompts(tmp_path):
+    first = EditProposal("write_file", str(tmp_path / "a.py"), None, "a", {})
+    second = EditProposal("write_file", str(tmp_path / "b.py"), None, "b", {})
+    third = EditProposal("write_file", str(tmp_path / "c.py"), None, "c", {})
+
+    requester, call_log = _build_requester_with_responses(
+        [AllowedOutcome(option_id="allow_session", outcome="selected")]
+    )
+    try:
+        assert requester(first) is True
+        assert requester(second) is True
+        assert requester(third) is True
+        # Only the first proposal prompted; the next two short-circuited.
+        assert call_log == [["allow_once", "allow_session", "deny"], [], []]
+    finally:
+        requester._patcher.stop()
+
+
+def test_edit_approval_allow_session_still_prompts_on_sensitive_paths(tmp_path):
+    benign = EditProposal("write_file", str(tmp_path / "a.py"), None, "a", {})
+    sensitive = EditProposal("write_file", str(tmp_path / ".env"), None, "SECRET=x", {})
+
+    requester, call_log = _build_requester_with_responses(
+        [
+            AllowedOutcome(option_id="allow_session", outcome="selected"),
+            AllowedOutcome(option_id="allow_once", outcome="selected"),
+        ]
+    )
+    try:
+        assert requester(benign) is True
+        # Sensitive path must re-prompt even after session opt-in.
+        assert requester(sensitive) is True
+        assert call_log == [
+            ["allow_once", "allow_session", "deny"],
+            ["allow_once", "allow_session", "deny"],
+        ]
+    finally:
+        requester._patcher.stop()
+
+
+def test_edit_approval_allow_once_does_not_enable_session(tmp_path):
+    first = EditProposal("write_file", str(tmp_path / "a.py"), None, "a", {})
+    second = EditProposal("write_file", str(tmp_path / "b.py"), None, "b", {})
+
+    requester, call_log = _build_requester_with_responses(
+        [
+            AllowedOutcome(option_id="allow_once", outcome="selected"),
+            AllowedOutcome(option_id="allow_once", outcome="selected"),
+        ]
+    )
+    try:
+        assert requester(first) is True
+        assert requester(second) is True
+        # Each proposal prompts — allow_once does not persist across calls.
+        assert call_log == [
+            ["allow_once", "allow_session", "deny"],
+            ["allow_once", "allow_session", "deny"],
+        ]
+    finally:
+        requester._patcher.stop()
 
 
 def test_workspace_auto_approval_allows_workspace_and_tmp_but_not_sensitive(tmp_path):

--- a/tests/acp/test_edit_approval.py
+++ b/tests/acp/test_edit_approval.py
@@ -193,9 +193,10 @@ def _build_requester_with_responses(responses):
     given outcomes in order, one per call. Returns ``(requester, call_log)``.
 
     ``call_log`` is a list of the option-id lists offered to each request,
-    so tests can assert that ``allow_session`` is surfaced and that
-    subsequent edits skip the prompt entirely (call_log shorter than the
-    number of edits proposed).
+    with one entry per requester call. Skipped prompts (where the session
+    opt-in short-circuited before scheduling a permission request) record an
+    empty list, so ``call_log`` stays the same length as the number of edits
+    proposed while still showing which calls actually surfaced options.
     """
 
     loop = MagicMock(spec=asyncio.AbstractEventLoop)
@@ -215,14 +216,18 @@ def _build_requester_with_responses(responses):
         side_effect=_schedule,
     )
     patcher.start()
+    # The patch must stay active for the lifetime of the requester so repeated
+    # calls within a test exercise the same _schedule shim; callers stop it via
+    # ``requester._patcher``. But if construction itself raises, stop the patch
+    # here so it does not leak into other tests and cause order-dependent
+    # failures.
     try:
         requester = make_acp_edit_approval_requester(
             request_permission, loop, session_id="s1", timeout=1.0,
         )
-    finally:
-        # Keep the patch active for the lifetime of the requester so that
-        # repeated calls within a test exercise the same _schedule shim.
-        pass
+    except BaseException:
+        patcher.stop()
+        raise
 
     original = requester
 


### PR DESCRIPTION
## What does this PR do?

ACP edit approval prompts (`write_file`, `patch`) only offered "Allow once" or "Deny", forcing the user to click through every single edit even when the terminal-command bridge in the same ACP session already surfaced `allow_session` / `allow_always`. A single agent run that touches a handful of files could fire 20+ sequential prompts.

This PR adds an "Allow edits for session" option to the edit approval requester. Selecting it sets a closure-scoped flag so subsequent edits in the same ACP run auto-approve without re-prompting, mirroring the existing server-side `AUTO_APPROVE_SESSION` policy in `should_auto_approve_edit`. Sensitive paths (`.env`, `id_rsa`, anything under `.ssh` / `.git`) still prompt even after the user opts in — same exception the policy already enforces.

Mirrors `acp_adapter/permissions.py::_build_permission_options` for the option shape (id `allow_session`, kind `allow_always` because ACP has no session-scoped kind, name "Allow edits for session"). The dispatcher contract for `_requester` (sync `bool`) is preserved, so no callers need to change.

## Related Issue

Fixes #29410

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `acp_adapter/edit_approval.py` — add `allow_session` option, closure-scoped `session_state["allow_for_session"]` flag, sensitive-path short-circuit, and outcome mapping that flips the flag on selection.
- `tests/acp/test_edit_approval.py` — 4 new tests covering option presence, session opt-in skipping subsequent prompts, sensitive-path re-prompt after opt-in, and `allow_once` NOT enabling session scope.

## How to Test

1. `uv run --with pytest --with pytest-xdist --with pytest-asyncio --with pytest-timeout --with 'agent-client-protocol==0.9.0' python3 -m pytest tests/acp/test_edit_approval.py -v`
2. New tests all pass; 3 pre-existing failures (`test_write_file_approval_mutates_and_request_includes_diff`, `test_patch_replace_approval_request_includes_full_file_diff`, `test_write_file_new_file_request_has_empty_old_text`) reproduce identically on clean `origin/main` — they are macOS-tmpdir-as-sensitive-system-path baseline noise, not touched by this PR.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run focused tests for the touched code and all pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A: option name + behavior is self-describing in the prompt; no docs page references the previous two-option list
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A: no new config keys; the `AUTO_APPROVE_SESSION` policy was already documented
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — sensitive-path check reuses existing `_is_sensitive_auto_approve_path` which already handles cross-platform path parts
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

> Audited siblings: `acp_adapter/permissions.py::_build_permission_options` already offers `allow_session`/`allow_always` for terminal commands; this PR only widens the parallel surface in `edit_approval.py`. `allow_always` (persistent across runs) is intentionally NOT added here — it would need server-side config persistence and is out of scope. Happy to follow up with a separate PR if maintainers want it.