### PR TITLE
fix(gateway): exempt slash commands from weixin content-fingerprint dedup (#29779)

### DIFF
--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -1388,10 +1388,13 @@ class WeixinAdapter(BasePlatformAdapter):
         if message_id and self._dedup.is_duplicate(message_id):
             return
 
-        # Secondary content-fingerprint dedup for text messages
+        # Secondary content-fingerprint dedup for text messages.
+        # Slash commands are exempt: users intentionally re-issue them
+        # (e.g. /approve once per pending approval) and the 5-minute TTL
+        # would otherwise silently drop every repeat (#29779).
         item_list = message.get("item_list") or []
         text = _extract_text(item_list)
-        if text:
+        if text and not text.lstrip().startswith("/"):
             content_key = f"content:{sender_id}:{hashlib.md5(text.encode()).hexdigest()}"
             if self._dedup.is_duplicate(content_key):
                 logger.debug("[%s] Content-dedup: skipping duplicate message from %s", self.name, sender_id)

--- a/tests/gateway/test_weixin.py
+++ b/tests/gateway/test_weixin.py
@@ -883,3 +883,41 @@ class TestWeixinContentDedup:
         assert adapter.handle_message.await_count == 0
         # is_duplicate should only be called for message_id, never for content
         assert all("content:" not in str(call) for call in adapter._dedup.is_duplicate.call_args_list)
+
+    def test_repeated_slash_command_is_not_dropped_by_content_dedup(self):
+        """Regression for #29779 — `/approve` and other slash commands must
+        bypass content-fingerprint dedup; users re-issue them intentionally
+        (once per pending approval) and the 5-min TTL would otherwise drop
+        every repeat after the first.
+        """
+        adapter = _make_adapter()
+        adapter._poll_session = object()
+        adapter.handle_message = AsyncMock()
+
+        base_msg = {
+            "from_user_id": "wxid_user1",
+            "item_list": [{"type": 1, "text_item": {"text": "/approve"}}],
+        }
+
+        asyncio.run(adapter._process_message({**base_msg, "message_id": "msg-1"}))
+        asyncio.run(adapter._process_message({**base_msg, "message_id": "msg-2"}))
+        asyncio.run(adapter._process_message({**base_msg, "message_id": "msg-3"}))
+
+        assert adapter.handle_message.await_count == 3
+
+    def test_slash_command_with_leading_whitespace_is_not_dropped(self):
+        """Slash detection tolerates leading whitespace from clients that
+        trim differently."""
+        adapter = _make_adapter()
+        adapter._poll_session = object()
+        adapter.handle_message = AsyncMock()
+
+        base_msg = {
+            "from_user_id": "wxid_user1",
+            "item_list": [{"type": 1, "text_item": {"text": "  /approve"}}],
+        }
+
+        asyncio.run(adapter._process_message({**base_msg, "message_id": "msg-1"}))
+        asyncio.run(adapter._process_message({**base_msg, "message_id": "msg-2"}))
+
+        assert adapter.handle_message.await_count == 2


### PR DESCRIPTION
## What does this PR do?

The weixin adapter runs a secondary **content-fingerprint dedup** layer
(`gateway/platforms/weixin.py:1391-1398`, added in PR #16646 / issue
#16182 to catch iLink Bot redeliveries that share text but use fresh
`message_id`s). It silently drops any text message with an identical
md5 from the same sender inside the 5-minute TTL.

That same path silently drops intentional re-issues of slash commands.
The motivating case in the issue is `/approve`: a session with multiple
pending tool calls needs one `/approve` per pending call, but only the
first lands — every subsequent `/approve` from the same sender is
dropped at this gate (debug-level log, no warning). Same shape for
`/restart-sglang` and other operator commands.

Fix: skip the content-fingerprint layer when the text starts with `/`
(after `.lstrip()`, so clients that don't trim identically still match).
The `message_id` dedup above still catches genuine network-layer retries,
and the original #16182 protection still applies to all free-form text
— the existing `test_duplicate_content_with_different_message_ids_is_dropped`
regression test continues to pass unchanged.

## Related Issue

Fixes #29779

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/platforms/weixin.py` — guard the content-fingerprint dedup with
  `not text.lstrip().startswith(\"/\")` so slash commands bypass it.
- `tests/gateway/test_weixin.py` — add two regression tests in
  `TestWeixinContentDedup`:
  - `test_repeated_slash_command_is_not_dropped_by_content_dedup` —
    three identical `/approve` messages with distinct `message_id`s
    must all reach `handle_message`.
  - `test_slash_command_with_leading_whitespace_is_not_dropped` —
    `\"  /approve\"` is still treated as a slash command.

## How to Test

```bash
uv run --with pytest --with pytest-xdist --with pytest-asyncio --with pytest-timeout --with aiohttp python3 -m pytest tests/gateway/test_weixin.py -v
```

Expect 56 passed, including the pre-existing
`test_duplicate_content_with_different_message_ids_is_dropped`
(non-slash duplicates are still deduped) and the two new
slash-command cases.

Manual regression guard: temporarily reverting the production guard
back to `if text:` causes both new tests to fail with
`assert <count> == 2|3` while the existing #16182 test still passes —
confirming the slash exemption is the only behavioral change.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run focused tests for the touched code and all pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.x

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A (internal helper, behavior change is documented in code comment + tests)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no config surface)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A (pure-Python, no path/IO involved)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Related / Positioning

PR #16646 (still open, by @prasadus92) is the *parent* of this code:
it added the content-fingerprint dedup to fix #16182 (iLink redeliveries
with mutated `message_id`s). That fix is preserved unchanged for
free-form text. This PR only narrows the exemption to slash commands —
the class of messages that users intentionally re-issue.

The issue lists three remediation options:

- Option A (remove the dedup entirely) would re-open #16182 for plain
  text, so rejected.
- Option B (warn-level log) doesn't fix the broken workflow, only
  makes it visible — rejected as the primary remedy.
- Option C (exempt slash commands) — this PR. It's the minimal fix
  that unblocks `/approve` while keeping the iLink protection intact.

> Audited siblings: confirmed only `gateway/platforms/weixin.py` runs
> this secondary content-fingerprint layer. `discord`, `slack`,
> `dingtalk`, `wecom`, `mattermost`, `feishu` all use the shared
> `MessageDeduplicator` for `message_id` dedup only — no widening
> needed.