### PR TITLE
feat: add resource-aware quota and outbox APIs

### DIFF
--- a/.hermes/plans/2026-05-23-resource-aware-work-dashboard.md
+++ b/.hermes/plans/2026-05-23-resource-aware-work-dashboard.md
@@ -1,0 +1,414 @@
+# Hermes Resource-Aware Work Dashboard Implementation Plan
+
+> **For Hermes:** Use subagent-driven-development skill to implement this plan task-by-task.
+
+**Goal:** Build a quota-aware Hermes/MITC work dashboard that displays Codex quota, protects interactive work from background quota drain, and lets Ed prepare prompts in an Outbox for delayed sending when quota recovers.
+
+**Architecture:** Implement one shared resource/policy layer for Codex quota, then have Web UI, TUI, cron policy, n8n alerts, and the Prompt Outbox consume that same state. Hermes remains source of truth for prompts, history, attachments, retention, and quota policy; n8n observes transitions and triggers alerts/actions through Hermes APIs.
+
+**Tech Stack:** Hermes Agent Python backend, SQLite state store, Hermes API/Web UI, Hermes cron scheduler, OpenAI Codex account usage, n8n on srv-n8n, Telegram notifications, TUI Node.js v20.19.2 for ui-tui build validation.
+
+---
+
+## Product Decisions Validated by Ed
+
+- Treat quota monitoring and delayed prompts as one product epic, not isolated features.
+- Interactive user requests take priority over background crons.
+- Non-critical project crons such as Graph'it can be paused below quota thresholds.
+- n8n should send transition-only alerts at 10%, 5%, 0%, and recovery.
+- Web UI should expose Codex quota directly.
+- Web UI should add an Outbox / "À envoyer" tab for prompt drafts queued for later.
+- Sending at 0% quota requires explicit confirmation.
+- Prompt-response history retention must be configurable for enterprise/legal policy.
+- Prompt drafts can later support attachments, merge/fusion, priority, and project tags.
+
+## Shared Concepts
+
+### Resource Status
+
+Normalize Codex quota into a reusable resource object:
+
+```json
+{
+  "provider": "openai-codex",
+  "ok": true,
+  "status": "ok|economy|warning|critical|exhausted|degraded",
+  "checked_at": "2026-05-23T12:00:00Z",
+  "stale": false,
+  "session": {
+    "remaining_percent": 72,
+    "reset_at": "2026-05-23T13:00:00Z"
+  },
+  "weekly": {
+    "remaining_percent": 41,
+    "reset_at": "2026-05-28T08:00:00Z"
+  }
+}
+```
+
+Status policy:
+
+- `ok`: >= 20%
+- `economy`: < 20%
+- `warning`: < 10%
+- `critical`: < 5%
+- `exhausted`: 0%
+- `degraded`: quota fetch failed repeatedly; never treat this as 0%
+
+### Prompt Outbox Entity
+
+```json
+{
+  "id": "uuid",
+  "title": "Short title",
+  "content": "Prompt text",
+  "status": "draft|queued|scheduled|waiting_quota|blocked|sent|answered|archived|failed",
+  "priority": 50,
+  "project": "Graph'it|MITC|infra|personal|null",
+  "tags": ["graphit", "codex-heavy"],
+  "provider": "openai-codex",
+  "send_condition": {
+    "mode": "manual|quota_positive|quota_above_threshold|quota_full|scheduled_time",
+    "threshold_percent": 10,
+    "scheduled_at": null,
+    "require_confirmation": true
+  },
+  "attachments": [],
+  "merged_from": [],
+  "retention_policy": "default|short|project|legal_hold|custom",
+  "created_at": "iso8601",
+  "updated_at": "iso8601",
+  "queued_at": null,
+  "sent_at": null
+}
+```
+
+### Prompt Response History Entity
+
+```json
+{
+  "id": "uuid",
+  "prompt_id": "uuid",
+  "session_id": "Hermes session id",
+  "request_snapshot": "exact prompt sent",
+  "response_snapshot": "assistant answer/final result",
+  "provider": "openai-codex",
+  "model": "gpt-5.5",
+  "quota_snapshot": {},
+  "attachments_snapshot": [],
+  "project": "MITC",
+  "tags": [],
+  "retention_policy": "default",
+  "created_at": "iso8601",
+  "expires_at": null,
+  "archived": false
+}
+```
+
+---
+
+## Phase 1: Codex quota resource and visibility
+
+### Task 1: Locate existing account usage implementation
+
+**Objective:** Find the current OpenAI Codex account usage/quota code path and avoid duplicating logic.
+
+**Files:**
+- Inspect: `agent/`, `hermes_cli/`, `gateway/`, `tools/`, `tests/`
+
+**Steps:**
+1. Search for `account_usage`, `quota`, `openai-codex`, `/quota`, and `gquota`.
+2. Identify the canonical function or command that returns Codex quota.
+3. Document source file and existing JSON shape in a short note inside this plan or an implementation issue.
+4. If no stable JSON exists, plan a small provider-neutral adapter.
+
+**Verification:**
+- There is a named Python function/module selected as the single source for quota fetch.
+- The implementation does not use `hermes insights` as remaining provider quota.
+
+### Task 2: Add quota resource service with TTL cache
+
+**Objective:** Expose a reusable Python service for cached Codex quota status.
+
+**Files:**
+- Create or modify: likely `agent/account_usage.py`, `agent/resource_policy.py`, or a new `agent/resources.py`
+- Test: `tests/agent/test_resource_policy.py` or similar
+
+**Implementation guidance:**
+- Cache result for 60-120 seconds.
+- Return stale/degraded state on fetch failures.
+- Do not block UI rendering on quota API latency.
+- Do not encode API failure as 0%.
+
+**Verification:**
+- Unit tests cover ok/warning/critical/exhausted/degraded.
+- Unit tests cover TTL cache hit and refresh.
+
+### Task 3: Expose quota through Hermes API
+
+**Objective:** Make quota available to Web UI/n8n via an internal API endpoint.
+
+**Files:**
+- Locate API server adapter under `gateway/` or Web UI backend.
+- Add endpoint: `GET /api/resources/codex-quota` or existing API naming equivalent.
+- Test route behavior.
+
+**Verification:**
+- Curling endpoint returns stable JSON.
+- Failed quota fetch returns `ok: false` / `status: degraded`, not 0%.
+
+### Task 4: Display quota in Web UI
+
+**Objective:** Show Codex quota badge/status in the Web UI chat/dashboard without blocking the UI.
+
+**Files:**
+- Locate Web UI frontend sources.
+- Add resource polling hook with TTL/backoff.
+- Add badge text such as `Codex S72% W41% reset 3h`.
+
+**Verification:**
+- Normal quota visible.
+- Warning/critical/exhausted style visible.
+- Degraded state visible.
+- UI remains responsive if endpoint is slow/unavailable.
+
+### Task 5: Keep TUI statusbar compatible
+
+**Objective:** Ensure TUI quota/statusbar work remains buildable after quota service changes.
+
+**Files:**
+- `ui-tui/packages/hermes-ink/...`
+- `ui-tui/dist/entry.js` if generated artifact is intentionally tracked in this branch.
+
+**Commands:**
+```bash
+cd /home/edou/src/hermes-agent/ui-tui
+export PATH=/home/edou/.local/bin:$PATH
+npm run type-check
+npm run build
+```
+
+**Verification:**
+- Type-check passes.
+- Build passes with Node.js v20.19.2.
+
+---
+
+## Phase 2: n8n transition alerts and cron protection
+
+### Task 6: Implement n8n quota monitor workflow
+
+**Objective:** Create workflow on srv-n8n that monitors quota and sends transition-only Telegram alerts.
+
+**Files/Systems:**
+- srv-n8n n8n instance.
+- Hermes quota API from Task 3.
+- Telegram notification credential/channel.
+
+**Workflow nodes:**
+1. Schedule Trigger every 5-10 minutes.
+2. HTTP Request to Hermes quota endpoint.
+3. Code node computes status + transitions using `$getWorkflowStaticData('global')`.
+4. Telegram notification node.
+5. Optional HTTP calls to pause/resume quota-managed crons.
+
+**Verification:**
+- Simulated 10%, 5%, 0%, and recovery transitions each send exactly one alert.
+- Consecutive unchanged states send no spam.
+- Fetch failure after N attempts sends degraded alert but does not pause jobs.
+
+### Task 7: Add quota-managed cron policy surface
+
+**Objective:** Let Hermes/n8n identify which crons may be paused by quota policy.
+
+**Files:**
+- Inspect `cron/` job model and CLI/API.
+- Add metadata/tags if supported; otherwise use explicit allowlist config.
+
+**Rules:**
+- Never pause critical jobs.
+- Pause only explicitly `quota-managed`/allowlisted jobs.
+- Track IDs paused by policy.
+- Resume only jobs paused by policy, not manually paused jobs.
+
+**Verification:**
+- Test job marked critical is not paused.
+- Test manually paused job is not resumed.
+- Test policy-paused job is resumed when quota >= 10%.
+
+---
+
+## Phase 3: Outbox MVP
+
+### Task 8: Add outbox persistence model
+
+**Objective:** Store prompt drafts/queued prompts in Hermes state DB or a profile-aware DB table.
+
+**Files:**
+- Inspect `hermes_state.py` and migration patterns.
+- Add tables for `prompt_outbox` and optionally `prompt_response_history`.
+- Test migrations on fresh and existing DB.
+
+**Minimum fields:**
+- id, title, content, status, priority, provider, project, tags JSON, send_condition JSON, created_at, updated_at, queued_at, sent_at, retention_policy.
+
+**Verification:**
+- CRUD operations work in tests.
+- Existing state DB migrates safely.
+
+### Task 9: Add Outbox API CRUD
+
+**Objective:** Expose prompt outbox operations to Web UI.
+
+**Endpoints:**
+- `GET /api/outbox/prompts`
+- `POST /api/outbox/prompts`
+- `PATCH /api/outbox/prompts/{id}`
+- `DELETE /api/outbox/prompts/{id}`
+- `POST /api/outbox/prompts/{id}/queue`
+- `POST /api/outbox/prompts/{id}/send`
+
+**Verification:**
+- API tests cover create, edit, delete, queue, manual send validation.
+- Deleting a sent prompt either archives or requires explicit destructive action.
+
+### Task 10: Add Web UI Outbox tab
+
+**Objective:** Add second tab to chat page for "À envoyer".
+
+**UI requirements:**
+- list prompt drafts;
+- create/edit/delete;
+- save draft;
+- queue;
+- priority selector;
+- send condition selector;
+- send now button;
+- blocked reason display.
+
+**Verification:**
+- User can create a prompt and refresh page without losing it.
+- User can queue prompt with quota threshold.
+- User sees why a prompt is blocked.
+
+### Task 11: Implement quota-aware send guard
+
+**Objective:** Enforce confirmation and policy before sending queued prompts.
+
+**Rules:**
+- If quota = 0 and manual send: return confirmation-required response.
+- If quota fetch degraded: do not auto-send.
+- If prompt older than configured threshold: require review before auto-send.
+- If prompt has attachments in future: default to confirmation-required.
+
+**Verification:**
+- Unit tests for all guard decisions.
+- UI shows confirmation flow at quota 0%.
+
+### Task 12: Add prompt-response history MVP
+
+**Objective:** Record sent prompt and final response snapshot linked to Hermes session ID.
+
+**Files:**
+- State DB model.
+- API endpoint `GET /api/outbox/history`.
+- Web UI history tab or section.
+
+**Verification:**
+- Sent prompt creates history record.
+- History record includes session id, provider/model, prompt snapshot, response snapshot, timestamps.
+
+---
+
+## Phase 4: Advanced dashboard features
+
+### Task 13: Attachments model
+
+**Objective:** Track attachments separately from prompt text.
+
+**Fields:** path/object key, original name, MIME type, size, checksum, retention policy, included_at_send.
+
+**Verification:**
+- Attachment metadata persists.
+- Missing attachment blocks send with clear reason.
+- Retention can purge attachment independently from prompt text.
+
+### Task 14: Merge/fusion action
+
+**Objective:** Let selected prompts merge into a single new prompt without losing provenance.
+
+**Modes:**
+- simple concat;
+- structured requirements doc;
+- deduplicate;
+- implementation plan.
+
+**Verification:**
+- New prompt contains `merged_from` IDs.
+- Source prompts are not destroyed by default.
+
+### Task 15: Retention policy
+
+**Objective:** Add configurable retention for drafts, history, and attachments.
+
+**Configuration:**
+- default days for archived drafts;
+- default days for response history;
+- shorter default for attachments;
+- project override;
+- legal hold/pinned exemption.
+
+**Verification:**
+- Dry-run purge lists records.
+- Purge skips pinned/legal-hold records.
+
+### Task 16: Batch send / process-ready endpoint
+
+**Objective:** Let n8n or scheduler process eligible prompts when quota recovers.
+
+**Endpoint:**
+- `POST /api/outbox/process-ready`
+
+**Rules:**
+- Order by priority and scheduled time.
+- Stop if quota drops below threshold.
+- Respect confirmation-required prompts.
+- Return summary of sent/skipped/blocked.
+
+**Verification:**
+- Recovery from 0 triggers process-ready but sends only eligible prompts.
+- Summary can be sent via Telegram.
+
+---
+
+## Quality Gates
+
+Run before merging implementation branches:
+
+```bash
+cd /home/edou/src/hermes-agent
+python -m pytest tests/ -o 'addopts=' -q
+cd ui-tui
+export PATH=/home/edou/.local/bin:$PATH
+npm run type-check
+npm run build
+```
+
+If Web UI has separate frontend commands, add them after locating the package.
+
+## Open Questions to Resolve During Implementation
+
+- Exact Web UI source location and framework/package commands.
+- Existing Hermes API route naming and authentication model.
+- Whether cron jobs already support tags/metadata; if not, define allowlist config first.
+- Whether prompt outbox belongs in `state.db` or profile-specific side DB.
+- Exact provider quota fetch function for OpenAI Codex OAuth.
+- Telegram destination/credential mechanism for srv-n8n.
+
+## Related Skills
+
+- `codex-quota-n8n-monitoring`
+- `hermes-prompt-outbox-dashboard`
+- `hermes-agent`
+- `n8n-operations`
+- `writing-plans`

--- a/agent/prompt_outbox.py
+++ b/agent/prompt_outbox.py
@@ -1,0 +1,368 @@
+"""Prompt Outbox persistence for the Hermes resource-aware dashboard."""
+
+from __future__ import annotations
+
+import json
+import math
+import sqlite3
+import threading
+import time
+import uuid
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, cast
+
+from hermes_constants import get_hermes_home
+from hermes_state import apply_wal_with_fallback
+
+_SCHEMA_SQL = """
+CREATE TABLE IF NOT EXISTS prompt_drafts (
+    id TEXT PRIMARY KEY,
+    title TEXT NOT NULL,
+    content TEXT NOT NULL,
+    status TEXT NOT NULL DEFAULT 'draft',
+    priority INTEGER NOT NULL DEFAULT 50,
+    project TEXT,
+    tags_json TEXT NOT NULL DEFAULT '[]',
+    provider TEXT NOT NULL DEFAULT 'openai-codex',
+    send_condition_json TEXT NOT NULL DEFAULT '{"mode":"manual","require_confirmation":true}',
+    attachments_json TEXT NOT NULL DEFAULT '[]',
+    merged_from_json TEXT NOT NULL DEFAULT '[]',
+    retention_policy TEXT NOT NULL DEFAULT 'default',
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    queued_at TEXT,
+    sent_at TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_prompt_drafts_status_priority
+    ON prompt_drafts(status, priority DESC, created_at ASC);
+CREATE INDEX IF NOT EXISTS idx_prompt_drafts_project
+    ON prompt_drafts(project);
+"""
+
+_VALID_STATUSES = {
+    "draft",
+    "queued",
+    "scheduled",
+    "waiting_quota",
+    "blocked",
+    "sent",
+    "answered",
+    "archived",
+    "failed",
+}
+_VALID_SEND_MODES = {
+    "manual",
+    "quota_positive",
+    "quota_above_threshold",
+    "quota_full",
+    "scheduled_time",
+}
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _json_dumps(value: Any) -> str:
+    return json.dumps(value, ensure_ascii=False, separators=(",", ":"))
+
+
+def _json_loads(value: str | None, default: Any) -> Any:
+    if not value:
+        return default
+    try:
+        return json.loads(value)
+    except (TypeError, json.JSONDecodeError):
+        return default
+
+
+def _normalize_send_condition(condition: dict[str, Any] | None) -> dict[str, Any]:
+    normalized: dict[str, Any] = {
+        "mode": "manual",
+        "require_confirmation": True,
+    }
+    if condition:
+        normalized.update(condition)
+    mode = normalized.get("mode")
+    if mode not in _VALID_SEND_MODES:
+        raise ValueError(f"Unsupported send condition mode: {mode}")
+    threshold = normalized.get("threshold_percent")
+    if normalized["mode"] == "quota_above_threshold" and threshold is None:
+        raise ValueError("threshold_percent is required for quota_above_threshold")
+    if threshold is not None:
+        try:
+            threshold_float = float(threshold)
+        except (TypeError, ValueError) as exc:
+            raise ValueError("threshold_percent must be a finite number") from exc
+        if not math.isfinite(threshold_float) or threshold_float < 0 or threshold_float > 100:
+            raise ValueError("threshold_percent must be between 0 and 100")
+        normalized["threshold_percent"] = threshold_float
+    return normalized
+
+
+def _normalize_tags(tags: list[str] | None) -> list[str]:
+    if not tags:
+        return []
+    return [str(tag).strip() for tag in tags if str(tag).strip()]
+
+
+@dataclass(frozen=True)
+class PromptDraft:
+    id: str
+    title: str
+    content: str
+    status: str
+    priority: int
+    project: str | None
+    tags: list[str]
+    provider: str
+    send_condition: dict[str, Any]
+    attachments: list[dict[str, Any]]
+    merged_from: list[str]
+    retention_policy: str
+    created_at: str
+    updated_at: str
+    queued_at: str | None = None
+    sent_at: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+class PromptDraftStore:
+    """SQLite-backed PromptDraft store used by the dashboard/API."""
+
+    def __init__(self, db_path: Path | None = None):
+        self.db_path = db_path or (get_hermes_home() / "outbox.db")
+        self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        self._lock = threading.Lock()
+        self._conn: sqlite3.Connection | None = sqlite3.connect(
+            str(self.db_path),
+            check_same_thread=False,
+            timeout=5.0,
+            isolation_level=None,
+        )
+        self._conn.row_factory = sqlite3.Row
+        apply_wal_with_fallback(self._conn, db_label="outbox.db")
+        self._init_schema()
+
+    def close(self) -> None:
+        with self._lock:
+            if self._conn is not None:
+                self._conn.close()
+                self._conn = None
+
+    def _init_schema(self) -> None:
+        with self._lock:
+            conn = cast(sqlite3.Connection, self._conn)
+            conn.executescript(_SCHEMA_SQL)
+
+    def _execute_write(self, sql: str, params: tuple[Any, ...]) -> sqlite3.Cursor:
+        last_exc: sqlite3.OperationalError | None = None
+        for attempt in range(10):
+            try:
+                with self._lock:
+                    conn = cast(sqlite3.Connection, self._conn)
+                    conn.execute("BEGIN IMMEDIATE")
+                    try:
+                        cur = conn.execute(sql, params)
+                        conn.commit()
+                        return cur
+                    except BaseException:
+                        conn.rollback()
+                        raise
+            except sqlite3.OperationalError as exc:
+                if "locked" in str(exc).lower() or "busy" in str(exc).lower():
+                    last_exc = exc
+                    time.sleep(min(0.05 * (attempt + 1), 0.5))
+                    continue
+                raise
+        raise last_exc or sqlite3.OperationalError("outbox.db write failed")
+
+    @staticmethod
+    def _row_to_prompt(row: sqlite3.Row | None) -> PromptDraft | None:
+        if row is None:
+            return None
+        return PromptDraft(
+            id=row["id"],
+            title=row["title"],
+            content=row["content"],
+            status=row["status"],
+            priority=int(row["priority"]),
+            project=row["project"],
+            tags=_json_loads(row["tags_json"], []),
+            provider=row["provider"],
+            send_condition=_json_loads(row["send_condition_json"], {"mode": "manual"}),
+            attachments=_json_loads(row["attachments_json"], []),
+            merged_from=_json_loads(row["merged_from_json"], []),
+            retention_policy=row["retention_policy"],
+            created_at=row["created_at"],
+            updated_at=row["updated_at"],
+            queued_at=row["queued_at"],
+            sent_at=row["sent_at"],
+        )
+
+    def list_prompts(
+        self,
+        *,
+        include_archived: bool = False,
+        status: str | None = None,
+        project: str | None = None,
+        limit: int = 100,
+    ) -> list[PromptDraft]:
+        clauses: list[str] = []
+        params: list[Any] = []
+        if not include_archived:
+            clauses.append("status != ?")
+            params.append("archived")
+        if status:
+            clauses.append("status = ?")
+            params.append(status)
+        if project:
+            clauses.append("project = ?")
+            params.append(project)
+        where = f"WHERE {' AND '.join(clauses)}" if clauses else ""
+        safe_limit = max(1, min(int(limit), 500))
+        with self._lock:
+            conn = cast(sqlite3.Connection, self._conn)
+            rows = conn.execute(
+                f"""
+                SELECT * FROM prompt_drafts
+                {where}
+                ORDER BY priority DESC, created_at ASC
+                LIMIT ?
+                """,
+                (*params, safe_limit),
+            ).fetchall()
+        return [prompt for row in rows if (prompt := self._row_to_prompt(row)) is not None]
+
+    def get_prompt(self, prompt_id: str) -> PromptDraft | None:
+        with self._lock:
+            conn = cast(sqlite3.Connection, self._conn)
+            row = conn.execute(
+                "SELECT * FROM prompt_drafts WHERE id = ?",
+                (prompt_id,),
+            ).fetchone()
+        return self._row_to_prompt(row)
+
+    def create_prompt(
+        self,
+        *,
+        title: str,
+        content: str,
+        status: str = "draft",
+        priority: int = 50,
+        project: str | None = None,
+        tags: list[str] | None = None,
+        provider: str = "openai-codex",
+        send_condition: dict[str, Any] | None = None,
+        attachments: list[dict[str, Any]] | None = None,
+        merged_from: list[str] | None = None,
+        retention_policy: str = "default",
+    ) -> PromptDraft:
+        title = title.strip()
+        content = content.strip()
+        if not title:
+            raise ValueError("title is required")
+        if not content:
+            raise ValueError("content is required")
+        if status not in _VALID_STATUSES:
+            raise ValueError(f"Unsupported prompt status: {status}")
+        now = _now_iso()
+        prompt_id = str(uuid.uuid4())
+        normalized_condition = _normalize_send_condition(send_condition)
+        queued_at = now if status == "queued" else None
+        self._execute_write(
+            """
+            INSERT INTO prompt_drafts (
+                id, title, content, status, priority, project, tags_json,
+                provider, send_condition_json, attachments_json, merged_from_json,
+                retention_policy, created_at, updated_at, queued_at, sent_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                prompt_id,
+                title,
+                content,
+                status,
+                int(priority),
+                project,
+                _json_dumps(_normalize_tags(tags)),
+                provider or "openai-codex",
+                _json_dumps(normalized_condition),
+                _json_dumps(attachments or []),
+                _json_dumps(merged_from or []),
+                retention_policy or "default",
+                now,
+                now,
+                queued_at,
+                None,
+            ),
+        )
+        prompt = self.get_prompt(prompt_id)
+        assert prompt is not None
+        return prompt
+
+    def update_prompt(self, prompt_id: str, **changes: Any) -> PromptDraft | None:
+        existing = self.get_prompt(prompt_id)
+        if existing is None:
+            return None
+
+        data = existing.to_dict()
+        for key, value in changes.items():
+            data[key] = value
+        if data.get("title") is None:
+            raise ValueError("title is required")
+        if data.get("content") is None:
+            raise ValueError("content is required")
+        if data.get("status") is None:
+            raise ValueError("status is required")
+        data["title"] = str(data["title"]).strip()
+        data["content"] = str(data["content"]).strip()
+        if not data["title"]:
+            raise ValueError("title is required")
+        if not data["content"]:
+            raise ValueError("content is required")
+        if data["status"] not in _VALID_STATUSES:
+            raise ValueError(f"Unsupported prompt status: {data['status']}")
+        data["tags"] = _normalize_tags(data.get("tags"))
+        data["send_condition"] = _normalize_send_condition(data.get("send_condition"))
+        data["updated_at"] = _now_iso()
+        if data["status"] == "queued" and not data.get("queued_at"):
+            data["queued_at"] = data["updated_at"]
+
+        self._execute_write(
+            """
+            UPDATE prompt_drafts
+            SET title = ?, content = ?, status = ?, priority = ?, project = ?,
+                tags_json = ?, provider = ?, send_condition_json = ?,
+                attachments_json = ?, merged_from_json = ?, retention_policy = ?,
+                updated_at = ?, queued_at = ?, sent_at = ?
+            WHERE id = ?
+            """,
+            (
+                data["title"],
+                data["content"],
+                data["status"],
+                int(data["priority"]),
+                data.get("project"),
+                _json_dumps(data["tags"]),
+                data.get("provider") or "openai-codex",
+                _json_dumps(data["send_condition"]),
+                _json_dumps(data.get("attachments") or []),
+                _json_dumps(data.get("merged_from") or []),
+                data.get("retention_policy") or "default",
+                data["updated_at"],
+                data.get("queued_at"),
+                data.get("sent_at"),
+                prompt_id,
+            ),
+        )
+        return self.get_prompt(prompt_id)
+
+    def delete_prompt(self, prompt_id: str) -> bool:
+        cur = self._execute_write("DELETE FROM prompt_drafts WHERE id = ?", (prompt_id,))
+        return cur.rowcount > 0

--- a/agent/resource_policy.py
+++ b/agent/resource_policy.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Any, Callable, Optional
+
+
+@dataclass(frozen=True)
+class QuotaWindowStatus:
+    label: str
+    remaining_percent: Optional[float] = None
+    used_percent: Optional[float] = None
+    reset_at: Optional[datetime] = None
+
+
+@dataclass(frozen=True)
+class QuotaResourceStatus:
+    provider: str
+    ok: bool
+    status: str
+    checked_at: datetime
+    remaining_percent: Optional[float] = None
+    windows: dict[str, QuotaWindowStatus] | None = None
+    plan: Optional[str] = None
+    stale: bool = False
+    error: Optional[str] = None
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _window_key(label: str) -> str:
+    normalized = str(label or "").strip().lower().replace(" ", "_")
+    if normalized in {"current_session", "primary", "primary_window"}:
+        return "session"
+    if normalized in {"current_week", "secondary", "secondary_window"}:
+        return "weekly"
+    return normalized or "unknown"
+
+
+def _remaining_from_used(used_percent: Optional[float]) -> Optional[float]:
+    if used_percent is None:
+        return None
+    remaining = 100.0 - float(used_percent)
+    if remaining < 0:
+        return 0.0
+    if remaining > 100:
+        return 100.0
+    return round(remaining, 2)
+
+
+def quota_status_for_remaining(remaining_percent: Optional[float]) -> str:
+    if remaining_percent is None:
+        return "degraded"
+    remaining = float(remaining_percent)
+    if remaining <= 0:
+        return "exhausted"
+    if remaining < 5:
+        return "critical"
+    if remaining < 10:
+        return "warning"
+    if remaining < 20:
+        return "economy"
+    return "ok"
+
+
+def build_quota_resource_status(
+    snapshot: Optional[Any],
+    *,
+    checked_at: Optional[datetime] = None,
+    stale: bool = False,
+    error: Optional[str] = None,
+) -> QuotaResourceStatus:
+    now = checked_at or _utc_now()
+    if snapshot is None:
+        return QuotaResourceStatus(
+            provider="openai-codex",
+            ok=False,
+            status="degraded",
+            checked_at=now,
+            remaining_percent=None,
+            windows={},
+            stale=stale,
+            error=error or "quota unavailable",
+        )
+
+    windows: dict[str, QuotaWindowStatus] = {}
+    remaining_values: list[float] = []
+    for window in snapshot.windows:
+        remaining = _remaining_from_used(window.used_percent)
+        if remaining is not None:
+            remaining_values.append(remaining)
+        windows[_window_key(window.label)] = QuotaWindowStatus(
+            label=window.label,
+            remaining_percent=remaining,
+            used_percent=None if window.used_percent is None else float(window.used_percent),
+            reset_at=window.reset_at,
+        )
+
+    constrained_remaining = min(remaining_values) if remaining_values else None
+    status = quota_status_for_remaining(constrained_remaining)
+    return QuotaResourceStatus(
+        provider=snapshot.provider,
+        ok=status != "degraded" and not snapshot.unavailable_reason,
+        status=status if not snapshot.unavailable_reason else "degraded",
+        checked_at=now,
+        remaining_percent=constrained_remaining,
+        windows=windows,
+        plan=snapshot.plan,
+        stale=stale,
+        error=snapshot.unavailable_reason or error,
+    )
+
+
+class CodexQuotaResourceCache:
+    """Small TTL cache for Codex quota resource status.
+
+    UI callers should use this instead of fetching account usage in render paths.
+    Fetch failures return the previous value as stale when possible; otherwise they
+    return a degraded status and never masquerade as exhausted quota.
+    """
+
+    def __init__(
+        self,
+        *,
+        ttl_seconds: int = 90,
+        fetcher: Callable[[], Optional[Any]] | None = None,
+        clock: Callable[[], datetime] = _utc_now,
+    ) -> None:
+        self.ttl = timedelta(seconds=max(1, int(ttl_seconds)))
+        if fetcher is None:
+            def default_fetcher() -> Optional[Any]:
+                from agent.account_usage import fetch_account_usage
+
+                return fetch_account_usage("openai-codex")
+
+            fetcher = default_fetcher
+
+        self.fetcher = fetcher
+        self.clock = clock
+        self._cached: Optional[QuotaResourceStatus] = None
+        self._cached_at: Optional[datetime] = None
+
+    def get(self, *, force_refresh: bool = False) -> QuotaResourceStatus:
+        now = self.clock()
+        if (
+            not force_refresh
+            and self._cached is not None
+            and self._cached_at is not None
+            and now - self._cached_at < self.ttl
+        ):
+            return self._cached
+
+        try:
+            snapshot = self.fetcher()
+            status = build_quota_resource_status(snapshot, checked_at=now)
+        except Exception as exc:
+            if self._cached is not None:
+                status = QuotaResourceStatus(
+                    provider=self._cached.provider,
+                    ok=False,
+                    status="degraded",
+                    checked_at=now,
+                    remaining_percent=self._cached.remaining_percent,
+                    windows=self._cached.windows or {},
+                    plan=self._cached.plan,
+                    stale=True,
+                    error=str(exc) or "quota unavailable",
+                )
+            else:
+                status = build_quota_resource_status(None, checked_at=now, error=str(exc) or "quota unavailable")
+
+        self._cached = status
+        self._cached_at = now
+        return status
+
+
+_default_codex_quota_cache = CodexQuotaResourceCache()
+
+
+def get_codex_quota_resource_status(*, force_refresh: bool = False) -> QuotaResourceStatus:
+    return _default_codex_quota_cache.get(force_refresh=force_refresh)

--- a/cli.py
+++ b/cli.py
@@ -3345,7 +3345,13 @@ class HermesCLI:
         snapshot["session_completion_tokens"] = getattr(agent, "session_completion_tokens", 0) or 0
         snapshot["session_total_tokens"] = getattr(agent, "session_total_tokens", 0) or 0
         snapshot["session_api_calls"] = getattr(agent, "session_api_calls", 0) or 0
-        snapshot["account_limits"] = self._maybe_refresh_account_limits_badge(agent)
+        account_limits = self._maybe_refresh_account_limits_badge(agent)
+        snapshot["account_limits"] = account_limits
+        # Derive the render style from the label in the same snapshot so the
+        # status bar cannot show a freshly-depleted quota with the previous
+        # cached green style for one render tick.
+        if account_limits:
+            snapshot["account_limits_style"] = self._account_limits_badge_style(account_limits)
 
         compressor = getattr(agent, "context_compressor", None)
         if compressor:
@@ -3712,7 +3718,14 @@ class HermesCLI:
             if total_width > width:
                 plain_text = "".join(text for _, text in frags)
                 trimmed = self._trim_status_bar_text(plain_text, width)
-                return [("class:status-bar", trimmed)]
+                overflow_style = "class:status-bar"
+                if snapshot.get("account_limits") and snapshot.get("account_limits_style") == "class:status-bar-critical":
+                    # When narrow terminals force us to collapse styled
+                    # fragments into a single trimmed string, preserve the
+                    # critical quota signal instead of falling back to the
+                    # default green/base status-bar style.
+                    overflow_style = "class:status-bar-critical"
+                return [(overflow_style, trimmed)]
             return frags
         except Exception:
             return [("class:status-bar", f" {self._build_status_bar_text()} ")]

--- a/cli.py
+++ b/cli.py
@@ -2977,6 +2977,7 @@ class HermesCLI:
         # cached so the prompt_toolkit render path never blocks on network.
         self._account_limits_lock = threading.Lock()
         self._account_limits_label: str | None = None
+        self._account_limits_style: str = "class:status-bar-good"
         self._account_limits_provider: str | None = None
         self._account_limits_checked_at: float = 0.0
         self._account_limits_refreshing = False
@@ -3169,10 +3170,23 @@ class HermesCLI:
             return ""
         return f"Acct {' '.join(parts[:2])}"
 
+    @staticmethod
+    def _account_limits_badge_style(label: str) -> str:
+        """Return status-bar style for the account-limit badge.
+
+        A depleted Codex session or weekly window is operationally critical:
+        make the quota badge red as soon as either compact value reaches 0%.
+        """
+        if re.search(r"(?<!\w)[SW]0%(?!\d)", label or ""):
+            return "class:status-bar-critical"
+        return "class:status-bar-good"
+
     def _maybe_refresh_account_limits_badge(self, agent: Any) -> str:
         """Return cached account limits and refresh them in the background if stale."""
         provider = (getattr(agent, "provider", None) or getattr(self, "provider", None) or "").strip()
         if not provider:
+            return ""
+        if not hasattr(self, "_account_limits_lock"):
             return ""
         # Keep this intentionally broad: fetch_account_usage() returns None for
         # unsupported providers, while supported account-backed providers get
@@ -3191,12 +3205,14 @@ class HermesCLI:
 
         def _worker() -> None:
             label = ""
+            style = "class:status-bar-good"
             success = False
             try:
                 from agent.account_usage import fetch_account_usage
                 snapshot = fetch_account_usage(provider, base_url=base_url, api_key=api_key)
                 if snapshot:
                     label = self._format_account_limits_badge(snapshot)
+                    style = self._account_limits_badge_style(label)
                     success = bool(label)
             except Exception:
                 label = ""
@@ -3207,11 +3223,13 @@ class HermesCLI:
                     # after a transient network/auth/quota endpoint failure.
                     if success:
                         self._account_limits_label = label
+                        self._account_limits_style = style
                         self._account_limits_provider = provider
                         self._account_limits_checked_at = time.monotonic()
                     else:
                         if self._account_limits_provider != provider:
                             self._account_limits_label = None
+                            self._account_limits_style = "class:status-bar-good"
                             self._account_limits_provider = provider
                         # Empty/failing fetches should retry quickly. The normal
                         # successful cache remains 5 minutes via the stale check.
@@ -3303,6 +3321,7 @@ class HermesCLI:
             "compressions": 0,
             "active_background_tasks": 0,
             "account_limits": "",
+            "account_limits_style": getattr(self, "_account_limits_style", "class:status-bar-good"),
         }
 
         # Count live /background tasks. The dict entry is removed in the
@@ -3617,6 +3636,7 @@ class HermesCLI:
                 percent_label = f"{percent}%" if percent is not None else "--"
                 if width < 76:
                     account_limits = snapshot.get("account_limits")
+                    account_limits_style = snapshot.get("account_limits_style", "class:status-bar-good")
                     compressions = snapshot.get("compressions", 0)
                     bg_count = snapshot.get("active_background_tasks", 0)
                     frags = [
@@ -3627,7 +3647,7 @@ class HermesCLI:
                     ]
                     if account_limits:
                         frags.append(("class:status-bar-dim", " · "))
-                        frags.append(("class:status-bar-good", account_limits))
+                        frags.append((account_limits_style, account_limits))
                     if compressions:
                         frags.append(("class:status-bar-dim", " · "))
                         frags.append((self._compression_count_style(compressions), f"🗜️ {compressions}"))
@@ -3652,6 +3672,7 @@ class HermesCLI:
 
                     bar_style = self._status_bar_context_style(percent)
                     account_limits = snapshot.get("account_limits")
+                    account_limits_style = snapshot.get("account_limits_style", "class:status-bar-good")
                     compressions = snapshot.get("compressions", 0)
                     bg_count = snapshot.get("active_background_tasks", 0)
                     frags = [
@@ -3666,7 +3687,7 @@ class HermesCLI:
                     ]
                     if account_limits:
                         frags.append(("class:status-bar-dim", " │ "))
-                        frags.append(("class:status-bar-good", account_limits))
+                        frags.append((account_limits_style, account_limits))
                     if compressions:
                         frags.append(("class:status-bar-dim", " │ "))
                         frags.append((self._compression_count_style(compressions), f"🗜️ {compressions}"))

--- a/cli.py
+++ b/cli.py
@@ -2973,6 +2973,13 @@ class HermesCLI:
 
         # Status bar visibility (toggled via /statusbar)
         self._status_bar_visible = True
+        # Account-limit badge in the status bar. Fetched asynchronously and
+        # cached so the prompt_toolkit render path never blocks on network.
+        self._account_limits_lock = threading.Lock()
+        self._account_limits_label: str | None = None
+        self._account_limits_provider: str | None = None
+        self._account_limits_checked_at: float = 0.0
+        self._account_limits_refreshing = False
         # When True, the input separator rules and the dynamic status bar are
         # hidden until the next user input. Set by _recover_after_resize() so a
         # SIGWINCH cannot stamp a freshly-drawn status bar on top of one that
@@ -3140,6 +3147,84 @@ class HermesCLI:
             return "class:status-bar-warn"
         return "class:status-bar-dim"
 
+    @staticmethod
+    def _format_account_limits_badge(snapshot: Any) -> str:
+        """Compact account-limit badge for the status bar, e.g. "Acct S71% W61%"."""
+        windows = getattr(snapshot, "windows", None) or ()
+        parts: list[str] = []
+        for window in windows:
+            used = getattr(window, "used_percent", None)
+            if used is None:
+                continue
+            remaining = max(0, min(100, round(100 - float(used))))
+            label = str(getattr(window, "label", "") or "").strip().lower()
+            if "week" in label:
+                prefix = "W"
+            elif "session" in label or "current" in label:
+                prefix = "S"
+            else:
+                prefix = (label[:1] or "Q").upper()
+            parts.append(f"{prefix}{remaining}%")
+        if not parts:
+            return ""
+        provider = str(getattr(snapshot, "provider", "") or "").lower()
+        label = "Codex" if "codex" in provider else "Acct"
+        return f"{label} {' '.join(parts[:2])}"
+
+    def _maybe_refresh_account_limits_badge(self, agent: Any) -> str:
+        """Return cached account limits and refresh them in the background if stale."""
+        provider = (getattr(agent, "provider", None) or getattr(self, "provider", None) or "").strip()
+        if not provider:
+            return ""
+        # Keep this intentionally broad: fetch_account_usage() returns None for
+        # unsupported providers, while supported account-backed providers get
+        # the same badge automatically.
+        now = time.monotonic()
+        with self._account_limits_lock:
+            cached = self._account_limits_label or ""
+            same_provider = self._account_limits_provider == provider
+            stale = (not same_provider) or (now - self._account_limits_checked_at > 300)
+            if not stale or self._account_limits_refreshing:
+                return cached if same_provider else ""
+            self._account_limits_refreshing = True
+
+        base_url = getattr(agent, "base_url", None) or getattr(self, "base_url", None)
+        api_key = getattr(agent, "api_key", None) or getattr(self, "api_key", None)
+
+        def _worker() -> None:
+            label = ""
+            success = False
+            try:
+                from agent.account_usage import fetch_account_usage
+                snapshot = fetch_account_usage(provider, base_url=base_url, api_key=api_key)
+                if snapshot:
+                    label = self._format_account_limits_badge(snapshot)
+                    success = bool(label)
+            except Exception:
+                label = ""
+                success = False
+            finally:
+                with self._account_limits_lock:
+                    # Do not replace a previously-good badge with an empty label
+                    # after a transient network/auth/quota endpoint failure.
+                    if success:
+                        self._account_limits_label = label
+                        self._account_limits_provider = provider
+                        self._account_limits_checked_at = time.monotonic()
+                    else:
+                        if self._account_limits_provider != provider:
+                            self._account_limits_label = None
+                            self._account_limits_provider = provider
+                        # Empty/failing fetches should retry quickly. The normal
+                        # successful cache remains 5 minutes via the stale check.
+                        self._account_limits_checked_at = time.monotonic() - 270
+                    self._account_limits_refreshing = False
+                self._invalidate(min_interval=0.0)
+
+        thread = threading.Thread(target=_worker, name="hermes-account-limits", daemon=True)
+        thread.start()
+        return cached if same_provider else ""
+
     def _build_context_bar(self, percent_used: Optional[int], width: int = 10) -> str:
         safe_percent = max(0, min(100, percent_used or 0))
         filled = round((safe_percent / 100) * width)
@@ -3219,6 +3304,7 @@ class HermesCLI:
             "session_api_calls": 0,
             "compressions": 0,
             "active_background_tasks": 0,
+            "account_limits": "",
         }
 
         # Count live /background tasks. The dict entry is removed in the
@@ -3242,6 +3328,7 @@ class HermesCLI:
         snapshot["session_completion_tokens"] = getattr(agent, "session_completion_tokens", 0) or 0
         snapshot["session_total_tokens"] = getattr(agent, "session_total_tokens", 0) or 0
         snapshot["session_api_calls"] = getattr(agent, "session_api_calls", 0) or 0
+        snapshot["account_limits"] = self._maybe_refresh_account_limits_badge(agent)
 
         compressor = getattr(agent, "context_compressor", None)
         if compressor:
@@ -3463,6 +3550,8 @@ class HermesCLI:
                 return self._trim_status_bar_text(text, width)
             if width < 76:
                 parts = [f"⚕ {snapshot['model_short']}", percent_label]
+                if snapshot.get("account_limits"):
+                    parts.append(snapshot["account_limits"])
                 compressions = snapshot.get("compressions", 0)
                 if compressions:
                     parts.append(f"🗜️ {compressions}")
@@ -3483,6 +3572,8 @@ class HermesCLI:
 
             compressions = snapshot.get("compressions", 0)
             parts = [f"⚕ {snapshot['model_short']}", context_label, percent_label]
+            if snapshot.get("account_limits"):
+                parts.append(snapshot["account_limits"])
             if compressions:
                 parts.append(f"🗜️ {compressions}")
             bg_count = snapshot.get("active_background_tasks", 0)
@@ -3527,6 +3618,7 @@ class HermesCLI:
                 percent = snapshot["context_percent"]
                 percent_label = f"{percent}%" if percent is not None else "--"
                 if width < 76:
+                    account_limits = snapshot.get("account_limits")
                     compressions = snapshot.get("compressions", 0)
                     bg_count = snapshot.get("active_background_tasks", 0)
                     frags = [
@@ -3535,6 +3627,9 @@ class HermesCLI:
                         ("class:status-bar-dim", " · "),
                         (self._status_bar_context_style(percent), percent_label),
                     ]
+                    if account_limits:
+                        frags.append(("class:status-bar-dim", " · "))
+                        frags.append(("class:status-bar-good", account_limits))
                     if compressions:
                         frags.append(("class:status-bar-dim", " · "))
                         frags.append((self._compression_count_style(compressions), f"🗜️ {compressions}"))
@@ -3558,6 +3653,7 @@ class HermesCLI:
                         context_label = "ctx --"
 
                     bar_style = self._status_bar_context_style(percent)
+                    account_limits = snapshot.get("account_limits")
                     compressions = snapshot.get("compressions", 0)
                     bg_count = snapshot.get("active_background_tasks", 0)
                     frags = [
@@ -3570,6 +3666,9 @@ class HermesCLI:
                         ("class:status-bar-dim", " "),
                         (bar_style, percent_label),
                     ]
+                    if account_limits:
+                        frags.append(("class:status-bar-dim", " │ "))
+                        frags.append(("class:status-bar-good", account_limits))
                     if compressions:
                         frags.append(("class:status-bar-dim", " │ "))
                         frags.append((self._compression_count_style(compressions), f"🗜️ {compressions}"))

--- a/cli.py
+++ b/cli.py
@@ -8099,6 +8099,8 @@ class HermesCLI:
             self._handle_codex_runtime(cmd_original)
         elif canonical == "gquota":
             self._handle_gquota_command(cmd_original)
+        elif canonical == "quota":
+            self._show_account_quota(cmd_original)
 
         elif canonical == "personality":
             # Use original case (handler lowercases the personality name itself)
@@ -9545,6 +9547,46 @@ class HermesCLI:
         # sys.exit inside a non-main thread does not exit the process).
         self._pending_relaunch = ["update"]
         return True
+
+    def _show_account_quota(self, cmd_original: str = "/quota"):
+        """Show provider account quota/limits without the full token-usage report."""
+        parts = cmd_original.split(maxsplit=1)
+        requested_provider = parts[1].strip() if len(parts) > 1 else ""
+        agent = self.agent
+        provider = requested_provider or getattr(agent, "provider", None) or getattr(self, "provider", None)
+        base_url = getattr(agent, "base_url", None) if agent else getattr(self, "base_url", None)
+        api_key = getattr(agent, "api_key", None) if agent else getattr(self, "api_key", None)
+
+        if not provider:
+            print("  Account quota unavailable: no provider configured yet.")
+            return
+
+        from agent.account_usage import fetch_account_usage, render_account_usage_lines
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as _pool:
+            try:
+                account_snapshot = _pool.submit(
+                    fetch_account_usage,
+                    provider,
+                    base_url=base_url,
+                    api_key=api_key,
+                ).result(timeout=15.0)
+            except concurrent.futures.TimeoutError:
+                print(f"  Account quota unavailable for {provider}: timed out.")
+                return
+            except Exception as e:
+                print(f"  Account quota unavailable for {provider}: {e}")
+                return
+
+        account_lines = render_account_usage_lines(account_snapshot)
+        if not account_lines:
+            print(f"  Account quota unavailable for {provider}.")
+            print("  Supported today: openai-codex, anthropic OAuth, openrouter.")
+            return
+
+        print()
+        for line in account_lines:
+            print(f"  {line}")
 
     def _show_usage(self):
         """Show rate limits (if available) and session token usage."""

--- a/cli.py
+++ b/cli.py
@@ -3167,9 +3167,7 @@ class HermesCLI:
             parts.append(f"{prefix}{remaining}%")
         if not parts:
             return ""
-        provider = str(getattr(snapshot, "provider", "") or "").lower()
-        label = "Codex" if "codex" in provider else "Acct"
-        return f"{label} {' '.join(parts[:2])}"
+        return f"Acct {' '.join(parts[:2])}"
 
     def _maybe_refresh_account_limits_badge(self, agent: Any) -> str:
         """Return cached account limits and refresh them in the background if stale."""

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -127,6 +127,8 @@ COMMAND_REGISTRY: list[CommandDef] = [
                args_hint="[auto|codex_app_server]"),
     CommandDef("gquota", "Show Google Gemini Code Assist quota usage", "Info",
                cli_only=True),
+    CommandDef("quota", "Show account quota/limits for the current provider, including Codex", "Info",
+               cli_only=True, aliases=("cquota", "limits"), args_hint="[provider]"),
 
     CommandDef("personality", "Set a predefined personality", "Configuration",
                args_hint="[name]"),

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -23,7 +23,7 @@ import time
 import urllib.parse
 import urllib.request
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple, cast
 
 import yaml
 
@@ -54,7 +54,7 @@ try:
     from fastapi.middleware.cors import CORSMiddleware
     from fastapi.responses import FileResponse, HTMLResponse, JSONResponse, Response
     from fastapi.staticfiles import StaticFiles
-    from pydantic import BaseModel
+    from pydantic import BaseModel, Field
 except ImportError:
     # First try lazy-installing the dashboard extras. Only the user actually
     # running `hermes dashboard` needs fastapi+uvicorn; lazy install keeps
@@ -66,7 +66,7 @@ except ImportError:
         from fastapi.middleware.cors import CORSMiddleware
         from fastapi.responses import FileResponse, HTMLResponse, JSONResponse, Response
         from fastapi.staticfiles import StaticFiles
-        from pydantic import BaseModel
+        from pydantic import BaseModel, Field
     except Exception:
         raise SystemExit(
             "Web UI requires fastapi and uvicorn.\n"
@@ -474,6 +474,36 @@ class ModelAssignment(BaseModel):
     task: str = ""
 
 
+class PromptDraftCreate(BaseModel):
+    title: str
+    content: str
+    status: str = "draft"
+    priority: int = 50
+    project: Optional[str] = None
+    tags: List[str] = Field(default_factory=list)
+    provider: str = "openai-codex"
+    send_condition: Dict[str, Any] = Field(
+        default_factory=lambda: {"mode": "manual", "require_confirmation": True}
+    )
+    attachments: List[Dict[str, Any]] = Field(default_factory=list)
+    merged_from: List[str] = Field(default_factory=list)
+    retention_policy: str = "default"
+
+
+class PromptDraftUpdate(BaseModel):
+    title: Optional[str] = None
+    content: Optional[str] = None
+    status: Optional[str] = None
+    priority: Optional[int] = None
+    project: Optional[str] = None
+    tags: Optional[List[str]] = None
+    provider: Optional[str] = None
+    send_condition: Optional[Dict[str, Any]] = None
+    attachments: Optional[List[Dict[str, Any]]] = None
+    merged_from: Optional[List[str]] = None
+    retention_policy: Optional[str] = None
+
+
 _GATEWAY_HEALTH_URL = os.getenv("GATEWAY_HEALTH_URL")
 try:
     _GATEWAY_HEALTH_TIMEOUT = float(os.getenv("GATEWAY_HEALTH_TIMEOUT", "3"))
@@ -638,6 +668,147 @@ async def get_status():
         "gateway_updated_at": gateway_updated_at,
         "active_sessions": active_sessions,
     }
+
+
+def _isoformat_or_value(value: Any) -> Any:
+    formatter = getattr(value, "isoformat", None)
+    return formatter() if callable(formatter) else value
+
+
+def _quota_window_to_payload(window: Any) -> Dict[str, Any]:
+    reset_at = getattr(window, "reset_at", None)
+    return {
+        "label": getattr(window, "label", ""),
+        "remaining_percent": getattr(window, "remaining_percent", None),
+        "used_percent": getattr(window, "used_percent", None),
+        "reset_at": _isoformat_or_value(reset_at),
+    }
+
+
+def _quota_status_to_payload(status: Any) -> Dict[str, Any]:
+    checked_at = getattr(status, "checked_at", None)
+    windows = getattr(status, "windows", None) or {}
+    return {
+        "provider": getattr(status, "provider", "openai-codex"),
+        "ok": bool(getattr(status, "ok", False)),
+        "status": getattr(status, "status", "degraded"),
+        "checked_at": _isoformat_or_value(checked_at),
+        "remaining_percent": getattr(status, "remaining_percent", None),
+        "windows": {
+            key: _quota_window_to_payload(window)
+            for key, window in windows.items()
+        },
+        "plan": getattr(status, "plan", None),
+        "stale": bool(getattr(status, "stale", False)),
+        "error": getattr(status, "error", None),
+    }
+
+
+@app.get("/api/resources/codex-quota")
+async def get_codex_quota_resource(force_refresh: bool = False):
+    from agent.resource_policy import get_codex_quota_resource_status
+
+    status = get_codex_quota_resource_status(force_refresh=force_refresh)
+    return _quota_status_to_payload(status)
+
+
+def _prompt_to_payload(prompt: Any) -> Dict[str, Any]:
+    to_dict = getattr(prompt, "to_dict", None)
+    if callable(to_dict):
+        return to_dict()
+    return cast(Dict[str, Any], dict(prompt))
+
+
+def _open_prompt_outbox_store():
+    from agent.prompt_outbox import PromptDraftStore
+
+    return PromptDraftStore()
+
+
+@app.get("/api/outbox/prompts")
+async def list_outbox_prompts(
+    include_archived: bool = False,
+    status: Optional[str] = None,
+    project: Optional[str] = None,
+    limit: int = 100,
+):
+    store = _open_prompt_outbox_store()
+    try:
+        prompts = store.list_prompts(
+            include_archived=include_archived,
+            status=status,
+            project=project,
+            limit=limit,
+        )
+        return {"prompts": [_prompt_to_payload(prompt) for prompt in prompts]}
+    finally:
+        store.close()
+
+
+@app.post("/api/outbox/prompts")
+async def create_outbox_prompt(body: PromptDraftCreate):
+    store = _open_prompt_outbox_store()
+    try:
+        try:
+            prompt = store.create_prompt(
+                title=body.title,
+                content=body.content,
+                status=body.status,
+                priority=body.priority,
+                project=body.project,
+                tags=body.tags,
+                provider=body.provider,
+                send_condition=body.send_condition,
+                attachments=body.attachments,
+                merged_from=body.merged_from,
+                retention_policy=body.retention_policy,
+            )
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+        return _prompt_to_payload(prompt)
+    finally:
+        store.close()
+
+
+@app.get("/api/outbox/prompts/{prompt_id}")
+async def get_outbox_prompt(prompt_id: str):
+    store = _open_prompt_outbox_store()
+    try:
+        prompt = store.get_prompt(prompt_id)
+        if prompt is None:
+            raise HTTPException(status_code=404, detail="Prompt not found")
+        return _prompt_to_payload(prompt)
+    finally:
+        store.close()
+
+
+@app.patch("/api/outbox/prompts/{prompt_id}")
+async def update_outbox_prompt(prompt_id: str, body: PromptDraftUpdate):
+    store = _open_prompt_outbox_store()
+    try:
+        if hasattr(body, "model_dump"):
+            changes = body.model_dump(exclude_unset=True)
+        else:
+            changes = body.dict(exclude_unset=True)
+        try:
+            prompt = store.update_prompt(prompt_id, **changes)
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+        if prompt is None:
+            raise HTTPException(status_code=404, detail="Prompt not found")
+        return _prompt_to_payload(prompt)
+    finally:
+        store.close()
+
+
+@app.delete("/api/outbox/prompts/{prompt_id}")
+async def delete_outbox_prompt(prompt_id: str):
+    store = _open_prompt_outbox_store()
+    try:
+        deleted = store.delete_prompt(prompt_id)
+        return {"deleted": deleted}
+    finally:
+        store.close()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/agent/test_gemini_cloudcode.py
+++ b/tests/agent/test_gemini_cloudcode.py
@@ -1205,6 +1205,14 @@ class TestGquotaCommand:
 
         assert "/gquota" in COMMANDS
 
+    def test_quota_registered_with_codex_aliases(self):
+        from hermes_cli.commands import COMMANDS, resolve_command
+
+        assert "/quota" in COMMANDS
+        assert resolve_command("quota").name == "quota"
+        assert resolve_command("cquota").name == "quota"
+        assert resolve_command("limits").name == "quota"
+
 
 class TestRunGeminiOauthLoginPure:
     def test_returns_pool_compatible_dict(self, monkeypatch):

--- a/tests/agent/test_prompt_outbox.py
+++ b/tests/agent/test_prompt_outbox.py
@@ -1,0 +1,92 @@
+from pathlib import Path
+
+from agent.prompt_outbox import PromptDraftStore
+
+
+def test_prompt_draft_store_creates_and_lists_drafts(tmp_path: Path):
+    store = PromptDraftStore(tmp_path / "outbox.db")
+    try:
+        draft = store.create_prompt(
+            title="Pause crons Graphit",
+            content="Suspendre les crons Graphit si quota critique.",
+            project="Graph'it",
+            tags=["graphit", "quota"],
+            send_condition={"mode": "quota_positive", "require_confirmation": True},
+            priority=80,
+        )
+
+        drafts = store.list_prompts()
+
+        assert len(drafts) == 1
+        assert drafts[0].id == draft.id
+        assert drafts[0].title == "Pause crons Graphit"
+        assert drafts[0].status == "draft"
+        assert drafts[0].project == "Graph'it"
+        assert drafts[0].tags == ["graphit", "quota"]
+        assert drafts[0].send_condition["mode"] == "quota_positive"
+        assert drafts[0].priority == 80
+        assert drafts[0].created_at.endswith("+00:00")
+    finally:
+        store.close()
+
+
+def test_prompt_draft_store_updates_and_deletes_draft(tmp_path: Path):
+    store = PromptDraftStore(tmp_path / "outbox.db")
+    try:
+        draft = store.create_prompt(title="Initial", content="First prompt")
+
+        updated = store.update_prompt(
+            draft.id,
+            title="Updated",
+            content="Updated prompt",
+            status="queued",
+            priority=10,
+            project=None,
+            send_condition={"mode": "quota_above_threshold", "threshold_percent": 25},
+        )
+
+        assert updated is not None
+        assert updated.title == "Updated"
+        assert updated.project is None
+        assert updated.status == "queued"
+        assert updated.priority == 10
+        assert updated.send_condition["threshold_percent"] == 25
+        assert updated.updated_at >= draft.updated_at
+
+        assert store.delete_prompt(draft.id) is True
+        assert store.get_prompt(draft.id) is None
+        assert store.delete_prompt(draft.id) is False
+    finally:
+        store.close()
+
+
+def test_prompt_draft_store_rejects_invalid_threshold(tmp_path: Path):
+    store = PromptDraftStore(tmp_path / "outbox.db")
+    try:
+        try:
+            store.create_prompt(
+                title="Invalid",
+                content="Invalid threshold",
+                send_condition={"mode": "quota_above_threshold", "threshold_percent": "NaN"},
+            )
+        except ValueError as exc:
+            assert "threshold_percent" in str(exc)
+        else:
+            raise AssertionError("Expected invalid threshold_percent to be rejected")
+    finally:
+        store.close()
+
+def test_prompt_draft_store_filters_archived_by_default(tmp_path: Path):
+    store = PromptDraftStore(tmp_path / "outbox.db")
+    try:
+        active = store.create_prompt(title="Active", content="Keep visible")
+        archived = store.create_prompt(title="Archived", content="Hide by default")
+        store.update_prompt(archived.id, status="archived")
+
+        visible = store.list_prompts()
+        all_prompts = store.list_prompts(include_archived=True)
+
+        assert [draft.id for draft in visible] == [active.id]
+        assert {draft.id for draft in all_prompts} == {active.id, archived.id}
+    finally:
+        store.close()

--- a/tests/agent/test_resource_policy.py
+++ b/tests/agent/test_resource_policy.py
@@ -1,0 +1,60 @@
+from dataclasses import dataclass
+from datetime import datetime, timezone
+
+from agent.resource_policy import build_quota_resource_status
+
+
+@dataclass(frozen=True)
+class _UsageWindow:
+    label: str
+    used_percent: float | None = None
+    reset_at: object = None
+
+
+@dataclass(frozen=True)
+class _UsageSnapshot:
+    provider: str = "openai-codex"
+    source: str = "usage_api"
+    fetched_at: datetime = datetime(2026, 5, 23, 12, 0, tzinfo=timezone.utc)
+    plan: str = "Pro"
+    windows: tuple[_UsageWindow, ...] = ()
+    unavailable_reason: str | None = None
+
+
+def _snapshot(*windows: _UsageWindow) -> _UsageSnapshot:
+    return _UsageSnapshot(windows=tuple(windows))
+
+
+def test_build_quota_resource_status_uses_most_constrained_remaining_window():
+    snapshot = _snapshot(
+        _UsageWindow(label="Session", used_percent=15.0),
+        _UsageWindow(label="Weekly", used_percent=92.0),
+    )
+
+    status = build_quota_resource_status(snapshot)
+
+    assert status.provider == "openai-codex"
+    assert status.ok is True
+    assert status.status == "warning"
+    assert status.remaining_percent == 8.0
+    assert status.windows["session"].remaining_percent == 85.0
+    assert status.windows["weekly"].remaining_percent == 8.0
+
+
+def test_build_quota_resource_status_marks_zero_as_exhausted():
+    snapshot = _snapshot(_UsageWindow(label="Weekly", used_percent=100.0))
+
+    status = build_quota_resource_status(snapshot)
+
+    assert status.ok is True
+    assert status.status == "exhausted"
+    assert status.remaining_percent == 0.0
+
+
+def test_build_quota_resource_status_marks_missing_snapshot_as_degraded():
+    status = build_quota_resource_status(None)
+
+    assert status.ok is False
+    assert status.status == "degraded"
+    assert status.remaining_percent is None
+    assert status.error == "quota unavailable"

--- a/tests/cli/test_gquota_command.py
+++ b/tests/cli/test_gquota_command.py
@@ -1,3 +1,4 @@
+from datetime import datetime, timezone
 from unittest.mock import MagicMock, patch
 
 
@@ -19,3 +20,30 @@ def test_gquota_uses_chat_console_when_tui_is_live():
 
     assert live_console.print.call_count == 2
     cli.console.print.assert_not_called()
+
+
+def test_quota_command_fetches_current_provider_account_usage(capsys):
+    from agent.account_usage import AccountUsageSnapshot, AccountUsageWindow
+    from cli import HermesCLI
+
+    cli = HermesCLI.__new__(HermesCLI)
+    cli.agent = MagicMock(provider="openai-codex", base_url="https://chatgpt.com/backend-api/codex", api_key="tok")
+    snapshot = AccountUsageSnapshot(
+        provider="openai-codex",
+        source="usage_api",
+        fetched_at=datetime.now(timezone.utc),
+        windows=(AccountUsageWindow(label="Session", used_percent=12),),
+    )
+
+    with patch("agent.account_usage.fetch_account_usage", return_value=snapshot) as fetch:
+        cli._show_account_quota("/quota")
+
+    fetch.assert_called_once_with(
+        "openai-codex",
+        base_url="https://chatgpt.com/backend-api/codex",
+        api_key="tok",
+    )
+    out = capsys.readouterr().out
+    assert "Account limits" in out
+    assert "openai-codex" in out
+    assert "Session: 88% remaining" in out

--- a/tests/hermes_cli/test_account_limits_status_bar.py
+++ b/tests/hermes_cli/test_account_limits_status_bar.py
@@ -20,7 +20,7 @@ def _snapshot(provider: str = "openai-codex") -> AccountUsageSnapshot:
 
 
 def test_format_account_limits_badge_uses_remaining_percentages() -> None:
-    assert HermesCLI._format_account_limits_badge(_snapshot()) == "Codex S86% W98%"
+    assert HermesCLI._format_account_limits_badge(_snapshot()) == "Acct S86% W98%"
 
 
 def test_format_account_limits_badge_falls_back_for_generic_provider() -> None:
@@ -57,8 +57,8 @@ def test_status_bar_text_includes_cached_account_limits(monkeypatch) -> None:
         session_api_calls=0,
         context_compressor=None,
     )
-    monkeypatch.setattr(shell, "_maybe_refresh_account_limits_badge", lambda agent: "Codex S86% W98%")
+    monkeypatch.setattr(shell, "_maybe_refresh_account_limits_badge", lambda agent: "Acct S86% W98%")
 
     text = shell._build_status_bar_text(width=100)
 
-    assert "Codex S86% W98%" in text
+    assert "Acct S86% W98%" in text

--- a/tests/hermes_cli/test_account_limits_status_bar.py
+++ b/tests/hermes_cli/test_account_limits_status_bar.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+from agent.account_usage import AccountUsageSnapshot, AccountUsageWindow
+from cli import HermesCLI
+
+
+def _snapshot(provider: str = "openai-codex") -> AccountUsageSnapshot:
+    return AccountUsageSnapshot(
+        provider=provider,
+        source="test",
+        fetched_at=datetime.now(timezone.utc),
+        windows=(
+            AccountUsageWindow(label="Session", used_percent=14.4),
+            AccountUsageWindow(label="Weekly", used_percent=2.1),
+        ),
+    )
+
+
+def test_format_account_limits_badge_uses_remaining_percentages() -> None:
+    assert HermesCLI._format_account_limits_badge(_snapshot()) == "Codex S86% W98%"
+
+
+def test_format_account_limits_badge_falls_back_for_generic_provider() -> None:
+    assert HermesCLI._format_account_limits_badge(_snapshot("anthropic")) == "Acct S86% W98%"
+
+
+def test_format_account_limits_badge_ignores_missing_usage() -> None:
+    snapshot = AccountUsageSnapshot(
+        provider="openai-codex",
+        source="test",
+        fetched_at=datetime.now(timezone.utc),
+        windows=(AccountUsageWindow(label="Session", used_percent=None),),
+    )
+
+    assert HermesCLI._format_account_limits_badge(snapshot) == ""
+
+
+def test_status_bar_text_includes_cached_account_limits(monkeypatch) -> None:
+    shell = HermesCLI.__new__(HermesCLI)
+    shell.model = "openai-codex/gpt-5.1-codex"
+    shell.session_start = datetime.now()
+    shell._prompt_start_time = None
+    shell._prompt_duration = 0.0
+    shell._background_tasks = {}
+    shell.agent = SimpleNamespace(
+        model="openai-codex/gpt-5.1-codex",
+        session_input_tokens=0,
+        session_output_tokens=0,
+        session_cache_read_tokens=0,
+        session_cache_write_tokens=0,
+        session_prompt_tokens=0,
+        session_completion_tokens=0,
+        session_total_tokens=0,
+        session_api_calls=0,
+        context_compressor=None,
+    )
+    monkeypatch.setattr(shell, "_maybe_refresh_account_limits_badge", lambda agent: "Codex S86% W98%")
+
+    text = shell._build_status_bar_text(width=100)
+
+    assert "Codex S86% W98%" in text

--- a/tests/hermes_cli/test_account_limits_status_bar.py
+++ b/tests/hermes_cli/test_account_limits_status_bar.py
@@ -95,3 +95,60 @@ def test_status_bar_fragments_render_depleted_account_limits_as_critical(monkeyp
     frags = shell._get_status_bar_fragments()
 
     assert ("class:status-bar-critical", "Acct S0% W42%") in frags
+
+
+def test_status_bar_snapshot_derives_depleted_account_style_from_current_label(monkeypatch) -> None:
+    shell = HermesCLI.__new__(HermesCLI)
+    shell.model = "openai-codex/gpt-5.5-codex"
+    shell.session_start = datetime.now()
+    shell._prompt_start_time = None
+    shell._prompt_duration = 0.0
+    shell._background_tasks = {}
+    shell._account_limits_style = "class:status-bar-good"
+    shell.agent = SimpleNamespace(
+        model="openai-codex/gpt-5.5-codex",
+        session_input_tokens=0,
+        session_output_tokens=0,
+        session_cache_read_tokens=0,
+        session_cache_write_tokens=0,
+        session_prompt_tokens=0,
+        session_completion_tokens=0,
+        session_total_tokens=0,
+        session_api_calls=0,
+        context_compressor=None,
+    )
+    monkeypatch.setattr(shell, "_maybe_refresh_account_limits_badge", lambda agent: "Acct S0% W42%")
+
+    snapshot = shell._get_status_bar_snapshot()
+
+    assert snapshot["account_limits"] == "Acct S0% W42%"
+    assert snapshot["account_limits_style"] == "class:status-bar-critical"
+
+
+def test_status_bar_overflow_preserves_depleted_account_critical_style(monkeypatch) -> None:
+    shell = HermesCLI.__new__(HermesCLI)
+    shell._status_bar_visible = True
+    shell._model_picker_state = None
+    monkeypatch.setattr(shell, "_get_tui_terminal_width", lambda: 76)
+    monkeypatch.setattr(
+        shell,
+        "_get_status_bar_snapshot",
+        lambda: {
+            "model_short": "gpt-5.5-codex",
+            "context_percent": 12,
+            "context_length": 200_000,
+            "context_tokens": 24_000,
+            "account_limits": "Acct S0% W42%",
+            "account_limits_style": "class:status-bar-critical",
+            "compressions": 0,
+            "active_background_tasks": 0,
+            "duration": "123m",
+            "prompt_elapsed": "⏲ 99s",
+        },
+    )
+
+    frags = shell._get_status_bar_fragments()
+
+    assert len(frags) == 1
+    assert frags[0][0] == "class:status-bar-critical"
+    assert "Acct S0%" in frags[0][1]

--- a/tests/hermes_cli/test_account_limits_status_bar.py
+++ b/tests/hermes_cli/test_account_limits_status_bar.py
@@ -23,6 +23,12 @@ def test_format_account_limits_badge_uses_remaining_percentages() -> None:
     assert HermesCLI._format_account_limits_badge(_snapshot()) == "Acct S86% W98%"
 
 
+def test_account_limits_badge_style_turns_critical_for_depleted_session_or_weekly() -> None:
+    assert HermesCLI._account_limits_badge_style("Acct S0% W98%") == "class:status-bar-critical"
+    assert HermesCLI._account_limits_badge_style("Acct S86% W0%") == "class:status-bar-critical"
+    assert HermesCLI._account_limits_badge_style("Acct S86% W98%") == "class:status-bar-good"
+
+
 def test_format_account_limits_badge_falls_back_for_generic_provider() -> None:
     assert HermesCLI._format_account_limits_badge(_snapshot("anthropic")) == "Acct S86% W98%"
 
@@ -62,3 +68,30 @@ def test_status_bar_text_includes_cached_account_limits(monkeypatch) -> None:
     text = shell._build_status_bar_text(width=100)
 
     assert "Acct S86% W98%" in text
+
+
+def test_status_bar_fragments_render_depleted_account_limits_as_critical(monkeypatch) -> None:
+    shell = HermesCLI.__new__(HermesCLI)
+    shell._status_bar_visible = True
+    shell._model_picker_state = None
+    monkeypatch.setattr(shell, "_get_tui_terminal_width", lambda: 100)
+    monkeypatch.setattr(
+        shell,
+        "_get_status_bar_snapshot",
+        lambda: {
+            "model_short": "gpt-5.5-codex",
+            "context_percent": 12,
+            "context_length": 200_000,
+            "context_tokens": 24_000,
+            "account_limits": "Acct S0% W42%",
+            "account_limits_style": "class:status-bar-critical",
+            "compressions": 0,
+            "active_background_tasks": 0,
+            "duration": "1m",
+            "prompt_elapsed": "⏲ 0s",
+        },
+    )
+
+    frags = shell._get_status_bar_fragments()
+
+    assert ("class:status-bar-critical", "Acct S0% W42%") in frags

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -125,6 +125,100 @@ class TestWebServerEndpoints:
         assert "hermes_home" in data
         assert "active_sessions" in data
 
+    def test_outbox_prompt_crud_endpoints(self):
+        create_resp = self.client.post(
+            "/api/outbox/prompts",
+            json={
+                "title": "Pause crons Graphit",
+                "content": "Suspendre les crons Graphit si quota critique.",
+                "project": "Graph'it",
+                "tags": ["graphit", "quota"],
+                "priority": 80,
+                "send_condition": {"mode": "quota_positive", "require_confirmation": True},
+            },
+        )
+
+        assert create_resp.status_code == 200
+        created = create_resp.json()
+        assert created["id"]
+        assert created["title"] == "Pause crons Graphit"
+        assert created["status"] == "draft"
+        assert created["send_condition"]["mode"] == "quota_positive"
+
+        list_resp = self.client.get("/api/outbox/prompts")
+        assert list_resp.status_code == 200
+        assert list_resp.json()["prompts"][0]["id"] == created["id"]
+
+        patch_resp = self.client.patch(
+            f"/api/outbox/prompts/{created['id']}",
+            json={
+                "status": "queued",
+                "priority": 10,
+                "send_condition": {"mode": "quota_above_threshold", "threshold_percent": 25},
+            },
+        )
+        assert patch_resp.status_code == 200
+        patched = patch_resp.json()
+        assert patched["status"] == "queued"
+        assert patched["priority"] == 10
+        assert patched["send_condition"]["threshold_percent"] == 25
+
+        delete_resp = self.client.delete(f"/api/outbox/prompts/{created['id']}")
+        assert delete_resp.status_code == 200
+        assert delete_resp.json() == {"deleted": True}
+
+        missing_resp = self.client.get(f"/api/outbox/prompts/{created['id']}")
+        assert missing_resp.status_code == 404
+
+    def test_get_codex_quota_resource(self, monkeypatch):
+        from dataclasses import dataclass
+        from datetime import datetime, timezone
+
+        import agent.resource_policy as resource_policy
+
+        @dataclass(frozen=True)
+        class _Window:
+            label: str
+            remaining_percent: float
+            used_percent: float
+            reset_at: datetime | None = None
+
+        @dataclass(frozen=True)
+        class _Status:
+            provider: str = "openai-codex"
+            ok: bool = True
+            status: str = "warning"
+            checked_at: datetime = datetime(2026, 5, 23, 12, 0, tzinfo=timezone.utc)
+            remaining_percent: float = 8.0
+            windows: dict | None = None
+            plan: str = "Pro"
+            stale: bool = False
+            error: str | None = None
+
+        quota_status = _Status(
+            windows={
+                "session": _Window("Session", 85.0, 15.0),
+                "weekly": _Window("Weekly", 8.0, 92.0),
+            }
+        )
+        monkeypatch.setattr(
+            resource_policy,
+            "get_codex_quota_resource_status",
+            lambda force_refresh=False: quota_status,
+        )
+
+        resp = self.client.get("/api/resources/codex-quota")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["provider"] == "openai-codex"
+        assert data["ok"] is True
+        assert data["status"] == "warning"
+        assert data["remaining_percent"] == 8.0
+        assert data["windows"]["session"]["remaining_percent"] == 85.0
+        assert data["windows"]["weekly"]["remaining_percent"] == 8.0
+        assert data["checked_at"] == "2026-05-23T12:00:00+00:00"
+
     def test_get_status_filters_unconfigured_gateway_platforms(self, monkeypatch):
         import gateway.config as gateway_config
         import hermes_cli.web_server as web_server

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -2424,6 +2424,55 @@ def _(rid, params: dict) -> dict:
     )
 
 
+@method("account.usage")
+def _(rid, params: dict) -> dict:
+    session, err = _sess_nowait(params, rid)
+    if err:
+        return err
+    agent = session.get("agent")
+    requested_provider = str(params.get("provider") or "").strip()
+    if agent:
+        provider = requested_provider or getattr(agent, "provider", None)
+        base_url = getattr(agent, "base_url", None)
+        api_key = getattr(agent, "api_key", None)
+    else:
+        from hermes_cli.runtime_provider import resolve_runtime_provider
+
+        runtime = resolve_runtime_provider(requested=requested_provider or None)
+        provider = str(runtime.get("provider", "") or requested_provider or "")
+        base_url = runtime.get("base_url")
+        api_key = runtime.get("api_key")
+
+    if not provider:
+        return _ok(
+            rid,
+            {"output": "Account quota unavailable: no provider configured yet."},
+        )
+
+    try:
+        from agent.account_usage import fetch_account_usage, render_account_usage_lines
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+            snapshot = pool.submit(
+                fetch_account_usage,
+                provider,
+                base_url=base_url,
+                api_key=api_key,
+            ).result(timeout=15.0)
+    except concurrent.futures.TimeoutError:
+        return _ok(rid, {"output": f"Account quota unavailable for {provider}: timed out."})
+    except Exception as e:
+        return _ok(rid, {"output": f"Account quota unavailable for {provider}: {e}"})
+
+    lines = render_account_usage_lines(snapshot)
+    if not lines:
+        lines = [
+            f"Account quota unavailable for {provider}.",
+            "Supported today: openai-codex, anthropic OAuth, openrouter.",
+        ]
+    return _ok(rid, {"output": "\n".join(lines)})
+
+
 @method("session.status")
 def _(rid, params: dict) -> dict:
     session, err = _sess_nowait(params, rid)

--- a/ui-tui/packages/hermes-ink/src/utils/execFileNoThrow.ts
+++ b/ui-tui/packages/hermes-ink/src/utils/execFileNoThrow.ts
@@ -1,4 +1,4 @@
-import { spawn } from 'child_process'
+import { spawn, type ChildProcess, type StdioOptions } from 'child_process'
 type ExecFileOptions = {
   input?: string
   timeout?: number
@@ -32,11 +32,11 @@ export function execFileNoThrow(
     // doesn't inherit those pipe FDs — prevents handle leaks that can
     // keep the parent process alive. No output data is collected in
     // this mode; both stdout and stderr will be empty strings.
-    const stdioConfig = options.resolveOnExit
-      ? ['pipe', 'ignore', 'ignore'] as const
-      : 'pipe' as const
+    const stdioConfig: StdioOptions = options.resolveOnExit
+      ? ['pipe', 'ignore', 'ignore']
+      : 'pipe'
 
-    const child = spawn(file, args, {
+    const child: ChildProcess = spawn(file, args, {
       cwd: options.useCwd ? process.cwd() : undefined,
       env: options.env,
       stdio: stdioConfig

--- a/ui-tui/src/app/slash/commands/core.ts
+++ b/ui-tui/src/app/slash/commands/core.ts
@@ -7,6 +7,7 @@ import { SECTION_NAMES, isSectionName, nextDetailsMode, parseDetailsMode } from 
 import type {
   ConfigGetValueResponse,
   ConfigSetResponse,
+  AccountUsageResponse,
   SessionSaveResponse,
   SessionStatusResponse,
   SessionSteerResponse,
@@ -176,6 +177,31 @@ export const coreCommands: SlashCommand[] = [
       ctx.gateway
         .rpc<SessionStatusResponse>('session.status', { session_id: ctx.sid })
         .then(ctx.guarded<SessionStatusResponse>(r => ctx.transcript.page(r.output || '(no status)', 'Status')))
+        .catch(ctx.guardedErr)
+    }
+  },
+
+  {
+    aliases: ['cquota', 'limits'],
+    help: 'show account quota/limits for current provider, including Codex',
+    name: 'quota',
+    usage: '/quota [provider]',
+    run: (arg, ctx) => {
+      if (!ctx.sid) {
+        return ctx.transcript.sys('no active session')
+      }
+
+      const provider = arg.trim() || undefined
+      ctx.transcript.sys(`checking ${provider || 'current provider'} quota...`)
+      ctx.gateway
+        .rpc<AccountUsageResponse>('account.usage', { session_id: ctx.sid, ...(provider && { provider }) })
+        .then(
+          ctx.guarded<AccountUsageResponse>(r => {
+            const output = r.output || 'Account quota unavailable.'
+            const long = output.length > 180 || output.split('\n').filter(Boolean).length > 2
+            long ? ctx.transcript.page(output, 'Quota') : ctx.transcript.sys(output)
+          })
+        )
         .catch(ctx.guardedErr)
     }
   },

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -43,6 +43,10 @@ export interface SlashExecResponse {
   warning?: string
 }
 
+export interface AccountUsageResponse {
+  output?: string
+}
+
 export type CommandDispatchResponse =
   | { output?: string; type: 'exec' | 'plugin' }
   | { target: string; type: 'alias' }


### PR DESCRIPTION
## Summary
- render the Hermes CLI account-limit badge as `Acct Sxx% Wyy%` for account-backed providers
- add Codex quota resource policy endpoint with cached status payloads
- add SQLite-backed PromptDraft outbox store plus CRUD API routes
- add dashboard implementation plan and focused tests for quota/outbox behavior
- preserve the prior TUI execFileNoThrow build fix included on this branch

## Validation
- /usr/local/lib/hermes-agent/venv/bin/python -m pytest tests/hermes_cli/test_account_limits_status_bar.py -q -o 'addopts='
- /usr/local/lib/hermes-agent/venv/bin/python -m py_compile cli.py hermes_cli/commands.py tui_gateway/server.py
- /usr/local/lib/hermes-agent/venv/bin/python -m pytest tests/test_account_usage.py tests/cli/test_gquota_command.py tests/agent/test_gemini_cloudcode.py::TestGquotaCommand -q -o 'addopts='

## Dashboard companion
- edoumo/hermes-dashboard main now includes persistent Outbox API binding in commit 4ddc6c7.