### PR TITLE
fix(telegram): resolve channel_post media updates via effective message normalization

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -4956,11 +4956,12 @@ class TelegramAdapter(BasePlatformAdapter):
 
     async def _handle_media_message(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         """Handle incoming media messages, downloading images to local cache."""
-        if not update.message:
+        msg = self._effective_update_message(update)
+        if not msg:
             return
-        if not self._should_process_message(update.message):
-            if self._should_observe_unmentioned_group_message(update.message):
-                _m = update.message
+        if not self._should_process_message(msg):
+            if self._should_observe_unmentioned_group_message(msg):
+                _m = msg
                 if _m.sticker:
                     _observe_type = MessageType.STICKER
                 elif _m.photo:
@@ -4975,8 +4976,6 @@ class TelegramAdapter(BasePlatformAdapter):
                     _observe_type = MessageType.DOCUMENT
                 self._observe_unmentioned_group_message(_m, _observe_type, update_id=update.update_id)
             return
-
-        msg = update.message
         
         # Determine media type
         if msg.sticker:

--- a/tests/gateway/test_telegram_channel_posts.py
+++ b/tests/gateway/test_telegram_channel_posts.py
@@ -98,7 +98,17 @@ def _make_adapter(telegram_adapter_cls):
     return a
 
 
-def _make_channel_message(text="channel id test @hermes_bot"):
+def _make_channel_message(
+    text="channel id test @hermes_bot",
+    *,
+    caption=None,
+    sticker=None,
+    photo=None,
+    video=None,
+    audio=None,
+    voice=None,
+    document=None,
+):
     chat = SimpleNamespace(
         id=-1003950368353,
         type="channel",
@@ -110,9 +120,16 @@ def _make_channel_message(text="channel id test @hermes_bot"):
         chat=chat,
         from_user=None,
         text=text,
-        caption=None,
+        caption=caption,
         entities=[],
         caption_entities=[],
+        sticker=sticker,
+        photo=photo,
+        video=video,
+        audio=audio,
+        voice=voice,
+        document=document,
+        media_group_id=None,
         message_thread_id=None,
         is_topic_message=False,
         message_id=11,
@@ -177,5 +194,23 @@ async def test_command_handler_uses_effective_message_for_channel_post(telegram_
     event = adapter.handle_message.await_args.args[0]
     assert event.text == "/status"
     assert event.message_type == MessageType.COMMAND
+    assert event.source.chat_type == "channel"
+    assert event.source.chat_id == "-1003950368353"
+
+
+@pytest.mark.asyncio
+async def test_media_handler_uses_effective_message_for_channel_post(telegram_adapter_cls):
+    adapter = _make_adapter(telegram_adapter_cls)
+    msg = _make_channel_message(text=None, sticker=SimpleNamespace())
+    update = _make_channel_update(msg)
+    adapter._handle_sticker = AsyncMock()
+    adapter.handle_message = AsyncMock()
+
+    await adapter._handle_media_message(update, MagicMock())
+
+    adapter._handle_sticker.assert_awaited_once()
+    adapter.handle_message.assert_awaited_once()
+    event = adapter.handle_message.await_args.args[0]
+    assert event.message_type == MessageType.STICKER
     assert event.source.chat_type == "channel"
     assert event.source.chat_id == "-1003950368353"


### PR DESCRIPTION
## What does this PR do?

This PR fixes a missed Telegram `channel_post` code path for media messages.

In Telegram, channel broadcasts arrive as `Update.channel_post` rather than `Update.message`. PR `704872a62` introduced `_effective_update_message()` and updated the text/command/location handlers to use it, but `_handle_media_message()` was still reading `update.message` directly. As a result, channel-post media updates (for example stickers, photos, videos, audio, voice notes, and documents) could be silently ignored before a `MessageEvent` was ever built.

The fix keeps the existing behavior and simply aligns the media handler with the same invariant already established for the sibling handlers: normalize the incoming update through `effective_message` first, then process it normally. This is the smallest behavior-preserving fix and directly addresses the broken path without changing unrelated Telegram media logic.

## Related Issue

Fixes #<issue-number>

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Updated [`gateway/platforms/telegram.py`](gateway/platforms/telegram.py) so `_handle_media_message()` uses `_effective_update_message(update)` instead of reading `update.message` directly.
- Updated the "observe unmentioned group message" branch inside the same media handler to use the normalized message object consistently.
- Added a regression test in [`tests/gateway/test_telegram_channel_posts.py`](tests/gateway/test_telegram_channel_posts.py) covering a `channel_post` media message and asserting it is routed through the media handler instead of being dropped.

## How to Test

1. Reproduce the old behavior by sending a Telegram channel media post (for example a sticker) to the bot path that reaches `_handle_media_message()`. Before this fix, the handler could return early because `update.message` is `None` for `channel_post` updates.
2. Run the regression test:
   - Linux/macOS/CI: `scripts/run_tests.sh tests/gateway/test_telegram_channel_posts.py -q`
   - Windows local override: `uv run --extra dev pytest tests/gateway/test_telegram_channel_posts.py -q -n 0 --timeout-method=thread`
3. Confirm the channel-post media test passes and that channel-post text/command coverage still passes alongside it.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)




## Screenshots / Logs

Local targeted verification passed:

```text
uv run --extra dev pytest tests/gateway/test_telegram_channel_posts.py -q -n 0 --timeout-method=thread
....                                                                     [100%]
4 passed in 1.51s