### PR TITLE
fix: improve dashboard terminal clipboard and wheel handling

### DIFF
--- a/ui-tui/src/__tests__/clarifyPasteResult.test.ts
+++ b/ui-tui/src/__tests__/clarifyPasteResult.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+
+import { clarifyPasteResult } from '../components/prompts.js'
+
+describe('clarifyPasteResult — ask prompt paste insertion', () => {
+  it('inserts pasted text at the current custom-answer cursor', () => {
+    expect(clarifyPasteResult('there ', 6, 'hello world')).toEqual({
+      cursor: 12,
+      value: 'hello there world'
+    })
+  })
+
+  it('normalizes Windows CRLF clipboard text before insertion', () => {
+    expect(clarifyPasteResult('one\r\ntwo', 1, 'ab')).toEqual({
+      cursor: 8,
+      value: 'aone\ntwob'
+    })
+  })
+
+  it('strips terminal paste terminator newlines without dropping internal newlines', () => {
+    expect(clarifyPasteResult('one\ntwo\n\n', 0, '')).toEqual({
+      cursor: 7,
+      value: 'one\ntwo'
+    })
+  })
+
+  it('ignores empty or newline-only clipboard payloads', () => {
+    expect(clarifyPasteResult(null, 2, 'abcd')).toBeNull()
+    expect(clarifyPasteResult('\n\n', 2, 'abcd')).toBeNull()
+  })
+})

--- a/ui-tui/src/components/prompts.tsx
+++ b/ui-tui/src/components/prompts.tsx
@@ -1,11 +1,13 @@
 import { Box, Text, useInput } from '@hermes/ink'
 import { useState } from 'react'
 
+import { readClipboardText } from '../lib/clipboard.js'
 import { isMac } from '../lib/platform.js'
+import { stripTrailingPasteNewlines } from '../lib/text.js'
 import type { Theme } from '../theme.js'
 import type { ApprovalReq, ClarifyReq, ConfirmReq } from '../types.js'
 
-import { TextInput } from './textInput.js'
+import { type PasteEvent, TextInput } from './textInput.js'
 
 const OPTS = ['once', 'session', 'always', 'deny'] as const
 const LABELS = { always: 'Always allow', deny: 'Deny', once: 'Allow once', session: 'Allow this session' } as const
@@ -22,6 +24,8 @@ type ApprovalAction =
   | { kind: 'choose'; choice: (typeof OPTS)[number] }
   | { kind: 'move'; delta: -1 | 1 }
   | { kind: 'noop' }
+
+type ClarifyPasteResult = { cursor: number; value: string } | null
 
 /**
  * Pure key-dispatch for the approval prompt — exported so the regression
@@ -58,6 +62,19 @@ export function approvalAction(ch: string, key: ApprovalKey, sel: number): Appro
   }
 
   return { kind: 'noop' }
+}
+
+export function clarifyPasteResult(raw: null | string, cursor: number, value: string): ClarifyPasteResult {
+  const cleaned = stripTrailingPasteNewlines((raw ?? '').replace(/\r\n/g, '\n').replace(/\r/g, '\n'))
+
+  if (!cleaned || !/[^\n]/.test(cleaned)) {
+    return null
+  }
+
+  return {
+    cursor: cursor + cleaned.length,
+    value: value.slice(0, cursor) + cleaned + value.slice(cursor)
+  }
 }
 
 export function ApprovalPrompt({ onChoice, req, t }: ApprovalPromptProps) {
@@ -126,6 +143,14 @@ export function ClarifyPrompt({ cols = 80, onAnswer, onCancel, req, t }: Clarify
     </Text>
   )
 
+  const pasteIntoCustom = ({ cursor, hotkey, text, value }: PasteEvent) => {
+    if (hotkey && !text) {
+      return readClipboardText().then(clipText => clarifyPasteResult(clipText, cursor, value))
+    }
+
+    return clarifyPasteResult(text, cursor, value)
+  }
+
   useInput((ch, key) => {
     if (key.escape) {
       typing && choices.length ? setTyping(false) : onCancel()
@@ -163,7 +188,7 @@ export function ClarifyPrompt({ cols = 80, onAnswer, onCancel, req, t }: Clarify
 
         <Box>
           <Text color={t.color.label}>{'> '}</Text>
-          <TextInput columns={Math.max(20, cols - 6)} onChange={setCustom} onSubmit={onAnswer} value={custom} />
+          <TextInput columns={Math.max(20, cols - 6)} onChange={setCustom} onPaste={pasteIntoCustom} onSubmit={onAnswer} value={custom} />
         </Box>
 
         <Text color={t.color.muted}>

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -104,6 +104,16 @@ function terminalLineHeightForWidth(layoutWidthPx: number): number {
   return layoutWidthPx < 1024 ? 1.02 : 1.15;
 }
 
+function tuiWheelInputForDelta(deltaY: number): string | null {
+  if (!deltaY) return null;
+
+  // SGR mouse wheel report: button 64 = wheel-up, 65 = wheel-down.
+  // Coordinates are irrelevant to the TUI transcript-scroll handler; use the
+  // top-left cell to avoid coupling browser pixels to terminal cells.
+  const button = deltaY < 0 ? 64 : 65;
+  return `\x1b[<${button};1;1M`;
+}
+
 export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
   const hostRef = useRef<HTMLDivElement | null>(null);
   const termRef = useRef<Terminal | null>(null);
@@ -356,6 +366,9 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
     term.attachCustomKeyEventHandler((ev) => {
       if (ev.type !== "keydown") return true;
 
+      // Keep keyboard shortcuts terminal-like and avoid hijacking ordinary
+      // browser Ctrl+C/Ctrl+V on Windows/Linux. Context menu and browser-menu
+      // copy/paste are handled by host-level ClipboardEvents below.
       // Copy: Cmd+C on macOS, Ctrl+Shift+C on other platforms. Bare Ctrl+C
       // is reserved for SIGINT to the TUI child — matches xterm / gnome-terminal /
       // konsole / Windows Terminal. Ctrl+Shift+C only copies if a selection exists;
@@ -399,25 +412,68 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
       return true;
     });
 
+    const onHostCopy = (ev: ClipboardEvent) => {
+      const sel = term.getSelection();
+      if (!sel) return;
+      ev.clipboardData?.setData("text/plain", sel);
+      ev.preventDefault();
+      term.clearSelection();
+    };
+
+    const onHostPaste = (ev: ClipboardEvent) => {
+      const text = ev.clipboardData?.getData("text/plain") ?? "";
+      if (!text) return;
+      term.paste(text);
+      ev.preventDefault();
+      term.focus();
+    };
+
+    host.addEventListener("copy", onHostCopy);
+    host.addEventListener("paste", onHostPaste);
+
     const fit = new FitAddon();
     fitRef.current = fit;
     term.loadAddon(fit);
 
-    // Dashboard chat should scroll the browser-side transcript, not send
-    // mouse-wheel protocol bytes through the PTY.
-    term.attachCustomWheelEventHandler((ev) => {
+    // Dashboard chat should scroll the browser-side transcript for fresh
+    // sessions, not send mouse-wheel protocol bytes through the PTY. Resumed
+    // sessions are different: historical transcript rows are virtualized inside
+    // the TUI and are not present in xterm's browser scrollback, so route wheel
+    // input back to the TUI transcript scroller for those PTYs only.
+    //
+    // Keep the host capture listener as a belt-and-suspenders guard: in some
+    // browser/layout combinations xterm's own wheel listener does not see the
+    // event before parent scroll containers do.
+    const scrollTerminalForWheel = (ev: WheelEvent): boolean => {
       const delta = ev.deltaY;
       if (!delta) {
         return false;
       }
 
-      const step = Math.max(1, Math.round(Math.abs(delta) / 50));
-      term.scrollLines(delta > 0 ? step : -step);
+      if (resumeParam) {
+        const wheelInput = tuiWheelInputForDelta(delta);
+        const wsCurrent = wsRef.current;
+
+        if (wheelInput && wsCurrent?.readyState === WebSocket.OPEN) {
+          wsCurrent.send(wheelInput);
+        }
+      } else {
+        const step = Math.max(1, Math.round(Math.abs(delta) / 50));
+        term.scrollLines(delta > 0 ? step : -step);
+      }
 
       ev.preventDefault();
       ev.stopPropagation();
-      return false;
-    });
+      ev.stopImmediatePropagation();
+      return true;
+    };
+
+    const onHostWheel = (ev: WheelEvent) => {
+      scrollTerminalForWheel(ev);
+    };
+    host.addEventListener("wheel", onHostWheel, { capture: true, passive: false });
+
+    term.attachCustomWheelEventHandler((ev) => !scrollTerminalForWheel(ev));
 
     const unicode11 = new Unicode11Addon();
     term.loadAddon(unicode11);
@@ -630,6 +686,9 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
       syncMetricsRef.current = null;
       onDataDisposable.dispose();
       onResizeDisposable.dispose();
+      host.removeEventListener("copy", onHostCopy);
+      host.removeEventListener("paste", onHostPaste);
+      host.removeEventListener("wheel", onHostWheel, { capture: true });
       if (metricsDebounce) clearTimeout(metricsDebounce);
       window.removeEventListener("resize", scheduleSyncTerminalMetrics);
       window.visualViewport?.removeEventListener(


### PR DESCRIPTION
## Summary
- add host-level copy/paste event handling for the dashboard embedded terminal so context-menu/browser-menu clipboard operations work with xterm selections and pasted text
- wire the ask/clarify prompt's custom-answer `TextInput` to its own paste handler so nested ask prompts handle pasted text the same way as the regular composer
- preserve terminal-style keyboard semantics on Windows/Linux by not hijacking bare Ctrl+C/Ctrl+V in the dashboard host handler
- add a capture-phase wheel listener that keeps fresh dashboard sessions on xterm scrollback, while routing URL-resumed sessions through the TUI transcript wheel path because their historical rows are virtualized inside the TUI

## Test Plan
- [x] `cd web && ./node_modules/.bin/tsc --noEmit -p tsconfig.app.json --tsBuildInfoFile /tmp/hermes-upstream-web-tsconfig.app.tsbuildinfo`
- [x] `cd web && ./node_modules/.bin/eslint src/pages/ChatPage.tsx` (passes with one pre-existing `react-hooks/exhaustive-deps` warning)
- [x] `cd web && npm run build`
- [x] `. .venv/bin/activate && python -m pytest tests/hermes_cli/test_web_server.py::TestPtyWebSocket -q`
- [x] `cd ui-tui && npx eslint src/components/prompts.tsx src/__tests__/clarifyPasteResult.test.ts`
- [x] `cd ui-tui && npm test -- --run src/__tests__/clarifyPasteResult.test.ts src/__tests__/approvalAction.test.ts src/__tests__/textInputRightClick.test.ts src/__tests__/clipboard.test.ts`
- [x] `cd ui-tui && npm run build`
- [x] `cd ui-tui && npm run type-check -- --pretty false` has pre-existing `packages/hermes-ink/src/utils/execFileNoThrow.ts` errors; no errors in the amended ask-prompt files

## Manual verification
- Mouse selection in the dashboard terminal remains possible.
- Context-menu copy/paste works in the regular prompt/response area.
- Context-menu paste works while stopped at an ask/clarify prompt's custom-answer input.
- Bare Ctrl+C/Ctrl+V on Windows/Linux are not hijacked by the dashboard key handler; Ctrl+V continues to pass through to the existing TUI clipboard/image fallback.
- Fresh-session wheel scrolling uses xterm scrollback and does not forward wheel input into the PTY.
- URL-resumed-session wheel scrolling sends only SGR wheel reports to the TUI transcript scroller, avoiding prompt input history while allowing virtualized resumed history to scroll.

## Notes
The wheel handling is intentionally split by session source. Fresh dashboard sessions keep the upstream xterm-owned scrollback path (`term.scrollLines(...)`). URL-resumed sessions use a narrow SGR-wheel bridge because their already persisted history is virtualized inside the TUI rather than present in xterm scrollback.

Fixes #30083
Refs #24860
