### PR TITLE
fix: reject kanban tasks for unknown profiles

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -81,6 +81,24 @@ def _task_to_dict(t: kb.Task) -> dict[str, Any]:
     }
 
 
+def _validate_assignee_profile(profile: Optional[str]) -> Optional[str]:
+    """Return an error message when profile is not dispatchable.
+
+    Empty installs and tests often have no profiles yet, so only enforce the
+    guardrail once at least one configured profile exists on disk.
+    """
+    if not profile:
+        return None
+    profiles = kb.list_profiles_on_disk()
+    named_profiles = [name for name in profiles if name != "default"]
+    if profile == "default" and "default" in profiles:
+        return None
+    if not named_profiles or profile in profiles:
+        return None
+    allowed = ", ".join(profiles)
+    return f"unknown assignee profile: {profile}. Available profiles: {allowed}"
+
+
 def _run_state_kwargs(args: argparse.Namespace) -> Optional[dict[str, str]]:
     st = getattr(args, "state_type", None)
     sn = getattr(args, "state_name", None)
@@ -1286,6 +1304,10 @@ def _cmd_create(args: argparse.Namespace) -> int:
             file=sys.stderr,
         )
         return 2
+    assignee_error = _validate_assignee_profile(args.assignee)
+    if assignee_error:
+        print(f"kanban: {assignee_error}", file=sys.stderr)
+        return 2
     with kb.connect() as conn:
         task_id = kb.create_task(
             conn,
@@ -1576,6 +1598,10 @@ def _cmd_show(args: argparse.Namespace) -> int:
 
 def _cmd_assign(args: argparse.Namespace) -> int:
     profile = None if args.profile.lower() in {"none", "-", "null"} else args.profile
+    assignee_error = _validate_assignee_profile(profile)
+    if assignee_error:
+        print(f"kanban: {assignee_error}", file=sys.stderr)
+        return 2
     with kb.connect() as conn:
         ok = kb.assign_task(conn, args.task_id, profile)
     if not ok:
@@ -1603,6 +1629,10 @@ def _cmd_reclaim(args: argparse.Namespace) -> int:
 
 def _cmd_reassign(args: argparse.Namespace) -> int:
     profile = None if args.profile.lower() in {"none", "-", "null"} else args.profile
+    assignee_error = _validate_assignee_profile(profile)
+    if assignee_error:
+        print(f"kanban: {assignee_error}", file=sys.stderr)
+        return 2
     with kb.connect() as conn:
         ok = kb.reassign_task(
             conn, args.task_id, profile,

--- a/tests/hermes_cli/test_kanban_cli.py
+++ b/tests/hermes_cli/test_kanban_cli.py
@@ -250,6 +250,42 @@ def test_run_slash_assign_reassigns(kanban_home):
     assert "bob" in show
 
 
+def test_run_slash_create_rejects_missing_profile_when_profiles_exist(kanban_home):
+    profiles = kanban_home / "profiles"
+    profiles.mkdir()
+    (profiles / "coder").mkdir()
+    (profiles / "coder" / "config.yaml").write_text("model: test\n")
+
+    out = kc.run_slash("create 'stranded task' --assignee pm")
+
+    assert "unknown assignee profile: pm" in out
+    assert "coder" in out
+    with kb.connect() as conn:
+        assert kb.list_tasks(conn) == []
+
+
+def test_run_slash_assign_rejects_missing_profile_when_profiles_exist(kanban_home):
+    profiles = kanban_home / "profiles"
+    profiles.mkdir()
+    (profiles / "coder").mkdir()
+    (profiles / "coder" / "config.yaml").write_text("model: test\n")
+    (profiles / "reviewer").mkdir()
+    (profiles / "reviewer" / "config.yaml").write_text("model: test\n")
+
+    out = kc.run_slash("create 'x' --assignee coder")
+    import re
+    m = re.search(r"(t_[a-f0-9]+)", out)
+    assert m, out
+    tid = m.group(1)
+
+    rejected = kc.run_slash(f"assign {tid} pm")
+
+    assert "unknown assignee profile: pm" in rejected
+    assert "coder" in rejected and "reviewer" in rejected
+    show = kc.run_slash(f"show {tid}")
+    assert "assignee:  coder" in show
+
+
 def test_run_slash_link_unlink(kanban_home):
     a = kc.run_slash("create 'a'")
     b = kc.run_slash("create 'b'")

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -848,6 +848,24 @@ def test_create_rejects_no_assignee(worker_env):
     assert json.loads(kt._handle_create({"title": "t"})).get("error")
 
 
+def test_create_rejects_missing_profile_when_profiles_exist(worker_env):
+    from pathlib import Path
+    from tools import kanban_tools as kt
+
+    home = Path.home() / ".hermes"
+    profiles = home / "profiles"
+    profiles.mkdir()
+    (profiles / "coder").mkdir()
+    (profiles / "coder" / "config.yaml").write_text("model: test\n")
+
+    out = kt._handle_create({"title": "stranded", "assignee": "pm"})
+    d = json.loads(out)
+
+    assert d.get("error")
+    assert "unknown assignee profile: pm" in d["error"]
+    assert "coder" in d["error"]
+
+
 def test_create_rejects_non_list_parents(worker_env):
     from tools import kanban_tools as kt
     out = kt._handle_create({"title": "t", "assignee": "a", "parents": 42})

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -185,9 +185,24 @@ def _normalize_profile(value: Any) -> Optional[str]:
     if value is None:
         return None
     text = str(value).strip()
-    if not text or text.lower() in {"none", "-", "null"}:
+    if text.lower() in {"", "none", "-", "null"}:
         return None
     return text
+
+
+def _validate_assignee_profile(profile: Optional[str]) -> Optional[str]:
+    """Return an error when a requested assignee is not dispatchable."""
+    if not profile:
+        return None
+    from hermes_cli import kanban_db as kb
+    profiles = kb.list_profiles_on_disk()
+    named_profiles = [name for name in profiles if name != "default"]
+    if profile == "default" and "default" in profiles:
+        return None
+    if not named_profiles or profile in profiles:
+        return None
+    allowed = ", ".join(profiles)
+    return f"unknown assignee profile: {profile}. Available profiles: {allowed}"
 
 
 def _parse_bool_arg(args: dict, name: str, *, default: bool = False):
@@ -651,6 +666,10 @@ def _handle_create(args: dict, **kw) -> str:
             "assignee is required — name the profile that should execute this "
             "task (the dispatcher will only spawn tasks with an assignee)"
         )
+    assignee = _normalize_profile(assignee)
+    assignee_error = _validate_assignee_profile(assignee)
+    if assignee_error:
+        return tool_error(f"kanban_create: {assignee_error}")
     body = args.get("body")
     parents = args.get("parents") or []
     tenant = args.get("tenant") or os.environ.get("HERMES_TENANT")
@@ -689,7 +708,7 @@ def _handle_create(args: dict, **kw) -> str:
                 conn,
                 title=str(title).strip(),
                 body=body,
-                assignee=str(assignee),
+                assignee=assignee,
                 parents=tuple(parents),
                 tenant=tenant,
                 priority=int(priority) if priority is not None else 0,


### PR DESCRIPTION
## Summary
- reject Kanban CLI create/assign/reassign when the requested assignee is not an installed profile
- apply the same guardrail to kanban_create tool fan-out
- keep fresh installs/test homes permissive until named profiles exist, while still allowing default

## Test Plan
- uv run pytest tests/hermes_cli/test_kanban*.py tests/tools/test_kanban_tools.py -q