### PR TITLE
fix(codex): sanitize kwargs for gpt-5.5 on Codex backend

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -978,6 +978,21 @@ class _CodexCompletionsAdapter:
                     }
                     resp_kwargs["include"] = ["reasoning.encrypted_content"]
 
+        # GPT-5.5 / codex-gpt-5.5 on the Codex backend rejects reasoning,
+        # include, and store kwargs with 400.  Mirror the stripping from
+        # agent/transports/codex.py so auxiliary callers (compression,
+        # flush_memories, MoA) targeting these models don't 400.
+        from agent.transports.codex import _CODEX_KWARG_STRIP_KEYS, _CODEX_STRIP_MODEL_PREFIXES
+
+        model_lower = model.lower()
+        if any(
+            model_lower == p or model_lower.startswith(p + "-") or model_lower.startswith(p + ".")
+            for p in _CODEX_STRIP_MODEL_PREFIXES
+        ):
+            stripped = [k for k in _CODEX_KWARG_STRIP_KEYS if k in resp_kwargs]
+            for _key in stripped:
+                resp_kwargs.pop(_key)
+
         # Tools support for auxiliary callers (e.g. skills_hub) that pass function schemas
         tools = kwargs.get("tools")
         if tools:

--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -7,10 +7,20 @@ streaming, or the _run_codex_stream() call path.
 
 import hashlib
 import json
+import logging
 from typing import Any, Dict, List, Optional
 
 from agent.transports.base import ProviderTransport
 from agent.transports.types import NormalizedResponse, ToolCall
+
+logger = logging.getLogger(__name__)
+
+# Kwargs that the Codex backend rejects with HTTP 400 for certain models
+# (currently GPT-5.5 / codex-gpt-5.5).  Shared with auxiliary_client.py.
+_CODEX_KWARG_STRIP_KEYS = ("reasoning", "include", "store")
+
+# Model prefixes that trigger kwarg stripping on the Codex backend.
+_CODEX_STRIP_MODEL_PREFIXES = ("gpt-5.5", "codex-gpt-5.5")
 
 
 def _content_cache_key(instructions: str, tools: Optional[List[Dict[str, Any]]]) -> Optional[str]:
@@ -303,6 +313,25 @@ class ResponsesApiTransport(ProviderTransport):
         request_overrides = params.get("request_overrides")
         if request_overrides:
             kwargs.update(request_overrides)
+
+        # GPT-5.5 / codex-gpt-5.5 on the Codex backend rejects reasoning,
+        # include, and store kwargs with 400.  Strip them if present.
+        # Runs AFTER request_overrides so user-injected values are also
+        # cleaned.  See run_agent.py:_codex_gpt55_hang_hint() for the
+        # upstream symptom history (#21444, #32892).
+        model_lower = model.lower()
+        if is_codex_backend and any(
+            model_lower == p or model_lower.startswith(p + "-") or model_lower.startswith(p + ".")
+            for p in _CODEX_STRIP_MODEL_PREFIXES
+        ):
+            stripped = [k for k in _CODEX_KWARG_STRIP_KEYS if k in kwargs]
+            for _key in stripped:
+                kwargs.pop(_key)
+            if stripped:
+                logger.debug(
+                    "codex kwarg sanitize: stripped %s for model %s",
+                    stripped, model,
+                )
 
         # xAI Responses API rejects ``service_tier`` (HTTP 400 "Argument not
         # supported: service_tier") — hit when ``/fast`` priority-processing

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -5653,3 +5653,71 @@ class TestCustomEndpointApiKeyInheritance:
             )
 
         assert captured.get("api_key") == "no-key-required"
+
+
+# ---------------------------------------------------------------------------
+# GPT-5.5 kwarg stripping in auxiliary Codex adapter
+# ---------------------------------------------------------------------------
+
+
+class TestCodexAuxiliaryGpt55Stripping:
+    """_CodexCompletionsAdapter must strip reasoning/include/store for
+    GPT-5.5 on the Codex backend, matching the main transport behavior."""
+
+    @staticmethod
+    def _build_adapter(model="gpt-5.5"):
+        from agent.auxiliary_client import _CodexCompletionsAdapter
+        from types import SimpleNamespace
+
+        message_item = SimpleNamespace(
+            type="message",
+            role="assistant",
+            status="completed",
+            content=[SimpleNamespace(type="output_text", text="hi")],
+        )
+        events = [
+            SimpleNamespace(type="response.created"),
+            SimpleNamespace(type="response.output_item.done", item=message_item),
+            SimpleNamespace(
+                type="response.completed",
+                response=SimpleNamespace(
+                    status="completed",
+                    id="resp_test",
+                    usage=SimpleNamespace(input_tokens=1, output_tokens=1, total_tokens=2),
+                ),
+            ),
+        ]
+
+        class _FakeCreateStream:
+            def __iter__(self): return iter(events)
+            def close(self): pass
+
+        captured_kwargs = {}
+
+        def _create(**kwargs):
+            captured_kwargs.update(kwargs)
+            return _FakeCreateStream()
+
+        real_client = MagicMock()
+        real_client.responses.create = _create
+        adapter = _CodexCompletionsAdapter(real_client, model)
+        return adapter, captured_kwargs
+
+    def test_gpt55_strips_reasoning_and_include(self):
+        adapter, captured = self._build_adapter("gpt-5.5")
+        adapter.create(
+            messages=[{"role": "user", "content": "hi"}],
+            extra_body={"reasoning": {"effort": "medium"}},
+        )
+        assert "reasoning" not in captured
+        assert "include" not in captured
+        assert "store" not in captured
+
+    def test_gpt54_preserves_reasoning(self):
+        adapter, captured = self._build_adapter("gpt-5.4")
+        adapter.create(
+            messages=[{"role": "user", "content": "hi"}],
+            extra_body={"reasoning": {"effort": "medium"}},
+        )
+        assert captured.get("reasoning") == {"effort": "medium", "summary": "auto"}
+        assert "include" in captured

--- a/tests/agent/transports/test_codex_transport.py
+++ b/tests/agent/transports/test_codex_transport.py
@@ -969,3 +969,117 @@ class TestPreflightSlashEnumStrip:
         assert params["properties"]["model_id"].get("enum") == [
             "Qwen/Qwen3.5-0.8B", "plain-id"
         ]
+
+
+# ---------------------------------------------------------------------------
+# GPT-5.5 kwarg stripping (regression)
+# ---------------------------------------------------------------------------
+
+
+class TestCodexGpt55KwargStripping:
+    """GPT-5.5 / codex-gpt-5.5 on the Codex backend reject reasoning,
+    include, and store with HTTP 400.  These tests verify the stripping
+    logic covers all edge cases."""
+
+    def _build(self, transport, model, is_codex_backend=True, **extra):
+        messages = [{"role": "user", "content": "Hi"}]
+        return transport.build_kwargs(
+            model=model, messages=messages, tools=[],
+            is_codex_backend=is_codex_backend, **extra,
+        )
+
+    def test_gpt55_strips_reasoning(self, transport):
+        """GPT-5.5 on codex: reasoning must be stripped."""
+        kw = self._build(transport, "gpt-5.5")
+        assert "reasoning" not in kw
+
+    def test_gpt55_strips_include(self, transport):
+        """GPT-5.5 on codex: include must be stripped."""
+        kw = self._build(transport, "gpt-5.5")
+        assert "include" not in kw
+
+    def test_gpt55_strips_store(self, transport):
+        """GPT-5.5 on codex: store must be stripped."""
+        kw = self._build(transport, "gpt-5.5")
+        assert "store" not in kw
+
+    def test_gpt55_strips_injected_via_request_overrides(self, transport):
+        """Values injected via request_overrides must also be stripped."""
+        kw = self._build(
+            transport, "gpt-5.5",
+            request_overrides={"reasoning": {"effort": "high"}, "store": True},
+        )
+        assert "reasoning" not in kw
+        assert "store" not in kw
+
+    def test_case_insensitive_prefix(self, transport):
+        """GPT-5.5 (uppercase) must also trigger stripping."""
+        kw = self._build(transport, "GPT-5.5")
+        assert "reasoning" not in kw
+        assert "include" not in kw
+
+    def test_codex_gpt55_case_insensitive(self, transport):
+        kw = self._build(transport, "Codex-GPT-5.5")
+        assert "reasoning" not in kw
+        assert "include" not in kw
+
+    def test_non_codex_backend_preserves_kwargs(self, transport):
+        """Non-codex backends must NOT strip these kwargs."""
+        kw = self._build(transport, "gpt-5.5", is_codex_backend=False)
+        assert kw.get("reasoning") is not None
+        assert "include" in kw
+        assert kw.get("store") is False
+
+    def test_non_affected_model_preserves_reasoning(self, transport):
+        """GPT-5.4 must NOT strip reasoning/include."""
+        kw = self._build(transport, "gpt-5.4")
+        assert kw.get("reasoning") is not None
+        assert isinstance(kw.get("reasoning"), dict)
+        assert "include" in kw
+
+    def test_partial_prefix_no_false_positive(self, transport):
+        """gpt-5.50 must not trigger stripping."""
+        kw = self._build(transport, "gpt-5.50")
+        assert kw.get("reasoning") is not None
+
+    def test_gpt55_preserves_other_kwargs(self, transport):
+        """Stripping must not remove unrelated kwargs."""
+        kw = self._build(
+            transport, "gpt-5.5",
+            request_overrides={"extra_headers": {"X-Test": "1"}, "parallel_tool_calls": True},
+        )
+        assert kw.get("extra_headers") == {"X-Test": "1"}
+        assert kw.get("parallel_tool_calls") is True
+
+    def test_gpt55_no_error_when_keys_absent(self, transport):
+        """Stripping when keys are already absent must not raise."""
+        kw = self._build(transport, "gpt-5.5")
+        assert "reasoning" not in kw
+        assert "include" not in kw
+
+    def test_strip_keys_constant_matches_fix(self, transport):
+        """Verify the module constant covers the expected keys."""
+        from agent.transports.codex import _CODEX_KWARG_STRIP_KEYS
+        assert set(_CODEX_KWARG_STRIP_KEYS) == {"reasoning", "include", "store"}
+
+    def test_gpt5codex_not_stripped(self, transport):
+        """gpt-5-codex must NOT be stripped — it supports reasoning."""
+        kw = self._build(transport, "gpt-5-codex")
+        assert kw.get("reasoning") is not None
+        assert "include" in kw
+
+    def test_gpt55_multiturn_works_without_reasoning(self, transport):
+        """GPT-5.5 multi-turn: stripping include/reasoning is safe because
+        the model does not support reasoning at all.  A second turn must
+        still produce valid kwargs without reasoning-related fields."""
+        # Turn 1
+        kw1 = self._build(transport, "gpt-5.5")
+        assert "reasoning" not in kw1
+        assert "include" not in kw1
+        assert "store" not in kw1
+
+        # Turn 2 — same stripping must apply, no residual state
+        kw2 = self._build(transport, "gpt-5.5")
+        assert "reasoning" not in kw2
+        assert "include" not in kw2
+        assert "store" not in kw2


### PR DESCRIPTION
Title: fix(codex): sanitize kwargs for gpt-5.5 on Codex backend

Description:
GPT-5.5 / codex-gpt-5.5 on the Codex backend rejects requests that include reasoning, include, or store kwargs with HTTP 400, since these are Responses API parameters not supported by the older completions-compatible Codex surface.

Added a post-hoc sanitization step in ResponsesApiTransport.build_kwargs() that strips reasoning, include, and store when the model name starts with gpt-5.5 or codex-gpt-5.5 on the codex backend. All other models (gpt-4o, xAI, GitHub) are unaffected.

39 codex transport tests pass.