### PR TITLE
docs: fix Google Workspace CLI link

### DIFF
--- a/website/docs/user-guide/skills/google-workspace.md
+++ b/website/docs/user-guide/skills/google-workspace.md
@@ -7,7 +7,7 @@ description: "Send email, manage calendar events, search Drive, read/write Sheet
 
 # Google Workspace Skill
 
-Gmail, Calendar, Drive, Contacts, Sheets, and Docs integration for Hermes. Uses OAuth2 with automatic token refresh. Prefers the [Google Workspace CLI (`gws`)](https://github.com/nicholasgasior/gws) when available for broader coverage, and falls back to Google's Python client libraries otherwise.
+Gmail, Calendar, Drive, Contacts, Sheets, and Docs integration for Hermes. Uses OAuth2 with automatic token refresh. Prefers the [Google Workspace CLI (`gws`)](https://github.com/googleworkspace/cli) when available for broader coverage, and falls back to Google's Python client libraries otherwise.
 
 **Skill path:** `skills/productivity/google-workspace/`
 


### PR DESCRIPTION
## Summary
- Update the Google Workspace CLI (`gws`) documentation link to the current upstream repository.
- Replace the dead `nicholasgasior/gws` URL with `googleworkspace/cli`.

## Test Plan
- Verified `https://github.com/nicholasgasior/gws` returns 404.
- Verified `https://github.com/googleworkspace/cli` returns 200.

Closes #28922
