### PR TITLE
fix(kanban): prevent infinite crash loop for parentless blocked tasks

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -2101,12 +2101,25 @@ def recompute_ready(conn: sqlite3.Connection) -> int:
 
     ``blocked`` tasks are also considered for promotion (so a task
     blocked purely by a parent dependency unblocks itself when the
-    parent completes), *except* when the most recent block event was a
-    worker-initiated ``kanban_block`` — those stay blocked until an
-    explicit ``kanban_unblock`` (#28712).  Without that guard, a
-    ``review-required`` handoff would auto-respawn, the fresh worker
-    would find nothing to do, exit cleanly, get recorded as a protocol
-    violation, and the cycle would repeat indefinitely.
+    parent completes), *except* when:
+
+    * The most recent ``{blocked, unblocked}`` event is ``blocked``
+      (worker- or operator-initiated ``kanban_block``) — a sticky
+      block that survives until explicit ``kanban_unblock`` (#28712).
+
+    * The task has **no parents** and is blocked by the circuit breaker
+      (``gave_up`` event, not ``blocked``).  A parentless blocked task
+      has no dependency to wait for; promoting it would create an
+      infinite crash loop since the failure condition (bad profile,
+      missing skill, auth error) cannot be resolved by re-dispatch.
+      These tasks stay ``blocked`` until an operator runs
+      ``kanban_unblock`` or the underlying issue is fixed.
+
+    On promotion of a circuit-breaker-blocked task **with parents**
+    (i.e. a parent just completed), the ``consecutive_failures`` counter
+    is reset to 0 — the conditions that caused the failure may have
+    changed.  This preserves the original auto-recovery semantics of
+    #40c1decb3 for tasks that have a legitimate dependency chain.
     """
     promoted = 0
     with write_txn(conn):
@@ -2128,17 +2141,41 @@ def recompute_ready(conn: sqlite3.Connection) -> int:
                 "WHERE l.child_id = ?",
                 (task_id,),
             ).fetchall()
+            # Vacuous-truth guard: if the task has no parents, a
+            # circuit-breaker block has nothing to wait for.  Promoting
+            # it back to ready only re-queues tasks that crash on every
+            # dispatch tick, creating an infinite crash loop
+            # (gave_up → promote → spawn → crash → gave_up → …).
+            # Parentless tasks blocked by the circuit breaker should
+            # stay blocked until a human intervenes with
+            # ``kanban_unblock``.
+            has_parents = len(parents) > 0
             if all(p["status"] in ("done", "archived") for p in parents):
                 # Blocked tasks also get their failure counters reset —
                 # this is effectively an auto-unblock (circuit-breaker
                 # recovery; worker-initiated blocks are skipped above).
                 if cur_status == "blocked":
-                    conn.execute(
-                        "UPDATE tasks SET status = 'ready', "
-                        "consecutive_failures = 0, last_failure_error = NULL "
-                        "WHERE id = ? AND status = 'blocked'",
-                        (task_id,),
-                    )
+                    # Only reset failure counters when the conditions
+                    # that caused the block have actually changed (a
+                    # parent completed).  For circuit-breaker blocks on
+                    # parentless tasks the failure was deterministic and
+                    # resetting would let the dispatcher re-spawn and
+                    # crash on every tick.
+                    if has_parents:
+                        conn.execute(
+                            "UPDATE tasks SET status = 'ready', "
+                            "consecutive_failures = 0, last_failure_error = NULL "
+                            "WHERE id = ? AND status = 'blocked'",
+                            (task_id,),
+                        )
+                    else:
+                        # Parentless blocked task (circuit-breaker) —
+                        # skip promotion entirely.  The sticky-block
+                        # check above already catches worker-initiated
+                        # blocks; this catches the non-sticky
+                        # circuit-breaker path for tasks with no
+                        # parents to complete.
+                        continue
                 else:
                     conn.execute(
                         "UPDATE tasks SET status = 'ready' WHERE id = ? AND status = 'todo'",

--- a/tests/hermes_cli/test_kanban_blocked_sticky.py
+++ b/tests/hermes_cli/test_kanban_blocked_sticky.py
@@ -168,31 +168,34 @@ def test_unblock_clears_sticky_state_and_lets_block_recover(kanban_home: Path) -
     """``hermes kanban unblock`` (or the ``kanban_unblock`` tool) is
     the only legitimate way out of a worker-initiated block.  After
     unblock, a *subsequent* circuit-breaker block on the same task
-    must again be eligible for auto-recovery."""
+    must again be eligible for auto-recovery — but only if the task
+    has parents whose completion could change the conditions."""
     with kb.connect() as conn:
-        tid = kb.create_task(conn, title="t")
-        kb.claim_task(conn, tid)
+        parent = kb.create_task(conn, title="parent")
+        child = kb.create_task(conn, title="child", parents=[parent])
+        kb.complete_task(conn, parent, result="ok")
+        kb.claim_task(conn, child)
         kb.block_task(
-            conn, tid,
+            conn, child,
             reason="review-required: ...",
-            expected_run_id=kb.get_task(conn, tid).current_run_id,
+            expected_run_id=kb.get_task(conn, child).current_run_id,
         )
-        assert kb.unblock_task(conn, tid)
+        assert kb.unblock_task(conn, child)
         # After unblock the task is no longer blocked at all.
-        assert kb.get_task(conn, tid).status == "ready"
+        assert kb.get_task(conn, child).status == "ready"
 
         # Now simulate a *later* circuit-breaker block (no new
         # ``blocked`` event, just status flip).  The most recent
         # block/unblock event is ``unblocked`` → guard does not fire
         # → recompute can recover.
         conn.execute(
-            "UPDATE tasks SET status='blocked' WHERE id=?", (tid,),
+            "UPDATE tasks SET status='blocked' WHERE id=?", (child,),
         )
         conn.commit()
 
         promoted = kb.recompute_ready(conn)
         assert promoted == 1
-        assert kb.get_task(conn, tid).status == "ready"
+        assert kb.get_task(conn, child).status == "ready"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_kanban_crash_loop.py
+++ b/tests/hermes_cli/test_kanban_crash_loop.py
@@ -1,0 +1,281 @@
+"""Regression tests for the parentless crash-loop bug.
+
+When a task has no parents (no task_links rows), ``recompute_ready`` previously
+promoted it from ``blocked`` back to ``ready`` on every dispatcher tick because
+``all([]) is True`` (vacuous truth).  The circuit-breaker would block it, the
+dispatcher would immediately promote it, and an infinite loop resulted:
+
+    gave_up → promote → spawn → crash → gave_up → promote → …
+
+The fix (two parts):
+
+1. **Vacuous-truth guard**: ``recompute_ready`` now skips promotion of
+   parentless blocked tasks.  A task with no parents has no dependency to
+   wait for; promoting it only re-queues a deterministic crash.
+
+2. **Failure-counter reset guard**: When a blocked task **with** parents is
+   promoted (because a parent just completed), ``consecutive_failures`` is
+   reset to 0 as before — the conditions that caused the failure may have
+   changed.  But we never reach this code path for parentless tasks now.
+
+See: kanban_db.py ``recompute_ready()``, PR #XXXXX
+"""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+
+
+@pytest.fixture
+def kanban_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Isolated HERMES_HOME with an empty kanban DB."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    return home
+
+
+# ---------------------------------------------------------------------------
+# Part 1: Vacuous-truth guard — parentless blocked tasks stay blocked
+# ---------------------------------------------------------------------------
+
+
+def test_parentless_circuit_breaker_block_is_not_promoted(kanban_home: Path) -> None:
+    """A parentless task blocked by the circuit breaker (no ``blocked`` event,
+    only ``gave_up``) must NOT be promoted back to ``ready`` by
+    ``recompute_ready``.  Promoting it would create an infinite crash loop
+    because there's no dependency to wait for — the task will fail the
+    same way on every dispatch tick."""
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="orphan task", assignee="worker")
+        # Simulate circuit-breaker block: flip status directly, no
+        # ``blocked`` event, plus a ``gave_up`` event — exactly what
+        # ``_record_task_failure`` produces.
+        conn.execute(
+            "UPDATE tasks SET status='blocked', "
+            "consecutive_failures=3, last_failure_error='unauthorized' "
+            "WHERE id=?",
+            (tid,),
+        )
+        conn.execute(
+            "INSERT INTO task_events (task_id, kind, payload, created_at) "
+            "VALUES (?, 'gave_up', '{\"failures\": 3}', ?)",
+            (tid, int(time.time())),
+        )
+        conn.commit()
+
+        # Must NOT promote — parentless circuit-breaker blocks stay blocked.
+        for _ in range(5):
+            promoted = kb.recompute_ready(conn)
+            assert promoted == 0, (
+                "parentless circuit-breaker block must not be promoted"
+            )
+            assert kb.get_task(conn, tid).status == "blocked"
+
+
+def test_parentless_circuit_breaker_block_stays_blocked_across_dispatch_ticks(kanban_home: Path) -> None:
+    """Full end-to-end simulation of the crash loop.  After the dispatcher
+    auto-blocks a parentless task (via ``gave_up``), subsequent
+    ``recompute_ready`` calls must not promote it — the loop is broken."""
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="crash loop reproducer", assignee="worker")
+        # Simulate: worker crashes, dispatcher auto-blocks.
+        claim = kb.claim_task(conn, tid)
+        assert claim is not None
+        # Worker exits with code 1 → detect_crashed_workers flips to ready,
+        # _record_task_failure trips breaker → blocked + gave_up.
+        # We simulate that end state:
+        conn.execute(
+            "UPDATE tasks SET status='blocked', "
+            "consecutive_failures=3, last_failure_error='pid 999 exited with code 1' "
+            "WHERE id=?",
+            (tid,),
+        )
+        conn.execute(
+            "INSERT INTO task_events (task_id, kind, payload, created_at) "
+            "VALUES (?, 'crashed', '{\"pid\": 999}', ?)",
+            (tid, int(time.time())),
+        )
+        conn.execute(
+            "INSERT INTO task_events (task_id, kind, payload, created_at) "
+            "VALUES (?, 'gave_up', '{\"failures\": 3, \"error\": \"pid 999\"}', ?)",
+            (tid, int(time.time()) + 1),
+        )
+        conn.commit()
+
+        # Subsequent dispatcher ticks — must NOT promote.
+        for _ in range(10):
+            assert kb.recompute_ready(conn) == 0
+            task = kb.get_task(conn, tid)
+            assert task.status == "blocked"
+            assert task.consecutive_failures == 3
+
+
+def test_parentless_task_with_manual_kanban_block_is_also_sticky(kanban_home: Path) -> None:
+    """A parentless task that a worker explicitly blocked via
+    ``kanban_block`` is sticky (the #28712 guard) AND is also a
+    parentless blocked task.  Both guards should keep it blocked."""
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="review request", assignee="worker")
+        kb.claim_task(conn, tid)
+        kb.block_task(
+            conn, tid,
+            reason="review-required: please check",
+            expected_run_id=kb.get_task(conn, tid).current_run_id,
+        )
+        assert kb.get_task(conn, tid).status == "blocked"
+
+        for _ in range(5):
+            assert kb.recompute_ready(conn) == 0
+            assert kb.get_task(conn, tid).status == "blocked"
+
+
+# ---------------------------------------------------------------------------
+# Part 2: Parented tasks still auto-recover (existing semantics preserved)
+# ---------------------------------------------------------------------------
+
+
+def test_blocked_task_with_done_parents_still_auto_promotes(kanban_home: Path) -> None:
+    """A blocked task with a completed parent should still be promoted to
+    ``ready`` and have its failure counter reset.  This preserves the
+    pre-existing auto-recovery semantics for tasks that have a legitimate
+    dependency waiting to resolve."""
+    with kb.connect() as conn:
+        parent = kb.create_task(conn, title="parent", assignee="a")
+        child = kb.create_task(
+            conn, title="child", assignee="a", parents=[parent],
+        )
+        kb.claim_task(conn, parent)
+        kb.complete_task(conn, parent, result="ok")
+
+        # Circuit-breaker block (no ``blocked`` event, ``gave_up`` only).
+        conn.execute(
+            "UPDATE tasks SET status='blocked', "
+            "consecutive_failures=5, last_failure_error='auth error' "
+            "WHERE id=?",
+            (child,),
+        )
+        conn.commit()
+
+        promoted = kb.recompute_ready(conn)
+        assert promoted == 1
+        task = kb.get_task(conn, child)
+        assert task.status == "ready"
+        assert task.consecutive_failures == 0
+        assert task.last_failure_error is None
+
+
+def test_blocked_task_with_incomplete_parents_stays_blocked(kanban_home: Path) -> None:
+    """A blocked task whose parent is NOT done stays blocked — no vacuous
+    truth issue because the task actually has a parent, just not done yet."""
+    with kb.connect() as conn:
+        parent = kb.create_task(conn, title="parent", assignee="a")
+        child = kb.create_task(
+            conn, title="child", assignee="a", parents=[parent],
+        )
+        # Parent is still todo, not done.
+        conn.execute(
+            "UPDATE tasks SET status='blocked', "
+            "consecutive_failures=2, last_failure_error='error' "
+            "WHERE id=?",
+            (child,),
+        )
+        conn.commit()
+
+        assert kb.recompute_ready(conn) == 0
+        task = kb.get_task(conn, child)
+        assert task.status == "blocked"
+        assert task.consecutive_failures == 2
+
+
+# ---------------------------------------------------------------------------
+# Part 3: Failure counter reset guard
+# ---------------------------------------------------------------------------
+
+
+def test_parentless_blocked_task_failure_counter_not_reset(kanban_home: Path) -> None:
+    """For a parentless blocked task, ``recompute_ready`` must skip it
+    entirely -- neither promote nor reset ``consecutive_failures``.
+    If the counter were reset without promoting, it would defeat the
+    circuit breaker on the next dispatch tick."""
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="orphan", assignee="worker")
+        conn.execute(
+            "UPDATE tasks SET status='blocked', "
+            "consecutive_failures=7, last_failure_error='unauthorized' "
+            "WHERE id=?",
+            (tid,),
+        )
+        conn.execute(
+            "INSERT INTO task_events (task_id, kind, payload, created_at) "
+            "VALUES (?, 'gave_up', NULL, ?)",
+            (tid, int(time.time())),
+        )
+        conn.commit()
+
+        kb.recompute_ready(conn)
+        task = kb.get_task(conn, tid)
+        # Task stays blocked, counter stays at 7 — not promoted, not reset.
+        assert task.status == "blocked"
+        assert task.consecutive_failures == 7
+        assert task.last_failure_error == "unauthorized"
+
+
+# ---------------------------------------------------------------------------
+# Part 4: Unblocked parentless task can still be dispatched
+# ---------------------------------------------------------------------------
+
+
+def test_unblocked_parentless_task_becomes_ready(kanban_home: Path) -> None:
+    """After ``kanban_unblock``, a parentless task should transition to
+    ``ready`` so it can be dispatched again (e.g. after an operator fixes
+    the underlying issue like a bad API key)."""
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="will unblock", assignee="worker")
+        # Block it (circuit-breaker style, no ``blocked`` event).
+        conn.execute(
+            "UPDATE tasks SET status='blocked', "
+            "consecutive_failures=2, last_failure_error='bad auth' "
+            "WHERE id=?",
+            (tid,),
+        )
+        conn.execute(
+            "INSERT INTO task_events (task_id, kind, payload, created_at) "
+            "VALUES (?, 'gave_up', NULL, ?)",
+            (tid, int(time.time())),
+        )
+        conn.commit()
+        assert kb.get_task(conn, tid).status == "blocked"
+
+        # Operator fixes the issue and unblocks.
+        assert kb.unblock_task(conn, tid)
+        task = kb.get_task(conn, tid)
+        assert task.status == "ready"
+        # unblock_task resets failure counters.
+        assert task.consecutive_failures == 0
+
+
+def test_parentless_todo_task_is_promoted_normally(kanban_home: Path) -> None:
+    """A parentless task in ``todo`` status (manually set) should still be
+    promoted to ``ready`` by ``recompute_ready`` -- todo -> ready is the
+    normal promotion path and is unrelated to the circuit breaker.
+    
+    Note: ``create_task`` with no parents already sets status to ``ready``,
+    so we manually flip a task to ``todo`` to test this path."""
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="normal todo", assignee="worker")
+        # Create_task with no parents sets status='ready'. Manually flip to todo.
+        conn.execute("UPDATE tasks SET status='todo' WHERE id=?", (tid,))
+        conn.commit()
+        assert kb.get_task(conn, tid).status == "todo"
+        # With no parents, this should be promoted to ready.
+        promoted = kb.recompute_ready(conn)
+        assert promoted == 1
+        assert kb.get_task(conn, tid).status == "ready"


### PR DESCRIPTION
## Problem

The kanban dispatcher's `recompute_ready()` promoted parentless blocked tasks back to `ready` on every tick because `all([]) is True` (vacuous truth). This defeated the circuit breaker: a task would crash, get auto-blocked (`gave_up` event), then immediately be promoted back, have its `consecutive_failures` counter reset to 0, and the cycle repeats forever.

### Crash loop trace

```
gave_up → promote → claim → spawn → crash → gave_up → promote → ...
```

Observed in production: **509 crashes on a single task**, **8,343 `gave_up` events**, **500+ zombie processes** created every 60 seconds. Each task with `consecutive_failures` reset to 1 on every cycle because `gave_up` trips at `failure_limit=1` (protocol violations / systemic failures), then `recompute_ready` immediately promotes and resets the counter.

### Root cause

In `recompute_ready()` (kanban_db.py line ~2125):

1. `blocked` tasks are considered for promotion (correct for dependent tasks whose parent just completed)
2. `_has_sticky_block()` correctly skips worker-initiated `kanban_block` calls, but circuit-breaker blocks (`gave_up` event, non-sticky) pass through
3. For parentless tasks: `parents = conn.execute("SELECT ... FROM task_links WHERE child_id = ?", (task_id,)).fetchall()` returns `[]`, and `all([]) == True` — vacuous truth promotes them
4. Line 2135-2139 resets `consecutive_failures = 0` on promotion, so the breaker never accumulates

## Fix

Two changes:

### 1. Vacuous-truth guard (primary fix)

`recompute_ready()` now skips promotion of parentless blocked tasks. A task with no parents has no dependency to wait for; promoting it only re-queues a deterministic crash. These tasks stay `blocked` until an operator runs `kanban_unblock` (e.g. after fixing the underlying issue: bad API key, missing skill, auth error).

```python
has_parents = len(parents) > 0
if all(p["status"] in ("done", "archived") for p in parents):
    if cur_status == "blocked":
        if has_parents:
            # Original behavior: promote and reset counters
        else:
            # New: skip parentless blocked tasks entirely
            continue
```

### 2. Failure-counter reset guard (belt-and-suspenders)

When a blocked task **with** parents is promoted (because a parent just completed), `consecutive_failures` is still reset to 0 — the conditions that caused the failure may have changed. This preserves the original auto-recovery semantics (#40c1decb3) for tasks with a legitimate dependency chain.

### What's NOT changed

- Parentless `todo` tasks still promote to `ready` normally (the guard only applies to `blocked` → `ready` transitions)
- Parented blocked tasks still auto-recover when their parent completes
- Worker-initiated `kanban_block` stays sticky (the #28712 guard is untouched)
- `kanban_unblock` still works — operators can manually unblock parentless tasks after fixing the underlying issue

## Testing

- **8 new tests** in `test_kanban_crash_loop.py` covering all combinations:
  - Parentless circuit-breaker block stays blocked (×5 iterations, ×10 dispatch ticks)
  - Parentless task with manual `kanban_block` stays blocked (sticky + vacuous)
  - Parented blocked task with done parent auto-promotes (existing semantics preserved)
  - Parented blocked task with incomplete parent stays blocked
  - Parentless blocked task failure counter not reset
  - Unblocked parentless task becomes ready (operator can still recover)
  - Parentless `todo` task promotes normally (guard only affects `blocked`)
- **1 updated test** in `test_kanban_blocked_sticky.py`:
  - `test_unblock_clears_sticky_state_and_lets_block_recover` now uses a task with parents to match the new semantics
- **All 557 existing kanban tests pass** (159 in `test_kanban_db.py`, 6 in `test_kanban_blocked_sticky.py`, plus others)