### PR TITLE
fix(goals): migrate active goal across compression split

### DIFF
--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -396,6 +396,15 @@ def compress_context(
                 parent_session_id=old_session_id,
             )
             agent._session_db_created = True
+            try:
+                from hermes_cli.goals import migrate_goal_session
+
+                migrate_goal_session(old_session_id, agent.session_id)
+            except Exception as goal_exc:
+                logger.debug(
+                    "Goal state migration after compression split failed: %s",
+                    goal_exc,
+                )
             # Auto-number the title for the continuation session
             if old_title:
                 try:

--- a/hermes_cli/goals.py
+++ b/hermes_cli/goals.py
@@ -8,7 +8,9 @@ goal is done, turn budget is exhausted, the user pauses/clears it, or the
 user sends a new message (which takes priority and pauses the goal loop).
 
 State is persisted in SessionDB's ``state_meta`` table keyed by
-``goal:<session_id>`` so ``/resume`` picks it up.
+``goal:<session_id>`` so ``/resume`` picks it up. When context compression
+rotates a session_id, the active goal state is migrated to the new key so
+autonomous continuation survives compaction.
 
 Design notes / invariants:
 
@@ -277,6 +279,42 @@ def clear_goal(session_id: str) -> None:
         return
     state.status = "cleared"
     save_goal(session_id, state)
+
+
+def migrate_goal_session(old_session_id: str, new_session_id: str) -> bool:
+    """Move an active goal from an old session_id to a new session_id.
+
+    Context compression splits the transcript and rotates ``agent.session_id``.
+    Goals are keyed by session_id, so without this migration the next gateway
+    post-turn hook binds ``GoalManager(new_session_id)`` and sees no active
+    goal, stopping the autonomous /goal loop before the configured turn budget.
+
+    Returns True when an active goal was copied. The old key is marked cleared
+    (audit-preserving) instead of deleted.
+    """
+    if not old_session_id or not new_session_id or old_session_id == new_session_id:
+        return False
+
+    state = load_goal(old_session_id)
+    if state is None or state.status != "active":
+        return False
+
+    existing = load_goal(new_session_id)
+    if existing is not None and existing.status == "active":
+        logger.warning(
+            "GoalManager: refusing to overwrite active goal on compressed session %s",
+            new_session_id,
+        )
+        return False
+
+    save_goal(new_session_id, state)
+    clear_goal(old_session_id)
+    logger.info(
+        "GoalManager: migrated active goal from %s to %s during session split",
+        old_session_id,
+        new_session_id,
+    )
+    return True
 
 
 # ──────────────────────────────────────────────────────────────────────

--- a/tests/hermes_cli/test_goals.py
+++ b/tests/hermes_cli/test_goals.py
@@ -252,6 +252,55 @@ class TestGoalManager:
         assert mgr2.state.goal == "do the thing"
         assert mgr2.is_active()
 
+    def test_migrate_goal_session_preserves_active_goal_after_compression_split(self, hermes_home):
+        """Compression rotates session_id; the active /goal must follow the new session.
+
+        Regression: the goal was keyed as goal:<old_session_id>. After context
+        compression created <new_session_id>, GoalManager(new_session_id) saw no
+        goal, so the autonomous /goal loop stopped long before goals.max_turns.
+        """
+        from hermes_cli.goals import GoalManager, load_goal, migrate_goal_session
+
+        old_mgr = GoalManager(session_id="goal-before-compression", default_max_turns=240)
+        old_state = old_mgr.set("finish milestone")
+        old_state.turns_used = 7
+        old_state.last_verdict = "continue"
+        old_state.last_reason = "more work"
+        old_state.subgoals.append("tests pass")
+        from hermes_cli.goals import save_goal
+        save_goal("goal-before-compression", old_state)
+
+        migrated = migrate_goal_session(
+            "goal-before-compression",
+            "goal-after-compression",
+        )
+
+        assert migrated is True
+        old_after = load_goal("goal-before-compression")
+        assert old_after is not None
+        assert old_after.status == "cleared"
+        new_mgr = GoalManager(session_id="goal-after-compression", default_max_turns=20)
+        assert new_mgr.is_active()
+        assert new_mgr.state is not None
+        assert new_mgr.state.goal == "finish milestone"
+        assert new_mgr.state.max_turns == 240
+        assert new_mgr.state.turns_used == 7
+        assert new_mgr.state.last_verdict == "continue"
+        assert new_mgr.state.last_reason == "more work"
+        assert new_mgr.state.subgoals == ["tests pass"]
+
+    def test_migrate_goal_session_ignores_inactive_or_missing_goal(self, hermes_home):
+        from hermes_cli.goals import GoalManager, load_goal, migrate_goal_session
+
+        assert migrate_goal_session("missing-old", "new") is False
+
+        mgr = GoalManager(session_id="done-old")
+        mgr.set("already done")
+        mgr.mark_done("complete")
+
+        assert migrate_goal_session("done-old", "done-new") is False
+        assert load_goal("done-new") is None
+
     def test_evaluate_after_turn_done(self, hermes_home):
         """Judge says done → status=done, no continuation."""
         from hermes_cli import goals


### PR DESCRIPTION
## Summary
- migrate an active `/goal` state when context compression rotates `session_id`
- preserve the old goal row as `cleared` for audit instead of deleting it
- add regression coverage for active-goal migration and inactive/missing no-op cases

## Root cause
`/goal` state is stored in `SessionDB.state_meta` under `goal:<session_id>`. Context compression creates a continuation session and updates `agent.session_id`. After that split, `GoalManager(new_session_id)` could not find the active goal, so the autonomous goal loop stopped before `goals.max_turns` with no user-facing warning.

## Notes
This is a focused fix for the auto-compression split path. It is related to the existing reports/PRs around goal persistence across compression, including #18467, #18427, and #18749.

Fixes #18467

## Test plan
- [x] `python -m pytest tests/hermes_cli/test_goals.py::TestGoalManager::test_migrate_goal_session_preserves_active_goal_after_compression_split tests/hermes_cli/test_goals.py::TestGoalManager::test_migrate_goal_session_ignores_inactive_or_missing_goal -q -o 'addopts='`
- [x] `python -m pytest tests/hermes_cli/test_goals.py tests/run_agent/test_compression_persistence.py -q -o 'addopts='`
