### PR TITLE
fix(cli): preserve top-level chat flags

### DIFF
--- a/hermes_cli/_parser.py
+++ b/hermes_cli/_parser.py
@@ -244,10 +244,17 @@ def build_top_level_parser():
     )
     _inherited_flag(
         chat_parser,
-        "-m", "--model", help="Model to use (e.g., anthropic/claude-sonnet-4)",
+        "-m",
+        "--model",
+        default=argparse.SUPPRESS,
+        help="Model to use (e.g., anthropic/claude-sonnet-4)",
     )
-    chat_parser.add_argument(
-        "-t", "--toolsets", help="Comma-separated toolsets to enable"
+    _inherited_flag(
+        chat_parser,
+        "-t",
+        "--toolsets",
+        default=argparse.SUPPRESS,
+        help="Comma-separated toolsets to enable",
     )
     _inherited_flag(
         chat_parser,
@@ -264,7 +271,7 @@ def build_top_level_parser():
         # are also valid values, and runtime resolution (resolve_runtime_provider)
         # handles validation/error reporting consistently with the top-level
         # `--provider` flag.
-        default=None,
+        default=argparse.SUPPRESS,
         help="Inference provider (default: auto). Built-in or a user-defined name from `providers:` in config.yaml.",
     )
     chat_parser.add_argument(
@@ -361,7 +368,7 @@ def build_top_level_parser():
         chat_parser,
         "--tui",
         action="store_true",
-        default=False,
+        default=argparse.SUPPRESS,
         help="Launch the modern TUI instead of the classic REPL",
     )
     _inherited_flag(

--- a/tests/hermes_cli/test_top_level_chat_flag_inheritance.py
+++ b/tests/hermes_cli/test_top_level_chat_flag_inheritance.py
@@ -1,0 +1,56 @@
+from hermes_cli._parser import build_top_level_parser
+
+
+def test_top_level_chat_flags_survive_when_subcommand_comes_last() -> None:
+    parser, _subparsers, _chat_parser = build_top_level_parser()
+
+    args = parser.parse_args([
+        "-m",
+        "anthropic/claude-sonnet-4.6",
+        "--provider",
+        "anthropic",
+        "-t",
+        "web",
+        "--tui",
+        "chat",
+    ])
+
+    assert args.command == "chat"
+    assert args.model == "anthropic/claude-sonnet-4.6"
+    assert args.provider == "anthropic"
+    assert args.toolsets == "web"
+    assert args.tui is True
+
+
+def test_chat_subparser_flags_still_work_when_subcommand_comes_first() -> None:
+    parser, _subparsers, _chat_parser = build_top_level_parser()
+
+    args = parser.parse_args([
+        "chat",
+        "-m",
+        "anthropic/claude-sonnet-4.6",
+        "--provider",
+        "anthropic",
+        "-t",
+        "web",
+        "--tui",
+    ])
+
+    assert args.command == "chat"
+    assert args.model == "anthropic/claude-sonnet-4.6"
+    assert args.provider == "anthropic"
+    assert args.toolsets == "web"
+    assert args.tui is True
+
+
+
+def test_chat_subparser_defaults_still_exist_without_shared_top_level_flags() -> None:
+    parser, _subparsers, _chat_parser = build_top_level_parser()
+
+    args = parser.parse_args(["chat"])
+
+    assert args.command == "chat"
+    assert args.tui is False
+    assert args.model is None
+    assert args.provider is None
+    assert args.toolsets is None


### PR DESCRIPTION
## Summary
- preserve top-level `chat` flags when the `chat` subcommand comes last, instead of letting chat subparser defaults clobber parsed values
- move `-t/--toolsets` onto the inherited-flag path so relaunch/session flows behave consistently with other shared chat options
- add regression coverage for both command orders and for the default `chat` path with no shared flags

## Verification
- `scripts/run_tests.sh tests/hermes_cli/test_top_level_chat_flag_inheritance.py tests/hermes_cli/test_ignore_user_config_flags.py`
- `ruff check hermes_cli/_parser.py tests/hermes_cli/test_top_level_chat_flag_inheritance.py`
- independent delegated code review pass

Closes #28780
