### PR TITLE
fix(gateway): anchor cwd to HERMES_HOME on startup

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2505,6 +2505,15 @@ def run_gateway(verbose: int = 0, quiet: bool = False, replace: bool = False):
     """
     sys.path.insert(0, str(PROJECT_ROOT))
 
+    # Anchor cwd to HERMES_HOME so context-file discovery (AGENTS.md, etc.)
+    # always resolves against the correct profile directory rather than the
+    # incidental working directory of whatever shell launched the gateway.
+    try:
+        from hermes_constants import get_hermes_home
+        os.chdir(get_hermes_home())
+    except Exception:
+        pass  # best-effort; don't block gateway startup
+
     # Refresh the systemd unit definition on every boot so that restart
     # settings (RestartSec, StartLimitIntervalSec, etc.) stay current even
     # when the process was respawned via exit-code-75 (stale-code or


### PR DESCRIPTION
## Problem

When running multiple Hermes profiles (via `HERMES_HOME`), the gateway
inherits the **incidental working directory** of whatever shell launched
it.  Context-file discovery (`AGENTS.md`, `.hermes.md`, `.cursorrules`,
etc.) resolves against `os.getcwd()`, not `HERMES_HOME`.  This causes
multi-profile setups to load the wrong project context and agent identity.

**Concrete example:**  A profile with `HERMES_HOME=~/.hermes-lead`
launched from `~/.openclaw/workspace/` picked up that directory's
`AGENTS.md` (a different agent persona) instead of its own.

## Fix

Call `os.chdir(get_hermes_home())` at the start of `run_gateway()`, before
any context-file loading happens.  Best-effort: a failure does not block
gateway startup.

## Testing

- Verified on a live multi-profile setup: after the fix, `lsof -p <pid> grep cwd`
  confirms the gateway cwd matches HERMES_HOME regardless of launch directory.
- Existing single-profile setups are unaffected (HERMES_HOME is typically the
  default `~/.hermes` which is already the expected cwd).
