### PR TITLE
fix(cli): use `uv tool upgrade` when Hermes is a uv tool install (#29700)

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -319,6 +319,42 @@ def stamp_install_method(method: str) -> None:
         pass
 
 
+def is_uv_tool_install(uv_path: Optional[str] = None) -> bool:
+    """Return True when Hermes is installed via ``uv tool install hermes-agent``.
+
+    ``uv tool`` installs live outside any virtualenv, so ``uv pip install``
+    (the previous update path) fails with ``No virtual environment found``.
+    The fast path inspects ``sys.prefix`` for the standard uv tool layout
+    (``.../uv/tools/hermes-agent/...``); the authoritative fallback shells
+    out to ``uv tool list``. Returns False on any error so callers fall
+    back to the legacy pip path.
+    """
+    prefix = os.path.normpath(sys.prefix).replace(os.sep, "/").lower()
+    if "/uv/tools/hermes-agent/" in prefix + "/":
+        return True
+    if uv_path is None:
+        import shutil
+        uv_path = shutil.which("uv")
+    if not uv_path:
+        return False
+    try:
+        result = subprocess.run(
+            [uv_path, "tool", "list"],
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return False
+    if result.returncode != 0:
+        return False
+    for line in result.stdout.splitlines():
+        tokens = line.strip().split()
+        if tokens and tokens[0] == "hermes-agent":
+            return True
+    return False
+
+
 def recommended_update_command_for_method(method: str) -> str:
     """Return the update command or guidance for a given install method."""
     if method == "nixos":
@@ -331,6 +367,8 @@ def recommended_update_command_for_method(method: str) -> str:
         import shutil
         uv = shutil.which("uv")
         if uv:
+            if is_uv_tool_install(uv):
+                return "uv tool upgrade hermes-agent"
             return "uv pip install --upgrade hermes-agent"
         return "pip install --upgrade hermes-agent"
     return "hermes update"

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -319,39 +319,31 @@ def stamp_install_method(method: str) -> None:
         pass
 
 
-def is_uv_tool_install(uv_path: Optional[str] = None) -> bool:
-    """Return True when Hermes is installed via ``uv tool install hermes-agent``.
+def is_uv_tool_install() -> bool:
+    """Return True when the *running* Hermes lives in a ``uv tool`` layout.
 
-    ``uv tool`` installs live outside any virtualenv, so ``uv pip install``
-    (the previous update path) fails with ``No virtual environment found``.
-    The fast path inspects ``sys.prefix`` for the standard uv tool layout
-    (``.../uv/tools/hermes-agent/...``); the authoritative fallback shells
-    out to ``uv tool list``. Returns False on any error so callers fall
-    back to the legacy pip path.
+    ``uv tool install hermes-agent`` places the install at
+    ``.../uv/tools/hermes-agent/...`` (default ``~/.local/share/uv/tools``,
+    or ``$UV_TOOL_DIR/...``). Such installs live outside any virtualenv, so
+    ``uv pip install`` fails with ``No virtual environment found`` and the
+    update path must use ``uv tool upgrade`` instead.
+
+    Detection is intentionally restricted to properties of the running
+    interpreter (``sys.prefix`` / ``sys.executable``). We deliberately do
+    NOT consult ``uv tool list``: it would also return True when
+    ``hermes-agent`` happens to be uv-tool-installed on the machine while
+    the *active* Hermes is a regular pip/venv install, causing
+    ``hermes update`` to upgrade the wrong copy. It would also block on a
+    subprocess call (~seconds) just to compute a recommendation string.
     """
-    prefix = os.path.normpath(sys.prefix).replace(os.sep, "/").lower()
-    if "/uv/tools/hermes-agent/" in prefix + "/":
+    def _has_uv_tool_marker(path: str) -> bool:
+        norm = os.path.normpath(path).replace(os.sep, "/").lower()
+        return "/uv/tools/hermes-agent/" in norm + "/"
+
+    if _has_uv_tool_marker(sys.prefix):
         return True
-    if uv_path is None:
-        import shutil
-        uv_path = shutil.which("uv")
-    if not uv_path:
-        return False
-    try:
-        result = subprocess.run(
-            [uv_path, "tool", "list"],
-            capture_output=True,
-            text=True,
-            timeout=15,
-        )
-    except (OSError, subprocess.SubprocessError):
-        return False
-    if result.returncode != 0:
-        return False
-    for line in result.stdout.splitlines():
-        tokens = line.strip().split()
-        if tokens and tokens[0] == "hermes-agent":
-            return True
+    if _has_uv_tool_marker(sys.executable or ""):
+        return True
     return False
 
 
@@ -364,11 +356,10 @@ def recommended_update_command_for_method(method: str) -> str:
     if method == "docker":
         return "docker pull nousresearch/hermes-agent:latest"
     if method == "pip":
+        if is_uv_tool_install():
+            return "uv tool upgrade hermes-agent"
         import shutil
-        uv = shutil.which("uv")
-        if uv:
-            if is_uv_tool_install(uv):
-                return "uv tool upgrade hermes-agent"
+        if shutil.which("uv"):
             return "uv pip install --upgrade hermes-agent"
         return "pip install --upgrade hermes-agent"
     return "hermes update"

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -8887,13 +8887,17 @@ def cmd_update(args):
 def _cmd_update_pip(args):
     """Update Hermes via pip (for PyPI installs)."""
     from hermes_cli import __version__
+    from hermes_cli.config import is_uv_tool_install
 
     print(f"→ Current version: {__version__}")
     print("→ Checking PyPI for updates...")
 
     uv = shutil.which("uv")
     if uv:
-        cmd = [uv, "pip", "install", "--upgrade", "hermes-agent"]
+        if is_uv_tool_install(uv):
+            cmd = [uv, "tool", "upgrade", "hermes-agent"]
+        else:
+            cmd = [uv, "pip", "install", "--upgrade", "hermes-agent"]
     else:
         cmd = [sys.executable, "-m", "pip", "install", "--upgrade", "hermes-agent"]
 

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -8893,11 +8893,13 @@ def _cmd_update_pip(args):
     print("→ Checking PyPI for updates...")
 
     uv = shutil.which("uv")
-    if uv:
-        if is_uv_tool_install(uv):
-            cmd = [uv, "tool", "upgrade", "hermes-agent"]
-        else:
-            cmd = [uv, "pip", "install", "--upgrade", "hermes-agent"]
+    if is_uv_tool_install():
+        if not uv:
+            print("✗ Detected a uv-tool install but `uv` is not on PATH; install uv and retry.")
+            sys.exit(1)
+        cmd = [uv, "tool", "upgrade", "hermes-agent"]
+    elif uv:
+        cmd = [uv, "pip", "install", "--upgrade", "hermes-agent"]
     else:
         cmd = [sys.executable, "-m", "pip", "install", "--upgrade", "hermes-agent"]
 

--- a/tests/hermes_cli/test_uv_tool_update.py
+++ b/tests/hermes_cli/test_uv_tool_update.py
@@ -6,6 +6,10 @@ environment found``. ``is_uv_tool_install`` should detect this layout and
 both the user-facing recommended command and the actual
 ``_cmd_update_pip`` subprocess invocation should switch to
 ``uv tool upgrade hermes-agent``.
+
+Detection is restricted to properties of the running interpreter
+(``sys.prefix`` / ``sys.executable``) so a pip/venv install on a machine
+that also has ``uv tool install hermes-agent`` does not get misclassified.
 """
 from __future__ import annotations
 
@@ -26,68 +30,59 @@ class TestIsUvToolInstall:
         from hermes_cli import config
 
         with patch.object(config.sys, "prefix", "/home/user/.local/share/uv/tools/hermes-agent"):
-            assert config.is_uv_tool_install("uv") is True
+            assert config.is_uv_tool_install() is True
 
-    def test_returns_true_when_uv_tool_list_includes_hermes_agent(self):
-        from hermes_cli import config
-
-        completed = subprocess.CompletedProcess(
-            ["uv", "tool", "list"],
-            0,
-            stdout="hermes-agent v0.14.0\n- hermes\n- hermes-bot\nblack v23.0.0\n- black\n",
-            stderr="",
-        )
-        with patch.object(config.sys, "prefix", "/some/unrelated/venv"), \
-             patch("subprocess.run", return_value=completed) as mock_run:
-            assert config.is_uv_tool_install("/usr/local/bin/uv") is True
-            mock_run.assert_called_once()
-            assert mock_run.call_args[0][0] == ["/usr/local/bin/uv", "tool", "list"]
-
-    def test_returns_false_when_uv_tool_list_lacks_hermes_agent(self):
-        from hermes_cli import config
-
-        completed = subprocess.CompletedProcess(
-            ["uv", "tool", "list"], 0, stdout="black v23.0.0\n- black\nruff v0.5.0\n- ruff\n", stderr=""
-        )
-        with patch.object(config.sys, "prefix", "/some/unrelated/venv"), \
-             patch("subprocess.run", return_value=completed):
-            assert config.is_uv_tool_install("uv") is False
-
-    def test_returns_false_when_uv_tool_list_fails(self):
-        from hermes_cli import config
-
-        completed = subprocess.CompletedProcess(["uv", "tool", "list"], 2, stdout="", stderr="oops")
-        with patch.object(config.sys, "prefix", "/some/unrelated/venv"), \
-             patch("subprocess.run", return_value=completed):
-            assert config.is_uv_tool_install("uv") is False
-
-    def test_returns_false_when_subprocess_raises(self):
+    def test_returns_true_when_sys_executable_matches_uv_tool_layout(self):
+        """Some uv-tool layouts surface the marker on ``sys.executable`` (bin/python)."""
         from hermes_cli import config
 
         with patch.object(config.sys, "prefix", "/some/unrelated/venv"), \
-             patch("subprocess.run", side_effect=subprocess.TimeoutExpired(["uv"], 15)):
-            assert config.is_uv_tool_install("uv") is False
+             patch.object(
+                 config.sys,
+                 "executable",
+                 "/home/user/.local/share/uv/tools/hermes-agent/bin/python",
+             ):
+            assert config.is_uv_tool_install() is True
 
-    def test_returns_false_when_no_uv_available(self):
+    def test_returns_false_when_neither_prefix_nor_executable_matches(self):
         from hermes_cli import config
 
         with patch.object(config.sys, "prefix", "/some/unrelated/venv"), \
-             patch("shutil.which", return_value=None):
+             patch.object(config.sys, "executable", "/usr/bin/python3"):
             assert config.is_uv_tool_install() is False
 
-    def test_indented_alias_line_does_not_false_positive(self):
-        """A tool whose alias line is ``- hermes-agent`` shouldn't match."""
+    def test_does_not_consult_uv_tool_list(self):
+        """Detection must NOT shell out: ``uv tool list`` would false-positive
+        when the active install is pip/venv but the machine also has
+        ``uv tool install hermes-agent`` somewhere on disk. Copilot review on
+        PR #29703 flagged this; the fix is to never call ``uv tool list``
+        from the detection path."""
         from hermes_cli import config
 
-        completed = subprocess.CompletedProcess(
-            ["uv", "tool", "list"],
-            0,
-            stdout="some-other-tool v1.0.0\n- hermes-agent\n",
-            stderr="",
-        )
         with patch.object(config.sys, "prefix", "/some/unrelated/venv"), \
-             patch("subprocess.run", return_value=completed):
-            assert config.is_uv_tool_install("uv") is False
+             patch.object(config.sys, "executable", "/usr/bin/python3"), \
+             patch("subprocess.run") as mock_run:
+            assert config.is_uv_tool_install() is False
+            mock_run.assert_not_called()
+
+    def test_case_insensitive_match(self):
+        """Match must be case-insensitive — Windows paths preserve case
+        (e.g. ``...AppData\\Local\\UV\\Tools\\hermes-agent``) and a case-sensitive
+        check would miss them. We exercise the lower-cased compare path here
+        without monkey-patching ``os.sep``, which would break the whole suite."""
+        from hermes_cli import config
+
+        with patch.object(
+            config.sys, "prefix", "/HOME/USER/.local/share/UV/Tools/hermes-agent"
+        ):
+            assert config.is_uv_tool_install() is True
+
+    def test_handles_empty_executable(self):
+        from hermes_cli import config
+
+        with patch.object(config.sys, "prefix", "/some/unrelated/venv"), \
+             patch.object(config.sys, "executable", ""):
+            assert config.is_uv_tool_install() is False
 
 
 # ---------------------------------------------------------------------------
@@ -104,6 +99,16 @@ class TestRecommendedUpdateCommandForUvTool:
             cmd = config.recommended_update_command_for_method("pip")
             assert cmd == "uv tool upgrade hermes-agent"
 
+    def test_uv_tool_install_recommends_uv_tool_upgrade_even_without_uv_on_path(self):
+        """Recommendation reflects the *install method*, not whether ``uv`` is
+        currently on PATH — the user needs to know the right command to run."""
+        from hermes_cli import config
+
+        with patch("shutil.which", return_value=None), \
+             patch.object(config, "is_uv_tool_install", return_value=True):
+            cmd = config.recommended_update_command_for_method("pip")
+            assert cmd == "uv tool upgrade hermes-agent"
+
     def test_uv_pip_install_keeps_legacy_recommendation(self):
         """Existing behavior: uv is on PATH but Hermes is a regular pip install."""
         from hermes_cli import config
@@ -114,11 +119,27 @@ class TestRecommendedUpdateCommandForUvTool:
             assert cmd == "uv pip install --upgrade hermes-agent"
 
     def test_no_uv_falls_back_to_plain_pip(self):
-        from hermes_cli.config import recommended_update_command_for_method
+        from hermes_cli import config
 
-        with patch("shutil.which", return_value=None):
-            cmd = recommended_update_command_for_method("pip")
+        with patch("shutil.which", return_value=None), \
+             patch.object(config, "is_uv_tool_install", return_value=False):
+            cmd = config.recommended_update_command_for_method("pip")
             assert cmd == "pip install --upgrade hermes-agent"
+
+    def test_recommendation_does_not_spawn_subprocess(self):
+        """Computing the recommendation string must be cheap — no ``uv tool list``
+        spawn. Copilot review on PR #29703 flagged the prior subprocess hop
+        as adding overhead and a multi-second timeout window for what is
+        purely a display string."""
+        from hermes_cli import config
+
+        with patch.object(config.sys, "prefix", "/some/unrelated/venv"), \
+             patch.object(config.sys, "executable", "/usr/bin/python3"), \
+             patch("shutil.which", return_value="/usr/local/bin/uv"), \
+             patch("subprocess.run") as mock_run:
+            cmd = config.recommended_update_command_for_method("pip")
+            mock_run.assert_not_called()
+            assert cmd == "uv pip install --upgrade hermes-agent"
 
 
 # ---------------------------------------------------------------------------
@@ -162,7 +183,8 @@ class TestCmdUpdatePipUsesUvTool:
         from hermes_cli.main import _cmd_update_pip
 
         mock_run.return_value = subprocess.CompletedProcess(["pip"], 0, stdout="", stderr="")
-        with patch("shutil.which", return_value=None):
+        with patch("shutil.which", return_value=None), \
+             patch("hermes_cli.config.is_uv_tool_install", return_value=False):
             _cmd_update_pip(SimpleNamespace())
 
         cmd = mock_run.call_args[0][0]
@@ -178,3 +200,18 @@ class TestCmdUpdatePipUsesUvTool:
             with pytest.raises(SystemExit) as exc_info:
                 _cmd_update_pip(SimpleNamespace())
         assert exc_info.value.code == 1
+
+    @patch("subprocess.run")
+    def test_uv_tool_install_without_uv_on_path_exits_with_hint(self, mock_run):
+        """If the running interpreter looks like a uv-tool install but ``uv`` is
+        somehow missing from PATH, surface a clear hint instead of silently
+        falling back to ``python -m pip``, which would either fail (no venv)
+        or upgrade the wrong copy."""
+        from hermes_cli.main import _cmd_update_pip
+
+        with patch("shutil.which", return_value=None), \
+             patch("hermes_cli.config.is_uv_tool_install", return_value=True):
+            with pytest.raises(SystemExit) as exc_info:
+                _cmd_update_pip(SimpleNamespace())
+        assert exc_info.value.code == 1
+        mock_run.assert_not_called()

--- a/tests/hermes_cli/test_uv_tool_update.py
+++ b/tests/hermes_cli/test_uv_tool_update.py
@@ -1,0 +1,180 @@
+"""Tests for uv-tool install detection in the update path (issue #29700).
+
+``uv tool install hermes-agent`` lives outside any venv, so the previous
+``uv pip install --upgrade`` update path failed with ``No virtual
+environment found``. ``is_uv_tool_install`` should detect this layout and
+both the user-facing recommended command and the actual
+``_cmd_update_pip`` subprocess invocation should switch to
+``uv tool upgrade hermes-agent``.
+"""
+from __future__ import annotations
+
+import subprocess
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# is_uv_tool_install
+# ---------------------------------------------------------------------------
+
+
+class TestIsUvToolInstall:
+    def test_returns_true_when_sys_prefix_matches_uv_tool_layout(self):
+        from hermes_cli import config
+
+        with patch.object(config.sys, "prefix", "/home/user/.local/share/uv/tools/hermes-agent"):
+            assert config.is_uv_tool_install("uv") is True
+
+    def test_returns_true_when_uv_tool_list_includes_hermes_agent(self):
+        from hermes_cli import config
+
+        completed = subprocess.CompletedProcess(
+            ["uv", "tool", "list"],
+            0,
+            stdout="hermes-agent v0.14.0\n- hermes\n- hermes-bot\nblack v23.0.0\n- black\n",
+            stderr="",
+        )
+        with patch.object(config.sys, "prefix", "/some/unrelated/venv"), \
+             patch("subprocess.run", return_value=completed) as mock_run:
+            assert config.is_uv_tool_install("/usr/local/bin/uv") is True
+            mock_run.assert_called_once()
+            assert mock_run.call_args[0][0] == ["/usr/local/bin/uv", "tool", "list"]
+
+    def test_returns_false_when_uv_tool_list_lacks_hermes_agent(self):
+        from hermes_cli import config
+
+        completed = subprocess.CompletedProcess(
+            ["uv", "tool", "list"], 0, stdout="black v23.0.0\n- black\nruff v0.5.0\n- ruff\n", stderr=""
+        )
+        with patch.object(config.sys, "prefix", "/some/unrelated/venv"), \
+             patch("subprocess.run", return_value=completed):
+            assert config.is_uv_tool_install("uv") is False
+
+    def test_returns_false_when_uv_tool_list_fails(self):
+        from hermes_cli import config
+
+        completed = subprocess.CompletedProcess(["uv", "tool", "list"], 2, stdout="", stderr="oops")
+        with patch.object(config.sys, "prefix", "/some/unrelated/venv"), \
+             patch("subprocess.run", return_value=completed):
+            assert config.is_uv_tool_install("uv") is False
+
+    def test_returns_false_when_subprocess_raises(self):
+        from hermes_cli import config
+
+        with patch.object(config.sys, "prefix", "/some/unrelated/venv"), \
+             patch("subprocess.run", side_effect=subprocess.TimeoutExpired(["uv"], 15)):
+            assert config.is_uv_tool_install("uv") is False
+
+    def test_returns_false_when_no_uv_available(self):
+        from hermes_cli import config
+
+        with patch.object(config.sys, "prefix", "/some/unrelated/venv"), \
+             patch("shutil.which", return_value=None):
+            assert config.is_uv_tool_install() is False
+
+    def test_indented_alias_line_does_not_false_positive(self):
+        """A tool whose alias line is ``- hermes-agent`` shouldn't match."""
+        from hermes_cli import config
+
+        completed = subprocess.CompletedProcess(
+            ["uv", "tool", "list"],
+            0,
+            stdout="some-other-tool v1.0.0\n- hermes-agent\n",
+            stderr="",
+        )
+        with patch.object(config.sys, "prefix", "/some/unrelated/venv"), \
+             patch("subprocess.run", return_value=completed):
+            assert config.is_uv_tool_install("uv") is False
+
+
+# ---------------------------------------------------------------------------
+# recommended_update_command_for_method
+# ---------------------------------------------------------------------------
+
+
+class TestRecommendedUpdateCommandForUvTool:
+    def test_uv_tool_install_recommends_uv_tool_upgrade(self):
+        from hermes_cli import config
+
+        with patch("shutil.which", return_value="/usr/local/bin/uv"), \
+             patch.object(config, "is_uv_tool_install", return_value=True):
+            cmd = config.recommended_update_command_for_method("pip")
+            assert cmd == "uv tool upgrade hermes-agent"
+
+    def test_uv_pip_install_keeps_legacy_recommendation(self):
+        """Existing behavior: uv is on PATH but Hermes is a regular pip install."""
+        from hermes_cli import config
+
+        with patch("shutil.which", return_value="/usr/local/bin/uv"), \
+             patch.object(config, "is_uv_tool_install", return_value=False):
+            cmd = config.recommended_update_command_for_method("pip")
+            assert cmd == "uv pip install --upgrade hermes-agent"
+
+    def test_no_uv_falls_back_to_plain_pip(self):
+        from hermes_cli.config import recommended_update_command_for_method
+
+        with patch("shutil.which", return_value=None):
+            cmd = recommended_update_command_for_method("pip")
+            assert cmd == "pip install --upgrade hermes-agent"
+
+
+# ---------------------------------------------------------------------------
+# _cmd_update_pip subprocess command
+# ---------------------------------------------------------------------------
+
+
+class TestCmdUpdatePipUsesUvTool:
+    @patch("subprocess.run")
+    def test_runs_uv_tool_upgrade_when_uv_tool_install(self, mock_run):
+        """The actual subprocess invocation must switch to ``uv tool upgrade``."""
+        from hermes_cli.main import _cmd_update_pip
+
+        mock_run.return_value = subprocess.CompletedProcess(["uv"], 0, stdout="", stderr="")
+        with patch("shutil.which", return_value="/usr/local/bin/uv"), \
+             patch("hermes_cli.config.is_uv_tool_install", return_value=True):
+            _cmd_update_pip(SimpleNamespace())
+
+        assert mock_run.call_args[0][0] == ["/usr/local/bin/uv", "tool", "upgrade", "hermes-agent"]
+
+    @patch("subprocess.run")
+    def test_runs_uv_pip_install_when_not_uv_tool(self, mock_run):
+        """Existing behavior preserved when uv is present but Hermes isn't a tool install."""
+        from hermes_cli.main import _cmd_update_pip
+
+        mock_run.return_value = subprocess.CompletedProcess(["uv"], 0, stdout="", stderr="")
+        with patch("shutil.which", return_value="/usr/local/bin/uv"), \
+             patch("hermes_cli.config.is_uv_tool_install", return_value=False):
+            _cmd_update_pip(SimpleNamespace())
+
+        assert mock_run.call_args[0][0] == [
+            "/usr/local/bin/uv",
+            "pip",
+            "install",
+            "--upgrade",
+            "hermes-agent",
+        ]
+
+    @patch("subprocess.run")
+    def test_falls_back_to_pip_when_no_uv(self, mock_run):
+        from hermes_cli.main import _cmd_update_pip
+
+        mock_run.return_value = subprocess.CompletedProcess(["pip"], 0, stdout="", stderr="")
+        with patch("shutil.which", return_value=None):
+            _cmd_update_pip(SimpleNamespace())
+
+        cmd = mock_run.call_args[0][0]
+        assert cmd[1:] == ["-m", "pip", "install", "--upgrade", "hermes-agent"]
+
+    @patch("subprocess.run")
+    def test_exits_nonzero_on_subprocess_failure(self, mock_run):
+        from hermes_cli.main import _cmd_update_pip
+
+        mock_run.return_value = subprocess.CompletedProcess(["uv"], 1, stdout="", stderr="")
+        with patch("shutil.which", return_value="/usr/local/bin/uv"), \
+             patch("hermes_cli.config.is_uv_tool_install", return_value=True):
+            with pytest.raises(SystemExit) as exc_info:
+                _cmd_update_pip(SimpleNamespace())
+        assert exc_info.value.code == 1


### PR DESCRIPTION
## What does this PR do?

`hermes update` fails on machines where Hermes was installed via `uv tool install hermes-agent`. The previous `_cmd_update_pip` runs `uv pip install --upgrade hermes-agent`, which errors with `No virtual environment found; run uv venv ...` because `uv tool` installs live outside any venv. The fix detects the `uv tool` layout and runs `uv tool upgrade hermes-agent` instead. Mirrors the install-method resolver in `hermes_cli.config.detect_install_method`: a new helper `is_uv_tool_install` checks `sys.prefix` for the standard `uv/tools/hermes-agent/` path first (free, deterministic), then falls back to `uv tool list` for non-standard prefixes. Both `_cmd_update_pip` and `recommended_update_command_for_method("pip")` consult the same helper so the user-facing recommendation and the actual subprocess call stay aligned.

## Related Issue

Fixes #29700

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/config.py` — added `is_uv_tool_install(uv_path=None)` helper and routed `recommended_update_command_for_method("pip")` through it. Detection: `sys.prefix` containing `/uv/tools/hermes-agent/` (fast path); falls back to `uv tool list` parsing. Returns `False` (legacy path) on any error.
- `hermes_cli/main.py` — `_cmd_update_pip` now invokes `[uv, "tool", "upgrade", "hermes-agent"]` when `is_uv_tool_install` is `True`; otherwise the original `uv pip install` and `pip install` commands are unchanged.
- `tests/hermes_cli/test_uv_tool_update.py` — 14 new tests covering: prefix-path detection, `uv tool list` parsing (positive and negative), subprocess failure modes (non-zero exit, timeout), missing `uv` on PATH, indented-alias false-positive guard, both branches of `recommended_update_command_for_method`, and both branches of the `_cmd_update_pip` subprocess invocation including the exit-on-failure path.

## How to Test

1. On a machine where `hermes-agent` was installed via `uv tool install hermes-agent`, run `hermes update`. Before this PR: errors with `No virtual environment found`. After: runs `uv tool upgrade hermes-agent`.
2. Focused tests: `uv run --with pytest --with pytest-xdist --with pytest-asyncio --with pytest-timeout python3 -m pytest tests/hermes_cli/test_uv_tool_update.py -v` — 14 pass.
3. Regression: `... tests/hermes_cli/test_pip_install_detection.py tests/hermes_cli/test_cmd_update.py tests/hermes_cli/test_managed_installs.py tests/hermes_cli/test_banner_pip_update.py -v` — 26 pass, no regressions.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run focused tests for the touched code and all pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.x

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; the helper is self-documenting and not part of the public API surface.
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A; no new config keys.
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A.
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — the `sys.prefix` check normalizes separators with `os.sep` → `/`, and `uv tool list` output format is identical across platforms.
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A.

## For New Skills

_N/A._

## Salvage / Widening

> Sibling code paths that may need the same fix: `hermes_cli.config.detect_install_method` could grow a `"uv-tool"` return value, and installers (`scripts/install.sh` / `install.ps1`) could stamp `~/.hermes/.install_method` with `uv-tool` for explicit detection. Intentionally left out of this PR's scope to keep the diff small and the runtime fix immediately available — happy to widen if preferred.