### PR TITLE
fix(proxy): require client bearer for subscription proxy

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -10914,6 +10914,11 @@ def main():
         default=None,
         help="Bind port (default: 8645)",
     )
+    proxy_start.add_argument(
+        "--api-key",
+        default=None,
+        help="Client bearer token required by the proxy (default: generated per start)",
+    )
 
     proxy_subparsers.add_parser(
         "status", help="Show which proxy upstreams are ready"

--- a/hermes_cli/proxy/cli.py
+++ b/hermes_cli/proxy/cli.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import secrets
 import sys
 from typing import Any
 
@@ -54,19 +55,28 @@ def cmd_proxy_start(args: Any) -> int:
 
     host = getattr(args, "host", None) or DEFAULT_HOST
     port = getattr(args, "port", None) or DEFAULT_PORT
+    client_api_key = getattr(args, "api_key", None) or secrets.token_urlsafe(24)
 
     print(
         f"Starting Hermes proxy for {adapter.display_name}\n"
         f"  Listening on:  http://{host}:{port}/v1\n"
         f"  Forwarding to: (resolved per-request from your subscription)\n"
-        f"  Use any bearer token in the client — the proxy attaches your real credential.\n"
+        f"  Client token:  {client_api_key}\n"
+        f"  Configure clients with this token as the API key.\n"
         f"\n"
         f"Press Ctrl+C to stop.",
         file=sys.stderr,
     )
 
     try:
-        asyncio.run(run_server(adapter, host=host, port=port))
+        asyncio.run(
+            run_server(
+                adapter,
+                host=host,
+                port=port,
+                client_api_key=client_api_key,
+            )
+        )
     except KeyboardInterrupt:
         print("\nproxy: stopped", file=sys.stderr)
     except OSError as exc:

--- a/hermes_cli/proxy/server.py
+++ b/hermes_cli/proxy/server.py
@@ -12,6 +12,7 @@ or rewrite request/response bodies. It's a credential-attaching forwarder.
 from __future__ import annotations
 
 import asyncio
+import hmac
 import json
 import logging
 import signal
@@ -82,7 +83,10 @@ def _filter_response_headers(headers) -> dict:
     return out
 
 
-def create_app(adapter: UpstreamAdapter) -> "web.Application":
+def create_app(
+    adapter: UpstreamAdapter,
+    client_api_key: Optional[str] = None,
+) -> "web.Application":
     """Build the aiohttp application bound to a specific upstream adapter."""
     if not AIOHTTP_AVAILABLE:
         raise RuntimeError(
@@ -95,6 +99,15 @@ def create_app(adapter: UpstreamAdapter) -> "web.Application":
     # bare-string keys.
     _adapter_key = web.AppKey("adapter", UpstreamAdapter)
     app[_adapter_key] = adapter
+
+    def _authorized(request: "web.Request") -> bool:
+        if not client_api_key:
+            return True
+        auth = request.headers.get("Authorization", "")
+        scheme, _, supplied = auth.partition(" ")
+        if scheme.lower() != "bearer" or not supplied:
+            return False
+        return hmac.compare_digest(supplied, client_api_key)
 
     async def handle_health(request: "web.Request") -> "web.Response":
         return web.json_response(
@@ -117,6 +130,13 @@ def create_app(adapter: UpstreamAdapter) -> "web.Application":
         )
 
     async def handle_proxy(request: "web.Request") -> "web.StreamResponse":
+        if not _authorized(request):
+            return _json_error(
+                401,
+                "Invalid Hermes proxy API key",
+                code="invalid_proxy_api_key",
+            )
+
         # Extract the path *after* /v1
         rel_path = request.match_info.get("tail", "")
         rel_path = "/" + rel_path.lstrip("/")
@@ -257,6 +277,7 @@ async def run_server(
     host: str = DEFAULT_HOST,
     port: int = DEFAULT_PORT,
     shutdown_event: Optional[asyncio.Event] = None,
+    client_api_key: Optional[str] = None,
 ) -> None:
     """Run the proxy in the current event loop until shutdown_event is set.
 
@@ -268,7 +289,7 @@ async def run_server(
             "pip install 'hermes-agent[messaging]' or `pip install aiohttp`."
         )
 
-    app = create_app(adapter)
+    app = create_app(adapter, client_api_key=client_api_key)
     runner = web.AppRunner(app, access_log=None)
     await runner.setup()
     site = web.TCPSite(runner, host=host, port=port)

--- a/tests/hermes_cli/test_proxy_server_auth.py
+++ b/tests/hermes_cli/test_proxy_server_auth.py
@@ -1,0 +1,101 @@
+"""Security regression tests for hermes_cli.proxy.server."""
+
+from __future__ import annotations
+
+import pytest
+from aiohttp import ClientSession, web
+
+from hermes_cli.proxy.adapters.base import UpstreamAdapter, UpstreamCredential
+from hermes_cli.proxy.server import create_app
+
+
+class _FakeAdapter(UpstreamAdapter):
+    name = "fake"
+    display_name = "Fake Subscription"
+    allowed_paths = frozenset({"/chat/completions", "/models"})
+
+    def __init__(self, base_url: str) -> None:
+        self.base_url = base_url
+
+    def is_authenticated(self) -> bool:
+        return True
+
+    def get_credential(self) -> UpstreamCredential:
+        return UpstreamCredential(
+            bearer="REAL_PROVIDER_ACCESS_TOKEN_SECRET",
+            base_url=self.base_url,
+            token_type="Bearer",
+            expires_at=None,
+        )
+
+
+async def _start_upstream(captured: dict[str, str | None]) -> tuple[web.AppRunner, int]:
+    async def upstream_handler(request: web.Request) -> web.Response:
+        captured["authorization"] = request.headers.get("Authorization")
+        return web.json_response({"ok": True})
+
+    upstream_app = web.Application()
+    upstream_app.router.add_route("*", "/v1/{tail:.*}", upstream_handler)
+    runner = web.AppRunner(upstream_app)
+    await runner.setup()
+    site = web.TCPSite(runner, "127.0.0.1", 0)
+    await site.start()
+    return runner, runner.addresses[0][1]
+
+
+async def _start_proxy(upstream_port: int) -> tuple[web.AppRunner, int]:
+    proxy_app = create_app(
+        _FakeAdapter(f"http://127.0.0.1:{upstream_port}/v1"),
+        client_api_key="required-client-secret",
+    )
+    runner = web.AppRunner(proxy_app)
+    await runner.setup()
+    site = web.TCPSite(runner, "127.0.0.1", 0)
+    await site.start()
+    return runner, runner.addresses[0][1]
+
+
+@pytest.mark.asyncio
+async def test_proxy_rejects_requests_without_configured_client_bearer() -> None:
+    captured: dict[str, str | None] = {}
+    upstream_runner, upstream_port = await _start_upstream(captured)
+    proxy_runner, proxy_port = await _start_proxy(upstream_port)
+
+    try:
+        async with ClientSession() as session:
+            response = await session.post(
+                f"http://127.0.0.1:{proxy_port}/v1/chat/completions",
+                headers={"Authorization": "Bearer attacker-supplied-token"},
+                json={"model": "paid-model", "messages": []},
+            )
+            body = await response.json()
+
+        assert response.status == 401
+        assert body["error"]["code"] == "invalid_proxy_api_key"
+        assert captured == {}
+    finally:
+        await proxy_runner.cleanup()
+        await upstream_runner.cleanup()
+
+
+@pytest.mark.asyncio
+async def test_proxy_accepts_configured_client_bearer_and_replaces_upstream_auth() -> None:
+    captured: dict[str, str | None] = {}
+    upstream_runner, upstream_port = await _start_upstream(captured)
+    proxy_runner, proxy_port = await _start_proxy(upstream_port)
+
+    try:
+        async with ClientSession() as session:
+            response = await session.post(
+                f"http://127.0.0.1:{proxy_port}/v1/chat/completions",
+                headers={"Authorization": "Bearer required-client-secret"},
+                json={"model": "paid-model", "messages": []},
+            )
+            body = await response.json()
+
+        assert response.status == 200
+        assert body == {"ok": True}
+        assert captured["authorization"] == "Bearer REAL_PROVIDER_ACCESS_TOKEN_SECRET"
+    finally:
+        await proxy_runner.cleanup()
+        await upstream_runner.cleanup()

--- a/website/docs/user-guide/features/subscription-proxy.md
+++ b/website/docs/user-guide/features/subscription-proxy.md
@@ -46,7 +46,8 @@ hermes proxy start
 Starting Hermes proxy for Nous Portal
   Listening on:  http://127.0.0.1:8645/v1
   Forwarding to: (resolved per-request from your subscription)
-  Use any bearer token in the client — the proxy attaches your real credential.
+  Client token:  <generated-token>
+  Configure clients with this token as the API key.
 ```
 
 Leave this running in the foreground. Use `tmux`, `nohup`, or a systemd
@@ -58,13 +59,14 @@ Any OpenAI-compatible app config takes the same triple:
 
 ```
 Base URL:   http://127.0.0.1:8645/v1
-API key:    anything (e.g. "sk-unused")
+API key:    the generated client token printed by `hermes proxy start`
 Model:      Hermes-4-70B    # or Hermes-4.3-36B, Hermes-4-405B
 ```
 
-The proxy ignores the `Authorization` header from your app and attaches
-your real Portal credential to the upstream request. Refreshes happen
-automatically when the bearer approaches expiry.
+The proxy requires the configured client bearer before it forwards a
+request. After that check passes, it replaces the client bearer with
+your real Portal credential on the upstream request. Refreshes happen
+automatically when the upstream bearer approaches expiry.
 
 ## Available providers
 
@@ -124,7 +126,7 @@ Edit `~/.openviking/ov.conf`:
     "provider": "openai",
     "model": "Hermes-4-70B",
     "api_base": "http://127.0.0.1:8645/v1",
-    "api_key": "unused-proxy-attaches-real-creds"
+    "api_key": "paste-the-generated-client-token-here"
   }
 }
 ```
@@ -152,7 +154,7 @@ bookmark summarization. In its config:
 ```bash
 # Karakeep .env
 OPENAI_API_BASE_URL=http://127.0.0.1:8645/v1
-OPENAI_API_KEY=any-non-empty-string
+OPENAI_API_KEY=paste-the-generated-client-token-here
 INFERENCE_TEXT_MODEL=Hermes-4-70B
 ```
 
@@ -168,10 +170,10 @@ machines on your network use it:
 hermes proxy start --host 0.0.0.0 --port 8645
 ```
 
-⚠ **Be aware:** anyone on your network can now use your Portal
-subscription. The proxy has no auth of its own — it accepts any bearer.
-Use a firewall, VPN, or reverse proxy with proper auth if you expose
-this beyond your trusted network.
+⚠ **Be aware:** the proxy now requires a client bearer token before it
+forwards requests, but a listener on `0.0.0.0` is still reachable from
+your LAN. Prefer a firewall or VPN for non-local use, and pass a stable
+secret with `--api-key` if clients need to reconnect after restarts.
 
 ## Rate limits
 
@@ -185,9 +187,10 @@ subscription quota. Monitor usage at
 The proxy is intentionally minimal. Per request:
 
 1. Receive `POST /v1/chat/completions` from your app
-2. Look up the adapter's current credential (refresh if expiring)
-3. Forward the request body verbatim, with `Authorization: Bearer <minted-key>`
-4. Stream the response back unchanged (SSE preserved)
+2. Require the configured client bearer token
+3. Look up the adapter's current credential (refresh if expiring)
+4. Forward the request body verbatim with the upstream bearer token
+5. Stream the response back unchanged (SSE preserved)
 
 No transformation. No logging of request bodies. No agent loop. The
 proxy is a credential-attaching pass-through.


### PR DESCRIPTION
## Summary
- require a generated or operator-supplied client bearer before the subscription proxy forwards OpenAI-compatible requests
- keep replacing the accepted client bearer with the resolved upstream OAuth credential
- document the new client token flow and add regression coverage for rejected and accepted requests

## Test Plan
- `TMPDIR=/tmp/hermes-agent-pytest python -m pytest -n 0 -q tests/hermes_cli/test_proxy.py tests/hermes_cli/test_proxy_server_auth.py`
