### PR TITLE
feat(kanban): per-call subscribe API with atomic notification subscription

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -91,6 +91,36 @@ def _run_state_kwargs(args: argparse.Namespace) -> Optional[dict[str, str]]:
     return {"state_type": st, "state_name": sn}
 
 
+def _build_subscribe_from_args(args: argparse.Namespace) -> Optional[dict[str, str]]:
+    """Build a ``subscribe`` dict from CLI ``--subscribe-*`` flags.
+
+    Includes ``notifier_profile`` from the current profile when at least
+    one flag was passed.  Returns ``None`` when no flags were provided.
+    """
+    sub_platform = (getattr(args, "subscribe_platform", None) or "").strip()
+    sub_chat_id = (getattr(args, "subscribe_chat_id", None) or "").strip()
+    sub_thread_id = (getattr(args, "subscribe_thread_id", None) or "").strip()
+    sub_user_id = (getattr(args, "subscribe_user_id", None) or "").strip()
+    if not any((sub_platform, sub_chat_id, sub_thread_id, sub_user_id)):
+        return None
+    if not sub_platform or not sub_chat_id:
+        raise argparse.ArgumentTypeError(
+            "--subscribe-platform and --subscribe-chat-id must be passed together"
+        )
+    subscribe: dict[str, str] = {
+        "platform": sub_platform,
+        "chat_id": sub_chat_id,
+    }
+    if sub_thread_id:
+        subscribe["thread_id"] = sub_thread_id
+    if sub_user_id:
+        subscribe["user_id"] = sub_user_id
+    profile = os.environ.get("HERMES_PROFILE", "")
+    if profile:
+        subscribe["notifier_profile"] = profile
+    return subscribe
+
+
 def _parse_workspace_flag(value: str) -> tuple[str, Optional[str]]:
     """Parse ``--workspace`` into ``(kind, path|None)``.
 
@@ -341,6 +371,14 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
                                "two retries. Omit to use the dispatcher's "
                                "kanban.failure_limit config "
                                f"(default {kb.DEFAULT_FAILURE_LIMIT}).")
+    p_create.add_argument("--subscribe-platform", default=None,
+                          help="Auto-subscribe task notifications for this platform")
+    p_create.add_argument("--subscribe-chat-id", default=None,
+                          help="Chat ID for the notification subscription")
+    p_create.add_argument("--subscribe-thread-id", default=None,
+                          help="Optional thread/topic ID for the notification subscription")
+    p_create.add_argument("--subscribe-user-id", default=None,
+                          help="Optional user ID for the notification subscription")
     p_create.add_argument("--initial-status",
                           choices=sorted(kb.VALID_INITIAL_STATUSES),
                           default="running",
@@ -1286,6 +1324,11 @@ def _cmd_create(args: argparse.Namespace) -> int:
             file=sys.stderr,
         )
         return 2
+    try:
+        subscribe = _build_subscribe_from_args(args)
+    except argparse.ArgumentTypeError as exc:
+        print(f"kanban: {exc}", file=sys.stderr)
+        return 2
     with kb.connect() as conn:
         task_id = kb.create_task(
             conn,
@@ -1304,6 +1347,7 @@ def _cmd_create(args: argparse.Namespace) -> int:
             max_runtime_seconds=max_runtime,
             skills=getattr(args, "skills", None) or None,
             max_retries=max_retries,
+            subscribe=subscribe,
             initial_status=getattr(args, "initial_status", "running"),
         )
         task = kb.get_task(conn, task_id)

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1387,8 +1387,38 @@ def _canonical_assignee(assignee: Optional[str]) -> Optional[str]:
     if assignee is None:
         return None
     from hermes_cli.profiles import normalize_profile_name
-
     return normalize_profile_name(assignee)
+
+
+def _resolve_subscribe_dict(
+    subscribe: Optional[dict],
+) -> Optional[dict[str, str]]:
+    """Normalise a ``subscribe`` dict from an explicit caller argument.
+
+    Returns ``None`` when the dict is missing or lacks required keys.
+    The dict may contain ``notifier_profile`` which is forwarded to the
+    subscription row.
+    """
+    if not isinstance(subscribe, dict):
+        return None
+    platform = str(subscribe.get("platform") or "").strip()
+    chat_id = str(subscribe.get("chat_id") or "").strip()
+    if not platform or not chat_id:
+        return None
+    resolved: dict[str, str] = {
+        "platform": platform,
+        "chat_id": chat_id,
+    }
+    thread_id = str(subscribe.get("thread_id") or "").strip()
+    if thread_id:
+        resolved["thread_id"] = thread_id
+    user_id = str(subscribe.get("user_id") or "").strip()
+    if user_id:
+        resolved["user_id"] = user_id
+    notifier_profile = str(subscribe.get("notifier_profile") or "").strip()
+    if notifier_profile:
+        resolved["notifier_profile"] = notifier_profile
+    return resolved
 
 
 def create_task(
@@ -1409,6 +1439,7 @@ def create_task(
     max_runtime_seconds: Optional[int] = None,
     skills: Optional[Iterable[str]] = None,
     max_retries: Optional[int] = None,
+    subscribe: Optional[dict] = None,
     initial_status: str = "running",
     session_id: Optional[str] = None,
     board: Optional[str] = None,
@@ -1526,6 +1557,11 @@ def create_task(
         if board_default:
             workspace_path = str(board_default)
 
+    # Resolve notification subscription from explicit caller argument.
+    resolved_subscribe: Optional[dict[str, str]] = None
+    if isinstance(subscribe, dict):
+        resolved_subscribe = _resolve_subscribe_dict(subscribe)
+
     # Retry once on the extremely unlikely id collision.
     for attempt in range(2):
         task_id = _new_task_id()
@@ -1610,6 +1646,16 @@ def create_task(
                         "skills": list(skills_list) if skills_list else None,
                     },
                 )
+                if resolved_subscribe:
+                    _add_notify_sub_inner(
+                        conn,
+                        task_id=task_id,
+                        platform=resolved_subscribe["platform"],
+                        chat_id=resolved_subscribe["chat_id"],
+                        thread_id=resolved_subscribe.get("thread_id"),
+                        user_id=resolved_subscribe.get("user_id"),
+                        notifier_profile=resolved_subscribe.get("notifier_profile"),
+                    )
             return task_id
         except sqlite3.IntegrityError:
             if attempt == 1:
@@ -5820,6 +5866,34 @@ def add_notify_sub(
                 """,
                 (notifier_profile, task_id, platform, chat_id, thread_id or ""),
             )
+
+
+def _add_notify_sub_inner(
+    conn: sqlite3.Connection,
+    *,
+    task_id: str,
+    platform: str,
+    chat_id: str,
+    thread_id: Optional[str] = None,
+    user_id: Optional[str] = None,
+    notifier_profile: Optional[str] = None,
+) -> None:
+    """Insert/update a notify sub — assumes caller already holds a write_txn."""
+    now = int(time.time())
+    conn.execute(
+        """INSERT OR IGNORE INTO kanban_notify_subs
+            (task_id, platform, chat_id, thread_id, user_id, notifier_profile, created_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?)""",
+        (task_id, platform, chat_id, thread_id or "", user_id, notifier_profile, now),
+    )
+    if notifier_profile:
+        conn.execute(
+            """UPDATE kanban_notify_subs
+                 SET notifier_profile = ?
+               WHERE task_id = ? AND platform = ? AND chat_id = ? AND thread_id = ?
+                 AND (notifier_profile IS NULL OR notifier_profile = '')""",
+            (notifier_profile, task_id, platform, chat_id, thread_id or ""),
+        )
 
 
 def list_notify_subs(

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -682,6 +682,29 @@ def _handle_create(args: dict, **kw) -> str:
             f"parents must be a list of task ids, got {type(parents).__name__}"
         )
     board = args.get("board")
+    # Resolve notification subscription from gateway session context.
+    # Only works when running under the gateway (not CLI / test context).
+    _subscribe: Optional[dict[str, str]] = None
+    try:
+        from gateway.session_context import get_session_env
+        sub_platform = get_session_env("HERMES_SESSION_PLATFORM", "")
+        sub_chat_id = get_session_env("HERMES_SESSION_CHAT_ID", "")
+        if sub_platform and sub_chat_id:
+            _subscribe = {
+                "platform": sub_platform,
+                "chat_id": sub_chat_id,
+            }
+            sub_thread = get_session_env("HERMES_SESSION_THREAD_ID", "")
+            if sub_thread:
+                _subscribe["thread_id"] = sub_thread
+            sub_user = get_session_env("HERMES_SESSION_USER_ID", "")
+            if sub_user:
+                _subscribe["user_id"] = sub_user
+            notifier_profile = os.environ.get("HERMES_PROFILE", "")
+            if notifier_profile:
+                _subscribe["notifier_profile"] = notifier_profile
+    except ImportError:
+        pass  # CLI / test context — no gateway module available
     try:
         kb, conn = _connect(board=board)
         try:
@@ -705,6 +728,7 @@ def _handle_create(args: dict, **kw) -> str:
                 initial_status=str(initial_status),
                 created_by=os.environ.get("HERMES_PROFILE") or "worker",
                 session_id=session_id,
+                subscribe=_subscribe,
             )
             new_task = kb.get_task(conn, new_tid)
             return _ok(


### PR DESCRIPTION
## Summary

Adds a subscribe= parameter to create_task() that creates a notification subscription inside the same write transaction as the task row, and wires it to the tool handler via gateway.session_context.get_session_env() and to the CLI via explicit --subscribe-* flags.

## Changes (143 lines, 3 files)

### kanban_db.py (+76/-1)
- New `_resolve_subscribe_dict()` helper: normalises a caller-supplied subscribe dict
- `create_task(..., subscribe=...)` parameter for per-call notification subscription
- `_add_notify_sub_inner()` helper designed to run inside an existing write_txn
- Subscription insert is inside create_task's write_txn — atomic with task creation

### tools/kanban_tools.py (+24)
- Tool handler resolves session context via `gateway.session_context.get_session_env()` (task-local contextvars, safe for concurrent gateway sessions)
- Forwards notifier_profile from os.environ.get("HERMES_PROFILE")
- Passes subscribe=... to create_task()

### kanban.py (+44)
- New `_build_subscribe_from_args()` helper
- `--subscribe-platform`, `--subscribe-chat-id`, `--subscribe-thread-id`, `--subscribe-user-id` CLI flags
- Includes notifier_profile from HERMES_PROFILE

## Key differences from prior approaches

| Aspect | PR #28720 (flooryyyy) | This PR |
|--------|----------------------|---------|
| Transaction safety | External call after task creation | Same write_txn as task |
| Session source | get_session_env() (correct) | get_session_env() (correct) |
| Atomicity | ❌ | ✅ |
| Notifier profile | Missing | Included |
| CLI support | ❌ | `--subscribe-*` flags |
| Coverage | Tool handler only | Tool handler + CLI + programmatic |
| Diff size | 34 lines, 1 file | 143 lines, 3 files |

## Test Results
- 167/167 kanban_db tests pass
- 81/81 kanban_tools tests pass
- 18/18 notify tests pass