### PR TITLE
feat(macos): use Hermes app identity for services

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -39,6 +39,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 from hermes_constants import get_hermes_home
 from hermes_cli._subprocess_compat import windows_hide_flags
 from hermes_cli.config import load_config, _expand_env_vars
+from hermes_cli.macos_identity import executable_for_role
 from hermes_time import now as _hermes_now
 
 logger = logging.getLogger(__name__)
@@ -874,7 +875,10 @@ def _run_job_script(script_path: str) -> tuple[bool, str]:
             )
         argv = [_bash, str(path)]
     else:
-        argv = [sys.executable, str(path)]
+        argv = [
+            executable_for_role(role="cron", hermes_home=_get_hermes_home(), python_path=sys.executable),
+            str(path),
+        ]
 
     run_env = os.environ.copy()
     run_env["HERMES_HOME"] = str(_get_hermes_home())

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -38,6 +38,7 @@ from hermes_cli.setup import (
     prompt, prompt_choice, prompt_yes_no,
 )
 from hermes_cli.colors import Colors, color
+from hermes_cli.macos_identity import executable_for_role
 
 logger = logging.getLogger(__name__)
 
@@ -2783,10 +2784,18 @@ def _launchd_domain() -> str:
 def generate_launchd_plist() -> str:
     python_path = get_python_path()
     working_dir = str(PROJECT_ROOT)
-    hermes_home = str(get_hermes_home().resolve())
+    hermes_home_path = get_hermes_home().resolve()
+    hermes_home = str(hermes_home_path)
     log_dir = get_hermes_home() / "logs"
     log_dir.mkdir(parents=True, exist_ok=True)
     label = get_launchd_label()
+    profile = _profile_suffix() or None
+    gateway_executable = executable_for_role(
+        role="gateway",
+        hermes_home=hermes_home_path,
+        python_path=python_path,
+        profile=profile,
+    )
     profile_arg = _profile_arg(hermes_home)
     # Build a sane PATH for the launchd plist.  launchd provides only a
     # minimal default (/usr/bin:/bin:/usr/sbin:/sbin) which misses Homebrew,
@@ -2809,7 +2818,7 @@ def generate_launchd_plist() -> str:
 
     # Build ProgramArguments array, including --profile when using a named profile
     prog_args = [
-        f"<string>{python_path}</string>",
+        f"<string>{gateway_executable}</string>",
         "<string>-m</string>",
         "<string>hermes_cli.main</string>",
     ]

--- a/hermes_cli/macos_identity.py
+++ b/hermes_cli/macos_identity.py
@@ -1,0 +1,255 @@
+"""macOS process identity helpers for Hermes.
+
+Hermes is a Python application, but launching long-lived services directly via
+``python -m ...`` makes Activity Monitor and other macOS surfaces show every
+process as ``python3.11`` with the generic Python icon.  On macOS the most
+reliable lightweight fix is to launch the interpreter through a Hermes-named
+executable inside a tiny ``.app`` bundle:
+
+* the executable is a symlink to the active Python interpreter, so the runtime
+  environment stays identical;
+* the executable basename becomes the process name;
+* the enclosing bundle gives macOS a stable display name and icon.
+
+This module intentionally has no third-party dependencies and is a no-op on
+non-macOS platforms.
+"""
+
+from __future__ import annotations
+
+import os
+import plistlib
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+
+PROJECT_ROOT = Path(__file__).parent.parent.resolve()
+DEFAULT_ICON_SOURCE = PROJECT_ROOT / "website" / "static" / "img" / "logo.png"
+
+
+def is_macos() -> bool:
+    return sys.platform == "darwin"
+
+
+def _safe_component(value: str) -> str:
+    value = re.sub(r"[^A-Za-z0-9._ ()-]+", "-", value).strip(" .-")
+    return value or "Hermes"
+
+
+def _bundle_identifier(display_name: str) -> str:
+    suffix = re.sub(r"[^A-Za-z0-9]+", ".", display_name.lower()).strip(".")
+    return f"ai.hermes.{suffix or 'agent'}"
+
+
+def default_display_name(role: str = "agent", profile: str | None = None) -> str:
+    """Return the human-facing macOS process/app name for a Hermes role."""
+    normalized = (role or "agent").strip().lower().replace("_", "-")
+    role_names = {
+        "agent": "Hermes",
+        "cli": "Hermes",
+        "chat": "Hermes",
+        "gateway": "Hermes Gateway",
+        "cron": "Hermes Cron",
+        "mcp": "Hermes MCP",
+        "acp": "Hermes ACP",
+    }
+    name = role_names.get(normalized, f"Hermes {normalized.title()}")
+    if profile and profile not in {"default", "root"}:
+        return f"{name} ({profile})"
+    return name
+
+
+def _write_info_plist(app_dir: Path, display_name: str, executable_name: str, icon_stem: str) -> None:
+    plist = {
+        "CFBundleDevelopmentRegion": "en",
+        "CFBundleDisplayName": display_name,
+        "CFBundleExecutable": executable_name,
+        "CFBundleIconFile": icon_stem,
+        "CFBundleIdentifier": _bundle_identifier(display_name),
+        "CFBundleInfoDictionaryVersion": "6.0",
+        "CFBundleName": display_name,
+        "CFBundlePackageType": "APPL",
+        "CFBundleShortVersionString": "1.0",
+        "CFBundleVersion": "1",
+        # Hermes gateway/profile agents are background processes; this prevents
+        # a Dock icon while preserving app metadata for Activity Monitor.
+        "LSBackgroundOnly": True,
+    }
+    (app_dir / "Contents").mkdir(parents=True, exist_ok=True)
+    with (app_dir / "Contents" / "Info.plist").open("wb") as handle:
+        plistlib.dump(plist, handle, sort_keys=False)
+
+
+def _run_quiet(cmd: list[str], timeout: float = 15) -> None:
+    proc = subprocess.Popen(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    try:
+        returncode = proc.wait(timeout=timeout)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        proc.wait()
+        raise
+    if returncode != 0:
+        raise subprocess.CalledProcessError(returncode, cmd)
+
+
+def _generate_icns(icon_source: Path, resources_dir: Path, icon_stem: str) -> bool:
+    """Generate ``Resources/<icon_stem>.icns`` from a PNG using macOS tools.
+
+    Returns True when a real ``.icns`` exists, False when the caller should use
+    the PNG fallback.  Failures are deliberately non-fatal: naming the process
+    is more important than icon conversion, and iconutil/sips can be absent on
+    stripped-down CI images.
+    """
+    if not icon_source.exists():
+        return False
+    icns = resources_dir / f"{icon_stem}.icns"
+    if icns.exists():
+        return True
+    if not shutil.which("sips") or not shutil.which("iconutil"):
+        return False
+
+    iconset = resources_dir / f"{icon_stem}.iconset"
+    try:
+        if iconset.exists():
+            shutil.rmtree(iconset)
+        iconset.mkdir(parents=True, exist_ok=True)
+        sizes = [16, 32, 64, 128, 256, 512]
+        for size in sizes:
+            _run_quiet(
+                ["sips", "-z", str(size), str(size), str(icon_source), "--out", str(iconset / f"icon_{size}x{size}.png")],
+                timeout=15,
+            )
+            _run_quiet(
+                ["sips", "-z", str(size * 2), str(size * 2), str(icon_source), "--out", str(iconset / f"icon_{size}x{size}@2x.png")],
+                timeout=15,
+            )
+        _run_quiet(
+            ["iconutil", "-c", "icns", str(iconset), "-o", str(icns)],
+            timeout=15,
+        )
+        return icns.exists()
+    except Exception:
+        return False
+    finally:
+        shutil.rmtree(iconset, ignore_errors=True)
+
+
+def _link_virtualenv_payload(contents_dir: Path, python_executable: Path) -> None:
+    """Make a symlinked venv interpreter keep seeing its venv packages.
+
+    Python determines virtualenv membership from ``pyvenv.cfg`` near the
+    executable path.  Once the executable is symlinked into ``Foo.app`` it no
+    longer sees the original venv, so imports fall back to the base interpreter.
+    Mirroring ``pyvenv.cfg`` and ``lib`` into ``Contents`` preserves the venv
+    while keeping the Hermes-named executable basename.
+    """
+    venv_dir = python_executable.parent.parent
+    pyvenv_cfg = venv_dir / "pyvenv.cfg"
+    lib_dir = venv_dir / "lib"
+    if not pyvenv_cfg.exists() or not lib_dir.exists():
+        return
+
+    shutil.copy2(pyvenv_cfg, contents_dir / "pyvenv.cfg")
+    lib_link = contents_dir / "lib"
+    if lib_link.exists() or lib_link.is_symlink():
+        try:
+            current_target = Path(os.readlink(lib_link)) if lib_link.is_symlink() else lib_link
+            if current_target != lib_dir:
+                if lib_link.is_dir() and not lib_link.is_symlink():
+                    shutil.rmtree(lib_link)
+                else:
+                    lib_link.unlink()
+        except OSError:
+            lib_link.unlink(missing_ok=True)
+    if not lib_link.exists():
+        lib_link.symlink_to(lib_dir)
+
+
+def ensure_app_bundle(
+    *,
+    base_dir: Path,
+    display_name: str,
+    python_path: str | Path | None = None,
+    icon_source: Path | None = None,
+) -> Path:
+    """Create/update a named Hermes ``.app`` bundle and return its executable.
+
+    ``base_dir`` should live in the relevant Hermes home so profile-specific
+    services do not fight over bundle metadata.
+    """
+    python_executable = Path(python_path or sys.executable).absolute()
+    app_dir = base_dir / f"{_safe_component(display_name)}.app"
+    contents = app_dir / "Contents"
+    macos_dir = contents / "MacOS"
+    resources_dir = contents / "Resources"
+    executable_name = _safe_component(display_name)
+    executable_path = macos_dir / executable_name
+    icon_stem = "Hermes"
+
+    macos_dir.mkdir(parents=True, exist_ok=True)
+    resources_dir.mkdir(parents=True, exist_ok=True)
+
+    if executable_path.exists() or executable_path.is_symlink():
+        try:
+            current_target = Path(os.readlink(executable_path)) if executable_path.is_symlink() else executable_path
+            if current_target != python_executable:
+                executable_path.unlink()
+        except OSError:
+            executable_path.unlink(missing_ok=True)
+    if not executable_path.exists():
+        executable_path.symlink_to(python_executable)
+    _link_virtualenv_payload(contents, python_executable)
+
+    source = icon_source or DEFAULT_ICON_SOURCE
+    icon_file_stem = icon_stem
+    if not _generate_icns(source, resources_dir, icon_stem):
+        # Best-effort fallback.  Some macOS surfaces accept PNG here; even when
+        # they don't, the bundle remains valid and the process name is fixed.
+        if source.exists():
+            shutil.copy2(source, resources_dir / f"{icon_stem}.png")
+            icon_file_stem = f"{icon_stem}.png"
+
+    _write_info_plist(app_dir, display_name, executable_name, icon_file_stem)
+    return executable_path
+
+
+def executable_for_role(
+    *,
+    role: str,
+    hermes_home: Path,
+    python_path: str | Path | None = None,
+    profile: str | None = None,
+) -> str:
+    """Return a macOS named executable for ``role``; otherwise return Python.
+
+    This is safe to call from service generators on any platform.
+    """
+    if not is_macos():
+        return str(python_path or sys.executable)
+    display_name = default_display_name(role, profile)
+    app_base = Path(hermes_home).resolve() / "macos-apps"
+    return str(ensure_app_bundle(base_dir=app_base, display_name=display_name, python_path=python_path))
+
+
+def maybe_reexec_current_process(role: str = "agent", profile: str | None = None) -> None:
+    """Re-exec the current macOS Python process through a Hermes-named bundle.
+
+    This is intentionally opt-in because re-execing interactive shells can be
+    surprising.  Callers set ``HERMES_MACOS_IDENTITY_REEXEC=1`` when they want
+    foreground CLI processes to get the same Activity Monitor identity as
+    launchd-managed services.
+    """
+    if not is_macos() or os.environ.get("HERMES_MACOS_IDENTITY_REEXEC") != "1":
+        return
+    if os.environ.get("HERMES_MACOS_IDENTITY_ACTIVE") == "1":
+        return
+    from hermes_constants import get_hermes_home
+
+    executable = executable_for_role(role=role, hermes_home=get_hermes_home(), python_path=sys.executable, profile=profile)
+    if Path(executable).resolve() == Path(sys.executable).resolve() and Path(sys.executable).name.startswith("Hermes"):
+        return
+    os.environ["HERMES_MACOS_IDENTITY_ACTIVE"] = "1"
+    os.execv(executable, [executable, *sys.argv])

--- a/tests/cron/test_cron_script.py
+++ b/tests/cron/test_cron_script.py
@@ -148,11 +148,20 @@ class TestRunJobScript:
         from cron import scheduler as sched_mod
         from cron.scheduler import _run_job_script
 
-        # Use a very short timeout
+        # This test exercises timeout handling, not real process cleanup. Mock
+        # subprocess.run so it stays hermetic under the live-system guard.
         monkeypatch.setattr(sched_mod, "_SCRIPT_TIMEOUT", 1)
 
         script = cron_env / "scripts" / "slow.py"
         script.write_text("import time; time.sleep(30)\n")
+
+        def fake_run(argv, **kwargs):
+            assert argv == [sys.executable, str(script)]
+            assert kwargs["timeout"] == 1
+            raise sched_mod.subprocess.TimeoutExpired(cmd=argv, timeout=1)
+
+        monkeypatch.setattr(sched_mod, "executable_for_role", lambda **kwargs: sys.executable)
+        monkeypatch.setattr(sched_mod.subprocess, "run", fake_run)
 
         success, output = _run_job_script(str(script))
         assert success is False
@@ -173,6 +182,38 @@ class TestRunJobScript:
         assert success is True
         parsed = json.loads(output)
         assert parsed["new_prs"][0]["number"] == 42
+
+    def test_python_script_uses_macos_identity_executable(self, cron_env, monkeypatch):
+        """Cron Python scripts use the role-specific executable on macOS."""
+        from cron import scheduler as sched_mod
+        from cron.scheduler import _run_job_script
+
+        script = cron_env / "scripts" / "identity.py"
+        script.write_text('print("identity")\n')
+        calls = []
+
+        def fake_executable_for_role(**kwargs):
+            calls.append(kwargs)
+            return "/tmp/Hermes Cron.app/Contents/MacOS/Hermes Cron"
+
+        def fake_run(argv, **kwargs):
+            assert argv == ["/tmp/Hermes Cron.app/Contents/MacOS/Hermes Cron", str(script)]
+            return type("Result", (), {"returncode": 0, "stdout": "identity\n", "stderr": ""})()
+
+        monkeypatch.setattr(sched_mod, "executable_for_role", fake_executable_for_role)
+        monkeypatch.setattr(sched_mod.subprocess, "run", fake_run)
+
+        success, output = _run_job_script(str(script))
+
+        assert success is True
+        assert output == "identity"
+        assert calls == [
+            {
+                "role": "cron",
+                "hermes_home": cron_env,
+                "python_path": sys.executable,
+            }
+        ]
 
 
 class TestBuildJobPromptWithScript:

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -67,6 +67,7 @@ class TestSystemdServiceRefresh:
 
         monkeypatch.setattr(gateway_cli, "get_systemd_unit_path", lambda system=False: unit_path)
         monkeypatch.setattr(gateway_cli, "generate_systemd_unit", lambda system=False, run_as_user=None: "new unit\n")
+        monkeypatch.setattr(gateway_cli, "_preflight_user_systemd", lambda **kwargs: None)
 
         calls = []
 
@@ -90,6 +91,7 @@ class TestSystemdServiceRefresh:
 
         monkeypatch.setattr(gateway_cli, "get_systemd_unit_path", lambda system=False: unit_path)
         monkeypatch.setattr(gateway_cli, "generate_systemd_unit", lambda system=False, run_as_user=None: "new unit\n")
+        monkeypatch.setattr(gateway_cli, "_preflight_user_systemd", lambda **kwargs: None)
 
         calls = []
         monkeypatch.setattr("gateway.status.get_running_pid", lambda: None)
@@ -475,6 +477,30 @@ class TestLaunchdServiceRecovery:
             == DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT
         )
 
+    def test_launchd_plist_uses_macos_app_executable_for_process_identity(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(gateway_cli, "get_python_path", lambda: str(tmp_path / "python"))
+        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: tmp_path / "hermes-home")
+        monkeypatch.setattr(gateway_cli, "_profile_suffix", lambda: "coder")
+        calls = []
+
+        def fake_executable_for_role(**kwargs):
+            calls.append(kwargs)
+            return "/tmp/Hermes Gateway.app/Contents/MacOS/Hermes Gateway"
+
+        monkeypatch.setattr(gateway_cli, "executable_for_role", fake_executable_for_role)
+
+        plist = gateway_cli.generate_launchd_plist()
+
+        assert "<string>/tmp/Hermes Gateway.app/Contents/MacOS/Hermes Gateway</string>" in plist
+        assert calls == [
+            {
+                "role": "gateway",
+                "hermes_home": tmp_path / "hermes-home",
+                "python_path": str(tmp_path / "python"),
+                "profile": "coder",
+            }
+        ]
+
     def test_launchd_install_repairs_outdated_plist_without_force(self, tmp_path, monkeypatch):
         plist_path = tmp_path / "ai.hermes.gateway.plist"
         plist_path.write_text("<plist>old content</plist>", encoding="utf-8")
@@ -742,6 +768,7 @@ class TestGatewaySystemServiceRouting:
 
         monkeypatch.setattr(gateway_cli, "_select_systemd_scope", lambda system=False: False)
         monkeypatch.setattr(gateway_cli, "_require_service_installed", lambda action, system=False: None)
+        monkeypatch.setattr(gateway_cli, "_preflight_user_systemd", lambda **kwargs: None)
         monkeypatch.setattr(gateway_cli, "refresh_systemd_unit_if_needed", lambda system=False: calls.append(("refresh", system)))
         monkeypatch.setattr(gateway_cli, "_get_restart_drain_timeout", lambda: 12.0)
         monkeypatch.setattr(
@@ -787,6 +814,7 @@ class TestGatewaySystemServiceRouting:
 
         monkeypatch.setattr(gateway_cli, "_select_systemd_scope", lambda system=False: False)
         monkeypatch.setattr(gateway_cli, "_require_service_installed", lambda action, system=False: None)
+        monkeypatch.setattr(gateway_cli, "_preflight_user_systemd", lambda **kwargs: None)
         monkeypatch.setattr(gateway_cli, "refresh_systemd_unit_if_needed", lambda system=False: None)
         monkeypatch.setattr(gateway_cli, "_get_restart_drain_timeout", lambda: 10.0)
         monkeypatch.setattr("gateway.status.get_running_pid", lambda: None)
@@ -846,6 +874,7 @@ class TestGatewaySystemServiceRouting:
 
         monkeypatch.setattr(gateway_cli, "_select_systemd_scope", lambda system=False: False)
         monkeypatch.setattr(gateway_cli, "_require_service_installed", lambda action, system=False: None)
+        monkeypatch.setattr(gateway_cli, "_preflight_user_systemd", lambda **kwargs: None)
         monkeypatch.setattr(gateway_cli, "refresh_systemd_unit_if_needed", lambda system=False: None)
         monkeypatch.setattr("gateway.status.get_running_pid", lambda: None)
         monkeypatch.setattr(gateway_cli, "_recover_pending_systemd_restart", lambda system=False, previous_pid=None: False)
@@ -876,6 +905,7 @@ class TestGatewaySystemServiceRouting:
     def test_systemd_restart_recovers_failed_planned_restart(self, monkeypatch, capsys):
         monkeypatch.setattr(gateway_cli, "_select_systemd_scope", lambda system=False: False)
         monkeypatch.setattr(gateway_cli, "_require_service_installed", lambda action, system=False: None)
+        monkeypatch.setattr(gateway_cli, "_preflight_user_systemd", lambda **kwargs: None)
         monkeypatch.setattr(gateway_cli, "refresh_systemd_unit_if_needed", lambda system=False: None)
         monkeypatch.setattr(
             "gateway.status.read_runtime_status",

--- a/tests/hermes_cli/test_macos_identity.py
+++ b/tests/hermes_cli/test_macos_identity.py
@@ -1,0 +1,57 @@
+from pathlib import Path
+import plistlib
+
+from hermes_cli import macos_identity
+
+
+def test_ensure_app_bundle_creates_named_python_symlink_and_plist(tmp_path):
+    python = tmp_path / "python3.11"
+    python.write_text("#!/bin/sh\n", encoding="utf-8")
+    icon = tmp_path / "logo.png"
+    icon.write_bytes(b"png")
+
+    executable = macos_identity.ensure_app_bundle(
+        base_dir=tmp_path / "apps",
+        display_name="Hermes Gateway (coder)",
+        python_path=python,
+        icon_source=icon,
+    )
+
+    assert executable.name == "Hermes Gateway (coder)"
+    assert executable.is_symlink()
+    assert executable.resolve() == python
+
+    app_dir = tmp_path / "apps" / "Hermes Gateway (coder).app"
+    info = plistlib.loads((app_dir / "Contents" / "Info.plist").read_bytes())
+    assert info["CFBundleName"] == "Hermes Gateway (coder)"
+    assert info["CFBundleDisplayName"] == "Hermes Gateway (coder)"
+    assert info["CFBundleExecutable"] == "Hermes Gateway (coder)"
+    assert info["LSBackgroundOnly"] is True
+    assert (app_dir / "Contents" / "Resources" / "Hermes.png").exists()
+
+
+def test_executable_for_role_is_python_on_non_macos(monkeypatch, tmp_path):
+    monkeypatch.setattr(macos_identity.sys, "platform", "linux")
+
+    assert macos_identity.executable_for_role(
+        role="gateway",
+        hermes_home=tmp_path,
+        python_path="/usr/bin/python3",
+    ) == "/usr/bin/python3"
+
+
+def test_executable_for_role_creates_profile_scoped_macos_app(monkeypatch, tmp_path):
+    monkeypatch.setattr(macos_identity.sys, "platform", "darwin")
+    monkeypatch.setattr(macos_identity, "_generate_icns", lambda *args, **kwargs: False)
+    python = tmp_path / "python"
+    python.write_text("", encoding="utf-8")
+
+    executable = Path(macos_identity.executable_for_role(
+        role="gateway",
+        hermes_home=tmp_path / "hermes-home",
+        python_path=python,
+        profile="family-agent",
+    ))
+
+    assert executable.name == "Hermes Gateway (family-agent)"
+    assert executable.parent.parent.parent == tmp_path / "hermes-home" / "macos-apps" / "Hermes Gateway (family-agent).app"


### PR DESCRIPTION
## Summary
- Add a macOS process identity helper that creates tiny role-specific Hermes `.app` bundles with Hermes display names/icons while symlinking back to the active Python interpreter.
- Use the helper for launchd gateway ProgramArguments so Activity Monitor shows `Hermes Gateway` / profile-scoped names instead of `python3.11`.
- Use the helper for cron Python script execution so scheduled script processes show `Hermes Cron` on macOS while staying a no-op on non-macOS.
- Harden related tests so systemd service tests remain hermetic on macOS hosts without user systemd.

## Test plan
- `python -m ruff check hermes_cli/macos_identity.py hermes_cli/gateway.py cron/scheduler.py tests/hermes_cli/test_macos_identity.py tests/hermes_cli/test_gateway_service.py tests/cron/test_cron_script.py`
- `scripts/run_tests.sh tests/hermes_cli/test_macos_identity.py tests/cron/test_cron_script.py tests/hermes_cli/test_gateway_service.py -- -q`
- Manual macOS smoke check: `executable_for_role(role="gateway", profile="coder")` creates `Hermes Gateway (coder).app` with matching `CFBundleDisplayName`, executable name, and `LSBackgroundOnly=true`.


## Example

<img width="644" height="191" alt="obraz" src="https://github.com/user-attachments/assets/a9f8b6f7-efb3-4c99-9d3e-e61abe235317" />
