### PR TITLE
fix(cron): require exact silent marker

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -126,8 +126,8 @@ _LEGACY_HOME_TARGET_ENV_VARS = {
 
 from cron.jobs import get_due_jobs, mark_job_run, save_job_output, advance_next_run
 
-# Sentinel: when a cron agent has nothing new to report, it can start its
-# response with this marker to suppress delivery.  Output is still saved
+# Sentinel: when a cron agent has nothing new to report, it can respond
+# exactly with this marker to suppress delivery. Output is still saved
 # locally for audit.
 SILENT_MARKER = "[SILENT]"
 
@@ -1868,14 +1868,15 @@ def tick(verbose: bool = True, adapters=None, loop=None) -> int:
                     logger.info("Output saved to: %s", output_file)
 
                 # Deliver the final response to the origin/target chat.
-                # If the agent responded with [SILENT], skip delivery (but
-                # output is already saved above).  Failed jobs always deliver.
+                # If the agent responded with exactly [SILENT], skip delivery
+                # (but output is already saved above).  Failed jobs always
+                # deliver.
                 deliver_content = final_response if success else f"⚠️ Cron job '{job.get('name', job['id'])}' failed:\n{error}"
                 # Treat whitespace-only final responses the same as empty
                 # responses: do not deliver a blank message, and let the
                 # empty-response guard below mark the run as a soft failure.
                 should_deliver = bool(deliver_content.strip())
-                if should_deliver and success and SILENT_MARKER in deliver_content.strip().upper():
+                if should_deliver and success and deliver_content.strip() == SILENT_MARKER:
                     logger.info("Job '%s': agent returned %s — skipping delivery", job["id"], SILENT_MARKER)
                     should_deliver = False
 

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -1745,6 +1745,11 @@ class TestRunJobSkillBacked:
 class TestSilentDelivery:
     """Verify that [SILENT] responses suppress delivery while still saving output."""
 
+    @pytest.fixture(autouse=True)
+    def _disable_next_run_writes(self):
+        with patch("cron.scheduler.advance_next_run"):
+            yield
+
     def _make_job(self):
         return {
             "id": "monitor-job",
@@ -1758,38 +1763,80 @@ class TestSilentDelivery:
              patch("cron.scheduler.run_job", return_value=(True, "# output", "[SILENT]", None)), \
              patch("cron.scheduler.save_job_output", return_value="/tmp/out.md"), \
              patch("cron.scheduler._deliver_result") as deliver_mock, \
-             patch("cron.scheduler.mark_job_run"):
+             patch("cron.scheduler.mark_job_run") as mark_mock:
             from cron.scheduler import tick
             with caplog.at_level(logging.INFO, logger="cron.scheduler"):
                 tick(verbose=False)
         deliver_mock.assert_not_called()
+        mark_mock.assert_called_once_with("monitor-job", True, None, delivery_error=None)
         assert any(SILENT_MARKER in r.message for r in caplog.records)
 
-    def test_silent_with_note_suppresses_delivery(self):
+    def test_silent_marker_with_extra_text_delivers(self):
+        response = "[SILENT] No changes detected"
         with patch("cron.scheduler.get_due_jobs", return_value=[self._make_job()]), \
-             patch("cron.scheduler.run_job", return_value=(True, "# output", "[SILENT] No changes detected", None)), \
+             patch("cron.scheduler.run_job", return_value=(True, "# output", response, None)), \
              patch("cron.scheduler.save_job_output", return_value="/tmp/out.md"), \
-             patch("cron.scheduler._deliver_result") as deliver_mock, \
+             patch("cron.scheduler._deliver_result", return_value=None) as deliver_mock, \
+             patch("cron.scheduler.mark_job_run") as mark_mock:
+            from cron.scheduler import tick
+            tick(verbose=False)
+        deliver_mock.assert_called_once()
+        assert deliver_mock.call_args.args[1] == response
+        mark_mock.assert_called_once_with("monitor-job", True, None, delivery_error=None)
+
+    def test_silent_marker_mentioned_in_content_delivers(self):
+        """Only an exact marker response suppresses delivery."""
+        response = "New findings found, so this report should not be `[SILENT]`."
+        with patch("cron.scheduler.get_due_jobs", return_value=[self._make_job()]), \
+             patch("cron.scheduler.run_job", return_value=(True, "# output", response, None)), \
+             patch("cron.scheduler.save_job_output", return_value="/tmp/out.md"), \
+             patch("cron.scheduler._deliver_result", return_value=None) as deliver_mock, \
              patch("cron.scheduler.mark_job_run"):
             from cron.scheduler import tick
             tick(verbose=False)
-        deliver_mock.assert_not_called()
+        deliver_mock.assert_called_once()
+        assert deliver_mock.call_args.args[1] == response
 
-    def test_silent_trailing_suppresses_delivery(self):
-        """Agent appended [SILENT] after explanation text — must still suppress."""
+    def test_silent_marker_after_content_delivers(self):
+        """A report ending with the marker is still content, not a silent run."""
         response = "2 deals filtered out (like<10, reply<15).\n\n[SILENT]"
         with patch("cron.scheduler.get_due_jobs", return_value=[self._make_job()]), \
              patch("cron.scheduler.run_job", return_value=(True, "# output", response, None)), \
              patch("cron.scheduler.save_job_output", return_value="/tmp/out.md"), \
-             patch("cron.scheduler._deliver_result") as deliver_mock, \
+             patch("cron.scheduler._deliver_result", return_value=None) as deliver_mock, \
              patch("cron.scheduler.mark_job_run"):
             from cron.scheduler import tick
             tick(verbose=False)
-        deliver_mock.assert_not_called()
+        deliver_mock.assert_called_once()
+        assert deliver_mock.call_args.args[1] == response
 
-    def test_silent_is_case_insensitive(self):
+    def test_lowercase_silent_marker_with_extra_text_delivers(self):
+        response = "[silent] nothing new"
         with patch("cron.scheduler.get_due_jobs", return_value=[self._make_job()]), \
-             patch("cron.scheduler.run_job", return_value=(True, "# output", "[silent] nothing new", None)), \
+             patch("cron.scheduler.run_job", return_value=(True, "# output", response, None)), \
+             patch("cron.scheduler.save_job_output", return_value="/tmp/out.md"), \
+             patch("cron.scheduler._deliver_result", return_value=None) as deliver_mock, \
+             patch("cron.scheduler.mark_job_run"):
+            from cron.scheduler import tick
+            tick(verbose=False)
+        deliver_mock.assert_called_once()
+        assert deliver_mock.call_args.args[1] == response
+
+    def test_lowercase_silent_marker_delivers(self):
+        response = "[silent]"
+        with patch("cron.scheduler.get_due_jobs", return_value=[self._make_job()]), \
+             patch("cron.scheduler.run_job", return_value=(True, "# output", response, None)), \
+             patch("cron.scheduler.save_job_output", return_value="/tmp/out.md"), \
+             patch("cron.scheduler._deliver_result", return_value=None) as deliver_mock, \
+             patch("cron.scheduler.mark_job_run"):
+            from cron.scheduler import tick
+            tick(verbose=False)
+        deliver_mock.assert_called_once()
+        assert deliver_mock.call_args.args[1] == response
+
+    def test_whitespace_wrapped_silent_marker_suppresses_delivery(self):
+        with patch("cron.scheduler.get_due_jobs", return_value=[self._make_job()]), \
+             patch("cron.scheduler.run_job", return_value=(True, "# output", "  [SILENT]\n", None)), \
              patch("cron.scheduler.save_job_output", return_value="/tmp/out.md"), \
              patch("cron.scheduler._deliver_result") as deliver_mock, \
              patch("cron.scheduler.mark_job_run"):
@@ -1799,14 +1846,16 @@ class TestSilentDelivery:
 
     def test_failed_job_always_delivers(self):
         """Failed jobs deliver regardless of [SILENT] in output."""
+        error = "[SILENT] provider failed"
         with patch("cron.scheduler.get_due_jobs", return_value=[self._make_job()]), \
-             patch("cron.scheduler.run_job", return_value=(False, "# output", "", "some error")), \
+             patch("cron.scheduler.run_job", return_value=(False, "# output", "", error)), \
              patch("cron.scheduler.save_job_output", return_value="/tmp/out.md"), \
-             patch("cron.scheduler._deliver_result") as deliver_mock, \
+             patch("cron.scheduler._deliver_result", return_value=None) as deliver_mock, \
              patch("cron.scheduler.mark_job_run"):
             from cron.scheduler import tick
             tick(verbose=False)
         deliver_mock.assert_called_once()
+        assert error in deliver_mock.call_args.args[1]
 
     def test_output_saved_even_when_delivery_suppressed(self):
         with patch("cron.scheduler.get_due_jobs", return_value=[self._make_job()]), \
@@ -1847,6 +1896,12 @@ class TestBuildJobPromptSilentHint:
         result = _build_job_prompt(job)
         assert "[SILENT]" in result
         assert "Check for updates" in result
+
+    def test_silent_guidance_requires_exact_marker_response(self):
+        job = {"prompt": "Check for updates"}
+        result = _build_job_prompt(job)
+        assert 'with exactly "[SILENT]" (nothing else)' in result
+        assert "Never combine [SILENT] with content" in result
 
     def test_hint_present_even_without_prompt(self):
         job = {"prompt": ""}


### PR DESCRIPTION
## What does this PR do?

Cron delivery suppression currently treats any successful final response containing `[SILENT]` as a silent run. That can swallow legitimate reports that mention the marker in explanatory text.

This changes cron delivery suppression to only skip delivery when the final response is exactly `[SILENT]` after trimming surrounding whitespace. Any extra content, including `[SILENT] No changes detected`, lowercase `[silent]`, a report that mentions `[SILENT]`, a report ending with `[SILENT]`, or a failed-job error containing `[SILENT]`, is delivered normally.

Historical context:

- #5023 requested platform-level `[SILENT]` suppression and explicitly listed exact stripped `[SILENT]` matching as the first filter rule.
- #4308 previously proposed the exact-match approach.
- #5654 broadened suppression to marker-anywhere matching, which fixed trailing-marker suppression but also introduced false positives for legitimate reports that mention `[SILENT]`.
- #15649 covers the same exact-match repair, but it is currently conflicting with `main` (`mergeable=CONFLICTING`, `mergeStateStatus=DIRTY`) and has not been updated since 2026-04-25.

This PR is a fresh, narrowly scoped replacement on current `origin/main`.

## Related Issue

Related: #5023, #4308, #5654, #15649.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `cron/scheduler.py`: change `[SILENT]` suppression from substring detection to exact trimmed marker matching.
- `tests/cron/test_scheduler.py`: update silent-delivery coverage so marker mentions, marker-plus-content, trailing marker content, failed-job marker content, and lowercase marker variants are delivered, while whitespace-wrapped exact `[SILENT]` still suppresses delivery.
- `tests/cron/test_scheduler.py`: assert delivered content and successful `mark_job_run` recording for representative silent and non-silent cases.
- `tests/cron/test_scheduler.py`: isolate `TestSilentDelivery` from `advance_next_run` cron-store writes.
- `tests/cron/test_scheduler.py`: pin the cron prompt wording that tells agents to respond with exactly `[SILENT]` and not combine it with content.

## How to Test

1. `scripts/run_tests.sh tests/cron/test_scheduler.py`
2. `scripts/run_tests.sh tests/cron`
3. `python -m ruff check cron/scheduler.py tests/cron/test_scheduler.py`
4. `git diff --check`
5. `scripts/run_tests.sh` (attempted full suite; see logs below)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.3.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A.

## Screenshots / Logs

```text
scripts/run_tests.sh tests/cron/test_scheduler.py
=== Summary: 1 files, 131 tests passed, 0 failed (100% complete) in 3.8s (16 workers) ===

scripts/run_tests.sh tests/cron
=== Summary: 14 files, 377 tests passed, 0 failed (100% complete) in 10.9s (16 workers) ===

python -m ruff check cron/scheduler.py tests/cron/test_scheduler.py
All checks passed!

git diff --check
# no output
```

Full-suite note:

```text
scripts/run_tests.sh
# attempted on macOS 26.3.1; did not pass in this local environment
=== 12 files with test failures (29 tests failed) ===
=== 12 files where no tests ran (collection/import error, timeout before collection, etc.) ===
```

The full-suite failures appear outside this PR's cron scheduler scope and are local environment/platform related, including missing optional ACP/MCP symbols/imports, macOS systemd/systemctl expectations, local AWS/provider credential behavior, browser executable availability, and PTY support fallback behavior.
