### PR TITLE
fix(state): survive broken trigram fts index

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -336,6 +336,7 @@ class SessionDB:
 
         self._lock = threading.Lock()
         self._write_count = 0
+        self._trigram_fts_available = True
         try:
             self._conn = sqlite3.connect(
                 str(self.db_path),
@@ -548,6 +549,50 @@ class SessionDB:
                             "reconcile %s.%s: %s", table_name, col_name, exc,
                         )
 
+    def _backfill_trigram_fts(self, cursor: sqlite3.Cursor) -> None:
+        cursor.execute(
+            "INSERT INTO messages_fts_trigram(rowid, content) "
+            "SELECT id, "
+            "COALESCE(content, '') || ' ' || "
+            "COALESCE(tool_name, '') || ' ' || "
+            "COALESCE(tool_calls, '') "
+            "FROM messages"
+        )
+
+    def _rebuild_trigram_fts(self, cursor: sqlite3.Cursor, reason: Exception) -> bool:
+        """Rebuild the optional trigram FTS index without touching transcripts."""
+        logger.warning("Rebuilding messages_fts_trigram after init failure: %s", reason)
+        for trigger in (
+            "messages_fts_trigram_insert",
+            "messages_fts_trigram_delete",
+            "messages_fts_trigram_update",
+        ):
+            try:
+                cursor.execute(f"DROP TRIGGER IF EXISTS {trigger}")
+            except sqlite3.DatabaseError:
+                pass
+        try:
+            cursor.execute("DROP TABLE IF EXISTS messages_fts_trigram")
+        except sqlite3.DatabaseError:
+            # If the virtual table constructor is broken, DROP TABLE can fail
+            # before it reaches the shadow tables. Remove only the optional FTS
+            # schema entries; sessions/messages remain ordinary tables.
+            try:
+                cursor.execute("PRAGMA writable_schema=ON")
+                cursor.execute("DELETE FROM sqlite_schema WHERE name LIKE 'messages_fts_trigram%'")
+            except sqlite3.DatabaseError as exc:
+                cursor.execute("PRAGMA writable_schema=OFF")
+                logger.warning(
+                    "Could not repair messages_fts_trigram; disabling optional "
+                    "trigram search for this connection: %s",
+                    exc,
+                )
+                return False
+            cursor.execute("PRAGMA writable_schema=OFF")
+        cursor.executescript(FTS_TRIGRAM_SQL)
+        self._backfill_trigram_fts(cursor)
+        return True
+
     def _init_schema(self):
         """Create tables and FTS if they don't exist, reconcile columns.
 
@@ -686,8 +731,12 @@ class SessionDB:
         # Trigram FTS5 for CJK/substring search
         try:
             cursor.execute("SELECT * FROM messages_fts_trigram LIMIT 0")
-        except sqlite3.OperationalError:
-            cursor.executescript(FTS_TRIGRAM_SQL)
+        except sqlite3.DatabaseError as exc:
+            if "no such table" in str(exc).lower():
+                cursor.executescript(FTS_TRIGRAM_SQL)
+                self._backfill_trigram_fts(cursor)
+            else:
+                self._trigram_fts_available = self._rebuild_trigram_fts(cursor, exc)
 
         self._conn.commit()
 
@@ -1497,6 +1546,10 @@ class SessionDB:
             num_tool_calls = len(tool_calls) if isinstance(tool_calls, list) else 1
 
         def _do(conn):
+            conn.execute(
+                "INSERT OR IGNORE INTO sessions (id, source, started_at) VALUES (?, ?, ?)",
+                (session_id, "unknown", time.time()),
+            )
             cursor = conn.execute(
                 """INSERT INTO messages (session_id, role, content, tool_call_id,
                    tool_calls, tool_name, timestamp, token_count, finish_reason,
@@ -2235,7 +2288,7 @@ class SessionDB:
                 self._count_cjk(t) < 3 for t in _tokens_for_check
             )
 
-            if cjk_count >= 3 and not _any_short_cjk:
+            if self._trigram_fts_available and cjk_count >= 3 and not _any_short_cjk:
                 # Trigram FTS5 path — quote each non-operator token to handle
                 # FTS5 special chars (%, *, etc.) while preserving boolean
                 # operators (AND, OR, NOT) for multi-term queries.
@@ -2281,7 +2334,8 @@ class SessionDB:
                 with self._lock:
                     try:
                         tri_cursor = self._conn.execute(tri_sql, tri_params)
-                    except sqlite3.OperationalError:
+                    except sqlite3.DatabaseError:
+                        self._trigram_fts_available = False
                         matches = []
                     else:
                         matches = [dict(row) for row in tri_cursor.fetchall()]
@@ -3270,4 +3324,3 @@ class SessionDB:
                 (error[:500], session_id),
             )
         self._execute_write(_do)
-

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -1,5 +1,6 @@
 """Tests for hermes_state.py — SessionDB SQLite CRUD, FTS5 search, export."""
 
+import sqlite3
 import time
 import pytest
 from pathlib import Path
@@ -38,6 +39,20 @@ class TestSessionLifecycle:
 
     def test_get_nonexistent_session(self, db):
         assert db.get_session("nonexistent") is None
+
+    def test_append_message_creates_missing_session_row(self, db):
+        """Gateway flushes can race with session creation; don't drop messages."""
+        message_id = db.append_message(
+            session_id="missing-session",
+            role="user",
+            content="persist this gateway message",
+        )
+
+        session = db.get_session("missing-session")
+        assert message_id > 0
+        assert session is not None
+        assert session["source"] == "unknown"
+        assert session["message_count"] == 1
 
     def test_end_session(self, db):
         db.create_session(session_id="s1", source="cli")
@@ -2905,12 +2920,69 @@ class TestFTS5ToolCallMigration:
     """v11 migration: pre-existing state.db with old external-content FTS tables
     must be re-indexed so tool_name / tool_calls become searchable after upgrade."""
 
+    def test_rebuild_trigram_fts_preserves_messages(self, tmp_path):
+        """A corrupt optional trigram index must not make state.db unusable."""
+        db_path = tmp_path / "repair.db"
+        session_db = SessionDB(db_path=db_path)
+        try:
+            session_db.create_session("s1", "cli")
+            session_db.append_message(
+                "s1",
+                role="assistant",
+                content="substring recovery message",
+                tool_name="REPAIRTOOL",
+            )
+
+            cursor = session_db._conn.cursor()
+            for trigger in (
+                "messages_fts_trigram_insert",
+                "messages_fts_trigram_delete",
+                "messages_fts_trigram_update",
+            ):
+                cursor.execute(f"DROP TRIGGER IF EXISTS {trigger}")
+            cursor.execute("DROP TABLE IF EXISTS messages_fts_trigram")
+
+            rebuilt = session_db._rebuild_trigram_fts(
+                cursor,
+                sqlite3.DatabaseError("vtable constructor failed: messages_fts_trigram"),
+            )
+            session_db._conn.commit()
+
+            assert rebuilt is True
+            indexed_count = session_db._conn.execute(
+                "SELECT count(*) FROM messages_fts_trigram"
+            ).fetchone()[0]
+            assert indexed_count == 1
+            assert len(session_db.search_messages("substring")) == 1
+            assert len(session_db.search_messages("REPAIRTOOL")) == 1
+        finally:
+            session_db.close()
+
+    def test_rebuild_trigram_fts_degrades_when_schema_repair_is_blocked(self, db):
+        """Some sqlite builds block writable_schema; state.db must still open."""
+        class BlockedSchemaCursor:
+            def execute(self, sql):
+                if sql == "DROP TABLE IF EXISTS messages_fts_trigram":
+                    raise sqlite3.DatabaseError(
+                        "vtable constructor failed: messages_fts_trigram"
+                    )
+                if sql.startswith("DELETE FROM sqlite_schema"):
+                    raise sqlite3.OperationalError("table sqlite_master may not be modified")
+
+            def executescript(self, _sql):
+                raise AssertionError("blocked schema repair must not recreate FTS")
+
+        rebuilt = db._rebuild_trigram_fts(
+            BlockedSchemaCursor(),
+            sqlite3.DatabaseError("vtable constructor failed: messages_fts_trigram"),
+        )
+
+        assert rebuilt is False
+
     def test_v10_to_v11_upgrade_backfills_tool_fields(self, tmp_path):
         """Simulate an existing user: build a v10-shaped DB by hand, insert a
         row with tool_calls, then open via SessionDB (which runs migrations).
         After upgrade, the tool_calls token must be searchable."""
-        import sqlite3
-
         db_path = tmp_path / "legacy.db"
 
         # Build the pre-v11 schema by hand: external-content FTS tables +
@@ -2998,4 +3070,3 @@ class TestFTS5ToolCallMigration:
             assert version == SCHEMA_VERSION
         finally:
             session_db.close()
-


### PR DESCRIPTION
## What does this PR do?

Fixes a `state.db` failure mode where a broken optional `messages_fts_trigram` FTS5 virtual table can prevent `SessionDB` from initializing, even though the canonical `sessions` and `messages` tables are intact.

This matters because the gateway now relies on `state.db` as canonical transcript storage. If SessionDB init fails, the agent can appear to have no conversation history despite ordinary transcript rows still being present.

The approach is intentionally narrow:

- probe the optional trigram FTS table with `sqlite3.DatabaseError`, not only `OperationalError`;
- try to rebuild the optional trigram FTS table and backfill it from `messages`;
- if sqlite blocks schema repair for a broken vtable, disable only trigram search for that connection instead of failing the whole DB open;
- make `append_message()` create a missing session row defensively so gateway flush races do not drop messages.

This is related to #27770, but not a duplicate: #27770 makes trigram FTS optional for size/configuration. This PR handles the corrupt-vtable constructor failure path that prevents `state.db` from opening.

## Related Issue

Fixes #
Refs #27770

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_state.py`
  - Added trigram FTS backfill/rebuild helpers.
  - Treats broken optional trigram FTS as recoverable during schema init.
  - Falls back by disabling trigram search on the connection if schema repair is blocked.
  - Routes CJK trigram search through LIKE fallback when trigram search is unavailable.
  - Makes `append_message()` insert a missing `sessions` row with source `unknown` before inserting the message.
- `tests/test_hermes_state.py`
  - Added regression coverage for missing-session append self-healing.
  - Added regression coverage for trigram FTS rebuild preserving messages.
  - Added regression coverage for blocked schema repair degrading instead of failing DB open.

## How to Test

1. Run syntax checks:
   ```bash
   python -m py_compile hermes_state.py tests/test_hermes_state.py
   ```
2. Run focused state DB tests:
   ```bash
   python -m pytest tests/test_hermes_state.py -q
   ```
3. Optional real-world regression check: open a copy of a `state.db` where `SELECT * FROM messages_fts_trigram LIMIT 0` raises `vtable constructor failed: messages_fts_trigram`; SessionDB should still open and ordinary writes should still work.

Local verification:

- `python -m py_compile hermes_state.py tests/test_hermes_state.py` passed.
- `python -m pytest tests/test_hermes_state.py -q` passed: `218 passed in 1.45s`.
- A copy of an actual broken DB opened successfully after this patch: `integrity ok`, `sessions 446`, `messages 27893`, and a new message write succeeded with trigram search disabled for the connection.
- `scripts/run_tests.sh` was attempted. It completed with unrelated environment/live-system failures in this macOS sandbox: `24354 passed, 333 failed`; failures were in socket binding, live-system guard, systemd/platform, OAuth/env tests, and unrelated web provider expectations.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(state): survive broken trigram fts index`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS, Python 3.11.9

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — SQLite-only recovery path, no platform-specific calls
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

```text
$ python -m pytest tests/test_hermes_state.py -q
218 passed in 1.45s
```
