### PR TITLE
feat(kanban): auto-subscribe on CLI create from --subscribe-* args or env vars

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -91,6 +91,24 @@ def _run_state_kwargs(args: argparse.Namespace) -> Optional[dict[str, str]]:
     return {"state_type": st, "state_name": sn}
 
 
+def _infer_subscribe_from_env() -> Optional[dict[str, str]]:
+    platform = (os.environ.get("HERMES_NOTIFY_PLATFORM") or "").strip()
+    chat_id = (os.environ.get("HERMES_NOTIFY_CHAT_ID") or "").strip()
+    if not platform or not chat_id:
+        return None
+    subscribe = {
+        "platform": platform,
+        "chat_id": chat_id,
+    }
+    thread_id = (os.environ.get("HERMES_NOTIFY_THREAD_ID") or "").strip()
+    user_id = (os.environ.get("HERMES_NOTIFY_USER_ID") or "").strip()
+    if thread_id:
+        subscribe["thread_id"] = thread_id
+    if user_id:
+        subscribe["user_id"] = user_id
+    return subscribe
+
+
 def _parse_workspace_flag(value: str) -> tuple[str, Optional[str]]:
     """Parse ``--workspace`` into ``(kind, path|None)``.
 
@@ -341,6 +359,14 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
                                "two retries. Omit to use the dispatcher's "
                                "kanban.failure_limit config "
                                f"(default {kb.DEFAULT_FAILURE_LIMIT}).")
+    p_create.add_argument("--subscribe-platform", default=None,
+                          help="Auto-subscribe task notifications for this platform")
+    p_create.add_argument("--subscribe-chat-id", default=None,
+                          help="Chat ID for the notification subscription")
+    p_create.add_argument("--subscribe-thread-id", default=None,
+                          help="Optional thread/topic ID for the notification subscription")
+    p_create.add_argument("--subscribe-user-id", default=None,
+                          help="Optional user ID for the notification subscription")
     p_create.add_argument("--initial-status",
                           choices=sorted(kb.VALID_INITIAL_STATUSES),
                           default="running",
@@ -1286,6 +1312,28 @@ def _cmd_create(args: argparse.Namespace) -> int:
             file=sys.stderr,
         )
         return 2
+    subscribe = None
+    sub_platform = (getattr(args, "subscribe_platform", None) or "").strip()
+    sub_chat_id = (getattr(args, "subscribe_chat_id", None) or "").strip()
+    sub_thread_id = (getattr(args, "subscribe_thread_id", None) or "").strip()
+    sub_user_id = (getattr(args, "subscribe_user_id", None) or "").strip()
+    if any((sub_platform, sub_chat_id, sub_thread_id, sub_user_id)):
+        if not sub_platform or not sub_chat_id:
+            print(
+                "kanban: --subscribe-platform and --subscribe-chat-id must be passed together",
+                file=sys.stderr,
+            )
+            return 2
+        subscribe = {
+            "platform": sub_platform,
+            "chat_id": sub_chat_id,
+        }
+        if sub_thread_id:
+            subscribe["thread_id"] = sub_thread_id
+        if sub_user_id:
+            subscribe["user_id"] = sub_user_id
+    if subscribe is None:
+        subscribe = _infer_subscribe_from_env()
     with kb.connect() as conn:
         task_id = kb.create_task(
             conn,
@@ -1304,6 +1352,7 @@ def _cmd_create(args: argparse.Namespace) -> int:
             max_runtime_seconds=max_runtime,
             skills=getattr(args, "skills", None) or None,
             max_retries=max_retries,
+            subscribe=subscribe,
             initial_status=getattr(args, "initial_status", "running"),
         )
         task = kb.get_task(conn, task_id)

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1409,6 +1409,7 @@ def create_task(
     max_runtime_seconds: Optional[int] = None,
     skills: Optional[Iterable[str]] = None,
     max_retries: Optional[int] = None,
+    subscribe: Optional[dict] = None,
     initial_status: str = "running",
     session_id: Optional[str] = None,
     board: Optional[str] = None,
@@ -1436,6 +1437,13 @@ def create_task(
     ``kanban-worker``. Use this to pin a task to a specialist skill
     (e.g. ``skills=["translation"]`` so the worker loads the
     translation skill regardless of the profile's default config).
+
+    ``subscribe`` optionally creates a notification subscription in the
+    same write transaction as the task row. Expected keys: ``platform``
+    and ``chat_id`` (required), plus optional ``thread_id`` and
+    ``user_id``. When ``subscribe`` is omitted, the gateway-provided
+    ``HERMES_NOTIFY_PLATFORM`` / ``HERMES_NOTIFY_CHAT_ID`` env vars are
+    used as a best-effort fallback.
     """
     assignee = _canonical_assignee(assignee)
     if not title or not title.strip():
@@ -1526,6 +1534,34 @@ def create_task(
         if board_default:
             workspace_path = str(board_default)
 
+    # Resolve notification subscription from explicit arg or env vars.
+    resolved_subscribe: Optional[dict[str, str]] = None
+    if not subscribe:
+        sub_platform = os.environ.get("HERMES_NOTIFY_PLATFORM")
+        sub_chat_id = os.environ.get("HERMES_NOTIFY_CHAT_ID")
+        if sub_platform and sub_chat_id:
+            subscribe = {
+                "platform": sub_platform,
+                "chat_id": sub_chat_id,
+            }
+            sub_thread = os.environ.get("HERMES_NOTIFY_THREAD_ID")
+            if sub_thread:
+                subscribe["thread_id"] = sub_thread
+    if isinstance(subscribe, dict):
+        platform = str(subscribe.get("platform") or "").strip()
+        chat_id = str(subscribe.get("chat_id") or "").strip()
+        if platform and chat_id:
+            resolved_subscribe = {
+                "platform": platform,
+                "chat_id": chat_id,
+            }
+            thread_id = str(subscribe.get("thread_id") or "").strip()
+            if thread_id:
+                resolved_subscribe["thread_id"] = thread_id
+            user_id = str(subscribe.get("user_id") or "").strip()
+            if user_id:
+                resolved_subscribe["user_id"] = user_id
+
     # Retry once on the extremely unlikely id collision.
     for attempt in range(2):
         task_id = _new_task_id()
@@ -1610,6 +1646,15 @@ def create_task(
                         "skills": list(skills_list) if skills_list else None,
                     },
                 )
+                if resolved_subscribe:
+                    _add_notify_sub_inner(
+                        conn,
+                        task_id=task_id,
+                        platform=resolved_subscribe["platform"],
+                        chat_id=resolved_subscribe["chat_id"],
+                        thread_id=resolved_subscribe.get("thread_id"),
+                        user_id=resolved_subscribe.get("user_id"),
+                    )
             return task_id
         except sqlite3.IntegrityError:
             if attempt == 1:
@@ -5786,6 +5831,34 @@ def task_age(task: Task) -> dict:
 # Notification subscriptions (used by the gateway kanban-notifier)
 # ---------------------------------------------------------------------------
 
+def _add_notify_sub_inner(
+    conn: sqlite3.Connection,
+    *,
+    task_id: str,
+    platform: str,
+    chat_id: str,
+    thread_id: Optional[str] = None,
+    user_id: Optional[str] = None,
+    notifier_profile: Optional[str] = None,
+) -> None:
+    """Insert/update a notify sub — assumes caller already holds a write_txn."""
+    now = int(time.time())
+    conn.execute(
+        """INSERT OR IGNORE INTO kanban_notify_subs
+            (task_id, platform, chat_id, thread_id, user_id, notifier_profile, created_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?)""",
+        (task_id, platform, chat_id, thread_id or "", user_id, notifier_profile, now),
+    )
+    if notifier_profile:
+        conn.execute(
+            """UPDATE kanban_notify_subs
+                 SET notifier_profile = ?
+               WHERE task_id = ? AND platform = ? AND chat_id = ? AND thread_id = ?
+                 AND (notifier_profile IS NULL OR notifier_profile = '')""",
+            (notifier_profile, task_id, platform, chat_id, thread_id or ""),
+        )
+
+
 def add_notify_sub(
     conn: sqlite3.Connection,
     *,
@@ -5798,28 +5871,16 @@ def add_notify_sub(
 ) -> None:
     """Register a gateway source that wants terminal-state notifications
     for ``task_id``. Idempotent on (task, platform, chat, thread)."""
-    now = int(time.time())
     with write_txn(conn):
-        conn.execute(
-            """
-            INSERT OR IGNORE INTO kanban_notify_subs
-                (task_id, platform, chat_id, thread_id, user_id, notifier_profile, created_at)
-            VALUES (?, ?, ?, ?, ?, ?, ?)
-            """,
-            (task_id, platform, chat_id, thread_id or "", user_id, notifier_profile, now),
+        _add_notify_sub_inner(
+            conn,
+            task_id=task_id,
+            platform=platform,
+            chat_id=chat_id,
+            thread_id=thread_id,
+            user_id=user_id,
+            notifier_profile=notifier_profile,
         )
-        if notifier_profile:
-            # Self-heal legacy rows that predate notifier ownership by
-            # backfilling only when the existing value is unset.
-            conn.execute(
-                """
-                UPDATE kanban_notify_subs
-                   SET notifier_profile = ?
-                 WHERE task_id = ? AND platform = ? AND chat_id = ? AND thread_id = ?
-                   AND (notifier_profile IS NULL OR notifier_profile = '')
-                """,
-                (notifier_profile, task_id, platform, chat_id, thread_id or ""),
-            )
 
 
 def list_notify_subs(

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -1605,6 +1605,82 @@ def test_session_id_compose_with_tenant_filter(kanban_home):
     assert [t.title for t in rows] == ["match"]
 
 
+def test_create_task_without_subscribe_creates_no_subs(kanban_home, monkeypatch):
+    """No notify sub is created when subscribe=None and no env vars set."""
+    monkeypatch.delenv("HERMES_NOTIFY_PLATFORM", raising=False)
+    monkeypatch.delenv("HERMES_NOTIFY_CHAT_ID", raising=False)
+    monkeypatch.delenv("HERMES_NOTIFY_THREAD_ID", raising=False)
+    monkeypatch.delenv("HERMES_NOTIFY_USER_ID", raising=False)
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="no-sub")
+        subs = kb.list_notify_subs(conn, task_id=tid)
+    assert subs == []
+
+
+def test_create_task_with_subscribe_dict_creates_sub(kanban_home):
+    """Passing subscribe=dict creates a row in kanban_notify_subs."""
+    with kb.connect() as conn:
+        tid = kb.create_task(
+            conn, title="with-sub",
+            subscribe={"platform": "telegram", "chat_id": "123"},
+        )
+        subs = kb.list_notify_subs(conn, task_id=tid)
+    assert len(subs) == 1
+    assert subs[0]["platform"] == "telegram"
+    assert subs[0]["chat_id"] == "123"
+    assert subs[0]["task_id"] == tid
+
+
+def test_create_task_with_subscribe_includes_optional_fields(kanban_home):
+    """thread_id and user_id are persisted when passed in subscribe dict."""
+    with kb.connect() as conn:
+        tid = kb.create_task(
+            conn, title="with-optional",
+            subscribe={
+                "platform": "discord",
+                "chat_id": "456",
+                "thread_id": "thread-1",
+                "user_id": "user-1",
+            },
+        )
+        subs = kb.list_notify_subs(conn, task_id=tid)
+    assert len(subs) == 1
+    assert subs[0]["platform"] == "discord"
+    assert subs[0]["chat_id"] == "456"
+    assert subs[0]["thread_id"] == "thread-1"
+    assert subs[0]["user_id"] == "user-1"
+
+
+def test_create_task_falls_back_to_env_vars(kanban_home, monkeypatch):
+    """When subscribe=None but HERMES_NOTIFY_PLATFORM/CHAT_ID are set,
+    the env vars are used as fallback."""
+    monkeypatch.setenv("HERMES_NOTIFY_PLATFORM", "telegram")
+    monkeypatch.setenv("HERMES_NOTIFY_CHAT_ID", "999")
+    monkeypatch.setenv("HERMES_NOTIFY_THREAD_ID", "topic-x")
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="env-fallback")
+        subs = kb.list_notify_subs(conn, task_id=tid)
+    assert len(subs) == 1
+    assert subs[0]["platform"] == "telegram"
+    assert subs[0]["chat_id"] == "999"
+    assert subs[0]["thread_id"] == "topic-x"
+
+
+def test_create_task_env_vars_skipped_when_subscribe_passed(kanban_home, monkeypatch):
+    """Explicit subscribe=dict takes precedence over env vars."""
+    monkeypatch.setenv("HERMES_NOTIFY_PLATFORM", "slack")
+    monkeypatch.setenv("HERMES_NOTIFY_CHAT_ID", "111")
+    with kb.connect() as conn:
+        tid = kb.create_task(
+            conn, title="explicit-override",
+            subscribe={"platform": "telegram", "chat_id": "222"},
+        )
+        subs = kb.list_notify_subs(conn, task_id=tid)
+    assert len(subs) == 1
+    assert subs[0]["platform"] == "telegram"
+    assert subs[0]["chat_id"] == "222"
+
+
 # ---------------------------------------------------------------------------
 # Shared-board path resolution (issue #19348)
 #


### PR DESCRIPTION
## Problem

`hermes kanban create` does not auto-subscribe the creator to task notifications, while `hermes kanban create` in gateway does. The CLI path lacks the `_infer_subscribe_from_env()` fallback that the gateway path has.

Additionally, there is no way to explicitly subscribe on creation from the CLI without a separate `hermes kanban notify-subscribe` call.

## Changes

1. **`_infer_subscribe_from_env()`** — new function that reads `HERMES_NOTIFY_PLATFORM` / `HERMES_NOTIFY_CHAT_ID` / `HERMES_NOTIFY_THREAD_ID` / `HERMES_NOTIFY_USER_ID` env vars, used as a fallback when no explicit `--subscribe-*` args are given.

2. **`--subscribe-platform`, `--subscribe-chat-id`, `--subscribe-thread-id`, `--subscribe-user-id`** — new CLI arguments on `hermes kanban create` for explicit subscription.

3. **`create_task()` subscribe parameter** — `kanban_db.py` now accepts an optional `subscribe` dict and atomically creates the notification subscription inside the same write transaction as the task row.

4. **Env var fallback** — When neither explicit args nor `subscribe` param is provided, the function falls back to `HERMES_NOTIFY_*` env vars (matching the gateway path behavior).
