### PR TITLE
feat: auto-update background thread + AI-driven goal tools

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -185,6 +185,25 @@ SKILLS_GUIDANCE = (
     "Skills that aren't maintained become liabilities."
 )
 
+GOAL_GUIDANCE = (
+    "# Multi-turn goal pursuit\n"
+    "You can use `set_goal` to establish a standing goal that the system will "
+    "automatically continue working on across multiple conversation turns. "
+    "After each turn, a Judge model evaluates whether the goal is satisfied; "
+    "if not, a continuation prompt is injected and you keep working. "
+    "Use this when a task requires multiple steps — e.g. refactoring a large "
+    "codebase, conducting multi-phase research, or building a feature with "
+    "several sub-components. After setting a goal, simply continue working "
+    "normally; the system handles the rest.\n\n"
+    "Key points:\n"
+    "- Set a **specific, verifiable goal** so the Judge knows when it's done.\n"
+    "- The turn budget defaults to 20 turns; set `max_turns` higher for large tasks.\n"
+    "- Call `get_goal_status` to check progress at any time.\n"
+    "- Call `clear_goal` when the goal is no longer relevant.\n"
+    "- If you're blocked and need user input, say so — the Judge treats "
+    "this as \"done\" with a reason, so the goal pauses and the user can respond."
+)
+
 KANBAN_GUIDANCE = (
     "# Kanban task execution protocol\n"
     "You have been assigned ONE task from "

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -108,6 +108,9 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
         tool_guidance.append(SESSION_SEARCH_GUIDANCE)
     if "skill_manage" in agent.valid_tool_names:
         tool_guidance.append(SKILLS_GUIDANCE)
+    if "set_goal" in agent.valid_tool_names:
+        from agent.prompt_builder import GOAL_GUIDANCE
+        tool_guidance.append(GOAL_GUIDANCE)
     # Kanban worker/orchestrator lifecycle — only present when the
     # dispatcher spawned this process (kanban_show check_fn gates on
     # HERMES_KANBAN_TASK env var). Normal chat sessions never see

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1643,6 +1643,29 @@ class GatewayRunner:
                 self._teams_pipeline_runtime_error,
             )
 
+    def _start_auto_update_thread(self) -> None:
+        """Start the background auto-update daemon thread if enabled.
+
+        Reads the ``updates.auto_update`` and ``updates.auto_update_interval``
+        keys from config.yaml.  The thread checks for new versions and applies
+        them automatically in the background.
+        """
+        try:
+            from hermes_cli.config import load_config
+            from hermes_cli.auto_update import AutoUpdateThread, check_restart_marker
+
+            cfg = load_config()
+            _thread = AutoUpdateThread(cfg)
+            _thread.start()
+
+            # If the restart marker from a previous auto-update exists,
+            # flag a restart so the gateway can act on it.
+            if check_restart_marker():
+                self._restart_requested = True
+                logger.info("Auto-update restart marker found — restart pending")
+        except Exception as exc:
+            logger.debug("auto-update thread failed to start: %s", exc)
+
 
     def _warn_if_docker_media_delivery_is_risky(self) -> None:
         """Warn when Docker-backed gateways lack an explicit export mount.
@@ -4099,6 +4122,11 @@ class GatewayRunner:
         # destination platform's home channel, then forges a synthetic user
         # turn so the agent kicks off the new chat.
         asyncio.create_task(self._handoff_watcher())
+
+        # Start background auto-update thread — periodically checks for
+        # new versions and applies them when ``updates.auto_update``
+        # is enabled in config.yaml.
+        self._start_auto_update_thread()
 
         logger.info("Press Ctrl+C to stop")
         

--- a/hermes_cli/auto_update.py
+++ b/hermes_cli/auto_update.py
@@ -1,0 +1,237 @@
+"""Background auto-update for Hermes Agent.
+
+When ``updates.auto_update`` is enabled in config, a daemon thread
+periodically checks for newer versions (git origin/main or PyPI) and
+applies them with ``hermes update --yes``. After a successful update it
+triggers a gateway restart so the new code takes effect.
+
+The thread is started once during gateway initialisation.  CLI mode does
+not auto-update (the user runs ``hermes update`` manually).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import subprocess
+import sys
+import threading
+import time
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+# Marker file written after a successful auto-update so we don't
+# restart-loop.  Cleared after the gateway restarts.
+_RESTART_MARKER = Path(
+    os.environ.get("HERMES_HOME") or os.path.expanduser("~/.hermes"),
+) / ".auto_update_restarted"
+
+
+def _fetch_remote() -> bool:
+    """Try ``git fetch origin main``. Returns True on success."""
+    try:
+        result = subprocess.run(
+            ["git", "fetch", "origin", "main"],
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        return result.returncode == 0
+    except Exception as exc:
+        logger.debug("auto-update: git fetch failed: %s", exc)
+        return False
+
+
+def _check_behind() -> int:
+    """Return number of commits behind origin/main (0 = up-to-date)."""
+    try:
+        result = subprocess.run(
+            ["git", "rev-list", "--count", "HEAD..origin/main"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        if result.returncode == 0:
+            return int(result.stdout.strip())
+    except Exception as exc:
+        logger.debug("auto-update: rev-list failed: %s", exc)
+    return 0
+
+
+def _has_changed_pyproject() -> bool:
+    """Check if pyproject.toml or requirements changed upstream."""
+    try:
+        result = subprocess.run(
+            ["git", "diff", "--name-only", "HEAD..origin/main", "--",
+             "pyproject.toml", "uv.lock", "requirements*.txt"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        return bool(result.stdout.strip())
+    except Exception:
+        return True  # safer to assume yes on error
+
+
+def _run_update() -> bool:
+    """Run ``hermes update --yes``. Returns True if successful."""
+    hermes_bin = _find_hermes_bin()
+    if not hermes_bin:
+        return False
+    try:
+        result = subprocess.run(
+            [hermes_bin, "update", "--yes"],
+            capture_output=True,
+            text=True,
+            timeout=300,
+        )
+        if result.returncode == 0:
+            logger.info("auto-update: update applied successfully")
+            return True
+        else:
+            logger.warning(
+                "auto-update: update failed (exit %d): %s",
+                result.returncode,
+                result.stderr[-300:],
+            )
+            return False
+    except subprocess.TimeoutExpired:
+        logger.warning("auto-update: update timed out after 300s")
+        return False
+    except Exception as exc:
+        logger.warning("auto-update: update exception: %s", exc)
+        return False
+
+
+def _find_hermes_bin() -> str | None:
+    """Locate the ``hermes`` binary."""
+    import shutil
+    return shutil.which("hermes") or os.environ.get("HERMES_BIN")
+
+
+def _schedule_gateway_restart() -> None:
+    """Write the restart marker so the gateway runner knows to restart."""
+    try:
+        _RESTART_MARKER.parent.mkdir(parents=True, exist_ok=True)
+        _RESTART_MARKER.write_text("1")
+        logger.info("auto-update: restart marker written, gateway will restart")
+    except Exception as exc:
+        logger.warning("auto-update: failed to write restart marker: %s", exc)
+
+
+def check_restart_marker() -> bool:
+    """Check if the auto-update restart marker exists and clear it.
+
+    Called early in gateway startup so it can act before accepting messages.
+    Returns True if a restart is expected (i.e. we just updated).
+    """
+    if _RESTART_MARKER.exists():
+        try:
+            _RESTART_MARKER.unlink()
+        except Exception:
+            pass
+        return True
+    return False
+
+
+def auto_update_cycle(config: dict) -> bool:
+    """Run one auto-update check+apply cycle.
+
+    Args:
+        config: The loaded config dict (with ``updates`` section).
+
+    Returns:
+        True if an update was applied and a restart is needed.
+    """
+    updates_cfg = config.get("updates", {})
+    if not updates_cfg.get("auto_update", False):
+        return False
+
+    project_root = Path(__file__).resolve().parent.parent
+    git_dir = project_root / ".git"
+    if not git_dir.is_dir():
+        logger.debug("auto-update: not a git checkout, skipping")
+        return False
+
+    if not _fetch_remote():
+        logger.debug("auto-update: fetch failed, will retry next cycle")
+        return False
+
+    behind = _check_behind()
+    if behind <= 0:
+        logger.debug("auto-update: already up to date")
+        return False
+
+    logger.info("auto-update: %d commit(s) behind, applying update", behind)
+    if not _run_update():
+        logger.warning("auto-update: update failed, will retry next cycle")
+        return False
+
+    # Update applied — schedule a gateway restart.
+    _schedule_gateway_restart()
+    return True
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Background thread
+# ──────────────────────────────────────────────────────────────────────
+
+
+class AutoUpdateThread:
+    """Daemon thread that periodically checks for updates.
+
+    Started once during gateway init.  Runs forever in the background.
+    """
+
+    def __init__(self, config: dict) -> None:
+        self._config = config
+        updates_cfg = config.get("updates", {})
+        self._enabled = bool(updates_cfg.get("auto_update", False))
+        self._interval = int(updates_cfg.get("auto_update_interval", 86400))
+        self._restart_requested = False
+        self._thread: threading.Thread | None = None
+        self._stop_event = threading.Event()
+
+    def start(self) -> None:
+        if not self._enabled:
+            logger.debug("auto-update: disabled by config")
+            return
+        if self._thread and self._thread.is_alive():
+            return
+        self._thread = threading.Thread(
+            target=self._loop,
+            name="auto-update",
+            daemon=True,
+        )
+        self._thread.start()
+        logger.info(
+            "auto-update: background thread started (interval=%ds)",
+            self._interval,
+        )
+
+    def stop(self) -> None:
+        self._stop_event.set()
+
+    @property
+    def restart_requested(self) -> bool:
+        return self._restart_requested
+
+    def _loop(self) -> None:
+        while not self._stop_event.is_set():
+            try:
+                updated = auto_update_cycle(self._config)
+                if updated:
+                    self._restart_requested = True
+                    return  # thread exits; caller handles restart
+            except Exception as exc:
+                logger.warning("auto-update: cycle failed: %s", exc)
+
+            self._stop_event.wait(self._interval)
+
+
+__all__ = [
+    "auto_update_cycle",
+    "AutoUpdateThread",
+    "check_restart_marker",
+]

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1668,6 +1668,12 @@ DEFAULT_CONFIG = {
 
     # ``hermes update`` behaviour.
     "updates": {
+        # Automatically check for and apply updates in the background.
+        # When enabled, the gateway runs a background thread that periodically
+        # checks git/PyPI for new versions and applies them automatically.
+        "auto_update": False,
+        # Interval in seconds between auto-update checks. Default: 24 hours.
+        "auto_update_interval": 86400,
         # Run a full ``hermes backup``-style zip of HERMES_HOME before every
         # ``hermes update``.  Backups land in ``<HERMES_HOME>/backups/`` and
         # can be restored with ``hermes import <path>``.  Off by default —

--- a/tools/goals_tool.py
+++ b/tools/goals_tool.py
@@ -1,0 +1,241 @@
+"""Goal management tools for autonomous AI goal-setting.
+
+Allows the AI agent to set, check, and clear standing goals that the
+Judge loop (the Ralph loop) then automatically drives to completion.
+
+Usage (from the AI's perspective):
+  - ``set_goal(goal=\"...\", max_turns=20)`` — start working toward a goal.
+  - ``get_goal_status()`` — check whether a goal is active / done / paused.
+  - ``clear_goal()`` — abandon the current goal.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Optional
+
+from tools.registry import registry
+
+logger = logging.getLogger(__name__)
+
+
+def _get_goal_manager(task_id: str, max_turns: int = 20):
+    """Create a ``GoalManager`` bound to the current session.
+
+    ``task_id`` is the agent's ``session_id`` — the same value the gateway
+    and CLI use when constructing GoalManagers for the /goal command.
+    """
+    try:
+        from hermes_cli.goals import GoalManager
+    except ImportError:
+        return None
+    if not task_id:
+        return None
+    return GoalManager(session_id=task_id, default_max_turns=max_turns)
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Tool: set_goal
+# ──────────────────────────────────────────────────────────────────────
+
+
+def _set_goal_available() -> bool:
+    """Available when the goals module can be imported."""
+    try:
+        from hermes_cli import goals  # noqa: F401
+        return True
+    except ImportError:
+        return False
+
+
+def set_goal(goal: str, max_turns: int = 20, task_id: Optional[str] = None) -> str:
+    """Set a standing goal the agent works on across turns.
+
+    The Judge loop evaluates progress after each turn and automatically
+    continues if the goal is not yet achieved.
+
+    Args:
+        goal: The goal text describing what to achieve.
+        max_turns: Maximum number of turns before auto-pause (default: 20).
+
+    Returns:
+        A JSON string describing the result.
+    """
+    if not goal or not goal.strip():
+        return json.dumps({
+            "success": False,
+            "error": "Goal text cannot be empty.",
+        })
+
+    mgr = _get_goal_manager(task_id or "")
+    if mgr is None:
+        return json.dumps({
+            "success": False,
+            "error": "Goal system unavailable (SessionDB not reachable).",
+        })
+
+    try:
+        state = mgr.set(goal, max_turns=max_turns)
+        return json.dumps({
+            "success": True,
+            "goal": state.goal,
+            "max_turns": state.max_turns,
+            "message": f"Goal set: {state.goal}. Working toward it across turns.",
+        }, ensure_ascii=False)
+    except ValueError as exc:
+        return json.dumps({
+            "success": False,
+            "error": str(exc),
+        })
+
+
+registry.register(
+    name="set_goal",
+    toolset="core",
+    schema={
+        "name": "set_goal",
+        "description": (
+            "Set a standing goal that the agent will work on across multiple turns. "
+            "Once set, the system automatically evaluates progress after each turn "
+            "and continues working until the goal is achieved, the turn budget runs "
+            "out, or the user interrupts. Use this when a task requires multiple "
+            "steps that span several conversation turns — e.g. refactoring a large "
+            "codebase, running a multi-phase analysis, or implementing a feature "
+            "with multiple sub-tasks. After setting the goal, continue working "
+            "normally; the system handles continuation automatically."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "goal": {
+                    "type": "string",
+                    "description": "The goal to work toward. Be specific about what constitutes completion.",
+                },
+                "max_turns": {
+                    "type": "integer",
+                    "description": "Maximum number of turns before auto-pausing (default: 20).",
+                    "default": 20,
+                },
+            },
+            "required": ["goal"],
+        },
+    },
+    handler=lambda args, **kw: set_goal(
+        goal=args.get("goal", ""),
+        max_turns=int(args.get("max_turns", 20)),
+        task_id=kw.get("task_id"),
+    ),
+    check_fn=_set_goal_available,
+)
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Tool: get_goal_status
+# ──────────────────────────────────────────────────────────────────────
+
+
+def get_goal_status(task_id: Optional[str] = None) -> str:
+    """Check the current goal status.
+
+    Returns:
+        A JSON string with status information.
+    """
+    mgr = _get_goal_manager(task_id or "")
+    if mgr is None:
+        return json.dumps({
+            "success": False,
+            "error": "Goal system unavailable.",
+        })
+
+    state = mgr.state
+    if state is None:
+        return json.dumps({
+            "success": True,
+            "has_goal": False,
+            "message": "No active goal. Use set_goal to create one.",
+        })
+
+    sub = f", {len(state.subgoals)} subgoal(s)" if state.subgoals else ""
+    return json.dumps({
+        "success": True,
+        "has_goal": True,
+        "goal": state.goal,
+        "status": state.status,
+        "turns_used": state.turns_used,
+        "max_turns": state.max_turns,
+        "last_verdict": state.last_verdict,
+        "last_reason": state.last_reason,
+        "summary": f"Goal ({state.status}, {state.turns_used}/{state.max_turns} turns{sub}): {state.goal}",
+    }, ensure_ascii=False)
+
+
+registry.register(
+    name="get_goal_status",
+    toolset="core",
+    schema={
+        "name": "get_goal_status",
+        "description": (
+            "Check the current goal status: whether a standing goal is active, "
+            "paused, done, or cleared. Also shows turn usage and the last judge "
+            "verdict. Useful to understand progress before deciding next steps."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {},
+        },
+    },
+    handler=lambda args, **kw: get_goal_status(task_id=kw.get("task_id")),
+    check_fn=_set_goal_available,
+)
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Tool: clear_goal
+# ──────────────────────────────────────────────────────────────────────
+
+
+def clear_goal(task_id: Optional[str] = None) -> str:
+    """Clear (abandon) the current goal.
+
+    The Judge loop stops, and the agent returns to normal turn-by-turn
+    conversation.
+
+    Returns:
+        A JSON string describing the result.
+    """
+    mgr = _get_goal_manager(task_id or "")
+    if mgr is None:
+        return json.dumps({
+            "success": False,
+            "error": "Goal system unavailable.",
+        })
+
+    had_goal = mgr.has_goal()
+    mgr.clear()
+    return json.dumps({
+        "success": True,
+        "had_goal": had_goal,
+        "message": "Goal cleared." if had_goal else "No active goal to clear.",
+    })
+
+
+registry.register(
+    name="clear_goal",
+    toolset="core",
+    schema={
+        "name": "clear_goal",
+        "description": (
+            "Clear (abandon) the current standing goal. The Judge loop stops "
+            "and the agent returns to normal turn-by-turn conversation. "
+            "Use this when the goal has been superseded by a new priority or "
+            "when the current work is no longer needed."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {},
+        },
+    },
+    handler=lambda args, **kw: clear_goal(task_id=kw.get("task_id")),
+    check_fn=_set_goal_available,
+)

--- a/toolsets.py
+++ b/toolsets.py
@@ -52,6 +52,8 @@ _HERMES_CORE_TOOLS = [
     "session_search",
     # Clarifying questions
     "clarify",
+    # Goal management (autonomous multi-turn goal pursuit)
+    "set_goal", "get_goal_status", "clear_goal",
     # Code execution + delegation
     "execute_code", "delegate_task",
     # Cronjob management


### PR DESCRIPTION
Adds two major features:

1. Background auto-update (config-driven)
   - `updates.auto_update: true` enables a daemon thread that periodically
     checks git origin/main for new commits and runs `hermes update --yes`.
   - After a successful update, writes a restart marker so the gateway
     restarts with the new code.
   - `updates.auto_update_interval` (default: 86400s / 24h) controls check
     frequency.
   - Thread lives inside the gateway process; CLI mode is unaffected.

2. AI-driven goal tools (autonomous multi-turn pursuit)
   - `set_goal(goal, max_turns=20)` — AI calls this to start a standing
     goal. The Judge loop evaluates progress after each turn and
     auto-continues until done.
   - `get_goal_status()` — check current goal state.
   - `clear_goal()` — abandon the current goal.
   - Tools use `task_id` (= session_id) to bind GoalManager, matching the
     same SessionDB persistence the /goal slash command uses.
   - GOAL_GUIDANCE injected into system prompt when `set_goal` tool is
     available, teaching the AI when and how to use the goal system.

Config additions (hermes_cli/config.py DEFAULT_CONFIG):
  - updates.auto_update (bool, default: False)
  - updates.auto_update_interval (int, default: 86400)

New files:
  - hermes_cli/auto_update.py — AutoUpdateThread + helpers
  - tools/goals_tool.py — set_goal / get_goal_status / clear_goal
