### PR TITLE
fix(agent): ignore stale local base_url for direct providers

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -340,6 +340,35 @@ def init_agent(
     except Exception:
         pass
 
+    # If a direct API-key provider is selected, a leftover local custom base URL
+    # from a previous gateway/subscription route must not override the provider
+    # registry endpoint.  This bit the Nous -> DeepSeek migration: config kept
+    # model.base_url=http://localhost:8081/v1, so Hermes sent DeepSeek's model
+    # slug to the stale local LiteLLM/Z.AI route and failed with "Unknown Model".
+    # Clear the local override and let resolve_provider_client() pick the
+    # provider's canonical endpoint (e.g. https://api.deepseek.com/v1).
+    try:
+        from hermes_cli.auth import PROVIDER_REGISTRY
+
+        _base_host = urlparse(agent.base_url or "").hostname or ""
+        if (
+            agent.provider in PROVIDER_REGISTRY
+            and agent.provider not in {"custom", "openrouter"}
+            and _base_host in {"localhost", "127.0.0.1", "::1"}
+        ):
+            logger.warning(
+                "Ignoring local model.base_url %s for direct provider %s; "
+                "using provider registry endpoint instead",
+                agent.base_url,
+                agent.provider,
+            )
+            agent.base_url = ""
+            agent.api_key = ""
+            base_url = ""
+            api_key = ""
+    except Exception:
+        logger.debug("Provider localhost base_url guard skipped", exc_info=True)
+
     # GPT-5.x models usually require the Responses API path, but some
     # providers have exceptions (for example Copilot's gpt-5-mini still
     # uses chat completions). Also auto-upgrade for direct OpenAI URLs

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -52,6 +52,37 @@ def test_is_destructive_command_treats_install_as_mutating():
     assert run_agent._is_destructive_command("install template.env .env") is True
 
 
+def test_direct_provider_ignores_stale_local_base_url():
+    """Direct providers should not reuse stale localhost gateway URLs.
+
+    Regression for Nous -> DeepSeek migration: model.base_url still pointed at a
+    stale local LiteLLM-style gateway route, so the direct DeepSeek provider
+    sent deepseek-v4-pro to the wrong upstream and failed with a Z.AI Unknown Model.
+    """
+    routed = SimpleNamespace(api_key="dummy", base_url="https://api.deepseek.com/v1")
+
+    with (
+        patch("agent.agent_init.get_tool_definitions", return_value=_make_tool_defs("web_search")),
+        patch("agent.agent_init.check_toolset_requirements", return_value={}),
+        patch("agent.auxiliary_client.resolve_provider_client", return_value=(routed, "deepseek-v4-pro")) as resolve,
+        patch("run_agent.OpenAI") as openai_cls,
+    ):
+        AIAgent(
+            api_key="dummy",
+            base_url="http://localhost:8081/v1",
+            provider="deepseek",
+            model="deepseek/deepseek-v4-pro",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+
+    resolve.assert_any_call("deepseek", model="deepseek-v4-pro", raw_codex=True)
+    _, kwargs = openai_cls.call_args
+    assert kwargs["base_url"] == "https://api.deepseek.com/v1"
+    assert kwargs["api_key"] == "dummy"
+
+
 @pytest.fixture()
 def agent():
     """Minimal AIAgent with mocked OpenAI client and tool loading."""


### PR DESCRIPTION
## Summary

- Ignore stale loopback `model.base_url` values when a direct API-key provider from `PROVIDER_REGISTRY` is selected.
- Clear the stale local override before client construction so `resolve_provider_client()` uses the provider's canonical endpoint.
- Add a regression test for migrating to `deepseek` with an old `http://localhost:8081/v1` base URL.

Fixes #30033

## Test plan

- `python -m pytest tests/run_agent/test_run_agent.py::test_direct_provider_ignores_stale_local_base_url -q -o addopts=`
- `python -m pytest tests/run_agent/test_run_agent.py -q -o addopts=`
- `python -m py_compile agent/agent_init.py tests/run_agent/test_run_agent.py`

## Notes

This is intentionally narrow: it only handles loopback URLs (`localhost`, `127.0.0.1`, `::1`) for direct registry providers, and leaves custom/aggregator routing behavior unchanged.