### PR TITLE
fix(gateway): align session store contract with DB-only reality and prevent silent transcript loss

### DIFF
--- a/gateway/session.py
+++ b/gateway/session.py
@@ -670,7 +670,8 @@ class SessionStore:
     Manages session storage and retrieval.
     
     Uses SQLite (via SessionDB) for session metadata and message transcripts.
-    Falls back to legacy JSONL files if SQLite is unavailable.
+    Session routing metadata still persists in sessions.json if SQLite is
+    unavailable, but transcript persistence is disabled until state.db opens.
     """
     
     def __init__(self, sessions_dir: Path, config: GatewayConfig,
@@ -681,14 +682,39 @@ class SessionStore:
         self._loaded = False
         self._lock = threading.Lock()
         self._has_active_processes_fn = has_active_processes_fn
+        self._session_db_unavailable_message: Optional[str] = None
+        self._transcript_db_warning_emitted = False
         
         # Initialize SQLite session database
         self._db = None
+        _hermes_state = None
         try:
-            from hermes_state import SessionDB
-            self._db = SessionDB()
+            import hermes_state as _hermes_state
+            self._db = _hermes_state.SessionDB()
         except Exception as e:
-            print(f"[gateway] Warning: SQLite session store unavailable, falling back to JSONL: {e}")
+            self._session_db_unavailable_message = (
+                _hermes_state.format_session_db_unavailable(
+                    prefix="SQLite session store not available"
+                )
+                if _hermes_state is not None
+                else f"SQLite session store not available: {e}."
+            )
+            logger.warning(
+                "%s Gateway session routing will continue via sessions.json, "
+                "but transcript persistence is disabled.",
+                self._session_db_unavailable_message,
+            )
+
+    def _warn_transcript_db_unavailable_once(self) -> None:
+        """Emit one warning when transcript reads/writes are disabled."""
+        if self._db or self._transcript_db_warning_emitted:
+            return
+        self._transcript_db_warning_emitted = True
+        logger.warning(
+            "%s Transcript reads/writes are disabled; conversation history "
+            "will not persist until state.db opens successfully.",
+            self._session_db_unavailable_message or "SQLite session store not available.",
+        )
     
     def _ensure_loaded(self) -> None:
         """Load sessions index from disk if not already loaded."""
@@ -1257,6 +1283,10 @@ class SessionStore:
                      _flush_messages_to_session_db(), preventing the
                      duplicate-write bug (#860).
         """
+        if not self._db:
+            if not skip_db:
+                self._warn_transcript_db_unavailable_once()
+            return
         if self._db and not skip_db:
             try:
                 self._db.append_message(
@@ -1287,6 +1317,9 @@ class SessionStore:
         Used by /retry, /undo, and /compress to persist modified conversation
         history. state.db is the canonical store.
         """
+        if not self._db:
+            self._warn_transcript_db_unavailable_once()
+            return
         if self._db:
             try:
                 self._db.replace_messages(session_id, messages)
@@ -1301,6 +1334,7 @@ class SessionStore:
         migrated (their DB row holds the full message history).
         """
         if not self._db:
+            self._warn_transcript_db_unavailable_once()
             return []
         try:
             return self._db.get_messages_as_conversation(session_id)

--- a/tests/gateway/test_session.py
+++ b/tests/gateway/test_session.py
@@ -1,5 +1,6 @@
 """Tests for gateway session management."""
 import json
+import logging
 import pytest
 from pathlib import Path
 from unittest.mock import patch, MagicMock
@@ -570,6 +571,36 @@ class TestLoadTranscriptDBOnly:
         assert len(result) == 2
         assert result[0]["content"] == "db-q"
         assert result[1]["content"] == "db-a"
+
+    def test_init_warning_does_not_claim_jsonl_fallback(self, tmp_path, caplog):
+        config = GatewayConfig()
+        with caplog.at_level(logging.WARNING, logger="gateway.session"):
+            with patch("hermes_state.SessionDB", side_effect=Exception("DB unavailable")):
+                SessionStore(sessions_dir=tmp_path, config=config)
+
+        messages = [r.getMessage() for r in caplog.records]
+        assert any("transcript persistence is disabled" in msg for msg in messages)
+        assert all("falling back to JSONL" not in msg for msg in messages)
+
+    def test_transcript_db_unavailable_warns_once(self, tmp_path, caplog):
+        config = GatewayConfig()
+        with patch("gateway.session.SessionStore._ensure_loaded"):
+            store = SessionStore(sessions_dir=tmp_path, config=config)
+        store._loaded = True
+        store._db = None
+        store._session_db_unavailable_message = "SQLite session store not available: DB unavailable."
+        store._transcript_db_warning_emitted = False
+
+        with caplog.at_level(logging.WARNING, logger="gateway.session"):
+            assert store.load_transcript("missing") == []
+            store.append_to_transcript("missing", {"role": "user", "content": "hi"})
+            store.rewrite_transcript("missing", [])
+
+        warnings = [
+            r.getMessage() for r in caplog.records
+            if "Transcript reads/writes are disabled" in r.getMessage()
+        ]
+        assert len(warnings) == 1
 
 
 class TestSessionStoreSwitchSession:


### PR DESCRIPTION
## Summary

This PR fixes a misleading degraded-path behavior in gateway session persistence.

Recent refactors made `state.db` the canonical transcript store and intentionally removed the legacy JSONL transcript fallback. However, the gateway session store still reported that it would "fall back to JSONL" when SQLite initialization failed. In practice, session routing continued, but transcript reads and writes became silent no-ops, which could lead to unnoticed conversation-history loss.

This change brings the behavior, logging, and tests back into alignment with the current DB-only design:
- removes the stale "falling back to JSONL" claim
- makes the degraded mode explicit in warnings
- surfaces transcript persistence loss clearly instead of failing silently
- adds regression coverage so this contract does not drift again

## Related Issue

Fixes #

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Tests (adding or improving test coverage)

## What Changed

- Updated the gateway session-store messaging to reflect the real persistence model.
- Replaced the misleading fallback warning with a warning that accurately explains that session routing can continue while transcript persistence is unavailable.
- Added a one-time warning for transcript read/write operations when the session database is unavailable, preventing silent no-op behavior from going unnoticed.
- Added regression tests covering:
  - the initialization warning text for the DB-unavailable path
  - one-time warning behavior for transcript operations without an available session DB

## Why This Approach

Reintroducing the removed JSONL transcript fallback would conflict with the current persistence model and recent cleanup work that made `state.db` the single source of truth. The higher-confidence fix is to make the degraded behavior explicit, observable, and tested.

This keeps normal behavior unchanged while improving robustness and debuggability when SQLite is unavailable.

## How to Test

1. Run the targeted gateway session tests:

   scripts/run_tests.sh tests/gateway/test_session.py -q
   
2. Run adjacent transcript-path regressions:

scripts/run_tests.sh tests/gateway/test_load_transcript_db_only.py tests/gateway/test_retry_replacement.py -q   