### PR TITLE
Fix GitGuardian-triggering test literals

### DIFF
--- a/tests/cli/test_openai_provider_auto.py
+++ b/tests/cli/test_openai_provider_auto.py
@@ -1,0 +1,19 @@
+"""Tests for native OpenAI API provider auto-detection."""
+
+from hermes_cli.auth import resolve_provider
+
+
+def test_auto_detects_openai_api_key_as_openai(monkeypatch):
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.setenv("OPENAI_API_KEY", "openai-test-key")
+    monkeypatch.setattr("hermes_cli.auth._load_auth_store", lambda: {})
+
+    assert resolve_provider("auto") == "openai"
+
+
+def test_openrouter_key_still_wins_openrouter(monkeypatch):
+    monkeypatch.setenv("OPENROUTER_API_KEY", "openrouter-test-key")
+    monkeypatch.setenv("OPENAI_API_KEY", "openai-test-key")
+    monkeypatch.setattr("hermes_cli.auth._load_auth_store", lambda: {})
+
+    assert resolve_provider("auto") == "openrouter"

--- a/tests/gateway/test_inbound_log_redaction.py
+++ b/tests/gateway/test_inbound_log_redaction.py
@@ -1,0 +1,14 @@
+from agent.redact import redact_sensitive_text
+
+
+def test_inbound_log_preview_redacts_secret_like_content(monkeypatch):
+    monkeypatch.setattr("agent.redact._REDACT_ENABLED", True)
+
+    preview = redact_sensitive_text(
+        "Use OPENAI_API_KEY=example-secret-1234 for this",
+        force=True,
+    )
+
+    assert "example-secret-1234" not in preview
+    assert "OPENAI_API_KEY=" in preview
+    assert "exampl...1234" in preview


### PR DESCRIPTION
This amends the Hermes agent test literals to avoid secret-shaped placeholders that GitGuardian flags, and fixes the redaction test to use the shared redaction helper directly.\n\nVerification:\n- pytest tests/cli/test_openai_provider_auto.py tests/gateway/test_inbound_log_redaction.py -q