### PR TITLE
fix(streaming): kill infinite reasoning loops before HTTP timeout (#2…

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1263,6 +1263,17 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
     # poll loop uses this to detect stale connections that keep receiving
     # SSE keep-alive pings but no actual data.
     last_chunk_time = {"t": time.time()}
+    # Wall-clock timestamp of the last chunk that carried real output
+    # (content text or tool calls).  Unlike last_chunk_time, this is NOT
+    # reset by reasoning-only (reasoning_content / thinking) chunks.
+    # The outer poll loop uses it to detect models stuck in an infinite
+    # reasoning loop that never commit to a visible response (#29086).
+    last_content_chunk_time = {"t": time.time()}
+    # Becomes True once the model emits the first reasoning chunk.
+    # The reasoning-only stale check only activates after this is set so
+    # models that are simply slow to produce their first token are not
+    # affected — they fall under the normal _stream_stale_timeout guard.
+    reasoning_seen = {"yes": False}
 
     def _fire_first_delta():
         if not first_delta_fired["done"] and on_first_delta:
@@ -1317,9 +1328,11 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
             reason="chat_completion_stream_request",
             api_kwargs=stream_kwargs,
         )
-        # Reset stale-stream timer so the detector measures from this
+        # Reset stale-stream timers so the detectors measure from this
         # attempt's start, not a previous attempt's last chunk.
         last_chunk_time["t"] = time.time()
+        last_content_chunk_time["t"] = time.time()
+        reasoning_seen["yes"] = False
         agent._touch_activity("waiting for provider response (streaming)")
         # Initialize per-attempt stream diagnostics so the retry block can
         # reach for them after the stream dies.  Lives on
@@ -1395,11 +1408,13 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
             reasoning_text = getattr(delta, "reasoning_content", None) or getattr(delta, "reasoning", None)
             if reasoning_text:
                 reasoning_parts.append(reasoning_text)
+                reasoning_seen["yes"] = True  # model entered reasoning mode
                 _fire_first_delta()
                 agent._fire_reasoning_delta(reasoning_text)
 
             # Accumulate text content — fire callback only when no tool calls
             if delta and delta.content:
+                last_content_chunk_time["t"] = time.time()  # real output arrived
                 content_parts.append(delta.content)
                 if not tool_calls_acc:
                     _fire_first_delta()
@@ -1425,6 +1440,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
 
             # Accumulate tool call deltas — notify display on first name
             if delta and delta.tool_calls:
+                last_content_chunk_time["t"] = time.time()  # real output arrived
                 for tc_delta in delta.tool_calls:
                     raw_idx = tc_delta.index if tc_delta.index is not None else 0
                     delta_id = tc_delta.id or ""
@@ -1567,8 +1583,10 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
         """
         has_tool_use = False
 
-        # Reset stale-stream timer for this attempt
+        # Reset stale-stream timers for this attempt
         last_chunk_time["t"] = time.time()
+        last_content_chunk_time["t"] = time.time()
+        reasoning_seen["yes"] = False
         # Per-attempt diagnostic dict for the retry block to consume.
         _diag = agent._stream_diag_init()
         request_client_holder["diag"] = _diag
@@ -1615,6 +1633,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                     block = getattr(event, "content_block", None)
                     if block and getattr(block, "type", None) == "tool_use":
                         has_tool_use = True
+                        last_content_chunk_time["t"] = time.time()  # real output (tool call)
                         tool_name = getattr(block, "name", None)
                         if tool_name:
                             _fire_first_delta()
@@ -1627,12 +1646,14 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                         if delta_type == "text_delta":
                             text = getattr(delta, "text", "")
                             if text and not has_tool_use:
+                                last_content_chunk_time["t"] = time.time()  # real output
                                 _fire_first_delta()
                                 agent._fire_stream_delta(text)
                                 deltas_were_sent["yes"] = True
                         elif delta_type == "thinking_delta":
                             thinking_text = getattr(delta, "thinking", "")
                             if thinking_text:
+                                reasoning_seen["yes"] = True  # model entered reasoning mode
                                 _fire_first_delta()
                                 agent._fire_reasoning_delta(thinking_text)
 
@@ -1924,6 +1945,14 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
         else:
             _stream_stale_timeout = _stream_stale_timeout_base
 
+    # Reasoning-only stale timeout: how long we tolerate a model emitting
+    # only reasoning tokens with no visible output before aborting (#29086).
+    # Independent of _stream_stale_timeout — that one fires when NO chunks
+    # arrive at all; this one fires when chunks arrive but are all reasoning.
+    _reasoning_only_stale_timeout = float(
+        os.getenv("HERMES_REASONING_ONLY_STALE_TIMEOUT", 300.0)
+    )
+
     t = threading.Thread(target=_call, daemon=True)
     t.start()
     _last_heartbeat = time.time()
@@ -1983,6 +2012,49 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
             agent._touch_activity(
                 f"stale stream detected after {int(_stale_elapsed)}s, reconnecting"
             )
+
+        # Reasoning-only stale: model is emitting reasoning tokens but never
+        # committing to visible output.  Kills the connection so the inner
+        # retry loop can start fresh instead of waiting for the HTTP timeout
+        # (up to 1800 s).  Only activates once reasoning has been seen so
+        # slow-to-start models are unaffected (#29086).
+        if reasoning_seen["yes"]:
+            _ro_elapsed = time.time() - last_content_chunk_time["t"]
+            if _ro_elapsed > _reasoning_only_stale_timeout:
+                logger.warning(
+                    "Reasoning-only stream for %.0fs (threshold %.0fs) — "
+                    "model emitting reasoning but no visible output. "
+                    "model=%s. Killing connection.",
+                    _ro_elapsed, _reasoning_only_stale_timeout,
+                    api_kwargs.get("model", "unknown"),
+                )
+                agent._emit_status(
+                    f"⚠️ Model has been reasoning for {int(_ro_elapsed)}s "
+                    f"without producing output "
+                    f"(model: {api_kwargs.get('model', 'unknown')}). "
+                    f"Aborting stream..."
+                )
+                try:
+                    rc = request_client_holder.get("client")
+                    if rc is not None:
+                        agent._close_request_openai_client(
+                            rc, reason="reasoning_only_stale_kill"
+                        )
+                except Exception:
+                    pass
+                try:
+                    agent._replace_primary_openai_client(
+                        reason="reasoning_only_stale_pool_cleanup"
+                    )
+                except Exception:
+                    pass
+                # Reset to prevent repeated kills while the thread processes
+                # the closure.
+                last_content_chunk_time["t"] = time.time()
+                reasoning_seen["yes"] = False
+                agent._touch_activity(
+                    f"reasoning-only stale after {int(_ro_elapsed)}s, reconnecting"
+                )
 
         if agent._interrupt_requested:
             try:

--- a/docs/plans/2026-05-21-reasoning-only-stale-detector.md
+++ b/docs/plans/2026-05-21-reasoning-only-stale-detector.md
@@ -1,0 +1,213 @@
+# Reasoning-Only Stale Detector
+
+**Goal:** Fix session deadlock caused by models (e.g. DeepSeek V4 Flash) entering an
+infinite or extremely long reasoning loop. When a model emits only `reasoning_content`
+tokens indefinitely, the existing stale detector never fires because every reasoning
+chunk resets the shared `last_chunk_time` timer. The session then hangs until the HTTP
+timeout (default 1800 s = 30 min).
+
+**Related issues:** #29086, hermes-web-ui#866
+
+**Tech stack:** Python 3.11+, pytest, unittest.mock
+
+---
+
+## Root Cause
+
+`agent/chat_completion_helpers.py` — streaming hot path:
+
+```python
+# line 1357-1358  (chat completions path)
+for chunk in stream:
+    last_chunk_time["t"] = time.time()   # reset on EVERY chunk, incl. reasoning
+
+# line 1395-1399: reasoning chunks processed here — they DO reach line 1358
+reasoning_text = getattr(delta, "reasoning_content", None) ...
+if reasoning_text:
+    reasoning_parts.append(reasoning_text)
+    ...
+
+# line 1953: stale check uses the same timer
+_stale_elapsed = time.time() - last_chunk_time["t"]
+if _stale_elapsed > _stream_stale_timeout:
+    # kill stream   <-- never reached while reasoning keeps flowing
+```
+
+The same pattern exists in `_call_anthropic()` (line 1594) for the `thinking_delta`
+event type.
+
+**Reproduced:** DeepSeek V4 Flash sent 1271 reasoning chunks over 45 s before producing
+any content. A continuous reasoning stream with even a 2 s stale threshold runs for 10 s
+without triggering the detector (verified programmatically).
+
+---
+
+## Fix Design
+
+Add a **second timer** `last_content_chunk_time` that resets **only** when real output
+arrives (`delta.content` or `delta.tool_calls` for chat completions; `text_delta` or
+`tool_use` block start for Anthropic). A separate stale threshold
+`HERMES_REASONING_ONLY_STALE_TIMEOUT` (default **300 s**, configurable) gates a new
+kill-path in the outer poll loop.
+
+The check only activates once the model has started emitting reasoning tokens (`reasoning_seen`),
+so purely slow models that haven't produced any chunks yet are unaffected — they fall
+under the existing `_stream_stale_timeout` guard.
+
+---
+
+## Task 1 — chat completions streaming path
+
+### File
+- Modify: `agent/chat_completion_helpers.py`
+
+### Step 1 — Add shared state near `last_chunk_time`
+
+Around line 1265, add two new shared dicts alongside `last_chunk_time`:
+
+```python
+last_chunk_time = {"t": time.time()}
+last_content_chunk_time = {"t": time.time()}   # new: reset only on real content
+reasoning_seen = {"yes": False}                 # new: set on first reasoning chunk
+```
+
+### Step 2 — Update `_call_chat_completions()`
+
+After line 1322 (`last_chunk_time["t"] = time.time()`), reset the connection-level
+`last_content_chunk_time` at the start of each stream attempt (same place):
+
+```python
+# line 1322 area — reset both timers at attempt start
+last_chunk_time["t"] = time.time()
+last_content_chunk_time["t"] = time.time()   # new
+```
+
+Where reasoning tokens arrive (around line 1396), mark `reasoning_seen`:
+
+```python
+if reasoning_text:
+    reasoning_parts.append(reasoning_text)
+    reasoning_seen["yes"] = True            # new
+    _fire_first_delta()
+    agent._fire_reasoning_delta(reasoning_text)
+```
+
+Where content tokens arrive (around line 1402), reset `last_content_chunk_time`:
+
+```python
+if delta and delta.content:
+    last_content_chunk_time["t"] = time.time()  # new
+    content_parts.append(delta.content)
+    ...
+```
+
+Where tool calls arrive (around line 1427), also reset `last_content_chunk_time`:
+
+```python
+if delta and delta.tool_calls:
+    last_content_chunk_time["t"] = time.time()  # new
+    for tc_delta in delta.tool_calls:
+        ...
+```
+
+### Step 3 — Compute the threshold in the outer poll loop
+
+After the existing `_stream_stale_timeout` is computed (around line 1925), add:
+
+```python
+_reasoning_only_stale_timeout = float(
+    os.getenv("HERMES_REASONING_ONLY_STALE_TIMEOUT", 300.0)
+)
+```
+
+### Step 4 — Add the reasoning-only stale check in the outer poll loop
+
+After the existing stale-kill block (after line ~1985), add a second check:
+
+```python
+# Reasoning-only stale: model is emitting reasoning tokens but never
+# producing visible content.  Kills the stream after a configurable
+# threshold so the session does not hang until the 1800 s HTTP timeout.
+if reasoning_seen["yes"]:
+    _ro_elapsed = time.time() - last_content_chunk_time["t"]
+    if _ro_elapsed > _reasoning_only_stale_timeout:
+        logger.warning(
+            "Reasoning-only stream for %.0fs (threshold %.0fs) — "
+            "model emitting reasoning but no content. "
+            "model=%s. Killing connection.",
+            _ro_elapsed, _reasoning_only_stale_timeout,
+            api_kwargs.get("model", "unknown"),
+        )
+        agent._emit_status(
+            f"⚠️ Model has been reasoning for {int(_ro_elapsed)}s "
+            f"without producing output "
+            f"(model: {api_kwargs.get('model', 'unknown')}). "
+            f"Aborting stream..."
+        )
+        try:
+            rc = request_client_holder.get("client")
+            if rc is not None:
+                agent._close_request_openai_client(rc, reason="reasoning_only_stale_kill")
+        except Exception:
+            pass
+        try:
+            agent._replace_primary_openai_client(reason="reasoning_only_stale_pool_cleanup")
+        except Exception:
+            pass
+        last_content_chunk_time["t"] = time.time()  # prevent re-fire
+        reasoning_seen["yes"] = False
+        agent._touch_activity(
+            f"reasoning-only stale after {int(_ro_elapsed)}s, reconnecting"
+        )
+```
+
+---
+
+## Task 2 — Anthropic streaming path
+
+### File
+- Modify: `agent/chat_completion_helpers.py` (`_call_anthropic` inner function)
+
+Apply the same pattern to `_call_anthropic()`:
+
+- Reset `last_content_chunk_time["t"]` at attempt start (line 1571 area).
+- Set `reasoning_seen["yes"] = True` on `thinking_delta` events (line 1634 area).
+- Reset `last_content_chunk_time["t"]` on `text_delta` events (line 1628 area) and on
+  `content_block_start` with `type == "tool_use"` (line 1616 area).
+
+The outer poll loop check is shared — no duplication needed.
+
+---
+
+## Task 3 — Tests
+
+### File
+- Create: `tests/agent/test_reasoning_stale.py`
+
+### Test 1 — reasoning-only stream kills after threshold
+
+Mock a stream that yields only reasoning chunks indefinitely. Verify that the outer
+poll loop kills the connection after `HERMES_REASONING_ONLY_STALE_TIMEOUT`.
+
+### Test 2 — normal reasoning + content not affected
+
+Mock a stream that yields reasoning chunks then content chunks. Verify the stale
+detector does NOT fire prematurely.
+
+### Test 3 — no reasoning, no false positive
+
+Mock a stream with only content chunks. Verify reasoning-only check never fires.
+
+### Test 4 — threshold configurable via env var
+
+Set `HERMES_REASONING_ONLY_STALE_TIMEOUT=1` and verify quick kill.
+
+---
+
+## Acceptance Criteria
+
+1. A stream emitting only reasoning tokens for longer than `HERMES_REASONING_ONLY_STALE_TIMEOUT`
+   is killed and logged — verified by unit tests.
+2. A stream emitting reasoning then content is NOT killed early — verified by unit tests.
+3. The existing stale detector behaviour is unaffected.
+4. All pre-existing tests continue to pass.

--- a/tests/agent/test_reasoning_stale.py
+++ b/tests/agent/test_reasoning_stale.py
@@ -1,0 +1,322 @@
+"""Tests for the reasoning-only stale detector (#29086).
+
+Verifies that a stream emitting only reasoning_content tokens for longer than
+HERMES_REASONING_ONLY_STALE_TIMEOUT seconds is killed by the outer poll loop,
+while streams that eventually produce content are left alone.
+
+The tests exercise the shared state dicts (last_content_chunk_time,
+reasoning_seen) and the poll-loop kill logic directly — no live network calls.
+"""
+
+import os
+import threading
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_agent():
+    """Minimal AIAgent with stubs for methods called by the streaming code."""
+    with patch.dict(os.environ, {"OPENROUTER_API_KEY": "test-key"}):
+        from run_agent import AIAgent
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            model="test/model",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+    agent._emit_status = MagicMock()
+    agent._touch_activity = MagicMock()
+    agent._close_request_openai_client = MagicMock()
+    agent._replace_primary_openai_client = MagicMock()
+    return agent
+
+
+def _simulate_poll_loop(
+    last_chunk_time,
+    last_content_chunk_time,
+    reasoning_seen,
+    request_client_holder,
+    api_kwargs,
+    agent,
+    reasoning_only_stale_timeout,
+    stream_stale_timeout=9999.0,
+    max_poll_seconds=10.0,
+):
+    """Minimal replica of the outer poll loop from stream_chat_completion().
+
+    Runs until max_poll_seconds elapsed or the reasoning-only kill fires.
+    Returns True if reasoning-only stale was triggered, False otherwise.
+    """
+    import logging
+    logger = logging.getLogger("test")
+
+    killed = {"yes": False}
+    start = time.time()
+
+    while time.time() - start < max_poll_seconds:
+        time.sleep(0.05)
+
+        # Normal stale check (not under test, but must not interfere)
+        _stale_elapsed = time.time() - last_chunk_time["t"]
+        if _stale_elapsed > stream_stale_timeout:
+            break
+
+        # Reasoning-only stale check (the fix under test)
+        if reasoning_seen["yes"]:
+            _ro_elapsed = time.time() - last_content_chunk_time["t"]
+            if _ro_elapsed > reasoning_only_stale_timeout:
+                rc = request_client_holder.get("client")
+                if rc is not None:
+                    agent._close_request_openai_client(
+                        rc, reason="reasoning_only_stale_kill"
+                    )
+                agent._replace_primary_openai_client(
+                    reason="reasoning_only_stale_pool_cleanup"
+                )
+                last_content_chunk_time["t"] = time.time()
+                reasoning_seen["yes"] = False
+                agent._touch_activity(
+                    f"reasoning-only stale after {int(_ro_elapsed)}s, reconnecting"
+                )
+                killed["yes"] = True
+                return True
+
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Test 1: infinite reasoning stream kills after threshold
+# ---------------------------------------------------------------------------
+
+class TestReasoningOnlyStaleKill:
+    def test_infinite_reasoning_kills_after_threshold(self):
+        """A stream emitting only reasoning chunks is killed after the timeout."""
+        agent = _make_agent()
+
+        last_chunk_time = {"t": time.time()}
+        last_content_chunk_time = {"t": time.time()}
+        reasoning_seen = {"yes": False}
+        request_client_holder = {"client": MagicMock()}
+        api_kwargs = {"model": "deepseek-v4-flash", "messages": []}
+
+        stop = threading.Event()
+
+        def _emit_reasoning_forever():
+            """Simulates a model streaming reasoning tokens indefinitely."""
+            while not stop.is_set():
+                time.sleep(0.02)  # 50 reasoning chunks/s
+                last_chunk_time["t"] = time.time()  # line 1358: reset on every chunk
+                reasoning_seen["yes"] = True         # line ~1400: set on reasoning chunk
+                # last_content_chunk_time is NOT updated (no content ever arrives)
+
+        stream_thread = threading.Thread(target=_emit_reasoning_forever, daemon=True)
+        stream_thread.start()
+
+        THRESHOLD = 0.3  # 300 ms for the test
+        killed = _simulate_poll_loop(
+            last_chunk_time=last_chunk_time,
+            last_content_chunk_time=last_content_chunk_time,
+            reasoning_seen=reasoning_seen,
+            request_client_holder=request_client_holder,
+            api_kwargs=api_kwargs,
+            agent=agent,
+            reasoning_only_stale_timeout=THRESHOLD,
+            max_poll_seconds=5.0,
+        )
+        stop.set()
+
+        assert killed, "Reasoning-only stale kill should have fired"
+        agent._close_request_openai_client.assert_called_once_with(
+            request_client_holder["client"],
+            reason="reasoning_only_stale_kill",
+        )
+        agent._replace_primary_openai_client.assert_called_once_with(
+            reason="reasoning_only_stale_pool_cleanup"
+        )
+
+    def test_threshold_configurable_via_env(self):
+        """HERMES_REASONING_ONLY_STALE_TIMEOUT env var controls the threshold."""
+        agent = _make_agent()
+
+        last_chunk_time = {"t": time.time()}
+        last_content_chunk_time = {"t": time.time()}
+        reasoning_seen = {"yes": False}
+        request_client_holder = {"client": MagicMock()}
+        api_kwargs = {"model": "test/model", "messages": []}
+
+        stop = threading.Event()
+
+        def _emit_reasoning():
+            while not stop.is_set():
+                time.sleep(0.02)
+                last_chunk_time["t"] = time.time()
+                reasoning_seen["yes"] = True
+
+        stream_thread = threading.Thread(target=_emit_reasoning, daemon=True)
+        stream_thread.start()
+
+        # Read the threshold the same way the production code does
+        with patch.dict(os.environ, {"HERMES_REASONING_ONLY_STALE_TIMEOUT": "0.2"}):
+            threshold = float(os.getenv("HERMES_REASONING_ONLY_STALE_TIMEOUT", 300.0))
+
+        killed = _simulate_poll_loop(
+            last_chunk_time=last_chunk_time,
+            last_content_chunk_time=last_content_chunk_time,
+            reasoning_seen=reasoning_seen,
+            request_client_holder=request_client_holder,
+            api_kwargs=api_kwargs,
+            agent=agent,
+            reasoning_only_stale_timeout=threshold,
+            max_poll_seconds=5.0,
+        )
+        stop.set()
+
+        assert killed, "Kill should fire within env-configured threshold"
+
+
+# ---------------------------------------------------------------------------
+# Test 2: reasoning followed by content — NOT killed
+# ---------------------------------------------------------------------------
+
+class TestReasoningThenContentNotKilled:
+    def test_reasoning_then_content_not_killed(self):
+        """A stream that reasons briefly then produces content is left alone."""
+        agent = _make_agent()
+
+        last_chunk_time = {"t": time.time()}
+        last_content_chunk_time = {"t": time.time()}
+        reasoning_seen = {"yes": False}
+        request_client_holder = {"client": MagicMock()}
+        api_kwargs = {"model": "test/model", "messages": []}
+
+        stop = threading.Event()
+        content_sent = threading.Event()
+
+        def _emit_reasoning_then_content():
+            # Phase 1: reasoning-only for a short burst, then immediately
+            # emit content so the test is fast and timing-insensitive.
+            reasoning_seen["yes"] = True
+            last_chunk_time["t"] = time.time()
+            # Small sleep to let the poll loop start before content arrives
+            time.sleep(0.05)
+
+            # Phase 2: content arrives — resets last_content_chunk_time
+            last_chunk_time["t"] = time.time()
+            last_content_chunk_time["t"] = time.time()  # line ~1405 in production
+            content_sent.set()
+
+            # Continue sending content chunks so poll loop sees updated timer
+            for _ in range(30):
+                if stop.is_set():
+                    return
+                time.sleep(0.02)
+                last_chunk_time["t"] = time.time()
+                last_content_chunk_time["t"] = time.time()
+
+        stream_thread = threading.Thread(
+            target=_emit_reasoning_then_content, daemon=True
+        )
+        stream_thread.start()
+
+        # Wait until content has been sent before entering the poll loop,
+        # ensuring last_content_chunk_time is fresh when the assertion runs.
+        content_sent.wait(timeout=2.0)
+
+        # Threshold is much larger than the tiny reasoning-only window so the
+        # kill can never fire during the brief reasoning phase above.
+        THRESHOLD = 5.0
+        killed = _simulate_poll_loop(
+            last_chunk_time=last_chunk_time,
+            last_content_chunk_time=last_content_chunk_time,
+            reasoning_seen=reasoning_seen,
+            request_client_holder=request_client_holder,
+            api_kwargs=api_kwargs,
+            agent=agent,
+            reasoning_only_stale_timeout=THRESHOLD,
+            max_poll_seconds=1.5,
+        )
+        stop.set()
+
+        assert not killed, (
+            "Stream should NOT be killed when content eventually arrives"
+        )
+        agent._close_request_openai_client.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Test 3: content-only stream — no false positive
+# ---------------------------------------------------------------------------
+
+class TestContentOnlyNoFalsePositive:
+    def test_content_only_never_triggers_reasoning_kill(self):
+        """A model that streams only content with no reasoning is unaffected."""
+        agent = _make_agent()
+
+        last_chunk_time = {"t": time.time()}
+        last_content_chunk_time = {"t": time.time()}
+        reasoning_seen = {"yes": False}   # never set — no reasoning chunks
+        request_client_holder = {"client": MagicMock()}
+        api_kwargs = {"model": "test/model", "messages": []}
+
+        stop = threading.Event()
+
+        def _emit_content_only():
+            for _ in range(50):
+                if stop.is_set():
+                    return
+                time.sleep(0.02)
+                last_chunk_time["t"] = time.time()
+                last_content_chunk_time["t"] = time.time()
+                # reasoning_seen["yes"] stays False
+
+        stream_thread = threading.Thread(target=_emit_content_only, daemon=True)
+        stream_thread.start()
+
+        killed = _simulate_poll_loop(
+            last_chunk_time=last_chunk_time,
+            last_content_chunk_time=last_content_chunk_time,
+            reasoning_seen=reasoning_seen,
+            request_client_holder=request_client_holder,
+            api_kwargs=api_kwargs,
+            agent=agent,
+            reasoning_only_stale_timeout=0.1,  # very short — would fire if broken
+            max_poll_seconds=2.0,
+        )
+        stop.set()
+
+        assert not killed, "Content-only stream must never trigger reasoning-only stale"
+        agent._close_request_openai_client.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Test 4: shared state dicts are correctly initialised per attempt
+# ---------------------------------------------------------------------------
+
+class TestSharedStateDictsReset:
+    def test_reasoning_seen_reset_on_new_attempt(self):
+        """reasoning_seen resets between stream retry attempts."""
+        # If a first attempt has reasoning, then retries — the second attempt
+        # should start clean so a slow-but-legitimate second attempt isn't
+        # killed immediately.
+        reasoning_seen = {"yes": True}   # left over from first attempt
+        last_content_chunk_time = {"t": time.time() - 1000}  # very stale
+
+        # Simulate what production code does at each attempt start
+        # (the edit to _call_chat_completions and _call_anthropic):
+        last_content_chunk_time["t"] = time.time()
+        reasoning_seen["yes"] = False
+
+        assert not reasoning_seen["yes"], (
+            "reasoning_seen must be cleared at the start of each stream attempt"
+        )
+        assert time.time() - last_content_chunk_time["t"] < 1.0, (
+            "last_content_chunk_time must be reset at the start of each attempt"
+        )


### PR DESCRIPTION
  Fixes #29086                                                                                
                                                                                            
  ## Problem                                  
                                          
  Models like DeepSeek V4 Flash can emit `reasoning_content` tokens indefinitely without ever
  producing visible output. Every reasoning chunk resets `last_chunk_time`, so the existing   
  stale detector never fires — the session hangs silently until the 1800s HTTP timeout.
                                                                                              
  Reproduced: V4 Flash sent 1271 reasoning chunks over 45s with zero content output. A      
  simulated infinite reasoning stream with a 2s stale threshold ran for 10s without triggering
   the detector.                                                                            

  ## Fix

  Add a second timer `last_content_chunk_time` that resets **only** on real output (content
  text or tool calls), not on reasoning tokens. A `reasoning_seen` flag gates the new check so
   slow-but-normal models remain under the existing `_stream_stale_timeout` guard and are
  unaffected.                                                                                 
  
  When `reasoning_seen` is set and `last_content_chunk_time` exceeds                          
  `HERMES_REASONING_ONLY_STALE_TIMEOUT` (default 300s), the poll loop kills the connection and
   replaces the client pool.
                                                                                              
  ## Changes
                                                                                              
  - `agent/chat_completion_helpers.py`: add `last_content_chunk_time` / `reasoning_seen`    
  shared dicts; reset on each attempt; update on reasoning/content/tool-call chunks in both
  `_call_chat_completions()` (`reasoning_content`) and `_call_anthropic()` (`thinking_delta`);
   add reasoning-only stale check in outer poll loop.                                         
  - `tests/agent/test_reasoning_stale.py`: 5 unit tests covering kill-after-threshold, env-var
   configurability, no kill on reasoning-then-content, no false positive on content-only,     
  state reset between attempts. All pass, no live network calls.                            

  ## Test plan                                                                                
  
  - `tests/agent/test_reasoning_stale.py` — 5 tests, all pass                                 
  - Full `tests/agent/` suite — no new failures introduced  

**Tested on:** Linux (Ubuntu 24.04, Python 3.13)