### PR TITLE
fix(execute_code): forward docker_env/forward_env/extra_args to spawned containers

### DIFF
--- a/tests/tools/test_code_execution_container_config.py
+++ b/tests/tools/test_code_execution_container_config.py
@@ -1,0 +1,99 @@
+"""Tests for docker container_config key propagation in code_execution_tool.
+
+Mirrors tests/tools/test_file_tools_container_config.py — the execute_code
+sandbox must forward the same docker_env / docker_forward_env /
+docker_extra_args keys that terminal_tool already forwards, so containers it
+spawns get host env vars and extra docker flags (e.g. AppArmor overrides).
+"""
+
+import threading
+from unittest.mock import patch, MagicMock
+
+import tools.code_execution_tool as code_execution_tool
+
+
+def _make_env_config(**overrides):
+    base = {
+        "env_type": "docker",
+        "docker_image": "test-image:latest",
+        "singularity_image": "docker://test",
+        "modal_image": "test",
+        "daytona_image": "test",
+        "cwd": "/workspace",
+        "host_cwd": None,
+        "timeout": 180,
+        "container_cpu": 2,
+        "container_memory": 4096,
+        "container_disk": 20480,
+        "container_persistent": False,
+        "vercel_runtime": "",
+        "docker_volumes": [],
+        "docker_run_as_host_user": False,
+        "docker_env": {"FOO": "bar"},
+        "docker_forward_env": ["MY_SECRET", "API_KEY"],
+        "docker_extra_args": ["--security-opt", "apparmor=unconfined"],
+    }
+    base.update(overrides)
+    return base
+
+
+class TestCodeExecutionContainerConfig:
+    def _run(self, env_config, task_id):
+        captured = {}
+        mock_env = MagicMock()
+
+        def fake_create_env(**kwargs):
+            captured.update(kwargs)
+            return mock_env
+
+        with patch("tools.terminal_tool._get_env_config", return_value=env_config), \
+             patch("tools.terminal_tool._task_env_overrides", {}), \
+             patch("tools.terminal_tool._active_environments", {}), \
+             patch("tools.terminal_tool._last_activity", {}), \
+             patch("tools.terminal_tool._creation_locks", {}), \
+             patch("tools.terminal_tool._creation_locks_lock", threading.Lock()), \
+             patch("tools.terminal_tool._resolve_container_task_id", lambda t: t), \
+             patch("tools.terminal_tool._create_environment", side_effect=fake_create_env), \
+             patch("tools.terminal_tool._start_cleanup_thread"):
+            code_execution_tool._get_or_create_env(task_id)
+
+        return captured.get("container_config", {})
+
+    def test_docker_env_passed(self):
+        """docker_env is forwarded to container_config."""
+        cc = self._run(_make_env_config(docker_env={"FOO": "bar"}), "t1")
+        assert cc.get("docker_env") == {"FOO": "bar"}
+
+    def test_docker_forward_env_passed(self):
+        """docker_forward_env is forwarded to container_config."""
+        cc = self._run(_make_env_config(docker_forward_env=["MY_SECRET"]), "t2")
+        assert cc.get("docker_forward_env") == ["MY_SECRET"]
+
+    def test_docker_extra_args_passed(self):
+        """docker_extra_args is forwarded to container_config."""
+        cc = self._run(
+            _make_env_config(docker_extra_args=["--security-opt", "apparmor=unconfined"]),
+            "t3",
+        )
+        assert cc.get("docker_extra_args") == ["--security-opt", "apparmor=unconfined"]
+
+    def test_docker_env_defaults_to_empty_dict(self):
+        """docker_env defaults to {} when absent from config."""
+        cfg = _make_env_config()
+        del cfg["docker_env"]
+        cc = self._run(cfg, "t4")
+        assert cc.get("docker_env") == {}
+
+    def test_docker_forward_env_defaults_to_empty_list(self):
+        """docker_forward_env defaults to [] when absent from config."""
+        cfg = _make_env_config()
+        del cfg["docker_forward_env"]
+        cc = self._run(cfg, "t5")
+        assert cc.get("docker_forward_env") == []
+
+    def test_docker_extra_args_defaults_to_empty_list(self):
+        """docker_extra_args defaults to [] when absent from config."""
+        cfg = _make_env_config()
+        del cfg["docker_extra_args"]
+        cc = self._run(cfg, "t6")
+        assert cc.get("docker_extra_args") == []

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -621,6 +621,15 @@ def _get_or_create_env(task_id: str):
                 "vercel_runtime": config.get("vercel_runtime", ""),
                 "docker_volumes": config.get("docker_volumes", []),
                 "docker_run_as_host_user": config.get("docker_run_as_host_user", False),
+                # Local patch (2026-05-18): upstream omitted docker_env /
+                # docker_forward_env / docker_extra_args here, so execute_code
+                # spawned containers without env vars or extra flags even when
+                # terminal_tool spawns had them. Symptom: himalaya keyring
+                # failed inside execute_code containers (docker-default
+                # AppArmor blocking D-Bus method calls to host gnome-keyring).
+                "docker_env": config.get("docker_env", {}),
+                "docker_forward_env": config.get("docker_forward_env", []),
+                "docker_extra_args": config.get("docker_extra_args", []),
             }
 
         ssh_config = None


### PR DESCRIPTION
## What does this PR do?

`_get_or_create_env()` in `code_execution_tool.py` builds the `container_config` dict for the `execute_code` sandbox, but omitted three docker keys. `terminal_tool.py` already forwards all three when it builds its own `container_config`, so `execute_code`-spawned containers ran **without host env vars, forwarded env, or extra docker flags** — while `terminal`-spawned containers had them. The two tools spawn the same kind of container but were not at parity.

This adds the missing keys:

```python
"docker_env": config.get("docker_env", {}),
"docker_forward_env": config.get("docker_forward_env", []),
"docker_extra_args": config.get("docker_extra_args", []),
```

**Concrete symptom:** a tool that depends on a host service from inside an `execute_code` container fails — e.g. a keyring-backed CLI can't reach the host secret service because the docker-default AppArmor profile blocks D-Bus, and the `--security-opt apparmor=unconfined` override (a `docker_extra_args` value) never reached the container. The same code under the `terminal` tool worked.

The keys default to `{}` / `[]` / `[]`, so this is a **no-op for any setup that doesn't configure them**.

## Related Issue

No tracking issue — found while debugging a host-service integration that worked under `terminal` but failed under `execute_code`.

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/code_execution_tool.py` — `_get_or_create_env()` adds `docker_env`, `docker_forward_env`, `docker_extra_args` to `container_config`
- `tests/tools/test_code_execution_container_config.py` — 6 tests (forwarding + defaults), mirroring the existing `test_file_tools_container_config.py`

## How to Test

1. Run `pytest tests/tools/test_code_execution_container_config.py -q` — 6 passed.
2. Set `docker_extra_args`/`docker_env`/`docker_forward_env` in the env config; the container the `execute_code` tool spawns now receives them (previously only `terminal`-spawned containers did).

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run the affected test suite — `tests/tools/test_code_execution_container_config.py`: 6 passed
- [x] I've added tests for my changes (6 new tests)
- [x] I've tested on my platform: Ubuntu (Linux 6.8)

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (keys already exist and are consumed by `terminal_tool`)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — N/A (Docker-only path, no platform-specific code)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A (no schema change)