### PR TITLE
fix: preserve Discord slash command reply anchors

### DIFF
--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -2882,6 +2882,8 @@ class DiscordAdapter(BasePlatformAdapter):
         interaction: discord.Interaction,
         command_text: str,
         followup_msg: str | None = None,
+        *,
+        visible_anchor: bool = False,
     ) -> None:
         """Common handler for simple slash commands that dispatch a command string.
 
@@ -2889,6 +2891,11 @@ class DiscordAdapter(BasePlatformAdapter):
         then cleans up the deferred response.  If *followup_msg* is provided
         the "thinking..." indicator is replaced with that text; otherwise it
         is deleted so the channel isn't cluttered.
+
+        ``visible_anchor=True`` makes the interaction response public and keeps
+        it as a reply target.  Discord slash commands do not have a normal
+        channel message ID, so queued/backgrounded follow-ups otherwise break
+        the visible reply chain.
         """
         # Log the invoker so ghost-command reports can be triaged.  Discord
         # native slash invocations are always user-initiated (no bot can fire
@@ -2913,12 +2920,31 @@ class DiscordAdapter(BasePlatformAdapter):
         if not await self._check_slash_authorization(interaction, command_text):
             return
 
-        await interaction.response.defer(ephemeral=True)
+        await interaction.response.defer(ephemeral=not visible_anchor)
         event = self._build_slash_event(interaction, command_text)
+
+        if visible_anchor:
+            try:
+                original = await interaction.original_response()
+                original_id = getattr(original, "id", None)
+                if original_id is not None:
+                    event.message_id = str(original_id)
+                    try:
+                        event.source.message_id = str(original_id)
+                    except Exception:
+                        pass
+            except Exception as e:
+                logger.debug("Discord slash visible anchor lookup failed: %s", e)
+
         await self.handle_message(event)
         try:
             if followup_msg:
                 await interaction.edit_original_response(content=followup_msg)
+            elif visible_anchor:
+                preview = command_text.strip()
+                if len(preview) > 180:
+                    preview = preview[:177] + "..."
+                await interaction.edit_original_response(content=preview or "Queued.")
             else:
                 await interaction.delete_original_response()
         except Exception as e:
@@ -2977,7 +3003,13 @@ class DiscordAdapter(BasePlatformAdapter):
         @tree.command(name="steer", description="Inject a message after the next tool call (no interrupt)")
         @discord.app_commands.describe(prompt="Text to inject into the agent's next tool result")
         async def slash_steer(interaction: discord.Interaction, prompt: str):
-            await self._run_simple_slash(interaction, f"/steer {prompt}".strip())
+            preview = prompt[:120] + ("..." if len(prompt) > 120 else "")
+            await self._run_simple_slash(
+                interaction,
+                f"/steer {prompt}".strip(),
+                f"Steer: {preview}",
+                visible_anchor=True,
+            )
 
         @tree.command(name="compress", description="Compress conversation context")
         async def slash_compress(interaction: discord.Interaction):
@@ -3069,12 +3101,35 @@ class DiscordAdapter(BasePlatformAdapter):
         @tree.command(name="queue", description="Queue a prompt for the next turn (doesn't interrupt)")
         @discord.app_commands.describe(prompt="The prompt to queue")
         async def slash_queue(interaction: discord.Interaction, prompt: str):
-            await self._run_simple_slash(interaction, f"/queue {prompt}", "Queued for the next turn.")
+            preview = prompt[:120] + ("..." if len(prompt) > 120 else "")
+            await self._run_simple_slash(
+                interaction,
+                f"/queue {prompt}",
+                f"Queued: {preview}",
+                visible_anchor=True,
+            )
 
         @tree.command(name="background", description="Run a prompt in the background")
         @discord.app_commands.describe(prompt="The prompt to run in the background")
         async def slash_background(interaction: discord.Interaction, prompt: str):
-            await self._run_simple_slash(interaction, f"/background {prompt}", "Background task started~")
+            preview = prompt[:120] + ("..." if len(prompt) > 120 else "")
+            await self._run_simple_slash(
+                interaction,
+                f"/background {prompt}",
+                f"Background: {preview}",
+                visible_anchor=True,
+            )
+
+        @tree.command(name="btw", description="Run a side prompt in the background")
+        @discord.app_commands.describe(prompt="The side prompt to run in the background")
+        async def slash_btw(interaction: discord.Interaction, prompt: str):
+            preview = prompt[:120] + ("..." if len(prompt) > 120 else "")
+            await self._run_simple_slash(
+                interaction,
+                f"/btw {prompt}",
+                f"BTW: {preview}",
+                visible_anchor=True,
+            )
 
         # ── Auto-register any gateway-available commands not yet on the tree ──
         # This ensures new commands added to COMMAND_REGISTRY in

--- a/tests/gateway/test_discord_slash_commands.py
+++ b/tests/gateway/test_discord_slash_commands.py
@@ -97,7 +97,14 @@ class FakeTree:
 
 
 @pytest.fixture
-def adapter():
+def adapter(monkeypatch):
+    for key in (
+        "DISCORD_ALLOWED_CHANNELS",
+        "DISCORD_IGNORED_CHANNELS",
+        "DISCORD_NO_THREAD_CHANNELS",
+        "DISCORD_FREE_RESPONSE_CHANNELS",
+    ):
+        monkeypatch.delenv(key, raising=False)
     config = PlatformConfig(enabled=True, token="***")
     adapter = DiscordAdapter(config)
     adapter._client = SimpleNamespace(
@@ -156,6 +163,88 @@ async def test_registers_native_restart_slash_command(adapter):
         "/restart",
         "Restart requested~",
     )
+
+
+@pytest.mark.asyncio
+async def test_queue_steer_background_and_btw_use_visible_reply_anchor(adapter):
+    adapter._run_simple_slash = AsyncMock()
+    adapter._register_slash_commands()
+
+    assert "queue" in adapter._client.tree.commands
+    assert "steer" in adapter._client.tree.commands
+    assert "background" in adapter._client.tree.commands
+    assert "btw" in adapter._client.tree.commands
+
+    interaction = SimpleNamespace()
+
+    await adapter._client.tree.commands["queue"](interaction, prompt="next thing")
+    adapter._run_simple_slash.assert_awaited_with(
+        interaction,
+        "/queue next thing",
+        "Queued: next thing",
+        visible_anchor=True,
+    )
+
+    adapter._run_simple_slash.reset_mock()
+    await adapter._client.tree.commands["steer"](interaction, prompt="steer this")
+    adapter._run_simple_slash.assert_awaited_with(
+        interaction,
+        "/steer steer this",
+        "Steer: steer this",
+        visible_anchor=True,
+    )
+
+    adapter._run_simple_slash.reset_mock()
+    await adapter._client.tree.commands["background"](interaction, prompt="side quest")
+    adapter._run_simple_slash.assert_awaited_with(
+        interaction,
+        "/background side quest",
+        "Background: side quest",
+        visible_anchor=True,
+    )
+
+    adapter._run_simple_slash.reset_mock()
+    await adapter._client.tree.commands["btw"](interaction, prompt="also check x")
+    adapter._run_simple_slash.assert_awaited_with(
+        interaction,
+        "/btw also check x",
+        "BTW: also check x",
+        visible_anchor=True,
+    )
+
+
+@pytest.mark.asyncio
+async def test_run_simple_slash_visible_anchor_uses_original_response_as_message_id(adapter):
+    captured_events = []
+
+    async def capture_handle(event):
+        captured_events.append(event)
+
+    adapter.handle_message = capture_handle
+    interaction = SimpleNamespace(
+        channel=SimpleNamespace(id=123, name="ops", guild=SimpleNamespace(name="Server")),
+        channel_id=123,
+        user=SimpleNamespace(id=42, display_name="Conor"),
+        response=SimpleNamespace(defer=AsyncMock()),
+        original_response=AsyncMock(return_value=SimpleNamespace(id=98765)),
+        edit_original_response=AsyncMock(),
+        delete_original_response=AsyncMock(),
+    )
+
+    await adapter._run_simple_slash(
+        interaction,
+        "/queue next thing",
+        "Queued: next thing",
+        visible_anchor=True,
+    )
+
+    interaction.response.defer.assert_awaited_once_with(ephemeral=False)
+    interaction.original_response.assert_awaited_once()
+    interaction.edit_original_response.assert_awaited_once_with(content="Queued: next thing")
+    interaction.delete_original_response.assert_not_awaited()
+    assert len(captured_events) == 1
+    assert captured_events[0].message_id == "98765"
+    assert captured_events[0].source.message_id == "98765"
 
 
 # ------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Use visible Discord interaction responses for `/queue`, `/steer`, `/background`, and `/btw` so follow-up work has a concrete message anchor.
- Add a native `/btw` slash command.
- Add tests for visible reply anchoring and command registration.

## Test plan
- `python -m pytest tests/gateway/test_discord_slash_commands.py -q`
