### PR TITLE
fix(ollama): emit top-level reasoning_effort=none on /v1/chat/complet…

### DIFF
--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -407,6 +407,7 @@ def _run_review_in_thread(
                 enabled_toolsets=getattr(agent, "enabled_toolsets", None),
                 disabled_toolsets=getattr(agent, "disabled_toolsets", None),
                 skip_memory=True,
+                reasoning_config=getattr(agent, "reasoning_config", None),  # propagate — fixes #25758
             )
             review_agent._memory_write_origin = "background_review"
             review_agent._memory_write_context = "background_review"

--- a/plugins/model-providers/custom/__init__.py
+++ b/plugins/model-providers/custom/__init__.py
@@ -3,8 +3,11 @@
 Covers any endpoint registered as provider="custom", including local
 Ollama instances. Key quirks:
   - ollama_num_ctx → extra_body.options.num_ctx (local context window)
-  - reasoning_config disabled → extra_body.think = False
+  - reasoning disabled → reasoning_effort="none" on /v1/chat/completions
+                         + think=False on /api/chat (for proxies/older Ollama)
 """
+
+from __future__ import annotations
 
 from typing import Any
 
@@ -13,7 +16,7 @@ from providers.base import ProviderProfile
 
 
 class CustomProfile(ProviderProfile):
-    """Custom/Ollama local provider — think=false and num_ctx support."""
+    """Custom/Ollama local provider — think control and num_ctx support."""
 
     def build_api_kwargs_extras(
         self,
@@ -23,6 +26,7 @@ class CustomProfile(ProviderProfile):
         **ctx: Any,
     ) -> tuple[dict[str, Any], dict[str, Any]]:
         extra_body: dict[str, Any] = {}
+        top_level: dict[str, Any] = {}
 
         # Ollama context window
         if ollama_num_ctx:
@@ -30,14 +34,17 @@ class CustomProfile(ProviderProfile):
             options["num_ctx"] = ollama_num_ctx
             extra_body["options"] = options
 
-        # Disable thinking when reasoning is turned off
+        # Disable thinking when reasoning is turned off.
+        # Ollama's /v1/chat/completions honours reasoning_effort="none" (#14820).
+        # The native /api/chat field think=False is also emitted for proxies.
         if reasoning_config and isinstance(reasoning_config, dict):
             _effort = (reasoning_config.get("effort") or "").strip().lower()
             _enabled = reasoning_config.get("enabled", True)
             if _effort == "none" or _enabled is False:
-                extra_body["think"] = False
+                top_level["reasoning_effort"] = "none"  # /v1/chat/completions
+                extra_body["think"] = False             # /api/chat + proxies
 
-        return extra_body, {}
+        return extra_body, top_level
 
     def fetch_models(
         self,

--- a/tests/plugins/model_providers/test_custom_profile.py
+++ b/tests/plugins/model_providers/test_custom_profile.py
@@ -1,0 +1,157 @@
+"""Unit tests for the Custom/Ollama provider profile's thinking-mode wiring.
+
+When ``reasoning_effort: none`` (or ``enabled: False``) is set, Hermes must
+suppress Qwen3/DeepSeek-style thinking on Ollama.  Ollama exposes two knobs:
+
+  1. ``extra_body["think"] = False``  — honoured on the native /api/chat endpoint.
+  2. top-level ``reasoning_effort = "none"`` — honoured on /v1/chat/completions
+     (the OpenAI-compat path that Hermes actually uses).
+
+The original code only emitted (1), which Ollama silently ignores on /v1/chat/completions,
+causing every request to run the full reasoning chain regardless of the user's config
+(NousResearch/hermes-agent#6152, #25758).  Both fields must be emitted together.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture
+def custom_profile():
+    """Resolve the registered custom/Ollama provider profile."""
+    import model_tools  # noqa: F401 — triggers plugin discovery
+    import providers
+
+    profile = providers.get_provider_profile("custom")
+    assert profile is not None, "custom provider profile must be registered"
+    return profile
+
+
+class TestCustomProfileThinkingDisabled:
+    """When reasoning is disabled, both think=False and reasoning_effort='none' are emitted."""
+
+    def test_effort_none_emits_both_fields(self, custom_profile):
+        """``reasoning_effort: none`` → extra_body.think=False + top-level reasoning_effort='none'."""
+        extra_body, top_level = custom_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "none"},
+        )
+        assert extra_body.get("think") is False, "extra_body.think must be False for /api/chat compat"
+        assert top_level.get("reasoning_effort") == "none", (
+            "top-level reasoning_effort must be 'none' for /v1/chat/completions"
+        )
+
+    def test_enabled_false_emits_both_fields(self, custom_profile):
+        """``enabled: False`` → same wire shape as effort=none."""
+        extra_body, top_level = custom_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": False},
+        )
+        assert extra_body.get("think") is False
+        assert top_level.get("reasoning_effort") == "none"
+
+    def test_enabled_false_with_any_effort_emits_both_fields(self, custom_profile):
+        """``enabled: False`` takes precedence over any effort value."""
+        extra_body, top_level = custom_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": False, "effort": "high"},
+        )
+        assert extra_body.get("think") is False
+        assert top_level.get("reasoning_effort") == "none"
+
+
+class TestCustomProfileThinkingEnabled:
+    """When reasoning is active (default), neither suppression field is emitted."""
+
+    def test_no_reasoning_config_emits_nothing(self, custom_profile):
+        """No reasoning_config → no think field, no reasoning_effort."""
+        extra_body, top_level = custom_profile.build_api_kwargs_extras(
+            reasoning_config=None,
+        )
+        assert "think" not in extra_body
+        assert "reasoning_effort" not in top_level
+
+    @pytest.mark.parametrize("effort", ["low", "medium", "high", "xhigh", ""])
+    def test_active_efforts_do_not_suppress(self, custom_profile, effort):
+        """Efforts other than 'none' must not suppress thinking."""
+        extra_body, top_level = custom_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": effort},
+        )
+        assert "think" not in extra_body
+        assert "reasoning_effort" not in top_level
+
+    def test_enabled_true_medium_effort_emits_nothing(self, custom_profile):
+        """Default config (enabled=True, effort=medium) → no suppression fields."""
+        extra_body, top_level = custom_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "medium"},
+        )
+        assert "think" not in extra_body
+        assert "reasoning_effort" not in top_level
+
+
+class TestCustomProfileOllamaNumCtx:
+    """ollama_num_ctx is forwarded into extra_body.options regardless of reasoning config."""
+
+    def test_num_ctx_forwarded(self, custom_profile):
+        extra_body, _ = custom_profile.build_api_kwargs_extras(
+            reasoning_config=None,
+            ollama_num_ctx=65536,
+        )
+        assert extra_body.get("options", {}).get("num_ctx") == 65536
+
+    def test_num_ctx_plus_disabled_thinking(self, custom_profile):
+        """num_ctx and think=False can coexist in extra_body."""
+        extra_body, top_level = custom_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": False},
+            ollama_num_ctx=131072,
+        )
+        assert extra_body.get("options", {}).get("num_ctx") == 131072
+        assert extra_body.get("think") is False
+        assert top_level.get("reasoning_effort") == "none"
+
+    def test_no_num_ctx_means_no_options_key(self, custom_profile):
+        extra_body, _ = custom_profile.build_api_kwargs_extras(
+            reasoning_config=None,
+            ollama_num_ctx=None,
+        )
+        assert "options" not in extra_body
+
+
+class TestCustomProfileFullKwargsIntegration:
+    """End-to-end: ChatCompletionsTransport produces the correct wire shape."""
+
+    def test_thinking_disabled_full_kwargs(self, custom_profile):
+        """reasoning_effort=none → top-level + extra_body both carry suppression."""
+        from agent.transports.chat_completions import ChatCompletionsTransport
+
+        kwargs = ChatCompletionsTransport().build_kwargs(
+            model="qwen3.6:35b",
+            messages=[{"role": "user", "content": "ping"}],
+            tools=None,
+            provider_profile=custom_profile,
+            reasoning_config={"enabled": True, "effort": "none"},
+            base_url="http://172.18.0.1:11434/v1",
+            provider_name="custom",
+        )
+        # Top-level field — what Ollama /v1/chat/completions actually honours
+        assert kwargs.get("reasoning_effort") == "none", (
+            "reasoning_effort must be at top-level for Ollama /v1/chat/completions"
+        )
+        # extra_body field — backward-compat for /api/chat and proxies
+        assert kwargs.get("extra_body", {}).get("think") is False, (
+            "extra_body.think=False must be present for /api/chat compat"
+        )
+
+    def test_thinking_enabled_full_kwargs(self, custom_profile):
+        """Default config → no suppression fields on the wire."""
+        from agent.transports.chat_completions import ChatCompletionsTransport
+
+        kwargs = ChatCompletionsTransport().build_kwargs(
+            model="qwen3.6:35b",
+            messages=[{"role": "user", "content": "ping"}],
+            tools=None,
+            provider_profile=custom_profile,
+            reasoning_config={"enabled": True, "effort": "medium"},
+            base_url="http://172.18.0.1:11434/v1",
+            provider_name="custom",
+        )
+        assert "reasoning_effort" not in kwargs
+        assert "think" not in kwargs.get("extra_body", {})


### PR DESCRIPTION
fix(ollama): emit top-level `reasoning_effort=none` on `/v1/chat/completions` + propagate `reasoning_config` to bg-review fork

Fixes #6152
Fixes #25758

## What does this PR do?

When `reasoning_effort: none` is set (via `/reasoning none` or `config.yaml`), Hermes should suppress thinking on Ollama. It doesn't — the model always runs its full reasoning chain regardless of the user's config.

Two root causes:

**Defect 1 (main agent):** The `custom` provider plugin emits `extra_body["think"] = False` to disable thinking. This works on Ollama's native `/api/chat` endpoint but is silently ignored on `/v1/chat/completions` — the OpenAI-compat path Hermes actually uses. The field that `/v1/chat/completions` honours is a top-level `reasoning_effort = "none"`, which was never emitted.

**Defect 2 (bg-review fork):** `_spawn_background_review()` creates a new `AIAgent` without passing `reasoning_config`. Even when Defect 1 is fixed, the review fork always defaults to `reasoning_effort=medium` and can produce 200k+ token reasoning traces taking up to 28 minutes per turn.

## Related Issue

Fixes #6152
Fixes #25758

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `plugins/model-providers/custom/__init__.py` — emit `top_level["reasoning_effort"] = "none"` alongside the existing `extra_body["think"] = False` when reasoning is disabled. The top-level field is what Ollama's `/v1/chat/completions` actually processes (confirmed in `openai/openai.go`); `think=False` is kept for `/api/chat` backward-compat and proxies.

- `agent/background_review.py` — pass `reasoning_config=getattr(agent, "reasoning_config", None)` when constructing the forked `AIAgent`, so the review fork inherits the parent's reasoning settings.

- `tests/plugins/model_providers/test_custom_profile.py` — new test file covering the `CustomProfile.build_api_kwargs_extras()` wire shape, following the pattern in `test_deepseek_profile.py`.

## How to Test

1. Configure Hermes with a local Ollama endpoint running a thinking-capable model (e.g. `qwen3.6:35b`)
2. Run `hermes` and set `/reasoning none`
3. Send any message — observe that the response arrives in ~2-5s with `out=` token count matching only the answer (no reasoning chain)
4. Compare with `/reasoning medium` — response takes 30-60s+ with significantly higher `out=` token count
5. Run `pytest tests/plugins/model_providers/test_custom_profile.py -v` — all 15 tests pass

## Checklist

### Code
- [x] I've read the [[Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [[Conventional Commits](https://www.conventionalcommits.org/)](https://www.conventionalcommits.org/)
- [x] I searched for [[existing PRs](https://github.com/NousResearch/hermes-agent/pulls)](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu 24.04 (WSL2)

### Documentation & Housekeeping
- [x] I've updated relevant documentation — N/A
- [x] I've updated `cli-config.yaml.example` — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A
- [x] I've considered cross-platform impact — fix is provider-level, platform-agnostic
- [x] I've updated tool descriptions/schemas — N/A

## Screenshots / Logs

**Without fix** (`reasoning_effort: none` silently ignored — model thinks):
```
API call #1: model=qwen3.6:35b in=15964 out=26 latency=68.9s
```

**With fix** (thinking correctly disabled):
```
API call #1: model=qwen3.6:35b in=19018 out=8 latency=47.3s
```

Direct Ollama API verification (`test_ollama_thinking.py`):
```
Default (no reasoning_effort) — Time: 17.3s, Thinking: YES (589 chars)
reasoning_effort="none"       — Time:  1.6s, Thinking: NO
think=False (extra_body)      — Time: 21.7s, Thinking: YES (ignored as expected)
reasoning_effort="low"        — Time: 14.3s, Thinking: YES (low effort, not disabled)
```