### PR TITLE
fix(tui): keep /model visible in slash completion until args are typed

### DIFF
--- a/ui-tui/src/__tests__/useCompletion.test.ts
+++ b/ui-tui/src/__tests__/useCompletion.test.ts
@@ -32,4 +32,28 @@ describe('completionRequestForInput', () => {
   it('leaves plain text alone', () => {
     expect(completionRequestForInput('hello there')).toBeNull()
   })
+
+  it('returns slash completion for bare /model (so the entry stays visible)', () => {
+    expect(completionRequestForInput('/model')).toMatchObject({
+      method: 'complete.slash',
+      params: { text: '/model' },
+      replaceFrom: 1
+    })
+  })
+
+  it('returns slash completion for partial /mode prefix', () => {
+    expect(completionRequestForInput('/mode')).toMatchObject({
+      method: 'complete.slash',
+      params: { text: '/mode' },
+      replaceFrom: 1
+    })
+  })
+
+  it('defers to the ModelPicker once /model has args (trailing space)', () => {
+    expect(completionRequestForInput('/model ')).toBeNull()
+  })
+
+  it('defers to the ModelPicker once /model has a value', () => {
+    expect(completionRequestForInput('/model gpt-4')).toBeNull()
+  })
 })

--- a/ui-tui/src/hooks/useCompletion.ts
+++ b/ui-tui/src/hooks/useCompletion.ts
@@ -23,7 +23,7 @@ export function completionRequestForInput(
 
   // `/model` uses the two-step ModelPicker (real curated IDs).
   // Slash completion here only showed short aliases + vendor/family meta.
-  if (isSlashCommand && /^\/model(?:\s|$)/.test(input)) {
+  if (isSlashCommand && /^\/model\s/.test(input)) {
     return null
   }
 


### PR DESCRIPTION
## Summary

Fixes #30029. In the TUI, slash command completion can desync after overtype + backspace: typing `/model `, then backspacing back to `/model`, made the `/model` entry vanish from the slash selector. The same shape applies to any character composed past `/model` and then deleted.

## Root cause

`completionRequestForInput` in `ui-tui/src/hooks/useCompletion.ts` hands off to the two-step ModelPicker when the user enters the `/model` command:

```ts
if (isSlashCommand && /^\/model(?:\s|$)/.test(input)) {
  return null
}
```

The intent was: once the user has committed to `/model` and is composing args, suppress the short-alias slash list and let `ModelPicker` take over.

But the regex `/^\/model(?:\s|$)/` also matches the bare `/model` token (no trailing whitespace). So while *typing* `/m → /mo → /model` the request returned `null` at exactly the moment input became `/model` — and the same happens when *backspacing* from `/model foo` back to `/model`. The slash selector cleared its `completions`, so `/model` appeared to "disappear".

## Fix

Require whitespace after `/model` before deferring to the picker. Bare `/model` is now returned as a normal slash completion, so it remains visible/selectable in the selector. The ModelPicker hand-off still fires the instant the user types the space.

```ts
if (isSlashCommand && /^\/model\s/.test(input)) {
  return null
}
```

One-line behavior change; the original intent (no short-alias list while composing model args) is preserved.

## Test Plan

- [x] `cd ui-tui && npm test -- useCompletion --run` — 8 tests pass (4 existing + 4 new).
- [x] New tests cover:
  - `/model` (bare) → slash completion (not null)
  - `/mode` (partial) → slash completion
  - `/model ` (trailing space) → null (defer to ModelPicker)
  - `/model gpt-4` → null (defer to ModelPicker)
- [x] Repro from the issue: type `/foo`, space, backspace — slash matches remain visible. Type `/model`, space, backspace — `/model` stays in the selector.

## Notes

Pre-existing TypeScript errors in `packages/hermes-ink/src/utils/execFileNoThrow.ts` are unrelated to this change.

Closes #30029
