### PR TITLE
fix(openviking): store memories via content/write API instead of session messages

### DIFF
--- a/plugins/memory/openviking/__init__.py
+++ b/plugins/memory/openviking/__init__.py
@@ -608,7 +608,7 @@ class OpenVikingMemoryProvider(MemoryProvider):
             logger.warning("OpenViking session commit failed: %s", e)
 
     def on_memory_write(self, action: str, target: str, content: str) -> None:
-        """Mirror built-in memory writes to OpenViking as explicit memories."""
+        """Mirror built-in memory writes to OpenViking via content/write."""
         if not self._client or action != "add" or not content:
             return
 
@@ -618,13 +618,12 @@ class OpenVikingMemoryProvider(MemoryProvider):
                     self._endpoint, self._api_key,
                     account=self._account, user=self._user, agent=self._agent,
                 )
-                # Add as a user message with memory context so the commit
-                # picks it up as an explicit memory during extraction
-                client.post(f"/api/v1/sessions/{self._session_id}/messages", {
-                    "role": "user",
-                    "parts": [
-                        {"type": "text", "text": f"[Memory note — {target}] {content}"},
-                    ],
+                slug = uuid.uuid4().hex[:12]
+                uri = f"viking://user/{client._user}/memories/preferences/mem_{slug}.md"
+                client.post("/api/v1/content/write", {
+                    "uri": uri,
+                    "content": content,
+                    "mode": "create",
                 })
             except Exception as e:
                 logger.debug("OpenViking memory mirror failed: %s", e)
@@ -858,24 +857,40 @@ class OpenVikingMemoryProvider(MemoryProvider):
         if not content:
             return tool_error("content is required")
 
-        # Store as a session message that will be extracted during commit.
-        # The category hint helps OpenViking's extraction classify correctly.
         category = args.get("category", "")
-        text = f"[Remember] {content}"
-        if category:
-            text = f"[Remember — {category}] {content}"
 
-        self._client.post(f"/api/v1/sessions/{self._session_id}/messages", {
-            "role": "user",
-            "parts": [
-                {"type": "text", "text": text},
-            ],
-        })
+        # Map category to a viking:// subdirectory for organized storage
+        subdir_map = {
+            "preference": "preferences",
+            "entity": "entities",
+            "event": "events",
+            "case": "cases",
+            "pattern": "patterns",
+        }
+        subdir = subdir_map.get(category, "preferences")
 
-        return json.dumps({
-            "status": "stored",
-            "message": "Memory recorded. Will be extracted and indexed on session commit.",
-        })
+        # Build a deterministic URI with UUID to avoid collisions
+        usr = self._user
+        slug = uuid.uuid4().hex[:12]
+        uri = f"viking://user/{usr}/memories/{subdir}/mem_{slug}.md"
+
+        # Write directly via content/write API.
+        # This creates the file, stores the content, and queues vector indexing
+        # in a single call — no dependency on session commit / VLM extraction.
+        try:
+            result = self._client.post("/api/v1/content/write", {
+                "uri": uri,
+                "content": content,
+                "mode": "create",
+            })
+            written = result.get("result", {}).get("written_bytes", 0)
+            return json.dumps({
+                "status": "stored",
+                "message": f"Memory stored ({written}b) and queued for vector indexing.",
+            })
+        except Exception as e:
+            logger.error("OpenViking content/write failed: %s", e)
+            return tool_error(f"Failed to store memory: {e}")
 
     def _tool_add_resource(self, args: dict) -> str:
         url = args.get("url", "")


### PR DESCRIPTION
## What

`_tool_remember` and `on_memory_write` in the OpenViking memory provider were posting memories as session messages that depend on commit-time VLM extraction to persist. With `extraction_enabled: false` (no VLM configured), the extraction pipeline never processes these messages — memories are silently lost.

Replace both paths with direct POST to `/api/v1/content/write?mode=create`, which creates the file, stores the content, and queues vector indexing in a single API call. Error reporting is immediate — no silent failures.

## Changes

### `_tool_remember`
| Before (broken) | After |
|---|---|
| POST to session messages -> wait for commit extraction -> never indexed | POST to `content/write?mode=create` -> immediately queued for indexing |
| Category only decorates message text | Category maps to proper `viking://` subdirectory (preferences, entities, events, cases, patterns) |
| Returns "Will be extracted on session commit" (never happened) | Returns actual byte count + "queued for vector indexing" |
| Silent failure on extraction | Immediate error on write failure |

### `on_memory_write`
Same pattern: was posting `[Memory note - target] content` to session messages. Now writes directly to `content/write`.

## How to test

1. Call `viking_remember(category="event", content="test")`
2. Response should say `Memory stored (Xb) and queued for vector indexing` (not "...extracted on session commit")
3. `viking_search(query="test")` should return the memory immediately (score > 0.8)
4. `viking_read(uri=<result>)` should return the exact content written

## Related

- Closes #17998
- Replaces closed PR #29664 (was titled "bypass broken extraction pipeline" — this is the proper fix, not a workaround)
- Previous approach had fallback to session messages; this removes the dead code entirely

## Checklist
- [x] Single logical change
- [x] Conventional commit format
- [x] 30 tests passing
- [x] End-to-end tested against live OpenViking instance
