### PR TITLE
fix(slack): preserve final-send on Slack DM streaming path

### DIFF
--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -881,14 +881,24 @@ class SlackAdapter(BasePlatformAdapter):
             return SendResult(success=False, error="Not connected")
         try:
             formatted = self.format_message(content)
-            await self._get_client(chat_id).chat_update(
+            result = await self._get_client(chat_id).chat_update(
                 channel=chat_id,
                 ts=message_id,
                 text=formatted,
             )
+            if isinstance(result, dict) and result.get("ok") is False:
+                return SendResult(
+                    success=False,
+                    error=str(result.get("error") or "Slack chat.update failed"),
+                    raw_response=result,
+                )
             if finalize:
                 await self.stop_typing(chat_id)
-            return SendResult(success=True, message_id=message_id)
+            return SendResult(
+                success=True,
+                message_id=message_id,
+                raw_response=result,
+            )
         except Exception as e:  # pragma: no cover - defensive logging
             logger.error(
                 "[Slack] Failed to edit message %s in channel %s: %s",

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -64,6 +64,7 @@ import gateway.platforms.slack as _slack_mod
 _slack_mod.SLACK_AVAILABLE = True
 
 from gateway.platforms.slack import SlackAdapter  # noqa: E402
+from gateway.stream_consumer import GatewayStreamConsumer, StreamConsumerConfig  # noqa: E402
 
 
 # ---------------------------------------------------------------------------
@@ -1781,6 +1782,70 @@ class TestEditMessageStreamingPipeline:
         result = await adapter.edit_message("C123", "ts1", "**hello**")
         assert result.success is False
         assert "Not connected" in result.error
+
+    @pytest.mark.asyncio
+    async def test_edit_message_reports_slack_update_failure(self, adapter):
+        """chat.update ok=False must not look like delivered stream content."""
+        adapter._app.client.chat_update = AsyncMock(
+            return_value={"ok": False, "error": "message_not_found"}
+        )
+
+        result = await adapter.edit_message(
+            "D123",
+            "stream_ts",
+            "final answer",
+            finalize=True,
+        )
+
+        assert result.success is False
+        assert result.error == "message_not_found"
+        assert result.raw_response == {"ok": False, "error": "message_not_found"}
+
+    @pytest.mark.asyncio
+    async def test_slack_dm_stream_update_failure_falls_back_to_final_post(self, adapter):
+        """Min repro: failed Slack DM stream edit must not drop final-send.
+
+        Before this guard, SlackAdapter.edit_message treated chat.update
+        ``ok=False`` as success.  GatewayStreamConsumer then marked
+        final_response_sent/final_content_delivered, causing gateway/run.py to
+        drop the normal fresh chat.postMessage final-send even though the DM
+        never received the final update.
+        """
+        adapter._app.client.chat_postMessage = AsyncMock(
+            return_value={"ok": True, "ts": "stream_ts"}
+        )
+        adapter._app.client.chat_update = AsyncMock(
+            return_value={"ok": False, "error": "message_not_found"}
+        )
+        adapter._app.client.assistant_threads_setStatus = AsyncMock()
+
+        consumer = GatewayStreamConsumer(
+            adapter,
+            "D123",
+            StreamConsumerConfig(
+                edit_interval=0,
+                buffer_threshold=1,
+                cursor="",
+                transport="edit",
+                chat_type="dm",
+            ),
+        )
+        consumer._message_id = "stream_ts"
+        consumer._message_created_ts = 0.0
+        consumer._already_sent = True
+        consumer._last_sent_text = "partial"
+
+        consumer.on_delta("final answer")
+        consumer.finish()
+        await asyncio.wait_for(consumer.run(), timeout=1.0)
+
+        assert consumer.final_response_sent is True
+        assert consumer.final_content_delivered is False
+        adapter._app.client.chat_update.assert_awaited()
+        adapter._app.client.chat_postMessage.assert_awaited_once()
+        post_kwargs = adapter._app.client.chat_postMessage.call_args.kwargs
+        assert post_kwargs["channel"] == "D123"
+        assert post_kwargs["text"] == "final answer"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Treat Slack `chat.update` responses with `ok: false` as failed edits instead of delivered stream content.
- Preserve/fallback-deliver the final Slack DM response when a streaming final update cannot be applied.
- Add a min-repro that mocks a Slack DM stream preview whose final `chat.update` returns `message_not_found`; the stream consumer now falls back to a fresh `chat.postMessage` with the final answer instead of dropping it.

## Min repro
```python
adapter._app.client.chat_postMessage = AsyncMock(return_value={"ok": True, "ts": "stream_ts"})
adapter._app.client.chat_update = AsyncMock(return_value={"ok": False, "error": "message_not_found"})

consumer = GatewayStreamConsumer(
    adapter,
    "D123",
    StreamConsumerConfig(edit_interval=0, buffer_threshold=1, cursor="", transport="edit", chat_type="dm"),
)
consumer._message_id = "stream_ts"
consumer._already_sent = True
consumer._last_sent_text = "partial"
consumer.on_delta("final answer")
consumer.finish()
await consumer.run()

assert consumer.final_content_delivered is False
adapter._app.client.chat_postMessage.assert_awaited_once()
```

## Tests
- `uv run --extra dev pytest tests/gateway/test_slack.py -q`
