### PR TITLE
fix(mcp): handle DCR clients with secrets

### DIFF
--- a/tests/tools/test_mcp_oauth.py
+++ b/tests/tools/test_mcp_oauth.py
@@ -235,7 +235,10 @@ class TestBuildOAuthAuth:
         assert json.loads(token_path.read_text())["access_token"] == "access-token"
 
     @pytest.mark.asyncio
-    async def test_malformed_201_refresh_response_clears_tokens(self, tmp_path, monkeypatch):
+    async def test_malformed_201_refresh_response_clears_tokens(
+        self, tmp_path, monkeypatch, caplog
+    ):
+        import logging
         import httpx
 
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
@@ -244,12 +247,15 @@ class TestBuildOAuthAuth:
         assert provider is not None
         provider.context.current_tokens = object()
 
-        result = await provider._handle_refresh_response(
-            httpx.Response(201, content=b'{"not_a_token": true}')
+        response = httpx.Response(
+            201, content=b'{"refresh_token": "refresh-secret"}'
         )
+        with caplog.at_level(logging.WARNING, logger="tools.mcp_oauth"):
+            result = await provider._handle_refresh_response(response)
 
         assert result is False
         assert provider.context.current_tokens is None
+        assert "refresh-secret" not in caplog.text
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_mcp_oauth.py
+++ b/tests/tools/test_mcp_oauth.py
@@ -257,6 +257,28 @@ class TestBuildOAuthAuth:
         assert "access-secret" not in str(exc_info.value)
 
     @pytest.mark.asyncio
+    async def test_token_read_error_does_not_expose_body(self, tmp_path, monkeypatch):
+        import httpx
+        from mcp.client.auth.oauth2 import OAuthTokenError
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        _set_interactive_stdin(monkeypatch)
+        provider = build_oauth_auth("supabase", "https://mcp.supabase.com/mcp")
+        assert provider is not None
+
+        class _ReadErrorResponse:
+            status_code = 201
+
+            async def aread(self):
+                raise httpx.ReadError("access-secret refresh-secret")
+
+        with pytest.raises(OAuthTokenError, match="^Invalid token response$") as exc_info:
+            await provider._handle_token_response(_ReadErrorResponse())
+
+        assert "access-secret" not in str(exc_info.value)
+        assert "refresh-secret" not in str(exc_info.value)
+
+    @pytest.mark.asyncio
     async def test_malformed_201_refresh_response_clears_tokens(
         self, tmp_path, monkeypatch, caplog
     ):

--- a/tests/tools/test_mcp_oauth.py
+++ b/tests/tools/test_mcp_oauth.py
@@ -191,11 +191,15 @@ class TestBuildOAuthAuth:
         from urllib.parse import parse_qs
 
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        _set_interactive_stdin(monkeypatch)
         provider = build_oauth_auth("supabase", "https://mcp.supabase.com/mcp")
+        assert provider is not None
+        redirect_uris = provider.context.client_metadata.redirect_uris
+        assert redirect_uris is not None
         provider.context.client_info = OAuthClientInformationFull.model_validate({
             "client_id": "client-id",
             "client_secret": "secret",
-            "redirect_uris": [str(provider.context.client_metadata.redirect_uris[0])],
+            "redirect_uris": [str(redirect_uris[0])],
             "token_endpoint_auth_method": "none",
         })
 
@@ -204,6 +208,7 @@ class TestBuildOAuthAuth:
 
         assert body["client_id"] == ["client-id"]
         assert body["client_secret"] == ["secret"]
+        assert provider.context.client_info is not None
         assert provider.context.client_info.token_endpoint_auth_method == "client_secret_post"
 
     @pytest.mark.asyncio
@@ -211,7 +216,9 @@ class TestBuildOAuthAuth:
         import httpx
 
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        _set_interactive_stdin(monkeypatch)
         provider = build_oauth_auth("supabase", "https://mcp.supabase.com/mcp")
+        assert provider is not None
         response = httpx.Response(201, json={
             "access_token": "access-token",
             "token_type": "Bearer",
@@ -220,7 +227,9 @@ class TestBuildOAuthAuth:
 
         await provider._handle_token_response(response)
 
-        assert provider.context.current_tokens.access_token == "access-token"
+        tokens = provider.context.current_tokens
+        assert tokens is not None
+        assert tokens.access_token == "access-token"
         token_path = tmp_path / "mcp-tokens" / "supabase.json"
         assert token_path.exists()
         assert json.loads(token_path.read_text())["access_token"] == "access-token"

--- a/tests/tools/test_mcp_oauth.py
+++ b/tests/tools/test_mcp_oauth.py
@@ -234,6 +234,23 @@ class TestBuildOAuthAuth:
         assert token_path.exists()
         assert json.loads(token_path.read_text())["access_token"] == "access-token"
 
+    @pytest.mark.asyncio
+    async def test_malformed_201_refresh_response_clears_tokens(self, tmp_path, monkeypatch):
+        import httpx
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        _set_interactive_stdin(monkeypatch)
+        provider = build_oauth_auth("supabase", "https://mcp.supabase.com/mcp")
+        assert provider is not None
+        provider.context.current_tokens = object()
+
+        result = await provider._handle_refresh_response(
+            httpx.Response(201, content=b'{"not_a_token": true}')
+        )
+
+        assert result is False
+        assert provider.context.current_tokens is None
+
 
 # ---------------------------------------------------------------------------
 # Utility functions

--- a/tests/tools/test_mcp_oauth.py
+++ b/tests/tools/test_mcp_oauth.py
@@ -235,6 +235,28 @@ class TestBuildOAuthAuth:
         assert json.loads(token_path.read_text())["access_token"] == "access-token"
 
     @pytest.mark.asyncio
+    async def test_malformed_201_token_response_does_not_expose_body(
+        self, tmp_path, monkeypatch
+    ):
+        import httpx
+        from mcp.client.auth.oauth2 import OAuthTokenError
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        _set_interactive_stdin(monkeypatch)
+        provider = build_oauth_auth("supabase", "https://mcp.supabase.com/mcp")
+        assert provider is not None
+
+        with pytest.raises(OAuthTokenError, match="^Invalid token response$") as exc_info:
+            await provider._handle_token_response(
+                httpx.Response(
+                    201,
+                    content=b'{"access_token": {"secret": "access-secret"}}',
+                )
+            )
+
+        assert "access-secret" not in str(exc_info.value)
+
+    @pytest.mark.asyncio
     async def test_malformed_201_refresh_response_clears_tokens(
         self, tmp_path, monkeypatch, caplog
     ):
@@ -256,6 +278,27 @@ class TestBuildOAuthAuth:
         assert result is False
         assert provider.context.current_tokens is None
         assert "refresh-secret" not in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_refresh_read_error_clears_tokens(self, tmp_path, monkeypatch):
+        import httpx
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        _set_interactive_stdin(monkeypatch)
+        provider = build_oauth_auth("supabase", "https://mcp.supabase.com/mcp")
+        assert provider is not None
+        provider.context.current_tokens = object()
+
+        class _ReadErrorResponse:
+            status_code = 201
+
+            async def aread(self):
+                raise httpx.ReadError("body read failed")
+
+        result = await provider._handle_refresh_response(_ReadErrorResponse())
+
+        assert result is False
+        assert provider.context.current_tokens is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_mcp_oauth.py
+++ b/tests/tools/test_mcp_oauth.py
@@ -112,6 +112,43 @@ class TestHermesTokenStorage:
             f"token parent dir mode {oct(parent_mode)} != 0o700 — siblings can traverse"
         )
 
+    def test_client_info_with_secret_uses_client_secret_post(self, tmp_path, monkeypatch):
+        from mcp.shared.auth import OAuthClientInformationFull
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        storage = HermesTokenStorage("supabase")
+        client_info = OAuthClientInformationFull.model_validate({
+            "client_id": "client-id",
+            "client_secret": "secret",
+            "redirect_uris": ["http://127.0.0.1:12345/callback"],
+        })
+
+        asyncio.run(storage.set_client_info(client_info))
+        loaded = asyncio.run(storage.get_client_info())
+
+        assert loaded is not None
+        assert loaded.token_endpoint_auth_method == "client_secret_post"
+        client_path = tmp_path / "mcp-tokens" / "supabase.client.json"
+        assert json.loads(client_path.read_text())["token_endpoint_auth_method"] == "client_secret_post"
+
+    def test_client_info_with_secret_and_none_method_is_coerced(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        token_dir = tmp_path / "mcp-tokens"
+        token_dir.mkdir(parents=True)
+        client_path = token_dir / "supabase.client.json"
+        client_path.write_text(json.dumps({
+            "client_id": "client-id",
+            "client_secret": "secret",
+            "redirect_uris": ["http://127.0.0.1:12345/callback"],
+            "token_endpoint_auth_method": "none",
+        }))
+
+        loaded = asyncio.run(HermesTokenStorage("supabase").get_client_info())
+
+        assert loaded is not None
+        assert loaded.token_endpoint_auth_method == "client_secret_post"
+        assert json.loads(client_path.read_text())["token_endpoint_auth_method"] == "client_secret_post"
+
 
     def test_corrupt_tokens_returns_none(self, tmp_path, monkeypatch):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
@@ -147,6 +184,46 @@ class TestBuildOAuthAuth:
         })
         assert provider is not None
         assert provider.context.client_metadata.scope == "read write admin"
+
+    @pytest.mark.asyncio
+    async def test_token_exchange_includes_secret_for_dcr_secret_client(self, tmp_path, monkeypatch):
+        from mcp.shared.auth import OAuthClientInformationFull
+        from urllib.parse import parse_qs
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        provider = build_oauth_auth("supabase", "https://mcp.supabase.com/mcp")
+        provider.context.client_info = OAuthClientInformationFull.model_validate({
+            "client_id": "client-id",
+            "client_secret": "secret",
+            "redirect_uris": [str(provider.context.client_metadata.redirect_uris[0])],
+            "token_endpoint_auth_method": "none",
+        })
+
+        request = await provider._exchange_token_authorization_code("auth-code", "verifier")
+        body = parse_qs(request.content.decode())
+
+        assert body["client_id"] == ["client-id"]
+        assert body["client_secret"] == ["secret"]
+        assert provider.context.client_info.token_endpoint_auth_method == "client_secret_post"
+
+    @pytest.mark.asyncio
+    async def test_token_response_accepts_201_created(self, tmp_path, monkeypatch):
+        import httpx
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        provider = build_oauth_auth("supabase", "https://mcp.supabase.com/mcp")
+        response = httpx.Response(201, json={
+            "access_token": "access-token",
+            "token_type": "Bearer",
+            "refresh_token": "refresh-token",
+        })
+
+        await provider._handle_token_response(response)
+
+        assert provider.context.current_tokens.access_token == "access-token"
+        token_path = tmp_path / "mcp-tokens" / "supabase.json"
+        assert token_path.exists()
+        assert json.loads(token_path.read_text())["access_token"] == "access-token"
 
 
 # ---------------------------------------------------------------------------
@@ -633,7 +710,7 @@ def test_build_oauth_auth_preserves_server_url_path():
             captured.update(kwargs)
 
     with patch.object(mcp_oauth, "_OAUTH_AVAILABLE", True), \
-         patch.object(mcp_oauth, "OAuthClientProvider", _FakeProvider), \
+         patch.object(mcp_oauth, "HermesOAuthClientProvider", _FakeProvider), \
          patch.object(mcp_oauth, "_is_interactive", return_value=True), \
          patch.object(mcp_oauth, "_maybe_preregister_client"), \
          patch.object(mcp_oauth, "HermesTokenStorage") as mock_storage_cls:

--- a/tests/tools/test_mcp_oauth_manager.py
+++ b/tests/tools/test_mcp_oauth_manager.py
@@ -420,6 +420,29 @@ async def test_manager_malformed_201_token_response_does_not_expose_body(
 
 
 @pytest.mark.asyncio
+async def test_manager_token_read_error_does_not_expose_body(tmp_path, monkeypatch):
+    import httpx
+    from mcp.client.auth.oauth2 import OAuthTokenError
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    provider = _provider_with_token_endpoint(
+        tmp_path, {}, "https://idp.example.com/oauth/token", monkeypatch
+    )
+
+    class _ReadErrorResponse:
+        status_code = 201
+
+        async def aread(self):
+            raise httpx.ReadError("access-secret refresh-secret")
+
+    with pytest.raises(OAuthTokenError, match="^Invalid token response$") as exc_info:
+        await provider._handle_token_response(_ReadErrorResponse())
+
+    assert "access-secret" not in str(exc_info.value)
+    assert "refresh-secret" not in str(exc_info.value)
+
+
+@pytest.mark.asyncio
 async def test_manager_malformed_201_refresh_response_clears_tokens(
     tmp_path, monkeypatch, caplog
 ):

--- a/tests/tools/test_mcp_oauth_manager.py
+++ b/tests/tools/test_mcp_oauth_manager.py
@@ -374,13 +374,17 @@ async def test_manager_provider_token_exchange_includes_dcr_secret(tmp_path, mon
 
     reset_manager_for_tests()
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _set_interactive_stdin(monkeypatch)
 
     mgr = MCPOAuthManager()
     provider = mgr.get_or_build_provider("supabase", "https://mcp.supabase.com/mcp", None)
+    assert provider is not None
+    redirect_uris = provider.context.client_metadata.redirect_uris
+    assert redirect_uris is not None
     provider.context.client_info = OAuthClientInformationFull.model_validate({
         "client_id": "client-id",
         "client_secret": "secret",
-        "redirect_uris": [str(provider.context.client_metadata.redirect_uris[0])],
+        "redirect_uris": [str(redirect_uris[0])],
         "token_endpoint_auth_method": "none",
     })
 
@@ -388,5 +392,5 @@ async def test_manager_provider_token_exchange_includes_dcr_secret(tmp_path, mon
     body = parse_qs(request.content.decode())
 
     assert body["client_secret"] == ["secret"]
+    assert provider.context.client_info is not None
     assert provider.context.client_info.token_endpoint_auth_method == "client_secret_post"
-

--- a/tests/tools/test_mcp_oauth_manager.py
+++ b/tests/tools/test_mcp_oauth_manager.py
@@ -397,6 +397,29 @@ async def test_manager_provider_token_exchange_includes_dcr_secret(tmp_path, mon
 
 
 @pytest.mark.asyncio
+async def test_manager_malformed_201_token_response_does_not_expose_body(
+    tmp_path, monkeypatch
+):
+    from mcp.client.auth.oauth2 import OAuthTokenError
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    provider = _provider_with_token_endpoint(
+        tmp_path, {}, "https://idp.example.com/oauth/token", monkeypatch
+    )
+
+    with pytest.raises(OAuthTokenError, match="^Invalid token response$") as exc_info:
+        await provider._handle_token_response(
+            _fake_response(
+                201,
+                "https://idp.example.com/oauth/token",
+                b'{"access_token": {"secret": "access-secret"}}',
+            )
+        )
+
+    assert "access-secret" not in str(exc_info.value)
+
+
+@pytest.mark.asyncio
 async def test_manager_malformed_201_refresh_response_clears_tokens(
     tmp_path, monkeypatch, caplog
 ):
@@ -419,3 +442,25 @@ async def test_manager_malformed_201_refresh_response_clears_tokens(
     assert result is False
     assert provider.context.current_tokens is None
     assert "refresh-secret" not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_manager_refresh_read_error_clears_tokens(tmp_path, monkeypatch):
+    import httpx
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    provider = _provider_with_token_endpoint(
+        tmp_path, {}, "https://idp.example.com/oauth/token", monkeypatch
+    )
+    provider.context.current_tokens = object()
+
+    class _ReadErrorResponse:
+        status_code = 201
+
+        async def aread(self):
+            raise httpx.ReadError("body read failed")
+
+    result = await provider._handle_refresh_response(_ReadErrorResponse())
+
+    assert result is False
+    assert provider.context.current_tokens is None

--- a/tests/tools/test_mcp_oauth_manager.py
+++ b/tests/tools/test_mcp_oauth_manager.py
@@ -364,3 +364,29 @@ def test_bridge_forwards_requests_and_poisons_on_token_endpoint_400(
     assert not (d / "srv.client.json").exists()
     assert provider._initialized is False
     assert provider.context.client_info is None
+@pytest.mark.asyncio
+async def test_manager_provider_token_exchange_includes_dcr_secret(tmp_path, monkeypatch):
+    """The manager provider path applies the same Supabase DCR secret fix."""
+    from urllib.parse import parse_qs
+
+    from mcp.shared.auth import OAuthClientInformationFull
+    from tools.mcp_oauth_manager import MCPOAuthManager, reset_manager_for_tests
+
+    reset_manager_for_tests()
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    mgr = MCPOAuthManager()
+    provider = mgr.get_or_build_provider("supabase", "https://mcp.supabase.com/mcp", None)
+    provider.context.client_info = OAuthClientInformationFull.model_validate({
+        "client_id": "client-id",
+        "client_secret": "secret",
+        "redirect_uris": [str(provider.context.client_metadata.redirect_uris[0])],
+        "token_endpoint_auth_method": "none",
+    })
+
+    request = await provider._exchange_token_authorization_code("auth-code", "verifier")
+    body = parse_qs(request.content.decode())
+
+    assert body["client_secret"] == ["secret"]
+    assert provider.context.client_info.token_endpoint_auth_method == "client_secret_post"
+

--- a/tests/tools/test_mcp_oauth_manager.py
+++ b/tests/tools/test_mcp_oauth_manager.py
@@ -394,3 +394,19 @@ async def test_manager_provider_token_exchange_includes_dcr_secret(tmp_path, mon
     assert body["client_secret"] == ["secret"]
     assert provider.context.client_info is not None
     assert provider.context.client_info.token_endpoint_auth_method == "client_secret_post"
+
+
+@pytest.mark.asyncio
+async def test_manager_malformed_201_refresh_response_clears_tokens(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    provider = _provider_with_token_endpoint(
+        tmp_path, {}, "https://idp.example.com/oauth/token", monkeypatch
+    )
+    provider.context.current_tokens = object()
+
+    result = await provider._handle_refresh_response(
+        _fake_response(201, "https://idp.example.com/oauth/token", b'{"not_a_token": true}')
+    )
+
+    assert result is False
+    assert provider.context.current_tokens is None

--- a/tests/tools/test_mcp_oauth_manager.py
+++ b/tests/tools/test_mcp_oauth_manager.py
@@ -397,16 +397,25 @@ async def test_manager_provider_token_exchange_includes_dcr_secret(tmp_path, mon
 
 
 @pytest.mark.asyncio
-async def test_manager_malformed_201_refresh_response_clears_tokens(tmp_path, monkeypatch):
+async def test_manager_malformed_201_refresh_response_clears_tokens(
+    tmp_path, monkeypatch, caplog
+):
+    import logging
+
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
     provider = _provider_with_token_endpoint(
         tmp_path, {}, "https://idp.example.com/oauth/token", monkeypatch
     )
     provider.context.current_tokens = object()
 
-    result = await provider._handle_refresh_response(
-        _fake_response(201, "https://idp.example.com/oauth/token", b'{"not_a_token": true}')
+    response = _fake_response(
+        201,
+        "https://idp.example.com/oauth/token",
+        b'{"refresh_token": "refresh-secret"}',
     )
+    with caplog.at_level(logging.WARNING, logger="tools.mcp_oauth_manager"):
+        result = await provider._handle_refresh_response(response)
 
     assert result is False
     assert provider.context.current_tokens is None
+    assert "refresh-secret" not in caplog.text

--- a/tools/mcp_oauth.py
+++ b/tools/mcp_oauth.py
@@ -1093,10 +1093,11 @@ def _get_hermes_oauth_provider_class() -> type | None:
             if 200 <= response.status_code < 300:
                 from mcp.client.auth.utils import handle_token_response_scopes
                 from mcp.client.auth.oauth2 import OAuthTokenError
+                from httpx import HTTPError
 
                 try:
                     token_response = await handle_token_response_scopes(response)
-                except OAuthTokenError:
+                except (HTTPError, OAuthTokenError):
                     raise OAuthTokenError("Invalid token response") from None
                 self.context.current_tokens = token_response
                 self.context.update_token_expiry(token_response)

--- a/tools/mcp_oauth.py
+++ b/tools/mcp_oauth.py
@@ -1120,7 +1120,7 @@ def _get_hermes_oauth_provider_class() -> type | None:
                 await self.context.storage.set_tokens(token_response)
                 return True
             except ValidationError:
-                logger.exception("Invalid refresh response")
+                logger.warning("Invalid refresh response: %s", response.status_code)
                 self.context.clear_tokens()
                 return False
 

--- a/tools/mcp_oauth.py
+++ b/tools/mcp_oauth.py
@@ -1048,64 +1048,79 @@ def _paste_callback_reader(result: dict) -> None:
 # ---------------------------------------------------------------------------
 
 
-class HermesOAuthClientProvider(OAuthClientProvider):
-    """OAuth provider with pragmatic fixes for real-world MCP providers.
+HermesOAuthClientProvider: Any = None
 
-    Supabase MCP dynamic registration returns ``client_secret`` but omits
-    ``token_endpoint_auth_method``. The upstream MCP SDK treats the missing
-    method as ``none`` and therefore omits ``client_secret`` from the token
-    request, causing Supabase to reject the exchange and the browser to show
-    the authorization page again. Coerce the in-memory client info right before
-    token/refresh requests as well as persisting the fixed shape in storage.
-    """
 
-    def _coerce_client_secret_post(self) -> None:
-        info = getattr(self.context, "client_info", None)
-        if not info or not getattr(info, "client_secret", None):
-            return
-        method = getattr(info, "token_endpoint_auth_method", None)
-        if method not in (None, "none", ""):
-            return
-        data = info.model_dump(mode="json", exclude_none=True)
-        data["token_endpoint_auth_method"] = "client_secret_post"
-        self.context.client_info = OAuthClientInformationFull.model_validate(data)
+def _get_hermes_oauth_provider_class() -> type | None:
+    global HermesOAuthClientProvider
+    if HermesOAuthClientProvider is not None:
+        return HermesOAuthClientProvider
+    if not _ensure_sdk_loaded():
+        return None
 
-    async def _exchange_token_authorization_code(self, *args: Any, **kwargs: Any):
-        self._coerce_client_secret_post()
-        return await super()._exchange_token_authorization_code(*args, **kwargs)
+    class _HermesOAuthClientProvider(OAuthClientProvider):
+        """OAuth provider with pragmatic fixes for real-world MCP providers.
 
-    async def _refresh_token(self):
-        self._coerce_client_secret_post()
-        return await super()._refresh_token()
+        Supabase MCP dynamic registration returns ``client_secret`` but omits
+        ``token_endpoint_auth_method``. The upstream MCP SDK treats the missing
+        method as ``none`` and therefore omits ``client_secret`` from the token
+        request, causing Supabase to reject the exchange and the browser to show
+        the authorization page again. Coerce the in-memory client info right before
+        token/refresh requests as well as persisting the fixed shape in storage.
+        """
 
-    async def _handle_token_response(self, response):
-        """Accept any 2xx token response and avoid leaking token bodies in errors."""
-        if 200 <= response.status_code < 300:
-            from mcp.client.auth.utils import handle_token_response_scopes
+        def _coerce_client_secret_post(self) -> None:
+            info = getattr(self.context, "client_info", None)
+            if not info or not getattr(info, "client_secret", None):
+                return
+            method = getattr(info, "token_endpoint_auth_method", None)
+            if method not in (None, "none", ""):
+                return
+            data = info.model_dump(mode="json", exclude_none=True)
+            data["token_endpoint_auth_method"] = "client_secret_post"
+            self.context.client_info = OAuthClientInformationFull.model_validate(data)
 
-            token_response = await handle_token_response_scopes(response)
+        async def _exchange_token_authorization_code(self, *args: Any, **kwargs: Any):
+            self._coerce_client_secret_post()
+            return await super()._exchange_token_authorization_code(*args, **kwargs)
+
+        async def _refresh_token(self):
+            self._coerce_client_secret_post()
+            return await super()._refresh_token()
+
+        async def _handle_token_response(self, response):
+            """Accept any 2xx token response and avoid leaking token bodies in errors."""
+            if 200 <= response.status_code < 300:
+                from mcp.client.auth.utils import handle_token_response_scopes
+
+                token_response = await handle_token_response_scopes(response)
+                self.context.current_tokens = token_response
+                self.context.update_token_expiry(token_response)
+                await self.context.storage.set_tokens(token_response)
+                return
+
+            from mcp.client.auth.oauth2 import OAuthTokenError
+
+            raise OAuthTokenError(f"Token exchange failed ({response.status_code})")
+
+        async def _handle_refresh_response(self, response) -> bool:
+            """Accept any 2xx refresh response and avoid logging token bodies."""
+            if not (200 <= response.status_code < 300):
+                logger.warning("Token refresh failed: %s", response.status_code)
+                self.context.clear_tokens()
+                return False
+
+            content = await response.aread()
+            token_response = OAuthToken.model_validate_json(content)
             self.context.current_tokens = token_response
             self.context.update_token_expiry(token_response)
             await self.context.storage.set_tokens(token_response)
-            return
+            return True
 
-        from mcp.client.auth.oauth2 import OAuthTokenError
-
-        raise OAuthTokenError(f"Token exchange failed ({response.status_code})")
-
-    async def _handle_refresh_response(self, response) -> bool:
-        """Accept any 2xx refresh response and avoid logging token bodies."""
-        if not (200 <= response.status_code < 300):
-            logger.warning("Token refresh failed: %s", response.status_code)
-            self.context.clear_tokens()
-            return False
-
-        content = await response.aread()
-        token_response = OAuthToken.model_validate_json(content)
-        self.context.current_tokens = token_response
-        self.context.update_token_expiry(token_response)
-        await self.context.storage.set_tokens(token_response)
-        return True
+    _HermesOAuthClientProvider.__name__ = "HermesOAuthClientProvider"
+    _HermesOAuthClientProvider.__qualname__ = "HermesOAuthClientProvider"
+    HermesOAuthClientProvider = _HermesOAuthClientProvider
+    return HermesOAuthClientProvider
 
 
 # ---------------------------------------------------------------------------
@@ -1443,7 +1458,15 @@ def build_oauth_auth(
     )
     callback_handler = _make_callback_waiter(resolved_port)
 
-    return HermesOAuthClientProvider(
+    provider_class = _get_hermes_oauth_provider_class()
+    if provider_class is None:
+        logger.warning(
+            "MCP OAuth requested for '%s' but the provider class is unavailable",
+            server_name,
+        )
+        return None
+
+    return provider_class(
         server_url=server_url,
         client_metadata=client_metadata,
         storage=storage,

--- a/tools/mcp_oauth.py
+++ b/tools/mcp_oauth.py
@@ -1092,8 +1092,12 @@ def _get_hermes_oauth_provider_class() -> type | None:
             """Accept any 2xx token response and avoid leaking token bodies in errors."""
             if 200 <= response.status_code < 300:
                 from mcp.client.auth.utils import handle_token_response_scopes
+                from mcp.client.auth.oauth2 import OAuthTokenError
 
-                token_response = await handle_token_response_scopes(response)
+                try:
+                    token_response = await handle_token_response_scopes(response)
+                except OAuthTokenError:
+                    raise OAuthTokenError("Invalid token response") from None
                 self.context.current_tokens = token_response
                 self.context.update_token_expiry(token_response)
                 await self.context.storage.set_tokens(token_response)
@@ -1111,6 +1115,7 @@ def _get_hermes_oauth_provider_class() -> type | None:
                 return False
 
             from pydantic import ValidationError
+            from httpx import HTTPError
 
             try:
                 content = await response.aread()
@@ -1119,7 +1124,7 @@ def _get_hermes_oauth_provider_class() -> type | None:
                 self.context.update_token_expiry(token_response)
                 await self.context.storage.set_tokens(token_response)
                 return True
-            except ValidationError:
+            except (HTTPError, ValidationError):
                 logger.warning("Invalid refresh response: %s", response.status_code)
                 self.context.clear_tokens()
                 return False

--- a/tools/mcp_oauth.py
+++ b/tools/mcp_oauth.py
@@ -1110,12 +1110,19 @@ def _get_hermes_oauth_provider_class() -> type | None:
                 self.context.clear_tokens()
                 return False
 
-            content = await response.aread()
-            token_response = OAuthToken.model_validate_json(content)
-            self.context.current_tokens = token_response
-            self.context.update_token_expiry(token_response)
-            await self.context.storage.set_tokens(token_response)
-            return True
+            from pydantic import ValidationError
+
+            try:
+                content = await response.aread()
+                token_response = OAuthToken.model_validate_json(content)
+                self.context.current_tokens = token_response
+                self.context.update_token_expiry(token_response)
+                await self.context.storage.set_tokens(token_response)
+                return True
+            except ValidationError:
+                logger.exception("Invalid refresh response")
+                self.context.clear_tokens()
+                return False
 
     _HermesOAuthClientProvider.__name__ = "HermesOAuthClientProvider"
     _HermesOAuthClientProvider.__qualname__ = "HermesOAuthClientProvider"

--- a/tools/mcp_oauth.py
+++ b/tools/mcp_oauth.py
@@ -521,13 +521,32 @@ class HermesTokenStorage:
         if OAuthClientInformationFull is None and not _ensure_sdk_loaded():
             return None
         try:
-            return OAuthClientInformationFull.model_validate(data)
+            info = OAuthClientInformationFull.model_validate(data)
+            # Some dynamic registration providers (notably Supabase MCP) return
+            # a client_secret but omit token_endpoint_auth_method. The MCP SDK
+            # defaults that missing field to "none", which causes token exchange
+            # to omit client_secret and fail with "Required parameter: client_secret".
+            # If a secret is present, use client_secret_post unless the provider
+            # explicitly saved a different method.
+            if getattr(info, "client_secret", None) and data.get("token_endpoint_auth_method") in (None, "none", ""):
+                data["token_endpoint_auth_method"] = "client_secret_post"
+                info = OAuthClientInformationFull.model_validate(data)
+                _write_json(self._client_info_path(), info.model_dump(mode="json", exclude_none=True))
+            return info
         except (ValueError, TypeError, KeyError) as exc:
             logger.warning("Corrupt client info at %s -- ignoring: %s", self._client_info_path(), exc)
             return None
 
     async def set_client_info(self, client_info: "OAuthClientInformationFull") -> None:
-        _write_json(self._client_info_path(), client_info.model_dump(mode="json", exclude_none=True))
+        data = client_info.model_dump(mode="json", exclude_none=True)
+        # Supabase MCP dynamic client registration returns a client_secret but
+        # omits token_endpoint_auth_method. The MCP SDK defaults that to
+        # "none", which makes token exchange omit client_secret and loops the
+        # browser authorization page. Persist the effective method immediately
+        # so this flow and subsequent retries use client_secret_post.
+        if data.get("client_secret") and data.get("token_endpoint_auth_method") in (None, "none", ""):
+            data["token_endpoint_auth_method"] = "client_secret_post"
+        _write_json(self._client_info_path(), data)
         logger.debug("OAuth client info saved for %s", self._server_name)
 
     # -- oauth server metadata --------------------------------------------
@@ -1025,6 +1044,71 @@ def _paste_callback_reader(result: dict) -> None:
 
 
 # ---------------------------------------------------------------------------
+# OAuth provider compatibility shims
+# ---------------------------------------------------------------------------
+
+
+class HermesOAuthClientProvider(OAuthClientProvider):
+    """OAuth provider with pragmatic fixes for real-world MCP providers.
+
+    Supabase MCP dynamic registration returns ``client_secret`` but omits
+    ``token_endpoint_auth_method``. The upstream MCP SDK treats the missing
+    method as ``none`` and therefore omits ``client_secret`` from the token
+    request, causing Supabase to reject the exchange and the browser to show
+    the authorization page again. Coerce the in-memory client info right before
+    token/refresh requests as well as persisting the fixed shape in storage.
+    """
+
+    def _coerce_client_secret_post(self) -> None:
+        info = getattr(self.context, "client_info", None)
+        if not info or not getattr(info, "client_secret", None):
+            return
+        method = getattr(info, "token_endpoint_auth_method", None)
+        if method not in (None, "none", ""):
+            return
+        data = info.model_dump(mode="json", exclude_none=True)
+        data["token_endpoint_auth_method"] = "client_secret_post"
+        self.context.client_info = OAuthClientInformationFull.model_validate(data)
+
+    async def _exchange_token_authorization_code(self, *args: Any, **kwargs: Any):
+        self._coerce_client_secret_post()
+        return await super()._exchange_token_authorization_code(*args, **kwargs)
+
+    async def _refresh_token(self):
+        self._coerce_client_secret_post()
+        return await super()._refresh_token()
+
+    async def _handle_token_response(self, response):
+        """Accept any 2xx token response and avoid leaking token bodies in errors."""
+        if 200 <= response.status_code < 300:
+            from mcp.client.auth.utils import handle_token_response_scopes
+
+            token_response = await handle_token_response_scopes(response)
+            self.context.current_tokens = token_response
+            self.context.update_token_expiry(token_response)
+            await self.context.storage.set_tokens(token_response)
+            return
+
+        from mcp.client.auth.oauth2 import OAuthTokenError
+
+        raise OAuthTokenError(f"Token exchange failed ({response.status_code})")
+
+    async def _handle_refresh_response(self, response) -> bool:
+        """Accept any 2xx refresh response and avoid logging token bodies."""
+        if not (200 <= response.status_code < 300):
+            logger.warning("Token refresh failed: %s", response.status_code)
+            self.context.clear_tokens()
+            return False
+
+        content = await response.aread()
+        token_response = OAuthToken.model_validate_json(content)
+        self.context.current_tokens = token_response
+        self.context.update_token_expiry(token_response)
+        await self.context.storage.set_tokens(token_response)
+        return True
+
+
+# ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
 
@@ -1359,7 +1443,7 @@ def build_oauth_auth(
     )
     callback_handler = _make_callback_waiter(resolved_port)
 
-    return OAuthClientProvider(
+    return HermesOAuthClientProvider(
         server_url=server_url,
         client_metadata=client_metadata,
         storage=storage,

--- a/tools/mcp_oauth_manager.py
+++ b/tools/mcp_oauth_manager.py
@@ -146,6 +146,68 @@ def _make_hermes_provider_class() -> Optional[type]:
             # clients. See _maybe_flag_poisoned_client.
             self._hermes_preregistered = preregistered
 
+        def _coerce_client_secret_post(self) -> None:
+            """Use client_secret_post when dynamic registration returned a secret.
+
+            Some MCP OAuth providers, notably Supabase, return a
+            ``client_secret`` from dynamic client registration but omit
+            ``token_endpoint_auth_method``. The MCP SDK treats the missing
+            value as public-client auth (``none``), so token exchange omits the
+            secret and Supabase rejects it with ``Required parameter:
+            client_secret``. Coerce the in-memory client info before token and
+            refresh requests.
+            """
+            info = getattr(self.context, "client_info", None)
+            if not info or not getattr(info, "client_secret", None):
+                return
+            method = getattr(info, "token_endpoint_auth_method", None)
+            if method not in (None, "none", ""):
+                return
+            from mcp.shared.auth import OAuthClientInformationFull
+
+            data = info.model_dump(mode="json", exclude_none=True)
+            data["token_endpoint_auth_method"] = "client_secret_post"
+            self.context.client_info = OAuthClientInformationFull.model_validate(data)
+
+        async def _exchange_token_authorization_code(self, *args: Any, **kwargs: Any):
+            self._coerce_client_secret_post()
+            return await super()._exchange_token_authorization_code(*args, **kwargs)
+
+        async def _refresh_token(self):
+            self._coerce_client_secret_post()
+            return await super()._refresh_token()
+
+        async def _handle_token_response(self, response):
+            """Accept any 2xx token response and avoid leaking token bodies in errors."""
+            if 200 <= response.status_code < 300:
+                from mcp.client.auth.utils import handle_token_response_scopes
+
+                token_response = await handle_token_response_scopes(response)
+                self.context.current_tokens = token_response
+                self.context.update_token_expiry(token_response)
+                await self.context.storage.set_tokens(token_response)
+                return
+
+            from mcp.client.auth.oauth2 import OAuthTokenError
+
+            raise OAuthTokenError(f"Token exchange failed ({response.status_code})")
+
+        async def _handle_refresh_response(self, response) -> bool:
+            """Accept any 2xx refresh response and avoid logging token bodies."""
+            if not (200 <= response.status_code < 300):
+                logger.warning("Token refresh failed: %s", response.status_code)
+                self.context.clear_tokens()
+                return False
+
+            from mcp.shared.auth import OAuthToken
+
+            content = await response.aread()
+            token_response = OAuthToken.model_validate_json(content)
+            self.context.current_tokens = token_response
+            self.context.update_token_expiry(token_response)
+            await self.context.storage.set_tokens(token_response)
+            return True
+
         async def _initialize(self) -> None:
             """Load stored tokens + client info AND seed token_expiry_time.
 

--- a/tools/mcp_oauth_manager.py
+++ b/tools/mcp_oauth_manager.py
@@ -210,7 +210,7 @@ def _make_hermes_provider_class() -> Optional[type]:
                 await self.context.storage.set_tokens(token_response)
                 return True
             except ValidationError:
-                logger.exception("Invalid refresh response")
+                logger.warning("Invalid refresh response: %s", response.status_code)
                 self.context.clear_tokens()
                 return False
 

--- a/tools/mcp_oauth_manager.py
+++ b/tools/mcp_oauth_manager.py
@@ -181,8 +181,12 @@ def _make_hermes_provider_class() -> Optional[type]:
             """Accept any 2xx token response and avoid leaking token bodies in errors."""
             if 200 <= response.status_code < 300:
                 from mcp.client.auth.utils import handle_token_response_scopes
+                from mcp.client.auth.oauth2 import OAuthTokenError
 
-                token_response = await handle_token_response_scopes(response)
+                try:
+                    token_response = await handle_token_response_scopes(response)
+                except OAuthTokenError:
+                    raise OAuthTokenError("Invalid token response") from None
                 self.context.current_tokens = token_response
                 self.context.update_token_expiry(token_response)
                 await self.context.storage.set_tokens(token_response)
@@ -200,6 +204,7 @@ def _make_hermes_provider_class() -> Optional[type]:
                 return False
 
             from mcp.shared.auth import OAuthToken
+            from httpx import HTTPError
             from pydantic import ValidationError
 
             try:
@@ -209,7 +214,7 @@ def _make_hermes_provider_class() -> Optional[type]:
                 self.context.update_token_expiry(token_response)
                 await self.context.storage.set_tokens(token_response)
                 return True
-            except ValidationError:
+            except (HTTPError, ValidationError):
                 logger.warning("Invalid refresh response: %s", response.status_code)
                 self.context.clear_tokens()
                 return False

--- a/tools/mcp_oauth_manager.py
+++ b/tools/mcp_oauth_manager.py
@@ -182,10 +182,11 @@ def _make_hermes_provider_class() -> Optional[type]:
             if 200 <= response.status_code < 300:
                 from mcp.client.auth.utils import handle_token_response_scopes
                 from mcp.client.auth.oauth2 import OAuthTokenError
+                from httpx import HTTPError
 
                 try:
                     token_response = await handle_token_response_scopes(response)
-                except OAuthTokenError:
+                except (HTTPError, OAuthTokenError):
                     raise OAuthTokenError("Invalid token response") from None
                 self.context.current_tokens = token_response
                 self.context.update_token_expiry(token_response)

--- a/tools/mcp_oauth_manager.py
+++ b/tools/mcp_oauth_manager.py
@@ -200,13 +200,19 @@ def _make_hermes_provider_class() -> Optional[type]:
                 return False
 
             from mcp.shared.auth import OAuthToken
+            from pydantic import ValidationError
 
-            content = await response.aread()
-            token_response = OAuthToken.model_validate_json(content)
-            self.context.current_tokens = token_response
-            self.context.update_token_expiry(token_response)
-            await self.context.storage.set_tokens(token_response)
-            return True
+            try:
+                content = await response.aread()
+                token_response = OAuthToken.model_validate_json(content)
+                self.context.current_tokens = token_response
+                self.context.update_token_expiry(token_response)
+                await self.context.storage.set_tokens(token_response)
+                return True
+            except ValidationError:
+                logger.exception("Invalid refresh response")
+                self.context.clear_tokens()
+                return False
 
         async def _initialize(self) -> None:
             """Load stored tokens + client info AND seed token_expiry_time.


### PR DESCRIPTION
## Summary

Fixes Supabase hosted MCP OAuth when dynamic client registration returns a `client_secret` without `token_endpoint_auth_method`.

The MCP SDK treats a missing method as public-client auth (`none`), which omits `client_secret` from the authorization-code token exchange. Supabase rejects that with `Required parameter: client_secret`, causing browser consent to appear to loop.

This PR:

- coerces OAuth client info with a `client_secret` and missing/`none` auth method to `client_secret_post`
- persists that corrected method in Hermes' MCP OAuth client cache
- applies the same in-memory coercion before token exchange and refresh in both OAuth provider paths
- accepts any 2xx token/refresh response, not just exactly `200`
- avoids including token response bodies in token-exchange error messages
- adds regression tests for storage, token exchange, 201 token responses, and the manager provider path

Closes #29680

## Verification

```bash
venv/bin/python -m py_compile tools/mcp_oauth.py tools/mcp_oauth_manager.py tests/tools/test_mcp_oauth.py tests/tools/test_mcp_oauth_manager.py
venv/bin/python -m pytest -q tests/tools/test_mcp_oauth.py tests/tools/test_mcp_oauth_manager.py
venv/bin/python -m pytest -q tests/tools/test_mcp_oauth.py tests/tools/test_mcp_oauth_manager.py tests/tools/test_mcp_oauth_metadata.py tests/tools/test_mcp_oauth_bidirectional.py tests/tools/test_mcp_oauth_cold_load_expiry.py
PYTHONPATH=/Users/hans/.hermes/hermes-agent /Users/hans/.hermes/hermes-agent/venv/bin/hermes mcp test supabase
```

Results:

```text
54 passed in 2.33s
74 passed in 3.09s
hermes mcp test supabase: ✓ Connected, ✓ Tools discovered: 23
```

Local end-to-end Supabase MCP smoke testing also passed after removing and reinstalling the server config/tokens: create temporary table, insert/select/delete row, drop table, verify final `list_tables` returned empty.
