### PR TITLE
fix(gateway): add canonical health status

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -17,6 +17,7 @@ from typing import Dict, List, Optional, Any, Callable
 from enum import Enum
 
 from hermes_cli.config import get_hermes_home
+from hermes_cli.env_loader import load_hermes_dotenv
 from utils import is_truthy_value
 
 logger = logging.getLogger(__name__)
@@ -703,6 +704,10 @@ def load_gateway_config() -> GatewayConfig:
     4. Built-in defaults
     """
     _home = get_hermes_home()
+    try:
+        load_hermes_dotenv(hermes_home=_home)
+    except Exception as e:
+        logger.debug("Failed to load Hermes .env before gateway config parse: %s", e)
     gw_data: dict = {}
 
     # Legacy fallback: gateway.json provides the base layer.

--- a/gateway/status.py
+++ b/gateway/status.py
@@ -222,6 +222,58 @@ def _build_runtime_status_record() -> dict[str, Any]:
     return payload
 
 
+def _current_process_is_gateway_runtime() -> bool:
+    """Return True when the current process is the gateway daemon/runtime.
+
+    CLI inspection commands like ``hermes gateway health`` should be able to
+    update auxiliary runtime fields without hijacking the canonical daemon PID.
+    Distinguish the real gateway process (`gateway run`) from operator/CLI
+    subcommands (`gateway health`, `gateway status`, etc.).
+    """
+    argv = [str(part) for part in sys.argv]
+    return "gateway" in argv and "run" in argv
+
+
+def _runtime_status_identity_is_live_gateway(payload: dict[str, Any]) -> bool:
+    """Return True if the stored runtime identity still belongs to a live gateway."""
+    try:
+        pid = int(payload.get("pid"))
+    except (TypeError, ValueError):
+        return False
+
+    if _IS_WINDOWS:
+        try:
+            import psutil  # type: ignore
+
+            if not psutil.pid_exists(pid):
+                return False
+        except Exception:
+            return False
+    else:
+        try:
+            os.kill(pid, 0)  # windows-footgun: ok - guarded by _IS_WINDOWS false branch
+        except (ProcessLookupError, PermissionError, OSError):
+            return False
+
+    recorded_start = payload.get("start_time")
+    current_start = _get_process_start_time(pid)
+    if recorded_start is not None and current_start is not None and recorded_start != current_start:
+        return False
+
+    argv = payload.get("argv")
+    if isinstance(argv, list) and argv:
+        return _record_looks_like_gateway(payload)
+    return _looks_like_gateway_process(pid)
+
+
+def _get_live_gateway_identity_record() -> Optional[dict[str, Any]]:
+    """Return the live gateway identity from gateway.pid when available."""
+    record = _read_pid_record()
+    if not isinstance(record, dict):
+        return None
+    return record if _runtime_status_identity_is_live_gateway(record) else None
+
+
 def _read_json_file(path: Path) -> Optional[dict[str, Any]]:
     if not path.exists():
         return None
@@ -507,20 +559,37 @@ def write_runtime_status(
     exit_reason: Any = _UNSET,
     restart_requested: Any = _UNSET,
     active_agents: Any = _UNSET,
-    platform: Any = _UNSET,
+    platform: Optional[str] = None,
     platform_state: Any = _UNSET,
+    updated_at: Any = _UNSET,
     error_code: Any = _UNSET,
     error_message: Any = _UNSET,
+    lcm_runtime: Any = _UNSET,
+    lcm_recent_turn: Any = _UNSET,
+    lcm_memory: Any = _UNSET,
+    lcm_gateway: Any = _UNSET,
 ) -> None:
     """Persist gateway runtime health information for diagnostics/status."""
     path = _get_runtime_status_path()
+
     payload = _read_json_file(path) or _build_runtime_status_record()
     current_record = _build_pid_record()
     payload.setdefault("platforms", {})
-    payload["kind"] = current_record["kind"]
-    payload["pid"] = current_record["pid"]
-    payload["argv"] = current_record["argv"]
-    payload["start_time"] = current_record["start_time"]
+    payload.setdefault("kind", _GATEWAY_KIND)
+    if _current_process_is_gateway_runtime():
+        payload["pid"] = current_record["pid"]
+        payload["start_time"] = current_record["start_time"]
+        payload["argv"] = current_record["argv"]
+    elif not _runtime_status_identity_is_live_gateway(payload):
+        live_record = _get_live_gateway_identity_record()
+        if live_record:
+            payload["pid"] = live_record.get("pid")
+            payload["start_time"] = live_record.get("start_time")
+            payload["argv"] = live_record.get("argv")
+        elif not payload.get("pid"):
+            payload["pid"] = current_record["pid"]
+            payload["start_time"] = current_record["start_time"]
+            payload["argv"] = current_record["argv"]
     payload["updated_at"] = _utc_now_iso()
 
     if gateway_state is not _UNSET:
@@ -532,7 +601,7 @@ def write_runtime_status(
     if active_agents is not _UNSET:
         payload["active_agents"] = max(0, int(active_agents))
 
-    if platform is not _UNSET:
+    if platform is not _UNSET and platform is not None:
         platform_payload = payload["platforms"].get(platform, {})
         if platform_state is not _UNSET:
             platform_payload["state"] = platform_state
@@ -542,6 +611,15 @@ def write_runtime_status(
             platform_payload["error_message"] = error_message
         platform_payload["updated_at"] = _utc_now_iso()
         payload["platforms"][platform] = platform_payload
+
+    if lcm_runtime is not _UNSET:
+        payload["lcm_runtime"] = lcm_runtime
+    if lcm_recent_turn is not _UNSET:
+        payload["lcm_recent_turn"] = lcm_recent_turn
+    if lcm_memory is not _UNSET:
+        payload["lcm_memory"] = lcm_memory
+    if lcm_gateway is not _UNSET:
+        payload["lcm_gateway"] = lcm_gateway
 
     _write_json_file(path, payload)
 

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -3,8 +3,9 @@ Gateway subcommand for hermes CLI.
 
 Handles: hermes gateway [run|start|stop|restart|status|install|uninstall|setup]
 """
-
 import asyncio
+import json
+import getpass
 import logging
 import os
 import shutil
@@ -12,6 +13,10 @@ import signal
 import subprocess
 import sys
 import textwrap
+import time
+from datetime import datetime, timezone
+import urllib.error
+import urllib.request
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -2252,11 +2257,11 @@ def _hermes_home_for_target_user(target_home_dir: str) -> str:
 
 
 def _build_service_path_dirs(project_root: Path | None = None) -> list[str]:
-    """Build PATH directory list for service units, excluding non-existent dirs."""
+    """Build PATH directory list for service units, excluding inaccessible dirs."""
     if project_root is None:
         project_root = PROJECT_ROOT
 
-    def _is_dir(path: Path) -> bool:
+    def _safe_is_dir(path: Path) -> bool:
         try:
             return path.is_dir()
         except OSError:
@@ -2265,21 +2270,21 @@ def _build_service_path_dirs(project_root: Path | None = None) -> list[str]:
     candidates = []
 
     venv_bin = project_root / "venv" / "bin"
-    if _is_dir(venv_bin):
+    if _safe_is_dir(venv_bin):
         candidates.append(str(venv_bin))
     elif sys.prefix != sys.base_prefix:
         candidates.append(str(Path(sys.prefix) / "bin"))
 
     node_bin = project_root / "node_modules" / ".bin"
-    if _is_dir(node_bin):
+    if _safe_is_dir(node_bin):
         candidates.append(str(node_bin))
 
     hermes_home = get_hermes_home()
     hermes_node = hermes_home / "node" / "bin"
-    if _is_dir(hermes_node):
+    if _safe_is_dir(hermes_node):
         candidates.append(str(hermes_node))
     hermes_nm = hermes_home / "node_modules" / ".bin"
-    if _is_dir(hermes_nm):
+    if _safe_is_dir(hermes_nm):
         candidates.append(str(hermes_nm))
 
     return candidates
@@ -2380,7 +2385,7 @@ Environment="PATH={sane_path}"
 Environment="VIRTUAL_ENV={venv_dir}"
 Environment="HERMES_HOME={hermes_home}"
 Restart=always
-RestartSec=5
+RestartSec=10
 RestartMaxDelaySec=300
 RestartSteps=5
 RestartForceExitStatus={GATEWAY_SERVICE_RESTART_EXIT_CODE}
@@ -2415,7 +2420,7 @@ Environment="PATH={sane_path}"
 Environment="VIRTUAL_ENV={venv_dir}"
 Environment="HERMES_HOME={hermes_home}"
 Restart=always
-RestartSec=5
+RestartSec=10
 RestartMaxDelaySec=300
 RestartSteps=5
 RestartForceExitStatus={GATEWAY_SERVICE_RESTART_EXIT_CODE}
@@ -4331,14 +4336,358 @@ def _platform_status(platform: dict) -> str:
     return "not configured"
 
 
-def _runtime_health_lines() -> list[str]:
-    """Summarize the latest persisted gateway runtime health state."""
+def _load_runtime_health_state() -> dict | None:
     try:
         from gateway.status import read_runtime_status
     except Exception:
-        return []
+        return None
+    return read_runtime_status() or None
 
-    state = read_runtime_status()
+
+def _parse_iso_datetime(value: object) -> datetime | None:
+    if not isinstance(value, str) or not value.strip():
+        return None
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _latest_event_age_seconds(events: list[object], workflow: str, *, now: datetime | None = None) -> float | None:
+    now = now or datetime.now(timezone.utc)
+    latest: datetime | None = None
+    for event in events:
+        if not isinstance(event, dict):
+            continue
+        if str(event.get("workflow") or "").strip() != workflow:
+            continue
+        recorded_at = _parse_iso_datetime(event.get("recorded_at"))
+        if recorded_at and (latest is None or recorded_at > latest):
+            latest = recorded_at
+    if latest is None:
+        return None
+    return max(0.0, (now - latest).total_seconds())
+
+
+def _build_gateway_lcm_scorecard(lcm_gateway: dict | None, *, now: datetime | None = None) -> dict[str, object]:
+    state = lcm_gateway if isinstance(lcm_gateway, dict) else {}
+    counters = state.get("workflow_counters") if isinstance(state.get("workflow_counters"), dict) else {}
+    recent_events = state.get("recent_workflow_events") if isinstance(state.get("recent_workflow_events"), list) else []
+    workflows: dict[str, object] = {}
+    total_success = 0
+    total_failure = 0
+    latest_outcome_by_workflow: dict[str, str] = {}
+    for event in recent_events:
+        if not isinstance(event, dict):
+            continue
+        workflow = str(event.get("workflow") or "").strip()
+        outcome = str(event.get("outcome") or "").strip().lower()
+        if workflow and outcome in {"success", "failure"}:
+            latest_outcome_by_workflow[workflow] = outcome
+    now = now or datetime.now(timezone.utc)
+    stale_workflows: list[str] = []
+    for workflow, counts in counters.items():
+        if not isinstance(counts, dict):
+            continue
+        success = int(counts.get("success", 0) or 0)
+        failure = int(counts.get("failure", 0) or 0)
+        total_success += success
+        total_failure += failure
+        total = success + failure
+        entry = {
+            "success": success,
+            "failure": failure,
+            "total": total,
+            "success_rate_pct": round((success / total) * 100, 1) if total else None,
+        }
+        latest = latest_outcome_by_workflow.get(workflow)
+        if latest:
+            entry["latest_outcome"] = latest
+        age_seconds = _latest_event_age_seconds(recent_events, workflow, now=now)
+        if age_seconds is not None:
+            entry["latest_event_age_seconds"] = round(age_seconds, 1)
+            # Gateway/API health proof should be fresh because `hermes gateway health`
+            # records this event on every invocation. If it is older than five
+            # minutes, the scorecard is stale rather than green-by-history.
+            if workflow == "health_check_execution" and age_seconds > 300:
+                entry["freshness"] = "stale"
+                stale_workflows.append(workflow)
+            else:
+                entry["freshness"] = "fresh"
+        elif total:
+            entry["freshness"] = "unknown"
+        workflows[workflow] = entry
+    total_events = total_success + total_failure
+    latest_health = None
+    if stale_workflows:
+        latest_health = "unknown"
+    elif latest_outcome_by_workflow:
+        if any(outcome == "failure" for outcome in latest_outcome_by_workflow.values()):
+            latest_health = "degraded"
+        elif any(outcome == "success" for outcome in latest_outcome_by_workflow.values()):
+            latest_health = "ok"
+    runtime_health = latest_health or ("degraded" if total_failure else ("ok" if total_success else "never"))
+    result = {
+        "overall": {
+            "success": total_success,
+            "failure": total_failure,
+            "total": total_events,
+            "success_rate_pct": round((total_success / total_events) * 100, 1) if total_events else None,
+        },
+        "workflows": workflows,
+        "runtime_health": runtime_health,
+    }
+    if stale_workflows:
+        result["stale_workflows"] = stale_workflows
+    return result
+
+
+def _record_gateway_workflow_event(
+    runtime_state: dict | None,
+    workflow: str,
+    outcome: str,
+    *,
+    failure_class: str | None = None,
+    details: dict[str, object] | None = None,
+) -> dict[str, object]:
+    state = dict(runtime_state or {})
+    lcm_gateway = state.get("lcm_gateway") if isinstance(state.get("lcm_gateway"), dict) else {}
+    counters = lcm_gateway.get("workflow_counters") if isinstance(lcm_gateway.get("workflow_counters"), dict) else {}
+    events = lcm_gateway.get("recent_workflow_events") if isinstance(lcm_gateway.get("recent_workflow_events"), list) else []
+    counters = {name: dict(value) for name, value in counters.items() if isinstance(value, dict)}
+    events = [dict(item) for item in events if isinstance(item, dict)]
+    workflow_counts = counters.setdefault(workflow, {"success": 0, "failure": 0})
+    workflow_counts["success" if outcome == "success" else "failure"] += 1
+    events.append({
+        "workflow": workflow,
+        "outcome": outcome,
+        "failure_class": failure_class,
+        "details": details or {},
+        "recorded_at": datetime.now(timezone.utc).isoformat(),
+    })
+    lcm_gateway = {
+        "workflow_counters": counters,
+        "recent_workflow_events": events[-20:],
+    }
+    lcm_gateway["scorecard"] = _build_gateway_lcm_scorecard(lcm_gateway)
+    state["lcm_gateway"] = lcm_gateway
+    return state
+
+
+def _coalesce_health(*values: object) -> str:
+    normalized = []
+    for value in values:
+        text = str(value or "").strip().lower()
+        if text:
+            normalized.append(text)
+    if any(value == "degraded" for value in normalized):
+        return "degraded"
+    if any(value == "ok" for value in normalized):
+        return "ok"
+    return "unknown"
+
+
+def _coalesce_complete_health(*values: object) -> str:
+    normalized = []
+    for value in values:
+        text = str(value or "").strip().lower()
+        if text:
+            normalized.append(text)
+    if any(value == "degraded" for value in normalized):
+        return "degraded"
+    if not normalized:
+        return "unknown"
+    if all(value == "ok" for value in normalized):
+        return "ok"
+    return "unknown"
+
+
+def _build_architecture_dashboard(
+    *,
+    runtime_state: dict | None,
+    lcm_gateway: dict | None,
+) -> dict[str, object]:
+    runtime_state = runtime_state if isinstance(runtime_state, dict) else {}
+    runtime_lcm = runtime_state.get("lcm_runtime") if isinstance(runtime_state.get("lcm_runtime"), dict) else {}
+    runtime_scorecard = runtime_lcm.get("scorecard") if isinstance(runtime_lcm.get("scorecard"), dict) else {}
+    recent_turn_lcm = runtime_state.get("lcm_recent_turn") if isinstance(runtime_state.get("lcm_recent_turn"), dict) else {}
+    recent_turn_scorecard = recent_turn_lcm.get("scorecard") if isinstance(recent_turn_lcm.get("scorecard"), dict) else {}
+    memory_lcm = runtime_state.get("lcm_memory") if isinstance(runtime_state.get("lcm_memory"), dict) else {}
+    memory_scorecard = memory_lcm.get("scorecard") if isinstance(memory_lcm.get("scorecard"), dict) else {}
+    gateway_scorecard = lcm_gateway.get("scorecard") if isinstance(lcm_gateway, dict) and isinstance(lcm_gateway.get("scorecard"), dict) else {}
+
+    fallback_workflow = runtime_scorecard.get("workflows", {}).get("fallback_activation") if isinstance(runtime_scorecard.get("workflows"), dict) else None
+    continuity_workflows = recent_turn_scorecard.get("workflows", {}) if isinstance(recent_turn_scorecard.get("workflows"), dict) else {}
+    memory_workflows = memory_scorecard.get("workflows", {}) if isinstance(memory_scorecard.get("workflows"), dict) else {}
+    gateway_workflows = gateway_scorecard.get("workflows", {}) if isinstance(gateway_scorecard.get("workflows"), dict) else {}
+
+    fallback_status = runtime_scorecard.get("runtime_health") if isinstance(fallback_workflow, dict) else "unknown"
+    active_agents = int(runtime_state.get("active_agents", 0) or 0) if isinstance(runtime_state, dict) else 0
+    continuity_required = bool(continuity_workflows) or active_agents > 0
+    continuity_status = recent_turn_scorecard.get("continuity_health") if continuity_workflows else ("not_applicable" if not continuity_required else "unknown")
+    memory_status = memory_scorecard.get("memory_sync_health") if memory_workflows else "unknown"
+    memory_write_signal = memory_workflows.get("memory_write_propagation")
+    memory_audit_signal = memory_workflows.get("memory_audit")
+    memory_reconcile_signal = memory_workflows.get("memory_reconcile_projection")
+    healthcheck_status = gateway_scorecard.get("runtime_health") if isinstance(gateway_workflows.get("health_check_execution"), dict) else "unknown"
+    hermes_acts_status = _coalesce_health(fallback_status, continuity_status)
+    honcho_remembers_status = _coalesce_health(memory_status)
+    lcm_proves_inputs = [fallback_status, memory_status, healthcheck_status]
+    if continuity_required:
+        lcm_proves_inputs.append(continuity_status)
+    lcm_proves_status = _coalesce_complete_health(*lcm_proves_inputs)
+    overall_status = _coalesce_complete_health(hermes_acts_status, honcho_remembers_status, lcm_proves_status)
+
+    return {
+        "hermes_acts": {
+            "status": hermes_acts_status,
+            "signals": {
+                "fallback_activation": runtime_scorecard.get("workflows", {}).get("fallback_activation"),
+                "short_confirmation_binding": recent_turn_scorecard.get("workflows", {}).get("short_confirmation_binding"),
+                "ambiguity_resolution": recent_turn_scorecard.get("workflows", {}).get("ambiguity_resolution"),
+            },
+        },
+        "honcho_remembers": {
+            "status": honcho_remembers_status,
+            "signals": {
+                "memory_write_propagation": memory_write_signal,
+                "memory_audit": memory_audit_signal,
+                "memory_reconcile_projection": memory_reconcile_signal,
+            },
+        },
+        "lcm_proves": {
+            "status": lcm_proves_status,
+            "signals": {
+                "fallback_activation": runtime_scorecard.get("workflows", {}).get("fallback_activation"),
+                "short_confirmation_binding": recent_turn_scorecard.get("workflows", {}).get("short_confirmation_binding"),
+                "ambiguity_resolution": recent_turn_scorecard.get("workflows", {}).get("ambiguity_resolution"),
+                "memory_write_propagation": memory_write_signal,
+                "memory_audit": memory_audit_signal,
+                "memory_reconcile_projection": memory_reconcile_signal,
+                "health_check_execution": gateway_scorecard.get("workflows", {}).get("health_check_execution"),
+            },
+        },
+        "overall": {
+            "status": overall_status,
+        },
+    }
+
+
+def _probe_api_server_health(url: str, timeout: float = 2.0) -> dict[str, object]:
+    try:
+        with urllib.request.urlopen(url, timeout=timeout) as resp:
+            body = resp.read().decode("utf-8", errors="replace")
+            data = json.loads(body)
+            return {"ok": True, "url": url, "body": data}
+    except Exception as e:
+        return {"ok": False, "url": url, "error": str(e)}
+
+
+def build_gateway_health_payload(system: bool = False) -> dict[str, object]:
+    from gateway.config import Platform, load_gateway_config
+    from gateway.status import write_runtime_status
+
+    snapshot = get_gateway_runtime_snapshot(system=system)
+    runtime_state = _load_runtime_health_state() or {}
+    config = load_gateway_config()
+    api_cfg = config.platforms.get(Platform.API_SERVER)
+    api_enabled = bool(api_cfg and api_cfg.enabled)
+    api_host = None
+    api_port = None
+    api_health = None
+    api_health_detailed = None
+    if api_enabled:
+        extra = api_cfg.extra if isinstance(api_cfg.extra, dict) else {}
+        api_host = str(extra.get("host") or "127.0.0.1")
+        api_port = int(extra.get("port") or 8642)
+        base = f"http://{api_host}:{api_port}"
+        api_health = _probe_api_server_health(f"{base}/health")
+        api_health_detailed = _probe_api_server_health(f"{base}/health/detailed")
+        health_ok = bool(api_health.get("ok"))
+        detailed_ok = bool(api_health_detailed.get("ok"))
+        runtime_state = _record_gateway_workflow_event(
+            runtime_state,
+            "health_check_execution",
+            "success" if health_ok and detailed_ok else "failure",
+            failure_class=None if health_ok and detailed_ok else "api_health_probe_failed",
+            details={
+                "health_ok": health_ok,
+                "health_detailed_ok": detailed_ok,
+                "host": api_host,
+                "port": api_port,
+            },
+        )
+        write_runtime_status(lcm_gateway=runtime_state.get("lcm_gateway"))
+        reloaded_runtime_state = _load_runtime_health_state() or {}
+        if isinstance(reloaded_runtime_state, dict) and not isinstance(reloaded_runtime_state.get("lcm_gateway"), dict):
+            reloaded_runtime_state = {**reloaded_runtime_state, "lcm_gateway": runtime_state.get("lcm_gateway") or {}}
+        runtime_state = reloaded_runtime_state or runtime_state
+
+    return {
+        "manager": snapshot.manager,
+        "service_installed": snapshot.service_installed,
+        "service_running": snapshot.service_running,
+        "gateway_pids": list(snapshot.gateway_pids),
+        "running": snapshot.running,
+        "runtime_state": runtime_state,
+        "api_server": {
+            "configured": api_enabled,
+            "host": api_host,
+            "port": api_port,
+            "health": api_health,
+            "health_detailed": api_health_detailed,
+        },
+        "lcm_gateway": runtime_state.get("lcm_gateway") or {},
+        "architecture_dashboard": _build_architecture_dashboard(
+            runtime_state=runtime_state,
+            lcm_gateway=runtime_state.get("lcm_gateway") or {},
+        ),
+    }
+
+
+def print_gateway_health(system: bool = False, json_output: bool = False) -> None:
+    payload = build_gateway_health_payload(system=system)
+    if json_output:
+        print(json.dumps(payload, ensure_ascii=False, indent=2))
+        return
+
+    runtime_state = payload.get("runtime_state") or {}
+    gateway_state = runtime_state.get("gateway_state") or "unknown"
+    print(f"Gateway runtime: {gateway_state}")
+    connected = []
+    for name, pdata in (runtime_state.get("platforms") or {}).items():
+        if isinstance(pdata, dict) and pdata.get("state") == "connected":
+            connected.append(name)
+    if connected:
+        print(f"Connected platforms: {', '.join(sorted(connected))}")
+    api = payload.get("api_server") or {}
+    if api.get("configured"):
+        print(f"API server configured: http://{api.get('host')}:{api.get('port')}")
+        health = api.get("health") or {}
+        detailed = api.get("health_detailed") or {}
+        print(f"  /health: {'ok' if health.get('ok') else 'fail'}")
+        print(f"  /health/detailed: {'ok' if detailed.get('ok') else 'fail'}")
+    else:
+        print("API server configured: no")
+    lcm_gateway = payload.get("lcm_gateway") or {}
+    scorecard = lcm_gateway.get("scorecard") or {}
+    if scorecard:
+        print(f"Gateway proof health: {scorecard.get('runtime_health') or 'unknown'}")
+    dashboard = payload.get("architecture_dashboard") or {}
+    if dashboard:
+        print("Architecture dashboard:")
+        print(f"  Hermes acts: {dashboard.get('hermes_acts', {}).get('status', 'unknown')}")
+        print(f"  Honcho remembers: {dashboard.get('honcho_remembers', {}).get('status', 'unknown')}")
+        print(f"  LCM proves: {dashboard.get('lcm_proves', {}).get('status', 'unknown')}")
+        print(f"  Overall: {dashboard.get('overall', {}).get('status', 'unknown')}")
+
+
+def _runtime_health_lines() -> list[str]:
+    """Summarize the latest persisted gateway runtime health state."""
+    state = _load_runtime_health_state()
     if not state:
         return []
 
@@ -6358,6 +6707,12 @@ def _gateway_command_inner(args):
             # Start fresh
             print("Starting gateway...")
             run_gateway(verbose=0)
+
+    elif subcmd == "health":
+        print_gateway_health(
+            system=getattr(args, "system", False),
+            json_output=getattr(args, "json", False),
+        )
 
     elif subcmd == "status":
         deep = getattr(args, "deep", False)

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -12080,6 +12080,19 @@ def main():
         help="Target the Linux system-level gateway service",
     )
 
+    # gateway health
+    gateway_health = gateway_subparsers.add_parser("health", help="Show canonical gateway/API-server health")
+    gateway_health.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit machine-readable JSON",
+    )
+    gateway_health.add_argument(
+        "--system",
+        action="store_true",
+        help="Target the Linux system-level gateway service",
+    )
+
     # gateway install
     gateway_install = gateway_subparsers.add_parser(
         "install", help="Install gateway as a systemd/launchd background service"

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -66,6 +66,7 @@ AUTHOR_MAP = {
     "195255660+EvilHumphrey@users.noreply.github.com": "EvilHumphrey",
     "270604154+superearn-fisher@users.noreply.github.com": "superearn-fisher",
     "3540493+kpadilha@users.noreply.github.com": "kpadilha",
+    "krishna@padilha.com": "kpadilha",
     "40378218+chaconne67@users.noreply.github.com": "chaconne67",
     "Pluviobyte@users.noreply.github.com": "Pluviobyte",
     "sanghyuk_seo@nexcubecorp.com": "sanghyuk-seo-nexcube",

--- a/tests/gateway/test_api_server_env_loading.py
+++ b/tests/gateway/test_api_server_env_loading.py
@@ -1,0 +1,29 @@
+from pathlib import Path
+
+from gateway.config import Platform, load_gateway_config
+
+
+def test_load_gateway_config_reads_api_server_settings_from_hermes_dotenv(monkeypatch, tmp_path):
+    hermes_home = tmp_path / '.hermes'
+    hermes_home.mkdir(parents=True)
+    (hermes_home / '.env').write_text(
+        'API_SERVER_ENABLED=true\nAPI_SERVER_HOST=127.0.0.1\nAPI_SERVER_PORT=8642\n',
+        encoding='utf-8',
+    )
+    (hermes_home / 'config.yaml').write_text('', encoding='utf-8')
+
+    monkeypatch.setenv('HERMES_HOME', str(hermes_home))
+    monkeypatch.delenv('API_SERVER_ENABLED', raising=False)
+    monkeypatch.delenv('API_SERVER_HOST', raising=False)
+    monkeypatch.delenv('API_SERVER_PORT', raising=False)
+
+    config = load_gateway_config()
+
+    assert Platform.API_SERVER in config.platforms
+    api_cfg = config.platforms[Platform.API_SERVER]
+    assert api_cfg.enabled is True
+    assert api_cfg.extra['host'] == '127.0.0.1'
+    assert api_cfg.extra['port'] == 8642
+
+    # load_gateway_config bridges dotenv values into os.environ for downstream users too.
+    assert str(Path(hermes_home / '.env')).endswith('.env')

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -270,6 +270,7 @@ class TestGatewayRuntimeStatus:
     def test_write_runtime_status_overwrites_stale_pid_on_restart(self, tmp_path, monkeypatch):
         """Regression: setdefault() preserved stale PID from previous process (#1631)."""
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setattr(status, "_current_process_is_gateway_runtime", lambda: True)
 
         # Simulate a previous gateway run that left a state file with a stale PID
         state_path = tmp_path / "gateway_state.json"
@@ -357,6 +358,85 @@ class TestGatewayRuntimeStatus:
         assert payload["platforms"]["discord"]["state"] == "connected"
         assert payload["platforms"]["discord"]["error_code"] is None
         assert payload["platforms"]["discord"]["error_message"] is None
+
+    def test_write_runtime_status_omits_platform_bucket_when_platform_is_unspecified(self, tmp_path, monkeypatch):
+        """Runtime status updates without a platform must not create JSON ``"null"`` buckets."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        status.write_runtime_status(gateway_state="running")
+        status.write_runtime_status(lcm_runtime={"scorecard": {"runtime_health": "ok"}})
+
+        payload = status.read_runtime_status()
+        assert "null" not in payload["platforms"]
+        assert None not in payload["platforms"]
+        assert payload["platforms"] == {}
+
+    def test_write_runtime_status_persists_recent_turn_memory_and_gateway_scorecards(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        recent_turn = {"scorecard": {"continuity_health": "ok"}}
+        memory = {"scorecard": {"memory_sync_health": "degraded"}}
+        lcm_gateway = {"scorecard": {"runtime_health": "ok"}}
+
+        status.write_runtime_status(
+            gateway_state="running",
+            lcm_recent_turn=recent_turn,
+            lcm_memory=memory,
+            lcm_gateway=lcm_gateway,
+        )
+
+        payload = status.read_runtime_status()
+        assert payload["lcm_recent_turn"] == recent_turn
+        assert payload["lcm_memory"] == memory
+        assert payload["lcm_gateway"] == lcm_gateway
+
+    def test_write_runtime_status_does_not_hijack_gateway_pid_from_cli_health_process(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        state_path = tmp_path / "gateway_state.json"
+        state_path.write_text(json.dumps({
+            "pid": 4242,
+            "start_time": 111.0,
+            "argv": ["/repo/hermes_cli/main.py", "gateway", "run", "--replace"],
+            "kind": "hermes-gateway",
+            "platforms": {},
+            "updated_at": "2026-01-01T00:00:00+00:00",
+        }))
+        monkeypatch.setattr(status, "_current_process_is_gateway_runtime", lambda: False)
+        monkeypatch.setattr(status, "_runtime_status_identity_is_live_gateway", lambda payload: True)
+
+        status.write_runtime_status(lcm_runtime={"scorecard": {"runtime_health": "ok"}})
+
+        payload = status.read_runtime_status()
+        assert payload["pid"] == 4242
+        assert payload["start_time"] == 111.0
+        assert payload["argv"] == ["/repo/hermes_cli/main.py", "gateway", "run", "--replace"]
+        assert payload["lcm_runtime"]["scorecard"]["runtime_health"] == "ok"
+
+    def test_write_runtime_status_recovers_live_gateway_identity_from_pid_file_for_cli_health(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        (tmp_path / "gateway_state.json").write_text(json.dumps({
+            "pid": 99999,
+            "start_time": 1000.0,
+            "argv": ["/repo/hermes_cli/main.py", "gateway", "health", "--json"],
+            "kind": "hermes-gateway",
+            "platforms": {},
+            "updated_at": "2026-01-01T00:00:00+00:00",
+        }))
+        (tmp_path / "gateway.pid").write_text(json.dumps({
+            "pid": 4242,
+            "start_time": 111.0,
+            "argv": ["/repo/hermes_cli/main.py", "gateway", "run", "--replace"],
+            "kind": "hermes-gateway",
+        }))
+        monkeypatch.setattr(status, "_current_process_is_gateway_runtime", lambda: False)
+        monkeypatch.setattr(status, "_runtime_status_identity_is_live_gateway", lambda payload: payload.get("pid") == 4242)
+
+        status.write_runtime_status(lcm_runtime={"scorecard": {"runtime_health": "ok"}})
+
+        payload = status.read_runtime_status()
+        assert payload["pid"] == 4242
+        assert payload["start_time"] == 111.0
+        assert payload["argv"] == ["/repo/hermes_cli/main.py", "gateway", "run", "--replace"]
 
 
 class TestTerminatePid:

--- a/tests/hermes_cli/test_gateway.py
+++ b/tests/hermes_cli/test_gateway.py
@@ -1,5 +1,6 @@
 """Tests for hermes_cli.gateway."""
 
+import json
 import sys
 from types import ModuleType, SimpleNamespace
 
@@ -67,6 +68,352 @@ def test_run_gateway_exits_nonzero_when_start_gateway_reports_failure(monkeypatc
     assert calls == [(True, None)]
 
 
+def test_build_architecture_dashboard_summarizes_known_and_missing_layers():
+    dashboard = gateway._build_architecture_dashboard(
+        runtime_state={
+            "lcm_runtime": {
+                "scorecard": {
+                    "runtime_health": "ok",
+                    "workflows": {
+                        "fallback_activation": {"success": 1, "failure": 0, "total": 1, "success_rate_pct": 100.0},
+                    },
+                }
+            }
+        },
+        lcm_gateway={
+            "scorecard": {
+                "runtime_health": "degraded",
+                "workflows": {
+                    "health_check_execution": {"success": 0, "failure": 1, "total": 1, "success_rate_pct": 0.0},
+                },
+            }
+        },
+    )
+
+    assert dashboard["hermes_acts"]["status"] == "ok"
+    assert dashboard["honcho_remembers"]["status"] == "unknown"
+    assert dashboard["lcm_proves"]["status"] == "degraded"
+    assert dashboard["overall"]["status"] == "degraded"
+
+
+def test_build_architecture_dashboard_integrates_memory_and_recent_turn_scorecards():
+    dashboard = gateway._build_architecture_dashboard(
+        runtime_state={
+            "lcm_runtime": {
+                "scorecard": {
+                    "runtime_health": "ok",
+                    "workflows": {
+                        "fallback_activation": {"success": 1, "failure": 0, "total": 1, "success_rate_pct": 100.0},
+                    },
+                }
+            },
+            "lcm_memory": {
+                "scorecard": {
+                    "memory_sync_health": "ok",
+                    "workflows": {
+                        "memory_write_propagation": {"success": 2, "failure": 0, "total": 2, "success_rate_pct": 100.0},
+                    },
+                }
+            },
+            "lcm_recent_turn": {
+                "scorecard": {
+                    "continuity_health": "ok",
+                    "workflows": {
+                        "short_confirmation_binding": {"success": 1, "failure": 0, "total": 1, "success_rate_pct": 100.0},
+                    },
+                }
+            },
+        },
+        lcm_gateway={
+            "scorecard": {
+                "runtime_health": "ok",
+                "workflows": {
+                    "health_check_execution": {"success": 1, "failure": 0, "total": 1, "success_rate_pct": 100.0},
+                },
+            }
+        },
+    )
+
+    assert dashboard["hermes_acts"]["status"] == "ok"
+    assert dashboard["honcho_remembers"]["status"] == "ok"
+    assert dashboard["lcm_proves"]["status"] == "ok"
+    assert dashboard["honcho_remembers"]["signals"]["memory_write_propagation"]["success"] == 2
+    assert dashboard["hermes_acts"]["signals"]["short_confirmation_binding"]["success"] == 1
+    assert dashboard["overall"]["status"] == "ok"
+
+
+def test_build_architecture_dashboard_marks_lcm_proves_unknown_when_required_proof_is_missing():
+    dashboard = gateway._build_architecture_dashboard(
+        runtime_state={
+            "active_agents": 1,
+            "lcm_runtime": {
+                "scorecard": {
+                    "runtime_health": "ok",
+                    "workflows": {
+                        "fallback_activation": {"success": 1, "failure": 0, "total": 1, "success_rate_pct": 100.0},
+                    },
+                }
+            },
+            "lcm_memory": {
+                "scorecard": {
+                    "memory_sync_health": "ok",
+                    "workflows": {
+                        "memory_write_propagation": {"success": 2, "failure": 0, "total": 2, "success_rate_pct": 100.0},
+                    },
+                }
+            },
+        },
+        lcm_gateway={
+            "scorecard": {
+                "runtime_health": "ok",
+                "workflows": {
+                    "health_check_execution": {"success": 1, "failure": 0, "total": 1, "success_rate_pct": 100.0},
+                },
+            }
+        },
+    )
+
+    assert dashboard["hermes_acts"]["status"] == "ok"
+    assert dashboard["honcho_remembers"]["status"] == "ok"
+    assert dashboard["lcm_proves"]["status"] == "unknown"
+    assert dashboard["overall"]["status"] == "unknown"
+
+
+def test_build_architecture_dashboard_ignores_runtime_health_without_matching_workflow():
+    dashboard = gateway._build_architecture_dashboard(
+        runtime_state={
+            "lcm_runtime": {
+                "scorecard": {
+                    "runtime_health": "ok",
+                    "workflows": {
+                        "health_check_execution": {"success": 1, "failure": 0, "total": 1, "success_rate_pct": 100.0},
+                    },
+                }
+            },
+            "lcm_memory": {
+                "scorecard": {
+                    "memory_sync_health": "ok",
+                    "workflows": {
+                        "memory_audit": {"success": 1, "failure": 0, "total": 1, "success_rate_pct": 100.0},
+                    },
+                }
+            },
+        },
+        lcm_gateway={
+            "scorecard": {
+                "runtime_health": "ok",
+                "workflows": {
+                    "health_check_execution": {"success": 1, "failure": 0, "total": 1, "success_rate_pct": 100.0},
+                },
+            }
+        },
+    )
+
+    assert dashboard["hermes_acts"]["status"] == "unknown"
+    assert dashboard["lcm_proves"]["status"] == "unknown"
+
+
+def test_gateway_health_json_uses_runtime_and_api_probe(monkeypatch, capsys):
+    monkeypatch.setattr(
+        gateway,
+        "build_gateway_health_payload",
+        lambda system=False: {
+            "manager": "systemd",
+            "service_installed": True,
+            "service_running": True,
+            "gateway_pids": [123],
+            "running": True,
+            "runtime_state": {"gateway_state": "running"},
+            "api_server": {
+                "configured": True,
+                "host": "127.0.0.1",
+                "port": 8642,
+                "health": {"ok": True},
+                "health_detailed": {"ok": True},
+            },
+            "lcm_gateway": {
+                "scorecard": {"runtime_health": "ok"},
+            },
+        },
+    )
+
+    gateway.gateway_command(SimpleNamespace(gateway_command="health", system=False, json=True))
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["runtime_state"]["gateway_state"] == "running"
+    assert payload["api_server"]["configured"] is True
+    assert payload["lcm_gateway"]["scorecard"]["runtime_health"] == "ok"
+
+
+def test_gateway_health_text_reports_api_server_status(monkeypatch, capsys):
+    monkeypatch.setattr(
+        gateway,
+        "build_gateway_health_payload",
+        lambda system=False: {
+            "manager": "systemd",
+            "service_installed": True,
+            "service_running": True,
+            "gateway_pids": [123],
+            "running": True,
+            "runtime_state": {
+                "gateway_state": "running",
+                "platforms": {
+                    "telegram": {"state": "connected"},
+                    "api_server": {"state": "connected"},
+                },
+            },
+            "api_server": {
+                "configured": True,
+                "host": "127.0.0.1",
+                "port": 8642,
+                "health": {"ok": True},
+                "health_detailed": {"ok": True},
+            },
+            "lcm_gateway": {
+                "scorecard": {"runtime_health": "ok"},
+            },
+            "architecture_dashboard": {
+                "hermes_acts": {"status": "ok"},
+                "honcho_remembers": {"status": "unknown"},
+                "lcm_proves": {"status": "ok"},
+                "overall": {"status": "ok"},
+            },
+        },
+    )
+
+    gateway.gateway_command(SimpleNamespace(gateway_command="health", system=False, json=False))
+
+    out = capsys.readouterr().out
+    assert "Gateway runtime: running" in out
+    assert "API server configured: http://127.0.0.1:8642" in out
+    assert "/health: ok" in out
+    assert "/health/detailed: ok" in out
+    assert "Gateway proof health: ok" in out
+    assert "Architecture dashboard:" in out
+
+
+def test_gateway_health_json_exposes_architecture_dashboard(monkeypatch, capsys):
+    monkeypatch.setattr(
+        gateway,
+        "build_gateway_health_payload",
+        lambda system=False: {
+            "runtime_state": {
+                "gateway_state": "running",
+                "lcm_runtime": {
+                    "scorecard": {
+                        "runtime_health": "ok",
+                        "workflows": {
+                            "fallback_activation": {"success": 1, "failure": 0, "total": 1, "success_rate_pct": 100.0}
+                        },
+                    }
+                },
+            },
+            "api_server": {
+                "configured": True,
+                "host": "127.0.0.1",
+                "port": 8642,
+                "health": {"ok": True},
+                "health_detailed": {"ok": True},
+            },
+            "lcm_gateway": {
+                "scorecard": {
+                    "runtime_health": "ok",
+                    "workflows": {
+                        "health_check_execution": {"success": 1, "failure": 0, "total": 1, "success_rate_pct": 100.0}
+                    },
+                }
+            },
+            "architecture_dashboard": {
+                "hermes_acts": {"status": "ok"},
+                "honcho_remembers": {"status": "unknown"},
+                "lcm_proves": {"status": "ok"},
+                "overall": {"status": "ok"},
+            },
+        },
+    )
+
+    gateway.gateway_command(SimpleNamespace(gateway_command="health", system=False, json=True))
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["architecture_dashboard"]["hermes_acts"]["status"] == "ok"
+    assert payload["architecture_dashboard"]["honcho_remembers"]["status"] == "unknown"
+    assert payload["architecture_dashboard"]["lcm_proves"]["status"] == "ok"
+
+
+def test_build_gateway_health_payload_reads_recent_turn_and_memory_from_runtime_status(monkeypatch):
+    runtime_state = {
+        "gateway_state": "running",
+        "lcm_runtime": {
+            "scorecard": {
+                "runtime_health": "ok",
+                "workflows": {
+                    "fallback_activation": {"success": 1, "failure": 0, "total": 1, "success_rate_pct": 100.0},
+                },
+            },
+        },
+        "lcm_recent_turn": {
+            "scorecard": {
+                "continuity_health": "ok",
+                "workflows": {
+                    "short_confirmation_binding": {"success": 2, "failure": 0, "total": 2, "success_rate_pct": 100.0},
+                },
+            },
+        },
+        "lcm_memory": {
+            "scorecard": {
+                "memory_sync_health": "ok",
+                "workflows": {
+                    "memory_write_propagation": {"success": 3, "failure": 0, "total": 3, "success_rate_pct": 100.0},
+                },
+            },
+        },
+    }
+    monkeypatch.setattr(gateway, "get_gateway_runtime_snapshot", lambda system=False: SimpleNamespace(
+        manager="systemd",
+        service_installed=True,
+        service_running=True,
+        gateway_pids=[123],
+        running=True,
+    ))
+    monkeypatch.setattr(gateway, "_load_runtime_health_state", lambda: runtime_state)
+    monkeypatch.setattr(gateway, "_probe_api_server_health", lambda url, timeout=2.0: {"ok": True, "url": url})
+    monkeypatch.setattr(gateway, "_record_gateway_workflow_event", lambda state, workflow, outcome, **kwargs: {
+        **state,
+        "lcm_gateway": {
+            "scorecard": {
+                "runtime_health": "ok",
+                "workflows": {
+                    "health_check_execution": {"success": 1, "failure": 0, "total": 1, "success_rate_pct": 100.0},
+                },
+            },
+        },
+    })
+    from gateway.config import Platform
+
+    monkeypatch.setattr("gateway.config.load_gateway_config", lambda: SimpleNamespace(platforms={
+        Platform.API_SERVER: SimpleNamespace(enabled=True, extra={"host": "127.0.0.1", "port": 8642})
+    }))
+    write_calls = []
+    monkeypatch.setattr("gateway.status.write_runtime_status", lambda **kwargs: write_calls.append(kwargs))
+
+    payload = gateway.build_gateway_health_payload(system=False)
+
+    expected_lcm_gateway = {
+        "scorecard": {
+            "runtime_health": "ok",
+            "workflows": {
+                "health_check_execution": {"success": 1, "failure": 0, "total": 1, "success_rate_pct": 100.0},
+            },
+        },
+    }
+
+    assert payload["runtime_state"]["lcm_recent_turn"]["scorecard"]["continuity_health"] == "ok"
+    assert payload["runtime_state"]["lcm_memory"]["scorecard"]["memory_sync_health"] == "ok"
+    assert payload["architecture_dashboard"]["hermes_acts"]["status"] == "ok"
+    assert payload["architecture_dashboard"]["honcho_remembers"]["status"] == "ok"
+    assert payload["architecture_dashboard"]["lcm_proves"]["status"] == "ok"
+    assert payload["lcm_gateway"] == expected_lcm_gateway
+    assert write_calls == [{"lcm_gateway": expected_lcm_gateway}]
 def test_run_gateway_refuses_root_in_official_docker(monkeypatch, tmp_path, capsys):
     project_root = tmp_path / "opt" / "hermes"
     (project_root / "docker").mkdir(parents=True)


### PR DESCRIPTION
## What does this PR do?

Adds a canonical `hermes gateway health` surface and fixes gateway status reads so they do not overwrite the identity of the live gateway process.

Before this change, CLI/API health reads could refresh the gateway status file using the short-lived inspection process identity. That made the status record ambiguous and could hide the actual daemon PID/start time that operators need when deciding whether a restart is safe.

This refresh rebases the existing PR onto current `main` and keeps the change scoped to gateway health/status behavior and its tests.

## Related Issue

No linked issue.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/gateway.py`: add/refresh canonical gateway health command behavior and preserve live runtime identity when reading status.
- `gateway/status.py`: preserve daemon identity fields when status is updated by non-daemon readers.
- `gateway/config.py` and `hermes_cli/main.py`: wire the health/status command surface.
- `tests/hermes_cli/test_gateway.py`: add CLI coverage for the gateway health/status behavior.
- `tests/gateway/test_status.py`: add regression coverage for preserving runtime identity.
- `tests/gateway/test_api_server_env_loading.py`: cover API-server env loading used by gateway health diagnostics.

## How to Test

Targeted validation run on this PR branch:

1. Compile touched runtime files:

   ```bash
   python -m py_compile gateway/config.py gateway/status.py hermes_cli/gateway.py hermes_cli/main.py
   # passed
   ```

2. Run focused gateway/status tests:

   ```bash
   pytest tests/hermes_cli/test_gateway.py tests/gateway/test_status.py tests/gateway/test_api_server_env_loading.py -q -o 'addopts='
   # 101 passed in 1.38s
   ```

3. Run the Windows footgun checker:

   ```bash
   python scripts/check-windows-footguns.py --all
   # passed: No Windows footguns found
   ```

4. Check patch formatting:

   ```bash
   git diff --check upstream/main...HEAD
   # passed
   ```

5. Full suite status:

   ```bash
   pytest tests/ -q -o 'addopts='
   ```

   Full-suite validation was attempted on this refreshed branch, but it did not complete green: the run timed out after 600s around 19% progress with order-dependent failures already observed. The first reported failure was `tests/acp/test_approval_isolation.py::TestAcpExecAskGate::test_interactive_env_var_routes_to_callback`; that same test passed when run standalone on both current `upstream/main` and this PR branch. Because full-suite validation is not green, the full-suite checklist item remains unchecked.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A — this PR does not add a skill.

## Screenshots / Logs

Current refreshed branch state:

```bash
git rev-list --left-right --count upstream/main...HEAD
# 0 1
```

GitHub branch was refreshed from `a6d80ebcd57062eabe538c2ea650ce2b88c02c7c` to `f53804ad0dccaea2415f1aa5956feacc53a80a54`. A follow-up amend fixed the Windows footgun checker and author attribution.



Additional CI refresh note (2026-06-01):
- Amended the PR commit author/committer to `kpadilha <krishna@padilha.com>` and added `krishna@padilha.com -> kpadilha` to `scripts/release.py` AUTHOR_MAP so the attribution gate does not rely on local agent identity.
- Revalidated locally after amend: `python3 -m py_compile gateway/status.py scripts/release.py`; `python3 scripts/check-windows-footguns.py --all` -> no footguns; `git diff --check upstream/main...HEAD`; `uv sync --extra dev && uv run python -m pytest tests/hermes_cli/test_gateway.py tests/gateway/test_status.py tests/gateway/test_api_server_env_loading.py -q` -> 101 passed in 1.86s.

- CI rerun note: recreated the same tree as a new commit (`f53804ad0`) only to retrigger CI after `build-arm64` failed during Docker Buildx bootstrap with `The operation was canceled` before the image build step; no code delta was introduced by this rerun commit.

- CI flake note: one rerun hit `tests/gateway/test_stream_consumer.py::TestSegmentBreakOnToolBoundary::test_edit_failure_sends_only_unsent_tail_at_finish` in slice 1. The exact test passed locally 5/5 and the full file passed locally on both this PR tree and a clean `upstream/main` worktree.