### PR TITLE
fix(wecom): retry on ercode 846609 after WebSocket reconnect

### DIFF
--- a/gateway/platforms/wecom.py
+++ b/gateway/platforms/wecom.py
@@ -1222,15 +1222,14 @@ class WeComAdapter(BasePlatformAdapter):
         return response
 
     async def _send_reply_markdown(self, reply_req_id: str, content: str) -> Dict[str, Any]:
-        response = await self._send_reply_request(
-            reply_req_id,
-            {
-                "msgtype": "markdown",
-                "markdown": {"content": content[:self.MAX_MESSAGE_LENGTH]},
-            },
-        )
-        self._raise_for_wecom_error(response, "send reply markdown")
-        return response
+       body = {"msgtype": "markdown", "markdown": {"content": content[:self.MAX_MESSAGE_LENGTH]}}
+       response = await self._send_reply_request(reply_req_id, body)
+       if self._is_transient_ws_error(response):
+           logger.warning("[%s] Transient WS error in reply markdown (ercode %s) — reconnecting", self.name, response.get("errcode"))
+           await self._connect_ws()
+           response = await self._send_reply_request(reply_req_id, body)
+       self._raise_for_wecom_error(response, "send reply markdown")
+       return response
 
     async def _send_reply_media_message(
         self,

--- a/gateway/platforms/wecom.py
+++ b/gateway/platforms/wecom.py
@@ -996,13 +996,24 @@ class WeComAdapter(BasePlatformAdapter):
             "downgrade_note": None,
         }
 
-    @staticmethod
+    # WeCom error codes that indicate a transient WebSocket session issue
+    # and should trigger reconnect + retry rather than hard failure.
+    _TRANSIENT_ERRCODES = {
+        846609,  # aibot websocket not subscribed — session WS disconnected
+        846601,  # aibot websocket timeout
+        846602,  # aibot websocket send failed
+    }
+
     def _response_error(response: Dict[str, Any]) -> Optional[str]:
         errcode = response.get("errcode", 0)
         if errcode in {0, None}:
             return None
         errmsg = str(response.get("errmsg") or "unknown error")
         return f"WeCom errcode {errcode}: {errmsg}"
+
+    def _is_transient_ws_error(self, response: Dict[str, Any]) -> bool:
+        """Return True if the error is a transient WebSocket session error."""
+        return int(response.get("errcode", 0)) in self._TRANSIENT_ERRCODES
 
     @classmethod
     def _raise_for_wecom_error(cls, response: Dict[str, Any], operation: str) -> None:
@@ -1363,6 +1374,32 @@ class WeComAdapter(BasePlatformAdapter):
                         "markdown": {"content": content[:self.MAX_MESSAGE_LENGTH]},
                     },
                 )
+
+            # Retry once on transient WebSocket session errors (ercode 846609).
+            # The session-level WS disconnects within 1-2s of connecting;
+            # reconnecting the main WS and retrying usually succeeds (issue #29667).
+            if self._is_transient_ws_error(response):
+                logger.warning(
+                    "[%s] Transient WS error (ercode %s) — reconnecting and retrying",
+                    self.name, response.get("errcode"),
+                )
+                try:
+                    await self._connect_ws()
+                    if reply_req_id:
+                        response = await self._send_reply_markdown(reply_req_id, content)
+                    else:
+                        response = await self._send_request(
+                            APP_CMD_SEND,
+                            {
+                                "chatid": chat_id,
+                                "msgtype": "markdown",
+                                "markdown": {"content": content[:self.MAX_MESSAGE_LENGTH]},
+                            },
+                        )
+                except Exception as retry_exc:
+                    logger.error("[%s] Retry after reconnect failed: %s", self.name, retry_exc)
+                    return SendResult(success=False, error=f"Fallback send also failed: {retry_exc}")
+
         except asyncio.TimeoutError:
             return SendResult(success=False, error="Timeout sending message to WeCom")
         except Exception as exc:


### PR DESCRIPTION
## Problem

WeCom replies fail with ercode 846609 when session WebSocket disconnects within 1-2s. 173+ occurrences in a single day (issue #29667).

## Fix

1. _TRANSIENT_ERRCODES set for 846609/846601/846602
2. send() path: reconnect + retry
3. _send_reply_markdown() path: reconnect + retry

Fixes #29667