### PR TITLE
feat(dashboard): add paper mono theme

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1073,7 +1073,7 @@ DEFAULT_CONFIG = {
 
     # Web dashboard settings
     "dashboard": {
-        "theme": "default",  # Dashboard visual theme: "default", "midnight", "ember", "mono", "cyberpunk", "rose"
+        "theme": "default",  # Dashboard visual theme: "default", "midnight", "ember", "mono", "paper-mono", "cyberpunk", "rose"
         # Hide the token/cost analytics surfaces (Analytics page, token bars and
         # cost figures on the Models page) by default.  The numbers shown there
         # are a local debug estimate: they only count successful main-agent

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -297,7 +297,7 @@ _SCHEMA_OVERRIDES: Dict[str, Dict[str, Any]] = {
     "dashboard.theme": {
         "type": "select",
         "description": "Web dashboard visual theme",
-        "options": ["default", "midnight", "ember", "mono", "cyberpunk", "rose"],
+        "options": ["default", "midnight", "ember", "mono", "paper-mono", "cyberpunk", "rose"],
     },
     "display.resume_display": {
         "type": "select",
@@ -3753,6 +3753,7 @@ _BUILTIN_DASHBOARD_THEMES = [
     {"name": "midnight",      "label": "Midnight",            "description": "Deep blue-violet with cool accents"},
     {"name": "ember",     "label": "Ember",          "description": "Warm crimson and bronze — forge vibes"},
     {"name": "mono",      "label": "Mono",           "description": "Clean grayscale — minimal and focused"},
+    {"name": "paper-mono", "label": "Paper Mono",    "description": "Light paper workspace -- readable and calm"},
     {"name": "cyberpunk", "label": "Cyberpunk",      "description": "Neon green on black — matrix terminal"},
     {"name": "rose",      "label": "Rosé",           "description": "Soft pink and warm ivory — easy on the eyes"},
 ]

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -449,7 +449,10 @@ export default function App() {
 
         <Typography
           className="font-bold text-[0.95rem] leading-[0.95] tracking-[0.05em] text-midground"
-          style={{ mixBlendMode: "plus-lighter" }}
+          style={{
+            color: "var(--component-header-brand-color)",
+            mixBlendMode: "var(--component-header-brand-blend-mode, plus-lighter)" as React.CSSProperties["mixBlendMode"],
+          }}
         >
           {t.app.brand}
         </Typography>
@@ -499,7 +502,10 @@ export default function App() {
 
                 <Typography
                   className="font-bold text-[1.125rem] leading-[0.95] tracking-[0.0525rem] text-midground"
-                  style={{ mixBlendMode: "plus-lighter" }}
+                  style={{
+                    color: "var(--component-header-brand-color)",
+                    mixBlendMode: "var(--component-header-brand-blend-mode, plus-lighter)" as React.CSSProperties["mixBlendMode"],
+                  }}
                 >
                   Hermes
                   <br />

--- a/web/src/components/Backdrop.tsx
+++ b/web/src/components/Backdrop.tsx
@@ -33,7 +33,8 @@ export function Backdrop() {
         className="pointer-events-none fixed inset-0 z-[1]"
         style={{
           backgroundColor: "var(--background-base)",
-          mixBlendMode: "difference",
+          mixBlendMode:
+            "var(--component-backdrop-base-blend-mode, difference)" as React.CSSProperties["mixBlendMode"],
         }}
       />
 

--- a/web/src/components/SidebarFooter.tsx
+++ b/web/src/components/SidebarFooter.tsx
@@ -31,7 +31,11 @@ export function SidebarFooter() {
           "transition-opacity hover:opacity-90",
           "focus-visible:rounded-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-midground/40",
         )}
-        style={{ mixBlendMode: "plus-lighter" }}
+        style={{
+          color: "var(--component-header-brand-color)",
+          mixBlendMode:
+            "var(--component-header-brand-blend-mode, plus-lighter)" as React.CSSProperties["mixBlendMode"],
+        }}
       >
         {t.app.footer.org}
       </a>

--- a/web/src/themes/presets.ts
+++ b/web/src/themes/presets.ts
@@ -130,6 +130,126 @@ export const monoTheme: DashboardTheme = {
   },
 };
 
+export const paperMonoTheme: DashboardTheme = {
+  name: "paper-mono",
+  label: "Paper Mono",
+  description: "Light paper workspace -- readable and calm",
+  palette: {
+    background: { hex: "#f6f7f9", alpha: 1 },
+    midground: { hex: "#18202a", alpha: 1 },
+    foreground: { hex: "#ffffff", alpha: 0 },
+    warmGlow: "rgba(37, 99, 235, 0.08)",
+    noiseOpacity: 0.08,
+  },
+  typography: {
+    ...DEFAULT_TYPOGRAPHY,
+    fontSans: SYSTEM_SANS,
+    fontMono: `"JetBrains Mono", ${SYSTEM_MONO}`,
+    fontDisplay: SYSTEM_SANS,
+    baseSize: "15px",
+    lineHeight: "1.58",
+    letterSpacing: "0",
+  },
+  layout: {
+    ...DEFAULT_LAYOUT,
+    radius: "0.5rem",
+    density: "comfortable",
+  },
+  componentStyles: {
+    backdrop: {
+      baseBlendMode: "normal",
+      fillerOpacity: "0",
+      fillerBlendMode: "normal",
+    },
+    card: {
+      background: "#ffffff",
+      boxShadow: "0 1px 2px rgba(16, 24, 40, 0.06)",
+    },
+    header: {
+      background: "rgba(255, 255, 255, 0.94)",
+      brandColor: "#111827",
+      brandBlendMode: "normal",
+    },
+    sidebar: {
+      background: "rgba(255, 255, 255, 0.96)",
+    },
+    tab: {
+      clipPath: "none",
+    },
+  },
+  colorOverrides: {
+    card: "#ffffff",
+    cardForeground: "#18202a",
+    popover: "#ffffff",
+    popoverForeground: "#18202a",
+    primary: "#2563eb",
+    primaryForeground: "#ffffff",
+    secondary: "#eef1f5",
+    secondaryForeground: "#18202a",
+    muted: "#eef1f5",
+    mutedForeground: "#667085",
+    accent: "#dbeafe",
+    accentForeground: "#1e3a8a",
+    destructive: "#c2410c",
+    destructiveForeground: "#ffffff",
+    success: "#16803c",
+    warning: "#b7791f",
+    border: "#d7dde5",
+    input: "#cbd5e1",
+    ring: "#2563eb",
+  },
+  customCSS: `
+    body {
+      background: var(--background-base);
+      color: var(--midground-base);
+    }
+
+    .bg-black {
+      background-color: var(--background-base) !important;
+    }
+
+    .font-mondwest,
+    .font-display,
+    .font-expanded,
+    .font-compressed,
+    .font-serif {
+      font-family: var(--theme-font-sans) !important;
+    }
+
+    .font-mono,
+    .font-mono-ui,
+    code,
+    kbd,
+    pre,
+    samp {
+      font-family: var(--theme-font-mono) !important;
+    }
+
+    .uppercase {
+      text-transform: none !important;
+    }
+
+    .tracking-wide,
+    .tracking-wider,
+    .tracking-widest,
+    [class*="tracking-["] {
+      letter-spacing: 0 !important;
+    }
+
+    .blend-lighter {
+      mix-blend-mode: normal !important;
+    }
+
+    .theme-default-filler {
+      display: none !important;
+    }
+
+    small {
+      font-size: 0.875rem;
+    }
+  `,
+};
+
 export const cyberpunkTheme: DashboardTheme = {
   name: "cyberpunk",
   label: "Cyberpunk",
@@ -210,6 +330,7 @@ export const BUILTIN_THEMES: Record<string, DashboardTheme> = {
   midnight: midnightTheme,
   ember: emberTheme,
   mono: monoTheme,
+  "paper-mono": paperMonoTheme,
   cyberpunk: cyberpunkTheme,
   rose: roseTheme,
 };


### PR DESCRIPTION
## Summary
- add a built-in `paper-mono` dashboard theme for a light, readable workspace
- expose the theme through dashboard config/schema and the built-in theme list API
- let theme component styles control brand text and backdrop blend modes so light themes keep the header/sidebar readable

## Tests
- `python3 -m py_compile hermes_cli/config.py hermes_cli/web_server.py`
- `git diff --check`
- `git merge-tree --write-tree upstream/main HEAD`
- `npm run build`
