### PR TITLE
fix: use localhost for MCP OAuth loopback redirect URIs

### DIFF
--- a/tests/tools/test_mcp_oauth.py
+++ b/tests/tools/test_mcp_oauth.py
@@ -166,6 +166,10 @@ class TestBuildOAuthAuth:
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
         auth = build_oauth_auth("test", "https://example.com/mcp")
         assert isinstance(auth, OAuthClientProvider)
+        assert auth.context.client_metadata is not None
+        redirect_uri = str(auth.context.client_metadata.redirect_uris[0])
+        assert redirect_uri.startswith("http://localhost:")
+        assert redirect_uri.endswith("/callback")
 
     def test_returns_none_without_sdk(self, monkeypatch):
         import tools.mcp_oauth as mod
@@ -191,6 +195,8 @@ class TestBuildOAuthAuth:
         data = json.loads(client_path.read_text())
         assert data["client_id"] == "my-app-id"
         assert data["client_secret"] == "my-secret"
+        assert data["redirect_uris"][0].startswith("http://localhost:")
+        assert data["redirect_uris"][0].endswith("/callback")
 
     def test_scope_passed_through(self, tmp_path, monkeypatch):
         try:

--- a/tools/mcp_oauth.py
+++ b/tools/mcp_oauth.py
@@ -52,6 +52,13 @@ from hermes_constants import secure_parent_dir
 
 logger = logging.getLogger(__name__)
 
+# Bind the callback listener to the IPv4 loopback for reliable local accept(),
+# but advertise ``localhost`` in redirect URIs. Some OAuth providers accept
+# loopback redirects only as ``http://localhost:...`` and reject the equivalent
+# numeric form ``http://127.0.0.1:...``.
+CALLBACK_BIND_HOST = "127.0.0.1"
+CALLBACK_REDIRECT_HOST = "localhost"
+
 # ---------------------------------------------------------------------------
 # Lazy imports -- MCP SDK with OAuth support is optional
 # ---------------------------------------------------------------------------
@@ -121,7 +128,7 @@ def _safe_filename(name: str) -> str:
 def _find_free_port() -> int:
     """Find an available TCP port on localhost."""
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-        s.bind(("127.0.0.1", 0))
+        s.bind((CALLBACK_BIND_HOST, 0))
         return s.getsockname()[1]
 
 
@@ -401,13 +408,13 @@ async def _redirect_handler(authorization_url: str) -> None:
     print(msg, file=sys.stderr)
 
     # On a remote SSH session the OAuth provider redirects to
-    # http://127.0.0.1:<port>/callback, which reaches the callback server on
+    # http://localhost:<port>/callback, which reaches the callback server on
     # the *remote* machine — not the user's local machine where the browser
     # opened.  Print a port-forward hint so the user knows to tunnel first.
     if _oauth_port and (os.getenv("SSH_CLIENT") or os.getenv("SSH_TTY")):
         print(
             f"  Remote session detected. The OAuth provider will redirect your browser to\n"
-            f"    http://127.0.0.1:{_oauth_port}/callback\n"
+            f"    http://{CALLBACK_REDIRECT_HOST}:{_oauth_port}/callback\n"
             f"  which the callback listener on THIS machine is waiting on. If your browser\n"
             f"  is on a different machine, forward the port first in a separate terminal:\n"
             f"\n"
@@ -456,7 +463,7 @@ async def _wait_for_callback() -> tuple[str, str | None]:
 
     # Start a temporary server on the known port
     try:
-        server = HTTPServer(("127.0.0.1", _oauth_port), handler_cls)
+        server = HTTPServer((CALLBACK_BIND_HOST, _oauth_port), handler_cls)
     except OSError:
         # Port already in use — the server from build_oauth_auth is running.
         # Fall back to polling the server started by build_oauth_auth.
@@ -546,7 +553,7 @@ def _build_client_metadata(cfg: dict) -> "OAuthClientMetadata":
         )
     client_name = cfg.get("client_name", "Hermes Agent")
     scope = cfg.get("scope")
-    redirect_uri = f"http://127.0.0.1:{port}/callback"
+    redirect_uri = f"http://{CALLBACK_REDIRECT_HOST}:{port}/callback"
 
     metadata_kwargs: dict[str, Any] = {
         "client_name": client_name,
@@ -573,7 +580,7 @@ def _maybe_preregister_client(
     if not client_id:
         return
     port = cfg["_resolved_port"]
-    redirect_uri = f"http://127.0.0.1:{port}/callback"
+    redirect_uri = f"http://{CALLBACK_REDIRECT_HOST}:{port}/callback"
 
     info_dict: dict[str, Any] = {
         "client_id": client_id,


### PR DESCRIPTION
## Summary
- generate MCP OAuth redirect URIs with `http://localhost:<port>/callback`
- keep the local callback listener bound to `127.0.0.1`
- add tests to lock in the new redirect URI behavior

## Motivation
Some OAuth providers accept loopback redirect URIs only in the `localhost` form and reject the equivalent numeric loopback address `127.0.0.1`.

That breaks first-time OAuth bootstrap during dynamic client registration even though the callback server is still strictly local.

This surfaced against the Superset MCP server at:
- `https://XXXX.net/mcp`

In that flow:
- `http://localhost:<port>/callback` was accepted
- `http://127.0.0.1:<port>/callback` was rejected

## Implementation
In `tools/mcp_oauth.py`:
- keep the callback server bound to `127.0.0.1`
- generate advertised redirect URIs with `localhost`
- update the SSH hint text accordingly
- centralize the distinction with separate bind/redirect host constants

In `tests/tools/test_mcp_oauth.py`:
- assert generated redirect URIs start with `http://localhost:`
- assert generated redirect URIs end with `/callback`

## Why this is safe
This does not broaden callback exposure:
- the HTTP listener still binds to loopback only
- only the hostname used in the advertised redirect URI changes
- `localhost` still resolves to the local machine in the standard desktop/CLI OAuth loopback flow

So this is a compatibility fix, not a security relaxation.

## Validation
- `/home/philipp/.hermes/hermes-agent/venv/bin/python -m pytest tests/tools/test_mcp_oauth.py -q` → 42 passed
- `/home/philipp/.hermes/hermes-agent/venv/bin/python -m pytest tests/tools/test_mcp_oauth_integration.py -q` → 5 passed
- `/home/philipp/.hermes/hermes-agent/venv/bin/hermes mcp test superset` → connected successfully, 112 tools discovered

Observed successful redirect URI:
- `http://localhost:50611/callback`

## Note on overlap
There is already an open broader redirect-host plumbing PR (#21482). This PR is intentionally narrower: it fixes the concrete interoperability issue by switching generated loopback redirect URIs to `localhost` while preserving loopback-only binding on `127.0.0.1`.
