### PR TITLE
fix(gateway): stop stale Telegram typing refreshes

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1348,6 +1348,10 @@ class BasePlatformAdapter(ABC):
         # Chats where typing indicator is paused (e.g. during approval waits).
         # _keep_typing skips send_typing when the chat_id is in this set.
         self._typing_paused: set = set()
+        # Per-chat typing lease generation.  A surviving stale _keep_typing task
+        # must not be able to keep refreshing a platform typing bubble after the
+        # response was delivered or a newer turn took ownership of the chat.
+        self._typing_generations: Dict[str, int] = {}
 
     @property
     def message_len_fn(self) -> Callable[[str], int]:
@@ -2272,6 +2276,7 @@ class BasePlatformAdapter(ABC):
         interval: float = 2.0,
         metadata=None,
         stop_event: asyncio.Event | None = None,
+        typing_generation: int | None = None,
     ) -> None:
         """
         Continuously send typing indicator until cancelled.
@@ -2300,6 +2305,11 @@ class BasePlatformAdapter(ABC):
         try:
             while True:
                 if stop_event is not None and stop_event.is_set():
+                    return
+                if (
+                    typing_generation is not None
+                    and self._typing_generations.get(chat_id) != typing_generation
+                ):
                     return
                 if chat_id not in self._typing_paused:
                     try:
@@ -3094,23 +3104,34 @@ class BasePlatformAdapter(ABC):
         interrupt_event = self._active_sessions.get(session_key) or asyncio.Event()
         self._active_sessions[session_key] = interrupt_event
         
-        # Start continuous typing indicator (refreshes every 2 seconds)
+        # Start continuous typing indicator (refreshes every 2 seconds).  Give
+        # each loop a per-chat lease so a stale task cannot keep refreshing the
+        # typing bubble after this turn has finished or another turn took over.
         _thread_metadata = _thread_metadata_for_source(event.source, _reply_anchor_for_event(event))
-        _keep_typing_kwargs = {"metadata": _thread_metadata}
+        _typing_chat_id = event.source.chat_id
+        _typing_generation = self._typing_generations.get(_typing_chat_id, 0) + 1
+        self._typing_generations[_typing_chat_id] = _typing_generation
+        _typing_stop_event = asyncio.Event()
+        _keep_typing_kwargs: Dict[str, Any] = {"metadata": _thread_metadata}
         try:
             _keep_typing_sig = inspect.signature(self._keep_typing)
         except (TypeError, ValueError):
             _keep_typing_sig = None
         if _keep_typing_sig is None or "stop_event" in _keep_typing_sig.parameters:
-            _keep_typing_kwargs["stop_event"] = interrupt_event
+            _keep_typing_kwargs["stop_event"] = _typing_stop_event
+        if _keep_typing_sig is None or "typing_generation" in _keep_typing_sig.parameters:
+            _keep_typing_kwargs["typing_generation"] = _typing_generation
         typing_task = asyncio.create_task(
             self._keep_typing(
-                event.source.chat_id,
+                _typing_chat_id,
                 **_keep_typing_kwargs,
             )
         )
 
         async def _stop_typing_task() -> None:
+            if self._typing_generations.get(_typing_chat_id) == _typing_generation:
+                self._typing_generations[_typing_chat_id] = _typing_generation + 1
+            _typing_stop_event.set()
             typing_task.cancel()
             try:
                 await asyncio.wait_for(asyncio.shield(typing_task), timeout=0.5)

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -1866,15 +1866,17 @@ class TelegramAdapter(BasePlatformAdapter):
                         raise
                 message_ids.append(str(msg.message_id))
 
-            # Re-trigger typing indicator after sending a message.
-            # Telegram clears the typing state when a new message is delivered,
-            # so without this the "...typing" bubble disappears mid-response
-            # (especially noticeable when the agent sends intermediate progress
-            # messages like "Checking:" before running tools).
-            try:
-                await self.send_typing(chat_id, metadata=metadata)
-            except Exception:
-                pass  # Typing failures are non-fatal
+            # Re-trigger typing indicator after non-final progress messages.
+            # Telegram clears the typing state when a new message is delivered;
+            # refreshing it is useful for intermediate progress, but doing this
+            # after the final notified response can leave a confusing post-send
+            # typing bubble.  Final responses pass metadata['notify']=True from
+            # BasePlatformAdapter.
+            if not (metadata and metadata.get("notify")):
+                try:
+                    await self.send_typing(chat_id, metadata=metadata)
+                except Exception:
+                    pass  # Typing failures are non-fatal
 
             return SendResult(
                 success=True,

--- a/tests/gateway/test_keep_typing_timeout.py
+++ b/tests/gateway/test_keep_typing_timeout.py
@@ -198,3 +198,25 @@ class TestKeepTypingTimeoutPerTick:
         assert calls == [], (
             f"send_typing was called on a paused chat: {calls}"
         )
+
+    @pytest.mark.asyncio
+    async def test_stale_typing_generation_exits_before_refreshing(self, monkeypatch):
+        """A stale typing loop must not keep refreshing a chat after its
+        ownership lease has been invalidated by turn cleanup or a newer turn."""
+        adapter = _StubAdapter()
+        calls = []
+
+        async def recording_send_typing(chat_id, metadata=None):
+            calls.append(chat_id)
+
+        monkeypatch.setattr(adapter, "send_typing", recording_send_typing)
+        adapter.stop_typing = MagicMock(return_value=asyncio.sleep(0))
+        adapter._typing_generations["chat"] = 2
+
+        await adapter._keep_typing(
+            chat_id="chat",
+            interval=0.1,
+            typing_generation=1,
+        )
+
+        assert calls == []

--- a/tests/gateway/test_telegram_thread_fallback.py
+++ b/tests/gateway/test_telegram_thread_fallback.py
@@ -456,6 +456,68 @@ async def test_send_private_dm_topic_uses_direct_messages_topic_id():
     assert call_log[0]["direct_messages_topic_id"] == 99999
 
 
+@pytest.mark.asyncio
+async def test_send_final_notify_does_not_retrigger_typing():
+    """Final Telegram responses should not leave a post-send typing bubble."""
+    adapter = _make_adapter()
+    message_calls = []
+    typing_calls = []
+
+    async def mock_send_message(**kwargs):
+        message_calls.append(dict(kwargs))
+        return SimpleNamespace(message_id=42)
+
+    async def mock_send_chat_action(**kwargs):
+        typing_calls.append(dict(kwargs))
+
+    adapter._bot = SimpleNamespace(
+        send_message=mock_send_message,
+        send_chat_action=mock_send_chat_action,
+    )
+
+    result = await adapter.send(
+        chat_id="123",
+        content="final response",
+        metadata={"notify": True},
+    )
+
+    assert result.success is True
+    assert len(message_calls) == 1
+    assert typing_calls == []
+
+
+@pytest.mark.asyncio
+async def test_send_non_final_progress_retriggers_typing():
+    """Intermediate Telegram progress messages should keep the typing bubble alive."""
+    adapter = _make_adapter()
+    message_calls = []
+    typing_calls = []
+
+    async def mock_send_message(**kwargs):
+        message_calls.append(dict(kwargs))
+        return SimpleNamespace(message_id=42)
+
+    async def mock_send_chat_action(**kwargs):
+        typing_calls.append(dict(kwargs))
+
+    adapter._bot = SimpleNamespace(
+        send_message=mock_send_message,
+        send_chat_action=mock_send_chat_action,
+    )
+
+    result = await adapter.send(
+        chat_id="123",
+        content="progress update",
+        metadata={"notify": False},
+    )
+
+    assert result.success is True
+    assert len(message_calls) == 1
+    assert typing_calls == [
+        {"chat_id": 123, "action": "typing", "message_thread_id": None},
+    ]
+
+
 def test_base_gateway_metadata_marks_telegram_dm_topics_as_reply_fallback():
     source = SimpleNamespace(
         platform=Platform.TELEGRAM,


### PR DESCRIPTION
## Summary
- add per-chat typing generation leases so stale `_keep_typing` loops exit before refreshing platform typing indicators
- use a dedicated typing stop event instead of sharing the session interrupt event
- avoid re-triggering Telegram typing after final notified responses while preserving progress-message typing refreshes

## Test Plan
- `./venv/bin/python -m pytest tests/gateway/test_keep_typing_timeout.py tests/gateway/test_telegram_thread_fallback.py tests/gateway/test_telegram_network.py tests/gateway/test_telegram_noise_filter.py -q`

## Notes
This addresses cases where Telegram can keep showing typing after the final response because a stale keep-typing task survived cleanup or because `send()` refreshed typing after the final notified response.