### PR TITLE
fix(ci): clear latest main blockers

### DIFF
--- a/tests/hermes_cli/test_tui_npm_install.py
+++ b/tests/hermes_cli/test_tui_npm_install.py
@@ -168,7 +168,7 @@ def test_make_tui_argv_skips_build_only_on_termux_when_fresh(
 
     argv, cwd = main_mod._make_tui_argv(tmp_path, tui_dev=False)
 
-    assert argv == ["/bin/node", str(tmp_path / "dist" / "entry.js")]
+    assert argv == ["/bin/node", "--expose-gc", str(tmp_path / "dist" / "entry.js")]
     assert cwd == tmp_path
 
 

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -12564,19 +12564,6 @@
         "uuid": "^11.1.0 || ^12 || ^13 || ^14.0.0"
       }
     },
-    "node_modules/mermaid/node_modules/uuid": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/esm/bin/uuid"
-      }
-    },
     "node_modules/methods": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
@@ -16895,15 +16882,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "^5.1.0"
-      }
-    },
     "node_modules/range-parser": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
@@ -17921,12 +17899,12 @@
       }
     },
     "node_modules/serialize-javascript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.5.tgz",
+      "integrity": "sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==",
       "license": "BSD-3-Clause",
-      "dependencies": {
-        "randombytes": "^2.1.0"
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/serve-handler": {
@@ -19405,12 +19383,16 @@
       }
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/value-equal": {

--- a/website/package.json
+++ b/website/package.json
@@ -34,6 +34,10 @@
     "@docusaurus/types": "3.9.2",
     "typescript": "~5.6.2"
   },
+  "overrides": {
+    "serialize-javascript": "^7.0.5",
+    "uuid": "^14.0.0"
+  },
   "browserslist": {
     "production": [
       ">0.5%",


### PR DESCRIPTION
## What does this PR do?

Unblocks the current `main` CI failures on `0ce12a9241051621af4c3406a27bb793bb3154d7`.

- Updates the TUI npm-install regression expectation now that `_make_tui_argv()` intentionally passes `--expose-gc` on the wheel-bundled launch path.
- Pins safe transitive versions for the website lockfile so the current Dependabot audit failures for `serialize-javascript` and `uuid` are gone without taking broad dependency upgrades.

## Related Issue

No issue. Current `main` CI unblocker.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tests/hermes_cli/test_tui_npm_install.py`
  - Updates the fresh Termux wheel-bundled launch assertion to include `--expose-gc`, matching the current runtime contract after `fix(tui): also pass --expose-gc on the wheel-bundled launch path` landed.
- `website/package.json`
  - Adds narrow npm `overrides` for `serialize-javascript` and `uuid`.
- `website/package-lock.json`
  - Refreshes the lockfile so `serialize-javascript` resolves to `7.0.5` and `uuid` resolves to `14.0.0`.

## How to Test

1. Reproduce current main failure with `scripts/run_tests.sh tests/hermes_cli/test_tui_npm_install.py -- -q --tb=short` on `main`.
2. Run the focused test after this PR.
3. Run website audit validation and verify `uuid`, `serialize-javascript`, `sockjs`, `copy-webpack-plugin`, and `css-minimizer-webpack-plugin` are absent from the audit vulnerability map.
4. Build the website with the updated lockfile.

## Validation Status

Local validation on Arch Linux, Node v22.22.2, npm 11.14.1:

- [x] `scripts/run_tests.sh tests/hermes_cli/test_tui_npm_install.py -- -q --tb=short`, 15 passed
- [x] `venv/bin/python -m py_compile tests/hermes_cli/test_tui_npm_install.py`
- [x] `venv/bin/python -m ruff check tests/hermes_cli/test_tui_npm_install.py`
- [x] `npm --prefix website audit --package-lock-only --json`, current blockers absent (`uuid`, `serialize-javascript`, `sockjs`, `copy-webpack-plugin`, `css-minimizer-webpack-plugin`)
- [x] `cd website && npm ci --ignore-scripts --no-audit --no-fund && npm run build`
- [x] `git diff --check`

Note: `npm run build` still prints existing Docusaurus broken-link warnings, but exits successfully.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Arch Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A

## Screenshots / Logs

Current `main` blockers at the time this PR was opened:

- `test`, failing `tests/hermes_cli/test_tui_npm_install.py::test_make_tui_argv_skips_build_only_on_termux_when_fresh`
- `Dependabot`, failing on vulnerable website transitives including `serialize-javascript` and `uuid`
