### PR TITLE
fix: preserve virtualenv path in terminal snapshots

### DIFF
--- a/tests/tools/test_base_environment.py
+++ b/tests/tools/test_base_environment.py
@@ -5,9 +5,13 @@ init_session() failure handling, and the CWD marker contract.
 """
 
 import uuid
+import os
+import subprocess
 from unittest.mock import MagicMock
 
-from tools.environments.base import BaseEnvironment, _cwd_marker
+import pytest
+
+from tools.environments.base import BaseEnvironment, _cwd_marker, _virtualenv_path_guard
 
 
 class _TestableEnv(BaseEnvironment):
@@ -89,6 +93,68 @@ class TestWrapCommand:
         wrapped = env._wrap_command("ls", "/nonexistent")
 
         assert "exit 126" in wrapped
+
+    def test_virtualenv_path_guard_runs_before_snapshot_update(self):
+        env = _TestableEnv()
+        env._snapshot_ready = True
+        wrapped = env._wrap_command("echo hello", "/tmp")
+
+        guard_pos = wrapped.index('if [ -n "${VIRTUAL_ENV:-}" ]')
+        export_pos = wrapped.index("export -p >")
+        assert guard_pos < export_pos
+
+
+@pytest.mark.skipif(not os.path.isfile("/bin/bash"), reason="Requires /bin/bash")
+class TestVirtualenvPathGuard:
+    def _run_guard(self, env):
+        proc = subprocess.run(
+            ["/bin/bash", "-c", f"{_virtualenv_path_guard()}\nprintf '%s' \"$PATH\""],
+            env=env,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=True,
+        )
+        return proc.stdout
+
+    def test_prepends_virtualenv_bin_when_directory_exists(self, tmp_path):
+        venv = tmp_path / ".venv"
+        (venv / "bin").mkdir(parents=True)
+
+        path = self._run_guard({
+            "VIRTUAL_ENV": str(venv),
+            "PATH": "/usr/bin:/bin",
+        })
+
+        assert path == f"{venv / 'bin'}:/usr/bin:/bin"
+
+    def test_leaves_path_unchanged_when_virtualenv_unset(self):
+        path = self._run_guard({"PATH": "/usr/bin:/bin"})
+
+        assert path == "/usr/bin:/bin"
+
+    def test_leaves_path_unchanged_when_virtualenv_bin_missing(self, tmp_path):
+        venv = tmp_path / ".venv"
+        venv.mkdir()
+
+        path = self._run_guard({
+            "VIRTUAL_ENV": str(venv),
+            "PATH": "/usr/bin:/bin",
+        })
+
+        assert path == "/usr/bin:/bin"
+
+    def test_does_not_duplicate_virtualenv_bin(self, tmp_path):
+        venv = tmp_path / ".venv"
+        bin_dir = venv / "bin"
+        bin_dir.mkdir(parents=True)
+
+        path = self._run_guard({
+            "VIRTUAL_ENV": str(venv),
+            "PATH": f"/usr/local/bin:{bin_dir}:/usr/bin:/bin",
+        })
+
+        assert path == f"/usr/local/bin:{bin_dir}:/usr/bin:/bin"
 
 
 class TestExtractCwdFromOutput:

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -280,6 +280,24 @@ def _cwd_marker(session_id: str) -> str:
     return f"__HERMES_CWD_{session_id}__"
 
 
+def _virtualenv_path_guard() -> str:
+    """Return a shell snippet that keeps ``$VIRTUAL_ENV/bin`` on PATH.
+
+    Login shell profile scripts can reset PATH after the subprocess inherits
+    VIRTUAL_ENV from the gateway.  Preserve the active virtualenv's console
+    scripts in terminal snapshots without changing PATH when VIRTUAL_ENV is
+    unset or points at a non-existent venv.
+    """
+    return (
+        'if [ -n "${VIRTUAL_ENV:-}" ] && [ -d "$VIRTUAL_ENV/bin" ]; then\n'
+        '  case ":$PATH:" in\n'
+        '    *":$VIRTUAL_ENV/bin:"*) ;;\n'
+        '    *) export PATH="$VIRTUAL_ENV/bin${PATH:+:$PATH}" ;;\n'
+        "  esac\n"
+        "fi"
+    )
+
+
 # ---------------------------------------------------------------------------
 # BaseEnvironment
 # ---------------------------------------------------------------------------
@@ -369,7 +387,9 @@ class BaseEnvironment(ABC):
         # backends) into every terminal-tool response.
         _quoted_snap = shlex.quote(self._snapshot_path)
         _quoted_cwd_file = shlex.quote(self._cwd_file)
+        path_guard = _virtualenv_path_guard()
         bootstrap = (
+            f"{path_guard}\n"
             f"export -p > {_quoted_snap}\n"
             f"declare -f | grep -vE '^_[^_]' >> {_quoted_snap}\n"
             f"alias -p >> {_quoted_snap}\n"
@@ -451,6 +471,7 @@ class BaseEnvironment(ABC):
 
         # Re-dump env vars to snapshot (last-writer-wins for concurrent calls)
         if self._snapshot_ready:
+            parts.append(_virtualenv_path_guard())
             parts.append(f"export -p > {_quoted_snap} 2>/dev/null || true")
 
         # Write CWD to file (local reads this) and stdout marker (remote parses this)
@@ -851,4 +872,3 @@ class BaseEnvironment(ABC):
         from tools.terminal_tool import _transform_sudo_command
 
         return _transform_sudo_command(command)
-


### PR DESCRIPTION
## Summary

- Preserve `$VIRTUAL_ENV/bin` in terminal environment snapshots so gateway/container terminal subprocesses can resolve the Hermes CLI by bare `hermes`.
- Derive the path from `VIRTUAL_ENV` and no-op when the virtualenv bin directory is absent.
- Add focused regression coverage for valid, unset, invalid, and duplicate PATH cases.

## Root cause

Hermes gateway/container processes can run from a virtualenv while terminal sessions initialize through a login shell. Login profile scripts may reset `PATH` before `BaseEnvironment.init_session()` writes the snapshot. The snapshot then omits `$VIRTUAL_ENV/bin`, so later terminal tool commands cannot resolve console scripts installed in the active virtualenv.

## Test plan

- [x] `PYTHONPATH=. /opt/hermes/.venv/bin/python -m pytest tests/tools/test_base_environment.py tests/test_subprocess_home_isolation.py -q -o 'addopts='` → `39 passed, 1 warning`
- [x] `PYTHONPATH=. /opt/hermes/.venv/bin/python -m pytest tests/tools/test_base_environment.py tests/tools/test_docker_environment.py tests/tools/test_ssh_environment.py tests/tools/test_daytona_environment.py tests/tools/test_managed_modal_environment.py tests/tools/test_vercel_sandbox_environment.py -q -o 'addopts='` → `109 passed, 11 skipped, 13 warnings`
- [x] `PYTHONPATH=. /opt/hermes/.venv/bin/python -m ruff check tools/environments/base.py tests/tools/test_base_environment.py` → `All checks passed!`
- [x] Smoke: simulated login/profile PATH reset with `LocalEnvironment`; `command -v hermes` resolved `/opt/hermes/.venv/bin/hermes` and PATH started with `/opt/hermes/.venv/bin`.

## Deployment note

This is the source-level fix. Existing Docker/gateway deployments still need an image rebuild and container restart to pick it up.
