### PR TITLE
fix(langfuse): differentiate ACP-mode trace keys by thread ID

### DIFF
--- a/plugins/observability/langfuse/__init__.py
+++ b/plugins/observability/langfuse/__init__.py
@@ -221,6 +221,10 @@ def _get_langfuse() -> Optional[Langfuse]:
 
 def _trace_key(task_id: str, session_id: str) -> str:
     if task_id:
+        # In ACP mode, task_id == session_id, so all turns on the same thread
+        # get the same key and traces collapse. Differentiate by thread ID.
+        if task_id == session_id:
+            return f"acp:{threading.get_ident()}"
         return task_id
     if session_id:
         return f"session:{session_id}"


### PR DESCRIPTION
## Problem

ACP mode passes `task_id=session_id` to `run_conversation()`, causing `_trace_key()` to return the same key for every turn. Since ACP uses a fixed thread pool, all turns on the same thread collide and produce only 1 trace in Langfuse regardless of how many rounds you chat.

## Root Cause

`plugins/observability/langfuse/__init__.py` — `_trace_key()`:
```python
def _trace_key(task_id: str, session_id: str) -> str:
    if task_id:
        return task_id  # ← In ACP mode this is always session_id
    ...
```

And `acp_adapter/server.py:1459` passes `task_id=session_id`, so every turn on the same thread gets the identical key.

## Fix

When `task_id == session_id` (ACP mode), include the thread ID in the key so each turn on each thread gets a unique trace ID:

```python
if task_id == session_id:
    return f"acp:{threading.get_ident()}"
```

This preserves the existing non-ACP behavior (where `task_id` differs from `session_id` in normal CLI/TUI usage).

Fixes #29776.