### PR TITLE
fix(gateway): add .md/.markdown to MEDIA regex extension whitelist

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2159,7 +2159,7 @@ class BasePlatformAdapter(ABC):
         # Extract MEDIA:<path> tags, allowing optional whitespace after the colon
         # and quoted/backticked paths for LLM-formatted outputs.
         media_pattern = re.compile(
-            r'''[`"']?MEDIA:\s*(?P<path>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|(?:~/|/)\S+(?:[^\S\n]+\S+)*?\.(?:png|jpe?g|gif|webp|mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|flac|epub|pdf|zip|rar|7z|docx?|xlsx?|pptx?|txt|csv|apk|ipa)(?=[\s`"',;:)\]}]|$))[`"']?'''
+            r'''[`"']?MEDIA:\s*(?P<path>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|(?:~/|/)\S+(?:[^\S\n]+\S+)*?\.(?:png|jpe?g|gif|webp|mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|flac|epub|pdf|zip|rar|7z|docx?|xlsx?|pptx?|txt|csv|md|markdown|apk|ipa)(?=[\s`"',;:)\]}]|$))[`"']?'''
         )
         for match in media_pattern.finditer(content):
             path = match.group("path").strip()

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -16522,7 +16522,7 @@ class GatewayRunner:
                             r'MEDIA:((?:/|~\/)\S+\.(?:png|jpe?g|gif|webp|'
                             r'mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|'
                             r'flac|epub|pdf|zip|rar|7z|docx?|xlsx?|pptx?|'
-                            r'txt|csv|apk|ipa))',
+                            r'txt|csv|md|markdown|apk|ipa))',
                             re.IGNORECASE
                         )
                         for _match in _TOOL_MEDIA_RE.finditer(_hc):
@@ -16818,7 +16818,7 @@ class GatewayRunner:
                                 r'MEDIA:((?:/|~\/)\S+\.(?:png|jpe?g|gif|webp|'
                                 r'mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|'
                                 r'flac|epub|pdf|zip|rar|7z|docx?|xlsx?|pptx?|'
-                                r'txt|csv|apk|ipa))',
+                                r'txt|csv|md|markdown|apk|ipa))',
                                 re.IGNORECASE
                             )
                             for match in _TOOL_MEDIA_RE.finditer(content):


### PR DESCRIPTION
The MEDIA extraction regex was tightened in `ea49b3862` to require an explicit extension whitelist instead of the previous catch-all `\S+` pattern, but the whitelist omitted `.md` and `.markdown` files.

This causes `MEDIA:/path/to/file.md` tags to be silently stripped from messages without uploading the file — the tag is removed from display text but never matched by `extract_media()`, so no Discord/Telegram/etc. attachment is created.

Simple fix: add `md|markdown` alongside the existing text-based extensions (`txt|csv`).

3 lines changed across 2 files (`gateway/platforms/base.py` + `gateway/run.py`).

Tested locally — applying the fix restores `.md` file delivery immediately.