### PR TITLE
fix(models): prefer max_context_window_tokens for Copilot models

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -2510,7 +2510,10 @@ def get_copilot_model_context(model_id: str, api_key: Optional[str] = None) -> O
             continue
         caps = item.get("capabilities") or {}
         limits = caps.get("limits") or {}
-        max_prompt = limits.get("max_prompt_tokens")
+        max_prompt = (
+            limits.get("max_context_window_tokens")
+            or limits.get("max_prompt_tokens")
+        )
         if isinstance(max_prompt, int) and max_prompt > 0:
             cache[mid] = max_prompt
 

--- a/tests/hermes_cli/test_copilot_context.py
+++ b/tests/hermes_cli/test_copilot_context.py
@@ -10,6 +10,41 @@ import pytest
 from hermes_cli.models import get_copilot_model_context
 
 
+# ── Catalog with max_context_window_tokens (preferred field) ──────────────────
+_SAMPLE_CATALOG_WITH_CONTEXT_WINDOW = [
+    {
+        # Issue #29146: max_context_window_tokens should be preferred over max_prompt_tokens
+        "id": "gpt-5.5",
+        "capabilities": {
+            "type": "chat",
+            "limits": {
+                "max_context_window_tokens": 400000,
+                "max_prompt_tokens": 272000,
+                "max_output_tokens": 128000,
+            },
+        },
+    },
+    {
+        # max_context_window_tokens only (no max_prompt_tokens)
+        "id": "claude-3.7-sonnet",
+        "capabilities": {
+            "type": "chat",
+            "limits": {
+                "max_context_window_tokens": 200000,
+                "max_output_tokens": 64000,
+            },
+        },
+    },
+    {
+        # max_prompt_tokens only (legacy format — should still work)
+        "id": "claude-opus-4.6-1m",
+        "capabilities": {
+            "type": "chat",
+            "limits": {"max_prompt_tokens": 1000000, "max_output_tokens": 64000},
+        },
+    },
+]
+
 # Sample catalog items mimicking the Copilot /models API response
 _SAMPLE_CATALOG = [
     {
@@ -105,6 +140,34 @@ class TestGetCopilotModelContext:
     @patch("hermes_cli.models.fetch_github_model_catalog", return_value=[])
     def test_returns_none_for_empty_catalog(self, mock_fetch):
         assert get_copilot_model_context("gpt-4.1") is None
+
+    # ── max_context_window_tokens tests (issue #29146) ─────────────────────────
+
+    @patch(
+        "hermes_cli.models.fetch_github_model_catalog",
+        return_value=_SAMPLE_CATALOG_WITH_CONTEXT_WINDOW,
+    )
+    def test_prefers_max_context_window_over_max_prompt_tokens(self, mock_fetch):
+        # gpt-5.5 has both fields — context_window must win
+        assert get_copilot_model_context("gpt-5.5") == 400_000
+
+    @patch(
+        "hermes_cli.models.fetch_github_model_catalog",
+        return_value=_SAMPLE_CATALOG_WITH_CONTEXT_WINDOW,
+    )
+    def test_max_context_window_tokens_alone_is_used(self, mock_fetch):
+        # claude-3.7-sonnet has only max_context_window_tokens — must be used
+        assert get_copilot_model_context("claude-3.7-sonnet") == 200_000
+
+    @patch(
+        "hermes_cli.models.fetch_github_model_catalog",
+        return_value=_SAMPLE_CATALOG_WITH_CONTEXT_WINDOW,
+    )
+    def test_max_prompt_tokens_still_works_when_no_context_window(
+        self, mock_fetch
+    ):
+        # claude-opus-4.6-1m has only max_prompt_tokens — fallback still works
+        assert get_copilot_model_context("claude-opus-4.6-1m") == 1_000_000
 
 
 class TestModelMetadataCopilotIntegration:


### PR DESCRIPTION
## Summary

For GitHub Copilot models, Hermes was reading only `max_prompt_tokens` from the Copilot `/models` API catalog. The newer catalog format exposes a separate `max_context_window_tokens` field which represents the actual context window size users expect to see.

For example, GPT-5.5 reports `max_context_window_tokens: 400000` alongside `max_prompt_tokens: 272000` — the old code showed 272k instead of the real 400k context window.

## Problem

In `get_copilot_model_context()` (`hermes_cli/models.py`), the limits lookup was:

```python
max_prompt = limits.get("max_prompt_tokens")
```

This missed the newer `max_context_window_tokens` field entirely.

## Solution

Prefer `max_context_window_tokens` when present, falling back to `max_prompt_tokens` for older catalog payloads:

```python
max_prompt = (
    limits.get("max_context_window_tokens")
    or limits.get("max_prompt_tokens")
)
```

## Files Changed

| File | Change |
|------|--------|
| `hermes_cli/models.py` | 1-line fix: prefer `max_context_window_tokens` |
| `tests/hermes_cli/test_copilot_context.py` | 3 new test cases for the new field |

## Test Results

```
tests/hermes_cli/test_copilot_context.py::TestGetCopilotModelContext::test_prefers_max_context_window_over_max_prompt_tokens PASSED
tests/hermes_cli/test_copilot_context.py::TestGetCopilotModelContext::test_max_context_window_tokens_alone_is_used PASSED
tests/hermes_cli/test_copilot_context.py::TestGetCopilotModelContext::test_max_prompt_tokens_still_works_when_no_context_window PASSED
14 passed in 10.40s
```

Closes #29146
