### PR TITLE
fix(gateway): trim command whitespace

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1076,7 +1076,7 @@ class MessageEvent:
     
     def is_command(self) -> bool:
         """Check if this is a command message (e.g., /new, /reset)."""
-        return self.text.startswith("/")
+        return self.text.strip().startswith("/")
     
     def get_command(self) -> Optional[str]:
         """Extract command name if this is a command message."""

--- a/gateway/platforms/mattermost.py
+++ b/gateway/platforms/mattermost.py
@@ -724,7 +724,9 @@ class MattermostAdapter(BasePlatformAdapter):
         chat_type = _CHANNEL_TYPE_MAP.get(channel_type_raw, "channel")
 
         # For DMs, user_id is sufficient.  For channels, check for @mention.
-        message_text = post.get("message", "")
+        # Normalize leading/trailing whitespace before mention stripping and
+        # command classification so commands pasted with padding still work.
+        message_text = post.get("message", "").strip()
 
         # Mention-gating for non-DM channels.
         # Config (config.yaml `mattermost.*` with env-var fallback):

--- a/tests/gateway/test_mattermost.py
+++ b/tests/gateway/test_mattermost.py
@@ -6,6 +6,7 @@ import pytest
 from unittest.mock import MagicMock, patch, AsyncMock
 
 from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import MessageType
 
 
 # ---------------------------------------------------------------------------
@@ -389,6 +390,58 @@ class TestMattermostWebSocketParsing:
         assert self.adapter.handle_message.called
         msg_event = self.adapter.handle_message.call_args[0][0]
         assert msg_event.source.thread_id == "root_post_123"
+
+    @pytest.mark.asyncio
+    async def test_dm_command_with_padding_is_stripped_and_classified(self):
+        """Mattermost DMs should accept slash commands with surrounding whitespace."""
+        post_data = {
+            "id": "post_command",
+            "user_id": "user_123",
+            "channel_id": "dm_chan",
+            "message": "  /status   ",
+        }
+        event = {
+            "event": "posted",
+            "data": {
+                "post": json.dumps(post_data),
+                "channel_type": "D",
+                "sender_name": "@alice",
+            },
+        }
+
+        await self.adapter._handle_ws_event(event)
+
+        assert self.adapter.handle_message.called
+        msg_event = self.adapter.handle_message.call_args[0][0]
+        assert msg_event.text == "/status"
+        assert msg_event.message_type == MessageType.COMMAND
+        assert msg_event.get_command() == "status"
+
+    @pytest.mark.asyncio
+    async def test_channel_mention_command_with_padding_is_stripped_and_classified(self):
+        """Mention-stripped channel commands should tolerate padded text."""
+        post_data = {
+            "id": "post_command_channel",
+            "user_id": "user_123",
+            "channel_id": "chan_456",
+            "message": "  @bot_user_id   /restart   ",
+        }
+        event = {
+            "event": "posted",
+            "data": {
+                "post": json.dumps(post_data),
+                "channel_type": "O",
+                "sender_name": "@alice",
+            },
+        }
+
+        await self.adapter._handle_ws_event(event)
+
+        assert self.adapter.handle_message.called
+        msg_event = self.adapter.handle_message.call_args[0][0]
+        assert msg_event.text == "/restart"
+        assert msg_event.message_type == MessageType.COMMAND
+        assert msg_event.get_command() == "restart"
 
     @pytest.mark.asyncio
     async def test_invalid_post_json_ignored(self):

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -66,6 +66,18 @@ class TestMessageEventIsCommand:
         event = MessageEvent(text="")
         assert event.is_command() is False
 
+    def test_leading_whitespace_slash_command(self):
+        event = MessageEvent(text="   /new")
+        assert event.is_command() is True
+
+    def test_leading_newline_slash_command(self):
+        event = MessageEvent(text="\n/new")
+        assert event.is_command() is True
+
+    def test_embedded_slash_not_command(self):
+        event = MessageEvent(text="hello /new")
+        assert event.is_command() is False
+
     def test_slash_only(self):
         event = MessageEvent(text="/")
         assert event.is_command() is True
@@ -79,6 +91,15 @@ class TestMessageEventGetCommand:
     def test_command_with_args(self):
         event = MessageEvent(text="/reset session")
         assert event.get_command() == "reset"
+
+    def test_leading_whitespace_command(self):
+        event = MessageEvent(text="   /new")
+        assert event.get_command() == "new"
+
+    def test_leading_newline_command_with_args(self):
+        event = MessageEvent(text="\n/new session name")
+        assert event.get_command() == "new"
+        assert event.get_command_args() == "session name"
 
     def test_not_a_command(self):
         event = MessageEvent(text="hello")


### PR DESCRIPTION
## Summary

Fixes gateway slash command handling when commands are pasted or sent with surrounding whitespace.

Changes:
- `MessageEvent.is_command()` now checks `self.text.strip().startswith("/")`, so leading whitespace before a slash command does not prevent command recognition.
- Mattermost normalizes leading/trailing whitespace before mention stripping and command classification, so padded DM/channel commands like `  /status   ` and `  @bot   /restart   ` are classified as commands and dispatch correctly.

This is intentionally separate from the Mattermost threading PR so the command parsing fix can be reviewed independently.

## Test plan

- [x] `uv run --with pytest==9.0.2 --with pytest-asyncio==1.3.0 --with pytest-timeout==2.4.0 --with aiohttp==3.13.2 pytest tests/gateway/test_platform_base.py tests/gateway/test_mattermost.py -q -o addopts=`
  - `145 passed, 2 skipped`
- [x] `python3 -m py_compile gateway/platforms/base.py gateway/platforms/mattermost.py tests/gateway/test_platform_base.py tests/gateway/test_mattermost.py`
- [x] `git diff --check origin/main..HEAD`