### PR TITLE
feat: customize Discord lifecycle reactions

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -941,7 +941,15 @@ def load_gateway_config() -> GatewayConfig:
                 if "auto_thread" in discord_cfg and not os.getenv("DISCORD_AUTO_THREAD"):
                     os.environ["DISCORD_AUTO_THREAD"] = str(discord_cfg["auto_thread"]).lower()
                 if "reactions" in discord_cfg and not os.getenv("DISCORD_REACTIONS"):
-                    os.environ["DISCORD_REACTIONS"] = str(discord_cfg["reactions"]).lower()
+                    reactions_cfg = discord_cfg["reactions"]
+                    if isinstance(reactions_cfg, dict):
+                        os.environ["DISCORD_REACTIONS"] = json.dumps(
+                            reactions_cfg,
+                            ensure_ascii=False,
+                            separators=(",", ":"),
+                        )
+                    else:
+                        os.environ["DISCORD_REACTIONS"] = str(reactions_cfg).lower()
                 # ignored_channels: channels where bot never responds (even when mentioned)
                 ic = discord_cfg.get("ignored_channels")
                 if ic is not None and not os.getenv("DISCORD_IGNORED_CHANNELS"):

--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -1344,29 +1344,91 @@ class DiscordAdapter(BasePlatformAdapter):
             logger.debug("[%s] remove_reaction failed (%s): %s", self.name, emoji, e)
             return False
 
+    def _reaction_config(self) -> Optional[Dict[str, Optional[str]]]:
+        """Return configured lifecycle reaction emojis, or None when disabled.
+
+        ``DISCORD_REACTIONS`` remains backwards-compatible with boolean-ish
+        values, and also accepts a JSON object from ``discord.reactions``:
+
+            {"processing": "👀", "success": "✅", "failure": null}
+
+        Missing keys use defaults. Null/empty/false-ish mapping values disable
+        only that individual lifecycle reaction.
+        """
+        raw = os.getenv("DISCORD_REACTIONS", "true").strip()
+        if raw.lower() in {"false", "0", "no", "off"}:
+            return None
+
+        config: Dict[str, Optional[str]] = {
+            "processing": "👀",
+            "success": "✅",
+            "failure": "❌",
+        }
+        if not raw or raw.lower() in {"true", "1", "yes", "on"}:
+            return config
+
+        try:
+            parsed = json.loads(raw)
+        except Exception:
+            logger.debug("[%s] invalid DISCORD_REACTIONS mapping; using defaults", self.name)
+            return config
+
+        if isinstance(parsed, bool):
+            return config if parsed else None
+        if not isinstance(parsed, dict):
+            return config
+
+        if parsed.get("enabled") is False:
+            return None
+
+        for key in ("processing", "success", "failure"):
+            if key not in parsed:
+                continue
+            value = parsed[key]
+            if value is None or value is False:
+                config[key] = None
+            else:
+                emoji = str(value).strip()
+                config[key] = None if emoji.lower() in {"", "null", "none", "false", "0", "no", "off"} else emoji
+        return config
+
     def _reactions_enabled(self) -> bool:
         """Check if message reactions are enabled via config/env."""
-        return os.getenv("DISCORD_REACTIONS", "true").lower() not in {"false", "0", "no"}
+        return self._reaction_config() is not None
+
+    def _reaction_emoji(self, name: str) -> Optional[str]:
+        config = self._reaction_config()
+        if config is None:
+            return None
+        return config.get(name)
 
     async def on_processing_start(self, event: MessageEvent) -> None:
         """Add an in-progress reaction for normal Discord message events."""
-        if not self._reactions_enabled():
+        emoji = self._reaction_emoji("processing")
+        if not emoji:
             return
         message = event.raw_message
         if hasattr(message, "add_reaction"):
-            await self._add_reaction(message, "👀")
+            await self._add_reaction(message, emoji)
 
     async def on_processing_complete(self, event: MessageEvent, outcome: ProcessingOutcome) -> None:
         """Swap the in-progress reaction for a final success/failure reaction."""
-        if not self._reactions_enabled():
+        reaction_config = self._reaction_config()
+        if reaction_config is None:
             return
         message = event.raw_message
         if hasattr(message, "add_reaction"):
-            await self._remove_reaction(message, "👀")
+            processing_emoji = reaction_config.get("processing")
+            if processing_emoji:
+                await self._remove_reaction(message, processing_emoji)
             if outcome == ProcessingOutcome.SUCCESS:
-                await self._add_reaction(message, "✅")
+                emoji = reaction_config.get("success")
+                if emoji:
+                    await self._add_reaction(message, emoji)
             elif outcome == ProcessingOutcome.FAILURE:
-                await self._add_reaction(message, "❌")
+                emoji = reaction_config.get("failure")
+                if emoji:
+                    await self._add_reaction(message, emoji)
 
     async def send(
         self,

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1354,7 +1354,7 @@ DEFAULT_CONFIG = {
         "thread_require_mention": False,  # If True, require @mention in threads too (multi-bot threads)
         "history_backfill": True,         # If True, prepend recent channel scrollback when bot is triggered (recovers messages missed while require_mention gated them out)
         "history_backfill_limit": 50,     # Max number of recent messages to scan when assembling the backfill block
-        "reactions": True,             # Add 👀/✅/❌ reactions to messages during processing
+        "reactions": True,             # True or {processing, success, failure}; null entry disables that reaction
         "channel_prompts": {},         # Per-channel ephemeral system prompts (forum parents apply to child threads)
         # Opt-in DM role-based auth (#12136). By default, DISCORD_ALLOWED_ROLES
         # authorizes only guild messages in the role's own guild — DMs require

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -324,6 +324,26 @@ class TestLoadGatewayConfig:
 
         assert os.environ.get("DISCORD_THREAD_REQUIRE_MENTION") == "true"
 
+    def test_bridges_discord_reaction_mapping_from_config_yaml(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "discord:\n"
+            "  reactions:\n"
+            "    processing: ⏳\n"
+            "    success: 🎉\n"
+            "    failure: null\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.delenv("DISCORD_REACTIONS", raising=False)
+
+        load_gateway_config()
+
+        assert os.environ.get("DISCORD_REACTIONS") == '{"processing":"⏳","success":"🎉","failure":null}'
+
     def test_thread_require_mention_yaml_does_not_overwrite_env(self, tmp_path, monkeypatch):
         """Explicit env var should win over config.yaml (env > yaml precedence)."""
         hermes_home = tmp_path / ".hermes"

--- a/tests/gateway/test_discord_reactions.py
+++ b/tests/gateway/test_discord_reactions.py
@@ -56,7 +56,8 @@ class FakeTree:
 
 
 @pytest.fixture
-def adapter():
+def adapter(monkeypatch):
+    monkeypatch.delenv("DISCORD_REACTIONS", raising=False)
     config = PlatformConfig(enabled=True, token="***")
     adapter = DiscordAdapter(config)
     adapter._client = SimpleNamespace(
@@ -246,3 +247,66 @@ async def test_on_processing_complete_cancelled_removes_eyes_without_terminal_re
 
     raw_message.remove_reaction.assert_awaited_once_with("👀", adapter._client.user)
     raw_message.add_reaction.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_reactions_can_be_customized_via_json_env(adapter, monkeypatch):
+    """DISCORD_REACTIONS as a mapping customizes lifecycle emojis."""
+    monkeypatch.setenv(
+        "DISCORD_REACTIONS",
+        '{"processing": "⏳", "success": "🎉", "failure": "💥"}',
+    )
+
+    raw_message = SimpleNamespace(
+        add_reaction=AsyncMock(),
+        remove_reaction=AsyncMock(),
+    )
+
+    event = _make_event("8", raw_message)
+    await adapter.on_processing_start(event)
+    await adapter.on_processing_complete(event, ProcessingOutcome.SUCCESS)
+
+    raw_message.add_reaction.assert_any_await("⏳")
+    raw_message.remove_reaction.assert_awaited_once_with("⏳", adapter._client.user)
+    raw_message.add_reaction.assert_any_await("🎉")
+
+
+@pytest.mark.asyncio
+async def test_null_reaction_entry_disables_only_that_outcome(adapter, monkeypatch):
+    """A null reaction mapping value suppresses only that lifecycle reaction."""
+    monkeypatch.setenv(
+        "DISCORD_REACTIONS",
+        '{"processing": null, "success": "🎉", "failure": "💥"}',
+    )
+
+    raw_message = SimpleNamespace(
+        add_reaction=AsyncMock(),
+        remove_reaction=AsyncMock(),
+    )
+
+    event = _make_event("9", raw_message)
+    await adapter.on_processing_start(event)
+    await adapter.on_processing_complete(event, ProcessingOutcome.SUCCESS)
+
+    raw_message.remove_reaction.assert_not_awaited()
+    raw_message.add_reaction.assert_awaited_once_with("🎉")
+
+
+@pytest.mark.asyncio
+async def test_null_terminal_reaction_still_removes_processing(adapter, monkeypatch):
+    monkeypatch.setenv(
+        "DISCORD_REACTIONS",
+        '{"processing": "⏳", "success": null, "failure": "💥"}',
+    )
+
+    raw_message = SimpleNamespace(
+        add_reaction=AsyncMock(),
+        remove_reaction=AsyncMock(),
+    )
+
+    event = _make_event("10", raw_message)
+    await adapter.on_processing_start(event)
+    await adapter.on_processing_complete(event, ProcessingOutcome.SUCCESS)
+
+    raw_message.add_reaction.assert_awaited_once_with("⏳")
+    raw_message.remove_reaction.assert_awaited_once_with("⏳", adapter._client.user)

--- a/website/docs/user-guide/messaging/discord.md
+++ b/website/docs/user-guide/messaging/discord.md
@@ -282,7 +282,7 @@ Discord behavior is controlled through two files: **`~/.hermes/.env`** for crede
 | `DISCORD_IGNORE_NO_MENTION` | No | `true` | When `true`, the bot stays silent if a message `@mentions` other users but does **not** mention the bot. Prevents the bot from jumping into conversations directed at other people. Only applies in server channels, not DMs. |
 | `DISCORD_AUTO_THREAD` | No | `true` | When `true`, automatically creates a new thread for every `@mention` in a text channel, so each conversation is isolated (similar to Slack behavior). Messages already inside threads or DMs are unaffected. |
 | `DISCORD_ALLOW_BOTS` | No | `"none"` | Controls how the bot handles messages from other Discord bots. `"none"` — ignore all other bots. `"mentions"` — only accept bot messages that `@mention` Hermes. `"all"` — accept all bot messages. |
-| `DISCORD_REACTIONS` | No | `true` | When `true`, the bot adds emoji reactions to messages during processing (👀 when starting, ✅ on success, ❌ on error). Set to `false` to disable reactions entirely. |
+| `DISCORD_REACTIONS` | No | `true` | When `true`, the bot adds emoji reactions to messages during processing (👀 when starting, ✅ on success, ❌ on error). Set to `false` to disable reactions entirely. Advanced: set to a JSON object with `processing`, `success`, and/or `failure` to customize emojis; use `null`/`false`/empty string for one key to disable only that lifecycle reaction. |
 | `DISCORD_IGNORED_CHANNELS` | No | — | Comma-separated channel IDs where the bot **never** responds, even when `@mentioned`. Takes priority over all other channel settings. |
 | `DISCORD_ALLOWED_CHANNELS` | No | — | Comma-separated channel IDs. When set, the bot **only** responds in these channels (plus DMs if allowed). Overrides `config.yaml` `discord.allowed_channels`. Combine with `DISCORD_IGNORED_CHANNELS` to express allow/deny rules. |
 | `DISCORD_NO_THREAD_CHANNELS` | No | — | Comma-separated channel IDs where the bot responds directly in the channel instead of creating a thread. Only relevant when `DISCORD_AUTO_THREAD` is `true`. |
@@ -310,7 +310,7 @@ discord:
   thread_require_mention: false   # If true, require @mention in threads too (multi-bot threads)
   free_response_channels: ""      # Comma-separated channel IDs (or YAML list)
   auto_thread: true               # Auto-create threads on @mention
-  reactions: true                 # Add emoji reactions during processing
+  reactions: true                 # true, false, or mapping shown below
   ignored_channels: []            # Channel IDs where bot never responds
   no_thread_channels: []          # Channel IDs where bot responds without threading
   history_backfill: true          # Prepend recent channel scrollback on mention (default: true)
@@ -378,14 +378,35 @@ Messages sent in existing threads or DMs are unaffected by this setting. Channel
 
 #### `discord.reactions`
 
-**Type:** boolean — **Default:** `true`
+**Type:** boolean or mapping — **Default:** `true`
 
 Controls whether the bot adds emoji reactions to messages as visual feedback:
 - 👀 added when the bot starts processing your message
 - ✅ added when the response is delivered successfully
 - ❌ added if an error occurs during processing
 
-Disable this if you find the reactions distracting or if the bot's role doesn't have the **Add Reactions** permission.
+Disable this if you find the reactions distracting or if the bot's role doesn't have the **Add Reactions** permission:
+
+```yaml
+discord:
+  reactions: false
+```
+
+You can also customize each lifecycle emoji. Set an entry to `null` (or `false` / empty string) to disable only that specific reaction while leaving the others enabled:
+
+```yaml
+discord:
+  reactions:
+    processing: ⏳
+    success: 🎉
+    failure: null   # no error reaction
+```
+
+The equivalent env var accepts JSON:
+
+```bash
+DISCORD_REACTIONS='{"processing":"⏳","success":"🎉","failure":null}'
+```
 
 #### `discord.ignored_channels`
 


### PR DESCRIPTION
## Summary
- Allow `discord.reactions` / `DISCORD_REACTIONS` to be a per-lifecycle emoji mapping
- Preserve existing boolean behavior while supporting `null`/false-ish values to disable individual processing/success/failure reactions
- Document the YAML/JSON formats and add regression coverage

## Test Plan
- `python -m pytest tests/gateway/test_discord_reactions.py tests/gateway/test_config.py -q -o 'addopts='`
- `python -m ruff check gateway/platforms/discord.py gateway/config.py hermes_cli/config.py tests/gateway/test_discord_reactions.py tests/gateway/test_config.py`
