### PR TITLE
fix(kanban): worker spawn uses -z oneshot at root level

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -5392,7 +5392,7 @@ def _default_spawn(
         cmd.extend(["-m", task.model_override])
     cmd.extend([
         "chat",
-        "-q", prompt,
+        "-z", prompt,  # -z = one-shot mode, skips TUI init (fixes protocol violation in no-TTY envs like launchd/cron)
     ])
     # Redirect output to a per-task log under <board-root>/logs/.
     # Anchored at the board root (not the shared kanban root), so

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -5391,9 +5391,10 @@ def _default_spawn(
     if task.model_override:
         cmd.extend(["-m", task.model_override])
     cmd.extend([
-        "chat",
-        "-z", prompt,  # -z = one-shot mode, skips TUI init (fixes protocol violation in no-TTY envs like launchd/cron)
+        "-z", prompt,  # -z = one-shot mode at root level, skips TUI init
     ])
+    # -z is a root-level flag — the "chat" subcommand is not needed
+    # and would cause "unrecognized arguments" if placed after it.
     # Redirect output to a per-task log under <board-root>/logs/.
     # Anchored at the board root (not the shared kanban root), so
     # `hermes kanban log` on a specific board reads its own file and


### PR DESCRIPTION
## Summary

Two related fixes to `kanban-worker` skill's worker-spawn command so it works under headless / no-TTY environments (launchd, cron, CI).

1. **`-q` → `-z` / `--oneshot`** for the spawn command. `-q` triggers TUI initialization which fails in no-TTY environments and causes workers to exit rc=0 without ever calling `kanban_complete`. The upstream `-z` flag is designed exactly for scripted/headless use — skips banner, spinner, and TUI init entirely. (commit `ed66ee0a9`)

2. **Move `-z` to root-level argparse position** + remove the redundant `chat` subcommand. `-z` is a root-level argparse flag; when placed after the `chat` subcommand it raises `unrecognized arguments`. `-z` is designed to work without `chat` anyway. (commit `70f7f6b8b`)

## Background

Discovered while running a long-lived launchd-driven `hermes kanban dispatch` loop. Workers spawned by the kanban-worker skill exited immediately with rc=0 but never wrote `kanban_complete`, leaving tasks in `claimed` state until heartbeat timeout reclaimed them — silent failure mode. Root cause was `-q` blocking on TUI initialization in the no-TTY environment.

Both flags (`-q` and `-z`) already exist in upstream `run_agent.py`; this change is purely on the consumer side (the `kanban-worker` skill that builds the spawn command).

## Test plan

- [x] Local: launchd-managed `hermes kanban dispatch` loop on macOS now completes tasks end-to-end (kanban_complete written, status transitions to done)
- [x] Local: confirmed `-z` skips TUI init and writes session log normally
- [ ] Maintainers may want to verify against CI / non-launchd headless setups

🤖 Generated with [Claude Code](https://claude.com/claude-code)