### PR TITLE
fix: prevent Discord NO_REPLY bot loops

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -3156,6 +3156,9 @@ class BasePlatformAdapter(ABC):
                 response = None
             if not response:
                 logger.debug("[%s] Handler returned empty/None response for %s", self.name, event.source.chat_id)
+            elif isinstance(response, str) and response.strip() == "NO_REPLY":
+                logger.info("[%s] Handler returned NO_REPLY for %s; suppressing delivery", self.name, event.source.chat_id)
+                response = None
             if response:
                 # Capture [[as_document]] before extract_media strips it, so the
                 # dispatch partition below can route image-extension files

--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -748,6 +748,19 @@ class DiscordAdapter(BasePlatformAdapter):
                 # permitted by DISCORD_ALLOW_BOTS are not rejected for
                 # not being in DISCORD_ALLOWED_USERS (fixes #4466).
                 if getattr(message.author, "bot", False):
+                    bot_text = getattr(message, "clean_content", None)
+                    if not isinstance(bot_text, str):
+                        bot_text = message.content or ""
+                    bot_text = bot_text.strip()
+                    if bot_text == "NO_REPLY":
+                        logger.info(
+                            "[%s] Ignoring bot NO_REPLY sentinel from %s in %s",
+                            self.name,
+                            getattr(message.author, "id", "unknown"),
+                            getattr(message.channel, "id", "unknown"),
+                        )
+                        return
+
                     allow_bots = os.getenv("DISCORD_ALLOW_BOTS", "none").lower().strip()
                     if allow_bots == "none":
                         return
@@ -3784,6 +3797,10 @@ class DiscordAdapter(BasePlatformAdapter):
                     continue
 
                 content = getattr(msg, "clean_content", msg.content) or ""
+                if not isinstance(content, str):
+                    content = msg.content or ""
+                if getattr(msg.author, "bot", False) and content.strip() == "NO_REPLY":
+                    continue
                 if not content and msg.attachments:
                     content = "(attachment)"
                 if not content:

--- a/tests/gateway/test_discord_bot_filter.py
+++ b/tests/gateway/test_discord_bot_filter.py
@@ -48,6 +48,13 @@ class TestDiscordBotFilter(unittest.TestCase):
             return False  # own messages always ignored
 
         if getattr(message.author, "bot", False):
+            bot_text = getattr(message, "clean_content", None)
+            if not isinstance(bot_text, str):
+                bot_text = message.content or ""
+            bot_text = bot_text.strip()
+            if bot_text == "NO_REPLY":
+                return False
+
             allow = allow_bots.lower().strip()
             if allow == "none":
                 return False
@@ -97,6 +104,14 @@ class TestDiscordBotFilter(unittest.TestCase):
         bot = _make_author(bot=True)
         msg = _make_message(author=bot, mentions=[our_user])
         self.assertTrue(self._run_filter(msg, "mentions", our_user))
+
+    def test_bot_no_reply_sentinel_always_rejected(self):
+        """Bot NO_REPLY sentinel messages are control tokens, not prompts."""
+        our_user = _make_author(is_self=True)
+        bot = _make_author(bot=True)
+        msg = _make_message(author=bot, content="NO_REPLY", mentions=[our_user])
+        self.assertFalse(self._run_filter(msg, "mentions", our_user))
+        self.assertFalse(self._run_filter(msg, "all", our_user))
 
     def test_default_is_none(self):
         """Default behavior (no env var) should be 'none'."""


### PR DESCRIPTION
## Summary

- Drop Discord bot messages whose content is exactly `NO_REPLY` before they can enter the agent loop
- Exclude bot `NO_REPLY` sentinel messages from Discord channel history backfill
- Suppress literal `NO_REPLY` platform responses at delivery time
- Add regression coverage for the Discord bot filter behavior

## Why

When bot-to-bot routing is enabled with `DISCORD_ALLOW_BOTS=mentions`, a bot `NO_REPLY` sentinel can be treated as a real prompt. If the receiving agent then intentionally stays silent, the gateway can surface empty-response retries and create noisy bot-to-bot loops. `NO_REPLY` should behave as a control/silence token, not a user prompt.

## Verification

- `./venv/bin/python -m pytest tests/gateway/test_discord_bot_filter.py tests/gateway/test_discord_bot_auth_bypass.py -q`
