### PR TITLE
fix: honor fallback api_mode override

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -752,6 +752,14 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
         # falling through to OpenRouter defaults.
         fb_base_url_hint = (fb.get("base_url") or "").strip() or None
         fb_api_key_hint = (fb.get("api_key") or "").strip() or None
+        fb_api_mode_hint = (fb.get("api_mode") or "").strip() or None
+        if fb_api_mode_hint not in {
+            "chat_completions",
+            "codex_responses",
+            "anthropic_messages",
+            "bedrock_converse",
+        }:
+            fb_api_mode_hint = None
         if not fb_api_key_hint:
             # key_env and api_key_env are both documented aliases (see
             # _normalize_custom_provider_entry in hermes_cli/config.py).
@@ -766,7 +774,8 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
         fb_client, _resolved_fb_model = resolve_provider_client(
             fb_provider, model=fb_model, raw_codex=True,
             explicit_base_url=fb_base_url_hint,
-            explicit_api_key=fb_api_key_hint)
+            explicit_api_key=fb_api_key_hint,
+            api_mode=fb_api_mode_hint)
         if fb_client is None:
             logging.warning(
                 "Fallback to %s failed: provider not configured",
@@ -779,33 +788,39 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
         except Exception:
             pass
 
-        # Determine api_mode from provider / base URL / model
-        fb_api_mode = "chat_completions"
+        # Determine api_mode from provider / base URL / model.
+        # Fallback entries may explicitly pin api_mode. Honor that override
+        # before applying provider heuristics so a Codex/Responses primary can
+        # safely fall back to a plain OpenAI-compatible chat endpoint without
+        # carrying Responses-only encrypted reasoning/include metadata into a
+        # chat-completions request.
+        fb_api_mode = fb_api_mode_hint or "chat_completions"
         fb_base_url = str(fb_client.base_url)
         _fb_is_azure = agent._is_azure_openai_url(fb_base_url)
-        if fb_provider == "openai-codex":
-            fb_api_mode = "codex_responses"
-        elif fb_provider == "anthropic" or fb_base_url.rstrip("/").lower().endswith("/anthropic"):
-            fb_api_mode = "anthropic_messages"
-        elif _fb_is_azure:
-            # Azure OpenAI serves gpt-5.x on /chat/completions — does NOT
-            # support the Responses API. Stay on chat_completions.
-            fb_api_mode = "chat_completions"
-        elif agent._is_direct_openai_url(fb_base_url):
-            fb_api_mode = "codex_responses"
-        elif agent._provider_model_requires_responses_api(
-            fb_model,
-            provider=fb_provider,
-        ):
-            # GPT-5.x models usually need Responses API, but keep
-            # provider-specific exceptions like Copilot gpt-5-mini on
-            # chat completions.
-            fb_api_mode = "codex_responses"
-        elif fb_provider == "bedrock" or (
-            base_url_hostname(fb_base_url).startswith("bedrock-runtime.")
-            and base_url_host_matches(fb_base_url, "amazonaws.com")
-        ):
-            fb_api_mode = "bedrock_converse"
+        if not fb_api_mode_hint:
+            if fb_provider == "openai-codex":
+                fb_api_mode = "codex_responses"
+            elif fb_provider == "anthropic" or fb_base_url.rstrip("/").lower().endswith("/anthropic"):
+                fb_api_mode = "anthropic_messages"
+            elif _fb_is_azure:
+                # Azure OpenAI serves gpt-5.x on /chat/completions — does NOT
+                # support the Responses API. Stay on chat_completions.
+                fb_api_mode = "chat_completions"
+            elif agent._is_direct_openai_url(fb_base_url):
+                fb_api_mode = "codex_responses"
+            elif agent._provider_model_requires_responses_api(
+                fb_model,
+                provider=fb_provider,
+            ):
+                # GPT-5.x models usually need Responses API, but keep
+                # provider-specific exceptions like Copilot gpt-5-mini on
+                # chat completions.
+                fb_api_mode = "codex_responses"
+            elif fb_provider == "bedrock" or (
+                base_url_hostname(fb_base_url).startswith("bedrock-runtime.")
+                and base_url_host_matches(fb_base_url, "amazonaws.com")
+            ):
+                fb_api_mode = "bedrock_converse"
 
         old_model = agent.model
 
@@ -905,6 +920,7 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
                 base_url=agent.base_url,
                 api_key=getattr(agent, "api_key", ""),  # callable preserved → call_llm
                 provider=agent.provider,
+                api_mode=agent.api_mode,
             )
 
         agent._emit_status(

--- a/tests/agent/test_fallback_api_mode.py
+++ b/tests/agent/test_fallback_api_mode.py
@@ -1,0 +1,169 @@
+import sys
+import types
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+sys.modules.setdefault("fire", types.SimpleNamespace(Fire=lambda *a, **k: None))
+sys.modules.setdefault("firecrawl", types.SimpleNamespace(Firecrawl=object))
+sys.modules.setdefault("fal_client", types.SimpleNamespace())
+
+import run_agent
+from agent.chat_completion_helpers import build_api_kwargs
+
+
+def _patch_agent_bootstrap(monkeypatch):
+    monkeypatch.setattr(run_agent, "get_tool_definitions", lambda **kwargs: [])
+    monkeypatch.setattr(run_agent, "check_toolset_requirements", lambda: {})
+
+
+def _build_codex_primary_agent(monkeypatch, fallback_entry):
+    _patch_agent_bootstrap(monkeypatch)
+    agent = run_agent.AIAgent(
+        model="gpt-5.5",
+        provider="openai-codex",
+        api_mode="codex_responses",
+        base_url="https://chatgpt.com/backend-api/codex",
+        api_key="codex-token",
+        fallback_model=[fallback_entry],
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+    agent._cleanup_task_resources = lambda task_id: None
+    agent._persist_session = lambda messages, history=None: None
+    agent._save_trajectory = lambda messages, user_message, completed: None
+    agent._emit_status = lambda *_args, **_kwargs: None
+    agent.context_compressor = None
+    return agent
+
+
+def test_fallback_entry_api_mode_override_wins_for_direct_openai(monkeypatch):
+    """A Codex primary can fall back to OpenAI Chat Completions.
+
+    Direct api.openai.com normally routes to codex_responses for GPT-5-ish
+    models, but fallback_providers entries must be able to pin
+    chat_completions so Responses-only encrypted reasoning metadata is not
+    sent to chat-only fallback models.
+    """
+    fallback_entry = {
+        "provider": "custom",
+        "model": "gpt-4.1-mini",
+        "base_url": "https://api.openai.com/v1",
+        "api_key": "fallback-key",
+        "api_mode": "chat_completions",
+    }
+    agent = _build_codex_primary_agent(monkeypatch, fallback_entry)
+
+    fallback_client = SimpleNamespace(
+        api_key="fallback-key",
+        base_url="https://api.openai.com/v1",
+        _custom_headers={},
+    )
+    resolve_calls = []
+
+    def resolver(*args, **kwargs):
+        resolve_calls.append(kwargs)
+        return fallback_client, "gpt-4.1-mini"
+
+    monkeypatch.setattr("agent.auxiliary_client.resolve_provider_client", resolver)
+
+    assert agent._try_activate_fallback() is True
+    assert resolve_calls[0]["api_mode"] == "chat_completions"
+
+    assert agent.provider == "custom"
+    assert agent.model == "gpt-4.1-mini"
+    assert agent.base_url == "https://api.openai.com/v1"
+    assert agent.api_mode == "chat_completions"
+
+    kwargs = build_api_kwargs(agent, [{"role": "user", "content": "hi"}])
+    assert "input" not in kwargs
+    assert "include" not in kwargs
+    assert kwargs["messages"] == [{"role": "user", "content": "hi"}]
+
+
+def test_fallback_without_api_mode_still_uses_direct_openai_responses(monkeypatch):
+    """Keep the existing heuristic when no fallback api_mode override exists."""
+    fallback_entry = {
+        "provider": "custom",
+        "model": "gpt-5.1",
+        "base_url": "https://api.openai.com/v1",
+        "api_key": "fallback-key",
+    }
+    agent = _build_codex_primary_agent(monkeypatch, fallback_entry)
+
+    fallback_client = SimpleNamespace(
+        api_key="fallback-key",
+        base_url="https://api.openai.com/v1",
+        _custom_headers={},
+    )
+    resolve_calls = []
+
+    def resolver(*args, **kwargs):
+        resolve_calls.append(kwargs)
+        return fallback_client, "gpt-5.1"
+
+    monkeypatch.setattr("agent.auxiliary_client.resolve_provider_client", resolver)
+
+    assert agent._try_activate_fallback() is True
+    assert resolve_calls[0]["api_mode"] is None
+    assert agent.api_mode == "codex_responses"
+
+
+def test_invalid_fallback_api_mode_is_ignored(monkeypatch):
+    """Invalid api_mode values should not override normal routing heuristics."""
+    fallback_entry = {
+        "provider": "custom",
+        "model": "gpt-5.1",
+        "base_url": "https://api.openai.com/v1",
+        "api_key": "***",
+        "api_mode": "not-a-real-mode",
+    }
+    agent = _build_codex_primary_agent(monkeypatch, fallback_entry)
+
+    fallback_client = SimpleNamespace(
+        api_key="fallback-key",
+        base_url="https://api.openai.com/v1",
+        _custom_headers={},
+    )
+    resolve_calls = []
+
+    def resolver(*args, **kwargs):
+        resolve_calls.append(kwargs)
+        return fallback_client, "gpt-5.1"
+
+    monkeypatch.setattr("agent.auxiliary_client.resolve_provider_client", resolver)
+
+    assert agent._try_activate_fallback() is True
+    assert resolve_calls[0]["api_mode"] is None
+    assert agent.api_mode == "codex_responses"
+
+
+def test_context_compressor_receives_fallback_api_mode(monkeypatch):
+    """Compression must track the fallback transport, not the primary transport."""
+    fallback_entry = {
+        "provider": "custom",
+        "model": "gpt-4.1-mini",
+        "base_url": "https://api.openai.com/v1",
+        "api_key": "***",
+        "api_mode": "chat_completions",
+    }
+    agent = _build_codex_primary_agent(monkeypatch, fallback_entry)
+    agent.context_compressor = SimpleNamespace(update_model=MagicMock())
+
+    fallback_client = SimpleNamespace(
+        api_key="fallback-key",
+        base_url="https://api.openai.com/v1",
+        _custom_headers={},
+    )
+    monkeypatch.setattr(
+        "agent.auxiliary_client.resolve_provider_client",
+        lambda *args, **kwargs: (fallback_client, "gpt-4.1-mini"),
+    )
+    monkeypatch.setattr(
+        "agent.model_metadata.get_model_context_length",
+        lambda *args, **kwargs: 128000,
+    )
+
+    assert agent._try_activate_fallback() is True
+    agent.context_compressor.update_model.assert_called_once()
+    assert agent.context_compressor.update_model.call_args.kwargs["api_mode"] == "chat_completions"


### PR DESCRIPTION
## Summary
- honor `fallback_providers[*].api_mode` before applying fallback provider/base-url heuristics
- keep existing heuristic behavior when no explicit fallback `api_mode` is configured
- add regression coverage for Codex/Responses primary failing over to a direct OpenAI-compatible Chat Completions fallback

## Why
When the primary agent runs via Codex/Responses and falls back to a plain OpenAI-compatible chat model, the current fallback activation path re-infers `api_mode` from `https://api.openai.com/v1` and forces `codex_responses`. That can send Responses-only encrypted reasoning/include metadata to chat-only fallback models and fail with:

```text
Encrypted content is not supported with this model
```

An explicit fallback entry such as:

```yaml
fallback_providers:
  - provider: custom
    model: gpt-4.1-mini
    base_url: https://api.openai.com/v1
    api_key_env: OPENAI_API_KEY
    api_mode: chat_completions
```

should remain on `chat_completions` even if the primary runtime was `codex_responses`.

## Tests
- `python -m pytest tests/agent/test_fallback_api_mode.py tests/run_agent/test_run_agent_codex_responses.py -q -o 'addopts='`

Related: #23450
