### PR TITLE
fix(gateway): scope resume title lookup

### DIFF
--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -2719,9 +2719,22 @@ class GatewaySlashCommandsMixin:
         ):
             name = name[1:-1].strip()
 
+        user_source = source.platform.value if source.platform else None
+        user_id = source.user_id
+
+        def _session_matches_resume_scope(session: dict) -> bool:
+            if user_source and session.get("source") != user_source:
+                return False
+            if user_id is not None and session.get("user_id") != user_id:
+                return False
+            return True
+
         def _list_titled_sessions() -> list[dict]:
-            user_source = source.platform.value if source.platform else None
-            sessions = self._session_db.list_sessions_rich(source=user_source, limit=10)
+            sessions = self._session_db.list_sessions_rich(
+                source=user_source,
+                user_id=user_id,
+                limit=10,
+            )
             return [s for s in sessions if s.get("title")][:10]
 
         if not name:
@@ -2779,10 +2792,14 @@ class GatewaySlashCommandsMixin:
             # Try direct session ID lookup first (so `/resume <session_id>`
             # works in the gateway, not just `/resume <title>`).
             session = self._session_db.get_session(name)
-            if session:
+            if session and _session_matches_resume_scope(session):
                 target_id = session["id"]
             else:
-                target_id = self._session_db.resolve_session_by_title(name)
+                target_id = self._session_db.resolve_session_by_title(
+                    name,
+                    source=user_source,
+                    user_id=user_id,
+                )
         if not target_id:
             return t("gateway.resume.not_found", name=name)
         # Compression creates child continuations that hold the live transcript.
@@ -2895,6 +2912,7 @@ class GatewaySlashCommandsMixin:
             self._session_db.create_session(
                 session_id=new_session_id,
                 source=source.platform.value if source.platform else "gateway",
+                user_id=source.user_id,
                 model=(self.config.get("model", {}) or {}).get("default") if isinstance(self.config, dict) else None,
                 model_config={"_branched_from": parent_session_id},
                 parent_session_id=parent_session_id,

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1863,16 +1863,33 @@ class SessionDB:
         rowcount = self._execute_write(_do)
         return rowcount > 0
 
-    def get_session_by_title(self, title: str) -> Optional[Dict[str, Any]]:
+    def get_session_by_title(
+        self,
+        title: str,
+        source: str = None,
+        user_id: str = None,
+    ) -> Optional[Dict[str, Any]]:
         """Look up a session by exact title. Returns session dict or None."""
+        where_clauses = ["title = ?"]
+        params = [title]
+        if source:
+            where_clauses.append("source = ?")
+            params.append(source)
+        if user_id is not None:
+            where_clauses.append("user_id = ?")
+            params.append(user_id)
+        query = f"SELECT * FROM sessions WHERE {' AND '.join(where_clauses)}"
         with self._lock:
-            cursor = self._conn.execute(
-                "SELECT * FROM sessions WHERE title = ?", (title,)
-            )
+            cursor = self._conn.execute(query, params)
             row = cursor.fetchone()
         return dict(row) if row else None
 
-    def resolve_session_by_title(self, title: str) -> Optional[str]:
+    def resolve_session_by_title(
+        self,
+        title: str,
+        source: str = None,
+        user_id: str = None,
+    ) -> Optional[str]:
         """Resolve a title to a session ID, preferring the latest in a lineage.
 
         If the exact title exists, returns that session's ID.
@@ -1881,17 +1898,26 @@ class SessionDB:
         latest numbered variant (the most recent continuation).
         """
         # First try exact match
-        exact = self.get_session_by_title(title)
+        exact = self.get_session_by_title(title, source=source, user_id=user_id)
 
         # Also search for numbered variants: "title #2", "title #3", etc.
         # Escape SQL LIKE wildcards (%, _) in the title to prevent false matches
         escaped = title.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+        where_clauses = ["title LIKE ? ESCAPE '\\'"]
+        params = [f"{escaped} #%"]
+        if source:
+            where_clauses.append("source = ?")
+            params.append(source)
+        if user_id is not None:
+            where_clauses.append("user_id = ?")
+            params.append(user_id)
+        query = (
+            "SELECT id, title, started_at FROM sessions "
+            f"WHERE {' AND '.join(where_clauses)} "
+            "ORDER BY started_at DESC"
+        )
         with self._lock:
-            cursor = self._conn.execute(
-                "SELECT id, title, started_at FROM sessions "
-                "WHERE title LIKE ? ESCAPE '\\' ORDER BY started_at DESC",
-                (f"{escaped} #%",),
-            )
+            cursor = self._conn.execute(query, params)
             numbered = cursor.fetchall()
 
         if numbered:
@@ -1976,6 +2002,7 @@ class SessionDB:
         self,
         source: str = None,
         exclude_sources: List[str] = None,
+        user_id: str = None,
         limit: int = 20,
         offset: int = 0,
         include_children: bool = False,
@@ -2037,6 +2064,9 @@ class SessionDB:
         if source:
             where_clauses.append("s.source = ?")
             params.append(source)
+        if user_id is not None:
+            where_clauses.append("s.user_id = ?")
+            params.append(user_id)
         if exclude_sources:
             placeholders = ",".join("?" for _ in exclude_sources)
             where_clauses.append(f"s.source NOT IN ({placeholders})")

--- a/tests/gateway/test_matrix_project_context_isolation.py
+++ b/tests/gateway/test_matrix_project_context_isolation.py
@@ -427,7 +427,11 @@ async def test_matrix_resume_quoted_title_same_room():
     )
 
     assert "Resumed session" in result
-    runner._session_db.resolve_session_by_title.assert_called_once_with("Project B Plan")
+    runner._session_db.resolve_session_by_title.assert_called_once_with(
+        "Project B Plan",
+        source="matrix",
+        user_id=SENDER,
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_resume_command.py
+++ b/tests/gateway/test_resume_command.py
@@ -77,8 +77,8 @@ class TestHandleResumeCommand:
         """With no argument, lists recently titled sessions."""
         from hermes_state import SessionDB
         db = SessionDB(db_path=tmp_path / "state.db")
-        db.create_session("sess_001", "telegram")
-        db.create_session("sess_002", "telegram")
+        db.create_session("sess_001", "telegram", user_id="12345")
+        db.create_session("sess_002", "telegram", user_id="12345")
         db.set_session_title("sess_001", "Research")
         db.set_session_title("sess_002", "Coding")
 
@@ -91,6 +91,24 @@ class TestHandleResumeCommand:
         assert "1." in result
         assert "2." in result
         assert "/resume 1" in result
+        db.close()
+
+    @pytest.mark.asyncio
+    async def test_list_named_sessions_scoped_to_user_id(self, tmp_path):
+        """With no argument, only lists titles owned by the requesting user."""
+        from hermes_state import SessionDB
+        db = SessionDB(db_path=tmp_path / "state.db")
+        db.create_session("own_session", "telegram", user_id="12345")
+        db.create_session("other_session", "telegram", user_id="99999")
+        db.set_session_title("own_session", "Own Work")
+        db.set_session_title("other_session", "Other Work")
+
+        event = _make_event(text="/resume")
+        runner = _make_runner(session_db=db, event=event)
+        result = await runner._handle_resume_command(event)
+
+        assert "Own Work" in result
+        assert "Other Work" not in result
         db.close()
 
     @pytest.mark.asyncio
@@ -112,11 +130,11 @@ class TestHandleResumeCommand:
         """Numeric argument resumes the indexed titled session from the list."""
         from hermes_state import SessionDB
         db = SessionDB(db_path=tmp_path / "state.db")
-        db.create_session("sess_001", "telegram")
-        db.create_session("sess_002", "telegram")
+        db.create_session("sess_001", "telegram", user_id="12345")
+        db.create_session("sess_002", "telegram", user_id="12345")
         db.set_session_title("sess_001", "Research")
         db.set_session_title("sess_002", "Coding")
-        db.create_session("current_session_001", "telegram")
+        db.create_session("current_session_001", "telegram", user_id="12345")
 
         event = _make_event(text="/resume 2")
         runner = _make_runner(session_db=db, current_session_id="current_session_001",
@@ -153,9 +171,9 @@ class TestHandleResumeCommand:
         """Resolves a title and switches to that session."""
         from hermes_state import SessionDB
         db = SessionDB(db_path=tmp_path / "state.db")
-        db.create_session("old_session_abc", "telegram")
+        db.create_session("old_session_abc", "telegram", user_id="12345")
         db.set_session_title("old_session_abc", "My Project")
-        db.create_session("current_session_001", "telegram")
+        db.create_session("current_session_001", "telegram", user_id="12345")
 
         event = _make_event(text="/resume My Project")
         runner = _make_runner(session_db=db, current_session_id="current_session_001",
@@ -168,6 +186,69 @@ class TestHandleResumeCommand:
         runner.session_store.switch_session.assert_called_once()
         call_args = runner.session_store.switch_session.call_args
         assert call_args[0][1] == "old_session_abc"
+        db.close()
+
+    @pytest.mark.asyncio
+    async def test_resume_by_name_scoped_to_user_id(self, tmp_path):
+        """Does not resolve a title owned by another user on the same platform."""
+        from hermes_state import SessionDB
+        db = SessionDB(db_path=tmp_path / "state.db")
+        db.create_session("other_session", "telegram", user_id="99999")
+        db.set_session_title("other_session", "Other User Work")
+        db.create_session("current_session_001", "telegram", user_id="12345")
+
+        event = _make_event(text="/resume Other User Work")
+        runner = _make_runner(
+            session_db=db,
+            current_session_id="current_session_001",
+            event=event,
+        )
+        result = await runner._handle_resume_command(event)
+
+        assert "No session found" in result
+        runner.session_store.switch_session.assert_not_called()
+        db.close()
+
+    @pytest.mark.asyncio
+    async def test_resume_by_name_scoped_to_source(self, tmp_path):
+        """Does not resolve a title owned by the same user on another source."""
+        from hermes_state import SessionDB
+        db = SessionDB(db_path=tmp_path / "state.db")
+        db.create_session("cli_session", "cli", user_id="12345")
+        db.set_session_title("cli_session", "CLI Work")
+        db.create_session("current_session_001", "telegram", user_id="12345")
+
+        event = _make_event(text="/resume CLI Work")
+        runner = _make_runner(
+            session_db=db,
+            current_session_id="current_session_001",
+            event=event,
+        )
+        result = await runner._handle_resume_command(event)
+
+        assert "No session found" in result
+        runner.session_store.switch_session.assert_not_called()
+        db.close()
+
+    @pytest.mark.asyncio
+    async def test_resume_by_session_id_scoped_to_user_id(self, tmp_path):
+        """Does not resume a direct session id owned by another user."""
+        from hermes_state import SessionDB
+        db = SessionDB(db_path=tmp_path / "state.db")
+        db.create_session("other_session", "telegram", user_id="99999")
+        db.set_session_title("other_session", "Other User Work")
+        db.create_session("current_session_001", "telegram", user_id="12345")
+
+        event = _make_event(text="/resume other_session")
+        runner = _make_runner(
+            session_db=db,
+            current_session_id="current_session_001",
+            event=event,
+        )
+        result = await runner._handle_resume_command(event)
+
+        assert "No session found" in result
+        runner.session_store.switch_session.assert_not_called()
         db.close()
 
     @pytest.mark.asyncio
@@ -188,7 +269,7 @@ class TestHandleResumeCommand:
         """Returns friendly message when already on the requested session."""
         from hermes_state import SessionDB
         db = SessionDB(db_path=tmp_path / "state.db")
-        db.create_session("current_session_001", "telegram")
+        db.create_session("current_session_001", "telegram", user_id="12345")
         db.set_session_title("current_session_001", "Active Project")
 
         event = _make_event(text="/resume Active Project")
@@ -203,11 +284,11 @@ class TestHandleResumeCommand:
         """Asking for 'My Project' when 'My Project #2' exists gets the latest."""
         from hermes_state import SessionDB
         db = SessionDB(db_path=tmp_path / "state.db")
-        db.create_session("sess_v1", "telegram")
+        db.create_session("sess_v1", "telegram", user_id="12345")
         db.set_session_title("sess_v1", "My Project")
-        db.create_session("sess_v2", "telegram")
+        db.create_session("sess_v2", "telegram", user_id="12345")
         db.set_session_title("sess_v2", "My Project #2")
-        db.create_session("current_session_001", "telegram")
+        db.create_session("current_session_001", "telegram", user_id="12345")
 
         event = _make_event(text="/resume My Project")
         runner = _make_runner(session_db=db, current_session_id="current_session_001",
@@ -221,17 +302,45 @@ class TestHandleResumeCommand:
         db.close()
 
     @pytest.mark.asyncio
+    async def test_resume_lineage_scoped_to_user_id(self, tmp_path):
+        """Lineage lookup ignores numbered continuations owned by other users."""
+        from hermes_state import SessionDB
+        db = SessionDB(db_path=tmp_path / "state.db")
+        db.create_session("own_session", "telegram", user_id="12345")
+        db.set_session_title("own_session", "My Project")
+        db.create_session("other_session", "telegram", user_id="99999")
+        db.set_session_title("other_session", "My Project #2")
+        db.create_session("current_session_001", "telegram", user_id="12345")
+
+        event = _make_event(text="/resume My Project")
+        runner = _make_runner(
+            session_db=db,
+            current_session_id="current_session_001",
+            event=event,
+        )
+        await runner._handle_resume_command(event)
+
+        call_args = runner.session_store.switch_session.call_args
+        assert call_args[0][1] == "own_session"
+        db.close()
+
+    @pytest.mark.asyncio
     async def test_resume_follows_compression_continuation(self, tmp_path):
         """Gateway /resume should reopen the live descendant after compression."""
         from hermes_state import SessionDB
 
         db = SessionDB(db_path=tmp_path / "state.db")
-        db.create_session("compressed_root", "telegram")
+        db.create_session("compressed_root", "telegram", user_id="12345")
         db.set_session_title("compressed_root", "Compressed Work")
         db.end_session("compressed_root", "compression")
-        db.create_session("compressed_child", "telegram", parent_session_id="compressed_root")
+        db.create_session(
+            "compressed_child",
+            "telegram",
+            user_id="12345",
+            parent_session_id="compressed_root",
+        )
         db.append_message("compressed_child", "user", "hello from continuation")
-        db.create_session("current_session_001", "telegram")
+        db.create_session("current_session_001", "telegram", user_id="12345")
 
         event = _make_event(text="/resume Compressed Work")
         runner = _make_runner(
@@ -259,9 +368,9 @@ class TestHandleResumeCommand:
         """Switching sessions clears any cached running agent."""
         from hermes_state import SessionDB
         db = SessionDB(db_path=tmp_path / "state.db")
-        db.create_session("old_session", "telegram")
+        db.create_session("old_session", "telegram", user_id="12345")
         db.set_session_title("old_session", "Old Work")
-        db.create_session("current_session_001", "telegram")
+        db.create_session("current_session_001", "telegram", user_id="12345")
 
         event = _make_event(text="/resume Old Work")
         runner = _make_runner(session_db=db, current_session_id="current_session_001",
@@ -285,9 +394,9 @@ class TestHandleResumeCommand:
         import threading
         from hermes_state import SessionDB
         db = SessionDB(db_path=tmp_path / "state.db")
-        db.create_session("old_session", "telegram")
+        db.create_session("old_session", "telegram", user_id="12345")
         db.set_session_title("old_session", "Old Work")
-        db.create_session("current_session_001", "telegram")
+        db.create_session("current_session_001", "telegram", user_id="12345")
 
         event = _make_event(text="/resume Old Work")
         runner = _make_runner(session_db=db, current_session_id="current_session_001",

--- a/tests/gateway/test_session_boundary_security_state.py
+++ b/tests/gateway/test_session_boundary_security_state.py
@@ -176,6 +176,7 @@ async def test_branch_clears_session_scoped_approval_and_yolo_state():
     result = await runner._handle_branch_command(_make_event("/branch"))
 
     assert "Branched to" in result
+    assert runner._session_db.create_session.call_args.kwargs["user_id"] == "u1"
     assert is_approved(session_key, "recursive delete") is False
     assert is_session_yolo_enabled(session_key) is False
     assert session_key not in runner._pending_approvals

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -2469,6 +2469,23 @@ class TestTitleUniqueness:
         assert result is not None
         assert result["id"] == "s1"
 
+    def test_get_session_by_title_scoped_to_user_id(self, db):
+        db.create_session("s1", "telegram", user_id="user-a")
+        db.create_session("s2", "telegram", user_id="user-b")
+        db.set_session_title("s1", "refactoring auth")
+        db.set_session_title("s2", "deployment notes")
+
+        result = db.get_session_by_title(
+            "deployment notes", source="telegram", user_id="user-a"
+        )
+        assert result is None
+
+        result = db.get_session_by_title(
+            "deployment notes", source="telegram", user_id="user-b"
+        )
+        assert result is not None
+        assert result["id"] == "s2"
+
     def test_get_session_by_title_not_found(self, db):
         assert db.get_session_by_title("nonexistent") is None
 
@@ -2503,6 +2520,26 @@ class TestTitleLineage:
         db.set_session_title("s3", "my project #3")
         # Resolving "my project" should return s3 (latest numbered variant)
         assert db.resolve_session_by_title("my project") == "s3"
+
+    def test_resolve_lineage_scoped_to_user_id(self, db):
+        """Numbered variants owned by another user do not shadow an exact title."""
+        db.create_session("s1", "telegram", user_id="user-a")
+        db.set_session_title("s1", "my project")
+        db.create_session("s2", "telegram", user_id="user-b")
+        db.set_session_title("s2", "my project #2")
+
+        assert (
+            db.resolve_session_by_title(
+                "my project", source="telegram", user_id="user-a"
+            )
+            == "s1"
+        )
+        assert (
+            db.resolve_session_by_title(
+                "my project", source="telegram", user_id="user-b"
+            )
+            == "s2"
+        )
 
     def test_resolve_exact_numbered(self, db):
         """Resolving an exact numbered title returns that specific session."""
@@ -2720,6 +2757,13 @@ class TestListSessionsRich:
         db.create_session("s1", "cli")
         db.create_session("s2", "telegram")
         sessions = db.list_sessions_rich(source="cli")
+        assert len(sessions) == 1
+        assert sessions[0]["id"] == "s1"
+
+    def test_rich_list_user_id_filter(self, db):
+        db.create_session("s1", "telegram", user_id="user-a")
+        db.create_session("s2", "telegram", user_id="user-b")
+        sessions = db.list_sessions_rich(source="telegram", user_id="user-a")
         assert len(sessions) == 1
         assert sessions[0]["id"] == "s1"
 


### PR DESCRIPTION
﻿## Summary
- Scope gateway `/resume` listing, title resolution, and direct session-id resolution to the requesting platform and user id.
- Preserve unscoped `SessionDB` behavior for callers that do not pass scope filters.
- Persist the gateway user id on `/branch`-created sessions so scoped `/resume` can keep them visible.
- Rebased onto current `upstream/main`; this now patches the moved slash-command implementation in `gateway/slash_commands.py` and removes the old `_docs` addition from the PR.

## Notes
- Addresses #29149 at a high level; detailed advisory material remains out of the public PR.
- The current gateway supports `/resume <session_id>`, so this revision scopes both title and direct-id paths.

## Validation
- `uv run pytest -q tests\gateway\test_resume_command.py tests\test_hermes_state.py::TestTitleUniqueness tests\test_hermes_state.py::TestTitleLineage tests\test_hermes_state.py::TestListSessionsRich tests\gateway\test_session_boundary_security_state.py::test_branch_clears_session_scoped_approval_and_yolo_state tests\gateway\test_session_boundary_security_state.py::test_resume_clears_session_scoped_approval_and_yolo_state -o addopts=`
- `uv run ruff check gateway\slash_commands.py hermes_state.py tests\gateway\test_resume_command.py tests\gateway\test_session_boundary_security_state.py tests\test_hermes_state.py`
- `python -m py_compile gateway\slash_commands.py hermes_state.py`
- `git diff --check`
