### PR TITLE
feat(agent): add cost_tagging support for departmental token tracking

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1091,6 +1091,11 @@ def init_agent(
         _agent_section = {}
     agent._tool_use_enforcement = _agent_section.get("tool_use_enforcement", "auto")
 
+    # Per-turn time injection — when True, injects the current wall-clock
+    # time (minute-precision) before each LLM call.  Lives outside the
+    # cached system prompt so prefix cache stays warm.
+    agent.time_injection = bool(_agent_section.get("time_injection", False))
+
     # App-level API retry count (wraps each model API call).  Default 3,
     # overridable via agent.api_max_retries in config.yaml.  See #11616.
     try:

--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1096,6 +1096,11 @@ def init_agent(
     # cached system prompt so prefix cache stays warm.
     agent.time_injection = bool(_agent_section.get("time_injection", False))
 
+    # Cost tagging — when True, attaches departmental/service tags to
+    # token usage data for downstream cost attribution.
+    agent.cost_tagging = bool(_agent_section.get("cost_tagging", False))
+    agent.cost_tags: Dict[str, str] = {}
+
     # App-level API retry count (wraps each model API call).  Default 3,
     # overridable via agent.api_max_retries in config.yaml.  See #11616.
     try:

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -4030,6 +4030,7 @@ def run_conversation(
         "estimated_cost_usd": agent.session_estimated_cost_usd,
         "cost_status": agent.session_cost_status,
         "cost_source": agent.session_cost_source,
+        "cost_tags": dict(agent.cost_tags) if agent.cost_tagging else {},
     }
     if agent._tool_guardrail_halt_decision is not None:
         result["guardrail"] = agent._tool_guardrail_halt_decision.to_metadata()

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -802,6 +802,20 @@ def run_conversation(
         effective_system = active_system_prompt or ""
         if agent.ephemeral_system_prompt:
             effective_system = (effective_system + "\n\n" + agent.ephemeral_system_prompt).strip()
+        # Per-turn wall-clock time injection (agent.time_injection config).
+        # Injected as an ephemeral addition — outside the cached system
+        # prompt — so the prefix cache stays warm across turns.  The
+        # volatile-block date-only timestamp in build_system_prompt_parts
+        # is left unchanged for sessions that don't want per-turn time.
+        if getattr(agent, "time_injection", False):
+            from hermes_time import now as _hermes_now
+            _now = _hermes_now()
+            _tz = _now.strftime("%Z") or ""
+            time_line = (
+                f"Current time: {_now.strftime('%A, %B %d, %Y %I:%M %p')}"
+                f"{' ' + _tz if _tz else ''}"
+            )
+            effective_system = (effective_system + "\n\n" + time_line).strip()
         if effective_system:
             api_messages = [{"role": "system", "content": effective_system}] + api_messages
 

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -586,6 +586,12 @@ DEFAULT_CONFIG = {
         # only controls how inbound user images are presented.
         "image_input_mode": "auto",
         "disabled_toolsets": [],
+        # Per-turn time injection: when true, the current time (with
+        # minute precision) is injected into the system prompt before
+        # every LLM call.  The existing date-only timestamp in the
+        # volatile system prompt block is left unchanged for byte-stable
+        # prompt caching; this field lives outside the cache.
+        "time_injection": False,
     },
     
     "terminal": {

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -592,8 +592,12 @@ DEFAULT_CONFIG = {
         # volatile system prompt block is left unchanged for byte-stable
         # prompt caching; this field lives outside the cache.
         "time_injection": False,
+        # Cost tagging — when True, attaches departmental/service tags
+        # to token usage for downstream cost attribution per department,
+        # skill, or service.  Default: False (backward compatible).
+        "cost_tagging": False,
     },
-    
+
     "terminal": {
         "backend": "local",
         "modal_mode": "auto",

--- a/run_agent.py
+++ b/run_agent.py
@@ -563,6 +563,24 @@ class AIAgent:
         if hasattr(self, "context_compressor") and self.context_compressor:
             self.context_compressor.on_session_reset()
 
+    def set_cost_tags(self, tags: Dict[str, str]) -> None:
+        """Set cost attribution tags for departmental/service token tracking.
+
+        When ``cost_tagging`` is enabled in config, these tags are attached
+        to every usage-info payload returned by ``run_conversation()`` so
+        downstream aggregators can attribute token consumption by
+        department, skill, service, or any other dimension.
+
+        ``cost_tagging`` must be ``True`` in config.yaml for tags to have
+        any effect; calling this method when disabled is a no-op.
+
+        Args:
+            tags: Key-value pairs such as
+                  ``{"department": "framework", "service": "research"}``.
+        """
+        if self.cost_tagging:
+            self.cost_tags = tags
+
     def _ensure_lmstudio_runtime_loaded(self, config_context_length: Optional[int] = None) -> None:
         """
         Preload the LM Studio model with at least Hermes' minimum context.


### PR DESCRIPTION
## Summary

Adds `agent.cost_tagging` config option for departmental/service-level token cost attribution.

## Problem

When multiple teams or services share a single Hermes Agent deployment, there is no way to attribute token consumption to individual departments. This makes cost tracking and budgeting difficult for organizations.

## Solution

A new boolean config `agent.cost_tagging` (default `false`) plus a public API method `set_cost_tags()`:
1. Config read in `agent_init.py` → enabled flag + tags dict
2. `set_cost_tags(tags: Dict[str, str])` on `AIAgent` — callers set departmental tags
3. Tags attached to every `run_conversation()` result dict under `cost_tags` key

### Usage example
```python
agent = AIAgent(...)
agent.set_cost_tags({"department": "research", "service": "rag-pipeline"})
result = agent.run_conversation("...")
# result["cost_tags"] == {"department": "research", "service": "rag-pipeline"}
```

### Design decisions
- **Zero overhead when disabled** — `cost_tagging=False` adds only a boolean check
- **Backward compatible** — default `False`, `cost_tags: {}` in result
- **No new dependencies** — pure Python dict

## Files changed
- `agent/agent_init.py` — read config, store on agent
- `agent/conversation_loop.py` — attach tags to result dict
- `hermes_cli/config.py` — add default config entry
- `run_agent.py` — add `set_cost_tags()` public API method

## Dependencies

This PR depends on #29798 (feat/time-injection) — both touch shared config and init files. Apply #29798 first.