### PR TITLE
Include tool call ids in run event SSE

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -2791,29 +2791,46 @@ class APIServerAdapter(BasePlatformAdapter):
             if q is None:
                 return
             try:
-                loop.call_soon_threadsafe(q.put_nowait, event)
+                try:
+                    current_loop = asyncio.get_running_loop()
+                except RuntimeError:
+                    current_loop = None
+                if current_loop is loop:
+                    q.put_nowait(event)
+                else:
+                    future = asyncio.run_coroutine_threadsafe(q.put(event), loop)
+                    future.result(timeout=5)
             except Exception:
                 pass
 
         def _callback(event_type: str, tool_name: str = None, preview: str = None, args=None, **kwargs):
             ts = time.time()
+            tool_call_id = kwargs.get("tool_call_id") or kwargs.get("toolCallId")
             if event_type == "tool.started":
-                _push({
+                event = {
                     "event": "tool.started",
                     "run_id": run_id,
                     "timestamp": ts,
                     "tool": tool_name,
                     "preview": preview,
-                })
+                }
+                if tool_call_id:
+                    event["tool_call_id"] = tool_call_id
+                    event["toolCallId"] = tool_call_id
+                _push(event)
             elif event_type == "tool.completed":
-                _push({
+                event = {
                     "event": "tool.completed",
                     "run_id": run_id,
                     "timestamp": ts,
                     "tool": tool_name,
                     "duration": round(kwargs.get("duration", 0), 3),
                     "error": kwargs.get("is_error", False),
-                })
+                }
+                if tool_call_id:
+                    event["tool_call_id"] = tool_call_id
+                    event["toolCallId"] = tool_call_id
+                _push(event)
             elif event_type == "reasoning.available":
                 _push({
                     "event": "reasoning.available",

--- a/run_agent.py
+++ b/run_agent.py
@@ -37,6 +37,7 @@ import concurrent.futures
 import contextvars
 import copy
 import hashlib
+import inspect
 import json
 import logging
 logger = logging.getLogger(__name__)
@@ -2910,6 +2911,62 @@ class AIAgent:
             and not self.tool_progress_callback
             and getattr(self, "platform", "") == "cli"
         )
+
+    @staticmethod
+    def _callback_accepts_keyword_metadata(callback, metadata: dict) -> bool:
+        """Return True when a callback can receive the supplied keyword metadata."""
+        if not metadata:
+            return False
+        try:
+            signature = inspect.signature(callback)
+        except (TypeError, ValueError):
+            # Some callables do not expose a signature. Let the call path try
+            # keyword metadata and fall back to the legacy signature on TypeError.
+            return True
+
+        parameters = signature.parameters.values()
+        if any(param.kind == inspect.Parameter.VAR_KEYWORD for param in parameters):
+            return True
+
+        accepted = {
+            name
+            for name, param in signature.parameters.items()
+            if param.kind in {
+                inspect.Parameter.POSITIONAL_OR_KEYWORD,
+                inspect.Parameter.KEYWORD_ONLY,
+            }
+        }
+        return all(key in accepted for key in metadata)
+
+    def _emit_tool_progress_event(
+        self,
+        event_type: str,
+        tool_name: str = None,
+        preview: str = None,
+        args=None,
+        **metadata,
+    ) -> None:
+        """Emit tool progress while preserving the legacy callback signature."""
+        callback = self.tool_progress_callback
+        if not callback:
+            return
+
+        metadata = {key: value for key, value in metadata.items() if value is not None}
+        try:
+            if self._callback_accepts_keyword_metadata(callback, metadata):
+                callback(event_type, tool_name, preview, args, **metadata)
+            else:
+                callback(event_type, tool_name, preview, args)
+        except TypeError:
+            if not metadata:
+                logging.debug("Tool progress callback error", exc_info=True)
+                return
+            try:
+                callback(event_type, tool_name, preview, args)
+            except Exception:
+                logging.debug("Tool progress callback error", exc_info=True)
+        except Exception:
+            logging.debug("Tool progress callback error", exc_info=True)
 
     def _emit_status(self, message: str) -> None:
         """Emit a lifecycle status message to both CLI and gateway channels.
@@ -11126,7 +11183,13 @@ class AIAgent:
             if self.tool_progress_callback:
                 try:
                     preview = _build_tool_preview(name, args)
-                    self.tool_progress_callback("tool.started", name, preview, args)
+                    self._emit_tool_progress_event(
+                        "tool.started",
+                        name,
+                        preview,
+                        args,
+                        tool_call_id=tc.id,
+                    )
                 except Exception as cb_err:
                     logging.debug(f"Tool progress callback error: {cb_err}")
 
@@ -11350,9 +11413,10 @@ class AIAgent:
 
                 if not blocked and self.tool_progress_callback:
                     try:
-                        self.tool_progress_callback(
+                        self._emit_tool_progress_event(
                             "tool.completed", function_name, None, None,
                             duration=tool_duration, is_error=is_error,
+                            tool_call_id=tc.id,
                         )
                     except Exception as cb_err:
                         logging.debug(f"Tool progress callback error: {cb_err}")
@@ -11519,7 +11583,13 @@ class AIAgent:
             if not _execution_blocked and self.tool_progress_callback:
                 try:
                     preview = _build_tool_preview(function_name, function_args)
-                    self.tool_progress_callback("tool.started", function_name, preview, function_args)
+                    self._emit_tool_progress_event(
+                        "tool.started",
+                        function_name,
+                        preview,
+                        function_args,
+                        tool_call_id=tool_call.id,
+                    )
                 except Exception as cb_err:
                     logging.debug(f"Tool progress callback error: {cb_err}")
 
@@ -11784,9 +11854,10 @@ class AIAgent:
 
             if not _execution_blocked and self.tool_progress_callback:
                 try:
-                    self.tool_progress_callback(
+                    self._emit_tool_progress_event(
                         "tool.completed", function_name, None, None,
                         duration=tool_duration, is_error=_is_error_result,
+                        tool_call_id=tool_call.id,
                     )
                 except Exception as cb_err:
                     logging.debug(f"Tool progress callback error: {cb_err}")

--- a/tests/gateway/test_api_server_runs.py
+++ b/tests/gateway/test_api_server_runs.py
@@ -54,6 +54,16 @@ def _create_runs_app(adapter: APIServerAdapter) -> web.Application:
     return app
 
 
+def _sse_data_events(body: str) -> list[dict]:
+    """Parse JSON SSE data lines from a test response body."""
+    events = []
+    for line in body.splitlines():
+        if not line.startswith("data: "):
+            continue
+        events.append(json.loads(line[len("data: "):]))
+    return events
+
+
 def _make_slow_agent(**kwargs):
     """Create a mock agent that blocks in run_conversation until interrupted.
 
@@ -306,6 +316,123 @@ class TestRunEvents:
                 assert "run.completed" in body
                 assert "Hello!" in body
 
+    @pytest.mark.asyncio
+    async def test_events_stream_tool_lifecycle_includes_stable_tool_call_id(self, adapter):
+        app = _create_runs_app(adapter)
+
+        class ToolProgressAgent:
+            session_prompt_tokens = 1
+            session_completion_tokens = 1
+            session_total_tokens = 2
+
+            def __init__(self, **kwargs):
+                self.tool_progress_callback = kwargs["tool_progress_callback"]
+
+            def run_conversation(self, user_message=None, conversation_history=None, task_id=None):
+                cb = self.tool_progress_callback
+                cb(
+                    "tool.started",
+                    "read_file",
+                    "read: README.md",
+                    {"path": "README.md"},
+                    tool_call_id="call_read_1",
+                )
+                cb("reasoning.available", "_thinking", "thinking", None)
+                cb(
+                    "tool.completed",
+                    "read_file",
+                    None,
+                    None,
+                    duration=0.1234,
+                    is_error=False,
+                    tool_call_id="call_read_1",
+                )
+                return {"final_response": "done"}
+
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent", side_effect=ToolProgressAgent):
+                resp = await cli.post("/v1/runs", json={"input": "read README"})
+                assert resp.status == 202
+                run_id = (await resp.json())["run_id"]
+
+                events_resp = await cli.get(f"/v1/runs/{run_id}/events")
+                assert events_resp.status == 200
+                events = _sse_data_events(await events_resp.text())
+
+        started = [event for event in events if event["event"] == "tool.started"]
+        completed = [event for event in events if event["event"] == "tool.completed"]
+        reasoning = [event for event in events if event["event"] == "reasoning.available"]
+
+        assert len(started) == 1
+        assert started[0]["tool"] == "read_file"
+        assert started[0]["tool_call_id"] == "call_read_1"
+        assert started[0]["toolCallId"] == "call_read_1"
+        assert len(completed) == 1
+        assert completed[0]["tool_call_id"] == "call_read_1"
+        assert completed[0]["toolCallId"] == "call_read_1"
+        assert completed[0]["error"] is False
+        assert completed[0]["duration"] == 0.123
+        assert len(reasoning) == 1
+        assert "tool_call_id" not in reasoning[0]
+
+    @pytest.mark.asyncio
+    async def test_events_stream_same_tool_calls_get_distinct_tool_call_ids(self, adapter):
+        app = _create_runs_app(adapter)
+
+        class TwoToolCallsAgent:
+            session_prompt_tokens = 1
+            session_completion_tokens = 1
+            session_total_tokens = 2
+
+            def __init__(self, **kwargs):
+                self.tool_progress_callback = kwargs["tool_progress_callback"]
+
+            def run_conversation(self, user_message=None, conversation_history=None, task_id=None):
+                cb = self.tool_progress_callback
+                for call_id, path in (
+                    ("call_read_1", "README.md"),
+                    ("call_read_2", "CONTRIBUTING.md"),
+                ):
+                    cb(
+                        "tool.started",
+                        "read_file",
+                        f"read: {path}",
+                        {"path": path},
+                        tool_call_id=call_id,
+                    )
+                    cb(
+                        "tool.completed",
+                        "read_file",
+                        None,
+                        None,
+                        duration=0.1,
+                        is_error=False,
+                        tool_call_id=call_id,
+                    )
+                return {"final_response": "done"}
+
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent", side_effect=TwoToolCallsAgent):
+                resp = await cli.post("/v1/runs", json={"input": "read docs"})
+                assert resp.status == 202
+                run_id = (await resp.json())["run_id"]
+
+                events_resp = await cli.get(f"/v1/runs/{run_id}/events")
+                assert events_resp.status == 200
+                events = _sse_data_events(await events_resp.text())
+
+        started_ids = [
+            event["tool_call_id"]
+            for event in events
+            if event["event"] == "tool.started"
+        ]
+        completed_ids = [
+            event["tool_call_id"]
+            for event in events
+            if event["event"] == "tool.completed"
+        ]
+        assert started_ids == ["call_read_1", "call_read_2"]
+        assert completed_ids == ["call_read_1", "call_read_2"]
 
 
     @pytest.mark.asyncio

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -1803,6 +1803,38 @@ class TestExecuteToolCalls:
         assert len(messages) == 1
         assert messages[0]["role"] == "tool"
 
+    def test_sequential_tool_progress_callback_includes_tool_call_id(self, agent):
+        tc = _mock_tool_call(name="web_search", arguments='{"query":"hello"}', call_id="call_seq_1")
+        mock_msg = _mock_assistant_msg(content="", tool_calls=[tc])
+        messages = []
+        progress = []
+        agent.tool_progress_callback = (
+            lambda event, name, preview, args, **kw: progress.append((event, name, kw))
+        )
+
+        with patch("run_agent.handle_function_call", return_value='{"success": true}'):
+            agent._execute_tool_calls_sequential(mock_msg, messages, "task-1")
+
+        assert progress[0] == ("tool.started", "web_search", {"tool_call_id": "call_seq_1"})
+        assert progress[1][0:2] == ("tool.completed", "web_search")
+        assert progress[1][2]["tool_call_id"] == "call_seq_1"
+
+    def test_tool_progress_callback_legacy_signature_still_works(self, agent):
+        tc = _mock_tool_call(name="web_search", arguments='{"query":"hello"}', call_id="call_legacy")
+        mock_msg = _mock_assistant_msg(content="", tool_calls=[tc])
+        messages = []
+        progress = []
+
+        def legacy_callback(event, name=None, preview=None, args=None):
+            progress.append((event, name, preview, args))
+
+        agent.tool_progress_callback = legacy_callback
+
+        with patch("run_agent.handle_function_call", return_value='{"success": true}'):
+            agent._execute_tool_calls_sequential(mock_msg, messages, "task-1")
+
+        assert [event[0] for event in progress] == ["tool.started", "tool.completed"]
+
     def test_vprint_suppressed_in_parseable_quiet_mode(self, agent):
         agent.suppress_status_output = True
 
@@ -2128,6 +2160,32 @@ class TestConcurrentToolExecution:
         assert len(completes) == 2
         assert {entry[0] for entry in completes} == {"c1", "c2"}
         assert {entry[3] for entry in completes} == {'{"id":1}', '{"id":2}'}
+
+    def test_concurrent_tool_progress_callback_uses_distinct_tool_call_ids(self, agent):
+        tc1 = _mock_tool_call(name="web_search", arguments='{"query":"one"}', call_id="call_same_tool_1")
+        tc2 = _mock_tool_call(name="web_search", arguments='{"query":"two"}', call_id="call_same_tool_2")
+        mock_msg = _mock_assistant_msg(content="", tool_calls=[tc1, tc2])
+        messages = []
+        progress = []
+        agent.tool_progress_callback = (
+            lambda event, name, preview, args, **kw: progress.append((event, name, kw))
+        )
+
+        with patch("run_agent.handle_function_call", side_effect=['{"id":1}', '{"id":2}']):
+            agent._execute_tool_calls_concurrent(mock_msg, messages, "task-1")
+
+        started_ids = [
+            kw["tool_call_id"]
+            for event, _name, kw in progress
+            if event == "tool.started"
+        ]
+        completed_ids = {
+            kw["tool_call_id"]
+            for event, _name, kw in progress
+            if event == "tool.completed"
+        }
+        assert started_ids == ["call_same_tool_1", "call_same_tool_2"]
+        assert completed_ids == {"call_same_tool_1", "call_same_tool_2"}
 
     def test_invoke_tool_handles_agent_level_tools(self, agent):
         """_invoke_tool should handle todo tool directly."""

--- a/tests/run_agent/test_tool_call_guardrail_runtime.py
+++ b/tests/run_agent/test_tool_call_guardrail_runtime.py
@@ -184,9 +184,12 @@ def test_config_enabled_hard_stop_concurrent_path_does_not_submit_blocked_calls_
     assert starts == [("c-allow", "web_search", allowed_args)]
     started_events = [event for event in progress_events if event[0] == "tool.started"]
     completed_events = [event for event in progress_events if event[0] == "tool.completed"]
-    assert started_events == [("tool.started", "web_search", allowed_args, {})]
+    assert started_events == [
+        ("tool.started", "web_search", allowed_args, {"tool_call_id": "c-allow"})
+    ]
     assert len(completed_events) == 1
     assert completed_events[0][1] == "web_search"
+    assert completed_events[0][3]["tool_call_id"] == "c-allow"
 
 
 def test_plugin_pre_tool_block_wins_without_counting_as_toolguard_block():


### PR DESCRIPTION
## Summary
- propagate the provider tool call id through run-agent tool progress events
- include tool_call_id / toolCallId on /v1/runs/{run_id}/events tool.started and tool.completed payloads
- preserve legacy tool_progress_callback consumers and fix run-event queue ordering so tool events are not overtaken by stream close

## Tests
- uv run --with pytest --with pytest-xdist --with pytest-asyncio python -m pytest tests/run_agent/test_run_agent.py tests/run_agent/test_tool_call_guardrail_runtime.py tests/gateway/test_api_server_runs.py -k 'tool_progress_callback or config_enabled_hard_stop_concurrent_path or tool_lifecycle_includes_stable_tool_call_id or same_tool_calls_get_distinct_tool_call_ids'
- uv run --with ruff ruff check run_agent.py gateway/platforms/api_server.py tests/run_agent/test_run_agent.py tests/run_agent/test_tool_call_guardrail_runtime.py tests/gateway/test_api_server_runs.py
- uv run python -m py_compile run_agent.py gateway/platforms/api_server.py