### PR TITLE
fix: harden agent write and shell guardrails

### DIFF
--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -89,6 +89,26 @@ class TestDetectDangerousSudo:
         assert is_dangerous is True
         assert key is not None
 
+    def test_prompt_shell_python_traversal_markers_are_detected(self):
+        cmd = "python3 - <<'PY'\n().__class__.__base__.__subclasses__()\nPY"
+        is_dangerous, key, desc = detect_dangerous_command(cmd)
+        assert is_dangerous is True
+        assert key is not None
+        assert "traversal" in desc.lower() or "script execution" in desc.lower()
+
+    def test_import_loader_traversal_marker_is_detected(self):
+        is_dangerous, key, desc = detect_dangerous_command("grep BuiltinImporter exploit.py")
+        assert is_dangerous is True
+        assert key is not None
+        assert "import-loader" in desc.lower()
+
+    def test_write_to_user_launchagent_requires_approval(self):
+        cmd = "cat payload.plist > ~/Library/LaunchAgents/com.evil.plist"
+        is_dangerous, key, desc = detect_dangerous_command(cmd)
+        assert is_dangerous is True
+        assert key is not None
+        assert "system file" in desc.lower() or "sensitive" in desc.lower()
+
 
 class TestDetectSqlPatterns:
     def test_drop_table(self):

--- a/tests/tools/test_file_tools.py
+++ b/tests/tools/test_file_tools.py
@@ -142,6 +142,26 @@ class TestWriteFileHandler:
         assert "error" in result
         assert "string" in result["error"].lower() or "content" in result["error"].lower()
 
+    @patch("tools.file_tools._get_file_ops")
+    def test_write_refuses_user_persistence_paths(self, mock_get):
+        from tools.file_tools import write_file_tool
+
+        result = json.loads(write_file_tool("~/Library/LaunchAgents/com.evil.plist", "plist"))
+
+        assert "error" in result
+        assert "persistence/credential" in result["error"]
+        mock_get.assert_not_called()
+
+    @patch("tools.file_tools._get_file_ops")
+    def test_write_refuses_agent_credential_paths(self, mock_get):
+        from tools.file_tools import write_file_tool
+
+        result = json.loads(write_file_tool("~/.hermes/.env", "TOKEN=bad"))
+
+        assert "error" in result
+        assert "persistence/credential" in result["error"]
+        mock_get.assert_not_called()
+
 
 class TestPatchHandler:
     @patch("tools.file_tools._get_file_ops")

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -127,7 +127,12 @@ _PROJECT_ENV_PATH = r'(?:(?:/|\.{1,2}/)?(?:[^\s/"\'`]+/)*\.env(?:\.[^/\s"\'`]+)*
 _PROJECT_CONFIG_PATH = r'(?:(?:/|\.{1,2}/)?(?:[^\s/"\'`]+/)*config\.yaml)'
 _SHELL_RC_FILES = (
     r'(?:~|\$home|\$\{home\})/\.'
-    r'(?:bashrc|zshrc|profile|bash_profile|zprofile)\b'
+    r'(?:bashrc|zshrc|profile|bash_profile|zprofile|zlogin|zshenv)\b'
+)
+_USER_PERSISTENCE_PATH = (
+    r'(?:~|\$home|\$\{home\})/(?:'
+    r'Library/LaunchAgents/|\.config/systemd/user/|\.config/autostart/|'
+    r'\.local/share/systemd/user/|\.ssh/)'
 )
 _CREDENTIAL_FILES = (
     r'(?:~|\$home|\$\{home\})/\.'
@@ -149,6 +154,7 @@ _SENSITIVE_WRITE_TARGET = (
     rf'{_SSH_SENSITIVE_PATH}|'
     rf'{_HERMES_ENV_PATH}|'
     rf'{_SHELL_RC_FILES}|'
+    rf'{_USER_PERSISTENCE_PATH}|'
     rf'{_CREDENTIAL_FILES})'
 )
 _PROJECT_SENSITIVE_WRITE_TARGET = rf'(?:{_PROJECT_ENV_PATH}|{_PROJECT_CONFIG_PATH})'
@@ -344,6 +350,9 @@ DANGEROUS_PATTERNS = [
     # Any shell invocation via -c or combined flags like -lc, -ic, etc.
     (r'\b(bash|sh|zsh|ksh)\s+-[^\s]*c(\s+|$)', "shell command via -c/-lc flag"),
     (r'\b(python[23]?|perl|ruby|node)\s+-[ec]\s+', "script execution via -e/-c flag"),
+    (r'\b(?:eval|exec)\s*\(', "dynamic code evaluation"),
+    (r'__(?:class|base|mro|subclasses|globals|builtins|import)__', "Python object graph / builtins traversal"),
+    (r'\b(?:BuiltinImporter|load_module)\b', "Python import-loader traversal"),
     (r'\b(curl|wget)\b.*\|\s*(ba)?sh\b', "pipe remote content to shell"),
     (r'\b(bash|sh|zsh|ksh)\s+<\s*<?\s*\(\s*(curl|wget)\b', "execute remote script via process substitution"),
     (rf'\btee\b.*["\']?{_SENSITIVE_WRITE_TARGET}', "overwrite system file via tee"),

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -154,6 +154,43 @@ _SENSITIVE_PATH_PREFIXES = (
 )
 _SENSITIVE_EXACT_PATHS = {"/var/run/docker.sock", "/run/docker.sock"}
 
+# User-level persistence and credential targets. These are not always system
+# paths, but an LLM-controlled arbitrary-file-write sink can turn them into
+# code execution on the next shell, GUI login, cron tick, or agent restart.
+# Keep these refusals in the file tools themselves so write_file/patch cannot
+# bypass the terminal approval layer.
+_USER_PERSISTENCE_PREFIXES = (
+    ".ssh/",
+    "Library/LaunchAgents/",
+    ".config/systemd/user/",
+    ".config/autostart/",
+    ".local/share/systemd/user/",
+)
+_USER_PERSISTENCE_EXACT = {
+    ".bashrc", ".bash_profile", ".profile", ".zshrc", ".zprofile",
+    ".zlogin", ".zshenv", ".config/fish/config.fish", ".netrc",
+    ".pgpass", ".npmrc", ".pypirc", ".hermes/.env", ".hermes/config.yaml",
+}
+
+
+def _user_relative_path(path: str) -> str | None:
+    """Return *path* relative to the current home directory when applicable."""
+    try:
+        home = Path.home().resolve()
+        resolved = Path(path).expanduser().resolve()
+        return resolved.relative_to(home).as_posix()
+    except (OSError, ValueError):
+        return None
+
+
+def _is_user_persistence_path(path: str) -> bool:
+    rel = _user_relative_path(path)
+    if rel is None:
+        return False
+    return rel in _USER_PERSISTENCE_EXACT or any(
+        rel.startswith(prefix) for prefix in _USER_PERSISTENCE_PREFIXES
+    )
+
 
 def _check_sensitive_path(filepath: str, task_id: str = "default") -> str | None:
     """Return an error message if the path targets a sensitive system location."""
@@ -171,6 +208,11 @@ def _check_sensitive_path(filepath: str, task_id: str = "default") -> str | None
             return _err
     if resolved in _SENSITIVE_EXACT_PATHS or normalized in _SENSITIVE_EXACT_PATHS:
         return _err
+    if _is_user_persistence_path(resolved) or _is_user_persistence_path(normalized):
+        return (
+            f"Refusing to write to sensitive user persistence/credential path: {filepath}\n"
+            "Use the terminal tool so the approval system can review the write."
+        )
     return None
 
 


### PR DESCRIPTION
## Summary
- Refuse file-tool writes to user persistence and credential paths such as LaunchAgents, shell startup files, SSH config, and Hermes env/config.
- Expand terminal approval detection for prompt-shell RCE markers from the Microsoft agent-framework RCE write-up.
- Add regression tests for prompt-shell traversal markers and persistence-path writes.

## Test Plan
- python -m pytest -o 'addopts=' tests/tools/test_file_tools.py tests/tools/test_approval.py -q
- python -m py_compile tools/file_tools.py tools/approval.py tests/tools/test_file_tools.py tests/tools/test_approval.py
- targeted changed-file security scan: high=0