### PR TITLE
fix(auth): resolve Codex credentials from pool fallback

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -3194,6 +3194,27 @@ def _read_codex_tokens(*, _lock: bool = True) -> Dict[str, Any]:
     else:
         auth_store = _load_auth_store()
     state = _load_provider_state(auth_store, "openai-codex")
+    source = "hermes-auth-store"
+    if not state:
+        pool_entries = read_credential_pool("openai-codex")
+        if isinstance(pool_entries, list):
+            for entry in sorted(
+                (e for e in pool_entries if isinstance(e, dict)),
+                key=lambda e: int(e.get("priority") or 0),
+            ):
+                access_token = str(entry.get("access_token") or entry.get("api_key") or "").strip()
+                refresh_token = str(entry.get("refresh_token") or "").strip()
+                if access_token and refresh_token:
+                    state = {
+                        "tokens": {
+                            "access_token": access_token,
+                            "refresh_token": refresh_token,
+                        },
+                        "last_refresh": entry.get("last_refresh"),
+                        "auth_mode": entry.get("auth_mode") or "chatgpt",
+                    }
+                    source = f"pool:{entry.get('label') or entry.get('id') or 'openai-codex'}"
+                    break
     if not state:
         raise AuthError(
             "No Codex credentials stored. Run `hermes auth` to authenticate.",
@@ -3228,6 +3249,7 @@ def _read_codex_tokens(*, _lock: bool = True) -> Dict[str, Any]:
     return {
         "tokens": tokens,
         "last_refresh": state.get("last_refresh"),
+        "source": source,
     }
 
 
@@ -3443,7 +3465,7 @@ def resolve_codex_runtime_credentials(
         "provider": "openai-codex",
         "base_url": base_url,
         "api_key": access_token,
-        "source": "hermes-auth-store",
+        "source": data.get("source") or "hermes-auth-store",
         "last_refresh": data.get("last_refresh"),
         "auth_mode": "chatgpt",
     }

--- a/tests/hermes_cli/test_auth_codex_provider.py
+++ b/tests/hermes_cli/test_auth_codex_provider.py
@@ -75,6 +75,32 @@ def test_read_codex_tokens_missing(tmp_path, monkeypatch):
     assert exc.value.code == "codex_auth_missing"
 
 
+def test_read_codex_tokens_from_credential_pool_when_provider_state_missing(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir(parents=True, exist_ok=True)
+    (hermes_home / "auth.json").write_text(json.dumps({
+        "version": 1,
+        "providers": {},
+        "credential_pool": {
+            "openai-codex": [{
+                "id": "cred-1",
+                "label": "openai-codex-oauth-2",
+                "priority": 0,
+                "access_token": "pool-access",
+                "refresh_token": "pool-refresh",
+                "last_refresh": "2026-05-20T07:53:19Z",
+            }]
+        },
+    }))
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    data = _read_codex_tokens()
+
+    assert data["tokens"]["access_token"] == "pool-access"
+    assert data["tokens"]["refresh_token"] == "pool-refresh"
+    assert data["source"] == "pool:openai-codex-oauth-2"
+
+
 def test_resolve_codex_runtime_credentials_missing_access_token(tmp_path, monkeypatch):
     hermes_home = tmp_path / "hermes"
     _setup_hermes_auth(hermes_home, access_token="")


### PR DESCRIPTION
## What does this PR do?

Fixes Codex runtime credential resolution when OAuth credentials exist only in the credential pool and the legacy/provider-state slot is empty.

This can happen after `hermes auth add openai-codex --type oauth` appends a fresh pooled credential without writing the older provider-state shape. Before this change, `_read_codex_tokens()` raised `codex_auth_missing` even though a valid pooled Codex credential was present. The runtime now falls back to the selected pooled credential and preserves the source label for diagnostics.

## Related Issue

N/A — found while validating local gateway/runtime auth after an upstream cleanup.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/auth.py`
  - Let `_read_codex_tokens()` fall back to `read_credential_pool("openai-codex")` when provider state is absent.
  - Preserve a `source` field so `resolve_codex_runtime_credentials()` can report whether credentials came from provider state or a pool entry.
- `tests/hermes_cli/test_auth_codex_provider.py`
  - Add regression coverage for provider-state-missing / credential-pool-present Codex auth.

## How to Test

Targeted validation run on Ubuntu/Linux with Python 3.11:

1. `python -m py_compile hermes_cli/auth.py`
2. `python -m pytest tests/hermes_cli/test_auth_codex_provider.py -q -o 'addopts='`

Result:

```text
17 passed in 0.40s
```

Full `pytest tests/ -q` was not run for this small PR branch, so the full-suite checklist item is intentionally left unchecked.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Debian Linux / Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A

## Screenshots / Logs

```text
$ python -m pytest tests/hermes_cli/test_auth_codex_provider.py -q -o 'addopts='
.................                                                        [100%]
17 passed in 0.40s
```
