### PR TITLE
fix: wire STT lazy-install into transcription_tools.py

### DIFF
--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -197,6 +197,26 @@ def _normalize_local_command_model(model_name: Optional[str]) -> str:
     return _normalize_local_model(model_name)
 
 
+def _try_lazy_install_stt() -> bool:
+    """Attempt to lazy-install faster-whisper and return True on success.
+
+    The module-level ``_HAS_FASTER_WHISPER`` flag is set at import time and
+    cached. If the package wasn't installed at startup, calling ``ensure()``
+    installs it. This function re-checks dynamically after installation so
+    the provider can use it immediately without a process restart.
+    """
+    try:
+        from tools.lazy_deps import ensure
+        ensure("stt.faster_whisper")
+        # Re-check dynamically after install
+        import importlib.util as _iu
+        if _iu.find_spec("faster_whisper"):
+            return True
+    except Exception:
+        pass
+    return False
+
+
 def _get_provider(stt_config: dict) -> str:
     """Determine which STT provider to use.
 
@@ -218,6 +238,9 @@ def _get_provider(stt_config: dict) -> str:
                 return "local"
             if _has_local_command():
                 return "local_command"
+            # Try lazy-install before giving up
+            if _try_lazy_install_stt():
+                return "local"
             logger.warning(
                 "STT provider 'local' configured but unavailable "
                 "(install faster-whisper or set HERMES_LOCAL_STT_COMMAND)"
@@ -285,6 +308,9 @@ def _get_provider(stt_config: dict) -> str:
         return "local"
     if _has_local_command():
         return "local_command"
+    # Try lazy-install before falling through to cloud providers
+    if _try_lazy_install_stt():
+        return "local"
     if _HAS_OPENAI and get_env_value("GROQ_API_KEY"):
         logger.info("No local STT available, using Groq Whisper API")
         return "groq"
@@ -403,7 +429,8 @@ def _transcribe_local(file_path: str, model_name: str) -> Dict[str, Any]:
     global _local_model, _local_model_name
 
     if not _HAS_FASTER_WHISPER:
-        return {"success": False, "transcript": "", "error": "faster-whisper not installed"}
+        if not _try_lazy_install_stt():
+            return {"success": False, "transcript": "", "error": "faster-whisper not installed"}
 
     try:
         # Lazy-load the model (downloads on first use, ~150 MB for 'base')


### PR DESCRIPTION
## Problem

The `ensure("stt.faster_whisper")` lazy-install mechanism was defined in `lazy_deps.py` but never called from the STT code path in `transcription_tools.py`. When `_HAS_FASTER_WHISPER` (a module-level constant) evaluated to `False` at import time — which happens on every fresh container build or venv recreation — `_get_provider()` returned `"none"` immediately without attempting installation.

**User-visible symptom:** Voice message auto-transcription breaks silently after `docker compose pull && up`. The config is correct (`stt.provider: local`, `stt.local.model: base.en`), but the gateway logs: `STT provider local configured but unavailable (install faster-whisper...)` and voice messages are dropped with "no STT provider is configured".

## Fix

Add a `_try_lazy_install_stt()` helper that calls `ensure("stt.faster_whisper")` and re-checks dynamically via `importlib.util.find_spec` (since the module-level constant is already cached). Wire it into all three gates in `transcription_tools.py`:

- `_get_provider()` explicit `"local"` path — tries lazy-install before logging warning + returning `"none"`
- `_get_provider()` auto-detect path — tries lazy-install before falling through to cloud providers
- `_transcribe_local()` guard — tries lazy-install before returning error

## Testing

- [ ] Fresh venv without faster-whisper: send voice message → lazy-install fires, transcription works on first attempt
- [ ] Existing venv with faster-whisper: no change in behavior (already-True path unchanged)
- [ ] Offline/restricted environment: lazy-install fails gracefully, logs warning, returns `"none"` (no crash)