### PR TITLE
fix: move WhatsApp bridge default port off 3000

### DIFF
--- a/gateway/platforms/whatsapp.py
+++ b/gateway/platforms/whatsapp.py
@@ -231,7 +231,7 @@ class WhatsAppAdapter(BasePlatformAdapter):
     
     Configuration:
     - bridge_script: Path to the Node.js bridge script
-    - bridge_port: Port for HTTP communication (default: 3000)
+    - bridge_port: Port for HTTP communication (default: 3099)
     - session_path: Path to store WhatsApp session data
     - dm_policy: "open" | "allowlist" | "disabled" — how DMs are handled (default: "open")
     - allow_from: List of sender IDs allowed in DMs (when dm_policy="allowlist")
@@ -243,6 +243,7 @@ class WhatsAppAdapter(BasePlatformAdapter):
     # WhatsApp allows ~65K but long messages are unreadable on mobile.
     MAX_MESSAGE_LENGTH = 4096
     DEFAULT_REPLY_PREFIX = "⚕ *Hermes Agent*\n────────────\n"
+    DEFAULT_BRIDGE_PORT = 3099
     
     # Default bridge location relative to the hermes-agent install
     _DEFAULT_BRIDGE_DIR = Path(__file__).resolve().parents[2] / "scripts" / "whatsapp-bridge"
@@ -250,7 +251,7 @@ class WhatsAppAdapter(BasePlatformAdapter):
     def __init__(self, config: PlatformConfig):
         super().__init__(config, Platform.WHATSAPP)
         self._bridge_process: Optional[subprocess.Popen] = None
-        self._bridge_port: int = config.extra.get("bridge_port", 3000)
+        self._bridge_port: int = config.extra.get("bridge_port", self.DEFAULT_BRIDGE_PORT)
         self._bridge_script: Optional[str] = config.extra.get(
             "bridge_script",
             str(self._DEFAULT_BRIDGE_DIR / "bridge.js"),

--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -43,7 +43,7 @@ const WHATSAPP_DEBUG =
   typeof process.env.WHATSAPP_DEBUG === 'string' &&
   ['1', 'true', 'yes', 'on'].includes(process.env.WHATSAPP_DEBUG.toLowerCase());
 
-const PORT = parseInt(getArg('port', '3000'), 10);
+const PORT = parseInt(getArg('port', '3099'), 10);
 const SESSION_DIR = getArg('session', path.join(process.env.HOME || '~', '.hermes', 'whatsapp', 'session'));
 const IMAGE_CACHE_DIR = path.join(process.env.HOME || '~', '.hermes', 'image_cache');
 const DOCUMENT_CACHE_DIR = path.join(process.env.HOME || '~', '.hermes', 'document_cache');

--- a/tests/gateway/test_whatsapp_connect.py
+++ b/tests/gateway/test_whatsapp_connect.py
@@ -18,7 +18,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from gateway.config import Platform
+from gateway.config import Platform, PlatformConfig
 
 
 # ---------------------------------------------------------------------------
@@ -101,6 +101,26 @@ def _connect_patches(mock_proc, mock_fh, mock_client_cls=None):
     if mock_client_cls is not None:
         base.append(patch("aiohttp.ClientSession", mock_client_cls))
     return base
+
+
+# ---------------------------------------------------------------------------
+# Adapter configuration defaults
+# ---------------------------------------------------------------------------
+
+class TestWhatsAppAdapterDefaults:
+    def test_default_bridge_port_avoids_common_dev_server_port(self):
+        from gateway.platforms.whatsapp import WhatsAppAdapter
+
+        adapter = WhatsAppAdapter(PlatformConfig())
+
+        assert adapter._bridge_port == 3099
+
+    def test_configured_bridge_port_is_preserved(self):
+        from gateway.platforms.whatsapp import WhatsAppAdapter
+
+        adapter = WhatsAppAdapter(PlatformConfig(extra={"bridge_port": 4123}))
+
+        assert adapter._bridge_port == 4123
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -30,6 +30,7 @@ from tools.send_message_tool import (
     _send_signal,
     _send_telegram,
     _send_to_platform,
+    _send_whatsapp,
     send_message_tool,
 )
 
@@ -685,6 +686,21 @@ class TestSendToPlatformChunking:
 
 
 class TestSendToPlatformWhatsapp:
+    @staticmethod
+    def _build_mock(response_status=200, response_data=None, response_text="error body"):
+        mock_resp = MagicMock()
+        mock_resp.status = response_status
+        mock_resp.json = AsyncMock(return_value=response_data or {"messageId": "msg123"})
+        mock_resp.text = AsyncMock(return_value=response_text)
+        mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
+        mock_resp.__aexit__ = AsyncMock(return_value=None)
+
+        mock_session = MagicMock()
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=None)
+        mock_session.post = MagicMock(return_value=mock_resp)
+        return mock_session, mock_resp
+
     def test_whatsapp_routes_via_local_bridge_sender(self):
         chat_id = "test-user@lid"
         async_mock = AsyncMock(return_value={"success": True, "platform": "whatsapp", "chat_id": chat_id, "message_id": "abc123"})
@@ -701,6 +717,16 @@ class TestSendToPlatformWhatsapp:
 
         assert result["success"] is True
         async_mock.assert_awaited_once_with({"bridge_port": 3000}, chat_id, "hello from hermes")
+
+    def test_whatsapp_sender_default_port_matches_adapter(self):
+        mock_session, _ = self._build_mock()
+
+        with patch("aiohttp.ClientSession", return_value=mock_session):
+            result = asyncio.run(_send_whatsapp({}, "test-user@lid", "hello"))
+
+        assert result["success"] is True
+        call_url = mock_session.post.call_args.args[0]
+        assert call_url == "http://localhost:3099/send"
 
 
 class TestSendTelegramHtmlDetection:

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -45,6 +45,7 @@ _IMAGE_EXTS = {".jpg", ".jpeg", ".png", ".webp", ".gif"}
 _VIDEO_EXTS = {".mp4", ".mov", ".avi", ".mkv", ".3gp"}
 _AUDIO_EXTS = {".ogg", ".opus", ".mp3", ".wav", ".m4a", ".flac"}
 _VOICE_EXTS = {".ogg", ".opus"}
+_DEFAULT_WHATSAPP_BRIDGE_PORT = 3099
 # Telegram's Bot API sendAudio only accepts MP3 / M4A. Other audio
 # formats either route through sendVoice (Opus/OGG) or fall back to
 # document delivery.
@@ -1277,7 +1278,7 @@ async def _send_whatsapp(extra, chat_id, message):
     except ImportError:
         return {"error": "aiohttp not installed. Run: pip install aiohttp"}
     try:
-        bridge_port = extra.get("bridge_port", 3000)
+        bridge_port = extra.get("bridge_port", _DEFAULT_WHATSAPP_BRIDGE_PORT)
         async with aiohttp.ClientSession() as session:
             async with session.post(
                 f"http://localhost:{bridge_port}/send",


### PR DESCRIPTION
## Summary
- change the WhatsApp adapter and bundled bridge default port from 3000 to 3099
- keep explicit `bridge_port` config overrides working unchanged
- align the send_message WhatsApp helper fallback with the adapter default

## Test Plan
- `python -m pytest tests/gateway/test_whatsapp_connect.py::TestWhatsAppAdapterDefaults tests/tools/test_send_message_tool.py::TestSendToPlatformWhatsapp -q`
- `python -m pytest tests/gateway/test_whatsapp_connect.py tests/gateway/test_whatsapp_formatting.py tests/gateway/test_whatsapp_group_gating.py tests/gateway/test_whatsapp_reply_prefix.py tests/tools/test_send_message_tool.py::TestSendToPlatformWhatsapp -q`
- `python -m pytest tests/hermes_cli/test_doctor.py -q`

Closes #24122
