### PR TITLE
fix(security): validate secret in _reload_dynamic_routes to prevent HMAC bypass (#8306)

### DIFF
--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -308,11 +308,26 @@ class WebhookAdapter(BasePlatformAdapter):
             data = json.loads(subs_path.read_text(encoding="utf-8"))
             if not isinstance(data, dict):
                 return
-            # Merge: static routes take precedence over dynamic ones
-            self._dynamic_routes = {
-                k: v for k, v in data.items()
-                if k not in self._static_routes
-            }
+            # Merge: static routes take precedence over dynamic ones.
+            # Reject any dynamic route whose effective secret is empty —
+            # an empty secret would cause _handle_webhook to skip HMAC
+            # validation entirely, letting unauthenticated callers in.
+            new_dynamic: Dict[str, dict] = {}
+            for k, v in data.items():
+                if k in self._static_routes:
+                    continue
+                effective_secret = v.get("secret", self._global_secret)
+                if not effective_secret:
+                    logger.warning(
+                        "[webhook] Dynamic route '%s' skipped: 'secret' is "
+                        "missing or empty. Set a valid HMAC secret, or use "
+                        "'%s' to explicitly disable auth (testing only).",
+                        k,
+                        _INSECURE_NO_AUTH,
+                    )
+                    continue
+                new_dynamic[k] = v
+            self._dynamic_routes = new_dynamic
             self._routes = {**self._dynamic_routes, **self._static_routes}
             self._dynamic_routes_mtime = mtime
             logger.info(

--- a/tests/gateway/test_webhook_dynamic_routes.py
+++ b/tests/gateway/test_webhook_dynamic_routes.py
@@ -85,3 +85,70 @@ class TestDynamicRouteLoading:
         adapter._reload_dynamic_routes()
         assert "static" in adapter._routes
         assert len(adapter._dynamic_routes) == 0
+
+
+class TestDynamicRouteSecretValidation:
+    """Regression tests for #8306 — hot-reloaded dynamic routes with empty
+    or missing secrets must be rejected so the per-request HMAC check in
+    ``_handle_webhook`` can never see a falsy secret and skip validation."""
+
+    def test_empty_secret_string_rejected(self, tmp_path, caplog):
+        (tmp_path / _DYNAMIC_ROUTES_FILENAME).write_text(
+            json.dumps({"monitor": {"secret": "", "prompt": "test"}})
+        )
+        # No global secret: _global_secret falls back to None, so the route
+        # has no effective secret at all.
+        config = PlatformConfig(
+            enabled=True,
+            extra={"routes": {"static": {"secret": "s"}}},
+        )
+        adapter = WebhookAdapter(config)
+        adapter._reload_dynamic_routes()
+        assert "monitor" not in adapter._routes
+        assert "monitor" not in adapter._dynamic_routes
+
+    def test_missing_secret_key_rejected_without_global(self, tmp_path):
+        (tmp_path / _DYNAMIC_ROUTES_FILENAME).write_text(
+            json.dumps({"hook-a": {"prompt": "test"}})
+        )
+        config = PlatformConfig(
+            enabled=True,
+            extra={"routes": {"static": {"secret": "s"}}},
+        )
+        adapter = WebhookAdapter(config)
+        adapter._reload_dynamic_routes()
+        assert "hook-a" not in adapter._routes
+        assert "hook-a" not in adapter._dynamic_routes
+
+    def test_missing_secret_falls_back_to_global(self, tmp_path):
+        # When 'secret' key is absent, dict.get() returns the global default,
+        # so a route with no per-route secret is still admitted when a global
+        # secret is configured.
+        (tmp_path / _DYNAMIC_ROUTES_FILENAME).write_text(
+            json.dumps({"hook-b": {"prompt": "test"}})
+        )
+        adapter = _make_adapter()  # _make_adapter sets a global secret
+        adapter._reload_dynamic_routes()
+        assert "hook-b" in adapter._dynamic_routes
+
+    def test_empty_per_route_secret_rejected_even_with_global(self, tmp_path):
+        # Critical case: dict.get('secret', default) returns '' when the key
+        # is present and empty, NOT the default. So even with a global secret
+        # set, an empty per-route secret must still be skipped.
+        (tmp_path / _DYNAMIC_ROUTES_FILENAME).write_text(
+            json.dumps({"sneaky": {"secret": "", "prompt": "test"}})
+        )
+        adapter = _make_adapter()  # has a global secret
+        adapter._reload_dynamic_routes()
+        assert "sneaky" not in adapter._dynamic_routes
+
+    def test_insecure_no_auth_secret_still_admitted(self, tmp_path):
+        # INSECURE_NO_AUTH is the explicit opt-in for unauthenticated routes
+        # (loopback-only enforcement happens at startup). Hot-reload must keep
+        # it working — it's a non-empty string so the validator accepts it.
+        (tmp_path / _DYNAMIC_ROUTES_FILENAME).write_text(
+            json.dumps({"local-test": {"secret": "INSECURE_NO_AUTH", "prompt": "t"}})
+        )
+        adapter = _make_adapter()
+        adapter._reload_dynamic_routes()
+        assert "local-test" in adapter._dynamic_routes


### PR DESCRIPTION
Salvage of #8306 onto current main, preserving @memosr's authorship.

## Summary

Adds per-route secret validation to `_reload_dynamic_routes()` in `gateway/platforms/webhook.py` so the hot-reload path enforces the same secret invariant that `connect()` already does at startup.

## Root cause

`connect()` validates that every route has an HMAC secret at startup (lines 149-157). But `_reload_dynamic_routes()` — called on every webhook request (line 329) for mtime-gated hot-reload — admitted any route present in `webhook_subscriptions.json`, including ones with `"secret": ""`. The downstream request handler's gate `if secret and secret != _INSECURE_NO_AUTH:` (line 356) then skipped HMAC entirely because empty string is falsy, allowing an unsigned POST to dispatch agent work.

Maps to SECURITY.md §2.6 ("Authorization is required at every surface that crosses a trust boundary") and §3.1 ("Code paths that fail open … are code bugs in scope"). The webhook adapter is an explicit external-surface listed in §2.6.

## Fix

Per-route effective-secret check inside the hot-reload merge loop. Routes with empty/missing effective secrets are skipped with a WARNING and never enter `_routes`. `INSECURE_NO_AUTH` opt-in is preserved (non-empty string passes the validator; loopback-only enforcement still happens at startup).

## Validation

- Cherry-pick clean onto current main
- 60/60 existing webhook tests pass (`test_webhook_adapter.py` + `test_webhook_dynamic_routes.py`)
- +5 regression tests under `TestDynamicRouteSecretValidation`:
  - empty `"secret": ""` with no global → skipped
  - missing `secret` key with no global → skipped
  - missing `secret` key WITH global → falls back to global, admitted
  - empty `"secret": ""` WITH global → still skipped (dict.get returns `""` when the key is present and empty, NOT the default)
  - `INSECURE_NO_AUTH` → still admitted (explicit opt-in preserved)
- Live E2E: malicious `{"monitor": {"secret": "", "prompt": "..."}}` in `webhook_subscriptions.json` → not admitted → `_handle_webhook` returns 404. Legit routes and `INSECURE_NO_AUTH` still work.

## Relationship to GHSA-27g9-x3x6-4m35

A separate researcher filed `GHSA-27g9-x3x6-4m35` ("Unauthenticated webhook route dispatch when HMAC secret is missing") today, addressing the same root cause via a different patch location — defense-at-handler with an explicit 500 response. That advisory was closed; its PoC required bypassing `connect()` via direct handler reuse in tests, which is not a practical production path.

PR #8306's exploit path is meaningfully different and does not require bypassing `connect()`: the hot-reload runs on every request and can admit a bad route at any moment after startup, so a normally-started gateway can be made vulnerable by any later write to `webhook_subscriptions.json` (agent's `hermes webhook subscribe`, hand-edit, broken upstream tool). This fix closes the parity gap with `connect()`'s startup invariant.

Closes #8306.

## Infographic

![pr-8306-webhook-secret-hotreload](https://v3b.fal.media/files/b/0a9b1120/7ZjLJkvECM2ZxfS7I1eNS_c3qSXEmK.png)
