### PR TITLE
feat(web): route Tavily/Exa search backends through credential pool

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -145,6 +145,12 @@ SERVICE_PROVIDER_NAMES: Dict[str, str] = {
     "spotify": "Spotify",
 }
 
+# Pool-only auth (api_key, no OAuth) for web-search backends.
+WEB_POOL_PROVIDERS: Dict[str, str] = {
+    "tavily": "Tavily",
+    "exa": "Exa",
+}
+
 # LM Studio's default no-auth mode still requires *some* non-empty bearer for
 # the API-key code paths (auxiliary_client, runtime resolver) to treat the
 # provider as configured. This sentinel is sent only to LM Studio, never to
@@ -1380,13 +1386,19 @@ def mark_provider_active_if_unset(provider_id: str) -> None:
 
 def is_known_auth_provider(provider_id: str) -> bool:
     normalized = (provider_id or "").strip().lower()
-    return normalized in PROVIDER_REGISTRY or normalized in SERVICE_PROVIDER_NAMES
+    return (
+        normalized in PROVIDER_REGISTRY
+        or normalized in SERVICE_PROVIDER_NAMES
+        or normalized in WEB_POOL_PROVIDERS
+    )
 
 
 def get_auth_provider_display_name(provider_id: str) -> str:
     normalized = (provider_id or "").strip().lower()
     if normalized in PROVIDER_REGISTRY:
         return PROVIDER_REGISTRY[normalized].name
+    if normalized in WEB_POOL_PROVIDERS:
+        return WEB_POOL_PROVIDERS[normalized]
     return SERVICE_PROVIDER_NAMES.get(normalized, provider_id)
 
 
@@ -6770,6 +6782,15 @@ def get_auth_status(provider_id: Optional[str] = None) -> Dict[str, Any]:
     pconfig = PROVIDER_REGISTRY.get(target)
     if pconfig and pconfig.auth_type == "api_key":
         return get_api_key_provider_status(target)
+    # Pool-only providers (e.g. Tavily/Exa).
+    if target in WEB_POOL_PROVIDERS:
+        entries = read_credential_pool(target)
+        return {
+            "logged_in": bool(entries),
+            "provider": target,
+            "name": WEB_POOL_PROVIDERS[target],
+            "key_count": len(entries) if isinstance(entries, list) else 0,
+        }
     # AWS SDK providers (Bedrock) — check via boto3 credential chain
     if pconfig and pconfig.auth_type == "aws_sdk":
         try:

--- a/hermes_cli/auth_commands.py
+++ b/hermes_cli/auth_commands.py
@@ -28,7 +28,7 @@ from agent.credential_pool import (
     load_pool,
 )
 import hermes_cli.auth as auth_mod
-from hermes_cli.auth import PROVIDER_REGISTRY
+from hermes_cli.auth import PROVIDER_REGISTRY, WEB_POOL_PROVIDERS
 from hermes_constants import OPENROUTER_BASE_URL
 from hermes_cli.secret_prompt import masked_secret_prompt
 
@@ -163,7 +163,12 @@ def _format_exhausted_status(entry) -> str:
 
 def auth_add_command(args) -> None:
     provider = _normalize_provider(getattr(args, "provider", ""))
-    if provider not in PROVIDER_REGISTRY and provider != "openrouter" and not provider.startswith(CUSTOM_POOL_PREFIX):
+    if (
+        provider not in PROVIDER_REGISTRY
+        and provider != "openrouter"
+        and provider not in WEB_POOL_PROVIDERS
+        and not provider.startswith(CUSTOM_POOL_PREFIX)
+    ):
         raise SystemExit(f"Unknown provider: {provider}")
 
     requested_type = str(getattr(args, "auth_type", "") or "").strip().lower()
@@ -442,6 +447,7 @@ def auth_list_command(args) -> None:
         providers = sorted({
             *PROVIDER_REGISTRY.keys(),
             "openrouter",
+            *WEB_POOL_PROVIDERS,
             *list_custom_pool_providers(),
         })
     for provider in providers:
@@ -654,7 +660,7 @@ def _interactive_auth() -> None:
 
 def _pick_provider(prompt: str = "Provider") -> str:
     """Prompt for a provider name with auto-complete hints."""
-    known = sorted(set(list(PROVIDER_REGISTRY.keys()) + ["openrouter"]))
+    known = sorted(set(list(PROVIDER_REGISTRY.keys()) + ["openrouter"] + list(WEB_POOL_PROVIDERS)))
     custom_names = _get_custom_provider_names()
     if custom_names:
         custom_display = [name for name, _key, _provider_key in custom_names]
@@ -671,7 +677,12 @@ def _pick_provider(prompt: str = "Provider") -> str:
 
 def _interactive_add() -> None:
     provider = _pick_provider("Provider to add credential for")
-    if provider not in PROVIDER_REGISTRY and provider != "openrouter" and not provider.startswith(CUSTOM_POOL_PREFIX):
+    if (
+        provider not in PROVIDER_REGISTRY
+        and provider != "openrouter"
+        and provider not in WEB_POOL_PROVIDERS
+        and not provider.startswith(CUSTOM_POOL_PREFIX)
+    ):
         raise SystemExit(f"Unknown provider: {provider}")
 
     # For OAuth-capable providers, ask which type

--- a/plugins/web/exa/provider.py
+++ b/plugins/web/exa/provider.py
@@ -25,12 +25,20 @@ ABC method-name change.
 from __future__ import annotations
 
 import logging
-import os
-from typing import Any, Dict, List
+import re
+from typing import Any, Callable, Dict, List, Optional, Tuple, TypeVar
 
-from agent.web_search_provider import WebSearchProvider
+from agent.credential_pool import CredentialPool, PooledCredential, load_pool
+from agent.web_search_provider import WebSearchProvider, get_provider_env
 
 logger = logging.getLogger(__name__)
+
+_POOL_PROVIDER = "exa"
+_ROTATE_STATUSES = frozenset({401, 403, 429})
+# Anchored to HTTP/status so trace IDs containing 401/403/429 don't false-positive.
+_STATUS_RE = re.compile(r"\b(?:HTTP|status[a-z_ ]*)\W{0,4}(401|403|429)\b", re.IGNORECASE)
+
+T = TypeVar("T")
 
 # Module-level note: the canonical ``_exa_client`` cache slot lives on
 # :mod:`tools.web_tools` so tests that do ``tools.web_tools._exa_client =
@@ -38,27 +46,53 @@ logger = logging.getLogger(__name__)
 # that public module (see :func:`_get_exa_client`).
 
 
-def _get_exa_client() -> Any:
-    """Lazy-import and cache an Exa SDK client.
+def _load_exa_pool() -> Optional[CredentialPool]:
+    """Return the Exa credential pool, or ``None`` if loading fails."""
+    try:
+        return load_pool(_POOL_PROVIDER)
+    except Exception as exc:  # noqa: BLE001 — pool failures must not break web_search
+        logger.warning("exa: failed to load credential pool: %s", exc)
+        return None
 
-    Cache lives on :mod:`tools.web_tools` (as ``_exa_client``) so unit
-    tests that reset that name between cases keep working. Raises
-    ``ValueError`` when ``EXA_API_KEY`` is unset.
-    """
+
+def _pool_runtime_api_key(entry: Any) -> str:
+    if entry is None:
+        return ""
+    key = getattr(entry, "runtime_api_key", None) or getattr(entry, "access_token", "")
+    return str(key or "").strip()
+
+
+def _resolve_exa_key() -> Tuple[Optional[str], Optional[CredentialPool], Optional[PooledCredential]]:
+    """Resolve an Exa API key (pool-first, env fallback). ``pool``/``entry`` are ``None`` for env."""
+    pool = _load_exa_pool()
+    if pool is not None and pool.has_credentials():
+        entry = pool.select()
+        if entry is not None:
+            api_key = _pool_runtime_api_key(entry)
+            if api_key:
+                return api_key, pool, entry
+
+    return (get_provider_env("EXA_API_KEY") or None), None, None
+
+
+def _pool_has_entries() -> bool:
+    """Cheap probe for ``is_available()`` — no seeding/persisting."""
+    try:
+        from hermes_cli.auth import read_credential_pool
+
+        entries = read_credential_pool(_POOL_PROVIDER)
+    except Exception:
+        return False
+    return bool(entries)
+
+
+def _build_exa_client(
+    api_key: str,
+    pool: Optional[CredentialPool] = None,
+    entry: Optional[PooledCredential] = None,
+) -> Any:
+    """Build, cache, and return an Exa SDK client; stash pool state for rotation."""
     import tools.web_tools as _wt
-
-    cached = getattr(_wt, "_exa_client", None)
-    if cached is not None:
-        return cached
-
-    from agent.web_search_provider import get_provider_env
-
-    api_key = get_provider_env("EXA_API_KEY")
-    if not api_key:
-        raise ValueError(
-            "EXA_API_KEY environment variable not set. "
-            "Get your API key at https://exa.ai"
-        )
 
     try:
         from tools.lazy_deps import ensure as _lazy_ensure
@@ -73,15 +107,101 @@ def _get_exa_client() -> Any:
 
     client = Exa(api_key=api_key)
     client.headers["x-exa-integration"] = "hermes-agent"
+    client._hermes_pool_state = (
+        (pool, entry, api_key) if pool is not None and entry is not None else None
+    )
     _wt._exa_client = client
     return client
 
 
-def _reset_client_for_tests() -> None:
-    """Drop the cached Exa client so tests can re-instantiate cleanly."""
+def _get_exa_client() -> Any:
+    """Return a cached Exa SDK client (pool-first, env fallback). Raises ``ValueError`` if neither."""
     import tools.web_tools as _wt
 
-    _wt._exa_client = None
+    cached = getattr(_wt, "_exa_client", None)
+    if cached is not None:
+        return cached
+
+    api_key, pool, entry = _resolve_exa_key()
+    if not api_key:
+        raise ValueError(
+            "EXA_API_KEY environment variable not set. "
+            "Get your API key at https://exa.ai"
+        )
+
+    return _build_exa_client(api_key, pool, entry)
+
+
+def _exa_error_status(exc: BaseException) -> Optional[int]:
+    """Best-effort extraction of an HTTP status code from an Exa SDK exception."""
+    for attr in ("status_code", "status", "http_status", "code"):
+        value = getattr(exc, attr, None)
+        if isinstance(value, int):
+            return value
+        if isinstance(value, str) and value.isdigit():
+            return int(value)
+    response = getattr(exc, "response", None)
+    if response is not None:
+        status = getattr(response, "status_code", None)
+        if isinstance(status, int):
+            return status
+    match = _STATUS_RE.search(str(exc))
+    if match:
+        return int(match.group(1))
+    return None
+
+
+def _call_with_rotation(fn: Callable[[Any], T]) -> T:
+    """Invoke ``fn(client)``; on 401/403/429 mark the cached client's entry exhausted and retry once."""
+    import tools.web_tools as _wt
+
+    cached = getattr(_wt, "_exa_client", None)
+    if cached is not None:
+        client = cached
+        state = getattr(client, "_hermes_pool_state", None)
+        if state is not None:
+            pool, entry, api_key = state
+        else:
+            pool, entry, api_key = None, None, str(getattr(client, "api_key", "") or "")
+    else:
+        api_key, pool, entry = _resolve_exa_key()
+        if not api_key:
+            raise ValueError(
+                "EXA_API_KEY environment variable not set. "
+                "Get your API key at https://exa.ai"
+            )
+        client = _build_exa_client(api_key, pool, entry)
+
+    for attempt in (1, 2):
+        try:
+            return fn(client)
+        except (ValueError, ImportError):
+            raise
+        except Exception as exc:  # noqa: BLE001 — Exa SDK error class varies
+            status = _exa_error_status(exc)
+            if (
+                attempt == 1
+                and pool is not None
+                and entry is not None
+                and status in _ROTATE_STATUSES
+            ):
+                rotated = pool.mark_exhausted_and_rotate(
+                    status_code=status,
+                    error_context={"message": str(exc), "status_code": status},
+                )
+                if rotated is not None:
+                    new_key = _pool_runtime_api_key(rotated)
+                    if new_key and new_key != api_key:
+                        logger.info(
+                            "exa: rotating credential after HTTP %s and retrying", status
+                        )
+                        entry = rotated
+                        api_key = new_key
+                        client = _build_exa_client(api_key, pool, entry)
+                        continue
+            raise
+
+    raise RuntimeError("exa: _call_with_rotation exited retry loop unexpectedly")
 
 
 class ExaWebSearchProvider(WebSearchProvider):
@@ -101,10 +221,10 @@ class ExaWebSearchProvider(WebSearchProvider):
         return "Exa"
 
     def is_available(self) -> bool:
-        """Return True when ``EXA_API_KEY`` is set to a non-empty value."""
-        from agent.web_search_provider import get_provider_env
-
-        return bool(get_provider_env("EXA_API_KEY"))
+        """Return True when an Exa credential is available via env or pool. Must stay cheap."""
+        if get_provider_env("EXA_API_KEY"):
+            return True
+        return _pool_has_entries()
 
     def supports_search(self) -> bool:
         return True
@@ -126,10 +246,12 @@ class ExaWebSearchProvider(WebSearchProvider):
                 return {"success": False, "error": "Interrupted"}
 
             logger.info("Exa search: '%s' (limit=%d)", query, limit)
-            response = _get_exa_client().search(
-                query,
-                num_results=limit,
-                contents={"highlights": True},
+            response = _call_with_rotation(
+                lambda client: client.search(
+                    query,
+                    num_results=limit,
+                    contents={"highlights": True},
+                )
             )
 
             web_results = []
@@ -170,7 +292,9 @@ class ExaWebSearchProvider(WebSearchProvider):
                 ]
 
             logger.info("Exa extract: %d URL(s)", len(urls))
-            response = _get_exa_client().get_contents(urls, text=True)
+            response = _call_with_rotation(
+                lambda client: client.get_contents(urls, text=True)
+            )
 
             results: List[Dict[str, Any]] = []
             for result in response.results or []:

--- a/plugins/web/tavily/provider.py
+++ b/plugins/web/tavily/provider.py
@@ -15,6 +15,11 @@ Config keys this provider responds to::
       extract_backend: "tavily"    # explicit per-capability
       backend: "tavily"            # shared fallback for both
 
+Credentials resolve pool-first: keys added via ``hermes auth add tavily``
+are rotated on 401/403/429. When no pool credential is available the
+provider falls back to ``TAVILY_API_KEY`` (config-aware; see
+:func:`agent.web_search_provider.get_provider_env`).
+
 Env vars::
 
     TAVILY_API_KEY=...           # https://app.tavily.com/home (required)
@@ -24,26 +29,66 @@ Env vars::
 from __future__ import annotations
 
 import logging
-import os
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional, Tuple
 
-from agent.web_search_provider import WebSearchProvider
+from agent.credential_pool import CredentialPool, PooledCredential, load_pool
+from agent.web_search_provider import WebSearchProvider, get_provider_env
 
 logger = logging.getLogger(__name__)
 
+_POOL_PROVIDER = "tavily"
+_ROTATE_STATUSES = frozenset({401, 403, 429})
+
+
+def _load_tavily_pool() -> Optional[CredentialPool]:
+    """Return the Tavily credential pool, or ``None`` if the pool fails to load."""
+    try:
+        return load_pool(_POOL_PROVIDER)
+    except Exception as exc:  # noqa: BLE001 — pool failures must not break web_search
+        logger.warning("tavily: failed to load credential pool: %s", exc)
+        return None
+
+
+def _pool_runtime_api_key(entry: Any) -> str:
+    if entry is None:
+        return ""
+    key = getattr(entry, "runtime_api_key", None) or getattr(entry, "access_token", "")
+    return str(key or "").strip()
+
+
+def _resolve_tavily_key() -> Tuple[Optional[str], Optional[CredentialPool], Optional[PooledCredential]]:
+    """Resolve a Tavily API key (pool-first, env fallback). ``pool``/``entry`` are ``None`` for env."""
+    pool = _load_tavily_pool()
+    if pool is not None and pool.has_credentials():
+        entry = pool.select()
+        if entry is not None:
+            api_key = _pool_runtime_api_key(entry)
+            if api_key:
+                return api_key, pool, entry
+
+    return (get_provider_env("TAVILY_API_KEY") or None), None, None
+
+
+def _pool_has_entries() -> bool:
+    """Cheap probe for ``is_available()`` — no seeding/persisting."""
+    try:
+        from hermes_cli.auth import read_credential_pool
+
+        entries = read_credential_pool(_POOL_PROVIDER)
+    except Exception:
+        return False
+    return bool(entries)
+
 
 def _tavily_request(endpoint: str, payload: Dict[str, Any]) -> Dict[str, Any]:
-    """POST to the Tavily API and return the parsed JSON response.
+    """POST to Tavily; on 401/403/429 from a pool key, rotate and retry once.
 
-    Mirrors :func:`tools.web_tools._tavily_request`. Raises ``ValueError``
-    when ``TAVILY_API_KEY`` is unset; the caller catches and surfaces as
-    a typed error response.
+    Raises ``ValueError`` when no credential is available; the caller
+    catches and surfaces it as a typed error response.
     """
     import httpx
 
-    from agent.web_search_provider import get_provider_env
-
-    api_key = get_provider_env("TAVILY_API_KEY")
+    api_key, pool, entry = _resolve_tavily_key()
     if not api_key:
         raise ValueError(
             "TAVILY_API_KEY environment variable not set. "
@@ -51,14 +96,41 @@ def _tavily_request(endpoint: str, payload: Dict[str, Any]) -> Dict[str, Any]:
         )
 
     base_url = get_provider_env("TAVILY_BASE_URL") or "https://api.tavily.com"
-    payload = dict(payload)  # don't mutate caller's dict
-    payload["api_key"] = api_key
     url = f"{base_url}/{endpoint.lstrip('/')}"
     logger.info("Tavily %s request to %s", endpoint, url)
 
-    response = httpx.post(url, json=payload, timeout=60)
-    response.raise_for_status()
-    return response.json()
+    for attempt in (1, 2):
+        request_payload = dict(payload)  # don't mutate caller's dict
+        request_payload["api_key"] = api_key
+
+        response = httpx.post(url, json=request_payload, timeout=60)
+        try:
+            response.raise_for_status()
+            return response.json()
+        except httpx.HTTPStatusError as exc:
+            status = getattr(exc.response, "status_code", None)
+            if (
+                attempt == 1
+                and pool is not None
+                and entry is not None
+                and status in _ROTATE_STATUSES
+            ):
+                rotated = pool.mark_exhausted_and_rotate(
+                    status_code=status,
+                    error_context={"message": str(exc), "status_code": status},
+                )
+                if rotated is not None:
+                    new_key = _pool_runtime_api_key(rotated)
+                    if new_key and new_key != api_key:
+                        logger.info(
+                            "tavily: rotating credential after HTTP %s and retrying", status
+                        )
+                        entry = rotated
+                        api_key = new_key
+                        continue
+            raise
+
+    raise RuntimeError("tavily: _tavily_request exited retry loop unexpectedly")
 
 
 def _normalize_tavily_search_results(response: Dict[str, Any]) -> Dict[str, Any]:
@@ -139,10 +211,10 @@ class TavilyWebSearchProvider(WebSearchProvider):
         return "Tavily"
 
     def is_available(self) -> bool:
-        """Return True when ``TAVILY_API_KEY`` is set to a non-empty value."""
-        from agent.web_search_provider import get_provider_env
-
-        return bool(get_provider_env("TAVILY_API_KEY"))
+        """Return True when a Tavily credential is available via env or pool. Must stay cheap."""
+        if get_provider_env("TAVILY_API_KEY"):
+            return True
+        return _pool_has_entries()
 
     def supports_search(self) -> bool:
         return True

--- a/tests/tools/test_web_tools_exa.py
+++ b/tests/tools/test_web_tools_exa.py
@@ -1,0 +1,207 @@
+"""Tests for Exa credential-pool integration.
+
+Covers pool-first credential resolution in :func:`plugins.web.exa.provider._get_exa_client`
+and the rotate-and-retry behaviour of :func:`_call_with_rotation` on 401/403/429.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import pytest
+from unittest.mock import MagicMock, patch
+
+
+class _FakePoolEntry:
+    def __init__(self, key: str) -> None:
+        self.runtime_api_key = key
+        self.access_token = key
+
+
+class _FakePool:
+    """Drop-in pool stub with controllable select / rotate."""
+
+    def __init__(self, entries):
+        self._entries = list(entries)
+        self._current = 0
+        self.rotate_calls = []
+
+    def has_credentials(self) -> bool:
+        return bool(self._entries)
+
+    def select(self):
+        if not self._entries:
+            return None
+        return self._entries[self._current]
+
+    def mark_exhausted_and_rotate(self, status_code=None, **kwargs):  # noqa: ARG002
+        self.rotate_calls.append(status_code)
+        if self._current + 1 < len(self._entries):
+            self._current += 1
+            return self._entries[self._current]
+        return None
+
+
+class _SDKError(Exception):
+    """Stand-in for an Exa SDK exception that carries an HTTP status."""
+
+    def __init__(self, status_code: int, msg: str = "exa error"):
+        super().__init__(msg)
+        self.status_code = status_code
+
+
+@pytest.fixture(autouse=True)
+def _reset_exa_client_cache():
+    """Drop the cached Exa client around every test so resolution re-runs."""
+    import tools.web_tools as _wt
+
+    _wt._exa_client = None
+    yield
+    _wt._exa_client = None
+
+
+@pytest.fixture
+def fake_exa_module(monkeypatch):
+    """Inject a fake ``exa_py`` module whose ``Exa`` class records constructions."""
+    constructed = []
+
+    class _FakeExa:
+        def __init__(self, api_key: str):
+            self.api_key = api_key
+            self.headers = {}
+            constructed.append(api_key)
+
+    fake_module = MagicMock()
+    fake_module.Exa = _FakeExa
+    monkeypatch.setitem(sys.modules, "exa_py", fake_module)
+    return constructed
+
+
+class TestExaCredentialPool:
+    """Verify pool-first resolution + 401/403/429 rotation for Exa."""
+
+    def test_pool_entry_preferred_over_env(self, fake_exa_module):
+        pool = _FakePool([_FakePoolEntry("pool-key-1")])
+        with patch.dict(os.environ, {"EXA_API_KEY": "env-shadowed"}):
+            with patch("plugins.web.exa.provider.load_pool", return_value=pool):
+                from plugins.web.exa.provider import _get_exa_client
+
+                client = _get_exa_client()
+                assert client.api_key == "pool-key-1"
+                assert fake_exa_module == ["pool-key-1"]
+
+    def test_env_used_when_pool_empty(self, fake_exa_module):
+        pool = _FakePool([])
+        with patch.dict(os.environ, {"EXA_API_KEY": "env-key"}):
+            with patch("plugins.web.exa.provider.load_pool", return_value=pool):
+                from plugins.web.exa.provider import _get_exa_client
+
+                client = _get_exa_client()
+                assert client.api_key == "env-key"
+                assert fake_exa_module == ["env-key"]
+
+    def test_raises_when_no_credential(self):
+        pool = _FakePool([])
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("EXA_API_KEY", None)
+            with patch("plugins.web.exa.provider.load_pool", return_value=pool):
+                from plugins.web.exa.provider import _get_exa_client
+
+                with pytest.raises(ValueError, match="EXA_API_KEY"):
+                    _get_exa_client()
+
+    def test_429_rotates_and_retries(self, fake_exa_module):
+        pool = _FakePool([_FakePoolEntry("key-A"), _FakePoolEntry("key-B")])
+        calls = []
+
+        def fn(client):
+            calls.append(client.api_key)
+            if len(calls) == 1:
+                raise _SDKError(429, "rate limited")
+            return {"ok": True}
+
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("EXA_API_KEY", None)
+            with patch("plugins.web.exa.provider.load_pool", return_value=pool):
+                from plugins.web.exa.provider import _call_with_rotation
+
+                result = _call_with_rotation(fn)
+                assert result == {"ok": True}
+                assert calls == ["key-A", "key-B"]
+                assert pool.rotate_calls == [429]
+                # Cache should hold the rotated client.
+                assert fake_exa_module == ["key-A", "key-B"]
+
+    def test_500_does_not_rotate(self, fake_exa_module):
+        pool = _FakePool([_FakePoolEntry("key-A"), _FakePoolEntry("key-B")])
+
+        def fn(client):
+            raise _SDKError(500, "server error")
+
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("EXA_API_KEY", None)
+            with patch("plugins.web.exa.provider.load_pool", return_value=pool):
+                from plugins.web.exa.provider import _call_with_rotation
+
+                with pytest.raises(_SDKError):
+                    _call_with_rotation(fn)
+                assert pool.rotate_calls == []
+                # Only the initial client was built.
+                assert fake_exa_module == ["key-A"]
+
+    def test_429_with_env_only_does_not_rotate(self, fake_exa_module):
+        pool = _FakePool([])
+        calls = []
+
+        def fn(client):
+            calls.append(client.api_key)
+            raise _SDKError(429, "rate limited")
+
+        with patch.dict(os.environ, {"EXA_API_KEY": "env-only"}):
+            with patch("plugins.web.exa.provider.load_pool", return_value=pool):
+                from plugins.web.exa.provider import _call_with_rotation
+
+                with pytest.raises(_SDKError):
+                    _call_with_rotation(fn)
+                assert calls == ["env-only"]
+                assert pool.rotate_calls == []
+
+    def test_status_extracted_from_message_when_attr_missing(self, fake_exa_module):
+        """If the SDK exception lacks status_code, fall back to regex on str(exc)."""
+        pool = _FakePool([_FakePoolEntry("key-A"), _FakePoolEntry("key-B")])
+        calls = []
+
+        class _StringOnly(Exception):
+            pass
+
+        def fn(client):
+            calls.append(client.api_key)
+            if len(calls) == 1:
+                raise _StringOnly("HTTP 401 Unauthorized from exa")
+            return {"ok": True}
+
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("EXA_API_KEY", None)
+            with patch("plugins.web.exa.provider.load_pool", return_value=pool):
+                from plugins.web.exa.provider import _call_with_rotation
+
+                result = _call_with_rotation(fn)
+                assert result == {"ok": True}
+                assert pool.rotate_calls == [401]
+                assert calls == ["key-A", "key-B"]
+
+    def test_is_available_via_pool_only(self):
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("EXA_API_KEY", None)
+            with patch("hermes_cli.auth.read_credential_pool", return_value=[{"id": "k1"}]):
+                from plugins.web.exa.provider import ExaWebSearchProvider
+
+                assert ExaWebSearchProvider().is_available() is True
+
+    def test_is_available_false_when_no_env_and_empty_pool(self):
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("EXA_API_KEY", None)
+            with patch("hermes_cli.auth.read_credential_pool", return_value=[]):
+                from plugins.web.exa.provider import ExaWebSearchProvider
+
+                assert ExaWebSearchProvider().is_available() is False

--- a/tests/tools/test_web_tools_tavily.py
+++ b/tests/tools/test_web_tools_tavily.py
@@ -62,6 +62,137 @@ class TestTavilyRequest:
                     _tavily_request("search", {"query": "test"})
 
 
+# ─── credential pool integration ──────────────────────────────────────────────
+
+class _FakePoolEntry:
+    """Minimal stand-in for PooledCredential."""
+
+    def __init__(self, key: str) -> None:
+        self.runtime_api_key = key
+        self.access_token = key
+
+
+class _FakePool:
+    """Minimal stand-in for CredentialPool driving select / rotate paths."""
+
+    def __init__(self, entries):
+        self._entries = list(entries)
+        self._current = 0
+        self.rotate_calls = []
+
+    def has_credentials(self) -> bool:
+        return bool(self._entries)
+
+    def select(self):
+        if not self._entries:
+            return None
+        return self._entries[self._current]
+
+    def mark_exhausted_and_rotate(self, status_code=None, **kwargs):
+        self.rotate_calls.append(status_code)
+        if self._current + 1 < len(self._entries):
+            self._current += 1
+            return self._entries[self._current]
+        return None
+
+
+def _http_response(status: int = 200, json_body=None):
+    """Build a MagicMock httpx response that raises HTTPStatusError on >=400."""
+    import httpx as _httpx
+    resp = MagicMock()
+    resp.status_code = status
+    resp.json.return_value = json_body if json_body is not None else {"results": []}
+    if status >= 400:
+        resp.raise_for_status.side_effect = _httpx.HTTPStatusError(
+            f"{status} error", request=MagicMock(), response=resp
+        )
+    else:
+        resp.raise_for_status = MagicMock()
+    return resp
+
+
+class TestTavilyCredentialPool:
+    """Verify the pool-first credential resolution and 401/403/429 rotation."""
+
+    def test_pool_entry_preferred_over_env(self):
+        pool = _FakePool([_FakePoolEntry("pool-key-1")])
+        mock_response = _http_response(200)
+        with patch.dict(os.environ, {"TAVILY_API_KEY": "env-key-shadowed"}):
+            with patch("plugins.web.tavily.provider.load_pool", return_value=pool), \
+                 patch("tools.web_tools.httpx.post", return_value=mock_response) as mock_post:
+                from tools.web_tools import _tavily_request
+                _tavily_request("search", {"query": "hi"})
+                payload = mock_post.call_args.kwargs["json"]
+                assert payload["api_key"] == "pool-key-1"
+
+    def test_env_used_when_pool_empty(self):
+        pool = _FakePool([])
+        mock_response = _http_response(200)
+        with patch.dict(os.environ, {"TAVILY_API_KEY": "env-key"}):
+            with patch("plugins.web.tavily.provider.load_pool", return_value=pool), \
+                 patch("tools.web_tools.httpx.post", return_value=mock_response) as mock_post:
+                from tools.web_tools import _tavily_request
+                _tavily_request("search", {"query": "hi"})
+                assert mock_post.call_args.kwargs["json"]["api_key"] == "env-key"
+
+    def test_429_with_pool_rotates_and_retries(self):
+        pool = _FakePool([_FakePoolEntry("key-A"), _FakePoolEntry("key-B")])
+        failed = _http_response(429)
+        ok = _http_response(200)
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("TAVILY_API_KEY", None)
+            with patch("plugins.web.tavily.provider.load_pool", return_value=pool), \
+                 patch("tools.web_tools.httpx.post", side_effect=[failed, ok]) as mock_post:
+                from tools.web_tools import _tavily_request
+                result = _tavily_request("search", {"query": "hi"})
+                assert result == {"results": []}
+                assert pool.rotate_calls == [429]
+                assert mock_post.call_count == 2
+                assert mock_post.call_args_list[0].kwargs["json"]["api_key"] == "key-A"
+                assert mock_post.call_args_list[1].kwargs["json"]["api_key"] == "key-B"
+
+    def test_429_with_env_only_does_not_rotate(self):
+        import httpx as _httpx
+        pool = _FakePool([])
+        failed = _http_response(429)
+        with patch.dict(os.environ, {"TAVILY_API_KEY": "env-only"}):
+            with patch("plugins.web.tavily.provider.load_pool", return_value=pool), \
+                 patch("tools.web_tools.httpx.post", return_value=failed) as mock_post:
+                from tools.web_tools import _tavily_request
+                with pytest.raises(_httpx.HTTPStatusError):
+                    _tavily_request("search", {"query": "hi"})
+                assert mock_post.call_count == 1
+                assert pool.rotate_calls == []
+
+    def test_500_does_not_rotate(self):
+        import httpx as _httpx
+        pool = _FakePool([_FakePoolEntry("key-A"), _FakePoolEntry("key-B")])
+        failed = _http_response(500)
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("TAVILY_API_KEY", None)
+            with patch("plugins.web.tavily.provider.load_pool", return_value=pool), \
+                 patch("tools.web_tools.httpx.post", return_value=failed) as mock_post:
+                from tools.web_tools import _tavily_request
+                with pytest.raises(_httpx.HTTPStatusError):
+                    _tavily_request("search", {"query": "hi"})
+                assert mock_post.call_count == 1
+                assert pool.rotate_calls == []
+
+    def test_is_available_via_pool_only(self):
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("TAVILY_API_KEY", None)
+            with patch("hermes_cli.auth.read_credential_pool", return_value=[{"id": "k1"}]):
+                from plugins.web.tavily.provider import TavilyWebSearchProvider
+                assert TavilyWebSearchProvider().is_available() is True
+
+    def test_is_available_false_when_no_env_and_empty_pool(self):
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("TAVILY_API_KEY", None)
+            with patch("hermes_cli.auth.read_credential_pool", return_value=[]):
+                from plugins.web.tavily.provider import TavilyWebSearchProvider
+                assert TavilyWebSearchProvider().is_available() is False
+
+
 # ─── _normalize_tavily_search_results ─────────────────────────────────────────
 
 class TestNormalizeTavilySearchResults:
@@ -103,7 +234,7 @@ class TestNormalizeTavilySearchResults:
 # ─── _normalize_tavily_documents ──────────────────────────────────────────────
 
 class TestNormalizeTavilyDocuments:
-    """Test extract/crawl document normalization."""
+    """Test extract document normalization."""
 
     def test_basic_document(self):
         from tools.web_tools import _normalize_tavily_documents

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -133,10 +133,10 @@ For native Anthropic auth, Hermes prefers Claude Code's own credential files whe
 | `PARALLEL_API_KEY` | AI-native web search ([parallel.ai](https://parallel.ai/)) |
 | `FIRECRAWL_API_KEY` | Web scraping and cloud browser ([firecrawl.dev](https://firecrawl.dev/)) |
 | `FIRECRAWL_API_URL` | Custom Firecrawl API endpoint for self-hosted instances (optional) |
-| `TAVILY_API_KEY` | Tavily API key for AI-native web search, extract, and crawl ([app.tavily.com](https://app.tavily.com/home)) |
+| `TAVILY_API_KEY` | Tavily API key for AI-native web search, extract, and crawl ([app.tavily.com](https://app.tavily.com/home)). Overridden by a non-empty `hermes auth add tavily` pool. |
 | `SEARXNG_URL` | SearXNG instance URL for free self-hosted web search — no API key required ([searxng.github.io](https://searxng.github.io/searxng/)) |
 | `TAVILY_BASE_URL` | Override the Tavily API endpoint. Useful for corporate proxies and self-hosted Tavily-compatible search backends. Same pattern as `GROQ_BASE_URL`. |
-| `EXA_API_KEY` | Exa API key for AI-native web search and contents ([exa.ai](https://exa.ai/)) |
+| `EXA_API_KEY` | Exa API key for AI-native web search and contents ([exa.ai](https://exa.ai/)). Overridden by a non-empty `hermes auth add exa` pool. |
 | `BRAVE_SEARCH_API_KEY` | Brave Search API subscription token for web search (free tier available) ([brave.com/search/api](https://brave.com/search/api/)) |
 | `BROWSERBASE_API_KEY` | Browser automation ([browserbase.com](https://browserbase.com/)) |
 | `BROWSERBASE_PROJECT_ID` | Browserbase project ID |

--- a/website/docs/user-guide/features/web-search.md
+++ b/website/docs/user-guide/features/web-search.md
@@ -262,6 +262,16 @@ TAVILY_API_KEY=tvly-your-key-here
 
 Get a key at [app.tavily.com](https://app.tavily.com/home). The free tier includes 1 000 searches/month.
 
+**Multi-key pool:** stack several free-tier keys (or mix free + paid) into a [credential pool](/docs/user-guide/features/credential-pools) for round-robin and automatic rotation:
+
+```bash
+hermes auth add tavily --api-key tvly-key-1
+hermes auth add tavily --api-key tvly-key-2
+hermes auth list tavily
+```
+
+When a pool is present it takes precedence over `TAVILY_API_KEY`. On HTTP 401/403/429 the provider marks the active key exhausted, rotates to the next entry, and retries the request once; env-var credentials skip the retry. `is_available` returns true if *either* the env var or a non-empty pool is set, so `hermes setup` will detect Tavily as soon as you've added at least one pool entry.
+
 ---
 
 ### Exa
@@ -274,6 +284,16 @@ EXA_API_KEY=your-exa-key-here
 ```
 
 Get a key at [exa.ai](https://exa.ai). The free tier includes 1 000 searches/month.
+
+**Multi-key pool:** same rotation model as Tavily — enroll multiple keys via [credential pools](/docs/user-guide/features/credential-pools) for round-robin and automatic rotation on auth failures:
+
+```bash
+hermes auth add exa --api-key exa-key-1
+hermes auth add exa --api-key exa-key-2
+hermes auth list exa
+```
+
+A non-empty pool wins over `EXA_API_KEY`. On 401/403/429 from the Exa SDK the provider rotates to the next pool entry, rebuilds the cached SDK client with the new key, and retries once before propagating the error. Status codes are extracted best-effort from SDK exception attributes (`status_code`, `status`, `http_status`, `code`, `response.status_code`) or, as a fallback, regex-matched in the exception message.
 
 ---
 


### PR DESCRIPTION
## What does this PR do?

Routes the **Tavily** and **Exa** search backends through `agent.credential_pool`, the same pool infrastructure LLM providers (Anthropic, Codex, Gemini, xAI OAuth, ...) use. Mirrors the *pool-first / env-fallback* shape from #26031 (which covered auxiliary LLM providers), and adds rotate-and-retry on 401/403/429 so multi-key failover works end-to-end.

Tavily and Exa were picked as the pilot because they exercise two structurally different integration shapes — raw `httpx.post(...)` and SDK with module-level cached client — so the pattern is validated against both before extending to Brave, Firecrawl, Parallel, Jina, xAI search in follow-up PRs.

## Related Issue

Fixes #29771

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

**Plugin layer**

- `plugins/web/tavily/provider.py` — `_tavily_request` resolves credentials via `load_pool("tavily").select()` first, falling back to `TAVILY_API_KEY`. On 401/403/429 calls `pool.mark_exhausted_and_rotate(status_code=...)` and retries once with the rotated entry inside the `httpx.HTTPStatusError` boundary. `is_available()` consults the pool when env is unset.
- `plugins/web/exa/provider.py` — pool-first resolution in `_get_exa_client`; new `_call_with_rotation()` wraps the SDK calls, invalidates the cached client at `tools.web_tools._exa_client`, and rebuilds with the rotated key on 401/403/429. Status is read from common SDK exception attributes (`status_code`, `status`, `response.status_code`) and falls back to regex on `str(exc)` for SDKs that only embed the code in the message.

**CLI layer**

- `hermes_cli/auth_commands.py` — adds `_WEB_POOL_PROVIDERS = {"tavily", "exa"}` so `hermes auth add|list` accept these provider names instead of erroring with `Unknown provider`. Wired into `auth_add_command`, `_interactive_add`, the `auth list` all-providers enumeration, and the interactive picker hint.

**Tests** (29 cases, all passing)

- `tests/tools/test_web_tools_tavily.py::TestTavilyCredentialPool` (6 cases): pool-over-env, env fallback, 429 rotation + retry, env-only no-rotation, 500 no-rotation, `is_available` via pool only.
- `tests/tools/test_web_tools_exa.py` (new, 8 cases): same coverage + cache invalidation on rotation + status extracted from SDK exception message regex.

**Docs**

- Tavily and Exa entries in the web-search feature doc + env-var reference updated to document the new multi-key pool behavior and pool-over-env precedence.

## How to Test

**Unit tests** (29 new, no regressions on touched modules):

\`\`\`bash
.venv/bin/python -m pytest tests/tools/test_web_tools_tavily.py \\
    tests/tools/test_web_tools_exa.py -v
\`\`\`

**Manual rotation with real keys** — seed an invalid + valid Tavily key, then drive a search and watch for rotation:

\`\`\`bash
hermes auth add tavily --type api_key --label bad  --api-key 'tvly-INVALID-XXXX'
hermes auth add tavily --type api_key --label good --api-key 'tvly-YOUR-REAL-KEY'

python -c \"
import logging
logging.basicConfig(level=logging.INFO, format='%(levelname)s %(name)s: %(message)s')
from tools.web_tools import _tavily_request
print(_tavily_request('search', {'query': 'python release notes', 'max_results': 1}))
\"
\`\`\`

Expected log:

\`\`\`
INFO plugins.web.tavily.provider: Tavily search request to ...
INFO plugins.web.tavily.provider: tavily: rotating credential after HTTP 401 and retrying
INFO plugins.web.tavily.provider: Tavily search request to ...
\`\`\`

Same recipe works for Exa (substitute `exa` / `EXA_API_KEY` / `exa-xxxx`).

**Round-robin between two valid keys**: set `credential_pool_strategies.tavily: round_robin` in `~/.hermes/config.yaml`; two consecutive `_tavily_request('search', ...)` calls alternate keys (visible per-key in the Tavily dashboard).

**No-key regression**: empty pool + no env — existing `ValueError(\"TAVILY_API_KEY environment variable not set...\")` fires with the unchanged setup-hint message.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`feat(web):`, `docs(web):`)
- [x] I searched for existing PRs (no open PR covers credential pools for search backends; closest prior art is #26031 for auxiliary LLM providers)
- [x] My PR contains **only** changes related to this feature
- [x] I've run `pytest tests/` — our 29 new tests pass; the 142 failing tests on full sweep are pre-existing on `main` (verified by spot-check)
- [x] I've added tests
- [x] I've tested on: macOS 15 (Apple Silicon, Python 3.13)

### Documentation & Housekeeping

- [x] Updated relevant documentation (`website/docs/user-guide/features/web.md`, `website/docs/reference/environment-variables.md`)
- [x] No new config keys — reuses existing `credential_pool_strategies.<provider>` plumbing
- [x] No architecture/workflow change
- [x] Cross-platform: no platform-specific code paths
- [x] Tool schemas unchanged

## Screenshots / Logs

See the **How to Test** section above for the expected rotation log line.