### PR TITLE
feat: add Hermes PR provenance workflow

### DIFF
--- a/hermes_cli/provenance_check.py
+++ b/hermes_cli/provenance_check.py
@@ -1,0 +1,460 @@
+"""Validate Hermes provider-level Git/PR provenance.
+
+The CLI entry point is ``hermes-provenance-check``.  It validates the
+portable provenance contract documented by the bundled
+``hermes-pr-provenance`` skill:
+
+- Hermes-authored commits should have final, contiguous ``Writer:`` trailers.
+- ``Refs:`` should be present when a branch is tied to a task/issue.
+- ``Writer:`` values should be provider-level, not exact model names.
+- PR bodies should contain a concise ``## Provenance`` block when requested.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Iterable, Sequence
+
+TRAILER_RE = re.compile(r"^([A-Za-z][A-Za-z0-9-]*):\s*(.*)$")
+PROVENANCE_HEADING_RE = re.compile(r"^##\s+Provenance\s*$", re.IGNORECASE | re.MULTILINE)
+NEXT_H2_RE = re.compile(r"^##\s+", re.MULTILINE)
+
+DEFAULT_ALLOWED_WRITERS = frozenset(
+    {
+        "chat",  # Some repos use chat/human for existing local enums.
+        "claude",
+        "codex",
+        "cursor",
+        "gemini",
+        "grok",
+        "human",
+        "openrouter",
+        "user",
+    }
+)
+
+MODELISH_WRITER_RE = re.compile(
+    r"(?:[/.]|\d|gpt|opus|sonnet|haiku|flash|pro|reasoning|mini|large)",
+    re.IGNORECASE,
+)
+
+REQUIRED_PR_PROVENANCE_FIELDS = (
+    "GitHub actor",
+    "PR created by",
+    "Implemented by",
+    "Writers from commit trailers",
+    "Task ledger",
+)
+
+
+@dataclass(frozen=True)
+class Commit:
+    sha: str
+    subject: str
+    body: str
+
+    @property
+    def short_sha(self) -> str:
+        return self.sha[:12]
+
+
+@dataclass(frozen=True)
+class TrailerBlock:
+    trailers: dict[str, list[str]]
+    raw_lines: tuple[str, ...]
+
+    def values(self, key: str) -> list[str]:
+        return self.trailers.get(key.lower(), [])
+
+
+@dataclass(frozen=True)
+class Finding:
+    severity: str
+    message: str
+    commit: str | None = None
+
+    def as_dict(self) -> dict[str, str | None]:
+        return {"severity": self.severity, "message": self.message, "commit": self.commit}
+
+
+@dataclass
+class CheckResult:
+    range_spec: str | None = None
+    commit_count: int = 0
+    writers: set[str] = field(default_factory=set)
+    refs: set[str] = field(default_factory=set)
+    findings: list[Finding] = field(default_factory=list)
+    pr_block: str | None = None
+
+    @property
+    def errors(self) -> list[Finding]:
+        return [f for f in self.findings if f.severity == "error"]
+
+    @property
+    def warnings(self) -> list[Finding]:
+        return [f for f in self.findings if f.severity == "warning"]
+
+    @property
+    def ok(self) -> bool:
+        return not self.errors
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "ok": self.ok,
+            "range": self.range_spec,
+            "commit_count": self.commit_count,
+            "writers": sorted(self.writers),
+            "refs": sorted(self.refs),
+            "findings": [f.as_dict() for f in self.findings],
+            "pr_block": self.pr_block,
+        }
+
+
+def run_git(args: Sequence[str], cwd: Path | None = None) -> str:
+    completed = subprocess.run(
+        ["git", *args],
+        cwd=str(cwd) if cwd else None,
+        check=False,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    if completed.returncode != 0:
+        cmd = " ".join(["git", *args])
+        raise RuntimeError(f"{cmd} failed: {completed.stderr.strip()}")
+    return completed.stdout
+
+
+def parse_final_trailer_block(message: str) -> TrailerBlock:
+    """Return the final contiguous Git trailer block.
+
+    This intentionally accepts only simple ``Key: value`` trailer lines at the
+    end of the commit message. If a blank line appears between ``Writer:`` and
+    ``Refs:``, the earlier trailer is outside the final block and therefore
+    treated as missing by the validator.
+    """
+
+    lines = message.rstrip("\n").splitlines()
+    raw_reversed: list[str] = []
+
+    for line in reversed(lines):
+        if not line.strip():
+            break
+        if not TRAILER_RE.match(line):
+            break
+        raw_reversed.append(line)
+
+    raw_lines = tuple(reversed(raw_reversed))
+    parsed: dict[str, list[str]] = {}
+    for line in raw_lines:
+        match = TRAILER_RE.match(line)
+        if not match:
+            continue
+        key, value = match.group(1).lower(), match.group(2).strip()
+        parsed.setdefault(key, []).append(value)
+    return TrailerBlock(trailers=parsed, raw_lines=raw_lines)
+
+
+def find_all_trailer_values(message: str, key: str) -> list[str]:
+    needle = key.lower()
+    values: list[str] = []
+    for line in message.splitlines():
+        match = TRAILER_RE.match(line)
+        if match and match.group(1).lower() == needle:
+            values.append(match.group(2).strip())
+    return values
+
+
+def parse_git_log(raw: str) -> list[Commit]:
+    commits: list[Commit] = []
+    for record in raw.split("\x1e"):
+        record = record.strip("\n")
+        if not record:
+            continue
+        parts = record.split("\x1f", 2)
+        if len(parts) != 3:
+            continue
+        sha, subject, body = parts
+        commits.append(Commit(sha=sha.strip(), subject=subject.strip(), body=body))
+    return commits
+
+
+def get_commits(range_spec: str, cwd: Path | None = None) -> list[Commit]:
+    raw = run_git(["log", "--format=%H%x1f%s%x1f%B%x1e", range_spec], cwd=cwd)
+    return parse_git_log(raw)
+
+
+def normalize_allowed_writers(extra_writers: Iterable[str]) -> set[str]:
+    allowed = set(DEFAULT_ALLOWED_WRITERS)
+    allowed.update(writer.strip().lower() for writer in extra_writers if writer.strip())
+    return allowed
+
+
+def validate_writer_value(
+    writer: str,
+    allowed_writers: set[str],
+    *,
+    allow_any_writer: bool,
+) -> str | None:
+    if not writer:
+        return "empty Writer trailer"
+    normalized = writer.lower()
+    if MODELISH_WRITER_RE.search(normalized):
+        return (
+            f"Writer value {writer!r} looks model-specific; use a provider-level "
+            "value such as codex, grok, claude, or gemini"
+        )
+    if not re.fullmatch(r"[a-z][a-z0-9_-]*", normalized):
+        return f"Writer value {writer!r} is not a simple provider token"
+    if not allow_any_writer and normalized not in allowed_writers:
+        return (
+            f"Writer value {writer!r} is not in the allowed provider set; "
+            "pass --allowed-writer for repository-specific enums"
+        )
+    return None
+
+
+def validate_commits(
+    commits: Sequence[Commit],
+    *,
+    range_spec: str | None = None,
+    require_refs: bool = True,
+    allowed_writers: set[str] | None = None,
+    allow_any_writer: bool = False,
+    allow_model_provenance: bool = False,
+) -> CheckResult:
+    allowed_writers = allowed_writers or normalize_allowed_writers(())
+    result = CheckResult(range_spec=range_spec, commit_count=len(commits))
+
+    for commit in commits:
+        block = parse_final_trailer_block(commit.body)
+        writers = block.values("writer")
+        refs = block.values("refs")
+        writer_models = find_all_trailer_values(commit.body, "writer-model")
+        all_writers = find_all_trailer_values(commit.body, "writer")
+        all_refs = find_all_trailer_values(commit.body, "refs")
+
+        if writer_models and not allow_model_provenance:
+            result.findings.append(
+                Finding(
+                    "error",
+                    "Writer-Model trailer is present but exact model provenance is not enabled",
+                    commit.short_sha,
+                )
+            )
+
+        if all_writers and not writers:
+            result.findings.append(
+                Finding(
+                    "error",
+                    "Writer trailer exists but is not in the final contiguous trailer block",
+                    commit.short_sha,
+                )
+            )
+        if all_refs and not refs:
+            result.findings.append(
+                Finding(
+                    "error",
+                    "Refs trailer exists but is not in the final contiguous trailer block",
+                    commit.short_sha,
+                )
+            )
+
+        if not writers:
+            result.findings.append(
+                Finding("error", "missing final Writer trailer", commit.short_sha)
+            )
+        for writer in writers:
+            result.writers.add(writer.lower())
+            problem = validate_writer_value(
+                writer,
+                allowed_writers,
+                allow_any_writer=allow_any_writer,
+            )
+            if problem:
+                result.findings.append(Finding("error", problem, commit.short_sha))
+
+        if require_refs and not refs:
+            result.findings.append(
+                Finding("error", "missing final Refs trailer", commit.short_sha)
+            )
+        for ref in refs:
+            if not ref:
+                result.findings.append(Finding("error", "empty Refs trailer", commit.short_sha))
+            else:
+                result.refs.add(ref)
+
+    if not commits:
+        result.findings.append(
+            Finding("warning", "no commits found in range; nothing to validate")
+        )
+
+    return result
+
+
+def extract_pr_provenance_block(body: str) -> str | None:
+    match = PROVENANCE_HEADING_RE.search(body)
+    if not match:
+        return None
+    next_match = NEXT_H2_RE.search(body, match.end())
+    end = next_match.start() if next_match else len(body)
+    return body[match.start() : end].strip()
+
+
+def validate_pr_body(body: str, result: CheckResult) -> None:
+    block = extract_pr_provenance_block(body)
+    result.pr_block = block
+    if block is None:
+        result.findings.append(Finding("error", "PR body is missing a ## Provenance block"))
+        return
+
+    lower_block = block.lower()
+    for field_name in REQUIRED_PR_PROVENANCE_FIELDS:
+        if field_name.lower() not in lower_block:
+            result.findings.append(
+                Finding("error", f"PR provenance block is missing {field_name!r}")
+            )
+
+    missing_writers = [writer for writer in result.writers if writer not in lower_block]
+    if missing_writers:
+        result.findings.append(
+            Finding(
+                "warning",
+                "PR provenance block does not mention detected writer(s): "
+                + ", ".join(sorted(missing_writers)),
+            )
+        )
+
+
+def emit_pr_block(result: CheckResult, github_actor: str | None = None) -> str:
+    writers = ", ".join(sorted(result.writers)) if result.writers else "unknown"
+    refs = ", ".join(sorted(result.refs)) if result.refs else "none"
+    actor = github_actor or "<github-login-or-bot-account>"
+    return "\n".join(
+        [
+            "## Provenance",
+            "",
+            f"- GitHub actor: {actor}",
+            f"- PR created by: {writers}",
+            f"- Implemented by: {writers}",
+            f"- Writers from commit trailers: {writers}",
+            f"- Task ledger: {refs}",
+        ]
+    )
+
+
+def print_human_report(result: CheckResult, *, include_pr_block: bool = False) -> None:
+    print("Hermes provenance check")
+    if result.range_spec:
+        print(f"Range: {result.range_spec}")
+    print(f"Commits: {result.commit_count}")
+    print(f"Writers: {', '.join(sorted(result.writers)) if result.writers else 'none'}")
+    print(f"Refs: {', '.join(sorted(result.refs)) if result.refs else 'none'}")
+
+    for finding in result.findings:
+        prefix = finding.severity.upper()
+        location = f" {finding.commit}" if finding.commit else ""
+        print(f"{prefix}{location}: {finding.message}")
+
+    print("PASS" if result.ok else "FAIL")
+
+    if include_pr_block:
+        print()
+        print(result.pr_block or emit_pr_block(result))
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Validate Hermes provider-level commit/PR provenance."
+    )
+    range_group = parser.add_mutually_exclusive_group()
+    range_group.add_argument("--range", dest="range_spec", help="Explicit git range, e.g. main..HEAD")
+    parser.add_argument("--base", default="origin/main", help="Base ref when --range is not set (default: origin/main)")
+    parser.add_argument("--head", default="HEAD", help="Head ref when --range is not set (default: HEAD)")
+    parser.add_argument("--repo", type=Path, default=Path.cwd(), help="Repository path (default: cwd)")
+    parser.add_argument(
+        "--no-require-refs",
+        action="store_true",
+        help="Do not fail commits that have Writer but no Refs trailer.",
+    )
+    parser.add_argument(
+        "--allowed-writer",
+        action="append",
+        default=[],
+        help="Allow an additional repository-specific Writer value. Repeatable.",
+    )
+    parser.add_argument(
+        "--allow-any-writer",
+        action="store_true",
+        help="Allow any simple provider token, while still rejecting model-looking Writer values.",
+    )
+    parser.add_argument(
+        "--allow-model-provenance",
+        action="store_true",
+        help="Allow Writer-Model trailers. Off by default because model provenance is deferred.",
+    )
+    parser.add_argument(
+        "--pr-body",
+        help="Validate a PR body markdown file. Use '-' to read from stdin.",
+    )
+    parser.add_argument(
+        "--emit-pr-block",
+        action="store_true",
+        help="Print a starter ## Provenance block from detected writers/refs.",
+    )
+    parser.add_argument(
+        "--github-actor",
+        help="GitHub actor to include when emitting a PR provenance block.",
+    )
+    parser.add_argument("--json", action="store_true", help="Emit machine-readable JSON.")
+    return parser
+
+
+def read_pr_body_arg(value: str) -> str:
+    if value == "-":
+        return sys.stdin.read()
+    return Path(value).read_text(encoding="utf-8")
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    range_spec = args.range_spec or f"{args.base}..{args.head}"
+    result: CheckResult
+    try:
+        commits = get_commits(range_spec, cwd=args.repo)
+        result = validate_commits(
+            commits,
+            range_spec=range_spec,
+            require_refs=not args.no_require_refs,
+            allowed_writers=normalize_allowed_writers(args.allowed_writer),
+            allow_any_writer=args.allow_any_writer,
+            allow_model_provenance=args.allow_model_provenance,
+        )
+        if args.pr_body:
+            validate_pr_body(read_pr_body_arg(args.pr_body), result)
+        if args.emit_pr_block:
+            result.pr_block = emit_pr_block(result, args.github_actor)
+    except Exception as exc:  # pragma: no cover - defensive CLI boundary
+        result = CheckResult(range_spec=range_spec)
+        result.findings.append(Finding("error", str(exc)))
+
+    if args.json:
+        print(json.dumps(result.as_dict(), indent=2, sort_keys=True))
+    else:
+        print_human_report(result, include_pr_block=args.emit_pr_block)
+
+    return 0 if result.ok else 1
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -210,6 +210,7 @@ all = [
 hermes = "hermes_cli.main:main"
 hermes-agent = "run_agent:main"
 hermes-acp = "acp_adapter.entry:main"
+hermes-provenance-check = "hermes_cli.provenance_check:main"
 
 [tool.setuptools]
 py-modules = ["run_agent", "model_tools", "toolsets", "batch_runner", "trajectory_compressor", "toolset_distributions", "cli", "hermes_bootstrap", "hermes_constants", "hermes_state", "hermes_time", "hermes_logging", "utils"]

--- a/skills/devops/hermes-git-workflow/SKILL.md
+++ b/skills/devops/hermes-git-workflow/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: hermes-git-workflow
+description: "Use when Hermes maintains Git repositories and needs clean commits, pushes, remotes, and provider-level provenance for shared bot-account work."
+version: 1.0.0
+author: Hermes Agent
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [git, github, ssh, automation, hermes, workflow]
+    related_skills: [github-pr-workflow, hermes-pr-provenance]
+---
+
+# Hermes Git Workflow
+
+## Overview
+
+Hermes frequently pushes through a shared machine user or bot account while the actual code was written by a routed provider family. This skill keeps Git hygiene and provenance consistent across repositories without depending on a project-specific closeout process.
+
+## When to Use
+
+Use this skill when Hermes:
+
+- Creates commits or pushes branches.
+- Initializes or fixes a repository remote.
+- Works in a repo where a human reviews changes through GitHub.
+- Needs to distinguish the GitHub actor from the provider route that wrote the change.
+
+If a repository has stronger local workflow rules, follow those first and use this skill only for the portable baseline.
+
+## Core Rules
+
+- Keep the working tree understandable: inspect status before and after edits.
+- Prefer the repository's documented branch, commit, and closeout workflow.
+- Push when the repo workflow expects remote visibility, especially for PR-based review.
+- Prefer SSH remotes when the environment already has an authenticated deploy/user key.
+- Do not embed secrets in remotes, commit messages, PR bodies, or logs.
+- Include provider-level `Writer:` trailers for Hermes-authored commits.
+
+## Provider Provenance
+
+When Hermes writes code, docs, or repo updates, the GitHub account often remains the same while the active provider route changes. Preserve that distinction with provider-level commit trailers:
+
+```text
+Writer: codex
+Refs: #123
+```
+
+Rules:
+
+- `Writer:` is the stable provider family used by automation and issue ledgers.
+- Use values such as `codex`, `grok`, `claude`, `gemini`, `openrouter`, `human`, or the repository's existing writer vocabulary.
+- For GPT-5.5 through OpenAI Codex, use `Writer: codex`.
+- Do not add `Writer-Model:` by default; exact model/version tracking is deferred unless the user or repository explicitly asks for it.
+- Keep `Writer:`, `Refs:`, and any `Co-Authored-By:` trailers contiguous at the end of commit messages with no blank lines between them.
+- For PRs, include a short `## Provenance` block with GitHub actor, PR creator, implementer, writer trailers, and task ledger.
+- For Beads/issue-led repos, keep fields like `implemented_by`, `closed_by`, and `pr_created_by` provider-level where the repo supports metadata.
+- Load `hermes-pr-provenance` for the full portable PR/GitHub/Beads contract.
+
+## Commit Example
+
+```bash
+git add src/auth/login.py tests/test_login.py
+git commit -m "fix: correct redirect URL after login
+
+Preserves the ?next= parameter instead of always redirecting to /dashboard.
+
+Writer: codex
+Refs: #42"
+git push -u origin HEAD
+```
+
+## Provenance Helper
+
+Before opening or updating a PR, run:
+
+```bash
+hermes-provenance-check --base origin/main --head HEAD
+```
+
+Use `--emit-pr-block` to generate a starter `## Provenance` section from commit trailers.
+
+## Pitfalls
+
+- Leaving changes uncommitted in a repo where the human expects to pull/review remote work.
+- Using HTTPS remotes without credential helpers configured.
+- Forgetting to fetch/rebase before pushing a long-lived branch.
+- Encoding exact model names in `Writer:`; this can break workflows that parse `Writer:` as a small provider enum.
+- Adding model-level provenance by default; keep the portable baseline provider-level unless explicitly requested.
+
+## Verification Checklist
+
+- [ ] `git status --short` inspected before final handoff.
+- [ ] Commit messages include provider-level `Writer:` trailers when Hermes authored work.
+- [ ] `Refs:` points to a GitHub issue, Beads id, PR, or task id when available.
+- [ ] `hermes-provenance-check` passes for the branch or intentional exceptions are documented.
+- [ ] Remote push completed when the workflow expects GitHub/remote visibility.

--- a/skills/github/github-code-review/SKILL.md
+++ b/skills/github/github-code-review/SKILL.md
@@ -8,7 +8,7 @@ platforms: [linux, macos, windows]
 metadata:
   hermes:
     tags: [GitHub, Code-Review, Pull-Requests, Git, Quality]
-    related_skills: [github-auth, github-pr-workflow]
+    related_skills: [github-auth, github-pr-workflow, hermes-pr-provenance]
 ---
 
 # GitHub Code Review
@@ -19,6 +19,7 @@ Perform code reviews on local changes before pushing, or review open PRs on GitH
 
 - Authenticated with GitHub (see `github-auth` skill)
 - Inside a git repository
+- When posting a formal review or summary comment as Hermes, use `hermes-pr-provenance` if provider-level attribution should be visible on the PR.
 
 ### Setup (for PR interactions)
 

--- a/skills/github/github-issues/SKILL.md
+++ b/skills/github/github-issues/SKILL.md
@@ -8,7 +8,7 @@ platforms: [linux, macos, windows]
 metadata:
   hermes:
     tags: [GitHub, Issues, Project-Management, Bug-Tracking, Triage]
-    related_skills: [github-auth, github-pr-workflow]
+    related_skills: [github-auth, github-pr-workflow, hermes-pr-provenance]
 ---
 
 # GitHub Issues Management
@@ -19,6 +19,8 @@ Create, search, triage, and manage GitHub issues. Each section shows `gh` first,
 
 - Authenticated with GitHub (see `github-auth` skill)
 - Inside a git repo with a GitHub remote, or specify the repo explicitly
+
+When issue work is part of a Hermes-authored branch or PR, use `hermes-pr-provenance` so issue comments/closures, commit trailers, PR body provenance, and optional Beads metadata agree on the provider-level writer.
 
 ### Setup
 
@@ -354,6 +356,21 @@ curl -s \
       -d '{"state": "closed", "state_reason": "not_planned"}'
     echo "Closed #$num"
   done
+```
+
+## Hermes Provenance for Issue-Led Work
+
+When Hermes comments on, closes, or links issues as part of repository work, keep provider-level attribution aligned with commits and PRs:
+
+- Commit trailers should include `Writer: codex` and `Refs: #42` (or the repo's provider/task ids).
+- PR bodies should include the standard `## Provenance` block from `hermes-pr-provenance`.
+- If the repo uses Beads, mirror the provider into supported metadata such as `implemented_by=codex`, `closed_by=codex`, or `pr_created_by=codex`.
+- Avoid noisy provenance on tiny comments unless the repository expects it.
+
+For substantial issue comments, a compact footer is acceptable:
+
+```markdown
+Provenance: Writer: codex
 ```
 
 ## Quick Reference Table

--- a/skills/github/github-pr-workflow/SKILL.md
+++ b/skills/github/github-pr-workflow/SKILL.md
@@ -8,7 +8,7 @@ platforms: [linux, macos, windows]
 metadata:
   hermes:
     tags: [GitHub, Pull-Requests, CI/CD, Git, Automation, Merge]
-    related_skills: [github-auth, github-code-review]
+    related_skills: [github-auth, github-code-review, hermes-pr-provenance]
 ---
 
 # GitHub Pull Request Workflow
@@ -77,19 +77,22 @@ Branch naming conventions:
 
 ## 2. Making Commits
 
-Use the agent's file tools (`write_file`, `patch`) to make changes, then commit:
+Use the agent's file tools (`write_file`, `patch`) to make changes, then commit. When Hermes or a routed provider authored the code/update, include provider-level provenance trailers so the GitHub actor (`hermesbot`, etc.) can be distinguished from the actual writer route:
 
 ```bash
 # Stage specific files
 git add src/auth.py src/models/user.py tests/test_auth.py
 
-# Commit with a conventional commit message
+# Commit with a conventional commit message plus provider provenance trailers
 git commit -m "feat: add JWT-based user authentication
 
 - Add login/register endpoints
 - Add User model with password hashing
 - Add auth middleware for protected routes
-- Add unit tests for auth flow"
+- Add unit tests for auth flow
+
+Writer: codex
+Refs: #42"
 ```
 
 Commit message format (Conventional Commits):
@@ -97,9 +100,19 @@ Commit message format (Conventional Commits):
 type(scope): short description
 
 Longer explanation if needed. Wrap at 72 characters.
+
+Writer: <writer-provider>
+Refs: #<issue-or-pr-or-task>
+Co-Authored-By: <stable agent/provider persona> <noreply@example.com>
 ```
 
 Types: `feat`, `fix`, `refactor`, `docs`, `test`, `ci`, `chore`, `perf`
+
+Hermes provenance rules:
+- Keep `Writer:` stable and provider-level (`claude`, `codex`, `grok`, `gemini`, `openrouter`, or the repository's existing writer vocabulary). Do **not** encode exact model names in `Writer:` because downstream audit/issue tooling may parse it as an enum.
+- Do not add exact model/version trailers by default; model-level provenance is deferred unless the user or repository explicitly requests it.
+- Keep `Writer:`, `Refs:`, and any `Co-Authored-By:` trailers contiguous at the end of the commit message with no blank lines between them.
+- In Beads/issue-led repositories, preserve provider-level fields such as `implemented_by`, `closed_by`, and `pr_created_by` (see `hermes-pr-provenance`).
 
 ## 3. Pushing and Creating a PR
 
@@ -110,6 +123,8 @@ git push -u origin HEAD
 ```
 
 ### Create the PR
+
+Include a provenance block when Hermes created or updated the branch so reviewers can see which routed provider produced the changes, not just which GitHub bot/account pushed them. See `hermes-pr-provenance` for the full portable contract.
 
 **With gh:**
 
@@ -122,6 +137,13 @@ gh pr create \
 
 ## Test Plan
 - [ ] Unit tests pass
+
+## Provenance
+- GitHub actor: hermesbot-almace
+- PR created by: codex
+- Implemented by: codex
+- Writers from commit trailers: codex
+- Task ledger: GitHub #42
 
 Closes #42"
 ```
@@ -139,7 +161,7 @@ curl -s -X POST \
   https://api.github.com/repos/$OWNER/$REPO/pulls \
   -d "{
     \"title\": \"feat: add JWT-based user authentication\",
-    \"body\": \"## Summary\nAdds login and register API endpoints.\n\nCloses #42\",
+    \"body\": \"## Summary\nAdds login and register API endpoints.\n\n## Provenance\n- GitHub actor: hermesbot-almace\n- PR created by: codex\n- Implemented by: codex\n- Writers from commit trailers: codex\n- Task ledger: GitHub #42\n\nCloses #42\",
     \"head\": \"$BRANCH\",
     \"base\": \"main\"
   }"
@@ -255,7 +277,10 @@ After identifying the issue, use file tools (`patch`, `write_file`) to fix it:
 
 ```bash
 git add <fixed_files>
-git commit -m "fix: resolve CI failure in <check_name>"
+git commit -m "fix: resolve CI failure in <check_name>
+
+Writer: codex
+Refs: #42"
 git push
 ```
 
@@ -270,7 +295,7 @@ When asked to auto-fix CI, follow this loop:
 1. Check CI status → identify failures
 2. Read failure logs → understand the error
 3. Use `read_file` + `patch`/`write_file` → fix the code
-4. `git add . && git commit -m "fix: ..." && git push`
+4. `git add . && git commit -m $'fix: ...\n\nWriter: codex\nRefs: #42' && git push`
 5. Wait for CI → re-check status
 6. Repeat if still failing (up to 3 attempts, then ask the user)
 
@@ -342,7 +367,10 @@ git checkout -b fix/login-redirect-bug
 git add src/auth/login.py tests/test_login.py
 git commit -m "fix: correct redirect URL after login
 
-Preserves the ?next= parameter instead of always redirecting to /dashboard."
+Preserves the ?next= parameter instead of always redirecting to /dashboard.
+
+Writer: codex
+Refs: #42"
 
 # 5. Push
 git push -u origin HEAD
@@ -350,10 +378,17 @@ git push -u origin HEAD
 # 6. Create PR (picks gh or curl based on what's available)
 # ... (see Section 3)
 
+# Optional but recommended: validate commit and PR provenance before handoff
+hermes-provenance-check --base origin/main --head HEAD
+
 # 7. Monitor CI (see Section 4)
 
 # 8. Merge when green (see Section 6)
 ```
+
+## Hermes PR Provenance Reference
+
+For the full portable Hermes provider-attribution pattern — `Writer:` trailers, PR provenance blocks, optional Beads metadata, and the `hermes-provenance-check` helper — load `hermes-pr-provenance`.
 
 ## Useful PR Commands Reference
 

--- a/skills/github/github-repo-management/SKILL.md
+++ b/skills/github/github-repo-management/SKILL.md
@@ -8,7 +8,7 @@ platforms: [linux, macos, windows]
 metadata:
   hermes:
     tags: [GitHub, Repositories, Git, Releases, Secrets, Configuration]
-    related_skills: [github-auth, github-pr-workflow, github-issues]
+    related_skills: [github-auth, github-pr-workflow, github-issues, hermes-pr-provenance]
 ---
 
 # GitHub Repository Management
@@ -18,6 +18,7 @@ Create, clone, fork, configure, and manage GitHub repositories. Each section sho
 ## Prerequisites
 
 - Authenticated with GitHub (see `github-auth` skill)
+- When creating a repository from Hermes-authored local work or an initial commit, use `hermes-pr-provenance`/`hermes-git-workflow` so commits and any opening PR identify the provider-level writer.
 
 ### Setup
 
@@ -124,7 +125,10 @@ cd my-new-project
 cd /path/to/existing/project
 git init
 git add .
-git commit -m "Initial commit"
+git commit -m "chore: initial commit
+
+Writer: codex
+Refs: initial-setup"
 git remote add origin https://github.com/$GH_USER/my-new-project.git
 git push -u origin main
 ```

--- a/skills/github/hermes-pr-provenance/SKILL.md
+++ b/skills/github/hermes-pr-provenance/SKILL.md
@@ -1,0 +1,231 @@
+---
+name: hermes-pr-provenance
+description: "Use when Hermes creates or updates Git commits, GitHub PRs/issues, or Beads records so provider-level writer provenance is recorded consistently across projects."
+version: 1.0.0
+author: Hermes Agent
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [github, git, pull-requests, issues, beads, provenance, hermes]
+    related_skills: [github-pr-workflow, github-issues, hermes-git-workflow]
+---
+
+# Hermes PR Provenance
+
+## Overview
+
+Hermes often pushes through one shared GitHub actor, such as `hermesbot` or `hermes agent`, while the actual work was authored by a routed provider family such as Codex, Grok, Claude, or Gemini. This skill standardizes that distinction for any repository without importing Tailboard-specific DP-11 rules.
+
+The universal rule is:
+
+- GitHub actor/account tells who pushed or opened the PR.
+- `Writer:` tells which Hermes provider family wrote the code or update.
+- PR and Beads metadata mirror the same provider-level writer.
+- Exact model/version tracking is intentionally deferred by default.
+
+## When to Use
+
+Use this skill for any Hermes-authored or Hermes-updated repository work:
+
+- Creating commits.
+- Pushing branches.
+- Opening or updating GitHub PRs.
+- Creating, commenting on, or closing GitHub issues.
+- Claiming, updating, closing, or cross-linking Beads issues.
+- Summarizing provenance in handoffs or PR descriptions.
+
+Do not use this as a replacement for repository-specific ship/closeout rules. If a repository has stronger local rules, follow them first and add this provider-level provenance where compatible.
+
+## Writer Vocabulary
+
+Use provider/route-family values, not exact model versions.
+
+Preferred universal values:
+
+| Writer value | Use when |
+|---|---|
+| `codex` | OpenAI Codex / GPT-Codex route authored the change. |
+| `grok` | xAI / Grok route authored the change. |
+| `claude` | Claude wrote/reviewed through an approved headless Claude route. |
+| `gemini` | Gemini route authored the change. |
+| `openrouter` | OpenRouter-hosted route authored the change and no narrower repo vocabulary exists. |
+| `human` | A human authored the change and Hermes is only recording or pushing it. |
+| `user` | Use only if the target repo already prefers `user` over `human`. |
+
+If the repository already defines a writer vocabulary, use the repository vocabulary. Do not introduce exact model strings into `Writer:`.
+
+For GPT-5.5 through OpenAI Codex, record:
+
+```text
+Writer: codex
+```
+
+## Commit Trailer Contract
+
+Every Hermes-authored commit should end with contiguous Git trailers.
+
+Minimum shape when an issue or task exists:
+
+```text
+Writer: codex
+Refs: #123
+```
+
+For Beads-only tasks, use the Beads id in `Refs:` when there is no GitHub issue:
+
+```text
+Writer: codex
+Refs: tb-123
+```
+
+Rules:
+
+- Keep `Writer:` provider-level.
+- Do not add `Writer-Model:` by default.
+- Do not put model versions in `Writer:`.
+- Keep `Writer:`, `Refs:`, and `Co-Authored-By:` trailers contiguous at the end of the commit message.
+- Do not insert blank lines between trailers.
+- Use `Refs:` with the colon; omitting the colon can break trailer parsing.
+- `Co-Authored-By:` is optional and should identify a stable agent/provider persona, not a rotating exact model version.
+
+Example commit message:
+
+```text
+fix: preserve redirect URL after login
+
+Preserves the ?next= parameter instead of always redirecting to /dashboard.
+
+Writer: codex
+Refs: #42
+```
+
+If multiple providers materially authored one commit and splitting commits is not practical, use repeated `Writer:` trailers:
+
+```text
+Writer: codex
+Writer: grok
+Refs: #42
+```
+
+Prefer one writer per commit when possible.
+
+## PR Provenance Block
+
+Hermes-created or Hermes-updated PRs should include a concise provenance section.
+
+Template:
+
+```markdown
+## Provenance
+
+- GitHub actor: <github-login-or-bot-account>
+- PR created by: <writer-provider>
+- Implemented by: <writer-provider-or-comma-list>
+- Writers from commit trailers: <writer-provider-or-comma-list>
+- Task ledger: <Beads tb-id(s), GitHub issue(s), or none>
+```
+
+Example:
+
+```markdown
+## Provenance
+
+- GitHub actor: hermesbot-almace
+- PR created by: codex
+- Implemented by: codex
+- Writers from commit trailers: codex
+- Task ledger: Beads tb-123; GitHub #42
+```
+
+Do not include exact model names unless the user explicitly asks for model-level tracking in that repository.
+
+## Beads Integration
+
+Use Beads when a repository has a `.beads/` directory or otherwise documents Beads as the task ledger. Do not force Beads into repositories that do not use it.
+
+Detection:
+
+```bash
+if command -v bd >/dev/null 2>&1 && [ -d .beads ]; then
+  echo "Beads repo detected"
+fi
+```
+
+Recommended provider-level metadata, where the repo/tooling accepts it:
+
+```bash
+bd update <id> --claim
+bd update <id> --set-metadata implemented_by=codex
+bd update <id> --set-metadata pr_created_by=codex --set-metadata github_pr="#123"
+bd update <id> --status closed --set-metadata closed_by=codex
+```
+
+Guidelines:
+
+- Keep Beads fields provider-level: `implemented_by=codex`, `closed_by=codex`, `pr_created_by=codex`.
+- Do not add model-specific fields like `implemented_models` unless the repository explicitly asks for model-level provenance.
+- Do not overwrite existing metadata from another provider or human; append/update only according to the repo's Beads conventions.
+- If the repo has a local Beads skill or close protocol, follow that first.
+- If `bd update --set-metadata` is unavailable, add a Beads comment/note or include the provenance in the PR body instead.
+- Keep Git commit trailers as the durable source of writer provenance even when Beads metadata is also updated.
+
+## GitHub Issues and Comments
+
+For substantial issue comments or status updates written by Hermes, include provider attribution when useful:
+
+```markdown
+Hermes update: investigated and opened PR #123.
+
+Provenance: Writer: codex
+```
+
+Avoid noisy provenance on tiny comments unless the repository expects it.
+
+## Validator / Helper
+
+Use the bundled helper before opening or updating a PR:
+
+```bash
+hermes-provenance-check --base origin/main --head HEAD
+```
+
+Common variants:
+
+```bash
+# Validate a specific commit range.
+hermes-provenance-check --range main..HEAD
+
+# Check a PR body markdown file too.
+hermes-provenance-check --base origin/main --pr-body /tmp/pr-body.md
+
+# Print a starter provenance block from detected commit writers and refs.
+hermes-provenance-check --base origin/main --emit-pr-block
+
+# Allow a repository-specific writer enum in addition to the defaults.
+hermes-provenance-check --allowed-writer cursor --allowed-writer chat
+```
+
+The helper fails when Hermes-authored commits are missing `Writer:`, when `Refs:` is required but absent, when trailers are not in the final contiguous trailer block, or when exact-model provenance appears without an explicit opt-in.
+
+## Verification Checklist
+
+Before handing off or merging:
+
+- [ ] Each Hermes-authored commit has at least one provider-level `Writer:` trailer.
+- [ ] Relevant commits include `Refs:` for the GitHub issue, PR, Beads id, or task id.
+- [ ] Trailers are contiguous with no blank lines between them.
+- [ ] The PR body has a `## Provenance` block when Hermes created or materially updated the PR.
+- [ ] Beads metadata is provider-level if Beads is present and supports metadata.
+- [ ] `hermes-provenance-check` passes, or any intentional exception is documented.
+- [ ] No exact model/version was recorded unless the user explicitly requested it.
+- [ ] Repository-specific closeout rules still take precedence.
+
+## Common Pitfalls
+
+1. Confusing GitHub actor with writer provider. The bot account may push every commit, but `Writer:` captures which Hermes route authored it.
+2. Encoding exact model names in `Writer:`. This breaks repos that parse `Writer:` as a small enum.
+3. Adding `Writer-Model:` everywhere. Exact model provenance is deferred unless explicitly requested.
+4. Forgetting `Refs:`. Many audit and task-ledger workflows rely on commit-to-task linkage.
+5. Adding blank lines between trailers. Git trailer parsing expects a contiguous trailer block.
+6. Applying Tailboard DP-11 to every repo. Tailboard can keep its own richer rules; this skill is the portable baseline.

--- a/tests/hermes_cli/test_provenance_check.py
+++ b/tests/hermes_cli/test_provenance_check.py
@@ -1,0 +1,171 @@
+from __future__ import annotations
+
+from hermes_cli.provenance_check import (
+    Commit,
+    CheckResult,
+    emit_pr_block,
+    extract_pr_provenance_block,
+    normalize_allowed_writers,
+    parse_final_trailer_block,
+    validate_commits,
+    validate_pr_body,
+)
+
+
+def test_parse_final_trailer_block_requires_contiguous_final_block() -> None:
+    message = """fix: example
+
+Body.
+
+Writer: codex
+
+Refs: #42
+"""
+
+    block = parse_final_trailer_block(message)
+
+    assert block.values("writer") == []
+    assert block.values("refs") == ["#42"]
+
+
+def test_validate_commits_accepts_provider_level_writer_and_refs() -> None:
+    commit = Commit(
+        sha="abcdef1234567890",
+        subject="fix: example",
+        body="""fix: example
+
+Body.
+
+Writer: codex
+Refs: #42
+""",
+    )
+
+    result = validate_commits([commit], range_spec="main..HEAD")
+
+    assert result.ok
+    assert result.writers == {"codex"}
+    assert result.refs == {"#42"}
+
+
+def test_validate_commits_rejects_model_specific_writer() -> None:
+    commit = Commit(
+        sha="abcdef1234567890",
+        subject="fix: example",
+        body="""fix: example
+
+Body.
+
+Writer: gpt-5.5
+Refs: #42
+""",
+    )
+
+    result = validate_commits([commit])
+
+    assert not result.ok
+    assert any("model-specific" in finding.message for finding in result.errors)
+
+
+def test_validate_commits_rejects_writer_outside_final_trailer_block() -> None:
+    commit = Commit(
+        sha="abcdef1234567890",
+        subject="fix: example",
+        body="""fix: example
+
+Body.
+
+Writer: codex
+
+Refs: #42
+""",
+    )
+
+    result = validate_commits([commit])
+
+    assert not result.ok
+    assert any("not in the final contiguous trailer block" in finding.message for finding in result.errors)
+    assert any("missing final Writer" in finding.message for finding in result.errors)
+
+
+def test_validate_commits_supports_repository_specific_writer_enum() -> None:
+    commit = Commit(
+        sha="abcdef1234567890",
+        subject="fix: example",
+        body="""fix: example
+
+Body.
+
+Writer: auditbot
+Refs: tb-123
+""",
+    )
+
+    result = validate_commits(
+        [commit],
+        allowed_writers=normalize_allowed_writers(["auditbot"]),
+    )
+
+    assert result.ok
+    assert result.writers == {"auditbot"}
+
+
+def test_validate_commits_rejects_writer_model_by_default() -> None:
+    commit = Commit(
+        sha="abcdef1234567890",
+        subject="fix: example",
+        body="""fix: example
+
+Body.
+
+Writer: codex
+Writer-Model: gpt-5.5
+Refs: #42
+""",
+    )
+
+    result = validate_commits([commit])
+
+    assert not result.ok
+    assert any("Writer-Model" in finding.message for finding in result.errors)
+
+
+def test_validate_pr_body_requires_provenance_fields() -> None:
+    result = CheckResult(writers={"codex"}, refs={"#42"})
+    body = """## Summary
+Fixes the bug.
+
+## Provenance
+
+- GitHub actor: hermesbot-almace
+- PR created by: codex
+- Implemented by: codex
+- Writers from commit trailers: codex
+- Task ledger: GitHub #42
+
+Closes #42
+"""
+
+    validate_pr_body(body, result)
+
+    assert result.ok
+    assert extract_pr_provenance_block(body) is not None
+
+
+def test_validate_pr_body_fails_without_provenance_block() -> None:
+    result = CheckResult(writers={"codex"}, refs={"#42"})
+
+    validate_pr_body("## Summary\nNo provenance here.\n", result)
+
+    assert not result.ok
+    assert any("missing a ## Provenance" in finding.message for finding in result.errors)
+
+
+def test_emit_pr_block_uses_detected_writers_and_refs() -> None:
+    result = CheckResult(writers={"codex"}, refs={"#42"})
+
+    block = emit_pr_block(result, github_actor="hermesbot-almace")
+
+    assert "GitHub actor: hermesbot-almace" in block
+    assert "PR created by: codex" in block
+    assert "Task ledger: #42" in block


### PR DESCRIPTION
## Summary
- Add bundled hermes-pr-provenance skill for provider-level Writer/Refs, PR provenance blocks, and Beads metadata guidance
- Add generic hermes-git-workflow skill and wire GitHub PR/issues/review/repo skills to the shared provenance contract
- Add hermes-provenance-check console helper for validating commit trailers and optional PR body provenance

## Test Plan
- [x] python -m pytest tests/hermes_cli/test_provenance_check.py -q
- [x] python -m ruff check hermes_cli/provenance_check.py tests/hermes_cli/test_provenance_check.py
- [x] python -m hermes_cli.provenance_check --range origin/main..HEAD --emit-pr-block --github-actor hermesbot-almace

## Provenance
- GitHub actor: hermesbot-almace
- PR created by: codex
- Implemented by: codex
- Writers from commit trailers: codex
- Task ledger: hermes-pr-provenance