### PR TITLE
fix: resolve agent-browser native binary fallback

### DIFF
--- a/hermes_cli/dep_ensure.py
+++ b/hermes_cli/dep_ensure.py
@@ -21,7 +21,11 @@ import subprocess
 import sys
 from pathlib import Path
 
-from hermes_constants import agent_browser_runnable, find_node_executable
+from hermes_constants import (
+    agent_browser_managed_shim_candidates,
+    find_node_executable,
+    resolve_agent_browser_candidate,
+)
 from tools.environments.local import hermes_subprocess_env
 
 _IS_WINDOWS = platform.system() == "Windows"
@@ -32,7 +36,7 @@ _DEP_CHECKS = {
     # a managed one and trigger a redundant re-install.
     "node": lambda: find_node_executable("node") is not None,
     "browser": lambda: (
-        agent_browser_runnable(shutil.which("agent-browser"))
+        resolve_agent_browser_candidate(shutil.which("agent-browser")) is not None
         or _has_system_browser()
         or _has_hermes_agent_browser()
     ),
@@ -62,14 +66,10 @@ def _has_system_browser() -> bool:
 def _has_hermes_agent_browser() -> bool:
     from hermes_constants import get_hermes_home
     home = get_hermes_home()
-    if _IS_WINDOWS:
-        # npm -g --prefix puts .cmd shims directly in the prefix dir on Windows
-        return (home / "node" / "agent-browser.cmd").is_file()
-    # install.sh installs globally into $HERMES_HOME/node/bin/ via npm -g --prefix
-    # Also check legacy node_modules/.bin/ path for git-clone installs.
-    return (
-        (home / "node" / "bin" / "agent-browser").is_file()
-        or (home / "node_modules" / ".bin" / "agent-browser").is_file()
+    probe_env = hermes_subprocess_env(inherit_credentials=False)
+    return any(
+        resolve_agent_browser_candidate(str(candidate), env=probe_env)
+        for candidate in agent_browser_managed_shim_candidates(home)
     )
 
 

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -19,8 +19,11 @@ from hermes_cli.config import (
     recommended_update_command_for_method,
 )
 from hermes_cli.env_loader import load_hermes_dotenv
-from hermes_constants import display_hermes_home
-from hermes_constants import agent_browser_runnable
+from hermes_constants import (
+    agent_browser_managed_shim_candidates,
+    display_hermes_home,
+    resolve_agent_browser_candidate,
+)
 
 PROJECT_ROOT = get_project_root()
 HERMES_HOME = get_hermes_home()
@@ -2108,7 +2111,6 @@ def run_doctor(args):
     if _safe_which("node"):
         check_ok("Node.js")
         # Check if agent-browser is installed
-        agent_browser_path = PROJECT_ROOT / "node_modules" / "agent-browser"
         agent_browser_ok = False
         _which_ab = shutil.which("agent-browser")
         # `hermes acp --setup-browser` installs agent-browser into the
@@ -2126,21 +2128,16 @@ def run_doctor(args):
             except Exception:
                 return None
 
-        _managed_ab = (
-            _which_in(HERMES_HOME / "node" / "bin")
-            or _which_in(HERMES_HOME / "node")
+        candidates = (
+            _which_ab,
+            *(str(path) for path in agent_browser_managed_shim_candidates(HERMES_HOME)),
+            _which_in(PROJECT_ROOT / "node_modules" / ".bin"),
         )
-        _legacy_ab = _which_in(HERMES_HOME / "node_modules" / ".bin")
-        if agent_browser_path.exists():
-            check_ok("agent-browser (Node.js)", "(browser automation)")
-            agent_browser_ok = True
-        elif _which_ab and agent_browser_runnable(_which_ab):
-            check_ok("agent-browser", "(browser automation)")
-            agent_browser_ok = True
-        elif _managed_ab and agent_browser_runnable(_managed_ab):
-            check_ok("agent-browser", "(browser automation)")
-            agent_browser_ok = True
-        elif _legacy_ab and agent_browser_runnable(_legacy_ab):
+        resolved_ab = next(
+            (resolve_agent_browser_candidate(candidate) for candidate in candidates if candidate),
+            None,
+        )
+        if resolved_ab:
             check_ok("agent-browser", "(browser automation)")
             agent_browser_ok = True
         elif _which_ab:

--- a/hermes_cli/nous_subscription.py
+++ b/hermes_cli/nous_subscription.py
@@ -159,33 +159,28 @@ def _toolset_enabled(config: Dict[str, object], toolset_key: str) -> bool:
 def _has_agent_browser() -> bool:
     import shutil
 
-    from hermes_constants import agent_browser_runnable, with_hermes_node_path
+    from hermes_constants import (
+        agent_browser_managed_shim_candidates,
+        get_hermes_home,
+        resolve_agent_browser_candidate,
+        with_hermes_node_path,
+    )
+
+    probe_env = with_hermes_node_path()
+    candidates = (
+        shutil.which("agent-browser"),
+        *(str(path) for path in agent_browser_managed_shim_candidates(get_hermes_home())),
+    )
+    if any(resolve_agent_browser_candidate(candidate, env=probe_env) for candidate in candidates):
+        return True
 
     # Validate the resolved binary actually runs — a dangling global symlink
     # (issue #48521) is reported by ``which`` but fails at exec. Fall through to
     # the local node_modules copy, which the validator also checks.
-    if agent_browser_runnable(shutil.which("agent-browser")):
-        return True
-
-    # Hermes-managed Node dirs (Windows installer / POSIX $HERMES_HOME/node)
-    # are prepended to PATH at runtime but usually absent from the *probe*
-    # process's PATH — the same rung `_find_agent_browser` searches. Without
-    # it a successful install keeps reporting "needs setup" on Windows.
-    managed_path = with_hermes_node_path().get("PATH", "")
-    if managed_path:
-        managed_hit = shutil.which("agent-browser", path=managed_path)
-        if managed_hit and agent_browser_runnable(managed_hit):
-            return True
-
-    # Local node_modules/.bin: resolve via PATHEXT-aware ``shutil.which`` so
-    # Windows picks the executable ``.cmd`` shim. Probing the extensionless
-    # POSIX shim directly fails exec (WinError 193) even right after a
-    # successful ``npm install`` — the bug that pinned every browser row on
-    # "Setup required" in the desktop GUI.
     local_bin_dir = Path(__file__).parent.parent / "node_modules" / ".bin"
     if local_bin_dir.is_dir():
         local_which = shutil.which("agent-browser", path=str(local_bin_dir))
-        if local_which and agent_browser_runnable(local_which):
+        if local_which and resolve_agent_browser_candidate(local_which, env=probe_env):
             return True
     return False
 

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -634,7 +634,15 @@ def find_node_executable_on_path(command: str, path: str | None = None) -> str |
     *path* optionally overrides the ambient PATH for callers probing a
     constructed environment without mutating process-global state.
     """
-    search_path = os.environ.get("PATH", "") if path is None else path
+    if path is None:
+        if sys.platform != "win32":
+            # Preserve the normal call shape for callers and test doubles that
+            # intentionally model the ambient process PATH.
+            return shutil.which(command)
+        search_path = os.environ.get("PATH", "")
+    else:
+        search_path = path
+
     if sys.platform != "win32":
         return shutil.which(command, path=search_path)
 

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -5,6 +5,7 @@ without risk of circular imports.
 """
 
 import os
+import platform
 import shutil
 import stat
 import sys
@@ -679,7 +680,122 @@ def with_hermes_node_path(env: dict[str, str] | None = None) -> dict[str, str]:
     return merged
 
 
-def agent_browser_runnable(path: str | None) -> bool:
+def agent_browser_native_binary_names() -> tuple[str, ...]:
+    """Return published agent-browser native binary names for this host."""
+    machine = platform.machine().lower()
+    arch = {
+        "amd64": "x64",
+        "x64": "x64",
+        "x86_64": "x64",
+        "aarch64": "arm64",
+        "arm64": "arm64",
+    }.get(machine)
+    if arch is None:
+        return ()
+    if sys.platform.startswith("linux"):
+        return (
+            f"agent-browser-linux-{arch}",
+            f"agent-browser-linux-musl-{arch}",
+        )
+    if sys.platform == "darwin":
+        return (
+            f"agent-browser-darwin-{arch}",
+            f"agent-browser-macos-{arch}",
+        )
+    if sys.platform.startswith("win"):
+        return (
+            f"agent-browser-win32-{arch}.exe",
+            f"agent-browser-windows-{arch}.exe",
+        )
+    return ()
+
+
+def agent_browser_managed_shim_candidates(
+    home: Path | None = None,
+) -> tuple[Path, ...]:
+    """Return agent-browser shims installed under Hermes-managed storage."""
+    root = home or get_hermes_home()
+    if sys.platform.startswith("win"):
+        return (root / "node" / "agent-browser.cmd",)
+    return (
+        root / "node" / "bin" / "agent-browser",
+        root / "node_modules" / ".bin" / "agent-browser",
+    )
+
+
+def agent_browser_native_sibling_candidates(path: str | None) -> tuple[Path, ...]:
+    """Return native binaries associated with an npm agent-browser shim."""
+    if not path:
+        return ()
+    raw = Path(path)
+    try:
+        resolved = raw.resolve(strict=False)
+    except OSError:
+        resolved = raw
+
+    directories = [resolved.parent]
+    for parent in (raw.parent, resolved.parent):
+        if parent.name.lower() == ".bin":
+            directories.append(parent.parent / "agent-browser" / "bin")
+        directories.append(parent / "node_modules" / "agent-browser" / "bin")
+
+    candidates: list[Path] = []
+    seen: set[Path] = set()
+    for directory in directories:
+        for name in agent_browser_native_binary_names():
+            candidate = directory / name
+            if candidate not in seen:
+                seen.add(candidate)
+                candidates.append(candidate)
+    return tuple(candidates)
+
+
+def prepare_agent_browser_native_candidate(path: Path) -> bool:
+    """Make a regular native candidate executable when its install permits it."""
+    if not path.is_file():
+        return False
+    if os.access(path, os.X_OK):
+        return True
+    try:
+        path.chmod(path.stat().st_mode | 0o111)
+    except OSError:
+        return False
+    return os.access(path, os.X_OK)
+
+
+def resolve_agent_browser_candidate(
+    path: str | None,
+    *,
+    env: dict[str, str] | None = None,
+    validate: bool = True,
+) -> str | None:
+    """Resolve a runnable npm shim or associated native binary."""
+    if path:
+        direct = Path(path)
+        if direct.name in agent_browser_native_binary_names():
+            if prepare_agent_browser_native_candidate(direct) and (
+                not validate or agent_browser_runnable(path, env=env)
+            ):
+                return path
+        elif not validate:
+            if os.path.exists(path) and (os.name == "nt" or os.access(path, os.X_OK)):
+                return path
+        elif agent_browser_runnable(path, env=env):
+            return path
+    for candidate in agent_browser_native_sibling_candidates(path):
+        if not prepare_agent_browser_native_candidate(candidate):
+            continue
+        resolved = str(candidate)
+        if not validate or agent_browser_runnable(resolved, env=env):
+            return resolved
+    return None
+
+
+def agent_browser_runnable(
+    path: str | None,
+    *,
+    env: dict[str, str] | None = None,
+) -> bool:
     """Return True only when *path* is an agent-browser CLI that actually runs.
 
     A bare presence check (``shutil.which`` / ``Path.exists``) is not enough:
@@ -719,7 +835,7 @@ def agent_browser_runnable(path: str | None) -> bool:
             [path, "--version"],
             capture_output=True,
             timeout=10,
-            env=with_hermes_node_path(),
+            env=with_hermes_node_path(env),
             creationflags=windows_hide_flags(),
         )
     except (OSError, subprocess.TimeoutExpired, ValueError):

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -623,16 +623,20 @@ def find_hermes_node_executable(command: str) -> str | None:
     return resolved
 
 
-def find_node_executable_on_path(command: str) -> str | None:
+def find_node_executable_on_path(command: str, path: str | None = None) -> str | None:
     """Return a Node/npm executable from PATH with Windows shim ordering.
 
     ``shutil.which("npm")`` can resolve an extensionless npm shim before the
     ``.cmd`` shim on Windows. Python's CreateProcess cannot execute that shim
     directly, so prefer the launchable variants explicitly for Hermes-owned
     subprocesses.
+
+    *path* optionally overrides the ambient PATH for callers probing a
+    constructed environment without mutating process-global state.
     """
+    search_path = os.environ.get("PATH", "") if path is None else path
     if sys.platform != "win32":
-        return shutil.which(command)
+        return shutil.which(command, path=search_path)
 
     command_str = str(command)
     has_path_separator = any(
@@ -642,7 +646,7 @@ def find_node_executable_on_path(command: str) -> str | None:
         return command_str if Path(command_str).is_file() else None
 
     for name in _candidate_node_command_names(command_str):
-        for directory in os.environ.get("PATH", "").split(os.pathsep):
+        for directory in search_path.split(os.pathsep):
             if not directory:
                 continue
             candidate = Path(directory) / name

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -710,11 +710,10 @@ def _run_doctor_with_managed_agent_browser(monkeypatch, tmp_path, runnable):
         return "/usr/bin/node" if cmd in {"node", "npm"} else None
 
     monkeypatch.setattr(doctor_mod.shutil, "which", _fake_which)
-    # agent_browser_runnable is imported into doctor's namespace
     monkeypatch.setattr(
         doctor_mod,
-        "agent_browser_runnable",
-        lambda path: runnable and str(path) == str(managed_ab),
+        "resolve_agent_browser_candidate",
+        lambda path: str(managed_ab) if runnable and str(path) == str(managed_ab) else None,
     )
 
     fake_model_tools = types.SimpleNamespace(

--- a/tests/hermes_cli/test_nous_subscription.py
+++ b/tests/hermes_cli/test_nous_subscription.py
@@ -224,8 +224,8 @@ def test_has_agent_browser_resolves_via_hermes_managed_node_path(monkeypatch, tm
         "hermes_constants.with_hermes_node_path", lambda: {"PATH": str(managed_dir)}
     )
     monkeypatch.setattr(
-        "hermes_constants.agent_browser_runnable",
-        lambda p: bool(p) and str(p) == str(managed_bin),
+        "hermes_constants.resolve_agent_browser_candidate",
+        lambda p, **_: str(managed_bin) if p else None,
     )
 
     assert ns._has_agent_browser() is True

--- a/tests/test_agent_browser_native_resolution_27312.py
+++ b/tests/test_agent_browser_native_resolution_27312.py
@@ -39,6 +39,14 @@ def test_agent_browser_native_binary_names_cover_linux_x64(monkeypatch):
     )
 
 
+def test_find_node_executable_on_path_accepts_explicit_path(tmp_path):
+    node = tmp_path / "node"
+    node.write_text("#!/bin/sh\nexit 0\n")
+    node.chmod(node.stat().st_mode | stat.S_IXUSR)
+
+    assert hermes_constants.find_node_executable_on_path("node", str(tmp_path)) == str(node)
+
+
 def test_agent_browser_candidate_presence_mode_does_not_execute(tmp_path, monkeypatch):
     candidate = tmp_path / "agent-browser"
     candidate.write_text("#!/bin/sh\nexit 0\n")

--- a/tests/test_agent_browser_native_resolution_27312.py
+++ b/tests/test_agent_browser_native_resolution_27312.py
@@ -1,0 +1,201 @@
+import stat
+import subprocess
+
+import hermes_constants
+
+
+
+def test_resolve_agent_browser_candidate_uses_native_sibling_when_shim_is_not_runnable(
+    tmp_path, monkeypatch
+):
+    package_bin = tmp_path / "node_modules" / "agent-browser" / "bin"
+    package_bin.mkdir(parents=True)
+    shim = package_bin / "agent-browser.js"
+    shim.write_text("#!/usr/bin/env node\n")
+    shim.chmod(shim.stat().st_mode | stat.S_IXUSR)
+    native = package_bin / "agent-browser-linux-x64"
+    native.write_text("#!/bin/sh\nexit 0\n")
+    native.chmod(native.stat().st_mode | stat.S_IXUSR)
+    shim_link = tmp_path / "bin" / "agent-browser"
+    shim_link.parent.mkdir()
+    shim_link.symlink_to(shim)
+
+    monkeypatch.setattr(
+        hermes_constants,
+        "agent_browser_runnable",
+        lambda path, **_: path == str(native),
+    )
+
+    assert hermes_constants.resolve_agent_browser_candidate(str(shim_link)) == str(native)
+
+
+def test_agent_browser_native_binary_names_cover_linux_x64(monkeypatch):
+    monkeypatch.setattr(hermes_constants.platform, "machine", lambda: "x86_64")
+    monkeypatch.setattr(hermes_constants.sys, "platform", "linux")
+
+    assert hermes_constants.agent_browser_native_binary_names() == (
+        "agent-browser-linux-x64",
+        "agent-browser-linux-musl-x64",
+    )
+
+
+def test_agent_browser_candidate_presence_mode_does_not_execute(tmp_path, monkeypatch):
+    candidate = tmp_path / "agent-browser"
+    candidate.write_text("#!/bin/sh\nexit 0\n")
+    candidate.chmod(candidate.stat().st_mode | stat.S_IXUSR)
+
+    def fail_if_called(*args, **kwargs):
+        raise AssertionError("presence-only resolution must not execute a candidate")
+
+    monkeypatch.setattr(hermes_constants, "agent_browser_runnable", fail_if_called)
+    assert hermes_constants.resolve_agent_browser_candidate(str(candidate), validate=False) == str(candidate)
+
+
+def test_agent_browser_native_sibling_candidates_follow_resolved_bin_symlink(tmp_path):
+    package_bin = tmp_path / "node_modules" / "agent-browser" / "bin"
+    package_bin.mkdir(parents=True)
+    shim = package_bin / "agent-browser.js"
+    shim.write_text("#!/usr/bin/env node\n")
+    link = tmp_path / "bin" / "agent-browser"
+    link.parent.mkdir()
+    link.symlink_to(shim)
+
+    candidates = hermes_constants.agent_browser_native_sibling_candidates(str(link))
+
+    assert package_bin / "agent-browser-linux-x64" in candidates
+
+
+def test_agent_browser_native_binary_names_cover_windows_arm64(monkeypatch):
+    monkeypatch.setattr(hermes_constants.platform, "machine", lambda: "ARM64")
+    monkeypatch.setattr(hermes_constants.sys, "platform", "win32")
+
+    assert hermes_constants.agent_browser_native_binary_names() == (
+        "agent-browser-win32-arm64.exe",
+        "agent-browser-windows-arm64.exe",
+    )
+
+
+def test_agent_browser_native_binary_names_skip_unknown_architecture(monkeypatch):
+    monkeypatch.setattr(hermes_constants.platform, "machine", lambda: "riscv64")
+    monkeypatch.setattr(hermes_constants.sys, "platform", "linux")
+
+    assert hermes_constants.agent_browser_native_binary_names() == ()
+
+
+def test_agent_browser_candidate_presence_mode_accepts_native_binary(tmp_path, monkeypatch):
+    native = tmp_path / "agent-browser-linux-x64"
+    native.write_text("not executed")
+    native.chmod(native.stat().st_mode | stat.S_IXUSR)
+
+    def fail_if_called(*args, **kwargs):
+        raise AssertionError("presence-only resolution must not execute a candidate")
+
+    monkeypatch.setattr(hermes_constants, "agent_browser_runnable", fail_if_called)
+    assert hermes_constants.resolve_agent_browser_candidate(str(native), validate=False) == str(native)
+
+
+def test_agent_browser_runnable_accepts_explicit_environment(monkeypatch, tmp_path):
+    captured = {}
+
+    def fake_run(*args, **kwargs):
+        captured.update(kwargs)
+        return type("Completed", (), {"returncode": 0})()
+
+    candidate = tmp_path / "agent-browser"
+    candidate.write_text("#!/bin/sh\nexit 0\n")
+    candidate.chmod(candidate.stat().st_mode | stat.S_IXUSR)
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    assert hermes_constants.agent_browser_runnable(str(candidate), env={"PATH": "/custom"}) is True
+    assert captured["env"]["PATH"].startswith("/custom")
+
+
+def test_agent_browser_native_candidate_is_made_executable(tmp_path):
+    native = tmp_path / "agent-browser-linux-x64"
+    native.write_text("#!/bin/sh\nexit 0\n")
+    native.chmod(stat.S_IRUSR | stat.S_IWUSR)
+
+    assert hermes_constants.prepare_agent_browser_native_candidate(native) is True
+    assert native.stat().st_mode & stat.S_IXUSR
+
+
+def test_agent_browser_native_candidate_rejects_missing_file(tmp_path):
+    assert hermes_constants.prepare_agent_browser_native_candidate(
+        tmp_path / "agent-browser-linux-x64"
+    ) is False
+
+
+def test_resolve_agent_browser_candidate_accepts_runnable_path_candidate(tmp_path):
+    candidate = tmp_path / "agent-browser-helper"
+    candidate.write_text("#!/bin/sh\nexit 0\n")
+    candidate.chmod(candidate.stat().st_mode | stat.S_IXUSR)
+
+    assert hermes_constants.resolve_agent_browser_candidate(str(candidate)) == str(candidate)
+
+
+def test_native_sibling_candidates_are_deduplicated(tmp_path):
+    package_bin = tmp_path / "node_modules" / "agent-browser" / "bin"
+    package_bin.mkdir(parents=True)
+    shim = package_bin / "agent-browser.js"
+    shim.write_text("#!/usr/bin/env node\n")
+    link = package_bin / ".bin" / "agent-browser"
+    link.parent.mkdir()
+    link.symlink_to(shim)
+
+    candidates = hermes_constants.agent_browser_native_sibling_candidates(str(link))
+
+    assert len(candidates) == len(set(candidates))
+
+
+def test_agent_browser_native_binary_names_cover_macos(monkeypatch):
+    monkeypatch.setattr(hermes_constants.platform, "machine", lambda: "arm64")
+    monkeypatch.setattr(hermes_constants.sys, "platform", "darwin")
+
+    assert hermes_constants.agent_browser_native_binary_names() == (
+        "agent-browser-darwin-arm64",
+        "agent-browser-macos-arm64",
+    )
+
+
+def test_prepare_native_candidate_preserves_existing_permissions(tmp_path):
+    native = tmp_path / "agent-browser-linux-x64"
+    native.write_text("#!/bin/sh\nexit 0\n")
+    native.chmod(stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR)
+    before = native.stat().st_mode
+
+    assert hermes_constants.prepare_agent_browser_native_candidate(native) is True
+    assert native.stat().st_mode == before
+
+
+def test_resolve_agent_browser_candidate_passes_probe_environment(tmp_path, monkeypatch):
+    candidate = tmp_path / "agent-browser"
+    candidate.write_text("#!/bin/sh\nexit 0\n")
+    candidate.chmod(candidate.stat().st_mode | stat.S_IXUSR)
+    seen = {}
+
+    def fake_runnable(path, **kwargs):
+        seen.update(kwargs)
+        return True
+
+    monkeypatch.setattr(hermes_constants, "agent_browser_runnable", fake_runnable)
+    assert hermes_constants.resolve_agent_browser_candidate(
+        str(candidate), env={"PATH": "/probe"}
+    ) == str(candidate)
+    assert seen["env"] == {"PATH": "/probe"}
+
+
+def test_native_sibling_resolution_returns_none_when_all_probes_fail(tmp_path, monkeypatch):
+    package_bin = tmp_path / "node_modules" / "agent-browser" / "bin"
+    package_bin.mkdir(parents=True)
+    shim = package_bin / "agent-browser.js"
+    shim.write_text("#!/usr/bin/env node\n")
+    shim.chmod(shim.stat().st_mode | stat.S_IXUSR)
+    native = package_bin / "agent-browser-linux-x64"
+    native.write_text("not runnable")
+    native.chmod(native.stat().st_mode | stat.S_IXUSR)
+    link = tmp_path / "bin" / "agent-browser"
+    link.parent.mkdir()
+    link.symlink_to(shim)
+
+    monkeypatch.setattr(hermes_constants, "agent_browser_runnable", lambda *_args, **_kwargs: False)
+    assert hermes_constants.resolve_agent_browser_candidate(str(link)) is None

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -66,9 +66,12 @@ from typing import Dict, Any, Optional, List, Tuple, Union
 from pathlib import Path
 from agent.redact import redact_cdp_url
 from hermes_constants import (
+    agent_browser_native_binary_names,
+    agent_browser_native_sibling_candidates,
     agent_browser_runnable,
     get_hermes_home,
     get_hermes_home_override,
+    prepare_agent_browser_native_candidate,
 )
 from utils import env_int, is_truthy_value
 from hermes_cli.config import DEFAULT_CONFIG, cfg_get
@@ -2296,6 +2299,60 @@ def _agent_browser_candidate_present(path: str | None) -> bool:
     return os.path.exists(path) and (os.name == "nt" or os.access(path, os.X_OK))
 
 
+def _browser_node_available(extended_path: str = "") -> bool:
+    return bool(
+        shutil.which("node")
+        or (extended_path and shutil.which("node", path=extended_path))
+    )
+
+
+def _agent_browser_shim_requires_node(path: str) -> bool:
+    try:
+        sample = Path(path).read_bytes()[:1024]
+    except OSError:
+        return False
+    if sample.startswith((b"\x7fELF", b"MZ", b"\xcf\xfa\xed\xfe", b"\xca\xfe\xba\xbe")):
+        return False
+    text = sample.decode("utf-8", errors="ignore").lower()
+    return "node" in text and ("agent-browser" in text or ".js" in text)
+
+
+def _resolve_agent_browser_candidate(
+    path: str | None,
+    extended_path: str = "",
+    *,
+    validate: bool,
+) -> str | None:
+    if not path:
+        return None
+    probe_env = {"PATH": extended_path} if extended_path else None
+    if _agent_browser_shim_requires_node(path) and not _browser_node_available(extended_path):
+        logger.debug("browser: skipping agent-browser shim without node on PATH: %s", path)
+    elif validate:
+        if agent_browser_runnable(path, env=probe_env):
+            return path
+    elif _agent_browser_candidate_present(path):
+        return path
+
+    for candidate in agent_browser_native_sibling_candidates(path):
+        if not prepare_agent_browser_native_candidate(candidate):
+            continue
+        resolved = str(candidate)
+        if not validate or agent_browser_runnable(resolved, env=probe_env):
+            return resolved
+    return None
+
+
+def _candidate_agent_browser_native_bins() -> list[Path]:
+    repo_root = Path(__file__).parent.parent
+    roots = [
+        repo_root / "node_modules" / "agent-browser" / "bin",
+        get_hermes_home() / "node_modules" / "agent-browser" / "bin",
+        get_hermes_home() / "node" / "lib" / "node_modules" / "agent-browser" / "bin",
+    ]
+    return [root / name for root in roots for name in agent_browser_native_binary_names()]
+
+
 def _find_agent_browser(*, validate: bool = True) -> str:
     """
     Find the agent-browser CLI executable.
@@ -2333,30 +2390,54 @@ def _find_agent_browser(*, validate: bool = True) -> str:
     # the next working resolution (extended PATH → local .bin → npx) instead of
     # caching the broken one and silently killing every browser tool.
 
-    # Check if it's in PATH (global install)
-    which_result = shutil.which("agent-browser")
-    if which_result and (
-        agent_browser_runnable(which_result) if validate else _agent_browser_candidate_present(which_result)
-    ):
+    extended_path = _merge_browser_path(os.environ.get("PATH", ""))
+
+    # A Node-backed shim is not usable without Node; try its packaged native
+    # sibling before falling through to local and npx candidates.
+    which_result = _resolve_agent_browser_candidate(
+        shutil.which("agent-browser"), extended_path, validate=validate
+    )
+    if which_result:
         if not validate:
             return which_result
         _cached_agent_browser = which_result
         _agent_browser_resolved = True
         return which_result
 
-    # Build an extended search PATH including Hermes-managed Node, macOS
-    # versioned Homebrew installs, and fallback system dirs like Termux.
-    extended_path = _merge_browser_path("")
     if extended_path:
-        which_result = shutil.which("agent-browser", path=extended_path)
-        if which_result and (
-            agent_browser_runnable(which_result) if validate else _agent_browser_candidate_present(which_result)
-        ):
+        which_result = _resolve_agent_browser_candidate(
+            shutil.which("agent-browser", path=extended_path),
+            extended_path,
+            validate=validate,
+        )
+        if which_result:
             if not validate:
                 return which_result
             _cached_agent_browser = which_result
             _agent_browser_resolved = True
             return which_result
+
+    native_binary = next(
+        (
+            str(candidate)
+            for candidate in _candidate_agent_browser_native_bins()
+            if prepare_agent_browser_native_candidate(candidate)
+            and (
+                not validate
+                or agent_browser_runnable(
+                    str(candidate),
+                    env={"PATH": extended_path} if extended_path else None,
+                )
+            )
+        ),
+        None,
+    )
+    if native_binary:
+        if not validate:
+            return native_binary
+        _cached_agent_browser = native_binary
+        _agent_browser_resolved = True
+        return native_binary
 
     # Check local node_modules/.bin/ (npm install in repo root).
     # On Windows, npm drops three shims in .bin: an extensionless POSIX shell
@@ -2369,10 +2450,12 @@ def _find_agent_browser(*, validate: bool = True) -> str:
     repo_root = Path(__file__).parent.parent
     local_bin_dir = repo_root / "node_modules" / ".bin"
     if local_bin_dir.is_dir():
-        local_which = shutil.which("agent-browser", path=str(local_bin_dir))
-        if local_which and (
-            agent_browser_runnable(local_which) if validate else _agent_browser_candidate_present(local_which)
-        ):
+        local_which = _resolve_agent_browser_candidate(
+            shutil.which("agent-browser", path=str(local_bin_dir)),
+            extended_path,
+            validate=validate,
+        )
+        if local_which:
             if not validate:
                 return local_which
             _cached_agent_browser = local_which
@@ -2383,7 +2466,7 @@ def _find_agent_browser(*, validate: bool = True) -> str:
     npx_path = shutil.which("npx")
     if not npx_path and extended_path:
         npx_path = shutil.which("npx", path=extended_path)
-    if npx_path:
+    if npx_path and _browser_node_available(extended_path):
         if not validate:
             return "npx agent-browser"
         _cached_agent_browser = "npx agent-browser"
@@ -2592,10 +2675,7 @@ def _run_browser_command(
         # Honour either the legacy AGENT_BROWSER_CHROME_FLAGS (never consumed by
         # agent-browser itself, but documented in older notes) or the real
         # AGENT_BROWSER_ARGS — if the user pre-sets either, don't overwrite it.
-        if (
-            "AGENT_BROWSER_ARGS" not in browser_env
-            and "AGENT_BROWSER_CHROME_FLAGS" not in browser_env
-        ):
+        if "AGENT_BROWSER_ARGS" not in browser_env:
             if _needs_chromium_sandbox_bypass():
                 logger.debug(
                     "browser: sandbox bypass needed (root/docker/AppArmor userns) — "

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -69,6 +69,7 @@ from hermes_constants import (
     agent_browser_native_binary_names,
     agent_browser_native_sibling_candidates,
     agent_browser_runnable,
+    find_node_executable_on_path,
     get_hermes_home,
     get_hermes_home_override,
     prepare_agent_browser_native_candidate,
@@ -2300,10 +2301,7 @@ def _agent_browser_candidate_present(path: str | None) -> bool:
 
 
 def _browser_node_available(extended_path: str = "") -> bool:
-    return bool(
-        shutil.which("node")
-        or (extended_path and shutil.which("node", path=extended_path))
-    )
+    return bool(find_node_executable_on_path("node", extended_path or None))
 
 
 def _agent_browser_shim_requires_node(path: str) -> bool:


### PR DESCRIPTION
## What does this PR do?

**Current status:** This branch has been rebuilt from the latest `main` while preserving the validated fix scope and addressing the prior review requirement for runnable native candidates.


Fixes local browser startup in service environments where `agent-browser` resolves to an npm Node.js shim but `node` is unavailable in the runtime `PATH`.

The runtime resolver now skips Node-backed npm shims when Node is missing and falls back to packaged native `agent-browser` binaries, including native binaries adjacent to a resolved global npm shim. This covers layouts such as:

```text
/usr/local/bin/agent-browser -> .../lib/node_modules/agent-browser/bin/agent-browser.js
.../lib/node_modules/agent-browser/bin/agent-browser-linux-x64
```

The change also keeps the sandbox fallback aligned with the actual `agent-browser` environment contract: only `AGENT_BROWSER_ARGS` suppresses automatic `--no-sandbox` injection, while the legacy `AGENT_BROWSER_CHROME_FLAGS` note no longer blocks the fallback.

## Related Issue

Fixes #27312

This PR is the canonical current-main implementation path for the issue. An earlier implementation PR remains open only as historical review context and is not modified by this update.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_constants.py`
  - Provides the shared platform-aware candidate resolver and validates native candidates with the effective browser environment.
  - Preserves the existing ambient-PATH lookup call shape while allowing explicit managed-PATH probing.
- `tools/browser_tool.py`
  - Uses the shared resolver for runtime candidate discovery and skips Node-backed npm shims when Node is unavailable.
  - Searches packaged native binaries, including native siblings of resolved npm shims, and preserves the `AGENT_BROWSER_ARGS` sandbox contract.
- `hermes_cli/dep_ensure.py`, `hermes_cli/doctor.py`, `hermes_cli/nous_subscription.py`
  - Use the same candidate resolution behavior for availability and diagnostics.
- `tests/test_agent_browser_native_resolution_27312.py`
  - Covers Node-less shim fallback, native sibling lookup, platform naming, presence-only checks, environment propagation, executable preparation, failed probes, and compatibility behavior.

## How to Test

1. Simulate a global npm install where `agent-browser` resolves to a Node-backed shim but `node` is unavailable.
2. Verify Hermes resolves the adjacent packaged native binary instead of returning the unusable shim or `npx agent-browser`.
3. Run the targeted browser resolver and related browser hardening tests.

Validated locally on Linux from the latest `main`:

```bash
uv run --extra dev pytest \
  tests/test_managed_runtime_resolution.py \
  tests/test_agent_browser_native_resolution_27312.py \
  tests/tools/test_browser_hardening.py \
  tests/tools/test_browser_homebrew_paths.py \
  tests/hermes_cli/test_nous_subscription.py \
  tests/hermes_cli/test_doctor.py \
  tests/hermes_cli/test_dep_ensure.py \
  tests/tools/test_browser_eval_supervisor_path.py \
  tests/agent/lsp/test_install_and_lint_fixes.py \
  tests/hermes_cli/test_tui_resume_flow.py \
  tests/hermes_cli/test_tui_npm_install.py \
  -q -o 'addopts='
# 133 passed, 2 skipped

git diff --check upstream/main...HEAD
python -m compileall -q hermes_constants.py tools/browser_tool.py hermes_cli/dep_ensure.py hermes_cli/nous_subscription.py hermes_cli/doctor.py tests/test_agent_browser_native_resolution_27312.py
```

The full `pytest tests/` suite was attempted locally but could not complete collection because optional dependencies including `aiohttp` and some ACP/gateway/e2e dependencies are not installed. The upstream CI run is the authoritative full-suite gate; it is intentionally not marked as passed below.

After the first upstream CI run exposed a compatibility issue in an existing `shutil.which` test double, the follow-up preserves the legacy ambient-PATH call shape while keeping explicit managed-PATH probing.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu/Linux; targeted subset also checked on macOS arm64

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Targeted validation from the latest `main`:

```text
133 passed, 2 skipped
```

