### PR TITLE
fix: keep memory and skill prompts clean

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -873,7 +873,7 @@ def _build_skills_manifest(skills_dir: Path) -> dict[str, list[int]]:
     return manifest
 
 
-def _load_skills_snapshot(skills_dir: Path) -> Optional[dict]:
+def _load_skills_snapshot(skills_dir: Path, manifest: Optional[dict] = None) -> Optional[dict]:
     """Load the disk snapshot if it exists and its manifest still matches."""
     snapshot_path = _skills_prompt_snapshot_path()
     if not snapshot_path.exists():
@@ -886,7 +886,8 @@ def _load_skills_snapshot(skills_dir: Path) -> Optional[dict]:
         return None
     if snapshot.get("version") != _SKILLS_SNAPSHOT_VERSION:
         return None
-    if snapshot.get("manifest") != _build_skills_manifest(skills_dir):
+    target_manifest = manifest if manifest is not None else _build_skills_manifest(skills_dir)
+    if snapshot.get("manifest") != target_manifest:
         return None
     return snapshot
 
@@ -1018,6 +1019,23 @@ def build_skills_system_prompt(
     if not skills_dir.exists() and not external_dirs:
         return ""
 
+    local_manifest = _build_skills_manifest(skills_dir)
+    external_manifests = {}
+    for d in external_dirs:
+        if d.exists():
+            try:
+                external_manifests[str(d.resolve())] = _build_skills_manifest(d)
+            except Exception:
+                external_manifests[str(d.resolve())] = {"__manifest_error__": [0, 0]}
+
+    def _manifest_to_key(m: dict[str, list[int]]) -> tuple:
+        return tuple(sorted((k, tuple(v)) for k, v in m.items()))
+
+    manifest_key = (
+        _manifest_to_key(local_manifest),
+        tuple(sorted((d_str, _manifest_to_key(m)) for d_str, m in external_manifests.items()))
+    )
+
     # ── Layer 1: in-process LRU cache ─────────────────────────────────
     # Include the resolved platform so per-platform disabled-skill lists
     # produce distinct cache entries (gateway serves multiple platforms).
@@ -1035,6 +1053,7 @@ def build_skills_system_prompt(
         tuple(sorted(str(ts) for ts in (available_toolsets or set()))),
         _platform_hint,
         tuple(sorted(disabled)),
+        manifest_key,
     )
     with _SKILLS_PROMPT_CACHE_LOCK:
         cached = _SKILLS_PROMPT_CACHE.get(cache_key)
@@ -1043,7 +1062,7 @@ def build_skills_system_prompt(
             return cached
 
     # ── Layer 2: disk snapshot ────────────────────────────────────────
-    snapshot = _load_skills_snapshot(skills_dir)
+    snapshot = _load_skills_snapshot(skills_dir, local_manifest)
 
     skills_by_category: dict[str, list[tuple[str, str]]] = {}
     category_descriptions: dict[str, str] = {}

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -1194,4 +1194,98 @@ class TestOpenAIModelExecutionGuidance:
 # =========================================================================
 
 
+class TestSkillsPromptCacheInvalidation:
+    def test_rebuilds_prompt_when_skill_file_changed(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        pb = pytest.importorskip("agent.prompt_builder")
 
+        # Create a skill
+        skill_dir = tmp_path / "skills" / "general" / "test-cache-skill"
+        skill_dir.mkdir(parents=True)
+        skill_file = skill_dir / "SKILL.md"
+        skill_file.write_text(
+            "---\nname: test-cache-skill\ndescription: Initial description\n---\n"
+        )
+
+        # Build prompt first time
+        result1 = pb.build_skills_system_prompt(
+            available_tools=set(),
+            available_toolsets=set(),
+        )
+        assert "Initial description" in result1
+
+        # Build prompt second time - should hit cache
+        result2 = pb.build_skills_system_prompt(
+            available_tools=set(),
+            available_toolsets=set(),
+        )
+        assert result1 is result2 or result1 == result2
+
+        # Now modify the skill file and physically push the mtime forward to avoid timestamp collision issues
+        skill_file.write_text(
+            "---\nname: test-cache-skill\ndescription: Updated description\n---\n"
+        )
+        st = skill_file.stat()
+        import os
+        os.utime(skill_file, (st.st_atime, st.st_mtime + 5))
+
+        # Build prompt third time - should invalidate cache and reload updated description
+        result3 = pb.build_skills_system_prompt(
+            available_tools=set(),
+            available_toolsets=set(),
+        )
+        assert "Updated description" in result3
+        assert "Initial description" not in result3
+
+
+class TestSkillsPromptCacheExternalDirsException:
+    @pytest.fixture(autouse=True)
+    def _clear_skills_cache(self):
+        from agent.prompt_builder import clear_skills_system_prompt_cache
+        clear_skills_system_prompt_cache(clear_snapshot=True)
+        yield
+        clear_skills_system_prompt_cache(clear_snapshot=True)
+
+    def test_external_dir_exception_sentinel_invalidates_cache(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        from pathlib import Path
+
+        ext_dir = tmp_path / "ext_skills"
+        ext_dir.mkdir()
+
+        pb = pytest.importorskip("agent.prompt_builder")
+        orig_build_manifest = pb._build_skills_manifest
+
+        # 模拟切换异常状态的标志
+        manifest_error = True
+
+        def mock_build_manifest(d):
+            if Path(d).resolve() == ext_dir.resolve() and manifest_error:
+                raise OSError("Simulated error during stat/iter_index")
+            return orig_build_manifest(d)
+
+        monkeypatch.setattr(
+            pb,
+            "get_all_skills_dirs",
+            lambda: [tmp_path / "skills", ext_dir],
+        )
+        monkeypatch.setattr(pb, "_build_skills_manifest", mock_build_manifest)
+
+        # 1. 出错时第一次调用，应该成功并不崩溃（使用错误哨兵值构建 cache_key）
+        result_error = pb.build_skills_system_prompt()
+
+        # 2. 第二次调用，依然出错，应命中缓存
+        result_error_cached = pb.build_skills_system_prompt()
+        assert result_error == result_error_cached
+
+        # 3. 消除错误状态，并在 external 目录下新建一个技能
+        manifest_error = False
+        ext_skill_dir = ext_dir / "general" / "ext-skill"
+        ext_skill_dir.mkdir(parents=True)
+        (ext_skill_dir / "SKILL.md").write_text(
+            "---\nname: ext-skill\ndescription: External skill\n---\n"
+        )
+
+        # 4. 再次调用，缓存必须失效并载入外部技能
+        result_recovered = pb.build_skills_system_prompt()
+        assert "ext-skill" in result_recovered

--- a/tests/tools/test_memory_tool.py
+++ b/tests/tools/test_memory_tool.py
@@ -135,7 +135,7 @@ class TestMemoryStoreAdd:
 class TestMemoryStoreReplace:
     def test_replace_entry(self, store):
         store.add("memory", "Python 3.11 project")
-        result = store.replace("memory", "3.11", "Python 3.12 project")
+        result = store.replace("memory", "3.11 project", "Python 3.12 project")
         assert result["success"] is True
         assert "Python 3.12 project" in result["entries"]
         assert "Python 3.11 project" not in result["entries"]
@@ -148,7 +148,7 @@ class TestMemoryStoreReplace:
     def test_replace_ambiguous_match(self, store):
         store.add("memory", "server A runs nginx")
         store.add("memory", "server B runs nginx")
-        result = store.replace("memory", "nginx", "apache")
+        result = store.replace("memory", "runs nginx", "apache")
         assert result["success"] is False
         assert "Multiple" in result["error"]
 
@@ -255,3 +255,80 @@ class TestMemoryToolDispatcher:
     def test_remove_requires_old_text(self, store):
         result = json.loads(memory_tool(action="remove", store=store))
         assert result["success"] is False
+
+
+class TestMemoryStoreWhitespaceDeduplication:
+    def test_add_whitespace_insensitive_deduplication(self, store):
+        store.add("memory", "fact   with  multiple \n  spaces")
+        # Equivalent content with different spacing should be rejected
+        result = store.add("memory", "fact with multiple spaces")
+        assert result["success"] is True
+        assert len(store.memory_entries) == 1
+
+    def test_load_whitespace_insensitive_deduplication(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("tools.memory_tool.get_memory_dir", lambda: tmp_path)
+        mem_file = tmp_path / "MEMORY.md"
+        mem_file.write_text("duplicate \n entry\n§\nduplicate   entry\n§\nunique entry")
+
+        store = MemoryStore()
+        store.load_from_disk()
+        assert len(store.memory_entries) == 2
+        # Should keep the first one
+        assert store.memory_entries[0] == "duplicate \n entry"
+
+    def test_replace_whitespace_insensitive_match(self, store):
+        store.add("memory", "server   configured   with \n python")
+        result = store.replace("memory", "server configured with python", "server with py3")
+        assert result["success"] is True
+        assert "server with py3" in store.memory_entries
+        assert len(store.memory_entries) == 1
+
+    def test_remove_whitespace_insensitive_match(self, store):
+        store.add("memory", "server   configured   with \n python")
+        result = store.remove("memory", "server configured with python")
+        assert result["success"] is True
+        assert len(store.memory_entries) == 0
+
+
+class TestMemoryStoreShortQueryProtection:
+    def test_short_query_exact_match_replace_success(self, store):
+        # 长度小于 8（"short" 长度为 5），如果精确匹配，replace 应该成功
+        store.add("memory", "short")
+        result = store.replace("memory", "short", "longer replacement")
+        assert result["success"] is True
+        assert "longer replacement" in store.memory_entries
+        assert "short" not in store.memory_entries
+
+    def test_short_query_substring_match_replace_fails(self, store):
+        # 长度小于 8（"short" 长度为 5），如果是子串但非精确匹配，replace 应该失败
+        store.add("memory", "this is a short entry")
+        result = store.replace("memory", "short", "longer replacement")
+        assert result["success"] is False
+        assert "No entry matched" in result["error"]
+        assert "this is a short entry" in store.memory_entries
+
+    def test_short_query_exact_match_remove_success(self, store):
+        # 长度小于 8，精确匹配 remove 成功
+        store.add("memory", "short")
+        result = store.remove("memory", "short")
+        assert result["success"] is True
+        assert len(store.memory_entries) == 0
+
+    def test_short_query_substring_match_remove_fails(self, store):
+        # 长度小于 8，子串非精确匹配 remove 失败
+        store.add("memory", "this is a short entry")
+        result = store.remove("memory", "short")
+        assert result["success"] is False
+        assert "No entry matched" in result["error"]
+        assert "this is a short entry" in store.memory_entries
+
+    def test_long_query_substring_match_works(self, store):
+        # 长度大于等于 8（"longquery" 长度为 9），子串匹配应该能正常 replace 和 remove
+        store.add("memory", "this has a longquery in it")
+        result = store.replace("memory", "longquery", "this has a replaced value in it")
+        assert result["success"] is True
+        assert "this has a replaced value in it" in store.memory_entries
+
+        result2 = store.remove("memory", "replaced value")
+        assert result2["success"] is True
+        assert len(store.memory_entries) == 0

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -104,6 +104,23 @@ def _scan_memory_content(content: str) -> Optional[str]:
     return None
 
 
+def _normalize_content(content: str) -> str:
+    """Normalize whitespace and newlines for comparison."""
+    return " ".join(content.split())
+
+
+def _deduplicate_entries(entries: List[str]) -> List[str]:
+    """Deduplicate entries based on normalized whitespace, preserving order and original formatting."""
+    seen = set()
+    deduped = []
+    for e in entries:
+        norm = _normalize_content(e)
+        if norm not in seen:
+            seen.add(norm)
+            deduped.append(e)
+    return deduped
+
+
 class MemoryStore:
     """
     Bounded curated memory with file persistence. One instance per AIAgent.
@@ -132,8 +149,8 @@ class MemoryStore:
         self.user_entries = self._read_file(mem_dir / "USER.md")
 
         # Deduplicate entries (preserves order, keeps first occurrence)
-        self.memory_entries = list(dict.fromkeys(self.memory_entries))
-        self.user_entries = list(dict.fromkeys(self.user_entries))
+        self.memory_entries = _deduplicate_entries(self.memory_entries)
+        self.user_entries = _deduplicate_entries(self.user_entries)
 
         # Capture frozen snapshot for system prompt injection
         self._system_prompt_snapshot = {
@@ -191,7 +208,7 @@ class MemoryStore:
         Called under file lock to get the latest state before mutating.
         """
         fresh = self._read_file(self._path_for(target))
-        fresh = list(dict.fromkeys(fresh))  # deduplicate
+        fresh = _deduplicate_entries(fresh)  # deduplicate
         self._set_entries(target, fresh)
 
     def save_to_disk(self, target: str):
@@ -239,8 +256,9 @@ class MemoryStore:
             entries = self._entries_for(target)
             limit = self._char_limit(target)
 
-            # Reject exact duplicates
-            if content in entries:
+            # Reject equivalent duplicates
+            norm_content = _normalize_content(content)
+            if any(_normalize_content(e) == norm_content for e in entries):
                 return self._success_response(target, "Entry already exists (no duplicate added).")
 
             # Calculate what the new total would be
@@ -284,7 +302,11 @@ class MemoryStore:
             self._reload_target(target)
 
             entries = self._entries_for(target)
-            matches = [(i, e) for i, e in enumerate(entries) if old_text in e]
+            norm_old = _normalize_content(old_text)
+            if len(norm_old) < 8:
+                matches = [(i, e) for i, e in enumerate(entries) if norm_old == _normalize_content(e)]
+            else:
+                matches = [(i, e) for i, e in enumerate(entries) if norm_old in _normalize_content(e)]
 
             if not matches:
                 return {"success": False, "error": f"No entry matched '{old_text}'."}
@@ -334,7 +356,11 @@ class MemoryStore:
             self._reload_target(target)
 
             entries = self._entries_for(target)
-            matches = [(i, e) for i, e in enumerate(entries) if old_text in e]
+            norm_old = _normalize_content(old_text)
+            if len(norm_old) < 8:
+                matches = [(i, e) for i, e in enumerate(entries) if norm_old == _normalize_content(e)]
+            else:
+                matches = [(i, e) for i, e in enumerate(entries) if norm_old in _normalize_content(e)]
 
             if not matches:
                 return {"success": False, "error": f"No entry matched '{old_text}'."}


### PR DESCRIPTION
This PR resolves issues with memory duplication and prompt cache invalidation:

- **Memory Clean Up**: Normalizes whitespace formatting for duplicate checks, ensuring duplicate memories aren't added. Restricts replace/remove action match queries shorter than 8 chars to exact match to prevent accidental overrides.
- **Skills Prompt Cache**: Resolves cache stale bugs by building a manifest key over all skills (SKILL.md / DESCRIPTION.md changes) and includes a fallback error sentinel for external scanning directories.
- **Focused Regression Tests**: Coverage for exact match protections, external manifest exceptions, and mtime cache invalidation.