### PR TITLE
fix(codex-responses): drop mismatched data:image input parts (#29711)

### DIFF
--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -10,6 +10,8 @@ in and return transformed results.
 
 from __future__ import annotations
 
+import base64
+import binascii
 import hashlib
 import json
 import logging
@@ -76,6 +78,70 @@ _TOOL_CALL_LEAK_PATTERN = re.compile(
 # Multimodal content helpers
 # ---------------------------------------------------------------------------
 
+# Magic-byte signatures keyed by MIME image subtype.  Used to drop inline
+# data: URLs whose declared MIME doesn't match the actual payload (e.g. a
+# .docx ZIP base64-encoded under image/jpeg).  Such mismatches cause the
+# Responses provider to 400 the entire request — a single bad attachment
+# would poison all the valid images in the same turn.
+_IMAGE_MAGIC_SIGNATURES: Dict[str, tuple[tuple[bytes, ...], ...]] = {
+    "jpeg": ((b"\xff\xd8\xff",),),
+    "jpg": ((b"\xff\xd8\xff",),),
+    "png": ((b"\x89PNG\r\n\x1a\n",),),
+    "gif": ((b"GIF87a",), (b"GIF89a",)),
+}
+
+_DATA_URL_RE = re.compile(r"^data:image/([A-Za-z0-9.+-]+);base64,(.*)$", re.DOTALL)
+
+
+def _is_valid_inline_image_data_url(url: str) -> bool:
+    """Return True if the URL is safe to forward to a Responses provider.
+
+    Non-data URLs (http/https) pass through unchanged.  Inline ``data:image``
+    URLs are decoded and magic-checked against their declared MIME subtype;
+    mismatches return False so the caller can drop the part.  Unknown image
+    subtypes (e.g. ``image/heic``) pass through to avoid over-aggressive
+    filtering of formats whose magic we don't track.
+    """
+    if not isinstance(url, str) or not url:
+        return False
+    if not url.startswith("data:"):
+        return True
+
+    m = _DATA_URL_RE.match(url)
+    if not m:
+        logger.warning("Skipping input_image with malformed data URL prefix")
+        return False
+    subtype = m.group(1).strip().lower()
+    payload = m.group(2)
+    try:
+        decoded = base64.b64decode(payload, validate=False)
+    except (binascii.Error, ValueError):
+        logger.warning("Skipping input_image with undecodable base64 payload (mime=%s)", subtype)
+        return False
+
+    signatures = _IMAGE_MAGIC_SIGNATURES.get(subtype)
+    if subtype == "webp":
+        if len(decoded) >= 12 and decoded[0:4] == b"RIFF" and decoded[8:12] == b"WEBP":
+            return True
+        prefix_hex = decoded[:8].hex()
+        logger.warning(
+            "Skipping input_image with declared MIME %s but mismatched magic bytes (first 8 bytes: %s)",
+            f"image/{subtype}", prefix_hex,
+        )
+        return False
+    if signatures is None:
+        return True
+    for sig_group in signatures:
+        if all(decoded.startswith(sig) for sig in sig_group):
+            return True
+    prefix_hex = decoded[:8].hex()
+    logger.warning(
+        "Skipping input_image with declared MIME %s but mismatched magic bytes (first 8 bytes: %s)",
+        f"image/{subtype}", prefix_hex,
+    )
+    return False
+
+
 def _chat_content_to_responses_parts(content: Any, *, role: str = "user") -> List[Dict[str, Any]]:
     """Convert chat-style multimodal content to Responses API input parts.
 
@@ -119,6 +185,8 @@ def _chat_content_to_responses_parts(content: Any, *, role: str = "user") -> Lis
             else:
                 url = image_ref
             if not isinstance(url, str) or not url:
+                continue
+            if not _is_valid_inline_image_data_url(url):
                 continue
             image_part: Dict[str, Any] = {"type": "input_image", "image_url": url}
             if isinstance(detail, str) and detail.strip():

--- a/tests/agent/test_codex_responses_adapter_image_validation.py
+++ b/tests/agent/test_codex_responses_adapter_image_validation.py
@@ -1,0 +1,130 @@
+"""Tests for inline data:image/* magic-byte validation in the Codex Responses adapter.
+
+Regression coverage for issue #29711: a Discord attachment misclassified as an
+``input_image`` could embed non-image bytes (e.g. a .docx ZIP starting with
+``PK\\x03\\x04``) under a ``data:image/jpeg;base64,...`` URL.  The Responses
+provider then 400'd the entire request, poisoning all sibling valid images.
+The adapter must now drop such mismatched parts (with a warning) while
+preserving valid inline images, remote URLs, and unknown image subtypes.
+"""
+
+from __future__ import annotations
+
+import base64
+import logging
+
+import pytest
+
+from agent.codex_responses_adapter import (
+    _chat_content_to_responses_parts,
+    _is_valid_inline_image_data_url,
+)
+
+
+def _data_url(mime: str, raw: bytes) -> str:
+    return f"data:{mime};base64,{base64.b64encode(raw).decode('ascii')}"
+
+
+JPEG_BYTES = b"\xff\xd8\xff\xe0\x00\x10JFIF\x00\x01"
+PNG_BYTES = b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR"
+GIF_BYTES = b"GIF89a\x01\x00\x01\x00"
+WEBP_BYTES = b"RIFF\x24\x00\x00\x00WEBPVP8 "
+ZIP_BYTES = b"PK\x03\x04\x14\x00\x00\x00word/numbering.xml"
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for the guard helper
+# ---------------------------------------------------------------------------
+
+
+def test_valid_jpeg_data_url_passes():
+    assert _is_valid_inline_image_data_url(_data_url("image/jpeg", JPEG_BYTES)) is True
+
+
+def test_valid_png_data_url_passes():
+    assert _is_valid_inline_image_data_url(_data_url("image/png", PNG_BYTES)) is True
+
+
+def test_valid_gif_data_url_passes():
+    assert _is_valid_inline_image_data_url(_data_url("image/gif", GIF_BYTES)) is True
+
+
+def test_valid_webp_data_url_passes():
+    assert _is_valid_inline_image_data_url(_data_url("image/webp", WEBP_BYTES)) is True
+
+
+def test_jpeg_declared_with_zip_payload_is_dropped(caplog):
+    url = _data_url("image/jpeg", ZIP_BYTES)
+    with caplog.at_level(logging.WARNING, logger="agent.codex_responses_adapter"):
+        assert _is_valid_inline_image_data_url(url) is False
+    assert any("mismatched magic bytes" in r.message for r in caplog.records)
+
+
+def test_png_declared_with_random_bytes_is_dropped(caplog):
+    url = _data_url("image/png", b"not a real png at all")
+    with caplog.at_level(logging.WARNING, logger="agent.codex_responses_adapter"):
+        assert _is_valid_inline_image_data_url(url) is False
+    assert any("mismatched magic bytes" in r.message for r in caplog.records)
+
+
+def test_webp_declared_with_zip_payload_is_dropped(caplog):
+    url = _data_url("image/webp", ZIP_BYTES)
+    with caplog.at_level(logging.WARNING, logger="agent.codex_responses_adapter"):
+        assert _is_valid_inline_image_data_url(url) is False
+
+
+def test_remote_http_url_passes_through():
+    assert _is_valid_inline_image_data_url("https://example.com/cat.png") is True
+
+
+def test_unknown_image_subtype_passes_through():
+    # We don't track heic magic — must not over-aggressively drop it.
+    url = _data_url("image/heic", b"\x00\x00\x00\x20ftypheic")
+    assert _is_valid_inline_image_data_url(url) is True
+
+
+def test_malformed_data_url_is_dropped(caplog):
+    with caplog.at_level(logging.WARNING, logger="agent.codex_responses_adapter"):
+        assert _is_valid_inline_image_data_url("data:image/jpeg;notbase64") is False
+
+
+def test_empty_url_is_dropped():
+    assert _is_valid_inline_image_data_url("") is False
+
+
+# ---------------------------------------------------------------------------
+# Integration: full conversion pipeline
+# ---------------------------------------------------------------------------
+
+
+def test_mixed_attachments_drops_only_invalid(caplog):
+    good_jpeg = _data_url("image/jpeg", JPEG_BYTES)
+    good_png = _data_url("image/png", PNG_BYTES)
+    bad_docx_as_jpeg = _data_url("image/jpeg", ZIP_BYTES)
+
+    content = [
+        {"type": "text", "text": "look at these"},
+        {"type": "image_url", "image_url": {"url": good_jpeg}},
+        {"type": "image_url", "image_url": {"url": bad_docx_as_jpeg}},
+        {"type": "image_url", "image_url": {"url": good_png}},
+    ]
+
+    with caplog.at_level(logging.WARNING, logger="agent.codex_responses_adapter"):
+        parts = _chat_content_to_responses_parts(content, role="user")
+
+    image_parts = [p for p in parts if p.get("type") == "input_image"]
+    urls = [p["image_url"] for p in image_parts]
+    assert urls == [good_jpeg, good_png], (
+        "Bad image must be dropped while preserving order of the valid ones."
+    )
+    assert any("mismatched magic bytes" in r.message for r in caplog.records)
+
+
+def test_remote_image_url_preserved_in_pipeline():
+    content = [
+        {"type": "image_url", "image_url": {"url": "https://example.com/x.png"}},
+    ]
+    parts = _chat_content_to_responses_parts(content, role="user")
+    image_parts = [p for p in parts if p.get("type") == "input_image"]
+    assert len(image_parts) == 1
+    assert image_parts[0]["image_url"] == "https://example.com/x.png"


### PR DESCRIPTION
## What does this PR do?

Fixes a Discord -> Responses-provider failure where a single misclassified non-image attachment poisons the whole multimodal request.

When a Discord message carries valid screenshots plus a document attachment (e.g. .docx), the document can be routed into the multimodal content list as an `input_image` whose URL declares `data:image/jpeg;base64,...` but whose decoded payload starts with the ZIP/DOCX signature `PK\x03\x04`. Responses-compatible providers then reject the **entire** request with HTTP 400 (invalid image). That single bad part takes down the otherwise-valid sibling images.

This PR adds a magic-byte preflight at the central chat-content -> Responses-parts conversion site in `agent/codex_responses_adapter.py` (`_chat_content_to_responses_parts`, the location explicitly suggested by the issue reporter). For inline `data:image/(jpeg|png|gif|webp)` URLs we base64-decode the payload and verify the declared MIME subtype against the actual file signature. Mismatches are dropped with a WARNING log so the request still flies with the valid images. Remote http(s) URLs and unknown image subtypes (e.g. `image/heic`) pass through unchanged.

## Related Issue

Fixes #29711

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/codex_responses_adapter.py`: new `_is_valid_inline_image_data_url(url)` helper, new `_IMAGE_MAGIC_SIGNATURES` table and `_DATA_URL_RE` regex, and a guard call in `_chat_content_to_responses_parts` right before emitting an `input_image` part. Mismatched payloads are skipped with `logger.warning(...)`.
- `tests/agent/test_codex_responses_adapter_image_validation.py` (new, 13 tests) covering valid jpeg/png/gif/webp data URLs, the bug reproducer (jpeg-declared ZIP payload), png-declared garbage, webp-declared ZIP, remote https URLs, unknown subtype (heic) pass-through, malformed data URL, empty URL, plus a mixed list (2 good + 1 bad) where only the 2 valid images survive with order preserved.

## How to Test

1. Activate the venv on this branch.
2. `pytest tests/agent/test_codex_responses_adapter_image_validation.py -x -q` -> 13 passed.
3. `pytest tests/run_agent/test_run_agent_multimodal_prologue.py tests/run_agent/test_provider_parity.py -x -q` -> 108 passed locally (no regression).

## Checklist

### Code

- [x] Read the Contributing Guide
- [x] Conventional Commits format (`fix(codex-responses): ...`)
- [x] Searched for existing PRs (none found for #29711)
- [x] Only changes related to this fix
- [x] Ran relevant tests, all pass (13 new + 108 adjacent)
- [x] Added tests for the fix
- [x] Tested on macOS

### Documentation and Housekeeping

- [x] Docs: N/A (internal adapter helper, behavior covered by docstrings)
- [x] cli-config.yaml.example: N/A
- [x] CONTRIBUTING.md / AGENTS.md: N/A
- [x] Cross-platform impact: N/A (pure data validation, no OS-specific code)
- [x] Tool descriptions/schemas: N/A

## Screenshots / Logs

Example warning when the bug payload arrives:

```
WARNING agent.codex_responses_adapter: Skipping input_image with declared MIME image/jpeg but mismatched magic bytes (first 8 bytes: 504b030414000000)
```

Valid sibling images in the same content list are preserved and forwarded to the provider, so the agent can answer instead of 400-ing.
