### PR TITLE
Harden todo history hydration

### DIFF
--- a/_docs/2026-05-21_todo_hydration_hardening_codex.md
+++ b/_docs/2026-05-21_todo_hydration_hardening_codex.md
@@ -1,0 +1,42 @@
+# Todo Hydration Hardening
+
+Date: 2026-05-21
+Branch: codex/hermes-security-review-20260521
+
+## Summary
+
+Hardened `AIAgent._hydrate_todo_store()` so persisted todo state is restored
+only from a tool result that is paired with an earlier assistant `todo` tool
+call. This narrows session-history hydration to canonical tool-call history
+instead of accepting any tool-shaped message that happens to contain a
+`todos` array.
+
+The todo store now also caps restored and newly written todo data:
+
+- maximum todo items: 100
+- maximum todo id length: 128 characters
+- maximum todo content length: 1000 characters
+- maximum todo hydration result payload: 128000 characters
+
+## Verification
+
+Commands run:
+
+```powershell
+$env:UV_PROJECT_ENVIRONMENT = Join-Path $env:TEMP 'hermes-agent-codex-test-env'
+uv run --extra dev python -m pytest tests\run_agent\test_run_agent.py::TestHydrateTodoStore tests\tools\test_todo_tool.py -q --timeout-method=thread
+uv run --extra dev python -m pytest tests\tools\test_read_loop_detection.py::TestTodoInjectionFiltering -q --timeout-method=thread
+uv run --extra dev python -m compileall run_agent.py tools\todo_tool.py
+git diff --check
+```
+
+Results:
+
+- `19 passed` for hydrate and todo-tool tests.
+- `4 passed` for todo injection filtering.
+- `compileall` completed successfully.
+- `git diff --check` reported no whitespace errors.
+
+Note: the checkout-local `.venv` did not have `pytest`, and `uv run` against
+that `.venv` could not replace a locked `hermes.exe`. Verification therefore
+used `UV_PROJECT_ENVIRONMENT` under `%TEMP%`.

--- a/run_agent.py
+++ b/run_agent.py
@@ -2128,14 +2128,30 @@ class AIAgent:
         
         The gateway creates a fresh AIAgent per message, so the in-memory
         TodoStore is empty. We scan the history for the most recent todo
-        tool response and replay it to reconstruct the state.
+        tool response with a matching assistant todo call and replay it to
+        reconstruct the state.
         """
+        from tools.todo_tool import MAX_TODO_RESULT_CHARS
+
         # Walk history backwards to find the most recent todo tool response
         last_todo_response = None
-        for msg in reversed(history):
+        for idx in range(len(history) - 1, -1, -1):
+            msg = history[idx]
             if msg.get("role") != "tool":
                 continue
             content = msg.get("content", "")
+            if not self._tool_response_matches_todo_call(history, idx):
+                continue
+            if not isinstance(content, str):
+                continue
+            if len(content) > MAX_TODO_RESULT_CHARS:
+                logger.warning(
+                    "Skipping oversized todo tool response during hydration: "
+                    "session=%s chars=%d",
+                    self.session_id or "none",
+                    len(content),
+                )
+                continue
             # Quick check: todo responses contain "todos" key
             if '"todos"' not in content:
                 continue
@@ -2153,6 +2169,62 @@ class AIAgent:
             if not self.quiet_mode:
                 self._vprint(f"{self.log_prefix}📋 Restored {len(last_todo_response)} todo item(s) from history")
         _set_interrupt(False)
+
+    @classmethod
+    def _tool_response_matches_todo_call(
+        cls,
+        history: List[Dict[str, Any]],
+        tool_index: int,
+    ) -> bool:
+        """Return True when a tool result belongs to a prior assistant todo call."""
+        if tool_index < 0 or tool_index >= len(history):
+            return False
+        tool_msg = history[tool_index]
+        tool_call_id = tool_msg.get("tool_call_id")
+        if not tool_call_id:
+            return False
+
+        for prior_idx in range(tool_index - 1, -1, -1):
+            prior = history[prior_idx]
+            role = prior.get("role")
+            if role == "assistant":
+                return cls._assistant_has_todo_tool_call(prior, tool_call_id)
+            if role in {"user", "system"}:
+                return False
+        return False
+
+    @classmethod
+    def _assistant_has_todo_tool_call(
+        cls,
+        assistant_msg: Dict[str, Any],
+        tool_call_id: str,
+    ) -> bool:
+        tool_calls = assistant_msg.get("tool_calls")
+        if not isinstance(tool_calls, list):
+            return False
+
+        for tool_call in tool_calls:
+            if cls._tool_call_id(tool_call) != tool_call_id:
+                continue
+            if cls._tool_call_name(tool_call) == "todo":
+                return True
+        return False
+
+    @staticmethod
+    def _tool_call_id(tool_call: Any) -> Optional[str]:
+        if isinstance(tool_call, dict):
+            return tool_call.get("id")
+        return getattr(tool_call, "id", None)
+
+    @staticmethod
+    def _tool_call_name(tool_call: Any) -> Optional[str]:
+        if isinstance(tool_call, dict):
+            function = tool_call.get("function") or {}
+            if isinstance(function, dict):
+                return function.get("name")
+            return getattr(function, "name", None)
+        function = getattr(tool_call, "function", None)
+        return getattr(function, "name", None)
 
     @property
     def is_interrupted(self) -> bool:

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -921,6 +921,20 @@ class TestInterrupt:
 
 
 class TestHydrateTodoStore:
+    @staticmethod
+    def _assistant_todo_call(call_id="c1"):
+        return {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {
+                    "id": call_id,
+                    "type": "function",
+                    "function": {"name": "todo", "arguments": "{}"},
+                }
+            ],
+        }
+
     def test_no_todo_in_history(self, agent):
         history = [
             {"role": "user", "content": "hello"},
@@ -934,7 +948,7 @@ class TestHydrateTodoStore:
         todos = [{"id": "1", "content": "do thing", "status": "pending"}]
         history = [
             {"role": "user", "content": "plan"},
-            {"role": "assistant", "content": "ok"},
+            self._assistant_todo_call("c1"),
             {
                 "role": "tool",
                 "content": json.dumps({"todos": todos}),
@@ -945,11 +959,51 @@ class TestHydrateTodoStore:
             agent._hydrate_todo_store(history)
         assert agent._todo_store.has_items()
 
-    def test_skips_non_todo_tools(self, agent):
+    def test_skips_tool_response_without_matching_todo_call(self, agent):
+        todos = [{"id": "1", "content": "do thing", "status": "pending"}]
         history = [
             {
                 "role": "tool",
-                "content": '{"result": "search done"}',
+                "content": json.dumps({"todos": todos}),
+                "tool_call_id": "c1",
+            },
+        ]
+        with patch("run_agent._set_interrupt"):
+            agent._hydrate_todo_store(history)
+        assert not agent._todo_store.has_items()
+
+    def test_skips_tool_response_matched_to_non_todo_call(self, agent):
+        todos = [{"id": "1", "content": "do thing", "status": "pending"}]
+        history = [
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "c1",
+                        "type": "function",
+                        "function": {"name": "web_search", "arguments": "{}"},
+                    }
+                ],
+            },
+            {
+                "role": "tool",
+                "content": json.dumps({"todos": todos}),
+                "tool_call_id": "c1",
+            },
+        ]
+        with patch("run_agent._set_interrupt"):
+            agent._hydrate_todo_store(history)
+        assert not agent._todo_store.has_items()
+
+    def test_skips_oversized_todo_tool_response(self, agent):
+        from tools.todo_tool import MAX_TODO_RESULT_CHARS
+
+        history = [
+            self._assistant_todo_call("c1"),
+            {
+                "role": "tool",
+                "content": '{"todos":"' + ("x" * MAX_TODO_RESULT_CHARS) + '"}',
                 "tool_call_id": "c1",
             },
         ]
@@ -959,6 +1013,7 @@ class TestHydrateTodoStore:
 
     def test_invalid_json_skipped(self, agent):
         history = [
+            self._assistant_todo_call("c1"),
             {
                 "role": "tool",
                 "content": 'not valid json "todos" oops',

--- a/tests/tools/test_todo_tool.py
+++ b/tests/tools/test_todo_tool.py
@@ -2,7 +2,13 @@
 
 import json
 
-from tools.todo_tool import TodoStore, todo_tool
+from tools.todo_tool import (
+    MAX_TODO_CONTENT_CHARS,
+    MAX_TODO_ID_CHARS,
+    MAX_TODO_ITEMS,
+    TodoStore,
+    todo_tool,
+)
 
 
 class TestWriteAndRead:
@@ -35,6 +41,20 @@ class TestWriteAndRead:
             {"id": "2", "content": "Other task", "status": "pending"},
             {"id": "1", "content": "Latest version", "status": "in_progress"},
         ]
+
+    def test_write_caps_items_and_text_lengths(self):
+        store = TodoStore()
+        result = store.write([
+            {
+                "id": f"{i}-" + ("i" * MAX_TODO_ID_CHARS),
+                "content": "c" * (MAX_TODO_CONTENT_CHARS + 50),
+                "status": "pending",
+            }
+            for i in range(MAX_TODO_ITEMS + 25)
+        ])
+        assert len(result) == MAX_TODO_ITEMS
+        assert all(len(item["id"]) <= MAX_TODO_ID_CHARS for item in result)
+        assert all(len(item["content"]) <= MAX_TODO_CONTENT_CHARS for item in result)
 
 
 class TestHasItems:

--- a/tools/todo_tool.py
+++ b/tools/todo_tool.py
@@ -20,6 +20,10 @@ from typing import Dict, Any, List, Optional
 
 # Valid status values for todo items
 VALID_STATUSES = {"pending", "in_progress", "completed", "cancelled"}
+MAX_TODO_ITEMS = 100
+MAX_TODO_ID_CHARS = 128
+MAX_TODO_CONTENT_CHARS = 1000
+MAX_TODO_RESULT_CHARS = 128_000
 
 
 class TodoStore:
@@ -44,22 +48,38 @@ class TodoStore:
             merge: if False, replace the entire list. If True, update
                    existing items by id and append new ones.
         """
+        limited_todos = self._limit_items(todos)
+
         if not merge:
             # Replace mode: new list entirely
-            self._items = [self._validate(t) for t in self._dedupe_by_id(todos)]
+            self._items = self._dedupe_validated_by_id(
+                [self._validate(t) for t in limited_todos]
+            )
         else:
             # Merge mode: update existing items by id, append new ones
             existing = {item["id"]: item for item in self._items}
-            for t in self._dedupe_by_id(todos):
-                item_id = str(t.get("id", "")).strip()
+            for t in self._dedupe_by_id(limited_todos):
+                item_id = (
+                    self._normalize_text(
+                        t.get("id", ""),
+                        max_chars=MAX_TODO_ID_CHARS,
+                        fallback="",
+                    )
+                    if isinstance(t, dict)
+                    else ""
+                )
                 if not item_id:
                     continue  # Can't merge without an id
 
                 if item_id in existing:
                     # Update only the fields the LLM actually provided
-                    if "content" in t and t["content"]:
-                        existing[item_id]["content"] = str(t["content"]).strip()
-                    if "status" in t and t["status"]:
+                    if isinstance(t, dict) and "content" in t and t["content"]:
+                        existing[item_id]["content"] = self._normalize_text(
+                            t["content"],
+                            max_chars=MAX_TODO_CONTENT_CHARS,
+                            fallback=existing[item_id]["content"],
+                        )
+                    if isinstance(t, dict) and "status" in t and t["status"]:
                         status = str(t["status"]).strip().lower()
                         if status in VALID_STATUSES:
                             existing[item_id]["status"] = status
@@ -129,11 +149,22 @@ class TodoStore:
         Ensures required fields exist and status is valid.
         Returns a clean dict with only {id, content, status}.
         """
-        item_id = str(item.get("id", "")).strip()
+        if not isinstance(item, dict):
+            item = {}
+
+        item_id = TodoStore._normalize_text(
+            item.get("id", ""),
+            max_chars=MAX_TODO_ID_CHARS,
+            fallback="?",
+        )
         if not item_id:
             item_id = "?"
 
-        content = str(item.get("content", "")).strip()
+        content = TodoStore._normalize_text(
+            item.get("content", ""),
+            max_chars=MAX_TODO_CONTENT_CHARS,
+            fallback="(no description)",
+        )
         if not content:
             content = "(no description)"
 
@@ -144,11 +175,43 @@ class TodoStore:
         return {"id": item_id, "content": content, "status": status}
 
     @staticmethod
+    def _normalize_text(value: Any, *, max_chars: int, fallback: str) -> str:
+        text = str(value).strip()
+        if not text:
+            return fallback
+        return text[:max_chars]
+
+    @staticmethod
+    def _limit_items(todos: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        if not isinstance(todos, list):
+            return []
+        return todos[:MAX_TODO_ITEMS]
+
+    @staticmethod
+    def _item_id_for_dedupe(item: Dict[str, Any]) -> str:
+        if not isinstance(item, dict):
+            return "?"
+        return TodoStore._normalize_text(
+            item.get("id", ""),
+            max_chars=MAX_TODO_ID_CHARS,
+            fallback="?",
+        )
+
+    @staticmethod
     def _dedupe_by_id(todos: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
         """Collapse duplicate ids, keeping the last occurrence in its position."""
         last_index: Dict[str, int] = {}
         for i, item in enumerate(todos):
-            item_id = str(item.get("id", "")).strip() or "?"
+            item_id = TodoStore._item_id_for_dedupe(item)
+            last_index[item_id] = i
+        return [todos[i] for i in sorted(last_index.values())]
+
+    @staticmethod
+    def _dedupe_validated_by_id(todos: List[Dict[str, str]]) -> List[Dict[str, str]]:
+        """Collapse duplicate ids, keeping the last occurrence in its position."""
+        last_index: Dict[str, int] = {}
+        for i, item in enumerate(todos):
+            item_id = item.get("id") or "?"
             last_index[item_id] = i
         return [todos[i] for i in sorted(last_index.values())]
 


### PR DESCRIPTION
## Summary

- Restore todo state only from tool results paired with a prior assistant `todo` tool call.
- Bound todo hydration and write data by item count, id length, content length, and result payload size.
- Add focused regression coverage for canonical hydration, forged/unmatched tool results, oversized payloads, and todo store caps.

Addresses #29152 using only the public tracking issue scope; advisory details are intentionally omitted here.

## Verification

- `uv run --extra dev python -m pytest tests\run_agent\test_run_agent.py::TestHydrateTodoStore tests\tools\test_todo_tool.py -q --timeout-method=thread` -> 19 passed
- `uv run --extra dev python -m pytest tests\tools\test_read_loop_detection.py::TestTodoInjectionFiltering -q --timeout-method=thread` -> 4 passed
- `uv run --extra dev python -m compileall run_agent.py tools\todo_tool.py`
- `git diff --check`

Note: verification used `UV_PROJECT_ENVIRONMENT` under `%TEMP%` because the checkout-local `.venv` lacked pytest and had a locked `hermes.exe`.