### PR TITLE
fix: avoid deprecated utcnow in BlueBubbles temp GUIDs

### DIFF
--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -14,7 +14,7 @@ import logging
 import os
 import re
 import uuid
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 from urllib.parse import quote
 
@@ -380,7 +380,7 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         payload = {
             "addresses": [address],
             "message": message,
-            "tempGuid": f"temp-{datetime.utcnow().timestamp()}",
+            "tempGuid": f"temp-{datetime.now(timezone.utc).timestamp()}",
         }
         try:
             res = await self._api_post("/api/v1/chat/new", payload)
@@ -436,7 +436,7 @@ class BlueBubblesAdapter(BasePlatformAdapter):
                 )
             payload: Dict[str, Any] = {
                 "chatGuid": guid,
-                "tempGuid": f"temp-{datetime.utcnow().timestamp()}",
+                "tempGuid": f"temp-{datetime.now(timezone.utc).timestamp()}",
                 "message": chunk,
             }
             if reply_to and self._private_api_enabled and self._helper_connected:


### PR DESCRIPTION
## Summary

Replace the remaining `datetime.utcnow()` calls in the BlueBubbles adapter with `datetime.now(timezone.utc)`.

## Bug

`datetime.utcnow()` is deprecated in Python 3.12 because it returns a naive datetime. The BlueBubbles adapter used it to generate temporary GUID timestamps for new chats and text messages, which can emit deprecation warnings on newer Python versions.

## Before/After

Before:
```python
f"temp-{datetime.utcnow().timestamp()}"
```

After:
```python
f"temp-{datetime.now(timezone.utc).timestamp()}"
```

The generated value remains a UTC timestamp, but it now comes from an explicitly timezone-aware UTC datetime.

## Verification

- `python -m compileall -q gateway/platforms/bluebubbles.py`
- `git diff --check`