### PR TITLE
fix(feishu): share gateway lark client with doc/drive tools for DM agents

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -4452,7 +4452,7 @@ class FeishuAdapter(BasePlatformAdapter):
         await self._webhook_site.start()
 
     def _build_lark_client(self, domain: Any) -> Any:
-        return (
+        client = (
             lark.Client.builder()
             .app_id(self._app_id)
             .app_secret(self._app_secret)
@@ -4460,6 +4460,18 @@ class FeishuAdapter(BasePlatformAdapter):
             .log_level(lark.LogLevel.WARNING)
             .build()
         )
+        # Share the pre-authenticated client with the doc/drive tools so
+        # DM / group-chat agents (which run in worker threads where the
+        # feishu_comment thread-local was never populated) can still reach
+        # the Feishu API. See #29760.
+        try:
+            from tools import feishu_doc_tool, feishu_drive_tool
+            feishu_doc_tool.set_default_client(client)
+            feishu_drive_tool.set_default_client(client)
+        except Exception:
+            # Tool modules are best-effort; never block adapter startup.
+            logger.debug("[Feishu] failed to share lark client with feishu tools", exc_info=True)
+        return client
 
     async def _feishu_send_with_retry(
         self,

--- a/tests/tools/test_feishu_default_client.py
+++ b/tests/tools/test_feishu_default_client.py
@@ -1,0 +1,140 @@
+"""Regression tests for #29760 — Feishu doc/drive tools must reach the gateway-
+built lark client in DM / group-chat agent threads, where the comment-handler
+thread-local was never populated."""
+
+from __future__ import annotations
+
+import threading
+from unittest import mock
+
+import pytest
+
+from tools import feishu_doc_tool, feishu_drive_tool
+
+
+@pytest.fixture(autouse=True)
+def _reset_clients():
+    """Reset both per-thread and process-wide client state on every test."""
+    for mod in (feishu_doc_tool, feishu_drive_tool):
+        if hasattr(mod._local, "client"):
+            del mod._local.client
+        mod._default_client = None
+    yield
+    for mod in (feishu_doc_tool, feishu_drive_tool):
+        if hasattr(mod._local, "client"):
+            del mod._local.client
+        mod._default_client = None
+
+
+@pytest.mark.parametrize("mod", [feishu_doc_tool, feishu_drive_tool])
+def test_get_client_returns_none_without_any_injection(mod):
+    assert mod.get_client() is None
+
+
+@pytest.mark.parametrize("mod", [feishu_doc_tool, feishu_drive_tool])
+def test_default_client_visible_when_thread_local_unset(mod):
+    """The gateway-wide default must be returned when no thread-local exists.
+
+    This is the #29760 path: the gateway adapter registers the lark client
+    once at connect time; an AIAgent later spawned in a worker thread for a
+    DM / group chat must inherit it without further plumbing."""
+    sentinel = object()
+    mod.set_default_client(sentinel)
+    assert mod.get_client() is sentinel
+
+
+@pytest.mark.parametrize("mod", [feishu_doc_tool, feishu_drive_tool])
+def test_thread_local_wins_over_default(mod):
+    """The comment-handler thread-local (set_client) must take precedence."""
+    default = object()
+    scoped = object()
+    mod.set_default_client(default)
+    mod.set_client(scoped)
+    assert mod.get_client() is scoped
+
+
+@pytest.mark.parametrize("mod", [feishu_doc_tool, feishu_drive_tool])
+def test_default_client_is_visible_across_threads(mod):
+    """A worker thread that never called set_client must still see the default.
+
+    This is the literal failure mode in #29760: the gateway adapter creates
+    the lark client on the asyncio thread, but AIAgent runs Feishu tool
+    invocations in a different worker thread where set_client was never
+    called."""
+    sentinel = object()
+    mod.set_default_client(sentinel)
+
+    seen: list = []
+
+    def _worker():
+        seen.append(mod.get_client())
+
+    t = threading.Thread(target=_worker)
+    t.start()
+    t.join()
+    assert seen == [sentinel]
+
+
+@pytest.mark.parametrize("mod", [feishu_doc_tool, feishu_drive_tool])
+def test_thread_local_does_not_leak_to_default(mod):
+    """set_client on one thread must not become the process-wide default."""
+    scoped = object()
+    mod.set_client(scoped)
+
+    seen: list = []
+
+    def _worker():
+        seen.append(mod.get_client())
+
+    t = threading.Thread(target=_worker)
+    t.start()
+    t.join()
+    assert seen == [None]
+
+
+def test_gateway_build_lark_client_registers_default(monkeypatch):
+    """FeishuAdapter._build_lark_client must register the new client as the
+    process-wide default for both tool modules. This is the actual wiring
+    point that resolves #29760 — without it, the DM path's worker thread
+    returns ``None`` from get_client() even though the gateway has a live
+    client."""
+    from gateway.platforms import feishu as feishu_mod
+
+    sentinel = object()
+
+    class _FakeBuilder:
+        def app_id(self, *_):
+            return self
+        def app_secret(self, *_):
+            return self
+        def domain(self, *_):
+            return self
+        def log_level(self, *_):
+            return self
+        def build(self):
+            return sentinel
+
+    class _FakeClient:
+        @staticmethod
+        def builder():
+            return _FakeBuilder()
+
+    class _FakeLark:
+        class LogLevel:
+            WARNING = 0
+        Client = _FakeClient
+
+    monkeypatch.setattr(feishu_mod, "lark", _FakeLark, raising=False)
+
+    # Call _build_lark_client through an instance bound only enough to
+    # satisfy the method — we sidestep the full FeishuAdapter __init__ to
+    # keep this test scoped to the wiring behavior, not the adapter's
+    # config loading.
+    adapter = feishu_mod.FeishuAdapter.__new__(feishu_mod.FeishuAdapter)
+    adapter._app_id = "test-app-id"
+    adapter._app_secret = "test-app-secret"
+    built = feishu_mod.FeishuAdapter._build_lark_client(adapter, domain=mock.Mock())
+
+    assert built is sentinel
+    assert feishu_doc_tool._default_client is sentinel
+    assert feishu_drive_tool._default_client is sentinel

--- a/tools/feishu_doc_tool.py
+++ b/tools/feishu_doc_tool.py
@@ -13,7 +13,11 @@ from tools.registry import registry, tool_error, tool_result
 logger = logging.getLogger(__name__)
 
 # Thread-local storage for the lark client injected by feishu_comment handler.
+# The thread-local layer scopes a per-handler client (e.g. the comment-callback
+# path); the module-level default acts as the gateway-wide fallback so DM /
+# group-chat agents that run in worker threads still find a client.
 _local = threading.local()
+_default_client = None
 
 
 def set_client(client):
@@ -21,9 +25,20 @@ def set_client(client):
     _local.client = client
 
 
+def set_default_client(client):
+    """Register a process-wide fallback lark client.
+
+    Called by the Feishu gateway adapter at connect time so DM / group-chat
+    agents — which run in worker threads where ``set_client`` was never
+    called — can still reach the gateway's pre-authenticated client.
+    """
+    global _default_client
+    _default_client = client
+
+
 def get_client():
-    """Return the lark client for the current thread, or None."""
-    return getattr(_local, "client", None)
+    """Return the lark client for the current thread, or the gateway default."""
+    return getattr(_local, "client", None) or _default_client
 
 
 # ---------------------------------------------------------------------------

--- a/tools/feishu_drive_tool.py
+++ b/tools/feishu_drive_tool.py
@@ -14,7 +14,11 @@ from tools.registry import registry, tool_error, tool_result
 logger = logging.getLogger(__name__)
 
 # Thread-local storage for the lark client injected by feishu_comment handler.
+# The thread-local layer scopes a per-handler client (e.g. the comment-callback
+# path); the module-level default acts as the gateway-wide fallback so DM /
+# group-chat agents that run in worker threads still find a client.
 _local = threading.local()
+_default_client = None
 
 
 def set_client(client):
@@ -22,9 +26,20 @@ def set_client(client):
     _local.client = client
 
 
+def set_default_client(client):
+    """Register a process-wide fallback lark client.
+
+    Called by the Feishu gateway adapter at connect time so DM / group-chat
+    agents — which run in worker threads where ``set_client`` was never
+    called — can still reach the gateway's pre-authenticated client.
+    """
+    global _default_client
+    _default_client = client
+
+
 def get_client():
-    """Return the lark client for the current thread, or None."""
-    return getattr(_local, "client", None)
+    """Return the lark client for the current thread, or the gateway default."""
+    return getattr(_local, "client", None) or _default_client
 
 
 def _check_feishu():


### PR DESCRIPTION
## What does this PR do?

Wires the Feishu adapter's pre-authenticated lark client into the doc/drive tool layer so DM and group-chat agents — which run on worker threads where the comment-callback thread-local was never populated — can actually invoke `feishu_doc_read` / `feishu_drive_*`. Today every Feishu doc/drive call in those contexts fails with `Feishu client not available (not in a Feishu comment context)`.

Root cause: `tools/feishu_doc_tool.py` and `tools/feishu_drive_tool.py` only consult a `threading.local`, and the only writer is `gateway/platforms/feishu_comment.py::_run_comment_agent`. The DM/group-chat dispatch never calls `set_client`, so `get_client()` returns `None`.

Fix: add `set_default_client()` to both tool modules and have `get_client()` fall back to it. The adapter registers the live client inside `_build_lark_client`, so both connect modes (websocket + webhook) pick it up without duplicating the wire-up. The comment-handler's thread-local still wins when both are set, and `set_client` on one thread does not leak into the process-wide default.

## Related Issue

Fixes #29760

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/feishu_doc_tool.py` — add `_default_client` module-level state, `set_default_client()`, and a fallback in `get_client()`.
- `tools/feishu_drive_tool.py` — same wiring, mirrored verbatim for the drive tools.
- `gateway/platforms/feishu.py` — `_build_lark_client` now calls `set_default_client` on both tool modules so websocket + webhook connect paths both register the client once.
- `tests/tools/test_feishu_default_client.py` — regression suite parametrized over both tool modules: default visible without thread-local, thread-local wins over default, cross-thread visibility (the literal #29760 worker-thread scenario), no leak from `set_client` into the process-wide default, and `_build_lark_client` registers the new client on the doc + drive modules.

## How to Test

1. `uv run --with pytest --with pytest-xdist --with pytest-asyncio --with pytest-timeout python3 -m pytest tests/tools/test_feishu_default_client.py tests/tools/test_feishu_tools.py tests/gateway/test_feishu_comment.py -v` — 52 passed locally.
2. Manual smoke: DM the Feishu bot a request that calls `feishu_doc_read` on a document the app has access to; before this change it returned the "not in a Feishu comment context" tool_error, after it succeeds.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run focused tests for the touched code and all pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.x

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — module docstrings on the affected helpers explain the thread-local-vs-default layering.
- [x] N/A `cli-config.yaml.example` (no new config keys)
- [x] N/A `CONTRIBUTING.md` / `AGENTS.md` (no architecture/workflow change)
- [x] I've considered cross-platform impact (Windows, macOS) — wiring is pure Python, no platform-specific paths.
- [x] N/A tool descriptions/schemas (tool behavior unchanged when a client is reachable)

## Related / Positioning

- #29933 (RayseeAll, env-var fallback) is orthogonal: it builds a *new* client from `FEISHU_APP_ID` / `FEISHU_APP_SECRET` when neither thread-local nor (now) default is set, and is aimed at headless / cron / non-gateway invocations. The two compose cleanly — the precedence chain becomes thread-local → gateway-registered default → env-var rebuilt fallback — so merging both gives full coverage of DM, comment, and headless contexts.

> Audited siblings: the only other module today using the same per-thread lark-client pattern is `gateway/platforms/feishu_comment.py`, which I intentionally left alone — its thread-local `set_client` is still authoritative for the comment-callback path, which is exactly what the layering preserves. No widening needed.

## Screenshots / Logs

_N/A — wiring change, no UI._