### PR TITLE
test: isolate DDGS web backend fallback checks

### DIFF
--- a/tests/tools/test_web_tools_config.py
+++ b/tests/tools/test_web_tools_config.py
@@ -386,7 +386,8 @@ class TestBackendSelection:
     def test_fallback_no_keys_defaults_to_firecrawl(self):
         """No keys, no config → 'firecrawl' (will fail at client init)."""
         from tools.web_tools import _get_backend
-        with patch("tools.web_tools._load_web_config", return_value={}):
+        with patch("tools.web_tools._load_web_config", return_value={}), \
+             patch("tools.web_tools._ddgs_package_importable", return_value=False):
             assert _get_backend() == "firecrawl"
 
     def test_invalid_config_falls_through_to_fallback(self):
@@ -603,7 +604,8 @@ class TestCheckWebApiKey:
 
     def test_no_keys_returns_false(self):
         from tools.web_tools import check_web_api_key
-        assert check_web_api_key() is False
+        with patch("tools.web_tools._ddgs_package_importable", return_value=False):
+            assert check_web_api_key() is False
 
     def test_both_keys_returns_true(self):
         with patch.dict(os.environ, {


### PR DESCRIPTION
## Summary
- make no-key web backend fallback tests explicitly simulate DDGS being unavailable
- keep expectations stable in runtimes where the optional ddgs package is already installed/configured

## Verification
- scripts/run_tests.sh tests/hermes_cli/test_doctor.py tests/hermes_cli/test_kanban_db_init.py tests/tools/test_web_tools_config.py