### PR TITLE
fix(cli): honor root-level provider when model is a string

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -437,7 +437,24 @@ def load_cli_config() -> Dict[str, Any]:
             # only used as a FALLBACK when model.provider / model.base_url
             # is not already set — never as an override.  The canonical
             # location is model.provider (written by `hermes model`).
-            if not defaults["model"].get("provider"):
+            #
+            # Special case: when `model:` is written as a STRING (short
+            # form — see every profile config in profiles/*/config.yaml),
+            # the dict has no provider slot at all, so model.provider stays
+            # at the hardcoded "auto" default and the truthy check below
+            # short-circuits. That leaves the root-level `provider:` —
+            # the user's only way to specify provider in the short form —
+            # silently dropped. Every kanban worker subprocess then hits
+            # AuthError on the primary provider and falls through to the
+            # configured fallback chain (regression flooding profile
+            # error logs throughout May 2026 with thousands of "Primary
+            # provider auth failed" warnings).
+            _model_was_string = isinstance(file_config.get("model"), str)
+            _cur_provider = (defaults["model"].get("provider") or "").strip().lower()
+            _provider_unset = (not _cur_provider) or (
+                _model_was_string and _cur_provider == "auto"
+            )
+            if _provider_unset:
                 root_provider = file_config.get("provider")
                 if root_provider:
                     defaults["model"]["provider"] = root_provider

--- a/tests/cli/test_cli_init.py
+++ b/tests/cli/test_cli_init.py
@@ -430,7 +430,8 @@ class TestRootLevelProviderOverride:
         assert cfg["model"]["provider"] == "openrouter"
 
     def test_root_provider_ignored_when_default_model_provider_exists(self, tmp_path, monkeypatch):
-        """Even when model.provider is the default 'auto', root-level provider is ignored."""
+        """Even when model.provider is the default 'auto', root-level provider is ignored
+        when `model:` is written in the dict form (the canonical "place provider here" shape)."""
         import yaml
 
         hermes_home = tmp_path / ".hermes"
@@ -452,6 +453,35 @@ class TestRootLevelProviderOverride:
 
         # Root-level "opencode-go" must NOT leak through
         assert cfg["model"]["provider"] != "opencode-go"
+
+    def test_root_provider_honored_when_model_is_string(self, tmp_path, monkeypatch):
+        """When `model:` is a STRING (short form), the dict has no provider slot —
+        the root-level `provider:` is the user's only way to specify it and must be honored.
+
+        Regression: every profile config in profiles/*/config.yaml uses the short form
+        plus a root-level `provider: copilot`. Pre-fix, model.provider stayed at the
+        hardcoded "auto" default and the legacy fallback short-circuited (because "auto"
+        is truthy), causing every kanban worker subprocess to hit AuthError on the
+        primary provider and fall through to the fallback chain.
+        """
+        import yaml
+
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(yaml.safe_dump({
+            "model": "claude-opus-4.7-1m-internal",  # short form
+            "provider": "copilot",                    # root-level (only place it can go)
+        }))
+
+        import cli
+        monkeypatch.setattr(cli, "_hermes_home", hermes_home)
+        cfg = cli.load_cli_config()
+
+        assert cfg["model"]["default"] == "claude-opus-4.7-1m-internal"
+        assert cfg["model"]["provider"] == "copilot"
 
     def test_terminal_vercel_runtime_bridged_to_env(self, tmp_path, monkeypatch):
         """Classic CLI must expose terminal.vercel_runtime to terminal_tool.py."""


### PR DESCRIPTION
## Problem

When `model:` is a plain string in `config.yaml`, the CLI was dropping the root-level `provider:` and falling back to defaults. The dict form worked; the string form didn't. Surprising and undocumented.

## Fix

Resolve `provider` from the root config when `model` is a string, matching the dict-form behaviour.

## Test

Regression test added in `tests/cli/test_cli_init.py`.

## Risk

Tiny. One narrow branch in `cli.py`.