### PR TITLE
feat(whatsapp): support channel_prompts for per-user/per-group prompts

### DIFF
--- a/gateway/platforms/whatsapp.py
+++ b/gateway/platforms/whatsapp.py
@@ -1268,6 +1268,16 @@ class WhatsAppAdapter(BasePlatformAdapter):
                         except Exception as e:
                             print(f"[{self.name}] Failed to read document text: {e}", flush=True)
 
+            # Per-user/per-group ephemeral prompt (matches Slack/Telegram pattern).
+            # Looks up whatsapp.channel_prompts keyed by senderId (DMs) or chatId (groups).
+            from gateway.platforms.base import resolve_channel_prompt
+            _primary_key = data.get("chatId") if data.get("isGroup") else data.get("senderId")
+            _channel_prompt = resolve_channel_prompt(
+                self.config.extra,
+                str(_primary_key or ""),
+                str(data.get("chatId") or "") if not data.get("isGroup") else None,
+            )
+
             return MessageEvent(
                 text=body,
                 message_type=msg_type,
@@ -1276,6 +1286,7 @@ class WhatsAppAdapter(BasePlatformAdapter):
                 message_id=data.get("messageId"),
                 media_urls=cached_urls,
                 media_types=media_types,
+                channel_prompt=_channel_prompt,
             )
         except Exception as e:
             print(f"[{self.name}] Error building event: {e}")

--- a/tests/gateway/test_whatsapp_channel_prompts.py
+++ b/tests/gateway/test_whatsapp_channel_prompts.py
@@ -1,0 +1,114 @@
+"""Tests for WhatsApp channel_prompts resolution (per-user/per-group)."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+
+def _make_adapter(channel_prompts: dict | None = None):
+    """Build a WhatsAppAdapter shell with just enough config for channel-prompt lookup."""
+    from gateway.platforms.whatsapp import WhatsAppAdapter
+
+    adapter = object.__new__(WhatsAppAdapter)
+    adapter.config = MagicMock()
+    adapter.config.extra = {"channel_prompts": channel_prompts or {}}
+    return adapter
+
+
+def _resolve_for(adapter, data: dict) -> str | None:
+    """Replicate the adapter's per-event lookup logic.
+
+    Keeps the test focused on the *resolution* contract — full event-building
+    requires a live bridge and DB and is exercised separately.
+    """
+    from gateway.platforms.base import resolve_channel_prompt
+
+    primary_key = data.get("chatId") if data.get("isGroup") else data.get("senderId")
+    return resolve_channel_prompt(
+        adapter.config.extra,
+        str(primary_key or ""),
+        str(data.get("chatId") or "") if not data.get("isGroup") else None,
+    )
+
+
+def test_dm_resolves_by_sender_id():
+    adapter = _make_adapter({
+        "436642361246@s.whatsapp.net": "You are Eleana's assistant. Reply in Spanish.",
+    })
+    prompt = _resolve_for(adapter, {
+        "isGroup": False,
+        "senderId": "436642361246@s.whatsapp.net",
+        "chatId": "436642361246@s.whatsapp.net",
+    })
+    assert prompt == "You are Eleana's assistant. Reply in Spanish."
+
+
+def test_dm_falls_back_to_chat_id():
+    """When senderId is missing but chatId matches, the prompt still resolves."""
+    adapter = _make_adapter({
+        "436642361246@s.whatsapp.net": "Eleana prompt",
+    })
+    prompt = _resolve_for(adapter, {
+        "isGroup": False,
+        "senderId": None,
+        "chatId": "436642361246@s.whatsapp.net",
+    })
+    assert prompt == "Eleana prompt"
+
+
+def test_group_resolves_by_chat_id():
+    adapter = _make_adapter({
+        "120363025@g.us": "Family group assistant.",
+    })
+    prompt = _resolve_for(adapter, {
+        "isGroup": True,
+        "chatId": "120363025@g.us",
+        "senderId": "436641147220@s.whatsapp.net",  # individual member — ignored for groups
+    })
+    assert prompt == "Family group assistant."
+
+
+def test_no_match_returns_none():
+    adapter = _make_adapter({
+        "436642361246@s.whatsapp.net": "Eleana prompt",
+    })
+    prompt = _resolve_for(adapter, {
+        "isGroup": False,
+        "senderId": "999999999999@s.whatsapp.net",
+        "chatId": "999999999999@s.whatsapp.net",
+    })
+    assert prompt is None
+
+
+def test_empty_config_returns_none():
+    adapter = _make_adapter({})
+    prompt = _resolve_for(adapter, {
+        "isGroup": False,
+        "senderId": "436642361246@s.whatsapp.net",
+    })
+    assert prompt is None
+
+
+def test_whitespace_prompt_treated_as_absent():
+    adapter = _make_adapter({
+        "436642361246@s.whatsapp.net": "   \n  ",
+    })
+    prompt = _resolve_for(adapter, {
+        "isGroup": False,
+        "senderId": "436642361246@s.whatsapp.net",
+    })
+    assert prompt is None
+
+
+def test_group_does_not_match_individual_sender():
+    """In a group, sender's personal prompt must not leak in — only the group's prompt counts."""
+    adapter = _make_adapter({
+        "436642361246@s.whatsapp.net": "Eleana DM prompt",
+        "120363025@g.us": "Group prompt",
+    })
+    # Eleana writes in the family group — she should get the group prompt, not her DM one.
+    prompt = _resolve_for(adapter, {
+        "isGroup": True,
+        "chatId": "120363025@g.us",
+        "senderId": "436642361246@s.whatsapp.net",
+    })
+    assert prompt == "Group prompt"


### PR DESCRIPTION
## Summary

WhatsApp adapter was the only gateway platform not consuming the shared `resolve_channel_prompt()` helper. Slack, Mattermost, and Telegram all inject per-channel ephemeral prompts from `channel_prompts` in their platform config; WhatsApp ignored them.

This wires WhatsApp into the same pattern.

## Motivation

Family/multi-user WhatsApp bots: each contact (or group) should be able to get a distinct persona — different language, tone, allowed capability set — without running a separate gateway process and a separate phone number per persona.

Without this, every WhatsApp DM/group sees the same global system prompt regardless of who's writing.

## Behavior

| Scenario | Lookup key | Fallback |
|---|---|---|
| Direct message | `senderId` | `chatId` |
| Group message | `chatId` only | — (sender's personal prompt does NOT leak into the group) |

Matches the existing Slack/Telegram/Discord semantics. Blank/whitespace prompts are treated as absent (handled by `resolve_channel_prompt` already).

## Config example

```yaml
whatsapp:
  channel_prompts:
    '436XXXXXXXXX@s.whatsapp.net': 'You are X. Reply in Spanish.'
    '436YYYYYYYYY@s.whatsapp.net': 'You are kid-safe assistant. Reply in ES or DE only.'
    '120XXXXXXXXX@g.us':           'Family group assistant.'
```

## Changes

- `gateway/platforms/whatsapp.py` — +11 lines: import the helper, derive `_primary_key` from `isGroup`, pass `channel_prompt` to `MessageEvent`.
- `tests/gateway/test_whatsapp_channel_prompts.py` — new, 7 tests covering DM, group, fallback, no-match, whitespace, and the group-doesn't-match-sender invariant.

## Test results

```
$ python -m pytest tests/gateway/test_whatsapp_*.py -q
94 passed, 1 warning in 4.63s
```

Existing channel-prompt tests for other platforms still pass:

```
$ python -m pytest tests/gateway/test_discord_channel_prompts.py \
                   tests/gateway/test_telegram_group_gating.py \
                   tests/gateway/test_config.py \
                   tests/hermes_cli/test_config.py \
                   tests/gateway/test_pending_event_none.py -q
154 passed in 3.91s
```

## Backward compatibility

Fully backward compatible. If `whatsapp.channel_prompts` is unset or empty, `resolve_channel_prompt` returns `None` and `channel_prompt=None` is passed to `MessageEvent` — the same value that was passed implicitly before (omitting it defaulted to `None`). No behavior change for existing setups.
