### PR TITLE
docs: clarify x_search platform enablement

### DIFF
--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -3077,6 +3077,9 @@ def _apply_toolset_change(config: dict, platform: str, toolset_names: List[str],
 def _platforms_missing_toolset(config: dict, toolset_name: str, exclude_platform: str) -> List[str]:
     """Return explicitly configured platforms that do not include a toolset.
 
+    Keep this helper toolset-agnostic so future CLI-vs-gateway visibility
+    gaps can reuse the same check; ``x_search`` is only the first caller.
+
     Non-interactive ``hermes tools enable`` defaults to the CLI platform.  Users
     often run it after seeing a tool in the CLI list, then expect Matrix or
     another gateway to see the same tool.  Only warn for platforms that already

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -3074,6 +3074,27 @@ def _apply_toolset_change(config: dict, platform: str, toolset_names: List[str],
     _save_platform_tools(config, platform, updated)
 
 
+def _platforms_missing_toolset(config: dict, toolset_name: str, exclude_platform: str) -> List[str]:
+    """Return explicitly configured platforms that do not include a toolset.
+
+    Non-interactive ``hermes tools enable`` defaults to the CLI platform.  Users
+    often run it after seeing a tool in the CLI list, then expect Matrix or
+    another gateway to see the same tool.  Only warn for platforms that already
+    have explicit platform_toolsets lists; default/unconfigured platforms can
+    still receive credential-gated auto-enable behavior.
+    """
+    platform_toolsets = config.get("platform_toolsets") or {}
+    missing: List[str] = []
+    for pkey, configured_toolsets in platform_toolsets.items():
+        if pkey == exclude_platform or pkey not in PLATFORMS:
+            continue
+        if not isinstance(configured_toolsets, list):
+            continue
+        if toolset_name not in {str(ts) for ts in configured_toolsets}:
+            missing.append(pkey)
+    return sorted(missing)
+
+
 def _apply_mcp_change(config: dict, targets: List[str], action: str) -> Set[str]:
     """Add or remove specific MCP tools from a server's exclude list.
 
@@ -3202,4 +3223,12 @@ def tools_disable_enable_command(args):
     ]
     if successful:
         verb = "Disabled" if action == "disable" else "Enabled"
-        _print_success(f"{verb}: {', '.join(successful)}")
+        _print_success(f"{verb} for {platform}: {', '.join(successful)}")
+        if action == "enable" and platform == "cli" and "x_search" in successful:
+            missing_platforms = _platforms_missing_toolset(config, "x_search", platform)
+            if missing_platforms:
+                _print_info(
+                    "x_search was enabled for CLI only. To expose it in a "
+                    "gateway, also run e.g. `hermes tools enable --platform "
+                    "matrix x_search`."
+                )

--- a/tests/hermes_cli/test_tools_disable_enable.py
+++ b/tests/hermes_cli/test_tools_disable_enable.py
@@ -59,6 +59,22 @@ class TestToolsEnableBuiltin:
         saved = mock_save.call_args[0][0]
         assert saved["platform_toolsets"]["cli"].count("web") == 1
 
+    def test_enable_x_search_cli_warns_when_matrix_explicitly_missing_it(self, capsys):
+        config = {
+            "platform_toolsets": {
+                "cli": ["web"],
+                "matrix": ["web", "memory"],
+            }
+        }
+        with patch("hermes_cli.tools_config.load_config", return_value=config), \
+             patch("hermes_cli.tools_config.save_config"):
+            tools_disable_enable_command(
+                Namespace(tools_action="enable", names=["x_search"], platform="cli")
+            )
+        out = capsys.readouterr().out
+        assert "Enabled for cli: x_search" in out
+        assert "hermes tools enable --platform matrix x_search" in out
+
 
 # ── MCP tool disable ────────────────────────────────────────────────────────
 

--- a/website/docs/user-guide/features/x-search.md
+++ b/website/docs/user-guide/features/x-search.md
@@ -33,6 +33,15 @@ hermes tools
 # → 🐦 X (Twitter) Search   (press space to toggle on)
 ```
 
+Non-interactive `hermes tools enable x_search` applies to the CLI platform by
+default. If you use a messaging gateway with explicit `platform_toolsets`
+configured, enable it for that platform too:
+
+```bash
+hermes tools enable --platform matrix x_search
+systemctl --user restart hermes-gateway.service
+```
+
 The picker offers two credential choices:
 
 1. **xAI Grok OAuth (SuperGrok Subscription)** — opens the browser to `accounts.x.ai` if you're not already logged in


### PR DESCRIPTION
## What does this PR do?

  Clarifies that `hermes tools enable x_search` applies to the CLI platform by default, and adds a targeted
  CLI hint when `x_search` is enabled for CLI while explicitly configured gateway platforms such as Matrix
  do not include it.

  This solves a confusing setup failure where `x_search` appears enabled in CLI, but a Matrix gateway still
  cannot see the native `x_search` tool because `platform_toolsets.matrix` has its own explicit toolset
  list. The fix keeps the existing platform-specific behavior intact and points users to the correct
  command instead of silently implying all platforms were updated.

  ## Type of Change

  - [x] 🐛 Bug fix (non-breaking change that fixes an issue)
  - [ ] ✨ New feature (non-breaking change that adds functionality)
  - [ ] 🔒 Security fix
  - [x] 📝 Documentation update
  - [x] ✅ Tests (adding or improving test coverage)
  - [ ] ♻️ Refactor (no behavior change)
  - [ ] 🎯 New skill (bundled or hub)

  ## Changes Made

  - `hermes_cli/tools_config.py`
    - Include the target platform in non-interactive enable/disable success output.
    - Add a targeted `x_search` hint when CLI is enabled but explicitly configured gateway platforms are
  missing `x_search`.
  - `website/docs/user-guide/features/x-search.md`
    - Document that `hermes tools enable x_search` defaults to CLI.
    - Add the Matrix gateway command: `hermes tools enable --platform matrix x_search`.
  - `tests/hermes_cli/test_tools_disable_enable.py`
    - Add regression coverage for the CLI `x_search` hint when Matrix is explicitly configured without it.

  ## How to Test

  1. Configure explicit platform toolsets where CLI includes or enables `x_search`, but Matrix does not.
  2. Run `hermes tools enable x_search`.
  3. Confirm the output says it enabled `x_search` for CLI and prints the Matrix follow-up hint.

  Test run:

  ```bash
  python -m pytest tests/hermes_cli/test_tools_disable_enable.py tests/hermes_cli/test_tools_config.py -q

  Result:

  89 passed in 1.64s

  ## Checklist

  ### Code

  - [x] I've read the Contributing Guide
    (https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
  - [x] My commit messages follow Conventional Commits (https://www.conventionalcommits.org/) (fix(scope):,
    feat(scope):, etc.)
  - [x] I searched for existing PRs (https://github.com/NousResearch/hermes-agent/pulls) to make sure this
    isn't a duplicate
  - [x] My PR contains only changes related to this fix/feature (no unrelated commits)
  - [ ] I've run pytest tests/ -q and all tests pass
  - [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
  - [x] I've tested on my platform: Fedora Linux

  ### Documentation & Housekeeping

  - [x] I've updated relevant documentation (README, docs/, docstrings) — or N/A
  - [x] I've updated cli-config.yaml.example if I added/changed config keys — or N/A
  - [x] I've updated CONTRIBUTING.md or AGENTS.md if I changed architecture or workflows — or N/A
  - [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide
    (https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) —
    or N/A
  - [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A