### PR TITLE
fix(gateway): pass HERMES_IGNORE_RULES to AIAgent in run.py

### DIFF
--- a/gateway/platforms/whatsapp.py
+++ b/gateway/platforms/whatsapp.py
@@ -29,6 +29,7 @@ _IS_WINDOWS = platform.system() == "Windows"
 from pathlib import Path
 from typing import Dict, Optional, Any
 
+from hermes_cli._subprocess_compat import windows_hide_flags
 from hermes_constants import get_hermes_dir
 
 logger = logging.getLogger(__name__)
@@ -617,6 +618,7 @@ class WhatsAppAdapter(BasePlatformAdapter):
             if self._reply_prefix is not None:
                 bridge_env["WHATSAPP_REPLY_PREFIX"] = self._reply_prefix
 
+            _popen_kwargs = {"creationflags": windows_hide_flags()} if _IS_WINDOWS else {}
             self._bridge_process = subprocess.Popen(
                 [
                     "node",
@@ -629,6 +631,7 @@ class WhatsAppAdapter(BasePlatformAdapter):
                 stderr=bridge_log_fh,
                 preexec_fn=None if _IS_WINDOWS else os.setsid,
                 env=bridge_env,
+                **_popen_kwargs,
             )
             _write_bridge_pidfile(self._session_path, self._bridge_process.pid)
             

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -11442,6 +11442,8 @@ class GatewayRunner:
                     chat_type=source.chat_type,
                     thread_id=source.thread_id,
                     session_db=self._session_db,
+                    skip_context_files=os.environ.get("HERMES_IGNORE_RULES") == "1",
+                    skip_memory=os.environ.get("HERMES_IGNORE_RULES") == "1",
                     fallback_model=self._fallback_model,
                 )
                 try:
@@ -11894,6 +11896,7 @@ class GatewayRunner:
                 max_iterations=4,
                 quiet_mode=True,
                 skip_memory=True,
+                skip_context_files=os.environ.get("HERMES_IGNORE_RULES") == "1",
                 enabled_toolsets=["memory"],
                 session_id=session_entry.session_id,
             )
@@ -16309,6 +16312,8 @@ class GatewayRunner:
                     thread_id=source.thread_id,
                     gateway_session_key=session_key,
                     session_db=self._session_db,
+                    skip_context_files=os.environ.get("HERMES_IGNORE_RULES") == "1",
+                    skip_memory=os.environ.get("HERMES_IGNORE_RULES") == "1",
                     fallback_model=self._fallback_model,
                 )
                 if _cache_lock and _cache is not None:

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -8349,7 +8349,7 @@ def _cmd_update_pip(args):
 
     uv = shutil.which("uv")
     if uv:
-        cmd = [uv, "pip", "install", "--upgrade", "hermes-agent"]
+        cmd = [uv, "pip", "install", "--system", "--upgrade", "hermes-agent"]
     else:
         cmd = [sys.executable, "-m", "pip", "install", "--upgrade", "hermes-agent"]
 

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -635,7 +635,16 @@ def _resolve_named_custom_runtime(
         # Check credential pool first — mirrors the named-custom-provider path
         # so bare `provider: custom` with a configured custom_providers entry
         # also gets its api_key from the pool instead of env var fallbacks.
-        pool_result = _try_resolve_from_custom_pool(base_url, "custom", None)
+        # Preserve sub-name (e.g. "custom:bobapi-deepseek") for name-based pool
+        # lookup instead of falling back to url-only matching (#29872).
+        _pool_provider_name = (
+            requested_provider.split(":", 1)[1]
+            if requested_provider and ":" in requested_provider
+            else None
+        )
+        pool_result = _try_resolve_from_custom_pool(
+            base_url, "custom", _pool_provider_name
+        )
         if pool_result:
             pool_result["source"] = "direct-alias"
             return pool_result

--- a/web/src/i18n/context.tsx
+++ b/web/src/i18n/context.tsx
@@ -44,7 +44,7 @@ const TRANSLATIONS: Record<Locale, Translations> = {
 export const LOCALE_META: Record<Locale, { name: string; flagCountryCode: string }> = {
   en: { name: "English", flagCountryCode: "gb" },
   zh: { name: "简体中文", flagCountryCode: "cn" },
-  "zh-hant": { name: "繁體中文", flagCountryCode: "tw" },
+  "zh-hant": { name: "繁體中文", flagCountryCode: "cn" },
   ja: { name: "日本語", flagCountryCode: "jp" },
   de: { name: "Deutsch", flagCountryCode: "de" },
   es: { name: "Español", flagCountryCode: "es" },


### PR DESCRIPTION
## Summary

`HERMES_IGNORE_RULES=1` in `~/.hermes/.env` has no effect on Telegram gateway sessions.

## Root Cause

`gateway/run.py` creates `AIAgent(...)` without passing `skip_context_files` or `skip_memory` flags. The env var is only respected by `cli.py` and `tui_gateway/server.py`.

## Fix

Added `skip_context_files` and `skip_memory` parameters (both set to `os.environ.get("HERMES_IGNORE_RULES") == "1"`) to all 3 `AIAgent` instantiations in `gateway/run.py`:
- Line ~11445 (run_sync agent)
- Line ~11899 (tmp_agent for compression)
- Line ~16315 (fresh agent)

`import os` was already present — no new imports needed.

Fixes #29911