### PR TITLE
fix(kimi-k2): parse inline tool calls from content string

### DIFF
--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -16,6 +16,7 @@ from agent.lmstudio_reasoning import resolve_lmstudio_effort
 from agent.moonshot_schema import is_moonshot_model, sanitize_moonshot_tools
 from agent.prompt_builder import DEVELOPER_ROLE_MODELS
 from agent.transports.base import ProviderTransport
+from agent.transports.kimi_k2_parser import try_parse as try_parse_k2
 from agent.transports.types import NormalizedResponse, ToolCall, Usage
 
 
@@ -529,6 +530,11 @@ class ChatCompletionsTransport(ProviderTransport):
         is preserved via ToolCall.provider_data.  reasoning_details (OpenRouter
         unified format) and reasoning_content (DeepSeek/Moonshot) are also
         preserved for downstream replay.
+
+        When ``msg.tool_calls`` is empty but the content contains Kimi K2
+        inline tool-call markers (``<|tool_calls_section_begin|>``), a K2
+        parser fallback reconstructs ``ToolCall`` objects from the embedded
+        JSON and strips the markers from the content string.
         """
         choice = response.choices[0]
         msg = choice.message
@@ -561,6 +567,16 @@ class ChatCompletionsTransport(ProviderTransport):
                         provider_data=tc_provider_data or None,
                     )
                 )
+
+        # Fallback: Kimi K2 (OpenRouter/Moonshot) embeds tool calls inside
+        # the content string when the structured ``tool_calls`` field is
+        # empty.  Parse them out so the agent loop sees proper ToolCall
+        # objects rather than raw tagged text.
+        if not tool_calls:
+            content, parsed = try_parse_k2(msg.content)
+            if parsed:
+                tool_calls = parsed
+                msg.content = content
 
         usage = None
         if hasattr(response, "usage") and response.usage:

--- a/agent/transports/kimi_k2_parser.py
+++ b/agent/transports/kimi_k2_parser.py
@@ -1,0 +1,106 @@
+"""Parser for Kimi K2 inline tool-call format.
+
+Kimi K2 (via OpenRouter and Moonshot) sometimes returns tool calls
+embedded inside the content string as tagged JSON instead of in the
+structured ``tool_calls`` field.  This module detects and normalises
+that format so the agent loop receives proper ``ToolCall`` objects.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Any
+
+from agent.transports.types import ToolCall
+
+# Kimi K2 inline markers
+_SECTION_BEGIN = "<|tool_calls_section_begin|>"
+_SECTION_END = "<|tool_calls_section_end|>"
+_CALL_BEGIN = "<|tool_call_begin|>"
+_CALL_END = "<|tool_call_end|>"
+
+# Matches a single tool call: <|tool_call_begin|>{...json...}<|tool_call_end|>
+_CALL_RE = re.compile(
+    re.escape(_CALL_BEGIN) + r"(\{.*?\})" + re.escape(_CALL_END),
+    re.DOTALL,
+)
+
+
+def _has_k2_markers(content: str | None) -> bool:
+    """Return ``True`` if *content* has Kimi K2 tool-call markers."""
+    return bool(content) and _SECTION_BEGIN in content
+
+
+def _strip_section(content: str) -> str:
+    """Remove all ``<|tool_calls_section_begin|>...<|tool_calls_section_end|>`` blocks."""
+    result = content
+    while True:
+        si = result.find(_SECTION_BEGIN)
+        if si == -1:
+            break
+        ei = result.find(_SECTION_END, si)
+        if ei == -1:
+            break
+        result = result[:si] + result[ei + len(_SECTION_END):]
+    return result
+
+
+def _json_arg(value: Any) -> str:
+    """Normalise *value* to a JSON string for ``ToolCall.arguments``."""
+    if isinstance(value, dict):
+        return json.dumps(value)
+    if isinstance(value, str):
+        return value
+    return str(value)
+
+
+def _build_call(data: dict[str, Any]) -> ToolCall | None:
+    """Build a ``ToolCall`` from a parsed K2 JSON dict, or ``None`` if invalid."""
+    name = data.get("name", "")
+    if not name:
+        return None
+    arguments = _json_arg(data.get("arguments", {}))
+    call_id = data.get("id")
+    return ToolCall(
+        id=str(call_id) if call_id else None,
+        name=name,
+        arguments=arguments,
+    )
+
+
+def parse_k2_tool_calls(content: str) -> tuple[str | None, list[ToolCall]]:
+    """Extract ``ToolCall`` objects embedded in a Kimi K2 content string.
+
+    Returns ``(cleaned_content, tool_calls)`` where *cleaned_content* is
+    *content* with all tool-call sections removed (or ``None`` if nothing
+    remains after stripping).
+    """
+    tool_calls: list[ToolCall] = []
+
+    for match in _CALL_RE.finditer(content):
+        raw = match.group(1)
+        try:
+            data: dict[str, Any] = json.loads(raw)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(data, dict):
+            continue
+        tc = _build_call(data)
+        if tc is not None:
+            tool_calls.append(tc)
+
+    cleaned = _strip_section(content).strip() or None
+    return cleaned, tool_calls
+
+
+def try_parse(content: str | None) -> tuple[str | None, list[ToolCall] | None]:
+    """Attempt to parse Kimi K2 tool calls from *content*.
+
+    Returns ``(cleaned_content, tool_calls)`` when K2 markers are found,
+    or ``(content, None)`` when they are not (so callers can use the
+    return value unconditionally).
+    """
+    if not _has_k2_markers(content):
+        return content, None
+    return parse_k2_tool_calls(content)  # type: ignore[arg-type]

--- a/tests/agent/transports/test_kimi_k2_parser.py
+++ b/tests/agent/transports/test_kimi_k2_parser.py
@@ -1,0 +1,189 @@
+"""Tests for the Kimi K2 inline tool-call parser."""
+
+import json
+
+import pytest
+from agent.transports.kimi_k2_parser import (
+    try_parse,
+    parse_k2_tool_calls,
+    _has_k2_markers,
+    _strip_section,
+)
+
+
+class TestHasK2Markers:
+    def test_detects_section_begin(self):
+        assert _has_k2_markers("<|tool_calls_section_begin|>...")
+
+    def test_none_content(self):
+        assert not _has_k2_markers(None)
+
+    def test_empty_content(self):
+        assert not _has_k2_markers("")
+
+    def test_plain_text(self):
+        assert not _has_k2_markers("Hello world")
+
+
+class TestStripSection:
+    def test_strip_single_section(self):
+        result = _strip_section("a<|tool_calls_section_begin|>stuff<|tool_calls_section_end|>b")
+        assert result == "ab"
+
+    def test_strip_trailing_text(self):
+        result = _strip_section("lead<|tool_calls_section_begin|>inner<|tool_calls_section_end|>trail")
+        assert result == "leadtrail"
+
+    def test_strip_multiple_sections(self):
+        result = _strip_section(
+            "a<|tool_calls_section_begin|>1<|tool_calls_section_end|>"
+            "b<|tool_calls_section_begin|>2<|tool_calls_section_end|>c"
+        )
+        assert result == "abc"
+
+    def test_no_section_passthrough(self):
+        assert _strip_section("hello") == "hello"
+
+
+class TestParseK2ToolCalls:
+    def test_basic(self):
+        content = (
+            "I'll search.\n"
+            "<|tool_calls_section_begin|>\n"
+            '<|tool_call_begin|>{"name": "web_search", "arguments": {"q": "hi"}, "id": "c1"}<|tool_call_end|>\n'
+            "<|tool_calls_section_end|>"
+        )
+        cleaned, calls = parse_k2_tool_calls(content)
+        assert len(calls) == 1
+        assert calls[0].name == "web_search"
+        assert calls[0].id == "c1"
+        assert '"q": "hi"' in calls[0].arguments
+        assert cleaned == "I'll search."
+
+    def test_multiple_tool_calls(self):
+        content = (
+            "<|tool_calls_section_begin|>"
+            '<|tool_call_begin|>{"name": "a", "arguments": {}, "id": "1"}<|tool_call_end|>'
+            '<|tool_call_begin|>{"name": "b", "arguments": {"x": 1}, "id": "2"}<|tool_call_end|>'
+            "<|tool_calls_section_end|>"
+        )
+        cleaned, calls = parse_k2_tool_calls(content)
+        assert len(calls) == 2
+        assert calls[0].name == "a"
+        assert calls[1].name == "b"
+        assert cleaned is None  # content was only tags
+
+    def test_no_id(self):
+        content = (
+            "<|tool_calls_section_begin|>"
+            '<|tool_call_begin|>{"name": "search", "arguments": {"q": "test"}}<|tool_call_end|>'
+            "<|tool_calls_section_end|>"
+        )
+        _, calls = parse_k2_tool_calls(content)
+        assert len(calls) == 1
+        assert calls[0].id is None
+
+    def test_arguments_as_dict(self):
+        content = (
+            "<|tool_calls_section_begin|>"
+            '<|tool_call_begin|>{"name": "f", "arguments": {"key": "value"}, "id": "c1"}<|tool_call_end|>'
+            "<|tool_calls_section_end|>"
+        )
+        _, calls = parse_k2_tool_calls(content)
+        assert json.loads(calls[0].arguments) == {"key": "value"}
+
+    def test_arguments_as_string(self):
+        content = (
+            "<|tool_calls_section_begin|>"
+            '<|tool_call_begin|>{"name": "f", "arguments": "{\\"key\\": \\"value\\"}", "id": "c1"}<|tool_call_end|>'
+            "<|tool_calls_section_end|>"
+        )
+        _, calls = parse_k2_tool_calls(content)
+        assert json.loads(calls[0].arguments) == {"key": "value"}
+
+    def test_empty_name_skipped(self):
+        content = (
+            "<|tool_calls_section_begin|>"
+            '<|tool_call_begin|>{"name": "", "arguments": {}, "id": "c1"}<|tool_call_end|>'
+            '<|tool_call_begin|>{"name": "real", "arguments": {}, "id": "c2"}<|tool_call_end|>'
+            "<|tool_calls_section_end|>"
+        )
+        _, calls = parse_k2_tool_calls(content)
+        assert len(calls) == 1
+        assert calls[0].name == "real"
+
+    def test_malformed_json_skipped(self):
+        content = (
+            "<|tool_calls_section_begin|>"
+            '<|tool_call_begin|>{not-json}<|tool_call_end|>'
+            '<|tool_call_begin|>{"name": "ok", "arguments": {}, "id": "c1"}<|tool_call_end|>'
+            "<|tool_calls_section_end|>"
+        )
+        _, calls = parse_k2_tool_calls(content)
+        assert len(calls) == 1
+        assert calls[0].name == "ok"
+
+    def test_not_a_dict_skipped(self):
+        content = (
+            "<|tool_calls_section_begin|>"
+            '<|tool_call_begin|>"just a string"<|tool_call_end|>'
+            '<|tool_call_begin|>{"name": "ok", "arguments": {}, "id": "c1"}<|tool_call_end|>'
+            "<|tool_calls_section_end|>"
+        )
+        _, calls = parse_k2_tool_calls(content)
+        assert len(calls) == 1
+        assert calls[0].name == "ok"
+
+    def test_extra_fields_preserved(self):
+        content = (
+            "<|tool_calls_section_begin|>"
+            '<|tool_call_begin|>{"name": "f", "type": "function", "arguments": {"x": 1}, "id": "c1", "extra": "val"}<|tool_call_end|>'
+            "<|tool_calls_section_end|>"
+        )
+        _, calls = parse_k2_tool_calls(content)
+        assert len(calls) == 1
+        assert calls[0].name == "f"
+        assert calls[0].id == "c1"
+
+
+class TestTryParse:
+    def test_no_markers_returns_original(self):
+        content, calls = try_parse("Hello world")
+        assert content == "Hello world"
+        assert calls is None
+
+    def test_none_passthrough(self):
+        content, calls = try_parse(None)
+        assert content is None
+        assert calls is None
+
+    def test_empty_passthrough(self):
+        content, calls = try_parse("")
+        assert content == ""
+        assert calls is None
+
+    def test_with_markers_parses(self):
+        content = (
+            "<|tool_calls_section_begin|>"
+            '<|tool_call_begin|>{"name": "search", "arguments": {"q": "x"}, "id": "c1"}<|tool_call_end|>'
+            "<|tool_calls_section_end|>"
+        )
+        cleaned, calls = try_parse(content)
+        assert calls is not None
+        assert len(calls) == 1
+        assert calls[0].name == "search"
+
+    def test_content_before_and_after(self):
+        content = (
+            "Before.\n"
+            "<|tool_calls_section_begin|>"
+            '<|tool_call_begin|>{"name": "a", "arguments": {}, "id": "1"}<|tool_call_end|>'
+            "<|tool_calls_section_end|>"
+            "\nAfter."
+        )
+        cleaned, calls = try_parse(content)
+        assert cleaned == "Before.\n\nAfter."
+        assert len(calls) == 1
+
+
+


### PR DESCRIPTION
Title: fix(kimi-k2): parse inline tool calls from content string

Description:
Kimi K2 (via OpenRouter/Moonshot) returns tool calls embedded as tagged JSON inside the content string (<|tool_calls_section_begin|><|tool_call_begin|>{...}<|tool_call_end|><|tool_calls_section_end|>) instead of in the structured tool_calls field. The agent loop then receives raw tagged text as content, leaking tool-call tokens into downstream messages.

Added agent/transports/kimi_k2_parser.py with a try_parse() function that detects K2 markers and reconstructs proper ToolCall objects. Wired it into ChatCompletionsTransport.normalize_response() as a fallback when msg.tool_calls is empty but K2 markers are present. The content is cleaned of the tool-call section after parsing.

67 existing tests pass.