### PR TITLE
docs(voice): use `uv pip install faster-whisper` in STT install hints

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -10640,7 +10640,7 @@ class HermesCLI:
         if not reqs.get("stt_available", reqs.get("stt_key_set")):
             raise RuntimeError(
                 "Voice mode requires an STT provider for transcription.\n"
-                "Option 1: pip install faster-whisper  (free, local)\n"
+                "Option 1: uv pip install faster-whisper  (free, local)\n"
                 "Option 2: Set GROQ_API_KEY (free tier)\n"
                 "Option 3: Set VOICE_TOOLS_OPENAI_KEY (paid)"
             )

--- a/cli.py
+++ b/cli.py
@@ -10640,7 +10640,8 @@ class HermesCLI:
         if not reqs.get("stt_available", reqs.get("stt_key_set")):
             raise RuntimeError(
                 "Voice mode requires an STT provider for transcription.\n"
-                "Option 1: uv pip install faster-whisper  (free, local)\n"
+                "Option 1: uv pip install faster-whisper  "
+                "(free, local; `pip install faster-whisper` also works if pip is on PATH)\n"
                 "Option 2: Set GROQ_API_KEY (free tier)\n"
                 "Option 3: Set VOICE_TOOLS_OPENAI_KEY (paid)"
             )

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7938,7 +7938,8 @@ class GatewayRunner:
                                 "🎤 I received your voice message but can't transcribe it — "
                                 "no speech-to-text provider is configured.\n\n"
                                 "To enable voice: install faster-whisper "
-                                "(`pip install faster-whisper` in the Hermes venv) "
+                                "(`uv pip install faster-whisper` in the Hermes venv; "
+                                "`pip install faster-whisper` also works if pip is on PATH) "
                                 "and set `stt.enabled: true` in config.yaml, "
                                 "then /restart the gateway."
                             )

--- a/tools/voice_mode.py
+++ b/tools/voice_mode.py
@@ -1077,7 +1077,7 @@ def check_voice_requirements() -> Dict[str, Any]:
         details_parts.append("STT provider: OK (OpenAI)")
     else:
         details_parts.append(
-            "STT provider: MISSING (pip install faster-whisper, "
+            "STT provider: MISSING (uv pip install faster-whisper, "
             "or set GROQ_API_KEY / VOICE_TOOLS_OPENAI_KEY)"
         )
 

--- a/tools/voice_mode.py
+++ b/tools/voice_mode.py
@@ -1077,7 +1077,8 @@ def check_voice_requirements() -> Dict[str, Any]:
         details_parts.append("STT provider: OK (OpenAI)")
     else:
         details_parts.append(
-            "STT provider: MISSING (uv pip install faster-whisper, "
+            "STT provider: MISSING (uv pip install faster-whisper — "
+            "`pip install faster-whisper` also works if pip is on PATH, "
             "or set GROQ_API_KEY / VOICE_TOOLS_OPENAI_KEY)"
         )
 


### PR DESCRIPTION
## What does this PR do?

Three runtime messages tell users to `pip install faster-whisper` to enable local STT. Reported in #29782 for the gateway STT failure message under Telegram-in-Docker, where the user hit `bash: pip: command not found` because the Hermes Docker image is built on `ghcr.io/astral-sh/uv` with a uv-managed venv that doesn't ship `pip` on PATH. Users on modern `uv tool install` / `uv venv` installs see the same problem.

The canonical install command in this repo is `uv pip install` (see [`tools/lazy_deps.py:509` `feature_install_command()`](https://github.com/NousResearch/hermes-agent/blob/main/tools/lazy_deps.py#L504-L509), which generates `uv pip install ...` for every lazy backend including `stt.faster_whisper`). `uv pip install` works in Docker (uv image), in `uv tool install` venvs, and in pip-based venvs that already have uv on PATH.

> Audited siblings: grepped `pip install faster-whisper` across `gateway/`, `cli.py`, `tools/` — exactly three runtime message strings emit this hint and all three are updated by this PR. Docs (`website/docs/`, `README.md`, skills) intentionally left alone — those are read in browser context where the user can copy whichever variant fits their install, and changing them is a separate scope.

## Related Issue

Fixes #29782

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/run.py` — Telegram/Discord/Slack/WhatsApp/etc. voice reply when no STT provider is configured. Now suggests `` `uv pip install faster-whisper` in the Hermes venv `` and notes that `` `pip install faster-whisper` `` also works if `pip` is on PATH.
- `tools/voice_mode.py` — `/voice` status line for missing STT now says `uv pip install faster-whisper`.
- `cli.py` — Voice-mode startup error "Option 1" now says `uv pip install faster-whisper  (free, local)`.

Before/after on the gateway message reported in the issue:

```
Before: To enable voice: install faster-whisper (`pip install faster-whisper` in the Hermes venv) and set `stt.enabled: true` ...
After:  To enable voice: install faster-whisper (`uv pip install faster-whisper` in the Hermes venv; `pip install faster-whisper` also works if pip is on PATH) and set `stt.enabled: true` ...
```

## How to Test

1. Reproduce the original failure on `origin/main`:
   ```bash
   docker run --rm ghcr.io/astral-sh/uv:0.11.6-python3.13-trixie bash -lc 'pip install faster-whisper'
   # bash: pip: command not found
   ```
2. Verify `uv pip install` works in the same env:
   ```bash
   docker run --rm ghcr.io/astral-sh/uv:0.11.6-python3.13-trixie bash -lc 'uv venv && source .venv/bin/activate && uv pip install faster-whisper'
   # Resolved + installed
   ```
3. Existing test pass:
   ```bash
   uv run --with pytest --with pytest-xdist --with pytest-asyncio --with pytest-timeout python3 -m pytest tests/tools/test_voice_mode.py -v
   # 45 passed, 15 skipped
   ```
4. Trigger the gateway STT hint by sending a voice message to a Telegram bot with `stt.enabled: false` (or no STT configured), and confirm the new copy is rendered.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run focused tests for the touched code and all pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features) — N/A: cosmetic copy change in user-facing message strings; a string-equality test would be brittle without protecting against a real regression class.
- [x] I've tested on my platform: macOS 15.x

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (in-product hints updated; web docs intentionally left alone)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no config keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — `uv` is cross-platform; the new hint is correct on macOS, Linux, Windows.
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A