### PR TITLE
feat: add engineering patterns skill

### DIFF
--- a/skills/software-development/engineering-patterns/SKILL.md
+++ b/skills/software-development/engineering-patterns/SKILL.md
@@ -1,0 +1,269 @@
+---
+name: engineering-patterns
+description: "Use when designing systems, reviewing code, refactoring legacy code, choosing GoF patterns, defining boundaries, writing tests around risky changes, or evaluating engineering trade-offs. Applies canonical engineering patterns without cargo-culting them."
+version: 1.3.0
+author: Tyler Mayfield + Hermes Agent
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [architecture, design-patterns, gof, code-quality, engineering-culture, solid, refactoring, ddd]
+    related_skills: [zen-of-python, architecture-doc-generator, explain-code-callout, requesting-code-review, test-driven-development, systematic-debugging, project-understanding, verification-before-completion]
+---
+
+# Engineering Patterns
+
+## Overview
+
+Use this skill to apply proven software engineering patterns from canonical engineering literature without turning them into cargo cults. The goal is not to name a pattern first; the goal is to diagnose the engineering pressure, pick the smallest useful abstraction, protect behavior with tests where needed, and explain trade-offs clearly.
+
+This skill synthesizes ideas from Clean Architecture, Domain-Driven Design, GoF Design Patterns, Refactoring, The Pragmatic Programmer, Code Complete, Working Effectively with Legacy Code, Peopleware, The Mythical Man-Month, and SICP.
+
+## When to Use
+
+- Designing a new service, module boundary, domain model, API, or library
+- Reviewing code for cohesion, coupling, testability, dependency direction, and pattern fit
+- Choosing between GoF patterns without over-engineering
+- Refactoring existing behavior safely
+- Working with legacy code that lacks tests or hides dependencies
+- Planning team structure, delivery scope, ownership, or coordination trade-offs
+- Explaining architecture decisions in plain language
+
+## Do Not Use When
+
+- The task is a tiny one-off script or syntax question
+- A direct function, small helper, or framework convention is clearly enough
+- The user only wants a quick implementation and has not asked for design analysis
+- There is no meaningful variation, boundary pressure, duplication, or testability problem
+- Applying the skill would add jargon or indirection without improving maintainability
+
+## Operating Procedure
+
+
+When applying this skill, do not start by naming a pattern. Start by diagnosing the engineering situation.
+
+1. **Classify the task**
+   - New design: service, module, domain model, API, library
+   - Review: PR, architecture, code smell, testability, coupling
+   - Refactor: existing behavior must stay stable
+   - Legacy change: code has weak/no tests or hidden dependencies
+   - Team/process: scope, delivery, interruptions, ownership, coordination
+
+2. **State the concrete problem in one sentence**
+   - Good: “Provider fallback logic is duplicated across three modules and new providers require editing all callers.”
+   - Bad: “We need Strategy.”
+
+3. **Pick at most two candidate principles/patterns**
+   - Use the decision matrix below.
+   - Prefer the smallest pattern that solves the current problem.
+   - If several patterns seem plausible, compare their trade-offs before choosing.
+
+4. **Check the simpler alternative**
+   - Could a plain function, dictionary dispatch, small value object, or module-level helper solve it?
+   - Only introduce indirection when it buys testability, extensibility, clarity, or boundary protection.
+
+5. **Define the boundary and contract**
+   - What data crosses the boundary?
+   - Who owns the abstraction?
+   - What invariants must hold?
+   - What dependencies are allowed to point where?
+
+6. **Apply the smallest safe change**
+   - New code: build the simplest structure that keeps the boundary clean.
+   - Existing code: add characterization tests or seams first.
+   - Large migration: use expand-contract, not a big-bang rewrite.
+
+7. **Verify behavior and explain trade-offs**
+   - Run relevant tests or define a manual verification path.
+   - State why the chosen pattern beats the simpler option.
+   - Document known costs: indirection, extra files/classes, performance, onboarding complexity.
+
+---
+
+## Quick Decision Matrix
+
+
+| Situation | Start With |
+|-----------|------------|
+| New service/domain to model | DDD bounded contexts + ubiquitous language |
+| Existing code, need to change safely | Feathers characterization tests + seams first |
+| Code review / smell detection | Fowler code smells + SOLID checks |
+| Architectural boundary decision | Clean Architecture dependency rule + Pragmatic orthogonality |
+| API/library design | SICP abstraction + GoF Adapter/Facade/Strategy + Law of Demeter |
+| Daily construction quality | Pragmatic DRY + Code Complete complexity rules |
+| Legacy modernization | Feathers seams + DDD anticorruption layer + expand-contract changes |
+| Team/schedule planning | Brooks's Law + Peopleware flow-state protection |
+| Pattern choice | Problem intent first, GoF structure second |
+
+---
+
+## Code Review Checklist
+
+
+Use this checklist during PR review or before claiming a refactor/design is complete.
+
+### Problem and intent
+
+- [ ] The code solves a clearly stated problem, not an imagined future requirement
+- [ ] Names match the domain language used by users/stakeholders
+- [ ] The design can be explained without pattern jargon
+- [ ] The pattern, if any, is named after the problem is understood
+
+### Cohesion and responsibility
+
+- [ ] Each module/class/function has one primary reason to change
+- [ ] Data and behavior that belong together are co-located
+- [ ] No god object, manager class, or “utility dumping ground” is emerging
+- [ ] Long functions/classes are split by behavior, not arbitrary line count
+
+### Coupling and boundaries
+
+- [ ] Dependencies point in the intended direction
+- [ ] Domain/application logic does not depend on framework, ORM, UI, or provider details
+- [ ] Boundary objects are stable DTOs/events/value objects, not leaked infrastructure models
+- [ ] External APIs/legacy schemas are behind adapters or anticorruption layers
+
+### Change safety
+
+- [ ] Existing behavior is protected by tests before refactoring
+- [ ] Legacy code changes identify a seam before invasive edits
+- [ ] Public API changes use expand-contract where possible
+- [ ] Tests assert behavior, not implementation trivia
+
+### Simplicity and trade-offs
+
+- [ ] A simpler alternative was considered
+- [ ] New abstractions are justified by real variation, duplication, or boundary pressure
+- [ ] The design avoids premature generality
+- [ ] Trade-offs are documented when the design is non-obvious
+
+### Common pattern signals
+
+- [ ] Repeated `if provider == ...` or `switch type` logic suggests Strategy/Factory/Registry
+- [ ] Many callers performing setup in the same order suggests Builder or Template Method
+- [ ] Third-party/legacy interface mismatch suggests Adapter
+- [ ] Complex subsystem used in one common way suggests Facade
+- [ ] Cross-cutting behavior suggests Decorator or middleware
+- [ ] State-dependent conditionals suggest State or an explicit state machine
+- [ ] Undo/queue/deferred execution suggests Command
+
+---
+
+## Modern Python and TypeScript Pattern Translations
+
+
+GoF patterns came from class-heavy OO languages. In Python and TypeScript, the cleanest implementation is often a function, protocol/interface, registry, middleware, or data object rather than a deep inheritance hierarchy.
+
+| Classic Pattern | Modern Python Form | Modern TypeScript Form | Use This Instead Of |
+|-----------------|--------------------|-------------------------|---------------------|
+| Strategy | Callable, `Protocol`, provider class, dict of functions | Function type, interface, object map | Long provider `if/elif` chains |
+| Factory Method | Function returning a protocol/interface implementation | Factory function returning interface | Constructors scattered across callers |
+| Abstract Factory | Module/object that creates related implementations | Factory object with typed methods | Passing many concrete classes around |
+| Builder | Dataclass/Pydantic builder, fluent object, validated config assembler | Builder object, schema parser, config composer | Huge constructors or partially valid objects |
+| Adapter | Thin wrapper around SDK/API/legacy response | Wrapper/client class, mapping layer | Leaking third-party response shapes |
+| Facade | Service module with a simple public function | Service/client facade | Callers orchestrating many subsystem details |
+| Decorator | Function decorator, context manager, middleware | Higher-order function, middleware | Repeating logging/retry/auth behavior |
+| Observer | Callback list, event bus, signal emitter | EventEmitter, observable, pub/sub | Direct calls from producer to every consumer |
+| Command | Task object, dataclass command, queue message | Command object, action payload | Passing raw ad-hoc dicts through queues |
+| State | Enum + transition table, state object | Discriminated union + transition map | Large stateful conditional blocks |
+| Template Method | Pipeline function with hook callables | Pipeline function with typed hooks | Subclassing only to override one step |
+| Chain of Responsibility | Middleware list, validator chain | Middleware/handler chain | One giant validation/orchestration function |
+| Proxy | Lazy property, caching wrapper, authorization wrapper | Proxy object, wrapper service | Callers manually managing cache/auth/lazy load |
+| Value Object (DDD) | Frozen dataclass/Pydantic model | readonly type/interface/class | Repeated primitive tuples/strings |
+
+### Translation rules
+
+- Prefer functions and composition before inheritance.
+- Prefer `Protocol`/interface boundaries over concrete base classes when behavior matters more than shared implementation.
+- Prefer registries for plugin/provider lookup when new implementations will be added over time.
+- Prefer discriminated unions / enums for finite state when transitions are simple; use State objects when behavior per state is substantial.
+- Prefer explicit DTOs/value objects at boundaries instead of passing raw provider/framework dictionaries everywhere.
+
+---
+
+
+## Canonical Pattern Heuristics
+
+Use these as quick triggers; see `references/canonical-engineering-books.md` for the full book-by-book synthesis.
+
+| Pressure | Heuristic |
+|----------|-----------|
+| Business/domain complexity | Use DDD bounded contexts, ubiquitous language, value objects, and aggregate boundaries only where invariants justify them |
+| Framework/provider coupling | Apply Clean Architecture dependency direction; put policy inward and infrastructure at the edge |
+| Repeated conditional behavior | Consider Strategy, Registry, State, or polymorphism after checking if a simple dictionary dispatch is enough |
+| Unsafe legacy change | Add Feathers-style characterization tests and seams before invasive edits |
+| Duplicated knowledge | Apply DRY to duplicated decisions, not every repeated line of similar-looking code |
+| Complex construction | Consider Builder or a validated config assembler when objects have ordered steps or invariants |
+| External API mismatch | Use Adapter or an anticorruption layer so provider schemas do not leak inward |
+| Complex subsystem usage | Use Facade when most callers need one common path through many details |
+| Cross-cutting behavior | Use Decorator, middleware, or wrapper services for retry/auth/logging/instrumentation |
+| Team coordination pressure | Remember Brooks's Law and Peopleware: protect focus, limit coordination surfaces, and make ownership explicit |
+
+## Pattern Selection Rules
+
+1. Name the concrete problem before naming the pattern.
+2. Prefer functions, modules, protocols/interfaces, value objects, and registries over inheritance-heavy structures in Python and TypeScript.
+3. Introduce indirection only when it buys real extensibility, testability, boundary protection, or readability.
+4. If two patterns both fit, choose the one with fewer moving parts and clearer failure modes.
+5. Keep old public seams or re-exports during refactors when callers/tests monkeypatch them.
+6. Use expand-contract for public API or schema migrations: add the new path, migrate callers, then remove the old path.
+7. Document the cost of the pattern: extra files/classes, cognitive load, performance, and onboarding impact.
+
+## Common Pitfalls
+
+
+1. **Pattern worship** — applying a pattern before the matching problem exists.
+2. **Conflating pattern with implementation** — a class named `Factory` that does 15 unrelated things is not a Factory.
+3. **Ignoring composition** — modern code often implements GoF ideas with functions, composition, registries, and middleware rather than inheritance.
+4. **Singleton abuse** — most “I need just one” cases are scoped instances or dependency injection, not globals.
+5. **Forgetting trade-offs** — every pattern adds indirection and cognitive cost. State why the benefit is worth it.
+6. **Visitor on unstable structures** — if element types change often, every visitor changes too.
+7. **Premature optimization** — measure before optimizing; most performance problems live in a small part of the code.
+8. **Big bang rewrites** — prefer incremental modernization behind seams and boundaries.
+9. **Adding people to a late project** — this usually increases coordination overhead.
+10. **Second-system over-engineering** — set explicit scope boundaries and success criteria before designing.
+11. **Metric gaming** — optimize for outcomes, not proxy outputs.
+12. **Feature envy** — move behavior toward the data it operates on, or introduce a proper domain object.
+13. **Refactoring without preserving test hooks** — keep old module-level names/re-exports if tests or callers monkeypatch them.
+14. **Schema-blind signal extraction** — handle flat and nested input schemas at boundaries; otherwise results fail silently.
+15. **Forcing all modules into a pattern at once** — deploy registries/catalogs first, then convert modules one at a time.
+
+---
+
+## Worked Examples and References
+
+
+This skill absorbed the detailed GoF examples from the old `design-patterns` skill. Reference files were copied into this skill:
+
+- `references/worked-example-reconiq.md` — Strategy + Registry + Template Method applied to ReconIQ
+- `references/competitor-search-case-study.md` — Builder + Strategy + Template Method for competitor query generation
+- `references/case-study-3-fallback-chain.md` — Chain of Responsibility + Strategy + Factory for provider fallback chains
+- `references/gof-pattern-catalog.md` — detailed GoF pattern catalog extracted from the original skill
+- `references/canonical-engineering-books.md` — detailed book-by-book synthesis extracted from the original skill
+
+Use those references when applying these patterns to real Python/FastAPI code.
+
+---
+
+## Architecture Decision Record Mini-Template
+
+
+Use an ADR when the choice affects module boundaries, dependencies, deployment, data ownership, provider selection, or long-term maintenance. Keep it short enough that future maintainers will actually read it.
+
+```markdown
+# ADR-NNN: <decision title>
+
+## Verification Checklist
+
+
+Before claiming a design is good:
+
+- [ ] The problem is clearly stated before the pattern is named
+- [ ] The chosen pattern’s intent matches the actual problem
+- [ ] A simpler alternative was considered
+- [ ] Trade-offs are documented: indirection, complexity, testability, performance
+- [ ] Dependencies point in the intended direction
+- [ ] Boundaries pass stable DTOs/events/value objects, not framework internals
+- [ ] Tests protect behavior before refactoring
+- [ ] The team/process impact was considered, not only code structure
+- [ ] The design can be explained in plain language without pattern jargon

--- a/skills/software-development/engineering-patterns/references/canonical-engineering-books.md
+++ b/skills/software-development/engineering-patterns/references/canonical-engineering-books.md
@@ -1,0 +1,322 @@
+# Canonical Engineering Books Reference
+
+Detailed synthesis moved out of the main skill to keep the default load concise.
+
+## 1. Clean Architecture — Robert C. Martin
+
+
+**Core thesis:** Separate code into layers with strict dependency rules. Inner layers know nothing about outer layers.
+
+**Patterns and heuristics:**
+
+- **Dependency Rule** — source dependencies point inward. Business policy must not depend on frameworks, databases, UIs, or APIs.
+- **Boundary Lines** — define what crosses a boundary: DTOs, commands, events, or primitives, not ORM models or framework objects.
+- **Ports and Adapters** — put abstract interfaces near the policy that owns them; implement details at the edge.
+- **Humble Object** — split testable logic from hard-to-test infrastructure.
+- **SOLID applied:**
+  - Single Responsibility — one reason to change
+  - Open/Closed — add behavior by extension, not invasive edits
+  - Liskov Substitution — subtypes preserve contracts
+  - Interface Segregation — many narrow interfaces beat one fat interface
+  - Dependency Inversion — policy depends on abstractions, details implement them
+
+**Example structure:**
+
+```text
+src/
+  domain/       # entities, value objects; no external dependencies
+  use_cases/    # application business rules
+  interfaces/   # ports owned by inner policy
+  adapters/     # DB/API/UI/framework implementations
+```
+
+---
+
+## 2. Domain-Driven Design — Eric Evans
+
+
+**Core thesis:** Model the domain. Let code reflect the ubiquitous language of the business.
+
+**Patterns and heuristics:**
+
+- **Bounded Context** — each context owns its model. Do not share one canonical model across different business languages.
+- **Aggregate** — cluster related entities/value objects under one root. Treat the aggregate as the consistency boundary.
+- **Entity vs. Value Object** — entities have identity; value objects are equal by attributes.
+- **Ubiquitous Language** — use the same terms in code, docs, tickets, and stakeholder conversations.
+- **Domain Events** — represent important domain facts as events: `InvoicePaid`, `LeadQualified`, `ReportGenerated`.
+- **Anticorruption Layer** — wrap legacy/external schemas so they do not leak into your domain model.
+
+**Use when:** the business domain is complex enough that nouns, workflows, lifecycle states, and invariants matter.
+
+---
+
+## 3. GoF Design Patterns — Gamma, Helm, Johnson, Vlissides
+
+
+**Core thesis:** Reusable OO design patterns describe recurring problems, solution structures, and trade-offs. They are not templates to force into code.
+
+Prefer pattern recognition over pattern application. First name the problem; only then choose the pattern.
+
+### Creational patterns — object creation
+
+| Pattern | Intent | Use When |
+|---------|--------|----------|
+| Singleton | Ensure exactly one instance and provide a global access point | A true process-wide singleton is required, e.g. config registry; beware global state |
+| Factory Method | Let subclasses or functions decide which concrete class to instantiate | Caller knows the abstraction, not the implementation |
+| Abstract Factory | Produce families of related objects without naming concrete classes | Multiple product families must vary together, e.g. themed UI widgets |
+| Builder | Separate construction of a complex object from representation | Construction has steps, optional parameters, or invariants |
+| Prototype | Create objects by copying an existing instance | Cloning is cheaper or more flexible than construction |
+
+### Structural patterns — object composition
+
+| Pattern | Intent | Use When |
+|---------|--------|----------|
+| Adapter | Convert one interface into another clients expect | Wrapping third-party, legacy, or incompatible APIs |
+| Bridge | Decouple abstraction from implementation so both can vary | Two dimensions vary independently; avoid subclass explosion |
+| Composite | Treat individual objects and compositions uniformly | Trees: filesystem, UI components, org charts |
+| Decorator | Add responsibilities dynamically without subclassing | Stackable behavior: middleware, buffered IO, logging wrappers |
+| Facade | Provide a simplified interface to a subsystem | Hide subsystem complexity behind a common path |
+| Flyweight | Share common intrinsic state among many fine-grained objects | Many identical-ish objects: particles, glyphs, tiles |
+| Proxy | Control access to another object | Lazy loading, caching, security, remote access, instrumentation |
+
+### Behavioral patterns — interaction and responsibility
+
+| Pattern | Intent | Use When |
+|---------|--------|----------|
+| Chain of Responsibility | Pass request along handlers until one handles it | Middleware, validation chains, event bubbling |
+| Command | Encapsulate a request as an object | Undo/redo, queues, macros, transaction logs |
+| Interpreter | Represent grammar + interpreter for a small language | Tiny fixed DSL; otherwise prefer parser generators |
+| Iterator | Traverse collections without exposing internals | Language-level iteration or custom traversal |
+| Mediator | Centralize complex communication | Many objects need coordination; avoid mesh dependencies |
+| Memento | Capture/restore state without exposing internals | Undo, snapshots, checkpoints |
+| Observer | Notify dependents when state changes | Events, pub/sub, reactive UI, MVC |
+| State | Change behavior when internal state changes | Explicit state machines without giant conditionals |
+| Strategy | Interchangeable algorithms behind one interface | Sort/search/payment/provider selection at runtime |
+| Template Method | Define an algorithm skeleton with overridable steps | Fixed pipeline with customizable stages |
+| Visitor | Add operations to a stable object structure | AST traversal, file trees; avoid if node classes change often |
+
+### GoF selection flowchart
+
+```text
+Is plain code enough?
+  yes -> use plain functions/classes
+  no
+Need controlled creation?
+  complex construction -> Builder
+  choose concrete type -> Factory Method / Abstract Factory
+  clone existing object -> Prototype
+  exactly one true global -> Singleton, but challenge this hard
+Need composition/adaptation?
+  incompatible interface -> Adapter
+  complex subsystem -> Facade
+  stackable behavior -> Decorator
+  tree uniformity -> Composite
+  two independent variation axes -> Bridge
+  controlled/lazy access -> Proxy
+Need behavior orchestration?
+  interchangeable algorithms -> Strategy
+  fixed algorithm skeleton -> Template Method
+  request pipeline -> Chain of Responsibility
+  action object / undo / queue -> Command
+  state-dependent behavior -> State
+  one-to-many notification -> Observer
+  stable object structure + new operations -> Visitor
+```
+
+### Natural pattern combinations
+
+- Decorator + Composite — UI trees with bordered/scrollable components
+- Observer + Mediator — observers register with a coordinating mediator
+- Command + Memento — commands implement undo using captured pre-state
+- Strategy + State — both delegate behavior; State transitions itself, Strategy is selected externally
+- Adapter + Facade — adapter converts an interface; facade simplifies a subsystem
+- Strategy + Registry — provider/plugin systems selected by name or capability
+- Builder + Template Method — fixed construction pipeline with overrideable steps
+
+---
+
+## 4. Refactoring — Martin Fowler
+
+
+**Core thesis:** Improve internal structure without changing external behavior, guided by tests.
+
+**Code smells checklist:**
+
+- Duplicated code
+- Long method / long function
+- Large class / god object
+- Long parameter list
+- Divergent change — one class changes for many unrelated reasons
+- Shotgun surgery — one change requires touching many files
+- Feature envy — a method manipulates another object’s data more than its own
+- Primitive obsession — missing small domain objects/value types
+- Switch statements that want polymorphism or Strategy
+- Temporary fields and speculative generality
+
+**Core refactorings:** Extract Method, Inline Method, Rename Variable, Move Method, Introduce Parameter Object, Extract Class, Replace Conditional with Polymorphism, Split Phase, Encapsulate Variable.
+
+**Rules:**
+
+- **Rule of Three** — wait until duplication appears three times before extracting a general abstraction.
+- **Small safe steps** — refactor in behavior-preserving increments; run tests between steps.
+- **Expand-Contract** — add the new interface, migrate callers, then remove the old interface.
+
+---
+
+## 5. The Pragmatic Programmer — Thomas & Hunt
+
+
+**Core thesis:** Take responsibility for craft, tools, design, and feedback loops.
+
+**Principles:**
+
+- **DRY** — every piece of knowledge has one authoritative representation.
+- **Orthogonality** — independent components can change independently.
+- **Tracer Bullets** — build thin end-to-end functionality early for feedback.
+- **Design by Contract** — define preconditions, postconditions, and invariants.
+- **Temporal Coupling** — if A must happen before B, make the sequence explicit.
+- **Plain Text Power** — prefer human-readable, tool-friendly formats where possible.
+- **Automation** — automate repeated tasks; do not rely on memory.
+- **Law of Demeter** — talk only to immediate collaborators; avoid train wreck calls.
+
+---
+
+## 6. Code Complete 2 — Steve McConnell
+
+
+**Core thesis:** Construction quality matters. Most software cost is paid in code comprehension, modification, testing, and debugging.
+
+**Rules of thumb:**
+
+- Routines should do one thing completely and well.
+- Keep variable scope minimal; initialize close to first use.
+- Prefer named constants over magic numbers.
+- Use guard clauses to reduce nesting.
+- Prefer positive conditionals over double negatives.
+- Hide complexity behind well-named abstractions.
+- Class cohesion matters: everything in a class should belong together.
+- Subclasses should specialize, not generalize.
+
+---
+
+## 7. Working Effectively with Legacy Code — Michael Feathers
+
+
+**Core thesis:** Legacy code is code without tests. Improve it by finding seams and adding characterization tests.
+
+**Patterns:**
+
+- **Seam** — a place where behavior can change without editing that location.
+- **Characterization Test** — capture existing behavior before changing it, even if the behavior is odd.
+- **Sprout Method/Class** — add new behavior beside old behavior rather than rewriting everything.
+- **Wrap Method/Class** — wrap old behavior with a new boundary.
+- **Extract Interface** — introduce a mockable seam.
+- **Subclass and Override** — isolate hard dependencies for tests.
+- **Lean Test Addition** — add the minimum tests needed for the change at hand.
+
+---
+
+## 8. Peopleware — DeMarco & Lister
+
+
+**Core thesis:** Software project failures are usually sociological before they are technological.
+
+**Patterns:**
+
+- **Protect Flow State** — batch interruptions; focus blocks are productive infrastructure.
+- **Team Room / High-Bandwidth Collaboration** — create dedicated synchronous space when needed.
+- **Quality of Work Life → Quality of Product** — burnout creates defects.
+- **Remove Demotivators** — bad tools, unclear requirements, and constant interruptions hurt more than perks help.
+- **Measure Outcomes, Not Outputs** — lines of code and ticket counts invite gaming.
+
+---
+
+## 9. The Mythical Man-Month — Frederick Brooks
+
+
+**Core thesis:** Adding people to a late software project makes it later.
+
+**Patterns:**
+
+- **Brooks's Law** — communication paths scale as N(N-1)/2.
+- **Surgical Team** — small focused teams with clear technical leadership beat committees.
+- **Second-System Effect** — the second version is at highest risk of over-engineering.
+- **No Silver Bullet** — no single tool/method eliminates essential complexity.
+- **Plan to Throw One Away** — prototype to learn; expect the first design to be wrong.
+- **Essential vs. Accidental Difficulty** — complexity, conformance, changeability, and invisibility are essential.
+
+---
+
+## 10. Structure and Interpretation of Computer Programs — Abelson & Sussman
+
+
+**Core thesis:** Build the right abstractions. Computation is abstraction at multiple levels.
+
+**Patterns:**
+
+- **Data Abstraction** — separate operations from representation.
+- **Procedural Abstraction** — name reusable computation patterns.
+- **Metalinguistic Abstraction** — build small languages/DSLs to express domain ideas directly.
+- **Closures** — functions with captured environments power callbacks, memoization, and partial application.
+- **Streams / Lazy Evaluation** — separate sequence description from evaluation.
+- **Interpreters** — when behavior is data, build an evaluator.
+
+---
+
+## Cross-Book Synthesis
+
+
+```text
+Architecture Decisions
+  Clean Architecture Dependency Rule
+  + DDD Bounded Contexts
+  + Pragmatic Orthogonality
+  -> boundary protection and modularity
+
+Code Quality
+  Pragmatic DRY
+  + SOLID
+  + Code Complete complexity management
+  + Fowler smells
+  -> readable, cohesive, maintainable code
+
+Change Safety
+  Feathers characterization tests
+  + Fowler refactorings
+  + expand-contract changes
+  -> confident incremental improvement
+
+Team Design
+  Peopleware flow state
+  + Brooks's Law
+  + clear ownership
+  -> small teams, focus, less coordination tax
+
+Abstraction
+  SICP abstraction
+  + GoF patterns
+  + DDD value objects
+  + Interface Segregation
+  -> right abstraction at the right level
+```
+
+---
+
+## What Not to Cargo-Cult
+
+
+Every canonical book has sharp ideas that can become harmful when copied mechanically.
+
+- **Clean Architecture:** do not create four layers for a tiny CRUD endpoint. Use boundaries where policy and details genuinely need separation.
+- **DDD:** do not introduce aggregates, repositories, and domain events for a simple data-entry app with no domain complexity.
+- **GoF:** do not recreate Java-style inheritance hierarchies in Python/TypeScript when functions, registries, or interfaces solve the problem.
+- **Refactoring:** do not refactor endlessly without a behavioral goal or test safety net.
+- **Pragmatic Programmer:** do not interpret DRY as “remove all textual similarity.” DRY is about duplicated knowledge, not every repeated line.
+- **Code Complete:** do not turn local style preferences into universal laws. Optimize for team consistency and comprehensibility.
+- **Legacy Code:** do not try to test the entire legacy system before making one change. Add targeted characterization tests around the seam you need.
+- **Peopleware:** do not use “protecting flow” as an excuse to avoid necessary communication or slow feedback loops.
+- **Mythical Man-Month:** do not treat small teams as a universal fix. Some work needs coordination; the point is to make coordination explicit and bounded.
+- **SICP:** do not build a DSL just because you can. Build one when it makes domain ideas simpler than host-language code.
+
+---
+

--- a/skills/software-development/engineering-patterns/references/case-study-3-fallback-chain.md
+++ b/skills/software-development/engineering-patterns/references/case-study-3-fallback-chain.md
@@ -1,0 +1,121 @@
+# Case Study 3: Fallback Chain — Chain of Responsibility
+
+> Source: ReconIQ project (`~/Documents/ReconIQ/`) — implemented 2026-05-20
+
+## Problem
+
+`FirecrawlSearchProvider` failed with "Insufficient credits" (a billing error).
+`discover_competitors()` had no fallback — one provider, one shot. When Firecrawl
+ran out of credits, the entire competitor module returned empty results silently.
+
+## Solution
+
+`research/search_provider.py` — `FallbackSearchProvider` wraps primary + fallback:
+
+```python
+class FallbackSearchProvider(SearchProvider):
+    """Chain-of-Responsibility: try primary, fall back to secondary on failure."""
+
+    def __init__(self, primary: SearchProvider, fallback: SearchProvider):
+        self._primary = primary
+        self._fallback = fallback
+
+    def _is_fallback_worthy(self, result: dict[str, Any]) -> bool:
+        if not result.get("results") and not result.get("accounts"):
+            return True
+        for msg in result.get("data_limitations") or []:
+            lower = msg.lower()
+            if any(kw in lower for kw in (
+                "insufficient credits", "payment required",
+                "api error", "rate limit", "unauthorized", "timeout",
+            )):
+                return True
+        return False
+
+    def discover_competitors(self, company_profile, target_url):
+        primary_result = self._primary.discover_competitors(company_profile, target_url)
+        if not self._is_fallback_worthy(primary_result):
+            return primary_result
+        fallback_result = self._fallback.discover_competitors(company_profile, target_url)
+        fallback_result["data_limitations"] = (
+            (primary_result.get("data_limitations") or [])
+            + (fallback_result.get("data_limitations") or [])
+        )
+        fallback_result["provider"] = f"{self._primary.name}+{self._fallback.name}"
+        return fallback_result
+```
+
+## Configuration
+
+Fallback chain is data, not code. In `config.yaml`:
+
+```yaml
+search:
+  provider: "firecrawl"
+  firecrawl:
+    api_key: "${FIRECRAWL_API_KEY}"
+  serpapi:
+    api_key: "${SERPAPI_API_KEY}"
+  fallback_chains:
+    firecrawl:
+      - serpapi   # SerpAPI tried when Firecrawl fails
+```
+
+The factory reads `fallback_chains` and builds the chain at startup. Adding a
+third fallback is one line in config, zero lines in Python code.
+
+## Chain of Responsibility Pattern
+
+`FallbackSearchProvider` is the textbook Chain of Responsibility: a request
+passes through handlers until one succeeds. The key insight is that the
+**trigger condition** (`_is_fallback_worthy`) is centralized in one place rather
+than scattered across provider classes. Any provider can be primary or fallback
+— the chain composition is determined entirely by config data.
+
+## SerpAPI Provider
+
+Fixed-cost model ($10/month / 5,000 searches) vs Firecrawl's credits model.
+Uses `urllib.request` directly, no external library dependency. Returns real
+Google results including local map listings:
+
+```python
+def _search(self, query: str, limit: int = 5) -> list[dict[str, str]]:
+    import urllib.request, urllib.parse, json
+    params = {"q": query, "api_key": self._api_key, "num": limit, "engine": "google"}
+    url = f"https://serpapi.com/search?{urllib.parse.urlencode(params)}"
+    with urllib.request.urlopen(url, timeout=30) as response:
+        data = json.loads(response.read().decode())
+    organic = data.get("search_results", {}).get("organic_results", [])
+    return [
+        {"title": item.get("title", "") or "",
+         "url": item.get("link", "") or "",
+         "snippet": item.get("snippet", "") or ""}
+        for item in organic[:limit] if item.get("link")
+    ]
+```
+
+## Composable Chains
+
+Three-provider chain:
+```python
+FallbackSearchProvider(
+    FirecrawlSearchProvider(firecrawl_key),
+    FallbackSearchProvider(SerpAPISearchProvider(serpapi_key), DuckDuckGoProvider())
+)
+```
+
+## Design Patterns Applied
+
+1. **Chain of Responsibility** — request propagates through handlers until one succeeds;
+   trigger condition centralized; chain order from config
+2. **Strategy** — concrete providers implement the same `SearchProvider` interface,
+   fully interchangeable
+3. **Factory** — `get_search_provider()` reads config and builds the provider graph;
+   configuration format (`fallback_chains`) is data-driven, not hardcoded in Python
+
+## Files
+
+- `research/search_provider.py` — `SerpAPISearchProvider`, `FallbackSearchProvider`
+- `tests/test_search_provider.py` — 22 tests
+- `config.yaml` — `serpapi` config + `fallback_chains` section
+- `.env` / `.env.example` — `SERPAPI_API_KEY` field

--- a/skills/software-development/engineering-patterns/references/competitor-search-case-study.md
+++ b/skills/software-development/engineering-patterns/references/competitor-search-case-study.md
@@ -1,0 +1,137 @@
+# Case Study 2: Competitor Search — Builder + Strategy + Template Method
+
+> Source: ReconIQ project (`~/Documents/ReconIQ/`) — implemented 2026-05-20
+
+## Problem
+
+`discover_competitors()` built a single query string from whatever company profile
+fields were available, with no explicit industry signal and no fallback queries.
+"Companies like Acme" returns national brands and Wikipedia entries, not local
+competitors in the same industry and location.
+
+## Root Cause
+
+Five distinct failure modes compounded:
+1. `services_products` empty → no industry signal
+2. No location narrowing → generic national results
+3. Company domain ignored for industry context
+4. Single query with no fallback
+5. `service_area` not used for location signal
+
+## Solution
+
+`research/competitor_query.py` — `CompetitorQueryBuilder`:
+
+```python
+class CompetitorQueryBuilder:
+    def __init__(self, company_profile: dict):
+        self._company_profile = company_profile
+
+    @cached_property
+    def industry_signals(self) -> list[str]:
+        # Priority: what_they_do → target_audience → services_products
+        p = self._company_profile
+        signals = []
+        if p.get("what_they_do"): signals.append(p["what_they_do"])
+        if p.get("target_audience"): signals.append(p["target_audience"])
+        if p.get("services_products"):
+            for s in p["services_products"]:
+                if isinstance(s, dict):
+                    signals.extend([s.get("product",""), s.get("service","")])
+                else:
+                    signals.append(str(s))
+        return [s for s in signals if s]
+
+    @cached_property
+    def location_signals(self) -> list[str]:
+        p = self._company_profile
+        signals = []
+        city = (p.get("city") or "").strip()
+        state = (p.get("state") or "").strip()
+        city_state = f"{city} {state}" if city and state else ""
+        if p.get("service_area"):
+            for area in p["service_area"]:
+                area = area.strip()
+                if area and area != city and area != city_state:
+                    signals.append(area)
+        if city and state: signals.append(city_state)
+        if p.get("zip"): signals.append(p["zip"])
+        return signals
+
+    def build_query_set(self) -> list[tuple[str, str]]:
+        return [
+            ("industry_location", self._industry_location_query()),
+            ("services_location", self._services_location_query()),
+            ("companies_like", self._companies_like_query()),
+            ("directory", self._directory_query()),
+            ("industry_only", self._industry_only_query()),
+        ]
+```
+
+**Builder**: signals accumulate lazily via `@cached_property` — expensive
+extractions are only computed once and only when needed.
+
+**Strategy**: each `_industry_location_query()`, etc. is a fully encapsulated
+query constructor. The priority order is fixed in `build_query_set()` (Template
+Method), but individual strategies can be overridden independently.
+
+**Template Method**: `build_query_set()` defines the fixed sequence. Callers
+depend on this order — they stop once they have 5+ deduplicated results.
+
+## Backward Compatibility
+
+```python
+# search_provider.py — re-export preserves test monkeypatch targets
+from research.competitor_query import _build_competitor_query  # noqa: F401
+```
+
+## Deduplication Bug Fixed
+
+```python
+# OLD — didn't catch "Vancouver WA" when city="Vancouver"
+area != city  # "Vancouver WA" != "Vancouver" → True (no dedup)
+
+# NEW — normalized comparison
+city_state = f"{city} {state}"
+area != city_state  # "Vancouver WA" != "Vancouver WA" → False (correct dedup)
+```
+
+## Five Query Strategies
+
+| Strategy | Example Query | When Used |
+|----------|--------------|-----------|
+| `industry_location` | `"hvac contractor Vancouver WA"` | Strongest local signal |
+| `services_location` | `"furnace repair, AC installation Vancouver WA"` | Fallback when industry desc is vague |
+| `companies_like` | `"companies like Acme HVAC Vancouver WA"` | Adds industry context to avoid self-match |
+| `directory` | `"top hvac contractors in Vancouver WA"` | Catches listing/roundup pages |
+| `industry_only` | `"hvac contractor"` | Last resort — regional players |
+
+## Schema Mismatch Bug Discovered
+
+The company profile data arrives with a **nested** location schema:
+```python
+{"location": {"city": "Ridgefield", "state": "WA", "service_area": [...], "zip": "98642"}}
+```
+
+But `_extract_location_signals` originally read flat keys (`location_city`, `location_state`). The function silently returned `[]` — no error, just empty results. Every query variant lost its geographic qualifier and returned generic national results instead of local competitors.
+
+**Fix**: the function now handles both schemas:
+```python
+loc = profile.get("location", {})
+if not isinstance(loc, dict):
+    loc = {}
+city = loc.get("city", "") or profile.get("location_city", "") or ""
+state = loc.get("state", "") or profile.get("location_state", "") or ""
+```
+
+**Lesson**: signal-extraction functions that return empty arrays silently on schema mismatch are a durable class of bug. Add schema validation at the boundary before signal extraction begins, especially when the data schema is controlled by another module or service.
+
+## Test Coverage
+
+`tests/test_competitor_query.py` — 23 tests covering:
+- Signal extraction (industry, location, name, services)
+- Each query strategy with real and empty inputs
+- `CompetitorQueryBuilder` integration
+- Backward-compat `_build_competitor_query()` function
+- Deduplication of `service_area` vs `city+state`
+- URL deduplication across query results

--- a/skills/software-development/engineering-patterns/references/gof-pattern-catalog.md
+++ b/skills/software-development/engineering-patterns/references/gof-pattern-catalog.md
@@ -1,0 +1,83 @@
+# GoF Pattern Catalog
+
+**Core thesis:** Reusable OO design patterns describe recurring problems, solution structures, and trade-offs. They are not templates to force into code.
+
+Prefer pattern recognition over pattern application. First name the problem; only then choose the pattern.
+
+### Creational patterns — object creation
+
+| Pattern | Intent | Use When |
+|---------|--------|----------|
+| Singleton | Ensure exactly one instance and provide a global access point | A true process-wide singleton is required, e.g. config registry; beware global state |
+| Factory Method | Let subclasses or functions decide which concrete class to instantiate | Caller knows the abstraction, not the implementation |
+| Abstract Factory | Produce families of related objects without naming concrete classes | Multiple product families must vary together, e.g. themed UI widgets |
+| Builder | Separate construction of a complex object from representation | Construction has steps, optional parameters, or invariants |
+| Prototype | Create objects by copying an existing instance | Cloning is cheaper or more flexible than construction |
+
+### Structural patterns — object composition
+
+| Pattern | Intent | Use When |
+|---------|--------|----------|
+| Adapter | Convert one interface into another clients expect | Wrapping third-party, legacy, or incompatible APIs |
+| Bridge | Decouple abstraction from implementation so both can vary | Two dimensions vary independently; avoid subclass explosion |
+| Composite | Treat individual objects and compositions uniformly | Trees: filesystem, UI components, org charts |
+| Decorator | Add responsibilities dynamically without subclassing | Stackable behavior: middleware, buffered IO, logging wrappers |
+| Facade | Provide a simplified interface to a subsystem | Hide subsystem complexity behind a common path |
+| Flyweight | Share common intrinsic state among many fine-grained objects | Many identical-ish objects: particles, glyphs, tiles |
+| Proxy | Control access to another object | Lazy loading, caching, security, remote access, instrumentation |
+
+### Behavioral patterns — interaction and responsibility
+
+| Pattern | Intent | Use When |
+|---------|--------|----------|
+| Chain of Responsibility | Pass request along handlers until one handles it | Middleware, validation chains, event bubbling |
+| Command | Encapsulate a request as an object | Undo/redo, queues, macros, transaction logs |
+| Interpreter | Represent grammar + interpreter for a small language | Tiny fixed DSL; otherwise prefer parser generators |
+| Iterator | Traverse collections without exposing internals | Language-level iteration or custom traversal |
+| Mediator | Centralize complex communication | Many objects need coordination; avoid mesh dependencies |
+| Memento | Capture/restore state without exposing internals | Undo, snapshots, checkpoints |
+| Observer | Notify dependents when state changes | Events, pub/sub, reactive UI, MVC |
+| State | Change behavior when internal state changes | Explicit state machines without giant conditionals |
+| Strategy | Interchangeable algorithms behind one interface | Sort/search/payment/provider selection at runtime |
+| Template Method | Define an algorithm skeleton with overridable steps | Fixed pipeline with customizable stages |
+| Visitor | Add operations to a stable object structure | AST traversal, file trees; avoid if node classes change often |
+
+### GoF selection flowchart
+
+```text
+Is plain code enough?
+  yes -> use plain functions/classes
+  no
+Need controlled creation?
+  complex construction -> Builder
+  choose concrete type -> Factory Method / Abstract Factory
+  clone existing object -> Prototype
+  exactly one true global -> Singleton, but challenge this hard
+Need composition/adaptation?
+  incompatible interface -> Adapter
+  complex subsystem -> Facade
+  stackable behavior -> Decorator
+  tree uniformity -> Composite
+  two independent variation axes -> Bridge
+  controlled/lazy access -> Proxy
+Need behavior orchestration?
+  interchangeable algorithms -> Strategy
+  fixed algorithm skeleton -> Template Method
+  request pipeline -> Chain of Responsibility
+  action object / undo / queue -> Command
+  state-dependent behavior -> State
+  one-to-many notification -> Observer
+  stable object structure + new operations -> Visitor
+```
+
+### Natural pattern combinations
+
+- Decorator + Composite — UI trees with bordered/scrollable components
+- Observer + Mediator — observers register with a coordinating mediator
+- Command + Memento — commands implement undo using captured pre-state
+- Strategy + State — both delegate behavior; State transitions itself, Strategy is selected externally
+- Adapter + Facade — adapter converts an interface; facade simplifies a subsystem
+- Strategy + Registry — provider/plugin systems selected by name or capability
+- Builder + Template Method — fixed construction pipeline with overrideable steps
+
+---

--- a/skills/software-development/engineering-patterns/references/worked-example-reconiq.md
+++ b/skills/software-development/engineering-patterns/references/worked-example-reconiq.md
@@ -1,0 +1,149 @@
+# Worked Example: ReconIQ Pattern Application
+
+> Source: ReconIQ project (`~/Documents/ReconIQ/`) — refactored 2026-05-19
+
+Three patterns applied to a FastAPI + Streamlit + Next.js marketing intelligence
+platform. All existing tests pass (425/426 — 1 pre-existing failure unrelated).
+
+## Techniques Learned
+
+### 1. Backward-Compatible Re-export for Test Monkeypatching
+
+When refactoring a module whose functions are monkeypatched by test fixtures,
+keep the old names available as module-level re-exports:
+
+```python
+# coordinator.py — old: direct imports used by tests
+from research.outreach import run as run_outreach
+from research.prospect_score import compute_prospect_score
+
+# coordinator.py — refactored: add explicit re-exports
+from research.outreach import run as run_outreach  # noqa: F401
+from research.prospect_score import compute_prospect_score  # noqa: F401
+```
+
+Tests like `monkeypatch.setattr(coordinator, "run_outreach", mock_fn)` still
+work because the name lives on the module. Without this, tests get
+`AttributeError: module has no attribute 'run_outreach'`.
+
+### 2. Gradual Registry Adoption
+
+Don't try to convert all modules to a new pattern in one pass. Instead:
+
+1. **Deploy the catalog first**: `ModuleRegistry.register_existing()` lets
+   you centralize module metadata (names, labels, order, dependencies) while
+   modules continue using their existing `run()` functions.
+2. **Keep old dispatch working**: Coordinator calls `run_company_profile()`,
+   `run_seo_keywords()`, etc. directly — same as before.
+3. **Registry is the catalog**: `ModuleRegistry.get_labels()` replaces
+   the hard-coded `MODULE_LABELS` dict. Coordinator queries registry for
+   names/ordering instead of maintaining its own copy.
+4. **Template Method ready for future**: `BaseResearchModule` and
+   `@research_module` decorator exist but aren't forced on existing code.
+
+This avoids the "refactor everything at once" pitfall — the first attempt
+tried to route company_profile through `ModuleRegistry.get().execute()` and
+broke because the module's signature didn't match the new interface.
+
+### 3. Strategy Pattern with Factory Function
+
+```python
+# search_provider.py — factory selects the right provider
+def get_search_provider(config=None) -> SearchProvider:
+    if not search_cfg.get("enabled", False):
+        return DisabledSearchProvider()
+    if provider_name == "firecrawl":
+        return FirecrawlSearchProvider(api_key=api_key, api_url=api_url)
+    return DisabledSearchProvider()
+```
+
+Key design choices:
+- **Factory function, not DI container**: reads existing config.yaml → .env,
+  no new dependency.
+- **DisabledSearchProvider as default**: local-first by design. When search
+  is disabled or credentials are missing, returns clean empty results with
+  `data_limitations` rather than crashing.
+- **search.py delegates**: existing callers (`discover_competitors()`,
+  `discover_social_accounts()`) now call `get_search_provider().discover_*()`
+  — zero API change for callers.
+
+### 4. Registry Pattern for Module Catalog
+
+```python
+class ModuleRegistry:
+    _modules: ClassVar[dict[str, ModuleDescriptor]] = {}
+
+    @classmethod
+    def ensure_initialized(cls):
+        cls.register_existing("company_profile", "Company Profile",
+            order=10, downstream_group="primary")
+        cls.register_existing("seo_keywords", "SEO Keywords",
+            dependencies=("company_profile",), order=20,
+            downstream_group="parallel_downstream")
+        # ...
+```
+
+Benefits over the old hard-coded dict:
+- Order metadata (`order=10`) drives pipeline sequence
+- Group metadata (`downstream_group="parallel_downstream"`) identifies
+  modules that can run concurrently
+- Dependency metadata enables future automatic dependency resolution
+- `register_existing()` is idempotent — safe to call multiple times
+
+### 5. Template Method for Research Modules
+
+```python
+class BaseResearchModule(abc.ABC):
+    def execute(self, inputs, llm_complete, scrape_result=None, **kwargs):
+        prompt = self.build_prompt(inputs, scrape_result, **kwargs)
+        data = self._call_llm(prompt)
+        data = self.process_result(data, inputs, scrape_result, **kwargs)
+        return self._validate(data)
+
+    @abc.abstractmethod
+    def build_prompt(self, inputs, scrape_result, **kwargs) -> str: ...
+    def get_system_prompt(self) -> str: return ""
+    def process_result(self, data, inputs, scrape_result, **kwargs): ...
+```
+
+The skeleton handles JSON parsing, retries, evidence attachment, and schema
+validation. Subclasses override only `build_prompt()` and optionally
+`get_system_prompt()` and `process_result()`.
+
+Combined with `@research_module` decorator for auto-registration:
+```python
+@research_module(name="company_profile", label="Company Profile",
+                 required_keys=[...], schema_class=CompanyProfileSchema,
+                 order=10, max_tokens=1500)
+class CompanyProfileModule(BaseResearchModule):
+    def build_prompt(self, inputs, scrape_result, target_url=None, **kwargs):
+        return f"TARGET URL: {target_url}\n\n..."
+```
+
+## Pitfalls Encountered
+
+1. **Don't wrap existing function-based modules in Template Method prematurely.**
+   The first coordinator rewrite tried `ModuleRegistry.get("company_profile").execute()`
+   but the module wasn't yet a `BaseResearchModule` subclass — its `run()` function
+   signature was different. Fix: keep calling `run()` directly, only use registry
+   for catalog.
+
+2. **Re-importing inside a function body bypasses test monkeypatching.**
+   `from research.prospect_score import compute_prospect_score` inside the
+   coordinator's `run_all()` function creates a local binding that monkeypatch
+   can't reach. Fix: import at module level and reference the module-level name.
+
+3. **Patch tool can produce malformed output on structural changes.**
+   When inserting a new method before an existing one in a class, the diff can
+   produce duplicate fragments. Fix: rewrite the entire file when the change
+   affects class structure.
+
+## File Inventory
+
+| File | Pattern | Status |
+|------|---------|--------|
+| `research/search_provider.py` | Strategy | New — 268 lines |
+| `research/search.py` | Strategy delegate | Refactored — 58 lines (was 150) |
+| `research/module.py` | Registry + Template Method | New — 330 lines |
+| `research/coordinator.py` | Registry consumer | Refactored — 292 lines (was 286) |
+| `DESIGN_PATTERNS.md` | Documentation | New — full old/new comparison |


### PR DESCRIPTION
## Summary

Adds a new `engineering-patterns` skill under `skills/software-development/`.

The skill helps Hermes apply software engineering patterns without cargo-culting them. It covers:

- architecture and module-boundary decisions
- code review heuristics
- safe refactoring and legacy-code changes
- GoF pattern selection
- modern Python/TypeScript pattern translations
- engineering trade-off analysis
- anti-overengineering checks

The main `SKILL.md` is intentionally concise, with deeper reference material split into `references/`.

## Test Plan

- [x] Validated SKILL.md frontmatter
- [x] Confirmed description length is under 1024 chars
- [x] Confirmed total skill size is under 100,000 chars
- [x] Confirmed supporting references are included
