### PR TITLE
feat(cron): support prompt_file field for loading cron job prompts from disk

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -954,6 +954,54 @@ def _parse_wake_gate(script_output: str) -> bool:
     return gate.get("wakeAgent", True) is not False
 
 
+def _load_prompt_file(prompt_file: str) -> str:
+    """Load a cron job prompt from an external file.
+
+    Relative paths are resolved against ``HERMES_HOME/cron-jobs/``.
+    Absolute and ``~``-prefixed paths are validated to stay within that
+    directory (same path-traversal guard as ``_run_job_script``).
+
+    Args:
+        prompt_file: Path to the prompt file.
+
+    Returns:
+        The file contents as a string, or an error message prefixed with
+        ``[Prompt File Error]`` so the LLM can report it to the user.
+    """
+    prompts_dir = _get_hermes_home() / "cron-jobs"
+    prompts_dir.mkdir(parents=True, exist_ok=True)
+    prompts_dir_resolved = prompts_dir.resolve()
+
+    raw = Path(prompt_file).expanduser()
+    if raw.is_absolute():
+        path = raw.resolve()
+    else:
+        path = (prompts_dir / raw).resolve()
+
+    # Guard against path traversal
+    try:
+        path.relative_to(prompts_dir_resolved)
+    except ValueError:
+        return (
+            "[Prompt File Error] The prompt_file path is outside the "
+            "allowed directory. Paths must resolve within "
+            f"{prompts_dir_resolved}. Got: {prompt_file}"
+        )
+
+    if not path.is_file():
+        return (
+            f"[Prompt File Error] The prompt_file was not found or is not "
+            f"a regular file: {path}"
+        )
+
+    try:
+        return path.read_text(encoding="utf-8").strip()
+    except (OSError, PermissionError) as e:
+        return (
+            f"[Prompt File Error] Failed to read prompt_file at {path}: {e}"
+        )
+
+
 def _build_job_prompt(job: dict, prerun_script: Optional[tuple] = None) -> str:
     """Build the effective prompt for a cron job, optionally loading one or more skills first.
 
@@ -966,6 +1014,11 @@ def _build_job_prompt(job: dict, prerun_script: Optional[tuple] = None) -> str:
             (if any) runs inline as before.
     """
     prompt = str(job.get("prompt") or "")
+    # If prompt_file is set, load prompt from the external file.
+    # If both prompt and prompt_file are set, prompt_file wins.
+    prompt_file = job.get("prompt_file")
+    if prompt_file:
+        prompt = _load_prompt_file(prompt_file)
     skills = job.get("skills")
 
     # Run data-collection script if configured, inject output as context.

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -7,7 +7,7 @@ from unittest.mock import AsyncMock, patch, MagicMock
 
 import pytest
 
-from cron.scheduler import _resolve_origin, _resolve_delivery_target, _deliver_result, _send_media_via_adapter, run_job, SILENT_MARKER, _build_job_prompt
+from cron.scheduler import _resolve_origin, _resolve_delivery_target, _deliver_result, _send_media_via_adapter, run_job, SILENT_MARKER, _build_job_prompt, _load_prompt_file
 from tools.env_passthrough import clear_env_passthrough
 from tools.credential_files import clear_credential_files
 
@@ -2548,3 +2548,77 @@ class TestSendMediaTimeoutCancelsFuture:
         # 2. Second file still got dispatched — one timeout doesn't abort the batch
         adapter.send_video.assert_called_once()
         assert adapter.send_video.call_args[1]["video_path"] == str(fast.resolve())
+
+
+class TestLoadPromptFile:
+    """Tests for _load_prompt_file() — resolution, traversal guards, error handling."""
+
+    def test_load_from_relative_path(self, tmp_path):
+        prompt_file = tmp_path / "cron-jobs" / "my-prompt.md"
+        prompt_file.parent.mkdir(parents=True)
+        prompt_file.write_text("Hello from file", encoding="utf-8")
+
+        with patch("cron.scheduler._get_hermes_home", return_value=tmp_path):
+            result = _load_prompt_file("my-prompt.md")
+
+        assert result == "Hello from file"
+
+    def test_load_from_absolute_path_within_allowed(self, tmp_path):
+        prompt_file = tmp_path / "cron-jobs" / "sub" / "prompt.txt"
+        prompt_file.parent.mkdir(parents=True)
+        prompt_file.write_text("absolute path", encoding="utf-8")
+
+        with patch("cron.scheduler._get_hermes_home", return_value=tmp_path):
+            result = _load_prompt_file(str(prompt_file))
+
+        assert result == "absolute path"
+
+    def test_path_traversal_rejected(self, tmp_path):
+        outside = tmp_path / "secret.txt"
+        outside.write_text("leaked", encoding="utf-8")
+
+        with patch("cron.scheduler._get_hermes_home", return_value=tmp_path):
+            result = _load_prompt_file("../secret.txt")
+
+        assert result.startswith("[Prompt File Error]")
+        assert "outside the allowed directory" in result
+
+    def test_absolute_path_traversal_rejected(self, tmp_path):
+        outside = tmp_path / "outside.txt"
+        outside.write_text("leaked", encoding="utf-8")
+
+        with patch("cron.scheduler._get_hermes_home", return_value=tmp_path):
+            result = _load_prompt_file(str(outside))
+
+        assert result.startswith("[Prompt File Error]")
+        assert "outside the allowed directory" in result
+
+    def test_missing_file_returns_error(self, tmp_path):
+        with patch("cron.scheduler._get_hermes_home", return_value=tmp_path):
+            result = _load_prompt_file("nonexistent.md")
+
+        assert result.startswith("[Prompt File Error]")
+        assert "not found" in result
+
+    def test_prompt_file_wins_over_inline_prompt(self, tmp_path):
+        """When both prompt and prompt_file are set, prompt_file wins."""
+        prompt_file = tmp_path / "cron-jobs" / "from-file.md"
+        prompt_file.parent.mkdir(parents=True)
+        prompt_file.write_text("file content", encoding="utf-8")
+
+        job = {
+            "prompt": "inline content",
+            "prompt_file": "from-file.md",
+        }
+
+        with patch("cron.scheduler._get_hermes_home", return_value=tmp_path):
+            result = _build_job_prompt(job)
+
+        assert "file content" in result
+        assert "inline content" not in result
+
+    def test_inline_prompt_used_when_no_prompt_file(self):
+        """When prompt_file is not set, inline prompt is used as before."""
+        job = {"prompt": "inline content"}
+        result = _build_job_prompt(job)
+        assert "inline content" in result


### PR DESCRIPTION
## Description

Adds a `prompt_file` field on cron job dicts, parallel to the existing `script` field. When set, the prompt is loaded from the specified file instead of the inline `prompt` string. If both `prompt` and `prompt_file` are set, `prompt_file` wins.

Relative paths resolve against `HERMES_HOME/cron-jobs/`. Path traversal is prevented with the same guard as `_run_job_script`.

This is step 1 from the proposal in #30020 — the minimal ~50-line change that unblocks per-job folder conventions without changing existing behavior.

## Changes

- `cron/scheduler.py`: added `_load_prompt_file()` helper that resolves, validates, and reads prompt files from `HERMES_HOME/cron-jobs/`, with path-traversal guards mirroring `_run_job_script`.
- Modified `_build_job_prompt()` to check for `prompt_file` first and load from file instead of the inline prompt field.

Refs #30020