### PR TITLE
feat(feishu): env-var fallback when no Feishu comment context

### DIFF
--- a/tools/feishu_doc_tool.py
+++ b/tools/feishu_doc_tool.py
@@ -66,6 +66,20 @@ def _check_feishu():
         return False
 
 
+def _build_client() -> Optional[Any]:
+    """Build a lark client from env vars (fallback when set_client wasn't called)."""
+    import os
+    app_id = os.getenv("FEISHU_APP_ID", "").strip()
+    app_secret = os.getenv("FEISHU_APP_SECRET", "").strip()
+    if not app_id or not app_secret:
+        return None
+    try:
+        from lark_oapi import Client
+        return Client(app_id=app_id, app_secret=app_secret)
+    except Exception:
+        return None
+
+
 def _handle_feishu_doc_read(args: dict, **kwargs) -> str:
     doc_token = args.get("doc_token", "").strip()
     if not doc_token:
@@ -73,7 +87,12 @@ def _handle_feishu_doc_read(args: dict, **kwargs) -> str:
 
     client = get_client()
     if client is None:
-        return tool_error("Feishu client not available (not in a Feishu comment context)")
+        client = _build_client()
+    if client is None:
+        return tool_error(
+            "Feishu client not available. Set FEISHU_APP_ID and FEISHU_APP_SECRET env vars, "
+            "or use this tool within a Feishu comment context."
+        )
 
     try:
         from lark_oapi import AccessTokenType

--- a/tools/feishu_drive_tool.py
+++ b/tools/feishu_drive_tool.py
@@ -27,6 +27,27 @@ def get_client():
     return getattr(_local, "client", None)
 
 
+def _build_client() -> Optional[Any]:
+    """Build a lark client from env vars (fallback when set_client wasn't called)."""
+    import os
+    app_id = os.getenv("FEISHU_APP_ID", "").strip()
+    app_secret = os.getenv("FEISHU_APP_SECRET", "").strip()
+    if not app_id or not app_secret:
+        return None
+    try:
+        from lark_oapi import Client
+        return Client(app_id=app_id, app_secret=app_secret)
+    except Exception:
+        return None
+
+
+def _get_client_with_fallback():
+    client = get_client()
+    if client is None:
+        client = _build_client()
+    return client
+
+
 def _check_feishu():
     # See ``tools/feishu_doc_tool.py::_check_feishu`` — ``find_spec`` keeps
     # CLI startup fast (the SDK itself takes ~5s to import eagerly).
@@ -131,9 +152,12 @@ FEISHU_DRIVE_LIST_COMMENTS_SCHEMA = {
 
 
 def _handle_list_comments(args: dict, **kwargs) -> str:
-    client = get_client()
+    client = _get_client_with_fallback()
     if client is None:
-        return tool_error("Feishu client not available")
+        return tool_error(
+            "Feishu client not available. Set FEISHU_APP_ID and FEISHU_APP_SECRET env vars, "
+            "or use this tool within a Feishu comment context."
+        )
 
     file_token = args.get("file_token", "").strip()
     if not file_token:
@@ -206,9 +230,12 @@ FEISHU_DRIVE_LIST_REPLIES_SCHEMA = {
 
 
 def _handle_list_replies(args: dict, **kwargs) -> str:
-    client = get_client()
+    client = _get_client_with_fallback()
     if client is None:
-        return tool_error("Feishu client not available")
+        return tool_error(
+            "Feishu client not available. Set FEISHU_APP_ID and FEISHU_APP_SECRET env vars, "
+            "or use this tool within a Feishu comment context."
+        )
 
     file_token = args.get("file_token", "").strip()
     comment_id = args.get("comment_id", "").strip()
@@ -278,9 +305,12 @@ FEISHU_DRIVE_REPLY_SCHEMA = {
 
 
 def _handle_reply_comment(args: dict, **kwargs) -> str:
-    client = get_client()
+    client = _get_client_with_fallback()
     if client is None:
-        return tool_error("Feishu client not available")
+        return tool_error(
+            "Feishu client not available. Set FEISHU_APP_ID and FEISHU_APP_SECRET env vars, "
+            "or use this tool within a Feishu comment context."
+        )
 
     file_token = args.get("file_token", "").strip()
     comment_id = args.get("comment_id", "").strip()
@@ -349,9 +379,12 @@ FEISHU_DRIVE_ADD_COMMENT_SCHEMA = {
 
 
 def _handle_add_comment(args: dict, **kwargs) -> str:
-    client = get_client()
+    client = _get_client_with_fallback()
     if client is None:
-        return tool_error("Feishu client not available")
+        return tool_error(
+            "Feishu client not available. Set FEISHU_APP_ID and FEISHU_APP_SECRET env vars, "
+            "or use this tool within a Feishu comment context."
+        )
 
     file_token = args.get("file_token", "").strip()
     content = args.get("content", "").strip()


### PR DESCRIPTION
## Summary

`feishu_doc_tool` and `feishu_drive_tool` currently bail out with `"Feishu client not available (not in a Feishu comment context)"` whenever `get_client()` returns `None`. That's the correct behaviour for the in-app comment-callback path (where the host hands a pre-authenticated `lark.Client` to the tool via `set_client`), but it blocks every other use case — most notably any **headless agent** invoked by cron / systemd / a long-running profile that wants to read Feishu docs or list comments on its own schedule.

This PR adds a small env-var fallback so those tools become usable outside the comment context, without changing in-context behaviour.

## What changes

- New `_build_client()` helper in both `tools/feishu_doc_tool.py` and `tools/feishu_drive_tool.py` that constructs a `lark_oapi.Client` from `FEISHU_APP_ID` / `FEISHU_APP_SECRET` env vars.
- Tool handlers fall through `get_client() → _build_client() → error` instead of `get_client() → error`.
- Updated error message points users to either set the env vars or invoke from a comment context.

## What does not change

- `set_client()` / comment-callback path is untouched — `get_client()` still wins when a host-provided client is present.
- If neither path yields a client, the tool still errors out with a clearer message.
- No new dependencies (`lark_oapi.Client` is already a transitive dep of the existing code).

## Motivation

We run a janemain profile that polls Feishu docs on a schedule. Before this PR, the only way to make the feishu tools work in that environment was a local patch — exactly what this PR upstreams.

## Test plan

- [x] Local: janemain agent (no Feishu comment context, `FEISHU_APP_ID`/`SECRET` in env) successfully reads docs and lists comments via these tools.
- [x] Local: with env vars unset, the new error message fires and the original failure mode is preserved.
- [ ] Maintainers may want to verify against the comment-callback path on a real Feishu deployment (no behaviour change expected since `get_client()` still short-circuits when set).

🤖 Generated with [Claude Code](https://claude.com/claude-code)