### PR TITLE
fix(tts): optimize Opus output for Telegram voice

### DIFF
--- a/tests/tools/test_tts_gemini.py
+++ b/tests/tools/test_tts_gemini.py
@@ -419,6 +419,43 @@ class TestGenerateGeminiTts:
         assert prompt_text == "Hi there."
         assert "audio tag rewrite failed" in caplog.text
 
+    def test_ogg_output_uses_telegram_voice_opus_args(
+        self,
+        tmp_path,
+        monkeypatch,
+        mock_gemini_response,
+    ):
+        from tools import tts_tool
+        from tools.tts_tool import _generate_gemini_tts
+
+        captured = {}
+
+        def fake_run(cmd, **kwargs):
+            captured["cmd"] = cmd
+            captured["kwargs"] = kwargs
+            return SimpleNamespace(returncode=0, stderr=b"")
+
+        monkeypatch.setenv("GEMINI_API_KEY", "test-key")
+        monkeypatch.setattr(tts_tool.shutil, "which", lambda name: f"/usr/bin/{name}")
+        monkeypatch.setattr(tts_tool.subprocess, "run", fake_run)
+
+        output_path = str(tmp_path / "speech.ogg")
+        with patch("requests.post", return_value=mock_gemini_response):
+            assert _generate_gemini_tts("Hi", output_path, {}) == output_path
+
+        cmd = captured["cmd"]
+        assert cmd[0] == "/usr/bin/ffmpeg"
+        assert cmd[-1] == output_path
+        assert cmd == tts_tool._telegram_voice_opus_cmd(
+            "/usr/bin/ffmpeg",
+            cmd[cmd.index("-i") + 1],
+            output_path,
+        )
+        assert cmd[cmd.index("-vbr") + 1] == "on"
+        assert cmd[cmd.index("-application") + 1] == "voip"
+        assert cmd[cmd.index("-compression_level") + 1] == "10"
+        assert captured["kwargs"]["timeout"] == 30
+
 
 class TestGeminiInCheckRequirements:
     def test_gemini_api_key_satisfies_requirements(self, monkeypatch):

--- a/tests/tools/test_tts_opus_routing.py
+++ b/tests/tools/test_tts_opus_routing.py
@@ -1,4 +1,5 @@
 import json
+import types
 from pathlib import Path
 from unittest.mock import Mock
 
@@ -68,3 +69,35 @@ def test_edge_telegram_converts_to_opus_voice(tmp_path, monkeypatch):
     assert result["voice_compatible"] is True
     assert result["media_tag"] == f"[[audio_as_voice]]\nMEDIA:{opus}"
     convert.assert_called_once_with(str(out))
+
+
+def test_convert_to_opus_uses_telegram_voice_quality_args(tmp_path, monkeypatch):
+    mp3 = tmp_path / "speech.mp3"
+    mp3.write_bytes(b"mp3")
+    captured = {}
+
+    def fake_run(cmd, **kwargs):
+        captured["cmd"] = cmd
+        captured["kwargs"] = kwargs
+        (tmp_path / "speech.ogg").write_bytes(b"ogg")
+        return types.SimpleNamespace(returncode=0, stderr=b"")
+
+    monkeypatch.setattr(tts_tool, "_has_ffmpeg", lambda: True)
+    monkeypatch.setattr(tts_tool.subprocess, "run", fake_run)
+
+    assert tts_tool._convert_to_opus(str(mp3)) == str(tmp_path / "speech.ogg")
+
+    cmd = captured["cmd"]
+    assert cmd == tts_tool._telegram_voice_opus_cmd(
+        "ffmpeg",
+        str(mp3),
+        str(tmp_path / "speech.ogg"),
+    )
+    assert "-vbr" in cmd
+    assert cmd[cmd.index("-vbr") + 1] == "on"
+    assert "-application" in cmd
+    assert cmd[cmd.index("-application") + 1] == "voip"
+    assert "-compression_level" in cmd
+    assert cmd[cmd.index("-compression_level") + 1] == "10"
+    assert "off" not in cmd
+    assert captured["kwargs"]["timeout"] == 30

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -883,6 +883,21 @@ def _has_ffmpeg() -> bool:
     return shutil.which("ffmpeg") is not None
 
 
+def _telegram_voice_opus_cmd(ffmpeg: str, input_path: str, output_path: str) -> list[str]:
+    """Build ffmpeg args for Telegram voice-compatible OGG Opus speech."""
+    return [
+        ffmpeg, "-i", input_path,
+        "-acodec", "libopus",
+        "-ac", "1",
+        "-b:a", "64k",
+        "-vbr", "on",
+        "-application", "voip",
+        "-compression_level", "10",
+        "-y", "-loglevel", "error",
+        output_path,
+    ]
+
+
 def _convert_to_opus(mp3_path: str) -> Optional[str]:
     """
     Convert an MP3 file to OGG Opus format for Telegram voice bubbles.
@@ -899,8 +914,7 @@ def _convert_to_opus(mp3_path: str) -> Optional[str]:
     ogg_path = mp3_path.rsplit(".", 1)[0] + ".ogg"
     try:
         result = subprocess.run(
-            ["ffmpeg", "-i", mp3_path, "-acodec", "libopus",
-             "-ac", "1", "-b:a", "64k", "-vbr", "off", ogg_path, "-y"],
+            _telegram_voice_opus_cmd("ffmpeg", mp3_path, ogg_path),
             capture_output=True, timeout=30,
             stdin=subprocess.DEVNULL,
         )
@@ -1674,13 +1688,7 @@ def _generate_gemini_tts(text: str, output_path: str, tts_config: Dict[str, Any]
             # For .ogg output, force libopus encoding (Telegram voice bubbles
             # require Opus specifically; ffmpeg's default for .ogg is Vorbis).
             if output_path.lower().endswith(".ogg"):
-                cmd = [
-                    ffmpeg, "-i", wav_path,
-                    "-acodec", "libopus", "-ac", "1",
-                    "-b:a", "64k", "-vbr", "off",
-                    "-y", "-loglevel", "error",
-                    output_path,
-                ]
+                cmd = _telegram_voice_opus_cmd(ffmpeg, wav_path, output_path)
             else:
                 cmd = [ffmpeg, "-i", wav_path, "-y", "-loglevel", "error", output_path]
             result = subprocess.run(cmd, capture_output=True, timeout=30, stdin=subprocess.DEVNULL)


### PR DESCRIPTION
## Summary
- use one shared ffmpeg command builder for Telegram voice OGG Opus output
- switch speech Opus encoding from CBR-style -vbr off to VBR, application=voip, and compression_level=10
- apply the same settings to Edge conversion and Gemini .ogg output

Fixes #18818.

## Verification
- /usr/local/lib/hermes-agent/venv/bin/pytest -q -o addopts="" tests/tools/test_tts_opus_routing.py tests/tools/test_tts_gemini.py
- result: 19 passed
- /usr/local/lib/hermes-agent/venv/bin/python -m py_compile tools/tts_tool.py
- git diff --check