### PR TITLE
fix(kanban): auto-retry blocked gates after remediation

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -2149,6 +2149,78 @@ def recompute_ready(conn: sqlite3.Connection) -> int:
     return promoted
 
 
+def auto_unblock_resolved_blocked_children(
+    conn: sqlite3.Connection,
+    parent_id: str,
+) -> int:
+    """Unblock blocked child tasks whose blocker parent just resolved.
+
+    This is the review/remediation retry valve: a review gate can be linked
+    as a child of the remediation card it is waiting on.  When the remediation
+    reaches ``done`` and every other parent is also done/archived, the blocked
+    review should become ``ready`` for re-review instead of waiting for a human
+    orchestrator to notice and run ``unblock`` manually.
+    """
+    released = 0
+    now = int(time.time())
+    with write_txn(conn):
+        rows = conn.execute(
+            "SELECT child_id FROM task_links l "
+            "JOIN tasks c ON c.id = l.child_id "
+            "WHERE l.parent_id = ? AND c.status = 'blocked' "
+            "ORDER BY c.created_at ASC",
+            (parent_id,),
+        ).fetchall()
+        for row in rows:
+            child_id = row["child_id"]
+            undone = conn.execute(
+                "SELECT 1 FROM task_links l "
+                "JOIN tasks p ON p.id = l.parent_id "
+                "WHERE l.child_id = ? "
+                "AND p.status NOT IN ('done', 'archived') LIMIT 1",
+                (child_id,),
+            ).fetchone()
+            if undone:
+                continue
+
+            stale = conn.execute(
+                "SELECT current_run_id FROM tasks WHERE id = ? AND status = 'blocked'",
+                (child_id,),
+            ).fetchone()
+            if stale and stale["current_run_id"]:
+                conn.execute(
+                    """
+                    UPDATE task_runs
+                       SET status = 'reclaimed', outcome = 'reclaimed',
+                           summary = COALESCE(summary, 'invariant recovery on auto-unblock'),
+                           ended_at = ?,
+                           claim_lock = NULL, claim_expires = NULL, worker_pid = NULL
+                     WHERE id = ? AND ended_at IS NULL
+                    """,
+                    (now, int(stale["current_run_id"])),
+                )
+
+            cur = conn.execute(
+                "UPDATE tasks SET status = 'ready', current_run_id = NULL "
+                "WHERE id = ? AND status = 'blocked'",
+                (child_id,),
+            )
+            if cur.rowcount != 1:
+                continue
+            _append_event(
+                conn,
+                child_id,
+                "unblocked",
+                {
+                    "status": "ready",
+                    "auto": True,
+                    "resolved_parent": parent_id,
+                },
+            )
+            released += 1
+    return released
+
+
 # ---------------------------------------------------------------------------
 # Claim / complete / block
 # ---------------------------------------------------------------------------
@@ -2895,6 +2967,10 @@ def complete_task(
     _clear_failure_counter(conn, task_id)
     # Recompute ready status for dependents (separate txn so children see done).
     recompute_ready(conn)
+    # If this completion resolved a remediation/blocker parent for a blocked
+    # review gate, wake that gate for re-review.  ``recompute_ready`` only
+    # promotes todo tasks; blocked tasks need this explicit retry valve.
+    auto_unblock_resolved_blocked_children(conn, task_id)
     # Clean up the scratch workspace and any stale tmux session for the worker.
     _cleanup_workspace(conn, task_id)
     return True

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -305,6 +305,57 @@ def test_recompute_ready_fan_in_waits_for_all_parents(kanban_home):
         assert kb.get_task(conn, c).status == "ready"
 
 
+def test_completed_blocker_auto_unblocks_blocked_gate(kanban_home):
+    """A blocked review gate linked under a remediation should wake up.
+
+    Review/remediation loops commonly look like:
+    implementation done -> review blocks -> remediation task runs -> review
+    should re-run. The remediation must be able to gate the blocked review
+    without requiring an orchestrator to manually unblock the review after the
+    remediation completes.
+    """
+    with kb.connect() as conn:
+        implementation = kb.create_task(conn, title="implementation")
+        kb.complete_task(conn, implementation, summary="implementation done")
+
+        review = kb.create_task(
+            conn,
+            title="review gate",
+            assignee="reviewer",
+            parents=[implementation],
+        )
+        review_task = kb.get_task(conn, review)
+        assert review_task is not None
+        assert review_task.status == "ready"
+        assert kb.claim_task(conn, review, claimer="host:reviewer") is not None
+
+        remediation = kb.create_task(
+            conn,
+            title="remediation",
+            assignee="worker",
+            parents=[implementation],
+        )
+        kb.link_tasks(conn, remediation, review)
+        assert kb.block_task(conn, review, reason="waiting on remediation")
+        review_task = kb.get_task(conn, review)
+        assert review_task is not None
+        assert review_task.status == "blocked"
+
+        kb.complete_task(conn, remediation, summary="remediation fixed")
+
+        review_task = kb.get_task(conn, review)
+        assert review_task is not None
+        assert review_task.status == "ready"
+        events = kb.list_events(conn, review)
+        assert any(
+            ev.kind == "unblocked"
+            and ev.payload
+            and ev.payload.get("auto") is True
+            and ev.payload.get("resolved_parent") == remediation
+            for ev in events
+        )
+
+
 # ---------------------------------------------------------------------------
 # Atomic claim (CAS)
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -604,7 +604,44 @@ def test_block_happy_path(worker_env):
     from hermes_cli import kanban_db as kb
     conn = kb.connect()
     try:
-        assert kb.get_task(conn, worker_env).status == "blocked"
+        task = kb.get_task(conn, worker_env)
+        assert task is not None
+        assert task.status == "blocked"
+    finally:
+        conn.close()
+
+
+def test_block_waits_on_cards_created_by_same_worker(worker_env):
+    """Create-remediation-then-block should self-wire the retry gate.
+
+    Workers often create a focused remediation card and then block the current
+    review/gate. The current task must be linked under that remediation so the
+    remediation completion can wake the gate for re-review.
+    """
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+
+    created = json.loads(kt._handle_create({
+        "title": "remediate finding",
+        "assignee": "test-worker",
+    }))
+    assert created["ok"] is True
+    remediation = created["task_id"]
+
+    blocked = json.loads(kt._handle_block({"reason": "waiting on remediation"}))
+    assert blocked["ok"] is True
+
+    conn = kb.connect()
+    try:
+        assert remediation in kb.parent_ids(conn, worker_env)
+        task = kb.get_task(conn, worker_env)
+        assert task is not None
+        assert task.status == "blocked"
+
+        assert kb.complete_task(conn, remediation, summary="fixed")
+        task = kb.get_task(conn, worker_env)
+        assert task is not None
+        assert task.status == "ready"
     finally:
         conn.close()
 

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -45,6 +45,12 @@ logger = logging.getLogger(__name__)
 KANBAN_LIST_DEFAULT_LIMIT = 50
 KANBAN_LIST_MAX_LIMIT = 200
 
+# Per-process memory of cards this worker created during the current task run.
+# When the same worker later blocks the task, these cards are treated as
+# remediation/blocker parents so their completion can wake the blocked gate for
+# retry.  This covers the common review pattern: create remediation -> block.
+_CREATED_TASKS_BY_WORKER_TASK: dict[str, list[str]] = {}
+
 
 def _profile_has_kanban_toolset() -> bool:
     # Uses load_config() which has mtime-based caching, so this adds
@@ -500,6 +506,7 @@ def _handle_complete(args: dict, **kw) -> str:
                 return tool_error(
                     f"could not complete {tid} (unknown id or already terminal)"
                 )
+            _CREATED_TASKS_BY_WORKER_TASK.pop(tid, None)
             run = kb.latest_run(conn, tid)
             return _ok(task_id=tid, run_id=run.id if run else None)
         finally:
@@ -528,6 +535,24 @@ def _handle_block(args: dict, **kw) -> str:
     try:
         kb, conn = _connect(board=board)
         try:
+            waiting_on = list(_CREATED_TASKS_BY_WORKER_TASK.get(tid, []))
+            for blocker_id in waiting_on:
+                if blocker_id == tid:
+                    continue
+                try:
+                    kb.link_tasks(conn, parent_id=blocker_id, child_id=tid)
+                except ValueError:
+                    # If the worker already parented the remediation on this
+                    # task, adding the reverse edge would create a cycle.  Do
+                    # not fail the block call; the explicit dependency graph is
+                    # already carrying the worker's intent and a reviewer can
+                    # diagnose the cycle from the events.
+                    logger.debug(
+                        "kanban_block skipped auto blocker link %s -> %s",
+                        blocker_id,
+                        tid,
+                        exc_info=True,
+                    )
             ok = kb.block_task(
                 conn, tid,
                 reason=reason,
@@ -538,6 +563,7 @@ def _handle_block(args: dict, **kw) -> str:
                     f"could not block {tid} (unknown id or not in "
                     f"running/ready)"
                 )
+            _CREATED_TASKS_BY_WORKER_TASK.pop(tid, None)
             run = kb.latest_run(conn, tid)
             return _ok(task_id=tid, run_id=run.id if run else None)
         finally:
@@ -707,6 +733,11 @@ def _handle_create(args: dict, **kw) -> str:
                 session_id=session_id,
             )
             new_task = kb.get_task(conn, new_tid)
+            current_tid = os.environ.get("HERMES_KANBAN_TASK")
+            if current_tid:
+                created = _CREATED_TASKS_BY_WORKER_TASK.setdefault(current_tid, [])
+                if new_tid not in created:
+                    created.append(new_tid)
             return _ok(
                 task_id=new_tid,
                 status=new_task.status if new_task else None,


### PR DESCRIPTION
## Summary
- add a Kanban retry valve that unblocks blocked child gates once a remediation parent completes
- surface blocker/remediation metadata through the kanban tool layer
- cover retry behavior and tool output with focused tests

## Test Plan
- python -m pytest tests/hermes_cli/test_kanban_db.py tests/tools/test_kanban_tools.py -q -o 'addopts='

## Notes
- rebased onto current origin/main before push
- pushed via fork because direct push to NousResearch/hermes-agent is not permitted for this account