### PR TITLE
fix(tools): serialize concurrent ddgs web_search calls to prevent libcurl deadlock

### DIFF
--- a/plugins/web/ddgs/provider.py
+++ b/plugins/web/ddgs/provider.py
@@ -13,11 +13,29 @@ whether the package is importable; the plugin still registers either way so
 from __future__ import annotations
 
 import logging
+import threading
 from typing import Any, Dict
 
 from agent.web_search_provider import WebSearchProvider
 
 logger = logging.getLogger(__name__)
+
+# Serialize all ddgs invocations process-wide.
+#
+# The ``ddgs`` package wraps ``primp`` (compiled libcurl extension) and
+# spawns its own internal ThreadPoolExecutor inside ``DDGS().text()``.
+# Two ``DDGS()`` calls dispatched concurrently — e.g. when the agent
+# emits two ``web_search`` tool calls in one LLM response and
+# ``execute_tool_calls_concurrent()`` runs them in parallel because
+# ``web_search`` is in ``_PARALLEL_SAFE_TOOLS`` — race on the shared
+# libcurl state and deadlock the entire process (futex_do_wait,
+# SIGINT-immune; only SIGKILL recovers).  See issue #29966.
+#
+# Serializing at the provider layer keeps ``web_search`` parallel-safe
+# for backends that *are* thread-safe (Brave / Exa / Tavily / Firecrawl
+# / SearXNG — stateless HTTP) while collapsing concurrent ddgs calls
+# into sequential ones.
+_DDGS_CALL_LOCK = threading.Lock()
 
 
 class DDGSWebSearchProvider(WebSearchProvider):
@@ -72,7 +90,7 @@ class DDGSWebSearchProvider(WebSearchProvider):
 
         try:
             web_results = []
-            with DDGS() as client:
+            with _DDGS_CALL_LOCK, DDGS() as client:
                 for i, hit in enumerate(client.text(query, max_results=safe_limit)):
                     if i >= safe_limit:
                         break

--- a/tests/tools/test_web_providers_ddgs.py
+++ b/tests/tools/test_web_providers_ddgs.py
@@ -156,6 +156,59 @@ class TestDDGSProviderSearch:
         assert result["success"] is True
         assert result["data"]["web"] == []
 
+    def test_concurrent_calls_serialize_through_lock(self, monkeypatch):
+        # Issue #29966 — without serialization, concurrent ddgs calls race on
+        # the shared libcurl state inside primp and deadlock the process.
+        # Two DDGS() instances must never be live at the same moment.
+        import threading
+        import time
+
+        in_flight = {"count": 0, "max": 0}
+        in_flight_lock = threading.Lock()
+
+        class _ConcurrencyTrackingDDGS:
+            def __enter__(self):
+                with in_flight_lock:
+                    in_flight["count"] += 1
+                    in_flight["max"] = max(in_flight["max"], in_flight["count"])
+                time.sleep(0.02)
+                return self
+
+            def __exit__(self, *_a):
+                with in_flight_lock:
+                    in_flight["count"] -= 1
+                return False
+
+            def text(self, query, max_results=5):
+                yield {"title": query, "href": f"https://{query}.example.com", "body": ""}
+
+        fake = types.ModuleType("ddgs")
+        fake.DDGS = _ConcurrencyTrackingDDGS
+        monkeypatch.setitem(sys.modules, "ddgs", fake)
+        monkeypatch.delitem(sys.modules, "plugins.web.ddgs.provider", raising=False)
+        from plugins.web.ddgs.provider import DDGSWebSearchProvider
+
+        provider = DDGSWebSearchProvider()
+        results = []
+        results_lock = threading.Lock()
+
+        def _run(q: str) -> None:
+            r = provider.search(q, limit=1)
+            with results_lock:
+                results.append(r)
+
+        threads = [threading.Thread(target=_run, args=(f"q{i}",)) for i in range(4)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=5.0)
+
+        assert all(not t.is_alive() for t in threads), "ddgs threads deadlocked"
+        assert len(results) == 4
+        assert all(r["success"] for r in results)
+        # The lock must keep at most one DDGS() context live at a time.
+        assert in_flight["max"] == 1, f"expected 1 concurrent DDGS, saw {in_flight['max']}"
+
 
 # ---------------------------------------------------------------------------
 # Integration: _is_backend_available / _get_backend / check_web_api_key


### PR DESCRIPTION
## What does this PR do?

When the agent emits two `web_search` tool calls in a single LLM response, `execute_tool_calls_concurrent()` dispatches both in parallel because `web_search` is listed in `_PARALLEL_SAFE_TOOLS`. With the `ddgs` backend selected, each call wraps `primp` (a compiled libcurl C extension) and spawns its own internal `ThreadPoolExecutor` inside `DDGS().text()`. The two `DDGS()` instances race on shared libcurl state and hard-freeze the entire Hermes process — `futex_do_wait`, SIGINT-immune, only SIGKILL recovers (see #29966 for the forensic trace).

Fix at the provider layer: wrap the `with DDGS() as client:` block in a module-level `threading.Lock()`. Concurrent ddgs calls collapse into sequential ones; thread-safe providers (Brave / Exa / Tavily / Firecrawl / SearXNG — all stateless HTTP via `httpx`/`requests`) are unaffected.

> Audited siblings: confirmed every other plugin under `plugins/web/` uses HTTP-only (`httpx` / `requests`) clients with no shared mutable state. No widening needed.

## Related Issue

Fixes #29966

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `plugins/web/ddgs/provider.py` — add module-level `_DDGS_CALL_LOCK = threading.Lock()`; wrap the `with DDGS() as client:` block in the lock so at most one `DDGS()` context is live process-wide.
- `tests/tools/test_web_providers_ddgs.py` — new regression test `test_concurrent_calls_serialize_through_lock`: spawns 4 threads each calling `DDGSWebSearchProvider().search()` against a tracking-DDGS stub; asserts `in_flight["max"] == 1` (only the lock prevents the stub's `__enter__` from being re-entered concurrently).

## How to Test

1. Run the focused test, which fails without the lock and passes with it:
   ```
   uv run --with pytest --with pytest-asyncio --with pytest-timeout python3 -m pytest \
     tests/tools/test_web_providers_ddgs.py::TestDDGSProviderSearch::test_concurrent_calls_serialize_through_lock -v -p no:xdist
   ```
2. Run the full web-providers suite to confirm no regressions:
   ```
   uv run --with pytest --with pytest-asyncio --with pytest-timeout python3 -m pytest \
     tests/tools/test_web_providers.py tests/tools/test_web_providers_ddgs.py tests/tools/test_web_tools_config.py \
     tests/tools/test_web_providers_brave_free.py tests/tools/test_web_providers_searxng.py tests/tools/test_web_providers_xai.py -v -p no:xdist
   ```
   → 168 passed locally.
3. Regression guard: temporarily revert the lock (`with DDGS() as client:` only); rerun (1) — the new test fails with `expected 1 concurrent DDGS, saw 4`. Restore the lock; passes.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run focused tests for the touched code and all pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.x

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A (internal locking, comment in-source)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — `threading.Lock` is stdlib and portable
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A (`web_search` semantics unchanged; only concurrency is constrained)