### PR TITLE
feat(skills): add blockchain/mine-bean optional skill

### DIFF
--- a/optional-skills/blockchain/mine-bean/SKILL.md
+++ b/optional-skills/blockchain/mine-bean/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: mine-bean
+version: 0.2.0
+description: Mine $BEAN on Base from inside Hermes Agent. Round-based on-chain deployment, five strategy presets, autonomous cron mode, signed Gitlawb audit log.
+author: MineBean
+license: MIT
+homepage: https://minebean.com
+repository: https://github.com/damo-nu11/hermes-mine-bean
+network: base-mainnet
+audit_log: gitlawb://did:key:z6MkwVfgaAnuypajisEkJLkVbWPiPEBwceMkGutfXpEEYHKi/minebean-rounds
+---
+
+# mine-bean
+
+MineBean ($BEAN) is a round-based mining game on Base. New round every 60 seconds. Pick a strategy, deploy ETH into blocks on a 5x5 grid, earn $BEAN rewards on each round close. Occasional beanpot jackpots hit ~1-in-777 rounds.
+
+This skill gives any Hermes agent access to the live game through seven tools and a `/minebean` slash command. Run interactively from a chat, or schedule headless mining via the bundled `hermes-minebean-deploy` console script.
+
+## Install
+
+```bash
+pip install hermes-mine-bean
+hermes plugins enable minebean
+```
+
+Or with MCP support for Claude Desktop / Cursor:
+
+```bash
+pip install "hermes-mine-bean[mcp]"
+```
+
+## Configure
+
+Add to `~/.hermes/.env`:
+
+```
+# Required for autonomous mining (broadcasting)
+MINEBEAN_DEPLOYER_KEY=0x...your_dedicated_test_wallet_private_key...
+
+# Or for Bankr-managed signing
+# BANKR_API_KEY=bk_ptr_...
+# MINEBEAN_MINER_ADDRESS=0x...
+
+# Optional safety guards
+MINEBEAN_MAX_DEPLOYS_PER_DAY=100
+MINEBEAN_PER_BLOCK_WEI=2500000000000
+
+# Optional RPC override
+# BASE_RPC_URL=https://mainnet.base.org
+```
+
+For read-only inspection (no broadcasting):
+
+```
+MINEBEAN_MINER_ADDRESS=0x...the_address_you_want_to_observe...
+```
+
+## Tools
+
+| Tool | What it does |
+|---|---|
+| `minebean_status` | Live round state, beanpot pool, caller's pending balances |
+| `minebean_pending` | Pending ETH + BEAN for any address |
+| `minebean_set_profile` | Save default strategy (sniper, anti-winner, beanpot-hunter, anti-loser, nostradamus) |
+| `minebean_deploy` | Build deploy plan, optionally broadcast (dry-run default) |
+| `minebean_claim` | Claim pending winnings (dry-run default) |
+| `minebean_autostart` | Install autonomous mining cron job |
+| `minebean_autostop` | Remove the cron job |
+
+Slash command: `/minebean <subcommand>`. Try `/minebean status` first.
+
+## Strategy presets
+
+All five use the closed-form EV optimum `X* = sqrt(K × P × T) − T` where P is BEAN price in ETH, T is the deployment total (strategy-specific), and K = B / 0.105.
+
+| Preset | Blocks | T source | K | At T ≥ threshold |
+|---|---|---|---|---|
+| anti-winner | 24 (excl. prev winner) | current grid | 10.476 (B=1.1) | Deploy minimum (beanpot eligibility) |
+| nostradamus | All 25 | avg of last 3 rounds | 9.524 (B=1.0) | Skip |
+| anti-loser | 24 (excl. coldest 100-rd) | max(grid, avg last 3) | 9.524 | Skip |
+| sniper | All 25 | live grid at deploy | 9.524 | Skip |
+| beanpot-hunter | All 25 | current grid | dynamic (B=1+pot/777) | Skip if pot < 62.16 BEAN |
+
+Beanpot-hunter additionally scales size linearly from 0.5% of wallet at 62.16 BEAN to max at 700 BEAN. Sniper uses adaptive 2-10s timing offsets at broadcast.
+
+## Autonomous mode
+
+```bash
+hermes cron add --name "MineBean deploy" --no-agent --script /path/to/wrapper.sh "every 60s"
+```
+
+Or use the built-in autostart: `/minebean autostart every 60s`.
+
+The cron entry enforces `MINEBEAN_MAX_DEPLOYS_PER_DAY` and exits cleanly on ceiling hit (cron doesn't error-spam).
+
+## Privacy mode
+
+Configure your Hermes runtime to route LLM inference through Venice for end-to-end no-log privacy. The skill itself runs entirely on-chain reads + writes, so privacy mode is about your conversational layer with the agent, not the mining loop.
+
+## Safety
+
+- `dry_run=true` is the hard default on every deploy and claim call. Live broadcast requires `MINEBEAN_LIVE_BROADCAST_UNLOCKED=1`.
+- Daily deploy ceiling enforced via env var
+- Already-deployed-this-round guard prevents accidental double-deploys
+- Readonly mode (just `MINEBEAN_MINER_ADDRESS`, no key) lets users inspect any address without exposing keys
+
+## Verifiability
+
+Every round is mirrored to `gitlawb://did:key:.../minebean-rounds` every 5 minutes. Signed, append-only, replicated across the Gitlawb network. Pull the latest window file to audit any round independently of minebean.com.
+
+## Repo
+
+Source, issues, releases: https://github.com/damo-nu11/hermes-mine-bean

--- a/optional-skills/blockchain/mine-bean/scripts/minebean_client.py
+++ b/optional-skills/blockchain/mine-bean/scripts/minebean_client.py
@@ -1,0 +1,68 @@
+"""Minimal MineBean client helper.
+
+Ships at agent.minebean.com/.well-known/skills/mine-bean/scripts/minebean_client.py
+as a fallback path for Hermes agents that prefer a single-file install over the
+full pip package. The pip package (hermes-mine-bean) is the recommended path
+because it ships the full 7-tool plugin, MCP server, and console script.
+
+This file is intentionally tiny. It just shows how to read the current MineBean
+round state directly from Base mainnet without any dependencies beyond stdlib
++ requests (which Hermes already ships with).
+
+Usage:
+    python minebean_client.py
+"""
+from __future__ import annotations
+
+import json
+import sys
+import urllib.request
+
+
+BASE_RPC_URL = "https://mainnet.base.org"
+GRIDMINING_ADDRESS = "0x9632495bDb93FD6B0740Ab69cc6c71C9c01da4f0"
+
+# Function selector for `currentRoundId()`, computed once and hardcoded so we
+# don't need eth-abi/eth-hash to derive it at runtime.
+CURRENT_ROUND_ID_SELECTOR = "0x4cf088d9"
+
+
+def _rpc(method: str, params: list, *, timeout: int = 30) -> dict:
+    """Bare stdlib JSON-RPC call. User-Agent header is required by Base's RPC."""
+    body = json.dumps({"jsonrpc": "2.0", "method": method, "params": params, "id": 1}).encode()
+    req = urllib.request.Request(
+        BASE_RPC_URL,
+        data=body,
+        headers={
+            "Content-Type": "application/json",
+            "User-Agent": "minebean-client/0.2.0",
+        },
+        method="POST",
+    )
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        return json.loads(resp.read().decode())
+
+
+def current_round_id() -> int:
+    """Read the current round id from GridMining."""
+    result = _rpc(
+        "eth_call",
+        [{"to": GRIDMINING_ADDRESS, "data": CURRENT_ROUND_ID_SELECTOR}, "latest"],
+    )
+    if "error" in result:
+        raise RuntimeError(f"RPC error: {result['error']}")
+    return int(result["result"], 16)
+
+
+def main() -> int:
+    try:
+        round_id = current_round_id()
+        print(json.dumps({"ok": True, "current_round_id": round_id}))
+        return 0
+    except Exception as exc:
+        print(json.dumps({"ok": False, "error": f"{type(exc).__name__}: {exc}"}))
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
# feat(skills): add blockchain/mine-bean optional skill

Adds a new optional skill `optional-skills/blockchain/mine-bean/` for mining $BEAN on the MineBean protocol (Base mainnet, chain 8453). Mirrors the structure of the existing `optional-skills/blockchain/base/` and the recently-proposed `blockchain/botcoin-mining/` skill (#21054).

## What it does

MineBean is a round-based on-chain mining game on Base. Every 60 seconds a new round opens on a 5×5 grid; miners deploy ETH into blocks and earn $BEAN rewards plus an ETH share when the round closes. Occasional beanpot jackpots hit ~1-in-777 rounds.

This skill gives any Hermes Agent five canonical EV-aware strategy presets (sniper, anti-winner, anti-loser, nostradamus, beanpot-hunter), each using the closed-form optimum `X* = sqrt(K × P × T) − T` against the live grid. The skill files cover read-only observation; for write paths, agents are pointed at the full pip-installable plugin.

## Files added (2 net-new, 0 modified)

- `optional-skills/blockchain/mine-bean/SKILL.md` — frontmatter + Procedure (install, configure, strategy table, autonomous mode, safety, verifiability via Gitlawb)
- `optional-skills/blockchain/mine-bean/scripts/minebean_client.py` — stdlib-only readonly helper (`currentRoundId()` via `eth_call` to the GridMining contract at `0x9632495bDb93FD6B0740Ab69cc6c71C9c01da4f0`)

Both files are byte-identical to what is hosted at:
- https://agent.minebean.com/.well-known/skills/mine-bean/SKILL.md
- https://agent.minebean.com/.well-known/skills/mine-bean/scripts/minebean_client.py

## Companion artifacts (not in this PR)

- Full Hermes-native plugin at `github.com/damo-nu11/hermes-mine-bean` (registered tools, `/minebean` slash command, autonomous cron entry, MCP server)
- PyPI: `hermes-mine-bean` (planned shortly)
- Live mining receipts on Base:
  - Anti-winner first broadcast: https://basescan.org/tx/0x6662a2adb55adfdf1a75e1dfd1766b5e36dbed455bbe5acdac0f316ff8c3600c
  - Sniper: https://basescan.org/tx/0x9e5d0935070e87e9586609517921b985a71a47a7fa1812248d3322460afbf33b
  - Nostradamus: https://basescan.org/tx/0x7896d16ffa06bba469c8539ea101768def4f14f7b8c4843a3e73a5b58c6cb803
  - Beanpot-hunter: https://basescan.org/tx/0x93dc4b0400d7e1d679e68d05fcd55460d9204e34f957b7df86be98e16a11cf2a

## Safety

Live broadcast in the companion plugin is gated behind `MINEBEAN_LIVE_BROADCAST_UNLOCKED=1`. The skill itself (this PR) does not include any write paths; the readonly client only calls `currentRoundId()` and surfaces the state. Any user wanting to actually mine installs the full plugin separately.

## Verifiability

Every settled round is mirrored to a signed Gitlawb DID (`gitlawb://did:key:z6MkwVfgaAnuypajisEkJLkVbWPiPEBwceMkGutfXpEEYHKi/minebean-rounds`) every 5 minutes. Pull any window file to audit round outcomes independently of `minebean.com`.

## License

MIT. Author: MineBean (https://minebean.com).