### PR TITLE
feat: add static doctor and cron preflight

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -1586,6 +1586,7 @@ def create_job(
     attach_to_session: Optional[bool] = None,
     monitor_script: Optional[str] = None,
     monitor_url: Optional[str] = None,
+    smoke: Optional[Dict[str, Any]] = None,
 ) -> Dict[str, Any]:
     """
     Create a new cron job.
@@ -1679,6 +1680,12 @@ def create_job(
     normalized_monitor_script = normalized_monitor_script or None
     normalized_monitor_url = str(monitor_url).strip() if isinstance(monitor_url, str) else None
     normalized_monitor_url = normalized_monitor_url or None
+    if smoke is not None:
+        from hermes_cli.reliability_doctor import validate_smoke_spec
+
+        normalized_smoke = validate_smoke_spec(smoke)
+    else:
+        normalized_smoke = None
 
     # Monitor-mode validation: exactly one source, and monitor mode only
     # makes sense when there IS an agent to suppress/wake.
@@ -1783,6 +1790,8 @@ def create_job(
     # global cron.mirror_delivery config, default off).
     if normalized_attach is not None:
         job["attach_to_session"] = normalized_attach
+    if normalized_smoke is not None:
+        job["smoke"] = normalized_smoke
 
     with _jobs_lock():
         jobs = load_jobs()
@@ -1857,6 +1866,7 @@ def list_jobs(include_disabled: bool = False) -> List[Dict[str, Any]]:
 
 def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]:
     """Update a job by ID, refreshing derived schedule fields when needed."""
+    updates = dict(updates or {})
     # Block mutation of immutable fields. ``id`` in particular is a filesystem
     # path component under OUTPUT_DIR — letting an update change it leaks
     # path-escape values into output writes/deletes.
@@ -1865,6 +1875,11 @@ def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]
         raise ValueError(
             f"Cron job field(s) cannot be updated: {', '.join(sorted(bad_fields))}"
         )
+    clear_smoke = "smoke" in updates and updates["smoke"] is None
+    if "smoke" in updates and updates["smoke"] is not None:
+        from hermes_cli.reliability_doctor import validate_smoke_spec
+
+        updates["smoke"] = validate_smoke_spec(updates["smoke"])
 
     with _jobs_lock():
         jobs = load_jobs()
@@ -1891,7 +1906,6 @@ def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]
 
             previous_inference_axes = _normalized_inference_axes(job)
             updated = _apply_skill_fields({**job, **updates})
-
             # Re-check execution-mode invariants on the MERGED record when
             # any participating field changes, so create-time invariants
             # can't be violated through the update door (e.g. flipping
@@ -1908,6 +1922,8 @@ def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]
                     bool(updated.get("no_agent")),
                     _upd_script or None,
                 )
+            if clear_smoke:
+                updated.pop("smoke", None)
             schedule_changed = "schedule" in updates
             inference_fields_changed = bool(
                 {"provider", "model", "base_url", "no_agent"}.intersection(updates)

--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -9,11 +9,18 @@ import json
 import sys
 from pathlib import Path
 from typing import Iterable, List, Optional
+import yaml
 
 PROJECT_ROOT = Path(__file__).parent.parent.resolve()
 sys.path.insert(0, str(PROJECT_ROOT))
 
 from hermes_cli.colors import Colors, color
+from hermes_cli.reliability_doctor import (
+    DiagnosticResult,
+    diagnose_cron,
+    render_diagnostic_text,
+    validate_smoke_spec,
+)
 
 # Gateway-lifecycle command detection lives in ``cron.lifecycle_guard`` so it
 # can be shared across every job-creation path (CLI + the agent's ``cronjob``
@@ -46,6 +53,25 @@ def _cron_api(**kwargs):
     from tools.cronjob_tools import cronjob as cronjob_tool
 
     return json.loads(cronjob_tool(**kwargs))
+
+
+def _load_smoke_file(path: str) -> dict:
+    smoke_path = Path(path).expanduser()
+    raw = smoke_path.read_bytes()
+    if len(raw) > 256 * 1024:
+        raise ValueError("smoke file is larger than 256 KiB")
+    data = yaml.safe_load(raw.decode("utf-8"))
+    return validate_smoke_spec(data)
+
+
+def _run_saved_job_preflight(job_id: str, *, strict: bool) -> int:
+    results = diagnose_cron(job_id)
+    print(render_diagnostic_text(results))
+    failed = any(result.status == "fail" for result in results)
+    if not failed:
+        return 0
+    print("Job saved. Preflight failed.")
+    return 1 if strict else 0
 
 
 def _active_cron_provider_name() -> str:
@@ -348,6 +374,13 @@ def cron_create(args):
     # raises GatewayLifecycleBlocked, the `cronjob` tool wrapper catches it and
     # returns it as result["error"], and the `if not result.get("success")`
     # branch below prints it in red and exits 1 — same UX as before.
+    smoke = None
+    if getattr(args, "smoke_file", None):
+        try:
+            smoke = _load_smoke_file(args.smoke_file)
+        except Exception as e:
+            print(color(f"Failed to load smoke file: {e}", Colors.RED))
+            return 1
     result = _cron_api(
         action="create",
         schedule=args.schedule,
@@ -364,6 +397,7 @@ def cron_create(args):
         no_agent=getattr(args, "no_agent", False) or None,
         monitor_script=getattr(args, "monitor_script", None),
         monitor_url=getattr(args, "monitor_url", None),
+        smoke=smoke,
     )
     if not result.get("success"):
         print(color(f"Failed to create job: {result.get('error', 'unknown error')}", Colors.RED))
@@ -386,7 +420,12 @@ def cron_create(args):
         print(f"  Workdir: {job_data['workdir']}")
     print(f"  Next run: {result['next_run_at']}")
     _warn_if_gateway_not_running()
-    return 0
+    if getattr(args, "skip_preflight", False):
+        return 0
+    return _run_saved_job_preflight(
+        result["job_id"],
+        strict=bool(getattr(args, "strict_preflight", False)),
+    )
 
 
 def cron_edit(args):
@@ -402,6 +441,21 @@ def cron_edit(args):
     if not job:
         print(color(f"Job not found: {args.job_id}", Colors.RED))
         return 1
+    if getattr(args, "smoke_file", None) and getattr(args, "clear_smoke", False):
+        print(color("--smoke-file cannot be used with --clear-smoke", Colors.RED))
+        return 1
+    smoke_update = None
+    smoke_supplied = False
+    if getattr(args, "smoke_file", None):
+        try:
+            smoke_update = _load_smoke_file(args.smoke_file)
+            smoke_supplied = True
+        except Exception as e:
+            print(color(f"Failed to load smoke file: {e}", Colors.RED))
+            return 1
+    elif getattr(args, "clear_smoke", False):
+        smoke_update = {}
+        smoke_supplied = True
 
     existing_skills = list(job.get("skills") or ([] if not job.get("skill") else [job.get("skill")]))
     replacement_skills = _normalize_skills(getattr(args, "skill", None), getattr(args, "skills", None))
@@ -435,6 +489,7 @@ def cron_edit(args):
         no_agent=getattr(args, "no_agent", None),
         monitor_script=getattr(args, "monitor_script", None),
         monitor_url=getattr(args, "monitor_url", None),
+        smoke=smoke_update if smoke_supplied else None,
     )
     if not result.get("success"):
         print(color(f"Failed to update job: {result.get('error', 'unknown error')}", Colors.RED))
@@ -458,7 +513,12 @@ def cron_edit(args):
         print("  Mode: no-agent (script stdout delivered directly)")
     if updated.get("workdir"):
         print(f"  Workdir: {updated['workdir']}")
-    return 0
+    if getattr(args, "skip_preflight", False):
+        return 0
+    return _run_saved_job_preflight(
+        updated["job_id"],
+        strict=bool(getattr(args, "strict_preflight", False)),
+    )
 
 
 def _job_action(action: str, job_id: str, success_verb: str) -> int:

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -35,6 +35,14 @@ from hermes_cli.models import _HERMES_USER_AGENT
 from hermes_cli.vercel_auth import describe_vercel_auth
 from hermes_constants import OPENROUTER_MODELS_URL
 from utils import base_url_host_matches
+from hermes_cli.reliability_doctor import (
+    diagnose_all_crons,
+    diagnose_all_skills,
+    diagnose_cron,
+    diagnose_skill,
+    render_diagnostic_json,
+    render_diagnostic_text,
+)
 
 
 _PROVIDER_ENV_HINTS = (
@@ -902,6 +910,9 @@ def run_doctor(args):
     # Doctor runs from the interactive CLI, so CLI-gated tool availability
     # checks (like cronjob management) should see the same context as `hermes`.
     os.environ.setdefault("HERMES_INTERACTIVE", "1")
+
+    if getattr(args, "doctor_target", None):
+        return _run_targeted_doctor(args)
 
     # Handle `hermes doctor --ack <id>` as a fast path. Persist the ack and
     # return without running the rest of the diagnostics — the user has
@@ -2998,8 +3009,46 @@ def run_doctor(args):
         print()
         if not should_fix:
             print(color("  Tip: run 'hermes doctor --fix' to auto-fix what's possible.", Colors.DIM))
+
     else:
         print(color("─" * 60, Colors.GREEN))
         print(color("  All checks passed! 🎉", Colors.GREEN, Colors.BOLD))
     
     print()
+
+
+def _run_targeted_doctor(args) -> int:
+    target_type = getattr(args, "doctor_target", None)
+    target = getattr(args, "target", None)
+    all_targets = bool(getattr(args, "all", False))
+    as_json = bool(getattr(args, "json", False))
+    if bool(target) == all_targets:
+        print("Specify exactly one target or --all.")
+        return 2
+
+    if target_type == "skill":
+        results = (
+            diagnose_all_skills() if all_targets else diagnose_skill(target)
+        )
+    elif target_type == "cron":
+        results = (
+            diagnose_all_crons() if all_targets else diagnose_cron(target)
+        )
+    else:
+        print("Unknown doctor target.")
+        return 2
+
+    if as_json:
+        print(render_diagnostic_json(results))
+    else:
+        print(render_diagnostic_text(results))
+
+    flat = []
+    if isinstance(results, dict):
+        for items in results.values():
+            flat.extend(items)
+    else:
+        flat = list(results)
+    if any(item.reason == "cron_ref_ambiguous" for item in flat):
+        return 2
+    return 1 if any(item.status == "fail" for item in flat) else 0

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -4632,7 +4632,7 @@ def cmd_cron(args):
     """Cron job management."""
     from hermes_cli.cron import cron_command
 
-    cron_command(args)
+    return cron_command(args)
 
 
 def cmd_sync(args):
@@ -4896,7 +4896,7 @@ def cmd_doctor(args):
     """Check configuration and dependencies."""
     from hermes_cli.doctor import run_doctor
 
-    run_doctor(args)
+    return run_doctor(args)
 
 
 def cmd_verify(args):

--- a/hermes_cli/reliability_doctor.py
+++ b/hermes_cli/reliability_doctor.py
@@ -1,0 +1,636 @@
+"""Static reliability diagnostics and safe smoke declarations.
+
+This module is intentionally side-effect light: it validates declarations and
+returns structured results, but it does not print CLI output or mutate cron
+state.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+import shutil
+import sys
+import json
+import os
+from dataclasses import asdict, dataclass
+from importlib.machinery import PathFinder
+from pathlib import Path, PurePosixPath
+from typing import Any, Mapping, cast
+
+from cron.jobs import AmbiguousJobReference, list_jobs, resolve_job_ref
+from hermes_cli.config import get_hermes_home
+from tools.skills_tool import (
+    _collect_prerequisite_values,
+    _find_all_skills,
+    _get_required_environment_variables,
+    skill_view,
+)
+
+
+SMOKE_VERSION = 1
+MAX_PROBES = 32
+MAX_TEXT_LENGTH = 512
+ALLOWED_PROBE_TYPES = {
+    "command-exists",
+    "env-present",
+    "file-exists",
+    "directory-exists",
+    "python-import",
+    "mcp-configured",
+}
+ALLOWED_ROOTS = {"hermes_home", "scripts_dir", "workdir", "skill_dir"}
+
+_COMMON_FIELDS = {"type"}
+_FIELDS_BY_TYPE = {
+    "command-exists": _COMMON_FIELDS | {"name"},
+    "env-present": _COMMON_FIELDS | {"name"},
+    "file-exists": _COMMON_FIELDS | {"root", "path"},
+    "directory-exists": _COMMON_FIELDS | {"root", "path"},
+    "python-import": _COMMON_FIELDS | {"module"},
+    "mcp-configured": _COMMON_FIELDS | {"server"},
+}
+_IDENT_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_.-]*$")
+_MODULE_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z_][A-Za-z0-9_]*)*$")
+_INVISIBLE_CODEPOINTS = {
+    "\u200b",
+    "\u200c",
+    "\u200d",
+    "\u2060",
+    "\ufeff",
+    "\u2061",
+    "\u2062",
+    "\u2063",
+    "\u2064",
+    "\u2066",
+    "\u2067",
+    "\u2068",
+    "\u2069",
+}
+
+
+class SmokeValidationError(ValueError):
+    """Raised when a smoke declaration fails the safe schema."""
+
+
+@dataclass(frozen=True)
+class DiagnosticResult:
+    subject_type: str
+    subject: str
+    probe_type: str
+    target: str
+    status: str
+    reason: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def validate_smoke_spec(value: object) -> dict[str, Any]:
+    """Return a fresh canonical smoke declaration or raise ``SmokeValidationError``."""
+    if not isinstance(value, dict):
+        raise SmokeValidationError("invalid_smoke_spec")
+    value_map = cast(dict[str, Any], value)
+    if any(not isinstance(key, str) for key in value_map):
+        raise SmokeValidationError("invalid_smoke_field")
+    unknown = set(value_map) - {"version", "probes"}
+    if unknown:
+        raise SmokeValidationError(f"unknown_field:{sorted(unknown)[0]}")
+    if value_map.get("version") != SMOKE_VERSION:
+        raise SmokeValidationError("invalid_version")
+    probes = value_map.get("probes")
+    if not isinstance(probes, list):
+        raise SmokeValidationError("invalid_probes")
+    if len(probes) > MAX_PROBES:
+        raise SmokeValidationError("too_many_probes")
+    return {
+        "version": SMOKE_VERSION,
+        "probes": [_validate_probe(probe) for probe in probes],
+    }
+
+
+def resolve_probe_path(
+    root_name: str,
+    relative_path: str,
+    roots: Mapping[str, Path | None],
+) -> Path | None:
+    """Resolve a smoke path and reject traversal/symlink escapes."""
+    root = roots.get(root_name)
+    if root is None:
+        return None
+    root_path = Path(root).expanduser().resolve()
+    candidate = (root_path / relative_path).resolve()
+    try:
+        candidate.relative_to(root_path)
+    except ValueError as exc:
+        raise SmokeValidationError("path_escape") from exc
+    return candidate
+
+
+def evaluate_static_probes(
+    smoke: dict,
+    *,
+    subject_type: str,
+    subject: str,
+    roots: Mapping[str, Path | None],
+    env: Mapping[str, str] | None = None,
+    mcp_servers: Mapping[str, object] | None = None,
+) -> list[DiagnosticResult]:
+    """Evaluate non-executing smoke probes."""
+    environment = env if env is not None else os.environ
+    results: list[DiagnosticResult] = []
+    for probe in smoke.get("probes", []):
+        probe_type = probe.get("type", "")
+        if probe_type == "env-present":
+            name = str(probe["name"])
+            results.append(
+                _result(
+                    subject_type,
+                    subject,
+                    probe_type,
+                    name,
+                    "pass" if name in environment else "fail",
+                    "env_present" if name in environment else "env_missing",
+                )
+            )
+        elif probe_type == "command-exists":
+            name = str(probe["name"])
+            found = shutil.which(name) is not None
+            results.append(
+                _result(
+                    subject_type,
+                    subject,
+                    probe_type,
+                    name,
+                    "pass" if found else "fail",
+                    "command_found" if found else "command_missing",
+                )
+            )
+        elif probe_type in {"file-exists", "directory-exists"}:
+            results.append(_evaluate_path_probe(probe, subject_type, subject, roots))
+        elif probe_type == "python-import":
+            module = str(probe["module"])
+            found = _module_is_findable(module)
+            results.append(
+                _result(
+                    subject_type,
+                    subject,
+                    probe_type,
+                    module,
+                    "pass" if found else "fail",
+                    "python_import_found" if found else "python_import_missing",
+                )
+            )
+        elif probe_type == "mcp-configured":
+            server = str(probe["server"])
+            servers = mcp_servers if mcp_servers is not None else _load_mcp_servers()
+            found = server in servers
+            results.append(
+                _result(
+                    subject_type,
+                    subject,
+                    probe_type,
+                    server,
+                    "pass" if found else "fail",
+                    "mcp_configured" if found else "mcp_missing",
+                )
+            )
+    return results
+
+
+def diagnose_skill(
+    name: str,
+    *,
+    env: Mapping[str, str] | None = None,
+) -> list[DiagnosticResult]:
+    """Run static diagnostics for a discovered skill."""
+    discovered = {str(skill.get("name")) for skill in _find_all_skills()}
+    if name not in discovered:
+        return [_result("skill", name, "skill", name, "fail", "skill_not_found")]
+
+    frontmatter = _load_skill_frontmatter(name)
+    if frontmatter is None:
+        return [_result("skill", name, "skill", name, "fail", "skill_unreadable")]
+
+    try:
+        legacy_env_vars, commands = _collect_prerequisite_values(frontmatter)
+        required_env = [
+            item
+            for item in _get_required_environment_variables(
+                frontmatter, legacy_env_vars
+            )
+            if not item.get("optional")
+        ]
+    except Exception:
+        return [
+            _result(
+                "skill",
+                name,
+                "skill-metadata",
+                name,
+                "fail",
+                "invalid_skill_metadata",
+            )
+        ]
+    probes: list[dict[str, Any]] = []
+    probes.extend(
+        {"type": "env-present", "name": item["name"]} for item in required_env
+    )
+    probes.extend({"type": "command-exists", "name": command} for command in commands)
+    if not probes:
+        return [_result("skill", name, "skill", name, "pass", "skill_found")]
+    smoke = validate_smoke_spec({"version": SMOKE_VERSION, "probes": probes})
+    return evaluate_static_probes(
+        smoke,
+        subject_type="skill",
+        subject=name,
+        roots={},
+        env=env,
+    )
+
+
+def diagnose_all_skills() -> dict[str, list[DiagnosticResult]]:
+    """Diagnose every currently discovered skill."""
+    return {
+        str(skill.get("name")): diagnose_skill(str(skill.get("name")))
+        for skill in _find_all_skills()
+    }
+
+
+def diagnose_cron(ref: str) -> list[DiagnosticResult]:
+    """Run static diagnostics for a cron job reference."""
+    try:
+        job = resolve_job_ref(ref)
+    except AmbiguousJobReference:
+        return [_result("cron", ref, "cron", ref, "fail", "cron_ref_ambiguous")]
+    if not job:
+        return [_result("cron", ref, "cron", ref, "fail", "cron_not_found")]
+
+    subject = str(job.get("id") or ref)
+    results: list[DiagnosticResult] = []
+    prompt = str(job.get("prompt") or "").strip()
+    skills = [str(skill) for skill in (job.get("skills") or []) if str(skill).strip()]
+    script = job.get("script")
+    has_script = isinstance(script, str) and bool(script.strip())
+    schedule = str(job.get("schedule_display") or "")
+    if prompt:
+        results.append(
+            _result(
+                "cron", subject, "cron-prompt", "prompt", "pass", "cron_prompt_present"
+            )
+        )
+    elif job.get("no_agent") and has_script:
+        results.append(
+            _result(
+                "cron",
+                subject,
+                "cron-prompt",
+                "prompt",
+                "skipped",
+                "cron_prompt_not_required",
+            )
+        )
+    elif skills:
+        results.append(
+            _result(
+                "cron",
+                subject,
+                "cron-prompt",
+                "prompt",
+                "skipped",
+                "cron_prompt_from_skill",
+            )
+        )
+    else:
+        results.append(
+            _result(
+                "cron", subject, "cron-prompt", "prompt", "fail", "cron_prompt_missing"
+            )
+        )
+    for skill in skills:
+        results.append(
+            _result("cron", subject, "cron-skill", skill, "pass", "cron_skill_attached")
+        )
+        results.extend(diagnose_skill(skill))
+    results.append(
+        _result(
+            "cron",
+            subject,
+            "cron-schedule",
+            schedule or "schedule",
+            "pass" if job.get("schedule") else "fail",
+            "cron_schedule_present" if job.get("schedule") else "cron_schedule_missing",
+        )
+    )
+
+    if has_script:
+        assert isinstance(script, str)
+        results.append(_diagnose_job_script(script, subject))
+
+    if "smoke" in job and job.get("smoke") is not None:
+        try:
+            smoke = validate_smoke_spec(job["smoke"])
+        except SmokeValidationError:
+            results.append(
+                _result(
+                    "cron", subject, "smoke-schema", "smoke", "fail", "invalid_smoke"
+                )
+            )
+        else:
+            results.extend(
+                evaluate_static_probes(
+                    smoke,
+                    subject_type="cron",
+                    subject=subject,
+                    roots=_roots_for_job(job),
+                )
+            )
+    return results
+
+
+def render_diagnostic_json(
+    results: list[DiagnosticResult] | Mapping[str, list[DiagnosticResult]],
+) -> str:
+    """Render structured diagnostics without raw output fields."""
+    if isinstance(results, Mapping):
+        result_map = cast(Mapping[str, list[DiagnosticResult]], results)
+        payload = {}
+        used_keys: set[str] = set()
+        for key, value in result_map.items():
+            safe_key = _safe_mapping_key(key, used_keys)
+            used_keys.add(safe_key)
+            payload[safe_key] = [item.to_dict() for item in value]
+    else:
+        payload = [item.to_dict() for item in results]
+    return json.dumps(payload, sort_keys=True)
+
+
+def render_diagnostic_text(
+    results: list[DiagnosticResult] | Mapping[str, list[DiagnosticResult]],
+) -> str:
+    """Render compact human diagnostics without secret values."""
+    flat: list[DiagnosticResult] = []
+    if isinstance(results, Mapping):
+        result_map = cast(Mapping[str, list[DiagnosticResult]], results)
+        for items in result_map.values():
+            flat.extend(items)
+    else:
+        flat = list(results)
+    lines = []
+    for item in flat:
+        lines.append(
+            f"{item.status.upper()} {item.subject_type}:{item.subject} "
+            f"{item.probe_type}:{item.target} {item.reason}"
+        )
+    return "\n".join(lines)
+
+
+def diagnose_all_crons() -> dict[str, list[DiagnosticResult]]:
+    """Diagnose all cron jobs, including disabled jobs."""
+    return {
+        str(job.get("id")): diagnose_cron(str(job.get("id")))
+        for job in list_jobs(include_disabled=True)
+    }
+
+
+def _evaluate_path_probe(
+    probe: Mapping[str, Any],
+    subject_type: str,
+    subject: str,
+    roots: Mapping[str, Path | None],
+) -> DiagnosticResult:
+    root = str(probe["root"])
+    target = f"{root}:{probe['path']}"
+    try:
+        path = resolve_probe_path(root, str(probe["path"]), roots)
+    except SmokeValidationError as exc:
+        return _result(
+            subject_type,
+            subject,
+            str(probe["type"]),
+            target,
+            "fail",
+            str(exc),
+        )
+    if path is None:
+        return _result(
+            subject_type,
+            subject,
+            str(probe["type"]),
+            target,
+            "skipped",
+            "root_unavailable",
+        )
+    if probe["type"] == "file-exists":
+        exists = path.is_file()
+        return _result(
+            subject_type,
+            subject,
+            "file-exists",
+            target,
+            "pass" if exists else "fail",
+            "file_exists" if exists else "file_missing",
+        )
+    exists = path.is_dir()
+    return _result(
+        subject_type,
+        subject,
+        "directory-exists",
+        target,
+        "pass" if exists else "fail",
+        "directory_exists" if exists else "directory_missing",
+    )
+
+
+def _diagnose_job_script(script: str, subject: str) -> DiagnosticResult:
+    scripts_dir = (get_hermes_home() / "scripts").resolve()
+    raw = Path(script).expanduser()
+    candidate = raw.resolve() if raw.is_absolute() else (scripts_dir / raw).resolve()
+    try:
+        candidate.relative_to(scripts_dir)
+    except ValueError:
+        return _result(
+            "cron", subject, "cron-script", script, "fail", "script_path_escape"
+        )
+    exists = candidate.is_file()
+    return _result(
+        "cron",
+        subject,
+        "cron-script",
+        script,
+        "pass" if exists else "fail",
+        "script_exists" if exists else "script_missing",
+    )
+
+
+def _load_skill_frontmatter(name: str) -> dict[str, Any] | None:
+    try:
+        payload = json.loads(skill_view(name, preprocess=False, metadata_only=True))
+    except Exception:
+        return None
+    if not isinstance(payload, dict) or not payload.get("success"):
+        return None
+    frontmatter = payload.get("frontmatter")
+    return frontmatter if isinstance(frontmatter, dict) else None
+
+
+def _roots_for_job(job: Mapping[str, Any]) -> dict[str, Path | None]:
+    hermes_home = get_hermes_home()
+    workdir = job.get("workdir")
+    return {
+        "hermes_home": hermes_home,
+        "scripts_dir": hermes_home / "scripts",
+        "workdir": Path(workdir).expanduser()
+        if isinstance(workdir, str) and workdir
+        else Path.cwd(),
+        "skill_dir": None,
+    }
+
+
+def _module_is_findable(module: str) -> bool:
+    search_paths: list[str] | None = list(sys.path)
+    spec = None
+    for index, part in enumerate(module.split(".")):
+        fullname = ".".join(module.split(".")[: index + 1])
+        spec = PathFinder.find_spec(fullname, search_paths)
+        if spec is None:
+            return False
+        if index < len(module.split(".")) - 1:
+            locations = spec.submodule_search_locations
+            if locations is None:
+                return False
+            search_paths = list(locations)
+    return spec is not None
+
+
+def _load_mcp_servers() -> Mapping[str, object]:
+    try:
+        from hermes_cli.config import load_config
+
+        cfg = load_config()
+    except Exception:
+        return {}
+    if not isinstance(cfg, dict):
+        return {}
+    mcp = cfg.get("mcp")
+    if isinstance(mcp, dict):
+        servers = mcp.get("servers")
+        if isinstance(servers, dict):
+            return servers
+    servers = cfg.get("mcp_servers")
+    return servers if isinstance(servers, dict) else {}
+
+
+def _result(
+    subject_type: str,
+    subject: str,
+    probe_type: str,
+    target: str,
+    status: str,
+    reason: str,
+) -> DiagnosticResult:
+    return DiagnosticResult(
+        subject_type=_safe_diagnostic_text(subject_type),
+        subject=_safe_diagnostic_text(subject),
+        probe_type=_safe_diagnostic_text(probe_type),
+        target=_safe_diagnostic_text(target),
+        status=_safe_diagnostic_text(status),
+        reason=_safe_diagnostic_text(reason),
+    )
+
+
+def _safe_diagnostic_text(value: object) -> str:
+    text = str(value)
+    safe = "".join(
+        "�" if ord(ch) < 32 or ord(ch) == 127 or ch in _INVISIBLE_CODEPOINTS else ch
+        for ch in text
+    )
+    return safe[:MAX_TEXT_LENGTH]
+
+
+def _safe_mapping_key(value: object, used: set[str]) -> str:
+    raw = str(value)
+    safe = _safe_diagnostic_text(raw)
+    if safe == raw and safe not in used:
+        return safe
+    nonce = 0
+    while True:
+        digest_input = f"{raw}\0{nonce}".encode("utf-8", errors="replace")
+        suffix = f"#{hashlib.sha256(digest_input).hexdigest()[:12]}"
+        candidate = f"{safe[: MAX_TEXT_LENGTH - len(suffix)]}{suffix}"
+        if candidate not in used:
+            return candidate
+        nonce += 1
+
+
+def _validate_probe(probe: object) -> dict[str, Any]:
+    if not isinstance(probe, dict):
+        raise SmokeValidationError("invalid_probe")
+    probe_map = cast(dict[str, Any], probe)
+    if any(not isinstance(key, str) for key in probe_map):
+        raise SmokeValidationError("invalid_probe_field")
+    probe_type = probe_map.get("type")
+    if not isinstance(probe_type, str) or probe_type not in ALLOWED_PROBE_TYPES:
+        raise SmokeValidationError("unknown_probe_type")
+    allowed = _FIELDS_BY_TYPE[str(probe_type)]
+    unknown = set(probe_map) - allowed
+    if unknown:
+        raise SmokeValidationError(f"unknown_probe_field:{sorted(unknown)[0]}")
+    if probe_type in {"command-exists", "env-present"}:
+        return {
+            "type": probe_type,
+            "name": _validate_identifier(probe_map.get("name"), "name"),
+        }
+    if probe_type in {"file-exists", "directory-exists"}:
+        return {
+            "type": probe_type,
+            "root": _validate_root(probe_map.get("root")),
+            "path": _validate_relative_path(probe_map.get("path")),
+        }
+    if probe_type == "python-import":
+        module = _validate_text(probe_map.get("module"), "module")
+        if not _MODULE_RE.fullmatch(module):
+            raise SmokeValidationError("invalid_module")
+        return {"type": probe_type, "module": module}
+    if probe_type == "mcp-configured":
+        return {
+            "type": probe_type,
+            "server": _validate_identifier(probe_map.get("server"), "server"),
+        }
+    raise SmokeValidationError("unknown_probe_type")
+
+
+def _validate_root(value: object) -> str:
+    root = _validate_text(value, "root")
+    if root not in ALLOWED_ROOTS:
+        raise SmokeValidationError("invalid_root")
+    return root
+
+
+def _validate_identifier(value: object, field: str) -> str:
+    text = _validate_text(value, field)
+    if not _IDENT_RE.fullmatch(text):
+        raise SmokeValidationError(f"invalid_{field}")
+    return text
+
+
+def _validate_text(value: object, field: str) -> str:
+    if not isinstance(value, str) or not value or len(value) > MAX_TEXT_LENGTH:
+        raise SmokeValidationError(f"invalid_{field}")
+    if any(
+        ord(ch) < 32 or ord(ch) == 127 or ch in _INVISIBLE_CODEPOINTS for ch in value
+    ):
+        raise SmokeValidationError("invalid_text")
+    return value
+
+
+def _validate_relative_path(value: object) -> str:
+    text = _validate_text(value, "path").replace("\\", "/")
+    path = PurePosixPath(text)
+    if (
+        path.is_absolute()
+        or ":" in path.parts[0]
+        or any(part in {"", ".", ".."} for part in path.parts)
+    ):
+        raise SmokeValidationError("invalid_path")
+    return path.as_posix()

--- a/hermes_cli/subcommands/cron.py
+++ b/hermes_cli/subcommands/cron.py
@@ -7,9 +7,69 @@ import ``main`` (cycle avoidance).
 
 from __future__ import annotations
 
+import argparse
 from typing import Callable
 
 from hermes_cli.subcommands._shared import add_accept_hooks_flag
+
+
+class _StoreTrueWithConflicts(argparse.Action):
+    def __init__(self, option_strings, dest, *, conflicts=(), **kwargs):
+        self._conflicts = conflicts
+        super().__init__(option_strings, dest, nargs=0, **kwargs)
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        for conflict in self._conflicts:
+            if getattr(namespace, conflict, None):
+                parser.error(
+                    f"{option_string} cannot be used with --{conflict.replace('_', '-')}"
+                )
+        setattr(namespace, self.dest, True)
+
+
+class _StoreWithConflicts(argparse.Action):
+    def __init__(self, option_strings, dest, *, conflicts=(), **kwargs):
+        self._conflicts = conflicts
+        super().__init__(option_strings, dest, **kwargs)
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        for conflict in self._conflicts:
+            if getattr(namespace, conflict, None):
+                parser.error(
+                    f"{option_string} cannot be used with --{conflict.replace('_', '-')}"
+                )
+        setattr(namespace, self.dest, values)
+
+
+def _add_preflight_flags(parser, *, edit: bool = False) -> None:
+    parser.add_argument(
+        "--smoke-file",
+        action=_StoreWithConflicts,
+        conflicts=("clear_smoke",),
+        help="Read a JSON/YAML smoke declaration and store it with the job.",
+    )
+    if edit:
+        parser.add_argument(
+            "--clear-smoke",
+            action=_StoreTrueWithConflicts,
+            conflicts=("smoke_file",),
+            default=False,
+            help="Remove stored smoke metadata.",
+        )
+    parser.add_argument(
+        "--skip-preflight",
+        action=_StoreTrueWithConflicts,
+        conflicts=("strict_preflight",),
+        default=False,
+        help="Save without running post-save diagnostics.",
+    )
+    parser.add_argument(
+        "--strict-preflight",
+        action=_StoreTrueWithConflicts,
+        conflicts=("skip_preflight",),
+        default=False,
+        help="Return non-zero when post-save diagnostics fail.",
+    )
 
 
 def build_cron_parser(subparsers, *, cmd_cron: Callable) -> None:
@@ -105,6 +165,7 @@ def build_cron_parser(subparsers, *, cmd_cron: Callable) -> None:
         dest="model_provider",
         help="Inference provider paired with --model (e.g. 'openrouter', 'nous').",
     )
+    _add_preflight_flags(cron_create)
 
     # cron edit
     cron_edit = cron_subparsers.add_parser(
@@ -197,6 +258,7 @@ def build_cron_parser(subparsers, *, cmd_cron: Callable) -> None:
         dest="model_provider",
         help="Inference provider paired with --model. Pass empty string to clear.",
     )
+    _add_preflight_flags(cron_edit, edit=True)
 
     # lifecycle actions
     cron_pause = cron_subparsers.add_parser("pause", help="Pause a scheduled job")

--- a/hermes_cli/subcommands/doctor.py
+++ b/hermes_cli/subcommands/doctor.py
@@ -41,4 +41,15 @@ def build_doctor_parser(subparsers, *, cmd_doctor: Callable) -> None:
             "doctor` first to see active advisories and their IDs."
         ),
     )
+    doctor_targets = doctor_parser.add_subparsers(dest="doctor_target")
+    for target_name in ("skill", "cron"):
+        target_parser = doctor_targets.add_parser(
+            target_name,
+            help=f"Run targeted {target_name} diagnostics",
+        )
+        target_parser.add_argument(
+            "target", nargs="?", help=f"{target_name} name or ID"
+        )
+        target_parser.add_argument("--all", action="store_true", default=False)
+        target_parser.add_argument("--json", action="store_true", default=False)
     doctor_parser.set_defaults(func=cmd_doctor)

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -4,6 +4,7 @@ import threading
 import pytest
 from datetime import datetime, timedelta, timezone
 
+from hermes_cli.reliability_doctor import SmokeValidationError
 from cron.jobs import (
     parse_duration,
     parse_schedule,
@@ -224,6 +225,84 @@ class TestJobCRUD:
         fetched = get_job(job["id"])
         assert fetched is not None
         assert fetched["prompt"] == "Check server status"
+
+    def test_create_job_persists_canonical_smoke(self, tmp_cron_dir):
+        smoke = {
+            "version": 1,
+            "probes": [
+                {"type": "env-present", "name": "GH_TOKEN"},
+                {"type": "command-exists", "name": "gh"},
+            ],
+        }
+
+        job = create_job(prompt="Check server status", schedule="30m", smoke=smoke)
+
+        assert job["smoke"] == smoke
+        assert load_jobs()[0]["smoke"] == job["smoke"]
+
+    def test_create_job_rejects_command_smoke(self, tmp_cron_dir):
+        with pytest.raises(SmokeValidationError, match="unknown_probe_type"):
+            create_job(
+                prompt="Check server status",
+                schedule="30m",
+                smoke={
+                    "version": 1,
+                    "probes": [
+                        {
+                            "type": "command",
+                            "argv": ["true"],
+                            "expected_exit_codes": [0],
+                        }
+                    ],
+                },
+            )
+
+    def test_update_job_replaces_and_clears_smoke(self, tmp_cron_dir):
+        job = create_job(
+            prompt="Check server status",
+            schedule="30m",
+            smoke={"version": 1, "probes": [{"type": "env-present", "name": "GH_TOKEN"}]},
+        )
+
+        updated = update_job(
+            job["id"],
+            {"smoke": {"version": 1, "probes": [{"type": "command-exists", "name": "gh"}]}},
+        )
+        assert updated["smoke"]["probes"] == [{"type": "command-exists", "name": "gh"}]
+
+        cleared = update_job(job["id"], {"smoke": None})
+        assert "smoke" not in cleared
+        assert "smoke" not in load_jobs()[0]
+
+    def test_normalize_job_record_preserves_invalid_hand_edited_smoke_for_doctor(
+        self, tmp_cron_dir
+    ):
+        save_jobs(
+            [
+                {
+                    "id": "abc123",
+                    "name": "Hand Edited",
+                    "prompt": "Run",
+                    "schedule": {"kind": "interval", "minutes": 60},
+                    "schedule_display": "every 60m",
+                    "enabled": True,
+                    "smoke": {"version": 1, "probes": [{"type": "shell", "command": "echo nope"}]},
+                }
+            ]
+        )
+
+        [job] = list_jobs()
+
+        assert job["smoke"] == {
+            "version": 1,
+            "probes": [{"type": "shell", "command": "echo nope"}],
+        }
+
+    def test_legacy_job_without_smoke_is_byte_compatible(self, tmp_cron_dir):
+        job = create_job(prompt="Check server status", schedule="30m")
+
+        assert "smoke" not in job
+        assert "smoke" not in load_jobs()[0]
 
     def test_list_jobs(self, tmp_cron_dir):
         create_job(prompt="Job 1", schedule="every 1h")
@@ -1215,10 +1294,6 @@ class TestJobsJsonUtf8Bom:
 
         loaded = load_jobs()
         assert [j["id"] for j in loaded] == ["plainjob01"]
-
-
-
-
 class TestAdvanceNextRuns:
     """Tests for advance_next_runs() — the batched due-set advance.
 

--- a/tests/hermes_cli/test_cron.py
+++ b/tests/hermes_cli/test_cron.py
@@ -6,6 +6,7 @@ from types import SimpleNamespace
 import pytest
 
 from cron.jobs import create_job, get_job, list_jobs
+from hermes_cli.reliability_doctor import diagnose_cron
 from hermes_cli import cron as cron_cli
 from hermes_cli.cron import cron_command
 
@@ -19,7 +20,6 @@ def tmp_cron_dir(tmp_path, monkeypatch):
 
 
 class TestCronCommandLifecycle:
-
     def test_edit_can_replace_and_clear_skills(self, tmp_cron_dir, capsys):
         job = create_job(
             prompt="Combine skill outputs",
@@ -103,14 +103,12 @@ class TestCronCommandLifecycle:
         assert jobs[0]["name"] == "Skill combo"
 
 
-
 class TestGatewayNotRunningWarning:
     """`cron create` / `cron list` must warn when the gateway (and thus the
     cron ticker) isn't running, since jobs only fire inside the gateway.
     Regression guard for #51038 — the most common cron 'jobs never fired'
     report was simply a gateway that was never started.
     """
-
 
     def test_list_warns_when_gateway_absent(self, tmp_cron_dir, capsys, monkeypatch):
         create_job(prompt="Daily report", schedule="0 11 * * *")
@@ -148,7 +146,6 @@ class TestExternalCronProviderStatus:
         assert "Gateway is not running" not in out
         # Still surfaces the active-job summary.
         assert "active job(s)" in out
-
 
     def test_create_silent_for_chronos_even_without_gateway(
         self, tmp_cron_dir, capsys, monkeypatch
@@ -206,7 +203,9 @@ def test_cron_list_warns_when_gateway_not_running(monkeypatch, capsys):
 
 def test_cron_tick_invokes_scheduler_tick_with_verbose(monkeypatch):
     calls = []
-    monkeypatch.setattr("cron.scheduler.tick", lambda verbose=False: calls.append(verbose))
+    monkeypatch.setattr(
+        "cron.scheduler.tick", lambda verbose=False: calls.append(verbose)
+    )
 
     cron_cli.cron_tick()
 
@@ -214,7 +213,9 @@ def test_cron_tick_invokes_scheduler_tick_with_verbose(monkeypatch):
 
 
 def test_cron_create_failure_returns_nonzero(monkeypatch, capsys):
-    monkeypatch.setattr(cron_cli, "_cron_api", lambda **kwargs: {"success": False, "error": "boom"})
+    monkeypatch.setattr(
+        cron_cli, "_cron_api", lambda **kwargs: {"success": False, "error": "boom"}
+    )
 
     args = SimpleNamespace(
         schedule="every day",
@@ -234,3 +235,286 @@ def test_cron_create_failure_returns_nonzero(monkeypatch, capsys):
     out = capsys.readouterr().out
     assert rc == 1
     assert "Failed to create job: boom" in out
+
+
+def _base_create_args(**overrides):
+    data = {
+        "cron_command": "create",
+        "schedule": "every 1h",
+        "prompt": "Run",
+        "name": "Smoke",
+        "deliver": None,
+        "repeat": None,
+        "skill": None,
+        "skills": None,
+        "script": None,
+        "workdir": None,
+        "model": None,
+        "model_provider": None,
+        "no_agent": False,
+        "smoke_file": None,
+        "skip_preflight": False,
+        "strict_preflight": False,
+    }
+    data.update(overrides)
+    return Namespace(**data)
+
+
+def _base_edit_args(job_id, **overrides):
+    data = {
+        "cron_command": "edit",
+        "job_id": job_id,
+        "schedule": None,
+        "prompt": None,
+        "name": None,
+        "deliver": None,
+        "repeat": None,
+        "skill": None,
+        "skills": None,
+        "clear_skills": False,
+        "add_skills": None,
+        "remove_skills": None,
+        "script": None,
+        "workdir": None,
+        "model": None,
+        "model_provider": None,
+        "no_agent": None,
+        "smoke_file": None,
+        "clear_smoke": False,
+        "skip_preflight": False,
+        "strict_preflight": False,
+    }
+    data.update(overrides)
+    return Namespace(**data)
+
+
+def test_cron_create_validates_smoke_file_before_saving(tmp_cron_dir, tmp_path, capsys):
+    smoke_file = tmp_path / "smoke.yaml"
+    smoke_file.write_text(
+        "version: 1\nprobes:\n  - type: shell\n    command: echo nope\n"
+    )
+
+    rc = cron_cli.cron_create(_base_create_args(smoke_file=str(smoke_file)))
+
+    assert rc == 1
+    assert list_jobs(include_disabled=True) == []
+    assert "Failed to load smoke file" in capsys.readouterr().out
+
+
+def test_cron_create_rejects_command_probe_smoke_file_before_saving(
+    tmp_cron_dir, tmp_path, capsys
+):
+    smoke_file = tmp_path / "smoke.yaml"
+    smoke_file.write_text(
+        "\n".join([
+            "version: 1",
+            "probes:",
+            "  - type: command",
+            "    argv: ['true']",
+            "    expected_exit_codes: [0]",
+        ]),
+        encoding="utf-8",
+    )
+
+    rc = cron_cli.cron_create(_base_create_args(smoke_file=str(smoke_file)))
+
+    assert rc == 1
+    assert list_jobs(include_disabled=True) == []
+    assert "Failed to load smoke file" in capsys.readouterr().out
+
+
+def test_cron_create_saves_then_runs_static_preflight_by_default(
+    tmp_cron_dir, monkeypatch
+):
+    calls = []
+    monkeypatch.setattr(
+        cron_cli,
+        "_run_saved_job_preflight",
+        lambda job_id, strict: calls.append((job_id, strict)) or 0,
+    )
+
+    rc = cron_cli.cron_create(_base_create_args())
+
+    [job] = list_jobs(include_disabled=True)
+    assert rc == 0
+    assert calls == [(job["id"], False)]
+
+
+def test_cron_create_skip_preflight_does_not_diagnose(tmp_cron_dir, monkeypatch):
+    monkeypatch.setattr(
+        cron_cli,
+        "_run_saved_job_preflight",
+        lambda *args, **kwargs: pytest.fail("preflight should be skipped"),
+        raising=False,
+    )
+
+    assert cron_cli.cron_create(_base_create_args(skip_preflight=True)) == 0
+
+
+def test_cron_create_warn_mode_returns_zero_after_failed_preflight(
+    tmp_cron_dir, monkeypatch, capsys
+):
+    monkeypatch.setattr(
+        cron_cli,
+        "diagnose_cron",
+        lambda job_id: [
+            cron_cli.DiagnosticResult(
+                "cron", job_id, "smoke-schema", "smoke", "fail", "invalid_smoke"
+            )
+        ],
+    )
+
+    rc = cron_cli.cron_create(_base_create_args())
+
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "Created job:" in out
+    assert "Job saved. Preflight failed." in out
+
+
+def test_cron_create_strict_mode_says_saved_and_returns_nonzero(
+    tmp_cron_dir, monkeypatch, capsys
+):
+    monkeypatch.setattr(
+        cron_cli,
+        "diagnose_cron",
+        lambda job_id: [
+            cron_cli.DiagnosticResult(
+                "cron", job_id, "smoke-schema", "smoke", "fail", "invalid_smoke"
+            )
+        ],
+    )
+
+    rc = cron_cli.cron_create(_base_create_args(strict_preflight=True))
+
+    out = capsys.readouterr().out
+    assert rc == 1
+    assert "Created job:" in out
+    assert "Job saved. Preflight failed." in out
+    assert "rollback" not in out.lower()
+
+
+def test_cron_create_no_agent_script_passes_strict_static_preflight(
+    tmp_cron_dir, monkeypatch
+):
+    script = tmp_cron_dir / "scripts" / "watchdog.py"
+    script.parent.mkdir(parents=True)
+    script.write_text("print('ok')\n", encoding="utf-8")
+    monkeypatch.setattr(
+        "hermes_cli.reliability_doctor.get_hermes_home", lambda: tmp_cron_dir
+    )
+
+    rc = cron_cli.cron_create(
+        _base_create_args(
+            prompt=None,
+            no_agent=True,
+            script="watchdog.py",
+            strict_preflight=True,
+        )
+    )
+
+    assert rc == 0
+
+
+def test_cron_edit_clear_smoke_removes_metadata(tmp_cron_dir):
+    job = create_job(
+        prompt="Run",
+        schedule="every 1h",
+        smoke={"version": 1, "probes": [{"type": "env-present", "name": "GH_TOKEN"}]},
+    )
+
+    rc = cron_cli.cron_edit(
+        _base_edit_args(job["id"], clear_smoke=True, skip_preflight=True)
+    )
+
+    assert rc == 0
+    assert "smoke" not in get_job(job["id"])
+
+
+def test_cron_edit_strict_failure_does_not_claim_rollback(
+    tmp_cron_dir, monkeypatch, capsys
+):
+    job = create_job(prompt="Run", schedule="every 1h")
+    monkeypatch.setattr(
+        cron_cli,
+        "diagnose_cron",
+        lambda job_id: [
+            cron_cli.DiagnosticResult("cron", job_id, "cron", job_id, "fail", "broken")
+        ],
+    )
+
+    rc = cron_cli.cron_edit(
+        _base_edit_args(job["id"], name="Updated", strict_preflight=True)
+    )
+
+    out = capsys.readouterr().out
+    assert rc == 1
+    assert get_job(job["id"])["name"] == "Updated"
+    assert "Updated job:" in out
+    assert "Job saved. Preflight failed." in out
+    assert "rollback" not in out.lower()
+
+
+def test_cron_edit_invalid_yaml_does_not_mutate_job(tmp_cron_dir, tmp_path):
+    job = create_job(prompt="Run", schedule="every 1h", name="Original")
+    smoke_file = tmp_path / "smoke.yaml"
+    smoke_file.write_text("version: [", encoding="utf-8")
+
+    rc = cron_cli.cron_edit(
+        _base_edit_args(job["id"], name="Mutated", smoke_file=str(smoke_file))
+    )
+
+    assert rc == 1
+    assert get_job(job["id"])["name"] == "Original"
+
+
+def test_integration_cron_static_smoke_create_diagnose_and_clear(
+    tmp_cron_dir, tmp_path, monkeypatch
+):
+    workdir = tmp_path / "project"
+    workdir.mkdir()
+    (workdir / "marker.txt").write_text("ok", encoding="utf-8")
+    smoke_file = tmp_path / "smoke.yaml"
+    smoke_file.write_text(
+        "\n".join([
+            "version: 1",
+            "probes:",
+            "  - type: file-exists",
+            "    root: workdir",
+            "    path: marker.txt",
+            "  - type: env-present",
+            "    name: PATH",
+        ]),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr("hermes_cli.gateway.find_gateway_pids", lambda: [])
+
+    create_rc = cron_cli.cron_create(
+        _base_create_args(
+            smoke_file=str(smoke_file),
+            workdir=str(workdir),
+        )
+    )
+
+    [job] = list_jobs(include_disabled=True)
+    assert create_rc == 0
+    assert job["smoke"]["probes"][0]["type"] == "file-exists"
+
+    static_results = diagnose_cron(job["id"])
+    assert any(
+        result.probe_type == "file-exists" and result.status == "pass"
+        for result in static_results
+    )
+    assert any(
+        result.probe_type == "env-present"
+        and result.status == "pass"
+        and result.reason == "env_present"
+        for result in static_results
+    )
+
+    edit_rc = cron_cli.cron_edit(
+        _base_edit_args(job["id"], clear_smoke=True, skip_preflight=True)
+    )
+
+    assert edit_rc == 0
+    assert "smoke" not in get_job(job["id"])

--- a/tests/hermes_cli/test_cron_parser_builder.py
+++ b/tests/hermes_cli/test_cron_parser_builder.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 
 import argparse
 
+import pytest
+
 from hermes_cli.subcommands.cron import build_cron_parser
 
 
@@ -25,10 +27,25 @@ def _build():
 
 def test_cron_subactions_present():
     parser = _build()
-    for action in ("list", "create", "edit", "pause", "resume", "run", "remove", "status", "runs", "tick"):
-        ns = parser.parse_args(["cron", action] if action in ("list", "status", "runs", "tick")
-                               else ["cron", action, "jobid"] if action in ("pause", "resume", "run", "remove", "edit")
-                               else ["cron", "create", "30m"])
+    for action in (
+        "list",
+        "create",
+        "edit",
+        "pause",
+        "resume",
+        "run",
+        "remove",
+        "status",
+        "runs",
+        "tick",
+    ):
+        ns = parser.parse_args(
+            ["cron", action]
+            if action in ("list", "status", "runs", "tick")
+            else ["cron", action, "jobid"]
+            if action in ("pause", "resume", "run", "remove", "edit")
+            else ["cron", "create", "30m"]
+        )
         assert ns.command == "cron"
         assert ns.cron_command == action
 
@@ -48,3 +65,53 @@ def test_cron_accept_hooks_flag_on_run_and_tick():
     assert ns.accept_hooks is True
     ns2 = parser.parse_args(["cron", "tick", "--accept-hooks"])
     assert ns2.accept_hooks is True
+
+
+def test_cron_create_accepts_smoke_and_static_preflight_flags():
+    parser = _build()
+
+    ns = parser.parse_args([
+        "cron",
+        "create",
+        "every 1h",
+        "Run",
+        "--smoke-file",
+        "smoke.yaml",
+        "--strict-preflight",
+    ])
+
+    assert ns.smoke_file == "smoke.yaml"
+    assert ns.strict_preflight is True
+    assert ns.skip_preflight is False
+
+
+def test_cron_edit_accepts_clear_smoke():
+    parser = _build()
+
+    ns = parser.parse_args(["cron", "edit", "job", "--clear-smoke"])
+
+    assert ns.clear_smoke is True
+
+
+def test_cron_rejects_conflicting_preflight_flags():
+    parser = _build()
+
+    for argv in (
+        ["cron", "create", "every 1h", "--skip-preflight", "--strict-preflight"],
+        ["cron", "edit", "job", "--smoke-file", "smoke.yaml", "--clear-smoke"],
+    ):
+        try:
+            parser.parse_args(argv)
+        except SystemExit as exc:
+            assert exc.code == 2
+        else:  # pragma: no cover - should be rejected
+            raise AssertionError(f"expected parser rejection for {argv!r}")
+
+
+def test_cron_rejects_removed_preflight_smoke_flag():
+    parser = _build()
+
+    with pytest.raises(SystemExit) as exc:
+        parser.parse_args(["cron", "create", "every 1h", "--preflight-smoke"])
+
+    assert exc.value.code == 2

--- a/tests/hermes_cli/test_doctor_reliability.py
+++ b/tests/hermes_cli/test_doctor_reliability.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+import argparse
+import json
+
+import pytest
+
+import hermes_cli.doctor as doctor_mod
+from hermes_cli.subcommands.doctor import build_doctor_parser
+from hermes_cli.reliability_doctor import DiagnosticResult
+
+
+def test_targeted_doctor_human_mode_returns_zero_without_failures(monkeypatch, capsys):
+    monkeypatch.setattr(
+        doctor_mod,
+        "diagnose_skill",
+        lambda target: [
+            DiagnosticResult(
+                "skill", target, "env-present", "GH_TOKEN", "pass", "env_present"
+            )
+        ],
+    )
+
+    rc = doctor_mod.run_doctor(
+        argparse.Namespace(
+            doctor_target="skill", target="github", all=False, smoke=False, json=False
+        )
+    )
+
+    assert rc == 0
+    assert (
+        "PASS skill:github env-present:GH_TOKEN env_present" in capsys.readouterr().out
+    )
+
+
+def test_targeted_doctor_human_mode_returns_one_for_failures(monkeypatch):
+    monkeypatch.setattr(
+        doctor_mod,
+        "diagnose_skill",
+        lambda target: [
+            DiagnosticResult(
+                "skill", target, "env-present", "GH_TOKEN", "fail", "env_missing"
+            )
+        ],
+    )
+
+    rc = doctor_mod.run_doctor(
+        argparse.Namespace(
+            doctor_target="skill", target="github", all=False, smoke=False, json=False
+        )
+    )
+
+    assert rc == 1
+
+
+def test_targeted_doctor_json_mode_is_valid_and_stable(monkeypatch, capsys):
+    monkeypatch.setattr(
+        doctor_mod,
+        "diagnose_all_skills",
+        lambda: {
+            "github": [
+                DiagnosticResult(
+                    "skill", "github", "command-exists", "gh", "pass", "command_found"
+                )
+            ]
+        },
+    )
+
+    rc = doctor_mod.run_doctor(
+        argparse.Namespace(
+            doctor_target="skill", target=None, all=True, smoke=False, json=True
+        )
+    )
+
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["github"][0]["reason"] == "command_found"
+    assert "stdout" not in payload["github"][0]
+
+
+def test_targeted_doctor_all_json_bounds_and_disambiguates_stored_ids(
+    monkeypatch, capsys
+):
+    first = "x" * 600 + "a"
+    second = "x" * 600 + "b"
+    monkeypatch.setattr(
+        doctor_mod,
+        "diagnose_all_crons",
+        lambda: {
+            first: [DiagnosticResult("cron", first, "cron", first, "pass", "ok")],
+            second: [DiagnosticResult("cron", second, "cron", second, "pass", "ok")],
+        },
+    )
+
+    rc = doctor_mod.run_doctor(
+        argparse.Namespace(
+            doctor_target="cron", target=None, all=True, smoke=False, json=True
+        )
+    )
+
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert len(payload) == 2
+    assert all(len(key) <= 512 for key in payload)
+    assert first not in payload
+    assert second not in payload
+
+
+def test_targeted_doctor_ambiguous_cron_names_return_exit_2(monkeypatch):
+    monkeypatch.setattr(
+        doctor_mod,
+        "diagnose_cron",
+        lambda target: [
+            DiagnosticResult(
+                "cron", target, "cron", target, "fail", "cron_ref_ambiguous"
+            )
+        ],
+    )
+
+    rc = doctor_mod.run_doctor(
+        argparse.Namespace(
+            doctor_target="cron", target="daily", all=False, smoke=False, json=False
+        )
+    )
+
+    assert rc == 2
+
+
+def test_targeted_doctor_parser_rejects_removed_smoke_flag():
+    parser = argparse.ArgumentParser(prog="hermes")
+    subparsers = parser.add_subparsers(dest="command")
+    build_doctor_parser(subparsers, cmd_doctor=lambda args: args)
+
+    with pytest.raises(SystemExit) as exc:
+        parser.parse_args(["doctor", "cron", "daily", "--smoke"])
+
+    assert exc.value.code == 2
+
+
+@pytest.mark.parametrize(
+    "args",
+    [
+        argparse.Namespace(
+            doctor_target="skill", target=None, all=False, smoke=False, json=False
+        ),
+        argparse.Namespace(
+            doctor_target="cron", target=None, all=False, smoke=False, json=False
+        ),
+    ],
+)
+def test_targeted_doctor_requires_target_or_all(args):
+    assert doctor_mod.run_doctor(args) == 2

--- a/tests/hermes_cli/test_main_reliability_exit_codes.py
+++ b/tests/hermes_cli/test_main_reliability_exit_codes.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+
+
+def _run_driver(
+    argvs: list[list[str]], hermes_home
+) -> subprocess.CompletedProcess[str]:
+    driver = r"""
+import json
+import sys
+from pathlib import Path
+
+import cron.jobs as jobs
+import hermes_cli.main as main_mod
+
+base = Path(sys.argv[1])
+jobs.CRON_DIR = base / "cron"
+jobs.JOBS_FILE = jobs.CRON_DIR / "jobs.json"
+jobs.OUTPUT_DIR = jobs.CRON_DIR / "output"
+
+results = []
+for argv in json.loads(sys.argv[2]):
+    sys.argv = ["hermes", *argv]
+    try:
+        rc = main_mod.main()
+        code = int(rc or 0)
+    except SystemExit as exc:
+        code = int(exc.code or 0)
+    results.append({"argv": argv, "code": code})
+print(json.dumps(results))
+"""
+    return subprocess.run(
+        [sys.executable, "-c", driver, str(hermes_home), json.dumps(argvs)],
+        capture_output=True,
+        text=True,
+        timeout=120,
+        env={
+            "HERMES_HOME": str(hermes_home),
+            "HOME": str(hermes_home / "host-home"),
+            "PATH": "",
+            "PYTHONPATH": ".",
+        },
+    )
+
+
+def _parsed_results(result: subprocess.CompletedProcess[str]) -> list[dict]:
+    assert result.returncode == 0, result.stderr
+    return json.loads(result.stdout.strip().splitlines()[-1])
+
+
+def test_main_doctor_target_missing_returns_one(tmp_path):
+    home = tmp_path / "hermes-home"
+    (home / "host-home").mkdir(parents=True)
+
+    result = _run_driver([["doctor", "skill", "missing-skill"]], home)
+
+    assert _parsed_results(result)[0]["code"] == 1
+
+
+def test_main_doctor_invalid_target_selection_returns_two(tmp_path):
+    home = tmp_path / "hermes-home"
+    (home / "host-home").mkdir(parents=True)
+
+    result = _run_driver([["doctor", "skill"]], home)
+
+    assert _parsed_results(result)[0]["code"] == 2
+
+
+def test_main_cron_strict_preflight_failure_returns_one_after_save(tmp_path):
+    home = tmp_path / "hermes-home"
+    (home / "host-home").mkdir(parents=True)
+
+    result = _run_driver(
+        [
+            [
+                "cron",
+                "create",
+                "every 1h",
+                "Run",
+                "--name",
+                "Strict Fail",
+                "--strict-preflight",
+                "--skill",
+                "missing-skill",
+            ]
+        ],
+        home,
+    )
+
+    assert _parsed_results(result)[0]["code"] == 1
+    assert "Created job:" in result.stdout
+    assert "Job saved. Preflight failed." in result.stdout

--- a/tests/hermes_cli/test_reliability_doctor_checks.py
+++ b/tests/hermes_cli/test_reliability_doctor_checks.py
@@ -1,0 +1,569 @@
+from __future__ import annotations
+
+import json
+import sys
+
+import pytest
+
+import hermes_cli.reliability_doctor as rd
+from hermes_cli.reliability_doctor import (
+    DiagnosticResult,
+    SmokeValidationError,
+    diagnose_all_crons,
+    diagnose_all_skills,
+    diagnose_cron,
+    diagnose_skill,
+    evaluate_static_probes,
+    resolve_probe_path,
+    validate_smoke_spec,
+)
+
+
+def test_resolve_probe_path_stays_within_selected_root(tmp_path):
+    root = tmp_path / "root"
+    nested = root / "scripts"
+    nested.mkdir(parents=True)
+
+    resolved = resolve_probe_path("workdir", "scripts/check.py", {"workdir": root})
+
+    assert resolved == nested / "check.py"
+
+
+def test_resolve_probe_path_rejects_symlink_escape(tmp_path):
+    root = tmp_path / "root"
+    outside = tmp_path / "outside"
+    root.mkdir()
+    outside.mkdir()
+    (root / "escape").symlink_to(outside, target_is_directory=True)
+
+    with pytest.raises(SmokeValidationError, match="path_escape"):
+        resolve_probe_path("workdir", "escape/secret.txt", {"workdir": root})
+
+
+def test_env_present_reports_presence_without_value(monkeypatch):
+    monkeypatch.setenv("GH_TOKEN", "PLANTED_SECRET")
+    smoke = validate_smoke_spec({
+        "version": 1,
+        "probes": [{"type": "env-present", "name": "GH_TOKEN"}],
+    })
+
+    [result] = evaluate_static_probes(
+        smoke,
+        subject_type="skill",
+        subject="github",
+        roots={},
+        env={"GH_TOKEN": "PLANTED_SECRET"},
+    )
+
+    assert result.status == "pass"
+    assert result.reason == "env_present"
+    assert "PLANTED_SECRET" not in repr(result)
+    assert "PLANTED_SECRET" not in str(result.to_dict())
+
+
+def test_static_env_present_defaults_to_current_process_environment(monkeypatch):
+    monkeypatch.setenv("SMOKE_PRESENT_IN_PROCESS", "PLANTED_SECRET")
+    smoke = validate_smoke_spec({
+        "version": 1,
+        "probes": [{"type": "env-present", "name": "SMOKE_PRESENT_IN_PROCESS"}],
+    })
+
+    [result] = evaluate_static_probes(
+        smoke,
+        subject_type="skill",
+        subject="local",
+        roots={},
+    )
+
+    assert result.status == "pass"
+    assert result.reason == "env_present"
+    assert "PLANTED_SECRET" not in str(result.to_dict())
+
+
+def test_command_exists_uses_which_without_running_command(monkeypatch):
+    called = {}
+
+    def fake_which(name):
+        called["name"] = name
+        return "/usr/bin/gh"
+
+    monkeypatch.setattr("hermes_cli.reliability_doctor.shutil.which", fake_which)
+    smoke = validate_smoke_spec({
+        "version": 1,
+        "probes": [{"type": "command-exists", "name": "gh"}],
+    })
+
+    [result] = evaluate_static_probes(
+        smoke, subject_type="skill", subject="github", roots={}, env={}
+    )
+
+    assert called == {"name": "gh"}
+    assert result.status == "pass"
+    assert result.reason == "command_found"
+
+
+def test_python_import_checks_top_level_and_dotted_module_without_import_side_effect(
+    tmp_path,
+):
+    package = tmp_path / "sideeffectpkg"
+    package.mkdir()
+    marker = tmp_path / "imported"
+    (package / "__init__.py").write_text(
+        f"from pathlib import Path\nPath({str(marker)!r}).write_text('imported')\n",
+        encoding="utf-8",
+    )
+    (package / "submodule.py").write_text("VALUE = 1\n", encoding="utf-8")
+    smoke = validate_smoke_spec({
+        "version": 1,
+        "probes": [
+            {"type": "python-import", "module": "sideeffectpkg"},
+            {"type": "python-import", "module": "sideeffectpkg.submodule"},
+        ],
+    })
+
+    old_path = list(sys.path)
+    try:
+        sys.path.insert(0, str(tmp_path))
+        results = evaluate_static_probes(
+            smoke, subject_type="skill", subject="local", roots={}, env={}
+        )
+    finally:
+        sys.path[:] = old_path
+
+    assert [r.status for r in results] == ["pass", "pass"]
+    assert not marker.exists()
+
+
+def test_mcp_configured_reads_config_presence_without_connecting(tmp_path, monkeypatch):
+    def fail_import(name, *args, **kwargs):
+        if name == "tools.mcp_tool":  # pragma: no cover - should never happen
+            raise AssertionError("static MCP check must not connect/import mcp tool")
+        return real_import(name, *args, **kwargs)
+
+    real_import = __import__
+    monkeypatch.setattr("builtins.__import__", fail_import)
+    smoke = validate_smoke_spec({
+        "version": 1,
+        "probes": [{"type": "mcp-configured", "server": "github"}],
+    })
+
+    [result] = evaluate_static_probes(
+        smoke,
+        subject_type="cron",
+        subject="daily",
+        roots={},
+        env={},
+        mcp_servers={"github": {"command": "mcp-server-github"}},
+    )
+
+    assert result == DiagnosticResult(
+        subject_type="cron",
+        subject="daily",
+        probe_type="mcp-configured",
+        target="github",
+        status="pass",
+        reason="mcp_configured",
+    )
+
+
+def test_path_probe_symlink_escape_returns_stable_failure(tmp_path):
+    root = tmp_path / "root"
+    outside = tmp_path / "outside"
+    root.mkdir()
+    outside.mkdir()
+    (root / "escape").symlink_to(outside, target_is_directory=True)
+    smoke = validate_smoke_spec({
+        "version": 1,
+        "probes": [{"type": "file-exists", "root": "workdir", "path": "escape/x"}],
+    })
+
+    [result] = evaluate_static_probes(
+        smoke,
+        subject_type="cron",
+        subject="daily",
+        roots={"workdir": root},
+    )
+
+    assert result.status == "fail"
+    assert result.reason == "path_escape"
+
+
+def test_diagnose_skill_reports_required_env_and_commands(monkeypatch):
+    monkeypatch.setattr(rd, "_find_all_skills", lambda: [{"name": "github"}])
+    monkeypatch.setattr(
+        rd,
+        "skill_view",
+        lambda name, preprocess=False, metadata_only=False: json.dumps({
+            "success": True,
+            "frontmatter": {
+                "name": "github",
+                "required_environment_variables": [{"name": "GH_TOKEN"}],
+                "prerequisites": {"commands": ["gh"]},
+            },
+        }),
+    )
+    monkeypatch.setattr(
+        rd.shutil, "which", lambda name: "/usr/bin/gh" if name == "gh" else None
+    )
+
+    results = diagnose_skill("github")
+
+    assert [(r.probe_type, r.target, r.status, r.reason) for r in results] == [
+        ("env-present", "GH_TOKEN", "fail", "env_missing"),
+        ("command-exists", "gh", "pass", "command_found"),
+    ]
+
+
+def test_diagnose_skill_defaults_to_current_process_environment(monkeypatch):
+    monkeypatch.setattr(rd, "_find_all_skills", lambda: [{"name": "github"}])
+    monkeypatch.setattr(
+        rd,
+        "_load_skill_frontmatter",
+        lambda name: {"required_environment_variables": ["GH_TOKEN"]},
+    )
+    monkeypatch.setenv("GH_TOKEN", "PLANTED_SECRET")
+
+    results = diagnose_skill("github")
+
+    [env_result] = [result for result in results if result.probe_type == "env-present"]
+    assert env_result.status == "pass"
+    assert env_result.reason == "env_present"
+    assert "PLANTED_SECRET" not in str(env_result.to_dict())
+
+
+def test_diagnose_skill_does_not_fail_for_missing_optional_environment(monkeypatch):
+    monkeypatch.setattr(rd, "_find_all_skills", lambda: [{"name": "optional"}])
+    monkeypatch.setattr(
+        rd,
+        "_load_skill_frontmatter",
+        lambda name: {
+            "required_environment_variables": [
+                {"name": "OPTIONAL_TOKEN", "optional": True}
+            ]
+        },
+    )
+
+    results = diagnose_skill("optional", env={})
+
+    assert all(result.status != "fail" for result in results)
+    assert all(result.target != "OPTIONAL_TOKEN" for result in results)
+
+
+def test_diagnose_skill_reports_malformed_legacy_prerequisites_without_crashing(
+    monkeypatch,
+):
+    monkeypatch.setattr(rd, "_find_all_skills", lambda: [{"name": "legacy"}])
+    monkeypatch.setattr(
+        rd,
+        "_load_skill_frontmatter",
+        lambda name: {"prerequisites": {"commands": 7}},
+    )
+
+    results = diagnose_skill("legacy", env={})
+
+    assert results == [
+        DiagnosticResult(
+            "skill",
+            "legacy",
+            "skill-metadata",
+            "legacy",
+            "fail",
+            "invalid_skill_metadata",
+        )
+    ]
+
+
+def test_diagnose_skill_does_not_return_environment_value(monkeypatch):
+    monkeypatch.setattr(rd, "_find_all_skills", lambda: [{"name": "github"}])
+    monkeypatch.setattr(
+        rd,
+        "skill_view",
+        lambda name, preprocess=False, metadata_only=False: json.dumps({
+            "success": True,
+            "frontmatter": {
+                "name": "github",
+                "prerequisites": {"env_vars": ["GH_TOKEN"]},
+            },
+        }),
+    )
+
+    results = diagnose_skill("github", env={"GH_TOKEN": "PLANTED_SECRET"})
+
+    assert results[0].status == "pass"
+    assert "PLANTED_SECRET" not in repr(results)
+    assert "PLANTED_SECRET" not in str([r.to_dict() for r in results])
+
+
+def test_diagnose_skill_not_found_is_stable_failure(monkeypatch):
+    monkeypatch.setattr(rd, "_find_all_skills", lambda: [{"name": "other"}])
+
+    [result] = diagnose_skill("missing")
+
+    assert result == DiagnosticResult(
+        subject_type="skill",
+        subject="missing",
+        probe_type="skill",
+        target="missing",
+        status="fail",
+        reason="skill_not_found",
+    )
+
+
+def test_diagnose_all_skills_uses_current_skill_discovery(monkeypatch):
+    monkeypatch.setattr(
+        rd, "_find_all_skills", lambda: [{"name": "one"}, {"name": "two"}]
+    )
+    monkeypatch.setattr(
+        rd,
+        "diagnose_skill",
+        lambda name: [
+            DiagnosticResult("skill", name, "skill", name, "pass", "skill_found")
+        ],
+    )
+
+    result = diagnose_all_skills()
+
+    assert list(result) == ["one", "two"]
+    assert result["one"][0].reason == "skill_found"
+
+
+def test_diagnose_cron_reports_prompt_or_skill_and_schedule(monkeypatch):
+    monkeypatch.setattr(
+        rd,
+        "resolve_job_ref",
+        lambda ref: {
+            "id": "abc123",
+            "name": "daily",
+            "prompt": "Summarize",
+            "skills": ["github"],
+            "schedule": {"kind": "interval"},
+            "schedule_display": "every 1h",
+        },
+    )
+
+    results = diagnose_cron("daily")
+
+    assert ("cron-prompt", "prompt", "pass", "cron_prompt_present") in [
+        (r.probe_type, r.target, r.status, r.reason) for r in results
+    ]
+    assert ("cron-skill", "github", "pass", "cron_skill_attached") in [
+        (r.probe_type, r.target, r.status, r.reason) for r in results
+    ]
+    assert ("cron-schedule", "every 1h", "pass", "cron_schedule_present") in [
+        (r.probe_type, r.target, r.status, r.reason) for r in results
+    ]
+
+
+def test_diagnose_cron_reports_missing_stored_script(monkeypatch, tmp_path):
+    monkeypatch.setattr(rd, "get_hermes_home", lambda: tmp_path)
+    monkeypatch.setattr(
+        rd,
+        "resolve_job_ref",
+        lambda ref: {
+            "id": "abc123",
+            "prompt": "Run",
+            "script": "reports/check.py",
+            "schedule": {"kind": "interval"},
+        },
+    )
+
+    results = diagnose_cron("daily")
+
+    assert ("cron-script", "reports/check.py", "fail", "script_missing") in [
+        (r.probe_type, r.target, r.status, r.reason) for r in results
+    ]
+
+
+def test_diagnose_no_agent_cron_does_not_require_prompt(monkeypatch, tmp_path):
+    script = tmp_path / "scripts" / "watchdog.py"
+    script.parent.mkdir(parents=True)
+    script.write_text("print('ok')\n", encoding="utf-8")
+    monkeypatch.setattr(rd, "get_hermes_home", lambda: tmp_path)
+    monkeypatch.setattr(
+        rd,
+        "resolve_job_ref",
+        lambda ref: {
+            "id": "abc123",
+            "prompt": "",
+            "skills": [],
+            "no_agent": True,
+            "script": "watchdog.py",
+            "schedule": {"kind": "interval"},
+        },
+    )
+
+    results = diagnose_cron("watchdog")
+
+    assert all(result.status != "fail" for result in results)
+    assert any(result.reason == "cron_prompt_not_required" for result in results)
+    assert any(result.reason == "script_exists" for result in results)
+
+
+def test_diagnose_cron_reports_existing_stored_script(monkeypatch, tmp_path):
+    script = tmp_path / "scripts" / "reports" / "check.py"
+    script.parent.mkdir(parents=True)
+    script.write_text("print('ok')\n", encoding="utf-8")
+    monkeypatch.setattr(rd, "get_hermes_home", lambda: tmp_path)
+    monkeypatch.setattr(
+        rd,
+        "resolve_job_ref",
+        lambda ref: {
+            "id": "abc123",
+            "prompt": "Run",
+            "script": "reports/check.py",
+            "schedule": {"kind": "interval"},
+        },
+    )
+
+    results = diagnose_cron("daily")
+
+    assert ("cron-script", "reports/check.py", "pass", "script_exists") in [
+        (r.probe_type, r.target, r.status, r.reason) for r in results
+    ]
+
+
+def test_diagnose_cron_rejects_hand_edited_script_escape(monkeypatch, tmp_path):
+    monkeypatch.setattr(rd, "get_hermes_home", lambda: tmp_path)
+    monkeypatch.setattr(
+        rd,
+        "resolve_job_ref",
+        lambda ref: {
+            "id": "abc123",
+            "prompt": "Run",
+            "script": "../outside.py",
+            "schedule": {"kind": "interval"},
+        },
+    )
+
+    results = diagnose_cron("daily")
+
+    assert ("cron-script", "../outside.py", "fail", "script_path_escape") in [
+        (r.probe_type, r.target, r.status, r.reason) for r in results
+    ]
+
+
+def test_diagnose_cron_diagnoses_attached_skill_prerequisites(monkeypatch):
+    monkeypatch.setattr(
+        rd,
+        "resolve_job_ref",
+        lambda ref: {
+            "id": "abc123",
+            "name": "daily",
+            "prompt": "",
+            "skills": ["github"],
+            "schedule": {"kind": "interval"},
+        },
+    )
+    monkeypatch.setattr(
+        rd,
+        "diagnose_skill",
+        lambda name: [
+            DiagnosticResult(
+                "skill", name, "env-present", "GH_TOKEN", "fail", "env_missing"
+            )
+        ],
+    )
+
+    results = diagnose_cron("daily")
+
+    assert ("cron-skill", "github", "pass", "cron_skill_attached") in [
+        (r.probe_type, r.target, r.status, r.reason) for r in results
+    ]
+    assert ("skill", "github", "env-present", "GH_TOKEN", "fail", "env_missing") in [
+        (r.subject_type, r.subject, r.probe_type, r.target, r.status, r.reason)
+        for r in results
+    ]
+
+
+def test_diagnose_cron_runs_static_smoke_only(monkeypatch, tmp_path):
+    marker = tmp_path / "marker.txt"
+    marker.write_text("ok", encoding="utf-8")
+    monkeypatch.setattr(
+        rd,
+        "resolve_job_ref",
+        lambda ref: {
+            "id": "abc123",
+            "name": "daily",
+            "prompt": "Run",
+            "schedule": {"kind": "interval"},
+            "workdir": str(tmp_path),
+            "smoke": {
+                "version": 1,
+                "probes": [
+                    {
+                        "type": "file-exists",
+                        "root": "workdir",
+                        "path": "marker.txt",
+                    }
+                ],
+            },
+        },
+    )
+
+    results = diagnose_cron("daily")
+
+    assert any(
+        result.probe_type == "file-exists" and result.status == "pass"
+        for result in results
+    )
+
+
+def test_diagnose_cron_reports_invalid_hand_edited_smoke_without_crashing(monkeypatch):
+    monkeypatch.setattr(
+        rd,
+        "resolve_job_ref",
+        lambda ref: {
+            "id": "abc123",
+            "name": "daily",
+            "prompt": "Summarize",
+            "schedule": {"kind": "interval"},
+            "smoke": {
+                "version": 1,
+                "probes": [{"type": "shell", "command": "echo nope"}],
+            },
+        },
+    )
+
+    results = diagnose_cron("daily")
+
+    assert any(
+        r.probe_type == "smoke-schema" and r.reason == "invalid_smoke" for r in results
+    )
+
+
+def test_diagnose_cron_ref_preserves_ambiguous_name_failure(monkeypatch):
+    from cron.jobs import AmbiguousJobReference
+
+    def raise_ambiguous(ref):
+        raise AmbiguousJobReference(ref, [{"id": "one"}, {"id": "two"}])
+
+    monkeypatch.setattr(rd, "resolve_job_ref", raise_ambiguous)
+
+    [result] = diagnose_cron("daily")
+
+    assert result.status == "fail"
+    assert result.reason == "cron_ref_ambiguous"
+
+
+def test_diagnose_all_crons_includes_disabled_jobs(monkeypatch):
+    monkeypatch.setattr(
+        rd,
+        "list_jobs",
+        lambda include_disabled=False: (
+            [
+                {"id": "enabled", "name": "Enabled", "enabled": True},
+                {"id": "disabled", "name": "Disabled", "enabled": False},
+            ]
+            if include_disabled
+            else [{"id": "enabled", "name": "Enabled", "enabled": True}]
+        ),
+    )
+    monkeypatch.setattr(
+        rd,
+        "diagnose_cron",
+        lambda ref: [DiagnosticResult("cron", ref, "cron", ref, "pass", "cron_found")],
+    )
+
+    result = diagnose_all_crons()
+
+    assert list(result) == ["enabled", "disabled"]

--- a/tests/hermes_cli/test_reliability_doctor_schema.py
+++ b/tests/hermes_cli/test_reliability_doctor_schema.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+import pytest
+
+from hermes_cli.reliability_doctor import (
+    DiagnosticResult,
+    SmokeValidationError,
+    validate_smoke_spec,
+)
+
+
+def test_validate_smoke_spec_canonicalises_supported_static_probes():
+    source = {
+        "version": 1,
+        "probes": [
+            {"type": "command-exists", "name": "gh"},
+            {"type": "env-present", "name": "GH_TOKEN"},
+            {"type": "file-exists", "root": "hermes_home", "path": "scripts/a.py"},
+            {"type": "directory-exists", "root": "workdir", "path": "fixtures"},
+            {"type": "python-import", "module": "yaml"},
+            {"type": "mcp-configured", "server": "example"},
+        ],
+    }
+
+    validated = validate_smoke_spec(source)
+
+    assert validated == {
+        "version": 1,
+        "probes": [
+            {"type": "command-exists", "name": "gh"},
+            {"type": "env-present", "name": "GH_TOKEN"},
+            {"type": "file-exists", "root": "hermes_home", "path": "scripts/a.py"},
+            {"type": "directory-exists", "root": "workdir", "path": "fixtures"},
+            {"type": "python-import", "module": "yaml"},
+            {"type": "mcp-configured", "server": "example"},
+        ],
+    }
+
+
+def test_validate_smoke_spec_rejects_unknown_top_level_field():
+    with pytest.raises(SmokeValidationError, match="unknown_field"):
+        validate_smoke_spec({"version": 1, "probes": [], "extra": True})
+
+
+def test_validate_smoke_spec_rejects_unknown_probe_field():
+    with pytest.raises(SmokeValidationError, match="unknown_probe_field"):
+        validate_smoke_spec({
+            "version": 1,
+            "probes": [{"type": "env-present", "name": "X", "value": "secret"}],
+        })
+
+
+def test_validate_smoke_spec_rejects_command_probe_with_stable_reason():
+    with pytest.raises(SmokeValidationError, match="unknown_probe_type"):
+        validate_smoke_spec({
+            "version": 1,
+            "probes": [
+                {"type": "command", "argv": ["true"], "expected_exit_codes": [0]}
+            ],
+        })
+
+
+def test_validate_smoke_spec_rejects_more_than_32_probes():
+    probes = [{"type": "env-present", "name": f"X_{idx}"} for idx in range(33)]
+    with pytest.raises(SmokeValidationError, match="too_many_probes"):
+        validate_smoke_spec({"version": 1, "probes": probes})
+
+
+@pytest.mark.parametrize(
+    "path", ["/etc/passwd", "../secret", "a/../../secret", "C:/temp/x"]
+)
+def test_validate_smoke_spec_rejects_absolute_and_parent_paths(path):
+    with pytest.raises(SmokeValidationError, match="invalid_path"):
+        validate_smoke_spec({
+            "version": 1,
+            "probes": [{"type": "file-exists", "root": "workdir", "path": path}],
+        })
+
+
+@pytest.mark.parametrize("value", ["BAD\nNAME", "BAD\u200bNAME", "BAD\x00NAME"])
+def test_validate_smoke_spec_rejects_control_and_invisible_characters(value):
+    with pytest.raises(SmokeValidationError, match="invalid_text"):
+        validate_smoke_spec({
+            "version": 1,
+            "probes": [{"type": "env-present", "name": value}],
+        })
+
+
+@pytest.mark.parametrize(
+    ("probe", "reason"),
+    [
+        (
+            {"type": "file-exists", "root": "workdir", "path": ["secret"]},
+            "invalid_path",
+        ),
+        ({"type": "env-present", "name": {"bad": "shape"}}, "invalid_name"),
+        ({"type": "python-import", "module": "bad-name"}, "invalid_module"),
+        ({"type": "mcp-configured", "server": "bad/name"}, "invalid_server"),
+    ],
+)
+def test_validate_smoke_spec_malformed_shapes_raise_stable_reasons(probe, reason):
+    with pytest.raises(SmokeValidationError, match=reason):
+        validate_smoke_spec({"version": 1, "probes": [probe]})
+
+
+@pytest.mark.parametrize(
+    ("spec", "reason"),
+    [
+        ({"version": 1, "probes": [{"type": []}]}, "unknown_probe_type"),
+        (
+            {
+                "version": 1,
+                "probes": [{"type": "env-present", "name": "TOKEN", 1: "x"}],
+            },
+            "invalid_probe_field",
+        ),
+        ({"version": 1, "probes": [], 1: "x"}, "invalid_smoke_field"),
+    ],
+)
+def test_validate_smoke_spec_non_string_schema_shapes_raise_stable_reasons(
+    spec, reason
+):
+    with pytest.raises(SmokeValidationError, match=reason):
+        validate_smoke_spec(spec)
+
+
+def test_diagnostic_result_to_dict_has_no_free_form_output_field():
+    result = DiagnosticResult(
+        subject_type="cron",
+        subject="daily",
+        probe_type="env-present",
+        target="GH_TOKEN",
+        status="pass",
+        reason="env_present",
+    )
+
+    assert result.to_dict() == {
+        "subject_type": "cron",
+        "subject": "daily",
+        "probe_type": "env-present",
+        "target": "GH_TOKEN",
+        "status": "pass",
+        "reason": "env_present",
+    }
+    forbidden = {
+        "stdout",
+        "stderr",
+        "output",
+        "detail",
+        "exception",
+        "environment",
+        "exit_code",
+        "duration_ms",
+    }
+    assert forbidden.isdisjoint(result.to_dict())

--- a/tests/hermes_cli/test_reliability_doctor_security.py
+++ b/tests/hermes_cli/test_reliability_doctor_security.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import inspect
+import json
+
+import hermes_cli.reliability_doctor as reliability_doctor
+from hermes_cli.reliability_doctor import (
+    evaluate_static_probes,
+    render_diagnostic_json,
+    render_diagnostic_text,
+    validate_smoke_spec,
+)
+
+
+def test_reliability_doctor_exposes_no_command_execution_path():
+    source = inspect.getsource(reliability_doctor)
+
+    assert not hasattr(reliability_doctor, "execute_command_probe")
+    assert "subprocess" not in source
+    assert "Popen" not in source
+    assert "psutil" not in source
+    assert "build_subprocess_env" not in source
+
+
+def test_command_probe_is_rejected_before_static_evaluation():
+    try:
+        validate_smoke_spec({
+            "version": 1,
+            "probes": [
+                {"type": "command", "argv": ["true"], "expected_exit_codes": [0]}
+            ],
+        })
+    except Exception as exc:
+        assert str(exc) == "unknown_probe_type"
+    else:  # pragma: no cover - should be rejected
+        raise AssertionError("command smoke probes must not validate")
+
+
+def test_static_diagnostics_do_not_disclose_secret_values(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "PLANTED_PROVIDER_SECRET")
+    smoke = validate_smoke_spec({
+        "version": 1,
+        "probes": [{"type": "env-present", "name": "OPENAI_API_KEY"}],
+    })
+
+    [result] = evaluate_static_probes(
+        smoke, subject_type="cron", subject="job", roots={}
+    )
+
+    assert result.status == "pass"
+    assert "PLANTED_PROVIDER_SECRET" not in repr(result)
+    assert "PLANTED_PROVIDER_SECRET" not in json.dumps(result.to_dict())
+    assert "PLANTED_PROVIDER_SECRET" not in render_diagnostic_text([result])
+    assert "PLANTED_PROVIDER_SECRET" not in render_diagnostic_json([result])
+
+
+def test_hand_edited_job_fields_cannot_inject_or_expand_diagnostic_output(monkeypatch):
+    malicious_schedule = "every 1h\nFAIL forged " + ("x" * 2_000)
+    monkeypatch.setattr(
+        reliability_doctor,
+        "resolve_job_ref",
+        lambda ref: {
+            "id": "job\nFAIL forged-subject",
+            "prompt": "Run",
+            "schedule": {"kind": "interval"},
+            "schedule_display": malicious_schedule,
+        },
+    )
+
+    results = reliability_doctor.diagnose_cron("daily")
+    text = render_diagnostic_text(results)
+    payload = render_diagnostic_json(results)
+
+    assert "\nFAIL forged" not in text
+    assert "\nFAIL forged" not in payload
+    assert len(text) < 1_200

--- a/tests/hermes_cli/test_subcommands_batch.py
+++ b/tests/hermes_cli/test_subcommands_batch.py
@@ -97,6 +97,41 @@ def test_config_get_unset_subcommands_parse():
     assert ns.key == "terminal.backend"
 
 
+def test_doctor_targeted_subcommands_parse_without_breaking_existing_shapes():
+    parser = argparse.ArgumentParser(prog="hermes")
+    sub = parser.add_subparsers(dest="command")
+    handler = _h("doctor")
+    build_doctor_parser(sub, cmd_doctor=handler)
+
+    ns = parser.parse_args(["doctor"])
+    assert ns.func is handler
+    assert ns.command == "doctor"
+    assert ns.fix is False
+    assert ns.ack is None
+    assert getattr(ns, "doctor_target", None) is None
+
+    ns = parser.parse_args(["doctor", "--fix"])
+    assert ns.fix is True
+    assert getattr(ns, "doctor_target", None) is None
+
+    ns = parser.parse_args(["doctor", "--ack", "ADV-1"])
+    assert ns.ack == "ADV-1"
+    assert getattr(ns, "doctor_target", None) is None
+
+    ns = parser.parse_args(["doctor", "skill", "example", "--json"])
+    assert ns.doctor_target == "skill"
+    assert ns.target == "example"
+    assert ns.all is False
+    assert ns.json is True
+
+    with pytest.raises(SystemExit) as exc:
+        parser.parse_args(["doctor", "skill", "example", "--smoke"])
+    assert exc.value.code == 2
+
+    ns = parser.parse_args(["doctor", "cron", "--all"])
+    assert ns.doctor_target == "cron"
+    assert ns.all is True
+    assert ns.target is None
 
 
 # ── deprecated `hermes login` fails gracefully, not with argparse error ────

--- a/tests/tools/test_cronjob_tools.py
+++ b/tests/tools/test_cronjob_tools.py
@@ -246,6 +246,130 @@ class TestUnifiedCronjobTool:
         assert listing["jobs"][0]["name"] == "Server Check"
         assert listing["jobs"][0]["state"] == "scheduled"
 
+    def test_cronjob_create_accepts_and_returns_smoke_summary(self):
+        created = json.loads(
+            cronjob(
+                action="create",
+                prompt="Check server status",
+                schedule="every 1h",
+                name="Server Check",
+                smoke={
+                    "version": 1,
+                    "probes": [
+                        {"type": "env-present", "name": "GH_TOKEN"},
+                        {"type": "command-exists", "name": "gh"},
+                    ],
+                },
+            )
+        )
+
+        assert created["success"] is True
+        assert created["job"]["smoke"] == {
+            "version": 1,
+            "probe_count": 2,
+            "probe_types": ["command-exists", "env-present"],
+        }
+
+    def test_cronjob_update_replaces_smoke(self):
+        created = json.loads(
+            cronjob(action="create", prompt="Run", schedule="every 1h", name="Smoke")
+        )
+
+        updated = json.loads(
+            cronjob(
+                action="update",
+                job_id=created["job_id"],
+                smoke={"version": 1, "probes": [{"type": "command-exists", "name": "gh"}]},
+            )
+        )
+
+        assert updated["success"] is True
+        assert updated["job"]["smoke"]["probe_types"] == ["command-exists"]
+
+    def test_cronjob_update_empty_smoke_clears_metadata(self):
+        created = json.loads(
+            cronjob(
+                action="create",
+                prompt="Run",
+                schedule="every 1h",
+                name="Smoke",
+                smoke={"version": 1, "probes": [{"type": "env-present", "name": "GH_TOKEN"}]},
+            )
+        )
+
+        updated = json.loads(cronjob(action="update", job_id=created["job_id"], smoke={}))
+
+        assert updated["success"] is True
+        assert "smoke" not in updated["job"]
+
+    def test_cronjob_rejects_invalid_smoke_before_create(self):
+        result = json.loads(
+            cronjob(
+                action="create",
+                prompt="Run",
+                schedule="every 1h",
+                smoke={"version": 1, "probes": [{"type": "shell", "command": "echo nope"}]},
+            )
+        )
+
+        assert result["success"] is False
+        assert "smoke" in result["error"].lower()
+
+    def test_cronjob_rejects_command_probe_before_create(self):
+        result = json.loads(
+            cronjob(
+                action="create",
+                prompt="Run",
+                schedule="every 1h",
+                smoke={
+                    "version": 1,
+                    "probes": [
+                        {
+                            "type": "command",
+                            "argv": ["true"],
+                            "expected_exit_codes": [0],
+                        }
+                    ],
+                },
+            )
+        )
+
+        assert result["success"] is False
+        assert "unknown_probe_type" in result["error"]
+
+    def test_cronjob_rejects_command_probe_before_update(self):
+        created = json.loads(
+            cronjob(action="create", prompt="Run", schedule="every 1h", name="Smoke")
+        )
+
+        result = json.loads(
+            cronjob(
+                action="update",
+                job_id=created["job_id"],
+                smoke={
+                    "version": 1,
+                    "probes": [
+                        {
+                            "type": "command",
+                            "argv": ["true"],
+                            "expected_exit_codes": [0],
+                        }
+                    ],
+                },
+            )
+        )
+
+        assert result["success"] is False
+        assert "unknown_probe_type" in result["error"]
+
+    def test_cronjob_schema_exposes_smoke_object(self):
+        from tools.cronjob_tools import CRONJOB_SCHEMA
+
+        smoke_schema = CRONJOB_SCHEMA["parameters"]["properties"]["smoke"]
+        assert smoke_schema["type"] == "object"
+        assert "Command probes are rejected" in smoke_schema["description"]
+        assert "run_smoke" not in CRONJOB_SCHEMA["parameters"]["properties"]
+
     def test_list_handles_partial_legacy_job_records(self):
         from cron.jobs import save_jobs
 

--- a/tests/tools/test_skills_tool.py
+++ b/tests/tools/test_skills_tool.py
@@ -411,6 +411,38 @@ class TestSkillView:
 
 
 class TestSkillViewSecureSetupOnLoad:
+    def test_metadata_only_never_requests_missing_secrets(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("TENOR_API_KEY", raising=False)
+        calls = []
+
+        def fail_secret_callback(var_name, prompt, metadata=None):
+            calls.append((var_name, prompt, metadata))
+            raise AssertionError("metadata-only reads must not request secrets")
+
+        monkeypatch.setattr(
+            skills_tool_module,
+            "_secret_capture_callback",
+            fail_secret_callback,
+            raising=False,
+        )
+
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(
+                tmp_path,
+                "gif-search",
+                frontmatter_extra=(
+                    "required_environment_variables:\n"
+                    "  - name: TENOR_API_KEY\n"
+                    "    prompt: Tenor API key\n"
+                ),
+            )
+            raw = skill_view("gif-search", metadata_only=True)
+
+        result = json.loads(raw)
+        assert result["success"] is True
+        assert result["frontmatter"]["name"] == "gif-search"
+        assert calls == []
+
     def test_requests_missing_required_env_and_continues(self, tmp_path, monkeypatch):
         monkeypatch.delenv("TENOR_API_KEY", raising=False)
         calls = []

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -594,7 +594,25 @@ def _format_job(job: Dict[str, Any]) -> Dict[str, Any]:
         result["enabled_toolsets"] = job["enabled_toolsets"]
     if job.get("workdir"):
         result["workdir"] = job["workdir"]
+    smoke_summary = _smoke_summary(job.get("smoke"))
+    if smoke_summary:
+        result["smoke"] = smoke_summary
     return result
+
+
+def _smoke_summary(smoke: Any) -> Optional[Dict[str, Any]]:
+    if not isinstance(smoke, dict):
+        return None
+    probes = smoke.get("probes")
+    if not isinstance(probes, list):
+        return None
+    return {
+        "version": smoke.get("version", 1),
+        "probe_count": len(probes),
+        "probe_types": sorted(
+            {str(probe.get("type")) for probe in probes if isinstance(probe, dict)}
+        ),
+    }
 
 
 def _execute_job_now(
@@ -1052,6 +1070,7 @@ def cronjob(
     attach_to_session: Optional[bool] = None,
     monitor_script: Optional[str] = None,
     monitor_url: Optional[str] = None,
+    smoke: Optional[Dict[str, Any]] = None,
     task_id: str = None,
     session_id: Optional[str] = None,
 ) -> str:
@@ -1102,6 +1121,13 @@ def cronjob(
             base_url_error = _validate_cron_base_url(provider, base_url)
             if base_url_error:
                 return tool_error(base_url_error, success=False)
+            try:
+                if smoke is not None:
+                    from hermes_cli.reliability_doctor import validate_smoke_spec
+
+                    smoke = validate_smoke_spec(smoke)
+            except Exception as e:
+                return tool_error(f"Invalid smoke metadata: {e}", success=False)
 
             # Validate context_from references existing jobs
             if context_from:
@@ -1140,6 +1166,7 @@ def cronjob(
                     attach_to_session=attach_to_session,
                     monitor_script=_normalize_optional_job_value(monitor_script),
                     monitor_url=_normalize_optional_job_value(monitor_url),
+                    smoke=smoke,
                 )
             except CronSchedulerRegistrationError as exc:
                 _partial = exc.to_dict()
@@ -1399,6 +1426,16 @@ def cronjob(
                 # Empty string clears the field (restores old behaviour);
                 # otherwise pass raw — update_job() validates / normalizes.
                 updates["workdir"] = _normalize_optional_job_value(workdir) or None
+            if smoke is not None:
+                if smoke == {}:
+                    updates["smoke"] = None
+                else:
+                    try:
+                        from hermes_cli.reliability_doctor import validate_smoke_spec
+
+                        updates["smoke"] = validate_smoke_spec(smoke)
+                    except Exception as e:
+                        return tool_error(f"Invalid smoke metadata: {e}", success=False)
             if no_agent is not None:
                 # Toggling no_agent on/off at update time. If flipping to True,
                 # we need a script to already exist on the job (or be part of
@@ -1552,6 +1589,15 @@ Important safety rule: cron-run sessions should not recursively schedule more cr
                 "type": "boolean",
                 "description": "When True, this job becomes CONTINUABLE: the user can reply to its delivery and the agent has the brief in context instead of asking 'what is that?'. On thread-capable platforms (Telegram topics, Discord/Slack threads) a dedicated thread is opened for the job and its replies; on DM-only platforms (WhatsApp/Signal) the brief is mirrored into the origin DM session. Use this for conversational recurring jobs the user will reply to — daily briefings, reminders that kick off follow-up work. Leave unset for fire-and-forget alerts/watchdogs. Overrides the global cron.mirror_delivery config for this one job. Only the origin chat is touched (never fan-out targets); no effect when deliver='local'."
             },
+            "smoke": {
+                "type": "object",
+                "description": (
+                    "Optional static declarative preflight metadata to validate and store with the job. "
+                    "Supported probes are file-exists, directory-exists, env-present, command-exists, "
+                    "python-import, and mcp-configured. Command probes are rejected. "
+                    "On update, pass an empty object to clear."
+                ),
+            },
         },
         "required": ["action"]
     }
@@ -1611,6 +1657,7 @@ registry.register(
         no_agent=args.get("no_agent"),
         monitor_script=args.get("monitor_script"),
         monitor_url=args.get("monitor_url"),
+        smoke=args.get("smoke"),
         task_id=kw.get("task_id"),
         session_id=kw.get("session_id"),
     ),

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -1059,6 +1059,7 @@ def skill_view(
     file_path: str = None,
     task_id: str = None,
     preprocess: bool = True,
+    metadata_only: bool = False,
 ) -> str:
     """
     View the content of a skill or a specific file within a skill directory.
@@ -1071,6 +1072,8 @@ def skill_view(
         preprocess: Apply configured SKILL.md template and inline shell rendering
             to main skill content. Internal slash/preload callers disable this
             because they render the skill message themselves.
+        metadata_only: Return parsed frontmatter without setup, registration,
+            preprocessing, or read-tracking hooks.
 
     Returns:
         JSON string with skill content or error message
@@ -1129,6 +1132,26 @@ def skill_view(
                                 f"been cleaned up — try again after the "
                                 f"plugin is reloaded."
                             ),
+                        },
+                        ensure_ascii=False,
+                    )
+                if metadata_only:
+                    try:
+                        plugin_content = plugin_skill_md.read_text(encoding="utf-8")
+                        plugin_frontmatter, _ = _parse_frontmatter(plugin_content)
+                    except Exception:
+                        return json.dumps(
+                            {
+                                "success": False,
+                                "error": f"Failed to read skill '{name}'.",
+                            },
+                            ensure_ascii=False,
+                        )
+                    return json.dumps(
+                        {
+                            "success": True,
+                            "name": plugin_frontmatter.get("name", bare),
+                            "frontmatter": plugin_frontmatter,
                         },
                         ensure_ascii=False,
                     )
@@ -1382,6 +1405,16 @@ def skill_view(
                         f"Skill '{resolved_name}' is disabled. "
                         "Enable it with `hermes skills` or inspect the files directly on disk."
                     ),
+                },
+                ensure_ascii=False,
+            )
+
+        if metadata_only:
+            return json.dumps(
+                {
+                    "success": True,
+                    "name": resolved_name,
+                    "frontmatter": parsed_frontmatter,
                 },
                 ensure_ascii=False,
             )

--- a/website/docs/user-guide/features/cron.md
+++ b/website/docs/user-guide/features/cron.md
@@ -94,6 +94,68 @@ cron:
 
 Or: `hermes config set cron.preflight false`
 
+## Reliability preflight and smoke checks
+
+Cron jobs can store optional smoke metadata that `hermes doctor` uses to check
+whether the job still has the local prerequisites it needs. These checks are
+static and declarative: Hermes validates the declaration, checks attached
+skills, checks paths, environment-variable presence, command availability,
+Python import availability, and MCP server configuration. Smoke/preflight
+metadata cannot run arbitrary commands.
+
+```bash
+hermes doctor cron <job_id_or_name>
+hermes doctor cron --all --json
+hermes doctor skill <skill_name>
+hermes doctor skill --all --json
+```
+
+Attach smoke metadata from a JSON or YAML file when creating or editing a job:
+
+```bash
+hermes cron create "every 1h" "Refresh the local report" \
+  --workdir /home/me/projects/reporting \
+  --smoke-file ./cron-smoke.yaml
+
+hermes cron edit <job_id_or_name> --smoke-file ./cron-smoke.yaml
+hermes cron edit <job_id_or_name> --clear-smoke
+```
+
+Supported smoke files use `version: 1` and a `probes` list:
+
+```yaml
+version: 1
+probes:
+  - type: file-exists
+    root: workdir
+    path: scripts/report.py
+  - type: directory-exists
+    root: hermes_home
+    path: cron
+  - type: env-present
+    name: REPORT_API_TOKEN
+  - type: command-exists
+    name: python
+  - type: python-import
+    module: requests
+  - type: mcp-configured
+    server: filesystem
+```
+
+Path probes are limited to declared roots (`hermes_home`, `scripts_dir`,
+`workdir`, or `skill_dir`) and relative paths. `env-present` checks only
+presence and never exposes environment values in doctor output.
+
+After `hermes cron create` or `hermes cron edit`, Hermes saves the job first and
+then runs static preflight by default. Add `--skip-preflight` to save without
+checking, or `--strict-preflight` to return a non-zero exit code if the
+post-save preflight fails. Strict mode does not roll back or delete the job; the
+output says `Job saved. Preflight failed.` so the saved state is unambiguous.
+
+Preflight probes never run on scheduler ticks. The `cronjob` model tool may
+validate and store static smoke metadata, but unsupported probe types such as
+`command` are rejected before the job is saved.
+
 ## Letting unpinned jobs track global defaults
 
 The model/provider drift guard is enabled by default. If your unpinned cron


### PR DESCRIPTION
## Summary

Adds targeted reliability diagnostics for skills and cron jobs, plus safe declarative preflight checks for cron create/edit workflows.

- `hermes doctor skill <name>` and `hermes doctor cron <id-or-name>` report stable human-readable or JSON diagnostics.
- Cron jobs can store a versioned `smoke` specification containing static probes.
- `hermes cron create` and `hermes cron edit` save first, then run static preflight by default.
- The `cronjob` model tool validates and stores the same metadata but never executes it.

## Static-only security model

This rewrite deliberately provides no generic command probe and no subprocess execution path.

Supported probe types are:

- `file-exists`
- `directory-exists`
- `env-present`
- `command-exists`
- `python-import`
- `mcp-configured`

Unsupported probe types such as `command` are rejected before save. File probes accept only relative paths under declared roots and reject traversal and symlink escapes. Environment checks report presence only and never expose values. Probe summaries are bounded and sanitized.

## CLI behaviour

- `--skip-preflight` saves without checking.
- `--strict-preflight` returns a non-zero exit code when post-save preflight fails.
- Strict failure does not roll back the saved job; output explicitly states `Job saved. Preflight failed.`
- Hand-edited or legacy invalid metadata is diagnosed rather than crashing.
- Stored cron scripts are checked under `HERMES_HOME/scripts` without execution; missing files and path escapes fail preflight.
- Skill prerequisites are read through a metadata-only path that cannot trigger credential capture or setup hooks.
- Scheduler ticks do not run preflight probes.

## Verification

- Repository-canonical focused suite: **587 passed** across 46 cron/reliability and skill-metadata files.
- Ruff checks passed.
- Ruff formatting checks passed for the new and changed scoped regions.
- `ty check hermes_cli/reliability_doctor.py` passed.
- CLI help and removed-flag rejection probes passed.
- `git diff --check` passed.

The implementation was rebuilt from current `main`; it does not reuse the original shell-command design.
