### PR TITLE
feat(agent): add compression.notify config to control context compaction status visibility

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -771,6 +771,8 @@ DEFAULT_CONFIG = {
                                       # 0 for long-running rolling-compaction sessions
                                       # where you want nothing pinned except the
                                       # system prompt + rolling summary + recent tail.
+        "notify": True,              # push "Compacting context..." status to messaging platforms;
+                                      # set false to log only (no user-visible notification)
     },
 
     # Anthropic prompt caching (Claude via OpenRouter or native Anthropic API).

--- a/run_agent.py
+++ b/run_agent.py
@@ -2136,6 +2136,7 @@ class AIAgent:
         compression_protect_first = max(
             0, int(_compression_cfg.get("protect_first_n", 3))
         )
+        compression_notify = str(_compression_cfg.get("notify", True)).lower() in {"true", "1", "yes"}
 
         # Read optional explicit context_length override for the auxiliary
         # compression model. Custom endpoints often cannot report this via
@@ -2352,6 +2353,7 @@ class AIAgent:
                 api_mode=self.api_mode,
             )
         self.compression_enabled = compression_enabled
+        self._compression_notify = compression_notify
 
         # Reject models whose context window is below the minimum required
         # for reliable tool-calling workflows (64K tokens).
@@ -10656,9 +10658,14 @@ class AIAgent:
             f"{approx_tokens:,}" if approx_tokens else "unknown", self.model,
             focus_topic,
         )
-        self._emit_status(
-            "🗜️ Compacting context — summarizing earlier conversation so I can continue..."
-        )
+        if self._compression_notify:
+            self._emit_status(
+                "🗜️ Compacting context — summarizing earlier conversation so I can continue..."
+            )
+        else:
+            logger.info(
+                "🗜️ Compacting context — summarizing earlier conversation so I can continue..."
+            )
 
         # Notify external memory provider before compression discards context
         if self._memory_manager:

--- a/tests/run_agent/test_413_compression.py
+++ b/tests/run_agent/test_413_compression.py
@@ -441,6 +441,34 @@ class TestPreflightCompression:
         assert "Compacting context" in events[0][1]
         assert events[1] == ("compress", "started")
 
+    def test_compress_context_silent_when_notify_false(self, agent):
+        """When compression.notify is false, no lifecycle event is pushed to user."""
+        agent._compression_notify = False
+        events = []
+        agent.status_callback = lambda ev, msg: events.append((ev, msg))
+
+        def _fake_compress(messages, current_tokens=None, focus_topic=None):
+            events.append(("compress", "started"))
+            return [{"role": "user", "content": f"{SUMMARY_PREFIX}\nPrevious conversation"}]
+
+        with (
+            patch.object(agent.context_compressor, "compress", side_effect=_fake_compress),
+            patch.object(agent, "_build_system_prompt", return_value="new system prompt"),
+            patch("run_agent.estimate_request_tokens_rough", return_value=42),
+        ):
+            compressed, new_system_prompt = agent._compress_context(
+                [{"role": "user", "content": "hello"}],
+                "system prompt",
+                approx_tokens=1234,
+            )
+
+        assert compressed == [{"role": "user", "content": f"{SUMMARY_PREFIX}\nPrevious conversation"}]
+        assert new_system_prompt == "new system prompt"
+        # Compression itself still fires
+        assert ("compress", "started") in events
+        # But no lifecycle event was pushed to the user
+        assert not any(ev == "lifecycle" for ev, msg in events)
+
     def test_preflight_compresses_oversized_history(self, agent):
         """When loaded history exceeds the model's context threshold, compress before API call."""
         agent.compression_enabled = True


### PR DESCRIPTION
## What changed

Added `compression.notify` config option (default: `true`) to control whether the "🗜 Compacting context..." lifecycle message is pushed to messaging platforms (Telegram, Discord, etc.) or only written to logs.

## Why

The compaction status message (`_emit_status("🗜 Compacting context...")`) is bridged to gateway `adapter.send()` via `status_callback`, so it always appears as a user-visible message on messaging platforms. For users who consider this internal agent logging rather than actionable information, there was no way to suppress the notification.

This was introduced in `00ad3d3c` (May 13). Before that, compression was silent.

## Changes

- **`hermes_cli/config.py`**: Added `"notify": True` to the `compression` default config block
- **`run_agent.py`**:
  - Read `notify` from `_compression_cfg` in `AIAgent.__init__`
  - Store as `self._compression_notify`
  - In `_compress_context()`: use `_emit_status()` when `notify=True`, `logger.info()` when `notify=False`
- **`tests/run_agent/test_413_compression.py`**: Added `test_compress_context_silent_when_notify_false` to verify no lifecycle event is pushed when `notify=False`

## How to test

```bash
# Disable compaction notifications (log only)
hermes config set compression.notify false

# Re-enable (default)
hermes config set compression.notify true
```

Restart gateway after changing. Compression itself is unaffected — only the user-visible notification changes.

## Platforms tested

- Linux (Ubuntu, Python 3.11)