### PR TITLE
feat: LiteLLM provider + pi_dual prompt cache strategy

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -68,6 +68,7 @@ def _ra():
     patches reach this code path.
     """
     import run_agent
+
     return run_agent
 
 
@@ -117,7 +118,9 @@ def _custom_provider_extra_body_for_agent(
     return fallback
 
 
-def _merge_custom_provider_extra_body(agent, custom_providers: List[Dict[str, Any]]) -> None:
+def _merge_custom_provider_extra_body(
+    agent, custom_providers: List[Dict[str, Any]]
+) -> None:
     extra_body = _custom_provider_extra_body_for_agent(
         provider=agent.provider,
         model=agent.model,
@@ -270,13 +273,17 @@ def init_agent(
     agent._chat_name = chat_name
     agent._chat_type = chat_type
     agent._thread_id = thread_id
-    agent._gateway_session_key = gateway_session_key  # Stable per-chat key (e.g. agent:main:telegram:dm:123)
+    agent._gateway_session_key = (
+        gateway_session_key  # Stable per-chat key (e.g. agent:main:telegram:dm:123)
+    )
     # Pluggable print function — CLI replaces this with _cprint so that
     # raw ANSI status lines are routed through prompt_toolkit's renderer
     # instead of going directly to stdout where patch_stdout's StdoutProxy
     # would mangle the escape sequences.  None = use builtins.print.
     agent._print_fn = None
-    agent.background_review_callback = None  # Optional sync callback for gateway delivery
+    agent.background_review_callback = (
+        None  # Optional sync callback for gateway delivery
+    )
     agent.skip_context_files = skip_context_files
     agent.load_soul_identity = load_soul_identity
     agent.pass_session_id = pass_session_id
@@ -285,11 +292,21 @@ def init_agent(
     agent.log_prefix = f"{log_prefix} " if log_prefix else ""
     # Store effective base URL for feature detection (prompt caching, reasoning, etc.)
     agent.base_url = base_url or ""
-    provider_name = provider.strip().lower() if isinstance(provider, str) and provider.strip() else None
+    provider_name = (
+        provider.strip().lower()
+        if isinstance(provider, str) and provider.strip()
+        else None
+    )
     agent.provider = provider_name or ""
     agent.acp_command = acp_command or command
     agent.acp_args = list(acp_args or args or [])
-    if api_mode in {"chat_completions", "codex_responses", "anthropic_messages", "bedrock_converse", "codex_app_server"}:
+    if api_mode in {
+        "chat_completions",
+        "codex_responses",
+        "anthropic_messages",
+        "bedrock_converse",
+        "codex_app_server",
+    }:
         agent.api_mode = api_mode
     elif agent.provider == "openai-codex":
         agent.api_mode = "codex_responses"
@@ -304,7 +321,9 @@ def init_agent(
     elif (provider_name is None) and agent._base_url_hostname == "api.x.ai":
         agent.api_mode = "codex_responses"
         agent.provider = "xai"
-    elif agent.provider == "anthropic" or (provider_name is None and agent._base_url_hostname == "api.anthropic.com"):
+    elif agent.provider == "anthropic" or (
+        provider_name is None and agent._base_url_hostname == "api.anthropic.com"
+    ):
         agent.api_mode = "anthropic_messages"
         agent.provider = "anthropic"
     elif agent._base_url_lower.rstrip("/").endswith("/anthropic"):
@@ -380,8 +399,9 @@ def init_agent(
     # AIAgent is created for every gateway request, so without the guard
     # each message leaks one OS thread and the process eventually exhausts
     # the system thread limit (RuntimeError: can't start new thread).
-    if (agent.provider == "openrouter" or agent._is_openrouter_url()) and \
-            not _ra()._openrouter_prewarm_done.is_set():
+    if (
+        agent.provider == "openrouter" or agent._is_openrouter_url()
+    ) and not _ra()._openrouter_prewarm_done.is_set():
         _ra()._openrouter_prewarm_done.set()
         threading.Thread(
             target=fetch_model_metadata,
@@ -402,7 +422,6 @@ def init_agent(
     agent.status_callback = status_callback
     agent.tool_gen_callback = tool_gen_callback
 
-    
     # Tool execution state — allows _vprint during tool execution
     # even when stream consumers are registered (no tokens streaming then)
     agent._executing_tools = False
@@ -435,12 +454,12 @@ def init_agent(
     # their tids explicitly.
     agent._tool_worker_threads: set[int] = set()
     agent._tool_worker_threads_lock = threading.Lock()
-    
+
     # Subagent delegation state
-    agent._delegate_depth = 0        # 0 = top-level agent, incremented for children
-    agent._active_children = []      # Running child AIAgents (for interrupt propagation)
+    agent._delegate_depth = 0  # 0 = top-level agent, incremented for children
+    agent._active_children = []  # Running child AIAgents (for interrupt propagation)
     agent._active_children_lock = threading.Lock()
-    
+
     # Store OpenRouter provider preferences
     agent.providers_allowed = providers_allowed
     agent.providers_ignored = providers_ignored
@@ -453,15 +472,17 @@ def init_agent(
     # Store toolset filtering options
     agent.enabled_toolsets = enabled_toolsets
     agent.disabled_toolsets = disabled_toolsets
-    
+
     # Model response configuration
     agent.max_tokens = max_tokens  # None = use model default
-    agent.reasoning_config = reasoning_config  # None = use default (medium for OpenRouter)
+    agent.reasoning_config = (
+        reasoning_config  # None = use default (medium for OpenRouter)
+    )
     agent.service_tier = service_tier
     agent.request_overrides = dict(request_overrides or {})
     agent.prefill_messages = prefill_messages or []  # Prefilled conversation turns
     agent._force_ascii_payload = False
-    
+
     # Anthropic prompt caching: auto-enabled for Claude models on native
     # Anthropic, OpenRouter, and third-party gateways that speak the
     # Anthropic protocol (``api_mode == 'anthropic_messages'``). Reduces
@@ -476,6 +497,7 @@ def init_agent(
     # 1h tier costs 2x on write vs 1.25x for 5m, but amortizes across long
     # sessions with >5-minute pauses between turns (#14971).
     agent._cache_ttl = "5m"
+    agent._cache_strategy = "system_and_3"
     try:
         from hermes_cli.config import load_config as _load_pc_cfg
 
@@ -483,6 +505,9 @@ def init_agent(
         _ttl = _pc_cfg.get("cache_ttl", "5m")
         if _ttl in {"5m", "1h"}:
             agent._cache_ttl = _ttl
+        _strat = _pc_cfg.get("strategy", "system_and_3")
+        if _strat in {"system_and_3", "pi_dual"}:
+            agent._cache_strategy = _strat
     except Exception:
         pass
 
@@ -516,11 +541,14 @@ def init_agent(
     # both live under ~/.hermes/logs/.  Idempotent, so gateway mode
     # (which creates a new AIAgent per message) won't duplicate handlers.
     from hermes_logging import setup_logging, setup_verbose_logging
+
     setup_logging(hermes_home=_ra()._hermes_home)
 
     if agent.verbose_logging:
         setup_verbose_logging()
-        _ra().logger.info("Verbose logging enabled (third-party library logs suppressed)")
+        _ra().logger.info(
+            "Verbose logging enabled (third-party library logs suppressed)"
+        )
     elif agent.quiet_mode:
         # In quiet mode (CLI default), keep console output clean —
         # but DO NOT raise per-logger levels. Doing so prevents the
@@ -533,7 +561,7 @@ def init_agent(
         # console. Any future noise reduction belongs at the
         # handler level inside hermes_logging.py, not here.
         pass
-    
+
     # Internal stream callback (set during streaming TTS).
     # Initialized here so _vprint can reference it before run_conversation.
     agent._stream_callback = None
@@ -583,13 +611,20 @@ def init_agent(
     _provider_timeout = get_provider_request_timeout(agent.provider, agent.model)
 
     if agent.api_mode == "anthropic_messages":
-        from agent.anthropic_adapter import build_anthropic_client, resolve_anthropic_token
+        from agent.anthropic_adapter import (
+            build_anthropic_client,
+            resolve_anthropic_token,
+        )
+
         # Bedrock + Claude → use AnthropicBedrock SDK for full feature parity
         # (prompt caching, thinking budgets, adaptive thinking).
         _is_bedrock_anthropic = agent.provider == "bedrock"
         if _is_bedrock_anthropic:
             from agent.anthropic_adapter import build_anthropic_bedrock_client
-            _region_match = re.search(r"bedrock-runtime\.([a-z0-9-]+)\.", base_url or "")
+
+            _region_match = re.search(
+                r"bedrock-runtime\.([a-z0-9-]+)\.", base_url or ""
+            )
             _br_region = _region_match.group(1) if _region_match else "us-east-1"
             agent._bedrock_region = _br_region
             agent._anthropic_client = build_anthropic_bedrock_client(_br_region)
@@ -600,13 +635,19 @@ def init_agent(
             agent.client = None
             agent._client_kwargs = {}
             if not agent.quiet_mode:
-                print(f"🤖 AI Agent initialized with model: {agent.model} (AWS Bedrock + AnthropicBedrock SDK, {_br_region})")
+                print(
+                    f"🤖 AI Agent initialized with model: {agent.model} (AWS Bedrock + AnthropicBedrock SDK, {_br_region})"
+                )
         else:
             # Only fall back to ANTHROPIC_TOKEN when the provider is actually Anthropic.
             # Other anthropic_messages providers (MiniMax, Alibaba, etc.) must use their own API key.
             # Falling back would send Anthropic credentials to third-party endpoints (Fixes #1739, #minimax-401).
             _is_native_anthropic = agent.provider == "anthropic"
-            effective_key = (api_key or resolve_anthropic_token() or "") if _is_native_anthropic else (api_key or "")
+            effective_key = (
+                (api_key or resolve_anthropic_token() or "")
+                if _is_native_anthropic
+                else (api_key or "")
+            )
             agent.api_key = effective_key
             agent._anthropic_api_key = effective_key
             agent._anthropic_base_url = base_url
@@ -618,13 +659,20 @@ def init_agent(
             # that cause 401/403 on their endpoints.  Guards #1739 and
             # the third-party identity-injection bug.
             from agent.anthropic_adapter import _is_oauth_token as _is_oat
-            agent._is_anthropic_oauth = _is_oat(effective_key) if _is_native_anthropic else False
-            agent._anthropic_client = build_anthropic_client(effective_key, base_url, timeout=_provider_timeout)
+
+            agent._is_anthropic_oauth = (
+                _is_oat(effective_key) if _is_native_anthropic else False
+            )
+            agent._anthropic_client = build_anthropic_client(
+                effective_key, base_url, timeout=_provider_timeout
+            )
             # No OpenAI client needed for Anthropic mode
             agent.client = None
             agent._client_kwargs = {}
             if not agent.quiet_mode:
-                print(f"🤖 AI Agent initialized with model: {agent.model} (Anthropic native)")
+                print(
+                    f"🤖 AI Agent initialized with model: {agent.model} (Anthropic native)"
+                )
                 # ``effective_key`` may be a callable Entra ID bearer
                 # provider for Azure Foundry anthropic_messages mode.
                 # The Anthropic adapter installs an httpx event hook
@@ -645,6 +693,7 @@ def init_agent(
         agent._bedrock_guardrail_config = None
         try:
             from hermes_cli.config import load_config as _load_br_cfg
+
             _gr = _load_br_cfg().get("bedrock", {}).get("guardrail", {})
             if _gr.get("guardrail_identifier") and _gr.get("guardrail_version"):
                 agent._bedrock_guardrail_config = {
@@ -652,7 +701,9 @@ def init_agent(
                     "guardrailVersion": _gr["guardrail_version"],
                 }
                 if _gr.get("stream_processing_mode"):
-                    agent._bedrock_guardrail_config["streamProcessingMode"] = _gr["stream_processing_mode"]
+                    agent._bedrock_guardrail_config["streamProcessingMode"] = _gr[
+                        "stream_processing_mode"
+                    ]
                 if _gr.get("trace"):
                     agent._bedrock_guardrail_config["trace"] = _gr["trace"]
         except Exception:
@@ -661,7 +712,9 @@ def init_agent(
         agent._client_kwargs = {}
         if not agent.quiet_mode:
             _gr_label = " + Guardrails" if agent._bedrock_guardrail_config else ""
-            print(f"🤖 AI Agent initialized with model: {agent.model} (AWS Bedrock, {agent._bedrock_region}{_gr_label})")
+            print(
+                f"🤖 AI Agent initialized with model: {agent.model} (AWS Bedrock, {agent._bedrock_region}{_gr_label})"
+            )
     else:
         if api_key and base_url:
             # Explicit credentials from CLI/gateway — construct directly.
@@ -690,10 +743,14 @@ def init_agent(
             effective_base = base_url
             if base_url_host_matches(effective_base, "openrouter.ai"):
                 from agent.auxiliary_client import build_or_headers
+
                 client_kwargs["default_headers"] = build_or_headers()
             elif base_url_host_matches(effective_base, "integrate.api.nvidia.com"):
                 from agent.auxiliary_client import build_nvidia_nim_headers
-                client_kwargs["default_headers"] = build_nvidia_nim_headers(effective_base)
+
+                client_kwargs["default_headers"] = build_nvidia_nim_headers(
+                    effective_base
+                )
             elif base_url_host_matches(effective_base, "api.routermint.com"):
                 client_kwargs["default_headers"] = _ra()._routermint_headers()
             elif base_url_host_matches(effective_base, "api.githubcopilot.com"):
@@ -708,6 +765,7 @@ def init_agent(
                 client_kwargs["default_headers"] = _ra()._qwen_portal_headers()
             elif base_url_host_matches(effective_base, "chatgpt.com"):
                 from agent.auxiliary_client import _codex_cloudflare_headers
+
                 client_kwargs["default_headers"] = _codex_cloudflare_headers(api_key)
             elif "default_headers" not in client_kwargs:
                 # Fall back to profile.default_headers for providers that
@@ -715,6 +773,7 @@ def init_agent(
                 # Kimi User-Agent on non-kimi.com endpoints).
                 try:
                     from providers import get_provider_profile as _gpf
+
                     _ph = _gpf(agent.provider)
                     if _ph and _ph.default_headers:
                         client_kwargs["default_headers"] = dict(_ph.default_headers)
@@ -723,8 +782,10 @@ def init_agent(
         else:
             # No explicit creds — use the centralized provider router
             from agent.auxiliary_client import resolve_provider_client
+
             _routed_client, _ = resolve_provider_client(
-                agent.provider or "auto", model=agent.model, raw_codex=True)
+                agent.provider or "auto", model=agent.model, raw_codex=True
+            )
             if _routed_client is not None:
                 client_kwargs = {
                     "api_key": _routed_client.api_key,
@@ -753,6 +814,7 @@ def init_agent(
                     _env_hint = f"{_explicit.upper()}_API_KEY"
                     try:
                         from hermes_cli.auth import PROVIDER_REGISTRY
+
                         _pcfg = PROVIDER_REGISTRY.get(_explicit)
                         if _pcfg and _pcfg.api_key_env_vars:
                             _env_hint = _pcfg.api_key_env_vars[0]
@@ -762,20 +824,33 @@ def init_agent(
                     _fb_entries = []
                     if isinstance(fallback_model, list):
                         _fb_entries = [
-                            f for f in fallback_model
-                            if isinstance(f, dict) and f.get("provider") and f.get("model")
+                            f
+                            for f in fallback_model
+                            if isinstance(f, dict)
+                            and f.get("provider")
+                            and f.get("model")
                         ]
-                    elif isinstance(fallback_model, dict) and fallback_model.get("provider") and fallback_model.get("model"):
+                    elif (
+                        isinstance(fallback_model, dict)
+                        and fallback_model.get("provider")
+                        and fallback_model.get("model")
+                    ):
                         _fb_entries = [fallback_model]
                     _fb_resolved = False
                     for _fb in _fb_entries:
                         _fb_explicit_key = (_fb.get("api_key") or "").strip() or None
                         if not _fb_explicit_key:
-                            _fb_key_env = (_fb.get("key_env") or _fb.get("api_key_env") or "").strip()
+                            _fb_key_env = (
+                                _fb.get("key_env") or _fb.get("api_key_env") or ""
+                            ).strip()
                             if _fb_key_env:
-                                _fb_explicit_key = os.getenv(_fb_key_env, "").strip() or None
+                                _fb_explicit_key = (
+                                    os.getenv(_fb_key_env, "").strip() or None
+                                )
                         _fb_client, _fb_model = resolve_provider_client(
-                            _fb["provider"], model=_fb["model"], raw_codex=True,
+                            _fb["provider"],
+                            model=_fb["model"],
+                            raw_codex=True,
                             explicit_base_url=_fb.get("base_url"),
                             explicit_api_key=_fb_explicit_key,
                         )
@@ -791,7 +866,9 @@ def init_agent(
                                 client_kwargs["timeout"] = _provider_timeout
                             _fb_headers = getattr(_fb_client, "_custom_headers", None)
                             if not _fb_headers:
-                                _fb_headers = getattr(_fb_client, "_default_headers", None)
+                                _fb_headers = getattr(
+                                    _fb_client, "_default_headers", None
+                                )
                             if _fb_headers:
                                 client_kwargs["default_headers"] = dict(_fb_headers)
                             _fb_resolved = True
@@ -809,7 +886,7 @@ def init_agent(
                         "select a provider, or run `hermes setup` for first-time "
                         "configuration."
                     )
-        
+
         agent._client_kwargs = client_kwargs  # stored for rebuilding after interrupt
 
         # Enable fine-grained tool streaming for Claude on OpenRouter.
@@ -819,7 +896,10 @@ def init_agent(
         # stream tool call arguments token-by-token, keeping the
         # connection alive.
         _effective_base = str(client_kwargs.get("base_url", "")).lower()
-        if base_url_host_matches(_effective_base, "openrouter.ai") and "claude" in (agent.model or "").lower():
+        if (
+            base_url_host_matches(_effective_base, "openrouter.ai")
+            and "claude" in (agent.model or "").lower()
+        ):
             headers = client_kwargs.get("default_headers") or {}
             existing_beta = headers.get("x-anthropic-beta", "")
             _FINE_GRAINED = "fine-grained-tool-streaming-2025-05-14"
@@ -833,7 +913,9 @@ def init_agent(
         agent.api_key = client_kwargs.get("api_key", "")
         agent.base_url = client_kwargs.get("base_url", agent.base_url)
         try:
-            agent.client = agent._create_openai_client(client_kwargs, reason="agent_init", shared=True)
+            agent.client = agent._create_openai_client(
+                client_kwargs, reason="agent_init", shared=True
+            )
             if not agent.quiet_mode:
                 print(f"🤖 AI Agent initialized with model: {agent.model}")
                 if base_url:
@@ -847,23 +929,33 @@ def init_agent(
                 key_used = client_kwargs.get("api_key", "none")
                 if is_token_provider(key_used):
                     print("🔑 Using credentials: Microsoft Entra ID")
-                elif isinstance(key_used, str) and key_used and key_used != "dummy-key" and len(key_used) > 12:
+                elif (
+                    isinstance(key_used, str)
+                    and key_used
+                    and key_used != "dummy-key"
+                    and len(key_used) > 12
+                ):
                     print(f"🔑 Using API key: {key_used[:8]}...{key_used[-4:]}")
                 else:
                     print("⚠️  Warning: API key appears invalid or missing")
         except Exception as e:
             raise RuntimeError(f"Failed to initialize OpenAI client: {e}")
-    
+
     # Provider fallback chain — ordered list of backup providers tried
     # when the primary is exhausted (rate-limit, overload, connection
     # failure).  Supports both legacy single-dict ``fallback_model`` and
     # new list ``fallback_providers`` format.
     if isinstance(fallback_model, list):
         agent._fallback_chain = [
-            f for f in fallback_model
+            f
+            for f in fallback_model
             if isinstance(f, dict) and f.get("provider") and f.get("model")
         ]
-    elif isinstance(fallback_model, dict) and fallback_model.get("provider") and fallback_model.get("model"):
+    elif (
+        isinstance(fallback_model, dict)
+        and fallback_model.get("provider")
+        and fallback_model.get("model")
+    ):
         agent._fallback_chain = [fallback_model]
     else:
         agent._fallback_chain = []
@@ -876,8 +968,12 @@ def init_agent(
             fb = agent._fallback_chain[0]
             print(f"🔄 Fallback model: {fb['model']} ({fb['provider']})")
         else:
-            print(f"🔄 Fallback chain ({len(agent._fallback_chain)} providers): " +
-                  " → ".join(f"{f['model']} ({f['provider']})" for f in agent._fallback_chain))
+            print(
+                f"🔄 Fallback chain ({len(agent._fallback_chain)} providers): "
+                + " → ".join(
+                    f"{f['model']} ({f['provider']})" for f in agent._fallback_chain
+                )
+            )
 
     # Get available tools with filtering
     agent.tools = _ra().get_tool_definitions(
@@ -885,7 +981,7 @@ def init_agent(
         disabled_toolsets=disabled_toolsets,
         quiet_mode=agent.quiet_mode,
     )
-    
+
     # Show tool configuration and store valid tool names for validation
     agent.valid_tool_names = set()
     if agent.tools:
@@ -908,6 +1004,7 @@ def init_agent(
     # membership test + reference on every system-prompt rebuild
     # (init + each context compression).
     from agent.prompt_builder import KANBAN_GUIDANCE
+
     agent._kanban_worker_guidance = (
         KANBAN_GUIDANCE if "kanban_show" in agent.valid_tool_names else ""
     )
@@ -915,19 +1012,29 @@ def init_agent(
     # Check tool requirements
     if agent.tools and not agent.quiet_mode:
         requirements = _ra().check_toolset_requirements()
-        missing_reqs = [name for name, available in requirements.items() if not available]
+        missing_reqs = [
+            name for name, available in requirements.items() if not available
+        ]
         if missing_reqs:
-            print(f"⚠️  Some tools may not work due to missing requirements: {missing_reqs}")
-    
+            print(
+                f"⚠️  Some tools may not work due to missing requirements: {missing_reqs}"
+            )
+
     # Show trajectory saving status
     if agent.save_trajectories and not agent.quiet_mode:
         print("📝 Trajectory saving enabled")
-    
+
     # Show ephemeral system prompt status
     if agent.ephemeral_system_prompt and not agent.quiet_mode:
-        prompt_preview = agent.ephemeral_system_prompt[:60] + "..." if len(agent.ephemeral_system_prompt) > 60 else agent.ephemeral_system_prompt
-        print(f"🔒 Ephemeral system prompt: '{prompt_preview}' (not saved to trajectories)")
-    
+        prompt_preview = (
+            agent.ephemeral_system_prompt[:60] + "..."
+            if len(agent.ephemeral_system_prompt) > 60
+            else agent.ephemeral_system_prompt
+        )
+        print(
+            f"🔒 Ephemeral system prompt: '{prompt_preview}' (not saved to trajectories)"
+        )
+
     # Show prompt caching status
     if agent._use_prompt_caching and not agent.quiet_mode:
         if agent._use_native_cache_layout and agent.provider == "anthropic":
@@ -937,7 +1044,7 @@ def init_agent(
         else:
             source = "Claude via OpenRouter"
         print(f"💾 Prompt caching: ENABLED ({source}, {agent._cache_ttl} TTL)")
-    
+
     # Session logging setup - auto-save conversation trajectories for debugging
     agent.session_start = datetime.now()
     if session_id:
@@ -958,6 +1065,7 @@ def init_agent(
     os.environ["HERMES_SESSION_ID"] = agent.session_id
     try:
         from gateway.session_context import _SESSION_ID
+
         _SESSION_ID.set(agent.session_id)
     except Exception:
         pass  # CLI/test mode — ContextVar not needed
@@ -973,30 +1081,32 @@ def init_agent(
     agent._session_json_enabled = False
     try:
         from hermes_cli.config import load_config as _load_sess_cfg
-        _sess_cfg = (_load_sess_cfg().get("sessions") or {})
+
+        _sess_cfg = _load_sess_cfg().get("sessions") or {}
         agent._session_json_enabled = bool(_sess_cfg.get("write_json_snapshots", False))
     except Exception:
         pass
     # logs_dir is retained unconditionally for request_dump_*.json (debug
     # breadcrumb path written by agent_runtime_helpers.dump_api_request_debug).
-    
+
     # Track conversation messages for session logging
     agent._session_messages: List[Dict[str, Any]] = []
     agent._memory_write_origin = "assistant_tool"
     agent._memory_write_context = "foreground"
-    
+
     # Cached system prompt -- built once per session, only rebuilt on compression
     agent._cached_system_prompt: Optional[str] = None
-    
+
     # Filesystem checkpoint manager (transparent — not a tool)
     from tools.checkpoint_manager import CheckpointManager
+
     agent._checkpoint_mgr = CheckpointManager(
         enabled=checkpoints_enabled,
         max_snapshots=checkpoint_max_snapshots,
         max_total_size_mb=checkpoint_max_total_size_mb,
         max_file_size_mb=checkpoint_max_file_size_mb,
     )
-    
+
     # SQLite session store (optional -- provided by CLI or gateway)
     agent._session_db = session_db
     agent._parent_session_id = parent_session_id
@@ -1007,14 +1117,16 @@ def init_agent(
         "reasoning_config": reasoning_config,
         "max_tokens": max_tokens,
     }
-    
+
     # In-memory todo list for task planning (one per agent/session)
     from tools.todo_tool import TodoStore
+
     agent._todo_store = TodoStore()
-    
+
     # Load config once for memory, skills, and compression sections
     try:
         from hermes_cli.config import load_config as _load_agent_config
+
         _agent_cfg = _load_agent_config()
     except Exception:
         _agent_cfg = {}
@@ -1046,6 +1158,7 @@ def init_agent(
             agent._memory_nudge_interval = int(mem_config.get("nudge_interval", 10))
             if agent._memory_enabled or agent._user_profile_enabled:
                 from tools.memory_tool import MemoryStore
+
                 agent._memory_store = MemoryStore(
                     memory_char_limit=mem_config.get("memory_char_limit", 2200),
                     user_char_limit=mem_config.get("user_char_limit", 1375),
@@ -1053,8 +1166,6 @@ def init_agent(
                 agent._memory_store.load_from_disk()
         except Exception:
             pass  # Memory is optional -- don't break agent init
-    
-
 
     # Memory provider plugin (external — one at a time, alongside built-in)
     # Reads memory.provider from config to select which plugin to activate.
@@ -1066,6 +1177,7 @@ def init_agent(
             if _mem_provider_name and _mem_provider_name.strip():
                 from agent.memory_manager import MemoryManager as _MemoryManager
                 from plugins.memory import load_memory_provider as _load_mem
+
                 agent._memory_manager = _MemoryManager()
                 _mp = _load_mem(_mem_provider_name)
                 if _mp and _mp.is_available():
@@ -1105,15 +1217,21 @@ def init_agent(
                     # Profile identity for per-profile provider scoping
                     try:
                         from hermes_cli.profiles import get_active_profile_name
+
                         _profile = get_active_profile_name()
                         _init_kwargs["agent_identity"] = _profile
                         _init_kwargs["agent_workspace"] = "hermes"
                     except Exception:
                         pass
                     agent._memory_manager.initialize_all(**_init_kwargs)
-                    _ra().logger.info("Memory provider '%s' activated", _mem_provider_name)
+                    _ra().logger.info(
+                        "Memory provider '%s' activated", _mem_provider_name
+                    )
                 else:
-                    _ra().logger.debug("Memory provider '%s' not found or not available", _mem_provider_name)
+                    _ra().logger.debug(
+                        "Memory provider '%s' not found or not available",
+                        _mem_provider_name,
+                    )
                     agent._memory_manager = None
         except Exception as _mpe:
             _ra().logger.warning("Memory provider plugin init failed: %s", _mpe)
@@ -1145,7 +1263,9 @@ def init_agent(
     agent._skill_nudge_interval = 10
     try:
         skills_config = _agent_cfg.get("skills", {})
-        agent._skill_nudge_interval = int(skills_config.get("creation_nudge_interval", 10))
+        agent._skill_nudge_interval = int(
+            skills_config.get("creation_nudge_interval", 10)
+        )
     except Exception:
         pass
 
@@ -1174,13 +1294,20 @@ def init_agent(
         _compression_cfg = {}
     compression_threshold = float(_compression_cfg.get("threshold", 0.50))
     try:
-        from agent.auxiliary_client import _compression_threshold_for_model as _cthresh_fn
+        from agent.auxiliary_client import (
+            _compression_threshold_for_model as _cthresh_fn,
+        )
+
         _model_cthresh = _cthresh_fn(agent.model)
         if _model_cthresh is not None:
             compression_threshold = _model_cthresh
     except Exception:
         pass
-    compression_enabled = str(_compression_cfg.get("enabled", True)).lower() in {"true", "1", "yes"}
+    compression_enabled = str(_compression_cfg.get("enabled", True)).lower() in {
+        "true",
+        "1",
+        "yes",
+    }
     compression_target_ratio = float(_compression_cfg.get("target_ratio", 0.20))
     compression_protect_last = int(_compression_cfg.get("protect_last_n", 20))
     # protect_first_n is the number of non-system messages to protect at
@@ -1189,9 +1316,7 @@ def init_agent(
     # 0 means "preserve only the system prompt + summary + tail", which
     # is a legitimate (and common) configuration for long-running
     # rolling-compaction sessions.
-    compression_protect_first = max(
-        0, int(_compression_cfg.get("protect_first_n", 3))
-    )
+    compression_protect_first = max(0, int(_compression_cfg.get("protect_first_n", 3)))
     compression_abort_on_summary_failure = str(
         _compression_cfg.get("abort_on_summary_failure", False)
     ).lower() in {"true", "1", "yes"}
@@ -1269,6 +1394,7 @@ def init_agent(
     # context-length override and plugin context-engine init).
     try:
         from hermes_cli.config import get_compatible_custom_providers
+
         _custom_providers = get_compatible_custom_providers(_agent_cfg)
     except Exception:
         _custom_providers = _agent_cfg.get("custom_providers")
@@ -1284,6 +1410,7 @@ def init_agent(
     if _config_context_length is None and _custom_providers:
         try:
             from hermes_cli.config import get_custom_provider_context_length
+
             _cp_ctx_resolved = get_custom_provider_context_length(
                 model=agent.model,
                 base_url=agent.base_url,
@@ -1319,7 +1446,8 @@ def init_agent(
                                         "custom_providers: %r — must be a positive "
                                         "integer (e.g. 256000, not '256K'). "
                                         "Falling back to auto-detection.",
-                                        agent.model, _cp_ctx,
+                                        agent.model,
+                                        _cp_ctx,
                                     )
                                     print(
                                         f"\n⚠ Invalid context_length for model {agent.model!r} in custom_providers: {_cp_ctx!r}\n"
@@ -1334,8 +1462,6 @@ def init_agent(
     agent._config_context_length = _config_context_length
 
     agent._ensure_lmstudio_runtime_loaded(_config_context_length)
-
-
 
     # Select context engine: config-driven (like memory providers).
     # 1. Check config.yaml context.engine setting
@@ -1354,14 +1480,18 @@ def init_agent(
         # Try loading from plugins/context_engine/<name>/
         try:
             from plugins.context_engine import load_context_engine
+
             _selected_engine = load_context_engine(_engine_name)
         except Exception as _ce_load_err:
-            _ra().logger.debug("Context engine load from plugins/context_engine/: %s", _ce_load_err)
+            _ra().logger.debug(
+                "Context engine load from plugins/context_engine/: %s", _ce_load_err
+            )
 
         # Try general plugin system as fallback
         if _selected_engine is None:
             try:
                 from hermes_cli.plugins import get_plugin_context_engine
+
                 _candidate = get_plugin_context_engine()
                 if _candidate and _candidate.name == _engine_name:
                     _selected_engine = _candidate
@@ -1379,6 +1509,7 @@ def init_agent(
         agent.context_compressor = _selected_engine
         # Resolve context_length for plugin engines — mirrors switch_model() path
         from agent.model_metadata import get_model_context_length
+
         _plugin_ctx_len = get_model_context_length(
             agent.model,
             base_url=agent.base_url,
@@ -1417,6 +1548,7 @@ def init_agent(
     # Reject models whose context window is below the minimum required
     # for reliable tool-calling workflows (64K tokens).
     from agent.model_metadata import MINIMUM_CONTEXT_LENGTH
+
     _ctx = getattr(agent.context_compressor, "context_length", 0)
     if _ctx and _ctx < MINIMUM_CONTEXT_LENGTH:
         raise ValueError(
@@ -1436,7 +1568,11 @@ def init_agent(
     # against plugin paths that may register the same schemas via
     # ctx.register_tool(). Mirrors the memory tools dedup above.
     agent._context_engine_tool_names: set = set()
-    if hasattr(agent, "context_compressor") and agent.context_compressor and agent.tools is not None:
+    if (
+        hasattr(agent, "context_compressor")
+        and agent.context_compressor
+        and agent.tools is not None
+    ):
         _existing_tool_names = {
             t.get("function", {}).get("name")
             for t in agent.tools
@@ -1484,7 +1620,7 @@ def init_agent(
     agent.session_estimated_cost_usd = 0.0
     agent.session_cost_status = "unknown"
     agent.session_cost_source = "none"
-    
+
     # ── Ollama num_ctx injection ──
     # Ollama defaults to 2048 context regardless of the model's capabilities.
     # When running against an Ollama server, detect the model's max context
@@ -1500,15 +1636,23 @@ def init_agent(
         try:
             agent._ollama_num_ctx = int(_ollama_num_ctx_override)
         except (TypeError, ValueError):
-            _ra().logger.debug("Invalid ollama_num_ctx config value: %r", _ollama_num_ctx_override)
-    if agent._ollama_num_ctx is None and agent.base_url and is_local_endpoint(agent.base_url):
+            _ra().logger.debug(
+                "Invalid ollama_num_ctx config value: %r", _ollama_num_ctx_override
+            )
+    if (
+        agent._ollama_num_ctx is None
+        and agent.base_url
+        and is_local_endpoint(agent.base_url)
+    ):
         try:
             # ``agent.api_key`` may be a callable (Entra token provider).
             # Ollama detection makes a manual HTTP request and expects a
             # string — Azure Foundry isn't a local endpoint so this branch
             # never fires for Entra, but guard defensively.
             _key_for_ollama = agent.api_key if isinstance(agent.api_key, str) else ""
-            _detected = query_ollama_num_ctx(agent.model, agent.base_url, api_key=_key_for_ollama or "")
+            _detected = query_ollama_num_ctx(
+                agent.model, agent.base_url, api_key=_key_for_ollama or ""
+            )
             if _detected and _detected > 0:
                 agent._ollama_num_ctx = _detected
         except Exception as exc:
@@ -1525,7 +1669,8 @@ def init_agent(
     ):
         _ra().logger.info(
             "Ollama num_ctx capped: %d -> %d (model.context_length override)",
-            agent._ollama_num_ctx, _config_context_length,
+            agent._ollama_num_ctx,
+            _config_context_length,
         )
         agent._ollama_num_ctx = _config_context_length
     if agent._ollama_num_ctx and not agent.quiet_mode:
@@ -1536,9 +1681,13 @@ def init_agent(
 
     if not agent.quiet_mode:
         if compression_enabled:
-            print(f"📊 Context limit: {agent.context_compressor.context_length:,} tokens (compress at {int(compression_threshold*100)}% = {agent.context_compressor.threshold_tokens:,})")
+            print(
+                f"📊 Context limit: {agent.context_compressor.context_length:,} tokens (compress at {int(compression_threshold*100)}% = {agent.context_compressor.threshold_tokens:,})"
+            )
         else:
-            print(f"📊 Context limit: {agent.context_compressor.context_length:,} tokens (auto-compression disabled)")
+            print(
+                f"📊 Context limit: {agent.context_compressor.context_length:,} tokens (auto-compression disabled)"
+            )
 
     # Check immediately so CLI users see the warning at startup.
     # Gateway status_callback is not yet wired, so any warning is stored
@@ -1577,12 +1726,13 @@ def init_agent(
         "compressor_threshold_tokens": _cc.threshold_tokens,
     }
     if agent.api_mode == "anthropic_messages":
-        agent._primary_runtime.update({
-            "anthropic_api_key": agent._anthropic_api_key,
-            "anthropic_base_url": agent._anthropic_base_url,
-            "is_anthropic_oauth": agent._is_anthropic_oauth,
-        })
-
+        agent._primary_runtime.update(
+            {
+                "anthropic_api_key": agent._anthropic_api_key,
+                "anthropic_base_url": agent._anthropic_base_url,
+                "is_anthropic_oauth": agent._is_anthropic_oauth,
+            }
+        )
 
 
 __all__ = ["init_agent"]

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -39,10 +39,18 @@ from agent.message_sanitization import (
     _repair_tool_call_arguments,
     _sanitize_surrogates,
 )
-from agent.tool_dispatch_helpers import _trajectory_normalize_msg, make_tool_result_message
+from agent.tool_dispatch_helpers import (
+    _trajectory_normalize_msg,
+    make_tool_result_message,
+)
 from agent.trajectory import convert_scratchpad_to_think
 from agent.error_classifier import classify_api_error, FailoverReason
-from utils import base_url_host_matches, base_url_hostname, env_var_enabled, atomic_json_write
+from utils import (
+    base_url_host_matches,
+    base_url_hostname,
+    env_var_enabled,
+    atomic_json_write,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -50,19 +58,21 @@ logger = logging.getLogger(__name__)
 def _ra():
     """Lazy ``run_agent`` reference for test-patch routing."""
     import run_agent
+
     return run_agent
 
 
-
-def convert_to_trajectory_format(agent, messages: List[Dict[str, Any]], user_query: str, completed: bool) -> List[Dict[str, Any]]:
+def convert_to_trajectory_format(
+    agent, messages: List[Dict[str, Any]], user_query: str, completed: bool
+) -> List[Dict[str, Any]]:
     """
     Convert internal message format to trajectory format for saving.
-    
+
     Args:
         messages (List[Dict]): Internal message history
         user_query (str): Original user query
         completed (bool): Whether the conversation completed successfully
-        
+
     Returns:
         List[Dict]: Messages in trajectory format
     """
@@ -71,7 +81,7 @@ def convert_to_trajectory_format(agent, messages: List[Dict[str, Any]], user_que
     # embedding ~1MB base64 blobs into every saved trajectory.
     messages = [_trajectory_normalize_msg(m) for m in messages]
     trajectory = []
-    
+
     # Add system message with tool definitions
     system_msg = (
         "You are a function calling AI model. You are provided with function signatures within <tools> </tools> XML tags. "
@@ -86,71 +96,69 @@ def convert_to_trajectory_format(agent, messages: List[Dict[str, Any]], user_que
         "Each function call should be enclosed within <tool_call> </tool_call> XML tags.\n"
         "Example:\n<tool_call>\n{'name': <function-name>,'arguments': <args-dict>}\n</tool_call>"
     )
-    
-    trajectory.append({
-        "from": "system",
-        "value": system_msg
-    })
-    
+
+    trajectory.append({"from": "system", "value": system_msg})
+
     # Add the actual user prompt (from the dataset) as the first human message
-    trajectory.append({
-        "from": "human",
-        "value": user_query
-    })
-    
+    trajectory.append({"from": "human", "value": user_query})
+
     # Skip the first message (the user query) since we already added it above.
     # Prefill messages are injected at API-call time only (not in the messages
     # list), so no offset adjustment is needed here.
     i = 1
-    
+
     while i < len(messages):
         msg = messages[i]
-        
+
         if msg["role"] == "assistant":
             # Check if this message has tool calls
             if "tool_calls" in msg and msg["tool_calls"]:
                 # Format assistant message with tool calls
                 # Add <think> tags around reasoning for trajectory storage
                 content = ""
-                
+
                 # Prepend reasoning in <think> tags if available (native thinking tokens)
                 if msg.get("reasoning") and msg["reasoning"].strip():
                     content = f"<think>\n{msg['reasoning']}\n</think>\n"
-                
+
                 if msg.get("content") and msg["content"].strip():
                     # Convert any <REASONING_SCRATCHPAD> tags to <think> tags
                     # (used when native thinking is disabled and model reasons via XML)
                     content += convert_scratchpad_to_think(msg["content"]) + "\n"
-                
+
                 # Add tool calls wrapped in XML tags
                 for tool_call in msg["tool_calls"]:
-                    if not tool_call or not isinstance(tool_call, dict): continue
+                    if not tool_call or not isinstance(tool_call, dict):
+                        continue
                     # Parse arguments - should always succeed since we validate during conversation
                     # but keep try-except as safety net
                     try:
-                        arguments = json.loads(tool_call["function"]["arguments"]) if isinstance(tool_call["function"]["arguments"], str) else tool_call["function"]["arguments"]
+                        arguments = (
+                            json.loads(tool_call["function"]["arguments"])
+                            if isinstance(tool_call["function"]["arguments"], str)
+                            else tool_call["function"]["arguments"]
+                        )
                     except json.JSONDecodeError:
                         # This shouldn't happen since we validate and retry during conversation,
                         # but if it does, log warning and use empty dict
-                        logging.warning(f"Unexpected invalid JSON in trajectory conversion: {tool_call['function']['arguments'][:100]}")
+                        logging.warning(
+                            f"Unexpected invalid JSON in trajectory conversion: {tool_call['function']['arguments'][:100]}"
+                        )
                         arguments = {}
-                    
+
                     tool_call_json = {
                         "name": tool_call["function"]["name"],
-                        "arguments": arguments
+                        "arguments": arguments,
                     }
                     content += f"<tool_call>\n{json.dumps(tool_call_json, ensure_ascii=False)}\n</tool_call>\n"
-                
+
                 # Ensure every gpt turn has a <think> block (empty if no reasoning)
                 # so the format is consistent for training data
                 if "<think>" not in content:
                     content = "<think>\n</think>\n" + content
-                
-                trajectory.append({
-                    "from": "gpt",
-                    "value": content.rstrip()
-                })
-                
+
+                trajectory.append({"from": "gpt", "value": content.rstrip()})
+
                 # Collect all subsequent tool responses
                 tool_responses = []
                 j = i + 1
@@ -158,7 +166,7 @@ def convert_to_trajectory_format(agent, messages: List[Dict[str, Any]], user_que
                     tool_msg = messages[j]
                     # Format tool response with XML tags
                     tool_response = "<tool_response>\n"
-                    
+
                     # Try to parse tool content as JSON if it looks like JSON
                     tool_content = tool_msg["content"]
                     try:
@@ -166,63 +174,58 @@ def convert_to_trajectory_format(agent, messages: List[Dict[str, Any]], user_que
                             tool_content = json.loads(tool_content)
                     except (json.JSONDecodeError, AttributeError):
                         pass  # Keep as string if not valid JSON
-                    
+
                     tool_index = len(tool_responses)
                     tool_name = (
                         msg["tool_calls"][tool_index]["function"]["name"]
                         if tool_index < len(msg["tool_calls"])
                         else "unknown"
                     )
-                    tool_response += json.dumps({
-                        "tool_call_id": tool_msg.get("tool_call_id", ""),
-                        "name": tool_name,
-                        "content": tool_content
-                    }, ensure_ascii=False)
+                    tool_response += json.dumps(
+                        {
+                            "tool_call_id": tool_msg.get("tool_call_id", ""),
+                            "name": tool_name,
+                            "content": tool_content,
+                        },
+                        ensure_ascii=False,
+                    )
                     tool_response += "\n</tool_response>"
                     tool_responses.append(tool_response)
                     j += 1
-                
+
                 # Add all tool responses as a single message
                 if tool_responses:
-                    trajectory.append({
-                        "from": "tool",
-                        "value": "\n".join(tool_responses)
-                    })
+                    trajectory.append(
+                        {"from": "tool", "value": "\n".join(tool_responses)}
+                    )
                     i = j - 1  # Skip the tool messages we just processed
-            
+
             else:
                 # Regular assistant message without tool calls
                 # Add <think> tags around reasoning for trajectory storage
                 content = ""
-                
+
                 # Prepend reasoning in <think> tags if available (native thinking tokens)
                 if msg.get("reasoning") and msg["reasoning"].strip():
                     content = f"<think>\n{msg['reasoning']}\n</think>\n"
-                
+
                 # Convert any <REASONING_SCRATCHPAD> tags to <think> tags
                 # (used when native thinking is disabled and model reasons via XML)
                 raw_content = msg["content"] or ""
                 content += convert_scratchpad_to_think(raw_content)
-                
+
                 # Ensure every gpt turn has a <think> block (empty if no reasoning)
                 if "<think>" not in content:
                     content = "<think>\n</think>\n" + content
-                
-                trajectory.append({
-                    "from": "gpt",
-                    "value": content.strip()
-                })
-        
-        elif msg["role"] == "user":
-            trajectory.append({
-                "from": "human",
-                "value": msg["content"]
-            })
-        
-        i += 1
-    
-    return trajectory
 
+                trajectory.append({"from": "gpt", "value": content.strip()})
+
+        elif msg["role"] == "user":
+            trajectory.append({"from": "human", "value": msg["content"]})
+
+        i += 1
+
+    return trajectory
 
 
 def sanitize_tool_call_arguments(
@@ -307,7 +310,10 @@ def sanitize_tool_call_arguments(
                 scan_index = message_index + 1
                 while scan_index < len(messages):
                     candidate = messages[scan_index]
-                    if not isinstance(candidate, dict) or candidate.get("role") != "tool":
+                    if (
+                        not isinstance(candidate, dict)
+                        or candidate.get("role") != "tool"
+                    ):
                         break
                     if candidate.get("tool_call_id") == tool_call_id:
                         existing_tool_msg = candidate
@@ -332,7 +338,6 @@ def sanitize_tool_call_arguments(
         message_index += 1
 
     return repaired
-
 
 
 def repair_message_sequence(agent, messages: List[Dict]) -> int:
@@ -382,7 +387,7 @@ def repair_message_sequence(agent, messages: List[Dict]) -> int:
         role = msg.get("role")
         if role == "assistant":
             known_tool_ids = set()
-            for tc in (msg.get("tool_calls") or []):
+            for tc in msg.get("tool_calls") or []:
                 tc_id = tc.get("id") if isinstance(tc, dict) else None
                 if tc_id:
                     known_tool_ids.add(tc_id)
@@ -436,7 +441,6 @@ def repair_message_sequence(agent, messages: List[Dict]) -> int:
     return repairs
 
 
-
 def strip_think_blocks(agent, content: str) -> str:
     """Remove reasoning/thinking blocks from content, returning only visible text.
 
@@ -473,19 +477,37 @@ def strip_think_blocks(agent, content: str) -> str:
     # 1. Closed tag pairs — case-insensitive for all variants so
     #    mixed-case tags (<THINK>, <Thinking>) don't slip through to
     #    the unterminated-tag pass and take trailing content with them.
-    content = re.sub(r'<think>.*?</think>', '', content, flags=re.DOTALL | re.IGNORECASE)
-    content = re.sub(r'<thinking>.*?</thinking>', '', content, flags=re.DOTALL | re.IGNORECASE)
-    content = re.sub(r'<reasoning>.*?</reasoning>', '', content, flags=re.DOTALL | re.IGNORECASE)
-    content = re.sub(r'<REASONING_SCRATCHPAD>.*?</REASONING_SCRATCHPAD>', '', content, flags=re.DOTALL | re.IGNORECASE)
-    content = re.sub(r'<thought>.*?</thought>', '', content, flags=re.DOTALL | re.IGNORECASE)
+    content = re.sub(
+        r"<think>.*?</think>", "", content, flags=re.DOTALL | re.IGNORECASE
+    )
+    content = re.sub(
+        r"<thinking>.*?</thinking>", "", content, flags=re.DOTALL | re.IGNORECASE
+    )
+    content = re.sub(
+        r"<reasoning>.*?</reasoning>", "", content, flags=re.DOTALL | re.IGNORECASE
+    )
+    content = re.sub(
+        r"<REASONING_SCRATCHPAD>.*?</REASONING_SCRATCHPAD>",
+        "",
+        content,
+        flags=re.DOTALL | re.IGNORECASE,
+    )
+    content = re.sub(
+        r"<thought>.*?</thought>", "", content, flags=re.DOTALL | re.IGNORECASE
+    )
     # 1b. Tool-call XML blocks (openclaw/openclaw#67318). Handle the
     #     generic tag names first — they have no attribute gating since
     #     a literal <tool_call> in prose is already vanishingly rare.
-    for _tc_name in ("tool_call", "tool_calls", "tool_result",
-                      "function_call", "function_calls"):
+    for _tc_name in (
+        "tool_call",
+        "tool_calls",
+        "tool_result",
+        "function_call",
+        "function_calls",
+    ):
         content = re.sub(
-            rf'<{_tc_name}\b[^>]*>.*?</{_tc_name}>',
-            '',
+            rf"<{_tc_name}\b[^>]*>.*?</{_tc_name}>",
+            "",
             content,
             flags=re.DOTALL | re.IGNORECASE,
         )
@@ -495,10 +517,10 @@ def strip_think_blocks(agent, content: str) -> str:
     #     punctuation) AND carries a name="..." attribute. This keeps
     #     prose mentions like "Use <function> to declare" safe.
     content = re.sub(
-        r'(?:(?<=^)|(?<=[\n\r.!?:]))[ \t]*'
-        r'<function\b[^>]*\bname\s*=[^>]*>'
-        r'(?:(?:(?!</function>).)*)</function>',
-        '',
+        r"(?:(?<=^)|(?<=[\n\r.!?:]))[ \t]*"
+        r"<function\b[^>]*\bname\s*=[^>]*>"
+        r"(?:(?:(?!</function>).)*)</function>",
+        "",
         content,
         flags=re.DOTALL | re.IGNORECASE,
     )
@@ -507,15 +529,15 @@ def strip_think_blocks(agent, content: str) -> str:
     #    Strip from the tag to end of string.  Fixes #8878 / #9568
     #    (MiniMax M2.7 leaking raw reasoning into assistant content).
     content = re.sub(
-        r'(?:^|\n)[ \t]*<(?:think|thinking|reasoning|thought|REASONING_SCRATCHPAD)\b[^>]*>.*$',
-        '',
+        r"(?:^|\n)[ \t]*<(?:think|thinking|reasoning|thought|REASONING_SCRATCHPAD)\b[^>]*>.*$",
+        "",
         content,
         flags=re.DOTALL | re.IGNORECASE,
     )
     # 3. Stray orphan open/close tags that slipped through.
     content = re.sub(
-        r'</?(?:think|thinking|reasoning|thought|REASONING_SCRATCHPAD)>\s*',
-        '',
+        r"</?(?:think|thinking|reasoning|thought|REASONING_SCRATCHPAD)>\s*",
+        "",
         content,
         flags=re.IGNORECASE,
     )
@@ -524,13 +546,12 @@ def strip_think_blocks(agent, content: str) -> str:
     #     during streaming may still be valuable to the user; matches
     #     OpenClaw's intentional asymmetry.)
     content = re.sub(
-        r'</(?:tool_call|tool_calls|tool_result|function_call|function_calls|function)>\s*',
-        '',
+        r"</(?:tool_call|tool_calls|tool_result|function_call|function_calls|function)>\s*",
+        "",
         content,
         flags=re.IGNORECASE,
     )
     return content
-
 
 
 def recover_with_credential_pool(
@@ -570,7 +591,9 @@ def recover_with_credential_pool(
 
     if effective_reason == FailoverReason.billing:
         rotate_status = status_code if status_code is not None else 402
-        next_entry = pool.mark_exhausted_and_rotate(status_code=rotate_status, error_context=error_context)
+        next_entry = pool.mark_exhausted_and_rotate(
+            status_code=rotate_status, error_context=error_context
+        )
         if next_entry is not None:
             _ra().logger.info(
                 "Credential %s (billing) — rotated to pool entry %s",
@@ -593,7 +616,9 @@ def recover_with_credential_pool(
         if not has_retried_429 and not usage_limit_reached:
             return False, True
         rotate_status = status_code if status_code is not None else 429
-        next_entry = pool.mark_exhausted_and_rotate(status_code=rotate_status, error_context=error_context)
+        next_entry = pool.mark_exhausted_and_rotate(
+            status_code=rotate_status, error_context=error_context
+        )
         if next_entry is not None:
             _ra().logger.info(
                 "Credential %s (rate limit) — rotated to pool entry %s",
@@ -618,7 +643,11 @@ def recover_with_credential_pool(
         # Any 403 against ``xai-oauth`` is treated as entitlement here so
         # the refresh loop can't spin in those cases either.
         is_entitlement = agent._is_entitlement_failure(error_context, status_code)
-        if not is_entitlement and status_code == 403 and (agent.provider or "") == "xai-oauth":
+        if (
+            not is_entitlement
+            and status_code == 403
+            and (agent.provider or "") == "xai-oauth"
+        ):
             is_entitlement = True
         if is_entitlement:
             _ra().logger.info(
@@ -631,13 +660,17 @@ def recover_with_credential_pool(
             return False, has_retried_429
         refreshed = pool.try_refresh_current()
         if refreshed is not None:
-            _ra().logger.info(f"Credential auth failure — refreshed pool entry {getattr(refreshed, 'id', '?')}")
+            _ra().logger.info(
+                f"Credential auth failure — refreshed pool entry {getattr(refreshed, 'id', '?')}"
+            )
             agent._swap_credential(refreshed)
             return True, has_retried_429
         # Refresh failed — rotate to next credential instead of giving up.
         # The failed entry is already marked exhausted by try_refresh_current().
         rotate_status = status_code if status_code is not None else 401
-        next_entry = pool.mark_exhausted_and_rotate(status_code=rotate_status, error_context=error_context)
+        next_entry = pool.mark_exhausted_and_rotate(
+            status_code=rotate_status, error_context=error_context
+        )
         if next_entry is not None:
             _ra().logger.info(
                 "Credential %s (auth refresh failed) — rotated to pool entry %s",
@@ -650,9 +683,12 @@ def recover_with_credential_pool(
     return False, has_retried_429
 
 
-
 def try_recover_primary_transport(
-    agent, api_error: Exception, *, retry_count: int, max_retries: int,
+    agent,
+    api_error: Exception,
+    *,
+    retry_count: int,
+    max_retries: int,
 ) -> bool:
     """Attempt one extra primary-provider recovery cycle for transient transport failures.
 
@@ -686,7 +722,9 @@ def try_recover_primary_transport(
         if getattr(agent, "client", None) is not None:
             try:
                 agent._close_openai_client(
-                    agent.client, reason="primary_recovery", shared=True,
+                    agent.client,
+                    reason="primary_recovery",
+                    shared=True,
                 )
             except Exception:
                 pass
@@ -704,10 +742,12 @@ def try_recover_primary_transport(
 
         if agent.api_mode == "anthropic_messages":
             from agent.anthropic_adapter import build_anthropic_client
+
             agent._anthropic_api_key = rt["anthropic_api_key"]
             agent._anthropic_base_url = rt["anthropic_base_url"]
             agent._anthropic_client = build_anthropic_client(
-                rt["anthropic_api_key"], rt["anthropic_base_url"],
+                rt["anthropic_api_key"],
+                rt["anthropic_base_url"],
                 timeout=get_provider_request_timeout(agent.provider, agent.model),
             )
             agent._is_anthropic_oauth = rt["is_anthropic_oauth"]
@@ -731,8 +771,8 @@ def try_recover_primary_transport(
         logging.warning("Primary transport recovery failed: %s", e)
         return False
 
-# ── End provider fallback ──────────────────────────────────────────────
 
+# ── End provider fallback ──────────────────────────────────────────────
 
 
 def drop_thinking_only_and_merge_users(
@@ -768,11 +808,7 @@ def drop_thinking_only_and_merge_users(
     merges = 0
     for m in kept:
         prev = merged[-1] if merged else None
-        if (
-            prev is not None
-            and prev.get("role") == "user"
-            and m.get("role") == "user"
-        ):
+        if prev is not None and prev.get("role") == "user" and m.get("role") == "user":
             prev_content = prev.get("content", "")
             cur_content = m.get("content", "")
             # Work on a copy of ``prev`` so the caller's input dicts are
@@ -820,7 +856,6 @@ def drop_thinking_only_and_merge_users(
     return merged
 
 
-
 def restore_primary_runtime(agent) -> bool:
     """Restore the primary runtime at the start of a new turn.
 
@@ -851,7 +886,7 @@ def restore_primary_runtime(agent) -> bool:
         # ── Core runtime state ──
         agent.model = rt["model"]
         agent.provider = rt["provider"]
-        agent.base_url = rt["base_url"]           # setter updates _base_url_lower
+        agent.base_url = rt["base_url"]  # setter updates _base_url_lower
         agent.api_mode = rt["api_mode"]
         if hasattr(agent, "_transport_cache"):
             agent._transport_cache.clear()
@@ -868,10 +903,12 @@ def restore_primary_runtime(agent) -> bool:
         # ── Rebuild client for the primary provider ──
         if agent.api_mode == "anthropic_messages":
             from agent.anthropic_adapter import build_anthropic_client
+
             agent._anthropic_api_key = rt["anthropic_api_key"]
             agent._anthropic_base_url = rt["anthropic_base_url"]
             agent._anthropic_client = build_anthropic_client(
-                rt["anthropic_api_key"], rt["anthropic_base_url"],
+                rt["anthropic_api_key"],
+                rt["anthropic_base_url"],
                 timeout=get_provider_request_timeout(agent.provider, agent.model),
             )
             agent._is_anthropic_oauth = rt["is_anthropic_oauth"]
@@ -899,61 +936,74 @@ def restore_primary_runtime(agent) -> bool:
 
         logging.info(
             "Primary runtime restored for new turn: %s (%s)",
-            agent.model, agent.provider,
+            agent.model,
+            agent.provider,
         )
         return True
     except Exception as e:
         logging.warning("Failed to restore primary runtime: %s", e)
         return False
 
+
 # Which error types indicate a transient transport failure worth
 # one more attempt with a rebuilt client / connection pool.
-_TRANSIENT_TRANSPORT_ERRORS = frozenset({
-    "ReadTimeout", "ConnectTimeout", "PoolTimeout",
-    "ConnectError", "RemoteProtocolError",
-    "APIConnectionError", "APITimeoutError",
-})
-
+_TRANSIENT_TRANSPORT_ERRORS = frozenset(
+    {
+        "ReadTimeout",
+        "ConnectTimeout",
+        "PoolTimeout",
+        "ConnectError",
+        "RemoteProtocolError",
+        "APIConnectionError",
+        "APITimeoutError",
+    }
+)
 
 
 def extract_reasoning(agent, assistant_message) -> Optional[str]:
     """
     Extract reasoning/thinking content from an assistant message.
-    
+
     OpenRouter and various providers can return reasoning in multiple formats:
     1. message.reasoning - Direct reasoning field (DeepSeek, Qwen, etc.)
     2. message.reasoning_content - Alternative field (Moonshot AI, Novita, etc.)
     3. message.reasoning_details - Array of {type, summary, ...} objects (OpenRouter unified)
-    
+
     Args:
         assistant_message: The assistant message object from the API response
-        
+
     Returns:
         Combined reasoning text, or None if no reasoning found
     """
     reasoning_parts = []
-    
+
     # Check direct reasoning field
-    if hasattr(assistant_message, 'reasoning') and assistant_message.reasoning:
+    if hasattr(assistant_message, "reasoning") and assistant_message.reasoning:
         reasoning_parts.append(assistant_message.reasoning)
-    
+
     # Check reasoning_content field (alternative name used by some providers)
-    if hasattr(assistant_message, 'reasoning_content') and assistant_message.reasoning_content:
+    if (
+        hasattr(assistant_message, "reasoning_content")
+        and assistant_message.reasoning_content
+    ):
         # Don't duplicate if same as reasoning
         if assistant_message.reasoning_content not in reasoning_parts:
             reasoning_parts.append(assistant_message.reasoning_content)
-    
+
     # Check reasoning_details array (OpenRouter unified format)
     # Format: [{"type": "reasoning.summary", "summary": "...", ...}, ...]
-    if hasattr(assistant_message, 'reasoning_details') and assistant_message.reasoning_details:
+    if (
+        hasattr(assistant_message, "reasoning_details")
+        and assistant_message.reasoning_details
+    ):
         for detail in assistant_message.reasoning_details:
             if isinstance(detail, dict):
                 # Extract summary from reasoning detail object
                 summary = (
-                    detail.get('summary')
-                    or detail.get('thinking')
-                    or detail.get('content')
-                    or detail.get('text')
+                    detail.get("summary")
+                    or detail.get("thinking")
+                    or detail.get("content")
+                    or detail.get("text")
                 )
                 if summary and summary not in reasoning_parts:
                     reasoning_parts.append(summary)
@@ -989,13 +1039,12 @@ def extract_reasoning(agent, assistant_message) -> Optional[str]:
                 cleaned = block.strip()
                 if cleaned and cleaned not in reasoning_parts:
                     reasoning_parts.append(cleaned)
-    
+
     # Combine all reasoning parts
     if reasoning_parts:
         return "\n\n".join(reasoning_parts)
-    
-    return None
 
+    return None
 
 
 def dump_api_request_debug(
@@ -1055,10 +1104,14 @@ def dump_api_request_debug(
             response_obj = getattr(error, "response", None)
             if response_obj is not None:
                 try:
-                    error_info["response_status"] = getattr(response_obj, "status_code", None)
+                    error_info["response_status"] = getattr(
+                        response_obj, "status_code", None
+                    )
                     error_info["response_text"] = response_obj.text
                 except Exception as e:
-                    _ra().logger.debug("Could not extract error response details: %s", e)
+                    _ra().logger.debug(
+                        "Could not extract error response details: %s", e
+                    )
 
             dump_payload["error"] = error_info
 
@@ -1069,7 +1122,9 @@ def dump_api_request_debug(
             encoding="utf-8",
         )
 
-        agent._vprint(f"{agent.log_prefix}🧾 Request debug dump written to: {dump_file}")
+        agent._vprint(
+            f"{agent.log_prefix}🧾 Request debug dump written to: {dump_file}"
+        )
 
         if env_var_enabled("HERMES_DUMP_REQUEST_STDOUT"):
             print(json.dumps(dump_payload, ensure_ascii=False, indent=2, default=str))
@@ -1079,7 +1134,6 @@ def dump_api_request_debug(
         if agent.verbose_logging:
             logging.warning(f"Failed to dump API request debug payload: {dump_error}")
         return None
-
 
 
 def anthropic_prompt_cache_policy(
@@ -1129,9 +1183,9 @@ def anthropic_prompt_cache_policy(
     # OpenRouter-equivalent endpoint for caching layout purposes.
     is_nous_portal = "nousresearch" in eff_base_url.lower()
     is_anthropic_wire = eff_api_mode == "anthropic_messages"
-    is_native_anthropic = (
-        is_anthropic_wire
-        and (eff_provider == "anthropic" or base_url_hostname(eff_base_url) == "api.anthropic.com")
+    is_native_anthropic = is_anthropic_wire and (
+        eff_provider == "anthropic"
+        or base_url_hostname(eff_base_url) == "api.anthropic.com"
     )
 
     if is_native_anthropic:
@@ -1148,8 +1202,15 @@ def anthropic_prompt_cache_policy(
     if is_nous_portal and "qwen" in model_lower:
         return True, False
     if is_anthropic_wire and is_claude:
-        # Third-party Anthropic-compatible gateway.
+        # Third-party Anthropic-compatible gateway (MiniMax, LiteLLM, etc.).
         return True, True
+    # LiteLLM proxy with Anthropic Messages transport: cache-capable for
+    # Claude-aliased models (opus4.6[1M], sonnet4.6[1M], etc.) even when
+    # the model name doesn't literally contain "claude".
+    if is_anthropic_wire and provider_lower == "litellm":
+        _litellm_claude_hints = {"opus", "sonnet", "haiku", "claude"}
+        if any(h in model_lower for h in _litellm_claude_hints):
+            return True, True
 
     # MiniMax on its Anthropic-compatible endpoint serves its own
     # model family (MiniMax-M2.7, M2.5, M2.1, M2) with documented
@@ -1162,10 +1223,9 @@ def anthropic_prompt_cache_policy(
     # Docs: https://platform.minimax.io/docs/api-reference/anthropic-api-compatible-cache
     if is_anthropic_wire:
         is_minimax_provider = provider_lower in {"minimax", "minimax-cn"}
-        is_minimax_host = (
-            base_url_host_matches(eff_base_url, "api.minimax.io")
-            or base_url_host_matches(eff_base_url, "api.minimaxi.com")
-        )
+        is_minimax_host = base_url_host_matches(
+            eff_base_url, "api.minimax.io"
+        ) or base_url_host_matches(eff_base_url, "api.minimaxi.com")
         if is_minimax_provider or is_minimax_host:
             return True, True
 
@@ -1176,7 +1236,10 @@ def anthropic_prompt_cache_policy(
     # through the subscription on every turn.
     model_is_qwen = "qwen" in model_lower
     provider_is_alibaba_family = provider_lower in {
-        "opencode", "opencode-zen", "opencode-go", "alibaba",
+        "opencode",
+        "opencode-zen",
+        "opencode-go",
+        "alibaba",
     }
     if provider_is_alibaba_family and model_is_qwen:
         # Envelope layout (native_anthropic=False): markers on inner
@@ -1187,9 +1250,11 @@ def anthropic_prompt_cache_policy(
     return False, False
 
 
-
-def create_openai_client(agent, client_kwargs: dict, *, reason: str, shared: bool) -> Any:
+def create_openai_client(
+    agent, client_kwargs: dict, *, reason: str, shared: bool
+) -> Any:
     from agent.auxiliary_client import _validate_base_url, _validate_proxy_env_urls
+
     # Treat client_kwargs as read-only. Callers pass agent._client_kwargs (or shallow
     # copies of it) in; any in-place mutation leaks back into the stored dict and is
     # reused on subsequent requests. #10933 hit this by injecting an httpx.Client
@@ -1201,7 +1266,9 @@ def create_openai_client(agent, client_kwargs: dict, *, reason: str, shared: boo
     client_kwargs = dict(client_kwargs)
     _validate_proxy_env_urls()
     _validate_base_url(client_kwargs.get("base_url"))
-    if agent.provider == "copilot-acp" or str(client_kwargs.get("base_url", "")).startswith("acp://copilot"):
+    if agent.provider == "copilot-acp" or str(
+        client_kwargs.get("base_url", "")
+    ).startswith("acp://copilot"):
         from agent.copilot_acp_client import CopilotACPClient
 
         client = CopilotACPClient(**client_kwargs)
@@ -1212,12 +1279,15 @@ def create_openai_client(agent, client_kwargs: dict, *, reason: str, shared: boo
             agent._client_log_context(),
         )
         return client
-    if agent.provider == "google-gemini-cli" or str(client_kwargs.get("base_url", "")).startswith("cloudcode-pa://"):
+    if agent.provider == "google-gemini-cli" or str(
+        client_kwargs.get("base_url", "")
+    ).startswith("cloudcode-pa://"):
         from agent.gemini_cloudcode_adapter import GeminiCloudCodeClient
 
         # Strip OpenAI-specific kwargs the Gemini client doesn't accept
         safe_kwargs = {
-            k: v for k, v in client_kwargs.items()
+            k: v
+            for k, v in client_kwargs.items()
             if k in {"api_key", "base_url", "default_headers", "project_id", "timeout"}
         }
         client = GeminiCloudCodeClient(**safe_kwargs)
@@ -1229,13 +1299,18 @@ def create_openai_client(agent, client_kwargs: dict, *, reason: str, shared: boo
         )
         return client
     if agent.provider == "gemini":
-        from agent.gemini_native_adapter import GeminiNativeClient, is_native_gemini_base_url
+        from agent.gemini_native_adapter import (
+            GeminiNativeClient,
+            is_native_gemini_base_url,
+        )
 
         base_url = str(client_kwargs.get("base_url", "") or "")
         if is_native_gemini_base_url(base_url):
             safe_kwargs = {
-                k: v for k, v in client_kwargs.items()
-                if k in {"api_key", "base_url", "default_headers", "timeout", "http_client"}
+                k: v
+                for k, v in client_kwargs.items()
+                if k
+                in {"api_key", "base_url", "default_headers", "timeout", "http_client"}
             }
             if "http_client" not in safe_kwargs:
                 keepalive_http = agent._build_keepalive_http_client(base_url)
@@ -1267,7 +1342,9 @@ def create_openai_client(agent, client_kwargs: dict, *, reason: str, shared: boo
     # Tests in ``tests/run_agent/test_create_openai_client_reuse.py`` and
     # ``tests/run_agent/test_sequential_chats_live.py`` pin this invariant.
     if "http_client" not in client_kwargs:
-        keepalive_http = agent._build_keepalive_http_client(client_kwargs.get("base_url", ""))
+        keepalive_http = agent._build_keepalive_http_client(
+            client_kwargs.get("base_url", "")
+        )
         if keepalive_http is not None:
             client_kwargs["http_client"] = keepalive_http
     # Uses the module-level `OpenAI` name, resolved lazily on first
@@ -1282,7 +1359,7 @@ def create_openai_client(agent, client_kwargs: dict, *, reason: str, shared: boo
     return client
 
 
-def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mode=''):
+def switch_model(agent, new_model, new_provider, api_key="", base_url="", api_mode=""):
     """Switch the model/provider in-place for a live agent.
 
     Called by the /model command handlers (CLI and gateway) after
@@ -1347,19 +1424,29 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
             resolve_anthropic_token,
             _is_oauth_token,
         )
+
         # Only fall back to ANTHROPIC_TOKEN when the provider is actually Anthropic.
         # Other anthropic_messages providers (MiniMax, Alibaba, etc.) must use their own
         # API key — falling back would send Anthropic credentials to third-party endpoints.
         _is_native_anthropic = new_provider == "anthropic"
-        effective_key = (api_key or agent.api_key or resolve_anthropic_token() or "") if _is_native_anthropic else (api_key or agent.api_key or "")
+        effective_key = (
+            (api_key or agent.api_key or resolve_anthropic_token() or "")
+            if _is_native_anthropic
+            else (api_key or agent.api_key or "")
+        )
         agent.api_key = effective_key
         agent._anthropic_api_key = effective_key
-        agent._anthropic_base_url = base_url or getattr(agent, "_anthropic_base_url", None)
+        agent._anthropic_base_url = base_url or getattr(
+            agent, "_anthropic_base_url", None
+        )
         agent._anthropic_client = build_anthropic_client(
-            effective_key, agent._anthropic_base_url,
+            effective_key,
+            agent._anthropic_base_url,
             timeout=get_provider_request_timeout(agent.provider, agent.model),
         )
-        agent._is_anthropic_oauth = _is_oauth_token(effective_key) if _is_native_anthropic else False
+        agent._is_anthropic_oauth = (
+            _is_oauth_token(effective_key) if _is_native_anthropic else False
+        )
         agent.client = None
         agent._client_kwargs = {}
     else:
@@ -1394,12 +1481,14 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
     # ── Update context compressor ──
     if hasattr(agent, "context_compressor") and agent.context_compressor:
         from agent.model_metadata import get_model_context_length
+
         # Re-read custom_providers from live config so per-model
         # context_length overrides are honored when switching to a
         # custom provider mid-session (closes #15779).
         _sm_custom_providers = None
         try:
             from hermes_cli.config import load_config, get_compatible_custom_providers
+
             _sm_cfg = load_config()
             _sm_custom_providers = get_compatible_custom_providers(_sm_cfg)
         except Exception:
@@ -1431,7 +1520,11 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
     agent._cached_system_prompt = None
 
     # ── Update _primary_runtime so the change persists across turns ──
-    _cc = agent.context_compressor if hasattr(agent, "context_compressor") and agent.context_compressor else None
+    _cc = (
+        agent.context_compressor
+        if hasattr(agent, "context_compressor") and agent.context_compressor
+        else None
+    )
     agent._primary_runtime = {
         "model": agent.model,
         "provider": agent.provider,
@@ -1442,18 +1535,24 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
         "use_prompt_caching": agent._use_prompt_caching,
         "use_native_cache_layout": agent._use_native_cache_layout,
         "compressor_model": getattr(_cc, "model", agent.model) if _cc else agent.model,
-        "compressor_base_url": getattr(_cc, "base_url", agent.base_url) if _cc else agent.base_url,
+        "compressor_base_url": (
+            getattr(_cc, "base_url", agent.base_url) if _cc else agent.base_url
+        ),
         "compressor_api_key": getattr(_cc, "api_key", "") if _cc else "",
-        "compressor_provider": getattr(_cc, "provider", agent.provider) if _cc else agent.provider,
+        "compressor_provider": (
+            getattr(_cc, "provider", agent.provider) if _cc else agent.provider
+        ),
         "compressor_context_length": _cc.context_length if _cc else 0,
         "compressor_threshold_tokens": _cc.threshold_tokens if _cc else 0,
     }
     if api_mode == "anthropic_messages":
-        agent._primary_runtime.update({
-            "anthropic_api_key": agent._anthropic_api_key,
-            "anthropic_base_url": agent._anthropic_base_url,
-            "is_anthropic_oauth": agent._is_anthropic_oauth,
-        })
+        agent._primary_runtime.update(
+            {
+                "anthropic_api_key": agent._anthropic_api_key,
+                "anthropic_base_url": agent._anthropic_base_url,
+                "is_anthropic_oauth": agent._is_anthropic_oauth,
+            }
+        )
 
     # ── Reset fallback state ──
     agent._fallback_activated = False
@@ -1471,7 +1570,8 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
     fallback_chain = list(getattr(agent, "_fallback_chain", []) or [])
     if old_norm and new_norm and old_norm != new_norm:
         fallback_chain = [
-            entry for entry in fallback_chain
+            entry
+            for entry in fallback_chain
             if (entry.get("provider") or "").strip().lower() not in {old_norm, new_norm}
         ]
     agent._fallback_chain = fallback_chain
@@ -1479,14 +1579,22 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
 
     logging.info(
         "Model switched in-place: %s (%s) -> %s (%s)",
-        old_model, old_provider, new_model, new_provider,
+        old_model,
+        old_provider,
+        new_model,
+        new_provider,
     )
 
 
-
-def invoke_tool(agent, function_name: str, function_args: dict, effective_task_id: str,
-                 tool_call_id: Optional[str] = None, messages: list = None,
-                 pre_tool_block_checked: bool = False) -> str:
+def invoke_tool(
+    agent,
+    function_name: str,
+    function_args: dict,
+    effective_task_id: str,
+    tool_call_id: Optional[str] = None,
+    messages: list = None,
+    pre_tool_block_checked: bool = False,
+) -> str:
     """Invoke a single tool and return the result string. No display logic.
 
     Handles both agent-level tools (todo, memory, etc.) and registry-dispatched
@@ -1498,8 +1606,11 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
     if not pre_tool_block_checked:
         try:
             from hermes_cli.plugins import get_pre_tool_call_block_message
+
             block_message = get_pre_tool_call_block_message(
-                function_name, function_args, task_id=effective_task_id or "",
+                function_name,
+                function_args,
+                task_id=effective_task_id or "",
             )
         except Exception:
             pass
@@ -1508,6 +1619,7 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
 
     if function_name == "todo":
         from tools.todo_tool import todo_tool as _todo_tool
+
         return _todo_tool(
             todos=function_args.get("todos"),
             merge=function_args.get("merge", False),
@@ -1517,8 +1629,12 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
         session_db = agent._get_session_db_for_recall()
         if not session_db:
             from hermes_state import format_session_db_unavailable
-            return json.dumps({"success": False, "error": format_session_db_unavailable()})
+
+            return json.dumps(
+                {"success": False, "error": format_session_db_unavailable()}
+            )
         from tools.session_search_tool import session_search as _session_search
+
         return _session_search(
             query=function_args.get("query", ""),
             role_filter=function_args.get("role_filter"),
@@ -1533,6 +1649,7 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
     elif function_name == "memory":
         target = function_args.get("target", "memory")
         from tools.memory_tool import memory_tool as _memory_tool
+
         result = _memory_tool(
             action=function_args.get("action"),
             target=target,
@@ -1559,6 +1676,7 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
         return agent._memory_manager.handle_tool_call(function_name, function_args)
     elif function_name == "clarify":
         from tools.clarify_tool import clarify_tool as _clarify_tool
+
         return _clarify_tool(
             question=function_args.get("question", ""),
             choices=function_args.get("choices"),
@@ -1568,13 +1686,16 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
         return agent._dispatch_delegate_task(function_args)
     else:
         return _ra().handle_function_call(
-            function_name, function_args, effective_task_id,
+            function_name,
+            function_args,
+            effective_task_id,
             tool_call_id=tool_call_id,
             session_id=agent.session_id or "",
-            enabled_tools=list(agent.valid_tool_names) if agent.valid_tool_names else None,
+            enabled_tools=(
+                list(agent.valid_tool_names) if agent.valid_tool_names else None
+            ),
             skip_pre_tool_call_hook=True,
         )
-
 
 
 def repair_tool_call(agent, tool_name: str) -> str | None:
@@ -1650,7 +1771,6 @@ def repair_tool_call(agent, tool_name: str) -> str | None:
     return None
 
 
-
 def sanitize_api_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     """Fix orphaned tool_call / tool_result pairs before every LLM call.
 
@@ -1690,8 +1810,11 @@ def sanitize_api_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]
     orphaned_results = result_call_ids - surviving_call_ids
     if orphaned_results:
         messages = [
-            m for m in messages
-            if not (m.get("role") == "tool" and m.get("tool_call_id") in orphaned_results)
+            m
+            for m in messages
+            if not (
+                m.get("role") == "tool" and m.get("tool_call_id") in orphaned_results
+            )
         ]
         _ra().logger.debug(
             "Pre-call sanitizer: removed %d orphaned tool result(s)",
@@ -1708,19 +1831,20 @@ def sanitize_api_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]
                 for tc in msg.get("tool_calls") or []:
                     cid = _ra().AIAgent._get_tool_call_id_static(tc)
                     if cid in missing_results:
-                        patched.append({
-                            "role": "tool",
-                            "name": _ra().AIAgent._get_tool_call_name_static(tc),
-                            "content": "[Result unavailable — see context summary above]",
-                            "tool_call_id": cid,
-                        })
+                        patched.append(
+                            {
+                                "role": "tool",
+                                "name": _ra().AIAgent._get_tool_call_name_static(tc),
+                                "content": "[Result unavailable — see context summary above]",
+                                "tool_call_id": cid,
+                            }
+                        )
         messages = patched
         _ra().logger.debug(
             "Pre-call sanitizer: added %d stub tool result(s)",
             len(missing_results),
         )
     return messages
-
 
 
 def looks_like_codex_intermediate_ack(
@@ -1740,7 +1864,10 @@ def looks_like_codex_intermediate_ack(
         return False
 
     has_future_ack = bool(
-        re.search(r"\b(i['’]ll|i will|let me|i can do that|i can help with that)\b", assistant_text)
+        re.search(
+            r"\b(i['’]ll|i will|let me|i can do that|i can help with that)\b",
+            assistant_text,
+        )
     )
     if not has_future_ack:
         return False
@@ -1788,13 +1915,15 @@ def looks_like_codex_intermediate_ack(
         or "~/" in user_text
         or "/" in user_text
     )
-    assistant_mentions_action = any(marker in assistant_text for marker in action_markers)
+    assistant_mentions_action = any(
+        marker in assistant_text for marker in action_markers
+    )
     assistant_targets_workspace = any(
         marker in assistant_text for marker in workspace_markers
     )
-    return (user_targets_workspace or assistant_targets_workspace) and assistant_mentions_action
-
-
+    return (
+        user_targets_workspace or assistant_targets_workspace
+    ) and assistant_mentions_action
 
 
 def copy_reasoning_content_for_api(agent, source_msg: dict, api_msg: dict) -> None:
@@ -1868,7 +1997,6 @@ def copy_reasoning_content_for_api(agent, source_msg: dict, api_msg: dict) -> No
     api_msg.pop("reasoning_content", None)
 
 
-
 def _iter_pool_sockets(client: Any):
     """Yield raw sockets reachable from an OpenAI/httpx client pool.
 
@@ -1888,9 +2016,7 @@ def _iter_pool_sockets(client: Any):
         if pool is None:
             return
         connections = (
-            getattr(pool, "_connections", None)
-            or getattr(pool, "_pool", None)
-            or []
+            getattr(pool, "_connections", None) or getattr(pool, "_pool", None) or []
         )
     except Exception:
         return
@@ -1902,9 +2028,8 @@ def _iter_pool_sockets(client: Any):
         if inner is not None:
             candidates.append(inner)
         for candidate in candidates:
-            stream = (
-                getattr(candidate, "_network_stream", None)
-                or getattr(candidate, "_stream", None)
+            stream = getattr(candidate, "_network_stream", None) or getattr(
+                candidate, "_stream", None
             )
             if stream is None:
                 continue
@@ -1928,6 +2053,7 @@ def _iter_pool_sockets(client: Any):
                 if callable(extra):
                     try:
                         from anyio.abc import SocketAttribute
+
                         sock = extra(SocketAttribute.raw_socket)
                     except Exception:
                         sock = None
@@ -1957,6 +2083,7 @@ def cleanup_dead_connections(agent) -> bool:
         for sock in _iter_pool_sockets(client):
             # Probe socket health with a non-blocking recv peek
             import socket as _socket
+
             try:
                 sock.setblocking(False)
                 data = sock.recv(1, _socket.MSG_PEEK | _socket.MSG_DONTWAIT)
@@ -1981,7 +2108,6 @@ def cleanup_dead_connections(agent) -> bool:
     except Exception as exc:
         _ra().logger.debug("Dead connection check error: %s", exc)
     return False
-
 
 
 def extract_api_error_context(error: Exception) -> Dict[str, Any]:
@@ -2032,10 +2158,16 @@ def extract_api_error_context(error: Exception) -> Dict[str, Any]:
     if "reset_at" not in context:
         message = context.get("message") or ""
         if isinstance(message, str):
-            delay_match = re.search(r"quotaResetDelay[:\s\"]+(\\d+(?:\\.\\d+)?)(ms|s)", message, re.IGNORECASE)
+            delay_match = re.search(
+                r"quotaResetDelay[:\s\"]+(\\d+(?:\\.\\d+)?)(ms|s)",
+                message,
+                re.IGNORECASE,
+            )
             if delay_match:
                 value = float(delay_match.group(1))
-                seconds = value / 1000.0 if delay_match.group(2).lower() == "ms" else value
+                seconds = (
+                    value / 1000.0 if delay_match.group(2).lower() == "ms" else value
+                )
                 context["reset_at"] = time.time() + seconds
             else:
                 sec_match = re.search(
@@ -2049,8 +2181,9 @@ def extract_api_error_context(error: Exception) -> Dict[str, Any]:
     return context
 
 
-
-def apply_pending_steer_to_tool_results(agent, messages: list, num_tool_msgs: int) -> None:
+def apply_pending_steer_to_tool_results(
+    agent, messages: list, num_tool_msgs: int
+) -> None:
     """Append any pending /steer text to the last tool result in this turn.
 
     Called at the end of a tool-call batch, before the next API call.
@@ -2091,7 +2224,9 @@ def apply_pending_steer_to_tool_results(agent, messages: list, num_tool_msgs: in
                     agent._pending_steer = steer_text
         else:
             existing = getattr(agent, "_pending_steer", None)
-            agent._pending_steer = (existing + "\n" + steer_text) if existing else steer_text
+            agent._pending_steer = (
+                (existing + "\n" + steer_text) if existing else steer_text
+            )
         return
     marker = f"\n\nUser guidance: {steer_text}"
     existing_content = messages[target_idx].get("content", "")
@@ -2112,7 +2247,6 @@ def apply_pending_steer_to_tool_results(agent, messages: list, num_tool_msgs: in
         len(steer_text),
         steer_text[:120] + ("..." if len(steer_text) > 120 else ""),
     )
-
 
 
 def force_close_tcp_sockets(client: Any) -> int:
@@ -2143,7 +2277,6 @@ def force_close_tcp_sockets(client: Any) -> int:
     except Exception as exc:
         _ra().logger.debug("Force-close TCP sockets sweep error: %s", exc)
     return closed
-
 
 
 __all__ = [

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -79,6 +79,7 @@ def _ra():
     ``run_agent.OpenAI`` and have those patches reach this code path.
     """
     import run_agent
+
     return run_agent
 
 
@@ -128,7 +129,8 @@ def _restore_or_build_system_prompt(agent, system_message, conversation_history)
                 "Session DB get_session failed for system-prompt restore "
                 "(session=%s): %s. Falling back to fresh build — prefix "
                 "cache will miss for this turn.",
-                agent.session_id, exc,
+                agent.session_id,
+                exc,
             )
 
     if stored_prompt:
@@ -147,7 +149,8 @@ def _restore_or_build_system_prompt(agent, system_message, conversation_history)
             "from scratch this turn. Prefix cache will miss until "
             "the rebuild persists. Investigate the previous turn's "
             "update_system_prompt write path.",
-            agent.session_id, stored_state,
+            agent.session_id,
+            stored_state,
         )
 
     # First turn of a new session (or recovering from a broken stored
@@ -159,6 +162,7 @@ def _restore_or_build_system_prompt(agent, system_message, conversation_history)
     # to initialise session-scoped state (e.g. warm a memory cache).
     try:
         from hermes_cli.plugins import invoke_hook as _invoke_hook
+
         _invoke_hook(
             "on_session_start",
             session_id=agent.session_id,
@@ -174,13 +178,16 @@ def _restore_or_build_system_prompt(agent, system_message, conversation_history)
     # subsequent turn).
     if agent._session_db:
         try:
-            agent._session_db.update_system_prompt(agent.session_id, agent._cached_system_prompt)
+            agent._session_db.update_system_prompt(
+                agent.session_id, agent._cached_system_prompt
+            )
         except Exception as exc:
             logger.warning(
                 "Session DB update_system_prompt failed for session %s: "
                 "%s. Subsequent turns will rebuild the system prompt and "
                 "miss the prefix cache.",
-                agent.session_id, exc,
+                agent.session_id,
+                exc,
             )
 
 
@@ -225,6 +232,7 @@ def run_conversation(
     # default. Idempotent — fine to call every turn.
     try:
         from agent.auxiliary_client import set_runtime_main
+
         set_runtime_main(
             getattr(agent, "provider", "") or "",
             getattr(agent, "model", "") or "",
@@ -235,6 +243,7 @@ def run_conversation(
     # Tag all log records on this thread with the session ID so
     # ``hermes logs --session <id>`` can filter a single conversation.
     from hermes_logging import set_session_context
+
     set_session_context(agent.session_id)
 
     # Bind the skill write-origin ContextVar for this thread so tool
@@ -244,6 +253,7 @@ def run_conversation(
     # the review fork runs on its own thread with a fresh context,
     # so the foreground value here does not leak into it.
     from tools.skill_provenance import set_current_write_origin
+
     set_current_write_origin(getattr(agent, "_memory_write_origin", "assistant_tool"))
 
     # If the previous turn activated fallback, restore the primary
@@ -270,7 +280,7 @@ def run_conversation(
     # state registry.  Set BEFORE any tool dispatch so snapshots taken at
     # child-launch time see the parent's real id, not None.
     agent._current_task_id = effective_task_id
-    
+
     # Reset retry counters and iteration budget at the start of each turn
     # so subagent usage from a previous turn doesn't eat into the next one.
     agent._invalid_tool_retries = 0
@@ -318,12 +328,17 @@ def run_conversation(
 
     # Log conversation turn start for debugging/observability
     _preview_text = _summarize_user_message_for_log(user_message)
-    _msg_preview = (_preview_text[:80] + "...") if len(_preview_text) > 80 else _preview_text
+    _msg_preview = (
+        (_preview_text[:80] + "...") if len(_preview_text) > 80 else _preview_text
+    )
     _msg_preview = _msg_preview.replace("\n", " ")
     logger.info(
         "conversation turn: session=%s model=%s provider=%s platform=%s history=%d msg=%r",
-        agent.session_id or "none", agent.model, agent.provider or "unknown",
-        agent.platform or "unknown", len(conversation_history or []),
+        agent.session_id or "none",
+        agent.model,
+        agent.provider or "unknown",
+        agent.platform or "unknown",
+        len(conversation_history or []),
         _msg_preview,
     )
 
@@ -355,14 +370,15 @@ def run_conversation(
                 # % preserves original 1-in-N cadence rather than firing a
                 # review immediately on resume (which would surprise users
                 # whose session happened to land just past a multiple of N).
-                agent._turns_since_memory = prior_user_turns % agent._memory_nudge_interval
-
+                agent._turns_since_memory = (
+                    prior_user_turns % agent._memory_nudge_interval
+                )
 
     # Prefill messages (few-shot priming) are injected at API-call time only,
     # never stored in the messages list. This keeps them ephemeral: they won't
     # be saved to session DB, session logs, or batch trajectories, but they're
     # automatically re-applied on every API call (including session continuations).
-    
+
     # Track user turns for memory flush and periodic nudge logic
     agent._user_turn_count += 1
 
@@ -379,15 +395,19 @@ def run_conversation(
         think_scrubber.reset()
 
     # Preserve the original user message (no nudge injection).
-    original_user_message = persist_user_message if persist_user_message is not None else user_message
+    original_user_message = (
+        persist_user_message if persist_user_message is not None else user_message
+    )
 
     # Track memory nudge trigger (turn-based, checked here).
     # Skill trigger is checked AFTER the agent loop completes, based on
     # how many tool iterations THIS turn used.
     _should_review_memory = False
-    if (agent._memory_nudge_interval > 0
-            and "memory" in agent.valid_tool_names
-            and agent._memory_store):
+    if (
+        agent._memory_nudge_interval > 0
+        and "memory" in agent.valid_tool_names
+        and agent._memory_store
+    ):
         agent._turns_since_memory += 1
         if agent._turns_since_memory >= agent._memory_nudge_interval:
             _should_review_memory = True
@@ -398,11 +418,13 @@ def run_conversation(
     messages.append(user_msg)
     current_turn_user_idx = len(messages) - 1
     agent._persist_user_message_idx = current_turn_user_idx
-    
+
     if not agent.quiet_mode:
         _print_preview = _summarize_user_message_for_log(user_message)
-        agent._safe_print(f"💬 Starting conversation: '{_print_preview[:60]}{'...' if len(_print_preview) > 60 else ''}'")
-    
+        agent._safe_print(
+            f"💬 Starting conversation: '{_print_preview[:60]}{'...' if len(_print_preview) > 60 else ''}'"
+        )
+
     # ── System prompt (cached per session for prefix caching) ──
     # Built once on first call, reused for all subsequent calls.
     # Only rebuilt after context compression events (which invalidate
@@ -428,8 +450,10 @@ def run_conversation(
     # 4xx and abort the request entirely).
     if (
         agent.compression_enabled
-        and len(messages) > agent.context_compressor.protect_first_n
-                            + agent.context_compressor.protect_last_n + 1
+        and len(messages)
+        > agent.context_compressor.protect_first_n
+        + agent.context_compressor.protect_last_n
+        + 1
     ):
         # Include tool schema tokens — with many tools these can add
         # 20-30K+ tokens that the old sys+msg estimate missed entirely.
@@ -457,7 +481,9 @@ def run_conversation(
             for _pass in range(3):
                 _orig_len = len(messages)
                 messages, active_system_prompt = agent._compress_context(
-                    messages, system_message, approx_tokens=_preflight_tokens,
+                    messages,
+                    system_message,
+                    approx_tokens=_preflight_tokens,
                     task_id=effective_task_id,
                 )
                 if len(messages) >= _orig_len:
@@ -502,6 +528,7 @@ def run_conversation(
     _plugin_user_context = ""
     try:
         from hermes_cli.plugins import invoke_hook as _invoke_hook
+
         _pre_results = _invoke_hook(
             "pre_llm_call",
             session_id=agent.session_id,
@@ -541,7 +568,7 @@ def run_conversation(
     # present are surfaced in an advisory footer so the model cannot
     # over-claim success while the file is actually unchanged on disk.
     agent._turn_failed_file_mutations: Dict[str, Dict[str, Any]] = {}
-    
+
     # Record the execution thread so interrupt()/clear_interrupt() can
     # scope the tool-level interrupt signal to THIS agent's thread only.
     # Must be set before any thread-scoped interrupt syncing.
@@ -563,7 +590,9 @@ def run_conversation(
     # and can gate context/dialectic refresh via contextCadence/dialecticCadence.
     if agent._memory_manager:
         try:
-            _turn_msg = original_user_message if isinstance(original_user_message, str) else ""
+            _turn_msg = (
+                original_user_message if isinstance(original_user_message, str) else ""
+            )
             agent._memory_manager.on_turn_start(agent._user_turn_count, _turn_msg)
         except Exception:
             pass
@@ -576,7 +605,9 @@ def run_conversation(
     _ext_prefetch_cache = ""
     if agent._memory_manager:
         try:
-            _query = original_user_message if isinstance(original_user_message, str) else ""
+            _query = (
+                original_user_message if isinstance(original_user_message, str) else ""
+            )
             _ext_prefetch_cache = agent._memory_manager.prefetch_all(_query) or ""
         except Exception:
             pass
@@ -595,7 +626,9 @@ def run_conversation(
             should_review_memory=_should_review_memory,
         )
 
-    while (api_call_count < agent.max_iterations and agent.iteration_budget.remaining > 0) or agent._budget_grace_call:
+    while (
+        api_call_count < agent.max_iterations and agent.iteration_budget.remaining > 0
+    ) or agent._budget_grace_call:
         # Reset per-turn checkpoint dedup so each iteration can take one snapshot
         agent._checkpoint_mgr.new_turn()
 
@@ -606,7 +639,7 @@ def run_conversation(
             if not agent.quiet_mode:
                 agent._safe_print("\n⚡ Breaking out of tool loop due to interrupt...")
             break
-        
+
         api_call_count += 1
         agent._api_call_count = api_call_count
         agent._touch_activity(f"starting API call #{api_call_count}")
@@ -619,7 +652,9 @@ def run_conversation(
         elif not agent.iteration_budget.consume():
             _turn_exit_reason = "budget_exhausted"
             if not agent.quiet_mode:
-                agent._safe_print(f"\n⚠️  Iteration budget exhausted ({agent.iteration_budget.used}/{agent.iteration_budget.max_total} iterations used)")
+                agent._safe_print(
+                    f"\n⚠️  Iteration budget exhausted ({agent.iteration_budget.used}/{agent.iteration_budget.max_total} iterations used)"
+                )
             break
 
         # Fire step_callback for gateway hooks (agent:step event)
@@ -648,14 +683,15 @@ def run_conversation(
                         break
                 agent.step_callback(api_call_count, prev_tools)
             except Exception as _step_err:
-                logger.debug("step_callback error (iteration %s): %s", api_call_count, _step_err)
+                logger.debug(
+                    "step_callback error (iteration %s): %s", api_call_count, _step_err
+                )
 
         # Track tool-calling iterations for skill nudge.
         # Counter resets whenever skill_manage is actually used.
-        if (agent._skill_nudge_interval > 0
-                and "skill_manage" in agent.valid_tool_names):
+        if agent._skill_nudge_interval > 0 and "skill_manage" in agent.valid_tool_names:
             agent._iters_since_skill += 1
-        
+
         # ── Pre-API-call /steer drain ──────────────────────────────────
         # If a /steer arrived during the previous API call (while the model
         # was thinking), drain it now — before we build api_messages — so
@@ -699,12 +735,18 @@ def run_conversation(
                 if _lock is not None:
                     with _lock:
                         if agent._pending_steer:
-                            agent._pending_steer = agent._pending_steer + "\n" + _pre_api_steer
+                            agent._pending_steer = (
+                                agent._pending_steer + "\n" + _pre_api_steer
+                            )
                         else:
                             agent._pending_steer = _pre_api_steer
                 else:
                     existing = getattr(agent, "_pending_steer", None)
-                    agent._pending_steer = (existing + "\n" + _pre_api_steer) if existing else _pre_api_steer
+                    agent._pending_steer = (
+                        (existing + "\n" + _pre_api_steer)
+                        if existing
+                        else _pre_api_steer
+                    )
 
         # Prepare messages for API call
         # If we have an ephemeral system prompt, prepend it to the messages
@@ -801,14 +843,20 @@ def run_conversation(
         # stay warm.
         effective_system = active_system_prompt or ""
         if agent.ephemeral_system_prompt:
-            effective_system = (effective_system + "\n\n" + agent.ephemeral_system_prompt).strip()
+            effective_system = (
+                effective_system + "\n\n" + agent.ephemeral_system_prompt
+            ).strip()
         if effective_system:
-            api_messages = [{"role": "system", "content": effective_system}] + api_messages
+            api_messages = [
+                {"role": "system", "content": effective_system}
+            ] + api_messages
 
         # Inject ephemeral prefill messages right after the system prompt
         # but before conversation history. Same API-call-time-only pattern.
         if agent.prefill_messages:
-            sys_offset = 1 if (api_messages and api_messages[0].get("role") == "system") else 0
+            sys_offset = (
+                1 if (api_messages and api_messages[0].get("role") == "system") else 0
+            )
             for idx, pfm in enumerate(agent.prefill_messages):
                 api_messages.insert(sys_offset + idx, pfm.copy())
 
@@ -823,6 +871,7 @@ def run_conversation(
                 api_messages,
                 cache_ttl=agent._cache_ttl,
                 native_anthropic=agent._use_native_cache_layout,
+                strategy=getattr(agent, "_cache_strategy", "system_and_3"),
             )
 
         # Safety net: strip orphaned tool results / add stubs for missing
@@ -859,13 +908,17 @@ def run_conversation(
                 if isinstance(tc, dict) and "function" in tc:
                     try:
                         args_obj = json.loads(tc["function"]["arguments"])
-                        tc = {**tc, "function": {
-                            **tc["function"],
-                            "arguments": json.dumps(
-                                args_obj, separators=(",", ":"),
-                                sort_keys=True,
-                            ),
-                        }}
+                        tc = {
+                            **tc,
+                            "function": {
+                                **tc["function"],
+                                "arguments": json.dumps(
+                                    args_obj,
+                                    separators=(",", ":"),
+                                    sort_keys=True,
+                                ),
+                            },
+                        }
                     except Exception:
                         tc["function"]["arguments"] = _repair_tool_call_arguments(
                             tc["function"]["arguments"],
@@ -883,14 +936,20 @@ def run_conversation(
         # Calculate approximate request size for logging
         total_chars = sum(len(str(msg)) for msg in api_messages)
         approx_tokens = estimate_messages_tokens_rough(api_messages)
-        
+
         # Thinking spinner for quiet mode (animated during API call)
         thinking_spinner = None
-        
+
         if not agent.quiet_mode:
-            agent._vprint(f"\n{agent.log_prefix}🔄 Making API call #{api_call_count}/{agent.max_iterations}...")
-            agent._vprint(f"{agent.log_prefix}   📊 Request size: {len(api_messages)} messages, ~{approx_tokens:,} tokens (~{total_chars:,} chars)")
-            agent._vprint(f"{agent.log_prefix}   🔧 Available tools: {len(agent.tools) if agent.tools else 0}")
+            agent._vprint(
+                f"\n{agent.log_prefix}🔄 Making API call #{api_call_count}/{agent.max_iterations}..."
+            )
+            agent._vprint(
+                f"{agent.log_prefix}   📊 Request size: {len(api_messages)} messages, ~{approx_tokens:,} tokens (~{total_chars:,} chars)"
+            )
+            agent._vprint(
+                f"{agent.log_prefix}   🔧 Available tools: {len(agent.tools) if agent.tools else 0}"
+            )
         else:
             # Animated thinking spinner in quiet mode
             face = random.choice(KawaiiSpinner.get_thinking_faces())
@@ -899,28 +958,41 @@ def run_conversation(
                 # CLI TUI mode: use prompt_toolkit widget instead of raw spinner
                 # (works in both streaming and non-streaming modes)
                 agent.thinking_callback(f"{face} {verb}...")
-            elif not agent._has_stream_consumers() and agent._should_start_quiet_spinner():
+            elif (
+                not agent._has_stream_consumers()
+                and agent._should_start_quiet_spinner()
+            ):
                 # Raw KawaiiSpinner only when no streaming consumers and the
                 # spinner output has a safe sink.
-                spinner_type = random.choice(['brain', 'sparkle', 'pulse', 'moon', 'star'])
-                thinking_spinner = KawaiiSpinner(f"{face} {verb}...", spinner_type=spinner_type, print_fn=agent._print_fn)
+                spinner_type = random.choice(
+                    ["brain", "sparkle", "pulse", "moon", "star"]
+                )
+                thinking_spinner = KawaiiSpinner(
+                    f"{face} {verb}...",
+                    spinner_type=spinner_type,
+                    print_fn=agent._print_fn,
+                )
                 thinking_spinner.start()
-        
+
         # Log request details if verbose
         if agent.verbose_logging:
-            logging.debug(f"API Request - Model: {agent.model}, Messages: {len(messages)}, Tools: {len(agent.tools) if agent.tools else 0}")
-            logging.debug(f"Last message role: {messages[-1]['role'] if messages else 'none'}")
+            logging.debug(
+                f"API Request - Model: {agent.model}, Messages: {len(messages)}, Tools: {len(agent.tools) if agent.tools else 0}"
+            )
+            logging.debug(
+                f"Last message role: {messages[-1]['role'] if messages else 'none'}"
+            )
             logging.debug(f"Total message size: ~{approx_tokens:,} tokens")
-        
+
         api_start_time = time.time()
         retry_count = 0
         max_retries = agent._api_max_retries
         primary_recovery_attempted = False
         max_compression_attempts = 3
-        codex_auth_retry_attempted=False
-        anthropic_auth_retry_attempted=False
-        nous_auth_retry_attempted=False
-        copilot_auth_retry_attempted=False
+        codex_auth_retry_attempted = False
+        anthropic_auth_retry_attempted = False
+        nous_auth_retry_attempted = False
+        copilot_auth_retry_attempted = False
         thinking_sig_retry_attempted = False
         image_shrink_retry_attempted = False
         oauth_1m_beta_retry_attempted = False
@@ -945,6 +1017,7 @@ def run_conversation(
                         nous_rate_limit_remaining,
                         format_remaining as _fmt_nous_remaining,
                     )
+
                     _nous_remaining = nous_rate_limit_remaining()
                     if _nous_remaining is not None and _nous_remaining > 0:
                         _nous_msg = (
@@ -987,10 +1060,13 @@ def run_conversation(
                 if agent._force_ascii_payload:
                     _sanitize_structure_non_ascii(api_kwargs)
                 if agent.api_mode == "codex_responses":
-                    api_kwargs = agent._get_transport().preflight_kwargs(api_kwargs, allow_stream=False)
+                    api_kwargs = agent._get_transport().preflight_kwargs(
+                        api_kwargs, allow_stream=False
+                    )
 
                 try:
                     from hermes_cli.plugins import invoke_hook as _invoke_hook
+
                     request_messages = api_kwargs.get("messages")
                     if not isinstance(request_messages, list):
                         request_messages = api_kwargs.get("input")
@@ -1014,7 +1090,11 @@ def run_conversation(
                         base_url=agent.base_url,
                         api_mode=agent.api_mode,
                         api_call_count=api_call_count,
-                        request_messages=list(request_messages) if isinstance(request_messages, list) else [],
+                        request_messages=(
+                            list(request_messages)
+                            if isinstance(request_messages, list)
+                            else []
+                        ),
                         message_count=len(api_messages),
                         tool_count=len(agent.tools or []),
                         approx_input_tokens=approx_tokens,
@@ -1067,6 +1147,7 @@ def run_conversation(
                     # health checking, but skip for Mock clients in tests
                     # (mocks return SimpleNamespace, not stream iterators).
                     from unittest.mock import Mock
+
                     if isinstance(getattr(agent, "client", None), Mock):
                         _use_streaming = False
 
@@ -1076,9 +1157,9 @@ def run_conversation(
                     )
                 else:
                     response = agent._interruptible_api_call(api_kwargs)
-                
+
                 api_duration = time.time() - api_start_time
-                
+
                 # Stop thinking spinner silently -- the response box or tool
                 # execution messages that follow are more informative.
                 if thinking_spinner:
@@ -1086,15 +1167,21 @@ def run_conversation(
                     thinking_spinner = None
                 if agent.thinking_callback:
                     agent.thinking_callback("")
-                
+
                 if not agent.quiet_mode:
-                    agent._vprint(f"{agent.log_prefix}⏱️  API call completed in {api_duration:.2f}s")
-                
+                    agent._vprint(
+                        f"{agent.log_prefix}⏱️  API call completed in {api_duration:.2f}s"
+                    )
+
                 if agent.verbose_logging:
                     # Log response with provider info if available
-                    resp_model = getattr(response, 'model', 'N/A') if response else 'N/A'
-                    logging.debug(f"API Response received - Model: {resp_model}, Usage: {response.usage if hasattr(response, 'usage') else 'N/A'}")
-                
+                    resp_model = (
+                        getattr(response, "model", "N/A") if response else "N/A"
+                    )
+                    logging.debug(
+                        f"API Response received - Model: {resp_model}, Usage: {response.usage if hasattr(response, 'usage') else 'N/A'}"
+                    )
+
                 # Validate response shape before proceeding
                 response_invalid = False
                 error_details = []
@@ -1108,26 +1195,41 @@ def run_conversation(
                             # Provider returned a terminal failure (e.g. quota exhaustion).
                             # Treat as invalid so the fallback chain is triggered instead of
                             # letting the error bubble up outside the retry/fallback loop.
-                            _codex_resp_status = str(getattr(response, "status", "") or "").strip().lower()
+                            _codex_resp_status = (
+                                str(getattr(response, "status", "") or "")
+                                .strip()
+                                .lower()
+                            )
                             if _codex_resp_status in {"failed", "cancelled"}:
                                 _codex_error_obj = getattr(response, "error", None)
                                 _codex_error_msg = (
-                                    _codex_error_obj.get("message") if isinstance(_codex_error_obj, dict)
-                                    else str(_codex_error_obj) if _codex_error_obj
-                                    else f"Responses API returned status '{_codex_resp_status}'"
+                                    _codex_error_obj.get("message")
+                                    if isinstance(_codex_error_obj, dict)
+                                    else (
+                                        str(_codex_error_obj)
+                                        if _codex_error_obj
+                                        else f"Responses API returned status '{_codex_resp_status}'"
+                                    )
                                 )
                                 logging.warning(
                                     "Codex response status='%s' (error=%s). Routing to fallback. %s",
-                                    _codex_resp_status, _codex_error_msg,
+                                    _codex_resp_status,
+                                    _codex_error_msg,
                                     agent._client_log_context(),
                                 )
                                 response_invalid = True
-                                error_details.append(f"response.status={_codex_resp_status}: {_codex_error_msg}")
+                                error_details.append(
+                                    f"response.status={_codex_resp_status}: {_codex_error_msg}"
+                                )
                             else:
                                 # output_text fallback: stream backfill may have failed
                                 # but normalize can still recover from output_text
                                 _out_text = getattr(response, "output_text", None)
-                                _out_text_stripped = _out_text.strip() if isinstance(_out_text, str) else ""
+                                _out_text_stripped = (
+                                    _out_text.strip()
+                                    if isinstance(_out_text, str)
+                                    else ""
+                                )
                                 if _out_text_stripped:
                                     logger.debug(
                                         "Codex response.output is empty but output_text is present "
@@ -1136,11 +1238,14 @@ def run_conversation(
                                     )
                                 else:
                                     _resp_status = getattr(response, "status", None)
-                                    _resp_incomplete = getattr(response, "incomplete_details", None)
+                                    _resp_incomplete = getattr(
+                                        response, "incomplete_details", None
+                                    )
                                     logger.warning(
                                         "Codex response.output is empty after stream backfill "
                                         "(status=%s, incomplete_details=%s, model=%s). %s",
-                                        _resp_status, _resp_incomplete,
+                                        _resp_status,
+                                        _resp_incomplete,
                                         getattr(response, "model", None),
                                         f"api_mode={agent.api_mode} provider={agent.provider}",
                                     )
@@ -1153,7 +1258,9 @@ def run_conversation(
                         if response is None:
                             error_details.append("response is None")
                         else:
-                            error_details.append("response.content invalid (not a non-empty list)")
+                            error_details.append(
+                                "response.content invalid (not a non-empty list)"
+                            )
                 elif agent.api_mode == "bedrock_converse":
                     _btv = agent._get_transport()
                     if not _btv.validate_response(response):
@@ -1161,14 +1268,16 @@ def run_conversation(
                         if response is None:
                             error_details.append("response is None")
                         else:
-                            error_details.append("Bedrock response invalid (no output or choices)")
+                            error_details.append(
+                                "Bedrock response invalid (no output or choices)"
+                            )
                 else:
                     _ctv = agent._get_transport()
                     if not _ctv.validate_response(response):
                         response_invalid = True
                         if response is None:
                             error_details.append("response is None")
-                        elif not hasattr(response, 'choices'):
+                        elif not hasattr(response, "choices"):
                             error_details.append("response has no 'choices' attribute")
                         elif response.choices is None:
                             error_details.append("response.choices is None")
@@ -1182,16 +1291,18 @@ def run_conversation(
                         thinking_spinner = None
                     if agent.thinking_callback:
                         agent.thinking_callback("")
-                    
+
                     # Invalid response — could be rate limiting, provider timeout,
                     # upstream server error, or malformed response.
                     retry_count += 1
-                    
+
                     # Eager fallback: empty/malformed responses are a common
                     # rate-limit symptom.  Switch to fallback immediately
                     # rather than retrying with extended backoff.
                     if agent._fallback_index < len(agent._fallback_chain):
-                        agent._emit_status("⚠️ Empty/malformed response — switching to fallback...")
+                        agent._emit_status(
+                            "⚠️ Empty/malformed response — switching to fallback..."
+                        )
                     if agent._try_activate_fallback():
                         retry_count = 0
                         compression_attempts = 0
@@ -1201,31 +1312,47 @@ def run_conversation(
                     # Check for error field in response (some providers include this)
                     error_msg = "Unknown"
                     provider_name = "Unknown"
-                    if response and hasattr(response, 'error') and response.error:
+                    if response and hasattr(response, "error") and response.error:
                         error_msg = str(response.error)
                         # Try to extract provider from error metadata
-                        if hasattr(response.error, 'metadata') and response.error.metadata:
-                            provider_name = response.error.metadata.get('provider_name', 'Unknown')
-                    elif response and hasattr(response, 'message') and response.message:
+                        if (
+                            hasattr(response.error, "metadata")
+                            and response.error.metadata
+                        ):
+                            provider_name = response.error.metadata.get(
+                                "provider_name", "Unknown"
+                            )
+                    elif response and hasattr(response, "message") and response.message:
                         error_msg = str(response.message)
-                    
+
                     # Try to get provider from model field (OpenRouter often returns actual model used)
-                    if provider_name == "Unknown" and response and hasattr(response, 'model') and response.model:
+                    if (
+                        provider_name == "Unknown"
+                        and response
+                        and hasattr(response, "model")
+                        and response.model
+                    ):
                         provider_name = f"model={response.model}"
-                    
+
                     # Check for x-openrouter-provider or similar metadata
                     if provider_name == "Unknown" and response:
                         # Log all response attributes for debugging
-                        resp_attrs = {k: str(v)[:100] for k, v in vars(response).items() if not k.startswith('_')}
+                        resp_attrs = {
+                            k: str(v)[:100]
+                            for k, v in vars(response).items()
+                            if not k.startswith("_")
+                        }
                         if agent.verbose_logging:
-                            logging.debug(f"Response attributes for invalid response: {resp_attrs}")
-                    
+                            logging.debug(
+                                f"Response attributes for invalid response: {resp_attrs}"
+                            )
+
                     # Extract error code from response for contextual diagnostics
                     _resp_error_code = None
-                    if response and hasattr(response, 'error') and response.error:
-                        _code_raw = getattr(response.error, 'code', None)
+                    if response and hasattr(response, "error") and response.error:
+                        _code_raw = getattr(response.error, "code", None)
                         if _code_raw is None and isinstance(response.error, dict):
-                            _code_raw = response.error.get('code')
+                            _code_raw = response.error.get("code")
                         if _code_raw is not None:
                             try:
                                 _resp_error_code = int(_code_raw)
@@ -1237,58 +1364,90 @@ def run_conversation(
                     if _resp_error_code == 524:
                         _failure_hint = f"upstream provider timed out (Cloudflare 524, {api_duration:.0f}s)"
                     elif _resp_error_code == 504:
-                        _failure_hint = f"upstream gateway timeout (504, {api_duration:.0f}s)"
+                        _failure_hint = (
+                            f"upstream gateway timeout (504, {api_duration:.0f}s)"
+                        )
                     elif _resp_error_code == 429:
                         _failure_hint = f"rate limited by upstream provider (429)"
                     elif _resp_error_code in {500, 502}:
                         _failure_hint = f"upstream server error ({_resp_error_code}, {api_duration:.0f}s)"
                     elif _resp_error_code in {503, 529}:
-                        _failure_hint = f"upstream provider overloaded ({_resp_error_code})"
+                        _failure_hint = (
+                            f"upstream provider overloaded ({_resp_error_code})"
+                        )
                     elif _resp_error_code is not None:
                         _failure_hint = f"upstream error (code {_resp_error_code}, {api_duration:.0f}s)"
                     elif api_duration < 10:
-                        _failure_hint = f"fast response ({api_duration:.1f}s) — likely rate limited"
+                        _failure_hint = (
+                            f"fast response ({api_duration:.1f}s) — likely rate limited"
+                        )
                     elif api_duration > 60:
                         _failure_hint = f"slow response ({api_duration:.0f}s) — likely upstream timeout"
                     else:
                         _failure_hint = f"response time {api_duration:.1f}s"
 
-                    agent._vprint(f"{agent.log_prefix}⚠️  Invalid API response (attempt {retry_count}/{max_retries}): {', '.join(error_details)}", force=True)
-                    agent._vprint(f"{agent.log_prefix}   🏢 Provider: {provider_name}", force=True)
+                    agent._vprint(
+                        f"{agent.log_prefix}⚠️  Invalid API response (attempt {retry_count}/{max_retries}): {', '.join(error_details)}",
+                        force=True,
+                    )
+                    agent._vprint(
+                        f"{agent.log_prefix}   🏢 Provider: {provider_name}", force=True
+                    )
                     cleaned_provider_error = agent._clean_error_message(error_msg)
-                    agent._vprint(f"{agent.log_prefix}   📝 Provider message: {cleaned_provider_error}", force=True)
-                    agent._vprint(f"{agent.log_prefix}   ⏱️  {_failure_hint}", force=True)
-                    
+                    agent._vprint(
+                        f"{agent.log_prefix}   📝 Provider message: {cleaned_provider_error}",
+                        force=True,
+                    )
+                    agent._vprint(
+                        f"{agent.log_prefix}   ⏱️  {_failure_hint}", force=True
+                    )
+
                     if retry_count >= max_retries:
                         # Try fallback before giving up
-                        agent._emit_status(f"⚠️ Max retries ({max_retries}) for invalid responses — trying fallback...")
+                        agent._emit_status(
+                            f"⚠️ Max retries ({max_retries}) for invalid responses — trying fallback..."
+                        )
                         if agent._try_activate_fallback():
                             retry_count = 0
                             compression_attempts = 0
                             primary_recovery_attempted = False
                             continue
-                        agent._emit_status(f"❌ Max retries ({max_retries}) exceeded for invalid responses. Giving up.")
-                        logging.error(f"{agent.log_prefix}Invalid API response after {max_retries} retries.")
+                        agent._emit_status(
+                            f"❌ Max retries ({max_retries}) exceeded for invalid responses. Giving up."
+                        )
+                        logging.error(
+                            f"{agent.log_prefix}Invalid API response after {max_retries} retries."
+                        )
                         agent._persist_session(messages, conversation_history)
                         return {
                             "messages": messages,
                             "completed": False,
                             "api_calls": api_call_count,
                             "error": f"Invalid API response after {max_retries} retries: {_failure_hint}",
-                            "failed": True  # Mark as failure for filtering
+                            "failed": True,  # Mark as failure for filtering
                         }
-                    
+
                     # Backoff before retry — jittered exponential: 5s base, 120s cap
-                    wait_time = jittered_backoff(retry_count, base_delay=5.0, max_delay=120.0)
-                    agent._vprint(f"{agent.log_prefix}⏳ Retrying in {wait_time:.1f}s ({_failure_hint})...", force=True)
-                    logging.warning(f"Invalid API response (retry {retry_count}/{max_retries}): {', '.join(error_details)} | Provider: {provider_name}")
-                    
+                    wait_time = jittered_backoff(
+                        retry_count, base_delay=5.0, max_delay=120.0
+                    )
+                    agent._vprint(
+                        f"{agent.log_prefix}⏳ Retrying in {wait_time:.1f}s ({_failure_hint})...",
+                        force=True,
+                    )
+                    logging.warning(
+                        f"Invalid API response (retry {retry_count}/{max_retries}): {', '.join(error_details)} | Provider: {provider_name}"
+                    )
+
                     # Sleep in small increments to stay responsive to interrupts
                     sleep_end = time.time() + wait_time
                     _backoff_touch_counter = 0
                     while time.time() < sleep_end:
                         if agent._interrupt_requested:
-                            agent._vprint(f"{agent.log_prefix}⚡ Interrupt detected during retry wait, aborting.", force=True)
+                            agent._vprint(
+                                f"{agent.log_prefix}⚡ Interrupt detected during retry wait, aborting.",
+                                force=True,
+                            )
                             agent._persist_session(messages, conversation_history)
                             agent.clear_interrupt()
                             return {
@@ -1318,7 +1477,10 @@ def run_conversation(
                         incomplete_reason = incomplete_details.get("reason")
                     else:
                         incomplete_reason = getattr(incomplete_details, "reason", None)
-                    if status == "incomplete" and incomplete_reason in {"max_output_tokens", "length"}:
+                    if status == "incomplete" and incomplete_reason in {
+                        "max_output_tokens",
+                        "length",
+                    }:
                         finish_reason = "length"
                     else:
                         finish_reason = "stop"
@@ -1347,7 +1509,10 @@ def run_conversation(
                         finish_reason = "length"
 
                 if finish_reason == "length":
-                    agent._vprint(f"{agent.log_prefix}⚠️  Response truncated (finish_reason='length') - model hit max output tokens", force=True)
+                    agent._vprint(
+                        f"{agent.log_prefix}⚠️  Response truncated (finish_reason='length') - model hit max output tokens",
+                        force=True,
+                    )
 
                     # Normalize the truncated response to a single OpenAI-style
                     # message shape so text-continuation and tool-call retry
@@ -1366,8 +1531,14 @@ def run_conversation(
                         _trunc_result = _trunc_transport.normalize_response(response)
                     _trunc_msg = _trunc_result
 
-                    _trunc_content = getattr(_trunc_msg, "content", None) if _trunc_msg else None
-                    _trunc_has_tool_calls = bool(getattr(_trunc_msg, "tool_calls", None)) if _trunc_msg else False
+                    _trunc_content = (
+                        getattr(_trunc_msg, "content", None) if _trunc_msg else None
+                    )
+                    _trunc_has_tool_calls = (
+                        bool(getattr(_trunc_msg, "tool_calls", None))
+                        if _trunc_msg
+                        else False
+                    )
 
                     # ── Detect thinking-budget exhaustion ──────────────
                     # When the model spends ALL output tokens on reasoning
@@ -1382,8 +1553,9 @@ def run_conversation(
                     # truncations that deserve continuation retries, not as
                     # thinking-budget exhaustion.
                     _has_think_tags = bool(
-                        _trunc_content and re.search(
-                            r'<(?:think|thinking|reasoning|REASONING_SCRATCHPAD)[^>]*>',
+                        _trunc_content
+                        and re.search(
+                            r"<(?:think|thinking|reasoning|REASONING_SCRATCHPAD)[^>]*>",
                             _trunc_content,
                             re.IGNORECASE,
                         )
@@ -1392,7 +1564,12 @@ def run_conversation(
                         not _trunc_has_tool_calls
                         and _has_think_tags
                         and (
-                            (_trunc_content is not None and not agent._has_content_after_think_block(_trunc_content))
+                            (
+                                _trunc_content is not None
+                                and not agent._has_content_after_think_block(
+                                    _trunc_content
+                                )
+                            )
                             or _trunc_content is None
                         )
                     )
@@ -1430,14 +1607,22 @@ def run_conversation(
                             "error": _exhaust_error,
                         }
 
-                    if agent.api_mode in {"chat_completions", "bedrock_converse", "anthropic_messages"}:
+                    if agent.api_mode in {
+                        "chat_completions",
+                        "bedrock_converse",
+                        "anthropic_messages",
+                    }:
                         assistant_message = _trunc_msg
                         if assistant_message is not None and not _trunc_has_tool_calls:
                             length_continue_retries += 1
-                            interim_msg = agent._build_assistant_message(assistant_message, finish_reason)
+                            interim_msg = agent._build_assistant_message(
+                                assistant_message, finish_reason
+                            )
                             messages.append(interim_msg)
                             if assistant_message.content:
-                                truncated_response_parts.append(assistant_message.content)
+                                truncated_response_parts.append(
+                                    assistant_message.content
+                                )
 
                             if length_continue_retries < 3:
                                 agent._vprint(
@@ -1457,7 +1642,9 @@ def run_conversation(
                                 restart_with_length_continuation = True
                                 break
 
-                            partial_response = agent._strip_think_blocks("".join(truncated_response_parts)).strip()
+                            partial_response = agent._strip_think_blocks(
+                                "".join(truncated_response_parts)
+                            ).strip()
                             agent._cleanup_task_resources(effective_task_id)
                             agent._persist_session(messages, conversation_history)
                             return {
@@ -1469,7 +1656,11 @@ def run_conversation(
                                 "error": "Response remained truncated after 3 continuation attempts",
                             }
 
-                    if agent.api_mode in {"chat_completions", "bedrock_converse", "anthropic_messages"}:
+                    if agent.api_mode in {
+                        "chat_completions",
+                        "bedrock_converse",
+                        "anthropic_messages",
+                    }:
                         assistant_message = _trunc_msg
                         if assistant_message is not None and _trunc_has_tool_calls:
                             if truncated_tool_call_retries < 1:
@@ -1499,8 +1690,12 @@ def run_conversation(
 
                     # If we have prior messages, roll back to last complete state
                     if len(messages) > 1:
-                        agent._vprint(f"{agent.log_prefix}   ⏪ Rolling back to last complete assistant turn")
-                        rolled_back_messages = agent._get_messages_up_to_last_assistant(messages)
+                        agent._vprint(
+                            f"{agent.log_prefix}   ⏪ Rolling back to last complete assistant turn"
+                        )
+                        rolled_back_messages = agent._get_messages_up_to_last_assistant(
+                            messages
+                        )
 
                         agent._cleanup_task_resources(effective_task_id)
                         agent._persist_session(messages, conversation_history)
@@ -1511,11 +1706,14 @@ def run_conversation(
                             "api_calls": api_call_count,
                             "completed": False,
                             "partial": True,
-                            "error": "Response truncated due to output length limit"
+                            "error": "Response truncated due to output length limit",
                         }
                     else:
                         # First message was truncated - mark as failed
-                        agent._vprint(f"{agent.log_prefix}❌ First response truncated - cannot recover", force=True)
+                        agent._vprint(
+                            f"{agent.log_prefix}❌ First response truncated - cannot recover",
+                            force=True,
+                        )
                         agent._persist_session(messages, conversation_history)
                         return {
                             "final_response": None,
@@ -1523,11 +1721,11 @@ def run_conversation(
                             "api_calls": api_call_count,
                             "completed": False,
                             "failed": True,
-                            "error": "First response truncated due to output length limit"
+                            "error": "First response truncated due to output length limit",
                         }
-                
+
                 # Track actual token usage from response for context management
-                if hasattr(response, 'usage') and response.usage:
+                if hasattr(response, "usage") and response.usage:
                     canonical_usage = normalize_usage(
                         response.usage,
                         provider=agent.provider,
@@ -1548,9 +1746,15 @@ def run_conversation(
                     # from the error message), not guessed probe tiers.
                     if getattr(agent.context_compressor, "_context_probed", False):
                         ctx = agent.context_compressor.context_length
-                        if getattr(agent.context_compressor, "_context_probe_persistable", False):
+                        if getattr(
+                            agent.context_compressor,
+                            "_context_probe_persistable",
+                            False,
+                        ):
                             save_context_length(agent.model, agent.base_url, ctx)
-                            agent._safe_print(f"{agent.log_prefix}💾 Cached context length: {ctx:,} tokens for {agent.model}")
+                            agent._safe_print(
+                                f"{agent.log_prefix}💾 Cached context length: {ctx:,} tokens for {agent.model}"
+                            )
                         agent.context_compressor._context_probed = False
                         agent.context_compressor._context_probe_persistable = False
 
@@ -1561,7 +1765,9 @@ def run_conversation(
                     agent.session_input_tokens += canonical_usage.input_tokens
                     agent.session_output_tokens += canonical_usage.output_tokens
                     agent.session_cache_read_tokens += canonical_usage.cache_read_tokens
-                    agent.session_cache_write_tokens += canonical_usage.cache_write_tokens
+                    agent.session_cache_write_tokens += (
+                        canonical_usage.cache_write_tokens
+                    )
                     agent.session_reasoning_tokens += canonical_usage.reasoning_tokens
 
                     # Log API call details for debugging/observability
@@ -1570,9 +1776,14 @@ def run_conversation(
                         _cache_pct = f" cache={canonical_usage.cache_read_tokens}/{prompt_tokens} ({100*canonical_usage.cache_read_tokens/prompt_tokens:.0f}%)"
                     logger.info(
                         "API call #%d: model=%s provider=%s in=%d out=%d total=%d latency=%.1fs%s",
-                        agent.session_api_calls, agent.model, agent.provider or "unknown",
-                        prompt_tokens, completion_tokens, total_tokens,
-                        api_duration, _cache_pct,
+                        agent.session_api_calls,
+                        agent.model,
+                        agent.provider or "unknown",
+                        prompt_tokens,
+                        completion_tokens,
+                        total_tokens,
+                        api_duration,
+                        _cache_pct,
                     )
 
                     cost_result = estimate_usage_cost(
@@ -1583,7 +1794,9 @@ def run_conversation(
                         api_key=getattr(agent, "api_key", ""),
                     )
                     if cost_result.amount_usd is not None:
-                        agent.session_estimated_cost_usd += float(cost_result.amount_usd)
+                        agent.session_estimated_cost_usd += float(
+                            cost_result.amount_usd
+                        )
                     agent.session_cost_status = cost_result.status
                     agent.session_cost_source = cost_result.source
 
@@ -1611,14 +1824,20 @@ def run_conversation(
                                 cache_read_tokens=canonical_usage.cache_read_tokens,
                                 cache_write_tokens=canonical_usage.cache_write_tokens,
                                 reasoning_tokens=canonical_usage.reasoning_tokens,
-                                estimated_cost_usd=float(cost_result.amount_usd)
-                                if cost_result.amount_usd is not None else None,
+                                estimated_cost_usd=(
+                                    float(cost_result.amount_usd)
+                                    if cost_result.amount_usd is not None
+                                    else None
+                                ),
                                 cost_status=cost_result.status,
                                 cost_source=cost_result.source,
                                 billing_provider=agent.provider,
                                 billing_base_url=agent.base_url,
-                                billing_mode="subscription_included"
-                                if cost_result.status == "included" else None,
+                                billing_mode=(
+                                    "subscription_included"
+                                    if cost_result.status == "included"
+                                    else None
+                                ),
                                 model=agent.model,
                                 api_call_count=1,
                             )
@@ -1628,12 +1847,16 @@ def run_conversation(
                             # the root cause of undercounted analytics.
                             logger.debug(
                                 "Token persistence failed (session=%s, tokens=%d): %s",
-                                agent.session_id, total_tokens, e,
+                                agent.session_id,
+                                total_tokens,
+                                e,
                             )
-                    
+
                     if agent.verbose_logging:
-                        logging.debug(f"Token usage: prompt={usage_dict['prompt_tokens']:,}, completion={usage_dict['completion_tokens']:,}, total={usage_dict['total_tokens']:,}")
-                    
+                        logging.debug(
+                            f"Token usage: prompt={usage_dict['prompt_tokens']:,}, completion={usage_dict['completion_tokens']:,}, total={usage_dict['total_tokens']:,}"
+                        )
+
                     # Surface cache hit stats for any provider that reports
                     # them — not just those where we inject cache_control
                     # markers.  OpenAI/Kimi/DeepSeek/Qwen all do automatic
@@ -1655,7 +1878,7 @@ def run_conversation(
                             f"{cached:,}/{prompt:,} tokens "
                             f"({hit_pct:.0f}% hit, {written:,} written)"
                         )
-                
+
                 has_retried_429 = False  # Reset on success
                 # Clear Nous rate limit state on successful request —
                 # proves the limit has reset and other sessions can
@@ -1663,6 +1886,7 @@ def run_conversation(
                 if agent.provider == "nous":
                     try:
                         from agent.nous_rate_guard import clear_nous_rate_limit
+
                         clear_nous_rate_limit()
                     except Exception:
                         pass
@@ -1676,7 +1900,9 @@ def run_conversation(
                 if agent.thinking_callback:
                     agent.thinking_callback("")
                 api_elapsed = time.time() - api_start_time
-                agent._vprint(f"{agent.log_prefix}⚡ Interrupted during API call.", force=True)
+                agent._vprint(
+                    f"{agent.log_prefix}⚡ Interrupted during API call.", force=True
+                )
                 agent._persist_session(messages, conversation_history)
                 interrupted = True
                 final_response = f"Operation interrupted: waiting for model response ({api_elapsed:.1f}s elapsed)."
@@ -1701,16 +1927,18 @@ def run_conversation(
                 # first to strip surrogates, then once more for pure
                 # ASCII-only locale sanitization if needed.
                 # -----------------------------------------------------------
-                if isinstance(api_error, UnicodeEncodeError) and getattr(agent, '_unicode_sanitization_passes', 0) < 2:
+                if (
+                    isinstance(api_error, UnicodeEncodeError)
+                    and getattr(agent, "_unicode_sanitization_passes", 0) < 2
+                ):
                     _err_str = str(api_error).lower()
                     _is_ascii_codec = "'ascii'" in _err_str or "ascii" in _err_str
                     # Detect surrogate errors — utf-8 codec refusing to
                     # encode U+D800..U+DFFF.  The error text is:
                     #   "'utf-8' codec can't encode characters in position
                     #    N-M: surrogates not allowed"
-                    _is_surrogate_error = (
-                        "surrogate" in _err_str
-                        or ("'utf-8'" in _err_str and not _is_ascii_codec)
+                    _is_surrogate_error = "surrogate" in _err_str or (
+                        "'utf-8'" in _err_str and not _is_ascii_codec
                     )
                     # Sanitize surrogates from both the canonical `messages`
                     # list AND `api_messages` (the API-copy, which may carry
@@ -1770,7 +1998,9 @@ def run_conversation(
                             _sanitize_structure_non_ascii(api_kwargs)
                         _prefill_sanitized = False
                         if isinstance(getattr(agent, "prefill_messages", None), list):
-                            _prefill_sanitized = _sanitize_messages_non_ascii(agent.prefill_messages)
+                            _prefill_sanitized = _sanitize_messages_non_ascii(
+                                agent.prefill_messages
+                            )
 
                         _tools_sanitized = False
                         if isinstance(getattr(agent, "tools", None), list):
@@ -1783,8 +2013,12 @@ def run_conversation(
                                 active_system_prompt = _sanitized_system
                                 agent._cached_system_prompt = _sanitized_system
                                 _system_sanitized = True
-                        if isinstance(getattr(agent, "ephemeral_system_prompt", None), str):
-                            _sanitized_ephemeral = _strip_non_ascii(agent.ephemeral_system_prompt)
+                        if isinstance(
+                            getattr(agent, "ephemeral_system_prompt", None), str
+                        ):
+                            _sanitized_ephemeral = _strip_non_ascii(
+                                agent.ephemeral_system_prompt
+                            )
                             if _sanitized_ephemeral != agent.ephemeral_system_prompt:
                                 agent.ephemeral_system_prompt = _sanitized_ephemeral
                                 _system_sanitized = True
@@ -1796,7 +2030,9 @@ def run_conversation(
                             else None
                         )
                         if isinstance(_default_headers, dict):
-                            _headers_sanitized = _sanitize_structure_non_ascii(_default_headers)
+                            _headers_sanitized = _sanitize_structure_non_ascii(
+                                _default_headers
+                            )
 
                         # Sanitize the API key — non-ASCII characters in
                         # credentials (e.g. ʋ instead of v from a bad
@@ -1814,12 +2050,16 @@ def run_conversation(
                             _clean_key = _strip_non_ascii(_raw_key)
                             if _clean_key != _raw_key:
                                 agent.api_key = _clean_key
-                                if isinstance(getattr(agent, "_client_kwargs", None), dict):
+                                if isinstance(
+                                    getattr(agent, "_client_kwargs", None), dict
+                                ):
                                     agent._client_kwargs["api_key"] = _clean_key
                                 # Also update the live client — it holds its
                                 # own copy of api_key which auth_headers reads
                                 # dynamically on every request.
-                                if getattr(agent, "client", None) is not None and hasattr(agent.client, "api_key"):
+                                if getattr(
+                                    agent, "client", None
+                                ) is not None and hasattr(agent.client, "api_key"):
                                     agent.client.api_key = _clean_key
                                 _credential_sanitized = True
                                 agent._vprint(
@@ -1873,9 +2113,11 @@ def run_conversation(
                 # provider wordings are observed in the wild.
                 _err_body = ""
                 try:
-                    _err_body = str(getattr(api_error, "body", None) or
-                                    getattr(api_error, "message", None) or
-                                    str(api_error))
+                    _err_body = str(
+                        getattr(api_error, "body", None)
+                        or getattr(api_error, "message", None)
+                        or str(api_error)
+                    )
                 except Exception:
                     pass
                 _err_status = getattr(api_error, "status_code", None)
@@ -1935,7 +2177,11 @@ def run_conversation(
                     agent._vprint(
                         f"{agent.log_prefix}⚠️  Server rejected image content — "
                         f"switching to text-only mode for this session"
-                        + (". Stripped images from history and retrying." if _imgs_removed else "."),
+                        + (
+                            ". Stripped images from history and retrying."
+                            if _imgs_removed
+                            else "."
+                        ),
                         force=True,
                     )
                     continue
@@ -1945,7 +2191,11 @@ def run_conversation(
 
                 # ── Classify the error for structured recovery decisions ──
                 _compressor = getattr(agent, "context_compressor", None)
-                _ctx_len = getattr(_compressor, "context_length", 200000) if _compressor else 200000
+                _ctx_len = (
+                    getattr(_compressor, "context_length", 200000)
+                    if _compressor
+                    else 200000
+                )
                 classified = classify_api_error(
                     api_error,
                     provider=getattr(agent, "provider", "") or "",
@@ -1956,16 +2206,21 @@ def run_conversation(
                 )
                 logger.debug(
                     "Error classified: reason=%s status=%s retryable=%s compress=%s rotate=%s fallback=%s",
-                    classified.reason.value, classified.status_code,
-                    classified.retryable, classified.should_compress,
-                    classified.should_rotate_credential, classified.should_fallback,
+                    classified.reason.value,
+                    classified.status_code,
+                    classified.retryable,
+                    classified.should_compress,
+                    classified.should_rotate_credential,
+                    classified.should_fallback,
                 )
 
-                recovered_with_pool, has_retried_429 = agent._recover_with_credential_pool(
-                    status_code=status_code,
-                    has_retried_429=has_retried_429,
-                    classified_reason=classified.reason,
-                    error_context=error_context,
+                recovered_with_pool, has_retried_429 = (
+                    agent._recover_with_credential_pool(
+                        status_code=status_code,
+                        has_retried_429=has_retried_429,
+                        classified_reason=classified.reason,
+                        error_context=error_context,
+                    )
                 )
                 if recovered_with_pool:
                     continue
@@ -2004,7 +2259,8 @@ def run_conversation(
                 # proposed unconditional omit so capable subscriptions
                 # don't silently lose the capability).
                 if (
-                    classified.reason == FailoverReason.oauth_long_context_beta_forbidden
+                    classified.reason
+                    == FailoverReason.oauth_long_context_beta_forbidden
                     and agent.api_mode == "anthropic_messages"
                     and agent._is_anthropic_oauth
                     and not oauth_1m_beta_retry_attempted
@@ -2032,8 +2288,12 @@ def run_conversation(
                 ):
                     codex_auth_retry_attempted = True
                     if agent._try_refresh_codex_client_credentials(force=True):
-                        _label = "xAI OAuth" if agent.provider == "xai-oauth" else "Codex"
-                        agent._vprint(f"{agent.log_prefix}🔐 {_label} auth refreshed after 401. Retrying request...")
+                        _label = (
+                            "xAI OAuth" if agent.provider == "xai-oauth" else "Codex"
+                        )
+                        agent._vprint(
+                            f"{agent.log_prefix}🔐 {_label} auth refreshed after 401. Retrying request..."
+                        )
                         continue
                 if (
                     agent.api_mode == "chat_completions"
@@ -2043,29 +2303,46 @@ def run_conversation(
                 ):
                     nous_auth_retry_attempted = True
                     if agent._try_refresh_nous_client_credentials(force=True):
-                        print(f"{agent.log_prefix}🔐 Nous agent key refreshed after 401. Retrying request...")
+                        print(
+                            f"{agent.log_prefix}🔐 Nous agent key refreshed after 401. Retrying request..."
+                        )
                         continue
                     # Credential refresh didn't help — show diagnostic info.
                     # Most common causes: Portal OAuth expired/revoked,
                     # account out of credits, or agent key blocked.
                     from hermes_constants import display_hermes_home as _dhh_fn
+
                     _dhh = _dhh_fn()
                     _body_text = ""
                     try:
-                        _body = getattr(api_error, "body", None) or getattr(api_error, "response", None)
+                        _body = getattr(api_error, "body", None) or getattr(
+                            api_error, "response", None
+                        )
                         if _body is not None:
                             _body_text = str(_body)[:200]
                     except Exception:
                         pass
-                    print(f"{agent.log_prefix}🔐 Nous 401 — Portal authentication failed.")
+                    print(
+                        f"{agent.log_prefix}🔐 Nous 401 — Portal authentication failed."
+                    )
                     if _body_text:
                         print(f"{agent.log_prefix}   Response: {_body_text}")
-                    print(f"{agent.log_prefix}   Most likely: Portal OAuth expired, account out of credits, or agent key revoked.")
+                    print(
+                        f"{agent.log_prefix}   Most likely: Portal OAuth expired, account out of credits, or agent key revoked."
+                    )
                     print(f"{agent.log_prefix}   Troubleshooting:")
-                    print(f"{agent.log_prefix}     • Re-authenticate: hermes login --provider nous")
-                    print(f"{agent.log_prefix}     • Check credits / billing: https://portal.nousresearch.com")
-                    print(f"{agent.log_prefix}     • Verify stored credentials: {_dhh}/auth.json")
-                    print(f"{agent.log_prefix}     • Switch providers temporarily: /model <model> --provider openrouter")
+                    print(
+                        f"{agent.log_prefix}     • Re-authenticate: hermes login --provider nous"
+                    )
+                    print(
+                        f"{agent.log_prefix}     • Check credits / billing: https://portal.nousresearch.com"
+                    )
+                    print(
+                        f"{agent.log_prefix}     • Verify stored credentials: {_dhh}/auth.json"
+                    )
+                    print(
+                        f"{agent.log_prefix}     • Switch providers temporarily: /model <model> --provider openrouter"
+                    )
                 if (
                     agent.provider == "copilot"
                     and status_code == 401
@@ -2073,45 +2350,79 @@ def run_conversation(
                 ):
                     copilot_auth_retry_attempted = True
                     if agent._try_refresh_copilot_client_credentials():
-                        agent._vprint(f"{agent.log_prefix}🔐 Copilot credentials refreshed after 401. Retrying request...")
+                        agent._vprint(
+                            f"{agent.log_prefix}🔐 Copilot credentials refreshed after 401. Retrying request..."
+                        )
                         continue
                 if (
                     agent.api_mode == "anthropic_messages"
                     and status_code == 401
-                    and hasattr(agent, '_anthropic_api_key')
+                    and hasattr(agent, "_anthropic_api_key")
                     and not anthropic_auth_retry_attempted
                 ):
                     anthropic_auth_retry_attempted = True
                     from agent.anthropic_adapter import _is_oauth_token
                     from agent.azure_identity_adapter import is_token_provider
+
                     if agent._try_refresh_anthropic_client_credentials():
-                        print(f"{agent.log_prefix}🔐 Anthropic credentials refreshed after 401. Retrying request...")
+                        print(
+                            f"{agent.log_prefix}🔐 Anthropic credentials refreshed after 401. Retrying request..."
+                        )
                         continue
                     # Credential refresh didn't help — show diagnostic info
                     key = agent._anthropic_api_key
-                    print(f"{agent.log_prefix}🔐 Anthropic 401 — authentication failed.")
+                    print(
+                        f"{agent.log_prefix}🔐 Anthropic 401 — authentication failed."
+                    )
                     if is_token_provider(key):
                         # Azure Foundry Entra ID — the bearer token is
                         # minted per-request by an httpx event hook on a
                         # custom http_client passed to the SDK. The 401
                         # means Azure rejected the JWT (RBAC role missing,
                         # az login expired, IMDS unreachable, etc.).
-                        print(f"{agent.log_prefix}   Auth method: Microsoft Entra ID (httpx event hook)")
-                        print(f"{agent.log_prefix}   Run `hermes doctor` for credential-chain diagnostics, or")
-                        print(f"{agent.log_prefix}   `az login` if your developer session expired.")
+                        print(
+                            f"{agent.log_prefix}   Auth method: Microsoft Entra ID (httpx event hook)"
+                        )
+                        print(
+                            f"{agent.log_prefix}   Run `hermes doctor` for credential-chain diagnostics, or"
+                        )
+                        print(
+                            f"{agent.log_prefix}   `az login` if your developer session expired."
+                        )
                     else:
-                        auth_method = "Bearer (OAuth/setup-token)" if _is_oauth_token(key) else "x-api-key (API key)"
+                        auth_method = (
+                            "Bearer (OAuth/setup-token)"
+                            if _is_oauth_token(key)
+                            else "x-api-key (API key)"
+                        )
                         print(f"{agent.log_prefix}   Auth method: {auth_method}")
-                        print(f"{agent.log_prefix}   Token prefix: {key[:12]}..." if isinstance(key, str) and len(key) > 12 else f"{agent.log_prefix}   Token: (empty or short)")
+                        print(
+                            f"{agent.log_prefix}   Token prefix: {key[:12]}..."
+                            if isinstance(key, str) and len(key) > 12
+                            else f"{agent.log_prefix}   Token: (empty or short)"
+                        )
                     print(f"{agent.log_prefix}   Troubleshooting:")
                     from hermes_constants import display_hermes_home as _dhh_fn
+
                     _dhh = _dhh_fn()
-                    print(f"{agent.log_prefix}     • Check ANTHROPIC_TOKEN in {_dhh}/.env for Hermes-managed OAuth/setup tokens")
-                    print(f"{agent.log_prefix}     • Check ANTHROPIC_API_KEY in {_dhh}/.env for API keys or legacy token values")
-                    print(f"{agent.log_prefix}     • For API keys: verify at https://platform.claude.com/settings/keys")
-                    print(f"{agent.log_prefix}     • For Claude Code: run 'claude /login' to refresh, then retry")
-                    print(f"{agent.log_prefix}     • Legacy cleanup: hermes config set ANTHROPIC_TOKEN \"\"")
-                    print(f"{agent.log_prefix}     • Clear stale keys: hermes config set ANTHROPIC_API_KEY \"\"")
+                    print(
+                        f"{agent.log_prefix}     • Check ANTHROPIC_TOKEN in {_dhh}/.env for Hermes-managed OAuth/setup tokens"
+                    )
+                    print(
+                        f"{agent.log_prefix}     • Check ANTHROPIC_API_KEY in {_dhh}/.env for API keys or legacy token values"
+                    )
+                    print(
+                        f"{agent.log_prefix}     • For API keys: verify at https://platform.claude.com/settings/keys"
+                    )
+                    print(
+                        f"{agent.log_prefix}     • For Claude Code: run 'claude /login' to refresh, then retry"
+                    )
+                    print(
+                        f'{agent.log_prefix}     • Legacy cleanup: hermes config set ANTHROPIC_TOKEN ""'
+                    )
+                    print(
+                        f'{agent.log_prefix}     • Clear stale keys: hermes config set ANTHROPIC_API_KEY ""'
+                    )
 
                 # ── Thinking block signature recovery ─────────────────
                 # Anthropic signs thinking blocks against the full turn
@@ -2136,7 +2447,8 @@ def run_conversation(
                     logging.warning(
                         "%sThinking block signature recovery: stripped "
                         "reasoning_details from %d messages",
-                        agent.log_prefix, len(messages),
+                        agent.log_prefix,
+                        len(messages),
                     )
                     continue
 
@@ -2156,11 +2468,13 @@ def run_conversation(
                     llama_cpp_grammar_retry_attempted = True
                     try:
                         from tools.schema_sanitizer import strip_pattern_and_format
+
                         _, _stripped = strip_pattern_and_format(agent.tools)
                     except Exception as _strip_exc:  # pragma: no cover — defensive
                         logging.warning(
                             "%sllama.cpp grammar recovery: strip helper failed: %s",
-                            agent.log_prefix, _strip_exc,
+                            agent.log_prefix,
+                            _strip_exc,
                         )
                         _stripped = 0
                     if _stripped:
@@ -2172,7 +2486,8 @@ def run_conversation(
                         logging.warning(
                             "%sllama.cpp grammar recovery: stripped %d "
                             "pattern/format keyword(s) from tool schemas",
-                            agent.log_prefix, _stripped,
+                            agent.log_prefix,
+                            _stripped,
                         )
                         continue
                     # No keywords found to strip — fall through to normal
@@ -2188,7 +2503,7 @@ def run_conversation(
                 agent._touch_activity(
                     f"API error recovery (attempt {retry_count}/{max_retries})"
                 )
-                
+
                 error_type = type(api_error).__name__
                 error_msg = str(api_error).lower()
                 _error_summary = agent._summarize_api_error(api_error)
@@ -2205,25 +2520,35 @@ def run_conversation(
                 _base = getattr(agent, "base_url", "unknown")
                 _model = getattr(agent, "model", "unknown")
                 _status_code_str = f" [HTTP {status_code}]" if status_code else ""
-                agent._vprint(f"{agent.log_prefix}⚠️  API call failed (attempt {retry_count}/{max_retries}): {error_type}{_status_code_str}", force=True)
-                agent._vprint(f"{agent.log_prefix}   🔌 Provider: {_provider}  Model: {_model}", force=True)
+                agent._vprint(
+                    f"{agent.log_prefix}⚠️  API call failed (attempt {retry_count}/{max_retries}): {error_type}{_status_code_str}",
+                    force=True,
+                )
+                agent._vprint(
+                    f"{agent.log_prefix}   🔌 Provider: {_provider}  Model: {_model}",
+                    force=True,
+                )
                 agent._vprint(f"{agent.log_prefix}   🌐 Endpoint: {_base}", force=True)
-                agent._vprint(f"{agent.log_prefix}   📝 Error: {_error_summary}", force=True)
+                agent._vprint(
+                    f"{agent.log_prefix}   📝 Error: {_error_summary}", force=True
+                )
                 if status_code and status_code < 500:
                     _err_body = getattr(api_error, "body", None)
                     _err_body_str = str(_err_body)[:300] if _err_body else None
                     if _err_body_str:
-                        agent._vprint(f"{agent.log_prefix}   📋 Details: {_err_body_str}", force=True)
-                agent._vprint(f"{agent.log_prefix}   ⏱️  Elapsed: {elapsed_time:.2f}s  Context: {len(api_messages)} msgs, ~{approx_tokens:,} tokens")
+                        agent._vprint(
+                            f"{agent.log_prefix}   📋 Details: {_err_body_str}",
+                            force=True,
+                        )
+                agent._vprint(
+                    f"{agent.log_prefix}   ⏱️  Elapsed: {elapsed_time:.2f}s  Context: {len(api_messages)} msgs, ~{approx_tokens:,} tokens"
+                )
 
                 # Actionable hint for OpenRouter "no tool endpoints" error.
                 # This fires regardless of whether fallback succeeds — the
                 # user needs to know WHY their model failed so they can fix
                 # their provider routing, not just silently fall back.
-                if (
-                    agent._is_openrouter_url()
-                    and "support tool use" in error_msg
-                ):
+                if agent._is_openrouter_url() and "support tool use" in error_msg:
                     agent._vprint(
                         f"{agent.log_prefix}   💡 No OpenRouter providers for {_model} support tool calling with your current settings.",
                         force=True,
@@ -2244,7 +2569,10 @@ def run_conversation(
 
                 # Check for interrupt before deciding to retry
                 if agent._interrupt_requested:
-                    agent._vprint(f"{agent.log_prefix}⚡ Interrupt detected during error handling, aborting retries.", force=True)
+                    agent._vprint(
+                        f"{agent.log_prefix}⚡ Interrupt detected during error handling, aborting retries.",
+                        force=True,
+                    )
                     agent._persist_session(messages, conversation_history)
                     agent.clear_interrupt()
                     return {
@@ -2254,7 +2582,7 @@ def run_conversation(
                         "completed": False,
                         "interrupted": True,
                     }
-                
+
                 # Check for 413 payload-too-large BEFORE generic 4xx handler.
                 # A 413 is a payload-size error — the correct response is to
                 # compress history and retry, not abort immediately.
@@ -2299,7 +2627,8 @@ def run_conversation(
                     if compression_attempts <= max_compression_attempts:
                         original_len = len(messages)
                         messages, active_system_prompt = agent._compress_context(
-                            messages, system_message,
+                            messages,
+                            system_message,
                             approx_tokens=approx_tokens,
                             task_id=effective_task_id,
                         )
@@ -2326,7 +2655,9 @@ def run_conversation(
                     FailoverReason.rate_limit,
                     FailoverReason.billing,
                 }
-                if is_rate_limited and agent._fallback_index < len(agent._fallback_chain):
+                if is_rate_limited and agent._fallback_index < len(
+                    agent._fallback_chain
+                ):
                     # Don't eagerly fallback if credential pool rotation may
                     # still recover.  See _pool_may_recover_from_rate_limit
                     # for the single-credential-pool and CloudCode-quota
@@ -2337,7 +2668,9 @@ def run_conversation(
                         base_url=getattr(agent, "base_url", None),
                     )
                     if not pool_may_recover:
-                        agent._emit_status("⚠️ Rate limited — switching to fallback provider...")
+                        agent._emit_status(
+                            "⚠️ Rate limited — switching to fallback provider..."
+                        )
                         if agent._try_activate_fallback(reason=classified.reason):
                             retry_count = 0
                             compression_attempts = 0
@@ -2376,10 +2709,10 @@ def run_conversation(
                             is_genuine_nous_rate_limit,
                             record_nous_rate_limit,
                         )
+
                         _err_resp = getattr(api_error, "response", None)
                         _err_hdrs = (
-                            getattr(_err_resp, "headers", None)
-                            if _err_resp else None
+                            getattr(_err_resp, "headers", None) if _err_resp else None
                         )
                         _genuine_nous_rate_limit = is_genuine_nous_rate_limit(
                             headers=_err_hdrs,
@@ -2449,9 +2782,17 @@ def run_conversation(
                 if is_payload_too_large:
                     compression_attempts += 1
                     if compression_attempts > max_compression_attempts:
-                        agent._vprint(f"{agent.log_prefix}❌ Max compression attempts ({max_compression_attempts}) reached for payload-too-large error.", force=True)
-                        agent._vprint(f"{agent.log_prefix}   💡 Try /new to start a fresh conversation, or /compress to retry compression.", force=True)
-                        logging.error(f"{agent.log_prefix}413 compression failed after {max_compression_attempts} attempts.")
+                        agent._vprint(
+                            f"{agent.log_prefix}❌ Max compression attempts ({max_compression_attempts}) reached for payload-too-large error.",
+                            force=True,
+                        )
+                        agent._vprint(
+                            f"{agent.log_prefix}   💡 Try /new to start a fresh conversation, or /compress to retry compression.",
+                            force=True,
+                        )
+                        logging.error(
+                            f"{agent.log_prefix}413 compression failed after {max_compression_attempts} attempts."
+                        )
                         agent._persist_session(messages, conversation_history)
                         return {
                             "messages": messages,
@@ -2462,11 +2803,15 @@ def run_conversation(
                             "failed": True,
                             "compression_exhausted": True,
                         }
-                    agent._emit_status(f"⚠️  Request payload too large (413) — compression attempt {compression_attempts}/{max_compression_attempts}...")
+                    agent._emit_status(
+                        f"⚠️  Request payload too large (413) — compression attempt {compression_attempts}/{max_compression_attempts}..."
+                    )
 
                     original_len = len(messages)
                     messages, active_system_prompt = agent._compress_context(
-                        messages, system_message, approx_tokens=approx_tokens,
+                        messages,
+                        system_message,
+                        approx_tokens=approx_tokens,
                         task_id=effective_task_id,
                     )
                     # Compression created a new session — clear history
@@ -2475,14 +2820,24 @@ def run_conversation(
                     conversation_history = None
 
                     if len(messages) < original_len:
-                        agent._emit_status(f"🗜️ Compressed {original_len} → {len(messages)} messages, retrying...")
+                        agent._emit_status(
+                            f"🗜️ Compressed {original_len} → {len(messages)} messages, retrying..."
+                        )
                         time.sleep(2)  # Brief pause between compression retries
                         restart_with_compressed_messages = True
                         break
                     else:
-                        agent._vprint(f"{agent.log_prefix}❌ Payload too large and cannot compress further.", force=True)
-                        agent._vprint(f"{agent.log_prefix}   💡 Try /new to start a fresh conversation, or /compress to retry compression.", force=True)
-                        logging.error(f"{agent.log_prefix}413 payload too large. Cannot compress further.")
+                        agent._vprint(
+                            f"{agent.log_prefix}❌ Payload too large and cannot compress further.",
+                            force=True,
+                        )
+                        agent._vprint(
+                            f"{agent.log_prefix}   💡 Try /new to start a fresh conversation, or /compress to retry compression.",
+                            force=True,
+                        )
+                        logging.error(
+                            f"{agent.log_prefix}413 payload too large. Cannot compress further."
+                        )
                         agent._persist_session(messages, conversation_history)
                         return {
                             "messages": messages,
@@ -2533,9 +2888,17 @@ def run_conversation(
                         # loop forever if the error keeps recurring.
                         compression_attempts += 1
                         if compression_attempts > max_compression_attempts:
-                            agent._vprint(f"{agent.log_prefix}❌ Max compression attempts ({max_compression_attempts}) reached.", force=True)
-                            agent._vprint(f"{agent.log_prefix}   💡 Try /new to start a fresh conversation, or /compress to retry compression.", force=True)
-                            logging.error(f"{agent.log_prefix}Context compression failed after {max_compression_attempts} attempts.")
+                            agent._vprint(
+                                f"{agent.log_prefix}❌ Max compression attempts ({max_compression_attempts}) reached.",
+                                force=True,
+                            )
+                            agent._vprint(
+                                f"{agent.log_prefix}   💡 Try /new to start a fresh conversation, or /compress to retry compression.",
+                                force=True,
+                            )
+                            logging.error(
+                                f"{agent.log_prefix}Context compression failed after {max_compression_attempts} attempts."
+                            )
                             agent._persist_session(messages, conversation_history)
                             return {
                                 "messages": messages,
@@ -2553,13 +2916,17 @@ def run_conversation(
                     # Try to parse the actual limit from the error message
                     parsed_limit = parse_context_limit_from_error(error_msg)
                     _provider_lower = (getattr(agent, "provider", "") or "").lower()
-                    _base_lower = (getattr(agent, "base_url", "") or "").rstrip("/").lower()
-                    is_minimax_provider = (
-                        _provider_lower in {"minimax", "minimax-cn"}
-                        or _base_lower.startswith((
+                    _base_lower = (
+                        (getattr(agent, "base_url", "") or "").rstrip("/").lower()
+                    )
+                    is_minimax_provider = _provider_lower in {
+                        "minimax",
+                        "minimax-cn",
+                    } or _base_lower.startswith(
+                        (
                             "https://api.minimax.io/anthropic",
                             "https://api.minimaxi.com/anthropic",
-                        ))
+                        )
                     )
                     minimax_delta_only_overflow = (
                         is_minimax_provider
@@ -2568,7 +2935,10 @@ def run_conversation(
                     )
                     if parsed_limit and parsed_limit < old_ctx:
                         new_ctx = parsed_limit
-                        agent._vprint(f"{agent.log_prefix}Context limit detected from API: {new_ctx:,} tokens (was {old_ctx:,})", force=True)
+                        agent._vprint(
+                            f"{agent.log_prefix}Context limit detected from API: {new_ctx:,} tokens (was {old_ctx:,})",
+                            force=True,
+                        )
                     elif minimax_delta_only_overflow:
                         new_ctx = old_ctx
                         agent._vprint(
@@ -2600,15 +2970,29 @@ def run_conversation(
                             compressor._context_probe_persistable = bool(
                                 parsed_limit and parsed_limit == new_ctx
                             )
-                        agent._vprint(f"{agent.log_prefix}⚠️  Context length exceeded — stepping down: {old_ctx:,} → {new_ctx:,} tokens", force=True)
+                        agent._vprint(
+                            f"{agent.log_prefix}⚠️  Context length exceeded — stepping down: {old_ctx:,} → {new_ctx:,} tokens",
+                            force=True,
+                        )
                     else:
-                        agent._vprint(f"{agent.log_prefix}⚠️  Context length exceeded at minimum tier — attempting compression...", force=True)
+                        agent._vprint(
+                            f"{agent.log_prefix}⚠️  Context length exceeded at minimum tier — attempting compression...",
+                            force=True,
+                        )
 
                     compression_attempts += 1
                     if compression_attempts > max_compression_attempts:
-                        agent._vprint(f"{agent.log_prefix}❌ Max compression attempts ({max_compression_attempts}) reached.", force=True)
-                        agent._vprint(f"{agent.log_prefix}   💡 Try /new to start a fresh conversation, or /compress to retry compression.", force=True)
-                        logging.error(f"{agent.log_prefix}Context compression failed after {max_compression_attempts} attempts.")
+                        agent._vprint(
+                            f"{agent.log_prefix}❌ Max compression attempts ({max_compression_attempts}) reached.",
+                            force=True,
+                        )
+                        agent._vprint(
+                            f"{agent.log_prefix}   💡 Try /new to start a fresh conversation, or /compress to retry compression.",
+                            force=True,
+                        )
+                        logging.error(
+                            f"{agent.log_prefix}Context compression failed after {max_compression_attempts} attempts."
+                        )
                         agent._persist_session(messages, conversation_history)
                         return {
                             "messages": messages,
@@ -2619,11 +3003,15 @@ def run_conversation(
                             "failed": True,
                             "compression_exhausted": True,
                         }
-                    agent._emit_status(f"🗜️ Context too large (~{approx_tokens:,} tokens) — compressing ({compression_attempts}/{max_compression_attempts})...")
+                    agent._emit_status(
+                        f"🗜️ Context too large (~{approx_tokens:,} tokens) — compressing ({compression_attempts}/{max_compression_attempts})..."
+                    )
 
                     original_len = len(messages)
                     messages, active_system_prompt = agent._compress_context(
-                        messages, system_message, approx_tokens=approx_tokens,
+                        messages,
+                        system_message,
+                        approx_tokens=approx_tokens,
                         task_id=effective_task_id,
                     )
                     # Compression created a new session — clear history
@@ -2633,15 +3021,25 @@ def run_conversation(
 
                     if len(messages) < original_len or new_ctx and new_ctx < old_ctx:
                         if len(messages) < original_len:
-                            agent._emit_status(f"🗜️ Compressed {original_len} → {len(messages)} messages, retrying...")
+                            agent._emit_status(
+                                f"🗜️ Compressed {original_len} → {len(messages)} messages, retrying..."
+                            )
                         time.sleep(2)  # Brief pause between compression retries
                         restart_with_compressed_messages = True
                         break
                     else:
                         # Can't compress further and already at minimum tier
-                        agent._vprint(f"{agent.log_prefix}❌ Context length exceeded and cannot compress further.", force=True)
-                        agent._vprint(f"{agent.log_prefix}   💡 The conversation has accumulated too much content. Try /new to start fresh, or /compress to manually trigger compression.", force=True)
-                        logging.error(f"{agent.log_prefix}Context length exceeded: {approx_tokens:,} tokens. Cannot compress further.")
+                        agent._vprint(
+                            f"{agent.log_prefix}❌ Context length exceeded and cannot compress further.",
+                            force=True,
+                        )
+                        agent._vprint(
+                            f"{agent.log_prefix}   💡 The conversation has accumulated too much content. Try /new to start fresh, or /compress to manually trigger compression.",
+                            force=True,
+                        )
+                        logging.error(
+                            f"{agent.log_prefix}Context length exceeded: {approx_tokens:,} tokens. Cannot compress further."
+                        )
                         agent._persist_session(messages, conversation_history)
                         return {
                             "messages": messages,
@@ -2683,7 +3081,8 @@ def run_conversation(
                     or (
                         not classified.retryable
                         and not classified.should_compress
-                        and classified.reason not in {
+                        and classified.reason
+                        not in {
                             FailoverReason.rate_limit,
                             FailoverReason.billing,
                             FailoverReason.overloaded,
@@ -2698,7 +3097,9 @@ def run_conversation(
                 if is_client_error:
                     # Try fallback before aborting — a different provider
                     # may not have the same issue (rate limit, auth, etc.)
-                    agent._emit_status(f"⚠️ Non-retryable error (HTTP {status_code}) — trying fallback...")
+                    agent._emit_status(
+                        f"⚠️ Non-retryable error (HTTP {status_code}) — trying fallback..."
+                    )
                     if agent._try_activate_fallback():
                         retry_count = 0
                         compression_attempts = 0
@@ -2706,41 +3107,94 @@ def run_conversation(
                         continue
                     if api_kwargs is not None:
                         agent._dump_api_request_debug(
-                            api_kwargs, reason="non_retryable_client_error", error=api_error,
+                            api_kwargs,
+                            reason="non_retryable_client_error",
+                            error=api_error,
                         )
                     agent._emit_status(
                         f"❌ Non-retryable error (HTTP {status_code}): "
                         f"{agent._summarize_api_error(api_error)}"
                     )
-                    agent._vprint(f"{agent.log_prefix}❌ Non-retryable client error (HTTP {status_code}). Aborting.", force=True)
-                    agent._vprint(f"{agent.log_prefix}   🔌 Provider: {_provider}  Model: {_model}", force=True)
-                    agent._vprint(f"{agent.log_prefix}   🌐 Endpoint: {_base}", force=True)
+                    agent._vprint(
+                        f"{agent.log_prefix}❌ Non-retryable client error (HTTP {status_code}). Aborting.",
+                        force=True,
+                    )
+                    agent._vprint(
+                        f"{agent.log_prefix}   🔌 Provider: {_provider}  Model: {_model}",
+                        force=True,
+                    )
+                    agent._vprint(
+                        f"{agent.log_prefix}   🌐 Endpoint: {_base}", force=True
+                    )
                     # Actionable guidance for common auth errors
-                    if classified.is_auth or classified.reason == FailoverReason.billing:
-                        if _provider in {"openai-codex", "xai-oauth"} and status_code == 401:
+                    if (
+                        classified.is_auth
+                        or classified.reason == FailoverReason.billing
+                    ):
+                        if (
+                            _provider in {"openai-codex", "xai-oauth"}
+                            and status_code == 401
+                        ):
                             if _provider == "openai-codex":
-                                agent._vprint(f"{agent.log_prefix}   💡 Codex OAuth token was rejected (HTTP 401). Your token may have been", force=True)
-                                agent._vprint(f"{agent.log_prefix}      refreshed by another client (Codex CLI, VS Code). To fix:", force=True)
-                                agent._vprint(f"{agent.log_prefix}      1. Run `codex` in your terminal to generate fresh tokens.", force=True)
-                                agent._vprint(f"{agent.log_prefix}      2. Then run `hermes auth` to re-authenticate.", force=True)
+                                agent._vprint(
+                                    f"{agent.log_prefix}   💡 Codex OAuth token was rejected (HTTP 401). Your token may have been",
+                                    force=True,
+                                )
+                                agent._vprint(
+                                    f"{agent.log_prefix}      refreshed by another client (Codex CLI, VS Code). To fix:",
+                                    force=True,
+                                )
+                                agent._vprint(
+                                    f"{agent.log_prefix}      1. Run `codex` in your terminal to generate fresh tokens.",
+                                    force=True,
+                                )
+                                agent._vprint(
+                                    f"{agent.log_prefix}      2. Then run `hermes auth` to re-authenticate.",
+                                    force=True,
+                                )
                             else:
-                                agent._vprint(f"{agent.log_prefix}   💡 xAI OAuth token was rejected (HTTP 401). To fix:", force=True)
-                                agent._vprint(f"{agent.log_prefix}      re-authenticate with xAI Grok OAuth (SuperGrok Subscription) from `hermes model`.", force=True)
+                                agent._vprint(
+                                    f"{agent.log_prefix}   💡 xAI OAuth token was rejected (HTTP 401). To fix:",
+                                    force=True,
+                                )
+                                agent._vprint(
+                                    f"{agent.log_prefix}      re-authenticate with xAI Grok OAuth (SuperGrok Subscription) from `hermes model`.",
+                                    force=True,
+                                )
                         else:
-                            agent._vprint(f"{agent.log_prefix}   💡 Your API key was rejected by the provider. Check:", force=True)
-                            agent._vprint(f"{agent.log_prefix}      • Is the key valid? Run: hermes setup", force=True)
-                            agent._vprint(f"{agent.log_prefix}      • Does your account have access to {_model}?", force=True)
+                            agent._vprint(
+                                f"{agent.log_prefix}   💡 Your API key was rejected by the provider. Check:",
+                                force=True,
+                            )
+                            agent._vprint(
+                                f"{agent.log_prefix}      • Is the key valid? Run: hermes setup",
+                                force=True,
+                            )
+                            agent._vprint(
+                                f"{agent.log_prefix}      • Does your account have access to {_model}?",
+                                force=True,
+                            )
                             if base_url_host_matches(str(_base), "openrouter.ai"):
-                                agent._vprint(f"{agent.log_prefix}      • Check credits: https://openrouter.ai/settings/credits", force=True)
+                                agent._vprint(
+                                    f"{agent.log_prefix}      • Check credits: https://openrouter.ai/settings/credits",
+                                    force=True,
+                                )
                     else:
-                        agent._vprint(f"{agent.log_prefix}   💡 This type of error won't be fixed by retrying.", force=True)
-                    logging.error(f"{agent.log_prefix}Non-retryable client error: {api_error}")
+                        agent._vprint(
+                            f"{agent.log_prefix}   💡 This type of error won't be fixed by retrying.",
+                            force=True,
+                        )
+                    logging.error(
+                        f"{agent.log_prefix}Non-retryable client error: {api_error}"
+                    )
                     # Skip session persistence when the error is likely
                     # context-overflow related (status 400 + large session).
                     # Persisting the failed user message would make the
                     # session even larger, causing the same failure on the
                     # next attempt. (#1630)
-                    if status_code == 400 and (approx_tokens > 50000 or len(api_messages) > 80):
+                    if status_code == 400 and (
+                        approx_tokens > 50000 or len(api_messages) > 80
+                    ):
                         agent._vprint(
                             f"{agent.log_prefix}⚠️  Skipping session persistence "
                             f"for large failed session to prevent growth loop.",
@@ -2762,14 +3216,21 @@ def run_conversation(
                     # client once for transient transport errors (stale
                     # connection pool, TCP reset).  Only attempted once
                     # per API call block.
-                    if not primary_recovery_attempted and agent._try_recover_primary_transport(
-                        api_error, retry_count=retry_count, max_retries=max_retries,
+                    if (
+                        not primary_recovery_attempted
+                        and agent._try_recover_primary_transport(
+                            api_error,
+                            retry_count=retry_count,
+                            max_retries=max_retries,
+                        )
                     ):
                         primary_recovery_attempted = True
                         retry_count = 0
                         continue
                     # Try fallback before giving up entirely
-                    agent._emit_status(f"⚠️ Max retries ({max_retries}) exhausted — trying fallback...")
+                    agent._emit_status(
+                        f"⚠️ Max retries ({max_retries}) exhausted — trying fallback..."
+                    )
                     if agent._try_activate_fallback():
                         retry_count = 0
                         compression_attempts = 0
@@ -2777,23 +3238,35 @@ def run_conversation(
                         continue
                     _final_summary = agent._summarize_api_error(api_error)
                     if is_rate_limited:
-                        agent._emit_status(f"❌ Rate limited after {max_retries} retries — {_final_summary}")
+                        agent._emit_status(
+                            f"❌ Rate limited after {max_retries} retries — {_final_summary}"
+                        )
                     else:
-                        agent._emit_status(f"❌ API failed after {max_retries} retries — {_final_summary}")
-                    agent._vprint(f"{agent.log_prefix}   💀 Final error: {_final_summary}", force=True)
+                        agent._emit_status(
+                            f"❌ API failed after {max_retries} retries — {_final_summary}"
+                        )
+                    agent._vprint(
+                        f"{agent.log_prefix}   💀 Final error: {_final_summary}",
+                        force=True,
+                    )
 
                     # Detect SSE stream-drop pattern (e.g. "Network
                     # connection lost") and surface actionable guidance.
                     # This typically happens when the model generates a
                     # very large tool call (write_file with huge content)
                     # and the proxy/CDN drops the stream mid-response.
-                    _is_stream_drop = (
-                        not getattr(api_error, "status_code", None)
-                        and any(p in error_msg for p in (
-                            "connection lost", "connection reset",
-                            "connection closed", "network connection",
-                            "network error", "terminated",
-                        ))
+                    _is_stream_drop = not getattr(
+                        api_error, "status_code", None
+                    ) and any(
+                        p in error_msg
+                        for p in (
+                            "connection lost",
+                            "connection reset",
+                            "connection closed",
+                            "network connection",
+                            "network error",
+                            "terminated",
+                        )
                     )
                     if _is_stream_drop:
                         agent._vprint(
@@ -2813,15 +3286,24 @@ def run_conversation(
 
                     logging.error(
                         "%sAPI call failed after %s retries. %s | provider=%s model=%s msgs=%s tokens=~%s",
-                        agent.log_prefix, max_retries, _final_summary,
-                        _provider, _model, len(api_messages), f"{approx_tokens:,}",
+                        agent.log_prefix,
+                        max_retries,
+                        _final_summary,
+                        _provider,
+                        _model,
+                        len(api_messages),
+                        f"{approx_tokens:,}",
                     )
                     if api_kwargs is not None:
                         agent._dump_api_request_debug(
-                            api_kwargs, reason="max_retries_exhausted", error=api_error,
+                            api_kwargs,
+                            reason="max_retries_exhausted",
+                            error=api_error,
                         )
                     agent._persist_session(messages, conversation_history)
-                    _final_response = f"API call failed after {max_retries} retries: {_final_summary}"
+                    _final_response = (
+                        f"API call failed after {max_retries} retries: {_final_summary}"
+                    )
                     if _is_stream_drop:
                         _final_response += (
                             "\n\nThe provider's stream connection keeps "
@@ -2843,19 +3325,33 @@ def run_conversation(
                 # For rate limits, respect the Retry-After header if present
                 _retry_after = None
                 if is_rate_limited:
-                    _resp_headers = getattr(getattr(api_error, "response", None), "headers", None)
+                    _resp_headers = getattr(
+                        getattr(api_error, "response", None), "headers", None
+                    )
                     if _resp_headers and hasattr(_resp_headers, "get"):
-                        _ra_raw = _resp_headers.get("retry-after") or _resp_headers.get("Retry-After")
+                        _ra_raw = _resp_headers.get("retry-after") or _resp_headers.get(
+                            "Retry-After"
+                        )
                         if _ra_raw:
                             try:
-                                _retry_after = min(float(_ra_raw), 120)  # Cap at 2 minutes
+                                _retry_after = min(
+                                    float(_ra_raw), 120
+                                )  # Cap at 2 minutes
                             except (TypeError, ValueError):
                                 pass
-                wait_time = _retry_after if _retry_after else jittered_backoff(retry_count, base_delay=2.0, max_delay=60.0)
+                wait_time = (
+                    _retry_after
+                    if _retry_after
+                    else jittered_backoff(retry_count, base_delay=2.0, max_delay=60.0)
+                )
                 if is_rate_limited:
-                    agent._emit_status(f"⏱️ Rate limited. Waiting {wait_time:.1f}s (attempt {retry_count + 1}/{max_retries})...")
+                    agent._emit_status(
+                        f"⏱️ Rate limited. Waiting {wait_time:.1f}s (attempt {retry_count + 1}/{max_retries})..."
+                    )
                 else:
-                    agent._emit_status(f"⏳ Retrying in {wait_time:.1f}s (attempt {retry_count}/{max_retries})...")
+                    agent._emit_status(
+                        f"⏳ Retrying in {wait_time:.1f}s (attempt {retry_count}/{max_retries})..."
+                    )
                 logger.warning(
                     "Retrying API call in %ss (attempt %s/%s) %s error=%s",
                     wait_time,
@@ -2870,7 +3366,10 @@ def run_conversation(
                 _backoff_touch_counter = 0
                 while time.time() < sleep_end:
                     if agent._interrupt_requested:
-                        agent._vprint(f"{agent.log_prefix}⚡ Interrupt detected during retry wait, aborting.", force=True)
+                        agent._vprint(
+                            f"{agent.log_prefix}⚡ Interrupt detected during retry wait, aborting.",
+                            force=True,
+                        )
                         agent._persist_session(messages, conversation_history)
                         agent.clear_interrupt()
                         return {
@@ -2889,7 +3388,7 @@ def run_conversation(
                             f"error retry backoff ({retry_count}/{max_retries}), "
                             f"{int(sleep_end - time.time())}s remaining"
                         )
-        
+
         # If the API call was interrupted, skip response processing
         if interrupted:
             _turn_exit_reason = "interrupted_during_api_call"
@@ -2919,7 +3418,9 @@ def run_conversation(
         # the `response` variable is still None. Break out cleanly.
         if response is None:
             _turn_exit_reason = "all_retries_exhausted_no_response"
-            print(f"{agent.log_prefix}❌ All API retries exhausted with no successful response.")
+            print(
+                f"{agent.log_prefix}❌ All API retries exhausted with no successful response."
+            )
             agent._persist_session(messages, conversation_history)
             break
 
@@ -2931,14 +3432,18 @@ def run_conversation(
             normalized = _transport.normalize_response(response, **_normalize_kwargs)
             assistant_message = normalized
             finish_reason = normalized.finish_reason
-            
+
             # Normalize content to string — some OpenAI-compatible servers
             # (llama-server, etc.) return content as a dict or list instead
             # of a plain string, which crashes downstream .strip() calls.
-            if assistant_message.content is not None and not isinstance(assistant_message.content, str):
+            if assistant_message.content is not None and not isinstance(
+                assistant_message.content, str
+            ):
                 raw = assistant_message.content
                 if isinstance(raw, dict):
-                    assistant_message.content = raw.get("text", "") or raw.get("content", "") or json.dumps(raw)
+                    assistant_message.content = (
+                        raw.get("text", "") or raw.get("content", "") or json.dumps(raw)
+                    )
                 elif isinstance(raw, list):
                     # Multimodal content list — extract text parts
                     parts = []
@@ -2955,7 +3460,10 @@ def run_conversation(
 
             try:
                 from hermes_cli.plugins import invoke_hook as _invoke_hook
-                _assistant_tool_calls = getattr(assistant_message, "tool_calls", None) or []
+
+                _assistant_tool_calls = (
+                    getattr(assistant_message, "tool_calls", None) or []
+                )
                 _assistant_text = assistant_message.content or ""
                 _invoke_hook(
                     "post_api_request",
@@ -2983,72 +3491,97 @@ def run_conversation(
             # Handle assistant response
             if assistant_message.content and not agent.quiet_mode:
                 if agent.verbose_logging:
-                    agent._vprint(f"{agent.log_prefix}🤖 Assistant: {assistant_message.content}")
+                    agent._vprint(
+                        f"{agent.log_prefix}🤖 Assistant: {assistant_message.content}"
+                    )
                 else:
-                    agent._vprint(f"{agent.log_prefix}🤖 Assistant: {assistant_message.content[:100]}{'...' if len(assistant_message.content) > 100 else ''}")
+                    agent._vprint(
+                        f"{agent.log_prefix}🤖 Assistant: {assistant_message.content[:100]}{'...' if len(assistant_message.content) > 100 else ''}"
+                    )
 
             # Notify progress callback of model's thinking (used by subagent
             # delegation to relay the child's reasoning to the parent display).
-            if (assistant_message.content and agent.tool_progress_callback):
+            if assistant_message.content and agent.tool_progress_callback:
                 _think_text = assistant_message.content.strip()
                 # Strip reasoning XML tags that shouldn't leak to parent display
                 _think_text = re.sub(
-                    r'</?(?:REASONING_SCRATCHPAD|think|reasoning)>', '', _think_text
+                    r"</?(?:REASONING_SCRATCHPAD|think|reasoning)>", "", _think_text
                 ).strip()
                 # For subagents: relay first line to parent display (existing behaviour).
                 # For all agents with a structured callback: emit reasoning.available event.
-                first_line = _think_text.split('\n')[0][:80] if _think_text else ""
-                if first_line and getattr(agent, '_delegate_depth', 0) > 0:
+                first_line = _think_text.split("\n")[0][:80] if _think_text else ""
+                if first_line and getattr(agent, "_delegate_depth", 0) > 0:
                     try:
                         agent.tool_progress_callback("_thinking", first_line)
                     except Exception:
                         pass
                 elif _think_text:
                     try:
-                        agent.tool_progress_callback("reasoning.available", "_thinking", _think_text[:500], None)
+                        agent.tool_progress_callback(
+                            "reasoning.available", "_thinking", _think_text[:500], None
+                        )
                     except Exception:
                         pass
-            
+
             # Check for incomplete <REASONING_SCRATCHPAD> (opened but never closed)
             # This means the model ran out of output tokens mid-reasoning — retry up to 2 times
             if has_incomplete_scratchpad(assistant_message.content or ""):
                 agent._incomplete_scratchpad_retries += 1
-                
-                agent._vprint(f"{agent.log_prefix}⚠️  Incomplete <REASONING_SCRATCHPAD> detected (opened but never closed)")
-                
+
+                agent._vprint(
+                    f"{agent.log_prefix}⚠️  Incomplete <REASONING_SCRATCHPAD> detected (opened but never closed)"
+                )
+
                 if agent._incomplete_scratchpad_retries <= 2:
-                    agent._vprint(f"{agent.log_prefix}🔄 Retrying API call ({agent._incomplete_scratchpad_retries}/2)...")
+                    agent._vprint(
+                        f"{agent.log_prefix}🔄 Retrying API call ({agent._incomplete_scratchpad_retries}/2)..."
+                    )
                     # Don't add the broken message, just retry
                     continue
                 else:
                     # Max retries - discard this turn and save as partial
-                    agent._vprint(f"{agent.log_prefix}❌ Max retries (2) for incomplete scratchpad. Saving as partial.", force=True)
+                    agent._vprint(
+                        f"{agent.log_prefix}❌ Max retries (2) for incomplete scratchpad. Saving as partial.",
+                        force=True,
+                    )
                     agent._incomplete_scratchpad_retries = 0
-                    
-                    rolled_back_messages = agent._get_messages_up_to_last_assistant(messages)
+
+                    rolled_back_messages = agent._get_messages_up_to_last_assistant(
+                        messages
+                    )
                     agent._cleanup_task_resources(effective_task_id)
                     agent._persist_session(messages, conversation_history)
-                    
+
                     return {
                         "final_response": None,
                         "messages": rolled_back_messages,
                         "api_calls": api_call_count,
                         "completed": False,
                         "partial": True,
-                        "error": "Incomplete REASONING_SCRATCHPAD after 2 retries"
+                        "error": "Incomplete REASONING_SCRATCHPAD after 2 retries",
                     }
-            
+
             # Reset incomplete scratchpad counter on clean response
             agent._incomplete_scratchpad_retries = 0
 
             if agent.api_mode == "codex_responses" and finish_reason == "incomplete":
                 agent._codex_incomplete_retries += 1
 
-                interim_msg = agent._build_assistant_message(assistant_message, finish_reason)
+                interim_msg = agent._build_assistant_message(
+                    assistant_message, finish_reason
+                )
                 interim_has_content = bool((interim_msg.get("content") or "").strip())
-                interim_has_reasoning = bool(interim_msg.get("reasoning", "").strip()) if isinstance(interim_msg.get("reasoning"), str) else False
-                interim_has_codex_reasoning = bool(interim_msg.get("codex_reasoning_items"))
-                interim_has_codex_message_items = bool(interim_msg.get("codex_message_items"))
+                interim_has_reasoning = (
+                    bool(interim_msg.get("reasoning", "").strip())
+                    if isinstance(interim_msg.get("reasoning"), str)
+                    else False
+                )
+                interim_has_codex_reasoning = bool(
+                    interim_msg.get("codex_reasoning_items")
+                )
+                interim_has_codex_message_items = bool(
+                    interim_msg.get("codex_message_items")
+                )
 
                 if (
                     interim_has_content
@@ -3064,16 +3597,26 @@ def run_conversation(
                     # while visible content/reasoning are unchanged), compare
                     # those opaque payloads too so we don't silently drop the
                     # newer continuation state.
-                    last_codex_items = last_msg.get("codex_reasoning_items") if isinstance(last_msg, dict) else None
+                    last_codex_items = (
+                        last_msg.get("codex_reasoning_items")
+                        if isinstance(last_msg, dict)
+                        else None
+                    )
                     interim_codex_items = interim_msg.get("codex_reasoning_items")
-                    last_codex_message_items = last_msg.get("codex_message_items") if isinstance(last_msg, dict) else None
+                    last_codex_message_items = (
+                        last_msg.get("codex_message_items")
+                        if isinstance(last_msg, dict)
+                        else None
+                    )
                     interim_codex_message_items = interim_msg.get("codex_message_items")
                     duplicate_interim = (
                         isinstance(last_msg, dict)
                         and last_msg.get("role") == "assistant"
                         and last_msg.get("finish_reason") == "incomplete"
-                        and (last_msg.get("content") or "") == (interim_msg.get("content") or "")
-                        and (last_msg.get("reasoning") or "") == (interim_msg.get("reasoning") or "")
+                        and (last_msg.get("content") or "")
+                        == (interim_msg.get("content") or "")
+                        and (last_msg.get("reasoning") or "")
+                        == (interim_msg.get("reasoning") or "")
                         and last_codex_items == interim_codex_items
                         and last_codex_message_items == interim_codex_message_items
                     )
@@ -3083,7 +3626,9 @@ def run_conversation(
 
                 if agent._codex_incomplete_retries < 3:
                     if not agent.quiet_mode:
-                        agent._vprint(f"{agent.log_prefix}↻ Codex response incomplete; continuing turn ({agent._codex_incomplete_retries}/3)")
+                        agent._vprint(
+                            f"{agent.log_prefix}↻ Codex response incomplete; continuing turn ({agent._codex_incomplete_retries}/3)"
+                        )
                     agent._session_messages = messages
                     continue
 
@@ -3099,26 +3644,33 @@ def run_conversation(
                 }
             elif hasattr(agent, "_codex_incomplete_retries"):
                 agent._codex_incomplete_retries = 0
-            
+
             # Check for tool calls
             if assistant_message.tool_calls:
                 if not agent.quiet_mode:
-                    agent._vprint(f"{agent.log_prefix}🔧 Processing {len(assistant_message.tool_calls)} tool call(s)...")
-                
+                    agent._vprint(
+                        f"{agent.log_prefix}🔧 Processing {len(assistant_message.tool_calls)} tool call(s)..."
+                    )
+
                 if agent.verbose_logging:
                     for tc in assistant_message.tool_calls:
-                        logging.debug(f"Tool call: {tc.function.name} with args: {tc.function.arguments[:200]}...")
-                
+                        logging.debug(
+                            f"Tool call: {tc.function.name} with args: {tc.function.arguments[:200]}..."
+                        )
+
                 # Validate tool call names - detect model hallucinations
                 # Repair mismatched tool names before validating
                 for tc in assistant_message.tool_calls:
                     if tc.function.name not in agent.valid_tool_names:
                         repaired = agent._repair_tool_call(tc.function.name)
                         if repaired:
-                            print(f"{agent.log_prefix}🔧 Auto-repaired tool name: '{tc.function.name}' -> '{repaired}'")
+                            print(
+                                f"{agent.log_prefix}🔧 Auto-repaired tool name: '{tc.function.name}' -> '{repaired}'"
+                            )
                             tc.function.name = repaired
                 invalid_tool_calls = [
-                    tc.function.name for tc in assistant_message.tool_calls
+                    tc.function.name
+                    for tc in assistant_message.tool_calls
                     if tc.function.name not in agent.valid_tool_names
                 ]
                 if invalid_tool_calls:
@@ -3128,11 +3680,20 @@ def run_conversation(
                     # Return helpful error to model — model can agent-correct next turn
                     available = ", ".join(sorted(agent.valid_tool_names))
                     invalid_name = invalid_tool_calls[0]
-                    invalid_preview = invalid_name[:80] + "..." if len(invalid_name) > 80 else invalid_name
-                    agent._vprint(f"{agent.log_prefix}⚠️  Unknown tool '{invalid_preview}' — sending error to model for agent-correction ({agent._invalid_tool_retries}/3)")
+                    invalid_preview = (
+                        invalid_name[:80] + "..."
+                        if len(invalid_name) > 80
+                        else invalid_name
+                    )
+                    agent._vprint(
+                        f"{agent.log_prefix}⚠️  Unknown tool '{invalid_preview}' — sending error to model for agent-correction ({agent._invalid_tool_retries}/3)"
+                    )
 
                     if agent._invalid_tool_retries >= 3:
-                        agent._vprint(f"{agent.log_prefix}❌ Max retries (3) for invalid tool calls exceeded. Stopping as partial.", force=True)
+                        agent._vprint(
+                            f"{agent.log_prefix}❌ Max retries (3) for invalid tool calls exceeded. Stopping as partial.",
+                            force=True,
+                        )
                         agent._invalid_tool_retries = 0
                         agent._persist_session(messages, conversation_history)
                         return {
@@ -3141,26 +3702,30 @@ def run_conversation(
                             "api_calls": api_call_count,
                             "completed": False,
                             "partial": True,
-                            "error": f"Model generated invalid tool call: {invalid_preview}"
+                            "error": f"Model generated invalid tool call: {invalid_preview}",
                         }
 
-                    assistant_msg = agent._build_assistant_message(assistant_message, finish_reason)
+                    assistant_msg = agent._build_assistant_message(
+                        assistant_message, finish_reason
+                    )
                     messages.append(assistant_msg)
                     for tc in assistant_message.tool_calls:
                         if tc.function.name not in agent.valid_tool_names:
                             content = f"Tool '{tc.function.name}' does not exist. Available tools: {available}"
                         else:
                             content = "Skipped: another tool call in this turn used an invalid name. Please retry this tool call."
-                        messages.append({
-                            "role": "tool",
-                            "name": tc.function.name,
-                            "tool_call_id": tc.id,
-                            "content": content,
-                        })
+                        messages.append(
+                            {
+                                "role": "tool",
+                                "name": tc.function.name,
+                                "tool_call_id": tc.id,
+                                "content": content,
+                            }
+                        )
                     continue
                 # Reset retry counter on successful tool call validation
                 agent._invalid_tool_retries = 0
-                
+
                 # Validate tool call arguments are valid JSON
                 # Handle empty strings as empty objects (common model quirk)
                 invalid_json_args = []
@@ -3180,7 +3745,7 @@ def run_conversation(
                         json.loads(args)
                     except json.JSONDecodeError as e:
                         invalid_json_args.append((tc.function.name, str(e)))
-                
+
                 if invalid_json_args:
                     # Check if the invalid JSON is due to truncation rather
                     # than a model formatting mistake.  Routers sometimes
@@ -3215,27 +3780,39 @@ def run_conversation(
                     agent._invalid_json_retries += 1
 
                     tool_name, error_msg = invalid_json_args[0]
-                    agent._vprint(f"{agent.log_prefix}⚠️  Invalid JSON in tool call arguments for '{tool_name}': {error_msg}")
+                    agent._vprint(
+                        f"{agent.log_prefix}⚠️  Invalid JSON in tool call arguments for '{tool_name}': {error_msg}"
+                    )
 
                     if agent._invalid_json_retries < 3:
-                        agent._vprint(f"{agent.log_prefix}🔄 Retrying API call ({agent._invalid_json_retries}/3)...")
+                        agent._vprint(
+                            f"{agent.log_prefix}🔄 Retrying API call ({agent._invalid_json_retries}/3)..."
+                        )
                         # Don't add anything to messages, just retry the API call
                         continue
                     else:
                         # Instead of returning partial, inject tool error results so the model can recover.
                         # Using tool results (not user messages) preserves role alternation.
-                        agent._vprint(f"{agent.log_prefix}⚠️  Injecting recovery tool results for invalid JSON...")
+                        agent._vprint(
+                            f"{agent.log_prefix}⚠️  Injecting recovery tool results for invalid JSON..."
+                        )
                         agent._invalid_json_retries = 0  # Reset for next attempt
-                        
+
                         # Append the assistant message with its (broken) tool_calls
-                        recovery_assistant = agent._build_assistant_message(assistant_message, finish_reason)
+                        recovery_assistant = agent._build_assistant_message(
+                            assistant_message, finish_reason
+                        )
                         messages.append(recovery_assistant)
-                        
+
                         # Respond with tool error results for each tool call
                         invalid_names = {name for name, _ in invalid_json_args}
                         for tc in assistant_message.tool_calls:
                             if tc.function.name in invalid_names:
-                                err = next(e for n, e in invalid_json_args if n == tc.function.name)
+                                err = next(
+                                    e
+                                    for n, e in invalid_json_args
+                                    if n == tc.function.name
+                                )
                                 tool_result = (
                                     f"Error: Invalid JSON arguments. {err}. "
                                     f"For tools with no required parameters, use an empty object: {{}}. "
@@ -3243,14 +3820,16 @@ def run_conversation(
                                 )
                             else:
                                 tool_result = "Skipped: other tool call in this response had invalid JSON."
-                            messages.append({
-                                "role": "tool",
-                                "name": tc.function.name,
-                                "tool_call_id": tc.id,
-                                "content": tool_result,
-                            })
+                            messages.append(
+                                {
+                                    "role": "tool",
+                                    "name": tc.function.name,
+                                    "tool_call_id": tc.id,
+                                    "content": tool_result,
+                                }
+                            )
                         continue
-                
+
                 # Reset retry counter on successful JSON validation
                 agent._invalid_json_retries = 0
 
@@ -3262,8 +3841,10 @@ def run_conversation(
                     assistant_message.tool_calls
                 )
 
-                assistant_msg = agent._build_assistant_message(assistant_message, finish_reason)
-                
+                assistant_msg = agent._build_assistant_message(
+                    assistant_message, finish_reason
+                )
+
                 # If this turn has both content AND tool_calls, capture the content
                 # as a fallback final response. Common pattern: model delivers its
                 # answer and calls memory/skill tools as a side-effect in the same
@@ -3276,9 +3857,14 @@ def run_conversation(
                     # skill_manage, etc.).  If any substantive tool is present
                     # (search_files, read_file, write_file, terminal, ...),
                     # keep output visible so the user sees progress.
-                    _HOUSEKEEPING_TOOLS = frozenset({
-                        "memory", "todo", "skill_manage", "session_search",
-                    })
+                    _HOUSEKEEPING_TOOLS = frozenset(
+                        {
+                            "memory",
+                            "todo",
+                            "skill_manage",
+                            "session_search",
+                        }
+                    )
                     _all_housekeeping = all(
                         tc.function.name in _HOUSEKEEPING_TOOLS
                         for tc in assistant_message.tool_calls
@@ -3290,7 +3876,7 @@ def run_conversation(
                         clean = agent._strip_think_blocks(turn_content).strip()
                         if clean:
                             agent._vprint(f"  ┊ 💬 {clean}")
-                
+
                 # Pop thinking-only prefill message(s) before appending
                 # (tool-call path — same rationale as the final-response path).
                 _had_prefill = False
@@ -3332,7 +3918,9 @@ def run_conversation(
                     except Exception:
                         pass
 
-                agent._execute_tool_calls(assistant_message, messages, effective_task_id, api_call_count)
+                agent._execute_tool_calls(
+                    assistant_message, messages, effective_task_id, api_call_count
+                )
 
                 if agent._tool_guardrail_halt_decision is not None:
                     decision = agent._tool_guardrail_halt_decision
@@ -3363,7 +3951,7 @@ def run_conversation(
                 _tc_names = {tc.function.name for tc in assistant_message.tool_calls}
                 if _tc_names == {"execute_code"}:
                     agent.iteration_budget.refund()
-                
+
                 # Use real token counts from the API response to decide
                 # compression.  prompt_tokens + completion_tokens is the
                 # actual context size the provider reported plus the
@@ -3395,10 +3983,13 @@ def run_conversation(
                         messages, tools=agent.tools or None
                     )
 
-                if agent.compression_enabled and _compressor.should_compress(_real_tokens):
+                if agent.compression_enabled and _compressor.should_compress(
+                    _real_tokens
+                ):
                     agent._safe_print("  ⟳ compacting context…")
                     messages, active_system_prompt = agent._compress_context(
-                        messages, system_message,
+                        messages,
+                        system_message,
                         approx_tokens=agent.context_compressor.last_prompt_tokens,
                         task_id=effective_task_id,
                     )
@@ -3406,24 +3997,24 @@ def run_conversation(
                     # _flush_messages_to_session_db writes compressed messages
                     # to the new session (see preflight compression comment).
                     conversation_history = None
-                
+
                 # Save session log incrementally (so progress is visible even if interrupted)
                 agent._session_messages = messages
-                
+
                 # Continue loop for next response
                 continue
-            
+
             else:
                 # No tool calls - this is the final response
                 final_response = assistant_message.content or ""
-                
+
                 # Fix: unmute output when entering the no-tool-call branch
                 # so the user can see empty-response warnings and recovery
                 # status messages.  _mute_post_response was set during a
                 # prior housekeeping tool turn and should not silence the
                 # final response path.
                 agent._mute_post_response = False
-                
+
                 # Check if response only has think block with no actual content after it
                 if not agent._has_content_after_think_block(final_response):
                     # ── Partial stream recovery ─────────────────────
@@ -3436,7 +4027,9 @@ def run_conversation(
                     )
                     if agent._has_content_after_think_block(_partial_streamed):
                         _turn_exit_reason = "partial_stream_recovery"
-                        _recovered = agent._strip_think_blocks(_partial_streamed).strip()
+                        _recovered = agent._strip_think_blocks(
+                            _partial_streamed
+                        ).strip()
                         logger.info(
                             "Partial stream content delivered (%d chars) "
                             "— using as final response",
@@ -3460,11 +4053,17 @@ def run_conversation(
                     # likely mid-task narration ("I'll scan the directory...") and
                     # the empty follow-up means the model choked — let the
                     # post-tool nudge below handle that instead of exiting early.
-                    fallback = getattr(agent, '_last_content_with_tools', None)
-                    if fallback and getattr(agent, '_last_content_tools_all_housekeeping', False):
+                    fallback = getattr(agent, "_last_content_with_tools", None)
+                    if fallback and getattr(
+                        agent, "_last_content_tools_all_housekeeping", False
+                    ):
                         _turn_exit_reason = "fallback_prior_turn_content"
-                        logger.info("Empty follow-up after tool calls — using prior turn content as final response")
-                        agent._emit_status("↻ Empty response after tool calls — using earlier content as final answer")
+                        logger.info(
+                            "Empty follow-up after tool calls — using prior turn content as final response"
+                        )
+                        agent._emit_status(
+                            "↻ Empty response after tool calls — using earlier content as final answer"
+                        )
                         agent._last_content_with_tools = None
                         agent._last_content_tools_all_housekeeping = False
                         agent._empty_content_retries = 0
@@ -3500,7 +4099,7 @@ def run_conversation(
                     # after tool calls route to prefill instead of nudge.
                     _has_inline_thinking = bool(
                         re.search(
-                            r'<think>|<thinking>|<reasoning>',
+                            r"<think>|<thinking>|<reasoning>",
                             final_response or "",
                             re.IGNORECASE,
                         )
@@ -3528,19 +4127,23 @@ def run_conversation(
                         #   tool(result) → assistant("(empty)") → user(nudge)
                         # Without this, we'd have tool → user which most
                         # APIs reject as an invalid sequence.
-                        _nudge_msg = agent._build_assistant_message(assistant_message, finish_reason)
+                        _nudge_msg = agent._build_assistant_message(
+                            assistant_message, finish_reason
+                        )
                         _nudge_msg["content"] = "(empty)"
                         _nudge_msg["_empty_recovery_synthetic"] = True
                         messages.append(_nudge_msg)
-                        messages.append({
-                            "role": "user",
-                            "content": (
-                                "You just executed tool calls but returned an "
-                                "empty response. Please process the tool "
-                                "results above and continue with the task."
-                            ),
-                            "_empty_recovery_synthetic": True,
-                        })
+                        messages.append(
+                            {
+                                "role": "user",
+                                "content": (
+                                    "You just executed tool calls but returned an "
+                                    "empty response. Please process the tool "
+                                    "results above and continue with the task."
+                                ),
+                                "_empty_recovery_synthetic": True,
+                            }
+                        )
                         continue
 
                     # ── Thinking-only prefill continuation ──────────
@@ -3586,19 +4189,21 @@ def run_conversation(
                     # always populate reasoning fields via OpenRouter,
                     # so the old `not _has_structured` guard blocked
                     # retries for every reasoning model after prefill.
-                    _truly_empty = not agent._strip_think_blocks(
-                        final_response
-                    ).strip()
+                    _truly_empty = not agent._strip_think_blocks(final_response).strip()
                     _prefill_exhausted = (
-                        _has_structured
-                        and agent._thinking_prefill_retries >= 2
+                        _has_structured and agent._thinking_prefill_retries >= 2
                     )
-                    if _truly_empty and (not _has_structured or _prefill_exhausted) and agent._empty_content_retries < 3:
+                    if (
+                        _truly_empty
+                        and (not _has_structured or _prefill_exhausted)
+                        and agent._empty_content_retries < 3
+                    ):
                         agent._empty_content_retries += 1
                         logger.warning(
                             "Empty response (no content or reasoning) — "
                             "retry %d/3 (model=%s)",
-                            agent._empty_content_retries, agent.model,
+                            agent._empty_content_retries,
+                            agent.model,
                         )
                         agent._emit_status(
                             f"⚠️ Empty response from model — retrying "
@@ -3616,7 +4221,8 @@ def run_conversation(
                         logger.warning(
                             "Empty response after %d retries — "
                             "attempting fallback (model=%s, provider=%s)",
-                            agent._empty_content_retries, agent.model,
+                            agent._empty_content_retries,
+                            agent.model,
                             agent.provider,
                         )
                         agent._emit_status(
@@ -3632,7 +4238,8 @@ def run_conversation(
                             logger.info(
                                 "Fallback activated after empty responses: "
                                 "now using %s on %s",
-                                agent.model, agent.provider,
+                                agent.model,
+                                agent.provider,
                             )
                             continue
 
@@ -3642,7 +4249,9 @@ def run_conversation(
                     _turn_exit_reason = "empty_response_exhausted"
                     reasoning_text = agent._extract_reasoning(assistant_message)
                     agent._drop_trailing_empty_response_scaffolding(messages)
-                    assistant_msg = agent._build_assistant_message(assistant_message, finish_reason)
+                    assistant_msg = agent._build_assistant_message(
+                        assistant_message, finish_reason
+                    )
                     assistant_msg["content"] = "(empty)"
                     # This is a user-facing failure sentinel for the gateway,
                     # not real assistant content. Persisting it makes later
@@ -3653,11 +4262,16 @@ def run_conversation(
                     messages.append(assistant_msg)
 
                     if reasoning_text:
-                        reasoning_preview = reasoning_text[:500] + "..." if len(reasoning_text) > 500 else reasoning_text
+                        reasoning_preview = (
+                            reasoning_text[:500] + "..."
+                            if len(reasoning_text) > 500
+                            else reasoning_text
+                        )
                         logger.warning(
                             "Reasoning-only response (no visible content) "
                             "after exhausting retries and fallback. "
-                            "Reasoning: %s", reasoning_preview,
+                            "Reasoning: %s",
+                            reasoning_preview,
                         )
                         agent._emit_status(
                             "⚠️ Model produced reasoning but no visible "
@@ -3668,18 +4282,22 @@ def run_conversation(
                             "Empty response (no content or reasoning) "
                             "after %d retries. No fallback available. "
                             "model=%s provider=%s",
-                            agent._empty_content_retries, agent.model,
+                            agent._empty_content_retries,
+                            agent.model,
                             agent.provider,
                         )
                         agent._emit_status(
                             "❌ Model returned no content after all retries"
-                            + (" and fallback attempts." if agent._fallback_chain else
-                               ". No fallback providers configured.")
+                            + (
+                                " and fallback attempts."
+                                if agent._fallback_chain
+                                else ". No fallback providers configured."
+                            )
                         )
 
                     final_response = "(empty)"
                     break
-                
+
                 # Reset retry counter/signature on successful content
                 agent._empty_content_retries = 0
                 agent._thinking_prefill_retries = 0
@@ -3695,7 +4313,9 @@ def run_conversation(
                     )
                 ):
                     codex_ack_continuations += 1
-                    interim_msg = agent._build_assistant_message(assistant_message, "incomplete")
+                    interim_msg = agent._build_assistant_message(
+                        assistant_message, "incomplete"
+                    )
                     messages.append(interim_msg)
                     agent._emit_interim_assistant_message(interim_msg)
 
@@ -3716,10 +4336,12 @@ def run_conversation(
                     final_response = "".join(truncated_response_parts) + final_response
                     truncated_response_parts = []
                     length_continue_retries = 0
-                
+
                 final_response = agent._strip_think_blocks(final_response).strip()
-                
-                final_msg = agent._build_assistant_message(assistant_message, finish_reason)
+
+                final_msg = agent._build_assistant_message(
+                    assistant_message, finish_reason
+                )
 
                 # Pop thinking-only prefill and empty-response retry
                 # scaffolding before appending the final response.  These
@@ -3737,21 +4359,27 @@ def run_conversation(
                     messages.pop()
 
                 messages.append(final_msg)
-                
+
                 _turn_exit_reason = f"text_response(finish_reason={finish_reason})"
                 if not agent.quiet_mode:
-                    agent._safe_print(f"🎉 Conversation completed after {api_call_count} OpenAI-compatible API call(s)")
+                    agent._safe_print(
+                        f"🎉 Conversation completed after {api_call_count} OpenAI-compatible API call(s)"
+                    )
                 break
-            
+
         except Exception as e:
-            error_msg = f"Error during OpenAI-compatible API call #{api_call_count}: {str(e)}"
+            error_msg = (
+                f"Error during OpenAI-compatible API call #{api_call_count}: {str(e)}"
+            )
             try:
                 print(f"❌ {error_msg}")
             except (OSError, ValueError):
                 logger.error(error_msg)
-            
-            logger.debug("Outer loop error in API call #%d", api_call_count, exc_info=True)
-            
+
+            logger.debug(
+                "Outer loop error in API call #%d", api_call_count, exc_info=True
+            )
+
             # If an assistant message with tool_calls was already appended,
             # the API expects a role="tool" result for every tool_call_id.
             # Fill in error results for any that weren't answered yet.
@@ -3764,11 +4392,12 @@ def run_conversation(
                 if msg.get("role") == "assistant" and msg.get("tool_calls"):
                     answered_ids = {
                         m["tool_call_id"]
-                        for m in messages[idx + 1:]
+                        for m in messages[idx + 1 :]
                         if isinstance(m, dict) and m.get("role") == "tool"
                     }
                     for tc in msg["tool_calls"]:
-                        if not tc or not isinstance(tc, dict): continue
+                        if not tc or not isinstance(tc, dict):
+                            continue
                         if tc["id"] not in answered_ids:
                             err_msg = {
                                 "role": "tool",
@@ -3778,7 +4407,7 @@ def run_conversation(
                             }
                             messages.append(err_msg)
                 break
-            
+
             # Non-tool errors don't need a synthetic message injected.
             # The error is already printed to the user (line above), and
             # the retry loop continues.  Injecting a fake user/assistant
@@ -3788,20 +4417,23 @@ def run_conversation(
             # If we're near the limit, break to avoid infinite loops
             if api_call_count >= agent.max_iterations - 1:
                 _turn_exit_reason = f"error_near_max_iterations({error_msg[:80]})"
-                final_response = f"I apologize, but I encountered repeated errors: {error_msg}"
+                final_response = (
+                    f"I apologize, but I encountered repeated errors: {error_msg}"
+                )
                 # Append as assistant so the history stays valid for
                 # session resume (avoids consecutive user messages).
                 messages.append({"role": "assistant", "content": final_response})
                 break
-    
+
     if final_response is None and (
-        api_call_count >= agent.max_iterations
-        or agent.iteration_budget.remaining <= 0
+        api_call_count >= agent.max_iterations or agent.iteration_budget.remaining <= 0
     ):
         # Budget exhausted — ask the model for a summary via one extra
         # API call with tools stripped.  _handle_max_iterations injects a
         # user message and makes a single toolless request.
-        _turn_exit_reason = f"max_iterations_reached({api_call_count}/{agent.max_iterations})"
+        _turn_exit_reason = (
+            f"max_iterations_reached({api_call_count}/{agent.max_iterations})"
+        )
         agent._emit_status(
             f"⚠️ Iteration budget exhausted ({api_call_count}/{agent.max_iterations}) "
             "— asking model to summarise"
@@ -3837,7 +4469,9 @@ def run_conversation(
                 logger.info(
                     "kanban_block called for task %s after iteration "
                     "exhaustion (%d/%d)",
-                    _kanban_task, api_call_count, agent.max_iterations,
+                    _kanban_task,
+                    api_call_count,
+                    agent.max_iterations,
                 )
             except Exception:
                 logger.warning(
@@ -3852,7 +4486,9 @@ def run_conversation(
 
     # Save trajectory if enabled.  ``user_message`` may be a multimodal
     # list of parts; the trajectory format wants a plain string.
-    agent._save_trajectory(messages, _summarize_user_message_for_log(user_message), completed)
+    agent._save_trajectory(
+        messages, _summarize_user_message_for_log(user_message), completed
+    )
 
     # Clean up VM and browser for this task after conversation completes
     agent._cleanup_task_resources(effective_task_id)
@@ -3880,7 +4516,8 @@ def run_conversation(
                 break
 
     _turn_tool_count = sum(
-        1 for m in messages
+        1
+        for m in messages
         if isinstance(m, dict) and m.get("role") == "assistant" and m.get("tool_calls")
     )
     _resp_len = len(final_response) if final_response else 0
@@ -3892,9 +4529,15 @@ def run_conversation(
         "tool_turns=%d last_msg_role=%s response_len=%d session=%s"
     )
     _diag_args = (
-        _turn_exit_reason, agent.model, api_call_count, agent.max_iterations,
-        _budget_used, _budget_max,
-        _turn_tool_count, _last_msg_role, _resp_len,
+        _turn_exit_reason,
+        agent.model,
+        api_call_count,
+        agent.max_iterations,
+        _budget_used,
+        _budget_max,
+        _turn_tool_count,
+        _last_msg_role,
+        _resp_len,
         agent.session_id or "none",
     )
 
@@ -3902,8 +4545,10 @@ def run_conversation(
         # Agent was mid-work — this is the "just stops" case.
         logger.warning(
             "Turn ended with pending tool result (agent may appear stuck). "
-            + _diag_msg + " last_tool=%s",
-            *_diag_args, _last_tool_name,
+            + _diag_msg
+            + " last_tool=%s",
+            *_diag_args,
+            _last_tool_name,
         )
     else:
         logger.info(_diag_msg, *_diag_args)
@@ -3940,6 +4585,7 @@ def run_conversation(
     if final_response and not interrupted:
         try:
             from hermes_cli.plugins import invoke_hook as _invoke_hook
+
             _transform_results = _invoke_hook(
                 "transform_llm_output",
                 response_text=final_response,
@@ -3961,6 +4607,7 @@ def run_conversation(
     if final_response and not interrupted:
         try:
             from hermes_cli.plugins import invoke_hook as _invoke_hook
+
             _invoke_hook(
                 "post_llm_call",
                 session_id=agent.session_id,
@@ -4012,7 +4659,8 @@ def run_conversation(
         "prompt_tokens": agent.session_prompt_tokens,
         "completion_tokens": agent.session_completion_tokens,
         "total_tokens": agent.session_total_tokens,
-        "last_prompt_tokens": getattr(agent.context_compressor, "last_prompt_tokens", 0) or 0,
+        "last_prompt_tokens": getattr(agent.context_compressor, "last_prompt_tokens", 0)
+        or 0,
         "estimated_cost_usd": agent.session_estimated_cost_usd,
         "cost_status": agent.session_cost_status,
         "cost_source": agent.session_cost_source,
@@ -4026,11 +4674,11 @@ def run_conversation(
     if _leftover_steer:
         result["pending_steer"] = _leftover_steer
     agent._response_was_previewed = False
-    
+
     # Include interrupt message if one triggered the interrupt
     if interrupted and agent._interrupt_message:
         result["interrupt_message"] = agent._interrupt_message
-    
+
     # Clear interrupt state after handling
     agent.clear_interrupt()
 
@@ -4039,9 +4687,11 @@ def run_conversation(
 
     # Check skill trigger NOW — based on how many tool iterations THIS turn used.
     _should_review_skills = False
-    if (agent._skill_nudge_interval > 0
-            and agent._iters_since_skill >= agent._skill_nudge_interval
-            and "skill_manage" in agent.valid_tool_names):
+    if (
+        agent._skill_nudge_interval > 0
+        and agent._iters_since_skill >= agent._skill_nudge_interval
+        and "skill_manage" in agent.valid_tool_names
+    ):
         _should_review_skills = True
         agent._iters_since_skill = 0
 
@@ -4054,7 +4704,11 @@ def run_conversation(
 
     # Background memory/skill review — runs AFTER the response is delivered
     # so it never competes with the user's task for model attention.
-    if final_response and not interrupted and (_should_review_memory or _should_review_skills):
+    if (
+        final_response
+        and not interrupted
+        and (_should_review_memory or _should_review_skills)
+    ):
         try:
             agent._spawn_background_review(
                 messages_snapshot=list(messages),
@@ -4076,6 +4730,7 @@ def run_conversation(
     # Plugins can use this for cleanup, flushing buffers, etc.
     try:
         from hermes_cli.plugins import invoke_hook as _invoke_hook
+
         _invoke_hook(
             "on_session_end",
             session_id=agent.session_id,
@@ -4088,7 +4743,6 @@ def run_conversation(
         logger.warning("on_session_end hook failed: %s", exc)
 
     return result
-
 
 
 __all__ = ["run_conversation"]

--- a/agent/prompt_caching.py
+++ b/agent/prompt_caching.py
@@ -1,9 +1,13 @@
-"""Anthropic prompt caching strategy.
+"""Anthropic prompt caching strategies.
 
-Single layout: ``system_and_3``. 4 cache_control breakpoints — system
-prompt + last 3 non-system messages, all at the same TTL (5m or 1h).
-Reduces input token costs by ~75% on multi-turn conversations within a
-single session.
+Two layouts:
+
+* ``system_and_3`` (default) — 4 cache_control breakpoints: system
+  prompt + last 3 non-system messages, all at the same TTL.
+
+* ``pi_dual`` — 3 targeted breakpoints: system prompt, last assistant
+  ``tool_use`` block, and last user message.  Excludes ``role: tool``
+  messages entirely.  Inspired by PI/OpenClaw's cache extension.
 
 Pure functions -- no class state, no AIAgent dependency.
 """
@@ -11,8 +15,12 @@ Pure functions -- no class state, no AIAgent dependency.
 import copy
 from typing import Any, Dict, List
 
+_VALID_STRATEGIES = {"system_and_3", "pi_dual"}
 
-def _apply_cache_marker(msg: dict, cache_marker: dict, native_anthropic: bool = False) -> None:
+
+def _apply_cache_marker(
+    msg: dict, cache_marker: dict, native_anthropic: bool = False
+) -> None:
     """Add cache_control to a single message, handling all format variations."""
     role = msg.get("role", "")
     content = msg.get("content")
@@ -38,6 +46,34 @@ def _apply_cache_marker(msg: dict, cache_marker: dict, native_anthropic: bool = 
             last["cache_control"] = cache_marker
 
 
+def _apply_content_block_marker(
+    msg: dict, block_index: int, cache_marker: dict
+) -> None:
+    """Add cache_control to a specific content block within a message."""
+    content = msg.get("content")
+    if isinstance(content, list) and 0 <= block_index < len(content):
+        block = content[block_index]
+        if isinstance(block, dict):
+            block["cache_control"] = cache_marker
+
+
+def _mark_last_content_block(msg: dict, cache_marker: dict) -> None:
+    """Add cache_control to the last content block, normalizing string content."""
+    content = msg.get("content")
+    if content is None or content == "":
+        msg["cache_control"] = cache_marker
+        return
+    if isinstance(content, str):
+        msg["content"] = [
+            {"type": "text", "text": content, "cache_control": cache_marker}
+        ]
+        return
+    if isinstance(content, list) and content:
+        last = content[-1]
+        if isinstance(last, dict):
+            last["cache_control"] = cache_marker
+
+
 def _build_marker(ttl: str) -> Dict[str, str]:
     """Build a cache_control marker dict for the given TTL ('5m' or '1h')."""
     marker: Dict[str, str] = {"type": "ephemeral"}
@@ -46,25 +82,12 @@ def _build_marker(ttl: str) -> Dict[str, str]:
     return marker
 
 
-def apply_anthropic_cache_control(
-    api_messages: List[Dict[str, Any]],
-    cache_ttl: str = "5m",
-    native_anthropic: bool = False,
+def _apply_system_and_3(
+    messages: List[Dict[str, Any]],
+    marker: Dict[str, str],
+    native_anthropic: bool,
 ) -> List[Dict[str, Any]]:
-    """Apply system_and_3 caching strategy to messages for Anthropic models.
-
-    Places up to 4 cache_control breakpoints: system prompt + last 3 non-system
-    messages, all at the same TTL.
-
-    Returns:
-        Deep copy of messages with cache_control breakpoints injected.
-    """
-    messages = copy.deepcopy(api_messages)
-    if not messages:
-        return messages
-
-    marker = _build_marker(cache_ttl)
-
+    """Original strategy: system + last 3 non-system messages (4 breakpoints max)."""
     breakpoints_used = 0
 
     if messages[0].get("role") == "system":
@@ -77,3 +100,78 @@ def apply_anthropic_cache_control(
         _apply_cache_marker(messages[idx], marker, native_anthropic=native_anthropic)
 
     return messages
+
+
+def _apply_pi_dual(
+    messages: List[Dict[str, Any]],
+    marker: Dict[str, str],
+    native_anthropic: bool,
+) -> List[Dict[str, Any]]:
+    """PI-style dual strategy: system + last assistant tool_use + last user (3 breakpoints).
+
+    Never marks role:tool messages.  When native_anthropic is False,
+    falls back to system_and_3 to avoid regressions on OpenRouter.
+    """
+    if not native_anthropic:
+        return _apply_system_and_3(messages, marker, native_anthropic)
+
+    # 1. Mark system prompt
+    if messages and messages[0].get("role") == "system":
+        _mark_last_content_block(messages[0], marker)
+
+    # 2. Find and mark last assistant message containing a tool_use block
+    for i in range(len(messages) - 1, -1, -1):
+        msg = messages[i]
+        if msg.get("role") != "assistant":
+            continue
+        content = msg.get("content")
+        if not isinstance(content, list):
+            continue
+        last_tool_use_idx = None
+        for j in range(len(content) - 1, -1, -1):
+            block = content[j]
+            if isinstance(block, dict) and block.get("type") == "tool_use":
+                last_tool_use_idx = j
+                break
+        if last_tool_use_idx is not None:
+            _apply_content_block_marker(msg, last_tool_use_idx, marker)
+            break
+
+    # 3. Find and mark last user message
+    for i in range(len(messages) - 1, -1, -1):
+        msg = messages[i]
+        if msg.get("role") == "user":
+            _mark_last_content_block(msg, marker)
+            break
+
+    return messages
+
+
+def apply_anthropic_cache_control(
+    api_messages: List[Dict[str, Any]],
+    cache_ttl: str = "5m",
+    native_anthropic: bool = False,
+    strategy: str = "system_and_3",
+) -> List[Dict[str, Any]]:
+    """Apply caching strategy to messages for Anthropic models.
+
+    Strategies:
+        system_and_3: System prompt + last 3 non-system messages (4 breakpoints).
+        pi_dual: System prompt + last assistant tool_use + last user (3 breakpoints).
+                 Falls back to system_and_3 when native_anthropic is False.
+
+    Returns:
+        Deep copy of messages with cache_control breakpoints injected.
+    """
+    messages = copy.deepcopy(api_messages)
+    if not messages:
+        return messages
+
+    marker = _build_marker(cache_ttl)
+
+    if strategy not in _VALID_STRATEGIES:
+        strategy = "system_and_3"
+
+    if strategy == "pi_dual":
+        return _apply_pi_dual(messages, marker, native_anthropic)
+    return _apply_system_and_3(messages, marker, native_anthropic)

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -81,18 +81,20 @@ NOUS_DEVICE_CODE_SOURCE = "device_code"
 NOUS_INFERENCE_AUTH_MODE_AUTO = "auto"
 NOUS_INFERENCE_AUTH_MODE_FRESH = "fresh"
 NOUS_INFERENCE_AUTH_MODE_LEGACY = "legacy"
-NOUS_INFERENCE_AUTH_MODES = frozenset({
-    NOUS_INFERENCE_AUTH_MODE_AUTO,
-    NOUS_INFERENCE_AUTH_MODE_FRESH,
-    NOUS_INFERENCE_AUTH_MODE_LEGACY,
-})
+NOUS_INFERENCE_AUTH_MODES = frozenset(
+    {
+        NOUS_INFERENCE_AUTH_MODE_AUTO,
+        NOUS_INFERENCE_AUTH_MODE_FRESH,
+        NOUS_INFERENCE_AUTH_MODE_LEGACY,
+    }
+)
 NOUS_AUTH_PATH_INVOKE_JWT = "invoke_jwt"
 NOUS_AUTH_PATH_LEGACY_SESSION_KEY_CACHE = "legacy_session_key_cache"
 NOUS_AUTH_PATH_LEGACY_SESSION_KEY_MINT = "legacy_session_key_mint"
 DEFAULT_AGENT_KEY_MIN_TTL_SECONDS = 30 * 60  # 30 minutes
-ACCESS_TOKEN_REFRESH_SKEW_SECONDS = 120       # refresh 2 min before expiry
+ACCESS_TOKEN_REFRESH_SKEW_SECONDS = 120  # refresh 2 min before expiry
 NOUS_INVOKE_JWT_MIN_TTL_SECONDS = ACCESS_TOKEN_REFRESH_SKEW_SECONDS
-DEVICE_AUTH_POLL_INTERVAL_CAP_SECONDS = 1     # poll at most every 1s
+DEVICE_AUTH_POLL_INTERVAL_CAP_SECONDS = 1  # poll at most every 1s
 DEFAULT_CODEX_BASE_URL = "https://chatgpt.com/backend-api/codex"
 DEFAULT_XAI_OAUTH_BASE_URL = "https://api.x.ai/v1"
 MINIMAX_OAUTH_CLIENT_ID = "78257093-7e40-4613-99e0-527b14b39113"
@@ -126,24 +128,30 @@ QWEN_ACCESS_TOKEN_REFRESH_SKEW_SECONDS = 120
 DEFAULT_SPOTIFY_ACCOUNTS_BASE_URL = "https://accounts.spotify.com"
 DEFAULT_SPOTIFY_API_BASE_URL = "https://api.spotify.com/v1"
 DEFAULT_SPOTIFY_REDIRECT_URI = "http://127.0.0.1:43827/spotify/callback"
-SPOTIFY_DOCS_URL = "https://hermes-agent.nousresearch.com/docs/user-guide/features/spotify"
+SPOTIFY_DOCS_URL = (
+    "https://hermes-agent.nousresearch.com/docs/user-guide/features/spotify"
+)
 SPOTIFY_DASHBOARD_URL = "https://developer.spotify.com/dashboard"
 SPOTIFY_ACCESS_TOKEN_REFRESH_SKEW_SECONDS = 120
 
 XAI_OAUTH_DOCS_URL = "https://hermes-agent.nousresearch.com/docs/guides/xai-grok-oauth"
-OAUTH_OVER_SSH_DOCS_URL = "https://hermes-agent.nousresearch.com/docs/guides/oauth-over-ssh"
-DEFAULT_SPOTIFY_SCOPE = " ".join((
-    "user-modify-playback-state",
-    "user-read-playback-state",
-    "user-read-currently-playing",
-    "user-read-recently-played",
-    "playlist-read-private",
-    "playlist-read-collaborative",
-    "playlist-modify-public",
-    "playlist-modify-private",
-    "user-library-read",
-    "user-library-modify",
-))
+OAUTH_OVER_SSH_DOCS_URL = (
+    "https://hermes-agent.nousresearch.com/docs/guides/oauth-over-ssh"
+)
+DEFAULT_SPOTIFY_SCOPE = " ".join(
+    (
+        "user-modify-playback-state",
+        "user-read-playback-state",
+        "user-read-currently-playing",
+        "user-read-recently-played",
+        "playlist-read-private",
+        "playlist-read-collaborative",
+        "playlist-modify-public",
+        "playlist-modify-private",
+        "user-library-read",
+        "user-library-modify",
+    )
+)
 SERVICE_PROVIDER_NAMES: Dict[str, str] = {
     "spotify": "Spotify",
 }
@@ -163,12 +171,16 @@ LMSTUDIO_NOAUTH_PLACEHOLDER = "dummy-lm-api-key"
 # Provider Registry
 # =============================================================================
 
+
 @dataclass
 class ProviderConfig:
     """Describes a known inference provider."""
+
     id: str
     name: str
-    auth_type: str  # "oauth_device_code", "oauth_external", "oauth_minimax", or "api_key"
+    auth_type: (
+        str  # "oauth_device_code", "oauth_external", "oauth_minimax", or "api_key"
+    )
     portal_base_url: str = ""
     inference_base_url: str = ""
     client_id: str = ""
@@ -311,15 +323,22 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         inference_base_url=MINIMAX_OAUTH_GLOBAL_INFERENCE,
         client_id=MINIMAX_OAUTH_CLIENT_ID,
         scope=MINIMAX_OAUTH_SCOPE,
-        extra={"region": "global", "cn_portal_base_url": MINIMAX_OAUTH_CN_BASE,
-               "cn_inference_base_url": MINIMAX_OAUTH_CN_INFERENCE},
+        extra={
+            "region": "global",
+            "cn_portal_base_url": MINIMAX_OAUTH_CN_BASE,
+            "cn_inference_base_url": MINIMAX_OAUTH_CN_INFERENCE,
+        },
     ),
     "anthropic": ProviderConfig(
         id="anthropic",
         name="Anthropic",
         auth_type="api_key",
         inference_base_url="https://api.anthropic.com",
-        api_key_env_vars=("ANTHROPIC_API_KEY", "ANTHROPIC_TOKEN", "CLAUDE_CODE_OAUTH_TOKEN"),
+        api_key_env_vars=(
+            "ANTHROPIC_API_KEY",
+            "ANTHROPIC_TOKEN",
+            "CLAUDE_CODE_OAUTH_TOKEN",
+        ),
         base_url_env_var="ANTHROPIC_BASE_URL",
     ),
     "alibaba": ProviderConfig(
@@ -454,6 +473,14 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         api_key_env_vars=("AZURE_FOUNDRY_API_KEY",),
         base_url_env_var="AZURE_FOUNDRY_BASE_URL",
     ),
+    "litellm": ProviderConfig(
+        id="litellm",
+        name="LiteLLM",
+        auth_type="api_key",
+        inference_base_url="",  # User-provided endpoint
+        api_key_env_vars=("LITELLM_API_KEY",),
+        base_url_env_var="LITELLM_BASE_URL",
+    ),
 }
 
 # Auto-extend PROVIDER_REGISTRY with any api-key provider registered in
@@ -461,6 +488,7 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
 # plugins/model-providers/<name>/ plugin — no edits to this file required.
 try:
     from providers import list_providers as _list_providers_for_registry
+
     for _pp in _list_providers_for_registry():
         if _pp.name in PROVIDER_REGISTRY:
             continue
@@ -471,10 +499,24 @@ try:
         # openrouter/custom are aggregator/user-supplied and handled outside
         # the registry — adding them here breaks runtime_provider resolution
         # that relies on `openrouter not in PROVIDER_REGISTRY`).
-        if _pp.name in {"copilot", "kimi-coding", "kimi-coding-cn", "zai", "openrouter", "custom"}:
+        if _pp.name in {
+            "copilot",
+            "kimi-coding",
+            "kimi-coding-cn",
+            "zai",
+            "openrouter",
+            "custom",
+        }:
             continue
-        _api_key_vars = tuple(v for v in _pp.env_vars if not v.endswith("_BASE_URL") and not v.endswith("_URL"))
-        _base_url_var = next((v for v in _pp.env_vars if v.endswith("_BASE_URL") or v.endswith("_URL")), None)
+        _api_key_vars = tuple(
+            v
+            for v in _pp.env_vars
+            if not v.endswith("_BASE_URL") and not v.endswith("_URL")
+        )
+        _base_url_var = next(
+            (v for v in _pp.env_vars if v.endswith("_BASE_URL") or v.endswith("_URL")),
+            None,
+        )
         PROVIDER_REGISTRY[_pp.name] = ProviderConfig(
             id=_pp.name,
             name=_pp.display_name or _pp.name,
@@ -494,6 +536,7 @@ except Exception:
 # =============================================================================
 # Anthropic Key Helper
 # =============================================================================
+
 
 def get_anthropic_key() -> str:
     """Return the first usable Anthropic credential, or ``""``.
@@ -546,7 +589,6 @@ def _resolve_kimi_base_url(api_key: str, default_url: str, env_override: str) ->
     return default_url
 
 
-
 _PLACEHOLDER_SECRET_VALUES = {
     "*",
     "**",
@@ -581,7 +623,11 @@ def _resolve_api_key_provider_secret(
     if provider_id == "copilot":
         # Use the dedicated copilot auth module for proper token validation
         try:
-            from hermes_cli.copilot_auth import resolve_copilot_token, get_copilot_api_token
+            from hermes_cli.copilot_auth import (
+                resolve_copilot_token,
+                get_copilot_api_token,
+            )
+
             token, source = resolve_copilot_token()
             if token:
                 return get_copilot_api_token(token), source
@@ -592,6 +638,7 @@ def _resolve_api_key_provider_secret(
         return "", ""
 
     from hermes_cli.config import get_env_value
+
     for env_var in pconfig.api_key_env_vars:
         # Check both os.environ and ~/.hermes/.env file
         val = (get_env_value(env_var) or "").strip()
@@ -601,11 +648,14 @@ def _resolve_api_key_provider_secret(
     # Fallback: try credential pool (e.g. zai key stored via auth.json)
     try:
         from agent.credential_pool import load_pool
+
         pool = load_pool(provider_id)
         if pool and pool.has_credentials():
             entry = pool.peek()
             if entry:
-                key = getattr(entry, "access_token", "") or getattr(entry, "runtime_api_key", "")
+                key = getattr(entry, "access_token", "") or getattr(
+                    entry, "runtime_api_key", ""
+                )
                 key = str(key).strip()
                 if has_usable_secret(key):
                     return key, f"credential_pool:{provider_id}"
@@ -628,10 +678,20 @@ def _resolve_api_key_provider_secret(
 
 ZAI_ENDPOINTS = [
     # (id, base_url, probe_models, label)
-    ("global",        "https://api.z.ai/api/paas/v4",        ["glm-5"],   "Global"),
-    ("cn",            "https://open.bigmodel.cn/api/paas/v4", ["glm-5"],   "China"),
-    ("coding-global", "https://api.z.ai/api/coding/paas/v4",  ["glm-5.1", "glm-5v-turbo", "glm-4.7"], "Global (Coding Plan)"),
-    ("coding-cn",     "https://open.bigmodel.cn/api/coding/paas/v4", ["glm-5.1", "glm-5v-turbo", "glm-4.7"], "China (Coding Plan)"),
+    ("global", "https://api.z.ai/api/paas/v4", ["glm-5"], "Global"),
+    ("cn", "https://open.bigmodel.cn/api/paas/v4", ["glm-5"], "China"),
+    (
+        "coding-global",
+        "https://api.z.ai/api/coding/paas/v4",
+        ["glm-5.1", "glm-5v-turbo", "glm-4.7"],
+        "Global (Coding Plan)",
+    ),
+    (
+        "coding-cn",
+        "https://open.bigmodel.cn/api/coding/paas/v4",
+        ["glm-5.1", "glm-5v-turbo", "glm-4.7"],
+        "China (Coding Plan)",
+    ),
 ]
 
 
@@ -660,16 +720,28 @@ def detect_zai_endpoint(api_key: str, timeout: float = 8.0) -> Optional[Dict[str
                     timeout=timeout,
                 )
                 if resp.status_code == 200:
-                    logger.debug("Z.AI endpoint probe: %s (%s) model=%s OK", ep_id, base_url, model)
+                    logger.debug(
+                        "Z.AI endpoint probe: %s (%s) model=%s OK",
+                        ep_id,
+                        base_url,
+                        model,
+                    )
                     return {
                         "id": ep_id,
                         "base_url": base_url,
                         "model": model,
                         "label": label,
                     }
-                logger.debug("Z.AI endpoint probe: %s model=%s returned %s", ep_id, model, resp.status_code)
+                logger.debug(
+                    "Z.AI endpoint probe: %s model=%s returned %s",
+                    ep_id,
+                    model,
+                    resp.status_code,
+                )
             except Exception as exc:
-                logger.debug("Z.AI endpoint probe: %s model=%s failed: %s", ep_id, model, exc)
+                logger.debug(
+                    "Z.AI endpoint probe: %s model=%s failed: %s", ep_id, model, exc
+                )
     return None
 
 
@@ -715,7 +787,11 @@ def _resolve_zai_base_url(api_key: str, default_url: str, env_override: str) -> 
             "key_hash": key_hash,
         }
         _save_provider_state(auth_store, "zai", state)
-        logger.info("Z.AI: auto-detected endpoint %s (%s)", detected["label"], detected["base_url"])
+        logger.info(
+            "Z.AI: auto-detected endpoint %s (%s)",
+            detected["label"],
+            detected["base_url"],
+        )
         return detected["base_url"]
 
     logger.debug("Z.AI: probe failed, falling back to default %s", default_url)
@@ -725,6 +801,7 @@ def _resolve_zai_base_url(api_key: str, default_url: str, env_override: str) -> 
 # =============================================================================
 # Error Types
 # =============================================================================
+
 
 class AuthError(RuntimeError):
     """Structured auth error with UX mapping hints."""
@@ -784,19 +861,24 @@ def _oauth_trace_enabled() -> bool:
     return raw in {"1", "true", "yes", "on"}
 
 
-def _oauth_trace(event: str, *, sequence_id: Optional[str] = None, **fields: Any) -> None:
+def _oauth_trace(
+    event: str, *, sequence_id: Optional[str] = None, **fields: Any
+) -> None:
     if not _oauth_trace_enabled():
         return
     payload: Dict[str, Any] = {"event": event}
     if sequence_id:
         payload["sequence_id"] = sequence_id
     payload.update(fields)
-    logger.info("oauth_trace %s", json.dumps(payload, sort_keys=True, ensure_ascii=False))
+    logger.info(
+        "oauth_trace %s", json.dumps(payload, sort_keys=True, ensure_ascii=False)
+    )
 
 
 # =============================================================================
 # Auth Store — persistence layer for ~/.hermes/auth.json
 # =============================================================================
+
 
 def _auth_file_path() -> Path:
     path = get_hermes_home() / "auth.json"
@@ -832,6 +914,7 @@ def _global_auth_file_path() -> Optional[Path]:
     """
     try:
         from hermes_constants import get_default_hermes_root
+
         global_root = get_default_hermes_root()
     except Exception:
         return None
@@ -996,13 +1079,16 @@ def _load_auth_store(auth_file: Optional[Path] = None) -> Dict[str, Any]:
         corrupt_path = auth_file.with_suffix(".json.corrupt")
         try:
             import shutil
+
             shutil.copy2(auth_file, corrupt_path)
         except Exception:
             pass
         logger.warning(
             "auth: failed to parse %s (%s) — starting with empty store. "
             "Corrupt file preserved at %s",
-            auth_file, exc, corrupt_path,
+            auth_file,
+            exc,
+            corrupt_path,
         )
         return {"version": AUTH_STORE_VERSION, "providers": {}}
 
@@ -1019,8 +1105,11 @@ def _load_auth_store(auth_file: Optional[Path] = None) -> Dict[str, Any]:
         providers = {}
         if "nous_portal" in systems:
             providers["nous"] = systems["nous_portal"]
-        return {"version": AUTH_STORE_VERSION, "providers": providers,
-                "active_provider": "nous" if providers else None}
+        return {
+            "version": AUTH_STORE_VERSION,
+            "providers": providers,
+            "active_provider": "nous" if providers else None,
+        }
 
     return {"version": AUTH_STORE_VERSION, "providers": {}}
 
@@ -1035,7 +1124,9 @@ def _save_auth_store(auth_store: Dict[str, Any]) -> Path:
     auth_store["version"] = AUTH_STORE_VERSION
     auth_store["updated_at"] = datetime.now(timezone.utc).isoformat()
     payload = json.dumps(auth_store, indent=2) + "\n"
-    tmp_path = auth_file.with_name(f"{auth_file.name}.tmp.{os.getpid()}.{uuid.uuid4().hex}")
+    tmp_path = auth_file.with_name(
+        f"{auth_file.name}.tmp.{os.getpid()}.{uuid.uuid4().hex}"
+    )
     try:
         # Create with 0o600 atomically via os.open(O_EXCL) + fdopen to close
         # the TOCTOU window where default umask (often 0o644) briefly exposed
@@ -1074,7 +1165,9 @@ def _save_auth_store(auth_store: Dict[str, Any]) -> Path:
     return auth_file
 
 
-def _load_provider_state(auth_store: Dict[str, Any], provider_id: str) -> Optional[Dict[str, Any]]:
+def _load_provider_state(
+    auth_store: Dict[str, Any], provider_id: str
+) -> Optional[Dict[str, Any]]:
     providers = auth_store.get("providers")
     if not isinstance(providers, dict):
         return None
@@ -1082,7 +1175,9 @@ def _load_provider_state(auth_store: Dict[str, Any], provider_id: str) -> Option
     return dict(state) if isinstance(state, dict) else None
 
 
-def _save_provider_state(auth_store: Dict[str, Any], provider_id: str, state: Dict[str, Any]) -> None:
+def _save_provider_state(
+    auth_store: Dict[str, Any], provider_id: str, state: Dict[str, Any]
+) -> None:
     providers = auth_store.setdefault("providers", {})
     if not isinstance(providers, dict):
         auth_store["providers"] = {}
@@ -1276,6 +1371,7 @@ def is_provider_explicitly_configured(provider_id: str) -> bool:
     # 2. Check config.yaml model.provider
     try:
         from hermes_cli.config import load_config
+
         cfg = load_config()
         model_cfg = cfg.get("model")
         if isinstance(model_cfg, dict):
@@ -1365,6 +1461,7 @@ def _get_config_hint_for_unknown_provider(provider_name: str) -> str:
     """
     try:
         from hermes_cli.config import validate_config_structure
+
         issues = validate_config_structure()
         if not issues:
             return ""
@@ -1402,45 +1499,93 @@ def resolve_provider(
 
     # Normalize provider aliases
     _PROVIDER_ALIASES = {
-        "glm": "zai", "z-ai": "zai", "z.ai": "zai", "zhipu": "zai",
-        "google": "gemini", "google-gemini": "gemini", "google-ai-studio": "gemini",
-        "x-ai": "xai", "x.ai": "xai", "grok": "xai",
-        "xai-oauth": "xai-oauth", "x-ai-oauth": "xai-oauth",
-        "grok-oauth": "xai-oauth", "xai-grok-oauth": "xai-oauth",
-        "kimi": "kimi-coding", "kimi-for-coding": "kimi-coding", "moonshot": "kimi-coding",
-        "kimi-cn": "kimi-coding-cn", "moonshot-cn": "kimi-coding-cn",
-        "step": "stepfun", "stepfun-coding-plan": "stepfun",
-        "arcee-ai": "arcee", "arceeai": "arcee",
-        "gmi-cloud": "gmi", "gmicloud": "gmi",
-        "minimax-china": "minimax-cn", "minimax_cn": "minimax-cn",
-        "minimax-portal": "minimax-oauth", "minimax-global": "minimax-oauth", "minimax_oauth": "minimax-oauth",
-        "alibaba_coding": "alibaba-coding-plan", "alibaba-coding": "alibaba-coding-plan",
+        "glm": "zai",
+        "z-ai": "zai",
+        "z.ai": "zai",
+        "zhipu": "zai",
+        "google": "gemini",
+        "google-gemini": "gemini",
+        "google-ai-studio": "gemini",
+        "x-ai": "xai",
+        "x.ai": "xai",
+        "grok": "xai",
+        "xai-oauth": "xai-oauth",
+        "x-ai-oauth": "xai-oauth",
+        "grok-oauth": "xai-oauth",
+        "xai-grok-oauth": "xai-oauth",
+        "kimi": "kimi-coding",
+        "kimi-for-coding": "kimi-coding",
+        "moonshot": "kimi-coding",
+        "kimi-cn": "kimi-coding-cn",
+        "moonshot-cn": "kimi-coding-cn",
+        "step": "stepfun",
+        "stepfun-coding-plan": "stepfun",
+        "arcee-ai": "arcee",
+        "arceeai": "arcee",
+        "gmi-cloud": "gmi",
+        "gmicloud": "gmi",
+        "minimax-china": "minimax-cn",
+        "minimax_cn": "minimax-cn",
+        "minimax-portal": "minimax-oauth",
+        "minimax-global": "minimax-oauth",
+        "minimax_oauth": "minimax-oauth",
+        "alibaba_coding": "alibaba-coding-plan",
+        "alibaba-coding": "alibaba-coding-plan",
         "alibaba_coding_plan": "alibaba-coding-plan",
-        "claude": "anthropic", "claude-code": "anthropic",
-        "github": "copilot", "github-copilot": "copilot",
-        "github-models": "copilot", "github-model": "copilot",
-        "github-copilot-acp": "copilot-acp", "copilot-acp-agent": "copilot-acp",
-        "aigateway": "ai-gateway", "vercel": "ai-gateway", "vercel-ai-gateway": "ai-gateway",
-        "opencode": "opencode-zen", "zen": "opencode-zen",
-        "qwen-portal": "qwen-oauth", "qwen-cli": "qwen-oauth", "qwen-oauth": "qwen-oauth", "google-gemini-cli": "google-gemini-cli", "gemini-cli": "google-gemini-cli", "gemini-oauth": "google-gemini-cli",
-        "hf": "huggingface", "hugging-face": "huggingface", "huggingface-hub": "huggingface",
-        "mimo": "xiaomi", "xiaomi-mimo": "xiaomi",
-        "tencent": "tencent-tokenhub", "tokenhub": "tencent-tokenhub",
-        "tencent-cloud": "tencent-tokenhub", "tencentmaas": "tencent-tokenhub",
-        "aws": "bedrock", "aws-bedrock": "bedrock", "amazon-bedrock": "bedrock", "amazon": "bedrock",
-        "go": "opencode-go", "opencode-go-sub": "opencode-go",
-        "kilo": "kilocode", "kilo-code": "kilocode", "kilo-gateway": "kilocode",
-        "lmstudio": "lmstudio", "lm-studio": "lmstudio", "lm_studio": "lmstudio",
+        "claude": "anthropic",
+        "claude-code": "anthropic",
+        "github": "copilot",
+        "github-copilot": "copilot",
+        "github-models": "copilot",
+        "github-model": "copilot",
+        "github-copilot-acp": "copilot-acp",
+        "copilot-acp-agent": "copilot-acp",
+        "aigateway": "ai-gateway",
+        "vercel": "ai-gateway",
+        "vercel-ai-gateway": "ai-gateway",
+        "opencode": "opencode-zen",
+        "zen": "opencode-zen",
+        "qwen-portal": "qwen-oauth",
+        "qwen-cli": "qwen-oauth",
+        "qwen-oauth": "qwen-oauth",
+        "google-gemini-cli": "google-gemini-cli",
+        "gemini-cli": "google-gemini-cli",
+        "gemini-oauth": "google-gemini-cli",
+        "hf": "huggingface",
+        "hugging-face": "huggingface",
+        "huggingface-hub": "huggingface",
+        "mimo": "xiaomi",
+        "xiaomi-mimo": "xiaomi",
+        "tencent": "tencent-tokenhub",
+        "tokenhub": "tencent-tokenhub",
+        "tencent-cloud": "tencent-tokenhub",
+        "tencentmaas": "tencent-tokenhub",
+        "aws": "bedrock",
+        "aws-bedrock": "bedrock",
+        "amazon-bedrock": "bedrock",
+        "amazon": "bedrock",
+        "go": "opencode-go",
+        "opencode-go-sub": "opencode-go",
+        "kilo": "kilocode",
+        "kilo-code": "kilocode",
+        "kilo-gateway": "kilocode",
+        "lmstudio": "lmstudio",
+        "lm-studio": "lmstudio",
+        "lm_studio": "lmstudio",
         # Local server aliases — route through the generic custom provider
-        "ollama": "custom", "ollama_cloud": "ollama-cloud",
-        "vllm": "custom", "llamacpp": "custom",
-        "llama.cpp": "custom", "llama-cpp": "custom",
+        "ollama": "custom",
+        "ollama_cloud": "ollama-cloud",
+        "vllm": "custom",
+        "llamacpp": "custom",
+        "llama.cpp": "custom",
+        "llama-cpp": "custom",
     }
     # Extend with aliases declared in plugins/model-providers/<name>/ that aren't already mapped.
     # This keeps providers/ as the single source for new aliases while the
     # hardcoded dict above remains authoritative for existing ones.
     try:
         from providers import list_providers as _lp
+
         for _pp in _lp():
             for _alias in _pp.aliases:
                 if _alias not in _PROVIDER_ALIASES:
@@ -1480,7 +1625,9 @@ def resolve_provider(
     except Exception as e:
         logger.debug("Could not detect active auth provider: %s", e)
 
-    if has_usable_secret(os.getenv("OPENAI_API_KEY")) or has_usable_secret(os.getenv("OPENROUTER_API_KEY")):
+    if has_usable_secret(os.getenv("OPENAI_API_KEY")) or has_usable_secret(
+        os.getenv("OPENROUTER_API_KEY")
+    ):
         return "openrouter"
 
     # Auto-detect API-key providers by checking their env vars
@@ -1503,6 +1650,7 @@ def resolve_provider(
     # This runs after API-key providers so explicit keys always win.
     try:
         from agent.bedrock_adapter import has_aws_credentials
+
         if has_aws_credentials():
             return "bedrock"
     except ImportError:
@@ -1519,6 +1667,7 @@ def resolve_provider(
 # =============================================================================
 # Timestamp / TTL helpers
 # =============================================================================
+
 
 def _parse_iso_timestamp(value: Any) -> Optional[float]:
     if not isinstance(value, str) or not value:
@@ -1690,12 +1839,9 @@ def _choose_nous_inference_auth_path(
         )
     ):
         return NOUS_AUTH_PATH_INVOKE_JWT, None
-    if (
-        inference_auth_mode == NOUS_INFERENCE_AUTH_MODE_AUTO
-        and _agent_key_is_usable(
-            state,
-            max(60, int(min_key_ttl_seconds)),
-        )
+    if inference_auth_mode == NOUS_INFERENCE_AUTH_MODE_AUTO and _agent_key_is_usable(
+        state,
+        max(60, int(min_key_ttl_seconds)),
     ):
         return NOUS_AUTH_PATH_LEGACY_SESSION_KEY_CACHE, None
     return (
@@ -1804,13 +1950,15 @@ def _select_nous_invoke_jwt(
     )
 
 
-_NOUS_EFFECTIVE_STATE_IGNORED_KEYS = frozenset({
-    # These are derived from expires_at/JWT exp and naturally tick down between
-    # reads. Persisting only these changes makes auth.json noisy and defeats
-    # the mtime-keyed auth-status cache.
-    "expires_in",
-    "agent_key_expires_in",
-})
+_NOUS_EFFECTIVE_STATE_IGNORED_KEYS = frozenset(
+    {
+        # These are derived from expires_at/JWT exp and naturally tick down between
+        # reads. Persisting only these changes makes auth.json noisy and defeats
+        # the mtime-keyed auth-status cache.
+        "expires_in",
+        "agent_key_expires_in",
+    }
+)
 
 
 def _nous_effective_provider_state(state: Dict[str, Any]) -> Dict[str, Any]:
@@ -1865,7 +2013,9 @@ def _save_qwen_cli_tokens(tokens: Dict[str, Any]) -> Path:
     secure_parent_dir(auth_path)
     # Per-process random temp suffix avoids collisions between concurrent
     # writers and stale leftovers from a crashed prior write.
-    tmp_path = auth_path.with_name(f"{auth_path.name}.tmp.{os.getpid()}.{uuid.uuid4().hex}")
+    tmp_path = auth_path.with_name(
+        f"{auth_path.name}.tmp.{os.getpid()}.{uuid.uuid4().hex}"
+    )
     # Create with 0o600 atomically via os.open(O_EXCL) — closes the TOCTOU
     # window where write_text() + post-write chmod briefly exposed tokens
     # at process umask (typically 0o644). See #19673, #21148.
@@ -1889,7 +2039,9 @@ def _save_qwen_cli_tokens(tokens: Dict[str, Any]) -> Path:
     return auth_path
 
 
-def _qwen_access_token_is_expiring(expiry_date_ms: Any, skew_seconds: int = QWEN_ACCESS_TOKEN_REFRESH_SKEW_SECONDS) -> bool:
+def _qwen_access_token_is_expiring(
+    expiry_date_ms: Any, skew_seconds: int = QWEN_ACCESS_TOKEN_REFRESH_SKEW_SECONDS
+) -> bool:
     try:
         expiry_ms = int(expiry_date_ms)
     except Exception:
@@ -1897,7 +2049,9 @@ def _qwen_access_token_is_expiring(expiry_date_ms: Any, skew_seconds: int = QWEN
     return (time.time() + max(0, int(skew_seconds))) * 1000 >= expiry_ms
 
 
-def _refresh_qwen_cli_tokens(tokens: Dict[str, Any], timeout_seconds: float = 20.0) -> Dict[str, Any]:
+def _refresh_qwen_cli_tokens(
+    tokens: Dict[str, Any], timeout_seconds: float = 20.0
+) -> Dict[str, Any]:
     refresh_token = str(tokens.get("refresh_token", "") or "").strip()
     if not refresh_token:
         raise AuthError(
@@ -1945,7 +2099,10 @@ def _refresh_qwen_cli_tokens(tokens: Dict[str, Any], timeout_seconds: float = 20
             code="qwen_refresh_invalid_json",
         ) from exc
 
-    if not isinstance(payload, dict) or not str(payload.get("access_token", "") or "").strip():
+    if (
+        not isinstance(payload, dict)
+        or not str(payload.get("access_token", "") or "").strip()
+    ):
         raise AuthError(
             "Qwen OAuth refresh response missing access_token.",
             provider="qwen-oauth",
@@ -1960,9 +2117,17 @@ def _refresh_qwen_cli_tokens(tokens: Dict[str, Any], timeout_seconds: float = 20
 
     refreshed = {
         "access_token": str(payload.get("access_token", "") or "").strip(),
-        "refresh_token": str(payload.get("refresh_token", refresh_token) or refresh_token).strip(),
-        "token_type": str(payload.get("token_type", tokens.get("token_type", "Bearer")) or "Bearer").strip() or "Bearer",
-        "resource_url": str(payload.get("resource_url", tokens.get("resource_url", "portal.qwen.ai")) or "portal.qwen.ai").strip(),
+        "refresh_token": str(
+            payload.get("refresh_token", refresh_token) or refresh_token
+        ).strip(),
+        "token_type": str(
+            payload.get("token_type", tokens.get("token_type", "Bearer")) or "Bearer"
+        ).strip()
+        or "Bearer",
+        "resource_url": str(
+            payload.get("resource_url", tokens.get("resource_url", "portal.qwen.ai"))
+            or "portal.qwen.ai"
+        ).strip(),
         "expiry_date": int(time.time() * 1000) + max(1, expires_in_seconds) * 1000,
     }
     _save_qwen_cli_tokens(refreshed)
@@ -1979,7 +2144,9 @@ def resolve_qwen_runtime_credentials(
     access_token = str(tokens.get("access_token", "") or "").strip()
     should_refresh = bool(force_refresh)
     if not should_refresh and refresh_if_expiring:
-        should_refresh = _qwen_access_token_is_expiring(tokens.get("expiry_date"), refresh_skew_seconds)
+        should_refresh = _qwen_access_token_is_expiring(
+            tokens.get("expiry_date"), refresh_skew_seconds
+        )
     if should_refresh:
         tokens = _refresh_qwen_cli_tokens(tokens)
         access_token = str(tokens.get("access_token", "") or "").strip()
@@ -1990,7 +2157,10 @@ def resolve_qwen_runtime_credentials(
             code="qwen_access_token_missing",
         )
 
-    base_url = os.getenv("HERMES_QWEN_BASE_URL", "").strip().rstrip("/") or DEFAULT_QWEN_BASE_URL
+    base_url = (
+        os.getenv("HERMES_QWEN_BASE_URL", "").strip().rstrip("/")
+        or DEFAULT_QWEN_BASE_URL
+    )
     return {
         "provider": "qwen-oauth",
         "base_url": base_url,
@@ -2028,6 +2198,7 @@ def get_qwen_auth_status() -> Dict[str, Any]:
 # uses to construct a GeminiCloudCodeClient instead of the default OpenAI SDK.
 # Actual HTTP traffic goes to https://cloudcode-pa.googleapis.com/v1internal:*.
 # =============================================================================
+
 
 def resolve_gemini_oauth_runtime_credentials(
     *,
@@ -2094,6 +2265,8 @@ def get_gemini_oauth_auth_status() -> Dict[str, Any]:
         "email": creds.email,
         "project_id": creds.project_id,
     }
+
+
 # Spotify auth — PKCE tokens stored in ~/.hermes/auth.json
 # =============================================================================
 
@@ -2216,15 +2389,17 @@ def _spotify_build_authorize_url(
     code_challenge: str,
     accounts_base_url: str,
 ) -> str:
-    query = urlencode({
-        "client_id": client_id,
-        "response_type": "code",
-        "redirect_uri": redirect_uri,
-        "scope": scope,
-        "state": state,
-        "code_challenge_method": "S256",
-        "code_challenge": code_challenge,
-    })
+    query = urlencode(
+        {
+            "client_id": client_id,
+            "response_type": "code",
+            "redirect_uri": redirect_uri,
+            "scope": scope,
+            "state": state,
+            "code_challenge_method": "S256",
+            "code_challenge": code_challenge,
+        }
+    )
     return f"{accounts_base_url}/authorize?{query}"
 
 
@@ -2252,7 +2427,9 @@ def _spotify_validate_redirect_uri(redirect_uri: str) -> tuple[str, int, str]:
     return host, parsed.port, parsed.path or "/"
 
 
-def _make_spotify_callback_handler(expected_path: str) -> tuple[type[BaseHTTPRequestHandler], dict[str, Any]]:
+def _make_spotify_callback_handler(
+    expected_path: str,
+) -> tuple[type[BaseHTTPRequestHandler], dict[str, Any]]:
     result: dict[str, Any] = {
         "code": None,
         "state": None,
@@ -2310,7 +2487,9 @@ def _spotify_wait_for_callback(
             code="spotify_callback_bind_failed",
         ) from exc
 
-    thread = threading.Thread(target=server.serve_forever, kwargs={"poll_interval": 0.1}, daemon=True)
+    thread = threading.Thread(
+        target=server.serve_forever, kwargs={"poll_interval": 0.1}, daemon=True
+    )
     thread.start()
     deadline = time.monotonic() + max(5.0, timeout_seconds)
     try:
@@ -2364,7 +2543,9 @@ def _xai_callback_cors_origin(origin: Optional[str]) -> str:
     return origin if origin in allowed else ""
 
 
-def _make_xai_callback_handler(expected_path: str) -> tuple[type[BaseHTTPRequestHandler], dict[str, Any]]:
+def _make_xai_callback_handler(
+    expected_path: str,
+) -> tuple[type[BaseHTTPRequestHandler], dict[str, Any]]:
     result: dict[str, Any] = {
         "code": None,
         "state": None,
@@ -2530,25 +2711,28 @@ def _spotify_token_payload_to_state(
     expires_in = _coerce_ttl_seconds(token_payload.get("expires_in", 0))
     expires_at = datetime.fromtimestamp(now.timestamp() + expires_in, tz=timezone.utc)
     state = dict(previous_state or {})
-    state.update({
-        "client_id": client_id,
-        "redirect_uri": redirect_uri,
-        "accounts_base_url": accounts_base_url,
-        "api_base_url": api_base_url,
-        "scope": requested_scope,
-        "granted_scope": str(token_payload.get("scope") or requested_scope).strip(),
-        "token_type": str(token_payload.get("token_type", "Bearer") or "Bearer").strip() or "Bearer",
-        "access_token": str(token_payload.get("access_token", "") or "").strip(),
-        "refresh_token": str(
-            token_payload.get("refresh_token")
-            or state.get("refresh_token")
-            or ""
-        ).strip(),
-        "obtained_at": now.isoformat(),
-        "expires_at": expires_at.isoformat(),
-        "expires_in": expires_in,
-        "auth_type": "oauth_pkce",
-    })
+    state.update(
+        {
+            "client_id": client_id,
+            "redirect_uri": redirect_uri,
+            "accounts_base_url": accounts_base_url,
+            "api_base_url": api_base_url,
+            "scope": requested_scope,
+            "granted_scope": str(token_payload.get("scope") or requested_scope).strip(),
+            "token_type": str(
+                token_payload.get("token_type", "Bearer") or "Bearer"
+            ).strip()
+            or "Bearer",
+            "access_token": str(token_payload.get("access_token", "") or "").strip(),
+            "refresh_token": str(
+                token_payload.get("refresh_token") or state.get("refresh_token") or ""
+            ).strip(),
+            "obtained_at": now.isoformat(),
+            "expires_at": expires_at.isoformat(),
+            "expires_in": expires_in,
+            "auth_type": "oauth_pkce",
+        }
+    )
     return state
 
 
@@ -2590,7 +2774,10 @@ def _spotify_exchange_code_for_tokens(
             code="spotify_token_exchange_failed",
         )
     payload = response.json()
-    if not isinstance(payload, dict) or not str(payload.get("access_token", "") or "").strip():
+    if (
+        not isinstance(payload, dict)
+        or not str(payload.get("access_token", "") or "").strip()
+    ):
         raise AuthError(
             "Spotify token response did not include an access_token.",
             provider="spotify",
@@ -2644,7 +2831,10 @@ def _refresh_spotify_oauth_state(
         )
 
     payload = response.json()
-    if not isinstance(payload, dict) or not str(payload.get("access_token", "") or "").strip():
+    if (
+        not isinstance(payload, dict)
+        or not str(payload.get("access_token", "") or "").strip()
+    ):
         raise AuthError(
             "Spotify refresh response did not include an access_token.",
             provider="spotify",
@@ -2804,11 +2994,16 @@ def login_spotify_command(args) -> None:
         if getattr(exc, "code", "") != "spotify_client_id_missing":
             raise
         client_id = _spotify_interactive_setup(
-            redirect_uri_hint=getattr(args, "redirect_uri", None) or DEFAULT_SPOTIFY_REDIRECT_URI,
+            redirect_uri_hint=getattr(args, "redirect_uri", None)
+            or DEFAULT_SPOTIFY_REDIRECT_URI,
         )
 
-    redirect_uri = _spotify_redirect_uri(getattr(args, "redirect_uri", None), existing_state)
-    scope = _spotify_scope_string(getattr(args, "scope", None) or existing_state.get("scope"))
+    redirect_uri = _spotify_redirect_uri(
+        getattr(args, "redirect_uri", None), existing_state
+    )
+    scope = _spotify_scope_string(
+        getattr(args, "scope", None) or existing_state.get("scope")
+    )
     accounts_base_url = _spotify_accounts_base_url(existing_state)
     api_base_url = _spotify_api_base_url(existing_state)
     open_browser = not getattr(args, "no_browser", False)
@@ -2885,9 +3080,11 @@ def login_spotify_command(args) -> None:
     print("  Provider state saved under providers.spotify")
     print(f"  Docs: {SPOTIFY_DOCS_URL}")
 
+
 # =============================================================================
 # SSH / remote session detection
 # =============================================================================
+
 
 def _is_remote_session() -> bool:
     """Detect environments where loopback OAuth can't reach the local browser.
@@ -2907,12 +3104,12 @@ def _is_remote_session() -> bool:
     # (well-known, documented env vars set by the host platform) so
     # we don't falsely trip on a developer's local shell.
     for var in (
-        "CLOUD_SHELL",         # GCP Cloud Shell
-        "CODESPACES",          # GitHub Codespaces
-        "CODESPACE_NAME",      # GitHub Codespaces (alt)
-        "GITPOD_WORKSPACE_ID", # Gitpod
-        "REPL_ID",             # Replit
-        "STACKBLITZ",          # StackBlitz
+        "CLOUD_SHELL",  # GCP Cloud Shell
+        "CODESPACES",  # GitHub Codespaces
+        "CODESPACE_NAME",  # GitHub Codespaces (alt)
+        "GITPOD_WORKSPACE_ID",  # Gitpod
+        "REPL_ID",  # Replit
+        "STACKBLITZ",  # StackBlitz
     ):
         if os.getenv(var):
             return True
@@ -3001,6 +3198,7 @@ def _ssh_user_at_host() -> str:
     """
     try:
         import socket as _socket
+
         hostname = _socket.gethostname() or "<this-host>"
     except OSError:
         hostname = "<this-host>"
@@ -3062,9 +3260,10 @@ def _print_loopback_ssh_hint(redirect_uri: str, *, docs_url: str | None = None) 
 # where one app's refresh invalidates the other's session.
 # =============================================================================
 
+
 def _read_codex_tokens(*, _lock: bool = True) -> Dict[str, Any]:
     """Read Codex OAuth tokens from Hermes auth store (~/.hermes/auth.json).
-    
+
     Returns dict with 'tokens' (access_token, refresh_token) and 'last_refresh'.
     Raises AuthError if no Codex tokens are stored.
     """
@@ -3142,7 +3341,9 @@ def refresh_codex_oauth_pure(
         )
 
     timeout = httpx.Timeout(max(5.0, float(timeout_seconds)))
-    with httpx.Client(timeout=timeout, headers={"Accept": "application/json"}) as client:
+    with httpx.Client(
+        timeout=timeout, headers={"Accept": "application/json"}
+    ) as client:
         response = client.post(
             CODEX_OAUTH_TOKEN_URL,
             headers={"Content-Type": "application/x-www-form-urlencoded"},
@@ -3234,7 +3435,7 @@ def _refresh_codex_auth_tokens(
     timeout_seconds: float,
 ) -> Dict[str, str]:
     """Refresh Codex access token using the refresh token.
-    
+
     Saves the new tokens to Hermes auth store automatically.
     """
     refreshed = refresh_codex_oauth_pure(
@@ -3252,7 +3453,7 @@ def _refresh_codex_auth_tokens(
 
 def _import_codex_cli_tokens() -> Optional[Dict[str, str]]:
     """Try to read tokens from ~/.codex/auth.json (Codex CLI shared file).
-    
+
     Returns tokens dict if valid and not expired, None otherwise.
     Does NOT write to the shared file.
     """
@@ -3276,7 +3477,8 @@ def _import_codex_cli_tokens() -> Optional[Dict[str, str]]:
         # but no working credentials.
         if _codex_access_token_is_expiring(access_token, 0):
             logger.debug(
-                "Codex CLI tokens at %s are expired — skipping import.", auth_path,
+                "Codex CLI tokens at %s are expired — skipping import.",
+                auth_path,
             )
             return None
         return dict(tokens)
@@ -3294,21 +3496,31 @@ def resolve_codex_runtime_credentials(
     data = _read_codex_tokens()
     tokens = dict(data["tokens"])
     access_token = str(tokens.get("access_token", "") or "").strip()
-    refresh_timeout_seconds = float(os.getenv("HERMES_CODEX_REFRESH_TIMEOUT_SECONDS", "20"))
+    refresh_timeout_seconds = float(
+        os.getenv("HERMES_CODEX_REFRESH_TIMEOUT_SECONDS", "20")
+    )
 
     should_refresh = bool(force_refresh)
     if (not should_refresh) and refresh_if_expiring:
-        should_refresh = _codex_access_token_is_expiring(access_token, refresh_skew_seconds)
+        should_refresh = _codex_access_token_is_expiring(
+            access_token, refresh_skew_seconds
+        )
     if should_refresh:
         # Re-read under lock to avoid racing with other Hermes processes
-        with _auth_store_lock(timeout_seconds=max(float(AUTH_LOCK_TIMEOUT_SECONDS), refresh_timeout_seconds + 5.0)):
+        with _auth_store_lock(
+            timeout_seconds=max(
+                float(AUTH_LOCK_TIMEOUT_SECONDS), refresh_timeout_seconds + 5.0
+            )
+        ):
             data = _read_codex_tokens(_lock=False)
             tokens = dict(data["tokens"])
             access_token = str(tokens.get("access_token", "") or "").strip()
 
             should_refresh = bool(force_refresh)
             if (not should_refresh) and refresh_if_expiring:
-                should_refresh = _codex_access_token_is_expiring(access_token, refresh_skew_seconds)
+                should_refresh = _codex_access_token_is_expiring(
+                    access_token, refresh_skew_seconds
+                )
 
             if should_refresh:
                 tokens = _refresh_codex_auth_tokens(tokens, refresh_timeout_seconds)
@@ -3332,6 +3544,7 @@ def resolve_codex_runtime_credentials(
 # =============================================================================
 # xAI Grok OAuth — tokens stored in ~/.hermes/auth.json
 # =============================================================================
+
 
 def _read_xai_oauth_tokens(*, _lock: bool = True) -> Dict[str, Any]:
     if _lock:
@@ -3411,7 +3624,9 @@ def _xai_access_token_is_expiring(access_token: str, skew_seconds: int = 0) -> b
             return False
         payload_b64 = parts[1]
         payload_b64 += "=" * (-len(payload_b64) % 4)
-        payload = json.loads(base64.urlsafe_b64decode(payload_b64.encode("ascii")).decode("utf-8"))
+        payload = json.loads(
+            base64.urlsafe_b64decode(payload_b64.encode("ascii")).decode("utf-8")
+        )
         exp = payload.get("exp")
         if not isinstance(exp, (int, float)):
             return False
@@ -3488,21 +3703,24 @@ def _xai_validate_inference_base_url(value: str, *, fallback: str) -> str:
     except Exception:
         logger.warning(
             "Ignoring malformed xAI base_url override %r; using %s instead.",
-            candidate, fallback,
+            candidate,
+            fallback,
         )
         return fallback
     if parsed.scheme != "https":
         logger.warning(
             "Refusing non-HTTPS xAI base_url override %r (xai-oauth bearer would "
             "be sent in cleartext); falling back to %s.",
-            candidate, fallback,
+            candidate,
+            fallback,
         )
         return fallback
     host = (parsed.hostname or "").lower()
     if not host:
         logger.warning(
             "Ignoring xAI base_url override %r with no hostname; using %s instead.",
-            candidate, fallback,
+            candidate,
+            fallback,
         )
         return fallback
     if host != "x.ai" and not host.endswith(".x.ai"):
@@ -3511,7 +3729,9 @@ def _xai_validate_inference_base_url(value: str, *, fallback: str) -> str:
             "(expected x.ai or a *.x.ai subdomain). The xai-oauth bearer is only "
             "valid against xAI's inference API; sending it elsewhere would leak "
             "the credential. Falling back to %s.",
-            candidate, host, fallback,
+            candidate,
+            host,
+            fallback,
         )
         return fallback
     return candidate
@@ -3550,7 +3770,9 @@ def _xai_oauth_discovery(timeout_seconds: float = 15.0) -> Dict[str, str]:
             provider="xai-oauth",
             code="xai_discovery_incomplete",
         )
-    authorization_endpoint = str(payload.get("authorization_endpoint", "") or "").strip()
+    authorization_endpoint = str(
+        payload.get("authorization_endpoint", "") or ""
+    ).strip()
     token_endpoint = str(payload.get("token_endpoint", "") or "").strip()
     if not authorization_endpoint or not token_endpoint:
         raise AuthError(
@@ -3581,7 +3803,10 @@ def refresh_xai_oauth_pure(
             code="xai_auth_missing_refresh_token",
             relogin_required=True,
         )
-    endpoint = token_endpoint.strip() or _xai_oauth_discovery(timeout_seconds)["token_endpoint"]
+    endpoint = (
+        token_endpoint.strip()
+        or _xai_oauth_discovery(timeout_seconds)["token_endpoint"]
+    )
     # Re-validate cached endpoints on the refresh hot path: an auth.json
     # written by an older Hermes (or hand-edited) may carry a non-xAI
     # token_endpoint that would receive every future refresh_token in
@@ -3589,7 +3814,9 @@ def refresh_xai_oauth_pure(
     # with a clear error so the user can re-run `hermes model` to refetch.
     _xai_validate_oauth_endpoint(endpoint, field="token_endpoint")
     timeout = httpx.Timeout(max(5.0, float(timeout_seconds)))
-    with httpx.Client(timeout=timeout, headers={"Accept": "application/json"}) as client:
+    with httpx.Client(
+        timeout=timeout, headers={"Accept": "application/json"}
+    ) as client:
         response = client.post(
             endpoint,
             headers={"Content-Type": "application/x-www-form-urlencoded"},
@@ -3613,19 +3840,18 @@ def refresh_xai_oauth_pure(
                 "xAI token refresh failed with HTTP 403."
                 + (f" Response: {detail}" if detail else "")
                 + " This OAuth account is not authorized for xAI API"
-                  " access — xAI may be restricting API/OAuth use to"
-                  " specific SuperGrok tiers despite the in-app"
-                  " subscription being active. Re-logging in won't"
-                  " change that; set ``XAI_API_KEY`` and switch to"
-                  " ``provider: xai`` (API-key path) if available, or"
-                  " upgrade your subscription at https://x.ai/grok.",
+                " access — xAI may be restricting API/OAuth use to"
+                " specific SuperGrok tiers despite the in-app"
+                " subscription being active. Re-logging in won't"
+                " change that; set ``XAI_API_KEY`` and switch to"
+                " ``provider: xai`` (API-key path) if available, or"
+                " upgrade your subscription at https://x.ai/grok.",
                 provider="xai-oauth",
                 code="xai_oauth_tier_denied",
                 relogin_required=False,
             )
         raise AuthError(
-            "xAI token refresh failed."
-            + (f" Response: {detail}" if detail else ""),
+            "xAI token refresh failed." + (f" Response: {detail}" if detail else ""),
             provider="xai-oauth",
             code="xai_refresh_failed",
             relogin_required=(response.status_code in {400, 401}),
@@ -3704,16 +3930,24 @@ def resolve_xai_oauth_runtime_credentials(
     data = _read_xai_oauth_tokens()
     tokens = dict(data["tokens"])
     access_token = str(tokens.get("access_token", "") or "").strip()
-    refresh_timeout_seconds = float(os.getenv("HERMES_XAI_REFRESH_TIMEOUT_SECONDS", "20"))
+    refresh_timeout_seconds = float(
+        os.getenv("HERMES_XAI_REFRESH_TIMEOUT_SECONDS", "20")
+    )
     discovery = dict(data.get("discovery") or {})
     token_endpoint = str(discovery.get("token_endpoint", "") or "").strip()
     redirect_uri = str(data.get("redirect_uri", "") or "").strip()
 
     should_refresh = bool(force_refresh)
     if (not should_refresh) and refresh_if_expiring:
-        should_refresh = _xai_access_token_is_expiring(access_token, refresh_skew_seconds)
+        should_refresh = _xai_access_token_is_expiring(
+            access_token, refresh_skew_seconds
+        )
     if should_refresh:
-        with _auth_store_lock(timeout_seconds=max(float(AUTH_LOCK_TIMEOUT_SECONDS), refresh_timeout_seconds + 5.0)):
+        with _auth_store_lock(
+            timeout_seconds=max(
+                float(AUTH_LOCK_TIMEOUT_SECONDS), refresh_timeout_seconds + 5.0
+            )
+        ):
             data = _read_xai_oauth_tokens(_lock=False)
             tokens = dict(data["tokens"])
             access_token = str(tokens.get("access_token", "") or "").strip()
@@ -3722,10 +3956,14 @@ def resolve_xai_oauth_runtime_credentials(
             redirect_uri = str(data.get("redirect_uri", "") or "").strip()
             should_refresh = bool(force_refresh)
             if (not should_refresh) and refresh_if_expiring:
-                should_refresh = _xai_access_token_is_expiring(access_token, refresh_skew_seconds)
+                should_refresh = _xai_access_token_is_expiring(
+                    access_token, refresh_skew_seconds
+                )
             if should_refresh:
                 if not token_endpoint:
-                    token_endpoint = _xai_oauth_discovery(refresh_timeout_seconds)["token_endpoint"]
+                    token_endpoint = _xai_oauth_discovery(refresh_timeout_seconds)[
+                        "token_endpoint"
+                    ]
                 try:
                     tokens = _refresh_xai_oauth_tokens(
                         tokens,
@@ -3754,11 +3992,14 @@ def resolve_xai_oauth_runtime_credentials(
                                 "relogin_required": True,
                                 "at": datetime.now(timezone.utc).isoformat(),
                             }
-                            _store_provider_state(_q_store, "xai-oauth", _q_state, set_active=False)
+                            _store_provider_state(
+                                _q_store, "xai-oauth", _q_state, set_active=False
+                            )
                             _save_auth_store(_q_store)
                         except Exception as _save_exc:
                             logger.debug(
-                                "xAI OAuth: failed to persist quarantined state: %s", _save_exc,
+                                "xAI OAuth: failed to persist quarantined state: %s",
+                                _save_exc,
                             )
                     raise
 
@@ -3781,6 +4022,7 @@ def resolve_xai_oauth_runtime_credentials(
 # TLS verification helper
 # =============================================================================
 
+
 def _default_verify() -> bool | ssl.SSLContext:
     """Platform-aware default SSL verify for httpx clients.
 
@@ -3793,6 +4035,7 @@ def _default_verify() -> bool | ssl.SSLContext:
     if sys.platform == "darwin":
         try:
             import certifi
+
             return ssl.create_default_context(cafile=certifi.where())
         except ImportError:
             pass
@@ -3809,7 +4052,8 @@ def _resolve_verify(
     tls_state = tls_state if isinstance(tls_state, dict) else {}
 
     effective_insecure = (
-        is_truthy_value(insecure, default=False) if insecure is not None
+        is_truthy_value(insecure, default=False)
+        if insecure is not None
         else is_truthy_value(tls_state.get("insecure", False), default=False)
     )
     effective_ca = (
@@ -3838,6 +4082,7 @@ def _resolve_verify(
 # OAuth Device Code Flow — generic, parameterized by provider
 # =============================================================================
 
+
 def _request_device_code(
     client: httpx.Client,
     portal_base_url: str,
@@ -3856,8 +4101,12 @@ def _request_device_code(
     data = response.json()
 
     required_fields = [
-        "device_code", "user_code", "verification_uri",
-        "verification_uri_complete", "expires_in", "interval",
+        "device_code",
+        "user_code",
+        "verification_uri",
+        "verification_uri_complete",
+        "expires_in",
+        "interval",
     ]
     missing = [f for f in required_fields if f not in data]
     if missing:
@@ -3889,7 +4138,8 @@ def _is_nous_invoke_scope_refusal(exc: Exception) -> bool:
     return (
         "invalid_scope" in text
         or "unsupported_scope" in text
-        or "scope" in text and NOUS_INFERENCE_INVOKE_SCOPE in text
+        or "scope" in text
+        and NOUS_INFERENCE_INVOKE_SCOPE in text
     )
 
 
@@ -3929,7 +4179,9 @@ def _request_nous_device_code_with_scope_fallback(
             and _nous_scope_has_invoke(scope)
             and _is_nous_invoke_scope_refusal(exc)
         ):
-            logger.info("Nous inference auth: NAS refused invoke scope, retrying legacy scope")
+            logger.info(
+                "Nous inference auth: NAS refused invoke scope, retrying legacy scope"
+            )
             _oauth_trace("nous_device_code_invoke_scope_refused")
             retry_scope = NOUS_LEGACY_AGENT_KEY_SCOPE
             return (
@@ -3987,7 +4239,9 @@ def _poll_for_token(
             time.sleep(current_interval)
             continue
 
-        description = error_payload.get("error_description") or "Unknown authentication error"
+        description = (
+            error_payload.get("error_description") or "Unknown authentication error"
+        )
         raise RuntimeError(f"{error_code}: {description}")
 
     raise TimeoutError("Timed out waiting for device authorization")
@@ -4037,6 +4291,7 @@ def _nous_shared_auth_dir() -> Path:
     if override:
         return Path(override).expanduser()
     from hermes_constants import get_default_hermes_root
+
     return get_default_hermes_root() / "shared"
 
 
@@ -4050,6 +4305,7 @@ def _nous_shared_store_path() -> Path:
     # shared store).
     if os.environ.get("PYTEST_CURRENT_TEST"):
         from hermes_constants import get_default_hermes_root
+
         real_home_shared = (
             get_default_hermes_root() / "shared" / NOUS_SHARED_STORE_FILENAME
         ).resolve(strict=False)
@@ -4155,7 +4411,8 @@ def _write_shared_nous_state(state: Dict[str, Any]) -> None:
         "scope": state.get("scope") or DEFAULT_NOUS_SCOPE,
         "client_id": state.get("client_id") or DEFAULT_NOUS_CLIENT_ID,
         "portal_base_url": state.get("portal_base_url") or DEFAULT_NOUS_PORTAL_URL,
-        "inference_base_url": state.get("inference_base_url") or DEFAULT_NOUS_INFERENCE_URL,
+        "inference_base_url": state.get("inference_base_url")
+        or DEFAULT_NOUS_INFERENCE_URL,
         "obtained_at": state.get("obtained_at"),
         "expires_at": state.get("expires_at"),
         "updated_at": datetime.now(timezone.utc).isoformat(),
@@ -4279,7 +4536,8 @@ def _is_terminal_codex_oauth_refresh_error(exc: Exception) -> bool:
     return (
         isinstance(exc, AuthError)
         and exc.provider == "openai-codex"
-        and exc.code in {
+        and exc.code
+        in {
             "codex_refresh_failed",
             "codex_auth_missing_refresh_token",
             "invalid_grant",
@@ -4374,7 +4632,9 @@ def _try_import_shared_nous_state(
     flow.
     """
     try:
-        with _nous_shared_store_lock(timeout_seconds=max(timeout_seconds + 5.0, AUTH_LOCK_TIMEOUT_SECONDS)):
+        with _nous_shared_store_lock(
+            timeout_seconds=max(timeout_seconds + 5.0, AUTH_LOCK_TIMEOUT_SECONDS)
+        ):
             shared = _read_shared_nous_state()
             if not shared:
                 return None
@@ -4386,8 +4646,10 @@ def _try_import_shared_nous_state(
                 "access_token": shared.get("access_token"),
                 "refresh_token": shared.get("refresh_token"),
                 "client_id": shared.get("client_id") or DEFAULT_NOUS_CLIENT_ID,
-                "portal_base_url": shared.get("portal_base_url") or DEFAULT_NOUS_PORTAL_URL,
-                "inference_base_url": shared.get("inference_base_url") or DEFAULT_NOUS_INFERENCE_URL,
+                "portal_base_url": shared.get("portal_base_url")
+                or DEFAULT_NOUS_PORTAL_URL,
+                "inference_base_url": shared.get("inference_base_url")
+                or DEFAULT_NOUS_INFERENCE_URL,
                 "token_type": shared.get("token_type") or "Bearer",
                 "scope": shared.get("scope") or DEFAULT_NOUS_SCOPE,
                 "obtained_at": shared.get("obtained_at"),
@@ -4397,7 +4659,9 @@ def _try_import_shared_nous_state(
                 "tls": {"insecure": False, "ca_bundle": None},
             }
 
-            def _persist_shared_refresh(updated_state: Dict[str, Any], _reason: str) -> None:
+            def _persist_shared_refresh(
+                updated_state: Dict[str, Any], _reason: str
+            ) -> None:
                 _write_shared_nous_state(updated_state)
 
             refreshed = refresh_nous_oauth_from_state(
@@ -4449,18 +4713,25 @@ def _refresh_access_token(
     if response.status_code == 200:
         payload = response.json()
         if "access_token" not in payload:
-            raise AuthError("Refresh response missing access_token",
-                            provider="nous", code="invalid_token", relogin_required=True)
+            raise AuthError(
+                "Refresh response missing access_token",
+                provider="nous",
+                code="invalid_token",
+                relogin_required=True,
+            )
         return payload
 
     try:
         error_payload = response.json()
     except Exception as exc:
-        raise AuthError("Refresh token exchange failed",
-                        provider="nous", relogin_required=True) from exc
+        raise AuthError(
+            "Refresh token exchange failed", provider="nous", relogin_required=True
+        ) from exc
 
     code = str(error_payload.get("error", "invalid_grant"))
-    description = str(error_payload.get("error_description") or "Refresh token exchange failed")
+    description = str(
+        error_payload.get("error_description") or "Refresh token exchange failed"
+    )
     relogin = code in {"invalid_grant", "invalid_token", "refresh_token_reused"}
 
     # Detect the OAuth 2.1 "refresh token reuse" signal from the Nous portal
@@ -4471,7 +4742,11 @@ def _refresh_access_token(
     # retires the original RT, Hermes's next refresh uses it, and the whole
     # session chain gets revoked as a token-theft signal (#15099).
     lowered = description.lower()
-    if code == "refresh_token_reused" or "reuse" in lowered or "reuse detected" in lowered:
+    if (
+        code == "refresh_token_reused"
+        or "reuse" in lowered
+        or "reuse detected" in lowered
+    ):
         description = (
             "Nous Portal detected refresh-token reuse and revoked this session.\n"
             "This usually means an external process (monitoring script, "
@@ -4505,18 +4780,22 @@ def _mint_agent_key(
     if response.status_code == 200:
         payload = response.json()
         if "api_key" not in payload:
-            raise AuthError("Mint response missing api_key",
-                            provider="nous", code="server_error")
+            raise AuthError(
+                "Mint response missing api_key", provider="nous", code="server_error"
+            )
         return payload
 
     try:
         error_payload = response.json()
     except Exception as exc:
-        raise AuthError("Agent key mint request failed",
-                        provider="nous", code="server_error") from exc
+        raise AuthError(
+            "Agent key mint request failed", provider="nous", code="server_error"
+        ) from exc
 
     code = str(error_payload.get("error", "server_error"))
-    description = str(error_payload.get("error_description") or "Agent key mint request failed")
+    description = str(
+        error_payload.get("error_description") or "Agent key mint request failed"
+    )
     relogin = code in {"invalid_token", "invalid_grant"}
     raise AuthError(description, provider="nous", code=code, relogin_required=relogin)
 
@@ -4530,7 +4809,9 @@ def fetch_nous_models(
 ) -> List[str]:
     """Fetch available model IDs from the Nous inference API."""
     timeout = httpx.Timeout(timeout_seconds)
-    with httpx.Client(timeout=timeout, headers={"Accept": "application/json"}, verify=verify) as client:
+    with httpx.Client(
+        timeout=timeout, headers={"Accept": "application/json"}, verify=verify
+    ) as client:
         response = client.get(
             f"{inference_base_url.rstrip('/')}/models",
             headers={"Authorization": f"Bearer {api_key}"},
@@ -4540,7 +4821,9 @@ def fetch_nous_models(
         description = f"/models request failed with status {response.status_code}"
         try:
             err = response.json()
-            description = str(err.get("error_description") or err.get("error") or description)
+            description = str(
+                err.get("error_description") or err.get("error") or description
+            )
         except Exception as e:
             logger.debug("Could not parse error response JSON: %s", e)
         raise AuthError(description, provider="nous", code="models_fetch_failed")
@@ -4619,9 +4902,13 @@ def resolve_nous_access_token(
             or DEFAULT_NOUS_PORTAL_URL
         ).rstrip("/")
         client_id = str(state.get("client_id") or DEFAULT_NOUS_CLIENT_ID)
-        verify = _resolve_verify(insecure=insecure, ca_bundle=ca_bundle, auth_state=state)
+        verify = _resolve_verify(
+            insecure=insecure, ca_bundle=ca_bundle, auth_state=state
+        )
 
-        with _nous_shared_store_lock(timeout_seconds=max(timeout_seconds + 5.0, AUTH_LOCK_TIMEOUT_SECONDS)):
+        with _nous_shared_store_lock(
+            timeout_seconds=max(timeout_seconds + 5.0, AUTH_LOCK_TIMEOUT_SECONDS)
+        ):
             merged_shared = _merge_shared_nous_oauth_state(state)
             access_token = state.get("access_token")
             refresh_token = state.get("refresh_token")
@@ -4678,7 +4965,9 @@ def resolve_nous_access_token(
             access_ttl = _coerce_ttl_seconds(refreshed.get("expires_in"))
             state["access_token"] = refreshed["access_token"]
             state["refresh_token"] = refreshed.get("refresh_token") or refresh_token
-            state["token_type"] = refreshed.get("token_type") or state.get("token_type") or "Bearer"
+            state["token_type"] = (
+                refreshed.get("token_type") or state.get("token_type") or "Bearer"
+            )
             state["scope"] = refreshed.get("scope") or state.get("scope")
             state["obtained_at"] = now.isoformat()
             state["expires_in"] = access_ttl
@@ -4731,7 +5020,9 @@ def refresh_nous_oauth_pure(
         "refresh_token": refresh_token,
         "client_id": client_id or DEFAULT_NOUS_CLIENT_ID,
         "portal_base_url": (portal_base_url or DEFAULT_NOUS_PORTAL_URL).rstrip("/"),
-        "inference_base_url": (inference_base_url or DEFAULT_NOUS_INFERENCE_URL).rstrip("/"),
+        "inference_base_url": (inference_base_url or DEFAULT_NOUS_INFERENCE_URL).rstrip(
+            "/"
+        ),
         "token_type": token_type or "Bearer",
         "scope": scope or DEFAULT_NOUS_SCOPE,
         "obtained_at": obtained_at,
@@ -4746,7 +5037,9 @@ def refresh_nous_oauth_pure(
     verify = _resolve_verify(insecure=insecure, ca_bundle=ca_bundle, auth_state=state)
     timeout = httpx.Timeout(timeout_seconds if timeout_seconds else 15.0)
 
-    with httpx.Client(timeout=timeout, headers={"Accept": "application/json"}, verify=verify) as client:
+    with httpx.Client(
+        timeout=timeout, headers={"Accept": "application/json"}, verify=verify
+    ) as client:
         min_agent_key_ttl = max(60, int(min_key_ttl_seconds))
         legacy_session_keys = _nous_legacy_session_keys_forced()
         current_invoke_jwt_usable = (
@@ -4757,12 +5050,9 @@ def refresh_nous_oauth_pure(
                 expires_at=state.get("expires_at"),
             )
         )
-        if (
-            force_refresh
-            or (
-                _is_expiring(state.get("expires_at"), ACCESS_TOKEN_REFRESH_SKEW_SECONDS)
-                and not current_invoke_jwt_usable
-            )
+        if force_refresh or (
+            _is_expiring(state.get("expires_at"), ACCESS_TOKEN_REFRESH_SKEW_SECONDS)
+            and not current_invoke_jwt_usable
         ):
             refreshed = _refresh_access_token(
                 client=client,
@@ -4773,8 +5063,12 @@ def refresh_nous_oauth_pure(
             now = datetime.now(timezone.utc)
             access_ttl = _coerce_ttl_seconds(refreshed.get("expires_in"))
             state["access_token"] = refreshed["access_token"]
-            state["refresh_token"] = refreshed.get("refresh_token") or state["refresh_token"]
-            state["token_type"] = refreshed.get("token_type") or state.get("token_type") or "Bearer"
+            state["refresh_token"] = (
+                refreshed.get("refresh_token") or state["refresh_token"]
+            )
+            state["token_type"] = (
+                refreshed.get("token_type") or state.get("token_type") or "Bearer"
+            )
             state["scope"] = refreshed.get("scope") or state.get("scope")
             refreshed_url = _optional_base_url(refreshed.get("inference_base_url"))
             if refreshed_url:
@@ -4948,8 +5242,11 @@ def resolve_nous_runtime_credentials(
         state = _load_provider_state(auth_store, "nous")
 
         if not state:
-            raise AuthError("Hermes is not logged into Nous Portal.",
-                            provider="nous", relogin_required=True)
+            raise AuthError(
+                "Hermes is not logged into Nous Portal.",
+                provider="nous",
+                relogin_required=True,
+            )
 
         persisted_state = dict(state)
         state_persisted = False
@@ -4971,9 +5268,8 @@ def resolve_nous_runtime_credentials(
             nonlocal persisted_state, state_persisted
             # Skip writes where only derived TTL countdowns changed; this keeps
             # the mtime-keyed Nous auth-status cache warm during read paths.
-            if (
-                _nous_effective_provider_state(state)
-                == _nous_effective_provider_state(persisted_state)
+            if _nous_effective_provider_state(state) == _nous_effective_provider_state(
+                persisted_state
             ):
                 _oauth_trace(
                     "nous_state_persist_skipped",
@@ -5007,7 +5303,9 @@ def resolve_nous_runtime_credentials(
             # _write_shared_nous_state.
             _write_shared_nous_state(state)
 
-        verify = _resolve_verify(insecure=insecure, ca_bundle=ca_bundle, auth_state=state)
+        verify = _resolve_verify(
+            insecure=insecure, ca_bundle=ca_bundle, auth_state=state
+        )
         timeout = httpx.Timeout(timeout_seconds if timeout_seconds else 15.0)
         _oauth_trace(
             "nous_runtime_credentials_start",
@@ -5017,13 +5315,18 @@ def resolve_nous_runtime_credentials(
             refresh_token_fp=_token_fingerprint(state.get("refresh_token")),
         )
 
-        with httpx.Client(timeout=timeout, headers={"Accept": "application/json"}, verify=verify) as client:
+        with httpx.Client(
+            timeout=timeout, headers={"Accept": "application/json"}, verify=verify
+        ) as client:
             access_token = state.get("access_token")
             refresh_token = state.get("refresh_token")
 
             if not isinstance(access_token, str) or not access_token:
-                raise AuthError("No access token found for Nous Portal login.",
-                                provider="nous", relogin_required=True)
+                raise AuthError(
+                    "No access token found for Nous Portal login.",
+                    provider="nous",
+                    relogin_required=True,
+                )
 
             # Step 1: refresh access token if expiring. If the access token
             # is already a valid invoke JWT, trust its own exp claim even when
@@ -5040,23 +5343,29 @@ def resolve_nous_runtime_credentials(
                 _is_expiring(state.get("expires_at"), ACCESS_TOKEN_REFRESH_SKEW_SECONDS)
                 and not current_invoke_jwt_usable
             ):
-                with _nous_shared_store_lock(timeout_seconds=max(timeout_seconds + 5.0, AUTH_LOCK_TIMEOUT_SECONDS)):
+                with _nous_shared_store_lock(
+                    timeout_seconds=max(
+                        timeout_seconds + 5.0, AUTH_LOCK_TIMEOUT_SECONDS
+                    )
+                ):
                     if _merge_shared_nous_oauth_state(state):
                         access_token = state.get("access_token")
                         refresh_token = state.get("refresh_token")
                         _persist_state("post_shared_merge_access_expiring")
 
-                    if (
-                        _is_expiring(state.get("expires_at"), ACCESS_TOKEN_REFRESH_SKEW_SECONDS)
-                        and not _nous_invoke_jwt_is_usable(
-                            access_token,
-                            scope=state.get("scope"),
-                            expires_at=state.get("expires_at"),
-                        )
+                    if _is_expiring(
+                        state.get("expires_at"), ACCESS_TOKEN_REFRESH_SKEW_SECONDS
+                    ) and not _nous_invoke_jwt_is_usable(
+                        access_token,
+                        scope=state.get("scope"),
+                        expires_at=state.get("expires_at"),
                     ):
                         if not isinstance(refresh_token, str) or not refresh_token:
-                            raise AuthError("Session expired and no refresh token is available.",
-                                            provider="nous", relogin_required=True)
+                            raise AuthError(
+                                "Session expired and no refresh token is available.",
+                                provider="nous",
+                                relogin_required=True,
+                            )
 
                         _oauth_trace(
                             "refresh_start",
@@ -5066,8 +5375,10 @@ def resolve_nous_runtime_credentials(
                         )
                         try:
                             refreshed = _refresh_access_token(
-                                client=client, portal_base_url=portal_base_url,
-                                client_id=client_id, refresh_token=refresh_token,
+                                client=client,
+                                portal_base_url=portal_base_url,
+                                client_id=client_id,
+                                refresh_token=refresh_token,
                             )
                         except AuthError as exc:
                             if _is_terminal_nous_refresh_error(exc):
@@ -5081,16 +5392,26 @@ def resolve_nous_runtime_credentials(
                                     exc,
                                     reason="runtime_access_refresh_failure",
                                 )
-                                _persist_state("terminal_runtime_access_refresh_failure")
+                                _persist_state(
+                                    "terminal_runtime_access_refresh_failure"
+                                )
                             raise
                         now = datetime.now(timezone.utc)
                         access_ttl = _coerce_ttl_seconds(refreshed.get("expires_in"))
                         previous_refresh_token = refresh_token
                         state["access_token"] = refreshed["access_token"]
-                        state["refresh_token"] = refreshed.get("refresh_token") or refresh_token
-                        state["token_type"] = refreshed.get("token_type") or state.get("token_type") or "Bearer"
+                        state["refresh_token"] = (
+                            refreshed.get("refresh_token") or refresh_token
+                        )
+                        state["token_type"] = (
+                            refreshed.get("token_type")
+                            or state.get("token_type")
+                            or "Bearer"
+                        )
                         state["scope"] = refreshed.get("scope") or state.get("scope")
-                        refreshed_url = _optional_base_url(refreshed.get("inference_base_url"))
+                        refreshed_url = _optional_base_url(
+                            refreshed.get("inference_base_url")
+                        )
                         if refreshed_url:
                             inference_base_url = refreshed_url
                         state["obtained_at"] = now.isoformat()
@@ -5104,7 +5425,9 @@ def resolve_nous_runtime_credentials(
                             "refresh_success",
                             sequence_id=sequence_id,
                             reason="access_expiring",
-                            previous_refresh_token_fp=_token_fingerprint(previous_refresh_token),
+                            previous_refresh_token_fp=_token_fingerprint(
+                                previous_refresh_token
+                            ),
                             new_refresh_token_fp=_token_fingerprint(refresh_token),
                         )
                         # Persist immediately so downstream mint failures cannot drop rotated refresh tokens.
@@ -5145,8 +5468,10 @@ def resolve_nous_runtime_credentials(
                         access_token_fp=_token_fingerprint(access_token),
                     )
                     mint_payload = _mint_agent_key(
-                        client=client, portal_base_url=portal_base_url,
-                        access_token=access_token, min_ttl_seconds=min_key_ttl_seconds,
+                        client=client,
+                        portal_base_url=portal_base_url,
+                        access_token=access_token,
+                        min_ttl_seconds=min_key_ttl_seconds,
                     )
                 except AuthError as exc:
                     _oauth_trace(
@@ -5161,7 +5486,11 @@ def resolve_nous_runtime_credentials(
                         and isinstance(latest_refresh_token, str)
                         and latest_refresh_token
                     ):
-                        with _nous_shared_store_lock(timeout_seconds=max(timeout_seconds + 5.0, AUTH_LOCK_TIMEOUT_SECONDS)):
+                        with _nous_shared_store_lock(
+                            timeout_seconds=max(
+                                timeout_seconds + 5.0, AUTH_LOCK_TIMEOUT_SECONDS
+                            )
+                        ):
                             if _merge_shared_nous_oauth_state(state):
                                 access_token = state.get("access_token")
                                 latest_refresh_token = state.get("refresh_token")
@@ -5171,12 +5500,16 @@ def resolve_nous_runtime_credentials(
                                     "refresh_start",
                                     sequence_id=sequence_id,
                                     reason="mint_retry_after_invalid_token",
-                                    refresh_token_fp=_token_fingerprint(latest_refresh_token),
+                                    refresh_token_fp=_token_fingerprint(
+                                        latest_refresh_token
+                                    ),
                                 )
                                 try:
                                     refreshed = _refresh_access_token(
-                                        client=client, portal_base_url=portal_base_url,
-                                        client_id=client_id, refresh_token=latest_refresh_token,
+                                        client=client,
+                                        portal_base_url=portal_base_url,
+                                        client_id=client_id,
+                                        refresh_token=latest_refresh_token,
                                     )
                                 except AuthError as exc:
                                     if _is_terminal_nous_refresh_error(exc):
@@ -5190,15 +5523,30 @@ def resolve_nous_runtime_credentials(
                                             exc,
                                             reason="runtime_mint_retry_refresh_failure",
                                         )
-                                        _persist_state("terminal_runtime_mint_retry_refresh_failure")
+                                        _persist_state(
+                                            "terminal_runtime_mint_retry_refresh_failure"
+                                        )
                                     raise
                                 now = datetime.now(timezone.utc)
-                                access_ttl = _coerce_ttl_seconds(refreshed.get("expires_in"))
+                                access_ttl = _coerce_ttl_seconds(
+                                    refreshed.get("expires_in")
+                                )
                                 state["access_token"] = refreshed["access_token"]
-                                state["refresh_token"] = refreshed.get("refresh_token") or latest_refresh_token
-                                state["token_type"] = refreshed.get("token_type") or state.get("token_type") or "Bearer"
-                                state["scope"] = refreshed.get("scope") or state.get("scope")
-                                refreshed_url = _optional_base_url(refreshed.get("inference_base_url"))
+                                state["refresh_token"] = (
+                                    refreshed.get("refresh_token")
+                                    or latest_refresh_token
+                                )
+                                state["token_type"] = (
+                                    refreshed.get("token_type")
+                                    or state.get("token_type")
+                                    or "Bearer"
+                                )
+                                state["scope"] = refreshed.get("scope") or state.get(
+                                    "scope"
+                                )
+                                refreshed_url = _optional_base_url(
+                                    refreshed.get("inference_base_url")
+                                )
                                 if refreshed_url:
                                     inference_base_url = refreshed_url
                                 state["obtained_at"] = now.isoformat()
@@ -5212,8 +5560,12 @@ def resolve_nous_runtime_credentials(
                                     "refresh_success",
                                     sequence_id=sequence_id,
                                     reason="mint_retry_after_invalid_token",
-                                    previous_refresh_token_fp=_token_fingerprint(latest_refresh_token),
-                                    new_refresh_token_fp=_token_fingerprint(refresh_token),
+                                    previous_refresh_token_fp=_token_fingerprint(
+                                        latest_refresh_token
+                                    ),
+                                    new_refresh_token_fp=_token_fingerprint(
+                                        refresh_token
+                                    ),
                                 )
                                 # Persist retry refresh immediately for crash safety and cross-process visibility.
                                 _persist_state("post_refresh_mint_retry")
@@ -5239,8 +5591,10 @@ def resolve_nous_runtime_credentials(
                             )
                         else:
                             mint_payload = _mint_agent_key(
-                                client=client, portal_base_url=portal_base_url,
-                                access_token=access_token, min_ttl_seconds=min_key_ttl_seconds,
+                                client=client,
+                                portal_base_url=portal_base_url,
+                                access_token=access_token,
+                                min_ttl_seconds=min_key_ttl_seconds,
                             )
                     else:
                         raise
@@ -5278,8 +5632,11 @@ def resolve_nous_runtime_credentials(
 
     api_key = state.get("agent_key")
     if not isinstance(api_key, str) or not api_key:
-        raise AuthError("Failed to resolve a Nous inference API key",
-                        provider="nous", code="server_error")
+        raise AuthError(
+            "Failed to resolve a Nous inference API key",
+            provider="nous",
+            code="server_error",
+        )
 
     expires_at = state.get("agent_key_expires_at")
     expires_epoch = _parse_iso_timestamp(expires_at)
@@ -5308,6 +5665,7 @@ def resolve_nous_runtime_credentials(
 # =============================================================================
 # Status helpers
 # =============================================================================
+
 
 def _empty_nous_auth_status() -> Dict[str, Any]:
     return {
@@ -5339,15 +5697,17 @@ def _snapshot_nous_pool_status() -> Dict[str, Any]:
             return _empty_nous_auth_status()
 
         def _entry_sort_key(entry: Any) -> tuple[float, float, int]:
-            agent_exp = _parse_iso_timestamp(getattr(entry, "agent_key_expires_at", None)) or 0.0
+            agent_exp = (
+                _parse_iso_timestamp(getattr(entry, "agent_key_expires_at", None))
+                or 0.0
+            )
             access_exp = _parse_iso_timestamp(getattr(entry, "expires_at", None)) or 0.0
             priority = int(getattr(entry, "priority", 0) or 0)
             return (agent_exp, access_exp, -priority)
 
         entry = max(entries, key=_entry_sort_key)
-        access_token = (
-            getattr(entry, "access_token", None)
-            or getattr(entry, "runtime_api_key", "")
+        access_token = getattr(entry, "access_token", None) or getattr(
+            entry, "runtime_api_key", ""
         )
         if not access_token:
             return _empty_nous_auth_status()
@@ -5422,10 +5782,7 @@ def get_nous_auth_status() -> Dict[str, Any]:
     cached = _nous_auth_status_cache
     if cached is not None:
         cached_at, cached_mtime, cached_status = cached
-        if (
-            cached_mtime == mtime
-            and (now - cached_at) < _NOUS_AUTH_STATUS_CACHE_TTL
-        ):
+        if cached_mtime == mtime and (now - cached_at) < _NOUS_AUTH_STATUS_CACHE_TTL:
             return dict(cached_status)
 
     status = _compute_nous_auth_status()
@@ -5453,11 +5810,13 @@ def _compute_nous_auth_status() -> Dict[str, Any]:
             base_status.update(
                 {
                     "logged_in": True,
-                    "portal_base_url": refreshed_state.get("portal_base_url") or base_status.get("portal_base_url"),
+                    "portal_base_url": refreshed_state.get("portal_base_url")
+                    or base_status.get("portal_base_url"),
                     "inference_base_url": creds.get("base_url")
                     or refreshed_state.get("inference_base_url")
                     or base_status.get("inference_base_url"),
-                    "access_expires_at": refreshed_state.get("expires_at") or base_status.get("access_expires_at"),
+                    "access_expires_at": refreshed_state.get("expires_at")
+                    or base_status.get("access_expires_at"),
                     "agent_key_expires_at": creds.get("expires_at")
                     or refreshed_state.get("agent_key_expires_at")
                     or base_status.get("agent_key_expires_at"),
@@ -5468,12 +5827,14 @@ def _compute_nous_auth_status() -> Dict[str, Any]:
             )
             return base_status
         except AuthError as exc:
-            base_status.update({
-                "logged_in": False,
-                "error": str(exc),
-                "relogin_required": bool(getattr(exc, "relogin_required", False)),
-                "error_code": getattr(exc, "code", None),
-            })
+            base_status.update(
+                {
+                    "logged_in": False,
+                    "error": str(exc),
+                    "relogin_required": bool(getattr(exc, "relogin_required", False)),
+                    "error_code": getattr(exc, "code", None),
+                }
+            )
             return base_status
 
     return _snapshot_nous_pool_status()
@@ -5481,7 +5842,7 @@ def _compute_nous_auth_status() -> Dict[str, Any]:
 
 def get_codex_auth_status() -> Dict[str, Any]:
     """Status snapshot for Codex auth.
-    
+
     Checks the credential pool first (where `hermes auth` stores credentials),
     then falls back to the legacy provider state.
     """
@@ -5489,13 +5850,13 @@ def get_codex_auth_status() -> Dict[str, Any]:
     # `hermes model` store device_code tokens.
     try:
         from agent.credential_pool import load_pool
+
         pool = load_pool("openai-codex")
         if pool and pool.has_credentials():
             entry = pool.select()
             if entry is not None:
-                api_key = (
-                    getattr(entry, "runtime_api_key", None)
-                    or getattr(entry, "access_token", "")
+                api_key = getattr(entry, "runtime_api_key", None) or getattr(
+                    entry, "access_token", ""
                 )
                 if api_key and not _codex_access_token_is_expiring(api_key, 0):
                     return {
@@ -5536,9 +5897,8 @@ def get_xai_oauth_auth_status() -> Dict[str, Any]:
         if pool and pool.has_credentials():
             entry = pool.select()
             if entry is not None:
-                api_key = (
-                    getattr(entry, "runtime_api_key", None)
-                    or getattr(entry, "access_token", "")
+                api_key = getattr(entry, "runtime_api_key", None) or getattr(
+                    entry, "access_token", ""
                 )
                 if api_key and not _xai_access_token_is_expiring(api_key, 0):
                     return {
@@ -5614,7 +5974,11 @@ def get_external_process_provider_status(provider_id: str) -> Dict[str, Any]:
     )
     raw_args = os.getenv("HERMES_COPILOT_ACP_ARGS", "").strip()
     args = shlex.split(raw_args) if raw_args else ["--acp", "--stdio"]
-    base_url = os.getenv(pconfig.base_url_env_var, "").strip() if pconfig.base_url_env_var else ""
+    base_url = (
+        os.getenv(pconfig.base_url_env_var, "").strip()
+        if pconfig.base_url_env_var
+        else ""
+    )
     if not base_url:
         base_url = pconfig.inference_base_url
 
@@ -5662,9 +6026,14 @@ def get_auth_status(provider_id: Optional[str] = None) -> Dict[str, Any]:
     if pconfig and pconfig.auth_type == "aws_sdk":
         try:
             from agent.bedrock_adapter import has_aws_credentials
+
             return {"logged_in": has_aws_credentials(), "provider": target}
         except ImportError:
-            return {"logged_in": False, "provider": target, "error": "boto3 not installed"}
+            return {
+                "logged_in": False,
+                "provider": target,
+                "error": "boto3 not installed",
+            }
     return {"logged_in": False}
 
 
@@ -5686,6 +6055,7 @@ def _get_azure_foundry_auth_status() -> Dict[str, Any]:
     info: Dict[str, Any] = {"provider": "azure-foundry"}
     try:
         from hermes_cli.config import load_config, get_env_value
+
         cfg = load_config()
     except Exception:
         cfg = {}
@@ -5694,7 +6064,9 @@ def _get_azure_foundry_auth_status() -> Dict[str, Any]:
     auth_mode = "api_key"
     base_url = ""
     if isinstance(model_cfg, dict):
-        auth_mode = str(model_cfg.get("auth_mode") or "api_key").strip().lower() or "api_key"
+        auth_mode = (
+            str(model_cfg.get("auth_mode") or "api_key").strip().lower() or "api_key"
+        )
         base_url = str(model_cfg.get("base_url") or "").strip()
     info["auth_mode"] = auth_mode
     info["base_url"] = base_url
@@ -5706,6 +6078,7 @@ def _get_azure_foundry_auth_status() -> Dict[str, Any]:
                 SCOPE_AI_AZURE_DEFAULT,
                 has_azure_identity_installed,
             )
+
             installed = has_azure_identity_installed()
             entra_cfg = {}
             if isinstance(model_cfg, dict) and isinstance(model_cfg.get("entra"), dict):
@@ -5738,7 +6111,9 @@ def _get_azure_foundry_auth_status() -> Dict[str, Any]:
 
     # api_key mode (default)
     try:
-        api_key = get_env_value("AZURE_FOUNDRY_API_KEY") or os.getenv("AZURE_FOUNDRY_API_KEY", "")
+        api_key = get_env_value("AZURE_FOUNDRY_API_KEY") or os.getenv(
+            "AZURE_FOUNDRY_API_KEY", ""
+        )
     except Exception:
         api_key = os.getenv("AZURE_FOUNDRY_API_KEY", "")
     info["logged_in"] = has_usable_secret(api_key)
@@ -5800,7 +6175,11 @@ def resolve_external_process_provider_credentials(provider_id: str) -> Dict[str,
             code="invalid_provider",
         )
 
-    base_url = os.getenv(pconfig.base_url_env_var, "").strip() if pconfig.base_url_env_var else ""
+    base_url = (
+        os.getenv(pconfig.base_url_env_var, "").strip()
+        if pconfig.base_url_env_var
+        else ""
+    )
     if not base_url:
         base_url = pconfig.inference_base_url
 
@@ -5833,6 +6212,7 @@ def resolve_external_process_provider_credentials(provider_id: str) -> Dict[str,
 # =============================================================================
 # CLI Commands — login / logout
 # =============================================================================
+
 
 def _update_config_for_provider(
     provider_id: str,
@@ -6093,6 +6473,7 @@ def _prompt_model_selection(
         )
         idx = menu.show()
         from hermes_cli.curses_ui import flush_stdin
+
         flush_stdin()
         if idx is None:
             return None
@@ -6118,7 +6499,9 @@ def _prompt_model_selection(
     if _unavailable:
         _upgrade_url = (portal_url or DEFAULT_NOUS_PORTAL_URL).rstrip("/")
         print()
-        print(f"  {_DIM}── Unavailable models (requires paid tier — upgrade at {_upgrade_url}) ──{_RESET}")
+        print(
+            f"  {_DIM}── Unavailable models (requires paid tier — upgrade at {_upgrade_url}) ──{_RESET}"
+        )
         for mid in _unavailable:
             print(f"  {'':>{num_width}}  {_DIM}{_label(mid)}{_RESET}")
     print()
@@ -6187,17 +6570,25 @@ def _login_openai_codex(
             # here the token should be valid — but double-check before telling
             # the user "Login successful!".
             _resolved_key = existing.get("api_key", "")
-            if isinstance(_resolved_key, str) and _resolved_key and not _codex_access_token_is_expiring(_resolved_key, 60):
+            if (
+                isinstance(_resolved_key, str)
+                and _resolved_key
+                and not _codex_access_token_is_expiring(_resolved_key, 60)
+            ):
                 print("Existing Codex credentials found in Hermes auth store.")
                 try:
                     reuse = input("Use existing credentials? [Y/n]: ").strip().lower()
                 except (EOFError, KeyboardInterrupt):
                     reuse = "y"
                 if reuse in {"", "y", "yes"}:
-                    config_path = _update_config_for_provider("openai-codex", existing.get("base_url", DEFAULT_CODEX_BASE_URL))
+                    config_path = _update_config_for_provider(
+                        "openai-codex", existing.get("base_url", DEFAULT_CODEX_BASE_URL)
+                    )
                     print()
                     print("Login successful!")
-                    print(f"  Config updated: {config_path} (model.provider=openai-codex)")
+                    print(
+                        f"  Config updated: {config_path} (model.provider=openai-codex)"
+                    )
                     return
             else:
                 print("Existing Codex credentials are expired. Starting fresh login...")
@@ -6209,14 +6600,25 @@ def _login_openai_codex(
         cli_tokens = _import_codex_cli_tokens()
         if cli_tokens:
             print("Found existing Codex CLI credentials at ~/.codex/auth.json")
-            print("Hermes will create its own session to avoid conflicts with Codex CLI / VS Code.")
+            print(
+                "Hermes will create its own session to avoid conflicts with Codex CLI / VS Code."
+            )
             try:
-                do_import = input("Import these credentials? (a separate login is recommended) [y/N]: ").strip().lower()
+                do_import = (
+                    input(
+                        "Import these credentials? (a separate login is recommended) [y/N]: "
+                    )
+                    .strip()
+                    .lower()
+                )
             except (EOFError, KeyboardInterrupt):
                 do_import = "n"
             if do_import in {"y", "yes"}:
                 _save_codex_tokens(cli_tokens)
-                base_url = os.getenv("HERMES_CODEX_BASE_URL", "").strip().rstrip("/") or DEFAULT_CODEX_BASE_URL
+                base_url = (
+                    os.getenv("HERMES_CODEX_BASE_URL", "").strip().rstrip("/")
+                    or DEFAULT_CODEX_BASE_URL
+                )
                 config_path = _update_config_for_provider("openai-codex", base_url)
                 print()
                 print("Credentials imported. Note: if Codex CLI refreshes its token,")
@@ -6234,10 +6636,13 @@ def _login_openai_codex(
 
     # Save tokens to Hermes auth store
     _save_codex_tokens(creds["tokens"], creds.get("last_refresh"))
-    config_path = _update_config_for_provider("openai-codex", creds.get("base_url", DEFAULT_CODEX_BASE_URL))
+    config_path = _update_config_for_provider(
+        "openai-codex", creds.get("base_url", DEFAULT_CODEX_BASE_URL)
+    )
     print()
     print("Login successful!")
     from hermes_constants import display_hermes_home as _dhh
+
     print(f"  Auth state: {_dhh()}/auth.json")
     print(f"  Config updated: {config_path} (model.provider=openai-codex)")
 
@@ -6254,7 +6659,11 @@ def _login_xai_oauth(
         try:
             existing = resolve_xai_oauth_runtime_credentials()
             api_key = existing.get("api_key", "")
-            if isinstance(api_key, str) and api_key and not _xai_access_token_is_expiring(api_key, 60):
+            if (
+                isinstance(api_key, str)
+                and api_key
+                and not _xai_access_token_is_expiring(api_key, 60)
+            ):
                 print("Existing xAI OAuth credentials found in Hermes auth store.")
                 try:
                     reuse = input("Use existing credentials? [Y/n]: ").strip().lower()
@@ -6294,10 +6703,13 @@ def _login_xai_oauth(
         redirect_uri=creds.get("redirect_uri", ""),
         last_refresh=creds.get("last_refresh"),
     )
-    config_path = _update_config_for_provider("xai-oauth", creds.get("base_url", DEFAULT_XAI_OAUTH_BASE_URL))
+    config_path = _update_config_for_provider(
+        "xai-oauth", creds.get("base_url", DEFAULT_XAI_OAUTH_BASE_URL)
+    )
     print()
     print("Login successful!")
     from hermes_constants import display_hermes_home as _dhh
+
     print(f"  Auth state: {_dhh()}/auth.json")
     print(f"  Config updated: {config_path} (model.provider=xai-oauth)")
 
@@ -6417,12 +6829,12 @@ def _xai_oauth_exchange_code_for_tokens(
                 f"xAI token exchange failed (HTTP 403)."
                 + (f" Response: {body}" if body else "")
                 + " This OAuth account is not authorized for xAI API"
-                  " access — xAI may be restricting API/OAuth use to"
-                  " specific SuperGrok tiers despite the in-app"
-                  " subscription being active. Set ``XAI_API_KEY``"
-                  " and switch to ``provider: xai`` (API-key path) if"
-                  " available, or upgrade your subscription at"
-                  " https://x.ai/grok.",
+                " access — xAI may be restricting API/OAuth use to"
+                " specific SuperGrok tiers despite the in-app"
+                " subscription being active. Set ``XAI_API_KEY``"
+                " and switch to ``provider: xai`` (API-key path) if"
+                " available, or upgrade your subscription at"
+                " https://x.ai/grok.",
                 provider="xai-oauth",
                 code="xai_oauth_tier_denied",
                 relogin_required=False,
@@ -6528,7 +6940,9 @@ def _xai_oauth_loopback_login(
                 if opened:
                     print("Browser opened for xAI authorization.")
                 else:
-                    print("Could not open the browser automatically; use the URL above.")
+                    print(
+                        "Could not open the browser automatically; use the URL above."
+                    )
 
             callback = _xai_wait_for_callback(
                 server,
@@ -6603,7 +7017,8 @@ def _xai_oauth_loopback_login(
             "refresh_token": refresh_token,
             "id_token": str(payload.get("id_token", "") or "").strip(),
             "expires_in": payload.get("expires_in"),
-            "token_type": str(payload.get("token_type") or "Bearer").strip() or "Bearer",
+            "token_type": str(payload.get("token_type") or "Bearer").strip()
+            or "Bearer",
         },
         "discovery": discovery,
         "redirect_uri": redirect_uri,
@@ -6631,13 +7046,15 @@ def _codex_device_code_login() -> Dict[str, Any]:
     except Exception as exc:
         raise AuthError(
             f"Failed to request device code: {exc}",
-            provider="openai-codex", code="device_code_request_failed",
+            provider="openai-codex",
+            code="device_code_request_failed",
         )
 
     if resp.status_code != 200:
         raise AuthError(
             f"Device code request returned status {resp.status_code}.",
-            provider="openai-codex", code="device_code_request_error",
+            provider="openai-codex",
+            code="device_code_request_error",
         )
 
     device_data = resp.json()
@@ -6648,7 +7065,8 @@ def _codex_device_code_login() -> Dict[str, Any]:
     if not user_code or not device_auth_id:
         raise AuthError(
             "Device code response missing required fields.",
-            provider="openai-codex", code="device_code_incomplete",
+            provider="openai-codex",
+            code="device_code_incomplete",
         )
 
     # Step 2: Show user the code
@@ -6682,7 +7100,8 @@ def _codex_device_code_login() -> Dict[str, Any]:
                 else:
                     raise AuthError(
                         f"Device auth polling returned status {poll_resp.status_code}.",
-                        provider="openai-codex", code="device_code_poll_error",
+                        provider="openai-codex",
+                        code="device_code_poll_error",
                     )
     except KeyboardInterrupt:
         print("\nLogin cancelled.")
@@ -6691,7 +7110,8 @@ def _codex_device_code_login() -> Dict[str, Any]:
     if code_resp is None:
         raise AuthError(
             "Login timed out after 15 minutes.",
-            provider="openai-codex", code="device_code_timeout",
+            provider="openai-codex",
+            code="device_code_timeout",
         )
 
     # Step 4: Exchange authorization code for tokens
@@ -6702,7 +7122,8 @@ def _codex_device_code_login() -> Dict[str, Any]:
     if not authorization_code or not code_verifier:
         raise AuthError(
             "Device auth response missing authorization_code or code_verifier.",
-            provider="openai-codex", code="device_code_incomplete_exchange",
+            provider="openai-codex",
+            code="device_code_incomplete_exchange",
         )
 
     try:
@@ -6721,13 +7142,15 @@ def _codex_device_code_login() -> Dict[str, Any]:
     except Exception as exc:
         raise AuthError(
             f"Token exchange failed: {exc}",
-            provider="openai-codex", code="token_exchange_failed",
+            provider="openai-codex",
+            code="token_exchange_failed",
         )
 
     if token_resp.status_code != 200:
         raise AuthError(
             f"Token exchange returned status {token_resp.status_code}.",
-            provider="openai-codex", code="token_exchange_error",
+            provider="openai-codex",
+            code="token_exchange_error",
         )
 
     tokens = token_resp.json()
@@ -6737,7 +7160,8 @@ def _codex_device_code_login() -> Dict[str, Any]:
     if not access_token:
         raise AuthError(
             "Token exchange did not return an access_token.",
-            provider="openai-codex", code="token_exchange_no_access_token",
+            provider="openai-codex",
+            code="token_exchange_no_access_token",
         )
 
     # Return tokens for the caller to persist (no longer writes to ~/.codex/)
@@ -6760,20 +7184,28 @@ def _codex_device_code_login() -> Dict[str, Any]:
 
 # ==================== MiniMax Portal OAuth ====================
 
+
 def _minimax_pkce_pair() -> tuple:
     """Generate (code_verifier, code_challenge_S256, state) for MiniMax OAuth."""
     import secrets
+
     verifier = secrets.token_urlsafe(64)[:96]
-    challenge = base64.urlsafe_b64encode(
-        hashlib.sha256(verifier.encode()).digest()
-    ).decode().rstrip("=")
+    challenge = (
+        base64.urlsafe_b64encode(hashlib.sha256(verifier.encode()).digest())
+        .decode()
+        .rstrip("=")
+    )
     state = secrets.token_urlsafe(16)
     return verifier, challenge, state
 
 
 def _minimax_request_user_code(
-    client: httpx.Client, *, portal_base_url: str, client_id: str,
-    code_challenge: str, state: str,
+    client: httpx.Client,
+    *,
+    portal_base_url: str,
+    client_id: str,
+    code_challenge: str,
+    state: str,
 ) -> Dict[str, Any]:
     response = client.post(
         f"{portal_base_url}/oauth/code",
@@ -6794,19 +7226,22 @@ def _minimax_request_user_code(
     if response.status_code != 200:
         raise AuthError(
             f"MiniMax OAuth authorization failed: {response.text or response.reason_phrase}",
-            provider="minimax-oauth", code="authorization_failed",
+            provider="minimax-oauth",
+            code="authorization_failed",
         )
     payload = response.json()
     for field in ("user_code", "verification_uri", "expired_in"):
         if field not in payload:
             raise AuthError(
                 f"MiniMax OAuth response missing field: {field}",
-                provider="minimax-oauth", code="authorization_incomplete",
+                provider="minimax-oauth",
+                code="authorization_incomplete",
             )
     if payload.get("state") != state:
         raise AuthError(
             "MiniMax OAuth state mismatch (possible CSRF).",
-            provider="minimax-oauth", code="state_mismatch",
+            provider="minimax-oauth",
+            code="state_mismatch",
         )
     return payload
 
@@ -6826,12 +7261,19 @@ def _minimax_resolve_token_expiry_unix(expired_in: int, *, now: datetime) -> flo
 
 
 def _minimax_poll_token(
-    client: httpx.Client, *, portal_base_url: str, client_id: str,
-    user_code: str, code_verifier: str, expired_in: int, interval_ms: Optional[int],
+    client: httpx.Client,
+    *,
+    portal_base_url: str,
+    client_id: str,
+    user_code: str,
+    code_verifier: str,
+    expired_in: int,
+    interval_ms: Optional[int],
 ) -> Dict[str, Any]:
     # OpenClaw treats expired_in as a unix-ms timestamp (Date.now() < expireTimeMs).
     # Defensive parsing: if it's small enough to be a duration, treat as seconds.
     import time as _time
+
     now_ms = int(_time.time() * 1000)
     raw = int(expired_in)
     if _minimax_expired_in_looks_like_unix_ms(raw, now_ms=now_ms):
@@ -6860,23 +7302,30 @@ def _minimax_poll_token(
             payload = {}
 
         if response.status_code != 200:
-            msg = (payload.get("base_resp", {}) or {}).get("status_msg") or response.text
+            msg = (payload.get("base_resp", {}) or {}).get(
+                "status_msg"
+            ) or response.text
             raise AuthError(
                 f"MiniMax OAuth error: {msg or 'unknown'}",
-                provider="minimax-oauth", code="token_exchange_failed",
+                provider="minimax-oauth",
+                code="token_exchange_failed",
             )
 
         status = payload.get("status")
         if status == "error":
             raise AuthError(
                 "MiniMax OAuth reported an error. Please try again later.",
-                provider="minimax-oauth", code="authorization_denied",
+                provider="minimax-oauth",
+                code="authorization_denied",
             )
         if status == "success":
-            if not all(payload.get(k) for k in ("access_token", "refresh_token", "expired_in")):
+            if not all(
+                payload.get(k) for k in ("access_token", "refresh_token", "expired_in")
+            ):
                 raise AuthError(
                     "MiniMax OAuth success payload missing required token fields.",
-                    provider="minimax-oauth", code="token_incomplete",
+                    provider="minimax-oauth",
+                    code="token_incomplete",
                 )
             return payload
         # "pending" or any other status -> keep polling
@@ -6884,7 +7333,8 @@ def _minimax_poll_token(
 
     raise AuthError(
         "MiniMax OAuth timed out before authorization completed.",
-        provider="minimax-oauth", code="timeout",
+        provider="minimax-oauth",
+        code="timeout",
     )
 
 
@@ -6897,7 +7347,9 @@ def _minimax_save_auth_state(auth_state: Dict[str, Any]) -> None:
 
 
 def _minimax_oauth_login(
-    *, region: str = "global", open_browser: bool = True,
+    *,
+    region: str = "global",
+    open_browser: bool = True,
     timeout_seconds: float = 15.0,
 ) -> Dict[str, Any]:
     """Run MiniMax OAuth flow, persist tokens, return auth state dict."""
@@ -6917,13 +7369,17 @@ def _minimax_oauth_login(
     print(f"Starting Hermes login via MiniMax ({region}) OAuth...")
     print(f"Portal: {portal_base_url}")
 
-    with httpx.Client(timeout=httpx.Timeout(timeout_seconds),
-                      headers={"Accept": "application/json"},
-                      follow_redirects=True) as client:
+    with httpx.Client(
+        timeout=httpx.Timeout(timeout_seconds),
+        headers={"Accept": "application/json"},
+        follow_redirects=True,
+    ) as client:
         code_data = _minimax_request_user_code(
-            client, portal_base_url=portal_base_url,
+            client,
+            portal_base_url=portal_base_url,
             client_id=pconfig.client_id,
-            code_challenge=challenge, state=state,
+            code_challenge=challenge,
+            state=state,
         )
         verification_url = str(code_data["verification_uri"])
         user_code = str(code_data["user_code"])
@@ -6943,16 +7399,19 @@ def _minimax_oauth_login(
         print("Waiting for approval...")
 
         token_data = _minimax_poll_token(
-            client, portal_base_url=portal_base_url,
+            client,
+            portal_base_url=portal_base_url,
             client_id=pconfig.client_id,
-            user_code=user_code, code_verifier=verifier,
+            user_code=user_code,
+            code_verifier=verifier,
             expired_in=int(code_data["expired_in"]),
             interval_ms=interval_ms,
         )
 
     now = datetime.now(timezone.utc)
     expires_at_unix = _minimax_resolve_token_expiry_unix(
-        int(token_data["expired_in"]), now=now,
+        int(token_data["expired_in"]),
+        now=now,
     )
     expires_in_s = max(0, int(expires_at_unix - now.timestamp()))
 
@@ -6968,7 +7427,9 @@ def _minimax_oauth_login(
         "refresh_token": token_data["refresh_token"],
         "resource_url": token_data.get("resource_url"),
         "obtained_at": now.isoformat(),
-        "expires_at": datetime.fromtimestamp(expires_at_unix, tz=timezone.utc).isoformat(),
+        "expires_at": datetime.fromtimestamp(
+            expires_at_unix, tz=timezone.utc
+        ).isoformat(),
         "expires_in": expires_in_s,
     }
 
@@ -6980,14 +7441,18 @@ def _minimax_oauth_login(
 
 
 def _refresh_minimax_oauth_state(
-    state: Dict[str, Any], *, timeout_seconds: float = 15.0,
+    state: Dict[str, Any],
+    *,
+    timeout_seconds: float = 15.0,
     force: bool = False,
 ) -> Dict[str, Any]:
     """Refresh MiniMax OAuth access token if close to expiry (or forced)."""
     if not state.get("refresh_token"):
         raise AuthError(
             "MiniMax OAuth state has no refresh_token; please re-login.",
-            provider="minimax-oauth", code="no_refresh_token", relogin_required=True,
+            provider="minimax-oauth",
+            code="no_refresh_token",
+            relogin_required=True,
         )
     try:
         expires_at = datetime.fromisoformat(state.get("expires_at", "")).timestamp()
@@ -6998,8 +7463,9 @@ def _refresh_minimax_oauth_state(
         return state
 
     portal_base_url = state["portal_base_url"]
-    with httpx.Client(timeout=httpx.Timeout(timeout_seconds),
-                      follow_redirects=True) as client:
+    with httpx.Client(
+        timeout=httpx.Timeout(timeout_seconds), follow_redirects=True
+    ) as client:
         response = client.post(
             f"{portal_base_url}/oauth/token",
             data={
@@ -7014,39 +7480,49 @@ def _refresh_minimax_oauth_state(
         )
     if response.status_code != 200:
         body = response.text.lower()
-        relogin = any(m in body for m in
-                      ("invalid_grant", "refresh_token_reused", "invalid_refresh_token"))
+        relogin = any(
+            m in body
+            for m in ("invalid_grant", "refresh_token_reused", "invalid_refresh_token")
+        )
         raise AuthError(
             f"MiniMax OAuth refresh failed: {response.text or response.reason_phrase}",
-            provider="minimax-oauth", code="refresh_failed",
+            provider="minimax-oauth",
+            code="refresh_failed",
             relogin_required=relogin,
         )
     payload = response.json()
     if payload.get("status") != "success":
         raise AuthError(
             "MiniMax OAuth refresh did not return success.",
-            provider="minimax-oauth", code="refresh_failed",
+            provider="minimax-oauth",
+            code="refresh_failed",
             relogin_required=True,
         )
     now_dt = datetime.now(timezone.utc)
     expires_at_unix = _minimax_resolve_token_expiry_unix(
-        int(payload["expired_in"]), now=now_dt,
+        int(payload["expired_in"]),
+        now=now_dt,
     )
     expires_in_s = max(0, int(expires_at_unix - now_dt.timestamp()))
     new_state = dict(state)
-    new_state.update({
-        "access_token": payload["access_token"],
-        "refresh_token": payload.get("refresh_token", state["refresh_token"]),
-        "obtained_at": now_dt.isoformat(),
-        "expires_at": datetime.fromtimestamp(expires_at_unix, tz=timezone.utc).isoformat(),
-        "expires_in": expires_in_s,
-    })
+    new_state.update(
+        {
+            "access_token": payload["access_token"],
+            "refresh_token": payload.get("refresh_token", state["refresh_token"]),
+            "obtained_at": now_dt.isoformat(),
+            "expires_at": datetime.fromtimestamp(
+                expires_at_unix, tz=timezone.utc
+            ).isoformat(),
+            "expires_in": expires_in_s,
+        }
+    )
     _minimax_save_auth_state(new_state)
     return new_state
 
 
 def resolve_minimax_oauth_runtime_credentials(
-    *, min_token_ttl_seconds: int = MINIMAX_OAUTH_REFRESH_SKEW_SECONDS,
+    *,
+    min_token_ttl_seconds: int = MINIMAX_OAUTH_REFRESH_SKEW_SECONDS,
 ) -> Dict[str, Any]:
     """Return {provider, api_key, base_url, source} for minimax-oauth."""
     state = get_provider_auth_state("minimax-oauth")
@@ -7054,7 +7530,9 @@ def resolve_minimax_oauth_runtime_credentials(
         raise AuthError(
             "Not logged into MiniMax OAuth. Run `hermes model` and select "
             "MiniMax (OAuth).",
-            provider="minimax-oauth", code="not_logged_in", relogin_required=True,
+            provider="minimax-oauth",
+            code="not_logged_in",
+            relogin_required=True,
         )
     try:
         state = _refresh_minimax_oauth_state(state)
@@ -7063,7 +7541,13 @@ def resolve_minimax_oauth_runtime_credentials(
             # Terminal refresh failure — clear dead tokens from auth.json so
             # subsequent calls fail fast without a network retry, mirroring
             # the Nous / xAI-OAuth / Codex-OAuth quarantine pattern.
-            for _k in ("access_token", "refresh_token", "expires_at", "expires_in", "obtained_at"):
+            for _k in (
+                "access_token",
+                "refresh_token",
+                "expires_at",
+                "expires_in",
+                "obtained_at",
+            ):
                 state.pop(_k, None)
             state["last_auth_error"] = {
                 "provider": "minimax-oauth",
@@ -7076,7 +7560,9 @@ def resolve_minimax_oauth_runtime_credentials(
             try:
                 _minimax_save_auth_state(state)
             except Exception as _save_exc:
-                logger.debug("MiniMax OAuth: failed to persist quarantined state: %s", _save_exc)
+                logger.debug(
+                    "MiniMax OAuth: failed to persist quarantined state: %s", _save_exc
+                )
         raise
     return {
         "provider": "minimax-oauth",
@@ -7111,7 +7597,9 @@ def _login_minimax_oauth(args, pconfig: ProviderConfig) -> None:
     timeout = getattr(args, "timeout", None) or 15.0
     try:
         _minimax_oauth_login(
-            region=region, open_browser=open_browser, timeout_seconds=timeout,
+            region=region,
+            open_browser=open_browser,
+            timeout_seconds=timeout,
         )
     except AuthError as exc:
         print(format_auth_error(exc))
@@ -7161,7 +7649,9 @@ def _nous_device_code_login(
     elif ca_bundle:
         print(f"TLS verification: custom CA bundle ({ca_bundle})")
 
-    with httpx.Client(timeout=timeout, headers={"Accept": "application/json"}, verify=verify) as client:
+    with httpx.Client(
+        timeout=timeout, headers={"Accept": "application/json"}, verify=verify
+    ) as client:
         device_data, scope = _request_nous_device_code_with_scope_fallback(
             client=client,
             portal_base_url=portal_base_url,
@@ -7187,7 +7677,9 @@ def _nous_device_code_login(
             else:
                 print("  Could not open browser automatically — use the URL above.")
 
-        effective_interval = max(1, min(interval, DEVICE_AUTH_POLL_INTERVAL_CAP_SECONDS))
+        effective_interval = max(
+            1, min(interval, DEVICE_AUTH_POLL_INTERVAL_CAP_SECONDS)
+        )
         print(f"Waiting for approval (polling every {effective_interval}s)...")
 
         token_data = _poll_for_token(
@@ -7291,7 +7783,9 @@ def _login_nous(args, pconfig: ProviderConfig) -> None:
                     min_key_ttl_seconds=5 * 60,
                 )
                 if auth_state is None:
-                    print("Could not refresh shared credentials — falling back to device-code login.")
+                    print(
+                        "Could not refresh shared credentials — falling back to device-code login."
+                    )
 
         if auth_state is None:
             auth_state = _nous_device_code_login(
@@ -7346,11 +7840,14 @@ def _login_nous(args, pconfig: ProviderConfig) -> None:
                 )
 
             from hermes_cli.models import (
-                get_curated_nous_model_ids, get_pricing_for_provider,
-                check_nous_free_tier, partition_nous_models_by_tier,
+                get_curated_nous_model_ids,
+                get_pricing_for_provider,
+                check_nous_free_tier,
+                partition_nous_models_by_tier,
                 union_with_portal_free_recommendations,
                 union_with_portal_paid_recommendations,
             )
+
             model_ids = get_curated_nous_model_ids()
 
             print()
@@ -7366,10 +7863,14 @@ def _login_nous(args, pconfig: ProviderConfig) -> None:
                     # as free so users on older Hermes builds still see
                     # newly-launched free models without a CLI release.
                     model_ids, pricing = union_with_portal_free_recommendations(
-                        model_ids, pricing, _portal_for_recs,
+                        model_ids,
+                        pricing,
+                        _portal_for_recs,
                     )
                     model_ids, unavailable_models = partition_nous_models_by_tier(
-                        model_ids, pricing, free_tier=True,
+                        model_ids,
+                        pricing,
+                        free_tier=True,
                     )
                 else:
                     # Paid-tier mirror: pull paidRecommendedModels so newly
@@ -7377,13 +7878,18 @@ def _login_nous(args, pconfig: ProviderConfig) -> None:
                     # the in-repo curated list and docs-hosted manifest
                     # haven't caught up yet.
                     model_ids, pricing = union_with_portal_paid_recommendations(
-                        model_ids, pricing, _portal_for_recs,
+                        model_ids,
+                        pricing,
+                        _portal_for_recs,
                     )
             _portal = auth_state.get("portal_base_url", "")
             if model_ids:
-                print(f"Showing {len(model_ids)} curated models — use \"Enter custom model name\" for others.")
+                print(
+                    f'Showing {len(model_ids)} curated models — use "Enter custom model name" for others.'
+                )
                 selected_model = _prompt_model_selection(
-                    model_ids, pricing=pricing,
+                    model_ids,
+                    pricing=pricing,
                     unavailable_models=unavailable_models,
                     portal_url=_portal,
                 )
@@ -7396,7 +7902,9 @@ def _login_nous(args, pconfig: ProviderConfig) -> None:
         except Exception as exc:
             message = format_auth_error(exc) if isinstance(exc, AuthError) else str(exc)
             print()
-            print(f"Login succeeded, but could not fetch available models. Reason: {message}")
+            print(
+                f"Login succeeded, but could not fetch available models. Reason: {message}"
+            )
 
         # Write provider + model atomically so config is never mismatched.
         # If no model was selected (user picked "Skip (keep current)",
@@ -7421,7 +7929,9 @@ def _login_nous(args, pconfig: ProviderConfig) -> None:
             return
 
         config_path = _update_config_for_provider(
-            "nous", inference_base_url, default_model=selected_model,
+            "nous",
+            inference_base_url,
+            default_model=selected_model,
         )
         if selected_model:
             _save_model_choice(selected_model)

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -32,38 +32,41 @@ COPILOT_REASONING_EFFORTS_O_SERIES = ["low", "medium", "high"]
 # Fallback OpenRouter snapshot used when the live catalog is unavailable.
 # (model_id, display description shown in menus)
 OPENROUTER_MODELS: list[tuple[str, str]] = [
-    ("anthropic/claude-opus-4.7",              ""),
-    ("anthropic/claude-opus-4.6",              ""),
-    ("anthropic/claude-sonnet-4.6",            ""),
-    ("moonshotai/kimi-k2.6",                   "recommended"),
-    ("openrouter/pareto-code",                 "auto-routes to cheapest coder meeting openrouter.min_coding_score"),
-    ("qwen/qwen3.6-plus",                      ""),
-    ("anthropic/claude-haiku-4.5",             ""),
-    ("openai/gpt-5.5",                         ""),
-    ("openai/gpt-5.5-pro",                     ""),
-    ("openai/gpt-5.4-mini",                    ""),
-    ("openai/gpt-5.4-nano",                    ""),
-    ("openai/gpt-5.3-codex",                   ""),
-    ("xiaomi/mimo-v2.5-pro",                   ""),
-    ("tencent/hy3-preview",                    ""),
-    ("google/gemini-3-pro-image-preview",      ""),
-    ("google/gemini-3-flash-preview",          ""),
-    ("google/gemini-3.1-pro-preview",          ""),
-    ("google/gemini-3.1-flash-lite-preview",   ""),
-    ("qwen/qwen3.6-35b-a3b",                   ""),
-    ("stepfun/step-3.5-flash",                 ""),
-    ("minimax/minimax-m2.7",                   ""),
-    ("z-ai/glm-5.1",                           ""),
-    ("x-ai/grok-4.20",                         ""),
-    ("x-ai/grok-4.3",                          ""),
-    ("nvidia/nemotron-3-super-120b-a12b",      ""),
-    ("deepseek/deepseek-v4-pro",               ""),
+    ("anthropic/claude-opus-4.7", ""),
+    ("anthropic/claude-opus-4.6", ""),
+    ("anthropic/claude-sonnet-4.6", ""),
+    ("moonshotai/kimi-k2.6", "recommended"),
+    (
+        "openrouter/pareto-code",
+        "auto-routes to cheapest coder meeting openrouter.min_coding_score",
+    ),
+    ("qwen/qwen3.6-plus", ""),
+    ("anthropic/claude-haiku-4.5", ""),
+    ("openai/gpt-5.5", ""),
+    ("openai/gpt-5.5-pro", ""),
+    ("openai/gpt-5.4-mini", ""),
+    ("openai/gpt-5.4-nano", ""),
+    ("openai/gpt-5.3-codex", ""),
+    ("xiaomi/mimo-v2.5-pro", ""),
+    ("tencent/hy3-preview", ""),
+    ("google/gemini-3-pro-image-preview", ""),
+    ("google/gemini-3-flash-preview", ""),
+    ("google/gemini-3.1-pro-preview", ""),
+    ("google/gemini-3.1-flash-lite-preview", ""),
+    ("qwen/qwen3.6-35b-a3b", ""),
+    ("stepfun/step-3.5-flash", ""),
+    ("minimax/minimax-m2.7", ""),
+    ("z-ai/glm-5.1", ""),
+    ("x-ai/grok-4.20", ""),
+    ("x-ai/grok-4.3", ""),
+    ("nvidia/nemotron-3-super-120b-a12b", ""),
+    ("deepseek/deepseek-v4-pro", ""),
     # Free tier
-    ("openrouter/elephant-alpha",              "free"),
-    ("openrouter/owl-alpha",                   "free"),
-    ("tencent/hy3-preview:free",               "free"),
+    ("openrouter/elephant-alpha", "free"),
+    ("openrouter/owl-alpha", "free"),
+    ("tencent/hy3-preview:free", "free"),
     ("nvidia/nemotron-3-super-120b-a12b:free", "free"),
-    ("inclusionai/ring-2.6-1t:free",           "free"),
+    ("inclusionai/ring-2.6-1t:free", "free"),
 ]
 
 _openrouter_catalog_cache: list[tuple[str, str]] | None = None
@@ -74,21 +77,21 @@ _openrouter_catalog_cache: list[tuple[str, str]] | None = None
 # Slugs match Vercel's actual /v1/models catalog (e.g. alibaba/ for Qwen,
 # zai/ and xai/ without hyphens).
 VERCEL_AI_GATEWAY_MODELS: list[tuple[str, str]] = [
-    ("moonshotai/kimi-k2.6",                 "recommended"),
-    ("alibaba/qwen3.6-plus",                 ""),
-    ("zai/glm-5.1",                          ""),
-    ("minimax/minimax-m2.7",                 ""),
-    ("anthropic/claude-sonnet-4.6",          ""),
-    ("anthropic/claude-opus-4.7",            ""),
-    ("anthropic/claude-opus-4.6",            ""),
-    ("anthropic/claude-haiku-4.5",           ""),
-    ("openai/gpt-5.4",                       ""),
-    ("openai/gpt-5.4-mini",                  ""),
-    ("openai/gpt-5.3-codex",                 ""),
-    ("google/gemini-3.1-pro-preview",        ""),
-    ("google/gemini-3-flash",                ""),
+    ("moonshotai/kimi-k2.6", "recommended"),
+    ("alibaba/qwen3.6-plus", ""),
+    ("zai/glm-5.1", ""),
+    ("minimax/minimax-m2.7", ""),
+    ("anthropic/claude-sonnet-4.6", ""),
+    ("anthropic/claude-opus-4.7", ""),
+    ("anthropic/claude-opus-4.6", ""),
+    ("anthropic/claude-haiku-4.5", ""),
+    ("openai/gpt-5.4", ""),
+    ("openai/gpt-5.4-mini", ""),
+    ("openai/gpt-5.3-codex", ""),
+    ("google/gemini-3.1-pro-preview", ""),
+    ("google/gemini-3-flash", ""),
     ("google/gemini-3.1-flash-lite-preview", ""),
-    ("xai/grok-4.20-reasoning",              ""),
+    ("xai/grok-4.20-reasoning", ""),
 ]
 
 _ai_gateway_catalog_cache: list[tuple[str, str]] | None = None
@@ -102,6 +105,7 @@ def _codex_curated_models() -> list[str]:
     flow without maintaining a separate static list.
     """
     from hermes_cli.codex_models import DEFAULT_CODEX_MODELS, _add_forward_compat_models
+
     return _add_forward_compat_models(list(DEFAULT_CODEX_MODELS))
 
 
@@ -146,6 +150,7 @@ def _xai_curated_models() -> list[str]:
     """
     try:
         from agent.models_dev import _load_disk_cache
+
         data = _load_disk_cache()
         xai = data.get("xai") if isinstance(data, dict) else None
         models = xai.get("models") if isinstance(xai, dict) else None
@@ -464,6 +469,17 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "deepseek/deepseek-r1-0528",
         "qwen/qwen3-235b-a22b-fp8",
     ],
+    "litellm": [
+        "opus4.6[1M]",
+        "sonnet4.6[1M]",
+        "claude-opus-4-6@default[1M]",
+        "claude-sonnet-4-6@default[1M]",
+        "opus",
+        "sonnet",
+        "haiku",
+        "gemini-3-flash",
+        "gemini-3.1-pro",
+    ],
 }
 
 # Vercel AI Gateway: derive the bare-model-id catalog from the curated
@@ -495,7 +511,10 @@ def _is_model_free(model_id: str, pricing: dict[str, dict[str, str]]) -> bool:
 # Nous Portal account tier detection
 # ---------------------------------------------------------------------------
 
-def fetch_nous_account_tier(access_token: str, portal_base_url: str = "") -> dict[str, Any]:
+
+def fetch_nous_account_tier(
+    access_token: str, portal_base_url: str = ""
+) -> dict[str, Any]:
     """Fetch the user's Nous Portal account/subscription info.
 
     Calls ``<portal>/api/oauth/account`` with the OAuth access token.
@@ -611,7 +630,9 @@ def union_with_portal_free_recommendations(
     except Exception:
         return (list(curated_ids), dict(pricing))
 
-    free_block = payload.get("freeRecommendedModels") if isinstance(payload, dict) else None
+    free_block = (
+        payload.get("freeRecommendedModels") if isinstance(payload, dict) else None
+    )
     if not isinstance(free_block, list) or not free_block:
         return (list(curated_ids), dict(pricing))
 
@@ -682,7 +703,9 @@ def union_with_portal_paid_recommendations(
     except Exception:
         return (list(curated_ids), dict(pricing))
 
-    paid_block = payload.get("paidRecommendedModels") if isinstance(payload, dict) else None
+    paid_block = (
+        payload.get("paidRecommendedModels") if isinstance(payload, dict) else None
+    )
     if not isinstance(paid_block, list) or not paid_block:
         return (list(curated_ids), dict(pricing))
 
@@ -730,7 +753,10 @@ def check_nous_free_tier() -> bool:
             return cached_result
 
     try:
-        from hermes_cli.auth import get_provider_auth_state, resolve_nous_runtime_credentials
+        from hermes_cli.auth import (
+            get_provider_auth_state,
+            resolve_nous_runtime_credentials,
+        )
 
         # Ensure we have a fresh token (triggers refresh if needed)
         resolve_nous_runtime_credentials(min_key_ttl_seconds=60)
@@ -829,6 +855,7 @@ def _resolve_nous_portal_url() -> str:
             DEFAULT_NOUS_PORTAL_URL,
             get_provider_auth_state,
         )
+
         state = get_provider_auth_state("nous") or {}
         portal = str(state.get("portal_base_url") or "").strip()
         if portal:
@@ -892,7 +919,10 @@ def get_nous_recommended_aux_model(
     if vision:
         paid_key, free_key = "paidRecommendedVisionModel", "freeRecommendedVisionModel"
     else:
-        paid_key, free_key = "paidRecommendedCompactionModel", "freeRecommendedCompactionModel"
+        paid_key, free_key = (
+            "paidRecommendedCompactionModel",
+            "freeRecommendedCompactionModel",
+        )
 
     # Preference order:
     #   free tier  → free only
@@ -916,47 +946,144 @@ def get_nous_recommended_aux_model(
 #   tui_desc    — longer description for the `hermes model` interactive picker
 # ---------------------------------------------------------------------------
 
+
 class ProviderEntry(NamedTuple):
     slug: str
     label: str
-    tui_desc: str   # detailed description for `hermes model` TUI
+    tui_desc: str  # detailed description for `hermes model` TUI
+
 
 CANONICAL_PROVIDERS: list[ProviderEntry] = [
-    ProviderEntry("nous",           "Nous Portal",              "Nous Portal (Nous Research subscription)"),
-    ProviderEntry("openrouter",     "OpenRouter",               "OpenRouter (100+ models, pay-per-use)"),
-    ProviderEntry("novita",         "NovitaAI",                 "NovitaAI (AI-native cloud: Model API, Agent Sandbox, GPU Cloud)"),
-    ProviderEntry("lmstudio",       "LM Studio",                "LM Studio (local desktop app with built-in model server)"),
-    ProviderEntry("anthropic",      "Anthropic",                "Anthropic (Claude models — API key or Claude Code)"),
-    ProviderEntry("openai-codex",   "OpenAI Codex",             "OpenAI Codex"),
-    ProviderEntry("alibaba",        "Qwen Cloud",               "Qwen Cloud / DashScope Coding (Qwen + multi-provider)"),
-    ProviderEntry("xai-oauth",      "xAI Grok OAuth (SuperGrok Subscription)", "xAI Grok OAuth (SuperGrok Subscription)"),
-    ProviderEntry("xiaomi",         "Xiaomi MiMo",              "Xiaomi MiMo (MiMo-V2.5 and V2 models — pro, omni, flash)"),
-    ProviderEntry("tencent-tokenhub", "Tencent TokenHub",       "Tencent TokenHub (Hy3 Preview — direct API via tokenhub.tencentmaas.com)"),
-    ProviderEntry("nvidia",         "NVIDIA NIM",               "NVIDIA NIM (Nemotron models — build.nvidia.com or local NIM)"),
-    ProviderEntry("copilot",        "GitHub Copilot",           "GitHub Copilot (uses GITHUB_TOKEN or gh auth token)"),
-    ProviderEntry("copilot-acp",    "GitHub Copilot ACP",       "GitHub Copilot ACP (spawns `copilot --acp --stdio`)"),
-    ProviderEntry("huggingface",    "Hugging Face",             "Hugging Face Inference Providers (20+ open models)"),
-    ProviderEntry("gemini",         "Google AI Studio",         "Google AI Studio (Gemini models — native Gemini API)"),
-    ProviderEntry("google-gemini-cli", "Google Gemini (OAuth)",   "Google Gemini via OAuth + Code Assist (free tier supported; no API key needed)"),
-    ProviderEntry("deepseek",       "DeepSeek",                 "DeepSeek (DeepSeek-V3, R1, coder — direct API)"),
-    ProviderEntry("xai",            "xAI",                      "xAI (Grok models — direct API)"),
-    ProviderEntry("zai",            "Z.AI / GLM",               "Z.AI / GLM (Zhipu AI direct API)"),
-    ProviderEntry("kimi-coding",    "Kimi / Kimi Coding Plan",  "Kimi Coding Plan (api.kimi.com) & Moonshot API"),
-    ProviderEntry("kimi-coding-cn", "Kimi / Moonshot (China)",  "Kimi / Moonshot China (Moonshot CN direct API)"),
-    ProviderEntry("stepfun",        "StepFun Step Plan",       "StepFun Step Plan (agent/coding models via Step Plan API)"),
-    ProviderEntry("minimax",        "MiniMax",                  "MiniMax (global direct API)"),
-    ProviderEntry("minimax-oauth",  "MiniMax (OAuth)",          "MiniMax via OAuth browser login (Coding Plan, minimax.io)"),
-    ProviderEntry("minimax-cn",     "MiniMax (China)",          "MiniMax China (domestic direct API)"),
-    ProviderEntry("ollama-cloud",   "Ollama Cloud",             "Ollama Cloud (cloud-hosted open models — ollama.com)"),
-    ProviderEntry("arcee",          "Arcee AI",                 "Arcee AI (Trinity models — direct API)"),
-    ProviderEntry("gmi",            "GMI Cloud",                "GMI Cloud (multi-model direct API)"),
-    ProviderEntry("kilocode",       "Kilo Code",                "Kilo Code (Kilo Gateway API)"),
-    ProviderEntry("opencode-zen",   "OpenCode Zen",             "OpenCode Zen (35+ curated models, pay-as-you-go)"),
-    ProviderEntry("opencode-go",    "OpenCode Go",              "OpenCode Go (open models, $10/month subscription)"),
-    ProviderEntry("bedrock",        "AWS Bedrock",              "AWS Bedrock (Claude, Nova, Llama, DeepSeek — IAM or API key)"),
-    ProviderEntry("azure-foundry",  "Azure Foundry",            "Azure Foundry (OpenAI-style or Anthropic-style endpoint — your Azure AI deployment)"),
-    ProviderEntry("ai-gateway",     "Vercel AI Gateway",        "Vercel AI Gateway"),
-    ProviderEntry("qwen-oauth",     "Qwen OAuth (Portal)",      "Qwen OAuth (reuses local Qwen CLI login)"),
+    ProviderEntry("nous", "Nous Portal", "Nous Portal (Nous Research subscription)"),
+    ProviderEntry("openrouter", "OpenRouter", "OpenRouter (100+ models, pay-per-use)"),
+    ProviderEntry(
+        "novita",
+        "NovitaAI",
+        "NovitaAI (AI-native cloud: Model API, Agent Sandbox, GPU Cloud)",
+    ),
+    ProviderEntry(
+        "lmstudio",
+        "LM Studio",
+        "LM Studio (local desktop app with built-in model server)",
+    ),
+    ProviderEntry(
+        "anthropic", "Anthropic", "Anthropic (Claude models — API key or Claude Code)"
+    ),
+    ProviderEntry("openai-codex", "OpenAI Codex", "OpenAI Codex"),
+    ProviderEntry(
+        "alibaba", "Qwen Cloud", "Qwen Cloud / DashScope Coding (Qwen + multi-provider)"
+    ),
+    ProviderEntry(
+        "xai-oauth",
+        "xAI Grok OAuth (SuperGrok Subscription)",
+        "xAI Grok OAuth (SuperGrok Subscription)",
+    ),
+    ProviderEntry(
+        "xiaomi",
+        "Xiaomi MiMo",
+        "Xiaomi MiMo (MiMo-V2.5 and V2 models — pro, omni, flash)",
+    ),
+    ProviderEntry(
+        "tencent-tokenhub",
+        "Tencent TokenHub",
+        "Tencent TokenHub (Hy3 Preview — direct API via tokenhub.tencentmaas.com)",
+    ),
+    ProviderEntry(
+        "nvidia",
+        "NVIDIA NIM",
+        "NVIDIA NIM (Nemotron models — build.nvidia.com or local NIM)",
+    ),
+    ProviderEntry(
+        "copilot",
+        "GitHub Copilot",
+        "GitHub Copilot (uses GITHUB_TOKEN or gh auth token)",
+    ),
+    ProviderEntry(
+        "copilot-acp",
+        "GitHub Copilot ACP",
+        "GitHub Copilot ACP (spawns `copilot --acp --stdio`)",
+    ),
+    ProviderEntry(
+        "huggingface",
+        "Hugging Face",
+        "Hugging Face Inference Providers (20+ open models)",
+    ),
+    ProviderEntry(
+        "gemini",
+        "Google AI Studio",
+        "Google AI Studio (Gemini models — native Gemini API)",
+    ),
+    ProviderEntry(
+        "google-gemini-cli",
+        "Google Gemini (OAuth)",
+        "Google Gemini via OAuth + Code Assist (free tier supported; no API key needed)",
+    ),
+    ProviderEntry(
+        "deepseek", "DeepSeek", "DeepSeek (DeepSeek-V3, R1, coder — direct API)"
+    ),
+    ProviderEntry("xai", "xAI", "xAI (Grok models — direct API)"),
+    ProviderEntry("zai", "Z.AI / GLM", "Z.AI / GLM (Zhipu AI direct API)"),
+    ProviderEntry(
+        "kimi-coding",
+        "Kimi / Kimi Coding Plan",
+        "Kimi Coding Plan (api.kimi.com) & Moonshot API",
+    ),
+    ProviderEntry(
+        "kimi-coding-cn",
+        "Kimi / Moonshot (China)",
+        "Kimi / Moonshot China (Moonshot CN direct API)",
+    ),
+    ProviderEntry(
+        "stepfun",
+        "StepFun Step Plan",
+        "StepFun Step Plan (agent/coding models via Step Plan API)",
+    ),
+    ProviderEntry("minimax", "MiniMax", "MiniMax (global direct API)"),
+    ProviderEntry(
+        "minimax-oauth",
+        "MiniMax (OAuth)",
+        "MiniMax via OAuth browser login (Coding Plan, minimax.io)",
+    ),
+    ProviderEntry(
+        "minimax-cn", "MiniMax (China)", "MiniMax China (domestic direct API)"
+    ),
+    ProviderEntry(
+        "ollama-cloud",
+        "Ollama Cloud",
+        "Ollama Cloud (cloud-hosted open models — ollama.com)",
+    ),
+    ProviderEntry("arcee", "Arcee AI", "Arcee AI (Trinity models — direct API)"),
+    ProviderEntry("gmi", "GMI Cloud", "GMI Cloud (multi-model direct API)"),
+    ProviderEntry("kilocode", "Kilo Code", "Kilo Code (Kilo Gateway API)"),
+    ProviderEntry(
+        "opencode-zen",
+        "OpenCode Zen",
+        "OpenCode Zen (35+ curated models, pay-as-you-go)",
+    ),
+    ProviderEntry(
+        "opencode-go",
+        "OpenCode Go",
+        "OpenCode Go (open models, $10/month subscription)",
+    ),
+    ProviderEntry(
+        "bedrock",
+        "AWS Bedrock",
+        "AWS Bedrock (Claude, Nova, Llama, DeepSeek — IAM or API key)",
+    ),
+    ProviderEntry(
+        "azure-foundry",
+        "Azure Foundry",
+        "Azure Foundry (OpenAI-style or Anthropic-style endpoint — your Azure AI deployment)",
+    ),
+    ProviderEntry("ai-gateway", "Vercel AI Gateway", "Vercel AI Gateway"),
+    ProviderEntry(
+        "qwen-oauth", "Qwen OAuth (Portal)", "Qwen OAuth (reuses local Qwen CLI login)"
+    ),
+    ProviderEntry(
+        "litellm",
+        "LiteLLM",
+        "LiteLLM (self-hosted proxy — Anthropic, OpenAI, Gemini via unified gateway)",
+    ),
 ]
 
 # Auto-extend CANONICAL_PROVIDERS with any provider registered in providers/
@@ -966,10 +1093,17 @@ CANONICAL_PROVIDERS: list[ProviderEntry] = [
 _canonical_slugs = {p.slug for p in CANONICAL_PROVIDERS}
 try:
     from providers import list_providers as _list_providers_for_canonical
+
     for _pp in _list_providers_for_canonical():
         if _pp.name in _canonical_slugs:
             continue
-        if _pp.auth_type in {"oauth_device_code", "oauth_external", "external_process", "aws_sdk", "copilot"}:
+        if _pp.auth_type in {
+            "oauth_device_code",
+            "oauth_external",
+            "external_process",
+            "aws_sdk",
+            "copilot",
+        }:
             continue  # non-api-key flows need bespoke picker UX; skip auto-inject
         _label = _pp.display_name or _pp.name
         _desc = _pp.description or f"{_label} (direct API)"
@@ -1063,6 +1197,8 @@ _PROVIDER_ALIASES = {
     "lm_studio": "lmstudio",
     "ollama": "custom",  # bare "ollama" = local; use "ollama-cloud" for cloud
     "ollama_cloud": "ollama-cloud",
+    "lite-llm": "litellm",
+    "lite_llm": "litellm",
 }
 
 
@@ -1085,7 +1221,10 @@ def _openrouter_model_is_free(pricing: Any) -> bool:
     if not isinstance(pricing, dict):
         return False
     try:
-        return float(pricing.get("prompt", "0")) == 0 and float(pricing.get("completion", "0")) == 0
+        return (
+            float(pricing.get("prompt", "0")) == 0
+            and float(pricing.get("completion", "0")) == 0
+        )
     except (TypeError, ValueError):
         return False
 
@@ -1132,6 +1271,7 @@ def fetch_openrouter_models(
     # free pricing) is applied on top either way.
     try:
         from hermes_cli.model_catalog import get_curated_openrouter_models
+
         remote = get_curated_openrouter_models()
     except Exception:
         remote = None
@@ -1198,6 +1338,7 @@ def get_curated_nous_model_ids() -> list[str]:
     """
     try:
         from hermes_cli.model_catalog import get_curated_nous_models
+
         remote = get_curated_nous_models()
     except Exception:
         remote = None
@@ -1211,7 +1352,10 @@ def _ai_gateway_model_is_free(pricing: Any) -> bool:
     if not isinstance(pricing, dict):
         return False
     try:
-        return float(pricing.get("input", "0")) == 0 and float(pricing.get("output", "0")) == 0
+        return (
+            float(pricing.get("input", "0")) == 0
+            and float(pricing.get("output", "0")) == 0
+        )
     except (TypeError, ValueError):
         return False
 
@@ -1293,8 +1437,6 @@ def ai_gateway_model_ids(*, force_refresh: bool = False) -> list[str]:
     return [mid for mid, _ in fetch_ai_gateway_models(force_refresh=force_refresh)]
 
 
-
-
 # ---------------------------------------------------------------------------
 # Pricing helpers — fetch live pricing from OpenRouter-compatible /v1/models
 # ---------------------------------------------------------------------------
@@ -1365,26 +1507,40 @@ def format_model_pricing_table(
         max((len(r[2]) for r in rows if r[2]), default=4),
         3,  # minimum: "In" / "Out" header
     )
-    cache_col = max(
-        max((len(r[3]) for r in rows if r[3]), default=4),
-        5,  # minimum: "Cache" header
-    ) if has_cache else 0
+    cache_col = (
+        max(
+            max((len(r[3]) for r in rows if r[3]), default=4),
+            5,  # minimum: "Cache" header
+        )
+        if has_cache
+        else 0
+    )
     lines: list[str] = []
 
     # Header
     if has_cache:
-        lines.append(f"{indent}{'Model':<{name_col}} {'In':>{price_col}}  {'Out':>{price_col}}  {'Cache':>{cache_col}}  /Mtok")
-        lines.append(f"{indent}{'-' * name_col} {'-' * price_col}  {'-' * price_col}  {'-' * cache_col}")
+        lines.append(
+            f"{indent}{'Model':<{name_col}} {'In':>{price_col}}  {'Out':>{price_col}}  {'Cache':>{cache_col}}  /Mtok"
+        )
+        lines.append(
+            f"{indent}{'-' * name_col} {'-' * price_col}  {'-' * price_col}  {'-' * cache_col}"
+        )
     else:
-        lines.append(f"{indent}{'Model':<{name_col}} {'In':>{price_col}}  {'Out':>{price_col}}  /Mtok")
+        lines.append(
+            f"{indent}{'Model':<{name_col}} {'In':>{price_col}}  {'Out':>{price_col}}  /Mtok"
+        )
         lines.append(f"{indent}{'-' * name_col} {'-' * price_col}  {'-' * price_col}")
 
     for mid, inp, out, cache, is_cur in rows:
         marker = "  ← current" if is_cur else ""
         if has_cache:
-            lines.append(f"{indent}{mid:<{name_col}} {inp:>{price_col}}  {out:>{price_col}}  {cache:>{cache_col}}{marker}")
+            lines.append(
+                f"{indent}{mid:<{name_col}} {inp:>{price_col}}  {out:>{price_col}}  {cache:>{cache_col}}{marker}"
+            )
         else:
-            lines.append(f"{indent}{mid:<{name_col}} {inp:>{price_col}}  {out:>{price_col}}{marker}")
+            lines.append(
+                f"{indent}{mid:<{name_col}} {inp:>{price_col}}  {out:>{price_col}}{marker}"
+            )
 
     return lines
 
@@ -1512,6 +1668,7 @@ def _resolve_nous_pricing_credentials() -> tuple[str, str]:
     """
     try:
         from hermes_cli.auth import resolve_nous_runtime_credentials
+
         creds = resolve_nous_runtime_credentials()
         if creds:
             return (creds.get("api_key", ""), creds.get("base_url", ""))
@@ -1520,7 +1677,9 @@ def _resolve_nous_pricing_credentials() -> tuple[str, str]:
     return ("", _DEFAULT_NOUS_INFERENCE_BASE)
 
 
-def get_pricing_for_provider(provider: str, *, force_refresh: bool = False) -> dict[str, dict[str, str]]:
+def get_pricing_for_provider(
+    provider: str, *, force_refresh: bool = False
+) -> dict[str, dict[str, str]]:
     """Return live pricing for providers that support it (openrouter, nous, ai-gateway, novita)."""
     normalized = normalize_provider(provider)
     if normalized == "openrouter":
@@ -1568,7 +1727,9 @@ def _fetch_novita_pricing(
     if not api_key:
         return {}
 
-    base_url = os.getenv("NOVITA_BASE_URL", "").strip() or "https://api.novita.ai/openai/v1"
+    base_url = (
+        os.getenv("NOVITA_BASE_URL", "").strip() or "https://api.novita.ai/openai/v1"
+    )
     cache_key = base_url.rstrip("/")
     if not force_refresh and cache_key in _pricing_cache:
         return _pricing_cache[cache_key]
@@ -1641,6 +1802,7 @@ def list_available_providers() -> list[dict[str, str]]:
         has_creds = False
         try:
             from hermes_cli.auth import get_auth_status, has_usable_secret
+
             if pid == "custom":
                 custom_base_url = _get_custom_base_url() or ""
                 has_creds = bool(custom_base_url.strip())
@@ -1651,12 +1813,14 @@ def list_available_providers() -> list[dict[str, str]]:
                 has_creds = bool(status.get("logged_in") or status.get("configured"))
         except Exception:
             pass
-        result.append({
-            "id": pid,
-            "label": label,
-            "aliases": alias_list,
-            "authenticated": has_creds,
-        })
+        result.append(
+            {
+                "id": pid,
+                "label": label,
+                "aliases": alias_list,
+                "authenticated": has_creds,
+            }
+        )
     return result
 
 
@@ -1681,7 +1845,7 @@ def parse_model_input(raw: str, current_provider: str) -> tuple[str, str]:
     colon = stripped.find(":")
     if colon > 0:
         provider_part = stripped[:colon].strip().lower()
-        model_part = stripped[colon + 1:].strip()
+        model_part = stripped[colon + 1 :].strip()
         if provider_part and model_part and provider_part in _KNOWN_PROVIDER_NAMES:
             # Support custom:name:model triple syntax for named custom
             # providers.  ``custom:local:qwen`` → ("custom:local", "qwen").
@@ -1689,7 +1853,7 @@ def parse_model_input(raw: str, current_provider: str) -> tuple[str, str]:
             if provider_part == "custom" and ":" in model_part:
                 second_colon = model_part.find(":")
                 custom_name = model_part[:second_colon].strip()
-                actual_model = model_part[second_colon + 1:].strip()
+                actual_model = model_part[second_colon + 1 :].strip()
                 if custom_name and actual_model:
                     return (f"custom:{custom_name}", actual_model)
             return (normalize_provider(provider_part), model_part)
@@ -1700,6 +1864,7 @@ def _get_custom_base_url() -> str:
     """Get the custom endpoint base_url from config.yaml."""
     try:
         from hermes_cli.config import load_config
+
         config = load_config()
         model_cfg = config.get("model", {})
         if isinstance(model_cfg, dict):
@@ -1775,9 +1940,7 @@ def _resolve_static_model_alias(
         if not models:
             return None
         prefix = (
-            f"{vendor}/{family}"
-            if provider in _AGGREGATOR_PROVIDERS
-            else family
+            f"{vendor}/{family}" if provider in _AGGREGATOR_PROVIDERS else family
         ).lower()
         for model in models:
             if model.lower().startswith(prefix):
@@ -2098,23 +2261,25 @@ def _resolve_copilot_catalog_api_key() -> str:
 # Also excluded: providers that already have dedicated live-endpoint
 # branches below (copilot, anthropic, ai-gateway, ollama-cloud, custom,
 # stepfun, openai-codex) — those paths handle freshness themselves.
-_MODELS_DEV_PREFERRED: frozenset[str] = frozenset({
-    "opencode-go",
-    "opencode-zen",
-    "deepseek",
-    "kilocode",
-    "fireworks",
-    "mistral",
-    "togetherai",
-    "cohere",
-    "perplexity",
-    "groq",
-    "nvidia",
-    "huggingface",
-    "zai",
-    "gemini",
-    "google",
-})
+_MODELS_DEV_PREFERRED: frozenset[str] = frozenset(
+    {
+        "opencode-go",
+        "opencode-zen",
+        "deepseek",
+        "kilocode",
+        "fireworks",
+        "mistral",
+        "togetherai",
+        "cohere",
+        "perplexity",
+        "groq",
+        "nvidia",
+        "huggingface",
+        "zai",
+        "gemini",
+        "google",
+    }
+)
 
 
 def _merge_with_models_dev(provider: str, curated: list[str]) -> list[str]:
@@ -2129,6 +2294,7 @@ def _merge_with_models_dev(provider: str, curated: list[str]) -> list[str]:
     """
     try:
         from agent.models_dev import list_agentic_models
+
         mdev = list_agentic_models(provider)
     except Exception:
         mdev = []
@@ -2154,7 +2320,9 @@ def _merge_with_models_dev(provider: str, curated: list[str]) -> list[str]:
     return merged
 
 
-def provider_model_ids(provider: Optional[str], *, force_refresh: bool = False) -> list[str]:
+def provider_model_ids(
+    provider: Optional[str], *, force_refresh: bool = False
+) -> list[str]:
     """Return the best known model catalog for a provider.
 
     Tries live API endpoints for providers that support them (Codex, Nous),
@@ -2196,10 +2364,17 @@ def provider_model_ids(provider: Optional[str], *, force_refresh: bool = False) 
     if normalized == "nous":
         # Try live Nous Portal /models endpoint
         try:
-            from hermes_cli.auth import fetch_nous_models, resolve_nous_runtime_credentials
+            from hermes_cli.auth import (
+                fetch_nous_models,
+                resolve_nous_runtime_credentials,
+            )
+
             creds = resolve_nous_runtime_credentials()
             if creds:
-                live = fetch_nous_models(api_key=creds.get("api_key", ""), inference_base_url=creds.get("base_url", ""))
+                live = fetch_nous_models(
+                    api_key=creds.get("api_key", ""),
+                    inference_base_url=creds.get("base_url", ""),
+                )
                 if live:
                     return live
         except Exception:
@@ -2272,6 +2447,7 @@ def provider_model_ids(provider: Optional[str], *, force_refresh: bool = False) 
     if normalized == "bedrock":
         try:
             from agent.bedrock_adapter import bedrock_model_ids_or_none
+
             ids = bedrock_model_ids_or_none()
             if ids is not None:
                 return ids
@@ -2330,7 +2506,12 @@ def _fetch_anthropic_models(timeout: float = 5.0) -> Optional[list[str]]:
     is_oauth = _is_oauth_token(token)
     if is_oauth:
         headers["Authorization"] = f"Bearer {token}"
-        from agent.anthropic_adapter import _COMMON_BETAS, _OAUTH_ONLY_BETAS, _CONTEXT_1M_BETA
+        from agent.anthropic_adapter import (
+            _COMMON_BETAS,
+            _OAUTH_ONLY_BETAS,
+            _CONTEXT_1M_BETA,
+        )
+
         headers["anthropic-beta"] = ",".join(_COMMON_BETAS + _OAUTH_ONLY_BETAS)
     else:
         headers["x-api-key"] = token
@@ -2351,15 +2532,15 @@ def _fetch_anthropic_models(timeout: float = 5.0) -> Optional[list[str]]:
             # context beta with 400 "long context beta is not yet available
             # for this subscription". Retry once without the beta; re-raise
             # anything else so the outer except logs it.
-            if (
-                is_oauth
-                and http_err.code == 400
-            ):
+            if is_oauth and http_err.code == 400:
                 try:
                     body_text = http_err.read().decode(errors="ignore").lower()
                 except Exception:
                     body_text = ""
-                if "long context beta" in body_text and "not yet available" in body_text:
+                if (
+                    "long context beta" in body_text
+                    and "not yet available" in body_text
+                ):
                     headers["anthropic-beta"] = ",".join(
                         [b for b in _COMMON_BETAS if b != _CONTEXT_1M_BETA]
                         + list(_OAUTH_ONLY_BETAS)
@@ -2371,14 +2552,18 @@ def _fetch_anthropic_models(timeout: float = 5.0) -> Optional[list[str]]:
                 raise
         models = [m["id"] for m in data.get("data", []) if m.get("id")]
         # Sort: latest/largest first (opus > sonnet > haiku, higher version first)
-        return sorted(models, key=lambda m: (
-            "opus" not in m,      # opus first
-            "sonnet" not in m,    # then sonnet
-            "haiku" not in m,     # then haiku
-            m,                    # alphabetical within tier
-        ))
+        return sorted(
+            models,
+            key=lambda m: (
+                "opus" not in m,  # opus first
+                "sonnet" not in m,  # then sonnet
+                "haiku" not in m,  # then haiku
+                m,  # alphabetical within tier
+            ),
+        )
     except Exception as e:
         import logging
+
         logging.getLogger(__name__).debug("Failed to fetch Anthropic models: %s", e)
         return None
 
@@ -2401,6 +2586,7 @@ def copilot_default_headers() -> dict[str, str]:
     """
     try:
         from hermes_cli.copilot_auth import copilot_request_headers
+
         return copilot_request_headers(is_agent_turn=True)
     except ImportError:
         return {
@@ -2446,10 +2632,12 @@ def fetch_github_model_catalog(
     """Fetch the live GitHub Copilot model catalog for this account."""
     attempts: list[dict[str, str]] = []
     if api_key:
-        attempts.append({
-            **copilot_default_headers(),
-            "Authorization": f"Bearer {api_key}",
-        })
+        attempts.append(
+            {
+                **copilot_default_headers(),
+                "Authorization": f"Bearer {api_key}",
+            }
+        )
     attempts.append(copilot_default_headers())
 
     for headers in attempts:
@@ -2483,7 +2671,9 @@ _copilot_context_cache_time: float = 0.0
 _COPILOT_CONTEXT_CACHE_TTL = 3600  # 1 hour
 
 
-def get_copilot_model_context(model_id: str, api_key: Optional[str] = None) -> Optional[int]:
+def get_copilot_model_context(
+    model_id: str, api_key: Optional[str] = None
+) -> Optional[int]:
     """Look up max_prompt_tokens for a Copilot model from the live /models API.
 
     Results are cached in-process for 1 hour to avoid repeated API calls.
@@ -2492,7 +2682,9 @@ def get_copilot_model_context(model_id: str, api_key: Optional[str] = None) -> O
     global _copilot_context_cache, _copilot_context_cache_time
 
     # Serve from cache if fresh
-    if _copilot_context_cache and (time.time() - _copilot_context_cache_time < _COPILOT_CONTEXT_CACHE_TTL):
+    if _copilot_context_cache and (
+        time.time() - _copilot_context_cache_time < _COPILOT_CONTEXT_CACHE_TTL
+    ):
         if model_id in _copilot_context_cache:
             return _copilot_context_cache[model_id]
         # Cache is fresh but model not in it — don't re-fetch
@@ -2571,26 +2763,34 @@ def _lmstudio_fetch_raw_models(
     except urllib.error.HTTPError as exc:
         if exc.code in {401, 403}:
             from hermes_cli.auth import AuthError
+
             raise AuthError(
                 f"LM Studio rejected the request with HTTP {exc.code}.",
                 provider="lmstudio",
                 code="auth_rejected",
             ) from exc
         import logging
+
         logging.getLogger(__name__).debug(
-            "LM Studio probe at %s failed with HTTP %s", server_root, exc.code,
+            "LM Studio probe at %s failed with HTTP %s",
+            server_root,
+            exc.code,
         )
         return None
     except Exception as exc:
         import logging
+
         logging.getLogger(__name__).debug(
-            "LM Studio probe at %s failed: %s", server_root, exc,
+            "LM Studio probe at %s failed: %s",
+            server_root,
+            exc,
         )
         return None
 
     raw_models = payload.get("models") if isinstance(payload, dict) else None
     if not isinstance(raw_models, list):
         import logging
+
         logging.getLogger(__name__).debug(
             "LM Studio probe at %s returned malformed payload (no `models` list)",
             server_root,
@@ -2614,7 +2814,9 @@ def probe_lmstudio_models(
     Raises ``AuthError`` on HTTP 401/403 so callers can surface token issues
     separately from reachability problems.
     """
-    raw_models = _lmstudio_fetch_raw_models(api_key=api_key, base_url=base_url, timeout=timeout)
+    raw_models = _lmstudio_fetch_raw_models(
+        api_key=api_key, base_url=base_url, timeout=timeout
+    )
     if raw_models is None:
         return None
 
@@ -2670,7 +2872,9 @@ def ensure_lmstudio_model_loaded(
     headers = _lmstudio_request_headers(api_key)
 
     try:
-        raw_models = _lmstudio_fetch_raw_models(api_key=api_key, base_url=base_url, timeout=10)
+        raw_models = _lmstudio_fetch_raw_models(
+            api_key=api_key, base_url=base_url, timeout=10
+        )
     except Exception:
         raw_models = None
     if raw_models is None:
@@ -2696,10 +2900,12 @@ def ensure_lmstudio_model_loaded(
         if isinstance(loaded_ctx, int) and loaded_ctx >= target_context_length:
             return loaded_ctx
 
-    body = json.dumps({
-        "model": model,
-        "context_length": target_context_length,
-    }).encode()
+    body = json.dumps(
+        {
+            "model": model,
+            "context_length": target_context_length,
+        }
+    ).encode()
     load_headers = dict(headers)
     load_headers["Content-Type"] = "application/json"
     try:
@@ -2731,7 +2937,9 @@ def lmstudio_model_reasoning_options(
     or the model does not declare a reasoning capability.
     """
     try:
-        raw_models = _lmstudio_fetch_raw_models(api_key=api_key, base_url=base_url, timeout=timeout)
+        raw_models = _lmstudio_fetch_raw_models(
+            api_key=api_key, base_url=base_url, timeout=timeout
+        )
     except Exception:
         raw_models = None
     if not raw_models:
@@ -2751,7 +2959,9 @@ def lmstudio_model_reasoning_options(
     return []
 
 
-def _fetch_github_models(api_key: Optional[str] = None, timeout: float = 5.0) -> Optional[list[str]]:
+def _fetch_github_models(
+    api_key: Optional[str] = None, timeout: float = 5.0
+) -> Optional[list[str]]:
     catalog = fetch_github_model_catalog(api_key=api_key, timeout=timeout)
     if not catalog:
         return None
@@ -2907,7 +3117,9 @@ def copilot_model_api_mode(
 
     # Secondary: check catalog for non-GPT-5 models (Claude via /v1/messages, etc.)
     if catalog:
-        catalog_entry = next((item for item in catalog if item.get("id") == normalized), None)
+        catalog_entry = next(
+            (item for item in catalog if item.get("id") == normalized), None
+        )
         if isinstance(catalog_entry, dict):
             supported_endpoints = {
                 str(endpoint).strip()
@@ -2915,7 +3127,10 @@ def copilot_model_api_mode(
                 if str(endpoint).strip()
             }
             # For non-GPT-5 models, check if they only support messages API
-            if "/v1/messages" in supported_endpoints and "/chat/completions" not in supported_endpoints:
+            if (
+                "/v1/messages" in supported_endpoints
+                and "/chat/completions" not in supported_endpoints
+            ):
                 return "anthropic_messages"
 
     return "chat_completions"
@@ -2930,11 +3145,11 @@ def copilot_model_api_mode(
 # ``gpt-5.4``, ``o1-preview``) but tight enough to leave GPT-4 / 3.5 / Llama /
 # Mistral / Grok deployments on chat completions.
 _AZURE_FOUNDRY_RESPONSES_PREFIXES = (
-    "codex",       # codex-*, codex-mini
-    "gpt-5",       # gpt-5, gpt-5.x, gpt-5-codex, gpt-5.x-codex
-    "o1",          # o1, o1-preview, o1-mini
-    "o3",          # o3, o3-mini
-    "o4",          # o4, o4-mini
+    "codex",  # codex-*, codex-mini
+    "gpt-5",  # gpt-5, gpt-5.x, gpt-5-codex, gpt-5.x-codex
+    "o1",  # o1, o1-preview, o1-mini
+    "o3",  # o3, o3-mini
+    "o4",  # o4, o4-mini
 )
 
 
@@ -2967,7 +3182,9 @@ def azure_foundry_model_api_mode(model_name: Optional[str]) -> Optional[str]:
     return None
 
 
-def normalize_opencode_model_id(provider_id: Optional[str], model_id: Optional[str]) -> str:
+def normalize_opencode_model_id(
+    provider_id: Optional[str], model_id: Optional[str]
+) -> str:
     """Normalize OpenCode config IDs to the bare model slug used in API requests."""
     provider = normalize_provider(provider_id)
     current = str(model_id or "").strip()
@@ -2976,7 +3193,7 @@ def normalize_opencode_model_id(provider_id: Optional[str], model_id: Optional[s
 
     prefix = f"{provider}/"
     if current.lower().startswith(prefix):
-        return current[len(prefix):]
+        return current[len(prefix) :]
     return current
 
 
@@ -3027,11 +3244,15 @@ def github_model_reasoning_efforts(
 
     catalog_entry = None
     if catalog is not None:
-        catalog_entry = next((item for item in catalog if item.get("id") == normalized), None)
+        catalog_entry = next(
+            (item for item in catalog if item.get("id") == normalized), None
+        )
     elif api_key:
         fetched_catalog = fetch_github_model_catalog(api_key=api_key)
         if fetched_catalog:
-            catalog_entry = next((item for item in fetched_catalog if item.get("id") == normalized), None)
+            catalog_entry = next(
+                (item for item in fetched_catalog if item.get("id") == normalized), None
+            )
 
     if catalog_entry is not None:
         capabilities = catalog_entry.get("capabilities")
@@ -3121,7 +3342,11 @@ def probe_api_models(
                     "models": [m.get("id", "") for m in data.get("data", [])],
                     "probed_url": url,
                     "resolved_base_url": candidate_base.rstrip("/"),
-                    "suggested_base_url": alternate_base if alternate_base != candidate_base else normalized,
+                    "suggested_base_url": (
+                        alternate_base
+                        if alternate_base != candidate_base
+                        else normalized
+                    ),
                     "used_fallback": is_fallback,
                 }
         except Exception:
@@ -3144,6 +3369,7 @@ def _fetch_ai_gateway_models(timeout: float = 5.0) -> Optional[list[str]]:
     base_url = os.getenv("AI_GATEWAY_BASE_URL", "").strip()
     if not base_url:
         from hermes_constants import AI_GATEWAY_BASE_URL
+
         base_url = AI_GATEWAY_BASE_URL
 
     url = base_url.rstrip("/") + "/models"
@@ -3177,13 +3403,14 @@ def fetch_api_models(
     Returns a list of model ID strings, or ``None`` if the endpoint could not
     be reached (network error, timeout, auth failure, etc.).
     """
-    return probe_api_models(api_key, base_url, timeout=timeout, api_mode=api_mode).get("models")
+    return probe_api_models(api_key, base_url, timeout=timeout, api_mode=api_mode).get(
+        "models"
+    )
 
 
 # ---------------------------------------------------------------------------
 # Ollama Cloud — merged model discovery with disk cache
 # ---------------------------------------------------------------------------
-
 
 
 _OLLAMA_CLOUD_CACHE_TTL = 3600  # 1 hour
@@ -3205,6 +3432,7 @@ def _strip_ollama_cloud_suffix(model_id: str) -> str:
 def _ollama_cloud_cache_path() -> Path:
     """Return the path for the Ollama Cloud model cache."""
     from hermes_constants import get_hermes_home
+
     return get_hermes_home() / "ollama_cloud_models_cache.json"
 
 
@@ -3239,9 +3467,12 @@ def _save_ollama_cloud_cache(models: list[str]) -> None:
     """Persist the merged Ollama Cloud model list to disk."""
     try:
         from utils import atomic_json_write
+
         cache_path = _ollama_cloud_cache_path()
         cache_path.parent.mkdir(parents=True, exist_ok=True)
-        atomic_json_write(cache_path, {"models": models, "cached_at": time.time()}, indent=None)
+        atomic_json_write(
+            cache_path, {"models": models, "cached_at": time.time()}, indent=None
+        )
     except Exception:
         pass
 
@@ -3284,6 +3515,7 @@ def fetch_ollama_cloud_models(
     mdev_models: list[str] = []
     try:
         from agent.models_dev import list_agentic_models
+
         mdev_models = list_agentic_models("ollama-cloud")
     except Exception:
         pass
@@ -3339,10 +3571,13 @@ def validate_requested_model(
         normalized = "custom"
     requested_for_lookup = requested
     if normalized == "copilot":
-        requested_for_lookup = normalize_copilot_model_id(
-            requested,
-            api_key=api_key,
-        ) or requested
+        requested_for_lookup = (
+            normalize_copilot_model_id(
+                requested,
+                api_key=api_key,
+            )
+            or requested
+        )
 
     if not requested:
         return {
@@ -3362,6 +3597,7 @@ def validate_requested_model(
 
     if normalized == "lmstudio":
         from hermes_cli.auth import AuthError
+
         # Use probe_lmstudio_models so we can distinguish None (unreachable
         # / malformed response) from [] (reachable, but no chat-capable models
         # are loaded). fetch_lmstudio_models collapses both to [].
@@ -3369,28 +3605,41 @@ def validate_requested_model(
             models = probe_lmstudio_models(api_key=api_key, base_url=base_url)
         except AuthError as exc:
             return {
-                "accepted": False, "persist": False, "recognized": False,
+                "accepted": False,
+                "persist": False,
+                "recognized": False,
                 "message": (
                     f"{exc} Set `LM_API_KEY` (or update it) to match the server's bearer token."
                 ),
             }
         if models is None:
             return {
-                "accepted": False, "persist": False, "recognized": False,
+                "accepted": False,
+                "persist": False,
+                "recognized": False,
                 "message": f"Could not reach LM Studio's `/api/v1/models` to validate `{requested}`.",
             }
         if not models:
             return {
-                "accepted": False, "persist": False, "recognized": False,
+                "accepted": False,
+                "persist": False,
+                "recognized": False,
                 "message": (
                     f"LM Studio is reachable but no chat-capable models are loaded. "
                     f"Load `{requested}` in LM Studio (Developer tab → Load Model) and try again."
                 ),
             }
         if requested_for_lookup in set(models):
-            return {"accepted": True, "persist": True, "recognized": True, "message": None}
+            return {
+                "accepted": True,
+                "persist": True,
+                "recognized": True,
+                "message": None,
+            }
         return {
-            "accepted": False, "persist": False, "recognized": False,
+            "accepted": False,
+            "persist": False,
+            "recognized": False,
             "message": f"Model `{requested}` was not found in LM Studio's model listing.",
         }
 
@@ -3424,7 +3673,9 @@ def validate_requested_model(
             suggestions = get_close_matches(requested, api_models, n=3, cutoff=0.5)
             suggestion_text = ""
             if suggestions:
-                suggestion_text = "\n  Similar models: " + ", ".join(f"`{s}`" for s in suggestions)
+                suggestion_text = "\n  Similar models: " + ", ".join(
+                    f"`{s}`" for s in suggestions
+                )
 
             message = (
                 f"Note: `{requested}` was not found in this custom endpoint's model listing "
@@ -3478,7 +3729,9 @@ def validate_requested_model(
                     "message": None,
                 }
             # Auto-correct if the top match is very similar (e.g. typo)
-            auto = get_close_matches(requested_for_lookup, catalog_models, n=1, cutoff=0.9)
+            auto = get_close_matches(
+                requested_for_lookup, catalog_models, n=1, cutoff=0.9
+            )
             if auto:
                 return {
                     "accepted": True,
@@ -3487,11 +3740,19 @@ def validate_requested_model(
                     "corrected_model": auto[0],
                     "message": f"Auto-corrected `{requested}` → `{auto[0]}`",
                 }
-            suggestions = get_close_matches(requested_for_lookup, catalog_models, n=3, cutoff=0.5)
+            suggestions = get_close_matches(
+                requested_for_lookup, catalog_models, n=3, cutoff=0.5
+            )
             suggestion_text = ""
             if suggestions:
-                suggestion_text = "\n  Similar models: " + ", ".join(f"`{s}`" for s in suggestions)
-            provider_label = "OpenAI Codex" if normalized == "openai-codex" else "xAI Grok OAuth (SuperGrok Subscription)"
+                suggestion_text = "\n  Similar models: " + ", ".join(
+                    f"`{s}`" for s in suggestions
+                )
+            provider_label = (
+                "OpenAI Codex"
+                if normalized == "openai-codex"
+                else "xAI Grok OAuth (SuperGrok Subscription)"
+            )
             return {
                 "accepted": True,
                 "persist": True,
@@ -3522,7 +3783,9 @@ def validate_requested_model(
                 }
             # Auto-correct close matches (case-insensitive)
             catalog_lower_list = list(catalog_lower.keys())
-            auto = get_close_matches(requested_for_lookup.lower(), catalog_lower_list, n=1, cutoff=0.9)
+            auto = get_close_matches(
+                requested_for_lookup.lower(), catalog_lower_list, n=1, cutoff=0.9
+            )
             if auto:
                 corrected = catalog_lower[auto[0]]
                 return {
@@ -3532,10 +3795,14 @@ def validate_requested_model(
                     "corrected_model": corrected,
                     "message": f"Auto-corrected `{requested}` → `{corrected}`",
                 }
-            suggestions = get_close_matches(requested_for_lookup.lower(), catalog_lower_list, n=3, cutoff=0.5)
+            suggestions = get_close_matches(
+                requested_for_lookup.lower(), catalog_lower_list, n=3, cutoff=0.5
+            )
             suggestion_text = ""
             if suggestions:
-                suggestion_text = "\n  Similar models: " + ", ".join(f"`{catalog_lower[s]}`" for s in suggestions)
+                suggestion_text = "\n  Similar models: " + ", ".join(
+                    f"`{catalog_lower[s]}`" for s in suggestions
+                )
             return {
                 "accepted": True,
                 "persist": True,
@@ -3564,7 +3831,9 @@ def validate_requested_model(
                     "recognized": True,
                     "message": None,
                 }
-            auto = get_close_matches(requested_for_lookup, anthropic_models, n=1, cutoff=0.9)
+            auto = get_close_matches(
+                requested_for_lookup, anthropic_models, n=1, cutoff=0.9
+            )
             if auto:
                 return {
                     "accepted": True,
@@ -3573,10 +3842,14 @@ def validate_requested_model(
                     "corrected_model": auto[0],
                     "message": f"Auto-corrected `{requested}` → `{auto[0]}`",
                 }
-            suggestions = get_close_matches(requested, anthropic_models, n=3, cutoff=0.5)
+            suggestions = get_close_matches(
+                requested, anthropic_models, n=3, cutoff=0.5
+            )
             suggestion_text = ""
             if suggestions:
-                suggestion_text = "\n  Similar models: " + ", ".join(f"`{s}`" for s in suggestions)
+                suggestion_text = "\n  Similar models: " + ", ".join(
+                    f"`{s}`" for s in suggestions
+                )
             # Accept anyway — Anthropic sometimes gates newer/preview models
             # (e.g. snapshot IDs, early-access releases) behind accounts
             # even though they aren't listed on /v1/models.
@@ -3639,7 +3912,11 @@ def validate_requested_model(
         # Gemini model.  Strip the prefix before comparison.  See #12532.
         if normalized == "gemini":
             api_models = [
-                m[len("models/"):] if isinstance(m, str) and m.startswith("models/") else m
+                (
+                    m[len("models/") :]
+                    if isinstance(m, str) and m.startswith("models/")
+                    else m
+                )
                 for m in api_models
             ]
         if requested_for_lookup in set(api_models):
@@ -3670,7 +3947,9 @@ def validate_requested_model(
             suggestions = get_close_matches(requested, api_models, n=3, cutoff=0.5)
             suggestion_text = ""
             if suggestions:
-                suggestion_text = "\n  Similar models: " + ", ".join(f"`{s}`" for s in suggestions)
+                suggestion_text = "\n  Similar models: " + ", ".join(
+                    f"`{s}`" for s in suggestions
+                )
 
         return {
             "accepted": False,
@@ -3690,7 +3969,11 @@ def validate_requested_model(
     # AWS SDK control plane (ListFoundationModels + ListInferenceProfiles).
     if normalized == "bedrock":
         try:
-            from agent.bedrock_adapter import discover_bedrock_models, resolve_bedrock_region
+            from agent.bedrock_adapter import (
+                discover_bedrock_models,
+                resolve_bedrock_region,
+            )
+
             region = resolve_bedrock_region()
             discovered = discover_bedrock_models(region)
             discovered_ids = {m["id"] for m in discovered}
@@ -3703,10 +3986,14 @@ def validate_requested_model(
                 }
             # Not in discovered list — still accept (user may have custom
             # inference profiles or cross-account access), but warn.
-            suggestions = get_close_matches(requested, list(discovered_ids), n=3, cutoff=0.4)
+            suggestions = get_close_matches(
+                requested, list(discovered_ids), n=3, cutoff=0.4
+            )
             suggestion_text = ""
             if suggestions:
-                suggestion_text = "\n  Similar models: " + ", ".join(f"`{s}`" for s in suggestions)
+                suggestion_text = "\n  Similar models: " + ", ".join(
+                    f"`{s}`" for s in suggestions
+                )
             return {
                 "accepted": True,
                 "persist": True,

--- a/tests/agent/test_prompt_caching_pi_dual.py
+++ b/tests/agent/test_prompt_caching_pi_dual.py
@@ -1,0 +1,287 @@
+"""Tests for pi_dual prompt caching strategy."""
+
+import copy
+import pytest
+
+from agent.prompt_caching import apply_anthropic_cache_control
+
+
+MARKER_5M = {"type": "ephemeral"}
+MARKER_1H = {"type": "ephemeral", "ttl": "1h"}
+
+
+def _has_cache_control(msg_or_block):
+    """Check if a message or content block has cache_control."""
+    if isinstance(msg_or_block, dict):
+        if "cache_control" in msg_or_block:
+            return True
+        content = msg_or_block.get("content")
+        if isinstance(content, list):
+            return any("cache_control" in b for b in content if isinstance(b, dict))
+    return False
+
+
+def _get_cache_marker(msg):
+    """Extract the cache_control marker from a message."""
+    if "cache_control" in msg:
+        return msg["cache_control"]
+    content = msg.get("content")
+    if isinstance(content, list):
+        for block in content:
+            if isinstance(block, dict) and "cache_control" in block:
+                return block["cache_control"]
+    return None
+
+
+class TestPiDualMarksCorrectMessages:
+    def test_marks_system_assistant_tool_use_and_user(self):
+        messages = [
+            {"role": "system", "content": "SYSTEM"},
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "text", "text": "thinking"},
+                    {
+                        "type": "tool_use",
+                        "id": "toolu_1",
+                        "name": "read_file",
+                        "input": {"path": "x"},
+                    },
+                ],
+            },
+            {"role": "tool", "tool_use_id": "toolu_1", "content": "RESULT"},
+            {"role": "user", "content": "next"},
+        ]
+        result = apply_anthropic_cache_control(
+            messages, strategy="pi_dual", native_anthropic=True
+        )
+
+        # System marked
+        assert _has_cache_control(result[0])
+        # Assistant tool_use block marked (not the text block)
+        ast_content = result[1]["content"]
+        assert "cache_control" not in ast_content[0]  # text block unmarked
+        assert ast_content[1].get("cache_control") == MARKER_5M  # tool_use marked
+        # Tool message NOT marked
+        assert not _has_cache_control(result[2])
+        # User marked
+        assert _has_cache_control(result[3])
+
+    def test_no_tool_use_still_marks_system_and_user(self):
+        messages = [
+            {"role": "system", "content": "SYSTEM"},
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "hi there"},
+            {"role": "user", "content": "thanks"},
+        ]
+        result = apply_anthropic_cache_control(
+            messages, strategy="pi_dual", native_anthropic=True
+        )
+
+        assert _has_cache_control(result[0])  # system
+        assert not _has_cache_control(result[1])  # first user
+        assert not _has_cache_control(result[2])  # assistant (no tool_use)
+        assert _has_cache_control(result[3])  # last user
+
+
+class TestPiDualNeverMarksToolMessages:
+    def test_tool_messages_never_get_cache_control(self):
+        messages = [
+            {"role": "system", "content": "SYSTEM"},
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "tool_use", "id": "t1", "name": "exec", "input": {}},
+                    {"type": "tool_use", "id": "t2", "name": "read", "input": {}},
+                ],
+            },
+            {"role": "tool", "tool_use_id": "t1", "content": "output1"},
+            {"role": "tool", "tool_use_id": "t2", "content": "output2"},
+            {"role": "user", "content": "continue"},
+        ]
+        result = apply_anthropic_cache_control(
+            messages, strategy="pi_dual", native_anthropic=True
+        )
+
+        assert not _has_cache_control(result[2])
+        assert not _has_cache_control(result[3])
+
+
+class TestPiDualTTL:
+    def test_1h_ttl_marker(self):
+        messages = [
+            {"role": "system", "content": "SYSTEM"},
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "tool_use", "id": "t1", "name": "read", "input": {}},
+                ],
+            },
+            {"role": "tool", "tool_use_id": "t1", "content": "data"},
+            {"role": "user", "content": "next"},
+        ]
+        result = apply_anthropic_cache_control(
+            messages, cache_ttl="1h", native_anthropic=True, strategy="pi_dual"
+        )
+
+        sys_marker = _get_cache_marker(result[0])
+        assert sys_marker == MARKER_1H
+        tool_use_marker = result[1]["content"][0].get("cache_control")
+        assert tool_use_marker == MARKER_1H
+        user_marker = _get_cache_marker(result[3])
+        assert user_marker == MARKER_1H
+
+
+class TestPiDualFallback:
+    def test_non_native_falls_back_to_system_and_3(self):
+        """When native_anthropic=False, pi_dual falls back to system_and_3."""
+        messages = [
+            {"role": "system", "content": "System"},
+            {"role": "user", "content": "msg1"},
+            {"role": "assistant", "content": "msg2"},
+            {"role": "user", "content": "msg3"},
+            {"role": "assistant", "content": "msg4"},
+        ]
+        pi_result = apply_anthropic_cache_control(
+            messages, native_anthropic=False, strategy="pi_dual"
+        )
+        sys3_result = apply_anthropic_cache_control(
+            messages, native_anthropic=False, strategy="system_and_3"
+        )
+        assert pi_result == sys3_result
+
+    def test_invalid_strategy_defaults_to_system_and_3(self):
+        messages = [
+            {"role": "system", "content": "System"},
+            {"role": "user", "content": "hello"},
+        ]
+        bad_result = apply_anthropic_cache_control(messages, strategy="nonexistent")
+        default_result = apply_anthropic_cache_control(
+            messages, strategy="system_and_3"
+        )
+        assert bad_result == default_result
+
+
+class TestPiDualEdgeCases:
+    def test_empty_messages(self):
+        result = apply_anthropic_cache_control(
+            [], strategy="pi_dual", native_anthropic=True
+        )
+        assert result == []
+
+    def test_deep_copy_preserves_original(self):
+        messages = [
+            {"role": "system", "content": "SYSTEM"},
+            {"role": "user", "content": "hello"},
+        ]
+        original = copy.deepcopy(messages)
+        apply_anthropic_cache_control(
+            messages, strategy="pi_dual", native_anthropic=True
+        )
+        assert messages == original
+
+    def test_multiple_assistant_tool_use_marks_last_one(self):
+        messages = [
+            {"role": "system", "content": "SYSTEM"},
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "tool_use", "id": "t1", "name": "first", "input": {}},
+                ],
+            },
+            {"role": "tool", "tool_use_id": "t1", "content": "r1"},
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "tool_use", "id": "t2", "name": "second", "input": {}},
+                ],
+            },
+            {"role": "tool", "tool_use_id": "t2", "content": "r2"},
+            {"role": "user", "content": "done"},
+        ]
+        result = apply_anthropic_cache_control(
+            messages, strategy="pi_dual", native_anthropic=True
+        )
+
+        # First assistant tool_use should NOT be marked
+        assert "cache_control" not in result[1]["content"][0]
+        # Second (last) assistant tool_use SHOULD be marked
+        assert result[3]["content"][0].get("cache_control") == MARKER_5M
+
+    def test_assistant_with_multiple_tool_use_marks_last_block(self):
+        messages = [
+            {"role": "system", "content": "SYSTEM"},
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "tool_use", "id": "t1", "name": "first", "input": {}},
+                    {"type": "text", "text": "middle"},
+                    {"type": "tool_use", "id": "t2", "name": "second", "input": {}},
+                ],
+            },
+            {"role": "tool", "tool_use_id": "t1", "content": "r1"},
+            {"role": "tool", "tool_use_id": "t2", "content": "r2"},
+            {"role": "user", "content": "next"},
+        ]
+        result = apply_anthropic_cache_control(
+            messages, strategy="pi_dual", native_anthropic=True
+        )
+
+        ast_content = result[1]["content"]
+        assert "cache_control" not in ast_content[0]  # first tool_use
+        assert "cache_control" not in ast_content[1]  # text
+        assert ast_content[2].get("cache_control") == MARKER_5M  # last tool_use
+
+    def test_max_3_breakpoints(self):
+        """pi_dual should use at most 3 breakpoints: system + tool_use + user."""
+        messages = [
+            {"role": "system", "content": "SYSTEM"},
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "tool_use", "id": "t1", "name": "read", "input": {}},
+                ],
+            },
+            {"role": "tool", "tool_use_id": "t1", "content": "data"},
+            {"role": "user", "content": "next"},
+        ]
+        result = apply_anthropic_cache_control(
+            messages, strategy="pi_dual", native_anthropic=True
+        )
+
+        count = 0
+        for msg in result:
+            content = msg.get("content")
+            if isinstance(content, list):
+                for item in content:
+                    if isinstance(item, dict) and "cache_control" in item:
+                        count += 1
+            if "cache_control" in msg:
+                count += 1
+        assert count == 3
+
+
+class TestSystemAnd3Unchanged:
+    """Verify system_and_3 behavior is identical to the original implementation."""
+
+    def test_system_and_3_still_works(self):
+        messages = [
+            {"role": "system", "content": "System"},
+            {"role": "user", "content": "msg1"},
+            {"role": "assistant", "content": "msg2"},
+            {"role": "user", "content": "msg3"},
+            {"role": "assistant", "content": "msg4"},
+        ]
+        result = apply_anthropic_cache_control(messages, strategy="system_and_3")
+        # System + last 3 non-system = 4 breakpoints
+        count = 0
+        for msg in result:
+            if _has_cache_control(msg):
+                count += 1
+        assert count == 4
+
+    def test_default_strategy_is_system_and_3(self):
+        messages = [{"role": "system", "content": "System"}]
+        explicit = apply_anthropic_cache_control(messages, strategy="system_and_3")
+        default = apply_anthropic_cache_control(messages)
+        assert explicit == default

--- a/tests/run_agent/test_anthropic_prompt_cache_policy.py
+++ b/tests/run_agent/test_anthropic_prompt_cache_policy.py
@@ -87,7 +87,9 @@ class TestThirdPartyAnthropicGateway:
         )
         should, native = agent._anthropic_prompt_cache_policy()
         assert should is True, "Third-party Anthropic gateway with Claude must cache"
-        assert native is True, "Third-party Anthropic gateway uses native cache_control layout"
+        assert (
+            native is True
+        ), "Third-party Anthropic gateway uses native cache_control layout"
 
     def test_third_party_anthropic_non_claude_unknown_provider_does_not_cache(self):
         # A provider exposing e.g. GLM via anthropic_messages transport from
@@ -326,7 +328,64 @@ class TestExplicitOverrides:
         assert (should, native) == (True, False)
 
 
+class TestLiteLLMProvider:
+    """LiteLLM proxy with Anthropic Messages transport — cache-capable for Claude aliases."""
+
+    def test_litellm_opus_alias_caches_with_native_layout(self):
+        agent = _make_agent(
+            provider="litellm",
+            base_url="http://10.71.1.33:4000/v1",
+            api_mode="anthropic_messages",
+            model="opus4.6[1M]",
+        )
+        assert agent._anthropic_prompt_cache_policy() == (True, True)
+
+    def test_litellm_sonnet_alias_caches(self):
+        agent = _make_agent(
+            provider="litellm",
+            base_url="http://example.test/v1",
+            api_mode="anthropic_messages",
+            model="sonnet4.6[1M]",
+        )
+        assert agent._anthropic_prompt_cache_policy() == (True, True)
+
+    def test_litellm_claude_full_id_caches(self):
+        agent = _make_agent(
+            provider="litellm",
+            base_url="http://example.test/v1",
+            api_mode="anthropic_messages",
+            model="claude-opus-4-6@default[1M]",
+        )
+        assert agent._anthropic_prompt_cache_policy() == (True, True)
+
+    def test_litellm_haiku_caches(self):
+        agent = _make_agent(
+            provider="litellm",
+            base_url="http://example.test/v1",
+            api_mode="anthropic_messages",
+            model="haiku",
+        )
+        assert agent._anthropic_prompt_cache_policy() == (True, True)
+
+    def test_litellm_gemini_on_anthropic_wire_does_not_cache(self):
+        agent = _make_agent(
+            provider="litellm",
+            base_url="http://example.test/v1",
+            api_mode="anthropic_messages",
+            model="gemini-3-flash",
+        )
+        assert agent._anthropic_prompt_cache_policy() == (False, False)
+
+    def test_litellm_on_chat_completions_does_not_cache(self):
+        agent = _make_agent(
+            provider="litellm",
+            base_url="http://example.test/v1",
+            api_mode="chat_completions",
+            model="opus4.6[1M]",
+        )
+        assert agent._anthropic_prompt_cache_policy() == (False, False)
+
+
 # ─────────────────────────────────────────────────────────────────────
 # Long-lived prefix cache policy (cross-session 1h tier)
 # ─────────────────────────────────────────────────────────────────────
-


### PR DESCRIPTION
## Summary

- **LiteLLM model picker support**: LiteLLM appears as a selectable provider in `/model` with cached Claude aliases (`opus4.6[1M]`, `sonnet4.6[1M]`, etc.) and Gemini models. Registered in CANONICAL_PROVIDERS, PROVIDER_REGISTRY, and the prompt cache policy.
- **`pi_dual` cache strategy**: New configurable prompt caching strategy (`prompt_caching.strategy: pi_dual` in config.yaml) that places 3 targeted breakpoints — system prompt, last assistant `tool_use` block, and last user message — while never marking `role: tool` messages. Inspired by PI/OpenClaw's cache extension behavior.
- **Default behavior unchanged**: `system_and_3` remains the default. `pi_dual` falls back to `system_and_3` on non-native (OpenRouter) transport to avoid regressions.

## Why

Rico's LiteLLM proxy exposes cached Opus/Sonnet 1M aliases that work well in OpenClaw. Hermes could call them manually, but the model picker didn't expose LiteLLM cleanly, and Hermes' existing prompt cache strategy didn't match the PI dual-breakpoint strategy that avoids stale tool-result caching while preserving cache efficiency.

`*-nocache` aliases are intentionally not shown — they are slow and cause excessive tool recalls.

## Changes

| File | What |
|------|------|
| `hermes_cli/models.py` | LiteLLM in CANONICAL_PROVIDERS, _PROVIDER_MODELS (9 models), _PROVIDER_ALIASES |
| `hermes_cli/auth.py` | PROVIDER_REGISTRY entry (LITELLM_API_KEY, LITELLM_BASE_URL) |
| `agent/agent_runtime_helpers.py` | Cache policy recognizes `litellm` + `anthropic_messages` + Claude aliases |
| `agent/prompt_caching.py` | Added `strategy` param, `_apply_pi_dual` implementation |
| `agent/agent_init.py` | Reads `prompt_caching.strategy` from config |
| `agent/conversation_loop.py` | Passes strategy to cache function |

## Config

```yaml
providers:
  litellm:
    label: LiteLLM
    base_url: http://your-proxy:4000/v1
    api_key: ${LITELLM_API_KEY}
    api_mode: anthropic_messages

prompt_caching:
  cache_ttl: 5m
  strategy: pi_dual
```

## Important: LiteLLM proxy caching != provider prompt caching

LiteLLM's response/semantic cache (`/docs/proxy/caching`) is NOT the same as provider prompt caching (`/docs/completion/prompt_caching`). This PR targets provider prompt caching only — cache_control breakpoints sent to Anthropic/OpenAI/Gemini through LiteLLM. Do not rely on LiteLLM response cache for main agent turns.

## Test plan

- [x] 6 new LiteLLM cache policy tests (opus alias, sonnet, full ID, haiku, gemini negative, chat_completions negative)
- [x] 13 new pi_dual strategy tests (correct marks, tool exclusion, TTL, fallback, edge cases, breakpoint count)
- [x] 14 existing prompt caching tests pass unchanged
- [x] 242 broader test suite (hermes_cli + run_agent) passes

```
python -m pytest tests/agent/test_prompt_caching.py tests/agent/test_prompt_caching_pi_dual.py tests/run_agent/test_anthropic_prompt_cache_policy.py -q
# 57 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)