### PR TITLE
feat(proof): add local proof trail command

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -11462,7 +11462,7 @@ _BUILTIN_SUBCOMMANDS = frozenset(
         "dump", "fallback", "gateway", "hooks", "import", "insights",
         "gui", "desktop", "kanban", "login", "logout", "logs", "lsp", "mcp", "memory", "migrate",
         "model", "pairing", "plugins", "portal", "postinstall", "profile", "proxy",
-        "prompt-size",
+        "prompt-size", "proof",
         "send", "sessions", "setup",
         "skills", "slack", "status", "tools", "uninstall", "update",
         "version", "webhook", "whatsapp", "chat", "secrets", "security",
@@ -13556,6 +13556,42 @@ Examples:
         _register_curator_cli(curator_parser)
     except Exception as _exc:
         logging.getLogger(__name__).debug("curator CLI wiring failed: %s", _exc)
+
+    # =========================================================================
+    # proof command
+    # =========================================================================
+    proof_parser = subparsers.add_parser(
+        "proof",
+        help="Create durable local proof artifacts for agent actions",
+    )
+    proof_sub = proof_parser.add_subparsers(dest="proof_command")
+    proof_create = proof_sub.add_parser(
+        "create",
+        help="Create a proof artifact under the local proofs directory",
+    )
+    proof_create.add_argument("--title", required=True)
+    proof_create.add_argument("--status", default="recorded")
+    proof_create.add_argument("--rationale", default="")
+    proof_create.add_argument("--input", dest="inputs", action="append", default=[])
+    proof_create.add_argument("--file", dest="files", action="append", default=[])
+    proof_create.add_argument("--command", dest="commands", action="append", default=[])
+    proof_create.add_argument("--validation", dest="validations", action="append", default=[])
+    proof_create.add_argument("--related", dest="related", action="append", default=[])
+    proof_create.add_argument("--reference", dest="references", action="append", default=[])
+    proof_create.add_argument("--final-state", default="")
+    proof_create.add_argument("--output-dir", default="")
+    proof_create.add_argument("--json", action="store_true")
+
+    def cmd_proof(args):
+        sub = getattr(args, "proof_command", None)
+        if sub == "create":
+            from hermes_cli.proof_trail_cmd import proof_trail_command
+
+            proof_trail_command(args)
+            return
+        proof_parser.print_help()
+
+    proof_parser.set_defaults(func=cmd_proof)
 
     # =========================================================================
     # memory command

--- a/hermes_cli/proof_trail_cmd.py
+++ b/hermes_cli/proof_trail_cmd.py
@@ -1,0 +1,193 @@
+"""Proof trail command helpers.
+
+Creates compact, durable Markdown proof artifacts for important agent actions.
+The command is intentionally filesystem-local and dependency-light so users can
+record rationale, evidence, validation, and final state without needing an
+external service.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable
+
+from hermes_constants import get_hermes_home
+
+
+def default_proof_dir() -> Path:
+    """Return the default local proof artifact directory."""
+    return get_hermes_home() / "proofs"
+
+
+def slugify_title(title: str) -> str:
+    slug = re.sub(r"[^a-z0-9]+", "-", (title or "").strip().lower()).strip("-")
+    slug = re.sub(r"-+", "-", slug)
+    return slug or "proof"
+
+
+def _list_lines(items: Iterable[str], *, code: bool = False) -> str:
+    values = [str(item).strip() for item in items if str(item).strip()]
+    if not values:
+        return "- None recorded\n"
+    if code:
+        return "".join(f"- `{item}`\n" for item in values)
+    return "".join(f"- {item}\n" for item in values)
+
+
+def _command_blocks(commands: Iterable[str]) -> str:
+    values = [str(item).strip() for item in commands if str(item).strip()]
+    if not values:
+        return "- None recorded\n"
+    return "\n".join(f"```bash\n{cmd}\n```" for cmd in values) + "\n"
+
+
+def build_proof_markdown(
+    *,
+    title: str,
+    status: str,
+    rationale: str,
+    inputs: list[str],
+    files: list[str],
+    commands: list[str],
+    validations: list[str],
+    related: list[str],
+    final_state: str,
+    references: list[str],
+    timestamp: str,
+) -> str:
+    """Build the Markdown body for a proof artifact."""
+    safe_title = title.strip() or "Task Proof"
+    safe_status = status.strip() or "recorded"
+    return f"""---
+type: proof
+status: "{safe_status}"
+created: "{timestamp[:10]}"
+updated: "{timestamp[:10]}"
+---
+
+# {safe_title}
+
+## Summary
+
+- **Status:** {safe_status}
+- **Timestamp:** {timestamp}
+
+## Rationale
+
+{rationale.strip() or "No rationale recorded."}
+
+## Inputs
+
+{_list_lines(inputs)}
+## Files Changed
+
+{_list_lines(files, code=True)}
+## Commands / Evidence
+
+{_command_blocks(commands)}
+## Validation
+
+{_list_lines(validations)}
+## Related Artifacts
+
+{_list_lines(related)}
+## References
+
+{_list_lines(references)}
+## Final State
+
+{final_state.strip() or "No final state recorded."}
+
+## History
+
+- **{timestamp[:10]}** — Proof artifact created.
+"""
+
+
+def _load_index(index_path: Path) -> dict[str, Any]:
+    if not index_path.exists():
+        return {"proofs": []}
+    try:
+        payload = json.loads(index_path.read_text(encoding="utf-8"))
+        if isinstance(payload, dict) and isinstance(payload.get("proofs"), list):
+            return payload
+    except Exception:
+        pass
+    return {"proofs": []}
+
+
+def create_proof_record(
+    *,
+    title: str,
+    status: str,
+    rationale: str,
+    inputs: list[str],
+    files: list[str],
+    commands: list[str],
+    validations: list[str],
+    related: list[str],
+    final_state: str,
+    references: list[str],
+    output_dir: Path | None = None,
+    timestamp: str | None = None,
+) -> dict[str, Any]:
+    """Create a proof Markdown file and update the local proof index."""
+    timestamp = timestamp or datetime.now(timezone.utc).isoformat()
+    output_dir = output_dir or default_proof_dir()
+    output_dir.mkdir(parents=True, exist_ok=True)
+    date_prefix = timestamp[:10]
+    slug = slugify_title(title)
+    proof_path = output_dir / f"{date_prefix}-{slug}.md"
+    markdown = build_proof_markdown(
+        title=title,
+        status=status,
+        rationale=rationale,
+        inputs=inputs,
+        files=files,
+        commands=commands,
+        validations=validations,
+        related=related,
+        final_state=final_state,
+        references=references,
+        timestamp=timestamp,
+    )
+    proof_path.write_text(markdown, encoding="utf-8")
+
+    index_path = output_dir / "proof-index.json"
+    index = _load_index(index_path)
+    record = {
+        "title": title,
+        "status": status,
+        "timestamp": timestamp,
+        "path": str(proof_path),
+        "slug": slug,
+    }
+    index["proofs"] = [p for p in index.get("proofs", []) if p.get("path") != str(proof_path)]
+    index["proofs"].insert(0, record)
+    index_path.write_text(json.dumps(index, indent=2, ensure_ascii=False), encoding="utf-8")
+
+    return {"success": True, "path": str(proof_path), "index_path": str(index_path), "record": record}
+
+
+def proof_trail_command(args, *, timestamp: str | None = None) -> None:
+    result = create_proof_record(
+        title=args.title,
+        status=args.status,
+        rationale=args.rationale,
+        inputs=list(args.inputs or []),
+        files=list(args.files or []),
+        commands=list(args.commands or []),
+        validations=list(args.validations or []),
+        related=list(args.related or []),
+        final_state=args.final_state,
+        references=list(args.references or []),
+        output_dir=Path(args.output_dir) if args.output_dir else None,
+        timestamp=timestamp,
+    )
+    if bool(getattr(args, "json", False)):
+        print(json.dumps(result, indent=2, ensure_ascii=False))
+    else:
+        print(f"Proof written: {result['path']}")

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -67,6 +67,7 @@ AUTHOR_MAP = {
     "195255660+EvilHumphrey@users.noreply.github.com": "EvilHumphrey",
     "270604154+superearn-fisher@users.noreply.github.com": "superearn-fisher",
     "3540493+kpadilha@users.noreply.github.com": "kpadilha",
+    "krishna@padilha.com": "kpadilha",
     "40378218+chaconne67@users.noreply.github.com": "chaconne67",
     "Pluviobyte@users.noreply.github.com": "Pluviobyte",
     "sanghyuk_seo@nexcubecorp.com": "sanghyuk-seo-nexcube",

--- a/tests/hermes_cli/test_proof_trail_cmd.py
+++ b/tests/hermes_cli/test_proof_trail_cmd.py
@@ -1,0 +1,101 @@
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+from hermes_cli.proof_trail_cmd import (
+    build_proof_markdown,
+    create_proof_record,
+    default_proof_dir,
+    proof_trail_command,
+    slugify_title,
+)
+
+
+def test_default_proof_dir_uses_hermes_home(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    assert default_proof_dir() == tmp_path / "proofs"
+
+
+def test_slugify_title_is_filesystem_safe_and_stable():
+    assert slugify_title("Agent Run: Validation Proof!") == "agent-run-validation-proof"
+    assert slugify_title("  ") == "proof"
+
+
+def test_build_proof_markdown_contains_required_sections():
+    markdown = build_proof_markdown(
+        title="Agent Run Proof Trail",
+        status="validated",
+        rationale="Need durable proof for autonomous actions.",
+        inputs=["handoff.md", "plan.md"],
+        files=["hermes_cli/proof_trail_cmd.py"],
+        commands=["pytest tests/hermes_cli/test_proof_trail_cmd.py -q"],
+        validations=["5 passed"],
+        related=["ticket-123"],
+        final_state="Ready for future tasks.",
+        references=["session:abc"],
+        timestamp="2026-04-24T20:00:00+00:00",
+    )
+
+    for heading in [
+        "## Rationale",
+        "## Inputs",
+        "## Files Changed",
+        "## Commands / Evidence",
+        "## Validation",
+        "## Related Artifacts",
+        "## References",
+        "## Final State",
+    ]:
+        assert heading in markdown
+    assert "status: \"validated\"" in markdown
+    assert "- `hermes_cli/proof_trail_cmd.py`" in markdown
+    assert "```bash\npytest tests/hermes_cli/test_proof_trail_cmd.py -q\n```" in markdown
+
+
+def test_create_proof_record_writes_markdown_and_json_index(tmp_path):
+    result = create_proof_record(
+        title="Autonomy Monitor Implementation",
+        status="validated",
+        rationale="Record proof trail.",
+        inputs=["handoff"],
+        files=["script.py"],
+        commands=["pytest -q"],
+        validations=["passed"],
+        related=["health-check"],
+        final_state="done",
+        references=["summary-node-3"],
+        output_dir=tmp_path,
+        timestamp="2026-04-24T20:00:00+00:00",
+    )
+
+    proof_path = Path(result["path"])
+    index_path = tmp_path / "proof-index.json"
+    assert proof_path.exists()
+    assert proof_path.name == "2026-04-24-autonomy-monitor-implementation.md"
+    assert index_path.exists()
+    index = json.loads(index_path.read_text(encoding="utf-8"))
+    assert index["proofs"][0]["title"] == "Autonomy Monitor Implementation"
+    assert index["proofs"][0]["status"] == "validated"
+
+
+def test_proof_trail_command_outputs_json(tmp_path, capsys):
+    args = SimpleNamespace(
+        title="Proof CLI Smoke",
+        status="validated",
+        rationale="Smoke proof command.",
+        inputs=["input-a"],
+        files=["file-a"],
+        commands=["cmd-a"],
+        validations=["ok"],
+        related=["artifact-a"],
+        final_state="complete",
+        references=["ref-a"],
+        output_dir=str(tmp_path),
+        json=True,
+    )
+
+    proof_trail_command(args, timestamp="2026-04-24T20:00:00+00:00")
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["success"] is True
+    assert Path(payload["path"]).exists()


### PR DESCRIPTION
## What does this PR do?

Adds a small `hermes proof create` command that writes local Markdown proof artifacts plus a JSON index.

The goal is to give users a lightweight way to record rationale, inputs, changed files, command evidence, validation, related artifacts, references, and final state for important agent actions without depending on an external service. The default output is local to the Hermes home directory (`~/.hermes/proofs` via `get_hermes_home()`), and callers can override it with `--output-dir`.

## Related Issue

N/A — extracted from local operational use into a generic, dependency-light command.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/main.py`
  - Add `hermes proof create` parser and CLI flags.
  - Add `proof` to `_BUILTIN_SUBCOMMANDS` so the startup plugin-discovery fast path stays covered.
- `hermes_cli/proof_trail_cmd.py`
  - Add Markdown proof artifact builder.
  - Add proof record writer and local `proof-index.json` maintenance.
  - Default output directory to `get_hermes_home() / "proofs"`.
- `scripts/release.py`
  - Map `krishna@padilha.com` to `kpadilha` so the contributor attribution check accepts the canonical commit identity.
- `tests/hermes_cli/test_proof_trail_cmd.py`
  - Cover slug generation, default path resolution, Markdown sections, index writes, and JSON CLI output.

## How to Test

Targeted validation run on Debian/Linux with Python 3.11:

1. `python -m py_compile hermes_cli/main.py hermes_cli/proof_trail_cmd.py`
2. `python -m pytest tests/hermes_cli/test_proof_trail_cmd.py tests/hermes_cli/test_startup_plugin_gating.py -q`
3. `python -m hermes_cli.main proof create --title 'Proof Trail Smoke' --status validated --rationale 'CLI smoke' --output-dir "$TMP" --json`

Results:

```text
42 passed in 0.64s
```

CLI smoke produced:

```json
{
  "success": true,
  "path": "/tmp/.../2026-06-01-proof-trail-smoke.md",
  "index_path": "/tmp/.../proof-index.json",
  "record": {
    "title": "Proof Trail Smoke",
    "status": "validated",
    "slug": "proof-trail-smoke"
  }
}
```

Full `pytest tests/ -q` was not run locally for this PR branch, so the full-suite checklist item is intentionally left unchecked. GitHub Actions runs the repository shard matrix on the PR.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Debian Linux / Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A

## Screenshots / Logs

```text
$ python -m pytest tests/hermes_cli/test_proof_trail_cmd.py tests/hermes_cli/test_startup_plugin_gating.py -q
..........................................                               [100%]
42 passed in 0.64s
```
