### PR TITLE
fix(gateway): keep Telegram topic routing explicit

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2081,8 +2081,11 @@ class GatewayRunner:
         and ``_build_message_event`` strips the thread_id on plain replies
         (#3206 — needed for non-topic users). Both route the user to the
         wrong session. When topic mode is on, rewrite the thread_id to the
-        user's most-recent binding if the inbound id is missing/General or
-        not a known topic for this chat. Returns None to leave it alone.
+        user's most-recent binding only when the inbound id is missing or
+        General/root. Explicit non-General topic ids are authoritative even
+        when not yet bound; otherwise the first message in a newly opened topic
+        gets forced back into the user's previous topic. Returns None to leave
+        it alone.
         """
         if (
             source.platform != Platform.TELEGRAM
@@ -2106,8 +2109,12 @@ class GatewayRunner:
             return None
         inbound = str(source.thread_id or "")
         is_lobby = not inbound or inbound in self._TELEGRAM_GENERAL_TOPIC_IDS
-        known = {str(b.get("thread_id") or "") for b in bindings}
-        if not is_lobby and inbound in known:
+        if not is_lobby:
+            # Trust explicit non-General Telegram DM-topic ids.  Rewriting every
+            # unknown topic to the user's last-active binding makes newly opened
+            # topics unusable: all messages get forced back into an older topic.
+            # Recovery is only safe when Telegram stripped the topic id or sent
+            # the root/General lane.
             return None
         user_id = str(source.user_id)
         for b in bindings:  # newest-first

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2038,6 +2038,38 @@ class GatewayRunner:
             session_id=session_entry.session_id,
         )
 
+    def _sync_telegram_topic_binding(
+        self,
+        source: SessionSource,
+        session_entry,
+        *,
+        reason: str,
+    ) -> None:
+        """Keep topic-mode Telegram bindings aligned with session rotations.
+
+        Compression rotates the underlying Hermes session_id while the
+        Telegram topic thread_id stays the same. If the topic binding is left
+        pointing at the pre-compression session, the next message in that topic
+        gets rebound to the oversized parent transcript and can compact again.
+        """
+        if not self._is_telegram_topic_lane(source):
+            return
+        try:
+            self._record_telegram_topic_binding(source, session_entry)
+            logger.info(
+                "telegram topic binding synced after %s: chat=%s thread=%s session=%s",
+                reason,
+                source.chat_id,
+                source.thread_id,
+                session_entry.session_id,
+            )
+        except Exception:
+            logger.debug(
+                "Failed to sync Telegram topic binding after %s",
+                reason,
+                exc_info=True,
+            )
+
     def _recover_telegram_topic_thread_id(
         self,
         source: SessionSource,
@@ -8247,6 +8279,11 @@ class GatewayRunner:
                                     if _hyg_new_sid != session_entry.session_id:
                                         session_entry.session_id = _hyg_new_sid
                                         self.session_store._save()
+                                        self._sync_telegram_topic_binding(
+                                            source,
+                                            session_entry,
+                                            reason="hygiene-compression",
+                                        )
 
                                     self.session_store.rewrite_transcript(
                                         session_entry.session_id, _compressed
@@ -8508,9 +8545,16 @@ class GatewayRunner:
             response = _sanitize_gateway_final_response(source.platform, response)
 
             # If the agent's session_id changed during compression, update
-            # session_entry so transcript writes below go to the right session.
+            # session_entry so transcript writes below go to the right session,
+            # and keep Telegram topic-mode's thread_id -> session_id binding
+            # from snapping the next turn back to the oversized parent session.
             if agent_result.get("session_id") and agent_result["session_id"] != session_entry.session_id:
                 session_entry.session_id = agent_result["session_id"]
+                self._sync_telegram_topic_binding(
+                    source,
+                    session_entry,
+                    reason="agent-compression",
+                )
 
             # Prepend reasoning/thinking if display is enabled (per-platform)
             try:

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2219,8 +2219,6 @@ WantedBy=multi-user.target
     sane_path = ":".join(path_entries)
     return f"""[Unit]
 Description={SERVICE_DESCRIPTION}
-After=network-online.target
-Wants=network-online.target
 StartLimitIntervalSec=0
 
 [Service]

--- a/tests/gateway/test_telegram_topic_mode.py
+++ b/tests/gateway/test_telegram_topic_mode.py
@@ -267,6 +267,62 @@ async def test_managed_topic_binding_reuses_restored_session_over_static_lane_se
 
 
 @pytest.mark.asyncio
+async def test_topic_binding_follows_session_id_rotation_after_compression(
+    tmp_path, monkeypatch
+):
+    import gateway.run as gateway_run
+
+    session_db = SessionDB(db_path=tmp_path / "state.db")
+    session_db.enable_telegram_topic_mode(chat_id="208214988", user_id="208214988")
+    session_key = build_session_key(_make_source(thread_id="17585"))
+    session_db.create_session(
+        session_id="oversized-parent-session",
+        source="telegram",
+        user_id="208214988",
+    )
+    session_db.create_session(
+        session_id="compressed-child-session",
+        source="telegram",
+        user_id="208214988",
+        parent_session_id="oversized-parent-session",
+    )
+    session_db.bind_telegram_topic(
+        chat_id="208214988",
+        thread_id="17585",
+        user_id="208214988",
+        session_key=session_key,
+        session_id="oversized-parent-session",
+    )
+    runner = _make_runner(session_db=session_db)
+
+    async def fake_run_agent(*args, **kwargs):
+        assert kwargs.get("session_id") == "oversized-parent-session"
+        return {
+            "success": True,
+            "final_response": "compressed response",
+            "session_id": "compressed-child-session",
+            "messages": [],
+            "last_prompt_tokens": 1234,
+        }
+
+    runner._run_agent = AsyncMock(side_effect=fake_run_agent)
+
+    monkeypatch.setattr(
+        gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"}
+    )
+
+    result = await runner._handle_message(_make_event("continue", thread_id="17585"))
+
+    assert result == "compressed response"
+    binding = session_db.get_telegram_topic_binding(
+        chat_id="208214988",
+        thread_id="17585",
+    )
+    assert binding is not None
+    assert binding["session_id"] == "compressed-child-session"
+
+
+@pytest.mark.asyncio
 async def test_telegram_group_prompt_is_not_topic_lobby_even_when_dm_topic_mode_enabled(
     tmp_path, monkeypatch
 ):

--- a/tests/gateway/test_telegram_topic_mode.py
+++ b/tests/gateway/test_telegram_topic_mode.py
@@ -1231,22 +1231,24 @@ def test_recover_returns_none_for_known_topic(tmp_path):
     assert runner._recover_telegram_topic_thread_id(_make_source(thread_id="222")) is None
 
 
-def test_recover_rewrites_unknown_thread_id_to_most_recent(tmp_path):
-    # Cross-topic Reply leak: inbound thread_id is a Telegram-only id we never bound.
+def test_recover_returns_none_for_unknown_explicit_topic_id(tmp_path):
+    # First message in a new Telegram topic is explicit but not bound yet.
+    # Do not force it back into the user's last-active topic.
     db = SessionDB(db_path=tmp_path / "state.db")
     _seed_two_topic_bindings(db)
     runner = _make_runner(session_db=db)
 
-    assert runner._recover_telegram_topic_thread_id(_make_source(thread_id="9999")) == "222"
+    assert runner._recover_telegram_topic_thread_id(_make_source(thread_id="9999")) is None
 
 
-def test_recover_rewrites_lobby_thread_id_to_most_recent(tmp_path):
-    # Stripped plain reply: thread_id is None, topic mode is on.
+@pytest.mark.parametrize("thread_id", [None, "1"])
+def test_recover_rewrites_lobby_thread_id_to_most_recent(tmp_path, thread_id):
+    # Stripped plain reply / General root lane: topic mode is on.
     db = SessionDB(db_path=tmp_path / "state.db")
     _seed_two_topic_bindings(db)
     runner = _make_runner(session_db=db)
 
-    assert runner._recover_telegram_topic_thread_id(_make_source(thread_id=None)) == "222"
+    assert runner._recover_telegram_topic_thread_id(_make_source(thread_id=thread_id)) == "222"
 
 
 def test_recover_returns_none_when_topic_mode_disabled(tmp_path):

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -324,6 +324,8 @@ class TestGeneratedSystemdUnits:
         unit = gateway_cli.generate_systemd_unit(system=False)
 
         assert "ExecStart=" in unit
+        assert "After=network-online.target" not in unit
+        assert "Wants=network-online.target" not in unit
         assert "ExecStop=" not in unit
         assert "ExecReload=/bin/kill -USR1 $MAINPID" in unit
         assert f"RestartForceExitStatus={GATEWAY_SERVICE_RESTART_EXIT_CODE}" in unit
@@ -388,6 +390,8 @@ class TestGeneratedSystemdUnits:
         assert "ExecStop=" not in unit
         assert "ExecReload=/bin/kill -USR1 $MAINPID" in unit
         assert f"RestartForceExitStatus={GATEWAY_SERVICE_RESTART_EXIT_CODE}" in unit
+        assert "After=network-online.target" in unit
+        assert "Wants=network-online.target" in unit
         # TimeoutStopSec must exceed the default drain_timeout (60s) so
         # systemd doesn't SIGKILL the cgroup before post-interrupt cleanup
         # (tool subprocess kill, adapter disconnect) runs — issue #8202.


### PR DESCRIPTION
## Summary
- sync Telegram DM topic bindings when compression rotates the underlying session id
- stop rewriting explicit non-General DM topic ids to the user's last-active topic
- keep recovery for missing/root topic ids and update topic-mode regression tests

## Why
A newly opened Telegram topic can arrive with an explicit thread id that is not bound yet. Treating that unknown id as recoverable forces the turn back into the previous topic, so the agent appears to reply in the wrong topic.

Compression can also rotate the Hermes session id while the Telegram topic stays the same. The binding must follow the compressed child session so later turns do not snap back to the pre-compression parent.

## Test plan
- ./venv/bin/python -m pytest -q tests/gateway/test_telegram_topic_mode.py -k 'recover or topic_binding_follows_session_id_rotation_after_compression'
- ./venv/bin/python -m pytest -q tests/gateway/test_telegram_topic_mode.py

Related: #20470, #27166, #29712