### PR TITLE
fix(cron): reject missing cron scripts at create-time with scheduler-host hint

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -896,7 +896,11 @@ def _run_job_script(script_path: str) -> tuple[bool, str]:
         )
 
     if not path.exists():
-        return False, f"Script not found: {path}"
+        return False, (
+            f"Script not found on scheduler host: {path}. "
+            "Cron scripts always execute on the scheduler host; "
+            "`terminal.backend` (SSH/Docker/etc.) is not honoured for cron scripts."
+        )
     if not path.is_file():
         return False, f"Script path is not a file: {path}"
 

--- a/tests/cron/test_cron_script.py
+++ b/tests/cron/test_cron_script.py
@@ -222,6 +222,8 @@ class TestCronjobToolScript:
         monkeypatch.setenv("HERMES_INTERACTIVE", "1")
         from tools.cronjob_tools import cronjob
 
+        (cron_env / "scripts" / "monitor.py").write_text("print('hi')\n")
+
         result = json.loads(cronjob(
             action="create",
             schedule="every 1h",
@@ -234,6 +236,8 @@ class TestCronjobToolScript:
     def test_update_script(self, cron_env, monkeypatch):
         monkeypatch.setenv("HERMES_INTERACTIVE", "1")
         from tools.cronjob_tools import cronjob
+
+        (cron_env / "scripts" / "new_script.py").write_text("print('hi')\n")
 
         create_result = json.loads(cronjob(
             action="create",
@@ -253,6 +257,8 @@ class TestCronjobToolScript:
     def test_clear_script(self, cron_env, monkeypatch):
         monkeypatch.setenv("HERMES_INTERACTIVE", "1")
         from tools.cronjob_tools import cronjob
+
+        (cron_env / "scripts" / "some_script.py").write_text("print('hi')\n")
 
         create_result = json.loads(cronjob(
             action="create",
@@ -274,6 +280,8 @@ class TestCronjobToolScript:
         monkeypatch.setenv("HERMES_INTERACTIVE", "1")
         from tools.cronjob_tools import cronjob
 
+        (cron_env / "scripts" / "data_collector.py").write_text("print('hi')\n")
+
         cronjob(
             action="create",
             schedule="every 1h",
@@ -285,6 +293,60 @@ class TestCronjobToolScript:
         assert list_result["success"] is True
         assert len(list_result["jobs"]) == 1
         assert list_result["jobs"][0]["script"] == "data_collector.py"
+
+
+class TestScriptMissingOnSchedulerHost:
+    """Regression tests for #29849 — script existence on the scheduler host.
+
+    `terminal.backend` (SSH/Docker/etc.) is not honoured for cron scripts;
+    they always execute locally. Surface this at both the API boundary
+    (creation time) and the runtime "Script not found" message so users
+    targeting a remote backend get a clear diagnostic instead of a generic
+    file-not-found at the next tick.
+    """
+
+    def test_create_missing_script_rejected_with_scheduler_host_hint(self, cron_env, monkeypatch):
+        monkeypatch.setenv("HERMES_INTERACTIVE", "1")
+        from tools.cronjob_tools import cronjob
+
+        result = json.loads(cronjob(
+            action="create",
+            schedule="every 1h",
+            prompt="Monitor things",
+            script="missing.sh",
+        ))
+        assert result["success"] is False
+        msg = result.get("error", "")
+        assert "Script not found on scheduler host" in msg
+        assert "terminal.backend" in msg
+
+    def test_update_missing_script_rejected(self, cron_env, monkeypatch):
+        monkeypatch.setenv("HERMES_INTERACTIVE", "1")
+        from tools.cronjob_tools import cronjob
+
+        create_result = json.loads(cronjob(
+            action="create",
+            schedule="every 1h",
+            prompt="Monitor things",
+        ))
+        job_id = create_result["job_id"]
+
+        update_result = json.loads(cronjob(
+            action="update",
+            job_id=job_id,
+            script="never_written.py",
+        ))
+        assert update_result["success"] is False
+        assert "Script not found on scheduler host" in update_result.get("error", "")
+
+    def test_run_missing_script_message_mentions_scheduler_host(self, cron_env):
+        """Runtime path is also self-explaining when a script was deleted between create and tick."""
+        from cron.scheduler import _run_job_script
+
+        success, output = _run_job_script("disappeared.sh")
+        assert success is False
+        assert "Script not found on scheduler host" in output
+        assert "terminal.backend" in output
 
 
 class TestScriptPathContainment:
@@ -441,6 +503,8 @@ class TestCronjobToolScriptValidation:
         monkeypatch.setenv("HERMES_INTERACTIVE", "1")
         from tools.cronjob_tools import cronjob
 
+        (cron_env / "scripts" / "monitor.py").write_text("print('hi')\n")
+
         result = json.loads(cronjob(
             action="create",
             schedule="every 1h",
@@ -473,6 +537,8 @@ class TestCronjobToolScriptValidation:
         """Clearing a script (empty string) should always be permitted."""
         monkeypatch.setenv("HERMES_INTERACTIVE", "1")
         from tools.cronjob_tools import cronjob
+
+        (cron_env / "scripts" / "monitor.py").write_text("print('hi')\n")
 
         create_result = json.loads(cronjob(
             action="create",

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -343,16 +343,23 @@ def _normalize_deliver_param(value: Any) -> Optional[str]:
 def _validate_cron_script_path(script: Optional[str]) -> Optional[str]:
     """Validate a cron job script path at the API boundary.
 
-    Scripts must be relative paths that resolve within HERMES_HOME/scripts/.
+    Scripts must be relative paths that resolve within HERMES_HOME/scripts/
+    *and* exist on the scheduler host's filesystem at validation time.
     Absolute paths and ~ expansion are rejected to prevent arbitrary script
     execution via prompt injection.
+
+    The existence check catches the surprise documented in #29849: cron
+    scripts always run on the scheduler host, independent of
+    ``terminal.backend`` — silently scheduling a job that points at a file
+    only present on a remote backend means the job fails at runtime with
+    a generic "Script not found" instead of at creation.
 
     Returns an error string if blocked, else None (valid).
     """
     if not script or not script.strip():
         return None  # empty/None = clearing the field, always OK
 
-    from hermes_constants import get_hermes_home
+    from hermes_constants import display_hermes_home, get_hermes_home
 
     raw = script.strip()
 
@@ -360,9 +367,9 @@ def _validate_cron_script_path(script: Optional[str]) -> Optional[str]:
     # Only relative paths within ~/.hermes/scripts/ are allowed.
     if raw.startswith(("/", "~")) or (len(raw) >= 2 and raw[1] == ":"):
         return (
-            f"Script path must be relative to ~/.hermes/scripts/. "
+            f"Script path must be relative to {display_hermes_home()}/scripts/. "
             f"Got absolute or home-relative path: {raw!r}. "
-            f"Place scripts in ~/.hermes/scripts/ and use just the filename."
+            f"Place scripts in {display_hermes_home()}/scripts/ and use just the filename."
         )
 
     # Validate containment after resolution
@@ -374,6 +381,18 @@ def _validate_cron_script_path(script: Optional[str]) -> Optional[str]:
     if containment_error:
         return (
             f"Script path escapes the scripts directory via traversal: {raw!r}"
+        )
+
+    # Existence check on the scheduler host — cron scripts always execute
+    # locally, so the file must be present here even when terminal.backend
+    # points elsewhere (see #29849).
+    resolved = (scripts_dir / raw).resolve()
+    if not resolved.exists():
+        return (
+            f"Script not found on scheduler host: {display_hermes_home()}/scripts/{raw}. "
+            "Cron scripts always execute on the scheduler host; "
+            "`terminal.backend` (SSH/Docker/etc.) is not honoured for cron scripts. "
+            f"Place the file in {display_hermes_home()}/scripts/ on this host before scheduling the job."
         )
 
     return None
@@ -754,7 +773,7 @@ Important safety rule: cron-run sessions should not recursively schedule more cr
             },
             "script": {
                 "type": "string",
-                "description": f"Optional path to a script that runs each tick. In the default mode its stdout is injected into the agent's prompt as context (data-collection / change-detection pattern). With no_agent=True, the script IS the job and its stdout is delivered verbatim (classic watchdog pattern). Relative paths resolve under {display_hermes_home()}/scripts/. ``.sh``/``.bash`` extensions run via bash, everything else via Python. On update, pass empty string to clear."
+                "description": f"Optional path to a script that runs each tick. In the default mode its stdout is injected into the agent's prompt as context (data-collection / change-detection pattern). With no_agent=True, the script IS the job and its stdout is delivered verbatim (classic watchdog pattern). Relative paths resolve under {display_hermes_home()}/scripts/. The script must exist on the scheduler host at creation time — cron scripts always execute locally, independent of `terminal.backend` (SSH/Docker/etc.). ``.sh``/``.bash`` extensions run via bash, everything else via Python. On update, pass empty string to clear."
             },
             "no_agent": {
                 "type": "boolean",


### PR DESCRIPTION
## What does this PR do?

Closes the surprise from #29849: when `terminal.backend` is set to a remote backend (e.g. `ssh`) and a user creates a `no_agent=True` cron job whose script lives on that remote host, the scheduler silently accepts the job and then fails at every tick with a generic `Script not found`. Cron scripts always execute on the scheduler host; `terminal.backend` is not honoured for them.

This PR surfaces the constraint where the user actually feels it:

- `_validate_cron_script_path` in `tools/cronjob_tools.py` now requires the script to exist on the scheduler host at validation time and names the constraint explicitly in the rejection message.
- The runtime `Script not found` message in `cron/scheduler.py::_run_job_script` carries the same hint, for the case where the script is removed between scheduling and tick (or the job was created via the direct `cron.jobs.create_job` path that bypasses the API-boundary validator).
- The `script` schema docstring documents the scheduler-host execution constraint so the agent stops handing out invalid paths in the first place.

The validator runs on the API-tool boundary used by the agent and MCP clients; the WebUI/`/api/jobs` path and direct `create_job` callers retain their existing behaviour, with the runtime hint catching them on the first tick.

## Related Issue

Fixes #29849

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/cronjob_tools.py` — `_validate_cron_script_path` adds an `exists()` check after containment, and the rejection messages use `display_hermes_home()` so they're profile-safe. The `script` schema description documents scheduler-host execution.
- `cron/scheduler.py` — `_run_job_script` `Script not found` message names the scheduler-host vs `terminal.backend` distinction.
- `tests/cron/test_cron_script.py` — new `TestScriptMissingOnSchedulerHost` class with three regression cases (create rejected, update rejected, runtime message contains the hint). Four existing tests that created jobs with non-existent scripts (`TestCronjobToolScript::test_create_with_script`/`test_update_script`/`test_clear_script`/`test_list_shows_script`, and `TestCronjobToolScriptValidation::test_create_with_relative_script_allowed`/`test_update_clear_script_allowed`) now write the script file first.

## How to Test

1. Reproduce the issue: configure `terminal.backend: ssh` and ask the agent to `cronjob(action='create', no_agent=True, script='id_check.sh', schedule='0 12 * * *')` without placing `id_check.sh` in the scheduler host's `~/.hermes/scripts/`.
2. Before this PR: the create call returns `success: true`; the next tick fails with `Script not found: <path>`.
3. After this PR: the create call returns `success: false` with a message that names the scheduler-host vs `terminal.backend` constraint and tells the user where to place the file.
4. `uv run --with pytest --with pytest-xdist --with pytest-asyncio --with pytest-timeout python3 -m pytest tests/cron/test_cron_script.py -v` — 39 passed.
5. Broader regression: `uv run --with pytest --with pytest-xdist --with pytest-asyncio --with pytest-timeout python3 -m pytest tests/cron/ tests/tools/test_cronjob_tools.py tests/tools/test_cron_prompt_injection.py tests/tools/test_cron_approval_mode.py` — 458 passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run focused tests for the touched code and all pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.x

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — schema docstring and `_validate_cron_script_path` docstring
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — windows-absolute and tilde rejection paths still pass; the new existence check uses pathlib so it's portable
- [x] I've updated tool descriptions/schemas if I changed tool behavior — `cronjob` `script` schema description updated

> Sibling code paths that may need the same fix: the runtime resolver in `cron/scheduler.py::_run_job_script` already carries the matching hint. The WebUI `/api/jobs` create path in `gateway/platforms/api_server.py::_handle_create_job` does not currently accept `script` so there's nothing to mirror there today. The direct `cron.jobs.create_job` storage layer is intentionally left unguarded — the runtime hint covers users who reach it (e.g. via legacy job records or other entry points).

## Related / Positioning

This is a behavior + diagnostic fix only. It does not implement Option A from the issue (running cron scripts through the configured `terminal.backend`), which would be a structural change well outside the surgical scope. The issue's Option B (creation-time guardrail) and Option C (docs) are both addressed here.