### PR TITLE
docs(vision): document model.supports_vision override for custom-provider models

### DIFF
--- a/website/docs/user-guide/features/vision.md
+++ b/website/docs/user-guide/features/vision.md
@@ -199,7 +199,20 @@ When a user attaches an image — from the CLI clipboard, the gateway (Telegram/
 | **Vision-capable** (GPT-4V, Claude with vision, Gemini, Qwen-VL, MiMo-VL, etc.) | Sent as **real pixels** using the provider's native image content format above. No text summary layer. |
 | **Text-only** (DeepSeek V3, smaller open-source models, older chat-only endpoints) | Routed through the `vision_analyze` auxiliary tool — an auxiliary vision model describes the image, and the text description is injected into the conversation. |
 
-You don't configure this — Hermes looks up your current model's capability in the provider metadata and picks the right path automatically. The practical effect: you can switch between vision and non-vision models mid-session and image handling "just works" without changing your workflow. Text-only models get coherent context about the image rather than a broken multimodal payload they'd have to reject.
+In most cases you don't configure this — Hermes looks up your current model's capability in the provider metadata and picks the right path automatically. The practical effect: you can switch between vision and non-vision models mid-session and image handling "just works" without changing your workflow. Text-only models get coherent context about the image rather than a broken multimodal payload they'd have to reject.
+
+### Overriding the auto-detected capability
+
+If you're running a vision-capable model on a `provider: custom` endpoint that Hermes can't auto-detect — for example a local llama.cpp or vLLM build serving a model that isn't listed in the bundled `models.dev` metadata — Hermes will fall back to the `vision_analyze` text-pipeline by default. Set `supports_vision: true` on your `model:` block to opt that model into native routing for user-attached images:
+
+```yaml
+model:
+  default: my-llava
+  provider: custom
+  supports_vision: true        # opt this model into native image routing
+```
+
+Use a YAML boolean (`true` or `false`). For user-attached images this single knob is enough — you don't also need to pin `agent.image_input_mode: native`. (Other vision entry points such as `vision_analyze` and `browser_vision` continue to follow their own routing logic — see [`vision_analyze` has the same dual behavior](#vision_analyze-has-the-same-dual-behavior) below.)
 
 Which auxiliary model handles the text-description path is configurable under `auxiliary.vision` — see [Auxiliary Models](/docs/user-guide/configuration#auxiliary-models).
 


### PR DESCRIPTION
## Summary

Documents the new `model.supports_vision` config override merged in #29679 (single-knob native vision for custom-provider models, salvage of #17936 by @CNSeniorious000). The page currently asserts "you don't configure this" for image-routing capability, which is now stale: for custom-provider models that aren't listed in the bundled `models.dev` metadata, users can opt in to native image routing without falling back to the `vision_analyze` text-pipeline.

## What changed

- Soften the "you don't configure this" line to "in most cases you don't configure this"
- Add a new `### Overriding the auto-detected capability` subsection documenting the `model.supports_vision: true` knob, with a YAML example for the common `provider: custom` case
- Scope the claim explicitly to **user-attached image routing** — `vision_analyze` and `browser_vision` still follow their own logic (see #29987 for in-flight work extending the override to those tools)
- Note that `agent.image_input_mode: native` is no longer required as a companion pin

Single file, ~13 added lines. Diff motivated entirely by behavior introduced in #29679's `_supports_vision_override()` resolver in `agent/image_routing.py`.

## Out of scope

- I deliberately did **not** document the per-provider/per-model nested form (`providers.<provider>.models.<model>.supports_vision`) — its config-namespace relationship to the existing `custom_providers:` block documented in `website/docs/integrations/providers.md` is non-trivial enough to deserve its own section (or a follow-up patch alongside #29987 when the broader override surface stabilises).
- No changes to `providers.md`, `configuration.md`, or test fixtures.

If this has already landed via a separate docs patch / blog post, please feel free to close + mark accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
