### PR TITLE
fix(cron): restore cron session environment after jobs

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -44,6 +44,7 @@ from hermes_cli._subprocess_compat import windows_hide_flags
 from hermes_cli.config import load_config, _expand_env_vars
 from hermes_cli.fallback_config import get_fallback_chain
 from hermes_time import now as _hermes_now
+from tools.approval import reset_hermes_cron_context, set_hermes_cron_context
 
 logger = logging.getLogger(__name__)
 
@@ -2749,6 +2750,17 @@ def _guard_job_credential_exfil(job: dict) -> None:
 def run_job(
     job: dict, *, defer_agent_teardown: Optional[list] = None
 ) -> tuple[bool, str, str, Optional[str]]:
+    """Execute a single cron job with cron approval context bound."""
+    token = set_hermes_cron_context(True)
+    try:
+        return _run_job_impl(job, defer_agent_teardown=defer_agent_teardown)
+    finally:
+        reset_hermes_cron_context(token)
+
+
+def _run_job_impl(
+    job: dict, *, defer_agent_teardown: Optional[list] = None
+) -> tuple[bool, str, str, Optional[str]]:
     """
     Execute a single cron job.
 
@@ -3004,11 +3016,6 @@ def run_job(
     logger.info("Prompt: %s", prompt[:100])
 
     agent = None
-
-    # Mark this as a cron session so the approval system can apply cron_mode.
-    # This env var is process-wide and persists for the lifetime of the
-    # scheduler process — every job this process runs is a cron job.
-    os.environ["HERMES_CRON_SESSION"] = "1"
 
     # Use ContextVars for per-job session/delivery state so parallel jobs
     # don't clobber each other's targets (os.environ is process-global).

--- a/tests/cron/test_cron_approval_context.py
+++ b/tests/cron/test_cron_approval_context.py
@@ -1,0 +1,80 @@
+import concurrent.futures
+import os
+import threading
+
+import pytest
+
+import cron.scheduler as scheduler
+import tools.approval as approval
+
+
+@pytest.mark.parametrize("initial", [None, "legacy"])
+def test_run_job_preserves_original_cron_env(monkeypatch, initial):
+    if initial is None:
+        monkeypatch.delenv("HERMES_CRON_SESSION", raising=False)
+    else:
+        monkeypatch.setenv("HERMES_CRON_SESSION", initial)
+
+    seen = {}
+
+    def fake_impl(job, *, defer_agent_teardown=None):
+        seen["is_cron"] = approval.is_hermes_cron_session()
+        seen["env"] = os.environ.get("HERMES_CRON_SESSION")
+        return True, "out", "final", None
+
+    monkeypatch.setattr(scheduler, "_run_job_impl", fake_impl)
+
+    assert scheduler.run_job({"id": "env-preserve"}) == (
+        True,
+        "out",
+        "final",
+        None,
+    )
+
+    assert seen == {"is_cron": True, "env": initial}
+    assert os.environ.get("HERMES_CRON_SESSION") == initial
+
+
+def test_run_job_resets_cron_context_after_setup_exception(monkeypatch):
+    monkeypatch.delenv("HERMES_CRON_SESSION", raising=False)
+
+    with pytest.raises(KeyError):
+        scheduler.run_job({"prompt": "missing id"})
+
+    assert approval.is_hermes_cron_session() is False
+
+
+def test_cron_context_does_not_leak_to_parallel_gateway_context(monkeypatch):
+    monkeypatch.delenv("HERMES_CRON_SESSION", raising=False)
+    monkeypatch.setenv("HERMES_GATEWAY_SESSION", "1")
+
+    entered = threading.Event()
+    release = threading.Event()
+    seen = {}
+
+    def fake_impl(job, *, defer_agent_teardown=None):
+        seen["cron_thread_is_cron"] = approval.is_hermes_cron_session()
+        seen["cron_thread_is_gateway"] = approval._is_gateway_approval_context()
+        entered.set()
+        assert release.wait(5), "test timed out waiting to release cron job"
+        return True, "out", "final", None
+
+    monkeypatch.setattr(scheduler, "_run_job_impl", fake_impl)
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=2) as pool:
+        cron_future = pool.submit(scheduler.run_job, {"id": "parallel-cron"})
+        assert entered.wait(5), "test timed out waiting for cron job to start"
+
+        seen["gateway_thread_is_cron"] = approval.is_hermes_cron_session()
+        seen["gateway_thread_is_gateway"] = approval._is_gateway_approval_context()
+
+        release.set()
+        assert cron_future.result(timeout=5) == (True, "out", "final", None)
+
+    assert seen == {
+        "cron_thread_is_cron": True,
+        "cron_thread_is_gateway": False,
+        "gateway_thread_is_cron": False,
+        "gateway_thread_is_gateway": True,
+    }
+    assert os.environ.get("HERMES_CRON_SESSION") is None

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -65,6 +65,15 @@ _hermes_interactive_ctx: contextvars.ContextVar[Optional[str]] = contextvars.Con
     default=None,
 )
 
+# Cron-session flag. Scheduled jobs can run concurrently with each other and
+# with gateway/interactive turns in the same process, so cron approval mode
+# must not depend on process-global os.environ mutation. None = unset -> fall
+# back to the legacy env var for external callers/tests that still export it.
+_hermes_cron_ctx: contextvars.ContextVar[Optional[str]] = contextvars.ContextVar(
+    "hermes_cron_session",
+    default=None,
+)
+
 
 def set_hermes_interactive_context(interactive: bool) -> contextvars.Token:
     """Bind interactive mode for the current context (thread or asyncio task).
@@ -91,6 +100,28 @@ def _is_interactive_cli() -> bool:
     if ctx_val is not None:
         return is_truthy_value(ctx_val)
     return env_var_enabled("HERMES_INTERACTIVE")
+
+
+def set_hermes_cron_context(is_cron: bool = True) -> contextvars.Token:
+    """Bind cron-session mode for the current context."""
+    return _hermes_cron_ctx.set("1" if is_cron else "")
+
+
+def reset_hermes_cron_context(token: contextvars.Token) -> None:
+    """Restore the prior cron-session marker."""
+    _hermes_cron_ctx.reset(token)
+
+
+def is_hermes_cron_session() -> bool:
+    """True when the current context is running a cron job.
+
+    Prefers the context-local marker set by the scheduler and falls back to the
+    legacy ``HERMES_CRON_SESSION`` env var for single-threaded external callers.
+    """
+    ctx_val = _hermes_cron_ctx.get()
+    if ctx_val is not None:
+        return is_truthy_value(ctx_val)
+    return env_var_enabled("HERMES_CRON_SESSION")
 
 
 def _fire_approval_hook(hook_name: str, **kwargs) -> None:
@@ -238,7 +269,7 @@ def _is_gateway_approval_context() -> bool:
     fall through to the gateway branch would submit a pending approval
     with no listener and block the job indefinitely.
     """
-    if env_var_enabled("HERMES_CRON_SESSION"):
+    if is_hermes_cron_session():
         return False
     if env_var_enabled("HERMES_GATEWAY_SESSION"):
         return True
@@ -2869,7 +2900,7 @@ def _run_approval_gate(
 
     if not is_cli and not is_gateway:
         # Cron sessions: respect cron_mode config
-        if env_var_enabled("HERMES_CRON_SESSION"):
+        if is_hermes_cron_session():
             if _get_cron_approval_mode() == "deny":
                 return {
                     "approved": False,
@@ -3397,7 +3428,7 @@ def check_all_command_guards(command: str, env_type: str,
     # flows, we do not block on approvals and we skip external guard work.
     if not is_cli and not is_gateway and not is_ask:
         # Cron sessions: respect cron_mode config
-        if env_var_enabled("HERMES_CRON_SESSION"):
+        if is_hermes_cron_session():
             if _get_cron_approval_mode() == "deny":
                 # Run detection to get a description for the block message
                 is_dangerous, _pk, description = detect_dangerous_command(command)
@@ -3848,7 +3879,7 @@ def check_execute_code_guard(code: str, env_type: str,
     is_ask = env_var_enabled("HERMES_EXEC_ASK")
 
     # Cron: no user is present to approve arbitrary code.
-    if env_var_enabled("HERMES_CRON_SESSION"):
+    if is_hermes_cron_session():
         if _get_cron_approval_mode() == "deny":
             return {
                 "approved": False,


### PR DESCRIPTION
## Summary
- restore the previous `HERMES_CRON_SESSION` environment value after each cron job finishes
- keep `HERMES_CRON_SESSION=1` visible during the actual cron agent run so approval/tooling can still detect cron mode
- extend the existing auto-delivery cron session test to assert both in-run presence and post-run cleanup

## Why
`HERMES_CRON_SESSION` is process-wide. The scheduler can run inside long-lived gateway processes that also serve interactive chats, so leaving the marker set after a cron tick can make later interactive tool calls look like non-interactive cron executions.

## Tests
- `git diff --check`
- `env -u WEIXIN_HOME_CHANNEL /home/dso2ng/.hermes/hermes-agent/venv/bin/python -m pytest tests/cron/test_scheduler.py::TestRunJobSessionPersistence::test_run_job_sets_auto_delivery_env_from_dotenv_home_channel -q`
- `env -u WEIXIN_HOME_CHANNEL /home/dso2ng/.hermes/hermes-agent/venv/bin/python -m pytest tests/cron/test_scheduler.py -q`
- `/home/dso2ng/.hermes/hermes-agent/venv/bin/python -m py_compile cron/scheduler.py tests/cron/test_scheduler.py`
