### PR TITLE
fix(osv-check): guard json.loads against non-JSON API responses

### DIFF
--- a/tools/osv_check.py
+++ b/tools/osv_check.py
@@ -148,7 +148,11 @@ def _query_osv(
     )
 
     with urllib.request.urlopen(req, timeout=_TIMEOUT) as resp:
-        result = json.loads(resp.read())
+        try:
+            result = json.loads(resp.read())
+        except json.JSONDecodeError:
+            logger.debug("OSV API returned non-JSON response for %s/%s", ecosystem, package)
+            return []
 
     vulns = result.get("vulns", [])
     # Only malware advisories — ignore regular CVEs


### PR DESCRIPTION
## Problem

`_query_osv()` in `tools/osv_check.py` calls `json.loads(resp.read())` without a `try/except` guard. When the OSV API returns a non-JSON response (HTTP 502 HTML page, rate-limit response, or gateway error), this raises `json.JSONDecodeError`.

While the caller already catches `Exception` (fail-open pattern), handling this inside `_query_osv()` provides:
1. A clearer, more specific error message in debug logs
2. Returns the expected `list` type instead of raising
3. Follows the principle of handling errors close to the source

## Fix

Wrap `json.loads(resp.read())` in `try/except json.JSONDecodeError`, log at debug level, and return an empty list.

**Diff:** +5 lines, -1 line (1 file)

## Testing

- Verified syntax: `ast.parse()` passes
- The fix is purely defensive — no behavior change for valid JSON responses
- Fail-open semantics preserved: empty list = no malware found = allow
