### PR TITLE
fix: restart TUI gateway transport after exit

### DIFF
--- a/ui-tui/packages/hermes-ink/src/utils/execFileNoThrow.ts
+++ b/ui-tui/packages/hermes-ink/src/utils/execFileNoThrow.ts
@@ -1,4 +1,4 @@
-import { spawn } from 'child_process'
+import { type ChildProcess, spawn, type StdioOptions } from 'child_process'
 type ExecFileOptions = {
   input?: string
   timeout?: number
@@ -32,11 +32,11 @@ export function execFileNoThrow(
     // doesn't inherit those pipe FDs — prevents handle leaks that can
     // keep the parent process alive. No output data is collected in
     // this mode; both stdout and stderr will be empty strings.
-    const stdioConfig = options.resolveOnExit
-      ? ['pipe', 'ignore', 'ignore'] as const
-      : 'pipe' as const
+    const stdioConfig: StdioOptions = options.resolveOnExit
+      ? ['pipe', 'ignore', 'ignore']
+      : 'pipe'
 
-    const child = spawn(file, args, {
+    const child: ChildProcess = spawn(file, args, {
       cwd: options.useCwd ? process.cwd() : undefined,
       env: options.env,
       stdio: stdioConfig
@@ -80,13 +80,13 @@ export function execFileNoThrow(
         }, options.timeout)
       : null
 
-    child.stdout?.on('data', chunk => {
+    child.stdout?.on('data', (chunk: Buffer) => {
       stdout += String(chunk)
     })
-    child.stderr?.on('data', chunk => {
+    child.stderr?.on('data', (chunk: Buffer) => {
       stderr += String(chunk)
     })
-    child.on('error', error => {
+    child.on('error', (error: Error) => {
       settle(1, String(error))
     })
 
@@ -95,12 +95,12 @@ export function execFileNoThrow(
       // daemon it forked still holds the inherited stdio pipes open.
       // When a signal kills the child, code is null — map that to 1
       // so callers don't mistake a signal-terminated run for success.
-      child.on('exit', (code, signal) => {
+      child.on('exit', (code: number | null, signal: NodeJS.Signals | null) => {
         const exitCode = timedOut ? 124 : (code ?? (signal ? 1 : 0))
         settle(exitCode)
       })
     } else {
-      child.on('close', (code, signal) => {
+      child.on('close', (code: number | null, signal: NodeJS.Signals | null) => {
         const exitCode = timedOut ? 124 : (code ?? (signal ? 1 : 0))
         settle(exitCode)
       })

--- a/ui-tui/src/__tests__/gatewayClient.test.ts
+++ b/ui-tui/src/__tests__/gatewayClient.test.ts
@@ -100,6 +100,7 @@ describe('GatewayClient websocket attach mode', () => {
     originalGatewayUrl = process.env.HERMES_TUI_GATEWAY_URL
     originalSidecarUrl = process.env.HERMES_TUI_SIDECAR_URL
     FakeWebSocket.reset()
+    delete process.env.HERMES_TUI_SIDECAR_URL
     ;(globalThis as { WebSocket?: unknown }).WebSocket = FakeWebSocket as unknown as typeof WebSocket
   })
 

--- a/ui-tui/src/app/useMainApp.ts
+++ b/ui-tui/src/app/useMainApp.ts
@@ -1,4 +1,4 @@
-import { useApp, useHasSelection, useSelection, useStdout, useTerminalTitle, type ScrollBoxHandle } from '@hermes/ink'
+import { type ScrollBoxHandle, useApp, useHasSelection, useSelection, useStdout, useTerminalTitle } from '@hermes/ink'
 import { useStore } from '@nanostores/react'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
@@ -139,6 +139,7 @@ export function useMainApp(gw: GatewayClient) {
   const msgIdsRef = useRef(new WeakMap<Msg, string>())
   const msgIdSeqRef = useRef(0)
   const heightCachesRef = useRef(new Map<string, Map<string, number>>())
+  const gatewayRestartTimerRef = useRef<null | ReturnType<typeof setTimeout>>(null)
 
   colsRef.current = cols
   historyItemsRef.current = historyItems
@@ -604,13 +605,30 @@ export function useMainApp(gw: GatewayClient) {
   onEventRef.current = onEvent
 
   useEffect(() => {
-    const handler = (ev: GatewayEvent) => onEventRef.current(ev)
+    const handler = (ev: GatewayEvent) => {
+      if (ev.type === 'gateway.ready' && gatewayRestartTimerRef.current) {
+        clearTimeout(gatewayRestartTimerRef.current)
+        gatewayRestartTimerRef.current = null
+      }
+
+      onEventRef.current(ev)
+    }
 
     const exitHandler = () => {
       turnController.reset()
-      patchUiState({ busy: false, sid: null, status: 'gateway exited' })
-      turnController.pushActivity('gateway exited · /logs to inspect', 'error')
-      sys('error: gateway exited')
+      patchUiState({ busy: false, sid: null, status: 'gateway restarting…' })
+      turnController.pushActivity('gateway exited · restarting transport', 'error')
+      sys('error: gateway exited; restarting transport')
+
+      if (gatewayRestartTimerRef.current) {
+        return
+      }
+
+      gatewayRestartTimerRef.current = setTimeout(() => {
+        gatewayRestartTimerRef.current = null
+        gw.start()
+      }, 500)
+      gatewayRestartTimerRef.current.unref?.()
     }
 
     gw.on('event', handler)
@@ -619,6 +637,11 @@ export function useMainApp(gw: GatewayClient) {
 
     // entry.tsx's setupGracefulExit handles process cleanup on real exit.
     return () => {
+      if (gatewayRestartTimerRef.current) {
+        clearTimeout(gatewayRestartTimerRef.current)
+        gatewayRestartTimerRef.current = null
+      }
+
       gw.off('event', handler)
       gw.off('exit', exitHandler)
     }


### PR DESCRIPTION
## Summary
- Restart the TUI gateway transport automatically after an internal gateway exit instead of leaving the UI stuck at "gateway exited".
- Clear/suppress restart timers on gateway.ready and unmount.
- Fix TUI type-check annotations for execFileNoThrow and make websocket attach tests ignore ambient sidecar env vars.

## Test Plan
- npm run type-check --prefix ui-tui
- npm run build --prefix ui-tui
- npm test --prefix ui-tui
- npx eslint src/app/useMainApp.ts packages/hermes-ink/src/utils/execFileNoThrow.ts src/__tests__/gatewayClient.test.ts
- git diff --check -- ui-tui/src/app/useMainApp.ts ui-tui/packages/hermes-ink/src/utils/execFileNoThrow.ts ui-tui/src/__tests__/gatewayClient.test.ts