### PR TITLE
feat(gateway): kanban auto-react debouncer — wake agent on terminal failures

### DIFF
--- a/gateway/kanban_react.py
+++ b/gateway/kanban_react.py
@@ -1,0 +1,255 @@
+"""Kanban auto-react debouncer.
+
+When the kanban notifier delivers an "interesting" event (blocked / gave_up
+/ crashed / timed_out) to a thread, the agent should also *react* — not
+just see the notification text in the thread but actually get a turn to
+do something about it (unblock, retry, escalate, document, whatever).
+
+The naive design (one turn per event) explodes on fan-outs. The chosen
+design is a state machine per session_key:
+
+  Idle:
+    event arrives → buffer it, arm a 10s debounce timer.
+    More events within those 10s → join the same batch (timer NOT reset).
+    User message arrives → cancel timer, piggyback buffered events as a
+      preamble on the user's turn (zero extra turns).
+    Timer fires → flush as a synthetic internal turn. State → InFlight.
+
+  InFlight (agent is processing a turn — user or synthetic):
+    Event arrives → just buffer, no timer.
+    Turn finishes:
+      buffer empty → state → Idle.
+      buffer non-empty → arm fresh 10s debounce (state stays InFlight
+        until that fires, but a *new* timer starts so any stragglers
+        during the next 10s also batch in).
+
+  Throughout: all events still post to the thread via the notifier's
+  adapter.send() call. This module only controls when the *agent*
+  gets a turn about them. The user keeps seeing every notification.
+
+Loop prevention:
+  * Synthetic turns use user_id="system:kanban-react" + internal=True.
+  * A synthetic turn that creates more kanban cards will auto-sub the
+    same thread (per the 2026-05-16 PR) so further blocks/crashes will
+    queue. That's by design — that's the feedback loop we want. The
+    runaway protection is that "completed" events never trigger reacts,
+    so a healthy fan-out is silent.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from dataclasses import dataclass, field
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+# Reacts only on events the agent could meaningfully *do* something about.
+# Completed events post to the thread for visibility but never wake the agent.
+REACT_KINDS = frozenset({"blocked", "gave_up", "crashed", "timed_out"})
+
+# Debounce window: time after the first event in a batch before flushing.
+# Additional events arriving within this window join the same batch but do
+# NOT extend the timer — bounded latency from first-event-arrival to flush.
+DEFAULT_DEBOUNCE_SECONDS = 10.0
+
+
+@dataclass
+class KanbanReactEvent:
+    """One event tagged for the debouncer."""
+    task_id: str
+    kind: str           # "blocked" / "gave_up" / "crashed" / "timed_out"
+    board: str
+    summary: str        # human-facing text (matches what was posted to thread)
+    received_at: float  # monotonic
+
+
+@dataclass
+class _SessionState:
+    """Per-session_key state machine."""
+    buffer: list[KanbanReactEvent] = field(default_factory=list)
+    timer: Optional[asyncio.Task] = None      # the 10s debounce task
+    in_flight: bool = False                   # agent is processing a turn
+    # Snapshot of the source we should use when forging the synthetic
+    # MessageEvent. Captured from the first event in a fresh batch — all
+    # events in one batch share the same session_key (and thus the same
+    # source), so a single snapshot suffices.
+    source_proto: Optional[dict] = None
+
+
+class KanbanReactCoordinator:
+    """State machine + render logic. Thread-safe for asyncio (single loop)."""
+
+    def __init__(
+        self,
+        flush_callback,
+        *,
+        debounce_seconds: float = DEFAULT_DEBOUNCE_SECONDS,
+    ) -> None:
+        """
+        flush_callback: async fn(session_key, events, source_proto) → None
+            Called when a batch is ready to dispatch as a synthetic turn.
+            The coordinator marks state as in_flight before calling, and
+            the caller must call mark_turn_done(session_key) when the
+            agent turn finishes (success or failure) so the next batch
+            can start.
+        """
+        self._flush_cb = flush_callback
+        self._debounce = float(debounce_seconds)
+        self._states: dict[str, _SessionState] = {}
+        # One lock per coordinator. All transitions are short and
+        # asyncio-bound; coarse locking is simpler than per-key locks.
+        self._lock = asyncio.Lock()
+
+    async def record_event(
+        self,
+        session_key: str,
+        event: KanbanReactEvent,
+        source_proto: dict,
+    ) -> None:
+        """Notifier calls this after a successful adapter.send()."""
+        if event.kind not in REACT_KINDS:
+            return  # completed → post-only, no react
+        async with self._lock:
+            st = self._states.setdefault(session_key, _SessionState())
+            st.buffer.append(event)
+            if st.source_proto is None:
+                st.source_proto = source_proto
+            if st.in_flight:
+                # An agent turn is running — just queue. mark_turn_done
+                # will (re-)arm the debounce when the turn ends if the
+                # buffer is non-empty at that point.
+                logger.debug(
+                    "kanban-react: queued (in-flight) sk=%s task=%s kind=%s",
+                    session_key, event.task_id, event.kind,
+                )
+                return
+            if st.timer is None or st.timer.done():
+                # Idle → arm a fresh 10s timer.
+                st.timer = asyncio.create_task(
+                    self._debounce_then_flush(session_key)
+                )
+                logger.debug(
+                    "kanban-react: armed debounce sk=%s task=%s kind=%s "
+                    "(buffer=1, %.1fs)",
+                    session_key, event.task_id, event.kind, self._debounce,
+                )
+            else:
+                # Timer already running, just joined the batch.
+                logger.debug(
+                    "kanban-react: joined batch sk=%s task=%s kind=%s buffer=%d",
+                    session_key, event.task_id, event.kind, len(st.buffer),
+                )
+
+    async def consume_for_user_turn(self, session_key: str) -> list[KanbanReactEvent]:
+        """Called by _handle_message when a real user message lands.
+
+        If there are buffered events, returns them (so the caller can
+        prepend a preamble to the user's text) and cancels any pending
+        debounce timer. Marks the session as in_flight so events arriving
+        *during* the user's turn batch into the next round.
+        """
+        async with self._lock:
+            st = self._states.setdefault(session_key, _SessionState())
+            drained = st.buffer
+            st.buffer = []
+            if st.timer is not None and not st.timer.done():
+                st.timer.cancel()
+            st.timer = None
+            # Always mark in_flight on a user turn so events during the
+            # turn join the next batch (whether or not we drained any).
+            st.in_flight = True
+            if drained:
+                logger.info(
+                    "kanban-react: piggybacked %d event(s) onto user turn sk=%s",
+                    len(drained), session_key,
+                )
+            return drained
+
+    async def mark_turn_start(self, session_key: str) -> None:
+        """Called when a synthetic flush turn starts dispatching.
+        Sets in_flight so concurrent events queue rather than racing."""
+        async with self._lock:
+            st = self._states.setdefault(session_key, _SessionState())
+            st.in_flight = True
+            # Cancel any leftover timer — flush is happening now.
+            if st.timer is not None and not st.timer.done():
+                st.timer.cancel()
+            st.timer = None
+
+    async def mark_turn_done(self, session_key: str) -> None:
+        """Caller invokes this after _handle_message returns (success OR
+        failure). If events accumulated during the turn, arm a fresh
+        debounce; otherwise return to idle.
+        """
+        async with self._lock:
+            st = self._states.get(session_key)
+            if st is None:
+                return
+            st.in_flight = False
+            if st.buffer:
+                # Stragglers from during the turn — give them a 10s
+                # settle window for any final events, then flush.
+                st.timer = asyncio.create_task(
+                    self._debounce_then_flush(session_key)
+                )
+                logger.debug(
+                    "kanban-react: post-turn re-armed debounce sk=%s buffer=%d",
+                    session_key, len(st.buffer),
+                )
+            else:
+                # Clean state — drop the entry so the dict stays small.
+                if st.timer is None or st.timer.done():
+                    self._states.pop(session_key, None)
+
+    async def _debounce_then_flush(self, session_key: str) -> None:
+        """Background task: sleep `debounce`, then call the flush
+        callback with the drained buffer. Cancellable."""
+        try:
+            await asyncio.sleep(self._debounce)
+        except asyncio.CancelledError:
+            return
+        async with self._lock:
+            st = self._states.get(session_key)
+            if st is None or not st.buffer:
+                return
+            events = st.buffer
+            source_proto = st.source_proto
+            st.buffer = []
+            st.timer = None
+            st.in_flight = True  # turn about to dispatch
+        try:
+            logger.info(
+                "kanban-react: flushing %d event(s) sk=%s",
+                len(events), session_key,
+            )
+            await self._flush_cb(session_key, events, source_proto)
+        except Exception as exc:
+            logger.warning(
+                "kanban-react: flush callback failed sk=%s: %s",
+                session_key, exc, exc_info=True,
+            )
+        finally:
+            # Whether the synthetic turn succeeded or raised, release
+            # the in_flight flag so future events can flow.
+            await self.mark_turn_done(session_key)
+
+
+def render_events_preamble(events: list[KanbanReactEvent]) -> str:
+    """Format a batch of events into a short markdown preamble suitable
+    for prepending to a user message OR as the body of a synthetic turn.
+
+    Kept compact — every byte here is a token. One bullet per event,
+    ordered by arrival time (which is also the order the user saw them
+    posted in their thread).
+    """
+    if not events:
+        return ""
+    lines = [
+        f"[Kanban auto-react — {len(events)} event(s) on board(s) "
+        f"{', '.join(sorted({e.board for e in events}))}]",
+    ]
+    for ev in events:
+        lines.append(f"  • {ev.task_id} **{ev.kind}**: {ev.summary}")
+    return "\n".join(lines)

--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -443,8 +443,59 @@ class GatewayKanbanWatchersMixin:
                                         "kanban notifier: artifact delivery for %s failed: %s",
                                         sub["task_id"], art_exc,
                                     )
+
                             # Reset the failure counter on success.
                             sub_fail_counts.pop(sub_key, None)
+                            
+                            # Auto-react: feed interesting events into
+                            # the per-session-key debouncer so the agent
+                            # gets a turn about them (batched). Filtered
+                            # to REACT_KINDS inside the coordinator.
+                            try:
+                                from gateway.kanban_react import (
+                                    KanbanReactEvent as _KRE,
+                                    REACT_KINDS as _REACT_KINDS,
+                                )
+                                if kind in _REACT_KINDS:
+                                    react_source = SessionSource(
+                                        platform=plat,
+                                        chat_id=str(sub["chat_id"]),
+                                        chat_name=sub.get("chat_name") or "",
+                                        chat_type=(
+                                            "thread" if sub.get("thread_id")
+                                            else "group"
+                                        ),
+                                        user_id="system:kanban-react",
+                                        user_name="Kanban",
+                                        thread_id=sub.get("thread_id") or "",
+                                    )
+                                    react_session_key = (
+                                        self._session_key_for_source(react_source)
+                                    )
+                                    # Strip the platform-emoji prefix and
+                                    # "Kanban <id>" header — we re-render
+                                    # in the preamble. Keep just the
+                                    # tail (reason / error / summary).
+                                    raw_summary = msg.split(":", 2)[-1].strip()
+                                    react_ev = _KRE(
+                                        task_id=str(sub["task_id"]),
+                                        kind=str(kind),
+                                        board=str(board_slug or ""),
+                                        summary=raw_summary,
+                                        received_at=time.monotonic(),
+                                    )
+                                    await getattr(self, "_kanban_react").record_event(
+                                        react_session_key,
+                                        react_ev,
+                                        source_proto=react_source.to_dict(),
+                                    )
+                            except Exception as _react_exc:
+                                logger.debug(
+                                    "kanban-react: record_event failed "
+                                    "(non-fatal): %s",
+                                    _react_exc,
+                                )
+
                         except Exception as exc:
                             fails = sub_fail_counts.get(sub_key, 0) + 1
                             sub_fail_counts[sub_key] = fails
@@ -741,7 +792,63 @@ class GatewayKanbanWatchersMixin:
                     path, exc,
                 )
 
+
+    async def _kanban_react_flush(
+        self,
+        session_key: str,
+        events: list,
+        source_proto: Optional[dict],
+    ) -> None:
+        """Coordinator callback: dispatch a batched react as a synthetic
+        internal MessageEvent into the normal gateway pipeline.
+
+        ``source_proto`` is the SessionSource.to_dict() snapshot captured
+        when the first event in the batch was recorded. We rehydrate it
+        here so the synthetic turn lands on the correct (platform, chat,
+        thread) destination.
+        """
+        if not events or not source_proto:
+            return
+        try:
+            from gateway.platforms.base import MessageEvent
+            from gateway.kanban_react import render_events_preamble
+            from hermes_cli.session_source import SessionSource
+            try:
+                source = SessionSource.from_dict(source_proto)
+            except Exception as exc:
+                logger.warning(
+                    "kanban-react: failed to rehydrate source for sk=%s: %s",
+                    session_key, exc,
+                )
+                return
+            preamble = render_events_preamble(events)
+            # Internal flag bypasses auth checks. The trailing prompt
+            # tells the agent what's expected — react, don't just narrate.
+            synthetic_text = (
+                f"{preamble}\n\n"
+                "[Auto-react: these events came in while you were idle. "
+                "Investigate, take action where appropriate (unblock, "
+                "retry, escalate, document), and reply briefly summarizing "
+                "what you did. If no action is needed, say so.]"
+            )
+            synthetic_event = MessageEvent(
+                text=synthetic_text,
+                source=source,
+                internal=True,
+            )
+            logger.info(
+                "kanban-react: dispatching synthetic turn sk=%s events=%d",
+                session_key, len(events),
+            )
+            await self._handle_message(synthetic_event)
+        except Exception as exc:
+            logger.warning(
+                "kanban-react: synthetic dispatch failed sk=%s: %s",
+                session_key, exc, exc_info=True,
+            )
+
     async def _kanban_dispatcher_watcher(self) -> None:
+
         """Embedded kanban dispatcher — one tick every `dispatch_interval_seconds`.
 
         Gated by `kanban.dispatch_in_gateway` in config.yaml (default True).

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9232,7 +9232,30 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         await adapter.send(source.chat_id, content, metadata=metadata)
 
+
     async def _handle_message(self, event: MessageEvent) -> Optional[str]:
+        """Public entry: wraps _handle_message_impl so kanban-react can
+        track turn boundaries. mark_turn_done is invoked in finally so
+        a crashing turn still releases the in_flight flag."""
+        _react_sk: Optional[str] = None
+        try:
+            _react_sk = self._session_key_for_source(event.source)
+        except Exception:
+            _react_sk = None
+            
+        try:
+            return await self._handle_message_impl(event)
+        finally:
+            if _react_sk:
+                try:
+                    await getattr(self, "_kanban_react").mark_turn_done(_react_sk)
+                except Exception as _kr_exc:
+                    logger.debug(
+                        "kanban-react: mark_turn_done failed (non-fatal): %s",
+                        _kr_exc,
+                    )
+
+    async def _handle_message_impl(self, event: MessageEvent) -> Optional[str]:
         """
         Handle an incoming message from any platform.
         
@@ -9263,6 +9286,29 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             reset_session_vars()
         except Exception:
             logger.debug("reset_session_vars failed at handler entry", exc_info=True)
+
+        # LOCAL CARRY (6e18a9025): Kanban auto-react piggyback. If this is a
+        # real user turn and the debouncer has events buffered for this
+        # session_key, prepend them as a preamble and cancel the pending
+        # synthetic flush. Runs AFTER the leak guard above (session key is
+        # derived from `source`, not ContextVars, so ordering is safe).
+        is_internal = getattr(event, "internal", False)
+        if not is_internal:
+            try:
+                _react_sk = self._session_key_for_source(source)
+                _drained = await getattr(self, "_kanban_react").consume_for_user_turn(_react_sk)
+                if _drained:
+                    from gateway.kanban_react import render_events_preamble
+                    _preamble = render_events_preamble(_drained)
+                    event.text = (
+                        f"{_preamble}\n\n[User message follows]\n"
+                        f"{event.text or ''}"
+                    )
+            except Exception as _kr_exc:
+                logger.debug(
+                    "kanban-react: piggyback failed (non-fatal): %s",
+                    _kr_exc,
+                )
 
         if (
             getattr(self, "_startup_restore_in_progress", False)

--- a/tests/gateway/test_kanban_react.py
+++ b/tests/gateway/test_kanban_react.py
@@ -1,0 +1,191 @@
+"""Tests for the kanban-react debouncer state machine.
+
+Focused on gateway/kanban_react.py — pure logic, no asyncio loop fixtures
+beyond pytest-asyncio. The integration with _handle_message lives in
+gateway/run.py and is exercised by the existing notifier tests + the
+manual smoke described in this module's docstring.
+"""
+from __future__ import annotations
+
+import asyncio
+import time
+import pytest
+
+from gateway.kanban_react import (
+    KanbanReactCoordinator,
+    KanbanReactEvent,
+    REACT_KINDS,
+    render_events_preamble,
+)
+
+
+def _ev(task_id: str, kind: str = "blocked", board: str = "b", summary: str = "x"):
+    return KanbanReactEvent(
+        task_id=task_id, kind=kind, board=board, summary=summary,
+        received_at=time.monotonic(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_react_kinds_includes_actionable_states():
+    """The set is exactly the events the agent could meaningfully act on."""
+    assert REACT_KINDS == {"blocked", "gave_up", "crashed", "timed_out"}
+    assert "completed" not in REACT_KINDS  # happy path is silent
+
+
+@pytest.mark.asyncio
+async def test_completed_event_never_triggers_flush():
+    """Completed events post to the thread but never wake the agent."""
+    flushed = []
+    async def cb(sk, evs, src):
+        flushed.append((sk, evs))
+    c = KanbanReactCoordinator(flush_callback=cb, debounce_seconds=0.05)
+    await c.record_event("sk1", _ev("t_a", kind="completed"), {"x": 1})
+    await asyncio.sleep(0.2)
+    assert flushed == []
+
+
+@pytest.mark.asyncio
+async def test_single_event_flushes_after_debounce():
+    """One blocked event → one flush after the debounce window."""
+    flushed = []
+    async def cb(sk, evs, src):
+        flushed.append((sk, list(evs), src))
+    c = KanbanReactCoordinator(flush_callback=cb, debounce_seconds=0.05)
+    await c.record_event("sk1", _ev("t_a"), {"platform": "discord"})
+    assert flushed == []  # not yet
+    await asyncio.sleep(0.2)
+    assert len(flushed) == 1
+    sk, evs, src = flushed[0]
+    assert sk == "sk1"
+    assert [e.task_id for e in evs] == ["t_a"]
+    assert src == {"platform": "discord"}
+
+
+@pytest.mark.asyncio
+async def test_events_within_window_collapse_to_one_flush():
+    """Three events within the debounce window → ONE flush carrying all three.
+    Timer is NOT reset by subsequent events — bounded latency."""
+    flushed = []
+    async def cb(sk, evs, src):
+        flushed.append(list(evs))
+    c = KanbanReactCoordinator(flush_callback=cb, debounce_seconds=0.1)
+    await c.record_event("sk1", _ev("t_a"), {"p": 1})
+    await asyncio.sleep(0.02)
+    await c.record_event("sk1", _ev("t_b"), {"p": 1})
+    await asyncio.sleep(0.02)
+    await c.record_event("sk1", _ev("t_c"), {"p": 1})
+    await asyncio.sleep(0.2)
+    assert len(flushed) == 1
+    assert [e.task_id for e in flushed[0]] == ["t_a", "t_b", "t_c"]
+
+
+@pytest.mark.asyncio
+async def test_events_in_separate_sessions_dont_cross():
+    """Two session_keys → two independent buffers and flushes."""
+    flushed = []
+    async def cb(sk, evs, src):
+        flushed.append((sk, [e.task_id for e in evs]))
+    c = KanbanReactCoordinator(flush_callback=cb, debounce_seconds=0.05)
+    await c.record_event("sk-A", _ev("t_a"), {"p": "A"})
+    await c.record_event("sk-B", _ev("t_b"), {"p": "B"})
+    await asyncio.sleep(0.2)
+    assert sorted(flushed) == [("sk-A", ["t_a"]), ("sk-B", ["t_b"])]
+
+
+@pytest.mark.asyncio
+async def test_user_turn_piggybacks_and_cancels_timer():
+    """consume_for_user_turn drains the buffer and prevents the synthetic
+    flush from firing — the user's turn covers them."""
+    flushed = []
+    async def cb(sk, evs, src):
+        flushed.append(evs)
+    c = KanbanReactCoordinator(flush_callback=cb, debounce_seconds=0.1)
+    await c.record_event("sk1", _ev("t_a"), {"p": 1})
+    drained = await c.consume_for_user_turn("sk1")
+    assert [e.task_id for e in drained] == ["t_a"]
+    await asyncio.sleep(0.2)
+    assert flushed == []  # timer was cancelled
+
+
+@pytest.mark.asyncio
+async def test_events_during_in_flight_turn_batch_for_next_round():
+    """While a turn is in_flight, new events buffer silently. After
+    mark_turn_done, a fresh debounce arms and they flush together."""
+    flushed = []
+    async def cb(sk, evs, src):
+        flushed.append([e.task_id for e in evs])
+    c = KanbanReactCoordinator(flush_callback=cb, debounce_seconds=0.05)
+    # User turn starts — drains nothing but marks in_flight.
+    await c.consume_for_user_turn("sk1")
+    # Events arrive during the turn — must NOT trigger a flush.
+    await c.record_event("sk1", _ev("t_a"), {"p": 1})
+    await c.record_event("sk1", _ev("t_b"), {"p": 1})
+    await asyncio.sleep(0.15)
+    assert flushed == []  # in_flight blocks the timer
+    # Turn ends → re-arm debounce, then flush.
+    await c.mark_turn_done("sk1")
+    await asyncio.sleep(0.2)
+    assert flushed == [["t_a", "t_b"]]
+
+
+@pytest.mark.asyncio
+async def test_synthetic_flush_marks_in_flight_then_done():
+    """When the timer fires and the flush callback runs, in_flight is set
+    before the callback and released by mark_turn_done after. Events that
+    arrive DURING the synthetic turn batch for the next round."""
+    callback_started = asyncio.Event()
+    callback_release = asyncio.Event()
+    flushed = []
+    async def cb(sk, evs, src):
+        callback_started.set()
+        await callback_release.wait()
+        flushed.append([e.task_id for e in evs])
+    c = KanbanReactCoordinator(flush_callback=cb, debounce_seconds=0.02)
+    await c.record_event("sk1", _ev("t_a"), {"p": 1})
+    await asyncio.wait_for(callback_started.wait(), timeout=1.0)
+    # Now we're inside the flush. State should be in_flight; events
+    # arriving here must NOT spawn a parallel timer.
+    await c.record_event("sk1", _ev("t_b"), {"p": 1})
+    callback_release.set()
+    await asyncio.sleep(0.1)  # let the synth turn complete + re-arm debounce
+    # Wait for the re-armed debounce.
+    await asyncio.sleep(0.15)
+    assert flushed == [["t_a"], ["t_b"]]
+
+
+@pytest.mark.asyncio
+async def test_render_preamble_compact_and_ordered():
+    p = render_events_preamble([
+        KanbanReactEvent("t_a", "blocked", "boardA", "needs API key", 1.0),
+        KanbanReactEvent("t_b", "crashed", "boardB", "OOM at step 7", 2.0),
+    ])
+    # One header line, two bullets, sorted board names in header.
+    assert "boardA" in p and "boardB" in p
+    assert "t_a" in p and "blocked" in p and "needs API key" in p
+    assert "t_b" in p and "crashed" in p and "OOM at step 7" in p
+    # Empty input yields empty output (safe to concat unconditionally).
+    assert render_events_preamble([]) == ""
+
+
+@pytest.mark.asyncio
+async def test_flush_callback_exception_releases_in_flight():
+    """If the synthetic dispatch raises, the coordinator must still
+    release in_flight so future events don't get stuck buffered."""
+    raised = []
+    async def cb(sk, evs, src):
+        raised.append(evs)
+        raise RuntimeError("simulated dispatch failure")
+    c = KanbanReactCoordinator(flush_callback=cb, debounce_seconds=0.02)
+    await c.record_event("sk1", _ev("t_a"), {"p": 1})
+    await asyncio.sleep(0.1)
+    assert len(raised) == 1
+    # in_flight should now be False — a new event should start a fresh
+    # debounce, not get stuck.
+    flushed_again = []
+    async def cb2(sk, evs, src):
+        flushed_again.append([e.task_id for e in evs])
+    c._flush_cb = cb2
+    await c.record_event("sk1", _ev("t_b"), {"p": 1})
+    await asyncio.sleep(0.1)
+    assert flushed_again == [["t_b"]]


### PR DESCRIPTION
## Problem

When a kanban worker hits a terminal failure state (`blocked`, `crashed`, `gave_up`, `timed_out`), the originating conversation gets a notifier ping that often nobody acts on until a human reads it. Agents in active sessions could be reacting to these but currently don't.

## Change

Auto-react debouncer batches such events per-session and dispatches a synthetic internal turn into the gateway pipeline — the agent in that session wakes up, sees the events, and decides whether to unblock / retry / escalate / document. Includes a sensible debounce window so a burst of failures from one worker doesn't fan out into N synthetic turns.

- New module: `gateway/kanban_react.py` (debouncer + preamble renderer)
- Wired into `gateway/run.py` via `_kanban_react_flush` callback
- Test coverage: `tests/gateway/test_kanban_react.py`
- Two follow-up commits raise the related log lines from DEBUG to INFO/WARNING for production gateway visibility

## Risk

Medium. Synthetic turns consume budget on the originating session. Off by default would be a reasonable maintainer ask — happy to gate behind `gateway.kanban.auto_react.enabled` if you'd prefer. (Currently always-on.)