### PR TITLE
fix(file_tools): allow writes to user-owned /etc/nixos/ on NixOS

### DIFF
--- a/tests/tools/test_file_write_safety.py
+++ b/tests/tools/test_file_write_safety.py
@@ -107,5 +107,42 @@ class TestCheckSensitivePathMacOSBypass:
         assert _check_sensitive_path("/tmp/safe_file.txt") is None
 
 
+class TestNixOSConfigException:
+    """NixOS users manage /etc/nixos/ as personal dotfiles — file tools
+    should allow writes when the config tree is user-owned."""
+
+    def test_nixos_config_allowed(self, tmp_path, monkeypatch):
+        """User-owned /etc/nixos/ tree should allow writes."""
+        from tools import file_tools
+        etc_nixos = tmp_path / "etc" / "nixos"
+        etc_nixos.mkdir(parents=True)
+        path = etc_nixos / "config.nix"
+        path.touch()
+        monkeypatch.setattr(file_tools, "_NIXOS_ETC_PREFIX", str(tmp_path / "etc") + "/")
+        assert file_tools._is_sensitive_nixos_config(str(path)) is True
+
+    def test_nixos_new_file_allowed(self, tmp_path, monkeypatch):
+        """Non-existent file under user-owned /etc/nixos/ should be allowed."""
+        from tools import file_tools
+        etc_nixos = tmp_path / "etc" / "nixos"
+        etc_nixos.mkdir(parents=True)
+        new_file = etc_nixos / "new-module.nix"
+        monkeypatch.setattr(file_tools, "_NIXOS_ETC_PREFIX", str(tmp_path / "etc") + "/")
+        assert file_tools._is_sensitive_nixos_config(str(new_file)) is True
+
+    def test_non_nixos_etc_blocked(self):
+        """Paths outside /etc/nixos/ should never match."""
+        from tools.file_tools import _is_sensitive_nixos_config
+        assert _is_sensitive_nixos_config("/etc/passwd") is False
+        assert _is_sensitive_nixos_config("/etc/ssh/sshd_config") is False
+        assert _is_sensitive_nixos_config("/etc/foo") is False
+
+    def test_nonexistent_etc_nixos_safe_default(self, monkeypatch):
+        """When /etc/nixos/ doesn't exist, return False (safe default)."""
+        from tools import file_tools
+        monkeypatch.setattr(file_tools, "_NIXOS_ETC_PREFIX", "/nonexistent/path/")
+        assert file_tools._is_sensitive_nixos_config("/nonexistent/path/imaginary.nix") is False
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -153,7 +153,30 @@ _SENSITIVE_PATH_PREFIXES = (
     "/private/etc/", "/private/var/",
 )
 _SENSITIVE_EXACT_PATHS = {"/var/run/docker.sock", "/run/docker.sock"}
+_NIXOS_ETC_PREFIX = "/etc/nixos/"
 
+
+def _is_sensitive_nixos_config(path: str) -> bool:
+    """Return True if *path* lives under /etc/nixos/ AND is user-owned.
+
+    The prefix check uses the literal path so symlinks (e.g. /etc/nixos →
+    /home/user/config/nixos) are still recognised.  Ownership is determined
+    by climbing to the deepest existing parent — os.stat() follows symlinks
+    automatically, so chown'd directories and symlinked user directories
+    both work correctly.  When /etc/nixos/ doesn't exist at all (non-NixOS
+    systems), returns False → the default sensitive-path guard applies.
+    """
+    if not path.startswith(_NIXOS_ETC_PREFIX):
+        return False
+    p = Path(path)
+    for c in [p] + list(p.parents):
+        try:
+            return c.stat().st_uid == os.getuid()
+        except FileNotFoundError:
+            continue
+        except OSError:
+            continue
+    return False
 
 def _check_sensitive_path(filepath: str, task_id: str = "default") -> str | None:
     """Return an error message if the path targets a sensitive system location."""
@@ -168,7 +191,14 @@ def _check_sensitive_path(filepath: str, task_id: str = "default") -> str | None
     )
     for prefix in _SENSITIVE_PATH_PREFIXES:
         if resolved.startswith(prefix) or normalized.startswith(prefix):
-            return _err
+            # Allow writes under /etc/nixos/ when the config dir is user-owned.
+            # NixOS users manage /etc/nixos/ as personal dotfiles — it's not a
+            # system path in the traditional sense.  Check the deepest existing
+            # parent's ownership to avoid weakening the guard for root-owned
+            # /etc/ entries (passwd, shadow, ssh/, sudoers, etc.).
+            if (not _is_sensitive_nixos_config(resolved)
+                    and not _is_sensitive_nixos_config(normalized)):
+                return _err
     if resolved in _SENSITIVE_EXACT_PATHS or normalized in _SENSITIVE_EXACT_PATHS:
         return _err
     return None


### PR DESCRIPTION
## Problem

Hermes file tools (`write_file`, `patch`) refuse all paths under `/etc/` — including `/etc/nixos/`. On NixOS, users manage their system configuration under `/etc/nixos/` as personal dotfiles. It's often symlinked to a home-directory path or chown'd to the user. The blanket `/etc/` block forces agents to use `sudo sed` via terminal, which is a constant papercut for NixOS workflows where the agent is helping with `nixos-rebuild` and config edits.

The existing guard is *correct* for system-critical paths (`/etc/passwd`, `/etc/shadow`, `/etc/ssh/`, `/etc/sudoers`) — this PR doesn't weaken those.

## Solution

Add a targeted exception in `_check_sensitive_path`: when a path is under `/etc/nixos/` **and** the deepest existing parent directory is owned by the current user, file tools allow the write.

- **Prefix check uses the literal path** — symlinked `/etc/nixos → ~/config/nixos` is still recognised
- **`os.stat()` follows symlinks automatically** — both chown'd directories and symlinked user directories work
- **Non-existent `/etc/nixos/` returns false** — safe default on non-NixOS systems
- **Root-owned `/etc/nixos/` still blocked** — no security regression

## Testing

- 4 new tests in `test_file_write_safety.py` covering: user-owned config, non-existent file under user-owned dir, non-nixos /etc/ paths still blocked, safe default when /etc/nixos/ doesn't exist
- All 16 existing tests continue to pass

## Manual verification (NixOS)

```python
>>> _check_sensitive_path('/etc/nixos/home/default.nix')  # None (allowed)
>>> _check_sensitive_path('/etc/passwd')                   # blocked
>>> _check_sensitive_path('/boot/vmlinuz')                 # blocked
```