### PR TITLE
fix(kanban): make SCHEMA_SQL execution resilient to missing columns

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1057,7 +1057,24 @@ def connect(
                 # process are cheap. The lock prevents same-process dispatcher
                 # threads from racing through the additive ALTER TABLE pass with
                 # stale PRAGMA snapshots during gateway startup.
-                conn.executescript(SCHEMA_SQL)
+                #
+                # executescript wraps all statements in a single implicit
+                # transaction. On legacy DBs, a CREATE INDEX that references a
+                # column added by _migrate_add_optional_columns (below) will
+                # abort the entire script before the column migration can run.
+                # Catch this so the migration can add the column, then create
+                # the index afterwards (its own "IF NOT EXISTS" CREATE INDEX
+                # calls handle this idempotently).
+                try:
+                    conn.executescript(SCHEMA_SQL)
+                except sqlite3.OperationalError as exc:
+                    msg = str(exc).lower()
+                    if "no such column" not in msg:
+                        raise
+                    # SCHEMA_SQL was rolled back entirely, but CREATE TABLE
+                    # IF NOT EXISTS means existing tables are intact. The
+                    # migration below will add missing columns and recreate
+                    # all additive indexes via IF NOT EXISTS.
                 _migrate_add_optional_columns(conn)
                 _INITIALIZED_PATHS.add(resolved)
     except Exception:


### PR DESCRIPTION
## Problem

When a new column is added to the `tasks` table in `SCHEMA_SQL` alongside a `CREATE INDEX` referencing that column, `conn.executescript(SCHEMA_SQL)` aborts entirely on legacy DBs where the column doesn't exist yet. The index fails with `OperationalError: no such column: <X>`, and `_migrate_add_optional_columns()` never runs.

## Root Cause

`conn.executescript()` wraps all statements in a single implicit transaction. One `CREATE INDEX` failure aborts everything, including the `_migrate_add_optional_columns` call that would have added the missing column.

## Fix

Wrap `executescript` in try/except, catching the specific `no such column` error. When this occurs (legacy DB with missing column), the entire script is rolled back — but `CREATE TABLE IF NOT EXISTS` means existing tables are intact. The migration function then adds the missing column and creates all additive indexes via its own `CREATE INDEX IF NOT EXISTS` calls (idempotent).

On fresh DBs, the `executescript` succeeds normally (no missing columns). On legacy DBs with a missing column, the except path gracefully falls through to migration.

The convention already keeps additive indexes in `_migrate_add_optional_columns` (see `idx_tasks_session_id`, `idx_tasks_tenant`, `idx_tasks_idempotency`), but this is only enforced by code review. This change provides a structural safety net.

## Testing

- Fresh DB: `executescript` succeeds → migration is a no-op for columns, adds indexes → ✅
- Legacy DB with missing column: `executescript` raises `no such column` → caught → migration adds column + creates index → ✅
- Legacy DB with all columns present: `executescript` succeeds normally → ✅