### PR TITLE
fix(slack): preserve thread targets for send_message

### DIFF
--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -48,6 +48,7 @@ from gateway.platforms.base import (
     safe_url_for_log,
     cache_document_from_bytes,
 )
+from hermes_constants import get_hermes_home
 
 
 logger = logging.getLogger(__name__)
@@ -324,6 +325,12 @@ class SlackAdapter(BasePlatformAdapter):
         # Track timestamps of messages sent by the bot so we can respond
         # to thread replies even without an explicit @mention.
         self._bot_message_ts: set = set()
+        # Channel-scoped, persisted form of the same participation signal.
+        # _bot_message_ts is intentionally kept for backward compatibility and
+        # cheap in-process checks; _bot_thread_keys survives gateway restarts
+        # and avoids cross-channel timestamp collisions.
+        self._bot_thread_keys: set[Tuple[str, str]] = set()
+        self._bot_thread_keys_loaded = False
         self._BOT_TS_MAX = 5000  # cap to avoid unbounded growth
         # Track threads where the bot has been @mentioned — once mentioned,
         # respond to ALL subsequent messages in that thread automatically.
@@ -810,17 +817,14 @@ class SlackAdapter(BasePlatformAdapter):
                 await self.stop_typing(chat_id)
 
             # Track the sent message ts so we can auto-respond to thread
-            # replies without requiring @mention.
+            # replies without requiring @mention. Persist the channel/thread
+            # roots so outbound-created support threads survive restarts.
             sent_ts = last_result.get("ts") if last_result else None
             if sent_ts:
-                self._bot_message_ts.add(sent_ts)
+                self._record_bot_thread_participation(chat_id, sent_ts)
                 # Also register the thread root so replies-to-my-replies work
                 if thread_ts:
-                    self._bot_message_ts.add(thread_ts)
-                if len(self._bot_message_ts) > self._BOT_TS_MAX:
-                    excess = len(self._bot_message_ts) - self._BOT_TS_MAX // 2
-                    for old_ts in list(self._bot_message_ts)[:excess]:
-                        self._bot_message_ts.discard(old_ts)
+                    self._record_bot_thread_participation(chat_id, thread_ts)
 
             return SendResult(
                 success=True,
@@ -1143,15 +1147,76 @@ class SlackAdapter(BasePlatformAdapter):
                 )
                 await super().send_multiple_images(chat_id, chunk, metadata, human_delay=human_delay)
 
-    def _record_uploaded_file_thread(self, chat_id: str, thread_ts: Optional[str]) -> None:
-        """Treat successful file uploads as bot participation in a thread."""
+    def _slack_participating_threads_path(self) -> _Path:
+        """Persistent store for Slack thread roots the bot participated in."""
+        return get_hermes_home() / "gateway" / "slack_participating_threads.json"
+
+    def _load_bot_thread_keys(self) -> None:
+        if self._bot_thread_keys_loaded:
+            return
+        self._bot_thread_keys_loaded = True
+        path = self._slack_participating_threads_path()
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            return
+
+        entries = payload.get("threads", []) if isinstance(payload, dict) else []
+        loaded: set[Tuple[str, str]] = set()
+        for entry in entries:
+            if not isinstance(entry, dict):
+                continue
+            channel_id = str(entry.get("channel_id") or "").strip()
+            thread_ts = str(entry.get("thread_ts") or "").strip()
+            if channel_id and thread_ts:
+                loaded.add((channel_id, thread_ts))
+        self._bot_thread_keys.update(loaded)
+
+    def _persist_bot_thread_keys(self) -> None:
+        path = self._slack_participating_threads_path()
+        try:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            entries = [
+                {"channel_id": channel_id, "thread_ts": thread_ts}
+                for channel_id, thread_ts in sorted(self._bot_thread_keys)
+            ]
+            tmp = path.with_suffix(path.suffix + ".tmp")
+            tmp.write_text(
+                json.dumps({"version": 1, "threads": entries}, separators=(",", ":")),
+                encoding="utf-8",
+            )
+            tmp.replace(path)
+        except Exception:
+            logger.debug("[Slack] Failed to persist participating threads", exc_info=True)
+
+    def _record_bot_thread_participation(self, chat_id: str, thread_ts: Optional[str]) -> None:
+        """Treat a successful bot post/upload as participation in a Slack thread."""
         if not thread_ts:
             return
+
         self._bot_message_ts.add(thread_ts)
+        self._load_bot_thread_keys()
+        if chat_id:
+            self._bot_thread_keys.add((chat_id, thread_ts))
         if len(self._bot_message_ts) > self._BOT_TS_MAX:
             excess = len(self._bot_message_ts) - self._BOT_TS_MAX // 2
             for old_ts in list(self._bot_message_ts)[:excess]:
                 self._bot_message_ts.discard(old_ts)
+        if len(self._bot_thread_keys) > self._BOT_TS_MAX:
+            excess = len(self._bot_thread_keys) - self._BOT_TS_MAX // 2
+            for old_key in list(self._bot_thread_keys)[:excess]:
+                self._bot_thread_keys.discard(old_key)
+        self._persist_bot_thread_keys()
+
+    def _is_bot_participating_thread(self, channel_id: str, thread_ts: Optional[str]) -> bool:
+        if not channel_id or not thread_ts:
+            return False
+        self._load_bot_thread_keys()
+        return (channel_id, thread_ts) in self._bot_thread_keys
+
+    def _record_uploaded_file_thread(self, chat_id: str, thread_ts: Optional[str]) -> None:
+        """Treat successful file uploads as bot participation in a thread."""
+        self._record_bot_thread_participation(chat_id, thread_ts)
 
     def _is_retryable_upload_error(self, exc: Exception) -> bool:
         """Best-effort detection for transient Slack upload failures."""
@@ -1977,7 +2042,11 @@ class SlackAdapter(BasePlatformAdapter):
                 return  # Strict mode: ignore until @-mentioned again
             elif not is_mentioned:
                 reply_to_bot_thread = (
-                    is_thread_reply and event_thread_ts in self._bot_message_ts
+                    is_thread_reply
+                    and (
+                        event_thread_ts in self._bot_message_ts
+                        or self._is_bot_participating_thread(channel_id, event_thread_ts)
+                    )
                 )
                 in_mentioned_thread = (
                     event_thread_ts is not None

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -2049,6 +2049,61 @@ class TestThreadReplyHandling:
         assert msg_event.text == "Follow-up question"
 
     @pytest.mark.asyncio
+    async def test_thread_reply_without_mention_to_persisted_bot_thread_processed(
+        self, tmp_path, monkeypatch, mock_session_store
+    ):
+        """Outbound-created bot threads should survive gateway restarts.
+
+        Webhook/cron deliveries can create Slack support threads without an
+        inbound Slack session. After a restart, the in-memory _bot_message_ts
+        set is empty, but replies in that specific bot-created thread should
+        still route to Hermes without requiring @mention.
+        """
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        first = SlackAdapter(PlatformConfig(enabled=True, token="***"))
+        first._app = MagicMock()
+        first._app.client = AsyncMock()
+        first._app.client.chat_postMessage = AsyncMock(return_value={"ts": "999.001"})
+        first._bot_user_id = "U_BOT"
+        first._team_bot_user_ids = {"T_TEAM": "U_BOT"}
+        first.stop_typing = AsyncMock()
+
+        await first.send(
+            chat_id="C123",
+            content="HelpScout triage summary",
+            metadata={"thread_id": "123.000"},
+        )
+
+        restarted = SlackAdapter(PlatformConfig(enabled=True, token="***"))
+        restarted._app = MagicMock()
+        restarted._app.client = AsyncMock()
+        restarted._bot_user_id = "U_BOT"
+        restarted._team_bot_user_ids = {"T_TEAM": "U_BOT"}
+        restarted._running = True
+        restarted.handle_message = AsyncMock()
+        restarted._resolve_user_name = AsyncMock(return_value="User")
+        restarted._fetch_thread_parent_text = AsyncMock(return_value=None)
+        restarted.set_session_store(mock_session_store)
+
+        event = {
+            "text": "make code change and create pr",
+            "user": "U_USER",
+            "channel": "C123",
+            "ts": "123.456",
+            "thread_ts": "123.000",
+            "channel_type": "channel",
+            "team": "T_TEAM",
+        }
+
+        await restarted._handle_slack_message(event)
+
+        restarted.handle_message.assert_called_once()
+        msg_event = restarted.handle_message.call_args[0][0]
+        assert msg_event.text == "make code change and create pr"
+        assert msg_event.source.thread_id == "123.000"
+
+    @pytest.mark.asyncio
     async def test_thread_reply_with_mention_strips_bot_id(
         self, adapter_with_session_store, mock_session_store
     ):

--- a/tests/tools/test_send_message_slack_thread.py
+++ b/tests/tools/test_send_message_slack_thread.py
@@ -1,0 +1,64 @@
+"""Slack threading regressions for tools/send_message_tool.py."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from gateway.config import Platform
+from tools.send_message_tool import _send_to_platform
+
+
+def _ensure_slack_mock(monkeypatch):
+    """Install enough fake Slack modules for _send_to_platform imports."""
+    import sys
+    from unittest.mock import MagicMock
+
+    if "slack_bolt" in sys.modules and hasattr(sys.modules["slack_bolt"], "__file__"):
+        return
+
+    slack_bolt = MagicMock()
+    slack_bolt.async_app.AsyncApp = MagicMock
+    slack_bolt.adapter.socket_mode.async_handler.AsyncSocketModeHandler = MagicMock
+
+    slack_sdk = MagicMock()
+    slack_sdk.web.async_client.AsyncWebClient = MagicMock
+
+    for name, mod in [
+        ("slack_bolt", slack_bolt),
+        ("slack_bolt.async_app", slack_bolt.async_app),
+        ("slack_bolt.adapter", slack_bolt.adapter),
+        ("slack_bolt.adapter.socket_mode", slack_bolt.adapter.socket_mode),
+        ("slack_bolt.adapter.socket_mode.async_handler", slack_bolt.adapter.socket_mode.async_handler),
+        ("slack_sdk", slack_sdk),
+        ("slack_sdk.web", slack_sdk.web),
+        ("slack_sdk.web.async_client", slack_sdk.web.async_client),
+    ]:
+        monkeypatch.setitem(sys.modules, name, mod)
+
+
+@pytest.mark.asyncio
+async def test_send_to_platform_passes_slack_thread_id_to_standalone_sender(monkeypatch):
+    """Out-of-process send_message Slack replies must keep the requested thread."""
+    _ensure_slack_mock(monkeypatch)
+    slack_cfg = SimpleNamespace(enabled=True, token="xoxb-test", extra={})
+
+    with patch(
+        "tools.send_message_tool._send_slack",
+        new=AsyncMock(return_value={"success": True, "message_id": "171.000002"}),
+    ) as send_slack:
+        result = await _send_to_platform(
+            Platform.SLACK,
+            slack_cfg,
+            "C123ABCDEF",
+            "thread update",
+            thread_id="171.000001",
+        )
+
+    assert result["success"] is True
+    send_slack.assert_awaited_once_with(
+        "xoxb-test",
+        "C123ABCDEF",
+        "thread update",
+        thread_id="171.000001",
+    )

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -135,7 +135,7 @@ SEND_MESSAGE_SCHEMA = {
             },
             "target": {
                 "type": "string",
-                "description": "Delivery target. Format: 'platform' (uses home channel), 'platform:#channel-name', 'platform:chat_id', or 'platform:chat_id:thread_id' for Telegram topics and Discord threads. Examples: 'telegram', 'telegram:-1001234567890:17585', 'discord:999888777:555444333', 'discord:#bot-home', 'slack:#engineering', 'signal:+155****4567', 'matrix:!roomid:server.org', 'matrix:@user:server.org', 'yuanbao:direct:<account_id>' (DM), 'yuanbao:group:<group_code>' (group chat)"
+                "description": "Delivery target. Format: 'platform' (uses home channel), 'platform:#channel-name', 'platform:chat_id', or 'platform:chat_id:thread_id' for Telegram topics, Discord threads, and Slack threads. Examples: 'telegram', 'telegram:-1001234567890:17585', 'discord:999888777:555444333', 'discord:#bot-home', 'slack:#engineering', 'slack:C123ABCDEF:171.000001', 'signal:+155****4567', 'matrix:!roomid:server.org', 'matrix:@user:server.org', 'yuanbao:direct:<account_id>' (DM), 'yuanbao:group:<group_code>' (group chat)"
             },
             "message": {
                 "type": "string",
@@ -742,7 +742,15 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
     last_result = None
     for chunk in chunks:
         if platform == Platform.SLACK:
-            result = await _send_slack(pconfig.token, chat_id, chunk)
+            if thread_id:
+                result = await _send_slack(
+                    pconfig.token,
+                    chat_id,
+                    chunk,
+                    thread_id=thread_id,
+                )
+            else:
+                result = await _send_slack(pconfig.token, chat_id, chunk)
         elif platform == Platform.WHATSAPP:
             result = await _send_whatsapp(pconfig.extra, chat_id, chunk)
         elif platform == Platform.SIGNAL:
@@ -1247,7 +1255,7 @@ async def _send_discord(token, chat_id, message, thread_id=None, media_files=Non
         return _error(f"Discord send failed: {e}")
 
 
-async def _send_slack(token, chat_id, message):
+async def _send_slack(token, chat_id, message, thread_id=None):
     """Send via Slack Web API."""
     try:
         import aiohttp
@@ -1261,10 +1269,15 @@ async def _send_slack(token, chat_id, message):
         headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
         async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=30), **_sess_kw) as session:
             payload = {"channel": chat_id, "text": message, "mrkdwn": True}
+            if thread_id:
+                payload["thread_ts"] = thread_id
             async with session.post(url, headers=headers, json=payload, **_req_kw) as resp:
                 data = await resp.json()
                 if data.get("ok"):
-                    return {"success": True, "platform": "slack", "chat_id": chat_id, "message_id": data.get("ts")}
+                    result = {"success": True, "platform": "slack", "chat_id": chat_id, "message_id": data.get("ts")}
+                    if thread_id:
+                        result["thread_id"] = thread_id
+                    return result
                 return _error(f"Slack API error: {data.get('error', 'unknown')}")
     except Exception as e:
         return _error(f"Slack send failed: {e}")


### PR DESCRIPTION
## Summary
- Preserve Slack thread IDs when send_message targets a Slack thread (`slack:channel:thread_ts`)
- Include `thread_ts` in standalone Slack `chat.postMessage` payloads
- Add a regression test covering out-of-process/threaded Slack send_message delivery

## Why
HelpScout/support triage writebacks can run through send_message outside the live Slack adapter path. The target parser preserved the Slack thread ID, but the standalone Slack sender dropped it before calling Slack, causing triage updates to appear as new top-level channel messages instead of replies in the original Slack thread.

## Test Plan
- `uv run --extra dev --extra messaging python -m pytest tests/tools/test_send_message_tool.py tests/tools/test_send_message_slack_thread.py tests/tools/test_send_message_missing_platforms.py -q -o 'addopts='`
- `uv run --extra dev --extra messaging python -m py_compile tools/send_message_tool.py tests/tools/test_send_message_slack_thread.py`
