### PR TITLE
fix(config): refuse config set on invalid yaml

### DIFF
--- a/_docs/2026-05-22_config-set-parse-hardening_codex.md
+++ b/_docs/2026-05-22_config-set-parse-hardening_codex.md
@@ -1,0 +1,44 @@
+# Config Set Parse Hardening
+
+Date: 2026-05-22
+Branch: `codex/hermes-env-config-hardening-20260522`
+
+## Summary
+
+This change hardens `hermes config set` so it refuses to write when the existing
+`config.yaml` cannot be parsed or is not a top-level mapping. The goal is to
+preserve the user's on-disk configuration instead of treating an unreadable file
+as an empty config and writing over it.
+
+## GitHub Triage
+
+Related public items:
+
+- #5214: Improve handling for locked or invalid config.yaml writes.
+- #14276: Broader open PR for config parse failure guards and recovery.
+- #29655: ruamel fallback for round-trip config writes.
+
+This PR keeps the scope narrow: only the direct `hermes config set` mutation path
+is changed, with regression tests that prove malformed or non-mapping YAML stays
+untouched.
+
+## Changes
+
+- `set_config_value()` now returns `True`/`False`.
+- Secret writes to `.env` still return success after saving.
+- Existing malformed `config.yaml` now triggers a refusal message and no write.
+- Existing non-mapping YAML now triggers a refusal message and no write.
+- Nested key navigation or write failures are surfaced without rewriting the
+  original file.
+
+## Verification
+
+```powershell
+uv run --extra dev python -m pytest -o addopts= tests/hermes_cli/test_set_config_value.py tests/cli/test_cli_save_config_value.py
+uv run --extra dev ruff check hermes_cli/config.py tests/hermes_cli/test_set_config_value.py
+```
+
+Results:
+
+- `43 passed in 9.08s`
+- `ruff` passed.

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -5192,11 +5192,11 @@ def edit_config():
     subprocess.run([editor, str(config_path)])
 
 
-def set_config_value(key: str, value: str):
+def set_config_value(key: str, value: str) -> bool:
     """Set a configuration value."""
     if is_managed():
         managed_error("set configuration values")
-        return
+        return False
     # Check if it's an API key (goes to .env)
     api_keys = [
         'OPENROUTER_API_KEY', 'OPENAI_API_KEY', 'ANTHROPIC_API_KEY', 'VOICE_TOOLS_OPENAI_KEY',
@@ -5213,7 +5213,7 @@ def set_config_value(key: str, value: str):
     if key.upper() in api_keys or key.upper().endswith(('_API_KEY', '_TOKEN')) or key.upper().startswith('TERMINAL_SSH'):
         save_env_value(key.upper(), value)
         print(f"✓ Set {key} in {get_env_path()}")
-        return
+        return True
     
     # Otherwise it goes to config.yaml
     # Read the raw user config (not merged with defaults) to avoid
@@ -5223,9 +5223,21 @@ def set_config_value(key: str, value: str):
     if config_path.exists():
         try:
             with open(config_path, encoding="utf-8") as f:
-                user_config = yaml.safe_load(f) or {}
-        except Exception:
-            user_config = {}
+                loaded_config = yaml.safe_load(f) or {}
+        except Exception as exc:
+            _warn_config_parse_failure(config_path, exc)
+            print(
+                f"✗ Refusing to update {config_path}: existing config.yaml "
+                "is not valid YAML. Fix the file and retry."
+            )
+            return False
+        if not isinstance(loaded_config, dict):
+            print(
+                f"✗ Refusing to update {config_path}: top-level YAML "
+                "must be a mapping."
+            )
+            return False
+        user_config = loaded_config
     
     # Handle nested keys (e.g., "tts.provider") including numeric list
     # indices (e.g., "custom_providers.0.api_key").  Delegates to
@@ -5242,12 +5254,16 @@ def set_config_value(key: str, value: str):
     elif value.replace('.', '', 1).isdigit():
         value = float(value)
 
-    _set_nested(user_config, key, value)
-    
-    # Write only user config back (not the full merged defaults)
-    ensure_hermes_home()
-    from utils import atomic_yaml_write
-    atomic_yaml_write(config_path, user_config, sort_keys=False)
+    try:
+        _set_nested(user_config, key, value)
+
+        # Write only user config back (not the full merged defaults)
+        ensure_hermes_home()
+        from utils import atomic_yaml_write
+        atomic_yaml_write(config_path, user_config, sort_keys=False)
+    except Exception as exc:
+        print(f"✗ Failed to set {key}: {exc}")
+        return False
     
     # Keep .env in sync for keys that terminal_tool reads directly from env vars.
     # config.yaml is authoritative, but terminal_tool only reads TERMINAL_ENV etc.
@@ -5277,6 +5293,7 @@ def set_config_value(key: str, value: str):
         save_env_value(_config_to_env_sync[key], str(value))
 
     print(f"✓ Set {key} = {value} in {config_path}")
+    return True
 
 
 # =============================================================================

--- a/tests/hermes_cli/test_set_config_value.py
+++ b/tests/hermes_cli/test_set_config_value.py
@@ -132,6 +132,28 @@ class TestConfigYamlRouting:
         assert "vercel_runtime: python3.13" in config
         assert "TERMINAL_VERCEL_RUNTIME=python3.13" in env_content
 
+    def test_malformed_yaml_is_not_overwritten(self, _isolated_hermes_home, capsys):
+        config_path = _isolated_hermes_home / "config.yaml"
+        original = "model: [unterminated\n"
+        config_path.write_text(original, encoding="utf-8")
+
+        result = set_config_value("model", "gpt-4o")
+
+        assert result is False
+        assert config_path.read_text(encoding="utf-8") == original
+        assert "Refusing to update" in capsys.readouterr().out
+
+    def test_non_mapping_yaml_is_not_overwritten(self, _isolated_hermes_home, capsys):
+        config_path = _isolated_hermes_home / "config.yaml"
+        original = "- just\n- a\n- list\n"
+        config_path.write_text(original, encoding="utf-8")
+
+        result = set_config_value("model", "gpt-4o")
+
+        assert result is False
+        assert config_path.read_text(encoding="utf-8") == original
+        assert "top-level YAML must be a mapping" in capsys.readouterr().out
+
 
 # ---------------------------------------------------------------------------
 # Empty / falsy values — regression tests for #4277


### PR DESCRIPTION
## Summary
- Refuse direct `hermes config set` writes when the existing `config.yaml` is invalid YAML.
- Refuse writes when the existing `config.yaml` is not a top-level mapping.
- Return explicit success/failure from `set_config_value()` and keep the original file untouched on refusal.

## Notes
- Related to #5214 and #14276.
- This is intentionally narrower than #14276: it only hardens the direct config-set mutation path on current main.
- No real secrets or local config content are included in the tests.

## Tests
- uv run --extra dev python -m pytest -o addopts= tests/hermes_cli/test_set_config_value.py tests/cli/test_cli_save_config_value.py
- uv run --extra dev python -m compileall hermes_cli/config.py
- uv run --extra dev ruff check hermes_cli/config.py tests/hermes_cli/test_set_config_value.py
- git diff --check
