### PR TITLE
docs: add demo app architecture page

### DIFF
--- a/demo-app-architecture.html
+++ b/demo-app-architecture.html
@@ -1,0 +1,216 @@
+<!doctype html>
+<html lang="ru">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Demo App Architecture</title>
+  <style>
+    @import url('https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;600;700&display=swap');
+    :root {
+      --bg: #020617;
+      --panel: #0f172a;
+      --text: #e2e8f0;
+      --muted: #94a3b8;
+      --grid: #1e293b;
+      --cyan: #22d3ee;
+      --emerald: #34d399;
+      --violet: #a78bfa;
+      --amber: #fbbf24;
+      --rose: #fb7185;
+      --orange: #fb923c;
+      --slate: #94a3b8;
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      min-height: 100vh;
+      background:
+        radial-gradient(circle at 20% 10%, rgba(34, 211, 238, .12), transparent 28%),
+        radial-gradient(circle at 80% 5%, rgba(167, 139, 250, .11), transparent 32%),
+        var(--bg);
+      color: var(--text);
+      font-family: 'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
+      padding: 32px;
+    }
+    .wrap { max-width: 1180px; margin: 0 auto; }
+    header { display: flex; align-items: center; justify-content: space-between; gap: 24px; margin-bottom: 20px; }
+    .title { display: flex; align-items: center; gap: 12px; }
+    .pulse {
+      width: 12px; height: 12px; border-radius: 999px; background: var(--emerald);
+      box-shadow: 0 0 0 rgba(52, 211, 153, .75);
+      animation: pulse 1.8s infinite;
+    }
+    @keyframes pulse { 0% { box-shadow: 0 0 0 0 rgba(52, 211, 153, .7); } 70% { box-shadow: 0 0 0 12px rgba(52, 211, 153, 0); } 100% { box-shadow: 0 0 0 0 rgba(52, 211, 153, 0); } }
+    h1 { margin: 0; font-size: 24px; letter-spacing: -0.03em; }
+    .subtitle { margin: 6px 0 0; color: var(--muted); font-size: 12px; }
+    .badge { border: 1px solid #334155; color: var(--muted); border-radius: 999px; padding: 8px 12px; font-size: 11px; background: rgba(15,23,42,.7); }
+    .diagram-card { border: 1px solid #1e293b; background: rgba(15,23,42,.72); border-radius: 18px; padding: 18px; box-shadow: 0 18px 60px rgba(0,0,0,.28); overflow: auto; }
+    svg { width: 100%; height: auto; display: block; min-width: 980px; }
+    .label { fill: #e2e8f0; font-size: 12px; font-weight: 700; }
+    .sub { fill: #94a3b8; font-size: 9px; }
+    .tiny { fill: #cbd5e1; font-size: 8px; }
+    .arrow { stroke: #64748b; stroke-width: 1.6; fill: none; }
+    .arrow-green { stroke: #34d399; stroke-width: 1.8; fill: none; }
+    .arrow-orange { stroke: #fb923c; stroke-width: 1.8; fill: none; }
+    .arrow-rose { stroke: #fb7185; stroke-width: 1.6; stroke-dasharray: 5 4; fill: none; }
+    .boundary-label { fill: #fbbf24; font-size: 10px; font-weight: 700; }
+    .cards { display: grid; grid-template-columns: repeat(3, 1fr); gap: 14px; margin-top: 16px; }
+    .card { border: 1px solid #1e293b; background: rgba(15,23,42,.62); border-radius: 14px; padding: 14px; }
+    .card-header { display: flex; align-items: center; gap: 8px; margin-bottom: 8px; }
+    .dot { width: 8px; height: 8px; border-radius: 999px; }
+    .cyan { background: var(--cyan); } .emerald { background: var(--emerald); } .violet { background: var(--violet); }
+    h3 { margin: 0; font-size: 13px; }
+    ul { margin: 0; padding-left: 0; list-style: none; color: var(--muted); font-size: 11px; line-height: 1.7; }
+    footer { margin-top: 14px; color: #64748b; font-size: 10px; text-align: right; }
+    @media (max-width: 800px) { body { padding: 16px; } header { align-items: flex-start; flex-direction: column; } .cards { grid-template-columns: 1fr; } }
+  </style>
+</head>
+<body>
+  <div class="wrap">
+    <header>
+      <div>
+        <div class="title"><div class="pulse"></div><h1>Пробная архитектура приложения</h1></div>
+        <p class="subtitle">SaaS-платформа: web/mobile clients → API gateway → microservices → event bus → databases/analytics</p>
+      </div>
+      <div class="badge">demo · dark SVG · offline HTML</div>
+    </header>
+
+    <main class="diagram-card">
+      <svg viewBox="0 0 1120 720" role="img" aria-label="Demo application architecture diagram">
+        <defs>
+          <pattern id="grid" width="40" height="40" patternUnits="userSpaceOnUse">
+            <path d="M 40 0 L 0 0 0 40" fill="none" stroke="#1e293b" stroke-width="0.5"/>
+          </pattern>
+          <marker id="arrow" markerWidth="10" markerHeight="10" refX="8" refY="3" orient="auto" markerUnits="strokeWidth">
+            <path d="M0,0 L0,6 L9,3 z" fill="#64748b" />
+          </marker>
+          <marker id="arrowGreen" markerWidth="10" markerHeight="10" refX="8" refY="3" orient="auto" markerUnits="strokeWidth">
+            <path d="M0,0 L0,6 L9,3 z" fill="#34d399" />
+          </marker>
+          <marker id="arrowOrange" markerWidth="10" markerHeight="10" refX="8" refY="3" orient="auto" markerUnits="strokeWidth">
+            <path d="M0,0 L0,6 L9,3 z" fill="#fb923c" />
+          </marker>
+          <marker id="arrowRose" markerWidth="10" markerHeight="10" refX="8" refY="3" orient="auto" markerUnits="strokeWidth">
+            <path d="M0,0 L0,6 L9,3 z" fill="#fb7185" />
+          </marker>
+          <filter id="glow"><feGaussianBlur stdDeviation="2" result="blur"/><feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+        </defs>
+
+        <rect width="1120" height="720" rx="14" fill="#020617"/>
+        <rect width="1120" height="720" fill="url(#grid)" opacity="0.75"/>
+
+        <!-- boundaries -->
+        <rect x="250" y="70" width="790" height="520" rx="12" fill="rgba(120, 53, 15, 0.08)" stroke="#fbbf24" stroke-width="1.2" stroke-dasharray="8 4"/>
+        <text x="270" y="95" class="boundary-label">CLOUD REGION · eu-central-1</text>
+        <rect x="285" y="130" width="705" height="315" rx="10" fill="rgba(136, 19, 55, 0.07)" stroke="#fb7185" stroke-width="1" stroke-dasharray="4 4"/>
+        <text x="305" y="152" fill="#fb7185" font-size="9" font-weight="700">PRIVATE SECURITY GROUP</text>
+
+        <!-- arrows behind components -->
+        <path class="arrow" marker-end="url(#arrow)" d="M180 180 C215 180, 220 190, 255 190"/>
+        <path class="arrow" marker-end="url(#arrow)" d="M180 270 C215 270, 220 250, 255 250"/>
+        <path class="arrow-green" marker-end="url(#arrowGreen)" d="M410 220 L465 220"/>
+        <path class="arrow-green" marker-end="url(#arrowGreen)" d="M585 170 L645 170"/>
+        <path class="arrow-green" marker-end="url(#arrowGreen)" d="M585 270 L645 270"/>
+        <path class="arrow-orange" marker-end="url(#arrowOrange)" d="M740 200 C785 210, 805 255, 805 302"/>
+        <path class="arrow-orange" marker-end="url(#arrowOrange)" d="M740 300 C785 292, 805 278, 805 258"/>
+        <path class="arrow-green" marker-end="url(#arrowGreen)" d="M760 170 L835 170"/>
+        <path class="arrow-green" marker-end="url(#arrowGreen)" d="M760 270 L835 270"/>
+        <path class="arrow" marker-end="url(#arrow)" d="M915 270 C955 320, 960 388, 900 420"/>
+        <path class="arrow-rose" marker-end="url(#arrowRose)" d="M352 305 C410 365, 480 384, 555 390"/>
+        <path class="arrow-orange" marker-end="url(#arrowOrange)" d="M815 380 C780 455, 690 490, 590 505"/>
+        <path class="arrow" marker-end="url(#arrow)" d="M835 170 C885 120, 960 113, 1030 130"/>
+
+        <!-- component helper: opaque rect + transparent rect -->
+        <!-- clients -->
+        <rect x="40" y="145" width="140" height="70" rx="6" fill="#0f172a"/>
+        <rect x="40" y="145" width="140" height="70" rx="6" fill="rgba(8, 51, 68, 0.4)" stroke="#22d3ee" stroke-width="1.5"/>
+        <text x="60" y="175" class="label">Web Client</text><text x="60" y="193" class="sub">React / Next.js</text>
+
+        <rect x="40" y="235" width="140" height="70" rx="6" fill="#0f172a"/>
+        <rect x="40" y="235" width="140" height="70" rx="6" fill="rgba(8, 51, 68, 0.4)" stroke="#22d3ee" stroke-width="1.5"/>
+        <text x="60" y="265" class="label">Mobile App</text><text x="60" y="283" class="sub">iOS / Android</text>
+
+        <!-- api gateway -->
+        <rect x="255" y="180" width="155" height="90" rx="6" fill="#0f172a"/>
+        <rect x="255" y="180" width="155" height="90" rx="6" fill="rgba(120, 53, 15, 0.3)" stroke="#fbbf24" stroke-width="1.5"/>
+        <text x="282" y="215" class="label">API Gateway</text><text x="282" y="235" class="sub">TLS · rate limit · routing</text><text x="282" y="252" class="tiny">REST / GraphQL</text>
+
+        <!-- services -->
+        <rect x="465" y="135" width="120" height="70" rx="6" fill="#0f172a"/>
+        <rect x="465" y="135" width="120" height="70" rx="6" fill="rgba(6, 78, 59, 0.4)" stroke="#34d399" stroke-width="1.5"/>
+        <text x="490" y="165" class="label">Auth</text><text x="490" y="183" class="sub">JWT / OAuth2</text>
+
+        <rect x="465" y="235" width="120" height="70" rx="6" fill="#0f172a"/>
+        <rect x="465" y="235" width="120" height="70" rx="6" fill="rgba(6, 78, 59, 0.4)" stroke="#34d399" stroke-width="1.5"/>
+        <text x="492" y="265" class="label">Core API</text><text x="492" y="283" class="sub">business logic</text>
+
+        <rect x="645" y="135" width="115" height="70" rx="6" fill="#0f172a"/>
+        <rect x="645" y="135" width="115" height="70" rx="6" fill="rgba(6, 78, 59, 0.4)" stroke="#34d399" stroke-width="1.5"/>
+        <text x="667" y="165" class="label">Billing</text><text x="667" y="183" class="sub">payments</text>
+
+        <rect x="645" y="235" width="115" height="70" rx="6" fill="#0f172a"/>
+        <rect x="645" y="235" width="115" height="70" rx="6" fill="rgba(6, 78, 59, 0.4)" stroke="#34d399" stroke-width="1.5"/>
+        <text x="663" y="265" class="label">Workers</text><text x="663" y="283" class="sub">async tasks</text>
+
+        <!-- message bus -->
+        <rect x="750" y="325" width="130" height="55" rx="6" fill="#0f172a"/>
+        <rect x="750" y="325" width="130" height="55" rx="6" fill="rgba(251, 146, 60, 0.3)" stroke="#fb923c" stroke-width="1.5"/>
+        <text x="775" y="350" class="label">Event Bus</text><text x="775" y="367" class="sub">Kafka / SQS</text>
+
+        <!-- data -->
+        <rect x="835" y="135" width="125" height="70" rx="6" fill="#0f172a"/>
+        <rect x="835" y="135" width="125" height="70" rx="6" fill="rgba(76, 29, 149, 0.4)" stroke="#a78bfa" stroke-width="1.5"/>
+        <text x="861" y="165" class="label">Postgres</text><text x="861" y="183" class="sub">primary DB</text>
+
+        <rect x="835" y="235" width="125" height="70" rx="6" fill="#0f172a"/>
+        <rect x="835" y="235" width="125" height="70" rx="6" fill="rgba(76, 29, 149, 0.4)" stroke="#a78bfa" stroke-width="1.5"/>
+        <text x="873" y="265" class="label">Redis</text><text x="873" y="283" class="sub">cache / queue</text>
+
+        <rect x="555" y="465" width="170" height="80" rx="6" fill="#0f172a"/>
+        <rect x="555" y="465" width="170" height="80" rx="6" fill="rgba(76, 29, 149, 0.4)" stroke="#a78bfa" stroke-width="1.5"/>
+        <text x="585" y="500" class="label">Analytics Store</text><text x="585" y="520" class="sub">ClickHouse / BigQuery</text>
+
+        <!-- security / observability / external -->
+        <rect x="270" y="365" width="165" height="70" rx="6" fill="#0f172a"/>
+        <rect x="270" y="365" width="165" height="70" rx="6" fill="rgba(136, 19, 55, 0.4)" stroke="#fb7185" stroke-width="1.5"/>
+        <text x="303" y="395" class="label">Secrets Vault</text><text x="303" y="413" class="sub">KMS · policies</text>
+
+        <rect x="760" y="410" width="140" height="70" rx="6" fill="#0f172a"/>
+        <rect x="760" y="410" width="140" height="70" rx="6" fill="rgba(30, 41, 59, 0.5)" stroke="#94a3b8" stroke-width="1.5"/>
+        <text x="785" y="440" class="label">Monitoring</text><text x="785" y="458" class="sub">logs · metrics · traces</text>
+
+        <rect x="965" y="100" width="110" height="60" rx="6" fill="#0f172a"/>
+        <rect x="965" y="100" width="110" height="60" rx="6" fill="rgba(30, 41, 59, 0.5)" stroke="#94a3b8" stroke-width="1.5"/>
+        <text x="986" y="126" class="label">Stripe</text><text x="986" y="143" class="sub">external API</text>
+
+        <!-- legend below boundaries -->
+        <g transform="translate(250 625)">
+          <rect x="0" y="0" width="620" height="48" rx="8" fill="rgba(15, 23, 42, 0.9)" stroke="#334155"/>
+          <circle cx="24" cy="24" r="5" fill="#22d3ee"/><text x="38" y="28" class="tiny">Frontend</text>
+          <circle cx="126" cy="24" r="5" fill="#34d399"/><text x="140" y="28" class="tiny">Backend</text>
+          <circle cx="230" cy="24" r="5" fill="#a78bfa"/><text x="244" y="28" class="tiny">Data</text>
+          <circle cx="315" cy="24" r="5" fill="#fb923c"/><text x="329" y="28" class="tiny">Events</text>
+          <circle cx="418" cy="24" r="5" fill="#fb7185"/><text x="432" y="28" class="tiny">Security</text>
+          <circle cx="525" cy="24" r="5" fill="#fbbf24"/><text x="539" y="28" class="tiny">Cloud</text>
+        </g>
+      </svg>
+    </main>
+
+    <section class="cards">
+      <div class="card">
+        <div class="card-header"><div class="dot cyan"></div><h3>Клиенты и вход</h3></div>
+        <ul><li>• Web и Mobile обращаются через API Gateway</li><li>• Gateway отвечает за TLS, лимиты и маршрутизацию</li></ul>
+      </div>
+      <div class="card">
+        <div class="card-header"><div class="dot emerald"></div><h3>Сервисы</h3></div>
+        <ul><li>• Auth, Core API, Billing и Workers разделены</li><li>• Синхронные вызовы плюс события для async-задач</li></ul>
+      </div>
+      <div class="card">
+        <div class="card-header"><div class="dot violet"></div><h3>Данные и наблюдаемость</h3></div>
+        <ul><li>• Postgres для транзакций, Redis для кэша</li><li>• Event Bus питает аналитику и мониторинг</li></ul>
+      </div>
+    </section>
+    <footer>Generated by Hermes · demo-app-architecture.html</footer>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Adds an offline HTML/SVG demo architecture page.
- Shows a dark-themed SaaS architecture with clients, gateway, services, events, data, security, and monitoring layers.

## Test Plan
- Parsed the HTML with Python HTMLParser.
