### PR TITLE
docs: fix BROWSERBASE_SESSION_TIMEOUT unit (ms → seconds)

### DIFF
--- a/plugins/browser/browserbase/provider.py
+++ b/plugins/browser/browserbase/provider.py
@@ -26,7 +26,7 @@ Optional feature knobs::
     BROWSERBASE_PROXIES=true      # default true
     BROWSERBASE_ADVANCED_STEALTH=false
     BROWSERBASE_KEEP_ALIVE=true   # default true
-    BROWSERBASE_SESSION_TIMEOUT=... (ms, integer)
+    BROWSERBASE_SESSION_TIMEOUT=... (seconds, integer, max 21600 = 6h)
 """
 
 from __future__ import annotations

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -33,8 +33,8 @@ Environment Variables:
   requires Scale Plan (default: "false")
 - BROWSERBASE_KEEP_ALIVE: Enable keepAlive for session reconnection after disconnects,
   requires paid plan (default: "true")
-- BROWSERBASE_SESSION_TIMEOUT: Custom session timeout in milliseconds. Set to extend
-  beyond project default. Common values: 600000 (10min), 1800000 (30min) (default: none)
+- BROWSERBASE_SESSION_TIMEOUT: Custom session timeout in seconds (max 21600 = 6h).
+  Set to extend beyond project default. Common values: 600 (10min), 1800 (30min) (default: none)
 
 Usage:
     from tools.browser_tool import browser_navigate, browser_snapshot, browser_click

--- a/website/docs/user-guide/features/browser.md
+++ b/website/docs/user-guide/features/browser.md
@@ -376,9 +376,9 @@ BROWSERBASE_ADVANCED_STEALTH=false
 # Session reconnection after disconnects — requires paid plan (default: "true")
 BROWSERBASE_KEEP_ALIVE=true
 
-# Custom session timeout in milliseconds (default: project default)
-# Examples: 600000 (10min), 1800000 (30min)
-BROWSERBASE_SESSION_TIMEOUT=600000
+# Custom session timeout in seconds (max 21600 = 6 hours) (default: project default)
+# Examples: 600 (10min), 1800 (30min), 21600 (6h max)
+BROWSERBASE_SESSION_TIMEOUT=1800
 
 # Inactivity timeout before auto-cleanup in seconds (default: 120)
 BROWSER_INACTIVITY_TIMEOUT=120


### PR DESCRIPTION
## Summary

`BROWSERBASE_SESSION_TIMEOUT` is documented as milliseconds in three places, but the value is forwarded as-is to the Browserbase `POST /v1/sessions` API `timeout` field, which is **seconds** (max `21600` = 6 hours). Following the docs causes every session creation to fail with HTTP 400.

This PR is **docs-only** — it corrects the documented unit to match the upstream Browserbase API (and the existing Hermes Python code path), without changing any runtime behaviour.

## Repro (current docs are wrong)

Using the value the docs recommend (`1800000`, "30 minutes in ms"):

```bash
curl -sS -X POST https://api.browserbase.com/v1/sessions \
  -H "X-BB-API-Key: $BROWSERBASE_API_KEY" \
  -H "Content-Type: application/json" \
  -d '{"projectId":"'"$BROWSERBASE_PROJECT_ID"'","timeout":1800000}'
```

Response (HTTP 400):

```json
{"statusCode":400,"code":"FST_ERR_VALIDATION","error":"Bad Request","message":"body/timeout must be <= 21600"}
```

In other words, the upper bound the API enforces (`21600`) is exactly 6 hours **in seconds**, which is the unit the Browserbase API actually expects.

## Verification (seconds work)

Same call with `1800` (30 minutes in seconds):

```bash
curl -sS -X POST https://api.browserbase.com/v1/sessions \
  -H "X-BB-API-Key: $BROWSERBASE_API_KEY" \
  -H "Content-Type: application/json" \
  -d '{"projectId":"'"$BROWSERBASE_PROJECT_ID"'","timeout":1800}'
```

Returns HTTP 201, `status: "RUNNING"`, and `expiresAt - startedAt == 1800s` exactly. This also matches the [Browserbase official SDK](https://docs.browserbase.com/reference/api/create-a-session) `defaultTimeout`/`timeout` field, which is documented in seconds.

## Options considered

**Option A — fix the docs (this PR).** Align the three doc/comment sites with the Browserbase API's actual unit (seconds). No behaviour change. Users who happen to have a working config today (i.e. anyone who set a sensible value ≤ 21600 expecting seconds) keep working.

**Option B — fix the code** (e.g. `session_config["timeout"] = timeout_val // 1000`). This would silently break every user who is currently passing seconds and relying on the value being forwarded verbatim — values like `1800` would become `1` (effectively zero), shortening sessions dramatically. Because the only values that "work" under the current documented-as-ms semantics are values ≤ 21600 (the API caps it), those users are already passing seconds in practice. Converting would punish the people who are doing the right thing.

Option A is therefore strictly safer and also aligns Hermes with upstream Browserbase semantics and the Browserbase SDK's `defaultTimeout` field. If a future change wants to add an explicit `BROWSERBASE_SESSION_TIMEOUT_MS` knob with conversion, it can be layered on top without breaking existing users.

## Affected files

- `website/docs/user-guide/features/browser.md` — `.env` example comment block: unit corrected to seconds, added max (`21600 = 6 hours`), example value updated from `600000` to `1800`.
- `plugins/browser/browserbase/provider.py` — module docstring "Optional feature knobs" block: `(ms, integer)` → `(seconds, integer, max 21600 = 6h)`.
- `tools/browser_tool.py` — `Environment Variables` docstring entry for `BROWSERBASE_SESSION_TIMEOUT`: "milliseconds" → "seconds (max 21600 = 6h)" and example values rescaled (`600000`/`1800000` → `600`/`1800`).

No Python logic is changed; `git diff --stat` is `3 files changed, 6 insertions(+), 6 deletions(-)`.
