### PR TITLE
fix(tui): pass --expose-gc as node argv instead of NODE_OPTIONS

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1152,7 +1152,7 @@ def _make_tui_argv(tui_dir: Path, tui_dev: bool) -> tuple[list[str], Path]:
         bundled = _find_bundled_tui()
         if bundled is not None:
             node = _node_bin("node")
-            return [node, str(bundled)], bundled.parent
+            return [node, "--expose-gc", str(bundled)], bundled.parent
 
     # 2. Normal flow: npm install if needed, always esbuild, then node dist/entry.js.
     #    --dev flow: npm install if needed, then tsx src/entry.tsx.

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1146,7 +1146,7 @@ def _make_tui_argv(tui_dir: Path, tui_dev: bool) -> tuple[list[str], Path]:
             p = Path(ext_dir)
             if (p / "dist" / "entry.js").is_file():
                 node = _node_bin("node")
-                return [node, str(p / "dist" / "entry.js")], p
+                return [node, "--expose-gc", str(p / "dist" / "entry.js")], p
 
         # 1b. Bundled in wheel (pip install)
         bundled = _find_bundled_tui()
@@ -1229,7 +1229,7 @@ def _make_tui_argv(tui_dir: Path, tui_dev: bool) -> tuple[list[str], Path]:
             sys.exit(1)
 
     node = _node_bin("node")
-    return [node, str(tui_dir / "dist" / "entry.js")], tui_dir
+    return [node, "--expose-gc", str(tui_dir / "dist" / "entry.js")], tui_dir
 
 
 def _normalize_tui_toolsets(toolsets: object) -> list[str]:
@@ -1351,16 +1351,16 @@ def _launch_tui(
         env["HERMES_TUI_TOOL_PROGRESS"] = "off"
     if accept_hooks:
         env["HERMES_ACCEPT_HOOKS"] = "1"
-    # Guarantee an 8GB V8 heap + exposed GC for the TUI. Default node cap is
-    # ~1.5–4GB depending on version and can fatal-OOM on long sessions with
-    # large transcripts / reasoning blobs. Token-level merge: respect any
-    # user-supplied --max-old-space-size (they may have set it higher) and
-    # avoid duplicating --expose-gc.
+    # Guarantee an 8GB V8 heap for the TUI. Default node cap is ~1.5–4GB
+    # depending on version and can fatal-OOM on long sessions with large
+    # transcripts / reasoning blobs. Token-level merge: respect any
+    # user-supplied --max-old-space-size (they may have set it higher).
+    # --expose-gc is *not* added here: Node rejects it in NODE_OPTIONS
+    # ("--expose-gc is not allowed in NODE_OPTIONS") and refuses to start.
+    # It is passed as a direct argv flag in _make_tui_argv() instead.
     _tokens = env.get("NODE_OPTIONS", "").split()
     if not any(t.startswith("--max-old-space-size=") for t in _tokens):
         _tokens.append("--max-old-space-size=8192")
-    if "--expose-gc" not in _tokens:
-        _tokens.append("--expose-gc")
     env["NODE_OPTIONS"] = " ".join(_tokens)
     # HERMES_TUI_RESUME is an internal hand-off from the Python wrapper to the
     # Ink app.  Because we start from os.environ.copy(), an exported/stale value

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -48,6 +48,7 @@ AUTHOR_MAP = {
     # teknium (multiple emails)
     "teknium1@gmail.com": "teknium1",
     "me@promplate.dev": "CNSeniorious000",
+    "yichengqiao21@gmail.com": "YarrowQiao",
     "erhanyasarx@gmail.com": "erhnysr",
     "30366221+WorldWriter@users.noreply.github.com": "WorldWriter",
     "dafeng@DafengdeMacBook-Pro.local": "WorldWriter",


### PR DESCRIPTION
Salvage of #21711 by @YarrowQiao onto current main + sibling-site fix.

## Summary
`hermes --tui` fails to start on Node versions that enforce the `NODE_OPTIONS` allowlist:

    /usr/bin/node: --expose-gc is not allowed in NODE_OPTIONS

`--expose-gc` is not in Node's allowlist for `NODE_OPTIONS` (security: env-var-set flags must be safe to inject) and must be passed as a direct CLI flag. The fix moves it from the `NODE_OPTIONS` builder in `_launch_tui()` into the node argv built by `_make_tui_argv()`. `--max-old-space-size=8192` stays in `NODE_OPTIONS` (it *is* allowlisted) so downstream node spawns inherit the heap cap.

## Changes
- `hermes_cli/main.py` — drop `--expose-gc` from `NODE_OPTIONS`, insert it as argv[1] on all three production node-launch paths (ext_dir, wheel-bundled, built tui_dir).
- `scripts/release.py` — map `yichengqiao21@gmail.com` → `YarrowQiao` for changelog attribution.

## Sibling-site fix added during salvage
Original PR covered the `ext_dir` and `tui_dir` paths but missed the pip-wheel path (`bundled`). Without that, wheel installs would have lost `--expose-gc` entirely. Now all three sites are consistent.

## Validation
- Bug confirmed live on `origin/main` before the fix (grep shows `--expose-gc` appended to `NODE_OPTIONS`).
- Reproduced empirically: `NODE_OPTIONS='--expose-gc' node ...` rejected on affected Node builds; `node --expose-gc ...` accepted universally.
- `py_compile` clean.
- Closes #17187 and Discord report.

Credit to @YarrowQiao — original commit preserved via cherry-pick.


## Infographic

![tui-expose-gc-fix](https://v3b.fal.media/files/b/0a9b23e5/dv62RJspEIjUjgvXy6Jhw_nixR0YdV.png)
