### PR TITLE
fix(telegram): allow disabling typing indicators

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -866,6 +866,11 @@ def load_gateway_config() -> GatewayConfig:
                         bridged["channel_prompts"] = {str(k): v for k, v in channel_prompts.items()}
                     else:
                         bridged["channel_prompts"] = channel_prompts
+                if plat == Platform.TELEGRAM and "typing_indicators" in platform_cfg:
+                    bridged["typing_indicators"] = _coerce_bool(
+                        platform_cfg.get("typing_indicators"),
+                        True,
+                    )
                 if "gateway_restart_notification" in platform_cfg:
                     bridged["gateway_restart_notification"] = platform_cfg["gateway_restart_notification"]
                 enabled_was_explicit = "enabled" in platform_cfg

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -3930,6 +3930,14 @@ class TelegramAdapter(BasePlatformAdapter):
 
     async def send_typing(self, chat_id: str, metadata: Optional[Dict[str, Any]] = None) -> None:
         """Send typing indicator."""
+        typing_indicators = self.config.extra.get("typing_indicators", True)
+        if isinstance(typing_indicators, str):
+            typing_indicators = typing_indicators.strip().lower() not in {"0", "false", "no", "off"}
+        env_override = os.getenv("TELEGRAM_TYPING_INDICATORS")
+        if env_override is not None:
+            typing_indicators = env_override.strip().lower() not in {"0", "false", "no", "off"}
+        if not typing_indicators:
+            return
         if self._bot:
             _is_dm_topic: bool = False
             message_thread_id: Optional[int] = None

--- a/tests/gateway/test_telegram_typing_indicator_config.py
+++ b/tests/gateway/test_telegram_typing_indicator_config.py
@@ -1,0 +1,36 @@
+import pytest
+
+from gateway.config import PlatformConfig
+from gateway.platforms.telegram import TelegramAdapter
+
+
+class DummyBot:
+    def __init__(self):
+        self.actions = []
+
+    async def send_chat_action(self, **kwargs):
+        self.actions.append(kwargs)
+
+
+@pytest.mark.asyncio
+async def test_telegram_typing_indicators_can_be_disabled_by_config():
+    adapter = TelegramAdapter(PlatformConfig(extra={"typing_indicators": False}))
+    bot = DummyBot()
+    adapter._bot = bot
+
+    await adapter.send_typing("123", metadata={"thread_id": "131"})
+
+    assert bot.actions == []
+
+
+@pytest.mark.asyncio
+async def test_telegram_typing_indicators_default_enabled():
+    adapter = TelegramAdapter(PlatformConfig(extra={}))
+    bot = DummyBot()
+    adapter._bot = bot
+
+    await adapter.send_typing("123", metadata={"thread_id": "131"})
+
+    assert bot.actions == [
+        {"chat_id": 123, "action": "typing", "message_thread_id": 131}
+    ]


### PR DESCRIPTION
## Summary
- Bridge telegram.typing_indicators from config into Telegram adapter extra config
- Allow typing indicators to be disabled by config or TELEGRAM_TYPING_INDICATORS env override
- Add focused regression coverage

## Test Plan
- python -m py_compile gateway/config.py gateway/platforms/telegram.py tests/gateway/test_telegram_typing_indicator_config.py
- python -m pytest tests/gateway/test_telegram_typing_indicator_config.py -q -o addopts=