### PR TITLE
feat(retry): OpenRouter rate limit improvements

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -936,6 +936,7 @@ def run_conversation(
         finish_reason = "stop"
         response = None  # Guard against UnboundLocalError if all retries fail
         api_kwargs = None  # Guard against UnboundLocalError in except handler
+        _last_response_headers = None  # Track headers for proactive rate limit detection
 
         while retry_count < max_retries:
             # ── Nous Portal rate limit guard ──────────────────────
@@ -984,6 +985,42 @@ def run_conversation(
                     pass
                 except Exception:
                     pass  # Never let rate guard break the agent loop
+
+            # ── Proactive OpenRouter rate limit detection ──────────────────
+            # If previous response headers showed critically low headroom
+            # (<2 requests remaining), sleep until reset window to avoid 429s.
+            # This prevents hammering the provider when concurrency is high.
+            if _last_response_headers and agent.provider in {"openrouter", "nous-api"}:
+                _headroom_reset = check_rate_limit_headroom(
+                    _last_response_headers, threshold=2
+                )
+                if _headroom_reset and _headroom_reset > 0:
+                    _wait_until = time.time() + _headroom_reset
+                    agent._emit_status(
+                        f"⏳ Rate limit headroom critical. "
+                        f"Waiting {_headroom_reset:.1f}s for reset..."
+                    )
+                    agent._vprint(
+                        f"{agent.log_prefix}⏳ Proactive throttle: "
+                        f"x-ratelimit-remaining < 2, sleeping {_headroom_reset:.1f}s until reset",
+                        force=True,
+                    )
+                    while time.time() < _wait_until:
+                        if agent._interrupt_requested:
+                            agent._vprint(
+                                f"{agent.log_prefix}⚡ Interrupt during proactive throttle.",
+                                force=True,
+                            )
+                            agent.clear_interrupt()
+                            agent._persist_session(messages, conversation_history)
+                            return {
+                                "final_response": "Operation interrupted during rate limit wait.",
+                                "messages": messages,
+                                "api_calls": api_call_count,
+                                "completed": False,
+                                "interrupted": True,
+                            }
+                        time.sleep(0.2)
 
             try:
                 agent._reset_stream_delivery_tracking()
@@ -1661,6 +1698,16 @@ def run_conversation(
                         )
                 
                 has_retried_429 = False  # Reset on success
+
+                # Capture response headers for proactive rate limit detection
+                # on next iteration (used by check_rate_limit_headroom).
+                _last_response_headers = None
+                if response and hasattr(response, "headers"):
+                    _last_response_headers = response.headers
+                elif response and hasattr(response, "_response"):
+                    # Some transport wrappers nest the raw response
+                    _last_response_headers = getattr(response._response, "headers", None)
+
                 # Clear Nous rate limit state on successful request —
                 # proves the limit has reset and other sessions can
                 # resume hitting Nous.

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -61,7 +61,11 @@ from agent.nous_rate_guard import (
 )
 from agent.process_bootstrap import _install_safe_stdio
 from agent.prompt_caching import apply_anthropic_cache_control
-from agent.retry_utils import jittered_backoff
+from agent.retry_utils import (
+    check_rate_limit_headroom,
+    extract_rate_limit_reset_seconds,
+    jittered_backoff,
+)
 from agent.trajectory import has_incomplete_scratchpad
 from agent.usage_pricing import estimate_usage_cost, normalize_usage
 from hermes_constants import display_hermes_home as _dhh_fn
@@ -2840,18 +2844,28 @@ def run_conversation(
                         "error": _final_summary,
                     }
 
-                # For rate limits, respect the Retry-After header if present
-                _retry_after = None
+                # For rate limits, prefer x-ratelimit-reset-* headers over Retry-After
+                # x-ratelimit-reset-requests is more precise (OpenRouter-specific).
+                # Cap at 300s (5 min) to cover RPM windows but prevent indefinite waits.
+                _reset_wait = None
                 if is_rate_limited:
                     _resp_headers = getattr(getattr(api_error, "response", None), "headers", None)
-                    if _resp_headers and hasattr(_resp_headers, "get"):
-                        _ra_raw = _resp_headers.get("retry-after") or _resp_headers.get("Retry-After")
-                        if _ra_raw:
+                    if _resp_headers:
+                        # Try to parse Retry-After first (some providers only provide this)
+                        _retry_after_raw = None
+                        if hasattr(_resp_headers, "get"):
+                            _retry_after_raw = _resp_headers.get("retry-after") or _resp_headers.get("Retry-After")
+                        _retry_after = None
+                        if _retry_after_raw:
                             try:
-                                _retry_after = min(float(_ra_raw), 120)  # Cap at 2 minutes
+                                _retry_after = float(_retry_after_raw)
                             except (TypeError, ValueError):
                                 pass
-                wait_time = _retry_after if _retry_after else jittered_backoff(retry_count, base_delay=2.0, max_delay=60.0)
+                        # Prefer reset-requests header (more precise for OpenRouter)
+                        _reset_wait = extract_rate_limit_reset_seconds(
+                            _resp_headers, retry_after=_retry_after, max_cap=300.0
+                        )
+                wait_time = _reset_wait if _reset_wait else jittered_backoff(retry_count, base_delay=2.0, max_delay=60.0)
                 if is_rate_limited:
                     agent._emit_status(f"⏱️ Rate limited. Waiting {wait_time:.1f}s (attempt {retry_count + 1}/{max_retries})...")
                 else:

--- a/agent/retry_utils.py
+++ b/agent/retry_utils.py
@@ -2,12 +2,14 @@
 
 Replaces fixed exponential backoff with jittered delays to prevent
 thundering-herd retry spikes when multiple sessions hit the same
-rate-limited provider concurrently.
+rate-limited provider concurrently. Also provides proactive rate limit
+awareness via x-ratelimit-* headers.
 """
 
 import random
 import threading
 import time
+from typing import Any, Mapping, Optional
 
 # Monotonic counter for jitter seed uniqueness within the same process.
 # Protected by a lock to avoid race conditions in concurrent retry paths
@@ -55,3 +57,105 @@ def jittered_backoff(
     jitter = rng.uniform(0, jitter_ratio * delay)
 
     return delay + jitter
+
+
+def extract_rate_limit_reset_seconds(
+    headers: Mapping[str, str],
+    *,
+    retry_after: Optional[float] = None,
+    max_cap: float = 300.0,
+    provider: str = "openrouter",
+) -> Optional[float]:
+    """Extract and prioritize rate limit reset time from headers.
+
+    Prefers x-ratelimit-reset-requests (OpenRouter/OpenAI-compatible)
+    over generic Retry-After, as it's more precise. Both are capped
+    at max_cap to prevent indefinite waits during daily limits.
+
+    Args:
+        headers: Response headers (case-insensitive).
+        retry_after: Pre-parsed Retry-After value in seconds (fallback).
+        max_cap: Maximum wait time in seconds (default 300s = 5 min).
+        provider: Provider name for logging context.
+
+    Returns:
+        Wait time in seconds, or None if no rate limit info found.
+    """
+    if not headers:
+        return retry_after
+
+    # Normalize headers to lowercase for case-insensitive lookup
+    lowered = {k.lower(): v for k, v in headers.items()}
+
+    # Prefer x-ratelimit-reset-requests (RPM window reset time)
+    # or x-ratelimit-reset-requests-1h (hourly window reset time).
+    # OpenRouter populates both; we use the minute window first as
+    # it's typically the tighter constraint for free tier (20 RPM).
+    for header_name in [
+        "x-ratelimit-reset-requests",
+        "x-ratelimit-reset-requests-1h",
+        "x-ratelimit-reset-tokens",
+        "x-ratelimit-reset-tokens-1h",
+    ]:
+        raw_value = lowered.get(header_name)
+        if raw_value:
+            try:
+                reset_seconds = float(raw_value)
+                if reset_seconds > 0:
+                    # Cap to prevent infinitely long waits
+                    capped = min(reset_seconds, max_cap)
+                    return capped
+            except (TypeError, ValueError):
+                continue
+
+    # Fallback to Retry-After if provided
+    if retry_after is not None and retry_after > 0:
+        return min(retry_after, max_cap)
+
+    return None
+
+
+def check_rate_limit_headroom(
+    headers: Mapping[str, str],
+    *,
+    threshold: int = 2,
+) -> Optional[float]:
+    """Check if rate limit headroom is critically low.
+
+    Returns the reset time in seconds if remaining requests/tokens
+    fall below threshold, indicating proactive throttling is needed.
+    Used to avoid unnecessary 429 responses.
+
+    Args:
+        headers: Response headers from previous request.
+        threshold: Alert if remaining requests ≤ this value (default 2).
+
+    Returns:
+        Reset time in seconds if low headroom, None otherwise.
+    """
+    if not headers:
+        return None
+
+    lowered = {k.lower(): v for k, v in headers.items()}
+
+    # Check requests/min headroom first (tighter for free tier)
+    try:
+        remaining_req = int(float(lowered.get("x-ratelimit-remaining-requests", threshold + 1)))
+        if remaining_req <= threshold:
+            reset = lowered.get("x-ratelimit-reset-requests")
+            if reset:
+                return float(reset)
+    except (TypeError, ValueError):
+        pass
+
+    # Check tokens/min as secondary signal
+    try:
+        remaining_tok = int(float(lowered.get("x-ratelimit-remaining-tokens", threshold + 1)))
+        if remaining_tok <= threshold:
+            reset = lowered.get("x-ratelimit-reset-tokens")
+            if reset:
+                return float(reset)
+    except (TypeError, ValueError):
+        pass
+
+    return None

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -586,7 +586,9 @@ agent:
   # to 1 if you use fallback providers and want fast failover on flaky
   # primaries (default 3). The OpenAI SDK does its own low-level retries
   # underneath this wrapper — this is the Hermes-level loop.
-  # api_max_retries: 3
+  # Increased to 6 for OpenRouter free tier (20 RPM) — allows exponential
+  # backoff to settle within 60s window before fallback.
+  api_max_retries: 6
   
   # Enable verbose logging
   verbose: false


### PR DESCRIPTION
Implements 4 improvements to handle OpenRouter free tier (20 RPM) rate limits:

1. **Prefer x-ratelimit-reset-* headers over Retry-After** — More precise, provider-specific. Cap extended from 120s → 300s to handle RPM window resets within 60s cycles.

2. **New helper functions in retry_utils.py:**
   - extract_rate_limit_reset_seconds(): Parse and prioritize rate-limit headers
   - check_rate_limit_headroom(): Detect critical low headroom for proactive throttling

3. **Increased api_max_retries: 3 → 6** — With jittered exponential backoff, 6 retries sum ~60s before fallback, sufficient for OpenRouter RPM window.

4. **Foundation for proactive throttling** — check_rate_limit_headroom() enables pre-call checks to avoid 429s.

Fixes: Worker hitting 20 RPM limit on OpenRouter free tier. Jittered backoff + reset-requests headers now self-heal within 60s window.