### PR TITLE
feat: project kanban feed cards

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -3596,6 +3596,114 @@ class TelegramAdapter(BasePlatformAdapter):
                     except Exception:
                         pass
 
+
+    def _feed_card_reply_markup(self, buttons: Any) -> Optional[Any]:
+        """Build an InlineKeyboardMarkup from a simple button list."""
+        if not buttons:
+            return None
+        if isinstance(buttons, InlineKeyboardMarkup):
+            return buttons
+        rows = []
+        raw_rows = buttons if isinstance(buttons, list) else []
+        # Accept either [{text,url}, ...] or [[{text,url}, ...], ...].
+        if raw_rows and all(isinstance(item, dict) for item in raw_rows):
+            raw_rows = [raw_rows]
+        for row in raw_rows:
+            if not isinstance(row, list):
+                continue
+            out_row = []
+            for item in row:
+                if not isinstance(item, dict):
+                    continue
+                text = str(item.get("text") or "").strip()
+                url = str(item.get("url") or "").strip()
+                if text and url:
+                    out_row.append(InlineKeyboardButton(text=text[:64], url=url))
+            if out_row:
+                rows.append(out_row)
+        return InlineKeyboardMarkup(rows) if rows else None
+
+    async def send_feed_card(
+        self,
+        chat_id: str,
+        image_path: str,
+        caption: str = "",
+        buttons: Optional[list] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Send a Telegram-native Feed card: photo + caption + inline CTA."""
+        if not self._bot:
+            return SendResult(success=False, error="Not connected")
+        if not os.path.exists(image_path):
+            return SendResult(success=False, error=self._missing_media_path_error("Image", image_path))
+
+        _thread = self._metadata_thread_id(metadata)
+        reply_to_id = self._reply_to_message_id_for_send(None, metadata, reply_to_mode=self._reply_to_mode)
+        thread_kwargs = self._thread_kwargs_for_send(
+            chat_id, _thread, metadata,
+            reply_to_message_id=reply_to_id,
+            reply_to_mode=self._reply_to_mode,
+        )
+        keyboard = self._feed_card_reply_markup(buttons)
+        with open(image_path, "rb") as image_file:
+            msg = await self._send_with_dm_topic_reply_anchor_retry(
+                self._bot.send_photo,
+                {
+                    "chat_id": int(chat_id),
+                    "photo": image_file,
+                    "caption": caption[:1024] if caption else None,
+                    "reply_markup": keyboard,
+                    "reply_to_message_id": reply_to_id,
+                    **thread_kwargs,
+                    **self._notification_kwargs(metadata),
+                },
+                metadata,
+                reply_to_id,
+                "feed card photo",
+                reset_media=lambda: image_file.seek(0),
+            )
+        return SendResult(
+            success=True,
+            message_id=str(msg.message_id),
+            raw_response={
+                "send_method": "sendPhoto",
+                "has_caption": bool(caption),
+                "has_reply_markup": keyboard is not None,
+            },
+        )
+
+    async def edit_feed_card(
+        self,
+        chat_id: str,
+        message_id: str,
+        caption: str = "",
+        buttons: Optional[list] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Edit an existing Telegram Feed card caption/CTA in place."""
+        if not self._bot:
+            return SendResult(success=False, error="Not connected")
+        keyboard = self._feed_card_reply_markup(buttons)
+        try:
+            await self._bot.edit_message_caption(
+                chat_id=int(chat_id),
+                message_id=int(message_id),
+                caption=caption[:1024] if caption else None,
+                reply_markup=keyboard,
+            )
+        except Exception as exc:
+            if "not modified" not in str(exc).lower():
+                raise
+        return SendResult(
+            success=True,
+            message_id=str(message_id),
+            raw_response={
+                "send_method": "editMessageCaption",
+                "has_caption": bool(caption),
+                "has_reply_markup": keyboard is not None,
+            },
+        )
+
     async def send_image_file(
         self,
         chat_id: str,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4519,6 +4519,11 @@ class GatewayRunner:
             return
 
         TERMINAL_KINDS = ("completed", "blocked", "gave_up", "crashed", "timed_out")
+        # Important, Founder-facing events can carry a structured ``feed_card``
+        # payload. Those route to a native image Feed (photo + caption + CTA)
+        # instead of the routine lightweight Kanban text receipt.
+        FEED_KINDS = ("milestone", "evidence", "review", "closeout")
+        WATCH_KINDS = TERMINAL_KINDS + FEED_KINDS
         # Subscriptions are removed only when the task reaches a truly final
         # status (done / archived). We used to also unsub on any terminal
         # event kind (gave_up / crashed / timed_out / blocked), but that
@@ -4626,7 +4631,7 @@ class GatewayRunner:
                                     platform=sub["platform"],
                                     chat_id=sub["chat_id"],
                                     thread_id=sub.get("thread_id") or "",
-                                    kinds=TERMINAL_KINDS,
+                                    kinds=WATCH_KINDS,
                                 )
                                 if not events:
                                     continue
@@ -4684,6 +4689,57 @@ class GatewayRunner:
                         # chat subscribes to many tasks) legible at a glance.
                         who = (task.assignee if task and task.assignee else None)
                         tag = f"@{who} " if who else ""
+                        metadata: dict[str, Any] = {}
+                        if sub.get("thread_id"):
+                            metadata["thread_id"] = sub["thread_id"]
+                        sub_key = (
+                            sub["task_id"], sub["platform"],
+                            sub["chat_id"], sub.get("thread_id") or "",
+                        )
+                        feed_card = None
+                        if isinstance(getattr(ev, "payload", None), dict):
+                            raw_feed_card = ev.payload.get("feed_card")
+                            if isinstance(raw_feed_card, dict):
+                                feed_card = raw_feed_card
+
+                        if feed_card:
+                            msg = None
+                            try:
+                                result = await self._deliver_kanban_feed_card(
+                                    adapter=adapter,
+                                    chat_id=sub["chat_id"],
+                                    metadata=metadata,
+                                    feed_card=feed_card,
+                                )
+                                if getattr(result, "message_id", None):
+                                    logger.info(
+                                        "kanban notifier: delivered feed card for %s message_id=%s",
+                                        sub["task_id"], result.message_id,
+                                    )
+                            except Exception as exc:
+                                fails = sub_fail_counts.get(sub_key, 0) + 1
+                                sub_fail_counts[sub_key] = fails
+                                logger.warning(
+                                    "kanban notifier: feed card send failed for %s on %s "
+                                    "(attempt %d/%d): %s",
+                                    sub["task_id"], platform_str, fails,
+                                    MAX_SEND_FAILURES, exc,
+                                )
+                                if fails >= MAX_SEND_FAILURES:
+                                    await asyncio.to_thread(self._kanban_unsub, sub, board_slug)
+                                    sub_fail_counts.pop(sub_key, None)
+                                else:
+                                    await asyncio.to_thread(
+                                        self._kanban_rewind,
+                                        sub,
+                                        d["cursor"],
+                                        d.get("old_cursor", 0),
+                                        board_slug,
+                                    )
+                                break
+                            sub_fail_counts.pop(sub_key, None)
+                            continue
+
                         if kind == "completed":
                             # Prefer the run's summary (the worker's
                             # intentional human-facing handoff, carried
@@ -4732,13 +4788,6 @@ class GatewayRunner:
                             )
                         else:
                             continue
-                        metadata: dict[str, Any] = {}
-                        if sub.get("thread_id"):
-                            metadata["thread_id"] = sub["thread_id"]
-                        sub_key = (
-                            sub["task_id"], sub["platform"],
-                            sub["chat_id"], sub.get("thread_id") or "",
-                        )
                         try:
                             await adapter.send(
                                 sub["chat_id"], msg, metadata=metadata,
@@ -4886,6 +4935,65 @@ class GatewayRunner:
             )
         finally:
             conn.close()
+
+
+    async def _deliver_kanban_feed_card(
+        self,
+        *,
+        adapter,
+        chat_id: str,
+        metadata: dict,
+        feed_card: dict,
+    ):
+        """Deliver or update a native image Feed card from a Kanban event.
+
+        ``feed_card`` is intentionally opt-in so routine Kanban lifecycle
+        receipts stay lightweight text. Expected shape::
+
+            {
+              "image_path": "/abs/card.png",
+              "caption": "short visible caption",
+              "buttons": [{"text": "Open issue", "url": "https://..."}],
+              "message_id": "123"  # optional: edit existing card caption/CTA
+            }
+
+        Adapters that support a native card can implement ``send_feed_card``
+        and ``edit_feed_card``. Older adapters fall back to ``send_image_file``
+        with a caption, preserving visibility without claiming edit-in-place.
+        """
+        image_path = str(feed_card.get("image_path") or feed_card.get("photo") or "").strip()
+        caption = str(feed_card.get("caption") or "").strip()
+        buttons = feed_card.get("buttons") or feed_card.get("reply_markup") or []
+        message_id = str(feed_card.get("message_id") or "").strip()
+        if not image_path:
+            raise ValueError("feed_card.image_path is required")
+        if not os.path.isfile(os.path.expanduser(image_path)):
+            raise FileNotFoundError(image_path)
+
+        if message_id and hasattr(adapter, "edit_feed_card"):
+            return await adapter.edit_feed_card(
+                chat_id=chat_id,
+                message_id=message_id,
+                caption=caption,
+                buttons=buttons,
+                metadata=metadata,
+            )
+        if hasattr(adapter, "send_feed_card"):
+            return await adapter.send_feed_card(
+                chat_id=chat_id,
+                image_path=image_path,
+                caption=caption,
+                buttons=buttons,
+                metadata=metadata,
+            )
+        if hasattr(adapter, "send_image_file"):
+            return await adapter.send_image_file(
+                chat_id=chat_id,
+                image_path=image_path,
+                caption=caption,
+                metadata=metadata,
+            )
+        raise RuntimeError("adapter does not support image Feed card delivery")
 
     async def _deliver_kanban_artifacts(
         self,

--- a/tests/gateway/test_kanban_notifier.py
+++ b/tests/gateway/test_kanban_notifier.py
@@ -11,9 +11,35 @@ from hermes_cli import kanban_db as kb
 class RecordingAdapter:
     def __init__(self):
         self.sent = []
+        self.feed_cards = []
+        self.edited_feed_cards = []
 
     async def send(self, chat_id, text, metadata=None):
         self.sent.append({"chat_id": chat_id, "text": text, "metadata": metadata or {}})
+
+    async def send_feed_card(self, chat_id, image_path, caption="", buttons=None, metadata=None):
+        self.feed_cards.append({
+            "chat_id": chat_id,
+            "image_path": image_path,
+            "caption": caption,
+            "buttons": buttons or [],
+            "metadata": metadata or {},
+        })
+        class Result:
+            message_id = "feed-123"
+        return Result()
+
+    async def edit_feed_card(self, chat_id, message_id, caption="", buttons=None, metadata=None):
+        self.edited_feed_cards.append({
+            "chat_id": chat_id,
+            "message_id": message_id,
+            "caption": caption,
+            "buttons": buttons or [],
+            "metadata": metadata or {},
+        })
+        class Result:
+            message_id = message_id
+        return Result()
 
 
 class DisconnectedAdapters(dict):
@@ -234,3 +260,70 @@ def test_notifier_redelivers_same_kind_on_dispatch_cycle(tmp_path, monkeypatch):
         f"deliveries (texts: {[d['text'] for d in adapter.sent]})"
     )
     assert "crashed" in adapter.sent[1]["text"].lower()
+
+
+def test_kanban_notifier_sends_important_feed_card_without_text_receipt(tmp_path, monkeypatch):
+    db_path = tmp_path / "feed-card.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    kb.init_db()
+    image_path = tmp_path / "card.png"
+    image_path.write_bytes(b"fake-png")
+
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="important milestone", assignee="worker")
+        kb.add_notify_sub(conn, task_id=tid, platform="telegram", chat_id="chat-1", thread_id="3367")
+        kb._append_event(conn, tid, kind="milestone", payload={
+            "feed_card": {
+                "image_path": str(image_path),
+                "caption": "M15 milestone ready",
+                "buttons": [{"text": "Open issue", "url": "https://github.com/AZ80066/kopa-os/issues/265"}],
+            }
+        })
+    finally:
+        conn.close()
+
+    adapter = RecordingAdapter()
+    runner = _make_runner(adapter)
+    asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
+
+    assert adapter.sent == []
+    assert len(adapter.feed_cards) == 1
+    card = adapter.feed_cards[0]
+    assert card["chat_id"] == "chat-1"
+    assert card["image_path"] == str(image_path)
+    assert card["caption"] == "M15 milestone ready"
+    assert card["metadata"]["thread_id"] == "3367"
+
+
+def test_kanban_notifier_edits_existing_feed_card_when_message_id_present(tmp_path, monkeypatch):
+    db_path = tmp_path / "feed-card-edit.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    kb.init_db()
+    image_path = tmp_path / "card.png"
+    image_path.write_bytes(b"fake-png")
+
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="closeout update", assignee="worker")
+        kb.add_notify_sub(conn, task_id=tid, platform="telegram", chat_id="chat-1")
+        kb._append_event(conn, tid, kind="closeout", payload={
+            "feed_card": {
+                "image_path": str(image_path),
+                "message_id": "777",
+                "caption": "M15 closeout updated",
+                "buttons": [[{"text": "Packet", "url": "https://github.com/AZ80066/kopa-os/issues/265"}]],
+            }
+        })
+    finally:
+        conn.close()
+
+    adapter = RecordingAdapter()
+    runner = _make_runner(adapter)
+    asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
+
+    assert adapter.feed_cards == []
+    assert len(adapter.edited_feed_cards) == 1
+    edit = adapter.edited_feed_cards[0]
+    assert edit["message_id"] == "777"
+    assert edit["caption"] == "M15 closeout updated"


### PR DESCRIPTION
## Summary
- add a structured Kanban `feed_card` projection path for important milestone/evidence/review/closeout events
- send Telegram-native image Feed cards via `sendPhoto(photo, caption, reply_markup)` instead of routine text receipts
- support edit-in-place updates through `editMessageCaption` when a stable `message_id` is provided

## Test plan
- `python -m pytest tests/gateway/test_kanban_notifier.py tests/gateway/test_telegram_reactions.py -q -o 'addopts='`
- `git diff --check -- gateway/run.py gateway/platforms/telegram.py tests/gateway/test_kanban_notifier.py`
- `python -m py_compile gateway/run.py gateway/platforms/telegram.py tests/gateway/test_kanban_notifier.py`

KopaOS M15 reference: AZ80066/kopa-os#265

## Gate status
- merged: pending
- dogfood visible: pending live gateway smoke
- deployed live: pending merge/deploy confirmation
