### PR TITLE
fix(cli): honour HERMES_PROFILE env var in _apply_profile_override

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -452,7 +452,25 @@ def _apply_profile_override() -> None:
         if Path(hermes_home_env).parent.name == "profiles":
             return
 
-    # 2. If no flag, check active_profile in the hermes root.
+    # 2. HERMES_PROFILE env var as explicit selector.
+    # Without this, sibling gateways launched as
+    # ``HERMES_PROFILE=alice hermes telegram --replace`` and
+    # ``HERMES_PROFILE=bob hermes telegram --replace`` from the same $HOME
+    # both fall through to ``active_profile`` and resolve to the same
+    # ``gateway.pid`` — ``--replace`` then SIGKILLs the sibling. See #29948.
+    # Priority: -p flag > HERMES_HOME profile path > HERMES_PROFILE > active_profile.
+    # ``HERMES_PROFILE=default`` is a no-op (mirrors the active_profile rule
+    # below) since the default profile IS ~/.hermes itself.
+    if profile_name is None:
+        env_profile = os.environ.get("HERMES_PROFILE", "").strip()
+        if env_profile and env_profile.casefold() != "default":
+            import re as _re
+
+            if _re.match(r"^[a-z0-9][a-z0-9_-]{0,63}$", env_profile):
+                profile_name = env_profile
+                consume = 0  # don't strip anything from argv
+
+    # 3. If no flag and no env var, check active_profile in the hermes root.
     #
     # EXCEPTION: a supervised s6 gateway child (exported by the container
     # run-script as HERMES_S6_SUPERVISED_CHILD=1) must NOT follow the sticky
@@ -477,7 +495,7 @@ def _apply_profile_override() -> None:
         except (UnicodeDecodeError, OSError):
             pass  # corrupted file, skip
 
-    # 3. If we found a profile, resolve and set HERMES_HOME
+    # 4. If we found a profile, resolve and set HERMES_HOME
     if profile_name is not None:
         try:
             from hermes_cli.profiles import resolve_profile_env

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -62,7 +62,20 @@ except ModuleNotFoundError:
     pass
 
 import os
+import re
 import sys
+
+# Profile names must match hermes_cli.profiles._PROFILE_ID_RE so we never hand
+# resolve_profile_env() a value it would reject + sys.exit on. Compiled once at
+# module level and shared by every validation site in _apply_profile_override
+# (both the -p/--profile flag and the HERMES_PROFILE env var) so the two
+# validators can't drift apart.
+_PROFILE_ID_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{0,63}$")
+
+
+def _is_valid_profile_id(name: str) -> bool:
+    """Return True if ``name`` is a syntactically valid profile id."""
+    return bool(_PROFILE_ID_RE.match(name))
 
 
 def _set_process_title() -> None:
@@ -431,9 +444,7 @@ def _apply_profile_override() -> None:
     # Mirrors hermes_cli.profiles._PROFILE_ID_RE so we never call
     # resolve_profile_env() with a value it must reject + sys.exit on.
     if profile_name is not None and consume == 2:
-        import re as _re
-
-        if not _re.match(r"^[a-z0-9][a-z0-9_-]{0,63}$", profile_name):
+        if not _is_valid_profile_id(profile_name):
             profile_name = None
             consume = 0
             profile_index = None
@@ -464,9 +475,7 @@ def _apply_profile_override() -> None:
     if profile_name is None:
         env_profile = os.environ.get("HERMES_PROFILE", "").strip()
         if env_profile and env_profile.casefold() != "default":
-            import re as _re
-
-            if _re.match(r"^[a-z0-9][a-z0-9_-]{0,63}$", env_profile):
+            if _is_valid_profile_id(env_profile):
                 profile_name = env_profile
                 consume = 0  # don't strip anything from argv
 

--- a/tests/hermes_cli/test_apply_profile_override.py
+++ b/tests/hermes_cli/test_apply_profile_override.py
@@ -16,6 +16,7 @@ import sys
 from pathlib import Path
 from types import SimpleNamespace
 
+from hermes_cli.main import _is_valid_profile_id
 
 
 def _run_apply_profile_override(
@@ -36,8 +37,22 @@ def _run_apply_profile_override(
     if active_profile and active_profile != "default":
         (hermes_root / "profiles" / active_profile).mkdir(parents=True, exist_ok=True)
 
-    if hermes_profile and hermes_profile != "default":
-        (hermes_root / "profiles" / hermes_profile).mkdir(parents=True, exist_ok=True)
+    # Only pre-create the profile dir for values production would actually
+    # resolve. _apply_profile_override .strip()s HERMES_PROFILE and validates
+    # it against _PROFILE_ID_RE, so whitespace-only / invalid values never
+    # reach a mkdir there. Mirror that here so we don't create directories with
+    # trailing-space or otherwise-invalid names (unsupported on Windows) and so
+    # the test fixture matches production behaviour.
+    if hermes_profile is not None:
+        stripped_profile = hermes_profile.strip()
+        if (
+            stripped_profile
+            and stripped_profile != "default"
+            and _is_valid_profile_id(stripped_profile)
+        ):
+            (hermes_root / "profiles" / stripped_profile).mkdir(
+                parents=True, exist_ok=True
+            )
 
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
     if hermes_home is not None:

--- a/tests/hermes_cli/test_apply_profile_override.py
+++ b/tests/hermes_cli/test_apply_profile_override.py
@@ -20,7 +20,7 @@ from types import SimpleNamespace
 
 def _run_apply_profile_override(
     tmp_path, monkeypatch, *, hermes_home: str | None, active_profile: str | None,
-    argv: list[str] | None = None,
+    argv: list[str] | None = None, hermes_profile: str | None = None,
 ):
     """Run _apply_profile_override in isolation.
 
@@ -36,11 +36,18 @@ def _run_apply_profile_override(
     if active_profile and active_profile != "default":
         (hermes_root / "profiles" / active_profile).mkdir(parents=True, exist_ok=True)
 
+    if hermes_profile and hermes_profile != "default":
+        (hermes_root / "profiles" / hermes_profile).mkdir(parents=True, exist_ok=True)
+
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
     if hermes_home is not None:
         monkeypatch.setenv("HERMES_HOME", hermes_home)
     else:
         monkeypatch.delenv("HERMES_HOME", raising=False)
+    if hermes_profile is not None:
+        monkeypatch.setenv("HERMES_PROFILE", hermes_profile)
+    else:
+        monkeypatch.delenv("HERMES_PROFILE", raising=False)
 
     monkeypatch.setattr(sys, "argv", argv or ["hermes", "gateway", "start"])
 
@@ -156,6 +163,7 @@ class TestApplyProfileOverrideHermesHomeGuard:
 
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
         monkeypatch.delenv("HERMES_HOME", raising=False)
+        monkeypatch.delenv("HERMES_PROFILE", raising=False)
         monkeypatch.setattr(sys, "argv", ["hermes", "gateway", "start"])
         (hermes_root / "active_profile").write_text("default")
 
@@ -323,3 +331,170 @@ class TestSupervisedChildIgnoresStickyProfile:
         assert result is not None
         assert result.endswith("coder")
 
+
+class TestApplyProfileOverrideHermesProfileEnv:
+    """Regression guard for issue #29948.
+
+    HERMES_PROFILE env var must select the profile dir when HERMES_HOME and
+    -p flag are unset.  Without this, sibling gateways launched as
+    ``HERMES_PROFILE=alice hermes telegram --replace`` and
+    ``HERMES_PROFILE=bob hermes telegram --replace`` from the same $HOME both
+    fall through to ``active_profile`` and resolve to the same
+    ``gateway.pid`` — ``--replace`` then SIGKILLs the sibling.
+    """
+
+    def test_hermes_profile_env_selects_profile(self, tmp_path, monkeypatch):
+        """HERMES_PROFILE=alice (no HERMES_HOME, no -p flag) must resolve
+        HERMES_HOME to .../profiles/alice.
+        """
+        result = _run_apply_profile_override(
+            tmp_path,
+            monkeypatch,
+            hermes_home=None,
+            active_profile=None,
+            hermes_profile="alice",
+        )
+
+        assert result is not None
+        assert "profiles" in result
+        assert result.endswith("alice")
+
+    def test_hermes_profile_env_distinct_pidfiles_for_siblings(
+        self, tmp_path, monkeypatch
+    ):
+        """Two gateways with distinct HERMES_PROFILE values must resolve to
+        distinct profile directories — the actual repro from issue #29948.
+        """
+        alice_home = _run_apply_profile_override(
+            tmp_path,
+            monkeypatch,
+            hermes_home=None,
+            active_profile=None,
+            hermes_profile="alice",
+        )
+
+        bob_home = _run_apply_profile_override(
+            tmp_path,
+            monkeypatch,
+            hermes_home=None,
+            active_profile=None,
+            hermes_profile="bob",
+        )
+
+        assert alice_home != bob_home, (
+            f"alice and bob must resolve to distinct profile dirs, got "
+            f"alice={alice_home!r} bob={bob_home!r}"
+        )
+        assert alice_home and alice_home.endswith("alice")
+        assert bob_home and bob_home.endswith("bob")
+
+    def test_hermes_profile_env_beats_active_profile(self, tmp_path, monkeypatch):
+        """When both HERMES_PROFILE and active_profile are set, HERMES_PROFILE wins.
+
+        Active_profile is the sticky default; HERMES_PROFILE is explicit per-process
+        intent. The explicit env var must take precedence so an operator can run
+        ``HERMES_PROFILE=alice hermes telegram`` without first switching the
+        sticky default.
+        """
+        result = _run_apply_profile_override(
+            tmp_path,
+            monkeypatch,
+            hermes_home=None,
+            active_profile="coder",
+            hermes_profile="alice",
+        )
+
+        assert result is not None
+        assert result.endswith("alice"), (
+            f"HERMES_PROFILE=alice must override active_profile=coder, got {result!r}"
+        )
+
+    def test_p_flag_beats_hermes_profile_env(self, tmp_path, monkeypatch):
+        """-p flag is the highest-priority selector and must beat HERMES_PROFILE."""
+        hermes_root = tmp_path / ".hermes"
+        hermes_root.mkdir(parents=True, exist_ok=True)
+        (hermes_root / "profiles" / "alice").mkdir(parents=True, exist_ok=True)
+        (hermes_root / "profiles" / "bob").mkdir(parents=True, exist_ok=True)
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.delenv("HERMES_HOME", raising=False)
+        monkeypatch.setenv("HERMES_PROFILE", "bob")
+        monkeypatch.setattr(sys, "argv", ["hermes", "-p", "alice", "gateway", "start"])
+
+        from hermes_cli.main import _apply_profile_override
+        _apply_profile_override()
+
+        result = os.environ.get("HERMES_HOME")
+        assert result is not None
+        assert result.endswith("alice"), (
+            f"-p flag must beat HERMES_PROFILE, got {result!r}"
+        )
+
+    def test_hermes_home_profile_path_beats_hermes_profile_env(
+        self, tmp_path, monkeypatch
+    ):
+        """HERMES_HOME already pointing at a profile dir is already-resolved
+        and must be trusted over a stale HERMES_PROFILE inherited from the parent.
+        """
+        hermes_root = tmp_path / ".hermes"
+        alice_dir = hermes_root / "profiles" / "alice"
+        alice_dir.mkdir(parents=True, exist_ok=True)
+        (hermes_root / "profiles" / "bob").mkdir(parents=True, exist_ok=True)
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(alice_dir))
+        monkeypatch.setenv("HERMES_PROFILE", "bob")
+        monkeypatch.setattr(sys, "argv", ["hermes", "gateway", "start"])
+
+        from hermes_cli.main import _apply_profile_override
+        _apply_profile_override()
+
+        assert os.environ.get("HERMES_HOME") == str(alice_dir), (
+            "HERMES_HOME pointing to a profile dir must be trusted as-is"
+        )
+
+    def test_invalid_hermes_profile_env_is_ignored(self, tmp_path, monkeypatch):
+        """An invalid HERMES_PROFILE value (e.g. uppercase, special chars) must
+        not abort or be passed through to resolve_profile_env. Falls through
+        to active_profile / default.
+        """
+        result = _run_apply_profile_override(
+            tmp_path,
+            monkeypatch,
+            hermes_home=None,
+            active_profile=None,
+            hermes_profile="Not Valid!",  # spaces + uppercase + punctuation
+        )
+
+        assert result is None, (
+            "Invalid HERMES_PROFILE should be silently ignored, not cause a "
+            f"redirect or abort. Got HERMES_HOME={result!r}"
+        )
+
+    def test_hermes_profile_default_does_not_redirect(self, tmp_path, monkeypatch):
+        """HERMES_PROFILE=default is a no-op — there is no profiles/default/ dir;
+        the default profile IS ~/.hermes itself. Must leave HERMES_HOME unset.
+        """
+        result = _run_apply_profile_override(
+            tmp_path,
+            monkeypatch,
+            hermes_home=None,
+            active_profile=None,
+            hermes_profile="default",
+        )
+
+        assert result is None, (
+            f"HERMES_PROFILE=default should not redirect, got HERMES_HOME={result!r}"
+        )
+
+    def test_empty_hermes_profile_env_is_ignored(self, tmp_path, monkeypatch):
+        """HERMES_PROFILE='' or whitespace-only must be treated as unset."""
+        result = _run_apply_profile_override(
+            tmp_path,
+            monkeypatch,
+            hermes_home=None,
+            active_profile=None,
+            hermes_profile="   ",
+        )
+
+        assert result is None


### PR DESCRIPTION
## What does this PR do?

When `HERMES_HOME` and `-p`/`--profile` are both unset, the current resolver only reads the sticky `active_profile` file. Sibling gateways launched from the same `$HOME` with different `HERMES_PROFILE` env vars both fall through to the same `active_profile` value and resolve to the same `~/.hermes/profiles/<sticky>/gateway.pid`, so `--replace` ends up SIGKILLing the sibling. The fix inserts a `HERMES_PROFILE` check between the existing HERMES_HOME-profile-path trust step and the `active_profile` fallback, with the explicit precedence chain:

    -p flag > HERMES_HOME profile path > HERMES_PROFILE > active_profile

`HERMES_PROFILE=default` is a no-op (mirrors the `active_profile` rule since the default profile IS `~/.hermes` itself). Invalid values silently fall through rather than aborting so a stale inherited env var never brings down the CLI.

## Related Issue

Fixes #29948

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/main.py` — `_apply_profile_override()` now reads `HERMES_PROFILE` (validated against the profile-id regex; ignored on `default`/empty/invalid) before falling back to `active_profile`.
- `tests/hermes_cli/test_apply_profile_override.py` — adds 8 regression tests covering: env-var-selects-profile, distinct-pidfiles-for-siblings (the actual #29948 repro), beats-active-profile, -p-flag-beats-env, HERMES_HOME-profile-path-beats-env, invalid-value-ignored, default-is-no-op, empty-is-ignored. Also threads `HERMES_PROFILE` through the existing helper so other tests in the file remain hermetic when the dev's shell exports it.

## How to Test

1. `uv run --with pytest --with pytest-xdist --with pytest-asyncio --with pytest-timeout python3 -m pytest tests/hermes_cli/test_apply_profile_override.py -v`
2. End-to-end repro from the issue:
   ```bash
   HERMES_PROFILE=alice hermes telegram --replace &
   HERMES_PROFILE=bob   hermes telegram --replace &
   ```
   Before: `alice` gets SIGKILLed because both gateways resolve to `~/.hermes/profiles/<sticky>/gateway.pid`. After: each gateway resolves to its own `profiles/<name>/gateway.pid` and both coexist.
3. Regression guard: reverting the `hermes_cli/main.py` chunk causes the three new behaviour tests (`test_hermes_profile_env_selects_profile`, `test_hermes_profile_env_distinct_pidfiles_for_siblings`, `test_hermes_profile_env_beats_active_profile`) to fail with the pre-fix HERMES_HOME values; the five precedence/validation tests still pass since they exercise rules the old code already handled correctly.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(cli):` here)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run focused tests for the touched code and all 12 pass (4 pre-existing + 8 new)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15.x

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (the new env var slot in the precedence chain is documented inline)
- [x] I've updated `cli-config.yaml.example` — N/A (env-var only, no config schema change)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — the new code path uses `os.environ` + a re.match, no platform branches
- [x] I've updated tool descriptions/schemas — N/A

## Related / Positioning

Sits between two earlier merged precedence patches:

- #19668 (teknium1) tightened the `-p` argv validation so `pytest -p no:xdist` no longer leaks into the resolver — same regex used here for `HERMES_PROFILE` validation.
- #22677 (teknium1, salvage of #22654) added the `HERMES_HOME == hermes root → still honour active_profile` step that this PR sits between.

`HERMES_PROFILE` is already established elsewhere in the codebase as the per-process persona identifier — `hermes_cli/kanban_db.py:5353` sets it explicitly when spawning workers, and `tools/kanban_tools.py:623` reads it as the kanban comment author. This PR extends the same env var to also drive profile-directory selection at startup, which is the natural mental model users already have.

## Contract Protected

Precedence chain `-p flag > HERMES_HOME profile path > HERMES_PROFILE > active_profile` — each step tested in isolation (`test_p_flag_beats_hermes_profile_env`, `test_hermes_home_profile_path_beats_hermes_profile_env`, `test_hermes_profile_env_beats_active_profile`) plus the repro (`test_hermes_profile_env_distinct_pidfiles_for_siblings`). Validation invariant: invalid HERMES_PROFILE values fall through silently (`test_invalid_hermes_profile_env_is_ignored`) rather than aborting `_apply_profile_override` and bricking the CLI.

> Audited siblings: confirmed every downstream profile resolver (`get_hermes_home`, `get_default_hermes_root`, `get_active_profile_name`, `gateway/status.py::_get_pid_path`) reads `HERMES_HOME` as the single source of truth. No widening needed — once `_apply_profile_override` sets `HERMES_HOME`, the rest of the resolver chain inherits the corrected value.