### PR TITLE
fix(feishu): enable document tools in DM sessions

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -1712,6 +1712,8 @@ class FeishuAdapter(BasePlatformAdapter):
         self._ws_thread_loop = None
         self._loop = None
         self._event_handler = None
+        self._client = None
+        self._set_tool_clients(None)
         self._persist_seen_message_ids()
         await self._release_app_lock()
 
@@ -4414,6 +4416,7 @@ class FeishuAdapter(BasePlatformAdapter):
             raise RuntimeError("websockets not installed; websocket mode unavailable")
         domain = FEISHU_DOMAIN if self._domain_name != "lark" else LARK_DOMAIN
         self._client = self._build_lark_client(domain)
+        self._set_tool_clients(self._client)
         self._event_handler = self._build_event_handler()
         if self._event_handler is None:
             raise RuntimeError("failed to build Feishu event handler")
@@ -4440,6 +4443,7 @@ class FeishuAdapter(BasePlatformAdapter):
             raise RuntimeError("aiohttp not installed; webhook mode unavailable")
         domain = FEISHU_DOMAIN if self._domain_name != "lark" else LARK_DOMAIN
         self._client = self._build_lark_client(domain)
+        self._set_tool_clients(self._client)
         self._event_handler = self._build_event_handler()
         if self._event_handler is None:
             raise RuntimeError("failed to build Feishu event handler")
@@ -4460,6 +4464,14 @@ class FeishuAdapter(BasePlatformAdapter):
             .log_level(lark.LogLevel.WARNING)
             .build()
         )
+
+    @staticmethod
+    def _set_tool_clients(client: Any) -> None:
+        from tools.feishu_doc_tool import set_shared_client as set_doc_client
+        from tools.feishu_drive_tool import set_shared_client as set_drive_client
+
+        set_doc_client(client)
+        set_drive_client(client)
 
     async def _feishu_send_with_retry(
         self,

--- a/tests/gateway/test_feishu_tool_client_binding.py
+++ b/tests/gateway/test_feishu_tool_client_binding.py
@@ -1,0 +1,16 @@
+"""Tests for Feishu adapter client binding into Feishu document tools."""
+
+from unittest.mock import patch
+
+
+def test_set_tool_clients_updates_shared_feishu_tool_clients():
+    from gateway.platforms.feishu import FeishuAdapter
+
+    client = object()
+    with patch("tools.feishu_doc_tool.set_shared_client") as set_doc_client, patch(
+        "tools.feishu_drive_tool.set_shared_client"
+    ) as set_drive_client:
+        FeishuAdapter._set_tool_clients(client)
+
+    set_doc_client.assert_called_once_with(client)
+    set_drive_client.assert_called_once_with(client)

--- a/tests/tools/test_feishu_tools.py
+++ b/tests/tools/test_feishu_tools.py
@@ -6,8 +6,8 @@ import unittest
 from tools.registry import registry
 
 # Trigger tool discovery so feishu tools get registered
-importlib.import_module("tools.feishu_doc_tool")
-importlib.import_module("tools.feishu_drive_tool")
+doc_tool = importlib.import_module("tools.feishu_doc_tool")
+drive_tool = importlib.import_module("tools.feishu_drive_tool")
 
 
 class TestFeishuToolRegistration(unittest.TestCase):
@@ -56,6 +56,28 @@ class TestFeishuToolRegistration(unittest.TestCase):
             props = entry.schema["parameters"].get("properties", {})
             self.assertIn("file_token", props, f"{tool_name} missing file_token param")
             self.assertIn("file_type", props, f"{tool_name} missing file_type param")
+
+
+class TestFeishuToolClientFallback(unittest.TestCase):
+    def tearDown(self):
+        doc_tool.set_client(None)
+        doc_tool.set_shared_client(None)
+        drive_tool.set_client(None)
+        drive_tool.set_shared_client(None)
+
+    def test_doc_tool_uses_shared_client_when_thread_local_missing(self):
+        shared = object()
+        doc_tool.set_shared_client(shared)
+
+        self.assertIs(doc_tool.get_client(), shared)
+
+    def test_drive_tool_prefers_thread_local_over_shared(self):
+        shared = object()
+        local = object()
+        drive_tool.set_shared_client(shared)
+        drive_tool.set_client(local)
+
+        self.assertIs(drive_tool.get_client(), local)
 
 
 if __name__ == "__main__":

--- a/tools/feishu_doc_tool.py
+++ b/tools/feishu_doc_tool.py
@@ -14,6 +14,7 @@ logger = logging.getLogger(__name__)
 
 # Thread-local storage for the lark client injected by feishu_comment handler.
 _local = threading.local()
+_shared_client = None
 
 
 def set_client(client):
@@ -21,9 +22,18 @@ def set_client(client):
     _local.client = client
 
 
+def set_shared_client(client):
+    """Store a process-wide fallback client for Feishu DM/gateway tool calls."""
+    global _shared_client
+    _shared_client = client
+
+
 def get_client():
-    """Return the lark client for the current thread, or None."""
-    return getattr(_local, "client", None)
+    """Return the thread-local client, or the shared fallback when present."""
+    client = getattr(_local, "client", None)
+    if client is not None:
+        return client
+    return _shared_client
 
 
 # ---------------------------------------------------------------------------
@@ -73,7 +83,7 @@ def _handle_feishu_doc_read(args: dict, **kwargs) -> str:
 
     client = get_client()
     if client is None:
-        return tool_error("Feishu client not available (not in a Feishu comment context)")
+        return tool_error("Feishu client not available")
 
     try:
         from lark_oapi import AccessTokenType

--- a/tools/feishu_drive_tool.py
+++ b/tools/feishu_drive_tool.py
@@ -15,6 +15,7 @@ logger = logging.getLogger(__name__)
 
 # Thread-local storage for the lark client injected by feishu_comment handler.
 _local = threading.local()
+_shared_client = None
 
 
 def set_client(client):
@@ -22,9 +23,18 @@ def set_client(client):
     _local.client = client
 
 
+def set_shared_client(client):
+    """Store a process-wide fallback client for Feishu DM/gateway tool calls."""
+    global _shared_client
+    _shared_client = client
+
+
 def get_client():
-    """Return the lark client for the current thread, or None."""
-    return getattr(_local, "client", None)
+    """Return the thread-local client, or the shared fallback when present."""
+    client = getattr(_local, "client", None)
+    if client is not None:
+        return client
+    return _shared_client
 
 
 def _check_feishu():


### PR DESCRIPTION
## Summary
- add shared Feishu client fallbacks for doc and drive tools outside comment-thread locals
- bind and clear those shared clients from the Feishu gateway adapter connect/disconnect lifecycle
- cover the DM fallback and precedence behavior with targeted tests

Fixes #29760

## Testing
- uv run --frozen pytest -q -o addopts= tests/tools/test_feishu_tools.py tests/gateway/test_feishu_tool_client_binding.py\n- uv run --frozen ruff check tools/feishu_doc_tool.py tools/feishu_drive_tool.py gateway/platforms/feishu.py tests/tools/test_feishu_tools.py tests/gateway/test_feishu_tool_client_binding.py\n- git diff --check