### PR TITLE
fix(packaging): include plugin dashboard assets in wheel

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,9 +20,32 @@ def _data_file_tree(root_name: str) -> list[tuple[str, list[str]]]:
     return sorted(grouped.items())
 
 
+def _plugin_dashboard_data_files() -> list[tuple[str, list[str]]]:
+    """Collect non-Python dashboard plugin assets for wheel inclusion.
+
+    Discovers any ``plugins/<name>/dashboard/`` directory with non-Python
+    assets (``manifest.json``, ``dist/`` bundles, etc.) — no need to
+    enumerate plugin names manually.  ``.py`` files are excluded because
+    setuptools package discovery handles them.
+    """
+    grouped: defaultdict[str, list[str]] = defaultdict(list)
+    for dashboard_dir in sorted(REPO_ROOT.glob("plugins/*/dashboard")):
+        if not dashboard_dir.is_dir():
+            continue
+        for path in sorted(dashboard_dir.rglob("*")):
+            if not path.is_file():
+                continue
+            if path.suffix == ".py":
+                continue
+            rel_path = path.relative_to(REPO_ROOT)
+            grouped[str(rel_path.parent)].append(str(rel_path))
+    return sorted(grouped.items())
+
+
 setup(
     data_files=[
         *_data_file_tree("skills"),
         *_data_file_tree("optional-skills"),
+        *_plugin_dashboard_data_files(),
     ]
 )


### PR DESCRIPTION
## Description

manifest.json and dist/ bundles for kanban, achievements, and
example-dashboard plugins were missing from the installed wheel,
causing the dashboard plugin loader to silently skip them.

Fixes #30010
Related: #28609

## Changes

- `setup.py`: added `_plugin_dashboard_data_files()` helper that collects non-Python dashboard assets (manifest.json, dist/index.js, dist/style.css) from plugin dashboard directories, excluding .py files already handled by setuptools package discovery.