### PR TITLE
fix(kanban): snap notify-sub cursor to current MAX(id) at creation

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -7172,7 +7172,7 @@ def add_notify_sub(
     for ``task_id``. Idempotent on (task, platform, chat, thread)."""
     now = int(time.time())
     with write_txn(conn):
-        conn.execute(
+        cur = conn.execute(
             """
             INSERT OR IGNORE INTO kanban_notify_subs
                 (task_id, platform, chat_id, thread_id, user_id, notifier_profile, created_at)
@@ -7180,6 +7180,27 @@ def add_notify_sub(
             """,
             (task_id, platform, chat_id, thread_id or "", user_id, notifier_profile, now),
         )
+        if cur.rowcount > 0:
+            # Snap the cursor to the current MAX(id) of task_events for this
+            # task so the new subscription starts caught up: only events
+            # generated AFTER subscription should fire notifications. Without
+            # this, a sub created on an already-active task would replay
+            # every backlogged terminal event on the next watcher tick — see
+            # issue #29905, where 27 stale subs at last_event_id=0 produced
+            # a 100+ notification burst at gateway boot. Idempotency: only
+            # runs when INSERT OR IGNORE actually inserted; existing rows
+            # keep their advancing cursor.
+            conn.execute(
+                """
+                UPDATE kanban_notify_subs
+                   SET last_event_id = COALESCE(
+                       (SELECT MAX(id) FROM task_events WHERE task_id = ?),
+                       0
+                   )
+                 WHERE task_id = ? AND platform = ? AND chat_id = ? AND thread_id = ?
+                """,
+                (task_id, task_id, platform, chat_id, thread_id or ""),
+            )
         if notifier_profile:
             # Self-heal legacy rows that predate notifier ownership by
             # backfilling only when the existing value is unset.

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -587,6 +587,13 @@ def test_notify_claim_is_single_owner_and_rewindable(kanban_home):
     try:
         tid = kb.create_task(conn1, title="x", assignee="w")
         kb.add_notify_sub(conn1, task_id=tid, platform="telegram", chat_id="123")
+        # add_notify_sub snaps the cursor to MAX(id) over task_events so the
+        # sub starts caught up (#29905). Capture that snapped value as the
+        # baseline; the watcher's claim then only sees events generated
+        # AFTER subscription.
+        snapped_cursor = int(
+            kb.list_notify_subs(conn1, tid)[0]["last_event_id"]
+        )
         kb.complete_task(conn1, tid, result="ok")
 
         old_cursor, claimed_cursor, events = kb.claim_unseen_events_for_sub(
@@ -596,7 +603,7 @@ def test_notify_claim_is_single_owner_and_rewindable(kanban_home):
             chat_id="123",
             kinds=["completed", "blocked"],
         )
-        assert old_cursor == 0
+        assert old_cursor == snapped_cursor
         assert claimed_cursor > old_cursor
         assert [ev.kind for ev in events] == ["completed"]
 

--- a/tests/hermes_cli/test_kanban_notify.py
+++ b/tests/hermes_cli/test_kanban_notify.py
@@ -674,8 +674,9 @@ def test_add_notify_sub_snaps_cursor_past_existing_events(kanban_home):
         tid = kb.create_task(conn, title="pre-existing events", assignee="worker1")
         # Pre-populate task_events so a fresh sub created now would otherwise
         # see them all on the next tick.
-        kb._append_event(conn, tid, kind="completed")
-        kb._append_event(conn, tid, kind="blocked")
+        with kb.write_txn(conn):
+            kb._append_event(conn, tid, kind="completed")
+            kb._append_event(conn, tid, kind="blocked")
         max_id_before = conn.execute(
             "SELECT MAX(id) FROM task_events WHERE task_id = ?", (tid,),
         ).fetchone()[0]
@@ -684,7 +685,7 @@ def test_add_notify_sub_snaps_cursor_past_existing_events(kanban_home):
         kb.add_notify_sub(conn, task_id=tid, platform="telegram", chat_id="chat-late")
 
         sub = kb.list_notify_subs(conn, tid)[0]
-        assert sub["last_event_id"] == max_id_before, (
+        assert int(sub["last_event_id"]) == max_id_before, (
             "Expected new sub to start at the current MAX(id); got "
             f"{sub['last_event_id']} vs {max_id_before}"
         )
@@ -701,7 +702,8 @@ def test_add_notify_sub_snaps_cursor_past_existing_events(kanban_home):
         assert replayed == []
 
         # And a NEW event after subscription must still be delivered.
-        kb._append_event(conn, tid, kind="gave_up")
+        with kb.write_txn(conn):
+            kb._append_event(conn, tid, kind="gave_up")
         _, _, fresh = kb.claim_unseen_events_for_sub(
             conn,
             task_id=tid,
@@ -727,7 +729,8 @@ def test_add_notify_sub_idempotent_does_not_rewind_cursor(kanban_home):
         kb.add_notify_sub(conn, task_id=tid, platform="telegram", chat_id="chat-x")
 
         # Simulate the watcher having advanced the cursor.
-        kb._append_event(conn, tid, kind="completed")
+        with kb.write_txn(conn):
+            kb._append_event(conn, tid, kind="completed")
         kb.claim_unseen_events_for_sub(
             conn,
             task_id=tid,
@@ -736,12 +739,12 @@ def test_add_notify_sub_idempotent_does_not_rewind_cursor(kanban_home):
             kinds=("completed", "blocked", "gave_up", "crashed", "timed_out"),
         )
         sub_before = kb.list_notify_subs(conn, tid)[0]
-        cursor_before = sub_before["last_event_id"]
+        cursor_before = int(sub_before["last_event_id"])
         assert cursor_before > 0
 
         # Re-subscribe (no-op insert). Cursor must not move.
         kb.add_notify_sub(conn, task_id=tid, platform="telegram", chat_id="chat-x")
         sub_after = kb.list_notify_subs(conn, tid)[0]
-        assert sub_after["last_event_id"] == cursor_before
+        assert int(sub_after["last_event_id"]) == cursor_before
     finally:
         conn.close()

--- a/tests/hermes_cli/test_kanban_notify.py
+++ b/tests/hermes_cli/test_kanban_notify.py
@@ -343,6 +343,7 @@ async def test_notifier_skips_subscription_owned_by_other_profile(kanban_home):
             chat_id="chat1",
             notifier_profile="default",
         )
+        snapped_cursor = int(kb.list_notify_subs(conn, tid)[0]["last_event_id"])
         kb.complete_task(conn, tid, result="done")
     finally:
         conn.close()
@@ -379,7 +380,13 @@ async def test_notifier_skips_subscription_owned_by_other_profile(kanban_home):
     finally:
         conn.close()
     assert len(subs) == 1
-    assert int(subs[0]["last_event_id"]) == 0, "wrong profile must not claim the event"
+    # The wrong profile must not have advanced the cursor: it should still
+    # point at the snapshot taken when the sub was created (the `created`
+    # event id), so the owning profile's watcher will deliver the unseen
+    # ``completed`` event on its next tick.
+    assert int(subs[0]["last_event_id"]) == snapped_cursor, (
+        "wrong profile must not claim the event"
+    )
 
 
 @pytest.mark.asyncio
@@ -653,3 +660,88 @@ async def test_notifier_artifact_delivery_skips_missing_files(kanban_home, tmp_p
     # Only the real file was uploaded.
     assert len(documents_uploaded) == 1
     assert "real.pdf" in documents_uploaded[0]
+
+
+def test_add_notify_sub_snaps_cursor_past_existing_events(kanban_home):
+    """Regression for #29905: a subscription created on an already-active task
+    must start caught-up, not replay every backlogged terminal event on the
+    next watcher tick.
+    """
+    import hermes_cli.kanban_db as kb
+
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="pre-existing events", assignee="worker1")
+        # Pre-populate task_events so a fresh sub created now would otherwise
+        # see them all on the next tick.
+        kb._append_event(conn, tid, kind="completed")
+        kb._append_event(conn, tid, kind="blocked")
+        max_id_before = conn.execute(
+            "SELECT MAX(id) FROM task_events WHERE task_id = ?", (tid,),
+        ).fetchone()[0]
+        assert max_id_before is not None and max_id_before > 0
+
+        kb.add_notify_sub(conn, task_id=tid, platform="telegram", chat_id="chat-late")
+
+        sub = kb.list_notify_subs(conn, tid)[0]
+        assert sub["last_event_id"] == max_id_before, (
+            "Expected new sub to start at the current MAX(id); got "
+            f"{sub['last_event_id']} vs {max_id_before}"
+        )
+
+        # The watcher's claim path should now see nothing for this sub —
+        # the storm in #29905 was 100+ messages from exactly this state.
+        _, _, replayed = kb.claim_unseen_events_for_sub(
+            conn,
+            task_id=tid,
+            platform="telegram",
+            chat_id="chat-late",
+            kinds=("completed", "blocked", "gave_up", "crashed", "timed_out"),
+        )
+        assert replayed == []
+
+        # And a NEW event after subscription must still be delivered.
+        kb._append_event(conn, tid, kind="gave_up")
+        _, _, fresh = kb.claim_unseen_events_for_sub(
+            conn,
+            task_id=tid,
+            platform="telegram",
+            chat_id="chat-late",
+            kinds=("completed", "blocked", "gave_up", "crashed", "timed_out"),
+        )
+        assert len(fresh) == 1 and fresh[0].kind == "gave_up"
+    finally:
+        conn.close()
+
+
+def test_add_notify_sub_idempotent_does_not_rewind_cursor(kanban_home):
+    """Re-subscribing the same (task, platform, chat, thread) tuple must NOT
+    rewind the cursor: existing rows are IGNORED by the INSERT, and the snap
+    only fires for newly-inserted rows.
+    """
+    import hermes_cli.kanban_db as kb
+
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="resub", assignee="worker1")
+        kb.add_notify_sub(conn, task_id=tid, platform="telegram", chat_id="chat-x")
+
+        # Simulate the watcher having advanced the cursor.
+        kb._append_event(conn, tid, kind="completed")
+        kb.claim_unseen_events_for_sub(
+            conn,
+            task_id=tid,
+            platform="telegram",
+            chat_id="chat-x",
+            kinds=("completed", "blocked", "gave_up", "crashed", "timed_out"),
+        )
+        sub_before = kb.list_notify_subs(conn, tid)[0]
+        cursor_before = sub_before["last_event_id"]
+        assert cursor_before > 0
+
+        # Re-subscribe (no-op insert). Cursor must not move.
+        kb.add_notify_sub(conn, task_id=tid, platform="telegram", chat_id="chat-x")
+        sub_after = kb.list_notify_subs(conn, tid)[0]
+        assert sub_after["last_event_id"] == cursor_before
+    finally:
+        conn.close()


### PR DESCRIPTION
## What does this PR do?

`add_notify_sub` previously inserted `kanban_notify_subs` rows with `last_event_id = 0` (the schema default). A subscription created on an already-active task therefore replayed every prior terminal event on the next `_kanban_notifier_watcher` tick — issue #29905 reports a 100+ message burst at gateway boot caused by 27 stale subs at `last_event_id=0`.

After this PR, `add_notify_sub` snaps the cursor to `COALESCE(MAX(id) FROM task_events WHERE task_id = ?, 0)` inside the same `write_txn` as the INSERT, so a new sub starts caught up. Only events generated **after** subscription fire notifications. The snap is gated on `cur.rowcount > 0`, so the existing `INSERT OR IGNORE` semantics are preserved: a re-subscription against an existing `(task, platform, chat, thread)` tuple is still a no-op and never rewinds the advancing cursor.

Scope is limited to the root cause (the missing snap on creation). Existing subs already sitting at `last_event_id=0` are out of scope here — the reporter's workaround SQL handles those, and a separate on-connect migration would be a larger, riskier change to bundle.

> Audited siblings: `add_notify_sub` is the only production path that inserts into `kanban_notify_subs` (verified via `rg \"INSERT.*INTO kanban_notify_subs\"`). `claim_unseen_events_for_sub` / `advance_notify_cursor` / `rewind_notify_cursor` all read/write the existing cursor and need no change. No widening needed.

## Related Issue

Fixes #29905

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor
- [ ] 🎯 New skill

## Changes Made

- `hermes_cli/kanban_db.py` — `add_notify_sub` now snaps `last_event_id` to the current `MAX(id)` over `task_events` for the task after a newly-inserted row.
- `tests/hermes_cli/test_kanban_notify.py` — two new regression tests: backlogged terminal events must NOT replay for a newly-created sub; fresh post-subscription events MUST still deliver; idempotent re-subscription MUST NOT rewind the cursor.
- `tests/hermes_cli/test_kanban_notify.py::test_notifier_skips_subscription_owned_by_other_profile` — invariant updated from \"cursor must equal 0\" to \"cursor must equal the snapped baseline\" (same intent: wrong-profile watcher must not advance the cursor).
- `tests/hermes_cli/test_kanban_core_functionality.py::test_notify_claim_is_single_owner_and_rewindable` — `old_cursor` baseline is now the snapped value rather than the hard-coded `0`; the rest of the single-owner / rewind invariants are unchanged.

## How to Test

```bash
uv run --with pytest --with pytest-xdist --with pytest-asyncio --with pytest-timeout \
  python3 -m pytest tests/hermes_cli/test_kanban_notify.py \
                    tests/gateway/test_kanban_notifier.py \
                    tests/hermes_cli/test_kanban_db.py \
                    tests/hermes_cli/test_kanban_core_functionality.py -v
```

Manual repro per the issue: create a task, append a couple of terminal events directly to `task_events`, then call `add_notify_sub` — on `main` the next watcher tick fires once per backlogged event; with this PR no notifications fire until a new event arrives.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(kanban):`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate (no open/merged/closed PR by anyone addresses the storm-on-boot cursor-snap; #28748 / #29891 / #29097 are orthogonal feature work on board-level subs and auto-subscribe)
- [x] My PR contains **only** changes related to this fix
- [x] I've run focused tests for the touched code and all pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15.x

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (internal DB helper; no public-facing config or docs key changed)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A (pure SQLite/Python logic)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A