### PR TITLE
fix(auxiliary_client): configured fallback_chain is finally exercised at runtime

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -2559,14 +2559,22 @@ def _try_payment_fallback(
     failed_provider: str,
     task: str = None,
     reason: str = "payment error",
-) -> Tuple[Optional[Any], Optional[str], str]:
+) -> Tuple[Optional[Any], Optional[str], str, str]:
     """Try alternative providers after a payment/credit or connection error.
 
     Iterates the standard auto-detection chain, skipping the provider that
     failed.
 
     Returns:
-        (client, model, provider_label) or (None, None, "") if no fallback.
+        (client, model, provider, provider_label) or (None, None, "", "")
+        if no fallback. ``provider`` is the canonical provider identifier
+        consumed by ``_build_call_kwargs``'s routing (e.g. "openrouter",
+        "azure-foundry"); ``provider_label`` is a human-readable string
+        used in logs only. They are kept distinct because ``_build_call_kwargs``
+        routes max_tokens vs max_completion_tokens by exact-string match on
+        provider — a label like ``main-agent(azure-foundry)`` would
+        silently fall through to the default ``max_tokens`` branch,
+        re-introducing Z2O-1623 (Azure 400 on reasoning models).
     """
     # Normalise the failed provider label for matching.
     skip = failed_provider.lower().strip()
@@ -2582,6 +2590,16 @@ def _try_payment_fallback(
                        "custom": "local/custom", "local/custom": "local/custom"}
     skip_chain_labels = {_alias_to_label.get(s, s) for s in skip_labels}
 
+    # Map chain labels back to the canonical provider identifier
+    # ``_build_call_kwargs`` routes on. Most chain keys ARE the provider
+    # ("openrouter", "nous", "openai-codex"), but "local/custom" → "custom":
+    # the chain key is human-friendly, the routing key is bare. Without
+    # this inversion, payment-chain fallbacks to a custom endpoint pointed
+    # at api.openai.com would re-introduce the same class of bug as
+    # Z2O-1623 one frame deeper — emitting max_tokens instead of
+    # max_completion_tokens for reasoning models.
+    _label_to_provider = {"local/custom": "custom"}
+
     tried = []
     for label, try_fn in _get_provider_chain():
         if label in skip_chain_labels:
@@ -2596,21 +2614,22 @@ def _try_payment_fallback(
                 "Auxiliary %s: %s on %s — falling back to %s (%s)",
                 task or "call", reason, failed_provider, label, model or "default",
             )
-            return client, model, label
+            provider = _label_to_provider.get(label, label)
+            return client, model, provider, label
         tried.append(label)
 
     logger.warning(
         "Auxiliary %s: %s on %s and no fallback available (tried: %s)",
         task or "call", reason, failed_provider, ", ".join(tried),
     )
-    return None, None, ""
+    return None, None, "", ""
 
 
 def _try_main_agent_model_fallback(
     failed_provider: str,
     task: str = None,
     reason: str = "error",
-) -> Tuple[Optional[Any], Optional[str], str]:
+) -> Tuple[Optional[Any], Optional[str], str, str]:
     """Last-resort fallback to the user's main agent provider + model.
 
     Used after the configured fallback_chain is exhausted (or empty) for
@@ -2622,20 +2641,23 @@ def _try_main_agent_model_fallback(
     retrying the same backend that just failed).
 
     Returns:
-        (client, model, provider_label) or (None, None, "") if no fallback.
+        (client, model, provider, provider_label) or (None, None, "", "")
+        if no fallback. See ``_try_payment_fallback`` docstring for why the
+        provider identifier is returned separately from the human-readable
+        label.
     """
     main_provider = (_read_main_provider() or "").strip()
     main_model = (_read_main_model() or "").strip()
     if not main_provider or not main_model or main_provider.lower() in {"auto", ""}:
-        return None, None, ""
+        return None, None, "", ""
 
     skip = (failed_provider or "").lower().strip()
     if main_provider.lower() == skip:
         # The thing that failed IS the main model — nothing to fall back to.
-        return None, None, ""
+        return None, None, "", ""
     if _is_provider_unhealthy(main_provider):
         _log_skip_unhealthy(main_provider, task)
-        return None, None, ""
+        return None, None, "", ""
 
     try:
         client, resolved_model = resolve_provider_client(
@@ -2645,21 +2667,21 @@ def _try_main_agent_model_fallback(
         client, resolved_model = None, None
 
     if client is None:
-        return None, None, ""
+        return None, None, "", ""
 
     label = f"main-agent({main_provider})"
     logger.info(
         "Auxiliary %s: %s on %s — falling back to main agent model %s (%s)",
         task or "call", reason, failed_provider, label, resolved_model or main_model,
     )
-    return client, resolved_model or main_model, label
+    return client, resolved_model or main_model, main_provider, label
 
 
 def _try_configured_fallback_chain(
     task: str,
     failed_provider: str,
     reason: str = "error",
-) -> Tuple[Optional[Any], Optional[str], str]:
+) -> Tuple[Optional[Any], Optional[str], str, str]:
     """Try user-configured fallback_chain for a specific auxiliary task.
 
     Reads auxiliary.<task>.fallback_chain from config.yaml and tries each
@@ -2667,15 +2689,22 @@ def _try_configured_fallback_chain(
     ``base_url``, and ``api_key`` are optional.
 
     Returns:
-        (client, model, provider_label) or (None, None, "") if no fallback.
+        (client, model, provider, provider_label) or (None, None, "", "")
+        if no fallback. ``provider`` is the canonical identifier from the
+        chain entry (e.g. "azure-foundry"); ``provider_label`` is a
+        formatted log-only string like ``fallback_chain[0](azure-foundry)``.
+        See ``_try_payment_fallback`` for why these are returned separately
+        — passing the label as the provider to ``_build_call_kwargs`` was
+        Z2O-1623: every chain entry pointed at Azure reasoning models got
+        max_tokens instead of max_completion_tokens and 400'd.
     """
     if not task:
-        return None, None, ""
+        return None, None, "", ""
 
     task_config = _get_auxiliary_task_config(task)
     chain = task_config.get("fallback_chain")
     if not chain or not isinstance(chain, list):
-        return None, None, ""
+        return None, None, "", ""
 
     skip = failed_provider.lower().strip()
     tried = []
@@ -2703,7 +2732,7 @@ def _try_configured_fallback_chain(
                 "Auxiliary %s: %s on %s — configured fallback to %s (%s)",
                 task, reason, failed_provider, label, fb_model or "default",
             )
-            return fb_client, fb_model, label
+            return fb_client, fb_model, fb_provider, label
         tried.append(label)
 
     if tried:
@@ -2711,7 +2740,7 @@ def _try_configured_fallback_chain(
             "Auxiliary %s: configured fallback_chain exhausted (tried: %s)",
             task, ", ".join(tried),
         )
-    return None, None, ""
+    return None, None, "", ""
 
 
 def _resolve_single_provider(
@@ -4751,20 +4780,24 @@ def call_llm(
             # when the user left `provider: auto`, defeating the point of
             # configuring a chain. Now the configured chain is consulted first
             # in BOTH branches.
-            fb_client, fb_model, fb_label = (None, None, "")
-            fb_client, fb_model, fb_label = _try_configured_fallback_chain(
+            # Z2O-1623: _build_call_kwargs routes max_tokens vs
+            # max_completion_tokens by exact-string provider match. Pass
+            # fb_provider (e.g. "azure-foundry") to that arg; reserve
+            # fb_label (e.g. "fallback_chain[0](azure-foundry)") for logs.
+            fb_client, fb_model, fb_provider, fb_label = (None, None, "", "")
+            fb_client, fb_model, fb_provider, fb_label = _try_configured_fallback_chain(
                 task, resolved_provider or "auto", reason=reason)
             if fb_client is None:
                 if is_auto:
-                    fb_client, fb_model, fb_label = _try_payment_fallback(
+                    fb_client, fb_model, fb_provider, fb_label = _try_payment_fallback(
                         resolved_provider, task, reason=reason)
                 else:
-                    fb_client, fb_model, fb_label = _try_main_agent_model_fallback(
+                    fb_client, fb_model, fb_provider, fb_label = _try_main_agent_model_fallback(
                         resolved_provider, task, reason=reason)
 
             if fb_client is not None:
                 fb_kwargs = _build_call_kwargs(
-                    fb_label, fb_model, messages,
+                    fb_provider, fb_model, messages,
                     temperature=temperature, max_tokens=max_tokens,
                     tools=tools, timeout=effective_timeout,
                     extra_body=effective_extra_body,
@@ -5100,21 +5133,22 @@ async def async_call_llm(
 
             # Fallback order (#26882, #26803) — mirrors sync path above:
             # configured fallback_chain first regardless of auto, then auto
-            # chain or main-model.
-            fb_client, fb_model, fb_label = (None, None, "")
-            fb_client, fb_model, fb_label = _try_configured_fallback_chain(
+            # chain or main-model. Z2O-1623: pass fb_provider (not fb_label)
+            # to _build_call_kwargs — see sync branch above.
+            fb_client, fb_model, fb_provider, fb_label = (None, None, "", "")
+            fb_client, fb_model, fb_provider, fb_label = _try_configured_fallback_chain(
                 task, resolved_provider or "auto", reason=reason)
             if fb_client is None:
                 if is_auto:
-                    fb_client, fb_model, fb_label = _try_payment_fallback(
+                    fb_client, fb_model, fb_provider, fb_label = _try_payment_fallback(
                         resolved_provider, task, reason=reason)
                 else:
-                    fb_client, fb_model, fb_label = _try_main_agent_model_fallback(
+                    fb_client, fb_model, fb_provider, fb_label = _try_main_agent_model_fallback(
                         resolved_provider, task, reason=reason)
 
             if fb_client is not None:
                 fb_kwargs = _build_call_kwargs(
-                    fb_label, fb_model, messages,
+                    fb_provider, fb_model, messages,
                     temperature=temperature, max_tokens=max_tokens,
                     tools=tools, timeout=effective_timeout,
                     extra_body=effective_extra_body,

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -202,6 +202,29 @@ def _is_arcee_trinity_thinking(model: Optional[str]) -> bool:
     return bare == "trinity-large-thinking"
 
 
+def _is_reasoning_model(model: Optional[str]) -> bool:
+    """True for OpenAI reasoning model families (gpt-5.x, gpt-4o*, o1/o3/o4).
+
+    These models share two contracts that callers must honour when routed
+    through Azure OpenAI or Azure AI Foundry:
+    * ``max_completion_tokens`` instead of ``max_tokens``
+    * temperature must be the model default (no ``temperature=0.x`` passed)
+
+    Both contracts return HTTP 400 with "Unsupported parameter/value" on
+    Azure when violated. api.openai.com is more forgiving on temperature
+    (accepts any value) but still rejects ``max_tokens``. Callers that
+    need to route on this predicate should also branch on provider.
+    """
+    m = (model or "").lower()
+    return (
+        m.startswith("gpt-5")
+        or m.startswith("gpt-4o")
+        or m.startswith("o1")
+        or m.startswith("o3")
+        or m.startswith("o4")
+    )
+
+
 def _fixed_temperature_for_model(
     model: Optional[str],
     base_url: Optional[str] = None,
@@ -4338,6 +4361,20 @@ def _build_call_kwargs(
         if _forbids_sampling_params(model):
             temperature = None
 
+    # Azure-style providers (Azure OpenAI + Azure AI Foundry) reject any
+    # non-default temperature on reasoning models (gpt-5.x, gpt-4o*, o-series)
+    # with HTTP 400: "'temperature' does not support 0.3 with this model.
+    # Only the default (1) value is supported." The reactive temperature
+    # retry below catches this on the PRIMARY call, but the fallback call
+    # sites at lines ~4800/5150 invoke .create() directly with no retry
+    # wrapping — so temperature leaks through on the fallback path and
+    # surfaces as a user-visible aux warning. Strip preemptively here so
+    # every code path that builds kwargs through this function is
+    # protected, not just the ones with reactive-retry guards.
+    if temperature is not None and provider in {"azure", "azure-foundry"} \
+            and _is_reasoning_model(model):
+        temperature = None
+
     if temperature is not None:
         kwargs["temperature"] = temperature
 
@@ -4356,19 +4393,6 @@ def _build_call_kwargs(
             provider == "zai"
             and ("4v" in _model_lower or "5v" in _model_lower or "-v" in _model_lower)
         )
-
-        def _is_reasoning_model(m: str) -> bool:
-            """gpt-5.x, gpt-4o*, o1/o3/o4 series all require max_completion_tokens
-            instead of max_tokens on direct-OpenAI-compatible endpoints
-            (Azure, api.openai.com, GitHub Copilot)."""
-            m = m.lower()
-            return (
-                m.startswith("gpt-5")
-                or m.startswith("gpt-4o")
-                or m.startswith("o1")
-                or m.startswith("o3")
-                or m.startswith("o4")
-            )
 
         if _skip_max_tokens:
             pass  # ZAI vision models do not accept max_tokens

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -4315,6 +4315,11 @@ def _build_call_kwargs(
     if max_tokens is not None:
         # Codex adapter handles max_tokens internally; OpenRouter/Nous use max_tokens.
         # Direct OpenAI api.openai.com with newer models needs max_completion_tokens.
+        # Azure OpenAI (both *.openai.azure.com and *.cognitiveservices.azure.com,
+        # the latter being Azure AI Foundry) with reasoning models (gpt-5.x,
+        # gpt-4o, o-series) also rejects max_tokens with HTTP 400
+        # "Unsupported parameter: 'max_tokens' is not supported with this
+        # model. Use 'max_completion_tokens' instead." — same rule applies.
         # ZAI vision models (glm-4v-flash, glm-4v-plus, etc.) reject max_tokens with
         # error code 1210 ("API 调用参数有误") on multimodal requests — skip it.
         _model_lower = (model or "").lower()
@@ -4322,6 +4327,20 @@ def _build_call_kwargs(
             provider == "zai"
             and ("4v" in _model_lower or "5v" in _model_lower or "-v" in _model_lower)
         )
+
+        def _is_reasoning_model(m: str) -> bool:
+            """gpt-5.x, gpt-4o*, o1/o3/o4 series all require max_completion_tokens
+            instead of max_tokens on direct-OpenAI-compatible endpoints
+            (Azure, api.openai.com, GitHub Copilot)."""
+            m = m.lower()
+            return (
+                m.startswith("gpt-5")
+                or m.startswith("gpt-4o")
+                or m.startswith("o1")
+                or m.startswith("o3")
+                or m.startswith("o4")
+            )
+
         if _skip_max_tokens:
             pass  # ZAI vision models do not accept max_tokens
         elif provider == "custom":
@@ -4330,6 +4349,11 @@ def _build_call_kwargs(
                 kwargs["max_completion_tokens"] = max_tokens
             else:
                 kwargs["max_tokens"] = max_tokens
+        elif provider in {"azure", "azure-foundry"} and _is_reasoning_model(_model_lower):
+            # Azure rejects max_tokens for reasoning models — must use
+            # max_completion_tokens. Applies to both the classic Azure OpenAI
+            # domain and the Azure AI Foundry domain (cognitiveservices.azure.com).
+            kwargs["max_completion_tokens"] = max_tokens
         else:
             kwargs["max_tokens"] = max_tokens
 

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -2724,12 +2724,20 @@ def _resolve_single_provider(
 
     Uses the existing provider resolution infrastructure where possible.
     """
-    # Reuse resolve_provider_client which handles provider→client mapping
+    # Reuse resolve_provider_client which handles provider→client mapping.
+    #
+    # NOTE on the keyword argument names: ``resolve_provider_client``'s public
+    # signature uses ``explicit_base_url`` and ``explicit_api_key`` (see its
+    # ``def`` ~line 2925). Earlier this call site passed ``base_url=`` and
+    # ``api_key=``, which raised ``TypeError`` at runtime — silently dropping
+    # every configured ``auxiliary.<task>.fallback_chain`` entry that specified
+    # an endpoint. Map the local parameter names to the callee's expected
+    # keyword names explicitly.
     client, resolved_model = resolve_provider_client(
         provider=provider,
         model=model,
-        base_url=base_url,
-        api_key=api_key,
+        explicit_base_url=base_url,
+        explicit_api_key=api_key,
     )
     return client
 
@@ -4708,19 +4716,25 @@ def call_llm(
                         task or "call", reason, resolved_provider, first_err)
 
             # Fallback order (#26882, #26803):
-            #   1. User-configured fallback_chain (per-task) if set
-            #   2. Main agent model (last-resort safety net)
-            # For auto users (no explicit aux provider), use the full
-            # auto-detection chain instead — its Step 1 IS the main agent
-            # model, so users on `auto` already get main-model fallback.
+            #   1. User-configured fallback_chain (per-task) — always tried
+            #      first if set, regardless of provider:auto or not.
+            #   2. Auto-detection chain (auto users) OR main agent model
+            #      (explicit-provider users) — last-resort safety net.
+            #
+            # Previously the auto path skipped the configured fallback_chain
+            # entirely and went straight to the built-in payment fallback. That
+            # silently ignored explicit per-task `fallback_chain:` config blocks
+            # when the user left `provider: auto`, defeating the point of
+            # configuring a chain. Now the configured chain is consulted first
+            # in BOTH branches.
             fb_client, fb_model, fb_label = (None, None, "")
-            if is_auto:
-                fb_client, fb_model, fb_label = _try_payment_fallback(
-                    resolved_provider, task, reason=reason)
-            else:
-                fb_client, fb_model, fb_label = _try_configured_fallback_chain(
-                    task, resolved_provider or "auto", reason=reason)
-                if fb_client is None:
+            fb_client, fb_model, fb_label = _try_configured_fallback_chain(
+                task, resolved_provider or "auto", reason=reason)
+            if fb_client is None:
+                if is_auto:
+                    fb_client, fb_model, fb_label = _try_payment_fallback(
+                        resolved_provider, task, reason=reason)
+                else:
                     fb_client, fb_model, fb_label = _try_main_agent_model_fallback(
                         resolved_provider, task, reason=reason)
 
@@ -5060,19 +5074,17 @@ async def async_call_llm(
             logger.info("Auxiliary %s (async): %s on %s (%s), trying fallback",
                         task or "call", reason, resolved_provider, first_err)
 
-            # Fallback order (#26882, #26803):
-            #   1. User-configured fallback_chain (per-task) if set
-            #   2. Main agent model (last-resort safety net)
-            # Auto users get the full auto-detection chain instead — its
-            # Step 1 IS the main agent model.
+            # Fallback order (#26882, #26803) — mirrors sync path above:
+            # configured fallback_chain first regardless of auto, then auto
+            # chain or main-model.
             fb_client, fb_model, fb_label = (None, None, "")
-            if is_auto:
-                fb_client, fb_model, fb_label = _try_payment_fallback(
-                    resolved_provider, task, reason=reason)
-            else:
-                fb_client, fb_model, fb_label = _try_configured_fallback_chain(
-                    task, resolved_provider or "auto", reason=reason)
-                if fb_client is None:
+            fb_client, fb_model, fb_label = _try_configured_fallback_chain(
+                task, resolved_provider or "auto", reason=reason)
+            if fb_client is None:
+                if is_auto:
+                    fb_client, fb_model, fb_label = _try_payment_fallback(
+                        resolved_provider, task, reason=reason)
+                else:
                     fb_client, fb_model, fb_label = _try_main_agent_model_fallback(
                         resolved_provider, task, reason=reason)
 

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -2251,7 +2251,17 @@ def run_conversation(
                     # still recover.  See _pool_may_recover_from_rate_limit
                     # for the single-credential-pool and CloudCode-quota
                     # exceptions.  Fixes #11314 and #13636.
-                    pool_may_recover = _pool_may_recover_from_rate_limit(
+                    #
+                    # NOTE: must go through ``_ra()`` (returns the
+                    # ``run_agent`` module) rather than calling the helper
+                    # bare. ``_pool_may_recover_from_rate_limit`` lives in
+                    # ``run_agent`` and is not imported at the top of this
+                    # file. A bare call raises ``NameError`` the first time
+                    # any user with a configured ``fallback_providers``
+                    # entry encounters a rate limit. Latent in 43e566f until
+                    # downstream consumers actually configured a fallback
+                    # chain and reached this branch.
+                    pool_may_recover = _ra()._pool_may_recover_from_rate_limit(
                         agent._credential_pool,
                         provider=agent.provider,
                         base_url=getattr(agent, "base_url", None),

--- a/run_agent.py
+++ b/run_agent.py
@@ -840,12 +840,23 @@ class AIAgent:
         does NOT support the Responses API — gpt-5.x models are served
         on the regular ``/chat/completions`` path — so routing decisions
         must treat Azure separately from direct OpenAI.
+
+        Two domains route here:
+
+        * ``{resource}.openai.azure.com`` — the classic Azure OpenAI domain.
+        * ``{resource}.cognitiveservices.azure.com`` — Azure AI Foundry's
+          domain. Functionally identical endpoint surface (same
+          ``/openai/v1`` path, same OpenAI-compatible client, same
+          ``/chat/completions``-only model serving), just a different
+          DNS suffix. Both must be classified as Azure or the fallback
+          API-mode derivation in ``chat_completion_helpers.py`` routes
+          gpt-5.x to ``/responses`` and 404s.
         """
         if base_url is not None:
             url = str(base_url).lower()
         else:
             url = getattr(self, "_base_url_lower", "") or ""
-        return "openai.azure.com" in url
+        return "openai.azure.com" in url or "cognitiveservices.azure.com" in url
 
     def _is_github_copilot_url(self, base_url: str = None) -> bool:
         """Return True when a base URL targets GitHub Copilot's OpenAI-compatible API."""

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -3132,3 +3132,109 @@ class TestZ2O1579ConfiguredFallbackChainFix:
         # Payment fallback should NOT be reached because configured chain
         # returned a working client.
         mock_payment.assert_not_called()
+
+
+class TestZ2O1621BuildCallKwargsAzureReasoningModel:
+    """Regression tests for the 2026-05-22 Verdigris/Mercator finding:
+    _build_call_kwargs emits max_tokens for provider=azure-foundry +
+    gpt-5.x, but Azure rejects max_tokens with HTTP 400 ("Unsupported
+    parameter: 'max_tokens' is not supported with this model. Use
+    'max_completion_tokens' instead.") for all gpt-5.x, gpt-4o*, and
+    o-series reasoning models. Same rule applies to both
+    *.openai.azure.com and *.cognitiveservices.azure.com (Azure AI
+    Foundry) domains."""
+
+    def test_azure_foundry_gpt5_uses_max_completion_tokens(self):
+        from agent.auxiliary_client import _build_call_kwargs
+
+        kwargs = _build_call_kwargs(
+            provider="azure-foundry",
+            model="gpt-5.5",
+            messages=[{"role": "user", "content": "hi"}],
+            max_tokens=500,
+        )
+        assert kwargs.get("max_completion_tokens") == 500
+        assert "max_tokens" not in kwargs
+
+    def test_azure_foundry_gpt5_mini_uses_max_completion_tokens(self):
+        from agent.auxiliary_client import _build_call_kwargs
+
+        kwargs = _build_call_kwargs(
+            provider="azure-foundry",
+            model="gpt-5-mini",
+            messages=[{"role": "user", "content": "hi"}],
+            max_tokens=500,
+        )
+        assert kwargs.get("max_completion_tokens") == 500
+
+    def test_azure_provider_with_o3_uses_max_completion_tokens(self):
+        from agent.auxiliary_client import _build_call_kwargs
+
+        kwargs = _build_call_kwargs(
+            provider="azure",
+            model="o3",
+            messages=[{"role": "user", "content": "hi"}],
+            max_tokens=500,
+        )
+        assert kwargs.get("max_completion_tokens") == 500
+
+    def test_azure_with_legacy_gpt35_still_uses_max_tokens(self):
+        """Non-reasoning models on Azure should keep the legacy max_tokens
+        key. The fix is scoped to reasoning models specifically."""
+        from agent.auxiliary_client import _build_call_kwargs
+
+        kwargs = _build_call_kwargs(
+            provider="azure",
+            model="gpt-3.5-turbo",
+            messages=[{"role": "user", "content": "hi"}],
+            max_tokens=500,
+        )
+        assert kwargs.get("max_tokens") == 500
+        assert "max_completion_tokens" not in kwargs
+
+    def test_openrouter_gpt5_still_uses_max_tokens(self):
+        """OpenRouter normalizes max_tokens itself and accepts it for all
+        models including gpt-5.x routed through its API. The fix must not
+        accidentally change OpenRouter behavior."""
+        from agent.auxiliary_client import _build_call_kwargs
+
+        kwargs = _build_call_kwargs(
+            provider="openrouter",
+            model="openai/gpt-5",
+            messages=[{"role": "user", "content": "hi"}],
+            max_tokens=500,
+        )
+        assert kwargs.get("max_tokens") == 500
+
+
+class TestZ2O1620PoolMayRecoverFromRateLimitImport:
+    """Regression test for the NameError that fired in
+    agent/conversation_loop.py:2254 when a user with a configured
+    fallback_providers entry hit a rate limit. The bare reference to
+    _pool_may_recover_from_rate_limit didn't import the symbol; the
+    fix routes through _ra() (which returns the run_agent module)
+    like every other run_agent helper in the file.
+
+    Pre-fix this code path was unreachable in practice because no
+    one had configured a fallback chain and reached the
+    `is_rate_limited AND _fallback_index < len(_fallback_chain)`
+    branch. After PR #30005's _resolve_auto fix it became reachable
+    — and immediately NameError'd."""
+
+    def test_pool_may_recover_helper_accessible_via_run_agent_module(self):
+        """The helper must be reachable from agent.conversation_loop via
+        the _ra() module accessor — if it isn't, the rate-limit
+        fallback path NameErrors at runtime."""
+        from agent.conversation_loop import _ra
+
+        run_agent_mod = _ra()
+        assert hasattr(run_agent_mod, "_pool_may_recover_from_rate_limit"), (
+            "_pool_may_recover_from_rate_limit must be defined on the "
+            "run_agent module — conversation_loop's rate-limit fallback "
+            "path calls it via _ra() and will NameError if it's missing."
+        )
+        # Sanity: it's callable with the expected positional arg.
+        # Passing None for credential_pool should be a no-op safe call
+        # (returns False per the existing test in
+        # tests/run_agent/test_provider_fallback.py).
+        assert run_agent_mod._pool_may_recover_from_rate_limit(None) is False

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -3207,6 +3207,100 @@ class TestZ2O1621BuildCallKwargsAzureReasoningModel:
         assert kwargs.get("max_tokens") == 500
 
 
+class TestAzureReasoningTemperatureStrip:
+    """Regression for the 6th-layer fallback bug surfaced after Z2O-1623
+    merged. Production fingerprint:
+
+        ⚠ Auxiliary title generation failed: HTTP 400: Unsupported value:
+        'temperature' does not support 0.3 with this model. Only the default
+        (1) value is supported.
+
+    Title-gen hardcodes temperature=0.3. The reactive temperature-retry
+    in call_llm wraps the PRIMARY call but the fallback call sites at
+    ~4800/5150 invoke .create() directly with no retry — so temperature
+    leaks through on the fallback path. Fix: strip non-default temperature
+    preemptively in _build_call_kwargs for Azure-style providers + reasoning
+    models, parallel to the existing max_completion_tokens routing."""
+
+    def test_azure_foundry_gpt5_strips_temperature(self):
+        from agent.auxiliary_client import _build_call_kwargs
+
+        kwargs = _build_call_kwargs(
+            provider="azure-foundry",
+            model="gpt-5.5",
+            messages=[{"role": "user", "content": "hi"}],
+            temperature=0.3,
+            max_tokens=500,
+        )
+        assert "temperature" not in kwargs, (
+            "Azure Foundry + gpt-5.5 must not emit temperature; "
+            "Azure rejects any non-default value with HTTP 400."
+        )
+        # Also confirm max_completion_tokens still routes correctly
+        assert kwargs.get("max_completion_tokens") == 500
+
+    def test_azure_classic_o3_strips_temperature(self):
+        from agent.auxiliary_client import _build_call_kwargs
+
+        kwargs = _build_call_kwargs(
+            provider="azure",
+            model="o3",
+            messages=[{"role": "user", "content": "hi"}],
+            temperature=0.5,
+        )
+        assert "temperature" not in kwargs
+
+    def test_azure_foundry_gpt4o_strips_temperature(self):
+        """gpt-4o is also a reasoning-family model on Azure."""
+        from agent.auxiliary_client import _build_call_kwargs
+
+        kwargs = _build_call_kwargs(
+            provider="azure-foundry",
+            model="gpt-4o",
+            messages=[{"role": "user", "content": "hi"}],
+            temperature=0.7,
+        )
+        assert "temperature" not in kwargs
+
+    def test_azure_with_legacy_gpt35_keeps_temperature(self):
+        """Non-reasoning legacy models on Azure should still respect the
+        passed temperature — they accept arbitrary values."""
+        from agent.auxiliary_client import _build_call_kwargs
+
+        kwargs = _build_call_kwargs(
+            provider="azure",
+            model="gpt-3.5-turbo",
+            messages=[{"role": "user", "content": "hi"}],
+            temperature=0.3,
+        )
+        assert kwargs.get("temperature") == 0.3
+
+    def test_openai_direct_gpt5_keeps_temperature(self):
+        """api.openai.com accepts arbitrary temperature even on gpt-5
+        reasoning models. The strip must be scoped to azure providers."""
+        from agent.auxiliary_client import _build_call_kwargs
+
+        kwargs = _build_call_kwargs(
+            provider="openai",
+            model="gpt-5",
+            messages=[{"role": "user", "content": "hi"}],
+            temperature=0.3,
+        )
+        assert kwargs.get("temperature") == 0.3
+
+    def test_openrouter_gpt5_keeps_temperature(self):
+        """OpenRouter normalizes parameters and accepts any temperature."""
+        from agent.auxiliary_client import _build_call_kwargs
+
+        kwargs = _build_call_kwargs(
+            provider="openrouter",
+            model="openai/gpt-5",
+            messages=[{"role": "user", "content": "hi"}],
+            temperature=0.3,
+        )
+        assert kwargs.get("temperature") == 0.3
+
+
 class TestZ2O1620PoolMayRecoverFromRateLimitImport:
     """Regression test for the NameError that fired in
     agent/conversation_loop.py:2254 when a user with a configured

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -1052,7 +1052,7 @@ class TestTryPaymentFallback:
         with patch("agent.auxiliary_client._try_openrouter", return_value=(None, None)), \
              patch("agent.auxiliary_client._try_nous", return_value=(mock_client, "nous-model")), \
              patch("agent.auxiliary_client._read_main_provider", return_value="openrouter"):
-            client, model, label = _try_payment_fallback("openrouter", task="compression")
+            client, model, provider, label = _try_payment_fallback("openrouter", task="compression")
         assert client is mock_client
         assert model == "nous-model"
         assert label == "nous"
@@ -1063,7 +1063,7 @@ class TestTryPaymentFallback:
              patch("agent.auxiliary_client._try_custom_endpoint", return_value=(None, None)), \
              patch("agent.auxiliary_client._resolve_api_key_provider", return_value=(None, None)), \
              patch("agent.auxiliary_client._read_main_provider", return_value="openrouter"):
-            client, model, label = _try_payment_fallback("openrouter")
+            client, model, provider, label = _try_payment_fallback("openrouter")
         assert client is None
         assert label == ""
 
@@ -1072,7 +1072,7 @@ class TestTryPaymentFallback:
         mock_client = MagicMock()
         with patch("agent.auxiliary_client._try_openrouter", return_value=(mock_client, "or-model")), \
              patch("agent.auxiliary_client._read_main_provider", return_value="openai-codex"):
-            client, model, label = _try_payment_fallback("openai-codex", task="vision")
+            client, model, provider, label = _try_payment_fallback("openai-codex", task="vision")
         assert client is mock_client
         assert label == "openrouter"
 
@@ -1087,7 +1087,7 @@ class TestTryPaymentFallback:
              patch("agent.auxiliary_client._try_custom_endpoint", return_value=(None, None)), \
              patch("agent.auxiliary_client._resolve_api_key_provider", return_value=(None, None)), \
              patch("agent.auxiliary_client._read_main_provider", return_value="openrouter"):
-            client, model, label = _try_payment_fallback("openrouter")
+            client, model, provider, label = _try_payment_fallback("openrouter")
         assert client is None
         assert model is None
         assert label == ""
@@ -1143,7 +1143,7 @@ class TestCallLlmPaymentFallback:
              patch("agent.auxiliary_client._resolve_task_provider_model",
                     return_value=("auto", "xiaomi/mimo-v2-pro", None, None, None)), \
              patch("agent.auxiliary_client._try_payment_fallback",
-                    return_value=(fallback_client, "fallback-model", "openrouter")):
+                    return_value=(fallback_client, "fallback-model", "openrouter", "openrouter")):
             result = call_llm(
                 task="session_search",
                 messages=[{"role": "user", "content": "hello"}],
@@ -1179,7 +1179,7 @@ class TestAuxiliaryFallbackLayering:
              patch("agent.auxiliary_client._resolve_task_provider_model",
                    return_value=("glm", "glm-4v-flash", None, None, None)), \
              patch("agent.auxiliary_client._try_configured_fallback_chain",
-                   return_value=(chain_client, "gpt-4o-mini", "fallback_chain[0](openai)")), \
+                   return_value=(chain_client, "gpt-4o-mini", "openai", "fallback_chain[0](openai)")), \
              patch("agent.auxiliary_client._try_main_agent_model_fallback",
                    side_effect=main_called):
             result = call_llm(
@@ -1208,9 +1208,9 @@ class TestAuxiliaryFallbackLayering:
              patch("agent.auxiliary_client._resolve_task_provider_model",
                    return_value=("glm", "glm-4v-flash", None, None, None)), \
              patch("agent.auxiliary_client._try_configured_fallback_chain",
-                   return_value=(None, None, "")), \
+                   return_value=(None, None, "", "")), \
              patch("agent.auxiliary_client._try_main_agent_model_fallback",
-                   return_value=(main_client, "claude-sonnet-4", "main-agent(openrouter)")):
+                   return_value=(main_client, "claude-sonnet-4", "openrouter", "main-agent(openrouter)")):
             result = call_llm(
                 task="vision",
                 messages=[{"role": "user", "content": "hello"}],
@@ -1230,9 +1230,9 @@ class TestAuxiliaryFallbackLayering:
              patch("agent.auxiliary_client._resolve_task_provider_model",
                    return_value=("glm", "glm-4v-flash", None, None, None)), \
              patch("agent.auxiliary_client._try_configured_fallback_chain",
-                   return_value=(None, None, "")), \
+                   return_value=(None, None, "", "")), \
              patch("agent.auxiliary_client._try_main_agent_model_fallback",
-                   return_value=(None, None, "")), \
+                   return_value=(None, None, "", "")), \
              caplog.at_level("WARNING", logger="agent.auxiliary_client"):
             with pytest.raises(Exception, match="Payment Required"):
                 call_llm(
@@ -1252,7 +1252,7 @@ class TestTryMainAgentModelFallback:
         from agent.auxiliary_client import _try_main_agent_model_fallback
         with patch("agent.auxiliary_client._read_main_provider", return_value="auto"), \
              patch("agent.auxiliary_client._read_main_model", return_value="some-model"):
-            client, model, label = _try_main_agent_model_fallback("glm", task="vision")
+            client, model, provider, label = _try_main_agent_model_fallback("glm", task="vision")
         assert client is None and model is None and label == ""
 
     def test_returns_none_when_failed_provider_equals_main(self):
@@ -1260,7 +1260,7 @@ class TestTryMainAgentModelFallback:
         from agent.auxiliary_client import _try_main_agent_model_fallback
         with patch("agent.auxiliary_client._read_main_provider", return_value="openrouter"), \
              patch("agent.auxiliary_client._read_main_model", return_value="anthropic/claude-sonnet-4"):
-            client, model, label = _try_main_agent_model_fallback("openrouter", task="vision")
+            client, model, provider, label = _try_main_agent_model_fallback("openrouter", task="vision")
         assert client is None and label == ""
 
     def test_resolves_main_provider_client(self):
@@ -1271,7 +1271,7 @@ class TestTryMainAgentModelFallback:
              patch("agent.auxiliary_client._is_provider_unhealthy", return_value=False), \
              patch("agent.auxiliary_client.resolve_provider_client",
                    return_value=(fake_client, "anthropic/claude-sonnet-4")):
-            client, model, label = _try_main_agent_model_fallback("glm", task="vision")
+            client, model, provider, label = _try_main_agent_model_fallback("glm", task="vision")
         assert client is fake_client
         assert model == "anthropic/claude-sonnet-4"
         assert label == "main-agent(openrouter)"
@@ -1281,7 +1281,7 @@ class TestTryMainAgentModelFallback:
         with patch("agent.auxiliary_client._read_main_provider", return_value="openrouter"), \
              patch("agent.auxiliary_client._read_main_model", return_value="anthropic/claude-sonnet-4"), \
              patch("agent.auxiliary_client._is_provider_unhealthy", return_value=True):
-            client, model, label = _try_main_agent_model_fallback("glm", task="vision")
+            client, model, provider, label = _try_main_agent_model_fallback("glm", task="vision")
         assert client is None
 
 
@@ -2551,7 +2551,7 @@ class TestAuxiliaryClientPoisonedCacheEviction:
                 return_value=(poisoned, "gpt-5.5"),
             ), patch(
                 "agent.auxiliary_client._try_payment_fallback",
-                return_value=(None, None, ""),
+                return_value=(None, None, "", ""),
             ):
                 with pytest.raises(ConnectionError):
                     call_llm(
@@ -2587,7 +2587,7 @@ class TestAuxiliaryClientPoisonedCacheEviction:
                 return_value=(poisoned, "gpt-5.5"),
             ), patch(
                 "agent.auxiliary_client._try_payment_fallback",
-                return_value=(None, None, ""),
+                return_value=(None, None, "", ""),
             ):
                 with pytest.raises(ConnectionError):
                     await async_call_llm(
@@ -2946,7 +2946,7 @@ class TestAuxUnhealthyCache:
              patch("agent.auxiliary_client._try_nous", return_value=(nous_client, "n-model")), \
              patch("agent.auxiliary_client._try_custom_endpoint") as custom_try, \
              patch("agent.auxiliary_client._resolve_api_key_provider", return_value=(None, None)):
-            client, model, label = _try_payment_fallback("openrouter", task="compression")
+            client, model, provider, label = _try_payment_fallback("openrouter", task="compression")
         assert client is nous_client
         assert label == "nous"
         # OR is skipped via skip_chain_labels (failed provider), custom via unhealthy cache.
@@ -2981,7 +2981,7 @@ class TestAuxUnhealthyCache:
              patch("agent.auxiliary_client._resolve_task_provider_model",
                     return_value=("auto", "google/gemini-3-flash-preview", None, None, None)), \
              patch("agent.auxiliary_client._try_payment_fallback",
-                    return_value=(nous_client, "n-model", "nous")), \
+                    return_value=(nous_client, "n-model", "nous", "nous")), \
              patch("agent.auxiliary_client._build_call_kwargs",
                     return_value={"model": "n-model", "messages": [{"role": "user", "content": "hi"}]}):
             assert _is_provider_unhealthy("openrouter") is False
@@ -3091,11 +3091,11 @@ class TestZ2O1579ConfiguredFallbackChainFix:
 
         def configured_chain_side_effect(*args, **kwargs):
             call_order.append("configured")
-            return (configured_fb_client, "gpt-5.5", "fallback_chain[0](azure-foundry)")
+            return (configured_fb_client, "gpt-5.5", "azure-foundry", "fallback_chain[0](azure-foundry)")
 
         def payment_fb_side_effect(*args, **kwargs):
             call_order.append("payment")
-            return (None, None, "")
+            return (None, None, "", "")
 
         with patch(
             "agent.auxiliary_client._get_cached_client",
@@ -3238,3 +3238,172 @@ class TestZ2O1620PoolMayRecoverFromRateLimitImport:
         # (returns False per the existing test in
         # tests/run_agent/test_provider_fallback.py).
         assert run_agent_mod._pool_may_recover_from_rate_limit(None) is False
+
+
+class TestZ2O1623FallbackProviderRouting:
+    """Regression for Z2O-1623. The three auxiliary fallback resolvers
+    (_try_configured_fallback_chain, _try_payment_fallback,
+    _try_main_agent_model_fallback) historically returned
+    (client, model, label) where ``label`` was a formatted log string
+    like ``fallback_chain[0](azure-foundry)`` or
+    ``main-agent(azure-foundry)``. The fallback call site in
+    ``call_llm`` then passed that label as the ``provider`` argument
+    to ``_build_call_kwargs``, defeating its exact-string routing
+    (``elif provider in {"azure", "azure-foundry"} and ...``). Result:
+    Azure reasoning-model fallbacks emitted ``max_tokens`` instead of
+    ``max_completion_tokens`` and 400'd, even though
+    ``_build_call_kwargs`` itself was correctly fixed in PR #8 / the
+    Z2O-1621 patch.
+
+    The fix extends the resolver return tuples to
+    (client, model, provider, label) and updates the call sites to
+    pass the provider — not the label — to ``_build_call_kwargs``.
+
+    These tests lock in:
+      1. Each resolver returns the canonical provider identifier as
+         the 3rd tuple element.
+      2. The full fallback flow in ``call_llm`` builds kwargs with
+         ``max_completion_tokens`` (not ``max_tokens``) when the
+         configured chain points at azure-foundry + gpt-5.5.
+    """
+
+    def test_configured_fallback_chain_returns_provider_identifier(self):
+        """The 3rd tuple element must be the chain entry's provider
+        string (e.g. 'azure-foundry'), not the formatted log label."""
+        from agent.auxiliary_client import _try_configured_fallback_chain
+
+        fake_client = MagicMock()
+        with patch("agent.auxiliary_client._get_auxiliary_task_config",
+                   return_value={"fallback_chain": [
+                       {"provider": "azure-foundry", "model": "gpt-5.5",
+                        "base_url": "https://x.cognitiveservices.azure.com/openai/v1",
+                        "api_key": "fake"}
+                   ]}), \
+             patch("agent.auxiliary_client._resolve_single_provider",
+                   return_value=fake_client):
+            client, model, provider, label = _try_configured_fallback_chain(
+                "title_generation", "azure-foundry-primary", reason="rate limit")
+
+        assert client is fake_client
+        assert model == "gpt-5.5"
+        assert provider == "azure-foundry", (
+            "Resolver must return the canonical provider identifier as "
+            "the 3rd tuple element so _build_call_kwargs can route "
+            "max_tokens vs max_completion_tokens correctly. A label like "
+            "'fallback_chain[0](azure-foundry)' here re-introduces Z2O-1623."
+        )
+        assert label == "fallback_chain[0](azure-foundry)"
+
+    def test_payment_fallback_returns_canonical_provider_for_openrouter(self):
+        """Most payment-chain labels (openrouter, nous, openai-codex) match
+        the canonical provider identifier directly. Lock that in."""
+        from agent.auxiliary_client import _try_payment_fallback
+
+        fake_client = MagicMock()
+        with patch("agent.auxiliary_client._try_openrouter",
+                   return_value=(fake_client, "google/gemini-3-flash-preview")), \
+             patch("agent.auxiliary_client._read_main_provider",
+                   return_value="some-other-provider"):
+            client, model, provider, label = _try_payment_fallback(
+                "some-other-provider", task="title_generation")
+
+        assert client is fake_client
+        assert provider == "openrouter"
+        assert label == "openrouter"
+
+    def test_payment_fallback_inverts_local_custom_to_custom(self):
+        """The "local/custom" chain label must map to "custom" — the
+        canonical provider identifier _build_call_kwargs routes on.
+        Without this inversion, a payment-chain fallback to a custom
+        endpoint at api.openai.com re-introduces the Z2O-1623 bug class:
+        emits max_tokens for reasoning models that require
+        max_completion_tokens."""
+        from agent.auxiliary_client import _try_payment_fallback
+
+        fake_client = MagicMock()
+        with patch("agent.auxiliary_client._try_openrouter",
+                   return_value=(None, None)), \
+             patch("agent.auxiliary_client._try_nous",
+                   return_value=(None, None)), \
+             patch("agent.auxiliary_client._try_custom_endpoint",
+                   return_value=(fake_client, "gpt-5")), \
+             patch("agent.auxiliary_client._read_main_provider",
+                   return_value="some-other-provider"):
+            client, model, provider, label = _try_payment_fallback(
+                "some-other-provider", task="title_generation")
+
+        assert client is fake_client
+        assert provider == "custom", (
+            "local/custom chain label must invert to 'custom' so "
+            "_build_call_kwargs's `elif provider == \"custom\":` "
+            "branch fires. Without this, reasoning models on "
+            "api.openai.com via the custom chain emit max_tokens and 400."
+        )
+        assert label == "local/custom"
+
+    def test_main_agent_model_fallback_returns_provider_identifier(self):
+        """The 3rd tuple element must be the main provider identifier
+        (e.g. 'azure-foundry'), not 'main-agent(azure-foundry)'."""
+        from agent.auxiliary_client import _try_main_agent_model_fallback
+
+        fake_client = MagicMock()
+        with patch("agent.auxiliary_client._read_main_provider",
+                   return_value="azure-foundry"), \
+             patch("agent.auxiliary_client._read_main_model",
+                   return_value="gpt-5.5"), \
+             patch("agent.auxiliary_client._is_provider_unhealthy",
+                   return_value=False), \
+             patch("agent.auxiliary_client.resolve_provider_client",
+                   return_value=(fake_client, "gpt-5.5")):
+            client, model, provider, label = _try_main_agent_model_fallback(
+                "different-provider", task="title_generation")
+
+        assert client is fake_client
+        assert provider == "azure-foundry"
+        assert label == "main-agent(azure-foundry)"
+
+    def test_call_llm_fallback_to_azure_foundry_uses_max_completion_tokens(
+        self, monkeypatch
+    ):
+        """End-to-end: when the primary aux call fails and the
+        configured fallback_chain points at azure-foundry + gpt-5.5,
+        the kwargs handed to the fallback client must contain
+        max_completion_tokens (not max_tokens). This is the exact
+        Z2O-1623 production fingerprint."""
+        primary_client = MagicMock()
+        rate_err = Exception("HTTP 429 Too Many Requests")
+        rate_err.status_code = 429
+        primary_client.chat.completions.create.side_effect = rate_err
+
+        fb_client = MagicMock()
+        fb_resp = MagicMock(choices=[
+            MagicMock(message=MagicMock(content="fallback title"))
+        ])
+        fb_client.chat.completions.create.return_value = fb_resp
+        fb_client.base_url = "https://swc.cognitiveservices.azure.com/openai/v1"
+
+        # Mirrors prod: auxiliary.title_generation has no explicit
+        # `provider:`, so resolved_provider is "auto" — that's the only
+        # gate that fires fallback on a 429 (see is_auto check in
+        # call_llm). With explicit providers, 429 propagates instead.
+        with patch("agent.auxiliary_client._get_cached_client",
+                   return_value=(primary_client, "gpt-5.5")), \
+             patch("agent.auxiliary_client._resolve_task_provider_model",
+                   return_value=("auto", "gpt-5.5", None, None, None)), \
+             patch("agent.auxiliary_client._try_configured_fallback_chain",
+                   return_value=(fb_client, "gpt-5.5", "azure-foundry",
+                                 "fallback_chain[0](azure-foundry)")):
+            result = call_llm(
+                task="title_generation",
+                messages=[{"role": "user", "content": "hi"}],
+                max_tokens=500,
+            )
+
+        assert result is fb_resp
+        fb_call_kwargs = fb_client.chat.completions.create.call_args.kwargs
+        assert fb_call_kwargs.get("max_completion_tokens") == 500, (
+            "Azure Foundry + gpt-5.5 fallback must emit "
+            "max_completion_tokens. If max_tokens leaks here, Z2O-1623 "
+            "has regressed and Azure returns HTTP 400 in prod."
+        )
+        assert "max_tokens" not in fb_call_kwargs

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -2991,3 +2991,144 @@ class TestAuxUnhealthyCache:
             )
             # After the 402, OpenRouter is in the unhealthy cache.
             assert _is_provider_unhealthy("openrouter") is True
+
+
+class TestZ2O1579ConfiguredFallbackChainFix:
+    """Regression tests for the two bugs Mercator self-diagnosed on 2026-05-21
+    (Verdigris Z2O-1579): configured auxiliary.<task>.fallback_chain was never
+    actually exercised at runtime because of (1) an argument-name mismatch
+    between _resolve_single_provider and resolve_provider_client and (2) the
+    auto path bypassing the configured chain entirely.
+
+    Both bugs landed silently — the YAML config was correct, the endpoint was
+    real and reachable, but no aux call ever reached the configured fallback
+    because of these two failures."""
+
+    def test_resolve_single_provider_passes_explicit_kwargs_to_resolve_provider_client(
+        self,
+    ):
+        """Bug 1: _resolve_single_provider was passing `base_url=` and
+        `api_key=` keyword arguments to resolve_provider_client, which expects
+        `explicit_base_url=` and `explicit_api_key=`. This raised TypeError
+        and silently dropped every configured fallback entry that specified
+        an endpoint. The fix maps the local parameter names to the callee's
+        expected keyword names."""
+        from agent.auxiliary_client import _resolve_single_provider
+
+        sentinel_client = MagicMock()
+        with patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            return_value=(sentinel_client, "gpt-5.5"),
+        ) as mock_resolve:
+            result = _resolve_single_provider(
+                provider="azure-foundry",
+                model="gpt-5.5",
+                base_url="https://mercator-aux-swc.cognitiveservices.azure.com/openai/v1",
+                api_key="sk-test",
+            )
+        assert result is sentinel_client
+        # The call MUST use explicit_base_url / explicit_api_key keywords —
+        # not base_url / api_key, which would TypeError.
+        mock_resolve.assert_called_once()
+        kwargs = mock_resolve.call_args.kwargs
+        assert kwargs["provider"] == "azure-foundry"
+        assert kwargs["model"] == "gpt-5.5"
+        assert (
+            kwargs["explicit_base_url"]
+            == "https://mercator-aux-swc.cognitiveservices.azure.com/openai/v1"
+        )
+        assert kwargs["explicit_api_key"] == "sk-test"
+        # The buggy keyword names must NOT be present in the call —
+        # resolve_provider_client doesn't accept them.
+        assert "base_url" not in kwargs
+        assert "api_key" not in kwargs
+
+    def test_resolve_single_provider_real_signature_compatibility(self):
+        """Sanity check: confirm resolve_provider_client's signature still
+        uses `explicit_base_url` / `explicit_api_key` and not the names the
+        bug used. If this test starts failing, the signature was renamed
+        upstream and this regression test (and the call site fix) need
+        re-aligning."""
+        import inspect
+        from agent.auxiliary_client import resolve_provider_client
+
+        sig = inspect.signature(resolve_provider_client)
+        params = set(sig.parameters.keys())
+        assert "explicit_base_url" in params, (
+            "resolve_provider_client signature changed — the Z2O-1579 fix in "
+            "_resolve_single_provider may need to be re-aligned."
+        )
+        assert "explicit_api_key" in params, (
+            "resolve_provider_client signature changed — the Z2O-1579 fix in "
+            "_resolve_single_provider may need to be re-aligned."
+        )
+
+    def test_auto_path_tries_configured_fallback_chain_before_built_in(self):
+        """Bug 2: when provider:auto (the default), call_llm went straight to
+        _try_payment_fallback (the built-in openrouter/nous/local/api-key
+        chain) and never consulted the user-configured
+        auxiliary.<task>.fallback_chain. This silently ignored every per-task
+        fallback_chain config block for auto users. The fix tries the
+        configured chain first in BOTH branches.
+
+        We assert _try_configured_fallback_chain is called BEFORE
+        _try_payment_fallback when the primary aux call fails with a
+        connection error and the provider is auto."""
+        from agent.auxiliary_client import call_llm
+
+        primary_client = MagicMock()
+        primary_client.base_url = "https://primary.example.com/v1/"
+        err = ConnectionError("Connection error.")
+        primary_client.chat.completions.create.side_effect = err
+
+        configured_fb_client = MagicMock()
+        configured_resp = MagicMock()
+        configured_resp.choices = [MagicMock(message=MagicMock(content="ok"))]
+        configured_fb_client.chat.completions.create.return_value = configured_resp
+
+        # Track call order so we can assert "configured-first".
+        call_order = []
+
+        def configured_chain_side_effect(*args, **kwargs):
+            call_order.append("configured")
+            return (configured_fb_client, "gpt-5.5", "fallback_chain[0](azure-foundry)")
+
+        def payment_fb_side_effect(*args, **kwargs):
+            call_order.append("payment")
+            return (None, None, "")
+
+        with patch(
+            "agent.auxiliary_client._get_cached_client",
+            return_value=(primary_client, "gpt-5.5"),
+        ), patch(
+            "agent.auxiliary_client._resolve_task_provider_model",
+            return_value=("auto", "gpt-5.5", None, None, None),
+        ), patch(
+            "agent.auxiliary_client._try_configured_fallback_chain",
+            side_effect=configured_chain_side_effect,
+        ) as mock_configured, patch(
+            "agent.auxiliary_client._try_payment_fallback",
+            side_effect=payment_fb_side_effect,
+        ) as mock_payment, patch(
+            "agent.auxiliary_client._build_call_kwargs",
+            return_value={"model": "gpt-5.5", "messages": [{"role": "user", "content": "hi"}]},
+        ), patch(
+            "agent.auxiliary_client._is_connection_error",
+            return_value=True,
+        ):
+            call_llm(
+                task="title_generation",
+                messages=[{"role": "user", "content": "hi"}],
+            )
+        # Configured chain MUST be tried first. Pre-fix behavior would have
+        # called _try_payment_fallback and never touched
+        # _try_configured_fallback_chain in the auto path.
+        assert call_order[0] == "configured", (
+            f"Expected configured chain to be tried first, got order: {call_order}. "
+            "Pre-fix code (Z2O-1579) called _try_payment_fallback in the auto "
+            "branch without consulting the user-configured fallback_chain."
+        )
+        mock_configured.assert_called_once()
+        # Payment fallback should NOT be reached because configured chain
+        # returned a working client.
+        mock_payment.assert_not_called()

--- a/tests/agent/test_unsupported_temperature_retry.py
+++ b/tests/agent/test_unsupported_temperature_retry.py
@@ -132,7 +132,7 @@ class TestCallLlmUnsupportedTemperatureRetry:
             patch("agent.auxiliary_client._validate_llm_response",
                   side_effect=lambda resp, _task: resp),
             patch("agent.auxiliary_client._try_payment_fallback",
-                  return_value=None),
+                  return_value=(None, None, "", "")),
         ):
             with pytest.raises(RuntimeError, match="Invalid value"):
                 call_llm(
@@ -162,7 +162,7 @@ class TestCallLlmUnsupportedTemperatureRetry:
             patch("agent.auxiliary_client._validate_llm_response",
                   side_effect=lambda resp, _task: resp),
             patch("agent.auxiliary_client._try_payment_fallback",
-                  return_value=None),
+                  return_value=(None, None, "", "")),
         ):
             with pytest.raises(RuntimeError):
                 call_llm(
@@ -225,7 +225,7 @@ class TestAsyncCallLlmUnsupportedTemperatureRetry:
             patch("agent.auxiliary_client._validate_llm_response",
                   side_effect=lambda resp, _task: resp),
             patch("agent.auxiliary_client._try_payment_fallback",
-                  return_value=None),
+                  return_value=(None, None, "", "")),
         ):
             with pytest.raises(RuntimeError, match="Invalid value"):
                 await async_call_llm(

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -4026,6 +4026,36 @@ class TestGpt5ApiModeRouting:
         agent.base_url = "https://my-resource.openai.azure.com/openai/v1"
         assert agent._is_azure_openai_url() is True
 
+    def test_is_azure_openai_url_detects_cognitiveservices_domain(self, agent):
+        """Azure AI Foundry resources use the cognitiveservices.azure.com
+        domain instead of openai.azure.com. The endpoint surface is
+        identical (same /openai/v1 path, same OpenAI-compatible client,
+        same /chat/completions-only model serving for gpt-5.x). Both
+        must be classified as Azure or the fallback api-mode derivation
+        in chat_completion_helpers.py routes gpt-5.x to /responses
+        and 404s.
+
+        Regression test for the case where Mercator (a downstream
+        Hermes consumer) configured a gpt-5.5 fallback at
+        ``mercator-aux-swc.cognitiveservices.azure.com/openai/v1`` and
+        observed the fallback rotation activate but immediately fail
+        on /responses because Azure was not detected."""
+        assert (
+            agent._is_azure_openai_url(
+                "https://mercator-aux-swc.cognitiveservices.azure.com/openai/v1"
+            )
+            is True
+        )
+        assert (
+            agent._is_azure_openai_url(
+                "https://any-resource.cognitiveservices.azure.com/"
+            )
+            is True
+        )
+        # And via the instance attribute, same as the openai.azure.com case.
+        agent.base_url = "https://my-foundry.cognitiveservices.azure.com/openai/v1"
+        assert agent._is_azure_openai_url() is True
+
 
 # ---------------------------------------------------------------------------
 # System prompt stability for prompt caching


### PR DESCRIPTION
## Summary

Two bugs caused configured `auxiliary.<task>.fallback_chain` entries to be silently ignored at runtime — even though the YAML config was correct, the endpoints were real, and the rest of the pipeline worked. Together they made every per-task fallback endpoint inert.

This was self-diagnosed by a downstream Hermes consumer ([Verdigris Mercator](https://github.com/VerdigrisAI/mercator)) on 2026-05-21 after 24+ hours of configured Azure Foundry fallback being silently ignored despite YAML correctness and curl-verified endpoint reach. The fix is two small targeted changes plus three regression tests.

## Bug 1 — argument-name mismatch in `_resolve_single_provider` (TypeError)

`_resolve_single_provider`'s body called `resolve_provider_client` with `base_url=` and `api_key=` keyword arguments. But `resolve_provider_client`'s public signature uses `explicit_base_url=` / `explicit_api_key=` (defined near line 2925 of `auxiliary_client.py`). So every configured `fallback_chain` entry that specified an endpoint raised `TypeError` when `_resolve_single_provider` tried to build the client. The exception was swallowed and the entry was silently dropped.

**Fix:** map the local parameter names to the callee's expected names explicitly.

```python
# Before — TypeError on every call:
client, resolved_model = resolve_provider_client(
    provider=provider, model=model,
    base_url=base_url, api_key=api_key,         # ❌ unexpected kwargs
)

# After — kwargs match the callee's signature:
client, resolved_model = resolve_provider_client(
    provider=provider, model=model,
    explicit_base_url=base_url, explicit_api_key=api_key,
)
```

## Bug 2 — auto-mode bypassed the configured chain entirely

In `call_llm` and `async_call_llm`, the fallback dispatch had two branches:

```python
if is_auto:
    _try_payment_fallback(...)              # built-in openrouter/nous chain
else:
    _try_configured_fallback_chain(...)     # user-configured per-task chain
    if no result: _try_main_agent_model_fallback(...)
```

**The `is_auto` branch never consulted the user-configured `fallback_chain`.** Users with `provider: auto` (the default) — i.e., most users — had every per-task `fallback_chain` config block silently ignored. The code only ever exercised the built-in payment fallback chain (openrouter → nous → local/custom → api-key), which is empty for many deployments.

**Fix:** try the configured chain first in BOTH branches. If it returns no client, fall through to the auto chain (auto users) or the main-agent-model fallback (explicit-provider users).

## Regression tests added

- `test_resolve_single_provider_passes_explicit_kwargs_to_resolve_provider_client` — asserts the call site uses `explicit_base_url` / `explicit_api_key`. Pre-fix code with `base_url=` / `api_key=` fails this test.
- `test_resolve_single_provider_real_signature_compatibility` — sanity check that `resolve_provider_client`'s signature still uses these names. If renamed upstream later, this test surfaces the drift loudly.
- `test_auto_path_tries_configured_fallback_chain_before_built_in` — mocks the primary aux call to fail with `ConnectionError` on `provider: auto` and asserts `_try_configured_fallback_chain` is called BEFORE `_try_payment_fallback`. Pre-fix behavior fails this test.

## Verification approach

After applying this patch to a downstream consumer pinned at `43e566f`, the configured `auxiliary.title_generation.fallback_chain` entry (pointing to a region-isolated Azure Foundry deployment) was exercised on the next connection error and the user-visible `⚠ Auxiliary title generation failed: Connection error.` warning stopped firing across consecutive turns. Same for `auxiliary.vision.fallback_chain`.

## Why this matters for any Hermes user with a configured fallback_chain

If you've ever added a `auxiliary.<task>.fallback_chain:` block to your config and noticed it didn't seem to help when your primary aux endpoint flaked — this is why. The chain wasn't being walked at all.

## Out of scope

- Retry-with-backoff on transient `APIConnectionError` for the primary aux call (would reduce the number of times we fall over to fallback at all). Separate concern; this PR just makes the existing fallback path actually work.
- Inline-credentials concerns in rendered config.yaml (Verdigris Z2O-1580); separately tracked.

🤖 Patch authored with assistance from Claude Code