### PR TITLE
fix(cli): detect pipx-managed installs in `hermes update`

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -8353,15 +8353,44 @@ def cmd_update(args):
 
 
 def _cmd_update_pip(args):
-    """Update Hermes via pip (for PyPI installs)."""
+    """Update Hermes via pip (for PyPI installs).
+
+    Detects pipx-managed installs (sys.prefix contains "pipx") and uses
+    ``pipx upgrade hermes-agent`` so the venv-managed install path works.
+    Without this check, ``uv pip install --upgrade hermes-agent`` fails on
+    pipx installs with "No virtual environment found; run ``uv venv`` to
+    create an environment, or pass ``--system`` to install into a non-virtual
+    environment" because uv refuses to mutate the system Python.
+    """
     from hermes_cli import __version__
 
     print(f"→ Current version: {__version__}")
     print("→ Checking PyPI for updates...")
 
+    # pipx-managed installs put the package under .../pipx/venvs/<name>/...
+    pipx_managed = "pipx" in sys.prefix.split(os.sep)
+    if pipx_managed:
+        pipx = shutil.which("pipx")
+        if pipx:
+            cmd = [pipx, "upgrade", "hermes-agent"]
+            print(f"→ Detected pipx-managed install; running: {' '.join(cmd)}")
+            result = subprocess.run(cmd)
+            if result.returncode != 0:
+                print("✗ Update failed")
+                sys.exit(1)
+            print("✓ Update complete! Restart hermes to use the new version.")
+            return
+        print(
+            "⚠ pipx-managed install detected but `pipx` binary not on PATH; "
+            "falling back to uv/pip"
+        )
+
     uv = shutil.which("uv")
     if uv:
-        cmd = [uv, "pip", "install", "--upgrade", "hermes-agent"]
+        # ``--system`` lets uv target the active interpreter when no venv is
+        # active, matching pip's default behaviour for ``hermes update``
+        # invoked outside an explicit venv.
+        cmd = [uv, "pip", "install", "--system", "--upgrade", "hermes-agent"]
     else:
         cmd = [sys.executable, "-m", "pip", "install", "--upgrade", "hermes-agent"]
 


### PR DESCRIPTION
## What changed and why

`hermes update` fails for pipx-managed installs (`pipx install hermes-agent`) because `_cmd_update_pip` invokes `uv pip install --upgrade hermes-agent` without `--system` or being inside a venv. uv refuses to mutate the system Python and prints:

```
error: No virtual environment found; run `uv venv` to create an environment,
or pass `--system` to install into a non-virtual environment
✗ Update failed
```

The launchd auto-updater at `scripts/auto-update.sh` already uses `pipx upgrade hermes-agent` and works correctly, so the interactive `hermes update` command is the only path that breaks for pipx users.

This PR makes `_cmd_update_pip` detect pipx-managed installs (`sys.prefix` contains `pipx`) and switch to `pipx upgrade hermes-agent`, matching the auto-updater. For non-pipx pip installs, `--system` is added to the `uv pip install` fallback so the same uv-no-venv failure does not affect users on bare pip installs invoked outside an active venv. The plain `python -m pip install` fallback is unchanged.

## How to reproduce the bug (before the fix)

```bash
pipx install hermes-agent
hermes update
# → ✗ Update failed
```

## How to test the fix

```bash
pipx install hermes-agent
hermes update
# → ✓ Detected pipx-managed install; running: /opt/homebrew/bin/pipx upgrade hermes-agent
# → ✓ Update complete! Restart hermes to use the new version.
```

## Platforms tested

- macOS 26.3.1 (Tahoe) on Apple Silicon
- pipx 1.12.0 + Python 3.14 + uv 0.11.15
- hermes-agent 0.14.0

I have not been able to test on Linux or WSL2; the patch is OS-agnostic (no platform-specific paths or shell quoting) but a second pair of eyes on those targets would be welcome.

## Scope

Single function change (`_cmd_update_pip`), no behavior change for non-pipx installs except adding `--system` to the uv fallback which matches uv's own recommendation when running outside a venv. No new dependencies, no test coverage added (the function currently has none in `tests/` to extend).

Conventional Commits: `fix(cli): detect pipx-managed installs in _cmd_update_pip`.