### PR TITLE
fix(auxiliary): support gemini cli compression provider

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -962,6 +962,39 @@ class AsyncCodexAuxiliaryClient:
         self._real_client = sync_wrapper._real_client
 
 
+class _AsyncGeminiCloudCodeCompletionsAdapter:
+    """Async facade for Gemini Cloud Code's sync chat adapter."""
+
+    def __init__(self, sync_adapter: Any):
+        self._sync = sync_adapter
+
+    async def create(self, **kwargs) -> Any:
+        import asyncio
+        return await asyncio.to_thread(self._sync.create, **kwargs)
+
+
+class _AsyncGeminiCloudCodeChatShim:
+    def __init__(self, adapter: _AsyncGeminiCloudCodeCompletionsAdapter):
+        self.completions = adapter
+
+
+class AsyncGeminiCloudCodeAuxiliaryClient:
+    """Async-compatible wrapper for GeminiCloudCodeClient."""
+
+    def __init__(self, sync_wrapper: Any):
+        sync_adapter = sync_wrapper.chat.completions
+        async_adapter = _AsyncGeminiCloudCodeCompletionsAdapter(sync_adapter)
+        self.chat = _AsyncGeminiCloudCodeChatShim(async_adapter)
+        self.api_key = sync_wrapper.api_key
+        self.base_url = sync_wrapper.base_url
+        self._real_client = sync_wrapper
+
+    def close(self):
+        close_fn = getattr(self._real_client, "close", None)
+        if callable(close_fn):
+            close_fn()
+
+
 class _AnthropicCompletionsAdapter:
     """OpenAI-client-compatible adapter for Anthropic Messages API."""
 
@@ -3013,6 +3046,13 @@ def _to_async_client(sync_client, model: str, is_vision: bool = False):
     except ImportError:
         pass
     try:
+        from agent.gemini_cloudcode_adapter import GeminiCloudCodeClient
+
+        if isinstance(sync_client, GeminiCloudCodeClient):
+            return AsyncGeminiCloudCodeAuxiliaryClient(sync_client), model
+    except ImportError:
+        pass
+    try:
         from agent.copilot_acp_client import CopilotACPClient
         if isinstance(sync_client, CopilotACPClient):
             return sync_client, model
@@ -3244,6 +3284,40 @@ def resolve_provider_client(
                            "but no Codex OAuth token found (run: hermes model)")
             return None, None
         final_model = _normalize_resolved_model(model or default, provider)
+        return (_to_async_client(client, final_model, is_vision=is_vision) if async_mode
+                else (client, final_model))
+
+    # ── Google Gemini CLI OAuth (Cloud Code Assist API) ────────────────
+    if provider == "google-gemini-cli":
+        try:
+            from agent.gemini_cloudcode_adapter import GeminiCloudCodeClient
+            from hermes_cli.auth import AuthError, resolve_gemini_oauth_runtime_credentials
+        except ImportError as exc:
+            logger.warning(
+                "resolve_provider_client: google-gemini-cli requested but "
+                "Gemini OAuth support is unavailable: %s",
+                exc,
+            )
+            return None, None
+        try:
+            creds = resolve_gemini_oauth_runtime_credentials()
+        except AuthError as exc:
+            logger.warning(
+                "resolve_provider_client: google-gemini-cli requested but "
+                "Gemini OAuth credentials are unavailable: %s",
+                exc,
+            )
+            return None, None
+        final_model = _normalize_resolved_model(
+            model or (main_runtime.get("model") if main_runtime else None) or _read_main_model() or "gemini-3-flash-preview",
+            provider,
+        ) or "gemini-3-flash-preview"
+        client = GeminiCloudCodeClient(
+            api_key=str(creds.get("api_key") or "google-oauth"),
+            base_url=str(creds.get("base_url") or "cloudcode-pa://google"),
+            project_id=str(creds.get("project_id") or ""),
+        )
+        logger.debug("resolve_provider_client: %s (%s)", provider, final_model)
         return (_to_async_client(client, final_model, is_vision=is_vision) if async_mode
                 else (client, final_model))
 

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -28,6 +28,7 @@ from agent.auxiliary_client import (
     _resolve_auto,
     _resolve_xai_oauth_for_aux,
     _CodexCompletionsAdapter,
+    AsyncGeminiCloudCodeAuxiliaryClient,
 )
 
 
@@ -82,6 +83,68 @@ class TestNormalizeAuxProvider:
     def test_maps_github_copilot_acp_aliases(self):
         assert _normalize_aux_provider("github-copilot-acp") == "copilot-acp"
         assert _normalize_aux_provider("copilot-acp-agent") == "copilot-acp"
+
+
+class TestGeminiCloudCodeAuxiliaryProvider:
+    class _FakeCloudCodeClient:
+        def __init__(self, *, api_key=None, base_url=None, project_id="", **_kwargs):
+            self.api_key = api_key
+            self.base_url = base_url
+            self.project_id = project_id
+            self.chat = SimpleNamespace(
+                completions=SimpleNamespace(create=lambda **_call_kwargs: SimpleNamespace(choices=[]))
+            )
+
+        def close(self):
+            pass
+
+    def test_resolves_google_gemini_cli_oauth_client(self, monkeypatch):
+        monkeypatch.setattr(
+            "hermes_cli.auth.resolve_gemini_oauth_runtime_credentials",
+            lambda: {
+                "api_key": "google-access-token",
+                "base_url": "cloudcode-pa://google",
+                "project_id": "project-123",
+            },
+        )
+        monkeypatch.setattr(
+            "agent.gemini_cloudcode_adapter.GeminiCloudCodeClient",
+            self._FakeCloudCodeClient,
+        )
+
+        client, model = resolve_provider_client(
+            "google-gemini-cli",
+            "gemini-3-flash-preview",
+        )
+
+        assert isinstance(client, self._FakeCloudCodeClient)
+        assert model == "gemini-3-flash-preview"
+        assert client.base_url == "cloudcode-pa://google"
+        assert client.project_id == "project-123"
+
+    def test_resolves_async_google_gemini_cli_oauth_client(self, monkeypatch):
+        monkeypatch.setattr(
+            "hermes_cli.auth.resolve_gemini_oauth_runtime_credentials",
+            lambda: {
+                "api_key": "google-access-token",
+                "base_url": "cloudcode-pa://google",
+                "project_id": "project-123",
+            },
+        )
+        monkeypatch.setattr(
+            "agent.gemini_cloudcode_adapter.GeminiCloudCodeClient",
+            self._FakeCloudCodeClient,
+        )
+
+        client, model = resolve_provider_client(
+            "google-gemini-cli",
+            "gemini-3-flash-preview",
+            async_mode=True,
+        )
+
+        assert isinstance(client, AsyncGeminiCloudCodeAuxiliaryClient)
+        assert model == "gemini-3-flash-preview"
+        assert client.base_url == "cloudcode-pa://google"
 
 
 class TestReadCodexAccessToken:


### PR DESCRIPTION
## Summary
- Add direct google-gemini-cli auxiliary provider routing.
- Wrap GeminiCloudCodeClient for async auxiliary compression calls.
- Add sync and async provider resolution tests.

## Test plan
- `python -m pytest tests/agent/test_auxiliary_client.py -q`
- `python -m pytest tests/run_agent/test_compression_feasibility.py tests/run_agent/test_compression_boundary.py -q`
- `python -m ruff check agent/auxiliary_client.py tests/agent/test_auxiliary_client.py`
- `python -m py_compile agent/auxiliary_client.py tests/agent/test_auxiliary_client.py`

Local commit: `9a34f481b`
