### PR TITLE
feat(agent): add Fireworks pricing entries + routing branch

### DIFF
--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -505,6 +505,43 @@ _OFFICIAL_DOCS_PRICING: Dict[tuple[str, str], PricingEntry] = {
         source="official_docs_snapshot",
         pricing_version="minimax-pricing-2026-04",
     ),
+    # Fireworks AI — serverless pricing for the models hermes typically routes
+    # through when configured with provider="fireworks". Fireworks publishes a
+    # cached_input rate per model alongside input/output, which maps to
+    # cache_read_cost_per_million. No separately published cache_write rate.
+    (
+        "fireworks",
+        "kimi-k2p6",
+    ): PricingEntry(
+        input_cost_per_million=Decimal("0.95"),
+        output_cost_per_million=Decimal("4.00"),
+        cache_read_cost_per_million=Decimal("0.16"),
+        source="official_docs_snapshot",
+        source_url="https://docs.fireworks.ai/serverless/pricing",
+        pricing_version="fireworks-pricing-2026-05",
+    ),
+    (
+        "fireworks",
+        "deepseek-v4-pro",
+    ): PricingEntry(
+        input_cost_per_million=Decimal("1.74"),
+        output_cost_per_million=Decimal("3.48"),
+        cache_read_cost_per_million=Decimal("0.145"),
+        source="official_docs_snapshot",
+        source_url="https://docs.fireworks.ai/serverless/pricing",
+        pricing_version="fireworks-pricing-2026-05",
+    ),
+    (
+        "fireworks",
+        "qwen3p6-plus",
+    ): PricingEntry(
+        input_cost_per_million=Decimal("0.50"),
+        output_cost_per_million=Decimal("3.00"),
+        cache_read_cost_per_million=Decimal("0.10"),
+        source="official_docs_snapshot",
+        source_url="https://fireworks.ai/models/fireworks/qwen3p6-plus",
+        pricing_version="fireworks-pricing-2026-05",
+    ),
 }
 
 
@@ -548,6 +585,10 @@ def resolve_billing_route(
         return BillingRoute(provider="openai", model=model.split("/")[-1], base_url=base_url or "", billing_mode="official_docs_snapshot")
     if provider_name in {"minimax", "minimax-cn"}:
         return BillingRoute(provider=provider_name, model=model.split("/")[-1], base_url=base_url or "", billing_mode="official_docs_snapshot")
+    if provider_name == "fireworks" or base_url_host_matches(base_url or "", "api.fireworks.ai"):
+        # Fireworks model ids look like accounts/fireworks/models/<name>;
+        # rsplit("/", 1)[-1] yields just <name> which is what the dict keys on.
+        return BillingRoute(provider="fireworks", model=model.rsplit("/", 1)[-1], base_url=base_url or "", billing_mode="official_docs_snapshot")
     if provider_name in {"custom", "local"} or (base and "localhost" in base):
         return BillingRoute(provider=provider_name or "custom", model=model, base_url=base_url or "", billing_mode="unknown")
     return BillingRoute(provider=provider_name or "unknown", model=model.split("/")[-1] if model else "", base_url=base_url or "", billing_mode="unknown")

--- a/tests/agent/test_usage_pricing.py
+++ b/tests/agent/test_usage_pricing.py
@@ -224,3 +224,46 @@ def test_deepseek_v4_pro_estimate_usage_cost():
     assert result.amount_usd is not None
     # 1M input × $1.74/M + 500K output × $3.48/M = $1.74 + $1.74 = $3.48
     assert float(result.amount_usd) == 3.48
+
+
+def test_fireworks_kimi_k2p6_resolves_with_full_model_path():
+    """Fireworks model ids look like accounts/fireworks/models/<name>;
+    the routing layer must strip the prefix so the dict lookup succeeds."""
+    entry = get_pricing_entry(
+        "accounts/fireworks/models/kimi-k2p6",
+        provider="fireworks",
+        base_url="https://api.fireworks.ai/inference/v1",
+    )
+
+    assert entry is not None
+    assert float(entry.input_cost_per_million) == 0.95
+    assert float(entry.output_cost_per_million) == 4.00
+    assert float(entry.cache_read_cost_per_million) == 0.16
+    assert entry.source == "official_docs_snapshot"
+
+
+def test_fireworks_base_url_host_match_alone_routes_to_pricing():
+    """Provider not explicitly passed; routing infers fireworks from the host."""
+    entry = get_pricing_entry(
+        "accounts/fireworks/models/deepseek-v4-pro",
+        base_url="https://api.fireworks.ai/inference/v1",
+    )
+
+    assert entry is not None
+    assert float(entry.input_cost_per_million) == 1.74
+    assert float(entry.output_cost_per_million) == 3.48
+
+
+def test_fireworks_qwen3p6_plus_estimate_usage_cost():
+    """End-to-end: Fireworks Qwen3.6-Plus sessions report a dollar estimate."""
+    result = estimate_usage_cost(
+        "accounts/fireworks/models/qwen3p6-plus",
+        CanonicalUsage(input_tokens=1_000_000, output_tokens=500_000),
+        provider="fireworks",
+        base_url="https://api.fireworks.ai/inference/v1",
+    )
+
+    assert result.status == "estimated"
+    assert result.amount_usd is not None
+    # 1M input × $0.50/M + 500K output × $3.00/M = $0.50 + $1.50 = $2.00
+    assert float(result.amount_usd) == 2.00


### PR DESCRIPTION
## What

Adds three pricing entries (Kimi K2.6, DeepSeek V4 Pro, Qwen 3.6 Plus) to `_OFFICIAL_DOCS_PRICING` and a `provider="fireworks"` branch to `resolve_billing_route()` so Fireworks-hosted sessions report a real dollar estimate instead of falling through to `billing_mode="unknown"`.

## Why

A Hermes deployment routing through `https://api.fireworks.ai/inference/v1` currently shows `Estimated Cost: N/A` everywhere — `state.db` accumulates `estimated_cost_usd = 0.0` for every session because `resolve_billing_route()` returns `billing_mode="unknown"` for any provider not in the explicit list (anthropic/openai/openai-codex/openrouter/minimax/custom).

Same shape as the recently-merged MiniMax entries (lines 489–507 of `agent/usage_pricing.py`) — a small static snapshot is the established pattern for providers that publish stable, documented per-million-token rates but don't expose pricing via their `/v1/models` endpoint.

## How it works

- **Pricing dict**: 3 new entries keyed by `("fireworks", "<bare-model-name>")` so the lookup matches whatever `model.rsplit("/", 1)[-1]` produces for the full Fireworks id (e.g., `accounts/fireworks/models/kimi-k2p6` → `kimi-k2p6`).
- **Routing branch**: triggers on explicit `provider="fireworks"` OR `base_url_host_matches(..., "api.fireworks.ai")` so deployments that omit the provider field (and only set the base URL) still get correct billing.
- Cache-read rates included where Fireworks publishes them; no cache-write rates published, so those are left null (matching the bundled OpenAI entries).

## Sources for the snapshot

- Kimi K2.6, DeepSeek V4 Pro: https://docs.fireworks.ai/serverless/pricing (canonical)
- Qwen 3.6 Plus: https://fireworks.ai/models/fireworks/qwen3p6-plus (per-model page; not on the headline pricing table)

`pricing_version="fireworks-pricing-2026-05"` is stamped on each entry so a future refresh diff is easy to spot.

## How to test

```bash
pytest tests/agent/test_usage_pricing.py -v
```

All 14 tests pass (11 pre-existing + 3 new). New tests:

- `test_fireworks_kimi_k2p6_resolves_with_full_model_path` — full `accounts/fireworks/models/kimi-k2p6` id routes to the snapshot entry.
- `test_fireworks_base_url_host_match_alone_routes_to_pricing` — `base_url` alone (no explicit `provider=`) still triggers the branch via host match.
- `test_fireworks_qwen3p6_plus_estimate_usage_cost` — end-to-end `estimate_usage_cost` returns `status="estimated"` with the expected dollar amount.

Tested on macOS (Python 3.11).

## Long-term direction

Filed issue #29861 proposing a dynamic pricing source (e.g. ingesting the community-maintained LiteLLM pricing JSON, or fetching from a hermes-hosted endpoint) as a permanent fix to the PR-per-model cycle this snapshot keeps adding to. This PR is intended as the immediate fix; whoever lands the dynamic-source change is welcome to remove these three entries when it does.