### PR TITLE
fix(kanban): guard write_txn ROLLBACK against SQLite auto-abort

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1345,7 +1345,14 @@ def write_txn(conn: sqlite3.Connection):
     try:
         yield conn
     except Exception:
-        conn.execute("ROLLBACK")
+        try:
+            conn.execute("ROLLBACK")
+        except sqlite3.OperationalError as exc:
+            # SQLite can auto-abort the transaction before we reach the
+            # explicit rollback; keep the original exception in that case.
+            msg = str(exc).lower()
+            if "cannot rollback" not in msg and "no transaction is active" not in msg:
+                raise
         raise
     else:
         conn.execute("COMMIT")

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -2012,6 +2012,30 @@ def test_connect_falls_back_to_delete_on_locking_protocol(kanban_home, caplog):
     conn.close()
 
 
+def test_write_txn_ignores_no_active_transaction_rollback_error():
+    """Rollback guard must preserve the original failure when SQLite already aborted."""
+
+    class _Conn:
+        def __init__(self) -> None:
+            self.calls: list[str] = []
+
+        def execute(self, sql, *args, **kwargs):
+            self.calls.append(sql)
+            if sql == "ROLLBACK":
+                raise sqlite3.OperationalError(
+                    "cannot rollback - no transaction is active"
+                )
+            return None
+
+    conn = _Conn()
+
+    with pytest.raises(RuntimeError, match="boom"):
+        with kb.write_txn(conn):  # type: ignore[arg-type]
+            raise RuntimeError("boom")
+
+    assert conn.calls == ["BEGIN IMMEDIATE", "ROLLBACK"]
+
+
 def test_unlink_tasks_triggers_recompute_ready(kanban_home):
     """Regression test for issue #22459.
 


### PR DESCRIPTION
## Problem

When `write_txn()` catches an exception from its body and tries to ROLLBACK, SQLite may have already auto-aborted the transaction. The bare `conn.execute("ROLLBACK")` then raises `OperationalError("cannot rollback - no transaction is active")`, **shadowing the original exception** and making debugging extremely confusing.

This is a real failure mode — any code path inside `write_txn` that triggers an SQLite auto-abort (e.g. an IntegrityError, a constraint failure, or a nested ROLLBACK via another codepath) will hit this.

## Fix

Guard the ROLLBACK with a try/except that swallows only the specific "cannot rollback" / "no transaction is active" errors. All other OperationalError variants are still re-raised. The original exception is preserved and propagated normally.

## Test

Added `test_write_txn_ignores_no_active_transaction_rollback_error` — uses a mock connection that raises OperationalError("cannot rollback - no transaction is active") on every ROLLBACK call, then verifies that the original RuntimeError("boom") is still raised and that the ROLLBACK was attempted.
