### PR TITLE
fix(gateway): prevent session fork during context compression

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8230,6 +8230,16 @@ class GatewayRunner:
                                 try:
                                     _hyg_agent._print_fn = lambda *a, **kw: None
 
+                                    # Bump the running agent's activity timestamp
+                                    # before blocking compression in the executor.
+                                    # Without this heartbeat, stale-lock eviction
+                                    # can fire and spawn a parallel agent instance
+                                    # if a second message arrives while the executor
+                                    # thread is busy — forking the session transcript.
+                                    _running = self._running_agents.get(session_key)
+                                    if _running and hasattr(_running, "_touch_activity"):
+                                        _running._touch_activity("session hygiene compression")
+
                                     loop = asyncio.get_running_loop()
                                     _compressed, _ = await loop.run_in_executor(
                                         None,
@@ -8238,6 +8248,11 @@ class GatewayRunner:
                                             approx_tokens=_approx_tokens,
                                         ),
                                     )
+                                    # Bump the activity timestamp again after compression
+                                    # so the "just finished" time is visible to diagnostics.
+                                    _running = self._running_agents.get(session_key)
+                                    if _running and hasattr(_running, "_touch_activity"):
+                                        _running._touch_activity("session hygiene compression done")
 
                                     # _compress_context ends the old session and creates
                                     # a new session_id.  Write compressed messages into
@@ -11914,11 +11929,21 @@ class GatewayRunner:
                 if not compressor.has_content_to_compress(msgs):
                     return t("gateway.compress.nothing_to_do")
 
+                # Bump the running agent's activity timestamp before blocking
+                # compression in the executor. Without this heartbeat, stale-lock
+                # eviction can fire during compression and spawn a parallel agent.
+                _running = self._running_agents.get(session_key)
+                if _running and hasattr(_running, "_touch_activity"):
+                    _running._touch_activity("session hygiene compression (/compact)")
+
                 loop = asyncio.get_running_loop()
                 compressed, _ = await loop.run_in_executor(
                     None,
                     lambda: tmp_agent._compress_context(msgs, "", approx_tokens=approx_tokens, focus_topic=focus_topic, force=True)
                 )
+                _running = self._running_agents.get(session_key)
+                if _running and hasattr(_running, "_touch_activity"):
+                    _running._touch_activity("session hygiene compression done (/compact)")
 
                 # _compress_context already calls end_session() on the old session
                 # (preserving its full transcript in SQLite) and creates a new


### PR DESCRIPTION
## What does this PR do?

Prevents parallel AIAgent instances from spawning on the same session key during context compression, which causes irrecoverable transcript forks (split brain — two files with the same `session_id` that diverge).

## Related Issue

N/A (observed in production, verified split-session evidence on disk)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- Add activity heartbeat before/after `run_in_executor` compression calls in both paths:
  - Automatic session hygiene compression (`_handle_message_with_agent`, ~L8230)
  - Manual `/compact` command path (~L11930)
- Heartbeat calls `_running._touch_activity("session hygiene compression")` on the live agent in `_running_agents` so the stale-lock eviction check sees the agent as active during the executor-blocking period

## Root Cause

The stale-lock eviction guard (`gateway/run.py:6695–6736`) checks the running agents `get_activity_summary()` timestamp. When session hygiene compression is dispatched to `run_in_executor`, the executor thread is busy but the event loop is free. The agents activity tracker is NOT updated during executor-bound work. A second message arriving while compression runs can see `seconds_since_activity > timeout` → evict → spawn parallel agent → transcript fork.

## How to Test

1. Set up a session with enough messages to trigger auto-compression (> token threshold)
2. Start a long-running conversation turn that will trigger compression
3. Send a second message during compression
4. Verify: second message is queued/rejected, NOT spawned as parallel agent
5. Verify: only ONE transcript file per `session_id` exists on disk

Existing test suite in `tests/gateway/test_session_race_guard.py` covers basic sentinel protection but not the executor-compression scenario.

## Checklist

### Code

- [x] Ive read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isnt a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [ ] Ive run `pytest tests/ -q` and all tests pass
- [ ] Ive added tests for my changes
- [x] Ive tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

- [x] N/A — no documentation, config, or tool changes