### PR TITLE
fix: prioritize active task after gateway resume

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -16679,8 +16679,11 @@ class GatewayRunner:
                     f"[System note: Your previous turn in this session was interrupted "
                     f"by {_reason_phrase}. The conversation history below is intact. "
                     f"If it contains unfinished tool result(s), process them first and "
-                    f"summarize what was accomplished, then address the user's new "
-                    f"message below.]\n\n"
+                    f"summarize what was accomplished. If the history contains a "
+                    f"preserved active task list, treat any in_progress item as the "
+                    f"current mission and resume or verify it before reacting to older "
+                    f"conversation asks, unless the newest user message explicitly "
+                    f"changes or cancels it. Then address the user's new message below.]\n\n"
                     + message
                 )
             elif _has_fresh_tool_tail:

--- a/tests/gateway/test_restart_resume_pending.py
+++ b/tests/gateway/test_restart_resume_pending.py
@@ -156,8 +156,11 @@ def _simulate_note_injection(
             f"[System note: Your previous turn in this session was interrupted "
             f"by {reason_phrase}. The conversation history below is intact. "
             f"If it contains unfinished tool result(s), process them first and "
-            f"summarize what was accomplished, then address the user's new "
-            f"message below.]\n\n"
+            f"summarize what was accomplished. If the history contains a "
+            f"preserved active task list, treat any in_progress item as the "
+            f"current mission and resume or verify it before reacting to older "
+            f"conversation asks, unless the newest user message explicitly "
+            f"changes or cancels it. Then address the user's new message below.]\n\n"
             + message
         )
     elif has_fresh_tool_tail:
@@ -442,6 +445,41 @@ class TestResumePendingSystemNote:
         assert "[System note:" in result
         assert "gateway restart" in result
         assert "what happened?" in result
+
+    def test_resume_pending_note_prioritizes_preserved_active_task_list(self):
+        """A restart after context compression must resume the active task.
+
+        Regression for the Discord dogfood failure: the transcript contained a
+        preserved todo list with an in-progress engineering task, but the next
+        turn answered an older inbox ask instead.  The recovery note must tell
+        the model that the preserved active task list is authoritative unless
+        the newest user message explicitly changes or cancels it.
+        """
+        entry = self._pending_entry(reason="restart_timeout")
+        result = _simulate_note_injection(
+            history=[
+                {
+                    "role": "user",
+                    "content": "Any news in the inboxes?",
+                    "timestamp": time.time() - 30,
+                },
+                {
+                    "role": "user",
+                    "content": (
+                        "[Your active task list was preserved across context compression]\n"
+                        "- [>] verify. Run targeted tests and runtime smoke checks (in_progress)\n"
+                        "- [ ] commit. Commit verified repo changes (pending)"
+                    ),
+                    "timestamp": time.time() - 5,
+                },
+            ],
+            user_message="Dude why the compaction issue?",
+            resume_entry=entry,
+        )
+        assert "preserved active task list" in result
+        assert "current mission" in result
+        assert "older" in result
+        assert "unless the newest user message explicitly changes or cancels it" in result
 
     def test_resume_pending_shutdown_note_mentions_shutdown(self):
         entry = self._pending_entry(reason="shutdown_timeout")

--- a/tests/tools/test_todo_tool.py
+++ b/tests/tools/test_todo_tool.py
@@ -71,6 +71,27 @@ class TestFormatForInjection:
         assert "Working" in text
         assert "context compression" in text.lower()
 
+    def test_injection_tells_model_to_resume_in_progress_task_first(self):
+        store = TodoStore()
+        store.write([
+            {"id": "verify", "content": "Run checks", "status": "in_progress"},
+            {"id": "commit", "content": "Commit changes", "status": "pending"},
+        ])
+        text = store.format_for_injection()
+        assert "current active task" in text
+        assert "resume" in text
+        assert "unless the newest user message explicitly changes or cancels it" in text
+
+    def test_injection_without_in_progress_does_not_reference_marker(self):
+        store = TodoStore()
+        store.write([
+            {"id": "commit", "content": "Commit changes", "status": "pending"},
+        ])
+        text = store.format_for_injection()
+        assert text is not None
+        assert "No item is marked in_progress" in text
+        assert "Treat the [>]" not in text
+
 
 class TestMergeMode:
     def test_update_existing_by_id(self):

--- a/tools/todo_tool.py
+++ b/tools/todo_tool.py
@@ -114,7 +114,20 @@ class TodoStore:
         if not active_items:
             return None
 
+        has_in_progress = any(item["status"] == "in_progress" for item in active_items)
         lines = ["[Your active task list was preserved across context compression]"]
+        if has_in_progress:
+            lines.append(
+                "Treat the [>] in_progress item as the current active task: "
+                "resume or verify it before older conversation asks, unless "
+                "the newest user message explicitly changes or cancels it."
+            )
+        else:
+            lines.append(
+                "No item is marked in_progress; use the pending items as next "
+                "tasks only if the newest user message does not explicitly "
+                "change or cancel them."
+            )
         for item in active_items:
             marker = markers.get(item["status"], "[?]")
             lines.append(f"- {marker} {item['id']}. {item['content']} ({item['status']})")


### PR DESCRIPTION
## Summary
- Prioritize preserved `in_progress` todos when a gateway turn resumes after restart or shutdown interruption.
- Add the same active-task priority rule to todo context-compression injection.
- Avoid misleading `[>]` guidance when only pending todos are preserved.
- Add regression tests for restart recovery and todo injection behavior.

## Verification
- `python -m py_compile gateway/run.py tools/todo_tool.py tests/gateway/test_restart_resume_pending.py tests/tools/test_todo_tool.py`
- `python -m pytest tests/tools/test_todo_tool.py tests/gateway/test_restart_resume_pending.py -q -o 'addopts='` , 80 passed
- `python -m pytest tests/gateway/test_restart_resume_pending.py tests/gateway/test_restart_drain.py tests/gateway/test_session.py tests/gateway/test_session_hygiene.py tests/tools/test_todo_tool.py -q -o 'addopts='` , 193 passed
- Static added-line scan found no secret, shell injection, eval/exec, pickle, or obvious SQL formatting patterns.
- Independent blocker review passed with no security or logic blockers.
