### PR TITLE
fix: improve telegram clarify choice buttons

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -384,6 +384,21 @@ class TelegramAdapter(BasePlatformAdapter):
             value = min(value, max_value)
         return value
 
+    @staticmethod
+    def _clarify_button_label(index: int, choice: object, *, max_len: int = 40) -> str:
+        """Build a readable Telegram inline-button label for a clarify choice.
+
+        Telegram caps callback payload size, not button text, but long labels are
+        heavily truncated on mobile.  Include the option number plus a compact
+        preview so the buttons are usable without relying on the plain-text list.
+        """
+        label = " ".join(str(choice).split()) or "Option"
+        prefix = f"{index + 1}. "
+        available = max(1, max_len - len(prefix))
+        if len(label) > available:
+            label = label[: max(1, available - 1)].rstrip() + "…"
+        return f"{prefix}{label}"
+
     @property
     def message_len_fn(self):
         """Telegram measures message length in UTF-16 code units."""
@@ -2529,8 +2544,8 @@ class TelegramAdapter(BasePlatformAdapter):
             if choices:
                 # Render full option text in the message body so mobile
                 # users can read long choices that would be truncated in
-                # inline button labels.  Buttons keep short numeric labels
-                # (1, 2, …, Other) to avoid Telegram truncation.
+                # inline button labels.  Buttons include option numbers plus
+                # compact previews while callback_data stays short.
                 option_lines = "\n".join(
                     f"{i + 1}. {_html.escape(str(c))}"
                     for i, c in enumerate(choices)
@@ -2551,7 +2566,7 @@ class TelegramAdapter(BasePlatformAdapter):
                 for idx in range(len(choices)):
                     rows.append([
                         InlineKeyboardButton(
-                            str(idx + 1),
+                            self._clarify_button_label(idx, choices[idx]),
                             callback_data=f"cl:{clarify_id}:{idx}",
                         )
                     ])

--- a/tests/gateway/test_telegram_clarify_buttons.py
+++ b/tests/gateway/test_telegram_clarify_buttons.py
@@ -150,7 +150,8 @@ class TestTelegramSendClarify:
     @pytest.mark.asyncio
     async def test_long_choice_rendered_in_body_not_truncated(self):
         """Long choice text appears in full in the message body;
-        button labels stay short numeric (1, 2, …)."""
+        button labels include option numbers plus compact previews while
+        callback_data stays short."""
         adapter = _make_adapter()
         mock_msg = MagicMock()
         mock_msg.message_id = 102
@@ -168,9 +169,18 @@ class TestTelegramSendClarify:
         kwargs = adapter._bot.send_message.call_args[1]
         # The full long choice text appears in the message body
         assert long_choice in kwargs["text"]
-        # The button label should be short ("1"), not the long choice
-        # (we can't inspect mock button labels directly, but the send
-        # succeeded — old truncation code could raise on edge cases)
+        # Button labels include a compact option preview; callbacks remain
+        # short (cl:<id>:<idx>) to stay under Telegram's 64-byte payload cap.
+
+    def test_clarify_button_labels_show_option_preview_and_truncate(self):
+        assert TelegramAdapter._clarify_button_label(0, "alpha") == "1. alpha"
+        label = TelegramAdapter._clarify_button_label(1, "x" * 200)
+        assert label.startswith("2. ")
+        assert label.endswith("…")
+        assert len(label) <= 40
+
+    def test_clarify_button_label_normalizes_whitespace(self):
+        assert TelegramAdapter._clarify_button_label(2, "  beta\n gamma  ") == "3. beta gamma"
 
     @pytest.mark.asyncio
     async def test_html_escapes_question(self):

--- a/tests/tools/test_clarify.py
+++ b/tests/tools/test_clarify.py
@@ -1,0 +1,50 @@
+"""Focused clarify availability/dispatch tests.
+
+This file intentionally keeps the short historical name ``test_clarify.py`` so
+focused commands that target it exercise the real ``tools/clarify_tool.py``
+implementation instead of failing with "file not found".
+"""
+
+import json
+
+from tools.registry import discover_builtin_tools, registry
+
+
+def test_clarify_tool_is_discoverable_and_registered():
+    imported = discover_builtin_tools()
+
+    assert "tools.clarify_tool" in imported
+    entry = registry.get_entry("clarify")
+    assert entry is not None
+    assert entry.toolset == "clarify"
+    assert entry.check_fn() is True
+
+
+def test_clarify_registry_handler_uses_callback_and_returns_response():
+    import tools.clarify_tool  # noqa: F401 - ensure registry side effect has run
+
+    entry = registry.get_entry("clarify")
+    assert entry is not None
+
+    result = json.loads(
+        entry.handler(
+            {"question": "Pick?", "choices": ["one", "two"]},
+            callback=lambda question, choices: choices[1],
+        )
+    )
+
+    assert result["question"] == "Pick?"
+    assert result["choices_offered"] == ["one", "two"]
+    assert result["user_response"] == "two"
+
+
+def test_clarify_registry_handler_reports_unavailable_without_callback():
+    import tools.clarify_tool  # noqa: F401 - ensure registry side effect has run
+
+    entry = registry.get_entry("clarify")
+    assert entry is not None
+
+    result = json.loads(entry.handler({"question": "Pick?"}))
+
+    assert "error" in result
+    assert "not available" in result["error"]


### PR DESCRIPTION
## Summary

- Improve Telegram clarify inline button labels so each choice button shows the option number plus a compact preview of the choice text.
- Keep Telegram callback payloads short (`cl:<clarify_id>:<idx>`) to stay safely under Telegram's callback_data limit.
- Add focused regression coverage for Telegram clarify button labels and clarify tool discoverability/dispatch.

## Why

Before this change, Telegram clarify buttons were hard to use because the inline buttons did not preserve enough visible context for each choice. The plain-text list still contained the full options, but the button row itself was less self-explanatory on mobile.

This keeps the safe callback payload design while making the buttons readable.

## Test plan

- [x] `/home/fgpaz/.hermes/hermes-agent/venv/bin/python -m pytest -o 'addopts=' tests/gateway/test_telegram_clarify_buttons.py tests/tools/test_clarify.py -q`
- [x] Result: `17 passed`

## Notes

This PR intentionally does not change callback semantics. It only changes button label generation and adds tests.
