### PR TITLE
fix(slack): default gateway_restart_notification=false for Slack platform

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -199,6 +199,14 @@ class Platform(Enum):
 _BUILTIN_PLATFORM_VALUES = frozenset(m.value for m in Platform.__members__.values())
 
 
+def _platform_value(platform: Optional[Platform | str]) -> Optional[str]:
+    if isinstance(platform, Platform):
+        return platform.value
+    if isinstance(platform, str):
+        return platform.strip().lower()
+    return None
+
+
 @dataclass
 class HomeChannel:
     """
@@ -279,7 +287,13 @@ class SessionResetPolicy:
 
 @dataclass
 class PlatformConfig:
-    """Configuration for a single messaging platform."""
+    """Configuration for a single messaging platform.
+
+    ``gateway_restart_notification`` controls lifecycle pings such as
+    "Gateway online" and "Gateway restarted". The generic dataclass default is
+    True for backwards compatibility, but platform-aware parsing defaults it to
+    False for Slack unless the operator explicitly sets it to true.
+    """
     enabled: bool = False
     token: Optional[str] = None  # Bot token (Telegram, Discord)
     api_key: Optional[str] = None  # API key if different from token
@@ -317,7 +331,11 @@ class PlatformConfig:
         return result
 
     @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> "PlatformConfig":
+    def from_dict(
+        cls,
+        data: Dict[str, Any],
+        platform: Optional[Platform | str] = None,
+    ) -> "PlatformConfig":
         home_channel = None
         if "home_channel" in data:
             home_channel = HomeChannel.from_dict(data["home_channel"])
@@ -329,6 +347,9 @@ class PlatformConfig:
         _grn = data.get("gateway_restart_notification")
         if _grn is None:
             _grn = data.get("extra", {}).get("gateway_restart_notification")
+        default_gateway_restart_notification = (
+            False if _platform_value(platform) == Platform.SLACK.value else True
+        )
 
         return cls(
             enabled=_coerce_bool(data.get("enabled"), False),
@@ -336,7 +357,10 @@ class PlatformConfig:
             api_key=data.get("api_key"),
             home_channel=home_channel,
             reply_to_mode=data.get("reply_to_mode", "first"),
-            gateway_restart_notification=_coerce_bool(_grn, True),
+            gateway_restart_notification=_coerce_bool(
+                _grn,
+                default_gateway_restart_notification,
+            ),
             extra=data.get("extra", {}),
         )
 
@@ -594,7 +618,10 @@ class GatewayConfig:
         for platform_name, platform_data in data.get("platforms", {}).items():
             try:
                 platform = Platform(platform_name)
-                platforms[platform] = PlatformConfig.from_dict(platform_data)
+                platforms[platform] = PlatformConfig.from_dict(
+                    platform_data,
+                    platform=platform,
+                )
             except ValueError:
                 pass  # Skip unknown platforms
         
@@ -1372,7 +1399,9 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     if slack_token:
         if Platform.SLACK not in config.platforms:
             # No yaml config for Slack — env-only setup, enable it
-            config.platforms[Platform.SLACK] = PlatformConfig()
+            config.platforms[Platform.SLACK] = PlatformConfig(
+                gateway_restart_notification=False,
+            )
             config.platforms[Platform.SLACK].enabled = True
         else:
             slack_config = config.platforms[Platform.SLACK]

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -61,6 +61,17 @@ class TestPlatformConfigRoundtrip:
         assert PlatformConfig().gateway_restart_notification is True
         assert PlatformConfig.from_dict({}).gateway_restart_notification is True
 
+    def test_gateway_restart_notification_defaults_false_for_slack(self):
+        restored = PlatformConfig.from_dict({}, platform=Platform.SLACK)
+        assert restored.gateway_restart_notification is False
+
+    def test_gateway_restart_notification_explicit_true_for_slack(self):
+        restored = PlatformConfig.from_dict(
+            {"gateway_restart_notification": True},
+            platform=Platform.SLACK,
+        )
+        assert restored.gateway_restart_notification is True
+
     def test_gateway_restart_notification_roundtrip_false(self):
         pc = PlatformConfig(enabled=True, gateway_restart_notification=False)
         restored = PlatformConfig.from_dict(pc.to_dict())

--- a/tests/gateway/test_restart_notification.py
+++ b/tests/gateway/test_restart_notification.py
@@ -8,7 +8,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 import gateway.run as gateway_run
-from gateway.config import HomeChannel, Platform
+from gateway.config import HomeChannel, Platform, PlatformConfig
 from gateway.platforms.base import MessageEvent, MessageType, SendResult
 from gateway.session import build_session_key
 from tests.gateway.restart_test_helpers import (
@@ -530,6 +530,59 @@ async def test_send_home_channel_startup_notification_default_flag_true(
     # silently flipping the default to False.
     assert runner.config.platforms[Platform.TELEGRAM].gateway_restart_notification is True
 
+    runner.config.platforms[Platform.TELEGRAM].home_channel = HomeChannel(
+        platform=Platform.TELEGRAM,
+        chat_id="home-42",
+        name="Ops Home",
+    )
+    adapter.send = AsyncMock(return_value=SendResult(success=True, message_id="home"))
+
+    delivered = await runner._send_home_channel_startup_notifications()
+
+    assert delivered == {("telegram", "home-42", None)}
+    adapter.send.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_send_home_channel_startup_notification_slack_default_skips(
+    tmp_path, monkeypatch
+):
+    """Slack defaults to no lifecycle pings unless explicitly opted in."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+
+    runner, adapter = make_restart_runner()
+    runner.config.platforms = {
+        Platform.SLACK: PlatformConfig.from_dict(
+            {"enabled": True},
+            platform=Platform.SLACK,
+        )
+    }
+    runner.config.platforms[Platform.SLACK].home_channel = HomeChannel(
+        platform=Platform.SLACK,
+        chat_id="C123",
+        name="Ops",
+    )
+    runner.adapters = {Platform.SLACK: adapter}
+    adapter.send = AsyncMock()
+
+    delivered = await runner._send_home_channel_startup_notifications()
+
+    assert delivered == set()
+    adapter.send.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_send_home_channel_startup_notification_non_slack_default_fires(
+    tmp_path, monkeypatch
+):
+    """Non-Slack platforms keep the prior default notification behavior."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+
+    runner, adapter = make_restart_runner()
+    runner.config.platforms[Platform.TELEGRAM] = PlatformConfig.from_dict(
+        {"enabled": True},
+        platform=Platform.TELEGRAM,
+    )
     runner.config.platforms[Platform.TELEGRAM].home_channel = HomeChannel(
         platform=Platform.TELEGRAM,
         chat_id="home-42",


### PR DESCRIPTION
## Rationale

Slack channels are often multi-participant user spaces, not operator back-channels. Sending gateway lifecycle messages like "Gateway online" or "Gateway restarted" into those channels by default creates noise and can reveal operational details to the wrong audience.

This changes platform-aware config parsing so Slack defaults `gateway_restart_notification` to `false` when the operator has not configured it. Explicit `gateway_restart_notification: true` still opts Slack back into the existing lifecycle pings. Non-Slack platforms keep the previous default of `true`.

## Polyphony bug story

Polyphony HM-15/HM-16 observed restart/startup pings landing in Slack channels after gateway restarts. Those pings were intended as operator lifecycle status, but in shared Slack channels they became unnecessary audience-wide notifications and a privacy/audience mismatch. Slack should require an explicit operator opt-in for those messages.

## Tests

- `PlatformConfig.from_dict(..., platform=Platform.SLACK)` defaults `gateway_restart_notification` to `false`
- explicit Slack `gateway_restart_notification: true` remains honored
- Slack home-channel startup notify loop skips when no override is present
- non-Slack home-channel startup notify loop still sends by default

Ran:

```
python -m pytest tests/gateway/test_config.py tests/gateway/test_restart_notification.py -q -o addopts=''
```