### PR TITLE
fix(skills): skip dependency dirs in skill scan

### DIFF
--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -24,7 +24,24 @@ PLATFORM_MAP = {
     "windows": "win32",
 }
 
-EXCLUDED_SKILL_DIRS = frozenset((".git", ".github", ".hub", ".archive"))
+EXCLUDED_SKILL_DIRS = frozenset(
+    (
+        ".git",
+        ".github",
+        ".hub",
+        ".archive",
+        ".venv",
+        "venv",
+        "node_modules",
+        "site-packages",
+        "__pycache__",
+        ".tox",
+        ".nox",
+        ".pytest_cache",
+        ".mypy_cache",
+        ".ruff_cache",
+    )
+)
 
 # ── Lazy YAML loader ─────────────────────────────────────────────────────
 
@@ -478,7 +495,8 @@ def extract_skill_description(frontmatter: Dict[str, Any]) -> str:
 def iter_skill_index_files(skills_dir: Path, filename: str):
     """Walk skills_dir yielding sorted paths matching *filename*.
 
-    Excludes ``.git``, ``.github``, ``.hub``, ``.archive`` directories.
+    Excludes Hermes metadata, VCS, virtualenv/dependency, and cache
+    directories so dependencies cannot register nested skills.
     """
     matches = []
     for root, dirs, files in os.walk(skills_dir, followlinks=True):

--- a/tests/agent/test_skill_utils.py
+++ b/tests/agent/test_skill_utils.py
@@ -1,6 +1,6 @@
-"""Tests for agent/skill_utils.py — extract_skill_conditions metadata handling."""
+"""Tests for agent/skill_utils.py."""
 
-from agent.skill_utils import extract_skill_conditions
+from agent.skill_utils import extract_skill_conditions, iter_skill_index_files
 
 
 def test_metadata_as_dict_with_hermes():
@@ -56,3 +56,41 @@ def test_metadata_missing_entirely():
         "fallback_for_tools": [],
         "requires_tools": [],
     }
+
+
+def test_iter_skill_index_files_prunes_dependency_dirs(tmp_path):
+    real = tmp_path / "real-skill"
+    real.mkdir()
+    (real / "SKILL.md").write_text("---\nname: real-skill\n---\n", encoding="utf-8")
+
+    nested = (
+        tmp_path
+        / "bring"
+        / "scripts"
+        / ".venv"
+        / "lib"
+        / "python3.13"
+        / "site-packages"
+        / "typer"
+        / ".agents"
+        / "skills"
+        / "typer"
+    )
+    nested.mkdir(parents=True)
+    (nested / "SKILL.md").write_text("---\nname: typer\n---\n", encoding="utf-8")
+
+    node_module = (
+        tmp_path
+        / "web-skill"
+        / "node_modules"
+        / "dep"
+        / ".agents"
+        / "skills"
+        / "dep"
+    )
+    node_module.mkdir(parents=True)
+    (node_module / "SKILL.md").write_text("---\nname: dep\n---\n", encoding="utf-8")
+
+    found = list(iter_skill_index_files(tmp_path, "SKILL.md"))
+
+    assert found == [real / "SKILL.md"]

--- a/tests/tools/test_skills_tool.py
+++ b/tests/tools/test_skills_tool.py
@@ -267,6 +267,32 @@ class TestFindAllSkills:
         assert len(skills) == 1
         assert skills[0]["name"] == "real-skill"
 
+    def test_skips_nested_virtualenv_dependency_skills(self, tmp_path):
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(tmp_path, "real-skill")
+            typer_skill = (
+                tmp_path
+                / "bring"
+                / "scripts"
+                / ".venv"
+                / "lib"
+                / "python3.13"
+                / "site-packages"
+                / "typer"
+                / ".agents"
+                / "skills"
+                / "typer"
+            )
+            typer_skill.mkdir(parents=True)
+            (typer_skill / "SKILL.md").write_text(
+                "---\nname: typer\ndescription: Should not be discovered.\n---\n",
+                encoding="utf-8",
+            )
+
+            skills = _find_all_skills()
+
+        assert [skill["name"] for skill in skills] == ["real-skill"]
+
     def test_finds_skills_in_symlinked_category_dir(self, tmp_path):
         external_root = tmp_path / "repo"
         skills_root = tmp_path / "skills"

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -79,6 +79,7 @@ from typing import Dict, Any, List, Optional, Set, Tuple
 from tools.registry import registry, tool_error
 from hermes_cli.config import cfg_get
 from utils import env_var_enabled
+from agent.skill_utils import EXCLUDED_SKILL_DIRS as _EXCLUDED_SKILL_DIRS
 
 logger = logging.getLogger(__name__)
 
@@ -101,7 +102,6 @@ _PLATFORM_MAP = {
     "windows": "win32",
 }
 _ENV_VAR_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
-_EXCLUDED_SKILL_DIRS = frozenset((".git", ".github", ".hub", ".archive"))
 _REMOTE_ENV_BACKENDS = frozenset(
     {"docker", "singularity", "modal", "ssh", "daytona", "vercel_sandbox"}
 )
@@ -1565,4 +1565,3 @@ registry.register(
     check_fn=check_skills_requirements,
     emoji="📚",
 )
-


### PR DESCRIPTION
## What does this PR do?

Fixes skill discovery so dependency-local `SKILL.md` files are not registered as Hermes skills when they live under a skill's virtualenv or dependency tree.

Root cause: the shared skill index walker only pruned Hermes metadata/VCS dirs (`.git`, `.github`, `.hub`, `.archive`). If a skill kept dependencies under its own directory, packages such as Typer could ship `.agents/skills/.../SKILL.md`, and Hermes would discover that nested dependency skill as if it were user-installed.

This expands the shared excluded directory set used by `iter_skill_index_files()` to include virtualenv, dependency, and cache directories such as `.venv`, `venv`, `node_modules`, and `site-packages`. `tools.skills_tool` now reuses the shared exclusion set instead of carrying a stale duplicate.

## Related Issue

No GitHub issue. Reported through Discord support.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Updated `agent/skill_utils.py` to prune virtualenv/dependency/cache directories during skill index walks.
- Updated `tools/skills_tool.py` to reuse the shared excluded-directory set.
- Added regression coverage for the exact nested `.venv/.../site-packages/typer/.agents/skills/typer/SKILL.md` shape.
- Added shared iterator coverage for both `.venv` and `node_modules` nested dependency skill files.

## How to Test

1. Create a real skill under a temporary skills root.
2. Create a fake dependency skill under `bring/scripts/.venv/lib/python3.13/site-packages/typer/.agents/skills/typer/SKILL.md`.
3. Run the skill scanner and verify only the real skill is discovered.

Validation run locally:

`pytest -q tests/tools/test_skills_tool.py tests/agent/test_skill_utils.py`

Result:

`92 passed in 1.75s`

Full-suite note:

I am not marking the full-suite checkbox on this PR. The default full-suite wrapper attempted to run the parallel test suite at CPU-count parallelism (`-j 32`) when no explicit worker cap was passed through its clean environment. That overcommits the workstation and is not acceptable to run as-is on this machine. Focused regression coverage for this skill-scanner fix passes.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A

## Screenshots / Logs

Focused test output:

`92 passed in 1.75s`

Full suite was not completed for the reason noted above.
