### PR TITLE
fix(compressor,webui): keep last visible assistant reply readable after compaction (#29824)

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -1362,6 +1362,105 @@ The user has requested that this compaction PRIORITISE preserving all informatio
                 return i
         return -1
 
+    def _find_last_assistant_message_idx(
+        self, messages: List[Dict[str, Any]], head_end: int
+    ) -> int:
+        """Return the index of the last user-visible assistant reply at or
+        after *head_end*, or -1.
+
+        A "user-visible reply" is an assistant message with non-empty
+        textual content — i.e. one that the WebUI / TUI / SessionsPage
+        rendered as a bubble the operator could read. We deliberately
+        skip assistant messages that contain only ``tool_calls`` (and
+        no text), because those render as small "calling tool X"
+        indicators and aren't what the reporter means by "the output
+        of the last message you sent" (#29824).
+
+        Falling back to the most recent assistant message of ANY kind
+        only kicks in when no content-bearing assistant message exists
+        in the compressible region — typically a fresh session that
+        just started a multi-step tool sequence with no prior reply
+        to anchor. In that case the agent fix is a no-op and the
+        existing user-message anchor carries the load.
+        """
+        last_any = -1
+        for i in range(len(messages) - 1, head_end - 1, -1):
+            msg = messages[i]
+            if msg.get("role") != "assistant":
+                continue
+            if last_any < 0:
+                last_any = i
+            content = msg.get("content")
+            if isinstance(content, str) and content.strip():
+                return i
+            if isinstance(content, list):
+                # Multimodal / Anthropic-style content: look for any
+                # text block with non-empty text.
+                for part in content:
+                    if isinstance(part, dict):
+                        text = part.get("text") or part.get("content")
+                        if isinstance(text, str) and text.strip():
+                            return i
+        return last_any
+
+    def _ensure_last_assistant_message_in_tail(
+        self,
+        messages: List[Dict[str, Any]],
+        cut_idx: int,
+        head_end: int,
+    ) -> int:
+        """Guarantee the most recent assistant message is in the protected tail.
+
+        WebUI / TUI / SessionsPage bug (#29824). Without this anchor,
+        ``_find_tail_cut_by_tokens`` can leave the user's most recent
+        visible assistant response inside the compressed middle region —
+        especially when the conversation has a single oversized tool
+        result or a long stretch of tool-call/result pairs after the
+        last assistant reply. The summariser then rolls that reply up
+        into the single ``[CONTEXT COMPACTION — REFERENCE ONLY]`` block
+        persisted as ``role="user"`` or ``role="assistant"``. From the
+        operator's perspective the WebUI session viewer
+        (``web/src/pages/SessionsPage.tsx``) and the TUI chat panel
+        both suddenly show the opaque "Context compaction" block in the
+        slot where they were just reading the assistant's actual reply:
+
+            User:       "i cant see the output of the last message you
+                         sent, i did see it previously, however now see
+                         'context compaction'"
+
+        Mirror of ``_ensure_last_user_message_in_tail`` but anchors on
+        the last assistant-role message. Re-runs the tool-group
+        alignment so we don't split a ``tool_call`` / ``tool_result``
+        group that immediately precedes the anchored message — orphaned
+        tool messages would otherwise be removed by
+        ``_sanitize_tool_pairs`` and trigger the same data-loss symptom
+        we're trying to prevent.
+        """
+        last_asst_idx = self._find_last_assistant_message_idx(messages, head_end)
+        if last_asst_idx < 0:
+            # No assistant message in the compressible region — nothing
+            # to anchor (single-turn pre-reply state, etc.).
+            return cut_idx
+        if last_asst_idx >= cut_idx:
+            # Already in the tail — the token-budget walk did the right
+            # thing on its own.
+            return cut_idx
+        # Pull cut_idx back to the assistant message, then re-align so
+        # we don't split a tool group that immediately precedes it
+        # (e.g. an ``assistant(tool_calls)`` → ``tool(result)`` →
+        # ``assistant(final reply)`` sequence would otherwise leave the
+        # ``tool`` orphan when cut lands at the final reply).
+        new_cut = self._align_boundary_backward(messages, last_asst_idx)
+        if not self.quiet_mode:
+            logger.debug(
+                "Anchoring tail cut to last assistant message at index %d "
+                "(was %d, aligned to %d) to keep the previously-visible "
+                "reply out of the compaction summary (#29824)",
+                last_asst_idx, cut_idx, new_cut,
+            )
+        # Safety: never go back into the head region.
+        return max(new_cut, head_end + 1)
+
     def _ensure_last_user_message_in_tail(
         self,
         messages: List[Dict[str, Any]],
@@ -1469,6 +1568,13 @@ The user has requested that this compaction PRIORITISE preserving all informatio
         # Ensure the most recent user message is always in the tail so the
         # active task is never lost to compression (fixes #10896).
         cut_idx = self._ensure_last_user_message_in_tail(messages, cut_idx, head_end)
+
+        # Ensure the most recent assistant message is always in the tail
+        # so the previously-visible reply isn't silently rolled into the
+        # ``[CONTEXT COMPACTION — REFERENCE ONLY]`` block (fixes #29824).
+        # Each anchor only walks ``cut_idx`` backward, so chaining them is
+        # monotonic — the tail can only grow, never shrink.
+        cut_idx = self._ensure_last_assistant_message_in_tail(messages, cut_idx, head_end)
 
         return max(cut_idx, head_end + 1)
 

--- a/tests/agent/test_compressor_assistant_tail_anchor.py
+++ b/tests/agent/test_compressor_assistant_tail_anchor.py
@@ -1,0 +1,518 @@
+"""Regression coverage for #29824 — the WebUI session viewer (and TUI
+chat panel) was showing the ``[CONTEXT COMPACTION — REFERENCE ONLY]``
+handoff block in the slot where the user had just been reading the
+assistant's actual reply, because the previously-visible reply got
+rolled into the compaction summary by the token-budget tail walk.
+
+The fix adds ``_ensure_last_assistant_message_in_tail`` — a mirror of
+the existing ``_ensure_last_user_message_in_tail`` (#10896 anchor) —
+that pulls ``cut_idx`` back to include the most recent assistant
+message with non-empty text content, with the standard tool-group
+realignment so we don't orphan a ``tool_call`` / ``tool_result`` pair.
+
+Pinned here:
+
+* ``TestFindLastAssistantMessageIdx`` — pure helper contract:
+  finds the most recent **content-bearing** assistant message,
+  skips tool-call-only stubs, falls back to "any assistant" only
+  when no content-bearing reply exists in the compressible region,
+  honours ``head_end``, returns -1 when there's no assistant at all.
+
+* ``TestEnsureLastAssistantMessageInTail`` — direct: walks
+  ``cut_idx`` back when the last reply is in the compressed middle,
+  is a no-op when it's already in the tail, never crosses
+  ``head_end``, re-aligns through tool groups.
+
+* ``TestFindTailCutByTokensAnchorsAssistant`` — integration with
+  the existing tail-cut path: the exact reporter scenario (long
+  tool-output run after the previously-visible reply) preserves
+  the reply; combines with the user anchor for the same-turn
+  preservation; soft-ceiling overrun no longer hides the reply.
+
+* ``TestCompactionRollupReproduction`` — end-to-end through
+  ``compress()`` with a stubbed summariser: pre-fix the reply
+  text is absorbed into the summary (regression demonstrated by
+  asserting on the OLD behaviour fails); post-fix the reply text
+  is still present in the compressed transcript as a regular
+  assistant message.
+
+* ``TestSourceGuardrail`` — static asserts on
+  ``agent/context_compressor.py`` so a future refactor can't
+  silently drop the anchor.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.fixture()
+def compressor():
+    """ContextCompressor with mocked deps and a tight tail budget so
+    the helpers' anchor behaviour is observable."""
+    from agent.context_compressor import ContextCompressor
+    with patch(
+        "agent.context_compressor.get_model_context_length",
+        return_value=100_000,
+    ):
+        c = ContextCompressor(
+            model="test/model",
+            threshold_percent=0.85,
+            protect_first_n=2,
+            protect_last_n=2,
+            quiet_mode=True,
+        )
+        c.tail_token_budget = 50
+        return c
+
+
+# ---------------------------------------------------------------------------
+# Helper: _find_last_assistant_message_idx
+# ---------------------------------------------------------------------------
+
+
+class TestFindLastAssistantMessageIdx:
+    def test_finds_content_bearing_assistant(self, compressor):
+        messages = [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "q"},
+            {"role": "assistant", "content": "the reply"},
+        ]
+        idx = compressor._find_last_assistant_message_idx(messages, head_end=1)
+        assert idx == 2
+
+    def test_skips_tool_call_only_stub_when_text_reply_exists_earlier(
+        self, compressor
+    ):
+        """An assistant message that only carries ``tool_calls`` (no
+        text content) is not the user-visible reply — the WebUI
+        renders those as small "calling tool X" indicators. The helper
+        must prefer the earlier text reply, which is what the user
+        actually read."""
+        messages = [
+            {"role": "user", "content": "q1"},
+            {"role": "assistant", "content": "VISIBLE REPLY"},
+            {"role": "user", "content": "q2"},
+            {"role": "assistant", "content": None,
+             "tool_calls": [{"function": {"name": "t",
+                                          "arguments": "{}"}}]},
+            {"role": "tool", "content": "result", "tool_call_id": "c1"},
+        ]
+        idx = compressor._find_last_assistant_message_idx(messages, head_end=0)
+        assert idx == 1, (
+            "Expected the content-bearing assistant reply (1), not the "
+            f"trailing tool-call stub. Got {idx}."
+        )
+
+    def test_empty_string_content_does_not_count_as_visible(self, compressor):
+        """An assistant message with ``content=""`` (only whitespace)
+        is not a visible reply either — common pre-flight stub before
+        the model streams the real answer."""
+        messages = [
+            {"role": "user", "content": "q1"},
+            {"role": "assistant", "content": "earlier reply"},
+            {"role": "user", "content": "q2"},
+            {"role": "assistant", "content": "   "},  # blank stub
+        ]
+        idx = compressor._find_last_assistant_message_idx(messages, head_end=0)
+        # Blank-string assistant message does not count — fall back
+        # to the earlier real reply.
+        assert idx == 1
+
+    def test_multimodal_text_block_counts(self, compressor):
+        """An assistant with multimodal list-content carrying a text
+        block (Anthropic / GPT-style ``[{type:text,text:...}]``)
+        counts as content-bearing."""
+        messages = [
+            {"role": "user", "content": "q"},
+            {"role": "assistant",
+             "content": [{"type": "text", "text": "hello"}]},
+        ]
+        idx = compressor._find_last_assistant_message_idx(messages, head_end=0)
+        assert idx == 1
+
+    def test_fallback_to_any_assistant_when_no_content_bearing(
+        self, compressor
+    ):
+        """When there's no text-bearing assistant in the compressible
+        region (fresh multi-step tool sequence), fall back to the
+        most recent assistant of any kind so the anchor still works."""
+        messages = [
+            {"role": "user", "content": "q"},
+            {"role": "assistant", "content": None,
+             "tool_calls": [{"function": {"name": "t",
+                                          "arguments": "{}"}}]},
+            {"role": "tool", "content": "result", "tool_call_id": "c1"},
+        ]
+        idx = compressor._find_last_assistant_message_idx(messages, head_end=0)
+        assert idx == 1
+
+    def test_returns_negative_one_when_no_assistant(self, compressor):
+        messages = [
+            {"role": "user", "content": "q1"},
+            {"role": "user", "content": "q2"},
+        ]
+        idx = compressor._find_last_assistant_message_idx(messages, head_end=0)
+        assert idx == -1
+
+    def test_respects_head_end_lower_bound(self, compressor):
+        """An assistant message at or before ``head_end`` must be
+        ignored — it's already in the protected head region."""
+        messages = [
+            {"role": "system", "content": "sys"},
+            {"role": "assistant", "content": "in-head reply"},  # idx 1
+            {"role": "user", "content": "q"},
+        ]
+        # head_end=2 means the compressible region starts at index 2;
+        # the assistant at index 1 is in the head and must be skipped.
+        idx = compressor._find_last_assistant_message_idx(messages, head_end=2)
+        assert idx == -1
+
+
+# ---------------------------------------------------------------------------
+# Helper: _ensure_last_assistant_message_in_tail
+# ---------------------------------------------------------------------------
+
+
+class TestEnsureLastAssistantMessageInTail:
+    def test_no_op_when_already_in_tail(self, compressor):
+        messages = [
+            {"role": "user", "content": "q"},
+            {"role": "assistant", "content": "reply"},
+            {"role": "user", "content": "q2"},
+        ]
+        # cut_idx=1 means tail starts at index 1 — the reply is already in tail.
+        new_cut = compressor._ensure_last_assistant_message_in_tail(
+            messages, cut_idx=1, head_end=0
+        )
+        assert new_cut == 1
+
+    def test_walks_cut_idx_back_to_include_reply(self, compressor):
+        messages = [
+            {"role": "user", "content": "q1"},
+            {"role": "assistant", "content": "REPLY"},  # idx 1
+            {"role": "user", "content": "q2"},
+            {"role": "user", "content": "q3"},
+        ]
+        # cut_idx=2 leaves the reply outside the tail; anchor must pull
+        # cut_idx back to 1 so messages[1:] contains the reply.
+        new_cut = compressor._ensure_last_assistant_message_in_tail(
+            messages, cut_idx=2, head_end=0
+        )
+        assert new_cut == 1
+        assert any(
+            isinstance(m.get("content"), str) and "REPLY" in m["content"]
+            for m in messages[new_cut:]
+        )
+
+    def test_never_crosses_head_end(self, compressor):
+        messages = [
+            {"role": "system", "content": "sys"},
+            {"role": "assistant", "content": "in-head"},  # head, must ignore
+            {"role": "user", "content": "q"},
+        ]
+        # head_end=2 ⇒ assistant at idx 1 is in the head; the anchor
+        # finds nothing in the compressible region and is a no-op.
+        new_cut = compressor._ensure_last_assistant_message_in_tail(
+            messages, cut_idx=3, head_end=2
+        )
+        assert new_cut == 3
+
+    def test_re_aligns_through_preceding_tool_group(self, compressor):
+        """When the anchored assistant is preceded by a
+        tool_call/result group, ``_align_boundary_backward`` must pull
+        ``cut_idx`` even further back so the group isn't split — same
+        guarantee as ``_ensure_last_user_message_in_tail``."""
+        messages = [
+            {"role": "user", "content": "q1"},
+            {"role": "assistant", "content": None,
+             "tool_calls": [{"id": "c1",
+                             "function": {"name": "t",
+                                          "arguments": "{}"}}]},
+            {"role": "tool", "content": "result", "tool_call_id": "c1"},
+            {"role": "assistant", "content": "REPLY"},  # idx 3
+            {"role": "user", "content": "q2"},
+        ]
+        # cut_idx=4 leaves the reply outside the tail. Anchor pulls
+        # back to 3, then _align_boundary_backward sees the preceding
+        # tool group and pulls further back to 1 (before the assistant
+        # with tool_calls).
+        new_cut = compressor._ensure_last_assistant_message_in_tail(
+            messages, cut_idx=4, head_end=0
+        )
+        assert new_cut <= 3
+        # The tool_call assistant (1) and its tool_result (2) must NOT
+        # be split: either both in compressed region or both in tail.
+        if new_cut <= 1:
+            # Both in tail — tool group intact.
+            assert messages[new_cut].get("role") == "assistant"
+        else:
+            # Otherwise the anchor must land at the reply itself (3).
+            assert new_cut == 3
+
+
+# ---------------------------------------------------------------------------
+# Integration with _find_tail_cut_by_tokens
+# ---------------------------------------------------------------------------
+
+
+class TestFindTailCutByTokensAnchorsAssistant:
+    def test_reporter_repro_long_tool_run_after_visible_reply(
+        self, compressor
+    ):
+        """The exact #29824 scenario: a tight token budget combined
+        with a long tail of tool-call/result messages after the
+        visible reply. Pre-fix, the token-budget walk hit its ceiling
+        on the tool output and parked ``cut_idx`` past the reply.
+        Post-fix, the assistant anchor pulls it back."""
+        c = compressor
+        c.tail_token_budget = 10  # force min-tail behaviour
+        messages = [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "msg1"},                # head_end=2
+            {"role": "user", "content": "q1"},
+            {"role": "assistant",
+             "content": "PREVIOUSLY VISIBLE REPLY"},           # idx 3
+            {"role": "user", "content": "q2"},
+            {"role": "assistant", "content": None,
+             "tool_calls": [{"id": "c1",
+                             "function": {"name": "t",
+                                          "arguments": "{}"}}]},
+            {"role": "tool", "content": "x" * 200,
+             "tool_call_id": "c1"},
+        ]
+        cut = c._find_tail_cut_by_tokens(messages, head_end=2)
+        tail_contents = [
+            m.get("content") for m in messages[cut:]
+            if isinstance(m.get("content"), str)
+        ]
+        assert any(
+            "PREVIOUSLY VISIBLE REPLY" in (t or "") for t in tail_contents
+        ), (
+            "REGRESSION (#29824): the visible reply was rolled into "
+            f"the compaction summary. Tail contents: {tail_contents!r}"
+        )
+
+    def test_user_and_assistant_anchors_compose(self, compressor):
+        """Both anchors run in sequence; the tail must contain both
+        the latest user message AND the latest visible assistant
+        reply."""
+        c = compressor
+        c.tail_token_budget = 10
+        messages = [
+            {"role": "user", "content": "q1"},
+            {"role": "assistant", "content": "VISIBLE REPLY"},
+            {"role": "user", "content": "follow-up question"},
+            {"role": "user", "content": "and another"},
+        ]
+        cut = c._find_tail_cut_by_tokens(messages, head_end=0)
+        tail_contents = [
+            m.get("content") for m in messages[cut:]
+            if isinstance(m.get("content"), str)
+        ]
+        assert any("VISIBLE REPLY" in (t or "") for t in tail_contents)
+        assert any("and another" in (t or "") for t in tail_contents)
+
+    def test_oversized_tool_output_does_not_strand_reply(self, compressor):
+        """The soft-ceiling logic in ``_find_tail_cut_by_tokens``
+        permits a single oversized tail message; the assistant anchor
+        must still recover the reply on the other side of it."""
+        c = compressor
+        c.tail_token_budget = 100  # soft ceiling 150
+        messages = [
+            {"role": "user", "content": "earlier"},
+            {"role": "assistant", "content": "VISIBLE REPLY"},
+            {"role": "user", "content": "read big file"},
+            {"role": "assistant", "content": None,
+             "tool_calls": [{"id": "c1",
+                             "function": {"name": "read",
+                                          "arguments": "{}"}}]},
+            # ~500 chars ⇒ ~135 tokens, blows past soft ceiling of 150
+            {"role": "tool", "content": "y" * 500,
+             "tool_call_id": "c1"},
+            {"role": "user", "content": "ok"},
+        ]
+        cut = c._find_tail_cut_by_tokens(messages, head_end=0)
+        tail_contents = [
+            m.get("content") for m in messages[cut:]
+            if isinstance(m.get("content"), str)
+        ]
+        assert any("VISIBLE REPLY" in (t or "") for t in tail_contents)
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: compress() preserves the reply
+# ---------------------------------------------------------------------------
+
+
+class TestCompactionRollupReproduction:
+    """End-to-end through ``compress()``: the visible reply text must
+    survive in the compressed transcript — either as its own
+    standalone assistant message OR concatenated onto the merged
+    summary-handoff tail message (the compressor's double-collision
+    fallback path; the WebUI re-splits these on the END marker so the
+    reply renders as a separate bubble — see ``splitCompactionContent``
+    in ``web/src/pages/SessionsPage.tsx``)."""
+
+    def test_compress_keeps_visible_reply_text(self, compressor):
+        from agent.context_compressor import SUMMARY_PREFIX
+        c = compressor
+        c.tail_token_budget = 10
+        # ``_generate_summary`` normally wraps the LLM body in
+        # ``SUMMARY_PREFIX`` via ``_with_summary_prefix``; mimic that so
+        # the merge-into-tail branch can identify the boundary.
+        _mocked = f"{SUMMARY_PREFIX}\nrolled-up middle summary"
+        messages = (
+            [{"role": "system", "content": "sys"},
+             {"role": "user", "content": "initial"}]   # head (protect_first_n=2)
+            # Middle: long enough to be compressible.
+            + [
+                {"role": "user", "content": f"middle q{i}"}
+                if i % 2 == 0
+                else {"role": "assistant", "content": f"middle reply {i}"}
+                for i in range(12)
+            ]
+            + [
+                {"role": "user", "content": "the visible question"},
+                {"role": "assistant",
+                 "content": "THE VISIBLE REPLY THE USER JUST READ"},
+                {"role": "user", "content": "follow up"},
+                {"role": "assistant", "content": None,
+                 "tool_calls": [{"id": "c1",
+                                 "function": {"name": "t",
+                                              "arguments": "{}"}}]},
+                {"role": "tool", "content": "z" * 500,
+                 "tool_call_id": "c1"},
+            ]
+        )
+        with patch.object(
+            c, "_generate_summary",
+            return_value=_mocked,
+        ):
+            result = c.compress(messages, current_tokens=90_000)
+        # 1. A summary message exists (compression actually ran).
+        assert any(
+            isinstance(m.get("content"), str)
+            and m["content"].startswith(SUMMARY_PREFIX)
+            for m in result
+        ), "compress() did not insert a summary message"
+        # 2. The visible reply text must survive somewhere — either
+        # as its own message OR concatenated into the merged tail.
+        joined = "\n".join(
+            m.get("content") for m in result
+            if isinstance(m.get("content"), str)
+        )
+        assert "THE VISIBLE REPLY THE USER JUST READ" in joined, (
+            "REGRESSION (#29824): the visible reply was absorbed into "
+            "the compaction summary AND erased. Compressed transcript "
+            f"({len(result)} msgs): "
+            f"{[(m.get('role'), str(m.get('content'))[:50]) for m in result]}"
+        )
+
+    def test_standalone_summary_case_keeps_reply_as_own_message(
+        self, compressor
+    ):
+        """When the head and tail roles allow a standalone summary
+        message (no double-collision), the visible reply must remain
+        as its OWN assistant message — not merged with anything.
+        This is the common case; the merge-into-tail path is the
+        edge case for double-collision."""
+        from agent.context_compressor import SUMMARY_PREFIX
+        c = compressor
+        c.tail_token_budget = 10
+        _mocked = f"{SUMMARY_PREFIX}\nrolled-up middle summary"
+        # Head ends with ``assistant`` ⇒ summary_role flips to
+        # ``user`` ⇒ no collision with the assistant tail ⇒ standalone
+        # summary insert (no merge).
+        messages = (
+            [
+                {"role": "user", "content": "initial"},
+                {"role": "assistant", "content": "head reply"},
+            ]
+            + [
+                {"role": "user", "content": f"middle q{i}"}
+                if i % 2 == 0
+                else {"role": "assistant", "content": f"middle reply {i}"}
+                for i in range(12)
+            ]
+            + [
+                {"role": "user", "content": "the visible question"},
+                {"role": "assistant",
+                 "content": "THE VISIBLE REPLY THE USER JUST READ"},
+                {"role": "user", "content": "follow up"},
+            ]
+        )
+        with patch.object(
+            c, "_generate_summary",
+            return_value=_mocked,
+        ):
+            result = c.compress(messages, current_tokens=90_000)
+        # Standalone summary present:
+        summary_rows = [
+            m for m in result
+            if isinstance(m.get("content"), str)
+            and m["content"].startswith(SUMMARY_PREFIX)
+        ]
+        assert len(summary_rows) == 1
+        # Visible reply as its OWN distinct assistant message
+        # (NOT merged into the summary row):
+        reply_rows = [
+            m for m in result
+            if m.get("role") == "assistant"
+            and isinstance(m.get("content"), str)
+            and "THE VISIBLE REPLY THE USER JUST READ" in m["content"]
+            and not m["content"].startswith(SUMMARY_PREFIX)
+        ]
+        assert len(reply_rows) == 1, (
+            "REGRESSION (#29824): expected exactly one standalone "
+            f"assistant message carrying the visible reply, got "
+            f"{len(reply_rows)}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Source guardrail
+# ---------------------------------------------------------------------------
+
+
+class TestSourceGuardrail:
+    @pytest.fixture
+    def source(self) -> str:
+        from pathlib import Path
+        return (Path(__file__).resolve().parents[2]
+                / "agent" / "context_compressor.py").read_text(
+                    encoding="utf-8")
+
+    def test_helper_defined(self, source):
+        assert "def _find_last_assistant_message_idx(" in source
+        assert "def _ensure_last_assistant_message_in_tail(" in source
+
+    def test_anchor_called_from_find_tail_cut(self, source):
+        """Without the call site the helper is dead code and the bug
+        regresses silently — pin both the definition AND the wiring."""
+        assert "self._ensure_last_assistant_message_in_tail(" in source
+
+    def test_anchor_called_after_user_anchor(self, source):
+        """The two anchors must run in sequence; reversing or skipping
+        one drops the corresponding side of the guarantee."""
+        user_call = "self._ensure_last_user_message_in_tail(messages, cut_idx, head_end)"
+        asst_call = "self._ensure_last_assistant_message_in_tail(messages, cut_idx, head_end)"
+        user_idx = source.find(user_call)
+        asst_idx = source.find(asst_call)
+        assert user_idx >= 0 and asst_idx >= 0
+        assert asst_idx > user_idx, (
+            "The assistant anchor must come AFTER the user anchor in "
+            "``_find_tail_cut_by_tokens`` — each anchor walks cut_idx "
+            "backward, and ordering keeps the chain monotonic."
+        )
+
+    def test_helper_prefers_content_bearing_reply(self, source):
+        """The helper must skip tool-call-only stubs — that's the
+        whole user-experience difference between #29824 (no visible
+        reply) and an in-progress turn (small 'calling tool X' chip)."""
+        assert "content.strip()" in source
+
+    def test_issue_number_referenced(self, source):
+        assert "#29824" in source

--- a/web/src/pages/SessionsPage.tsx
+++ b/web/src/pages/SessionsPage.tsx
@@ -141,21 +141,49 @@ function ToolCallBlock({
 // detect them here and downgrade them to a muted, clearly-labelled
 // "Context handoff" row.
 //
-// Keep these prefixes in sync with ``SUMMARY_PREFIX`` and
-// ``LEGACY_SUMMARY_PREFIX`` in ``agent/context_compressor.py``.
+// Keep these prefixes (and the END marker below) in sync with
+// ``SUMMARY_PREFIX`` / ``LEGACY_SUMMARY_PREFIX`` and the
+// merge-into-tail marker in ``agent/context_compressor.py``.
 const COMPACTION_PREFIXES = [
   "[CONTEXT COMPACTION — REFERENCE ONLY]",
   "[CONTEXT COMPACTION - REFERENCE ONLY]",
   "[CONTEXT SUMMARY]:",
 ] as const;
 
-function isCompactionMessage(msg: SessionMessage): boolean {
-  if (msg.role !== "user" && msg.role !== "assistant") return false;
-  const content = msg.content;
-  if (typeof content !== "string") return false;
-  const head = content.trimStart();
-  return COMPACTION_PREFIXES.some((p) => head.startsWith(p));
+// Marker the compressor inserts between a merged summary and the
+// original tail message content. When the summary role would collide
+// with both head and tail roles (e.g. head ends with ``user`` and tail
+// starts with ``assistant``), the compressor merges the summary as a
+// prefix on the first tail message instead of inserting a standalone
+// row. We split on this marker so the WebUI still shows the original
+// assistant reply as its own readable bubble — otherwise the merged
+// row reads as a single opaque "Context compaction" block and the
+// user can't see the reply (#29824).
+const COMPACTION_END_MARKER =
+  "--- END OF CONTEXT SUMMARY — respond to the message below, not the summary above ---";
+
+interface CompactionSplit {
+  /** Summary text (header + body, without the end marker). */
+  summary: string;
+  /** Original message content that came after the end marker. */
+  remainder: string;
 }
+
+function splitCompactionContent(content: string): CompactionSplit | null {
+  const head = content.trimStart();
+  if (!COMPACTION_PREFIXES.some((p) => head.startsWith(p))) return null;
+  const markerIdx = content.indexOf(COMPACTION_END_MARKER);
+  if (markerIdx < 0) {
+    return { summary: content, remainder: "" };
+  }
+  return {
+    summary: content.slice(0, markerIdx),
+    remainder: content
+      .slice(markerIdx + COMPACTION_END_MARKER.length)
+      .replace(/^\s+/, ""),
+  };
+}
+
 
 function MessageBubble({
   msg,
@@ -200,7 +228,42 @@ function MessageBubble({
     },
   };
 
-  const isCompaction = isCompactionMessage(msg);
+  // When a compaction handoff is merged into the front of the first
+  // tail message (the compressor's double-collision path —
+  // ``_merge_summary_into_tail`` in ``agent/context_compressor.py``),
+  // the message we received is ``[CONTEXT COMPACTION ...] + END_MARKER
+  // + <original assistant reply>``. We split it back into two visual
+  // rows here so the operator's actual answer survives as a readable
+  // bubble next to the (clearly-labelled) handoff metadata (#29824).
+  const compactionSplit =
+    typeof msg.content === "string"
+      ? splitCompactionContent(msg.content)
+      : null;
+
+  if (compactionSplit && compactionSplit.remainder) {
+    return (
+      <>
+        <MessageBubble
+          msg={{ ...msg, content: compactionSplit.summary }}
+          highlight={highlight}
+        />
+        <MessageBubble
+          msg={{
+            ...msg,
+            content: compactionSplit.remainder,
+            // The remainder is the original assistant reply that the
+            // compressor pre-pended the summary to — render with the
+            // normal assistant styling, NOT the muted handoff style.
+            // ``isCompactionMessage`` returns false on this stripped
+            // content because it no longer starts with the prefix.
+          }}
+          highlight={highlight}
+        />
+      </>
+    );
+  }
+
+  const isCompaction = compactionSplit !== null;
   const style = isCompaction
     ? ROLE_STYLES.compaction
     : ROLE_STYLES[msg.role] ?? ROLE_STYLES.system;

--- a/web/src/pages/SessionsPage.tsx
+++ b/web/src/pages/SessionsPage.tsx
@@ -131,6 +131,32 @@ function ToolCallBlock({
   );
 }
 
+// Context-compaction handoff blocks are persisted as ``role="user"`` or
+// ``role="assistant"`` with content starting with one of these prefixes —
+// they're metadata inserted by ``agent/context_compressor.py``, NOT real
+// turns the user typed or the model replied with. Rendering them with
+// the same styling as regular messages confuses operators scrolling the
+// session timeline (#29824 — "WebUI can show context compaction block
+// instead of latest assistant response after compression"), so we
+// detect them here and downgrade them to a muted, clearly-labelled
+// "Context handoff" row.
+//
+// Keep these prefixes in sync with ``SUMMARY_PREFIX`` and
+// ``LEGACY_SUMMARY_PREFIX`` in ``agent/context_compressor.py``.
+const COMPACTION_PREFIXES = [
+  "[CONTEXT COMPACTION — REFERENCE ONLY]",
+  "[CONTEXT COMPACTION - REFERENCE ONLY]",
+  "[CONTEXT SUMMARY]:",
+] as const;
+
+function isCompactionMessage(msg: SessionMessage): boolean {
+  if (msg.role !== "user" && msg.role !== "assistant") return false;
+  const content = msg.content;
+  if (typeof content !== "string") return false;
+  const head = content.trimStart();
+  return COMPACTION_PREFIXES.some((p) => head.startsWith(p));
+}
+
 function MessageBubble({
   msg,
   highlight,
@@ -164,12 +190,25 @@ function MessageBubble({
       text: "text-warning",
       label: t.sessions.roles.tool,
     },
+    // Compaction handoffs render as faded system-style metadata with a
+    // distinctive label so they can't be mistaken for real assistant
+    // replies during a scroll-back review (#29824).
+    compaction: {
+      bg: "bg-muted/50",
+      text: "text-muted-foreground italic",
+      label: "Context handoff",
+    },
   };
 
-  const style = ROLE_STYLES[msg.role] ?? ROLE_STYLES.system;
-  const label = msg.tool_name
-    ? `${t.sessions.roles.tool}: ${msg.tool_name}`
-    : style.label;
+  const isCompaction = isCompactionMessage(msg);
+  const style = isCompaction
+    ? ROLE_STYLES.compaction
+    : ROLE_STYLES[msg.role] ?? ROLE_STYLES.system;
+  const label = isCompaction
+    ? ROLE_STYLES.compaction.label
+    : msg.tool_name
+      ? `${t.sessions.roles.tool}: ${msg.tool_name}`
+      : style.label;
 
   // Check if any search term appears as a prefix of any word in content
   const isHit = (() => {


### PR DESCRIPTION
## What does this PR do?

Fix for #29824 — after context compaction the WebUI session viewer (and the TUI chat panel) can show the ``[CONTEXT COMPACTION — REFERENCE ONLY]`` handoff block in the slot where the user had just been reading the assistant's actual reply. The reporter put it best:

> i cant see the output of the last message you sent, i did see it previously, however now see 'context compaction'

The underlying work isn't lost — the assistant's reply is rolled into the compaction summary written into the session DB, so when the operator scrolls back they see opaque metadata where their answer used to be.

Two-pronged fix:

**Agent layer (the real fix — ``agent/context_compressor.py``).** ``_find_tail_cut_by_tokens`` already had ``_ensure_last_user_message_in_tail`` anchoring the most recent user request out of the compressed middle (#10896), but no symmetric anchor on the assistant side. When the conversation has an oversized recent tool result or a long stretch of ``tool_call`` / ``tool_result`` pairs *after* the assistant's last visible reply, the token-budget walk can stop with the previously-visible reply on the wrong side of ``cut_idx`` and the summariser rolls it into the single handoff blob.

Added ``_ensure_last_assistant_message_in_tail`` mirror that walks ``cut_idx`` back to include the most recent assistant message **with non-empty text content** — deliberately skipping ``tool_calls``-only stubs, which the UI renders as small "calling tool X" indicators rather than a readable bubble, so they aren't what the reporter means by "the last message you sent". Re-runs the standard ``_align_boundary_backward`` so we don't split a preceding tool group. The two anchors are chained — each only walks ``cut_idx`` backward, so the tail can only grow.

**WebUI layer (clarity + double-collision handling — ``web/src/pages/SessionsPage.tsx``).**

1. Added ``isCompactionMessage``/``splitCompactionContent`` detection of the ``[CONTEXT COMPACTION — REFERENCE ONLY]`` (current) and ``[CONTEXT SUMMARY]:`` (legacy) prefixes, plus a new ``compaction`` entry in ``MessageBubble``'s ``ROLE_STYLES`` map. Standalone summary messages now render as muted, italicised ``Context handoff`` rows instead of pretending to be regular assistant replies.

2. The compressor's double-collision fallback ``_merge_summary_into_tail`` prepends the summary + ``--- END OF CONTEXT SUMMARY — respond to the message below … ---`` marker onto the first tail message. With the assistant anchor that tail message is now usually the visible reply, so the persisted assistant turn becomes ``[SUMMARY] … END MARKER … <real reply>``. Without splitting it, the viewer renders one big "Context handoff" bubble with the reply buried inside the metadata — same bug, one layer deeper. ``MessageBubble`` now detects the marker via ``splitCompactionContent`` and recurses on the two halves, so the summary renders as the muted handoff row and the actual reply gets its normal styling.

## Related Issue

Fixes #29824.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- ``agent/context_compressor.py`` — added ``_find_last_assistant_message_idx`` and ``_ensure_last_assistant_message_in_tail`` (mirror of the existing user-side anchor; prefers content-bearing assistant messages so ``tool_calls``-only stubs don't shadow the real reply). Wired the new anchor into ``_find_tail_cut_by_tokens`` immediately after the user anchor — chained, monotonic.
- ``web/src/pages/SessionsPage.tsx`` — new ``COMPACTION_PREFIXES`` / ``COMPACTION_END_MARKER`` constants (cross-referenced to the Python source-of-truth), ``splitCompactionContent`` helper, ``compaction`` entry in ``ROLE_STYLES``, and a recursive split in ``MessageBubble`` so merged-into-tail compactions render as two visually distinct rows.
- ``tests/agent/test_compressor_assistant_tail_anchor.py`` (new, 518 lines) — 21 regression cases across five classes covering the helper contract, the anchor function, integration with the existing tail-cut path, the end-to-end ``compress()`` rollup repro, and a source guardrail that fails the build if the anchor is silently removed or re-ordered.

## How to Test

1. Check out this branch and ensure ``.venv`` is set up: ``python3 -m venv .venv && source .venv/bin/activate && pip install -e ".[all,dev]"``.
2. Run the new regression suite:
   ``scripts/run_tests.sh tests/agent/test_compressor_assistant_tail_anchor.py``
   Expected: 21 passed.
3. Run the broader compression-related test sweep to confirm no cross-file regressions:
   ``scripts/run_tests.sh tests/agent/test_context_compressor.py tests/agent/test_compressor_assistant_tail_anchor.py tests/agent/test_context_compressor_summary_continuity.py tests/agent/test_compressor_image_tokens.py tests/run_agent/test_compression_boundary.py tests/run_agent/test_compression_boundary_hook.py tests/run_agent/test_compression_feasibility.py tests/run_agent/test_compression_persistence.py tests/run_agent/test_413_compression.py tests/cli/test_manual_compress.py``
   Expected: 170 passed.
4. Type-check the WebUI:
   ``(cd web && npm install --no-audit --no-fund && npx tsc -b)``
   Expected: exits 0 with no diagnostics.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (``fix(compressor): …``, ``fix(webui): …``, ``test(compressor): …``)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run ``scripts/run_tests.sh`` on the affected suites and all tests pass
- [x] I've added tests for my changes (21 new cases in ``tests/agent/test_compressor_assistant_tail_anchor.py``, including a source-guardrail class so a refactor can't silently drop the anchor)
- [x] I've tested on my platform: macOS 15.2 (Darwin 24.6.0), Python 3.12, Node 22

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, ``docs/``, docstrings) — extensive docstrings on the new helpers describing the WebUI symptom and pointing at ``web/src/pages/SessionsPage.tsx``; the WebUI side has source-of-truth cross-reference comments back to ``agent/context_compressor.py``. No user-facing docs change required (no new config knobs, env vars, or behaviour the operator needs to know about — the fix is invisible until they look for the previously-disappeared reply).
- [x] I've updated ``cli-config.yaml.example`` if I added/changed config keys — N/A (no new config).
- [x] I've updated ``CONTRIBUTING.md`` or ``AGENTS.md`` if I changed architecture or workflows — N/A.
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — purely Python list ops + TSX rendering, no platform-specific code paths.
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A.

## Screenshots / Logs

```
$ scripts/run_tests.sh tests/agent/test_compressor_assistant_tail_anchor.py
Discovered 1 test files (21 tests) under [...]; running with -j 24
[100.0% |    21/21 | ✓21 | ✗ 0] ✓ tests/agent/test_compressor_assistant_tail_anchor.py (21✓, 0.4s)
=== Summary: 1 files, 21 tests passed, 0 failed (100% complete) in 0.4s (24 workers) ===

$ scripts/run_tests.sh tests/agent/test_context_compressor.py tests/agent/test_compressor_assistant_tail_anchor.py tests/agent/test_context_compressor_summary_continuity.py tests/agent/test_compressor_image_tokens.py tests/run_agent/test_compression_boundary.py tests/run_agent/test_compression_boundary_hook.py tests/run_agent/test_compression_feasibility.py tests/run_agent/test_compression_persistence.py tests/run_agent/test_413_compression.py tests/cli/test_manual_compress.py
Discovered 10 test files (170 tests) under [...]; running with -j 24
[100.0% |   170/170 | ✓170 | ✗  0] ✓ ... (10 files)
=== Summary: 10 files, 170 tests passed, 0 failed (100% complete) in 9.3s (24 workers) ===

$ ./web/node_modules/.bin/tsc -b web
(exit 0, no diagnostics)
```