### PR TITLE
fix(cli): add --system flag to uv pip install for uv tool installs (#29700)

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -8349,7 +8349,7 @@ def _cmd_update_pip(args):
 
     uv = shutil.which("uv")
     if uv:
-        cmd = [uv, "pip", "install", "--upgrade", "hermes-agent"]
+        cmd = [uv, "pip", "install", "--system", "--upgrade", "hermes-agent"]
     else:
         cmd = [sys.executable, "-m", "pip", "install", "--upgrade", "hermes-agent"]
 


### PR DESCRIPTION
## Summary
Fixes #29700 — `hermes update` fails when Hermes was installed via `uv tool install hermes-agent`.

## Root Cause
When Hermes is installed via `uv tool install`, the `_cmd_update_pip()` function runs `uv pip install --upgrade hermes-agent` without the `--system` flag. This causes:
```
error: No virtual environment found; run `uv venv` to create an environment, or pass `--system` to install into a non-virtual environment
```

## Fix
Add `--system` flag to the uv pip install command so it installs into the system Python environment.

## Testing
`uv pip install --system --upgrade hermes-agent` works correctly on systems where Hermes was installed via `uv tool install`.