### PR TITLE
test(tui): expect gc flag in Termux argv

### DIFF
--- a/tests/hermes_cli/test_tui_npm_install.py
+++ b/tests/hermes_cli/test_tui_npm_install.py
@@ -168,7 +168,7 @@ def test_make_tui_argv_skips_build_only_on_termux_when_fresh(
 
     argv, cwd = main_mod._make_tui_argv(tmp_path, tui_dev=False)
 
-    assert argv == ["/bin/node", str(tmp_path / "dist" / "entry.js")]
+    assert argv == ["/bin/node", "--expose-gc", str(tmp_path / "dist" / "entry.js")]
     assert cwd == tmp_path
 
 


### PR DESCRIPTION
## Summary
- update the Termux fresh-bundle TUI argv test to expect the current direct Node --expose-gc flag
- keeps the test aligned with the existing _make_tui_argv() launch behavior

## Verification
- /usr/local/lib/hermes-agent/venv/bin/pytest -q -o addopts="" tests/hermes_cli/test_tui_npm_install.py::test_make_tui_argv_skips_build_only_on_termux_when_fresh tests/hermes_cli/test_tui_npm_install.py::test_make_tui_argv_keeps_desktop_always_build_behaviour
- result: 2 passed