### PR TITLE
fix: keep Mattermost session activity in threads

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -3679,6 +3679,70 @@ class BasePlatformAdapter(ABC):
         """
         return content
     
+
+    @staticmethod
+    def _is_markdown_table_line(line: str) -> bool:
+        stripped = line.strip()
+        if not stripped.startswith("|") or stripped.count("|") < 2:
+            return False
+        # Separator row: | --- | :---: | ---: |
+        cells = [cell.strip() for cell in stripped.strip("|").split("|")]
+        if cells and all(re.fullmatch(r":?-{3,}:?", cell or "") for cell in cells):
+            return True
+        return True
+
+    @staticmethod
+    def _markdown_safe_split(remaining: str, cp_limit: int) -> int:
+        """Choose a split point that avoids breaking markdown blocks when possible.
+
+        Preference order:
+        1. paragraph boundary,
+        2. line boundary,
+        3. word boundary,
+        4. hard limit.
+
+        If the chosen point lands inside a pipe-table block, move to the start
+        of the table when there is enough room. That keeps normal-sized tables
+        intact instead of splitting header/separator/body across messages.
+        Very large tables still split at row boundaries because no formatter can
+        keep an over-limit table in one platform message.
+        """
+        if cp_limit >= len(remaining):
+            return len(remaining)
+        region = remaining[:cp_limit]
+        split_at = region.rfind("\n\n")
+        if split_at >= cp_limit // 3:
+            return split_at + 2
+        split_at = region.rfind("\n")
+        if split_at < cp_limit // 2:
+            split_at = region.rfind(" ")
+        if split_at < 1:
+            split_at = cp_limit
+
+        # Avoid splitting a contiguous markdown table block.
+        line_starts = []
+        pos = 0
+        for line in remaining.splitlines(keepends=True):
+            line_starts.append((pos, pos + len(line), line))
+            pos += len(line)
+        table_start = table_end = None
+        for idx, (start, end, line) in enumerate(line_starts):
+            if start <= split_at <= end and BasePlatformAdapter._is_markdown_table_line(line):
+                table_start = start
+                table_end = end
+                j = idx - 1
+                while j >= 0 and BasePlatformAdapter._is_markdown_table_line(line_starts[j][2]):
+                    table_start = line_starts[j][0]
+                    j -= 1
+                j = idx + 1
+                while j < len(line_starts) and BasePlatformAdapter._is_markdown_table_line(line_starts[j][2]):
+                    table_end = line_starts[j][1]
+                    j += 1
+                break
+        if table_start is not None and table_start > cp_limit // 4:
+            return table_start
+        return split_at
+
     @staticmethod
     def truncate_message(
         content: str,
@@ -3745,12 +3809,7 @@ class BasePlatformAdapter(ABC):
                 _cp_limit = _custom_unit_to_cp(remaining, headroom, _len)
             else:
                 _cp_limit = headroom
-            region = remaining[:_cp_limit]
-            split_at = region.rfind("\n")
-            if split_at < _cp_limit // 2:
-                split_at = region.rfind(" ")
-            if split_at < 1:
-                split_at = _cp_limit
+            split_at = BasePlatformAdapter._markdown_safe_split(remaining, _cp_limit)
 
             # Avoid splitting inside an inline code span (`...`).
             # If the text before split_at has an odd number of unescaped

--- a/gateway/platforms/mattermost.py
+++ b/gateway/platforms/mattermost.py
@@ -280,18 +280,24 @@ class MattermostAdapter(BasePlatformAdapter):
         formatted = self.format_message(content)
         chunks = self.truncate_message(formatted, MAX_POST_LENGTH)
 
+        thread_root = None
+        if self._reply_mode == "thread":
+            if reply_to:
+                thread_root = await self._resolve_root_id(reply_to)
+            elif metadata:
+                meta_thread = metadata.get("thread_id")
+                if meta_thread:
+                    thread_root = str(meta_thread)
+
         last_id = None
         for chunk in chunks:
             payload: Dict[str, Any] = {
                 "channel_id": chat_id,
                 "message": chunk,
             }
-            # Thread support: reply_to is the root post ID.
-            if reply_to and self._reply_mode == "thread":
-                # Ensure root_id points to the thread root, not a reply.
-                # Mattermost rejects non-root post IDs as root_id.
-                resolved_root = await self._resolve_root_id(reply_to)
-                payload["root_id"] = resolved_root
+            # Thread support: root_id must point to the thread root.
+            if thread_root:
+                payload["root_id"] = thread_root
 
             data = await self._api_post("posts", payload)
             if not data or "id" not in data:
@@ -786,8 +792,11 @@ class MattermostAdapter(BasePlatformAdapter):
         sender_id = post.get("user_id", "")
         sender_name = data.get("sender_name", "").lstrip("@") or sender_id
 
-        # Thread support: if the post is in a thread, use root_id.
-        thread_id = post.get("root_id") or None
+        # Thread support: route every channel turn into a Mattermost thread.
+        # Mattermost only sets root_id on replies; for a root post we use the
+        # post's own ID as the session/thread root so tool progress, approvals,
+        # streamed chunks, and final replies all stay under one conversation.
+        thread_id = post.get("root_id") or post_id or None
 
         # Determine message type.
         file_ids = post.get("file_ids") or []

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -514,9 +514,9 @@ class GatewayStreamConsumer:
                         _cp_budget = _custom_unit_to_cp(
                             self._accumulated, _safe_limit, _len_fn,
                         )
-                        split_at = self._accumulated.rfind("\n", 0, _cp_budget)
-                        if split_at < _safe_limit // 2:
-                            split_at = _safe_limit
+                        split_at = _BasePlatformAdapter._markdown_safe_split(
+                            self._accumulated, _cp_budget,
+                        )
                         chunk = self._accumulated[:split_at]
                         ok = await self._send_or_edit(chunk)
                         if self._fallback_final_send or not ok:
@@ -721,9 +721,7 @@ class GatewayStreamConsumer:
         remaining = text
         while len_fn(remaining) > limit:
             _cp_budget = _custom_unit_to_cp(remaining, limit, len_fn)
-            split_at = remaining.rfind("\n", 0, _cp_budget)
-            if split_at < limit // 2:
-                split_at = limit
+            split_at = _BasePlatformAdapter._markdown_safe_split(remaining, _cp_budget)
             chunks.append(remaining[:split_at])
             remaining = remaining[split_at:].lstrip("\n")
         if remaining:

--- a/tests/gateway/test_mattermost.py
+++ b/tests/gateway/test_mattermost.py
@@ -75,7 +75,7 @@ def _make_adapter():
     config = PlatformConfig(
         enabled=True,
         token="test-token",
-        extra={"url": "https://mm.example.com"},
+        extra={"url": "https://mm.example.com", "allowed_channels": []},
     )
     adapter = MattermostAdapter(config)
     return adapter
@@ -143,6 +143,16 @@ class TestMattermostTruncateMessage:
         msg = "x" * 4000
         chunks = self.adapter.truncate_message(msg, 4000)
         assert len(chunks) == 1
+
+    def test_table_block_not_split_when_it_can_fit_next_message(self):
+        intro = "Intro paragraph.\n\n"
+        table = "| A | B |\n| --- | --- |\n| 1 | 2 |\n| 3 | 4 |"
+        tail = "\n\n" + ("tail " * 20)
+        chunks = self.adapter.truncate_message(intro + table + tail, max_length=65)
+        assert len(chunks) > 1
+        assert chunks[0].startswith("Intro paragraph.")
+        assert "| A | B |" not in chunks[0]
+        assert "| A | B |" in chunks[1]
 
 
 # ---------------------------------------------------------------------------
@@ -236,6 +246,28 @@ class TestMattermostSend:
         assert result.success is True
         payload = self.adapter._session.post.call_args[1]["json"]
         assert "root_id" not in payload
+
+    @pytest.mark.asyncio
+    async def test_send_uses_metadata_thread_id_when_no_reply_to(self):
+        """Thread metadata should route sends even when reply_to is absent."""
+        self.adapter._reply_mode = "thread"
+
+        mock_resp = AsyncMock()
+        mock_resp.status = 200
+        mock_resp.json = AsyncMock(return_value={"id": "post_meta"})
+        mock_resp.text = AsyncMock(return_value="")
+        mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
+        mock_resp.__aexit__ = AsyncMock(return_value=False)
+
+        self.adapter._session.post = MagicMock(return_value=mock_resp)
+
+        result = await self.adapter.send(
+            "channel_1", "Metadata reply", metadata={"thread_id": "root_from_meta"}
+        )
+
+        assert result.success is True
+        payload = self.adapter._session.post.call_args[1]["json"]
+        assert payload["root_id"] == "root_from_meta"
 
     @pytest.mark.asyncio
     async def test_send_api_failure(self):
@@ -365,6 +397,29 @@ class TestMattermostWebSocketParsing:
         assert self.adapter.handle_message.called
         msg_event = self.adapter.handle_message.call_args[0][0]
         assert msg_event.source.chat_type == "dm"
+
+    @pytest.mark.asyncio
+    async def test_root_channel_post_uses_own_id_as_thread_id(self):
+        """Root channel posts should become their own Mattermost thread root."""
+        post_data = {
+            "id": "root_post_abc",
+            "user_id": "user_123",
+            "channel_id": "chan_456",
+            "message": "@bot_user_id Start a session",
+        }
+        event = {
+            "event": "posted",
+            "data": {
+                "post": json.dumps(post_data),
+                "channel_type": "O",
+                "sender_name": "@alice",
+            },
+        }
+
+        await self.adapter._handle_ws_event(event)
+        assert self.adapter.handle_message.called
+        msg_event = self.adapter.handle_message.call_args[0][0]
+        assert msg_event.source.thread_id == "root_post_abc"
 
     @pytest.mark.asyncio
     async def test_thread_id_from_root_id(self):


### PR DESCRIPTION
## Summary
- route root Mattermost channel posts into their own thread-backed session
- honor Mattermost `metadata["thread_id"]` when sending without an explicit `reply_to`
- improve overflow splitting to prefer paragraph/line boundaries and avoid breaking normal-sized markdown tables

## Test plan
- `python -m pytest tests/gateway/test_mattermost.py tests/gateway/test_stream_consumer.py -q -o 'addopts='`\n\n## Notes\nThis keeps tool progress, approval prompts, streamed chunks, and final responses organized under one Mattermost thread per user session.