### PR TITLE
fix(skills): make `hermes skills reset` honest when local copy differs from bundled

### DIFF
--- a/hermes_cli/skills_hub.py
+++ b/hermes_cli/skills_hub.py
@@ -1887,8 +1887,8 @@ def handle_skills_slash(cmd: str, console: Optional[Console] = None) -> None:
     elif action == "reset":
         if not args:
             c.print("[bold red]Usage:[/] /skills reset <name> [--restore] [--now]\n")
-            c.print("[dim]Clears the bundled-skills manifest entry so future updates stop marking it as user-modified.[/]")
-            c.print("[dim]Pass --restore to also replace the current copy with the bundled version.[/]\n")
+            c.print("[dim]Clears the bundled-skills manifest entry. If your local copy matches bundled, the next sync re-baselines and accepts upstream updates.[/]")
+            c.print("[dim]If your copy differs from bundled, it is preserved and keeps being skipped on updates — pass --restore to overwrite it with the bundled version.[/]\n")
             return
         name = args[0]
         restore = "--restore" in args

--- a/hermes_cli/subcommands/skills.py
+++ b/hermes_cli/subcommands/skills.py
@@ -142,11 +142,13 @@ def build_skills_parser(subparsers, *, cmd_skills: Callable) -> None:
 
     skills_reset = skills_subparsers.add_parser(
         "reset",
-        help="Reset a bundled skill — clears 'user-modified' tracking so updates work again",
+        help="Reset a bundled skill — re-baselines tracking when your copy matches bundled; use --restore for modified copies",
         description=(
-            "Clear a bundled skill's entry from the sync manifest (~/.hermes/skills/.bundled_manifest) "
-            "so future 'hermes update' runs stop marking it as user-modified. Pass --restore to also "
-            "replace the current copy with the bundled version."
+            "Clear a bundled skill's entry from the sync manifest (~/.hermes/skills/.bundled_manifest). "
+            "If your local copy is byte-identical to the bundled version, the next sync re-baselines "
+            "and future 'hermes update' runs accept upstream changes. If your copy genuinely differs "
+            "from bundled, the manifest stays cleared but the skill is preserved and continues to be "
+            "skipped on updates — pass --restore to overwrite your copy with the bundled version."
         ),
     )
     skills_reset.add_argument(

--- a/tests/tools/test_skills_sync.py
+++ b/tests/tools/test_skills_sync.py
@@ -594,7 +594,10 @@ class TestSyncSkills:
 
         captured = capsys.readouterr().out
         assert "new-skill" in captured
-        assert "hermes skills reset new-skill" in captured
+        # The hint must point at `--restore`: plain `reset` only clears the
+        # manifest entry and re-runs sync, which falls into this same branch
+        # again because user_hash != bundled_hash — leaving the user in a loop.
+        assert "hermes skills reset --restore new-skill" in captured
 
     def test_backfills_official_optional_provenance_for_existing_identical_skill(self, tmp_path):
         bundled = self._setup_bundled(tmp_path)
@@ -937,6 +940,37 @@ class TestResetBundledSkill:
 
         assert result["ok"] is False
         assert result["action"] == "bundled_missing"
+
+    def test_reset_on_genuinely_modified_skill_reports_preserved(self, tmp_path):
+        """When the user's copy genuinely differs from bundled, plain `reset`
+        cannot un-stick the skill — it clears the manifest, then sync skips
+        the skill because user_hash != bundled_hash and no manifest write
+        happens. The return message must say so honestly and point at
+        --restore, not falsely claim future syncs will accept upstream."""
+        bundled = self._setup_bundled(tmp_path)
+        skills_dir = tmp_path / "user_skills"
+        manifest_file = skills_dir / ".bundled_manifest"
+
+        dest = skills_dir / "productivity" / "google-workspace"
+        dest.mkdir(parents=True)
+        (dest / "SKILL.md").write_text(
+            "---\nname: google-workspace\n---\n# user-edited content, NOT bundled\n"
+        )
+        bundled_hash = _dir_hash(bundled / "productivity" / "google-workspace")
+        manifest_file.write_text(f"google-workspace:{bundled_hash}\n")
+
+        with self._patches(bundled, skills_dir, manifest_file):
+            result = reset_bundled_skill("google-workspace", restore=False)
+
+            assert result["ok"] is True
+            assert result["action"] == "manifest_cleared_local_preserved"
+            assert "--restore" in result["message"]
+            assert "preserved" in result["message"]
+            # Manifest entry stays absent — sync_skills hit the new-skill-
+            # collision branch and refused to poison the manifest.
+            assert "google-workspace" not in _read_manifest()
+            # User's edited copy is intact.
+            assert "user-edited" in (dest / "SKILL.md").read_text()
 
     def test_reset_no_op_when_already_clean(self, tmp_path):
         """If manifest has skill but user copy is in-sync, reset still safely clears + re-baselines."""

--- a/tests/tools/test_skills_sync.py
+++ b/tests/tools/test_skills_sync.py
@@ -972,6 +972,36 @@ class TestResetBundledSkill:
             # User's edited copy is intact.
             assert "user-edited" in (dest / "SKILL.md").read_text()
 
+    def test_reset_no_bundled_source_reports_no_bundled_action(self, tmp_path):
+        """A plain `reset` on a manifest-tracked skill that has NO bundled
+        source (removed upstream / bundled unavailable) must not be reported as
+        a 'local differs from bundled' divergence, and must not point at
+        --restore (which would fail with bundled_missing). It gets a dedicated
+        `manifest_cleared_no_bundled` action."""
+        bundled = self._setup_bundled(tmp_path)
+        skills_dir = tmp_path / "user_skills"
+        manifest_file = skills_dir / ".bundled_manifest"
+
+        # 'orphan-skill' is tracked in the manifest and present on disk, but is
+        # NOT in the bundled tree (only google-workspace is bundled).
+        dest = skills_dir / "productivity" / "orphan-skill"
+        dest.mkdir(parents=True)
+        (dest / "SKILL.md").write_text("---\nname: orphan-skill\n---\n# Orphan\n")
+        manifest_file.write_text("orphan-skill:OLDHASH00000000000000000000000000\n")
+
+        with self._patches(bundled, skills_dir, manifest_file):
+            result = reset_bundled_skill("orphan-skill", restore=False)
+
+            assert result["ok"] is True
+            assert result["action"] == "manifest_cleared_no_bundled"
+            # The message must be honest about the missing bundled source and
+            # must NOT recommend running --restore to recover (it can't).
+            assert "no bundled source" in result["message"]
+            assert "reset --restore" not in result["message"]
+            # Manifest entry is gone; the local copy is preserved untouched.
+            assert "orphan-skill" not in _read_manifest()
+            assert "Orphan" in (dest / "SKILL.md").read_text()
+
     def test_reset_no_op_when_already_clean(self, tmp_path):
         """If manifest has skill but user copy is in-sync, reset still safely clears + re-baselines."""
         bundled = self._setup_bundled(tmp_path)

--- a/tools/skills_sync.py
+++ b/tools/skills_sync.py
@@ -544,8 +544,8 @@ def sync_skills(quiet: bool = False) -> dict:
                         print(
                             f"  ⚠ {skill_name}: bundled version shipped but you "
                             f"already have a local skill by this name — yours "
-                            f"was kept. Run `hermes skills reset {skill_name}` "
-                            f"to replace it with the bundled version."
+                            f"was kept. Run `hermes skills reset --restore "
+                            f"{skill_name}` to replace it with the bundled version."
                         )
                 else:
                     dest.parent.mkdir(parents=True, exist_ok=True)
@@ -801,11 +801,29 @@ def reset_bundled_skill(name: str, restore: bool = False) -> dict:
         action = "restored"
         message = f"Restored '{name}' (no prior user copy, re-copied from bundled)."
     else:
-        action = "manifest_cleared"
-        message = (
-            f"Cleared manifest entry for '{name}'. Future `hermes update` runs "
-            f"will re-baseline against your current copy and accept upstream changes."
-        )
+        # Non-restore path: sync_skills() above either re-baselined the manifest
+        # (when user_hash matches the current bundled hash) or skipped without
+        # writing a manifest entry (when the user's copy genuinely differs from
+        # bundled — the new-skill-collision branch). Distinguish by reading the
+        # manifest after the resync so the user-facing message reflects what
+        # actually happened: a true re-baseline vs. a preserved local copy that
+        # will keep being skipped on future syncs.
+        manifest_after = _read_manifest()
+        if name in manifest_after:
+            action = "manifest_cleared"
+            message = (
+                f"Cleared manifest entry for '{name}'. Future `hermes update` runs "
+                f"will re-baseline against your current copy and accept upstream changes."
+            )
+        else:
+            action = "manifest_cleared_local_preserved"
+            message = (
+                f"Cleared manifest entry for '{name}', but your local copy differs "
+                f"from the bundled version, so it remains preserved and will not "
+                f"receive upstream updates. Use "
+                f"`hermes skills reset --restore {name}` to revert to the shipped "
+                f"version."
+            )
 
     return {"ok": True, "action": action, "message": message, "synced": synced}
 

--- a/tools/skills_sync.py
+++ b/tools/skills_sync.py
@@ -724,14 +724,30 @@ def reset_bundled_skill(name: str, restore: bool = False) -> dict:
         name: The skill name (matches the manifest key / skill frontmatter name).
         restore: If True, also delete the user's copy in SKILLS_DIR and let
                  the next sync re-copy the current bundled version. If False
-                 (default), only clear the manifest entry — the user's
-                 current copy is preserved but future updates work again.
+                 (default), only clear the manifest entry. A plain reset only
+                 re-baselines (and unsticks) the skill when the local copy is
+                 byte-identical to bundled; a genuinely modified or
+                 source-less copy is left preserved and still skipped on
+                 future syncs (see the action values below).
 
     Returns:
         dict with keys:
           - ok: bool, whether the reset succeeded
-          - action: one of "manifest_cleared", "restored", "not_in_manifest",
-                    "bundled_missing"
+          - action: one of
+                "manifest_cleared" — entry cleared and the resync re-baselined
+                    the skill, so future `hermes update` runs accept upstream
+                    changes;
+                "manifest_cleared_local_preserved" — entry cleared but the
+                    local copy differs from bundled, so it is preserved and
+                    still skipped on updates (use --restore to overwrite);
+                "manifest_cleared_no_bundled" — entry cleared but the skill has
+                    no bundled source (removed upstream / bundled unavailable),
+                    so the local copy is preserved and --restore cannot recover
+                    a shipped version;
+                "restored" — the local copy was replaced with the bundled
+                    version (restore=True);
+                "not_in_manifest" — the name is not a tracked bundled skill;
+                "bundled_missing" — restore=True but no bundled source exists.
           - message: human-readable description
           - synced: dict from sync_skills() if a sync was triggered, else None
     """
@@ -814,6 +830,20 @@ def reset_bundled_skill(name: str, restore: bool = False) -> dict:
             message = (
                 f"Cleared manifest entry for '{name}'. Future `hermes update` runs "
                 f"will re-baseline against your current copy and accept upstream changes."
+            )
+        elif not is_bundled:
+            # No bundled source backs this skill (removed upstream or the
+            # bundled dir is unavailable), so the resync had nothing to
+            # baseline against and left it out of the manifest. Don't blame a
+            # "local differs from bundled" divergence — and don't point at
+            # `--restore`, which would fail with `bundled_missing` here.
+            action = "manifest_cleared_no_bundled"
+            message = (
+                f"Cleared manifest entry for '{name}', but it has no bundled "
+                f"source (removed upstream or bundled skills are unavailable), "
+                f"so the local copy is preserved as-is and `hermes update` will "
+                f"leave it untouched. `--restore` cannot recover a shipped "
+                f"version for this skill."
             )
         else:
             action = "manifest_cleared_local_preserved"


### PR DESCRIPTION
## What does this PR do?

Fixes the misleading success message from `hermes skills reset <name>` (no `--restore`) when the user's local copy of a bundled skill genuinely differs from the bundled version.

Today, plain `reset` always returns:

> Cleared manifest entry for '\<name\>'. Future `hermes update` runs will re-baseline against your current copy and accept upstream changes.

But the implementation only re-baselines when `dir_hash(dest) == bundled_hash`. For genuinely modified skills, `sync_skills` falls into the new-skill-collision branch (`tools/skills_sync.py:204`), skips the skill, and refuses to poison the manifest. The manifest stays empty, the next sync prints the same "yours was kept. Run `hermes skills reset {name}`" message (`tools/skills_sync.py:222`) — and the user runs the exact same command that just told them updates would resume. That's the loop the issue describes.

Mirrors the runtime resolver `reset_bundled_skill -> sync_skills`: the success message now reflects which branch `sync_skills` actually took, and every user-facing surface that recommends `reset` (CLI `--help`, TUI `/skills reset` usage line) now points at `--restore` for modified copies.

## Related Issue

Fixes #29856

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/skills_sync.py` — `reset_bundled_skill(restore=False)` now re-reads the manifest after the resync and returns a new `manifest_cleared_local_preserved` action with an honest message when the local copy differs from bundled. The `sync_skills` collision hint now suggests `hermes skills reset --restore <name>` instead of plain `reset`.
- `hermes_cli/main.py` — `hermes skills reset --help` text updated to mirror the runtime: re-baseline path for byte-identical copies, `--restore` path for modified copies.
- `hermes_cli/skills_hub.py` — TUI `/skills reset` usage block updated identically.
- `tests/tools/test_skills_sync.py` — new test `test_reset_on_genuinely_modified_skill_reports_preserved` covers the bug repro from the issue (modified copy → must report preserved-with-restore). Existing `test_collision_prints_reset_hint` updated to assert the `--restore` suggestion.

## How to Test

1. Reproduce the bug on `main`:
   ```bash
   # In a fresh ~/.hermes, sync first, then edit a bundled skill:
   hermes  # runs sync_skills() automatically
   echo " # local edit" >> ~/.hermes/skills/productivity/google-workspace/SKILL.md
   hermes  # should now print "~ google-workspace (user-modified, skipping)"
   hermes skills reset google-workspace
   # Today: "Cleared manifest entry... Future updates will accept upstream changes."
   hermes  # should still print "~ google-workspace (user-modified, skipping)" — bug
   ```
2. Apply this PR and re-run:
   ```bash
   hermes skills reset google-workspace
   # Now: "Cleared manifest entry... your local copy differs from the bundled
   # version, so it remains preserved and will not receive upstream updates.
   # Use `hermes skills reset --restore google-workspace` to revert..."
   hermes skills reset --restore google-workspace
   # "Restored 'google-workspace' from bundled source." — actually works.
   ```
3. Focused tests:
   ```
   uv run --with pytest --with pytest-xdist --with pytest-asyncio --with pytest-timeout python3 -m pytest tests/tools/test_skills_sync.py -v
   ```
   46 passed locally (Python 3.11, macOS 15).

## Regression guard

Without `tools/skills_sync.py` changes, both `test_reset_on_genuinely_modified_skill_reports_preserved` and the updated `test_collision_prints_reset_hint` fail with the expected old messages, confirming each test is actually checking the fixed behavior:

```
AssertionError: assert 'hermes skills reset --restore new-skill' in
  '... Run `hermes skills reset new-skill` to replace it with the bundled version.\n...'
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run focused tests for the touched code and all pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.x

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; the runtime help text in `hermes_cli/main.py` and `hermes_cli/skills_hub.py` IS the user-facing doc, and both are updated.
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no config changes)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure-Python messaging change, no platform-specific paths.
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A (no tool schema changes)

> Audited siblings: `website/scripts/generate-skill-docs.py:484` already points users at `reset <name> --restore` for missing bundled skills (covered by `tests/website/test_generate_skill_docs.py:116`), so the website docs are already consistent. No further widening needed.