### PR TITLE
fix(aux): support google gemini cli oauth routing

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -221,6 +221,17 @@ def _fixed_temperature_for_model(
         return OMIT_TEMPERATURE
     if _is_arcee_trinity_thinking(model):
         return 0.5
+
+    bare = (model or "").strip().lower().rsplit("/", 1)[-1]
+    host = base_url_hostname(base_url or "")
+    if bare.startswith("gpt-5") and (
+        host == "api.openai.com"
+        or host == "chatgpt.com"
+        or host.endswith("chatgpt.com")
+    ):
+        logger.debug("Omitting temperature for GPT-5-family model %r", model)
+        return OMIT_TEMPERATURE
+
     return None
 
 
@@ -649,6 +660,15 @@ class _CodexCompletionsAdapter:
             if role == "system":
                 instructions = content if isinstance(content, str) else str(content)
             else:
+                if role == "tool":
+                    tool_name = msg.get("name") or msg.get("tool_call_id") or "tool"
+                    role = "user"
+                    if isinstance(content, str):
+                        content = f"[Tool result: {tool_name}]\n{content}"
+                    else:
+                        content = f"[Tool result: {tool_name}]\n{content!s}"
+                elif role not in {"assistant", "user", "developer"}:
+                    role = "user"
                 input_msgs.append({
                     "role": role,
                     "content": _convert_content_for_responses(content),
@@ -3060,8 +3080,24 @@ def _normalize_resolved_model(model_name: Optional[str], provider: str) -> Optio
     try:
         from hermes_cli.model_normalize import normalize_model_for_provider
 
-        return normalize_model_for_provider(model_name, provider)
+        normalized = normalize_model_for_provider(model_name, provider)
+        if provider == "google-gemini-cli":
+            cloudcode_aliases = {
+                "gemini-3-flash": "gemini-3-flash-preview",
+                "google/gemini-3-flash": "gemini-3-flash-preview",
+                "gemini-3-pro": "gemini-3.1-pro-preview",
+                "google/gemini-3-pro": "gemini-3.1-pro-preview",
+            }
+            return cloudcode_aliases.get(normalized, cloudcode_aliases.get(model_name, normalized))
+        return normalized
     except Exception:
+        if provider == "google-gemini-cli":
+            return {
+                "gemini-3-flash": "gemini-3-flash-preview",
+                "google/gemini-3-flash": "gemini-3-flash-preview",
+                "gemini-3-pro": "gemini-3.1-pro-preview",
+                "google/gemini-3-pro": "gemini-3.1-pro-preview",
+            }.get(model_name, model_name)
         return model_name
 
 
@@ -3668,6 +3704,28 @@ def resolve_provider_client(
             return resolve_provider_client("openai-codex", model, async_mode)
         if provider == "xai-oauth":
             return resolve_provider_client("xai-oauth", model, async_mode)
+        if provider == "google-gemini-cli":
+            try:
+                from agent import google_oauth
+                from agent.gemini_cloudcode_adapter import GeminiCloudCodeClient
+            except ImportError as exc:
+                logger.warning(
+                    "resolve_provider_client: google-gemini-cli requested but "
+                    "Gemini Cloud Code adapter is unavailable: %s", exc)
+                return None, None
+            if google_oauth.load_credentials() is None:
+                logger.warning(
+                    "resolve_provider_client: google-gemini-cli requested but "
+                    "Google OAuth credentials were not found (run: hermes login --provider google-gemini-cli)")
+                return None, None
+            final_model = _normalize_resolved_model(
+                model or _get_aux_model_for_provider(provider) or "gemini-3-flash",
+                provider,
+            )
+            client = GeminiCloudCodeClient()
+            logger.debug("resolve_provider_client: %s (%s)", provider, final_model)
+            return (_to_async_client(client, final_model, is_vision=is_vision) if async_mode
+                    else (client, final_model))
         # Other OAuth providers not directly supported
         logger.warning("resolve_provider_client: OAuth provider %s not "
                        "directly supported, try 'auto'", provider)
@@ -4174,14 +4232,27 @@ def _cached_client_accepts_slash_models(client: Any, cached_default: Optional[st
     return bool(cached_default and "/" in cached_default)
 
 
-def _compat_model(client: Any, model: Optional[str], cached_default: Optional[str]) -> Optional[str]:
-    """Keep slash-bearing model IDs only for cached clients that support them.
+def _compat_model(
+    client: Any,
+    model: Optional[str],
+    cached_default: Optional[str],
+    provider: Optional[str] = None,
+) -> Optional[str]:
+    """Return a provider-compatible model for cached clients.
 
-    Mirrors the guard in resolve_provider_client() which is skipped on cache hits.
+    Mirrors the guard in resolve_provider_client() which is skipped on cache
+    hits.  Also re-applies provider-specific model normalization on cache hits
+    and first-store returns: _get_cached_client() intentionally keys the cache by
+    provider credentials, not model, so a requested alias such as
+    ``gemini-3-flash`` must still be normalized to the Code Assist-available
+    ``gemini-3-flash-preview`` before the request is sent.
     """
-    if model and "/" in model and not _cached_client_accepts_slash_models(client, cached_default):
+    effective = model
+    if effective and provider:
+        effective = _normalize_resolved_model(effective, provider)
+    if effective and "/" in effective and not _cached_client_accepts_slash_models(client, cached_default):
         return cached_default
-    return model or cached_default
+    return effective or cached_default
 
 
 def _get_cached_client(
@@ -4244,13 +4315,13 @@ def _get_cached_client(
                     and not cached_loop.is_closed()
                 )
                 if loop_ok:
-                    effective = _compat_model(cached_client, model, cached_default)
+                    effective = _compat_model(cached_client, model, cached_default, provider)
                     return cached_client, effective
                 # Stale — evict and fall through to create a new client.
                 _force_close_async_httpx(cached_client)
                 del _client_cache[cache_key]
             else:
-                effective = _compat_model(cached_client, model, cached_default)
+                effective = _compat_model(cached_client, model, cached_default, provider)
                 return cached_client, effective
     # Build outside the lock
     client, default_model = resolve_provider_client(
@@ -4278,7 +4349,7 @@ def _get_cached_client(
                 _client_cache[cache_key] = (client, default_model, bound_loop)
             else:
                 client, default_model, _ = _client_cache[cache_key]
-    return client, model or default_model
+    return client, _compat_model(client, model, default_model, provider)
 
 
 def _resolve_task_provider_model(

--- a/agent/google_oauth.py
+++ b/agent/google_oauth.py
@@ -465,23 +465,125 @@ class GoogleCredentials:
 # Credential I/O (atomic + locked)
 # =============================================================================
 
+def _load_credentials_from_auth_pool() -> Optional[GoogleCredentials]:
+    """Load google-gemini-cli OAuth creds from the unified auth.json credential pool."""
+    auth_path = get_hermes_home() / "auth.json"
+    if not auth_path.exists():
+        return None
+    try:
+        data = json.loads(auth_path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError, IOError) as exc:
+        logger.warning("Failed to read Hermes auth store at %s: %s", auth_path, exc)
+        return None
+    pool = data.get("credential_pool", {}) if isinstance(data, dict) else {}
+    entries = pool.get("google-gemini-cli", []) if isinstance(pool, dict) else []
+    if not isinstance(entries, list):
+        return None
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        access_token = str(entry.get("access_token", "") or "")
+        refresh_token = str(entry.get("refresh_token", "") or "")
+        if not access_token and not refresh_token:
+            continue
+        expires_ms = 0
+        for key in ("expires_ms", "expires_at_ms"):
+            try:
+                expires_ms = int(entry.get(key, 0) or 0)
+                if expires_ms:
+                    break
+            except (TypeError, ValueError):
+                pass
+        if access_token and not refresh_token and not expires_ms:
+            # Some credential-pool migrations stored a live subscription access
+            # token without refresh metadata. Treat it as short-lived instead of
+            # forcing an immediate refresh that cannot succeed.
+            expires_ms = int((time.time() + 3600) * 1000)
+        return GoogleCredentials(
+            access_token=access_token,
+            refresh_token=refresh_token,
+            expires_ms=expires_ms,
+            email=str(entry.get("email", "") or ""),
+            project_id=str(entry.get("project_id", "") or ""),
+            managed_project_id=str(entry.get("managed_project_id", "") or ""),
+        )
+    return None
+
+
+def _candidate_gemini_cli_dirs() -> List[Path]:
+    """Candidate .gemini dirs, including profile HOME and the real user home outside profiles."""
+    candidates = [Path.home() / ".gemini"]
+    hermes_home = get_hermes_home()
+    parts = hermes_home.parts
+    if ".hermes" in parts:
+        idx = parts.index(".hermes")
+        if idx > 0:
+            candidates.append(Path(*parts[:idx]) / ".gemini")
+    seen: set[Path] = set()
+    ordered: List[Path] = []
+    for path in candidates:
+        if path not in seen:
+            seen.add(path)
+            ordered.append(path)
+    return ordered
+
+
+def _load_credentials_from_gemini_cli() -> Optional[GoogleCredentials]:
+    """Load OAuth credentials written by the upstream Gemini CLI subscription flow."""
+    for gemini_dir in _candidate_gemini_cli_dirs():
+        path = gemini_dir / "oauth_creds.json"
+        if not path.exists():
+            continue
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError, IOError) as exc:
+            logger.warning("Failed to read Gemini CLI OAuth credentials at %s: %s", path, exc)
+            continue
+        if not isinstance(data, dict):
+            continue
+        access_token = str(data.get("access_token", "") or "")
+        refresh_token = str(data.get("refresh_token", "") or "")
+        if not access_token and not refresh_token:
+            continue
+        try:
+            expires_ms = int(data.get("expiry_date", 0) or 0)
+        except (TypeError, ValueError):
+            expires_ms = 0
+        email = ""
+        accounts_path = gemini_dir / "google_accounts.json"
+        if accounts_path.exists():
+            try:
+                accounts = json.loads(accounts_path.read_text(encoding="utf-8"))
+                if isinstance(accounts, dict):
+                    email = str(accounts.get("active", "") or "")
+            except (json.JSONDecodeError, OSError, IOError):
+                pass
+        return GoogleCredentials(
+            access_token=access_token,
+            refresh_token=refresh_token,
+            expires_ms=expires_ms,
+            email=email,
+        )
+    return None
+
+
 def load_credentials() -> Optional[GoogleCredentials]:
-    """Load credentials from disk. Returns None if missing or corrupt."""
+    """Load credentials from disk, auth pool, or Gemini CLI. Returns None if missing/corrupt."""
     path = _credentials_path()
     if not path.exists():
-        return None
+        return _load_credentials_from_gemini_cli() or _load_credentials_from_auth_pool()
     try:
         with _credentials_lock():
             raw = path.read_text(encoding="utf-8")
         data = json.loads(raw)
     except (json.JSONDecodeError, OSError, IOError) as exc:
         logger.warning("Failed to read Google OAuth credentials at %s: %s", path, exc)
-        return None
+        return _load_credentials_from_auth_pool() or _load_credentials_from_gemini_cli()
     if not isinstance(data, dict):
-        return None
+        return _load_credentials_from_auth_pool() or _load_credentials_from_gemini_cli()
     creds = GoogleCredentials.from_dict(data)
     if not creds.access_token:
-        return None
+        return _load_credentials_from_auth_pool() or _load_credentials_from_gemini_cli()
     return creds
 
 

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -651,6 +651,111 @@ class TestExplicitProviderRouting:
             for record in caplog.records
         )
 
+    def test_explicit_google_gemini_cli_uses_oauth_subscription_not_api_key(self, tmp_path, monkeypatch):
+        """google-gemini-cli is OAuth-backed; auxiliary routing must use the subscription pool, not env keys."""
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir(parents=True)
+        (hermes_home / "auth.json").write_text(json.dumps({
+            "version": 1,
+            "credential_pool": {
+                "google-gemini-cli": [{
+                    "label": "Subscription",
+                    "auth_type": "oauth",
+                    "access_token": "google-access-token",
+                    "refresh_token": "",
+                    "source": "manual:google_pkce",
+                }]
+            },
+        }))
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        profile_home = tmp_path / "home"
+        profile_home.mkdir()
+        monkeypatch.setenv("HOME", str(profile_home))
+
+        from agent.google_oauth import load_credentials
+        creds = load_credentials()
+        assert creds is not None
+        assert not creds.access_token_expired()
+
+        client, model = resolve_provider_client("google-gemini-cli", model="gemini-3-flash")
+
+        assert client is not None
+        assert client.__class__.__name__ == "GeminiCloudCodeClient"
+        assert model == "gemini-3-flash-preview"
+
+    def test_cached_google_gemini_cli_normalizes_model_alias(self, monkeypatch):
+        """Cache hits must not reintroduce retired Code Assist aliases."""
+        import agent.auxiliary_client as aux
+
+        fake_client = SimpleNamespace(base_url="")
+        aux.shutdown_cached_clients()
+        monkeypatch.setattr(
+            aux,
+            "resolve_provider_client",
+            lambda provider, model=None, async_mode=False, **kwargs: (
+                fake_client,
+                "gemini-3-flash-preview",
+            ),
+        )
+
+        try:
+            first_client, first_model = aux._get_cached_client(
+                "google-gemini-cli", "gemini-3-flash"
+            )
+            second_client, second_model = aux._get_cached_client(
+                "google-gemini-cli", "gemini-3-flash"
+            )
+        finally:
+            aux.shutdown_cached_clients()
+
+        assert first_client is fake_client
+        assert second_client is fake_client
+        assert first_model == "gemini-3-flash-preview"
+        assert second_model == "gemini-3-flash-preview"
+
+class TestCodexCompletionsAdapter:
+    def test_converts_tool_messages_to_supported_responses_roles(self):
+        """Responses API rejects chat-completions role='tool'.
+
+        The Codex auxiliary adapter should preserve tool output as user-context
+        text instead of forwarding an unsupported role.
+        """
+        captured = {}
+
+        class _FakeStream:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def __iter__(self):
+                return iter(())
+
+            def get_final_response(self):
+                return SimpleNamespace(output=[], usage=None)
+
+        class _FakeResponses:
+            def stream(self, **kwargs):
+                captured.update(kwargs)
+                return _FakeStream()
+
+        fake_client = SimpleNamespace(responses=_FakeResponses())
+        adapter = _CodexCompletionsAdapter(fake_client, "gpt-5.2-codex")
+
+        adapter.create(messages=[
+            {"role": "system", "content": "sys"},
+            {"role": "assistant", "content": "I will inspect files."},
+            {"role": "tool", "tool_call_id": "call_1", "name": "read_file", "content": "file contents"},
+            {"role": "user", "content": "continue"},
+        ])
+
+        roles = [msg["role"] for msg in captured["input"]]
+        assert roles == ["assistant", "user", "user"]
+        assert all(role in {"assistant", "user", "system", "developer"} for role in roles)
+        assert captured["input"][1]["content"] == "[Tool result: read_file]\nfile contents"
+
+
 class TestGetTextAuxiliaryClient:
     """Test the full resolution chain for get_text_auxiliary_client."""
 
@@ -1524,6 +1629,42 @@ class TestKimiTemperatureOmitted:
             model=model,
             messages=[{"role": "user", "content": "hello"}],
             temperature=0.3,
+        )
+
+        assert kwargs["temperature"] == 0.3
+
+    @pytest.mark.parametrize(
+        "model,base_url",
+        [
+            ("gpt-5.5", "https://chatgpt.com/backend-api/codex"),
+            ("gpt-5.2-codex", "https://chatgpt.com/backend-api/codex"),
+            ("openai/gpt-5.5", "https://api.openai.com/v1"),
+        ],
+    )
+    def test_direct_openai_gpt5_omits_temperature(self, model, base_url):
+        """GPT-5-family direct OpenAI/Codex endpoints reject temperature."""
+        from agent.auxiliary_client import _build_call_kwargs
+
+        kwargs = _build_call_kwargs(
+            provider="openai-codex",
+            model=model,
+            messages=[{"role": "user", "content": "hello"}],
+            temperature=0.3,
+            base_url=base_url,
+        )
+
+        assert "temperature" not in kwargs
+
+    def test_openrouter_gpt5_preserves_temperature(self):
+        """OpenRouter handles sampling params; only direct OpenAI/Codex strips them."""
+        from agent.auxiliary_client import _build_call_kwargs
+
+        kwargs = _build_call_kwargs(
+            provider="openrouter",
+            model="openai/gpt-5.5",
+            messages=[{"role": "user", "content": "hello"}],
+            temperature=0.3,
+            base_url="https://openrouter.ai/api/v1",
         )
 
         assert kwargs["temperature"] == 0.3


### PR DESCRIPTION
## Summary
- Route `google-gemini-cli` auxiliary provider through Google OAuth / Gemini Cloud Code instead of API-key env resolution.
- Load Google Gemini CLI credentials from Hermes credential pool and upstream Gemini CLI oauth files as fallbacks.
- Normalize retired Gemini Code Assist aliases on cache hits and provider resolution.
- Convert Codex Responses adapter tool-role messages into supported user-context messages.
- Omit temperature for direct OpenAI/Codex GPT-5-family endpoints while preserving OpenRouter behavior.

## Test Plan
- `python -m pytest tests/agent/test_auxiliary_client.py -o 'addopts=' -q` — 179 passed
- `python -m pytest tests/agent/test_gemini_cloudcode.py -o 'addopts=' -q` — 88 passed
- `python -m compileall -q agent/auxiliary_client.py agent/google_oauth.py tests/agent/test_auxiliary_client.py`
- `git diff --check`

Created via Composio GitHub tools from fork branch `BeliyDym:fix/google-gemini-cli-aux-oauth`.