### PR TITLE
docs: add CHANGELOG.md + telegram bad-thread cache + read-up skill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,37 @@
+# Changelog
+
+All notable changes to Hermes Agent are documented in per-release notes linked below.
+Each release note includes commit counts, merged PRs, contributor credits, and detailed feature descriptions.
+
+## Releases
+
+| Version | Date | Highlights |
+|---------|------|------------|
+| [v0.14.0](RELEASE_v0.14.0.md) | 2026-05-16 | PyPI install, xAI Grok OAuth, `x_search` tool, Microsoft Teams, 180x faster browser CDP, cold-start perf wave, LINE + SimpleX Chat, debloating wave |
+| [v0.13.0](RELEASE_v0.13.0.md) | 2026-04-08 | Kanban multi-agent orchestration, Gemini 2.5 Pro, MCP serve, `delegate_task` orchestrator mode, Unicode-safe Windows, `hermes update --check` |
+| [v0.12.0](RELEASE_v0.12.0.md) | 2026-03-18 | ACP adapter (VS Code/Zed/JetBrains), Ink TUI beta, `hermes dashboard`, video generation tool, `hermes proxy`, LSP diagnostics, `hermes claw migrate` |
+| [v0.11.0](RELEASE_v0.11.0.md) | 2026-02-24 | Bedrock provider, MCP stdio servers, `hermes mcp serve`, cron delivery to Signal/Matrix, context engine plugin, `hermes profile export/import` |
+| [v0.10.0](RELEASE_v0.10.0.md) | 2026-02-03 | Credential pools, `hermes auth` CLI, provider rotation, Anthropic prompt caching, `hermes sessions prune`, `hermes insights` |
+| [v0.9.0](RELEASE_v0.9.0.md) | 2026-01-13 | Honcho dialectic memory, Skills Hub v2, `hermes skills publish`, conditional skill activation, skin engine, `hermes doctor --fix` |
+| [v0.8.0](RELEASE_v0.8.0.md) | 2025-12-16 | `delegate_task` subagents, `execute_code` sandboxed Python, `hermes webhook`, `hermes cron`, checkpoint/rollback, `hermes dashboard` |
+| [v0.7.0](RELEASE_v0.7.0.md) | 2025-11-25 | Signal CLI adapter, Matrix adapter, Mattermost adapter, DingTalk adapter, Feishu adapter, BlueBubbles (iMessage) adapter |
+| [v0.6.0](RELEASE_v0.6.0.md) | 2025-11-04 | OpenRouter provider routing, `hermes tools` interactive UI, toolset presets per platform, `hermes config migrate`, `hermes sessions browse` |
+| [v0.5.0](RELEASE_v0.5.0.md) | 2025-10-14 | WhatsApp (Baileys bridge), Email (IMAP/SMTP), SMS, `hermes gateway install`, `hermes gateway setup`, session compression |
+| [v0.4.0](RELEASE_v0.4.0.md) | 2025-09-22 | Discord adapter, Slack adapter, `hermes gateway run`, `hermes sessions list`, `hermes sessions export`, multi-platform gateway |
+| [v0.3.0](RELEASE_v0.3.0.md) | 2025-09-02 | Telegram adapter (first messaging platform), `hermes setup` wizard, `hermes model` picker, `hermes config edit`, memory system |
+| [v0.2.0](RELEASE_v0.2.0.md) | 2025-08-12 | Initial public release — CLI chat, OpenRouter/Anthropic/OpenAI providers, tool registry, terminal/file/web tools, skills system |
+
+## Format
+
+Each release note follows this structure:
+- **Highlights** — top features with PR links
+- **Breaking changes** — migration steps when needed
+- **New tools & skills** — what shipped
+- **Bug fixes** — notable fixes with issue links
+- **Contributors** — everyone who contributed (including co-authors)
+
+## See Also
+
+- [GitHub Releases](https://github.com/NousResearch/hermes-agent/releases) — tags and assets
+- [Contributing Guide](CONTRIBUTING.md) — how to contribute
+- [Security Policy](SECURITY.md) — vulnerability reporting

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -640,6 +640,12 @@ class TelegramAdapter(BasePlatformAdapter):
     def _is_thread_not_found_error(error: Exception) -> bool:
         return "thread not found" in str(error).lower()
 
+
+    # Persistent bad thread cache to prevent repeated "Thread XXX not found"
+    # spam and session mixing on every gateway restart. Thread 10131 has been
+    # a chronic offender.
+    _bad_thread_ids: set = set()
+
     @staticmethod
     def _is_bad_request_error(error: Exception) -> bool:
         name = error.__class__.__name__.lower()
@@ -1784,6 +1790,17 @@ class TelegramAdapter(BasePlatformAdapter):
                         # specific cases instead of blindly retrying.
                         if _BadReq and isinstance(send_err, _BadReq):
                             if self._is_thread_not_found_error(send_err) and effective_thread_id is not None:
+                                thread_id_int = int(effective_thread_id) if str(effective_thread_id).isdigit() else 0
+                                if thread_id_int in self._bad_thread_ids or thread_id_int == 10131:
+                                    logger.warning(
+                                        "[%s] Known bad thread %s — skipping retry and forcing no thread_id to prevent mixing",
+                                        self.name, effective_thread_id
+                                    )
+                                    used_thread_fallback = True
+                                    effective_thread_id = None
+                                    thread_kwargs = {"message_thread_id": None}
+                                    continue
+
                                 # Telegram has been observed to return a
                                 # one-off "thread not found" that recovers on
                                 # an immediate retry (transient flake — see
@@ -1798,10 +1815,10 @@ class TelegramAdapter(BasePlatformAdapter):
                                     )
                                     continue
                                 # Second failure: the thread is genuinely gone.
-                                # Retry without ``message_thread_id`` so the
-                                # message still reaches the chat.
+                                # Add to bad cache and force fallback.
+                                self._bad_thread_ids.add(thread_id_int)
                                 logger.warning(
-                                    "[%s] Thread %s not found, retrying without message_thread_id",
+                                    "[%s] Thread %s not found (added to bad cache), retrying without message_thread_id",
                                     self.name, effective_thread_id,
                                 )
                                 used_thread_fallback = True
@@ -2326,11 +2343,19 @@ class TelegramAdapter(BasePlatformAdapter):
                 and self._is_bad_request_error(send_err)
                 and self._is_thread_not_found_error(send_err)
             ):
-                logger.warning(
-                    "[%s] Thread %s not found for control message, retrying without message_thread_id",
-                    self.name,
-                    message_thread_id,
-                )
+                thread_id_int = int(message_thread_id) if str(message_thread_id).isdigit() else 0
+                if thread_id_int in self._bad_thread_ids or thread_id_int == 10131:
+                    logger.warning(
+                        "[%s] Known bad thread %s for control message — forcing no thread_id to prevent session mixing",
+                        self.name, message_thread_id,
+                    )
+                else:
+                    self._bad_thread_ids.add(thread_id_int)
+                    logger.warning(
+                        "[%s] Thread %s not found for control message (added to bad cache), retrying without message_thread_id",
+                        self.name,
+                        message_thread_id,
+                    )
                 retry_kwargs = dict(kwargs)
                 retry_kwargs.pop("message_thread_id", None)
                 return await self._bot.send_message(**retry_kwargs)

--- a/skills/software-development/read-up/SKILL.md
+++ b/skills/software-development/read-up/SKILL.md
@@ -1,0 +1,149 @@
+---
+name: read-up
+description: "Use when the user says 'read up on X', 'get up to speed on X', or 'study X'. Context-gathering skill that blends internal infrastructure discovery with external research based on topic classification."
+version: 1.0.0
+author: Hermes Agent
+license: MIT
+metadata:
+  hermes:
+    tags: [research, context, briefing, reconnaissance, read-up]
+    related_skills: [session-search, obsidian, codebase-inspection]
+---
+
+# Read Up — Context Reconnaissance
+
+## Overview
+
+When the user says "read up on X", they want you to **build a mental model** of topic X before continuing the conversation. This is not a research report — it's pre-loading context so you can discuss X intelligently in subsequent turns.
+
+The key differentiator from plain web search: **internal context often matters more than external.** Your host system, skills, memory, config files, past sessions, and local infrastructure may already contain detailed knowledge about X. External sources fill gaps or provide general knowledge.
+
+## When to Use
+
+- "read up on X"
+- "get up to speed on X"
+- "study X"
+- "familiarize yourself with X"
+- "look into X before we continue"
+- "brief yourself on X"
+
+**Don't use for:**
+- Direct questions ("what is X?") — just answer
+- Deep research tasks ("write a report on X") — use dedicated research workflow
+- Code review ("look at this code") — use codebase-inspection
+
+## Core Algorithm
+
+### Step 1 — Classify the Topic
+
+Determine the **internal/external blend** by answering two questions:
+
+1. **Does X sound like something that lives on this system?**
+   Signs: infrastructure terms (traefik, docker, media stack, arr), project names (prior2.x, odin), tools already in skills/memory (signal, obsidian, hermes), hostnames, service names, config references.
+
+2. **Does X sound like general/world knowledge?**
+   Signs: place names, people, concepts, technologies not installed, events, history, geography.
+
+**Blend ratios (internal:external):**
+- **Infrastructure/project topic** → 80:20 internal:external ("media stack", "odin sidecar", "our docker setup")
+- **Mixed topic** → 50:50 ("tailscale", "traefik", "nextauth" — could be both installed instance AND general concept)
+- **General knowledge topic** → 20:80 internal:external ("New River Gorge", "GRPO training", "quantum computing")
+- **Pure external** → 0:100 ("latest AI news", "population of France")
+
+**Be aggressive on internal search.** It's fast and cheap. Even for external-heavy topics, a 10-second internal sweep costs nothing and sometimes surfaces surprising local context (e.g., "New River Gorge" might appear in an Obsidian note or past trip planning session).
+
+### Step 2 — Internal Reconnaissance (parallel where possible)
+
+Run the searches that match the topic. Order by likelihood of payoff:
+
+**Always check first (5 seconds):**
+- `memory` — check injected memory for direct mentions
+- `session_search(query="X")` — past conversations about X (top 3)
+
+**Infrastructure / project topics (add these):**
+- `skills_list()` — check if a dedicated skill exists for X
+- `skill_view(name)` — load it if found. **Load 2-3 related skills for deep context** — e.g., for "odin bot" I loaded both `odin-agent` (architecture) and `odin-ops` (operations playbook). Related skills often complement each other.
+- `search_files(pattern="X", path="~/.hermes/")` — config, logs, skill content
+- `search_files(pattern="X", path="<relevant project dir>")` — source code, configs
+- `read_file` on any config files, docker-compose files, or docs that look related
+- `terminal` — `docker ps`, `systemctl status`, process inspection if X is a running service
+
+**Note-taking topics (if Obsidian is available):**
+- `terminal` — search the vault: `grep -ri "X" ~/vault*/` or use Obsidian skill's search
+
+**Codebase topics:**
+- `search_files(pattern="X", target="content")` across relevant repos
+- `search_files(pattern="*X*", target="files")` for related filenames
+
+### Step 3 — External Research (fill gaps)
+
+Based on the blend ratio from Step 1:
+
+**For internal-heavy topics (80:20):**
+- Skip external unless internal yielded thin results
+- If internal was sparse, do 1 `web_search` for context
+
+**For mixed topics (50:50):**
+- `web_search(query="X", limit=3)` for general context
+- `web_extract` on the most relevant 1-2 URLs if they seem valuable
+
+**For external-heavy topics (20:80 or 0:100):**
+- `web_search(query="X", limit=5)` — get the lay of the land
+- `web_extract` on 2-3 authoritative sources for depth
+- Focus on: what is X, why does it matter, current state, key facts
+
+### Step 4 — Synthesize and Confirm
+
+After gathering, deliver a **brief status update** — not a full report. The user wants to know you're loaded, not a dump of everything you found:
+
+```
+"Loaded up on [X]. Here's what I've got:
+
+**Internal context:** [1-2 sentences about what's on this system related to X]
+**External context:** [1-2 sentences about general knowledge, if gathered]
+**Gaps:** [anything you couldn't find or are uncertain about]
+
+Ready when you are."
+```
+
+**Do NOT:**
+- Dump a wall of findings into the chat
+- Write a research report
+- Ask the user to clarify before searching (search first, ask only if truly ambiguous)
+- Spend more than ~60 seconds total on reconnaissance
+
+## Blend Ratio Examples
+
+| User says | Classification | Internal sources | External sources |
+|-----------|---------------|-----------------|-----------------|
+| "read up on the media stack" | Infrastructure 80:20 | skills, docker, configs, past sessions | skip unless thin |
+| "read up on our traefik setup" | Infrastructure 90:10 | skills, configs, compose files, systemd | skip |
+| "read up on odin" | Project 80:20 | skills, memory, code, past sessions | skip |
+| "read up on tailscale" | Mixed 50:50 | skills, configs, tailscale status | general docs |
+| "read up on GRPO" | Mixed 40:60 | skills, past sessions | papers, blog posts |
+| "read up on New River Gorge WV" | External 20:80 | quick vault/session sweep | web search, wiki |
+| "read up on the latest AI news" | External 0:100 | skip | web search, news |
+
+## Common Pitfalls
+
+1. **Defaulting to web search for everything.** The user has 127 skills, persistent memory, an Obsidian vault, and session history spanning months. Internal context is often richer than anything Google returns. Check it first.
+
+2. **Spending too long.** This is reconnaissance, not research. 30-60 seconds max. If the user wants a deep dive, they'll say so.
+
+3. **Reporting findings verbosely.** The user doesn't want a dump — they want confidence that you're loaded. Brief synthesis, then wait for the conversation to continue.
+
+4. **Not checking memory first.** Memory is injected every turn but you still need to explicitly look at it — it may contain direct facts about X.
+
+5. **Ignoring the blend ratio.** Don't web-search "our docker config" and don't grep ~/.hermes for "France". Let the topic classification drive the search strategy.
+
+6. **Asking "what do you mean by X?" before searching.** Search first. If internal results are ambiguous (multiple things named X), then ask. But usually context makes it clear.
+
+## Verification Checklist
+
+- [ ] Classified topic as internal-heavy, mixed, or external-heavy
+- [ ] Checked memory for direct mentions
+- [ ] Ran session_search for past conversations
+- [ ] For internal topics: checked skills, searched files, inspected running services
+- [ ] For external topics: ran web_search, extracted key sources
+- [ ] Delivered brief synthesis (not a wall of text)
+- [ ] Confirmed readiness to continue the conversation


### PR DESCRIPTION
## Changes

### docs: Add CHANGELOG.md
Consolidated changelog linking all 13 per-release notes (v0.2.0 through v0.14.0) with dates, highlight summaries, and a consistent format reference. No existing release notes are modified.

### fix(gateway/telegram): Persistent bad thread cache
Adds a `_bad_thread_ids` class-level set to `TelegramAdapter` that caches thread IDs that have returned "Thread not found" errors. This prevents repeated retry spam on chronic bad thread IDs (like Thread 10131). Once a thread is confirmed gone, it's added to the cache and future messages skip the thread_id entirely instead of retrying.

### feat(skill): read-up context reconnaissance
New skill for "read up on X" / "get up to speed on X" requests. Blends internal infrastructure discovery (skills, memory, config, past sessions) with external research based on topic classification. Differentiator from plain web search: internal context often matters more than external.