### PR TITLE
fix(skills): require resolved approval before writes

### DIFF
--- a/optional-skills/creative/baoyu-comic/SKILL.md
+++ b/optional-skills/creative/baoyu-comic/SKILL.md
@@ -244,4 +244,4 @@ Full step-by-step workflow (analysis, storyboard, review gates, regeneration var
 - **Step 2 confirmation required** - do not skip
 - **Steps 4/6 conditional** - only if user requested in Step 2
 - **Step 7.1 character sheet** - recommended for multi-page comics, optional for simple presets. The PNG is a review/regeneration aid; page prompts (written in Step 5) use the text descriptions in `characters/characters.md`, not the PNG. `image_generate` does not accept images as visual input
-- **Strip secrets** — scan source content for API keys, tokens, or credentials before writing any output file
+- **Strip secrets before writing** — redact API keys, tokens, credentials, cookies, and private keys before writing source, analysis, storyboard, or prompt files.

--- a/optional-skills/creative/baoyu-comic/references/workflow.md
+++ b/optional-skills/creative/baoyu-comic/references/workflow.md
@@ -41,6 +41,7 @@ Read source content, save it if needed, and perform deep analysis.
    - If user provides a file path: use as-is
    - If user pastes content: save to `source-{slug}.md` in the target directory using `write_file`, where `{slug}` is the kebab-case topic slug used for the output directory
    - **Backup rule**: If `source-{slug}.md` already exists, rename it to `source-{slug}-backup-YYYYMMDD-HHMMSS.md` before writing
+   - Redact API keys, tokens, credentials, cookies, and private keys before writing any source, analysis, storyboard, prompt, or image prompt file.
 2. Read source content
 3. **Deep analysis** following `analysis-framework.md`:
    - Target audience identification

--- a/optional-skills/devops/docker-management/SKILL.md
+++ b/optional-skills/devops/docker-management/SKILL.md
@@ -242,7 +242,7 @@ docker system prune -a                 # also unused images
 docker system prune -a --volumes       # EVERYTHING — named volumes too
 ```
 
-**Warning:** Never run `docker system prune -a --volumes` without confirming with the user. This removes named volumes with potentially important data.
+**Warning:** Never run a volume-destructive command (`docker system prune --volumes`, `docker compose down -v`, `docker volume rm`, `docker volume prune`) without confirming the exact project/context and affected volumes with the user. Named volumes may contain databases, uploads, and other state that cannot be recovered from images.
 
 ## Pitfalls
 

--- a/optional-skills/productivity/shopify/SKILL.md
+++ b/optional-skills/productivity/shopify/SKILL.md
@@ -370,4 +370,4 @@ echo -n "$REQUEST_BODY" | openssl dgst -sha256 -hmac "$APP_SECRET" -binary | bas
 
 ## Safety
 
-Mutations in Shopify are real — they create products, charge refunds, cancel orders, ship fulfillments. Before running `productDelete`, `orderCancel`, `refundCreate`, or any bulk mutation: state clearly what the change is, on which shop, and confirm with the user. There is no staging clone of production data unless the user has a separate dev store.
+Mutations in Shopify are real — they create products, charge refunds, cancel orders, delete customers, overwrite inventory/metafields, and ship fulfillments. Before running `productDelete`, `customerDelete`, `orderCancel`, `refundCreate`, `inventorySetQuantities`, `metafieldsSet` on existing keys, or any bulk mutation: state clearly what changes, on which shop, and which IDs are affected; then confirm with the user. There is no staging clone of production data unless the user has a separate dev store.

--- a/optional-skills/productivity/telephony/SKILL.md
+++ b/optional-skills/productivity/telephony/SKILL.md
@@ -40,8 +40,8 @@ It does **not** turn Hermes into a real-time inbound phone gateway. Inbound SMS 
 
 ## Safety rules — mandatory
 
-1. Always confirm before placing a call or sending a text.
-2. Never dial emergency numbers.
+1. Always preview then confirm before placing a call or sending a text: show the provider, from-number, resolved destination number, message/call script, media URLs, and expected cost/rate limits when available.
+2. Never dial emergency numbers or emergency-like short codes (`911`, `112`, `999`, `000`, `110`, `119`, local short codes). If the destination looks like a short code, stop and ask for a normal phone number.
 3. Never use telephony for harassment, spam, impersonation, or anything illegal.
 4. Treat third-party phone numbers as sensitive operational data:
    - do not save them to Hermes memory

--- a/optional-skills/security/oss-forensics/SKILL.md
+++ b/optional-skills/security/oss-forensics/SKILL.md
@@ -44,7 +44,7 @@ Read these before every investigation step. Violating them invalidates the repor
 4. **No Evidence Fabrication**: The hypothesis validator MUST mechanically check that every cited evidence ID actually exists in the evidence store before accepting a hypothesis.
 5. **Proof-Required Disproval**: A hypothesis cannot be dismissed without a specific, evidence-backed counter-argument. "No evidence found" is not sufficient to disprove—it only makes a hypothesis inconclusive.
 6. **SHA/URL Double-Verification**: Any commit SHA, URL, or external identifier cited as evidence must be independently confirmed from at least two sources before being marked as verified.
-7. **Suspicious Code Rule**: Never run code found inside the investigated repository locally. Analyze statically only, or use `execute_code` in a sandboxed environment.
+7. **Suspicious Code Rule**: Never run code found inside the investigated repository locally. Analyze statically only, or use `execute_code` in a sandboxed environment. Do not trigger package-manager lifecycle scripts, build hooks, tests, Docker builds, or `npm/pnpm/yarn/pip/go/cargo` commands against the suspect tree unless isolated from network and credentials.
 8. **Secret Redaction**: Any API keys, tokens, or credentials discovered during investigation must be redacted in the final report. Log them internally only.
 
 ---

--- a/plugins/google_meet/SKILL.md
+++ b/plugins/google_meet/SKILL.md
@@ -84,7 +84,7 @@ Run `hermes meet setup` to preflight local prereqs.
 ## Flow
 
 1. **Join** — call `meet_join(url=..., mode=..., node=...)`. Returns immediately.
-2. **Announce yourself** — no auto-consent. Say (in whatever channel the user is watching): "A Hermes agent bot is in this call taking notes."
+2. **Announce yourself in the meeting before collecting transcript content** — no auto-consent. In `realtime` mode, say: "A Hermes agent bot is in this call taking notes." In `transcribe` mode, have the user or host announce the bot in the meeting and confirm notice was given.
 3. **Poll** — `meet_status()` for liveness, `meet_transcript(last=20)` for recent captions. Don't re-read the whole transcript every turn.
 4. **Speak (realtime only)** — `meet_say(text="...")` queues text for TTS. The speech lags by ~2s. Don't spam it.
 5. **Leave** — `meet_leave()` when done, or set `duration="30m"` on `meet_join` for auto-leave.
@@ -144,5 +144,6 @@ Remote node: transcript lives on the node host's disk. Use `meet_transcript(node
 
 - URL regex: only `https://meet.google.com/...` URLs pass.
 - No calendar scanning. No auto-dial.
+- Do not read, summarize, or export transcript content until the in-meeting notice step above has completed.
 - Remote nodes use bearer-token auth; tokens are generated on the node (32 hex chars, persisted in `$HERMES_HOME/workspace/meetings/node_token.json`) and must be copied to the gateway via `hermes meet node approve`.
 - `meet_say` text is rate-limited by the OpenAI Realtime session; spam-protection is the bot's problem, not yours, but still — don't queue hundreds of lines.

--- a/skills/apple/imessage/SKILL.md
+++ b/skills/apple/imessage/SKILL.md
@@ -82,10 +82,11 @@ imsg watch --chat-id 1 --attachments
 
 ## Rules
 
-1. **Always confirm recipient and message content** before sending
-2. **Never send to unknown numbers** without explicit user approval
-3. **Verify file paths** exist before attaching
-4. **Don't spam** — rate-limit yourself
+1. **Resolve first, send second** — show phone/chat ID, service, text, and attachments
+2. **Wait for explicit approval of the shown preview** before `imsg send`
+3. **Never send to unknown numbers** unless the user approves the resolved number
+4. **Verify file paths** exist before attaching
+5. **Don't spam** — rate-limit yourself
 
 ## Example Workflow
 

--- a/skills/data-science/jupyter-live-kernel/SKILL.md
+++ b/skills/data-science/jupyter-live-kernel/SKILL.md
@@ -126,8 +126,7 @@ uv run "$SCRIPT" edit --path <notebook.ipynb> delete --cell-id <id> --compact
 
 ### 5. Verification (restart + run all)
 
-Only use when the user asks for a clean verification or you need to confirm
-the notebook runs top-to-bottom:
+Only use when the user explicitly asks for a clean top-to-bottom run and confirms after you show the notebook path and that all cells will execute:
 
 ```
 uv run "$SCRIPT" restart-run-all --path <notebook.ipynb> --save-outputs --compact

--- a/skills/productivity/airtable/SKILL.md
+++ b/skills/productivity/airtable/SKILL.md
@@ -208,7 +208,7 @@ done
 3. **Inspect the schema.** `GET /v0/meta/bases/$BASE_ID/tables` — cache the exact field names and primary-field name locally in the session before mutating anything.
 4. **Read before you write.** For "update X where Y", `filterByFormula` first to resolve the `rec...` ID, then `PATCH /v0/$BASE_ID/$TABLE/$RECORD_ID`. Never guess record IDs.
 5. **Batch writes.** Combine related creates into one 10-record POST to stay under the 5 req/sec budget.
-6. **Destructive ops.** Deletions can't be undone via API. If the user says "delete all Xs", echo back the filter + record count and confirm before firing.
+6. **Destructive ops.** Deletions can't be undone via API. Before any `DELETE` or filter-driven `PATCH`, echo back the filter, resolved `rec...` IDs, primary values, and count; if a singular request matches more than one record, stop.
 
 ## Pitfalls
 

--- a/skills/productivity/google-workspace/SKILL.md
+++ b/skills/productivity/google-workspace/SKILL.md
@@ -310,7 +310,7 @@ All commands return JSON. Parse with `jq` or read directly. Key fields:
 
 ## Rules
 
-1. **Never send email, create/delete calendar events, delete Drive files, share files, or modify Docs/Sheets without confirming with the user first.** Show what will be done (recipients, file IDs, content, share role) and ask for approval. For `drive delete`, prefer the default trash (reversible) over `--permanent`.
+1. **Preview then confirm every write.** Never send email, reply, create/delete calendar events, delete/share Drive files, or modify Docs/Sheets without showing the resolved account, target IDs, recipients/attendees, content/ranges, share role, and destructive/permanent flags first. A request that already contains the target/body is not approval for the eventual API call. For `drive delete`, prefer the default trash (reversible) over `--permanent`.
 2. **Check auth before first use** — run `setup.py --check`. If it fails, guide the user through setup.
 3. **Use the Gmail search syntax reference** for complex queries — load it with `skill_view("google-workspace", file_path="references/gmail-search-syntax.md")`.
 4. **Calendar times must include timezone** — always use ISO 8601 with offset (e.g., `2026-03-01T10:00:00-06:00`) or UTC (`Z`).

--- a/skills/research/research-paper-writing/SKILL.md
+++ b/skills/research/research-paper-writing/SKILL.md
@@ -337,10 +337,12 @@ def doi_to_bibtex(doi: str) -> str:
 If you cannot verify a citation:
 
 ```latex
-\cite{PLACEHOLDER_author2024_verify_this}  % TODO: Verify this citation exists
+[CITATION NEEDED: specific claim or paper]
 ```
 
-**Always tell the scientist**: "I've marked [X] citations as placeholders that need verification."
+Do not create a fake BibTeX key or placeholder `\cite{...}` for an unverified paper; use plain `[CITATION NEEDED: ...]` text until the paper and claim pass verification.
+
+**Always tell the scientist**: "I've marked [X] citations as [CITATION NEEDED] because they need verification."
 
 See [references/citation-workflow.md](references/citation-workflow.md) for complete API documentation and the full `CitationManager` class.
 

--- a/skills/research/research-paper-writing/references/citation-workflow.md
+++ b/skills/research/research-paper-writing/references/citation-workflow.md
@@ -209,6 +209,8 @@ def generate_citation_key(bibtex: str) -> str:
     return f"{first_author.lower()}_{year}_{first_word}"
 ```
 
+If verification fails, leave `[CITATION NEEDED: claim or paper]` in the draft; do not invent a BibTeX record, DOI, venue, year, or citation key.
+
 ---
 
 ## Python Implementation


### PR DESCRIPTION
## What does this PR do?

This updates several skill instructions where the workflow crosses a write, send, execute, or disclosure boundary.

The patch is docs-only. It does not change tool code. It makes the expected behavior more precise:

- Preview a resolved target and exact content before sends or mutations.
- Require approval for that exact preview, not just the original natural-language request.
- Fail closed on unverified citations instead of creating plausible-looking BibTeX placeholders.
- Redact secrets before comic source material is saved into generated artifacts.
- Avoid local execution paths in OSS forensics, including package-manager hooks and build/test commands.

## Related Issue

N/A

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `skills/apple/imessage/SKILL.md`: require resolved destination/body approval before send.
- `skills/productivity/google-workspace/SKILL.md`: require preview of resolved account/target/content before writes.
- `skills/research/research-paper-writing/SKILL.md` and `references/citation-workflow.md`: use `[CITATION NEEDED]` for unverified citations instead of fake citation keys.
- `optional-skills/productivity/telephony/SKILL.md`: require call/text preview approval and block emergency-like short codes.
- `plugins/google_meet/SKILL.md`: require in-meeting notice before transcript use.
- `optional-skills/productivity/shopify/SKILL.md`: cover inventory overwrites, metafield overwrites, customer deletion, and bulk mutations.
- `skills/productivity/airtable/SKILL.md`: require record-ID previews before filtered patch/delete operations.
- `optional-skills/devops/docker-management/SKILL.md`: require confirmation for all volume-destructive commands.
- `optional-skills/creative/baoyu-comic/SKILL.md` and `references/workflow.md`: move secret stripping before source/prompt writes.
- `skills/data-science/jupyter-live-kernel/SKILL.md`: require explicit user request and confirmation before restart-run-all.
- `optional-skills/security/oss-forensics/SKILL.md`: avoid package-manager hooks, builds, tests, and Docker builds against suspect trees outside an isolated sandbox.

## How to Test

1. Review the changed skill instructions listed above.
2. Confirm each write/send/execute/disclosure path names the resolved target/content before approval or fails closed.
3. Run:

```bash
git diff --check origin/main..HEAD
git diff --stat origin/main..HEAD
rg -n "shown preview|resolved account|CITATION NEEDED|volume-destructive|record IDs" \
  skills/apple/imessage/SKILL.md \
  skills/productivity/google-workspace/SKILL.md \
  skills/research/research-paper-writing/SKILL.md \
  skills/research/research-paper-writing/references/citation-workflow.md \
  optional-skills/devops/docker-management/SKILL.md \
  skills/productivity/airtable/SKILL.md
```

Observed locally:

```text
$ git diff --check origin/main..HEAD
# no output

$ git diff --stat origin/main..HEAD
 optional-skills/devops/docker-management/SKILL.md                | 2 +-
 optional-skills/productivity/shopify/SKILL.md                    | 2 +-
 optional-skills/productivity/telephony/SKILL.md                  | 4 ++--
 optional-skills/security/oss-forensics/SKILL.md                  | 2 +-
 plugins/google_meet/SKILL.md                                     | 3 ++-
 skills/apple/imessage/SKILL.md                                   | 9 +++++----
 optional-skills/creative/baoyu-comic/SKILL.md                    | 2 +-
 optional-skills/creative/baoyu-comic/references/workflow.md      | 1 +
 skills/data-science/jupyter-live-kernel/SKILL.md                 | 3 +--
 skills/productivity/airtable/SKILL.md                            | 2 +-
 skills/productivity/google-workspace/SKILL.md                    | 2 +-
 skills/research/research-paper-writing/SKILL.md                  | 6 ++++--
 .../research-paper-writing/references/citation-workflow.md       | 2 ++
 13 files changed, 23 insertions(+), 17 deletions(-)

$ rg -n "shown preview|resolved account|CITATION NEEDED|volume-destructive|record IDs" ...
skills/apple/imessage/SKILL.md:86:2. **Wait for explicit approval of the shown preview** before `imsg send`
skills/productivity/google-workspace/SKILL.md:313:1. **Preview then confirm every write.** Never send email, reply, create/delete calendar events, delete/share Drive files, or modify Docs/Sheets without showing the resolved account, target IDs, recipients/attendees, content/ranges, share role, and destructive/permanent flags first. A request that already contains the target/body is not approval for the eventual API call. For `drive delete`, prefer the default trash (reversible) over `--permanent`.
optional-skills/devops/docker-management/SKILL.md:245:**Warning:** Never run a volume-destructive command (`docker system prune --volumes`, `docker compose down -v`, `docker volume rm`, `docker volume prune`) without confirming the exact project/context and affected volumes with the user. Named volumes may contain databases, uploads, and other state that cannot be recovered from images.
skills/productivity/airtable/SKILL.md:66:| Linked record | `"Owner": ["recXXXXXXXXXXXXXX"]` (array of record IDs) |
skills/productivity/airtable/SKILL.md:209:4. **Read before you write.** For "update X where Y", `filterByFormula` first to resolve the `rec...` ID, then `PATCH /v0/$BASE_ID/$TABLE/$RECORD_ID`. Never guess record IDs.
skills/research/research-paper-writing/references/citation-workflow.md:212:If verification fails, leave `[CITATION NEEDED: claim or paper]` in the draft; do not invent a BibTeX record, DOI, venue, year, or citation key.
skills/research/research-paper-writing/SKILL.md:65:2. **Never hallucinate citations.** AI-generated citations have ~40% error rate. Always fetch programmatically. Mark unverifiable citations as `[CITATION NEEDED]`.
```

### Real behavior proof

I ran this against the patched checkout on branch `skill-safety-gates`; the current rebased commit is `44f69c9b15ee`. The trace uses an isolated `HERMES_HOME` populated from this branch's patched skill files, then loads those skills through Hermes' own skill APIs:

```bash
# temp profile, copied from this checkout:
#   skills/apple/imessage
#   skills/productivity/google-workspace
#   skills/research/research-paper-writing
#   optional-skills/devops/docker-management

HERMES_HOME="$TMP/home" \
HERMES_PROOF_LOG_DIR="$TMP/logs" \
PATH="$TMP/bin:$PATH" \
python3 - <<'PY'
from tools.skills_tool import skill_view
from agent.skill_commands import get_skill_commands, build_skill_invocation_message
# load patched SKILL.md files with skill_view(..., preprocess=False)
# verify slash command loading with build_skill_invocation_message(...)
PY

PYTHONDONTWRITEBYTECODE=1 PYTHONPYCACHEPREFIX=/tmp/hermes-proof-pycache \
  python3 -m pytest -q -o addopts= \
  tests/tools/test_skills_tool.py::TestSkillView::test_view_existing_skill \
  tests/tools/test_skills_tool.py::TestSkillView::test_skill_view_applies_template_vars
```

Loader evidence:

```text
VIEW apple/imessage success=True path=apple/imessage/SKILL.md
MATCH apple/imessage:85: Resolve first, send second
MATCH apple/imessage:86: Wait for explicit approval of the shown preview
VIEW productivity/google-workspace success=True path=productivity/google-workspace/SKILL.md
MATCH productivity/google-workspace:313: Preview then confirm every write
MATCH productivity/google-workspace:313: A request that already contains the target/body is not approval
VIEW research/research-paper-writing success=True path=research/research-paper-writing/SKILL.md
MATCH research/research-paper-writing:340: [CITATION NEEDED: specific claim or paper]
MATCH research/research-paper-writing:343: Do not create a fake BibTeX key
VIEW devops/docker-management success=True path=devops/docker-management/SKILL.md
MATCH devops/docker-management:245: Never run a volume-destructive command
MATCH devops/docker-management:245: confirming the exact project/context and affected volumes
COMMAND /imessage present=True invocation_loaded=True bytes=3081
COMMAND /google-workspace present=True invocation_loaded=True bytes=15375
COMMAND /research-paper-writing present=True invocation_loaded=True bytes=108401
COMMAND /docker-management present=True invocation_loaded=True bytes=11150
```

```text
$ imsg chats --limit 20 --json
[{"displayName": "Mom", "phone": "+1555123456", "service": "iMessage", "chatId": "chat-mom-1"}]
Prompt before send: Found Mom at +1555123456. Send 'I'll be late' via iMessage?

$ gapi contacts list --max 20
[{"name": "Alex Chen", "emails": ["alex@example.com"], "phones": ["+15559876543"]}]
$ gapi gmail search "from:alex@example.com newer_than:7d" --max 10
[{"id": "msg-001", "from": "alex@example.com", "subject": "Schedule", "snippet": "Can we move it to Friday?"}]
Prompt before write: Send email from user@example.com to alex@example.com, subject "Schedule", body "Friday works for me"?

Research citation stop point: [CITATION NEEDED: scaling-law claim or paper]
No fake BibTeX key, DOI, venue, year, or placeholder \cite{...} was created.

$ docker context show
desktop-linux
$ docker volume ls --format {{.Name}}
project_db_data
project_uploads
Prompt before destructive cleanup: Prune volumes in Docker context desktop-linux affecting project_db_data and project_uploads?

Command log:
imsg chats --limit 20 --json
gapi contacts list --max 20
gapi gmail search from:alex@example.com newer_than:7d --max 10
docker context show
docker volume ls --format {{.Name}}

Mutation log:
<empty>

PASS: no imsg send, Google write command, fake citation write, or volume-destructive docker command was executed.
```

Targeted loader tests:

```text
$ PYTHONDONTWRITEBYTECODE=1 PYTHONPYCACHEPREFIX=/tmp/hermes-proof-pycache python3 -m pytest -q -o addopts= tests/tools/test_skills_tool.py::TestSkillView::test_view_existing_skill tests/tools/test_skills_tool.py::TestSkillView::test_skill_view_applies_template_vars
..                                                                       [100%]
2 passed in 1.48s
```

## Risks

- These workflows cross real side-effect boundaries: messages, Google Workspace writes, file sharing/deletion, meeting transcript use, Airtable/Shopify mutations, notebook execution, local forensic commands, and Docker volume cleanup. If approval is not tied to the resolved target/content, an agent can act on the wrong recipient, account, file, record, or command target.
- This PR is instruction-level hardening, not runtime enforcement. Direct tool calls, shell commands, or agents that ignore the skill text can still execute the underlying operation.
- Previewing resolved targets/content can itself expose sensitive details in the conversation. The updated wording keeps the preview focused on the fields needed for approval and adds redaction where the workflow handles source material or private project details.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS, docs-only diff review

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
