### PR TITLE
fix(discord): fetch and inject reply context for incoming messages

### DIFF
--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -4808,6 +4808,20 @@ class DiscordAdapter(BasePlatformAdapter):
             reply_to_id = str(message.reference.message_id)
             if message.reference.resolved:
                 reply_to_text = getattr(message.reference.resolved, "content", None) or None
+            # When Discord doesn't provide the resolved message inline
+            # (common in high-traffic servers or for older messages),
+            # fetch it from the API so the agent has reply context.
+            if reply_to_text is None and reply_to_id:
+                try:
+                    ref_msg = await message.channel.fetch_message(int(reply_to_id))
+                    reply_to_text = getattr(ref_msg, "content", None) or None
+                except Exception:
+                    logger.debug("Could not fetch reply-to message %s", reply_to_id)
+        # Prepend reply context to the message text so the agent can
+        # understand what the user is responding to.
+        if reply_to_text:
+            reply_context = f'[Replying to: "{reply_to_text[:200]}"]\n' if len(reply_to_text) <= 200 else f'[Replying to: "{reply_to_text[:200]}..."]\n'
+            event_text = reply_context + event_text
 
         event = MessageEvent(
             text=event_text,


### PR DESCRIPTION
## Summary

When a user replies to a message in Discord, Hermes now fetches the referenced message content and prepends it to the incoming message text so the agent understands the context of the reply.

## Problem

Issue #30049: When a user replies to a specific message in Discord, Hermes receives the new message text but has **no awareness of which message was being replied to**. This leads to confusing or incorrect responses because the agent can't see what the user is responding to.

The existing code only captured `reply_to_text` when Discord provided the `resolved` message object inline. This is unreliable — it's `None` for older messages, high-traffic servers, or cross-guild replies.

## Fix

Two changes in `_handle_message()` in `gateway/platforms/discord.py`:

1. **Fetch the referenced message via API** when `message.reference.resolved` is `None`:
   ```python
   if reply_to_text is None and reply_to_id:
       ref_msg = await message.channel.fetch_message(int(reply_to_id))
       reply_to_text = getattr(ref_msg, "content", None)
   ```

2. **Prepends reply context to the message text** so the agent sees it:
   ```
   [Replying to: "the original message text..."]
   the user's reply text
   ```

Caps at 200 characters to avoid flooding the context window.

## Testing

- [ ] Unit test: verify reply context is fetched when `resolved` is None
- [ ] Unit test: verify reply context is prepended to event text
- [ ] Integration test: verify agent receives full reply context in a Discord reply scenario

Fixes #30049