### PR TITLE
fix(gateway): skip shutdown-timeout startup auto-resume

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3493,10 +3493,12 @@ class GatewayRunner:
     # Drain-timeout reasons set by _stop_impl() when a still-running turn is
     # force-interrupted; "restart_interrupted" is set by
     # SessionStore.suspend_recently_active() on crash recovery (no
-    # .clean_shutdown marker).  All three mean "the agent was mid-turn and
-    # we killed it" — eligible for startup auto-resume.
+    # .clean_shutdown marker).  Startup only synthesizes recovery turns for
+    # restarts/crashes: shutdown-timeout sessions still resume on the next real
+    # user message, but are not auto-run immediately after the service comes
+    # back because that can replay lifecycle commands and flap the gateway.
     _AUTO_RESUME_REASONS = frozenset(
-        {"restart_timeout", "shutdown_timeout", "restart_interrupted"}
+        {"restart_timeout", "restart_interrupted"}
     )
 
     def _schedule_resume_pending_sessions(self) -> int:

--- a/tests/gateway/test_restart_resume_pending.py
+++ b/tests/gateway/test_restart_resume_pending.py
@@ -933,6 +933,39 @@ async def test_startup_auto_resume_includes_crash_recovery():
 
 
 @pytest.mark.asyncio
+async def test_startup_auto_resume_skips_shutdown_timeout():
+    """Shutdown-timeout sessions wait for an explicit user message.
+
+    A shutdown-timeout can be caused by a gateway lifecycle command. If startup
+    immediately replays that interrupted turn, it can re-run the same lifecycle
+    command and flap the gateway. The marker is preserved so the next real user
+    message still gets the resume_pending system note.
+    """
+    runner, adapter = make_restart_runner()
+    source = make_restart_source(chat_id="shutdown-chat")
+    pending_entry = SessionEntry(
+        session_key="agent:main:telegram:dm:shutdown-chat",
+        session_id="sid",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        origin=source,
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+        resume_pending=True,
+        resume_reason="shutdown_timeout",
+        last_resume_marked_at=datetime.now(),
+    )
+    runner.session_store._entries = {pending_entry.session_key: pending_entry}
+    adapter.handle_message = AsyncMock()
+
+    scheduled = runner._schedule_resume_pending_sessions()
+
+    assert scheduled == 0
+    adapter.handle_message.assert_not_called()
+    assert pending_entry.resume_pending is True
+
+
+@pytest.mark.asyncio
 async def test_startup_auto_resume_skips_stale_entries():
     """Entries older than the freshness window must not be auto-resumed."""
     runner, adapter = make_restart_runner()


### PR DESCRIPTION
## Summary

- do not synthesize startup auto-resume turns for `shutdown_timeout` sessions
- preserve the `resume_pending` marker so the next real user message still resumes with the existing system note
- add a regression test for the shutdown-timeout case

## Why

A shutdown-timeout can be caused by a gateway lifecycle command. If the service comes back and immediately replays that interrupted turn, it can re-run the same lifecycle command and flap the gateway. Restart-timeout and crash-recovery sessions still auto-resume as before.

## Test plan

- `uv run --extra dev pytest tests/gateway/test_restart_resume_pending.py::test_startup_auto_resume_schedules_fresh_pending_sessions tests/gateway/test_restart_resume_pending.py::test_startup_auto_resume_includes_crash_recovery tests/gateway/test_restart_resume_pending.py::test_startup_auto_resume_skips_shutdown_timeout tests/gateway/test_restart_resume_pending.py::test_startup_auto_resume_skips_disallowed_reasons -q -o 'addopts='`
- `uv run --extra dev ruff check gateway/run.py tests/gateway/test_restart_resume_pending.py`
- `python3 -m py_compile gateway/run.py tests/gateway/test_restart_resume_pending.py`
- `git diff --check`

## AI Disclosure

This fix was prepared with AI assistance.
