### PR TITLE
fix(cli): use 'uv tool upgrade' when hermes was installed via 'uv tool install' (#29700)

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -8720,7 +8720,26 @@ def _cmd_update_pip(args):
 
     uv = shutil.which("uv")
     if uv:
-        cmd = [uv, "pip", "install", "--upgrade", "hermes-agent"]
+        # Detect whether hermes-agent was installed via `uv tool install`.
+        # `uv pip install --upgrade` requires an active virtual environment,
+        # but `uv tool install` installs into an isolated tool environment
+        # with no activatable venv.  In that case we must use
+        # `uv tool upgrade hermes-agent` instead.
+        try:
+            tool_list = subprocess.run(
+                [uv, "tool", "list"],
+                capture_output=True,
+                text=True,
+                timeout=15,
+            )
+            is_uv_tool = tool_list.returncode == 0 and "hermes-agent" in tool_list.stdout
+        except (OSError, subprocess.TimeoutExpired):
+            is_uv_tool = False
+
+        if is_uv_tool:
+            cmd = [uv, "tool", "upgrade", "hermes-agent"]
+        else:
+            cmd = [uv, "pip", "install", "--upgrade", "hermes-agent"]
     else:
         cmd = [sys.executable, "-m", "pip", "install", "--upgrade", "hermes-agent"]
 

--- a/tests/hermes_cli/test_cmd_update_pip_uv_tool.py
+++ b/tests/hermes_cli/test_cmd_update_pip_uv_tool.py
@@ -1,0 +1,122 @@
+"""Tests for _cmd_update_pip uv-tool-install detection (issue #29700).
+
+When Hermes is installed via `uv tool install hermes-agent`, the update
+command must use `uv tool upgrade hermes-agent` instead of
+`uv pip install --upgrade hermes-agent`, which requires an active venv.
+"""
+import subprocess
+import sys
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch, call
+
+import pytest
+
+
+# Import the function under test; guard against heavy import side-effects
+# by patching print during module load.
+def _get_cmd_update_pip():
+    from hermes_cli.main import _cmd_update_pip
+    return _cmd_update_pip
+
+
+class TestCmdUpdatePipUvToolDetection:
+    """_cmd_update_pip routes to the correct uv sub-command."""
+
+    def _run(self, uv_path, tool_list_output, tool_list_rc=0, update_rc=0):
+        """Helper: run _cmd_update_pip with controlled subprocess outcomes."""
+        fn = _get_cmd_update_pip()
+
+        tool_list_result = SimpleNamespace(
+            returncode=tool_list_rc,
+            stdout=tool_list_output,
+            stderr="",
+        )
+        update_result = SimpleNamespace(returncode=update_rc)
+
+        captured_cmds = []
+
+        def fake_run(cmd, *args, **kwargs):
+            captured_cmds.append(cmd)
+            if kwargs.get("capture_output"):
+                return tool_list_result
+            return update_result
+
+        with patch("shutil.which", return_value=uv_path), \
+             patch("subprocess.run", side_effect=fake_run), \
+             patch("hermes_cli.main.__version__", "0.14.0", create=True), \
+             patch("builtins.print"):
+            fn(SimpleNamespace())
+
+        return captured_cmds
+
+    def test_uv_tool_install_uses_uv_tool_upgrade(self):
+        """When hermes-agent appears in `uv tool list`, use `uv tool upgrade`."""
+        cmds = self._run(
+            uv_path="/usr/bin/uv",
+            tool_list_output="hermes-agent v0.14.0\n",
+        )
+        # First call: tool list probe; second call: the actual upgrade
+        assert len(cmds) == 2
+        assert cmds[0] == ["/usr/bin/uv", "tool", "list"]
+        assert cmds[1] == ["/usr/bin/uv", "tool", "upgrade", "hermes-agent"]
+
+    def test_no_uv_tool_install_uses_uv_pip(self):
+        """When hermes-agent is NOT in `uv tool list`, fall back to uv pip."""
+        cmds = self._run(
+            uv_path="/usr/bin/uv",
+            tool_list_output="some-other-tool v1.0\n",
+        )
+        assert len(cmds) == 2
+        assert cmds[0] == ["/usr/bin/uv", "tool", "list"]
+        assert cmds[1] == ["/usr/bin/uv", "pip", "install", "--upgrade", "hermes-agent"]
+
+    def test_tool_list_failure_falls_back_to_uv_pip(self):
+        """If `uv tool list` exits non-zero, still fall back to uv pip."""
+        cmds = self._run(
+            uv_path="/usr/bin/uv",
+            tool_list_output="",
+            tool_list_rc=1,
+        )
+        assert cmds[-1] == ["/usr/bin/uv", "pip", "install", "--upgrade", "hermes-agent"]
+
+    def test_no_uv_falls_back_to_pip_module(self):
+        """When uv is not installed at all, use sys.executable -m pip."""
+        fn = _get_cmd_update_pip()
+        update_result = SimpleNamespace(returncode=0)
+        captured_cmds = []
+
+        def fake_run(cmd, *args, **kwargs):
+            captured_cmds.append(cmd)
+            return update_result
+
+        with patch("shutil.which", return_value=None), \
+             patch("subprocess.run", side_effect=fake_run), \
+             patch("hermes_cli.main.__version__", "0.14.0", create=True), \
+             patch("builtins.print"):
+            fn(SimpleNamespace())
+
+        assert len(captured_cmds) == 1
+        assert captured_cmds[0] == [sys.executable, "-m", "pip", "install", "--upgrade", "hermes-agent"]
+
+    def test_tool_list_timeout_falls_back_to_uv_pip(self):
+        """TimeoutExpired during `uv tool list` should fall back to uv pip."""
+        fn = _get_cmd_update_pip()
+        update_result = SimpleNamespace(returncode=0)
+        captured_cmds = []
+        call_count = 0
+
+        def fake_run(cmd, *args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if kwargs.get("capture_output"):
+                raise subprocess.TimeoutExpired(cmd, 15)
+            captured_cmds.append(cmd)
+            return update_result
+
+        with patch("shutil.which", return_value="/usr/bin/uv"), \
+             patch("subprocess.run", side_effect=fake_run), \
+             patch("hermes_cli.main.__version__", "0.14.0", create=True), \
+             patch("builtins.print"):
+            fn(SimpleNamespace())
+
+        assert captured_cmds == [["/usr/bin/uv", "pip", "install", "--upgrade", "hermes-agent"]]


### PR DESCRIPTION
## Summary

Fixes `hermes update` on systems where Hermes was installed via `uv tool install hermes-agent` (the standard install script).

## Root cause

`_cmd_update_pip()` always uses `uv pip install --upgrade hermes-agent` when `uv` is found. But `uv pip install` requires an active virtual environment, and `uv tool install` installs into an isolated tool environment — no activatable venv exists. The result:

```
→ Running: /home/user/.local/bin/uv pip install --upgrade hermes-agent
error: No virtual environment found; run `uv venv` to create an environment,
or pass --system to install into a non-virtual environment
✗ Update failed
```

## Fix

Before choosing the update command, probe `uv tool list` to detect the install method:

```python
tool_list = subprocess.run([uv, "tool", "list"], capture_output=True, text=True, timeout=15)
is_uv_tool = tool_list.returncode == 0 and "hermes-agent" in tool_list.stdout

if is_uv_tool:
    cmd = [uv, "tool", "upgrade", "hermes-agent"]   # correct for tool installs
else:
    cmd = [uv, "pip", "install", "--upgrade", "hermes-agent"]  # existing path
```

Fallback chain preserved: if `uv tool list` fails or times out (15 s), the prior `uv pip install` path is used. If `uv` isn't on PATH at all, `sys.executable -m pip` is used (unchanged).

The probe adds ~50 ms on the fast path (`uv tool list` has no network I/O).

## Tests

New file `tests/hermes_cli/test_cmd_update_pip_uv_tool.py` — 5 cases:

| Test | Asserts |
|------|---------|
| `test_uv_tool_install_uses_uv_tool_upgrade` | hermes-agent in tool list → `uv tool upgrade` |
| `test_no_uv_tool_install_uses_uv_pip` | not in tool list → `uv pip install` |
| `test_tool_list_failure_falls_back_to_uv_pip` | tool list rc!=0 → `uv pip install` |
| `test_tool_list_timeout_falls_back_to_uv_pip` | TimeoutExpired → `uv pip install` |
| `test_no_uv_falls_back_to_pip_module` | no uv → `sys.executable -m pip` |

```
5 passed in 1.52s
```

Fixes #29700