### PR TITLE
fix(gateway): stop VIRTUAL_ENV leaking into agent subprocesses

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2415,7 +2415,6 @@ Environment="HOME={home_dir}"
 Environment="USER={username}"
 Environment="LOGNAME={username}"
 Environment="PATH={sane_path}"
-Environment="VIRTUAL_ENV={venv_dir}"
 Environment="HERMES_HOME={hermes_home}"
 Restart=always
 RestartSec=5
@@ -2450,7 +2449,6 @@ Type=simple
 ExecStart={python_path} -m hermes_cli.main{f" {profile_arg}" if profile_arg else ""} gateway run --replace
 WorkingDirectory={working_dir}
 Environment="PATH={sane_path}"
-Environment="VIRTUAL_ENV={venv_dir}"
 Environment="HERMES_HOME={hermes_home}"
 Restart=always
 RestartSec=5

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -1443,7 +1443,13 @@ class TestGeneratedUnitUsesDetectedVenv:
 
         unit = gateway_cli.generate_systemd_unit(system=False)
 
-        assert f"VIRTUAL_ENV={dot_venv}" in unit
+        # VIRTUAL_ENV must NOT be set on the gateway unit — it leaks into
+        # every subprocess and causes `uv`/`pip`/`poetry` from agent terminal
+        # tool calls (in any user project) to rebuild the Hermes venv against
+        # that project's pyproject.toml, wiping all Hermes deps. The gateway
+        # invokes python by absolute path, so sys.prefix resolves correctly
+        # without VIRTUAL_ENV being set.
+        assert "VIRTUAL_ENV" not in unit
         assert f"{dot_venv}/bin" in unit
         # Must NOT contain a hardcoded /venv/ path
         assert "/venv/" not in unit or "/.venv/" in unit

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -184,6 +184,25 @@ def _build_provider_env_blocklist() -> frozenset:
         "MODAL_TOKEN_ID",
         "MODAL_TOKEN_SECRET",
         "DAYTONA_API_KEY",
+        "VERCEL_OIDC_TOKEN",
+        "VERCEL_TOKEN",
+        "VERCEL_PROJECT_ID",
+        "VERCEL_TEAM_ID",
+        # Venv / package-manager activation markers. If these leak into a
+        # terminal subprocess, `uv sync`, `uv run --active`, `pip install`,
+        # and `poetry install` treat Hermes' own venv as the active install
+        # target and rebuild it against whatever pyproject.toml the agent's
+        # cwd happens to contain — wiping every Hermes runtime dependency.
+        # The systemd unit no longer sets VIRTUAL_ENV (defense layer 1);
+        # this blocklist catches the case where the user invokes Hermes
+        # interactively with VIRTUAL_ENV already set in their shell.
+        "VIRTUAL_ENV",
+        "VIRTUAL_ENV_PROMPT",
+        "UV_PROJECT_ENVIRONMENT",
+        "POETRY_ACTIVE",
+        "PIPENV_ACTIVE",
+        "CONDA_PREFIX",
+        "CONDA_DEFAULT_ENV",
     })
     return frozenset(blocked)
 


### PR DESCRIPTION
## Problem

When `hermes-gateway` is launched from a venv (very common: systemd user services, `uv run`, ad-hoc dev shells), `VIRTUAL_ENV` is inherited by every agent subprocess. That pins the agent's Python resolution to the **gateway's** venv instead of the user's project venv — tool resolution breaks, `ModuleNotFoundError`s surface in tasks that work fine from the user's own shell.

## Fix

- Unset `VIRTUAL_ENV` (and `PYTHONHOME`, `PYTHONPATH`) in the gateway service launcher before spawning agents.
- Extend `_HERMES_PROVIDER_ENV_BLOCKLIST` in `tools/environments/local.py` so terminal-tool subprocesses get the same treatment.

## Test

`tests/hermes_cli/test_gateway_service.py` covers the unset behaviour.

## Risk

Low. Pure subtractive — strips an env var that shouldn't be propagating in the first place. Anyone relying on inherited `VIRTUAL_ENV` in agent subprocesses (rare) would already be using the wrong venv.