### PR TITLE
Add iOS Hermes Voice MVP skeleton

### DIFF
--- a/clients/ios/HermesVoice/.gitignore
+++ b/clients/ios/HermesVoice/.gitignore
@@ -1,0 +1,4 @@
+build/
+DerivedData/
+*.xcuserstate
+xcuserdata/

--- a/clients/ios/HermesVoice/HermesVoice.xcodeproj/project.pbxproj
+++ b/clients/ios/HermesVoice/HermesVoice.xcodeproj/project.pbxproj
@@ -1,0 +1,344 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 56;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		A10000000000000000000001 /* HermesVoiceApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000000000000000000001 /* HermesVoiceApp.swift */; };
+		A10000000000000000000002 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000000000000000000002 /* ContentView.swift */; };
+		A10000000000000000000003 /* Models.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000000000000000000003 /* Models.swift */; };
+		A10000000000000000000004 /* VoiceSessionAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000000000000000000004 /* VoiceSessionAPI.swift */; };
+		A10000000000000000000005 /* AudioRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000000000000000000005 /* AudioRecorder.swift */; };
+		A10000000000000000000006 /* AudioPlayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000000000000000000006 /* AudioPlayer.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		A20000000000000000000000 /* HermesVoice.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = HermesVoice.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		A20000000000000000000001 /* HermesVoiceApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HermesVoiceApp.swift; sourceTree = "<group>"; };
+		A20000000000000000000002 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		A20000000000000000000003 /* Models.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Models.swift; sourceTree = "<group>"; };
+		A20000000000000000000004 /* VoiceSessionAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceSessionAPI.swift; sourceTree = "<group>"; };
+		A20000000000000000000005 /* AudioRecorder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioRecorder.swift; sourceTree = "<group>"; };
+		A20000000000000000000006 /* AudioPlayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioPlayer.swift; sourceTree = "<group>"; };
+		A20000000000000000000007 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		A20000000000000000000008 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		A30000000000000000000001 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		A40000000000000000000001 = {
+			isa = PBXGroup;
+			children = (
+				A40000000000000000000002 /* HermesVoice */,
+				A40000000000000000000003 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		A40000000000000000000002 /* HermesVoice */ = {
+			isa = PBXGroup;
+			children = (
+				A20000000000000000000001 /* HermesVoiceApp.swift */,
+				A20000000000000000000002 /* ContentView.swift */,
+				A20000000000000000000003 /* Models.swift */,
+				A20000000000000000000004 /* VoiceSessionAPI.swift */,
+				A20000000000000000000005 /* AudioRecorder.swift */,
+				A20000000000000000000006 /* AudioPlayer.swift */,
+				A20000000000000000000007 /* Info.plist */,
+				A20000000000000000000008 /* README.md */,
+			);
+			path = HermesVoice;
+			sourceTree = "<group>";
+		};
+		A40000000000000000000003 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				A20000000000000000000000 /* HermesVoice.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		A50000000000000000000001 /* HermesVoice */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = A80000000000000000000002 /* Build configuration list for PBXNativeTarget "HermesVoice" */;
+			buildPhases = (
+				A60000000000000000000001 /* Sources */,
+				A30000000000000000000001 /* Frameworks */,
+				A60000000000000000000002 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = HermesVoice;
+			productName = HermesVoice;
+			productReference = A20000000000000000000000 /* HermesVoice.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		A70000000000000000000001 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 1510;
+				LastUpgradeCheck = 1510;
+				TargetAttributes = {
+					A50000000000000000000001 = {
+						CreatedOnToolsVersion = 15.1;
+					};
+				};
+			};
+			buildConfigurationList = A80000000000000000000001 /* Build configuration list for PBXProject "HermesVoice" */;
+			compatibilityVersion = "Xcode 14.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = A40000000000000000000001;
+			productRefGroup = A40000000000000000000003 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				A50000000000000000000001 /* HermesVoice */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		A60000000000000000000002 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		A60000000000000000000001 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A10000000000000000000001 /* HermesVoiceApp.swift in Sources */,
+				A10000000000000000000002 /* ContentView.swift in Sources */,
+				A10000000000000000000003 /* Models.swift in Sources */,
+				A10000000000000000000004 /* VoiceSessionAPI.swift in Sources */,
+				A10000000000000000000005 /* AudioRecorder.swift in Sources */,
+				A10000000000000000000006 /* AudioPlayer.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		A90000000000000000000001 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		A90000000000000000000002 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		A90000000000000000000003 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = "";
+				GENERATE_INFOPLIST_FILE = NO;
+				HERMES_SERVER_URL = "http://localhost:8000";
+				INFOPLIST_FILE = HermesVoice/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = dev.hermesagent.HermesVoice;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		A90000000000000000000004 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = "";
+				GENERATE_INFOPLIST_FILE = NO;
+				HERMES_SERVER_URL = "http://localhost:8000";
+				INFOPLIST_FILE = HermesVoice/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = dev.hermesagent.HermesVoice;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		A80000000000000000000001 /* Build configuration list for PBXProject "HermesVoice" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				A90000000000000000000001 /* Debug */,
+				A90000000000000000000002 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		A80000000000000000000002 /* Build configuration list for PBXNativeTarget "HermesVoice" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				A90000000000000000000003 /* Debug */,
+				A90000000000000000000004 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = A70000000000000000000001 /* Project object */;
+}

--- a/clients/ios/HermesVoice/HermesVoice.xcodeproj/xcshareddata/xcschemes/HermesVoice.xcscheme
+++ b/clients/ios/HermesVoice/HermesVoice.xcodeproj/xcshareddata/xcschemes/HermesVoice.xcscheme
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1510"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "A50000000000000000000001"
+               BuildableName = "HermesVoice.app"
+               BlueprintName = "HermesVoice"
+               ReferencedContainer = "container:HermesVoice.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "A50000000000000000000001"
+            BuildableName = "HermesVoice.app"
+            BlueprintName = "HermesVoice"
+            ReferencedContainer = "container:HermesVoice.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "A50000000000000000000001"
+            BuildableName = "HermesVoice.app"
+            BlueprintName = "HermesVoice"
+            ReferencedContainer = "container:HermesVoice.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/clients/ios/HermesVoice/HermesVoice/AudioPlayer.swift
+++ b/clients/ios/HermesVoice/HermesVoice/AudioPlayer.swift
@@ -1,0 +1,36 @@
+import AVFoundation
+import Foundation
+
+@MainActor
+final class AudioPlayer: NSObject, ObservableObject, AVAudioPlayerDelegate {
+    @Published private(set) var isPlaying = false
+
+    private var player: AVAudioPlayer?
+
+    func play(localFileURL: URL) throws {
+        let player = try AVAudioPlayer(contentsOf: localFileURL)
+        player.delegate = self
+        player.prepareToPlay()
+        player.play()
+        self.player = player
+        isPlaying = true
+    }
+
+    func play(remoteURL: URL) async throws {
+        let (downloadedURL, _) = try await URLSession.shared.download(from: remoteURL)
+        try play(localFileURL: downloadedURL)
+    }
+
+    func stop() {
+        player?.stop()
+        player = nil
+        isPlaying = false
+    }
+
+    nonisolated func audioPlayerDidFinishPlaying(_ player: AVAudioPlayer, successfully flag: Bool) {
+        Task { @MainActor in
+            self.player = nil
+            self.isPlaying = false
+        }
+    }
+}

--- a/clients/ios/HermesVoice/HermesVoice/AudioRecorder.swift
+++ b/clients/ios/HermesVoice/HermesVoice/AudioRecorder.swift
@@ -1,0 +1,58 @@
+import AVFoundation
+import Foundation
+
+@MainActor
+final class AudioRecorder: NSObject, ObservableObject, AVAudioRecorderDelegate {
+    @Published private(set) var isRecording = false
+
+    private var recorder: AVAudioRecorder?
+
+    func start() async throws {
+        let granted = await AVAudioApplication.requestRecordPermission()
+        guard granted else { throw RecorderError.microphonePermissionDenied }
+
+        let session = AVAudioSession.sharedInstance()
+        try session.setCategory(.playAndRecord, mode: .spokenAudio, options: [.defaultToSpeaker, .allowBluetoothHFP])
+        try session.setActive(true)
+
+        let url = Self.nextRecordingURL()
+        let settings: [String: Any] = [
+            AVFormatIDKey: Int(kAudioFormatMPEG4AAC),
+            AVSampleRateKey: 16_000,
+            AVNumberOfChannelsKey: 1,
+            AVEncoderAudioQualityKey: AVAudioQuality.medium.rawValue
+        ]
+        let recorder = try AVAudioRecorder(url: url, settings: settings)
+        recorder.delegate = self
+        recorder.record()
+        self.recorder = recorder
+        isRecording = true
+    }
+
+    func stop() -> URL? {
+        defer {
+            recorder = nil
+            isRecording = false
+        }
+        let url = recorder?.url
+        recorder?.stop()
+        return url
+    }
+
+    private static func nextRecordingURL() -> URL {
+        FileManager.default.temporaryDirectory
+            .appending(path: "hermes-turn-\(UUID().uuidString)")
+            .appendingPathExtension("m4a")
+    }
+}
+
+enum RecorderError: LocalizedError {
+    case microphonePermissionDenied
+
+    var errorDescription: String? {
+        switch self {
+        case .microphonePermissionDenied:
+            return "Microphone permission is required to call Jeeves."
+        }
+    }
+}

--- a/clients/ios/HermesVoice/HermesVoice/ContentView.swift
+++ b/clients/ios/HermesVoice/HermesVoice/ContentView.swift
@@ -1,0 +1,116 @@
+import SwiftUI
+
+@MainActor
+final class CallViewModel: ObservableObject {
+    @Published var status: CallStatus = .idle
+    @Published var messages: [VoiceMessage] = [
+        VoiceMessage(speaker: .system, text: "Tap Call Jeeves to start a Hermes voice session.")
+    ]
+
+    private let api = VoiceSessionAPI()
+    private let recorder = AudioRecorder()
+    private let player = AudioPlayer()
+    private var activeSession: VoiceSession?
+
+    var isBusy: Bool {
+        if case .starting = status { return true }
+        if case .ending = status { return true }
+        return false
+    }
+
+    var buttonTitle: String { status.isCalling ? "Hang Up" : "Call Jeeves" }
+
+    func toggleCall() {
+        if status.isCalling {
+            Task { await hangUp() }
+        } else {
+            Task { await startCall() }
+        }
+    }
+
+    private func startCall() async {
+        status = .starting
+        do {
+            let session = try await api.createSession()
+            activeSession = session
+            status = .calling(sessionID: session.id)
+            messages.append(VoiceMessage(speaker: .system, text: "Session \(session.id) started."))
+            try await recorder.start()
+            messages.append(VoiceMessage(speaker: .system, text: "Recording started. Tap Hang Up to end the MVP session."))
+        } catch {
+            status = .failed(error.localizedDescription)
+            messages.append(VoiceMessage(speaker: .system, text: error.localizedDescription))
+        }
+    }
+
+    private func hangUp() async {
+        status = .ending
+        let recordingURL = recorder.stop()
+        let session = activeSession
+        activeSession = nil
+
+        do {
+            if let session, let recordingURL {
+                let turn = try await api.sendTurn(sessionID: session.id, audioFileURL: recordingURL)
+                if let transcript = turn.transcript, !transcript.isEmpty {
+                    messages.append(VoiceMessage(speaker: .user, text: transcript))
+                }
+                if let reply = turn.reply, !reply.isEmpty {
+                    messages.append(VoiceMessage(speaker: .hermes, text: reply))
+                }
+                if let audioURL = turn.audioURL {
+                    try await player.play(remoteURL: audioURL)
+                }
+                try await api.endSession(sessionID: session.id)
+            }
+            status = .idle
+            messages.append(VoiceMessage(speaker: .system, text: "Call ended."))
+        } catch {
+            status = .failed(error.localizedDescription)
+            messages.append(VoiceMessage(speaker: .system, text: error.localizedDescription))
+        }
+    }
+}
+
+struct ContentView: View {
+    @StateObject private var viewModel = CallViewModel()
+
+    var body: some View {
+        NavigationStack {
+            VStack(spacing: 24) {
+                Text(viewModel.status.text)
+                    .font(.headline)
+                    .foregroundStyle(viewModel.status.isCalling ? .green : .secondary)
+
+                Button(action: viewModel.toggleCall) {
+                    Text(viewModel.buttonTitle)
+                        .font(.title2.weight(.semibold))
+                        .frame(width: 220, height: 220)
+                        .background(viewModel.status.isCalling ? Color.red : Color.accentColor)
+                        .foregroundStyle(.white)
+                        .clipShape(Circle())
+                        .shadow(radius: 8)
+                }
+                .disabled(viewModel.isBusy)
+                .accessibilityIdentifier("callJeevesButton")
+
+                List(viewModel.messages) { message in
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text(message.speaker.rawValue)
+                            .font(.caption.weight(.bold))
+                            .foregroundStyle(.secondary)
+                        Text(message.text)
+                            .font(.body)
+                    }
+                    .padding(.vertical, 4)
+                }
+            }
+            .padding()
+            .navigationTitle("Hermes Voice")
+        }
+    }
+}
+
+#Preview {
+    ContentView()
+}

--- a/clients/ios/HermesVoice/HermesVoice/HermesVoiceApp.swift
+++ b/clients/ios/HermesVoice/HermesVoice/HermesVoiceApp.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+@main
+struct HermesVoiceApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/clients/ios/HermesVoice/HermesVoice/Info.plist
+++ b/clients/ios/HermesVoice/HermesVoice/Info.plist
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleDisplayName</key>
+	<string>Hermes Voice</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>HERMES_SERVER_URL</key>
+	<string>$(HERMES_SERVER_URL)</string>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>Hermes Voice records your speech so Jeeves can respond during a voice session.</string>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+	</dict>
+</dict>
+</plist>

--- a/clients/ios/HermesVoice/HermesVoice/Models.swift
+++ b/clients/ios/HermesVoice/HermesVoice/Models.swift
@@ -1,0 +1,61 @@
+import Foundation
+
+struct VoiceMessage: Identifiable, Equatable {
+    enum Speaker: String {
+        case user = "You"
+        case hermes = "Hermes"
+        case system = "System"
+    }
+
+    let id = UUID()
+    let speaker: Speaker
+    let text: String
+}
+
+struct VoiceSession: Codable, Equatable {
+    let id: String
+}
+
+struct CreateVoiceSessionResponse: Codable {
+    let id: String
+}
+
+struct CreateTurnResponse: Codable {
+    let transcript: String?
+    let reply: String?
+    let audioURL: URL?
+
+    enum CodingKeys: String, CodingKey {
+        case transcript
+        case reply
+        case audioURL = "audio_url"
+    }
+}
+
+enum CallStatus: Equatable {
+    case idle
+    case starting
+    case calling(sessionID: String)
+    case ending
+    case failed(String)
+
+    var text: String {
+        switch self {
+        case .idle:
+            return "Ready"
+        case .starting:
+            return "Dialing Jeeves..."
+        case .calling:
+            return "Connected"
+        case .ending:
+            return "Hanging up..."
+        case .failed(let message):
+            return "Error: \(message)"
+        }
+    }
+
+    var isCalling: Bool {
+        if case .calling = self { return true }
+        return false
+    }
+}

--- a/clients/ios/HermesVoice/HermesVoice/VoiceSessionAPI.swift
+++ b/clients/ios/HermesVoice/HermesVoice/VoiceSessionAPI.swift
@@ -1,0 +1,81 @@
+import Foundation
+
+struct VoiceSessionAPI {
+    var baseURL: URL
+    var urlSession: URLSession = .shared
+
+    init(baseURL: URL = AppConfiguration.serverURL) {
+        self.baseURL = baseURL
+    }
+
+    func createSession() async throws -> VoiceSession {
+        let url = baseURL.appending(path: "/v1/voice/sessions")
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = try JSONEncoder().encode(["client": "ios-swiftui-mvp"])
+
+        let response: CreateVoiceSessionResponse = try await send(request)
+        return VoiceSession(id: response.id)
+    }
+
+    func sendTurn(sessionID: String, audioFileURL: URL) async throws -> CreateTurnResponse {
+        let url = baseURL.appending(path: "/v1/voice/sessions/\(sessionID)/turns")
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+
+        let boundary = "Boundary-\(UUID().uuidString)"
+        request.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
+        request.httpBody = try multipartBody(audioFileURL: audioFileURL, boundary: boundary)
+
+        return try await send(request)
+    }
+
+    func endSession(sessionID: String) async throws {
+        let url = baseURL.appending(path: "/v1/voice/sessions/\(sessionID)")
+        var request = URLRequest(url: url)
+        request.httpMethod = "DELETE"
+        _ = try await sendRaw(request)
+    }
+
+    private func send<T: Decodable>(_ request: URLRequest) async throws -> T {
+        let data = try await sendRaw(request)
+        return try JSONDecoder().decode(T.self, from: data)
+    }
+
+    private func sendRaw(_ request: URLRequest) async throws -> Data {
+        let (data, response) = try await urlSession.data(for: request)
+        guard let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode) else {
+            throw URLError(.badServerResponse)
+        }
+        return data
+    }
+
+    private func multipartBody(audioFileURL: URL, boundary: String) throws -> Data {
+        var data = Data()
+        let fileData = try Data(contentsOf: audioFileURL)
+        data.append("--\(boundary)\r\n")
+        data.append("Content-Disposition: form-data; name=\"audio\"; filename=\"turn.m4a\"\r\n")
+        data.append("Content-Type: audio/mp4\r\n\r\n")
+        data.append(fileData)
+        data.append("\r\n--\(boundary)--\r\n")
+        return data
+    }
+}
+
+private extension Data {
+    mutating func append(_ string: String) {
+        append(Data(string.utf8))
+    }
+}
+
+enum AppConfiguration {
+    static var serverURL: URL {
+        if let value = Bundle.main.object(forInfoDictionaryKey: "HERMES_SERVER_URL") as? String,
+           let url = URL(string: value),
+           !value.isEmpty {
+            return url
+        }
+        return URL(string: "http://localhost:8000")!
+    }
+}

--- a/clients/ios/HermesVoice/README.md
+++ b/clients/ios/HermesVoice/README.md
@@ -1,0 +1,80 @@
+# Hermes Voice iOS MVP
+
+Minimal SwiftUI iOS client skeleton for the phase-3-simple Hermes voice flow: tap one large button to dial Jeeves, start a backend voice session, record a single turn, hang up, and display transcript/reply messages.
+
+This is intentionally **not** a real VoIP/CallKit implementation yet. It does not receive background calls, integrate PushKit, maintain a persistent audio stream, or present the native iOS call UI.
+
+## Requirements
+
+- Xcode 15+
+- iOS 17+
+- A Hermes backend exposing the provisional voice-session contract below
+
+## Project
+
+Open:
+
+```bash
+open clients/ios/HermesVoice/HermesVoice.xcodeproj
+```
+
+Build from the repo root or this directory:
+
+```bash
+xcodebuild \
+  -project clients/ios/HermesVoice/HermesVoice.xcodeproj \
+  -target HermesVoice \
+  -sdk iphonesimulator \
+  CODE_SIGNING_ALLOWED=NO \
+  build
+```
+
+## Server URL configuration
+
+The app reads `HERMES_SERVER_URL` from `Info.plist`, backed by the Xcode build setting of the same name. The default is:
+
+```text
+http://localhost:8000
+```
+
+For device testing, override `HERMES_SERVER_URL` in Xcode build settings or via an `.xcconfig` that is not committed if it contains user-specific values.
+
+## Microphone permission
+
+`HermesVoice/Info.plist` includes:
+
+```xml
+<key>NSMicrophoneUsageDescription</key>
+<string>Hermes Voice records your speech so Jeeves can respond during a voice session.</string>
+```
+
+The app requests microphone access when the user starts a call.
+
+## Provisional backend contract
+
+The iOS skeleton uses simple endpoints until the backend voice slice stabilizes:
+
+- `POST /v1/voice/sessions`
+  - Request JSON: `{ "client": "ios-swiftui-mvp" }`
+  - Response JSON: `{ "id": "session-id" }`
+- `POST /v1/voice/sessions/{id}/turns`
+  - Request: multipart form-data with an `audio` field containing an `.m4a` recording
+  - Response JSON: `{ "transcript": "...", "reply": "...", "audio_url": "https://..." }`
+  - All response fields are optional so early backend implementations can return partial data.
+- `DELETE /v1/voice/sessions/{id}`
+  - Ends the session.
+
+## Current UX
+
+- Idle state: button says **Call Jeeves**.
+- Calling state: session is created and recording starts.
+- Hang up: recording stops, one audio turn is posted, optional transcript/reply/audio response is rendered, then the session is deleted.
+
+## Files
+
+- `HermesVoiceApp.swift` — app entry point
+- `ContentView.swift` — SwiftUI UI and simple call view model
+- `VoiceSessionAPI.swift` — provisional voice session API client
+- `AudioRecorder.swift` — AVFoundation `.m4a` recorder scaffold
+- `AudioPlayer.swift` — AVFoundation reply playback scaffold
+- `Models.swift` — small UI/API models


### PR DESCRIPTION
## Summary
- add a minimal iOS 17 SwiftUI Hermes Voice client under clients/ios/HermesVoice
- implement one-button call/hang-up UI with status text and transcript/reply list
- add provisional voice-session API client for POST /v1/voice/sessions, POST /v1/voice/sessions/{id}/turns, and DELETE /v1/voice/sessions/{id}
- add AVFoundation recorder/player scaffolding and setup README

## Validation
- xcodebuild -project clients/ios/HermesVoice/HermesVoice.xcodeproj -target HermesVoice -sdk iphonesimulator CODE_SIGNING_ALLOWED=NO build

## Notes
- intentionally not a real VoIP/CallKit/PushKit implementation yet
- backend voice-session contract is provisional and documented in the README