### PR TITLE
feat: add git projects dashboard workflow

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -11,10 +11,12 @@ Usage:
 
 import asyncio
 import hmac
+import hashlib
 import importlib.util
 import json
 import logging
 import os
+import re
 import secrets
 import subprocess
 import sys
@@ -474,6 +476,350 @@ class ModelAssignment(BaseModel):
     task: str = ""
 
 
+class ProjectIssueCreate(BaseModel):
+    title: str
+    body: str = ""
+    kind: str = "issue"
+    severity: str = "normal"
+    labels: List[str] = []
+    parent_task_ids: List[str] = []
+
+
+class ProjectImportRequest(BaseModel):
+    repo_url: str
+    branch: str = ""
+
+
+class ProjectSourceControlRequest(BaseModel):
+    action: str
+    branch: str = ""
+    create_from: str = ""
+
+
+_PROJECT_SCAN_SKIP_DIRS: frozenset[str] = frozenset({
+    ".git", ".hg", ".svn", ".cache", ".pytest_cache", ".mypy_cache",
+    "__pycache__", "node_modules", "venv", ".venv", "env", ".env",
+    "dist", "build", "out", "target", "bin", "obj", "coverage",
+})
+_PROJECT_SCAN_MAX_DEPTH = 4
+_PROJECT_SCAN_MAX_REPOS = 120
+
+
+def _managed_project_root() -> Path:
+    return Path(get_hermes_home()) / "dashboard-projects"
+
+
+def _repo_slug_from_url(repo_url: str) -> str:
+    cleaned = repo_url.strip().rstrip("/").removesuffix(".git")
+    match = re.search(r"github\.com[:/]([^/]+)/([^/#?]+)$", cleaned)
+    if match:
+        return f"{match.group(1)}-{match.group(2)}"
+    tail = re.sub(r"[^A-Za-z0-9_.-]+", "-", cleaned.split("/")[-1] or "project")
+    return tail.strip("-._") or f"project-{secrets.token_hex(3)}"
+
+
+def _validate_repo_url(repo_url: str) -> str:
+    repo_url = repo_url.strip()
+    if not repo_url:
+        raise HTTPException(status_code=400, detail="Repository URL is required")
+    if re.match(r"^(https://|git@)[^\s]+$", repo_url):
+        return repo_url
+    raise HTTPException(status_code=400, detail="Use an HTTPS or SSH git repository URL")
+
+
+def _project_issue_store_path() -> Path:
+    return Path(get_hermes_home()) / "dashboard-project-issues.json"
+
+
+def _load_project_issues() -> Dict[str, List[Dict[str, Any]]]:
+    path = _project_issue_store_path()
+    if not path.exists():
+        return {}
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        if isinstance(data, dict):
+            return {str(k): v for k, v in data.items() if isinstance(v, list)}
+    except Exception as exc:
+        _log.warning("Failed to read dashboard project issue store %s: %s", path, exc)
+    return {}
+
+
+def _save_project_issues(data: Dict[str, List[Dict[str, Any]]]) -> None:
+    path = _project_issue_store_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(json.dumps(data, indent=2, sort_keys=True), encoding="utf-8")
+    tmp.replace(path)
+
+
+def _project_id_for_path(path: Path) -> str:
+    return hashlib.sha1(str(path.resolve()).encode("utf-8", "ignore")).hexdigest()[:12]
+
+
+def _safe_git(path: Path, args: List[str], timeout: float = 2.5) -> str:
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(path), *args],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+    except Exception:
+        return ""
+    if result.returncode != 0:
+        return ""
+    return result.stdout.strip()
+
+
+def _normalise_github_remote(remote: str) -> Dict[str, str | None]:
+    remote = remote.strip()
+    if not remote:
+        return {"repo_url": None, "issues_url": None, "releases_url": None, "new_issue_url": None}
+
+    owner_repo: str | None = None
+    https_match = re.match(r"https://github\.com/([^/]+/[^/#]+?)(?:\.git)?/?$", remote)
+    ssh_match = re.match(r"git@github\.com:([^/]+/[^/#]+?)(?:\.git)?$", remote)
+    if https_match:
+        owner_repo = https_match.group(1)
+    elif ssh_match:
+        owner_repo = ssh_match.group(1)
+
+    if not owner_repo:
+        return {"repo_url": remote, "issues_url": None, "releases_url": None, "new_issue_url": None}
+
+    owner_repo = owner_repo.removesuffix(".git")
+    repo_url = f"https://github.com/{owner_repo}"
+    return {
+        "repo_url": repo_url,
+        "issues_url": f"{repo_url}/issues",
+        "releases_url": f"{repo_url}/releases",
+        "new_issue_url": f"{repo_url}/issues/new",
+    }
+
+
+def _default_project_roots() -> List[Path]:
+    roots: List[Path] = []
+    home = Path.home()
+    cwd = Path.cwd()
+    candidates = [
+        _managed_project_root(),
+        home / "projects",
+        home / "repos",
+        home / "workspace",
+        PROJECT_ROOT,
+        cwd,
+    ]
+    windows_users = Path("/mnt/c/Users")
+    if windows_users.exists():
+        for user_dir in windows_users.iterdir():
+            if not user_dir.is_dir():
+                continue
+            candidates.extend([
+                user_dir / "projects",
+                user_dir / "repos",
+                user_dir / "source" / "repos",
+                user_dir / "Documents" / "GitHub",
+            ])
+    seen: set[str] = set()
+    for candidate in candidates:
+        try:
+            resolved = candidate.resolve()
+        except Exception:
+            continue
+        key = str(resolved)
+        if key not in seen and resolved.exists() and resolved.is_dir():
+            seen.add(key)
+            roots.append(resolved)
+    return roots
+
+
+def _discover_git_repos() -> List[Path]:
+    repos: List[Path] = []
+    seen: set[str] = set()
+
+    def add_repo(path: Path) -> bool:
+        try:
+            resolved = path.resolve()
+        except Exception:
+            return False
+        key = str(resolved)
+        if key in seen:
+            return False
+        seen.add(key)
+        repos.append(resolved)
+        return len(repos) >= _PROJECT_SCAN_MAX_REPOS
+
+    def walk(path: Path, depth: int) -> bool:
+        if depth > _PROJECT_SCAN_MAX_DEPTH:
+            return False
+        try:
+            entries = list(path.iterdir())
+        except Exception:
+            return False
+        if any(e.name == ".git" for e in entries):
+            return add_repo(path)
+        for entry in entries:
+            if len(repos) >= _PROJECT_SCAN_MAX_REPOS:
+                return True
+            if not entry.is_dir():
+                continue
+            if entry.name in _PROJECT_SCAN_SKIP_DIRS:
+                continue
+            if entry.name.startswith(".") and entry.name not in {".hermes"}:
+                continue
+            if walk(entry, depth + 1):
+                return True
+        return False
+
+    for root in _default_project_roots():
+        if len(repos) >= _PROJECT_SCAN_MAX_REPOS:
+            break
+        walk(root, 0)
+    return sorted(repos, key=lambda p: p.name.lower())
+
+
+def _project_from_repo(path: Path, issues: Dict[str, List[Dict[str, Any]]]) -> Dict[str, Any]:
+    project_id = _project_id_for_path(path)
+    name = path.name
+    branch = _safe_git(path, ["branch", "--show-current"]) or _safe_git(path, ["rev-parse", "--short", "HEAD"])
+    remote = _safe_git(path, ["remote", "get-url", "origin"])
+    remote_links = _normalise_github_remote(remote)
+    latest_commit = _safe_git(path, ["log", "-1", "--format=%h"])
+    latest_commit_message = _safe_git(path, ["log", "-1", "--format=%s"])
+    last_commit_at = _safe_git(path, ["log", "-1", "--format=%cI"])
+    dirty = bool(_safe_git(path, ["status", "--porcelain"], timeout=3.5))
+    branches_raw = _safe_git(path, ["branch", "--format=%(refname:short)"], timeout=3.5)
+    branches = [line.strip() for line in branches_raw.splitlines() if line.strip()]
+    upstream = _safe_git(path, ["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"], timeout=2.5)
+    ahead = behind = 0
+    if upstream:
+        counts = _safe_git(path, ["rev-list", "--left-right", "--count", f"{upstream}...HEAD"], timeout=3.5).split()
+        if len(counts) == 2:
+            try:
+                behind, ahead = int(counts[0]), int(counts[1])
+            except ValueError:
+                behind = ahead = 0
+    project_issues = issues.get(project_id, [])
+    open_issues = [i for i in project_issues if i.get("status", "open") == "open"]
+    bug_reports = [i for i in open_issues if i.get("kind") == "bug"]
+
+    return {
+        "id": project_id,
+        "name": name,
+        "path": str(path),
+        "branch": branch or None,
+        "dirty": dirty,
+        "remote_url": remote or None,
+        **remote_links,
+        "branches": branches,
+        "upstream": upstream or None,
+        "ahead": ahead,
+        "behind": behind,
+        "managed": str(path).startswith(str(_managed_project_root())),
+        "latest_commit": latest_commit or None,
+        "latest_commit_message": latest_commit_message or None,
+        "last_commit_at": last_commit_at or None,
+        "issue_counts": {
+            "open": len(open_issues),
+            "bugs": len(bug_reports),
+            "total": len(project_issues),
+        },
+        "issues": sorted(project_issues, key=lambda i: i.get("created_at", ""), reverse=True)[:8],
+    }
+
+
+def _project_by_id(project_id: str) -> Dict[str, Any] | None:
+    payload = _dashboard_projects_payload()
+    return next((p for p in payload["projects"] if p["id"] == project_id), None)
+
+
+def _infer_issue_skills(issue: ProjectIssueCreate, project: Dict[str, Any]) -> List[str]:
+    text = " ".join([issue.kind, issue.title, issue.body, " ".join(issue.labels)]).lower()
+    skills = ["zeo-development-superpowers"]
+    if any(word in text for word in ("bug", "error", "fail", "broken", "traceback", "exception", "regression")):
+        skills.append("systematic-debugging")
+    if any(word in text for word in ("test", "coverage", "acceptance", "feature", "task", "bug")):
+        skills.append("test-driven-development")
+    if project.get("repo_url"):
+        skills.append("github-pr-workflow")
+    skills.append("requesting-code-review")
+    deduped: List[str] = []
+    for skill in skills:
+        if skill not in deduped:
+            deduped.append(skill)
+    return deduped
+
+
+def _create_issue_todo(record: Dict[str, Any], project: Dict[str, Any], issue: ProjectIssueCreate) -> Dict[str, Any]:
+    skills = _infer_issue_skills(issue, project)
+    assignee = os.getenv("HERMES_DASHBOARD_PROJECT_ASSIGNEE", "default")
+    branch_slug = re.sub(r"[^a-zA-Z0-9._-]+", "-", record["title"].lower()).strip("-._")[:48] or record["id"]
+    branch_name = f"issue/{record['id'].replace('local-', '')}-{branch_slug}"[:90]
+    body_parts = [
+        f"Resolve dashboard issue `{record['id']}` for project `{project['name']}`.",
+        f"Project path: {project['path']}",
+        f"Source branch now: {project.get('branch') or 'unknown'}",
+        f"Recommended working branch: {branch_name}",
+        "",
+        record["body"] or "No details provided.",
+    ]
+    try:
+        from hermes_cli import kanban_db
+
+        kanban_db.init_db()
+        conn = kanban_db.connect()
+        try:
+            task_id = kanban_db.create_task(
+                conn,
+                title=f"Resolve {project['name']}: {record['title']}",
+                body="\n".join(body_parts),
+                assignee=assignee,
+                created_by="dashboard",
+                workspace_kind="dir",
+                workspace_path=project["path"],
+                tenant=project["id"],
+                priority={"low": -1, "normal": 0, "high": 10, "critical": 25}.get(record["severity"], 0),
+                parents=tuple(pid.strip() for pid in issue.parent_task_ids if pid.strip()),
+                idempotency_key=f"dashboard-project-issue:{record['id']}",
+                skills=skills,
+            )
+        finally:
+            conn.close()
+        return {
+            "system": "kanban",
+            "task_id": task_id,
+            "assignee": assignee,
+            "skills": skills,
+            "workspace_kind": "dir",
+            "workspace_path": project["path"],
+            "recommended_branch": branch_name,
+            "parents": [pid.strip() for pid in issue.parent_task_ids if pid.strip()],
+        }
+    except Exception as exc:
+        _log.warning("Failed to create kanban todo for dashboard issue %s: %s", record.get("id"), exc)
+        return {
+            "system": "kanban",
+            "error": str(exc),
+            "assignee": assignee,
+            "skills": skills,
+            "workspace_kind": "dir",
+            "workspace_path": project["path"],
+            "recommended_branch": branch_name,
+        }
+
+
+def _dashboard_projects_payload() -> Dict[str, Any]:
+    issues = _load_project_issues()
+    projects = [_project_from_repo(path, issues) for path in _discover_git_repos()]
+    return {
+        "projects": projects,
+        "roots": [str(p) for p in _default_project_roots()],
+        "issue_store_path": str(_project_issue_store_path()),
+        "scan_limit": _PROJECT_SCAN_MAX_REPOS,
+    }
+
+
 _GATEWAY_HEALTH_URL = os.getenv("GATEWAY_HEALTH_URL")
 try:
     _GATEWAY_HEALTH_TIMEOUT = float(os.getenv("GATEWAY_HEALTH_TIMEOUT", "3"))
@@ -711,6 +1057,120 @@ def _tail_lines(path: Path, n: int) -> List[str]:
         return []
     lines = text.splitlines()
     return lines[-n:] if n > 0 else lines
+
+
+@app.get("/api/projects")
+async def list_projects():
+    """Discover accessible local git projects for the dashboard Projects tab."""
+    return _dashboard_projects_payload()
+
+
+@app.post("/api/projects/import")
+async def import_project(request: ProjectImportRequest):
+    repo_url = _validate_repo_url(request.repo_url)
+    root = _managed_project_root()
+    root.mkdir(parents=True, exist_ok=True)
+    dest = root / _repo_slug_from_url(repo_url)
+    if dest.exists() and not (dest / ".git").exists():
+        raise HTTPException(status_code=409, detail=f"Destination exists and is not a git repo: {dest}")
+
+    if (dest / ".git").exists():
+        result = subprocess.run(["git", "-C", str(dest), "fetch", "--all", "--prune"], capture_output=True, text=True, timeout=120)
+    else:
+        cmd = ["git", "clone"]
+        if request.branch.strip():
+            cmd.extend(["--branch", request.branch.strip()])
+        cmd.extend([repo_url, str(dest)])
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=300)
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout or "git operation failed").strip()[-2000:]
+        raise HTTPException(status_code=400, detail=detail)
+
+    issues = _load_project_issues()
+    project = _project_from_repo(dest, issues)
+    return {"ok": True, "project": project, "message": "Repository is available locally"}
+
+
+@app.post("/api/projects/{project_id}/source-control")
+async def project_source_control(project_id: str, request: ProjectSourceControlRequest):
+    project = _project_by_id(project_id)
+    if project is None:
+        raise HTTPException(status_code=404, detail="Project not found")
+    path = Path(project["path"])
+    action = request.action.strip().lower()
+    branch = request.branch.strip()
+    allowed: Dict[str, List[str]] = {
+        "fetch": ["fetch", "--all", "--prune"],
+        "pull": ["pull", "--ff-only"],
+        "push": ["push", "-u", "origin", project.get("branch") or "HEAD"],
+    }
+    if action == "checkout":
+        if not branch:
+            raise HTTPException(status_code=400, detail="Branch is required")
+        cmd = ["checkout", branch]
+    elif action == "create_branch":
+        if not branch:
+            raise HTTPException(status_code=400, detail="Branch is required")
+        cmd = ["checkout", "-b", branch]
+        if request.create_from.strip():
+            cmd.append(request.create_from.strip())
+    elif action in allowed:
+        cmd = allowed[action]
+    else:
+        raise HTTPException(status_code=400, detail="Unsupported source-control action")
+    result = subprocess.run(["git", "-C", str(path), *cmd], capture_output=True, text=True, timeout=180)
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout or "git command failed").strip()[-2000:]
+        raise HTTPException(status_code=400, detail=detail)
+    refreshed = _project_by_id(project_id) or project
+    return {"ok": True, "project": refreshed, "stdout": result.stdout.strip(), "stderr": result.stderr.strip()}
+
+
+@app.post("/api/projects/{project_id}/issues")
+async def create_project_issue(project_id: str, issue: ProjectIssueCreate):
+    title = issue.title.strip()
+    if not title:
+        raise HTTPException(status_code=400, detail="Issue title is required")
+
+    payload = _dashboard_projects_payload()
+    project = next((p for p in payload["projects"] if p["id"] == project_id), None)
+    if project is None:
+        raise HTTPException(status_code=404, detail="Project not found")
+
+    now = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+    labels = [str(label).strip() for label in issue.labels if str(label).strip()]
+    if issue.kind and issue.kind not in labels:
+        labels.insert(0, issue.kind)
+    record = {
+        "id": f"local-{int(time.time())}-{secrets.token_hex(3)}",
+        "project_id": project_id,
+        "project_name": project["name"],
+        "title": title,
+        "body": issue.body.strip(),
+        "kind": issue.kind.strip() or "issue",
+        "severity": issue.severity.strip() or "normal",
+        "labels": labels,
+        "status": "open",
+        "created_at": now,
+        "source": "dashboard",
+    }
+    record["todo"] = _create_issue_todo(record, project, issue)
+
+    data = _load_project_issues()
+    data.setdefault(project_id, []).append(record)
+    _save_project_issues(data)
+
+    repo_new_issue_url = project.get("new_issue_url")
+    if repo_new_issue_url:
+        body = record["body"]
+        if body:
+            body = f"{body}\n\nLogged locally in Hermes dashboard as `{record['id']}`."
+        else:
+            body = f"Logged locally in Hermes dashboard as `{record['id']}`."
+        qs = urllib.parse.urlencode({"title": title, "body": body, "labels": ",".join(labels)})
+        record["github_new_issue_url"] = f"{repo_new_issue_url}?{qs}"
+
+    return {"ok": True, "issue": record}
 
 
 @app.post("/api/gateway/restart")

--- a/plugins/hermes-git-projects/README.md
+++ b/plugins/hermes-git-projects/README.md
@@ -1,0 +1,81 @@
+# Hermes Git Projects
+
+Hermes Git Projects turns the Hermes dashboard into a lightweight project intake and source-control workbench.
+
+It is built for the workflow where an operator pastes a repository URL, Hermes creates or refreshes a local clone, scans the repository into a useful project card, logs issues against that local workspace, and creates actionable Kanban todos with suggested skills attached.
+
+## What it adds
+
+- Repository URL import from HTTPS or SSH Git remotes.
+- Managed local clones under `$HERMES_HOME/hermes-git-projects/repos/`.
+- Conservative project scanning with branch, remote, dirty state, ahead/behind, latest commit, and detected stack files.
+- Source-control actions: fetch, fast-forward pull, push current branch, checkout branch, create branch.
+- Local issue logging for each imported project.
+- Automatic Kanban todo creation when an issue is saved.
+- Suggested-skill storage so users can review, select, and extend the skills Hermes should attach to project work.
+- A dashboard tab called **Git Projects** backed by protected localhost dashboard APIs.
+
+## Why this exists
+
+Hermes can already edit files and use Git, but users need a clean intake layer for real projects. This plugin makes "paste repo URL → ready local workspace → log issue → create work item → branch/push changes" a first-class dashboard flow.
+
+## Storage layout
+
+All plugin state is profile-safe and lives under `get_hermes_home()`:
+
+```text
+$HERMES_HOME/hermes-git-projects/
+├── repos/                    # managed local clones
+├── issues.json               # local issue records + linked Kanban todo metadata
+└── suggested-skills.json     # editable suggested-skill catalog
+```
+
+No credentials or tokens are stored by the plugin. Git authentication is delegated to the user's existing Git/SSH/GitHub CLI setup.
+
+## Dashboard API
+
+Mounted at `/api/plugins/hermes-git-projects/`:
+
+- `GET /summary` — projects, issues, suggested skills, and storage paths.
+- `POST /import` — clone/fetch a repo URL and return scanned project metadata.
+- `POST /projects/{project_id}/source-control` — fetch, pull, push, checkout, or create branch.
+- `POST /projects/{project_id}/issues` — save a local issue and create a Kanban todo.
+- `GET /suggested-skills` — read the skill catalog.
+- `PUT /suggested-skills` — replace the skill catalog.
+
+## Suggested skills
+
+The default catalog is intentionally conservative:
+
+- `zeo-development-superpowers`
+- `systematic-debugging`
+- `test-driven-development`
+- `requesting-code-review`
+- `github-pr-workflow`
+- `github-code-review`
+- `github-repo-management`
+- `writing-plans`
+- `subagent-driven-development`
+
+Users can select a subset per issue in the dashboard. The selected skills are stored on the local issue and sent to Kanban task creation when available.
+
+## Installation
+
+As a bundled plugin, this directory can live under `plugins/hermes-git-projects/` in the Hermes repo. For a user-local install, copy the directory to:
+
+```text
+~/.hermes/plugins/hermes-git-projects/
+```
+
+Then restart `hermes dashboard` or use the dashboard plugin rescan endpoint.
+
+## Verification
+
+From the Hermes repo root:
+
+```bash
+python3 -m py_compile plugins/hermes-git-projects/dashboard/plugin_api.py
+hermes dashboard --no-open --skip-build
+```
+
+Then open the dashboard and use the **Git Projects** tab.

--- a/plugins/hermes-git-projects/__init__.py
+++ b/plugins/hermes-git-projects/__init__.py
@@ -1,0 +1,13 @@
+"""Hermes Git Projects plugin.
+
+This standalone plugin is primarily a dashboard extension. It intentionally
+registers no chat tools: project import, issue logging, source-control actions,
+and suggested-skill management live under the dashboard plugin API and UI.
+"""
+
+from __future__ import annotations
+
+
+def register(ctx) -> None:
+    """No-op CLI/gateway registration hook for plugin discovery."""
+    return None

--- a/plugins/hermes-git-projects/dashboard/dist/index.js
+++ b/plugins/hermes-git-projects/dashboard/dist/index.js
@@ -1,0 +1,264 @@
+(function () {
+  const SDK = window.__HERMES_PLUGIN_SDK__;
+  if (!SDK || !window.__HERMES_PLUGINS__) return;
+
+  const React = SDK.React;
+  const h = React.createElement;
+  const useState = SDK.hooks.useState;
+  const useEffect = SDK.hooks.useEffect;
+  const C = SDK.components || {};
+  const Card = C.Card || 'div';
+  const CardHeader = C.CardHeader || 'div';
+  const CardTitle = C.CardTitle || 'h2';
+  const CardContent = C.CardContent || 'div';
+  const Button = C.Button || 'button';
+  const Input = C.Input || 'input';
+  const Label = C.Label || 'label';
+  const Badge = C.Badge || 'span';
+  const Separator = C.Separator || 'hr';
+  const fetchJSON = SDK.fetchJSON;
+
+  const api = {
+    summary: () => fetchJSON('/api/plugins/hermes-git-projects/summary'),
+    importRepo: (payload) => fetchJSON('/api/plugins/hermes-git-projects/import', { method: 'POST', body: JSON.stringify(payload) }),
+    source: (id, payload) => fetchJSON('/api/plugins/hermes-git-projects/projects/' + encodeURIComponent(id) + '/source-control', { method: 'POST', body: JSON.stringify(payload) }),
+    issue: (id, payload) => fetchJSON('/api/plugins/hermes-git-projects/projects/' + encodeURIComponent(id) + '/issues', { method: 'POST', body: JSON.stringify(payload) }),
+    saveSkills: (skills) => fetchJSON('/api/plugins/hermes-git-projects/suggested-skills', { method: 'PUT', body: JSON.stringify({ skills }) }),
+  };
+
+  function cx() { return Array.from(arguments).filter(Boolean).join(' '); }
+  function small(text, className) { return h('div', { className: cx('text-xs text-muted-foreground', className) }, text); }
+  function badge(text, variant) { return h(Badge, { variant: variant || 'secondary', className: 'mr-1 mb-1' }, text); }
+
+  function GitProjectsPage() {
+    const [loading, setLoading] = useState(true);
+    const [busy, setBusy] = useState('');
+    const [error, setError] = useState('');
+    const [data, setData] = useState(null);
+    const [selectedId, setSelectedId] = useState('');
+    const [repoUrl, setRepoUrl] = useState('');
+    const [importBranch, setImportBranch] = useState('');
+    const [branchName, setBranchName] = useState('');
+    const [issue, setIssue] = useState({ title: '', body: '', kind: 'bug', severity: 'medium', labels: '', parent_task_ids: '', selected_skills: [] });
+    const [skillDraft, setSkillDraft] = useState(null);
+
+    function refresh(selectId) {
+      setLoading(true);
+      setError('');
+      return api.summary().then((payload) => {
+        setData(payload);
+        setSkillDraft(payload.suggested_skills || []);
+        if (selectId) setSelectedId(selectId);
+        else if (!selectedId && payload.projects && payload.projects[0]) setSelectedId(payload.projects[0].id);
+      }).catch((err) => setError(String(err && err.message || err))).finally(() => setLoading(false));
+    }
+
+    useEffect(() => { refresh(); }, []);
+
+    const projects = (data && data.projects) || [];
+    const selected = projects.find((p) => p.id === selectedId) || projects[0];
+    const skills = skillDraft || [];
+
+    function run(label, fn) {
+      setBusy(label);
+      setError('');
+      return fn().catch((err) => setError(String(err && err.message || err))).finally(() => setBusy(''));
+    }
+
+    function importRepo(e) {
+      e.preventDefault();
+      if (!repoUrl.trim()) return;
+      run('Importing repository...', () => api.importRepo({ repo_url: repoUrl.trim(), branch: importBranch.trim() || null }).then((payload) => {
+        setRepoUrl('');
+        setImportBranch('');
+        return refresh(payload.project && payload.project.id);
+      }));
+    }
+
+    function sourceAction(action) {
+      if (!selected) return;
+      const payload = { action, branch: (action === 'checkout' || action === 'create_branch') ? branchName.trim() : null };
+      run(action + '...', () => api.source(selected.id, payload).then((payload) => {
+        if (payload.project) setSelectedId(payload.project.id);
+        return refresh(selected.id);
+      }));
+    }
+
+    function toggleSkill(name) {
+      const current = issue.selected_skills || [];
+      const next = current.includes(name) ? current.filter((s) => s !== name) : current.concat([name]);
+      setIssue(Object.assign({}, issue, { selected_skills: next }));
+    }
+
+    function createIssue(e) {
+      e.preventDefault();
+      if (!selected || !issue.title.trim()) return;
+      const labels = issue.labels.split(',').map((s) => s.trim()).filter(Boolean);
+      const parents = issue.parent_task_ids.split(',').map((s) => s.trim()).filter(Boolean);
+      const selectedSkills = (issue.selected_skills && issue.selected_skills.length) ? issue.selected_skills : null;
+      run('Creating issue todo...', () => api.issue(selected.id, {
+        title: issue.title,
+        body: issue.body,
+        kind: issue.kind,
+        severity: issue.severity,
+        labels,
+        parent_task_ids: parents,
+        selected_skills: selectedSkills,
+      }).then(() => {
+        setIssue({ title: '', body: '', kind: 'bug', severity: 'medium', labels: '', parent_task_ids: '', selected_skills: [] });
+        return refresh(selected.id);
+      }));
+    }
+
+    function updateSkill(index, field, value) {
+      const next = skills.slice();
+      next[index] = Object.assign({}, next[index], { [field]: value });
+      setSkillDraft(next);
+    }
+
+    function saveSkills() {
+      const cleaned = skills.map((s) => Object.assign({}, s, {
+        triggers: Array.isArray(s.triggers) ? s.triggers : String(s.triggers || '').split(',').map((x) => x.trim()).filter(Boolean)
+      })).filter((s) => s.name && s.name.trim());
+      run('Saving skills...', () => api.saveSkills(cleaned).then(() => refresh(selected && selected.id)));
+    }
+
+    return h('div', { className: 'space-y-6' },
+      h('div', { className: 'flex flex-col gap-2 md:flex-row md:items-end md:justify-between' },
+        h('div', null,
+          h('h1', { className: 'text-2xl font-semibold tracking-tight' }, 'Hermes Git Projects'),
+          h('p', { className: 'text-sm text-muted-foreground max-w-3xl' }, 'Import Git repository URLs into managed local clones, scan them as Hermes-ready projects, log issues as Kanban todos, choose suggested skills, and run safe source-control actions from the dashboard.')
+        ),
+        data && h('div', { className: 'text-xs text-muted-foreground text-right' },
+          h('div', null, 'Storage: ', data.storage && data.storage.base),
+          h('div', null, projects.length + ' project(s) scanned')
+        )
+      ),
+
+      error && h(Card, { className: 'border-destructive' }, h(CardContent, { className: 'py-3 text-sm text-destructive' }, error)),
+      busy && h(Card, null, h(CardContent, { className: 'py-3 text-sm' }, busy)),
+
+      h(Card, null,
+        h(CardHeader, null, h(CardTitle, null, 'Import repository')),
+        h(CardContent, null,
+          h('form', { onSubmit: importRepo, className: 'grid gap-3 md:grid-cols-[1fr_180px_auto]' },
+            h('div', null,
+              h(Label, null, 'Repository URL'),
+              h(Input, { value: repoUrl, onChange: (e) => setRepoUrl(e.target.value), placeholder: 'https://github.com/org/repo.git or git@github.com:org/repo.git' })
+            ),
+            h('div', null,
+              h(Label, null, 'Branch optional'),
+              h(Input, { value: importBranch, onChange: (e) => setImportBranch(e.target.value), placeholder: 'main' })
+            ),
+            h(Button, { type: 'submit', disabled: !!busy || !repoUrl.trim(), className: 'self-end' }, 'Import')
+          )
+        )
+      ),
+
+      h('div', { className: 'grid gap-4 lg:grid-cols-[360px_1fr]' },
+        h(Card, null,
+          h(CardHeader, null, h(CardTitle, null, 'Projects')),
+          h(CardContent, { className: 'space-y-2' },
+            loading ? small('Scanning projects...') : projects.length ? projects.map((p) => h('button', {
+              key: p.id,
+              onClick: () => setSelectedId(p.id),
+              className: cx('w-full rounded-md border p-3 text-left transition hover:bg-muted', selected && selected.id === p.id && 'border-primary bg-muted')
+            },
+              h('div', { className: 'flex items-center justify-between gap-2' },
+                h('div', { className: 'font-medium truncate' }, p.name),
+                p.ready ? badge('ready') : badge('error', 'destructive')
+              ),
+              small(p.path, 'truncate'),
+              p.source_control && h('div', { className: 'mt-2 flex flex-wrap gap-1 text-xs' },
+                badge(p.source_control.branch || 'detached'),
+                p.source_control.dirty ? badge('dirty', 'destructive') : badge('clean'),
+                p.issue_count ? badge(p.issue_count + ' issues') : null
+              )
+            )) : small('No projects yet. Import a repo URL above.')
+          )
+        ),
+
+        selected ? h('div', { className: 'space-y-4' },
+          h(Card, null,
+            h(CardHeader, null, h(CardTitle, null, selected.name)),
+            h(CardContent, { className: 'space-y-3' },
+              small(selected.description || 'Ready for Hermes work.'),
+              h('div', { className: 'flex flex-wrap gap-1' }, (selected.stack || []).map((s) => badge(s))),
+              h(Separator, null),
+              h('div', { className: 'grid gap-2 md:grid-cols-2 text-sm' },
+                h('div', null, h('strong', null, 'Branch: '), selected.source_control && selected.source_control.branch),
+                h('div', null, h('strong', null, 'Upstream: '), selected.source_control && (selected.source_control.upstream || 'none')),
+                h('div', null, h('strong', null, 'Ahead/behind: '), selected.source_control ? (selected.source_control.ahead + '/' + selected.source_control.behind) : '0/0'),
+                h('div', null, h('strong', null, 'Latest: '), selected.source_control && selected.source_control.latest_commit),
+                h('div', { className: 'md:col-span-2 truncate' }, h('strong', null, 'Remote: '), selected.source_control && selected.source_control.remote)
+              ),
+              h('div', { className: 'flex flex-wrap gap-2' },
+                h(Button, { type: 'button', variant: 'secondary', onClick: () => sourceAction('fetch'), disabled: !!busy }, 'Fetch'),
+                h(Button, { type: 'button', variant: 'secondary', onClick: () => sourceAction('pull'), disabled: !!busy }, 'Pull ff-only'),
+                h(Button, { type: 'button', variant: 'secondary', onClick: () => sourceAction('push'), disabled: !!busy }, 'Push current'),
+                h(Input, { className: 'w-56', value: branchName, onChange: (e) => setBranchName(e.target.value), placeholder: 'branch name' }),
+                h(Button, { type: 'button', variant: 'secondary', onClick: () => sourceAction('checkout'), disabled: !!busy || !branchName.trim() }, 'Checkout'),
+                h(Button, { type: 'button', onClick: () => sourceAction('create_branch'), disabled: !!busy || !branchName.trim() }, 'Create branch')
+              )
+            )
+          ),
+
+          h(Card, null,
+            h(CardHeader, null, h(CardTitle, null, 'Log issue → create Kanban todo')),
+            h(CardContent, null,
+              h('form', { onSubmit: createIssue, className: 'space-y-3' },
+                h('div', { className: 'grid gap-3 md:grid-cols-3' },
+                  h('div', { className: 'md:col-span-2' }, h(Label, null, 'Title'), h(Input, { value: issue.title, onChange: (e) => setIssue(Object.assign({}, issue, { title: e.target.value })), placeholder: 'Fix login redirect bug' })),
+                  h('div', null, h(Label, null, 'Kind'), h(Input, { value: issue.kind, onChange: (e) => setIssue(Object.assign({}, issue, { kind: e.target.value })) }))
+                ),
+                h('div', null, h(Label, null, 'Details'), h('textarea', { className: 'min-h-24 w-full rounded-md border bg-background px-3 py-2 text-sm', value: issue.body, onChange: (e) => setIssue(Object.assign({}, issue, { body: e.target.value })), placeholder: 'What is broken, expected behavior, context, links...' })),
+                h('div', { className: 'grid gap-3 md:grid-cols-3' },
+                  h('div', null, h(Label, null, 'Severity'), h(Input, { value: issue.severity, onChange: (e) => setIssue(Object.assign({}, issue, { severity: e.target.value })) })),
+                  h('div', null, h(Label, null, 'Labels comma-separated'), h(Input, { value: issue.labels, onChange: (e) => setIssue(Object.assign({}, issue, { labels: e.target.value })) })),
+                  h('div', null, h(Label, null, 'Parent task ids comma-separated'), h(Input, { value: issue.parent_task_ids, onChange: (e) => setIssue(Object.assign({}, issue, { parent_task_ids: e.target.value })) }))
+                ),
+                h('div', null,
+                  h(Label, null, 'Suggested skills for this issue'),
+                  h('div', { className: 'mt-2 grid gap-2 md:grid-cols-2' }, skills.map((s) => h('label', { key: s.name, className: 'flex gap-2 rounded-md border p-2 text-sm' },
+                    h('input', { type: 'checkbox', checked: (issue.selected_skills || []).includes(s.name), onChange: () => toggleSkill(s.name) }),
+                    h('span', null, h('span', { className: 'font-medium' }, s.label || s.name), small(s.reason || s.name))
+                  )))
+                ),
+                h(Button, { type: 'submit', disabled: !!busy || !issue.title.trim() }, 'Save issue and create todo')
+              )
+            )
+          ),
+
+          h(Card, null,
+            h(CardHeader, null, h(CardTitle, null, 'Recent project issues')),
+            h(CardContent, { className: 'space-y-2' },
+              (selected.issues || []).length ? selected.issues.map((it) => h('div', { key: it.id, className: 'rounded-md border p-3' },
+                h('div', { className: 'flex items-center justify-between gap-2' }, h('div', { className: 'font-medium' }, it.title), it.todo_id ? badge('todo ' + it.todo_id) : badge('todo pending/error', 'destructive')),
+                small((it.kind || 'issue') + ' • ' + (it.severity || 'medium') + ' • branch ' + (it.recommended_branch || '')),
+                it.selected_skills && h('div', { className: 'mt-2' }, it.selected_skills.map((s) => badge(s)))
+              )) : small('No issues logged yet.')
+            )
+          )
+        ) : h(Card, null, h(CardContent, { className: 'py-8' }, small('Select or import a project.')))
+      ),
+
+      h(Card, null,
+        h(CardHeader, null, h(CardTitle, null, 'Suggested skills storage')),
+        h(CardContent, { className: 'space-y-3' },
+          small('These are stored in the plugin profile state. Users can choose them per issue; defaults are auto-attached when no explicit selection is made.'),
+          skills.map((s, i) => h('div', { key: i, className: 'grid gap-2 rounded-md border p-3 md:grid-cols-[220px_1fr_120px]' },
+            h(Input, { value: s.name || '', onChange: (e) => updateSkill(i, 'name', e.target.value), placeholder: 'skill-name' }),
+            h(Input, { value: s.reason || '', onChange: (e) => updateSkill(i, 'reason', e.target.value), placeholder: 'why this skill is useful' }),
+            h('label', { className: 'flex items-center gap-2 text-sm' }, h('input', { type: 'checkbox', checked: !!s.default, onChange: (e) => updateSkill(i, 'default', e.target.checked) }), 'Default')
+          )),
+          h('div', { className: 'flex gap-2' },
+            h(Button, { type: 'button', variant: 'secondary', onClick: () => setSkillDraft(skills.concat([{ name: '', label: '', reason: '', default: false, triggers: [] }])) }, 'Add skill'),
+            h(Button, { type: 'button', onClick: saveSkills, disabled: !!busy }, 'Save suggested skills')
+          )
+        )
+      )
+    );
+  }
+
+  window.__HERMES_PLUGINS__.register('hermes-git-projects', GitProjectsPage);
+})();

--- a/plugins/hermes-git-projects/dashboard/manifest.json
+++ b/plugins/hermes-git-projects/dashboard/manifest.json
@@ -1,0 +1,13 @@
+{
+  "name": "hermes-git-projects",
+  "label": "Git Projects",
+  "description": "Import Git repos as Hermes-ready projects with local clones, issue-to-todo automation, source-control actions, and selectable suggested skills.",
+  "icon": "Code",
+  "version": "0.1.0",
+  "tab": {
+    "path": "/git-projects",
+    "position": "after:skills"
+  },
+  "entry": "dist/index.js",
+  "api": "plugin_api.py"
+}

--- a/plugins/hermes-git-projects/dashboard/plugin_api.py
+++ b/plugins/hermes-git-projects/dashboard/plugin_api.py
@@ -1,0 +1,555 @@
+"""Hermes Git Projects dashboard plugin API.
+
+Routes are mounted by the dashboard at /api/plugins/hermes-git-projects/.
+The plugin keeps all state under get_hermes_home()/hermes-git-projects.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import shutil
+import subprocess
+import time
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel, Field
+
+from hermes_constants import get_hermes_home
+
+router = APIRouter()
+
+PLUGIN_NAME = "hermes-git-projects"
+SCAN_SKIP_DIRS = {
+    ".git", ".hg", ".svn", "node_modules", "venv", ".venv", "env", ".env",
+    "__pycache__", ".pytest_cache", ".mypy_cache", ".ruff_cache", "dist", "build",
+    "target", ".next", ".nuxt", ".vite", "coverage", ".cache",
+}
+MAX_SCAN_DEPTH = 4
+MAX_SCAN_REPOS = 160
+GIT_TIMEOUT = 45
+
+DEFAULT_SUGGESTED_SKILLS: List[Dict[str, Any]] = [
+    {
+        "name": "zeo-development-superpowers",
+        "label": "Zeo Development Superpowers",
+        "reason": "Use for Zeo-style implementation discipline: inspect, preserve architecture, verify, and report clearly.",
+        "default": True,
+        "triggers": ["implementation", "dashboard", "feature", "project"],
+    },
+    {
+        "name": "systematic-debugging",
+        "label": "Systematic Debugging",
+        "reason": "Use for bugs, regressions, failures, errors, broken builds, and unclear root causes.",
+        "default": True,
+        "triggers": ["bug", "error", "failure", "regression", "broken", "traceback"],
+    },
+    {
+        "name": "test-driven-development",
+        "label": "Test-Driven Development",
+        "reason": "Use when behavior changes need tests or acceptance checks before/alongside implementation.",
+        "default": True,
+        "triggers": ["feature", "test", "acceptance", "behavior", "bug"],
+    },
+    {
+        "name": "requesting-code-review",
+        "label": "Requesting Code Review",
+        "reason": "Use for non-trivial code changes before finalizing or pushing work.",
+        "default": True,
+        "triggers": ["review", "refactor", "security", "quality", "changes"],
+    },
+    {
+        "name": "github-pr-workflow",
+        "label": "GitHub PR Workflow",
+        "reason": "Use for GitHub-hosted repos when the work should land on a branch and become a PR.",
+        "default": False,
+        "triggers": ["github", "pull request", "branch", "push", "merge"],
+    },
+    {
+        "name": "github-code-review",
+        "label": "GitHub Code Review",
+        "reason": "Use when reviewing or preparing GitHub pull requests.",
+        "default": False,
+        "triggers": ["github", "pr", "review", "diff"],
+    },
+    {
+        "name": "github-repo-management",
+        "label": "GitHub Repo Management",
+        "reason": "Use for clone/fork/remote/release repository operations.",
+        "default": False,
+        "triggers": ["clone", "remote", "repo", "release", "fork"],
+    },
+    {
+        "name": "writing-plans",
+        "label": "Writing Plans",
+        "reason": "Use when the issue needs a scoped implementation plan before execution.",
+        "default": False,
+        "triggers": ["plan", "architecture", "multi-step", "scope"],
+    },
+    {
+        "name": "subagent-driven-development",
+        "label": "Subagent Driven Development",
+        "reason": "Use when work benefits from specialist agents, parallel inspection, or staged reviews.",
+        "default": False,
+        "triggers": ["subagent", "parallel", "specialist", "multi-agent"],
+    },
+]
+
+class ProjectImportRequest(BaseModel):
+    repo_url: str = Field(..., min_length=3)
+    branch: Optional[str] = None
+
+class SourceControlRequest(BaseModel):
+    action: str
+    branch: Optional[str] = None
+
+class ProjectIssueCreate(BaseModel):
+    title: str = Field(..., min_length=1)
+    body: str = ""
+    kind: str = "issue"
+    severity: str = "medium"
+    labels: List[str] = Field(default_factory=list)
+    assignee: Optional[str] = None
+    parent_task_ids: List[str] = Field(default_factory=list)
+    selected_skills: Optional[List[str]] = None
+    recommended_branch: Optional[str] = None
+
+class SuggestedSkill(BaseModel):
+    name: str
+    label: Optional[str] = None
+    reason: str = ""
+    default: bool = False
+    triggers: List[str] = Field(default_factory=list)
+
+class SuggestedSkillsUpdate(BaseModel):
+    skills: List[SuggestedSkill]
+
+
+def _base_dir() -> Path:
+    path = get_hermes_home() / PLUGIN_NAME
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+def _repos_dir() -> Path:
+    path = _base_dir() / "repos"
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+def _issues_path() -> Path:
+    return _base_dir() / "issues.json"
+
+def _skills_path() -> Path:
+    return _base_dir() / "suggested-skills.json"
+
+def _atomic_write_json(path: Path, payload: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    tmp.replace(path)
+
+def _read_json(path: Path, default: Any) -> Any:
+    try:
+        if not path.exists():
+            return default
+        return json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return default
+
+def _load_issues() -> Dict[str, Any]:
+    data = _read_json(_issues_path(), {"issues": []})
+    if not isinstance(data, dict) or not isinstance(data.get("issues"), list):
+        return {"issues": []}
+    return data
+
+def _save_issues(data: Dict[str, Any]) -> None:
+    _atomic_write_json(_issues_path(), data)
+
+def _load_suggested_skills() -> List[Dict[str, Any]]:
+    data = _read_json(_skills_path(), None)
+    if not data:
+        _atomic_write_json(_skills_path(), {"skills": DEFAULT_SUGGESTED_SKILLS})
+        return list(DEFAULT_SUGGESTED_SKILLS)
+    skills = data.get("skills") if isinstance(data, dict) else None
+    if not isinstance(skills, list):
+        return list(DEFAULT_SUGGESTED_SKILLS)
+    cleaned = []
+    for item in skills:
+        if isinstance(item, dict) and item.get("name"):
+            cleaned.append({
+                "name": str(item["name"]).strip(),
+                "label": item.get("label") or str(item["name"]).replace("-", " ").title(),
+                "reason": item.get("reason", ""),
+                "default": bool(item.get("default")),
+                "triggers": [str(t) for t in item.get("triggers", []) if t],
+            })
+    return cleaned or list(DEFAULT_SUGGESTED_SKILLS)
+
+def _git(repo: Path, args: List[str], timeout: int = GIT_TIMEOUT) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *args], cwd=str(repo), text=True, capture_output=True, timeout=timeout
+    )
+
+def _git_out(repo: Path, args: List[str], default: str = "") -> str:
+    try:
+        proc = _git(repo, args)
+    except Exception:
+        return default
+    if proc.returncode != 0:
+        return default
+    return proc.stdout.strip()
+
+def _git_checked(repo: Path, args: List[str], timeout: int = GIT_TIMEOUT) -> str:
+    try:
+        proc = _git(repo, args, timeout=timeout)
+    except subprocess.TimeoutExpired as exc:
+        raise HTTPException(status_code=504, detail=f"git {' '.join(args)} timed out") from exc
+    if proc.returncode != 0:
+        detail = (proc.stderr or proc.stdout or "git command failed").strip()[-1200:]
+        raise HTTPException(status_code=400, detail=detail)
+    return proc.stdout.strip()
+
+def _is_git_repo(path: Path) -> bool:
+    return (path / ".git").exists() and _git_out(path, ["rev-parse", "--is-inside-work-tree"]) == "true"
+
+def _validate_repo_url(url: str) -> str:
+    clean = url.strip()
+    if not clean:
+        raise HTTPException(status_code=400, detail="repo_url is required")
+    allowed = (
+        clean.startswith("https://")
+        or clean.startswith("http://")
+        or clean.startswith("ssh://")
+        or re.match(r"^[\w.-]+@[\w.-]+:[\w./~:-]+(?:\.git)?$", clean)
+    )
+    if not allowed:
+        raise HTTPException(status_code=400, detail="Only HTTPS, HTTP, SSH, or git@host:path repository URLs are supported")
+    if any(token in clean for token in ["\n", "\r", "\x00"]):
+        raise HTTPException(status_code=400, detail="Invalid repository URL")
+    return clean
+
+def _repo_slug(url: str) -> str:
+    base = url.rstrip("/").split("/")[-1]
+    if ":" in base and not base.startswith("http"):
+        base = base.split(":")[-1]
+    if base.endswith(".git"):
+        base = base[:-4]
+    base = re.sub(r"[^A-Za-z0-9._-]+", "-", base).strip(".-_") or "repo"
+    digest = hashlib.sha1(url.encode("utf-8")).hexdigest()[:8]
+    return f"{base}-{digest}"
+
+def _project_id(path: Path) -> str:
+    return "gp_" + hashlib.sha1(str(path.resolve()).encode("utf-8")).hexdigest()[:14]
+
+def _github_info(remote: str) -> Dict[str, Optional[str]]:
+    if not remote:
+        return {"host": None, "owner": None, "repo": None, "url": None, "issues_url": None, "new_issue_url": None}
+    owner = repo = None
+    m = re.match(r"https?://github\.com/([^/]+)/([^/]+?)(?:\.git)?/?$", remote)
+    if not m:
+        m = re.match(r"git@github\.com:([^/]+)/([^/]+?)(?:\.git)?$", remote)
+    if m:
+        owner, repo = m.group(1), m.group(2)
+        url = f"https://github.com/{owner}/{repo}"
+        return {"host": "github.com", "owner": owner, "repo": repo, "url": url, "issues_url": f"{url}/issues", "new_issue_url": f"{url}/issues/new"}
+    return {"host": None, "owner": None, "repo": None, "url": None, "issues_url": None, "new_issue_url": None}
+
+def _ahead_behind(repo: Path) -> Dict[str, int]:
+    upstream = _git_out(repo, ["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"], "")
+    if not upstream:
+        return {"ahead": 0, "behind": 0}
+    counts = _git_out(repo, ["rev-list", "--left-right", "--count", f"{upstream}...HEAD"], "0\t0")
+    parts = counts.replace("\t", " ").split()
+    try:
+        behind, ahead = int(parts[0]), int(parts[1])
+    except Exception:
+        behind = ahead = 0
+    return {"ahead": ahead, "behind": behind}
+
+def _detect_stack(repo: Path) -> List[str]:
+    markers = {
+        "pyproject.toml": "Python", "requirements.txt": "Python", "manage.py": "Django",
+        "package.json": "Node/React", "vite.config.ts": "Vite", "vite.config.js": "Vite",
+        "tailwind.config.js": "Tailwind", "tailwind.config.ts": "Tailwind", "docker-compose.yml": "Docker",
+        "Dockerfile": "Docker", "go.mod": "Go", "Cargo.toml": "Rust", "pom.xml": "Java/Maven",
+    }
+    found: List[str] = []
+    for name, label in markers.items():
+        if (repo / name).exists() and label not in found:
+            found.append(label)
+    return found
+
+def _source_control(repo: Path) -> Dict[str, Any]:
+    branch = _git_out(repo, ["branch", "--show-current"], "detached")
+    branches = [b.strip().lstrip("* ").strip() for b in _git_out(repo, ["branch", "--format", "%(refname:short)"], "").splitlines() if b.strip()]
+    remote = _git_out(repo, ["config", "--get", "remote.origin.url"], "")
+    status = _git_out(repo, ["status", "--short"], "")
+    latest = _git_out(repo, ["log", "-1", "--pretty=format:%h %s"], "")
+    upstream = _git_out(repo, ["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"], "")
+    ab = _ahead_behind(repo)
+    return {
+        "branch": branch,
+        "branches": branches,
+        "remote": remote,
+        "dirty": bool(status.strip()),
+        "status": status.splitlines()[:80],
+        "latest_commit": latest,
+        "upstream": upstream,
+        **ab,
+        "github": _github_info(remote),
+    }
+
+def _issue_records_for(project_id: str) -> List[Dict[str, Any]]:
+    return [i for i in _load_issues().get("issues", []) if i.get("project_id") == project_id]
+
+def _scan_repo(repo: Path) -> Dict[str, Any]:
+    sc = _source_control(repo)
+    pid = _project_id(repo)
+    return {
+        "id": pid,
+        "name": repo.name,
+        "path": str(repo),
+        "description": _read_description(repo),
+        "stack": _detect_stack(repo),
+        "source_control": sc,
+        "issues": _issue_records_for(pid),
+        "issue_count": len(_issue_records_for(pid)),
+        "ready": True,
+    }
+
+def _read_description(repo: Path) -> str:
+    for name in ("README.md", "README.rst", "README.txt"):
+        p = repo / name
+        if p.exists():
+            try:
+                for line in p.read_text(encoding="utf-8", errors="ignore").splitlines():
+                    s = line.strip(" #\t")
+                    if s:
+                        return s[:220]
+            except Exception:
+                pass
+    return "Imported Git project ready for Hermes work."
+
+def _discover_repos() -> List[Path]:
+    roots = [_repos_dir()]
+    cwd = Path.cwd()
+    for candidate in (cwd, cwd.parent):
+        if candidate.exists() and candidate not in roots:
+            roots.append(candidate)
+    repos: List[Path] = []
+    seen = set()
+    for root in roots:
+        if not root.exists():
+            continue
+        stack: List[tuple[Path, int]] = [(root, 0)]
+        while stack and len(repos) < MAX_SCAN_REPOS:
+            path, depth = stack.pop()
+            if path.name in SCAN_SKIP_DIRS:
+                continue
+            key = str(path.resolve())
+            if key in seen:
+                continue
+            seen.add(key)
+            if _is_git_repo(path):
+                repos.append(path)
+                continue
+            if depth >= MAX_SCAN_DEPTH:
+                continue
+            try:
+                children = [c for c in path.iterdir() if c.is_dir() and c.name not in SCAN_SKIP_DIRS]
+            except Exception:
+                continue
+            stack.extend((c, depth + 1) for c in children)
+    return repos
+
+def _projects() -> List[Dict[str, Any]]:
+    projects = []
+    for repo in _discover_repos():
+        try:
+            projects.append(_scan_repo(repo))
+        except Exception as exc:
+            projects.append({"id": _project_id(repo), "name": repo.name, "path": str(repo), "ready": False, "error": str(exc)})
+    return sorted(projects, key=lambda p: (not str(p.get("path", "")).startswith(str(_repos_dir())), p.get("name", "").lower()))
+
+def _find_project(project_id: str) -> Dict[str, Any]:
+    for project in _projects():
+        if project.get("id") == project_id:
+            return project
+    raise HTTPException(status_code=404, detail="Project not found")
+
+def _branch_slug(text: str) -> str:
+    value = re.sub(r"[^a-zA-Z0-9._/-]+", "-", text.lower()).strip("-/.")
+    value = re.sub(r"[-/]{2,}", "-", value)
+    return value[:80] or "issue"
+
+def _infer_skills(issue: ProjectIssueCreate, project: Dict[str, Any]) -> List[str]:
+    if issue.selected_skills is not None:
+        return _dedupe(issue.selected_skills)
+    text = " ".join([issue.title, issue.body, issue.kind, " ".join(issue.labels)]).lower()
+    selected: List[str] = []
+    for skill in _load_suggested_skills():
+        name = skill.get("name")
+        if not name:
+            continue
+        triggers = [str(t).lower() for t in skill.get("triggers", [])]
+        if skill.get("default") or any(t and t in text for t in triggers):
+            selected.append(name)
+    gh = (((project.get("source_control") or {}).get("github") or {}).get("url"))
+    if gh:
+        selected.append("github-pr-workflow")
+    return _dedupe(selected)
+
+def _dedupe(items: Iterable[str]) -> List[str]:
+    out: List[str] = []
+    seen = set()
+    for item in items:
+        clean = str(item).strip()
+        if clean and clean not in seen:
+            seen.add(clean)
+            out.append(clean)
+    return out
+
+def _create_kanban_task(project: Dict[str, Any], issue: Dict[str, Any]) -> Dict[str, Any]:
+    try:
+        from hermes_cli import kanban_db
+        conn = kanban_db.connect()
+        try:
+            body = issue.get("body") or ""
+            body += "\n\nHermes Git Projects issue metadata:\n"
+            body += f"- Project: {project.get('name')}\n- Workspace: {project.get('path')}\n- Issue id: {issue.get('id')}\n"
+            if issue.get("recommended_branch"):
+                body += f"- Recommended branch: {issue.get('recommended_branch')}\n"
+            task_id = kanban_db.create_task(
+                conn,
+                title=f"Resolve {project.get('name')}: {issue.get('title')}",
+                body=body.strip(),
+                assignee=issue.get("assignee"),
+                created_by="hermes-git-projects",
+                workspace_kind="dir",
+                workspace_path=project.get("path"),
+                parents=issue.get("parent_task_ids") or (),
+                skills=issue.get("selected_skills") or (),
+                # Kanban currently accepts "running" or "blocked" as explicit
+                # initial statuses. With no parents, "running" creates an
+                # immediately claimable task; with parents, create_task moves it
+                # to todo until dependencies are complete.
+                initial_status="running",
+                idempotency_key=f"hermes-git-projects:{issue.get('id')}",
+            )
+            return {"todo_id": task_id}
+        finally:
+            conn.close()
+    except Exception as exc:
+        return {"todo_error": str(exc)}
+
+@router.get("/summary")
+async def summary() -> Dict[str, Any]:
+    return {
+        "plugin": PLUGIN_NAME,
+        "description": "Import Git repos as Hermes projects, keep local clones, log issues into Kanban todos, and manage source-control actions.",
+        "storage": {"base": str(_base_dir()), "repos": str(_repos_dir()), "issues": str(_issues_path()), "suggested_skills": str(_skills_path())},
+        "projects": _projects(),
+        "suggested_skills": _load_suggested_skills(),
+    }
+
+@router.post("/import")
+async def import_project(body: ProjectImportRequest) -> Dict[str, Any]:
+    url = _validate_repo_url(body.repo_url)
+    target = _repos_dir() / _repo_slug(url)
+    if target.exists() and not _is_git_repo(target):
+        raise HTTPException(status_code=409, detail=f"Target exists but is not a git repo: {target}")
+    if not target.exists():
+        args = ["clone"]
+        if body.branch:
+            args += ["--branch", body.branch]
+        args += [url, str(target)]
+        try:
+            proc = subprocess.run(["git", *args], text=True, capture_output=True, timeout=180)
+        except subprocess.TimeoutExpired as exc:
+            raise HTTPException(status_code=504, detail="git clone timed out") from exc
+        if proc.returncode != 0:
+            raise HTTPException(status_code=400, detail=(proc.stderr or proc.stdout or "git clone failed")[-1200:])
+    else:
+        _git_checked(target, ["fetch", "--all", "--prune"], timeout=120)
+        if body.branch:
+            _git_checked(target, ["checkout", body.branch])
+    return {"ok": True, "project": _scan_repo(target), "message": "Repository imported and scanned"}
+
+@router.post("/projects/{project_id}/source-control")
+async def source_control(project_id: str, body: SourceControlRequest) -> Dict[str, Any]:
+    project = _find_project(project_id)
+    repo = Path(project["path"])
+    action = body.action.strip().lower()
+    if action == "fetch":
+        output = _git_checked(repo, ["fetch", "--all", "--prune"], timeout=120)
+    elif action == "pull":
+        output = _git_checked(repo, ["pull", "--ff-only"], timeout=120)
+    elif action == "push":
+        branch = _git_out(repo, ["branch", "--show-current"])
+        if not branch:
+            raise HTTPException(status_code=400, detail="Cannot push while HEAD is detached")
+        output = _git_checked(repo, ["push", "-u", "origin", branch], timeout=180)
+    elif action == "checkout":
+        if not body.branch:
+            raise HTTPException(status_code=400, detail="branch is required for checkout")
+        output = _git_checked(repo, ["checkout", body.branch])
+    elif action == "create_branch":
+        if not body.branch:
+            raise HTTPException(status_code=400, detail="branch is required for create_branch")
+        output = _git_checked(repo, ["checkout", "-b", body.branch])
+    else:
+        raise HTTPException(status_code=400, detail="action must be one of fetch, pull, push, checkout, create_branch")
+    return {"ok": True, "action": action, "output": output, "project": _scan_repo(repo)}
+
+@router.post("/projects/{project_id}/issues")
+async def create_issue(project_id: str, body: ProjectIssueCreate) -> Dict[str, Any]:
+    project = _find_project(project_id)
+    now = int(time.time())
+    issue_id = "gpi_" + hashlib.sha1(f"{project_id}:{body.title}:{now}".encode("utf-8")).hexdigest()[:12]
+    branch = body.recommended_branch or f"issue/{_branch_slug(body.title)}"
+    selected_skills = _infer_skills(body, project)
+    issue: Dict[str, Any] = {
+        "id": issue_id,
+        "project_id": project_id,
+        "title": body.title.strip(),
+        "body": body.body.strip(),
+        "kind": body.kind.strip() or "issue",
+        "severity": body.severity.strip() or "medium",
+        "labels": _dedupe(body.labels),
+        "assignee": body.assignee,
+        "parent_task_ids": _dedupe(body.parent_task_ids),
+        "selected_skills": selected_skills,
+        "recommended_branch": branch,
+        "workspace_path": project.get("path"),
+        "created_at": now,
+        "updated_at": now,
+    }
+    issue.update(_create_kanban_task(project, issue))
+    data = _load_issues()
+    data.setdefault("issues", []).insert(0, issue)
+    _save_issues(data)
+    return {"ok": True, "issue": issue, "project": _scan_repo(Path(project["path"]))}
+
+@router.get("/suggested-skills")
+async def suggested_skills() -> Dict[str, Any]:
+    return {"skills": _load_suggested_skills(), "path": str(_skills_path())}
+
+@router.put("/suggested-skills")
+async def update_suggested_skills(body: SuggestedSkillsUpdate) -> Dict[str, Any]:
+    cleaned = []
+    for skill in body.skills:
+        name = skill.name.strip()
+        if not name:
+            continue
+        cleaned.append({
+            "name": name,
+            "label": skill.label or name.replace("-", " ").title(),
+            "reason": skill.reason,
+            "default": skill.default,
+            "triggers": _dedupe(skill.triggers),
+        })
+    _atomic_write_json(_skills_path(), {"skills": cleaned})
+    return {"ok": True, "skills": cleaned, "path": str(_skills_path())}

--- a/plugins/hermes-git-projects/docs/architecture.md
+++ b/plugins/hermes-git-projects/docs/architecture.md
@@ -1,0 +1,35 @@
+# Hermes Git Projects Architecture
+
+## Data model
+
+A project is a local Git clone plus scanned metadata. The canonical key is a stable SHA-1 derived from the local repo path. This avoids leaking remote URLs into IDs and keeps IDs stable if the dashboard rescans.
+
+An issue is a local operational note that becomes a Kanban task. The issue record keeps the task id, selected skills, workspace path, recommended branch name, labels, severity, and optional parent task ids.
+
+Suggested skills are stored as editable JSON records:
+
+```json
+{
+  "skills": [
+    {
+      "name": "systematic-debugging",
+      "label": "Systematic Debugging",
+      "reason": "Use for bugs, regressions, failures, and unclear root causes.",
+      "default": true,
+      "triggers": ["bug", "error", "failure", "regression"]
+    }
+  ]
+}
+```
+
+## Boundaries
+
+- The plugin does not create remote GitHub issues automatically.
+- The plugin does not store credentials.
+- Destructive Git actions are intentionally omitted from the dashboard API.
+- Pull uses `git pull --ff-only` so dashboard actions do not create merge commits.
+- Push only pushes the current local branch to origin with upstream set.
+
+## Kanban integration
+
+Issue save attempts to import `hermes_cli.kanban_db` lazily. If Kanban is unavailable, the issue is still stored locally with a `todo_error` field so the user does not lose the report.

--- a/plugins/hermes-git-projects/plugin.yaml
+++ b/plugins/hermes-git-projects/plugin.yaml
@@ -1,0 +1,7 @@
+name: hermes-git-projects
+version: 0.1.0
+description: "Dashboard plugin for importing Git repository URLs as Hermes projects, keeping local clones, scanning source-control status, logging project issues, creating Kanban todos, and managing suggested skills for issue resolution."
+author: Hermes Agent
+kind: standalone
+provides_tools: []
+provides_hooks: []

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -25,6 +25,7 @@ import {
   Download,
   Eye,
   FileText,
+  FolderGit2,
   Globe,
   Heart,
   KeyRound,
@@ -66,6 +67,7 @@ import CronPage from "@/pages/CronPage";
 import ProfilesPage from "@/pages/ProfilesPage";
 import SkillsPage from "@/pages/SkillsPage";
 import PluginsPage from "@/pages/PluginsPage";
+import ProjectsPage from "@/pages/ProjectsPage";
 import ChatPage from "@/pages/ChatPage";
 import { LanguageSwitcher } from "@/components/LanguageSwitcher";
 import { ThemeSwitcher } from "@/components/ThemeSwitcher";
@@ -109,6 +111,7 @@ const BUILTIN_ROUTES_CORE: Record<string, ComponentType> = {
   "/": RootRedirect,
   "/sessions": SessionsPage,
   "/analytics": AnalyticsPage,
+  "/projects": ProjectsPage,
   "/models": ModelsPage,
   "/logs": LogsPage,
   "/cron": CronPage,
@@ -141,6 +144,7 @@ const BUILTIN_NAV_REST: NavItem[] = [
     label: "Analytics",
     icon: BarChart3,
   },
+  { path: "/projects", label: "Projects", icon: FolderGit2 },
   {
     path: "/models",
     labelKey: "models",
@@ -168,6 +172,7 @@ const ICON_MAP: Record<string, ComponentType<{ className?: string }>> = {
   Clock,
   Cpu,
   FileText,
+  FolderGit2,
   KeyRound,
   MessageSquare,
   Package,

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -63,6 +63,25 @@ async function getSessionToken(): Promise<string> {
 
 export const api = {
   getStatus: () => fetchJSON<StatusResponse>("/api/status"),
+  getProjects: () => fetchJSON<ProjectsResponse>("/api/projects"),
+  importProject: (request: ProjectImportRequest) =>
+    fetchJSON<ProjectImportResponse>("/api/projects/import", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(request),
+    }),
+  projectSourceControl: (projectId: string, request: ProjectSourceControlRequest) =>
+    fetchJSON<ProjectSourceControlResponse>(`/api/projects/${encodeURIComponent(projectId)}/source-control`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(request),
+    }),
+  createProjectIssue: (projectId: string, issue: ProjectIssueCreateRequest) =>
+    fetchJSON<ProjectIssueCreateResponse>(`/api/projects/${encodeURIComponent(projectId)}/issues`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(issue),
+    }),
   getSessions: (limit = 20, offset = 0) =>
     fetchJSON<PaginatedSessions>(`/api/sessions?limit=${limit}&offset=${offset}`),
   getSessionMessages: (id: string) =>
@@ -342,6 +361,102 @@ export const api = {
       body: JSON.stringify({ name }),
     }),
 };
+
+export interface ProjectIssueTodo {
+  system: string;
+  task_id?: string;
+  assignee?: string;
+  skills?: string[];
+  workspace_kind?: string;
+  workspace_path?: string;
+  recommended_branch?: string;
+  parents?: string[];
+  error?: string;
+}
+
+export interface ProjectIssue {
+  id: string;
+  project_id: string;
+  project_name: string;
+  title: string;
+  body: string;
+  kind: string;
+  severity: string;
+  labels: string[];
+  status: string;
+  created_at: string;
+  source: string;
+  todo?: ProjectIssueTodo;
+  github_new_issue_url?: string;
+}
+
+export interface ProjectInfo {
+  id: string;
+  name: string;
+  path: string;
+  branch: string | null;
+  dirty: boolean;
+  remote_url: string | null;
+  repo_url: string | null;
+  issues_url: string | null;
+  releases_url: string | null;
+  new_issue_url: string | null;
+  branches: string[];
+  upstream: string | null;
+  ahead: number;
+  behind: number;
+  managed: boolean;
+  latest_commit: string | null;
+  latest_commit_message: string | null;
+  last_commit_at: string | null;
+  issue_counts: { open: number; bugs: number; total: number };
+  issues: ProjectIssue[];
+}
+
+export interface ProjectsResponse {
+  projects: ProjectInfo[];
+  roots: string[];
+  issue_store_path: string;
+  scan_limit: number;
+}
+
+export interface ProjectImportRequest {
+  repo_url: string;
+  branch?: string;
+}
+
+export interface ProjectImportResponse {
+  ok: boolean;
+  project: ProjectInfo;
+  message: string;
+}
+
+export interface ProjectSourceControlRequest {
+  action: "fetch" | "pull" | "push" | "checkout" | "create_branch";
+  branch?: string;
+  create_from?: string;
+}
+
+export interface ProjectSourceControlResponse {
+  ok: boolean;
+  project: ProjectInfo;
+  stdout: string;
+  stderr: string;
+}
+
+export interface ProjectIssueCreateRequest {
+  title: string;
+  body?: string;
+  kind?: string;
+  severity?: string;
+  labels?: string[];
+  parent_task_ids?: string[];
+}
+
+export interface ProjectIssueCreateResponse {
+  ok: boolean;
+  issue: ProjectIssue;
+}
 
 export interface ActionResponse {
   name: string;

--- a/web/src/pages/ProjectsPage.tsx
+++ b/web/src/pages/ProjectsPage.tsx
@@ -1,0 +1,481 @@
+import { useCallback, useEffect, useMemo, useState, type ReactNode } from "react";
+import {
+  AlertTriangle,
+  Bug,
+  CheckCircle2,
+  ExternalLink,
+  GitBranch,
+  GitCommit,
+  Github,
+  RefreshCw,
+  Send,
+  UploadCloud,
+} from "lucide-react";
+import { Button } from "@nous-research/ui/ui/components/button";
+import { Badge } from "@nous-research/ui/ui/components/badge";
+import { Spinner } from "@nous-research/ui/ui/components/spinner";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Toast } from "@/components/Toast";
+import { api, type ProjectInfo, type ProjectsResponse } from "@/lib/api";
+import { cn } from "@/lib/utils";
+import { useToast } from "@/hooks/useToast";
+import { usePageHeader } from "@/contexts/usePageHeader";
+
+const KIND_OPTIONS = ["issue", "bug", "feature", "task"];
+const SEVERITY_OPTIONS = ["low", "normal", "high", "critical"];
+
+function formatDate(value: string | null): string {
+  if (!value) return "No commits yet";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return date.toLocaleString();
+}
+
+function labelsFromText(value: string): string[] {
+  return value
+    .split(",")
+    .map((label) => label.trim())
+    .filter(Boolean);
+}
+
+export default function ProjectsPage() {
+  const [payload, setPayload] = useState<ProjectsResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [query, setQuery] = useState("");
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [title, setTitle] = useState("");
+  const [body, setBody] = useState("");
+  const [kind, setKind] = useState("bug");
+  const [severity, setSeverity] = useState("normal");
+  const [labels, setLabels] = useState("");
+  const [parentTaskIds, setParentTaskIds] = useState("");
+  const [repoUrl, setRepoUrl] = useState("");
+  const [repoBranch, setRepoBranch] = useState("");
+  const [importing, setImporting] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const { toast, showToast } = useToast();
+  const { setEnd } = usePageHeader();
+
+  const load = useCallback(async () => {
+    const next = await api.getProjects();
+    setPayload(next);
+    setSelectedId((current) => {
+      if (current && next.projects.some((project) => project.id === current)) return current;
+      return next.projects[0]?.id ?? null;
+    });
+  }, []);
+
+  useEffect(() => {
+    // Initial API synchronization for the Projects dashboard.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    void load()
+      .catch((error) => showToast(error instanceof Error ? error.message : "Failed to load projects", "error"))
+      .finally(() => setLoading(false));
+  }, [load, showToast]);
+
+  useEffect(() => {
+    setEnd(
+      <Button
+        ghost
+        size="sm"
+        className="w-max gap-2"
+        disabled={loading}
+        onClick={() => {
+          setLoading(true);
+          void load().finally(() => setLoading(false));
+        }}
+      >
+        {loading ? <Spinner /> : <RefreshCw className="h-3.5 w-3.5" />}
+        Refresh projects
+      </Button>,
+    );
+    return () => setEnd(null);
+  }, [load, loading, setEnd]);
+
+  const projects = useMemo(() => payload?.projects ?? [], [payload]);
+  const filteredProjects = useMemo(() => {
+    const needle = query.trim().toLowerCase();
+    if (!needle) return projects;
+    return projects.filter((project) =>
+      [project.name, project.path, project.remote_url ?? "", project.branch ?? ""]
+        .join(" ")
+        .toLowerCase()
+        .includes(needle),
+    );
+  }, [projects, query]);
+
+  const selectedProject = projects.find((project) => project.id === selectedId) ?? filteredProjects[0] ?? null;
+
+  const importRepo = async () => {
+    const trimmed = repoUrl.trim();
+    if (!trimmed) {
+      showToast("Paste a repository URL first", "error");
+      return;
+    }
+    setImporting(true);
+    try {
+      const result = await api.importProject({ repo_url: trimmed, branch: repoBranch.trim() || undefined });
+      setRepoUrl("");
+      setRepoBranch("");
+      showToast(result.message || "Repository added", "success");
+      await load();
+      setSelectedId(result.project.id);
+    } catch (error) {
+      showToast(error instanceof Error ? error.message : "Failed to import repository", "error");
+    } finally {
+      setImporting(false);
+    }
+  };
+
+  const runSourceControl = async (action: "fetch" | "pull" | "push" | "checkout" | "create_branch", branch?: string, createFrom?: string) => {
+    if (!selectedProject) return;
+    try {
+      const result = await api.projectSourceControl(selectedProject.id, { action, branch, create_from: createFrom });
+      showToast(`${action.replace("_", " ")} complete`, "success");
+      await load();
+      setSelectedId(result.project.id);
+    } catch (error) {
+      showToast(error instanceof Error ? error.message : `Failed to ${action}`, "error");
+    }
+  };
+
+  const submitIssue = async () => {
+    if (!selectedProject) return;
+    const trimmed = title.trim();
+    if (!trimmed) {
+      showToast("Add a title first", "error");
+      return;
+    }
+    setSubmitting(true);
+    try {
+      const result = await api.createProjectIssue(selectedProject.id, {
+        title: trimmed,
+        body,
+        kind,
+        severity,
+        labels: labelsFromText(labels),
+        parent_task_ids: labelsFromText(parentTaskIds),
+      });
+      setTitle("");
+      setBody("");
+      setLabels("");
+      setParentTaskIds("");
+      showToast(result.issue.todo?.task_id ? `Logged locally and created todo ${result.issue.todo.task_id}` : "Logged locally in Hermes", "success");
+      if (result.issue.github_new_issue_url) {
+        window.open(result.issue.github_new_issue_url, "_blank", "noopener,noreferrer");
+      }
+      await load();
+    } catch (error) {
+      showToast(error instanceof Error ? error.message : "Failed to log issue", "error");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-4">
+      <Toast toast={toast} />
+
+      <div className="grid gap-4 xl:grid-cols-[minmax(320px,420px)_1fr]">
+        <Card>
+          <CardHeader>
+            <CardTitle>Projects</CardTitle>
+            <p className="text-[0.7rem] tracking-[0.08em] text-midground/55 normal-case">
+              Local git repositories Hermes can see. Scan roots: {payload?.roots.join(", ") || "loading..."}
+            </p>
+          </CardHeader>
+          <CardContent className="flex flex-col gap-3">
+            <div className="rounded-lg border border-midground/15 p-3">
+              <div className="mb-2 text-xs uppercase tracking-[0.14em] text-midground/45">Add repository</div>
+              <div className="grid gap-2">
+                <Input value={repoUrl} placeholder="https://github.com/owner/repo.git or git@github.com:owner/repo.git" onChange={(event) => setRepoUrl(event.target.value)} />
+                <div className="flex gap-2">
+                  <Input value={repoBranch} placeholder="Optional branch" onChange={(event) => setRepoBranch(event.target.value)} />
+                  <Button className="w-max gap-2" disabled={importing} onClick={() => void importRepo()}>
+                    {importing ? <Spinner /> : <UploadCloud className="h-3.5 w-3.5" />}
+                    Add
+                  </Button>
+                </div>
+              </div>
+              <p className="mt-2 text-xs text-midground/50">Hermes clones/fetches into the managed local project root so agents can edit and push branches quickly.</p>
+            </div>
+
+            <Input
+              value={query}
+              placeholder="Filter by name, path, branch, or remote..."
+              onChange={(event) => setQuery(event.target.value)}
+            />
+
+            {loading && projects.length === 0 ? (
+              <div className="flex items-center gap-2 text-sm text-midground/70">
+                <Spinner /> Scanning projects...
+              </div>
+            ) : filteredProjects.length === 0 ? (
+              <div className="rounded-md border border-midground/15 p-4 text-sm text-midground/70">
+                No git projects matched this filter.
+              </div>
+            ) : (
+              <div className="flex max-h-[66vh] flex-col gap-2 overflow-auto pr-1">
+                {filteredProjects.map((project) => (
+                  <button
+                    key={project.id}
+                    type="button"
+                    onClick={() => setSelectedId(project.id)}
+                    className={cn(
+                      "rounded-lg border p-3 text-left transition-colors",
+                      selectedProject?.id === project.id
+                        ? "border-midground/45 bg-midground/10"
+                        : "border-midground/15 hover:bg-midground/5",
+                    )}
+                  >
+                    <div className="flex items-start justify-between gap-3">
+                      <div className="min-w-0">
+                        <div className="truncate font-mondwest text-[0.95rem] tracking-[0.1em]">
+                          {project.name}
+                        </div>
+                        <div className="mt-1 truncate text-xs text-midground/55">{project.path}</div>
+                      </div>
+                      {project.dirty ? (
+                        <Badge tone="secondary" className="gap-1">
+                          <AlertTriangle className="h-3 w-3" /> dirty
+                        </Badge>
+                      ) : (
+                        <Badge tone="secondary" className="gap-1">
+                          <CheckCircle2 className="h-3 w-3" /> clean
+                        </Badge>
+                      )}
+                    </div>
+                    <div className="mt-3 flex flex-wrap gap-2 text-xs text-midground/70">
+                      {project.branch && (
+                        <span className="inline-flex items-center gap-1">
+                          <GitBranch className="h-3 w-3" /> {project.branch}
+                        </span>
+                      )}
+                      <span className="inline-flex items-center gap-1">
+                        <Bug className="h-3 w-3" /> {project.issue_counts.open} open
+                      </span>
+                    </div>
+                  </button>
+                ))}
+              </div>
+            )}
+          </CardContent>
+        </Card>
+
+        {selectedProject ? (
+          <ProjectDetail
+            project={selectedProject}
+            title={title}
+            body={body}
+            kind={kind}
+            severity={severity}
+            labels={labels}
+            submitting={submitting}
+            setTitle={setTitle}
+            setBody={setBody}
+            setKind={setKind}
+            setSeverity={setSeverity}
+            setLabels={setLabels}
+            parentTaskIds={parentTaskIds}
+            setParentTaskIds={setParentTaskIds}
+            runSourceControl={runSourceControl}
+            submitIssue={submitIssue}
+          />
+        ) : (
+          <Card>
+            <CardContent className="p-6 text-sm text-midground/70">Select a project to inspect it.</CardContent>
+          </Card>
+        )}
+      </div>
+
+      {payload && (
+        <p className="text-xs text-midground/45">
+          Local dashboard issue store: {payload.issue_store_path}. These notes are available for later Hermes sessions; GitHub links open separately when available.
+        </p>
+      )}
+    </div>
+  );
+}
+
+function ProjectDetail(props: {
+  project: ProjectInfo;
+  title: string;
+  body: string;
+  kind: string;
+  severity: string;
+  labels: string;
+  parentTaskIds: string;
+  submitting: boolean;
+  setTitle: (value: string) => void;
+  setBody: (value: string) => void;
+  setKind: (value: string) => void;
+  setSeverity: (value: string) => void;
+  setLabels: (value: string) => void;
+  setParentTaskIds: (value: string) => void;
+  runSourceControl: (action: "fetch" | "pull" | "push" | "checkout" | "create_branch", branch?: string, createFrom?: string) => Promise<void>;
+  submitIssue: () => void;
+}) {
+  const { project } = props;
+  const [branchName, setBranchName] = useState("");
+  const [newBranchName, setNewBranchName] = useState("");
+  return (
+    <div className="flex flex-col gap-4">
+      <Card>
+        <CardHeader>
+          <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+            <div>
+              <CardTitle>{project.name}</CardTitle>
+              <p className="mt-1 break-all text-sm text-midground/60">{project.path}</p>
+            </div>
+            <div className="flex flex-wrap gap-2">
+              {project.repo_url && <ProjectLink href={project.repo_url} label="Repo" icon={<Github className="h-3.5 w-3.5" />} />}
+              {project.issues_url && <ProjectLink href={project.issues_url} label="Issues" />}
+              {project.releases_url && <ProjectLink href={project.releases_url} label="Releases" />}
+            </div>
+          </div>
+        </CardHeader>
+        <CardContent className="grid gap-4 lg:grid-cols-3">
+          <InfoTile label="Branch" value={project.branch ?? "unknown"} icon={<GitBranch className="h-4 w-4" />} />
+          <InfoTile label="Sync" value={`${project.ahead} ahead / ${project.behind} behind${project.upstream ? ` vs ${project.upstream}` : ""}`} />
+          <InfoTile label="Working tree" value={project.dirty ? "Uncommitted changes" : "Clean"} icon={project.dirty ? <AlertTriangle className="h-4 w-4" /> : <CheckCircle2 className="h-4 w-4" />} />
+          <InfoTile label="Latest commit" value={[project.latest_commit, project.latest_commit_message].filter(Boolean).join(" — ") || "unknown"} icon={<GitCommit className="h-4 w-4" />} />
+          <InfoTile label="Last commit time" value={formatDate(project.last_commit_at)} />
+          <InfoTile label="Open local notes" value={`${project.issue_counts.open} open / ${project.issue_counts.total} total`} />
+          <InfoTile label="Bug reports" value={`${project.issue_counts.bugs}`} icon={<Bug className="h-4 w-4" />} />
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Source control</CardTitle>
+          <p className="text-[0.7rem] tracking-[0.08em] text-midground/55 normal-case">
+            Fetch, pull, push, checkout, or create working branches for this local copy.
+          </p>
+        </CardHeader>
+        <CardContent className="flex flex-col gap-3">
+          <div className="flex flex-wrap gap-2">
+            <Button ghost size="sm" onClick={() => void props.runSourceControl("fetch")}>Fetch</Button>
+            <Button ghost size="sm" onClick={() => void props.runSourceControl("pull")}>Pull ff-only</Button>
+            <Button ghost size="sm" onClick={() => void props.runSourceControl("push")}>Push branch</Button>
+          </div>
+          <div className="grid gap-2 lg:grid-cols-[1fr_auto]">
+            <select className="rounded-md border border-midground/20 bg-background px-3 py-2 text-sm" value={branchName} onChange={(event) => setBranchName(event.target.value)}>
+              <option value="">Select existing branch...</option>
+              {project.branches.map((branch) => <option key={branch} value={branch}>{branch}</option>)}
+            </select>
+            <Button ghost size="sm" disabled={!branchName} onClick={() => void props.runSourceControl("checkout", branchName)}>Checkout</Button>
+          </div>
+          <div className="grid gap-2 lg:grid-cols-[1fr_auto]">
+            <Input value={newBranchName} onChange={(event) => setNewBranchName(event.target.value)} placeholder="new branch, e.g. feature/project-import" />
+            <Button ghost size="sm" disabled={!newBranchName.trim()} onClick={() => void props.runSourceControl("create_branch", newBranchName.trim())}>Create branch</Button>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Log issue or bug report</CardTitle>
+          <p className="text-[0.7rem] tracking-[0.08em] text-midground/55 normal-case">
+            Saves a local Hermes note, creates a Kanban todo with relevant skills, and opens a prefilled GitHub issue page when available.
+          </p>
+        </CardHeader>
+        <CardContent className="flex flex-col gap-4">
+          <div className="grid gap-4 lg:grid-cols-[1fr_150px_150px]">
+            <div className="grid gap-2">
+              <Label htmlFor="project-issue-title">Title</Label>
+              <Input id="project-issue-title" value={props.title} onChange={(event) => props.setTitle(event.target.value)} placeholder="Short bug/feature/task title" />
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="project-issue-kind">Type</Label>
+              <select id="project-issue-kind" className="rounded-md border border-midground/20 bg-background px-3 py-2 text-sm" value={props.kind} onChange={(event) => props.setKind(event.target.value)}>
+                {KIND_OPTIONS.map((option) => <option key={option} value={option}>{option}</option>)}
+              </select>
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="project-issue-severity">Severity</Label>
+              <select id="project-issue-severity" className="rounded-md border border-midground/20 bg-background px-3 py-2 text-sm" value={props.severity} onChange={(event) => props.setSeverity(event.target.value)}>
+                {SEVERITY_OPTIONS.map((option) => <option key={option} value={option}>{option}</option>)}
+              </select>
+            </div>
+          </div>
+          <div className="grid gap-2">
+            <Label htmlFor="project-issue-body">Details</Label>
+            <textarea
+              id="project-issue-body"
+              className="min-h-28 rounded-md border border-midground/20 bg-background px-3 py-2 text-sm outline-none focus-visible:ring-1 focus-visible:ring-midground"
+              value={props.body}
+              onChange={(event) => props.setBody(event.target.value)}
+              placeholder="Steps to reproduce, expected behavior, screenshots to collect later, acceptance criteria, etc."
+            />
+          </div>
+          <div className="grid gap-2">
+            <Label htmlFor="project-issue-labels">Extra labels</Label>
+            <Input id="project-issue-labels" value={props.labels} onChange={(event) => props.setLabels(event.target.value)} placeholder="comma, separated, labels" />
+          </div>
+          <div className="grid gap-2">
+            <Label htmlFor="project-issue-parents">Parent Kanban task ids</Label>
+            <Input id="project-issue-parents" value={props.parentTaskIds} onChange={(event) => props.setParentTaskIds(event.target.value)} placeholder="optional parent task ids, comma separated" />
+          </div>
+          <Button className="w-fit gap-2" disabled={props.submitting} onClick={() => props.submitIssue()}>
+            {props.submitting ? <Spinner /> : <Send className="h-3.5 w-3.5" />}
+            Save issue
+          </Button>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Recent local notes</CardTitle>
+        </CardHeader>
+        <CardContent className="flex flex-col gap-2">
+          {project.issues.length === 0 ? (
+            <div className="rounded-md border border-midground/15 p-4 text-sm text-midground/70">No local issues logged yet.</div>
+          ) : (
+            project.issues.map((issue) => (
+              <div key={issue.id} className="rounded-lg border border-midground/15 p-3">
+                <div className="flex flex-wrap items-center gap-2">
+                  <Badge tone="secondary">{issue.kind}</Badge>
+                  <Badge tone="secondary">{issue.severity}</Badge>
+                  <span className="text-xs text-midground/45">{formatDate(issue.created_at)}</span>
+                </div>
+                <div className="mt-2 font-medium">{issue.title}</div>
+                {issue.body && <p className="mt-1 whitespace-pre-wrap text-sm text-midground/65">{issue.body}</p>}
+                {issue.todo && (
+                  <div className="mt-2 rounded-md bg-midground/5 p-2 text-xs text-midground/65">
+                    {issue.todo.task_id ? <>Todo: {issue.todo.task_id} assigned to {issue.todo.assignee ?? "default"}</> : <>Todo creation warning: {issue.todo.error}</>}
+                    {issue.todo.skills && <div className="mt-1">Skills: {issue.todo.skills.join(", ")}</div>}
+                    {issue.todo.recommended_branch && <div className="mt-1">Suggested branch: {issue.todo.recommended_branch}</div>}
+                  </div>
+                )}
+              </div>
+            ))
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+function ProjectLink({ href, label, icon }: { href: string; label: string; icon?: ReactNode }) {
+  return (
+    <a href={href} target="_blank" rel="noreferrer" className="inline-flex items-center gap-1.5 rounded-md border border-midground/20 px-3 py-1.5 text-sm hover:bg-midground/10">
+      {icon}
+      {label}
+      <ExternalLink className="h-3.5 w-3.5" />
+    </a>
+  );
+}
+
+function InfoTile({ label, value, icon }: { label: string; value: string; icon?: ReactNode }) {
+  return (
+    <div className="rounded-lg border border-midground/15 p-3">
+      <div className="flex items-center gap-2 text-xs uppercase tracking-[0.14em] text-midground/45">
+        {icon}
+        {label}
+      </div>
+      <div className="mt-2 break-words text-sm text-midground/85">{value}</div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add Git Projects dashboard plugin for repo import, local clones, source-control actions, issue logging, Kanban todo creation, and suggested-skill storage
- extend the built-in Projects page/API with repo import, branch/source-control controls, and issue-to-todo automation
- add typed frontend API support and Projects page UI

## Verification
- ./venv/bin/python -m py_compile hermes_cli/web_server.py plugins/hermes-git-projects/dashboard/plugin_api.py plugins/hermes-git-projects/__init__.py
- node --check plugins/hermes-git-projects/dashboard/dist/index.js
- cd web && npx eslint src/pages/ProjectsPage.tsx src/App.tsx src/lib/api.ts --max-warnings=0
- cd web && npm run build
- FastAPI/TestClient plugin smoke: summary, project scan, issue-to-Kanban todo, branch creation, suggested-skill update
