### PR TITLE
fix(gateway): preserve platform_message_id during session branching

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -12693,6 +12693,9 @@ class GatewayRunner:
                     reasoning_details=msg.get("reasoning_details"),
                     codex_reasoning_items=msg.get("codex_reasoning_items"),
                     codex_message_items=msg.get("codex_message_items"),
+                    platform_message_id=(
+                        msg.get("platform_message_id") or msg.get("message_id")
+                    ),
                 )
             except Exception:
                 pass  # Best-effort copy

--- a/tests/gateway/test_session_boundary_security_state.py
+++ b/tests/gateway/test_session_boundary_security_state.py
@@ -192,7 +192,7 @@ async def test_branch_clears_session_scoped_approval_and_yolo_state():
 async def test_branch_preserves_persisted_assistant_metadata():
     runner, _session_key = _make_branch_runner()
     runner.session_store.load_transcript.return_value = [
-        {"role": "user", "content": "hello"},
+        {"role": "user", "content": "hello", "message_id": "platform-msg-123"},
         {
             "role": "assistant",
             "content": "world",
@@ -210,6 +210,9 @@ async def test_branch_preserves_persisted_assistant_metadata():
     assert "Branched to" in result
     append_calls = runner._session_db.append_message.call_args_list
     assert len(append_calls) == 2
+    user_kwargs = append_calls[0].kwargs
+    assert user_kwargs["role"] == "user"
+    assert user_kwargs["platform_message_id"] == "platform-msg-123"
     assistant_kwargs = append_calls[1].kwargs
     assert assistant_kwargs["role"] == "assistant"
     assert assistant_kwargs["finish_reason"] == "stop"


### PR DESCRIPTION
## Summary

`/branch` komutu yeni session oluştururken transcript geçmişini kopyalıyor, ancak bu kopya sırasında platform-side `message_id` bilgisini düşürüyordu. Bu PR, branch edilen session’da da `platform_message_id` bilgisinin korunmasını sağlar.

Bu, kısa süre önce eklenen `state.db` exact-id round-trip invariant’ını branch flow için de tamamlar.

## Problem

`feat(state.db): persist platform_message_id; restore yuanbao exact-id recall` değişikliğiyle birlikte transcript satırlarının platform message id’si `state.db` içinde korunmaya başladı. Bu invariant:

- `append_message(...)`
- `replace_messages(...)`
- `load_transcript(...)`

path’lerinde zaten testleniyordu.

Ancak gateway `/branch` flow’unda geçmiş yeni session’a manuel olarak tekrar yazılırken `append_message(...)` çağrısına `platform_message_id` geçirilmediği için bu metadata kayboluyordu.

Sonuç olarak branch edilmiş session’larda platform-level exact-id lookup tekrar content-match fallback’ine düşebiliyordu.

## Fix

`gateway/run.py` içindeki branch history copy loop’unda `append_message(...)` çağrısına şu bilgi eklendi:

- `platform_message_id = msg.get("platform_message_id") or msg.get("message_id")`

Böylece parent transcript’te bulunan platform message id, branched session’a da aynen taşınıyor.

## User Impact

Bu düzeltme özellikle Yuanbao gibi platform-side exact-id recall / redaction kullanan path’lerde önemli:

- branch sonrası exact-id eşleşme korunur
- duplicate content durumlarında yanlış satırın hedeflenme riski azalır
- branch flow, canonical transcript metadata contract’ıyla uyumlu hale gelir

## Tests

`tests/gateway/test_session_boundary_security_state.py` güncellendi:

- mevcut branch metadata preservation testi korunuyor
- ek olarak user message üzerindeki `message_id`’nin branch sırasında `platform_message_id` olarak yeni session’a yazıldığı assert ediliyor

Çalıştırılan hedefli testler:

```bash
python -m pytest tests/gateway/test_session_boundary_security_state.py tests/gateway/platforms/test_yuanbao_recall_db_only.py -o addopts= -q

7 passed 1.12s