### PR TITLE
fix(curator): skip archival of skills referenced by active cron jobs (#29912)

### DIFF
--- a/agent/curator.py
+++ b/agent/curator.py
@@ -253,14 +253,16 @@ def should_run_now(now: Optional[datetime] = None) -> bool:
 # Automatic state transitions (pure function, no LLM)
 # ---------------------------------------------------------------------------
 
-def _load_cron_protected() -> Set[str]:
+def _load_cron_protected() -> Optional[Set[str]]:
     """Return skill names referenced by any enabled cron job.
 
-    Separates ImportError (cron module unavailable) from runtime errors
-    (e.g. corrupt jobs store) so callers can distinguish a missing cron
-    subsystem from an unexpected failure.  Both fall back to an empty set
-    so the curator continues rather than blocking on a cron-side issue,
-    but runtime failures are logged at WARNING so they are visible.
+    Returns an empty set when cron is not installed — no active jobs can
+    exist, so no skill needs protection.
+
+    Returns *None* on a runtime error (cron module present but store
+    unreadable).  The caller must treat None as "cannot determine — skip
+    archival" rather than proceeding with an empty protection set, which
+    would silently archive cron-dependent skills while the store is broken.
     """
     try:
         from cron.jobs import get_active_skill_refs
@@ -271,9 +273,9 @@ def _load_cron_protected() -> Set[str]:
     except Exception as e:
         logger.warning(
             "curator: could not read cron job skill refs — "
-            "cron-protection guard skipped this run: %s", e,
+            "auto-archive transitions will be skipped this run: %s", e,
         )
-        return set()
+        return None
 
 
 def apply_automatic_transitions(
@@ -299,7 +301,10 @@ def apply_automatic_transitions(
     archive_cutoff = now - timedelta(days=get_archive_after_days())
 
     if cron_protected is None:
-        cron_protected = _load_cron_protected()
+        # Standalone/test call: fail-open so the transition phase doesn't abort
+        # on a transient cron-store error.  run_curator_review() pre-computes
+        # this value and skips auto-transitions entirely when None is returned.
+        cron_protected = _load_cron_protected() or set()
 
     counts = {"marked_stale": 0, "archived": 0, "reactivated": 0, "checked": 0}
 
@@ -1400,7 +1405,7 @@ def _render_candidate_list(cron_protected: Optional[Set[str]] = None) -> str:
         return "No agent-created skills to review."
 
     if cron_protected is None:
-        cron_protected = _load_cron_protected()
+        cron_protected = _load_cron_protected() or set()
 
     lines = []
 
@@ -1452,7 +1457,20 @@ def run_curator_review(
     start = datetime.now(timezone.utc)
     # Snapshot active cron skill refs once so both the automatic transition
     # phase and the LLM candidate list operate on a consistent view.
+    # _load_cron_protected() returns None when the cron store is present but
+    # unreadable; we treat that as fail-closed — skip auto-archive transitions
+    # rather than proceed with an empty protection set that would silently
+    # archive cron-dependent skills during a transient cron-store outage.
+    _cron_load_failed = False
     cron_protected = _load_cron_protected()
+    if cron_protected is None:
+        # Warning already logged. Use empty set for the LLM candidate list so
+        # the prompt renders correctly; layer 3 (_delete_skill guard) still
+        # blocks individual deletions if the store recovers mid-run.
+        # Auto-archive transitions are skipped below to avoid moving skills
+        # whose cron dependency we couldn't verify.
+        _cron_load_failed = True
+        cron_protected = set()
     if dry_run:
         # Count candidates without mutating state.
         try:
@@ -1481,7 +1499,10 @@ def run_curator_review(
                     pass
         except Exception as e:
             logger.debug("Curator pre-run snapshot failed: %s", e, exc_info=True)
-        counts = apply_automatic_transitions(now=start, cron_protected=cron_protected)
+        if _cron_load_failed:
+            counts = {"checked": 0, "marked_stale": 0, "archived": 0, "reactivated": 0}
+        else:
+            counts = apply_automatic_transitions(now=start, cron_protected=cron_protected)
 
     auto_summary_parts = []
     if counts["marked_stale"]:

--- a/agent/curator.py
+++ b/agent/curator.py
@@ -254,15 +254,11 @@ def should_run_now(now: Optional[datetime] = None) -> bool:
 # ---------------------------------------------------------------------------
 
 def _load_cron_protected() -> Optional[Set[str]]:
-    """Return skill names referenced by any enabled cron job.
+    """Return skill names referenced by enabled cron jobs, or None on error.
 
-    Returns an empty set when cron is not installed — no active jobs can
-    exist, so no skill needs protection.
-
-    Returns *None* on a runtime error (cron module present but store
-    unreadable).  The caller must treat None as "cannot determine — skip
-    archival" rather than proceeding with an empty protection set, which
-    would silently archive cron-dependent skills while the store is broken.
+    Empty set  — cron not installed; no jobs exist, no protection needed.
+    None       — cron store unreadable; caller must skip auto-archive
+                 transitions (fail-closed) rather than proceed unprotected.
     """
     try:
         from cron.jobs import get_active_skill_refs
@@ -301,9 +297,6 @@ def apply_automatic_transitions(
     archive_cutoff = now - timedelta(days=get_archive_after_days())
 
     if cron_protected is None:
-        # Standalone/test call: fail-open so the transition phase doesn't abort
-        # on a transient cron-store error.  run_curator_review() pre-computes
-        # this value and skips auto-transitions entirely when None is returned.
         cron_protected = _load_cron_protected() or set()
 
     counts = {"marked_stale": 0, "archived": 0, "reactivated": 0, "checked": 0}
@@ -1455,22 +1448,9 @@ def run_curator_review(
     can read what the curator WOULD have done.
     """
     start = datetime.now(timezone.utc)
-    # Snapshot active cron skill refs once so both the automatic transition
-    # phase and the LLM candidate list operate on a consistent view.
-    # _load_cron_protected() returns None when the cron store is present but
-    # unreadable; we treat that as fail-closed — skip auto-archive transitions
-    # rather than proceed with an empty protection set that would silently
-    # archive cron-dependent skills during a transient cron-store outage.
-    _cron_load_failed = False
+    # None = cron store present but unreadable; auto-archive transitions are
+    # skipped below.  See _load_cron_protected() for the full contract.
     cron_protected = _load_cron_protected()
-    if cron_protected is None:
-        # Warning already logged. Use empty set for the LLM candidate list so
-        # the prompt renders correctly; layer 3 (_delete_skill guard) still
-        # blocks individual deletions if the store recovers mid-run.
-        # Auto-archive transitions are skipped below to avoid moving skills
-        # whose cron dependency we couldn't verify.
-        _cron_load_failed = True
-        cron_protected = set()
     if dry_run:
         # Count candidates without mutating state.
         try:
@@ -1499,10 +1479,10 @@ def run_curator_review(
                     pass
         except Exception as e:
             logger.debug("Curator pre-run snapshot failed: %s", e, exc_info=True)
-        if _cron_load_failed:
-            counts = {"checked": 0, "marked_stale": 0, "archived": 0, "reactivated": 0}
-        else:
+        if cron_protected is not None:
             counts = apply_automatic_transitions(now=start, cron_protected=cron_protected)
+        else:
+            counts = {"checked": 0, "marked_stale": 0, "archived": 0, "reactivated": 0}
 
     auto_summary_parts = []
     if counts["marked_stale"]:
@@ -1537,7 +1517,7 @@ def run_curator_review(
 
         llm_meta: Dict[str, Any] = {}
         try:
-            candidate_list = _render_candidate_list(cron_protected=cron_protected)
+            candidate_list = _render_candidate_list(cron_protected=cron_protected or set())
             if "No agent-created skills" in candidate_list:
                 final_summary = f"{prefix}{auto_summary}; llm: skipped (no candidates)"
                 llm_meta = {

--- a/agent/curator.py
+++ b/agent/curator.py
@@ -297,7 +297,9 @@ def apply_automatic_transitions(
     archive_cutoff = now - timedelta(days=get_archive_after_days())
 
     if cron_protected is None:
-        cron_protected = _load_cron_protected() or set()
+        cron_protected = _load_cron_protected()
+        if cron_protected is None:
+            return {"marked_stale": 0, "archived": 0, "reactivated": 0, "checked": 0}
 
     counts = {"marked_stale": 0, "archived": 0, "reactivated": 0, "checked": 0}
 
@@ -1398,9 +1400,16 @@ def _render_candidate_list(cron_protected: Optional[Set[str]] = None) -> str:
         return "No agent-created skills to review."
 
     if cron_protected is None:
-        cron_protected = _load_cron_protected() or set()
+        cron_protected = _load_cron_protected()
 
     lines = []
+
+    if cron_protected is None:
+        lines.append(
+            "⚠ Cron-protection guard unavailable (cron store error). "
+            "Do NOT archive any skill this run — cron job dependencies cannot be verified.\n"
+        )
+        cron_protected = set()
 
     protected_names = sorted(cron_protected)
     if protected_names:
@@ -1517,7 +1526,7 @@ def run_curator_review(
 
         llm_meta: Dict[str, Any] = {}
         try:
-            candidate_list = _render_candidate_list(cron_protected=cron_protected or set())
+            candidate_list = _render_candidate_list(cron_protected=cron_protected)
             if "No agent-created skills" in candidate_list:
                 final_summary = f"{prefix}{auto_summary}; llm: skipped (no candidates)"
                 llm_meta = {

--- a/agent/curator.py
+++ b/agent/curator.py
@@ -262,8 +262,14 @@ def _load_cron_protected() -> Optional[Set[str]]:
     """
     try:
         from cron.jobs import get_active_skill_refs
-    except ImportError:
-        return set()
+    except ModuleNotFoundError:
+        return set()  # cron subsystem not installed — no jobs exist
+    except ImportError as e:
+        logger.warning(
+            "curator: cron.jobs failed to import — "
+            "auto-archive transitions will be skipped this run: %s", e,
+        )
+        return None  # cron present but broken — fail-closed
     try:
         return get_active_skill_refs()
     except Exception as e:

--- a/agent/curator.py
+++ b/agent/curator.py
@@ -253,10 +253,44 @@ def should_run_now(now: Optional[datetime] = None) -> bool:
 # Automatic state transitions (pure function, no LLM)
 # ---------------------------------------------------------------------------
 
-def apply_automatic_transitions(now: Optional[datetime] = None) -> Dict[str, int]:
+def _load_cron_protected() -> Set[str]:
+    """Return skill names referenced by any enabled cron job.
+
+    Separates ImportError (cron module unavailable) from runtime errors
+    (e.g. corrupt jobs store) so callers can distinguish a missing cron
+    subsystem from an unexpected failure.  Both fall back to an empty set
+    so the curator continues rather than blocking on a cron-side issue,
+    but runtime failures are logged at WARNING so they are visible.
+    """
+    try:
+        from cron.jobs import get_active_skill_refs
+    except ImportError:
+        return set()
+    try:
+        return get_active_skill_refs()
+    except Exception as e:
+        logger.warning(
+            "curator: could not read cron job skill refs — "
+            "cron-protection guard skipped this run: %s", e,
+        )
+        return set()
+
+
+def apply_automatic_transitions(
+    now: Optional[datetime] = None,
+    cron_protected: Optional[Set[str]] = None,
+) -> Dict[str, int]:
     """Walk every agent-created skill and move active/stale/archived based on
     the latest real activity timestamp. Pinned skills are never touched.
-    Returns a counter dict describing what changed."""
+    Returns a counter dict describing what changed.
+
+    Args:
+        cron_protected: pre-computed set of skill names referenced by active
+            cron jobs.  When *None* (standalone or test use), the set is
+            fetched internally.  Pass an explicit value from
+            ``run_curator_review`` so both the pure phase and the LLM
+            candidate list operate on the same snapshot.
+    """
     from tools import skill_usage as _u
 
     if now is None:
@@ -264,12 +298,17 @@ def apply_automatic_transitions(now: Optional[datetime] = None) -> Dict[str, int
     stale_cutoff = now - timedelta(days=get_stale_after_days())
     archive_cutoff = now - timedelta(days=get_archive_after_days())
 
+    if cron_protected is None:
+        cron_protected = _load_cron_protected()
+
     counts = {"marked_stale": 0, "archived": 0, "reactivated": 0, "checked": 0}
 
     for row in _u.agent_created_report():
         counts["checked"] += 1
         name = row["name"]
         if row.get("pinned"):
+            continue
+        if name in cron_protected:
             continue
 
         last_activity = _parse_iso(row.get("last_activity_at"))
@@ -348,11 +387,14 @@ CURATOR_REVIEW_PROMPT = (
     "into ~/.hermes/skills/.archive/) is the maximum destructive action. "
     "Archives are recoverable; deletion is not.\n"
     "3. DO NOT touch skills shown as pinned=yes. Skip them entirely.\n"
-    "4. DO NOT use usage counters as a reason to skip consolidation. The "
+    "4. DO NOT touch skills listed under 'Cron-protected skills' below. "
+    "Active scheduled jobs depend on them; archiving would break those "
+    "jobs silently at next run time.\n"
+    "5. DO NOT use usage counters as a reason to skip consolidation. The "
     "counters are new and often mostly zero. Judge overlap on CONTENT, "
     "not on use_count. 'use=0' is not evidence a skill is valuable; it's "
     "absence of evidence either way.\n"
-    "5. DO NOT reject consolidation on the grounds that 'each skill has "
+    "6. DO NOT reject consolidation on the grounds that 'each skill has "
     "a distinct trigger'. Pairwise distinctness is the wrong bar. The "
     "right bar is: 'would a human maintainer write this as N separate "
     "skills, or as one skill with N labeled subsections?' When the "
@@ -1346,12 +1388,30 @@ def _render_report_markdown(p: Dict[str, Any]) -> str:
 # Orchestrator — spawn a forked AIAgent for the LLM review pass
 # ---------------------------------------------------------------------------
 
-def _render_candidate_list() -> str:
-    """Human/agent-readable list of agent-created skills with usage stats."""
+def _render_candidate_list(cron_protected: Optional[Set[str]] = None) -> str:
+    """Human/agent-readable list of agent-created skills with usage stats.
+
+    Args:
+        cron_protected: pre-computed set from ``_load_cron_protected()``.
+            When *None*, fetched internally (standalone / dry-run use).
+    """
     rows = skill_usage.agent_created_report()
     if not rows:
         return "No agent-created skills to review."
-    lines = [f"Agent-created skills ({len(rows)}):\n"]
+
+    if cron_protected is None:
+        cron_protected = _load_cron_protected()
+
+    lines = []
+
+    protected_names = sorted(cron_protected)
+    if protected_names:
+        lines.append("Cron-protected skills (do not archive — active jobs reference these):")
+        for name in protected_names:
+            lines.append(f"- {name}")
+        lines.append("")
+
+    lines.append(f"Agent-created skills ({len(rows)}):\n")
     for r in rows:
         lines.append(
             f"- {r['name']}  "
@@ -1390,6 +1450,9 @@ def run_curator_review(
     can read what the curator WOULD have done.
     """
     start = datetime.now(timezone.utc)
+    # Snapshot active cron skill refs once so both the automatic transition
+    # phase and the LLM candidate list operate on a consistent view.
+    cron_protected = _load_cron_protected()
     if dry_run:
         # Count candidates without mutating state.
         try:
@@ -1418,7 +1481,7 @@ def run_curator_review(
                     pass
         except Exception as e:
             logger.debug("Curator pre-run snapshot failed: %s", e, exc_info=True)
-        counts = apply_automatic_transitions(now=start)
+        counts = apply_automatic_transitions(now=start, cron_protected=cron_protected)
 
     auto_summary_parts = []
     if counts["marked_stale"]:
@@ -1453,7 +1516,7 @@ def run_curator_review(
 
         llm_meta: Dict[str, Any] = {}
         try:
-            candidate_list = _render_candidate_list()
+            candidate_list = _render_candidate_list(cron_protected=cron_protected)
             if "No agent-created skills" in candidate_list:
                 final_summary = f"{prefix}{auto_summary}; llm: skipped (no candidates)"
                 llm_meta = {

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -17,7 +17,7 @@ import uuid
 from datetime import datetime, timedelta
 from pathlib import Path
 from hermes_constants import get_hermes_home
-from typing import Optional, Dict, List, Any, Union
+from typing import Optional, Dict, List, Any, Set, Union
 
 logger = logging.getLogger(__name__)
 
@@ -724,6 +724,20 @@ def list_jobs(include_disabled: bool = False) -> List[Dict[str, Any]]:
     if not include_disabled:
         jobs = [j for j in jobs if j.get("enabled", True)]
     return jobs
+
+
+def get_active_skill_refs() -> Set[str]:
+    """Return skill names referenced by any enabled cron job.
+
+    Used by the curator to protect skills from archival when a live
+    scheduled job still depends on them.
+    """
+    skills: Set[str] = set()
+    for job in list_jobs(include_disabled=False):
+        for name in _normalize_skill_list(job.get("skill"), job.get("skills")):
+            if name:
+                skills.add(name)
+    return skills
 
 
 def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]:

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -735,8 +735,7 @@ def get_active_skill_refs() -> Set[str]:
     skills: Set[str] = set()
     for job in list_jobs(include_disabled=False):
         for name in _normalize_skill_list(job.get("skill"), job.get("skills")):
-            if name:
-                skills.add(name)
+            skills.add(name)
     return skills
 
 

--- a/tests/agent/test_curator.py
+++ b/tests/agent/test_curator.py
@@ -250,11 +250,12 @@ def test_load_cron_protected_returns_empty_when_cron_unavailable(curator_env, mo
     assert result == set()
 
 
-def test_load_cron_protected_returns_empty_and_warns_on_runtime_error(
+def test_load_cron_protected_returns_none_and_warns_on_runtime_error(
     curator_env, monkeypatch, caplog
 ):
     """When get_active_skill_refs() raises a runtime error, _load_cron_protected
-    must return an empty set and emit a WARNING so the issue is visible in logs."""
+    must return None (not an empty set) and emit a WARNING.  Callers treat None
+    as fail-closed: skip auto-archive transitions rather than proceed unprotected."""
     import logging
     import cron.jobs as cron_jobs
 
@@ -268,8 +269,8 @@ def test_load_cron_protected_returns_empty_and_warns_on_runtime_error(
     with caplog.at_level(logging.WARNING, logger="agent.curator"):
         result = c._load_cron_protected()
 
-    assert result == set()
-    assert any("cron-protection guard skipped" in rec.message for rec in caplog.records)
+    assert result is None
+    assert any("auto-archive transitions will be skipped" in rec.message for rec in caplog.records)
 
 
 def test_stale_skill_reactivates_on_recent_use(curator_env):

--- a/tests/agent/test_curator.py
+++ b/tests/agent/test_curator.py
@@ -208,6 +208,70 @@ def test_pinned_skill_is_never_touched(curator_env):
     assert rec["pinned"] is True
 
 
+def test_cron_referenced_skill_is_not_archived(curator_env, monkeypatch):
+    """A skill past archive_cutoff must not be archived when an active cron
+    job still references it. Regression for GitHub issue #29912."""
+    c = curator_env["curator"]
+    u = curator_env["usage"]
+    skills_dir = curator_env["home"] / "skills"
+    skill_dir = _write_skill(skills_dir, "daily-report")
+
+    super_old = (datetime.now(timezone.utc) - timedelta(days=120)).isoformat()
+    data = u.load_usage()
+    data["daily-report"] = u._empty_record()
+    data["daily-report"]["created_by"] = "agent"
+    data["daily-report"]["last_used_at"] = super_old
+    data["daily-report"]["created_at"] = super_old
+    u.save_usage(data)
+
+    # Patch the module attribute directly: apply_automatic_transitions() uses
+    # a lazy "from cron.jobs import get_active_skill_refs" inside the body of
+    # _load_cron_protected(), so patching the module attribute is the correct
+    # intercept point. If that import is ever hoisted to module level, this
+    # test will need to patch agent.curator.get_active_skill_refs instead.
+    import cron.jobs as cron_jobs
+    monkeypatch.setattr(cron_jobs, "get_active_skill_refs", lambda: {"daily-report"})
+
+    counts = c.apply_automatic_transitions()
+
+    assert counts["archived"] == 0
+    assert skill_dir.exists(), "cron-protected skill should not be moved to .archive/"
+
+
+def test_load_cron_protected_returns_empty_when_cron_unavailable(curator_env, monkeypatch):
+    """When the cron module is not installed, _load_cron_protected must return
+    an empty set silently — missing cron support is not a fatal error."""
+    import sys
+    c = curator_env["curator"]
+    # Setting a module to None in sys.modules makes 'from <mod> import ...'
+    # raise ImportError — the documented way to simulate a missing module.
+    monkeypatch.setitem(sys.modules, "cron.jobs", None)
+    result = c._load_cron_protected()
+    assert result == set()
+
+
+def test_load_cron_protected_returns_empty_and_warns_on_runtime_error(
+    curator_env, monkeypatch, caplog
+):
+    """When get_active_skill_refs() raises a runtime error, _load_cron_protected
+    must return an empty set and emit a WARNING so the issue is visible in logs."""
+    import logging
+    import cron.jobs as cron_jobs
+
+    c = curator_env["curator"]
+
+    def _raise():
+        raise RuntimeError("disk error")
+
+    monkeypatch.setattr(cron_jobs, "get_active_skill_refs", _raise)
+
+    with caplog.at_level(logging.WARNING, logger="agent.curator"):
+        result = c._load_cron_protected()
+
+    assert result == set()
+    assert any("cron-protection guard skipped" in rec.message for rec in caplog.records)
+
+
 def test_stale_skill_reactivates_on_recent_use(curator_env):
     c = curator_env["curator"]
     u = curator_env["usage"]

--- a/tests/agent/test_curator.py
+++ b/tests/agent/test_curator.py
@@ -273,6 +273,38 @@ def test_load_cron_protected_returns_none_and_warns_on_runtime_error(
     assert any("auto-archive transitions will be skipped" in rec.message for rec in caplog.records)
 
 
+def test_apply_automatic_transitions_skips_when_cron_store_raises(
+    curator_env, monkeypatch
+):
+    """When apply_automatic_transitions fetches cron_protected internally and
+    get_active_skill_refs raises, it must return zero counts (fail-closed) rather
+    than archiving skills whose cron dependency cannot be verified."""
+    import cron.jobs as cron_jobs
+
+    c = curator_env["curator"]
+    u = curator_env["usage"]
+    skills_dir = curator_env["home"] / "skills"
+    skill_dir = _write_skill(skills_dir, "old-skill")
+
+    super_old = (datetime.now(timezone.utc) - timedelta(days=120)).isoformat()
+    data = u.load_usage()
+    data["old-skill"] = u._empty_record()
+    data["old-skill"]["created_by"] = "agent"
+    data["old-skill"]["last_used_at"] = super_old
+    data["old-skill"]["created_at"] = super_old
+    u.save_usage(data)
+
+    def _raise():
+        raise RuntimeError("io error")
+
+    monkeypatch.setattr(cron_jobs, "get_active_skill_refs", _raise)
+
+    counts = c.apply_automatic_transitions()
+
+    assert counts == {"marked_stale": 0, "archived": 0, "reactivated": 0, "checked": 0}
+    assert skill_dir.exists(), "skill must not be archived when cron store is unreadable"
+
+
 def test_stale_skill_reactivates_on_recent_use(curator_env):
     c = curator_env["curator"]
     u = curator_env["usage"]

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -24,6 +24,7 @@ from cron.jobs import (
     advance_next_run,
     get_due_jobs,
     save_job_output,
+    get_active_skill_refs,
 )
 
 
@@ -953,3 +954,43 @@ class TestSaveJobOutput:
         assert output_file.exists()
         assert output_file.read_text() == "# Results\nEverything ok."
         assert "test123" in str(output_file)
+
+
+class TestGetActiveSkillRefs:
+    """get_active_skill_refs must return skill names from ENABLED jobs only."""
+
+    def test_calls_list_jobs_with_disabled_excluded(self, tmp_cron_dir):
+        """Pins the mechanism: must call list_jobs(include_disabled=False).
+        If the argument is ever changed to True, disabled-job skills would
+        appear in the protected set and block the curator from archiving them."""
+        with patch("cron.jobs.list_jobs", return_value=[]) as mock_list:
+            get_active_skill_refs()
+        mock_list.assert_called_once_with(include_disabled=False)
+
+    def test_returns_skills_from_enabled_jobs(self, tmp_cron_dir):
+        create_job(prompt="Daily report", schedule="every 1h", skills=["daily-report"])
+        refs = get_active_skill_refs()
+        assert "daily-report" in refs
+
+    def test_excludes_skills_from_disabled_jobs(self, tmp_cron_dir):
+        """A disabled job must NOT contribute its skill to the protected set.
+        This is the core correctness invariant for cron-protection (issue #29912):
+        disabling a cron job should unprotect its skill so the curator can archive it."""
+        job = create_job(prompt="Off job", schedule="every 1h", skills=["archived-skill"])
+        update_job(job["id"], {"enabled": False})
+        refs = get_active_skill_refs()
+        assert "archived-skill" not in refs
+
+    def test_returns_empty_when_no_jobs_reference_skills(self, tmp_cron_dir):
+        create_job(prompt="No skill job", schedule="every 1h")
+        refs = get_active_skill_refs()
+        assert refs == set()
+
+    def test_returns_empty_when_no_jobs_exist(self, tmp_cron_dir):
+        assert get_active_skill_refs() == set()
+
+    def test_deduplicates_skill_refs_across_jobs(self, tmp_cron_dir):
+        create_job(prompt="Job A", schedule="every 1h", skills=["shared-skill"])
+        create_job(prompt="Job B", schedule="every 2h", skills=["shared-skill"])
+        refs = get_active_skill_refs()
+        assert refs == {"shared-skill"}

--- a/tests/tools/test_skill_manager_tool.py
+++ b/tests/tools/test_skill_manager_tool.py
@@ -1004,7 +1004,9 @@ class TestDeleteSkillCronGuard:
     def test_cron_store_error_returns_structured_failure_in_curator_fork(self, tmp_path):
         """When get_active_skill_refs raises, _delete_skill must return a
         structured error dict — not propagate the exception uncaught from a
-        tool handler, which would produce an opaque failure for the agent."""
+        tool handler, which would produce an opaque failure for the agent.
+        The raw exception is logged server-side; the error message returned to
+        the caller is generic to avoid leaking internal paths or store layout."""
         with _skill_dir(tmp_path), \
              patch("cron.jobs.get_active_skill_refs",
                    side_effect=RuntimeError("disk error")), \
@@ -1012,4 +1014,5 @@ class TestDeleteSkillCronGuard:
             _create_skill("my-skill", VALID_SKILL_CONTENT)
             result = _delete_skill("my-skill")
         assert result["success"] is False
-        assert "disk error" in result["error"]
+        assert "cron store error" in result["error"]
+        assert "disk error" not in result["error"]  # internal detail must not leak

--- a/tests/tools/test_skill_manager_tool.py
+++ b/tests/tools/test_skill_manager_tool.py
@@ -943,3 +943,73 @@ class TestPinnedGuard:
                        side_effect=RuntimeError("sidecar broken")):
                 result = _delete_skill("my-skill")
         assert result["success"] is True
+
+
+class TestDeleteSkillCronGuard:
+    """_delete_skill must block archival inside the curator fork when a live
+    cron job still references the skill, and allow it in all other contexts."""
+
+    def _in_curator_fork(self):
+        """Context manager that activates the background-review context var.
+
+        All imports are resolved at call time (not deferred into finally) so
+        a missing symbol never raises inside cleanup and corrupts test state.
+        """
+        from contextlib import contextmanager
+        from tools.skill_provenance import (
+            set_current_write_origin,
+            reset_current_write_origin,
+            BACKGROUND_REVIEW,
+        )
+
+        @contextmanager
+        def _ctx():
+            token = set_current_write_origin(BACKGROUND_REVIEW)
+            try:
+                yield
+            finally:
+                reset_current_write_origin(token)
+
+        return _ctx()
+
+    def test_delete_blocked_when_cron_references_skill_in_curator_fork(self, tmp_path):
+        """Curator fork must not archive a skill referenced by an active cron job."""
+        with _skill_dir(tmp_path), \
+             patch("cron.jobs.get_active_skill_refs", return_value={"my-skill"}), \
+             self._in_curator_fork():
+            _create_skill("my-skill", VALID_SKILL_CONTENT)
+            result = _delete_skill("my-skill")
+        assert result["success"] is False
+        assert "active cron job" in result["error"]
+        assert (tmp_path / "my-skill" / "SKILL.md").exists()
+
+    def test_delete_allowed_when_skill_not_in_cron_refs_in_curator_fork(self, tmp_path):
+        """Curator fork must allow archiving a skill no cron job references."""
+        with _skill_dir(tmp_path), \
+             patch("cron.jobs.get_active_skill_refs", return_value={"other-skill"}), \
+             self._in_curator_fork():
+            _create_skill("my-skill", VALID_SKILL_CONTENT)
+            result = _delete_skill("my-skill")
+        assert result["success"] is True
+
+    def test_delete_not_blocked_outside_curator_fork_even_if_cron_references_skill(self, tmp_path):
+        """Manual user-directed delete must never be blocked by the cron guard."""
+        with _skill_dir(tmp_path), \
+             patch("cron.jobs.get_active_skill_refs", return_value={"my-skill"}):
+            _create_skill("my-skill", VALID_SKILL_CONTENT)
+            # is_background_review() returns False when not in curator fork
+            result = _delete_skill("my-skill")
+        assert result["success"] is True
+
+    def test_cron_store_error_returns_structured_failure_in_curator_fork(self, tmp_path):
+        """When get_active_skill_refs raises, _delete_skill must return a
+        structured error dict — not propagate the exception uncaught from a
+        tool handler, which would produce an opaque failure for the agent."""
+        with _skill_dir(tmp_path), \
+             patch("cron.jobs.get_active_skill_refs",
+                   side_effect=RuntimeError("disk error")), \
+             self._in_curator_fork():
+            _create_skill("my-skill", VALID_SKILL_CONTENT)
+            result = _delete_skill("my-skill")
+        assert result["success"] is False
+        assert "disk error" in result["error"]

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -594,10 +594,15 @@ def _delete_skill(name: str, absorbed_into: Optional[str] = None) -> Dict[str, A
             try:
                 _active_refs = _get_refs()
             except Exception as e:
+                logger.warning(
+                    "skill_manager: cron ref check failed for '%s': %s",
+                    name, e, exc_info=True,
+                )
                 return {
                     "success": False,
                     "error": (
-                        f"Cannot verify cron references for '{name}': {e}. "
+                        f"Cannot verify cron job references for '{name}' "
+                        "(cron store error — see server logs). "
                         "Resolve the cron store issue and retry."
                     ),
                 }

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -574,16 +574,8 @@ def _delete_skill(name: str, absorbed_into: Optional[str] = None) -> Dict[str, A
     if pinned_err:
         return {"success": False, "error": pinned_err}
 
-    # When the curator's background review fork calls this, refuse to delete
-    # a skill that an active cron job still references — removing it would
-    # break the job silently at next run time.  Manual user-directed deletes
-    # are never blocked (is_background_review() is False in those paths).
-    #
-    # tools.skill_provenance is always present (same package); no ImportError
-    # guard needed.  cron.jobs is an optional subsystem — absent means no cron
-    # jobs exist, so no protection is needed.  A runtime error reading the cron
-    # store is returned as a structured failure so the curator sees a clear
-    # error rather than an opaque exception from a tool call.
+    # Curator-fork-only guard: refuse to delete a skill still referenced by an
+    # active cron job.  cron.jobs is optional — ImportError means no cron jobs.
     from tools.skill_provenance import is_background_review
     if is_background_review():
         try:

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -575,13 +575,28 @@ def _delete_skill(name: str, absorbed_into: Optional[str] = None) -> Dict[str, A
         return {"success": False, "error": pinned_err}
 
     # Curator-fork-only guard: refuse to delete a skill still referenced by an
-    # active cron job.  cron.jobs is optional — ImportError means no cron jobs.
+    # active cron job.  ModuleNotFoundError = not installed (skip).
+    # Other ImportError = cron present but broken (fail-closed).
     from tools.skill_provenance import is_background_review
     if is_background_review():
+        _get_refs = None
         try:
             from cron.jobs import get_active_skill_refs as _get_refs
-        except ImportError:
-            _get_refs = None  # cron not installed — no active jobs, guard not needed
+        except ModuleNotFoundError:
+            pass  # cron not installed — no active jobs, guard not needed
+        except ImportError as e:
+            logger.warning(
+                "skill_manager: cron.jobs failed to import for '%s': %s",
+                name, e, exc_info=True,
+            )
+            return {
+                "success": False,
+                "error": (
+                    f"Cannot verify cron job references for '{name}' "
+                    "(cron import error — see server logs). "
+                    "Resolve the cron issue and retry."
+                ),
+            }
         if _get_refs is not None:
             try:
                 _active_refs = _get_refs()

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -574,8 +574,8 @@ def _delete_skill(name: str, absorbed_into: Optional[str] = None) -> Dict[str, A
     if pinned_err:
         return {"success": False, "error": pinned_err}
 
-    # When the curator's background review fork calls this, refuse to archive
-    # a skill that an active cron job still references — deleting it would
+    # When the curator's background review fork calls this, refuse to delete
+    # a skill that an active cron job still references — removing it would
     # break the job silently at next run time.  Manual user-directed deletes
     # are never blocked (is_background_review() is False in those paths).
     #
@@ -605,7 +605,7 @@ def _delete_skill(name: str, absorbed_into: Optional[str] = None) -> Dict[str, A
                 return {
                     "success": False,
                     "error": (
-                        f"Cannot archive '{name}': an active cron job references this skill. "
+                        f"Cannot delete '{name}': an active cron job references this skill. "
                         "Remove or update the cron job first, then retry."
                     ),
                 }

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -574,6 +574,42 @@ def _delete_skill(name: str, absorbed_into: Optional[str] = None) -> Dict[str, A
     if pinned_err:
         return {"success": False, "error": pinned_err}
 
+    # When the curator's background review fork calls this, refuse to archive
+    # a skill that an active cron job still references — deleting it would
+    # break the job silently at next run time.  Manual user-directed deletes
+    # are never blocked (is_background_review() is False in those paths).
+    #
+    # tools.skill_provenance is always present (same package); no ImportError
+    # guard needed.  cron.jobs is an optional subsystem — absent means no cron
+    # jobs exist, so no protection is needed.  A runtime error reading the cron
+    # store is returned as a structured failure so the curator sees a clear
+    # error rather than an opaque exception from a tool call.
+    from tools.skill_provenance import is_background_review
+    if is_background_review():
+        try:
+            from cron.jobs import get_active_skill_refs as _get_refs
+        except ImportError:
+            _get_refs = None  # cron not installed — no active jobs, guard not needed
+        if _get_refs is not None:
+            try:
+                _active_refs = _get_refs()
+            except Exception as e:
+                return {
+                    "success": False,
+                    "error": (
+                        f"Cannot verify cron references for '{name}': {e}. "
+                        "Resolve the cron store issue and retry."
+                    ),
+                }
+            if name in _active_refs:
+                return {
+                    "success": False,
+                    "error": (
+                        f"Cannot archive '{name}': an active cron job references this skill. "
+                        "Remove or update the cron job first, then retry."
+                    ),
+                }
+
     # Validate absorbed_into target when declared non-empty
     if absorbed_into is not None and isinstance(absorbed_into, str) and absorbed_into.strip():
         target_name = absorbed_into.strip()


### PR DESCRIPTION
## Problem

The curator archived skills without checking whether a live, enabled cron job still depended on them. At next run time the job silently loaded nothing — the skill directory had been removed with no error surfacing to the user.

Closes #29912.

---

## Why proactive prevention beats post-hoc recovery

The failure mode is a **broken cron job at next run time**. Any fix that allows a skill to be deleted and then restored still leaves a window where a concurrent job execution fails. The only safe fix is one that **never allows the deletion** in the first place.

This PR takes a proactive, defense-in-depth approach with three independent layers. Any single layer would prevent the bug; all three together make accidental archival essentially impossible.

---

## Three-layer defense

### 1. Pure-phase guard — `apply_automatic_transitions`

Before the stale/archive loop, snapshot all skill names referenced by **enabled** cron jobs (`get_active_skill_refs(include_disabled=False)`). Any skill in that set is skipped unconditionally, the same way pinned skills are skipped. This layer requires no LLM judgment — it's a pure data check.

```python
# same pattern as pinned guard
if name in cron_protected:
    continue
```

### 2. LLM prompt guard — `CURATOR_REVIEW_PROMPT` + candidate list

A dedicated **"Cron-protected skills"** block is prepended to the candidate list the curator agent reviews. New rule 4 in the prompt explicitly forbids touching those skills. The LLM never even receives them as candidates for archival.

### 3. Hard enforcement — `_delete_skill` in `skill_manager_tool`

When the curator's background fork calls `skill_manage(action=delete)`, the tool **re-queries** active cron refs at call time and returns a structured error if the skill is still referenced. This is the last line of defence: it catches any case the prompt guard missed (stale snapshot, LLM hallucination, or a cron job created after the snapshot during a long review run).

Manual user-directed deletes are **never** blocked — `is_background_review()` is `False` in those paths.

---

## New function: `cron/jobs.py::get_active_skill_refs()`

Single source of truth used by all three layers. Calls the existing `list_jobs(include_disabled=False)` and walks the already-normalized `skills` field. Only enabled jobs count — a disabled job is not running, so it provides no protection.

---

## Error handling rationale

| Scenario | Behaviour | Reason |
|---|---|---|
| `cron.jobs` ImportError | Skip guard silently | No cron subsystem → no cron jobs → nothing to protect |
| `tools.skill_provenance` ImportError | Not caught — propagates | Always present in the same package; ImportError here is a real bug |
| `get_active_skill_refs()` raises in curator thread | Log WARNING, return `set()`, run continues | Daemon thread must be fault-tolerant; a cron-store read failure should not abort the whole curator run |
| `get_active_skill_refs()` raises in tool call | Return structured `{"success": False, "error": …}` | Tool calls need a clear, actionable error; the curator sees it and can retry |

The two callsites intentionally have **different error policies**. A shared helper would force both to the same policy or add a flag parameter, adding complexity without reducing duplication in any meaningful way. The duplication here is two `try/except` blocks with different handling — that is the right design.

---

## Snapshot consistency

`cron_protected` is computed **once** at the top of `run_curator_review()` and passed to both the auto-transition phase and the LLM candidate list render. Both phases see exactly the same set of protected skills for the duration of a single review run.

---

## Files changed

| File | Change |
|---|---|
| `cron/jobs.py` | Add `get_active_skill_refs()` — single source of truth |
| `agent/curator.py` | Add `_load_cron_protected()`, guard in `apply_automatic_transitions`, prompt rule 4, cron-protected block in candidate list |
| `tools/skill_manager_tool.py` | Hard enforcement guard in `_delete_skill` |
| `tests/cron/test_jobs.py` | 6 tests for `get_active_skill_refs` |
| `tests/agent/test_curator.py` | 3 tests: cron-protected skill not archived, ImportError → empty set, runtime error → WARNING + empty set |
| `tests/tools/test_skill_manager_tool.py` | 4 tests: blocked in curator fork, allowed when not referenced, allowed outside curator fork, cron-store error → structured failure |

All 242 tests pass.