### PR TITLE
[Feature] Kanban: Add workflow engine for automatic task chaining

### DIFF
--- a/docs/proposals/kanban-workflow-engine.md
+++ b/docs/proposals/kanban-workflow-engine.md
@@ -1,0 +1,167 @@
+# Workflow Engine — Design Specification
+
+> This document defines the Kanban workflow engine proposed in the companion PR.
+> It is not an implementation; it serves as the design contract for review before code is written.
+
+## Overview
+
+Add an opt-in workflow engine to `dispatch_once` that automatically creates
+downstream tasks when upstream tasks complete, based on a declarative YAML
+workflow definition stored per board.
+
+## Workflow definition schema
+
+```yaml
+# .hermes/kanban/boards/{board}/workflow.yaml
+version: 1
+enabled: true
+
+# Global defaults applied to all auto-created tasks
+defaults:
+  workspace_kind: dir        # resolved from the completed task's workspace
+
+rules:
+  # Each rule matches on: assignee + optional mode field from task metadata
+  # and produces downstream task(s) based on outcome (pass / fail)
+
+  - trigger:
+      assignee: product-manager
+      mode: execute
+    outcomes:
+      pass:
+        - title: "Review PM output (UX perspective)"
+          assignee: ux-designer
+          mode: review
+          body_template: |
+            Review docs/PRD-draft.md from a UX research perspective.
+            Dimensions: feature completeness, user scenario coverage,
+            state definitions, error handling.
+            Pass → kanban_complete; Fail → kanban_block with itemized issues.
+
+  - trigger:
+      assignee: ux-designer
+      mode: review
+    outcomes:
+      pass:
+        - title: "UX research execution"
+          assignee: ux-designer
+          mode: execute
+      fail:
+        - title: "PM rework (UX feedback)"
+          assignee: product-manager
+          mode: rework
+          body_template: |
+            UX review did not pass. Revise docs/PRD-draft.md.
+            Feedback is in the upstream task's comment.
+```
+
+### Schema fields
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `version` | int | yes | Schema version. Must be `1`. |
+| `enabled` | bool | yes | Master toggle. `false` = skip all workflow processing. |
+| `defaults` | object | no | Defaults merged into every auto-created task. |
+| `rules` | list | yes | Ordered list of trigger → outcome mappings. |
+| `rules[].trigger` | object | yes | Match criteria. |
+| `rules[].trigger.assignee` | string | yes | Must match the completed task's assignee. |
+| `rules[].trigger.mode` | string | no | Must match `metadata.mode` on the completed task. |
+| `rules[].outcomes` | object | yes | Keys: `pass`, `fail`. At least one required. |
+| `rules[].outcomes.pass` | list | no | Tasks to create on pass. |
+| `rules[].outcomes.fail` | list | no | Tasks to create on fail. |
+| `outcomes[][].title` | string | yes | Task title. |
+| `outcomes[][].assignee` | string | yes | Profile to assign. |
+| `outcomes[][].mode` | string | no | Stored in task metadata for downstream matching. |
+| `outcomes[][].body_template` | string | no | Jinja2-like template for task body. Variables TBD. |
+
+## Integration point in dispatch_once
+
+```python
+def dispatch_once(conn, ...):
+    # ... existing reclaim / promote / spawn logic ...
+
+    # NEW: workflow advance (after spawn, same tick)
+    workflow_created = 0
+    if workflow_enabled(board_slug):
+        workflow_created = advance_workflow(conn, recently_completed_ids)
+    result.workflow_created = workflow_created
+    return result
+```
+
+## advance_workflow() algorithm
+
+```
+1. Filter recently_completed_ids to tasks whose status = done
+2. For each completed task:
+   a. Read workflow.yaml from board directory
+   b. If not enabled → skip
+   c. Match first rule where trigger.assignee == task.assignee
+      and (trigger.mode is unset or trigger.mode == task.metadata.mode)
+   d. Determine outcome:
+      - If task was blocked/gave_up → outcome = "fail"
+      - Else scan task's last comment + result for pass/fail keywords
+      - Default: pass (task completed normally without block)
+   e. Look up outcomes[outcome] in the matched rule
+   f. For each task spec in the outcome list:
+      - Create task via same code path as kanban_create
+      - Set parent = completed task id
+      - Merge defaults from workflow.yaml
+   g. Record created task ids in result
+3. Enforce max_chain_depth: count ancestors of each new task,
+   abort if depth exceeds configured limit
+4. Return count of created tasks
+```
+
+## Outcome detection
+
+### MVP: keyword scan (Option A)
+
+```yaml
+kanban:
+  workflow:
+    outcome_pass_keywords: ["通过", "pass", "approved"]
+    outcome_fail_keywords: ["不通过", "fail", "blocked"]
+```
+
+Scan the task's `result` field and the latest `comment` text. If any pass
+keyword is found → pass. If any fail keyword is found → fail. If neither →
+default to pass (task completed normally).
+
+### Future: structured metadata (Option B)
+
+Workers set `metadata.outcome = "pass"` or `"fail"` in their `kanban_complete`
+call. Cleaner but requires worker cooperation. Can be added later without
+breaking Option A.
+
+## Configuration
+
+```yaml
+# config.yaml
+kanban:
+  workflow:
+    enabled: false                  # global kill switch
+    outcome_pass_keywords: ["通过", "pass", "approved", "done"]
+    outcome_fail_keywords: ["不通过", "fail", "blocked", "block"]
+    max_chain_depth: 20             # safety limit against infinite loops
+```
+
+Per-board override via `workflow.yaml`'s `enabled` field.
+
+## Safety
+
+- `max_chain_depth` prevents runaway chain creation (default 20)
+- Only runs when `workflow.yaml` exists AND `enabled: true`
+- One rule matched per completed task (first match wins)
+- Fail path is explicit — no implicit rework loop
+- All created tasks are visible via `kanban list` and the dashboard
+
+## What this is NOT
+
+- Not a general DAG engine (no parallel fan-out, no complex conditionals)
+- Not a replacement for auto_decompose (that splits tasks; this chains stages)
+- Not requiring changes to any existing tool or worker behavior
+
+## Related
+
+- Issue #25020: broader auto-orchestration vision. This is a narrower, 
+  independently useful subset focused on deterministic chaining.


### PR DESCRIPTION
# [Feature] Kanban: Add workflow engine for automatic task chaining

## Problem

Kanban's dispatcher already handles task lifecycle: it spawns workers for ready tasks, reclaims crashed ones, and promotes child tasks when parents finish. But there is no mechanism to automatically create downstream tasks when an upstream task completes.

Right now, if you want a multi-stage workflow (like "PM writes PRD → UX reviews → UX executes → Behavior reviews → ..."), you are stuck with one of three workarounds:

**1. Pre-create the entire task graph upfront** with parent-child dependencies. This works for straight-line pipelines but falls apart when the next step depends on *how* the previous step turned out. A review that passes should trigger execution; a review that fails should loop back for fixes. Parent-child cannot express that.

**2. Have each worker call kanban_create to spawn its own successor**. This puts orchestration logic inside worker SOUL.md files. It is fragile: workers forget to create the card, or create it with the wrong assignee, and now you have flow control duplicated across six or eight profiles.

**3. Use a separate orchestrator profile as a middleman** (e.g., tech-director). Each worker finishes and creates an orchestrator card; the orchestrator reads the result and creates the real next step. This works but adds an extra API call at every transition and still requires one profile to encode the entire workflow.

None of these feel right. The dispatcher already knows when tasks complete. It ought to be able to decide what happens next.

## Proposed Solution

Add an opt-in **workflow engine** to `dispatch_once`. When enabled, after the normal promote/spawn cycle, the dispatcher checks recently completed tasks against a board-level workflow definition and auto-creates downstream tasks.

### Workflow definition

A YAML file in the board directory:

```yaml
# .hermes/kanban/boards/{board}/workflow.yaml
version: 1
enabled: true

rules:
  - trigger:
      assignee: product-manager
      mode: execute
    outcomes:
      pass:
        - title: "UX审核PM初版PRD"
          assignee: ux-designer
          mode: review
          body_template: |
            请从用户研究视角审核 docs/PRD-初版补全.md。
            审核维度：功能完整性、用户场景覆盖、状态定义、异常处理。
            通过→kanban_complete；不通过→kanban_block并逐条列出问题。

  - trigger:
      assignee: ux-designer
      mode: review
    outcomes:
      pass:
        - title: "UX补全执行"
          assignee: ux-designer
          mode: execute
      fail:
        - title: "PM修改（UX打回）"
          assignee: product-manager
          mode: rework
```

### Where it fits in dispatch_once

One new step after the existing spawn loop:

```python
if workflow_enabled(board):
    result.workflow_created = advance_workflow(conn, recently_completed_ids)
```

`advance_workflow()` does five things:

1. Finds tasks that transitioned to done in this tick
2. Loads `workflow.yaml` and matches rules against `(assignee, metadata.mode)`
3. Determines pass/fail by scanning the task's comment/result text for configurable keywords
4. Creates downstream task(s) via the same code path as `kanban_create`
5. Links them as children of the completed task

### How does the dispatcher know if a task passed or failed?

Two options, start simple:

**Option A (this PR): Keyword scan.** Search the task's last comment and result for pass/fail keywords. Default pass words: "通过", "pass", "approved". Everything else counts as fail, plus explicit fail words: "不通过", "fail", "blocked". Works with any existing worker without changes.

**Option B (future): Structured metadata.** Workers set `metadata.outcome = "pass|fail"` in their kanban_complete call. Cleaner but requires workers to cooperate.

### Configuration

```yaml
kanban:
  workflow:
    enabled: false              # off by default, opt-in
    outcome_pass_keywords: ["通过", "pass", "approved"]
    outcome_fail_keywords: ["不通过", "fail", "blocked"]
    max_chain_depth: 20         # safety limit against infinite loops
```

### What this is not

- Not a general DAG engine. No parallel fan-out, no complex conditionals beyond pass/fail.
- Not a replacement for auto_decompose (that splits one task into subtasks; this chains different stages).
- Not breaking backward compatibility. Disabled by default. Zero changes required from any existing worker or tool.

## Related issues

Related to #25020 ("Add an opt-in /Efficiency mode for kanban-backed auto orchestration"). That issue describes a broader vision: an AI-driven orchestrator that dynamically decides task decomposition, routing, and result comparison. This PR tackles a narrower, independently useful subset: deterministic task chaining based on a declarative workflow definition. The two approaches can coexist — workflow.yaml handles known, fixed pipelines (like a multi-stage PRD review process) without burning LLM tokens on orchestration decisions, while a future /Efficiency mode could handle open-ended tasks where the next step is not known in advance.

## Alternatives considered

**Conditional parent-child promotion:** Extend the existing promote logic so children only activate on certain outcomes. The problem is you need to pre-create both the pass-path and fail-path tasks before the parent finishes. For long chains this bloats the board with tasks that may never run.

**Post-complete hook in complete_task():** Fire a callback right after a task completes. But complete_task runs inside worker processes, not the dispatcher, so the hook would need cross-process coordination. The dispatcher tick already has DB access and sees all state transitions naturally.

**External polling script:** A cron job that watches the kanban DB and creates downstream tasks. This bypasses Dispatcher validation (created_cards verification, profile checks) and duplicates logic that lives in kanban_db.py.

## Scope — first version

**In:**
- YAML workflow file per board
- Trigger on assignee + optional mode metadata
- Binary pass/fail with keyword detection
- Auto-create downstream tasks with parent linkage
- Config toggle, depth safety limit

**Out of scope (deliberately):**
- Parallel fan-out
- Complex conditionals beyond binary pass/fail
- Retry/requeue logic
- Web UI for editing workflows
- Cross-board workflows