### PR TITLE
fix(hindsight): key prefetch cache by session and query

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -546,6 +546,14 @@ class HindsightMemoryProvider(MemoryProvider):
         self._timeout = _DEFAULT_TIMEOUT
         self._idle_timeout = _DEFAULT_IDLE_TIMEOUT
         self._prefetch_result = ""
+        # Key the cached prefetch result by (session_id, query) so that
+        # prefetch(B) cannot return a result that was warmed by an earlier
+        # queue_prefetch(A). Without this guard, the unkeyed
+        # _prefetch_result leaks A's recall into B's context, which is the
+        # H1 stale-prefetch bug (see Hindsight LTM repair plan B1 and
+        # ~/.hermes/scripts/hindsight-ltm-repair/repro_prefetch_and_metadata.py).
+        # Empty string sentinel matches the unset state of _prefetch_result.
+        self._prefetch_key: tuple[str, str] | None = None
         self._prefetch_lock = threading.Lock()
         self._prefetch_thread = None
         # Single-writer model for retain. sync_turn() enqueues; the writer
@@ -1282,11 +1290,32 @@ class HindsightMemoryProvider(MemoryProvider):
         if self._prefetch_thread and self._prefetch_thread.is_alive():
             logger.debug("Prefetch: waiting for background thread to complete")
             self._prefetch_thread.join(timeout=3.0)
+        # Read result + key under the same lock so the writer thread in
+        # queue_prefetch can't update one without the other.
+        expected_key = (session_id or "", query or "")
         with self._prefetch_lock:
+            cached_key = self._prefetch_key
             result = self._prefetch_result
+            # Always invalidate the cache after a read attempt. Even on a
+            # miss (key mismatch) we drop the stale entry so that a future
+            # prefetch() can't reuse it after the next queue_prefetch.
+            # This preserves the original "one-shot" semantics of the
+            # cache while keeping it safe across mismatched queries.
             self._prefetch_result = ""
+            self._prefetch_key = None
         if not result:
             logger.debug("Prefetch: no results available")
+            return ""
+        if cached_key != expected_key:
+            # Stale entry from a previous queue_prefetch(other_query) or
+            # other_session. Safe-empty is the correct response per the
+            # provider contract; do NOT inject the prior result.
+            logger.debug(
+                "Prefetch: dropping stale cached entry "
+                "(cached_key=%r expected_key=%r)",
+                cached_key,
+                expected_key,
+            )
             return ""
         logger.debug("Prefetch: returning %d chars of context", len(result))
         header = self._recall_prompt_preamble or (
@@ -1309,6 +1338,12 @@ class HindsightMemoryProvider(MemoryProvider):
         # Truncate query to max chars
         if self._recall_max_input_chars and len(query) > self._recall_max_input_chars:
             query = query[:self._recall_max_input_chars]
+
+        # Snapshot the key the result will be filed under. This is the
+        # query as it will be sent to the daemon (post-truncation) and
+        # the session_id supplied by the caller. prefetch() will only
+        # return the cached result if it sees the same key.
+        cache_key = (session_id or "", query or "")
 
         def _run():
             try:
@@ -1335,6 +1370,7 @@ class HindsightMemoryProvider(MemoryProvider):
                 if text:
                     with self._prefetch_lock:
                         self._prefetch_result = text
+                        self._prefetch_key = cache_key
             except Exception as e:
                 logger.debug("Hindsight prefetch failed: %s", e, exc_info=True)
 
@@ -1676,6 +1712,7 @@ class HindsightMemoryProvider(MemoryProvider):
             self._prefetch_thread.join(timeout=3.0)
         with self._prefetch_lock:
             self._prefetch_result = ""
+            self._prefetch_key = None
 
         # 3. Now rotate to the new session.
         if parent_session_id:

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -580,15 +580,20 @@ class TestPrefetch:
         assert provider.prefetch("test") == ""
 
     def test_prefetch_default_preamble(self, provider):
+        # Simulate a properly-keyed cache entry warmed by a prior
+        # queue_prefetch("test", session_id="test-session"). The
+        # provider fixture is initialized with session_id="test-session".
         provider._prefetch_result = "- some memory"
-        result = provider.prefetch("test")
+        provider._prefetch_key = ("test-session", "test")
+        result = provider.prefetch("test", session_id="test-session")
         assert "Hindsight Memory" in result
         assert "- some memory" in result
 
     def test_prefetch_custom_preamble(self, provider_with_config):
         p = provider_with_config(recall_prompt_preamble="Custom header:")
         p._prefetch_result = "- memory line"
-        result = p.prefetch("test")
+        p._prefetch_key = ("test-session", "test")
+        result = p.prefetch("test", session_id="test-session")
         assert result.startswith("Custom header:")
         assert "- memory line" in result
 
@@ -640,6 +645,103 @@ class TestPrefetch:
         assert call_kwargs["tags"] == ["t1"]
         assert call_kwargs["tags_match"] == "all"
         assert call_kwargs["types"] == ["world"]
+
+    # ------------------------------------------------------------------
+    # Regression: prefetch(query) must not return an unkeyed result from
+    # a previous queue_prefetch() for a different query. (B1 from the
+    # Hindsight LTM repair plan; reproducer at
+    # ~/.hermes/scripts/hindsight-ltm-repair/repro_prefetch_and_metadata.py.)
+    # ------------------------------------------------------------------
+    def test_prefetch_does_not_return_stale_queued_result_for_different_query(self, provider):
+        """If queue_prefetch(A) warms a result for topic A, a subsequent
+        prefetch(B) for an unrelated topic B must NOT return A's recall.
+
+        The provider must only return recall whose key matches the
+        current (query, session_id) being prefetched. Anything else is
+        safe-empty.
+        """
+        # Arrange — stub arecall so we can control what gets cached for
+        # topic A. arecall is called with kwargs by queue_prefetch.
+        topic_a = "Topic A: Barcelona hotel recommendation"
+        topic_b = "Topic B: current session start time"
+        marker_a = "ALPHA_BARCELONA_PREFETCH_MARKER"
+
+        def _recall_for_a(**kwargs):
+            assert kwargs.get("query") == topic_a
+            return SimpleNamespace(
+                results=[SimpleNamespace(text=f"Hotel notes {marker_a}")]
+            )
+
+        provider._client.arecall = AsyncMock(side_effect=_recall_for_a)
+
+        # Warm the cache for topic A (this populates _prefetch_result
+        # in the background writer thread).
+        provider.queue_prefetch(topic_a, session_id="session-A")
+        if provider._prefetch_thread:
+            provider._prefetch_thread.join(timeout=5.0)
+
+        # Act — now ask for topic B, which was never queued.
+        injected = provider.prefetch(topic_b, session_id="session-A")
+
+        # Assert — the marker for A must not leak into B's prefetch.
+        assert marker_a not in injected, (
+            "prefetch(B) returned a stale result keyed to A's queue_prefetch; "
+            "this is the H1 unkeyed-cache bug."
+        )
+        # Safe-empty when there is no fresh keyed result for the current
+        # query: prefetch must return "" rather than a stale prior result.
+        assert injected == "", (
+            "prefetch(B) should return empty when no fresh keyed cache "
+            "hit exists for (B, session-A); got non-empty injection."
+        )
+
+    def test_prefetch_returns_cached_result_when_query_matches(self, provider):
+        """The positive companion: queue_prefetch(A) followed by
+        prefetch(A, same session) MUST return A's warmed recall."""
+        topic_a = "Topic A: Barcelona hotel recommendation"
+        marker_a = "ALPHA_BARCELONA_PREFETCH_MARKER"
+
+        def _recall_for_a(**kwargs):
+            return SimpleNamespace(
+                results=[SimpleNamespace(text=f"Hotel notes {marker_a}")]
+            )
+
+        provider._client.arecall = AsyncMock(side_effect=_recall_for_a)
+
+        provider.queue_prefetch(topic_a, session_id="session-A")
+        if provider._prefetch_thread:
+            provider._prefetch_thread.join(timeout=5.0)
+
+        injected = provider.prefetch(topic_a, session_id="session-A")
+
+        assert marker_a in injected, (
+            "queue_prefetch(A) → prefetch(A) on the same session should "
+            "return the warmed recall."
+        )
+
+    def test_prefetch_does_not_return_cached_result_across_sessions(self, provider):
+        """A cache entry warmed for session-A must not satisfy a
+        prefetch(same query) issued from session-B."""
+        topic = "Topic A: Barcelona hotel recommendation"
+        marker_a = "ALPHA_BARCELONA_PREFETCH_MARKER"
+
+        def _recall(**kwargs):
+            return SimpleNamespace(
+                results=[SimpleNamespace(text=f"Hotel notes {marker_a}")]
+            )
+
+        provider._client.arecall = AsyncMock(side_effect=_recall)
+
+        provider.queue_prefetch(topic, session_id="session-A")
+        if provider._prefetch_thread:
+            provider._prefetch_thread.join(timeout=5.0)
+
+        injected = provider.prefetch(topic, session_id="session-B")
+        assert marker_a not in injected, (
+            "A cache entry keyed to session-A must not satisfy prefetch "
+            "for session-B even when the query string matches."
+        )
+        assert injected == ""
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Key Hindsight prefetch cache entries by `(session_id, query)` instead of treating `_prefetch_result` as an unqualified one-shot cache.
- Return safe-empty and clear the cached result when `prefetch()` is asked for a different query or session than the one warmed by `queue_prefetch()`.
- Clear the prefetch key during `on_session_switch()` alongside `_prefetch_result`.
- Add regression coverage for cross-query and cross-session stale-prefetch leaks, plus the matching positive cache-hit case.

## Test Plan
- `scripts/run_tests.sh tests/plugins/memory/test_hindsight_provider.py` — 99 passed.

## Notes
- This only changes the Hindsight provider cache guard and tests.
- No production Hindsight bank writes were performed.
