### PR TITLE
fix(agent): correct model when runtime provider auto-resolves to a different backend

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1473,6 +1473,7 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
         from hermes_cli.runtime_provider import (
             resolve_runtime_provider,
             format_runtime_provider_error,
+            model_for_runtime_provider,
         )
         from hermes_cli.auth import AuthError
         try:
@@ -1512,6 +1513,21 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
         except Exception as exc:
             message = format_runtime_provider_error(exc)
             raise RuntimeError(message) from exc
+
+        # Correct the model when the resolved provider differs from the
+        # configured model.provider. resolve_runtime_provider() returns
+        # credentials but no model, and `model` above is config model.default
+        # — when stale Codex auth makes auto-detect fall through to xai-oauth,
+        # pairing gpt-5.5 with xai-oauth 404s on every primary call before
+        # falling back. See model_for_runtime_provider() for the rationale.
+        _corrected_model = model_for_runtime_provider(runtime.get("provider"), config=_cfg)
+        if _corrected_model and _corrected_model != model:
+            logger.info(
+                "Job '%s': resolved provider '%s' does not match configured "
+                "model '%s' — using '%s' for that provider",
+                job_id, runtime.get("provider"), model, _corrected_model,
+            )
+            model = _corrected_model
 
         fallback_model = _cfg.get("fallback_providers") or _cfg.get("fallback_model") or None
         credential_pool = None

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -853,6 +853,7 @@ def _resolve_runtime_agent_kwargs() -> dict:
     from hermes_cli.runtime_provider import (
         resolve_runtime_provider,
         format_runtime_provider_error,
+        model_for_runtime_provider,
     )
     from hermes_cli.auth import AuthError
 
@@ -871,7 +872,7 @@ def _resolve_runtime_agent_kwargs() -> dict:
     except Exception as exc:
         raise RuntimeError(format_runtime_provider_error(exc)) from exc
 
-    return {
+    resolved = {
         "api_key": runtime.get("api_key"),
         "base_url": runtime.get("base_url"),
         "provider": runtime.get("provider"),
@@ -880,6 +881,18 @@ def _resolve_runtime_agent_kwargs() -> dict:
         "args": list(runtime.get("args") or []),
         "credential_pool": runtime.get("credential_pool"),
     }
+    # When the runtime auto-resolves a provider that differs from the
+    # configured model.provider (e.g. Codex auth is stale so auto-detect
+    # falls through to xai-oauth), the configured model.default belongs to
+    # the WRONG provider. resolve_runtime_provider() returns credentials but
+    # no model, so the caller pairs the resolved provider with the stale
+    # config model — every primary call then 404s ("model gpt-5.5 does not
+    # exist" on api.x.ai) before falling back. Attach a model the resolved
+    # provider actually serves so the primary call is consistent.
+    corrected_model = model_for_runtime_provider(runtime.get("provider"))
+    if corrected_model:
+        resolved["model"] = corrected_model
+    return resolved
 
 
 def _try_resolve_fallback_provider() -> dict | None:

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -1666,3 +1666,63 @@ def format_runtime_provider_error(error: Exception) -> str:
     if isinstance(error, AuthError):
         return format_auth_error(error)
     return str(error)
+
+
+def model_for_runtime_provider(
+    resolved_provider: Optional[str],
+    *,
+    config: Optional[Dict[str, Any]] = None,
+) -> Optional[str]:
+    """Return the model to use when the runtime resolved ``resolved_provider``.
+
+    ``resolve_runtime_provider()`` returns credentials but never a model — the
+    caller supplies one, normally config ``model.default``. That default is
+    only correct when the resolved provider matches ``model.provider``. When
+    auto-detection picks a different provider (e.g. stale Codex auth falls
+    through to xai-oauth), the configured model belongs to the wrong backend
+    and every API call 404s ("model gpt-5.5 does not exist" on api.x.ai)
+    before falling back to the chain.
+
+    Returns a model the resolved provider actually serves — preferring a
+    matching ``fallback_providers`` entry, else the provider's catalog
+    default. Returns ``None`` when the resolved provider matches the config
+    provider (``model.default`` is then correct) or when config declares no
+    concrete provider (a mismatch cannot be proven).
+    """
+    provider = (resolved_provider or "").strip().lower()
+    if not provider:
+        return None
+    try:
+        cfg = config if config is not None else load_config()
+    except Exception:
+        return None
+    if not isinstance(cfg, dict):
+        return None
+    model_cfg = cfg.get("model")
+    if isinstance(model_cfg, str):
+        model_cfg = {"default": model_cfg}
+    elif not isinstance(model_cfg, dict):
+        model_cfg = {}
+    cfg_provider = str(model_cfg.get("provider") or "").strip().lower()
+    # Only act when config declares a concrete provider that differs from the
+    # resolved one. Empty/"auto" config providers can't prove a mismatch.
+    if not cfg_provider or cfg_provider in {"auto", provider}:
+        return None
+    fb = cfg.get("fallback_providers") or cfg.get("fallback_model") or []
+    if isinstance(fb, dict):
+        fb = [fb]
+    for entry in fb:
+        if (
+            isinstance(entry, dict)
+            and str(entry.get("provider") or "").strip().lower() == provider
+            and entry.get("model")
+        ):
+            return str(entry["model"]).strip()
+    try:
+        from hermes_cli.models import get_default_model_for_provider
+        catalog_model = get_default_model_for_provider(provider)
+        if catalog_model:
+            return str(catalog_model).strip()
+    except Exception:
+        pass
+    return None

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -2701,3 +2701,96 @@ def test_host_derived_key_helper_basic_cases():
     for k in ("DEEPSEEK_API_KEY", "GROQ_API_KEY", "MISTRAL_API_KEY",
               "OPENAI_API_KEY", "OPENROUTER_API_KEY"):
         _os.environ.pop(k, None)
+
+
+class TestModelForRuntimeProvider:
+    """``model_for_runtime_provider()`` — pick a model the *resolved* provider
+    actually serves, instead of blindly reusing config ``model.default``.
+
+    Regression guard for the misroute bug: config declares ``gpt-5.5`` on
+    ``openai-codex``, but stale Codex auth makes the runtime resolve to
+    ``xai-oauth``; pairing ``gpt-5.5`` with api.x.ai 404s every first call.
+    """
+
+    _CFG = {
+        "model": {"provider": "openai-codex", "default": "gpt-5.5"},
+        "fallback_providers": [
+            {"provider": "xai-oauth", "model": "grok-4.3"},
+            {"provider": "openrouter", "model": "anthropic/claude-sonnet-4.6"},
+        ],
+    }
+
+    def test_returns_none_when_resolved_provider_matches_config(self):
+        # model.default is already correct — nothing to correct.
+        assert rp.model_for_runtime_provider("openai-codex", config=self._CFG) is None
+
+    def test_provider_match_is_case_insensitive(self):
+        assert rp.model_for_runtime_provider("OpenAI-Codex", config=self._CFG) is None
+
+    def test_returns_none_for_empty_resolved_provider(self):
+        assert rp.model_for_runtime_provider(None, config=self._CFG) is None
+        assert rp.model_for_runtime_provider("", config=self._CFG) is None
+        assert rp.model_for_runtime_provider("   ", config=self._CFG) is None
+
+    def test_returns_none_when_config_provider_unset_or_auto(self):
+        # Without a concrete config provider a mismatch cannot be proven.
+        for prov in ("", "auto", None):
+            cfg = {"model": {"provider": prov, "default": "gpt-5.5"}}
+            assert rp.model_for_runtime_provider("xai-oauth", config=cfg) is None
+
+    def test_corrects_to_matching_fallback_providers_entry(self):
+        # The core fix: resolved xai-oauth → use its fallback_providers model,
+        # not the openai-codex model.default.
+        assert (
+            rp.model_for_runtime_provider("xai-oauth", config=self._CFG)
+            == "grok-4.3"
+        )
+        assert (
+            rp.model_for_runtime_provider("openrouter", config=self._CFG)
+            == "anthropic/claude-sonnet-4.6"
+        )
+
+    def test_fallback_match_is_case_insensitive(self):
+        assert (
+            rp.model_for_runtime_provider("XAI-OAuth", config=self._CFG)
+            == "grok-4.3"
+        )
+
+    def test_falls_back_to_catalog_default_when_no_fallback_entry(self, monkeypatch):
+        # Resolved provider has no fallback_providers entry → catalog default.
+        import hermes_cli.models as _models
+
+        monkeypatch.setattr(
+            _models,
+            "get_default_model_for_provider",
+            lambda provider: "grok-4.3" if provider == "xai-oauth" else None,
+        )
+        cfg = {"model": {"provider": "openai-codex", "default": "gpt-5.5"}}
+        assert (
+            rp.model_for_runtime_provider("xai-oauth", config=cfg) == "grok-4.3"
+        )
+
+    def test_returns_none_when_no_fallback_and_no_catalog_default(self, monkeypatch):
+        import hermes_cli.models as _models
+
+        monkeypatch.setattr(
+            _models, "get_default_model_for_provider", lambda provider: None
+        )
+        cfg = {"model": {"provider": "openai-codex", "default": "gpt-5.5"}}
+        assert rp.model_for_runtime_provider("xai-oauth", config=cfg) is None
+
+    def test_accepts_string_model_config(self):
+        # model declared as a bare string (no provider) → cannot prove mismatch.
+        cfg = {"model": "gpt-5.5"}
+        assert rp.model_for_runtime_provider("xai-oauth", config=cfg) is None
+
+    def test_loads_config_when_not_supplied(self, monkeypatch):
+        monkeypatch.setattr(rp, "load_config", lambda: self._CFG)
+        assert rp.model_for_runtime_provider("xai-oauth") == "grok-4.3"
+
+    def test_returns_none_when_config_load_raises(self, monkeypatch):
+        def _boom():
+            raise RuntimeError("config unavailable")
+
+        monkeypatch.setattr(rp, "load_config", _boom)
+        assert rp.model_for_runtime_provider("xai-oauth") is None


### PR DESCRIPTION
## What does this PR do?

`resolve_runtime_provider()` returns credentials but **never a model** — callers pair the resolved provider with config `model.default`. That default is only correct when the resolved provider matches `model.provider`.

When auto-detection picks a *different* provider — e.g. stale `openai-codex` auth falls through to `xai-oauth` — `model.default` belongs to the wrong backend. `gpt-5.5` + `api.x.ai` then 404s with `model gpt-5.5 does not exist` on **every first LLM call** before self-healing down the fallback chain. Every cron run and new session wastes a 404 round-trip.

This PR adds `model_for_runtime_provider()`: given the resolved provider, it returns a model that provider actually serves — a matching `fallback_providers` entry, else the provider catalog default — or `None` when the resolved provider matches config (the default is correct) or config declares no concrete provider (a mismatch can't be proven).

It is wired into **both** runtime-resolution paths:
- `gateway/run.py` `_resolve_runtime_agent_kwargs()` — Telegram / API-server / message handlers
- `cron/scheduler.py` `_run_job_impl()` — crons resolve runtime independently and were not covered by the gateway path

## Related Issue

No tracking issue — bug found and root-caused while debugging recurring `gpt-5.5 does not exist` 404s in production logs.

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/runtime_provider.py` — new helper `model_for_runtime_provider()`
- `gateway/run.py` — `_resolve_runtime_agent_kwargs()` calls it and attaches the corrected `model`
- `cron/scheduler.py` — `_run_job_impl()` calls it and corrects `model` before constructing `AIAgent`
- `tests/hermes_cli/test_runtime_provider_resolution.py` — 11 regression tests (`TestModelForRuntimeProvider`)

The helper is a no-op (`returns None`) in the common case where the resolved provider matches config, so it cannot change behavior for correctly-authenticated setups.

## How to Test

1. Configure a primary provider whose credentials are absent/stale (e.g. `model.provider: openai-codex`, `model.default: gpt-5.5`, no `openai-codex` creds) with a `fallback_providers` entry for whatever auto-detection will land on.
2. **Before:** the first LLM call of every session/cron logs `NotFoundError ... model gpt-5.5 does not exist` against the fallback provider's host, then self-heals.
3. **After:** the runtime logs that the resolved provider doesn't match the configured model and uses the correct model — one clean call, zero 404s.

Verified in production: post-fix, the gateway makes a single clean call with no `NotFoundError`.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run the affected test suite — `tests/hermes_cli/test_runtime_provider_resolution.py`: 139 passed
- [x] I've added tests for my changes (11 new regression tests)
- [x] I've tested on my platform: Ubuntu (Linux 6.8)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstrings) — the helper carries a full rationale docstring
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no new config keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — N/A (pure Python, no platform-specific code)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A