### PR TITLE
fix(gateway): include html in MEDIA: extraction allowlist

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2159,7 +2159,7 @@ class BasePlatformAdapter(ABC):
         # Extract MEDIA:<path> tags, allowing optional whitespace after the colon
         # and quoted/backticked paths for LLM-formatted outputs.
         media_pattern = re.compile(
-            r'''[`"']?MEDIA:\s*(?P<path>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|(?:~/|/)\S+(?:[^\S\n]+\S+)*?\.(?:png|jpe?g|gif|webp|mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|flac|epub|pdf|zip|rar|7z|docx?|xlsx?|pptx?|txt|csv|apk|ipa)(?=[\s`"',;:)\]}]|$))[`"']?'''
+            r'''[`"']?MEDIA:\s*(?P<path>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|(?:~/|/)\S+(?:[^\S\n]+\S+)*?\.(?:png|jpe?g|gif|webp|mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|flac|epub|pdf|zip|rar|7z|docx?|xlsx?|pptx?|txt|csv|html?|apk|ipa)(?=[\s`"',;:)\]}]|$))[`"']?'''
         )
         for match in media_pattern.finditer(content):
             path = match.group("path").strip()

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -16520,7 +16520,7 @@ class GatewayRunner:
                             r'MEDIA:((?:/|~\/)\S+\.(?:png|jpe?g|gif|webp|'
                             r'mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|'
                             r'flac|epub|pdf|zip|rar|7z|docx?|xlsx?|pptx?|'
-                            r'txt|csv|apk|ipa))',
+                            r'txt|csv|html?|apk|ipa))',
                             re.IGNORECASE
                         )
                         for _match in _TOOL_MEDIA_RE.finditer(_hc):
@@ -16816,7 +16816,7 @@ class GatewayRunner:
                                 r'MEDIA:((?:/|~\/)\S+\.(?:png|jpe?g|gif|webp|'
                                 r'mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|'
                                 r'flac|epub|pdf|zip|rar|7z|docx?|xlsx?|pptx?|'
-                                r'txt|csv|apk|ipa))',
+                                r'txt|csv|html?|apk|ipa))',
                                 re.IGNORECASE
                             )
                             for match in _TOOL_MEDIA_RE.finditer(content):

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -329,6 +329,12 @@ class TestExtractMedia:
         assert media == [("/tmp/Jane Doe/speech.flac", False)]
         assert cleaned == ""
 
+    def test_media_tag_extracts_html_and_htm_paths(self):
+        for path in ("/tmp/report.html", "/tmp/page.htm"):
+            media, cleaned = BasePlatformAdapter.extract_media(f"MEDIA:{path}")
+            assert media == [(path, False)]
+            assert cleaned == ""
+
     def test_as_document_directive_stripped_from_cleaned_text(self):
         """[[as_document]] is a routing directive — strip it from
         user-visible text just like [[audio_as_voice]]. Callers detect the


### PR DESCRIPTION
## What does this PR do?

After `ea49b3862` (`fix(gateway): tighten MEDIA extraction regex...`) removed the `|\S+` fallback, the explicit extension allowlist became the only path for `MEDIA:` tag delivery. `.html` and `.htm` were never on that list — but they *are* in `_LOCAL_MEDIA_EXTS` (used by `extract_local_files`), so the two delivery pathways drifted out of sync.

Visible symptom: an agent emits `MEDIA: /tmp/report.html`, the tag is silently stripped from user-visible text by the cleanup `re.sub(r"MEDIA:\s*\S+", "", ...)` at `gateway/platforms/base.py:3175`, but the file is never delivered. The bare-path detector that *does* know about `.html` runs after the strip, on text that no longer contains the path. I hit this on Telegram; #29582 hit it on WeChat. The code is platform-agnostic (lives on `BasePlatformAdapter` and in the gateway runner), so every adapter is affected.

This patch adds `html?` to the three regex allowlists so the `MEDIA:` tag path matches what `_LOCAL_MEDIA_EXTS` already supports.

## Related Issue

Fixes #29582

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/base.py` — `html?` added to `extract_media()` `MEDIA:` regex (used by the gateway response loop).
- `gateway/run.py` (×2) — `html?` added to the two `_TOOL_MEDIA_RE` patterns at lines 16523 and 16819 (used by the agent loop to dedupe and collect `MEDIA:` paths emitted *inside tool/function results*, e.g. an MCP tool returning `MEDIA:/tmp/foo.html` in its JSON output).
- `tests/gateway/test_platform_base.py` — regression test asserting `.html` and `.htm` paths are extracted by `BasePlatformAdapter.extract_media`.

## Relationship to other open PRs

A couple of friendly in-flight PRs target the same issue. To save reviewer time and avoid duplication, here's how this one differs — happy to defer to either if preferred:

- **#29592 (@LeonSGP43)** patches `gateway/platforms/base.py:2162` (the adapter's response-text extractor). The same regression also lives in `gateway/run.py:16523` and `gateway/run.py:16819` — both were introduced by the same `ea49b3862` tightening commit and inherit the same missing `.html` entry. Those two regexes are used inside the agent loop to dedupe and collect `MEDIA:` paths from tool/function results (independent of the adapter path), so #29592 will still leave tool-emitted `MEDIA:/tmp/foo.html` paths dropped on the floor. This PR patches all three sites.
- **#29609 (@chenglyes)** is a cleaner long-term fix — derive the `MEDIA:` allowlist dynamically from `SUPPORTED_DOCUMENT_TYPES` so this kind of drift can't recur. If you're happy to merge that, please go with #29609 — this PR becomes redundant and I'll close it. This PR is the minimal three-spot patch for the case where a refactor is out of scope right now.
- For context: #28973 (@sebastiannicolas-analytia) was closed by @alt-glitch as a duplicate of #22492 / #24384 / #24049. That PR was identical in spirit to #29592 but only touched `base.py`. The `run.py` sites are the new substance here.

@alt-glitch — flagging you since you've been triaging the duplicate cluster. Happy to close immediately or rebase onto whichever path you prefer; just wanted the run.py gap visible somewhere so it doesn't get lost.

## How to Test

1. Run the regression test:
   ```
   scripts/run_tests.sh tests/gateway/test_platform_base.py::TestExtractMedia::test_media_tag_extracts_html_and_htm_paths
   ```
2. Verify nothing else regressed:
   ```
   scripts/run_tests.sh tests/gateway/test_platform_base.py tests/gateway/test_media_extraction.py tests/gateway/test_extract_local_files.py tests/gateway/test_tts_media_routing.py
   ```
   Locally: 145 passed / 2 skipped / 0 failures.
3. End-to-end repro: have an agent emit `MEDIA: /tmp/report.html` (file exists). Before this patch: tag silently stripped from user-visible text, file never delivered. After: file is delivered as a native attachment.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(gateway):`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) — see "Relationship to other open PRs" above
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run `scripts/run_tests.sh` against the affected tests and all pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS (Darwin 25.5.0, Python 3.13)

### Documentation & Housekeeping

- [x] N/A — no documentation impact (`website/docs/user-guide/features/deliverable-mode.md` already lists `.html .htm` as supported; this patch restores the behavior to match what the docs already promise)
- [x] N/A — no config keys added
- [x] N/A — no architecture or workflow changes
- [x] N/A — no cross-platform impact (regex literals only; behavior identical across OS)
- [x] N/A — no tool schema changes