### PR TITLE
Respect HERMES_IGNORE_RULES in gateway agent creation

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -11397,6 +11397,7 @@ class GatewayRunner:
             self._reasoning_config = reasoning_config
             self._service_tier = self._load_service_tier()
             turn_route = self._resolve_turn_agent_config(prompt, model, runtime_kwargs)
+            ignore_rules = is_truthy_value(os.environ.get("HERMES_IGNORE_RULES"))
 
             # Enrich the prompt with image descriptions so the background
             # agent can see user-attached images (same as the main flow).
@@ -11422,6 +11423,8 @@ class GatewayRunner:
                     max_iterations=max_iterations,
                     quiet_mode=True,
                     verbose_logging=False,
+                    skip_context_files=ignore_rules,
+                    skip_memory=ignore_rules,
                     enabled_toolsets=enabled_toolsets,
                     disabled_toolsets=disabled_toolsets,
                     reasoning_config=reasoning_config,
@@ -16249,6 +16252,7 @@ class GatewayRunner:
                 )
 
             turn_route = self._resolve_turn_agent_config(message, model, runtime_kwargs)
+            ignore_rules = is_truthy_value(os.environ.get("HERMES_IGNORE_RULES"))
 
             # Check agent cache — reuse the AIAgent from the previous message
             # in this session to preserve the frozen system prompt and tool
@@ -16286,6 +16290,8 @@ class GatewayRunner:
                     max_iterations=max_iterations,
                     quiet_mode=True,
                     verbose_logging=False,
+                    skip_context_files=ignore_rules,
+                    skip_memory=ignore_rules,
                     enabled_toolsets=enabled_toolsets,
                     disabled_toolsets=disabled_toolsets,
                     ephemeral_system_prompt=combined_ephemeral or None,

--- a/tests/gateway/test_session_model_override_routing.py
+++ b/tests/gateway/test_session_model_override_routing.py
@@ -126,6 +126,46 @@ def test_run_agent_prefers_session_override_over_global_runtime(monkeypatch):
     assert _CapturingAgent.last_init["reasoning_config"] == {"enabled": True, "effort": "high"}
 
 
+def test_run_agent_respects_ignore_rules_env(monkeypatch):
+    monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda: {})
+    monkeypatch.setattr(gateway_run, "load_dotenv", lambda *args, **kwargs: None)
+    monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", _explode_runtime_resolution)
+    monkeypatch.setenv("HERMES_IGNORE_RULES", "1")
+
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = _CapturingAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+    _CapturingAgent.last_init = None
+    runner = _make_runner()
+
+    source = SessionSource(
+        platform=Platform.LOCAL,
+        chat_id="cli",
+        chat_name="CLI",
+        chat_type="dm",
+        user_id="user-1",
+    )
+    session_key = "agent:main:local:dm"
+    runner._session_model_overrides[session_key] = _codex_override()
+
+    result = asyncio.run(
+        runner._run_agent(
+            message="ping",
+            context_prompt="",
+            history=[],
+            source=source,
+            session_id="session-1",
+            session_key=session_key,
+        )
+    )
+
+    assert result["final_response"] == "ok"
+    assert _CapturingAgent.last_init is not None
+    assert _CapturingAgent.last_init["skip_context_files"] is True
+    assert _CapturingAgent.last_init["skip_memory"] is True
+
+
 @pytest.mark.asyncio
 async def test_background_task_prefers_session_override_over_global_runtime(monkeypatch):
     monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda: {})
@@ -163,6 +203,42 @@ async def test_background_task_prefers_session_override_over_global_runtime(monk
     assert _CapturingAgent.last_init["base_url"] == "https://chatgpt.com/backend-api/codex"
     assert _CapturingAgent.last_init["api_key"] == "***"
     assert _CapturingAgent.last_init["reasoning_config"] == {"enabled": True, "effort": "high"}
+
+
+@pytest.mark.asyncio
+async def test_background_task_respects_ignore_rules_env(monkeypatch):
+    monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda: {})
+    monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", _explode_runtime_resolution)
+    monkeypatch.setenv("HERMES_IGNORE_RULES", "1")
+
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = _CapturingAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+    _CapturingAgent.last_init = None
+    runner = _make_runner()
+
+    adapter = AsyncMock()
+    adapter.send = AsyncMock()
+    adapter.extract_media = MagicMock(return_value=([], "ok"))
+    adapter.extract_images = MagicMock(return_value=([], "ok"))
+    runner.adapters[Platform.TELEGRAM] = adapter
+
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        user_id="12345",
+        chat_id="67890",
+        user_name="testuser",
+    )
+    session_key = runner._session_key_for_source(source)
+    runner._session_model_overrides[session_key] = _codex_override()
+
+    await runner._run_background_task("say hello", source, "bg_test")
+
+    assert _CapturingAgent.last_init is not None
+    assert _CapturingAgent.last_init["skip_context_files"] is True
+    assert _CapturingAgent.last_init["skip_memory"] is True
+
 
 def test_gateway_auth_fallback_uses_fallback_model_from_config(tmp_path, monkeypatch):
     """Regression: fallback provider must not inherit the primary model.
@@ -217,4 +293,3 @@ fallback_providers:
     assert model == "minimax/minimax-m2.7"
     assert runtime_kwargs["provider"] == "openrouter"
     assert runtime_kwargs["api_key"] == "sk-openrouter"
-


### PR DESCRIPTION
## What changed
This threads `HERMES_IGNORE_RULES` through the two gateway `AIAgent(...)` construction paths that were still missing it:

- the main cached/session agent path in `gateway/run.py`
- the `/background` task path in `gateway/run.py`

I also added regression coverage for both paths in `tests/gateway/test_session_model_override_routing.py`.

## Why
`cli.py` already turns `HERMES_IGNORE_RULES=1` into `skip_context_files=True` and `skip_memory=True`, but gateway sessions were still building fresh agents without those flags. That meant Telegram and other gateway-driven sessions could keep injecting memory and context files even when the env var was set.

## Validation
I couldn't get a full working clone of this repo to complete cleanly in this environment, so I wasn't able to run the repo's pytest target here. I did at least verify the edited Python files compile with `python3 -m py_compile`.

Fixes #29911.
