### PR TITLE
fix(kanban): defer scratch cleanup until children finish

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -2897,6 +2897,23 @@ def complete_task(
     recompute_ready(conn)
     # Clean up the scratch workspace and any stale tmux session for the worker.
     _cleanup_workspace(conn, task_id)
+    # Finishing the last child can unblock deferred scratch cleanup on a done
+    # parent that had to keep its workspace alive for downstream work.
+    try:
+        parent_rows = conn.execute(
+            """
+            SELECT DISTINCT l.parent_id
+              FROM task_links l
+              JOIN tasks p ON p.id = l.parent_id
+             WHERE l.child_id = ?
+               AND p.status = 'done'
+            """,
+            (task_id,),
+        ).fetchall()
+        for row in parent_rows:
+            _cleanup_workspace(conn, row["parent_id"])
+    except Exception:
+        pass
     return True
 
 
@@ -2922,6 +2939,19 @@ def _cleanup_workspace(conn: sqlite3.Connection, task_id: str) -> None:
         kind: Optional[str] = row["workspace_kind"]
         path: Optional[str] = row["workspace_path"]
         if kind != "scratch" or not path:
+            return
+        active_child = conn.execute(
+            """
+            SELECT 1
+              FROM task_links l
+              JOIN tasks c ON c.id = l.child_id
+             WHERE l.parent_id = ?
+               AND c.status NOT IN ('done', 'archived', 'gave_up')
+             LIMIT 1
+            """,
+            (task_id,),
+        ).fetchone()
+        if active_child:
             return
         import shutil
         wp = Path(path)

--- a/tests/hermes_cli/test_kanban_scratch_gc.py
+++ b/tests/hermes_cli/test_kanban_scratch_gc.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+
+
+@pytest.fixture
+def kanban_conn(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> sqlite3.Connection:
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+    conn = sqlite3.connect(":memory:", isolation_level=None)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA foreign_keys=ON")
+    conn.executescript(kb.SCHEMA_SQL)
+    kb._migrate_add_optional_columns(conn)
+    try:
+        yield conn
+    finally:
+        conn.close()
+
+
+def test_parent_scratch_survives_until_child_done(
+    kanban_conn: sqlite3.Connection,
+    tmp_path: Path,
+) -> None:
+    workspace = tmp_path / "parent-scratch"
+    workspace.mkdir()
+
+    parent = kb.create_task(
+        kanban_conn,
+        title="parent",
+        assignee="lead",
+        workspace_kind="scratch",
+        workspace_path=str(workspace),
+    )
+    child = kb.create_task(
+        kanban_conn,
+        title="child",
+        assignee="worker",
+        parents=[parent],
+    )
+
+    assert kb.complete_task(kanban_conn, parent, result="parent complete")
+    assert kb.get_task(kanban_conn, child).status == "ready"
+    assert workspace.is_dir()
+
+
+def test_parent_scratch_cleaned_after_last_child_done(
+    kanban_conn: sqlite3.Connection,
+    tmp_path: Path,
+) -> None:
+    workspace = tmp_path / "parent-scratch-last-child"
+    workspace.mkdir()
+
+    parent = kb.create_task(
+        kanban_conn,
+        title="parent",
+        assignee="lead",
+        workspace_kind="scratch",
+        workspace_path=str(workspace),
+    )
+    child = kb.create_task(
+        kanban_conn,
+        title="child",
+        assignee="worker",
+        parents=[parent],
+    )
+
+    assert kb.complete_task(kanban_conn, parent, result="parent complete")
+    assert workspace.is_dir()
+    assert kb.complete_task(kanban_conn, child, result="child complete")
+    assert not workspace.exists()


### PR DESCRIPTION
## Summary
- skip scratch workspace cleanup when a done parent still has active children
- retry parent cleanup when the last child finishes so deferred scratch dirs are eventually removed
- add regression tests for both the deferred and eventual cleanup paths

## Testing
- source .venv/bin/activate && pytest tests/hermes_cli/test_kanban_db.py tests/hermes_cli/test_kanban_scratch_gc.py -x -q -k not\ resolve_hermes_argv