### PR TITLE
fix(browser-cdp): guard json.loads on WebSocket frames against malformed data

### DIFF
--- a/tools/browser_cdp_tool.py
+++ b/tools/browser_cdp_tool.py
@@ -140,7 +140,11 @@ async def _cdp_call(
                         f"Timed out attaching to target {target_id}"
                     )
                 raw = await asyncio.wait_for(ws.recv(), timeout=remaining)
-                msg = json.loads(raw)
+                try:
+                    msg = json.loads(raw)
+                except json.JSONDecodeError:
+                    # Skip non-JSON frames (binary, malformed)
+                    continue
                 if msg.get("id") == attach_id:
                     if "error" in msg:
                         raise RuntimeError(
@@ -174,7 +178,11 @@ async def _cdp_call(
                     f"Timed out waiting for response to {method}"
                 )
             raw = await asyncio.wait_for(ws.recv(), timeout=remaining)
-            msg = json.loads(raw)
+            try:
+                msg = json.loads(raw)
+            except json.JSONDecodeError:
+                # Skip non-JSON frames (binary, malformed)
+                continue
             if msg.get("id") == call_id:
                 if "error" in msg:
                     raise RuntimeError(f"CDP error: {msg['error']}")


### PR DESCRIPTION
## Problem

`_cdp_call()` in `tools/browser_cdp_tool.py` has two `json.loads(raw)` calls (lines 143 and 177) inside WebSocket receive loops without `try/except` guards. If Chrome sends a non-JSON frame (binary data, malformed event, or protocol-level frame), the entire CDP session crashes with `json.JSONDecodeError`.

This is especially likely when:
- Chrome sends binary WebSocket frames (e.g., during heavy rendering)
- Network glitches corrupt a frame mid-transit
- Extensions inject non-standard CDP events

## Fix

Wrap both `json.loads(raw)` calls in `try/except json.JSONDecodeError` with `continue` to skip the malformed frame and keep waiting for the expected response. This is consistent with the existing comment `# Ignore events / out-of-order responses` — non-JSON frames are simply noise to skip.

**Diff:** +10 lines, -2 lines (1 file)

## Before vs After

| Scenario | Before | After |
|---|---|---|
| Non-JSON WebSocket frame | `json.JSONDecodeError` crash | Frame skipped, session continues |
| Binary frame from Chrome | Unhandled exception | Gracefully ignored |
| Malformed event data | CDP session aborted | Continues waiting for response |

## Testing

- Verified syntax: `ast.parse()` passes
- The fix is purely defensive — no behavior change for valid JSON frames
- Each `json.loads` is inside a `while True` loop that already handles timeout via `remaining <= 0`, so the loop will still terminate on real timeouts
