### PR TITLE
Fix #29726 — MCP server startup hang fix

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -13368,8 +13368,9 @@ Examples:
 
             discover_mcp_tools()
         except Exception:
-            logger.debug(
-                "MCP tool discovery failed at CLI startup",
+            logger.warning(
+                "MCP tool discovery failed at CLI startup — one or more "
+                "optional MCP servers may be unavailable. See logs for details.",
                 exc_info=True,
             )
         try:

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -1660,9 +1660,25 @@ class MCPServerTask:
                 self.session = None
 
     async def start(self, config: dict):
-        """Create the background Task and wait until ready (or failed)."""
+        """Create the background Task and wait until ready (or failed).
+
+        Raises asyncio.TimeoutError if the server does not become ready
+        within ``connect_timeout`` seconds.  On timeout the orphaned
+        run-task is cancelled to avoid resource leaks.
+        """
+        connect_timeout = config.get("connect_timeout", _DEFAULT_CONNECT_TIMEOUT)
         self._task = asyncio.ensure_future(self.run(config))
-        await self._ready.wait()
+        try:
+            await asyncio.wait_for(self._ready.wait(), timeout=connect_timeout)
+        except asyncio.TimeoutError:
+            # The server task is still spinning — cancel it to prevent leaks.
+            self._task.cancel()
+            try:
+                await self._task
+            except (asyncio.CancelledError, Exception):
+                pass
+            raise
+
         if self._error:
             raise self._error
 


### PR DESCRIPTION
Fix #29726 — One unhealthy optional MCP integration should not make the whole Hermes session unavailable

## Problem
When an MCP server is configured under `mcp_servers`, Hermes attempts to connect and discover tools during startup. If that MCP server is down, slow, misconfigured, or fails during `initialize` / `list_tools`, Hermes startup could hang indefinitely before the normal chat session becomes usable.

## Root Cause
The `MCPServerTask.start()` method called `await self._ready.wait()` with no timeout wrapper. If the server's internal `run()` loop never fires `_ready.set()` (e.g., due to a silently swallowed exception in a nested transport handler), `start()` blocks forever — and since MCP discovery runs serially per-server, one dead server freezes the entire startup.

## Fix
1. **`MCPServerTask.start()`** — wrapped `await self._ready.wait()` in `asyncio.wait_for(timeout=connect_timeout)`. On timeout: cancels the orphaned run-task to prevent resource leaks, then raises `TimeoutError`.
2. **`hermes_cli/main.py`** — changed MCP startup error log from `logger.debug` → `logger.warning` so users see a clear "MCP tool discovery failed" message instead of silently losing tools.

## Behavior Change
- Before: A hung/stuck MCP server could block Hermes startup indefinitely.
- After: Per-server connection timeout (default 60s, configurable via `connect_timeout`) limits wait time. Failed servers log a visible warning. The rest of Hermes starts normally with available servers only.

## Notes
- No breaking API changes. All existing MCP configs work identically.
- `discover_mcp_tools()` already used `asyncio.gather(return_exceptions=True)` and logged warnings for per-server failures — this just adds the missing timeout guard at the lowest level (`start()`).