### PR TITLE
feat(web-dashboard): add Gemini CLI OAuth provider

### DIFF
--- a/agent/google_oauth.py
+++ b/agent/google_oauth.py
@@ -838,6 +838,7 @@ def start_oauth_flow(
     open_browser: bool = True,
     callback_wait_seconds: float = CALLBACK_WAIT_SECONDS,
     project_id: str = "",
+    manual_paste: bool = False,
 ) -> GoogleCredentials:
     """Run the interactive browser OAuth flow and persist credentials.
 
@@ -847,6 +848,8 @@ def start_oauth_flow(
         callback_wait_seconds: Max seconds to wait for the browser callback.
         project_id: Initial GCP project ID to bake into the stored creds.
                     Can be discovered/updated later via update_project_ids().
+        manual_paste: Skip the loopback callback listener and paste the
+                      failed callback URL from another browser/device.
     """
     if not force_relogin:
         existing = load_credentials()
@@ -860,8 +863,8 @@ def start_oauth_flow(
     verifier, challenge = _generate_pkce_pair()
     state = secrets.token_urlsafe(16)
 
-    # If headless, skip the listener and go straight to paste mode
-    if _is_headless() and open_browser:
+    # If headless or explicitly requested, skip the listener and go straight to paste mode.
+    if manual_paste or (_is_headless() and open_browser):
         logger.info("Headless environment detected; using paste-mode OAuth fallback.")
         return _paste_mode_login(verifier, challenge, state, client_id, client_secret, project_id)
 
@@ -1030,9 +1033,19 @@ def _persist_token_response(
 # Pool-compatible variant
 # =============================================================================
 
-def run_gemini_oauth_login_pure() -> Dict[str, Any]:
+def run_gemini_oauth_login_pure(
+    *,
+    manual_paste: bool = False,
+    open_browser: bool = True,
+    callback_wait_seconds: float = CALLBACK_WAIT_SECONDS,
+) -> Dict[str, Any]:
     """Run the login flow and return a dict matching the credential pool shape."""
-    creds = start_oauth_flow(force_relogin=True)
+    creds = start_oauth_flow(
+        force_relogin=True,
+        manual_paste=manual_paste,
+        open_browser=open_browser,
+        callback_wait_seconds=callback_wait_seconds,
+    )
     return {
         "access_token": creds.access_token,
         "refresh_token": creds.refresh_token,

--- a/hermes_cli/auth_commands.py
+++ b/hermes_cli/auth_commands.py
@@ -364,7 +364,11 @@ def auth_add_command(args) -> None:
     if provider == "google-gemini-cli":
         from agent.google_oauth import run_gemini_oauth_login_pure
 
-        creds = run_gemini_oauth_login_pure()
+        creds = run_gemini_oauth_login_pure(
+            manual_paste=bool(getattr(args, "manual_paste", False)),
+            open_browser=not bool(getattr(args, "no_browser", False)),
+            callback_wait_seconds=float(getattr(args, "timeout", 300) or 300),
+        )
         label = (getattr(args, "label", None) or "").strip() or (
             creds.get("email") or _oauth_default_label(provider, len(pool.entries()) + 1)
         )

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -373,6 +373,7 @@ _LABEL_OVERRIDES: Dict[str, str] = {
     "nous": "Nous Portal",
     "openai-codex": "OpenAI Codex",
     "copilot-acp": "GitHub Copilot ACP",
+    "google-gemini-cli": "Google Gemini (OAuth)",
     "stepfun": "StepFun Step Plan",
     "xiaomi": "Xiaomi MiMo",
     "gmi": "GMI Cloud",

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -1445,7 +1445,7 @@ _OAUTH_PROVIDER_CATALOG: tuple[Dict[str, Any], ...] = (
     },
     {
         "id": "google-gemini-cli",
-        "name": "Google Gemini CLI (OAuth)",
+        "name": "Google Gemini (OAuth)",
         "flow": "external",
         "cli_command": "hermes auth add google-gemini-cli",
         "docs_url": "https://google-gemini.github.io/gemini-cli/docs/get-started/",

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -1444,6 +1444,14 @@ _OAUTH_PROVIDER_CATALOG: tuple[Dict[str, Any], ...] = (
         "status_fn": None,  # dispatched via auth.get_qwen_auth_status
     },
     {
+        "id": "google-gemini-cli",
+        "name": "Google Gemini CLI (OAuth)",
+        "flow": "external",
+        "cli_command": "hermes auth add google-gemini-cli",
+        "docs_url": "https://google-gemini.github.io/gemini-cli/docs/get-started/",
+        "status_fn": None,  # dispatched via auth.get_gemini_oauth_auth_status
+    },
+    {
         "id": "minimax-oauth",
         "name": "MiniMax (OAuth)",
         # MiniMax's flow is structurally device-code (verification URI +
@@ -1497,6 +1505,16 @@ def _resolve_provider_status(provider_id: str, status_fn) -> Dict[str, Any]:
                 "source_label": raw.get("auth_store_path") or "Qwen CLI",
                 "token_preview": _truncate_token(raw.get("access_token")),
                 "expires_at": raw.get("expires_at"),
+                "has_refresh_token": bool(raw.get("has_refresh_token")),
+            }
+        if provider_id == "google-gemini-cli":
+            raw = hauth.get_gemini_oauth_auth_status()
+            return {
+                "logged_in": bool(raw.get("logged_in")),
+                "source": raw.get("source") or "google_oauth",
+                "source_label": raw.get("auth_file") or "Google Gemini CLI",
+                "token_preview": _truncate_token(raw.get("access_token")),
+                "expires_at": raw.get("expires_at_ms"),
                 "has_refresh_token": bool(raw.get("has_refresh_token")),
             }
         if provider_id == "minimax-oauth":

--- a/plugins/model-providers/gemini/__init__.py
+++ b/plugins/model-providers/gemini/__init__.py
@@ -63,6 +63,7 @@ google_gemini_cli = GeminiProfile(
     name="google-gemini-cli",
     aliases=("gemini-cli", "gemini-oauth"),
     api_mode="chat_completions",
+    display_name="Google Gemini (OAuth)",
     env_vars=(),  # OAuth — no API key
     base_url="cloudcode-pa://google",  # Cloud Code Assist internal scheme
     auth_type="oauth_external",

--- a/tests/hermes_cli/test_overlay_slug_resolution.py
+++ b/tests/hermes_cli/test_overlay_slug_resolution.py
@@ -14,6 +14,7 @@ from unittest.mock import patch
 import pytest
 
 from hermes_cli.model_switch import list_authenticated_providers
+from hermes_cli.providers import get_label
 
 
 # -- Copilot slug resolution (env var path) ----------------------------------
@@ -42,6 +43,22 @@ def test_copilot_no_duplicate_entries():
     # Should have at most one copilot entry (may also have copilot-acp if creds exist)
     copilot_main = [s for s in copilot_slugs if s == "copilot"]
     assert len(copilot_main) == 1, f"Expected exactly one 'copilot' entry, got {copilot_main}"
+
+
+def test_google_gemini_cli_uses_display_label(monkeypatch):
+    """OAuth Gemini provider keeps its technical slug but displays a friendly label."""
+    monkeypatch.setattr(
+        "hermes_cli.auth._load_auth_store",
+        lambda: {"providers": {"google-gemini-cli": {}}, "credential_pool": {}},
+    )
+
+    providers = list_authenticated_providers(current_provider="google-gemini-cli")
+
+    gemini_cli = next((p for p in providers if p["slug"] == "google-gemini-cli"), None)
+    assert get_label("google-gemini-cli") == "Google Gemini (OAuth)"
+    assert gemini_cli is not None
+    assert gemini_cli["name"] == "Google Gemini (OAuth)"
+    assert gemini_cli["is_current"] is True
 
 
 # -- kimi-for-coding alias in auth.py ----------------------------------------


### PR DESCRIPTION
## Summary
- expose `google-gemini-cli` as a selectable OAuth provider in the dashboard model/provider surfaces
- allow the Gemini OAuth CLI flow to run in no-browser/manual paste environments
- add a friendly dashboard/model-picker label for Gemini OAuth while preserving the canonical provider slug

## Tests
- `python3 -m py_compile agent/google_oauth.py hermes_cli/auth_commands.py hermes_cli/providers.py hermes_cli/web_server.py plugins/model-providers/gemini/__init__.py`
- `.venv/bin/python -m pytest -o addopts='' tests/hermes_cli/test_overlay_slug_resolution.py -q`
- `git diff --check upstream/main...HEAD`
