### PR TITLE
fix(gateway): honor native image routing decisions in /background tasks

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -11398,9 +11398,10 @@ class GatewayRunner:
             self._service_tier = self._load_service_tier()
             turn_route = self._resolve_turn_agent_config(prompt, model, runtime_kwargs)
 
-            # Enrich the prompt with image descriptions so the background
-            # agent can see user-attached images (same as the main flow).
-            enriched_prompt = prompt
+            # Match the main gateway/CLI image ingress behavior: attach
+            # pixels natively for vision-capable models, otherwise fall back
+            # to the vision_analyze text pipeline.
+            enriched_prompt: Any = prompt
             if media_urls:
                 image_paths = []
                 for i, path in enumerate(media_urls):
@@ -11408,12 +11409,61 @@ class GatewayRunner:
                     if mtype.startswith("image/"):
                         image_paths.append(path)
                 if image_paths:
-                    try:
-                        enriched_prompt = await self._enrich_message_with_vision(
-                            prompt, image_paths,
+                    _img_mode = self._decide_image_input_mode()
+                    if _img_mode == "native":
+                        try:
+                            from agent.image_routing import build_native_content_parts
+
+                            _parts, _skipped = build_native_content_parts(
+                                prompt,
+                                image_paths,
+                            )
+                            if _skipped:
+                                logger.warning(
+                                    "Background task native image attachment skipped %d unreadable path(s): %s",
+                                    len(_skipped), _skipped,
+                                )
+                            if any(p.get("type") == "image_url" for p in _parts):
+                                logger.info(
+                                    "Background task image routing: native (model supports vision). Attaching %d image(s) inline.",
+                                    len(image_paths),
+                                )
+                                enriched_prompt = _parts
+                            else:
+                                logger.warning(
+                                    "Background task native image attachment produced no readable images; falling back to text vision enrichment."
+                                )
+                                enriched_prompt = await self._enrich_message_with_vision(
+                                    prompt,
+                                    image_paths,
+                                )
+                        except Exception as e:
+                            logger.warning(
+                                "Background task native image attachment failed; falling back to text vision enrichment: %s",
+                                e,
+                            )
+                            try:
+                                enriched_prompt = await self._enrich_message_with_vision(
+                                    prompt,
+                                    image_paths,
+                                )
+                            except Exception as enrich_exc:
+                                logger.warning(
+                                    "Background task vision enrichment failed after native attach fallback: %s",
+                                    enrich_exc,
+                                )
+                    else:
+                        logger.info(
+                            "Background task image routing: text (mode=%s). Pre-analyzing %d image(s) via vision_analyze.",
+                            _img_mode, len(image_paths),
                         )
-                    except Exception as e:
-                        logger.warning("Background task vision enrichment failed: %s", e)
+                        try:
+                            enriched_prompt = await self._enrich_message_with_vision(
+                                prompt,
+                                image_paths,
+                            )
+                        except Exception as e:
+                            logger.warning("Background task vision enrichment failed: %s", e)
 
             def run_sync():
                 agent = AIAgent(

--- a/tests/gateway/test_background_command.py
+++ b/tests/gateway/test_background_command.py
@@ -269,6 +269,129 @@ class TestRunBackgroundTask:
         mock_agent_instance.close.assert_called_once()
 
     @pytest.mark.asyncio
+    async def test_image_attachment_uses_native_routing_when_model_supports_vision(self, monkeypatch):
+        """Background tasks should mirror the native image path used by the main gateway flow."""
+        from gateway import run as gateway_run
+
+        runner = _make_runner()
+        runner._decide_image_input_mode = MagicMock(return_value="native")
+        runner._enrich_message_with_vision = AsyncMock(return_value="should not be used")
+        runner._resolve_session_agent_runtime = MagicMock(
+            return_value=("test-model", {"api_key": "test-key"})
+        )
+        runner._resolve_session_reasoning_config = MagicMock(return_value=None)
+        runner._load_service_tier = MagicMock(return_value=None)
+        runner._resolve_turn_agent_config = MagicMock(
+            return_value={
+                "model": "test-model",
+                "runtime": {"api_key": "test-key"},
+                "request_overrides": None,
+            }
+        )
+        runner._run_in_executor_with_context = AsyncMock(side_effect=lambda fn: fn())
+        monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda: {})
+
+        mock_adapter = AsyncMock()
+        mock_adapter.send = AsyncMock()
+        mock_adapter.extract_media = MagicMock(return_value=([], "done"))
+        mock_adapter.extract_images = MagicMock(return_value=([], "done"))
+        runner.adapters[Platform.TELEGRAM] = mock_adapter
+
+        source = SessionSource(
+            platform=Platform.TELEGRAM,
+            user_id="12345",
+            chat_id="67890",
+            user_name="testuser",
+        )
+        native_parts = [
+            {"type": "text", "text": "test prompt\n\n[Image attached at: /tmp/img.png]"},
+            {"type": "image_url", "image_url": {"url": "data:image/png;base64,ZmFrZQ==" }},
+        ]
+
+        with patch("agent.image_routing.build_native_content_parts", return_value=(native_parts, [])), \
+             patch("run_agent.AIAgent") as MockAgent:
+            mock_agent_instance = MagicMock()
+            mock_agent_instance.shutdown_memory_provider = MagicMock()
+            mock_agent_instance.close = MagicMock()
+            mock_agent_instance.run_conversation.return_value = {
+                "final_response": "done",
+                "messages": [],
+            }
+            MockAgent.return_value = mock_agent_instance
+
+            await runner._run_background_task(
+                "test prompt",
+                source,
+                "bg_test",
+                media_urls=["/tmp/img.png"],
+                media_types=["image/png"],
+            )
+
+        runner._decide_image_input_mode.assert_called_once_with()
+        runner._enrich_message_with_vision.assert_not_awaited()
+        assert mock_agent_instance.run_conversation.call_args.kwargs["user_message"] == native_parts
+
+    @pytest.mark.asyncio
+    async def test_image_attachment_uses_text_routing_when_native_mode_not_selected(self, monkeypatch):
+        """Background tasks should keep the existing text pipeline for non-native routes."""
+        from gateway import run as gateway_run
+
+        runner = _make_runner()
+        runner._decide_image_input_mode = MagicMock(return_value="text")
+        runner._enrich_message_with_vision = AsyncMock(return_value="enriched prompt")
+        runner._resolve_session_agent_runtime = MagicMock(
+            return_value=("test-model", {"api_key": "test-key"})
+        )
+        runner._resolve_session_reasoning_config = MagicMock(return_value=None)
+        runner._load_service_tier = MagicMock(return_value=None)
+        runner._resolve_turn_agent_config = MagicMock(
+            return_value={
+                "model": "test-model",
+                "runtime": {"api_key": "test-key"},
+                "request_overrides": None,
+            }
+        )
+        runner._run_in_executor_with_context = AsyncMock(side_effect=lambda fn: fn())
+        monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda: {})
+
+        mock_adapter = AsyncMock()
+        mock_adapter.send = AsyncMock()
+        mock_adapter.extract_media = MagicMock(return_value=([], "done"))
+        mock_adapter.extract_images = MagicMock(return_value=([], "done"))
+        runner.adapters[Platform.TELEGRAM] = mock_adapter
+
+        source = SessionSource(
+            platform=Platform.TELEGRAM,
+            user_id="12345",
+            chat_id="67890",
+            user_name="testuser",
+        )
+
+        with patch("agent.image_routing.build_native_content_parts") as mock_build_parts, \
+             patch("run_agent.AIAgent") as MockAgent:
+            mock_agent_instance = MagicMock()
+            mock_agent_instance.shutdown_memory_provider = MagicMock()
+            mock_agent_instance.close = MagicMock()
+            mock_agent_instance.run_conversation.return_value = {
+                "final_response": "done",
+                "messages": [],
+            }
+            MockAgent.return_value = mock_agent_instance
+
+            await runner._run_background_task(
+                "test prompt",
+                source,
+                "bg_test",
+                media_urls=["/tmp/img.png"],
+                media_types=["image/png"],
+            )
+
+        runner._decide_image_input_mode.assert_called_once_with()
+        runner._enrich_message_with_vision.assert_awaited_once_with("test prompt", ["/tmp/img.png"])
+        mock_build_parts.assert_not_called()
+        assert mock_agent_instance.run_conversation.call_args.kwargs["user_message"] == "enriched prompt"
+
+    @pytest.mark.asyncio
     async def test_telegram_dm_topic_completion_preserves_reply_anchor_metadata(self, monkeypatch):
         """Background completion metadata must let Telegram send thread id plus reply id."""
         from gateway import run as gateway_run


### PR DESCRIPTION
## Summary

This fixes an image-routing inconsistency in the gateway `/background` flow.

Recent fixes established the invariant that inbound user images should go through a single routing decision:
- native multimodal attachment when the active model supports vision
- `vision_analyze` text enrichment otherwise

The main gateway flow and the quiet CLI path already honor that invariant, but `/background` did not. When a user attached an image to `/background`, the gateway always forced the text pipeline, even for vision-capable models.

## Problem

`GatewayRunner._run_background_task()` unconditionally called `_enrich_message_with_vision()` for attached images.

That meant `/background` ignored the shared image-routing decision and always converted images into a lossy text summary instead of passing native image parts to the model.

User-visible impact:
- unnecessary `vision_analyze` work on vision-capable models
- slower background tasks
- extra cost
- the model sees a summary instead of the actual pixels

## Root Cause

The background-task code path had drifted from the main gateway/CLI image ingress behavior.

Sibling paths already route through the shared decision:
- main gateway flow decides native vs text before calling `run_conversation()`
- quiet CLI `--image` path was fixed recently to do the same

`/background` was still using the old unconditional text-enrichment path.

## Fix

Mirror the established routing behavior inside `_run_background_task()`:

- call `self._decide_image_input_mode()`
- if the mode is `native`, build OpenAI-style multimodal content with `build_native_content_parts()`
- if native attachment fails or produces no readable images, fall back to `_enrich_message_with_vision()`
- if the mode is `text`, preserve the existing vision-enrichment behavior

This keeps `/background` aligned with the current single-source-of-truth image-routing behavior without changing the non-native path.

## Tests

Added regression coverage in `tests/gateway/test_background_command.py`:

- `test_image_attachment_uses_native_routing_when_model_supports_vision`
  - verifies `/background` does **not** call `_enrich_message_with_vision()`
  - verifies native content parts are passed to `run_conversation()`

- `test_image_attachment_uses_text_routing_when_native_mode_not_selected`
  - verifies the existing text-enrichment path is preserved
  - verifies native part-building is not used in text mode

## Test Results

Ran locally:

```bash
python -m pytest tests/gateway/test_background_command.py -q --timeout-method=thread
23 passed in 2.34s

python -m pytest tests/gateway/test_native_image_buffer_isolation.py tests/agent/test_image_routing.py -q --timeout-method=thread
59 passed in 1.06s
