### PR TITLE
fix: render Feishu markdown tables as cards

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -155,7 +155,7 @@ _MARKDOWN_HINT_RE = re.compile(
 )
 # Detect markdown tables: a line starting with | followed by a separator line.
 # Feishu post-type 'md' elements do not render tables, so table content uses cards.
-_MARKDOWN_TABLE_RE = re.compile(r"^\|.*\|\n\|[-|: ]+\|", re.MULTILINE)
+_MARKDOWN_TABLE_RE = re.compile(r"^\s{0,3}\|.*\|\n\s{0,3}\|[-|: ]+\|", re.MULTILINE)
 _MARKDOWN_LINK_RE = re.compile(r"\[([^\]]+)\]\(([^)]+)\)")
 _MARKDOWN_FENCE_OPEN_RE = re.compile(r"^(`{3,}|~{3,})([^\n`~]*)\s*$")
 _MARKDOWN_FENCE_CLOSE_RE = re.compile(r"^```\s*$")

--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -64,7 +64,7 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Any, Dict, List, Literal, Optional, Sequence
+from typing import Any, Dict, List, Literal, Optional, Sequence, Tuple
 from urllib.error import HTTPError, URLError
 from urllib.parse import urlencode
 from urllib.request import Request, urlopen
@@ -154,10 +154,10 @@ _MARKDOWN_HINT_RE = re.compile(
     re.MULTILINE,
 )
 # Detect markdown tables: a line starting with | followed by a separator line.
-# Feishu post-type 'md' elements do not render tables, so we force text mode.
+# Feishu post-type 'md' elements do not render tables, so table content uses cards.
 _MARKDOWN_TABLE_RE = re.compile(r"^\|.*\|\n\|[-|: ]+\|", re.MULTILINE)
 _MARKDOWN_LINK_RE = re.compile(r"\[([^\]]+)\]\(([^)]+)\)")
-_MARKDOWN_FENCE_OPEN_RE = re.compile(r"^```([^\n`]*)\s*$")
+_MARKDOWN_FENCE_OPEN_RE = re.compile(r"^(`{3,}|~{3,})([^\n`~]*)\s*$")
 _MARKDOWN_FENCE_CLOSE_RE = re.compile(r"^```\s*$")
 _MENTION_RE = re.compile(r"@_user_\d+")
 _MULTISPACE_RE = re.compile(r"[ \t]{2,}")
@@ -556,6 +556,73 @@ def _build_markdown_post_payload(content: str) -> str:
         },
         ensure_ascii=False,
     )
+
+
+def _build_markdown_card_v2_payload(content: str) -> str:
+    """Build a Feishu/Lark JSON 2.0 card for Markdown content.
+
+    Feishu post-message `md` nodes do not reliably render Markdown tables, but
+    JSON 2.0 interactive-card markdown components do. Use a single markdown
+    component so the source text stays intact and Feishu handles table rendering.
+    """
+    return json.dumps(
+        {
+            "schema": "2.0",
+            "config": {"wide_screen_mode": True},
+            "body": {
+                "elements": [
+                    {
+                        "tag": "markdown",
+                        "content": content,
+                        "text_align": "left",
+                        "text_size": "normal",
+                    }
+                ]
+            },
+        },
+        ensure_ascii=False,
+    )
+
+
+def _match_markdown_fence_open(line: str) -> Optional[Tuple[str, int]]:
+    match = _MARKDOWN_FENCE_OPEN_RE.match(line.strip())
+    if not match:
+        return None
+    marker = match.group(1)
+    return marker[0], len(marker)
+
+
+def _is_markdown_fence_close(line: str, fence_char: str, min_length: int) -> bool:
+    stripped = line.strip()
+    return len(stripped) >= min_length and set(stripped) == {fence_char}
+
+
+def _markdown_without_fenced_code_blocks(content: str) -> str:
+    """Return markdown with fenced code-block bodies removed.
+
+    Table syntax inside a fenced code block is literal source text and should not
+    force card rendering. Preserve non-code lines for lightweight regex checks.
+    """
+    lines: List[str] = []
+    active_fence: Optional[Tuple[str, int]] = None
+    for raw_line in content.replace("\r\n", "\n").splitlines():
+        if active_fence is not None:
+            fence_char, min_length = active_fence
+            if _is_markdown_fence_close(raw_line, fence_char, min_length):
+                active_fence = None
+            continue
+
+        fence = _match_markdown_fence_open(raw_line)
+        if fence is not None:
+            active_fence = fence
+            continue
+
+        lines.append(raw_line)
+    return "\n".join(lines)
+
+
+def _contains_markdown_table_outside_fenced_code(content: str) -> bool:
+    return bool(_MARKDOWN_TABLE_RE.search(_markdown_without_fenced_code_blocks(content)))
 
 
 def _build_markdown_post_rows(content: str) -> List[List[Dict[str, str]]]:
@@ -1781,13 +1848,18 @@ class FeishuAdapter(BasePlatformAdapter):
                         metadata=metadata,
                     )
                 except Exception as exc:
-                    if msg_type != "post" or not _POST_CONTENT_INVALID_RE.search(str(exc)):
+                    if msg_type == "post" and _POST_CONTENT_INVALID_RE.search(str(exc)):
+                        logger.warning("[Feishu] Invalid post payload rejected by API; falling back to plain text")
+                        fallback_text = _strip_markdown_to_plain_text(chunk)
+                    elif msg_type == "interactive":
+                        logger.warning("[Feishu] Interactive card rejected by API; falling back to plain text")
+                        fallback_text = chunk
+                    else:
                         raise
-                    logger.warning("[Feishu] Invalid post payload rejected by API; falling back to plain text")
                     response = await self._feishu_send_with_retry(
                         chat_id=chat_id,
                         msg_type="text",
-                        payload=json.dumps({"text": _strip_markdown_to_plain_text(chunk)}, ensure_ascii=False),
+                        payload=json.dumps({"text": fallback_text}, ensure_ascii=False),
                         reply_to=reply_to,
                         metadata=metadata,
                     )
@@ -1801,6 +1873,15 @@ class FeishuAdapter(BasePlatformAdapter):
                         chat_id=chat_id,
                         msg_type="text",
                         payload=json.dumps({"text": _strip_markdown_to_plain_text(chunk)}, ensure_ascii=False),
+                        reply_to=reply_to,
+                        metadata=metadata,
+                    )
+                if msg_type == "interactive" and not self._response_succeeded(response):
+                    logger.warning("[Feishu] Interactive card response failed; falling back to plain text")
+                    response = await self._feishu_send_with_retry(
+                        chat_id=chat_id,
+                        msg_type="text",
+                        payload=json.dumps({"text": chunk}, ensure_ascii=False),
                         reply_to=reply_to,
                         metadata=metadata,
                     )
@@ -1823,22 +1904,41 @@ class FeishuAdapter(BasePlatformAdapter):
         if not self._client:
             return SendResult(success=False, error="Not connected")
 
+        client = self._client
         content = self.format_message(content)
         try:
             msg_type, payload = self._build_outbound_payload(content)
-            body = self._build_update_message_body(msg_type=msg_type, content=payload)
-            request = self._build_update_message_request(message_id=message_id, request_body=body)
-            response = await asyncio.to_thread(self._client.im.v1.message.update, request)
-            result = self._finalize_send_result(response, "update failed")
-            if not result.success and msg_type == "post" and _POST_CONTENT_INVALID_RE.search(result.error or ""):
-                logger.warning("[Feishu] Invalid post update payload rejected by API; falling back to plain text")
+
+            async def _fallback_to_text(fallback_text: str) -> SendResult:
                 fallback_body = self._build_update_message_body(
                     msg_type="text",
-                    content=json.dumps({"text": _strip_markdown_to_plain_text(content)}, ensure_ascii=False),
+                    content=json.dumps({"text": fallback_text}, ensure_ascii=False),
                 )
                 fallback_request = self._build_update_message_request(message_id=message_id, request_body=fallback_body)
-                fallback_response = await asyncio.to_thread(self._client.im.v1.message.update, fallback_request)
-                result = self._finalize_send_result(fallback_response, "update failed")
+                fallback_response = await asyncio.to_thread(client.im.v1.message.update, fallback_request)
+                return self._finalize_send_result(fallback_response, "update failed")
+
+            body = self._build_update_message_body(msg_type=msg_type, content=payload)
+            request = self._build_update_message_request(message_id=message_id, request_body=body)
+            try:
+                response = await asyncio.to_thread(client.im.v1.message.update, request)
+            except Exception as exc:
+                if msg_type == "post" and _POST_CONTENT_INVALID_RE.search(str(exc)):
+                    logger.warning("[Feishu] Invalid post update payload rejected by API; falling back to plain text")
+                    result = await _fallback_to_text(_strip_markdown_to_plain_text(content))
+                elif msg_type == "interactive":
+                    logger.warning("[Feishu] Interactive card update rejected by API; falling back to plain text")
+                    result = await _fallback_to_text(content)
+                else:
+                    raise
+            else:
+                result = self._finalize_send_result(response, "update failed")
+                if not result.success and msg_type == "post" and _POST_CONTENT_INVALID_RE.search(result.error or ""):
+                    logger.warning("[Feishu] Invalid post update payload rejected by API; falling back to plain text")
+                    result = await _fallback_to_text(_strip_markdown_to_plain_text(content))
+                elif not result.success and msg_type == "interactive":
+                    logger.warning("[Feishu] Interactive card update response failed; falling back to plain text")
+                    result = await _fallback_to_text(content)
             if result.success:
                 result.message_id = message_id
             return result
@@ -4222,12 +4322,11 @@ class FeishuAdapter(BasePlatformAdapter):
     # =========================================================================
 
     def _build_outbound_payload(self, content: str) -> tuple[str, str]:
-        # Feishu post-type 'md' elements do not render markdown tables; sending
-        # table content as post causes the message to appear blank on the client.
-        # Force plain text for anything that looks like a markdown table.
-        if _MARKDOWN_TABLE_RE.search(content):
-            text_payload = {"text": content}
-            return "text", json.dumps(text_payload, ensure_ascii=False)
+        # Feishu post-type 'md' elements do not render markdown tables; use a
+        # JSON 2.0 interactive-card markdown element instead. Ignore table-like
+        # text inside fenced code blocks because that should remain literal.
+        if _contains_markdown_table_outside_fenced_code(content):
+            return "interactive", _build_markdown_card_v2_payload(content)
         if _MARKDOWN_HINT_RE.search(content):
             return "post", _build_markdown_post_payload(content)
         text_payload = {"text": content}

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -2633,6 +2633,44 @@ class TestAdapterBehavior(unittest.TestCase):
         self.assertEqual(payload["body"]["elements"][0]["content"], content)
 
     @patch.dict(os.environ, {}, clear=True)
+    def test_send_uses_interactive_card_for_indented_markdown_table(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        captured = {}
+
+        class _MessageAPI:
+            def create(self, request):
+                captured["request"] = request
+                return SimpleNamespace(
+                    success=lambda: True,
+                    data=SimpleNamespace(message_id="om_indented_markdown_table"),
+                )
+
+        adapter._client = SimpleNamespace(
+            im=SimpleNamespace(
+                v1=SimpleNamespace(
+                    message=_MessageAPI(),
+                )
+            )
+        )
+
+        async def _direct(func, *args, **kwargs):
+            return func(*args, **kwargs)
+
+        content = "表格：\n  | Regex | Meaning |\n  | --- | --- |\n  | `a|b` | alternation |"
+        with patch("gateway.platforms.feishu.asyncio.to_thread", side_effect=_direct):
+            result = asyncio.run(adapter.send(chat_id="oc_chat", content=content))
+
+        self.assertTrue(result.success)
+        self.assertEqual(captured["request"].request_body.msg_type, "interactive")
+        payload = json.loads(captured["request"].request_body.content)
+        element = payload["body"]["elements"][0]
+        self.assertEqual(element["tag"], "markdown")
+        self.assertEqual(element["content"], content)
+
+    @patch.dict(os.environ, {}, clear=True)
     def test_send_falls_back_to_text_when_interactive_card_table_is_rejected(self):
         from gateway.config import PlatformConfig
         from gateway.platforms.feishu import FeishuAdapter

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -415,6 +415,51 @@ class TestFeishuAdapterMessaging(unittest.TestCase):
         )
 
     @patch.dict(os.environ, {}, clear=True)
+    def test_edit_message_falls_back_to_text_when_interactive_update_is_rejected(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        captured = {"calls": []}
+
+        class _MessageAPI:
+            def update(self, request):
+                captured["calls"].append(request)
+                if request.request_body.msg_type == "interactive":
+                    return SimpleNamespace(success=lambda: False, code=230001, msg="interactive card rejected")
+                return SimpleNamespace(success=lambda: True)
+
+        adapter._client = SimpleNamespace(
+            im=SimpleNamespace(
+                v1=SimpleNamespace(
+                    message=_MessageAPI(),
+                )
+            )
+        )
+
+        async def _direct(func, *args, **kwargs):
+            return func(*args, **kwargs)
+
+        content = "| 功能 | 状态 |\n| --- | --- |\n| 表格 | ✅ |"
+        with patch("gateway.platforms.feishu.asyncio.to_thread", side_effect=_direct):
+            result = asyncio.run(
+                adapter.edit_message(
+                    chat_id="oc_chat",
+                    message_id="om_progress",
+                    content=content,
+                )
+            )
+
+        self.assertTrue(result.success)
+        self.assertEqual(result.message_id, "om_progress")
+        self.assertEqual(captured["calls"][0].request_body.msg_type, "interactive")
+        self.assertEqual(captured["calls"][1].request_body.msg_type, "text")
+        self.assertEqual(
+            captured["calls"][1].request_body.content,
+            json.dumps({"text": content}, ensure_ascii=False),
+        )
+
+    @patch.dict(os.environ, {}, clear=True)
     def test_get_chat_info_uses_real_feishu_chat_api(self):
         from gateway.config import PlatformConfig
         from gateway.platforms.feishu import FeishuAdapter
@@ -2547,6 +2592,163 @@ class TestAdapterBehavior(unittest.TestCase):
         payload = json.loads(captured["request"].request_body.content)
         elements = payload["zh_cn"]["content"][0]
         self.assertEqual(elements, [{"tag": "md", "text": "可以用 **粗体** 和 *斜体*。"}])
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_send_uses_interactive_card_for_markdown_table(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        captured = {}
+
+        class _MessageAPI:
+            def create(self, request):
+                captured["request"] = request
+                return SimpleNamespace(
+                    success=lambda: True,
+                    data=SimpleNamespace(message_id="om_markdown_table"),
+                )
+
+        adapter._client = SimpleNamespace(
+            im=SimpleNamespace(
+                v1=SimpleNamespace(
+                    message=_MessageAPI(),
+                )
+            )
+        )
+
+        async def _direct(func, *args, **kwargs):
+            return func(*args, **kwargs)
+
+        content = "# 表格\n\n| 功能 | 状态 |\n| --- | --- |\n| 加粗 | ✅ |"
+        with patch("gateway.platforms.feishu.asyncio.to_thread", side_effect=_direct):
+            result = asyncio.run(adapter.send(chat_id="oc_chat", content=content))
+
+        self.assertTrue(result.success)
+        self.assertEqual(captured["request"].request_body.msg_type, "interactive")
+        payload = json.loads(captured["request"].request_body.content)
+        self.assertEqual(payload["schema"], "2.0")
+        self.assertTrue(payload["config"]["wide_screen_mode"])
+        self.assertEqual(payload["body"]["elements"][0]["tag"], "markdown")
+        self.assertEqual(payload["body"]["elements"][0]["content"], content)
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_send_falls_back_to_text_when_interactive_card_table_is_rejected(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        captured = {"calls": []}
+
+        class _MessageAPI:
+            def create(self, request):
+                captured["calls"].append(request)
+                if request.request_body.msg_type == "interactive":
+                    raise RuntimeError("interactive card rejected")
+                return SimpleNamespace(
+                    success=lambda: True,
+                    data=SimpleNamespace(message_id="om_table_plain"),
+                )
+
+        adapter._client = SimpleNamespace(
+            im=SimpleNamespace(
+                v1=SimpleNamespace(
+                    message=_MessageAPI(),
+                )
+            )
+        )
+
+        async def _direct(func, *args, **kwargs):
+            return func(*args, **kwargs)
+
+        content = "| 功能 | 状态 |\n| --- | --- |\n| 加粗 | ✅ |"
+        with patch("gateway.platforms.feishu.asyncio.to_thread", side_effect=_direct):
+            result = asyncio.run(adapter.send(chat_id="oc_chat", content=content))
+
+        self.assertTrue(result.success)
+        self.assertEqual(captured["calls"][0].request_body.msg_type, "interactive")
+        self.assertEqual(captured["calls"][-1].request_body.msg_type, "text")
+        self.assertEqual(
+            captured["calls"][-1].request_body.content,
+            json.dumps({"text": content}, ensure_ascii=False),
+        )
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_send_keeps_table_inside_fenced_code_block_as_post_markdown(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        captured = {}
+
+        class _MessageAPI:
+            def create(self, request):
+                captured["request"] = request
+                return SimpleNamespace(
+                    success=lambda: True,
+                    data=SimpleNamespace(message_id="om_code_table"),
+                )
+
+        adapter._client = SimpleNamespace(
+            im=SimpleNamespace(
+                v1=SimpleNamespace(
+                    message=_MessageAPI(),
+                )
+            )
+        )
+
+        async def _direct(func, *args, **kwargs):
+            return func(*args, **kwargs)
+
+        content = "代码：\n```markdown\n| A | B |\n| --- | --- |\n| 1 | 2 |\n```"
+        with patch("gateway.platforms.feishu.asyncio.to_thread", side_effect=_direct):
+            result = asyncio.run(adapter.send(chat_id="oc_chat", content=content))
+
+        self.assertTrue(result.success)
+        self.assertEqual(captured["request"].request_body.msg_type, "post")
+        payload = json.loads(captured["request"].request_body.content)
+        self.assertEqual(
+            payload["zh_cn"]["content"],
+            [
+                [{"tag": "md", "text": "代码："}],
+                [{"tag": "md", "text": "```markdown\n| A | B |\n| --- | --- |\n| 1 | 2 |\n```"}],
+            ],
+        )
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_send_keeps_table_inside_tilde_fenced_code_block_out_of_card(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        captured = {}
+
+        class _MessageAPI:
+            def create(self, request):
+                captured["request"] = request
+                return SimpleNamespace(
+                    success=lambda: True,
+                    data=SimpleNamespace(message_id="om_tilde_code_table"),
+                )
+
+        adapter._client = SimpleNamespace(
+            im=SimpleNamespace(
+                v1=SimpleNamespace(
+                    message=_MessageAPI(),
+                )
+            )
+        )
+
+        async def _direct(func, *args, **kwargs):
+            return func(*args, **kwargs)
+
+        content = "# 代码\n~~~markdown\n| A | B |\n| --- | --- |\n| 1 | 2 |\n~~~"
+        with patch("gateway.platforms.feishu.asyncio.to_thread", side_effect=_direct):
+            result = asyncio.run(adapter.send(chat_id="oc_chat", content=content))
+
+        self.assertTrue(result.success)
+        self.assertNotEqual(captured["request"].request_body.msg_type, "interactive")
+        self.assertEqual(captured["request"].request_body.msg_type, "post")
 
     @patch.dict(os.environ, {}, clear=True)
     def test_send_splits_fenced_code_blocks_into_separate_post_rows(self):


### PR DESCRIPTION
## Summary
- render Feishu/Lark Markdown tables via JSON 2.0 interactive cards instead of falling back to raw text
- keep regular Markdown on the existing `post` + `md` path
- ignore table-like syntax inside fenced code blocks, including backtick and tilde fences
- fall back to plain text when interactive card sends or edits are rejected

## Test Plan
- `python -m pytest tests/gateway/test_feishu.py -q`