### PR TITLE
feat(observability): add opt-in NeMo-Flow adaptive intercepts

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1499,36 +1499,88 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
         try:
             from hermes_cli.plugins import get_pre_tool_call_block_message
             block_message = get_pre_tool_call_block_message(
-                function_name, function_args, task_id=effective_task_id or "",
+                function_name,
+                function_args,
+                task_id=effective_task_id or "",
+                session_id=getattr(agent, "session_id", "") or "",
+                tool_call_id=tool_call_id or "",
+                turn_id=getattr(agent, "_current_turn_id", "") or "",
+                api_request_id=getattr(agent, "_current_api_request_id", "") or "",
             )
         except Exception:
             pass
     if block_message is not None:
-        return json.dumps({"error": block_message}, ensure_ascii=False)
+        result = json.dumps({"error": block_message}, ensure_ascii=False)
+        try:
+            from model_tools import _emit_post_tool_call_hook
+            _emit_post_tool_call_hook(
+                function_name=function_name,
+                function_args=function_args,
+                result=result,
+                task_id=effective_task_id or "",
+                session_id=getattr(agent, "session_id", "") or "",
+                tool_call_id=tool_call_id or "",
+                turn_id=getattr(agent, "_current_turn_id", "") or "",
+                api_request_id=getattr(agent, "_current_api_request_id", "") or "",
+                status="blocked",
+                error_type="plugin_block",
+                error_message=block_message,
+            )
+        except Exception:
+            pass
+        return result
+
+    tool_start_time = time.monotonic()
+
+    def _finish_agent_tool(result: Any) -> Any:
+        try:
+            from model_tools import _emit_post_tool_call_hook, _tool_result_observer_fields
+            status, error_type, error_message = _tool_result_observer_fields(result)
+            _emit_post_tool_call_hook(
+                function_name=function_name,
+                function_args=function_args,
+                result=result,
+                task_id=effective_task_id or "",
+                session_id=getattr(agent, "session_id", "") or "",
+                tool_call_id=tool_call_id or "",
+                turn_id=getattr(agent, "_current_turn_id", "") or "",
+                api_request_id=getattr(agent, "_current_api_request_id", "") or "",
+                duration_ms=int((time.monotonic() - tool_start_time) * 1000),
+                status=status,
+                error_type=error_type,
+                error_message=error_message,
+            )
+        except Exception:
+            pass
+        return result
 
     if function_name == "todo":
         from tools.todo_tool import todo_tool as _todo_tool
-        return _todo_tool(
-            todos=function_args.get("todos"),
-            merge=function_args.get("merge", False),
-            store=agent._todo_store,
+        return _finish_agent_tool(
+            _todo_tool(
+                todos=function_args.get("todos"),
+                merge=function_args.get("merge", False),
+                store=agent._todo_store,
+            )
         )
     elif function_name == "session_search":
         session_db = agent._get_session_db_for_recall()
         if not session_db:
             from hermes_state import format_session_db_unavailable
-            return json.dumps({"success": False, "error": format_session_db_unavailable()})
+            return _finish_agent_tool(json.dumps({"success": False, "error": format_session_db_unavailable()}))
         from tools.session_search_tool import session_search as _session_search
-        return _session_search(
-            query=function_args.get("query", ""),
-            role_filter=function_args.get("role_filter"),
-            limit=function_args.get("limit", 3),
-            session_id=function_args.get("session_id"),
-            around_message_id=function_args.get("around_message_id"),
-            window=function_args.get("window", 5),
-            sort=function_args.get("sort"),
-            db=session_db,
-            current_session_id=agent.session_id,
+        return _finish_agent_tool(
+            _session_search(
+                query=function_args.get("query", ""),
+                role_filter=function_args.get("role_filter"),
+                limit=function_args.get("limit", 3),
+                session_id=function_args.get("session_id"),
+                around_message_id=function_args.get("around_message_id"),
+                window=function_args.get("window", 5),
+                sort=function_args.get("sort"),
+                db=session_db,
+                current_session_id=agent.session_id,
+            )
         )
     elif function_name == "memory":
         target = function_args.get("target", "memory")
@@ -1554,23 +1606,27 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
                 )
             except Exception:
                 pass
-        return result
+        return _finish_agent_tool(result)
     elif agent._memory_manager and agent._memory_manager.has_tool(function_name):
-        return agent._memory_manager.handle_tool_call(function_name, function_args)
+        return _finish_agent_tool(agent._memory_manager.handle_tool_call(function_name, function_args))
     elif function_name == "clarify":
         from tools.clarify_tool import clarify_tool as _clarify_tool
-        return _clarify_tool(
-            question=function_args.get("question", ""),
-            choices=function_args.get("choices"),
-            callback=agent.clarify_callback,
+        return _finish_agent_tool(
+            _clarify_tool(
+                question=function_args.get("question", ""),
+                choices=function_args.get("choices"),
+                callback=agent.clarify_callback,
+            )
         )
     elif function_name == "delegate_task":
-        return agent._dispatch_delegate_task(function_args)
+        return _finish_agent_tool(agent._dispatch_delegate_task(function_args))
     else:
         return _ra().handle_function_call(
             function_name, function_args, effective_task_id,
             tool_call_id=tool_call_id,
             session_id=agent.session_id or "",
+            turn_id=getattr(agent, "_current_turn_id", "") or "",
+            api_request_id=getattr(agent, "_current_api_request_id", "") or "",
             enabled_tools=list(agent.valid_tool_names) if agent.valid_tool_names else None,
             skip_pre_tool_call_hook=True,
         )

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1115,26 +1115,23 @@ def run_conversation(
                         )
                     return agent._interruptible_api_call(next_api_kwargs)
 
-                try:
-                    from hermes_cli.middleware import run_api_execution_middleware
-                    response = run_api_execution_middleware(
-                        api_kwargs,
-                        _perform_api_call,
-                        original_request=_original_api_kwargs,
-                        task_id=effective_task_id,
-                        turn_id=turn_id,
-                        api_request_id=api_request_id,
-                        session_id=agent.session_id or "",
-                        platform=agent.platform or "",
-                        model=agent.model,
-                        provider=agent.provider,
-                        base_url=agent.base_url,
-                        api_mode=agent.api_mode,
-                        api_call_count=api_call_count,
-                        middleware_trace=_api_middleware_trace,
-                    )
-                except Exception:
-                    response = _perform_api_call(api_kwargs)
+                from hermes_cli.middleware import run_api_execution_middleware
+                response = run_api_execution_middleware(
+                    api_kwargs,
+                    _perform_api_call,
+                    original_request=_original_api_kwargs,
+                    task_id=effective_task_id,
+                    turn_id=turn_id,
+                    api_request_id=api_request_id,
+                    session_id=agent.session_id or "",
+                    platform=agent.platform or "",
+                    model=agent.model,
+                    provider=agent.provider,
+                    base_url=agent.base_url,
+                    api_mode=agent.api_mode,
+                    api_call_count=api_call_count,
+                    middleware_trace=_api_middleware_trace,
+                )
                 
                 api_duration = time.time() - api_start_time
                 

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -158,12 +158,13 @@ def _restore_or_build_system_prompt(agent, system_message, conversation_history)
     # session is created (not on continuation).  Plugins can use this
     # to initialise session-scoped state (e.g. warm a memory cache).
     try:
-        from hermes_cli.plugins import invoke_hook as _invoke_hook
+        from hermes_cli.plugins import OBSERVER_SCHEMA_VERSION, invoke_hook as _invoke_hook
         _invoke_hook(
             "on_session_start",
             session_id=agent.session_id,
             model=agent.model,
             platform=getattr(agent, "platform", None) or "",
+            telemetry_schema_version=OBSERVER_SCHEMA_VERSION,
         )
     except Exception as exc:
         logger.warning("on_session_start hook failed: %s", exc)
@@ -270,6 +271,9 @@ def run_conversation(
     # state registry.  Set BEFORE any tool dispatch so snapshots taken at
     # child-launch time see the parent's real id, not None.
     agent._current_task_id = effective_task_id
+    turn_id = f"{agent.session_id or 'session'}:{effective_task_id}:{uuid.uuid4().hex[:8]}"
+    agent._current_turn_id = turn_id
+    agent._current_api_request_id = ""
     
     # Reset retry counters and iteration budget at the start of each turn
     # so subagent usage from a previous turn doesn't eat into the next one.
@@ -501,16 +505,19 @@ def run_conversation(
     # All injected context is ephemeral (not persisted to session DB).
     _plugin_user_context = ""
     try:
-        from hermes_cli.plugins import invoke_hook as _invoke_hook
+        from hermes_cli.plugins import OBSERVER_SCHEMA_VERSION, invoke_hook as _invoke_hook
         _pre_results = _invoke_hook(
             "pre_llm_call",
             session_id=agent.session_id,
+            task_id=effective_task_id,
+            turn_id=turn_id,
             user_message=original_user_message,
             conversation_history=list(messages),
             is_first_turn=(not bool(conversation_history)),
             model=agent.model,
             platform=getattr(agent, "platform", None) or "",
             sender_id=getattr(agent, "_user_id", None) or "",
+            telemetry_schema_version=OBSERVER_SCHEMA_VERSION,
         )
         _ctx_parts: list[str] = []
         for r in _pre_results:
@@ -932,6 +939,8 @@ def run_conversation(
         finish_reason = "stop"
         response = None  # Guard against UnboundLocalError if all retries fail
         api_kwargs = None  # Guard against UnboundLocalError in except handler
+        api_request_id = f"{turn_id}:api:{api_call_count}"
+        agent._current_api_request_id = api_request_id
 
         while retry_count < max_retries:
             # ── Nous Portal rate limit guard ──────────────────────
@@ -990,7 +999,7 @@ def run_conversation(
                     api_kwargs = agent._get_transport().preflight_kwargs(api_kwargs, allow_stream=False)
 
                 try:
-                    from hermes_cli.plugins import invoke_hook as _invoke_hook
+                    from hermes_cli.plugins import OBSERVER_SCHEMA_VERSION, invoke_hook as _invoke_hook
                     request_messages = api_kwargs.get("messages")
                     if not isinstance(request_messages, list):
                         request_messages = api_kwargs.get("input")
@@ -1005,6 +1014,8 @@ def run_conversation(
                     _invoke_hook(
                         "pre_api_request",
                         task_id=effective_task_id,
+                        turn_id=turn_id,
+                        api_request_id=api_request_id,
                         session_id=agent.session_id or "",
                         user_message=original_user_message,
                         conversation_history=list(messages),
@@ -1020,6 +1031,9 @@ def run_conversation(
                         approx_input_tokens=approx_tokens,
                         request_char_count=total_chars,
                         max_tokens=agent.max_tokens,
+                        started_at=api_start_time,
+                        request=agent._api_request_payload_for_hook(api_kwargs),
+                        telemetry_schema_version=OBSERVER_SCHEMA_VERSION,
                     )
                 except Exception:
                     pass
@@ -1176,6 +1190,21 @@ def run_conversation(
                             error_details.append("response.choices is empty")
 
                 if response_invalid:
+                    agent._invoke_api_request_error_hook(
+                        task_id=effective_task_id,
+                        turn_id=turn_id,
+                        api_request_id=api_request_id,
+                        api_call_count=api_call_count,
+                        api_start_time=api_start_time,
+                        api_kwargs=api_kwargs,
+                        error_type="InvalidAPIResponse",
+                        error_message=", ".join(error_details) or "Invalid API response",
+                        status_code=getattr(getattr(response, "error", None), "code", None),
+                        retry_count=retry_count,
+                        max_retries=max_retries,
+                        retryable=True,
+                        reason="invalid_response",
+                    )
                     # Stop spinner before printing error messages
                     if thinking_spinner:
                         thinking_spinner.stop("(´;ω;`) oops, retrying...")
@@ -1959,6 +1988,21 @@ def run_conversation(
                     classified.reason.value, classified.status_code,
                     classified.retryable, classified.should_compress,
                     classified.should_rotate_credential, classified.should_fallback,
+                )
+                agent._invoke_api_request_error_hook(
+                    task_id=effective_task_id,
+                    turn_id=turn_id,
+                    api_request_id=api_request_id,
+                    api_call_count=api_call_count,
+                    api_start_time=api_start_time,
+                    api_kwargs=api_kwargs,
+                    error_type=type(api_error).__name__,
+                    error_message=str(api_error),
+                    status_code=status_code,
+                    retry_count=retry_count,
+                    max_retries=max_retries,
+                    retryable=classified.retryable,
+                    reason=classified.reason.value,
                 )
 
                 recovered_with_pool, has_retried_429 = agent._recover_with_credential_pool(
@@ -2954,12 +2998,15 @@ def run_conversation(
                     assistant_message.content = str(raw)
 
             try:
-                from hermes_cli.plugins import invoke_hook as _invoke_hook
+                from hermes_cli.plugins import OBSERVER_SCHEMA_VERSION, invoke_hook as _invoke_hook
                 _assistant_tool_calls = getattr(assistant_message, "tool_calls", None) or []
                 _assistant_text = assistant_message.content or ""
+                _api_ended_at = api_start_time + api_duration
                 _invoke_hook(
                     "post_api_request",
                     task_id=effective_task_id,
+                    turn_id=turn_id,
+                    api_request_id=api_request_id,
                     session_id=agent.session_id or "",
                     platform=agent.platform or "",
                     model=agent.model,
@@ -2968,14 +3015,21 @@ def run_conversation(
                     api_mode=agent.api_mode,
                     api_call_count=api_call_count,
                     api_duration=api_duration,
+                    started_at=api_start_time,
+                    ended_at=_api_ended_at,
                     finish_reason=finish_reason,
                     message_count=len(api_messages),
                     response_model=getattr(response, "model", None),
-                    response=response,
+                    response=agent._api_response_payload_for_hook(
+                        response,
+                        assistant_message,
+                        finish_reason=finish_reason,
+                    ),
                     usage=agent._usage_summary_for_api_request_hook(response),
                     assistant_message=assistant_message,
                     assistant_content_chars=len(_assistant_text),
                     assistant_tool_call_count=len(_assistant_tool_calls),
+                    telemetry_schema_version=OBSERVER_SCHEMA_VERSION,
                 )
             except Exception:
                 pass
@@ -3960,15 +4014,18 @@ def run_conversation(
     # to an external memory system).
     if final_response and not interrupted:
         try:
-            from hermes_cli.plugins import invoke_hook as _invoke_hook
+            from hermes_cli.plugins import OBSERVER_SCHEMA_VERSION, invoke_hook as _invoke_hook
             _invoke_hook(
                 "post_llm_call",
                 session_id=agent.session_id,
+                task_id=effective_task_id,
+                turn_id=turn_id,
                 user_message=original_user_message,
                 assistant_response=final_response,
                 conversation_history=list(messages),
                 model=agent.model,
                 platform=getattr(agent, "platform", None) or "",
+                telemetry_schema_version=OBSERVER_SCHEMA_VERSION,
             )
         except Exception as exc:
             logger.warning("post_llm_call hook failed: %s", exc)
@@ -4075,14 +4132,17 @@ def run_conversation(
     # Fired at the very end of every run_conversation call.
     # Plugins can use this for cleanup, flushing buffers, etc.
     try:
-        from hermes_cli.plugins import invoke_hook as _invoke_hook
+        from hermes_cli.plugins import OBSERVER_SCHEMA_VERSION, invoke_hook as _invoke_hook
         _invoke_hook(
             "on_session_end",
             session_id=agent.session_id,
+            task_id=effective_task_id,
+            turn_id=turn_id,
             completed=completed,
             interrupted=interrupted,
             model=agent.model,
             platform=getattr(agent, "platform", None) or "",
+            telemetry_schema_version=OBSERVER_SCHEMA_VERSION,
         )
     except Exception as exc:
         logger.warning("on_session_end hook failed: %s", exc)

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -997,6 +997,28 @@ def run_conversation(
                     _sanitize_structure_non_ascii(api_kwargs)
                 if agent.api_mode == "codex_responses":
                     api_kwargs = agent._get_transport().preflight_kwargs(api_kwargs, allow_stream=False)
+                _original_api_kwargs = dict(api_kwargs)
+                _api_middleware_trace = []
+                try:
+                    from hermes_cli.middleware import apply_api_request_middleware
+                    _api_request_middleware = apply_api_request_middleware(
+                        api_kwargs,
+                        task_id=effective_task_id,
+                        turn_id=turn_id,
+                        api_request_id=api_request_id,
+                        session_id=agent.session_id or "",
+                        platform=agent.platform or "",
+                        model=agent.model,
+                        provider=agent.provider,
+                        base_url=agent.base_url,
+                        api_mode=agent.api_mode,
+                        api_call_count=api_call_count,
+                    )
+                    api_kwargs = _api_request_middleware.payload
+                    _original_api_kwargs = _api_request_middleware.original_payload
+                    _api_middleware_trace = _api_request_middleware.trace
+                except Exception:
+                    pass
 
                 try:
                     from hermes_cli.plugins import OBSERVER_SCHEMA_VERSION, invoke_hook as _invoke_hook
@@ -1033,6 +1055,8 @@ def run_conversation(
                         max_tokens=agent.max_tokens,
                         started_at=api_start_time,
                         request=agent._api_request_payload_for_hook(api_kwargs),
+                        original_request=agent._api_request_payload_for_hook(_original_api_kwargs),
+                        middleware_trace=_api_middleware_trace,
                         telemetry_schema_version=OBSERVER_SCHEMA_VERSION,
                     )
                 except Exception:
@@ -1084,12 +1108,33 @@ def run_conversation(
                     if isinstance(getattr(agent, "client", None), Mock):
                         _use_streaming = False
 
-                if _use_streaming:
-                    response = agent._interruptible_streaming_api_call(
-                        api_kwargs, on_first_delta=_stop_spinner
+                def _perform_api_call(next_api_kwargs):
+                    if _use_streaming:
+                        return agent._interruptible_streaming_api_call(
+                            next_api_kwargs, on_first_delta=_stop_spinner
+                        )
+                    return agent._interruptible_api_call(next_api_kwargs)
+
+                try:
+                    from hermes_cli.middleware import run_api_execution_middleware
+                    response = run_api_execution_middleware(
+                        api_kwargs,
+                        _perform_api_call,
+                        original_request=_original_api_kwargs,
+                        task_id=effective_task_id,
+                        turn_id=turn_id,
+                        api_request_id=api_request_id,
+                        session_id=agent.session_id or "",
+                        platform=agent.platform or "",
+                        model=agent.model,
+                        provider=agent.provider,
+                        base_url=agent.base_url,
+                        api_mode=agent.api_mode,
+                        api_call_count=api_call_count,
+                        middleware_trace=_api_middleware_trace,
                     )
-                else:
-                    response = agent._interruptible_api_call(api_kwargs)
+                except Exception:
+                    response = _perform_api_call(api_kwargs)
                 
                 api_duration = time.time() - api_start_time
                 
@@ -3025,6 +3070,8 @@ def run_conversation(
                         assistant_message,
                         finish_reason=finish_reason,
                     ),
+                    original_request=agent._api_request_payload_for_hook(_original_api_kwargs),
+                    middleware_trace=_api_middleware_trace,
                     usage=agent._usage_summary_for_api_request_hook(response),
                     assistant_message=assistant_message,
                     assistant_content_chars=len(_assistant_text),

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -62,6 +62,78 @@ def _ra():
     return run_agent
 
 
+def _emit_terminal_post_tool_call(
+    agent,
+    *,
+    function_name: str,
+    function_args: dict,
+    result: Any,
+    effective_task_id: str,
+    tool_call_id: str,
+    duration_ms: int = 0,
+    status: str | None = None,
+    error_type: str | None = None,
+    error_message: str | None = None,
+) -> None:
+    try:
+        from model_tools import _emit_post_tool_call_hook, _tool_result_observer_fields
+        if status is None:
+            status, error_type, error_message = _tool_result_observer_fields(result)
+        _emit_post_tool_call_hook(
+            function_name=function_name,
+            function_args=function_args,
+            result=result,
+            task_id=effective_task_id or "",
+            session_id=getattr(agent, "session_id", "") or "",
+            tool_call_id=tool_call_id or "",
+            turn_id=getattr(agent, "_current_turn_id", "") or "",
+            api_request_id=getattr(agent, "_current_api_request_id", "") or "",
+            duration_ms=duration_ms,
+            status=status,
+            error_type=error_type,
+            error_message=error_message,
+        )
+    except Exception:
+        pass
+
+
+def _cancelled_tool_result(reason: str = "user interrupt") -> str:
+    return json.dumps(
+        {
+            "error": f"Tool execution cancelled by {reason}",
+            "status": "cancelled",
+        },
+        ensure_ascii=False,
+    )
+
+
+def _emit_cancelled_terminal_post_tool_call(
+    agent,
+    *,
+    function_name: str,
+    function_args: dict,
+    effective_task_id: str,
+    tool_call_id: str,
+    start_time: float,
+    reason: str = "user interrupt",
+    error_type: str = "keyboard_interrupt",
+) -> str:
+    result = _cancelled_tool_result(reason)
+    _emit_terminal_post_tool_call(
+        agent,
+        function_name=function_name,
+        function_args=function_args,
+        result=result,
+        effective_task_id=effective_task_id,
+        tool_call_id=tool_call_id,
+        duration_ms=int((time.time() - start_time) * 1000),
+        status="cancelled",
+        error_type=error_type,
+        error_message=f"Tool execution cancelled by {reason}",
+    )
+    return result
+
+
 def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effective_task_id: str, api_call_count: int = 0) -> None:
     """Execute multiple tool calls concurrently using a thread pool.
 
@@ -127,18 +199,46 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
         try:
             from hermes_cli.plugins import get_pre_tool_call_block_message
             block_message = get_pre_tool_call_block_message(
-                function_name, function_args, task_id=effective_task_id or "",
+                function_name,
+                function_args,
+                task_id=effective_task_id or "",
+                session_id=getattr(agent, "session_id", "") or "",
+                tool_call_id=getattr(tool_call, "id", "") or "",
+                turn_id=getattr(agent, "_current_turn_id", "") or "",
+                api_request_id=getattr(agent, "_current_api_request_id", "") or "",
             )
         except Exception:
             block_message = None
 
         if block_message is not None:
             block_result = json.dumps({"error": block_message}, ensure_ascii=False)
+            _emit_terminal_post_tool_call(
+                agent,
+                function_name=function_name,
+                function_args=function_args,
+                result=block_result,
+                effective_task_id=effective_task_id,
+                tool_call_id=getattr(tool_call, "id", "") or "",
+                status="blocked",
+                error_type="plugin_block",
+                error_message=block_message,
+            )
         else:
             guardrail_decision = agent._tool_guardrails.before_call(function_name, function_args)
             if not guardrail_decision.allows_execution:
                 block_result = agent._guardrail_block_result(guardrail_decision)
                 blocked_by_guardrail = True
+                _emit_terminal_post_tool_call(
+                    agent,
+                    function_name=function_name,
+                    function_args=function_args,
+                    result=block_result,
+                    effective_task_id=effective_task_id,
+                    tool_call_id=getattr(tool_call, "id", "") or "",
+                    status="blocked",
+                    error_type="guardrail_block",
+                    error_message=getattr(guardrail_decision, "message", None) or "Tool blocked by guardrail policy",
+                )
 
         parsed_calls.append((tool_call, function_name, function_args, block_result, blocked_by_guardrail))
 
@@ -232,42 +332,61 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
                 _set_sudo_password_callback(_parent_sudo_cb)
             except Exception:
                 pass
-        start = time.time()
         try:
-            result = agent._invoke_tool(
-                function_name,
-                function_args,
-                effective_task_id,
-                tool_call.id,
-                messages=messages,
-                pre_tool_block_checked=True,
-            )
-        except Exception as tool_error:
-            result = f"Error executing tool '{function_name}': {tool_error}"
-            logger.error("_invoke_tool raised for %s: %s", function_name, tool_error, exc_info=True)
-        duration = time.time() - start
-        is_error, _ = _detect_tool_failure(function_name, result)
-        if is_error:
-            logger.info("tool %s failed (%.2fs): %s", function_name, duration, result[:200])
-        else:
-            logger.info("tool %s completed (%.2fs, %d chars)", function_name, duration, len(result))
-        results[index] = (function_name, function_args, result, duration, is_error, False)
-        # Tear down worker-tid tracking.  Clear any interrupt bit we may
-        # have set so the next task scheduled onto this recycled tid
-        # starts with a clean slate.
-        with agent._tool_worker_threads_lock:
-            agent._tool_worker_threads.discard(_worker_tid)
-        try:
-            _ra()._set_interrupt(False, _worker_tid)
-        except Exception:
-            pass
-        # Clear thread-local callbacks so a recycled worker thread
-        # doesn't hold stale references to a disposed CLI instance.
-        try:
-            _set_approval_callback(None)
-            _set_sudo_password_callback(None)
-        except Exception:
-            pass
+            start = time.time()
+            try:
+                result = agent._invoke_tool(
+                    function_name,
+                    function_args,
+                    effective_task_id,
+                    tool_call.id,
+                    messages=messages,
+                    pre_tool_block_checked=True,
+                )
+            except KeyboardInterrupt:
+                try:
+                    agent.interrupt("keyboard interrupt")
+                except Exception:
+                    pass
+                result = _emit_cancelled_terminal_post_tool_call(
+                    agent,
+                    function_name=function_name,
+                    function_args=function_args,
+                    effective_task_id=effective_task_id,
+                    tool_call_id=getattr(tool_call, "id", "") or "",
+                    start_time=start,
+                )
+                duration = time.time() - start
+                logger.info("tool %s cancelled (%.2fs)", function_name, duration)
+                results[index] = (function_name, function_args, result, duration, True, False)
+                return
+            except Exception as tool_error:
+                result = f"Error executing tool '{function_name}': {tool_error}"
+                logger.error("_invoke_tool raised for %s: %s", function_name, tool_error, exc_info=True)
+            duration = time.time() - start
+            is_error, _ = _detect_tool_failure(function_name, result)
+            if is_error:
+                logger.info("tool %s failed (%.2fs): %s", function_name, duration, result[:200])
+            else:
+                logger.info("tool %s completed (%.2fs, %d chars)", function_name, duration, len(result))
+            results[index] = (function_name, function_args, result, duration, is_error, False)
+        finally:
+            # Tear down worker-tid tracking.  Clear any interrupt bit we may
+            # have set so the next task scheduled onto this recycled tid
+            # starts with a clean slate.
+            with agent._tool_worker_threads_lock:
+                agent._tool_worker_threads.discard(_worker_tid)
+            try:
+                _ra()._set_interrupt(False, _worker_tid)
+            except Exception:
+                pass
+            # Clear thread-local callbacks so a recycled worker thread
+            # doesn't hold stale references to a disposed CLI instance.
+            try:
+                _set_approval_callback(None)
+                _set_sudo_password_callback(None)
+            except Exception:
+                pass
 
     # Start spinner for CLI mode (skip when TUI handles tool progress)
     spinner = None
@@ -353,8 +472,30 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
             # Tool was cancelled (interrupt) or thread didn't return
             if agent._interrupt_requested:
                 function_result = f"[Tool execution cancelled — {name} was skipped due to user interrupt]"
+                _emit_terminal_post_tool_call(
+                    agent,
+                    function_name=name,
+                    function_args=args,
+                    result=function_result,
+                    effective_task_id=effective_task_id,
+                    tool_call_id=getattr(tc, "id", "") or "",
+                    status="cancelled",
+                    error_type="keyboard_interrupt",
+                    error_message="Tool execution cancelled by user interrupt",
+                )
             else:
                 function_result = f"Error executing tool '{name}': thread did not return a result"
+                _emit_terminal_post_tool_call(
+                    agent,
+                    function_name=name,
+                    function_args=args,
+                    result=function_result,
+                    effective_task_id=effective_task_id,
+                    tool_call_id=getattr(tc, "id", "") or "",
+                    status="error",
+                    error_type="thread_missing_result",
+                    error_message=function_result,
+                )
             tool_duration = 0.0
         else:
             function_name, function_args, function_result, tool_duration, is_error, blocked = r
@@ -501,7 +642,13 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
         try:
             from hermes_cli.plugins import get_pre_tool_call_block_message
             _block_msg = get_pre_tool_call_block_message(
-                function_name, function_args, task_id=effective_task_id or "",
+                function_name,
+                function_args,
+                task_id=effective_task_id or "",
+                session_id=getattr(agent, "session_id", "") or "",
+                tool_call_id=getattr(tool_call, "id", "") or "",
+                turn_id=getattr(agent, "_current_turn_id", "") or "",
+                api_request_id=getattr(agent, "_current_api_request_id", "") or "",
             )
         except Exception:
             pass
@@ -590,11 +737,33 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
             # Tool blocked by plugin policy — return error without executing.
             function_result = json.dumps({"error": _block_msg}, ensure_ascii=False)
             tool_duration = 0.0
+            _emit_terminal_post_tool_call(
+                agent,
+                function_name=function_name,
+                function_args=function_args,
+                result=function_result,
+                effective_task_id=effective_task_id,
+                tool_call_id=getattr(tool_call, "id", "") or "",
+                status="blocked",
+                error_type="plugin_block",
+                error_message=_block_msg,
+            )
         elif _guardrail_block_decision is not None:
             # Tool blocked by tool-loop guardrail — synthesize exactly one
             # tool result for the original tool_call_id without executing.
             function_result = agent._guardrail_block_result(_guardrail_block_decision)
             tool_duration = 0.0
+            _emit_terminal_post_tool_call(
+                agent,
+                function_name=function_name,
+                function_args=function_args,
+                result=function_result,
+                effective_task_id=effective_task_id,
+                tool_call_id=getattr(tool_call, "id", "") or "",
+                status="blocked",
+                error_type="guardrail_block",
+                error_message=getattr(_guardrail_block_decision, "message", None) or "Tool blocked by guardrail policy",
+            )
         elif function_name == "todo":
             from tools.todo_tool import todo_tool as _todo_tool
             function_result = _todo_tool(
@@ -749,10 +918,27 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                     function_name, function_args, effective_task_id,
                     tool_call_id=tool_call.id,
                     session_id=agent.session_id or "",
+                    turn_id=getattr(agent, "_current_turn_id", "") or "",
+                    api_request_id=getattr(agent, "_current_api_request_id", "") or "",
                     enabled_tools=list(agent.valid_tool_names) if agent.valid_tool_names else None,
                     skip_pre_tool_call_hook=True,
                 )
                 _spinner_result = function_result
+            except KeyboardInterrupt:
+                function_result = _emit_cancelled_terminal_post_tool_call(
+                    agent,
+                    function_name=function_name,
+                    function_args=function_args,
+                    effective_task_id=effective_task_id,
+                    tool_call_id=getattr(tool_call, "id", "") or "",
+                    start_time=tool_start_time,
+                )
+                _spinner_result = function_result
+                try:
+                    agent.interrupt("keyboard interrupt")
+                except Exception:
+                    pass
+                raise
             except Exception as tool_error:
                 function_result = f"Error executing tool '{function_name}': {tool_error}"
                 logger.error("handle_function_call raised for %s: %s", function_name, tool_error, exc_info=True)
@@ -769,9 +955,25 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                     function_name, function_args, effective_task_id,
                     tool_call_id=tool_call.id,
                     session_id=agent.session_id or "",
+                    turn_id=getattr(agent, "_current_turn_id", "") or "",
+                    api_request_id=getattr(agent, "_current_api_request_id", "") or "",
                     enabled_tools=list(agent.valid_tool_names) if agent.valid_tool_names else None,
                     skip_pre_tool_call_hook=True,
                 )
+            except KeyboardInterrupt:
+                _emit_cancelled_terminal_post_tool_call(
+                    agent,
+                    function_name=function_name,
+                    function_args=function_args,
+                    effective_task_id=effective_task_id,
+                    tool_call_id=getattr(tool_call, "id", "") or "",
+                    start_time=tool_start_time,
+                )
+                try:
+                    agent.interrupt("keyboard interrupt")
+                except Exception:
+                    pass
+                raise
             except Exception as tool_error:
                 function_result = f"Error executing tool '{function_name}': {tool_error}"
                 logger.error("handle_function_call raised for %s: %s", function_name, tool_error, exc_info=True)
@@ -790,6 +992,24 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
         # Log tool errors to the persistent error log so [error] tags
         # in the UI always have a corresponding detailed entry on disk.
         _is_error_result, _ = _detect_tool_failure(function_name, function_result)
+        _executor_owns_post_hook = (
+            not _execution_blocked
+            and (
+                function_name in {"todo", "session_search", "memory", "clarify", "delegate_task"}
+                or bool(agent._context_engine_tool_names and function_name in agent._context_engine_tool_names)
+                or bool(agent._memory_manager and agent._memory_manager.has_tool(function_name))
+            )
+        )
+        if _executor_owns_post_hook:
+            _emit_terminal_post_tool_call(
+                agent,
+                function_name=function_name,
+                function_args=function_args,
+                result=function_result,
+                effective_task_id=effective_task_id,
+                tool_call_id=getattr(tool_call, "id", "") or "",
+                duration_ms=int(tool_duration * 1000),
+            )
         if not _execution_blocked:
             function_result = agent._append_guardrail_observation(
                 function_name,

--- a/cli.py
+++ b/cli.py
@@ -774,8 +774,14 @@ def _run_cleanup():
     # Shut down memory provider (on_session_end + shutdown_all) at actual
     # session boundary — NOT per-turn inside run_conversation().
     try:
-        from hermes_cli.plugins import invoke_hook as _invoke_hook
-        _invoke_hook("on_session_finalize", session_id=_active_agent_ref.session_id if _active_agent_ref else None, platform="cli")
+        from hermes_cli.plugins import OBSERVER_SCHEMA_VERSION, invoke_hook as _invoke_hook
+        _invoke_hook(
+            "on_session_finalize",
+            session_id=_active_agent_ref.session_id if _active_agent_ref else None,
+            platform="cli",
+            reason="shutdown",
+            telemetry_schema_version=OBSERVER_SCHEMA_VERSION,
+        )
     except Exception:
         pass
     try:
@@ -791,6 +797,43 @@ def _run_cleanup():
                 _active_agent_ref.shutdown_memory_provider(_session_msgs)
             else:
                 _active_agent_ref.shutdown_memory_provider()
+    except Exception:
+        pass
+
+
+def _emit_interrupted_session_end(cli, *, reason: str = "keyboard_interrupt") -> None:
+    """Best-effort on_session_end hook for interrupted non-interactive runs."""
+    agent = getattr(cli, "agent", None)
+    if agent is None:
+        return
+
+    try:
+        agent.interrupt(reason.replace("_", " "))
+    except Exception:
+        pass
+
+    session_id = getattr(agent, "session_id", None) or getattr(cli, "session_id", None)
+    if session_id:
+        try:
+            cli.session_id = session_id
+        except Exception:
+            pass
+
+    try:
+        from hermes_cli.plugins import OBSERVER_SCHEMA_VERSION, invoke_hook as _invoke_hook
+        _invoke_hook(
+            "on_session_end",
+            session_id=session_id,
+            task_id=getattr(agent, "_current_task_id", "") or "",
+            turn_id=getattr(agent, "_current_turn_id", "") or "",
+            api_request_id=getattr(agent, "_current_api_request_id", "") or "",
+            completed=False,
+            interrupted=True,
+            model=getattr(agent, "model", None),
+            platform=getattr(agent, "platform", None) or "cli",
+            reason=reason,
+            telemetry_schema_version=OBSERVER_SCHEMA_VERSION,
+        )
     except Exception:
         pass
 
@@ -6004,11 +6047,13 @@ class HermesCLI:
         lifecycle point (shutdown, /new, /reset).
         """
         try:
-            from hermes_cli.plugins import invoke_hook as _invoke_hook
+            from hermes_cli.plugins import OBSERVER_SCHEMA_VERSION, invoke_hook as _invoke_hook
             _invoke_hook(
                 event_type,
                 session_id=self.agent.session_id if self.agent else None,
                 platform=getattr(self, "platform", None) or "cli",
+                reason="new_session" if event_type == "on_session_reset" else "session_boundary",
+                telemetry_schema_version=OBSERVER_SCHEMA_VERSION,
             )
         except Exception:
             pass
@@ -14165,7 +14210,7 @@ class HermesCLI:
             # the exit occurred, meaning run_conversation's hook didn't fire.
             if self.agent and getattr(self, '_agent_running', False):
                 try:
-                    from hermes_cli.plugins import invoke_hook as _invoke_hook
+                    from hermes_cli.plugins import OBSERVER_SCHEMA_VERSION, invoke_hook as _invoke_hook
                     _invoke_hook(
                         "on_session_end",
                         session_id=self.agent.session_id,
@@ -14173,6 +14218,8 @@ class HermesCLI:
                         interrupted=True,
                         model=getattr(self.agent, 'model', None),
                         platform=getattr(self.agent, 'platform', None) or "cli",
+                        reason="shutdown",
+                        telemetry_schema_version=OBSERVER_SCHEMA_VERSION,
                     )
                 except Exception:
                     pass
@@ -14409,6 +14456,7 @@ def main(
         raise KeyboardInterrupt()
     try:
         import signal as _signal
+        _signal.signal(_signal.SIGINT, _signal_handler_q)
         _signal.signal(_signal.SIGTERM, _signal_handler_q)
         if hasattr(_signal, "SIGHUP"):
             _signal.signal(_signal.SIGHUP, _signal_handler_q)
@@ -14445,10 +14493,15 @@ def main(
                     # status lines).  The response is printed once below.
                     cli.agent.stream_delta_callback = None
                     cli.agent.tool_gen_callback = None
-                    result = cli.agent.run_conversation(
-                        user_message=effective_query,
-                        conversation_history=cli.conversation_history,
-                    )
+                    try:
+                        result = cli.agent.run_conversation(
+                            user_message=effective_query,
+                            conversation_history=cli.conversation_history,
+                        )
+                    except KeyboardInterrupt:
+                        _emit_interrupted_session_end(cli, reason="keyboard_interrupt")
+                        print(f"\nsession_id: {cli.session_id}", file=sys.stderr)
+                        sys.exit(130)
                     # Sync session_id if mid-run compression created a
                     # continuation session. The exit line below reports
                     # session_id to stderr for automation wrappers; without

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3223,11 +3223,13 @@ class GatewayRunner:
     def _finalize_shutdown_agents(self, active_agents: Dict[str, Any]) -> None:
         for agent in active_agents.values():
             try:
-                from hermes_cli.plugins import invoke_hook as _invoke_hook
+                from hermes_cli.plugins import OBSERVER_SCHEMA_VERSION, invoke_hook as _invoke_hook
                 _invoke_hook(
                     "on_session_finalize",
                     session_id=getattr(agent, "session_id", None),
                     platform="gateway",
+                    reason="shutdown",
+                    telemetry_schema_version=OBSERVER_SCHEMA_VERSION,
                 )
             except Exception:
                 pass
@@ -4365,13 +4367,15 @@ class GatewayRunner:
                 for key, entry in _expired_entries:
                     try:
                         try:
-                            from hermes_cli.plugins import invoke_hook as _invoke_hook
+                            from hermes_cli.plugins import OBSERVER_SCHEMA_VERSION, invoke_hook as _invoke_hook
                             _parts = key.split(":")
                             _platform = _parts[2] if len(_parts) > 2 else ""
                             _invoke_hook(
                                 "on_session_finalize",
                                 session_id=entry.session_id,
                                 platform=_platform,
+                                reason="session_expired",
+                                telemetry_schema_version=OBSERVER_SCHEMA_VERSION,
                             )
                         except Exception:
                             pass
@@ -9043,12 +9047,20 @@ class GatewayRunner:
         # previous conversation must not survive the reset.
         self._clear_session_boundary_security_state(session_key)
 
+        _old_sid = old_entry.session_id if old_entry else None
+
         # Fire plugin on_session_finalize hook (session boundary)
         try:
-            from hermes_cli.plugins import invoke_hook as _invoke_hook
-            _old_sid = old_entry.session_id if old_entry else None
-            _invoke_hook("on_session_finalize", session_id=_old_sid,
-                         platform=source.platform.value if source.platform else "")
+            from hermes_cli.plugins import OBSERVER_SCHEMA_VERSION, invoke_hook as _invoke_hook
+            _invoke_hook(
+                "on_session_finalize",
+                session_id=_old_sid,
+                platform=source.platform.value if source.platform else "",
+                reason="new_session",
+                old_session_id=_old_sid,
+                new_session_id=new_entry.session_id if new_entry else None,
+                telemetry_schema_version=OBSERVER_SCHEMA_VERSION,
+            )
         except Exception:
             pass
 
@@ -9115,10 +9127,17 @@ class GatewayRunner:
 
         # Fire plugin on_session_reset hook (new session guaranteed to exist)
         try:
-            from hermes_cli.plugins import invoke_hook as _invoke_hook
+            from hermes_cli.plugins import OBSERVER_SCHEMA_VERSION, invoke_hook as _invoke_hook
             _new_sid = new_entry.session_id if new_entry else None
-            _invoke_hook("on_session_reset", session_id=_new_sid,
-                         platform=source.platform.value if source.platform else "")
+            _invoke_hook(
+                "on_session_reset",
+                session_id=_new_sid,
+                platform=source.platform.value if source.platform else "",
+                reason="new_session",
+                old_session_id=_old_sid,
+                new_session_id=_new_sid,
+                telemetry_schema_version=OBSERVER_SCHEMA_VERSION,
+            )
         except Exception:
             pass
 

--- a/hermes_cli/middleware.py
+++ b/hermes_cli/middleware.py
@@ -1,0 +1,228 @@
+"""Hermes middleware contract helpers.
+
+This module is the central integration surface for backend-neutral observer
+hooks and execution middleware. Runtime call sites stay in the agent loop and
+tool dispatcher, but contract constants, payload normalization, request
+rewrites, and execution wrappers live here so plugin authors do not need to
+reverse-engineer scattered call sites.
+"""
+
+from __future__ import annotations
+
+import logging
+from copy import deepcopy
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+OBSERVER_SCHEMA_VERSION = "hermes.observer.v1"
+MIDDLEWARE_SCHEMA_VERSION = "hermes.middleware.v1"
+
+TOOL_REQUEST_MIDDLEWARE = "tool_request"
+TOOL_EXECUTION_MIDDLEWARE = "tool_execution"
+API_REQUEST_MIDDLEWARE = "api_request"
+API_EXECUTION_MIDDLEWARE = "api_execution"
+
+VALID_MIDDLEWARE: set[str] = {
+    TOOL_REQUEST_MIDDLEWARE,
+    TOOL_EXECUTION_MIDDLEWARE,
+    API_REQUEST_MIDDLEWARE,
+    API_EXECUTION_MIDDLEWARE,
+}
+
+
+@dataclass
+class RequestMiddlewareResult:
+    """Result of applying request middleware to a mutable payload."""
+
+    payload: Any
+    original_payload: Any
+    changed: bool = False
+    trace: List[Dict[str, Any]] = field(default_factory=list)
+
+
+def observer_payload(**kwargs: Any) -> Dict[str, Any]:
+    """Return hook kwargs with the observer schema version populated."""
+    kwargs.setdefault("telemetry_schema_version", OBSERVER_SCHEMA_VERSION)
+    return kwargs
+
+
+def middleware_payload(**kwargs: Any) -> Dict[str, Any]:
+    """Return middleware kwargs with schema markers populated."""
+    kwargs.setdefault("telemetry_schema_version", OBSERVER_SCHEMA_VERSION)
+    kwargs.setdefault("middleware_schema_version", MIDDLEWARE_SCHEMA_VERSION)
+    return kwargs
+
+
+def invoke_observer_hook(hook_name: str, **kwargs: Any) -> List[Any]:
+    """Invoke a plugin hook through the shared observer contract."""
+    from hermes_cli.plugins import invoke_hook
+
+    return invoke_hook(hook_name, **observer_payload(**kwargs))
+
+
+def apply_tool_request_middleware(
+    tool_name: str,
+    args: Optional[Dict[str, Any]],
+    **context: Any,
+) -> RequestMiddlewareResult:
+    """Apply registered tool request middleware.
+
+    Middleware may return ``{"args": {...}}`` to replace the effective tool
+    arguments. Invalid return values are ignored and middleware exceptions are
+    fail-open.
+    """
+    original_args = deepcopy(args or {})
+    current_args = deepcopy(original_args)
+    trace: List[Dict[str, Any]] = []
+
+    for result in _invoke_middleware(
+        TOOL_REQUEST_MIDDLEWARE,
+        tool_name=tool_name,
+        args=current_args,
+        original_args=original_args,
+        **context,
+    ):
+        if not isinstance(result, dict):
+            continue
+        next_args = result.get("args")
+        if not isinstance(next_args, dict):
+            continue
+        current_args = deepcopy(next_args)
+        trace.append(_trace_entry(result))
+
+    return RequestMiddlewareResult(
+        payload=current_args,
+        original_payload=original_args,
+        changed=current_args != original_args,
+        trace=trace,
+    )
+
+
+def apply_api_request_middleware(
+    request: Dict[str, Any],
+    **context: Any,
+) -> RequestMiddlewareResult:
+    """Apply registered API request middleware.
+
+    Middleware may return ``{"request": {...}}`` to replace the effective API
+    kwargs before Hermes sends them to the provider.
+    """
+    original_request = deepcopy(request)
+    current_request = deepcopy(original_request)
+    trace: List[Dict[str, Any]] = []
+
+    for result in _invoke_middleware(
+        API_REQUEST_MIDDLEWARE,
+        request=current_request,
+        original_request=original_request,
+        **context,
+    ):
+        if not isinstance(result, dict):
+            continue
+        next_request = result.get("request")
+        if not isinstance(next_request, dict):
+            continue
+        current_request = deepcopy(next_request)
+        trace.append(_trace_entry(result))
+
+    return RequestMiddlewareResult(
+        payload=current_request,
+        original_payload=original_request,
+        changed=current_request != original_request,
+        trace=trace,
+    )
+
+
+def run_tool_execution_middleware(
+    tool_name: str,
+    args: Dict[str, Any],
+    next_call: Callable[[Dict[str, Any]], Any],
+    **context: Any,
+) -> Any:
+    """Run tool execution through registered execution middleware."""
+    callbacks = _get_middleware_callbacks(TOOL_EXECUTION_MIDDLEWARE)
+    return _run_execution_chain(
+        TOOL_EXECUTION_MIDDLEWARE,
+        callbacks,
+        next_call,
+        tool_name=tool_name,
+        args=args,
+        original_args=context.pop("original_args", args),
+        **context,
+    )
+
+
+def run_api_execution_middleware(
+    request: Dict[str, Any],
+    next_call: Callable[[Dict[str, Any]], Any],
+    **context: Any,
+) -> Any:
+    """Run API execution through registered execution middleware."""
+    callbacks = _get_middleware_callbacks(API_EXECUTION_MIDDLEWARE)
+    return _run_execution_chain(
+        API_EXECUTION_MIDDLEWARE,
+        callbacks,
+        next_call,
+        request=request,
+        original_request=context.pop("original_request", request),
+        **context,
+    )
+
+
+def _invoke_middleware(kind: str, **kwargs: Any) -> List[Any]:
+    from hermes_cli.plugins import invoke_middleware
+
+    return invoke_middleware(kind, **middleware_payload(**kwargs))
+
+
+def _get_middleware_callbacks(kind: str) -> List[Callable]:
+    from hermes_cli.plugins import get_plugin_manager
+
+    return list(get_plugin_manager()._middleware.get(kind, []))
+
+
+def _run_execution_chain(
+    kind: str,
+    callbacks: List[Callable],
+    terminal_call: Callable[[Any], Any],
+    **kwargs: Any,
+) -> Any:
+    payload_key = "args" if "args" in kwargs else "request"
+
+    def call_at(index: int, payload: Any) -> Any:
+        if index >= len(callbacks):
+            return terminal_call(payload)
+
+        callback = callbacks[index]
+
+        def next_call(next_payload: Any = None) -> Any:
+            return call_at(index + 1, payload if next_payload is None else next_payload)
+
+        call_kwargs = middleware_payload(**kwargs)
+        call_kwargs[payload_key] = payload
+        call_kwargs["next_call"] = next_call
+        try:
+            return callback(**call_kwargs)
+        except Exception as exc:
+            logger.warning(
+                "Middleware '%s' callback %s raised: %s",
+                kind,
+                getattr(callback, "__name__", repr(callback)),
+                exc,
+            )
+            return call_at(index + 1, payload)
+
+    return call_at(0, kwargs[payload_key])
+
+
+def _trace_entry(result: Dict[str, Any]) -> Dict[str, Any]:
+    entry: Dict[str, Any] = {}
+    for key in ("source", "reason", "name"):
+        value = result.get(key)
+        if isinstance(value, str) and value:
+            entry[key] = value
+    if not entry:
+        entry["source"] = "plugin"
+    return entry

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -125,6 +125,8 @@ _install_plugin_debug_handler()
 # Constants
 # ---------------------------------------------------------------------------
 
+OBSERVER_SCHEMA_VERSION = "hermes.observer.v1"
+
 VALID_HOOKS: Set[str] = {
     "pre_tool_call",
     "post_tool_call",
@@ -138,10 +140,12 @@ VALID_HOOKS: Set[str] = {
     "post_llm_call",
     "pre_api_request",
     "post_api_request",
+    "api_request_error",
     "on_session_start",
     "on_session_end",
     "on_session_finalize",
     "on_session_reset",
+    "subagent_start",
     "subagent_stop",
     # Gateway pre-dispatch hook. Fired once per incoming MessageEvent
     # after the internal-event guard but BEFORE auth/pairing and agent
@@ -1431,6 +1435,8 @@ def get_pre_tool_call_block_message(
     task_id: str = "",
     session_id: str = "",
     tool_call_id: str = "",
+    turn_id: str = "",
+    api_request_id: str = "",
 ) -> Optional[str]:
     """Check ``pre_tool_call`` hooks for a blocking directive.
 
@@ -1455,6 +1461,9 @@ def get_pre_tool_call_block_message(
         task_id=task_id,
         session_id=session_id,
         tool_call_id=tool_call_id,
+        turn_id=turn_id,
+        api_request_id=api_request_id,
+        telemetry_schema_version=OBSERVER_SCHEMA_VERSION,
     )
 
     for result in hook_results:

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -50,6 +50,7 @@ from typing import Any, Callable, Dict, List, Optional, Set, Union
 from hermes_constants import get_hermes_home
 from utils import env_var_enabled
 from hermes_cli.config import cfg_get
+from hermes_cli.middleware import OBSERVER_SCHEMA_VERSION, VALID_MIDDLEWARE
 
 
 def get_bundled_plugins_dir() -> Path:
@@ -124,8 +125,6 @@ _install_plugin_debug_handler()
 # ---------------------------------------------------------------------------
 # Constants
 # ---------------------------------------------------------------------------
-
-OBSERVER_SCHEMA_VERSION = "hermes.observer.v1"
 
 VALID_HOOKS: Set[str] = {
     "pre_tool_call",
@@ -279,6 +278,7 @@ class LoadedPlugin:
     module: Optional[types.ModuleType] = None
     tools_registered: List[str] = field(default_factory=list)
     hooks_registered: List[str] = field(default_factory=list)
+    middleware_registered: List[str] = field(default_factory=list)
     commands_registered: List[str] = field(default_factory=list)
     enabled: bool = False
     error: Optional[str] = None
@@ -719,6 +719,27 @@ class PluginContext:
         self._manager._hooks.setdefault(hook_name, []).append(callback)
         logger.debug("Plugin %s registered hook: %s", self.manifest.name, hook_name)
 
+    # -- middleware registration -------------------------------------------
+
+    def register_middleware(self, kind: str, callback: Callable) -> None:
+        """Register a behavior-changing middleware callback.
+
+        Middleware is separate from observer hooks: request middleware may
+        rewrite the effective payload, and execution middleware may wrap the
+        real callback. Unknown kinds are stored for forward compatibility but
+        warned so plugin authors can catch typos.
+        """
+        if kind not in VALID_MIDDLEWARE:
+            logger.warning(
+                "Plugin '%s' registered unknown middleware '%s' "
+                "(valid: %s)",
+                self.manifest.name,
+                kind,
+                ", ".join(sorted(VALID_MIDDLEWARE)),
+            )
+        self._manager._middleware.setdefault(kind, []).append(callback)
+        logger.debug("Plugin %s registered middleware: %s", self.manifest.name, kind)
+
     # -- skill registration -------------------------------------------------
 
     def register_skill(
@@ -777,6 +798,7 @@ class PluginManager:
     def __init__(self) -> None:
         self._plugins: Dict[str, LoadedPlugin] = {}
         self._hooks: Dict[str, List[Callable]] = {}
+        self._middleware: Dict[str, List[Callable]] = {}
         self._plugin_tool_names: Set[str] = set()
         self._plugin_platform_names: Set[str] = set()
         self._cli_commands: Dict[str, dict] = {}
@@ -803,6 +825,7 @@ class PluginManager:
         if force:
             self._plugins.clear()
             self._hooks.clear()
+            self._middleware.clear()
             self._plugin_tool_names.clear()
             self._cli_commands.clear()
             self._plugin_commands.clear()
@@ -1212,15 +1235,28 @@ class PluginManager:
                         for h in p.hooks_registered
                     }
                 )
+                loaded.middleware_registered = list(
+                    {
+                        kind
+                        for kind, cbs in self._middleware.items()
+                        if cbs
+                    }
+                    - {
+                        kind
+                        for name, p in self._plugins.items()
+                        for kind in p.middleware_registered
+                    }
+                )
                 loaded.commands_registered = [
                     c for c in self._plugin_commands
                     if self._plugin_commands[c].get("plugin") == manifest.name
                 ]
                 loaded.enabled = True
                 logger.debug(
-                    "  registered: %d tool(s), %d hook(s), %d slash command(s), %d CLI command(s)",
+                    "  registered: %d tool(s), %d hook(s), %d middleware, %d slash command(s), %d CLI command(s)",
                     len(loaded.tools_registered),
                     len(loaded.hooks_registered),
+                    len(loaded.middleware_registered),
                     len(loaded.commands_registered),
                     sum(
                         1 for c in self._cli_commands
@@ -1333,6 +1369,29 @@ class PluginManager:
                 )
         return results
 
+    def invoke_middleware(self, kind: str, **kwargs: Any) -> List[Any]:
+        """Call registered middleware callbacks for *kind*.
+
+        Each callback is isolated so one plugin cannot break the base runtime
+        path. Middleware that wants to change behavior must return the shape
+        documented by the caller-specific contract.
+        """
+        callbacks = self._middleware.get(kind, [])
+        results: List[Any] = []
+        for cb in callbacks:
+            try:
+                ret = cb(**kwargs)
+                if ret is not None:
+                    results.append(ret)
+            except Exception as exc:
+                logger.warning(
+                    "Middleware '%s' callback %s raised: %s",
+                    kind,
+                    getattr(cb, "__name__", repr(cb)),
+                    exc,
+                )
+        return results
+
     # -----------------------------------------------------------------------
     # Introspection
     # -----------------------------------------------------------------------
@@ -1352,6 +1411,7 @@ class PluginManager:
                     "enabled": loaded.enabled,
                     "tools": len(loaded.tools_registered),
                     "hooks": len(loaded.hooks_registered),
+                    "middleware": len(loaded.middleware_registered),
                     "commands": len(loaded.commands_registered),
                     "error": loaded.error,
                 }
@@ -1413,6 +1473,14 @@ def invoke_hook(hook_name: str, **kwargs: Any) -> List[Any]:
     return get_plugin_manager().invoke_hook(hook_name, **kwargs)
 
 
+def invoke_middleware(kind: str, **kwargs: Any) -> List[Any]:
+    """Invoke registered middleware callbacks.
+
+    Returns a list of non-``None`` return values from middleware callbacks.
+    """
+    return get_plugin_manager().invoke_middleware(kind, **kwargs)
+
+
 
 _thread_tool_whitelist = threading.local()
 
@@ -1437,6 +1505,8 @@ def get_pre_tool_call_block_message(
     tool_call_id: str = "",
     turn_id: str = "",
     api_request_id: str = "",
+    original_args: Optional[Dict[str, Any]] = None,
+    middleware_trace: Optional[List[Dict[str, Any]]] = None,
 ) -> Optional[str]:
     """Check ``pre_tool_call`` hooks for a blocking directive.
 
@@ -1458,6 +1528,8 @@ def get_pre_tool_call_block_message(
         "pre_tool_call",
         tool_name=tool_name,
         args=args if isinstance(args, dict) else {},
+        original_args=original_args if isinstance(original_args, dict) else (args if isinstance(args, dict) else {}),
+        middleware_trace=middleware_trace or [],
         task_id=task_id,
         session_id=session_id,
         tool_call_id=tool_call_id,

--- a/model_tools.py
+++ b/model_tools.py
@@ -738,12 +738,61 @@ def _coerce_boolean(value: str):
     return value
 
 
+def _emit_post_tool_call_hook(
+    *,
+    function_name: str,
+    function_args: Dict[str, Any],
+    result: Any,
+    task_id: Optional[str] = None,
+    session_id: Optional[str] = None,
+    tool_call_id: Optional[str] = None,
+    turn_id: Optional[str] = None,
+    api_request_id: Optional[str] = None,
+    duration_ms: int = 0,
+    status: str = "ok",
+    error_type: Optional[str] = None,
+    error_message: Optional[str] = None,
+) -> None:
+    try:
+        from hermes_cli.plugins import OBSERVER_SCHEMA_VERSION, invoke_hook
+        invoke_hook(
+            "post_tool_call",
+            tool_name=function_name,
+            args=function_args,
+            result=result,
+            task_id=task_id or "",
+            session_id=session_id or "",
+            tool_call_id=tool_call_id or "",
+            turn_id=turn_id or "",
+            api_request_id=api_request_id or "",
+            duration_ms=duration_ms,
+            status=status,
+            error_type=error_type,
+            error_message=error_message,
+            telemetry_schema_version=OBSERVER_SCHEMA_VERSION,
+        )
+    except Exception as _hook_err:
+        logger.debug("post_tool_call hook error: %s", _hook_err)
+
+
+def _tool_result_observer_fields(result: Any) -> tuple[str, Optional[str], Optional[str]]:
+    try:
+        parsed_result = json.loads(result) if isinstance(result, str) else result
+        if isinstance(parsed_result, dict) and parsed_result.get("error"):
+            return "error", "tool_error", str(parsed_result.get("error"))
+    except Exception:
+        pass
+    return "ok", None, None
+
+
 def handle_function_call(
     function_name: str,
     function_args: Dict[str, Any],
     task_id: Optional[str] = None,
     tool_call_id: Optional[str] = None,
     session_id: Optional[str] = None,
+    turn_id: Optional[str] = None,
+    api_request_id: Optional[str] = None,
     user_task: Optional[str] = None,
     enabled_tools: Optional[List[str]] = None,
     skip_pre_tool_call_hook: bool = False,
@@ -791,12 +840,28 @@ def handle_function_call(
                     task_id=task_id or "",
                     session_id=session_id or "",
                     tool_call_id=tool_call_id or "",
+                    turn_id=turn_id or "",
+                    api_request_id=api_request_id or "",
                 )
             except Exception as _hook_err:
                 logger.debug("pre_tool_call hook error: %s", _hook_err)
 
             if block_message is not None:
-                return json.dumps({"error": block_message}, ensure_ascii=False)
+                result = json.dumps({"error": block_message}, ensure_ascii=False)
+                _emit_post_tool_call_hook(
+                    function_name=function_name,
+                    function_args=function_args,
+                    result=result,
+                    task_id=task_id,
+                    session_id=session_id,
+                    tool_call_id=tool_call_id,
+                    turn_id=turn_id,
+                    api_request_id=api_request_id,
+                    status="blocked",
+                    error_type="plugin_block",
+                    error_message=block_message,
+                )
+                return result
 
         # ACP/Zed edit approval runs before any file mutation.  The requester
         # is bound via ContextVar only for ACP sessions, so CLI/gateway paths
@@ -829,37 +894,57 @@ def handle_function_call(
         # to wrap every tool manually.  We use monotonic() so the value is
         # unaffected by wall-clock adjustments during the call.
         _dispatch_start = time.monotonic()
-        if function_name == "execute_code":
-            # Prefer the caller-provided list so subagents can't overwrite
-            # the parent's tool set via the process-global.
-            sandbox_enabled = enabled_tools if enabled_tools is not None else _last_resolved_tool_names
-            result = registry.dispatch(
-                function_name, function_args,
-                task_id=task_id,
-                enabled_tools=sandbox_enabled,
-            )
-        else:
-            result = registry.dispatch(
-                function_name, function_args,
-                task_id=task_id,
-                user_task=user_task,
-            )
-        duration_ms = int((time.monotonic() - _dispatch_start) * 1000)
-
+        _approval_tokens = None
         try:
-            from hermes_cli.plugins import invoke_hook
-            invoke_hook(
-                "post_tool_call",
-                tool_name=function_name,
-                args=function_args,
-                result=result,
-                task_id=task_id or "",
-                session_id=session_id or "",
-                tool_call_id=tool_call_id or "",
-                duration_ms=duration_ms,
+            from tools.approval import (
+                reset_current_observability_context,
+                set_current_observability_context,
             )
-        except Exception as _hook_err:
-            logger.debug("post_tool_call hook error: %s", _hook_err)
+            _approval_tokens = set_current_observability_context(
+                turn_id=turn_id or "",
+                tool_call_id=tool_call_id or "",
+            )
+        except Exception:
+            reset_current_observability_context = None
+        try:
+            if function_name == "execute_code":
+                # Prefer the caller-provided list so subagents can't overwrite
+                # the parent's tool set via the process-global.
+                sandbox_enabled = enabled_tools if enabled_tools is not None else _last_resolved_tool_names
+                result = registry.dispatch(
+                    function_name, function_args,
+                    task_id=task_id,
+                    enabled_tools=sandbox_enabled,
+                )
+            else:
+                result = registry.dispatch(
+                    function_name, function_args,
+                    task_id=task_id,
+                    user_task=user_task,
+                )
+        finally:
+            if _approval_tokens is not None and reset_current_observability_context is not None:
+                try:
+                    reset_current_observability_context(_approval_tokens)
+                except Exception:
+                    pass
+        duration_ms = int((time.monotonic() - _dispatch_start) * 1000)
+        status, error_type, error_message = _tool_result_observer_fields(result)
+
+        _emit_post_tool_call_hook(
+            function_name=function_name,
+            function_args=function_args,
+            result=result,
+            task_id=task_id,
+            session_id=session_id,
+            tool_call_id=tool_call_id,
+            turn_id=turn_id,
+            api_request_id=api_request_id,
+            duration_ms=duration_ms,
+            status=status,
+            error_type=error_type,
+            error_message=error_message,
+        )
 
         # Generic tool-result canonicalization seam: plugins receive the
         # final result string (JSON, usually) and may replace it by
@@ -868,7 +953,7 @@ def handle_function_call(
         # is appended back into conversation context. Fail-open; the first
         # valid string return wins; non-string returns are ignored.
         try:
-            from hermes_cli.plugins import invoke_hook
+            from hermes_cli.plugins import OBSERVER_SCHEMA_VERSION, invoke_hook
             hook_results = invoke_hook(
                 "transform_tool_result",
                 tool_name=function_name,
@@ -877,7 +962,13 @@ def handle_function_call(
                 task_id=task_id or "",
                 session_id=session_id or "",
                 tool_call_id=tool_call_id or "",
+                turn_id=turn_id or "",
+                api_request_id=api_request_id or "",
                 duration_ms=duration_ms,
+                status=status,
+                error_type=error_type,
+                error_message=error_message,
+                telemetry_schema_version=OBSERVER_SCHEMA_VERSION,
             )
             for hook_result in hook_results:
                 if isinstance(hook_result, str):

--- a/model_tools.py
+++ b/model_tools.py
@@ -953,23 +953,19 @@ def handle_function_call(
                         task_id=task_id,
                         user_task=user_task,
                     )
-            try:
-                from hermes_cli.middleware import run_tool_execution_middleware
-                result = run_tool_execution_middleware(
-                    function_name,
-                    function_args,
-                    _dispatch,
-                    original_args=original_function_args,
-                    task_id=task_id or "",
-                    session_id=session_id or "",
-                    tool_call_id=tool_call_id or "",
-                    turn_id=turn_id or "",
-                    api_request_id=api_request_id or "",
-                    middleware_trace=middleware_trace,
-                )
-            except Exception as _middleware_err:
-                logger.debug("tool execution middleware error: %s", _middleware_err)
-                result = _dispatch(function_args)
+            from hermes_cli.middleware import run_tool_execution_middleware
+            result = run_tool_execution_middleware(
+                function_name,
+                function_args,
+                _dispatch,
+                original_args=original_function_args,
+                task_id=task_id or "",
+                session_id=session_id or "",
+                tool_call_id=tool_call_id or "",
+                turn_id=turn_id or "",
+                api_request_id=api_request_id or "",
+                middleware_trace=middleware_trace,
+            )
         finally:
             if _approval_tokens is not None and reset_current_observability_context is not None:
                 try:

--- a/model_tools.py
+++ b/model_tools.py
@@ -743,6 +743,8 @@ def _emit_post_tool_call_hook(
     function_name: str,
     function_args: Dict[str, Any],
     result: Any,
+    original_args: Optional[Dict[str, Any]] = None,
+    middleware_trace: Optional[List[Dict[str, Any]]] = None,
     task_id: Optional[str] = None,
     session_id: Optional[str] = None,
     tool_call_id: Optional[str] = None,
@@ -759,6 +761,8 @@ def _emit_post_tool_call_hook(
             "post_tool_call",
             tool_name=function_name,
             args=function_args,
+            original_args=original_args if isinstance(original_args, dict) else function_args,
+            middleware_trace=middleware_trace or [],
             result=result,
             task_id=task_id or "",
             session_id=session_id or "",
@@ -815,6 +819,27 @@ def handle_function_call(
     """
     # Coerce string arguments to their schema-declared types (e.g. "42"→42)
     function_args = coerce_tool_args(function_name, function_args)
+    if not isinstance(function_args, dict):
+        function_args = {}
+    original_function_args = dict(function_args)
+    middleware_trace: List[Dict[str, Any]] = []
+
+    try:
+        from hermes_cli.middleware import apply_tool_request_middleware
+        request_middleware = apply_tool_request_middleware(
+            function_name,
+            function_args,
+            task_id=task_id or "",
+            session_id=session_id or "",
+            tool_call_id=tool_call_id or "",
+            turn_id=turn_id or "",
+            api_request_id=api_request_id or "",
+        )
+        function_args = request_middleware.payload
+        middleware_trace = request_middleware.trace
+        original_function_args = request_middleware.original_payload
+    except Exception as _middleware_err:
+        logger.debug("tool request middleware error: %s", _middleware_err)
 
     try:
         if function_name in _AGENT_LOOP_TOOLS:
@@ -842,6 +867,8 @@ def handle_function_call(
                     tool_call_id=tool_call_id or "",
                     turn_id=turn_id or "",
                     api_request_id=api_request_id or "",
+                    original_args=original_function_args,
+                    middleware_trace=middleware_trace,
                 )
             except Exception as _hook_err:
                 logger.debug("pre_tool_call hook error: %s", _hook_err)
@@ -851,6 +878,8 @@ def handle_function_call(
                 _emit_post_tool_call_hook(
                     function_name=function_name,
                     function_args=function_args,
+                    original_args=original_function_args,
+                    middleware_trace=middleware_trace,
                     result=result,
                     task_id=task_id,
                     session_id=session_id,
@@ -911,17 +940,36 @@ def handle_function_call(
                 # Prefer the caller-provided list so subagents can't overwrite
                 # the parent's tool set via the process-global.
                 sandbox_enabled = enabled_tools if enabled_tools is not None else _last_resolved_tool_names
-                result = registry.dispatch(
-                    function_name, function_args,
-                    task_id=task_id,
-                    enabled_tools=sandbox_enabled,
-                )
+                def _dispatch(next_args: Dict[str, Any]) -> Any:
+                    return registry.dispatch(
+                        function_name, next_args,
+                        task_id=task_id,
+                        enabled_tools=sandbox_enabled,
+                    )
             else:
-                result = registry.dispatch(
-                    function_name, function_args,
-                    task_id=task_id,
-                    user_task=user_task,
+                def _dispatch(next_args: Dict[str, Any]) -> Any:
+                    return registry.dispatch(
+                        function_name, next_args,
+                        task_id=task_id,
+                        user_task=user_task,
+                    )
+            try:
+                from hermes_cli.middleware import run_tool_execution_middleware
+                result = run_tool_execution_middleware(
+                    function_name,
+                    function_args,
+                    _dispatch,
+                    original_args=original_function_args,
+                    task_id=task_id or "",
+                    session_id=session_id or "",
+                    tool_call_id=tool_call_id or "",
+                    turn_id=turn_id or "",
+                    api_request_id=api_request_id or "",
+                    middleware_trace=middleware_trace,
                 )
+            except Exception as _middleware_err:
+                logger.debug("tool execution middleware error: %s", _middleware_err)
+                result = _dispatch(function_args)
         finally:
             if _approval_tokens is not None and reset_current_observability_context is not None:
                 try:
@@ -934,6 +982,8 @@ def handle_function_call(
         _emit_post_tool_call_hook(
             function_name=function_name,
             function_args=function_args,
+            original_args=original_function_args,
+            middleware_trace=middleware_trace,
             result=result,
             task_id=task_id,
             session_id=session_id,
@@ -959,6 +1009,8 @@ def handle_function_call(
                 tool_name=function_name,
                 args=function_args,
                 result=result,
+                original_args=original_function_args,
+                middleware_trace=middleware_trace,
                 task_id=task_id or "",
                 session_id=session_id or "",
                 tool_call_id=tool_call_id or "",

--- a/plugins/observability/nemo_flow/README.md
+++ b/plugins/observability/nemo_flow/README.md
@@ -16,41 +16,52 @@ against the renamed NeMo Relay 0.3 package line:
 pip install "nemo-relay>=0.3"
 ```
 
-Useful local export settings:
+Configure export through NeMo Relay's agent-agnostic plugin file. By default,
+the Hermes plugin reads `.nemo-relay/plugins.toml` from the current working
+directory. Set `NEMO_RELAY_PLUGINS_TOML` only when the config lives elsewhere.
 
-```bash
-export HERMES_NEMO_FLOW_ATOF_ENABLED=1
-export HERMES_NEMO_FLOW_ATOF_OUTPUT_DIRECTORY=.nemo-flow/atof
-export HERMES_NEMO_FLOW_ATIF_ENABLED=1
-export HERMES_NEMO_FLOW_ATIF_OUTPUT_DIRECTORY=.nemo-flow/atif
+```toml
+version = 1
+
+[[components]]
+kind = "observability"
+enabled = true
+
+[components.config.atof]
+enabled = true
+output_directory = ".nemo-relay/atof"
+filename = "events.jsonl"
+mode = "overwrite"
+
+[components.config.atif]
+enabled = true
+output_directory = ".nemo-relay/atif"
+filename_template = "trajectory-{session_id}.json"
+subagent_export_mode = "embedded"
 ```
-
-To initialize NeMo Relay from a component config instead, set:
-
-```bash
-export HERMES_NEMO_FLOW_PLUGINS_TOML=.nemo-flow/plugins.toml
-```
-
-Optional overrides:
-
-- `HERMES_NEMO_FLOW_PLUGINS_TOML`
-- `HERMES_NEMO_FLOW_ATOF_FILENAME`
-- `HERMES_NEMO_FLOW_ATOF_MODE` (`append` or `overwrite`)
-- `HERMES_NEMO_FLOW_ATIF_FILENAME_TEMPLATE`
-- `HERMES_NEMO_FLOW_ATIF_AGENT_NAME`
-- `HERMES_NEMO_FLOW_ATIF_AGENT_VERSION`
-- `HERMES_NEMO_FLOW_ATIF_MODEL_NAME`
-- `HERMES_NEMO_FLOW_ADAPTIVE_ENABLED` (`1`, `true`, `yes`, or `on`)
-- `HERMES_NEMO_FLOW_ADAPTIVE_MODE` (`observe` by default)
 
 ## Adaptive Execution PoC
 
 By default, this plugin is passive: it observes Hermes hooks and emits
-NeMo Relay lifecycle events without changing execution. When
-`HERMES_NEMO_FLOW_ADAPTIVE_ENABLED=1`, the plugin also registers Hermes
-execution middleware and routes tool/provider callbacks through NeMo Relay's
-managed `tools.execute()` and `llm.execute()` helpers when those APIs are
-available.
+NeMo Relay lifecycle events without changing execution. When the same
+`plugins.toml` contains an enabled `adaptive` component, the plugin also routes
+Hermes tool/provider callbacks through NeMo Relay's managed `tools.execute()`
+and `llm.execute()` helpers when those APIs are available.
+
+```toml
+[[components]]
+kind = "adaptive"
+enabled = true
+
+[components.config]
+version = 1
+
+[components.config.state.backend]
+kind = "in_memory"
+
+[components.config.tool_parallelism]
+mode = "observe_only"
+```
 
 This enables NeMo Relay request intercepts and execution intercepts to run at the
 Hermes tool and LLM boundaries while preserving the raw Hermes provider response
@@ -72,3 +83,6 @@ subagent IDs, role/status fields when present, and derived
 `parent_trajectory_id` / `child_trajectory_id` values. This keeps the ATOF
 stream lossless for later ATIF conversion that can compact subagents into
 separate trajectories.
+
+For ATIF output, NeMo Relay's ATIF exporter embeds subagent trajectories in the
+parent trajectory by default under `subagent_trajectories`.

--- a/plugins/observability/nemo_flow/README.md
+++ b/plugins/observability/nemo_flow/README.md
@@ -1,7 +1,7 @@
-# NeMo-Flow Observability
+# NeMo Relay Observability
 
-Optional Hermes observability plugin that maps Hermes middleware hooks to
-NeMo-Flow scopes, LLM spans, tool spans, marks, ATOF, and ATIF.
+Optional Hermes observability plugin that maps Hermes observer hooks to
+NeMo Relay scopes, LLM spans, tool spans, marks, ATOF, and ATIF.
 
 Enable it with:
 
@@ -9,11 +9,11 @@ Enable it with:
 hermes plugins enable observability/nemo_flow
 ```
 
-The plugin fails open when `nemo-flow` is not installed. Install and test it
-against the pinned NeMo-Flow 0.2 package:
+The plugin fails open when `nemo-relay` is not installed. Install and test it
+against the renamed NeMo Relay 0.3 package line:
 
 ```bash
-pip install "nemo-flow==0.2"
+pip install "nemo-relay>=0.3"
 ```
 
 Useful local export settings:
@@ -25,7 +25,7 @@ export HERMES_NEMO_FLOW_ATIF_ENABLED=1
 export HERMES_NEMO_FLOW_ATIF_OUTPUT_DIRECTORY=.nemo-flow/atif
 ```
 
-To initialize NeMo-Flow from a component config instead, set:
+To initialize NeMo Relay from a component config instead, set:
 
 ```bash
 export HERMES_NEMO_FLOW_PLUGINS_TOML=.nemo-flow/plugins.toml
@@ -40,10 +40,26 @@ Optional overrides:
 - `HERMES_NEMO_FLOW_ATIF_AGENT_NAME`
 - `HERMES_NEMO_FLOW_ATIF_AGENT_VERSION`
 - `HERMES_NEMO_FLOW_ATIF_MODEL_NAME`
+- `HERMES_NEMO_FLOW_ADAPTIVE_ENABLED` (`1`, `true`, `yes`, or `on`)
+- `HERMES_NEMO_FLOW_ADAPTIVE_MODE` (`observe` by default)
+
+## Adaptive Execution PoC
+
+By default, this plugin is passive: it observes Hermes hooks and emits
+NeMo Relay lifecycle events without changing execution. When
+`HERMES_NEMO_FLOW_ADAPTIVE_ENABLED=1`, the plugin also registers Hermes
+execution middleware and routes tool/provider callbacks through NeMo Relay's
+managed `tools.execute()` and `llm.execute()` helpers when those APIs are
+available.
+
+This enables NeMo Relay request intercepts and execution intercepts to run at the
+Hermes tool and LLM boundaries while preserving the raw Hermes provider response
+for the agent loop. Treat this as an opt-in integration boundary for validating
+adaptive behavior before making NeMo Relay a default runtime backend.
 
 ## ATOF Mapping
 
-The plugin keeps NeMo-Flow's native event model:
+The plugin keeps NeMo Relay's native event model:
 
 - Hermes sessions map to `agent` scopes.
 - Hermes API request hooks map to `llm` scope start/end events.

--- a/plugins/observability/nemo_flow/README.md
+++ b/plugins/observability/nemo_flow/README.md
@@ -9,8 +9,12 @@ Enable it with:
 hermes plugins enable observability/nemo_flow
 ```
 
-The plugin fails open when `nemo-flow` is not installed. It targets the public
-Python API available in NeMo-Flow `0.2.0`.
+The plugin fails open when `nemo-flow` is not installed. Install and test it
+against the pinned NeMo-Flow 0.2 package:
+
+```bash
+pip install "nemo-flow==0.2"
+```
 
 Useful local export settings:
 

--- a/plugins/observability/nemo_flow/README.md
+++ b/plugins/observability/nemo_flow/README.md
@@ -1,0 +1,54 @@
+# NeMo-Flow Observability
+
+Optional Hermes observability plugin that maps Hermes middleware hooks to
+NeMo-Flow scopes, LLM spans, tool spans, marks, ATOF, and ATIF.
+
+Enable it with:
+
+```bash
+hermes plugins enable observability/nemo_flow
+```
+
+The plugin fails open when `nemo-flow` is not installed. It targets the public
+Python API available in NeMo-Flow `0.2.0`.
+
+Useful local export settings:
+
+```bash
+export HERMES_NEMO_FLOW_ATOF_ENABLED=1
+export HERMES_NEMO_FLOW_ATOF_OUTPUT_DIRECTORY=.nemo-flow/atof
+export HERMES_NEMO_FLOW_ATIF_ENABLED=1
+export HERMES_NEMO_FLOW_ATIF_OUTPUT_DIRECTORY=.nemo-flow/atif
+```
+
+To initialize NeMo-Flow from a component config instead, set:
+
+```bash
+export HERMES_NEMO_FLOW_PLUGINS_TOML=.nemo-flow/plugins.toml
+```
+
+Optional overrides:
+
+- `HERMES_NEMO_FLOW_PLUGINS_TOML`
+- `HERMES_NEMO_FLOW_ATOF_FILENAME`
+- `HERMES_NEMO_FLOW_ATOF_MODE` (`append` or `overwrite`)
+- `HERMES_NEMO_FLOW_ATIF_FILENAME_TEMPLATE`
+- `HERMES_NEMO_FLOW_ATIF_AGENT_NAME`
+- `HERMES_NEMO_FLOW_ATIF_AGENT_VERSION`
+- `HERMES_NEMO_FLOW_ATIF_MODEL_NAME`
+
+## ATOF Mapping
+
+The plugin keeps NeMo-Flow's native event model:
+
+- Hermes sessions map to `agent` scopes.
+- Hermes API request hooks map to `llm` scope start/end events.
+- Hermes tool hooks map to `tool` scope start/end events.
+- Turn, approval, subagent, and diagnostic fallback events map to `mark`
+  events.
+
+For subagent correlation, mark metadata includes parent and child session IDs,
+subagent IDs, role/status fields when present, and derived
+`parent_trajectory_id` / `child_trajectory_id` values. This keeps the ATOF
+stream lossless for later ATIF conversion that can compact subagents into
+separate trajectories.

--- a/plugins/observability/nemo_flow/__init__.py
+++ b/plugins/observability/nemo_flow/__init__.py
@@ -24,8 +24,6 @@ _RUNTIME: "_Runtime | object | None" = None
 class _SessionState:
     session_id: str
     handle: Any = None
-    atif_exporter: Any = None
-    atif_subscriber_name: str = ""
     llm_spans: dict[str, Any] = field(default_factory=dict)
     tool_spans: dict[str, Any] = field(default_factory=dict)
 
@@ -33,16 +31,7 @@ class _SessionState:
 @dataclass
 class _Settings:
     plugins_toml_path: str = ""
-    atof_enabled: bool = False
-    atof_output_directory: str = ""
-    atof_filename: str = "hermes-atof.jsonl"
-    atof_mode: str = "append"
-    atif_enabled: bool = False
-    atif_output_directory: str = ""
-    atif_filename_template: str = "hermes-atif-{session_id}.json"
-    atif_agent_name: str = "Hermes Agent"
-    atif_agent_version: str = "unknown"
-    atif_model_name: str = "unknown"
+    plugins_config: dict[str, Any] | None = None
     adaptive_enabled: bool = False
     adaptive_mode: str = "observe"
 
@@ -52,22 +41,18 @@ class _Runtime:
         self.nemo_flow = nemo_flow
         self.settings = settings
         self.sessions: dict[str, _SessionState] = {}
-        self.atof_exporter: Any = None
+        self.subagent_parents: dict[str, str] = {}
         self._plugin_config_initialized = self._configure_plugins_toml()
-        if not self._plugin_config_initialized:
-            self._configure_atof()
 
     def _configure_plugins_toml(self) -> bool:
-        if not self.settings.plugins_toml_path:
+        if not self.settings.plugins_config:
             return False
         plugin_mod = getattr(self.nemo_flow, "plugin", None)
         initialize = getattr(plugin_mod, "initialize", None)
         if not callable(initialize):
             return False
-        config_path = Path(self.settings.plugins_toml_path)
         try:
-            config = tomllib.loads(config_path.read_text(encoding="utf-8"))
-            result = initialize(config)
+            result = initialize(self.settings.plugins_config)
             if inspect.isawaitable(result):
                 asyncio.run(result)
             return True
@@ -78,21 +63,6 @@ class _Runtime:
             logger.debug("NeMo Relay plugins.toml init failed: %s", exc, exc_info=True)
             return False
 
-    def _configure_atof(self) -> None:
-        if not self.settings.atof_enabled:
-            return
-        config = self.nemo_flow.AtofExporterConfig()
-        if self.settings.atof_output_directory:
-            Path(self.settings.atof_output_directory).mkdir(parents=True, exist_ok=True)
-            config.output_directory = self.settings.atof_output_directory
-        config.filename = self.settings.atof_filename
-        if self.settings.atof_mode.lower() == "overwrite":
-            config.mode = self.nemo_flow.AtofExporterMode.Overwrite
-        else:
-            config.mode = self.nemo_flow.AtofExporterMode.Append
-        self.atof_exporter = self.nemo_flow.AtofExporter(config)
-        self.atof_exporter.register("hermes.nemo_flow.atof")
-
     def ensure_session(self, kwargs: dict[str, Any]) -> _SessionState:
         session_id = _session_id(kwargs)
         state = self.sessions.get(session_id)
@@ -100,35 +70,26 @@ class _Runtime:
             return state
 
         state = _SessionState(session_id=session_id)
-        if self.settings.atif_enabled:
-            state.atif_exporter = self.nemo_flow.AtifExporter(
-                session_id,
-                self.settings.atif_agent_name,
-                self.settings.atif_agent_version,
-                model_name=str(kwargs.get("model") or self.settings.atif_model_name),
-                extra={"source": "hermes-agent", "plugin": "observability/nemo_flow"},
-            )
-            state.atif_subscriber_name = f"hermes.nemo_flow.atif.{session_id}"
-            state.atif_exporter.register(state.atif_subscriber_name)
-
+        scope_payload = dict(kwargs)
+        parent_session_id = str(
+            scope_payload.get("parent_session_id") or self.subagent_parents.get(session_id) or ""
+        )
+        if parent_session_id:
+            scope_payload.setdefault("parent_session_id", parent_session_id)
+        scope_kwargs: dict[str, Any] = {
+            "data": {"session_id": session_id},
+            "metadata": _metadata(scope_payload),
+        }
+        parent_state = self.sessions.get(parent_session_id)
+        if parent_state is not None and parent_state.handle is not None:
+            scope_kwargs["handle"] = parent_state.handle
         state.handle = self.nemo_flow.scope.push(
             f"hermes-session-{session_id}",
             self.nemo_flow.ScopeType.Agent,
-            data={"session_id": session_id},
-            metadata=_metadata(kwargs),
+            **scope_kwargs,
         )
         self.sessions[session_id] = state
         return state
-
-    def export_atif(self, state: _SessionState) -> None:
-        if not self.settings.atif_enabled or state.atif_exporter is None:
-            return
-        output_dir = self.settings.atif_output_directory
-        if not output_dir:
-            return
-        Path(output_dir).mkdir(parents=True, exist_ok=True)
-        filename = self.settings.atif_filename_template.format(session_id=state.session_id)
-        Path(output_dir, filename).write_text(state.atif_exporter.export_json(), encoding="utf-8")
 
     def close_session(self, kwargs: dict[str, Any]) -> None:
         session_id = _session_id(kwargs)
@@ -140,12 +101,13 @@ class _Runtime:
                 self.nemo_flow.scope.pop(state.handle, output=_jsonable(kwargs))
             except Exception:
                 logger.debug("NeMo Relay session pop failed", exc_info=True)
-        self.export_atif(state)
-        if state.atif_exporter is not None and state.atif_subscriber_name:
-            try:
-                state.atif_exporter.deregister(state.atif_subscriber_name)
-            except Exception:
-                logger.debug("NeMo Relay ATIF deregister failed", exc_info=True)
+        self.subagent_parents.pop(session_id, None)
+
+    def note_subagent_start(self, kwargs: dict[str, Any]) -> None:
+        child_session_id = kwargs.get("child_session_id")
+        parent_session_id = kwargs.get("parent_session_id") or kwargs.get("session_id")
+        if child_session_id and parent_session_id:
+            self.subagent_parents[str(child_session_id)] = str(parent_session_id)
 
     def mark(self, name: str, kwargs: dict[str, Any]) -> None:
         state = self.ensure_session(kwargs)
@@ -264,7 +226,7 @@ def on_session_start(**kwargs: Any) -> None:
 def on_session_end(**kwargs: Any) -> None:
     runtime = _get_runtime()
     if runtime is not None:
-        _safe(lambda: (runtime.mark("hermes.session.end", kwargs), runtime.export_atif(runtime.ensure_session(kwargs))))
+        _safe(lambda: runtime.mark("hermes.session.end", kwargs))
 
 
 def on_session_finalize(**kwargs: Any) -> None:
@@ -423,7 +385,11 @@ def on_post_approval_response(**kwargs: Any) -> None:
 def on_subagent_start(**kwargs: Any) -> None:
     runtime = _get_runtime()
     if runtime is not None:
-        _safe(lambda: runtime.mark("hermes.subagent.start", kwargs))
+        def _emit() -> None:
+            runtime.note_subagent_start(kwargs)
+            runtime.mark("hermes.subagent.start", kwargs)
+
+        _safe(_emit)
 
 
 def on_subagent_stop(**kwargs: Any) -> None:
@@ -471,20 +437,13 @@ def _get_runtime() -> Optional[_Runtime]:
 
 
 def _load_settings() -> _Settings:
+    plugins_toml_path, plugins_config = _load_plugins_toml()
+    adaptive_config = _enabled_component_config(plugins_config, "adaptive")
     return _Settings(
-        plugins_toml_path=_env("HERMES_NEMO_FLOW_PLUGINS_TOML"),
-        atof_enabled=_env_bool("HERMES_NEMO_FLOW_ATOF_ENABLED"),
-        atof_output_directory=_env("HERMES_NEMO_FLOW_ATOF_OUTPUT_DIRECTORY"),
-        atof_filename=_env("HERMES_NEMO_FLOW_ATOF_FILENAME") or "hermes-atof.jsonl",
-        atof_mode=_env("HERMES_NEMO_FLOW_ATOF_MODE") or "append",
-        atif_enabled=_env_bool("HERMES_NEMO_FLOW_ATIF_ENABLED"),
-        atif_output_directory=_env("HERMES_NEMO_FLOW_ATIF_OUTPUT_DIRECTORY"),
-        atif_filename_template=_env("HERMES_NEMO_FLOW_ATIF_FILENAME_TEMPLATE") or "hermes-atif-{session_id}.json",
-        atif_agent_name=_env("HERMES_NEMO_FLOW_ATIF_AGENT_NAME") or "Hermes Agent",
-        atif_agent_version=_env("HERMES_NEMO_FLOW_ATIF_AGENT_VERSION") or "unknown",
-        atif_model_name=_env("HERMES_NEMO_FLOW_ATIF_MODEL_NAME") or "unknown",
-        adaptive_enabled=_env_bool("HERMES_NEMO_FLOW_ADAPTIVE_ENABLED"),
-        adaptive_mode=_env("HERMES_NEMO_FLOW_ADAPTIVE_MODE") or "observe",
+        plugins_toml_path=plugins_toml_path,
+        plugins_config=plugins_config,
+        adaptive_enabled=adaptive_config is not None,
+        adaptive_mode=_adaptive_mode(adaptive_config),
     )
 
 
@@ -492,8 +451,45 @@ def _env(name: str) -> str:
     return os.environ.get(name, "").strip()
 
 
-def _env_bool(name: str) -> bool:
-    return _env(name).lower() in {"1", "true", "yes", "on"}
+def _load_plugins_toml() -> tuple[str, dict[str, Any] | None]:
+    explicit_path = _env("NEMO_RELAY_PLUGINS_TOML")
+    candidates = [Path(explicit_path)] if explicit_path else [Path(".nemo-relay/plugins.toml")]
+    for path in candidates:
+        if not path.exists():
+            continue
+        try:
+            return str(path), tomllib.loads(path.read_text(encoding="utf-8"))
+        except Exception as exc:
+            logger.debug("NeMo Relay plugins.toml load failed for %s: %s", path, exc, exc_info=True)
+            return str(path), None
+    return "", None
+
+
+def _enabled_component_config(config: dict[str, Any] | None, kind: str) -> dict[str, Any] | None:
+    if not isinstance(config, dict):
+        return None
+    components = config.get("components")
+    if not isinstance(components, list):
+        return None
+    for component in components:
+        if not isinstance(component, dict):
+            continue
+        if component.get("kind") != kind or component.get("enabled") is not True:
+            continue
+        component_config = component.get("config")
+        return component_config if isinstance(component_config, dict) else {}
+    return None
+
+
+def _adaptive_mode(config: dict[str, Any] | None) -> str:
+    if not isinstance(config, dict):
+        return "observe"
+    tool_parallelism = config.get("tool_parallelism")
+    if isinstance(tool_parallelism, dict):
+        mode = tool_parallelism.get("mode")
+        if isinstance(mode, str) and mode:
+            return mode
+    return "observe"
 
 
 def _session_id(kwargs: dict[str, Any]) -> str:

--- a/plugins/observability/nemo_flow/__init__.py
+++ b/plugins/observability/nemo_flow/__init__.py
@@ -1,4 +1,4 @@
-"""nemo_flow — optional Hermes plugin for NeMo-Flow observability."""
+"""nemo_flow — optional Hermes plugin for NeMo Relay observability."""
 
 from __future__ import annotations
 
@@ -43,6 +43,8 @@ class _Settings:
     atif_agent_name: str = "Hermes Agent"
     atif_agent_version: str = "unknown"
     atif_model_name: str = "unknown"
+    adaptive_enabled: bool = False
+    adaptive_mode: str = "observe"
 
 
 class _Runtime:
@@ -70,10 +72,10 @@ class _Runtime:
                 asyncio.run(result)
             return True
         except RuntimeError:
-            logger.debug("NeMo-Flow plugins.toml init skipped inside a running event loop")
+            logger.debug("NeMo Relay plugins.toml init skipped inside a running event loop")
             return False
         except Exception as exc:
-            logger.debug("NeMo-Flow plugins.toml init failed: %s", exc, exc_info=True)
+            logger.debug("NeMo Relay plugins.toml init failed: %s", exc, exc_info=True)
             return False
 
     def _configure_atof(self) -> None:
@@ -137,13 +139,13 @@ class _Runtime:
             try:
                 self.nemo_flow.scope.pop(state.handle, output=_jsonable(kwargs))
             except Exception:
-                logger.debug("NeMo-Flow session pop failed", exc_info=True)
+                logger.debug("NeMo Relay session pop failed", exc_info=True)
         self.export_atif(state)
         if state.atif_exporter is not None and state.atif_subscriber_name:
             try:
                 state.atif_exporter.deregister(state.atif_subscriber_name)
             except Exception:
-                logger.debug("NeMo-Flow ATIF deregister failed", exc_info=True)
+                logger.debug("NeMo Relay ATIF deregister failed", exc_info=True)
 
     def mark(self, name: str, kwargs: dict[str, Any]) -> None:
         state = self.ensure_session(kwargs)
@@ -153,6 +155,84 @@ class _Runtime:
             data=_jsonable(kwargs),
             metadata=_metadata(kwargs),
         )
+
+    def managed_tool_enabled(self) -> bool:
+        return (
+            self.settings.adaptive_enabled
+            and callable(getattr(getattr(self.nemo_flow, "tools", None), "execute", None))
+        )
+
+    def managed_llm_enabled(self) -> bool:
+        return (
+            self.settings.adaptive_enabled
+            and callable(getattr(getattr(self.nemo_flow, "llm", None), "execute", None))
+            and callable(getattr(self.nemo_flow, "LLMRequest", None))
+        )
+
+    def execute_tool(self, kwargs: dict[str, Any]) -> Any:
+        state = self.ensure_session(kwargs)
+        tool_name = str(kwargs.get("tool_name") or "tool")
+        args = _jsonable(kwargs.get("args") or {})
+        next_call = kwargs.get("next_call")
+        if not callable(next_call):
+            return args
+
+        def _impl(next_args: Any) -> Any:
+            return next_call(next_args if isinstance(next_args, dict) else args)
+
+        return _resolve_awaitable(
+            self.nemo_flow.tools.execute(
+                tool_name,
+                args,
+                _impl,
+                handle=state.handle,
+                data=_jsonable(
+                    {
+                        "turn_id": kwargs.get("turn_id"),
+                        "api_request_id": kwargs.get("api_request_id"),
+                        "mode": self.settings.adaptive_mode,
+                    }
+                ),
+                metadata=_metadata(kwargs),
+            )
+        )
+
+    def execute_llm(self, kwargs: dict[str, Any]) -> Any:
+        state = self.ensure_session(kwargs)
+        request_body = _jsonable(kwargs.get("request") or {})
+        request = self.nemo_flow.LLMRequest({}, request_body)
+        next_call = kwargs.get("next_call")
+        if not callable(next_call):
+            return request_body
+
+        raw_response: dict[str, Any] = {"set": False, "value": None}
+
+        def _impl(next_request: Any) -> Any:
+            next_body = getattr(next_request, "content", next_request)
+            raw = next_call(next_body if isinstance(next_body, dict) else request_body)
+            raw_response["set"] = True
+            raw_response["value"] = raw
+            return _jsonable(raw)
+
+        managed_result = _resolve_awaitable(
+            self.nemo_flow.llm.execute(
+                str(kwargs.get("provider") or "llm"),
+                request,
+                _impl,
+                handle=state.handle,
+                data=_jsonable(
+                    {
+                        "turn_id": kwargs.get("turn_id"),
+                        "api_request_id": kwargs.get("api_request_id"),
+                        "api_call_count": kwargs.get("api_call_count"),
+                        "mode": self.settings.adaptive_mode,
+                    }
+                ),
+                metadata=_metadata(kwargs),
+                model_name=str(kwargs.get("model") or ""),
+            )
+        )
+        return raw_response["value"] if raw_response["set"] else managed_result
 
 
 def register(ctx) -> None:
@@ -171,6 +251,8 @@ def register(ctx) -> None:
     ctx.register_hook("post_approval_response", on_post_approval_response)
     ctx.register_hook("subagent_start", on_subagent_start)
     ctx.register_hook("subagent_stop", on_subagent_stop)
+    ctx.register_middleware("tool_execution", on_tool_execution_middleware)
+    ctx.register_middleware("api_execution", on_api_execution_middleware)
 
 
 def on_session_start(**kwargs: Any) -> None:
@@ -213,6 +295,8 @@ def on_pre_api_request(**kwargs: Any) -> None:
     runtime = _get_runtime()
     if runtime is None:
         return
+    if runtime.managed_llm_enabled():
+        return
 
     def _record() -> None:
         state = runtime.ensure_session(kwargs)
@@ -235,6 +319,8 @@ def on_pre_api_request(**kwargs: Any) -> None:
 def on_post_api_request(**kwargs: Any) -> None:
     runtime = _get_runtime()
     if runtime is None:
+        return
+    if runtime.managed_llm_enabled():
         return
 
     def _record() -> None:
@@ -278,6 +364,8 @@ def on_pre_tool_call(**kwargs: Any) -> None:
     runtime = _get_runtime()
     if runtime is None:
         return
+    if runtime.managed_tool_enabled():
+        return
 
     def _record() -> None:
         state = runtime.ensure_session(kwargs)
@@ -297,6 +385,11 @@ def on_pre_tool_call(**kwargs: Any) -> None:
 def on_post_tool_call(**kwargs: Any) -> None:
     runtime = _get_runtime()
     if runtime is None:
+        return
+    if runtime.managed_tool_enabled() and kwargs.get("status") != "blocked":
+        return
+    if runtime.managed_tool_enabled() and kwargs.get("status") == "blocked":
+        _safe(lambda: runtime.mark("hermes.tool.blocked", kwargs))
         return
 
     def _record() -> None:
@@ -339,6 +432,22 @@ def on_subagent_stop(**kwargs: Any) -> None:
         _safe(lambda: runtime.mark("hermes.subagent.stop", kwargs))
 
 
+def on_tool_execution_middleware(**kwargs: Any) -> Any:
+    runtime = _get_runtime()
+    next_call = kwargs.get("next_call")
+    if runtime is None or not runtime.managed_tool_enabled() or not callable(next_call):
+        return next_call(kwargs.get("args") or {}) if callable(next_call) else kwargs.get("args")
+    return runtime.execute_tool(kwargs)
+
+
+def on_api_execution_middleware(**kwargs: Any) -> Any:
+    runtime = _get_runtime()
+    next_call = kwargs.get("next_call")
+    if runtime is None or not runtime.managed_llm_enabled() or not callable(next_call):
+        return next_call(kwargs.get("request") or {}) if callable(next_call) else kwargs.get("request")
+    return runtime.execute_llm(kwargs)
+
+
 def _get_runtime() -> Optional[_Runtime]:
     global _RUNTIME
     with _LOCK:
@@ -347,15 +456,15 @@ def _get_runtime() -> Optional[_Runtime]:
         if isinstance(_RUNTIME, _Runtime):
             return _RUNTIME
         try:
-            import nemo_flow
+            import nemo_relay
         except Exception as exc:
-            logger.debug("NeMo-Flow plugin disabled: import failed: %s", exc)
+            logger.debug("NeMo Relay plugin disabled: import failed: %s", exc)
             _RUNTIME = _INIT_FAILED
             return None
         try:
-            _RUNTIME = _Runtime(nemo_flow=nemo_flow, settings=_load_settings())
+            _RUNTIME = _Runtime(nemo_flow=nemo_relay, settings=_load_settings())
         except Exception as exc:
-            logger.debug("NeMo-Flow plugin disabled: init failed: %s", exc, exc_info=True)
+            logger.debug("NeMo Relay plugin disabled: init failed: %s", exc, exc_info=True)
             _RUNTIME = _INIT_FAILED
             return None
         return _RUNTIME
@@ -374,6 +483,8 @@ def _load_settings() -> _Settings:
         atif_agent_name=_env("HERMES_NEMO_FLOW_ATIF_AGENT_NAME") or "Hermes Agent",
         atif_agent_version=_env("HERMES_NEMO_FLOW_ATIF_AGENT_VERSION") or "unknown",
         atif_model_name=_env("HERMES_NEMO_FLOW_ATIF_MODEL_NAME") or "unknown",
+        adaptive_enabled=_env_bool("HERMES_NEMO_FLOW_ADAPTIVE_ENABLED"),
+        adaptive_mode=_env("HERMES_NEMO_FLOW_ADAPTIVE_MODE") or "observe",
     )
 
 
@@ -458,7 +569,17 @@ def _safe(fn) -> None:
     try:
         fn()
     except Exception as exc:
-        logger.debug("NeMo-Flow hook handling failed: %s", exc, exc_info=True)
+        logger.debug("NeMo Relay hook handling failed: %s", exc, exc_info=True)
+
+
+def _resolve_awaitable(value: Any) -> Any:
+    if not inspect.isawaitable(value):
+        return value
+    try:
+        return asyncio.run(value)
+    except RuntimeError:
+        logger.debug("NeMo Relay adaptive awaitable skipped inside a running event loop")
+        raise
 
 
 def reset_for_tests() -> None:

--- a/plugins/observability/nemo_flow/__init__.py
+++ b/plugins/observability/nemo_flow/__init__.py
@@ -1,0 +1,467 @@
+"""nemo_flow — optional Hermes plugin for NeMo-Flow observability."""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+import json
+import logging
+import os
+import threading
+import tomllib
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+_INIT_FAILED = object()
+_LOCK = threading.RLock()
+_RUNTIME: "_Runtime | object | None" = None
+
+
+@dataclass
+class _SessionState:
+    session_id: str
+    handle: Any = None
+    atif_exporter: Any = None
+    atif_subscriber_name: str = ""
+    llm_spans: dict[str, Any] = field(default_factory=dict)
+    tool_spans: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class _Settings:
+    plugins_toml_path: str = ""
+    atof_enabled: bool = False
+    atof_output_directory: str = ""
+    atof_filename: str = "hermes-atof.jsonl"
+    atof_mode: str = "append"
+    atif_enabled: bool = False
+    atif_output_directory: str = ""
+    atif_filename_template: str = "hermes-atif-{session_id}.json"
+    atif_agent_name: str = "Hermes Agent"
+    atif_agent_version: str = "unknown"
+    atif_model_name: str = "unknown"
+
+
+class _Runtime:
+    def __init__(self, nemo_flow: Any, settings: _Settings) -> None:
+        self.nemo_flow = nemo_flow
+        self.settings = settings
+        self.sessions: dict[str, _SessionState] = {}
+        self.atof_exporter: Any = None
+        self._plugin_config_initialized = self._configure_plugins_toml()
+        if not self._plugin_config_initialized:
+            self._configure_atof()
+
+    def _configure_plugins_toml(self) -> bool:
+        if not self.settings.plugins_toml_path:
+            return False
+        plugin_mod = getattr(self.nemo_flow, "plugin", None)
+        initialize = getattr(plugin_mod, "initialize", None)
+        if not callable(initialize):
+            return False
+        config_path = Path(self.settings.plugins_toml_path)
+        try:
+            config = tomllib.loads(config_path.read_text(encoding="utf-8"))
+            result = initialize(config)
+            if inspect.isawaitable(result):
+                asyncio.run(result)
+            return True
+        except RuntimeError:
+            logger.debug("NeMo-Flow plugins.toml init skipped inside a running event loop")
+            return False
+        except Exception as exc:
+            logger.debug("NeMo-Flow plugins.toml init failed: %s", exc, exc_info=True)
+            return False
+
+    def _configure_atof(self) -> None:
+        if not self.settings.atof_enabled:
+            return
+        config = self.nemo_flow.AtofExporterConfig()
+        if self.settings.atof_output_directory:
+            Path(self.settings.atof_output_directory).mkdir(parents=True, exist_ok=True)
+            config.output_directory = self.settings.atof_output_directory
+        config.filename = self.settings.atof_filename
+        if self.settings.atof_mode.lower() == "overwrite":
+            config.mode = self.nemo_flow.AtofExporterMode.Overwrite
+        else:
+            config.mode = self.nemo_flow.AtofExporterMode.Append
+        self.atof_exporter = self.nemo_flow.AtofExporter(config)
+        self.atof_exporter.register("hermes.nemo_flow.atof")
+
+    def ensure_session(self, kwargs: dict[str, Any]) -> _SessionState:
+        session_id = _session_id(kwargs)
+        state = self.sessions.get(session_id)
+        if state is not None:
+            return state
+
+        state = _SessionState(session_id=session_id)
+        if self.settings.atif_enabled:
+            state.atif_exporter = self.nemo_flow.AtifExporter(
+                session_id,
+                self.settings.atif_agent_name,
+                self.settings.atif_agent_version,
+                model_name=str(kwargs.get("model") or self.settings.atif_model_name),
+                extra={"source": "hermes-agent", "plugin": "observability/nemo_flow"},
+            )
+            state.atif_subscriber_name = f"hermes.nemo_flow.atif.{session_id}"
+            state.atif_exporter.register(state.atif_subscriber_name)
+
+        state.handle = self.nemo_flow.scope.push(
+            f"hermes-session-{session_id}",
+            self.nemo_flow.ScopeType.Agent,
+            data={"session_id": session_id},
+            metadata=_metadata(kwargs),
+        )
+        self.sessions[session_id] = state
+        return state
+
+    def export_atif(self, state: _SessionState) -> None:
+        if not self.settings.atif_enabled or state.atif_exporter is None:
+            return
+        output_dir = self.settings.atif_output_directory
+        if not output_dir:
+            return
+        Path(output_dir).mkdir(parents=True, exist_ok=True)
+        filename = self.settings.atif_filename_template.format(session_id=state.session_id)
+        Path(output_dir, filename).write_text(state.atif_exporter.export_json(), encoding="utf-8")
+
+    def close_session(self, kwargs: dict[str, Any]) -> None:
+        session_id = _session_id(kwargs)
+        state = self.sessions.pop(session_id, None)
+        if state is None:
+            return
+        if state.handle is not None:
+            try:
+                self.nemo_flow.scope.pop(state.handle, output=_jsonable(kwargs))
+            except Exception:
+                logger.debug("NeMo-Flow session pop failed", exc_info=True)
+        self.export_atif(state)
+        if state.atif_exporter is not None and state.atif_subscriber_name:
+            try:
+                state.atif_exporter.deregister(state.atif_subscriber_name)
+            except Exception:
+                logger.debug("NeMo-Flow ATIF deregister failed", exc_info=True)
+
+    def mark(self, name: str, kwargs: dict[str, Any]) -> None:
+        state = self.ensure_session(kwargs)
+        self.nemo_flow.scope.event(
+            name,
+            handle=state.handle,
+            data=_jsonable(kwargs),
+            metadata=_metadata(kwargs),
+        )
+
+
+def register(ctx) -> None:
+    ctx.register_hook("on_session_start", on_session_start)
+    ctx.register_hook("on_session_end", on_session_end)
+    ctx.register_hook("on_session_finalize", on_session_finalize)
+    ctx.register_hook("on_session_reset", on_session_reset)
+    ctx.register_hook("pre_llm_call", on_pre_llm_call)
+    ctx.register_hook("post_llm_call", on_post_llm_call)
+    ctx.register_hook("pre_api_request", on_pre_api_request)
+    ctx.register_hook("post_api_request", on_post_api_request)
+    ctx.register_hook("api_request_error", on_api_request_error)
+    ctx.register_hook("pre_tool_call", on_pre_tool_call)
+    ctx.register_hook("post_tool_call", on_post_tool_call)
+    ctx.register_hook("pre_approval_request", on_pre_approval_request)
+    ctx.register_hook("post_approval_response", on_post_approval_response)
+    ctx.register_hook("subagent_start", on_subagent_start)
+    ctx.register_hook("subagent_stop", on_subagent_stop)
+
+
+def on_session_start(**kwargs: Any) -> None:
+    runtime = _get_runtime()
+    if runtime is not None:
+        _safe(lambda: runtime.ensure_session(kwargs))
+
+
+def on_session_end(**kwargs: Any) -> None:
+    runtime = _get_runtime()
+    if runtime is not None:
+        _safe(lambda: (runtime.mark("hermes.session.end", kwargs), runtime.export_atif(runtime.ensure_session(kwargs))))
+
+
+def on_session_finalize(**kwargs: Any) -> None:
+    runtime = _get_runtime()
+    if runtime is not None:
+        _safe(lambda: runtime.close_session(kwargs))
+
+
+def on_session_reset(**kwargs: Any) -> None:
+    runtime = _get_runtime()
+    if runtime is not None:
+        _safe(lambda: runtime.close_session(kwargs))
+
+
+def on_pre_llm_call(**kwargs: Any) -> None:
+    runtime = _get_runtime()
+    if runtime is not None:
+        _safe(lambda: runtime.mark("hermes.turn.start", kwargs))
+
+
+def on_post_llm_call(**kwargs: Any) -> None:
+    runtime = _get_runtime()
+    if runtime is not None:
+        _safe(lambda: runtime.mark("hermes.turn.end", kwargs))
+
+
+def on_pre_api_request(**kwargs: Any) -> None:
+    runtime = _get_runtime()
+    if runtime is None:
+        return
+
+    def _record() -> None:
+        state = runtime.ensure_session(kwargs)
+        request_payload = kwargs.get("request")
+        request_body = request_payload.get("body") if isinstance(request_payload, dict) else {}
+        request = runtime.nemo_flow.LLMRequest({}, _jsonable(request_body))
+        span = runtime.nemo_flow.llm.call(
+            str(kwargs.get("provider") or "llm"),
+            request,
+            handle=state.handle,
+            data=_jsonable({"turn_id": kwargs.get("turn_id"), "api_request_id": kwargs.get("api_request_id")}),
+            metadata=_metadata(kwargs),
+            model_name=str(kwargs.get("model") or ""),
+        )
+        state.llm_spans[_api_key(kwargs)] = span
+
+    _safe(_record)
+
+
+def on_post_api_request(**kwargs: Any) -> None:
+    runtime = _get_runtime()
+    if runtime is None:
+        return
+
+    def _record() -> None:
+        state = runtime.ensure_session(kwargs)
+        span = state.llm_spans.pop(_api_key(kwargs), None)
+        if span is None:
+            runtime.mark("hermes.api.response.unmatched", kwargs)
+            return
+        runtime.nemo_flow.llm.call_end(
+            span,
+            _jsonable(kwargs.get("response") or {}),
+            data=_jsonable({"usage": kwargs.get("usage"), "finish_reason": kwargs.get("finish_reason")}),
+            metadata=_metadata(kwargs),
+        )
+
+    _safe(_record)
+
+
+def on_api_request_error(**kwargs: Any) -> None:
+    runtime = _get_runtime()
+    if runtime is None:
+        return
+
+    def _record() -> None:
+        state = runtime.ensure_session(kwargs)
+        span = state.llm_spans.pop(_api_key(kwargs), None)
+        if span is None:
+            runtime.mark("hermes.api.error", kwargs)
+            return
+        runtime.nemo_flow.llm.call_end(
+            span,
+            {"error": _jsonable(kwargs.get("error") or {})},
+            data=_jsonable(kwargs),
+            metadata=_metadata(kwargs),
+        )
+
+    _safe(_record)
+
+
+def on_pre_tool_call(**kwargs: Any) -> None:
+    runtime = _get_runtime()
+    if runtime is None:
+        return
+
+    def _record() -> None:
+        state = runtime.ensure_session(kwargs)
+        span = runtime.nemo_flow.tools.call(
+            str(kwargs.get("tool_name") or "tool"),
+            _jsonable(kwargs.get("args") or {}),
+            handle=state.handle,
+            data=_jsonable({"turn_id": kwargs.get("turn_id"), "api_request_id": kwargs.get("api_request_id")}),
+            metadata=_metadata(kwargs),
+            tool_call_id=str(kwargs.get("tool_call_id") or ""),
+        )
+        state.tool_spans[_tool_key(kwargs)] = span
+
+    _safe(_record)
+
+
+def on_post_tool_call(**kwargs: Any) -> None:
+    runtime = _get_runtime()
+    if runtime is None:
+        return
+
+    def _record() -> None:
+        state = runtime.ensure_session(kwargs)
+        span = state.tool_spans.pop(_tool_key(kwargs), None)
+        if span is None:
+            runtime.mark("hermes.tool.response.unmatched", kwargs)
+            return
+        runtime.nemo_flow.tools.call_end(
+            span,
+            _jsonable(kwargs.get("result")),
+            data=_jsonable({"status": kwargs.get("status"), "duration_ms": kwargs.get("duration_ms")}),
+            metadata=_metadata(kwargs),
+        )
+
+    _safe(_record)
+
+
+def on_pre_approval_request(**kwargs: Any) -> None:
+    runtime = _get_runtime()
+    if runtime is not None:
+        _safe(lambda: runtime.mark("hermes.approval.request", kwargs))
+
+
+def on_post_approval_response(**kwargs: Any) -> None:
+    runtime = _get_runtime()
+    if runtime is not None:
+        _safe(lambda: runtime.mark("hermes.approval.response", kwargs))
+
+
+def on_subagent_start(**kwargs: Any) -> None:
+    runtime = _get_runtime()
+    if runtime is not None:
+        _safe(lambda: runtime.mark("hermes.subagent.start", kwargs))
+
+
+def on_subagent_stop(**kwargs: Any) -> None:
+    runtime = _get_runtime()
+    if runtime is not None:
+        _safe(lambda: runtime.mark("hermes.subagent.stop", kwargs))
+
+
+def _get_runtime() -> Optional[_Runtime]:
+    global _RUNTIME
+    with _LOCK:
+        if _RUNTIME is _INIT_FAILED:
+            return None
+        if isinstance(_RUNTIME, _Runtime):
+            return _RUNTIME
+        try:
+            import nemo_flow
+        except Exception as exc:
+            logger.debug("NeMo-Flow plugin disabled: import failed: %s", exc)
+            _RUNTIME = _INIT_FAILED
+            return None
+        try:
+            _RUNTIME = _Runtime(nemo_flow=nemo_flow, settings=_load_settings())
+        except Exception as exc:
+            logger.debug("NeMo-Flow plugin disabled: init failed: %s", exc, exc_info=True)
+            _RUNTIME = _INIT_FAILED
+            return None
+        return _RUNTIME
+
+
+def _load_settings() -> _Settings:
+    return _Settings(
+        plugins_toml_path=_env("HERMES_NEMO_FLOW_PLUGINS_TOML"),
+        atof_enabled=_env_bool("HERMES_NEMO_FLOW_ATOF_ENABLED"),
+        atof_output_directory=_env("HERMES_NEMO_FLOW_ATOF_OUTPUT_DIRECTORY"),
+        atof_filename=_env("HERMES_NEMO_FLOW_ATOF_FILENAME") or "hermes-atof.jsonl",
+        atof_mode=_env("HERMES_NEMO_FLOW_ATOF_MODE") or "append",
+        atif_enabled=_env_bool("HERMES_NEMO_FLOW_ATIF_ENABLED"),
+        atif_output_directory=_env("HERMES_NEMO_FLOW_ATIF_OUTPUT_DIRECTORY"),
+        atif_filename_template=_env("HERMES_NEMO_FLOW_ATIF_FILENAME_TEMPLATE") or "hermes-atif-{session_id}.json",
+        atif_agent_name=_env("HERMES_NEMO_FLOW_ATIF_AGENT_NAME") or "Hermes Agent",
+        atif_agent_version=_env("HERMES_NEMO_FLOW_ATIF_AGENT_VERSION") or "unknown",
+        atif_model_name=_env("HERMES_NEMO_FLOW_ATIF_MODEL_NAME") or "unknown",
+    )
+
+
+def _env(name: str) -> str:
+    return os.environ.get(name, "").strip()
+
+
+def _env_bool(name: str) -> bool:
+    return _env(name).lower() in {"1", "true", "yes", "on"}
+
+
+def _session_id(kwargs: dict[str, Any]) -> str:
+    return str(kwargs.get("session_id") or kwargs.get("parent_session_id") or "default")
+
+
+def _api_key(kwargs: dict[str, Any]) -> str:
+    return str(kwargs.get("api_request_id") or f"{_session_id(kwargs)}:{kwargs.get('api_call_count') or 'api'}")
+
+
+def _tool_key(kwargs: dict[str, Any]) -> str:
+    return str(
+        kwargs.get("tool_call_id")
+        or f"{_session_id(kwargs)}:{kwargs.get('turn_id') or ''}:{kwargs.get('tool_name') or 'tool'}"
+    )
+
+
+def _metadata(kwargs: dict[str, Any]) -> dict[str, Any]:
+    keys = (
+        "telemetry_schema_version",
+        "session_id",
+        "platform",
+        "task_id",
+        "turn_id",
+        "api_request_id",
+        "tool_call_id",
+        "parent_session_id",
+        "parent_turn_id",
+        "parent_subagent_id",
+        "child_session_id",
+        "child_subagent_id",
+        "child_role",
+        "child_status",
+        "provider",
+        "model",
+        "api_mode",
+        "status",
+        "reason",
+    )
+    metadata = {
+        key: _jsonable(kwargs[key])
+        for key in keys
+        if key in kwargs and kwargs[key] is not None
+    }
+    if "session_id" in metadata:
+        metadata.setdefault("trajectory_id", metadata["session_id"])
+    if "parent_session_id" in metadata:
+        metadata.setdefault("parent_trajectory_id", metadata["parent_session_id"])
+    if "child_session_id" in metadata:
+        metadata.setdefault("child_trajectory_id", metadata["child_session_id"])
+    return metadata
+
+
+def _jsonable(value: Any) -> Any:
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    if isinstance(value, dict):
+        return {str(k): _jsonable(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple, set)):
+        return [_jsonable(v) for v in value]
+    try:
+        if hasattr(value, "model_dump"):
+            return _jsonable(value.model_dump(mode="json"))
+    except Exception:
+        pass
+    try:
+        return json.loads(json.dumps(value, default=str))
+    except Exception:
+        return str(value)
+
+
+def _safe(fn) -> None:
+    try:
+        fn()
+    except Exception as exc:
+        logger.debug("NeMo-Flow hook handling failed: %s", exc, exc_info=True)
+
+
+def reset_for_tests() -> None:
+    global _RUNTIME
+    with _LOCK:
+        _RUNTIME = None

--- a/plugins/observability/nemo_flow/plugin.yaml
+++ b/plugins/observability/nemo_flow/plugin.yaml
@@ -1,6 +1,6 @@
 name: nemo_flow
 version: "0.1.0"
-description: "Optional NeMo-Flow observability for Hermes. Emits Hermes middleware hooks as NeMo-Flow scopes, LLM spans, tool spans, marks, ATOF, and ATIF when the optional nemo-flow package is installed."
+description: "Optional NeMo-Flow observability for Hermes. Emits Hermes middleware hooks as NeMo-Flow scopes, LLM spans, tool spans, marks, ATOF, and ATIF when the optional nemo-flow==0.2 package is installed."
 author: NousResearch
 hooks:
   - on_session_start

--- a/plugins/observability/nemo_flow/plugin.yaml
+++ b/plugins/observability/nemo_flow/plugin.yaml
@@ -1,6 +1,6 @@
 name: nemo_flow
 version: "0.1.0"
-description: "Optional NeMo-Flow observability for Hermes. Emits Hermes middleware hooks as NeMo-Flow scopes, LLM spans, tool spans, marks, ATOF, and ATIF when the optional nemo-flow==0.2 package is installed."
+description: "Optional NeMo Relay observability for Hermes. Emits Hermes observer hooks as NeMo Relay scopes, LLM spans, tool spans, marks, ATOF, and ATIF when the optional nemo-relay>=0.3 package is installed."
 author: NousResearch
 hooks:
   - on_session_start

--- a/plugins/observability/nemo_flow/plugin.yaml
+++ b/plugins/observability/nemo_flow/plugin.yaml
@@ -1,0 +1,20 @@
+name: nemo_flow
+version: "0.1.0"
+description: "Optional NeMo-Flow observability for Hermes. Emits Hermes middleware hooks as NeMo-Flow scopes, LLM spans, tool spans, marks, ATOF, and ATIF when the optional nemo-flow package is installed."
+author: NousResearch
+hooks:
+  - on_session_start
+  - on_session_end
+  - on_session_finalize
+  - on_session_reset
+  - pre_llm_call
+  - post_llm_call
+  - pre_api_request
+  - post_api_request
+  - api_request_error
+  - pre_tool_call
+  - post_tool_call
+  - pre_approval_request
+  - post_approval_response
+  - subagent_start
+  - subagent_stop

--- a/run_agent.py
+++ b/run_agent.py
@@ -1495,6 +1495,240 @@ class AIAgent:
         summary["total_tokens"] = cu.total_tokens
         return summary
 
+    @staticmethod
+    def _hook_payload_max_chars() -> int:
+        raw = os.getenv("HERMES_PLUGIN_PAYLOAD_MAX_CHARS", "50000")
+        try:
+            return max(1000, int(raw))
+        except (TypeError, ValueError):
+            return 50000
+
+    @staticmethod
+    def _is_sensitive_hook_key(key: Any) -> bool:
+        if not isinstance(key, str):
+            return False
+        lowered = key.lower().replace("-", "_")
+        exact = {
+            "api_key",
+            "authorization",
+            "proxy_authorization",
+            "cookie",
+            "set_cookie",
+        }
+        return lowered in exact or lowered.endswith("_api_key")
+
+    @classmethod
+    def _hook_jsonable(
+        cls,
+        value: Any,
+        *,
+        depth: int = 0,
+        max_depth: int = 8,
+        max_string: int = 8000,
+        max_sequence: int = 200,
+    ) -> Any:
+        if depth > max_depth:
+            return f"<{type(value).__name__} depth limit>"
+        if value is None or isinstance(value, (bool, int, float)):
+            return value
+        if isinstance(value, str):
+            if len(value) > max_string:
+                return value[:max_string] + f"...[truncated {len(value) - max_string} chars]"
+            return value
+        if isinstance(value, (bytes, bytearray)):
+            return f"<{len(value)} bytes>"
+        if isinstance(value, dict):
+            out: Dict[str, Any] = {}
+            for idx, (key, item) in enumerate(value.items()):
+                if idx >= max_sequence:
+                    out["_truncated_items"] = len(value) - max_sequence
+                    break
+                str_key = str(key)
+                if cls._is_sensitive_hook_key(str_key):
+                    out[str_key] = "<redacted>"
+                else:
+                    out[str_key] = cls._hook_jsonable(
+                        item,
+                        depth=depth + 1,
+                        max_depth=max_depth,
+                        max_string=max_string,
+                        max_sequence=max_sequence,
+                    )
+            return out
+        if isinstance(value, (list, tuple, set)):
+            seq = list(value)
+            out = [
+                cls._hook_jsonable(
+                    item,
+                    depth=depth + 1,
+                    max_depth=max_depth,
+                    max_string=max_string,
+                    max_sequence=max_sequence,
+                )
+                for item in seq[:max_sequence]
+            ]
+            if len(seq) > max_sequence:
+                out.append({"_truncated_items": len(seq) - max_sequence})
+            return out
+        try:
+            if hasattr(value, "model_dump"):
+                try:
+                    dumped = value.model_dump(mode="json")
+                except TypeError:
+                    dumped = value.model_dump()
+                return cls._hook_jsonable(
+                    dumped,
+                    depth=depth + 1,
+                    max_depth=max_depth,
+                    max_string=max_string,
+                    max_sequence=max_sequence,
+                )
+        except Exception:
+            pass
+        try:
+            from dataclasses import asdict, is_dataclass
+            if is_dataclass(value):
+                return cls._hook_jsonable(
+                    asdict(value),
+                    depth=depth + 1,
+                    max_depth=max_depth,
+                    max_string=max_string,
+                    max_sequence=max_sequence,
+                )
+        except Exception:
+            pass
+        if isinstance(value, SimpleNamespace):
+            return cls._hook_jsonable(
+                vars(value),
+                depth=depth + 1,
+                max_depth=max_depth,
+                max_string=max_string,
+                max_sequence=max_sequence,
+            )
+        if hasattr(value, "__dict__"):
+            try:
+                public_attrs = {
+                    k: v
+                    for k, v in vars(value).items()
+                    if not str(k).startswith("_")
+                }
+                return cls._hook_jsonable(
+                    public_attrs,
+                    depth=depth + 1,
+                    max_depth=max_depth,
+                    max_string=max_string,
+                    max_sequence=max_sequence,
+                )
+            except Exception:
+                pass
+        return str(value)[:max_string]
+
+    @classmethod
+    def _sanitize_hook_payload(cls, value: Any) -> Any:
+        payload = cls._hook_jsonable(value)
+        limit = cls._hook_payload_max_chars()
+        try:
+            encoded = json.dumps(payload, ensure_ascii=False, default=str)
+        except Exception:
+            return str(payload)[:limit]
+        if len(encoded) <= limit:
+            return payload
+        payload = cls._hook_jsonable(value, max_string=1000, max_sequence=50)
+        try:
+            encoded = json.dumps(payload, ensure_ascii=False, default=str)
+        except Exception:
+            return str(payload)[:limit]
+        if len(encoded) <= limit:
+            return payload
+        return {
+            "_truncated": True,
+            "original_type": type(value).__name__,
+            "preview": encoded[:limit],
+        }
+
+    def _api_request_payload_for_hook(self, api_kwargs: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+        body = copy.deepcopy(api_kwargs or {})
+        for key in ("timeout", "http_client"):
+            body.pop(key, None)
+        return self._sanitize_hook_payload(
+            {
+                "method": "POST",
+                "body": body,
+            }
+        )
+
+    def _api_response_payload_for_hook(
+        self,
+        response: Any,
+        assistant_message: Any,
+        *,
+        finish_reason: Optional[str],
+    ) -> Dict[str, Any]:
+        tool_calls = getattr(assistant_message, "tool_calls", None) or []
+        return self._sanitize_hook_payload(
+            {
+                "model": getattr(response, "model", None),
+                "finish_reason": finish_reason,
+                "assistant_message": {
+                    "role": getattr(assistant_message, "role", "assistant"),
+                    "content": getattr(assistant_message, "content", None),
+                    "tool_calls": tool_calls,
+                },
+                "usage": self._usage_summary_for_api_request_hook(response),
+                "raw_response": response,
+            }
+        )
+
+    def _invoke_api_request_error_hook(
+        self,
+        *,
+        task_id: str,
+        turn_id: str,
+        api_request_id: str,
+        api_call_count: int,
+        api_start_time: float,
+        api_kwargs: Optional[Dict[str, Any]],
+        error_type: str,
+        error_message: str,
+        status_code: Optional[int] = None,
+        retry_count: Optional[int] = None,
+        max_retries: Optional[int] = None,
+        retryable: Optional[bool] = None,
+        reason: Optional[str] = None,
+    ) -> None:
+        try:
+            from hermes_cli.plugins import OBSERVER_SCHEMA_VERSION, invoke_hook as _invoke_hook
+            ended_at = time.time()
+            _invoke_hook(
+                "api_request_error",
+                task_id=task_id,
+                turn_id=turn_id,
+                api_request_id=api_request_id,
+                session_id=self.session_id or "",
+                platform=self.platform or "",
+                model=self.model,
+                provider=self.provider,
+                base_url=self.base_url,
+                api_mode=self.api_mode,
+                api_call_count=api_call_count,
+                api_duration=ended_at - api_start_time,
+                started_at=api_start_time,
+                ended_at=ended_at,
+                status_code=status_code,
+                retry_count=retry_count,
+                max_retries=max_retries,
+                retryable=retryable,
+                reason=reason,
+                error={
+                    "type": error_type,
+                    "message": error_message,
+                },
+                request=self._api_request_payload_for_hook(api_kwargs),
+                telemetry_schema_version=OBSERVER_SCHEMA_VERSION,
+            )
+        except Exception:
+            pass
+
     def _dump_api_request_debug(
         self,
         api_kwargs: Dict[str, Any],

--- a/tests/cli/test_session_boundary_hooks.py
+++ b/tests/cli/test_session_boundary_hooks.py
@@ -1,5 +1,6 @@
 import pytest
 from unittest.mock import MagicMock, patch
+from types import SimpleNamespace
 from hermes_cli.plugins import VALID_HOOKS, PluginManager
 import os
 import shutil
@@ -24,12 +25,20 @@ def test_session_finalize_on_reset(mock_invoke_hook):
     cli.new_session(silent=True)
 
     # Check if on_session_finalize was called for the old session
-    mock_invoke_hook.assert_any_call(
-        "on_session_finalize", session_id="test-session-id", platform="cli"
+    assert any(
+        c.args == ("on_session_finalize",)
+        and c.kwargs["session_id"] == "test-session-id"
+        and c.kwargs["platform"] == "cli"
+        and c.kwargs["telemetry_schema_version"] == "hermes.observer.v1"
+        for c in mock_invoke_hook.call_args_list
     )
     # Check if on_session_reset was called for the new session
-    mock_invoke_hook.assert_any_call(
-        "on_session_reset", session_id=cli.session_id, platform="cli"
+    assert any(
+        c.args == ("on_session_reset",)
+        and c.kwargs["session_id"] == cli.session_id
+        and c.kwargs["platform"] == "cli"
+        and c.kwargs["telemetry_schema_version"] == "hermes.observer.v1"
+        for c in mock_invoke_hook.call_args_list
     )
 
 
@@ -45,9 +54,45 @@ def test_session_finalize_on_cleanup(mock_invoke_hook):
 
     cli_mod._run_cleanup()
 
-    mock_invoke_hook.assert_any_call(
-        "on_session_finalize", session_id="cleanup-session-id", platform="cli"
+    assert any(
+        c.args == ("on_session_finalize",)
+        and c.kwargs["session_id"] == "cleanup-session-id"
+        and c.kwargs["platform"] == "cli"
+        and c.kwargs["reason"] == "shutdown"
+        and c.kwargs["telemetry_schema_version"] == "hermes.observer.v1"
+        for c in mock_invoke_hook.call_args_list
     )
+
+
+@patch("hermes_cli.plugins.invoke_hook")
+def test_interrupted_session_end_helper_emits_observer_shape(mock_invoke_hook):
+    """Verify quiet single-query interruption emits a correlated session end."""
+    import cli as cli_mod
+
+    mock_agent = MagicMock()
+    mock_agent.session_id = "agent-session-id"
+    mock_agent.model = "test-model"
+    mock_agent.platform = "cli"
+    mock_agent._current_task_id = "task-1"
+    mock_agent._current_turn_id = "turn-1"
+    mock_agent._current_api_request_id = "api-1"
+    cli = SimpleNamespace(agent=mock_agent, session_id="cli-session-id")
+
+    cli_mod._emit_interrupted_session_end(cli, reason="keyboard_interrupt")
+
+    mock_agent.interrupt.assert_called_once_with("keyboard interrupt")
+    assert cli.session_id == "agent-session-id"
+    mock_invoke_hook.assert_called_once()
+    call = mock_invoke_hook.call_args
+    assert call.args == ("on_session_end",)
+    assert call.kwargs["session_id"] == "agent-session-id"
+    assert call.kwargs["task_id"] == "task-1"
+    assert call.kwargs["turn_id"] == "turn-1"
+    assert call.kwargs["api_request_id"] == "api-1"
+    assert call.kwargs["completed"] is False
+    assert call.kwargs["interrupted"] is True
+    assert call.kwargs["reason"] == "keyboard_interrupt"
+    assert call.kwargs["telemetry_schema_version"] == "hermes.observer.v1"
 
 
 @patch("hermes_cli.plugins.invoke_hook")

--- a/tests/gateway/test_session_boundary_hooks.py
+++ b/tests/gateway/test_session_boundary_hooks.py
@@ -81,8 +81,14 @@ async def test_reset_fires_finalize_hook(mock_invoke_hook):
 
     await runner._handle_reset_command(_make_event("/new"))
 
-    mock_invoke_hook.assert_any_call(
-        "on_session_finalize", session_id="sess-old", platform="telegram"
+    assert any(
+        c.args == ("on_session_finalize",)
+        and c.kwargs["session_id"] == "sess-old"
+        and c.kwargs["platform"] == "telegram"
+        and c.kwargs["old_session_id"] == "sess-old"
+        and c.kwargs["new_session_id"] == "sess-new"
+        and c.kwargs["telemetry_schema_version"] == "hermes.observer.v1"
+        for c in mock_invoke_hook.call_args_list
     )
 
 
@@ -94,8 +100,14 @@ async def test_reset_fires_reset_hook(mock_invoke_hook):
 
     await runner._handle_reset_command(_make_event("/new"))
 
-    mock_invoke_hook.assert_any_call(
-        "on_session_reset", session_id="sess-new", platform="telegram"
+    assert any(
+        c.args == ("on_session_reset",)
+        and c.kwargs["session_id"] == "sess-new"
+        and c.kwargs["platform"] == "telegram"
+        and c.kwargs["old_session_id"] == "sess-old"
+        and c.kwargs["new_session_id"] == "sess-new"
+        and c.kwargs["telemetry_schema_version"] == "hermes.observer.v1"
+        for c in mock_invoke_hook.call_args_list
     )
 
 

--- a/tests/hermes_cli/test_middleware.py
+++ b/tests/hermes_cli/test_middleware.py
@@ -1,0 +1,99 @@
+"""Tests for the Hermes plugin middleware contract helpers."""
+
+from __future__ import annotations
+
+from hermes_cli.middleware import (
+    apply_api_request_middleware,
+    apply_tool_request_middleware,
+    run_api_execution_middleware,
+    run_tool_execution_middleware,
+)
+
+
+def test_tool_request_middleware_preserves_original_nested_payload(monkeypatch):
+    def fake_invoke_middleware(kind, **kwargs):
+        assert kind == "tool_request"
+        assert kwargs["middleware_schema_version"] == "hermes.middleware.v1"
+        next_args = kwargs["args"]
+        next_args["nested"]["value"] = "mutated"
+        return [{"args": next_args, "source": "test"}]
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_middleware", fake_invoke_middleware)
+
+    result = apply_tool_request_middleware(
+        "demo_tool",
+        {"nested": {"value": "original"}},
+        task_id="task-1",
+    )
+
+    assert result.payload == {"nested": {"value": "mutated"}}
+    assert result.original_payload == {"nested": {"value": "original"}}
+    assert result.changed is True
+    assert result.trace == [{"source": "test"}]
+
+
+def test_api_request_middleware_preserves_original_nested_payload(monkeypatch):
+    def fake_invoke_middleware(kind, **kwargs):
+        assert kind == "api_request"
+        next_request = kwargs["request"]
+        next_request["body"]["metadata"] = {"trace": "added"}
+        return [{"request": next_request, "source": "api-test"}]
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_middleware", fake_invoke_middleware)
+
+    result = apply_api_request_middleware({"body": {"messages": []}}, task_id="task-1")
+
+    assert result.payload == {"body": {"messages": [], "metadata": {"trace": "added"}}}
+    assert result.original_payload == {"body": {"messages": []}}
+    assert result.changed is True
+    assert result.trace == [{"source": "api-test"}]
+
+
+def test_tool_execution_middleware_chains_in_order(monkeypatch):
+    calls = []
+
+    def first(**kwargs):
+        calls.append(("first", kwargs["args"]))
+        next_args = dict(kwargs["args"])
+        next_args["first"] = True
+        return kwargs["next_call"](next_args)
+
+    def second(**kwargs):
+        calls.append(("second", kwargs["args"]))
+        next_args = dict(kwargs["args"])
+        next_args["second"] = True
+        return kwargs["next_call"](next_args)
+
+    class Manager:
+        _middleware = {"tool_execution": [first, second]}
+
+    monkeypatch.setattr("hermes_cli.plugins.get_plugin_manager", lambda: Manager())
+
+    result = run_tool_execution_middleware(
+        "demo_tool",
+        {"start": True},
+        lambda args: {"final": args},
+    )
+
+    assert calls == [
+        ("first", {"start": True}),
+        ("second", {"start": True, "first": True}),
+    ]
+    assert result == {"final": {"start": True, "first": True, "second": True}}
+
+
+def test_api_execution_middleware_fail_opens_to_next_callback(monkeypatch):
+    def failing(**kwargs):
+        raise RuntimeError("middleware failed")
+
+    class Manager:
+        _middleware = {"api_execution": [failing]}
+
+    monkeypatch.setattr("hermes_cli.plugins.get_plugin_manager", lambda: Manager())
+
+    result = run_api_execution_middleware(
+        {"messages": []},
+        lambda request: {"called": request},
+    )
+
+    assert result == {"called": {"messages": []}}

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -328,6 +328,8 @@ class TestPluginHooks:
     def test_valid_hooks_include_request_scoped_api_hooks(self):
         assert "pre_api_request" in VALID_HOOKS
         assert "post_api_request" in VALID_HOOKS
+        assert "api_request_error" in VALID_HOOKS
+        assert "subagent_start" in VALID_HOOKS
         assert "transform_terminal_output" in VALID_HOOKS
         assert "transform_tool_result" in VALID_HOOKS
         assert "transform_llm_output" in VALID_HOOKS

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -13,6 +13,7 @@ import yaml
 from hermes_cli.plugins import (
     ENTRY_POINTS_GROUP,
     VALID_HOOKS,
+    VALID_MIDDLEWARE,
     LoadedPlugin,
     PluginContext,
     PluginManager,
@@ -494,6 +495,73 @@ class TestPluginHooks:
             mgr.discover_and_load()
 
         assert any("on_banana" in record.message for record in caplog.records)
+
+    def test_valid_middleware_kinds_include_adaptive_surfaces(self):
+        assert "tool_request" in VALID_MIDDLEWARE
+        assert "tool_execution" in VALID_MIDDLEWARE
+        assert "api_request" in VALID_MIDDLEWARE
+        assert "api_execution" in VALID_MIDDLEWARE
+
+    def test_register_and_invoke_middleware(self, tmp_path, monkeypatch):
+        """Registered middleware callbacks are collected by invoke_middleware()."""
+        plugins_dir = tmp_path / "hermes_test" / "plugins"
+        _make_plugin_dir(
+            plugins_dir,
+            "middleware_plugin",
+            register_body=(
+                'ctx.register_middleware("tool_request", '
+                'lambda **kw: {"args": {"path": kw["args"]["path"] + ".bak"}, "source": "test"})'
+            ),
+        )
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes_test"))
+
+        mgr = PluginManager()
+        mgr.discover_and_load()
+
+        results = mgr.invoke_middleware(
+            "tool_request",
+            tool_name="read_file",
+            args={"path": "a.txt"},
+            original_args={"path": "a.txt"},
+            telemetry_schema_version="hermes.observer.v1",
+            middleware_schema_version="hermes.middleware.v1",
+        )
+
+        assert results == [{"args": {"path": "a.txt.bak"}, "source": "test"}]
+        listing = {p["name"]: p for p in mgr.list_plugins()}
+        assert listing["middleware_plugin"]["middleware"] == 1
+
+    def test_middleware_exception_does_not_propagate(self, tmp_path, monkeypatch):
+        """A middleware callback that raises does not crash the caller."""
+        plugins_dir = tmp_path / "hermes_test" / "plugins"
+        _make_plugin_dir(
+            plugins_dir,
+            "bad_middleware",
+            register_body='ctx.register_middleware("tool_request", lambda **kw: 1/0)',
+        )
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes_test"))
+
+        mgr = PluginManager()
+        mgr.discover_and_load()
+
+        assert mgr.invoke_middleware("tool_request", args={}, original_args={}) == []
+
+    def test_invalid_middleware_name_warns(self, tmp_path, monkeypatch, caplog):
+        """Unknown middleware kinds are retained for forward compatibility."""
+        plugins_dir = tmp_path / "hermes_test" / "plugins"
+        _make_plugin_dir(
+            plugins_dir,
+            "warn_middleware",
+            register_body='ctx.register_middleware("tool_banana", lambda **kw: None)',
+        )
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes_test"))
+
+        with caplog.at_level(logging.WARNING, logger="hermes_cli.plugins"):
+            mgr = PluginManager()
+            mgr.discover_and_load()
+
+        assert "tool_banana" in mgr._middleware
+        assert any("tool_banana" in record.message for record in caplog.records)
 
 
 class TestPreToolCallBlocking:

--- a/tests/plugins/test_nemo_flow_plugin.py
+++ b/tests/plugins/test_nemo_flow_plugin.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import builtins
 import importlib
-import json
 import sys
 from pathlib import Path
 from types import SimpleNamespace
@@ -37,10 +36,6 @@ class _FakeNemoFlow:
         )
         self.plugin = SimpleNamespace(initialize=self._plugin_initialize)
         self.LLMRequest = _FakeLLMRequest
-        self.AtofExporterConfig = _FakeAtofExporterConfig
-        self.AtofExporterMode = SimpleNamespace(Append="append", Overwrite="overwrite")
-        self.AtofExporter = self._make_atof_exporter
-        self.AtifExporter = self._make_atif_exporter
 
     def _scope_push(self, name, scope_type, **kwargs):
         handle = ("scope", name)
@@ -81,12 +76,6 @@ class _FakeNemoFlow:
         self.events.append(("tool.execute.end", name, result, kwargs))
         return result
 
-    def _make_atof_exporter(self, config):
-        return _FakeAtofExporter(self.events, config)
-
-    def _make_atif_exporter(self, session_id, agent_name, agent_version, **kwargs):
-        return _FakeAtifExporter(self.events, session_id, agent_name, agent_version, kwargs)
-
     async def _plugin_initialize(self, config):
         self.events.append(("plugin.initialize", config))
         return {"diagnostics": []}
@@ -98,47 +87,38 @@ class _FakeLLMRequest:
         self.content = content
 
 
-class _FakeAtofExporterConfig:
-    def __init__(self):
-        self.output_directory = ""
-        self.filename = "events.jsonl"
-        self.mode = "append"
-
-
-class _FakeAtofExporter:
-    def __init__(self, events, config):
-        self.events = events
-        self.config = config
-
-    def register(self, name):
-        self.events.append(("atof.register", name, self.config.output_directory, self.config.filename))
-
-
-class _FakeAtifExporter:
-    def __init__(self, events, session_id, agent_name, agent_version, kwargs):
-        self.events = events
-        self.session_id = session_id
-        self.agent_name = agent_name
-        self.agent_version = agent_version
-        self.kwargs = kwargs
-
-    def register(self, name):
-        self.events.append(("atif.register", name, self.session_id))
-
-    def deregister(self, name):
-        self.events.append(("atif.deregister", name, self.session_id))
-        return True
-
-    def export_json(self):
-        return json.dumps({"session_id": self.session_id, "agent_name": self.agent_name})
-
-
 def _fresh_plugin(monkeypatch, fake):
     monkeypatch.setitem(sys.modules, "nemo_relay", fake)
     sys.modules.pop("plugins.observability.nemo_flow", None)
     plugin = importlib.import_module("plugins.observability.nemo_flow")
     plugin.reset_for_tests()
     return plugin
+
+
+def _write_plugins_toml(tmp_path, text: str) -> Path:
+    plugins_toml = tmp_path / "plugins.toml"
+    plugins_toml.write_text(text, encoding="utf-8")
+    return plugins_toml
+
+
+def _enable_adaptive(tmp_path, monkeypatch) -> None:
+    plugins_toml = _write_plugins_toml(
+        tmp_path,
+        """
+version = 1
+
+[[components]]
+kind = "adaptive"
+enabled = true
+
+[components.config]
+version = 1
+
+[components.config.tool_parallelism]
+mode = "observe_only"
+""",
+    )
+    monkeypatch.setenv("NEMO_RELAY_PLUGINS_TOML", str(plugins_toml))
 
 
 def test_manifest_fields():
@@ -174,13 +154,28 @@ def test_register_adds_observer_hooks_and_adaptive_middleware(monkeypatch):
     assert middleware_names == ["tool_execution", "api_execution"]
 
 
-def test_nemo_flow_plugin_emits_llm_tool_and_exports_atif(tmp_path, monkeypatch):
+def test_nemo_flow_plugin_emits_llm_tool_and_initializes_plugin_config(tmp_path, monkeypatch):
     fake = _FakeNemoFlow()
     plugin = _fresh_plugin(monkeypatch, fake)
-    monkeypatch.setenv("HERMES_NEMO_FLOW_ATOF_ENABLED", "1")
-    monkeypatch.setenv("HERMES_NEMO_FLOW_ATOF_OUTPUT_DIRECTORY", str(tmp_path / "atof"))
-    monkeypatch.setenv("HERMES_NEMO_FLOW_ATIF_ENABLED", "1")
-    monkeypatch.setenv("HERMES_NEMO_FLOW_ATIF_OUTPUT_DIRECTORY", str(tmp_path / "atif"))
+    plugins_toml = _write_plugins_toml(
+        tmp_path,
+        """
+version = 1
+
+[[components]]
+kind = "observability"
+enabled = true
+
+[components.config.atof]
+enabled = true
+output_directory = "events"
+
+[components.config.atif]
+enabled = true
+output_directory = "trajectories"
+""",
+    )
+    monkeypatch.setenv("NEMO_RELAY_PLUGINS_TOML", str(plugins_toml))
 
     base = {
         "session_id": "s1",
@@ -207,14 +202,12 @@ def test_nemo_flow_plugin_emits_llm_tool_and_exports_atif(tmp_path, monkeypatch)
     plugin.on_session_finalize(**base, reason="shutdown")
 
     event_names = [event[0] for event in fake.events]
-    assert "atof.register" in event_names
-    assert "atif.register" in event_names
+    assert "plugin.initialize" in event_names
     assert "llm.call" in event_names
     assert "llm.call_end" in event_names
     assert "tool.call" in event_names
     assert "tool.call_end" in event_names
     assert "scope.pop" in event_names
-    assert (tmp_path / "atif" / "hermes-atif-s1.json").exists()
 
 
 def test_nemo_flow_plugin_metadata_promotes_trajectory_and_subagent_ids(monkeypatch):
@@ -263,11 +256,50 @@ def test_nemo_flow_plugin_metadata_promotes_trajectory_and_subagent_ids(monkeypa
     assert stop_mark[2]["metadata"]["child_status"] == "completed"
 
 
+def test_nemo_flow_plugin_pushes_child_agent_scope_under_parent(monkeypatch):
+    fake = _FakeNemoFlow()
+    plugin = _fresh_plugin(monkeypatch, fake)
+
+    parent = {
+        "session_id": "parent-session",
+        "task_id": "task-1",
+        "turn_id": "turn-1",
+        "telemetry_schema_version": "hermes.observer.v1",
+    }
+    child = {
+        "session_id": "child-session",
+        "task_id": "child-task",
+        "turn_id": "child-turn",
+        "telemetry_schema_version": "hermes.observer.v1",
+    }
+
+    plugin.on_session_start(**parent, model="demo-model", platform="cli")
+    plugin.on_subagent_start(
+        parent_session_id="parent-session",
+        parent_turn_id="turn-1",
+        child_session_id="child-session",
+        child_subagent_id="child-sa",
+        child_role="leaf",
+        telemetry_schema_version="hermes.observer.v1",
+    )
+    plugin.on_session_start(**child, model="demo-model", platform="cli")
+    plugin.on_session_end(**child, completed=True, interrupted=False)
+    plugin.on_session_end(**parent, completed=True, interrupted=False)
+
+    child_scope_push = next(
+        event
+        for event in fake.events
+        if event[0] == "scope.push" and event[1] == "hermes-session-child-session"
+    )
+    assert child_scope_push[3]["handle"] == ("scope", "hermes-session-parent-session")
+    assert child_scope_push[3]["metadata"]["parent_session_id"] == "parent-session"
+
+
 def test_nemo_flow_plugin_can_initialize_plugins_toml(tmp_path, monkeypatch):
     fake = _FakeNemoFlow()
     plugin = _fresh_plugin(monkeypatch, fake)
-    plugins_toml = tmp_path / "plugins.toml"
-    plugins_toml.write_text(
+    plugins_toml = _write_plugins_toml(
+        tmp_path,
         """
 version = 1
 
@@ -279,14 +311,34 @@ enabled = true
 enabled = true
 output_directory = "events"
 """,
-        encoding="utf-8",
     )
-    monkeypatch.setenv("HERMES_NEMO_FLOW_PLUGINS_TOML", str(plugins_toml))
+    monkeypatch.setenv("NEMO_RELAY_PLUGINS_TOML", str(plugins_toml))
 
     plugin.on_session_start(session_id="s1")
 
     assert any(event[0] == "plugin.initialize" for event in fake.events)
-    assert not any(event[0] == "atof.register" for event in fake.events)
+
+
+def test_nemo_flow_plugin_reads_project_plugins_toml_by_default(tmp_path, monkeypatch):
+    fake = _FakeNemoFlow()
+    plugin = _fresh_plugin(monkeypatch, fake)
+    config_dir = tmp_path / ".nemo-relay"
+    config_dir.mkdir()
+    (config_dir / "plugins.toml").write_text(
+        """
+version = 1
+
+[[components]]
+kind = "observability"
+enabled = true
+""",
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(tmp_path)
+
+    plugin.on_session_start(session_id="s1")
+
+    assert any(event[0] == "plugin.initialize" for event in fake.events)
 
 
 def test_nemo_flow_plugin_noops_without_dependency(monkeypatch):
@@ -308,10 +360,10 @@ def test_nemo_flow_plugin_noops_without_dependency(monkeypatch):
     plugin.on_post_api_request(session_id="s1", api_request_id="api-1")
 
 
-def test_adaptive_tool_execution_middleware_uses_managed_execute(monkeypatch):
+def test_adaptive_tool_execution_middleware_uses_managed_execute(tmp_path, monkeypatch):
     fake = _FakeNemoFlow()
     plugin = _fresh_plugin(monkeypatch, fake)
-    monkeypatch.setenv("HERMES_NEMO_FLOW_ADAPTIVE_ENABLED", "1")
+    _enable_adaptive(tmp_path, monkeypatch)
 
     result = plugin.on_tool_execution_middleware(
         session_id="s1",
@@ -327,14 +379,15 @@ def test_adaptive_tool_execution_middleware_uses_managed_execute(monkeypatch):
     )
 
     assert result == {"result": {"intercepted": True, "path": "demo.txt"}}
+    assert any(event[0] == "plugin.initialize" for event in fake.events)
     assert any(event[0] == "tool.execute.start" for event in fake.events)
     assert not any(event[0] == "tool.call" for event in fake.events)
 
 
-def test_adaptive_llm_execution_middleware_preserves_raw_response(monkeypatch):
+def test_adaptive_llm_execution_middleware_preserves_raw_response(tmp_path, monkeypatch):
     fake = _FakeNemoFlow()
     plugin = _fresh_plugin(monkeypatch, fake)
-    monkeypatch.setenv("HERMES_NEMO_FLOW_ADAPTIVE_ENABLED", "1")
+    _enable_adaptive(tmp_path, monkeypatch)
     raw_response = object()
     seen_request = {}
 
@@ -359,10 +412,10 @@ def test_adaptive_llm_execution_middleware_preserves_raw_response(monkeypatch):
     assert execute_start[2]["messages"] == [{"role": "user", "content": "hi"}]
 
 
-def test_adaptive_observer_hooks_do_not_duplicate_managed_tool_spans(monkeypatch):
+def test_adaptive_observer_hooks_do_not_duplicate_managed_tool_spans(tmp_path, monkeypatch):
     fake = _FakeNemoFlow()
     plugin = _fresh_plugin(monkeypatch, fake)
-    monkeypatch.setenv("HERMES_NEMO_FLOW_ADAPTIVE_ENABLED", "1")
+    _enable_adaptive(tmp_path, monkeypatch)
 
     base = {
         "session_id": "s1",

--- a/tests/plugins/test_nemo_flow_plugin.py
+++ b/tests/plugins/test_nemo_flow_plugin.py
@@ -1,0 +1,263 @@
+"""Tests for the bundled observability/nemo_flow plugin."""
+
+from __future__ import annotations
+
+import builtins
+import importlib
+import json
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PLUGIN_DIR = REPO_ROOT / "plugins" / "observability" / "nemo_flow"
+
+
+class _FakeNemoFlow:
+    def __init__(self):
+        self.events = []
+        self.ScopeType = SimpleNamespace(Agent="agent")
+        self.scope = SimpleNamespace(
+            push=self._scope_push,
+            pop=self._scope_pop,
+            event=self._scope_event,
+        )
+        self.llm = SimpleNamespace(call=self._llm_call, call_end=self._llm_call_end)
+        self.tools = SimpleNamespace(call=self._tool_call, call_end=self._tool_call_end)
+        self.plugin = SimpleNamespace(initialize=self._plugin_initialize)
+        self.LLMRequest = _FakeLLMRequest
+        self.AtofExporterConfig = _FakeAtofExporterConfig
+        self.AtofExporterMode = SimpleNamespace(Append="append", Overwrite="overwrite")
+        self.AtofExporter = self._make_atof_exporter
+        self.AtifExporter = self._make_atif_exporter
+
+    def _scope_push(self, name, scope_type, **kwargs):
+        handle = ("scope", name)
+        self.events.append(("scope.push", name, scope_type, kwargs))
+        return handle
+
+    def _scope_pop(self, handle, **kwargs):
+        self.events.append(("scope.pop", handle, kwargs))
+
+    def _scope_event(self, name, **kwargs):
+        self.events.append(("scope.event", name, kwargs))
+
+    def _llm_call(self, name, request, **kwargs):
+        handle = ("llm", name)
+        self.events.append(("llm.call", name, request.content, kwargs))
+        return handle
+
+    def _llm_call_end(self, handle, response, **kwargs):
+        self.events.append(("llm.call_end", handle, response, kwargs))
+
+    def _tool_call(self, name, args, **kwargs):
+        handle = ("tool", name)
+        self.events.append(("tool.call", name, args, kwargs))
+        return handle
+
+    def _tool_call_end(self, handle, result, **kwargs):
+        self.events.append(("tool.call_end", handle, result, kwargs))
+
+    def _make_atof_exporter(self, config):
+        return _FakeAtofExporter(self.events, config)
+
+    def _make_atif_exporter(self, session_id, agent_name, agent_version, **kwargs):
+        return _FakeAtifExporter(self.events, session_id, agent_name, agent_version, kwargs)
+
+    async def _plugin_initialize(self, config):
+        self.events.append(("plugin.initialize", config))
+        return {"diagnostics": []}
+
+
+class _FakeLLMRequest:
+    def __init__(self, headers, content):
+        self.headers = headers
+        self.content = content
+
+
+class _FakeAtofExporterConfig:
+    def __init__(self):
+        self.output_directory = ""
+        self.filename = "events.jsonl"
+        self.mode = "append"
+
+
+class _FakeAtofExporter:
+    def __init__(self, events, config):
+        self.events = events
+        self.config = config
+
+    def register(self, name):
+        self.events.append(("atof.register", name, self.config.output_directory, self.config.filename))
+
+
+class _FakeAtifExporter:
+    def __init__(self, events, session_id, agent_name, agent_version, kwargs):
+        self.events = events
+        self.session_id = session_id
+        self.agent_name = agent_name
+        self.agent_version = agent_version
+        self.kwargs = kwargs
+
+    def register(self, name):
+        self.events.append(("atif.register", name, self.session_id))
+
+    def deregister(self, name):
+        self.events.append(("atif.deregister", name, self.session_id))
+        return True
+
+    def export_json(self):
+        return json.dumps({"session_id": self.session_id, "agent_name": self.agent_name})
+
+
+def _fresh_plugin(monkeypatch, fake):
+    monkeypatch.setitem(sys.modules, "nemo_flow", fake)
+    sys.modules.pop("plugins.observability.nemo_flow", None)
+    plugin = importlib.import_module("plugins.observability.nemo_flow")
+    plugin.reset_for_tests()
+    return plugin
+
+
+def test_manifest_fields():
+    data = yaml.safe_load((PLUGIN_DIR / "plugin.yaml").read_text())
+    assert data["name"] == "nemo_flow"
+    assert "pre_api_request" in data["hooks"]
+    assert "api_request_error" in data["hooks"]
+    assert "subagent_start" in data["hooks"]
+
+
+def test_nemo_flow_plugin_emits_llm_tool_and_exports_atif(tmp_path, monkeypatch):
+    fake = _FakeNemoFlow()
+    plugin = _fresh_plugin(monkeypatch, fake)
+    monkeypatch.setenv("HERMES_NEMO_FLOW_ATOF_ENABLED", "1")
+    monkeypatch.setenv("HERMES_NEMO_FLOW_ATOF_OUTPUT_DIRECTORY", str(tmp_path / "atof"))
+    monkeypatch.setenv("HERMES_NEMO_FLOW_ATIF_ENABLED", "1")
+    monkeypatch.setenv("HERMES_NEMO_FLOW_ATIF_OUTPUT_DIRECTORY", str(tmp_path / "atif"))
+
+    base = {
+        "session_id": "s1",
+        "task_id": "t1",
+        "turn_id": "turn-1",
+        "telemetry_schema_version": "hermes.observer.v1",
+    }
+    plugin.on_session_start(**base, model="demo-model", platform="cli")
+    plugin.on_pre_api_request(
+        **base,
+        api_request_id="api-1",
+        provider="openai",
+        model="demo-model",
+        request={"method": "POST", "body": {"messages": [{"role": "user", "content": "hi"}]}},
+    )
+    plugin.on_post_api_request(
+        **base,
+        api_request_id="api-1",
+        response={"assistant_message": {"role": "assistant", "content": "hello"}},
+    )
+    plugin.on_pre_tool_call(**base, tool_name="read_file", tool_call_id="tool-1", args={"path": "x"})
+    plugin.on_post_tool_call(**base, tool_name="read_file", tool_call_id="tool-1", result='{"ok": true}', status="ok")
+    plugin.on_session_end(**base, completed=True, interrupted=False)
+    plugin.on_session_finalize(**base, reason="shutdown")
+
+    event_names = [event[0] for event in fake.events]
+    assert "atof.register" in event_names
+    assert "atif.register" in event_names
+    assert "llm.call" in event_names
+    assert "llm.call_end" in event_names
+    assert "tool.call" in event_names
+    assert "tool.call_end" in event_names
+    assert "scope.pop" in event_names
+    assert (tmp_path / "atif" / "hermes-atif-s1.json").exists()
+
+
+def test_nemo_flow_plugin_metadata_promotes_trajectory_and_subagent_ids(monkeypatch):
+    fake = _FakeNemoFlow()
+    plugin = _fresh_plugin(monkeypatch, fake)
+
+    plugin.on_pre_llm_call(
+        session_id="parent-session",
+        task_id="task-1",
+        turn_id="turn-1",
+        telemetry_schema_version="hermes.observer.v1",
+    )
+    plugin.on_subagent_start(
+        parent_session_id="parent-session",
+        parent_turn_id="turn-1",
+        parent_subagent_id="parent-sa",
+        child_session_id="child-session",
+        child_subagent_id="child-sa",
+        child_role="leaf",
+        telemetry_schema_version="hermes.observer.v1",
+    )
+    plugin.on_subagent_stop(
+        parent_session_id="parent-session",
+        parent_turn_id="turn-1",
+        child_session_id="child-session",
+        child_role="leaf",
+        child_status="completed",
+        telemetry_schema_version="hermes.observer.v1",
+    )
+
+    turn_mark = next(event for event in fake.events if event[0] == "scope.event" and event[1] == "hermes.turn.start")
+    turn_metadata = turn_mark[2]["metadata"]
+    assert turn_metadata["session_id"] == "parent-session"
+    assert turn_metadata["trajectory_id"] == "parent-session"
+
+    start_mark = next(event for event in fake.events if event[0] == "scope.event" and event[1] == "hermes.subagent.start")
+    start_metadata = start_mark[2]["metadata"]
+    assert start_metadata["parent_session_id"] == "parent-session"
+    assert start_metadata["parent_trajectory_id"] == "parent-session"
+    assert start_metadata["child_session_id"] == "child-session"
+    assert start_metadata["child_trajectory_id"] == "child-session"
+    assert start_metadata["child_subagent_id"] == "child-sa"
+    assert start_metadata["child_role"] == "leaf"
+
+    stop_mark = next(event for event in fake.events if event[0] == "scope.event" and event[1] == "hermes.subagent.stop")
+    assert stop_mark[2]["metadata"]["child_status"] == "completed"
+
+
+def test_nemo_flow_plugin_can_initialize_plugins_toml(tmp_path, monkeypatch):
+    fake = _FakeNemoFlow()
+    plugin = _fresh_plugin(monkeypatch, fake)
+    plugins_toml = tmp_path / "plugins.toml"
+    plugins_toml.write_text(
+        """
+version = 1
+
+[[components]]
+kind = "observability"
+enabled = true
+
+[components.config.atof]
+enabled = true
+output_directory = "events"
+""",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_NEMO_FLOW_PLUGINS_TOML", str(plugins_toml))
+
+    plugin.on_session_start(session_id="s1")
+
+    assert any(event[0] == "plugin.initialize" for event in fake.events)
+    assert not any(event[0] == "atof.register" for event in fake.events)
+
+
+def test_nemo_flow_plugin_noops_without_dependency(monkeypatch):
+    monkeypatch.delitem(sys.modules, "nemo_flow", raising=False)
+    sys.modules.pop("plugins.observability.nemo_flow", None)
+    plugin = importlib.import_module("plugins.observability.nemo_flow")
+    plugin.reset_for_tests()
+
+    real_import = builtins.__import__
+
+    def blocked_import(name, *args, **kwargs):
+        if name == "nemo_flow":
+            raise ModuleNotFoundError("No module named 'nemo_flow'")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", blocked_import)
+
+    plugin.on_pre_api_request(session_id="s1", api_request_id="api-1")
+    plugin.on_post_api_request(session_id="s1", api_request_id="api-1")

--- a/tests/plugins/test_nemo_flow_plugin.py
+++ b/tests/plugins/test_nemo_flow_plugin.py
@@ -25,8 +25,16 @@ class _FakeNemoFlow:
             pop=self._scope_pop,
             event=self._scope_event,
         )
-        self.llm = SimpleNamespace(call=self._llm_call, call_end=self._llm_call_end)
-        self.tools = SimpleNamespace(call=self._tool_call, call_end=self._tool_call_end)
+        self.llm = SimpleNamespace(
+            call=self._llm_call,
+            call_end=self._llm_call_end,
+            execute=self._llm_execute,
+        )
+        self.tools = SimpleNamespace(
+            call=self._tool_call,
+            call_end=self._tool_call_end,
+            execute=self._tool_execute,
+        )
         self.plugin = SimpleNamespace(initialize=self._plugin_initialize)
         self.LLMRequest = _FakeLLMRequest
         self.AtofExporterConfig = _FakeAtofExporterConfig
@@ -53,6 +61,12 @@ class _FakeNemoFlow:
     def _llm_call_end(self, handle, response, **kwargs):
         self.events.append(("llm.call_end", handle, response, kwargs))
 
+    def _llm_execute(self, name, request, func, **kwargs):
+        self.events.append(("llm.execute.start", name, request.content, kwargs))
+        result = func(_FakeLLMRequest(request.headers, {"intercepted": True, **request.content}))
+        self.events.append(("llm.execute.end", name, result, kwargs))
+        return result
+
     def _tool_call(self, name, args, **kwargs):
         handle = ("tool", name)
         self.events.append(("tool.call", name, args, kwargs))
@@ -60,6 +74,12 @@ class _FakeNemoFlow:
 
     def _tool_call_end(self, handle, result, **kwargs):
         self.events.append(("tool.call_end", handle, result, kwargs))
+
+    def _tool_execute(self, name, args, func, **kwargs):
+        self.events.append(("tool.execute.start", name, args, kwargs))
+        result = func({"intercepted": True, **args})
+        self.events.append(("tool.execute.end", name, result, kwargs))
+        return result
 
     def _make_atof_exporter(self, config):
         return _FakeAtofExporter(self.events, config)
@@ -114,7 +134,7 @@ class _FakeAtifExporter:
 
 
 def _fresh_plugin(monkeypatch, fake):
-    monkeypatch.setitem(sys.modules, "nemo_flow", fake)
+    monkeypatch.setitem(sys.modules, "nemo_relay", fake)
     sys.modules.pop("plugins.observability.nemo_flow", None)
     plugin = importlib.import_module("plugins.observability.nemo_flow")
     plugin.reset_for_tests()
@@ -127,6 +147,31 @@ def test_manifest_fields():
     assert "pre_api_request" in data["hooks"]
     assert "api_request_error" in data["hooks"]
     assert "subagent_start" in data["hooks"]
+
+
+def test_register_adds_observer_hooks_and_adaptive_middleware(monkeypatch):
+    fake = _FakeNemoFlow()
+    plugin = _fresh_plugin(monkeypatch, fake)
+
+    class Ctx:
+        def __init__(self):
+            self.hooks = []
+            self.middleware = []
+
+        def register_hook(self, name, callback):
+            self.hooks.append((name, callback))
+
+        def register_middleware(self, kind, callback):
+            self.middleware.append((kind, callback))
+
+    ctx = Ctx()
+    plugin.register(ctx)
+
+    hook_names = [name for name, _ in ctx.hooks]
+    middleware_names = [name for name, _ in ctx.middleware]
+    assert "pre_api_request" in hook_names
+    assert "post_tool_call" in hook_names
+    assert middleware_names == ["tool_execution", "api_execution"]
 
 
 def test_nemo_flow_plugin_emits_llm_tool_and_exports_atif(tmp_path, monkeypatch):
@@ -245,7 +290,7 @@ output_directory = "events"
 
 
 def test_nemo_flow_plugin_noops_without_dependency(monkeypatch):
-    monkeypatch.delitem(sys.modules, "nemo_flow", raising=False)
+    monkeypatch.delitem(sys.modules, "nemo_relay", raising=False)
     sys.modules.pop("plugins.observability.nemo_flow", None)
     plugin = importlib.import_module("plugins.observability.nemo_flow")
     plugin.reset_for_tests()
@@ -253,11 +298,85 @@ def test_nemo_flow_plugin_noops_without_dependency(monkeypatch):
     real_import = builtins.__import__
 
     def blocked_import(name, *args, **kwargs):
-        if name == "nemo_flow":
-            raise ModuleNotFoundError("No module named 'nemo_flow'")
+        if name == "nemo_relay":
+            raise ModuleNotFoundError("No module named 'nemo_relay'")
         return real_import(name, *args, **kwargs)
 
     monkeypatch.setattr(builtins, "__import__", blocked_import)
 
     plugin.on_pre_api_request(session_id="s1", api_request_id="api-1")
     plugin.on_post_api_request(session_id="s1", api_request_id="api-1")
+
+
+def test_adaptive_tool_execution_middleware_uses_managed_execute(monkeypatch):
+    fake = _FakeNemoFlow()
+    plugin = _fresh_plugin(monkeypatch, fake)
+    monkeypatch.setenv("HERMES_NEMO_FLOW_ADAPTIVE_ENABLED", "1")
+
+    result = plugin.on_tool_execution_middleware(
+        session_id="s1",
+        task_id="t1",
+        turn_id="turn-1",
+        api_request_id="api-1",
+        tool_name="read_file",
+        tool_call_id="tool-1",
+        args={"path": "demo.txt"},
+        next_call=lambda args: {"result": args},
+        telemetry_schema_version="hermes.observer.v1",
+        middleware_schema_version="hermes.middleware.v1",
+    )
+
+    assert result == {"result": {"intercepted": True, "path": "demo.txt"}}
+    assert any(event[0] == "tool.execute.start" for event in fake.events)
+    assert not any(event[0] == "tool.call" for event in fake.events)
+
+
+def test_adaptive_llm_execution_middleware_preserves_raw_response(monkeypatch):
+    fake = _FakeNemoFlow()
+    plugin = _fresh_plugin(monkeypatch, fake)
+    monkeypatch.setenv("HERMES_NEMO_FLOW_ADAPTIVE_ENABLED", "1")
+    raw_response = object()
+    seen_request = {}
+
+    result = plugin.on_api_execution_middleware(
+        session_id="s1",
+        task_id="t1",
+        turn_id="turn-1",
+        api_request_id="api-1",
+        provider="openai",
+        model="demo-model",
+        request={"messages": [{"role": "user", "content": "hi"}]},
+        next_call=lambda request: (seen_request.update(request) or raw_response),
+        telemetry_schema_version="hermes.observer.v1",
+        middleware_schema_version="hermes.middleware.v1",
+    )
+
+    assert result is raw_response
+    assert seen_request["intercepted"] is True
+    assert seen_request["messages"] == [{"role": "user", "content": "hi"}]
+    execute_start = next(event for event in fake.events if event[0] == "llm.execute.start")
+    assert execute_start[1] == "openai"
+    assert execute_start[2]["messages"] == [{"role": "user", "content": "hi"}]
+
+
+def test_adaptive_observer_hooks_do_not_duplicate_managed_tool_spans(monkeypatch):
+    fake = _FakeNemoFlow()
+    plugin = _fresh_plugin(monkeypatch, fake)
+    monkeypatch.setenv("HERMES_NEMO_FLOW_ADAPTIVE_ENABLED", "1")
+
+    base = {
+        "session_id": "s1",
+        "task_id": "t1",
+        "turn_id": "turn-1",
+        "tool_name": "read_file",
+        "tool_call_id": "tool-1",
+        "args": {"path": "demo.txt"},
+        "telemetry_schema_version": "hermes.observer.v1",
+    }
+    plugin.on_pre_tool_call(**base)
+    plugin.on_post_tool_call(**base, result='{"ok": true}', status="ok")
+    plugin.on_post_tool_call(**base, result='{"error": "blocked"}', status="blocked")
+
+    assert not any(event[0] == "tool.call" for event in fake.events)
+    assert not any(event[0] == "tool.call_end" for event in fake.events)
+    assert any(event[0] == "scope.event" and event[1] == "hermes.tool.blocked" for event in fake.events)

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -1809,6 +1809,39 @@ class TestExecuteToolCalls:
         assert messages[0]["role"] == "tool"
         assert "search result" in messages[0]["content"]
 
+    def test_keyboard_interrupt_emits_cancelled_post_tool_hook(self, agent, monkeypatch):
+        tc = _mock_tool_call(name="web_search", arguments='{"q":"test"}', call_id="c1")
+        mock_msg = _mock_assistant_msg(content="", tool_calls=[tc])
+        messages = []
+        hook_calls = []
+        agent.session_id = "session-1"
+        agent._current_turn_id = "turn-1"
+        agent._current_api_request_id = "api-1"
+
+        def _capture_hook(hook_name, **kwargs):
+            hook_calls.append((hook_name, kwargs))
+            return []
+
+        monkeypatch.setattr("hermes_cli.plugins.invoke_hook", _capture_hook)
+
+        with (
+            patch("run_agent.handle_function_call", side_effect=KeyboardInterrupt),
+            patch("run_agent._set_interrupt"),
+            pytest.raises(KeyboardInterrupt),
+        ):
+            agent._execute_tool_calls_sequential(mock_msg, messages, "task-1")
+
+        post_calls = [kwargs for name, kwargs in hook_calls if name == "post_tool_call"]
+        assert len(post_calls) == 1
+        assert post_calls[0]["tool_name"] == "web_search"
+        assert post_calls[0]["tool_call_id"] == "c1"
+        assert post_calls[0]["session_id"] == "session-1"
+        assert post_calls[0]["turn_id"] == "turn-1"
+        assert post_calls[0]["api_request_id"] == "api-1"
+        assert post_calls[0]["status"] == "cancelled"
+        assert post_calls[0]["error_type"] == "keyboard_interrupt"
+        assert json.loads(post_calls[0]["result"])["status"] == "cancelled"
+
     def test_interrupt_skips_remaining(self, agent):
         tc1 = _mock_tool_call(name="web_search", arguments="{}", call_id="c1")
         tc2 = _mock_tool_call(name="web_search", arguments="{}", call_id="c2")
@@ -2184,6 +2217,8 @@ class TestConcurrentToolExecution:
                 "web_search", {"q": "test"}, "task-1",
                 tool_call_id=None,
                 session_id=agent.session_id,
+                turn_id="",
+                api_request_id="",
                 enabled_tools=list(agent.valid_tool_names),
                 skip_pre_tool_call_hook=True,
             )
@@ -2231,6 +2266,30 @@ class TestConcurrentToolExecution:
             result = agent._invoke_tool("todo", {"todos": []}, "task-1")
             mock_todo.assert_called_once()
         assert "ok" in result
+
+    def test_invoke_tool_agent_level_tool_emits_terminal_post_tool_hook(self, agent, monkeypatch):
+        """Agent-owned tool paths should close observer tool spans."""
+        hook_calls = []
+        monkeypatch.setattr(
+            "hermes_cli.plugins.get_pre_tool_call_block_message",
+            lambda *args, **kwargs: None,
+        )
+        monkeypatch.setattr(
+            "hermes_cli.plugins.invoke_hook",
+            lambda hook_name, **kwargs: hook_calls.append((hook_name, kwargs)) or [],
+        )
+
+        with patch("tools.todo_tool.todo_tool", return_value='{"ok":true}') as mock_todo:
+            result = agent._invoke_tool("todo", {"todos": []}, "task-1", tool_call_id="todo-1")
+
+        mock_todo.assert_called_once()
+        assert result == '{"ok":true}'
+        post_call = next(call for call in hook_calls if call[0] == "post_tool_call")
+        assert post_call[1]["tool_name"] == "todo"
+        assert post_call[1]["tool_call_id"] == "todo-1"
+        assert post_call[1]["status"] == "ok"
+        assert post_call[1]["error_type"] is None
+        assert isinstance(post_call[1]["duration_ms"], int)
 
     def test_invoke_tool_blocked_returns_error_and_skips_execution(self, agent, monkeypatch):
         """_invoke_tool should return error JSON when a plugin blocks the tool."""
@@ -2283,6 +2342,60 @@ class TestConcurrentToolExecution:
         assert len(messages) == 1
         assert messages[0]["role"] == "tool"
         assert json.loads(messages[0]["content"]) == {"error": "Blocked by policy"}
+
+    def test_sequential_blocked_tool_emits_terminal_post_tool_hook(self, agent, monkeypatch):
+        """Blocked pre_tool_call decisions still terminate observer tool spans."""
+        tool_call = _mock_tool_call(name="write_file",
+                                    arguments='{"path":"test.txt","content":"hello"}',
+                                    call_id="c1")
+        mock_msg = _mock_assistant_msg(content="", tool_calls=[tool_call])
+        messages = []
+        hook_calls = []
+
+        monkeypatch.setattr(
+            "hermes_cli.plugins.get_pre_tool_call_block_message",
+            lambda *args, **kwargs: "Blocked by policy",
+        )
+        monkeypatch.setattr(
+            "hermes_cli.plugins.invoke_hook",
+            lambda hook_name, **kwargs: hook_calls.append((hook_name, kwargs)) or [],
+        )
+
+        with patch("run_agent.handle_function_call", side_effect=AssertionError("should not run")):
+            agent._execute_tool_calls_sequential(mock_msg, messages, "task-1")
+
+        post_call = next(call for call in hook_calls if call[0] == "post_tool_call")
+        assert post_call[1]["tool_name"] == "write_file"
+        assert post_call[1]["tool_call_id"] == "c1"
+        assert post_call[1]["status"] == "blocked"
+        assert post_call[1]["error_type"] == "plugin_block"
+        assert post_call[1]["error_message"] == "Blocked by policy"
+
+    def test_sequential_agent_level_tool_emits_terminal_post_tool_hook(self, agent, monkeypatch):
+        """Sequential built-in tool paths should also close observer tool spans."""
+        tool_call = _mock_tool_call(name="todo", arguments='{"todos":[]}', call_id="todo-1")
+        mock_msg = _mock_assistant_msg(content="", tool_calls=[tool_call])
+        messages = []
+        hook_calls = []
+
+        monkeypatch.setattr(
+            "hermes_cli.plugins.get_pre_tool_call_block_message",
+            lambda *args, **kwargs: None,
+        )
+        monkeypatch.setattr(
+            "hermes_cli.plugins.invoke_hook",
+            lambda hook_name, **kwargs: hook_calls.append((hook_name, kwargs)) or [],
+        )
+
+        with patch("tools.todo_tool.todo_tool", return_value='{"ok":true}') as mock_todo:
+            agent._execute_tool_calls_sequential(mock_msg, messages, "task-1")
+
+        mock_todo.assert_called_once()
+        post_call = next(call for call in hook_calls if call[0] == "post_tool_call")
+        assert post_call[1]["tool_name"] == "todo"
+        assert post_call[1]["tool_call_id"] == "todo-1"
+        assert post_call[1]["result"] == '{"ok":true}'
+        assert post_call[1]["status"] == "ok"
 
     def test_blocked_memory_tool_does_not_reset_counter(self, agent, monkeypatch):
         """Blocked memory tool should not reset the nudge counter."""
@@ -2684,9 +2797,15 @@ class TestRunConversation:
         assert [call["api_call_count"] for call in pre_request_calls] == [1, 2]
         assert [call["api_call_count"] for call in post_request_calls] == [1, 2]
         assert all(call["session_id"] == agent.session_id for call in pre_request_calls)
+        assert all(call["turn_id"] == pre_request_calls[0]["turn_id"] for call in pre_request_calls + post_request_calls)
+        assert [call["api_request_id"] for call in pre_request_calls] == [
+            call["api_request_id"] for call in post_request_calls
+        ]
         assert all("message_count" in c and isinstance(c.get("request_messages"), list) for c in pre_request_calls)
+        assert all("request" in c and "messages" in c["request"]["body"] for c in pre_request_calls)
         assert any(msg.get("role") == "user" and msg.get("content") == "search something" for msg in pre_request_calls[0]["request_messages"])
-        assert all("usage" in c and "response" in c and "assistant_message" in c for c in post_request_calls)
+        assert all("usage" in c and "response" in c for c in post_request_calls)
+        assert all("assistant_message" in c["response"] for c in post_request_calls)
 
     def test_content_with_tool_calls_stays_silent_for_non_cli_quiet_mode(self, agent):
         self._setup_agent(agent)

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -2803,6 +2803,8 @@ class TestRunConversation:
         ]
         assert all("message_count" in c and isinstance(c.get("request_messages"), list) for c in pre_request_calls)
         assert all("request" in c and "messages" in c["request"]["body"] for c in pre_request_calls)
+        assert all("original_request" in c and "messages" in c["original_request"]["body"] for c in pre_request_calls)
+        assert all(c["middleware_trace"] == [] for c in pre_request_calls + post_request_calls)
         assert any(msg.get("role") == "user" and msg.get("content") == "search something" for msg in pre_request_calls[0]["request_messages"])
         assert all("usage" in c and "response" in c for c in post_request_calls)
         assert all("assistant_message" in c["response"] for c in post_request_calls)

--- a/tests/test_model_tools.py
+++ b/tests/test_model_tools.py
@@ -62,6 +62,9 @@ class TestHandleFunctionCall:
                 task_id="task-1",
                 session_id="session-1",
                 tool_call_id="call-1",
+                turn_id="",
+                api_request_id="",
+                telemetry_schema_version="hermes.observer.v1",
             ),
             call(
                 "post_tool_call",
@@ -71,7 +74,13 @@ class TestHandleFunctionCall:
                 task_id="task-1",
                 session_id="session-1",
                 tool_call_id="call-1",
+                turn_id="",
+                api_request_id="",
                 duration_ms=ANY,
+                status="ok",
+                error_type=None,
+                error_message=None,
+                telemetry_schema_version="hermes.observer.v1",
             ),
             call(
                 "transform_tool_result",
@@ -81,7 +90,13 @@ class TestHandleFunctionCall:
                 task_id="task-1",
                 session_id="session-1",
                 tool_call_id="call-1",
+                turn_id="",
+                api_request_id="",
                 duration_ms=ANY,
+                status="ok",
+                error_type=None,
+                error_message=None,
+                telemetry_schema_version="hermes.observer.v1",
             ),
         ]
 
@@ -137,7 +152,10 @@ class TestPreToolCallBlocking:
     """Verify that pre_tool_call hooks can block tool execution."""
 
     def test_blocked_tool_returns_error_and_skips_dispatch(self, monkeypatch):
+        hook_calls = []
+
         def fake_invoke_hook(hook_name, **kwargs):
+            hook_calls.append((hook_name, kwargs))
             if hook_name == "pre_tool_call":
                 return [{"action": "block", "message": "Blocked by policy"}]
             return []
@@ -156,6 +174,11 @@ class TestPreToolCallBlocking:
         result = json.loads(handle_function_call("read_file", {"path": "test.txt"}, task_id="t1"))
         assert result == {"error": "Blocked by policy"}
         assert not dispatch_called
+        post_call = next(call for call in hook_calls if call[0] == "post_tool_call")
+        assert post_call[1]["status"] == "blocked"
+        assert post_call[1]["error_type"] == "plugin_block"
+        assert post_call[1]["error_message"] == "Blocked by policy"
+        assert post_call[1]["duration_ms"] == 0
 
     def test_blocked_tool_skips_read_loop_notification(self, monkeypatch):
         notifications = []

--- a/tests/test_model_tools.py
+++ b/tests/test_model_tools.py
@@ -59,6 +59,8 @@ class TestHandleFunctionCall:
                 "pre_tool_call",
                 tool_name="web_search",
                 args={"q": "test"},
+                original_args={"q": "test"},
+                middleware_trace=[],
                 task_id="task-1",
                 session_id="session-1",
                 tool_call_id="call-1",
@@ -70,6 +72,8 @@ class TestHandleFunctionCall:
                 "post_tool_call",
                 tool_name="web_search",
                 args={"q": "test"},
+                original_args={"q": "test"},
+                middleware_trace=[],
                 result='{"ok":true}',
                 task_id="task-1",
                 session_id="session-1",
@@ -87,6 +91,8 @@ class TestHandleFunctionCall:
                 tool_name="web_search",
                 args={"q": "test"},
                 result='{"ok":true}',
+                original_args={"q": "test"},
+                middleware_trace=[],
                 task_id="task-1",
                 session_id="session-1",
                 tool_call_id="call-1",
@@ -126,6 +132,77 @@ class TestHandleFunctionCall:
         assert post_duration == transform_duration
         # pre_tool_call does NOT get duration_ms (nothing has run yet).
         assert "duration_ms" not in kwargs_by_hook["pre_tool_call"]
+
+    def test_tool_request_middleware_rewrites_args_before_hooks_and_dispatch(self, monkeypatch):
+        hook_calls = []
+        dispatched = {}
+
+        def fake_invoke_middleware(kind, **kwargs):
+            if kind == "tool_request":
+                assert kwargs["args"] == {"q": "original"}
+                assert kwargs["original_args"] == {"q": "original"}
+                return [{"args": {"q": "rewritten"}, "source": "test-middleware"}]
+            return []
+
+        def fake_invoke_hook(hook_name, **kwargs):
+            hook_calls.append((hook_name, kwargs))
+            return []
+
+        def fake_dispatch(tool_name, args, **kwargs):
+            dispatched["tool_name"] = tool_name
+            dispatched["args"] = args
+            return json.dumps({"ok": True, "args": args})
+
+        monkeypatch.setattr("hermes_cli.plugins.invoke_middleware", fake_invoke_middleware)
+        monkeypatch.setattr("hermes_cli.plugins.invoke_hook", fake_invoke_hook)
+        monkeypatch.setattr("model_tools.registry.dispatch", fake_dispatch)
+
+        result = json.loads(handle_function_call("web_search", {"q": "original"}, task_id="t1"))
+
+        assert result == {"ok": True, "args": {"q": "rewritten"}}
+        assert dispatched == {"tool_name": "web_search", "args": {"q": "rewritten"}}
+        pre_call = next(call for call in hook_calls if call[0] == "pre_tool_call")
+        assert pre_call[1]["args"] == {"q": "rewritten"}
+        assert pre_call[1]["original_args"] == {"q": "original"}
+        assert pre_call[1]["middleware_trace"] == [{"source": "test-middleware"}]
+
+    def test_tool_execution_middleware_wraps_dispatch(self, monkeypatch):
+        dispatched = {}
+        middleware_seen = {}
+
+        def around_tool(**kwargs):
+            middleware_seen["tool_name"] = kwargs["tool_name"]
+            middleware_seen["args"] = kwargs["args"]
+            middleware_seen["schema"] = kwargs["middleware_schema_version"]
+            next_args = dict(kwargs["args"])
+            next_args["wrapped"] = True
+            return kwargs["next_call"](next_args)
+
+        class Manager:
+            _middleware = {"tool_execution": [around_tool]}
+
+        def fake_dispatch(tool_name, args, **kwargs):
+            dispatched["tool_name"] = tool_name
+            dispatched["args"] = args
+            return json.dumps({"ok": True, "args": args})
+
+        monkeypatch.setattr("hermes_cli.plugins.invoke_middleware", lambda kind, **kwargs: [])
+        monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda hook_name, **kwargs: [])
+        monkeypatch.setattr("hermes_cli.plugins.get_plugin_manager", lambda: Manager())
+        monkeypatch.setattr("model_tools.registry.dispatch", fake_dispatch)
+
+        result = json.loads(handle_function_call("web_search", {"q": "test"}, task_id="t1"))
+
+        assert result == {"ok": True, "args": {"q": "test", "wrapped": True}}
+        assert dispatched == {
+            "tool_name": "web_search",
+            "args": {"q": "test", "wrapped": True},
+        }
+        assert middleware_seen == {
+            "tool_name": "web_search",
+            "args": {"q": "test"},
+            "schema": "hermes.middleware.v1",
+        }
 
 
 # =========================================================================

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -31,6 +31,14 @@ _approval_session_key: contextvars.ContextVar[str] = contextvars.ContextVar(
     "approval_session_key",
     default="",
 )
+_approval_turn_id: contextvars.ContextVar[str] = contextvars.ContextVar(
+    "approval_turn_id",
+    default="",
+)
+_approval_tool_call_id: contextvars.ContextVar[str] = contextvars.ContextVar(
+    "approval_tool_call_id",
+    default="",
+)
 
 
 def _fire_approval_hook(hook_name: str, **kwargs) -> None:
@@ -44,12 +52,15 @@ def _fire_approval_hook(hook_name: str, **kwargs) -> None:
     pre_approval_request, post_approval_response.
     """
     try:
-        from hermes_cli.plugins import invoke_hook
+        from hermes_cli.plugins import OBSERVER_SCHEMA_VERSION, invoke_hook
     except Exception:
         # Plugin system not available in this execution context
         # (e.g. bare tool-only imports, minimal test environments).
         return
     try:
+        kwargs.setdefault("turn_id", _approval_turn_id.get())
+        kwargs.setdefault("tool_call_id", _approval_tool_call_id.get())
+        kwargs.setdefault("telemetry_schema_version", OBSERVER_SCHEMA_VERSION)
         invoke_hook(hook_name, **kwargs)
     except Exception as exc:
         # invoke_hook() already swallows per-callback errors, so reaching here
@@ -67,6 +78,27 @@ def set_current_session_key(session_key: str) -> contextvars.Token[str]:
 def reset_current_session_key(token: contextvars.Token[str]) -> None:
     """Restore the prior approval session key context."""
     _approval_session_key.reset(token)
+
+
+def set_current_observability_context(
+    *,
+    turn_id: str = "",
+    tool_call_id: str = "",
+) -> tuple[contextvars.Token[str], contextvars.Token[str]]:
+    """Bind active tool correlation IDs to approval hooks."""
+    return (
+        _approval_turn_id.set(turn_id or ""),
+        _approval_tool_call_id.set(tool_call_id or ""),
+    )
+
+
+def reset_current_observability_context(
+    tokens: tuple[contextvars.Token[str], contextvars.Token[str]],
+) -> None:
+    """Restore prior approval hook correlation IDs."""
+    turn_token, tool_token = tokens
+    _approval_tool_call_id.reset(tool_token)
+    _approval_turn_id.reset(turn_token)
 
 
 def get_current_session_key(default: str = "default") -> str:

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1146,6 +1146,7 @@ def _build_child_agent(
     child._subagent_id = subagent_id
     child._parent_subagent_id = parent_subagent_id
     child._subagent_goal = goal
+    child._parent_turn_id = getattr(parent_agent, "_current_turn_id", "") or ""
 
     # Share a credential pool with the child when possible so subagents can
     # rotate credentials on rate limits instead of getting pinned to one key.
@@ -1170,6 +1171,22 @@ def _build_child_agent(
             child_progress_cb("subagent.spawn_requested", preview=goal)
         except Exception as exc:
             logger.debug("spawn_requested relay failed: %s", exc)
+
+    try:
+        from hermes_cli.plugins import OBSERVER_SCHEMA_VERSION, invoke_hook as _invoke_hook
+        _invoke_hook(
+            "subagent_start",
+            parent_session_id=getattr(parent_agent, "session_id", None),
+            parent_turn_id=getattr(parent_agent, "_current_turn_id", "") or "",
+            parent_subagent_id=parent_subagent_id,
+            child_session_id=getattr(child, "session_id", None),
+            child_subagent_id=subagent_id,
+            child_role=effective_role,
+            child_goal=goal,
+            telemetry_schema_version=OBSERVER_SCHEMA_VERSION,
+        )
+    except Exception:
+        logger.debug("subagent_start hook invocation failed", exc_info=True)
 
     return child
 
@@ -2245,9 +2262,10 @@ def delegate_task(
     # child was closed.
     _parent_session_id = getattr(parent_agent, "session_id", None)
     try:
-        from hermes_cli.plugins import invoke_hook as _invoke_hook
+        from hermes_cli.plugins import OBSERVER_SCHEMA_VERSION, invoke_hook as _invoke_hook
     except Exception:
         _invoke_hook = None
+        OBSERVER_SCHEMA_VERSION = "hermes.observer.v1"
     # Aggregate child spend here so the parent's footer/UI reflect the true
     # cost of a subagent-heavy turn.  Port of Kilo-Org/kilocode#9448.  Each
     # child's cost was captured in _run_single_child before its AIAgent was
@@ -2265,13 +2283,22 @@ def delegate_task(
         if _invoke_hook is None:
             continue
         try:
+            _child_index = entry.get("task_index", -1)
+            _child_agent = (
+                children[_child_index][2]
+                if isinstance(_child_index, int) and 0 <= _child_index < len(children)
+                else None
+            )
             _invoke_hook(
                 "subagent_stop",
                 parent_session_id=_parent_session_id,
+                parent_turn_id=getattr(parent_agent, "_current_turn_id", "") or "",
+                child_session_id=getattr(_child_agent, "session_id", None),
                 child_role=child_role,
                 child_summary=entry.get("summary"),
                 child_status=entry.get("status"),
                 duration_ms=int((entry.get("duration_seconds") or 0) * 1000),
+                telemetry_schema_version=OBSERVER_SCHEMA_VERSION,
             )
         except Exception:
             logger.debug("subagent_stop hook invocation failed", exc_info=True)

--- a/website/docs/developer-guide/plugin-middleware-contract.md
+++ b/website/docs/developer-guide/plugin-middleware-contract.md
@@ -1,0 +1,127 @@
+---
+sidebar_position: 16
+title: "Plugin Middleware Contract"
+description: "Stable observer hooks and middleware surfaces for Hermes plugins"
+---
+
+# Plugin Middleware Contract
+
+Hermes exposes a backend-neutral middleware contract for plugins that need to
+observe or carefully participate in agent execution. The implementation calls
+into this contract from several runtime files, but the supported integration
+surface is the contract in `hermes_cli.middleware` and `hermes_cli.plugins`.
+
+## Contract Families
+
+Hermes has two extension families:
+
+| Family | Purpose | May change execution? |
+|---|---|---|
+| Observer hooks | Lifecycle telemetry for sessions, turns, API calls, tools, approvals, and subagents. | No, except documented legacy return shapes. |
+| Middleware | Request rewrites and execution wrappers around API/tool calls. | Yes, when explicitly registered. |
+
+Observer payloads include `telemetry_schema_version = "hermes.observer.v1"`.
+Middleware payloads also include
+`middleware_schema_version = "hermes.middleware.v1"`.
+
+## Observer Hooks
+
+Observer hooks are registered with `ctx.register_hook(name, callback)`. Callback
+exceptions are logged and ignored so observability does not break the agent.
+
+Important hook groups:
+
+| Group | Hooks |
+|---|---|
+| Session | `on_session_start`, `on_session_end`, `on_session_finalize`, `on_session_reset` |
+| Turn | `pre_llm_call`, `post_llm_call` |
+| API/LLM | `pre_api_request`, `post_api_request`, `api_request_error` |
+| Tool | `pre_tool_call`, `post_tool_call`, `transform_tool_result` |
+| Approval | `pre_approval_request`, `post_approval_response` |
+| Subagent | `subagent_start`, `subagent_stop` |
+
+Correlation fields are stable across hook groups when available:
+
+- `session_id`
+- `task_id`
+- `turn_id`
+- `api_request_id`
+- `tool_call_id`
+- `parent_session_id`
+- `child_session_id`
+- `parent_subagent_id`
+- `child_subagent_id`
+
+`pre_tool_call` may return `{"action": "block", "message": "..."}` to block a
+tool. When a block wins, Hermes emits `post_tool_call` with `status="blocked"`
+and matching IDs so observers can close spans.
+
+`pre_llm_call`, `transform_llm_output`, `transform_terminal_output`, and
+`transform_tool_result` have existing behavior-changing return contracts. All
+other observer hook return values are ignored.
+
+## Middleware
+
+Middleware is registered with `ctx.register_middleware(kind, callback)`.
+
+Supported middleware kinds:
+
+| Kind | Callback purpose |
+|---|---|
+| `tool_request` | Rewrite tool arguments before `pre_tool_call` and execution. |
+| `tool_execution` | Wrap the real tool callback. |
+| `api_request` | Rewrite provider API kwargs before `pre_api_request` and dispatch. |
+| `api_execution` | Wrap the real provider API call. |
+
+Request middleware returns a replacement payload:
+
+```python
+def register(ctx):
+    def add_trace_id(**kw):
+        args = dict(kw["args"])
+        args["trace_id"] = kw["tool_call_id"]
+        return {"args": args, "source": "trace-plugin"}
+
+    ctx.register_middleware("tool_request", add_trace_id)
+```
+
+API request middleware uses the `request` key instead:
+
+```python
+return {"request": new_api_kwargs, "source": "provider-rewriter"}
+```
+
+Execution middleware receives `next_call` and must call it to continue:
+
+```python
+def register(ctx):
+    def around_tool(**kw):
+        result = kw["next_call"](kw["args"])
+        return result
+
+    ctx.register_middleware("tool_execution", around_tool)
+```
+
+Middleware exceptions are logged and skipped. This keeps the default runtime
+fail-open unless a plugin intentionally returns a documented blocking or
+replacement result.
+
+## Payload Guarantees
+
+For request middleware and downstream hooks, Hermes passes both the original
+and effective payload when a rewrite surface is active:
+
+- Tools: `original_args`, `args`
+- API calls: `original_request`, `request`
+- Middleware changes: `middleware_trace`
+
+Observer hooks always receive the effective payload in the legacy field name
+(`args` or `request`) so existing plugins keep working. New integrations that
+need exact provenance should inspect both original and effective fields.
+
+## Compatibility
+
+The contract is backend-neutral. A plugin may map it to Langfuse, NeMo-Flow,
+OpenTelemetry, local JSONL, or a custom runtime. NeMo-Flow Adaptive execution
+intercepts should use middleware, not passive observer hooks, because
+intercepts intentionally participate in the execution path.

--- a/website/docs/user-guide/features/hooks.md
+++ b/website/docs/user-guide/features/hooks.md
@@ -353,6 +353,9 @@ Gateway hooks only fire in the **gateway** (Telegram, Discord, Slack, WhatsApp, 
 
 [Plugins](/docs/user-guide/features/plugins) can register hooks that fire in **both CLI and gateway** sessions. These are registered programmatically via `ctx.register_hook()` in your plugin's `register()` function.
 
+For the stable payload fields and behavior-changing middleware surfaces, see
+the [Plugin Middleware Contract](/docs/developer-guide/plugin-middleware-contract).
+
 ```python
 def register(ctx):
     ctx.register_hook("pre_tool_call", my_tool_observer)

--- a/website/docs/user-guide/features/plugins.md
+++ b/website/docs/user-guide/features/plugins.md
@@ -190,6 +190,9 @@ When you upgrade to a version of Hermes that has opt-in plugins (config schema v
 ## Available hooks
 
 Plugins can register callbacks for these lifecycle events. See the **[Event Hooks page](/docs/user-guide/features/hooks#plugin-hooks)** for full details, callback signatures, and examples.
+Plugins that need a stable observer payload contract or behavior-changing
+execution middleware should also read the
+[Plugin Middleware Contract](/docs/developer-guide/plugin-middleware-contract).
 
 | Hook | Fires when |
 |------|-----------|


### PR DESCRIPTION
Title: feat(observability): add opt-in NeMo-Flow adaptive intercepts

Base branch: bbednarski/nmf-41B-nemoflow-plugin

## What does this PR do?

This PR is phase 3 of the NMF-41 stacked change. It adds an opt-in proof of concept for routing Hermes tool and LLM execution through NeMo-Flow's managed execution helpers.

When `HERMES_NEMO_FLOW_ADAPTIVE_ENABLED=1`, the NeMo-Flow plugin registers Hermes execution middleware and routes tool calls through `nemo_flow.tools.execute()` and LLM calls through `nemo_flow.llm.execute()` when those APIs are available. That allows NeMo-Flow request intercepts and execution intercepts to participate at the Hermes runtime boundary.

The default behavior remains passive observability. Adaptive execution is disabled unless explicitly enabled, and the plugin still fails open if NeMo-Flow is unavailable. The LLM middleware preserves Hermes' raw provider response for the agent loop while allowing NeMo-Flow to observe the JSON-compatible managed result. The plugin also suppresses duplicate manual tool/LLM spans when managed execution owns the lifecycle.

This PR is intentionally separate from the passive NeMo-Flow observability plugin so reviewers can evaluate execution interception independently.

## Related Issue

Relates to NMF-41

Fixes #

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `plugins/observability/nemo_flow/__init__.py`: adds `HERMES_NEMO_FLOW_ADAPTIVE_ENABLED` and `HERMES_NEMO_FLOW_ADAPTIVE_MODE` settings.
- `plugins/observability/nemo_flow/__init__.py`: registers `tool_execution` and `api_execution` middleware from the NeMo-Flow plugin.
- `plugins/observability/nemo_flow/__init__.py`: routes tool execution through `nemo_flow.tools.execute()` when adaptive mode is enabled.
- `plugins/observability/nemo_flow/__init__.py`: routes provider execution through `nemo_flow.llm.execute()` when adaptive mode is enabled and preserves the original Hermes response object.
- `plugins/observability/nemo_flow/__init__.py`: suppresses duplicate passive tool/LLM spans when managed execution owns those spans, while still marking blocked tools.
- `plugins/observability/nemo_flow/README.md`: documents the adaptive execution PoC and environment variables.
- `plugins/observability/nemo_flow/plugin.yaml`: clarifies that the plugin consumes observer hooks by default.
- `tests/plugins/test_nemo_flow_plugin.py`: adds managed execution tests for tool middleware, LLM middleware, raw response preservation, and duplicate-span suppression.

## Suggested Review Order

1. `plugins/observability/nemo_flow/README.md` for the opt-in behavior and rollout expectations.
2. Settings and capability checks in `plugins/observability/nemo_flow/__init__.py`: `_Settings`, `managed_tool_enabled()`, and `managed_llm_enabled()`.
3. Middleware entry points: `on_tool_execution_middleware()` and `on_api_execution_middleware()`.
4. Managed execution helpers: `_Runtime.execute_tool()` and `_Runtime.execute_llm()`, especially raw response preservation in the LLM path.
5. Duplicate lifecycle suppression in `on_pre_api_request`, `on_post_api_request`, `on_pre_tool_call`, and `on_post_tool_call`.
6. `tests/plugins/test_nemo_flow_plugin.py` adaptive tests for expected managed execution behavior.

## How to Test

1. Check out this stacked branch:
   ```bash
   git checkout bbednarski/nmf-41C-nemoflow-adaptive-intercepts
   ```
2. Run the focused plugin and middleware test suite:
   ```bash
   env HERMES_HOME=/private/tmp/hermes-agent-41c-tests .venv/bin/pytest \
     tests/plugins/test_nemo_flow_plugin.py \
     tests/hermes_cli/test_middleware.py \
     tests/hermes_cli/test_plugins.py::TestPluginHooks \
     tests/test_model_tools.py::TestHandleFunctionCall \
     tests/run_agent/test_run_agent.py::TestRunConversation::test_request_scoped_api_hooks_fire_for_each_api_call \
     -q
   ```
3. Confirm the expected result:
   ```text
   35 passed
   ```

Optional local smoke test with adaptive mode enabled:

```bash
hermes plugins enable observability/nemo_flow
export HERMES_NEMO_FLOW_ADAPTIVE_ENABLED=1
export HERMES_NEMO_FLOW_ATOF_ENABLED=1
export HERMES_NEMO_FLOW_ATOF_OUTPUT_DIRECTORY=.nemo-flow/atof
hermes -q "Use a tool, then summarize what happened."
```

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS/Darwin with Python 3.13.13, using the focused test suite above

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Focused validation:

```text
35 passed in 3.06s
```
