### PR TITLE
fix: stabilize terminal config defaults

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -42,7 +42,7 @@ from urllib.parse import unquote, urlparse
 from contextlib import contextmanager
 from pathlib import Path
 from datetime import datetime
-from typing import List, Dict, Any, Optional
+from typing import List, Dict, Any, Optional, cast
 
 logger = logging.getLogger(__name__)
 
@@ -301,7 +301,7 @@ def load_cli_config() -> Dict[str, Any]:
         config_path = project_config_path
 
     # Default configuration
-    defaults = {
+    defaults: Dict[str, Any] = {
         "model": {
             "default": "",
             "base_url": "",
@@ -404,6 +404,7 @@ def load_cli_config() -> Dict[str, Any]:
     # When using defaults (no config file / no terminal section), we should NOT
     # overwrite env vars that were already set by .env -- only a user's config
     # file should be authoritative.
+    default_terminal_config = defaults["terminal"].copy()
     _file_has_terminal_config = False
 
     # Load from file if exists
@@ -476,10 +477,13 @@ def load_cli_config() -> Dict[str, Any]:
 
     # Expand ${ENV_VAR} references in config values before bridging to env vars.
     from hermes_cli.config import _expand_env_vars
-    defaults = _expand_env_vars(defaults)
+    defaults = cast(Dict[str, Any], _expand_env_vars(defaults))
 
     # Apply terminal config to environment variables (so terminal_tool picks them up)
     terminal_config = defaults.get("terminal", {})
+    if not isinstance(terminal_config, dict):
+        terminal_config = default_terminal_config.copy()
+        defaults["terminal"] = terminal_config
     
     # Normalize config key: the new config system (hermes_cli/config.py) and all
     # documentation use "backend", the legacy cli-config.yaml uses "env_type".

--- a/cli.py
+++ b/cli.py
@@ -110,6 +110,12 @@ from hermes_cli.browser_connect import (
     try_launch_chrome_debug,
 )
 from hermes_cli.env_loader import load_hermes_dotenv
+from hermes_cli.terminal_config import (
+    default_terminal_config,
+    normalize_terminal_config,
+    resolve_cli_terminal_cwd,
+    terminal_env_values,
+)
 from utils import base_url_host_matches, is_truthy_value
 
 _hermes_home = get_hermes_home()
@@ -307,19 +313,7 @@ def load_cli_config() -> Dict[str, Any]:
             "base_url": "",
             "provider": "auto",
         },
-        "terminal": {
-            "env_type": "local",
-            "cwd": ".",  # "." is resolved to os.getcwd() at runtime
-            "timeout": 60,
-            "lifetime_seconds": 300,
-            "docker_image": "nikolaik/python-nodejs:python3.11-nodejs20",
-            "docker_forward_env": [],
-            "singularity_image": "docker://nikolaik/python-nodejs:python3.11-nodejs20",
-            "modal_image": "nikolaik/python-nodejs:python3.11-nodejs20",
-            "daytona_image": "nikolaik/python-nodejs:python3.11-nodejs20",
-            "docker_volumes": [],  # host:container volume mounts for Docker backend
-            "docker_mount_cwd_to_workspace": False,  # explicit opt-in only; default off for sandbox isolation
-        },
+        "terminal": default_terminal_config(),
         "browser": {
             "inactivity_timeout": 120,  # Auto-cleanup inactive browser sessions after 2 min
             "record_sessions": False,  # Auto-record browser sessions as WebM videos
@@ -404,7 +398,6 @@ def load_cli_config() -> Dict[str, Any]:
     # When using defaults (no config file / no terminal section), we should NOT
     # overwrite env vars that were already set by .env -- only a user's config
     # file should be authoritative.
-    default_terminal_config = defaults["terminal"].copy()
     _file_has_terminal_config = False
 
     # Load from file if exists
@@ -480,81 +473,27 @@ def load_cli_config() -> Dict[str, Any]:
     defaults = cast(Dict[str, Any], _expand_env_vars(defaults))
 
     # Apply terminal config to environment variables (so terminal_tool picks them up)
-    terminal_config = defaults.get("terminal", {})
-    if not isinstance(terminal_config, dict):
-        terminal_config = default_terminal_config.copy()
-        defaults["terminal"] = terminal_config
-    
-    # Normalize config key: the new config system (hermes_cli/config.py) and all
-    # documentation use "backend", the legacy cli-config.yaml uses "env_type".
-    # Accept both, with "backend" taking precedence (it's the documented key).
-    if "backend" in terminal_config:
-        terminal_config["env_type"] = terminal_config["backend"]
-    
-    # CWD resolution for CLI/TUI. The gateway has its own config bridge in
-    # gateway/run.py but may lazily import cli.py (triggering this code).
-    # Local backend: always os.getcwd(). Use `cd /dir && hermes` to control it.
-    # Non-local with placeholder: pop so terminal_tool uses its per-backend default.
-    # Non-local with explicit path: keep as-is.
-    _CWD_PLACEHOLDERS = (".", "auto", "cwd")
-    effective_backend = terminal_config.get("env_type", "local")
+    terminal_config = normalize_terminal_config(defaults.get("terminal", {}))
+    terminal_config["cwd"] = resolve_cli_terminal_cwd(
+        terminal_config,
+        invocation_cwd=os.getcwd(),
+    )
+    defaults["terminal"] = terminal_config
 
-    if effective_backend == "local":
-        terminal_config["cwd"] = os.getcwd()
-        defaults["terminal"]["cwd"] = terminal_config["cwd"]
-    elif terminal_config.get("cwd") in _CWD_PLACEHOLDERS:
-        terminal_config.pop("cwd", None)
-    
-    env_mappings = {
-        "env_type": "TERMINAL_ENV",
-        "cwd": "TERMINAL_CWD",
-        "timeout": "TERMINAL_TIMEOUT",
-        "lifetime_seconds": "TERMINAL_LIFETIME_SECONDS",
-        "docker_image": "TERMINAL_DOCKER_IMAGE",
-        "docker_forward_env": "TERMINAL_DOCKER_FORWARD_ENV",
-        "singularity_image": "TERMINAL_SINGULARITY_IMAGE",
-        "modal_image": "TERMINAL_MODAL_IMAGE",
-        "daytona_image": "TERMINAL_DAYTONA_IMAGE",
-        "vercel_runtime": "TERMINAL_VERCEL_RUNTIME",
-        # SSH config
-        "ssh_host": "TERMINAL_SSH_HOST",
-        "ssh_user": "TERMINAL_SSH_USER",
-        "ssh_port": "TERMINAL_SSH_PORT",
-        "ssh_key": "TERMINAL_SSH_KEY",
-        # Container resource config (docker, singularity, modal, daytona, vercel_sandbox -- ignored for local/ssh)
-        "container_cpu": "TERMINAL_CONTAINER_CPU",
-        "container_memory": "TERMINAL_CONTAINER_MEMORY",
-        "container_disk": "TERMINAL_CONTAINER_DISK",
-        "container_persistent": "TERMINAL_CONTAINER_PERSISTENT",
-        "docker_volumes": "TERMINAL_DOCKER_VOLUMES",
-        "docker_env": "TERMINAL_DOCKER_ENV",
-        "docker_mount_cwd_to_workspace": "TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE",
-        "docker_run_as_host_user": "TERMINAL_DOCKER_RUN_AS_HOST_USER",
-        "sandbox_dir": "TERMINAL_SANDBOX_DIR",
-        # Persistent shell (non-local backends)
-        "persistent_shell": "TERMINAL_PERSISTENT_SHELL",
-        # Sudo support (works with all backends)
-        "sudo_password": "SUDO_PASSWORD",
-    }
-    
     # Bridge config → env vars for terminal_tool. TERMINAL_CWD is force-exported
     # UNLESS we're inside a gateway process (detected by _HERMES_GATEWAY marker)
     # where it was already set correctly by gateway/run.py's config bridge.
     _is_gateway = os.environ.get("_HERMES_GATEWAY") == "1"
-    for config_key, env_var in env_mappings.items():
-        if config_key in terminal_config:
-            if env_var == "TERMINAL_CWD":
-                if _is_gateway:
-                    continue
-                # CLI: always export (overrides stale .env or inherited values)
-                os.environ[env_var] = str(terminal_config[config_key])
+    terminal_env = terminal_env_values(terminal_config, include_secrets=True)
+    for env_var, value in terminal_env.items():
+        if env_var == "TERMINAL_CWD":
+            if _is_gateway:
                 continue
-            if _file_has_terminal_config or env_var not in os.environ:
-                val = terminal_config[config_key]
-                if isinstance(val, (list, dict)):
-                    os.environ[env_var] = json.dumps(val)
-                else:
-                    os.environ[env_var] = str(val)
+            # CLI: always export (overrides stale .env or inherited values)
+            os.environ[env_var] = value
+            continue
+        if _file_has_terminal_config or env_var not in os.environ:
+            os.environ[env_var] = value
     
     # Apply browser config to environment variables
     browser_config = defaults.get("browser", {})

--- a/docs/superpowers/specs/2026-05-21-terminal-defaults-source-of-truth-contract.md
+++ b/docs/superpowers/specs/2026-05-21-terminal-defaults-source-of-truth-contract.md
@@ -1,0 +1,143 @@
+# Terminal Defaults Source-of-Truth Operational Contract
+
+## Context
+
+Phase 2 makes terminal runtime defaults and config-to-environment bridging explicit. The goal is to prevent drift between documented config, CLI/TUI config loading, gateway startup, and `tools/terminal_tool.py` runtime behavior.
+
+This document is an operational contract for maintainers. It records the source of truth, entrypoint-specific cwd rules, environment serialization rules, and the installed WSL runtime expectations that must remain stable unless a future task deliberately updates this contract and its tests.
+
+## Source of truth
+
+The canonical terminal config implementation lives in `hermes_cli.terminal_config`:
+
+- `DEFAULT_TERMINAL_CONFIG` owns terminal defaults.
+- `default_terminal_config()` returns a deep copy of the defaults.
+- `normalize_terminal_config(raw)` owns user-config normalization.
+- `resolve_cli_terminal_cwd(...)` owns CLI/TUI cwd resolution.
+- `resolve_gateway_terminal_cwd(...)` owns gateway cwd resolution.
+- `terminal_env_values(config, *, include_secrets=False)` owns config-to-`TERMINAL_*` environment serialization.
+
+Callers must not duplicate terminal default literals or independently serialize nested terminal config keys.
+
+## Normalization contract
+
+`backend` is the documented and canonical terminal backend key. `env_type` remains a legacy compatibility key because older runtime paths and environment names use `TERMINAL_ENV`.
+
+`normalize_terminal_config(raw)` must preserve these invariants:
+
+1. Missing, `null`, and non-dict terminal config normalize to `DEFAULT_TERMINAL_CONFIG` values.
+2. Partial dict config merges over defaults.
+3. Normalized config contains both `backend` and `env_type`.
+4. `backend` and `env_type` have the same normalized value.
+5. If both `backend` and `env_type` are present and non-empty, `backend` wins.
+6. Mutable defaults such as env passthrough lists, Docker env maps, volumes, and extra args are deep-copied so normalized configs cannot alias the shared defaults or raw input.
+
+## CLI/TUI cwd contract
+
+CLI/TUI config loading normalizes terminal config, resolves cwd with `resolve_cli_terminal_cwd(...)`, then bridges with `terminal_env_values(..., include_secrets=True)`.
+
+Cwd rules:
+
+- Local backend uses the Hermes invocation cwd for `TERMINAL_CWD`.
+- For local backend, an explicit configured `terminal.cwd` is intentionally ignored in favor of the invocation cwd.
+- Non-local backends preserve explicit configured cwd values.
+- Placeholder or missing non-local cwd values may resolve to no `TERMINAL_CWD` export so sandbox backends can keep their own safe defaults.
+- Placeholders are `.`, `auto`, and `cwd`.
+- A CLI/TUI process running inside a gateway process must not overwrite the gateway-selected `TERMINAL_CWD` marker path.
+
+The installed WSL config may set `terminal.cwd: /home/shlee`, but a direct CLI invocation from another directory still exports that invocation directory for local terminal commands.
+
+## Gateway cwd contract
+
+Gateway startup normalizes terminal config, resolves cwd with `resolve_gateway_terminal_cwd(...)`, and bridges with `terminal_env_values(...)` without secrets.
+
+Cwd rules:
+
+1. An explicit configured `terminal.cwd` wins.
+2. Placeholder or missing cwd first falls back to an existing non-placeholder `TERMINAL_CWD`.
+3. If no safe existing `TERMINAL_CWD` exists, use `MESSAGING_CWD`.
+4. If neither env value is usable, fall back to `Path.home()`.
+5. Placeholders are `.`, `auto`, and `cwd`.
+
+Gateway and CLI cwd behavior intentionally differ: gateway prioritizes stable service/runtime cwd, while direct CLI prioritizes the user's invocation cwd for local work.
+
+## Terminal tool runtime contract
+
+`tools/terminal_tool.py` reads terminal runtime settings from `TERMINAL_*` environment variables.
+
+- `TERMINAL_ENV` selects the backend.
+- `TERMINAL_CWD` selects cwd when exported.
+- `TERMINAL_TIMEOUT` and `TERMINAL_LIFETIME_SECONDS` select runtime timing values.
+- When `TERMINAL_CWD` is absent for the local backend, the terminal tool uses the live process cwd.
+- Sandbox and remote backends preserve backend-specific cwd safety behavior, including ignoring unsafe host/relative paths where appropriate.
+
+The terminal tool may use `default_terminal_config()` for fallback values, but it must not become a competing source of defaults.
+
+## Environment serialization and secret handling
+
+`terminal_env_values()` owns serialization from normalized config to process environment variables.
+
+Rules:
+
+- Scalar values serialize with `str(value)`.
+- Lists and dicts serialize as JSON.
+- `backend` serializes to `TERMINAL_ENV` and takes precedence over legacy `env_type` if both are present.
+- Sensitive mappings, such as `sudo_password` to `SUDO_PASSWORD`, are omitted by default.
+- Sensitive mappings require explicit `include_secrets=True`.
+- Gateway must call `terminal_env_values()` without `include_secrets=True`.
+- CLI/TUI may include sensitive terminal mappings only when deliberately calling `include_secrets=True` for process env bridging where legacy terminal behavior requires it.
+
+Do not log, display, or commit secret values while testing this bridge.
+
+## Installed WSL runtime contract
+
+The installed user config at `/home/shlee/.hermes/config.yaml` remains explicit and must not be edited by Phase 2 source changes:
+
+```yaml
+terminal:
+  backend: local
+  cwd: /home/shlee
+  timeout: 180
+  lifetime_seconds: 300
+```
+
+Expected installed display:
+
+```text
+◆ Terminal
+  Backend:      local
+  Working dir:  /home/shlee
+  Timeout:      180s
+```
+
+Expected runtime env bridge when loaded from `/home/shlee` with `HERMES_HOME=/home/shlee/.hermes` and outside gateway mode:
+
+- normalized terminal backend: `local`
+- normalized terminal env_type: `local`
+- normalized terminal cwd: `/home/shlee`
+- normalized terminal timeout: `180`
+- normalized terminal lifetime_seconds: `300`
+- `TERMINAL_ENV=local`
+- `TERMINAL_CWD=/home/shlee`
+- `TERMINAL_TIMEOUT=180`
+- `TERMINAL_LIFETIME_SECONDS=300`
+
+## Verification checklist
+
+Before declaring this contract or related terminal-default source-of-truth work complete, run fresh verification:
+
+```bash
+python -m pytest tests/hermes_cli/test_terminal_config_normalization.py tests/hermes_cli/test_ignore_user_config_flags.py tests/hermes_cli/test_placeholder_usage.py tests/gateway/test_config_cwd_bridge.py tests/tools/test_terminal_env_config.py tests/tools/test_terminal_config_env_sync.py tests/cli/test_cwd_env_respect.py tests/tools/test_terminal_task_cwd.py -q -o 'addopts='
+/home/shlee/.hermes/hermes-agent/venv/bin/python -m hermes_cli.main config show | awk '/◆ Terminal/{flag=1; print; next} flag && /^◆ /{flag=0} flag{print}'
+git diff --check
+git status --short
+```
+
+Also run a runtime env bridge probe from `/home/shlee` that sets `HERMES_HOME=/home/shlee/.hermes`, clears `_HERMES_GATEWAY`, imports `cli`, sets `cli._hermes_home = Path('/home/shlee/.hermes')`, calls `load_cli_config()`, and prints only non-secret terminal config/env values.
+
+## Out of scope
+
+- Editing `/home/shlee/.hermes/config.yaml` during Phase 2 source work.
+- Changing production code as part of this documentation task.
+- Changing sandbox backend behavior without a dedicated implementation plan and tests.
+- Printing secrets or dumping full config/env maps in verification output.

--- a/docs/superpowers/specs/2026-05-21-terminal-defaults-source-of-truth-contract.md
+++ b/docs/superpowers/specs/2026-05-21-terminal-defaults-source-of-truth-contract.md
@@ -55,9 +55,9 @@ Cwd rules:
 
 1. An explicit configured `terminal.cwd` wins.
 2. Placeholder or missing cwd first falls back to an existing non-placeholder `TERMINAL_CWD`.
-3. If no safe existing `TERMINAL_CWD` exists, use `MESSAGING_CWD`.
-4. If neither env value is usable, fall back to `Path.home()`.
-5. Placeholders are `.`, `auto`, and `cwd`.
+3. If no existing non-placeholder `TERMINAL_CWD` exists, gateway uses `MESSAGING_CWD` as provided.
+4. If `MESSAGING_CWD` is absent, gateway falls back to `Path.home()`.
+5. Placeholders are `.`, `auto`, and `cwd`. Existing `TERMINAL_CWD` placeholders are ignored, but `MESSAGING_CWD` is not placeholder-filtered by current code.
 
 Gateway and CLI cwd behavior intentionally differ: gateway prioritizes stable service/runtime cwd, while direct CLI prioritizes the user's invocation cwd for local work.
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -616,6 +616,9 @@ if _config_path.exists():
             terminal_env_values,
         )
 
+        _has_explicit_terminal_config = "terminal" in _cfg or any(
+            _terminal_alias in _cfg for _terminal_alias in ("backend", "cwd")
+        )
         _terminal_raw = _cfg.get("terminal", {})
         if not isinstance(_terminal_raw, dict):
             _terminal_raw = {}
@@ -635,8 +638,13 @@ if _config_path.exists():
             existing_env=os.environ,
             messaging_cwd=os.getenv("MESSAGING_CWD"),
         )
-        for _env_var, _env_value in terminal_env_values(_terminal_cfg).items():
-            os.environ[_env_var] = _env_value
+        if _has_explicit_terminal_config:
+            for _env_var, _env_value in terminal_env_values(_terminal_cfg).items():
+                os.environ[_env_var] = _env_value
+        else:
+            _existing_terminal_cwd = os.getenv("TERMINAL_CWD", "").strip().lower()
+            if _existing_terminal_cwd in {"", ".", "auto", "cwd"}:
+                os.environ["TERMINAL_CWD"] = _terminal_cfg["cwd"]
         # Compression config is read directly from config.yaml by run_agent.py
         # and auxiliary_client.py — no env var bridging needed.
         # Auxiliary model/direct-endpoint overrides (vision, web_extract).

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -610,51 +610,33 @@ if _config_path.exists():
                 os.environ[_key] = str(_val)
         # Terminal config is nested — bridge to TERMINAL_* env vars.
         # config.yaml overrides .env for these since it's the documented config path.
-        _terminal_cfg = _cfg.get("terminal", {})
-        if _terminal_cfg and isinstance(_terminal_cfg, dict):
-            _terminal_env_map = {
-                "backend": "TERMINAL_ENV",
-                "cwd": "TERMINAL_CWD",
-                "timeout": "TERMINAL_TIMEOUT",
-                "lifetime_seconds": "TERMINAL_LIFETIME_SECONDS",
-                "docker_image": "TERMINAL_DOCKER_IMAGE",
-                "docker_forward_env": "TERMINAL_DOCKER_FORWARD_ENV",
-                "singularity_image": "TERMINAL_SINGULARITY_IMAGE",
-                "modal_image": "TERMINAL_MODAL_IMAGE",
-                "daytona_image": "TERMINAL_DAYTONA_IMAGE",
-                "vercel_runtime": "TERMINAL_VERCEL_RUNTIME",
-                "ssh_host": "TERMINAL_SSH_HOST",
-                "ssh_user": "TERMINAL_SSH_USER",
-                "ssh_port": "TERMINAL_SSH_PORT",
-                "ssh_key": "TERMINAL_SSH_KEY",
-                "container_cpu": "TERMINAL_CONTAINER_CPU",
-                "container_memory": "TERMINAL_CONTAINER_MEMORY",
-                "container_disk": "TERMINAL_CONTAINER_DISK",
-                "container_persistent": "TERMINAL_CONTAINER_PERSISTENT",
-                "docker_volumes": "TERMINAL_DOCKER_VOLUMES",
-                "docker_env": "TERMINAL_DOCKER_ENV",
-                "docker_mount_cwd_to_workspace": "TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE",
-                "docker_run_as_host_user": "TERMINAL_DOCKER_RUN_AS_HOST_USER",
-                "sandbox_dir": "TERMINAL_SANDBOX_DIR",
-                "persistent_shell": "TERMINAL_PERSISTENT_SHELL",
-            }
-            for _cfg_key, _env_var in _terminal_env_map.items():
-                if _cfg_key in _terminal_cfg:
-                    _val = _terminal_cfg[_cfg_key]
-                    # Skip cwd placeholder values (".", "auto", "cwd") — the
-                    # gateway resolves these to Path.home() later (line ~255).
-                    # Writing the raw placeholder here would just be noise.
-                    # Only bridge explicit absolute paths from config.yaml.
-                    if _cfg_key == "cwd" and str(_val) in {".", "auto", "cwd"}:
-                        continue
-                    # Expand shell tilde in cwd so subprocess.Popen never
-                    # receives a literal "~/" which the kernel rejects.
-                    if _cfg_key == "cwd" and isinstance(_val, str):
-                        _val = os.path.expanduser(_val)
-                    if isinstance(_val, (list, dict)):
-                        os.environ[_env_var] = json.dumps(_val)
-                    else:
-                        os.environ[_env_var] = str(_val)
+        from hermes_cli.terminal_config import (
+            normalize_terminal_config,
+            resolve_gateway_terminal_cwd,
+            terminal_env_values,
+        )
+
+        _terminal_raw = _cfg.get("terminal", {})
+        if not isinstance(_terminal_raw, dict):
+            _terminal_raw = {}
+        else:
+            _terminal_raw = dict(_terminal_raw)
+
+        # Backwards-compatible top-level aliases are copied into the raw
+        # terminal config only when the terminal section itself did not specify
+        # the canonical key.
+        for _terminal_alias in ("backend", "cwd"):
+            if _terminal_alias not in _terminal_raw and _terminal_alias in _cfg:
+                _terminal_raw[_terminal_alias] = _cfg[_terminal_alias]
+
+        _terminal_cfg = normalize_terminal_config(_terminal_raw)
+        _terminal_cfg["cwd"] = resolve_gateway_terminal_cwd(
+            _terminal_cfg,
+            existing_env=os.environ,
+            messaging_cwd=os.getenv("MESSAGING_CWD"),
+        )
+        for _env_var, _env_value in terminal_env_values(_terminal_cfg).items():
+            os.environ[_env_var] = _env_value
         # Compression config is read directly from config.yaml by run_agent.py
         # and auxiliary_client.py — no env var bridging needed.
         # Auxiliary model/direct-endpoint overrides (vision, web_extract).

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -5039,6 +5039,8 @@ def show_config():
     print()
     print(color("◆ Terminal", Colors.CYAN, Colors.BOLD))
     terminal = config.get('terminal', {})
+    if not isinstance(terminal, dict):
+        terminal = DEFAULT_CONFIG.get('terminal', {})
     print(f"  Backend:      {terminal.get('backend', 'local')}")
     print(f"  Working dir:  {terminal.get('cwd', '.')}")
     print(f"  Timeout:      {terminal.get('timeout', 60)}s")

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -148,6 +148,7 @@ import yaml
 
 from hermes_cli.colors import Colors, color
 from hermes_cli.default_soul import DEFAULT_SOUL_MD
+from hermes_cli.terminal_config import default_terminal_config, normalize_terminal_config
 
 
 # =============================================================================
@@ -588,86 +589,7 @@ DEFAULT_CONFIG = {
         "disabled_toolsets": [],
     },
     
-    "terminal": {
-        "backend": "local",
-        "modal_mode": "auto",
-        "cwd": ".",  # Use current directory
-        "timeout": 180,
-        # Environment variables to pass through to sandboxed execution
-        # (terminal and execute_code).  Skill-declared required_environment_variables
-        # are passed through automatically; this list is for non-skill use cases.
-        "env_passthrough": [],
-        # Extra files to source in the login shell when building the
-        # per-session environment snapshot.  Use this when tools like nvm,
-        # pyenv, asdf, or custom PATH entries are registered by files that
-        # a bash login shell would skip — most commonly ``~/.bashrc``
-        # (bash doesn't source bashrc in non-interactive login mode) or
-        # zsh-specific files like ``~/.zshrc`` / ``~/.zprofile``.
-        # Paths support ``~`` / ``${VAR}``. Missing files are silently
-        # skipped. When empty, Hermes auto-sources ``~/.profile``,
-        # ``~/.bash_profile``, and ``~/.bashrc`` (in that order) if the
-        # snapshot shell is bash (this is the ``auto_source_bashrc``
-        # behaviour — disable with that key if you want strict login-only
-        # semantics).
-        "shell_init_files": [],
-        # When true (default), Hermes sources the user's shell rc files
-        # (``~/.profile``, ``~/.bash_profile``, ``~/.bashrc``) in the
-        # login shell used to build the environment snapshot. This
-        # captures PATH additions, shell functions, and aliases — which a
-        # plain ``bash -l -c`` would otherwise miss because bash skips
-        # bashrc in non-interactive login mode, and because a default
-        # Debian/Ubuntu ``~/.bashrc`` short-circuits on non-interactive
-        # sources. ``~/.profile`` and ``~/.bash_profile`` are tried first
-        # because ``n`` / ``nvm`` / ``asdf`` installers typically write
-        # their PATH exports there without an interactivity guard. Turn
-        # this off if your rc files misbehave when sourced
-        # non-interactively (e.g. one that hard-exits on TTY checks).
-        "auto_source_bashrc": True,
-        "docker_image": "nikolaik/python-nodejs:python3.11-nodejs20",
-        "docker_forward_env": [],
-        # Explicit environment variables to set inside Docker containers.
-        # Unlike docker_forward_env (which reads values from the host process),
-        # docker_env lets you specify exact key-value pairs — useful when Hermes
-        # runs as a systemd service without access to the user's shell environment.
-        # Example: {"SSH_AUTH_SOCK": "/run/user/1000/ssh-agent.sock"}
-        "docker_env": {},
-        "singularity_image": "docker://nikolaik/python-nodejs:python3.11-nodejs20",
-        "modal_image": "nikolaik/python-nodejs:python3.11-nodejs20",
-        "daytona_image": "nikolaik/python-nodejs:python3.11-nodejs20",
-        "vercel_runtime": "node24",
-        # Container resource limits (docker, singularity, modal, daytona, vercel_sandbox — ignored for local/ssh)
-        "container_cpu": 1,
-        "container_memory": 5120,       # MB (default 5GB)
-        "container_disk": 51200,        # MB (default 50GB)
-        "container_persistent": True,   # Persist filesystem across sessions
-        # Docker volume mounts — share host directories with the container.
-        # Each entry is "host_path:container_path" (standard Docker -v syntax).
-        # Example:
-        # ["/home/user/projects:/workspace/projects",
-        #  "/home/user/.hermes/cache/documents:/output"]
-        # For gateway MEDIA delivery, write inside Docker to /output/... and emit
-        # the host-visible path in MEDIA:, not the container path.
-        "docker_volumes": [],
-        # Explicit opt-in: mount the host cwd into /workspace for Docker sessions.
-        # Default off because passing host directories into a sandbox weakens isolation.
-        "docker_mount_cwd_to_workspace": False,
-        "docker_extra_args": [],        # Extra flags passed verbatim to docker run
-        # Explicit opt-in: run the Docker container as the host user's uid:gid
-        # (via `--user`).  When enabled, files written into bind-mounted dirs
-        # (docker_volumes, the persistent workspace, or the auto-mounted cwd)
-        # are owned by your host user instead of root, which avoids needing
-        # `sudo chown` after container runs. Default off to preserve behavior
-        # for images whose entrypoints expect to start as root (e.g. the
-        # bundled Hermes image, which drops to the `hermes` user via gosu).
-        # When on, SETUID/SETGID caps are omitted from the container since
-        # no privilege drop is needed.
-        "docker_run_as_host_user": False,
-        # Persistent shell — keep a long-lived bash shell across execute() calls
-        # so cwd/env vars/shell variables survive between commands.
-        # Enabled by default for non-local backends (SSH); local is always opt-in
-        # via TERMINAL_LOCAL_PERSISTENT env var.
-        "persistent_shell": True,
-    },
+    "terminal": default_terminal_config(),
 
     "web": {
         "backend": "",           # shared fallback — applies to both search and extract
@@ -5038,9 +4960,7 @@ def show_config():
     # Terminal
     print()
     print(color("◆ Terminal", Colors.CYAN, Colors.BOLD))
-    terminal = config.get('terminal', {})
-    if not isinstance(terminal, dict):
-        terminal = DEFAULT_CONFIG.get('terminal', {})
+    terminal = normalize_terminal_config(config.get('terminal', {}))
     print(f"  Backend:      {terminal.get('backend', 'local')}")
     print(f"  Working dir:  {terminal.get('cwd', '.')}")
     print(f"  Timeout:      {terminal.get('timeout', 60)}s")

--- a/hermes_cli/terminal_config.py
+++ b/hermes_cli/terminal_config.py
@@ -137,12 +137,13 @@ def resolve_cli_terminal_cwd(
 ) -> str | None:
     """Resolve CLI cwd placeholders against the process invocation cwd for local backends."""
 
+    backend = _stripped_nonempty(config.get("backend")) or _stripped_nonempty(config.get("env_type")) or "local"
+    if backend == "local":
+        return _expand_user(invocation_cwd or os.getcwd())
+
     cwd = config.get("cwd")
     if _is_placeholder_cwd(cwd):
-        backend = _stripped_nonempty(config.get("backend")) or _stripped_nonempty(config.get("env_type")) or "local"
-        if backend != "local":
-            return None
-        return _expand_user(invocation_cwd or os.getcwd())
+        return None
     return _expand_user(cwd)
 
 
@@ -170,14 +171,16 @@ def terminal_env_values(config: Mapping[str, Any], *, include_secrets: bool = Fa
     """Serialize terminal config values for process environment variables."""
 
     env: dict[str, str] = {}
-    if "env_type" not in config and config.get("backend") is not None:
-        env["TERMINAL_ENV"] = str(config["backend"])
+    backend = _stripped_nonempty(config.get("backend"))
+    if backend is not None:
+        env["TERMINAL_ENV"] = backend
 
     mappings = TERMINAL_ENV_MAPPINGS
     if include_secrets:
         mappings = {**TERMINAL_ENV_MAPPINGS, **SENSITIVE_TERMINAL_ENV_MAPPINGS}
-
     for config_key, env_key in mappings.items():
+        if env_key == "TERMINAL_ENV" and backend is not None:
+            continue
         if config_key not in config:
             continue
         value = config[config_key]

--- a/hermes_cli/terminal_config.py
+++ b/hermes_cli/terminal_config.py
@@ -68,11 +68,14 @@ TERMINAL_ENV_MAPPINGS: dict[str, str] = {
     "docker_run_as_host_user": "TERMINAL_DOCKER_RUN_AS_HOST_USER",
     "persistent_shell": "TERMINAL_PERSISTENT_SHELL",
     "sandbox_dir": "TERMINAL_SANDBOX_DIR",
-    "sudo_password": "SUDO_PASSWORD",
     "ssh_host": "TERMINAL_SSH_HOST",
     "ssh_user": "TERMINAL_SSH_USER",
     "ssh_port": "TERMINAL_SSH_PORT",
     "ssh_key": "TERMINAL_SSH_KEY",
+}
+
+SENSITIVE_TERMINAL_ENV_MAPPINGS: dict[str, str] = {
+    "sudo_password": "SUDO_PASSWORD",
 }
 
 
@@ -102,9 +105,10 @@ def normalize_terminal_config(raw: Any) -> dict[str, Any]:
     raw_env_type = None
 
     if isinstance(raw, Mapping):
-        config.update(raw)
-        raw_backend = raw.get("backend")
-        raw_env_type = raw.get("env_type")
+        raw_config = copy.deepcopy(raw)
+        config.update(raw_config)
+        raw_backend = raw_config.get("backend")
+        raw_env_type = raw_config.get("env_type")
 
     backend = _stripped_nonempty(raw_backend)
     env_type = _stripped_nonempty(raw_env_type)
@@ -130,11 +134,14 @@ def _expand_user(value: Any, home: str | os.PathLike[str] | None = None) -> str:
 
 def resolve_cli_terminal_cwd(
     config: Mapping[str, Any], invocation_cwd: str | os.PathLike[str] | None = None
-) -> str:
-    """Resolve CLI cwd placeholders against the process invocation cwd."""
+) -> str | None:
+    """Resolve CLI cwd placeholders against the process invocation cwd for local backends."""
 
     cwd = config.get("cwd")
     if _is_placeholder_cwd(cwd):
+        backend = _stripped_nonempty(config.get("backend")) or _stripped_nonempty(config.get("env_type")) or "local"
+        if backend != "local":
+            return None
         return _expand_user(invocation_cwd or os.getcwd())
     return _expand_user(cwd)
 
@@ -156,11 +163,18 @@ def resolve_gateway_terminal_cwd(
     return _expand_user(fallback, home=home)
 
 
-def terminal_env_values(config: Mapping[str, Any]) -> dict[str, str]:
+def terminal_env_values(config: Mapping[str, Any], *, include_secrets: bool = False) -> dict[str, str]:
     """Serialize terminal config values for process environment variables."""
 
     env: dict[str, str] = {}
-    for config_key, env_key in TERMINAL_ENV_MAPPINGS.items():
+    if "env_type" not in config and config.get("backend") is not None:
+        env["TERMINAL_ENV"] = str(config["backend"])
+
+    mappings = TERMINAL_ENV_MAPPINGS
+    if include_secrets:
+        mappings = {**TERMINAL_ENV_MAPPINGS, **SENSITIVE_TERMINAL_ENV_MAPPINGS}
+
+    for config_key, env_key in mappings.items():
         if config_key not in config:
             continue
         value = config[config_key]
@@ -176,6 +190,7 @@ def terminal_env_values(config: Mapping[str, Any]) -> dict[str, str]:
 __all__ = [
     "CWD_PLACEHOLDERS",
     "DEFAULT_TERMINAL_CONFIG",
+    "SENSITIVE_TERMINAL_ENV_MAPPINGS",
     "TERMINAL_ENV_MAPPINGS",
     "default_terminal_config",
     "normalize_terminal_config",

--- a/hermes_cli/terminal_config.py
+++ b/hermes_cli/terminal_config.py
@@ -158,8 +158,11 @@ def resolve_gateway_terminal_cwd(
     if not _is_placeholder_cwd(cwd):
         return _expand_user(cwd, home=home)
 
-    existing_cwd = (existing_env or {}).get("TERMINAL_CWD")
-    fallback = existing_cwd or messaging_cwd or home or Path.home()
+    existing_cwd = _stripped_nonempty((existing_env or {}).get("TERMINAL_CWD"))
+    if existing_cwd is not None and not _is_placeholder_cwd(existing_cwd):
+        fallback = existing_cwd
+    else:
+        fallback = messaging_cwd or home or Path.home()
     return _expand_user(fallback, home=home)
 
 

--- a/hermes_cli/terminal_config.py
+++ b/hermes_cli/terminal_config.py
@@ -1,0 +1,185 @@
+"""Shared terminal configuration normalization helpers.
+
+This module centralizes terminal runtime defaults and the small differences in
+how CLI and gateway entry points resolve placeholder working directories.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+import os
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+CWD_PLACEHOLDERS = {".", "auto", "cwd"}
+
+_DEFAULT_CONTAINER_IMAGE = "nikolaik/python-nodejs:python3.11-nodejs20"
+
+DEFAULT_TERMINAL_CONFIG: dict[str, Any] = {
+    "backend": "local",
+    "env_type": "local",
+    "modal_mode": "auto",
+    "cwd": ".",
+    "timeout": 180,
+    "lifetime_seconds": 300,
+    "env_passthrough": [],
+    "shell_init_files": [],
+    "auto_source_bashrc": True,
+    "docker_image": _DEFAULT_CONTAINER_IMAGE,
+    "docker_forward_env": [],
+    "docker_env": {},
+    "singularity_image": f"docker://{_DEFAULT_CONTAINER_IMAGE}",
+    "modal_image": _DEFAULT_CONTAINER_IMAGE,
+    "daytona_image": _DEFAULT_CONTAINER_IMAGE,
+    "vercel_runtime": "node24",
+    "container_cpu": 1,
+    "container_memory": 5120,
+    "container_disk": 51200,
+    "container_persistent": True,
+    "docker_volumes": [],
+    "docker_mount_cwd_to_workspace": False,
+    "docker_extra_args": [],
+    "docker_run_as_host_user": False,
+    "persistent_shell": True,
+}
+
+TERMINAL_ENV_MAPPINGS: dict[str, str] = {
+    "env_type": "TERMINAL_ENV",
+    "cwd": "TERMINAL_CWD",
+    "timeout": "TERMINAL_TIMEOUT",
+    "lifetime_seconds": "TERMINAL_LIFETIME_SECONDS",
+    "modal_mode": "TERMINAL_MODAL_MODE",
+    "docker_image": "TERMINAL_DOCKER_IMAGE",
+    "docker_forward_env": "TERMINAL_DOCKER_FORWARD_ENV",
+    "docker_env": "TERMINAL_DOCKER_ENV",
+    "singularity_image": "TERMINAL_SINGULARITY_IMAGE",
+    "modal_image": "TERMINAL_MODAL_IMAGE",
+    "daytona_image": "TERMINAL_DAYTONA_IMAGE",
+    "vercel_runtime": "TERMINAL_VERCEL_RUNTIME",
+    "container_cpu": "TERMINAL_CONTAINER_CPU",
+    "container_memory": "TERMINAL_CONTAINER_MEMORY",
+    "container_disk": "TERMINAL_CONTAINER_DISK",
+    "container_persistent": "TERMINAL_CONTAINER_PERSISTENT",
+    "docker_volumes": "TERMINAL_DOCKER_VOLUMES",
+    "docker_mount_cwd_to_workspace": "TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE",
+    "docker_extra_args": "TERMINAL_DOCKER_EXTRA_ARGS",
+    "docker_run_as_host_user": "TERMINAL_DOCKER_RUN_AS_HOST_USER",
+    "persistent_shell": "TERMINAL_PERSISTENT_SHELL",
+    "sandbox_dir": "TERMINAL_SANDBOX_DIR",
+    "sudo_password": "SUDO_PASSWORD",
+    "ssh_host": "TERMINAL_SSH_HOST",
+    "ssh_user": "TERMINAL_SSH_USER",
+    "ssh_port": "TERMINAL_SSH_PORT",
+    "ssh_key": "TERMINAL_SSH_KEY",
+}
+
+
+def default_terminal_config() -> dict[str, Any]:
+    """Return a fresh copy of the default terminal configuration."""
+
+    return copy.deepcopy(DEFAULT_TERMINAL_CONFIG)
+
+
+def _stripped_nonempty(value: Any) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def normalize_terminal_config(raw: Any) -> dict[str, Any]:
+    """Normalize user terminal config while accepting legacy ``env_type``.
+
+    ``backend`` is the canonical key. Legacy configs may set only ``env_type``;
+    when both keys are present and non-empty, ``backend`` wins. The returned
+    config always contains matching ``backend`` and ``env_type`` strings.
+    """
+
+    config = default_terminal_config()
+    raw_backend = None
+    raw_env_type = None
+
+    if isinstance(raw, Mapping):
+        config.update(raw)
+        raw_backend = raw.get("backend")
+        raw_env_type = raw.get("env_type")
+
+    backend = _stripped_nonempty(raw_backend)
+    env_type = _stripped_nonempty(raw_env_type)
+    canonical = backend or env_type or _stripped_nonempty(config.get("backend")) or "local"
+
+    config["backend"] = canonical
+    config["env_type"] = canonical
+    return config
+
+
+def _is_placeholder_cwd(value: Any) -> bool:
+    text = _stripped_nonempty(value)
+    return text is None or text.lower() in CWD_PLACEHOLDERS
+
+
+def _expand_user(value: Any, home: str | os.PathLike[str] | None = None) -> str:
+    text = str(value)
+    if home is not None and (text == "~" or text.startswith("~/")):
+        home_text = str(home)
+        return home_text if text == "~" else os.path.join(home_text, text[2:])
+    return str(Path(text).expanduser())
+
+
+def resolve_cli_terminal_cwd(
+    config: Mapping[str, Any], invocation_cwd: str | os.PathLike[str] | None = None
+) -> str:
+    """Resolve CLI cwd placeholders against the process invocation cwd."""
+
+    cwd = config.get("cwd")
+    if _is_placeholder_cwd(cwd):
+        return _expand_user(invocation_cwd or os.getcwd())
+    return _expand_user(cwd)
+
+
+def resolve_gateway_terminal_cwd(
+    config: Mapping[str, Any],
+    existing_env: Mapping[str, str] | None = None,
+    messaging_cwd: str | os.PathLike[str] | None = None,
+    home: str | os.PathLike[str] | None = None,
+) -> str:
+    """Resolve gateway cwd placeholders using env, message cwd, then home."""
+
+    cwd = config.get("cwd")
+    if not _is_placeholder_cwd(cwd):
+        return _expand_user(cwd, home=home)
+
+    existing_cwd = (existing_env or {}).get("TERMINAL_CWD")
+    fallback = existing_cwd or messaging_cwd or home or Path.home()
+    return _expand_user(fallback, home=home)
+
+
+def terminal_env_values(config: Mapping[str, Any]) -> dict[str, str]:
+    """Serialize terminal config values for process environment variables."""
+
+    env: dict[str, str] = {}
+    for config_key, env_key in TERMINAL_ENV_MAPPINGS.items():
+        if config_key not in config:
+            continue
+        value = config[config_key]
+        if value is None:
+            continue
+        if isinstance(value, (list, dict)):
+            env[env_key] = json.dumps(value)
+        else:
+            env[env_key] = str(value)
+    return env
+
+
+__all__ = [
+    "CWD_PLACEHOLDERS",
+    "DEFAULT_TERMINAL_CONFIG",
+    "TERMINAL_ENV_MAPPINGS",
+    "default_terminal_config",
+    "normalize_terminal_config",
+    "resolve_cli_terminal_cwd",
+    "resolve_gateway_terminal_cwd",
+    "terminal_env_values",
+]

--- a/tests/gateway/test_config_cwd_bridge.py
+++ b/tests/gateway/test_config_cwd_bridge.py
@@ -10,8 +10,15 @@ asserting the expected env var outcomes.
 """
 
 import os
-import json
+from collections.abc import Mapping
+
 import pytest
+
+from hermes_cli.terminal_config import (
+    normalize_terminal_config,
+    resolve_gateway_terminal_cwd,
+    terminal_env_values,
+)
 
 
 def _simulate_config_bridge(cfg: dict, initial_env: dict | None = None):
@@ -26,53 +33,27 @@ def _simulate_config_bridge(cfg: dict, initial_env: dict | None = None):
         if isinstance(val, (str, int, float, bool)) and key not in env:
             env[key] = str(val)
 
-    # --- Replicate lines 59-87: terminal config bridge ---
-    terminal_cfg = cfg.get("terminal", {})
-    if terminal_cfg and isinstance(terminal_cfg, dict):
-        terminal_env_map = {
-            "backend": "TERMINAL_ENV",
-            "cwd": "TERMINAL_CWD",
-            "timeout": "TERMINAL_TIMEOUT",
-            "vercel_runtime": "TERMINAL_VERCEL_RUNTIME",
-            "container_persistent": "TERMINAL_CONTAINER_PERSISTENT",
-            "container_cpu": "TERMINAL_CONTAINER_CPU",
-            "container_memory": "TERMINAL_CONTAINER_MEMORY",
-            "container_disk": "TERMINAL_CONTAINER_DISK",
-        }
-        for cfg_key, env_var in terminal_env_map.items():
-            if cfg_key in terminal_cfg:
-                val = terminal_cfg[cfg_key]
-                # Skip cwd placeholder values — don't overwrite already-resolved
-                # TERMINAL_CWD.  Mirrors the fix in gateway/run.py.
-                if cfg_key == "cwd" and str(val) in {".", "auto", "cwd"}:
-                    continue
-                # Expand shell tilde so subprocess.Popen never receives a literal
-                # "~/" which the kernel rejects.
-                if cfg_key == "cwd" and isinstance(val, str):
-                    val = os.path.expanduser(val)
-                if isinstance(val, list):
-                    env[env_var] = json.dumps(val)
-                else:
-                    env[env_var] = str(val)
+    # --- Replicate the gateway's shared terminal config bridge. ---
+    terminal_raw = cfg.get("terminal", {})
+    if not isinstance(terminal_raw, Mapping):
+        terminal_raw = {}
+    else:
+        terminal_raw = dict(terminal_raw)
 
-    # --- NEW: top-level aliases (the fix being tested) ---
-    top_level_aliases = {
-        "cwd": "TERMINAL_CWD",
-        "backend": "TERMINAL_ENV",
-    }
-    for alias_key, alias_env in top_level_aliases.items():
-        if alias_env not in env:
-            alias_val = cfg.get(alias_key)
-            if isinstance(alias_val, str) and alias_val.strip():
-                if alias_key == "cwd":
-                    alias_val = os.path.expanduser(alias_val)
-                env[alias_env] = alias_val.strip()
+    # Backwards-compatible top-level aliases are copied into the raw terminal
+    # config only when the terminal section itself did not specify the key.
+    for alias_key in ("backend", "cwd"):
+        if alias_key not in terminal_raw and alias_key in cfg:
+            terminal_raw[alias_key] = cfg[alias_key]
 
-    # --- Replicate lines 144-147: MESSAGING_CWD fallback ---
-    configured_cwd = env.get("TERMINAL_CWD", "")
-    if not configured_cwd or configured_cwd in {".", "auto", "cwd"}:
-        messaging_cwd = env.get("MESSAGING_CWD") or "/root"  # Path.home() for root
-        env["TERMINAL_CWD"] = messaging_cwd
+    terminal_cfg = normalize_terminal_config(terminal_raw)
+    terminal_cfg["cwd"] = resolve_gateway_terminal_cwd(
+        terminal_cfg,
+        existing_env=env,
+        messaging_cwd=env.get("MESSAGING_CWD"),
+        home=os.path.expanduser("~"),
+    )
+    env.update(terminal_env_values(terminal_cfg))
 
     return env
 
@@ -95,6 +76,14 @@ class TestTopLevelCwdAlias:
         result = _simulate_config_bridge(cfg)
         assert result["TERMINAL_CWD"] == "/home/hermes/projects"
         assert result["TERMINAL_ENV"] == "local"
+
+    def test_terminal_none_uses_shared_defaults_and_messaging_cwd(self):
+        cfg = {"terminal": None}
+        result = _simulate_config_bridge(cfg, {"MESSAGING_CWD": "/home/hermes/projects"})
+
+        assert result["TERMINAL_ENV"] == "local"
+        assert result["TERMINAL_CWD"] == "/home/hermes/projects"
+        assert result["TERMINAL_TIMEOUT"] == "180"
 
     def test_nested_terminal_takes_precedence_over_top_level(self):
         """terminal.cwd should win over top-level cwd."""
@@ -121,7 +110,7 @@ class TestTopLevelCwdAlias:
     def test_no_cwd_no_messaging_cwd_falls_back_to_home(self):
         cfg = {}
         result = _simulate_config_bridge(cfg)
-        assert result["TERMINAL_CWD"] == "/root"  # Path.home() for root user
+        assert result["TERMINAL_CWD"] == os.path.expanduser("~")
 
     def test_dot_cwd_triggers_messaging_fallback(self):
         """cwd: '.' should trigger MESSAGING_CWD fallback."""

--- a/tests/gateway/test_config_cwd_bridge.py
+++ b/tests/gateway/test_config_cwd_bridge.py
@@ -34,6 +34,10 @@ def _simulate_config_bridge(cfg: dict, initial_env: dict | None = None):
             env[key] = str(val)
 
     # --- Replicate the gateway's shared terminal config bridge. ---
+    explicit_terminal_config = "terminal" in cfg or any(
+        alias_key in cfg for alias_key in ("backend", "cwd")
+    )
+
     terminal_raw = cfg.get("terminal", {})
     if not isinstance(terminal_raw, Mapping):
         terminal_raw = {}
@@ -53,7 +57,12 @@ def _simulate_config_bridge(cfg: dict, initial_env: dict | None = None):
         messaging_cwd=env.get("MESSAGING_CWD"),
         home=os.path.expanduser("~"),
     )
-    env.update(terminal_env_values(terminal_cfg))
+    if explicit_terminal_config:
+        env.update(terminal_env_values(terminal_cfg))
+    else:
+        existing_cwd = str(env.get("TERMINAL_CWD", "")).strip().lower()
+        if existing_cwd in {"", ".", "auto", "cwd"}:
+            env["TERMINAL_CWD"] = terminal_cfg["cwd"]
 
     return env
 
@@ -144,6 +153,22 @@ class TestTopLevelCwdAlias:
         cfg = {}
         result = _simulate_config_bridge(cfg, {"MESSAGING_CWD": "/home/hermes/projects"})
         assert result["TERMINAL_CWD"] == "/home/hermes/projects"
+
+    def test_config_without_terminal_settings_preserves_inherited_terminal_env(self):
+        """Config without terminal settings must not clobber inherited TERMINAL_* env."""
+        cfg = {"model": "some-model"}
+        result = _simulate_config_bridge(
+            cfg,
+            {
+                "TERMINAL_ENV": "docker",
+                "TERMINAL_TIMEOUT": "77",
+                "TERMINAL_CWD": "/from-env",
+            },
+        )
+
+        assert result["TERMINAL_ENV"] == "docker"
+        assert result["TERMINAL_TIMEOUT"] == "77"
+        assert result["TERMINAL_CWD"] == "/from-env"
 
     def test_top_level_cwd_beats_messaging_cwd(self):
         """Explicit top-level cwd should take precedence over MESSAGING_CWD."""

--- a/tests/hermes_cli/test_ignore_user_config_flags.py
+++ b/tests/hermes_cli/test_ignore_user_config_flags.py
@@ -17,6 +17,7 @@ argparse → cmd_chat → cli.main() → HermesCLI → AIAgent call chain.
 from __future__ import annotations
 
 import os
+import sys
 import textwrap
 import importlib
 
@@ -105,6 +106,24 @@ class TestIgnoreUserConfigEnvGate:
 
         # "true" != "1", so user config IS loaded
         assert cfg["model"]["default"] == "anthropic/claude-sonnet-4.6"
+
+    def test_null_terminal_section_falls_back_to_defaults(self, tmp_path, monkeypatch):
+        """YAML ``terminal: null`` must not break CLI config loading."""
+        (tmp_path / "config.yaml").write_text("terminal: null\n", encoding="utf-8")
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        previous_cli = sys.modules.pop("cli", None)
+
+        try:
+            cli = importlib.import_module("cli")
+            monkeypatch.setattr(cli, "_hermes_home", tmp_path)
+            cfg = cli.load_cli_config()
+        finally:
+            sys.modules.pop("cli", None)
+            if previous_cli is not None:
+                sys.modules["cli"] = previous_cli
+
+        assert cfg["terminal"]["env_type"] == "local"
+        assert cfg["terminal"]["cwd"]
 
 
 class TestIgnoreRulesEnvGate:

--- a/tests/hermes_cli/test_ignore_user_config_flags.py
+++ b/tests/hermes_cli/test_ignore_user_config_flags.py
@@ -33,10 +33,24 @@ def _clean_env(monkeypatch):
     those writes aren't tracked by monkeypatch and won't be undone by it.
     We add explicit cleanup on yield to prevent cross-test pollution.
     """
-    for var in ("HERMES_IGNORE_USER_CONFIG", "HERMES_IGNORE_RULES"):
+    for var in (
+        "HERMES_IGNORE_USER_CONFIG",
+        "HERMES_IGNORE_RULES",
+        "TERMINAL_CWD",
+        "TERMINAL_ENV",
+        "TERMINAL_TIMEOUT",
+        "_HERMES_GATEWAY",
+    ):
         monkeypatch.delenv(var, raising=False)
     yield
-    for var in ("HERMES_IGNORE_USER_CONFIG", "HERMES_IGNORE_RULES"):
+    for var in (
+        "HERMES_IGNORE_USER_CONFIG",
+        "HERMES_IGNORE_RULES",
+        "TERMINAL_CWD",
+        "TERMINAL_ENV",
+        "TERMINAL_TIMEOUT",
+        "_HERMES_GATEWAY",
+    ):
         os.environ.pop(var, None)
 
 
@@ -124,6 +138,50 @@ class TestIgnoreUserConfigEnvGate:
 
         assert cfg["terminal"]["env_type"] == "local"
         assert cfg["terminal"]["cwd"]
+
+    def test_partial_terminal_config_uses_shared_defaults(self, tmp_path, monkeypatch):
+        """A partial terminal section should inherit shared terminal defaults."""
+        (tmp_path / "config.yaml").write_text(
+            textwrap.dedent(
+                """
+                terminal:
+                  backend: local
+                """
+            ).lstrip(),
+            encoding="utf-8",
+        )
+
+        load_cli_config = self._reload_cli(monkeypatch, tmp_path)
+        cfg = load_cli_config()
+
+        assert cfg["terminal"]["backend"] == "local"
+        assert cfg["terminal"]["env_type"] == "local"
+        assert cfg["terminal"]["timeout"] == 180
+        assert os.environ["TERMINAL_TIMEOUT"] == "180"
+
+    def test_local_terminal_cwd_uses_invocation_cwd(self, tmp_path, monkeypatch):
+        """Local CLI/TUI ignores configured cwd and uses invocation cwd."""
+        configured_cwd = tmp_path / "configured"
+        invocation_dir = tmp_path / "invocation"
+        configured_cwd.mkdir()
+        invocation_dir.mkdir()
+        (tmp_path / "config.yaml").write_text(
+            textwrap.dedent(
+                f"""
+                terminal:
+                  backend: local
+                  cwd: {configured_cwd}
+                """
+            ).lstrip(),
+            encoding="utf-8",
+        )
+        monkeypatch.chdir(invocation_dir)
+
+        load_cli_config = self._reload_cli(monkeypatch, tmp_path)
+        cfg = load_cli_config()
+
+        assert cfg["terminal"]["cwd"] == str(invocation_dir)
+        assert os.environ["TERMINAL_CWD"] == str(invocation_dir)
 
 
 class TestIgnoreRulesEnvGate:

--- a/tests/hermes_cli/test_placeholder_usage.py
+++ b/tests/hermes_cli/test_placeholder_usage.py
@@ -40,6 +40,20 @@ def test_show_config_marks_placeholders(tmp_path, capsys):
     assert "hermes config set <key> <value>" in out
 
 
+def test_show_config_handles_null_terminal_section(tmp_path, capsys):
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text("terminal: null\n", encoding="utf-8")
+
+    with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+        show_config()
+
+    out = capsys.readouterr().out
+    assert "◆ Terminal" in out
+    assert "Backend:" in out
+    assert "local" in out
+    assert "Working dir:" in out
+
+
 def test_setup_summary_marks_placeholders(tmp_path, capsys):
     with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
         _print_setup_summary({"tts": {"provider": "edge"}}, tmp_path)

--- a/tests/hermes_cli/test_placeholder_usage.py
+++ b/tests/hermes_cli/test_placeholder_usage.py
@@ -54,6 +54,22 @@ def test_show_config_handles_null_terminal_section(tmp_path, capsys):
     assert "Working dir:" in out
 
 
+def test_show_config_handles_partial_terminal_section(tmp_path, capsys):
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        "terminal:\n  backend: local\n",
+        encoding="utf-8",
+    )
+
+    with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+        show_config()
+
+    out = capsys.readouterr().out
+    assert "◆ Terminal" in out
+    assert "Backend:      local" in out
+    assert "Timeout:      180s" in out
+
+
 def test_setup_summary_marks_placeholders(tmp_path, capsys):
     with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
         _print_setup_summary({"tts": {"provider": "edge"}}, tmp_path)

--- a/tests/hermes_cli/test_terminal_config_normalization.py
+++ b/tests/hermes_cli/test_terminal_config_normalization.py
@@ -115,10 +115,10 @@ def test_cli_missing_cwd_resolves_to_invocation_cwd():
     assert resolve_cli_terminal_cwd(config, invocation_cwd="/tmp/invoked") == "/tmp/invoked"
 
 
-def test_explicit_cli_cwd_is_preserved_and_expanded():
-    config = normalize_terminal_config({"cwd": "~/project"})
+def test_explicit_local_cli_cwd_is_ignored_in_favor_of_invocation_cwd():
+    config = normalize_terminal_config({"backend": "local", "cwd": "~/project"})
 
-    assert resolve_cli_terminal_cwd(config) == str(Path("~/project").expanduser())
+    assert resolve_cli_terminal_cwd(config, invocation_cwd="/tmp/invoked") == "/tmp/invoked"
 
 
 @pytest.mark.parametrize("backend", ["ssh", "docker"])
@@ -139,9 +139,9 @@ def test_non_local_cli_missing_cwd_resolves_to_none(backend):
 
 @pytest.mark.parametrize("backend", ["ssh", "docker"])
 def test_non_local_cli_explicit_cwd_is_preserved(backend):
-    config = normalize_terminal_config({"backend": backend, "cwd": "/workspace"})
+    config = normalize_terminal_config({"backend": backend, "cwd": "~/project"})
 
-    assert resolve_cli_terminal_cwd(config, invocation_cwd="/tmp/invoked") == "/workspace"
+    assert resolve_cli_terminal_cwd(config, invocation_cwd="/tmp/invoked") == str(Path("~/project").expanduser())
 
 
 def test_gateway_placeholder_cwd_uses_messaging_cwd():
@@ -226,6 +226,12 @@ def test_terminal_env_values_uses_backend_for_terminal_env_when_env_type_absent(
 
     assert env["TERMINAL_ENV"] == "docker"
     assert env["TERMINAL_CWD"] == "/workspace"
+
+
+def test_terminal_env_values_prefers_backend_for_terminal_env_when_env_type_conflicts():
+    env = terminal_env_values({"backend": "ssh", "env_type": "docker"})
+
+    assert env["TERMINAL_ENV"] == "ssh"
 
 
 def test_terminal_env_values_serializes_config_to_environment_strings():

--- a/tests/hermes_cli/test_terminal_config_normalization.py
+++ b/tests/hermes_cli/test_terminal_config_normalization.py
@@ -166,6 +166,35 @@ def test_gateway_placeholder_cwd_uses_existing_terminal_cwd_first():
     )
 
 
+@pytest.mark.parametrize("existing_cwd", [".", "auto", "cwd"])
+def test_gateway_placeholder_existing_terminal_cwd_uses_messaging_cwd(existing_cwd):
+    config = normalize_terminal_config({"cwd": "."})
+
+    assert (
+        resolve_gateway_terminal_cwd(
+            config,
+            existing_env={"TERMINAL_CWD": existing_cwd},
+            messaging_cwd="/chat/workspace",
+            home="/home/hermes",
+        )
+        == "/chat/workspace"
+    )
+
+
+def test_gateway_placeholder_existing_terminal_cwd_without_messaging_cwd_uses_home():
+    config = normalize_terminal_config({"cwd": "."})
+
+    assert (
+        resolve_gateway_terminal_cwd(
+            config,
+            existing_env={"TERMINAL_CWD": "auto"},
+            messaging_cwd=None,
+            home="/home/hermes",
+        )
+        == "/home/hermes"
+    )
+
+
 def test_gateway_explicit_cwd_expands_home():
     config = normalize_terminal_config({"cwd": "~/project"})
 

--- a/tests/hermes_cli/test_terminal_config_normalization.py
+++ b/tests/hermes_cli/test_terminal_config_normalization.py
@@ -1,0 +1,141 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from hermes_cli.terminal_config import (
+    CWD_PLACEHOLDERS,
+    DEFAULT_TERMINAL_CONFIG,
+    normalize_terminal_config,
+    resolve_cli_terminal_cwd,
+    resolve_gateway_terminal_cwd,
+    terminal_env_values,
+)
+
+
+@pytest.mark.parametrize("raw", [None, "local", [], 123, False])
+def test_non_mapping_terminal_config_uses_defaults(raw):
+    config = normalize_terminal_config(raw)
+
+    assert config["backend"] == "local"
+    assert config["env_type"] == "local"
+    assert config["timeout"] == 180
+    assert config["lifetime_seconds"] == 300
+
+
+def test_partial_terminal_config_merges_with_defaults():
+    config = normalize_terminal_config({"timeout": 45})
+
+    assert config["timeout"] == 45
+    assert config["cwd"] == "."
+    assert config["lifetime_seconds"] == 300
+    assert config["backend"] == "local"
+    assert config["env_type"] == "local"
+
+
+@pytest.mark.parametrize("backend", ["docker", "ssh", "modal"])
+def test_backend_canonical_sets_env_type(backend):
+    config = normalize_terminal_config({"backend": backend})
+
+    assert config["backend"] == backend
+    assert config["env_type"] == backend
+
+
+def test_legacy_env_type_sets_backend_when_backend_missing():
+    config = normalize_terminal_config({"env_type": "docker"})
+
+    assert config["backend"] == "docker"
+    assert config["env_type"] == "docker"
+
+
+def test_backend_wins_over_env_type_when_both_are_present():
+    config = normalize_terminal_config({"backend": "ssh", "env_type": "docker"})
+
+    assert config["backend"] == "ssh"
+    assert config["env_type"] == "ssh"
+
+
+def test_default_terminal_config_is_deep_copied_for_docker_forward_env():
+    first = normalize_terminal_config(None)
+    second = normalize_terminal_config(None)
+
+    first["docker_forward_env"].append("TOKEN")
+
+    assert second["docker_forward_env"] == []
+    assert DEFAULT_TERMINAL_CONFIG["docker_forward_env"] == []
+
+
+@pytest.mark.parametrize("placeholder", sorted(CWD_PLACEHOLDERS))
+def test_cli_placeholder_cwd_resolves_to_invocation_cwd(placeholder):
+    config = normalize_terminal_config({"cwd": placeholder})
+
+    assert resolve_cli_terminal_cwd(config, invocation_cwd="/tmp/invoked") == "/tmp/invoked"
+
+
+def test_cli_missing_cwd_resolves_to_invocation_cwd():
+    config = normalize_terminal_config({})
+    config.pop("cwd")
+
+    assert resolve_cli_terminal_cwd(config, invocation_cwd="/tmp/invoked") == "/tmp/invoked"
+
+
+def test_explicit_cli_cwd_is_preserved_and_expanded():
+    config = normalize_terminal_config({"cwd": "~/project"})
+
+    assert resolve_cli_terminal_cwd(config) == str(Path("~/project").expanduser())
+
+
+def test_gateway_placeholder_cwd_uses_messaging_cwd():
+    config = normalize_terminal_config({"cwd": "auto"})
+
+    assert (
+        resolve_gateway_terminal_cwd(config, existing_env={}, messaging_cwd="/chat/workspace")
+        == "/chat/workspace"
+    )
+
+
+def test_gateway_placeholder_cwd_uses_existing_terminal_cwd_first():
+    config = normalize_terminal_config({"cwd": "."})
+
+    assert (
+        resolve_gateway_terminal_cwd(
+            config,
+            existing_env={"TERMINAL_CWD": "/existing/workspace"},
+            messaging_cwd="/chat/workspace",
+        )
+        == "/existing/workspace"
+    )
+
+
+def test_gateway_explicit_cwd_expands_home():
+    config = normalize_terminal_config({"cwd": "~/project"})
+
+    assert (
+        resolve_gateway_terminal_cwd(
+            config,
+            existing_env={"TERMINAL_CWD": "/existing/workspace"},
+            messaging_cwd="/chat/workspace",
+            home="/home/example",
+        )
+        == "/home/example/project"
+    )
+
+
+def test_terminal_env_values_serializes_config_to_environment_strings():
+    config = normalize_terminal_config(
+        {
+            "backend": "docker",
+            "cwd": "/workspace",
+            "timeout": 45,
+            "docker_forward_env": ["API_KEY", "TOKEN"],
+            "docker_env": {"DEBUG": "1"},
+        }
+    )
+
+    env = terminal_env_values(config)
+
+    assert env["TERMINAL_ENV"] == "docker"
+    assert env["TERMINAL_CWD"] == "/workspace"
+    assert env["TERMINAL_TIMEOUT"] == "45"
+    assert env["TERMINAL_DOCKER_FORWARD_ENV"] == json.dumps(["API_KEY", "TOKEN"])
+    assert env["TERMINAL_DOCKER_ENV"] == json.dumps({"DEBUG": "1"})

--- a/tests/hermes_cli/test_terminal_config_normalization.py
+++ b/tests/hermes_cli/test_terminal_config_normalization.py
@@ -1,3 +1,4 @@
+import copy
 import json
 from pathlib import Path
 
@@ -55,14 +56,49 @@ def test_backend_wins_over_env_type_when_both_are_present():
     assert config["env_type"] == "ssh"
 
 
-def test_default_terminal_config_is_deep_copied_for_docker_forward_env():
+@pytest.mark.parametrize(
+    ("key", "mutated_value"),
+    [
+        ("env_passthrough", "TOKEN"),
+        ("shell_init_files", "~/.bashrc"),
+        ("docker_forward_env", "TOKEN"),
+        ("docker_env", {"DEBUG": "1"}),
+        ("docker_volumes", "/host:/container"),
+        ("docker_extra_args", "--network=host"),
+    ],
+)
+def test_default_terminal_config_mutable_values_are_deep_copied(key, mutated_value):
     first = normalize_terminal_config(None)
     second = normalize_terminal_config(None)
 
-    first["docker_forward_env"].append("TOKEN")
+    if isinstance(first[key], dict):
+        first[key].update(mutated_value)
+    else:
+        first[key].append(mutated_value)
 
-    assert second["docker_forward_env"] == []
-    assert DEFAULT_TERMINAL_CONFIG["docker_forward_env"] == []
+    assert second[key] == DEFAULT_TERMINAL_CONFIG[key]
+    assert DEFAULT_TERMINAL_CONFIG[key] == ([] if isinstance(DEFAULT_TERMINAL_CONFIG[key], list) else {})
+
+
+@pytest.mark.parametrize(
+    ("key", "raw_value", "mutate_normalized"),
+    [
+        ("env_passthrough", ["TOKEN"], lambda value: value.append("EXTRA")),
+        ("shell_init_files", ["~/.bashrc"], lambda value: value.append("~/.profile")),
+        ("docker_forward_env", ["TOKEN"], lambda value: value.append("EXTRA")),
+        ("docker_env", {"DEBUG": "1"}, lambda value: value.update({"TRACE": "1"})),
+        ("docker_volumes", ["/host:/container"], lambda value: value.append("/tmp:/tmp")),
+        ("docker_extra_args", ["--network=host"], lambda value: value.append("--rm")),
+    ],
+)
+def test_normalized_mutable_values_do_not_alias_raw_input(key, raw_value, mutate_normalized):
+    raw = {key: raw_value}
+    expected_raw_value = copy.deepcopy(raw_value)
+    config = normalize_terminal_config(raw)
+
+    mutate_normalized(config[key])
+
+    assert raw[key] == expected_raw_value
 
 
 @pytest.mark.parametrize("placeholder", sorted(CWD_PLACEHOLDERS))
@@ -83,6 +119,29 @@ def test_explicit_cli_cwd_is_preserved_and_expanded():
     config = normalize_terminal_config({"cwd": "~/project"})
 
     assert resolve_cli_terminal_cwd(config) == str(Path("~/project").expanduser())
+
+
+@pytest.mark.parametrize("backend", ["ssh", "docker"])
+@pytest.mark.parametrize("placeholder", sorted(CWD_PLACEHOLDERS))
+def test_non_local_cli_placeholder_cwd_resolves_to_none(backend, placeholder):
+    config = normalize_terminal_config({"backend": backend, "cwd": placeholder})
+
+    assert resolve_cli_terminal_cwd(config, invocation_cwd="/tmp/invoked") is None
+
+
+@pytest.mark.parametrize("backend", ["ssh", "docker"])
+def test_non_local_cli_missing_cwd_resolves_to_none(backend):
+    config = normalize_terminal_config({"backend": backend})
+    config.pop("cwd")
+
+    assert resolve_cli_terminal_cwd(config, invocation_cwd="/tmp/invoked") is None
+
+
+@pytest.mark.parametrize("backend", ["ssh", "docker"])
+def test_non_local_cli_explicit_cwd_is_preserved(backend):
+    config = normalize_terminal_config({"backend": backend, "cwd": "/workspace"})
+
+    assert resolve_cli_terminal_cwd(config, invocation_cwd="/tmp/invoked") == "/workspace"
 
 
 def test_gateway_placeholder_cwd_uses_messaging_cwd():
@@ -119,6 +178,25 @@ def test_gateway_explicit_cwd_expands_home():
         )
         == "/home/example/project"
     )
+
+
+def test_terminal_env_values_omits_sudo_password_by_default():
+    env = terminal_env_values({"sudo_password": "secret"})
+
+    assert "SUDO_PASSWORD" not in env
+
+
+def test_terminal_env_values_includes_sudo_password_when_requested():
+    env = terminal_env_values({"sudo_password": "secret"}, include_secrets=True)
+
+    assert env["SUDO_PASSWORD"] == "secret"
+
+
+def test_terminal_env_values_uses_backend_for_terminal_env_when_env_type_absent():
+    env = terminal_env_values({"backend": "docker", "cwd": "/workspace"})
+
+    assert env["TERMINAL_ENV"] == "docker"
+    assert env["TERMINAL_CWD"] == "/workspace"
 
 
 def test_terminal_env_values_serializes_config_to_environment_strings():

--- a/tests/tools/test_terminal_config_env_sync.py
+++ b/tests/tools/test_terminal_config_env_sync.py
@@ -110,8 +110,10 @@ def _save_config_env_sync_keys() -> set[str]:
 
 
 # Keys present in the shared CLI/source-of-truth mapping but intentionally
-# absent from gateway/run.py or set_config_value.  Each entry must be justified.
-_CLI_ONLY_OK = frozenset({
+# not expected in gateway/run.py's terminal bridge.  Each entry must be
+# justified as an alias or non-TERMINAL_* credential, not a terminal_tool
+# setting that gateway merely has not wired yet.
+_GATEWAY_BRIDGE_EXEMPT_KEYS = frozenset({
     # `env_type` is a legacy YAML key alias for `backend` that cli.py
     # accepts for backwards-compat with older cli-config.yaml.  The
     # gateway path normalizes on the canonical `backend` key, which is
@@ -121,14 +123,16 @@ _CLI_ONLY_OK = frozenset({
     # used across backends, bridged to $SUDO_PASSWORD (not TERMINAL_*).
     # Treating it as terminal-only would be misleading.
     "sudo_password",
-    # modal_mode is normalized by CLI setup/subscription flows and consumed by
-    # terminal_tool when present, but gateway does not currently expose the
-    # managed-vs-direct Modal selector through its startup bridge.
-    "modal_mode",
-    # docker_extra_args is a Docker-only escape hatch consumed by terminal_tool;
-    # the gateway bridge intentionally stays on the historically supported
-    # Docker env/config keys until that surface is explicitly expanded.
+})
+
+
+# Temporary Task 3 known gap: these shared terminal keys are consumed by
+# terminal_tool, but gateway/run.py does not bridge them from config.yaml yet.
+# Keep this set exact so Task 3 fails here after wiring the bridge until the
+# temporary marker is removed or updated.
+TASK3_PENDING_GATEWAY_BRIDGE_KEYS = frozenset({
     "docker_extra_args",
+    "modal_mode",
 })
 
 
@@ -142,22 +146,48 @@ def _terminal_tool_env_var_names() -> set[str]:
     return set(pat.findall(source))
 
 
-def test_cli_and_gateway_env_maps_agree():
+def _normalized_gateway_env_map_keys() -> set[str]:
+    """Gateway terminal bridge keys normalized to the shared CLI key surface."""
+    # Normalize the legacy `env_type` alias: cli.py accepts both `env_type`
+    # and `backend` as source keys for TERMINAL_ENV; gateway only accepts
+    # `backend`.  Since cli.py copies `backend` → `env_type` before the
+    # lookup, they're equivalent.  Remove `backend` from the gateway side
+    # to avoid a spurious "backend missing from cli" failure.
+    return _gateway_env_map_keys() - {"backend"}
+
+
+def _shared_terminal_keys_missing_from_gateway() -> set[str]:
+    """Shared terminal keys that are neither gateway-bridged nor exempt aliases."""
+    cli_terminal_keys = _cli_env_map_keys() - _GATEWAY_BRIDGE_EXEMPT_KEYS
+    return cli_terminal_keys - _normalized_gateway_env_map_keys()
+
+
+def test_task3_pending_gateway_bridge_gaps_are_exact():
+    """Track temporary Task 3 gateway bridge omissions explicitly.
+
+    These keys are not CLI-only: terminal_tool consumes their TERMINAL_* env
+    vars.  Keep the pending set exact so wiring either key in Task 3 causes
+    this test to fail until the temporary marker is removed or updated.
+    """
+    assert (
+        _shared_terminal_keys_missing_from_gateway()
+        == TASK3_PENDING_GATEWAY_BRIDGE_KEYS
+    )
+
+
+def test_cli_and_gateway_env_maps_agree_except_task3_pending_gaps():
     """Shared CLI config and gateway/run.py must bridge the same terminal keys.
 
     Both feed the same downstream consumer (terminal_tool).  Drift between
     them means a config.yaml setting that "works in CLI mode but not gateway
     mode" (or vice-versa) — the bug class that shipped twice already.
     """
-    cli_keys = _cli_env_map_keys() - _CLI_ONLY_OK
-    gw_keys = _gateway_env_map_keys()
-
-    # Normalize the legacy `env_type` alias: cli.py accepts both `env_type`
-    # and `backend` as source keys for TERMINAL_ENV; gateway only accepts
-    # `backend`.  Since cli.py copies `backend` → `env_type` before the
-    # lookup, they're equivalent.  Remove `backend` from the gateway side
-    # to avoid a spurious "backend missing from cli" failure.
-    gw_keys = gw_keys - {"backend"}
+    cli_keys = (
+        _cli_env_map_keys()
+        - _GATEWAY_BRIDGE_EXEMPT_KEYS
+        - TASK3_PENDING_GATEWAY_BRIDGE_KEYS
+    )
+    gw_keys = _normalized_gateway_env_map_keys()
 
     missing_in_gateway = cli_keys - gw_keys
     missing_in_cli = gw_keys - cli_keys
@@ -170,7 +200,9 @@ def test_cli_and_gateway_env_maps_agree():
     )
     assert not missing_in_cli, (
         f"Keys in gateway/run.py _terminal_env_map but missing from shared "
-        f"TERMINAL_ENV_MAPPINGS: {sorted(missing_in_cli)}. Add them to both maps."
+        f"TERMINAL_ENV_MAPPINGS or still listed in "
+        f"TASK3_PENDING_GATEWAY_BRIDGE_KEYS: {sorted(missing_in_cli)}. Add them "
+        f"to both maps, or remove resolved Task 3 pending keys from the test."
     )
 
 

--- a/tests/tools/test_terminal_config_env_sync.py
+++ b/tests/tools/test_terminal_config_env_sync.py
@@ -6,7 +6,7 @@ at startup, by the config source-of-truth and by adjacent entry-point code paths
 
   1. hermes_cli.terminal_config.TERMINAL_ENV_MAPPINGS
                        -> shared CLI / TUI source-of-truth used by cli.py
-  2. gateway/run.py    -> ``_terminal_env_map`` dict (gateway / messaging
+  2. gateway/run.py    -> shared terminal_config helpers (gateway / messaging
                           platforms)
   3. hermes_cli/config.py:save_config_value
                        -> ``_config_to_env_sync`` dict (one-shot when the
@@ -20,7 +20,7 @@ for ``docker_run_as_host_user`` (gateway and CLI maps) and once for
 This test guards against future drift by treating the shared terminal_config
 mapping as the CLI source-of-truth, source-inspecting the remaining inline maps,
 and asserting the load-bearing terminal env vars stay aligned.  Source
-inspection for gateway/config maps (rather than executing their bridge paths)
+inspection for the remaining config map (rather than executing its bridge path)
 keeps the test independent of the user's ~/.hermes/config.yaml and mirrors the
 pattern used in tests/hermes_cli/test_config_drift.py.
 """
@@ -82,20 +82,20 @@ def _cli_env_map_keys() -> set[str]:
 
 
 def _gateway_env_map_keys() -> set[str]:
-    """terminal config keys bridged by gateway/run.py at module load."""
-    # gateway/run.py builds the dict at module top-level (not inside a
-    # function), so inspect the whole module source.
-    import gateway.run as gr
-    source = inspect.getsource(gr)
-    return _extract_dict_keys(source, "_terminal_env_map")
+    """Terminal config keys bridged by gateway/run.py via shared helpers."""
+    from hermes_cli.terminal_config import TERMINAL_ENV_MAPPINGS
+
+    # gateway/run.py additionally accepts the canonical `backend` key before
+    # terminal_env_values serializes it to TERMINAL_ENV.  The parity helper
+    # normalizes this alias away before comparing against the CLI map.
+    return set(TERMINAL_ENV_MAPPINGS) | {"backend"}
 
 
 def _gateway_env_map_values() -> set[str]:
-    """TERMINAL_* env vars bridged by gateway/run.py at module load."""
-    import gateway.run as gr
+    """TERMINAL_* env vars bridged by gateway/run.py via shared helpers."""
+    from hermes_cli.terminal_config import TERMINAL_ENV_MAPPINGS
 
-    source = inspect.getsource(gr)
-    return _extract_dict_values(source, "_terminal_env_map")
+    return set(TERMINAL_ENV_MAPPINGS.values())
 
 
 def _save_config_env_sync_keys() -> set[str]:
@@ -126,14 +126,10 @@ _GATEWAY_BRIDGE_EXEMPT_KEYS = frozenset({
 })
 
 
-# Temporary Task 3 known gap: these shared terminal keys are consumed by
-# terminal_tool, but gateway/run.py does not bridge them from config.yaml yet.
-# Keep this set exact so Task 3 fails here after wiring the bridge until the
-# temporary marker is removed or updated.
-TASK3_PENDING_GATEWAY_BRIDGE_KEYS = frozenset({
-    "docker_extra_args",
-    "modal_mode",
-})
+# Task 3 wires the gateway bridge through the shared terminal config helpers;
+# this set must remain empty so newly shared terminal keys cannot be hidden as
+# temporary gateway-only omissions.
+TASK3_PENDING_GATEWAY_BRIDGE_KEYS = frozenset()
 
 
 def _terminal_tool_env_var_names() -> set[str]:
@@ -148,12 +144,10 @@ def _terminal_tool_env_var_names() -> set[str]:
 
 def _normalized_gateway_env_map_keys() -> set[str]:
     """Gateway terminal bridge keys normalized to the shared CLI key surface."""
-    # Normalize the legacy `env_type` alias: cli.py accepts both `env_type`
-    # and `backend` as source keys for TERMINAL_ENV; gateway only accepts
-    # `backend`.  Since cli.py copies `backend` → `env_type` before the
-    # lookup, they're equivalent.  Remove `backend` from the gateway side
-    # to avoid a spurious "backend missing from cli" failure.
-    return _gateway_env_map_keys() - {"backend"}
+    # Normalize the legacy/backend aliases: `env_type` is a legacy YAML key
+    # alias and `backend` is the canonical gateway spelling for TERMINAL_ENV.
+    # Both serialize to the same env var, so exclude them from key-drift parity.
+    return _gateway_env_map_keys() - {"backend", "env_type"}
 
 
 def _shared_terminal_keys_missing_from_gateway() -> set[str]:
@@ -163,16 +157,22 @@ def _shared_terminal_keys_missing_from_gateway() -> set[str]:
 
 
 def test_task3_pending_gateway_bridge_gaps_are_exact():
-    """Track temporary Task 3 gateway bridge omissions explicitly.
-
-    These keys are not CLI-only: terminal_tool consumes their TERMINAL_* env
-    vars.  Keep the pending set exact so wiring either key in Task 3 causes
-    this test to fail until the temporary marker is removed or updated.
-    """
+    """Task 3 consumed all known gateway bridge omissions."""
     assert (
         _shared_terminal_keys_missing_from_gateway()
         == TASK3_PENDING_GATEWAY_BRIDGE_KEYS
     )
+
+
+def test_gateway_bridge_uses_shared_terminal_config_helpers():
+    """gateway/run.py should not carry a drift-prone inline terminal map."""
+    import gateway.run as gr
+
+    source = inspect.getsource(gr)
+    assert "normalize_terminal_config" in source
+    assert "resolve_gateway_terminal_cwd" in source
+    assert "terminal_env_values" in source
+    assert "_terminal_env_map" not in source
 
 
 def test_cli_and_gateway_env_maps_agree_except_task3_pending_gaps():
@@ -194,15 +194,15 @@ def test_cli_and_gateway_env_maps_agree_except_task3_pending_gaps():
 
     assert not missing_in_gateway, (
         f"Keys in shared TERMINAL_ENV_MAPPINGS but missing from gateway/run.py "
-        f"_terminal_env_map: {sorted(missing_in_gateway)}.  Add them to "
-        f"both maps (same bug class as docker_run_as_host_user shipping "
-        f"wired in cli but not gateway in April 2026)."
+        f"shared terminal bridge: {sorted(missing_in_gateway)}. Keep gateway "
+        f"wired through terminal_env_values so shared terminal config keys do "
+        f"not drift by entry point."
     )
     assert not missing_in_cli, (
-        f"Keys in gateway/run.py _terminal_env_map but missing from shared "
+        f"Keys in the gateway terminal bridge but missing from shared "
         f"TERMINAL_ENV_MAPPINGS or still listed in "
         f"TASK3_PENDING_GATEWAY_BRIDGE_KEYS: {sorted(missing_in_cli)}. Add them "
-        f"to both maps, or remove resolved Task 3 pending keys from the test."
+        f"to the shared map, or remove resolved Task 3 pending keys from the test."
     )
 
 
@@ -224,7 +224,7 @@ def test_gateway_terminal_env_map_points_at_terminal_tool_consumers():
     missing_consumers = _gateway_env_map_values() - _terminal_tool_env_var_names()
 
     assert not missing_consumers, (
-        "gateway/run.py _terminal_env_map contains env vars terminal_tool does "
+        "gateway/run.py shared terminal bridge contains env vars terminal_tool does "
         f"not consume: {sorted(missing_consumers)}. Remove dead mappings or add "
         "the terminal_tool consumer."
     )
@@ -264,10 +264,9 @@ def test_docker_run_as_host_user_is_bridged_everywhere():
     """Explicit pin for the bug we just fixed.
 
     docker_run_as_host_user was added to terminal_tool._get_env_config and
-    DockerEnvironment but NOT to the CLI env map or gateway/run.py's
-    _terminal_env_map, so ``terminal.docker_run_as_host_user: true`` in
-    config.yaml had no effect at runtime.  This guard makes the regression
-    impossible to reintroduce silently.
+    DockerEnvironment but NOT to the then-inline CLI/gateway bridge maps, so
+    ``terminal.docker_run_as_host_user: true`` in config.yaml had no effect at
+    runtime.  This guard makes the regression impossible to reintroduce silently.
     """
     assert "docker_run_as_host_user" in _cli_env_map_keys()
     assert "docker_run_as_host_user" in _gateway_env_map_keys()
@@ -277,8 +276,8 @@ def test_docker_run_as_host_user_is_bridged_everywhere():
 
 def test_docker_mount_cwd_to_workspace_is_bridged_everywhere():
     """Same regression class — docker_mount_cwd_to_workspace was missing from
-    gateway/run.py's _terminal_env_map until the docker_run_as_host_user
-    audit caught it.
+    gateway/run.py's legacy bridge until the docker_run_as_host_user audit
+    caught it.
     """
     assert "docker_mount_cwd_to_workspace" in _cli_env_map_keys()
     assert "docker_mount_cwd_to_workspace" in _gateway_env_map_keys()

--- a/tests/tools/test_terminal_config_env_sync.py
+++ b/tests/tools/test_terminal_config_env_sync.py
@@ -1,10 +1,11 @@
 """Regression tests for terminal config -> env-var bridging.
 
-terminal_tool._get_env_config() reads ALL terminal settings from os.environ
+terminal_tool._get_env_config() reads terminal settings from os.environ
 (TERMINAL_*).  config.yaml values therefore have to be bridged into env vars
-at startup, by THREE separate code paths:
+at startup, by the config source-of-truth and by adjacent entry-point code paths:
 
-  1. cli.py            -> ``env_mappings`` dict (CLI / TUI startup)
+  1. hermes_cli.terminal_config.TERMINAL_ENV_MAPPINGS
+                       -> shared CLI / TUI source-of-truth used by cli.py
   2. gateway/run.py    -> ``_terminal_env_map`` dict (gateway / messaging
                           platforms)
   3. hermes_cli/config.py:save_config_value
@@ -16,11 +17,12 @@ silently does nothing for that entry-point.  This bug already shipped once
 for ``docker_run_as_host_user`` (gateway and CLI maps) and once for
 ``docker_mount_cwd_to_workspace`` (gateway map).
 
-This test guards against future drift by extracting all three maps via source
-inspection and asserting they all bridge the same set of writable
-``terminal.*`` keys.  Source inspection (rather than importing the live
-dicts) keeps the test independent of the user's ~/.hermes/config.yaml and
-mirrors the pattern used in tests/hermes_cli/test_config_drift.py.
+This test guards against future drift by treating the shared terminal_config
+mapping as the CLI source-of-truth, source-inspecting the remaining inline maps,
+and asserting the load-bearing terminal env vars stay aligned.  Source
+inspection for gateway/config maps (rather than executing their bridge paths)
+keeps the test independent of the user's ~/.hermes/config.yaml and mirrors the
+pattern used in tests/hermes_cli/test_config_drift.py.
 """
 
 import ast
@@ -71,10 +73,12 @@ def _extract_dict_keys(source: str, dict_name: str) -> set[str]:
 
 
 def _cli_env_map_keys() -> set[str]:
-    """terminal config keys bridged by cli.load_cli_config()."""
-    import cli
-    source = inspect.getsource(cli.load_cli_config)
-    return _extract_dict_keys(source, "env_mappings")
+    """terminal config keys bridged by the shared CLI/source-of-truth map."""
+    from hermes_cli.terminal_config import SENSITIVE_TERMINAL_ENV_MAPPINGS, TERMINAL_ENV_MAPPINGS
+
+    # Include the intentionally sensitive SUDO_PASSWORD mapping by key name only
+    # so the CLI bridge surface stays represented without exposing secret values.
+    return set(TERMINAL_ENV_MAPPINGS) | set(SENSITIVE_TERMINAL_ENV_MAPPINGS)
 
 
 def _gateway_env_map_keys() -> set[str]:
@@ -84,6 +88,14 @@ def _gateway_env_map_keys() -> set[str]:
     import gateway.run as gr
     source = inspect.getsource(gr)
     return _extract_dict_keys(source, "_terminal_env_map")
+
+
+def _gateway_env_map_values() -> set[str]:
+    """TERMINAL_* env vars bridged by gateway/run.py at module load."""
+    import gateway.run as gr
+
+    source = inspect.getsource(gr)
+    return _extract_dict_values(source, "_terminal_env_map")
 
 
 def _save_config_env_sync_keys() -> set[str]:
@@ -97,8 +109,8 @@ def _save_config_env_sync_keys() -> set[str]:
     return {k.split(".", 1)[1] for k in keys if k.startswith("terminal.")}
 
 
-# Keys present in cli.py env_mappings but intentionally absent from
-# gateway/run.py or set_config_value.  Each entry must be justified.
+# Keys present in the shared CLI/source-of-truth mapping but intentionally
+# absent from gateway/run.py or set_config_value.  Each entry must be justified.
 _CLI_ONLY_OK = frozenset({
     # `env_type` is a legacy YAML key alias for `backend` that cli.py
     # accepts for backwards-compat with older cli-config.yaml.  The
@@ -109,6 +121,14 @@ _CLI_ONLY_OK = frozenset({
     # used across backends, bridged to $SUDO_PASSWORD (not TERMINAL_*).
     # Treating it as terminal-only would be misleading.
     "sudo_password",
+    # modal_mode is normalized by CLI setup/subscription flows and consumed by
+    # terminal_tool when present, but gateway does not currently expose the
+    # managed-vs-direct Modal selector through its startup bridge.
+    "modal_mode",
+    # docker_extra_args is a Docker-only escape hatch consumed by terminal_tool;
+    # the gateway bridge intentionally stays on the historically supported
+    # Docker env/config keys until that surface is explicitly expanded.
+    "docker_extra_args",
 })
 
 
@@ -123,7 +143,7 @@ def _terminal_tool_env_var_names() -> set[str]:
 
 
 def test_cli_and_gateway_env_maps_agree():
-    """cli.py and gateway/run.py must bridge the same set of terminal keys.
+    """Shared CLI config and gateway/run.py must bridge the same terminal keys.
 
     Both feed the same downstream consumer (terminal_tool).  Drift between
     them means a config.yaml setting that "works in CLI mode but not gateway
@@ -143,14 +163,38 @@ def test_cli_and_gateway_env_maps_agree():
     missing_in_cli = gw_keys - cli_keys
 
     assert not missing_in_gateway, (
-        f"Keys in cli.py env_mappings but missing from gateway/run.py "
+        f"Keys in shared TERMINAL_ENV_MAPPINGS but missing from gateway/run.py "
         f"_terminal_env_map: {sorted(missing_in_gateway)}.  Add them to "
         f"both maps (same bug class as docker_run_as_host_user shipping "
         f"wired in cli but not gateway in April 2026)."
     )
     assert not missing_in_cli, (
-        f"Keys in gateway/run.py _terminal_env_map but missing from cli.py "
-        f"env_mappings: {sorted(missing_in_cli)}.  Add them to both maps."
+        f"Keys in gateway/run.py _terminal_env_map but missing from shared "
+        f"TERMINAL_ENV_MAPPINGS: {sorted(missing_in_cli)}. Add them to both maps."
+    )
+
+
+def test_shared_terminal_env_map_points_at_terminal_tool_consumers():
+    """Every shared terminal env var should be consumed by terminal_tool."""
+    from hermes_cli.terminal_config import TERMINAL_ENV_MAPPINGS
+
+    missing_consumers = set(TERMINAL_ENV_MAPPINGS.values()) - _terminal_tool_env_var_names()
+
+    assert not missing_consumers, (
+        "Shared TERMINAL_ENV_MAPPINGS contains env vars terminal_tool does not "
+        f"consume: {sorted(missing_consumers)}. Remove dead mappings or add the "
+        "terminal_tool consumer."
+    )
+
+
+def test_gateway_terminal_env_map_points_at_terminal_tool_consumers():
+    """Every gateway terminal env var should be consumed by terminal_tool."""
+    missing_consumers = _gateway_env_map_values() - _terminal_tool_env_var_names()
+
+    assert not missing_consumers, (
+        "gateway/run.py _terminal_env_map contains env vars terminal_tool does "
+        f"not consume: {sorted(missing_consumers)}. Remove dead mappings or add "
+        "the terminal_tool consumer."
     )
 
 
@@ -188,7 +232,7 @@ def test_docker_run_as_host_user_is_bridged_everywhere():
     """Explicit pin for the bug we just fixed.
 
     docker_run_as_host_user was added to terminal_tool._get_env_config and
-    DockerEnvironment but NOT to cli.py's env_mappings or gateway/run.py's
+    DockerEnvironment but NOT to the CLI env map or gateway/run.py's
     _terminal_env_map, so ``terminal.docker_run_as_host_user: true`` in
     config.yaml had no effect at runtime.  This guard makes the regression
     impossible to reintroduce silently.

--- a/tests/tools/test_terminal_env_config.py
+++ b/tests/tools/test_terminal_env_config.py
@@ -1,0 +1,46 @@
+import os
+
+import pytest
+
+from hermes_cli.terminal_config import default_terminal_config
+from tools import terminal_tool
+
+
+@pytest.fixture(autouse=True)
+def clear_terminal_env_vars(monkeypatch):
+    for name in list(os.environ):
+        if name.startswith("TERMINAL_"):
+            monkeypatch.delenv(name, raising=False)
+
+
+def test_get_env_config_without_env_uses_shared_terminal_defaults(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    terminal_defaults = default_terminal_config()
+
+    config = terminal_tool._get_env_config()
+
+    assert config["env_type"] == terminal_defaults["env_type"]
+    assert config["cwd"] == str(tmp_path)
+    assert config["timeout"] == terminal_defaults["timeout"]
+    assert config["lifetime_seconds"] == terminal_defaults["lifetime_seconds"]
+    assert config["docker_image"] == terminal_defaults["docker_image"]
+    assert config["modal_image"] == terminal_defaults["modal_image"]
+    assert config["daytona_image"] == terminal_defaults["daytona_image"]
+    assert config["singularity_image"] == terminal_defaults["singularity_image"]
+    assert config["vercel_runtime"] == terminal_defaults["vercel_runtime"]
+    assert config["container_memory"] == terminal_defaults["container_memory"]
+    assert config["container_disk"] == terminal_defaults["container_disk"]
+
+
+def test_get_env_config_env_vars_override_shared_terminal_defaults(monkeypatch):
+    monkeypatch.setenv("TERMINAL_ENV", "docker")
+    monkeypatch.setenv("TERMINAL_TIMEOUT", "77")
+    monkeypatch.setenv("TERMINAL_LIFETIME_SECONDS", "88")
+    monkeypatch.setenv("TERMINAL_CONTAINER_MEMORY", "1024")
+
+    config = terminal_tool._get_env_config()
+
+    assert config["env_type"] == "docker"
+    assert config["timeout"] == 77
+    assert config["lifetime_seconds"] == 88
+    assert config["container_memory"] == 1024

--- a/tests/tools/test_terminal_env_config.py
+++ b/tests/tools/test_terminal_env_config.py
@@ -1,3 +1,4 @@
+import inspect
 import os
 
 import pytest
@@ -44,3 +45,10 @@ def test_get_env_config_env_vars_override_shared_terminal_defaults(monkeypatch):
     assert config["timeout"] == 77
     assert config["lifetime_seconds"] == 88
     assert config["container_memory"] == 1024
+
+
+def test_terminal_diagnostic_timeout_default_does_not_use_stale_literal():
+    """The operator-facing diagnostic script should not duplicate old timeout defaults."""
+    source = inspect.getsource(terminal_tool)
+
+    assert "os.getenv('TERMINAL_TIMEOUT', '60')" not in source

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -47,6 +47,7 @@ import subprocess
 from pathlib import Path
 from typing import Optional, Dict, Any, List
 
+from hermes_cli.terminal_config import default_terminal_config
 from utils import env_var_enabled
 
 logger = logging.getLogger(__name__)
@@ -1008,11 +1009,19 @@ def _parse_env_var(name: str, default: str, converter=int, type_label: str = "in
 
 def _get_env_config() -> Dict[str, Any]:
     """Get terminal environment configuration from environment variables."""
-    # Default image with Python and Node.js for maximum compatibility
-    default_image = "nikolaik/python-nodejs:python3.11-nodejs20"
-    env_type = os.getenv("TERMINAL_ENV", "local")
+    terminal_defaults = default_terminal_config()
+    env_type = os.getenv("TERMINAL_ENV", str(terminal_defaults["env_type"]))
     
-    mount_docker_cwd = os.getenv("TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE", "false").lower() in {"true", "1", "yes"}
+    def _bool_env(name: str, default: bool) -> bool:
+        return os.getenv(name, str(default)).lower() in {"true", "1", "yes"}
+
+    def _json_default(key: str) -> str:
+        return json.dumps(terminal_defaults[key])
+
+    mount_docker_cwd = _bool_env(
+        "TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE",
+        terminal_defaults["docker_mount_cwd_to_workspace"],
+    )
 
     # Default cwd: local uses the host's current directory, ssh uses the
     # remote home, Vercel uses its documented workspace root, and everything
@@ -1056,18 +1065,26 @@ def _get_env_config() -> Dict[str, Any]:
 
     return {
         "env_type": env_type,
-        "modal_mode": coerce_modal_mode(os.getenv("TERMINAL_MODAL_MODE", "auto")),
-        "docker_image": os.getenv("TERMINAL_DOCKER_IMAGE", default_image),
-        "docker_forward_env": _parse_env_var("TERMINAL_DOCKER_FORWARD_ENV", "[]", json.loads, "valid JSON"),
-        "singularity_image": os.getenv("TERMINAL_SINGULARITY_IMAGE", f"docker://{default_image}"),
-        "modal_image": os.getenv("TERMINAL_MODAL_IMAGE", default_image),
-        "daytona_image": os.getenv("TERMINAL_DAYTONA_IMAGE", default_image),
-        "vercel_runtime": os.getenv("TERMINAL_VERCEL_RUNTIME", "").strip(),
+        "modal_mode": coerce_modal_mode(os.getenv("TERMINAL_MODAL_MODE", str(terminal_defaults["modal_mode"]))),
+        "docker_image": os.getenv("TERMINAL_DOCKER_IMAGE", terminal_defaults["docker_image"]),
+        "docker_forward_env": _parse_env_var(
+            "TERMINAL_DOCKER_FORWARD_ENV",
+            _json_default("docker_forward_env"),
+            json.loads,
+            "valid JSON",
+        ),
+        "singularity_image": os.getenv("TERMINAL_SINGULARITY_IMAGE", terminal_defaults["singularity_image"]),
+        "modal_image": os.getenv("TERMINAL_MODAL_IMAGE", terminal_defaults["modal_image"]),
+        "daytona_image": os.getenv("TERMINAL_DAYTONA_IMAGE", terminal_defaults["daytona_image"]),
+        "vercel_runtime": os.getenv("TERMINAL_VERCEL_RUNTIME", terminal_defaults["vercel_runtime"]).strip(),
         "cwd": cwd,
         "host_cwd": host_cwd,
         "docker_mount_cwd_to_workspace": mount_docker_cwd,
-        "timeout": _parse_env_var("TERMINAL_TIMEOUT", "180"),
-        "lifetime_seconds": _parse_env_var("TERMINAL_LIFETIME_SECONDS", "300"),
+        "timeout": _parse_env_var("TERMINAL_TIMEOUT", str(terminal_defaults["timeout"])),
+        "lifetime_seconds": _parse_env_var(
+            "TERMINAL_LIFETIME_SECONDS",
+            str(terminal_defaults["lifetime_seconds"]),
+        ),
         # SSH-specific config
         "ssh_host": os.getenv("TERMINAL_SSH_HOST", ""),
         "ssh_user": os.getenv("TERMINAL_SSH_USER", ""),
@@ -1078,19 +1095,32 @@ def _get_env_config() -> Dict[str, Any]:
         # Per-backend env vars override if explicitly set.
         "ssh_persistent": os.getenv(
             "TERMINAL_SSH_PERSISTENT",
-            os.getenv("TERMINAL_PERSISTENT_SHELL", "true"),
+            os.getenv("TERMINAL_PERSISTENT_SHELL", str(terminal_defaults["persistent_shell"])),
         ).lower() in {"true", "1", "yes"},
-        "local_persistent": os.getenv("TERMINAL_LOCAL_PERSISTENT", "false").lower() in {"true", "1", "yes"},
+        "local_persistent": _bool_env("TERMINAL_LOCAL_PERSISTENT", terminal_defaults.get("local_persistent", False)),
         # Container resource config (applies to docker, singularity, modal,
         # daytona, and vercel_sandbox -- ignored for local/ssh)
-        "container_cpu": _parse_env_var("TERMINAL_CONTAINER_CPU", "1", float, "number"),
-        "container_memory": _parse_env_var("TERMINAL_CONTAINER_MEMORY", "5120"),     # MB (default 5GB)
-        "container_disk": _parse_env_var("TERMINAL_CONTAINER_DISK", "51200"),        # MB (default 50GB)
-        "container_persistent": os.getenv("TERMINAL_CONTAINER_PERSISTENT", "true").lower() in {"true", "1", "yes"},
-        "docker_volumes": _parse_env_var("TERMINAL_DOCKER_VOLUMES", "[]", json.loads, "valid JSON"),
-        "docker_env": _parse_env_var("TERMINAL_DOCKER_ENV", "{}", json.loads, "valid JSON"),
-        "docker_run_as_host_user": os.getenv("TERMINAL_DOCKER_RUN_AS_HOST_USER", "false").lower() in {"true", "1", "yes"},
-        "docker_extra_args": _parse_env_var("TERMINAL_DOCKER_EXTRA_ARGS", "[]", json.loads, "valid JSON"),
+        "container_cpu": _parse_env_var("TERMINAL_CONTAINER_CPU", str(terminal_defaults["container_cpu"]), float, "number"),
+        "container_memory": _parse_env_var("TERMINAL_CONTAINER_MEMORY", str(terminal_defaults["container_memory"])),
+        "container_disk": _parse_env_var("TERMINAL_CONTAINER_DISK", str(terminal_defaults["container_disk"])),
+        "container_persistent": _bool_env("TERMINAL_CONTAINER_PERSISTENT", terminal_defaults["container_persistent"]),
+        "docker_volumes": _parse_env_var(
+            "TERMINAL_DOCKER_VOLUMES",
+            _json_default("docker_volumes"),
+            json.loads,
+            "valid JSON",
+        ),
+        "docker_env": _parse_env_var("TERMINAL_DOCKER_ENV", _json_default("docker_env"), json.loads, "valid JSON"),
+        "docker_run_as_host_user": _bool_env(
+            "TERMINAL_DOCKER_RUN_AS_HOST_USER",
+            terminal_defaults["docker_run_as_host_user"],
+        ),
+        "docker_extra_args": _parse_env_var(
+            "TERMINAL_DOCKER_EXTRA_ARGS",
+            _json_default("docker_extra_args"),
+            json.loads,
+            "valid JSON",
+        ),
     }
 
 

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -2318,21 +2318,22 @@ if __name__ == "__main__":
     print("  result = terminal_tool(command='python server.py', background=True)")
 
     print("\nEnvironment Variables:")
-    default_img = "nikolaik/python-nodejs:python3.11-nodejs20"
+    terminal_defaults = default_terminal_config()
+    default_img = str(terminal_defaults["docker_image"])
     print(
         "  TERMINAL_ENV: "
-        f"{os.getenv('TERMINAL_ENV', 'local')} "
+        f"{os.getenv('TERMINAL_ENV', str(terminal_defaults['env_type']))} "
         "(local/docker/singularity/modal/daytona/vercel_sandbox/ssh)"
     )
     print(f"  TERMINAL_DOCKER_IMAGE: {os.getenv('TERMINAL_DOCKER_IMAGE', default_img)}")
-    print(f"  TERMINAL_SINGULARITY_IMAGE: {os.getenv('TERMINAL_SINGULARITY_IMAGE', f'docker://{default_img}')}")
-    print(f"  TERMINAL_MODAL_IMAGE: {os.getenv('TERMINAL_MODAL_IMAGE', default_img)}")
-    print(f"  TERMINAL_DAYTONA_IMAGE: {os.getenv('TERMINAL_DAYTONA_IMAGE', default_img)}")
+    print(f"  TERMINAL_SINGULARITY_IMAGE: {os.getenv('TERMINAL_SINGULARITY_IMAGE', str(terminal_defaults['singularity_image']))}")
+    print(f"  TERMINAL_MODAL_IMAGE: {os.getenv('TERMINAL_MODAL_IMAGE', str(terminal_defaults['modal_image']))}")
+    print(f"  TERMINAL_DAYTONA_IMAGE: {os.getenv('TERMINAL_DAYTONA_IMAGE', str(terminal_defaults['daytona_image']))}")
     print(f"  TERMINAL_CWD: {os.getenv('TERMINAL_CWD', os.getcwd())}")
     from hermes_constants import display_hermes_home as _dhh
     print(f"  TERMINAL_SANDBOX_DIR: {os.getenv('TERMINAL_SANDBOX_DIR', f'{_dhh()}/sandboxes')}")
-    print(f"  TERMINAL_TIMEOUT: {os.getenv('TERMINAL_TIMEOUT', '60')}")
-    print(f"  TERMINAL_LIFETIME_SECONDS: {os.getenv('TERMINAL_LIFETIME_SECONDS', '300')}")
+    print(f"  TERMINAL_TIMEOUT: {os.getenv('TERMINAL_TIMEOUT', str(terminal_defaults['timeout']))}")
+    print(f"  TERMINAL_LIFETIME_SECONDS: {os.getenv('TERMINAL_LIFETIME_SECONDS', str(terminal_defaults['lifetime_seconds']))}")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Fixes `terminal: null` config handling so `hermes config show` and CLI config loading do not crash.
- Centralizes terminal defaults/normalization/env serialization in `hermes_cli.terminal_config`.
- Reapplies the terminal-only work on top of current `origin/main` to avoid publishing unrelated local `main` workstreams.

## Scope control
- Base: `origin/main` at `c6a992e3e`.
- Head branch: `Hams-MyAI:integrate/terminal-on-origin-main-20260521`.
- Includes terminal config code, terminal/gateway tests, and terminal contract docs only.
- Excludes unrelated local Brain/gstack/Superpowers work from the diverged local `main`.

## Test Plan
- [x] `/home/shlee/.hermes/hermes-agent/venv/bin/python -m pytest tests/hermes_cli/test_terminal_config_normalization.py tests/hermes_cli/test_ignore_user_config_flags.py tests/hermes_cli/test_placeholder_usage.py tests/gateway/test_config_cwd_bridge.py tests/tools/test_terminal_env_config.py tests/tools/test_terminal_config_env_sync.py tests/cli/test_cwd_env_respect.py tests/tools/test_terminal_task_cwd.py -q -o 'addopts='`
- [x] `/home/shlee/.hermes/hermes-agent/venv/bin/python -m pytest tests/hermes_cli/test_config_drift.py -q -o 'addopts='`
- [x] `/home/shlee/.hermes/hermes-agent/venv/bin/python -m ruff check cli.py hermes_cli/config.py hermes_cli/terminal_config.py gateway/run.py tools/terminal_tool.py tests/gateway/test_config_cwd_bridge.py tests/hermes_cli/test_ignore_user_config_flags.py tests/hermes_cli/test_placeholder_usage.py tests/hermes_cli/test_terminal_config_normalization.py tests/tools/test_terminal_config_env_sync.py tests/tools/test_terminal_env_config.py`
- [x] `git diff --check origin/main..HEAD`

## Notes
The original local `main` remains diverged from `origin/main`. This PR intentionally publishes only the terminal config repair series on top of the latest remote `main`.

The upstream repository rejected direct push for `Hams-MyAI`, so the branch was pushed to the `Hams-MyAI/hermes-agent` fork and opened against `NousResearch/hermes-agent:main`.