### PR TITLE
fix: resolve TUI and website typecheck failures

### DIFF
--- a/ui-tui/package.json
+++ b/ui-tui/package.json
@@ -12,6 +12,7 @@
     "lint:fix": "eslint src/ packages/ --fix",
     "fmt": "prettier --write 'src/**/*.{ts,tsx}' 'packages/**/*.{ts,tsx}'",
     "fix": "npm run lint:fix && npm run fmt",
+    "pretest": "npm run build --prefix packages/hermes-ink",
     "test": "vitest run",
     "test:watch": "vitest"
   },

--- a/ui-tui/packages/hermes-ink/src/utils/execFileNoThrow.ts
+++ b/ui-tui/packages/hermes-ink/src/utils/execFileNoThrow.ts
@@ -1,4 +1,4 @@
-import { spawn } from 'child_process'
+import { spawn, type ChildProcess, type StdioOptions } from 'child_process'
 type ExecFileOptions = {
   input?: string
   timeout?: number
@@ -32,11 +32,11 @@ export function execFileNoThrow(
     // doesn't inherit those pipe FDs — prevents handle leaks that can
     // keep the parent process alive. No output data is collected in
     // this mode; both stdout and stderr will be empty strings.
-    const stdioConfig = options.resolveOnExit
-      ? ['pipe', 'ignore', 'ignore'] as const
-      : 'pipe' as const
+    const stdioConfig: StdioOptions = options.resolveOnExit
+      ? ['pipe', 'ignore', 'ignore']
+      : 'pipe'
 
-    const child = spawn(file, args, {
+    const child: ChildProcess = spawn(file, args, {
       cwd: options.useCwd ? process.cwd() : undefined,
       env: options.env,
       stdio: stdioConfig
@@ -80,10 +80,10 @@ export function execFileNoThrow(
         }, options.timeout)
       : null
 
-    child.stdout?.on('data', chunk => {
+    child.stdout?.on('data', (chunk: Buffer) => {
       stdout += String(chunk)
     })
-    child.stderr?.on('data', chunk => {
+    child.stderr?.on('data', (chunk: Buffer) => {
       stderr += String(chunk)
     })
     child.on('error', error => {

--- a/website/package.json
+++ b/website/package.json
@@ -14,6 +14,7 @@
     "serve": "docusaurus serve",
     "write-translations": "docusaurus write-translations",
     "write-heading-ids": "docusaurus write-heading-ids",
+    "pretypecheck": "node scripts/prebuild.mjs",
     "typecheck": "tsc",
     "lint:diagrams": "ascii-guard lint --exclude-code-blocks docs"
   },

--- a/website/src/components/UserStoriesCollage/index.tsx
+++ b/website/src/components/UserStoriesCollage/index.tsx
@@ -145,7 +145,7 @@ function sourceColor(source: string): string {
   }
 }
 
-export default function UserStoriesCollage(): JSX.Element {
+export default function UserStoriesCollage(): React.ReactElement {
   const [activeCategory, setActiveCategory] = useState<string>('all');
   const [activeSource, setActiveSource] = useState<string>('all');
 


### PR DESCRIPTION
## Summary
- fix `execFileNoThrow` child process typing by using explicit `StdioOptions` and `ChildProcess` types
- add a TUI `pretest` hook to build the local `@hermes/ink` package before Vitest imports it
- make website typecheck run the docs prebuild so generated `skills.json` exists
- replace `JSX.Element` annotation with `React.ReactElement` for the Docusaurus/React TS setup

## Verification
- `git diff --check`
- `npm --prefix ui-tui run type-check`
- `npm --prefix ui-tui test` — 75 files, 814 passed, 1 skipped
- `npm --prefix website run typecheck`
- `npm --prefix website run build` — succeeds with existing broken-link/broken-anchor warnings

## Notes
- PR #29819 could not be merged by my current GitHub token: branch policy blocks normal merge, admin merge/auto-merge require permissions this token does not have.
