### PR TITLE
fix(achievements): stabilize share dialog hover state

### DIFF
--- a/plugins/hermes-achievements/dashboard/dist/index.js
+++ b/plugins/hermes-achievements/dashboard/dist/index.js
@@ -521,7 +521,7 @@
       ? tx(t, "progress.hidden", "hidden")
       : (progress + (achievement.next_threshold ? " / " + achievement.next_threshold : ""));
     const [shareOpen, setShareOpen] = hooks.useState(false);
-    return React.createElement(C.Card, { className: cn("ha-card", "ha-state-" + state, tierClass(achievement.tier || achievement.next_tier)) },
+    return React.createElement(C.Card, { className: cn("ha-card", "ha-state-" + state, tierClass(achievement.tier || achievement.next_tier), shareOpen && "ha-card-share-open") },
       React.createElement(C.CardContent, { className: "ha-card-content" },
         React.createElement("div", { className: "ha-card-head" },
           React.createElement("div", { className: "ha-icon" }, React.createElement(AchievementIcon, { icon: achievement.icon || "secret" })),

--- a/plugins/hermes-achievements/dashboard/dist/style.css
+++ b/plugins/hermes-achievements/dashboard/dist/style.css
@@ -22,6 +22,7 @@
 .ha-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(320px, 1fr)); gap: .9rem; }
 .ha-card { --ha-tier: var(--color-border); position: relative; overflow: hidden; min-height: 214px; border: 1px solid color-mix(in srgb, var(--ha-tier) 46%, var(--color-border)); background: radial-gradient(circle at 2.6rem 2.2rem, color-mix(in srgb, var(--ha-tier) 16%, transparent), transparent 34%), linear-gradient(180deg, rgba(255,255,255,.04), transparent), color-mix(in srgb, var(--color-card) 92%, #000); transition: transform .16s ease, border-color .16s ease, opacity .16s ease, box-shadow .16s ease; }
 .ha-card:hover { transform: translateY(-2px); border-color: var(--ha-tier); box-shadow: 0 0 0 1px color-mix(in srgb, var(--ha-tier) 16%, transparent); }
+.ha-card.ha-card-share-open, .ha-card.ha-card-share-open:hover { transform: none; }
 .ha-card-content { position: relative; z-index: 1; padding: 1rem !important; display: flex; flex-direction: column; gap: .75rem; height: 100%; }
 .ha-card-head { display: grid; grid-template-columns: 3.1rem minmax(0, 1fr) auto; gap: .85rem; align-items: start; }
 .ha-icon { display: grid; place-items: center; width: 2.9rem; height: 2.9rem; color: var(--ha-tier); }

--- a/plugins/hermes-achievements/tests/test_achievement_engine.py
+++ b/plugins/hermes-achievements/tests/test_achievement_engine.py
@@ -151,6 +151,17 @@ class AchievementEngineTests(unittest.TestCase):
         stats = plugin_api.analyze_messages("s2", "Real config", [{"content": "edited config.yaml, manifest.json, and .env.local"}])
         self.assertGreaterEqual(stats["config_events"], 3)
 
+    def test_share_dialog_open_state_disables_card_hover_transform(self):
+        dist_dir = Path(__file__).resolve().parents[1] / "dashboard" / "dist"
+        index_js = (dist_dir / "index.js").read_text(encoding="utf-8")
+        style_css = (dist_dir / "style.css").read_text(encoding="utf-8")
+
+        self.assertIn('shareOpen && "ha-card-share-open"', index_js)
+        self.assertIn(
+            ".ha-card.ha-card-share-open, .ha-card.ha-card-share-open:hover { transform: none; }",
+            style_css,
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- Add a `share-open` class to achievement cards while the share dialog is open
- Disable the achievement card hover transform only while that share dialog state is active
- Add a regression test asserting the dashboard bundle and CSS contain the stabilization hooks

Fixes #29380

## Why
The share dialog is rendered from inside an achievement card. The card hover rule applies a transform, and CSS transforms create containing blocks for fixed-position descendants. When the share dialog opens while the card remains hovered, the card transform can interact with the fixed dialog and create the flickering behavior reported in #29380. Keeping normal hover behavior but suppressing that transform while the share dialog is open avoids the feedback loop.

## Test plan
- `scripts/run_tests.sh plugins/hermes-achievements/tests/test_achievement_engine.py -v --tb=short` — blocked before collection in this local worktree because the wrapper injects unsupported pytest timeout arguments in this environment: `--timeout=30 --timeout-method=signal`
- `python3 -m pytest plugins/hermes-achievements/tests/test_achievement_engine.py -v -o 'addopts=' --tb=short` — 11 passed in 2.01s
- `python3 -m py_compile plugins/hermes-achievements/tests/test_achievement_engine.py` — passed
- `git diff --check` — passed
