### PR TITLE
feat(dashboard): add xai oauth onboarding

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -1436,6 +1436,14 @@ _OAUTH_PROVIDER_CATALOG: tuple[Dict[str, Any], ...] = (
         "status_fn": None,  # dispatched via auth.get_codex_auth_status
     },
     {
+        "id": "xai-oauth",
+        "name": "xAI Grok OAuth (SuperGrok Subscription)",
+        "flow": "pkce",
+        "cli_command": "hermes auth add xai-oauth",
+        "docs_url": "https://hermes-agent.nousresearch.com/docs/guides/xai-grok-oauth",
+        "status_fn": None,  # dispatched via auth.get_xai_oauth_auth_status
+    },
+    {
         "id": "qwen-oauth",
         "name": "Qwen (via Qwen CLI)",
         "flow": "external",
@@ -1487,6 +1495,21 @@ def _resolve_provider_status(provider_id: str, status_fn) -> Dict[str, Any]:
                 "token_preview": _truncate_token(raw.get("api_key")),
                 "expires_at": None,
                 "has_refresh_token": False,
+                "last_refresh": raw.get("last_refresh"),
+            }
+        if provider_id == "xai-oauth":
+            raw = hauth.get_xai_oauth_auth_status()
+            source = raw.get("source") or "xai_oauth"
+            source_label = raw.get("auth_store") or "Hermes auth store"
+            if isinstance(source, str) and source.startswith("pool:"):
+                source_label = source
+            return {
+                "logged_in": bool(raw.get("logged_in")),
+                "source": source,
+                "source_label": source_label,
+                "token_preview": _truncate_token(raw.get("api_key")),
+                "expires_at": None,
+                "has_refresh_token": bool(raw.get("logged_in")),
                 "last_refresh": raw.get("last_refresh"),
             }
         if provider_id == "qwen-oauth":
@@ -1595,15 +1618,15 @@ async def disconnect_oauth_provider(provider_id: str, request: Request):
 #
 # Two flow shapes are supported:
 #
-#   PKCE (Anthropic):
-#     1. POST /api/providers/oauth/anthropic/start
-#          → server generates code_verifier + challenge, builds claude.ai
-#            authorize URL, stashes verifier in _oauth_sessions[session_id]
+#   PKCE (Anthropic, xai-oauth):
+#     1. POST /api/providers/oauth/{provider}/start
+#          → server generates code_verifier + challenge, builds authorize URL,
+#            stashes verifier in _oauth_sessions[session_id]
 #          → returns { session_id, flow: "pkce", auth_url }
 #     2. UI opens auth_url in a new tab. User authorizes, copies code.
-#     3. POST /api/providers/oauth/anthropic/submit { session_id, code }
-#          → server exchanges (code + verifier) → tokens at console.anthropic.com
-#          → persists to ~/.hermes/.anthropic_oauth.json AND credential pool
+#     3. POST /api/providers/oauth/{provider}/submit { session_id, code }
+#          → server exchanges (code + verifier) → tokens at the provider token
+#            endpoint and persists them via the existing Hermes auth helpers
 #          → returns { ok: true, status: "approved" }
 #
 #   Device code (Nous, OpenAI Codex):
@@ -1747,6 +1770,46 @@ def _start_anthropic_pkce() -> Dict[str, Any]:
     }
 
 
+def _start_xai_pkce() -> Dict[str, Any]:
+    """Begin xAI's PKCE flow. Returns the auth URL the UI should open."""
+    from hermes_cli import auth as hauth
+
+    discovery = hauth._xai_oauth_discovery(20.0)
+    redirect_uri = (
+        f"http://{hauth.XAI_OAUTH_REDIRECT_HOST}:{hauth.XAI_OAUTH_REDIRECT_PORT}"
+        f"{hauth.XAI_OAUTH_REDIRECT_PATH}"
+    )
+    hauth._xai_validate_loopback_redirect_uri(redirect_uri)
+
+    code_verifier = hauth._oauth_pkce_code_verifier()
+    code_challenge = hauth._oauth_pkce_code_challenge(code_verifier)
+    state = secrets.token_hex(16)
+    nonce = secrets.token_hex(16)
+    auth_url = hauth._xai_oauth_build_authorize_url(
+        authorization_endpoint=discovery["authorization_endpoint"],
+        redirect_uri=redirect_uri,
+        code_challenge=code_challenge,
+        state=state,
+        nonce=nonce,
+    )
+
+    sid, sess = _new_oauth_session("xai-oauth", "pkce")
+    sess["discovery"] = discovery
+    sess["token_endpoint"] = discovery["token_endpoint"]
+    sess["redirect_uri"] = redirect_uri
+    sess["code_verifier"] = code_verifier
+    sess["code_challenge"] = code_challenge
+    sess["state"] = state
+    sess["nonce"] = nonce
+
+    return {
+        "session_id": sid,
+        "flow": "pkce",
+        "auth_url": auth_url,
+        "expires_in": _OAUTH_SESSION_TTL_SECONDS,
+    }
+
+
 def _submit_anthropic_pkce(session_id: str, code_input: str) -> Dict[str, Any]:
     """Exchange authorization code for tokens. Persists on success."""
     with _oauth_sessions_lock:
@@ -1810,6 +1873,86 @@ def _submit_anthropic_pkce(session_id: str, code_input: str) -> Dict[str, Any]:
     with _oauth_sessions_lock:
         sess["status"] = "approved"
     _log.info("oauth/pkce: anthropic login completed (session=%s)", session_id)
+    return {"ok": True, "status": "approved"}
+
+
+def _submit_xai_pkce(session_id: str, code_input: str) -> Dict[str, Any]:
+    """Exchange an xAI authorization code and persist the resulting tokens."""
+    from datetime import datetime, timezone
+    from hermes_cli import auth as hauth
+
+    with _oauth_sessions_lock:
+        sess = _oauth_sessions.get(session_id)
+    if not sess or sess["provider"] != "xai-oauth" or sess["flow"] != "pkce":
+        raise HTTPException(status_code=404, detail="Unknown or expired session")
+    if sess["status"] != "pending":
+        return {"ok": False, "status": sess["status"], "message": sess.get("error_message")}
+
+    callback = hauth._parse_pasted_callback(code_input)
+    if callback.get("error"):
+        with _oauth_sessions_lock:
+            sess["status"] = "error"
+            sess["error_message"] = (
+                "xAI authorization failed: "
+                f"{callback.get('error_description') or callback.get('error')}"
+            )
+        return {"ok": False, "status": "error", "message": sess["error_message"]}
+
+    state = str(callback.get("state") or "").strip()
+    if not state:
+        with _oauth_sessions_lock:
+            sess["status"] = "error"
+            sess["error_message"] = (
+                "Paste the full xAI callback URL (or ?code=...&state=...) "
+                "so Hermes can verify the returned state."
+            )
+        return {"ok": False, "status": "error", "message": sess["error_message"]}
+    if state != sess["state"]:
+        with _oauth_sessions_lock:
+            sess["status"] = "error"
+            sess["error_message"] = "xAI authorization failed: state mismatch."
+        return {"ok": False, "status": "error", "message": sess["error_message"]}
+
+    code = str(callback.get("code") or "").strip()
+    if not code:
+        with _oauth_sessions_lock:
+            sess["status"] = "error"
+            sess["error_message"] = "xAI authorization failed: missing authorization code."
+        return {"ok": False, "status": "error", "message": sess["error_message"]}
+
+    try:
+        payload = hauth._xai_oauth_exchange_code_for_tokens(
+            token_endpoint=sess["token_endpoint"],
+            code=code,
+            redirect_uri=sess["redirect_uri"],
+            code_verifier=sess["code_verifier"],
+            code_challenge=sess["code_challenge"],
+        )
+        access_token = str(payload.get("access_token", "") or "").strip()
+        refresh_token = str(payload.get("refresh_token", "") or "").strip()
+        if not access_token or not refresh_token:
+            raise RuntimeError("xAI token exchange did not return both access and refresh tokens.")
+        hauth._save_xai_oauth_tokens(
+            {
+                "access_token": access_token,
+                "refresh_token": refresh_token,
+                "id_token": str(payload.get("id_token", "") or "").strip(),
+                "expires_in": payload.get("expires_in"),
+                "token_type": str(payload.get("token_type") or "Bearer").strip() or "Bearer",
+            },
+            discovery=sess.get("discovery"),
+            redirect_uri=sess["redirect_uri"],
+            last_refresh=datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+        )
+    except Exception as e:
+        with _oauth_sessions_lock:
+            sess["status"] = "error"
+            sess["error_message"] = f"xAI token exchange failed: {e}"
+        return {"ok": False, "status": "error", "message": sess["error_message"]}
+
+    with _oauth_sessions_lock:
+        sess["status"] = "approved"
+    _log.info("oauth/pkce: xai-oauth login completed (session=%s)", session_id)
     return {"ok": True, "status": "approved"}
 
 
@@ -2289,14 +2432,11 @@ async def start_oauth_login(provider_id: str, request: Request):
             detail=f"{provider_id} uses an external CLI; run `{catalog_entry['cli_command']}` manually",
         )
     try:
-        # The pkce branch is gated on provider_id == "anthropic" because
-        # `_start_anthropic_pkce()` is hardcoded to the Anthropic flow.
-        # Routing any other future pkce-flagged provider through it would
-        # silently launch the Anthropic OAuth flow (the bug fixed in this
-        # change for MiniMax). New PKCE providers must add their own
-        # start function and an explicit branch here.
-        if catalog_entry["flow"] == "pkce" and provider_id == "anthropic":
-            return _start_anthropic_pkce()
+        if catalog_entry["flow"] == "pkce":
+            if provider_id == "anthropic":
+                return _start_anthropic_pkce()
+            if provider_id == "xai-oauth":
+                return _start_xai_pkce()
         if catalog_entry["flow"] == "device_code":
             return await _start_device_code_flow(provider_id)
     except HTTPException:
@@ -2319,6 +2459,10 @@ async def submit_oauth_code(provider_id: str, body: OAuthSubmitBody, request: Re
     if provider_id == "anthropic":
         return await asyncio.get_running_loop().run_in_executor(
             None, _submit_anthropic_pkce, body.session_id, body.code,
+        )
+    if provider_id == "xai-oauth":
+        return await asyncio.get_running_loop().run_in_executor(
+            None, _submit_xai_pkce, body.session_id, body.code,
         )
     raise HTTPException(status_code=400, detail=f"submit not supported for {provider_id}")
 

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -1888,37 +1888,33 @@ def _submit_xai_pkce(session_id: str, code_input: str) -> Dict[str, Any]:
     if sess["status"] != "pending":
         return {"ok": False, "status": sess["status"], "message": sess.get("error_message")}
 
+    def _retryable(message: str) -> Dict[str, Any]:
+        return {
+            "ok": False,
+            "status": "error",
+            "message": message,
+            "retryable": True,
+        }
+
     callback = hauth._parse_pasted_callback(code_input)
     if callback.get("error"):
-        with _oauth_sessions_lock:
-            sess["status"] = "error"
-            sess["error_message"] = (
-                "xAI authorization failed: "
-                f"{callback.get('error_description') or callback.get('error')}"
-            )
-        return {"ok": False, "status": "error", "message": sess["error_message"]}
+        return _retryable(
+            "xAI authorization failed: "
+            f"{callback.get('error_description') or callback.get('error')}"
+        )
 
     state = str(callback.get("state") or "").strip()
     if not state:
-        with _oauth_sessions_lock:
-            sess["status"] = "error"
-            sess["error_message"] = (
-                "Paste the full xAI callback URL (or ?code=...&state=...) "
-                "so Hermes can verify the returned state."
-            )
-        return {"ok": False, "status": "error", "message": sess["error_message"]}
+        return _retryable(
+            "Paste the full xAI callback URL (or ?code=...&state=...) "
+            "so Hermes can verify the returned state."
+        )
     if state != sess["state"]:
-        with _oauth_sessions_lock:
-            sess["status"] = "error"
-            sess["error_message"] = "xAI authorization failed: state mismatch."
-        return {"ok": False, "status": "error", "message": sess["error_message"]}
+        return _retryable("xAI authorization failed: state mismatch.")
 
     code = str(callback.get("code") or "").strip()
     if not code:
-        with _oauth_sessions_lock:
-            sess["status"] = "error"
-            sess["error_message"] = "xAI authorization failed: missing authorization code."
-        return {"ok": False, "status": "error", "message": sess["error_message"]}
+        return _retryable("xAI authorization failed: missing authorization code.")
 
     try:
         payload = hauth._xai_oauth_exchange_code_for_tokens(
@@ -1932,6 +1928,10 @@ def _submit_xai_pkce(session_id: str, code_input: str) -> Dict[str, Any]:
         refresh_token = str(payload.get("refresh_token", "") or "").strip()
         if not access_token or not refresh_token:
             raise RuntimeError("xAI token exchange did not return both access and refresh tokens.")
+    except Exception as e:
+        return _retryable(f"xAI token exchange failed: {e}")
+
+    try:
         hauth._save_xai_oauth_tokens(
             {
                 "access_token": access_token,
@@ -1947,7 +1947,7 @@ def _submit_xai_pkce(session_id: str, code_input: str) -> Dict[str, Any]:
     except Exception as e:
         with _oauth_sessions_lock:
             sess["status"] = "error"
-            sess["error_message"] = f"xAI token exchange failed: {e}"
+            sess["error_message"] = f"xAI token save failed: {e}"
         return {"ok": False, "status": "error", "message": sess["error_message"]}
 
     with _oauth_sessions_lock:
@@ -2436,7 +2436,9 @@ async def start_oauth_login(provider_id: str, request: Request):
             if provider_id == "anthropic":
                 return _start_anthropic_pkce()
             if provider_id == "xai-oauth":
-                return _start_xai_pkce()
+                return await asyncio.get_running_loop().run_in_executor(
+                    None, _start_xai_pkce,
+                )
         if catalog_entry["flow"] == "device_code":
             return await _start_device_code_flow(provider_id)
     except HTTPException:

--- a/tests/hermes_cli/test_web_oauth_dispatch.py
+++ b/tests/hermes_cli/test_web_oauth_dispatch.py
@@ -316,27 +316,38 @@ def test_xai_oauth_provider_appears_in_catalog():
     assert providers["xai-oauth"]["cli_command"] == "hermes auth add xai-oauth"
 
 
-def test_xai_start_uses_xai_branch_not_anthropic():
-    """Click 'Login' on xAI → MUST route to the xAI-specific PKCE start helper."""
-    fake_response = {
-        "session_id": "xai-session",
-        "flow": "pkce",
-        "auth_url": "https://auth.x.ai/oauth/authorize?code=true&...",
-        "expires_in": 600,
-    }
-    with patch(
-        "hermes_cli.web_server._start_xai_pkce",
-        return_value=fake_response,
-    ) as patched:
-        resp = client.post(
-            "/api/providers/oauth/xai-oauth/start",
-            headers=HEADERS,
-        )
+def test_xai_start_runs_in_executor(monkeypatch):
+    """xAI PKCE discovery should be dispatched off the FastAPI event loop."""
+    from hermes_cli import web_server as ws
 
-    assert resp.status_code == 200, resp.text
-    assert resp.json() == fake_response
-    patched.assert_called_once_with()
-    assert "claude.ai" not in resp.text.lower()
+    called = {}
+
+    class _FakeLoop:
+        async def run_in_executor(self, executor, func, *args):
+            called["executor"] = executor
+            called["func"] = func
+            called["args"] = args
+            return func(*args)
+
+    monkeypatch.setattr(ws, "_require_token", lambda _request: None)
+    monkeypatch.setattr(ws.asyncio, "get_running_loop", lambda: _FakeLoop())
+    monkeypatch.setattr(
+        ws,
+        "_start_xai_pkce",
+        lambda: {
+            "session_id": "xai-session",
+            "flow": "pkce",
+            "auth_url": "https://auth.x.ai/oauth/authorize?code=true&...",
+            "expires_in": 600,
+        },
+    )
+
+    result = asyncio.run(ws.start_oauth_login("xai-oauth", object()))
+
+    assert result["flow"] == "pkce"
+    assert called["executor"] is None
+    assert called["func"] is ws._start_xai_pkce
+    assert called["args"] == ()
 
 
 def test_xai_submit_uses_xai_submitter():
@@ -415,6 +426,37 @@ def test_xai_submit_parses_callback_and_persists_tokens():
     assert saved["tokens"]["refresh_token"] == "refresh-123"
     assert saved["redirect_uri"] == "http://127.0.0.1:56121/callback"
     assert saved["discovery"]["token_endpoint"] == "https://auth.x.ai/oauth/token"
+
+
+def test_xai_submit_bad_paste_is_retryable_and_keeps_session_pending():
+    """Bare-code pastes should not poison the session; the user can correct and retry."""
+    from hermes_cli import web_server as ws
+
+    session_id = "xai-pkce-retryable-test"
+    ws._oauth_sessions[session_id] = {
+        "session_id": session_id,
+        "provider": "xai-oauth",
+        "flow": "pkce",
+        "created_at": time.time(),
+        "status": "pending",
+        "error_message": None,
+        "token_endpoint": "https://auth.x.ai/oauth/token",
+        "redirect_uri": "http://127.0.0.1:56121/callback",
+        "code_verifier": "verifier-123",
+        "code_challenge": "challenge-123",
+        "state": "state-123",
+        "discovery": {"token_endpoint": "https://auth.x.ai/oauth/token"},
+    }
+
+    try:
+        result = ws._submit_xai_pkce(session_id, "auth-code-only")
+        assert result["ok"] is False
+        assert result["status"] == "error"
+        assert result["retryable"] is True
+        assert "full xAI callback URL" in result["message"]
+        assert ws._oauth_sessions[session_id]["status"] == "pending"
+    finally:
+        ws._oauth_sessions.pop(session_id, None)
 
 
 def test_unknown_pkce_provider_rejected_cleanly():

--- a/tests/hermes_cli/test_web_oauth_dispatch.py
+++ b/tests/hermes_cli/test_web_oauth_dispatch.py
@@ -24,10 +24,39 @@ import time
 from datetime import datetime, timezone
 from unittest.mock import patch
 
-import httpx
+from hermes_cli.web_server import _SESSION_TOKEN, app
 from fastapi.testclient import TestClient
 
-from hermes_cli.web_server import _SESSION_TOKEN, app
+try:
+    import httpx
+except ModuleNotFoundError:
+    class _FakeRequest:
+        def __init__(self, method: str, url: str):
+            self.method = method
+            self.url = url
+
+    class _FakeResponse:
+        def __init__(self, status_code: int, *, json, request):
+            self.status_code = status_code
+            self._json = json
+            self.request = request
+            self.text = str(json)
+
+        def json(self):
+            return self._json
+
+    class _FakeHTTPStatusError(Exception):
+        def __init__(self, message: str, *, request, response):
+            super().__init__(message)
+            self.request = request
+            self.response = response
+
+    class _FakeHTTPXModule:
+        Request = _FakeRequest
+        Response = _FakeResponse
+        HTTPStatusError = _FakeHTTPStatusError
+
+    httpx = _FakeHTTPXModule()
 
 client = TestClient(app)
 HEADERS = {"X-Hermes-Session-Token": _SESSION_TOKEN}
@@ -274,6 +303,118 @@ def test_anthropic_pkce_branch_still_works():
     body = resp.json()
     assert body["flow"] == "pkce"
     assert "claude.ai" in body["auth_url"]
+
+
+def test_xai_oauth_provider_appears_in_catalog():
+    """Dashboard provider catalog should expose xAI OAuth as a PKCE flow."""
+    resp = client.get("/api/providers/oauth", headers=HEADERS)
+    assert resp.status_code == 200, resp.text
+
+    providers = {provider["id"]: provider for provider in resp.json()["providers"]}
+    assert "xai-oauth" in providers
+    assert providers["xai-oauth"]["flow"] == "pkce"
+    assert providers["xai-oauth"]["cli_command"] == "hermes auth add xai-oauth"
+
+
+def test_xai_start_uses_xai_branch_not_anthropic():
+    """Click 'Login' on xAI → MUST route to the xAI-specific PKCE start helper."""
+    fake_response = {
+        "session_id": "xai-session",
+        "flow": "pkce",
+        "auth_url": "https://auth.x.ai/oauth/authorize?code=true&...",
+        "expires_in": 600,
+    }
+    with patch(
+        "hermes_cli.web_server._start_xai_pkce",
+        return_value=fake_response,
+    ) as patched:
+        resp = client.post(
+            "/api/providers/oauth/xai-oauth/start",
+            headers=HEADERS,
+        )
+
+    assert resp.status_code == 200, resp.text
+    assert resp.json() == fake_response
+    patched.assert_called_once_with()
+    assert "claude.ai" not in resp.text.lower()
+
+
+def test_xai_submit_uses_xai_submitter():
+    """PKCE code submission for xAI must dispatch to the xAI submit helper."""
+    fake_response = {"ok": True, "status": "approved"}
+    callback_url = "http://127.0.0.1:56121/callback?code=abc&state=xyz"
+    with patch(
+        "hermes_cli.web_server._submit_xai_pkce",
+        return_value=fake_response,
+    ) as patched:
+        resp = client.post(
+            "/api/providers/oauth/xai-oauth/submit",
+            headers=HEADERS,
+            json={"session_id": "xai-session", "code": callback_url},
+        )
+
+    assert resp.status_code == 200, resp.text
+    assert resp.json() == fake_response
+    patched.assert_called_once_with("xai-session", callback_url)
+
+
+def test_xai_submit_parses_callback_and_persists_tokens():
+    """The xAI submit helper should accept a pasted callback URL and save tokens."""
+    from hermes_cli import web_server as ws
+
+    session_id = "xai-pkce-submit-test"
+    ws._oauth_sessions[session_id] = {
+        "session_id": session_id,
+        "provider": "xai-oauth",
+        "flow": "pkce",
+        "created_at": time.time(),
+        "status": "pending",
+        "error_message": None,
+        "token_endpoint": "https://auth.x.ai/oauth/token",
+        "redirect_uri": "http://127.0.0.1:56121/callback",
+        "code_verifier": "verifier-123",
+        "code_challenge": "challenge-123",
+        "state": "state-123",
+        "discovery": {"token_endpoint": "https://auth.x.ai/oauth/token"},
+    }
+    saved = {}
+
+    def fake_save(tokens, **kwargs):
+        saved["tokens"] = tokens
+        saved.update(kwargs)
+
+    try:
+        with patch(
+            "hermes_cli.auth._xai_oauth_exchange_code_for_tokens",
+            return_value={
+                "access_token": "access-123",
+                "refresh_token": "refresh-123",
+                "token_type": "Bearer",
+                "expires_in": 3600,
+            },
+        ) as exchange, patch(
+            "hermes_cli.auth._save_xai_oauth_tokens",
+            side_effect=fake_save,
+        ):
+            result = ws._submit_xai_pkce(
+                session_id,
+                "http://127.0.0.1:56121/callback?code=auth-code-123&state=state-123",
+            )
+    finally:
+        ws._oauth_sessions.pop(session_id, None)
+
+    assert result == {"ok": True, "status": "approved"}
+    exchange.assert_called_once_with(
+        token_endpoint="https://auth.x.ai/oauth/token",
+        code="auth-code-123",
+        redirect_uri="http://127.0.0.1:56121/callback",
+        code_verifier="verifier-123",
+        code_challenge="challenge-123",
+    )
+    assert saved["tokens"]["access_token"] == "access-123"
+    assert saved["tokens"]["refresh_token"] == "refresh-123"
+    assert saved["redirect_uri"] == "http://127.0.0.1:56121/callback"
+    assert saved["discovery"]["token_endpoint"] == "https://auth.x.ai/oauth/token"
 
 
 def test_unknown_pkce_provider_rejected_cleanly():

--- a/web/src/components/OAuthLoginModal.tsx
+++ b/web/src/components/OAuthLoginModal.tsx
@@ -33,6 +33,17 @@ export function OAuthLoginModal({ provider, onClose, onSuccess }: Props) {
   const isMounted = useRef(true);
   const pollTimer = useRef<number | null>(null);
   const { t } = useI18n();
+  const isXaiPkce = provider.id === "xai-oauth";
+  const pkcePlaceholder = isXaiPkce
+    ? "Paste full callback URL or ?code=...&state=..."
+    : t.oauth.pasteCode;
+  const pkceSteps = isXaiPkce
+    ? [
+        "A new tab opened to xAI. Sign in and approve access.",
+        "After authorizing, copy the full callback URL from the browser address bar.",
+        "Paste the full callback URL or ?code=...&state=... below and submit.",
+      ]
+    : [t.oauth.pkceStep1, t.oauth.pkceStep2, t.oauth.pkceStep3];
 
   // Initiate flow on mount
   useEffect(() => {
@@ -128,6 +139,9 @@ export function OAuthLoginModal({ provider, onClose, onSuccess }: Props) {
         setPhase("approved");
         onSuccess(`${provider.name} connected`);
         window.setTimeout(() => isMounted.current && onClose(), 1500);
+      } else if (resp.retryable) {
+        setPhase("awaiting_user");
+        setErrorMsg(resp.message || "Try pasting the callback again.");
       } else {
         setPhase("error");
         setErrorMsg(resp.message || "Token exchange failed");
@@ -211,15 +225,23 @@ export function OAuthLoginModal({ provider, onClose, onSuccess }: Props) {
           {start?.flow === "pkce" && phase === "awaiting_user" && (
             <>
               <ol className="text-sm space-y-2 list-decimal list-inside text-muted-foreground">
-                <li>{t.oauth.pkceStep1}</li>
-                <li>{t.oauth.pkceStep2}</li>
-                <li>{t.oauth.pkceStep3}</li>
+                {pkceSteps.map((step) => (
+                  <li key={step}>{step}</li>
+                ))}
               </ol>
+              {errorMsg && (
+                <div className="border border-destructive/30 bg-destructive/10 p-3 text-sm text-destructive">
+                  {errorMsg}
+                </div>
+              )}
               <div className="flex flex-col gap-2">
                 <Input
                   value={pkceCode}
-                  onChange={(e) => setPkceCode(e.target.value)}
-                  placeholder={t.oauth.pasteCode}
+                  onChange={(e) => {
+                    setPkceCode(e.target.value);
+                    if (errorMsg) setErrorMsg(null);
+                  }}
+                  placeholder={pkcePlaceholder}
                   onKeyDown={(e) => e.key === "Enter" && handleSubmitPkceCode()}
                   autoFocus
                 />

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -715,6 +715,7 @@ export interface OAuthSubmitResponse {
   ok: boolean;
   status: "approved" | "error";
   message?: string;
+  retryable?: boolean;
 }
 
 export interface OAuthPollResponse {

--- a/website/docs/guides/xai-grok-oauth.md
+++ b/website/docs/guides/xai-grok-oauth.md
@@ -63,6 +63,19 @@ You can trigger a login without going through the model picker:
 hermes auth add xai-oauth
 ```
 
+### Dashboard login
+
+If the web dashboard is installed, you can also connect from the browser:
+
+1. Run `hermes dashboard`
+2. Open **API Keys**
+3. Find **OAuth Providers**
+4. Click **Connect** next to **xAI Grok OAuth (SuperGrok Subscription)**
+5. Complete the browser flow at `accounts.x.ai`
+6. Paste the returned callback URL (or the `?code=...&state=...` query string) back into the dashboard modal
+
+This uses the same `xai-oauth` auth store as `hermes auth add xai-oauth`, so CLI, dashboard, gateway setup flows, and `x_search` all see the same login immediately.
+
 ### Remote / headless sessions
 
 On servers, containers, or SSH sessions where no browser is available, Hermes detects the remote environment and prints the authorization URL instead of opening a browser.

--- a/website/docs/user-guide/features/web-dashboard.md
+++ b/website/docs/user-guide/features/web-dashboard.md
@@ -131,6 +131,24 @@ Each key shows:
 - An input field to set or update the value
 - A delete button to remove it
 
+### OAuth Providers
+
+Below the raw `.env` editor, the dashboard also exposes browser-based OAuth providers that Hermes knows how to log into directly.
+
+- **PKCE flows** — open the provider's authorize page in a new tab, then paste the returned callback URL or code back into the modal
+- **Device-code flows** — show a verification URL plus user code while Hermes polls in the background
+- **External CLI flows** — show the exact CLI command when the provider owns its own login outside Hermes
+
+Current in-dashboard OAuth-capable providers include:
+
+- **Anthropic (Claude API)**
+- **xAI Grok OAuth (SuperGrok Subscription)**
+- **Nous Portal**
+- **OpenAI Codex (ChatGPT)**
+- **MiniMax (OAuth)**
+
+For xAI specifically, the dashboard flow is enough to unlock both the `xai-oauth` inference provider and direct-to-xAI tools like `x_search`; there is no separate X Search login once the OAuth provider card shows as connected.
+
 Advanced/rarely-used keys are hidden by default behind a toggle.
 
 ### Sessions

--- a/website/docs/user-guide/features/x-search.md
+++ b/website/docs/user-guide/features/x-search.md
@@ -17,7 +17,7 @@ The `x_search` tool lets the agent search X (Twitter) posts, profiles, and threa
 
 | Credential | Source | Setup |
 |------------|--------|-------|
-| **SuperGrok / X Premium+ OAuth** (preferred) | Browser login at `accounts.x.ai`, refreshed automatically | `hermes auth add xai-oauth` — see [xAI Grok OAuth (SuperGrok / X Premium+)](../../guides/xai-grok-oauth.md) |
+| **SuperGrok / X Premium+ OAuth** (preferred) | Browser login at `accounts.x.ai`, refreshed automatically | `hermes auth add xai-oauth` or **Dashboard → API Keys → OAuth Providers → Connect xAI Grok OAuth** — see [xAI Grok OAuth (SuperGrok / X Premium+)](../../guides/xai-grok-oauth.md) |
 | **`XAI_API_KEY`** | Paid xAI API key | Set in `~/.hermes/.env` |
 
 Both hit the same endpoint with the same payload — the only difference is the bearer token. **When both are configured, SuperGrok OAuth wins** so x_search runs against your subscription quota instead of paid API spend.


### PR DESCRIPTION
  ## What does this PR do?

  Adds dashboard-native `xai-oauth` onboarding so users can connect xAI Grok OAuth from the
  web UI instead of dropping to the CLI.

  This wires xAI into Hermes' existing dashboard OAuth system, adds explicit xAI PKCE
  handling, and makes the xAI callback-paste flow retryable and operator-friendly.

  ## Related Issue

  Delete the `Fixes #` line if there is no issue.

  ## Type of Change
  Check:

  - [x] ✨ New feature
  - [x] 📝 Documentation update
  - [x] ✅ Tests

  ## Changes Made

  - Added `xai-oauth` to the dashboard OAuth provider catalog in `hermes_cli/web_server.py`
  - Added xAI provider status wiring using existing auth helpers
  - Added explicit xAI PKCE start/submit branches instead of relying on Anthropic-specific
  logic
  - Moved xAI OAuth start off the FastAPI event loop by dispatching it through an executor
  - Made bad xAI callback pastes retryable instead of poisoning the session
  - Updated the dashboard OAuth modal to show xAI-specific instructions: paste the full
  callback URL or `?code=...&state=...`
  - Updated frontend response typing in `web/src/lib/api.ts`
  - Added regression tests and docs updates
  - Follow-up fix: xAI setup errors caused by bad paste input now stay in-place and can be
  retried without restarting the flow

  ## How to Test

  1. Run `hermes dashboard` and open API Keys → OAuth Providers
  2. Click Connect for `xAI Grok OAuth (SuperGrok Subscription)` and complete the browser
  flow
  3. Paste the full callback URL (or `?code=...&state=...`) into the modal and verify the
  provider connects
  4. Try a bad paste first and verify the modal stays retryable instead of forcing a full
  restart

  ## Checklist
  Check:

  - [x] My commit messages follow Conventional Commits
  - [x] My PR contains only changes related to this feature
  - [x] I've added tests for my changes
  - [x] I've tested on my platform: Linux
  - [x] I've updated relevant documentation — or N/A
  - [x] I've updated cli-config.yaml.example if I added/changed config keys — or N/A
  - [x] I've updated CONTRIBUTING.md or AGENTS.md if I changed architecture or workflows —
    or N/A
  - [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

  Leave unchecked unless you want to personally attest:

  - I've read the Contributing Guide
  - I searched for existing PRs
  - I've run pytest tests/ -q and all tests pass