### PR TITLE
fix(model_metadata): multiply n_ctx*total_slots in llama.cpp /v1/props (#29802)

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -769,9 +769,56 @@ def fetch_endpoint_model_metadata(
                         props = props_resp.json()
                         gen_settings = props.get("default_generation_settings", {})
                         n_ctx = gen_settings.get("n_ctx")
-                        model_alias = props.get("model_alias", "")
-                        if n_ctx and model_alias and model_alias in cache:
-                            cache[model_alias]["context_length"] = n_ctx
+                        # llama.cpp PR ggml-org/llama.cpp#10704 (Dec 2024,
+                        # "server: various fixes") moved ``n_ctx`` from
+                        # ``slot_params`` to ``server_slot``. Since then,
+                        # ``default_generation_settings.n_ctx`` is the
+                        # **per-slot** context budget — i.e. ``-c`` divided
+                        # by ``--parallel`` (which now defaults to ``-1`` /
+                        # auto and is frequently >= 2 on modern builds).
+                        #
+                        # The total context the user asked for with ``-c``
+                        # — and the budget a single request can actually
+                        # use when ``--kv-unified`` is on (the default
+                        # when ``--parallel`` is auto) — is
+                        # ``n_ctx * total_slots``. Without this multiplier
+                        # the TUI showed exactly half of ``-c`` on every
+                        # auto-parallel llama-server, which the user reads
+                        # as a context-display regression
+                        # (#29802: "TUI Context Display shows exactly half").
+                        total_slots = props.get("total_slots", 1)
+                        if (
+                            isinstance(n_ctx, int)
+                            and isinstance(total_slots, int)
+                            and total_slots > 1
+                        ):
+                            n_ctx = n_ctx * total_slots
+                        # Cache update: prefer the documented ``model_alias``
+                        # match, then ``model_path`` basename (modern
+                        # llama.cpp replaced ``model_alias`` with
+                        # ``model_path``), then — when the cache contains
+                        # exactly one model entry (the common llama.cpp
+                        # case: one model per server) — update that lone
+                        # entry. Without these fallbacks a missing alias
+                        # silently dropped the props correction and the
+                        # cache retained the bogus per-slot value from
+                        # ``/v1/models``.
+                        if n_ctx:
+                            target_keys: list[str] = []
+                            model_alias = props.get("model_alias", "")
+                            if model_alias and model_alias in cache:
+                                target_keys.append(model_alias)
+                            else:
+                                model_path = props.get("model_path", "")
+                                if isinstance(model_path, str) and model_path:
+                                    import os as _os
+                                    basename = _os.path.basename(model_path)
+                                    if basename and basename in cache:
+                                        target_keys.append(basename)
+                                if not target_keys and len(cache) == 1:
+                                    target_keys.append(next(iter(cache)))
+                            for key in target_keys:
+                                cache[key]["context_length"] = n_ctx
                 except Exception:
                     pass
 

--- a/tests/agent/test_model_metadata_llamacpp_props.py
+++ b/tests/agent/test_model_metadata_llamacpp_props.py
@@ -1,0 +1,485 @@
+"""Regression coverage for #29802 — the TUI context display showed
+exactly half of the value the user passed via ``llama-server -c``.
+
+Root cause. llama.cpp PR ggml-org/llama.cpp#10704 ("server: various
+fixes", Dec 2024) moved slot members including ``n_ctx`` from
+``slot_params`` to ``server_slot``. Since that refactor,
+``/v1/props.default_generation_settings.n_ctx`` is the **per-slot**
+budget — i.e. ``-c`` divided by ``--parallel``. Modern llama-server
+defaults ``--parallel -1`` (auto) which picks ``total_slots >= 2`` on
+common single-GPU setups, halving (or more) the reported value.
+
+Without the fix in ``fetch_endpoint_model_metadata`` we wrote that
+per-slot value verbatim into the context-length cache and every
+downstream consumer (TUI indicator, max-context guard, compression
+trigger) under-reported the context window.
+
+Pinned here:
+
+* ``TestLlamaCppPropsMultipliesBySlots`` — wire-level: parallel=2,
+  parallel=4, and the auto-1 no-op case all yield the correct total.
+* ``TestLlamaCppPropsCacheTargeting`` — robust cache-key resolution
+  via ``model_alias`` (legacy) → ``model_path`` basename (modern)
+  → lone-cache-entry fallback (one model per llama-server is the
+  normal case). Without these fallbacks a missing alias silently
+  dropped the props correction.
+* ``TestLlamaCppPropsDegrades`` — props endpoint 404, malformed
+  payload, network exception all leave the original ``/v1/models``
+  context_length in place; we never make the situation worse.
+* ``TestLlamaCppNonLlamacppUntouched`` — non-llama.cpp endpoints
+  (LM Studio, vLLM, plain custom OpenAI-compat) don't get props
+  multiplication.
+* ``TestSourceGuardrail`` — static asserts so a future refactor
+  can't quietly drop the multiplier or the cache-targeting fallbacks.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _resp(ok: bool = True, payload=None, status_code: int = 200):
+    r = MagicMock()
+    r.ok = ok
+    r.status_code = status_code
+    r.raise_for_status.return_value = None
+    r.json.return_value = payload if payload is not None else {}
+    r.text = ""
+    return r
+
+
+def _clear_caches():
+    from agent.model_metadata import (
+        _endpoint_model_metadata_cache,
+        _endpoint_model_metadata_cache_time,
+    )
+    _endpoint_model_metadata_cache.clear()
+    _endpoint_model_metadata_cache_time.clear()
+
+
+def _make_models_payload(model_id: str, owned_by: str = "llamacpp",
+                         baseline_ctx: int | None = None):
+    entry = {"id": model_id, "owned_by": owned_by}
+    if baseline_ctx is not None:
+        entry["context_length"] = baseline_ctx
+    return {"data": [entry]}
+
+
+def _wire_requests(monkeypatch, *, models_payload, props_payload,
+                   props_ok: bool = True, props_raises: bool = False):
+    """Wire ``requests.get`` so that ``/v1/models`` returns
+    ``models_payload`` and ``/v1/props`` returns ``props_payload``.
+
+    Set ``props_raises=True`` to make the props call raise an
+    exception instead of returning a response.
+    """
+    def fake_get(url, **kw):
+        if url.endswith("/v1/models") or url.endswith("/models"):
+            return _resp(True, models_payload)
+        if url.endswith("/v1/props") or url.endswith("/props"):
+            if props_raises:
+                raise ConnectionError("simulated props failure")
+            return _resp(props_ok, props_payload, status_code=200 if props_ok else 500)
+        return _resp(False, status_code=404)
+
+    monkeypatch.setattr("agent.model_metadata.requests.get", fake_get)
+
+
+# ---------------------------------------------------------------------------
+# Wire-level: n_ctx * total_slots
+# ---------------------------------------------------------------------------
+
+
+class TestLlamaCppPropsMultipliesBySlots:
+    """The exact-half bug: when ``total_slots > 1`` the per-slot ``n_ctx``
+    must be multiplied so the cached context length equals what ``-c``
+    was set to."""
+
+    def test_reporter_repro_parallel_2_yields_full_minus_c(self, monkeypatch):
+        """Reporter's exact scenario: ``-c 131072`` with default
+        ``--parallel -1`` settling on 2 slots reported 65.5K — the
+        fix must report 131072."""
+        _clear_caches()
+        models = _make_models_payload("llama-3.1-8b-instruct",
+                                      baseline_ctx=65536)
+        props = {
+            "default_generation_settings": {"n_ctx": 65536},
+            "total_slots": 2,
+            "model_path": "/opt/models/llama-3.1-8b-instruct.q4_k_m.gguf",
+        }
+        _wire_requests(monkeypatch, models_payload=models,
+                       props_payload=props)
+
+        with patch("agent.model_metadata.is_local_endpoint", return_value=True), \
+             patch("agent.model_metadata.detect_local_server_type",
+                   return_value="llamacpp"):
+            from agent.model_metadata import fetch_endpoint_model_metadata
+            result = fetch_endpoint_model_metadata(
+                "http://localhost:8080/v1", force_refresh=True
+            )
+        ctx = result["llama-3.1-8b-instruct"]["context_length"]
+        assert ctx == 131_072, (
+            f"Expected 131072 (65536 * 2 slots = -c 131072), got {ctx}. "
+            "Regression: #29802 — TUI displayed half the configured -c."
+        )
+
+    def test_parallel_4_multiplies_by_4(self, monkeypatch):
+        _clear_caches()
+        models = _make_models_payload("model-x", baseline_ctx=8192)
+        props = {
+            "default_generation_settings": {"n_ctx": 8192},
+            "total_slots": 4,
+            "model_path": "/models/model-x.gguf",
+        }
+        _wire_requests(monkeypatch, models_payload=models,
+                       props_payload=props)
+
+        with patch("agent.model_metadata.is_local_endpoint", return_value=True), \
+             patch("agent.model_metadata.detect_local_server_type",
+                   return_value="llamacpp"):
+            from agent.model_metadata import fetch_endpoint_model_metadata
+            result = fetch_endpoint_model_metadata(
+                "http://localhost:8080/v1", force_refresh=True
+            )
+        assert result["model-x"]["context_length"] == 32_768
+
+    def test_parallel_1_is_noop_modern_value_passes_through(self, monkeypatch):
+        """When the user runs ``--parallel 1`` the per-slot ``n_ctx``
+        already equals total ``-c`` — multiplication must be a no-op,
+        not 1×1=1 confused arithmetic."""
+        _clear_caches()
+        models = _make_models_payload("model-y", baseline_ctx=16384)
+        props = {
+            "default_generation_settings": {"n_ctx": 131_072},
+            "total_slots": 1,
+            "model_path": "/models/model-y.gguf",
+        }
+        _wire_requests(monkeypatch, models_payload=models,
+                       props_payload=props)
+
+        with patch("agent.model_metadata.is_local_endpoint", return_value=True), \
+             patch("agent.model_metadata.detect_local_server_type",
+                   return_value="llamacpp"):
+            from agent.model_metadata import fetch_endpoint_model_metadata
+            result = fetch_endpoint_model_metadata(
+                "http://localhost:8080/v1", force_refresh=True
+            )
+        assert result["model-y"]["context_length"] == 131_072
+
+    def test_missing_total_slots_assumes_1(self, monkeypatch):
+        """Older / minimal llama.cpp builds omit ``total_slots``. The
+        fix must treat that as ``total_slots = 1`` (the documented
+        default before the auto-parallel change) so the value passes
+        through unchanged — never accidentally zero or doubled."""
+        _clear_caches()
+        models = _make_models_payload("model-z", baseline_ctx=8192)
+        props = {
+            "default_generation_settings": {"n_ctx": 65_536},
+            "model_path": "/models/model-z.gguf",
+        }
+        _wire_requests(monkeypatch, models_payload=models,
+                       props_payload=props)
+
+        with patch("agent.model_metadata.is_local_endpoint", return_value=True), \
+             patch("agent.model_metadata.detect_local_server_type",
+                   return_value="llamacpp"):
+            from agent.model_metadata import fetch_endpoint_model_metadata
+            result = fetch_endpoint_model_metadata(
+                "http://localhost:8080/v1", force_refresh=True
+            )
+        assert result["model-z"]["context_length"] == 65_536
+
+    def test_zero_total_slots_does_not_zero_out(self, monkeypatch):
+        """Defensive: a buggy ``total_slots: 0`` payload must NOT
+        produce a 0-token context (which would crash the agent on
+        startup); the multiplication is gated on ``> 1``."""
+        _clear_caches()
+        models = _make_models_payload("model-q", baseline_ctx=16_000)
+        props = {
+            "default_generation_settings": {"n_ctx": 16_384},
+            "total_slots": 0,
+            "model_path": "/models/model-q.gguf",
+        }
+        _wire_requests(monkeypatch, models_payload=models,
+                       props_payload=props)
+
+        with patch("agent.model_metadata.is_local_endpoint", return_value=True), \
+             patch("agent.model_metadata.detect_local_server_type",
+                   return_value="llamacpp"):
+            from agent.model_metadata import fetch_endpoint_model_metadata
+            result = fetch_endpoint_model_metadata(
+                "http://localhost:8080/v1", force_refresh=True
+            )
+        # n_ctx passes through (16384) — no zero-multiplication
+        assert result["model-q"]["context_length"] == 16_384
+
+    def test_non_int_total_slots_passes_n_ctx_through(self, monkeypatch):
+        """Defensive: a malformed ``total_slots`` (string, float,
+        null) must not corrupt the n_ctx with bad arithmetic."""
+        _clear_caches()
+        models = _make_models_payload("model-w", baseline_ctx=8192)
+        props = {
+            "default_generation_settings": {"n_ctx": 32_768},
+            "total_slots": "garbage",
+            "model_path": "/models/model-w.gguf",
+        }
+        _wire_requests(monkeypatch, models_payload=models,
+                       props_payload=props)
+
+        with patch("agent.model_metadata.is_local_endpoint", return_value=True), \
+             patch("agent.model_metadata.detect_local_server_type",
+                   return_value="llamacpp"):
+            from agent.model_metadata import fetch_endpoint_model_metadata
+            result = fetch_endpoint_model_metadata(
+                "http://localhost:8080/v1", force_refresh=True
+            )
+        assert result["model-w"]["context_length"] == 32_768
+
+
+# ---------------------------------------------------------------------------
+# Cache-key targeting — the fallback chain
+# ---------------------------------------------------------------------------
+
+
+class TestLlamaCppPropsCacheTargeting:
+    """The original code only updated the cache when ``props.model_alias``
+    happened to match a cache key. On modern llama.cpp (which uses
+    ``model_path`` instead) the props correction silently dropped on
+    every release that omitted the legacy alias field — masking the
+    half-context bug as "we just never override the /v1/models value"
+    in some setups and "we override it but with the wrong number" in
+    others. The fix layers three fallbacks."""
+
+    def test_legacy_model_alias_matches_cache(self, monkeypatch):
+        """The original happy path: cache has an entry keyed by the
+        model_alias, and the props correction lands on it."""
+        _clear_caches()
+        models = _make_models_payload("legacy-alias", baseline_ctx=8192)
+        props = {
+            "default_generation_settings": {"n_ctx": 32_768},
+            "total_slots": 2,
+            "model_alias": "legacy-alias",
+        }
+        _wire_requests(monkeypatch, models_payload=models,
+                       props_payload=props)
+
+        with patch("agent.model_metadata.is_local_endpoint", return_value=True), \
+             patch("agent.model_metadata.detect_local_server_type",
+                   return_value="llamacpp"):
+            from agent.model_metadata import fetch_endpoint_model_metadata
+            result = fetch_endpoint_model_metadata(
+                "http://localhost:8080/v1", force_refresh=True
+            )
+        assert result["legacy-alias"]["context_length"] == 65_536
+
+    def test_modern_model_path_basename_matches_cache(self, monkeypatch):
+        """When ``model_alias`` is absent but ``model_path`` is set
+        (the modern schema), the basename of model_path drives the
+        cache-key match."""
+        _clear_caches()
+        # llama.cpp commonly registers the model under the gguf file
+        # basename in /v1/models.
+        models = _make_models_payload("phi-3-mini-q4.gguf",
+                                      baseline_ctx=2048)
+        props = {
+            "default_generation_settings": {"n_ctx": 2048},
+            "total_slots": 2,
+            "model_path": "/srv/models/phi-3-mini-q4.gguf",
+        }
+        _wire_requests(monkeypatch, models_payload=models,
+                       props_payload=props)
+
+        with patch("agent.model_metadata.is_local_endpoint", return_value=True), \
+             patch("agent.model_metadata.detect_local_server_type",
+                   return_value="llamacpp"):
+            from agent.model_metadata import fetch_endpoint_model_metadata
+            result = fetch_endpoint_model_metadata(
+                "http://localhost:8080/v1", force_refresh=True
+            )
+        assert result["phi-3-mini-q4.gguf"]["context_length"] == 4096
+
+    def test_lone_entry_fallback_when_no_alias_or_path_match(
+        self, monkeypatch
+    ):
+        """When neither ``model_alias`` nor ``model_path`` basename
+        matches any cache key (e.g. the model is listed in /v1/models
+        under a totally different id), but the cache has exactly one
+        model entry, that lone entry gets the props correction —
+        unambiguously, since llama-server serves one model per
+        process."""
+        _clear_caches()
+        models = _make_models_payload("arbitrary-id-from-models-endpoint",
+                                      baseline_ctx=8192)
+        props = {
+            "default_generation_settings": {"n_ctx": 16_384},
+            "total_slots": 4,
+        }  # no alias, no model_path
+        _wire_requests(monkeypatch, models_payload=models,
+                       props_payload=props)
+
+        with patch("agent.model_metadata.is_local_endpoint", return_value=True), \
+             patch("agent.model_metadata.detect_local_server_type",
+                   return_value="llamacpp"):
+            from agent.model_metadata import fetch_endpoint_model_metadata
+            result = fetch_endpoint_model_metadata(
+                "http://localhost:8080/v1", force_refresh=True
+            )
+        ctx = result["arbitrary-id-from-models-endpoint"]["context_length"]
+        assert ctx == 65_536, (
+            "Lone-cache-entry fallback dropped — modern llama.cpp builds "
+            "that omit both model_alias and model_path silently keep the "
+            "wrong per-slot value."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Graceful degradation
+# ---------------------------------------------------------------------------
+
+
+class TestLlamaCppPropsDegrades:
+    """When ``/v1/props`` is unreachable / malformed, the props
+    correction must be silently skipped — never raise, never corrupt
+    the cache."""
+
+    def test_props_404_leaves_baseline_intact(self, monkeypatch):
+        _clear_caches()
+        models = _make_models_payload("m", baseline_ctx=65_536)
+
+        def fake_get(url, **kw):
+            if url.endswith("/v1/models") or url.endswith("/models"):
+                return _resp(True, models)
+            return _resp(False, status_code=404)
+
+        monkeypatch.setattr("agent.model_metadata.requests.get", fake_get)
+        with patch("agent.model_metadata.is_local_endpoint", return_value=True), \
+             patch("agent.model_metadata.detect_local_server_type",
+                   return_value="llamacpp"):
+            from agent.model_metadata import fetch_endpoint_model_metadata
+            result = fetch_endpoint_model_metadata(
+                "http://localhost:8080/v1", force_refresh=True
+            )
+        # Baseline from /v1/models is preserved.
+        assert result["m"]["context_length"] == 65_536
+
+    def test_props_raises_does_not_propagate(self, monkeypatch):
+        _clear_caches()
+        models = _make_models_payload("m", baseline_ctx=8192)
+        _wire_requests(monkeypatch, models_payload=models,
+                       props_payload={}, props_raises=True)
+        with patch("agent.model_metadata.is_local_endpoint", return_value=True), \
+             patch("agent.model_metadata.detect_local_server_type",
+                   return_value="llamacpp"):
+            from agent.model_metadata import fetch_endpoint_model_metadata
+            result = fetch_endpoint_model_metadata(
+                "http://localhost:8080/v1", force_refresh=True
+            )
+        # No crash; baseline preserved.
+        assert result["m"]["context_length"] == 8192
+
+    def test_props_payload_missing_n_ctx_is_skipped(self, monkeypatch):
+        _clear_caches()
+        models = _make_models_payload("m", baseline_ctx=8192)
+        props = {
+            "default_generation_settings": {},  # no n_ctx
+            "total_slots": 2,
+            "model_alias": "m",
+        }
+        _wire_requests(monkeypatch, models_payload=models,
+                       props_payload=props)
+        with patch("agent.model_metadata.is_local_endpoint", return_value=True), \
+             patch("agent.model_metadata.detect_local_server_type",
+                   return_value="llamacpp"):
+            from agent.model_metadata import fetch_endpoint_model_metadata
+            result = fetch_endpoint_model_metadata(
+                "http://localhost:8080/v1", force_refresh=True
+            )
+        assert result["m"]["context_length"] == 8192
+
+
+# ---------------------------------------------------------------------------
+# Non-llama.cpp endpoints aren't affected
+# ---------------------------------------------------------------------------
+
+
+class TestLlamaCppNonLlamacppUntouched:
+    """The /props code path is gated on ``owned_by == "llamacpp"``.
+    Plain OpenAI-compatible / vLLM / etc. servers must not even try
+    /v1/props — and definitely must not get any multiplication."""
+
+    def test_vllm_owned_by_path_skips_props(self, monkeypatch):
+        _clear_caches()
+        models_payload = {
+            "data": [{
+                "id": "qwen2.5-coder",
+                "owned_by": "vllm",
+                "max_model_len": 65_536,
+            }]
+        }
+        # Wire props to a sentinel that, if read, would clobber the
+        # answer to the wrong value (16). If the test still passes
+        # with 65_536, the props branch was correctly skipped.
+        props_sentinel = {
+            "default_generation_settings": {"n_ctx": 16},
+            "total_slots": 2,
+        }
+        _wire_requests(monkeypatch, models_payload=models_payload,
+                       props_payload=props_sentinel)
+        with patch("agent.model_metadata.is_local_endpoint", return_value=True), \
+             patch("agent.model_metadata.detect_local_server_type",
+                   return_value="vllm"):
+            from agent.model_metadata import fetch_endpoint_model_metadata
+            result = fetch_endpoint_model_metadata(
+                "http://localhost:8000/v1", force_refresh=True
+            )
+        assert result["qwen2.5-coder"]["context_length"] == 65_536
+
+
+# ---------------------------------------------------------------------------
+# Source guardrail — prevent silent regression
+# ---------------------------------------------------------------------------
+
+
+class TestSourceGuardrail:
+    @pytest.fixture
+    def source(self) -> str:
+        from pathlib import Path
+        return (Path(__file__).resolve().parents[2]
+                / "agent" / "model_metadata.py").read_text(encoding="utf-8")
+
+    def test_multiplies_n_ctx_by_total_slots(self, source):
+        assert "n_ctx * total_slots" in source, (
+            "The #29802 fix must multiply ``n_ctx`` by ``total_slots`` "
+            "in the llama.cpp /props branch."
+        )
+
+    def test_multiplier_guarded_on_total_slots_greater_than_one(self, source):
+        assert "total_slots > 1" in source, (
+            "The multiplier must be gated on ``total_slots > 1`` so "
+            "single-slot servers and malformed payloads pass n_ctx "
+            "through unchanged."
+        )
+
+    def test_model_path_basename_fallback_present(self, source):
+        assert "model_path" in source and "basename" in source, (
+            "Modern llama.cpp /v1/props uses ``model_path`` instead of "
+            "``model_alias``; the cache-key fallback must use its basename."
+        )
+
+    def test_lone_cache_entry_fallback_present(self, source):
+        assert "len(cache) == 1" in source, (
+            "The lone-cache-entry fallback is the last line of defence "
+            "when llama.cpp omits both ``model_alias`` and ``model_path`` "
+            "— without it the props correction silently drops on minimal "
+            "build configurations."
+        )
+
+    def test_issue_number_referenced_in_comment(self, source):
+        assert "#29802" in source


### PR DESCRIPTION
## What does this PR do?

Fixes [#29802](https://github.com/NousResearch/hermes-agent/issues/29802) — when a user runs `llama-server -c 131072` (128K), the TUI context indicator showed exactly `65.5K`. The reporter's arithmetic was correct: `131072 / 2 = 65536`.

**Root cause.** llama.cpp PR [ggml-org/llama.cpp#10704](https://github.com/ggerganov/llama.cpp/pull/10704) ("server: various fixes", Dec 2024) moved slot members including `n_ctx` from `slot_params` to `server_slot`. Since that refactor:

```
/v1/props.default_generation_settings.n_ctx == per-slot KV budget
                                            == -c / --parallel
```

Modern `llama-server` defaults `--parallel -1` (auto), which typically picks `total_slots = 2` on a single GPU. The total `-c` value is therefore `n_ctx * total_slots`.

Hermes' `fetch_endpoint_model_metadata` was reading `gen_settings.n_ctx` verbatim and writing it into the context-length cache, so every downstream consumer — TUI indicator, context guard, compression trigger — under-reported the window by the slot divisor.

Schema reference (from `llama.cpp/tools/server/README.md`):

```json
{
  "default_generation_settings": { "id": 0, "n_ctx": 1024, ... },
  "total_slots": 1,
  "model_path": "../models/Meta-Llama-3.1-8B-Instruct-Q4_K_M.gguf",
  ...
}
```

**Fix.** In `agent/model_metadata.py`'s llama.cpp `/v1/props` branch, after reading `n_ctx`:

```python
total_slots = props.get("total_slots", 1)
if (
    isinstance(n_ctx, int)
    and isinstance(total_slots, int)
    and total_slots > 1
):
    n_ctx = n_ctx * total_slots
```

With `--kv-unified` (default since `--parallel` is auto) all slots share one KV buffer, so a single request can actually use the full pool — the multiplied value is the correct effective budget. For `total_slots == 1` the multiplication is a no-op; for malformed payloads (`0`, `"garbage"`, missing) `n_ctx` passes through unchanged.

**Cache-targeting robustness, while we're here.** The original code only updated the cache when `props.model_alias` happened to match a cache key. Modern llama.cpp `/v1/props` doesn't always include `model_alias` (the documented schema lists `model_path` instead), so the props correction silently dropped on builds that omit the legacy alias. Added a three-tier fallback:

1. `model_alias` match (legacy, current behavior)
2. `model_path` basename match (modern schema)
3. Lone-cache-entry update (llama.cpp serves one model per process — when `/v1/models` registered exactly one entry, that's unambiguously ours)

## Related Issue

Closes #29802 — *TUI Context Display shows exactly half of the actual context size (Regression)*.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/model_metadata.py`
  - After reading `default_generation_settings.n_ctx` from llama.cpp's `/v1/props`, multiply by `total_slots` when `total_slots > 1` (gated on `isinstance(int)` for both operands so a malformed `0` / `"garbage"` / missing payload can never corrupt the cached context).
  - Replace the single `model_alias`-only cache-key lookup with a three-tier fallback chain: `model_alias` → `os.path.basename(model_path)` → lone-cache-entry update. Without these fallbacks, modern llama.cpp builds that omit the legacy alias field silently kept the wrong per-slot value.
  - Heavily documented in the existing comment style — explains why the multiplier exists, names the upstream PR that introduced the per-slot semantics, and links the issue number.

- `tests/agent/test_model_metadata_llamacpp_props.py` (new, +485 lines, **18 cases** across five classes):
  - `TestLlamaCppPropsMultipliesBySlots` (6) — the reporter's exact `-c 131072 / parallel=2 → 131072` scenario, plus `parallel=4`, `parallel=1` no-op, missing `total_slots` defaults to 1, `total_slots: 0`, and `total_slots: "garbage"` defensive passes.
  - `TestLlamaCppPropsCacheTargeting` (3) — exercises each of the three cache-key tiers.
  - `TestLlamaCppPropsDegrades` (3) — props 404 / props raises / props missing `n_ctx` all leave the `/v1/models` baseline intact.
  - `TestLlamaCppNonLlamacppUntouched` (1) — vLLM `/v1/models` flow doesn't even enter the /props branch (uses a sentinel `n_ctx=16` that would corrupt the answer if the branch were wrongly entered).
  - `TestSourceGuardrail` (5) — static asserts on `agent/model_metadata.py` so a future refactor can't silently drop the multiplier, the `> 1` guard, the `model_path` basename fallback, the `len(cache) == 1` lone-entry fallback, or the `#29802` comment.

## How to Test

1. Check out the branch and activate the venv:
   ```
   git fetch origin fix/29802-tui-context-half-llamacpp
   git checkout fix/29802-tui-context-half-llamacpp
   source .venv/bin/activate   # or: python3 -m venv .venv && source .venv/bin/activate && pip install -e ".[all,dev]"
   ```
2. Run the new regression file on its own:
   ```
   scripts/run_tests.sh tests/agent/test_model_metadata_llamacpp_props.py
   ```
   Expected: **18 passed**.
3. Confirm no regression across the broader model-metadata suite:
   ```
   scripts/run_tests.sh tests/agent/test_model_metadata_llamacpp_props.py tests/agent/test_model_metadata_local_ctx.py tests/agent/test_model_metadata.py tests/hermes_cli/test_custom_provider_context_length.py tests/test_ollama_num_ctx.py
   ```
   Expected: **161 passed**.
4. Reproduce against a real llama-server (matches the issue setup):
   - Start: `llama-server -m <model>.gguf -c 131072` (do **not** pass `--parallel`).
   - Confirm `curl http://localhost:8080/v1/props | jq '{total_slots, n_ctx: .default_generation_settings.n_ctx}'` reports `total_slots > 1` and `n_ctx < 131072`.
   - Launch Hermes against the server. The context indicator now reads `0/128K` (pre-fix: `0/65.5K`).
   - As a control, restart `llama-server` with `--parallel 1` — indicator stays `0/128K` (was already correct in this branch).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(model_metadata): …` and `test(model_metadata): …`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run `scripts/run_tests.sh tests/agent/test_model_metadata_llamacpp_props.py tests/agent/test_model_metadata_local_ctx.py tests/agent/test_model_metadata.py tests/hermes_cli/test_custom_provider_context_length.py tests/test_ollama_num_ctx.py` and all 161 tests pass
- [x] I've added tests for my changes (18 new regression cases — per-slot multiplier, cache-key fallback chain, graceful degradation, non-llama.cpp isolation, source guardrail)
- [x] I've tested on my platform: macOS 15.2 (Darwin 24.6.0), Python 3.12; llama.cpp behaviour validated via faithful `/v1/props` mocks and the documented schema from `llama.cpp/tools/server/README.md`

### Documentation & Housekeeping

- [x] I've updated relevant documentation — the source-of-truth comment in `agent/model_metadata.py` explains the per-slot semantics and names the upstream PR ([ggml-org/llama.cpp#10704](https://github.com/ggerganov/llama.cpp/pull/10704)). No reference-docs update needed (this is a transparent bugfix; behaviour now matches what the existing TUI docs already imply)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure data-layer fix; behaviour identical across OSes
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

```
$ scripts/run_tests.sh tests/agent/test_model_metadata_llamacpp_props.py
1 files, 18 tests passed, 0 failed (100% complete) in 0.3s

$ scripts/run_tests.sh tests/agent/test_model_metadata_llamacpp_props.py tests/agent/test_model_metadata_local_ctx.py tests/agent/test_model_metadata.py tests/hermes_cli/test_custom_provider_context_length.py tests/test_ollama_num_ctx.py
5 files, 161 tests passed, 0 failed (100% complete) in 2.3s
```
