### PR TITLE
fix(codex): harden Responses tool schemas

### DIFF
--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -10,6 +10,7 @@ in and return transformed results.
 
 from __future__ import annotations
 
+import copy
 import hashlib
 import json
 import logging
@@ -202,6 +203,49 @@ def _derive_responses_function_call_id(
 # Schema conversion
 # ---------------------------------------------------------------------------
 
+_CODEX_FORBIDDEN_SCHEMA_KEYS = {"enum", "anyOf", "oneOf", "allOf", "not"}
+
+
+def _sanitize_codex_responses_schema(schema: Any) -> Dict[str, Any]:
+    """Return a Codex Responses-compatible function-parameters schema.
+
+    ChatGPT/Codex Responses is stricter than the Chat Completions schema
+    surface Hermes normally carries. Some MCP tools include validation
+    keywords Codex rejects, and some expose arrays without ``items``. Strip
+    validation-only constraints and inject permissive array items while
+    preserving the object/array/string shape that guides tool calls.
+    """
+    if not isinstance(schema, dict):
+        return {"type": "object", "properties": {}}
+
+    def scrub(node: Any) -> Any:
+        if isinstance(node, list):
+            return [scrub(item) for item in node]
+        if not isinstance(node, dict):
+            return copy.deepcopy(node)
+
+        out: Dict[str, Any] = {}
+        for key, value in node.items():
+            if key in _CODEX_FORBIDDEN_SCHEMA_KEYS:
+                continue
+            out[key] = scrub(value)
+
+        if out.get("type") == "object" and not isinstance(out.get("properties"), dict):
+            out["properties"] = {}
+        if out.get("type") == "array" and "items" not in out:
+            out["items"] = {}
+        return out
+
+    cleaned = scrub(schema)
+    if not isinstance(cleaned, dict):
+        return {"type": "object", "properties": {}}
+    if cleaned.get("type") != "object":
+        cleaned["type"] = "object"
+    if not isinstance(cleaned.get("properties"), dict):
+        cleaned["properties"] = {}
+    return cleaned
+
+
 def _responses_tools(tools: Optional[List[Dict[str, Any]]] = None) -> Optional[List[Dict[str, Any]]]:
     """Convert chat-completions tool schemas to Responses function-tool schemas."""
     if not tools:
@@ -218,7 +262,9 @@ def _responses_tools(tools: Optional[List[Dict[str, Any]]] = None) -> Optional[L
             "name": name,
             "description": fn.get("description", ""),
             "strict": False,
-            "parameters": fn.get("parameters", {"type": "object", "properties": {}}),
+            "parameters": _sanitize_codex_responses_schema(
+                fn.get("parameters", {"type": "object", "properties": {}})
+            ),
         })
     return converted or None
 

--- a/tests/agent/test_codex_responses_schema_sanitizer.py
+++ b/tests/agent/test_codex_responses_schema_sanitizer.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from agent.codex_responses_adapter import _responses_tools
+
+
+def _tool(name: str, parameters: dict) -> dict:
+    return {"type": "function", "function": {"name": name, "parameters": parameters}}
+
+
+def test_responses_tools_strip_codex_forbidden_schema_keywords_recursively():
+    tools = [_tool("memory", {
+        "type": "object",
+        "oneOf": [{"required": ["content"]}],
+        "properties": {
+            "action": {"type": "string", "enum": ["add", "remove"]},
+            "payload": {
+                "anyOf": [
+                    {"type": "object", "properties": {"x": {"type": "string"}}},
+                    {"type": "null"},
+                ],
+            },
+        },
+    })]
+
+    out = _responses_tools(tools)
+    assert out is not None
+    params = out[0]["parameters"]
+
+    assert "oneOf" not in params
+    assert "enum" not in params["properties"]["action"]
+    assert "anyOf" not in params["properties"]["payload"]
+
+
+def test_responses_tools_inject_array_items_for_codex_responses():
+    tools = [_tool("mcp_dinero_dinero_create_invoice", {
+        "type": "object",
+        "properties": {
+            "productLines": {"type": "array"},
+        },
+    })]
+
+    out = _responses_tools(tools)
+    assert out is not None
+
+    assert out[0]["parameters"]["properties"]["productLines"]["items"] == {}

--- a/tests/tools/test_schema_sanitizer.py
+++ b/tests/tools/test_schema_sanitizer.py
@@ -201,6 +201,18 @@ def test_items_sanitized_in_array_schema():
     assert items == {"type": "object", "properties": {}}
 
 
+def test_array_schema_without_items_gets_permissive_items():
+    tools = [_tool("t", {
+        "type": "object",
+        "properties": {
+            "bag": {"type": "array"},
+        },
+    })]
+    out = sanitize_tool_schemas(tools)
+    bag = out[0]["function"]["parameters"]["properties"]["bag"]
+    assert bag == {"type": "array", "items": {}}
+
+
 def test_empty_tools_list_returns_empty():
     assert sanitize_tool_schemas([]) == []
 

--- a/tools/schema_sanitizer.py
+++ b/tools/schema_sanitizer.py
@@ -284,6 +284,12 @@ def _sanitize_node(node: Any, path: str) -> Any:
     if out.get("type") == "object" and not isinstance(out.get("properties"), dict):
         out["properties"] = {}
 
+    # Array nodes without items: inject permissive default. OpenAI Codex
+    # Responses rejects arrays missing items with HTTP 400, and MCP servers
+    # sometimes ship arrays without item schemas.
+    if out.get("type") == "array" and "items" not in out:
+        out["items"] = {}
+
     # Prune ``required`` entries that don't exist in properties (defense
     # against malformed MCP schemas; also caught upstream for MCP tools, but
     # built-in tools or plugin tools may not have been through that path).


### PR DESCRIPTION
## Summary
- strip Codex Responses-incompatible schema validation keywords during tool conversion
- inject permissive `items: {}` for array schemas missing `items`
- cover both Responses conversion and shared schema sanitizer regressions

## Test Plan
- `python -m pytest tests/agent/test_codex_responses_schema_sanitizer.py tests/tools/test_schema_sanitizer.py tests/run_agent/test_run_agent_codex_responses.py -q -o 'addopts='`
- `python -m hermes_cli.main chat -q 'Svar kun med: OK' --provider openai-codex --model gpt-5.5 -Q -t terminal,file`
- `python -m hermes_cli.main chat -q 'Svar kun med: OK' --provider xai-proxy --model grok-4.3 -Q -t web,x_search`
