### PR TITLE
feat(xsearch): add cross-surface slash command family

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -4226,6 +4226,12 @@ class HermesCLI:
     def _slow_command_status(self, command: str) -> str:
         """Return a user-facing status message for slower slash commands."""
         cmd_lower = command.lower().strip()
+        if cmd_lower == "/xsearch status":
+            return "Checking X Search..."
+        if cmd_lower == "/xsearch setup":
+            return "Configuring X Search..."
+        if cmd_lower.startswith("/xsearch"):
+            return "Searching X..."
         if cmd_lower.startswith("/skills search"):
             return "Searching skills..."
         if cmd_lower.startswith("/skills browse"):
@@ -5784,6 +5790,20 @@ class HermesCLI:
         self.enabled_toolsets = _get_platform_tools(load_config(), "cli")
         self.new_session()
         _cprint(f"{_DIM}Session reset. New tool configuration is active.{_RST}")
+
+    def _handle_xsearch_command(self, cmd: str):
+        """Handle `/xsearch` in the CLI and slash worker."""
+        from hermes_cli.config import load_config
+        from hermes_cli.tools_config import _get_platform_tools
+        from hermes_cli.xsearch_command import run_xsearch_command
+
+        result = run_xsearch_command(cmd, platform="cli")
+        print(result.output)
+
+        if result.reset_session:
+            self.enabled_toolsets = _get_platform_tools(load_config(), "cli")
+            self.new_session()
+            _cprint(f"{_DIM}Session reset. New X Search tool configuration is active.{_RST}")
 
     def show_toolsets(self):
         """Display available toolsets with kawaii ASCII art."""
@@ -7842,6 +7862,9 @@ class HermesCLI:
             self._handle_profile_command()
         elif canonical == "tools":
             self._handle_tools_command(cmd_original)
+        elif canonical == "xsearch":
+            with self._busy_command(self._slow_command_status(cmd_original)):
+                self._handle_xsearch_command(cmd_original)
         elif canonical == "toolsets":
             self.show_toolsets()
         elif canonical == "config":

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7181,6 +7181,9 @@ class GatewayRunner:
         if canonical == "profile":
             return await self._handle_profile_command(event)
 
+        if canonical == "xsearch":
+            return await self._handle_xsearch_command(event)
+
         if canonical == "whoami":
             return await self._handle_whoami_command(event)
 
@@ -9147,6 +9150,16 @@ class GatewayRunner:
         ]
 
         return "\n".join(lines)
+
+    async def _handle_xsearch_command(self, event: MessageEvent) -> str:
+        """Handle `/xsearch` for messaging platforms."""
+        from hermes_cli.xsearch_command import run_xsearch_command
+
+        platform_key = _platform_config_key(event.source.platform)
+        raw_args = event.get_command_args().strip()
+        command = f"/xsearch {raw_args}".strip()
+        result = run_xsearch_command(command, platform=platform_key)
+        return result.output
 
 
     def _check_slash_access(

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9159,6 +9159,17 @@ class GatewayRunner:
         raw_args = event.get_command_args().strip()
         command = f"/xsearch {raw_args}".strip()
         result = run_xsearch_command(command, platform=platform_key)
+        if result.reset_session:
+            reset_reply = await self._handle_reset_command(
+                MessageEvent(text="/new", source=event.source)
+            )
+            combined = f"{result.output}\n\n{str(reset_reply)}"
+            if isinstance(reset_reply, EphemeralReply):
+                return EphemeralReply(
+                    combined,
+                    ttl_seconds=getattr(reset_reply, "ttl_seconds", None),
+                )
+            return combined
         return result.output
 
 

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -190,6 +190,14 @@ COMMAND_REGISTRY: list[CommandDef] = [
     CommandDef("browser", "Connect browser tools to your live Chromium-family browser via CDP", "Tools & Skills",
                cli_only=True, args_hint="[connect|disconnect|status]",
                subcommands=("connect", "disconnect", "status")),
+    CommandDef(
+        "xsearch",
+        "Run or manage X (Twitter) Search",
+        "Tools & Skills",
+        aliases=("x-search",),
+        args_hint="[status|setup|enable|disable|model [name]|<query>]",
+        subcommands=("status", "setup", "enable", "disable", "model"),
+    ),
     CommandDef("plugins", "List installed plugins and their status",
                "Tools & Skills", cli_only=True),
 

--- a/hermes_cli/xsearch_command.py
+++ b/hermes_cli/xsearch_command.py
@@ -1,0 +1,409 @@
+"""Shared `/xsearch` command logic for CLI, gateway, and dashboard chat."""
+
+from __future__ import annotations
+
+import json
+import shlex
+from dataclasses import dataclass
+from typing import Any
+
+from hermes_cli.config import get_env_value, load_config, save_config
+from hermes_constants import display_hermes_home
+
+_CONTROL_SUBCOMMANDS = {"status", "setup", "enable", "disable", "model"}
+DEFAULT_X_SEARCH_MODEL = "grok-4.20-reasoning"
+DEFAULT_X_SEARCH_TIMEOUT_SECONDS = 180
+DEFAULT_X_SEARCH_RETRIES = 2
+
+
+@dataclass(frozen=True)
+class XSearchCommandResult:
+    output: str
+    reset_session: bool = False
+
+
+def _x_search_config(cfg: dict[str, Any]) -> dict[str, Any]:
+    block = cfg.get("x_search")
+    return block if isinstance(block, dict) else {}
+
+
+def _effective_enabled(cfg: dict[str, Any], platform: str) -> bool:
+    return "x_search" in _get_platform_toolsets(cfg, platform)
+
+
+def _oauth_status() -> dict[str, Any]:
+    try:
+        from hermes_cli.auth import get_xai_oauth_auth_status
+    except Exception:
+        return {}
+    status = get_xai_oauth_auth_status() or {}
+    return status if isinstance(status, dict) else {}
+
+
+def _check_x_search_requirements() -> bool:
+    try:
+        from tools.x_search_tool import check_x_search_requirements
+    except Exception:
+        return False
+    return bool(check_x_search_requirements())
+
+
+def _run_x_search_tool(**kwargs: Any) -> str:
+    from tools.x_search_tool import x_search_tool
+
+    return x_search_tool(**kwargs)
+
+
+def _get_platform_toolsets(cfg: dict[str, Any], platform: str) -> set[str]:
+    from hermes_cli.tools_config import _get_platform_tools
+
+    return set(_get_platform_tools(cfg, platform))
+
+
+def _apply_toolset_toggle(
+    cfg: dict[str, Any],
+    platform: str,
+    toolset_names: list[str],
+    action: str,
+) -> None:
+    from hermes_cli.tools_config import _apply_toolset_change
+
+    _apply_toolset_change(cfg, platform, toolset_names, action)
+
+
+def _api_key_present() -> bool:
+    return bool(str(get_env_value("XAI_API_KEY") or "").strip())
+
+
+def _preferred_credential_source(
+    oauth_status: dict[str, Any],
+    *,
+    api_key_present: bool,
+) -> str:
+    if bool(oauth_status.get("logged_in")):
+        return "xai-oauth"
+    if api_key_present:
+        return "xai"
+    return "unavailable"
+
+
+def _bool_word(value: bool) -> str:
+    return "yes" if value else "no"
+
+
+def _coerce_int(value: Any, default: int, *, minimum: int = 0) -> int:
+    try:
+        return max(minimum, int(value))
+    except Exception:
+        return default
+
+
+def _usage_text() -> str:
+    return "\n".join(
+        [
+            "Usage:",
+            "  /xsearch <query> [--from handles] [--exclude handles] [--since YYYY-MM-DD] [--until YYYY-MM-DD] [--images] [--videos]",
+            "  /xsearch status",
+            "  /xsearch setup",
+            "  /xsearch enable",
+            "  /xsearch disable",
+            "  /xsearch model [name]",
+        ]
+    )
+
+
+def _status_text(platform: str) -> str:
+    cfg = load_config()
+    x_cfg = _x_search_config(cfg)
+    enabled = _effective_enabled(cfg, platform)
+    oauth_status = _oauth_status()
+    api_key_present = _api_key_present()
+    preferred = _preferred_credential_source(
+        oauth_status,
+        api_key_present=api_key_present,
+    )
+    ready = enabled and preferred != "unavailable" and _check_x_search_requirements()
+    lines = [
+        f"X Search status ({platform})",
+        f"- Ready: {_bool_word(ready)}",
+        f"- Toolset enabled: {_bool_word(enabled)}",
+        f"- Model: {str(x_cfg.get('model') or DEFAULT_X_SEARCH_MODEL).strip() or DEFAULT_X_SEARCH_MODEL}",
+        f"- Timeout: {_coerce_int(x_cfg.get('timeout_seconds', DEFAULT_X_SEARCH_TIMEOUT_SECONDS), DEFAULT_X_SEARCH_TIMEOUT_SECONDS, minimum=30)}s",
+        f"- Retries: {_coerce_int(x_cfg.get('retries', DEFAULT_X_SEARCH_RETRIES), DEFAULT_X_SEARCH_RETRIES)}",
+        f"- xAI OAuth logged in: {_bool_word(bool(oauth_status.get('logged_in')))}",
+        f"- XAI_API_KEY configured: {_bool_word(api_key_present)}",
+        f"- Preferred credential source: {preferred}",
+        f"- Config path: {display_hermes_home()}/config.yaml",
+    ]
+    if not ready:
+        lines.append("- Next step: run `/xsearch setup`")
+    return "\n".join(lines)
+
+
+def _ensure_default_model(cfg: dict[str, Any]) -> bool:
+    cfg.setdefault("x_search", {})
+    block = _x_search_config(cfg)
+    current = str(block.get("model") or "").strip()
+    if current:
+        return False
+    block["model"] = DEFAULT_X_SEARCH_MODEL
+    cfg["x_search"] = block
+    return True
+
+
+def _setup(platform: str) -> XSearchCommandResult:
+    cfg = load_config()
+    changed: list[str] = []
+    reset_session = False
+
+    if not _effective_enabled(cfg, platform):
+        _apply_toolset_toggle(cfg, platform, ["x_search"], "enable")
+        changed.append(f"enabled x_search for {platform}")
+        reset_session = True
+
+    if _ensure_default_model(cfg):
+        changed.append(f"set x_search.model to {DEFAULT_X_SEARCH_MODEL}")
+
+    if changed:
+        save_config(cfg)
+
+    oauth_status = _oauth_status()
+    api_key_present = _api_key_present()
+    preferred = _preferred_credential_source(
+        oauth_status,
+        api_key_present=api_key_present,
+    )
+    lines = ["X Search setup"]
+    if changed:
+        lines.extend(f"- {item}" for item in changed)
+    else:
+        lines.append("- no config changes were needed")
+
+    if preferred == "unavailable":
+        lines.extend(
+            [
+                "- Remaining auth step: sign in with `hermes auth add xai-oauth`",
+                "- Alternative auth step: set `XAI_API_KEY` in ~/.hermes/.env",
+                "- Then run `/xsearch status` or `/xsearch \"latest xai posts\"`",
+            ]
+        )
+    else:
+        lines.extend(
+            [
+                f"- Credential source ready: {preferred}",
+                "- Next: run `/xsearch status` to verify or `/xsearch \"latest xai posts\"` to search now",
+            ]
+        )
+
+    return XSearchCommandResult("\n".join(lines), reset_session=reset_session)
+
+
+def _toggle_toolset(platform: str, action: str) -> XSearchCommandResult:
+    cfg = load_config()
+    enabled = _effective_enabled(cfg, platform)
+    if action == "enable" and enabled:
+        return XSearchCommandResult(f"x_search is already enabled for {platform}")
+    if action == "disable" and not enabled:
+        return XSearchCommandResult(f"x_search is already disabled for {platform}")
+
+    _apply_toolset_toggle(cfg, platform, ["x_search"], action)
+    save_config(cfg)
+    verb = "Enabled" if action == "enable" else "Disabled"
+    return XSearchCommandResult(
+        f"{verb} x_search for {platform}.",
+        reset_session=True,
+    )
+
+
+def _set_or_show_model(rest: str) -> XSearchCommandResult:
+    value = rest.strip()
+    cfg = load_config()
+    block = _x_search_config(cfg)
+    current = str(block.get("model") or DEFAULT_X_SEARCH_MODEL).strip() or DEFAULT_X_SEARCH_MODEL
+    if not value:
+        return XSearchCommandResult(f"x_search.model: {current}")
+    block["model"] = value
+    cfg["x_search"] = block
+    save_config(cfg)
+    return XSearchCommandResult(f"x_search.model -> {value}")
+
+
+def _split_handles(value: str) -> list[str]:
+    return [part.strip() for part in value.split(",") if part.strip()]
+
+
+def _parse_search(rest: str) -> tuple[dict[str, Any] | None, str | None]:
+    try:
+        tokens = shlex.split(rest)
+    except ValueError as exc:
+        return None, f"xsearch parse error: {exc}"
+
+    if not tokens:
+        return None, _usage_text()
+
+    args: dict[str, Any] = {
+        "query": "",
+        "allowed_x_handles": [],
+        "excluded_x_handles": [],
+        "from_date": "",
+        "to_date": "",
+        "enable_image_understanding": False,
+        "enable_video_understanding": False,
+    }
+    query_tokens: list[str] = []
+    idx = 0
+    seen_flag = False
+    while idx < len(tokens):
+        token = tokens[idx]
+        if token == "--from":
+            seen_flag = True
+            idx += 1
+            if idx >= len(tokens):
+                return None, "xsearch: --from requires a comma-separated handle list"
+            args["allowed_x_handles"] = _split_handles(tokens[idx])
+        elif token == "--exclude":
+            seen_flag = True
+            idx += 1
+            if idx >= len(tokens):
+                return None, "xsearch: --exclude requires a comma-separated handle list"
+            args["excluded_x_handles"] = _split_handles(tokens[idx])
+        elif token == "--since":
+            seen_flag = True
+            idx += 1
+            if idx >= len(tokens):
+                return None, "xsearch: --since requires YYYY-MM-DD"
+            args["from_date"] = tokens[idx]
+        elif token == "--until":
+            seen_flag = True
+            idx += 1
+            if idx >= len(tokens):
+                return None, "xsearch: --until requires YYYY-MM-DD"
+            args["to_date"] = tokens[idx]
+        elif token == "--images":
+            seen_flag = True
+            args["enable_image_understanding"] = True
+        elif token == "--videos":
+            seen_flag = True
+            args["enable_video_understanding"] = True
+        elif token.startswith("--"):
+            return None, f"xsearch: unknown flag {token}"
+        else:
+            if seen_flag:
+                return None, "xsearch: put the query before flags"
+            query_tokens.append(token)
+        idx += 1
+
+    query = " ".join(query_tokens).strip()
+    if not query:
+        return None, "xsearch: query is required"
+    args["query"] = query
+    return args, None
+
+
+def _citation_rows(payload: dict[str, Any]) -> list[str]:
+    rows: list[str] = []
+    seen: set[str] = set()
+    combined = list(payload.get("citations") or []) + list(payload.get("inline_citations") or [])
+    for item in combined:
+        if not isinstance(item, dict):
+            continue
+        url = str(item.get("url") or "").strip()
+        if not url or url in seen:
+            continue
+        seen.add(url)
+        title = str(item.get("title") or "").strip()
+        rows.append(f"- {title + ' — ' if title else ''}{url}")
+        if len(rows) >= 5:
+            break
+    return rows
+
+
+def _format_search_result(raw: str) -> str:
+    try:
+        payload = json.loads(raw)
+    except Exception:
+        return raw
+
+    if not isinstance(payload, dict):
+        return raw
+
+    if not payload.get("success"):
+        error = str(payload.get("error") or "unknown x_search failure").strip()
+        lines = ["X Search error", error]
+        if "x_search is not enabled for this model" in error:
+            lines.append("Hint: try `/xsearch model grok-4.20-reasoning`.")
+        elif "No xAI credentials available" in error:
+            lines.append("Hint: run `/xsearch setup`.")
+        return "\n".join(lines)
+
+    answer = str(payload.get("answer") or "").strip() or "(no answer)"
+    model = str(payload.get("model") or DEFAULT_X_SEARCH_MODEL).strip() or DEFAULT_X_SEARCH_MODEL
+    source = str(payload.get("credential_source") or "unknown").strip() or "unknown"
+    lines = [
+        f"X Search via {model} ({source})",
+        "",
+        answer,
+    ]
+    citations = _citation_rows(payload)
+    if citations:
+        lines.extend(["", "Sources:", *citations])
+    if bool(payload.get("degraded")):
+        reason = str(payload.get("degraded_reason") or "no citations returned").strip()
+        lines.extend(["", f"Warning: degraded result — {reason}"])
+    return "\n".join(lines)
+
+
+def _run_search(rest: str, platform: str) -> XSearchCommandResult:
+    cfg = load_config()
+    if not _effective_enabled(cfg, platform):
+        return XSearchCommandResult(
+            f"x_search is disabled for {platform}. Run `/xsearch enable` or `/xsearch setup` first."
+        )
+    parsed, error = _parse_search(rest)
+    if error:
+        return XSearchCommandResult(error)
+    assert parsed is not None
+    return XSearchCommandResult(_format_search_result(_run_x_search_tool(**parsed)))
+
+
+def run_xsearch_command(command: str, *, platform: str = "cli") -> XSearchCommandResult:
+    text = command.strip()
+    if not text:
+        return XSearchCommandResult(_usage_text())
+
+    if text.startswith("/"):
+        text = text[1:]
+    if text.lower().startswith("xsearch"):
+        text = text[7:].strip()
+    elif text.lower().startswith("x-search"):
+        text = text[8:].strip()
+
+    if not text:
+        return XSearchCommandResult(_usage_text())
+
+    try:
+        tokens = shlex.split(text)
+    except ValueError as exc:
+        return XSearchCommandResult(f"xsearch parse error: {exc}")
+
+    if not tokens:
+        return XSearchCommandResult(_usage_text())
+
+    head = tokens[0].lower()
+    if head in {"status", "setup", "enable", "disable"} and len(tokens) == 1:
+        if head == "status":
+            return XSearchCommandResult(_status_text(platform))
+        if head == "setup":
+            return _setup(platform)
+        return _toggle_toolset(platform, head)
+
+    if head == "model":
+        remainder = text.split(None, 1)[1].strip() if len(tokens) > 1 else ""
+        return _set_or_show_model(remainder)
+
+    if head in _CONTROL_SUBCOMMANDS and len(tokens) > 1:
+        # Allow natural language searches that happen to start with words
+        # like "status" or "setup" as long as additional words are present.
+        return _run_search(text, platform)
+
+    return _run_search(text, platform)

--- a/tests/cli/test_cli_xsearch_command.py
+++ b/tests/cli/test_cli_xsearch_command.py
@@ -1,0 +1,25 @@
+from contextlib import nullcontext
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+pytest.importorskip("prompt_toolkit")
+
+from cli import HermesCLI
+
+
+def _make_cli():
+    cli_obj = HermesCLI.__new__(HermesCLI)
+    cli_obj.config = {}
+    cli_obj.console = MagicMock()
+    cli_obj._busy_command = lambda _status: nullcontext()
+    return cli_obj
+
+
+def test_process_command_dispatches_xsearch_through_handler():
+    cli_obj = _make_cli()
+
+    with patch.object(cli_obj, "_handle_xsearch_command") as mock_handler:
+        assert cli_obj.process_command("/xsearch status") is True
+
+    mock_handler.assert_called_once_with("/xsearch status")

--- a/tests/gateway/test_xsearch_command.py
+++ b/tests/gateway/test_xsearch_command.py
@@ -1,0 +1,41 @@
+from types import SimpleNamespace
+
+import pytest
+
+pytest.importorskip("httpx")
+
+import gateway.run as gateway_run
+from gateway.config import Platform
+from gateway.platforms.base import MessageEvent
+from gateway.session import SessionSource
+
+
+def _make_event(text="/xsearch status", platform=Platform.DISCORD):
+    source = SessionSource(
+        platform=platform,
+        user_id="user-1",
+        chat_id="chat-1",
+        user_name="tester",
+    )
+    return MessageEvent(text=text, source=source)
+
+
+def _make_runner():
+    return object.__new__(gateway_run.GatewayRunner)
+
+
+@pytest.mark.asyncio
+async def test_handle_xsearch_command_uses_platform_key(monkeypatch):
+    captured = {}
+
+    def _fake_run(command, *, platform="cli"):
+        captured["command"] = command
+        captured["platform"] = platform
+        return SimpleNamespace(output="ok", reset_session=False)
+
+    monkeypatch.setattr("hermes_cli.xsearch_command.run_xsearch_command", _fake_run)
+
+    result = await _make_runner()._handle_xsearch_command(_make_event())
+
+    assert result == "ok"
+    assert captured == {"command": "/xsearch status", "platform": "discord"}

--- a/tests/gateway/test_xsearch_command.py
+++ b/tests/gateway/test_xsearch_command.py
@@ -6,7 +6,7 @@ pytest.importorskip("httpx")
 
 import gateway.run as gateway_run
 from gateway.config import Platform
-from gateway.platforms.base import MessageEvent
+from gateway.platforms.base import EphemeralReply, MessageEvent
 from gateway.session import SessionSource
 
 
@@ -39,3 +39,26 @@ async def test_handle_xsearch_command_uses_platform_key(monkeypatch):
 
     assert result == "ok"
     assert captured == {"command": "/xsearch status", "platform": "discord"}
+
+
+@pytest.mark.asyncio
+async def test_handle_xsearch_command_resets_session_when_requested(monkeypatch):
+    def _fake_run(command, *, platform="cli"):
+        assert command == "/xsearch enable"
+        assert platform == "discord"
+        return SimpleNamespace(output="enabled", reset_session=True)
+
+    async def _fake_reset(_event):
+        return EphemeralReply("fresh session", ttl_seconds=45)
+
+    runner = _make_runner()
+    runner._handle_reset_command = _fake_reset
+
+    monkeypatch.setattr("hermes_cli.xsearch_command.run_xsearch_command", _fake_run)
+
+    result = await runner._handle_xsearch_command(_make_event("/xsearch enable"))
+
+    assert isinstance(result, EphemeralReply)
+    assert "enabled" in result
+    assert "fresh session" in result
+    assert result.ttl_seconds == 45

--- a/tests/hermes_cli/test_xsearch_command.py
+++ b/tests/hermes_cli/test_xsearch_command.py
@@ -1,0 +1,110 @@
+import json
+
+import hermes_cli.xsearch_command as xsearch_cmd
+
+
+def test_status_reports_ready_when_toolset_and_oauth_are_available(monkeypatch):
+    cfg = {
+        "platform_toolsets": {"cli": ["x_search"]},
+        "x_search": {
+            "model": "grok-4.20-reasoning",
+            "timeout_seconds": "90",
+            "retries": "1",
+        },
+    }
+
+    monkeypatch.setattr(xsearch_cmd, "load_config", lambda: cfg)
+    monkeypatch.setattr(xsearch_cmd, "_get_platform_toolsets", lambda *_args, **_kwargs: {"x_search"})
+    monkeypatch.setattr(xsearch_cmd, "_oauth_status", lambda: {"logged_in": True})
+    monkeypatch.setattr(xsearch_cmd, "get_env_value", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(xsearch_cmd, "_check_x_search_requirements", lambda: True)
+
+    result = xsearch_cmd.run_xsearch_command("/xsearch status")
+
+    assert "Ready: yes" in result.output
+    assert "Toolset enabled: yes" in result.output
+    assert "Preferred credential source: xai-oauth" in result.output
+
+
+def test_setup_enables_toolset_sets_default_model_and_requests_auth(monkeypatch):
+    cfg = {
+        "platform_toolsets": {"cli": []},
+        "x_search": {},
+    }
+    saved = {"called": False}
+
+    monkeypatch.setattr(xsearch_cmd, "load_config", lambda: cfg)
+    monkeypatch.setattr(
+        xsearch_cmd,
+        "_get_platform_toolsets",
+        lambda config, platform: set(config.get("platform_toolsets", {}).get(platform, [])),
+    )
+
+    def _fake_apply(config, platform, toolset_names, action):
+        assert action == "enable"
+        config.setdefault("platform_toolsets", {}).setdefault(platform, [])
+        for name in toolset_names:
+            if name not in config["platform_toolsets"][platform]:
+                config["platform_toolsets"][platform].append(name)
+
+    monkeypatch.setattr(xsearch_cmd, "_apply_toolset_toggle", _fake_apply)
+    monkeypatch.setattr(xsearch_cmd, "save_config", lambda _cfg: saved.__setitem__("called", True))
+    monkeypatch.setattr(xsearch_cmd, "_oauth_status", lambda: {"logged_in": False})
+    monkeypatch.setattr(xsearch_cmd, "get_env_value", lambda *_args, **_kwargs: None)
+
+    result = xsearch_cmd.run_xsearch_command("/xsearch setup")
+
+    assert result.reset_session is True
+    assert saved["called"] is True
+    assert cfg["x_search"]["model"] == xsearch_cmd.DEFAULT_X_SEARCH_MODEL
+    assert "enabled x_search for cli" in result.output
+    assert "hermes auth add xai-oauth" in result.output
+
+
+def test_search_parses_flags_and_formats_result(monkeypatch):
+    cfg = {
+        "platform_toolsets": {"cli": ["x_search"]},
+        "x_search": {"model": "grok-4.20-reasoning"},
+    }
+    captured = {}
+
+    monkeypatch.setattr(xsearch_cmd, "load_config", lambda: cfg)
+    monkeypatch.setattr(xsearch_cmd, "_get_platform_toolsets", lambda *_args, **_kwargs: {"x_search"})
+
+    def _fake_tool(**kwargs):
+        captured.update(kwargs)
+        return json.dumps(
+            {
+                "success": True,
+                "model": "grok-4.20-reasoning",
+                "credential_source": "xai-oauth",
+                "answer": "Summary",
+                "citations": [{"title": "xAI", "url": "https://x.com/xai/status/1"}],
+                "inline_citations": [],
+                "degraded": False,
+            }
+        )
+
+    monkeypatch.setattr(xsearch_cmd, "_run_x_search_tool", _fake_tool)
+
+    result = xsearch_cmd.run_xsearch_command(
+        "/xsearch latest grok launch reactions --from xai,openai --since 2026-05-20 --images"
+    )
+
+    assert captured["query"] == "latest grok launch reactions"
+    assert captured["allowed_x_handles"] == ["xai", "openai"]
+    assert captured["from_date"] == "2026-05-20"
+    assert captured["enable_image_understanding"] is True
+    assert "X Search via grok-4.20-reasoning (xai-oauth)" in result.output
+    assert "Sources:" in result.output
+
+
+def test_search_refuses_when_toolset_is_disabled(monkeypatch):
+    cfg = {"platform_toolsets": {"cli": []}, "x_search": {}}
+
+    monkeypatch.setattr(xsearch_cmd, "load_config", lambda: cfg)
+    monkeypatch.setattr(xsearch_cmd, "_get_platform_toolsets", lambda *_args, **_kwargs: set())
+
+    result = xsearch_cmd.run_xsearch_command("/xsearch latest xai posts")
+
+    assert "x_search is disabled for cli" in result.output

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -5493,7 +5493,9 @@ def _mirror_slash_side_effects(sid: str, session: dict, command: str) -> str:
     # with the session.compress / session.undo guards and the gateway
     # runner's running-agent /model guard.
     _MUTATES_WHILE_RUNNING = {"model", "personality", "prompt", "compress"}
-    if name in _MUTATES_WHILE_RUNNING and session.get("running"):
+    _xsearch_subcommand = arg.split(maxsplit=1)[0].lower() if arg else ""
+    _xsearch_mutates = name == "xsearch" and _xsearch_subcommand in {"enable", "disable", "setup"}
+    if (name in _MUTATES_WHILE_RUNNING or _xsearch_mutates) and session.get("running"):
         return f"session busy — /interrupt the current turn before running /{name}"
 
     try:
@@ -5521,6 +5523,11 @@ def _mirror_slash_side_effects(sid: str, session: dict, command: str) -> str:
             _emit("session.info", sid, _session_info(agent))
         elif name == "reload-mcp" and agent and hasattr(agent, "reload_mcp_tools"):
             agent.reload_mcp_tools()
+        elif name == "xsearch":
+            current_toolsets = getattr(agent, "enabled_toolsets", None) if agent else None
+            desired_toolsets = _load_enabled_toolsets()
+            if current_toolsets != desired_toolsets:
+                _reset_session_agent(sid, session)
         elif name == "stop":
             from tools.process_registry import process_registry
 

--- a/website/docs/reference/slash-commands.md
+++ b/website/docs/reference/slash-commands.md
@@ -86,6 +86,8 @@ Type `/` in the CLI to open the autocomplete menu. Built-in commands are case-in
 | `/tools [list\|disable\|enable] [name...]` | Manage tools: list available tools, or disable/enable specific tools for the current session. Disabling a tool removes it from the agent's toolset and triggers a session reset. |
 | `/toolsets` | List available toolsets |
 | `/browser [connect\|disconnect\|status]` | Manage a local Chromium-family CDP connection. `connect` attaches browser tools to a running Chrome, Brave, Chromium, or Edge instance (default: `http://127.0.0.1:9222`). `disconnect` detaches. `status` shows current connection. Auto-launches a supported Chromium-family browser if no debugger is detected. |
+| `/xsearch <query>` | Run X (Twitter) Search directly, bypassing model tool-choice discretion. Supports `--from`, `--exclude`, `--since`, `--until`, `--images`, and `--videos`. |
+| `/xsearch status\|setup\|enable\|disable\|model [name]` | Control the built-in `x_search` toolset from chat: inspect readiness, persist toolset enablement, and read/change `x_search.model`. `setup` auto-enables the toolset and prints any remaining auth steps (`hermes auth add xai-oauth` or `XAI_API_KEY`). |
 | `/skills` | Search, install, inspect, or manage skills from online registries |
 | `/cron` | Manage scheduled tasks (list, add/create, edit, pause, resume, run, remove) |
 | `/curator` | Background skill maintenance — `status`, `run`, `pin`, `archive`. See [Curator](/docs/user-guide/features/curator). |
@@ -214,6 +216,8 @@ The messaging gateway supports the following built-in commands inside Telegram, 
 | `/voice [on\|off\|tts\|join\|channel\|leave\|status]` | Control spoken replies in chat. `join`/`channel`/`leave` manage Discord voice-channel mode. |
 | `/rollback [number]` | List or restore filesystem checkpoints. |
 | `/background <prompt>` | Run a prompt in a separate background session. Results are delivered back to the same chat when the task finishes. See [Messaging Background Sessions](/docs/user-guide/messaging/#background-sessions). |
+| `/xsearch <query>` | Run X (Twitter) Search directly. Supports `--from`, `--exclude`, `--since`, `--until`, `--images`, and `--videos`. |
+| `/xsearch status\|setup\|enable\|disable\|model [name]` | Control the built-in `x_search` toolset from messaging: inspect readiness, persist toolset enablement for the current platform, and read/change `x_search.model`. `setup` auto-enables the toolset and prints any remaining auth steps. |
 | `/queue <prompt>` (alias: `/q`) | Queue a prompt for the next turn without interrupting the current one. |
 | `/steer <prompt>` | Inject a message after the next tool call without interrupting — the model picks it up on its next iteration rather than as a new turn. |
 | `/goal <text>` | Set a standing goal Hermes works toward across turns — our take on the Ralph loop. A judge model checks after each turn; if not done, Hermes auto-continues until it is, you pause/clear it, or the turn budget (default 20) is hit. Subcommands: `/goal status`, `/goal pause`, `/goal resume`, `/goal clear`. Safe to run mid-agent for status/pause/clear; setting a new goal requires `/stop` first. See [Persistent Goals](/docs/user-guide/features/goals). |
@@ -236,7 +240,7 @@ The messaging gateway supports the following built-in commands inside Telegram, 
 - `/skin`, `/snapshot`, `/gquota`, `/reload`, `/tools`, `/toolsets`, `/browser`, `/config`, `/cron`, `/skills`, `/platforms`, `/paste`, `/image`, `/statusbar`, `/plugins`, `/busy`, `/indicator`, `/redraw`, `/clear`, `/history`, `/save`, `/copy`, `/handoff`, and `/quit` are **CLI-only** commands.
 - `/verbose` is **CLI-only by default**, but can be enabled for messaging platforms by setting `display.tool_progress_command: true` in `config.yaml`. When enabled, it cycles the `display.tool_progress` mode and saves to config.
 - `/sethome`, `/update`, `/restart`, `/approve`, `/deny`, `/topic`, and `/commands` are **messaging-only** commands.
-- `/status`, `/background`, `/queue`, `/steer`, `/voice`, `/reload-mcp`, `/reload-skills`, `/rollback`, `/debug`, `/fast`, `/footer`, `/curator`, `/kanban`, `/sessions`, and `/yolo` work in **both** the CLI and the messaging gateway.
+- `/status`, `/background`, `/xsearch`, `/queue`, `/steer`, `/voice`, `/reload-mcp`, `/reload-skills`, `/rollback`, `/debug`, `/fast`, `/footer`, `/curator`, `/kanban`, `/sessions`, and `/yolo` work in **both** the CLI and the messaging gateway.
 - `/voice join`, `/voice channel`, and `/voice leave` are only meaningful on Discord.
 
 ## Confirmation prompts for destructive commands

--- a/website/docs/user-guide/features/x-search.md
+++ b/website/docs/user-guide/features/x-search.md
@@ -59,6 +59,47 @@ x_search:
   retries: 2
 ```
 
+## `/xsearch` command family
+
+Hermes also exposes X Search as a first-class slash command in the CLI, gateways, and dashboard chat:
+
+```text
+/xsearch <query>
+/xsearch status
+/xsearch setup
+/xsearch enable
+/xsearch disable
+/xsearch model [name]
+```
+
+Why use the command instead of natural language?
+
+- It forces a direct `x_search` call instead of hoping the model chooses the tool.
+- It gives you deterministic filters and cleaner failure messages.
+- It works as a control surface for setup and model selection.
+
+### Search flags
+
+```text
+/xsearch "grok 4 reactions" --from xai,openai --since 2026-05-20 --until 2026-05-21 --images
+```
+
+Supported flags:
+
+- `--from xai,openai` → `allowed_x_handles`
+- `--exclude spam1,spam2` → `excluded_x_handles`
+- `--since YYYY-MM-DD` → `from_date`
+- `--until YYYY-MM-DD` → `to_date`
+- `--images` → `enable_image_understanding`
+- `--videos` → `enable_video_understanding`
+
+### Control commands
+
+- `/xsearch status` shows whether the toolset is enabled on the current surface, the configured model, timeout/retry settings, and whether xAI OAuth or `XAI_API_KEY` is available.
+- `/xsearch setup` auto-enables the toolset for the current surface, ensures `x_search.model` has a value, and then prints any remaining auth step.
+- `/xsearch enable` / `/xsearch disable` persist toolset enablement for the current surface.
+- `/xsearch model [name]` shows or changes `x_search.model`.
+
 ## Tool parameters
 
 The agent calls `x_search` with these arguments:


### PR DESCRIPTION
  ## What does this PR do?

  Adds a first-class `/xsearch` command family across CLI, gateways, and dashboard chat for
  deterministic access to Hermes' existing built-in `x_search` tool.

  This surfaces explicit search/control operations (`search`, `status`, `setup`, `enable`,
  `disable`, `model`) without introducing a new backend or pretending `x_search` is a
  daemon/service.

  ## Related Issue

  Delete the `Fixes #` line if there is no issue.

  ## Type of Change
  Check:

  - [x] ✨ New feature
  - [x] 📝 Documentation update
  - [x] ✅ Tests

  ## Changes Made

  - Added shared `/xsearch` command logic in `hermes_cli/xsearch_command.py`
  - Registered `/xsearch` in `hermes_cli/commands.py`
  - Routed `/xsearch` through `cli.py`, `gateway/run.py`, and dashboard chat session sync in
  `tui_gateway/server.py`
  - Added support for:
    - `/xsearch <query>`
    - `/xsearch status`
    - `/xsearch setup`
    - `/xsearch enable`
    - `/xsearch disable`
    - `/xsearch model [name]`
  - Added structured search flags for existing tool args: `--from`, `--exclude`, `--since`,
  `--until`, `--images`, `--videos`
  - Added targeted tests and docs updates
  - Follow-up fix: gateway now resets the session after `/xsearch enable|disable|setup` so
  behavior matches CLI/session-refresh semantics

  ## How to Test

  1. Configure xAI OAuth or `XAI_API_KEY`
  2. Run `/xsearch status`, `/xsearch setup`, and `/xsearch "latest xai posts" --from xai
  --since 2026-05-20`
  3. Verify `/xsearch enable|disable|setup` resets the session and the next turn sees the
  updated tool availability

  ## Checklist
  Check:

  - [x] My commit messages follow Conventional Commits
  - [x] My PR contains only changes related to this feature
  - [x] I've added tests for my changes
  - [x] I've tested on my platform: Linux
  - [x] I've updated relevant documentation — or N/A
  - [x] I've updated cli-config.yaml.example if I added/changed config keys — or N/A
  - [x] I've updated CONTRIBUTING.md or AGENTS.md if I changed architecture or workflows —
    or N/A
  - [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

  Leave unchecked unless you want to personally attest:

  - I've read the Contributing Guide
  - I searched for existing PRs
  - I've run pytest tests/ -q and all tests pass