### PR TITLE
fix(tests): update plugin count to eight and add xai to expected providers

### DIFF
--- a/tests/plugins/web/test_web_search_provider_plugins.py
+++ b/tests/plugins/web/test_web_search_provider_plugins.py
@@ -2,7 +2,7 @@
 
 Covers:
 
-- All seven bundled plugins (brave-free, ddgs, searxng, exa, parallel,
+- All eight bundled plugins (brave-free, ddgs, searxng, exa, parallel,
   tavily, firecrawl) instantiate and self-report the expected
   capabilities + ABC-derived defaults.
 - Each plugin's ``is_available()`` correctly reflects env-var presence.
@@ -70,9 +70,9 @@ def _isolate_env(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 class TestBundledPluginsRegister:
-    """All seven bundled web plugins discover and register correctly."""
+    """All eight bundled web plugins discover and register correctly."""
 
-    def test_all_seven_plugins_present_in_registry(self) -> None:
+    def test_all_eight_plugins_present_in_registry(self) -> None:
         _ensure_plugins_loaded()
         from agent.web_search_registry import list_providers
 
@@ -85,6 +85,7 @@ class TestBundledPluginsRegister:
             "parallel",
             "searxng",
             "tavily",
+            "xai",
         ]
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
## What does this PR do?

This PR fixes two pre-existing test failures on the `main` branch:

1. **`test_all_seven_plugins_present_in_registry`** — The `xai` web search provider was added to the registry but the test was never updated. The test is renamed to `test_all_eight_plugins_present_in_registry` and `"xai"` is added to the expected provider list.

## Related Issue

Fixes pre-existing test failures on `main` (no dedicated issue — these were uncovered while validating PR #27716).

## Type of Change

- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `tests/plugins/web/test_web_search_provider_plugins.py`:
  - Renamed `test_all_seven_plugins_present_in_registry` → `test_all_eight_plugins_present_in_registry`
  - Added `"xai"` to the sorted expected provider list
  - Updated docstrings from "seven" to "eight"

## How to Test

1. Run `pytest tests/plugins/web/test_web_search_provider_plugins.py::TestBundledPluginsRegister::test_all_eight_plugins_present_in_registry -xvs`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(tests): update plugin count to eight and add xai to expected providers`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/plugins/web/test_web_search_provider_plugins.py::TestBundledPluginsRegister::test_all_eight_plugins_present_in_registry tests/hermes_cli/test_update_hangup_protection.py::TestInstallHangupProtection::test_wraps_stdout_and_stderr_with_mirror -v` and all tests pass
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] N/A — test-only changes, no documentation or config updates needed

## Screenshots / Logs

```
tests/plugins/web/test_web_search_provider_plugins.py::TestBundledPluginsRegister::test_all_eight_plugins_present_in_registry PASSED
```
