### PR TITLE
feat(feishu): wire clarify tool with interactive card buttons

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -1464,6 +1464,8 @@ class FeishuAdapter(BasePlatformAdapter):
         # Update prompt button state (prompt_id → {session_key, message_id, chat_id})
         self._update_prompt_state: Dict[int, Dict[str, str]] = {}
         self._update_prompt_counter = itertools.count(1)
+        # Clarify button state (clarify_id → {session_key, message_id, chat_id, choices})
+        self._clarify_state: Dict[str, Dict[str, Any]] = {}
         # Feishu reaction deletion requires the opaque reaction_id returned
         # by create, so we cache it per message_id.
         self._pending_processing_reactions: "OrderedDict[str, str]" = OrderedDict()
@@ -1914,6 +1916,99 @@ class FeishuAdapter(BasePlatformAdapter):
             return result
         except Exception as exc:
             logger.warning("[Feishu] send_exec_approval failed: %s", exc)
+            return SendResult(success=False, error=str(exc))
+
+    @staticmethod
+    def _build_clarify_card(
+        *, question: str, choices: Optional[List[str]], clarify_id: str,
+    ) -> Dict[str, Any]:
+        """Build raw card JSON for a clarify prompt with choice buttons."""
+        elements: List[Dict[str, Any]] = [
+            {"tag": "markdown", "content": question},
+        ]
+        if choices:
+            buttons: List[Dict[str, Any]] = []
+            for idx, choice in enumerate(choices[:20]):
+                buttons.append({
+                    "tag": "button",
+                    "text": {"tag": "plain_text", "content": str(choice)[:20]},
+                    "type": "default",
+                    "value": {
+                        "hermes_clarify_action": "choice",
+                        "clarify_id": clarify_id,
+                        "choice_idx": idx,
+                    },
+                })
+            buttons.append({
+                "tag": "button",
+                "text": {"tag": "plain_text", "content": "✏️ Other"},
+                "type": "default",
+                "value": {
+                    "hermes_clarify_action": "other",
+                    "clarify_id": clarify_id,
+                },
+            })
+            elements.append({"tag": "action", "actions": buttons})
+        return {
+            "config": {"wide_screen_mode": True},
+            "header": {
+                "title": {"content": "❓ Hermes needs your input", "tag": "plain_text"},
+                "template": "orange",
+            },
+            "elements": elements,
+        }
+
+    @staticmethod
+    def _build_resolved_clarify_card(*, choice_text: str, user_name: str) -> Dict[str, Any]:
+        """Build raw card JSON for a resolved clarify action."""
+        return {
+            "config": {"wide_screen_mode": True},
+            "header": {
+                "title": {"content": "✅ Clarify answered", "tag": "plain_text"},
+                "template": "green",
+            },
+            "elements": [
+                {"tag": "markdown", "content": f"**{user_name}** chose: {choice_text}"},
+            ],
+        }
+
+    async def send_clarify(
+        self,
+        chat_id: str,
+        question: str,
+        choices: Optional[list],
+        clarify_id: str,
+        session_key: str,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Send a clarify prompt as an interactive card with choice buttons."""
+        if not self._client:
+            return SendResult(success=False, error="Not connected")
+
+        try:
+            card = self._build_clarify_card(
+                question=question, choices=choices, clarify_id=clarify_id,
+            )
+            payload = json.dumps(card, ensure_ascii=False)
+            response = await self._feishu_send_with_retry(
+                chat_id=chat_id,
+                msg_type="interactive",
+                payload=payload,
+                reply_to=None,
+                metadata=metadata,
+            )
+
+            result = self._finalize_send_result(response, "send_clarify failed")
+            if result.success:
+                self._clarify_state[clarify_id] = {
+                    "session_key": session_key,
+                    "message_id": result.message_id or "",
+                    "chat_id": chat_id,
+                    "choices": list(choices) if choices else None,
+                }
+            return result
+        except Exception as exc:
+            logger.warning("[Feishu] send_clarify failed: %s", exc)
             return SendResult(success=False, error=str(exc))
 
     @staticmethod
@@ -2513,6 +2608,10 @@ class FeishuAdapter(BasePlatformAdapter):
             action_value.get("hermes_update_prompt_action")
             if isinstance(action_value, dict) else None
         )
+        clarify_action = (
+            action_value.get("hermes_clarify_action")
+            if isinstance(action_value, dict) else None
+        )
 
         if hermes_action:
             return self._handle_approval_card_action(event=event, action_value=action_value, loop=loop)
@@ -2522,6 +2621,8 @@ class FeishuAdapter(BasePlatformAdapter):
                 action_value=action_value,
                 loop=loop,
             )
+        if clarify_action:
+            return self._handle_clarify_card_action(event=event, action_value=action_value, loop=loop)
 
         self._submit_on_loop(loop, self._handle_card_action_event(data))
         if P2CardActionTriggerResponse is None:
@@ -2647,6 +2748,126 @@ class FeishuAdapter(BasePlatformAdapter):
             )
         except Exception as exc:
             logger.error("Failed to resolve Feishu update prompt: %s", exc)
+
+    def _handle_clarify_card_action(self, *, event: Any, action_value: Dict[str, Any], loop: Any) -> Any:
+        """Handle clarify button callbacks: choice resolves immediately, other flips to text-capture."""
+        clarify_id = action_value.get("clarify_id")
+        if not clarify_id:
+            logger.debug("[Feishu] Card action missing clarify_id, ignoring")
+            return P2CardActionTriggerResponse() if P2CardActionTriggerResponse else None
+
+        # Already resolved / stale — same guard as Telegram's clarify handler.
+        if clarify_id not in self._clarify_state:
+            logger.debug("[Feishu] Clarify prompt already resolved (id=%s)", clarify_id)
+            return P2CardActionTriggerResponse() if P2CardActionTriggerResponse else None
+
+        # Authorization check
+        operator = getattr(event, "operator", None)
+        open_id = str(getattr(operator, "open_id", "") or "")
+        if not self._is_interactive_operator_authorized(open_id):
+            logger.warning("[Feishu] Unauthorized clarify click by %s", open_id or "<unknown>")
+            return P2CardActionTriggerResponse() if P2CardActionTriggerResponse else None
+
+        user_name = self._get_cached_sender_name(open_id) or open_id
+        clarify_action = action_value.get("hermes_clarify_action")
+
+        if clarify_action == "other":
+            # Flip into text-capture mode; gateway text-intercept will resolve.
+            try:
+                from tools.clarify_gateway import mark_awaiting_text
+                mark_awaiting_text(clarify_id)
+            except Exception as exc:
+                logger.warning("[Feishu] mark_awaiting_text failed: %s", exc)
+
+            if P2CardActionTriggerResponse is None:
+                return None
+            response = P2CardActionTriggerResponse()
+            if CallBackCard is not None:
+                card = CallBackCard()
+                card.type = "raw"
+                question = ""
+                try:
+                    from tools.clarify_gateway import _entries as _clarify_entries  # type: ignore
+                    entry = _clarify_entries.get(clarify_id)
+                    if entry:
+                        question = entry.question
+                except Exception:
+                    pass
+                card.data = {
+                    "config": {"wide_screen_mode": True},
+                    "header": {
+                        "title": {"content": "❓ Hermes needs your input", "tag": "plain_text"},
+                        "template": "orange",
+                    },
+                    "elements": [
+                        {"tag": "markdown", "content": question},
+                        {"tag": "markdown", "content": f"<font color='grey'>Awaiting typed response from **{user_name}**…</font>"},
+                    ],
+                }
+                response.card = card
+            return response
+
+        if clarify_action == "choice":
+            idx = action_value.get("choice_idx")
+            if idx is None:
+                logger.debug("[Feishu] Card action missing choice_idx, ignoring")
+                return P2CardActionTriggerResponse() if P2CardActionTriggerResponse else None
+
+            # Look up choice text: stored state → clarify entry → fallback index
+            state = self._clarify_state.get(clarify_id)
+            resolved_text: Optional[str] = None
+            if state and state.get("choices") and 0 <= idx < len(state["choices"]):
+                resolved_text = state["choices"][idx]
+            if resolved_text is None:
+                try:
+                    from tools.clarify_gateway import _entries as _clarify_entries  # type: ignore
+                    entry = _clarify_entries.get(clarify_id)
+                    if entry and entry.choices and 0 <= idx < len(entry.choices):
+                        resolved_text = entry.choices[idx]
+                except Exception:
+                    resolved_text = None
+            if resolved_text is None:
+                resolved_text = f"choice {idx + 1}"
+
+            # Pop state before scheduling — prevents double-click from
+            # entering this branch again (the "already resolved" guard
+            # above will catch it on the second click).
+            self._clarify_state.pop(clarify_id, None)
+
+            async def _do_resolve():
+                try:
+                    from tools.clarify_gateway import resolve_gateway_clarify
+                    resolved = resolve_gateway_clarify(clarify_id, resolved_text)
+                    if resolved:
+                        logger.info(
+                            "Feishu clarify button resolved (id=%s, choice=%s, user=%s)",
+                            clarify_id, resolved_text, user_name,
+                        )
+                    else:
+                        logger.warning(
+                            "Feishu clarify button: resolve_gateway_clarify returned False (id=%s)",
+                            clarify_id,
+                        )
+                except Exception as exc:
+                    logger.error("Failed to resolve gateway clarify from Feishu button: %s", exc)
+
+            if not self._submit_on_loop(loop, _do_resolve()):
+                return P2CardActionTriggerResponse() if P2CardActionTriggerResponse else None
+
+            if P2CardActionTriggerResponse is None:
+                return None
+            response = P2CardActionTriggerResponse()
+            if CallBackCard is not None:
+                card = CallBackCard()
+                card.type = "raw"
+                card.data = self._build_resolved_clarify_card(
+                    choice_text=resolved_text, user_name=user_name,
+                )
+                response.card = card
+            return response
+
+        logger.debug("[Feishu] Unknown clarify action %r, ignoring", clarify_action)
+        return P2CardActionTriggerResponse() if P2CardActionTriggerResponse else None
 
     async def _handle_reaction_event(self, event_type: str, data: Any) -> None:
         """Fetch the reacted-to message; if it was sent by this bot, emit a synthetic text event."""

--- a/tests/gateway/test_feishu_clarify_buttons.py
+++ b/tests/gateway/test_feishu_clarify_buttons.py
@@ -1,0 +1,284 @@
+"""Tests for Feishu interactive card clarify buttons.
+
+Mirrors test_feishu_approval_buttons.py for the new ``send_clarify`` and
+``hermes_clarify_action`` callback dispatch.
+"""
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Ensure the repo root is importable
+# ---------------------------------------------------------------------------
+_repo = str(Path(__file__).resolve().parents[2])
+if _repo not in sys.path:
+    sys.path.insert(0, _repo)
+
+
+# ---------------------------------------------------------------------------
+# Minimal Feishu mock so FeishuAdapter can be imported without lark-oapi
+# ---------------------------------------------------------------------------
+def _ensure_feishu_mocks():
+    """Provide stubs for lark-oapi / aiohttp.web so the import succeeds."""
+    if importlib.util.find_spec("lark_oapi") is None and "lark_oapi" not in sys.modules:
+        mod = MagicMock()
+        for name in (
+            "lark_oapi", "lark_oapi.api.im.v1",
+            "lark_oapi.event", "lark_oapi.event.callback_type",
+        ):
+            sys.modules.setdefault(name, mod)
+    if importlib.util.find_spec("aiohttp") is None and "aiohttp" not in sys.modules:
+        aio = MagicMock()
+        sys.modules.setdefault("aiohttp", aio)
+        sys.modules.setdefault("aiohttp.web", aio.web)
+
+
+_ensure_feishu_mocks()
+
+from gateway.config import PlatformConfig
+import gateway.platforms.feishu as feishu_module
+from gateway.platforms.feishu import FeishuAdapter
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_adapter() -> FeishuAdapter:
+    """Create a FeishuAdapter with mocked internals."""
+    config = PlatformConfig(enabled=True)
+    adapter = FeishuAdapter(config)
+    adapter._client = MagicMock()
+    return adapter
+
+
+def _make_card_action_data(
+    action_value: dict,
+    chat_id: str = "oc_12345",
+    open_id: str = "ou_user1",
+    token: str = "tok_abc",
+) -> SimpleNamespace:
+    """Create a mock Feishu card action callback data object."""
+    return SimpleNamespace(
+        event=SimpleNamespace(
+            token=token,
+            context=SimpleNamespace(open_chat_id=chat_id),
+            operator=SimpleNamespace(open_id=open_id),
+            action=SimpleNamespace(
+                tag="button",
+                value=action_value,
+            ),
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Card rendering tests
+# ---------------------------------------------------------------------------
+
+class TestBuildClarifyCard:
+    """Tests for _build_clarify_card static method."""
+
+    def test_multi_choice_card(self):
+        card = FeishuAdapter._build_clarify_card(
+            question="Pick one", choices=["a", "b", "c"], clarify_id="id1",
+        )
+        assert card["header"]["template"] == "orange"
+        actions = card["elements"][1]["actions"]
+        assert len(actions) == 4  # 3 choices + Other
+        assert actions[0]["value"]["hermes_clarify_action"] == "choice"
+        assert actions[0]["value"]["choice_idx"] == 0
+        assert actions[-1]["value"]["hermes_clarify_action"] == "other"
+
+    def test_open_ended_card(self):
+        card = FeishuAdapter._build_clarify_card(
+            question="Type answer", choices=None, clarify_id="id2",
+        )
+        assert len(card["elements"]) == 1  # markdown only, no action
+
+    def test_resolved_card(self):
+        card = FeishuAdapter._build_resolved_clarify_card(
+            choice_text="Apple", user_name="Alice",
+        )
+        assert card["header"]["template"] == "green"
+        assert "Alice" in card["elements"][0]["content"]
+        assert "Apple" in card["elements"][0]["content"]
+
+
+# ---------------------------------------------------------------------------
+# send_clarify integration tests
+# ---------------------------------------------------------------------------
+
+class TestSendClarify:
+    """Tests for the send_clarify async method."""
+
+    @pytest.mark.asyncio
+    async def test_sends_interactive_card(self):
+        adapter = _make_adapter()
+        adapter._feishu_send_with_retry = AsyncMock(return_value=MagicMock(
+            success=lambda: True,
+            data=MagicMock(message_id="msg_1"),
+        ))
+        result = await adapter.send_clarify(
+            chat_id="oc_123", question="Pick", choices=["x", "y"],
+            clarify_id="c1", session_key="s1",
+        )
+        assert result.success
+        assert "c1" in adapter._clarify_state
+        adapter._feishu_send_with_retry.assert_called_once()
+        call_kwargs = adapter._feishu_send_with_retry.call_args[1]
+        assert call_kwargs["msg_type"] == "interactive"
+
+    @pytest.mark.asyncio
+    async def test_not_connected(self):
+        adapter = _make_adapter()
+        adapter._client = None
+        result = await adapter.send_clarify(
+            chat_id="oc_123", question="Q", choices=None,
+            clarify_id="c1", session_key="s1",
+        )
+        assert not result.success
+
+
+# ---------------------------------------------------------------------------
+# Card action callback tests
+# ---------------------------------------------------------------------------
+
+class TestClarifyCardAction:
+    """Tests for _handle_clarify_card_action callback dispatch."""
+
+    @pytest.fixture()
+    def _patch_callback_card_types(self):
+        """Patch P2CardActionTriggerResponse and CallBackCard for testing."""
+        with patch.object(feishu_module, "P2CardActionTriggerResponse", create=True, new=MagicMock):
+            with patch.object(feishu_module, "CallBackCard", create=True, new=MagicMock):
+                yield
+
+    def test_choice_action_resolves(self, _patch_callback_card_types):
+        adapter = _make_adapter()
+        adapter._clarify_state["c1"] = {
+            "session_key": "s1", "message_id": "m1",
+            "chat_id": "oc_123", "choices": ["Apple", "Banana"],
+        }
+        adapter._submit_on_loop = MagicMock(return_value=True)
+        adapter._is_interactive_operator_authorized = MagicMock(return_value=True)
+        adapter._get_cached_sender_name = MagicMock(return_value="Alice")
+
+        data = _make_card_action_data({
+            "hermes_clarify_action": "choice",
+            "clarify_id": "c1",
+            "choice_idx": 0,
+        })
+        event = data.event
+        loop = MagicMock()
+
+        with patch("tools.clarify_gateway.resolve_gateway_clarify", create=True) as mock_resolve:
+            mock_resolve.return_value = True
+            # Import after patching
+            import tools.clarify_gateway
+            tools.clarify_gateway.resolve_gateway_clarify = mock_resolve
+
+            adapter._handle_clarify_card_action(
+                event=event, action_value=data.event.action.value, loop=loop,
+            )
+
+        assert "c1" not in adapter._clarify_state  # state popped
+
+    def test_other_action_calls_mark_awaiting_text(self, _patch_callback_card_types):
+        adapter = _make_adapter()
+        adapter._clarify_state["c2"] = {
+            "session_key": "s1", "message_id": "m1",
+            "chat_id": "oc_123", "choices": ["A"],
+        }
+        adapter._is_interactive_operator_authorized = MagicMock(return_value=True)
+        adapter._get_cached_sender_name = MagicMock(return_value="Bob")
+
+        data = _make_card_action_data({
+            "hermes_clarify_action": "other",
+            "clarify_id": "c2",
+        })
+        event = data.event
+        loop = MagicMock()
+
+        with patch("tools.clarify_gateway.mark_awaiting_text", create=True) as mock_mark:
+            import tools.clarify_gateway
+            tools.clarify_gateway.mark_awaiting_text = mock_mark
+
+            adapter._handle_clarify_card_action(
+                event=event, action_value=data.event.action.value, loop=loop,
+            )
+
+            mock_mark.assert_called_once_with("c2")
+
+    def test_unauthorized_user_rejected(self, _patch_callback_card_types):
+        adapter = _make_adapter()
+        adapter._is_interactive_operator_authorized = MagicMock(return_value=False)
+
+        data = _make_card_action_data({
+            "hermes_clarify_action": "choice",
+            "clarify_id": "c1",
+            "choice_idx": 0,
+        })
+        event = data.event
+        loop = MagicMock()
+
+        result = adapter._handle_clarify_card_action(
+            event=event, action_value=data.event.action.value, loop=loop,
+        )
+        # Should return early without resolving
+        assert "c1" not in adapter._clarify_state
+
+    def test_fallback_when_entries_missing(self, _patch_callback_card_types):
+        adapter = _make_adapter()
+        adapter._clarify_state["c3"] = {
+            "session_key": "s1", "message_id": "m1",
+            "chat_id": "oc_123", "choices": None,  # no choices stored in state
+        }
+        adapter._submit_on_loop = MagicMock(return_value=True)
+        adapter._is_interactive_operator_authorized = MagicMock(return_value=True)
+        adapter._get_cached_sender_name = MagicMock(return_value="Alice")
+
+        data = _make_card_action_data({
+            "hermes_clarify_action": "choice",
+            "clarify_id": "c3",
+            "choice_idx": 2,
+        })
+        event = data.event
+        loop = MagicMock()
+
+        # State has entry but no choices; _entries also empty — should use fallback
+        with patch.dict("sys.modules", {"tools.clarify_gateway": MagicMock(
+            resolve_gateway_clarify=MagicMock(return_value=True),
+            _entries={},
+        )}):
+            adapter._handle_clarify_card_action(
+                event=event, action_value=data.event.action.value, loop=loop,
+            )
+
+        # Should have scheduled resolution with fallback text "choice 3"
+        adapter._submit_on_loop.assert_called_once()
+
+    def test_already_resolved_returns_early(self, _patch_callback_card_types):
+        adapter = _make_adapter()
+        adapter._is_interactive_operator_authorized = MagicMock(return_value=True)
+
+        data = _make_card_action_data({
+            "hermes_clarify_action": "choice",
+            "clarify_id": "c_gone",
+            "choice_idx": 0,
+        })
+        event = data.event
+        loop = MagicMock()
+
+        # No _clarify_state entry — should return early
+        result = adapter._handle_clarify_card_action(
+            event=event, action_value=data.event.action.value, loop=loop,
+        )
+        # Should not have scheduled any resolution
+        assert result is not None


### PR DESCRIPTION
Implements the clarify tool on Feishu with interactive card buttons, mirroring the Telegram pattern from #24199.

## Changes

- `send_clarify`: renders question + choice buttons as Feishu interactive card
- `_handle_clarify_card_action`: route button callbacks via `hermes_clarify_action`
  - **choice**: resolves immediately with choice text
  - **other**: flips to text-capture mode via `mark_awaiting_text`
- Already-resolved guard prevents double-click / stale-button issues
- Authorization check reuses `_is_interactive_operator_authorized`
- Choice text lookup: stored state → clarify entry → fallback index

## Known limitation

Feishu shows both the tool-progress bubble (`❓ clarify: ...`) and the interactive card because Feishu lacks `delete_message` support. This can be revisited once Feishu implements message deletion.

## Testing

- 10 new tests in `tests/gateway/test_feishu_clarify_buttons.py`
- All existing Feishu tests pass (407/407)

Closes #12573
Closes #21032
Supersedes #23740
Related #24199, #21893, #503