### PR TITLE
fix(kanban): strip session env vars from worker spawn

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -5293,6 +5293,23 @@ def _default_spawn(
     prompt = f"work kanban task {task.id}"
     env = dict(os.environ)
 
+    # Strip session-level env vars inherited from the parent process.
+    # When the dispatcher runs inside a gateway agent loop, env contains
+    # HERMES_SESSION_ID and other chat-context vars that would pin the
+    # worker to the dispatcher's session. Workers must start with a clean
+    # session state — the kanban-specific vars set below are the only
+    # Hermes context the worker should inherit.
+    _SESSION_ENV_STRIP = {
+        "HERMES_SESSION_ID",
+        "HERMES_CHAT_ID",
+        "HERMES_THREAD_ID",
+        "HERMES_USER_ID",
+        "HERMES_PLATFORM",
+        "HERMES_GATEWAY_MODE",
+    }
+    for key in _SESSION_ENV_STRIP:
+        env.pop(key, None)
+
     # Inject HERMES_HOME so the worker reads the profile-scoped config.yaml
     # (fallback_providers, toolsets, agent settings, etc.) instead of the root
     # config.  Without this, `env = dict(os.environ)` copies only the parent's


### PR DESCRIPTION
Title: fix(kanban): strip session env vars from worker spawn

Description:
When the kanban dispatcher runs inside a gateway agent loop, os.environ contains HERMES_SESSION_ID and other chat-context env vars that get inherited by _default_spawn() via dict(os.environ). This pins workers to the dispatcher's session, causing context pollution and missing tool registrations.

Added env var stripping right after the initial os.environ copy in _default_spawn(). Removes HERMES_SESSION_ID, HERMES_CHAT_ID, HERMES_THREAD_ID, HERMES_USER_ID, HERMES_PLATFORM, HERMES_GATEWAY_MODE — kanban-specific vars set later in the function are unaffected.

60 kanban tests pass.