### PR TITLE
fix(gateway): harden restart resume recovery

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1510,6 +1510,57 @@ def _last_transcript_timestamp(history: Optional[List[Dict[str, Any]]]) -> Any:
     return None
 
 
+def _last_usable_transcript_row(
+    history: Optional[List[Dict[str, Any]]],
+) -> Optional[Dict[str, Any]]:
+    """Return the last transcript row that would be replayed to the agent."""
+    if not history:
+        return None
+    for msg in reversed(history):
+        if not isinstance(msg, dict):
+            continue
+        role = msg.get("role")
+        if not role or role in {"session_meta", "system"}:
+            continue
+        return msg
+    return None
+
+
+def _last_user_message_id(
+    history: Optional[List[Dict[str, Any]]],
+) -> Optional[str]:
+    """Return the platform message id for the last persisted user turn."""
+    if not history:
+        return None
+    for msg in reversed(history):
+        if not isinstance(msg, dict) or msg.get("role") != "user":
+            continue
+        message_id = msg.get("message_id")
+        if message_id is None:
+            return None
+        text = str(message_id).strip()
+        return text or None
+    return None
+
+
+def _transcript_tail_is_completed_assistant(
+    history: Optional[List[Dict[str, Any]]],
+) -> bool:
+    """Return whether replayable history already ends in a final answer."""
+    msg = _last_usable_transcript_row(history)
+    if not msg or msg.get("role") != "assistant":
+        return False
+    if msg.get("tool_calls") or msg.get("function_call"):
+        return False
+    finish_reason = msg.get("finish_reason")
+    if finish_reason not in {"stop", "end_turn", "complete", "completed"}:
+        return False
+    content = msg.get("content")
+    if isinstance(content, str):
+        return bool(content.strip())
+    return bool(content)
+
+
 # Tool results can contain literal MEDIA: examples in docs, logs, or other
 # ordinary outputs. Only tools that intentionally create deliverable media
 # artifacts should be eligible for automatic append when the model omits them
@@ -9437,9 +9488,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         notified: set[tuple[str, str, Optional[str]]] = set()
         for session_key in active:
-            source = None
+            # The live cache carries the current inbound reply anchor; the
+            # persisted origin is intentionally long-lived and can be stale.
+            source = self._get_cached_session_source(session_key)
             try:
-                if getattr(self, "session_store", None) is not None:
+                if source is None and getattr(self, "session_store", None) is not None:
                     await self.async_session_store._ensure_loaded()
                     entry = self.session_store._entries.get(session_key)
                     source = getattr(entry, "origin", None) if entry else None
@@ -9449,9 +9502,6 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     session_key,
                     e,
                 )
-
-            if source is None:
-                source = self._get_cached_session_source(session_key)
 
             if source is not None:
                 platform_str = source.platform.value
@@ -10507,7 +10557,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 exc_info=(type(exc), exc, exc.__traceback__),
             )
 
-    async def _redeliver_pending_obligations(self) -> int:
+    async def _redeliver_pending_obligations(
+        self,
+        platform: Optional[Platform] = None,
+    ) -> int:
         """Redeliver final responses recorded in the delivery ledger by a
         previous (now dead) gateway process.
 
@@ -10538,8 +10591,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # holds a platform only after its connect() succeeded, and each
             # claim spends one of the row's three redelivery attempts.
             _deliverable = {
-                getattr(p, "value", str(p)) for p in self.adapters
+                getattr(p, "value", str(p))
+                for p in self.adapters
+                if platform is None or p == platform
             }
+            if not _deliverable:
+                return 0
             claimed = await asyncio.to_thread(
                 sweep_recoverable, None, deliverable_platforms=_deliverable
             )
@@ -10614,7 +10671,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     )
         return redelivered
 
-    def _schedule_resume_pending_sessions(self, platform=None) -> int:
+    async def _schedule_resume_pending_sessions(self, platform=None) -> int:
         """Auto-continue fresh restart-interrupted sessions after startup.
 
         ``resume_pending`` already preserves the transcript AND the existing
@@ -10639,16 +10696,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         """
         window = _auto_continue_freshness_window()
         try:
-            with self.session_store._lock:  # noqa: SLF001 — snapshot under lock
-                self.session_store._ensure_loaded_locked()  # noqa: SLF001
-                candidates = [
-                    entry for entry in self.session_store._entries.values()  # noqa: SLF001
-                    if entry.resume_pending
-                    and not entry.suspended
-                    and entry.origin is not None
-                    and entry.resume_reason in self._AUTO_RESUME_REASONS
-                    and (platform is None or entry.origin.platform == platform)
-                ]
+            candidates = [
+                entry
+                for entry in await self.async_session_store.list_resume_pending(
+                    platform=platform
+                )
+                if entry.resume_reason in self._AUTO_RESUME_REASONS
+            ]
         except Exception as exc:
             logger.warning("Failed to enumerate resume-pending sessions: %s", exc)
             return 0
@@ -10676,9 +10730,46 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         now = datetime.now()
         scheduled = 0
         for entry in candidates:
-            marker = entry.last_resume_marked_at or entry.updated_at
-            if marker is not None and (now - marker).total_seconds() > window:
+            effective_session_id = await self._effective_resume_session_id(entry)
+            history = None
+            try:
+                history = await self.async_session_store.load_transcript(
+                    effective_session_id
+                )
+                if not isinstance(history, list):
+                    history = None
+            except Exception:
+                logger.debug(
+                    "Failed to load transcript while checking auto-resume freshness for %s",
+                    entry.session_key,
+                    exc_info=True,
+                )
+
+            if _transcript_tail_is_completed_assistant(history):
+                try:
+                    await self.async_session_store.clear_resume_pending(
+                        entry.session_key
+                    )
+                except Exception:
+                    logger.debug(
+                        "clear stale resume_pending failed for %s",
+                        entry.session_key,
+                        exc_info=True,
+                    )
                 continue
+
+            transcript_ts = _last_transcript_timestamp(history)
+            if history:
+                if not _is_fresh_gateway_interruption(
+                    transcript_ts,
+                    now=now.timestamp(),
+                    window_secs=window,
+                ):
+                    continue
+            else:
+                marker = entry.last_resume_marked_at or entry.updated_at
+                if marker is not None and (now - marker).total_seconds() > window:
+                    continue
 
             # Already being resumed (e.g. scheduled at startup and still
             # in-flight) — don't synthesize a second continuation turn.
@@ -10686,6 +10777,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 continue
 
             source = entry.origin
+            resume_message_id = _last_user_message_id(history)
+            try:
+                source = dataclasses.replace(source, message_id=resume_message_id)
+            except Exception:
+                pass
             adapter = self._adapter_for_source(source)
             if adapter is None:
                 logger.debug(
@@ -10733,6 +10829,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 text="",
                 message_type=MessageType.TEXT,
                 source=source,
+                message_id=resume_message_id,
+                reply_to_message_id=resume_message_id,
                 internal=True,
             )
             task = asyncio.create_task(
@@ -10753,6 +10851,42 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 scheduled,
             )
         return scheduled
+
+    async def _effective_resume_session_id(self, entry) -> str:
+        """Return the transcript id an auto-resume would actually consume."""
+        session_id = str(getattr(entry, "session_id", "") or "")
+        source = getattr(entry, "origin", None)
+        session_db = getattr(self, "_session_db", None)
+        if (
+            source is None
+            or session_db is None
+            or getattr(source, "platform", None) != Platform.TELEGRAM
+            or getattr(source, "chat_type", None) != "dm"
+            or not getattr(source, "chat_id", None)
+            or not getattr(source, "thread_id", None)
+        ):
+            return session_id
+        try:
+            binding = await session_db.get_telegram_topic_binding(
+                chat_id=str(source.chat_id),
+                thread_id=str(source.thread_id),
+            )
+            bound_session_id = str((binding or {}).get("session_id") or "")
+            if not bound_session_id:
+                return session_id
+            try:
+                tip = await session_db.get_compression_tip(bound_session_id)
+            except Exception:
+                logger.debug(
+                    "Failed to resolve compression tip for Telegram topic resume binding %s",
+                    bound_session_id,
+                    exc_info=True,
+                )
+                tip = None
+            return str(tip or bound_session_id)
+        except Exception:
+            logger.debug("Failed to resolve Telegram topic resume binding", exc_info=True)
+            return session_id
 
     def _startup_should_abort(self) -> bool:
         return (
@@ -11656,7 +11790,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # that session) is strictly cheaper and more correct than re-running
         # the whole turn.
         await self._redeliver_pending_obligations()
-        self._schedule_resume_pending_sessions()
+        await self._schedule_resume_pending_sessions()
         await self._finish_startup_restore()
 
         # Drain any recovered process watchers (from crash recovery checkpoint)
@@ -12724,14 +12858,25 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         except Exception:
                             pass
 
-                        # A platform that was offline at gateway startup never
-                        # got its restart-interrupted sessions auto-resumed —
-                        # the startup pass skips sessions whose adapter isn't
-                        # connected yet. Now that it's back, retry the
-                        # auto-resume scoped to this platform so recovery
-                        # doesn't silently wait for a manual user message.
+                        # A platform that was offline at startup may have both
+                        # completed responses waiting in the durable ledger and
+                        # interrupted turns waiting to resume. Deliver stored
+                        # responses first so their resume markers are cleared
+                        # before considering another model turn.
                         try:
-                            self._schedule_resume_pending_sessions(platform=platform)
+                            await self._redeliver_pending_obligations(
+                                platform=platform
+                            )
+                        except Exception:
+                            logger.debug(
+                                "pending delivery redelivery after %s reconnect failed",
+                                platform.value,
+                                exc_info=True,
+                            )
+                        try:
+                            await self._schedule_resume_pending_sessions(
+                                platform=platform
+                            )
                         except Exception:
                             logger.debug(
                                 "resume-pending reschedule after %s reconnect failed",

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -12225,7 +12225,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 logger.debug("delivery ledger update failed", exc_info=True)
         return redelivered
 
-    async def _redeliver_pending_obligations(self) -> int:
+    async def _redeliver_pending_obligations(
+        self,
+        platform: Optional[Platform] = None,
+    ) -> int:
         """Claim + redeliver in one call — composition of
         :meth:`_claim_pending_obligations` and
         :meth:`_redeliver_claimed_obligations`.
@@ -12235,7 +12238,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         so the DB half can run inline before the abandonable send task.
         """
         return await self._redeliver_claimed_obligations(
-            await self._claim_pending_obligations()
+            await self._claim_pending_obligations(platform=platform)
         )
 
     async def _schedule_resume_pending_sessions(self, platform=None) -> int:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -12087,7 +12087,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             task, "background boot-path send failed after gate release: see traceback"
         )
 
-    async def _claim_pending_obligations(self) -> list:
+    async def _claim_pending_obligations(
+        self,
+        platform: Optional[Platform] = None,
+    ) -> list:
         """Claim recoverable delivery-ledger rows and clear their
         ``resume_pending`` flags. Pure DB work — no network sends.
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1744,6 +1744,57 @@ def _last_transcript_timestamp(history: Optional[List[Dict[str, Any]]]) -> Any:
     return None
 
 
+def _last_usable_transcript_row(
+    history: Optional[List[Dict[str, Any]]],
+) -> Optional[Dict[str, Any]]:
+    """Return the last transcript row that would be replayed to the agent."""
+    if not history:
+        return None
+    for msg in reversed(history):
+        if not isinstance(msg, dict):
+            continue
+        role = msg.get("role")
+        if not role or role in {"session_meta", "system"}:
+            continue
+        return msg
+    return None
+
+
+def _last_user_message_id(
+    history: Optional[List[Dict[str, Any]]],
+) -> Optional[str]:
+    """Return the platform message id for the last persisted user turn."""
+    if not history:
+        return None
+    for msg in reversed(history):
+        if not isinstance(msg, dict) or msg.get("role") != "user":
+            continue
+        message_id = msg.get("message_id")
+        if message_id is None:
+            return None
+        text = str(message_id).strip()
+        return text or None
+    return None
+
+
+def _transcript_tail_is_completed_assistant(
+    history: Optional[List[Dict[str, Any]]],
+) -> bool:
+    """Return whether replayable history already ends in a final answer."""
+    msg = _last_usable_transcript_row(history)
+    if not msg or msg.get("role") != "assistant":
+        return False
+    if msg.get("tool_calls") or msg.get("function_call"):
+        return False
+    finish_reason = msg.get("finish_reason")
+    if finish_reason not in {"stop", "end_turn", "complete", "completed"}:
+        return False
+    content = msg.get("content")
+    if isinstance(content, str):
+        return bool(content.strip())
+    return bool(content)
+
+
 # Tool results can contain literal MEDIA: examples in docs, logs, or other
 # ordinary outputs. Only tools that intentionally create deliverable media
 # artifacts should be eligible for automatic append when the model omits them
@@ -10846,9 +10897,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         notified: set[tuple[str, str, Optional[str]]] = set()
         for session_key in active:
-            source = None
+            # The live cache carries the current inbound reply anchor; the
+            # persisted origin is intentionally long-lived and can be stale.
+            source = self._get_cached_session_source(session_key)
             try:
-                if getattr(self, "session_store", None) is not None:
+                if source is None and getattr(self, "session_store", None) is not None:
                     await self.async_session_store._ensure_loaded()
                     entry = self.session_store._entries.get(session_key)
                     source = getattr(entry, "origin", None) if entry else None
@@ -10858,9 +10911,6 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     session_key,
                     e,
                 )
-
-            if source is None:
-                source = self._get_cached_session_source(session_key)
 
             if source is not None:
                 platform_str = source.platform.value
@@ -12066,8 +12116,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # holds a platform only after its connect() succeeded, and each
             # claim spends one of the row's three redelivery attempts.
             _deliverable = {
-                getattr(p, "value", str(p)) for p in self.adapters
+                getattr(p, "value", str(p))
+                for p in self.adapters
+                if platform is None or p == platform
             }
+            if not _deliverable:
+                return 0
             claimed = await asyncio.to_thread(
                 sweep_recoverable, None, deliverable_platforms=_deliverable
             )
@@ -12181,7 +12235,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             await self._claim_pending_obligations()
         )
 
-    def _schedule_resume_pending_sessions(self, platform=None) -> int:
+    async def _schedule_resume_pending_sessions(self, platform=None) -> int:
         """Auto-continue fresh restart-interrupted sessions after startup.
 
         ``resume_pending`` already preserves the transcript AND the existing
@@ -12206,16 +12260,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         """
         window = _auto_continue_freshness_window()
         try:
-            with self.session_store._lock:  # noqa: SLF001 — snapshot under lock
-                self.session_store._ensure_loaded_locked()  # noqa: SLF001
-                candidates = [
-                    entry for entry in self.session_store._entries.values()  # noqa: SLF001
-                    if entry.resume_pending
-                    and not entry.suspended
-                    and entry.origin is not None
-                    and entry.resume_reason in self._AUTO_RESUME_REASONS
-                    and (platform is None or entry.origin.platform == platform)
-                ]
+            candidates = [
+                entry
+                for entry in await self.async_session_store.list_resume_pending(
+                    platform=platform
+                )
+                if entry.resume_reason in self._AUTO_RESUME_REASONS
+            ]
         except Exception as exc:
             logger.warning("Failed to enumerate resume-pending sessions: %s", exc)
             return 0
@@ -12245,9 +12296,46 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         now = datetime.now()
         scheduled = 0
         for entry in candidates:
-            marker = entry.last_resume_marked_at or entry.updated_at
-            if marker is not None and (now - marker).total_seconds() > window:
+            effective_session_id = await self._effective_resume_session_id(entry)
+            history = None
+            try:
+                history = await self.async_session_store.load_transcript(
+                    effective_session_id
+                )
+                if not isinstance(history, list):
+                    history = None
+            except Exception:
+                logger.debug(
+                    "Failed to load transcript while checking auto-resume freshness for %s",
+                    entry.session_key,
+                    exc_info=True,
+                )
+
+            if _transcript_tail_is_completed_assistant(history):
+                try:
+                    await self.async_session_store.clear_resume_pending(
+                        entry.session_key
+                    )
+                except Exception:
+                    logger.debug(
+                        "clear stale resume_pending failed for %s",
+                        entry.session_key,
+                        exc_info=True,
+                    )
                 continue
+
+            transcript_ts = _last_transcript_timestamp(history)
+            if history:
+                if not _is_fresh_gateway_interruption(
+                    transcript_ts,
+                    now=now.timestamp(),
+                    window_secs=window,
+                ):
+                    continue
+            else:
+                marker = entry.last_resume_marked_at or entry.updated_at
+                if marker is not None and (now - marker).total_seconds() > window:
+                    continue
 
             # Already being resumed (e.g. scheduled at startup and still
             # in-flight) — don't synthesize a second continuation turn.
@@ -12255,6 +12343,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 continue
 
             source = entry.origin
+            resume_message_id = _last_user_message_id(history)
+            try:
+                source = dataclasses.replace(source, message_id=resume_message_id)
+            except Exception:
+                pass
             adapter = self._adapter_for_source(source)
             if adapter is None:
                 logger.debug(
@@ -12302,6 +12395,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 text="",
                 message_type=MessageType.TEXT,
                 source=source,
+                message_id=resume_message_id,
+                reply_to_message_id=resume_message_id,
                 internal=True,
             )
             task = asyncio.create_task(
@@ -12322,6 +12417,42 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 scheduled,
             )
         return scheduled
+
+    async def _effective_resume_session_id(self, entry) -> str:
+        """Return the transcript id an auto-resume would actually consume."""
+        session_id = str(getattr(entry, "session_id", "") or "")
+        source = getattr(entry, "origin", None)
+        session_db = getattr(self, "_session_db", None)
+        if (
+            source is None
+            or session_db is None
+            or getattr(source, "platform", None) != Platform.TELEGRAM
+            or getattr(source, "chat_type", None) != "dm"
+            or not getattr(source, "chat_id", None)
+            or not getattr(source, "thread_id", None)
+        ):
+            return session_id
+        try:
+            binding = await session_db.get_telegram_topic_binding(
+                chat_id=str(source.chat_id),
+                thread_id=str(source.thread_id),
+            )
+            bound_session_id = str((binding or {}).get("session_id") or "")
+            if not bound_session_id:
+                return session_id
+            try:
+                tip = await session_db.get_compression_tip(bound_session_id)
+            except Exception:
+                logger.debug(
+                    "Failed to resolve compression tip for Telegram topic resume binding %s",
+                    bound_session_id,
+                    exc_info=True,
+                )
+                tip = None
+            return str(tip or bound_session_id)
+        except Exception:
+            logger.debug("Failed to resolve Telegram topic resume binding", exc_info=True)
+            return session_id
 
     def _startup_should_abort(self) -> bool:
         return (
@@ -13318,7 +13449,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # a session whose final response was generated but never
         # confirmed-delivered has its answer in the ledger — redelivering it
         # is strictly cheaper and more correct than re-running the whole turn.
-        self._schedule_resume_pending_sessions()
+        await self._schedule_resume_pending_sessions()
         await self._finish_startup_restore()
 
         # Surface state.db init failures to the user's messaging platforms
@@ -14597,14 +14728,25 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         except Exception:
                             pass
 
-                        # A platform that was offline at gateway startup never
-                        # got its restart-interrupted sessions auto-resumed —
-                        # the startup pass skips sessions whose adapter isn't
-                        # connected yet. Now that it's back, retry the
-                        # auto-resume scoped to this platform so recovery
-                        # doesn't silently wait for a manual user message.
+                        # A platform that was offline at startup may have both
+                        # completed responses waiting in the durable ledger and
+                        # interrupted turns waiting to resume. Deliver stored
+                        # responses first so their resume markers are cleared
+                        # before considering another model turn.
                         try:
-                            self._schedule_resume_pending_sessions(platform=platform)
+                            await self._redeliver_pending_obligations(
+                                platform=platform
+                            )
+                        except Exception:
+                            logger.debug(
+                                "pending delivery redelivery after %s reconnect failed",
+                                platform.value,
+                                exc_info=True,
+                            )
+                        try:
+                            await self._schedule_resume_pending_sessions(
+                                platform=platform
+                            )
                         except Exception:
                             logger.debug(
                                 "resume-pending reschedule after %s reconnect failed",

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -1438,6 +1438,24 @@ class SessionStore:
         with self._lock:
             self._ensure_loaded_locked()
 
+    def list_resume_pending(
+        self, platform: Optional[Platform] = None
+    ) -> List[SessionEntry]:
+        """Return a stable snapshot of restart-interrupted routing entries."""
+        with self._lock:
+            self._ensure_loaded_locked()
+            return [
+                replace(entry)
+                for entry in self._entries.values()
+                if entry.resume_pending
+                and not entry.suspended
+                and entry.origin is not None
+                and (
+                    platform is None
+                    or entry.origin.platform == platform
+                )
+            ]
+
     def _routing_scope(self) -> str:
         """Namespace for this store's rows in the gateway_routing table.
 

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -1318,6 +1318,24 @@ class SessionStore:
         with self._lock:
             self._ensure_loaded_locked()
 
+    def list_resume_pending(
+        self, platform: Optional[Platform] = None
+    ) -> List[SessionEntry]:
+        """Return a stable snapshot of restart-interrupted routing entries."""
+        with self._lock:
+            self._ensure_loaded_locked()
+            return [
+                replace(entry)
+                for entry in self._entries.values()
+                if entry.resume_pending
+                and not entry.suspended
+                and entry.origin is not None
+                and (
+                    platform is None
+                    or entry.origin.platform == platform
+                )
+            ]
+
     def _routing_scope(self) -> str:
         """Namespace for this store's rows in the gateway_routing table.
 

--- a/tests/gateway/restart_test_helpers.py
+++ b/tests/gateway/restart_test_helpers.py
@@ -158,6 +158,24 @@ def make_restart_runner(
     runner.pairing_store = MagicMock()
     runner.session_store = MagicMock()
     runner.session_store._entries = {}
+    runner.session_store._ensure_loaded = MagicMock()
+    runner.session_store.load_transcript = MagicMock(return_value=[])
+    runner._async_session_store = MagicMock()
+    runner._async_session_store._store = runner.session_store
+    runner._async_session_store._ensure_loaded = AsyncMock()
+    runner._async_session_store.list_resume_pending = AsyncMock(
+        side_effect=lambda platform=None: [
+            entry
+            for entry in runner.session_store._entries.values()
+            if entry.resume_pending
+            and not entry.suspended
+            and entry.origin is not None
+            and (platform is None or entry.origin.platform == platform)
+        ]
+    )
+    runner._async_session_store.load_transcript = AsyncMock(return_value=[])
+    runner._async_session_store.clear_resume_pending = AsyncMock()
+    runner._session_db = None
     runner.delivery_router = MagicMock()
 
     platform_adapter = adapter or RestartTestAdapter()

--- a/tests/gateway/restart_test_helpers.py
+++ b/tests/gateway/restart_test_helpers.py
@@ -156,6 +156,24 @@ def make_restart_runner(
     runner.pairing_store = MagicMock()
     runner.session_store = MagicMock()
     runner.session_store._entries = {}
+    runner.session_store._ensure_loaded = MagicMock()
+    runner.session_store.load_transcript = MagicMock(return_value=[])
+    runner._async_session_store = MagicMock()
+    runner._async_session_store._store = runner.session_store
+    runner._async_session_store._ensure_loaded = AsyncMock()
+    runner._async_session_store.list_resume_pending = AsyncMock(
+        side_effect=lambda platform=None: [
+            entry
+            for entry in runner.session_store._entries.values()
+            if entry.resume_pending
+            and not entry.suspended
+            and entry.origin is not None
+            and (platform is None or entry.origin.platform == platform)
+        ]
+    )
+    runner._async_session_store.load_transcript = AsyncMock(return_value=[])
+    runner._async_session_store.clear_resume_pending = AsyncMock()
+    runner._session_db = None
     runner.delivery_router = MagicMock()
 
     platform_adapter = adapter or RestartTestAdapter()

--- a/tests/gateway/test_platform_reconnect.py
+++ b/tests/gateway/test_platform_reconnect.py
@@ -227,7 +227,13 @@ class TestPlatformReconnectWatcher:
         """
         runner = _make_runner()
         runner._sync_voice_mode_state_to_adapter = MagicMock()
-        runner._schedule_resume_pending_sessions = MagicMock(return_value=1)
+        order = []
+        runner._redeliver_pending_obligations = AsyncMock(
+            side_effect=lambda **_: order.append("ledger") or 1
+        )
+        runner._schedule_resume_pending_sessions = AsyncMock(
+            side_effect=lambda **_: order.append("resume") or 1
+        )
 
         platform_config = PlatformConfig(enabled=True, token="test")
         runner._failed_platforms[Platform.TELEGRAM] = {
@@ -258,9 +264,13 @@ class TestPlatformReconnectWatcher:
                 await run_one_iteration()
 
         assert Platform.TELEGRAM in runner.adapters
-        runner._schedule_resume_pending_sessions.assert_called_once_with(
+        runner._redeliver_pending_obligations.assert_awaited_once_with(
             platform=Platform.TELEGRAM
         )
+        runner._schedule_resume_pending_sessions.assert_awaited_once_with(
+            platform=Platform.TELEGRAM
+        )
+        assert order == ["ledger", "resume"]
 
 
     @pytest.mark.asyncio

--- a/tests/gateway/test_restart_resume_async_salvage.py
+++ b/tests/gateway/test_restart_resume_async_salvage.py
@@ -1,0 +1,132 @@
+"""Current-architecture regressions salvaged from PR #30030."""
+
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.config import Platform
+from gateway.platforms.base import MessageEvent, SendResult
+from gateway.run import GatewayRunner
+from gateway.session import SessionEntry, SessionSource
+from tests.gateway.restart_test_helpers import make_restart_runner
+
+
+def _pending_entry(*, session_id="sid", thread_id="topic"):
+    now = datetime.now()
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        user_id="u1",
+        chat_id="c1",
+        chat_type="dm",
+        thread_id=thread_id,
+        message_id="stale-anchor",
+    )
+    return SessionEntry(
+        session_key="agent:main:telegram:dm:u1",
+        session_id=session_id,
+        created_at=now,
+        updated_at=now,
+        origin=source,
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+        resume_pending=True,
+        resume_reason="restart_timeout",
+        last_resume_marked_at=now,
+    )
+
+
+@pytest.mark.asyncio
+async def test_resume_uses_async_store_and_latest_user_reply_anchor():
+    runner, adapter = make_restart_runner()
+    entry = _pending_entry()
+    runner.session_store._entries = {entry.session_key: entry}
+    runner._async_session_store.load_transcript = AsyncMock(
+        return_value=[
+            {"role": "user", "content": "old", "message_id": "111", "timestamp": datetime.now().timestamp()},
+            {"role": "assistant", "content": "working", "finish_reason": "tool_calls"},
+            {"role": "user", "content": "latest", "message_id": "222", "timestamp": datetime.now().timestamp()},
+        ]
+    )
+    captured = []
+
+    async def _capture(event):
+        captured.append(event)
+
+    adapter.handle_message = _capture
+    scheduled = await runner._schedule_resume_pending_sessions()
+    await __import__("asyncio").sleep(0)
+
+    assert scheduled == 1
+    assert captured
+    event = captured[0]
+    assert isinstance(event, MessageEvent)
+    assert event.message_id == "222"
+    assert event.reply_to_message_id == "222"
+    assert event.source.message_id == "222"
+    runner._async_session_store.load_transcript.assert_awaited_once_with("sid")
+
+
+@pytest.mark.asyncio
+async def test_resume_follows_topic_binding_compression_tip():
+    runner, adapter = make_restart_runner()
+    entry = _pending_entry(session_id="routing-parent")
+    runner.session_store._entries = {entry.session_key: entry}
+    runner._session_db = MagicMock()
+    runner._session_db.get_telegram_topic_binding = AsyncMock(
+        return_value={"session_id": "bound-parent"}
+    )
+    runner._session_db.get_compression_tip = AsyncMock(return_value="bound-child")
+    runner._async_session_store.load_transcript = AsyncMock(
+        return_value=[
+            {"role": "user", "content": "continue", "message_id": "333", "timestamp": datetime.now().timestamp()}
+        ]
+    )
+    adapter.handle_message = AsyncMock()
+
+    assert await runner._schedule_resume_pending_sessions() == 1
+    runner._async_session_store.load_transcript.assert_awaited_once_with("bound-child")
+
+
+@pytest.mark.asyncio
+async def test_completed_assistant_tail_clears_marker_without_rerun():
+    runner, adapter = make_restart_runner()
+    entry = _pending_entry()
+    runner.session_store._entries = {entry.session_key: entry}
+    runner._async_session_store.load_transcript = AsyncMock(
+        return_value=[
+            {"role": "user", "content": "question", "message_id": "444", "timestamp": datetime.now().timestamp()},
+            {"role": "assistant", "content": "done", "finish_reason": "stop", "timestamp": datetime.now().timestamp()},
+        ]
+    )
+    adapter.handle_message = AsyncMock()
+
+    assert await runner._schedule_resume_pending_sessions() == 0
+    runner._async_session_store.clear_resume_pending.assert_awaited_once_with(
+        entry.session_key
+    )
+    adapter.handle_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_shutdown_notification_prefers_live_reply_anchor():
+    runner, adapter = make_restart_runner()
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        user_id="u1",
+        chat_id="c1",
+        chat_type="dm",
+        thread_id="topic",
+        message_id="live-anchor",
+    )
+    key = "agent:main:telegram:dm:u1"
+    runner._running_agents = {key: object()}
+    runner._cache_session_source(key, source)
+    runner.session_store._entries[key] = _pending_entry()
+    adapter.send = AsyncMock(return_value=SendResult(success=True))
+
+    await runner._notify_active_sessions_of_shutdown()
+
+    metadata = adapter.send.await_args.kwargs["metadata"]
+    assert metadata["telegram_reply_to_message_id"] == "live-anchor"
+    runner._async_session_store._ensure_loaded.assert_not_awaited()

--- a/tests/gateway/test_restart_resume_pending.py
+++ b/tests/gateway/test_restart_resume_pending.py
@@ -606,7 +606,7 @@ async def test_startup_auto_resume_skips_unauthorized_owner():
     runner.session_store._entries = {pending_entry.session_key: pending_entry}
     adapter.handle_message = AsyncMock()
 
-    scheduled = runner._schedule_resume_pending_sessions()
+    scheduled = await runner._schedule_resume_pending_sessions()
     await asyncio.sleep(0)
 
     assert scheduled == 0
@@ -656,7 +656,9 @@ async def test_reconnect_reschedule_is_platform_scoped():
     adapter.handle_message = AsyncMock()
     runner.adapters = {Platform.TELEGRAM: adapter}
 
-    scheduled = runner._schedule_resume_pending_sessions(platform=Platform.TELEGRAM)
+    scheduled = await runner._schedule_resume_pending_sessions(
+        platform=Platform.TELEGRAM
+    )
     await asyncio.sleep(0)
 
     # Only the telegram session is resumed; the discord session waits for its
@@ -703,7 +705,7 @@ async def test_startup_restore_waits_for_resume_before_draining_inbound():
 
     adapter.handle_message = fake_handle_message
 
-    scheduled = runner._schedule_resume_pending_sessions()
+    scheduled = await runner._schedule_resume_pending_sessions()
     await asyncio.sleep(0)
 
     inbound = MessageEvent(
@@ -859,7 +861,7 @@ async def test_auto_resume_sets_sentinel_before_task_execution():
 
     adapter.handle_message = _slow_handle
 
-    scheduled = runner._schedule_resume_pending_sessions()
+    scheduled = await runner._schedule_resume_pending_sessions()
 
     assert scheduled == 1
     # The sentinel must be set immediately — before the task starts executing.
@@ -958,7 +960,7 @@ async def test_auto_resume_runs_agent_exactly_once_through_full_path():
     )
     adapter._run_processing_hook = AsyncMock()
 
-    scheduled = runner._schedule_resume_pending_sessions()
+    scheduled = await runner._schedule_resume_pending_sessions()
     assert scheduled == 1
     # Pre-claim must be visible immediately.
     assert runner._running_agents.get(session_key) is _AGENT_PENDING_SENTINEL

--- a/tests/gateway/test_restart_resume_pending.py
+++ b/tests/gateway/test_restart_resume_pending.py
@@ -643,7 +643,7 @@ async def test_startup_auto_resume_skips_unauthorized_owner():
     runner.session_store._entries = {pending_entry.session_key: pending_entry}
     adapter.handle_message = AsyncMock()
 
-    scheduled = runner._schedule_resume_pending_sessions()
+    scheduled = await runner._schedule_resume_pending_sessions()
     await asyncio.sleep(0)
 
     assert scheduled == 0
@@ -693,7 +693,9 @@ async def test_reconnect_reschedule_is_platform_scoped():
     adapter.handle_message = AsyncMock()
     runner.adapters = {Platform.TELEGRAM: adapter}
 
-    scheduled = runner._schedule_resume_pending_sessions(platform=Platform.TELEGRAM)
+    scheduled = await runner._schedule_resume_pending_sessions(
+        platform=Platform.TELEGRAM
+    )
     await asyncio.sleep(0)
 
     # Only the telegram session is resumed; the discord session waits for its
@@ -740,7 +742,7 @@ async def test_startup_restore_waits_for_resume_before_draining_inbound():
 
     adapter.handle_message = fake_handle_message
 
-    scheduled = runner._schedule_resume_pending_sessions()
+    scheduled = await runner._schedule_resume_pending_sessions()
     await asyncio.sleep(0)
 
     inbound = MessageEvent(
@@ -896,7 +898,7 @@ async def test_auto_resume_sets_sentinel_before_task_execution():
 
     adapter.handle_message = _slow_handle
 
-    scheduled = runner._schedule_resume_pending_sessions()
+    scheduled = await runner._schedule_resume_pending_sessions()
 
     assert scheduled == 1
     # The sentinel must be set immediately — before the task starts executing.
@@ -995,7 +997,7 @@ async def test_auto_resume_runs_agent_exactly_once_through_full_path():
     )
     adapter._run_processing_hook = AsyncMock()
 
-    scheduled = runner._schedule_resume_pending_sessions()
+    scheduled = await runner._schedule_resume_pending_sessions()
     assert scheduled == 1
     # Pre-claim must be visible immediately.
     assert runner._running_agents.get(session_key) is _AGENT_PENDING_SENTINEL


### PR DESCRIPTION
## Summary

Refreshes restart-resume recovery for the current async session architecture.

- Enumerate restart-interrupted sessions through a public `SessionStore.list_resume_pending()` snapshot and the `AsyncSessionStore` facade; the gateway no longer takes the store lock or reads `_entries` directly on the event loop.
- Load transcript freshness and reply anchors through `AsyncSessionStore.load_transcript()`.
- Resolve Telegram DM topic bindings and compression tips before selecting the transcript that recovery will consume.
- Anchor the synthetic resume event to the latest persisted user message, not a stale long-lived routing origin.
- Clear `resume_pending` without a new model turn when the transcript already ends in a completed assistant response.
- Preserve the pre-claim sentinel so inbound messages cannot race a startup resume into a duplicate agent.
- On platform reconnect, redeliver completed ledger obligations before scheduling interrupted turns, scoped to that platform.
- Prefer the live cached source for shutdown/restart notifications so topic replies target the current inbound message.

## Verification

Immutable current-main test archive:
- restart/resume/reconnect/delivery suites: **102 passed**
- Ruff, `py_compile`, and `git diff --check`: passed

Fixes #10163.
Related: #23314, #29713, #46963, #46997.
