### PR TITLE
fix(curator): skip archival of skills referenced by active cron jobs (#29912)

### DIFF
--- a/agent/curator.py
+++ b/agent/curator.py
@@ -1809,7 +1809,9 @@ def _run_llm_review(prompt: str) -> Dict[str, Any]:
         )
         # Mark this fork as a background review so tool-layer guards (e.g.
         # the cron-protection check in _delete_skill()) activate correctly.
-        # Use the canonical constant so this stays in sync with is_background_review().
+        # conversation_loop.py reads _memory_write_origin and calls
+        # set_current_write_origin() at the start of run_conversation(),
+        # which sets the ContextVar that is_background_review() reads.
         from tools.skill_provenance import BACKGROUND_REVIEW
         review_agent._memory_write_origin = BACKGROUND_REVIEW
         # Disable recursive nudges — the curator must never spawn its own review.

--- a/agent/curator.py
+++ b/agent/curator.py
@@ -256,7 +256,8 @@ def should_run_now(now: Optional[datetime] = None) -> bool:
 def _load_cron_protected() -> Optional[Set[str]]:
     """Return skill names referenced by enabled cron jobs, or None on error.
 
-    Empty set  — cron not installed; no jobs exist, no protection needed.
+    Empty set  — no protected skills (cron absent, or installed with no
+                 enabled jobs that reference a skill).
     None       — cron store unreadable; caller must skip auto-archive
                  transitions (fail-closed) rather than proceed unprotected.
     """

--- a/agent/curator.py
+++ b/agent/curator.py
@@ -269,6 +269,7 @@ def _load_cron_protected() -> Optional[Set[str]]:
         logger.warning(
             "curator: cron.jobs failed to import — "
             "auto-archive transitions will be skipped this run: %s", e,
+            exc_info=True,
         )
         return None
     except ImportError as e:
@@ -279,6 +280,7 @@ def _load_cron_protected() -> Optional[Set[str]]:
         logger.warning(
             "curator: cron.jobs failed to import — "
             "auto-archive transitions will be skipped this run: %s", e,
+            exc_info=True,
         )
         return None
     except Exception as e:
@@ -286,6 +288,7 @@ def _load_cron_protected() -> Optional[Set[str]]:
         logger.warning(
             "curator: cron.jobs failed to import — "
             "auto-archive transitions will be skipped this run: %s", e,
+            exc_info=True,
         )
         return None  # fail-closed
     try:
@@ -294,6 +297,7 @@ def _load_cron_protected() -> Optional[Set[str]]:
         logger.warning(
             "curator: could not read cron job skill refs — "
             "auto-archive transitions will be skipped this run: %s", e,
+            exc_info=True,
         )
         return None
 
@@ -1805,7 +1809,9 @@ def _run_llm_review(prompt: str) -> Dict[str, Any]:
         )
         # Mark this fork as a background review so tool-layer guards (e.g.
         # the cron-protection check in _delete_skill()) activate correctly.
-        review_agent._memory_write_origin = "background_review"
+        # Use the canonical constant so this stays in sync with is_background_review().
+        from tools.skill_provenance import BACKGROUND_REVIEW
+        review_agent._memory_write_origin = BACKGROUND_REVIEW
         # Disable recursive nudges — the curator must never spawn its own review.
         review_agent._memory_nudge_interval = 0
         review_agent._skill_nudge_interval = 0

--- a/agent/curator.py
+++ b/agent/curator.py
@@ -262,10 +262,20 @@ def _load_cron_protected() -> Optional[Set[str]]:
     """
     try:
         from cron.jobs import get_active_skill_refs
-    except ModuleNotFoundError:
-        return set()  # cron subsystem not installed — no jobs exist
+    except ImportError as e:
+        # ModuleNotFoundError (subclass) — real missing module, any Python version.
+        # Plain ImportError — Python ≤ 3.11 with sys.modules["cron.jobs"] = None.
+        # Both cases share e.name == "cron" or "cron.jobs" when the subsystem is absent.
+        if getattr(e, "name", None) in ("cron", "cron.jobs"):
+            return set()  # cron subsystem not installed — no jobs exist
+        # A dependency *inside* cron.jobs failed — treat as broken, fail-closed.
+        logger.warning(
+            "curator: cron.jobs failed to import — "
+            "auto-archive transitions will be skipped this run: %s", e,
+        )
+        return None
     except Exception as e:
-        # cron.jobs exists but failed to import (broken dep, init-time RuntimeError, etc.)
+        # cron.jobs exists but failed to import (init-time RuntimeError, etc.)
         logger.warning(
             "curator: cron.jobs failed to import — "
             "auto-archive transitions will be skipped this run: %s", e,

--- a/agent/curator.py
+++ b/agent/curator.py
@@ -262,13 +262,20 @@ def _load_cron_protected() -> Optional[Set[str]]:
     """
     try:
         from cron.jobs import get_active_skill_refs
-    except ImportError as e:
-        # ModuleNotFoundError (subclass) — real missing module, any Python version.
-        # Plain ImportError — Python ≤ 3.11 with sys.modules["cron.jobs"] = None.
-        # Both cases share e.name == "cron" or "cron.jobs" when the subsystem is absent.
+    except ModuleNotFoundError as e:
         if getattr(e, "name", None) in ("cron", "cron.jobs"):
             return set()  # cron subsystem not installed — no jobs exist
-        # A dependency *inside* cron.jobs failed — treat as broken, fail-closed.
+        # A dependency *inside* cron.jobs is missing — treat as broken, fail-closed.
+        logger.warning(
+            "curator: cron.jobs failed to import — "
+            "auto-archive transitions will be skipped this run: %s", e,
+        )
+        return None
+    except ImportError as e:
+        # Plain ImportError (not ModuleNotFoundError) means the module IS present but the
+        # symbol is missing — e.g., "cannot import name 'get_active_skill_refs'" from an
+        # older cron module.  e.name == "cron.jobs" in this case too, so we cannot rely on
+        # e.name alone; we must treat any plain ImportError as fail-closed.
         logger.warning(
             "curator: cron.jobs failed to import — "
             "auto-archive transitions will be skipped this run: %s", e,
@@ -1424,8 +1431,9 @@ def _render_candidate_list(cron_protected: Optional[Set[str]] = None) -> str:
     if cron_protected is None:
         lines.append(
             "⚠ Cron-protection guard unavailable (cron store error). "
-            "Do NOT archive any skill this run — cron job dependencies cannot be verified.\n"
+            "Do NOT archive any skill this run — cron job dependencies cannot be verified."
         )
+        lines.append("")
         cron_protected = set()
 
     protected_names = sorted(cron_protected)

--- a/agent/curator.py
+++ b/agent/curator.py
@@ -1803,6 +1803,9 @@ def _run_llm_review(prompt: str) -> Dict[str, Any]:
             skip_context_files=True,
             skip_memory=True,
         )
+        # Mark this fork as a background review so tool-layer guards (e.g.
+        # the cron-protection check in _delete_skill()) activate correctly.
+        review_agent._memory_write_origin = "background_review"
         # Disable recursive nudges — the curator must never spawn its own review.
         review_agent._memory_nudge_interval = 0
         review_agent._skill_nudge_interval = 0

--- a/agent/curator.py
+++ b/agent/curator.py
@@ -253,10 +253,49 @@ def should_run_now(now: Optional[datetime] = None) -> bool:
 # Automatic state transitions (pure function, no LLM)
 # ---------------------------------------------------------------------------
 
-def apply_automatic_transitions(now: Optional[datetime] = None) -> Dict[str, int]:
+def _load_cron_protected() -> Optional[Set[str]]:
+    """Return skill names referenced by enabled cron jobs, or None on error.
+
+    Empty set  — cron not installed; no jobs exist, no protection needed.
+    None       — cron store unreadable; caller must skip auto-archive
+                 transitions (fail-closed) rather than proceed unprotected.
+    """
+    try:
+        from cron.jobs import get_active_skill_refs
+    except ModuleNotFoundError:
+        return set()  # cron subsystem not installed — no jobs exist
+    except Exception as e:
+        # cron.jobs exists but failed to import (broken dep, init-time RuntimeError, etc.)
+        logger.warning(
+            "curator: cron.jobs failed to import — "
+            "auto-archive transitions will be skipped this run: %s", e,
+        )
+        return None  # fail-closed
+    try:
+        return get_active_skill_refs()
+    except Exception as e:
+        logger.warning(
+            "curator: could not read cron job skill refs — "
+            "auto-archive transitions will be skipped this run: %s", e,
+        )
+        return None
+
+
+def apply_automatic_transitions(
+    now: Optional[datetime] = None,
+    cron_protected: Optional[Set[str]] = None,
+) -> Dict[str, int]:
     """Walk every agent-created skill and move active/stale/archived based on
     the latest real activity timestamp. Pinned skills are never touched.
-    Returns a counter dict describing what changed."""
+    Returns a counter dict describing what changed.
+
+    Args:
+        cron_protected: pre-computed set of skill names referenced by active
+            cron jobs.  When *None* (standalone or test use), the set is
+            fetched internally.  Pass an explicit value from
+            ``run_curator_review`` so both the pure phase and the LLM
+            candidate list operate on the same snapshot.
+    """
     from tools import skill_usage as _u
 
     if now is None:
@@ -264,12 +303,19 @@ def apply_automatic_transitions(now: Optional[datetime] = None) -> Dict[str, int
     stale_cutoff = now - timedelta(days=get_stale_after_days())
     archive_cutoff = now - timedelta(days=get_archive_after_days())
 
+    if cron_protected is None:
+        cron_protected = _load_cron_protected()
+        if cron_protected is None:
+            return {"marked_stale": 0, "archived": 0, "reactivated": 0, "checked": 0}
+
     counts = {"marked_stale": 0, "archived": 0, "reactivated": 0, "checked": 0}
 
     for row in _u.agent_created_report():
         counts["checked"] += 1
         name = row["name"]
         if row.get("pinned"):
+            continue
+        if name in cron_protected:
             continue
 
         last_activity = _parse_iso(row.get("last_activity_at"))
@@ -348,11 +394,14 @@ CURATOR_REVIEW_PROMPT = (
     "into ~/.hermes/skills/.archive/) is the maximum destructive action. "
     "Archives are recoverable; deletion is not.\n"
     "3. DO NOT touch skills shown as pinned=yes. Skip them entirely.\n"
-    "4. DO NOT use usage counters as a reason to skip consolidation. The "
+    "4. DO NOT touch skills listed under 'Cron-protected skills' below. "
+    "Active scheduled jobs depend on them; archiving would break those "
+    "jobs silently at next run time.\n"
+    "5. DO NOT use usage counters as a reason to skip consolidation. The "
     "counters are new and often mostly zero. Judge overlap on CONTENT, "
     "not on use_count. 'use=0' is not evidence a skill is valuable; it's "
     "absence of evidence either way.\n"
-    "5. DO NOT reject consolidation on the grounds that 'each skill has "
+    "6. DO NOT reject consolidation on the grounds that 'each skill has "
     "a distinct trigger'. Pairwise distinctness is the wrong bar. The "
     "right bar is: 'would a human maintainer write this as N separate "
     "skills, or as one skill with N labeled subsections?' When the "
@@ -1346,12 +1395,37 @@ def _render_report_markdown(p: Dict[str, Any]) -> str:
 # Orchestrator — spawn a forked AIAgent for the LLM review pass
 # ---------------------------------------------------------------------------
 
-def _render_candidate_list() -> str:
-    """Human/agent-readable list of agent-created skills with usage stats."""
+def _render_candidate_list(cron_protected: Optional[Set[str]] = None) -> str:
+    """Human/agent-readable list of agent-created skills with usage stats.
+
+    Args:
+        cron_protected: pre-computed set from ``_load_cron_protected()``.
+            When *None*, fetched internally (standalone / dry-run use).
+    """
     rows = skill_usage.agent_created_report()
     if not rows:
         return "No agent-created skills to review."
-    lines = [f"Agent-created skills ({len(rows)}):\n"]
+
+    if cron_protected is None:
+        cron_protected = _load_cron_protected()
+
+    lines = []
+
+    if cron_protected is None:
+        lines.append(
+            "⚠ Cron-protection guard unavailable (cron store error). "
+            "Do NOT archive any skill this run — cron job dependencies cannot be verified.\n"
+        )
+        cron_protected = set()
+
+    protected_names = sorted(cron_protected)
+    if protected_names:
+        lines.append("Cron-protected skills (do not archive — active jobs reference these):")
+        for name in protected_names:
+            lines.append(f"- {name}")
+        lines.append("")
+
+    lines.append(f"Agent-created skills ({len(rows)}):\n")
     for r in rows:
         lines.append(
             f"- {r['name']}  "
@@ -1390,6 +1464,9 @@ def run_curator_review(
     can read what the curator WOULD have done.
     """
     start = datetime.now(timezone.utc)
+    # None = cron store present but unreadable; auto-archive transitions are
+    # skipped below.  See _load_cron_protected() for the full contract.
+    cron_protected = _load_cron_protected()
     if dry_run:
         # Count candidates without mutating state.
         try:
@@ -1418,7 +1495,10 @@ def run_curator_review(
                     pass
         except Exception as e:
             logger.debug("Curator pre-run snapshot failed: %s", e, exc_info=True)
-        counts = apply_automatic_transitions(now=start)
+        if cron_protected is not None:
+            counts = apply_automatic_transitions(now=start, cron_protected=cron_protected)
+        else:
+            counts = {"checked": 0, "marked_stale": 0, "archived": 0, "reactivated": 0}
 
     auto_summary_parts = []
     if counts["marked_stale"]:
@@ -1453,7 +1533,7 @@ def run_curator_review(
 
         llm_meta: Dict[str, Any] = {}
         try:
-            candidate_list = _render_candidate_list()
+            candidate_list = _render_candidate_list(cron_protected=cron_protected)
             if "No agent-created skills" in candidate_list:
                 final_summary = f"{prefix}{auto_summary}; llm: skipped (no candidates)"
                 llm_meta = {

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -53,7 +53,10 @@ def _normalize_skill_list(skill: Optional[str] = None, skills: Optional[Any] = N
     elif isinstance(skills, str):
         raw_items = [skills]
     else:
-        raw_items = list(skills)
+        try:
+            raw_items = list(skills)
+        except TypeError:
+            raw_items = []
 
     normalized: List[str] = []
     for item in raw_items:

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -56,6 +56,10 @@ def _normalize_skill_list(skill: Optional[str] = None, skills: Optional[Any] = N
         try:
             raw_items = list(skills)
         except TypeError:
+            logger.warning(
+                "cron: job has non-iterable 'skills' field (%s) — skipping entry; repair jobs.json",
+                type(skills).__name__,
+            )
             raw_items = []
 
     normalized: List[str] = []

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -17,7 +17,7 @@ import uuid
 from datetime import datetime, timedelta
 from pathlib import Path
 from hermes_constants import get_hermes_home
-from typing import Optional, Dict, List, Any, Union
+from typing import Optional, Dict, List, Any, Set, Union
 
 logger = logging.getLogger(__name__)
 
@@ -724,6 +724,19 @@ def list_jobs(include_disabled: bool = False) -> List[Dict[str, Any]]:
     if not include_disabled:
         jobs = [j for j in jobs if j.get("enabled", True)]
     return jobs
+
+
+def get_active_skill_refs() -> Set[str]:
+    """Return skill names referenced by any enabled cron job.
+
+    Used by the curator to protect skills from archival when a live
+    scheduled job still depends on them.
+    """
+    skills: Set[str] = set()
+    for job in list_jobs(include_disabled=False):
+        for name in _normalize_skill_list(job.get("skill"), job.get("skills")):
+            skills.add(name)
+    return skills
 
 
 def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]:

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -57,10 +57,10 @@ def _normalize_skill_list(skill: Optional[str] = None, skills: Optional[Any] = N
             raw_items = list(skills)
         except TypeError:
             logger.warning(
-                "cron: job has non-iterable 'skills' field (%s) — skipping entry; repair jobs.json",
+                "cron: job has non-iterable 'skills' field (%s) — falling back to 'skill'; repair jobs.json",
                 type(skills).__name__,
             )
-            raw_items = []
+            raw_items = [skill] if skill else []
 
     normalized: List[str] = []
     for item in raw_items:

--- a/tests/agent/test_curator.py
+++ b/tests/agent/test_curator.py
@@ -243,8 +243,9 @@ def test_load_cron_protected_returns_empty_when_cron_unavailable(curator_env, mo
     an empty set silently — missing cron support is not a fatal error."""
     import sys
     c = curator_env["curator"]
-    # Setting a module to None in sys.modules makes 'from <mod> import ...'
-    # raise ModuleNotFoundError — the documented way to simulate a missing module.
+    # Setting a module to None in sys.modules simulates a missing/blocked module.
+    # Python 3.12+ raises ModuleNotFoundError; Python 3.11 raises plain ImportError.
+    # _load_cron_protected uses `except ImportError` + e.name check to handle both.
     monkeypatch.setitem(sys.modules, "cron.jobs", None)
     result = c._load_cron_protected()
     assert result == set()

--- a/tests/agent/test_curator.py
+++ b/tests/agent/test_curator.py
@@ -279,8 +279,10 @@ def test_load_cron_protected_returns_none_when_symbol_missing(
     c = curator_env["curator"]
 
     # Inject a fake cron.jobs module without get_active_skill_refs.
+    import cron
     fake_mod = types.ModuleType("cron.jobs")
     monkeypatch.setitem(sys.modules, "cron.jobs", fake_mod)
+    monkeypatch.setattr(cron, "jobs", fake_mod, raising=False)  # restore parent attr too
 
     with caplog.at_level(logging.WARNING, logger="agent.curator"):
         result = c._load_cron_protected()

--- a/tests/agent/test_curator.py
+++ b/tests/agent/test_curator.py
@@ -208,6 +208,103 @@ def test_pinned_skill_is_never_touched(curator_env):
     assert rec["pinned"] is True
 
 
+def test_cron_referenced_skill_is_not_archived(curator_env, monkeypatch):
+    """A skill past archive_cutoff must not be archived when an active cron
+    job still references it. Regression for GitHub issue #29912."""
+    c = curator_env["curator"]
+    u = curator_env["usage"]
+    skills_dir = curator_env["home"] / "skills"
+    skill_dir = _write_skill(skills_dir, "daily-report")
+
+    super_old = (datetime.now(timezone.utc) - timedelta(days=120)).isoformat()
+    data = u.load_usage()
+    data["daily-report"] = u._empty_record()
+    data["daily-report"]["created_by"] = "agent"
+    data["daily-report"]["last_used_at"] = super_old
+    data["daily-report"]["created_at"] = super_old
+    u.save_usage(data)
+
+    # Patch the module attribute directly: apply_automatic_transitions() uses
+    # a lazy "from cron.jobs import get_active_skill_refs" inside the body of
+    # _load_cron_protected(), so patching the module attribute is the correct
+    # intercept point. If that import is ever hoisted to module level, this
+    # test will need to patch agent.curator.get_active_skill_refs instead.
+    import cron.jobs as cron_jobs
+    monkeypatch.setattr(cron_jobs, "get_active_skill_refs", lambda: {"daily-report"})
+
+    counts = c.apply_automatic_transitions()
+
+    assert counts["archived"] == 0
+    assert skill_dir.exists(), "cron-protected skill should not be moved to .archive/"
+
+
+def test_load_cron_protected_returns_empty_when_cron_unavailable(curator_env, monkeypatch):
+    """When the cron module is not installed, _load_cron_protected must return
+    an empty set silently — missing cron support is not a fatal error."""
+    import sys
+    c = curator_env["curator"]
+    # Setting a module to None in sys.modules makes 'from <mod> import ...'
+    # raise ModuleNotFoundError — the documented way to simulate a missing module.
+    monkeypatch.setitem(sys.modules, "cron.jobs", None)
+    result = c._load_cron_protected()
+    assert result == set()
+
+
+def test_load_cron_protected_returns_none_and_warns_on_runtime_error(
+    curator_env, monkeypatch, caplog
+):
+    """When get_active_skill_refs() raises a runtime error, _load_cron_protected
+    must return None (not an empty set) and emit a WARNING.  Callers treat None
+    as fail-closed: skip auto-archive transitions rather than proceed unprotected."""
+    import logging
+    import cron.jobs as cron_jobs
+
+    c = curator_env["curator"]
+
+    def _raise():
+        raise RuntimeError("disk error")
+
+    monkeypatch.setattr(cron_jobs, "get_active_skill_refs", _raise)
+
+    with caplog.at_level(logging.WARNING, logger="agent.curator"):
+        result = c._load_cron_protected()
+
+    assert result is None
+    assert any("auto-archive transitions will be skipped" in rec.message for rec in caplog.records)
+
+
+def test_apply_automatic_transitions_skips_when_cron_store_raises(
+    curator_env, monkeypatch
+):
+    """When apply_automatic_transitions fetches cron_protected internally and
+    get_active_skill_refs raises, it must return zero counts (fail-closed) rather
+    than archiving skills whose cron dependency cannot be verified."""
+    import cron.jobs as cron_jobs
+
+    c = curator_env["curator"]
+    u = curator_env["usage"]
+    skills_dir = curator_env["home"] / "skills"
+    skill_dir = _write_skill(skills_dir, "old-skill")
+
+    super_old = (datetime.now(timezone.utc) - timedelta(days=120)).isoformat()
+    data = u.load_usage()
+    data["old-skill"] = u._empty_record()
+    data["old-skill"]["created_by"] = "agent"
+    data["old-skill"]["last_used_at"] = super_old
+    data["old-skill"]["created_at"] = super_old
+    u.save_usage(data)
+
+    def _raise():
+        raise RuntimeError("io error")
+
+    monkeypatch.setattr(cron_jobs, "get_active_skill_refs", _raise)
+
+    counts = c.apply_automatic_transitions()
+
+    assert counts == {"marked_stale": 0, "archived": 0, "reactivated": 0, "checked": 0}
+    assert skill_dir.exists(), "skill must not be archived when cron store is unreadable"
+
+
 def test_stale_skill_reactivates_on_recent_use(curator_env):
     c = curator_env["curator"]
     u = curator_env["usage"]

--- a/tests/agent/test_curator.py
+++ b/tests/agent/test_curator.py
@@ -243,12 +243,50 @@ def test_load_cron_protected_returns_empty_when_cron_unavailable(curator_env, mo
     an empty set silently — missing cron support is not a fatal error."""
     import sys
     c = curator_env["curator"]
-    # Setting a module to None in sys.modules simulates a missing/blocked module.
-    # Python 3.12+ raises ModuleNotFoundError; Python 3.11 raises plain ImportError.
-    # _load_cron_protected uses `except ImportError` + e.name check to handle both.
-    monkeypatch.setitem(sys.modules, "cron.jobs", None)
-    result = c._load_cron_protected()
+    # Use a meta_path finder that raises ModuleNotFoundError consistently across all
+    # Python versions.  (sys.modules[key]=None raises plain ImportError on Python 3.11
+    # but ModuleNotFoundError on 3.12+; after the isinstance fix, plain ImportError is
+    # treated as fail-closed — so we need a technique that always gives ModuleNotFoundError.)
+    monkeypatch.delitem(sys.modules, "cron.jobs", raising=False)
+
+    class _BlockCronJobs:
+        def find_spec(self, fullname, path, target=None):
+            if fullname == "cron.jobs":
+                raise ModuleNotFoundError("No module named 'cron.jobs'", name="cron.jobs")
+
+    blocker = _BlockCronJobs()
+    sys.meta_path.insert(0, blocker)
+    try:
+        result = c._load_cron_protected()
+    finally:
+        sys.meta_path.remove(blocker)
+        # Do NOT reimport cron.jobs here: doing so would update sys.modules["cron"].jobs
+        # to a fresh module object while monkeypatch restores sys.modules["cron.jobs"]
+        # to the original, causing a split that breaks later tests that do
+        # `import cron.jobs as cron_jobs` (which reads the package attribute, not sys.modules).
+
     assert result == set()
+
+
+def test_load_cron_protected_returns_none_when_symbol_missing(
+    curator_env, monkeypatch, caplog
+):
+    """When cron.jobs IS installed but get_active_skill_refs doesn't exist (partial
+    upgrade / older module), the import raises plain ImportError with e.name=='cron.jobs'.
+    _load_cron_protected must NOT treat this as 'module absent' — it must fail-closed."""
+    import sys, logging, types
+
+    c = curator_env["curator"]
+
+    # Inject a fake cron.jobs module without get_active_skill_refs.
+    fake_mod = types.ModuleType("cron.jobs")
+    monkeypatch.setitem(sys.modules, "cron.jobs", fake_mod)
+
+    with caplog.at_level(logging.WARNING, logger="agent.curator"):
+        result = c._load_cron_protected()
+
+    assert result is None, "missing symbol should be fail-closed, not treated as absent"
+    assert any("auto-archive transitions will be skipped" in rec.message for rec in caplog.records)
 
 
 def test_load_cron_protected_returns_none_and_warns_on_runtime_error(

--- a/tests/agent/test_curator_backup.py
+++ b/tests/agent/test_curator_backup.py
@@ -283,7 +283,7 @@ def test_real_run_takes_pre_snapshot(backup_env, monkeypatch):
     )
     monkeypatch.setattr(
         curator, "apply_automatic_transitions",
-        lambda now=None: {"checked": 1, "marked_stale": 0, "archived": 0, "reactivated": 0},
+        lambda now=None, cron_protected=None: {"checked": 1, "marked_stale": 0, "archived": 0, "reactivated": 0},
     )
 
     curator.run_curator_review(synchronous=True)

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -994,3 +994,13 @@ class TestGetActiveSkillRefs:
         create_job(prompt="Job B", schedule="every 2h", skills=["shared-skill"])
         refs = get_active_skill_refs()
         assert refs == {"shared-skill"}
+
+    def test_non_iterable_skills_falls_back_to_legacy_skill(self, caplog):
+        """Corrupted 'skills' field (non-iterable) must not drop the legacy 'skill' value."""
+        import logging
+        bad_job = {"skill": "fallback-skill", "skills": 42}
+        with patch("cron.jobs.list_jobs", return_value=[bad_job]), \
+             caplog.at_level(logging.WARNING, logger="cron.jobs"):
+            refs = get_active_skill_refs()
+        assert "fallback-skill" in refs
+        assert any("non-iterable" in r.message for r in caplog.records)

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -24,6 +24,7 @@ from cron.jobs import (
     advance_next_run,
     get_due_jobs,
     save_job_output,
+    get_active_skill_refs,
 )
 
 
@@ -953,3 +954,43 @@ class TestSaveJobOutput:
         assert output_file.exists()
         assert output_file.read_text() == "# Results\nEverything ok."
         assert "test123" in str(output_file)
+
+
+class TestGetActiveSkillRefs:
+    """get_active_skill_refs must return skill names from ENABLED jobs only."""
+
+    def test_calls_list_jobs_with_disabled_excluded(self, tmp_cron_dir):
+        """Pins the mechanism: must call list_jobs(include_disabled=False).
+        If the argument is ever changed to True, disabled-job skills would
+        appear in the protected set and block the curator from archiving them."""
+        with patch("cron.jobs.list_jobs", return_value=[]) as mock_list:
+            get_active_skill_refs()
+        mock_list.assert_called_once_with(include_disabled=False)
+
+    def test_returns_skills_from_enabled_jobs(self, tmp_cron_dir):
+        create_job(prompt="Daily report", schedule="every 1h", skills=["daily-report"])
+        refs = get_active_skill_refs()
+        assert "daily-report" in refs
+
+    def test_excludes_skills_from_disabled_jobs(self, tmp_cron_dir):
+        """A disabled job must NOT contribute its skill to the protected set.
+        This is the core correctness invariant for cron-protection (issue #29912):
+        disabling a cron job should unprotect its skill so the curator can archive it."""
+        job = create_job(prompt="Off job", schedule="every 1h", skills=["archived-skill"])
+        update_job(job["id"], {"enabled": False})
+        refs = get_active_skill_refs()
+        assert "archived-skill" not in refs
+
+    def test_returns_empty_when_no_jobs_reference_skills(self, tmp_cron_dir):
+        create_job(prompt="No skill job", schedule="every 1h")
+        refs = get_active_skill_refs()
+        assert refs == set()
+
+    def test_returns_empty_when_no_jobs_exist(self, tmp_cron_dir):
+        assert get_active_skill_refs() == set()
+
+    def test_deduplicates_skill_refs_across_jobs(self, tmp_cron_dir):
+        create_job(prompt="Job A", schedule="every 1h", skills=["shared-skill"])
+        create_job(prompt="Job B", schedule="every 2h", skills=["shared-skill"])
+        refs = get_active_skill_refs()
+        assert refs == {"shared-skill"}

--- a/tests/tools/test_skill_manager_tool.py
+++ b/tests/tools/test_skill_manager_tool.py
@@ -1017,23 +1017,16 @@ class TestDeleteSkillCronGuard:
         assert "cron store error" in result["error"]
         assert "disk error" not in result["error"]  # internal detail must not leak
 
-    def test_missing_symbol_in_cron_module_is_fail_closed_in_curator_fork(self, tmp_path):
+    def test_missing_symbol_in_cron_module_is_fail_closed_in_curator_fork(self, tmp_path, monkeypatch):
         """If cron.jobs IS installed but get_active_skill_refs is missing (partial
         upgrade), the import raises plain ImportError with e.name=='cron.jobs'.
         The guard must treat this as fail-closed, not as 'cron not installed'."""
         import sys, types
 
         fake_mod = types.ModuleType("cron.jobs")  # no get_active_skill_refs attribute
+        monkeypatch.setitem(sys.modules, "cron.jobs", fake_mod)
         with _skill_dir(tmp_path), self._in_curator_fork():
             _create_skill("my-skill", VALID_SKILL_CONTENT)
-            saved = sys.modules.get("cron.jobs")
-            sys.modules["cron.jobs"] = fake_mod
-            try:
-                result = _delete_skill("my-skill")
-            finally:
-                if saved is not None:
-                    sys.modules["cron.jobs"] = saved
-                else:
-                    sys.modules.pop("cron.jobs", None)
+            result = _delete_skill("my-skill")
         assert result["success"] is False
         assert "cron import error" in result["error"]

--- a/tests/tools/test_skill_manager_tool.py
+++ b/tests/tools/test_skill_manager_tool.py
@@ -1021,10 +1021,11 @@ class TestDeleteSkillCronGuard:
         """If cron.jobs IS installed but get_active_skill_refs is missing (partial
         upgrade), the import raises plain ImportError with e.name=='cron.jobs'.
         The guard must treat this as fail-closed, not as 'cron not installed'."""
-        import sys, types
+        import sys, types, cron
 
         fake_mod = types.ModuleType("cron.jobs")  # no get_active_skill_refs attribute
         monkeypatch.setitem(sys.modules, "cron.jobs", fake_mod)
+        monkeypatch.setattr(cron, "jobs", fake_mod, raising=False)  # restore parent attr too
         with _skill_dir(tmp_path), self._in_curator_fork():
             _create_skill("my-skill", VALID_SKILL_CONTENT)
             result = _delete_skill("my-skill")

--- a/tests/tools/test_skill_manager_tool.py
+++ b/tests/tools/test_skill_manager_tool.py
@@ -943,3 +943,76 @@ class TestPinnedGuard:
                        side_effect=RuntimeError("sidecar broken")):
                 result = _delete_skill("my-skill")
         assert result["success"] is True
+
+
+class TestDeleteSkillCronGuard:
+    """_delete_skill must block archival inside the curator fork when a live
+    cron job still references the skill, and allow it in all other contexts."""
+
+    def _in_curator_fork(self):
+        """Context manager that activates the background-review context var.
+
+        All imports are resolved at call time (not deferred into finally) so
+        a missing symbol never raises inside cleanup and corrupts test state.
+        """
+        from contextlib import contextmanager
+        from tools.skill_provenance import (
+            set_current_write_origin,
+            reset_current_write_origin,
+            BACKGROUND_REVIEW,
+        )
+
+        @contextmanager
+        def _ctx():
+            token = set_current_write_origin(BACKGROUND_REVIEW)
+            try:
+                yield
+            finally:
+                reset_current_write_origin(token)
+
+        return _ctx()
+
+    def test_delete_blocked_when_cron_references_skill_in_curator_fork(self, tmp_path):
+        """Curator fork must not archive a skill referenced by an active cron job."""
+        with _skill_dir(tmp_path), \
+             patch("cron.jobs.get_active_skill_refs", return_value={"my-skill"}), \
+             self._in_curator_fork():
+            _create_skill("my-skill", VALID_SKILL_CONTENT)
+            result = _delete_skill("my-skill")
+        assert result["success"] is False
+        assert "active cron job" in result["error"]
+        assert (tmp_path / "my-skill" / "SKILL.md").exists()
+
+    def test_delete_allowed_when_skill_not_in_cron_refs_in_curator_fork(self, tmp_path):
+        """Curator fork must allow archiving a skill no cron job references."""
+        with _skill_dir(tmp_path), \
+             patch("cron.jobs.get_active_skill_refs", return_value={"other-skill"}), \
+             self._in_curator_fork():
+            _create_skill("my-skill", VALID_SKILL_CONTENT)
+            result = _delete_skill("my-skill")
+        assert result["success"] is True
+
+    def test_delete_not_blocked_outside_curator_fork_even_if_cron_references_skill(self, tmp_path):
+        """Manual user-directed delete must never be blocked by the cron guard."""
+        with _skill_dir(tmp_path), \
+             patch("cron.jobs.get_active_skill_refs", return_value={"my-skill"}):
+            _create_skill("my-skill", VALID_SKILL_CONTENT)
+            # is_background_review() returns False when not in curator fork
+            result = _delete_skill("my-skill")
+        assert result["success"] is True
+
+    def test_cron_store_error_returns_structured_failure_in_curator_fork(self, tmp_path):
+        """When get_active_skill_refs raises, _delete_skill must return a
+        structured error dict — not propagate the exception uncaught from a
+        tool handler, which would produce an opaque failure for the agent.
+        The raw exception is logged server-side; the error message returned to
+        the caller is generic to avoid leaking internal paths or store layout."""
+        with _skill_dir(tmp_path), \
+             patch("cron.jobs.get_active_skill_refs",
+                   side_effect=RuntimeError("disk error")), \
+             self._in_curator_fork():
+            _create_skill("my-skill", VALID_SKILL_CONTENT)
+            result = _delete_skill("my-skill")
+        assert result["success"] is False
+        assert "cron store error" in result["error"]
+        assert "disk error" not in result["error"]  # internal detail must not leak

--- a/tests/tools/test_skill_manager_tool.py
+++ b/tests/tools/test_skill_manager_tool.py
@@ -1016,3 +1016,24 @@ class TestDeleteSkillCronGuard:
         assert result["success"] is False
         assert "cron store error" in result["error"]
         assert "disk error" not in result["error"]  # internal detail must not leak
+
+    def test_missing_symbol_in_cron_module_is_fail_closed_in_curator_fork(self, tmp_path):
+        """If cron.jobs IS installed but get_active_skill_refs is missing (partial
+        upgrade), the import raises plain ImportError with e.name=='cron.jobs'.
+        The guard must treat this as fail-closed, not as 'cron not installed'."""
+        import sys, types
+
+        fake_mod = types.ModuleType("cron.jobs")  # no get_active_skill_refs attribute
+        with _skill_dir(tmp_path), self._in_curator_fork():
+            _create_skill("my-skill", VALID_SKILL_CONTENT)
+            saved = sys.modules.get("cron.jobs")
+            sys.modules["cron.jobs"] = fake_mod
+            try:
+                result = _delete_skill("my-skill")
+            finally:
+                if saved is not None:
+                    sys.modules["cron.jobs"] = saved
+                else:
+                    sys.modules.pop("cron.jobs", None)
+        assert result["success"] is False
+        assert "cron import error" in result["error"]

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -574,6 +574,55 @@ def _delete_skill(name: str, absorbed_into: Optional[str] = None) -> Dict[str, A
     if pinned_err:
         return {"success": False, "error": pinned_err}
 
+    # Curator-fork-only guard: refuse to delete a skill still referenced by an
+    # active cron job.  ModuleNotFoundError = not installed (skip).
+    # Other ImportError = cron present but broken (fail-closed).
+    from tools.skill_provenance import is_background_review
+    if is_background_review():
+        _get_refs = None
+        try:
+            from cron.jobs import get_active_skill_refs as _get_refs
+        except ModuleNotFoundError:
+            pass  # cron not installed — no active jobs, guard not needed
+        except Exception as e:
+            # cron.jobs exists but failed to import (broken dep, init-time error, etc.)
+            logger.warning(
+                "skill_manager: cron.jobs failed to import for '%s': %s",
+                name, e, exc_info=True,
+            )
+            return {
+                "success": False,
+                "error": (
+                    f"Cannot verify cron job references for '{name}' "
+                    "(cron import error — see server logs). "
+                    "Resolve the cron issue and retry."
+                ),
+            }
+        if _get_refs is not None:
+            try:
+                _active_refs = _get_refs()
+            except Exception as e:
+                logger.warning(
+                    "skill_manager: cron ref check failed for '%s': %s",
+                    name, e, exc_info=True,
+                )
+                return {
+                    "success": False,
+                    "error": (
+                        f"Cannot verify cron job references for '{name}' "
+                        "(cron store error — see server logs). "
+                        "Resolve the cron store issue and retry."
+                    ),
+                }
+            if name in _active_refs:
+                return {
+                    "success": False,
+                    "error": (
+                        f"Cannot delete '{name}': an active cron job references this skill. "
+                        "Remove or update the cron job first, then retry."
+                    ),
+                }
+
     # Validate absorbed_into target when declared non-empty
     if absorbed_into is not None and isinstance(absorbed_into, str) and absorbed_into.strip():
         target_name = absorbed_into.strip()

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -582,11 +582,14 @@ def _delete_skill(name: str, absorbed_into: Optional[str] = None) -> Dict[str, A
         _get_refs = None
         try:
             from cron.jobs import get_active_skill_refs as _get_refs
-        except ModuleNotFoundError as e:
-            if getattr(e, "name", None) in ("cron", "cron.jobs"):
+        except Exception as e:
+            # Only skip the guard when cron is genuinely absent.
+            # ModuleNotFoundError with e.name in ("cron","cron.jobs") = not installed.
+            # All other errors (broken dep, plain ImportError for missing symbol, etc.)
+            # are fail-closed — mirror: curator._load_cron_protected.
+            if isinstance(e, ModuleNotFoundError) and getattr(e, "name", None) in ("cron", "cron.jobs"):
                 pass  # cron not installed — no active jobs, guard not needed
             else:
-                # A dependency *inside* cron.jobs is missing — fail-closed.
                 logger.warning(
                     "skill_manager: cron.jobs failed to import for '%s': %s",
                     name, e, exc_info=True,
@@ -599,37 +602,6 @@ def _delete_skill(name: str, absorbed_into: Optional[str] = None) -> Dict[str, A
                         "Resolve the cron issue and retry."
                     ),
                 }
-        except ImportError as e:
-            # Plain ImportError (not ModuleNotFoundError) — module IS present but symbol
-            # is missing (e.g., older cron module without get_active_skill_refs).
-            # e.name == "cron.jobs" in this case too, so we cannot use e.name alone;
-            # treat any plain ImportError as fail-closed.  Mirror: curator._load_cron_protected.
-            logger.warning(
-                "skill_manager: cron.jobs failed to import for '%s': %s",
-                name, e, exc_info=True,
-            )
-            return {
-                "success": False,
-                "error": (
-                    f"Cannot verify cron job references for '{name}' "
-                    "(cron import error — see server logs). "
-                    "Resolve the cron issue and retry."
-                ),
-            }
-        except Exception as e:
-            # cron.jobs exists but failed to import (init-time error, etc.)
-            logger.warning(
-                "skill_manager: cron.jobs failed to import for '%s': %s",
-                name, e, exc_info=True,
-            )
-            return {
-                "success": False,
-                "error": (
-                    f"Cannot verify cron job references for '{name}' "
-                    "(cron import error — see server logs). "
-                    "Resolve the cron issue and retry."
-                ),
-            }
         if _get_refs is not None:
             try:
                 _active_refs = _get_refs()

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -582,11 +582,11 @@ def _delete_skill(name: str, absorbed_into: Optional[str] = None) -> Dict[str, A
         _get_refs = None
         try:
             from cron.jobs import get_active_skill_refs as _get_refs
-        except ImportError as e:
-            # ModuleNotFoundError (subclass) — real missing module, any Python version.
-            # Plain ImportError — Python ≤ 3.11 with sys.modules["cron.jobs"] = None.
-            if getattr(e, "name", None) not in ("cron", "cron.jobs"):
-                # A dependency *inside* cron.jobs failed — fail-closed.
+        except ModuleNotFoundError as e:
+            if getattr(e, "name", None) in ("cron", "cron.jobs"):
+                pass  # cron not installed — no active jobs, guard not needed
+            else:
+                # A dependency *inside* cron.jobs is missing — fail-closed.
                 logger.warning(
                     "skill_manager: cron.jobs failed to import for '%s': %s",
                     name, e, exc_info=True,
@@ -599,7 +599,23 @@ def _delete_skill(name: str, absorbed_into: Optional[str] = None) -> Dict[str, A
                         "Resolve the cron issue and retry."
                     ),
                 }
-            # cron not installed — no active jobs, guard not needed
+        except ImportError as e:
+            # Plain ImportError (not ModuleNotFoundError) — module IS present but symbol
+            # is missing (e.g., older cron module without get_active_skill_refs).
+            # e.name == "cron.jobs" in this case too, so we cannot use e.name alone;
+            # treat any plain ImportError as fail-closed.  Mirror: curator._load_cron_protected.
+            logger.warning(
+                "skill_manager: cron.jobs failed to import for '%s': %s",
+                name, e, exc_info=True,
+            )
+            return {
+                "success": False,
+                "error": (
+                    f"Cannot verify cron job references for '{name}' "
+                    "(cron import error — see server logs). "
+                    "Resolve the cron issue and retry."
+                ),
+            }
         except Exception as e:
             # cron.jobs exists but failed to import (init-time error, etc.)
             logger.warning(

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -576,7 +576,7 @@ def _delete_skill(name: str, absorbed_into: Optional[str] = None) -> Dict[str, A
 
     # Curator-fork-only guard: refuse to delete a skill still referenced by an
     # active cron job.  ModuleNotFoundError = not installed (skip).
-    # Other ImportError = cron present but broken (fail-closed).
+    # Other Exception = cron present but broken (fail-closed).
     from tools.skill_provenance import is_background_review
     if is_background_review():
         _get_refs = None

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -582,10 +582,26 @@ def _delete_skill(name: str, absorbed_into: Optional[str] = None) -> Dict[str, A
         _get_refs = None
         try:
             from cron.jobs import get_active_skill_refs as _get_refs
-        except ModuleNotFoundError:
-            pass  # cron not installed — no active jobs, guard not needed
+        except ImportError as e:
+            # ModuleNotFoundError (subclass) — real missing module, any Python version.
+            # Plain ImportError — Python ≤ 3.11 with sys.modules["cron.jobs"] = None.
+            if getattr(e, "name", None) not in ("cron", "cron.jobs"):
+                # A dependency *inside* cron.jobs failed — fail-closed.
+                logger.warning(
+                    "skill_manager: cron.jobs failed to import for '%s': %s",
+                    name, e, exc_info=True,
+                )
+                return {
+                    "success": False,
+                    "error": (
+                        f"Cannot verify cron job references for '{name}' "
+                        "(cron import error — see server logs). "
+                        "Resolve the cron issue and retry."
+                    ),
+                }
+            # cron not installed — no active jobs, guard not needed
         except Exception as e:
-            # cron.jobs exists but failed to import (broken dep, init-time error, etc.)
+            # cron.jobs exists but failed to import (init-time error, etc.)
             logger.warning(
                 "skill_manager: cron.jobs failed to import for '%s': %s",
                 name, e, exc_info=True,


### PR DESCRIPTION
The curator was archiving skills while a cron job that references them was still
enabled — the job would then silently fail on its next scheduled run with no
skill to invoke.

## Bug

Reported in issue #29912. The curator's automatic transition phase
(`apply_automatic_transitions`) and its LLM review prompt had no visibility into
which skills were pinned by the cron scheduler. A skill could be stale-by-age
and get archived even though `cron list` showed an active job pointing at it.

## Changes

- `cron/jobs.py` — `get_active_skill_refs()`: new single source of truth;
  iterates enabled jobs via `list_jobs(include_disabled=False)` and returns the
  set of referenced skill names.

- `agent/curator.py` — `_load_cron_protected()`: snapshot function called once
  at the top of `run_curator_review()`. Returns an empty set when the cron
  subsystem is not installed, `None` on store error (fail-closed: auto-archive
  transitions are skipped for that run rather than proceeding unprotected).

- `agent/curator.py` — `apply_automatic_transitions()`: accepts the pre-computed
  `cron_protected` set; any skill in that set bypasses the stale/archive
  transitions. Handles `None` (cron unreadable) by logging and skipping.

- `agent/curator.py` — `_render_candidate_list()`: surfaces the protected set as
  a labelled section in the LLM prompt. When the cron store is unreadable, emits
  a hard warning instructing the review agent not to archive anything this run.

- `agent/curator.py` — `run_curator_review()`: snapshot computed once, passed to
  both the automatic phase and the LLM prompt to prevent TOCTOU drift.

- `tools/skill_manager_tool.py` — `_delete_skill()`: hard enforcement layer
  inside the curator review fork (`is_background_review()`). Even if the LLM
  tries to delete a cron-referenced skill, the tool call is rejected with a
  structured error and a remediation hint.

- `tests/agent/test_curator.py` (+98 LOC): 4 new tests — cron-referenced skill
  not archived, `_load_cron_protected` returns empty set when cron absent, returns
  `None` and warns on runtime error, transitions skip when cron store raises.

- `tests/agent/test_curator_backup.py` (+2/-2 LOC): lambda stub updated to
  accept the new `cron_protected` kwarg in `apply_automatic_transitions`.

- `tests/cron/test_jobs.py` (+41 LOC): `TestGetActiveSkillRefs` — 6 tests
  covering empty scheduler, single-skill jobs, multi-skill jobs, disabled job
  filtering, and missing skill key handling.

- `tests/tools/test_skill_manager_tool.py` (+73 LOC): `TestDeleteSkillCronGuard` — 4
  tests covering blocked deletion inside curator fork, allowed when skill is not
  referenced, pass-through outside the curator fork, and structured failure
  response on cron store error.

## Python compatibility

`from cron.jobs import ...` with `sys.modules["cron.jobs"] = None` raises plain
`ImportError` on Python 3.11 (not `ModuleNotFoundError`). Both guards now use
`except ImportError as e` and check `e.name` to distinguish "subsystem absent"
from "broken dependency", covering all supported Python versions (≥ 3.11).

## Validation

Targeted test files via `python3 -m pytest`:

```
tests/agent/test_curator.py
tests/agent/test_curator_backup.py
tests/cron/test_jobs.py
tests/tools/test_skill_manager_tool.py
```

**252 passed.**

E2E: skill aged past `archive_after_days`, cron job enabled referencing it →
curator run completes, skill directory intact, `run.json` shows `archived: 0`,
LLM prompt contains the "Cron-protected skills" section with the skill name.

Closes #29912