### PR TITLE
fix: enforce strict website policy for cron jobs

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1135,7 +1135,21 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
     """Execute a single cron job, applying any per-job profile override."""
     job_id = job["id"]
     with _job_profile_context(job_id, job.get("profile")):
-        return _run_job_impl(job)
+        # LLM-driven cron jobs are unattended web-capable agent runs. Enable
+        # strict website policy around the entire implementation path so every
+        # pre-agent short-circuit and exception resets cleanly in one place.
+        if job.get("no_agent"):
+            return _run_job_impl(job)
+        from tools.website_policy import (
+            reset_unattended_strict_website_policy,
+            set_unattended_strict_website_policy,
+        )
+
+        unattended_policy_token = set_unattended_strict_website_policy(True)
+        try:
+            return _run_job_impl(job)
+        finally:
+            reset_unattended_strict_website_policy(unattended_policy_token)
 
 
 def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -1218,6 +1218,168 @@ class TestRunJobSessionPersistence:
         assert error is None
         assert final_response == "all good"
 
+    def test_run_job_activates_unattended_website_policy_during_agent_run(self, tmp_path, monkeypatch):
+        from tools.website_policy import _unattended_strict_enabled
+
+        monkeypatch.delenv("HERMES_UNATTENDED_STRICT_WEBSITE_POLICY", raising=False)
+        job = {
+            "id": "website-policy-active-job",
+            "name": "website policy active",
+            "prompt": "check policy",
+        }
+        fake_db = MagicMock()
+        seen = {}
+
+        class FakeAgent:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            def run_conversation(self, prompt):
+                seen["strict"] = _unattended_strict_enabled()
+                return {"final_response": "ok", "completed": True}
+
+            def close(self):
+                pass
+
+        with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler._resolve_origin", return_value=None), \
+             patch("dotenv.load_dotenv"), \
+             patch("hermes_state.SessionDB", return_value=fake_db), \
+             patch(
+                 "hermes_cli.runtime_provider.resolve_runtime_provider",
+                 return_value={
+                     "api_key": "***",
+                     "base_url": "https://example.invalid/v1",
+                     "provider": "openrouter",
+                     "api_mode": "chat_completions",
+                 },
+             ), \
+             patch("run_agent.AIAgent", FakeAgent):
+            success, _output, final_response, error = run_job(job)
+
+        assert success is True
+        assert error is None
+        assert final_response == "ok"
+        assert seen["strict"] is True
+        assert _unattended_strict_enabled() is False
+
+    def test_run_job_does_not_activate_unattended_website_policy_for_no_agent(self, tmp_path, monkeypatch):
+        from tools.website_policy import _unattended_strict_enabled
+
+        monkeypatch.delenv("HERMES_UNATTENDED_STRICT_WEBSITE_POLICY", raising=False)
+        job = {
+            "id": "website-policy-no-agent-job",
+            "name": "website policy no agent",
+            "script": "script.py",
+            "no_agent": True,
+        }
+        seen = {}
+
+        def fake_script(_script_path):
+            seen["strict"] = _unattended_strict_enabled()
+            return True, "script output"
+
+        with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler._run_job_script", side_effect=fake_script):
+            success, _output, final_response, error = run_job(job)
+
+        assert success is True
+        assert error is None
+        assert final_response == "script output"
+        assert seen["strict"] is False
+        assert _unattended_strict_enabled() is False
+
+    def test_run_job_resets_unattended_website_policy_after_wake_gate_skip(self, tmp_path, monkeypatch):
+        from tools.website_policy import _unattended_strict_enabled, set_unattended_strict_website_policy
+
+        monkeypatch.delenv("HERMES_UNATTENDED_STRICT_WEBSITE_POLICY", raising=False)
+        job = {
+            "id": "website-policy-wake-skip-job",
+            "name": "website policy wake skip",
+            "prompt": "check policy",
+            "script": "wake_gate.py",
+        }
+
+        with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler._run_job_script", return_value=(True, '{"wakeAgent": false}')):
+            success, _output, final_response, error = run_job(job)
+
+        leaked = _unattended_strict_enabled()
+        set_unattended_strict_website_policy(False)
+
+        assert success is True
+        assert error is None
+        assert final_response == SILENT_MARKER
+        assert leaked is False
+
+    def test_run_job_resets_unattended_website_policy_after_prompt_injection_block(self, tmp_path, monkeypatch):
+        import cron.scheduler as scheduler
+        from tools.website_policy import _unattended_strict_enabled, set_unattended_strict_website_policy
+
+        monkeypatch.delenv("HERMES_UNATTENDED_STRICT_WEBSITE_POLICY", raising=False)
+        job = {
+            "id": "website-policy-injection-job",
+            "name": "website policy injection",
+            "prompt": "check policy",
+        }
+
+        with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch(
+                 "cron.scheduler._build_job_prompt",
+                 side_effect=scheduler.CronPromptInjectionBlocked("blocked"),
+             ):
+            success, _output, final_response, error = run_job(job)
+
+        leaked = _unattended_strict_enabled()
+        set_unattended_strict_website_policy(False)
+
+        assert success is False
+        assert final_response == ""
+        assert error == "blocked"
+        assert leaked is False
+
+    def test_run_job_resets_unattended_website_policy_after_prompt_none_skip(self, tmp_path, monkeypatch):
+        from tools.website_policy import _unattended_strict_enabled, set_unattended_strict_website_policy
+
+        monkeypatch.delenv("HERMES_UNATTENDED_STRICT_WEBSITE_POLICY", raising=False)
+        job = {
+            "id": "website-policy-prompt-none-job",
+            "name": "website policy prompt none",
+            "prompt": "check policy",
+        }
+
+        with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler._build_job_prompt", return_value=None):
+            success, _output, final_response, error = run_job(job)
+
+        leaked = _unattended_strict_enabled()
+        set_unattended_strict_website_policy(False)
+
+        assert success is True
+        assert error is None
+        assert final_response == SILENT_MARKER
+        assert leaked is False
+
+    def test_run_job_resets_unattended_website_policy_after_pre_agent_exception(self, tmp_path, monkeypatch):
+        from tools.website_policy import _unattended_strict_enabled, set_unattended_strict_website_policy
+
+        monkeypatch.delenv("HERMES_UNATTENDED_STRICT_WEBSITE_POLICY", raising=False)
+        job = {
+            "id": "website-policy-pre-agent-error-job",
+            "name": "website policy pre agent error",
+            "prompt": "check policy",
+        }
+
+        with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler._build_job_prompt", side_effect=RuntimeError("boom")):
+            with pytest.raises(RuntimeError, match="boom"):
+                run_job(job)
+
+        leaked = _unattended_strict_enabled()
+        set_unattended_strict_website_policy(False)
+
+        assert leaked is False
+
     def test_tick_marks_empty_response_as_error(self, tmp_path):
         """When run_job returns success=True but final_response is empty,
         tick() should mark the job as error so last_status != 'ok'.

--- a/tests/tools/test_website_policy_strict.py
+++ b/tests/tools/test_website_policy_strict.py
@@ -1,0 +1,410 @@
+from pathlib import Path
+
+from tools.website_policy import check_website_access, invalidate_cache
+
+
+def _write_config(path: Path, text: str) -> Path:
+    path.write_text(text)
+    return path
+
+
+def test_unattended_strict_blocks_when_policy_disabled(tmp_path, monkeypatch):
+    cfg = _write_config(
+        tmp_path / "config.yaml",
+        """
+security:
+  website_blocklist:
+    enabled: false
+""".strip()
+        + "\n",
+    )
+    monkeypatch.setenv("HERMES_UNATTENDED_STRICT_WEBSITE_POLICY", "1")
+
+    result = check_website_access("https://example.com", config_path=cfg)
+
+    assert result is not None
+    assert result["rule"] == "policy-disabled"
+
+
+def test_unattended_strict_blocks_on_allowlist_miss(tmp_path, monkeypatch):
+    allowlist = tmp_path / "allow.txt"
+    allowlist.write_text("allowed.example\n")
+    cfg = _write_config(
+        tmp_path / "config.yaml",
+        f"""
+security:
+  website_blocklist:
+    enabled: true
+    mode: allowlist
+    allowlist_files:
+      - {allowlist}
+""".strip()
+        + "\n",
+    )
+    monkeypatch.setenv("HERMES_UNATTENDED_STRICT_WEBSITE_POLICY", "1")
+
+    result = check_website_access("https://blocked.example", config_path=cfg)
+
+    assert result is not None
+    assert result["rule"] == "allowlist-miss"
+
+
+def test_unattended_strict_allows_allowlisted_host(tmp_path, monkeypatch):
+    allowlist = tmp_path / "allow.txt"
+    allowlist.write_text("allowed.example\n")
+    cfg = _write_config(
+        tmp_path / "config.yaml",
+        f"""
+security:
+  website_blocklist:
+    enabled: true
+    mode: allowlist
+    allowlist_files:
+      - {allowlist}
+""".strip()
+        + "\n",
+    )
+    monkeypatch.setenv("HERMES_UNATTENDED_STRICT_WEBSITE_POLICY", "1")
+
+    result = check_website_access("https://allowed.example/path", config_path=cfg)
+
+    assert result is None
+
+
+def test_unattended_strict_reports_empty_allowlist(tmp_path, monkeypatch):
+    cfg = _write_config(
+        tmp_path / "config.yaml",
+        """
+security:
+  website_blocklist:
+    enabled: true
+    mode: allowlist
+""".strip()
+        + "\n",
+    )
+    monkeypatch.setenv("HERMES_UNATTENDED_STRICT_WEBSITE_POLICY", "1")
+
+    result = check_website_access("https://blocked.example", config_path=cfg)
+
+    assert result is not None
+    assert result["rule"] == "allowlist-empty"
+
+
+def test_unattended_strict_fails_closed_on_empty_configured_allowlist_file(tmp_path, monkeypatch):
+    allowlist = tmp_path / "allow.txt"
+    allowlist.write_text("# no active rules\n")
+    cfg = _write_config(
+        tmp_path / "config.yaml",
+        f"""
+security:
+  website_blocklist:
+    enabled: true
+    mode: blocklist
+    allowlist_files:
+      - {allowlist}
+""".strip()
+        + "\n",
+    )
+    monkeypatch.setenv("HERMES_UNATTENDED_STRICT_WEBSITE_POLICY", "1")
+
+    result = check_website_access("https://blocked.example", config_path=cfg)
+
+    assert result is not None
+    assert result["rule"] == "allowlist-empty"
+
+
+def test_unattended_strict_fails_closed_on_missing_configured_allowlist_file(tmp_path, monkeypatch):
+    cfg = _write_config(
+        tmp_path / "config.yaml",
+        f"""
+security:
+  website_blocklist:
+    enabled: true
+    mode: blocklist
+    allowlist_files:
+      - {tmp_path / "missing-allow.txt"}
+""".strip()
+        + "\n",
+    )
+    monkeypatch.setenv("HERMES_UNATTENDED_STRICT_WEBSITE_POLICY", "1")
+
+    result = check_website_access("https://blocked.example", config_path=cfg)
+
+    assert result is not None
+    assert result["rule"] == "allowlist-empty"
+
+
+def test_unattended_strict_fails_closed_without_configured_allowlist(tmp_path, monkeypatch):
+    cfg = _write_config(
+        tmp_path / "config.yaml",
+        """
+security:
+  website_blocklist:
+    enabled: true
+    mode: blocklist
+""".strip()
+        + "\n",
+    )
+    monkeypatch.setenv("HERMES_UNATTENDED_STRICT_WEBSITE_POLICY", "1")
+
+    result = check_website_access("https://unlisted.example", config_path=cfg)
+
+    assert result is not None
+    assert result["rule"] == "allowlist-empty"
+
+
+def test_unattended_strict_fails_closed_on_malformed_allowlist_file_entry(tmp_path, monkeypatch):
+    cfg = _write_config(
+        tmp_path / "config.yaml",
+        """
+security:
+  website_blocklist:
+    enabled: true
+    mode: blocklist
+    allowlist_files:
+      - 123
+""".strip()
+        + "\n",
+    )
+    monkeypatch.setenv("HERMES_UNATTENDED_STRICT_WEBSITE_POLICY", "1")
+
+    result = check_website_access("https://blocked.example", config_path=cfg)
+
+    assert result is not None
+    assert result["rule"] == "allowlist-empty"
+
+
+def test_config_strict_enforces_allowlist_files_in_blocklist_mode(tmp_path, monkeypatch):
+    allowlist = tmp_path / "allow.txt"
+    allowlist.write_text("allowed.example\n")
+    cfg = _write_config(
+        tmp_path / "config.yaml",
+        f"""
+security:
+  website_blocklist:
+    enabled: true
+    strict: true
+    mode: blocklist
+    allowlist_files:
+      - {allowlist}
+""".strip()
+        + "\n",
+    )
+    monkeypatch.delenv("HERMES_UNATTENDED_STRICT_WEBSITE_POLICY", raising=False)
+
+    allowed = check_website_access("https://allowed.example", config_path=cfg)
+    blocked = check_website_access("https://blocked.example", config_path=cfg)
+
+    assert allowed is None
+    assert blocked is not None
+    assert blocked["rule"] == "allowlist-miss"
+
+
+def test_unattended_strict_fails_closed_when_one_of_multiple_allowlist_files_is_empty(tmp_path, monkeypatch):
+    good_allowlist = tmp_path / "good-allow.txt"
+    empty_allowlist = tmp_path / "empty-allow.txt"
+    good_allowlist.write_text("allowed.example\n")
+    empty_allowlist.write_text("# no active rules\n")
+    cfg = _write_config(
+        tmp_path / "config.yaml",
+        f"""
+security:
+  website_blocklist:
+    enabled: true
+    mode: blocklist
+    allowlist_files:
+      - {good_allowlist}
+      - {empty_allowlist}
+""".strip()
+        + "\n",
+    )
+    monkeypatch.setenv("HERMES_UNATTENDED_STRICT_WEBSITE_POLICY", "1")
+
+    result = check_website_access("https://allowed.example", config_path=cfg)
+
+    assert result is not None
+    assert result["rule"] == "allowlist-empty"
+
+
+def test_unattended_strict_fails_closed_when_one_of_multiple_allowlist_files_is_missing(tmp_path, monkeypatch):
+    good_allowlist = tmp_path / "good-allow.txt"
+    missing_allowlist = tmp_path / "missing-allow.txt"
+    good_allowlist.write_text("allowed.example\n")
+    cfg = _write_config(
+        tmp_path / "config.yaml",
+        f"""
+security:
+  website_blocklist:
+    enabled: true
+    mode: blocklist
+    allowlist_files:
+      - {good_allowlist}
+      - {missing_allowlist}
+""".strip()
+        + "\n",
+    )
+    monkeypatch.setenv("HERMES_UNATTENDED_STRICT_WEBSITE_POLICY", "1")
+
+    result = check_website_access("https://allowed.example", config_path=cfg)
+
+    assert result is not None
+    assert result["rule"] == "allowlist-empty"
+
+
+def test_config_strict_blocks_when_policy_disabled(tmp_path, monkeypatch):
+    cfg = _write_config(
+        tmp_path / "config.yaml",
+        """
+security:
+  website_blocklist:
+    enabled: false
+    strict: true
+""".strip()
+        + "\n",
+    )
+    monkeypatch.delenv("HERMES_UNATTENDED_STRICT_WEBSITE_POLICY", raising=False)
+
+    result = check_website_access("https://example.com", config_path=cfg)
+
+    assert result is not None
+    assert result["rule"] == "policy-disabled"
+
+
+def test_config_strict_bypasses_cached_disabled_policy(tmp_path, monkeypatch):
+    hermes_home = tmp_path / ".hermes-disabled-cache"
+    hermes_home.mkdir()
+    cfg = hermes_home / "config.yaml"
+    _write_config(
+        cfg,
+        """
+security:
+  website_blocklist:
+    enabled: false
+""".strip()
+        + "\n",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.delenv("HERMES_UNATTENDED_STRICT_WEBSITE_POLICY", raising=False)
+    invalidate_cache()
+
+    first = check_website_access("https://unlisted.example")
+
+    allowlist = hermes_home / "allow.txt"
+    allowlist.write_text("allowed.example\n")
+    _write_config(
+        cfg,
+        """
+security:
+  website_blocklist:
+    enabled: true
+    strict: true
+    mode: blocklist
+    allowlist_files:
+      - allow.txt
+""".strip()
+        + "\n",
+    )
+    second = check_website_access("https://unlisted.example")
+
+    assert first is None
+    assert second is not None
+    assert second["rule"] == "allowlist-miss"
+
+
+def test_unattended_strict_bypasses_cached_allowlist_when_source_becomes_empty(tmp_path, monkeypatch):
+    hermes_home = tmp_path / ".hermes-cache"
+    hermes_home.mkdir()
+    allowlist = hermes_home / "allow.txt"
+    allowlist.write_text("allowed.example\n")
+    _write_config(
+        hermes_home / "config.yaml",
+        """
+security:
+  website_blocklist:
+    enabled: true
+    mode: allowlist
+    allowlist_files:
+      - allow.txt
+""".strip()
+        + "\n",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("HERMES_UNATTENDED_STRICT_WEBSITE_POLICY", "1")
+    invalidate_cache()
+
+    first = check_website_access("https://allowed.example")
+    allowlist.write_text("# source emptied after first load\n")
+    second = check_website_access("https://allowed.example")
+
+    assert first is None
+    assert second is not None
+    assert second["rule"] == "allowlist-empty"
+
+
+def test_config_strict_fails_closed_on_default_path_malformed_strict_value(tmp_path, monkeypatch):
+    hermes_home = tmp_path / ".hermes-malformed-strict"
+    hermes_home.mkdir()
+    _write_config(
+        hermes_home / "config.yaml",
+        """
+security:
+  website_blocklist:
+    enabled: true
+    strict: "true"
+    mode: invalid-mode
+""".strip()
+        + "\n",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.delenv("HERMES_UNATTENDED_STRICT_WEBSITE_POLICY", raising=False)
+    invalidate_cache()
+
+    result = check_website_access("https://example.com")
+
+    assert result is not None
+    assert result["rule"] == "policy-error"
+
+
+def test_config_strict_fails_closed_on_default_path_policy_error(tmp_path, monkeypatch):
+    hermes_home = tmp_path / ".hermes-strict"
+    hermes_home.mkdir()
+    _write_config(
+        hermes_home / "config.yaml",
+        """
+security:
+  website_blocklist:
+    enabled: true
+    strict: true
+    mode: invalid-mode
+""".strip()
+        + "\n",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.delenv("HERMES_UNATTENDED_STRICT_WEBSITE_POLICY", raising=False)
+
+    result = check_website_access("https://example.com")
+
+    assert result is not None
+    assert result["rule"] == "policy-error"
+
+
+def test_unattended_strict_fails_closed_on_default_path_policy_error(tmp_path, monkeypatch):
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    _write_config(
+        hermes_home / "config.yaml",
+        """
+security:
+  website_blocklist:
+    enabled: true
+    mode: invalid-mode
+""".strip()
+        + "\n",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("HERMES_UNATTENDED_STRICT_WEBSITE_POLICY", "1")
+
+    result = check_website_access("https://example.com")
+
+    assert result is not None
+    assert result["rule"] == "policy-error"

--- a/tools/website_policy.py
+++ b/tools/website_policy.py
@@ -12,8 +12,10 @@ from __future__ import annotations
 
 import fnmatch
 import logging
+import os
 import threading
 import time
+from contextvars import ContextVar, Token
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 from urllib.parse import urlparse
@@ -24,8 +26,11 @@ logger = logging.getLogger(__name__)
 
 _DEFAULT_WEBSITE_BLOCKLIST = {
     "enabled": False,
+    "mode": "blocklist",
     "domains": [],
     "shared_files": [],
+    "allowlist_files": [],
+    "strict": False,
 }
 
 # Cache: parsed policy + timestamp.  Avoids re-reading config.yaml on every
@@ -35,6 +40,21 @@ _cache_lock = threading.Lock()
 _cached_policy: Optional[Dict[str, Any]] = None
 _cached_policy_path: Optional[str] = None
 _cached_policy_time: float = 0.0
+_strict_unattended_policy: ContextVar[bool] = ContextVar("strict_unattended_website_policy", default=False)
+
+
+def set_unattended_strict_website_policy(enabled: bool) -> Token:
+    return _strict_unattended_policy.set(bool(enabled))
+
+
+def reset_unattended_strict_website_policy(token: Token) -> None:
+    _strict_unattended_policy.reset(token)
+
+
+def _unattended_strict_enabled() -> bool:
+    if _strict_unattended_policy.get():
+        return True
+    return str(os.getenv("HERMES_UNATTENDED_STRICT_WEBSITE_POLICY", "")).strip().lower() in {"1", "true", "yes", "on"}
 
 
 def _get_default_config_path() -> Path:
@@ -128,6 +148,28 @@ def _load_policy_config(config_path: Optional[Path] = None) -> Dict[str, Any]:
     return policy
 
 
+def _config_requests_strict_website_policy(config_path: Path) -> bool:
+    """Best-effort preflight for strict=true when full policy validation fails."""
+    if not config_path.exists():
+        return False
+    try:
+        import yaml
+        with open(config_path, encoding="utf-8") as f:
+            config = yaml.safe_load(f) or {}
+    except Exception:
+        return False
+    if not isinstance(config, dict):
+        return False
+    security = config.get("security") or {}
+    if not isinstance(security, dict):
+        return False
+    website_blocklist = security.get("website_blocklist") or {}
+    if not isinstance(website_blocklist, dict):
+        return False
+    strict_value = website_blocklist.get("strict")
+    return strict_value is not False and strict_value is not None
+
+
 def load_website_blocklist(config_path: Optional[Path] = None) -> Dict[str, Any]:
     """Load and return the parsed website blocklist policy.
 
@@ -140,8 +182,10 @@ def load_website_blocklist(config_path: Optional[Path] = None) -> Dict[str, Any]
     resolved_path = str(config_path) if config_path else "__default__"
     now = time.monotonic()
 
-    # Return cached policy if still fresh and same path
-    if config_path is None:
+    # Return cached policy if still fresh and same path. Strict modes bypass
+    # the cache so allowlist source failures (missing/unreadable/emptied files)
+    # fail closed immediately instead of after the cache TTL.
+    if config_path is None and not _unattended_strict_enabled() and not _config_requests_strict_website_policy(_get_default_config_path()):
         with _cache_lock:
             if (
                 _cached_policy is not None
@@ -161,12 +205,26 @@ def load_website_blocklist(config_path: Optional[Path] = None) -> Dict[str, Any]
     if not isinstance(raw_shared_files, list):
         raise WebsitePolicyError("security.website_blocklist.shared_files must be a list")
 
+    raw_allowlist_files = policy.get("allowlist_files", []) or []
+    if not isinstance(raw_allowlist_files, list):
+        raise WebsitePolicyError("security.website_blocklist.allowlist_files must be a list")
+
     enabled = policy.get("enabled", True)
     if not isinstance(enabled, bool):
         raise WebsitePolicyError("security.website_blocklist.enabled must be a boolean")
 
+    mode = str(policy.get("mode", "blocklist") or "blocklist").strip().lower()
+    if mode not in ("blocklist", "allowlist"):
+        raise WebsitePolicyError("security.website_blocklist.mode must be 'blocklist' or 'allowlist'")
+
+    strict = policy.get("strict", False)
+    if not isinstance(strict, bool):
+        raise WebsitePolicyError("security.website_blocklist.strict must be a boolean")
+
     rules: List[Dict[str, str]] = []
+    allow_rules: List[Dict[str, str]] = []
     seen: set[Tuple[str, str]] = set()
+    allow_seen: set[Tuple[str, str]] = set()
 
     for raw_rule in raw_domains:
         normalized = _normalize_rule(raw_rule)
@@ -187,10 +245,64 @@ def load_website_blocklist(config_path: Optional[Path] = None) -> Dict[str, Any]
             rules.append({"pattern": normalized, "source": str(path)})
             seen.add(key)
 
-    result = {"enabled": enabled, "rules": rules}
+    allowlist_configured = False
+    allowlist_source_errors: List[Dict[str, str]] = []
+    for allowlist_file in raw_allowlist_files:
+        allowlist_configured = True
+        if not isinstance(allowlist_file, str) or not allowlist_file.strip():
+            allowlist_source_errors.append({"source": repr(allowlist_file), "reason": "invalid-entry"})
+            continue
+        path = Path(allowlist_file).expanduser()
+        if not path.is_absolute():
+            path = (get_hermes_home() / path).resolve()
+        try:
+            raw_allowlist = path.read_text(encoding="utf-8")
+        except FileNotFoundError:
+            logger.warning("Shared allowlist file not found (skipping): %s", path)
+            allowlist_source_errors.append({"source": str(path), "reason": "not-found"})
+            continue
+        except (OSError, UnicodeDecodeError) as exc:
+            logger.warning("Failed to read shared allowlist file %s (skipping): %s", path, exc)
+            allowlist_source_errors.append({"source": str(path), "reason": type(exc).__name__})
+            continue
 
-    # Cache the result (only for the default path — explicit paths are tests)
-    if config_path == _get_default_config_path():
+        source_rule_count = 0
+        for line in raw_allowlist.splitlines():
+            stripped = line.strip()
+            if not stripped or stripped.startswith("#"):
+                continue
+            normalized = _normalize_rule(stripped)
+            if not normalized:
+                continue
+            source_rule_count += 1
+            key = (str(path), normalized)
+            if key in allow_seen:
+                continue
+            allow_rules.append({"pattern": normalized, "source": str(path)})
+            allow_seen.add(key)
+        if source_rule_count == 0:
+            allowlist_source_errors.append({"source": str(path), "reason": "empty"})
+
+    result = {
+        "enabled": enabled,
+        "mode": mode,
+        "strict": strict,
+        "rules": rules,
+        "allow_rules": allow_rules,
+        "allowlist_configured": allowlist_configured,
+        "allowlist_source_errors": allowlist_source_errors,
+    }
+    if not enabled and not rules and not allow_rules and mode == "blocklist" and strict is False:
+        result = {"enabled": False, "rules": []}
+
+    # Cache the result (only for non-strict default-path policies — explicit
+    # paths are tests, and strict policies must observe allowlist source
+    # changes immediately to preserve fail-closed behavior).
+    if (
+        config_path == _get_default_config_path()
+        and not _unattended_strict_enabled()
+        and not result.get("strict")
+    ):
         with _cache_lock:
             _cached_policy = result
             _cached_policy_path = "__default__"
@@ -230,39 +342,101 @@ def _extract_host_from_urlish(url: str) -> str:
 
 
 def check_website_access(url: str, config_path: Optional[Path] = None) -> Optional[Dict[str, str]]:
-    """Check whether a URL is allowed by the website blocklist policy.
+    """Check whether a URL is allowed by the website policy.
 
     Returns ``None`` if access is allowed, or a dict with block metadata
     (``host``, ``rule``, ``source``, ``message``) if blocked.
 
-    Never raises on policy errors — logs a warning and returns ``None``
-    (fail-open) so a config typo doesn't break all web tools.  Pass
-    ``config_path`` explicitly (tests) to get strict error propagation.
+    By default, config errors fail open for interactive/default usage to avoid
+    breaking all web tools on a typo. In unattended strict mode, config errors
+    fail closed and block access. Pass ``config_path`` explicitly (tests) to get
+    strict error propagation.
     """
-    # Fast path: if no explicit config_path and the cached policy is disabled
-    # or empty, skip all work (no YAML read, no host extraction).
     if config_path is None:
+        default_strict_requested = _config_requests_strict_website_policy(_get_default_config_path())
         with _cache_lock:
             if _cached_policy is not None and not _cached_policy.get("enabled"):
-                return None
+                unattended_strict = _unattended_strict_enabled()
+                if not unattended_strict and not default_strict_requested:
+                    return None
 
     host = _extract_host_from_urlish(url)
     if not host:
         return None
 
+    unattended_strict = _unattended_strict_enabled()
+
     try:
         policy = load_website_blocklist(config_path)
     except WebsitePolicyError as exc:
         if config_path is not None:
-            raise  # Tests pass explicit paths — let errors propagate
+            raise
+        if unattended_strict or _config_requests_strict_website_policy(_get_default_config_path()):
+            return {
+                "url": url,
+                "host": host,
+                "rule": "policy-error",
+                "source": "config",
+                "message": f"Blocked by strict unattended website policy due to config error: {exc}",
+            }
         logger.warning("Website policy config error (failing open): %s", exc)
         return None
     except Exception as exc:
+        if unattended_strict:
+            return {
+                "url": url,
+                "host": host,
+                "rule": "policy-error",
+                "source": "runtime",
+                "message": f"Blocked by strict unattended website policy due to runtime error: {exc}",
+            }
         logger.warning("Unexpected error loading website policy (failing open): %s", exc)
         return None
 
+    strict = unattended_strict or bool(policy.get("strict"))
     if not policy.get("enabled"):
+        if strict:
+            return {
+                "url": url,
+                "host": host,
+                "rule": "policy-disabled",
+                "source": "config",
+                "message": "Blocked because strict website policy is enabled but website policy is disabled.",
+            }
         return None
+
+    mode = str(policy.get("mode", "blocklist") or "blocklist").strip().lower()
+
+    allow_rules = policy.get("allow_rules", []) or []
+    allowlist_source_errors = policy.get("allowlist_source_errors", []) or []
+    enforce_allowlist = mode == "allowlist" or strict
+    if strict and enforce_allowlist and (allowlist_source_errors or not allow_rules):
+        bad_sources = ", ".join(
+            f"{item.get('source', 'unknown')} ({item.get('reason', 'invalid')})"
+            for item in allowlist_source_errors
+            if isinstance(item, dict)
+        )
+        detail = f" Bad allowlist source(s): {bad_sources}." if bad_sources else ""
+        return {
+            "url": url,
+            "host": host,
+            "rule": "allowlist-empty",
+            "source": "allowlist",
+            "message": "Blocked because unattended allowlist mode is active but no complete allowlist source set was loaded." + detail,
+        }
+    if enforce_allowlist:
+        for rule in allow_rules:
+            pattern = rule.get("pattern", "")
+            if _match_host_against_rule(host, pattern):
+                break
+        else:
+            return {
+                "url": url,
+                "host": host,
+                "rule": "allowlist-miss",
+                "source": "allowlist",
+                "message": f"Blocked by unattended allowlist: '{host}' is not in the approved source list.",
+            }
 
     for rule in policy.get("rules", []):
         pattern = rule.get("pattern", "")


### PR DESCRIPTION
## Summary
- activates strict website policy context for LLM-driven cron jobs while keeping `no_agent` script-only jobs outside the LLM web-policy context
- hardens strict allowlist behavior to fail closed on missing, malformed, empty, unreadable, or mixed-bad allowlist sources
- prevents strict-policy bypasses from cached disabled/default policies
- blocks disabled website policy when strict mode is requested
- adds regression coverage for scheduler ContextVar scope/reset and strict allowlist behavior

## Verification
- `python3 -m py_compile cron/scheduler.py tools/website_policy.py`
- `uv run python -m pytest tests/tools/test_website_policy.py tests/tools/test_website_policy_strict.py tests/cron/test_scheduler.py -k 'website_policy or unattended' -o 'addopts=' -q`
  - 45 passed, 127 deselected
- `uv run ruff check cron/scheduler.py tools/website_policy.py tests/cron/test_scheduler.py tests/tools/test_website_policy_strict.py`
  - All checks passed
- `git diff --check`
  - passed
- added-line static scan for common hardcoded secrets, shell execution, eval/exec, pickle, and SQL formatting patterns
  - no findings
- independent delegated review
  - passed with no blocking security concerns or logic errors

## Notes
A full test-suite attempt initially failed during collection because optional extras were missing. After `uv sync --extra all`, the suite progressed but showed broad failures/errors outside this change area and was stopped before completion.
