### PR TITLE
feat(provider): add Ambient as LLM provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,6 +23,14 @@
 # NOVITA_BASE_URL=https://api.novita.ai/openai/v1  # Override default base URL
 
 # =============================================================================
+# LLM PROVIDER (Ambient)
+# =============================================================================
+# Ambient — verified AI inference with cryptographic proof of every call (GLM-5.1)
+# Get your key at: https://app.ambient.xyz
+# AMBIENT_API_KEY=
+# AMBIENT_BASE_URL=https://api.ambient.xyz/v1  # Override default base URL
+
+# =============================================================================
 # LLM PROVIDER (Google AI Studio / Gemini)
 # =============================================================================
 # Native Gemini API via Google's OpenAI-compatible endpoint.

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -48,7 +48,7 @@ def _resolve_requests_verify() -> bool | str:
 _PROVIDER_PREFIXES: frozenset[str] = frozenset({
     "openrouter", "nous", "openai-codex", "copilot", "copilot-acp",
     "gemini", "ollama-cloud", "zai", "kimi-coding", "kimi-coding-cn", "stepfun", "minimax", "minimax-oauth", "minimax-cn", "anthropic", "deepseek",
-    "opencode-zen", "opencode-go", "kilocode", "alibaba", "novita",
+    "opencode-zen", "opencode-go", "kilocode", "alibaba", "novita", "ambient",
     "qwen-oauth",
     "xiaomi",
     "arcee",
@@ -444,6 +444,7 @@ _URL_TO_PROVIDER: Dict[str, str] = {
     "xiaomimimo.com": "xiaomi",
     "api.gmi-serving.com": "gmi",
     "api.novita.ai": "novita",
+    "api.ambient.xyz": "ambient",
     "tokenhub.tencentmaas.com": "tencent-tokenhub",
     "ollama.com": "ollama-cloud",
 }

--- a/hermes_cli/model_setup_flows.py
+++ b/hermes_cli/model_setup_flows.py
@@ -2385,7 +2385,7 @@ def _model_flow_api_key_provider(config, provider_id, current_model=""):
         )
         if model_list:
             print(f"  Found {len(model_list)} model(s) from Ollama Cloud")
-    elif provider_id == "novita":
+    elif provider_id in ("novita", "ambient"):
         from hermes_cli.models import fetch_api_models
 
         api_key_for_probe = existing_key or (get_env_value(key_env) if key_env else "")

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -506,6 +506,9 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "deepseek/deepseek-r1-0528",
         "qwen/qwen3-235b-a22b-fp8",
     ],
+    "ambient": [
+        "zai-org/GLM-5.1-FP8",
+    ],
 }
 
 # ---------------------------------------------------------------------------
@@ -1004,6 +1007,7 @@ CANONICAL_PROVIDERS: list[ProviderEntry] = [
     ProviderEntry("nous",           "Nous Portal",              "Nous Portal (Everything your agent needs, 300+ models with bundled tool use)"),
     ProviderEntry("openrouter",     "OpenRouter",               "OpenRouter (Pay-per-use API aggregator)"),
     ProviderEntry("novita",         "NovitaAI",                 "NovitaAI (Cloud: Model API, Agent Sandbox, GPU Cloud)"),
+    ProviderEntry("ambient",        "Ambient",                  "Ambient (verified AI inference with cryptographic proof — GLM-5.1)"),
     ProviderEntry("lmstudio",       "LM Studio",                "LM Studio (Local desktop app with built-in model server)"),
     ProviderEntry("anthropic",      "Anthropic",                "Anthropic (Claude models via API key or Claude Code)"),
     ProviderEntry("openai-codex",   "OpenAI Codex",             "OpenAI Codex (Codex CLI via ChatGPT subscription or API key)"),
@@ -1525,7 +1529,7 @@ def _resolve_nous_pricing_credentials() -> tuple[str, str]:
 
 
 def get_pricing_for_provider(provider: str, *, force_refresh: bool = False) -> dict[str, dict[str, str]]:
-    """Return live pricing for providers that support it (openrouter, nous, novita)."""
+    """Return live pricing for providers that support it (openrouter, nous, novita, ambient)."""
     normalized = normalize_provider(provider)
     if normalized == "openrouter":
         return fetch_models_with_pricing(
@@ -1535,6 +1539,18 @@ def get_pricing_for_provider(provider: str, *, force_refresh: bool = False) -> d
         )
     if normalized == "novita":
         return _fetch_novita_pricing(force_refresh=force_refresh)
+    if normalized == "ambient":
+        api_key = os.getenv("AMBIENT_API_KEY", "").strip()
+        base_url = os.getenv("AMBIENT_BASE_URL", "").strip() or "https://api.ambient.xyz/v1"
+        # fetch_models_with_pricing appends "/v1/models" to its base_url
+        # argument, so strip the trailing /v1 before passing.
+        if base_url.rstrip("/").endswith("/v1"):
+            base_url = base_url.rstrip("/")[:-3]
+        return fetch_models_with_pricing(
+            api_key=api_key,
+            base_url=base_url,
+            force_refresh=force_refresh,
+        )
     if normalized == "nous":
         api_key, base_url = _resolve_nous_pricing_credentials()
         if base_url:

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -191,6 +191,12 @@ HERMES_OVERLAYS: Dict[str, HermesOverlay] = {
         base_url_override="https://api.gmi-serving.com/v1",
         base_url_env_var="GMI_BASE_URL",
     ),
+    "ambient": HermesOverlay(
+        transport="openai_chat",
+        is_aggregator=True,
+        base_url_override="https://api.ambient.xyz/v1",
+        base_url_env_var="AMBIENT_BASE_URL",
+    ),
     "ollama-cloud": HermesOverlay(
         transport="openai_chat",
         base_url_override="https://ollama.com/v1",

--- a/plugins/model-providers/ambient/__init__.py
+++ b/plugins/model-providers/ambient/__init__.py
@@ -1,0 +1,21 @@
+"""Ambient provider profile."""
+
+from providers import register_provider
+from providers.base import ProviderProfile
+
+
+ambient = ProviderProfile(
+    name="ambient",
+    display_name="Ambient",
+    description="Ambient — verified AI inference with cryptographic proof of every call (GLM-5.1)",
+    signup_url="https://app.ambient.xyz",
+    env_vars=("AMBIENT_API_KEY", "AMBIENT_BASE_URL"),
+    base_url="https://api.ambient.xyz/v1",
+    auth_type="api_key",
+    default_aux_model="zai-org/GLM-5.1-FP8",
+    fallback_models=(
+        "zai-org/GLM-5.1-FP8",
+    ),
+)
+
+register_provider(ambient)

--- a/plugins/model-providers/ambient/plugin.yaml
+++ b/plugins/model-providers/ambient/plugin.yaml
@@ -1,0 +1,5 @@
+name: ambient-provider
+kind: model-provider
+version: 1.0.0
+description: Ambient verified AI inference platform
+author: Nous Research

--- a/tests/hermes_cli/test_api_key_providers.py
+++ b/tests/hermes_cli/test_api_key_providers.py
@@ -1225,6 +1225,104 @@ class TestNovitaProvider:
 
 
 # =============================================================================
+# Ambient provider tests
+# =============================================================================
+
+class TestAmbientProvider:
+    """Tests for Ambient — verified AI inference with cryptographic proof."""
+
+    def test_ambient_profile_loads(self):
+        from providers import get_provider_profile
+        profile = get_provider_profile("ambient")
+        assert profile is not None
+        assert profile.name == "ambient"
+        assert profile.display_name == "Ambient"
+        assert profile.base_url == "https://api.ambient.xyz/v1"
+        assert "AMBIENT_API_KEY" in profile.env_vars
+
+    def test_ambient_in_provider_registry(self):
+        """Auto-registration from ProviderProfile should expose Ambient."""
+        assert "ambient" in PROVIDER_REGISTRY
+        pconfig = PROVIDER_REGISTRY["ambient"]
+        assert pconfig.auth_type == "api_key"
+        assert pconfig.id == "ambient"
+        assert pconfig.inference_base_url == "https://api.ambient.xyz/v1"
+        assert pconfig.api_key_env_vars == ("AMBIENT_API_KEY",)
+        assert pconfig.base_url_env_var == "AMBIENT_BASE_URL"
+
+    def test_models_py_has_ambient(self):
+        from hermes_cli.models import _PROVIDER_MODELS
+        assert "ambient" in _PROVIDER_MODELS
+        assert len(_PROVIDER_MODELS["ambient"]) >= 1
+
+    def test_ambient_models_use_org_name_format(self):
+        from hermes_cli.models import _PROVIDER_MODELS
+        for model in _PROVIDER_MODELS["ambient"]:
+            assert "/" in model, f"Ambient model {model!r} missing org/ prefix"
+
+    def test_ambient_label(self):
+        from hermes_cli.models import _PROVIDER_LABELS
+        assert "ambient" in _PROVIDER_LABELS
+        assert _PROVIDER_LABELS["ambient"] == "Ambient"
+
+    def test_ambient_in_provider_prefixes(self):
+        from agent.model_metadata import _PROVIDER_PREFIXES
+        assert "ambient" in _PROVIDER_PREFIXES
+
+    def test_ambient_url_to_provider(self):
+        from agent.model_metadata import _URL_TO_PROVIDER
+        assert _URL_TO_PROVIDER.get("api.ambient.xyz") == "ambient"
+
+    def test_ambient_pricing_dispatch(self, monkeypatch):
+        """get_pricing_for_provider('ambient') routes to fetch_models_with_pricing
+        with /v1 stripped, and parses Ambient's canonical pricing shape."""
+        from hermes_cli import models as models_mod
+        monkeypatch.setenv("AMBIENT_API_KEY", "sk-test-key")
+        monkeypatch.delenv("AMBIENT_BASE_URL", raising=False)
+        models_mod._pricing_cache.pop("https://api.ambient.xyz", None)
+
+        seen_urls: list[str] = []
+        fake_payload = {
+            "data": [
+                {
+                    "id": "zai-org/GLM-5.1-FP8",
+                    "pricing": {
+                        "prompt": "0.0000014",
+                        "completion": "0.0000044",
+                        "input_cache_read": "0",
+                        "input_cache_write": "0",
+                    },
+                }
+            ]
+        }
+
+        class _FakeResp:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *args):
+                return False
+
+            def read(self):
+                import json as _json
+                return _json.dumps(fake_payload).encode()
+
+        def fake_urlopen(req, timeout=None):
+            seen_urls.append(req.full_url)
+            return _FakeResp()
+
+        monkeypatch.setattr(
+            models_mod.urllib.request, "urlopen", fake_urlopen
+        )
+
+        result = models_mod.get_pricing_for_provider("ambient")
+        assert seen_urls == ["https://api.ambient.xyz/v1/models"]
+        assert "zai-org/GLM-5.1-FP8" in result
+        assert result["zai-org/GLM-5.1-FP8"]["prompt"] == "0.0000014"
+        assert result["zai-org/GLM-5.1-FP8"]["completion"] == "0.0000044"
+
+
+# =============================================================================
 # MiniMax OAuth provider tests (added by feat/minimax-oauth-provider)
 # =============================================================================
 

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -21,6 +21,7 @@ You need at least one way to connect to an LLM. Use `hermes model` to switch pro
 | **Anthropic** | `hermes model` (Claude Max + extra usage credits via OAuth; also supports Anthropic API key or manual setup-token — see note below) |
 | **OpenRouter** | `OPENROUTER_API_KEY` in `~/.hermes/.env` |
 | **NovitaAI** | `NOVITA_API_KEY` in `~/.hermes/.env` (provider: `novita`, 200+ models, Model API, Agent Sandbox, GPU Cloud) |
+| **Ambient** | `AMBIENT_API_KEY` in `~/.hermes/.env` (provider: `ambient`; verified inference with cryptographic proof — GLM-5.1) |
 | **z.ai / GLM** | `GLM_API_KEY` in `~/.hermes/.env` (provider: `zai`) |
 | **Kimi / Moonshot** | `KIMI_API_KEY` in `~/.hermes/.env` (provider: `kimi-coding`) |
 | **Kimi / Moonshot (China)** | `KIMI_CN_API_KEY` in `~/.hermes/.env` (provider: `kimi-coding-cn`; aliases: `kimi-cn`, `moonshot-cn`) |
@@ -315,6 +316,26 @@ model:
 ```
 
 Get your API key at [novita.ai/settings/key-management](https://novita.ai/settings/key-management). The base URL can be overridden with `NOVITA_BASE_URL`.
+
+### Ambient
+
+[Ambient](https://ambiententerprise.ai) is verified AI infrastructure — every API call is accompanied by cryptographic proof of which model ran, what input was used, and what output was produced. Ambient serves GLM-5.1 at roughly half the cost of major providers while protecting all data, including reasoning content.
+
+```bash
+# Use GLM-5.1 through Ambient
+hermes chat --provider ambient --model zai-org/GLM-5.1-FP8
+# Requires: AMBIENT_API_KEY in ~/.hermes/.env
+```
+
+Or set it permanently in `config.yaml`:
+```yaml
+model:
+  provider: "ambient"
+  default: "zai-org/GLM-5.1-FP8"
+  base_url: "https://api.ambient.xyz/v1"
+```
+
+Get your API key at [app.ambient.xyz](https://app.ambient.xyz). The base URL can be overridden with `AMBIENT_BASE_URL`.
 
 ### Ollama Cloud — Managed Ollama Models, OAuth + API Key
 

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -100,7 +100,7 @@ Common options:
 | `-q`, `--query "..."` | One-shot, non-interactive prompt. |
 | `-m`, `--model <model>` | Override the model for this run. |
 | `-t`, `--toolsets <csv>` | Enable a comma-separated set of toolsets. |
-| `--provider <provider>` | Force a provider: `auto`, `openrouter`, `nous`, `openai-codex`, `copilot-acp`, `copilot`, `anthropic`, `gemini`, `huggingface`, `novita` (aliases `novita-ai`, `novitaai`), `openai-api`, `zai`, `kimi-coding`, `kimi-coding-cn`, `minimax`, `minimax-cn`, `minimax-oauth`, `kilocode`, `xiaomi`, `arcee`, `gmi`, `alibaba`, `alibaba-coding-plan` (alias `alibaba_coding`), `deepseek`, `nvidia`, `ollama-cloud`, `xai` (alias `grok`), `xai-oauth` (alias `grok-oauth`), `qwen-oauth`, `bedrock`, `opencode-zen`, `opencode-go`, `azure-foundry`, `lmstudio`, `stepfun`, `tencent-tokenhub` (alias `tencent`, `tokenhub`). |
+| `--provider <provider>` | Force a provider: `auto`, `openrouter`, `nous`, `openai-codex`, `copilot-acp`, `copilot`, `anthropic`, `gemini`, `huggingface`, `novita` (aliases `novita-ai`, `novitaai`), `ambient`, `openai-api`, `zai`, `kimi-coding`, `kimi-coding-cn`, `minimax`, `minimax-cn`, `minimax-oauth`, `kilocode`, `xiaomi`, `arcee`, `gmi`, `alibaba`, `alibaba-coding-plan` (alias `alibaba_coding`), `deepseek`, `nvidia`, `ollama-cloud`, `xai` (alias `grok`), `xai-oauth` (alias `grok-oauth`), `qwen-oauth`, `bedrock`, `opencode-zen`, `opencode-go`, `azure-foundry`, `lmstudio`, `stepfun`, `tencent-tokenhub` (alias `tencent`, `tokenhub`). |
 | `-s`, `--skills <name>` | Preload one or more skills for the session (can be repeated or comma-separated). |
 | `-v`, `--verbose` | Verbose output. |
 | `-Q`, `--quiet` | Programmatic mode: suppress banner/spinner/tool previews. |

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -78,6 +78,8 @@ Hermes reads environment variables from the process environment and, for user-ma
 | `DEEPSEEK_BASE_URL` | Custom DeepSeek API base URL |
 | `NOVITA_API_KEY` | NovitaAI API key — AI-native cloud for Model API, Agent Sandbox, and GPU Cloud ([novita.ai/settings/key-management](https://novita.ai/settings/key-management)) |
 | `NOVITA_BASE_URL` | Override NovitaAI base URL (default: `https://api.novita.ai/openai/v1`) |
+| `AMBIENT_API_KEY` | Ambient API key — verified AI inference with cryptographic proof, GLM-5.1 ([app.ambient.xyz](https://app.ambient.xyz)) |
+| `AMBIENT_BASE_URL` | Override Ambient base URL (default: `https://api.ambient.xyz/v1`) |
 | `NVIDIA_API_KEY` | NVIDIA NIM API key — Nemotron and open models ([build.nvidia.com](https://build.nvidia.com)) |
 | `NVIDIA_BASE_URL` | Override NVIDIA base URL (default: `https://integrate.api.nvidia.com/v1`; set to `http://localhost:8000/v1` for a local NIM endpoint) |
 | `STEPFUN_API_KEY` | StepFun API key — Step-series models ([platform.stepfun.com](https://platform.stepfun.com)) |


### PR DESCRIPTION
## What does this PR do?

Adds [Ambient](https://ambiententerprise.ai) as a first-class API-key provider.

Ambient is verified AI inference infrastructure - every API call ships with cryptographic proof of which model ran, what input was used, and what output was produced. Currently serves GLM-5.1 at roughly half the cost of major providers. The `/v1` endpoints are OpenAI-compatible.

## Related Issue

N/A — new-provider request, no preceding issue.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `plugins/model-providers/ambient/` — new `ProviderProfile` (id `ambient`, env `AMBIENT_API_KEY`/`AMBIENT_BASE_URL`, base `https://api.ambient.xyz/v1`, single curated model `zai-org/GLM-5.1-FP8`)
- `hermes_cli/providers.py` — `HermesOverlay` (`is_aggregator=True`, `base_url_env_var`)
- `hermes_cli/models.py` — `_PROVIDER_MODELS`, `CANONICAL_PROVIDERS`, and a `get_pricing_for_provider` branch reusing the existing `fetch_models_with_pricing` helper (Ambient's `/v1/models` already returns the canonical `{prompt, completion, input_cache_read, input_cache_write}` shape, no custom fetcher needed)
- `hermes_cli/main.py` — `_model_flow_api_key_provider` branch (collapsed with Novita's since the live → models.dev → curated flow is identical) and `--provider ambient` choice
- `agent/model_metadata.py` — `_PROVIDER_PREFIXES` and `_URL_TO_PROVIDER["api.ambient.xyz"]`
- `tests/hermes_cli/test_api_key_providers.py` — `TestAmbientProvider` (8 tests)
- Docs: `.env.example`, `integrations/providers.md`, `reference/environment-variables.md`, `reference/cli-commands.md`

No `auth.py:PROVIDER_REGISTRY` entry needed — the auto-extension at `auth.py:462` picks it up from the profile (same pattern as NovitaAI #25507).

## How to Test

1. Get a key at https://app.ambient.xyz, then `export AMBIENT_API_KEY=<key>`
2. `hermes chat --provider ambient --model zai-org/GLM-5.1-FP8 -q "hello"` — should return a normal response
3. `hermes doctor` — Ambient `/models` health check should pass
4. Test suite: `bash scripts/run_tests.sh tests/hermes_cli/test_api_key_providers.py` → **181/181 pass** (full file, including the 8 new `TestAmbientProvider` cases)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat(provider):`, `test(ambient):`, `docs:`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this feature
- [x] I've run the relevant tests and all pass (181/181 in `tests/hermes_cli/test_api_key_providers.py`)
- [x] I've added tests for my changes (`TestAmbientProvider`, 8 tests)
- [x] I've tested on my platform: Linux (CachyOS, kernel 7.0.3)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (`.env.example`, `website/docs/integrations/providers.md`, `website/docs/reference/environment-variables.md`, `website/docs/reference/cli-commands.md`)
- [x] N/A — no new config keys, so `cli-config.yaml.example` untouched
- [x] N/A — no architecture or workflow changes, so `CONTRIBUTING.md` / `AGENTS.md` untouched
- [x] Cross-platform: pure-Python plugin discovery + standard `urllib.request` for the catalog probe. No platform-specific code, no shell-outs.
- [x] N/A — no tool descriptions or schemas changed
