### PR TITLE
feat(config): add per-model max_tokens overlay

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1149,32 +1149,51 @@ def init_agent(
             _aux_context_config = None
     agent._aux_compression_context_length_config = _aux_context_config
 
+    def _parse_config_max_tokens(raw_value, config_path: str) -> int | None:
+        if raw_value is None:
+            return None
+        try:
+            if isinstance(raw_value, bool):
+                raise ValueError
+            parsed = int(raw_value)
+            if parsed <= 0:
+                raise ValueError
+            return parsed
+        except (TypeError, ValueError):
+            _ra().logger.warning(
+                "Invalid %s in config.yaml: %r — "
+                "must be a positive integer (e.g. 4096). "
+                "Falling back to the next max_tokens default.",
+                config_path,
+                raw_value,
+            )
+            print(
+                f"\n⚠ Invalid {config_path} in config.yaml: {raw_value!r}\n"
+                f"  Must be a positive integer (e.g. 4096).\n"
+                f"  Falling back to the next max_tokens default.\n",
+                file=sys.stderr,
+            )
+            return None
+
     # Read explicit model output-token override from config when the
-    # caller did not pass one directly.
+    # caller did not pass one directly. Per-model overlays let one profile
+    # switch between models with different output ceilings without changing
+    # the flat fallback.
     _model_cfg = _agent_cfg.get("model", {})
     if agent.max_tokens is None and isinstance(_model_cfg, dict):
-        _config_max_tokens = _model_cfg.get("max_tokens")
-        if _config_max_tokens is not None:
-            try:
-                if isinstance(_config_max_tokens, bool):
-                    raise ValueError
-                _parsed_max_tokens = int(_config_max_tokens)
-                if _parsed_max_tokens <= 0:
-                    raise ValueError
-                agent.max_tokens = _parsed_max_tokens
-            except (TypeError, ValueError):
-                _ra().logger.warning(
-                    "Invalid model.max_tokens in config.yaml: %r — "
-                    "must be a positive integer (e.g. 4096). "
-                    "Falling back to provider default.",
-                    _config_max_tokens,
+        _models_cfg = _model_cfg.get("models")
+        if isinstance(_models_cfg, dict):
+            _model_overlay = _models_cfg.get(agent.model)
+            if isinstance(_model_overlay, dict) and "max_tokens" in _model_overlay:
+                agent.max_tokens = _parse_config_max_tokens(
+                    _model_overlay.get("max_tokens"),
+                    f"model.models.{agent.model}.max_tokens",
                 )
-                print(
-                    f"\n⚠ Invalid model.max_tokens in config.yaml: {_config_max_tokens!r}\n"
-                    f"  Must be a positive integer (e.g. 4096).\n"
-                    f"  Falling back to provider default.\n",
-                    file=sys.stderr,
-                )
+        if agent.max_tokens is None:
+            agent.max_tokens = _parse_config_max_tokens(
+                _model_cfg.get("max_tokens"),
+                "model.max_tokens",
+            )
     agent._session_init_model_config["max_tokens"] = agent.max_tokens
 
     # Read explicit context_length override from model config

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -73,6 +73,17 @@ model:
   #
 # max_tokens: 8192
 
+  # Per-model overrides for profile-global model settings. These are useful
+  # when one profile switches between models with different output ceilings.
+  # The active model's max_tokens wins over the flat model.max_tokens above;
+  # unmatched models keep using the flat value or the provider default.
+  #
+  # models:
+  #   anthropic/claude-opus-4.6:
+  #     max_tokens: 32768
+  #   gpt-5.5:
+  #     max_tokens: 65536
+
 # Named provider overrides (optional)
 # Use this for per-provider request timeouts, non-stream stale timeouts,
 # and per-model exceptions.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -14637,6 +14637,7 @@ class GatewayRunner:
     _CACHE_BUSTING_CONFIG_KEYS: tuple = (
         ("model", "context_length"),
         ("model", "max_tokens"),
+        ("model", "models"),
         ("compression", "enabled"),
         ("compression", "threshold"),
         ("compression", "target_ratio"),

--- a/tests/gateway/test_agent_cache.py
+++ b/tests/gateway/test_agent_cache.py
@@ -142,6 +142,21 @@ class TestAgentConfigSignature:
         )
         assert sig1 != sig2
 
+    def test_model_models_change_busts_cache(self):
+        """Editing model.models overlays must produce a new signature."""
+        from gateway.run import GatewayRunner
+
+        runtime = {"api_key": "k", "base_url": "u", "provider": "p"}
+        sig1 = GatewayRunner._agent_config_signature(
+            "m", runtime, [], "",
+            cache_keys={"model.models": {"m": {"max_tokens": 4096}}},
+        )
+        sig2 = GatewayRunner._agent_config_signature(
+            "m", runtime, [], "",
+            cache_keys={"model.models": {"m": {"max_tokens": 8192}}},
+        )
+        assert sig1 != sig2
+
     def test_compression_threshold_change_busts_cache(self):
         from gateway.run import GatewayRunner
 
@@ -214,12 +229,14 @@ class TestExtractCacheBustingConfig:
                 "model": {
                     "context_length": 272_000,
                     "max_tokens": 4096,
+                    "models": {"gpt-5.5": {"max_tokens": 65536}},
                     "provider": "openrouter",
                 }
             }
         )
         assert out["model.context_length"] == 272_000
         assert out["model.max_tokens"] == 4096
+        assert out["model.models"] == {"gpt-5.5": {"max_tokens": 65536}}
 
     def test_reads_compression_subkeys(self):
         from gateway.run import GatewayRunner

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -813,6 +813,96 @@ class TestInit:
         assert a.max_tokens == 4096
         assert kwargs["max_tokens"] == 4096
 
+    def test_model_models_max_tokens_overlay_wins(self):
+        """model.models.<active>.max_tokens overrides the flat fallback."""
+        with (
+            patch("run_agent.get_tool_definitions", return_value=_make_tool_defs("terminal")),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+            patch(
+                "hermes_cli.config.load_config",
+                return_value={
+                    "model": {
+                        "max_tokens": 4096,
+                        "models": {
+                            "claude-opus-4-6-thinking": {"max_tokens": 8192},
+                            "gpt-5.5": {"max_tokens": 65536},
+                        },
+                    }
+                },
+            ),
+        ):
+            a = AIAgent(
+                api_key="test-k...7890",
+                provider="custom",
+                model="claude-opus-4-6-thinking",
+                base_url="http://proxy.example/v1",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+            )
+
+            kwargs = a._build_api_kwargs([{"role": "user", "content": "Hi"}])
+
+        assert a.max_tokens == 8192
+        assert kwargs["max_tokens"] == 8192
+
+    def test_model_models_max_tokens_overlay_falls_back_when_unmatched(self):
+        """Unmatched per-model entries leave model.max_tokens behavior unchanged."""
+        with (
+            patch("run_agent.get_tool_definitions", return_value=[]),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+            patch(
+                "hermes_cli.config.load_config",
+                return_value={
+                    "model": {
+                        "max_tokens": 4096,
+                        "models": {"gpt-5.5": {"max_tokens": 65536}},
+                    }
+                },
+            ),
+        ):
+            a = AIAgent(
+                api_key="test-k...7890",
+                provider="custom",
+                model="claude-opus-4-6-thinking",
+                base_url="http://proxy.example/v1",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+            )
+
+        assert a.max_tokens == 4096
+
+    def test_model_models_invalid_max_tokens_falls_back_to_flat(self):
+        """Invalid per-model max_tokens warns and uses model.max_tokens."""
+        with (
+            patch("run_agent.get_tool_definitions", return_value=[]),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+            patch(
+                "hermes_cli.config.load_config",
+                return_value={
+                    "model": {
+                        "max_tokens": 4096,
+                        "models": {"claude-opus-4-6-thinking": {"max_tokens": "64K"}},
+                    }
+                },
+            ),
+        ):
+            a = AIAgent(
+                api_key="test-k...7890",
+                provider="custom",
+                model="claude-opus-4-6-thinking",
+                base_url="http://proxy.example/v1",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+            )
+
+        assert a.max_tokens == 4096
+
     def test_constructor_max_tokens_wins_over_config(self):
         """Explicit constructor max_tokens keeps programmatic callers stable."""
         with (


### PR DESCRIPTION
If you use providers like openrouter, bedrock the single max_token setting isn't enough. It needs to be dynamic based on the model.

## Summary

Adds a `model.models.<id>.max_tokens` overlay so a single profile can switch between models with different output-token ceilings without mutating the flat `model.max_tokens` fallback.

```yaml
model:
  default: anthropic/claude-opus-4.6
  max_tokens: 8192              # fallback for unmatched models
  models:
    anthropic/claude-opus-4.6:
      max_tokens: 32768
    gpt-5.5:
      max_tokens: 65536
```

Resolution order is:

1. Explicit constructor/programmatic `max_tokens`
2. `model.models.<active_model>.max_tokens`
3. Flat `model.max_tokens`
4. Provider/model default

## Why this is not a duplicate

Related PRs solve adjacent scopes, but not this specific config shape:

- #24495 establishes the same `model.models.<id>` overlay pattern for `context_length` and `provider_routing`, and explicitly notes `max_tokens` as a natural future extension. This PR is that focused extension for output-token caps.
- #28142 / #28786 target `custom_providers[].models.<model>.max_tokens`, which helps custom-provider entries but not built-in providers like Bedrock/Anthropic/OpenAI or normal model switching within one profile.
- #20769 covers flat/global `model.max_tokens` propagation, but not per-active-model overrides.

## Changes

- `agent/agent_init.py`: resolve `model.models.<active>.max_tokens` before flat `model.max_tokens`, preserving constructor precedence and positive-int validation.
- `gateway/run.py`: include `model.models` in gateway agent cache-busting keys so edits to overlays rebuild cached agents.
- `cli-config.yaml.example`: document the per-model output-token overlay.
- Tests cover override wins, unmatched fallback, invalid per-model fallback, constructor precedence, and gateway cache invalidation.
