### PR TITLE
fix(runtime): harden email polling and checkpoint store repair

### DIFF
--- a/gateway/platforms/email.py
+++ b/gateway/platforms/email.py
@@ -22,6 +22,7 @@ import logging
 import os
 import re
 import smtplib
+import socket
 import ssl
 import uuid
 from email.header import decode_header
@@ -424,6 +425,8 @@ class EmailAdapter(BasePlatformAdapter):
                     imap.logout()
                 except Exception:
                     pass
+        except (TimeoutError, socket.timeout, imaplib.IMAP4.abort) as e:
+            logger.warning("[Email] IMAP transient timeout/abort during poll: %s", e)
         except Exception as e:
             logger.error("[Email] IMAP fetch error: %s", e)
         return results

--- a/tests/gateway/test_email.py
+++ b/tests/gateway/test_email.py
@@ -871,6 +871,19 @@ class TestFetchNewMessages(unittest.TestCase):
 
         self.assertEqual(results, [])
 
+    def test_fetch_handles_timeout_as_transient_warning(self):
+        """Read timeouts are transient poll noise, not hard adapter errors."""
+        import socket
+        adapter = self._make_adapter()
+
+        with patch("imaplib.IMAP4_SSL", side_effect=socket.timeout("The read operation timed out")), \
+             self.assertLogs("gateway.platforms.email", level="WARNING") as logs:
+            results = adapter._fetch_new_messages()
+
+        self.assertEqual(results, [])
+        self.assertTrue(any("transient timeout" in line for line in logs.output))
+        self.assertFalse(any("IMAP fetch error" in line for line in logs.output))
+
     def test_fetch_extracts_sender_name(self):
         """Sender name should be extracted from 'Name <addr>' format."""
         adapter = self._make_adapter()

--- a/tests/tools/test_checkpoint_manager.py
+++ b/tests/tools/test_checkpoint_manager.py
@@ -131,6 +131,20 @@ class TestStoreInit:
         assert _init_store(store, str(work_dir)) is None
         assert _init_store(store, str(work_dir)) is None
 
+    def test_init_repairs_store_missing_refs_directory(self, work_dir, checkpoint_base, monkeypatch):
+        """A partially-created bare store is repaired instead of left non-git."""
+        monkeypatch.setattr("tools.checkpoint_manager.CHECKPOINT_BASE", checkpoint_base)
+        store = _store_path(checkpoint_base)
+        assert _init_store(store, str(work_dir)) is None
+        (store / "refs").rename(store / "refs.missing")
+
+        assert _init_store(store, str(work_dir)) is None
+
+        assert (store / "refs" / "heads").exists()
+        ok, stdout, stderr = _run_git(["rev-parse", "--git-dir"], store, str(work_dir))
+        assert ok
+        assert stdout == str(store)
+
     def test_bc_init_shadow_repo_shim(self, work_dir, checkpoint_base, monkeypatch):
         """Backward-compatible helper still works for old callers/tests."""
         monkeypatch.setattr("tools.checkpoint_manager.CHECKPOINT_BASE", checkpoint_base)

--- a/tools/checkpoint_manager.py
+++ b/tools/checkpoint_manager.py
@@ -402,7 +402,42 @@ def _init_store(store: Path, working_dir: str) -> Optional[str]:
         _migrate_legacy_store(base)
 
     if (store / "HEAD").exists():
-        return None
+        for rel in (
+            _INDEXES_DIRNAME,
+            _PROJECTS_DIRNAME,
+            "refs",
+            "refs/heads",
+            "refs/tags",
+            _REFS_PREFIX,
+            "objects/info",
+            "objects/pack",
+            "info",
+        ):
+            try:
+                (store / rel).mkdir(parents=True, exist_ok=True)
+            except OSError as exc:
+                return f"Could not repair checkpoint store {store / rel}: {exc}"
+        exclude_path = store / "info" / "exclude"
+        if not exclude_path.exists():
+            try:
+                exclude_path.write_text(
+                    "\n".join(DEFAULT_EXCLUDES) + "\n", encoding="utf-8"
+                )
+            except OSError as exc:
+                return f"Could not repair checkpoint exclude file: {exc}"
+        ok, _stdout, stderr = _run_git(
+            ["rev-parse", "--git-dir"], store, working_dir, allowed_returncodes={128}
+        )
+        if ok:
+            return None
+        logger.warning("Repairing invalid checkpoint store at %s: %s", store, stderr)
+        try:
+            for rel in ("HEAD", "config", "description"):
+                path = store / rel
+                if path.exists():
+                    path.unlink()
+        except OSError as exc:
+            return f"Could not reset invalid checkpoint store: {exc}"
 
     store.mkdir(parents=True, exist_ok=True)
     (store / _INDEXES_DIRNAME).mkdir(exist_ok=True)


### PR DESCRIPTION
## Summary
- Treat transient IMAP socket timeouts/aborts as warning-level poll noise instead of hard email adapter errors
- Repair partially-created checkpoint bare stores before running git commands
- Add regression tests for both reliability cases

## Verification
- ./venv/bin/python -m pytest tests/gateway/test_email.py tests/tools/test_checkpoint_manager.py -q
- Independent reviewer verdict: approved / safe_to_commit

## Notes
- This PR follows the Hermes runtime reliability remediation pass from 2026-05-21.
- No credentials or user config values are included.