### PR TITLE
fix(gateway): bind Telegram handoffs to DM topics

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4213,26 +4213,39 @@ class GatewayRunner:
             str(home.thread_id) if home.thread_id else None
         )
 
-        # Determine chat_type for the destination source. If we created a
-        # thread, key the session_key as a thread (build_session_key sets
-        # thread sessions to user-shared by default, which is what we
-        # want — the synthetic turn and any later real-user message both
-        # land on the same key without needing a user_id).
-        if new_thread_id:
+        # Determine chat_type/user_id for the destination source.
+        #
+        # Telegram private-chat DM topics are represented differently from
+        # group/forum threads by the inbound adapter. A handoff-created topic
+        # in a positive Telegram chat_id must therefore use the same DM-topic
+        # source shape as the user's next real message; otherwise the synthetic
+        # handoff turn binds a generic `thread` session key while real replies
+        # arrive on a `dm` session key.
+        home_chat_id = str(home.chat_id)
+        is_telegram_private_chat = False
+        if platform == Platform.TELEGRAM:
+            try:
+                is_telegram_private_chat = int(home_chat_id) > 0
+            except (TypeError, ValueError):
+                is_telegram_private_chat = False
+
+        if new_thread_id and not is_telegram_private_chat:
             dest_chat_type = "thread"
+            dest_user_id = "system:handoff"
         else:
-            # No thread — assume DM-style for the home channel. For
-            # group/channel home channels without thread support
-            # (Matrix/WhatsApp/Signal), the platform's own keying makes
-            # the synthetic turn shared anyway (single-DM platforms).
+            # No thread — assume DM-style for the home channel. For Telegram
+            # private-chat topics, use the real user id (same as chat_id) so
+            # topic-mode checks and binding persistence see the same identity as
+            # subsequent inbound user messages.
             dest_chat_type = "dm"
+            dest_user_id = home_chat_id if is_telegram_private_chat else "system:handoff"
 
         dest_source = SessionSource(
             platform=platform,
-            chat_id=str(home.chat_id),
+            chat_id=home_chat_id,
             chat_name=home.name,
             chat_type=dest_chat_type,
-            user_id="system:handoff",
+            user_id=dest_user_id,
             user_name="Handoff",
             thread_id=effective_thread_id,
         )

--- a/tests/gateway/test_telegram_topic_mode.py
+++ b/tests/gateway/test_telegram_topic_mode.py
@@ -11,7 +11,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from hermes_state import SessionDB
-from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.config import GatewayConfig, HomeChannel, Platform, PlatformConfig
 from gateway.platforms.base import MessageEvent
 from gateway.session import SessionEntry, SessionSource, build_session_key
 
@@ -711,6 +711,49 @@ async def test_first_message_inside_topic_records_topic_binding(tmp_path, monkey
     assert binding["session_key"] == build_session_key(_make_source(thread_id="17585"))
 
 
+
+
+@pytest.mark.asyncio
+async def test_handoff_to_telegram_dm_topic_uses_dm_lane_not_generic_thread(tmp_path):
+    """Handoff-created Telegram DM topics must use the real DM-topic lane.
+
+    A positive Telegram chat_id is a private chat. If handoff treats the new
+    topic as generic chat_type="thread" with user_id="system:handoff", the
+    synthetic turn lands under agent:...:thread:chat:topic while real user
+    replies arrive as chat_type="dm" with user_id=chat_id. Recovery then sees
+    the topic as unbound and can rewrite it to another recent topic.
+    """
+    session_db = SessionDB(db_path=tmp_path / "state.db")
+    session_db.enable_telegram_topic_mode(chat_id="208214988", user_id="208214988")
+    runner = _make_runner(session_db=session_db)
+    runner.config.platforms[Platform.TELEGRAM].home_channel = HomeChannel(
+        platform=Platform.TELEGRAM,
+        chat_id="208214988",
+        name="Tester DM",
+    )
+    adapter = runner.adapters[Platform.TELEGRAM]
+    adapter.create_handoff_thread = AsyncMock(return_value="17585")
+    adapter.send.return_value = SimpleNamespace(success=True)
+    captured = {}
+
+    async def fake_handle_message(event):
+        captured["source"] = event.source
+        return "handoff ok"
+
+    runner._handle_message = AsyncMock(side_effect=fake_handle_message)
+
+    await runner._process_handoff({
+        "id": "cli-session",
+        "title": "CLI work",
+        "handoff_platform": "telegram",
+    })
+
+    expected_source = _make_source(thread_id="17585")
+    expected_key = build_session_key(expected_source)
+    runner.session_store.switch_session.assert_called_once_with(expected_key, "cli-session")
+    assert captured["source"].chat_type == "dm"
+    assert captured["source"].user_id == "208214988"
+    assert captured["source"].thread_id == "17585"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Fixes Telegram private-chat topic handoffs so the synthetic handoff turn uses the same DM-topic session lane as the user's next real message.

When `/handoff telegram` creates a new topic in a Telegram private chat, the gateway previously built the destination source as a generic `chat_type="thread"` with `user_id="system:handoff"`. Real Telegram DM-topic messages later arrive as `chat_type="dm"`, `user_id=<chat_id>`, `thread_id=<topic id>`. That mismatch means the synthetic handoff turn is switched under a different session key from the follow-up user message, and no `telegram_dm_topic_bindings` row is recorded for the handoff topic.

If topic recovery is enabled and there are older bindings for that chat, the next user message in the handoff topic can then look like an unknown topic and be recovered into a different, recently-active topic. That causes cross-topic context bleed.

## Fix

For Telegram handoff-created topics in positive/private chat IDs:

- build the destination `SessionSource` as `chat_type="dm"`
- use `user_id=str(home.chat_id)` so topic-mode checks match inbound user messages
- keep `thread_id=<new topic id>`
- compute the destination session key from that DM-topic source

Non-private/group/forum-style destinations still use the existing generic `chat_type="thread"` behavior.

## Relationship to existing Telegram topic PRs

Related but distinct from:

- #26609 — introduced topic recovery for stripped/cross-topic replies
- #28605 / #29287 / #29546 — narrow or preserve recovery behavior for brand-new Telegram DM topics
- #28870 / #27239 — harden routing across session splits/compression

Those PRs address recovery behavior and brand-new topic creation. This PR addresses the handoff path specifically: handoff-created Telegram private-chat topics were seeded under the wrong source/session-key shape before any real user message arrived.

## Reproduction shape

1. Enable Telegram private-chat topic mode.
2. Have at least one existing bound topic/session in the same private chat.
3. Handoff a CLI session to Telegram, creating a fresh topic.
4. Send a real user message in the handoff topic.

Before this PR, the synthetic turn used a generic thread session key while the real user message used a DM-topic key. Recovery could route the real user message into a previous topic's session.

## Tests

```bash
scripts/run_tests.sh tests/gateway/test_telegram_topic_mode.py tests/gateway/test_telegram_thread_fallback.py
# 84 passed
```
