### PR TITLE
fix: quiet plugin context compaction status

### DIFF
--- a/agent/context_engine.py
+++ b/agent/context_engine.py
@@ -29,6 +29,25 @@ from abc import ABC, abstractmethod
 from typing import Any, Dict, List
 
 
+def should_emit_automatic_compaction_status(engine: Any) -> bool:
+    """Return whether automatic compaction should be user-visible.
+
+    The built-in compressor historically emits lifecycle/status text when it
+    runs automatically. Third-party context engines, such as LCM, often treat
+    compaction as routine background maintenance; surfacing the host's generic
+    "compression" wording on every over-threshold turn is noisy and can imply
+    the lossy built-in compressor is active. Plugin engines can opt back into
+    the automatic status with ``emit_automatic_compaction_status = True``.
+    """
+
+    explicit = getattr(engine, "emit_automatic_compaction_status", None)
+    if explicit is not None:
+        return bool(explicit)
+
+    name = getattr(engine, "name", "compressor")
+    return not isinstance(name, str) or name in {"", "compressor"}
+
+
 class ContextEngine(ABC):
     """Base class all context engines must implement."""
 

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -36,6 +36,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, List, Optional, Tuple
 
+from agent.context_engine import should_emit_automatic_compaction_status
 from agent.model_metadata import estimate_request_tokens_rough
 
 logger = logging.getLogger(__name__)
@@ -301,9 +302,10 @@ def compress_context(
         f"{approx_tokens:,}" if approx_tokens else "unknown", agent.model,
         focus_topic,
     )
-    agent._emit_status(
-        "🗜️ Compacting context — summarizing earlier conversation so I can continue..."
-    )
+    if force or should_emit_automatic_compaction_status(agent.context_compressor):
+        agent._emit_status(
+            "🗜️ Compacting context — summarizing earlier conversation so I can continue..."
+        )
 
     # Notify external memory provider before compression discards context
     if agent._memory_manager:

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -53,6 +53,7 @@ from agent.model_metadata import (
     parse_context_limit_from_error,
     save_context_length,
 )
+from agent.context_engine import should_emit_automatic_compaction_status
 from agent.nous_rate_guard import (
     clear_nous_rate_limit,
     is_genuine_nous_rate_limit,
@@ -447,11 +448,12 @@ def run_conversation(
                 agent.model,
                 f"{agent.context_compressor.context_length:,}",
             )
-            agent._emit_status(
-                f"📦 Preflight compression: ~{_preflight_tokens:,} tokens "
-                f">= {agent.context_compressor.threshold_tokens:,} threshold. "
-                "This may take a moment."
-            )
+            if should_emit_automatic_compaction_status(agent.context_compressor):
+                agent._emit_status(
+                    f"📦 Preflight compression: ~{_preflight_tokens:,} tokens "
+                    f">= {agent.context_compressor.threshold_tokens:,} threshold. "
+                    "This may take a moment."
+                )
             # May need multiple passes for very large sessions with small
             # context windows (each pass summarises the middle N turns).
             for _pass in range(3):
@@ -3396,7 +3398,8 @@ def run_conversation(
                     )
 
                 if agent.compression_enabled and _compressor.should_compress(_real_tokens):
-                    agent._safe_print("  ⟳ compacting context…")
+                    if should_emit_automatic_compaction_status(_compressor):
+                        agent._safe_print("  ⟳ compacting context…")
                     messages, active_system_prompt = agent._compress_context(
                         messages, system_message,
                         approx_tokens=agent.context_compressor.last_prompt_tokens,

--- a/tests/agent/test_context_engine.py
+++ b/tests/agent/test_context_engine.py
@@ -4,7 +4,7 @@ import json
 import pytest
 from typing import Any, Dict, List
 
-from agent.context_engine import ContextEngine
+from agent.context_engine import ContextEngine, should_emit_automatic_compaction_status
 from agent.context_compressor import ContextCompressor
 
 
@@ -123,6 +123,19 @@ class TestDefaults:
     def test_should_compress_preflight_default_false(self):
         engine = StubEngine()
         assert engine.should_compress_preflight([]) is False
+
+    def test_builtin_compressor_emits_automatic_compaction_status_by_default(self):
+        engine = ContextCompressor(model="test", quiet_mode=True, config_context_length=200000)
+        assert should_emit_automatic_compaction_status(engine) is True
+
+    def test_plugin_engines_suppress_automatic_compaction_status_by_default(self):
+        engine = StubEngine()
+        assert should_emit_automatic_compaction_status(engine) is False
+
+    def test_plugin_engines_can_opt_into_automatic_compaction_status(self):
+        engine = StubEngine()
+        engine.emit_automatic_compaction_status = True
+        assert should_emit_automatic_compaction_status(engine) is True
 
 
 # ---------------------------------------------------------------------------

--- a/tests/run_agent/test_413_compression.py
+++ b/tests/run_agent/test_413_compression.py
@@ -493,6 +493,64 @@ class TestPreflightCompression:
             for ev, msg in status_messages
         )
 
+    def test_preflight_plugin_context_engine_compacts_without_user_visible_status(self, agent):
+        """Plugin context engines can handle normal automatic maintenance silently."""
+
+        class _PluginContextEngine:
+            name = "lcm"
+            protect_first_n = 0
+            protect_last_n = 0
+            context_length = 2_000
+            threshold_tokens = 200
+            compression_count = 0
+            last_prompt_tokens = 0
+            last_completion_tokens = 0
+            _last_compress_aborted = False
+            _last_summary_error = None
+            _last_aux_model_failure_model = None
+            _last_aux_model_failure_error = None
+
+            def __init__(self):
+                self.calls = []
+
+            def compress(self, messages, current_tokens=None, focus_topic=None, force=False):
+                self.calls.append((messages, current_tokens, focus_topic, force))
+                self.compression_count += 1
+                return [
+                    {"role": "user", "content": f"{SUMMARY_PREFIX}\nPrevious conversation"},
+                    {"role": "user", "content": "hello"},
+                ]
+
+        agent.compression_enabled = True
+        engine = _PluginContextEngine()
+        agent.context_compressor = engine
+        big_history = []
+        for i in range(20):
+            big_history.append({"role": "user", "content": f"Message number {i} with some extra text padding"})
+            big_history.append({"role": "assistant", "content": f"Response number {i} with extra padding here"})
+
+        ok_resp = _mock_response(content="After preflight", finish_reason="stop")
+        agent.client.chat.completions.create.side_effect = [ok_resp]
+        status_messages = []
+        agent.status_callback = lambda ev, msg: status_messages.append((ev, msg))
+
+        with (
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("hello", conversation_history=big_history)
+
+        assert engine.calls, "plugin context engine did not compact"
+        assert result["completed"] is True
+        assert result["final_response"] == "After preflight"
+        assert not [
+            msg for ev, msg in status_messages
+            if ev == "lifecycle" and (
+                "Preflight compression" in msg or "Compacting context" in msg
+            )
+        ]
+
     def test_no_preflight_when_under_threshold(self, agent):
         """When history fits within context, no preflight compression needed."""
         agent.compression_enabled = True
@@ -584,6 +642,63 @@ class TestToolResultPreflightCompression:
 
         mock_compress.assert_called_once()
         assert result["completed"] is True
+
+    def test_post_tool_plugin_context_engine_compacts_without_safe_print(self, agent):
+        """Automatic post-tool plugin compaction should not print status text."""
+
+        class _PluginContextEngine:
+            name = "lcm"
+            protect_first_n = 0
+            protect_last_n = 0
+            context_length = 200_000
+            threshold_tokens = 130_000
+            last_prompt_tokens = 0
+            last_completion_tokens = 0
+            compression_count = 0
+
+            def update_from_response(self, usage):
+                self.last_prompt_tokens = usage.get("prompt_tokens", 0)
+                self.last_completion_tokens = usage.get("completion_tokens", 0)
+
+            def should_compress(self, prompt_tokens=None):
+                tokens = prompt_tokens if prompt_tokens is not None else self.last_prompt_tokens
+                return tokens >= self.threshold_tokens
+
+        agent.compression_enabled = True
+        agent.context_compressor = _PluginContextEngine()
+        tc = SimpleNamespace(
+            id="tc1", type="function",
+            function=SimpleNamespace(name="web_search", arguments='{"query":"test"}'),
+        )
+        tool_resp = _mock_response(
+            content=None, finish_reason="stop", tool_calls=[tc],
+            usage={"prompt_tokens": 130_000, "completion_tokens": 5_000, "total_tokens": 135_000},
+        )
+        ok_resp = _mock_response(
+            content="Done after compression", finish_reason="stop",
+            usage={"prompt_tokens": 50_000, "completion_tokens": 100, "total_tokens": 50_100},
+        )
+        agent.client.chat.completions.create.side_effect = [tool_resp, ok_resp]
+
+        with (
+            patch("run_agent.handle_function_call", return_value="x" * 100_000),
+            patch.object(agent, "_compress_context") as mock_compress,
+            patch.object(agent, "_safe_print") as mock_safe_print,
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            mock_compress.return_value = (
+                [{"role": "user", "content": "hello"}], "compressed prompt",
+            )
+            result = agent.run_conversation("hello")
+
+        mock_compress.assert_called_once()
+        assert result["completed"] is True
+        assert not [
+            call.args[0] for call in mock_safe_print.call_args_list
+            if call.args and "compacting context" in str(call.args[0])
+        ]
 
     def test_anthropic_prompt_too_long_safety_net(self, agent):
         """Anthropic 'prompt is too long' error triggers compression as safety net."""


### PR DESCRIPTION
## Summary

- suppress automatic preflight/context compaction status text for plugin context engines such as LCM
- keep the existing user-visible status for the built-in compressor
- keep manual `/compress` status visible through the existing `force=True` path
- add regression coverage for preflight compaction, post-tool automatic compaction, and plugin opt-in behavior

Addresses stephenschoettler/hermes-lcm#168.

## Tests

- `python -m pytest tests/run_agent/test_413_compression.py::TestPreflightCompression::test_preflight_plugin_context_engine_compacts_without_user_visible_status -q --tb=short`
- `python -m pytest tests/run_agent/test_413_compression.py::TestToolResultPreflightCompression::test_post_tool_plugin_context_engine_compacts_without_safe_print -q --tb=short`
- `python -m pytest tests/run_agent/test_413_compression.py tests/agent/test_context_engine.py -q --tb=short`
- `python -m compileall -q agent/context_engine.py agent/conversation_loop.py agent/conversation_compression.py tests/run_agent/test_413_compression.py tests/agent/test_context_engine.py`
- `git diff --check`
- `./scripts/run_tests.sh tests/run_agent/test_413_compression.py tests/agent/test_context_engine.py`

## Notes

This keeps generic host logging intact. Only successful automatic user-facing maintenance noise is suppressed by default for non-built-in context engines. Plugin engines can opt back in with `emit_automatic_compaction_status = True`.