### PR TITLE
feat: add swarm operator live delegation stack

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -25,6 +25,7 @@ from agent.skill_utils import (
     skill_matches_platform,
 )
 from utils import atomic_json_write
+from agent.swarm_prompt import build_swarm_operator_prompt, swarm_operator_enabled
 
 logger = logging.getLogger(__name__)
 

--- a/agent/swarm_evidence.py
+++ b/agent/swarm_evidence.py
@@ -8,7 +8,7 @@ kinds are actually present with kind-specific fields.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, Dict, Iterable, List
+from typing import Any, Dict, Iterable, List, Set
 
 from agent.swarm_state import EvidenceRequirement
 
@@ -152,6 +152,62 @@ def _requirement_required(requirement: Any) -> bool:
     return bool(getattr(requirement, "required", True))
 
 
+def _requirement_metadata(requirement: Any) -> Dict[str, Any]:
+    if isinstance(requirement, EvidenceRequirement):
+        return dict(requirement.metadata or {})
+    if isinstance(requirement, dict):
+        metadata = dict(requirement.get("metadata") or {}) if isinstance(requirement.get("metadata"), dict) else {}
+        for key in ("permission_id", "approval_id", "id", "permission_ids", "approval_ids"):
+            if key in requirement and key not in metadata:
+                metadata[key] = requirement[key]
+        return metadata
+    metadata = getattr(requirement, "metadata", {})
+    return dict(metadata) if isinstance(metadata, dict) else {}
+
+
+def _approval_grant_status(grant: Any) -> str:
+    if isinstance(grant, dict):
+        return str(grant.get("status") or "").lower().strip()
+    return str(getattr(grant, "status", "") or "").lower().strip()
+
+
+def _approval_grant_id(grant: Any) -> str:
+    if isinstance(grant, dict):
+        return str(grant.get("permission_id") or grant.get("approval_id") or grant.get("id") or "")
+    return str(getattr(grant, "permission_id", "") or getattr(grant, "approval_id", "") or getattr(grant, "id", "") or "")
+
+
+def _approval_ids_for_requirement(requirement: Any) -> Set[str]:
+    metadata = _requirement_metadata(requirement)
+    ids: Set[str] = set()
+    for key in ("permission_id", "approval_id", "id"):
+        value = metadata.get(key)
+        if value:
+            ids.add(str(value))
+    for key in ("permission_ids", "approval_ids"):
+        value = metadata.get(key)
+        if isinstance(value, str):
+            ids.add(value)
+        elif isinstance(value, (list, tuple, set)):
+            ids.update(str(item) for item in value if item)
+    for attr in ("permission_id", "approval_id"):
+        value = getattr(requirement, attr, "")
+        if value:
+            ids.add(str(value))
+    return ids
+
+
+def _parent_approval_satisfies(requirement: Any, approval_grants: Iterable[Any] | None) -> bool:
+    approved_grants = [grant for grant in approval_grants or [] if _approval_grant_status(grant) == "approved"]
+    if not approved_grants:
+        return False
+    required_ids = _approval_ids_for_requirement(requirement)
+    if not required_ids:
+        return False
+    approved_ids = {_approval_grant_id(grant) for grant in approved_grants if _approval_grant_id(grant)}
+    return required_ids.issubset(approved_ids)
+
+
 def _item_satisfies_kind(item: EvidenceItem, kind: str) -> bool:
     actual = item.kind.lower().strip()
     expected = kind.lower().strip()
@@ -175,19 +231,30 @@ def _item_satisfies_kind(item: EvidenceItem, kind: str) -> bool:
     return bool(text.strip())
 
 
-def validate_evidence_packet(packet: EvidencePacket | Dict[str, Any], requirements: Iterable[Any]) -> EvidenceValidationResult:
+def validate_evidence_packet(
+    packet: EvidencePacket | Dict[str, Any],
+    requirements: Iterable[Any],
+    *,
+    approval_grants: Iterable[Any] | None = None,
+) -> EvidenceValidationResult:
     packet = EvidencePacket.from_result(packet)
+    required_requirements = []
     required_kinds = []
     for requirement in requirements or []:
         kind = _requirement_kind(requirement)
         if kind and _requirement_required(requirement):
+            required_requirements.append(requirement)
             required_kinds.append(kind)
 
     satisfied: List[str] = []
     missing: List[str] = []
     reasons: List[str] = []
-    for kind in required_kinds:
-        if any(_item_satisfies_kind(item, kind) for item in packet.evidence):
+    for requirement, kind in zip(required_requirements, required_kinds):
+        if kind.lower().strip() == "human_approval":
+            kind_satisfied = _parent_approval_satisfies(requirement, approval_grants)
+        else:
+            kind_satisfied = any(_item_satisfies_kind(item, kind) for item in packet.evidence)
+        if kind_satisfied:
             if kind not in satisfied:
                 satisfied.append(kind)
         else:

--- a/agent/swarm_evidence.py
+++ b/agent/swarm_evidence.py
@@ -1,0 +1,215 @@
+"""Structured evidence packets for swarm child outputs.
+
+This module stays deterministic and side-effect free. It parses child result
+payloads into a small evidence contract and validates that required evidence
+kinds are actually present with kind-specific fields.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, Iterable, List
+
+from agent.swarm_state import EvidenceRequirement
+
+
+@dataclass
+class EvidenceItem:
+    kind: str
+    description: str = ""
+    command: str = ""
+    output: str = ""
+    url: str = ""
+    path: str = ""
+    approved_by: str = ""
+    approval_id: str = ""
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_value(cls, value: Any) -> "EvidenceItem":
+        if isinstance(value, EvidenceItem):
+            return value
+        if isinstance(value, str):
+            return cls(kind="artifact", description=value)
+        if not isinstance(value, dict):
+            return cls(kind="artifact", description=repr(value))
+        return cls(
+            kind=str(value.get("kind") or value.get("type") or "artifact"),
+            description=str(value.get("description") or value.get("summary") or value.get("text") or ""),
+            command=str(value.get("command") or ""),
+            output=str(value.get("output") or value.get("stdout") or value.get("result") or ""),
+            url=str(value.get("url") or value.get("source") or ""),
+            path=str(value.get("path") or value.get("file") or value.get("artifact") or ""),
+            approved_by=str(value.get("approved_by") or value.get("approver") or ""),
+            approval_id=str(value.get("approval_id") or value.get("permission_id") or ""),
+            metadata={k: v for k, v in value.items() if k not in {"kind", "type", "description", "summary", "text", "command", "output", "stdout", "result", "url", "source", "path", "file", "artifact", "approved_by", "approver", "approval_id", "permission_id"}},
+        )
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "kind": self.kind,
+            "description": self.description,
+            "command": self.command,
+            "output": self.output,
+            "url": self.url,
+            "path": self.path,
+            "approved_by": self.approved_by,
+            "approval_id": self.approval_id,
+            "metadata": dict(self.metadata),
+        }
+
+
+@dataclass
+class EvidencePacket:
+    summary: str = ""
+    claims: List[str] = field(default_factory=list)
+    evidence: List[EvidenceItem] = field(default_factory=list)
+    assumptions: List[str] = field(default_factory=list)
+    unresolved: List[str] = field(default_factory=list)
+    risks: List[str] = field(default_factory=list)
+    confidence: str = "unknown"
+    side_effects_requested: List[str] = field(default_factory=list)
+    side_effects_performed: List[str] = field(default_factory=list)
+
+    @classmethod
+    def from_result(cls, result: Any) -> "EvidencePacket":
+        if isinstance(result, EvidencePacket):
+            return result
+        if isinstance(result, str):
+            return cls(summary=result)
+        if not isinstance(result, dict):
+            return cls(summary=repr(result))
+        raw_evidence = result.get("evidence") or []
+        if isinstance(raw_evidence, (str, dict)):
+            raw_evidence = [raw_evidence]
+        return cls(
+            summary=str(result.get("summary") or result.get("content") or result.get("message") or ""),
+            claims=_string_list(result.get("claims") or []),
+            evidence=[EvidenceItem.from_value(item) for item in raw_evidence if item is not None],
+            assumptions=_string_list(result.get("assumptions") or []),
+            unresolved=_string_list(result.get("unresolved") or result.get("open_issues") or []),
+            risks=_string_list(result.get("risks") or []),
+            confidence=str(result.get("confidence") or "unknown"),
+            side_effects_requested=_string_list(result.get("side_effects_requested") or []),
+            side_effects_performed=_string_list(result.get("side_effects_performed") or []),
+        )
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "summary": self.summary,
+            "claims": list(self.claims),
+            "evidence": [item.to_dict() for item in self.evidence],
+            "assumptions": list(self.assumptions),
+            "unresolved": list(self.unresolved),
+            "risks": list(self.risks),
+            "confidence": self.confidence,
+            "side_effects_requested": list(self.side_effects_requested),
+            "side_effects_performed": list(self.side_effects_performed),
+        }
+
+
+@dataclass
+class EvidenceValidationResult:
+    passed: bool
+    reasons: List[str] = field(default_factory=list)
+    missing_required_kinds: List[str] = field(default_factory=list)
+    satisfied_kinds: List[str] = field(default_factory=list)
+    unsupported_claims: List[str] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "passed": self.passed,
+            "reasons": list(self.reasons),
+            "missing_required_kinds": list(self.missing_required_kinds),
+            "satisfied_kinds": list(self.satisfied_kinds),
+            "unsupported_claims": list(self.unsupported_claims),
+        }
+
+
+def _string_list(value: Any) -> List[str]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        return [value] if value else []
+    if isinstance(value, (list, tuple, set)):
+        return [str(item) for item in value if item]
+    return [str(value)]
+
+
+def _requirement_kind(requirement: Any) -> str:
+    if isinstance(requirement, EvidenceRequirement):
+        return requirement.kind
+    if isinstance(requirement, dict):
+        return str(requirement.get("kind") or "")
+    return str(getattr(requirement, "kind", "") or "")
+
+
+def _requirement_required(requirement: Any) -> bool:
+    if isinstance(requirement, EvidenceRequirement):
+        return requirement.required
+    if isinstance(requirement, dict):
+        return bool(requirement.get("required", True))
+    return bool(getattr(requirement, "required", True))
+
+
+def _item_satisfies_kind(item: EvidenceItem, kind: str) -> bool:
+    actual = item.kind.lower().strip()
+    expected = kind.lower().strip()
+    if actual != expected:
+        return False
+    text = " ".join([item.description, item.command, item.output, item.url, item.path, item.approved_by, item.approval_id]).lower()
+    if expected == "citation":
+        return bool(item.url or item.metadata.get("title") or "http" in text or "source" in text)
+    if expected == "test":
+        return bool(item.command and item.output and any(marker in text for marker in ("pass", "fail", "pytest", "test", "lint", "typecheck")))
+    if expected == "command_output":
+        return bool(item.command and item.output)
+    if expected == "dry_run":
+        return bool((item.command or item.output or item.description) and any(marker in text for marker in ("dry-run", "dry run", "payload", "would", "no-op", "contract")))
+    if expected == "artifact":
+        return bool(item.path or item.url or item.description)
+    if expected == "human_approval":
+        # Child output cannot prove human approval. Parent/job permission state must
+        # verify approvals in a later live execution layer.
+        return False
+    return bool(text.strip())
+
+
+def validate_evidence_packet(packet: EvidencePacket | Dict[str, Any], requirements: Iterable[Any]) -> EvidenceValidationResult:
+    packet = EvidencePacket.from_result(packet)
+    required_kinds = []
+    for requirement in requirements or []:
+        kind = _requirement_kind(requirement)
+        if kind and _requirement_required(requirement):
+            required_kinds.append(kind)
+
+    satisfied: List[str] = []
+    missing: List[str] = []
+    reasons: List[str] = []
+    for kind in required_kinds:
+        if any(_item_satisfies_kind(item, kind) for item in packet.evidence):
+            if kind not in satisfied:
+                satisfied.append(kind)
+        else:
+            missing.append(kind)
+            reasons.append(f"missing_{kind}")
+
+    unsupported_claims = list(packet.claims) if missing and packet.claims else []
+    if packet.side_effects_performed and "human_approval" in missing:
+        reasons.append("side_effects_without_approval")
+
+    return EvidenceValidationResult(
+        passed=not missing and not (packet.side_effects_performed and "human_approval" in missing),
+        reasons=reasons,
+        missing_required_kinds=missing,
+        satisfied_kinds=satisfied,
+        unsupported_claims=unsupported_claims,
+    )
+
+
+__all__ = [
+    "EvidenceItem",
+    "EvidencePacket",
+    "EvidenceValidationResult",
+    "validate_evidence_packet",
+]

--- a/agent/swarm_executor.py
+++ b/agent/swarm_executor.py
@@ -210,12 +210,16 @@ def execute_swarm(
         failed = _result_failed(result)
         requirements = getattr(routing_plan, "evidence_requirements", []) or []
         if requirements:
-            evidence_validation = validate_evidence_packet(EvidencePacket.from_result(result), requirements)
+            evidence_validation = validate_evidence_packet(
+                EvidencePacket.from_result(result),
+                requirements,
+                approval_grants=job.permissions,
+            )
             if isinstance(result, dict):
                 result = {**result, "evidence_validation": evidence_validation.to_dict()}
                 if index < len(results):
                     results[index] = result
-        weak_output = detect_weak_output(result, requirements)
+        weak_output = detect_weak_output(result, requirements, approval_grants=job.permissions)
         if weak_output["weak"]:
             result = {**result, "weak_output": weak_output}
             if index < len(results):

--- a/agent/swarm_executor.py
+++ b/agent/swarm_executor.py
@@ -124,6 +124,16 @@ def _ensure_job_tasks(job: SwarmJob, routing_plan: RoutingPlan) -> None:
             toolsets=_coerce_toolsets(item.get("toolsets")),
             permission_required=_task_requires_permission(item),
         )
+    if not job.tasks and getattr(routing_plan, "permission_requests", None):
+        descriptions = "; ".join(grant.description for grant in routing_plan.permission_requests if getattr(grant, "description", ""))
+        job.add_task(
+            "Await human approval",
+            descriptions or "Permission required before live side effects",
+            task_id=f"{job.job_id}_permission_gate",
+            mode=str(routing_plan.mode),
+            permission_required=True,
+            metadata={"permission_ids": [grant.permission_id for grant in routing_plan.permission_requests]},
+        )
 
 
 def _parse_delegate_response(response: Any) -> List[Dict[str, Any]]:

--- a/agent/swarm_executor.py
+++ b/agent/swarm_executor.py
@@ -11,6 +11,7 @@ import json
 from dataclasses import dataclass, field
 from typing import Any, Callable, Dict, List, Optional
 
+from agent.swarm_learning import detect_weak_output
 from agent.swarm_state import AuditEvent, JobStatus, RoutingPlan, SwarmJob, SwarmTask, TaskStatus
 
 
@@ -173,26 +174,36 @@ def execute_swarm(
         results = [{"error": str(exc), "status": "failed", "critical": True}]
 
     failures = 0
+    weak_count = 0
     critical_failure = False
     for index, delegate in enumerate(delegates):
         task = by_id.get(str(delegate.get("swarm_task_id") or ""))
         result = results[index] if index < len(results) else {"error": "missing child result", "status": "failed"}
         failed = _result_failed(result)
+        weak_output = detect_weak_output(result, getattr(routing_plan, "evidence_requirements", []) or [])
+        if weak_output["weak"]:
+            result = {**result, "weak_output": weak_output}
+            if index < len(results):
+                results[index] = result
+        weak = bool(weak_output["weak"])
+        weak_count += 1 if weak else 0
         failures += 1 if failed else 0
         suggested = (routing_plan.suggested_tasks or [])[index] if index < len(routing_plan.suggested_tasks or []) else {}
         is_critical = bool(result.get("critical") or (isinstance(suggested, dict) and suggested.get("critical")))
         critical_failure = critical_failure or (failed and is_critical)
         if task:
             task.result = dict(result)
-            task.status = TaskStatus.FAILED.value if failed else TaskStatus.COMPLETED.value
+            task.status = TaskStatus.FAILED.value if failed else (TaskStatus.NEEDS_REVIEW.value if weak else TaskStatus.COMPLETED.value)
+            if weak:
+                job.audit.append(AuditEvent("weak_child_output", "Child result lacked required evidence", metadata={"task_id": task.task_id, **weak_output}))
 
     if critical_failure:
         final_status = JobStatus.FAILED.value
-    elif failures or blocked:
+    elif failures or blocked or weak_count:
         final_status = JobStatus.PARTIALLY_COMPLETED.value
     else:
         final_status = JobStatus.COMPLETED.value
-    job.transition(final_status, metadata={"failure_count": failures, "blocked_count": len(blocked)})
+    job.transition(final_status, metadata={"failure_count": failures, "blocked_count": len(blocked), "weak_output_count": weak_count})
 
     execution = SwarmExecutionResult(dispatched=delegates, results=results, blocked=blocked, status=job.status)
     job.metadata["swarm_execution"] = execution.to_dict()

--- a/agent/swarm_executor.py
+++ b/agent/swarm_executor.py
@@ -11,8 +11,10 @@ import json
 from dataclasses import dataclass, field
 from typing import Any, Callable, Dict, List, Optional
 
+from agent.swarm_evidence import EvidencePacket, validate_evidence_packet
 from agent.swarm_learning import detect_weak_output
 from agent.swarm_state import AuditEvent, JobStatus, RoutingPlan, SwarmJob, SwarmTask, TaskStatus
+from agent.swarm_synthesis import synthesize_swarm_result
 
 
 @dataclass
@@ -50,6 +52,30 @@ def _coerce_toolsets(value: Any) -> List[str]:
     return []
 
 
+def _format_evidence_contract(routing_plan: RoutingPlan) -> str:
+    requirements = getattr(routing_plan, "evidence_requirements", []) or []
+    lines = [
+        "",
+        "Required evidence contract:",
+        "Return a JSON-compatible result with keys: summary, claims, evidence, assumptions, unresolved, risks, confidence, side_effects_requested, side_effects_performed.",
+        "Each evidence item must include kind plus kind-specific fields such as command/output, url, path, approved_by, or approval_id.",
+        "If you cannot provide required evidence, say so explicitly in unresolved; do not claim completion without proof.",
+        "Required evidence:",
+    ]
+    if not requirements:
+        lines.append("- none explicitly required; still include evidence for material claims when available.")
+    for item in requirements:
+        if hasattr(item, "to_dict"):
+            data = item.to_dict()
+        elif isinstance(item, dict):
+            data = item
+        else:
+            continue
+        required = "required" if data.get("required", True) else "optional"
+        lines.append(f"- {data.get('kind', 'artifact')} ({required}): {data.get('description', '')}")
+    return "\n".join(lines)
+
+
 def build_delegate_tasks(
     routing_plan: RoutingPlan,
     job: SwarmJob,
@@ -68,10 +94,11 @@ def build_delegate_tasks(
             continue
         title = str(item.get("title") or item.get("goal") or f"Task {index}")
         description = str(item.get("description") or item.get("context") or title)
+        context = description + _format_evidence_contract(routing_plan)
         delegates.append(
             {
                 "goal": title,
-                "context": description,
+                "context": context,
                 "toolsets": _coerce_toolsets(item.get("toolsets")),
                 "swarm_task_id": str(item.get("task_id") or f"{job.job_id}_task_{index}"),
             }
@@ -158,6 +185,7 @@ def execute_swarm(
         job.transition(status, metadata={"blocked_count": len(blocked), "dispatched_count": 0})
         result = SwarmExecutionResult(dispatched=[], results=[], blocked=blocked, status=job.status)
         job.metadata["swarm_execution"] = result.to_dict()
+        synthesize_swarm_result(job, persist=True)
         return result
 
     job.transition(JobStatus.RUNNING.value, metadata={"dispatched_count": len(delegates), "max_children": max_children})
@@ -180,7 +208,14 @@ def execute_swarm(
         task = by_id.get(str(delegate.get("swarm_task_id") or ""))
         result = results[index] if index < len(results) else {"error": "missing child result", "status": "failed"}
         failed = _result_failed(result)
-        weak_output = detect_weak_output(result, getattr(routing_plan, "evidence_requirements", []) or [])
+        requirements = getattr(routing_plan, "evidence_requirements", []) or []
+        if requirements:
+            evidence_validation = validate_evidence_packet(EvidencePacket.from_result(result), requirements)
+            if isinstance(result, dict):
+                result = {**result, "evidence_validation": evidence_validation.to_dict()}
+                if index < len(results):
+                    results[index] = result
+        weak_output = detect_weak_output(result, requirements)
         if weak_output["weak"]:
             result = {**result, "weak_output": weak_output}
             if index < len(results):
@@ -207,6 +242,7 @@ def execute_swarm(
 
     execution = SwarmExecutionResult(dispatched=delegates, results=results, blocked=blocked, status=job.status)
     job.metadata["swarm_execution"] = execution.to_dict()
+    synthesize_swarm_result(job, persist=True)
     return execution
 
 

--- a/agent/swarm_executor.py
+++ b/agent/swarm_executor.py
@@ -1,0 +1,202 @@
+"""Bounded synchronous fan-out wrapper for Jeeves swarm operator.
+
+This is a thin adapter around an injected delegate function. It does not import
+or invoke the live delegate gateway path directly; production wiring can pass the
+existing ``delegate_task`` function later.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, List, Optional
+
+from agent.swarm_state import AuditEvent, JobStatus, RoutingPlan, SwarmJob, SwarmTask, TaskStatus
+
+
+@dataclass
+class SwarmExecutionResult:
+    dispatched: List[Dict[str, Any]] = field(default_factory=list)
+    results: List[Dict[str, Any]] = field(default_factory=list)
+    blocked: List[Dict[str, Any]] = field(default_factory=list)
+    status: str = JobStatus.COMPLETED.value
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "dispatched": [dict(item) for item in self.dispatched],
+            "results": [dict(item) for item in self.results],
+            "blocked": [dict(item) for item in self.blocked],
+            "status": self.status,
+        }
+
+
+def _task_requires_permission(item: Dict[str, Any]) -> bool:
+    return bool(
+        item.get("permission_required")
+        or item.get("requires_permission")
+        or item.get("permission")
+        or item.get("permission_request")
+    )
+
+
+def _coerce_toolsets(value: Any) -> List[str]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        return [value]
+    if isinstance(value, (list, tuple)):
+        return [str(item) for item in value if item]
+    return []
+
+
+def build_delegate_tasks(
+    routing_plan: RoutingPlan,
+    job: SwarmJob,
+    *,
+    max_children: Optional[int] = None,
+) -> List[Dict[str, Any]]:
+    """Translate routing suggestions into delegate_task batch entries.
+
+    Permission-required suggestions are excluded here and marked blocked by
+    ``execute_swarm``. Returned entries preserve per-task toolsets.
+    """
+    limit = max(0, int(max_children if max_children is not None else 3))
+    delegates: List[Dict[str, Any]] = []
+    for index, item in enumerate(routing_plan.suggested_tasks or [], start=1):
+        if not isinstance(item, dict) or _task_requires_permission(item):
+            continue
+        title = str(item.get("title") or item.get("goal") or f"Task {index}")
+        description = str(item.get("description") or item.get("context") or title)
+        delegates.append(
+            {
+                "goal": title,
+                "context": description,
+                "toolsets": _coerce_toolsets(item.get("toolsets")),
+                "swarm_task_id": str(item.get("task_id") or f"{job.job_id}_task_{index}"),
+            }
+        )
+        if len(delegates) >= limit:
+            break
+    return delegates
+
+
+def _ensure_job_tasks(job: SwarmJob, routing_plan: RoutingPlan) -> None:
+    if job.tasks:
+        return
+    for index, item in enumerate(routing_plan.suggested_tasks or [], start=1):
+        if not isinstance(item, dict):
+            continue
+        title = str(item.get("title") or item.get("goal") or f"Task {index}")
+        description = str(item.get("description") or item.get("context") or title)
+        job.add_task(
+            title,
+            description,
+            task_id=str(item.get("task_id") or f"{job.job_id}_task_{index}"),
+            mode=str(item.get("mode") or routing_plan.mode),
+            toolsets=_coerce_toolsets(item.get("toolsets")),
+            permission_required=_task_requires_permission(item),
+        )
+
+
+def _parse_delegate_response(response: Any) -> List[Dict[str, Any]]:
+    if isinstance(response, dict):
+        if isinstance(response.get("results"), list):
+            return [dict(item) for item in response["results"] if isinstance(item, dict)]
+        return [dict(response)]
+    if isinstance(response, list):
+        return [dict(item) for item in response if isinstance(item, dict)]
+    if isinstance(response, str):
+        try:
+            parsed = json.loads(response)
+        except json.JSONDecodeError:
+            return [{"ok": True, "content": response}]
+        return _parse_delegate_response(parsed)
+    return [{"ok": True, "content": repr(response)}]
+
+
+def _result_failed(result: Dict[str, Any]) -> bool:
+    status = str(result.get("status") or "").lower()
+    if status in {"failed", "error", "cancelled", "timeout"}:
+        return True
+    if result.get("error"):
+        return True
+    if result.get("ok") is False:
+        return True
+    return False
+
+
+def execute_swarm(
+    job: SwarmJob,
+    routing_plan: RoutingPlan,
+    delegate_fn: Callable[..., Any],
+    *,
+    max_children: int = 3,
+) -> SwarmExecutionResult:
+    """Run bounded independent tasks through an injected delegate function.
+
+    Updates ``job`` in-place and returns a structured summary. Critical task
+    failures (``metadata.critical`` or suggested task ``critical``) fail the job;
+    non-critical partial failures mark it ``partially_completed``.
+    """
+    job.routing_plan = routing_plan
+    _ensure_job_tasks(job, routing_plan)
+
+    blocked: List[Dict[str, Any]] = []
+    for task in job.tasks:
+        if task.permission_required:
+            task.status = TaskStatus.BLOCKED.value
+            task.updated_at = job.updated_at
+            blocked.append({"task_id": task.task_id, "title": task.title, "reason": "permission_required"})
+
+    delegates = build_delegate_tasks(routing_plan, job, max_children=max_children)
+    if blocked:
+        job.audit.append(AuditEvent("tasks_blocked", "Permission-required tasks were not dispatched", metadata={"blocked": blocked}))
+
+    if not delegates:
+        status = JobStatus.AWAITING_PERMISSION.value if blocked else JobStatus.COMPLETED.value
+        job.transition(status, metadata={"blocked_count": len(blocked), "dispatched_count": 0})
+        result = SwarmExecutionResult(dispatched=[], results=[], blocked=blocked, status=job.status)
+        job.metadata["swarm_execution"] = result.to_dict()
+        return result
+
+    job.transition(JobStatus.RUNNING.value, metadata={"dispatched_count": len(delegates), "max_children": max_children})
+    by_id: Dict[str, SwarmTask] = {task.task_id: task for task in job.tasks}
+    for delegate in delegates:
+        task = by_id.get(str(delegate.get("swarm_task_id") or ""))
+        if task:
+            task.status = TaskStatus.RUNNING.value
+
+    try:
+        raw = delegate_fn(tasks=[{k: v for k, v in item.items() if k != "swarm_task_id"} for item in delegates])
+        results = _parse_delegate_response(raw)
+    except Exception as exc:
+        results = [{"error": str(exc), "status": "failed", "critical": True}]
+
+    failures = 0
+    critical_failure = False
+    for index, delegate in enumerate(delegates):
+        task = by_id.get(str(delegate.get("swarm_task_id") or ""))
+        result = results[index] if index < len(results) else {"error": "missing child result", "status": "failed"}
+        failed = _result_failed(result)
+        failures += 1 if failed else 0
+        suggested = (routing_plan.suggested_tasks or [])[index] if index < len(routing_plan.suggested_tasks or []) else {}
+        is_critical = bool(result.get("critical") or (isinstance(suggested, dict) and suggested.get("critical")))
+        critical_failure = critical_failure or (failed and is_critical)
+        if task:
+            task.result = dict(result)
+            task.status = TaskStatus.FAILED.value if failed else TaskStatus.COMPLETED.value
+
+    if critical_failure:
+        final_status = JobStatus.FAILED.value
+    elif failures or blocked:
+        final_status = JobStatus.PARTIALLY_COMPLETED.value
+    else:
+        final_status = JobStatus.COMPLETED.value
+    job.transition(final_status, metadata={"failure_count": failures, "blocked_count": len(blocked)})
+
+    execution = SwarmExecutionResult(dispatched=delegates, results=results, blocked=blocked, status=job.status)
+    job.metadata["swarm_execution"] = execution.to_dict()
+    return execution
+
+
+__all__ = ["SwarmExecutionResult", "build_delegate_tasks", "execute_swarm"]

--- a/agent/swarm_honcho.py
+++ b/agent/swarm_honcho.py
@@ -1,0 +1,107 @@
+"""Inert Honcho summary adapter for Jeeves swarm operator.
+
+This module never imports or initializes Honcho by default. Production wiring may
+pass an injected writer; without one, persistence is a no-op unless a compatible
+memory plugin is present and explicitly enabled by the caller.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Dict, Mapping, Optional
+
+from agent.swarm_state import SwarmJob
+from agent.swarm_status import redact_secrets
+
+_SCRATCH_KEYS = {"scratchpad", "scratch", "chain_of_thought", "reasoning", "messages", "transcript"}
+
+
+def _short(text: Any, limit: int = 240) -> str:
+    value = " ".join(str(text or "").split())
+    return value if len(value) <= limit else value[: limit - 1].rstrip() + "…"
+
+
+def _safe_result_summary(result: Mapping[str, Any] | None) -> str:
+    if not isinstance(result, Mapping):
+        return ""
+    cleaned = {k: v for k, v in result.items() if str(k).lower() not in _SCRATCH_KEYS}
+    redacted = redact_secrets(cleaned)
+    if redacted.get("summary"):
+        return _short(redacted["summary"])
+    if redacted.get("error"):
+        return "error: " + _short(redacted["error"])
+    if redacted.get("status"):
+        return "status: " + _short(redacted["status"])
+    return ""
+
+
+def build_swarm_honcho_summary(job: SwarmJob) -> Dict[str, Any]:
+    """Return a compact, redacted payload suitable for parent-owned memory."""
+
+    lines = [
+        f"Jeeves swarm job {job.job_id}: {job.status}",
+        f"Request: {_short(job.original_request, 500)}",
+    ]
+    if job.routing_plan:
+        lines.append(f"Route: {job.routing_plan.mode} — {_short(job.routing_plan.reason)}")
+    if job.tasks:
+        lines.append("Tasks:")
+        for task in job.tasks:
+            result = _safe_result_summary(task.result)
+            suffix = f" — {result}" if result else ""
+            blocker = " (blocked)" if task.permission_required or task.status in {"blocked", "awaiting_permission"} else ""
+            lines.append(f"- {task.task_id}: {task.status}{blocker} — {_short(task.title)}{suffix}")
+    if job.evals:
+        passed = sum(1 for item in job.evals if item.passed)
+        lines.append(f"Verification: {passed}/{len(job.evals)} checks passed")
+    if job.permissions or (job.routing_plan and job.routing_plan.permission_requests):
+        lines.append("Permissions: outstanding or requested actions were parent-gated.")
+
+    metadata = redact_secrets(
+        {
+            "job_id": job.job_id,
+            "status": job.status,
+            "platform": job.platform,
+            "session_id": job.session_id,
+            "task_count": len(job.tasks),
+        }
+    )
+    return {"content": "\n".join(lines), "metadata": metadata}
+
+
+def _default_writer() -> Optional[Callable[[Dict[str, Any]], Any]]:
+    """Best-effort optional plugin hook; intentionally returns None if absent."""
+
+    try:
+        from plugins.memory.honcho.swarm import write_swarm_summary  # type: ignore
+    except Exception:
+        return None
+    return write_swarm_summary
+
+
+def persist_swarm_honcho_summary(
+    job: SwarmJob,
+    *,
+    enabled: bool = False,
+    writer: Optional[Callable[[Dict[str, Any]], Any]] = None,
+) -> Dict[str, Any]:
+    """Persist a compact swarm summary when explicitly enabled.
+
+    The function is safe to call unconditionally: disabled, missing dependency,
+    or writer failures are reported as structured no-op/error dictionaries and do
+    not raise into gateway flow.
+    """
+
+    if not enabled:
+        return {"persisted": False, "reason": "disabled"}
+    resolved_writer = writer or _default_writer()
+    if resolved_writer is None:
+        return {"persisted": False, "reason": "honcho_unavailable"}
+    payload = build_swarm_honcho_summary(job)
+    try:
+        resolved_writer(payload)
+    except Exception as exc:
+        return {"persisted": False, "reason": "writer_failed", "error": str(exc)}
+    return {"persisted": True, "reason": "ok", "metadata": payload["metadata"]}
+
+
+__all__ = ["build_swarm_honcho_summary", "persist_swarm_honcho_summary"]

--- a/agent/swarm_learning.py
+++ b/agent/swarm_learning.py
@@ -55,7 +55,12 @@ def _has_kind_evidence(result: Dict[str, Any], kind: str) -> bool:
     return any(result.get(key) for key in _KIND_KEYS.get(kind, (kind,)))
 
 
-def detect_weak_output(result: Dict[str, Any], evidence_requirements: Iterable[Any] = ()) -> Dict[str, Any]:
+def detect_weak_output(
+    result: Dict[str, Any],
+    evidence_requirements: Iterable[Any] = (),
+    *,
+    approval_grants: Iterable[Any] | None = None,
+) -> Dict[str, Any]:
     """Return weak-output annotation for a child result.
 
     Weak means the child result is not trustworthy enough for parent synthesis
@@ -64,15 +69,25 @@ def detect_weak_output(result: Dict[str, Any], evidence_requirements: Iterable[A
     """
 
     text = " ".join(str(result.get(key) or "") for key in ("summary", "content", "message", "status")).strip().lower()
+    evidence_requirements = list(evidence_requirements or [])
     required_kinds: List[str] = [_requirement_kind(item) for item in evidence_requirements if _requirement_required(item)]
     reasons: List[str] = []
+    overall_validation = validate_evidence_packet(
+        EvidencePacket.from_result(result),
+        evidence_requirements,
+        approval_grants=approval_grants,
+    )
 
-    if required_kinds and not _has_evidence(result):
+    if required_kinds and not _has_evidence(result) and not overall_validation.passed:
         reasons.append("no_evidence")
     if text in _VAGUE_SUCCESS_PHRASES or any(phrase in text for phrase in ("looks good", "should work", "seems fine")):
         reasons.append("vague_success_language")
     for kind in required_kinds:
-        validation = validate_evidence_packet(EvidencePacket.from_result(result), [item for item in evidence_requirements if _requirement_kind(item) == kind])
+        validation = validate_evidence_packet(
+            EvidencePacket.from_result(result),
+            [item for item in evidence_requirements if _requirement_kind(item) == kind],
+            approval_grants=approval_grants,
+        )
         if kind and not validation.passed:
             for reason in validation.reasons or [f"missing_{kind}"]:
                 if reason not in reasons:

--- a/agent/swarm_learning.py
+++ b/agent/swarm_learning.py
@@ -1,0 +1,86 @@
+"""Anti-illusion learning/weak-output helpers for swarm results.
+
+MVP scope is intentionally small and deterministic: annotate weak outputs; do
+not retry children or write durable memory from telemetry.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable, List
+
+_VAGUE_SUCCESS_PHRASES = (
+    "done",
+    "fixed",
+    "looks good",
+    "should work",
+    "seems fine",
+    "all good",
+    "ok",
+)
+
+_EVIDENCE_KEYS = ("evidence", "citations", "sources", "artifacts", "tests", "commands", "command_output", "dry_run", "approval")
+_KIND_KEYS = {
+    "citation": ("citations", "sources"),
+    "test": ("tests", "commands", "command_output"),
+    "command_output": ("command_output", "commands"),
+    "dry_run": ("dry_run", "dry_run_output", "payload_contract"),
+    "artifact": ("artifact", "artifacts", "path", "url", "file"),
+    "human_approval": ("approval", "human_approval", "approved_by", "permission_id"),
+}
+
+
+def _has_evidence(result: Dict[str, Any]) -> bool:
+    for key in _EVIDENCE_KEYS:
+        value = result.get(key)
+        if value:
+            return True
+    return False
+
+
+def _requirement_kind(item: Any) -> str:
+    if isinstance(item, dict):
+        return str(item.get("kind") or "")
+    return str(getattr(item, "kind", "") or "")
+
+
+def _requirement_required(item: Any) -> bool:
+    if isinstance(item, dict):
+        return bool(item.get("required", True))
+    return bool(getattr(item, "required", True))
+
+
+def _has_kind_evidence(result: Dict[str, Any], kind: str) -> bool:
+    return any(result.get(key) for key in _KIND_KEYS.get(kind, (kind,)))
+
+
+def detect_weak_output(result: Dict[str, Any], evidence_requirements: Iterable[Any] = ()) -> Dict[str, Any]:
+    """Return weak-output annotation for a child result.
+
+    Weak means the child result is not trustworthy enough for parent synthesis
+    without review. This is not a failure signal by itself; it is an evidence
+    insufficiency marker.
+    """
+
+    text = " ".join(str(result.get(key) or "") for key in ("summary", "content", "message", "status")).strip().lower()
+    required_kinds: List[str] = [_requirement_kind(item) for item in evidence_requirements if _requirement_required(item)]
+    reasons: List[str] = []
+
+    if required_kinds and not _has_evidence(result):
+        reasons.append("no_evidence")
+    if text in _VAGUE_SUCCESS_PHRASES or any(phrase in text for phrase in ("looks good", "should work", "seems fine")):
+        reasons.append("vague_success_language")
+    for kind in required_kinds:
+        if kind and not _has_kind_evidence(result, kind):
+            reason = f"missing_{kind}"
+            if reason not in reasons:
+                reasons.append(reason)
+
+    return {
+        "weak": bool(reasons),
+        "reasons": reasons,
+        "required_evidence": [kind for kind in required_kinds if kind],
+        "recommended_status": "needs_review" if reasons else "completed",
+    }
+
+
+__all__ = ["detect_weak_output"]

--- a/agent/swarm_learning.py
+++ b/agent/swarm_learning.py
@@ -8,6 +8,8 @@ from __future__ import annotations
 
 from typing import Any, Dict, Iterable, List
 
+from agent.swarm_evidence import EvidencePacket, validate_evidence_packet
+
 _VAGUE_SUCCESS_PHRASES = (
     "done",
     "fixed",
@@ -70,10 +72,11 @@ def detect_weak_output(result: Dict[str, Any], evidence_requirements: Iterable[A
     if text in _VAGUE_SUCCESS_PHRASES or any(phrase in text for phrase in ("looks good", "should work", "seems fine")):
         reasons.append("vague_success_language")
     for kind in required_kinds:
-        if kind and not _has_kind_evidence(result, kind):
-            reason = f"missing_{kind}"
-            if reason not in reasons:
-                reasons.append(reason)
+        validation = validate_evidence_packet(EvidencePacket.from_result(result), [item for item in evidence_requirements if _requirement_kind(item) == kind])
+        if kind and not validation.passed:
+            for reason in validation.reasons or [f"missing_{kind}"]:
+                if reason not in reasons:
+                    reasons.append(reason)
 
     return {
         "weak": bool(reasons),

--- a/agent/swarm_live_runner.py
+++ b/agent/swarm_live_runner.py
@@ -1,0 +1,314 @@
+"""Non-blocking, killable live execution runner for the swarm operator.
+
+The gateway hook must not run delegate fan-out inline: synchronous execution can
+block the gateway event loop, and thread timeouts cannot stop already-running
+work. This module gives the hook a narrow process boundary instead. The parent
+returns immediately after spawning a child process plus a monitor thread; the
+monitor terminates the child if it exceeds its timeout and persists the final
+state.
+"""
+
+from __future__ import annotations
+
+import multiprocessing
+import os
+import signal
+import threading
+from dataclasses import dataclass
+from typing import Any, Callable, Optional
+
+from agent.swarm_executor import execute_swarm
+from agent.swarm_state import AuditEvent, RoutingPlan, SwarmJob
+from agent.swarm_store import SwarmStore
+
+
+@dataclass
+class SwarmLiveRunHandle:
+    """Summary of a live runner launch attempt."""
+
+    started: bool
+    status: str
+    reason: str = ""
+    job_id: str = ""
+    pid: Optional[int] = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "started": self.started,
+            "status": self.status,
+            "reason": self.reason,
+            "job_id": self.job_id,
+            "pid": self.pid,
+        }
+
+
+def _coerce_timeout(value: float | int | str, default: float = 30.0) -> float:
+    try:
+        timeout = float(value)
+    except (TypeError, ValueError):
+        return default
+    if not 0 < timeout <= 30.0:
+        return default
+    # NaN fails both comparisons above; keep an explicit guard for readability.
+    if timeout != timeout:
+        return default
+    return timeout
+
+
+def _child_execute_swarm(
+    job: SwarmJob,
+    routing_plan: RoutingPlan,
+    delegate_fn: Callable[..., Any],
+    *,
+    store_base_dir: str,
+    max_children: int,
+) -> None:
+    try:
+        os.setsid()
+    except OSError:
+        # Best-effort process-group isolation. The monitor still kills the
+        # direct child if the platform refuses to create a new session.
+        pass
+    store = SwarmStore(base_dir=store_base_dir)
+    try:
+        store.append_event(
+            AuditEvent(
+                "live_delegation_child_started",
+                "Swarm live delegation child process started.",
+                metadata={"job_id": job.job_id},
+            )
+        )
+        execution = execute_swarm(job, routing_plan, delegate_fn, max_children=max_children)
+        job.metadata["live_delegation_status"] = "executed"
+        job.metadata["live_delegation_result"] = execution.to_dict()
+        job.audit.append(
+            AuditEvent(
+                "live_delegation_executed",
+                "Swarm live delegation completed in the child process.",
+                metadata={"status": execution.status, "dispatched_count": len(execution.dispatched)},
+            )
+        )
+        store.save_job(job)
+        store.append_event(
+            AuditEvent(
+                "live_delegation_finished",
+                "Swarm live delegation child process finished.",
+                metadata={"job_id": job.job_id, "status": job.status},
+            )
+        )
+    except BaseException as exc:  # noqa: BLE001 - child must persist failure instead of vanishing.
+        job.metadata["live_delegation_status"] = "failed"
+        job.metadata["live_delegation_error"] = str(exc)
+        job.audit.append(
+            AuditEvent(
+                "live_delegation_failed",
+                "Swarm live delegation failed in the child process.",
+                metadata={"error": str(exc)},
+            )
+        )
+        store.save_job(job)
+        store.append_event(
+            AuditEvent(
+                "live_delegation_failed",
+                "Swarm live delegation child process failed.",
+                metadata={"job_id": job.job_id, "error": str(exc)},
+            )
+        )
+
+
+def _load_latest_job(store: SwarmStore, fallback: SwarmJob) -> SwarmJob:
+    try:
+        return store.load_jobs().get(fallback.job_id, fallback)
+    except Exception:
+        return fallback
+
+
+def _isolated_process_group_id(process: Any) -> Optional[int]:
+    pid = getattr(process, "pid", None)
+    if not pid:
+        return None
+    try:
+        pgid = os.getpgid(pid)
+    except ProcessLookupError:
+        return None
+    except OSError:
+        return None
+    # The child calls setsid(), which makes pgid == pid. If that has not
+    # happened yet (or failed), pgid may be the gateway/test-runner group; never
+    # signal a non-isolated group from the monitor.
+    return pgid if pgid == pid else None
+
+
+def _terminate_process_tree(process: Any) -> None:
+    pgid = _isolated_process_group_id(process)
+    if pgid is not None:
+        try:
+            os.killpg(pgid, signal.SIGTERM)
+            return
+        except ProcessLookupError:
+            return
+        except OSError:
+            pass
+    try:
+        process.terminate()
+    except Exception:
+        pass
+
+
+def _kill_process_tree(process: Any) -> None:
+    pgid = _isolated_process_group_id(process)
+    if pgid is not None:
+        try:
+            os.killpg(pgid, signal.SIGKILL)
+            return
+        except ProcessLookupError:
+            return
+        except OSError:
+            pass
+    kill = getattr(process, "kill", None)
+    if callable(kill):
+        try:
+            kill()
+        except Exception:
+            pass
+
+
+def _persist_terminal_if_still_running(
+    *,
+    store: SwarmStore,
+    fallback: SwarmJob,
+    status: str,
+    event_type: str,
+    message: str,
+    metadata: dict[str, Any],
+) -> None:
+    latest = _load_latest_job(store, fallback)
+    if latest.metadata.get("live_delegation_status") != "running":
+        return
+    latest.metadata["live_delegation_status"] = status
+    latest.audit.append(AuditEvent(event_type, message, metadata=metadata))
+    store.save_job(latest)
+    store.append_event(AuditEvent(event_type, message, metadata={"job_id": latest.job_id, **metadata}))
+
+
+def _monitor_process(process: Any, *, store_base_dir: str, job: SwarmJob, timeout_seconds: float) -> None:
+    process.join(timeout_seconds)
+    store = SwarmStore(base_dir=store_base_dir)
+    if process.is_alive():
+        _terminate_process_tree(process)
+        process.join(2)
+        if process.is_alive():
+            _kill_process_tree(process)
+            process.join(2)
+        _persist_terminal_if_still_running(
+            store=store,
+            fallback=job,
+            status="timeout",
+            event_type="live_delegation_timeout",
+            message="Swarm live delegation exceeded its timeout and the child process tree was terminated.",
+            metadata={"timeout_seconds": timeout_seconds, "pid": getattr(process, "pid", None)},
+        )
+        return
+
+    exitcode = getattr(process, "exitcode", None)
+    if exitcode is not None:
+        _persist_terminal_if_still_running(
+            store=store,
+            fallback=job,
+            status="failed",
+            event_type="live_delegation_crashed",
+            message="Swarm live delegation child process exited before saving a terminal state.",
+            metadata={"exitcode": exitcode, "pid": getattr(process, "pid", None)},
+        )
+
+
+def start_live_swarm(
+    job: SwarmJob,
+    routing_plan: RoutingPlan,
+    delegate_fn: Callable[..., Any],
+    *,
+    store: SwarmStore,
+    max_children: int = 3,
+    timeout_seconds: float = 30.0,
+) -> SwarmLiveRunHandle:
+    """Start live swarm execution in a killable child process.
+
+    The function mutates ``job`` with launch metadata and returns immediately.
+    The caller should save the job after this returns so status is visible before
+    the child finishes.
+    """
+
+    if not callable(delegate_fn):
+        return SwarmLiveRunHandle(started=False, status="blocked", reason="missing_delegate_fn", job_id=job.job_id)
+
+    context_names = []
+    for name in ("forkserver", "fork"):
+        try:
+            multiprocessing.get_context(name)
+        except (ValueError, RuntimeError):
+            continue
+        context_names.append(name)
+    if not context_names:
+        return SwarmLiveRunHandle(started=False, status="blocked", reason="process_context_unavailable", job_id=job.job_id)
+
+    timeout = _coerce_timeout(timeout_seconds)
+    job.metadata["live_delegation_status"] = "running"
+    job.metadata["live_delegation_timeout_seconds"] = timeout
+    job.audit.append(
+        AuditEvent(
+            "live_delegation_started",
+            "Swarm live delegation launched in a killable child process.",
+            metadata={"timeout_seconds": timeout, "max_children": max_children},
+        )
+    )
+
+    store.save_job(job)
+    process = None
+    last_start_error: Optional[Exception] = None
+    for context_name in context_names:
+        ctx = multiprocessing.get_context(context_name)
+        job.metadata["live_delegation_context"] = context_name
+        candidate = ctx.Process(
+            target=_child_execute_swarm,
+            args=(job, routing_plan, delegate_fn),
+            kwargs={"store_base_dir": str(store.base_dir), "max_children": max_children},
+            daemon=True,
+        )
+        try:
+            candidate.start()
+        except Exception as exc:
+            last_start_error = exc
+            continue
+        process = candidate
+        job.metadata["live_delegation_context"] = context_name
+        break
+
+    if process is None:
+        error = str(last_start_error) if last_start_error is not None else "no process context could start"
+        job.metadata["live_delegation_status"] = "blocked"
+        job.metadata["live_delegation_block_reason"] = "process_start_failed"
+        job.metadata["live_delegation_error"] = error
+        job.audit.append(
+            AuditEvent(
+                "live_delegation_blocked",
+                "Swarm live delegation child process failed to start.",
+                metadata={"reason": "process_start_failed", "error": error},
+            )
+        )
+        store.save_job(job)
+        return SwarmLiveRunHandle(started=False, status="blocked", reason="process_start_failed", job_id=job.job_id)
+
+    job.metadata["live_delegation_pid"] = process.pid
+
+    monitor = threading.Thread(
+        target=_monitor_process,
+        kwargs={"process": process, "store_base_dir": str(store.base_dir), "job": job, "timeout_seconds": timeout},
+        name=f"swarm-live-monitor-{job.job_id}",
+        daemon=True,
+    )
+    monitor.start()
+
+    return SwarmLiveRunHandle(started=True, status="running", job_id=job.job_id, pid=process.pid)
+
+
+__all__ = ["SwarmLiveRunHandle", "start_live_swarm"]

--- a/agent/swarm_live_runner.py
+++ b/agent/swarm_live_runner.py
@@ -63,12 +63,14 @@ def _child_execute_swarm(
     store_base_dir: str,
     max_children: int,
 ) -> None:
-    try:
-        os.setsid()
-    except OSError:
-        # Best-effort process-group isolation. The monitor still kills the
-        # direct child if the platform refuses to create a new session.
-        pass
+    setsid = getattr(os, "setsid", None)
+    if callable(setsid):
+        try:
+            setsid()
+        except OSError:
+            # Best-effort process-group isolation. The monitor still kills the
+            # direct child if the platform refuses to create a new session.
+            pass
     store = SwarmStore(base_dir=store_base_dir)
     try:
         store.append_event(
@@ -141,9 +143,10 @@ def _isolated_process_group_id(process: Any) -> Optional[int]:
 
 def _terminate_process_tree(process: Any) -> None:
     pgid = _isolated_process_group_id(process)
-    if pgid is not None:
+    killpg = getattr(os, "killpg", None)
+    if pgid is not None and callable(killpg):
         try:
-            os.killpg(pgid, signal.SIGTERM)
+            killpg(pgid, signal.SIGTERM)
             return
         except ProcessLookupError:
             return
@@ -157,9 +160,10 @@ def _terminate_process_tree(process: Any) -> None:
 
 def _kill_process_tree(process: Any) -> None:
     pgid = _isolated_process_group_id(process)
-    if pgid is not None:
+    killpg = getattr(os, "killpg", None)
+    if pgid is not None and callable(killpg):
         try:
-            os.killpg(pgid, signal.SIGKILL)
+            killpg(pgid, getattr(signal, "SIGKILL", signal.SIGTERM))
             return
         except ProcessLookupError:
             return

--- a/agent/swarm_prompt.py
+++ b/agent/swarm_prompt.py
@@ -28,6 +28,20 @@ def _get_config_value(config: Any, key: str, default: Any = None) -> Any:
     return getattr(config, key, default)
 
 
+def _strict_bool(value: Any, *, default: bool) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        lowered = value.strip().lower()
+        if lowered in {"true", "1", "yes", "on"}:
+            return True
+        if lowered in {"false", "0", "no", "off"}:
+            return False
+    if isinstance(value, (int, float)) and value in {0, 1}:
+        return bool(value)
+    return default
+
+
 def swarm_operator_enabled(config: Optional[Dict[str, Any]] = None) -> bool:
     """Return whether the prompt contract should be injected."""
     if config is None:
@@ -37,7 +51,7 @@ def swarm_operator_enabled(config: Optional[Dict[str, Any]] = None) -> bool:
             config = cfg_get(load_config(), "swarm_operator", default={}) or {}
         except Exception:
             config = {}
-    return bool(_get_config_value(config, "enabled", False))
+    return _strict_bool(_get_config_value(config, "enabled", False), default=False)
 
 
 def build_swarm_operator_prompt(config: Optional[Dict[str, Any]] = None) -> str:

--- a/agent/swarm_prompt.py
+++ b/agent/swarm_prompt.py
@@ -1,0 +1,101 @@
+"""Prompt contract for the Jeeves swarm operator.
+
+This module is intentionally small and side-effect free. The operator prompt is
+only emitted when explicitly enabled in config; disabled-by-default rollout must
+not bloat normal Hermes sessions.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+
+def _get_config_value(config: Any, key: str, default: Any = None) -> Any:
+    if config is None:
+        return default
+    if isinstance(config, dict):
+        return config.get(key, default)
+    getter = getattr(config, "get", None)
+    if callable(getter):
+        try:
+            return getter(key, default)
+        except TypeError:
+            try:
+                value = getter(key)
+                return default if value is None else value
+            except Exception:
+                return default
+    return getattr(config, key, default)
+
+
+def swarm_operator_enabled(config: Optional[Dict[str, Any]] = None) -> bool:
+    """Return whether the prompt contract should be injected."""
+    if config is None:
+        try:
+            from hermes_cli.config import cfg_get, load_config
+
+            config = cfg_get(load_config(), "swarm_operator", default={}) or {}
+        except Exception:
+            config = {}
+    return bool(_get_config_value(config, "enabled", False))
+
+
+def build_swarm_operator_prompt(config: Optional[Dict[str, Any]] = None) -> str:
+    """Build the stable Jeeves operator prompt section when enabled.
+
+    The returned text is deterministic and compact. It does not enable live
+    gateway interception or dispatch anything; it only tells the parent agent how
+    to use existing Hermes primitives when the operator feature is enabled.
+    """
+    if config is None:
+        try:
+            from hermes_cli.config import cfg_get, load_config
+
+            config = cfg_get(load_config(), "swarm_operator", default={}) or {}
+        except Exception:
+            config = {}
+    if not swarm_operator_enabled(config):
+        return ""
+
+    max_children = _get_config_value(config, "max_children", 3)
+    dry_run = _get_config_value(config, "dry_run", True)
+    persist_to_honcho = _get_config_value(config, "persist_to_honcho", False)
+
+    return (
+        "# Jeeves Swarm Operator Contract\n"
+        "When the swarm operator is enabled, you are Jeeves: the single parent "
+        "operator responsible for triage, routing, verification, and one final "
+        "user-facing synthesis. Child agents must never send messages to the user.\n"
+        "\n"
+        "## Routing rules\n"
+        "- Handle simple explanatory or single-step work directly.\n"
+        "- Use delegate_task only for independent subtasks that benefit from parallel "
+        f"work, bounded by max_children={max_children}.\n"
+        "- Use scripts for >3 procedural steps/source-of-truth/validation/eval; "
+        "prefer deterministic local checks over ad-hoc conversational repetition.\n"
+        "- Use cron or kanban for durable work that must outlive the current turn; "
+        "delegate_task is only for synchronous fan-out inside this run.\n"
+        "\n"
+        "## Permission model\n"
+        "- External, destructive, deploy, payment, publish, send/message/email, or "
+        "cross-system side effects are default-denied unless already allowed by "
+        "Hermes policy or explicitly approved by the user.\n"
+        "- Permission-required subtasks stay blocked; do not dispatch children for "
+        "actions that need approval.\n"
+        "\n"
+        "## Subsystem policy\n"
+        "- n8n/docker are dumb pipes: use them only as execution substrates with an "
+        "explicit payload contract, dry-run/verification evidence, and permission "
+        "where required. They are not reasoning engines.\n"
+        "- Honcho/memory persistence is parent-owned: persist compact final summaries "
+        f"only when configured (persist_to_honcho={bool(persist_to_honcho)}), never "
+        "raw child scratchpads or secrets.\n"
+        "\n"
+        "## Status and rollout\n"
+        f"- Feature dry_run={bool(dry_run)}; do not assume live gateway interception.\n"
+        "- Keep job status inspectable: note active tasks, blockers, permission "
+        "requests, verification evidence, and final outcome."
+    )
+
+
+__all__ = ["build_swarm_operator_prompt", "swarm_operator_enabled"]

--- a/agent/swarm_router.py
+++ b/agent/swarm_router.py
@@ -1,0 +1,116 @@
+"""Deterministic first-pass router for the Jeeves swarm operator."""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Dict, List, Optional
+
+from agent.swarm_state import PermissionGrant, RoutingPlan
+
+_PERMISSION_WORDS = (
+    "send", "email", "message", "post", "publish", "deploy", "restart", "delete", "remove",
+    "drop", "destroy", "overwrite", "merge", "push", "charge", "buy", "purchase", "commit",
+)
+_PIPE_WORDS = ("n8n", "docker", "container", "compose", "workflow", "webhook")
+_SWARM_WORDS = (
+    "research", "review", "audit", "compare", "investigate", "lookup", "look up", "analyze",
+    "code", "implement", "fix", "test", "summarize", "parallel", "subagent", "agents",
+)
+_PROCEDURAL_WORDS = (
+    "then", "after that", "next", "finally", "validate", "verify", "check", "source of truth",
+    "ground truth", "eval", "run", "collect", "parse", "extract",
+)
+
+
+def _count_steps(text: str) -> int:
+    lowered = text.lower()
+    numbered = len(re.findall(r"(?:^|[\n;])\s*(?:\d+\.|[-*])\s+", text))
+    connectors = sum(lowered.count(word) for word in _PROCEDURAL_WORDS)
+    # Explicit commas/semicolons with procedural verbs are a decent v1 signal.
+    return max(numbered, connectors)
+
+
+def _permission_requests(text: str) -> List[PermissionGrant]:
+    lowered = text.lower()
+    requests: List[PermissionGrant] = []
+    for word in _PERMISSION_WORDS:
+        if re.search(rf"\b{re.escape(word)}\b", lowered):
+            requests.append(
+                PermissionGrant(
+                    permission_id=f"perm_{word.replace(' ', '_')}",
+                    description=f"Permission required before external/destructive action: {word}",
+                    scope={"matched_word": word},
+                )
+            )
+            break
+    if any(word in lowered for word in _PIPE_WORDS):
+        requests.append(
+            PermissionGrant(
+                permission_id="perm_pipe_execution",
+                description="Permission required before invoking n8n/docker execution pipes",
+                scope={"matched_pipe": True},
+            )
+        )
+    return requests
+
+
+def _suggested_tasks(text: str, mode: str) -> List[Dict[str, Any]]:
+    if mode == "direct":
+        return []
+    chunks = [part.strip(" .") for part in re.split(r"\b(?:and|then|;|\n)\b", text, flags=re.IGNORECASE) if part.strip()]
+    if len(chunks) < 2:
+        chunks = [text.strip()]
+    return [
+        {"title": chunk[:80], "description": chunk, "mode": mode}
+        for chunk in chunks[:6]
+    ]
+
+
+def route_request(
+    text: str,
+    platform_context: Optional[Dict[str, Any]] = None,
+    config: Optional[Dict[str, Any]] = None,
+) -> RoutingPlan:
+    """Classify a request without LLM calls.
+
+    Modes are conservative candidates: ``direct``, ``swarm``, ``script``, or
+    ``pipe``. Permission requests are advisory and default-deny downstream work.
+    """
+
+    del platform_context, config  # reserved for later live policy inputs
+    raw_text = text or ""
+    lowered = raw_text.lower()
+    permissions = _permission_requests(raw_text)
+    step_count = _count_steps(raw_text)
+
+    if any(word in lowered for word in _PIPE_WORDS):
+        mode = "pipe"
+        reason = "Request mentions n8n/docker-style execution pipes."
+    elif step_count > 3:
+        mode = "script"
+        reason = "Request appears to have more than three procedural/validation steps."
+    elif (
+        sum(1 for word in _SWARM_WORDS if word in lowered) >= 2
+        or (" and " in lowered and any(word in lowered for word in _SWARM_WORDS))
+        or re.search(r"\b(a|b|c)\b.*\b(a|b|c)\b", lowered)
+    ):
+        mode = "swarm"
+        reason = "Request contains multiple independent research/code/review signals."
+    else:
+        mode = "direct"
+        reason = "Simple prompt suitable for direct handling."
+
+    verification_required = mode in {"swarm", "script", "pipe"} or bool(permissions) or any(
+        word in lowered for word in ("verify", "validate", "test", "check")
+    )
+    return RoutingPlan(
+        mode=mode,
+        reason=reason,
+        suggested_tasks=_suggested_tasks(raw_text, mode),
+        permission_requests=permissions,
+        verification_required=verification_required,
+        metadata={"step_count": step_count, "permission_required": bool(permissions)},
+    )
+
+
+__all__ = ["route_request"]

--- a/agent/swarm_router.py
+++ b/agent/swarm_router.py
@@ -204,7 +204,14 @@ def _evidence_requirements(text: str, mode: str, permissions: List[PermissionGra
     if _contains_word(lowered, _CODE_WORDS):
         requirements.append(EvidenceRequirement("test", "Provide test/lint/typecheck evidence or explicit skipped-verification reason", source="router"))
     if permissions:
-        requirements.append(EvidenceRequirement("human_approval", "Get explicit human approval before external, destructive, or client-facing side effects", source="router"))
+        requirements.append(
+            EvidenceRequirement(
+                "human_approval",
+                "Get explicit human approval before external, destructive, or client-facing side effects",
+                source="router",
+                metadata={"permission_ids": [grant.permission_id for grant in permissions]},
+            )
+        )
     if telemetry.required_scaffold == "externalize_state":
         requirements.append(EvidenceRequirement("artifact", "Externalize state into a plan/checklist/artifact before synthesis", source="router"))
 

--- a/agent/swarm_router.py
+++ b/agent/swarm_router.py
@@ -67,10 +67,17 @@ def _suggested_tasks(text: str, mode: str) -> List[Dict[str, Any]]:
     chunks = [part.strip(" .") for part in re.split(r"\b(?:and|then|;|\n)\b", text, flags=re.IGNORECASE) if part.strip()]
     if len(chunks) < 2:
         chunks = [text.strip()]
-    return [
-        {"title": chunk[:80], "description": chunk, "mode": mode}
-        for chunk in chunks[:6]
-    ]
+    tasks: List[Dict[str, Any]] = []
+    for chunk in chunks[:6]:
+        lowered = chunk.lower()
+        permission_required = any(re.search(rf"\b{re.escape(word)}\b", lowered) for word in _PERMISSION_WORDS) or any(
+            word in lowered for word in _PIPE_WORDS
+        )
+        task: Dict[str, Any] = {"title": chunk[:80], "description": chunk, "mode": mode}
+        if permission_required:
+            task["permission_required"] = True
+        tasks.append(task)
+    return tasks
 
 
 def _bounded_score(value: int) -> int:

--- a/agent/swarm_router.py
+++ b/agent/swarm_router.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import re
 from typing import Any, Dict, List, Optional
 
-from agent.swarm_state import PermissionGrant, RoutingPlan
+from agent.swarm_state import EvidenceRequirement, PermissionGrant, RoutingPlan, RoutingTelemetry
 
 _PERMISSION_WORDS = (
     "send", "email", "message", "post", "publish", "deploy", "restart", "delete", "remove",
@@ -14,12 +14,19 @@ _PERMISSION_WORDS = (
 _PIPE_WORDS = ("n8n", "docker", "container", "compose", "workflow", "webhook")
 _SWARM_WORDS = (
     "research", "review", "audit", "compare", "investigate", "lookup", "look up", "analyze",
-    "code", "implement", "fix", "test", "summarize", "parallel", "subagent", "agents",
+    "code", "implement", "fix", "test", "summarize", "parallel", "subagent", "agents", "council",
+    "critique", "failure mode", "architecture", "strategy",
 )
 _PROCEDURAL_WORDS = (
     "then", "after that", "next", "finally", "validate", "verify", "check", "source of truth",
     "ground truth", "eval", "run", "collect", "parse", "extract",
 )
+_CONTEXT_REFERENCE_WORDS = (
+    "other session", "earlier", "previous", "above", "prior", "thread", "that file", "those files",
+    "last night", "we built", "context", "council",
+)
+_CURRENT_FACT_WORDS = ("current", "latest", "today", "news", "research", "docs", "available", "native")
+_CODE_WORDS = ("code", "implement", "fix", "patch", "config", "edit", "test", "tests", "lint", "typecheck", "function", "executor")
 
 
 def _count_steps(text: str) -> int:
@@ -66,6 +73,171 @@ def _suggested_tasks(text: str, mode: str) -> List[Dict[str, Any]]:
     ]
 
 
+def _bounded_score(value: int) -> int:
+    return max(0, min(3, value))
+
+
+def _safe_int(value: Any, default: int = 0) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _contains_word(text: str, words: tuple[str, ...]) -> bool:
+    return any(re.search(rf"\b{re.escape(word)}\b", text) for word in words)
+
+
+def score_context_pressure(text: str, platform_context: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    """Score context-cliff risk with mechanical signals only."""
+    ctx = platform_context or {}
+    lowered = (text or "").lower()
+    signals: Dict[str, Any] = {}
+    score = 0
+
+    if len(text or "") > 1200:
+        score += 1
+        signals["long_prompt"] = True
+    if len(text or "") > 3000:
+        score += 1
+        signals["very_long_prompt"] = True
+    cross_session = any(word in lowered for word in _CONTEXT_REFERENCE_WORDS)
+    if cross_session:
+        score += 1
+        signals["cross_session_reference"] = True
+    thread_count = _safe_int(ctx.get("thread_message_count") or ctx.get("message_count") or 0)
+    if thread_count >= 10:
+        score += 1
+        signals["long_thread"] = thread_count
+    if thread_count >= 20:
+        score += 1
+        signals["very_long_thread"] = thread_count
+    attachment_count = _safe_int(ctx.get("attachment_count") or ctx.get("file_count") or 0)
+    if attachment_count:
+        score += 1
+        signals["attachment_count"] = attachment_count
+    if ctx.get("compressed_context"):
+        score += 1
+        signals["compressed_context"] = True
+    source_count = _safe_int(ctx.get("source_count") or 0)
+    if source_count >= 3:
+        score += 1
+        signals["many_source_systems"] = source_count
+
+    return {"score": _bounded_score(score), "signals": signals}
+
+
+def score_complexity_risk(text: str, *, step_count: int = 0, permissions: Optional[List[PermissionGrant]] = None) -> Dict[str, Any]:
+    lowered = (text or "").lower()
+    signals: Dict[str, Any] = {}
+    score = 0
+    if step_count > 2:
+        score += 1
+        signals["multi_step"] = step_count
+    if step_count > 4:
+        score += 1
+        signals["long_dependency_chain"] = step_count
+    if _contains_word(lowered, _CODE_WORDS):
+        score += 1
+        signals["code_or_config"] = True
+    if permissions:
+        score += 2
+        signals["external_or_destructive"] = True
+    if any(word in lowered for word in ("source of truth", "ground truth", "eval", "audit", "verify", "validate")):
+        score += 1
+        signals["verification_burden"] = True
+    if any(word in lowered for word in ("architecture", "strategy", "council", "failure mode", "critique")):
+        score += 1
+        signals["ambiguous_judgment"] = True
+    return {"score": _bounded_score(score), "signals": signals}
+
+
+def score_illusion_risk(text: str, complexity_score: int, context_score: int, mode: str) -> Dict[str, Any]:
+    lowered = (text or "").lower()
+    signals: Dict[str, Any] = {}
+    score = 0
+    if complexity_score >= 2:
+        score += 1
+    if context_score >= 2:
+        score += 1
+    if mode == "swarm":
+        score += 1
+        signals["child_summary_risk"] = True
+    if any(word in lowered for word in _CURRENT_FACT_WORDS):
+        score += 1
+        signals["current_fact_claims_need_sources"] = True
+    if _contains_word(lowered, _CODE_WORDS) and "test" not in lowered:
+        score += 1
+        signals["code_claims_need_tests"] = True
+    if any(word in lowered for word in ("research", "review", "audit", "analyze", "summarize")):
+        signals["broad_analysis"] = True
+    return {"score": _bounded_score(score), "signals": signals}
+
+
+def _required_scaffold(mode: str, permissions: List[PermissionGrant], complexity: int, context: int) -> str:
+    if permissions:
+        return "approval"
+    if mode in {"script", "pipe"}:
+        return "script" if mode == "script" else "dry_run"
+    if context >= 3:
+        return "externalize_state"
+    if mode == "swarm" or complexity >= 2:
+        return "parallel_review"
+    if complexity or context:
+        return "checklist"
+    return "none"
+
+
+def _evidence_requirements(text: str, mode: str, permissions: List[PermissionGrant], telemetry: RoutingTelemetry) -> List[EvidenceRequirement]:
+    lowered = (text or "").lower()
+    requirements: List[EvidenceRequirement] = []
+    code_like = _contains_word(lowered, _CODE_WORDS)
+    research_like = any(word in lowered for word in ("research", "audit", "current", "latest", "docs", "available", "native")) or (
+        any(word in lowered for word in ("review", "analyze")) and not code_like
+    )
+    if research_like:
+        requirements.append(EvidenceRequirement("citation", "Provide source links or named source-of-truth evidence for research/current factual claims", source="router"))
+    if mode == "script" or telemetry.required_scaffold == "script":
+        requirements.append(EvidenceRequirement("command_output", "Provide command/script output or a skipped-verification reason", source="router"))
+    if mode == "pipe" or any(word in lowered for word in _PIPE_WORDS):
+        requirements.append(EvidenceRequirement("dry_run", "Provide dry-run output or payload contract before live pipe execution", source="router"))
+    if _contains_word(lowered, _CODE_WORDS):
+        requirements.append(EvidenceRequirement("test", "Provide test/lint/typecheck evidence or explicit skipped-verification reason", source="router"))
+    if permissions:
+        requirements.append(EvidenceRequirement("human_approval", "Get explicit human approval before external, destructive, or client-facing side effects", source="router"))
+    if telemetry.required_scaffold == "externalize_state":
+        requirements.append(EvidenceRequirement("artifact", "Externalize state into a plan/checklist/artifact before synthesis", source="router"))
+
+    deduped: List[EvidenceRequirement] = []
+    seen: set[str] = set()
+    for req in requirements:
+        if req.kind not in seen:
+            deduped.append(req)
+            seen.add(req.kind)
+    return deduped
+
+
+def _panel_policy(text: str, mode: str, complexity: int, context: int, illusion: int) -> Dict[str, Any]:
+    lowered = (text or "").lower()
+    considered = mode != "direct" or complexity > 0 or context > 0
+    explicit_council = any(word in lowered for word in ("council", "panel", "skeptic", "critique"))
+    required = bool(explicit_council or mode == "swarm" or complexity >= 2 or illusion >= 3)
+    roles: List[str] = []
+    if required:
+        if any(word in lowered for word in ("architecture", "strategy", "failure mode", "council")):
+            roles = ["scout", "skeptic", "synthesizer"]
+        elif _contains_word(lowered, _CODE_WORDS):
+            roles = ["builder", "reviewer", "verifier"]
+        else:
+            roles = ["researcher", "skeptic", "synthesizer"]
+    return {
+        "considered": considered,
+        "required": required,
+        "roles": roles,
+        "reason": "Panel required by complexity/context/illusion risk" if required else "Panel considered but not required",
+    }
+
+
 def route_request(
     text: str,
     platform_context: Optional[Dict[str, Any]] = None,
@@ -77,7 +249,7 @@ def route_request(
     ``pipe``. Permission requests are advisory and default-deny downstream work.
     """
 
-    del platform_context, config  # reserved for later live policy inputs
+    del config  # reserved for later live policy inputs
     raw_text = text or ""
     lowered = raw_text.lower()
     permissions = _permission_requests(raw_text)
@@ -100,7 +272,22 @@ def route_request(
         mode = "direct"
         reason = "Simple prompt suitable for direct handling."
 
-    verification_required = mode in {"swarm", "script", "pipe"} or bool(permissions) or any(
+    context_result = score_context_pressure(raw_text, platform_context)
+    complexity_result = score_complexity_risk(raw_text, step_count=step_count, permissions=permissions)
+    illusion_result = score_illusion_risk(raw_text, complexity_result["score"], context_result["score"], mode)
+    scaffold = _required_scaffold(mode, permissions, complexity_result["score"], context_result["score"])
+    telemetry = RoutingTelemetry(
+        complexity_risk=complexity_result["score"],
+        context_pressure=context_result["score"],
+        illusion_risk=illusion_result["score"],
+        required_scaffold=scaffold,
+        weak_output_risk=illusion_result["score"] >= 2,
+        signals={**context_result["signals"], **complexity_result["signals"], **illusion_result["signals"]},
+    )
+    evidence_requirements = _evidence_requirements(raw_text, mode, permissions, telemetry)
+    panel_policy = _panel_policy(raw_text, mode, telemetry.complexity_risk, telemetry.context_pressure, telemetry.illusion_risk)
+
+    verification_required = mode in {"swarm", "script", "pipe"} or bool(permissions) or bool(evidence_requirements) or any(
         word in lowered for word in ("verify", "validate", "test", "check")
     )
     return RoutingPlan(
@@ -109,8 +296,23 @@ def route_request(
         suggested_tasks=_suggested_tasks(raw_text, mode),
         permission_requests=permissions,
         verification_required=verification_required,
-        metadata={"step_count": step_count, "permission_required": bool(permissions)},
+        metadata={
+            "step_count": step_count,
+            "permission_required": bool(permissions),
+            "complexity_risk": telemetry.complexity_risk,
+            "context_pressure": telemetry.context_pressure,
+            "illusion_risk": telemetry.illusion_risk,
+            "required_scaffold": telemetry.required_scaffold,
+        },
+        evidence_requirements=evidence_requirements,
+        routing_telemetry=telemetry,
+        panel_policy=panel_policy,
     )
 
 
-__all__ = ["route_request"]
+__all__ = [
+    "route_request",
+    "score_complexity_risk",
+    "score_context_pressure",
+    "score_illusion_risk",
+]

--- a/agent/swarm_state.py
+++ b/agent/swarm_state.py
@@ -1,0 +1,371 @@
+"""Durable state objects for the Jeeves swarm operator.
+
+Sprint 1 intentionally keeps this module dependency-free: small dataclasses,
+explicit JSON conversion, and conservative defaults suitable for shadow mode.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Any, Dict, Iterable, List, Optional
+from uuid import uuid5, NAMESPACE_URL
+
+
+class JobStatus(str, Enum):
+    RECEIVED = "received"
+    TRIAGING = "triaging"
+    PLANNING = "planning"
+    AWAITING_PERMISSION = "awaiting_permission"
+    RUNNING = "running"
+    VERIFYING = "verifying"
+    SUMMARIZING = "summarizing"
+    COMPLETED = "completed"
+    FAILED = "failed"
+    CANCELLED = "cancelled"
+    PARTIALLY_COMPLETED = "partially_completed"
+
+
+class TaskStatus(str, Enum):
+    QUEUED = "queued"
+    BLOCKED = "blocked"
+    AWAITING_PERMISSION = "awaiting_permission"
+    RUNNING = "running"
+    NEEDS_REVIEW = "needs_review"
+    VERIFYING = "verifying"
+    COMPLETED = "completed"
+    FAILED = "failed"
+    CANCELLED = "cancelled"
+    SUPERSEDED = "superseded"
+
+
+_JOB_STATUSES = {item.value for item in JobStatus}
+_TASK_STATUSES = {item.value for item in TaskStatus}
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _stable_job_id(*, original_request: str, platform: str = "", user_id: str = "", chat_id: str = "", created_at: str = "") -> str:
+    seed = "\x1f".join([platform or "", user_id or "", chat_id or "", created_at or "", original_request or ""])
+    return f"swarm_{uuid5(NAMESPACE_URL, seed).hex[:20]}"
+
+
+def _copy_dict(value: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+    return dict(value or {})
+
+
+@dataclass
+class AuditEvent:
+    event_type: str
+    message: str = ""
+    timestamp: str = field(default_factory=_now)
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "event_type": self.event_type,
+            "message": self.message,
+            "timestamp": self.timestamp,
+            "metadata": _copy_dict(self.metadata),
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "AuditEvent":
+        return cls(
+            event_type=str(data.get("event_type") or "event"),
+            message=str(data.get("message") or ""),
+            timestamp=str(data.get("timestamp") or _now()),
+            metadata=_copy_dict(data.get("metadata")),
+        )
+
+
+@dataclass
+class PermissionGrant:
+    permission_id: str
+    description: str
+    status: str = "requested"
+    scope: Dict[str, Any] = field(default_factory=dict)
+    requested_at: str = field(default_factory=_now)
+    decided_at: Optional[str] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "permission_id": self.permission_id,
+            "description": self.description,
+            "status": self.status,
+            "scope": _copy_dict(self.scope),
+            "requested_at": self.requested_at,
+            "decided_at": self.decided_at,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "PermissionGrant":
+        return cls(
+            permission_id=str(data.get("permission_id") or data.get("id") or "permission"),
+            description=str(data.get("description") or ""),
+            status=str(data.get("status") or "requested"),
+            scope=_copy_dict(data.get("scope")),
+            requested_at=str(data.get("requested_at") or _now()),
+            decided_at=data.get("decided_at"),
+        )
+
+
+@dataclass
+class EvalResult:
+    name: str
+    passed: bool
+    details: str = ""
+    metadata: Dict[str, Any] = field(default_factory=dict)
+    timestamp: str = field(default_factory=_now)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "name": self.name,
+            "passed": self.passed,
+            "details": self.details,
+            "metadata": _copy_dict(self.metadata),
+            "timestamp": self.timestamp,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "EvalResult":
+        return cls(
+            name=str(data.get("name") or "eval"),
+            passed=bool(data.get("passed", False)),
+            details=str(data.get("details") or ""),
+            metadata=_copy_dict(data.get("metadata")),
+            timestamp=str(data.get("timestamp") or _now()),
+        )
+
+
+@dataclass
+class SwarmTask:
+    task_id: str
+    title: str
+    description: str = ""
+    status: str = TaskStatus.QUEUED.value
+    mode: str = "direct"
+    toolsets: List[str] = field(default_factory=list)
+    permission_required: bool = False
+    result: Optional[Dict[str, Any]] = None
+    created_at: str = field(default_factory=_now)
+    updated_at: str = field(default_factory=_now)
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if self.status not in _TASK_STATUSES:
+            raise ValueError(f"unknown task status: {self.status}")
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "task_id": self.task_id,
+            "title": self.title,
+            "description": self.description,
+            "status": self.status,
+            "mode": self.mode,
+            "toolsets": list(self.toolsets),
+            "permission_required": self.permission_required,
+            "result": _copy_dict(self.result) if self.result is not None else None,
+            "created_at": self.created_at,
+            "updated_at": self.updated_at,
+            "metadata": _copy_dict(self.metadata),
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "SwarmTask":
+        return cls(
+            task_id=str(data.get("task_id") or data.get("id") or "task"),
+            title=str(data.get("title") or ""),
+            description=str(data.get("description") or ""),
+            status=str(data.get("status") or TaskStatus.QUEUED.value),
+            mode=str(data.get("mode") or "direct"),
+            toolsets=list(data.get("toolsets") or []),
+            permission_required=bool(data.get("permission_required", False)),
+            result=_copy_dict(data.get("result")) if isinstance(data.get("result"), dict) else data.get("result"),
+            created_at=str(data.get("created_at") or _now()),
+            updated_at=str(data.get("updated_at") or data.get("created_at") or _now()),
+            metadata=_copy_dict(data.get("metadata")),
+        )
+
+
+@dataclass
+class RoutingPlan:
+    mode: str
+    reason: str
+    suggested_tasks: List[Dict[str, Any]] = field(default_factory=list)
+    permission_requests: List[PermissionGrant] = field(default_factory=list)
+    verification_required: bool = False
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "mode": self.mode,
+            "reason": self.reason,
+            "suggested_tasks": [dict(item) for item in self.suggested_tasks],
+            "permission_requests": [item.to_dict() for item in self.permission_requests],
+            "verification_required": self.verification_required,
+            "metadata": _copy_dict(self.metadata),
+        }
+
+    @classmethod
+    def from_dict(cls, data: Optional[Dict[str, Any]]) -> Optional["RoutingPlan"]:
+        if not data:
+            return None
+        return cls(
+            mode=str(data.get("mode") or "direct"),
+            reason=str(data.get("reason") or ""),
+            suggested_tasks=[dict(item) for item in data.get("suggested_tasks") or [] if isinstance(item, dict)],
+            permission_requests=[PermissionGrant.from_dict(item) for item in data.get("permission_requests") or [] if isinstance(item, dict)],
+            verification_required=bool(data.get("verification_required", False)),
+            metadata=_copy_dict(data.get("metadata")),
+        )
+
+
+@dataclass
+class SwarmJob:
+    job_id: str
+    original_request: str
+    status: str = JobStatus.RECEIVED.value
+    created_at: str = field(default_factory=_now)
+    updated_at: str = field(default_factory=_now)
+    platform: str = ""
+    user_id: str = ""
+    chat_id: str = ""
+    session_id: str = ""
+    routing_plan: Optional[RoutingPlan] = None
+    tasks: List[SwarmTask] = field(default_factory=list)
+    permissions: List[PermissionGrant] = field(default_factory=list)
+    evals: List[EvalResult] = field(default_factory=list)
+    audit: List[AuditEvent] = field(default_factory=list)
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if self.status not in _JOB_STATUSES:
+            raise ValueError(f"unknown job status: {self.status}")
+
+    @classmethod
+    def create(
+        cls,
+        original_request: str,
+        *,
+        platform: str = "",
+        user_id: str = "",
+        chat_id: str = "",
+        session_id: str = "",
+        job_id: Optional[str] = None,
+        created_at: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> "SwarmJob":
+        stamp = created_at or _now()
+        resolved_id = job_id or _stable_job_id(
+            original_request=original_request,
+            platform=platform,
+            user_id=user_id,
+            chat_id=chat_id,
+            created_at=stamp,
+        )
+        return cls(
+            job_id=resolved_id,
+            original_request=original_request,
+            status=JobStatus.RECEIVED.value,
+            created_at=stamp,
+            updated_at=stamp,
+            platform=platform,
+            user_id=user_id,
+            chat_id=chat_id,
+            session_id=session_id,
+            metadata=_copy_dict(metadata),
+        )
+
+    def add_task(self, title: str, description: str = "", **kwargs: Any) -> SwarmTask:
+        task_id = kwargs.pop("task_id", f"{self.job_id}_task_{len(self.tasks) + 1}")
+        task = SwarmTask(task_id=task_id, title=title, description=description, **kwargs)
+        self.tasks.append(task)
+        self.updated_at = _now()
+        self.audit.append(AuditEvent("task_added", f"Added task: {title}", metadata={"task_id": task.task_id}))
+        return task
+
+    def transition(self, status: str, message: str = "", metadata: Optional[Dict[str, Any]] = None) -> None:
+        if status not in _JOB_STATUSES:
+            raise ValueError(f"unknown job status: {status}")
+        old_status = self.status
+        self.status = status
+        self.updated_at = _now()
+        self.audit.append(
+            AuditEvent(
+                "status_changed",
+                message or f"Job status changed from {old_status} to {status}",
+                metadata={"from": old_status, "to": status, **_copy_dict(metadata)},
+            )
+        )
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "job_id": self.job_id,
+            "original_request": self.original_request,
+            "status": self.status,
+            "created_at": self.created_at,
+            "updated_at": self.updated_at,
+            "platform": self.platform,
+            "user_id": self.user_id,
+            "chat_id": self.chat_id,
+            "session_id": self.session_id,
+            "routing_plan": self.routing_plan.to_dict() if self.routing_plan else None,
+            "tasks": [task.to_dict() for task in self.tasks],
+            "permissions": [grant.to_dict() for grant in self.permissions],
+            "evals": [result.to_dict() for result in self.evals],
+            "audit": [event.to_dict() for event in self.audit],
+            "metadata": _copy_dict(self.metadata),
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "SwarmJob":
+        job = cls(
+            job_id=str(data.get("job_id") or data.get("id") or _stable_job_id(original_request=str(data.get("original_request") or ""))),
+            original_request=str(data.get("original_request") or ""),
+            status=str(data.get("status") or JobStatus.RECEIVED.value),
+            created_at=str(data.get("created_at") or _now()),
+            updated_at=str(data.get("updated_at") or data.get("created_at") or _now()),
+            platform=str(data.get("platform") or ""),
+            user_id=str(data.get("user_id") or ""),
+            chat_id=str(data.get("chat_id") or ""),
+            session_id=str(data.get("session_id") or ""),
+            routing_plan=RoutingPlan.from_dict(data.get("routing_plan")),
+            tasks=[SwarmTask.from_dict(item) for item in data.get("tasks") or [] if isinstance(item, dict)],
+            permissions=[PermissionGrant.from_dict(item) for item in data.get("permissions") or [] if isinstance(item, dict)],
+            evals=[EvalResult.from_dict(item) for item in data.get("evals") or [] if isinstance(item, dict)],
+            audit=[AuditEvent.from_dict(item) for item in data.get("audit") or [] if isinstance(item, dict)],
+            metadata=_copy_dict(data.get("metadata")),
+        )
+        return job
+
+
+# Convenience aliases requested by the implementation plan.
+def new_job(original_request: str, **kwargs: Any) -> SwarmJob:
+    return SwarmJob.create(original_request, **kwargs)
+
+
+def add_task(job: SwarmJob, title: str, description: str = "", **kwargs: Any) -> SwarmTask:
+    return job.add_task(title, description, **kwargs)
+
+
+def transition(job: SwarmJob, status: str, message: str = "", metadata: Optional[Dict[str, Any]] = None) -> None:
+    job.transition(status, message=message, metadata=metadata)
+
+
+__all__ = [
+    "AuditEvent",
+    "EvalResult",
+    "JobStatus",
+    "PermissionGrant",
+    "RoutingPlan",
+    "SwarmJob",
+    "SwarmTask",
+    "TaskStatus",
+    "add_task",
+    "new_job",
+    "transition",
+]

--- a/agent/swarm_state.py
+++ b/agent/swarm_state.py
@@ -192,6 +192,67 @@ class SwarmTask:
 
 
 @dataclass
+class EvidenceRequirement:
+    kind: str
+    description: str
+    required: bool = True
+    source: str = "parent"
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "kind": self.kind,
+            "description": self.description,
+            "required": self.required,
+            "source": self.source,
+            "metadata": _copy_dict(self.metadata),
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "EvidenceRequirement":
+        return cls(
+            kind=str(data.get("kind") or "artifact"),
+            description=str(data.get("description") or ""),
+            required=bool(data.get("required", True)),
+            source=str(data.get("source") or "parent"),
+            metadata=_copy_dict(data.get("metadata")),
+        )
+
+
+@dataclass
+class RoutingTelemetry:
+    complexity_risk: int = 0
+    context_pressure: int = 0
+    illusion_risk: int = 0
+    required_scaffold: str = "none"
+    weak_output_risk: bool = False
+    signals: Dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "complexity_risk": self.complexity_risk,
+            "context_pressure": self.context_pressure,
+            "illusion_risk": self.illusion_risk,
+            "required_scaffold": self.required_scaffold,
+            "weak_output_risk": self.weak_output_risk,
+            "signals": _copy_dict(self.signals),
+        }
+
+    @classmethod
+    def from_dict(cls, data: Optional[Dict[str, Any]]) -> "RoutingTelemetry":
+        if not isinstance(data, dict):
+            return cls()
+        return cls(
+            complexity_risk=int(data.get("complexity_risk") or 0),
+            context_pressure=int(data.get("context_pressure") or 0),
+            illusion_risk=int(data.get("illusion_risk") or 0),
+            required_scaffold=str(data.get("required_scaffold") or "none"),
+            weak_output_risk=bool(data.get("weak_output_risk", False)),
+            signals=_copy_dict(data.get("signals")),
+        )
+
+
+@dataclass
 class RoutingPlan:
     mode: str
     reason: str
@@ -199,8 +260,21 @@ class RoutingPlan:
     permission_requests: List[PermissionGrant] = field(default_factory=list)
     verification_required: bool = False
     metadata: Dict[str, Any] = field(default_factory=dict)
+    evidence_requirements: List[EvidenceRequirement] = field(default_factory=list)
+    routing_telemetry: RoutingTelemetry = field(default_factory=RoutingTelemetry)
+    panel_policy: Dict[str, Any] = field(default_factory=dict)
 
     def to_dict(self) -> Dict[str, Any]:
+        evidence_items = [
+            item.to_dict() if hasattr(item, "to_dict") else EvidenceRequirement.from_dict(item).to_dict()
+            for item in self.evidence_requirements
+            if isinstance(item, dict) or hasattr(item, "to_dict")
+        ]
+        telemetry = (
+            self.routing_telemetry.to_dict()
+            if hasattr(self.routing_telemetry, "to_dict")
+            else RoutingTelemetry.from_dict(self.routing_telemetry).to_dict()
+        )
         return {
             "mode": self.mode,
             "reason": self.reason,
@@ -208,6 +282,9 @@ class RoutingPlan:
             "permission_requests": [item.to_dict() for item in self.permission_requests],
             "verification_required": self.verification_required,
             "metadata": _copy_dict(self.metadata),
+            "evidence_requirements": evidence_items,
+            "routing_telemetry": telemetry,
+            "panel_policy": _copy_dict(self.panel_policy),
         }
 
     @classmethod
@@ -221,6 +298,9 @@ class RoutingPlan:
             permission_requests=[PermissionGrant.from_dict(item) for item in data.get("permission_requests") or [] if isinstance(item, dict)],
             verification_required=bool(data.get("verification_required", False)),
             metadata=_copy_dict(data.get("metadata")),
+            evidence_requirements=[EvidenceRequirement.from_dict(item) for item in data.get("evidence_requirements") or [] if isinstance(item, dict)],
+            routing_telemetry=RoutingTelemetry.from_dict(data.get("routing_telemetry")),
+            panel_policy=_copy_dict(data.get("panel_policy")),
         )
 
 
@@ -358,10 +438,12 @@ def transition(job: SwarmJob, status: str, message: str = "", metadata: Optional
 
 __all__ = [
     "AuditEvent",
+    "EvidenceRequirement",
     "EvalResult",
     "JobStatus",
     "PermissionGrant",
     "RoutingPlan",
+    "RoutingTelemetry",
     "SwarmJob",
     "SwarmTask",
     "TaskStatus",

--- a/agent/swarm_status.py
+++ b/agent/swarm_status.py
@@ -94,7 +94,10 @@ def format_swarm_status(jobs: Iterable[SwarmJob], *, include_completed: bool = F
             lines.append("  evidence:")
             for kind, count in sorted(synthesis.missing_evidence.items()):
                 lines.append(f"    - {kind}: missing ({count})")
-            if not synthesis.missing_evidence:
+            for kind, count in sorted(synthesis.satisfied_evidence.items()):
+                state = "approved" if kind == "human_approval" else "satisfied"
+                lines.append(f"    - {kind}: {state} ({count})")
+            if not synthesis.missing_evidence and not synthesis.satisfied_evidence:
                 lines.append("    - required evidence satisfied")
             lines.append(f"  safe to present complete: {'yes' if synthesis.safe_to_present_complete else 'no'}")
     return "\n".join(lines)

--- a/agent/swarm_status.py
+++ b/agent/swarm_status.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Any, Dict, Iterable, List, Mapping
 
 from agent.swarm_state import SwarmJob
+from agent.swarm_store import SwarmStore
 
 _SECRET_MARKERS = ("secret", "token", "key", "password", "credential", "api_key", "auth", "bearer")
 
@@ -90,4 +91,23 @@ def format_swarm_status(jobs: Iterable[SwarmJob], *, include_completed: bool = F
     return "\n".join(lines)
 
 
-__all__ = ["format_swarm_status", "redact_secrets"]
+def load_swarm_status_text(*, session_id: str = "", include_completed: bool = False) -> str:
+    """Load persisted swarm jobs and format them for status surfaces.
+
+    Fail closed: callers such as gateway /status should never error because the
+    optional swarm status file is absent or unreadable.
+    """
+    try:
+        jobs = list(SwarmStore().load_jobs().values())
+    except Exception:
+        return ""
+    if session_id:
+        scoped = [job for job in jobs if job.session_id == session_id]
+        if not scoped:
+            return ""
+        jobs = scoped
+    text = format_swarm_status(jobs, include_completed=include_completed)
+    return "" if text == "No active swarm operator jobs." else text
+
+
+__all__ = ["format_swarm_status", "load_swarm_status_text", "redact_secrets"]

--- a/agent/swarm_status.py
+++ b/agent/swarm_status.py
@@ -1,0 +1,93 @@
+"""Human-readable status formatting for Jeeves swarm operator jobs."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable, List, Mapping
+
+from agent.swarm_state import SwarmJob
+
+_SECRET_MARKERS = ("secret", "token", "key", "password", "credential", "api_key", "auth", "bearer")
+
+
+def _is_secret_key(key: str) -> bool:
+    lowered = key.lower()
+    return any(marker in lowered for marker in _SECRET_MARKERS)
+
+
+def redact_secrets(value: Any) -> Any:
+    """Recursively redact secret-looking metadata values."""
+    if isinstance(value, Mapping):
+        return {str(k): ("[REDACTED]" if _is_secret_key(str(k)) else redact_secrets(v)) for k, v in value.items()}
+    if isinstance(value, list):
+        return [redact_secrets(item) for item in value]
+    if isinstance(value, tuple):
+        return tuple(redact_secrets(item) for item in value)
+    return value
+
+
+def _short(text: str, limit: int = 96) -> str:
+    text = " ".join(str(text or "").split())
+    return text if len(text) <= limit else text[: limit - 1].rstrip() + "…"
+
+
+def _format_metadata(metadata: Dict[str, Any]) -> str:
+    redacted = redact_secrets(metadata or {})
+    if not redacted:
+        return ""
+    parts = []
+    for key in sorted(redacted):
+        value = redacted[key]
+        parts.append(f"{key}={_short(repr(value), 80)}")
+    return ", ".join(parts)
+
+
+def format_swarm_status(jobs: Iterable[SwarmJob], *, include_completed: bool = False) -> str:
+    """Format active swarm jobs with tasks, blockers, permissions and last event."""
+    selected: List[SwarmJob] = []
+    terminal = {"completed", "failed", "cancelled", "partially_completed"}
+    for job in jobs:
+        if include_completed or job.status not in terminal:
+            selected.append(job)
+
+    if not selected:
+        return "No active swarm operator jobs."
+
+    lines: List[str] = ["Swarm operator status:"]
+    for job in selected:
+        lines.append(f"- {job.job_id}: {job.status} — {_short(job.original_request)}")
+        if job.routing_plan:
+            lines.append(f"  route: {job.routing_plan.mode} ({_short(job.routing_plan.reason)})")
+        if job.tasks:
+            lines.append("  tasks:")
+            for task in job.tasks:
+                marker = " blocked" if task.status in {"blocked", "awaiting_permission"} or task.permission_required else ""
+                result = ""
+                if isinstance(task.result, dict):
+                    if task.result.get("summary"):
+                        result = f" — {_short(str(task.result.get('summary')))}"
+                    elif task.result.get("error"):
+                        result = f" — error: {_short(str(task.result.get('error')))}"
+                lines.append(f"    - {task.task_id}: {task.status}{marker} — {_short(task.title)}{result}")
+        blockers = [task for task in job.tasks if task.status in {"blocked", "awaiting_permission"} or task.permission_required]
+        if blockers:
+            lines.append("  blockers:")
+            for task in blockers:
+                lines.append(f"    - {task.task_id}: permission required for {_short(task.title)}")
+        permissions = list(job.permissions)
+        if job.routing_plan:
+            permissions.extend(job.routing_plan.permission_requests)
+        if permissions:
+            lines.append("  permission requests:")
+            for grant in permissions:
+                scope = _format_metadata(grant.scope)
+                suffix = f" ({scope})" if scope else ""
+                lines.append(f"    - {grant.permission_id}: {grant.status} — {_short(grant.description)}{suffix}")
+        if job.audit:
+            event = job.audit[-1]
+            metadata = _format_metadata(event.metadata)
+            suffix = f" [{metadata}]" if metadata else ""
+            lines.append(f"  last event: {event.event_type} — {_short(event.message)}{suffix}")
+    return "\n".join(lines)
+
+
+__all__ = ["format_swarm_status", "redact_secrets"]

--- a/agent/swarm_status.py
+++ b/agent/swarm_status.py
@@ -6,6 +6,7 @@ from typing import Any, Dict, Iterable, List, Mapping
 
 from agent.swarm_state import SwarmJob
 from agent.swarm_store import SwarmStore
+from agent.swarm_synthesis import synthesize_swarm_result
 
 _SECRET_MARKERS = ("secret", "token", "key", "password", "credential", "api_key", "auth", "bearer")
 
@@ -88,6 +89,14 @@ def format_swarm_status(jobs: Iterable[SwarmJob], *, include_completed: bool = F
             metadata = _format_metadata(event.metadata)
             suffix = f" [{metadata}]" if metadata else ""
             lines.append(f"  last event: {event.event_type} — {_short(event.message)}{suffix}")
+        if job.routing_plan and job.routing_plan.evidence_requirements:
+            synthesis = synthesize_swarm_result(job)
+            lines.append("  evidence:")
+            for kind, count in sorted(synthesis.missing_evidence.items()):
+                lines.append(f"    - {kind}: missing ({count})")
+            if not synthesis.missing_evidence:
+                lines.append("    - required evidence satisfied")
+            lines.append(f"  safe to present complete: {'yes' if synthesis.safe_to_present_complete else 'no'}")
     return "\n".join(lines)
 
 

--- a/agent/swarm_store.py
+++ b/agent/swarm_store.py
@@ -1,0 +1,91 @@
+"""Profile-safe JSON/JSONL store for swarm operator shadow state."""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from hermes_constants import get_hermes_home
+
+from agent.swarm_state import AuditEvent, SwarmJob
+
+
+class SwarmStoreError(RuntimeError):
+    """Raised when swarm state cannot be loaded without risking data loss."""
+
+
+class SwarmStore:
+    """Persist swarm jobs to a small state snapshot plus append-only metrics.
+
+    ``base_dir`` is primarily for tests. Production callers should omit it so
+    paths resolve beneath ``get_hermes_home() / "state"`` and respect profiles.
+    """
+
+    def __init__(self, base_dir: Optional[Path | str] = None):
+        self.base_dir = Path(base_dir) if base_dir is not None else get_hermes_home() / "state"
+        self.state_path = self.base_dir / "swarm_operator_state.json"
+        self.metrics_path = self.base_dir / "swarm_operator_metrics.jsonl"
+
+    def _ensure_dir(self) -> None:
+        self.base_dir.mkdir(parents=True, exist_ok=True)
+
+    def load_jobs(self) -> Dict[str, SwarmJob]:
+        if not self.state_path.exists():
+            return {}
+        try:
+            data = json.loads(self.state_path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as exc:
+            raise SwarmStoreError(f"Corrupt swarm state file: {self.state_path}: {exc}") from exc
+        except OSError as exc:
+            raise SwarmStoreError(f"Unable to read swarm state file: {self.state_path}: {exc}") from exc
+
+        if not isinstance(data, dict):
+            raise SwarmStoreError(f"Invalid swarm state file shape: {self.state_path}")
+        raw_jobs = data.get("jobs", {})
+        if not isinstance(raw_jobs, dict):
+            raise SwarmStoreError(f"Invalid swarm jobs shape: {self.state_path}")
+        jobs: Dict[str, SwarmJob] = {}
+        for job_id, raw_job in raw_jobs.items():
+            if not isinstance(raw_job, dict):
+                raise SwarmStoreError(f"Invalid swarm job {job_id!r} in {self.state_path}")
+            job = SwarmJob.from_dict(raw_job)
+            jobs[job.job_id] = job
+        return jobs
+
+    def save_job(self, job: SwarmJob) -> None:
+        self._ensure_dir()
+        jobs = self.load_jobs()
+        jobs[job.job_id] = job
+        payload = {
+            "version": 1,
+            "jobs": {job_id: item.to_dict() for job_id, item in sorted(jobs.items())},
+        }
+        fd, tmp_name = tempfile.mkstemp(prefix=f".{self.state_path.name}.", suffix=".tmp", dir=str(self.base_dir))
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                json.dump(payload, handle, ensure_ascii=False, indent=2, sort_keys=True)
+                handle.write("\n")
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.replace(tmp_name, self.state_path)
+        except Exception:
+            try:
+                os.unlink(tmp_name)
+            except OSError:
+                pass
+            raise
+
+    def append_event(self, event: AuditEvent | Dict[str, Any]) -> None:
+        self._ensure_dir()
+        if isinstance(event, AuditEvent):
+            payload = event.to_dict()
+        else:
+            payload = dict(event)
+        with self.metrics_path.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(payload, ensure_ascii=False, sort_keys=True) + "\n")
+
+
+__all__ = ["SwarmStore", "SwarmStoreError"]

--- a/agent/swarm_store.py
+++ b/agent/swarm_store.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import os
 import tempfile
+from contextlib import contextmanager
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
@@ -32,6 +33,23 @@ class SwarmStore:
     def _ensure_dir(self) -> None:
         self.base_dir.mkdir(parents=True, exist_ok=True)
 
+    @contextmanager
+    def _locked(self):
+        """Best-effort interprocess lock around read-modify-write store ops."""
+        self._ensure_dir()
+        lock_path = self.base_dir / ".swarm_operator_state.lock"
+        with lock_path.open("a+", encoding="utf-8") as handle:
+            if os.name == "posix":
+                import fcntl
+
+                fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+                try:
+                    yield
+                finally:
+                    fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+            else:  # pragma: no cover - Windows CI coverage is platform-specific.
+                yield
+
     def load_jobs(self) -> Dict[str, SwarmJob]:
         if not self.state_path.exists():
             return {}
@@ -56,36 +74,36 @@ class SwarmStore:
         return jobs
 
     def save_job(self, job: SwarmJob) -> None:
-        self._ensure_dir()
-        jobs = self.load_jobs()
-        jobs[job.job_id] = job
-        payload = {
-            "version": 1,
-            "jobs": {job_id: item.to_dict() for job_id, item in sorted(jobs.items())},
-        }
-        fd, tmp_name = tempfile.mkstemp(prefix=f".{self.state_path.name}.", suffix=".tmp", dir=str(self.base_dir))
-        try:
-            with os.fdopen(fd, "w", encoding="utf-8") as handle:
-                json.dump(payload, handle, ensure_ascii=False, indent=2, sort_keys=True)
-                handle.write("\n")
-                handle.flush()
-                os.fsync(handle.fileno())
-            os.replace(tmp_name, self.state_path)
-        except Exception:
+        with self._locked():
+            jobs = self.load_jobs()
+            jobs[job.job_id] = job
+            payload = {
+                "version": 1,
+                "jobs": {job_id: item.to_dict() for job_id, item in sorted(jobs.items())},
+            }
+            fd, tmp_name = tempfile.mkstemp(prefix=f".{self.state_path.name}.", suffix=".tmp", dir=str(self.base_dir))
             try:
-                os.unlink(tmp_name)
-            except OSError:
-                pass
-            raise
+                with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                    json.dump(payload, handle, ensure_ascii=False, indent=2, sort_keys=True)
+                    handle.write("\n")
+                    handle.flush()
+                    os.fsync(handle.fileno())
+                os.replace(tmp_name, self.state_path)
+            except Exception:
+                try:
+                    os.unlink(tmp_name)
+                except OSError:
+                    pass
+                raise
 
     def append_event(self, event: AuditEvent | Dict[str, Any]) -> None:
-        self._ensure_dir()
-        if isinstance(event, AuditEvent):
-            payload = event.to_dict()
-        else:
-            payload = dict(event)
-        with self.metrics_path.open("a", encoding="utf-8") as handle:
-            handle.write(json.dumps(payload, ensure_ascii=False, sort_keys=True) + "\n")
+        with self._locked():
+            if isinstance(event, AuditEvent):
+                payload = event.to_dict()
+            else:
+                payload = dict(event)
+            with self.metrics_path.open("a", encoding="utf-8") as handle:
+                handle.write(json.dumps(payload, ensure_ascii=False, sort_keys=True) + "\n")
 
 
 __all__ = ["SwarmStore", "SwarmStoreError"]

--- a/agent/swarm_synthesis.py
+++ b/agent/swarm_synthesis.py
@@ -21,6 +21,7 @@ class SwarmSynthesis:
     blocked_tasks: List[str] = field(default_factory=list)
     weak_tasks: List[str] = field(default_factory=list)
     missing_evidence: Dict[str, int] = field(default_factory=dict)
+    satisfied_evidence: Dict[str, int] = field(default_factory=dict)
     unresolved: List[str] = field(default_factory=list)
     risks: List[str] = field(default_factory=list)
     safe_to_present_complete: bool = True
@@ -33,6 +34,7 @@ class SwarmSynthesis:
             "blocked_tasks": list(self.blocked_tasks),
             "weak_tasks": list(self.weak_tasks),
             "missing_evidence": dict(self.missing_evidence),
+            "satisfied_evidence": dict(self.satisfied_evidence),
             "unresolved": list(self.unresolved),
             "risks": list(self.risks),
             "safe_to_present_complete": self.safe_to_present_complete,
@@ -47,7 +49,7 @@ def synthesize_swarm_result(job: SwarmJob, *, persist: bool = False) -> SwarmSyn
     for task in job.tasks:
         result = task.result or {}
         packet = EvidencePacket.from_result(result)
-        validation = validate_evidence_packet(packet, requirements)
+        validation = validate_evidence_packet(packet, requirements, approval_grants=job.permissions)
 
         if task.status in {"blocked", "awaiting_permission"} or task.permission_required:
             synthesis.blocked_tasks.append(task.task_id)
@@ -58,6 +60,8 @@ def synthesize_swarm_result(job: SwarmJob, *, persist: bool = False) -> SwarmSyn
         synthesis.risks.extend(packet.risks)
         for kind in validation.missing_required_kinds:
             synthesis.missing_evidence[kind] = synthesis.missing_evidence.get(kind, 0) + 1
+        for kind in validation.satisfied_kinds:
+            synthesis.satisfied_evidence[kind] = synthesis.satisfied_evidence.get(kind, 0) + 1
 
         claims = packet.claims or ([packet.summary] if packet.summary else [])
         if validation.passed:

--- a/agent/swarm_synthesis.py
+++ b/agent/swarm_synthesis.py
@@ -1,0 +1,98 @@
+"""Deterministic parent synthesis for swarm jobs.
+
+The synthesis layer is the parent-owned truth table: it decides which child
+claims are supported by required evidence and what must be disclosed before the
+operator presents a job as complete.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List
+
+from agent.swarm_evidence import EvidencePacket, validate_evidence_packet
+from agent.swarm_state import SwarmJob
+
+
+@dataclass
+class SwarmSynthesis:
+    verified_claims: List[str] = field(default_factory=list)
+    unverified_claims: List[str] = field(default_factory=list)
+    blocked_tasks: List[str] = field(default_factory=list)
+    weak_tasks: List[str] = field(default_factory=list)
+    missing_evidence: Dict[str, int] = field(default_factory=dict)
+    unresolved: List[str] = field(default_factory=list)
+    risks: List[str] = field(default_factory=list)
+    safe_to_present_complete: bool = True
+    user_disclosure: str = ""
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "verified_claims": list(self.verified_claims),
+            "unverified_claims": list(self.unverified_claims),
+            "blocked_tasks": list(self.blocked_tasks),
+            "weak_tasks": list(self.weak_tasks),
+            "missing_evidence": dict(self.missing_evidence),
+            "unresolved": list(self.unresolved),
+            "risks": list(self.risks),
+            "safe_to_present_complete": self.safe_to_present_complete,
+            "user_disclosure": self.user_disclosure,
+        }
+
+
+def synthesize_swarm_result(job: SwarmJob, *, persist: bool = False) -> SwarmSynthesis:
+    requirements = job.routing_plan.evidence_requirements if job.routing_plan else []
+    synthesis = SwarmSynthesis()
+
+    for task in job.tasks:
+        result = task.result or {}
+        packet = EvidencePacket.from_result(result)
+        validation = validate_evidence_packet(packet, requirements)
+
+        if task.status in {"blocked", "awaiting_permission"} or task.permission_required:
+            synthesis.blocked_tasks.append(task.task_id)
+        if isinstance(result, dict) and result.get("weak_output"):
+            synthesis.weak_tasks.append(task.task_id)
+
+        synthesis.unresolved.extend(packet.unresolved)
+        synthesis.risks.extend(packet.risks)
+        for kind in validation.missing_required_kinds:
+            synthesis.missing_evidence[kind] = synthesis.missing_evidence.get(kind, 0) + 1
+
+        claims = packet.claims or ([packet.summary] if packet.summary else [])
+        if validation.passed:
+            synthesis.verified_claims.extend(claims)
+        else:
+            synthesis.unverified_claims.extend(claims)
+
+    incomplete = bool(
+        synthesis.unverified_claims
+        or synthesis.blocked_tasks
+        or synthesis.weak_tasks
+        or synthesis.missing_evidence
+        or job.status in {"failed", "partially_completed", "awaiting_permission", "cancelled"}
+    )
+    synthesis.safe_to_present_complete = not incomplete
+    synthesis.user_disclosure = _build_disclosure(synthesis)
+    if persist:
+        job.metadata["swarm_synthesis"] = synthesis.to_dict()
+    return synthesis
+
+
+def _build_disclosure(synthesis: SwarmSynthesis) -> str:
+    if synthesis.safe_to_present_complete:
+        return "All delegated claims are supported by required evidence."
+    parts: List[str] = []
+    if synthesis.missing_evidence:
+        missing = ", ".join(f"{kind} x{count}" for kind, count in sorted(synthesis.missing_evidence.items()))
+        parts.append(f"Missing required evidence: {missing}.")
+    if synthesis.unverified_claims:
+        parts.append(f"Unverified claims: {len(synthesis.unverified_claims)}.")
+    if synthesis.weak_tasks:
+        parts.append(f"Weak child outputs: {', '.join(synthesis.weak_tasks)}.")
+    if synthesis.blocked_tasks:
+        parts.append(f"Blocked tasks: {', '.join(synthesis.blocked_tasks)}.")
+    return " ".join(parts) or "Swarm result is not safe to present as complete."
+
+
+__all__ = ["SwarmSynthesis", "synthesize_swarm_result"]

--- a/agent/swarm_verifier.py
+++ b/agent/swarm_verifier.py
@@ -1,0 +1,5 @@
+"""Compatibility alias for swarm verification helpers."""
+
+from agent.swarm_verify import VerificationPlan, apply_verification_results, build_verification_plan
+
+__all__ = ["VerificationPlan", "apply_verification_results", "build_verification_plan"]

--- a/agent/swarm_verify.py
+++ b/agent/swarm_verify.py
@@ -1,0 +1,156 @@
+"""Verification planning helpers for the Jeeves swarm operator.
+
+The planner is deliberately deterministic and side-effect free. It records what
+should be checked after direct/script/swarm work, but it does not execute tests or
+call external services; callers provide verification outcomes explicitly.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, Iterable, Mapping
+
+from agent.swarm_state import AuditEvent, EvalResult, JobStatus, RoutingPlan, SwarmJob
+
+
+@dataclass
+class VerificationPlan:
+    """A compact, serializable checklist for parent-owned verification."""
+
+    required: bool
+    steps: list[dict[str, Any]] = field(default_factory=list)
+    reason: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "required": self.required,
+            "steps": [dict(step) for step in self.steps],
+            "reason": self.reason,
+        }
+
+    def summary(self, *, results: Mapping[str, Any] | None = None) -> dict[str, Any]:
+        results = results or {}
+        total = len(self.steps)
+        passed = 0
+        failed = 0
+        for step in self.steps:
+            step_id = str(step.get("id") or "")
+            if step_id not in results:
+                continue
+            result = _coerce_result(step_id, results[step_id])
+            if result.passed:
+                passed += 1
+            else:
+                failed += 1
+        if failed:
+            status = "failed"
+        elif total and passed == total:
+            status = "passed"
+        elif not self.required and not total:
+            status = "skipped"
+        else:
+            status = "pending"
+        return {"status": status, "total": total, "passed": passed, "failed": failed}
+
+
+def _step(step_id: str, title: str, *, required: bool = True, source: str = "parent") -> dict[str, Any]:
+    return {"id": step_id, "title": title, "required": required, "source": source}
+
+
+def _job_text(job: SwarmJob, plan: RoutingPlan | None) -> str:
+    chunks: list[str] = [job.original_request]
+    if plan:
+        chunks.extend([plan.mode, plan.reason])
+        chunks.extend(str(item) for item in plan.suggested_tasks)
+        chunks.extend(grant.description for grant in plan.permission_requests)
+    for task in job.tasks:
+        chunks.extend([task.title, task.description, task.mode, str(task.metadata)])
+    return " ".join(chunks).lower()
+
+
+def _contains_any(text: str, needles: Iterable[str]) -> bool:
+    return any(needle in text for needle in needles)
+
+
+def build_verification_plan(job: SwarmJob, routing_plan: RoutingPlan | None = None) -> VerificationPlan:
+    """Build a conservative verification checklist for a swarm job."""
+
+    plan = routing_plan or job.routing_plan
+    required = bool(getattr(plan, "verification_required", False)) if plan else False
+    mode = str(getattr(plan, "mode", "direct") or "direct") if plan else "direct"
+    text = _job_text(job, plan)
+    steps: list[dict[str, Any]] = []
+
+    if mode in {"swarm", "script", "pipe"} or required:
+        steps.append(_step("final_consistency_check", "Verify final synthesis matches the original request"))
+    else:
+        steps.append(_step("direct_sanity_check", "Sanity-check the direct answer before final response", required=False))
+
+    if job.tasks:
+        steps.append(_step("child_result_review", "Review child task results and evidence", source="children"))
+    if any(task.status in {"blocked", "awaiting_permission"} or task.permission_required for task in job.tasks):
+        steps.append(_step("permission_blocker_review", "Confirm blocked tasks are disclosed and not executed"))
+    if any(task.result and (task.result.get("error") or task.result.get("ok") is False) for task in job.tasks):
+        steps.append(_step("failure_review", "Account for failed child results in the final outcome"))
+    if job.permissions or (plan and getattr(plan, "permission_requests", None)):
+        steps.append(_step("permission_request_review", "Review outstanding permission requests"))
+    if _contains_any(text, ("code", "config", "file edit", "patch", "implement", "test", "lint", "typecheck")):
+        steps.append(_step("code_config_verification", "Require test/lint/typecheck evidence or an explicit skipped-verification reason"))
+    if mode in {"script", "pipe"} or _contains_any(text, ("n8n", "docker", "script", "workflow", "webhook", "pipe")):
+        steps.append(_step("dry_run_payload_contract", "Require dry-run output or payload-contract evidence before live execution"))
+    if _contains_any(text, ("send", "email", "slack message", "client-facing", "external", "publish", "deploy")):
+        steps.append(_step("human_approval_review", "Require reviewer or human approval before external/client-facing action"))
+
+    # Stable de-duplication if several signals produced the same step.
+    deduped: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for item in steps:
+        step_id = str(item.get("id"))
+        if step_id not in seen:
+            seen.add(step_id)
+            deduped.append(item)
+
+    return VerificationPlan(required=required or any(step.get("required") for step in deduped), steps=deduped, reason=(plan.reason if plan else ""))
+
+
+def _coerce_result(name: str, raw: Any) -> EvalResult:
+    if isinstance(raw, EvalResult):
+        return raw
+    if isinstance(raw, tuple):
+        passed = bool(raw[0]) if raw else False
+        details = str(raw[1]) if len(raw) > 1 else ""
+        return EvalResult(name=name, passed=passed, details=details)
+    if isinstance(raw, Mapping):
+        return EvalResult(
+            name=str(raw.get("name") or name),
+            passed=bool(raw.get("passed", False)),
+            details=str(raw.get("details") or raw.get("summary") or ""),
+            metadata=dict(raw.get("metadata") or {}),
+        )
+    return EvalResult(name=name, passed=bool(raw), details="")
+
+
+def apply_verification_results(job: SwarmJob, verification: VerificationPlan, results: Mapping[str, Any]) -> dict[str, Any]:
+    """Persist verification results on ``job`` without executing checks."""
+
+    coerced: dict[str, EvalResult] = {}
+    for step in verification.steps:
+        step_id = str(step.get("id") or "")
+        if not step_id or step_id not in results:
+            continue
+        eval_result = _coerce_result(step_id, results[step_id])
+        coerced[eval_result.name] = eval_result
+        job.evals.append(eval_result)
+
+    summary = verification.summary(results=coerced)
+    job.metadata["swarm_verification"] = {**verification.to_dict(), **summary}
+    job.audit.append(AuditEvent("verification_recorded", "Swarm verification results recorded.", metadata=summary))
+
+    if summary["status"] == "failed" and job.status not in {JobStatus.FAILED.value, JobStatus.CANCELLED.value}:
+        job.transition(JobStatus.PARTIALLY_COMPLETED.value, "Verification failed", metadata=summary)
+    elif summary["status"] == "passed" and job.status in {JobStatus.RUNNING.value, JobStatus.VERIFYING.value}:
+        job.transition(JobStatus.COMPLETED.value, "Verification passed", metadata=summary)
+    return summary
+
+
+__all__ = ["VerificationPlan", "apply_verification_results", "build_verification_plan"]

--- a/agent/swarm_verify.py
+++ b/agent/swarm_verify.py
@@ -53,8 +53,8 @@ class VerificationPlan:
         return {"status": status, "total": total, "passed": passed, "failed": failed}
 
 
-def _step(step_id: str, title: str, *, required: bool = True, source: str = "parent") -> dict[str, Any]:
-    return {"id": step_id, "title": title, "required": required, "source": source}
+def _step(step_id: str, title: str, *, required: bool = True, source: str = "parent", **metadata: Any) -> dict[str, Any]:
+    return {"id": step_id, "title": title, "required": required, "source": source, **metadata}
 
 
 def _job_text(job: SwarmJob, plan: RoutingPlan | None) -> str:
@@ -100,6 +100,22 @@ def build_verification_plan(job: SwarmJob, routing_plan: RoutingPlan | None = No
         steps.append(_step("dry_run_payload_contract", "Require dry-run output or payload-contract evidence before live execution"))
     if _contains_any(text, ("send", "email", "slack message", "client-facing", "external", "publish", "deploy")):
         steps.append(_step("human_approval_review", "Require reviewer or human approval before external/client-facing action"))
+
+    for requirement in getattr(plan, "evidence_requirements", []) or []:
+        kind = str(getattr(requirement, "kind", "") or "artifact")
+        description = str(getattr(requirement, "description", "") or f"Provide {kind} evidence")
+        required_flag = bool(getattr(requirement, "required", True))
+        source = str(getattr(requirement, "source", "router") or "router")
+        steps.append(
+            _step(
+                f"evidence_{kind}",
+                description,
+                required=required_flag,
+                source=source,
+                evidence_kind=kind,
+                evidence_metadata=dict(getattr(requirement, "metadata", {}) or {}),
+            )
+        )
 
     # Stable de-duplication if several signals produced the same step.
     deduped: list[dict[str, Any]] = []

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -39,6 +39,7 @@ from agent.prompt_builder import (
     SKILLS_GUIDANCE,
     TOOL_USE_ENFORCEMENT_GUIDANCE,
     TOOL_USE_ENFORCEMENT_MODELS,
+    build_swarm_operator_prompt,
 )
 
 
@@ -130,6 +131,11 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
     nous_subscription_prompt = _r.build_nous_subscription_prompt(agent.valid_tool_names)
     if nous_subscription_prompt:
         stable_parts.append(nous_subscription_prompt)
+
+    swarm_operator_prompt = _r.build_swarm_operator_prompt()
+    if swarm_operator_prompt:
+        stable_parts.append(swarm_operator_prompt)
+
     # Tool-use enforcement: tells the model to actually call tools instead
     # of describing intended actions.  Controlled by config.yaml
     # agent.tool_use_enforcement:

--- a/docs/plans/2026-05-21-jeeves-swarm-operator.md
+++ b/docs/plans/2026-05-21-jeeves-swarm-operator.md
@@ -1,0 +1,440 @@
+# Jeeves Swarm Operator Implementation Plan
+
+> **For Hermes:** Use subagent-driven-development skill to implement this plan task-by-task.
+
+**Goal:** Build a production-safe Jeeves operator mode where every Garrett chat is received by Jeeves, routed into direct work / parallel subagents / durable jobs / scripts / dumb-pipe automations, then synthesized back into one verified response.
+
+**Architecture:** Do not build a second agent runtime. Reuse Hermes gateway ingress, `AIAgent`, `delegate_task`, cron, kanban, Honcho/autopilot ingest, existing approval flows, and gateway status/progress callbacks. Add a thin swarm/job state layer plus operator routing policy and shadow rollout controls.
+
+**Tech Stack:** Python, Hermes Agent gateway/runtime, SQLite/JSONL state, existing `delegate_task`, Honcho via existing autopilot ingest plugin, cron/kanban for durable work, pytest.
+
+---
+
+## Validated Existing Primitives
+
+- Gateway ingress/response: `gateway/platforms/base.py`, `gateway/run.py`.
+- Main runtime: `run_agent.py`, `agent/conversation_loop.py`.
+- Parallel in-turn agents: `tools/delegate_tool.py` via `delegate_task(tasks=[...])`.
+- Session/transcript state: `hermes_state.py`, `gateway/session.py`, `~/.hermes/state.db`.
+- Durable scheduled work: `cron/jobs.py`, `cron/scheduler.py`.
+- Durable worker/task substrate: `hermes_cli/kanban_db.py`, `tools/kanban_tools.py`.
+- Approval flow: existing gateway `/approve` and `/deny`, `tools/approval.py`.
+- Honcho signal path: `~/.hermes/plugins/autopilot-ingest/tools.py::ingest_signal`.
+- Live canonical approval ledger: `~/.hermes/state/open_decisions.json`.
+- Live machine audit pattern: `~/.hermes/state/*_state.json`, `~/.hermes/state/*_metrics.jsonl`.
+
+## Non-Negotiables
+
+1. Jeeves owns all user-facing synthesis; child agents do not DM Garrett.
+2. Side effects are default-denied unless already permitted by Hermes policy or explicitly approved.
+3. Subagents remain bounded by existing `delegation.max_concurrent_children`.
+4. Honcho writes come from the operator/parent, not noisy subagents.
+5. `delegate_task` is for synchronous fan-out; kanban/cron are for durable work.
+6. n8n/Docker are dumb execution pipes, not reasoning engines.
+7. Feature starts in shadow/dry-run mode before intercepting normal Slack behavior.
+
+---
+
+## Phase 1: Swarm State Model + Store
+
+### Task 1: Add swarm model tests
+
+**Objective:** Define durable, inspectable job/task/audit objects before implementation.
+
+**Files:**
+- Create: `tests/swarm/test_swarm_state.py`
+- Create: `agent/swarm_state.py`
+
+**Test cases:**
+- `SwarmJob.create(...)` sets `status='received'`, stable ID, timestamps, original request, and empty task/audit lists.
+- `SwarmJob.add_task(...)` appends a task and audit event.
+- `SwarmJob.transition(...)` records status changes and audit events.
+- JSON round-trip preserves job/task/permission/eval data.
+
+**Run:**
+
+```bash
+python -m pytest tests/swarm/test_swarm_state.py -q -o 'addopts='
+```
+
+**Expected:** fail before implementation, pass after.
+
+### Task 2: Implement `agent/swarm_state.py`
+
+**Objective:** Add small dataclass/Pydantic-free model to avoid introducing runtime dependencies.
+
+**Files:**
+- Modify/Create: `agent/swarm_state.py`
+
+**Implementation shape:**
+- Dataclasses/enums for:
+  - `SwarmJob`
+  - `SwarmTask`
+  - `RoutingPlan`
+  - `PermissionGrant`
+  - `EvalResult`
+  - `AuditEvent`
+- Helpers:
+  - `new_job(...)`
+  - `add_task(...)`
+  - `transition(...)`
+  - `to_dict()` / `from_dict()`
+- Statuses:
+  - job: `received`, `triaging`, `planning`, `awaiting_permission`, `running`, `verifying`, `summarizing`, `completed`, `failed`, `cancelled`, `partially_completed`
+  - task: `queued`, `blocked`, `awaiting_permission`, `running`, `needs_review`, `verifying`, `completed`, `failed`, `cancelled`, `superseded`
+
+**Verification:**
+
+```bash
+python -m pytest tests/swarm/test_swarm_state.py -q -o 'addopts='
+```
+
+---
+
+## Phase 2: Swarm Store + Shadow Audit
+
+### Task 3: Add JSONL store tests
+
+**Objective:** Persist swarm audit without touching production `state.db` first.
+
+**Files:**
+- Create: `tests/swarm/test_swarm_store.py`
+- Create: `agent/swarm_store.py`
+
+**Test cases:**
+- Store writes a job snapshot to `${HERMES_HOME}/state/swarm_operator_state.json`.
+- Store appends events to `${HERMES_HOME}/state/swarm_operator_metrics.jsonl`.
+- Store loads existing jobs on restart.
+- Store handles corrupt/missing files gracefully with explicit errors and no silent data loss.
+
+### Task 4: Implement `agent/swarm_store.py`
+
+**Objective:** Add profile-safe state using `get_hermes_home()`.
+
+**Files:**
+- Modify/Create: `agent/swarm_store.py`
+
+**Implementation shape:**
+- `SwarmStore(base_dir=None)`
+- `save_job(job)`
+- `load_jobs()`
+- `append_event(event)`
+- Atomic write for JSON snapshot.
+- Append-only JSONL for metrics/audit.
+
+**Verification:**
+
+```bash
+python -m pytest tests/swarm/test_swarm_store.py tests/swarm/test_swarm_state.py -q -o 'addopts='
+```
+
+---
+
+## Phase 3: Operator Routing Policy
+
+### Task 5: Add routing policy tests
+
+**Objective:** Classify requests deterministically before involving LLM routing.
+
+**Files:**
+- Create: `tests/swarm/test_swarm_routing.py`
+- Create: `agent/swarm_router.py`
+
+**Test cases:**
+- Simple explanatory prompt -> `direct`.
+- Multiple independent lookups or code/research/review request -> `swarm`.
+- More than 3 procedural/validation/source-of-truth steps -> `script` candidate.
+- External send/deploy/destructive wording -> permission required.
+- n8n/docker wording -> `pipe` candidate with permission gate.
+
+### Task 6: Implement `agent/swarm_router.py`
+
+**Objective:** Add first-pass deterministic router used by Jeeves before tool fan-out.
+
+**Files:**
+- Modify/Create: `agent/swarm_router.py`
+
+**Implementation shape:**
+- `route_request(text, platform_context=None, config=None) -> RoutingPlan`
+- Conservative heuristics only; no LLM required in v1.
+- Include `reason`, `mode`, `suggested_tasks`, `permission_requests`, `verification_required`.
+
+**Verification:**
+
+```bash
+python -m pytest tests/swarm/test_swarm_routing.py -q -o 'addopts='
+```
+
+---
+
+## Phase 4: Gateway Shadow Hook
+
+### Task 7: Add gateway shadow-mode hook tests
+
+**Objective:** Every inbound Garrett message can create a shadow job record without changing response behavior.
+
+**Files:**
+- Create: `tests/swarm/test_gateway_swarm_shadow.py`
+- Modify/Create: `gateway/builtin_hooks/swarm_operator.py`
+
+**Test cases:**
+- Hook receives inbound event metadata and message text.
+- If disabled, it does nothing.
+- If enabled in dry-run, it writes a `SwarmJob` and metrics event.
+- Hook never blocks normal message handling on store failure; it logs a clear warning.
+
+### Task 8: Implement shadow hook
+
+**Objective:** Deploy the safest possible first slice: observe only, no child agents.
+
+**Files:**
+- Modify/Create: `gateway/builtin_hooks/swarm_operator.py`
+- Modify: hook registration location if needed, likely `gateway/builtin_hooks/__init__.py` or `gateway/run.py` hook setup.
+
+**Implementation shape:**
+- Config keys, default disabled:
+  - `swarm_operator.enabled: false`
+  - `swarm_operator.dry_run: true`
+  - `swarm_operator.max_children: 3`
+  - `swarm_operator.persist_to_honcho: false`
+- On inbound message:
+  - create job
+  - route
+  - write state/metrics
+  - do not alter response
+
+**Verification:**
+
+```bash
+python -m pytest tests/swarm/test_gateway_swarm_shadow.py tests/swarm -q -o 'addopts='
+```
+
+---
+
+## Phase 5: Operator Prompt + Delegation Contract
+
+### Task 9: Add operator prompt builder tests
+
+**Objective:** Ensure Jeeves receives explicit swarm operating rules without bloating every session when disabled.
+
+**Files:**
+- Create: `tests/swarm/test_swarm_prompt.py`
+- Modify: `agent/prompt_builder.py` or a new `agent/swarm_prompt.py`
+
+**Test cases:**
+- Disabled config does not alter prompt.
+- Enabled config includes operator routing rules, delegation limits, permission model, and subsystem policy.
+- Prompt includes “scripts for >3 procedural steps/source-of-truth/validation/eval.”
+- Prompt includes “n8n/docker are dumb pipes.”
+
+### Task 10: Implement swarm operator prompt section
+
+**Objective:** Make Jeeves behave as operator using existing model/tool loop.
+
+**Files:**
+- Modify/Create: `agent/swarm_prompt.py`
+- Modify: `agent/prompt_builder.py`
+
+**Verification:**
+
+```bash
+python -m pytest tests/swarm/test_swarm_prompt.py tests/agent/test_prompt_builder.py -q -o 'addopts='
+```
+
+---
+
+## Phase 6: Bounded Parallel Swarm Execution
+
+### Task 11: Add executor tests with mocked `delegate_task`
+
+**Objective:** Prove operator can translate routing tasks into bounded delegate calls.
+
+**Files:**
+- Create: `tests/swarm/test_swarm_executor.py`
+- Create: `agent/swarm_executor.py`
+
+**Test cases:**
+- Executes at most `max_children` independent tasks.
+- Uses declared toolsets per task.
+- Aggregates results into job summary data.
+- Partial child failure marks job `partially_completed` unless critical.
+- Permission-required tasks remain blocked and are not dispatched.
+
+### Task 12: Implement `agent/swarm_executor.py`
+
+**Objective:** Add thin wrapper over existing `delegate_task`; do not build a new scheduler.
+
+**Files:**
+- Modify/Create: `agent/swarm_executor.py`
+
+**Implementation shape:**
+- `build_delegate_tasks(routing_plan, job)`
+- `execute_swarm(job, routing_plan, delegate_fn)`
+- Use injected `delegate_fn` for tests; production can call existing delegate path/tool later.
+- Return structured task results and update job state.
+
+**Verification:**
+
+```bash
+python -m pytest tests/swarm/test_swarm_executor.py tests/swarm -q -o 'addopts='
+```
+
+---
+
+## Phase 7: Status + Approval Integration
+
+### Task 13: Add status formatting tests
+
+**Objective:** Garrett can ask “what are you doing?” and get swarm/job status.
+
+**Files:**
+- Create: `tests/swarm/test_swarm_status.py`
+- Create: `agent/swarm_status.py`
+
+**Test cases:**
+- Formats active jobs with status, tasks, blockers, and last event.
+- Redacts secrets from audit metadata.
+- Shows permission requests clearly.
+
+### Task 14: Implement status formatter and wire to `/agents` or `/status`
+
+**Objective:** Surface swarm jobs alongside existing running agents.
+
+**Files:**
+- Modify/Create: `agent/swarm_status.py`
+- Modify: `gateway/run.py` status command area, if minimal and safe.
+
+**Verification:**
+
+```bash
+python -m pytest tests/swarm/test_swarm_status.py -q -o 'addopts='
+```
+
+---
+
+## Phase 8: Honcho Persistence
+
+### Task 15: Add Honcho persistence adapter tests
+
+**Objective:** Persist final swarm summaries through existing autopilot ingest path without exposing every child-agent scratchpad.
+
+**Files:**
+- Create: `tests/swarm/test_swarm_honcho.py`
+- Create: `agent/swarm_honcho.py`
+
+**Test cases:**
+- Builds a compact signal from job summary, task results, and verification state.
+- Uses stable `external_id` to dedupe.
+- Does not persist raw secrets/tool dumps.
+- No-op when disabled or ingest plugin unavailable.
+
+### Task 16: Implement Honcho summary adapter
+
+**Objective:** Parent/operator writes useful memory; children stay quiet.
+
+**Files:**
+- Modify/Create: `agent/swarm_honcho.py`
+
+**Verification:**
+
+```bash
+python -m pytest tests/swarm/test_swarm_honcho.py -q -o 'addopts='
+```
+
+---
+
+## Phase 9: Verification/Eval Layer
+
+### Task 17: Add verification planner tests
+
+**Objective:** Require tests/evidence for code/config/automation/source-of-truth work.
+
+**Files:**
+- Create: `tests/swarm/test_swarm_verifier.py`
+- Create: `agent/swarm_verifier.py`
+
+**Test cases:**
+- Code/config jobs require test/lint/typecheck or explicit skipped reason.
+- n8n/docker/script tasks require dry-run or payload contract evidence.
+- External/client-facing output requires reviewer/human approval.
+
+### Task 18: Implement verification planner
+
+**Objective:** Add structured eval requirements; execution can remain manual/tool-driven in v1.
+
+**Files:**
+- Modify/Create: `agent/swarm_verifier.py`
+
+**Verification:**
+
+```bash
+python -m pytest tests/swarm/test_swarm_verifier.py -q -o 'addopts='
+```
+
+---
+
+## Phase 10: Rollout
+
+### Task 19: Config defaults and docs
+
+**Objective:** Ship disabled-by-default with clear rollout instructions.
+
+**Files:**
+- Modify: `hermes_cli/config.py`
+- Create: `website/docs/user-guide/features/swarm-operator.md` or suitable docs path.
+
+**Config defaults:**
+
+```yaml
+swarm_operator:
+  enabled: false
+  dry_run: true
+  max_children: 3
+  persist_to_honcho: false
+  intercept_gateway: false
+  external_side_effects_enabled: false
+```
+
+### Task 20: Focused and adjacent tests
+
+**Objective:** Prove the feature does not break normal Hermes behavior.
+
+**Commands:**
+
+```bash
+python -m pytest tests/swarm -q -o 'addopts='
+python -m pytest tests/agent/test_prompt_builder.py tests/tools/test_delegate.py tests/cron/test_scheduler.py -q -o 'addopts='
+```
+
+### Task 21: Shadow rollout on Garrett’s local stack
+
+**Objective:** Enable dry-run shadow mode only after tests pass.
+
+**Manual steps, requiring Garrett approval before changing live config:**
+
+```bash
+hermes config set swarm_operator.enabled true
+hermes config set swarm_operator.dry_run true
+hermes config set swarm_operator.intercept_gateway false
+hermes gateway restart
+```
+
+**Verification:**
+- Send a Slack DM.
+- Confirm normal response still works.
+- Confirm `${HERMES_HOME}/state/swarm_operator_state.json` updates.
+- Confirm `${HERMES_HOME}/state/swarm_operator_metrics.jsonl` receives one event.
+- Confirm no subagents run in shadow mode.
+
+---
+
+## First Implementation Sprint Recommendation
+
+Start with Tasks 1-8 only:
+
+1. State model.
+2. Store.
+3. Router.
+4. Gateway shadow hook.
+
+This gives us the spine without risking the “oops I accidentally made a self-driving clown car with root access” problem. Once shadow data looks sane, wire Jeeves prompt/executor and then Honcho/status/evals.

--- a/docs/plans/2026-05-21-jeeves-swarm-operator.md
+++ b/docs/plans/2026-05-21-jeeves-swarm-operator.md
@@ -350,8 +350,8 @@ python -m pytest tests/swarm/test_swarm_honcho.py -q -o 'addopts='
 **Objective:** Require tests/evidence for code/config/automation/source-of-truth work.
 
 **Files:**
-- Create: `tests/swarm/test_swarm_verifier.py`
-- Create: `agent/swarm_verifier.py`
+- Create: `tests/swarm/test_swarm_verification.py`
+- Create: `agent/swarm_verify.py` (`agent/swarm_verifier.py` compatibility alias)
 
 **Test cases:**
 - Code/config jobs require test/lint/typecheck or explicit skipped reason.
@@ -363,7 +363,8 @@ python -m pytest tests/swarm/test_swarm_honcho.py -q -o 'addopts='
 **Objective:** Add structured eval requirements; execution can remain manual/tool-driven in v1.
 
 **Files:**
-- Modify/Create: `agent/swarm_verifier.py`
+- Modify/Create: `agent/swarm_verify.py`
+- Modify/Create: `agent/swarm_verifier.py` alias if external callers use verifier naming
 
 **Verification:**
 
@@ -391,8 +392,7 @@ swarm_operator:
   dry_run: true
   max_children: 3
   persist_to_honcho: false
-  intercept_gateway: false
-  external_side_effects_enabled: false
+  honcho_summary_enabled: false
 ```
 
 ### Task 20: Focused and adjacent tests
@@ -438,3 +438,13 @@ Start with Tasks 1-8 only:
 4. Gateway shadow hook.
 
 This gives us the spine without risking the “oops I accidentally made a self-driving clown car with root access” problem. Once shadow data looks sane, wire Jeeves prompt/executor and then Honcho/status/evals.
+
+## 2026-05-21 Safe Slice Notes
+
+Implemented the next disabled-by-default slice:
+
+- Repo `DEFAULT_CONFIG` now includes `swarm_operator` defaults; no user config changes.
+- Gateway `/status` safely appends persisted swarm status when available.
+- Honcho summary adapter is inert unless enabled and accepts injected writers for tests.
+- Verification planner records parent-owned checklist/eval metadata without executing tools.
+- User docs added at `website/docs/user-guide/features/swarm-operator.md`.

--- a/gateway/builtin_hooks/swarm_operator.py
+++ b/gateway/builtin_hooks/swarm_operator.py
@@ -13,6 +13,7 @@ import math
 from typing import Any, Dict, Optional
 
 from agent.swarm_honcho import persist_swarm_honcho_summary
+from agent.swarm_live_runner import start_live_swarm
 from agent.swarm_router import route_request
 from agent.swarm_state import AuditEvent, SwarmJob
 from agent.swarm_store import SwarmStore
@@ -69,6 +70,7 @@ def _swarm_config(config: Any) -> Dict[str, Any]:
         merged["max_children"] = int(merged.get("max_children", 3))
     except (TypeError, ValueError):
         merged["max_children"] = 3
+    merged["max_children"] = max(1, min(10, merged["max_children"]))
     merged["persist_to_honcho"] = _strict_bool(merged.get("persist_to_honcho", False), default=False)
     merged["honcho_summary_enabled"] = _strict_bool(merged.get("honcho_summary_enabled", False), default=False)
     return merged
@@ -128,6 +130,7 @@ def handle(event_type: str, context: Optional[Dict[str, Any]] = None) -> None:
         store = ctx.get("swarm_store") or SwarmStore()
 
         should_dispatch_live = bool(cfg["enabled"] and not cfg["dry_run"] and cfg["live_delegation_enabled"])
+        live_runner_started = False
         if should_dispatch_live:
             delegate_fn = ctx.get("swarm_delegate_fn")
             if message_truncated:
@@ -151,15 +154,25 @@ def handle(event_type: str, context: Optional[Dict[str, Any]] = None) -> None:
                     )
                 )
             else:
-                job.metadata["live_delegation_status"] = "blocked"
-                job.metadata["live_delegation_block_reason"] = "gateway_live_dispatch_disabled"
-                job.audit.append(
-                    AuditEvent(
-                        "live_delegation_blocked",
-                        "Live delegation passed the config gate, but gateway live dispatch remains disabled until a non-blocking killable runner is wired.",
-                        metadata={"reason": "gateway_live_dispatch_disabled"},
-                    )
+                handle = start_live_swarm(
+                    job,
+                    plan,
+                    delegate_fn,
+                    store=store,
+                    max_children=cfg["max_children"],
+                    timeout_seconds=cfg["live_delegation_timeout_seconds"],
                 )
+                live_runner_started = handle.started
+                if not handle.started:
+                    job.metadata["live_delegation_status"] = "blocked"
+                    job.metadata["live_delegation_block_reason"] = handle.reason
+                    job.audit.append(
+                        AuditEvent(
+                            "live_delegation_blocked",
+                            "Swarm live delegation runner could not start.",
+                            metadata=handle.to_dict(),
+                        )
+                    )
         elif not cfg["dry_run"]:
             job.metadata["live_delegation_status"] = "blocked"
             job.metadata["live_delegation_block_reason"] = "live_delegation_disabled"
@@ -171,7 +184,8 @@ def handle(event_type: str, context: Optional[Dict[str, Any]] = None) -> None:
                 )
             )
 
-        store.save_job(job)
+        if not live_runner_started:
+            store.save_job(job)
         store.append_event(
             AuditEvent(
                 "shadow_job_recorded",
@@ -189,7 +203,7 @@ def handle(event_type: str, context: Optional[Dict[str, Any]] = None) -> None:
                 },
             )
         )
-        if cfg["persist_to_honcho"] or cfg["honcho_summary_enabled"]:
+        if (cfg["persist_to_honcho"] or cfg["honcho_summary_enabled"]) and not live_runner_started:
             honcho_result = persist_swarm_honcho_summary(
                 job,
                 enabled=True,

--- a/gateway/builtin_hooks/swarm_operator.py
+++ b/gateway/builtin_hooks/swarm_operator.py
@@ -1,0 +1,110 @@
+"""Shadow-mode gateway hook for the Jeeves swarm operator.
+
+The hook is deliberately observe-only in Sprint 1. When disabled (the default)
+it does nothing. When enabled with dry_run=true it creates a SwarmJob, attaches
+a deterministic routing plan, and persists JSON/JSONL audit records without
+altering gateway response flow.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, Optional
+
+from agent.swarm_router import route_request
+from agent.swarm_state import AuditEvent, SwarmJob
+from agent.swarm_store import SwarmStore
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_CONFIG: Dict[str, Any] = {
+    "enabled": False,
+    "dry_run": True,
+    "max_children": 3,
+    "persist_to_honcho": False,
+}
+
+
+def _get_value(config: Any, key: str, default: Any = None) -> Any:
+    if isinstance(config, dict):
+        return config.get(key, default)
+    return getattr(config, key, default)
+
+
+def _swarm_config(config: Any) -> Dict[str, Any]:
+    raw = _get_value(config, "swarm_operator", {}) if config is not None else {}
+    if not isinstance(raw, dict):
+        raw = {}
+    merged = dict(DEFAULT_CONFIG)
+    merged.update(raw)
+    merged["enabled"] = bool(merged.get("enabled", False))
+    merged["dry_run"] = bool(merged.get("dry_run", True))
+    try:
+        merged["max_children"] = int(merged.get("max_children", 3))
+    except (TypeError, ValueError):
+        merged["max_children"] = 3
+    merged["persist_to_honcho"] = bool(merged.get("persist_to_honcho", False))
+    return merged
+
+
+def handle(event_type: str, context: Optional[Dict[str, Any]] = None) -> None:
+    if event_type != "agent:start":
+        return
+    ctx = context or {}
+    cfg = _swarm_config(ctx.get("gateway_config") or ctx.get("config"))
+    if not cfg["enabled"]:
+        return
+
+    try:
+        message = str(ctx.get("message") or "")
+        job = SwarmJob.create(
+            message,
+            platform=str(ctx.get("platform") or ""),
+            user_id=str(ctx.get("user_id") or ""),
+            chat_id=str(ctx.get("chat_id") or ""),
+            session_id=str(ctx.get("session_id") or ""),
+            metadata={
+                "dry_run": cfg["dry_run"],
+                "max_children": cfg["max_children"],
+                "persist_to_honcho": cfg["persist_to_honcho"],
+                "message_id": ctx.get("message_id"),
+            },
+        )
+        plan = route_request(
+            message,
+            platform_context={
+                "platform": job.platform,
+                "user_id": job.user_id,
+                "chat_id": job.chat_id,
+                "session_id": job.session_id,
+            },
+            config=cfg,
+        )
+        job.routing_plan = plan
+        job.audit.append(
+            AuditEvent(
+                "shadow_routed",
+                "Swarm operator shadow route recorded.",
+                metadata={"mode": plan.mode, "dry_run": cfg["dry_run"]},
+            )
+        )
+        store = ctx.get("swarm_store") or SwarmStore()
+        store.save_job(job)
+        store.append_event(
+            AuditEvent(
+                "shadow_job_recorded",
+                "Swarm operator shadow job persisted.",
+                metadata={
+                    "job_id": job.job_id,
+                    "mode": plan.mode,
+                    "platform": job.platform,
+                    "session_id": job.session_id,
+                    "dry_run": cfg["dry_run"],
+                },
+            )
+        )
+    except Exception as exc:
+        logger.warning("swarm operator shadow hook failed: %s", exc)
+
+
+__all__ = ["DEFAULT_CONFIG", "handle"]

--- a/gateway/builtin_hooks/swarm_operator.py
+++ b/gateway/builtin_hooks/swarm_operator.py
@@ -9,6 +9,7 @@ altering gateway response flow.
 from __future__ import annotations
 
 import logging
+import math
 from typing import Any, Dict, Optional
 
 from agent.swarm_honcho import persist_swarm_honcho_summary
@@ -21,6 +22,8 @@ logger = logging.getLogger(__name__)
 DEFAULT_CONFIG: Dict[str, Any] = {
     "enabled": False,
     "dry_run": True,
+    "live_delegation_enabled": False,
+    "live_delegation_timeout_seconds": 30.0,
     "max_children": 3,
     "persist_to_honcho": False,
     "honcho_summary_enabled": False,
@@ -33,20 +36,41 @@ def _get_value(config: Any, key: str, default: Any = None) -> Any:
     return getattr(config, key, default)
 
 
+def _strict_bool(value: Any, *, default: bool) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        lowered = value.strip().lower()
+        if lowered in {"true", "1", "yes", "on"}:
+            return True
+        if lowered in {"false", "0", "no", "off"}:
+            return False
+    if isinstance(value, (int, float)) and value in {0, 1}:
+        return bool(value)
+    return default
+
+
 def _swarm_config(config: Any) -> Dict[str, Any]:
     raw = _get_value(config, "swarm_operator", {}) if config is not None else {}
     if not isinstance(raw, dict):
         raw = {}
     merged = dict(DEFAULT_CONFIG)
     merged.update(raw)
-    merged["enabled"] = bool(merged.get("enabled", False))
-    merged["dry_run"] = bool(merged.get("dry_run", True))
+    merged["enabled"] = _strict_bool(merged.get("enabled", False), default=False)
+    merged["dry_run"] = _strict_bool(merged.get("dry_run", True), default=True)
+    merged["live_delegation_enabled"] = _strict_bool(merged.get("live_delegation_enabled", False), default=False)
+    try:
+        merged["live_delegation_timeout_seconds"] = float(merged.get("live_delegation_timeout_seconds", 30.0))
+    except (TypeError, ValueError):
+        merged["live_delegation_timeout_seconds"] = 30.0
+    if not math.isfinite(merged["live_delegation_timeout_seconds"]) or not (0 < merged["live_delegation_timeout_seconds"] <= 30.0):
+        merged["live_delegation_timeout_seconds"] = 30.0
     try:
         merged["max_children"] = int(merged.get("max_children", 3))
     except (TypeError, ValueError):
         merged["max_children"] = 3
-    merged["persist_to_honcho"] = bool(merged.get("persist_to_honcho", False))
-    merged["honcho_summary_enabled"] = bool(merged.get("honcho_summary_enabled", False))
+    merged["persist_to_honcho"] = _strict_bool(merged.get("persist_to_honcho", False), default=False)
+    merged["honcho_summary_enabled"] = _strict_bool(merged.get("honcho_summary_enabled", False), default=False)
     return merged
 
 
@@ -59,7 +83,10 @@ def handle(event_type: str, context: Optional[Dict[str, Any]] = None) -> None:
         return
 
     try:
-        message = str(ctx.get("message") or "")
+        preview_message = str(ctx.get("message") or "")
+        full_message = ctx.get("message_full")
+        message = str(full_message) if isinstance(full_message, str) else preview_message
+        message_truncated = bool(ctx.get("message_truncated", False)) and not isinstance(full_message, str)
         job = SwarmJob.create(
             message,
             platform=str(ctx.get("platform") or ""),
@@ -68,10 +95,12 @@ def handle(event_type: str, context: Optional[Dict[str, Any]] = None) -> None:
             session_id=str(ctx.get("session_id") or ""),
             metadata={
                 "dry_run": cfg["dry_run"],
+                "live_delegation_enabled": cfg["live_delegation_enabled"],
                 "max_children": cfg["max_children"],
                 "persist_to_honcho": cfg["persist_to_honcho"],
                 "honcho_summary_enabled": cfg["honcho_summary_enabled"],
                 "message_id": ctx.get("message_id"),
+                "message_truncated": message_truncated,
             },
         )
         plan = route_request(
@@ -89,10 +118,59 @@ def handle(event_type: str, context: Optional[Dict[str, Any]] = None) -> None:
             AuditEvent(
                 "shadow_routed",
                 "Swarm operator shadow route recorded.",
-                metadata={"mode": plan.mode, "dry_run": cfg["dry_run"]},
+                metadata={
+                    "mode": plan.mode,
+                    "dry_run": cfg["dry_run"],
+                    "live_delegation_enabled": cfg["live_delegation_enabled"],
+                },
             )
         )
         store = ctx.get("swarm_store") or SwarmStore()
+
+        should_dispatch_live = bool(cfg["enabled"] and not cfg["dry_run"] and cfg["live_delegation_enabled"])
+        if should_dispatch_live:
+            delegate_fn = ctx.get("swarm_delegate_fn")
+            if message_truncated:
+                job.metadata["live_delegation_status"] = "blocked"
+                job.metadata["live_delegation_block_reason"] = "truncated_message"
+                job.audit.append(
+                    AuditEvent(
+                        "live_delegation_blocked",
+                        "Live delegation requires the full user message; only a truncated preview was available.",
+                        metadata={"reason": "truncated_message"},
+                    )
+                )
+            elif not callable(delegate_fn):
+                job.metadata["live_delegation_status"] = "blocked"
+                job.metadata["live_delegation_block_reason"] = "missing_delegate_fn"
+                job.audit.append(
+                    AuditEvent(
+                        "live_delegation_blocked",
+                        "Live delegation gate was enabled, but no delegate function was available.",
+                        metadata={"reason": "missing_delegate_fn"},
+                    )
+                )
+            else:
+                job.metadata["live_delegation_status"] = "blocked"
+                job.metadata["live_delegation_block_reason"] = "gateway_live_dispatch_disabled"
+                job.audit.append(
+                    AuditEvent(
+                        "live_delegation_blocked",
+                        "Live delegation passed the config gate, but gateway live dispatch remains disabled until a non-blocking killable runner is wired.",
+                        metadata={"reason": "gateway_live_dispatch_disabled"},
+                    )
+                )
+        elif not cfg["dry_run"]:
+            job.metadata["live_delegation_status"] = "blocked"
+            job.metadata["live_delegation_block_reason"] = "live_delegation_disabled"
+            job.audit.append(
+                AuditEvent(
+                    "live_delegation_blocked",
+                    "Swarm operator stayed shadow-only because live delegation is not explicitly enabled.",
+                    metadata={"reason": "live_delegation_disabled"},
+                )
+            )
+
         store.save_job(job)
         store.append_event(
             AuditEvent(
@@ -104,6 +182,10 @@ def handle(event_type: str, context: Optional[Dict[str, Any]] = None) -> None:
                     "platform": job.platform,
                     "session_id": job.session_id,
                     "dry_run": cfg["dry_run"],
+                    "live_delegation_enabled": cfg["live_delegation_enabled"],
+                    "job_status": job.status,
+                    "live_delegation_status": job.metadata.get("live_delegation_status"),
+                    "live_delegation_block_reason": job.metadata.get("live_delegation_block_reason"),
                 },
             )
         )

--- a/gateway/builtin_hooks/swarm_operator.py
+++ b/gateway/builtin_hooks/swarm_operator.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import logging
 from typing import Any, Dict, Optional
 
+from agent.swarm_honcho import persist_swarm_honcho_summary
 from agent.swarm_router import route_request
 from agent.swarm_state import AuditEvent, SwarmJob
 from agent.swarm_store import SwarmStore
@@ -22,6 +23,7 @@ DEFAULT_CONFIG: Dict[str, Any] = {
     "dry_run": True,
     "max_children": 3,
     "persist_to_honcho": False,
+    "honcho_summary_enabled": False,
 }
 
 
@@ -44,6 +46,7 @@ def _swarm_config(config: Any) -> Dict[str, Any]:
     except (TypeError, ValueError):
         merged["max_children"] = 3
     merged["persist_to_honcho"] = bool(merged.get("persist_to_honcho", False))
+    merged["honcho_summary_enabled"] = bool(merged.get("honcho_summary_enabled", False))
     return merged
 
 
@@ -67,6 +70,7 @@ def handle(event_type: str, context: Optional[Dict[str, Any]] = None) -> None:
                 "dry_run": cfg["dry_run"],
                 "max_children": cfg["max_children"],
                 "persist_to_honcho": cfg["persist_to_honcho"],
+                "honcho_summary_enabled": cfg["honcho_summary_enabled"],
                 "message_id": ctx.get("message_id"),
             },
         )
@@ -103,6 +107,14 @@ def handle(event_type: str, context: Optional[Dict[str, Any]] = None) -> None:
                 },
             )
         )
+        if cfg["persist_to_honcho"] or cfg["honcho_summary_enabled"]:
+            honcho_result = persist_swarm_honcho_summary(
+                job,
+                enabled=True,
+                writer=ctx.get("swarm_honcho_writer"),
+            )
+            job.metadata["honcho_summary"] = honcho_result
+            store.save_job(job)
     except Exception as exc:
         logger.warning("swarm operator shadow hook failed: %s", exc)
 

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -493,6 +493,11 @@ class GatewayConfig:
     # fresh session exactly as if the reset policy had fired.  0 = disabled.
     session_store_max_age_days: int = 90
 
+    # Experimental Jeeves swarm operator config. Disabled by default; stored on
+    # GatewayConfig so gateway hooks honor the same config users set via the
+    # top-level Hermes config file.
+    swarm_operator: Dict[str, Any] = field(default_factory=dict)
+
     def get_connected_platforms(self) -> List[Platform]:
         """Return list of platforms that are enabled and configured."""
         connected = []
@@ -586,6 +591,7 @@ class GatewayConfig:
             "unauthorized_dm_behavior": self.unauthorized_dm_behavior,
             "streaming": self.streaming.to_dict(),
             "session_store_max_age_days": self.session_store_max_age_days,
+            "swarm_operator": dict(self.swarm_operator),
         }
     
     @classmethod
@@ -654,6 +660,7 @@ class GatewayConfig:
             unauthorized_dm_behavior=unauthorized_dm_behavior,
             streaming=StreamingConfig.from_dict(data.get("streaming", {})),
             session_store_max_age_days=session_store_max_age_days,
+            swarm_operator=dict(data.get("swarm_operator") or {}) if isinstance(data.get("swarm_operator"), dict) else {},
         )
 
     def get_unauthorized_dm_behavior(self, platform: Optional[Platform] = None) -> str:
@@ -760,6 +767,10 @@ def load_gateway_config() -> GatewayConfig:
                     yaml_cfg.get("unauthorized_dm_behavior"),
                     "pair",
                 )
+
+            swarm_operator_cfg = yaml_cfg.get("swarm_operator")
+            if isinstance(swarm_operator_cfg, dict):
+                gw_data["swarm_operator"] = swarm_operator_cfg
 
             # Merge platforms section from config.yaml into gw_data so that
             # nested keys like platforms.webhook.extra.routes are loaded.

--- a/gateway/hooks.py
+++ b/gateway/hooks.py
@@ -42,10 +42,11 @@ class HookRegistry:
         await registry.emit("agent:start", {"platform": "telegram", ...})
     """
 
-    def __init__(self):
+    def __init__(self, include_builtins: bool = False):
         # event_type -> [handler_fn, ...]
         self._handlers: Dict[str, List[Callable]] = {}
         self._loaded_hooks: List[dict] = []  # metadata for listing
+        self.include_builtins = include_builtins
 
     @property
     def loaded_hooks(self) -> List[dict]:
@@ -55,11 +56,23 @@ class HookRegistry:
     def _register_builtin_hooks(self) -> None:
         """Register built-in hooks that are always active.
 
-        Currently empty — no shipped built-in hooks. Kept as the extension
-        point for future always-on gateway hooks so they drop in without
-        re-plumbing discover_and_load().
+        Built-in hooks must be safe when their feature config is disabled; the
+        swarm operator hook defaults disabled and only records shadow state when
+        explicitly enabled.
         """
-        return
+        try:
+            from gateway.builtin_hooks.swarm_operator import handle as swarm_operator_handle
+        except Exception as exc:
+            print(f"[hooks] Error loading built-in swarm operator hook: {exc}", flush=True)
+            return
+
+        self._handlers.setdefault("agent:start", []).append(swarm_operator_handle)
+        self._loaded_hooks.append({
+            "name": "swarm_operator",
+            "description": "Jeeves swarm operator shadow audit hook",
+            "events": ["agent:start"],
+            "path": "gateway.builtin_hooks.swarm_operator",
+        })
 
     def discover_and_load(self) -> None:
         """
@@ -71,7 +84,8 @@ class HookRegistry:
           - HOOK.yaml with at least 'name' and 'events' keys
           - handler.py with a top-level 'handle' function (sync or async)
         """
-        self._register_builtin_hooks()
+        if self.include_builtins:
+            self._register_builtin_hooks()
 
         if not HOOKS_DIR.exists():
             return

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -42,7 +42,7 @@ from collections import OrderedDict
 from contextvars import copy_context
 from pathlib import Path
 from datetime import datetime
-from typing import Dict, Optional, Any, List, Union
+from typing import Callable, Coroutine, Dict, Optional, Any, List, Union, cast
 
 # account_usage imports the OpenAI SDK chain (~230 ms). Only needed by
 # /usage; we still import it at module top in the gateway because test
@@ -8411,22 +8411,22 @@ class GatewayRunner:
             run_generation,
         )
 
-        try:
-            # Emit agent:start hook
-            hook_ctx = {
-                "platform": source.platform.value if source.platform else "",
-                "user_id": source.user_id,
-                "chat_id": source.chat_id or "",
-                "session_id": session_entry.session_id,
-                "message": message_text[:500],
-                "message_full": message_text,
-                "message_truncated": len(message_text) > 500,
-                "message_id": self._reply_anchor_for_event(event),
-                "gateway_config": self.config,
-            }
-            await self.hooks.emit("agent:start", hook_ctx)
+        hook_ctx = {
+            "platform": source.platform.value if source.platform else "",
+            "user_id": source.user_id,
+            "chat_id": source.chat_id or "",
+            "session_id": session_entry.session_id,
+            "message": message_text[:500],
+            "message_full": message_text,
+            "message_truncated": len(message_text) > 500,
+            "message_id": self._reply_anchor_for_event(event),
+            "gateway_config": getattr(self, "config", None),
+        }
 
-            # Run the agent
+        try:
+            # Run the agent. The agent:start hook is emitted inside _run_agent
+            # after the AIAgent exists so live swarm delegation can receive a
+            # real parent-agent-backed delegate function instead of blocking.
             agent_result = await self._run_agent(
                 message=message_text,
                 context_prompt=context_prompt,
@@ -15407,6 +15407,61 @@ class GatewayRunner:
 
     # ------------------------------------------------------------------
 
+    def _make_swarm_delegate_fn(self, agent):
+        """Return the live swarm delegate bridge for an already-built parent agent."""
+
+        def _swarm_delegate_fn(*, tasks):
+            from tools.delegate_tool import delegate_task
+
+            return delegate_task(tasks=tasks, parent_agent=agent)
+
+        return _swarm_delegate_fn
+
+    def _emit_agent_start_hook_sync(
+        self,
+        *,
+        source: SessionSource,
+        session_id: str,
+        message: str,
+        event_message_id: Optional[str],
+        agent=None,
+    ) -> None:
+        """Emit agent:start from the worker thread after agent construction.
+
+        Live swarm delegation needs an injected function backed by the real
+        parent AIAgent. Emitting here keeps shadow hooks unchanged while making
+        the explicit live gate reachable from gateway sessions.
+        """
+        hooks = getattr(self, "hooks", None)
+        emit = getattr(hooks, "emit", None) if hooks is not None else None
+        if not callable(emit):
+            return
+        emit_hook = cast(Callable[[str, Dict[str, Any]], Coroutine[Any, Any, Any]], emit)
+        hook_ctx = {
+            "platform": source.platform.value if source.platform else "",
+            "user_id": source.user_id,
+            "chat_id": source.chat_id or "",
+            "session_id": session_id,
+            "message": (message or "")[:500],
+            "message_full": message,
+            "message_truncated": len(message or "") > 500,
+            "message_id": event_message_id,
+            "gateway_config": getattr(self, "config", None),
+        }
+        if agent is not None:
+            hook_ctx["swarm_delegate_fn"] = self._make_swarm_delegate_fn(agent)
+        try:
+            asyncio.run(emit_hook("agent:start", hook_ctx))
+        except RuntimeError:
+            # Defensive fallback for unusual test harnesses that call this from
+            # a thread with an active loop. Production _run_agent uses an
+            # executor worker thread, where asyncio.run is valid.
+            loop = asyncio.new_event_loop()
+            try:
+                loop.run_until_complete(emit_hook("agent:start", hook_ctx))
+            finally:
+                loop.close()
+
     async def _run_agent(
         self,
         message: str,
@@ -16716,6 +16771,14 @@ class GatewayRunner:
                 _srn = _pending_notes.pop(session_key, None)
                 if _srn:
                     message = _srn + "\n\n" + message
+
+            self._emit_agent_start_hook_sync(
+                source=source,
+                session_id=session_id,
+                message=message,
+                event_message_id=event_message_id,
+                agent=agent,
+            )
 
             _approval_session_key = session_key or ""
             _approval_session_token = set_current_session_key(_approval_session_key)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8419,6 +8419,8 @@ class GatewayRunner:
                 "chat_id": source.chat_id or "",
                 "session_id": session_entry.session_id,
                 "message": message_text[:500],
+                "message_full": message_text,
+                "message_truncated": len(message_text) > 500,
                 "message_id": self._reply_anchor_for_event(event),
                 "gateway_config": self.config,
             }

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1600,7 +1600,7 @@ class GatewayRunner:
         
         # Event hook system
         from gateway.hooks import HookRegistry
-        self.hooks = HookRegistry()
+        self.hooks = HookRegistry(include_builtins=True)
 
         # Per-chat voice reply mode: "off" | "voice_only" | "all"
         self._voice_mode: Dict[str, str] = self._load_voice_modes()
@@ -8419,6 +8419,8 @@ class GatewayRunner:
                 "chat_id": source.chat_id or "",
                 "session_id": session_entry.session_id,
                 "message": message_text[:500],
+                "message_id": self._reply_anchor_for_event(event),
+                "gateway_config": self.config,
             }
             await self.hooks.emit("agent:start", hook_ctx)
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9405,6 +9405,15 @@ class GatewayRunner:
             t("gateway.status.platforms", platforms=', '.join(connected_platforms)),
         ])
 
+        try:
+            from agent.swarm_status import load_swarm_status_text
+
+            swarm_status = load_swarm_status_text(session_id=session_entry.session_id)
+            if swarm_status:
+                lines.extend(["", swarm_status])
+        except Exception as exc:  # pragma: no cover — optional status surface
+            logger.debug("swarm status load failed in /status: %s", exc)
+
         # Session recap — what was this session ABOUT? Pure local compute,
         # no LLM call, no prompt-cache impact. Useful when juggling multiple
         # gateway sessions and you want a one-glance reminder of where this

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -512,6 +512,8 @@ DEFAULT_CONFIG = {
     "swarm_operator": {
         "enabled": False,
         "dry_run": True,
+        "live_delegation_enabled": False,
+        "live_delegation_timeout_seconds": 30.0,
         "max_children": 3,
         "persist_to_honcho": False,
         "honcho_summary_enabled": False,

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -506,6 +506,16 @@ DEFAULT_CONFIG = {
     "fallback_providers": [],
     "credential_pool_strategies": {},
     "toolsets": ["hermes-cli"],
+    # Jeeves swarm operator is an experimental gateway/agent coordination
+    # surface. It is disabled by default and remains dry-run/shadow-only until a
+    # user explicitly opts in via their profile config.
+    "swarm_operator": {
+        "enabled": False,
+        "dry_run": True,
+        "max_children": 3,
+        "persist_to_honcho": False,
+        "honcho_summary_enabled": False,
+    },
     "agent": {
         "max_turns": 90,
         # Inactivity timeout for gateway agent execution (seconds).

--- a/run_agent.py
+++ b/run_agent.py
@@ -130,6 +130,7 @@ from agent.prompt_builder import (
     HERMES_AGENT_HELP_GUIDANCE,
     KANBAN_GUIDANCE,
     build_nous_subscription_prompt,
+    build_swarm_operator_prompt,
 )
 from agent.model_metadata import (
     fetch_model_metadata,

--- a/tests/gateway/test_status_command.py
+++ b/tests/gateway/test_status_command.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from agent.swarm_state import SwarmJob
 from gateway.config import GatewayConfig, Platform, PlatformConfig
 from gateway.platforms.base import MessageEvent
 from gateway.session import SessionEntry, SessionSource, build_session_key
@@ -69,6 +70,33 @@ def _make_runner(session_entry: SessionEntry, *, platform: Platform = Platform.T
     runner._capture_gateway_honcho_if_configured = lambda *args, **kwargs: None
     runner._emit_gateway_run_progress = AsyncMock()
     return runner
+
+
+@pytest.mark.asyncio
+async def test_status_command_includes_swarm_operator_summary(monkeypatch, tmp_path):
+    session_entry = SessionEntry(
+        session_key=build_session_key(_make_source()),
+        session_id="sess-1",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+        total_tokens=0,
+    )
+    job = SwarmJob.create("parallel research", session_id="sess-1", created_at="2026-01-01T00:00:00+00:00")
+    job.add_task("look up A", task_id="t1")
+    from agent.swarm_store import SwarmStore
+
+    store = SwarmStore(base_dir=tmp_path)
+    store.save_job(job)
+
+    monkeypatch.setattr("agent.swarm_status.SwarmStore", lambda: store)
+    runner = _make_runner(session_entry)
+
+    result = await runner._handle_status_command(_make_event("/status"))
+
+    assert "Swarm operator status:" in result
+    assert "parallel research" in result
 
 
 @pytest.mark.asyncio

--- a/tests/swarm/test_gateway_swarm_delegate_wiring.py
+++ b/tests/swarm/test_gateway_swarm_delegate_wiring.py
@@ -1,0 +1,61 @@
+import json
+from types import SimpleNamespace
+from typing import Any, cast
+
+from gateway.config import Platform
+from gateway.run import GatewayRunner
+from gateway.session import SessionSource
+
+
+class _Hooks:
+    def __init__(self):
+        self.calls = []
+
+    async def emit(self, event_type, context):
+        self.calls.append((event_type, context))
+
+
+def test_swarm_delegate_fn_bridges_to_delegate_task_with_parent_agent(monkeypatch):
+    runner = GatewayRunner.__new__(GatewayRunner)
+    parent_agent = object()
+    captured = {}
+
+    def fake_delegate_task(*, tasks, parent_agent):
+        captured["tasks"] = tasks
+        captured["parent_agent"] = parent_agent
+        return json.dumps({"results": [{"status": "completed"}]})
+
+    monkeypatch.setattr("tools.delegate_tool.delegate_task", fake_delegate_task)
+
+    delegate_fn = runner._make_swarm_delegate_fn(parent_agent)
+    result = delegate_fn(tasks=[{"goal": "Verify smoke"}])
+
+    assert json.loads(result)["results"][0]["status"] == "completed"
+    assert captured == {"tasks": [{"goal": "Verify smoke"}], "parent_agent": parent_agent}
+
+
+def test_agent_start_hook_context_includes_live_swarm_delegate_fn():
+    runner = cast(Any, GatewayRunner.__new__(GatewayRunner))
+    runner.hooks = _Hooks()
+    runner.config = SimpleNamespace(swarm_operator={"enabled": True, "dry_run": False, "live_delegation_enabled": True})
+    source = SessionSource(platform=Platform.SLACK, chat_id="C123", user_id="U123")
+    agent = object()
+
+    runner._emit_agent_start_hook_sync(
+        source=source,
+        session_id="sess-1",
+        message="review code and test the result",
+        event_message_id="123.456",
+        agent=agent,
+    )
+
+    assert len(runner.hooks.calls) == 1
+    event_type, context = runner.hooks.calls[0]
+    assert event_type == "agent:start"
+    assert context["platform"] == "slack"
+    assert context["session_id"] == "sess-1"
+    assert context["message_full"] == "review code and test the result"
+    assert context["message_truncated"] is False
+    assert context["message_id"] == "123.456"
+    assert context["gateway_config"] is runner.config
+    assert callable(context["swarm_delegate_fn"])

--- a/tests/swarm/test_gateway_swarm_shadow.py
+++ b/tests/swarm/test_gateway_swarm_shadow.py
@@ -1,0 +1,84 @@
+import json
+import logging
+
+from gateway.builtin_hooks import swarm_operator
+from gateway.hooks import HookRegistry
+
+
+class FailingStore:
+    def save_job(self, job):
+        raise RuntimeError("disk full")
+
+    def append_event(self, event):  # pragma: no cover - save fails first
+        raise AssertionError("should not append")
+
+
+def _context(tmp_path, enabled=True):
+    from agent.swarm_store import SwarmStore
+
+    return {
+        "platform": "slack",
+        "user_id": "U123",
+        "chat_id": "C123",
+        "session_id": "S123",
+        "message": "Research docs and review code",
+        "message_id": "M123",
+        "gateway_config": {"swarm_operator": {"enabled": enabled, "dry_run": True, "max_children": 3}},
+        "swarm_store": SwarmStore(base_dir=tmp_path),
+    }
+
+
+def test_hook_receives_inbound_metadata_and_message_text(tmp_path):
+    swarm_operator.handle("agent:start", _context(tmp_path, enabled=True))
+
+    data = json.loads((tmp_path / "swarm_operator_state.json").read_text())
+    job = next(iter(data["jobs"].values()))
+    assert job["original_request"] == "Research docs and review code"
+    assert job["platform"] == "slack"
+    assert job["user_id"] == "U123"
+    assert job["chat_id"] == "C123"
+    assert job["session_id"] == "S123"
+    assert job["metadata"]["message_id"] == "M123"
+
+
+def test_hook_disabled_does_nothing(tmp_path):
+    swarm_operator.handle("agent:start", _context(tmp_path, enabled=False))
+
+    assert not (tmp_path / "swarm_operator_state.json").exists()
+    assert not (tmp_path / "swarm_operator_metrics.jsonl").exists()
+
+
+def test_hook_enabled_dry_run_writes_job_and_metrics_event(tmp_path):
+    swarm_operator.handle("agent:start", _context(tmp_path, enabled=True))
+
+    state = json.loads((tmp_path / "swarm_operator_state.json").read_text())
+    job = next(iter(state["jobs"].values()))
+    assert job["metadata"]["dry_run"] is True
+    assert job["routing_plan"]["mode"] == "swarm"
+
+    metrics = [json.loads(line) for line in (tmp_path / "swarm_operator_metrics.jsonl").read_text().splitlines()]
+    assert metrics[-1]["event_type"] == "shadow_job_recorded"
+    assert metrics[-1]["metadata"]["job_id"] == job["job_id"]
+
+
+def test_hook_never_blocks_normal_flow_on_store_failure(caplog):
+    context = _context(tmp_path="/tmp/unused", enabled=True)
+    context["swarm_store"] = FailingStore()
+
+    with caplog.at_level(logging.WARNING):
+        result = swarm_operator.handle("agent:start", context)
+
+    assert result is None
+    assert "swarm operator shadow hook failed" in caplog.text
+
+
+def test_builtin_hook_registry_registers_swarm_operator_default_disabled(tmp_path):
+    registry = HookRegistry(include_builtins=True)
+    registry.discover_and_load()
+
+    assert any(hook["name"] == "swarm_operator" for hook in registry.loaded_hooks)
+    # Default config omitted means disabled; emitting must not create runtime state.
+    import asyncio
+
+    asyncio.run(registry.emit("agent:start", {"message": "hello", "swarm_store": _context(tmp_path)["swarm_store"]}))
+    assert not (tmp_path / "swarm_operator_state.json").exists()

--- a/tests/swarm/test_gateway_swarm_shadow.py
+++ b/tests/swarm/test_gateway_swarm_shadow.py
@@ -1,5 +1,8 @@
 import json
 import logging
+import time
+
+import pytest
 
 from gateway.builtin_hooks import swarm_operator
 from gateway.hooks import HookRegistry
@@ -11,6 +14,28 @@ class FailingStore:
 
     def append_event(self, event):  # pragma: no cover - save fails first
         raise AssertionError("should not append")
+
+
+def live_delegate_success(**kwargs):
+    return {
+        "results": [
+            {
+                "summary": "researched",
+                "claims": ["docs reviewed"],
+                "evidence": [{"kind": "artifact", "path": "/tmp/research.md"}],
+            },
+            {
+                "summary": "reviewed",
+                "claims": ["code reviewed"],
+                "evidence": [{"kind": "artifact", "path": "/tmp/review.md"}],
+            },
+        ]
+    }
+
+
+def live_delegate_slow(**kwargs):
+    time.sleep(1.0)
+    return {"results": [{"summary": "late"}]}
 
 
 def _context(tmp_path, enabled=True):
@@ -26,6 +51,24 @@ def _context(tmp_path, enabled=True):
         "gateway_config": {"swarm_operator": {"enabled": enabled, "dry_run": True, "max_children": 3}},
         "swarm_store": SwarmStore(base_dir=tmp_path),
     }
+
+
+def _read_job(tmp_path):
+    data = json.loads((tmp_path / "swarm_operator_state.json").read_text())
+    return next(iter(data["jobs"].values()))
+
+
+def _wait_for_live_status(tmp_path, status, timeout=2.0):
+    deadline = time.monotonic() + timeout
+    last_job = None
+    while time.monotonic() < deadline:
+        last_job = _read_job(tmp_path)
+        if last_job["metadata"].get("live_delegation_status") == status:
+            return last_job
+        time.sleep(0.02)
+    assert last_job is not None
+    assert last_job["metadata"].get("live_delegation_status") == status
+    return last_job
 
 
 def test_hook_receives_inbound_metadata_and_message_text(tmp_path):
@@ -81,24 +124,19 @@ def test_hook_non_dry_run_without_live_gate_still_does_not_dispatch(tmp_path):
 
 
 def test_hook_live_delegation_requires_explicit_double_opt_in_and_safe_runner(tmp_path):
-    calls = []
     context = _context(tmp_path, enabled=True)
     context["gateway_config"]["swarm_operator"].update({"dry_run": False, "live_delegation_enabled": True, "max_children": 2})
-    context["swarm_delegate_fn"] = lambda **kwargs: calls.append(kwargs)
+    context["swarm_delegate_fn"] = live_delegate_success
 
+    started = time.monotonic()
     swarm_operator.handle("agent:start", context)
+    elapsed = time.monotonic() - started
 
-    assert calls == []
-    data = json.loads((tmp_path / "swarm_operator_state.json").read_text())
-    job = next(iter(data["jobs"].values()))
+    assert elapsed < 0.5
+    job = _wait_for_live_status(tmp_path, "executed")
     assert job["metadata"]["live_delegation_enabled"] is True
-    assert job["metadata"]["live_delegation_status"] == "blocked"
-    assert job["metadata"]["live_delegation_block_reason"] == "gateway_live_dispatch_disabled"
-    assert any(
-        event["event_type"] == "live_delegation_blocked"
-        and event["metadata"].get("reason") == "gateway_live_dispatch_disabled"
-        for event in job["audit"]
-    )
+    assert job["metadata"]["swarm_execution"]["status"] in {"completed", "partially_completed"}
+    assert any(event["event_type"] == "live_delegation_executed" for event in job["audit"])
 
 
 def test_hook_live_delegation_enabled_without_delegate_fn_blocks_instead_of_crashing(tmp_path):
@@ -118,6 +156,23 @@ def test_hook_live_delegation_enabled_without_delegate_fn_blocks_instead_of_cras
         for event in job["audit"]
     )
 
+
+@pytest.mark.live_system_guard_bypass
+def test_hook_live_delegation_timeout_kills_child_process(tmp_path):
+    context = _context(tmp_path, enabled=True)
+    context["gateway_config"]["swarm_operator"].update(
+        {"dry_run": False, "live_delegation_enabled": True, "live_delegation_timeout_seconds": 0.05}
+    )
+    context["swarm_delegate_fn"] = live_delegate_slow
+
+    started = time.monotonic()
+    swarm_operator.handle("agent:start", context)
+    elapsed = time.monotonic() - started
+
+    assert elapsed < 0.5
+    job = _wait_for_live_status(tmp_path, "timeout", timeout=3.0)
+    assert job["metadata"]["live_delegation_timeout_seconds"] == 0.05
+    assert any(event["event_type"] == "live_delegation_timeout" for event in job["audit"])
 
 
 def test_hook_live_delegation_blocks_when_only_truncated_message_preview_is_available(tmp_path):
@@ -139,21 +194,17 @@ def test_hook_live_delegation_blocks_when_only_truncated_message_preview_is_avai
 
 
 def test_hook_live_delegation_uses_full_message_when_gateway_supplies_it(tmp_path):
-    calls = []
     full_message = "Research docs and review code " + ("full-context " * 80)
     context = _context(tmp_path, enabled=True)
     context["message"] = full_message[:500]
     context["message_full"] = full_message
     context["message_truncated"] = True
     context["gateway_config"]["swarm_operator"].update({"dry_run": False, "live_delegation_enabled": True})
-
-    context["swarm_delegate_fn"] = lambda **kwargs: calls.append(kwargs)
+    context["swarm_delegate_fn"] = live_delegate_success
 
     swarm_operator.handle("agent:start", context)
 
-    assert calls == []
-    data = json.loads((tmp_path / "swarm_operator_state.json").read_text())
-    job = next(iter(data["jobs"].values()))
+    job = _wait_for_live_status(tmp_path, "executed")
     assert job["original_request"] == full_message
     assert job["metadata"]["message_truncated"] is False
 

--- a/tests/swarm/test_gateway_swarm_shadow.py
+++ b/tests/swarm/test_gateway_swarm_shadow.py
@@ -59,6 +59,103 @@ def test_hook_enabled_dry_run_writes_job_and_metrics_event(tmp_path):
     metrics = [json.loads(line) for line in (tmp_path / "swarm_operator_metrics.jsonl").read_text().splitlines()]
     assert metrics[-1]["event_type"] == "shadow_job_recorded"
     assert metrics[-1]["metadata"]["job_id"] == job["job_id"]
+    assert metrics[-1]["metadata"]["live_delegation_enabled"] is False
+
+
+def test_hook_non_dry_run_without_live_gate_still_does_not_dispatch(tmp_path):
+    calls = []
+    context = _context(tmp_path, enabled=True)
+    context["gateway_config"]["swarm_operator"]["dry_run"] = False
+    context["swarm_delegate_fn"] = lambda **kwargs: calls.append(kwargs)
+
+    swarm_operator.handle("agent:start", context)
+
+    assert calls == []
+    data = json.loads((tmp_path / "swarm_operator_state.json").read_text())
+    job = next(iter(data["jobs"].values()))
+    assert job["metadata"]["dry_run"] is False
+    assert job["metadata"]["live_delegation_enabled"] is False
+    assert any(event["event_type"] == "live_delegation_blocked" for event in job["audit"])
+    assert job["metadata"]["live_delegation_status"] == "blocked"
+    assert job["metadata"]["live_delegation_block_reason"] == "live_delegation_disabled"
+
+
+def test_hook_live_delegation_requires_explicit_double_opt_in_and_safe_runner(tmp_path):
+    calls = []
+    context = _context(tmp_path, enabled=True)
+    context["gateway_config"]["swarm_operator"].update({"dry_run": False, "live_delegation_enabled": True, "max_children": 2})
+    context["swarm_delegate_fn"] = lambda **kwargs: calls.append(kwargs)
+
+    swarm_operator.handle("agent:start", context)
+
+    assert calls == []
+    data = json.loads((tmp_path / "swarm_operator_state.json").read_text())
+    job = next(iter(data["jobs"].values()))
+    assert job["metadata"]["live_delegation_enabled"] is True
+    assert job["metadata"]["live_delegation_status"] == "blocked"
+    assert job["metadata"]["live_delegation_block_reason"] == "gateway_live_dispatch_disabled"
+    assert any(
+        event["event_type"] == "live_delegation_blocked"
+        and event["metadata"].get("reason") == "gateway_live_dispatch_disabled"
+        for event in job["audit"]
+    )
+
+
+def test_hook_live_delegation_enabled_without_delegate_fn_blocks_instead_of_crashing(tmp_path):
+    context = _context(tmp_path, enabled=True)
+    context["gateway_config"]["swarm_operator"].update({"dry_run": False, "live_delegation_enabled": True})
+
+    swarm_operator.handle("agent:start", context)
+
+    data = json.loads((tmp_path / "swarm_operator_state.json").read_text())
+    job = next(iter(data["jobs"].values()))
+    assert job["metadata"]["live_delegation_enabled"] is True
+    assert job["metadata"]["live_delegation_status"] == "blocked"
+    assert job["metadata"]["live_delegation_block_reason"] == "missing_delegate_fn"
+    assert any(
+        event["event_type"] == "live_delegation_blocked"
+        and event["metadata"].get("reason") == "missing_delegate_fn"
+        for event in job["audit"]
+    )
+
+
+
+def test_hook_live_delegation_blocks_when_only_truncated_message_preview_is_available(tmp_path):
+    calls = []
+    context = _context(tmp_path, enabled=True)
+    context["message"] = "Research docs and " + ("x" * 600)
+    context["message_truncated"] = True
+    context["gateway_config"]["swarm_operator"].update({"dry_run": False, "live_delegation_enabled": True})
+    context["swarm_delegate_fn"] = lambda **kwargs: calls.append(kwargs)
+
+    swarm_operator.handle("agent:start", context)
+
+    assert calls == []
+    data = json.loads((tmp_path / "swarm_operator_state.json").read_text())
+    job = next(iter(data["jobs"].values()))
+    assert job["metadata"]["message_truncated"] is True
+    assert job["metadata"]["live_delegation_status"] == "blocked"
+    assert job["metadata"]["live_delegation_block_reason"] == "truncated_message"
+
+
+def test_hook_live_delegation_uses_full_message_when_gateway_supplies_it(tmp_path):
+    calls = []
+    full_message = "Research docs and review code " + ("full-context " * 80)
+    context = _context(tmp_path, enabled=True)
+    context["message"] = full_message[:500]
+    context["message_full"] = full_message
+    context["message_truncated"] = True
+    context["gateway_config"]["swarm_operator"].update({"dry_run": False, "live_delegation_enabled": True})
+
+    context["swarm_delegate_fn"] = lambda **kwargs: calls.append(kwargs)
+
+    swarm_operator.handle("agent:start", context)
+
+    assert calls == []
+    data = json.loads((tmp_path / "swarm_operator_state.json").read_text())
+    job = next(iter(data["jobs"].values()))
+    assert job["original_request"] == full_message
+    assert job["metadata"]["message_truncated"] is False
 
 
 def test_hook_honcho_summary_uses_injected_writer_only_when_enabled(tmp_path):

--- a/tests/swarm/test_gateway_swarm_shadow.py
+++ b/tests/swarm/test_gateway_swarm_shadow.py
@@ -61,6 +61,31 @@ def test_hook_enabled_dry_run_writes_job_and_metrics_event(tmp_path):
     assert metrics[-1]["metadata"]["job_id"] == job["job_id"]
 
 
+def test_hook_honcho_summary_uses_injected_writer_only_when_enabled(tmp_path):
+    calls = []
+    context = _context(tmp_path, enabled=True)
+    context["gateway_config"]["swarm_operator"]["persist_to_honcho"] = True
+    context["swarm_honcho_writer"] = lambda payload: calls.append(payload)
+
+    swarm_operator.handle("agent:start", context)
+
+    assert len(calls) == 1
+    assert calls[0]["metadata"]["job_id"]
+    state = json.loads((tmp_path / "swarm_operator_state.json").read_text())
+    job = next(iter(state["jobs"].values()))
+    assert job["metadata"]["honcho_summary"]["persisted"] is True
+
+
+def test_hook_honcho_summary_not_called_when_disabled(tmp_path):
+    calls = []
+    context = _context(tmp_path, enabled=True)
+    context["swarm_honcho_writer"] = lambda payload: calls.append(payload)
+
+    swarm_operator.handle("agent:start", context)
+
+    assert calls == []
+
+
 def test_hook_never_blocks_normal_flow_on_store_failure(caplog):
     context = _context(tmp_path="/tmp/unused", enabled=True)
     context["swarm_store"] = FailingStore()

--- a/tests/swarm/test_swarm_config_defaults.py
+++ b/tests/swarm/test_swarm_config_defaults.py
@@ -9,6 +9,8 @@ def test_default_config_contains_disabled_swarm_operator():
 
     assert cfg["enabled"] is False
     assert cfg["dry_run"] is True
+    assert cfg["live_delegation_enabled"] is False
+    assert cfg["live_delegation_timeout_seconds"] == 30.0
     assert cfg["max_children"] == 3
     assert cfg["persist_to_honcho"] is False
     assert cfg["honcho_summary_enabled"] is False
@@ -21,6 +23,41 @@ def test_gateway_config_preserves_swarm_operator_settings_for_hooks():
     assert gateway_config.to_dict()["swarm_operator"]["max_children"] == 2
     assert _swarm_config(gateway_config)["enabled"] is True
     assert _swarm_config(gateway_config)["max_children"] == 2
+    assert _swarm_config(gateway_config)["live_delegation_enabled"] is False
+
+
+def test_swarm_config_parses_string_booleans_fail_closed_for_live_gate():
+    cfg = _swarm_config(
+        {
+            "swarm_operator": {
+                "enabled": "true",
+                "dry_run": "false",
+                "live_delegation_enabled": "false",
+                "persist_to_honcho": "no",
+                "honcho_summary_enabled": "off",
+            }
+        }
+    )
+
+    assert cfg["enabled"] is True
+    assert cfg["dry_run"] is False
+    assert cfg["live_delegation_enabled"] is False
+    assert cfg["persist_to_honcho"] is False
+    assert cfg["honcho_summary_enabled"] is False
+
+
+def test_swarm_config_invalid_live_gate_values_fail_closed():
+    cfg = _swarm_config({"swarm_operator": {"enabled": "sure", "dry_run": "nope", "live_delegation_enabled": "absolutely"}})
+
+    assert cfg["enabled"] is False
+    assert cfg["dry_run"] is True
+    assert cfg["live_delegation_enabled"] is False
+
+
+def test_swarm_config_rejects_non_finite_or_excessive_live_timeout():
+    for raw in ("inf", "nan", -1, 0, 999):
+        cfg = _swarm_config({"swarm_operator": {"live_delegation_timeout_seconds": raw}})
+        assert cfg["live_delegation_timeout_seconds"] == 30.0
 
 
 def test_load_gateway_config_bridges_top_level_swarm_operator_yaml():

--- a/tests/swarm/test_swarm_config_defaults.py
+++ b/tests/swarm/test_swarm_config_defaults.py
@@ -60,6 +60,11 @@ def test_swarm_config_rejects_non_finite_or_excessive_live_timeout():
         assert cfg["live_delegation_timeout_seconds"] == 30.0
 
 
+def test_swarm_config_clamps_max_children():
+    assert _swarm_config({"swarm_operator": {"max_children": -5}})["max_children"] == 1
+    assert _swarm_config({"swarm_operator": {"max_children": 999}})["max_children"] == 10
+
+
 def test_load_gateway_config_bridges_top_level_swarm_operator_yaml():
     config_path = get_hermes_home() / "config.yaml"
     config_path.write_text("swarm_operator:\n  enabled: true\n  max_children: 2\n", encoding="utf-8")

--- a/tests/swarm/test_swarm_config_defaults.py
+++ b/tests/swarm/test_swarm_config_defaults.py
@@ -1,0 +1,33 @@
+from gateway.builtin_hooks.swarm_operator import _swarm_config
+from gateway.config import GatewayConfig, load_gateway_config
+from hermes_cli.config import DEFAULT_CONFIG
+from hermes_constants import get_hermes_home
+
+
+def test_default_config_contains_disabled_swarm_operator():
+    cfg = DEFAULT_CONFIG["swarm_operator"]
+
+    assert cfg["enabled"] is False
+    assert cfg["dry_run"] is True
+    assert cfg["max_children"] == 3
+    assert cfg["persist_to_honcho"] is False
+    assert cfg["honcho_summary_enabled"] is False
+
+
+def test_gateway_config_preserves_swarm_operator_settings_for_hooks():
+    gateway_config = GatewayConfig.from_dict({"swarm_operator": {"enabled": True, "max_children": 2}})
+
+    assert gateway_config.swarm_operator["enabled"] is True
+    assert gateway_config.to_dict()["swarm_operator"]["max_children"] == 2
+    assert _swarm_config(gateway_config)["enabled"] is True
+    assert _swarm_config(gateway_config)["max_children"] == 2
+
+
+def test_load_gateway_config_bridges_top_level_swarm_operator_yaml():
+    config_path = get_hermes_home() / "config.yaml"
+    config_path.write_text("swarm_operator:\n  enabled: true\n  max_children: 2\n", encoding="utf-8")
+
+    gateway_config = load_gateway_config()
+
+    assert gateway_config.swarm_operator["enabled"] is True
+    assert _swarm_config(gateway_config)["max_children"] == 2

--- a/tests/swarm/test_swarm_evidence.py
+++ b/tests/swarm/test_swarm_evidence.py
@@ -3,7 +3,7 @@ from agent.swarm_evidence import (
     validate_evidence_packet,
 )
 from agent.swarm_synthesis import synthesize_swarm_result
-from agent.swarm_state import EvidenceRequirement, RoutingPlan, SwarmJob
+from agent.swarm_state import EvidenceRequirement, PermissionGrant, RoutingPlan, SwarmJob
 
 
 def test_valid_evidence_packet_satisfies_required_test_and_artifact():
@@ -73,6 +73,108 @@ def test_human_approval_requirement_cannot_be_faked_with_parent_verified_metadat
 
     assert result.passed is False
     assert "missing_human_approval" in result.reasons
+
+
+def test_approved_permission_grant_satisfies_human_approval_requirement():
+    packet = EvidencePacket.from_result({"claims": ["Approval exists"], "evidence": []})
+    grant = PermissionGrant("perm_send", "Send report", status="approved")
+
+    result = validate_evidence_packet(
+        packet,
+        [EvidenceRequirement("human_approval", "Garrett must approve", metadata={"permission_id": "perm_send"})],
+        approval_grants=[grant],
+    )
+
+    assert result.passed is True
+    assert "human_approval" in result.satisfied_kinds
+    assert result.missing_required_kinds == []
+
+
+def test_requested_denied_or_wrong_permission_grants_do_not_satisfy_human_approval():
+    packet = EvidencePacket.from_result({"claims": ["Approval exists"], "evidence": []})
+    requirement = EvidenceRequirement("human_approval", "Garrett must approve", metadata={"permission_id": "perm_send"})
+
+    for grant in (
+        PermissionGrant("perm_send", "Send report", status="requested"),
+        PermissionGrant("perm_send", "Send report", status="denied"),
+        PermissionGrant("perm_other", "Different action", status="approved"),
+    ):
+        result = validate_evidence_packet(packet, [requirement], approval_grants=[grant])
+        assert result.passed is False
+        assert result.missing_required_kinds == ["human_approval"]
+        assert "missing_human_approval" in result.reasons
+
+
+def test_dict_requirement_top_level_permission_id_must_match_approved_grant():
+    packet = EvidencePacket.from_result({"claims": ["Approval exists"], "evidence": []})
+    requirement = {"kind": "human_approval", "description": "Garrett must approve", "permission_id": "perm_send"}
+
+    wrong = validate_evidence_packet(
+        packet,
+        [requirement],
+        approval_grants=[{"permission_id": "perm_other", "status": "approved"}],
+    )
+    right = validate_evidence_packet(
+        packet,
+        [requirement],
+        approval_grants=[{"permission_id": "perm_send", "status": "approved"}],
+    )
+
+    assert wrong.passed is False
+    assert wrong.missing_required_kinds == ["human_approval"]
+    assert right.passed is True
+
+
+def test_multi_permission_human_approval_requirement_requires_all_grants_approved():
+    packet = EvidencePacket.from_result({"claims": ["Approval exists"], "evidence": []})
+    requirement = {
+        "kind": "human_approval",
+        "description": "Garrett must approve both side effects",
+        "permission_ids": ["perm_send", "perm_pipe_execution"],
+    }
+
+    partial = validate_evidence_packet(
+        packet,
+        [requirement],
+        approval_grants=[{"permission_id": "perm_send", "status": "approved"}],
+    )
+    complete = validate_evidence_packet(
+        packet,
+        [requirement],
+        approval_grants=[
+            {"permission_id": "perm_send", "status": "approved"},
+            {"permission_id": "perm_pipe_execution", "status": "approved"},
+        ],
+    )
+
+    assert partial.passed is False
+    assert partial.missing_required_kinds == ["human_approval"]
+    assert complete.passed is True
+
+
+def test_parent_synthesis_uses_job_permissions_for_human_approval():
+    job = SwarmJob.create("send report", created_at="2026-01-01T00:00:00+00:00")
+    job.routing_plan = RoutingPlan(
+        mode="swarm",
+        reason="approval needed",
+        evidence_requirements=[
+            EvidenceRequirement("human_approval", "Garrett approves send", metadata={"permission_id": "perm_send"})
+        ],
+        verification_required=True,
+    )
+    job.permissions.append(PermissionGrant("perm_send", "Send report", status="approved"))
+    task = job.add_task("send", status="completed")
+    task.result = {
+        "summary": "sent",
+        "claims": ["Report sent"],
+        "evidence": [{"kind": "human_approval", "approval_id": "fake", "parent_verified": True}],
+    }
+
+    synthesis = synthesize_swarm_result(job)
+
+    assert synthesis.safe_to_present_complete is True
+    assert synthesis.verified_claims == ["Report sent"]
+    assert synthesis.missing_evidence == {}
 
 
 def test_parent_synthesis_marks_unsupported_claims_unverified():

--- a/tests/swarm/test_swarm_evidence.py
+++ b/tests/swarm/test_swarm_evidence.py
@@ -1,0 +1,98 @@
+from agent.swarm_evidence import (
+    EvidencePacket,
+    validate_evidence_packet,
+)
+from agent.swarm_synthesis import synthesize_swarm_result
+from agent.swarm_state import EvidenceRequirement, RoutingPlan, SwarmJob
+
+
+def test_valid_evidence_packet_satisfies_required_test_and_artifact():
+    packet = EvidencePacket.from_result(
+        {
+            "summary": "implemented",
+            "claims": ["Tests pass", "Artifact written"],
+            "evidence": [
+                {"kind": "test", "command": "python -m pytest tests/swarm -q", "output": "64 passed"},
+                {"kind": "artifact", "path": "agent/swarm_evidence.py"},
+            ],
+            "confidence": "high",
+        }
+    )
+
+    result = validate_evidence_packet(
+        packet,
+        [
+            EvidenceRequirement("test", "Run focused tests"),
+            EvidenceRequirement("artifact", "Provide changed file path"),
+        ],
+    )
+
+    assert result.passed is True
+    assert result.missing_required_kinds == []
+
+
+def test_citation_does_not_satisfy_command_output_requirement():
+    packet = EvidencePacket.from_result(
+        {
+            "claims": ["Command ran"],
+            "evidence": [{"kind": "citation", "url": "https://example.com"}],
+        }
+    )
+
+    result = validate_evidence_packet(packet, [EvidenceRequirement("command_output", "Show command output")])
+
+    assert result.passed is False
+    assert result.missing_required_kinds == ["command_output"]
+    assert "missing_command_output" in result.reasons
+
+
+def test_human_approval_requirement_cannot_be_faked_by_child_summary():
+    packet = EvidencePacket.from_result(
+        {
+            "summary": "User approved it, pinky swear",
+            "claims": ["Approval exists"],
+            "evidence": [{"kind": "command_output", "command": "echo approved", "output": "approved"}],
+        }
+    )
+
+    result = validate_evidence_packet(packet, [EvidenceRequirement("human_approval", "Garrett must approve")])
+
+    assert result.passed is False
+    assert "missing_human_approval" in result.reasons
+
+
+def test_human_approval_requirement_cannot_be_faked_with_parent_verified_metadata():
+    packet = EvidencePacket.from_result(
+        {
+            "claims": ["Approval exists"],
+            "evidence": [{"kind": "human_approval", "approval_id": "fake", "parent_verified": True}],
+        }
+    )
+
+    result = validate_evidence_packet(packet, [EvidenceRequirement("human_approval", "Garrett must approve")])
+
+    assert result.passed is False
+    assert "missing_human_approval" in result.reasons
+
+
+def test_parent_synthesis_marks_unsupported_claims_unverified():
+    job = SwarmJob.create("research with proof", created_at="2026-01-01T00:00:00+00:00")
+    job.routing_plan = RoutingPlan(
+        mode="swarm",
+        reason="needs proof",
+        evidence_requirements=[EvidenceRequirement("citation", "Cite sources")],
+        verification_required=True,
+    )
+    task = job.add_task("research", status="completed")
+    task.result = {
+        "summary": "done",
+        "claims": ["Apple paper says models collapse"],
+        "evidence": [],
+    }
+
+    synthesis = synthesize_swarm_result(job)
+
+    assert synthesis.safe_to_present_complete is False
+    assert "Apple paper says models collapse" in synthesis.unverified_claims
+    assert synthesis.missing_evidence["citation"] == 1
+    assert "citation" in synthesis.user_disclosure

--- a/tests/swarm/test_swarm_executor.py
+++ b/tests/swarm/test_swarm_executor.py
@@ -233,6 +233,28 @@ def test_synthesis_persists_when_all_tasks_are_blocked_before_dispatch():
     assert job.metadata["swarm_synthesis"]["blocked_tasks"] == [job.tasks[0].task_id]
 
 
+def test_plan_level_permission_without_suggested_tasks_blocks_instead_of_completing():
+    job = SwarmJob.create("send email", created_at="2026-01-01T00:00:00+00:00")
+    plan = RoutingPlan(
+        mode="direct",
+        reason="direct side effect",
+        suggested_tasks=[],
+        permission_requests=[PermissionGrant("perm_send", "Permission required before send")],
+        verification_required=True,
+        evidence_requirements=[EvidenceRequirement("human_approval", "Garrett approves send", metadata={"permission_id": "perm_send"})],
+    )
+
+    def delegate_fn(**kwargs):
+        raise AssertionError("permission-only plans should not dispatch")
+
+    result = execute_swarm(job, plan, delegate_fn, max_children=3)
+
+    assert result.dispatched == []
+    assert job.status == "awaiting_permission"
+    assert job.tasks[0].permission_required is True
+    assert job.tasks[0].metadata["permission_ids"] == ["perm_send"]
+
+
 def test_approved_parent_permission_prevents_human_approval_weak_output_in_execution():
     job = SwarmJob.create("send report", created_at="2026-01-01T00:00:00+00:00")
     job.permissions.append(PermissionGrant("perm_send", "Send report", status="approved"))

--- a/tests/swarm/test_swarm_executor.py
+++ b/tests/swarm/test_swarm_executor.py
@@ -1,7 +1,7 @@
 import json
 
 from agent.swarm_executor import build_delegate_tasks, execute_swarm
-from agent.swarm_state import EvidenceRequirement, RoutingPlan, SwarmJob
+from agent.swarm_state import EvidenceRequirement, PermissionGrant, RoutingPlan, SwarmJob
 
 
 def _plan(tasks, mode="swarm"):
@@ -231,3 +231,28 @@ def test_synthesis_persists_when_all_tasks_are_blocked_before_dispatch():
     assert job.status == "awaiting_permission"
     assert job.metadata["swarm_synthesis"]["safe_to_present_complete"] is False
     assert job.metadata["swarm_synthesis"]["blocked_tasks"] == [job.tasks[0].task_id]
+
+
+def test_approved_parent_permission_prevents_human_approval_weak_output_in_execution():
+    job = SwarmJob.create("send report", created_at="2026-01-01T00:00:00+00:00")
+    job.permissions.append(PermissionGrant("perm_send", "Send report", status="approved"))
+    plan = RoutingPlan(
+        mode="swarm",
+        reason="approval needed",
+        suggested_tasks=[{"title": "send"}],
+        verification_required=True,
+        evidence_requirements=[
+            EvidenceRequirement("human_approval", "Garrett approves send", metadata={"permission_id": "perm_send"})
+        ],
+    )
+
+    def delegate_fn(**kwargs):
+        return {"results": [{"summary": "sent", "claims": ["Report sent"], "evidence": []}]}
+
+    execute_swarm(job, plan, delegate_fn, max_children=3)
+
+    assert job.status == "completed"
+    assert job.tasks[0].status == "completed"
+    assert "weak_output" not in job.tasks[0].result
+    assert job.tasks[0].result["evidence_validation"]["passed"] is True
+    assert job.metadata["swarm_synthesis"]["safe_to_present_complete"] is True

--- a/tests/swarm/test_swarm_executor.py
+++ b/tests/swarm/test_swarm_executor.py
@@ -1,7 +1,7 @@
 import json
 
 from agent.swarm_executor import build_delegate_tasks, execute_swarm
-from agent.swarm_state import RoutingPlan, SwarmJob
+from agent.swarm_state import EvidenceRequirement, RoutingPlan, SwarmJob
 
 
 def _plan(tasks, mode="swarm"):
@@ -100,3 +100,62 @@ def test_permission_required_tasks_remain_blocked_and_are_not_dispatched():
     assert result.blocked[0]["title"] == "send"
     assert job.tasks[1].status == "blocked"
     assert job.status == "partially_completed"
+
+
+def test_weak_child_output_without_required_evidence_is_marked_needs_review():
+    job = SwarmJob.create("research and cite sources", created_at="2026-01-01T00:00:00+00:00")
+    plan = RoutingPlan(
+        mode="swarm",
+        reason="research",
+        suggested_tasks=[{"title": "research"}],
+        verification_required=True,
+        evidence_requirements=[EvidenceRequirement("citation", "Cite sources")],
+    )
+
+    def delegate_fn(**kwargs):
+        return {"results": [{"summary": "Looks good"}]}
+
+    execute_swarm(job, plan, delegate_fn, max_children=3)
+
+    assert job.tasks[0].status == "needs_review"
+    assert job.tasks[0].result["weak_output"]["weak"] is True
+    assert "no_evidence" in job.tasks[0].result["weak_output"]["reasons"]
+    assert job.status == "partially_completed"
+
+
+def test_weak_output_detector_enforces_dry_run_kind_not_generic_evidence():
+    job = SwarmJob.create("run pipe", created_at="2026-01-01T00:00:00+00:00")
+    plan = RoutingPlan(
+        mode="pipe",
+        reason="pipe",
+        suggested_tasks=[{"title": "dry run"}],
+        verification_required=True,
+        evidence_requirements=[EvidenceRequirement("dry_run", "Show dry-run output")],
+    )
+
+    def delegate_fn(**kwargs):
+        return {"results": [{"summary": "done", "evidence": "some notes"}]}
+
+    execute_swarm(job, plan, delegate_fn, max_children=3)
+
+    assert job.tasks[0].status == "needs_review"
+    assert "missing_dry_run" in job.tasks[0].result["weak_output"]["reasons"]
+
+
+def test_weak_output_detector_accepts_dict_evidence_requirements():
+    job = SwarmJob.create("research", created_at="2026-01-01T00:00:00+00:00")
+    plan = RoutingPlan(
+        mode="swarm",
+        reason="research",
+        suggested_tasks=[{"title": "research"}],
+        verification_required=True,
+        evidence_requirements=[{"kind": "citation", "description": "Cite sources"}],
+    )
+
+    def delegate_fn(**kwargs):
+        return {"results": [{"summary": "done", "evidence": "generic"}]}
+
+    execute_swarm(job, plan, delegate_fn, max_children=3)
+
+    assert job.tasks[0].status == "needs_review"
+    assert "missing_citation" in job.tasks[0].result["weak_output"]["reasons"]

--- a/tests/swarm/test_swarm_executor.py
+++ b/tests/swarm/test_swarm_executor.py
@@ -1,0 +1,102 @@
+import json
+
+from agent.swarm_executor import build_delegate_tasks, execute_swarm
+from agent.swarm_state import RoutingPlan, SwarmJob
+
+
+def _plan(tasks, mode="swarm"):
+    return RoutingPlan(mode=mode, reason="test", suggested_tasks=tasks, verification_required=True)
+
+
+def test_executes_at_most_max_children_independent_tasks():
+    job = SwarmJob.create("do several things", created_at="2026-01-01T00:00:00+00:00")
+    plan = _plan([
+        {"title": "one"},
+        {"title": "two"},
+        {"title": "three"},
+    ])
+    calls = []
+
+    def delegate_fn(**kwargs):
+        calls.append(kwargs)
+        return {"results": [{"status": "completed"}, {"status": "completed"}]}
+
+    result = execute_swarm(job, plan, delegate_fn, max_children=2)
+
+    assert len(result.dispatched) == 2
+    assert len(calls[0]["tasks"]) == 2
+    assert job.status == "completed"
+
+
+def test_build_delegate_tasks_preserves_declared_toolsets():
+    job = SwarmJob.create("research and code", created_at="2026-01-01T00:00:00+00:00")
+    plan = _plan([
+        {"title": "research", "description": "look up docs", "toolsets": ["web"]},
+        {"title": "code", "description": "inspect files", "toolsets": ["terminal", "file"]},
+    ])
+
+    tasks = build_delegate_tasks(plan, job, max_children=3)
+
+    assert tasks[0]["toolsets"] == ["web"]
+    assert tasks[1]["toolsets"] == ["terminal", "file"]
+
+
+def test_aggregates_results_into_job_summary_data():
+    job = SwarmJob.create("parallel work", created_at="2026-01-01T00:00:00+00:00")
+    plan = _plan([{"title": "alpha"}, {"title": "beta"}])
+
+    def delegate_fn(**kwargs):
+        return json.dumps({"results": [{"summary": "A done"}, {"summary": "B done"}]})
+
+    result = execute_swarm(job, plan, delegate_fn, max_children=3)
+
+    assert result.results == [{"summary": "A done"}, {"summary": "B done"}]
+    assert job.metadata["swarm_execution"]["results"][0]["summary"] == "A done"
+    assert job.tasks[0].result is not None
+    assert job.tasks[0].result["summary"] == "A done"
+
+
+def test_partial_child_failure_marks_partially_completed_unless_critical():
+    job = SwarmJob.create("parallel work", created_at="2026-01-01T00:00:00+00:00")
+    plan = _plan([{"title": "alpha"}, {"title": "beta"}])
+
+    def delegate_fn(**kwargs):
+        return {"results": [{"summary": "A done"}, {"error": "boom", "status": "failed"}]}
+
+    execute_swarm(job, plan, delegate_fn, max_children=3)
+
+    assert job.status == "partially_completed"
+    assert job.tasks[1].status == "failed"
+
+
+def test_critical_child_failure_marks_failed():
+    job = SwarmJob.create("parallel work", created_at="2026-01-01T00:00:00+00:00")
+    plan = _plan([{"title": "alpha", "critical": True}])
+
+    def delegate_fn(**kwargs):
+        return {"results": [{"error": "boom", "status": "failed"}]}
+
+    execute_swarm(job, plan, delegate_fn, max_children=3)
+
+    assert job.status == "failed"
+
+
+def test_permission_required_tasks_remain_blocked_and_are_not_dispatched():
+    job = SwarmJob.create("send an email", created_at="2026-01-01T00:00:00+00:00")
+    plan = _plan([
+        {"title": "draft", "permission_required": False},
+        {"title": "send", "permission_required": True},
+    ])
+    calls = []
+
+    def delegate_fn(**kwargs):
+        calls.append(kwargs)
+        return {"results": [{"summary": "drafted"}]}
+
+    result = execute_swarm(job, plan, delegate_fn, max_children=3)
+
+    assert len(calls[0]["tasks"]) == 1
+    assert calls[0]["tasks"][0]["goal"] == "draft"
+    assert result.blocked[0]["title"] == "send"
+    assert job.tasks[1].status == "blocked"
+    assert job.status == "partially_completed"

--- a/tests/swarm/test_swarm_executor.py
+++ b/tests/swarm/test_swarm_executor.py
@@ -41,6 +41,29 @@ def test_build_delegate_tasks_preserves_declared_toolsets():
     assert tasks[1]["toolsets"] == ["terminal", "file"]
 
 
+def test_build_delegate_tasks_injects_required_evidence_contract():
+    job = SwarmJob.create("research with citations", created_at="2026-01-01T00:00:00+00:00")
+    plan = RoutingPlan(
+        mode="swarm",
+        reason="research",
+        suggested_tasks=[{"title": "research", "description": "find sources"}],
+        verification_required=True,
+        evidence_requirements=[
+            EvidenceRequirement("citation", "Cite source URLs"),
+            EvidenceRequirement("artifact", "Return any output path"),
+        ],
+    )
+
+    tasks = build_delegate_tasks(plan, job, max_children=3)
+
+    context = tasks[0]["context"]
+    assert "Required evidence" in context
+    assert "citation" in context
+    assert "artifact" in context
+    assert "claims" in context
+    assert "side_effects_performed" in context
+
+
 def test_aggregates_results_into_job_summary_data():
     job = SwarmJob.create("parallel work", created_at="2026-01-01T00:00:00+00:00")
     plan = _plan([{"title": "alpha"}, {"title": "beta"}])
@@ -159,3 +182,52 @@ def test_weak_output_detector_accepts_dict_evidence_requirements():
 
     assert job.tasks[0].status == "needs_review"
     assert "missing_citation" in job.tasks[0].result["weak_output"]["reasons"]
+
+
+def test_valid_structured_evidence_packet_is_not_marked_weak_and_synthesis_persists():
+    job = SwarmJob.create("research", created_at="2026-01-01T00:00:00+00:00")
+    plan = RoutingPlan(
+        mode="swarm",
+        reason="research",
+        suggested_tasks=[{"title": "research"}],
+        verification_required=True,
+        evidence_requirements=[EvidenceRequirement("citation", "Cite sources")],
+    )
+
+    def delegate_fn(**kwargs):
+        return {
+            "results": [
+                {
+                    "summary": "researched",
+                    "claims": ["claim is sourced"],
+                    "evidence": [{"kind": "citation", "url": "https://example.com/source"}],
+                }
+            ]
+        }
+
+    execute_swarm(job, plan, delegate_fn, max_children=3)
+
+    assert job.tasks[0].status == "completed"
+    assert "weak_output" not in job.tasks[0].result
+    assert job.metadata["swarm_synthesis"]["verified_claims"] == ["claim is sourced"]
+    assert job.metadata["swarm_synthesis"]["safe_to_present_complete"] is True
+
+
+def test_synthesis_persists_when_all_tasks_are_blocked_before_dispatch():
+    job = SwarmJob.create("send report", created_at="2026-01-01T00:00:00+00:00")
+    plan = RoutingPlan(
+        mode="swarm",
+        reason="approval needed",
+        suggested_tasks=[{"title": "send", "permission_required": True}],
+        verification_required=True,
+        evidence_requirements=[EvidenceRequirement("human_approval", "Garrett approves send")],
+    )
+
+    def delegate_fn(**kwargs):
+        raise AssertionError("blocked tasks should not dispatch")
+
+    execute_swarm(job, plan, delegate_fn, max_children=3)
+
+    assert job.status == "awaiting_permission"
+    assert job.metadata["swarm_synthesis"]["safe_to_present_complete"] is False
+    assert job.metadata["swarm_synthesis"]["blocked_tasks"] == [job.tasks[0].task_id]

--- a/tests/swarm/test_swarm_honcho.py
+++ b/tests/swarm/test_swarm_honcho.py
@@ -1,0 +1,41 @@
+from agent.swarm_honcho import build_swarm_honcho_summary, persist_swarm_honcho_summary
+from agent.swarm_state import SwarmJob
+
+
+def test_build_swarm_honcho_summary_redacts_secrets_and_child_scratchpads():
+    job = SwarmJob.create("ship it", created_at="2026-01-01T00:00:00+00:00", metadata={"api_key": "secret"})
+    task = job.add_task("draft", task_id="t1")
+    task.result = {"summary": "drafted", "scratchpad": "private chain", "token": "secret"}
+    job.transition("completed")
+
+    summary = build_swarm_honcho_summary(job)
+
+    assert "ship it" in summary["content"]
+    assert "drafted" in summary["content"]
+    assert "private chain" not in summary["content"]
+    assert "secret" not in summary["content"]
+    assert summary["metadata"]["job_id"] == job.job_id
+
+
+def test_persist_swarm_honcho_summary_noops_unless_enabled():
+    calls = []
+
+    result = persist_swarm_honcho_summary(
+        SwarmJob.create("noop", created_at="2026-01-01T00:00:00+00:00"),
+        enabled=False,
+        writer=lambda payload: calls.append(payload),
+    )
+
+    assert result["persisted"] is False
+    assert result["reason"] == "disabled"
+    assert calls == []
+
+
+def test_persist_swarm_honcho_summary_uses_injected_writer_when_enabled():
+    calls = []
+    job = SwarmJob.create("remember", created_at="2026-01-01T00:00:00+00:00")
+
+    result = persist_swarm_honcho_summary(job, enabled=True, writer=lambda payload: calls.append(payload))
+
+    assert result["persisted"] is True
+    assert calls[0]["metadata"]["job_id"] == job.job_id

--- a/tests/swarm/test_swarm_live_runner.py
+++ b/tests/swarm/test_swarm_live_runner.py
@@ -1,0 +1,196 @@
+import os
+import subprocess
+import time
+
+import pytest
+
+from agent.swarm_live_runner import _monitor_process, _terminate_process_tree, start_live_swarm
+from agent.swarm_state import RoutingPlan, SwarmJob
+from agent.swarm_store import SwarmStore
+
+
+def dummy_delegate(**kwargs):
+    return {"results": [{"summary": "ok"}]}
+
+
+def crash_delegate(**kwargs):
+    os._exit(7)
+
+
+def spawn_sleep_delegate(**kwargs):
+    pid_path = str(kwargs["tasks"][0]["context"].splitlines()[0])
+    child = subprocess.Popen(["/bin/sleep", "30"], start_new_session=False)
+    with open(pid_path, "w", encoding="utf-8") as handle:
+        handle.write(str(child.pid))
+    time.sleep(30)
+    return {"results": [{"summary": "late"}]}
+
+
+def _plan():
+    return RoutingPlan(mode="swarm", reason="test", suggested_tasks=[{"title": "research"}])
+
+
+def _wait_for_status(store, job_id, status, *, timeout=3.0):
+    deadline = time.monotonic() + timeout
+    latest = None
+    while time.monotonic() < deadline:
+        latest = store.load_jobs().get(job_id)
+        if latest and latest.metadata.get("live_delegation_status") == status:
+            return latest
+        time.sleep(0.02)
+    assert latest is not None
+    assert latest.metadata.get("live_delegation_status") == status
+    return latest
+
+
+def _process_exists(pid: int) -> bool:
+    result = subprocess.run(["/bin/ps", "-p", str(pid)], capture_output=True, text=True, check=False)
+    return result.returncode == 0
+
+
+class StartFailProcess:
+    pid = None
+
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def start(self):
+        raise RuntimeError("cannot fork today")
+
+
+class StartFailContext:
+    def Process(self, *args, **kwargs):
+        return StartFailProcess()
+
+
+class FakeProcess:
+    pid = 12345
+
+    def __init__(self):
+        self.terminated = False
+
+    def terminate(self):
+        self.terminated = True
+
+
+class ExitedZeroProcess:
+    pid = None
+    exitcode = 0
+
+    def join(self, timeout=None):
+        return None
+
+    def is_alive(self):
+        return False
+
+
+def test_process_tree_termination_does_not_signal_non_isolated_process_group(monkeypatch):
+    from agent import swarm_live_runner
+
+    calls = []
+    proc = FakeProcess()
+    monkeypatch.setattr(swarm_live_runner.os, "getpgid", lambda pid: os.getpgrp())
+    monkeypatch.setattr(swarm_live_runner.os, "killpg", lambda pgid, sig: calls.append((pgid, sig)))
+
+    _terminate_process_tree(proc)
+
+    assert calls == []
+    assert proc.terminated is True
+
+
+def test_monitor_marks_zero_exit_without_terminal_save_as_failed(tmp_path):
+    store = SwarmStore(base_dir=tmp_path)
+    job = SwarmJob.create("research docs", created_at="2026-01-01T00:00:00+00:00")
+    job.metadata["live_delegation_status"] = "running"
+    store.save_job(job)
+
+    _monitor_process(ExitedZeroProcess(), store_base_dir=str(tmp_path), job=job, timeout_seconds=1)
+
+    saved = store.load_jobs()[job.job_id]
+    assert saved.metadata["live_delegation_status"] == "failed"
+    assert any(event.event_type == "live_delegation_crashed" for event in saved.audit)
+
+
+def test_live_runner_falls_back_to_fork_for_non_pickleable_delegate(tmp_path):
+    store = SwarmStore(base_dir=tmp_path)
+    job = SwarmJob.create("research docs", created_at="2026-01-01T00:00:00+00:00")
+
+    def local_delegate(**kwargs):
+        return {"results": [{"summary": "ok"}]}
+
+    handle = start_live_swarm(job, _plan(), local_delegate, store=store, max_children=1, timeout_seconds=2)
+
+    assert handle.started is True
+    saved = _wait_for_status(store, job.job_id, "executed", timeout=4.0)
+    assert saved.metadata["live_delegation_context"] == "fork"
+
+
+def test_live_runner_process_start_failure_persists_blocked_status(tmp_path, monkeypatch):
+    from agent import swarm_live_runner
+
+    monkeypatch.setattr(swarm_live_runner.multiprocessing, "get_context", lambda name: StartFailContext())
+    store = SwarmStore(base_dir=tmp_path)
+    job = SwarmJob.create("research docs", created_at="2026-01-01T00:00:00+00:00")
+    plan = _plan()
+
+    handle = start_live_swarm(job, plan, dummy_delegate, store=store, max_children=2, timeout_seconds=1)
+
+    assert handle.started is False
+    assert handle.reason == "process_start_failed"
+    saved = store.load_jobs()[job.job_id]
+    assert saved.metadata["live_delegation_status"] == "blocked"
+    assert saved.metadata["live_delegation_block_reason"] == "process_start_failed"
+    assert any(event.event_type == "live_delegation_blocked" for event in saved.audit)
+
+
+def test_live_runner_missing_process_context_blocks_without_persisting_running(tmp_path, monkeypatch):
+    from agent import swarm_live_runner
+
+    def fail_context(name):
+        raise ValueError("fork unavailable")
+
+    monkeypatch.setattr(swarm_live_runner.multiprocessing, "get_context", fail_context)
+    store = SwarmStore(base_dir=tmp_path)
+    job = SwarmJob.create("research docs", created_at="2026-01-01T00:00:00+00:00")
+    plan = _plan()
+
+    handle = start_live_swarm(job, plan, dummy_delegate, store=store, max_children=2, timeout_seconds=1)
+
+    assert handle.started is False
+    assert handle.reason == "process_context_unavailable"
+    assert store.load_jobs() == {}
+
+
+@pytest.mark.live_system_guard_bypass
+def test_live_runner_marks_crashed_child_failed_instead_of_stuck_running(tmp_path):
+    store = SwarmStore(base_dir=tmp_path)
+    job = SwarmJob.create("research docs", created_at="2026-01-01T00:00:00+00:00")
+
+    handle = start_live_swarm(job, _plan(), crash_delegate, store=store, max_children=1, timeout_seconds=1)
+
+    assert handle.started is True
+    saved = _wait_for_status(store, job.job_id, "failed")
+    assert any(event.event_type == "live_delegation_crashed" for event in saved.audit)
+
+
+@pytest.mark.live_system_guard_bypass
+def test_live_runner_timeout_kills_delegate_subprocess_tree(tmp_path):
+    pid_path = tmp_path / "grandchild.pid"
+    store = SwarmStore(base_dir=tmp_path)
+    job = SwarmJob.create("research docs", created_at="2026-01-01T00:00:00+00:00")
+    plan = RoutingPlan(mode="swarm", reason="test", suggested_tasks=[{"title": "research", "description": str(pid_path)}])
+
+    handle = start_live_swarm(job, plan, spawn_sleep_delegate, store=store, max_children=1, timeout_seconds=0.5)
+
+    assert handle.started is True
+    saved = _wait_for_status(store, job.job_id, "timeout", timeout=4.0)
+    assert any(event.event_type == "live_delegation_timeout" for event in saved.audit)
+    deadline = time.monotonic() + 2
+    while time.monotonic() < deadline and not pid_path.exists():
+        time.sleep(0.02)
+    assert pid_path.exists()
+    grandchild_pid = int(pid_path.read_text(encoding="utf-8"))
+    deadline = time.monotonic() + 2
+    while time.monotonic() < deadline and _process_exists(grandchild_pid):
+        time.sleep(0.05)
+    assert not _process_exists(grandchild_pid)

--- a/tests/swarm/test_swarm_prompt.py
+++ b/tests/swarm/test_swarm_prompt.py
@@ -3,6 +3,8 @@ from agent.swarm_prompt import build_swarm_operator_prompt
 
 def test_disabled_config_does_not_alter_prompt():
     assert build_swarm_operator_prompt({"enabled": False}) == ""
+    assert build_swarm_operator_prompt({"enabled": "false"}) == ""
+    assert build_swarm_operator_prompt({"enabled": "not really"}) == ""
     assert build_swarm_operator_prompt({}) == ""
 
 

--- a/tests/swarm/test_swarm_prompt.py
+++ b/tests/swarm/test_swarm_prompt.py
@@ -1,0 +1,29 @@
+from agent.swarm_prompt import build_swarm_operator_prompt
+
+
+def test_disabled_config_does_not_alter_prompt():
+    assert build_swarm_operator_prompt({"enabled": False}) == ""
+    assert build_swarm_operator_prompt({}) == ""
+
+
+def test_enabled_config_includes_operator_rules_and_limits():
+    prompt = build_swarm_operator_prompt({"enabled": True, "max_children": 2})
+
+    assert "Jeeves Swarm Operator Contract" in prompt
+    assert "single parent operator" in prompt
+    assert "max_children=2" in prompt
+    assert "Permission-required subtasks stay blocked" in prompt
+    assert "Child agents must never send messages" in prompt
+
+
+def test_prompt_includes_script_threshold_contract():
+    prompt = build_swarm_operator_prompt({"enabled": True})
+
+    assert "scripts for >3 procedural steps/source-of-truth/validation/eval" in prompt
+
+
+def test_prompt_includes_dumb_pipe_policy():
+    prompt = build_swarm_operator_prompt({"enabled": True})
+
+    assert "n8n/docker are dumb pipes" in prompt
+    assert "They are not reasoning engines" in prompt

--- a/tests/swarm/test_swarm_routing.py
+++ b/tests/swarm/test_swarm_routing.py
@@ -57,10 +57,21 @@ def test_cross_session_context_pressure_is_first_class_telemetry():
 def test_external_actions_add_human_approval_evidence_requirement():
     plan = route_request("Draft and send the client-facing email, then deploy the update")
 
-    kinds = [item.kind for item in plan.evidence_requirements]
-    assert "human_approval" in kinds
+    approval_requirements = [item for item in plan.evidence_requirements if item.kind == "human_approval"]
+    assert approval_requirements
+    assert approval_requirements[0].metadata["permission_ids"] == [grant.permission_id for grant in plan.permission_requests]
     assert plan.routing_telemetry.complexity_risk >= 2
     assert plan.routing_telemetry.required_scaffold == "approval"
+
+
+def test_multi_permission_routes_scope_human_approval_requirement_to_all_permissions():
+    plan = route_request("Send a message and run the docker workflow")
+
+    permission_ids = [grant.permission_id for grant in plan.permission_requests]
+    approval_requirement = next(item for item in plan.evidence_requirements if item.kind == "human_approval")
+    assert "perm_send" in permission_ids
+    assert "perm_pipe_execution" in permission_ids
+    assert approval_requirement.metadata["permission_ids"] == permission_ids
 
 
 def test_procedural_source_of_truth_work_adds_command_or_dry_run_evidence():

--- a/tests/swarm/test_swarm_routing.py
+++ b/tests/swarm/test_swarm_routing.py
@@ -1,0 +1,41 @@
+from agent.swarm_router import route_request
+
+
+def test_simple_explanatory_prompt_routes_direct():
+    plan = route_request("Explain why the sky is blue")
+
+    assert plan.mode == "direct"
+    assert plan.permission_requests == []
+    assert plan.verification_required is False
+
+
+def test_multiple_independent_research_and_review_routes_swarm():
+    plan = route_request("Research the API docs and review the code for security issues")
+
+    assert plan.mode == "swarm"
+    assert plan.suggested_tasks
+    assert plan.verification_required is True
+
+
+def test_more_than_three_procedural_steps_routes_script_candidate():
+    plan = route_request("Collect the logs, then parse errors, validate counts, verify source of truth, and summarize")
+
+    assert plan.mode == "script"
+    assert plan.metadata["step_count"] > 3
+    assert plan.verification_required is True
+
+
+def test_external_send_deploy_destructive_wording_requires_permission():
+    plan = route_request("Deploy the service and delete the old release")
+
+    assert plan.permission_requests
+    assert plan.metadata["permission_required"] is True
+    assert plan.verification_required is True
+
+
+def test_n8n_docker_wording_routes_pipe_with_permission_gate():
+    plan = route_request("Run the n8n workflow in docker compose")
+
+    assert plan.mode == "pipe"
+    assert any(grant.permission_id == "perm_pipe_execution" for grant in plan.permission_requests)
+    assert plan.verification_required is True

--- a/tests/swarm/test_swarm_routing.py
+++ b/tests/swarm/test_swarm_routing.py
@@ -33,6 +33,15 @@ def test_external_send_deploy_destructive_wording_requires_permission():
     assert plan.verification_required is True
 
 
+def test_side_effect_suggested_tasks_are_marked_permission_required():
+    plan = route_request("Research docs and send an email update")
+
+    assert plan.permission_requests
+    assert len(plan.suggested_tasks) >= 2
+    assert plan.suggested_tasks[0].get("permission_required") is not True
+    assert plan.suggested_tasks[1]["permission_required"] is True
+
+
 def test_n8n_docker_wording_routes_pipe_with_permission_gate():
     plan = route_request("Run the n8n workflow in docker compose")
 

--- a/tests/swarm/test_swarm_routing.py
+++ b/tests/swarm/test_swarm_routing.py
@@ -39,3 +39,81 @@ def test_n8n_docker_wording_routes_pipe_with_permission_gate():
     assert plan.mode == "pipe"
     assert any(grant.permission_id == "perm_pipe_execution" for grant in plan.permission_requests)
     assert plan.verification_required is True
+
+
+def test_cross_session_context_pressure_is_first_class_telemetry():
+    plan = route_request(
+        "Using the other session and earlier thread, review the architecture, compare files, and propose next steps",
+        platform_context={"thread_message_count": 18, "compressed_context": True, "attachment_count": 2},
+    )
+
+    telemetry = plan.routing_telemetry
+    assert telemetry.context_pressure >= 3
+    assert telemetry.signals["cross_session_reference"] is True
+    assert telemetry.signals["compressed_context"] is True
+    assert telemetry.required_scaffold in {"externalize_state", "parallel_review", "script"}
+
+
+def test_external_actions_add_human_approval_evidence_requirement():
+    plan = route_request("Draft and send the client-facing email, then deploy the update")
+
+    kinds = [item.kind for item in plan.evidence_requirements]
+    assert "human_approval" in kinds
+    assert plan.routing_telemetry.complexity_risk >= 2
+    assert plan.routing_telemetry.required_scaffold == "approval"
+
+
+def test_procedural_source_of_truth_work_adds_command_or_dry_run_evidence():
+    plan = route_request("Collect CSV exports, parse every row, validate counts against source of truth, verify totals, and summarize")
+
+    kinds = [item.kind for item in plan.evidence_requirements]
+    assert plan.mode == "script"
+    assert "command_output" in kinds
+    assert plan.routing_telemetry.required_scaffold == "script"
+
+
+def test_complex_research_forces_role_separated_panel_policy():
+    plan = route_request("Get a model council to research the options, critique failure modes, and synthesize a recommendation")
+
+    assert plan.mode == "swarm"
+    assert plan.panel_policy["considered"] is True
+    assert plan.panel_policy["required"] is True
+    assert "skeptic" in plan.panel_policy["roles"]
+    assert "citation" in [item.kind for item in plan.evidence_requirements]
+
+
+def test_platform_context_non_numeric_values_do_not_break_routing():
+    plan = route_request("Explain profile setup", platform_context={"thread_message_count": "many", "attachment_count": "unknown", "source_count": None})
+
+    assert plan.mode == "direct"
+    assert plan.routing_telemetry.context_pressure >= 0
+
+
+def test_code_only_swarm_does_not_require_citation_evidence():
+    plan = route_request("Implement the router change and test the executor")
+
+    kinds = [item.kind for item in plan.evidence_requirements]
+    assert "test" in kinds
+    assert "citation" not in kinds
+
+
+def test_profile_word_does_not_trigger_code_file_evidence():
+    plan = route_request("Explain the profile settings")
+
+    assert "test" not in [item.kind for item in plan.evidence_requirements]
+
+
+def test_code_review_swarm_requires_tests_not_citations():
+    plan = route_request("Review the code and test the executor")
+
+    kinds = [item.kind for item in plan.evidence_requirements]
+    assert "test" in kinds
+    assert "citation" not in kinds
+
+
+def test_plural_tests_signal_counts_as_test_evidence_requirement():
+    plan = route_request("Analyze this function and write tests")
+
+    kinds = [item.kind for item in plan.evidence_requirements]
+    assert "test" in kinds
+    assert "citation" not in kinds

--- a/tests/swarm/test_swarm_state.py
+++ b/tests/swarm/test_swarm_state.py
@@ -1,0 +1,73 @@
+import json
+
+from agent.swarm_state import EvalResult, PermissionGrant, RoutingPlan, SwarmJob
+
+
+def test_swarm_job_create_sets_defaults_and_stable_shape():
+    job = SwarmJob.create(
+        "please check the logs",
+        platform="slack",
+        user_id="U1",
+        chat_id="C1",
+        session_id="S1",
+        created_at="2026-05-21T00:00:00+00:00",
+    )
+
+    assert job.job_id.startswith("swarm_")
+    assert job.status == "received"
+    assert job.created_at == "2026-05-21T00:00:00+00:00"
+    assert job.updated_at == job.created_at
+    assert job.original_request == "please check the logs"
+    assert job.tasks == []
+    assert job.audit == []
+
+    same = SwarmJob.create(
+        "please check the logs",
+        platform="slack",
+        user_id="U1",
+        chat_id="C1",
+        session_id="S1",
+        created_at="2026-05-21T00:00:00+00:00",
+    )
+    assert same.job_id == job.job_id
+
+
+def test_add_task_appends_task_and_audit_event():
+    job = SwarmJob.create("do work")
+    task = job.add_task("Research", "look up docs", mode="swarm", toolsets=["web"])
+
+    assert task in job.tasks
+    assert task.status == "queued"
+    assert job.audit[-1].event_type == "task_added"
+    assert job.audit[-1].metadata["task_id"] == task.task_id
+
+
+def test_transition_records_status_change_and_audit_event():
+    job = SwarmJob.create("do work")
+    job.transition("triaging", metadata={"reason": "shadow"})
+
+    assert job.status == "triaging"
+    assert job.audit[-1].event_type == "status_changed"
+    assert job.audit[-1].metadata["from"] == "received"
+    assert job.audit[-1].metadata["to"] == "triaging"
+    assert job.audit[-1].metadata["reason"] == "shadow"
+
+
+def test_json_round_trip_preserves_nested_data():
+    job = SwarmJob.create("deploy after approval", platform="slack", user_id="U1")
+    grant = PermissionGrant("perm_deploy", "Deploy production", scope={"env": "prod"})
+    job.permissions.append(grant)
+    job.evals.append(EvalResult("unit", True, "passed"))
+    job.routing_plan = RoutingPlan(
+        mode="swarm",
+        reason="multi-step",
+        suggested_tasks=[{"title": "Review code"}],
+        permission_requests=[grant],
+        verification_required=True,
+    )
+    job.add_task("Review code", permission_required=True)
+
+    encoded = json.loads(json.dumps(job.to_dict()))
+    restored = SwarmJob.from_dict(encoded)
+
+    assert restored.to_dict() == job.to_dict()

--- a/tests/swarm/test_swarm_state.py
+++ b/tests/swarm/test_swarm_state.py
@@ -1,6 +1,6 @@
 import json
 
-from agent.swarm_state import EvalResult, PermissionGrant, RoutingPlan, SwarmJob
+from agent.swarm_state import EvidenceRequirement, EvalResult, PermissionGrant, RoutingPlan, RoutingTelemetry, SwarmJob
 
 
 def test_swarm_job_create_sets_defaults_and_stable_shape():
@@ -71,3 +71,58 @@ def test_json_round_trip_preserves_nested_data():
     restored = SwarmJob.from_dict(encoded)
 
     assert restored.to_dict() == job.to_dict()
+
+
+def test_routing_plan_round_trip_preserves_anti_illusion_metadata():
+    requirement = EvidenceRequirement(
+        kind="citation",
+        description="Cite the source used for current facts",
+        source="router",
+        metadata={"reason": "research"},
+    )
+    telemetry = RoutingTelemetry(
+        complexity_risk=2,
+        context_pressure=3,
+        illusion_risk=3,
+        required_scaffold="parallel_review",
+        weak_output_risk=True,
+        signals={"cross_session_reference": True},
+    )
+    plan = RoutingPlan(
+        mode="swarm",
+        reason="needs a small panel",
+        verification_required=True,
+        evidence_requirements=[requirement],
+        routing_telemetry=telemetry,
+        panel_policy={"considered": True, "required": True, "roles": ["scout", "skeptic"]},
+    )
+
+    restored = RoutingPlan.from_dict(json.loads(json.dumps(plan.to_dict())))
+
+    assert restored.to_dict() == plan.to_dict()
+    assert restored.evidence_requirements[0].kind == "citation"
+    assert restored.routing_telemetry.context_pressure == 3
+    assert restored.panel_policy["roles"] == ["scout", "skeptic"]
+
+
+def test_routing_plan_from_dict_accepts_v1_snapshots_without_anti_illusion_fields():
+    restored = RoutingPlan.from_dict({"mode": "direct", "reason": "old snapshot"})
+
+    assert restored.mode == "direct"
+    assert restored.evidence_requirements == []
+    assert restored.routing_telemetry.to_dict() == RoutingTelemetry().to_dict()
+    assert restored.panel_policy == {}
+
+
+def test_routing_plan_to_dict_accepts_serialized_new_field_shapes():
+    plan = RoutingPlan(
+        mode="swarm",
+        reason="serialized",
+        evidence_requirements=[{"kind": "citation", "description": "cite"}],
+        routing_telemetry={"complexity_risk": 1, "required_scaffold": "checklist"},
+    )
+
+    encoded = plan.to_dict()
+
+    assert encoded["evidence_requirements"][0]["kind"] == "citation"
+    assert encoded["routing_telemetry"]["complexity_risk"] == 1

--- a/tests/swarm/test_swarm_status.py
+++ b/tests/swarm/test_swarm_status.py
@@ -83,3 +83,37 @@ def test_status_exposes_missing_evidence_from_synthesis():
     assert "evidence:" in text
     assert "citation: missing" in text
     assert "safe to present complete: no" in text
+
+
+def test_status_distinguishes_missing_and_approved_human_approval_without_mutating_metadata():
+    missing_job = SwarmJob.create("send missing", created_at="2026-01-01T00:00:00+00:00")
+    missing_job.routing_plan = RoutingPlan(
+        mode="swarm",
+        reason="approval needed",
+        evidence_requirements=[
+            EvidenceRequirement("human_approval", "Approve send", metadata={"permission_id": "perm_send"})
+        ],
+        verification_required=True,
+    )
+    missing_task = missing_job.add_task("send", status="completed")
+    missing_task.result = {"summary": "sent", "claims": ["sent"], "evidence": []}
+
+    approved_job = SwarmJob.create("send approved", created_at="2026-01-01T00:00:00+00:00")
+    approved_job.routing_plan = RoutingPlan(
+        mode="swarm",
+        reason="approval needed",
+        evidence_requirements=[
+            EvidenceRequirement("human_approval", "Approve send", metadata={"permission_id": "perm_send"})
+        ],
+        verification_required=True,
+    )
+    approved_job.permissions.append(PermissionGrant("perm_send", "Approve send", status="approved"))
+    approved_task = approved_job.add_task("send", status="completed")
+    approved_task.result = {"summary": "sent", "claims": ["sent"], "evidence": []}
+    before_metadata = dict(approved_job.metadata)
+
+    text = format_swarm_status([missing_job, approved_job], include_completed=True)
+
+    assert "human_approval: missing" in text
+    assert "human_approval: approved" in text
+    assert approved_job.metadata == before_metadata

--- a/tests/swarm/test_swarm_status.py
+++ b/tests/swarm/test_swarm_status.py
@@ -1,4 +1,4 @@
-from agent.swarm_state import AuditEvent, PermissionGrant, RoutingPlan, SwarmJob
+from agent.swarm_state import AuditEvent, EvidenceRequirement, PermissionGrant, RoutingPlan, SwarmJob
 from agent.swarm_status import format_swarm_status, load_swarm_status_text, redact_secrets
 from agent.swarm_store import SwarmStore
 
@@ -64,3 +64,22 @@ def test_load_swarm_status_text_does_not_fallback_to_other_sessions():
 
     assert load_swarm_status_text(session_id="session-b") == ""
     assert "private other session" in load_swarm_status_text(session_id="session-a")
+
+
+def test_status_exposes_missing_evidence_from_synthesis():
+    job = SwarmJob.create("research", created_at="2026-01-01T00:00:00+00:00")
+    job.routing_plan = RoutingPlan(
+        mode="swarm",
+        reason="needs proof",
+        evidence_requirements=[EvidenceRequirement("citation", "Cite sources")],
+        verification_required=True,
+    )
+    task = job.add_task("research", status="needs_review")
+    task.result = {"summary": "done", "claims": ["claim"], "evidence": []}
+    job.transition("partially_completed")
+
+    text = format_swarm_status([job], include_completed=True)
+
+    assert "evidence:" in text
+    assert "citation: missing" in text
+    assert "safe to present complete: no" in text

--- a/tests/swarm/test_swarm_status.py
+++ b/tests/swarm/test_swarm_status.py
@@ -1,0 +1,56 @@
+from agent.swarm_state import AuditEvent, PermissionGrant, RoutingPlan, SwarmJob
+from agent.swarm_status import format_swarm_status, redact_secrets
+
+
+def test_formats_active_jobs_with_status_tasks_blockers_and_last_event():
+    job = SwarmJob.create("Research A and B", created_at="2026-01-01T00:00:00+00:00")
+    job.routing_plan = RoutingPlan(mode="swarm", reason="parallel research")
+    job.transition("running")
+    job.add_task("Research A", status="running")
+    job.add_task("Send report", permission_required=True, status="blocked")
+    job.audit.append(AuditEvent("checkpoint", "waiting on approval", metadata={"safe": "yes"}))
+
+    text = format_swarm_status([job])
+
+    assert "Swarm operator status" in text
+    assert f"{job.job_id}: running" in text
+    assert "Research A" in text
+    assert "blockers:" in text
+    assert "permission required for Send report" in text
+    assert "last event: checkpoint" in text
+
+
+def test_redacts_secrets_from_audit_metadata():
+    job = SwarmJob.create("Check status", created_at="2026-01-01T00:00:00+00:00")
+    job.audit.append(
+        AuditEvent(
+            "tool_result",
+            "received metadata",
+            metadata={"api_key": "sk-live", "nested": {"token": "abc", "count": 2}},
+        )
+    )
+
+    text = format_swarm_status([job])
+
+    assert "sk-live" not in text
+    assert "abc" not in text
+    assert "[REDACTED]" in text
+    assert redact_secrets({"password": "p"})["password"] == "[REDACTED]"
+
+
+def test_shows_permission_requests_clearly():
+    job = SwarmJob.create("Deploy this", created_at="2026-01-01T00:00:00+00:00")
+    grant = PermissionGrant(
+        permission_id="perm_deploy",
+        description="Permission required before deploy",
+        scope={"target": "prod", "credential_token": "secret"},
+    )
+    job.permissions.append(grant)
+
+    text = format_swarm_status([job])
+
+    assert "permission requests:" in text
+    assert "perm_deploy: requested" in text
+    assert "Permission required before deploy" in text
+    assert "prod" in text
+    assert "secret" not in text

--- a/tests/swarm/test_swarm_status.py
+++ b/tests/swarm/test_swarm_status.py
@@ -1,5 +1,6 @@
 from agent.swarm_state import AuditEvent, PermissionGrant, RoutingPlan, SwarmJob
-from agent.swarm_status import format_swarm_status, redact_secrets
+from agent.swarm_status import format_swarm_status, load_swarm_status_text, redact_secrets
+from agent.swarm_store import SwarmStore
 
 
 def test_formats_active_jobs_with_status_tasks_blockers_and_last_event():
@@ -54,3 +55,12 @@ def test_shows_permission_requests_clearly():
     assert "Permission required before deploy" in text
     assert "prod" in text
     assert "secret" not in text
+
+
+def test_load_swarm_status_text_does_not_fallback_to_other_sessions():
+    job = SwarmJob.create("private other session", session_id="session-a", created_at="2026-01-01T00:00:00+00:00")
+    job.transition("running")
+    SwarmStore().save_job(job)
+
+    assert load_swarm_status_text(session_id="session-b") == ""
+    assert "private other session" in load_swarm_status_text(session_id="session-a")

--- a/tests/swarm/test_swarm_store.py
+++ b/tests/swarm/test_swarm_store.py
@@ -1,0 +1,59 @@
+import json
+
+import pytest
+
+from agent.swarm_state import AuditEvent, SwarmJob
+from agent.swarm_store import SwarmStore, SwarmStoreError
+
+
+def test_store_writes_job_snapshot(tmp_path):
+    store = SwarmStore(base_dir=tmp_path)
+    job = SwarmJob.create("hello", created_at="2026-05-21T00:00:00+00:00")
+
+    store.save_job(job)
+
+    state_path = tmp_path / "swarm_operator_state.json"
+    assert state_path.exists()
+    data = json.loads(state_path.read_text())
+    assert data["jobs"][job.job_id]["original_request"] == "hello"
+
+
+def test_store_appends_jsonl_metrics(tmp_path):
+    store = SwarmStore(base_dir=tmp_path)
+    store.append_event(AuditEvent("shadow", "recorded", metadata={"job_id": "j1"}))
+    store.append_event({"event_type": "shadow2", "metadata": {"job_id": "j2"}})
+
+    lines = (tmp_path / "swarm_operator_metrics.jsonl").read_text().splitlines()
+    assert [json.loads(line)["event_type"] for line in lines] == ["shadow", "shadow2"]
+
+
+def test_store_loads_existing_jobs_on_restart(tmp_path):
+    store = SwarmStore(base_dir=tmp_path)
+    job = SwarmJob.create("persist me")
+    job.add_task("task")
+    store.save_job(job)
+
+    reloaded = SwarmStore(base_dir=tmp_path).load_jobs()
+
+    assert list(reloaded) == [job.job_id]
+    assert reloaded[job.job_id].to_dict() == job.to_dict()
+
+
+def test_store_handles_missing_file_as_empty(tmp_path):
+    assert SwarmStore(base_dir=tmp_path).load_jobs() == {}
+
+
+def test_store_raises_explicit_error_on_corrupt_state(tmp_path):
+    state_path = tmp_path / "swarm_operator_state.json"
+    state_path.write_text("{not json", encoding="utf-8")
+
+    with pytest.raises(SwarmStoreError, match="Corrupt swarm state file"):
+        SwarmStore(base_dir=tmp_path).load_jobs()
+
+
+def test_store_raises_explicit_error_on_invalid_shape(tmp_path):
+    state_path = tmp_path / "swarm_operator_state.json"
+    state_path.write_text(json.dumps({"jobs": []}), encoding="utf-8")
+
+    with pytest.raises(SwarmStoreError, match="Invalid swarm jobs shape"):
+        SwarmStore(base_dir=tmp_path).load_jobs()

--- a/tests/swarm/test_swarm_verification.py
+++ b/tests/swarm/test_swarm_verification.py
@@ -1,0 +1,70 @@
+from agent.swarm_state import RoutingPlan, SwarmJob
+from agent.swarm_verify import build_verification_plan, apply_verification_results
+
+
+def test_build_verification_plan_includes_child_results_and_blockers():
+    job = SwarmJob.create("implement and test", created_at="2026-01-01T00:00:00+00:00")
+    job.add_task("code", task_id="t1")
+    job.add_task("deploy", task_id="t2", permission_required=True)
+    job.tasks[0].result = {"summary": "implemented", "evidence": "pytest passed"}
+    job.tasks[1].status = "blocked"
+    plan = RoutingPlan(mode="swarm", reason="parallel", verification_required=True)
+
+    verification = build_verification_plan(job, plan)
+
+    assert verification.required is True
+    assert "child_result_review" in [step["id"] for step in verification.steps]
+    assert "permission_blocker_review" in [step["id"] for step in verification.steps]
+    assert verification.summary()["status"] == "pending"
+
+
+def test_apply_verification_results_persists_evals_and_transitions():
+    job = SwarmJob.create("verify me", created_at="2026-01-01T00:00:00+00:00")
+    plan = RoutingPlan(mode="direct", reason="simple", verification_required=False)
+    verification = build_verification_plan(job, plan)
+
+    apply_verification_results(job, verification, {"direct_sanity_check": (True, "ok")})
+
+    assert job.evals[0].name == "direct_sanity_check"
+    assert job.evals[0].passed is True
+    assert job.metadata["swarm_verification"]["status"] == "passed"
+
+
+def test_apply_verification_results_marks_failed_verification_without_overwriting_failed_job():
+    job = SwarmJob.create("verify failure", created_at="2026-01-01T00:00:00+00:00")
+    job.transition("failed")
+    plan = RoutingPlan(mode="swarm", reason="parallel", verification_required=True)
+    verification = build_verification_plan(job, plan)
+
+    apply_verification_results(job, verification, {"final_consistency_check": {"passed": False, "details": "missing evidence"}})
+
+    assert job.status == "failed"
+    assert job.metadata["swarm_verification"]["status"] == "failed"
+
+
+def test_verification_plan_requires_code_config_evidence():
+    job = SwarmJob.create("implement config patch", created_at="2026-01-01T00:00:00+00:00")
+    job.add_task("Edit code", description="patch config and run tests")
+
+    verification = build_verification_plan(job, RoutingPlan(mode="swarm", reason="code work", verification_required=True))
+
+    step_ids = [step["id"] for step in verification.steps]
+    assert "code_config_verification" in step_ids
+
+
+def test_verification_plan_requires_dry_run_payload_contract_for_pipes():
+    job = SwarmJob.create("trigger n8n docker workflow", created_at="2026-01-01T00:00:00+00:00")
+
+    verification = build_verification_plan(job, RoutingPlan(mode="pipe", reason="n8n pipe", verification_required=True))
+
+    step_ids = [step["id"] for step in verification.steps]
+    assert "dry_run_payload_contract" in step_ids
+
+
+def test_verification_plan_requires_human_review_for_external_actions():
+    job = SwarmJob.create("send client-facing email", created_at="2026-01-01T00:00:00+00:00")
+
+    verification = build_verification_plan(job, RoutingPlan(mode="swarm", reason="external send", verification_required=True))
+
+    step_ids = [step["id"] for step in verification.steps]
+    assert "human_approval_review" in step_ids

--- a/tests/swarm/test_swarm_verification.py
+++ b/tests/swarm/test_swarm_verification.py
@@ -1,4 +1,4 @@
-from agent.swarm_state import RoutingPlan, SwarmJob
+from agent.swarm_state import EvidenceRequirement, RoutingPlan, SwarmJob
 from agent.swarm_verify import build_verification_plan, apply_verification_results
 
 
@@ -68,3 +68,26 @@ def test_verification_plan_requires_human_review_for_external_actions():
 
     step_ids = [step["id"] for step in verification.steps]
     assert "human_approval_review" in step_ids
+
+
+def test_verification_plan_maps_explicit_evidence_requirements_to_steps():
+    job = SwarmJob.create("research current docs and prove it", created_at="2026-01-01T00:00:00+00:00")
+    plan = RoutingPlan(
+        mode="swarm",
+        reason="research",
+        verification_required=True,
+        evidence_requirements=[
+            EvidenceRequirement("citation", "Cite current source"),
+            EvidenceRequirement("artifact", "Return output file path"),
+            EvidenceRequirement("human_approval", "Get Garrett approval before send"),
+        ],
+    )
+
+    verification = build_verification_plan(job, plan)
+
+    step_ids = [step["id"] for step in verification.steps]
+    assert "evidence_citation" in step_ids
+    assert "evidence_artifact" in step_ids
+    assert "evidence_human_approval" in step_ids
+    citation_step = next(step for step in verification.steps if step["id"] == "evidence_citation")
+    assert citation_step["evidence_kind"] == "citation"

--- a/website/docs/user-guide/features/swarm-operator.md
+++ b/website/docs/user-guide/features/swarm-operator.md
@@ -1,0 +1,60 @@
+---
+title: Jeeves Swarm Operator
+---
+
+# Jeeves Swarm Operator
+
+Jeeves Swarm Operator is an experimental coordination layer for routing a user request through direct work, bounded child-agent fan-out, durable jobs, scripts, or execution pipes, then returning one parent-owned response.
+
+It is **disabled by default**. The current implementation is safe shadow/dry-run infrastructure: state, routing records, status formatting, a no-op Honcho summary adapter, and verification planning helpers. It does not enable live interception, restart the gateway, or dispatch child agents unless explicitly wired later.
+
+## Default configuration
+
+The repository defaults are:
+
+```yaml
+swarm_operator:
+  enabled: false
+  dry_run: true
+  max_children: 3
+  persist_to_honcho: false
+  honcho_summary_enabled: false
+```
+
+Do not enable this in a live profile until the shadow rollout checklist passes.
+
+## Shadow state
+
+When the gateway hook is explicitly enabled in dry-run mode, it records job state under the active Hermes profile:
+
+- `${HERMES_HOME}/state/swarm_operator_state.json`
+- `${HERMES_HOME}/state/swarm_operator_metrics.jsonl`
+
+The store uses `get_hermes_home()` so profiles remain isolated.
+
+## Status
+
+`/status` can include a compact swarm status section when persisted swarm jobs exist. It shows active jobs, tasks, blockers, permission requests, and the latest audit event. Secret-looking metadata keys are redacted.
+
+## Honcho summaries
+
+Honcho persistence is parent-owned and inert unless enabled. The adapter writes only compact final summaries through an injected/optional writer and strips scratchpads, raw transcripts, reasoning, and secret-looking values. If Honcho is unavailable, persistence is a structured no-op.
+
+## Verification planner
+
+The verification helper builds deterministic checklists for direct/swarm/script/pipe work. It records explicit eval results on the `SwarmJob`; it does not run external tests or tools by itself.
+
+## Rollout checklist
+
+Before enabling locally:
+
+1. Run focused tests:
+
+   ```bash
+   python -m pytest tests/swarm -q -o 'addopts='
+   ```
+
+2. Review shadow state after a test message.
+3. Confirm normal gateway replies are unchanged.
+4. Confirm no external sends, deploys, restarts, or destructive actions occur without explicit approval.
+5. Only then consider setting `swarm_operator.enabled: true` in the profile config and restarting the gateway manually.


### PR DESCRIPTION
## Summary
- Adds the disabled-by-default swarm operator shadow spine and status surfaces.
- Adds evidence-aware routing, verification, synthesis, and approval gates for anti-illusion delegation.
- Adds a killable live delegation runner with interprocess state locking and fail-closed gateway wiring.

## Test Plan
- `python -m pytest tests/swarm -q -o 'addopts='` — 100 passed\n- `python -m pytest tests/swarm tests/agent/test_prompt_builder.py tests/cron/test_scheduler.py tests/gateway/test_status_command.py -q -o 'addopts='` — 365 passed, 1 skipped\n- Repeated live-runner/gateway/config subset 8x with `-o 'addopts='` — 27 passed each run\n- `git diff --check origin/main..HEAD`\n- `python -m py_compile` on swarm runtime files and gateway hook\n\n## Notes\n- Draft PR for review; swarm live delegation remains gated behind explicit config.\n- Local untracked `artifacts/` and `papertrail-665/` were not included.