### PR TITLE
chore(run_agent): remove four unused stdlib imports

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -33,8 +33,6 @@ except ModuleNotFoundError:
 
 import asyncio
 import base64
-import concurrent.futures
-import contextvars
 import copy
 import hashlib
 import json
@@ -43,13 +41,11 @@ logger = logging.getLogger(__name__)
 import os
 import random
 import re
-import ssl
 import sys
 import tempfile
 import time
 import threading
 from types import SimpleNamespace
-import urllib.request
 import uuid
 from typing import List, Dict, Any, Optional
 from urllib.parse import urlparse, parse_qs, urlunparse


### PR DESCRIPTION
    Summary

    Remove four unused stdlib imports from run_agent.py:
    - concurrent.futures — moved to agent/tool_executor.py (refactor 7955921)
    - contextvars — moved to agent/tool_executor.py (PR #18123)
    - ssl — moved to agent/conversation_loop.py (PR #14367)
    - urllib.request — moved to proxy module (refactor 5f309ae)

    These were left behind when the code that used them was extracted into separate modules during earlier refactors. Each target module already has its own import.

    Verification

    - grep -n 'concurrent\.futures\.\|contextvars\.\|ssl\.\|urllib\.request' run_agent.py returns only the removed import lines
    - grep -rn 'run_agent\.\(concurrent\|contextvars\|ssl\|urllib\)' --include="*.py" returns no results (no external code accesses these via run_agent's namespace)
    - No globals()/exec()/eval() usage in run_agent.py that could dynamically reference these names