### PR TITLE
fix(kanban): gate task.skills on resolvability to prevent worker crash loops

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -5199,39 +5199,50 @@ def _resolve_hermes_argv() -> list[str]:
     return _module_hermes_argv()
 
 
-def _kanban_worker_skill_available(hermes_home: Optional[str]) -> bool:
-    """True if the bundled ``kanban-worker`` skill resolves for the home the
-    spawned worker will run under.
+def _skill_available_for_home(skill_name: str, hermes_home: Optional[str]) -> bool:
+    """True if ``skill_name`` resolves under the worker's ``HERMES_HOME``.
 
-    The dispatcher injects ``--skills kanban-worker`` into every worker. When
-    the worker activates a profile (``hermes -p <name>``), its ``SKILLS_DIR``
-    becomes ``<profile_home>/skills`` — which on many profiles does NOT contain
-    the bundled skill (it ships in the *default* root home, not every
-    profile-scoped skills dir). Preloading a missing skill is fatal at CLI
-    startup (``ValueError: Unknown skill(s): kanban-worker``), aborting the
-    worker before the agent loop runs. Gate the flag on actual resolvability;
-    the kanban lifecycle contract is still injected via ``KANBAN_GUIDANCE``, so
-    omitting the flag only drops the supplementary pattern library.
+    Preloading a missing skill via ``--skills <name>`` is fatal at CLI startup
+    (``ValueError: Unknown skill(s): <name>``), aborting the worker before the
+    agent loop runs. When a worker activates a profile (``hermes -p <name>``)
+    its ``SKILLS_DIR`` becomes ``<profile_home>/skills`` — which may not
+    contain skills that exist in the *default* root home. Gate every
+    ``--skills`` injection on actual resolvability instead of trusting the
+    caller; dropping a missing flag is safer than crash-looping the worker
+    until the watchdog auto-blocks it.
+
+    Used for both the bundled ``kanban-worker`` skill (always injected) and
+    per-task ``task.skills`` overrides.
     """
     from pathlib import Path as _Path
 
+    if not skill_name:
+        return False
     # An unset HERMES_HOME means the worker falls back to the default root
-    # home (``~/.hermes``), which ships the bundled skill.
+    # home (``~/.hermes``), which ships the bundled skill set.
     base = _Path(hermes_home) if hermes_home else (_Path.home() / ".hermes")
     skills_root = base / "skills"
     if not skills_root.is_dir():
         return False
-    # Canonical bundled location first (cheap), then a bounded scan for
-    # profiles that have it nested elsewhere.
-    if (skills_root / "devops" / "kanban-worker" / "SKILL.md").is_file():
-        return True
+    # Bounded rglob covers nested categories (devops/, mlops/, etc.) without
+    # caller needing to know the category layout. Cheap on typical skill
+    # trees (a few dozen entries); short-circuits on first match.
     try:
-        for skill_md in skills_root.rglob("kanban-worker/SKILL.md"):
+        for skill_md in skills_root.rglob(f"{skill_name}/SKILL.md"):
             if skill_md.is_file():
                 return True
     except OSError:
         pass
     return False
+
+
+def _kanban_worker_skill_available(hermes_home: Optional[str]) -> bool:
+    """Back-compat shim: ``--skills kanban-worker`` resolvability check.
+
+    Retained as a named entry point because the bundled-worker case is
+    referenced in inline comments below; delegates to the generic helper.
+    """
+    return _skill_available_for_home("kanban-worker", hermes_home)
 
 
 def _worker_terminal_timeout_env(
@@ -5384,10 +5395,30 @@ def _default_spawn(
     # quoting ambiguity if a skill name ever contains unusual chars.
     # Dedupe against the built-in so we don't double-load kanban-worker
     # if a task author asks for it explicitly.
+    #
+    # Gate each name on resolvability under the worker's HERMES_HOME
+    # for the same reason kanban-worker is gated above: preloading a
+    # missing skill is fatal at CLI startup. Without this filter, a
+    # ``task.skills`` entry that exists in the root home but not in
+    # the profile-scoped skills dir crash-loops the worker (often
+    # 100+ respawns before the watchdog auto-blocks) instead of just
+    # running without the supplementary context. A skipped skill is
+    # logged to stderr so operators see why the worker did not get
+    # the requested skill loaded; the task still proceeds.
     if task.skills:
+        worker_home = env.get("HERMES_HOME")
         for sk in task.skills:
-            if sk and sk != "kanban-worker":
+            if not sk or sk == "kanban-worker":
+                continue
+            if _skill_available_for_home(sk, worker_home):
                 cmd.extend(["--skills", sk])
+            else:
+                sys.stderr.write(
+                    f"kanban: task {task.id} requested skill "
+                    f"{sk!r} but it does not resolve under "
+                    f"{worker_home or '~/.hermes'}/skills — "
+                    f"dropping flag, worker will start without it\n"
+                )
     if task.model_override:
         cmd.extend(["-m", task.model_override])
     cmd.extend([

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -10627,6 +10627,42 @@ def _resolve_hermes_argv() -> list[str]:
     return _module_hermes_argv()
 
 
+def _skill_available_for_home(skill_name: str, hermes_home: Optional[str]) -> bool:
+    """Return whether a worker can resolve ``skill_name`` in its profile.
+
+    ``--skills`` is loaded by the child CLI before the agent loop starts. A
+    missing or ambiguous name therefore aborts the worker instead of merely
+    omitting supplementary context. Reuse the same resolver as the worker
+    itself so profile-local skills, configured external directories,
+    frontmatter ``name:`` aliases, plugin-qualified lookups, and collision
+    handling cannot drift between the dispatch preflight and child startup.
+
+    The home override is context-local and does not mutate ``os.environ``;
+    dispatchers may have other gateway work in flight in the same process.
+    """
+    identifier = str(skill_name or "").strip()
+    if not identifier:
+        return False
+
+    try:
+        from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+        from agent.skill_commands import _load_skill_payload
+
+        token = set_hermes_home_override(hermes_home)
+        try:
+            return _load_skill_payload(identifier) is not None
+        finally:
+            reset_hermes_home_override(token)
+    except Exception as exc:
+        _log.debug(
+            "kanban worker: skill preflight failed for %r under HERMES_HOME=%r (%s)",
+            identifier,
+            hermes_home,
+            exc,
+        )
+        return False
+
+
 def _worker_terminal_timeout_env(
     max_runtime_seconds: Optional[int],
     current_timeout: Optional[str],
@@ -10864,10 +10900,25 @@ def _default_spawn(
     # accepts both forms (action='append' + comma-split), but
     # per-name pairs are easier to read in `ps` output and avoid any
     # quoting ambiguity if a skill name ever contains unusual chars.
+    #
+    # Gate each name against the same resolver the child CLI uses. A missing
+    # or ambiguous skill is fatal during CLI startup; dropping only that
+    # supplementary flag lets the worker run its kanban task instead of
+    # entering a crash loop.
     if task.skills:
+        worker_home = env.get("HERMES_HOME")
         for sk in task.skills:
-            if sk:
+            if not sk:
+                continue
+            if _skill_available_for_home(sk, worker_home):
                 cmd.extend(["--skills", sk])
+            else:
+                sys.stderr.write(
+                    f"kanban: task {task.id} requested skill "
+                    f"{sk!r} but it does not resolve under "
+                    f"{worker_home or '~/.hermes'} — dropping flag; "
+                    "worker will start without it\n"
+                )
     if task.model_override:
         cmd.extend(["-m", task.model_override])
         # Pin the provider too when the override names one, so the worker

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -2976,6 +2976,9 @@ def test_default_spawn_appends_per_task_skills(kanban_home, monkeypatch):
     """Dispatcher argv must carry one `--skills X` pair per task skill,
     in addition to the built-in kanban-worker."""
     monkeypatch.setattr(kb, "_kanban_worker_skill_available", lambda _h: True)
+    # Per-task skills are also resolvability-gated now; stub the helper so
+    # synthetic skill names ("translation", "github-code-review") pass.
+    monkeypatch.setattr(kb, "_skill_available_for_home", lambda _n, _h: True)
     captured = {}
 
     class FakeProc:
@@ -3026,6 +3029,7 @@ def test_default_spawn_appends_per_task_skills(kanban_home, monkeypatch):
 def test_default_spawn_dedupes_kanban_worker_from_task_skills(kanban_home, monkeypatch):
     """If a task explicitly lists 'kanban-worker', we don't double-pass it."""
     monkeypatch.setattr(kb, "_kanban_worker_skill_available", lambda _h: True)
+    monkeypatch.setattr(kb, "_skill_available_for_home", lambda _n, _h: True)
     captured = {}
 
     class FakeProc:
@@ -3057,6 +3061,66 @@ def test_default_spawn_dedupes_kanban_worker_from_task_skills(kanban_home, monke
     assert len(worker_pairs) == 1, (
         f"kanban-worker appeared {len(worker_pairs)} times in argv: {cmd}"
     )
+
+
+def test_default_spawn_drops_unresolvable_task_skills(
+    kanban_home, monkeypatch, capfd, tmp_path
+):
+    """Per-task skill names that don't resolve under the worker's
+    HERMES_HOME must be dropped from argv (with a stderr warning) instead
+    of being passed through to crash the CLI at startup.
+
+    Regression: a task with ``skills=["some-skill"]`` whose name only
+    exists in the global skills root — not the profile-scoped one the
+    worker actually loads — would crash-loop the worker with
+    ``ValueError: Unknown skill(s): some-skill`` until the watchdog
+    auto-blocked the task (often 100+ respawns).
+    """
+    monkeypatch.setattr(kb, "_kanban_worker_skill_available", lambda _h: True)
+    # Only "good-skill" resolves; "missing-skill" does not.
+    monkeypatch.setattr(
+        kb,
+        "_skill_available_for_home",
+        lambda name, _h: name == "good-skill",
+    )
+    captured = {}
+
+    class FakeProc:
+        pid = 7
+
+    def fake_popen(cmd, **kwargs):
+        captured["cmd"] = cmd
+        return FakeProc()
+
+    monkeypatch.setattr("subprocess.Popen", fake_popen)
+
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(
+            conn,
+            title="mixed resolvability",
+            assignee="x",
+            skills=["good-skill", "missing-skill"],
+        )
+        task = kb.get_task(conn, tid)
+        workspace = kb.resolve_workspace(task)
+        kb._default_spawn(task, str(workspace))
+    finally:
+        conn.close()
+
+    cmd = captured["cmd"]
+    skill_names = [
+        cmd[i + 1] for i, tok in enumerate(cmd)
+        if tok == "--skills" and i + 1 < len(cmd)
+    ]
+    assert "good-skill" in skill_names, skill_names
+    assert "missing-skill" not in skill_names, (
+        f"unresolvable skill leaked into argv: {skill_names}"
+    )
+
+    err = capfd.readouterr().err
+    assert "missing-skill" in err, err
+    assert tid in err, err  # Task id surfaced for operators triaging logs.
 
 
 def test_cli_create_skill_flag_repeatable(kanban_home):

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -743,6 +743,100 @@ def test_default_spawn_does_not_auto_load_any_skill(kanban_home, monkeypatch):
     assert env.get("HERMES_PROFILE") == "some-profile"
 
 
+def test_skill_preflight_matches_worker_resolver(kanban_home, tmp_path):
+    """The dispatcher probe honors local, external, alias, and collision rules."""
+    skills_root = kanban_home / "skills"
+    local_skill = skills_root / "kanban-test-category" / "local-skill-for-kanban-test"
+    local_skill.mkdir(parents=True)
+    (local_skill / "SKILL.md").write_text(
+        "---\nname: local-skill-for-kanban-test\n---\nlocal\n",
+        encoding="utf-8",
+    )
+
+    external_root = tmp_path / "external-skills"
+    aliased = external_root / "filesystem-name"
+    aliased.mkdir(parents=True)
+    (aliased / "SKILL.md").write_text(
+        "---\nname: alias-skill-for-kanban-test\n---\nalias\n",
+        encoding="utf-8",
+    )
+    collision = external_root / "external-collision"
+    collision.mkdir(parents=True)
+    (collision / "SKILL.md").write_text(
+        "---\nname: collision-skill-for-kanban-test\n---\nexternal\n",
+        encoding="utf-8",
+    )
+    local_collision = skills_root / "local-collision"
+    local_collision.mkdir()
+    (local_collision / "SKILL.md").write_text(
+        "---\nname: collision-skill-for-kanban-test\n---\nlocal\n",
+        encoding="utf-8",
+    )
+    (kanban_home / "config.yaml").write_text(
+        f"skills:\n  external_dirs:\n    - {external_root}\n",
+        encoding="utf-8",
+    )
+
+    assert kb._skill_available_for_home(
+        "local-skill-for-kanban-test", str(kanban_home)
+    ) is True
+    assert kb._skill_available_for_home(
+        "alias-skill-for-kanban-test", str(kanban_home)
+    ) is True
+    assert kb._skill_available_for_home(
+        "collision-skill-for-kanban-test", str(kanban_home)
+    ) is False
+    assert kb._skill_available_for_home(
+        "missing-skill-for-kanban-test", str(kanban_home)
+    ) is False
+
+
+def test_default_spawn_drops_unresolvable_task_skills(kanban_home, monkeypatch, capfd):
+    """Only skills resolved by the real filesystem resolver reach child argv."""
+    skill = kanban_home / "skills" / "good-skill-for-kanban-test"
+    skill.mkdir(parents=True)
+    (skill / "SKILL.md").write_text(
+        "---\nname: good-skill-for-kanban-test\n---\nusable\n",
+        encoding="utf-8",
+    )
+    captured = {}
+
+    class FakeProc:
+        pid = 7
+
+    def fake_popen(cmd, **kwargs):
+        captured["cmd"] = cmd
+        return FakeProc()
+
+    monkeypatch.setattr("subprocess.Popen", fake_popen)
+
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(
+            conn,
+            title="real skill preflight",
+            assignee="some-profile",
+            skills=["good-skill-for-kanban-test", "missing-skill-for-kanban-test"],
+        )
+        task = kb.get_task(conn, tid)
+        assert task is not None
+        workspace = kb.resolve_workspace(task)
+        assert kb._default_spawn(task, str(workspace)) == 7
+    finally:
+        conn.close()
+
+    cmd = captured["cmd"]
+    skill_names = [
+        cmd[index + 1]
+        for index, token in enumerate(cmd)
+        if token == "--skills" and index + 1 < len(cmd)
+    ]
+    assert skill_names == ["good-skill-for-kanban-test"]
+    err = capfd.readouterr().err
+    assert "missing-skill-for-kanban-test" in err
+    assert tid in err
+
+
 # ---------------------------------------------------------------------------
 # Per-task force-loaded skills
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

The dispatcher already gates the built-in `--skills kanban-worker` injection on resolvability under the worker's `HERMES_HOME` (see `_kanban_worker_skill_available` at `hermes_cli/kanban_db.py:5202`). The reason is documented in that function's docstring: preloading a missing skill is fatal at CLI startup (`ValueError: Unknown skill(s): <name>`), aborting the worker before the agent loop runs.

But per-task `task.skills` entries (`hermes_cli/kanban_db.py:5387-5389` before this patch) were passed through unconditionally:

```python
if task.skills:
    for sk in task.skills:
        if sk and sk != "kanban-worker":
            cmd.extend(["--skills", sk])
```

So a task whose skill name only exists in the global skills root — not the profile-scoped one the worker actually loads — crash-loops the worker until the dispatcher's watchdog eventually auto-blocks it.

## Observed impact

A task with `skills=['mlflow-eval-datasets-for-llm-pipelines']` running under a profile-scoped `HERMES_HOME` respawned **1032 times** before being blocked manually, because the skill lives in `~/.hermes/skills/mlops/` but not in `~/.hermes/profiles/<name>/skills/mlops/`. The CLI fails inside `_apply_skills_overrides` before any tool can call `block`, so the lifecycle's normal error path never runs.

Watchdog auto-block fires far too late (hundreds of respawns) when the failure happens before the agent loop.

## Fix

- Generalize `_kanban_worker_skill_available()` into `_skill_available_for_home(skill_name, hermes_home)`. The legacy name is kept as a back-compat shim that delegates, so external callers (if any) aren't broken.
- Apply the same gate to every `task.skills` entry in `_default_spawn`. Skipped skills emit a single-line stderr warning naming the task id and the missing skill so operators triaging logs see why the worker did not pick up the requested skill. The task still proceeds — running without the supplementary skill context is strictly better than crash-looping until the watchdog gives up.

### Contract change

This is a deliberate **fail-fast → silent-skip-with-warning** shift for `task.skills`. Trade-off:

- Before: dispatcher trusts the caller, missing skill crashes the worker loudly (in the kanban log) but invisibly to the operator (until the auto-block triggers).
- After: dispatcher validates against the actual filesystem the worker will load, drops the unresolvable flag, warns on stderr, and lets the worker run. Operators see the warning in the kanban log alongside the worker's normal output.

If a stricter posture is preferred — e.g. `task.skills` is treated as a hard contract and should fail the task immediately — I'm happy to flip this to `kanban_db.block_task(...)` instead of a warning. The current behavior matches what `_kanban_worker_skill_available` already does for the built-in skill.

## Tests

- Existing tests (`test_default_spawn_appends_per_task_skills`, `test_default_spawn_dedupes_kanban_worker_from_task_skills`) updated to stub the new helper so synthetic skill names (`translation`, `github-code-review`) still resolve.
- New regression test `test_default_spawn_drops_unresolvable_task_skills` exercises the mixed-resolvability path: one resolvable skill + one missing skill, asserts only the resolvable one reaches argv, and asserts the stderr warning contains both the task id and the missing skill name.

```
56 passed, 269 deselected in 0.95s
```

(`spawn or skill` filter across `tests/hermes_cli/test_kanban_core_functionality.py` + `tests/hermes_cli/test_kanban_db.py`.)

## Files

- `hermes_cli/kanban_db.py` — generalize helper + gate `task.skills`
- `tests/hermes_cli/test_kanban_core_functionality.py` — stub new helper in existing tests + add regression test