### PR TITLE
feat(acp): support clarify via elicitation

### DIFF
--- a/acp_adapter/elicitation.py
+++ b/acp_adapter/elicitation.py
@@ -8,11 +8,13 @@ preserve unstable capability fields in metadata.
 
 from __future__ import annotations
 
-from typing import Any
+from collections.abc import Awaitable
+from typing import Any, cast
 
 __all__ = [
     "OTHER_LABEL",
     "build_clarify_requested_schema",
+    "create_form_elicitation",
     "extract_clarify_answer",
     "supports_form_elicitation",
 ]
@@ -87,6 +89,41 @@ def build_clarify_requested_schema(*, question: str, choices: list[str] | None) 
         },
         "required": ["answer"],
     }
+
+
+async def create_form_elicitation(
+    conn: object,
+    *,
+    session_id: str,
+    question: str,
+    choices: list[str] | None,
+) -> object:
+    """Send an ACP form elicitation request and return the client response."""
+    requested_schema = build_clarify_requested_schema(question=question, choices=choices)
+
+    typed_helper = getattr(conn, "create_elicitation", None)
+    if callable(typed_helper):
+        result = typed_helper(
+            session_id=session_id,
+            mode="form",
+            message=question,
+            requested_schema=requested_schema,
+        )
+        return await cast(Awaitable[object], result)
+
+    params = {
+        "sessionId": session_id,
+        "mode": "form",
+        "message": question,
+        "requestedSchema": requested_schema,
+    }
+
+    raw_conn = getattr(conn, "_conn", conn)
+    send_request = getattr(raw_conn, "send_request", None)
+    if not callable(send_request):
+        raise RuntimeError("ACP connection does not support elicitation/create requests")
+    result = send_request("elicitation/create", params)
+    return await cast(Awaitable[object], result)
 
 
 def extract_clarify_answer(response: object) -> str:

--- a/acp_adapter/elicitation.py
+++ b/acp_adapter/elicitation.py
@@ -10,7 +10,12 @@ from __future__ import annotations
 
 from typing import Any
 
-__all__ = ["OTHER_LABEL", "build_clarify_requested_schema", "supports_form_elicitation"]
+__all__ = [
+    "OTHER_LABEL",
+    "build_clarify_requested_schema",
+    "extract_clarify_answer",
+    "supports_form_elicitation",
+]
 
 OTHER_LABEL = "Other (type your answer)"
 
@@ -82,6 +87,30 @@ def build_clarify_requested_schema(*, question: str, choices: list[str] | None) 
         },
         "required": ["answer"],
     }
+
+
+def extract_clarify_answer(response: object) -> str:
+    """Convert an ACP elicitation response into Hermes' clarify string result."""
+    if response is None:
+        return "[clarify prompt could not be delivered]"
+
+    action = _get_attr_or_key(response, "action")
+    if action == "decline":
+        return "[user declined the clarification]"
+    if action == "cancel":
+        return "[user cancelled the clarification]"
+    if action != "accept":
+        return "[clarify prompt could not be delivered]"
+
+    content = _get_attr_or_key(response, "content")
+    if content is None:
+        return "[clarify prompt could not be delivered]"
+
+    answer = _get_attr_or_key(content, "answer", "")
+    other = _get_attr_or_key(content, "other_answer", "")
+    if str(answer).strip() == OTHER_LABEL and str(other).strip():
+        return str(other).strip()
+    return str(answer or "").strip()
 
 
 def supports_form_elicitation(client_capabilities: object) -> bool:

--- a/acp_adapter/elicitation.py
+++ b/acp_adapter/elicitation.py
@@ -8,7 +8,10 @@ preserve unstable capability fields in metadata.
 
 from __future__ import annotations
 
-from collections.abc import Awaitable
+import asyncio
+import logging
+from collections.abc import Awaitable, Callable
+from concurrent.futures import TimeoutError as FutureTimeout
 from typing import Any, cast
 
 __all__ = [
@@ -16,8 +19,11 @@ __all__ = [
     "build_clarify_requested_schema",
     "create_form_elicitation",
     "extract_clarify_answer",
+    "make_elicitation_clarify_callback",
     "supports_form_elicitation",
 ]
+
+logger = logging.getLogger(__name__)
 
 OTHER_LABEL = "Other (type your answer)"
 
@@ -148,6 +154,55 @@ def extract_clarify_answer(response: object) -> str:
     if str(answer).strip() == OTHER_LABEL and str(other).strip():
         return str(other).strip()
     return str(answer or "").strip()
+
+
+def _format_timeout_sentinel(timeout: float) -> str:
+    seconds = max(1, int(timeout))
+    if seconds < 60:
+        return f"[user did not respond within {seconds}s]"
+    minutes = max(1, int(seconds / 60))
+    return f"[user did not respond within {minutes}m]"
+
+
+def make_elicitation_clarify_callback(
+    conn: object,
+    loop: asyncio.AbstractEventLoop,
+    session_id: str,
+    *,
+    timeout: float = 120.0,
+) -> Callable[[str, list[str] | None], str]:
+    """Create a blocking Hermes clarify callback backed by ACP elicitation."""
+
+    def _callback(question: str, choices: list[str] | None = None) -> str:
+        from agent.async_utils import safe_schedule_threadsafe
+
+        future = safe_schedule_threadsafe(
+            create_form_elicitation(
+                conn,
+                session_id=session_id,
+                question=question,
+                choices=choices,
+            ),
+            loop,
+            logger=logger,
+            log_message="ACP elicitation: failed to schedule on loop",
+        )
+        if future is None:
+            return "[clarify prompt could not be delivered]"
+
+        try:
+            response = future.result(timeout=timeout)
+        except FutureTimeout:
+            future.cancel()
+            logger.warning("ACP elicitation timed out")
+            return _format_timeout_sentinel(timeout)
+        except Exception as exc:
+            future.cancel()
+            logger.warning("ACP elicitation failed: %s", exc)
+            return "[clarify prompt could not be delivered]"
+        return extract_clarify_answer(response)
+
+    return _callback
 
 
 def supports_form_elicitation(client_capabilities: object) -> bool:

--- a/acp_adapter/elicitation.py
+++ b/acp_adapter/elicitation.py
@@ -10,7 +10,9 @@ from __future__ import annotations
 
 from typing import Any
 
-__all__ = ["supports_form_elicitation"]
+__all__ = ["OTHER_LABEL", "build_clarify_requested_schema", "supports_form_elicitation"]
+
+OTHER_LABEL = "Other (type your answer)"
 
 
 def _get_attr_or_key(value: Any, key: str, default: Any = None) -> Any:
@@ -42,6 +44,44 @@ def _metadata_elicitation(client_capabilities: object) -> Any:
         if elicitation is not None:
             return elicitation
     return None
+
+
+def build_clarify_requested_schema(*, question: str, choices: list[str] | None) -> dict[str, Any]:
+    """Build a simple ACP form schema for Hermes clarify prompts."""
+    if choices:
+        cleaned_choices = [str(choice).strip() for choice in choices if str(choice).strip()]
+        enum_values = cleaned_choices[:4]
+        if OTHER_LABEL not in enum_values:
+            enum_values.append(OTHER_LABEL)
+        return {
+            "type": "object",
+            "properties": {
+                "answer": {
+                    "type": "string",
+                    "title": question,
+                    "enum": enum_values,
+                },
+                "other_answer": {
+                    "type": "string",
+                    "title": "Other answer",
+                    "description": "Fill this only if you selected Other.",
+                },
+            },
+            "required": ["answer"],
+        }
+
+    return {
+        "type": "object",
+        "properties": {
+            "answer": {
+                "type": "string",
+                "title": question,
+                "minLength": 1,
+                "maxLength": 4000,
+            }
+        },
+        "required": ["answer"],
+    }
 
 
 def supports_form_elicitation(client_capabilities: object) -> bool:

--- a/acp_adapter/elicitation.py
+++ b/acp_adapter/elicitation.py
@@ -1,0 +1,71 @@
+"""ACP elicitation helpers.
+
+This module intentionally keeps ACP elicitation-specific behavior isolated from
+permission/authorization handling. Capability detection accepts generated SDK
+models as well as dict-like fallback data because older SDKs or clients may
+preserve unstable capability fields in metadata.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+__all__ = ["supports_form_elicitation"]
+
+
+def _get_attr_or_key(value: Any, key: str, default: Any = None) -> Any:
+    if value is None:
+        return default
+    if isinstance(value, dict):
+        return value.get(key, default)
+    return getattr(value, key, default)
+
+
+def _model_dump(value: Any) -> dict[str, Any] | None:
+    dump = getattr(value, "model_dump", None)
+    if not callable(dump):
+        return None
+    try:
+        data = dump(by_alias=True, exclude_none=True)
+    except TypeError:
+        data = dump()
+    return data if isinstance(data, dict) else None
+
+
+def _metadata_elicitation(client_capabilities: object) -> Any:
+    for metadata_key in ("meta", "_meta", "field_meta"):
+        meta = _get_attr_or_key(client_capabilities, metadata_key)
+        elicitation = _get_attr_or_key(meta, "elicitation")
+        if elicitation is not None:
+            return elicitation
+        elicitation = _get_attr_or_key(meta, "acp.elicitation")
+        if elicitation is not None:
+            return elicitation
+    return None
+
+
+def supports_form_elicitation(client_capabilities: object) -> bool:
+    """Return whether ACP client capabilities advertise form elicitation."""
+    if client_capabilities is None:
+        return False
+
+    elicitation = _get_attr_or_key(client_capabilities, "elicitation")
+    if elicitation is None:
+        elicitation = _metadata_elicitation(client_capabilities)
+
+    if elicitation is None:
+        return False
+
+    if isinstance(elicitation, dict):
+        if elicitation == {}:
+            return True
+        return "form" in elicitation
+
+    if getattr(elicitation, "form", None) is not None:
+        return True
+
+    data = _model_dump(elicitation)
+    if data is not None:
+        return data == {} or "form" in data
+
+    return False

--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -755,6 +755,46 @@ class HermesACPAgent(acp.Agent):
         loop = asyncio.get_running_loop()
         loop.call_soon(asyncio.create_task, self._send_usage_update(state))
 
+    def _acp_toolsets_for_client(self, base_toolsets: list[str] | None) -> list[str]:
+        """Return ACP toolsets adjusted for the connected client's capabilities."""
+        toolsets = _expand_acp_enabled_toolsets(base_toolsets or ["hermes-acp"])
+        # Clarify is exposed dynamically only for clients that can answer ACP
+        # form elicitations. Strip stale entries first so session/load after a
+        # reconnect to an unsupported client degrades back to assistant text.
+        toolsets = [toolset for toolset in toolsets if toolset != "clarify"]
+        if self._supports_elicitation_form():
+            toolsets.append("clarify")
+        return toolsets
+
+    def _refresh_agent_tool_surface(
+        self,
+        state: SessionState,
+        *,
+        mcp_server_names: list[str] | None = None,
+    ) -> None:
+        """Refresh a session agent's tools using ACP client capability gates."""
+        from model_tools import get_tool_definitions
+
+        base_toolsets = getattr(state.agent, "enabled_toolsets", None) or ["hermes-acp"]
+        enabled_toolsets = self._acp_toolsets_for_client(base_toolsets)
+        enabled_toolsets = _expand_acp_enabled_toolsets(
+            enabled_toolsets,
+            mcp_server_names=mcp_server_names,
+        )
+        state.agent.enabled_toolsets = enabled_toolsets
+        disabled_toolsets = getattr(state.agent, "disabled_toolsets", None) or []
+        state.agent.tools = get_tool_definitions(
+            enabled_toolsets=enabled_toolsets,
+            disabled_toolsets=disabled_toolsets,
+            quiet_mode=True,
+        )
+        state.agent.valid_tool_names = {
+            tool["function"]["name"] for tool in state.agent.tools or []
+        }
+        invalidate = getattr(state.agent, "_invalidate_system_prompt", None)
+        if callable(invalidate):
+            invalidate()
+
     async def _register_session_mcp_servers(
         self,
         state: SessionState,
@@ -793,25 +833,10 @@ class HermesACPAgent(acp.Agent):
             return
 
         try:
-            from model_tools import get_tool_definitions
-
-            enabled_toolsets = _expand_acp_enabled_toolsets(
-                getattr(state.agent, "enabled_toolsets", None) or ["hermes-acp"],
+            self._refresh_agent_tool_surface(
+                state,
                 mcp_server_names=[server.name for server in mcp_servers],
             )
-            state.agent.enabled_toolsets = enabled_toolsets
-            disabled_toolsets = getattr(state.agent, "disabled_toolsets", None)
-            state.agent.tools = get_tool_definitions(
-                enabled_toolsets=enabled_toolsets,
-                disabled_toolsets=disabled_toolsets,
-                quiet_mode=True,
-            )
-            state.agent.valid_tool_names = {
-                tool["function"]["name"] for tool in state.agent.tools or []
-            }
-            invalidate = getattr(state.agent, "_invalidate_system_prompt", None)
-            if callable(invalidate):
-                invalidate()
             logger.info(
                 "Session %s: refreshed tool surface after ACP MCP registration (%d tools)",
                 state.session_id,
@@ -1084,6 +1109,7 @@ class HermesACPAgent(acp.Agent):
     ) -> NewSessionResponse:
         state = self.session_manager.create_session(cwd=cwd)
         await self._register_session_mcp_servers(state, mcp_servers)
+        self._refresh_agent_tool_surface(state)
         logger.info("New session %s (cwd=%s)", state.session_id, cwd)
         self._schedule_available_commands_update(state.session_id)
         self._schedule_usage_update(state)
@@ -1105,6 +1131,7 @@ class HermesACPAgent(acp.Agent):
             logger.warning("load_session: session %s not found", session_id)
             return None
         await self._register_session_mcp_servers(state, mcp_servers)
+        self._refresh_agent_tool_surface(state)
         logger.info("Loaded session %s", session_id)
         # Per ACP spec, `session/load` must stream the prior conversation back
         # to the client via `session/update` notifications BEFORE responding,
@@ -1149,6 +1176,7 @@ class HermesACPAgent(acp.Agent):
             logger.warning("resume_session: session %s not found, creating new", session_id)
             state = self.session_manager.create_session(cwd=cwd)
         await self._register_session_mcp_servers(state, mcp_servers)
+        self._refresh_agent_tool_surface(state)
         logger.info("Resumed session %s", state.session_id)
         # See `load_session` above for the spec rationale — replay must
         # complete before the response so clients receive the full transcript
@@ -1194,6 +1222,7 @@ class HermesACPAgent(acp.Agent):
         new_id = state.session_id if state else ""
         if state is not None:
             await self._register_session_mcp_servers(state, mcp_servers)
+            self._refresh_agent_tool_surface(state)
         logger.info("Forked session %s -> %s", session_id, new_id)
         if new_id:
             self._schedule_available_commands_update(new_id)

--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -782,7 +782,7 @@ class HermesACPAgent(acp.Agent):
             mcp_server_names=mcp_server_names,
         )
         state.agent.enabled_toolsets = enabled_toolsets
-        disabled_toolsets = getattr(state.agent, "disabled_toolsets", None) or []
+        disabled_toolsets: Any = getattr(state.agent, "disabled_toolsets", None)
         state.agent.tools = get_tool_definitions(
             enabled_toolsets=enabled_toolsets,
             disabled_toolsets=disabled_toolsets,

--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -517,6 +517,8 @@ class HermesACPAgent(acp.Agent):
         super().__init__()
         self.session_manager = session_manager or SessionManager()
         self._conn: Optional[acp.Client] = None
+        self._client_capabilities: ClientCapabilities | None = None
+        self._client_info: Implementation | None = None
 
     # ---- Connection lifecycle -----------------------------------------------
 
@@ -525,6 +527,12 @@ class HermesACPAgent(acp.Agent):
         self._conn = conn
         logger.info("ACP client connected")
 
+
+    def _supports_elicitation_form(self) -> bool:
+        """Return whether the connected ACP client can answer form elicitations."""
+        from acp_adapter.elicitation import supports_form_elicitation
+
+        return supports_form_elicitation(self._client_capabilities)
 
     def _session_modes(self, state: SessionState) -> SessionModeState:
         """Return ACP session modes while preserving Zed's separate model picker.
@@ -829,6 +837,8 @@ class HermesACPAgent(acp.Agent):
             protocol_version if isinstance(protocol_version, int) else acp.PROTOCOL_VERSION
         )
         auth_methods = build_auth_methods()
+        self._client_capabilities = client_capabilities
+        self._client_info = client_info
 
         client_name = client_info.name if client_info else "unknown"
         logger.info(

--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -1381,7 +1381,9 @@ class HermesACPAgent(acp.Agent):
         tool_call_ids: dict[str, Deque[str]] = defaultdict(deque)
         tool_call_meta: dict[str, dict[str, Any]] = {}
         previous_approval_cb = None
+        previous_clarify_cb = None
         edit_approval_requester = None
+        clarify_cb = None
 
         streamed_message = False
 
@@ -1416,6 +1418,13 @@ class HermesACPAgent(acp.Agent):
                 )
             except Exception:
                 logger.debug("Could not create ACP edit approval requester", exc_info=True)
+            if self._supports_elicitation_form():
+                try:
+                    from acp_adapter.elicitation import make_elicitation_clarify_callback
+
+                    clarify_cb = make_elicitation_clarify_callback(conn, loop, session_id)
+                except Exception:
+                    logger.debug("Could not create ACP elicitation clarify callback", exc_info=True)
         else:
             tool_progress_cb = None
             reasoning_cb = None
@@ -1449,7 +1458,7 @@ class HermesACPAgent(acp.Agent):
         previous_session_id = None
 
         def _run_agent() -> dict:
-            nonlocal previous_approval_cb, previous_interactive, edit_approval_token, previous_session_id
+            nonlocal previous_approval_cb, previous_clarify_cb, previous_interactive, edit_approval_token, previous_session_id
             # Bind HERMES_SESSION_KEY for this session so per-session caches
             # (e.g. the interactive sudo password cache in tools.terminal_tool)
             # scope to the ACP session rather than leaking across sessions
@@ -1480,6 +1489,12 @@ class HermesACPAgent(acp.Agent):
                     edit_approval_token = set_edit_approval_requester(edit_approval_requester)
                 except Exception:
                     logger.debug("Could not set ACP edit approval requester", exc_info=True)
+            if clarify_cb:
+                try:
+                    previous_clarify_cb = getattr(agent, "clarify_callback", None)
+                    agent.clarify_callback = clarify_cb
+                except Exception:
+                    logger.debug("Could not set ACP clarify callback", exc_info=True)
             # Signal to tools.approval that we have an interactive callback
             # and the non-interactive auto-approve path must not fire.
             previous_interactive = os.environ.get("HERMES_INTERACTIVE")
@@ -1526,6 +1541,11 @@ class HermesACPAgent(acp.Agent):
                         reset_edit_approval_requester(edit_approval_token)
                     except Exception:
                         logger.debug("Could not restore ACP edit approval requester", exc_info=True)
+                if clarify_cb:
+                    try:
+                        agent.clarify_callback = previous_clarify_cb
+                    except Exception:
+                        logger.debug("Could not restore ACP clarify callback", exc_info=True)
                 if session_tokens is not None and clear_session_vars is not None:
                     try:
                         clear_session_vars(session_tokens)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,7 +111,7 @@ sms = ["aiohttp==3.13.3"]
 # (curl install script); this extra just pins the MCP client used to talk
 # to it, which is already provided by the `mcp` extra.
 computer-use = ["mcp==1.26.0"]
-acp = ["agent-client-protocol==0.9.0"]
+acp = ["agent-client-protocol==0.10.0"]
 # mistral: extra REMOVED 2026-05-12 — `mistralai` PyPI project quarantined
 # after malicious 2.4.6 release (Mini Shai-Hulud worm). Every version of
 # `mistralai` returns 404 on PyPI right now, so any pin we'd write is

--- a/tests/acp_adapter/test_acp_elicitation.py
+++ b/tests/acp_adapter/test_acp_elicitation.py
@@ -327,6 +327,7 @@ async def test_prompt_wires_clarify_callback_to_elicitation(monkeypatch):
 
     assert fake.clarify_answers == ["Elicited"]
     assert conn.requests[0][0] == "elicitation/create"
+    assert conn.request_permission_calls == []
     assert fake.clarify_callback is original_callback
 
 

--- a/tests/acp_adapter/test_acp_elicitation.py
+++ b/tests/acp_adapter/test_acp_elicitation.py
@@ -1,7 +1,10 @@
 from types import SimpleNamespace
 
+import pytest
+
 from acp_adapter.elicitation import (
     build_clarify_requested_schema,
+    create_form_elicitation,
     extract_clarify_answer,
     supports_form_elicitation,
 )
@@ -75,3 +78,53 @@ def test_decline_cancel_or_missing_returns_standard_sentinel():
     assert extract_clarify_answer({"action": "decline"}) == "[user declined the clarification]"
     assert extract_clarify_answer({"action": "cancel"}) == "[user cancelled the clarification]"
     assert extract_clarify_answer(None) == "[clarify prompt could not be delivered]"
+
+
+class TypedConn:
+    def __init__(self):
+        self.calls = []
+
+    async def create_elicitation(self, **kwargs):
+        self.calls.append(kwargs)
+        return {"action": "accept", "content": {"answer": "typed"}}
+
+
+class RawConn:
+    def __init__(self):
+        self.requests = []
+        self._conn = self
+
+    async def send_request(self, method, params):
+        self.requests.append((method, params))
+        return {"action": "accept", "content": {"answer": "raw"}}
+
+
+@pytest.mark.asyncio
+async def test_create_form_elicitation_prefers_typed_helper_if_available():
+    conn = TypedConn()
+    response = await create_form_elicitation(
+        conn,
+        session_id="s1",
+        question="Q?",
+        choices=None,
+    )
+    assert response["content"]["answer"] == "typed"
+    assert conn.calls[0].get("session_id") == "s1" or conn.calls[0].get("sessionId") == "s1"
+
+
+@pytest.mark.asyncio
+async def test_create_form_elicitation_uses_raw_json_rpc_fallback():
+    conn = RawConn()
+    response = await create_form_elicitation(
+        conn,
+        session_id="s1",
+        question="Q?",
+        choices=["A", "B"],
+    )
+    assert response["content"]["answer"] == "raw"
+    method, params = conn.requests[0]
+    assert method == "elicitation/create"
+    assert params["sessionId"] == "s1"
+    assert params["mode"] == "form"
+    assert params["message"] == "Q?"
+    assert params["requestedSchema"]["required"] == ["answer"]

--- a/tests/acp_adapter/test_acp_elicitation.py
+++ b/tests/acp_adapter/test_acp_elicitation.py
@@ -2,6 +2,7 @@ from types import SimpleNamespace
 
 from acp_adapter.elicitation import (
     build_clarify_requested_schema,
+    extract_clarify_answer,
     supports_form_elicitation,
 )
 
@@ -50,3 +51,27 @@ def test_choice_clarify_schema_preserves_other_path():
     assert "Strict" in props["answer"].get("enum", [])
     assert "Fallback" in props["answer"].get("enum", [])
     assert "Other (type your answer)" in props["answer"].get("enum", [])
+
+
+def test_extract_answer_from_accept_dict():
+    response = {"action": "accept", "content": {"answer": "Strict"}}
+    assert extract_clarify_answer(response) == "Strict"
+
+
+def test_extract_other_answer_from_accept_dict():
+    response = {
+        "action": "accept",
+        "content": {"answer": "Other (type your answer)", "other_answer": "Use raw JSON-RPC"},
+    }
+    assert extract_clarify_answer(response) == "Use raw JSON-RPC"
+
+
+def test_extract_answer_from_accept_object():
+    response = SimpleNamespace(action="accept", content={"answer": "Fallback"})
+    assert extract_clarify_answer(response) == "Fallback"
+
+
+def test_decline_cancel_or_missing_returns_standard_sentinel():
+    assert extract_clarify_answer({"action": "decline"}) == "[user declined the clarification]"
+    assert extract_clarify_answer({"action": "cancel"}) == "[user cancelled the clarification]"
+    assert extract_clarify_answer(None) == "[clarify prompt could not be delivered]"

--- a/tests/acp_adapter/test_acp_elicitation.py
+++ b/tests/acp_adapter/test_acp_elicitation.py
@@ -274,7 +274,7 @@ async def test_new_session_refreshes_supported_client_tool_surface(monkeypatch):
 class ClarifyFakeAgent(ToolSurfaceFakeAgent):
     def __init__(self):
         super().__init__()
-        self.clarify_callback = None
+        self.clarify_callback: object = None
         self.clarify_answers = []
 
     def run_conversation(self, *, user_message, conversation_history, task_id, **kwargs):
@@ -327,4 +327,61 @@ async def test_prompt_wires_clarify_callback_to_elicitation(monkeypatch):
 
     assert fake.clarify_answers == ["Elicited"]
     assert conn.requests[0][0] == "elicitation/create"
+    assert fake.clarify_callback is original_callback
+
+
+@pytest.mark.asyncio
+async def test_unsupported_client_new_session_has_no_clarify_tool(monkeypatch):
+    install_fake_model_tools(monkeypatch)
+    fake = ToolSurfaceFakeAgent()
+    manager = SessionManager(agent_factory=lambda: fake, db=NoopDb())
+    agent = HermesACPAgent(session_manager=manager)
+    agent.on_connect(ToolSurfaceConn())
+    await agent.initialize(client_capabilities=None)
+
+    response = await agent.new_session(cwd=".")
+    state = manager.get_session(response.session_id)
+
+    assert state is not None
+    assert "clarify" not in state.agent.enabled_toolsets
+    assert "clarify" not in state.agent.valid_tool_names
+
+
+@pytest.mark.asyncio
+async def test_url_only_elicitation_client_has_no_clarify_tool(monkeypatch):
+    install_fake_model_tools(monkeypatch)
+    fake = ToolSurfaceFakeAgent()
+    manager = SessionManager(agent_factory=lambda: fake, db=NoopDb())
+    agent = HermesACPAgent(session_manager=manager)
+    agent.on_connect(ToolSurfaceConn())
+    await agent.initialize(client_capabilities=SimpleNamespace(elicitation={"url": {}}))
+
+    response = await agent.new_session(cwd=".")
+    state = manager.get_session(response.session_id)
+
+    assert state is not None
+    assert "clarify" not in state.agent.enabled_toolsets
+    assert "clarify" not in state.agent.valid_tool_names
+
+
+@pytest.mark.asyncio
+async def test_unsupported_client_does_not_overwrite_existing_clarify_callback(monkeypatch):
+    install_fake_model_tools(monkeypatch)
+    fake = ClarifyFakeAgent()
+    original_callback = lambda _q, _c: "original"
+    fake.clarify_callback = original_callback
+    manager = SessionManager(agent_factory=lambda: fake, db=NoopDb())
+    agent = HermesACPAgent(session_manager=manager)
+    conn = ElicitationConn()
+    agent.on_connect(conn)
+    await agent.initialize(client_capabilities=SimpleNamespace(elicitation={"url": {}}))
+    response = await agent.new_session(cwd=".")
+
+    await agent.prompt(
+        session_id=response.session_id,
+        prompt=[TextContentBlock(type="text", text="ask normally if needed")],
+    )
+
+    assert fake.clarify_answers == ["original"]
+    assert conn.requests == []
     assert fake.clarify_callback is original_callback

--- a/tests/acp_adapter/test_acp_elicitation.py
+++ b/tests/acp_adapter/test_acp_elicitation.py
@@ -1,6 +1,9 @@
 from types import SimpleNamespace
 
-from acp_adapter.elicitation import supports_form_elicitation
+from acp_adapter.elicitation import (
+    build_clarify_requested_schema,
+    supports_form_elicitation,
+)
 
 
 def test_supports_form_elicitation_with_object_form():
@@ -27,3 +30,23 @@ def test_supports_form_elicitation_missing_is_false():
 def test_supports_form_elicitation_url_only_is_false():
     caps = SimpleNamespace(elicitation={"url": {}})
     assert supports_form_elicitation(caps) is False
+
+
+def test_open_ended_clarify_schema_has_required_answer_string():
+    schema = build_clarify_requested_schema(question="What branch?", choices=None)
+    assert schema["type"] == "object"
+    assert schema["required"] == ["answer"]
+    assert schema["properties"]["answer"]["type"] == "string"
+
+
+def test_choice_clarify_schema_preserves_other_path():
+    schema = build_clarify_requested_schema(
+        question="Which approach?",
+        choices=["Strict", "Fallback"],
+    )
+    props = schema["properties"]
+    assert "answer" in props
+    assert "other_answer" in props
+    assert "Strict" in props["answer"].get("enum", [])
+    assert "Fallback" in props["answer"].get("enum", [])
+    assert "Other (type your answer)" in props["answer"].get("enum", [])

--- a/tests/acp_adapter/test_acp_elicitation.py
+++ b/tests/acp_adapter/test_acp_elicitation.py
@@ -169,3 +169,100 @@ async def test_initialize_records_elicitation_capability():
 
     assert agent._supports_elicitation_form() is True
     assert agent._client_capabilities is caps
+
+
+class NoopDb:
+    def get_session(self, *_args, **_kwargs):
+        return None
+
+    def create_session(self, *_args, **_kwargs):
+        return None
+
+    def replace_messages(self, *_args, **_kwargs):
+        return None
+
+
+class ToolSurfaceFakeAgent:
+    def __init__(self):
+        self.enabled_toolsets = ["hermes-acp"]
+        self.disabled_toolsets = []
+        self.tools = []
+        self.valid_tool_names = set()
+        self.invalidated = 0
+        self.model = "fake-model"
+        self.provider = "fake-provider"
+
+    def _invalidate_system_prompt(self):
+        self.invalidated += 1
+
+
+class ToolSurfaceConn:
+    async def session_update(self, *_args, **_kwargs):
+        return None
+
+
+def install_fake_model_tools(monkeypatch):
+    calls = []
+
+    def get_tool_definitions(*, enabled_toolsets, disabled_toolsets=None, quiet_mode=True):
+        calls.append(list(enabled_toolsets))
+        tools = []
+        for toolset in enabled_toolsets:
+            if toolset == "clarify":
+                tools.append({"function": {"name": "clarify"}})
+            elif toolset.startswith("mcp-"):
+                tools.append({"function": {"name": f"{toolset}-tool"}})
+            else:
+                tools.append({"function": {"name": f"{toolset}-tool"}})
+        return tools
+
+    module = ModuleType("model_tools")
+    setattr(module, "get_tool_definitions", get_tool_definitions)
+    monkeypatch.setitem(sys.modules, "model_tools", module)
+    return calls
+
+
+@pytest.mark.asyncio
+async def test_acp_toolsets_add_clarify_only_for_form_elicitation():
+    supported = HermesACPAgent()
+    await supported.initialize(client_capabilities=SimpleNamespace(elicitation={"form": {}}))
+    assert "clarify" in supported._acp_toolsets_for_client(["hermes-acp"])
+
+    unsupported = HermesACPAgent()
+    await unsupported.initialize(client_capabilities=SimpleNamespace(elicitation={"url": {}}))
+    assert "clarify" not in unsupported._acp_toolsets_for_client(["hermes-acp", "clarify"])
+
+
+@pytest.mark.asyncio
+async def test_refresh_agent_tool_surface_gates_clarify_and_preserves_mcp(monkeypatch):
+    calls = install_fake_model_tools(monkeypatch)
+    fake = ToolSurfaceFakeAgent()
+    manager = SessionManager(agent_factory=lambda: fake, db=NoopDb())
+    agent = HermesACPAgent(session_manager=manager)
+    await agent.initialize(client_capabilities=SimpleNamespace(elicitation={"form": {}}))
+    state = manager.create_session(cwd=".")
+
+    agent._refresh_agent_tool_surface(state, mcp_server_names=["demo"])
+
+    assert "clarify" in state.agent.enabled_toolsets
+    assert "mcp-demo" in state.agent.enabled_toolsets
+    assert "clarify" in state.agent.valid_tool_names
+    assert "mcp-demo-tool" in state.agent.valid_tool_names
+    assert state.agent.invalidated == 1
+    assert "clarify" in calls[-1]
+
+
+@pytest.mark.asyncio
+async def test_new_session_refreshes_supported_client_tool_surface(monkeypatch):
+    install_fake_model_tools(monkeypatch)
+    fake = ToolSurfaceFakeAgent()
+    manager = SessionManager(agent_factory=lambda: fake, db=NoopDb())
+    agent = HermesACPAgent(session_manager=manager)
+    agent.on_connect(ToolSurfaceConn())
+    await agent.initialize(client_capabilities=SimpleNamespace(elicitation={"form": {}}))
+
+    response = await agent.new_session(cwd=".")
+    state = manager.get_session(response.session_id)
+
+    assert state is not None
+    assert "clarify" in state.agent.valid_tool_names

--- a/tests/acp_adapter/test_acp_elicitation.py
+++ b/tests/acp_adapter/test_acp_elicitation.py
@@ -1,8 +1,10 @@
 import asyncio
+import sys
 import threading
-from types import SimpleNamespace
+from types import ModuleType, SimpleNamespace
 
 import pytest
+from acp.schema import TextContentBlock
 
 from acp_adapter.elicitation import (
     build_clarify_requested_schema,
@@ -11,6 +13,8 @@ from acp_adapter.elicitation import (
     make_elicitation_clarify_callback,
     supports_form_elicitation,
 )
+from acp_adapter.server import HermesACPAgent
+from acp_adapter.session import SessionManager
 
 
 def test_supports_form_elicitation_with_object_form():
@@ -154,3 +158,14 @@ def test_elicitation_clarify_callback_schedules_on_loop():
         loop.call_soon_threadsafe(loop.stop)
         thread.join(timeout=2)
         loop.close()
+
+
+@pytest.mark.asyncio
+async def test_initialize_records_elicitation_capability():
+    agent = HermesACPAgent()
+    caps = SimpleNamespace(elicitation={"form": {}})
+
+    await agent.initialize(client_capabilities=caps)
+
+    assert agent._supports_elicitation_form() is True
+    assert agent._client_capabilities is caps

--- a/tests/acp_adapter/test_acp_elicitation.py
+++ b/tests/acp_adapter/test_acp_elicitation.py
@@ -200,6 +200,9 @@ class ToolSurfaceConn:
     async def session_update(self, *_args, **_kwargs):
         return None
 
+    async def request_permission(self, *_args, **_kwargs):
+        return SimpleNamespace(outcome="allow")
+
 
 def install_fake_model_tools(monkeypatch):
     calls = []
@@ -266,3 +269,62 @@ async def test_new_session_refreshes_supported_client_tool_surface(monkeypatch):
 
     assert state is not None
     assert "clarify" in state.agent.valid_tool_names
+
+
+class ClarifyFakeAgent(ToolSurfaceFakeAgent):
+    def __init__(self):
+        super().__init__()
+        self.clarify_callback = None
+        self.clarify_answers = []
+
+    def run_conversation(self, *, user_message, conversation_history, task_id, **kwargs):
+        answer = None
+        if callable(self.clarify_callback):
+            answer = self.clarify_callback("Q?", ["A"])
+            self.clarify_answers.append(answer)
+        messages = list(conversation_history or [])
+        messages.append({"role": "user", "content": user_message})
+        messages.append({"role": "assistant", "content": f"answer: {answer}"})
+        return {"final_response": f"answer: {answer}", "messages": messages}
+
+
+class ElicitationConn(ToolSurfaceConn):
+    def __init__(self):
+        self.updates = []
+        self.requests = []
+        self.request_permission_calls = []
+        self._conn = self
+
+    async def session_update(self, *args, **kwargs):
+        self.updates.append((args, kwargs))
+
+    async def request_permission(self, *args, **kwargs):
+        self.request_permission_calls.append((args, kwargs))
+        return SimpleNamespace(outcome="allow")
+
+    async def send_request(self, method, params):
+        self.requests.append((method, params))
+        return {"action": "accept", "content": {"answer": "Elicited"}}
+
+
+@pytest.mark.asyncio
+async def test_prompt_wires_clarify_callback_to_elicitation(monkeypatch):
+    install_fake_model_tools(monkeypatch)
+    fake = ClarifyFakeAgent()
+    original_callback = lambda _q, _c: "original"
+    fake.clarify_callback = original_callback
+    manager = SessionManager(agent_factory=lambda: fake, db=NoopDb())
+    agent = HermesACPAgent(session_manager=manager)
+    conn = ElicitationConn()
+    agent.on_connect(conn)
+    await agent.initialize(client_capabilities=SimpleNamespace(elicitation={"form": {}}))
+    response = await agent.new_session(cwd=".")
+
+    await agent.prompt(
+        session_id=response.session_id,
+        prompt=[TextContentBlock(type="text", text="ask if needed")],
+    )
+
+    assert fake.clarify_answers == ["Elicited"]
+    assert conn.requests[0][0] == "elicitation/create"
+    assert fake.clarify_callback is original_callback

--- a/tests/acp_adapter/test_acp_elicitation.py
+++ b/tests/acp_adapter/test_acp_elicitation.py
@@ -1,0 +1,29 @@
+from types import SimpleNamespace
+
+from acp_adapter.elicitation import supports_form_elicitation
+
+
+def test_supports_form_elicitation_with_object_form():
+    caps = SimpleNamespace(elicitation=SimpleNamespace(form=SimpleNamespace()))
+    assert supports_form_elicitation(caps) is True
+
+
+def test_supports_form_elicitation_with_dict_form():
+    caps = SimpleNamespace(elicitation={"form": {}})
+    assert supports_form_elicitation(caps) is True
+
+
+def test_supports_form_elicitation_with_empty_elicitation_object():
+    # ACP RFD-style shorthand: empty elicitation object means form supported.
+    caps = SimpleNamespace(elicitation={})
+    assert supports_form_elicitation(caps) is True
+
+
+def test_supports_form_elicitation_missing_is_false():
+    assert supports_form_elicitation(SimpleNamespace()) is False
+    assert supports_form_elicitation(None) is False
+
+
+def test_supports_form_elicitation_url_only_is_false():
+    caps = SimpleNamespace(elicitation={"url": {}})
+    assert supports_form_elicitation(caps) is False

--- a/tests/acp_adapter/test_acp_elicitation.py
+++ b/tests/acp_adapter/test_acp_elicitation.py
@@ -1,3 +1,5 @@
+import asyncio
+import threading
 from types import SimpleNamespace
 
 import pytest
@@ -6,6 +8,7 @@ from acp_adapter.elicitation import (
     build_clarify_requested_schema,
     create_form_elicitation,
     extract_clarify_answer,
+    make_elicitation_clarify_callback,
     supports_form_elicitation,
 )
 
@@ -128,3 +131,26 @@ async def test_create_form_elicitation_uses_raw_json_rpc_fallback():
     assert params["mode"] == "form"
     assert params["message"] == "Q?"
     assert params["requestedSchema"]["required"] == ["answer"]
+
+
+def test_elicitation_clarify_callback_schedules_on_loop():
+    conn = RawConn()
+    loop = asyncio.new_event_loop()
+    ready = threading.Event()
+
+    def run_loop():
+        asyncio.set_event_loop(loop)
+        ready.set()
+        loop.run_forever()
+
+    thread = threading.Thread(target=run_loop, daemon=True)
+    thread.start()
+    ready.wait(timeout=2)
+
+    try:
+        callback = make_elicitation_clarify_callback(conn, loop, "s1", timeout=2)
+        assert callback("Q?", ["A", "B"]) == "raw"
+    finally:
+        loop.call_soon_threadsafe(loop.stop)
+        thread.join(timeout=2)
+        loop.close()

--- a/uv.lock
+++ b/uv.lock
@@ -8,16 +8,20 @@ resolution-markers = [
     "python_full_version < '3.12'",
 ]
 
+[options]
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer-span = "P2D"
+
 [[package]]
 name = "agent-client-protocol"
-version = "0.9.0"
+version = "0.10.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/eb/13/3b893421369767e7043cc115d6ef0df417c298b84563be3a12df0416158d/agent_client_protocol-0.9.0.tar.gz", hash = "sha256:f744c48ab9af0f0b4452e5ab5498d61bcab97c26dbe7d6feec5fd36de49be30b", size = 71853, upload-time = "2026-03-26T01:21:00.379Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/21/5c/d60196c536c8f66bb6a238c8a6d0d6fa84a2e3436008c139cb4a79003a25/agent_client_protocol-0.10.0.tar.gz", hash = "sha256:f8a6041e27423131e42e4d0cdd850d5b094b1092f79cc29501ab2bd57b92ee88", size = 81502, upload-time = "2026-05-07T19:11:56.784Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8f/ed/c284543c08aa443a4ef2c8bd120be51da8433dd174c01749b5d87c333f22/agent_client_protocol-0.9.0-py3-none-any.whl", hash = "sha256:06911500b51d8cb69112544e2be01fc5e7db39ef88fecbc3848c5c6f194798ee", size = 56850, upload-time = "2026-03-26T01:20:59.252Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/cc/139895c0c5cd2acefc365085da0735d93df0cf8427ff4ee351961090e1af/agent_client_protocol-0.10.0-py3-none-any.whl", hash = "sha256:97a1a69c5d094e2625b09c4dbc2d5cf19637c4943630ceed52ab0578ecd5e14c", size = 65400, upload-time = "2026-05-07T19:11:55.614Z" },
 ]
 
 [[package]]
@@ -1778,7 +1782,7 @@ youtube = [
 
 [package.metadata]
 requires-dist = [
-    { name = "agent-client-protocol", marker = "extra == 'acp'", specifier = "==0.9.0" },
+    { name = "agent-client-protocol", marker = "extra == 'acp'", specifier = "==0.10.0" },
     { name = "aiohttp", marker = "extra == 'homeassistant'", specifier = "==3.13.3" },
     { name = "aiohttp", marker = "extra == 'messaging'", specifier = "==3.13.3" },
     { name = "aiohttp", marker = "extra == 'slack'", specifier = "==3.13.3" },

--- a/website/docs/user-guide/features/acp.md
+++ b/website/docs/user-guide/features/acp.md
@@ -31,6 +31,8 @@ Hermes runs with a curated `hermes-acp` toolset designed for editor workflows. I
 
 It intentionally excludes things that do not fit typical editor UX, such as messaging delivery and cronjob management.
 
+`clarify` is exposed only when the connected ACP client advertises `clientCapabilities.elicitation.form`. In that case Hermes uses ACP `elicitation/create` to collect the answer from the editor. Clients without form elicitation support do not receive the `clarify` tool; Hermes then falls back to ordinary assistant-message clarification. Dangerous command and edit approvals still use ACP permission requests — `clarify` is not an authorization path.
+
 ## Installation
 
 Install Hermes normally, then add the ACP extra:


### PR DESCRIPTION
## What does this PR do?

Adds ACP-native support for Hermes `clarify` prompts by routing clarification requests through ACP form elicitation when the client advertises `clientCapabilities.elicitation.form`.

Clients without form elicitation support do not receive the `clarify` tool and continue to degrade to normal assistant-message clarification. This keeps clarify separate from permission prompts and avoids using `session/request_permission` for clarification UX.

The implementation is spec-correct for `agent-client-protocol==0.10.0`, capability-gated, and not tied to a specific editor client.

## Related Issue

Fixes #29978

## Type of Change

- [x] New feature
- [x] Documentation update
- [x] Tests

## Changes Made

- `pyproject.toml`, `uv.lock`
  - Pin `agent-client-protocol==0.10.0`.

- `acp_adapter/elicitation.py`
  - Add helpers for detecting ACP form elicitation support.
  - Build clarify form schemas, including preserving “Other (type your answer)” when valid for the schema.
  - Normalize accepted, declined, cancelled, missing, and timeout-style elicitation responses.
  - Send ACP `elicitation/create` requests, using the typed helper when available and a raw request fallback otherwise.
  - Bridge Hermes’ sync `clarify_callback(question, choices)` interface to ACP elicitation.

- `acp_adapter/server.py`
  - Store initialize-time ACP client capabilities.
  - Capability-gate ACP `clarify` tool exposure.
  - Route ACP clarify callbacks through elicitation during prompt handling.
  - Restore the previous agent clarify callback after prompt execution.
  - Preserve existing disabled-toolset refresh semantics.

- `tests/acp_adapter/test_acp_elicitation.py`
  - Add coverage for capability detection, schema construction, answer extraction, raw ACP request shape, callback bridging, runtime tool exposure, unsupported-client fallback behavior, and no-permission-request regression coverage.

- `website/docs/user-guide/features/acp.md`
  - Document that ACP clarify support is exposed only when clients advertise form elicitation support.

## How to Test

Targeted ACP and related validation:

```bash
scripts/run_tests.sh tests/acp_adapter/ tests/acp/test_server.py tests/agent/test_copilot_acp_client.py tests/agent/test_copilot_acp_deprecation.py tests/scripts/test_release_acp_registry.py
```

Result:

```text
142 passed, 0 failed
```

Lockfile check:

```bash
uv lock --check
```

Result: passed.

Diff hygiene:

```bash
git diff --check origin/main...HEAD
```

Result: passed.

Windows compatibility check:

```bash
python scripts/check-windows-footguns.py --diff origin/main
```

Result:

```text
✓ No Windows footguns found (3 file(s) scanned).
```

Full suite was also attempted:

```bash
scripts/run_tests.sh
```

Result:

```text
24791 passed, 6 failed
```

The remaining failures are outside this ACP change:

- custom provider picker tests reading a live/local `gemma4:26b` model instead of test-provided custom models
- TUI argv expectation around `--expose-gc`
- one websocket broadcast timeout in `tests/hermes_cli/test_web_server.py`, which passed when rerun in isolation

Relevant ACP validation is green after rebasing onto latest `origin/main`.

## Checklist

### Code

- [x] Read the Contributing Guide
- [x] Commit messages follow Conventional Commits
- [x] Searched for duplicate PRs
- [x] PR contains only changes related to this feature
- [ ] Full test suite passes
  - Full suite was attempted with `scripts/run_tests.sh`; unrelated failures remain outside this ACP change.
- [x] Added tests for the change
- [x] Tested on Arch Linux

### Documentation and Housekeeping

- [x] Updated relevant docs
- [x] Config example update not needed; no config keys added
- [x] CONTRIBUTING.md / AGENTS.md update not needed
- [x] Considered cross-platform impact with `scripts/check-windows-footguns.py --diff origin/main`
- [x] Tool schema changes are capability-gated through ACP client capabilities

## Screenshots / Logs

No screenshots. This is protocol/tool-surface behavior covered by automated tests.

ACP request path used:

- Typed path when available: `conn.create_elicitation(...)`
- Raw fallback path: `conn._conn.send_request("elicitation/create", params)`
- Raw ACP method: `elicitation/create`
- Raw params: `sessionId`, `mode: "form"`, `message`, `requestedSchema`
