### PR TITLE
Preserve Feishu card context across gateway turns

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -1846,6 +1846,48 @@ class FeishuAdapter(BasePlatformAdapter):
             logger.error("[Feishu] Failed to edit message %s: %s", message_id, exc, exc_info=True)
             return SendResult(success=False, error=str(exc))
 
+    @staticmethod
+    def _metadata_value(metadata: Optional[Dict[str, Any]], key: str) -> Optional[str]:
+        if not metadata:
+            return None
+        value = metadata.get(key)
+        if value is None:
+            return None
+        text = str(value).strip()
+        return text or None
+
+    def _mirror_interactive_card(
+        self,
+        *,
+        chat_id: str,
+        summary: str,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        """Best-effort mirror for Feishu cards sent outside normal agent replies."""
+        try:
+            from gateway.mirror import mirror_to_session
+
+            mirror_to_session(
+                "feishu",
+                chat_id,
+                summary,
+                source_label="gateway",
+                thread_id=self._metadata_value(metadata, "thread_id"),
+                user_id=self._metadata_value(metadata, "user_id"),
+            )
+        except Exception:
+            logger.debug("[Feishu] Failed to mirror interactive card summary", exc_info=True)
+
+    @staticmethod
+    def _extract_card_context_hint(action_value: Any) -> Optional[str]:
+        if not isinstance(action_value, dict):
+            return None
+        for key in ("hermes_card_context", "card_context", "context", "summary", "title"):
+            value = action_value.get(key)
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+        return None
+
     async def send_exec_approval(
         self, chat_id: str, command: str, session_key: str,
         description: str = "dangerous command",
@@ -1911,6 +1953,8 @@ class FeishuAdapter(BasePlatformAdapter):
                     "message_id": result.message_id or "",
                     "chat_id": chat_id,
                 }
+                summary = f"⚠️ Command Approval Required\nCommand:\n{cmd_preview}\nReason: {description}"
+                self._mirror_interactive_card(chat_id=chat_id, summary=summary, metadata=metadata)
             return result
         except Exception as exc:
             logger.warning("[Feishu] send_exec_approval failed: %s", exc)
@@ -1979,6 +2023,10 @@ class FeishuAdapter(BasePlatformAdapter):
                     "message_id": result.message_id or "",
                     "chat_id": chat_id,
                 }
+                summary = f"⚕ Update Needs Your Input\n{prompt}"
+                if default:
+                    summary += f"\nDefault: {default}"
+                self._mirror_interactive_card(chat_id=chat_id, summary=summary, metadata=metadata)
             return result
         except Exception as exc:
             logger.warning("[Feishu] send_update_prompt failed: %s", exc)
@@ -2746,6 +2794,9 @@ class FeishuAdapter(BasePlatformAdapter):
                 synthetic_text += f" {json.dumps(action_value, ensure_ascii=False)}"
             except Exception:
                 pass
+        context_hint = self._extract_card_context_hint(action_value)
+        if context_hint:
+            synthetic_text += f"\nCard context: {context_hint}"
 
         sender_id = SimpleNamespace(open_id=open_id, user_id=None, union_id=None)
         sender_profile = await self._resolve_sender_profile(sender_id)

--- a/tests/gateway/test_feishu_approval_buttons.py
+++ b/tests/gateway/test_feishu_approval_buttons.py
@@ -154,6 +154,65 @@ class TestFeishuExecApproval:
         assert state["chat_id"] == "oc_12345"
 
     @pytest.mark.asyncio
+    async def test_mirrors_approval_card_summary(self):
+        adapter = _make_adapter()
+
+        mock_response = SimpleNamespace(
+            success=lambda: True,
+            data=SimpleNamespace(message_id="msg_004"),
+        )
+        with (
+            patch.object(
+                adapter, "_feishu_send_with_retry", new_callable=AsyncMock,
+                return_value=mock_response,
+            ),
+            patch("gateway.mirror.mirror_to_session", return_value=True) as mirror_mock,
+        ):
+            result = await adapter.send_exec_approval(
+                chat_id="oc_12345",
+                command="rm -rf /important",
+                session_key="agent:main:feishu:group:oc_12345",
+                description="dangerous deletion",
+                metadata={"thread_id": "thread_1"},
+            )
+
+        assert result.success is True
+        mirror_mock.assert_called_once()
+        assert mirror_mock.call_args.args[:3] == (
+            "feishu",
+            "oc_12345",
+            "⚠️ Command Approval Required\nCommand:\nrm -rf /important\nReason: dangerous deletion",
+        )
+        assert mirror_mock.call_args.kwargs == {
+            "source_label": "gateway",
+            "thread_id": "thread_1",
+            "user_id": None,
+        }
+
+    @pytest.mark.asyncio
+    async def test_approval_mirror_failure_is_non_fatal(self):
+        adapter = _make_adapter()
+
+        mock_response = SimpleNamespace(
+            success=lambda: True,
+            data=SimpleNamespace(message_id="msg_005"),
+        )
+        with (
+            patch.object(
+                adapter, "_feishu_send_with_retry", new_callable=AsyncMock,
+                return_value=mock_response,
+            ),
+            patch("gateway.mirror.mirror_to_session", side_effect=RuntimeError("no session")),
+        ):
+            result = await adapter.send_exec_approval(
+                chat_id="oc_12345",
+                command="echo test",
+                session_key="agent:main:feishu:group:oc_12345",
+            )
+
+        assert result.success is True
+
+    @pytest.mark.asyncio
     async def test_not_connected(self):
         adapter = _make_adapter()
         adapter._client = None
@@ -274,6 +333,38 @@ class TestFeishuUpdatePrompt:
         assert state["session_key"] == "my-session-key"
         assert state["message_id"] == "msg_up_002"
         assert state["chat_id"] == "oc_12345"
+
+    @pytest.mark.asyncio
+    async def test_mirrors_update_prompt_card_summary(self):
+        adapter = _make_adapter()
+
+        mock_response = SimpleNamespace(
+            success=lambda: True,
+            data=SimpleNamespace(message_id="msg_up_003"),
+        )
+        with (
+            patch.object(
+                adapter, "_feishu_send_with_retry", new_callable=AsyncMock,
+                return_value=mock_response,
+            ),
+            patch("gateway.mirror.mirror_to_session", return_value=True) as mirror_mock,
+        ):
+            result = await adapter.send_update_prompt(
+                chat_id="oc_12345",
+                prompt="Restore stashed changes after update?",
+                default="y",
+                session_key="agent:main:feishu:group:oc_12345",
+            )
+
+        assert result.success is True
+        mirror_mock.assert_called_once_with(
+            "feishu",
+            "oc_12345",
+            "⚕ Update Needs Your Input\nRestore stashed changes after update?\nDefault: y",
+            source_label="gateway",
+            thread_id=None,
+            user_id=None,
+        )
 
     @pytest.mark.asyncio
     async def test_not_connected(self):
@@ -405,6 +496,31 @@ class TestNonApprovalCardAction:
         mock_handle.assert_called_once()
         event = mock_handle.call_args[0][0]
         assert "/card button" in event.text
+
+    @pytest.mark.asyncio
+    async def test_routes_card_action_with_readable_context_hint(self):
+        adapter = _make_adapter()
+
+        data = _make_card_action_data(
+            action_value={
+                "custom_action": "something_else",
+                "hermes_card_context": "Deployment approval card for staging",
+            },
+            token="tok_context",
+        )
+
+        with (
+            patch.object(
+                adapter, "_resolve_sender_profile", new_callable=AsyncMock,
+                return_value={"user_id": "ou_u", "user_name": "Dave", "user_id_alt": None},
+            ),
+            patch.object(adapter, "get_chat_info", new_callable=AsyncMock, return_value={"name": "Test Chat"}),
+            patch.object(adapter, "_handle_message_with_guards", new_callable=AsyncMock) as mock_handle,
+        ):
+            await adapter._handle_card_action_event(data)
+
+        event = mock_handle.call_args[0][0]
+        assert "Card context: Deployment approval card for staging" in event.text
 
 
 # ===========================================================================


### PR DESCRIPTION
## Summary
- Mirror concise Feishu approval/update card summaries into gateway session history after successful card sends.
- Keep mirror writes best-effort so card delivery still succeeds if no matching session exists or mirror storage fails.
- Add readable `Card context:` hints to generic Feishu card action synthetic commands when the action payload supplies context.

## Why
Feishu interactive cards were sent outside the normal `send_message_tool` mirroring path, so follow-up replies or generic card-click commands could lack the bot-sent context that prompted the user action. The linked Feishu article also flagged `send_message_tool`, but this checkout already mirrors successful `send_message_tool` sends, so this PR is intentionally scoped to the remaining interactive-card gaps.

## Validation
- `scripts/run_tests.sh tests/gateway/test_feishu_approval_buttons.py -- -q`
- `scripts/run_tests.sh tests/gateway/test_feishu.py tests/gateway/test_feishu_approval_buttons.py -- -q`
- `venv/bin/ruff check gateway/platforms/feishu.py tests/gateway/test_feishu_approval_buttons.py`

## Not tested
- Live Feishu send/card-click smoke test. Per task clarification, focused unit coverage is sufficient for this first PR.
