### PR TITLE
fix(discord): gate bot messages in shared threads

### DIFF
--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -68,6 +68,60 @@ from gateway.platforms.base import (
 from tools.url_safety import is_safe_url
 
 
+_DISCORD_BOT_LOOP_FUEL_EXACT = {
+    "ok",
+    "ack",
+    "acknowledged",
+    "understood",
+    "收到",
+    "明白",
+    "确认",
+    "等",
+    "等老大",
+    "等指令",
+    "等待",
+    "静默",
+    "静默等待",
+    "保持静默",
+    "不发消息",
+    "不发任何消息",
+    "不再回复",
+    "停止",
+    "暂停",
+}
+
+_DISCORD_BOT_LOOP_FUEL_SUBSTRINGS = (
+    "the model returned no response",
+    "codex response remained incomplete",
+    "interrupting current task",
+    "i'll respond to your message shortly",
+    "ill respond to your message shortly",
+)
+
+
+def _normalize_discord_loop_fuel_text(content: str) -> str:
+    """Normalize Discord text for bot-to-bot loop-fuel detection."""
+    normalized = (content or "").strip().lower()
+    normalized = re.sub(r"<@!?\d+>", "", normalized)
+    normalized = re.sub(r"[\s`*_~>\-:：。.!！,，]+", " ", normalized).strip()
+    normalized = normalized.strip("()（）[]【】")
+    return normalized.strip()
+
+
+def _is_discord_bot_loop_fuel(content: str) -> bool:
+    """Return True for bot-originated ack/wait/stop/error messages.
+
+    These messages contain no actionable user intent but can ping another bot
+    in shared Discord threads, causing bot-to-bot acknowledgement loops.
+    """
+    normalized = _normalize_discord_loop_fuel_text(content)
+    if not normalized:
+        return True
+    if normalized in _DISCORD_BOT_LOOP_FUEL_EXACT:
+        return True
+    return any(needle in normalized for needle in _DISCORD_BOT_LOOP_FUEL_SUBSTRINGS)
+
+
 def _clean_discord_id(entry: str) -> str:
     """Strip common prefixes from a Discord user ID or username entry.
 
@@ -748,13 +802,30 @@ class DiscordAdapter(BasePlatformAdapter):
                 # permitted by DISCORD_ALLOW_BOTS are not rejected for
                 # not being in DISCORD_ALLOWED_USERS (fixes #4466).
                 if getattr(message.author, "bot", False):
+                    if _is_discord_bot_loop_fuel(getattr(message, "content", "")):
+                        logger.debug(
+                            "[%s] Ignoring bot loop-fuel Discord message from %s",
+                            self.name,
+                            getattr(message.author, "id", "unknown"),
+                        )
+                        return
+                    # Bot-originated Discord messages must explicitly mention this
+                    # bot.  Do not let shared-thread participation or
+                    # DISCORD_ALLOW_BOTS=all turn another bot's status chatter into
+                    # a new agent run.
+                    client_user = self._client.user if self._client else None
+                    if not client_user or client_user not in message.mentions:
+                        logger.debug(
+                            "[%s] Ignoring bot Discord message without self mention from %s",
+                            self.name,
+                            getattr(message.author, "id", "unknown"),
+                        )
+                        return
                     allow_bots = os.getenv("DISCORD_ALLOW_BOTS", "none").lower().strip()
                     if allow_bots == "none":
                         return
-                    elif allow_bots == "mentions":
-                        if not self._client.user or self._client.user not in message.mentions:
-                            return
-                    # "all" falls through; bot is permitted — skip the
+                    # "mentions" and "all" both fall through after the explicit
+                    # self-mention requirement above; bot is permitted — skip the
                     # human-user allowlist below (bots aren't in it).
                 else:
                     # Non-bot: enforce the configured user/role allowlists.
@@ -4536,6 +4607,7 @@ class DiscordAdapter(BasePlatformAdapter):
             in_bot_thread = (
                 is_thread
                 and thread_id in self._threads
+                and not getattr(message.author, "bot", False)
                 and not self._discord_thread_require_mention()
             )
 

--- a/tests/gateway/test_discord_bot_filter.py
+++ b/tests/gateway/test_discord_bot_filter.py
@@ -5,6 +5,8 @@ import os
 import unittest
 from unittest.mock import AsyncMock, MagicMock, patch
 
+from gateway.platforms.discord import _is_discord_bot_loop_fuel
+
 
 def _make_author(*, bot: bool = False, is_self: bool = False):
     """Create a mock Discord author."""
@@ -48,13 +50,14 @@ class TestDiscordBotFilter(unittest.TestCase):
             return False  # own messages always ignored
 
         if getattr(message.author, "bot", False):
+            if _is_discord_bot_loop_fuel(getattr(message, "content", "")):
+                return False
+            if not client_user or client_user not in message.mentions:
+                return False
             allow = allow_bots.lower().strip()
             if allow == "none":
                 return False
-            elif allow == "mentions":
-                if not client_user or client_user not in message.mentions:
-                    return False
-            # "all" falls through
+            # "mentions" and "all" both fall through after explicit self mention.
         
         return True  # message accepted
 
@@ -78,11 +81,19 @@ class TestDiscordBotFilter(unittest.TestCase):
         msg = _make_message(author=bot)
         self.assertFalse(self._run_filter(msg, "none"))
 
-    def test_allow_bots_all_accepts_bots(self):
-        """With allow_bots=all, all bot messages are accepted."""
+    def test_allow_bots_all_rejects_without_self_mention(self):
+        """Bot messages still require explicit self mention with allow_bots=all."""
+        our_user = _make_author(is_self=True)
         bot = _make_author(bot=True)
-        msg = _make_message(author=bot)
-        self.assertTrue(self._run_filter(msg, "all"))
+        msg = _make_message(author=bot, mentions=[])
+        self.assertFalse(self._run_filter(msg, "all", our_user))
+
+    def test_allow_bots_all_accepts_with_self_mention(self):
+        """With allow_bots=all, substantive bot messages with @mention are accepted."""
+        our_user = _make_author(is_self=True)
+        bot = _make_author(bot=True)
+        msg = _make_message(author=bot, content="Please review PR #123", mentions=[our_user])
+        self.assertTrue(self._run_filter(msg, "all", our_user))
 
     def test_allow_bots_mentions_rejects_without_mention(self):
         """With allow_bots=mentions, bot messages without @mention are rejected."""
@@ -99,18 +110,54 @@ class TestDiscordBotFilter(unittest.TestCase):
         self.assertTrue(self._run_filter(msg, "mentions", our_user))
 
     def test_default_is_none(self):
-        """Default behavior (no env var) should be 'none'."""
-        default = os.getenv("DISCORD_ALLOW_BOTS", "none")
+        """Document the adapter's code default when no env override is set."""
+        with patch.dict(os.environ, {}, clear=True):
+            default = os.getenv("DISCORD_ALLOW_BOTS", "none")
         self.assertEqual(default, "none")
 
     def test_case_insensitive(self):
         """Allow_bots value should be case-insensitive."""
+        our_user = _make_author(is_self=True)
         bot = _make_author(bot=True)
-        msg = _make_message(author=bot)
-        self.assertTrue(self._run_filter(msg, "ALL"))
-        self.assertTrue(self._run_filter(msg, "All"))
-        self.assertFalse(self._run_filter(msg, "NONE"))
-        self.assertFalse(self._run_filter(msg, "None"))
+        msg = _make_message(author=bot, content="Please review this", mentions=[our_user])
+        self.assertTrue(self._run_filter(msg, "ALL", our_user))
+        self.assertTrue(self._run_filter(msg, "All", our_user))
+        self.assertFalse(self._run_filter(msg, "NONE", our_user))
+        self.assertFalse(self._run_filter(msg, "None", our_user))
+
+    def test_bot_wait_ack_messages_are_loop_fuel(self):
+        """Bot wait/ack/stop chatter is ignored even when it mentions this bot."""
+        our_user = _make_author(is_self=True)
+        bot = _make_author(bot=True)
+        for content in [
+            "收到",
+            "等老大",
+            "（静默等待）",
+            "不发任何消息",
+            "⚠️ The model returned no response after processing tool results.",
+            "⚠️ Codex response remained incomplete after 3 continuation attempts",
+            "⚡ Interrupting current task (iteration 1/90). I'll respond to your message shortly.",
+        ]:
+            with self.subTest(content=content):
+                msg = _make_message(author=bot, content=content, mentions=[our_user])
+                self.assertFalse(self._run_filter(msg, "all", our_user))
+
+    def test_human_wait_text_is_not_bot_filtered(self):
+        """Humans can still send short wait/ack text; this gate only filters bots."""
+        human = _make_author(bot=False)
+        msg = _make_message(author=human, content="等老大")
+        self.assertTrue(self._run_filter(msg, "none"))
+
+    def test_substantive_bot_mention_is_not_loop_fuel(self):
+        """Substantive bot messages with self mention still support bot-to-bot review."""
+        our_user = _make_author(is_self=True)
+        bot = _make_author(bot=True)
+        msg = _make_message(
+            author=bot,
+            content="PR #123 is ready. Please review the diff and test plan.",
+            mentions=[our_user],
+        )
+        self.assertTrue(self._run_filter(msg, "all", our_user))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- require bot-originated Discord messages to explicitly mention the current bot before dispatch
- drop bot ack/wait/stop/error loop-fuel messages before model execution
- prevent participated-thread mention bypass from applying to bot messages
- add regression tests for bot filtering, loop-fuel text, and substantive bot review messages

## Test Plan
- python -m compileall gateway/platforms/discord.py tests/gateway/test_discord_bot_filter.py
- pytest -q -o addopts='' tests/gateway/test_discord_bot_filter.py tests/gateway/test_discord_reply_mode.py

## Notes
This is PR 1 / stop-the-bleeding only. Empty-response warning suppression remains a follow-up PR.