### PR TITLE
fix: ensure utf-8 encoding in jobs.json

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -436,7 +436,7 @@ def save_jobs(jobs: List[Dict[str, Any]]):
     fd, tmp_path = tempfile.mkstemp(dir=str(JOBS_FILE.parent), suffix='.tmp', prefix='.jobs_')
     try:
         with os.fdopen(fd, 'w', encoding='utf-8') as f:
-            json.dump({"jobs": jobs, "updated_at": _hermes_now().isoformat()}, f, indent=2)
+            json.dump({"jobs": jobs, "updated_at": _hermes_now().isoformat()}, f, indent=2, ensure_ascii=False)
             f.flush()
             os.fsync(f.fileno())
         atomic_replace(tmp_path, JOBS_FILE)


### PR DESCRIPTION
 Summary
    Ensure json.dump uses ensure_ascii=False when saving jobs.json to prevent Chinese characters from being escaped as \uXXXX.

Changes
    - File: cron/jobs.py
    - Modification: Added ensure_ascii=False to the json.dump() function call in the save_jobs method.

Why this is necessary
    Previously, the json.dump() method used its default behavior (ensure_ascii=True), which escaped all non-ASCII characters. 
   This rendered the jobs.json configuration file (which contains job names and prompt instructions in Chinese) unreadable for users inspecting the file directly. 
  By setting ensure_ascii=False, we ensure that the JSON file is saved with native UTF-8 encoding, improving maintainability and ease of debugging.

Verification
    - Verified that the jobs.json file now correctly displays Chinese characters instead of Unicode escape sequences.
    - Confirmed that the cron scheduling logic remains unaffected by this change.



