### PR TITLE
fix(kanban): close board count connections in boards list

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -15,6 +15,7 @@ Exposes the full Kanban command surface documented in the design spec
 from __future__ import annotations
 
 import argparse
+import contextlib
 import json
 import os
 import shlex
@@ -987,7 +988,10 @@ def _board_task_counts(slug: str) -> dict[str, int]:
         path = kb.kanban_db_path(board=slug)
         if not path.exists():
             return {}
-        with kb.connect(board=slug) as conn:
+        # ``sqlite3.Connection.__enter__`` manages only transaction scope; it
+        # does not close the DB handle. boards list can touch many board DBs in
+        # one long-lived process (gateway/web UI), so close explicitly here.
+        with contextlib.closing(kb.connect(board=slug)) as conn:
             rows = conn.execute(
                 "SELECT status, COUNT(*) AS n FROM tasks GROUP BY status"
             ).fetchall()

--- a/tests/hermes_cli/test_kanban_boards.py
+++ b/tests/hermes_cli/test_kanban_boards.py
@@ -28,6 +28,7 @@ _WORKTREE = Path(__file__).resolve().parents[2]
 if str(_WORKTREE) not in sys.path:
     sys.path.insert(0, str(_WORKTREE))
 
+from hermes_cli import kanban as kc
 from hermes_cli import kanban_db as kb
 
 
@@ -557,3 +558,41 @@ class TestCLI:
         res = _cli(["boards", "list", "--json"], env_extra=env)
         slugs = [b["slug"] for b in json.loads(res.stdout)]
         assert "rmme" not in slugs
+
+
+class TestBoardTaskCounts:
+    def test_board_task_counts_closes_sqlite_like_connection(self, tmp_path, monkeypatch):
+        db_path = tmp_path / "board.db"
+        db_path.write_text("", encoding="utf-8")
+
+        class FakeRow(dict):
+            pass
+
+        class FakeConn:
+            def __init__(self):
+                self.closed = False
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def execute(self, *_args, **_kwargs):
+                class _Cursor:
+                    def fetchall(self_inner):
+                        return [FakeRow(status="todo", n=2), FakeRow(status="done", n=1)]
+
+                return _Cursor()
+
+            def close(self):
+                self.closed = True
+
+        fake = FakeConn()
+        monkeypatch.setattr(kc.kb, "kanban_db_path", lambda board=None: db_path)
+        monkeypatch.setattr(kc.kb, "connect", lambda board=None: fake)
+
+        counts = kc._board_task_counts("alpha")
+
+        assert counts == {"todo": 2, "done": 1}
+        assert fake.closed is True


### PR DESCRIPTION
Fixes #30027

`hermes kanban boards list` currently leaks sqlite file descriptors across boards in long-lived processes.

The root cause is `_board_task_counts()` in `hermes_cli.kanban`, which uses `with kb.connect(board=slug) as conn:`. For `sqlite3.Connection`, that pattern manages transaction scope but does not close the handle.

Since `boards list` calls that helper once per board, per-board `kanban.db`, `kanban.db-wal`, and `kanban.db-shm` handles can accumulate in a single process.

This patch switches that read path to explicit closing and adds regression coverage for sqlite-like connections whose context manager does not call `close()`.

Validation:
`uv run --extra dev pytest tests/hermes_cli/test_kanban_boards.py -q -k 'board_task_counts_closes_sqlite_like_connection or boards_list_default_only or boards_create_and_switch'`

Result:
`3 passed in 10.36s`

Live repro before fix:
`{'base': 5, 'after': 68, 'delta': 63, 'boards': 21}`

Live repro after fix:
`{'base': 5, 'after': 5, 'delta': 0, 'boards': 21}`