### PR TITLE
feat: add LLM Wiki memory provider

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -137,6 +137,7 @@ def init_agent(
     checkpoint_max_total_size_mb: int = 500,
     checkpoint_max_file_size_mb: int = 10,
     pass_session_id: bool = False,
+    agent_context: str | None = None,
 ):
     """
     Initialize the AI Agent.
@@ -199,6 +200,7 @@ def init_agent(
     agent.quiet_mode = quiet_mode
     agent.ephemeral_system_prompt = ephemeral_system_prompt
     agent.platform = platform  # "cli", "telegram", "discord", "whatsapp", etc.
+    agent.agent_context = (agent_context or os.environ.get("HERMES_AGENT_CONTEXT") or "primary").strip() or "primary"
     agent._user_id = user_id  # Platform user identifier (gateway sessions)
     agent._user_name = user_name
     agent._chat_id = chat_id
@@ -988,7 +990,7 @@ def init_agent(
                         "session_id": agent.session_id,
                         "platform": platform or "cli",
                         "hermes_home": str(get_hermes_home()),
-                        "agent_context": "primary",
+                        "agent_context": getattr(agent, "agent_context", None) or "primary",
                     }
                     # Thread session title for memory provider scoping
                     # (e.g. honcho uses this to derive chat-scoped session keys)

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -665,9 +665,10 @@ class _CodexCompletionsAdapter:
         # by auxiliary calls such as context compression; if the timeout is not
         # forwarded and enforced, a Codex Responses stream can sit behind a
         # dead-looking CLI until the user force-interrupts the whole session.
-        timeout = kwargs.get("timeout")
-        if timeout is not None:
-            resp_kwargs["timeout"] = timeout
+        timeout = _normalize_aux_timeout(kwargs.get("timeout"), None)
+        # Forward None intentionally: httpx/OpenAI treat it as no timeout.
+        # Do not forward raw 0 — that means an already-expired deadline.
+        resp_kwargs["timeout"] = timeout
 
         # Note: the Codex endpoint (chatgpt.com/backend-api/codex) does NOT
         # support max_output_tokens or temperature — omit to avoid 400 errors.
@@ -747,7 +748,8 @@ class _CodexCompletionsAdapter:
         timeout_timer: Optional[threading.Timer] = None
 
         def _timeout_message() -> str:
-            return f"Codex auxiliary Responses stream exceeded {float(total_timeout):.1f}s total timeout"
+            seconds = float(total_timeout) if total_timeout is not None else 0.0
+            return f"Codex auxiliary Responses stream exceeded {seconds:.1f}s total timeout"
 
         def _close_client_on_timeout() -> None:
             timed_out.set()
@@ -2550,7 +2552,7 @@ def _retry_same_provider_sync(
     temperature: Optional[float],
     max_tokens: Optional[int],
     tools: Optional[list],
-    effective_timeout: float,
+    effective_timeout: Optional[float],
     effective_extra_body: dict,
 ) -> Any:
     if task == "vision":
@@ -2607,7 +2609,7 @@ async def _retry_same_provider_async(
     temperature: Optional[float],
     max_tokens: Optional[int],
     tools: Optional[list],
-    effective_timeout: float,
+    effective_timeout: Optional[float],
     effective_extra_body: dict,
 ) -> Any:
     if task == "vision":
@@ -4354,18 +4356,35 @@ def _get_auxiliary_task_config(task: str) -> Dict[str, Any]:
     return task_config if isinstance(task_config, dict) else {}
 
 
-def _get_task_timeout(task: str, default: float = _DEFAULT_AUX_TIMEOUT) -> float:
-    """Read timeout from auxiliary.{task}.timeout in config, falling back to *default*."""
+def _normalize_aux_timeout(raw: Any, default: Optional[float] = _DEFAULT_AUX_TIMEOUT) -> Optional[float]:
+    """Normalize auxiliary timeout values.
+
+    ``timeout: 0`` (or any negative value) means no request timeout.  This is
+    intentionally different from passing ``0`` through to HTTP clients: httpx /
+    the OpenAI SDK interpret a zero timeout as "deadline is already expired",
+    which fails immediately with a connection/timeout error and poisons context
+    compression.  Invalid values fall back to *default*.
+    """
+    if raw is None:
+        return default
+    try:
+        value = float(raw)
+    except (ValueError, TypeError):
+        return default
+    if value <= 0:
+        return None
+    return value
+
+
+def _get_task_timeout(task: str, default: Optional[float] = _DEFAULT_AUX_TIMEOUT) -> Optional[float]:
+    """Read timeout from auxiliary.{task}.timeout in config.
+
+    A configured value of ``0`` disables the timeout for that auxiliary task.
+    """
     if not task:
         return default
     task_config = _get_auxiliary_task_config(task)
-    raw = task_config.get("timeout")
-    if raw is not None:
-        try:
-            return float(raw)
-        except (ValueError, TypeError):
-            pass
-    return default
+    return _normalize_aux_timeout(task_config.get("timeout"), default)
 
 
 def _get_task_extra_body(task: str) -> Dict[str, Any]:
@@ -4453,7 +4472,7 @@ def _build_call_kwargs(
     temperature: Optional[float] = None,
     max_tokens: Optional[int] = None,
     tools: Optional[list] = None,
-    timeout: float = 30.0,
+    timeout: Optional[float] = 30.0,
     extra_body: Optional[dict] = None,
     base_url: Optional[str] = None,
 ) -> dict:
@@ -4668,7 +4687,7 @@ def call_llm(
                 f"No LLM provider configured for task={task} provider={resolved_provider}. "
                 f"Run: hermes setup")
 
-    effective_timeout = timeout if timeout is not None else _get_task_timeout(task)
+    effective_timeout = _normalize_aux_timeout(timeout, _get_task_timeout(task))
 
     # Log what we're about to do — makes auxiliary operations visible
     _base_info = str(getattr(client, "base_url", resolved_base_url) or "")
@@ -5062,7 +5081,7 @@ async def async_call_llm(
                 f"No LLM provider configured for task={task} provider={resolved_provider}. "
                 f"Run: hermes setup")
 
-    effective_timeout = timeout if timeout is not None else _get_task_timeout(task)
+    effective_timeout = _normalize_aux_timeout(timeout, _get_task_timeout(task))
 
     # Pass the client's actual base_url (not just resolved_base_url) so
     # endpoint-specific temperature overrides can distinguish

--- a/agent/memory_manager.py
+++ b/agent/memory_manager.py
@@ -51,8 +51,45 @@ _INTERNAL_NOTE_RE = re.compile(
 )
 
 
-def sanitize_context(text: str) -> str:
+def _stringify_context_value(value: Any) -> str:
+    """Convert provider-bound message content to text before regex scrubbing.
+
+    Gateway/model messages are usually plain strings, but multimodal or
+    provider-native turns can carry OpenAI-style content-part lists.  Memory
+    providers need a best-effort textual representation, not a TypeError from
+    ``re.sub``.
+    """
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value
+    if isinstance(value, list):
+        parts: list[str] = []
+        for item in value:
+            if isinstance(item, str):
+                parts.append(item)
+            elif isinstance(item, dict):
+                text = item.get("text")
+                if isinstance(text, str):
+                    parts.append(text)
+                elif item.get("type"):
+                    parts.append(f"[{item.get('type')} content omitted]")
+            else:
+                parts.append(str(item))
+        return "\n".join(part for part in parts if part)
+    if isinstance(value, dict):
+        text = value.get("text")
+        if isinstance(text, str):
+            return text
+        if value.get("type"):
+            return f"[{value.get('type')} content omitted]"
+        return ""
+    return str(value)
+
+
+def sanitize_context(text: Any) -> str:
     """Strip fence tags, injected context blocks, and system notes from provider output."""
+    text = _stringify_context_value(text)
     text = _INTERNAL_CONTEXT_RE.sub('', text)
     text = _INTERNAL_NOTE_RE.sub('', text)
     text = _FENCE_TAG_RE.sub('', text)

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1547,6 +1547,7 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
             load_soul_identity=True,
             skip_memory=True,  # Cron system prompts would corrupt user representations
             platform="cron",
+            agent_context="cron",
             session_id=_cron_session_id,
             session_db=_session_db,
         )

--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -3868,6 +3868,77 @@ class DiscordAdapter(BasePlatformAdapter):
     # Auto-thread helpers
     # ------------------------------------------------------------------
 
+    def _shared_thread_user_ids(self) -> List[str]:
+        """Return user IDs that should be pulled into every auto-created thread.
+
+        ``DISCORD_SHARED_THREAD_USERS`` is a pragmatic family/team-server knob:
+        when Hermes auto-threads a channel mention, try to add these users to the
+        thread and, if Discord permissions block that, post a tiny parent-channel
+        pointer that mentions them so they can jump in manually.
+        """
+        raw = os.getenv("DISCORD_SHARED_THREAD_USERS", "")
+        seen: set[str] = set()
+        ids: list[str] = []
+        for part in raw.split(","):
+            cleaned = _clean_discord_id(part)
+            if cleaned and cleaned not in seen:
+                seen.add(cleaned)
+                ids.append(cleaned)
+        return ids
+
+    async def _include_shared_thread_users(self, thread: Any, message: Any) -> None:
+        """Best-effort include configured shared users in an auto-created thread."""
+        user_ids = self._shared_thread_user_ids()
+        if not user_ids or not thread:
+            return
+
+        guild = getattr(message, "guild", None)
+        added_any = False
+        failed_user_ids: list[str] = []
+        for user_id in user_ids:
+            try:
+                member = None
+                if guild is not None:
+                    member = guild.get_member(int(user_id))
+                    if member is None:
+                        member = await guild.fetch_member(int(user_id))
+                if member is not None and hasattr(thread, "add_user"):
+                    await thread.add_user(member)
+                    added_any = True
+                else:
+                    failed_user_ids.append(user_id)
+            except Exception as exc:
+                failed_user_ids.append(user_id)
+                logger.debug(
+                    "[%s] Could not directly add shared user %s to Discord thread %s: %s",
+                    self.name,
+                    user_id,
+                    getattr(thread, "id", "unknown"),
+                    exc,
+                )
+
+        # Fallback: a parent-channel pointer is intentionally low-tech but more
+        # reliable than pretending a thread ping worked when Discord denied the
+        # add-member route. Keep it compact to avoid cluttering shared channels.
+        if failed_user_ids and hasattr(message.channel, "send"):
+            mentions = " ".join(f"<@{user_id}>" for user_id in failed_user_ids)
+            thread_ref = getattr(thread, "mention", None) or getattr(thread, "jump_url", None) or f"thread {getattr(thread, 'id', '')}"
+            try:
+                await message.channel.send(f"↳ {mentions} {thread_ref}")
+            except Exception as exc:
+                logger.debug(
+                    "[%s] Could not post shared-thread fallback pointer for thread %s: %s",
+                    self.name,
+                    getattr(thread, "id", "unknown"),
+                    exc,
+                )
+        elif added_any:
+            logger.debug(
+                "[%s] Added shared users to Discord thread %s",
+                self.name,
+                getattr(thread, "id", "unknown"),
+            )
+
     async def _auto_create_thread(self, message: 'DiscordMessage') -> Optional[Any]:
         """Create a thread from a user message for auto-threading.
 
@@ -3888,6 +3959,7 @@ class DiscordAdapter(BasePlatformAdapter):
 
         try:
             thread = await message.create_thread(name=thread_name, auto_archive_duration=1440)
+            await self._include_shared_thread_users(thread, message)
             return thread
         except Exception as direct_error:
             display_name = getattr(getattr(message, "author", None), "display_name", None) or "unknown user"
@@ -3899,6 +3971,7 @@ class DiscordAdapter(BasePlatformAdapter):
                     auto_archive_duration=1440,
                     reason=reason,
                 )
+                await self._include_shared_thread_users(thread, message)
                 return thread
             except Exception as fallback_error:
                 logger.warning(

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -912,7 +912,7 @@ DEFAULT_CONFIG = {
             "model": "",
             "base_url": "",
             "api_key": "",
-            "timeout": 120,        # seconds — compression summarises large contexts; increase for local models
+            "timeout": 120,        # seconds — compression summarises large contexts; set 0 to disable
             "extra_body": {},
         },
         # Note: session_search no longer uses an auxiliary LLM (PR #27590 —

--- a/hermes_wiki/__init__.py
+++ b/hermes_wiki/__init__.py
@@ -1,0 +1,25 @@
+from hermes_wiki.config import WikiConfig
+from hermes_wiki.models import WikiPage, Source, LogEntry, LintIssue
+
+def __getattr__(name):
+    if name == "WikiEngine":
+        from hermes_wiki.engine import WikiEngine
+        return WikiEngine
+    if name == "WikiSearch":
+        from hermes_wiki.search import WikiSearch
+        return WikiSearch
+    if name == "WikiLLM":
+        from hermes_wiki.llm import WikiLLM
+        return WikiLLM
+    raise AttributeError(f"module 'hermes_wiki' has no attribute {name!r}")
+
+__all__ = [
+    "WikiEngine",
+    "WikiSearch",
+    "WikiLLM",
+    "WikiConfig",
+    "WikiPage",
+    "Source",
+    "LogEntry",
+    "LintIssue",
+]

--- a/hermes_wiki/caretaker.py
+++ b/hermes_wiki/caretaker.py
@@ -1,0 +1,249 @@
+"""Agent-native caretaker loop for LLM Wiki.
+
+The caretaker coordinates read-only memory health signals for Hermes: wiki
+maintenance issues, retrieval regressions, and pending memory proposals. It is
+not a human UI and does not mutate canonical memory by default.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from hermes_wiki.config import WikiConfig
+from hermes_wiki.eval import Searcher, _build_searcher, evaluate_retrieval, load_retrieval_cases, result_to_dict
+from hermes_wiki.frontmatter import write_page
+from hermes_wiki.maintenance import (
+    MaintenanceReport,
+    _load_explicit_wiki_config,
+    _validate_report_path,
+    generate_maintenance_report,
+    maintenance_report_to_dict,
+)
+
+
+@dataclass(frozen=True)
+class CaretakerAction:
+    """A next memory operation Hermes can reason about or perform later."""
+
+    kind: str
+    severity: str
+    message: str
+    autonomous: bool
+    file_path: str | None = None
+
+
+@dataclass(frozen=True)
+class CaretakerReport:
+    """Aggregated agent-native wiki health report."""
+
+    maintenance: MaintenanceReport
+    retrieval_eval: Any | None = None
+    actions: list[CaretakerAction] = field(default_factory=list)
+
+    @property
+    def has_blockers(self) -> bool:
+        if self.maintenance.error_count > 0:
+            return True
+        if self.retrieval_eval is not None and not self.retrieval_eval.passed:
+            return True
+        return any(action.severity == "error" for action in self.actions)
+
+
+def _classify_maintenance_actions(report: MaintenanceReport) -> list[CaretakerAction]:
+    actions: list[CaretakerAction] = []
+    for issue in report.issues:
+        severity = issue.severity.value
+        if issue.category == "pending_proposal":
+            actions.append(
+                CaretakerAction(
+                    kind="review_pending_proposal",
+                    severity="info",
+                    message=issue.message,
+                    autonomous=True,
+                    file_path=issue.file_path,
+                )
+            )
+        elif issue.category == "broken_link":
+            actions.append(
+                CaretakerAction(
+                    kind="repair_broken_link",
+                    severity=severity,
+                    message=issue.message,
+                    autonomous=True,
+                    file_path=issue.file_path,
+                )
+            )
+        elif issue.category == "orphan_page":
+            actions.append(
+                CaretakerAction(
+                    kind="strengthen_wiki_graph",
+                    severity=severity,
+                    message=issue.message,
+                    autonomous=True,
+                    file_path=issue.file_path,
+                )
+            )
+        elif issue.category == "missing_source_coverage":
+            actions.append(
+                CaretakerAction(
+                    kind="find_source_evidence",
+                    severity=severity,
+                    message=issue.message,
+                    autonomous=False,
+                    file_path=issue.file_path,
+                )
+            )
+        else:
+            actions.append(
+                CaretakerAction(
+                    kind=f"inspect_{issue.category}",
+                    severity=severity,
+                    message=issue.message,
+                    autonomous=False,
+                    file_path=issue.file_path,
+                )
+            )
+    return actions
+
+
+def _classify_retrieval_actions(retrieval_eval: Any | None) -> list[CaretakerAction]:
+    if retrieval_eval is None or retrieval_eval.passed:
+        return []
+    actions: list[CaretakerAction] = []
+    for failure in retrieval_eval.failures:
+        missing = ", ".join(sorted(failure.missing_pages))
+        actions.append(
+            CaretakerAction(
+                kind="fix_retrieval_regression",
+                severity="error",
+                message=f"Retrieval eval failed for query {failure.query!r}; missing pages: {missing}",
+                autonomous=True,
+            )
+        )
+    return actions
+
+
+def _default_eval_cases_path(config: WikiConfig) -> Path:
+    return config.wiki_path / "evals" / "retrieval.yaml"
+
+
+def run_caretaker(
+    config: WikiConfig,
+    *,
+    eval_cases_path: str | Path | None = None,
+    searcher: Searcher | None = None,
+) -> CaretakerReport:
+    """Run a read-first caretaker pass for Hermes-owned wiki memory.
+
+    This scans local wiki markdown and, when retrieval cases are present,
+    runs deterministic retrieval evals. It does not ingest, reindex, call chat
+    models, mutate canonical pages, append logs, or create directories.
+    """
+
+    maintenance = generate_maintenance_report(config)
+    retrieval_eval = None
+
+    cases_path = Path(eval_cases_path) if eval_cases_path is not None else _default_eval_cases_path(config)
+    if cases_path.exists():
+        active_searcher = searcher if searcher is not None else _build_searcher(None)
+        retrieval_eval = evaluate_retrieval(active_searcher, load_retrieval_cases(cases_path))
+
+    actions = _classify_maintenance_actions(maintenance)
+    actions.extend(_classify_retrieval_actions(retrieval_eval))
+    return CaretakerReport(maintenance=maintenance, retrieval_eval=retrieval_eval, actions=actions)
+
+
+def caretaker_report_to_dict(report: CaretakerReport) -> dict[str, Any]:
+    return {
+        "has_blockers": report.has_blockers,
+        "maintenance": maintenance_report_to_dict(report.maintenance),
+        "retrieval_eval": result_to_dict(report.retrieval_eval) if report.retrieval_eval is not None else None,
+        "actions": [
+            {
+                "kind": action.kind,
+                "severity": action.severity,
+                "message": action.message,
+                "autonomous": action.autonomous,
+                "file_path": action.file_path,
+            }
+            for action in report.actions
+        ],
+    }
+
+
+def render_caretaker_report(report: CaretakerReport) -> str:
+    payload = caretaker_report_to_dict(report)
+    maintenance = payload["maintenance"]
+    retrieval = payload["retrieval_eval"]
+    lines = [
+        "# LLM Wiki Caretaker Report",
+        "",
+        "This is an agent-native memory health report for Hermes-owned durable memory.",
+        "",
+        "## Summary",
+        f"- Blockers: {'yes' if report.has_blockers else 'no'}",
+        f"- Pages: {maintenance['total_pages']}",
+        f"- Sources: {maintenance['total_sources']}",
+        f"- Maintenance issues: {len(maintenance['issues'])} ({maintenance['errors']} errors, {maintenance['warnings']} warnings, {maintenance['infos']} info)",
+        f"- Retrieval eval: {('not run' if retrieval is None else ('passed' if retrieval['passed'] else 'failed'))}",
+        "",
+        "## Hermes actions",
+    ]
+    if not report.actions:
+        lines.append("- No memory actions needed.")
+    else:
+        for action in report.actions:
+            agent_mode = "autonomous" if action.autonomous else "needs evidence"
+            file_path = f" `{action.file_path}`" if action.file_path else ""
+            lines.append(f"- **{action.severity} / {action.kind} / {agent_mode}**{file_path}: {action.message}")
+    return "\n".join(lines) + "\n"
+
+
+def _build_config(config_path: str | None) -> WikiConfig:
+    return _load_explicit_wiki_config(config_path) if config_path else WikiConfig.from_hermes_config()
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Run an agent-native LLM Wiki caretaker pass")
+    parser.add_argument("--config", help="Hermes config.yaml path to load wiki settings from")
+    parser.add_argument("--evals", help="Optional retrieval eval YAML/JSON path; defaults to <wiki>/evals/retrieval.yaml when present")
+    parser.add_argument("--json", action="store_true", help="Emit JSON instead of markdown")
+    parser.add_argument("--quiet", action="store_true", help="Print only when blockers exist")
+    parser.add_argument("--write-report", help="Explicit relative markdown path under reports/ for a caretaker report")
+    args = parser.parse_args(argv)
+
+    try:
+        config = _build_config(args.config)
+        searcher = None
+        eval_path = Path(args.evals) if args.evals else _default_eval_cases_path(config)
+        if eval_path.exists():
+            searcher = _build_searcher(args.config)
+        report = run_caretaker(config, eval_cases_path=eval_path, searcher=searcher)
+        if args.write_report:
+            if not args.config:
+                raise ValueError("--write-report requires explicit --config to avoid writing to the wrong wiki")
+            path = _validate_report_path(config, args.write_report)
+            write_page(path, {"title": "LLM Wiki Caretaker Report", "type": "caretaker_report", "status": "generated"}, render_caretaker_report(report))
+            print(json.dumps({"written": True, "path": str(path)}, sort_keys=True))
+            return 1 if report.has_blockers else 0
+        if args.quiet and not report.has_blockers:
+            return 0
+        output = caretaker_report_to_dict(report) if args.json else render_caretaker_report(report)
+        if args.json:
+            print(json.dumps(output, sort_keys=True))
+        else:
+            print(output, end="")
+        return 1 if report.has_blockers else 0
+    except (FileNotFoundError, ValueError, json.JSONDecodeError, yaml.YAMLError, OSError) as exc:
+        parser.error(str(exc))
+    return 2
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/hermes_wiki/caretaker_orchestrator.py
+++ b/hermes_wiki/caretaker_orchestrator.py
@@ -1,0 +1,149 @@
+"""Convert LLM Wiki caretaker findings into queued proposal drafts.
+
+The orchestrator is intentionally proposal-mediated: it translates caretaker
+actions into review artifacts and only writes under <wiki>/proposals when
+explicitly queued with an explicit config.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from hermes_wiki.caretaker import CaretakerAction, run_caretaker
+from hermes_wiki.config import WikiConfig
+from hermes_wiki.eval import _build_searcher
+from hermes_wiki.proposal_lifecycle import proposal_record_to_dict, read_proposal
+from hermes_wiki.proposals import MemoryProposal, _load_explicit_wiki_config, proposal_to_dict, queue_proposal, render_proposal_markdown
+
+
+@dataclass(frozen=True)
+class CaretakerProposalRun:
+    proposals: list[MemoryProposal] = field(default_factory=list)
+    queued_paths: list[Path] = field(default_factory=list)
+
+
+def caretaker_action_to_proposal(action: CaretakerAction | Any) -> MemoryProposal | None:
+    """Map a caretaker action to a safe memory proposal draft."""
+
+    kind = str(getattr(action, "kind", "") or "")
+    message = str(getattr(action, "message", "") or "")
+    file_path = getattr(action, "file_path", None)
+    target_pages = [str(file_path)] if file_path and str(file_path).startswith(("concepts/", "entities/", "comparisons/", "queries/")) else []
+    source_refs = [str(file_path)] if file_path else ["caretaker report"]
+
+    if kind == "repair_broken_link":
+        return MemoryProposal(
+            title=f"Repair broken link in {file_path or 'wiki'}",
+            rationale="Caretaker found a broken wikilink that weakens Hermes memory navigation.",
+            proposed_changes=[message, "Create the missing page or replace/remove the broken wikilink with a source-backed target."],
+            source_refs=source_refs,
+            target_pages=target_pages,
+            tags=["llm-wiki", "caretaker", "broken-link"],
+        )
+    if kind == "strengthen_wiki_graph":
+        return MemoryProposal(
+            title=f"Strengthen wiki graph links for {file_path or 'orphan page'}",
+            rationale="Caretaker found an orphan page with no inbound links, reducing agent navigability.",
+            proposed_changes=[message, "Add source-backed wikilinks from related canonical pages to improve retrieval and graph traversal."],
+            source_refs=source_refs,
+            target_pages=target_pages,
+            tags=["llm-wiki", "caretaker", "wiki-graph"],
+        )
+    if kind == "find_source_evidence":
+        return MemoryProposal(
+            title=f"Add source evidence for {file_path or 'wiki page'}",
+            rationale="Caretaker found a canonical page without explicit source coverage.",
+            proposed_changes=[message, "Find or ingest source-backed evidence before treating this page as durable memory."],
+            source_refs=source_refs,
+            target_pages=target_pages,
+            tags=["llm-wiki", "caretaker", "source-coverage"],
+        )
+    if kind == "fix_retrieval_regression":
+        return MemoryProposal(
+            title="Fix LLM Wiki retrieval regression",
+            rationale="Caretaker found a retrieval eval failure that blocks reliable Hermes memory recall.",
+            proposed_changes=[message, "Inspect page titles, aliases, source coverage, and eval expectations; update source-backed wiki content or evals deliberately."],
+            source_refs=["caretaker retrieval eval"],
+            target_pages=[],
+            tags=["llm-wiki", "caretaker", "retrieval-eval"],
+        )
+    return None
+
+
+def run_caretaker_orchestrator(
+    config: WikiConfig,
+    *,
+    queue: bool = False,
+    eval_cases_path: str | Path | None = None,
+) -> CaretakerProposalRun:
+    searcher = None
+    if eval_cases_path is not None and Path(eval_cases_path).exists():
+        searcher = _build_searcher(None)
+    report = run_caretaker(config, eval_cases_path=eval_cases_path, searcher=searcher)
+    proposals = [proposal for action in report.actions if (proposal := caretaker_action_to_proposal(action)) is not None]
+    queued_paths: list[Path] = []
+    if queue:
+        for proposal in proposals:
+            queued_paths.append(queue_proposal(config, proposal, write=True))
+    return CaretakerProposalRun(proposals=proposals, queued_paths=queued_paths)
+
+
+def _run_to_dict(result: CaretakerProposalRun, config: WikiConfig, *, include_markdown: bool = False) -> dict[str, Any]:
+    queued_records = []
+    for path in result.queued_paths:
+        queued_records.append(proposal_record_to_dict(read_proposal(config, path.stem)))
+    proposals = []
+    for proposal in result.proposals:
+        payload = proposal_to_dict(proposal)
+        if include_markdown:
+            payload["markdown"] = render_proposal_markdown(proposal)
+        proposals.append(payload)
+    return {
+        "queued": bool(result.queued_paths),
+        "queued_paths": [str(path) for path in result.queued_paths],
+        "queued_records": queued_records,
+        "proposals": proposals,
+    }
+
+
+def _render_run(result: CaretakerProposalRun) -> str:
+    if not result.proposals:
+        return "No caretaker proposals needed.\n"
+    return "\n---\n\n".join(render_proposal_markdown(proposal).strip() for proposal in result.proposals) + "\n"
+
+
+def _build_config(config_path: str | None) -> WikiConfig:
+    return _load_explicit_wiki_config(config_path) if config_path else WikiConfig.from_hermes_config()
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Draft or queue proposals from LLM Wiki caretaker findings")
+    parser.add_argument("--config", help="Hermes config.yaml path to load wiki settings from")
+    parser.add_argument("--evals", help="Optional retrieval eval YAML/JSON path")
+    parser.add_argument("--queue", action="store_true", help="Queue generated proposals under <wiki>/proposals")
+    parser.add_argument("--json", action="store_true", help="Emit JSON")
+    args = parser.parse_args(argv)
+
+    try:
+        if args.queue and not args.config:
+            raise ValueError("--queue requires explicit --config to avoid writing to the wrong wiki")
+        config = _build_config(args.config)
+        result = run_caretaker_orchestrator(config, queue=args.queue, eval_cases_path=args.evals)
+        if args.json:
+            print(json.dumps(_run_to_dict(result, config, include_markdown=not args.queue), sort_keys=True))
+        else:
+            print(_render_run(result), end="")
+        return 0
+    except (FileNotFoundError, ValueError, yaml.YAMLError, OSError) as exc:
+        parser.error(str(exc))
+    return 2
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/hermes_wiki/config.py
+++ b/hermes_wiki/config.py
@@ -1,0 +1,174 @@
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+
+
+@dataclass
+class WikiConfig:
+    wiki_path: Path = field(default_factory=lambda: Path(
+        os.environ.get("WIKI_PATH", os.path.expanduser("~/.hermes-dev/wiki"))
+    ))
+    wiki_name: str = "personal"
+
+    embedding_url: str = field(default_factory=lambda: os.environ.get(
+        "EMBEDDING_BASE_URL", "http://localhost:22222"
+    ))
+    embedding_model: str = "Qwen3-Embedding-8B"
+    embedding_dim: int = 4096
+    embedding_cache_path: Path | None = None
+    embedding_cache_max_entries: int = 100000
+
+    qdrant_url: str = field(default_factory=lambda: os.environ.get(
+        "QDRANT_URL", "http://localhost:6333"
+    ))
+    collection_prefix: str = "hermes_wiki"
+
+    llm_base_url: str = field(default_factory=lambda: os.environ.get(
+        "WIKI_LLM_URL", "http://localhost:8011/v1"
+    ))
+    llm_model: str = "gpt-5.5"
+    llm_api_key: str = "not-needed"
+    llm_max_tokens: int = 4096
+    llm_temperature: float = 0.3
+
+    chunk_max_tokens: int = 500
+    chunk_overlap_tokens: int = 50
+
+    log_rotation_threshold: int = 500
+    page_split_threshold: int = 200
+
+    @property
+    def collection_name(self) -> str:
+        return f"{self.collection_prefix}_{self.wiki_name}"
+
+    @property
+    def raw_dir(self) -> Path:
+        return self.wiki_path / "raw"
+
+    @property
+    def entities_dir(self) -> Path:
+        return self.wiki_path / "entities"
+
+    @property
+    def concepts_dir(self) -> Path:
+        return self.wiki_path / "concepts"
+
+    @property
+    def comparisons_dir(self) -> Path:
+        return self.wiki_path / "comparisons"
+
+    @property
+    def queries_dir(self) -> Path:
+        return self.wiki_path / "queries"
+
+    @property
+    def archive_dir(self) -> Path:
+        return self.wiki_path / "_archive"
+
+    @property
+    def index_path(self) -> Path:
+        return self.wiki_path / "index.md"
+
+    @property
+    def log_path(self) -> Path:
+        return self.wiki_path / "log.md"
+
+    @property
+    def schema_path(self) -> Path:
+        return self.wiki_path / "SCHEMA.md"
+
+    def ensure_dirs(self) -> None:
+        for d in [
+            self.wiki_path,
+            self.raw_dir / "articles",
+            self.raw_dir / "papers",
+            self.raw_dir / "transcripts",
+            self.raw_dir / "assets",
+            self.entities_dir,
+            self.concepts_dir,
+            self.comparisons_dir,
+            self.queries_dir,
+            self.archive_dir,
+        ]:
+            d.mkdir(parents=True, exist_ok=True)
+
+    @classmethod
+    def from_dict(cls, d: dict) -> WikiConfig:
+        wiki_cfg = d.get("wiki", {})
+        if not isinstance(wiki_cfg, dict):
+            raise ValueError("wiki config section must be a mapping")
+
+        embedding = wiki_cfg.get("embedding", {})
+        if not isinstance(embedding, dict):
+            raise ValueError("wiki.embedding config section must be a mapping")
+        vector = wiki_cfg.get("vector_store", {})
+        if not isinstance(vector, dict):
+            raise ValueError("wiki.vector_store config section must be a mapping")
+        llm = wiki_cfg.get("llm", {})
+        if not isinstance(llm, dict):
+            raise ValueError("wiki.llm config section must be a mapping")
+
+        kwargs = {}
+        if "path" in wiki_cfg:
+            kwargs["wiki_path"] = Path(os.path.expanduser(wiki_cfg["path"]))
+        if "name" in wiki_cfg:
+            kwargs["wiki_name"] = wiki_cfg["name"]
+        if "url" in embedding:
+            kwargs["embedding_url"] = embedding["url"]
+        if "model" in embedding:
+            kwargs["embedding_model"] = embedding["model"]
+        if "dim" in embedding:
+            kwargs["embedding_dim"] = embedding["dim"]
+        if "cache_path" in embedding:
+            kwargs["embedding_cache_path"] = Path(os.path.expanduser(str(embedding["cache_path"])))
+        if "cache_max_entries" in embedding:
+            kwargs["embedding_cache_max_entries"] = int(embedding["cache_max_entries"])
+        if "url" in vector:
+            kwargs["qdrant_url"] = vector["url"]
+        if "collection_prefix" in vector:
+            kwargs["collection_prefix"] = vector["collection_prefix"]
+        if "url" in llm:
+            kwargs["llm_base_url"] = llm["url"]
+        if "model" in llm:
+            kwargs["llm_model"] = llm["model"]
+        if "api_key" in llm:
+            kwargs["llm_api_key"] = llm["api_key"]
+
+        return cls(**kwargs)
+
+    @classmethod
+    def from_hermes_config(cls, config_path: str | Path | None = None) -> WikiConfig:
+        """Load wiki config from a Hermes config.yaml file.
+
+        Tries in order:
+        1. Explicit config_path argument
+        2. HERMES_HOME env var + /config.yaml
+        3. ~/.hermes-dev/config.yaml (dev install)
+        4. ~/.hermes/config.yaml (production)
+        5. Falls back to defaults
+        """
+        import yaml
+
+        candidates = []
+        if config_path:
+            candidates.append(Path(config_path))
+
+        hermes_home = os.environ.get("HERMES_HOME")
+        if hermes_home:
+            candidates.append(Path(hermes_home) / "config.yaml")
+
+        candidates.append(Path.home() / ".hermes-dev" / "config.yaml")
+        candidates.append(Path.home() / ".hermes" / "config.yaml")
+
+        for path in candidates:
+            if path.exists():
+                try:
+                    data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+                    if "wiki" in data:
+                        return cls.from_dict(data)
+                except Exception:
+                    continue
+
+        return cls()

--- a/hermes_wiki/engine.py
+++ b/hermes_wiki/engine.py
@@ -1,0 +1,730 @@
+from __future__ import annotations
+
+import hashlib
+import logging
+import re
+from datetime import date
+from pathlib import Path
+
+from hermes_wiki.config import WikiConfig
+from hermes_wiki.frontmatter import (
+    extract_wikilinks,
+    read_page,
+    slugify,
+    write_page,
+)
+from hermes_wiki.indexer import WikiIndexer
+from hermes_wiki.llm import WikiLLM
+from hermes_wiki.models import (
+    IngestResult,
+    IssueSeverity,
+    LintIssue,
+    LintReport,
+    QueryResult,
+)
+from hermes_wiki.search import WikiSearch
+
+logger = logging.getLogger(__name__)
+
+
+class WikiEngine:
+    """Main orchestrator for the LLM Wiki memory system.
+
+    Implements phased ingest pipeline:
+      Phase 1: Save raw source, detect duplicates/drift
+      Phase 2: LLM extracts candidate entities/concepts/facts
+      Phase 3: Resolve candidates against existing wiki pages
+      Phase 4: LLM generates/updates pages (constrained to known links)
+      Phase 5: Post-write lint repair (auto-stub or downgrade dangling links)
+      Phase 6: Index, update navigation, log
+    """
+
+    ALLOWED_SOURCE_TYPES = frozenset({"articles", "papers", "transcripts"})
+
+    def __init__(self, config: WikiConfig | None = None, *, read_only: bool = False):
+        self.config = config or WikiConfig()
+        self.read_only = read_only
+        if not read_only:
+            self.config.ensure_dirs()
+        self.search = WikiSearch(self.config, ensure_collection=not read_only, read_only=read_only)
+        self.llm = WikiLLM(self.config)
+        self.indexer = WikiIndexer(self.config)
+
+    @staticmethod
+    def _safe_slug(value: str | None) -> str | None:
+        """Return a normalized single-path-component slug or None if unsafe."""
+        if not value:
+            return None
+        raw = str(value).strip()
+        if not raw or "/" in raw or "\\" in raw or raw in {".", ".."}:
+            return None
+        slug = slugify(raw)
+        if not slug or slug in {".", ".."} or "/" in slug or "\\" in slug:
+            return None
+        return slug
+
+    @staticmethod
+    def _safe_child_path(directory: Path, slug: str | None) -> Path | None:
+        safe_slug = WikiEngine._safe_slug(slug)
+        if not safe_slug:
+            return None
+        root = directory.resolve()
+        path = (root / f"{safe_slug}.md").resolve()
+        if path.parent != root:
+            return None
+        return path
+
+    def init_wiki(self, domain: str, tags: list[str] | None = None) -> str:
+        """Initialize a new wiki with schema, index, and log."""
+        self.config.ensure_dirs()
+
+        tag_section = "\n".join(f"- {t}" for t in (tags or ["general"]))
+        schema = f"""# Wiki Schema
+
+## Domain
+{domain}
+
+## Conventions
+- File names: lowercase, hyphens, no spaces (e.g., `transformer-architecture.md`)
+- Every wiki page starts with YAML frontmatter
+- Use `[[wikilinks]]` to link between pages — ONLY to pages that exist
+- When updating a page, always bump the `updated` date
+- Every new page must be added to `index.md`
+- Every action must be appended to `log.md`
+- Provenance markers: `^[raw/articles/source-file.md]` with exact source paths
+
+## Frontmatter
+```yaml
+---
+title: Page Title
+created: YYYY-MM-DD
+updated: YYYY-MM-DD
+type: entity | concept | comparison | query | summary
+tags: [from taxonomy below]
+sources: [raw/articles/source-name.md]
+confidence: high | medium | low
+contested: true
+contradictions: [other-page-slug]
+---
+```
+
+## Tag Taxonomy
+{tag_section}
+
+## Page Thresholds
+- Create a page when an entity/concept is central to a source (not passing mentions)
+- Add to existing page when a source mentions something already covered
+- Don't create for passing mentions of well-known concepts (e.g., "Markdown", "Python")
+- Split pages exceeding 200 lines
+"""
+        self.config.schema_path.write_text(schema, encoding="utf-8")
+        self.indexer.rebuild_index()
+
+        log_content = (
+            "# Wiki Log\n\n"
+            "> Chronological record of all wiki actions. Append-only.\n"
+            "> Format: `## [YYYY-MM-DD] action | subject`\n\n"
+            f"## [{date.today().isoformat()}] create | Wiki initialized\n"
+            f"- Domain: {domain}\n"
+        )
+        self.config.log_path.write_text(log_content, encoding="utf-8")
+        self.search.reindex_all()
+
+        return f"Wiki initialized at {self.config.wiki_path}\nDomain: {domain}\nReady for sources."
+
+    def orient(self) -> str:
+        """Session orientation: read schema, index, recent log. Call at start of every session."""
+        parts = []
+
+        if self.config.schema_path.exists():
+            schema = self.config.schema_path.read_text(encoding="utf-8")
+            parts.append(f"## Schema\n{schema[:2000]}")
+
+        index_text = self.indexer.read_index()
+        if index_text:
+            parts.append(f"## Index\n{index_text[:3000]}")
+
+        recent = self.indexer.recent_log_entries(20)
+        parts.append(f"## Recent Activity\n{recent}")
+
+        status = self.status()
+        parts.append(
+            f"## Stats\n"
+            f"Pages: {status['total_pages']} | Sources: {status['total_sources']} | "
+            f"Chunks: {status['indexed_chunks']}"
+        )
+
+        return "\n\n".join(parts)
+
+    # ── Phased Ingest Pipeline ───────────────────────────────────────
+
+    def ingest_text(self, text: str, name: str, source_url: str | None = None,
+                    source_type: str = "articles", dry_run: bool = False) -> IngestResult:
+        """Ingest a text source into the wiki using the phased pipeline."""
+        source_type = str(source_type or "articles").strip().lower()
+        if source_type not in self.ALLOWED_SOURCE_TYPES:
+            allowed = ", ".join(sorted(self.ALLOWED_SOURCE_TYPES))
+            raise ValueError(f"Unsupported source_type {source_type!r}; expected one of: {allowed}")
+
+        slug = slugify(name)
+        source_rel = f"raw/{source_type}/{slug}.md"
+        result = IngestResult(source_path=source_rel)
+
+        # ── Phase 1: Save raw source, detect duplicates/drift ────────
+        source_path = self.config.raw_dir / source_type / f"{slug}.md"
+        body_hash = hashlib.sha256(text.encode()).hexdigest()
+
+        if source_path.exists():
+            existing_fm, _ = read_page(source_path)
+            if existing_fm.get("sha256") == body_hash:
+                return IngestResult(
+                    source_path=source_rel,
+                    key_facts=[f"Source '{name}' already ingested with identical content — skipped"],
+                )
+
+        if not dry_run:
+            write_page(source_path, {
+                "source_url": source_url or "",
+                "ingested": date.today().isoformat(),
+                "sha256": body_hash,
+            }, text)
+
+        # ── Phase 2: LLM extracts candidates ────────────────────────
+        schema_text = ""
+        if self.config.schema_path.exists():
+            schema_text = self.config.schema_path.read_text(encoding="utf-8")
+
+        existing_entities = self.indexer.list_entity_slugs()
+        existing_concepts = self.indexer.list_concept_slugs()
+
+        analysis = self.llm.analyze_source(
+            source_text=text,
+            existing_entities=existing_entities,
+            existing_concepts=existing_concepts,
+            schema_text=schema_text,
+        )
+
+        # ── Phase 3: Resolve candidates against existing pages ───────
+        all_known = set(self.indexer.list_all_slugs())
+        pages_to_create: list[tuple[str, dict, str]] = []  # (slug, info, type)
+        pages_to_update: list[tuple[str, dict, str]] = []
+
+        for entity in analysis.get("entities", []):
+            entity_slug = self._safe_slug(entity.get("slug") or entity.get("name", ""))
+            if not entity_slug:
+                logger.warning("Skipping entity with unsafe or empty slug: %r", entity.get("slug"))
+                continue
+            entity_path = self._safe_child_path(self.config.entities_dir, entity_slug)
+            if entity_path is None:
+                logger.warning("Skipping entity with unsafe slug: %r", entity_slug)
+                continue
+            if entity_path.exists():
+                pages_to_update.append((entity_slug, entity, "entity"))
+            else:
+                pages_to_create.append((entity_slug, entity, "entity"))
+
+        for concept in analysis.get("concepts", []):
+            concept_slug = self._safe_slug(concept.get("slug") or concept.get("name", ""))
+            if not concept_slug:
+                logger.warning("Skipping concept with unsafe or empty slug: %r", concept.get("slug"))
+                continue
+            concept_path = self._safe_child_path(self.config.concepts_dir, concept_slug)
+            if concept_path is None:
+                logger.warning("Skipping concept with unsafe slug: %r", concept_slug)
+                continue
+            if concept_path.exists():
+                pages_to_update.append((concept_slug, concept, "concept"))
+            else:
+                pages_to_create.append((concept_slug, concept, "concept"))
+
+        planned_slugs = all_known | {s for s, _, _ in pages_to_create} | {s for s, _, _ in pages_to_update}
+
+        if dry_run:
+            result.pages_created = [s for s, _, _ in pages_to_create]
+            result.pages_updated = [s for s, _, _ in pages_to_update]
+            result.entities_found = [e.get("name", "") for e in analysis.get("entities", [])]
+            result.concepts_found = [c.get("name", "") for c in analysis.get("concepts", [])]
+            result.key_facts = analysis.get("key_facts", [])
+            return result
+
+        # ── Phase 4: Generate/update pages ───────────────────────────
+        source_summary = analysis.get("summary", text[:2000])
+        known_pages = sorted(planned_slugs)
+
+        for page_slug, info, page_type in pages_to_create + pages_to_update:
+            type_dir = self.config.entities_dir if page_type == "entity" else self.config.concepts_dir
+            page_path = self._safe_child_path(type_dir, page_slug)
+            if page_path is None:
+                logger.warning("Skipping page with unsafe slug: %r", page_slug)
+                continue
+
+            existing_content = None
+            existing_fm = {}
+            if page_path.exists():
+                existing_fm, existing_content = read_page(page_path)
+
+            related = self.search.search(info.get("name", ""), limit=3, exclude_sources=True)
+            related_context = "\n\n".join(
+                f"[[{r.page_path.split('/')[-1].replace('.md', '')}]]: {r.text[:300]}"
+                for r in related if page_slug not in r.page_path
+            )
+
+            if page_type == "entity":
+                body = self.llm.generate_entity_page(
+                    entity=info,
+                    source_summary=source_summary,
+                    source_path=source_rel,
+                    existing_page_content=existing_content,
+                    related_context=related_context,
+                    known_pages=known_pages,
+                )
+            else:
+                body = self.llm.generate_concept_page(
+                    concept=info,
+                    source_summary=source_summary,
+                    source_path=source_rel,
+                    existing_page_content=existing_content,
+                    related_context=related_context,
+                    known_pages=known_pages,
+                )
+
+            tags = analysis.get("tags", [])
+            fm = existing_fm.copy()
+            fm.update({
+                "title": info.get("name", page_slug),
+                "type": page_type,
+                "tags": tags,
+                "updated": date.today().isoformat(),
+                "sources": list(set(fm.get("sources", []) + [source_rel])),
+            })
+            if "created" not in fm:
+                fm["created"] = date.today().isoformat()
+
+            write_page(page_path, fm, body)
+
+            if existing_content:
+                result.pages_updated.append(page_slug)
+            else:
+                result.pages_created.append(page_slug)
+
+        result.entities_found = [e.get("name", "") for e in analysis.get("entities", [])]
+        result.concepts_found = [c.get("name", "") for c in analysis.get("concepts", [])]
+        result.key_facts = analysis.get("key_facts", [])
+
+        # ── Phase 5: Post-write lint repair ──────────────────────────
+        touched_pages = result.pages_created + result.pages_updated
+        self._repair_dangling_links(touched_pages, planned_slugs)
+
+        # ── Phase 6: Index, navigate, log ────────────────────────────
+        for page_slug in touched_pages:
+            for subdir in ["entities", "concepts"]:
+                p = self.config.wiki_path / subdir / f"{page_slug}.md"
+                if p.exists():
+                    n = self.search.index_page(p)
+                    result.chunks_indexed += n
+                    break
+
+        source_chunks = self.search.index_source(source_path)
+        result.chunks_indexed += source_chunks
+
+        for page_slug in result.pages_created:
+            for subdir, ptype in [("entities", "entity"), ("concepts", "concept")]:
+                p = self.config.wiki_path / subdir / f"{page_slug}.md"
+                if p.exists():
+                    fm, _ = read_page(p)
+                    self.indexer.add_to_index(page_slug, fm.get("title", page_slug), ptype, fm.get("tags", []))
+                    break
+
+        log_details = []
+        if result.pages_created:
+            log_details.append(f"Created: {', '.join(result.pages_created)}")
+        if result.pages_updated:
+            log_details.append(f"Updated: {', '.join(result.pages_updated)}")
+        log_details.append(f"Indexed {result.chunks_indexed} chunks")
+        self.indexer.append_log("ingest", analysis.get("title", name), log_details)
+
+        return result
+
+    def _repair_dangling_links(self, page_slugs: list[str], known_slugs: set[str]) -> int:
+        """Post-write repair: downgrade wikilinks to unknown pages to plain text.
+
+        Returns count of links repaired.
+        """
+        repaired = 0
+        for page_slug in page_slugs:
+            for subdir in ["entities", "concepts", "comparisons", "queries"]:
+                page_path = self.config.wiki_path / subdir / f"{page_slug}.md"
+                if not page_path.exists():
+                    continue
+
+                text = page_path.read_text(encoding="utf-8")
+                original = text
+
+                def replace_unknown(match):
+                    nonlocal repaired
+                    raw = match.group(1)
+                    target = raw.split("|")[0].strip()
+                    display = raw.split("|")[1].strip() if "|" in raw else target
+                    target_slug = slugify(target)
+                    if target_slug in known_slugs:
+                        return match.group(0)
+                    repaired += 1
+                    return display
+
+                text = re.sub(r"\[\[([^\]]+)\]\]", replace_unknown, text)
+
+                if text != original:
+                    page_path.write_text(text, encoding="utf-8")
+                break
+
+        if repaired:
+            logger.info("Repaired %d dangling wikilinks", repaired)
+        return repaired
+
+    def ingest_file(self, file_path: str | Path, dry_run: bool = False) -> IngestResult:
+        """Ingest a file from the filesystem."""
+        path = Path(file_path)
+        if not path.exists():
+            raise FileNotFoundError(f"Source file not found: {path}")
+
+        text = path.read_text(encoding="utf-8")
+        source_type = "articles"
+        if path.suffix.lower() == ".pdf":
+            source_type = "papers"
+        elif any(kw in path.stem.lower() for kw in ["transcript", "meeting", "interview"]):
+            source_type = "transcripts"
+
+        return self.ingest_text(text, path.stem, source_type=source_type, dry_run=dry_run)
+
+    def query(self, question: str, file_result: bool = False,
+              log_query: bool = True) -> QueryResult:
+        """Answer a question using the wiki's compiled knowledge.
+
+        Args:
+            file_result: If True, file worthy answers as wiki pages.
+                         Default False — caller must opt in.
+            log_query: If False, skip appending to log.md (for read-only use).
+        """
+        search_results = self.search.search(question, limit=8, exclude_sources=False)
+
+        if not search_results:
+            return QueryResult(
+                question=question,
+                answer="No relevant content found in the wiki. Try ingesting some sources first.",
+                confidence="low",
+            )
+
+        unique_pages = {}
+        for r in search_results:
+            page_file = r.page_path.split("/")[-1].replace(".md", "")
+            if page_file not in unique_pages:
+                unique_pages[page_file] = []
+            unique_pages[page_file].append(r.text)
+
+        wiki_context_parts = []
+        for page_slug, chunks in list(unique_pages.items())[:5]:
+            for subdir in ["entities", "concepts", "comparisons", "queries"]:
+                page_path = self.config.wiki_path / subdir / f"{page_slug}.md"
+                if page_path.exists():
+                    fm, body = read_page(page_path)
+                    wiki_context_parts.append(
+                        f"## [[{page_slug}]] ({fm.get('type', 'unknown')})\n{body[:2000]}"
+                    )
+                    break
+            else:
+                combined = "\n\n".join(chunks[:2])
+                wiki_context_parts.append(f"## {page_slug}\n{combined}")
+
+        wiki_context = "\n\n---\n\n".join(wiki_context_parts)
+        search_text = "\n\n".join(
+            f"[{r.title}] (score: {r.score:.3f}): {r.text[:300]}"
+            for r in search_results[:5]
+        )
+
+        known_pages = self.indexer.list_all_slugs()
+        response = self.llm.answer_query(question, wiki_context, search_text, known_pages)
+
+        result = QueryResult(
+            question=question,
+            answer=response.get("answer", response.get("raw_response", "No answer generated.")),
+            sources_consulted=response.get("sources_consulted", []),
+            confidence=response.get("confidence", "medium"),
+        )
+
+        if file_result and response.get("worth_filing") and response.get("file_slug"):
+            file_slug = self._safe_slug(response.get("file_slug"))
+            if not file_slug:
+                logger.warning("Skipping filed query with unsafe slug: %r", response.get("file_slug"))
+                return result
+            file_title = response.get("file_title", question[:80])
+            query_path = self._safe_child_path(self.config.queries_dir, file_slug)
+            if query_path is None:
+                logger.warning("Skipping filed query with unsafe slug: %r", file_slug)
+                return result
+
+            fm = {
+                "title": file_title,
+                "created": date.today().isoformat(),
+                "updated": date.today().isoformat(),
+                "type": "query",
+                "tags": [],
+                "sources": result.sources_consulted,
+            }
+            write_page(query_path, fm, result.answer)
+            self.search.index_page(query_path)
+            self.indexer.add_to_index(file_slug, file_title, "query")
+            result.filed_as = file_slug
+
+        if log_query:
+            self.indexer.append_log(
+                "query",
+                question[:80],
+                [f"Confidence: {result.confidence}"]
+                + ([f"Filed as: {result.filed_as}"] if result.filed_as else []),
+            )
+
+        return result
+
+    _GENERIC_PROVENANCE = re.compile(
+        r"\^\[raw/(?:articles|papers|transcripts)/"
+        r"(?:source(?:-(?:file|name))?|TODO|example)\.md\]"
+    )
+
+    def lint(self, write_log: bool = True) -> LintReport:
+        """Health-check the wiki.
+
+        Args:
+            write_log: If False, skip appending to log.md (for tests/CI).
+        """
+        report = LintReport()
+        all_pages = self.indexer.get_all_pages()
+        all_slugs = set()
+        slug_to_path: dict[str, Path] = {}
+        inbound_links: dict[str, set[str]] = {}
+
+        known_source_paths = set()
+        for source in self.indexer.list_sources():
+            known_source_paths.add(source["path"])
+        report.total_sources = len(known_source_paths)
+
+        for page_type, entries in all_pages.items():
+            for entry in entries:
+                slug = entry["slug"]
+                all_slugs.add(slug)
+                page_path = self.config.wiki_path / entry["path"]
+                slug_to_path[slug] = page_path
+                inbound_links.setdefault(slug, set())
+                report.total_pages += 1
+
+        # ── Wikilink analysis ────────────────────────────────────────
+        for slug, page_path in slug_to_path.items():
+            if not page_path.exists():
+                continue
+            _, body = read_page(page_path)
+            links = extract_wikilinks(body)
+            report.total_links += len(links)
+
+            for link in links:
+                link_slug = slugify(link)
+                if link_slug in all_slugs:
+                    inbound_links[link_slug].add(slug)
+                else:
+                    report.broken_links += 1
+                    report.issues.append(LintIssue(
+                        severity=IssueSeverity.ERROR,
+                        category="broken_link",
+                        message=f"Broken wikilink [[{link}]]",
+                        file_path=str(page_path.relative_to(self.config.wiki_path)),
+                        suggestion=f"Create page '{link}' or remove the link",
+                    ))
+
+        # ── Orphan detection ─────────────────────────────────────────
+        for slug, sources in inbound_links.items():
+            if not sources:
+                report.orphan_pages += 1
+                report.issues.append(LintIssue(
+                    severity=IssueSeverity.WARNING,
+                    category="orphan_page",
+                    message=f"Page [[{slug}]] has no inbound links",
+                    file_path=slug_to_path[slug].name if slug in slug_to_path else None,
+                    suggestion="Add [[wikilinks]] from related pages",
+                ))
+
+        # ── Index completeness ───────────────────────────────────────
+        index_content = self.indexer.read_index()
+        for slug in all_slugs:
+            if f"[[{slug}]]" not in index_content:
+                report.issues.append(LintIssue(
+                    severity=IssueSeverity.WARNING,
+                    category="missing_from_index",
+                    message=f"Page [[{slug}]] not listed in index.md",
+                    suggestion="Run index rebuild",
+                ))
+
+        # ── Per-page checks ──────────────────────────────────────────
+        for slug, page_path in slug_to_path.items():
+            if not page_path.exists():
+                continue
+            fm, body = read_page(page_path)
+            rel_path = str(page_path.relative_to(self.config.wiki_path))
+
+            # Required frontmatter fields
+            for field in ["title", "type", "created", "updated"]:
+                if field not in fm:
+                    report.issues.append(LintIssue(
+                        severity=IssueSeverity.WARNING,
+                        category="missing_frontmatter",
+                        message=f"Missing '{field}' in frontmatter",
+                        file_path=rel_path,
+                    ))
+
+            # Page size
+            line_count = len(body.split("\n"))
+            if line_count > self.config.page_split_threshold:
+                report.issues.append(LintIssue(
+                    severity=IssueSeverity.INFO,
+                    category="large_page",
+                    message=f"Page has {line_count} lines",
+                    file_path=rel_path,
+                    suggestion="Consider splitting into sub-pages",
+                ))
+
+            # Contested flag
+            if fm.get("contested"):
+                report.issues.append(LintIssue(
+                    severity=IssueSeverity.WARNING,
+                    category="contested",
+                    message="Page marked as contested",
+                    file_path=rel_path,
+                ))
+
+            # Generic/fake provenance markers
+            fake_prov = self._GENERIC_PROVENANCE.findall(body)
+            if fake_prov:
+                report.issues.append(LintIssue(
+                    severity=IssueSeverity.ERROR,
+                    category="fake_provenance",
+                    message=f"{len(fake_prov)} generic provenance markers",
+                    file_path=rel_path,
+                    suggestion="Replace with real source paths",
+                ))
+
+            # Provenance paths that don't exist on disk (skip already-flagged generics)
+            all_prov = re.findall(r"\^\[(raw/[^\]]+\.md)\]", body)
+            for prov_path in all_prov:
+                if self._GENERIC_PROVENANCE.search(f"^[{prov_path}]"):
+                    continue
+                full_path = self.config.wiki_path / prov_path
+                if not full_path.exists() and prov_path not in known_source_paths:
+                    report.issues.append(LintIssue(
+                        severity=IssueSeverity.ERROR,
+                        category="missing_source",
+                        message=f"Provenance marker references non-existent source: {prov_path}",
+                        file_path=rel_path,
+                    ))
+
+            # Frontmatter sources that don't exist
+            fm_sources = fm.get("sources", [])
+            if isinstance(fm_sources, list):
+                for src in fm_sources:
+                    src_path = self.config.wiki_path / src
+                    if not src_path.exists():
+                        report.issues.append(LintIssue(
+                            severity=IssueSeverity.WARNING,
+                            category="missing_fm_source",
+                            message=f"Frontmatter source not found: {src}",
+                            file_path=rel_path,
+                        ))
+
+            # Body provenance not in frontmatter sources
+            if fm_sources and all_prov:
+                fm_source_set = set(fm_sources) if isinstance(fm_sources, list) else set()
+                for prov_path in set(all_prov):
+                    if prov_path not in fm_source_set and not self._GENERIC_PROVENANCE.match(f"^[{prov_path}]"):
+                        report.issues.append(LintIssue(
+                            severity=IssueSeverity.INFO,
+                            category="provenance_mismatch",
+                            message=f"Body cites {prov_path} but it's not in frontmatter sources",
+                            file_path=rel_path,
+                        ))
+
+        # ── Source integrity ─────────────────────────────────────────
+        for source_path_str in known_source_paths:
+            source_path = self.config.wiki_path / source_path_str
+            if source_path.exists():
+                fm, body = read_page(source_path)
+                stored_hash = fm.get("sha256")
+                if stored_hash:
+                    actual_hash = hashlib.sha256(body.encode()).hexdigest()
+                    if actual_hash != stored_hash:
+                        report.issues.append(LintIssue(
+                            severity=IssueSeverity.WARNING,
+                            category="source_drift",
+                            message="Source content hash mismatch",
+                            file_path=source_path_str,
+                            suggestion="Raw sources should be immutable",
+                        ))
+
+        # ── Vector collection health ─────────────────────────────────
+        vector_stats = self.search.collection_stats()
+        if report.total_pages > 0 and vector_stats.get("points", 0) == 0:
+            report.issues.append(LintIssue(
+                severity=IssueSeverity.ERROR,
+                category="empty_vector_index",
+                message=f"Wiki has {report.total_pages} pages but vector index has 0 chunks",
+                suggestion="Run reindex to rebuild the vector collection",
+            ))
+
+        if write_log:
+            self.indexer.append_log(
+                "lint",
+                f"{len(report.issues)} issues found",
+                [f"Errors: {report.error_count}, Warnings: {report.warning_count}"],
+            )
+
+        return report
+
+    def status(self) -> dict:
+        pages = self.indexer.get_all_pages()
+        sources = self.indexer.list_sources()
+        vector_stats = self.search.collection_stats()
+        recent_log = self.indexer.recent_log_entries(10)
+
+        return {
+            "wiki_path": str(self.config.wiki_path),
+            "total_pages": sum(len(v) for v in pages.values()),
+            "pages_by_type": {k: len(v) for k, v in pages.items()},
+            "total_sources": len(sources),
+            "vector_collection": vector_stats.get("collection", ""),
+            "indexed_chunks": vector_stats.get("points", 0),
+            "recent_activity": recent_log,
+            "initialized": self.config.schema_path.exists(),
+        }
+
+    def browse(self, page_type: str | None = None, tag: str | None = None,
+               limit: int = 20) -> list[dict]:
+        pages = self.indexer.get_all_pages()
+        results = []
+        for ptype, entries in pages.items():
+            if page_type and ptype != page_type + "s" and ptype != page_type:
+                continue
+            for entry in entries:
+                if tag and tag not in entry.get("tags", []):
+                    continue
+                entry["page_type"] = ptype
+                results.append(entry)
+
+        results.sort(key=lambda x: x.get("updated", ""), reverse=True)
+        return results[:limit]
+
+    def reindex(self) -> dict:
+        counts = self.search.reindex_all()
+        self.indexer.rebuild_index()
+        self.indexer.append_log(
+            "reindex", "Full reindex",
+            [f"Pages: {counts['pages']}, Sources: {counts['sources']}, Chunks: {counts['chunks']}"],
+        )
+        return counts
+
+    def close(self) -> None:
+        self.search.close()

--- a/hermes_wiki/eval.py
+++ b/hermes_wiki/eval.py
@@ -1,0 +1,227 @@
+"""Retrieval evaluation helpers for LLM Wiki dogfood/regression checks."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Iterable, Protocol
+
+import yaml
+
+
+class Searcher(Protocol):
+    """Minimal protocol implemented by WikiSearch and test fakes."""
+
+    def search(self, query: str, limit: int = 5) -> list[Any]: ...
+
+
+@dataclass(frozen=True)
+class RetrievalEvalCase:
+    """A retrieval expectation for one query."""
+
+    query: str
+    expected_pages: set[str]
+    top_k: int = 5
+
+
+@dataclass(frozen=True)
+class RetrievalEvalCaseResult:
+    """Result for one retrieval expectation."""
+
+    query: str
+    expected_pages: set[str]
+    retrieved_pages: list[str]
+    missing_pages: set[str]
+
+    @property
+    def passed(self) -> bool:
+        return not self.missing_pages
+
+
+@dataclass(frozen=True)
+class RetrievalEvalResult:
+    """Aggregate retrieval evaluation result."""
+
+    cases: list[RetrievalEvalCaseResult] = field(default_factory=list)
+
+    @property
+    def total(self) -> int:
+        return len(self.cases)
+
+    @property
+    def failures(self) -> list[RetrievalEvalCaseResult]:
+        return [case for case in self.cases if not case.passed]
+
+    @property
+    def passed(self) -> bool:
+        return not self.failures
+
+
+def _result_page_path(result: Any) -> str:
+    if isinstance(result, dict):
+        return str(result.get("page_path") or "").strip()
+    return str(getattr(result, "page_path", "") or "").strip()
+
+
+def evaluate_retrieval(searcher: Searcher, cases: Iterable[RetrievalEvalCase]) -> RetrievalEvalResult:
+    """Run retrieval expectations against a wiki searcher.
+
+    The helper intentionally validates page presence only. It does not judge answer
+    quality or generate text, so it can be used in deterministic tests and dogfood
+    smoke checks without invoking an LLM.
+    """
+
+    results: list[RetrievalEvalCaseResult] = []
+    for case in cases:
+        top_k = max(1, int(case.top_k or 1))
+        raw_results = searcher.search(case.query, limit=top_k)
+        retrieved_pages: list[str] = []
+        seen_pages: set[str] = set()
+        for result in raw_results:
+            page = _result_page_path(result)
+            if page and page not in seen_pages:
+                retrieved_pages.append(page)
+                seen_pages.add(page)
+        missing_pages = set(case.expected_pages) - set(retrieved_pages)
+        results.append(
+            RetrievalEvalCaseResult(
+                query=case.query,
+                expected_pages=set(case.expected_pages),
+                retrieved_pages=retrieved_pages,
+                missing_pages=missing_pages,
+            )
+        )
+    return RetrievalEvalResult(cases=results)
+
+
+def _coerce_expected_pages(value: Any, *, index: int) -> set[str]:
+    if isinstance(value, str):
+        pages = [value]
+    elif isinstance(value, list | tuple | set):
+        pages = list(value)
+    else:
+        raise ValueError(f"case {index}: expected_pages must be a string or list of strings")
+
+    cleaned: set[str] = set()
+    for raw_page in pages:
+        page = str(raw_page).strip()
+        if not page:
+            continue
+        candidate = Path(page)
+        if candidate.is_absolute() or ".." in candidate.parts:
+            raise ValueError(f"case {index}: expected_pages must be relative wiki page paths")
+        cleaned.add(page)
+    if not cleaned:
+        raise ValueError(f"case {index}: expected_pages must include at least one page path")
+    return cleaned
+
+
+def _case_from_mapping(item: Any, *, index: int) -> RetrievalEvalCase:
+    if not isinstance(item, dict):
+        raise ValueError(f"case {index}: expected a mapping")
+
+    query = str(item.get("query") or "").strip()
+    if not query:
+        raise ValueError(f"case {index}: query is required")
+
+    expected_pages = _coerce_expected_pages(item.get("expected_pages"), index=index)
+    top_k_raw = item.get("top_k", 5)
+    try:
+        top_k = max(1, int(top_k_raw))
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"case {index}: top_k must be an integer") from exc
+
+    return RetrievalEvalCase(query=query, expected_pages=expected_pages, top_k=top_k)
+
+
+def load_retrieval_cases(path: str | Path) -> list[RetrievalEvalCase]:
+    """Load retrieval eval cases from YAML or JSON.
+
+    Supported shapes:
+    - a top-level list of case mappings;
+    - a mapping with a `cases` list.
+    """
+
+    case_path = Path(path)
+    text = case_path.read_text(encoding="utf-8")
+    if case_path.suffix.lower() == ".json":
+        data = json.loads(text)
+    else:
+        data = yaml.safe_load(text)
+
+    if isinstance(data, dict):
+        data = data.get("cases")
+    if not isinstance(data, list):
+        raise ValueError("retrieval eval file must contain a list or a mapping with a cases list")
+    if not data:
+        raise ValueError("retrieval eval file must contain at least one case")
+
+    return [_case_from_mapping(item, index=index) for index, item in enumerate(data, start=1)]
+
+
+def result_to_dict(result: RetrievalEvalResult) -> dict[str, Any]:
+    """Convert a retrieval eval result into stable JSON-serializable data."""
+
+    return {
+        "passed": result.passed,
+        "total": result.total,
+        "failures": len(result.failures),
+        "cases": [
+            {
+                "query": case.query,
+                "passed": case.passed,
+                "expected_pages": sorted(case.expected_pages),
+                "retrieved_pages": case.retrieved_pages,
+                "missing_pages": sorted(case.missing_pages),
+            }
+            for case in result.cases
+        ],
+    }
+
+
+def _load_explicit_wiki_config(config_path: str | Path):
+    """Load exactly one explicit Hermes config file, with no fallback search."""
+
+    from hermes_wiki.config import WikiConfig
+
+    path = Path(config_path).expanduser()
+    if not path.exists():
+        raise FileNotFoundError(f"Hermes config not found: {config_path}")
+    data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    if not isinstance(data, dict):
+        raise ValueError(f"Hermes config must be a mapping: {config_path}")
+    if "wiki" not in data:
+        raise ValueError(f"Hermes config has no wiki section: {config_path}")
+    return WikiConfig.from_dict(data)
+
+
+def _build_searcher(config_path: str | None = None) -> Searcher:
+    from hermes_wiki.config import WikiConfig
+    from hermes_wiki.search import WikiSearch
+
+    config = _load_explicit_wiki_config(config_path) if config_path is not None else WikiConfig.from_hermes_config()
+    return WikiSearch(config, ensure_collection=False)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run retrieval eval cases from the command line."""
+
+    parser = argparse.ArgumentParser(description="Run LLM Wiki retrieval regression checks")
+    parser.add_argument("cases", help="YAML or JSON retrieval eval cases file")
+    parser.add_argument("--config", help="Hermes config.yaml path to load wiki settings from")
+    parser.add_argument("--pretty", action="store_true", help="Pretty-print JSON output")
+    args = parser.parse_args(argv)
+
+    try:
+        cases = load_retrieval_cases(args.cases)
+        result = evaluate_retrieval(_build_searcher(args.config), cases)
+    except (FileNotFoundError, ValueError, json.JSONDecodeError, yaml.YAMLError) as exc:
+        parser.error(str(exc))
+    print(json.dumps(result_to_dict(result), indent=2 if args.pretty else None, sort_keys=True))
+    return 0 if result.passed else 1
+
+
+if __name__ == "__main__":  # pragma: no cover - exercised via subprocess/CLI use
+    raise SystemExit(main())

--- a/hermes_wiki/frontmatter.py
+++ b/hermes_wiki/frontmatter.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import os
+import re
+import uuid
+import yaml
+from datetime import date, datetime
+from pathlib import Path
+from typing import Any
+
+
+def parse_frontmatter(text: str) -> tuple[dict[str, Any], str]:
+    """Parse YAML frontmatter from markdown text.
+
+    Returns (frontmatter_dict, body_text).
+    """
+    text = text.strip()
+    if not text.startswith("---\n"):
+        return {}, text
+
+    end_match = re.search(r"^---\s*$", text[4:], flags=re.MULTILINE)
+    if not end_match:
+        return {}, text
+
+    end = 4 + end_match.start()
+    yaml_str = text[4:end].strip()
+    body = text[4 + end_match.end():].strip()
+
+    try:
+        fm = yaml.safe_load(yaml_str) or {}
+    except yaml.YAMLError:
+        return {}, text
+
+    return fm, body
+
+
+def render_frontmatter(fm: dict[str, Any]) -> str:
+    """Render a frontmatter dict to YAML string with --- delimiters."""
+    cleaned = {}
+    for k, v in fm.items():
+        if isinstance(v, (date, datetime)):
+            cleaned[k] = v.isoformat() if isinstance(v, datetime) else str(v)
+        elif isinstance(v, list) and all(isinstance(i, str) for i in v):
+            cleaned[k] = v
+        else:
+            cleaned[k] = v
+
+    yaml_str = yaml.dump(cleaned, default_flow_style=False, sort_keys=False, allow_unicode=True).strip()
+    return f"---\n{yaml_str}\n---"
+
+
+def write_page(path: Path, frontmatter: dict[str, Any], body: str) -> None:
+    """Write a wiki page with frontmatter + body using atomic replacement."""
+    fm_str = render_frontmatter(frontmatter)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    content = f"{fm_str}\n\n{body}\n"
+    tmp_path = path.parent / f".{path.name}.{uuid.uuid4().hex}.tmp"
+    try:
+        tmp_path.write_text(content, encoding="utf-8")
+        os.replace(tmp_path, path)
+    finally:
+        if tmp_path.exists():
+            tmp_path.unlink()
+
+
+def read_page(path: Path) -> tuple[dict[str, Any], str]:
+    """Read a wiki page, returning (frontmatter, body)."""
+    if not path.exists():
+        return {}, ""
+    return parse_frontmatter(path.read_text(encoding="utf-8"))
+
+
+def extract_wikilinks(text: str) -> list[str]:
+    """Extract all [[wikilinks]] from text, resolving aliases.
+
+    [[Page|display text]] resolves to "Page" (the target, not the display text).
+    [[Page]] resolves to "Page".
+    """
+    raw = re.findall(r"\[\[([^\]]+)\]\]", text)
+    return [link.split("|")[0].strip() for link in raw]
+
+
+def slugify(title: str) -> str:
+    """Convert a title to a filename slug."""
+    title = title.split("|")[0].strip()
+    slug = title.lower().strip()
+    slug = re.sub(r"[^\w\s-]", "", slug)
+    slug = re.sub(r"[\s_]+", "-", slug)
+    slug = re.sub(r"-+", "-", slug)
+    return slug.strip("-")
+
+
+def chunk_markdown(text: str, max_tokens: int = 500) -> list[str]:
+    """Split markdown text into chunks, respecting heading structure.
+
+    Tries to split on headings first, then paragraphs for oversized sections.
+    Token count approximated as len(text) / 4.
+    """
+    sections = re.split(r"(?=^#{1,3}\s)", text, flags=re.MULTILINE)
+    chunks = []
+
+    for section in sections:
+        trimmed = section.strip()
+        if not trimmed:
+            continue
+
+        if len(trimmed) / 4 <= max_tokens:
+            chunks.append(trimmed)
+        else:
+            heading_match = re.match(r"^(#{1,3}\s+.+)\n", trimmed)
+            heading = heading_match.group(1) if heading_match else ""
+            body = trimmed[len(heading):].strip() if heading else trimmed
+
+            paragraphs = re.split(r"\n{2,}", body)
+            buf = heading + "\n\n" if heading else ""
+
+            for para in paragraphs:
+                candidate = buf + para + "\n\n"
+                if len(candidate) / 4 > max_tokens and buf.strip():
+                    chunks.append(buf.strip())
+                    buf = (heading + "\n\n" if heading else "") + para + "\n\n"
+                else:
+                    buf = candidate
+
+            if buf.strip():
+                chunks.append(buf.strip())
+
+    return chunks if chunks else [text.strip()]

--- a/hermes_wiki/indexer.py
+++ b/hermes_wiki/indexer.py
@@ -1,0 +1,224 @@
+from __future__ import annotations
+
+import re
+from datetime import date
+from pathlib import Path
+from typing import Optional
+
+from hermes_wiki.config import WikiConfig
+from hermes_wiki.frontmatter import read_page
+from hermes_wiki.models import LogEntry
+
+
+class WikiIndexer:
+    """Manages index.md and log.md for wiki navigation."""
+
+    def __init__(self, config: WikiConfig):
+        self.config = config
+
+    def read_index(self) -> str:
+        if self.config.index_path.exists():
+            return self.config.index_path.read_text(encoding="utf-8")
+        return ""
+
+    def get_all_pages(self) -> dict[str, list[dict]]:
+        """Scan filesystem and return all wiki pages grouped by type."""
+        pages: dict[str, list[dict]] = {
+            "entities": [],
+            "concepts": [],
+            "comparisons": [],
+            "queries": [],
+        }
+
+        for page_type, dir_path in [
+            ("entities", self.config.entities_dir),
+            ("concepts", self.config.concepts_dir),
+            ("comparisons", self.config.comparisons_dir),
+            ("queries", self.config.queries_dir),
+        ]:
+            if not dir_path.exists():
+                continue
+            for md_file in sorted(dir_path.glob("*.md")):
+                fm, _ = read_page(md_file)
+                pages[page_type].append({
+                    "slug": md_file.stem,
+                    "title": fm.get("title", md_file.stem),
+                    "tags": fm.get("tags", []),
+                    "updated": str(fm.get("updated", "")),
+                    "path": str(md_file.relative_to(self.config.wiki_path)),
+                    "confidence": fm.get("confidence"),
+                    "contested": fm.get("contested", False),
+                })
+
+        return pages
+
+    def rebuild_index(self) -> int:
+        """Rebuild index.md from filesystem. Returns total page count."""
+        pages = self.get_all_pages()
+        total = sum(len(v) for v in pages.values())
+
+        sections = [
+            f"# Wiki Index\n",
+            f"> Content catalog. Every wiki page listed under its type with a one-line summary.",
+            f"> Read this first to find relevant pages for any query.",
+            f"> Last updated: {date.today().isoformat()} | Total pages: {total}\n",
+        ]
+
+        for section_name, entries in [
+            ("Entities", pages["entities"]),
+            ("Concepts", pages["concepts"]),
+            ("Comparisons", pages["comparisons"]),
+            ("Queries", pages["queries"]),
+        ]:
+            sections.append(f"\n## {section_name}\n")
+            if entries:
+                for entry in entries:
+                    tags_str = f" [{', '.join(entry['tags'])}]" if entry['tags'] else ""
+                    contested = " ⚠️ CONTESTED" if entry.get('contested') else ""
+                    sections.append(f"- [[{entry['slug']}]] — {entry['title']}{tags_str}{contested}")
+            else:
+                sections.append("_No pages yet._")
+
+        self.config.index_path.write_text("\n".join(sections) + "\n", encoding="utf-8")
+        return total
+
+    def add_to_index(self, slug: str, title: str, page_type: str, tags: list[str] | None = None) -> None:
+        """Add a single entry to index.md without full rebuild."""
+        if not self.config.index_path.exists():
+            self.rebuild_index()
+            return
+
+        content = self.config.index_path.read_text(encoding="utf-8")
+
+        if f"[[{slug}]]" in content:
+            return
+
+        type_to_section = {
+            "entity": "## Entities",
+            "concept": "## Concepts",
+            "comparison": "## Comparisons",
+            "query": "## Queries",
+        }
+        section_header = type_to_section.get(page_type, "## Entities")
+
+        tags_str = f" [{', '.join(tags)}]" if tags else ""
+        new_entry = f"- [[{slug}]] — {title}{tags_str}"
+
+        if section_header in content:
+            no_pages = "_No pages yet._"
+            if no_pages in content.split(section_header)[1].split("\n##")[0]:
+                content = content.replace(
+                    f"{section_header}\n\n{no_pages}",
+                    f"{section_header}\n\n{new_entry}",
+                )
+            else:
+                pos = content.find(section_header)
+                next_section = content.find("\n## ", pos + len(section_header))
+                if next_section == -1:
+                    content = content.rstrip() + f"\n{new_entry}\n"
+                else:
+                    content = content[:next_section] + f"{new_entry}\n" + content[next_section:]
+        else:
+            content = content.rstrip() + f"\n\n{section_header}\n\n{new_entry}\n"
+
+        total_match = re.search(r"Total pages: (\d+)", content)
+        if total_match:
+            old_count = int(total_match.group(1))
+            content = content.replace(
+                f"Total pages: {old_count}",
+                f"Total pages: {old_count + 1}",
+            )
+
+        content = re.sub(
+            r"Last updated: \d{4}-\d{2}-\d{2}",
+            f"Last updated: {date.today().isoformat()}",
+            content,
+        )
+
+        self.config.index_path.write_text(content, encoding="utf-8")
+
+    def append_log(self, action: str, subject: str, details: list[str] | None = None) -> None:
+        """Append an entry to log.md."""
+        entry = LogEntry(
+            date=date.today(),
+            action=action,
+            subject=subject,
+            details=details or [],
+        )
+
+        log_text = ""
+        if self.config.log_path.exists():
+            log_text = self.config.log_path.read_text(encoding="utf-8")
+
+        log_text = log_text.rstrip() + "\n\n" + entry.to_markdown() + "\n"
+
+        entry_count = log_text.count("## [")
+        if entry_count > self.config.log_rotation_threshold:
+            year = date.today().year
+            archive_name = f"log-{year}.md"
+            archive_path = self.config.wiki_path / archive_name
+            suffix = 2
+            while archive_path.exists():
+                archive_name = f"log-{year}-{suffix}.md"
+                archive_path = self.config.wiki_path / archive_name
+                suffix += 1
+            archive_path.write_text(log_text, encoding="utf-8")
+            log_text = (
+                "# Wiki Log\n\n"
+                "> Chronological record of all wiki actions. Append-only.\n"
+                "> Format: `## [YYYY-MM-DD] action | subject`\n"
+                f"> Previous logs archived to {archive_name}\n\n"
+                f"## [{date.today().isoformat()}] rotate | Log rotated, {entry_count} entries archived\n"
+            )
+
+        self.config.log_path.write_text(log_text, encoding="utf-8")
+
+    def recent_log_entries(self, n: int = 20) -> str:
+        """Get the last N log entries as text."""
+        if not self.config.log_path.exists():
+            return "No log entries yet."
+
+        text = self.config.log_path.read_text(encoding="utf-8")
+        entries = re.split(r"(?=^## \[)", text, flags=re.MULTILINE)
+        entries = [e.strip() for e in entries if e.strip().startswith("## [")]
+        recent = entries[-n:] if len(entries) > n else entries
+        return "\n\n".join(recent) if recent else "No log entries yet."
+
+    def list_entity_slugs(self) -> list[str]:
+        """List all entity page slugs."""
+        if not self.config.entities_dir.exists():
+            return []
+        return [f.stem for f in sorted(self.config.entities_dir.glob("*.md"))]
+
+    def list_concept_slugs(self) -> list[str]:
+        """List all concept page slugs."""
+        if not self.config.concepts_dir.exists():
+            return []
+        return [f.stem for f in sorted(self.config.concepts_dir.glob("*.md"))]
+
+    def list_all_slugs(self) -> list[str]:
+        """List all wiki page slugs across all types."""
+        slugs = []
+        for subdir in ["entities", "concepts", "comparisons", "queries"]:
+            dir_path = self.config.wiki_path / subdir
+            if dir_path.exists():
+                slugs.extend(f.stem for f in dir_path.glob("*.md"))
+        return sorted(slugs)
+
+    def list_sources(self) -> list[dict]:
+        """List all raw sources with metadata."""
+        sources = []
+        for subdir in ["articles", "papers", "transcripts"]:
+            dir_path = self.config.raw_dir / subdir
+            if not dir_path.exists():
+                continue
+            for f in sorted(dir_path.glob("*.md")):
+                fm, _ = read_page(f)
+                sources.append({
+                    "path": str(f.relative_to(self.config.wiki_path)),
+                    "name": f.stem,
+                    "source_url": fm.get("source_url"),
+                    "ingested": str(fm.get("ingested", "")),
+                    "subdir": subdir,
+                })
+        return sources

--- a/hermes_wiki/llm.py
+++ b/hermes_wiki/llm.py
@@ -1,0 +1,239 @@
+from __future__ import annotations
+
+import json
+import logging
+import re
+from datetime import date
+from typing import Any
+
+import openai
+
+from hermes_wiki.config import WikiConfig
+
+logger = logging.getLogger(__name__)
+
+
+class WikiLLM:
+    """GPT 5.5 integration for wiki intelligence operations."""
+
+    def __init__(self, config: WikiConfig):
+        self.config = config
+        self._client = openai.OpenAI(
+            base_url=config.llm_base_url,
+            api_key=config.llm_api_key,
+        )
+
+    def _call(self, system: str, user: str, temperature: float | None = None) -> str:
+        resp = self._client.chat.completions.create(
+            model=self.config.llm_model,
+            messages=[
+                {"role": "system", "content": system},
+                {"role": "user", "content": user},
+            ],
+            temperature=temperature or self.config.llm_temperature,
+            max_tokens=self.config.llm_max_tokens,
+        )
+        return resp.choices[0].message.content or ""
+
+    def _call_json(self, system: str, user: str) -> dict:
+        raw = self._call(system, user)
+        raw = raw.strip()
+        if raw.startswith("```"):
+            lines = raw.split("\n")
+            lines = lines[1:]
+            if lines and lines[-1].strip() == "```":
+                lines = lines[:-1]
+            raw = "\n".join(lines)
+        start = raw.find("{")
+        end = raw.rfind("}") + 1
+        if start != -1 and end > start:
+            raw = raw[start:end]
+        try:
+            return json.loads(raw)
+        except json.JSONDecodeError:
+            logger.warning("Failed to parse LLM JSON response, returning raw text")
+            return {"raw_response": raw}
+
+    def analyze_source(self, source_text: str, existing_entities: list[str],
+                       existing_concepts: list[str], schema_text: str) -> dict:
+        """Analyze a source document to extract entities, concepts, key facts."""
+        system = f"""You are a wiki analyst. Analyze source documents and extract structured information.
+
+Today's date: {date.today().isoformat()}
+
+Wiki schema:
+{schema_text[:3000]}
+
+Existing entity pages (use exact slugs when referencing): {', '.join(existing_entities[:100]) or 'none yet'}
+Existing concept pages (use exact slugs when referencing): {', '.join(existing_concepts[:100]) or 'none yet'}
+
+Return valid JSON:
+{{
+  "title": "Brief title for this source",
+  "summary": "2-3 paragraph summary of key content",
+  "entities": [
+    {{"name": "Entity Name", "slug": "entity-name", "description": "One line", "is_new": true/false}}
+  ],
+  "concepts": [
+    {{"name": "Concept Name", "slug": "concept-name", "description": "One line", "is_new": true/false}}
+  ],
+  "key_facts": ["Fact 1", "Fact 2"],
+  "tags": ["tag1", "tag2"],
+  "cross_references": ["existing-page-slug"],
+  "contradictions": ["description of contradiction with existing knowledge"]
+}}
+
+IMPORTANT:
+- Mark is_new=false if entity/concept matches an existing page slug
+- Only create pages for entities/concepts CENTRAL to the source (not passing mentions)
+- Passing mentions like "Markdown", "Knowledge Base", "hypertext" should NOT get pages unless
+  the source discusses them substantively"""
+
+        return self._call_json(system, f"Analyze this source document:\n\n{source_text[:12000]}")
+
+    def generate_entity_page(self, entity: dict, source_summary: str,
+                             source_path: str, existing_page_content: str | None,
+                             related_context: str, known_pages: list[str]) -> str:
+        """Generate or update an entity wiki page."""
+        known_list = ", ".join(f"[[{p}]]" for p in known_pages[:80]) if known_pages else "none yet"
+
+        system = f"""You are a wiki page writer. Write or update an entity page.
+
+Today's date: {date.today().isoformat()}
+
+CRITICAL RULES:
+- Do NOT include YAML frontmatter (added separately)
+- ONLY use [[wikilinks]] to pages that exist. Known pages: {known_list}
+- Do NOT create wikilinks to pages that don't exist — use plain text instead
+- Add provenance markers using the EXACT source path: ^[{source_path}]
+- Start with a one-paragraph overview
+- Be concise and factual — scannable in 30 seconds
+- If updating existing content, preserve and extend it
+- Use markdown: headers, bullet lists, bold for key terms"""
+
+        user_parts = [f"Entity: {entity['name']}\nDescription: {entity.get('description', '')}"]
+        user_parts.append(f"\nSource ({source_path}):\n{source_summary[:4000]}")
+        if existing_page_content:
+            user_parts.append(f"\nExisting page to update:\n{existing_page_content[:4000]}")
+        if related_context:
+            user_parts.append(f"\nRelated wiki pages:\n{related_context[:3000]}")
+
+        body = self._call(system, "\n".join(user_parts))
+        return self._sanitize_wikilinks(body, known_pages)
+
+    def generate_concept_page(self, concept: dict, source_summary: str,
+                              source_path: str, existing_page_content: str | None,
+                              related_context: str, known_pages: list[str]) -> str:
+        """Generate or update a concept wiki page."""
+        known_list = ", ".join(f"[[{p}]]" for p in known_pages[:80]) if known_pages else "none yet"
+
+        system = f"""You are a wiki page writer. Write or update a concept page.
+
+Today's date: {date.today().isoformat()}
+
+CRITICAL RULES:
+- Do NOT include YAML frontmatter (added separately)
+- ONLY use [[wikilinks]] to pages that exist. Known pages: {known_list}
+- Do NOT create wikilinks to pages that don't exist — use plain text instead
+- Add provenance markers using the EXACT source path: ^[{source_path}]
+- Start with a clear definition/explanation
+- Include: current state of knowledge, open questions, related concepts
+- Be concise and factual
+- If updating, integrate new information with existing content"""
+
+        user_parts = [f"Concept: {concept['name']}\nDescription: {concept.get('description', '')}"]
+        user_parts.append(f"\nSource ({source_path}):\n{source_summary[:4000]}")
+        if existing_page_content:
+            user_parts.append(f"\nExisting page to update:\n{existing_page_content[:4000]}")
+        if related_context:
+            user_parts.append(f"\nRelated wiki pages:\n{related_context[:3000]}")
+
+        body = self._call(system, "\n".join(user_parts))
+        return self._sanitize_wikilinks(body, known_pages)
+
+    def _sanitize_wikilinks(self, body: str, known_pages: list[str]) -> str:
+        """Replace wikilinks to unknown pages with plain text."""
+        from hermes_wiki.frontmatter import slugify
+
+        known_slugs = set(known_pages)
+
+        def replace_link(match):
+            raw = match.group(1)
+            target = raw.split("|")[0].strip()
+            display = raw.split("|")[1].strip() if "|" in raw else target
+            slug = slugify(target)
+            if slug in known_slugs:
+                return match.group(0)
+            return display
+
+        return re.sub(r"\[\[([^\]]+)\]\]", replace_link, body)
+
+    def generate_source_summary(self, source_text: str, source_name: str,
+                                source_path: str) -> str:
+        """Generate a summary page for a raw source."""
+        system = f"""Write a concise summary of this source document.
+
+Today's date: {date.today().isoformat()}
+
+Structure:
+- Brief overview (1-2 paragraphs)
+- Key points (bullet list)
+- Notable claims or data
+
+Use provenance marker ^[{source_path}] for specific claims.
+Do NOT include YAML frontmatter.
+Do NOT use [[wikilinks]]."""
+
+        return self._call(system, f"Source: {source_name}\n\n{source_text[:12000]}")
+
+    def answer_query(self, question: str, wiki_context: str, search_results: str,
+                     known_pages: list[str]) -> dict:
+        """Answer a question using wiki context and search results."""
+        known_list = ", ".join(known_pages[:60])
+
+        system = f"""You are a wiki knowledge assistant. Answer questions using wiki content.
+
+Today's date: {date.today().isoformat()}
+
+Rules:
+- Base your answer on the wiki content provided, not general knowledge
+- Cite wiki pages using [[wikilinks]] — ONLY use these known pages: {known_list}
+- If the wiki doesn't have enough information, say so
+- Be direct and substantive
+
+Return valid JSON:
+{{
+  "answer": "Your detailed answer with [[wikilinks]] citations",
+  "sources_consulted": ["page-slug-1", "page-slug-2"],
+  "confidence": "high|medium|low",
+  "worth_filing": true/false,
+  "file_title": "Suggested title if worth_filing",
+  "file_slug": "suggested-slug"
+}}
+
+Set worth_filing=true ONLY for substantial synthesis or comparison — not simple lookups."""
+
+        user = f"Question: {question}\n\nWiki content:\n{wiki_context[:8000]}\n\nSearch results:\n{search_results[:4000]}"
+        return self._call_json(system, user)
+
+    def detect_contradictions(self, page_a_content: str, page_a_name: str,
+                              page_b_content: str, page_b_name: str) -> list[dict]:
+        """Detect contradictions between two wiki pages."""
+        system = """Analyze two wiki pages for contradictions — claims that conflict.
+
+Return valid JSON:
+{
+  "contradictions": [
+    {
+      "claim_a": "What page A says",
+      "claim_b": "What page B says (conflicting)",
+      "severity": "major|minor",
+      "resolution_suggestion": "How to resolve"
+    }
+  ]
+}
+
+Return empty list if no conflicts."""
+
+        user = f"Page: {page_a_name}\n{page_a_content[:4000]}\n\n---\n\nPage: {page_b_name}\n{page_b_content[:4000]}"
+        return self._call_json(system, user).get("contradictions", [])

--- a/hermes_wiki/maintenance.py
+++ b/hermes_wiki/maintenance.py
@@ -1,0 +1,271 @@
+"""Read-only maintenance reporting for LLM Wiki."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from hermes_wiki.config import WikiConfig
+from hermes_wiki.frontmatter import extract_wikilinks, read_page, slugify, write_page
+from hermes_wiki.models import IssueSeverity, LintIssue
+
+
+@dataclass
+class MaintenanceReport:
+    issues: list[LintIssue] = field(default_factory=list)
+    total_pages: int = 0
+    total_sources: int = 0
+    total_links: int = 0
+    broken_links: int = 0
+    orphan_pages: int = 0
+    pending_proposals: int = 0
+    pages_without_sources: int = 0
+
+    @property
+    def error_count(self) -> int:
+        return sum(1 for issue in self.issues if issue.severity == IssueSeverity.ERROR)
+
+    @property
+    def warning_count(self) -> int:
+        return sum(1 for issue in self.issues if issue.severity == IssueSeverity.WARNING)
+
+    @property
+    def info_count(self) -> int:
+        return sum(1 for issue in self.issues if issue.severity == IssueSeverity.INFO)
+
+
+_PAGE_DIRS = ("entities", "concepts", "comparisons", "queries")
+_PROVENANCE_RE = re.compile(r"\^\[(raw/[^\]]+\.md)\]")
+
+
+def _page_files(config: WikiConfig) -> list[Path]:
+    files: list[Path] = []
+    for directory_name in _PAGE_DIRS:
+        directory = config.wiki_path / directory_name
+        if directory.exists():
+            files.extend(sorted(directory.glob("*.md")))
+    return files
+
+
+def _source_files(config: WikiConfig) -> list[Path]:
+    raw_dir = config.wiki_path / "raw"
+    if not raw_dir.exists():
+        return []
+    return sorted(raw_dir.glob("**/*.md"))
+
+
+def _relative(config: WikiConfig, path: Path) -> str:
+    return str(path.relative_to(config.wiki_path))
+
+
+def _has_source_coverage(frontmatter: dict[str, Any], body: str) -> bool:
+    sources = frontmatter.get("sources")
+    if isinstance(sources, list) and any(str(source).strip() for source in sources):
+        return True
+    return bool(_PROVENANCE_RE.search(body))
+
+
+def _proposal_files(config: WikiConfig) -> list[Path]:
+    proposals_dir = config.wiki_path / "proposals"
+    if not proposals_dir.exists():
+        return []
+    return sorted(proposals_dir.glob("*.md"))
+
+
+def generate_maintenance_report(config: WikiConfig) -> MaintenanceReport:
+    """Generate a read-only wiki maintenance report.
+
+    This scans local wiki markdown files only. It does not write logs, ingest
+    sources, reindex vectors, call embeddings, or create directories.
+    """
+
+    report = MaintenanceReport()
+    pages = _page_files(config)
+    sources = _source_files(config)
+    report.total_pages = len(pages)
+    report.total_sources = len(sources)
+
+    slug_to_path = {path.stem: path for path in pages}
+    inbound_links = {slug: set() for slug in slug_to_path}
+
+    for page_path in pages:
+        fm, body = read_page(page_path)
+        rel_path = _relative(config, page_path)
+        links = extract_wikilinks(body)
+        report.total_links += len(links)
+        for link in links:
+            link_slug = slugify(link)
+            if link_slug in slug_to_path:
+                inbound_links[link_slug].add(page_path.stem)
+            else:
+                report.broken_links += 1
+                report.issues.append(
+                    LintIssue(
+                        severity=IssueSeverity.ERROR,
+                        category="broken_link",
+                        message=f"Broken wikilink [[{link}]]",
+                        file_path=rel_path,
+                        suggestion=f"Create page '{link}' or remove the link",
+                    )
+                )
+        if not _has_source_coverage(fm, body):
+            report.pages_without_sources += 1
+            report.issues.append(
+                LintIssue(
+                    severity=IssueSeverity.WARNING,
+                    category="missing_source_coverage",
+                    message="Page has no frontmatter sources or body provenance markers",
+                    file_path=rel_path,
+                    suggestion="Add source-backed provenance or re-ingest from a curated source",
+                )
+            )
+
+    for slug, inbound in inbound_links.items():
+        if not inbound:
+            report.orphan_pages += 1
+            report.issues.append(
+                LintIssue(
+                    severity=IssueSeverity.WARNING,
+                    category="orphan_page",
+                    message=f"Page [[{slug}]] has no inbound links",
+                    file_path=_relative(config, slug_to_path[slug]),
+                    suggestion="Add wikilinks from related pages",
+                )
+            )
+
+    for proposal_path in _proposal_files(config):
+        fm, _body = read_page(proposal_path)
+        if fm.get("status", "proposed") in {"proposed", "pending"}:
+            report.pending_proposals += 1
+            report.issues.append(
+                LintIssue(
+                    severity=IssueSeverity.INFO,
+                    category="pending_proposal",
+                    message=f"Pending proposal: {fm.get('title', proposal_path.stem)}",
+                    file_path=_relative(config, proposal_path),
+                    suggestion="Review, accept into canonical wiki pages, or close",
+                )
+            )
+
+    return report
+
+
+def maintenance_report_to_dict(report: MaintenanceReport) -> dict[str, Any]:
+    return {
+        "total_pages": report.total_pages,
+        "total_sources": report.total_sources,
+        "total_links": report.total_links,
+        "broken_links": report.broken_links,
+        "orphan_pages": report.orphan_pages,
+        "pending_proposals": report.pending_proposals,
+        "pages_without_sources": report.pages_without_sources,
+        "errors": report.error_count,
+        "warnings": report.warning_count,
+        "infos": report.info_count,
+        "issues": [
+            {
+                "severity": issue.severity.value,
+                "category": issue.category,
+                "message": issue.message,
+                "file_path": issue.file_path,
+                "suggestion": issue.suggestion,
+            }
+            for issue in report.issues
+        ],
+    }
+
+
+def render_maintenance_report(report: MaintenanceReport) -> str:
+    lines = [
+        "# LLM Wiki Maintenance Report",
+        "",
+        "## Summary",
+        f"- Pages: {report.total_pages}",
+        f"- Sources: {report.total_sources}",
+        f"- Links: {report.total_links}",
+        f"- Broken links: {report.broken_links}",
+        f"- Orphan pages: {report.orphan_pages}",
+        f"- Pending proposals: {report.pending_proposals}",
+        f"- Pages without source coverage: {report.pages_without_sources}",
+        f"- Issues: {len(report.issues)} ({report.error_count} errors, {report.warning_count} warnings, {report.info_count} info)",
+        "",
+        "## Issues",
+    ]
+    if not report.issues:
+        lines.append("No issues found.")
+    else:
+        for issue in report.issues:
+            file_path = f" `{issue.file_path}`" if issue.file_path else ""
+            suggestion = f" — {issue.suggestion}" if issue.suggestion else ""
+            lines.append(f"- **{issue.severity.value} / {issue.category}**{file_path}: {issue.message}{suggestion}")
+    return "\n".join(lines) + "\n"
+
+
+def _load_explicit_wiki_config(config_path: str | Path) -> WikiConfig:
+    path = Path(config_path).expanduser()
+    if not path.exists():
+        raise FileNotFoundError(f"Hermes config not found: {config_path}")
+    data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    if not isinstance(data, dict):
+        raise ValueError(f"Hermes config must be a mapping: {config_path}")
+    if "wiki" not in data:
+        raise ValueError(f"Hermes config has no wiki section: {config_path}")
+    return WikiConfig.from_dict(data)
+
+
+def _build_config(config_path: str | None) -> WikiConfig:
+    return _load_explicit_wiki_config(config_path) if config_path else WikiConfig.from_hermes_config()
+
+
+def _validate_report_path(config: WikiConfig, report_path: str) -> Path:
+    rel_path = Path(report_path)
+    if rel_path.is_absolute() or ".." in rel_path.parts:
+        raise ValueError("--write-report must be a relative path under reports/")
+    if not rel_path.parts or rel_path.parts[0] != "reports" or rel_path.suffix != ".md":
+        raise ValueError("--write-report must be a relative markdown path under reports/")
+    path = (config.wiki_path / rel_path).resolve()
+    reports_root = (config.wiki_path / "reports").resolve()
+    if path.parent != reports_root and reports_root not in path.parents:
+        raise ValueError("--write-report must stay inside reports/")
+    if not path.is_relative_to(config.wiki_path.resolve()):
+        raise ValueError("--write-report must stay inside the wiki")
+    return path
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Generate a read-only LLM Wiki maintenance report")
+    parser.add_argument("--config", help="Hermes config.yaml path to load wiki settings from")
+    parser.add_argument("--json", action="store_true", help="Emit JSON instead of markdown")
+    parser.add_argument("--write-report", help="Explicit relative path under the wiki for a markdown report")
+    args = parser.parse_args(argv)
+
+    try:
+        config = _build_config(args.config)
+        report = generate_maintenance_report(config)
+        if args.write_report:
+            if not args.config:
+                raise ValueError("--write-report requires explicit --config to avoid writing to the wrong wiki")
+            path = _validate_report_path(config, args.write_report)
+            write_page(
+                path,
+                {"title": "LLM Wiki Maintenance Report", "type": "maintenance_report", "status": "generated"},
+                render_maintenance_report(report),
+            )
+            print(json.dumps({"written": True, "path": str(path)}, sort_keys=True))
+        elif args.json:
+            print(json.dumps(maintenance_report_to_dict(report), sort_keys=True))
+        else:
+            print(render_maintenance_report(report), end="")
+    except (FileNotFoundError, ValueError, yaml.YAMLError, OSError) as exc:
+        parser.error(str(exc))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/hermes_wiki/models.py
+++ b/hermes_wiki/models.py
@@ -1,0 +1,182 @@
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass, field
+from datetime import date, datetime
+from enum import Enum
+from pathlib import Path
+from typing import Optional
+
+
+class PageType(str, Enum):
+    ENTITY = "entity"
+    CONCEPT = "concept"
+    COMPARISON = "comparison"
+    QUERY = "query"
+    SUMMARY = "summary"
+
+
+class IssueSeverity(str, Enum):
+    ERROR = "error"
+    WARNING = "warning"
+    INFO = "info"
+
+
+@dataclass
+class WikiPage:
+    path: Path
+    title: str
+    page_type: PageType
+    tags: list[str] = field(default_factory=list)
+    sources: list[str] = field(default_factory=list)
+    created: date | None = None
+    updated: date | None = None
+    confidence: str | None = None
+    contested: bool = False
+    contradictions: list[str] = field(default_factory=list)
+    content: str = ""
+    frontmatter: dict = field(default_factory=dict)
+
+    @property
+    def slug(self) -> str:
+        return self.path.stem
+
+    @property
+    def wikilink(self) -> str:
+        return f"[[{self.slug}]]"
+
+    @property
+    def content_hash(self) -> str:
+        return hashlib.sha256(self.content.encode()).hexdigest()[:16]
+
+
+@dataclass
+class Source:
+    path: Path
+    source_url: str | None = None
+    ingested: date | None = None
+    sha256: str | None = None
+    content: str = ""
+
+    def compute_body_hash(self) -> str:
+        body = self.content
+        if body.startswith("---"):
+            end = body.find("---", 3)
+            if end != -1:
+                body = body[end + 3:].strip()
+        return hashlib.sha256(body.encode()).hexdigest()
+
+    @property
+    def has_drifted(self) -> bool:
+        if not self.sha256:
+            return False
+        return self.compute_body_hash() != self.sha256
+
+
+@dataclass
+class LogEntry:
+    date: date
+    action: str
+    subject: str
+    details: list[str] = field(default_factory=list)
+
+    def to_markdown(self) -> str:
+        lines = [f"## [{self.date.isoformat()}] {self.action} | {self.subject}"]
+        for detail in self.details:
+            lines.append(f"- {detail}")
+        return "\n".join(lines)
+
+
+@dataclass
+class LintIssue:
+    severity: IssueSeverity
+    category: str
+    message: str
+    file_path: str | None = None
+    suggestion: str | None = None
+
+    def __str__(self) -> str:
+        prefix = f"[{self.severity.value.upper()}]"
+        loc = f" ({self.file_path})" if self.file_path else ""
+        sug = f" → {self.suggestion}" if self.suggestion else ""
+        return f"{prefix} {self.category}: {self.message}{loc}{sug}"
+
+
+@dataclass
+class IngestResult:
+    source_path: str
+    pages_created: list[str] = field(default_factory=list)
+    pages_updated: list[str] = field(default_factory=list)
+    entities_found: list[str] = field(default_factory=list)
+    concepts_found: list[str] = field(default_factory=list)
+    key_facts: list[str] = field(default_factory=list)
+    chunks_indexed: int = 0
+
+    @property
+    def total_pages_touched(self) -> int:
+        return len(self.pages_created) + len(self.pages_updated)
+
+    def summary(self) -> str:
+        parts = [f"Ingested: {self.source_path}"]
+        if self.pages_created:
+            parts.append(f"Created {len(self.pages_created)} pages: {', '.join(self.pages_created)}")
+        if self.pages_updated:
+            parts.append(f"Updated {len(self.pages_updated)} pages: {', '.join(self.pages_updated)}")
+        parts.append(f"Indexed {self.chunks_indexed} chunks for search")
+        if self.entities_found:
+            parts.append(f"Entities: {', '.join(self.entities_found)}")
+        if self.concepts_found:
+            parts.append(f"Concepts: {', '.join(self.concepts_found)}")
+        return "\n".join(parts)
+
+
+@dataclass
+class QueryResult:
+    question: str
+    answer: str
+    sources_consulted: list[str] = field(default_factory=list)
+    confidence: str = "medium"
+    filed_as: str | None = None
+
+    def summary(self) -> str:
+        parts = [self.answer]
+        if self.sources_consulted:
+            parts.append(f"\nSources: {', '.join(self.sources_consulted)}")
+        if self.filed_as:
+            parts.append(f"Filed as: {self.filed_as}")
+        return "\n".join(parts)
+
+
+@dataclass
+class LintReport:
+    issues: list[LintIssue] = field(default_factory=list)
+    total_pages: int = 0
+    total_sources: int = 0
+    total_links: int = 0
+    orphan_pages: int = 0
+    broken_links: int = 0
+
+    @property
+    def error_count(self) -> int:
+        return sum(1 for i in self.issues if i.severity == IssueSeverity.ERROR)
+
+    @property
+    def warning_count(self) -> int:
+        return sum(1 for i in self.issues if i.severity == IssueSeverity.WARNING)
+
+    def summary(self) -> str:
+        parts = [
+            f"Wiki Lint Report: {len(self.issues)} issues "
+            f"({self.error_count} errors, {self.warning_count} warnings)",
+            f"Pages: {self.total_pages} | Sources: {self.total_sources} | "
+            f"Links: {self.total_links} | Orphans: {self.orphan_pages} | "
+            f"Broken: {self.broken_links}",
+        ]
+        for sev in [IssueSeverity.ERROR, IssueSeverity.WARNING, IssueSeverity.INFO]:
+            issues = [i for i in self.issues if i.severity == sev]
+            if issues:
+                parts.append(f"\n{'─' * 40}")
+                parts.append(f"{sev.value.upper()} ({len(issues)}):")
+                for issue in issues:
+                    parts.append(f"  {issue}")
+        return "\n".join(parts)

--- a/hermes_wiki/proposal_lifecycle.py
+++ b/hermes_wiki/proposal_lifecycle.py
@@ -1,0 +1,202 @@
+"""Lifecycle operations for queued LLM Wiki memory proposals.
+
+This module manages proposal review artifacts only. It can list, show, and mark
+proposal status, but it does not mutate canonical wiki pages, ingest sources, or
+reindex vectors.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import dataclass, field
+from datetime import date
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from hermes_wiki.config import WikiConfig
+from hermes_wiki.frontmatter import read_page, slugify, write_page
+from hermes_wiki.proposals import _load_explicit_wiki_config
+
+_ALLOWED_STATUSES = {"proposed", "pending", "accepted", "rejected", "closed"}
+_MUTATION_COMMANDS = {"accept", "reject", "close"}
+
+
+@dataclass(frozen=True)
+class ProposalRecord:
+    """A queued memory proposal loaded from the proposals namespace."""
+
+    slug: str
+    title: str
+    status: str
+    path: Path
+    frontmatter: dict[str, Any] = field(default_factory=dict)
+    body: str = ""
+
+    @property
+    def target_pages(self) -> list[str]:
+        value = self.frontmatter.get("target_pages", [])
+        return [str(item) for item in value] if isinstance(value, list) else []
+
+    @property
+    def source_refs(self) -> list[str]:
+        value = self.frontmatter.get("source_refs", [])
+        return [str(item) for item in value] if isinstance(value, list) else []
+
+
+def _proposal_root(config: WikiConfig) -> Path:
+    return (config.wiki_path / "proposals").resolve()
+
+
+def _safe_slug(raw_slug: str) -> str:
+    original = str(raw_slug or "").strip()
+    slug = slugify(original)
+    if not slug or Path(original).is_absolute() or ".." in Path(original).parts or "/" in original or "\\" in original:
+        raise ValueError("unsafe proposal slug")
+    return slug
+
+
+def _proposal_path(config: WikiConfig, slug: str) -> Path:
+    safe = _safe_slug(slug)
+    root = _proposal_root(config)
+    path = (root / f"{safe}.md").resolve()
+    if path.parent != root:
+        raise ValueError("unsafe proposal slug")
+    return path
+
+
+def _record_from_path(config: WikiConfig, path: Path) -> ProposalRecord:
+    root = _proposal_root(config)
+    resolved = path.resolve()
+    if resolved.parent != root or resolved.suffix != ".md":
+        raise ValueError("proposal path must stay under proposals/")
+    fm, body = read_page(resolved)
+    slug = str(fm.get("slug") or resolved.stem).strip() or resolved.stem
+    status = str(fm.get("status", "proposed") or "proposed")
+    title = str(fm.get("title") or slug).strip()
+    return ProposalRecord(slug=slug, title=title, status=status, path=resolved, frontmatter=fm, body=body)
+
+
+def list_proposals(config: WikiConfig, *, status: str | None = None) -> list[ProposalRecord]:
+    """List queued proposal records sorted by slug."""
+
+    root = config.wiki_path / "proposals"
+    if not root.exists():
+        return []
+    records = [_record_from_path(config, path) for path in sorted(root.glob("*.md"))]
+    if status:
+        records = [record for record in records if record.status == status]
+    return sorted(records, key=lambda record: record.slug)
+
+
+def read_proposal(config: WikiConfig, slug: str) -> ProposalRecord:
+    """Read one proposal by safe slug."""
+
+    path = _proposal_path(config, slug)
+    if not path.exists():
+        raise FileNotFoundError(f"Proposal not found: {slug}")
+    return _record_from_path(config, path)
+
+
+def update_proposal_status(config: WikiConfig, slug: str, status: str, *, note: str | None = None) -> ProposalRecord:
+    """Update proposal frontmatter status only.
+
+    This intentionally preserves the proposal body and never writes canonical wiki
+    pages. Accepting a proposal means the review artifact has been accepted by a
+    separate curated workflow; it does not imply this helper applied page edits.
+    """
+
+    normalized = str(status or "").strip().lower()
+    if normalized not in _ALLOWED_STATUSES:
+        raise ValueError(f"unsupported proposal status: {status}")
+    record = read_proposal(config, slug)
+    fm = dict(record.frontmatter)
+    fm["status"] = normalized
+    fm["reviewed"] = date.today().isoformat()
+    if note:
+        fm["review_note"] = str(note).strip()
+    write_page(record.path, fm, record.body)
+    return read_proposal(config, slug)
+
+
+def proposal_record_to_dict(record: ProposalRecord, *, include_body: bool = False) -> dict[str, Any]:
+    payload = {
+        "slug": record.slug,
+        "title": record.title,
+        "status": record.status,
+        "path": str(record.path),
+        "target_pages": record.target_pages,
+        "source_refs": record.source_refs,
+        "created": record.frontmatter.get("created"),
+        "reviewed": record.frontmatter.get("reviewed"),
+        "review_note": record.frontmatter.get("review_note"),
+    }
+    if include_body:
+        payload["body"] = record.body
+    return payload
+
+
+def render_proposal_record(record: ProposalRecord) -> str:
+    return record.body if record.body else f"# {record.title}\n"
+
+
+def _build_config(config_path: str | None) -> WikiConfig:
+    return _load_explicit_wiki_config(config_path) if config_path else WikiConfig.from_hermes_config()
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="List, show, and review LLM Wiki memory proposals")
+    parser.add_argument("--config", help="Hermes config.yaml path to load wiki settings from")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    list_parser = subparsers.add_parser("list", help="List queued proposals")
+    list_parser.add_argument("--status", help="Optional proposal status filter")
+    list_parser.add_argument("--json", action="store_true", help="Emit JSON")
+
+    show_parser = subparsers.add_parser("show", help="Show a proposal")
+    show_parser.add_argument("slug")
+    show_parser.add_argument("--json", action="store_true", help="Emit JSON")
+
+    for command, help_text in (
+        ("accept", "Mark a proposal accepted"),
+        ("reject", "Mark a proposal rejected"),
+        ("close", "Mark a proposal closed"),
+    ):
+        status_parser = subparsers.add_parser(command, help=help_text)
+        status_parser.add_argument("slug")
+        status_parser.add_argument("--note", help="Optional review note")
+
+    args = parser.parse_args(argv)
+
+    try:
+        if args.command in _MUTATION_COMMANDS and not args.config:
+            raise ValueError(f"{args.command} requires explicit --config to avoid writing to the wrong wiki")
+        config = _build_config(args.config)
+        if args.command == "list":
+            records = list_proposals(config, status=args.status)
+            if args.json:
+                print(json.dumps([proposal_record_to_dict(record) for record in records], sort_keys=True))
+            else:
+                for record in records:
+                    print(f"{record.slug}\t{record.status}\t{record.title}")
+        elif args.command == "show":
+            record = read_proposal(config, args.slug)
+            if args.json:
+                print(json.dumps(proposal_record_to_dict(record, include_body=True), sort_keys=True))
+            else:
+                print(render_proposal_record(record), end="")
+        elif args.command == "accept":
+            print(json.dumps(proposal_record_to_dict(update_proposal_status(config, args.slug, "accepted", note=args.note)), sort_keys=True))
+        elif args.command == "reject":
+            print(json.dumps(proposal_record_to_dict(update_proposal_status(config, args.slug, "rejected", note=args.note)), sort_keys=True))
+        elif args.command == "close":
+            print(json.dumps(proposal_record_to_dict(update_proposal_status(config, args.slug, "closed", note=args.note)), sort_keys=True))
+    except (FileNotFoundError, ValueError, yaml.YAMLError, OSError) as exc:
+        parser.error(str(exc))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/hermes_wiki/proposals.py
+++ b/hermes_wiki/proposals.py
@@ -1,0 +1,207 @@
+"""Safe memory proposal helpers for LLM Wiki.
+
+A proposal is a review artifact, not durable accepted memory. The helpers here
+render and optionally queue explicit proposals without ingesting, reindexing, or
+modifying canonical wiki pages.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import dataclass, field
+from datetime import date
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from hermes_wiki.config import WikiConfig
+from hermes_wiki.frontmatter import slugify, write_page
+
+
+@dataclass(frozen=True)
+class MemoryProposal:
+    """A proposed durable-memory update awaiting review."""
+
+    title: str
+    rationale: str
+    proposed_changes: list[str]
+    source_refs: list[str]
+    target_pages: list[str] = field(default_factory=list)
+    tags: list[str] = field(default_factory=list)
+    slug: str | None = None
+    status: str = "proposed"
+
+
+def _clean_list(values: list[str] | tuple[str, ...] | None) -> list[str]:
+    return [str(value).strip() for value in values or [] if str(value).strip()]
+
+
+def _validate_relative_page_paths(paths: list[str], *, field_name: str) -> list[str]:
+    cleaned: list[str] = []
+    for raw_path in paths:
+        page = str(raw_path).strip()
+        if not page:
+            continue
+        candidate = Path(page)
+        if candidate.is_absolute() or ".." in candidate.parts:
+            raise ValueError(f"{field_name} must contain relative wiki page paths")
+        cleaned.append(page)
+    return cleaned
+
+
+def _proposal_slug(proposal: MemoryProposal) -> str:
+    raw_slug = proposal.slug if proposal.slug is not None else proposal.title
+    slug = slugify(raw_slug)
+    if not slug or Path(str(raw_slug)).is_absolute() or ".." in Path(str(raw_slug)).parts:
+        raise ValueError("unsafe proposal slug")
+    return slug
+
+
+def proposal_to_dict(proposal: MemoryProposal) -> dict[str, Any]:
+    """Return stable, JSON-serializable proposal metadata."""
+
+    title = str(proposal.title).strip()
+    rationale = str(proposal.rationale).strip()
+    proposed_changes = _clean_list(proposal.proposed_changes)
+    source_refs = _clean_list(proposal.source_refs)
+    target_pages = _validate_relative_page_paths(_clean_list(proposal.target_pages), field_name="target_pages")
+    tags = _clean_list(proposal.tags)
+    slug = _proposal_slug(proposal)
+
+    if not title:
+        raise ValueError("proposal title is required")
+    if not rationale:
+        raise ValueError("proposal rationale is required")
+    if not proposed_changes:
+        raise ValueError("proposal must include at least one proposed change")
+    if not source_refs:
+        raise ValueError("proposal must include at least one source reference")
+
+    return {
+        "type": "memory_proposal",
+        "title": title,
+        "slug": slug,
+        "status": str(proposal.status or "proposed"),
+        "created": date.today().isoformat(),
+        "target_pages": target_pages,
+        "source_refs": source_refs,
+        "tags": tags,
+    }
+
+
+def render_proposal_markdown(proposal: MemoryProposal) -> str:
+    """Render a human-reviewable memory proposal body."""
+
+    metadata = proposal_to_dict(proposal)
+    changes = _clean_list(proposal.proposed_changes)
+    source_refs = metadata["source_refs"]
+    target_pages = metadata["target_pages"]
+
+    sections = [
+        f"# {metadata['title']}",
+        "",
+        "## Rationale",
+        str(proposal.rationale).strip(),
+        "",
+        "## Proposed changes",
+        *(f"- {change}" for change in changes),
+        "",
+        "## Source references",
+        *(f"- {ref}" for ref in source_refs),
+        "",
+        "## Target pages",
+    ]
+    if target_pages:
+        sections.extend(f"- {page}" for page in target_pages)
+    else:
+        sections.append("- New page or reviewer-selected target")
+    sections.extend(
+        [
+            "",
+            "## Review checklist",
+            "- [ ] Source-backed",
+            "- [ ] Durable beyond the current week",
+            "- [ ] Not a raw transcript dump",
+            "- [ ] Safe to ingest into canonical wiki pages",
+        ]
+    )
+    return "\n".join(sections).strip() + "\n"
+
+
+def queue_proposal(config: WikiConfig, proposal: MemoryProposal, *, write: bool = False) -> Path:
+    """Return or explicitly write a pending proposal path under `<wiki>/proposals`.
+
+    With `write=False` this is a dry-run path calculation. With `write=True` the
+    proposal is written as a review artifact only; canonical wiki pages and the
+    vector index are not changed.
+    """
+
+    metadata = proposal_to_dict(proposal)
+    root = (config.wiki_path / "proposals").resolve()
+    path = (root / f"{metadata['slug']}.md").resolve()
+    if path.parent != root:
+        raise ValueError("unsafe proposal slug")
+    if write:
+        body = render_proposal_markdown(proposal)
+        write_page(path, metadata, body)
+    return path
+
+
+def _load_explicit_wiki_config(config_path: str | Path) -> WikiConfig:
+    path = Path(config_path).expanduser()
+    if not path.exists():
+        raise FileNotFoundError(f"Hermes config not found: {config_path}")
+    data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    if not isinstance(data, dict):
+        raise ValueError(f"Hermes config must be a mapping: {config_path}")
+    if "wiki" not in data:
+        raise ValueError(f"Hermes config has no wiki section: {config_path}")
+    return WikiConfig.from_dict(data)
+
+
+def _build_config(config_path: str | None) -> WikiConfig:
+    return _load_explicit_wiki_config(config_path) if config_path else WikiConfig.from_hermes_config()
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Draft or queue an LLM Wiki memory proposal")
+    parser.add_argument("--title", required=True, help="Proposal title")
+    parser.add_argument("--rationale", required=True, help="Why this memory should exist")
+    parser.add_argument("--change", action="append", required=True, help="Proposed durable-memory change")
+    parser.add_argument("--source", action="append", required=True, help="Source reference supporting the proposal")
+    parser.add_argument("--target", action="append", default=[], help="Relative wiki page path the proposal may update")
+    parser.add_argument("--tag", action="append", default=[], help="Proposal tag")
+    parser.add_argument("--slug", help="Optional proposal slug")
+    parser.add_argument("--config", help="Hermes config.yaml path to load wiki settings from")
+    parser.add_argument("--queue", action="store_true", help="Write the proposal under <wiki>/proposals")
+    parser.add_argument("--json", action="store_true", help="Emit JSON instead of markdown when not queueing")
+    args = parser.parse_args(argv)
+
+    try:
+        proposal = MemoryProposal(
+            title=args.title,
+            rationale=args.rationale,
+            proposed_changes=args.change,
+            source_refs=args.source,
+            target_pages=args.target,
+            tags=args.tag,
+            slug=args.slug,
+        )
+        if args.queue:
+            if not args.config:
+                raise ValueError("--queue requires explicit --config to avoid writing to the wrong wiki")
+            path = queue_proposal(_build_config(args.config), proposal, write=True)
+            print(json.dumps({"queued": True, "path": str(path)}, sort_keys=True))
+        elif args.json:
+            print(json.dumps(proposal_to_dict(proposal), sort_keys=True))
+        else:
+            print(render_proposal_markdown(proposal), end="")
+    except (FileNotFoundError, ValueError, yaml.YAMLError, OSError) as exc:
+        parser.error(str(exc))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/hermes_wiki/retrieval_introspection.py
+++ b/hermes_wiki/retrieval_introspection.py
@@ -1,0 +1,357 @@
+"""Read-only retrieval introspection for LLM Wiki search results."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Iterable, Protocol
+
+import yaml
+
+from hermes_wiki.config import WikiConfig
+from hermes_wiki.search import WikiSearch
+
+
+class Searcher(Protocol):
+    """Minimal search protocol used by WikiSearch and deterministic test fakes."""
+
+    def search(
+        self,
+        query: str,
+        limit: int = 5,
+        page_type: str | None = None,
+        tags: list[str] | None = None,
+        exclude_sources: bool = False,
+        search_mode: str = "dense",
+    ) -> list[Any]: ...
+
+
+@dataclass(frozen=True)
+class RetrievalHit:
+    """One ranked retrieval hit/chunk."""
+
+    rank: int
+    page_path: str
+    title: str
+    page_type: str
+    chunk_index: int
+    score: float | None
+    tags: list[str] = field(default_factory=list)
+    text_preview: str = ""
+
+
+@dataclass(frozen=True)
+class PageCoverage:
+    """Aggregate view of retrieval hits by page/source path."""
+
+    page_path: str
+    best_rank: int
+    best_score: float | None
+    hit_count: int
+
+
+@dataclass(frozen=True)
+class RetrievalIntrospectionReport:
+    """Agent-readable diagnostics for a single retrieval query."""
+
+    query: str
+    search_mode: str
+    top_k: int
+    hits: list[RetrievalHit]
+    pages: list[PageCoverage]
+    expected_pages: set[str] = field(default_factory=set)
+    missing_expected_pages: set[str] = field(default_factory=set)
+
+    @property
+    def passed_expected_pages(self) -> bool:
+        return not self.missing_expected_pages
+
+
+def _get_attr(result: Any, name: str, default: Any = "") -> Any:
+    if isinstance(result, dict):
+        return result.get(name, default)
+    return getattr(result, name, default)
+
+
+def _clean_preview(text: Any, *, max_chars: int = 200) -> str:
+    cleaned = re.sub(r"\s+", " ", str(text or "")).strip()
+    if len(cleaned) <= max_chars:
+        return cleaned
+    return f"{cleaned[: max_chars - 1].rstrip()}…"
+
+
+def _coerce_score(score: Any) -> float | None:
+    if score is None or score == "":
+        return None
+    try:
+        return float(score)
+    except (TypeError, ValueError):
+        return None
+
+
+def _validate_expected_pages(expected_pages: Iterable[str] | None) -> set[str]:
+    cleaned: set[str] = set()
+    for raw_page in expected_pages or []:
+        page = str(raw_page).strip()
+        if not page:
+            continue
+        candidate = Path(page)
+        if candidate.is_absolute() or ".." in candidate.parts:
+            raise ValueError("expected pages must be relative wiki page paths")
+        cleaned.add(page)
+    return cleaned
+
+
+def _call_searcher(
+    searcher: Searcher,
+    query: str,
+    *,
+    top_k: int,
+    page_type: str | None,
+    exclude_sources: bool,
+    search_mode: str,
+) -> list[Any]:
+    kwargs: dict[str, Any] = {}
+    if page_type:
+        kwargs["page_type"] = page_type
+    if exclude_sources:
+        kwargs["exclude_sources"] = True
+    if search_mode != "dense":
+        kwargs["search_mode"] = search_mode
+    return searcher.search(query, limit=top_k, **kwargs)
+
+
+def introspect_retrieval(
+    searcher: Searcher,
+    query: str,
+    *,
+    top_k: int = 5,
+    expected_pages: Iterable[str] | None = None,
+    page_type: str | None = None,
+    exclude_sources: bool = False,
+    search_mode: str = "dense",
+) -> RetrievalIntrospectionReport:
+    """Run one read-only retrieval query and expose ranked chunk/page diagnostics.
+
+    This helper intentionally performs search only. It does not call an LLM,
+    mutate wiki pages, append logs, ingest sources, reindex, or queue proposals.
+    """
+
+    cleaned_query = str(query or "").strip()
+    if not cleaned_query:
+        raise ValueError("query is required")
+    search_mode = (search_mode or "dense").strip().lower()
+    if search_mode not in {"dense", "sparse", "hybrid"}:
+        raise ValueError("search_mode must be one of: dense, sparse, hybrid")
+    top_k = max(1, int(top_k or 1))
+    expected = _validate_expected_pages(expected_pages)
+
+    raw_hits = _call_searcher(
+        searcher,
+        cleaned_query,
+        top_k=top_k,
+        page_type=page_type,
+        exclude_sources=exclude_sources,
+        search_mode=search_mode,
+    )
+    hits: list[RetrievalHit] = []
+    pages_by_path: dict[str, PageCoverage] = {}
+
+    for index, raw_hit in enumerate(raw_hits, start=1):
+        page_path = str(_get_attr(raw_hit, "page_path", "") or "").strip()
+        if not page_path:
+            continue
+        score = _coerce_score(_get_attr(raw_hit, "score", None))
+        hit = RetrievalHit(
+            rank=index,
+            page_path=page_path,
+            title=str(_get_attr(raw_hit, "title", "") or ""),
+            page_type=str(_get_attr(raw_hit, "page_type", "") or ""),
+            chunk_index=int(_get_attr(raw_hit, "chunk_index", 0) or 0),
+            score=score,
+            tags=list(_get_attr(raw_hit, "tags", []) or []),
+            text_preview=_clean_preview(_get_attr(raw_hit, "text", "")),
+        )
+        hits.append(hit)
+
+        existing = pages_by_path.get(page_path)
+        if existing is None:
+            pages_by_path[page_path] = PageCoverage(
+                page_path=page_path,
+                best_rank=index,
+                best_score=score,
+                hit_count=1,
+            )
+        else:
+            pages_by_path[page_path] = PageCoverage(
+                page_path=existing.page_path,
+                best_rank=existing.best_rank,
+                best_score=existing.best_score,
+                hit_count=existing.hit_count + 1,
+            )
+
+    retrieved_pages = set(pages_by_path)
+    return RetrievalIntrospectionReport(
+        query=cleaned_query,
+        search_mode=search_mode,
+        top_k=top_k,
+        hits=hits,
+        pages=list(pages_by_path.values()),
+        expected_pages=expected,
+        missing_expected_pages=expected - retrieved_pages,
+    )
+
+
+def _score_to_json(score: float | None) -> float | None:
+    if score is None:
+        return None
+    return round(score, 6)
+
+
+def introspection_to_dict(report: RetrievalIntrospectionReport) -> dict[str, Any]:
+    """Convert an introspection report into stable JSON-serializable data."""
+
+    return {
+        "query": report.query,
+        "search_mode": report.search_mode,
+        "top_k": report.top_k,
+        "passed_expected_pages": report.passed_expected_pages,
+        "expected_pages": sorted(report.expected_pages),
+        "missing_expected_pages": sorted(report.missing_expected_pages),
+        "pages": [
+            {
+                "page_path": page.page_path,
+                "best_rank": page.best_rank,
+                "best_score": _score_to_json(page.best_score),
+                "hit_count": page.hit_count,
+            }
+            for page in report.pages
+        ],
+        "hits": [
+            {
+                "rank": hit.rank,
+                "page_path": hit.page_path,
+                "title": hit.title,
+                "page_type": hit.page_type,
+                "chunk_index": hit.chunk_index,
+                "score": _score_to_json(hit.score),
+                "tags": hit.tags,
+                "text_preview": hit.text_preview,
+            }
+            for hit in report.hits
+        ],
+    }
+
+
+def render_introspection_markdown(report: RetrievalIntrospectionReport) -> str:
+    """Render retrieval diagnostics as compact Markdown for agent review."""
+
+    lines = [
+        "# LLM Wiki Retrieval Introspection",
+        "",
+        f"- Query: `{report.query}`",
+        f"- Search mode: `{report.search_mode}`",
+        f"- Top K: `{report.top_k}`",
+    ]
+    if report.expected_pages:
+        status = "✅ Expected page coverage passed" if report.passed_expected_pages else "❌ Expected page coverage failed"
+        lines.append(f"- {status}")
+        lines.append(f"- Expected pages: {', '.join(f'`{p}`' for p in sorted(report.expected_pages))}")
+        if report.missing_expected_pages:
+            lines.append(f"- Missing expected pages: {', '.join(f'`{p}`' for p in sorted(report.missing_expected_pages))}")
+
+    lines.extend([
+        "",
+        "## Page coverage",
+        "",
+        "| Page | Best rank | Best score | Hits |",
+        "| --- | ---: | ---: | ---: |",
+    ])
+    if report.pages:
+        for page in report.pages:
+            score = "" if page.best_score is None else f"{_score_to_json(page.best_score):g}"
+            lines.append(f"| `{page.page_path}` | {page.best_rank} | {score} | {page.hit_count} |")
+    else:
+        lines.append("| _No pages returned_ |  |  |  |")
+
+    lines.extend([
+        "",
+        "## Ranked chunk hits",
+        "",
+        "| Rank | Page | Score | Type | Chunk | Preview |",
+        "| ---: | --- | ---: | --- | ---: | --- |",
+    ])
+    if report.hits:
+        for hit in report.hits:
+            score = "" if hit.score is None else f"{_score_to_json(hit.score):g}"
+            preview = hit.text_preview.replace("|", "\\|")
+            lines.append(
+                f"| {hit.rank} | `{hit.page_path}` | {score} | {hit.page_type} | {hit.chunk_index} | {preview} |"
+            )
+    else:
+        lines.append("|  | _No chunks returned_ |  |  |  |  |")
+
+    return "\n".join(lines)
+
+
+def _load_explicit_wiki_config(config_path: str | Path) -> WikiConfig:
+    path = Path(config_path).expanduser()
+    if not path.exists():
+        raise FileNotFoundError(f"Hermes config not found: {config_path}")
+    data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    if not isinstance(data, dict):
+        raise ValueError(f"Hermes config must be a mapping: {config_path}")
+    if "wiki" not in data:
+        raise ValueError(f"Hermes config has no wiki section: {config_path}")
+    return WikiConfig.from_dict(data)
+
+
+def _build_searcher(config_path: str | None) -> Searcher:
+    config = _load_explicit_wiki_config(config_path) if config_path is not None else WikiConfig.from_hermes_config()
+    return WikiSearch(config, ensure_collection=False)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run read-only retrieval introspection from the command line."""
+
+    parser = argparse.ArgumentParser(description="Inspect LLM Wiki retrieval hits for one query")
+    parser.add_argument("query", help="Question/search query to inspect")
+    parser.add_argument("--config", help="Hermes config.yaml path to load wiki settings from")
+    parser.add_argument("--top-k", type=int, default=5, help="Number of chunk hits to retrieve")
+    parser.add_argument("--expected-page", action="append", default=[], help="Expected wiki page path; repeatable")
+    parser.add_argument("--page-type", help="Optional page_type filter")
+    parser.add_argument("--exclude-sources", action="store_true", help="Exclude raw source chunks from search results")
+    parser.add_argument(
+        "--search-mode",
+        choices=["dense", "sparse", "hybrid"],
+        default="dense",
+        help="Retrieval mode to inspect; default preserves dense semantic search",
+    )
+    parser.add_argument("--json", action="store_true", help="Emit JSON instead of Markdown")
+    args = parser.parse_args(argv)
+
+    try:
+        report = introspect_retrieval(
+            _build_searcher(args.config),
+            args.query,
+            top_k=args.top_k,
+            expected_pages=args.expected_page,
+            page_type=args.page_type,
+            exclude_sources=args.exclude_sources,
+            search_mode=args.search_mode,
+        )
+    except (FileNotFoundError, ValueError, json.JSONDecodeError, yaml.YAMLError) as exc:
+        parser.error(str(exc))
+
+    if args.json:
+        print(json.dumps(introspection_to_dict(report), sort_keys=True))
+    else:
+        print(render_introspection_markdown(report))
+    return 0 if report.passed_expected_pages else 1
+
+
+if __name__ == "__main__":  # pragma: no cover - exercised via subprocess/CLI use
+    raise SystemExit(main())

--- a/hermes_wiki/search.py
+++ b/hermes_wiki/search.py
@@ -1,0 +1,729 @@
+from __future__ import annotations
+
+import asyncio
+import concurrent.futures
+import hashlib
+import logging
+import re
+import threading
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+from hermes_wiki.config import WikiConfig
+from hermes_wiki.frontmatter import chunk_markdown, parse_frontmatter
+
+logger = logging.getLogger(__name__)
+
+_TOKEN_RE = re.compile(r"[A-Za-z0-9_]+")
+
+
+def tokenize_for_sparse_search(text: str) -> list[str]:
+    """Tokenize text for deterministic lexical/sparse-style matching.
+
+    The tokenizer intentionally keeps underscores inside tokens for config keys
+    while splitting paths, hyphenated model names, and dotted versions into
+    searchable literal parts.
+    """
+
+    return [token.lower() for token in _TOKEN_RE.findall(text or "")]
+
+
+def _result_key(result: WikiSearchResult) -> tuple[str, int]:
+    return (result.page_path, result.chunk_index)
+
+
+def reciprocal_rank_fusion(
+    ranked_lists: list[list[WikiSearchResult]],
+    *,
+    limit: int,
+    k: int = 60,
+) -> list[WikiSearchResult]:
+    """Fuse multiple ranked result lists using Reciprocal Rank Fusion."""
+
+    fused_scores: dict[tuple[str, int], float] = {}
+    representatives: dict[tuple[str, int], WikiSearchResult] = {}
+    best_rank: dict[tuple[str, int], int] = {}
+
+    for ranked in ranked_lists:
+        for rank, result in enumerate(ranked, start=1):
+            key = _result_key(result)
+            fused_scores[key] = fused_scores.get(key, 0.0) + 1.0 / (k + rank)
+            representatives.setdefault(key, result)
+            best_rank[key] = min(best_rank.get(key, rank), rank)
+
+    ordered_keys = sorted(
+        fused_scores,
+        key=lambda key: (-fused_scores[key], best_rank[key], representatives[key].page_path, representatives[key].chunk_index),
+    )
+    fused: list[WikiSearchResult] = []
+    for key in ordered_keys[: max(1, int(limit or 1))]:
+        base = representatives[key]
+        fused.append(
+            WikiSearchResult(
+                page_path=base.page_path,
+                title=base.title,
+                page_type=base.page_type,
+                chunk_index=base.chunk_index,
+                text=base.text,
+                score=fused_scores[key],
+                tags=base.tags,
+            )
+        )
+    return fused
+
+
+class _VectorCoreAsyncBridge:
+    """Dedicated event-loop thread for vector-core async clients used synchronously."""
+
+    def __init__(self) -> None:
+        self._loop = asyncio.new_event_loop()
+        self._thread = threading.Thread(target=self._run_loop, name="llm-wiki-vector-core", daemon=True)
+        self._thread.start()
+        self._closed = False
+
+    def _run_loop(self) -> None:
+        asyncio.set_event_loop(self._loop)
+        self._loop.run_forever()
+
+    def run(self, coro):
+        if self._closed:
+            raise RuntimeError("vector-core async bridge is closed")
+        future = asyncio.run_coroutine_threadsafe(coro, self._loop)
+        return future.result()
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        self._loop.call_soon_threadsafe(self._loop.stop)
+        self._thread.join(timeout=5.0)
+        self._loop.close()
+
+
+def _run_vector_core_async(coro):
+    """Run a vector-core coroutine for tests/one-shot utility code."""
+
+    bridge = _VectorCoreAsyncBridge()
+    try:
+        return bridge.run(coro)
+    finally:
+        bridge.close()
+
+
+class WikiSearchDependencyError(RuntimeError):
+    """Raised when optional LLM Wiki search dependencies are missing."""
+
+
+class EmbeddingCache:
+    """Hermes adapter around vector-core's persistent embedding cache.
+
+    vector-core keys cache rows by a caller-provided content hash. Hermes folds
+    model and dimension into that hash so cache rows cannot leak across
+    embedding model migrations while still using vector-core's SQLite/WAL,
+    JSON serialization, corruption handling, stats, and LRU behavior.
+    """
+
+    def __init__(self, cache_path: Path | str, *, max_entries: int = 100000):
+        try:
+            from vector_core.embeddings import EmbeddingCache as VectorCoreEmbeddingCache
+        except Exception as exc:  # pragma: no cover - dependency guard
+            raise WikiSearchDependencyError(
+                "vector-core is required for LLM Wiki embeddings; install hermes-agent[llm-wiki]"
+            ) from exc
+
+        self._vector_cache = VectorCoreEmbeddingCache(
+            Path(cache_path).expanduser(),
+            max_entries=max(1, int(max_entries or 1)),
+        )
+        self._ensure_vector_core_schema()
+
+    @property
+    def cache_path(self) -> Path:
+        return Path(self._vector_cache.cache_path)
+
+    @staticmethod
+    def key_for(text: str, *, model: str, dim: int) -> str:
+        payload = f"{model}\0{int(dim)}\0{text or ''}"
+        return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+    def _ensure_vector_core_schema(self) -> None:
+        """Drop the old Hermes-local cache schema if this profile already created it."""
+
+        conn = self._vector_cache._get_conn()
+        rows = conn.execute("PRAGMA table_info(embeddings)").fetchall()
+        columns = {row[1] for row in rows}
+        if rows and "content_hash" not in columns:
+            conn.execute("DROP TABLE embeddings")
+            conn.commit()
+            self._vector_cache._init_db()
+
+    def get(self, cache_key: str) -> list[float] | None:
+        return self._vector_cache.get(cache_key)
+
+    def set(self, cache_key: str, embedding: list[float], *, model: str, dim: int) -> None:
+        # The namespaced cache_key already includes model+dim. model is still
+        # passed through for vector-core metadata and operator inspection.
+        self._vector_cache.set(cache_key, embedding, model=model)
+
+    def stats(self) -> dict[str, float | int]:
+        return self._vector_cache.stats()
+
+    def close(self) -> None:
+        self._vector_cache.close()
+
+
+class _EmbeddingClient:
+    """Synchronous wrapper around vector-core's OpenAI-compatible embedding client."""
+
+    def __init__(self, config: WikiConfig, *, cache_enabled: bool = True):
+        try:
+            from vector_core.embeddings import EmbeddingClient as VectorCoreEmbeddingClient
+        except Exception as exc:  # pragma: no cover - dependency guard
+            raise WikiSearchDependencyError(
+                "vector-core is required for LLM Wiki embeddings; install hermes-agent[llm-wiki]"
+            ) from exc
+
+        base_url = config.embedding_url.rstrip("/")
+        if base_url.endswith("/v1"):
+            base_url = base_url[: -len("/v1")]
+        self._client = VectorCoreEmbeddingClient(
+            base_url=base_url,
+            model=config.embedding_model,
+            dim=config.embedding_dim,
+            timeout=60.0,
+        )
+        self._bridge = _VectorCoreAsyncBridge()
+        self._model = config.embedding_model
+        self._dim = config.embedding_dim
+        self._cache: EmbeddingCache | None = None
+        if cache_enabled:
+            cache_path = config.embedding_cache_path or (config.wiki_path / ".cache" / "embeddings.sqlite3")
+            self._cache = EmbeddingCache(cache_path, max_entries=config.embedding_cache_max_entries)
+
+    def embed_batch(self, texts: list[str]) -> list[list[float]]:
+        if not texts:
+            return []
+
+        results: list[list[float] | None] = [None] * len(texts)
+        missing_texts: list[str] = []
+        missing_keys: list[str] = []
+        missing_positions: dict[str, list[int]] = {}
+
+        for position, text in enumerate(texts):
+            cache_key = EmbeddingCache.key_for(text, model=self._model, dim=self._dim)
+            if self._cache is not None:
+                cached = self._cache.get(cache_key)
+                if cached is not None:
+                    results[position] = cached
+                    continue
+            if cache_key not in missing_positions:
+                missing_texts.append(text)
+                missing_keys.append(cache_key)
+                missing_positions[cache_key] = []
+            missing_positions[cache_key].append(position)
+
+        if missing_texts:
+            vectors = [self._normalize_dim(list(vector)) for vector in self._bridge.run(self._client.embed_batch(missing_texts))]
+            for cache_key, vector in zip(missing_keys, vectors):
+                if self._cache is not None:
+                    self._cache.set(cache_key, vector, model=self._model, dim=self._dim)
+                for position in missing_positions[cache_key]:
+                    results[position] = vector
+
+        return [vector if vector is not None else [] for vector in results]
+
+    def embed_single(self, text: str) -> list[float]:
+        return self.embed_batch([text])[0]
+
+    def _normalize_dim(self, vector: list[float]) -> list[float]:
+        if len(vector) == self._dim:
+            return vector
+        if len(vector) > self._dim:
+            return vector[: self._dim]
+        return vector + [0.0] * (self._dim - len(vector))
+
+    def close(self) -> None:
+        if self._cache is not None:
+            self._cache.close()
+        close = getattr(self._client, "close", None)
+        if close:
+            self._bridge.run(close())
+        self._bridge.close()
+
+
+class WikiSearch:
+    """Semantic search over wiki pages using Qdrant and OpenAI-compatible embeddings."""
+
+    def __init__(self, config: WikiConfig, *, ensure_collection: bool = True, read_only: bool = False):
+        self.config = config
+        self.read_only = read_only
+        try:
+            from qdrant_client import QdrantClient, models
+        except Exception as exc:  # pragma: no cover - dependency guard
+            raise WikiSearchDependencyError(
+                "qdrant-client is required for LLM Wiki vector search; install hermes-agent[llm-wiki]"
+            ) from exc
+
+        self._models = models
+        self._client = QdrantClient(url=config.qdrant_url)
+        self._embedder = _EmbeddingClient(config, cache_enabled=not read_only)
+        if ensure_collection:
+            self._ensure_collection()
+
+    def _ensure_collection(self) -> None:
+        models = self._models
+        try:
+            self._client.get_collection(self.config.collection_name)
+        except Exception:
+            self._client.create_collection(
+                collection_name=self.config.collection_name,
+                vectors_config={
+                    "dense": models.VectorParams(
+                        size=self.config.embedding_dim,
+                        distance=models.Distance.COSINE,
+                    )
+                },
+                sparse_vectors_config={"sparse": models.SparseVectorParams()},
+            )
+
+        for field in ["page_path", "page_type", "tags"]:
+            try:
+                self._client.create_payload_index(
+                    collection_name=self.config.collection_name,
+                    field_name=field,
+                    field_schema=models.PayloadSchemaType.KEYWORD,
+                )
+            except Exception:
+                # Existing indexes and older Qdrant versions are both safe to ignore.
+                pass
+
+    def index_page(self, page_path: Path) -> int:
+        """Index a single wiki page. Returns number of chunks indexed."""
+        if not page_path.exists():
+            return 0
+
+        text = page_path.read_text(encoding="utf-8")
+        fm, body = parse_frontmatter(text)
+        if not body.strip():
+            return 0
+
+        rel_path = str(page_path.relative_to(self.config.wiki_path))
+
+        title = fm.get("title", page_path.stem)
+        page_type = fm.get("type", "unknown")
+        tags = fm.get("tags", [])
+        updated = str(fm.get("updated", ""))
+
+        chunks = chunk_markdown(body, max_tokens=self.config.chunk_max_tokens)
+        if not chunks:
+            return 0
+
+        vectors = self._embedder.embed_batch(chunks)
+        points = []
+        for i, (chunk, vector) in enumerate(zip(chunks, vectors)):
+            points.append(self._point(
+                point_id=self._chunk_id(rel_path, i),
+                vector=vector,
+                payload={
+                    "page_path": rel_path,
+                    "page_type": page_type,
+                    "title": title,
+                    "tags": tags if isinstance(tags, list) else [tags],
+                    "updated": updated,
+                    "chunk_index": i,
+                    "text": chunk[:2000],
+                },
+            ))
+
+        self._client.upsert(self.config.collection_name, points=points)
+        self._delete_stale_page_chunks(rel_path, keep_chunks=len(points))
+        logger.info("Indexed %d chunks from %s", len(chunks), rel_path)
+        return len(chunks)
+
+    def index_source(self, source_path: Path) -> int:
+        """Index a raw source file. Returns number of chunks indexed."""
+        if not source_path.exists():
+            return 0
+
+        text = source_path.read_text(encoding="utf-8")
+        fm, body = parse_frontmatter(text)
+        if not body.strip():
+            return 0
+
+        rel_path = str(source_path.relative_to(self.config.wiki_path))
+
+        chunks = chunk_markdown(body, max_tokens=self.config.chunk_max_tokens)
+        if not chunks:
+            return 0
+
+        vectors = self._embedder.embed_batch(chunks)
+        points = []
+        for i, (chunk, vector) in enumerate(zip(chunks, vectors)):
+            points.append(self._point(
+                point_id=self._chunk_id(rel_path, i),
+                vector=vector,
+                payload={
+                    "page_path": rel_path,
+                    "page_type": "source",
+                    "title": source_path.stem,
+                    "tags": [],
+                    "updated": str(fm.get("ingested", "")),
+                    "chunk_index": i,
+                    "text": chunk[:2000],
+                },
+            ))
+
+        self._client.upsert(self.config.collection_name, points=points)
+        self._delete_stale_page_chunks(rel_path, keep_chunks=len(points))
+        logger.info("Indexed %d source chunks from %s", len(chunks), rel_path)
+        return len(chunks)
+
+    def _point(self, point_id: str, vector: list[float], payload: dict[str, Any]):
+        models = self._models
+        return models.PointStruct(
+            id=point_id,
+            vector={"dense": vector, "sparse": models.SparseVector(indices=[], values=[])},
+            payload=payload,
+        )
+
+    def search(
+        self,
+        query: str,
+        limit: int = 10,
+        page_type: str | None = None,
+        tags: list[str] | None = None,
+        exclude_sources: bool = False,
+        search_mode: str = "dense",
+    ) -> list[WikiSearchResult]:
+        """Search across the wiki.
+
+        Modes:
+        - dense: semantic vector search (default for backward compatibility)
+        - sparse: deterministic lexical search over indexed payload text
+        - hybrid: dense + sparse fused with Reciprocal Rank Fusion
+        """
+
+        mode = (search_mode or "dense").strip().lower()
+        if mode == "dense":
+            return self._dense_search(
+                query,
+                limit=limit,
+                page_type=page_type,
+                tags=tags,
+                exclude_sources=exclude_sources,
+            )
+        if mode == "sparse":
+            return self.sparse_search(
+                query,
+                limit=limit,
+                page_type=page_type,
+                tags=tags,
+                exclude_sources=exclude_sources,
+            )
+        if mode == "hybrid":
+            dense_results = self._dense_search(
+                query,
+                limit=max(limit * 2, limit),
+                page_type=page_type,
+                tags=tags,
+                exclude_sources=exclude_sources,
+            )
+            sparse_results = self.sparse_search(
+                query,
+                limit=max(limit * 2, limit),
+                page_type=page_type,
+                tags=tags,
+                exclude_sources=exclude_sources,
+            )
+            return reciprocal_rank_fusion([dense_results, sparse_results], limit=limit)
+        raise ValueError("search_mode must be one of: dense, sparse, hybrid")
+
+    def _dense_search(
+        self,
+        query: str,
+        *,
+        limit: int,
+        page_type: str | None = None,
+        tags: list[str] | None = None,
+        exclude_sources: bool = False,
+    ) -> list[WikiSearchResult]:
+        """Semantic search across the wiki."""
+        query_vector = self._embedder.embed_single(query)
+        models = self._models
+
+        filter_conditions = []
+        if page_type:
+            filter_conditions.append(models.FieldCondition(key="page_type", match=models.MatchValue(value=page_type)))
+        if tags:
+            for tag in tags:
+                filter_conditions.append(models.FieldCondition(key="tags", match=models.MatchValue(value=tag)))
+
+        response = self._client.query_points(
+            collection_name=self.config.collection_name,
+            query=query_vector,
+            using="dense",
+            query_filter=models.Filter(must=filter_conditions) if filter_conditions else None,
+            limit=limit * 2 if exclude_sources else limit,
+            with_payload=True,
+        )
+        hits = response.points
+
+        results = []
+        for h in hits:
+            payload = h.payload or {}
+            if exclude_sources and payload.get("page_type") == "source":
+                continue
+            results.append(WikiSearchResult(
+                page_path=payload.get("page_path", ""),
+                title=payload.get("title", ""),
+                page_type=payload.get("page_type", ""),
+                chunk_index=payload.get("chunk_index", 0),
+                text=payload.get("text", ""),
+                score=h.score,
+                tags=payload.get("tags", []),
+            ))
+
+        return results[:limit]
+
+    def sparse_search(
+        self,
+        query: str,
+        limit: int = 10,
+        page_type: str | None = None,
+        tags: list[str] | None = None,
+        exclude_sources: bool = False,
+    ) -> list[WikiSearchResult]:
+        """Deterministic lexical search over indexed payloads.
+
+        This is a local sparse-style ranker over Qdrant payload text. It improves
+        recall for literal names, IDs, commands, config keys, and file paths
+        without adding another dependency or mutating the vector collection.
+        """
+
+        query_terms = Counter(tokenize_for_sparse_search(query))
+        if not query_terms:
+            return []
+
+        results: list[WikiSearchResult] = []
+        offset = None
+        while True:
+            try:
+                points, next_offset = self._client.scroll(
+                    collection_name=self.config.collection_name,
+                    limit=256,
+                    offset=offset,
+                    with_payload=True,
+                    with_vectors=False,
+                )
+            except Exception as exc:
+                logger.warning("Could not run sparse wiki search: %s", exc)
+                return results[:limit]
+
+            for point in points:
+                payload = getattr(point, "payload", None) or {}
+                if not self._payload_matches_filters(
+                    payload,
+                    page_type=page_type,
+                    tags=tags,
+                    exclude_sources=exclude_sources,
+                ):
+                    continue
+                score = self._lexical_score(query_terms, payload)
+                if score <= 0:
+                    continue
+                results.append(
+                    WikiSearchResult(
+                        page_path=str(payload.get("page_path", "")),
+                        title=str(payload.get("title", "")),
+                        page_type=str(payload.get("page_type", "")),
+                        chunk_index=int(payload.get("chunk_index", 0) or 0),
+                        text=str(payload.get("text", "")),
+                        score=score,
+                        tags=list(payload.get("tags", []) or []),
+                    )
+                )
+
+            if next_offset is None:
+                break
+            offset = next_offset
+
+        results.sort(key=lambda item: (-float(item.score or 0.0), item.page_path, item.chunk_index))
+        return results[: max(1, int(limit or 1))]
+
+    def _payload_matches_filters(
+        self,
+        payload: dict[str, Any],
+        *,
+        page_type: str | None,
+        tags: list[str] | None,
+        exclude_sources: bool,
+    ) -> bool:
+        if exclude_sources and payload.get("page_type") == "source":
+            return False
+        if page_type and payload.get("page_type") != page_type:
+            return False
+        if tags:
+            payload_tags = set(payload.get("tags", []) or [])
+            if not all(tag in payload_tags for tag in tags):
+                return False
+        return bool(payload.get("page_path"))
+
+    def _lexical_score(self, query_terms: Counter[str], payload: dict[str, Any]) -> float:
+        tags = payload.get("tags", []) or []
+        weighted_text = " ".join(
+            [
+                str(payload.get("title", "")),
+                str(payload.get("title", "")),
+                str(payload.get("page_path", "")),
+                " ".join(str(tag) for tag in tags),
+                " ".join(str(tag) for tag in tags),
+                str(payload.get("text", "")),
+            ]
+        )
+        doc_terms = Counter(tokenize_for_sparse_search(weighted_text))
+        score = 0.0
+        for term, query_count in query_terms.items():
+            count = doc_terms.get(term, 0)
+            if count:
+                score += min(count, 5) * query_count
+        return score / max(1, sum(query_terms.values()))
+
+    def reindex_all(self) -> dict[str, int]:
+        """Re-index all wiki pages and sources without dropping the collection first."""
+        self._ensure_collection()
+        old_paths = self._existing_indexed_paths()
+        seen_paths: set[str] = set()
+
+        counts = {"pages": 0, "sources": 0, "chunks": 0}
+
+        for subdir in ["entities", "concepts", "comparisons", "queries"]:
+            dir_path = self.config.wiki_path / subdir
+            if dir_path.exists():
+                for md_file in sorted(dir_path.glob("*.md")):
+                    n = self.index_page(md_file)
+                    counts["pages"] += 1
+                    counts["chunks"] += n
+                    seen_paths.add(str(md_file.relative_to(self.config.wiki_path)))
+
+        for source_subdir in ["articles", "papers", "transcripts"]:
+            dir_path = self.config.raw_dir / source_subdir
+            if dir_path.exists():
+                for md_file in sorted(dir_path.glob("*.md")):
+                    n = self.index_source(md_file)
+                    counts["sources"] += 1
+                    counts["chunks"] += n
+                    seen_paths.add(str(md_file.relative_to(self.config.wiki_path)))
+
+        for stale_path in sorted(old_paths - seen_paths):
+            self._delete_page_chunks(stale_path)
+
+        logger.info(
+            "Full reindex: %d pages, %d sources, %d chunks",
+            counts["pages"], counts["sources"], counts["chunks"],
+        )
+        return counts
+
+    def _existing_indexed_paths(self) -> set[str]:
+        """Return page/source paths already present in the vector collection."""
+        paths: set[str] = set()
+        offset = None
+        while True:
+            try:
+                points, next_offset = self._client.scroll(
+                    collection_name=self.config.collection_name,
+                    limit=256,
+                    offset=offset,
+                    with_payload=True,
+                    with_vectors=False,
+                )
+            except Exception as exc:
+                logger.warning("Could not list existing wiki index paths: %s", exc)
+                return paths
+            for point in points:
+                payload = getattr(point, "payload", None) or {}
+                page_path = payload.get("page_path")
+                if isinstance(page_path, str) and page_path:
+                    paths.add(page_path)
+            if next_offset is None:
+                return paths
+            offset = next_offset
+
+    def collection_stats(self) -> dict:
+        """Get stats about the vector collection."""
+        try:
+            info = self._client.get_collection(collection_name=self.config.collection_name)
+            return {"collection": self.config.collection_name, "points": info.points_count}
+        except Exception:
+            return {"collection": self.config.collection_name, "points": 0}
+
+    def _delete_page_chunks(self, rel_path: str) -> None:
+        models = self._models
+        try:
+            self._client.delete(
+                collection_name=self.config.collection_name,
+                points_selector=models.FilterSelector(
+                    filter=models.Filter(
+                        must=[models.FieldCondition(key="page_path", match=models.MatchValue(value=rel_path))]
+                    )
+                ),
+            )
+        except Exception as e:
+            logger.warning("Could not delete chunks for %s: %s", rel_path, e)
+
+    def _delete_stale_page_chunks(self, rel_path: str, keep_chunks: int) -> None:
+        """Delete old chunks beyond the freshly upserted chunk range for a page."""
+        models = self._models
+        try:
+            self._client.delete(
+                collection_name=self.config.collection_name,
+                points_selector=models.FilterSelector(
+                    filter=models.Filter(
+                        must=[
+                            models.FieldCondition(key="page_path", match=models.MatchValue(value=rel_path)),
+                            models.FieldCondition(key="chunk_index", range=models.Range(gte=keep_chunks)),
+                        ]
+                    )
+                ),
+            )
+        except Exception as e:
+            logger.warning("Could not delete stale chunks for %s: %s", rel_path, e)
+
+    def _chunk_id(self, page_path: str, chunk_index: int) -> str:
+        """Generate a deterministic UUID-format ID for a chunk."""
+        raw = f"{page_path}::{chunk_index}"
+        h = hashlib.sha256(raw.encode()).hexdigest()
+        return f"{h[:8]}-{h[8:12]}-{h[12:16]}-{h[16:20]}-{h[20:32]}"
+
+    def close(self) -> None:
+        self._embedder.close()
+        close = getattr(self._client, "close", None)
+        if close:
+            close()
+
+
+class WikiSearchResult:
+    """A search result from the wiki vector store."""
+
+    __slots__ = ("page_path", "title", "page_type", "chunk_index", "text", "score", "tags")
+
+    def __init__(
+        self,
+        page_path: str,
+        title: str,
+        page_type: str,
+        chunk_index: int,
+        text: str,
+        score: float,
+        tags: list[str],
+    ):
+        self.page_path = page_path
+        self.title = title
+        self.page_type = page_type
+        self.chunk_index = chunk_index
+        self.text = text
+        self.score = score
+        self.tags = tags
+
+    def __repr__(self) -> str:
+        return f"WikiSearchResult({self.title!r}, score={self.score:.3f}, type={self.page_type})"

--- a/optional-skills/autonomous-ai-agents/honcho/SKILL.md
+++ b/optional-skills/autonomous-ai-agents/honcho/SKILL.md
@@ -181,7 +181,7 @@ If `dialecticDepthLevels` is omitted, rounds use **proportional levels** derived
 
 This keeps earlier passes cheap while using full depth on the final synthesis.
 
-**Depth at session start.** The session-start prewarm runs the full configured `dialecticDepth` in the background before turn 1. A single-pass prewarm on a cold peer often returns thin output — multi-pass depth runs the audit/reconcile cycle before the user ever speaks. Turn 1 consumes the prewarm result directly; if prewarm hasn't landed in time, turn 1 falls back to a synchronous call with a bounded timeout.
+**Depth at session start.** The session-start prewarm runs the full configured `dialecticDepth` in the background before turn 1. A single-pass prewarm on a cold peer often returns thin output — multi-pass depth runs the audit/reconcile cycle before the user ever speaks. Turn 1 consumes the prewarm result directly if it has landed; if prewarm hasn't landed in time, turn 1 queues an async recovery prefetch without imposing a Hermes-side timeout, and the result is picked up when it naturally completes.
 
 ### Level (how hard)
 

--- a/plugins/memory/honcho/__init__.py
+++ b/plugins/memory/honcho/__init__.py
@@ -191,6 +191,37 @@ ALL_TOOL_SCHEMAS = [PROFILE_SCHEMA, SEARCH_SCHEMA, REASONING_SCHEMA, CONTEXT_SCH
 class HonchoMemoryProvider(MemoryProvider):
     """Honcho AI-native memory with dialectic Q&A and persistent user modeling."""
 
+    # Auto-injected Honcho context must be a high-signal briefing, not a raw
+    # observation dump. Event lines like "user sent '[scorch]'" are useful for
+    # diagnostics via honcho_context(), but when injected into the prompt they
+    # are easy for the model to misattribute as current user discourse.
+    _MAX_SUMMARY_CHARS = 1800
+    _MAX_REPRESENTATION_LINES = 48
+    _MAX_CARD_LINES = 32
+    _MAX_AI_LINES = 24
+    _MAX_SECTION_CHARS = 4200
+    _MAX_CLAIM_CHARS = 420
+    _EPHEMERAL_OBSERVATION_RE = re.compile(
+        r"^\[\d{4}-\d{2}-\d{2}[^\]]*\]\s+On\s+.+?\b(?:"
+        r"sent(?:\s+(?:a|the)\s+message|\s+the\s+text|\s+a\s+message)?|"
+        r"said|told|asked|ran|restarted|waited|pasted|provided|shared|"
+        r"looked like|continued|uploaded|clicked|typed"
+        r")\b",
+        re.IGNORECASE,
+    )
+    _LOW_VALUE_OBSERVATION_RE = re.compile(
+        r"\b(?:system note|previous turn|gateway restart|conversation history below|"
+        r"message with no text content|sent the text\s+\"?\[scorch\]|"
+        r"containing a system note|interrupted by a gateway restart|"
+        r"explicit observations?|message event|turn event)\b",
+        re.IGNORECASE,
+    )
+    _LOW_CONFIDENCE_OBSERVATION_RE = re.compile(
+        r"\b(?:likely|probably|appears? to|seems? to|may be|might be|"
+        r"could be|inferred|suggests?|indicates? that .* may)\b",
+        re.IGNORECASE,
+    )
+
     def __init__(self):
         self._manager = None   # HonchoSessionManager
         self._config = None    # HonchoClientConfig
@@ -472,27 +503,139 @@ class HonchoMemoryProvider(MemoryProvider):
         # Session summary — session-scoped context, placed first for relevance
         summary = ctx.get("summary", "")
         if summary:
-            parts.append(f"## Session Summary\n{summary}")
+            summary = self._clip_text(str(summary), self._MAX_SUMMARY_CHARS)
+            if summary:
+                parts.append(f"## Session Summary\n{summary}")
 
         rep = ctx.get("representation", "")
         if rep:
-            parts.append(f"## User Representation\n{rep}")
+            rep = self._clean_injected_section(
+                str(rep), max_lines=self._MAX_REPRESENTATION_LINES
+            )
+            if rep:
+                parts.append(f"## User Representation\n{rep}")
 
         card = ctx.get("card", "")
         if card:
-            parts.append(f"## User Peer Card\n{card}")
+            card = self._clean_injected_section(str(card), max_lines=self._MAX_CARD_LINES)
+            if card:
+                parts.append(f"## User Peer Card\n{card}")
 
         ai_rep = ctx.get("ai_representation", "")
         if ai_rep:
-            parts.append(f"## AI Self-Representation\n{ai_rep}")
+            ai_rep = self._clean_injected_section(
+                str(ai_rep), max_lines=self._MAX_AI_LINES
+            )
+            if ai_rep:
+                parts.append(f"## AI Self-Representation\n{ai_rep}")
 
         ai_card = ctx.get("ai_card", "")
         if ai_card:
-            parts.append(f"## AI Identity Card\n{ai_card}")
+            ai_card = self._clean_injected_section(
+                str(ai_card), max_lines=self._MAX_AI_LINES
+            )
+            if ai_card:
+                parts.append(f"## AI Identity Card\n{ai_card}")
 
         if not parts:
             return ""
         return "\n\n".join(parts)
+
+    @classmethod
+    def _clean_injected_section(cls, text: str, *, max_lines: int) -> str:
+        """Deduplicate and filter Honcho text before automatic prompt injection.
+
+        This is intentionally conservative and only applies to auto-injected
+        prompt context. Tool calls like honcho_context()/honcho_search() still
+        expose raw Honcho output for debugging and cleanup.
+        """
+        lines: list[str] = []
+        seen: set[str] = set()
+        skipped = 0
+        emitted_chars = 0
+
+        for claim in cls._iter_injected_claims(text):
+            if cls._should_drop_injected_line(claim):
+                skipped += 1
+                continue
+            claim = cls._clip_text(claim, cls._MAX_CLAIM_CHARS)
+            if not claim:
+                continue
+            key = cls._dedupe_key(claim)
+            if key in seen:
+                skipped += 1
+                continue
+            next_chars = emitted_chars + len(claim) + (1 if lines else 0)
+            if next_chars > cls._MAX_SECTION_CHARS:
+                skipped += 1
+                break
+            seen.add(key)
+            lines.append(claim)
+            emitted_chars = next_chars
+            if len(lines) >= max_lines:
+                break
+
+        if skipped:
+            logger.debug(
+                "Honcho injected context filtered %d low-value/duplicate claims", skipped
+            )
+        return "\n".join(lines)
+
+    @classmethod
+    def _iter_injected_claims(cls, text: str):
+        """Yield Honcho claims even when the backend returns one giant line.
+
+        Honcho context sometimes arrives as a paragraph containing many timestamped
+        observations. Line-only filtering misses that shape, so split at timestamp
+        boundaries and, for still-long chunks, sentence boundaries.
+        """
+        for raw_line in (text or "").splitlines():
+            line = raw_line.strip()
+            if not line:
+                continue
+            expanded = re.sub(
+                r"\s+(?=\[\d{4}-\d{2}-\d{2}[^\]]*\]\s+)", "\n", line
+            )
+            for chunk in expanded.splitlines():
+                chunk = chunk.strip()
+                if not chunk:
+                    continue
+                if len(chunk) <= cls._MAX_CLAIM_CHARS * 2:
+                    yield chunk
+                    continue
+                for sentence in re.split(r"(?<=[.!?])\s+", chunk):
+                    sentence = sentence.strip()
+                    if sentence:
+                        yield sentence
+
+    @classmethod
+    def _should_drop_injected_line(cls, line: str) -> bool:
+        if cls._LOW_VALUE_OBSERVATION_RE.search(line):
+            return True
+        if cls._LOW_CONFIDENCE_OBSERVATION_RE.search(line):
+            return True
+        if cls._EPHEMERAL_OBSERVATION_RE.search(line):
+            return True
+        return False
+
+    @staticmethod
+    def _dedupe_key(line: str) -> str:
+        key = re.sub(r"^\[\d{4}-\d{2}-\d{2}[^\]]*\]\s+", "", line)
+        key = re.sub(r"^On\s+.+?\bat\s+\d{1,2}:\d{2}:\d{2},\s+", "", key, flags=re.IGNORECASE)
+        key = re.sub(r"\b\d{15,20}\b", "<id>", key)
+        key = re.sub(r"\s+", " ", key).strip().lower()
+        return key
+
+    @staticmethod
+    def _clip_text(text: str, max_chars: int) -> str:
+        text = (text or "").strip()
+        if not text or max_chars <= 0 or len(text) <= max_chars:
+            return text
+        clipped = text[:max_chars]
+        boundary = max(clipped.rfind("\n"), clipped.rfind(". "), clipped.rfind(" "))
+        if boundary > max_chars * 0.75:
+            clipped = clipped[:boundary]
+        return clipped.rstrip() + " …"
 
     def system_prompt_block(self) -> str:
         """Return system prompt text, adapted by recall_mode.

--- a/plugins/memory/honcho/__init__.py
+++ b/plugins/memory/honcho/__init__.py
@@ -603,10 +603,9 @@ class HonchoMemoryProvider(MemoryProvider):
 
         # ----- Layer 2: Dialectic supplement -----
         # On the very first turn, no queue_prefetch() has run yet so the
-        # dialectic result is empty.  Run with a bounded timeout so a slow
-        # Honcho connection doesn't block the first response indefinitely.
-        # On timeout we let the thread keep running and write its result into
-        # _prefetch_result under the lock, so the next turn picks it up.
+        # dialectic result is empty. Fire a background prefetch without any
+        # timeout-based wait; if it lands before we read below it can surface
+        # immediately, otherwise the next turn picks it up.
         #
         # Skip if the session-start prewarm already filled _prefetch_result —
         # firing another .chat() would be duplicate work.
@@ -616,9 +615,6 @@ class HonchoMemoryProvider(MemoryProvider):
             self._last_dialectic_turn = self._turn_count
 
         if self._last_dialectic_turn == -999 and query:
-            _first_turn_timeout = (
-                self._config.timeout if self._config and self._config.timeout else 8.0
-            )
             _fired_at = self._turn_count
 
             def _run_first_turn() -> None:
@@ -644,16 +640,7 @@ class HonchoMemoryProvider(MemoryProvider):
                 target=_run_first_turn, daemon=True, name="honcho-prefetch-first"
             )
             self._prefetch_thread.start()
-            self._prefetch_thread.join(timeout=_first_turn_timeout)
-            if self._prefetch_thread.is_alive():
-                logger.debug(
-                    "Honcho first-turn dialectic still running after %.1fs — "
-                    "will surface on next turn",
-                    _first_turn_timeout,
-                )
 
-        if self._prefetch_thread and self._prefetch_thread.is_alive():
-            self._prefetch_thread.join(timeout=3.0)
         with self._prefetch_lock:
             dialectic_result = self._prefetch_result
             fired_at = self._prefetch_result_fired_at
@@ -728,9 +715,10 @@ class HonchoMemoryProvider(MemoryProvider):
                 logger.debug("Honcho context prefetch failed: %s", e)
 
         # ----- Dialectic prefetch (supplement layer) -----
-        # Thread-alive guard with stale-thread recovery: a hung Honcho call
-        # older than timeout × multiplier is treated as dead so it can't
-        # block subsequent fires.
+        # Thread-alive guard: never stack dialectic calls for the same provider.
+        # We intentionally do not time out or recycle live threads here; slow
+        # Honcho/proxy/model work should finish naturally or be fixed at the
+        # backend layer.
         if self._thread_is_live():
             logger.debug("Honcho dialectic prefetch skipped: prior thread still running")
             return
@@ -796,9 +784,6 @@ class HonchoMemoryProvider(MemoryProvider):
     _HEURISTIC_LENGTH_MEDIUM = 120
     _HEURISTIC_LENGTH_HIGH = 400
 
-    # Liveness constants. A thread older than timeout × multiplier is treated
-    # as dead so a hung Honcho call can't block future retries indefinitely.
-    _STALE_THREAD_MULTIPLIER = 2.0
     # Pending result whose fire-turn is older than cadence × multiplier is
     # discarded on read so we don't inject context for a stale conversational
     # pivot after a gap of trivial-prompt turns.
@@ -808,19 +793,8 @@ class HonchoMemoryProvider(MemoryProvider):
     _BACKOFF_MAX = 8
 
     def _thread_is_live(self) -> bool:
-        """Thread-alive guard that treats threads older than the stale
-        threshold as dead, so a hung Honcho request can't block new fires."""
-        if not self._prefetch_thread or not self._prefetch_thread.is_alive():
-            return False
-        timeout = (self._config.timeout if self._config and self._config.timeout else 8.0)
-        age = time.monotonic() - self._prefetch_thread_started_at
-        if age > timeout * self._STALE_THREAD_MULTIPLIER:
-            logger.debug(
-                "Honcho prefetch thread age %.1fs exceeds stale threshold "
-                "%.1fs — treating as dead", age, timeout * self._STALE_THREAD_MULTIPLIER,
-            )
-            return False
-        return True
+        """Return whether a dialectic prefetch thread is still running."""
+        return bool(self._prefetch_thread and self._prefetch_thread.is_alive())
 
     def _effective_cadence(self) -> int:
         """Cadence plus empty-streak backoff, capped at _BACKOFF_MAX × base."""

--- a/plugins/memory/honcho/client.py
+++ b/plugins/memory/honcho/client.py
@@ -155,33 +155,6 @@ def _parse_dialectic_depth_levels(host_val, root_val, depth: int) -> list[str] |
     return None
 
 
-# Default HTTP timeout (seconds) applied when no explicit timeout is
-# configured via HonchoClientConfig.timeout, honcho.timeout / requestTimeout,
-# or HONCHO_TIMEOUT. Honcho calls happen on the post-response path of
-# run_conversation; without a cap the agent can block indefinitely when
-# the Honcho backend is unreachable, preventing the gateway from
-# delivering the already-generated response.
-_DEFAULT_HTTP_TIMEOUT = 30.0
-
-
-def _resolve_optional_float(*values: Any) -> float | None:
-    """Return the first non-empty value coerced to a positive float."""
-    for value in values:
-        if value is None:
-            continue
-        if isinstance(value, str):
-            value = value.strip()
-            if not value:
-                continue
-        try:
-            parsed = float(value)
-        except (TypeError, ValueError):
-            continue
-        if parsed > 0:
-            return parsed
-    return None
-
-
 _VALID_OBSERVATION_MODES = {"unified", "directional"}
 _OBSERVATION_MODE_ALIASES = {"shared": "unified", "separate": "directional", "cross": "directional"}
 
@@ -247,8 +220,6 @@ class HonchoClientConfig:
     environment: str = "production"
     # Optional base URL for self-hosted Honcho (overrides environment mapping)
     base_url: str | None = None
-    # Optional request timeout in seconds for Honcho SDK HTTP calls
-    timeout: float | None = None
     # Identity
     peer_name: str | None = None
     ai_peer: str = "hermes"
@@ -332,14 +303,12 @@ class HonchoClientConfig:
         resolved_host = host or resolve_active_host()
         api_key = os.environ.get("HONCHO_API_KEY")
         base_url = os.environ.get("HONCHO_BASE_URL", "").strip() or None
-        timeout = _resolve_optional_float(os.environ.get("HONCHO_TIMEOUT"))
         return cls(
             host=resolved_host,
             workspace_id=workspace_id,
             api_key=api_key,
             environment=os.environ.get("HONCHO_ENVIRONMENT", "production"),
             base_url=base_url,
-            timeout=timeout,
             ai_peer=resolved_host,
             enabled=bool(api_key or base_url),
         )
@@ -400,12 +369,6 @@ class HonchoClientConfig:
             or os.environ.get("HONCHO_BASE_URL", "").strip()
             or None
         )
-        timeout = _resolve_optional_float(
-            raw.get("timeout"),
-            raw.get("requestTimeout"),
-            os.environ.get("HONCHO_TIMEOUT"),
-        )
-
         # Auto-enable when API key or base_url is present (unless explicitly disabled)
         # Host-level enabled wins, then root-level, then auto-enable if key/url exists.
         host_enabled = host_block.get("enabled")
@@ -450,7 +413,6 @@ class HonchoClientConfig:
             api_key=api_key,
             environment=environment,
             base_url=base_url,
-            timeout=timeout,
             peer_name=host_block.get("peerName") or raw.get("peerName"),
             ai_peer=ai_peer,
             pin_peer_name=_resolve_bool(
@@ -716,8 +678,7 @@ def get_honcho_client(config: HonchoClientConfig | None = None) -> Honcho:
     # mapping, enabling remote self-hosted Honcho deployments without
     # requiring the server to live on localhost.
     resolved_base_url = config.base_url
-    resolved_timeout = config.timeout
-    if not resolved_base_url or resolved_timeout is None:
+    if not resolved_base_url:
         try:
             from hermes_cli.config import load_config
             hermes_cfg = load_config()
@@ -725,18 +686,8 @@ def get_honcho_client(config: HonchoClientConfig | None = None) -> Honcho:
             if isinstance(honcho_cfg, dict):
                 if not resolved_base_url:
                     resolved_base_url = honcho_cfg.get("base_url", "").strip() or None
-                if resolved_timeout is None:
-                    resolved_timeout = _resolve_optional_float(
-                        honcho_cfg.get("timeout"),
-                        honcho_cfg.get("request_timeout"),
-                    )
         except Exception:
             pass
-
-    # Fall back to the default so an unconfigured install cannot hang
-    # indefinitely on a stalled Honcho request.
-    if resolved_timeout is None:
-        resolved_timeout = _DEFAULT_HTTP_TIMEOUT
 
     if resolved_base_url:
         logger.info("Initializing Honcho client (base_url: %s, workspace: %s)", resolved_base_url, config.workspace_id)
@@ -769,8 +720,6 @@ def get_honcho_client(config: HonchoClientConfig | None = None) -> Honcho:
     }
     if resolved_base_url:
         kwargs["base_url"] = resolved_base_url
-    if resolved_timeout is not None:
-        kwargs["timeout"] = resolved_timeout
 
     _honcho_client = Honcho(**kwargs)
 

--- a/plugins/memory/llm_wiki/README.md
+++ b/plugins/memory/llm_wiki/README.md
@@ -1,0 +1,125 @@
+# LLM Wiki Memory Provider
+
+`llm_wiki` is a local-first, source-backed durable memory provider for Hermes Agent.
+
+It stores long-term knowledge as Markdown wiki pages, indexes chunks with Qdrant, and exposes read-first tools to Hermes. It is intended for curated, inspectable knowledge rather than automatic transcript summarization or hidden hosted memory.
+
+## What this provider is for
+
+Use LLM Wiki when memory should be:
+
+- inspectable as normal files
+- reviewable with Git diffs
+- source-backed and citeable
+- editable by humans
+- backed up as a folder
+- kept local by default
+
+Use Honcho/Mem0/Supermemory-style providers when you want automatic user modeling or hosted semantic memory. Use Hermes built-in `MEMORY.md`/`USER.md` for tiny boot-critical facts.
+
+## Safety defaults
+
+- `sync_turn()` is a no-op. Normal conversation turns are not automatically written.
+- `system_prompt_block()` is tiny and does not dump wiki content into the prompt.
+- `prefetch()` is bounded and cited.
+- `wiki_query` defaults to `file_result=false` and `log_query=false`.
+- `wiki_lint` defaults to `write_log=false`.
+- `wiki_ingest` defaults to `dry_run=true`, but all file ingest is limited to the primary agent context because dry-runs still read local files for analysis.
+- `wiki_reindex` and ingest writes are blocked outside the primary agent context.
+- `wiki_search.limit` is clamped.
+- `wiki_read` validates paths stay under the configured wiki root and caps oversized output.
+- Engine-generated slugs and ingest source categories are validated before path construction.
+- Reindexing upserts new vectors before deleting stale chunks, avoiding destructive rebuild-first behavior.
+
+## Config
+
+```yaml
+memory:
+  provider: llm_wiki
+
+wiki:
+  path: ~/.hermes/wiki/personal
+  name: personal
+  embedding:
+    url: http://localhost:22222
+    model: Qwen3-Embedding-8B
+    dim: 4096
+  vector_store:
+    url: http://localhost:6333
+    collection_prefix: hermes_wiki
+  llm:
+    url: http://localhost:8011/v1
+    model: gpt-5.5
+```
+
+## Dependencies
+
+The provider package is bundled with Hermes. Heavy search dependencies are optional:
+
+```bash
+pip install 'hermes-agent[llm-wiki]'
+```
+
+Provider discovery does not require `qdrant-client`; the engine lazily ensures the `memory.llm_wiki` dependency when a real wiki operation needs it.
+
+Runtime services:
+
+- Qdrant HTTP endpoint, default `http://localhost:6333`
+- OpenAI-compatible embedding endpoint, default `http://localhost:22222`
+- OpenAI-compatible chat endpoint for `wiki_query`, default `http://localhost:8011/v1`
+
+## Retrieval evals
+
+Use the read-only retrieval eval runner to catch regressions in page recall:
+
+```bash
+hermes-wiki-eval ~/.hermes/wiki/personal/evals/retrieval.yaml --config ~/.hermes/config.yaml --pretty
+# or: python -m hermes_wiki.eval ...
+```
+
+`--config` is authoritative when supplied: the file must exist and contain the intended `wiki:` settings; the runner will not silently fall back to another profile/config.
+
+Case file shape:
+
+```yaml
+cases:
+  - query: How autonomous should Hermes be?
+    expected_pages:
+      - concepts/user-autonomy-operating-policy.md
+      - entities/hermes.md
+    top_k: 5
+```
+
+The eval runner validates page-path presence only. It does not generate text, write wiki files, ingest sources, or reindex vectors. It still embeds eval query text and reads from the configured vector store, so use local/private endpoints for sensitive eval cases.
+
+## Memory proposals
+
+Use `hermes-wiki-propose` to draft a review artifact for durable memory without silently writing canonical wiki pages:
+
+```bash
+hermes-wiki-propose \
+  --title "Remember a stable preference" \
+  --rationale "Prevents repeated correction" \
+  --change "Add the preference to the relevant source-backed page" \
+  --source "discord:<message-or-thread-id>" \
+  --target concepts/example.md
+```
+
+By default it prints markdown only. Add `--queue --config ~/.hermes/config.yaml` to explicitly write a pending proposal under `<wiki>/proposals/`. `--queue` requires `--config` and fails closed rather than falling back to an ambient/default wiki path. Queueing does not ingest, reindex, or mutate canonical wiki pages.
+
+## Maintenance reports
+
+Use `hermes-wiki-maintenance` for a read-only health report over local wiki markdown:
+
+```bash
+hermes-wiki-maintenance --config ~/.hermes/config.yaml
+hermes-wiki-maintenance --config ~/.hermes/config.yaml --json
+```
+
+It checks broken wikilinks, orphan pages, pending proposals, and pages without source coverage. By default it only prints a report. `--write-report reports/maintenance.md` requires explicit `--config` and writes only under the dedicated `reports/` namespace; it does not ingest sources, reindex vectors, or mutate canonical entity/concept pages.
+
+## Privacy note
+
+Indexing sends wiki/source text to the configured embedding endpoint. `wiki_query` sends retrieved snippets plus the question to the configured chat endpoint. For sensitive memory, use local OpenAI-compatible endpoints and do not put secrets in wiki pages.
+
+See `website/docs/user-guide/features/llm-wiki-memory.md` for user-facing docs.

--- a/plugins/memory/llm_wiki/__init__.py
+++ b/plugins/memory/llm_wiki/__init__.py
@@ -1,0 +1,437 @@
+"""LLM Wiki memory provider.
+
+First-class MemoryProvider wrapper for Hermes LLM Wiki. The provider is
+intentionally read-first: rich durable memory should be retrieved explicitly
+or via bounded prefetch, not dumped into every prompt.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+from typing import Any, Dict, List
+
+import yaml
+
+from agent.memory_provider import MemoryProvider
+
+WikiEngine = None
+
+
+class LLMWikiMemoryProvider(MemoryProvider):
+    """MemoryProvider facade for the Hermes LLM Wiki."""
+
+    def __init__(self) -> None:
+        self._session_id = ""
+        self._hermes_home = ""
+        self._agent_context = "primary"
+        self.wiki_path = Path.home() / ".hermes" / "wiki" / "personal"
+        self.wiki_name = "personal"
+        self._engine_instance = None
+        self.prefetch_limit = 3
+        self.prefetch_max_chars = 1200
+        self.search_max_limit = 20
+        self.read_max_chars = 64_000
+
+    @property
+    def name(self) -> str:
+        return "llm_wiki"
+
+    def is_available(self) -> bool:
+        return importlib.util.find_spec("hermes_wiki.engine") is not None
+
+    def initialize(self, session_id: str, **kwargs: Any) -> None:
+        self._session_id = session_id
+        self._hermes_home = str(kwargs.get("hermes_home") or "")
+        self._agent_context = str(kwargs.get("agent_context") or "primary").strip().lower() or "primary"
+        self._load_wiki_config()
+
+    def system_prompt_block(self) -> str:
+        return (
+            "LLM Wiki memory is available as source-backed durable knowledge. "
+            "Use wiki_search/wiki_read/wiki_query when rich memory or policy is relevant; "
+            "do not assume the whole wiki is already in context. Queries default to read-only."
+        )
+
+    def prefetch(self, query: str, *, session_id: str = "") -> str:
+        query = (query or "").strip()
+        if not query:
+            return ""
+        try:
+            searcher = getattr(self._engine(), "search", None)
+            if searcher is None:
+                return ""
+            results = searcher.search(query, limit=self.prefetch_limit, exclude_sources=True)
+        except Exception:
+            return ""
+        return self._format_prefetch_results(results)
+
+    def sync_turn(self, user_content: str, assistant_content: str, *, session_id: str = "") -> None:
+        return None
+
+    def _format_prefetch_results(self, results: Any) -> str:
+        if not results:
+            return ""
+        header = "LLM Wiki relevant context (source-backed; use wiki_read/wiki_query for more):"
+        lines = [header]
+        remaining = self.prefetch_max_chars - len(header) - 1
+        for result in results:
+            data = self._search_result_to_dict(result)
+            page_path = data["page_path"]
+            title = data["title"] or page_path or "Untitled"
+            text = " ".join(data["text"].split())
+            score = data["score"]
+            score_text = f" score={score:.3f}" if isinstance(score, (int, float)) else ""
+            prefix = f"- [{page_path}] {title}{score_text}: "
+            if len(prefix) >= remaining:
+                break
+            snippet = text[: max(0, min(260, remaining - len(prefix) - 1))]
+            line = prefix + snippet
+            if len(line) > remaining:
+                break
+            lines.append(line)
+            remaining -= len(line) + 1
+            if remaining <= 40:
+                break
+        return "\n".join(lines)[: self.prefetch_max_chars]
+
+    def _search_result_to_dict(self, result: Any) -> Dict[str, Any]:
+        if isinstance(result, dict):
+            return {
+                "page_path": str(result.get("page_path", "")),
+                "title": str(result.get("title", "")),
+                "page_type": str(result.get("page_type", "")),
+                "chunk_index": result.get("chunk_index", 0),
+                "text": str(result.get("text", "")),
+                "score": result.get("score"),
+                "tags": result.get("tags", []),
+            }
+        return {
+            "page_path": str(getattr(result, "page_path", "")),
+            "title": str(getattr(result, "title", "")),
+            "page_type": str(getattr(result, "page_type", "")),
+            "chunk_index": getattr(result, "chunk_index", 0),
+            "text": str(getattr(result, "text", "")),
+            "score": getattr(result, "score", None),
+            "tags": getattr(result, "tags", []),
+        }
+
+    def _load_wiki_config(self) -> None:
+        config = self._wiki_config()
+        self.wiki_name = config.wiki_name
+        self.wiki_path = config.wiki_path
+
+    def _config_path(self) -> Path:
+        hermes_home = Path(self._hermes_home).expanduser() if self._hermes_home else Path.home() / ".hermes"
+        return hermes_home / "config.yaml"
+
+    def _load_config_data(self) -> Dict[str, Any]:
+        config_path = self._config_path()
+        if not config_path.exists():
+            return {}
+        data = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
+        return data if isinstance(data, dict) else {}
+
+    def _wiki_config(self):
+        from hermes_wiki.config import WikiConfig
+
+        data = self._load_config_data()
+        if "wiki" not in data:
+            hermes_home = Path(self._hermes_home).expanduser() if self._hermes_home else Path.home() / ".hermes"
+            data = {"wiki": {"path": str(hermes_home / "wiki" / "personal"), "name": "personal"}}
+        return WikiConfig.from_dict(data)
+
+    def get_config_schema(self) -> List[Dict[str, Any]]:
+        return [
+            {"key": "path", "description": "Filesystem path for the LLM Wiki", "default": "~/.hermes/wiki/personal"},
+            {"key": "name", "description": "Wiki name used for vector collection suffix", "default": "personal"},
+            {"key": "embedding_url", "description": "OpenAI-compatible embedding endpoint", "default": "http://localhost:22222"},
+            {"key": "embedding_model", "description": "Embedding model name", "default": "Qwen3-Embedding-8B"},
+            {"key": "embedding_dim", "description": "Embedding vector dimension", "default": 4096},
+            {"key": "qdrant_url", "description": "Qdrant HTTP URL", "default": "http://localhost:6333"},
+            {"key": "collection_prefix", "description": "Qdrant collection prefix", "default": "hermes_wiki"},
+            {"key": "llm_url", "description": "OpenAI-compatible LLM endpoint for wiki_query", "default": "http://localhost:8011/v1"},
+            {"key": "llm_model", "description": "LLM model used by wiki_query", "default": "gpt-5.5"},
+        ]
+
+    def save_config(self, values: Dict[str, Any], hermes_home: str) -> None:
+        config_path = Path(hermes_home).expanduser() / "config.yaml"
+        data: Dict[str, Any] = {}
+        if config_path.exists():
+            loaded = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
+            data = loaded if isinstance(loaded, dict) else {}
+
+        wiki = data.setdefault("wiki", {})
+        if not isinstance(wiki, dict):
+            wiki = {}
+            data["wiki"] = wiki
+
+        def set_if_present(key: str, section: Dict[str, Any], dest: str | None = None, *, cast=None) -> None:
+            if key not in values or values[key] in (None, ""):
+                return
+            value = values[key]
+            if cast is not None:
+                value = cast(value)
+            section[dest or key] = value
+
+        set_if_present("path", wiki)
+        set_if_present("name", wiki)
+        embedding = wiki.setdefault("embedding", {})
+        vector = wiki.setdefault("vector_store", {})
+        llm = wiki.setdefault("llm", {})
+        set_if_present("embedding_url", embedding, "url")
+        set_if_present("embedding_model", embedding, "model")
+        set_if_present("embedding_dim", embedding, "dim", cast=int)
+        set_if_present("qdrant_url", vector, "url")
+        set_if_present("collection_prefix", vector)
+        set_if_present("llm_url", llm, "url")
+        set_if_present("llm_model", llm, "model")
+
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+        config_path.write_text(yaml.safe_dump(data, sort_keys=False), encoding="utf-8")
+
+    def _ensure_optional_deps(self) -> None:
+        try:
+            from tools.lazy_deps import ensure as lazy_ensure
+
+            lazy_ensure("memory.llm_wiki", prompt=False)
+        except ImportError:
+            return
+
+    def _engine(self):
+        if self._engine_instance is None:
+            if self._writes_allowed():
+                self._ensure_optional_deps()
+            engine_cls = WikiEngine
+            if engine_cls is None:
+                try:
+                    from hermes_wiki.engine import WikiEngine as imported_engine
+                except Exception as exc:  # pragma: no cover - exercised by integration tests later
+                    raise RuntimeError("LLM Wiki engine is not importable") from exc
+                engine_cls = imported_engine
+            self._engine_instance = engine_cls(self._wiki_config(), read_only=not self._writes_allowed())
+        return self._engine_instance
+
+    def get_tool_schemas(self) -> List[Dict[str, Any]]:
+        return [
+            {
+                "name": "wiki_status",
+                "description": "Show LLM Wiki status for the active Hermes profile.",
+                "parameters": {"type": "object", "properties": {}, "required": []},
+            },
+            {
+                "name": "wiki_orient",
+                "description": "Orient to the LLM Wiki index and recent activity without writing logs.",
+                "parameters": {"type": "object", "properties": {}, "required": []},
+            },
+            {
+                "name": "wiki_search",
+                "description": "Search the LLM Wiki for source-backed durable memory.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "query": {"type": "string", "description": "Search query."},
+                        "limit": {
+                            "type": "integer",
+                            "description": "Maximum results.",
+                            "default": 5,
+                            "minimum": 1,
+                            "maximum": 20,
+                        },
+                    },
+                    "required": ["query"],
+                },
+            },
+            {
+                "name": "wiki_read",
+                "description": "Read a wiki page by slug or relative path.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "page": {"type": "string", "description": "Page slug or relative markdown path."},
+                    },
+                    "required": ["page"],
+                },
+            },
+            {
+                "name": "wiki_query",
+                "description": "Ask a question against the LLM Wiki. Defaults to read-only: no filed result and no query log.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "question": {"type": "string", "description": "Question to answer from wiki context."},
+                        "file_result": {
+                            "type": "boolean",
+                            "description": "Whether to file a durable query page if the result is worth keeping.",
+                            "default": False,
+                        },
+                        "log_query": {
+                            "type": "boolean",
+                            "description": "Whether to append this query to log.md.",
+                            "default": False,
+                        },
+                    },
+                    "required": ["question"],
+                },
+            },
+            {
+                "name": "wiki_lint",
+                "description": "Lint the LLM Wiki. Defaults to non-mutating: write_log=false.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "write_log": {"type": "boolean", "description": "Append result to log.md.", "default": False},
+                    },
+                    "required": [],
+                },
+            },
+            {
+                "name": "wiki_ingest",
+                "description": "Ingest a curated source file into the LLM Wiki. Defaults to dry_run=true.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "file_path": {"type": "string", "description": "Path to source file to ingest."},
+                        "dry_run": {"type": "boolean", "description": "Plan ingest without writing wiki files.", "default": True},
+                    },
+                    "required": ["file_path"],
+                },
+            },
+            {
+                "name": "wiki_reindex",
+                "description": "Rebuild the LLM Wiki vector index. Blocked outside primary agent contexts.",
+                "parameters": {"type": "object", "properties": {}, "required": []},
+            },
+        ]
+
+    @staticmethod
+    def _as_bool(value: Any, default: bool = False) -> bool:
+        """Parse bool-like tool arguments without treating "false" as truthy."""
+        if value is None:
+            return default
+        if isinstance(value, bool):
+            return value
+        if isinstance(value, (int, float)):
+            return bool(value)
+        if isinstance(value, str):
+            normalized = value.strip().lower()
+            if normalized in {"1", "true", "yes", "y", "on"}:
+                return True
+            if normalized in {"0", "false", "no", "n", "off", ""}:
+                return False
+        return bool(value)
+
+    def _clamp_limit(self, value: Any, default: int = 5) -> int:
+        try:
+            limit = int(value)
+        except (TypeError, ValueError):
+            limit = default
+        return max(1, min(self.search_max_limit, limit))
+
+    def handle_tool_call(self, tool_name: str, args: Dict[str, Any], **kwargs: Any) -> str:
+        args = args or {}
+        if tool_name == "wiki_status":
+            return json.dumps(self._engine().status(), indent=2, default=str)
+        if tool_name == "wiki_orient":
+            return str(self._engine().orient())
+        if tool_name == "wiki_query":
+            question = str(args.get("question") or "").strip()
+            if not question:
+                return "Error: question is required"
+            file_result = self._as_bool(args.get("file_result"), False)
+            log_query = self._as_bool(args.get("log_query"), False)
+            if (file_result or log_query) and not self._writes_allowed():
+                return self._write_blocked("wiki_query")
+            return str(
+                self._engine().query(
+                    question,
+                    file_result=file_result,
+                    log_query=log_query,
+                )
+            )
+        if tool_name == "wiki_read":
+            page = str(args.get("page") or "").strip()
+            if not page:
+                return "Error: page is required"
+            return self._read_page(page)
+        if tool_name == "wiki_search":
+            query = str(args.get("query") or "").strip()
+            if not query:
+                return "Error: query is required"
+            limit = self._clamp_limit(args.get("limit", 5), 5)
+            engine = self._engine()
+            searcher = getattr(engine, "search", None)
+            if searcher is None:
+                return "Error: wiki search is unavailable"
+            results = searcher.search(query, limit=limit) if hasattr(searcher, "search") else searcher(query, limit=limit)
+            return json.dumps([self._search_result_to_dict(r) for r in results], indent=2, default=str)
+        if tool_name == "wiki_lint":
+            write_log = self._as_bool(args.get("write_log"), False)
+            if write_log and not self._writes_allowed():
+                return self._write_blocked("wiki_lint")
+            return json.dumps(self._engine().lint(write_log=write_log), indent=2, default=str)
+        if tool_name == "wiki_ingest":
+            file_path = str(args.get("file_path") or "").strip()
+            if not file_path:
+                return "Error: file_path is required"
+            if not self._writes_allowed():
+                return self._write_blocked("wiki_ingest")
+            dry_run = self._as_bool(args.get("dry_run"), True)
+            return json.dumps(self._engine().ingest_file(file_path, dry_run=dry_run), indent=2, default=str)
+        if tool_name == "wiki_reindex":
+            if not self._writes_allowed():
+                return self._write_blocked("wiki_reindex")
+            return json.dumps(self._engine().reindex(), indent=2, default=str)
+        return super().handle_tool_call(tool_name, args, **kwargs)
+
+    def _writes_allowed(self) -> bool:
+        return self._agent_context == "primary"
+
+    def _write_blocked(self, operation: str) -> str:
+        return (
+            f"Blocked {operation}: LLM Wiki file ingest and durable writes are disabled in "
+            f"agent_context={self._agent_context!r}; use a primary agent context."
+        )
+
+    def _read_page(self, page: str) -> str:
+        path = self._resolve_page_path(page)
+        if path is None:
+            return f"Error: wiki page not found: {page}"
+        text = path.read_text(encoding="utf-8")
+        if len(text) <= self.read_max_chars:
+            return text
+        return text[: self.read_max_chars] + f"\n\n[truncated: {len(text) - self.read_max_chars} additional characters omitted]"
+
+    def _resolve_page_path(self, page: str) -> Path | None:
+        raw = str(page or "").strip()
+        if not raw:
+            return None
+
+        requested = Path(raw)
+        candidates: list[Path]
+        if requested.is_absolute():
+            candidates = [requested]
+        else:
+            candidates = [self.wiki_path / requested]
+            if requested.suffix == "":
+                candidates.append(self.wiki_path / f"{raw}.md")
+            if len(requested.parts) == 1:
+                slug = requested.stem if requested.suffix == ".md" else raw
+                for subdir in ("entities", "concepts", "comparisons", "queries"):
+                    candidates.append(self.wiki_path / subdir / f"{slug}.md")
+
+        wiki_root = self.wiki_path.resolve()
+        for candidate in candidates:
+            resolved = candidate.resolve()
+            if wiki_root not in resolved.parents and resolved != wiki_root:
+                return None
+            if resolved.exists() and resolved.is_file():
+                return resolved
+        return None
+
+
+def register(ctx: Any) -> None:
+    """Register the LLM Wiki memory provider with Hermes plugin context."""
+
+    ctx.register_memory_provider(LLMWikiMemoryProvider())

--- a/plugins/memory/llm_wiki/plugin.yaml
+++ b/plugins/memory/llm_wiki/plugin.yaml
@@ -1,0 +1,6 @@
+name: llm_wiki
+version: 0.1.0
+description: "LLM Wiki — source-backed durable memory provider for Hermes."
+requires_env: []
+hooks:
+  - prefetch

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,10 @@ modal = ["modal==1.3.4"]
 daytona = ["daytona==0.155.0"]
 vercel = ["vercel==0.5.7"]
 hindsight = ["hindsight-client==0.6.1"]
+llm-wiki = [
+  "qdrant-client==1.16.1",
+  "vector-core @ git+https://github.com/michaelkrauty/vector-core.git@551056769b66d35c56dbc48475785fbb646afbef",
+]
 dev = ["debugpy==1.8.20", "pytest==9.0.2", "pytest-asyncio==1.3.0", "pytest-xdist==3.8.0", "pytest-split==0.11.0", "mcp==1.26.0", "ty==0.0.21", "ruff==0.15.10"]
 messaging = ["python-telegram-bot[webhooks]==22.6", "discord.py[voice]==2.7.1", "aiohttp==3.13.3", "brotlicffi==1.2.0.1", "slack-bolt==1.27.0", "slack-sdk==3.40.1", "qrcode==7.4.2"]
 cron = []  # croniter is now a core dependency; this extra kept for back-compat
@@ -206,6 +210,13 @@ all = [
 hermes = "hermes_cli.main:main"
 hermes-agent = "run_agent:main"
 hermes-acp = "acp_adapter.entry:main"
+hermes-wiki-eval = "hermes_wiki.eval:main"
+hermes-wiki-propose = "hermes_wiki.proposals:main"
+hermes-wiki-proposals = "hermes_wiki.proposal_lifecycle:main"
+hermes-wiki-maintenance = "hermes_wiki.maintenance:main"
+hermes-wiki-introspect = "hermes_wiki.retrieval_introspection:main"
+hermes-wiki-caretaker = "hermes_wiki.caretaker:main"
+hermes-wiki-caretaker-propose = "hermes_wiki.caretaker_orchestrator:main"
 
 [tool.setuptools]
 py-modules = ["run_agent", "model_tools", "toolsets", "batch_runner", "trajectory_compressor", "toolset_distributions", "cli", "hermes_bootstrap", "hermes_constants", "hermes_state", "hermes_time", "hermes_logging", "utils"]
@@ -213,9 +224,10 @@ py-modules = ["run_agent", "model_tools", "toolsets", "batch_runner", "trajector
 [tool.setuptools.package-data]
 hermes_cli = ["web_dist/**/*", "tui_dist/**/*", "scripts/install.sh", "scripts/install.ps1"]
 gateway = ["assets/**/*"]
+plugins = ["**/plugin.yaml", "**/README.md"]
 
 [tool.setuptools.packages.find]
-include = ["agent", "agent.*", "tools", "tools.*", "hermes_cli", "gateway", "gateway.*", "tui_gateway", "tui_gateway.*", "cron", "acp_adapter", "plugins", "plugins.*", "providers", "providers.*"]
+include = ["agent", "agent.*", "tools", "tools.*", "hermes_cli", "gateway", "gateway.*", "tui_gateway", "tui_gateway.*", "cron", "acp_adapter", "plugins", "plugins.*", "providers", "providers.*", "hermes_wiki", "hermes_wiki.*"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/run_agent.py
+++ b/run_agent.py
@@ -412,6 +412,7 @@ class AIAgent:
         checkpoint_max_total_size_mb: int = 500,
         checkpoint_max_file_size_mb: int = 10,
         pass_session_id: bool = False,
+        agent_context: str | None = None,
     ):
         """Forwarder — see ``agent.agent_init.init_agent``."""
         from agent.agent_init import init_agent
@@ -481,6 +482,7 @@ class AIAgent:
             checkpoint_max_total_size_mb=checkpoint_max_total_size_mb,
             checkpoint_max_file_size_mb=checkpoint_max_file_size_mb,
             pass_session_id=pass_session_id,
+            agent_context=agent_context,
         )
 
     def _get_session_db_for_recall(self):

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -2331,6 +2331,57 @@ class TestCodexAuxiliaryAdapterTimeout:
         assert fake_client.responses.kwargs["timeout"] == 12.5
         assert response.choices[0].message.content == "summary"
 
+    def test_zero_timeout_disables_codex_deadline_and_forwards_none(self):
+        class FakeStream:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def __iter__(self):
+                # If timeout=0 created a total-timeout watchdog this would fail
+                # before the final response can be collected.
+                time.sleep(0.01)
+                return iter(())
+
+            def get_final_response(self):
+                return SimpleNamespace(
+                    output=[SimpleNamespace(
+                        type="message",
+                        content=[SimpleNamespace(type="output_text", text="summary")],
+                    )],
+                    usage=None,
+                )
+
+        class FakeResponses:
+            def __init__(self):
+                self.kwargs = None
+
+            def stream(self, **kwargs):
+                self.kwargs = kwargs
+                return FakeStream()
+
+        fake_client = SimpleNamespace(responses=FakeResponses())
+        adapter = _CodexCompletionsAdapter(fake_client, "gpt-5.5")
+
+        response = adapter.create(
+            messages=[{"role": "user", "content": "summarize this"}],
+            timeout=0,
+        )
+
+        assert fake_client.responses.kwargs["timeout"] is None
+        assert response.choices[0].message.content == "summary"
+
+    def test_task_timeout_zero_means_no_timeout(self):
+        from agent.auxiliary_client import _get_task_timeout
+
+        with patch(
+            "agent.auxiliary_client._get_auxiliary_task_config",
+            return_value={"timeout": 0},
+        ):
+            assert _get_task_timeout("compression") is None
+
     def test_enforces_total_timeout_while_stream_keeps_emitting_events(self):
         class SlowAliveStream:
             def __enter__(self):

--- a/tests/agent/test_memory_provider.py
+++ b/tests/agent/test_memory_provider.py
@@ -5,7 +5,7 @@ import pytest
 from unittest.mock import MagicMock, patch
 
 from agent.memory_provider import MemoryProvider
-from agent.memory_manager import MemoryManager
+from agent.memory_manager import MemoryManager, sanitize_context
 
 # ---------------------------------------------------------------------------
 # Concrete test provider
@@ -82,6 +82,27 @@ class MetadataMemoryProvider(FakeMemoryProvider):
 
     def on_memory_write(self, action, target, content, metadata=None):
         self.memory_writes.append((action, target, content, metadata or {}))
+
+
+# ---------------------------------------------------------------------------
+# Context sanitization tests
+# ---------------------------------------------------------------------------
+
+
+def test_sanitize_context_accepts_openai_content_parts():
+    content = [
+        {"type": "text", "text": "hello <memory-context>secret</memory-context>"},
+        {"type": "image_url", "image_url": {"url": "file:///tmp/example.png"}},
+        "plain tail",
+    ]
+
+    cleaned = sanitize_context(content)
+
+    assert "hello" in cleaned
+    assert "secret" not in cleaned
+    assert "plain tail" in cleaned
+    assert "[image_url content omitted]" in cleaned
+    assert "file:///tmp/example.png" not in cleaned
 
 
 # ---------------------------------------------------------------------------

--- a/tests/agent/test_memory_provider.py
+++ b/tests/agent/test_memory_provider.py
@@ -827,6 +827,90 @@ class TestMemoryContextFencing:
         assert combined.index("weather") < fence_start
 
 
+class TestHonchoInjectedContextGuard:
+    """Honcho auto-injection should not dump ephemeral observation logs."""
+
+    def test_filters_event_observations_and_keeps_durable_facts(self):
+        from plugins.memory.honcho import HonchoMemoryProvider
+
+        provider = HonchoMemoryProvider()
+        ctx = {
+            "representation": "\n".join([
+                "## Explicit Observations",
+                "[2026-05-21 01:08:15] On May 21, 2026 at 01:08:15, test-user sent the text \"[scorch]\".",
+                "[2026-05-21 02:11:11] On May 21, 2026 at 02:11:11, test-user said they ran the command `systemctl --user restart hermes-gateway.service`.",
+                "[2026-05-21 00:49:26] test-user prefers clean results with no scratchpad.",
+                "[2026-05-21 01:15:59] test-user prefers clean results with no scratchpad.",
+            ])
+        }
+
+        result = provider._format_first_turn_context(ctx)
+
+        assert "## User Representation" in result
+        assert "prefers clean results with no scratchpad" in result
+        assert "sent the text" not in result
+        assert "systemctl --user restart" not in result
+        assert result.count("prefers clean results with no scratchpad") == 1
+
+    def test_caps_injected_representation_lines(self):
+        from plugins.memory.honcho import HonchoMemoryProvider
+
+        provider = HonchoMemoryProvider()
+        ctx = {
+            "representation": "\n".join(
+                f"[2026-05-21 00:49:26] test-user durable fact {i}."
+                for i in range(80)
+            )
+        }
+
+        result = provider._format_first_turn_context(ctx)
+
+        assert "durable fact 0" in result
+        assert "durable fact 47" in result
+        assert "durable fact 48" not in result
+
+    def test_splits_giant_single_line_observation_dump(self):
+        from plugins.memory.honcho import HonchoMemoryProvider
+
+        provider = HonchoMemoryProvider()
+        giant_line = " ".join([
+            "## Explicit Observations",
+            "[2026-05-21 00:00:00] On May 21, 2026 at 00:00:00, test-user sent the text \"[scorch]\".",
+            "[2026-05-21 00:01:00] test-user prefers blunt, clean/no-scratchpad results.",
+            "[2026-05-21 00:02:00] test-user prefers blunt, clean/no-scratchpad results.",
+            "[2026-05-21 00:03:00] test-user is likely a developer/system administrator/technical lead.",
+            "[2026-05-21 00:04:00] test-user wants Hermes to be a reliable long-term memory system.",
+        ])
+        ctx = {"representation": giant_line}
+
+        result = provider._format_first_turn_context(ctx)
+
+        assert "prefers blunt, clean/no-scratchpad results" in result
+        assert result.count("prefers blunt, clean/no-scratchpad results") == 1
+        assert "reliable long-term memory system" in result
+        assert "sent the text" not in result
+        assert "likely a developer" not in result
+        assert "Explicit Observations" not in result
+
+    def test_caps_injected_section_by_characters(self):
+        from plugins.memory.honcho import HonchoMemoryProvider
+
+        provider = HonchoMemoryProvider()
+        ctx = {
+            "representation": "\n".join(
+                f"[2026-05-21 00:{i:02d}:00] durable claim {i}: " + ("x" * 180)
+                for i in range(60)
+            )
+        }
+
+        result = provider._format_first_turn_context(ctx)
+        injected = result.split("## User Representation\n", 1)[1]
+
+        assert len(injected) <= provider._MAX_SECTION_CHARS
+        assert "durable claim 0" in injected
+        assert "durable claim 59" not in injected
+
+
 # ---------------------------------------------------------------------------
 # AIAgent.commit_memory_session — routes to MemoryManager.on_session_end
 # ---------------------------------------------------------------------------
@@ -1012,6 +1096,79 @@ class TestOnMemoryWriteBridge:
         mgr.on_memory_write("add", "user", "test")
         # Good provider still received the call despite bad provider crashing
         assert good.memory_writes == [("add", "user", "test")]
+
+
+class TestAIAgentMemoryProviderContext:
+    def test_explicit_agent_context_reaches_memory_provider(self, tmp_path):
+        from run_agent import AIAgent
+
+        provider = FakeMemoryProvider("context-provider")
+        cfg = {"memory": {"provider": "context-provider"}}
+
+        with patch("run_agent.OpenAI"), \
+            patch("hermes_cli.config.load_config", return_value=cfg), \
+            patch("agent.agent_init.get_hermes_home", return_value=tmp_path), \
+            patch("plugins.memory.load_memory_provider", return_value=provider):
+            AIAgent(
+                api_key="key",
+                base_url="https://openrouter.ai/api/v1",
+                model="test/model",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=False,
+                platform="cron",
+                agent_context="cron",
+            )
+
+        assert provider.initialized is True
+        assert provider._init_kwargs["agent_context"] == "cron"
+        assert provider._init_kwargs["platform"] == "cron"
+
+    def test_agent_context_env_fallback_reaches_memory_provider(self, tmp_path, monkeypatch):
+        from run_agent import AIAgent
+
+        provider = FakeMemoryProvider("context-provider")
+        cfg = {"memory": {"provider": "context-provider"}}
+        monkeypatch.setenv("HERMES_AGENT_CONTEXT", "batch")
+
+        with patch("run_agent.OpenAI"), \
+            patch("hermes_cli.config.load_config", return_value=cfg), \
+            patch("agent.agent_init.get_hermes_home", return_value=tmp_path), \
+            patch("plugins.memory.load_memory_provider", return_value=provider):
+            AIAgent(
+                api_key="key",
+                base_url="https://openrouter.ai/api/v1",
+                model="test/model",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=False,
+                platform="cli",
+            )
+
+        assert provider._init_kwargs["agent_context"] == "batch"
+
+    def test_cli_platform_defaults_to_primary_agent_context(self, tmp_path, monkeypatch):
+        from run_agent import AIAgent
+
+        provider = FakeMemoryProvider("context-provider")
+        cfg = {"memory": {"provider": "context-provider"}}
+        monkeypatch.delenv("HERMES_AGENT_CONTEXT", raising=False)
+
+        with patch("run_agent.OpenAI"), \
+            patch("hermes_cli.config.load_config", return_value=cfg), \
+            patch("agent.agent_init.get_hermes_home", return_value=tmp_path), \
+            patch("plugins.memory.load_memory_provider", return_value=provider):
+            AIAgent(
+                api_key="key",
+                base_url="https://openrouter.ai/api/v1",
+                model="test/model",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=False,
+                platform="cli",
+            )
+
+        assert provider._init_kwargs["agent_context"] == "primary"
 
 
 class TestHonchoCadenceTracking:

--- a/tests/gateway/test_discord_slash_commands.py
+++ b/tests/gateway/test_discord_slash_commands.py
@@ -97,7 +97,8 @@ class FakeTree:
 
 
 @pytest.fixture
-def adapter():
+def adapter(monkeypatch):
+    monkeypatch.delenv("DISCORD_SHARED_THREAD_USERS", raising=False)
     config = PlatformConfig(enabled=True, token="***")
     adapter = DiscordAdapter(config)
     adapter._client = SimpleNamespace(
@@ -552,6 +553,85 @@ async def test_auto_create_thread_falls_back_to_hermes_when_only_mentions(adapte
 
     name = message.create_thread.await_args[1]["name"]
     assert name == "Hermes"
+
+
+@pytest.mark.asyncio
+async def test_auto_create_thread_adds_configured_shared_users(adapter, monkeypatch):
+    monkeypatch.setenv("DISCORD_SHARED_THREAD_USERS", "123, <@456>")
+    member_123 = SimpleNamespace(id=123)
+    member_456 = SimpleNamespace(id=456)
+    guild = SimpleNamespace(
+        get_member=MagicMock(side_effect=lambda user_id: member_123 if user_id == 123 else None),
+        fetch_member=AsyncMock(return_value=member_456),
+    )
+    thread = SimpleNamespace(id=999, mention="<#999>", add_user=AsyncMock())
+    message = SimpleNamespace(
+        content="Hello world",
+        create_thread=AsyncMock(return_value=thread),
+        channel=SimpleNamespace(send=AsyncMock()),
+        author=SimpleNamespace(display_name="Jezza"),
+        guild=guild,
+    )
+
+    result = await adapter._auto_create_thread(message)
+
+    assert result is thread
+    thread.add_user.assert_any_await(member_123)
+    thread.add_user.assert_any_await(member_456)
+    assert thread.add_user.await_count == 2
+    message.channel.send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_auto_create_thread_posts_parent_pointer_for_shared_user_add_failures(adapter, monkeypatch):
+    monkeypatch.setenv("DISCORD_SHARED_THREAD_USERS", "123,456")
+    member_123 = SimpleNamespace(id=123)
+    member_456 = SimpleNamespace(id=456)
+    guild = SimpleNamespace(
+        get_member=MagicMock(side_effect=lambda user_id: member_123 if user_id == 123 else member_456),
+        fetch_member=AsyncMock(),
+    )
+
+    async def add_user(member):
+        if member.id == 456:
+            raise RuntimeError("missing perms")
+
+    thread = SimpleNamespace(id=999, mention="<#999>", add_user=AsyncMock(side_effect=add_user))
+    message = SimpleNamespace(
+        content="Hello world",
+        create_thread=AsyncMock(return_value=thread),
+        channel=SimpleNamespace(send=AsyncMock()),
+        author=SimpleNamespace(display_name="Jezza"),
+        guild=guild,
+    )
+
+    result = await adapter._auto_create_thread(message)
+
+    assert result is thread
+    thread.add_user.assert_any_await(member_123)
+    thread.add_user.assert_any_await(member_456)
+    message.channel.send.assert_awaited_once_with("↳ <@456> <#999>")
+
+
+@pytest.mark.asyncio
+async def test_auto_create_thread_parent_pointer_for_unresolved_shared_user(adapter, monkeypatch):
+    monkeypatch.setenv("DISCORD_SHARED_THREAD_USERS", "123,123")
+    guild = SimpleNamespace(get_member=MagicMock(return_value=None), fetch_member=AsyncMock(return_value=None))
+    thread = SimpleNamespace(id=999, mention="<#999>", add_user=AsyncMock())
+    message = SimpleNamespace(
+        content="Hello world",
+        create_thread=AsyncMock(return_value=thread),
+        channel=SimpleNamespace(send=AsyncMock()),
+        author=SimpleNamespace(display_name="Jezza"),
+        guild=guild,
+    )
+
+    result = await adapter._auto_create_thread(message)
+
+    assert result is thread
+    thread.add_user.assert_not_awaited()
+    guild.fetch_member.assert_awaited_once_with(123)
+    message.channel.send.assert_awaited_once_with("↳ <@123> <#999>")
 
 
 @pytest.mark.asyncio

--- a/tests/honcho_plugin/test_client.py
+++ b/tests/honcho_plugin/test_client.py
@@ -28,7 +28,7 @@ class TestHonchoClientConfigDefaults:
         assert config.workspace_id == "hermes"
         assert config.api_key is None
         assert config.environment == "production"
-        assert config.timeout is None
+        assert not hasattr(config, "timeout")
         assert config.enabled is False
         assert config.save_messages is True
         assert config.session_strategy == "per-directory"
@@ -79,12 +79,6 @@ class TestFromEnv:
         assert config.api_key is None
         assert config.base_url == "http://localhost:8000"
         assert config.enabled is True
-
-    def test_reads_timeout_from_env(self):
-        with patch.dict(os.environ, {"HONCHO_TIMEOUT": "90"}, clear=True):
-            config = HonchoClientConfig.from_env()
-        assert config.timeout == 90.0
-
 
 class TestFromGlobalConfig:
     def test_missing_config_falls_back_to_env(self, tmp_path):
@@ -263,21 +257,6 @@ class TestFromGlobalConfig:
 
         config = HonchoClientConfig.from_global_config(config_path=config_file)
         assert config.base_url == "http://root:9000"
-
-    def test_timeout_from_config_root(self, tmp_path):
-        config_file = tmp_path / "config.json"
-        config_file.write_text(json.dumps({"timeout": 75}))
-
-        config = HonchoClientConfig.from_global_config(config_path=config_file)
-        assert config.timeout == 75.0
-
-    def test_request_timeout_alias_from_config_root(self, tmp_path):
-        config_file = tmp_path / "config.json"
-        config_file.write_text(json.dumps({"requestTimeout": "82.5"}))
-
-        config = HonchoClientConfig.from_global_config(config_path=config_file)
-        assert config.timeout == 82.5
-
 
 class TestResolveSessionName:
     def test_manual_override(self):
@@ -595,11 +574,10 @@ class TestGetHonchoClient:
         not importlib.util.find_spec("honcho"),
         reason="honcho SDK not installed"
     )
-    def test_passes_timeout_from_config(self):
+    def test_does_not_pass_timeout_to_sdk(self):
         fake_honcho = MagicMock(name="Honcho")
         cfg = HonchoClientConfig(
             api_key="test-key",
-            timeout=91.0,
             workspace_id="hermes",
             environment="production",
         )
@@ -609,13 +587,13 @@ class TestGetHonchoClient:
 
         assert client is fake_honcho
         mock_honcho.assert_called_once()
-        assert mock_honcho.call_args.kwargs["timeout"] == 91.0
+        assert "timeout" not in mock_honcho.call_args.kwargs
 
     @pytest.mark.skipif(
         not importlib.util.find_spec("honcho"),
         reason="honcho SDK not installed"
     )
-    def test_hermes_config_timeout_override_used_when_config_timeout_missing(self):
+    def test_hermes_timeout_config_is_ignored(self):
         fake_honcho = MagicMock(name="Honcho")
         cfg = HonchoClientConfig(
             api_key="test-key",
@@ -624,54 +602,12 @@ class TestGetHonchoClient:
         )
 
         with patch("honcho.Honcho", return_value=fake_honcho) as mock_honcho, \
-             patch("hermes_cli.config.load_config", return_value={"honcho": {"timeout": 88}}):
+             patch("hermes_cli.config.load_config", return_value={"honcho": {"timeout": 88, "request_timeout": "77.5"}}):
             client = get_honcho_client(cfg)
 
         assert client is fake_honcho
         mock_honcho.assert_called_once()
-        assert mock_honcho.call_args.kwargs["timeout"] == 88.0
-
-    @pytest.mark.skipif(
-        not importlib.util.find_spec("honcho"),
-        reason="honcho SDK not installed"
-    )
-    def test_defaults_to_30s_when_no_timeout_configured(self):
-        from plugins.memory.honcho.client import _DEFAULT_HTTP_TIMEOUT
-
-        fake_honcho = MagicMock(name="Honcho")
-        cfg = HonchoClientConfig(
-            api_key="test-key",
-            workspace_id="hermes",
-            environment="production",
-        )
-
-        with patch("honcho.Honcho", return_value=fake_honcho) as mock_honcho, \
-             patch("hermes_cli.config.load_config", return_value={}):
-            client = get_honcho_client(cfg)
-
-        assert client is fake_honcho
-        mock_honcho.assert_called_once()
-        assert mock_honcho.call_args.kwargs["timeout"] == _DEFAULT_HTTP_TIMEOUT
-
-    @pytest.mark.skipif(
-        not importlib.util.find_spec("honcho"),
-        reason="honcho SDK not installed"
-    )
-    def test_hermes_request_timeout_alias_used(self):
-        fake_honcho = MagicMock(name="Honcho")
-        cfg = HonchoClientConfig(
-            api_key="test-key",
-            workspace_id="hermes",
-            environment="production",
-        )
-
-        with patch("honcho.Honcho", return_value=fake_honcho) as mock_honcho, \
-             patch("hermes_cli.config.load_config", return_value={"honcho": {"request_timeout": "77.5"}}):
-            client = get_honcho_client(cfg)
-
-        assert client is fake_honcho
-        mock_honcho.assert_called_once()
-        assert mock_honcho.call_args.kwargs["timeout"] == 77.5
+        assert "timeout" not in mock_honcho.call_args.kwargs
 
 
 class TestResolveSessionNameGatewayKey:

--- a/tests/honcho_plugin/test_session.py
+++ b/tests/honcho_plugin/test_session.py
@@ -1301,9 +1301,9 @@ class TestSessionStartDialecticPrewarm:
         # The sync first-turn path must NOT have fired another .chat()
         assert p._manager.dialectic_query.call_count == 0
 
-    def test_turn1_falls_back_to_sync_when_prewarm_missing(self):
+    def test_turn1_queues_async_recovery_when_prewarm_missing(self):
         """If the prewarm produced nothing (empty graph, API blip), turn 1
-        still fires its own sync dialectic."""
+        queues a recovery dialectic without blocking on a timeout."""
         p = self._make_provider(dialectic_result="")  # prewarm returns empty
         if p._prefetch_thread:
             p._prefetch_thread.join(timeout=3.0)
@@ -1317,12 +1317,16 @@ class TestSessionStartDialecticPrewarm:
         p._turn_count = 1
 
         result = p.prefetch("hello world")
-        assert "sync recovery" in result
+        if p._prefetch_thread:
+            p._prefetch_thread.join(timeout=3.0)
+        p._turn_count = 2
+        recovered = p.prefetch("next turn")
+        assert ("sync recovery" in result) or ("sync recovery" in recovered)
         assert p._manager.dialectic_query.call_count == 1
 
 
 class TestDialecticLiveness:
-    """Liveness + observability: stale-thread recovery, stale-result discard,
+    """Liveness + observability: live-thread guarding, stale-result discard,
     empty-streak backoff, and the snapshot method used for diagnostics."""
 
     @staticmethod
@@ -1330,7 +1334,7 @@ class TestDialecticLiveness:
         from unittest.mock import patch, MagicMock
         from plugins.memory.honcho.client import HonchoClientConfig
 
-        defaults = dict(api_key="test-key", enabled=True, recall_mode="hybrid", timeout=2.0)
+        defaults = dict(api_key="test-key", enabled=True, recall_mode="hybrid")
         if cfg_extra:
             defaults.update(cfg_extra)
         cfg = HonchoClientConfig(**defaults)
@@ -1349,8 +1353,8 @@ class TestDialecticLiveness:
         _settle_prewarm(provider)
         return provider
 
-    def test_stale_thread_is_treated_as_dead(self):
-        """A thread older than timeout × multiplier no longer blocks new fires."""
+    def test_live_thread_is_not_recycled_by_age(self):
+        """A live thread is not recycled based on age; no timeout governs it."""
         import threading as _threading
         p = self._make_provider()
         p._session_key = "test"
@@ -1358,20 +1362,18 @@ class TestDialecticLiveness:
         p._last_dialectic_turn = 0
         p._manager.dialectic_query.return_value = "fresh synthesis"
 
-        # Plant an alive thread with an old timestamp (stale)
+        # Plant an alive thread with an old timestamp. Even if it looks old,
+        # the provider should not use timeout-age logic to recycle it.
         hold = _threading.Event()
         stuck = _threading.Thread(target=lambda: hold.wait(timeout=10.0), daemon=True)
         stuck.start()
         p._prefetch_thread = stuck
-        # timeout=2.0, multiplier=2.0, so anything older than 4s is stale
         p._prefetch_thread_started_at = 0.0  # very old (1970 monotonic baseline)
 
         p.queue_prefetch("hello")
-        # New thread should have been spawned since stuck one is stale
-        assert p._prefetch_thread is not stuck, "stale thread must be recycled"
-        if p._prefetch_thread:
-            p._prefetch_thread.join(timeout=2.0)
-        assert p._manager.dialectic_query.call_count == 1
+        # Existing live thread should remain in place; no new dialectic call.
+        assert p._prefetch_thread is stuck
+        assert p._manager.dialectic_query.call_count == 0
         hold.set()
         stuck.join(timeout=2.0)
 

--- a/tests/plugins/memory/test_llm_wiki_caretaker.py
+++ b/tests/plugins/memory/test_llm_wiki_caretaker.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+import yaml
+
+from hermes_wiki.caretaker import (
+    caretaker_report_to_dict,
+    main as caretaker_main,
+    render_caretaker_report,
+    run_caretaker,
+)
+from hermes_wiki.config import WikiConfig
+from hermes_wiki.frontmatter import write_page
+from hermes_wiki.proposals import MemoryProposal, queue_proposal
+
+
+class FakeSearchResult:
+    def __init__(self, page_path: str):
+        self.page_path = page_path
+
+
+class FakeSearcher:
+    def __init__(self, results_by_query):
+        self.results_by_query = results_by_query
+        self.calls = []
+
+    def search(self, query, limit=5):
+        self.calls.append((query, limit))
+        return self.results_by_query.get(query, [])
+
+
+def _write_page(config: WikiConfig, rel_path: str, fm: dict, body: str):
+    path = config.wiki_path / rel_path
+    write_page(path, fm, body)
+    return path
+
+
+def test_caretaker_report_is_read_only_and_classifies_pending_proposal(tmp_path):
+    config = WikiConfig(wiki_path=tmp_path / "wiki", wiki_name="test")
+    queue_proposal(
+        config,
+        MemoryProposal(
+            title="Pending memory",
+            rationale="Hermes should self-review this later.",
+            proposed_changes=["Store durable agent-owned memory."],
+            source_refs=["test-source"],
+        ),
+        write=True,
+    )
+    proposal_path = config.wiki_path / "proposals" / "pending-memory.md"
+    before = proposal_path.read_text(encoding="utf-8")
+
+    report = run_caretaker(config)
+
+    assert proposal_path.read_text(encoding="utf-8") == before
+    assert report.maintenance.pending_proposals == 1
+    assert report.has_blockers is False
+    assert any(action.kind == "review_pending_proposal" and action.autonomous for action in report.actions)
+
+
+def test_caretaker_runs_retrieval_eval_when_cases_are_supplied(tmp_path):
+    config = WikiConfig(wiki_path=tmp_path / "wiki", wiki_name="test")
+    cases_path = tmp_path / "retrieval.yaml"
+    cases_path.write_text(
+        yaml.safe_dump([
+            {
+                "query": "How should Hermes use memory?",
+                "expected_pages": ["concepts/hermes-memory.md"],
+                "top_k": 2,
+            }
+        ]),
+        encoding="utf-8",
+    )
+    searcher = FakeSearcher({"How should Hermes use memory?": [FakeSearchResult("concepts/hermes-memory.md")]})
+
+    report = run_caretaker(config, eval_cases_path=cases_path, searcher=searcher)
+
+    assert report.retrieval_eval is not None
+    assert report.retrieval_eval.passed is True
+    assert searcher.calls == [("How should Hermes use memory?", 2)]
+    assert report.has_blockers is False
+
+
+def test_caretaker_marks_eval_failure_as_blocker(tmp_path):
+    config = WikiConfig(wiki_path=tmp_path / "wiki", wiki_name="test")
+    cases_path = tmp_path / "retrieval.yaml"
+    cases_path.write_text(
+        yaml.safe_dump([
+            {
+                "query": "What is the user's preferred name?",
+                "expected_pages": ["entities/example-user.md"],
+            }
+        ]),
+        encoding="utf-8",
+    )
+    searcher = FakeSearcher({"What is the user's preferred name?": [FakeSearchResult("entities/hermes.md")]})
+
+    report = run_caretaker(config, eval_cases_path=cases_path, searcher=searcher)
+
+    assert report.has_blockers is True
+    assert any(action.kind == "fix_retrieval_regression" and action.severity == "error" for action in report.actions)
+
+
+def test_caretaker_report_to_dict_is_json_serializable(tmp_path):
+    config = WikiConfig(wiki_path=tmp_path / "wiki", wiki_name="test")
+
+    payload = caretaker_report_to_dict(run_caretaker(config))
+
+    assert json.loads(json.dumps(payload))["maintenance"]["total_pages"] == 0
+    assert "actions" in payload
+
+
+def test_render_caretaker_report_is_agent_native(tmp_path):
+    config = WikiConfig(wiki_path=tmp_path / "wiki", wiki_name="test")
+
+    text = render_caretaker_report(run_caretaker(config))
+
+    assert "# LLM Wiki Caretaker Report" in text
+    assert "## Hermes actions" in text
+    assert "Human UI" not in text
+
+
+def test_caretaker_cli_is_quiet_when_healthy(tmp_path, capsys):
+    config_path = tmp_path / "config.yaml"
+    wiki_path = tmp_path / "wiki"
+    config_path.write_text(f"wiki:\n  path: {wiki_path}\n  name: test\n", encoding="utf-8")
+
+    code = caretaker_main(["--config", str(config_path), "--quiet"])
+
+    assert code == 0
+    assert capsys.readouterr().out == ""
+    assert not wiki_path.exists()
+
+
+def test_caretaker_cli_writes_report_only_to_reports_namespace(tmp_path, capsys):
+    config_path = tmp_path / "config.yaml"
+    wiki_path = tmp_path / "wiki"
+    config_path.write_text(f"wiki:\n  path: {wiki_path}\n  name: test\n", encoding="utf-8")
+
+    code = caretaker_main(["--config", str(config_path), "--write-report", "reports/caretaker.md"])
+
+    payload = json.loads(capsys.readouterr().out)
+    assert code == 0
+    assert payload == {"path": str(wiki_path / "reports" / "caretaker.md"), "written": True}
+    assert (wiki_path / "reports" / "caretaker.md").exists()
+
+
+def test_caretaker_cli_rejects_write_report_outside_reports(tmp_path):
+    config_path = tmp_path / "config.yaml"
+    wiki_path = tmp_path / "wiki"
+    config_path.write_text(f"wiki:\n  path: {wiki_path}\n  name: test\n", encoding="utf-8")
+    canonical = _write_page(
+        WikiConfig(wiki_path=wiki_path, wiki_name="test"),
+        "concepts/existing.md",
+        {"title": "Existing", "type": "concept", "sources": ["raw/articles/source.md"]},
+        "Original.",
+    )
+    before = canonical.read_text(encoding="utf-8")
+
+    with pytest.raises(SystemExit):
+        caretaker_main(["--config", str(config_path), "--write-report", "concepts/existing.md"])
+
+    assert canonical.read_text(encoding="utf-8") == before

--- a/tests/plugins/memory/test_llm_wiki_caretaker_orchestrator.py
+++ b/tests/plugins/memory/test_llm_wiki_caretaker_orchestrator.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from hermes_wiki.caretaker_orchestrator import (
+    caretaker_action_to_proposal,
+    main as orchestrator_main,
+    run_caretaker_orchestrator,
+)
+from hermes_wiki.config import WikiConfig
+from hermes_wiki.frontmatter import write_page
+
+
+def _write_config(path, wiki_path):
+    path.write_text(f"wiki:\n  path: {wiki_path}\n  name: test\n", encoding="utf-8")
+
+
+def test_caretaker_orchestrator_drafts_proposal_for_broken_link_without_writing(tmp_path):
+    config = WikiConfig(wiki_path=tmp_path / "wiki", wiki_name="test")
+    write_page(
+        config.wiki_path / "concepts" / "broken.md",
+        {"title": "Broken", "type": "concept", "sources": ["raw/articles/source.md"]},
+        "Links to [[Missing Concept]].",
+    )
+
+    result = run_caretaker_orchestrator(config, queue=False)
+
+    assert result.proposals
+    assert result.queued_paths == []
+    assert not (config.wiki_path / "proposals").exists()
+    assert result.proposals[0].title.startswith("Repair broken link")
+    assert result.proposals[0].target_pages == ["concepts/broken.md"]
+
+
+def test_caretaker_orchestrator_queues_proposals_only_when_explicit(tmp_path):
+    config = WikiConfig(wiki_path=tmp_path / "wiki", wiki_name="test")
+    write_page(
+        config.wiki_path / "concepts" / "no-source.md",
+        {"title": "No Source", "type": "concept"},
+        "Needs provenance.",
+    )
+
+    result = run_caretaker_orchestrator(config, queue=True)
+
+    assert len(result.queued_paths) == 2  # missing source + orphan graph strengthening
+    assert all(path.exists() for path in result.queued_paths)
+    assert all(path.parent == config.wiki_path / "proposals" for path in result.queued_paths)
+
+
+def test_caretaker_orchestrator_has_no_output_for_clean_wiki(tmp_path):
+    config = WikiConfig(wiki_path=tmp_path / "wiki", wiki_name="test")
+    write_page(
+        config.wiki_path / "concepts" / "a.md",
+        {"title": "A", "type": "concept", "sources": ["raw/articles/source.md"]},
+        "Links to [[B]].",
+    )
+    write_page(
+        config.wiki_path / "concepts" / "b.md",
+        {"title": "B", "type": "concept", "sources": ["raw/articles/source.md"]},
+        "Links to [[A]].",
+    )
+
+    result = run_caretaker_orchestrator(config)
+
+    assert result.proposals == []
+    assert result.queued_paths == []
+
+
+def test_caretaker_action_to_proposal_rejects_unknown_action_kind():
+    class Action:
+        kind = "unknown"
+        message = "Unknown"
+        file_path = None
+        severity = "info"
+
+    assert caretaker_action_to_proposal(Action()) is None
+
+
+def test_caretaker_orchestrator_cli_prints_drafts_without_writing(tmp_path, capsys):
+    config_path = tmp_path / "config.yaml"
+    wiki_path = tmp_path / "wiki"
+    _write_config(config_path, wiki_path)
+    write_page(
+        wiki_path / "concepts" / "broken.md",
+        {"title": "Broken", "type": "concept", "sources": ["raw/articles/source.md"]},
+        "Links to [[Missing Concept]].",
+    )
+
+    code = orchestrator_main(["--config", str(config_path), "--json"])
+
+    payload = json.loads(capsys.readouterr().out)
+    assert code == 0
+    assert payload["queued"] is False
+    assert payload["proposals"][0]["title"].startswith("Repair broken link")
+    assert not (wiki_path / "proposals").exists()
+
+
+def test_caretaker_orchestrator_cli_queue_requires_explicit_config(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "ambient-home"))
+
+    with pytest.raises(SystemExit):
+        orchestrator_main(["--queue"])
+
+    assert not (tmp_path / "ambient-home").exists()
+
+
+def test_caretaker_orchestrator_cli_queues_with_explicit_config(tmp_path, capsys):
+    config_path = tmp_path / "config.yaml"
+    wiki_path = tmp_path / "wiki"
+    _write_config(config_path, wiki_path)
+    write_page(
+        wiki_path / "concepts" / "broken.md",
+        {"title": "Broken", "type": "concept", "sources": ["raw/articles/source.md"]},
+        "Links to [[Missing Concept]].",
+    )
+
+    code = orchestrator_main(["--config", str(config_path), "--queue", "--json"])
+
+    payload = json.loads(capsys.readouterr().out)
+    assert code == 0
+    assert payload["queued"] is True
+    assert payload["queued_paths"]
+    assert (wiki_path / "proposals").exists()

--- a/tests/plugins/memory/test_llm_wiki_embedding_cache.py
+++ b/tests/plugins/memory/test_llm_wiki_embedding_cache.py
@@ -1,0 +1,181 @@
+from __future__ import annotations
+
+import sqlite3
+
+from vector_core.embeddings import EmbeddingCache as VectorCoreEmbeddingCache
+from vector_core.embeddings import EmbeddingClient as VectorCoreEmbeddingClient
+
+from hermes_wiki.config import WikiConfig
+from hermes_wiki.search import EmbeddingCache, WikiSearch, _EmbeddingClient
+
+
+class _FakeVectorCoreClient:
+    def __init__(self):
+        self.calls: list[list[str]] = []
+        self.closed = False
+
+    async def embed_batch(self, texts: list[str]) -> list[list[float]]:
+        self.calls.append(list(texts))
+        return [[float(len(text)), float(idx)] for idx, text in enumerate(texts)]
+
+    async def close(self):
+        self.closed = True
+
+
+class _FakeBridge:
+    def run(self, coro):
+        return _run_for_test(coro)
+
+    def close(self):
+        return None
+
+
+def _run_for_test(coro):
+    import asyncio
+
+    return asyncio.run(coro)
+
+
+def _embedder(tmp_path, *, max_entries=100):
+    config = WikiConfig(
+        embedding_model="test-model",
+        embedding_dim=2,
+        embedding_cache_path=tmp_path / "embeddings.db",
+        embedding_cache_max_entries=max_entries,
+    )
+    embedder = _EmbeddingClient.__new__(_EmbeddingClient)
+    embedder._client = _FakeVectorCoreClient()
+    embedder._bridge = _FakeBridge()
+    embedder._model = config.embedding_model
+    embedder._dim = config.embedding_dim
+    embedder._cache = EmbeddingCache(config.embedding_cache_path, max_entries=config.embedding_cache_max_entries)
+    return embedder
+
+
+def test_embedding_cache_wraps_vector_core_cache(tmp_path):
+    cache = EmbeddingCache(tmp_path / "cache.db", max_entries=10)
+
+    assert isinstance(cache._vector_cache, VectorCoreEmbeddingCache)
+    assert cache.cache_path == tmp_path / "cache.db"
+
+
+def test_embedding_client_instantiates_vector_core_embedding_client(tmp_path):
+    config = WikiConfig(
+        embedding_url="http://embedding.test/v1",
+        embedding_model="test-model",
+        embedding_dim=2,
+        embedding_cache_path=tmp_path / "embeddings.db",
+    )
+
+    embedder = _EmbeddingClient(config)
+
+    assert isinstance(embedder._client, VectorCoreEmbeddingClient)
+    assert embedder._client.base_url == "http://embedding.test"
+    assert embedder._client.model == "test-model"
+    assert embedder._client.dim == 2
+
+
+def test_embedding_cache_round_trips_json_vectors_and_tracks_stats(tmp_path):
+    cache = EmbeddingCache(tmp_path / "cache.db", max_entries=10)
+    key = cache.key_for("hello", model="model-a", dim=2)
+
+    assert cache.get(key) is None
+    cache.set(key, [1.0, 2.5], model="model-a", dim=2)
+
+    assert cache.get(key) == [1.0, 2.5]
+    stats = cache.stats()
+    assert stats["entries"] == 1
+    assert stats["hits"] == 1
+    assert stats["misses"] == 1
+    assert stats["hit_rate"] == 0.5
+
+
+def test_embedding_cache_keys_include_model_and_dimension(tmp_path):
+    cache = EmbeddingCache(tmp_path / "cache.db")
+
+    text = "same text"
+    assert cache.key_for(text, model="model-a", dim=2) != cache.key_for(text, model="model-b", dim=2)
+    assert cache.key_for(text, model="model-a", dim=2) != cache.key_for(text, model="model-a", dim=4)
+
+
+def test_embedding_cache_deletes_corrupt_rows_as_misses(tmp_path):
+    cache = EmbeddingCache(tmp_path / "cache.db")
+    key = cache.key_for("bad", model="model-a", dim=2)
+    with sqlite3.connect(cache.cache_path) as conn:
+        conn.execute(
+            "INSERT INTO embeddings (content_hash, embedding, model, dim, created_at, accessed_at) VALUES (?, ?, ?, ?, '', '')",
+            (key, b"not-json", "model-a", 2),
+        )
+
+    assert cache.get(key) is None
+    with sqlite3.connect(cache.cache_path) as conn:
+        count = conn.execute("SELECT COUNT(*) FROM embeddings WHERE content_hash = ?", (key,)).fetchone()[0]
+    assert count == 0
+
+
+def test_embedding_cache_lru_eviction_respects_max_entries(tmp_path):
+    cache = EmbeddingCache(tmp_path / "cache.db", max_entries=2)
+    for text in ["one", "two", "three"]:
+        key = cache.key_for(text, model="model-a", dim=2)
+        cache.set(key, [1.0, 2.0], model="model-a", dim=2)
+
+    assert cache.stats()["entries"] == 2
+    assert cache.get(cache.key_for("three", model="model-a", dim=2)) == [1.0, 2.0]
+
+
+def test_embedding_client_uses_persistent_cache_for_duplicate_texts(tmp_path):
+    embedder = _embedder(tmp_path)
+
+    assert embedder.embed_batch(["alpha", "alpha", "beta"]) == [[5.0, 0.0], [5.0, 0.0], [4.0, 1.0]]
+    assert embedder._client.calls == [["alpha", "beta"]]
+
+    assert embedder.embed_batch(["alpha", "beta"]) == [[5.0, 0.0], [4.0, 1.0]]
+    assert embedder._client.calls == [["alpha", "beta"]]
+
+
+def test_embedding_client_cache_survives_new_embedder_instance(tmp_path):
+    first = _embedder(tmp_path)
+    assert first.embed_single("alpha") == [5.0, 0.0]
+    assert first._client.calls == [["alpha"]]
+
+    second = _embedder(tmp_path)
+    assert second.embed_single("alpha") == [5.0, 0.0]
+    assert second._client.calls == []
+
+
+def test_embedding_client_can_disable_cache_for_read_only_contexts(tmp_path):
+    config = WikiConfig(
+        embedding_model="test-model",
+        embedding_dim=2,
+        embedding_cache_path=tmp_path / "embeddings.db",
+    )
+    embedder = _EmbeddingClient.__new__(_EmbeddingClient)
+    embedder._client = _FakeVectorCoreClient()
+    embedder._bridge = _FakeBridge()
+    embedder._model = config.embedding_model
+    embedder._dim = config.embedding_dim
+    embedder._cache = None
+
+    assert embedder.embed_batch(["alpha", "alpha"]) == [[5.0, 0.0], [5.0, 0.0]]
+    assert embedder._client.calls == [["alpha"]]
+    assert not config.embedding_cache_path.exists()
+
+
+def test_wiki_search_read_only_disables_embedding_cache(monkeypatch, tmp_path):
+    captured = {}
+
+    class FakeQdrantClient:
+        def __init__(self, url):
+            self.url = url
+
+    class FakeEmbeddingClient:
+        def __init__(self, config, *, cache_enabled=True):
+            captured["cache_enabled"] = cache_enabled
+
+    monkeypatch.setattr("hermes_wiki.search._EmbeddingClient", FakeEmbeddingClient)
+    monkeypatch.setattr("qdrant_client.QdrantClient", FakeQdrantClient)
+
+    config = WikiConfig(wiki_path=tmp_path / "wiki", wiki_name="test")
+    WikiSearch(config, ensure_collection=False, read_only=True)
+
+    assert captured["cache_enabled"] is False

--- a/tests/plugins/memory/test_llm_wiki_hybrid_search.py
+++ b/tests/plugins/memory/test_llm_wiki_hybrid_search.py
@@ -1,0 +1,220 @@
+from types import SimpleNamespace
+
+from hermes_wiki.config import WikiConfig
+from hermes_wiki.search import WikiSearch, WikiSearchResult
+
+
+def _result(page_path, *, score, chunk_index=0, title=None, page_type="concept", text="", tags=None):
+    return WikiSearchResult(
+        page_path=page_path,
+        title=title or page_path.rsplit("/", 1)[-1].removesuffix(".md"),
+        page_type=page_type,
+        chunk_index=chunk_index,
+        text=text,
+        score=score,
+        tags=tags or [],
+    )
+
+
+class FakeScrollClient:
+    def __init__(self, payloads):
+        self.payloads = payloads
+        self.scroll_calls = []
+
+    def scroll(self, **kwargs):
+        self.scroll_calls.append(kwargs)
+        return [SimpleNamespace(payload=payload) for payload in self.payloads], None
+
+
+class FakeDenseSearch(WikiSearch):
+    def __init__(self, dense_results, lexical_payloads):
+        self.config = WikiConfig(wiki_name="test")
+        self._dense_results = dense_results
+        self._client = FakeScrollClient(lexical_payloads)
+
+    def _dense_search(self, query, *, limit, page_type=None, tags=None, exclude_sources=False):
+        return self._dense_results[:limit]
+
+
+def test_tokenize_for_sparse_search_keeps_paths_ids_and_acronyms():
+    from hermes_wiki.search import tokenize_for_sparse_search
+
+    assert tokenize_for_sparse_search("Qwen3-Embedding-8B concepts/foo_bar.md GPT-5.5") == [
+        "qwen3",
+        "embedding",
+        "8b",
+        "concepts",
+        "foo_bar",
+        "md",
+        "gpt",
+        "5",
+        "5",
+    ]
+
+
+def test_reciprocal_rank_fusion_promotes_results_seen_by_both_rankers():
+    from hermes_wiki.search import reciprocal_rank_fusion
+
+    dense = [
+        _result("concepts/dense-only.md", score=0.99),
+        _result("concepts/shared.md", score=0.90),
+    ]
+    sparse = [
+        _result("concepts/shared.md", score=4.0),
+        _result("concepts/sparse-only.md", score=3.0),
+    ]
+
+    fused = reciprocal_rank_fusion([dense, sparse], limit=3, k=10)
+
+    assert [r.page_path for r in fused] == [
+        "concepts/shared.md",
+        "concepts/dense-only.md",
+        "concepts/sparse-only.md",
+    ]
+    assert fused[0].score > fused[1].score
+
+
+def test_sparse_search_scores_literal_query_terms_from_payloads():
+    searcher = WikiSearch.__new__(WikiSearch)
+    searcher.config = WikiConfig(wiki_name="test")
+    searcher._client = FakeScrollClient([
+        {
+            "page_path": "concepts/random.md",
+            "title": "Random",
+            "page_type": "concept",
+            "chunk_index": 0,
+            "text": "semantic discussion without the literal token",
+            "tags": [],
+        },
+        {
+            "page_path": "entities/qwen3-embedding-8b.md",
+            "title": "Qwen3 Embedding 8B",
+            "page_type": "entity",
+            "chunk_index": 0,
+            "text": "Local embedding endpoint for Qwen3-Embedding-8B",
+            "tags": ["embedding"],
+        },
+    ])
+
+    results = searcher.sparse_search("Qwen3-Embedding-8B", limit=2)
+
+    assert [r.page_path for r in results] == ["entities/qwen3-embedding-8b.md"]
+    assert results[0].score > 0
+    assert searcher._client.scroll_calls[0]["collection_name"] == "hermes_wiki_test"
+
+
+def test_sparse_search_honors_filters_and_exclude_sources():
+    searcher = WikiSearch.__new__(WikiSearch)
+    searcher.config = WikiConfig(wiki_name="test")
+    searcher._client = FakeScrollClient([
+        {
+            "page_path": "raw/articles/qwen.md",
+            "title": "Qwen Source",
+            "page_type": "source",
+            "chunk_index": 0,
+            "text": "Qwen3-Embedding-8B",
+            "tags": [],
+        },
+        {
+            "page_path": "entities/qwen.md",
+            "title": "Qwen Entity",
+            "page_type": "entity",
+            "chunk_index": 0,
+            "text": "Qwen3-Embedding-8B",
+            "tags": ["embedding"],
+        },
+        {
+            "page_path": "concepts/qwen.md",
+            "title": "Qwen Concept",
+            "page_type": "concept",
+            "chunk_index": 0,
+            "text": "Qwen3-Embedding-8B",
+            "tags": ["embedding"],
+        },
+    ])
+
+    results = searcher.sparse_search(
+        "Qwen3-Embedding-8B",
+        limit=5,
+        page_type="entity",
+        tags=["embedding"],
+        exclude_sources=True,
+    )
+
+    assert [r.page_path for r in results] == ["entities/qwen.md"]
+
+
+def test_hybrid_search_fuses_dense_and_sparse_results():
+    searcher = FakeDenseSearch(
+        dense_results=[
+            _result("concepts/semantic.md", score=0.99),
+            _result("entities/qwen3-embedding-8b.md", score=0.60),
+        ],
+        lexical_payloads=[
+            {
+                "page_path": "entities/qwen3-embedding-8b.md",
+                "title": "Qwen3 Embedding 8B",
+                "page_type": "entity",
+                "chunk_index": 0,
+                "text": "Qwen3-Embedding-8B literal config key",
+                "tags": ["embedding"],
+            },
+            {
+                "page_path": "concepts/path-only.md",
+                "title": "Path Only",
+                "page_type": "concept",
+                "chunk_index": 0,
+                "text": "Qwen3-Embedding-8B appears here too",
+                "tags": [],
+            },
+        ],
+    )
+
+    results = searcher.search("Qwen3-Embedding-8B", limit=3, search_mode="hybrid")
+
+    assert [r.page_path for r in results] == [
+        "entities/qwen3-embedding-8b.md",
+        "concepts/semantic.md",
+        "concepts/path-only.md",
+    ]
+
+
+def test_search_defaults_to_dense_mode_for_backward_compatibility():
+    searcher = FakeDenseSearch(
+        dense_results=[_result("concepts/semantic.md", score=0.99)],
+        lexical_payloads=[
+            {
+                "page_path": "entities/qwen3-embedding-8b.md",
+                "title": "Qwen3 Embedding 8B",
+                "page_type": "entity",
+                "chunk_index": 0,
+                "text": "Qwen3-Embedding-8B",
+                "tags": [],
+            }
+        ],
+    )
+
+    results = searcher.search("Qwen3-Embedding-8B", limit=2)
+
+    assert [r.page_path for r in results] == ["concepts/semantic.md"]
+    assert searcher._client.scroll_calls == []
+
+
+def test_search_supports_sparse_only_mode():
+    searcher = FakeDenseSearch(
+        dense_results=[_result("concepts/semantic.md", score=0.99)],
+        lexical_payloads=[
+            {
+                "page_path": "entities/qwen3-embedding-8b.md",
+                "title": "Qwen3 Embedding 8B",
+                "page_type": "entity",
+                "chunk_index": 0,
+                "text": "Qwen3-Embedding-8B",
+                "tags": [],
+            }
+        ],
+    )
+
+    results = searcher.search("Qwen3-Embedding-8B", limit=2, search_mode="sparse")
+
+    assert [r.page_path for r in results] == ["entities/qwen3-embedding-8b.md"]

--- a/tests/plugins/memory/test_llm_wiki_maintenance.py
+++ b/tests/plugins/memory/test_llm_wiki_maintenance.py
@@ -1,0 +1,171 @@
+import json
+
+from hermes_wiki.config import WikiConfig
+from hermes_wiki.frontmatter import write_page
+from hermes_wiki.maintenance import generate_maintenance_report, maintenance_report_to_dict, render_maintenance_report, main as maintenance_main
+from hermes_wiki.proposals import MemoryProposal, queue_proposal
+
+
+def _write_page(config, rel_path, fm, body):
+    path = config.wiki_path / rel_path
+    write_page(path, fm, body)
+    return path
+
+
+def test_generate_maintenance_report_detects_broken_links_and_orphans(tmp_path):
+    config = WikiConfig(wiki_path=tmp_path / "wiki", wiki_name="test")
+    _write_page(
+        config,
+        "concepts/a.md",
+        {"title": "A", "type": "concept", "created": "2026-01-01", "updated": "2026-01-01"},
+        "Links to [[Missing Page]].",
+    )
+    _write_page(
+        config,
+        "concepts/orphan.md",
+        {"title": "Orphan", "type": "concept", "created": "2026-01-01", "updated": "2026-01-01"},
+        "No inbound links.",
+    )
+
+    report = generate_maintenance_report(config)
+
+    categories = {issue.category for issue in report.issues}
+    assert "broken_link" in categories
+    assert "orphan_page" in categories
+    assert report.total_pages == 2
+    assert report.broken_links == 1
+    assert report.orphan_pages >= 1
+
+
+def test_generate_maintenance_report_detects_pending_proposals(tmp_path):
+    config = WikiConfig(wiki_path=tmp_path / "wiki", wiki_name="test")
+    queue_proposal(
+        config,
+        MemoryProposal(
+            title="Pending proposal",
+            rationale="Needs review.",
+            proposed_changes=["Promote after review."],
+            source_refs=["test-source"],
+        ),
+        write=True,
+    )
+
+    report = generate_maintenance_report(config)
+
+    assert report.pending_proposals == 1
+    assert any(issue.category == "pending_proposal" for issue in report.issues)
+
+
+def test_generate_maintenance_report_detects_source_coverage_gap(tmp_path):
+    config = WikiConfig(wiki_path=tmp_path / "wiki", wiki_name="test")
+    _write_page(
+        config,
+        "concepts/no-source.md",
+        {"title": "No Source", "type": "concept", "created": "2026-01-01", "updated": "2026-01-01"},
+        "This page has no provenance marker.",
+    )
+
+    report = generate_maintenance_report(config)
+
+    assert report.pages_without_sources == 1
+    assert any(issue.category == "missing_source_coverage" for issue in report.issues)
+
+
+def test_maintenance_report_to_dict_is_json_serializable(tmp_path):
+    config = WikiConfig(wiki_path=tmp_path / "wiki", wiki_name="test")
+    _write_page(
+        config,
+        "concepts/a.md",
+        {"title": "A", "type": "concept", "created": "2026-01-01", "updated": "2026-01-01"},
+        "Body.",
+    )
+
+    payload = maintenance_report_to_dict(generate_maintenance_report(config))
+
+    assert json.loads(json.dumps(payload))["total_pages"] == 1
+    assert "issues" in payload
+
+
+def test_render_maintenance_report_contains_summary(tmp_path):
+    config = WikiConfig(wiki_path=tmp_path / "wiki", wiki_name="test")
+    _write_page(
+        config,
+        "concepts/a.md",
+        {"title": "A", "type": "concept", "created": "2026-01-01", "updated": "2026-01-01"},
+        "Body.",
+    )
+
+    text = render_maintenance_report(generate_maintenance_report(config))
+
+    assert "# LLM Wiki Maintenance Report" in text
+    assert "Pages:" in text
+    assert "Issues:" in text
+
+
+def test_maintenance_cli_is_read_only_by_default(tmp_path, capsys):
+    config_path = tmp_path / "config.yaml"
+    wiki_path = tmp_path / "wiki"
+    config_path.write_text(f"wiki:\n  path: {wiki_path}\n  name: test\n", encoding="utf-8")
+
+    code = maintenance_main(["--config", str(config_path)])
+
+    assert code == 0
+    assert "# LLM Wiki Maintenance Report" in capsys.readouterr().out
+    assert not wiki_path.exists()
+
+
+def test_maintenance_cli_write_report_requires_explicit_config(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "ambient-home"))
+
+    try:
+        maintenance_main(["--write-report", "reports/maintenance.md"])
+    except SystemExit:
+        pass
+
+    assert not (tmp_path / "ambient-home").exists()
+
+
+def test_maintenance_cli_write_report_allows_reports_namespace_only(tmp_path, capsys):
+    config_path = tmp_path / "config.yaml"
+    wiki_path = tmp_path / "wiki"
+    config_path.write_text(f"wiki:\n  path: {wiki_path}\n  name: test\n", encoding="utf-8")
+
+    code = maintenance_main(["--config", str(config_path), "--write-report", "reports/maintenance.md"])
+
+    payload = json.loads(capsys.readouterr().out)
+    assert code == 0
+    assert payload == {"path": str(wiki_path / "reports" / "maintenance.md"), "written": True}
+    assert (wiki_path / "reports" / "maintenance.md").exists()
+
+
+def test_maintenance_cli_write_report_rejects_canonical_paths(tmp_path):
+    config_path = tmp_path / "config.yaml"
+    wiki_path = tmp_path / "wiki"
+    config_path.write_text(f"wiki:\n  path: {wiki_path}\n  name: test\n", encoding="utf-8")
+    canonical = _write_page(
+        WikiConfig(wiki_path=wiki_path, wiki_name="test"),
+        "concepts/existing.md",
+        {"title": "Existing", "type": "concept", "created": "2026-01-01", "updated": "2026-01-01"},
+        "Original canonical content.",
+    )
+    before = canonical.read_text(encoding="utf-8")
+
+    try:
+        maintenance_main(["--config", str(config_path), "--write-report", "concepts/existing.md"])
+    except SystemExit:
+        pass
+
+    assert canonical.read_text(encoding="utf-8") == before
+
+
+def test_maintenance_cli_write_report_rejects_traversal(tmp_path):
+    config_path = tmp_path / "config.yaml"
+    wiki_path = tmp_path / "wiki"
+    config_path.write_text(f"wiki:\n  path: {wiki_path}\n  name: test\n", encoding="utf-8")
+
+    try:
+        maintenance_main(["--config", str(config_path), "--write-report", "../outside.md"])
+    except SystemExit:
+        pass
+
+    assert not (tmp_path / "outside.md").exists()

--- a/tests/plugins/memory/test_llm_wiki_proposal_lifecycle.py
+++ b/tests/plugins/memory/test_llm_wiki_proposal_lifecycle.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from hermes_wiki.config import WikiConfig
+from hermes_wiki.frontmatter import parse_frontmatter
+from hermes_wiki.proposal_lifecycle import (
+    list_proposals,
+    main as proposals_main,
+    proposal_record_to_dict,
+    read_proposal,
+    update_proposal_status,
+)
+from hermes_wiki.proposals import MemoryProposal, queue_proposal
+
+
+def _queue(config: WikiConfig, title: str, *, status: str = "proposed"):
+    return queue_proposal(
+        config,
+        MemoryProposal(
+            title=title,
+            rationale="Review lifecycle behavior.",
+            proposed_changes=["Keep proposal lifecycle explicit."],
+            source_refs=["test-source"],
+            target_pages=["concepts/example.md"],
+            status=status,
+        ),
+        write=True,
+    )
+
+
+def test_list_proposals_returns_records_sorted_by_slug(tmp_path):
+    config = WikiConfig(wiki_path=tmp_path / "wiki", wiki_name="test")
+    _queue(config, "Zulu proposal")
+    _queue(config, "Alpha proposal", status="accepted")
+
+    records = list_proposals(config)
+
+    assert [record.slug for record in records] == ["alpha-proposal", "zulu-proposal"]
+    assert [record.status for record in records] == ["accepted", "proposed"]
+    assert records[0].path == config.wiki_path / "proposals" / "alpha-proposal.md"
+
+
+def test_read_proposal_rejects_unsafe_slug(tmp_path):
+    config = WikiConfig(wiki_path=tmp_path / "wiki", wiki_name="test")
+
+    with pytest.raises(ValueError, match="unsafe proposal slug"):
+        read_proposal(config, "../escape")
+
+
+def test_update_proposal_status_updates_only_proposal_frontmatter(tmp_path):
+    config = WikiConfig(wiki_path=tmp_path / "wiki", wiki_name="test")
+    path = _queue(config, "Lifecycle proposal")
+    body_before = parse_frontmatter(path.read_text(encoding="utf-8"))[1]
+
+    record = update_proposal_status(config, "lifecycle-proposal", "accepted", note="Source-backed and applied.")
+
+    fm, body_after = parse_frontmatter(path.read_text(encoding="utf-8"))
+    assert record.status == "accepted"
+    assert fm["status"] == "accepted"
+    assert fm["review_note"] == "Source-backed and applied."
+    assert "reviewed" in fm
+    assert body_after == body_before
+    assert not (config.wiki_path / "concepts" / "example.md").exists()
+
+
+def test_update_proposal_status_rejects_unknown_status(tmp_path):
+    config = WikiConfig(wiki_path=tmp_path / "wiki", wiki_name="test")
+    _queue(config, "Lifecycle proposal")
+
+    with pytest.raises(ValueError, match="unsupported proposal status"):
+        update_proposal_status(config, "lifecycle-proposal", "maybe")
+
+
+def test_proposal_record_to_dict_is_json_serializable(tmp_path):
+    config = WikiConfig(wiki_path=tmp_path / "wiki", wiki_name="test")
+    _queue(config, "Serializable proposal")
+
+    payload = proposal_record_to_dict(read_proposal(config, "serializable-proposal"))
+
+    assert json.loads(json.dumps(payload))["slug"] == "serializable-proposal"
+    assert payload["target_pages"] == ["concepts/example.md"]
+
+
+def test_proposals_cli_lists_and_shows_with_explicit_config(tmp_path, capsys):
+    config_path = tmp_path / "config.yaml"
+    wiki_path = tmp_path / "wiki"
+    config_path.write_text(f"wiki:\n  path: {wiki_path}\n  name: test\n", encoding="utf-8")
+    _queue(WikiConfig(wiki_path=wiki_path, wiki_name="test"), "CLI proposal")
+
+    code = proposals_main(["--config", str(config_path), "list", "--json"])
+    list_payload = json.loads(capsys.readouterr().out)
+    assert code == 0
+    assert list_payload[0]["slug"] == "cli-proposal"
+
+    code = proposals_main(["--config", str(config_path), "show", "cli-proposal", "--json"])
+    show_payload = json.loads(capsys.readouterr().out)
+    assert code == 0
+    assert show_payload["title"] == "CLI proposal"
+
+
+def test_proposals_cli_mutations_require_explicit_config(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "ambient-home"))
+
+    with pytest.raises(SystemExit):
+        proposals_main(["accept", "anything"])
+
+    assert not (tmp_path / "ambient-home").exists()
+
+
+def test_proposals_cli_accept_reject_close_update_status(tmp_path, capsys):
+    config_path = tmp_path / "config.yaml"
+    wiki_path = tmp_path / "wiki"
+    config_path.write_text(f"wiki:\n  path: {wiki_path}\n  name: test\n", encoding="utf-8")
+    config = WikiConfig(wiki_path=wiki_path, wiki_name="test")
+    _queue(config, "Accept me")
+    _queue(config, "Reject me")
+    _queue(config, "Close me")
+
+    assert proposals_main(["--config", str(config_path), "accept", "accept-me", "--note", "Applied."]) == 0
+    accept_payload = json.loads(capsys.readouterr().out)
+    assert accept_payload["status"] == "accepted"
+
+    assert proposals_main(["--config", str(config_path), "reject", "reject-me"]) == 0
+    reject_payload = json.loads(capsys.readouterr().out)
+    assert reject_payload["status"] == "rejected"
+
+    assert proposals_main(["--config", str(config_path), "close", "close-me"]) == 0
+    close_payload = json.loads(capsys.readouterr().out)
+    assert close_payload["status"] == "closed"

--- a/tests/plugins/memory/test_llm_wiki_proposals.py
+++ b/tests/plugins/memory/test_llm_wiki_proposals.py
@@ -1,0 +1,181 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from hermes_wiki.config import WikiConfig
+from hermes_wiki.frontmatter import parse_frontmatter
+from hermes_wiki.proposals import MemoryProposal, main as propose_main, proposal_to_dict, queue_proposal, render_proposal_markdown
+
+
+def test_render_proposal_markdown_is_source_backed_and_reviewable():
+    proposal = MemoryProposal(
+        title="Remember the example user's default workout context",
+        rationale="Stable coaching preference that prevents repeated correction.",
+        proposed_changes=["Prefer short home workouts by default."],
+        source_refs=["session:test-thread"],
+        target_pages=["concepts/fitness-coaching-preferences.md"],
+        tags=["fitness", "preference"],
+    )
+
+    text = render_proposal_markdown(proposal)
+
+    assert "# Remember the example user's default workout context" in text
+    assert "## Rationale" in text
+    assert "Stable coaching preference" in text
+    assert "## Proposed changes" in text
+    assert "- Prefer short home workouts by default." in text
+    assert "## Source references" in text
+    assert "session:test-thread" in text
+    assert "concepts/fitness-coaching-preferences.md" in text
+
+
+def test_proposal_to_dict_is_json_serializable():
+    proposal = MemoryProposal(
+        title="Strict eval config validation",
+        rationale="Avoid evaluating the wrong wiki profile.",
+        proposed_changes=["Make explicit --config authoritative."],
+        source_refs=["raw/articles/llm-wiki-retrieval-eval-cli-and-karpathy-source-2026-05-21.md"],
+        target_pages=["concepts/strict-eval-config-validation.md"],
+    )
+
+    payload = proposal_to_dict(proposal)
+
+    assert json.loads(json.dumps(payload))["title"] == "Strict eval config validation"
+    assert payload["status"] == "proposed"
+
+
+def test_queue_proposal_requires_explicit_write(tmp_path):
+    config = WikiConfig(wiki_path=tmp_path / "wiki", wiki_name="test")
+    proposal = MemoryProposal(
+        title="Draft only",
+        rationale="Do not write unless explicitly requested.",
+        proposed_changes=["No silent durable writes."],
+        source_refs=["test"],
+    )
+
+    path = queue_proposal(config, proposal, write=False)
+
+    assert path == config.wiki_path / "proposals" / "draft-only.md"
+    assert not path.exists()
+
+
+def test_queue_proposal_writes_review_file_when_explicit(tmp_path):
+    config = WikiConfig(wiki_path=tmp_path / "wiki", wiki_name="test")
+    proposal = MemoryProposal(
+        title="Safe proposal queue",
+        rationale="Review before ingestion.",
+        proposed_changes=["Queue proposals as pending markdown."],
+        source_refs=["test"],
+        target_pages=["concepts/manual-curated-ingestion.md"],
+    )
+
+    path = queue_proposal(config, proposal, write=True)
+
+    assert path == config.wiki_path / "proposals" / "safe-proposal-queue.md"
+    fm, body = parse_frontmatter(path.read_text(encoding="utf-8"))
+    assert fm["type"] == "memory_proposal"
+    assert fm["status"] == "proposed"
+    assert fm["target_pages"] == ["concepts/manual-curated-ingestion.md"]
+    assert "# Safe proposal queue" in body
+
+
+def test_queue_proposal_rejects_unsafe_slug(tmp_path):
+    config = WikiConfig(wiki_path=tmp_path / "wiki", wiki_name="test")
+    proposal = MemoryProposal(
+        title="../escape",
+        rationale="Unsafe title should not be accepted.",
+        proposed_changes=["Reject traversal."],
+        source_refs=["test"],
+        slug="../escape",
+    )
+
+    with pytest.raises(ValueError, match="unsafe proposal slug"):
+        queue_proposal(config, proposal, write=True)
+
+
+def test_queue_proposal_rejects_absolute_target_pages(tmp_path):
+    config = WikiConfig(wiki_path=tmp_path / "wiki", wiki_name="test")
+    proposal = MemoryProposal(
+        title="Unsafe target",
+        rationale="Target pages are review metadata but should still be sane.",
+        proposed_changes=["Reject absolute target metadata."],
+        source_refs=["test"],
+        target_pages=["/tmp/outside.md"],
+    )
+
+    with pytest.raises(ValueError, match="target_pages"):
+        queue_proposal(config, proposal, write=True)
+
+
+def test_proposal_cli_prints_markdown_without_writing(tmp_path, capsys):
+    code = propose_main(
+        [
+            "--title",
+            "CLI draft",
+            "--rationale",
+            "Review before write.",
+            "--change",
+            "Draft only by default.",
+            "--source",
+            "test-source",
+            "--target",
+            "concepts/manual-curated-ingestion.md",
+        ]
+    )
+
+    out = capsys.readouterr().out
+    assert code == 0
+    assert "# CLI draft" in out
+    assert "Draft only by default." in out
+    assert not (tmp_path / "wiki").exists()
+
+
+def test_proposal_cli_queues_only_when_explicit(tmp_path, capsys):
+    config_path = tmp_path / "config.yaml"
+    wiki_path = tmp_path / "wiki"
+    config_path.write_text(f"wiki:\n  path: {wiki_path}\n  name: test\n", encoding="utf-8")
+
+    code = propose_main(
+        [
+            "--title",
+            "CLI queued",
+            "--rationale",
+            "Explicit queue requested.",
+            "--change",
+            "Write review artifact only.",
+            "--source",
+            "test-source",
+            "--config",
+            str(config_path),
+            "--queue",
+        ]
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    path = wiki_path / "proposals" / "cli-queued.md"
+    assert code == 0
+    assert payload == {"path": str(path), "queued": True}
+    assert path.exists()
+
+
+def test_proposal_cli_rejects_queue_without_explicit_config(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "ambient-home"))
+
+    with pytest.raises(SystemExit):
+        propose_main(
+            [
+                "--title",
+                "No ambient write",
+                "--rationale",
+                "Queueing must be profile-explicit.",
+                "--change",
+                "Do not write to ambient wiki paths.",
+                "--source",
+                "test-source",
+                "--queue",
+            ]
+        )
+
+    assert not (tmp_path / "ambient-home").exists()

--- a/tests/plugins/memory/test_llm_wiki_provider.py
+++ b/tests/plugins/memory/test_llm_wiki_provider.py
@@ -1,0 +1,1114 @@
+"""Tests for the LLM Wiki memory provider."""
+
+from __future__ import annotations
+
+import json
+import tomllib
+
+import pytest
+import yaml
+
+from hermes_wiki.config import WikiConfig
+from hermes_wiki.engine import WikiEngine
+from hermes_wiki.eval import (
+    RetrievalEvalCase,
+    _build_searcher,
+    evaluate_retrieval,
+    load_retrieval_cases,
+    main as eval_main,
+    result_to_dict,
+)
+from hermes_wiki.frontmatter import parse_frontmatter, write_page
+from hermes_wiki.indexer import WikiIndexer
+from hermes_wiki.search import WikiSearch
+from agent.memory_manager import MemoryManager
+from plugins.memory import load_memory_provider
+from plugins.memory.llm_wiki import LLMWikiMemoryProvider, register
+
+
+class DummyPluginContext:
+    def __init__(self) -> None:
+        self.registered = []
+
+    def register_memory_provider(self, provider) -> None:
+        self.registered.append(provider)
+
+
+def test_provider_name():
+    provider = LLMWikiMemoryProvider()
+
+    assert provider.name == "llm_wiki"
+
+
+class FakeRetrievalSearcher:
+    def __init__(self, results_by_query):
+        self.results_by_query = results_by_query
+        self.calls = []
+
+    def search(self, query, limit=5):
+        self.calls.append((query, limit))
+        return self.results_by_query.get(query, [])
+
+
+def test_retrieval_eval_passes_when_expected_page_is_in_top_k():
+    searcher = FakeRetrievalSearcher(
+        {
+            "How autonomous should Hermes be?": [
+                {"page_path": "entities/hermes.md", "title": "Hermes", "score": 0.8},
+                {"page_path": "concepts/user-autonomy-operating-policy.md", "title": "Policy", "score": 0.7},
+            ],
+        }
+    )
+
+    results = evaluate_retrieval(
+        searcher,
+        [
+            RetrievalEvalCase(
+                query="How autonomous should Hermes be?",
+                expected_pages={"concepts/user-autonomy-operating-policy.md"},
+                top_k=2,
+            )
+        ],
+    )
+
+    assert results.passed is True
+    assert results.total == 1
+    assert results.failures == []
+    assert searcher.calls == [("How autonomous should Hermes be?", 2)]
+
+
+def test_retrieval_eval_reports_missing_expected_pages():
+    searcher = FakeRetrievalSearcher(
+        {
+            "What are the memory boundaries?": [
+                {"page_path": "entities/hermes.md", "title": "Hermes", "score": 0.8},
+            ],
+        }
+    )
+
+    results = evaluate_retrieval(
+        searcher,
+        [
+            RetrievalEvalCase(
+                query="What are the memory boundaries?",
+                expected_pages={"concepts/context-injection-policy.md", "concepts/manual-curated-ingestion.md"},
+                top_k=3,
+            )
+        ],
+    )
+
+    assert results.passed is False
+    assert results.total == 1
+    assert results.failures[0].query == "What are the memory boundaries?"
+    assert results.failures[0].missing_pages == {
+        "concepts/context-injection-policy.md",
+        "concepts/manual-curated-ingestion.md",
+    }
+    assert results.failures[0].retrieved_pages == ["entities/hermes.md"]
+
+
+def test_retrieval_eval_accepts_object_search_results():
+    class Result:
+        page_path = "concepts/context-injection-policy.md"
+        title = "Context Injection Policy"
+        score = 0.9
+
+    searcher = FakeRetrievalSearcher({"How should memory context be injected?": [Result()]})
+
+    results = evaluate_retrieval(
+        searcher,
+        [
+            RetrievalEvalCase(
+                query="How should memory context be injected?",
+                expected_pages={"concepts/context-injection-policy.md"},
+            )
+        ],
+    )
+
+    assert results.passed is True
+    assert results.cases[0].retrieved_pages == ["concepts/context-injection-policy.md"]
+
+
+def test_retrieval_eval_deduplicates_retrieved_pages_preserving_order():
+    searcher = FakeRetrievalSearcher(
+        {
+            "What did we decide about memory?": [
+                {"page_path": "concepts/memory-log-wiki-boundary.md"},
+                {"page_path": "concepts/memory-log-wiki-boundary.md"},
+                {"page_path": "concepts/manual-curated-ingestion.md"},
+            ],
+        }
+    )
+
+    results = evaluate_retrieval(
+        searcher,
+        [
+            RetrievalEvalCase(
+                query="What did we decide about memory?",
+                expected_pages={"concepts/manual-curated-ingestion.md"},
+            )
+        ],
+    )
+
+    assert results.cases[0].retrieved_pages == [
+        "concepts/memory-log-wiki-boundary.md",
+        "concepts/manual-curated-ingestion.md",
+    ]
+
+
+def test_load_retrieval_cases_from_yaml(tmp_path):
+    cases_path = tmp_path / "cases.yaml"
+    cases_path.write_text(
+        """
+cases:
+  - query: How autonomous should Hermes be?
+    expected_pages:
+      - concepts/user-autonomy-operating-policy.md
+      - entities/hermes.md
+    top_k: 7
+""".strip(),
+        encoding="utf-8",
+    )
+
+    cases = load_retrieval_cases(cases_path)
+
+    assert cases == [
+        RetrievalEvalCase(
+            query="How autonomous should Hermes be?",
+            expected_pages={"concepts/user-autonomy-operating-policy.md", "entities/hermes.md"},
+            top_k=7,
+        )
+    ]
+
+
+def test_load_retrieval_cases_from_json_list(tmp_path):
+    cases_path = tmp_path / "cases.json"
+    cases_path.write_text(
+        json.dumps(
+            [
+                {
+                    "query": "What should Hermes call the example user?",
+                    "expected_pages": "entities/example-user.md",
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    cases = load_retrieval_cases(cases_path)
+
+    assert cases == [
+        RetrievalEvalCase(
+            query="What should Hermes call the example user?",
+            expected_pages={"entities/example-user.md"},
+            top_k=5,
+        )
+    ]
+
+
+def test_load_retrieval_cases_rejects_unsafe_entries(tmp_path):
+    cases_path = tmp_path / "cases.yaml"
+    cases_path.write_text("cases:\n  - expected_pages: []\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="query"):
+        load_retrieval_cases(cases_path)
+
+
+def test_load_retrieval_cases_rejects_traversal_expected_pages(tmp_path):
+    cases_path = tmp_path / "cases.yaml"
+    cases_path.write_text(
+        "cases:\n  - query: unsafe\n    expected_pages:\n      - ../outside.md\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="relative wiki page paths"):
+        load_retrieval_cases(cases_path)
+
+
+def test_result_to_dict_is_json_serializable():
+    result = evaluate_retrieval(
+        FakeRetrievalSearcher({"query": [{"page_path": "concepts/a.md"}]}),
+        [RetrievalEvalCase(query="query", expected_pages={"concepts/a.md"})],
+    )
+
+    payload = result_to_dict(result)
+
+    assert payload == {
+        "passed": True,
+        "total": 1,
+        "failures": 0,
+        "cases": [
+            {
+                "query": "query",
+                "passed": True,
+                "expected_pages": ["concepts/a.md"],
+                "retrieved_pages": ["concepts/a.md"],
+                "missing_pages": [],
+            }
+        ],
+    }
+    json.dumps(payload)
+
+
+def test_retrieval_eval_main_returns_nonzero_on_failure(tmp_path, monkeypatch, capsys):
+    cases_path = tmp_path / "cases.yaml"
+    cases_path.write_text(
+        "cases:\n  - query: missing\n    expected_pages:\n      - concepts/missing.md\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr("hermes_wiki.eval._build_searcher", lambda config_path=None: FakeRetrievalSearcher({"missing": []}))
+
+    code = eval_main([str(cases_path), "--pretty"])
+
+    payload = json.loads(capsys.readouterr().out)
+    assert code == 1
+    assert payload["passed"] is False
+    assert payload["cases"][0]["missing_pages"] == ["concepts/missing.md"]
+
+
+def test_retrieval_eval_main_returns_zero_on_success(tmp_path, monkeypatch, capsys):
+    cases_path = tmp_path / "cases.json"
+    cases_path.write_text(
+        json.dumps([{"query": "ok", "expected_pages": ["concepts/ok.md"]}]),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        "hermes_wiki.eval._build_searcher",
+        lambda config_path=None: FakeRetrievalSearcher({"ok": [{"page_path": "concepts/ok.md"}]}),
+    )
+
+    code = eval_main([str(cases_path)])
+
+    payload = json.loads(capsys.readouterr().out)
+    assert code == 0
+    assert payload["passed"] is True
+    assert payload["total"] == 1
+
+
+def test_retrieval_eval_build_searcher_rejects_missing_explicit_config(tmp_path):
+    with pytest.raises(FileNotFoundError, match="Hermes config not found"):
+        _build_searcher(str(tmp_path / "missing.yaml"))
+
+
+def test_retrieval_eval_build_searcher_rejects_explicit_config_without_wiki(tmp_path):
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text("memory:\n  provider: llm_wiki\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="no wiki section"):
+        _build_searcher(str(config_path))
+
+
+def test_retrieval_eval_build_searcher_rejects_malformed_wiki_config_sections(tmp_path):
+    for config_text, message in [
+        ("wiki: true\n", "wiki config section"),
+        ("wiki:\n  embedding: true\n", "wiki.embedding"),
+        ("wiki:\n  vector_store: true\n", "wiki.vector_store"),
+        ("wiki:\n  llm: true\n", "wiki.llm"),
+    ]:
+        config_path = tmp_path / f"config-{abs(hash(config_text))}.yaml"
+        config_path.write_text(config_text, encoding="utf-8")
+
+        with pytest.raises(ValueError, match=message):
+            _build_searcher(str(config_path))
+
+
+def test_frontmatter_requires_delimiter_on_own_line():
+    text = "---\ntitle: Demo\n--- appears in the body, not as a delimiter\n"
+
+    fm, body = parse_frontmatter(text)
+
+    assert fm == {}
+    assert body == text.strip()
+
+
+def test_write_page_replaces_existing_file_atomically(tmp_path):
+    page = tmp_path / "concepts" / "memory.md"
+    write_page(page, {"title": "Old"}, "old body")
+
+    write_page(page, {"title": "New"}, "new body")
+
+    text = page.read_text(encoding="utf-8")
+    assert "title: New" in text
+    assert "new body" in text
+    assert not list(page.parent.glob(".memory.md.*.tmp"))
+
+
+def test_log_rotation_preserves_existing_archive(tmp_path):
+    config = WikiConfig(wiki_path=tmp_path / "wiki", log_rotation_threshold=1)
+    config.ensure_dirs()
+    config.log_path.write_text("# Wiki Log\n\n## [2026-01-01] old | entry\n", encoding="utf-8")
+    existing_archive = config.wiki_path / "log-2026.md"
+    existing_archive.write_text("older archived logs\n", encoding="utf-8")
+    indexer = WikiIndexer(config)
+
+    indexer.append_log("test", "new entry")
+
+    archives = sorted(config.wiki_path.glob("log-2026*.md"))
+    assert existing_archive in archives
+    assert existing_archive.read_text(encoding="utf-8") == "older archived logs\n"
+    assert len(archives) == 2
+
+
+def test_search_index_page_embeds_before_deleting_existing_chunks(tmp_path):
+    class FailingEmbedder:
+        def embed_batch(self, texts):
+            raise RuntimeError("embedding down")
+
+    search = WikiSearch.__new__(WikiSearch)
+    search.config = WikiConfig(wiki_path=tmp_path / "wiki")
+    search.config.ensure_dirs()
+    page = search.config.concepts_dir / "memory.md"
+    write_page(page, {"title": "Memory", "type": "concept"}, "Body text")
+    search._embedder = FailingEmbedder()
+    search._delete_page_chunks = lambda rel_path: (_ for _ in ()).throw(AssertionError("deleted before embed"))
+
+    try:
+        search.index_page(page)
+    except RuntimeError as exc:
+        assert "embedding down" in str(exc)
+    else:
+        raise AssertionError("expected embedding failure")
+
+
+def test_search_index_page_upserts_before_deleting_stale_chunks(tmp_path):
+    class Embedder:
+        def embed_batch(self, texts):
+            return [[0.1, 0.2, 0.3, 0.4] for _ in texts]
+
+    class Client:
+        def upsert(self, *args, **kwargs):
+            raise RuntimeError("qdrant down")
+
+    search = WikiSearch.__new__(WikiSearch)
+    search.config = WikiConfig(wiki_path=tmp_path / "wiki", embedding_dim=4)
+    search.config.ensure_dirs()
+    page = search.config.concepts_dir / "memory.md"
+    write_page(page, {"title": "Memory", "type": "concept"}, "Body text")
+    search._embedder = Embedder()
+    search._client = Client()
+    search._point = lambda point_id, vector, payload: {"id": point_id, "payload": payload}
+    search._delete_stale_page_chunks = lambda rel_path, keep_chunks: (_ for _ in ()).throw(
+        AssertionError("deleted stale chunks before successful upsert")
+    )
+
+    try:
+        search.index_page(page)
+    except RuntimeError as exc:
+        assert "qdrant down" in str(exc)
+    else:
+        raise AssertionError("expected upsert failure")
+
+
+def test_reindex_all_does_not_delete_collection_first(tmp_path):
+    class FakeClient:
+        def delete_collection(self, name):
+            raise AssertionError("collection should not be deleted before safe reindex")
+
+        def scroll(self, **kwargs):
+            return [], None
+
+    search = WikiSearch.__new__(WikiSearch)
+    search.config = WikiConfig(wiki_path=tmp_path / "wiki")
+    search.config.ensure_dirs()
+    search._client = FakeClient()
+    search._ensure_collection = lambda: None
+    search.index_page = lambda path: 1
+    search.index_source = lambda path: 1
+    search._existing_indexed_paths = lambda: set()
+    search._delete_page_chunks = lambda rel_path: None
+    write_page(search.config.concepts_dir / "memory.md", {"title": "Memory", "type": "concept"}, "Body text")
+
+    counts = search.reindex_all()
+
+    assert counts == {"pages": 1, "sources": 0, "chunks": 1}
+
+
+def test_engine_rejects_unsafe_llm_slugs(tmp_path):
+    engine = WikiEngine.__new__(WikiEngine)
+
+    assert engine._safe_slug("Memory Policy") == "memory-policy"
+    assert engine._safe_slug("../escape") is None
+    assert engine._safe_slug("/tmp/escape") is None
+    assert engine._safe_slug("safe/escape") is None
+
+
+def test_engine_safe_child_path_blocks_traversal(tmp_path):
+    engine = WikiEngine.__new__(WikiEngine)
+    root = tmp_path / "wiki" / "entities"
+    root.mkdir(parents=True)
+
+    assert engine._safe_child_path(root, "memory").parent == root.resolve()
+    assert engine._safe_child_path(root, "../escape") is None
+
+
+def test_engine_ingest_text_rejects_unknown_source_type(tmp_path):
+    engine = WikiEngine.__new__(WikiEngine)
+    engine.config = WikiConfig(wiki_path=tmp_path / "wiki")
+
+    try:
+        engine.ingest_text("content", "Example", source_type="../../escape", dry_run=True)
+    except ValueError as exc:
+        assert "Unsupported source_type" in str(exc)
+    else:
+        raise AssertionError("unsafe source_type should be rejected before path construction")
+
+
+def test_engine_read_only_constructor_does_not_create_storage(monkeypatch, tmp_path):
+    calls = []
+
+    class FakeSearch:
+        def __init__(self, config, *, ensure_collection=True, read_only=False):
+            calls.append(("search", ensure_collection, read_only))
+
+    class FakeLLM:
+        def __init__(self, config):
+            calls.append(("llm", None))
+
+    class FakeIndexer:
+        def __init__(self, config):
+            calls.append(("indexer", None))
+
+    monkeypatch.setattr("hermes_wiki.engine.WikiSearch", FakeSearch)
+    monkeypatch.setattr("hermes_wiki.engine.WikiLLM", FakeLLM)
+    monkeypatch.setattr("hermes_wiki.engine.WikiIndexer", FakeIndexer)
+    config = WikiConfig(wiki_path=tmp_path / "wiki")
+
+    engine = WikiEngine(config, read_only=True)
+
+    assert engine.read_only is True
+    assert not config.wiki_path.exists()
+    assert ("search", False, True) in calls
+
+
+def test_plugin_metadata_exists():
+    metadata_path = "plugins/memory/llm_wiki/plugin.yaml"
+
+    with open(metadata_path, encoding="utf-8") as f:
+        metadata = yaml.safe_load(f)
+
+    assert metadata["name"] == "llm_wiki"
+    assert "memory" in metadata["description"].lower()
+
+
+def test_plugin_metadata_is_included_as_package_data():
+    with open("pyproject.toml", "rb") as f:
+        pyproject = tomllib.load(f)
+
+    package_data = pyproject["tool"]["setuptools"]["package-data"]
+
+    assert "plugins" in package_data
+    assert "**/plugin.yaml" in package_data["plugins"]
+
+
+def test_retrieval_eval_console_script_is_registered():
+    with open("pyproject.toml", "rb") as f:
+        pyproject = tomllib.load(f)
+
+    assert pyproject["project"]["scripts"]["hermes-wiki-eval"] == "hermes_wiki.eval:main"
+
+
+def test_config_schema_exposes_local_wiki_settings():
+    provider = LLMWikiMemoryProvider()
+
+    fields = {field["key"]: field for field in provider.get_config_schema()}
+
+    assert {"path", "name", "embedding_url", "embedding_model", "embedding_dim", "qdrant_url"} <= set(fields)
+    assert fields["path"]["default"] == "~/.hermes/wiki/personal"
+    assert fields["embedding_url"]["default"] == "http://localhost:22222"
+
+
+def test_save_config_writes_wiki_section_without_clobbering_existing_config(tmp_path):
+    (tmp_path / "config.yaml").write_text("model:\n  default: gpt-test\n", encoding="utf-8")
+    provider = LLMWikiMemoryProvider()
+
+    provider.save_config(
+        {
+            "path": str(tmp_path / "wiki" / "memory"),
+            "name": "memory",
+            "embedding_url": "http://embeddings.local",
+            "embedding_model": "embed-test",
+            "embedding_dim": "1024",
+            "qdrant_url": "http://qdrant.local",
+            "collection_prefix": "wiki_test",
+            "llm_url": "http://llm.local/v1",
+            "llm_model": "gpt-test",
+        },
+        str(tmp_path),
+    )
+
+    saved = yaml.safe_load((tmp_path / "config.yaml").read_text(encoding="utf-8"))
+    assert saved["model"]["default"] == "gpt-test"
+    assert saved["wiki"]["path"] == str(tmp_path / "wiki" / "memory")
+    assert saved["wiki"]["name"] == "memory"
+    assert saved["wiki"]["embedding"]["url"] == "http://embeddings.local"
+    assert saved["wiki"]["embedding"]["model"] == "embed-test"
+    assert saved["wiki"]["embedding"]["dim"] == 1024
+    assert saved["wiki"]["vector_store"]["url"] == "http://qdrant.local"
+    assert saved["wiki"]["vector_store"]["collection_prefix"] == "wiki_test"
+    assert saved["wiki"]["llm"]["url"] == "http://llm.local/v1"
+    assert saved["wiki"]["llm"]["model"] == "gpt-test"
+
+
+def test_is_available_requires_vendored_wiki_package_not_optional_qdrant(monkeypatch):
+    provider = LLMWikiMemoryProvider()
+
+    def fake_find_spec(name):
+        if name == "hermes_wiki.engine":
+            return object()
+        if name == "qdrant_client":
+            return None
+        raise AssertionError(name)
+
+    monkeypatch.setattr("plugins.memory.llm_wiki.importlib.util.find_spec", fake_find_spec)
+
+    assert provider.is_available() is True
+
+
+def test_engine_lazy_ensures_optional_deps(monkeypatch, tmp_path):
+    calls = []
+
+    class FakeWikiEngine:
+        def __init__(self, config, *, read_only=False):
+            calls.append((config, read_only))
+
+    monkeypatch.setattr("plugins.memory.llm_wiki.WikiEngine", FakeWikiEngine, raising=False)
+    monkeypatch.setattr("tools.lazy_deps.ensure", lambda feature, prompt=True: calls.append((feature, prompt)))
+    provider = LLMWikiMemoryProvider()
+    provider.initialize("s1", hermes_home=str(tmp_path), agent_context="primary")
+
+    provider._engine()
+
+    assert ("memory.llm_wiki", False) in calls
+
+
+def test_non_primary_engine_does_not_lazy_install_optional_deps(monkeypatch, tmp_path):
+    calls = []
+
+    class FakeWikiEngine:
+        def __init__(self, config, *, read_only=False):
+            calls.append((config, read_only))
+
+    monkeypatch.setattr("plugins.memory.llm_wiki.WikiEngine", FakeWikiEngine, raising=False)
+    monkeypatch.setattr("tools.lazy_deps.ensure", lambda feature, prompt=True: calls.append((feature, prompt)))
+    provider = LLMWikiMemoryProvider()
+    provider.initialize("s1", hermes_home=str(tmp_path), agent_context="cron")
+
+    provider._engine()
+
+    assert ("memory.llm_wiki", False) not in calls
+    assert calls[0][1] is True
+
+
+def test_register_registers_provider():
+    ctx = DummyPluginContext()
+
+    register(ctx)
+
+    assert len(ctx.registered) == 1
+    assert isinstance(ctx.registered[0], LLMWikiMemoryProvider)
+
+
+def test_initialize_uses_hermes_home_for_default_wiki(tmp_path):
+    provider = LLMWikiMemoryProvider()
+
+    provider.initialize("s1", hermes_home=str(tmp_path), agent_context="primary")
+
+    assert provider.wiki_path == tmp_path / "wiki" / "personal"
+    assert provider.wiki_name == "personal"
+
+
+def test_initialize_reads_config_wiki_section(tmp_path, monkeypatch):
+    custom_wiki = tmp_path / "configured-wiki"
+    (tmp_path / "config.yaml").write_text(
+        "wiki:\n"
+        f"  path: {custom_wiki}\n"
+        "  name: hermes_memory\n"
+        "  embedding:\n"
+        "    url: http://embeddings.local\n"
+        "    model: text-embedding-test\n"
+        "    dim: 1024\n"
+        "  vector_store:\n"
+        "    url: http://qdrant.local\n"
+        "    collection_prefix: test_wiki\n"
+        "  llm:\n"
+        "    url: http://llm.local/v1\n"
+        "    model: gpt-test\n",
+        encoding="utf-8",
+    )
+    provider = LLMWikiMemoryProvider()
+
+    provider.initialize("s1", hermes_home=str(tmp_path), agent_context="primary")
+    wiki_config = provider._wiki_config()
+
+    assert provider.wiki_path == custom_wiki
+    assert provider.wiki_name == "hermes_memory"
+    assert wiki_config.embedding_url == "http://embeddings.local"
+    assert wiki_config.embedding_model == "text-embedding-test"
+    assert wiki_config.embedding_dim == 1024
+    assert wiki_config.qdrant_url == "http://qdrant.local"
+    assert wiki_config.collection_prefix == "test_wiki"
+    assert wiki_config.llm_base_url == "http://llm.local/v1"
+    assert wiki_config.llm_model == "gpt-test"
+
+
+def test_initialize_expands_home_in_config(tmp_path, monkeypatch):
+    fake_home = tmp_path / "home"
+    monkeypatch.setenv("HOME", str(fake_home))
+    (tmp_path / "config.yaml").write_text(
+        "wiki:\n"
+        "  path: ~/custom-wiki\n"
+        "  name: memory\n",
+        encoding="utf-8",
+    )
+    provider = LLMWikiMemoryProvider()
+
+    provider.initialize("s1", hermes_home=str(tmp_path), agent_context="primary")
+
+    assert provider.wiki_path == fake_home / "custom-wiki"
+    assert provider.wiki_name == "memory"
+
+
+def test_initialize_normalizes_agent_context_case(tmp_path):
+    provider = LLMWikiMemoryProvider()
+
+    provider.initialize("s1", hermes_home=str(tmp_path), agent_context=" Primary ")
+
+    assert provider._agent_context == "primary"
+    assert provider._writes_allowed() is True
+
+
+def test_initialize_does_not_construct_engine(monkeypatch, tmp_path):
+    called = False
+
+    def boom(*args, **kwargs):
+        nonlocal called
+        called = True
+        raise AssertionError("engine should be lazy")
+
+    monkeypatch.setattr("plugins.memory.llm_wiki.WikiEngine", boom, raising=False)
+    provider = LLMWikiMemoryProvider()
+
+    provider.initialize("s1", hermes_home=str(tmp_path), agent_context="primary")
+
+    assert called is False
+
+
+def test_engine_constructs_once_when_requested(monkeypatch, tmp_path):
+    calls = []
+
+    class FakeWikiEngine:
+        def __init__(self, config, *, read_only=False):
+            calls.append((config, read_only))
+
+    monkeypatch.setattr("plugins.memory.llm_wiki.WikiEngine", FakeWikiEngine, raising=False)
+    provider = LLMWikiMemoryProvider()
+    provider.initialize("s1", hermes_home=str(tmp_path), agent_context="primary")
+    monkeypatch.setattr(provider, "_ensure_optional_deps", lambda: None)
+
+    first = provider._engine()
+    second = provider._engine()
+
+    assert first is second
+    assert len(calls) == 1
+    assert calls[0][0].wiki_path == tmp_path / "wiki" / "personal"
+    assert calls[0][0].wiki_name == "personal"
+    assert calls[0][1] is False
+
+
+def test_non_primary_engine_is_constructed_read_only(monkeypatch, tmp_path):
+    calls = []
+
+    class FakeWikiEngine:
+        def __init__(self, config, *, read_only=False):
+            calls.append((config, read_only))
+
+    monkeypatch.setattr("plugins.memory.llm_wiki.WikiEngine", FakeWikiEngine, raising=False)
+    provider = LLMWikiMemoryProvider()
+    provider.initialize("s1", hermes_home=str(tmp_path), agent_context="cron")
+    monkeypatch.setattr(provider, "_ensure_optional_deps", lambda: None)
+
+    provider._engine()
+
+    assert calls[0][0].wiki_path == tmp_path / "wiki" / "personal"
+    assert calls[0][1] is True
+
+
+def test_read_tool_schemas_present():
+    provider = LLMWikiMemoryProvider()
+
+    names = {schema["name"] for schema in provider.get_tool_schemas()}
+
+    assert {
+        "wiki_status",
+        "wiki_orient",
+        "wiki_search",
+        "wiki_read",
+        "wiki_query",
+    } <= names
+
+
+def test_query_tool_schema_defaults_to_read_only():
+    provider = LLMWikiMemoryProvider()
+
+    query_schema = next(schema for schema in provider.get_tool_schemas() if schema["name"] == "wiki_query")
+    properties = query_schema["parameters"]["properties"]
+
+    assert properties["file_result"].get("default") is False
+    assert properties["log_query"].get("default") is False
+
+
+class FakeEngine:
+    def __init__(self) -> None:
+        self.query_calls = []
+
+    def status(self):
+        return {"total_pages": 2, "sources": 1, "indexed_chunks": 7, "wiki": "/tmp/wiki"}
+
+    def orient(self):
+        return "# Wiki Orientation\nUseful index"
+
+    def query(self, question, file_result=False, log_query=False):
+        self.query_calls.append((question, file_result, log_query))
+        return "wiki answer"
+
+    def search(self, query, limit=5, exclude_sources=False):
+        return []
+
+    def lint(self, write_log=False):
+        return {"issues": [], "write_log": write_log}
+
+    def ingest_file(self, file_path, dry_run=True):
+        return {"file_path": str(file_path), "dry_run": dry_run}
+
+    def reindex(self):
+        return {"pages": 2, "sources": 1, "chunks": 7}
+
+
+def test_handle_status_tool_call_uses_engine(monkeypatch, tmp_path):
+    fake_engine = FakeEngine()
+    provider = LLMWikiMemoryProvider()
+    provider.initialize("s1", hermes_home=str(tmp_path), agent_context="primary")
+    monkeypatch.setattr(provider, "_engine", lambda: fake_engine)
+
+    result = provider.handle_tool_call("wiki_status", {})
+
+    assert "total_pages" in result
+    assert "2" in result
+
+
+def test_handle_orient_tool_call_uses_engine(monkeypatch, tmp_path):
+    fake_engine = FakeEngine()
+    provider = LLMWikiMemoryProvider()
+    provider.initialize("s1", hermes_home=str(tmp_path), agent_context="primary")
+    monkeypatch.setattr(provider, "_engine", lambda: fake_engine)
+
+    result = provider.handle_tool_call("wiki_orient", {})
+
+    assert result == "# Wiki Orientation\nUseful index"
+
+
+def test_handle_query_defaults_to_read_only(monkeypatch, tmp_path):
+    fake_engine = FakeEngine()
+    provider = LLMWikiMemoryProvider()
+    provider.initialize("s1", hermes_home=str(tmp_path))
+    monkeypatch.setattr(provider, "_engine", lambda: fake_engine)
+
+    result = provider.handle_tool_call("wiki_query", {"question": "What is memory?"})
+
+    assert "answer" in result
+    assert fake_engine.query_calls == [("What is memory?", False, False)]
+
+
+def test_boolean_tool_args_parse_string_false_as_false(monkeypatch, tmp_path):
+    fake_engine = FakeEngine()
+    provider = LLMWikiMemoryProvider()
+    provider.initialize("s1", hermes_home=str(tmp_path))
+    monkeypatch.setattr(provider, "_engine", lambda: fake_engine)
+
+    provider.handle_tool_call(
+        "wiki_query",
+        {"question": "What is memory?", "file_result": "false", "log_query": "false"},
+    )
+
+    assert fake_engine.query_calls == [("What is memory?", False, False)]
+
+
+def test_write_booleans_parse_string_false_safely(monkeypatch, tmp_path):
+    fake_engine = FakeEngine()
+    provider = LLMWikiMemoryProvider()
+    provider.initialize("s1", hermes_home=str(tmp_path), agent_context="cron")
+    monkeypatch.setattr(provider, "_engine", lambda: fake_engine)
+
+    result = provider.handle_tool_call("wiki_ingest", {"file_path": "source.md", "dry_run": "false"})
+
+    assert "blocked" in result.lower()
+
+
+def test_handle_read_page_by_relative_path(tmp_path):
+    page = tmp_path / "wiki" / "personal" / "concepts" / "memory.md"
+    page.parent.mkdir(parents=True)
+    page.write_text("# Memory\n\nUseful page", encoding="utf-8")
+
+    provider = LLMWikiMemoryProvider()
+    provider.initialize("s1", hermes_home=str(tmp_path), agent_context="primary")
+
+    result = provider.handle_tool_call("wiki_read", {"page": "concepts/memory.md"})
+
+    assert "# Memory" in result
+    assert "Useful page" in result
+
+
+def test_handle_read_page_by_bare_slug(tmp_path):
+    page = tmp_path / "wiki" / "personal" / "concepts" / "memory-policy.md"
+    page.parent.mkdir(parents=True)
+    page.write_text("# Memory Policy\n\nSlug lookup works", encoding="utf-8")
+
+    provider = LLMWikiMemoryProvider()
+    provider.initialize("s1", hermes_home=str(tmp_path), agent_context="primary")
+
+    result = provider.handle_tool_call("wiki_read", {"page": "memory-policy"})
+
+    assert "# Memory Policy" in result
+    assert "Slug lookup works" in result
+
+
+def test_handle_read_page_blocks_traversal(tmp_path):
+    outside = tmp_path / "outside.md"
+    outside.write_text("secret", encoding="utf-8")
+    provider = LLMWikiMemoryProvider()
+    provider.initialize("s1", hermes_home=str(tmp_path), agent_context="primary")
+
+    result = provider.handle_tool_call("wiki_read", {"page": "../outside.md"})
+
+    assert "secret" not in result
+    assert "not found" in result.lower()
+
+
+def test_system_prompt_block_is_tiny_and_retrieval_oriented(tmp_path):
+    provider = LLMWikiMemoryProvider()
+    provider.initialize("s1", hermes_home=str(tmp_path), agent_context="primary")
+
+    block = provider.system_prompt_block()
+
+    assert "LLM Wiki" in block
+    assert "wiki_search" in block
+    assert len(block) < 600
+
+
+def test_sync_turn_is_noop(monkeypatch, tmp_path):
+    provider = LLMWikiMemoryProvider()
+    provider.initialize("s1", hermes_home=str(tmp_path), agent_context="primary")
+    monkeypatch.setattr(provider, "_engine", lambda: (_ for _ in ()).throw(AssertionError("sync_turn must not load engine")))
+
+    provider.sync_turn("user", "assistant")
+
+
+def test_prefetch_returns_bounded_cited_results(monkeypatch, tmp_path):
+    class Result:
+        def __init__(self, page_path, title, text, score):
+            self.page_path = page_path
+            self.title = title
+            self.text = text
+            self.score = score
+
+    class Searcher:
+        def search(self, query, limit=3, exclude_sources=True):
+            assert exclude_sources is True
+            return [
+                Result("concepts/context.md", "Context Policy", "A" * 900, 0.91),
+                Result("entities/hermes.md", "Hermes", "B" * 900, 0.82),
+            ]
+
+    class Engine:
+        search = Searcher()
+
+    provider = LLMWikiMemoryProvider()
+    provider.initialize("s1", hermes_home=str(tmp_path), agent_context="primary")
+    monkeypatch.setattr(provider, "_engine", lambda: Engine())
+
+    result = provider.prefetch("memory policy")
+
+    assert "LLM Wiki relevant context" in result
+    assert "concepts/context.md" in result
+    assert "entities/hermes.md" in result
+    assert len(result) <= provider.prefetch_max_chars
+
+
+def test_prefetch_formats_dict_search_results(monkeypatch, tmp_path):
+    class Searcher:
+        def search(self, query, limit=3, exclude_sources=True):
+            return [{"page_path": "concepts/memory.md", "title": "Memory", "text": "Cited context", "score": 0.7}]
+
+    class Engine:
+        search = Searcher()
+
+    provider = LLMWikiMemoryProvider()
+    provider.initialize("s1", hermes_home=str(tmp_path), agent_context="primary")
+    monkeypatch.setattr(provider, "_engine", lambda: Engine())
+
+    result = provider.prefetch("memory")
+
+    assert "concepts/memory.md" in result
+    assert "Cited context" in result
+
+
+def test_write_tool_schemas_have_safe_defaults():
+    provider = LLMWikiMemoryProvider()
+    schemas = {schema["name"]: schema for schema in provider.get_tool_schemas()}
+
+    assert {"wiki_lint", "wiki_ingest", "wiki_reindex"} <= set(schemas)
+    assert schemas["wiki_lint"]["parameters"]["properties"]["write_log"]["default"] is False
+    assert schemas["wiki_ingest"]["parameters"]["properties"]["dry_run"]["default"] is True
+
+
+def test_lint_defaults_to_non_mutating(monkeypatch, tmp_path):
+    fake_engine = FakeEngine()
+    provider = LLMWikiMemoryProvider()
+    provider.initialize("s1", hermes_home=str(tmp_path), agent_context="primary")
+    monkeypatch.setattr(provider, "_engine", lambda: fake_engine)
+
+    result = provider.handle_tool_call("wiki_lint", {})
+
+    assert '"write_log": false' in result
+
+
+def test_ingest_actual_write_blocked_in_non_primary(monkeypatch, tmp_path):
+    fake_engine = FakeEngine()
+    provider = LLMWikiMemoryProvider()
+    provider.initialize("s1", hermes_home=str(tmp_path), agent_context="subagent")
+    monkeypatch.setattr(provider, "_engine", lambda: fake_engine)
+
+    result = provider.handle_tool_call("wiki_ingest", {"file_path": "/tmp/source.md", "dry_run": False})
+
+    assert "blocked" in result.lower()
+    assert "subagent" in result
+
+
+def test_ingest_dry_run_blocked_in_non_primary(monkeypatch, tmp_path):
+    fake_engine = FakeEngine()
+    provider = LLMWikiMemoryProvider()
+    provider.initialize("s1", hermes_home=str(tmp_path), agent_context="subagent")
+    monkeypatch.setattr(provider, "_engine", lambda: fake_engine)
+
+    result = provider.handle_tool_call("wiki_ingest", {"file_path": "/tmp/source.md"})
+
+    assert "blocked" in result.lower()
+    assert "subagent" in result
+
+
+def test_reindex_blocked_in_non_primary(monkeypatch, tmp_path):
+    fake_engine = FakeEngine()
+    provider = LLMWikiMemoryProvider()
+    provider.initialize("s1", hermes_home=str(tmp_path), agent_context="cron")
+    monkeypatch.setattr(provider, "_engine", lambda: fake_engine)
+
+    result = provider.handle_tool_call("wiki_reindex", {})
+
+    assert "blocked" in result.lower()
+    assert "cron" in result
+
+
+def test_mutating_query_options_blocked_in_non_primary(monkeypatch, tmp_path):
+    fake_engine = FakeEngine()
+    provider = LLMWikiMemoryProvider()
+    provider.initialize("s1", hermes_home=str(tmp_path), agent_context="subagent")
+    monkeypatch.setattr(provider, "_engine", lambda: fake_engine)
+
+    filed = provider.handle_tool_call("wiki_query", {"question": "save this", "file_result": True})
+    logged = provider.handle_tool_call("wiki_query", {"question": "log this", "log_query": True})
+
+    assert "blocked" in filed.lower()
+    assert "blocked" in logged.lower()
+    assert fake_engine.query_calls == []
+
+
+def test_lint_write_log_blocked_in_non_primary(monkeypatch, tmp_path):
+    fake_engine = FakeEngine()
+    provider = LLMWikiMemoryProvider()
+    provider.initialize("s1", hermes_home=str(tmp_path), agent_context="cron")
+    monkeypatch.setattr(provider, "_engine", lambda: fake_engine)
+
+    result = provider.handle_tool_call("wiki_lint", {"write_log": True})
+
+    assert "blocked" in result.lower()
+    assert "cron" in result
+
+
+def test_search_limit_is_clamped(monkeypatch, tmp_path):
+    calls = []
+
+    class Searcher:
+        def search(self, query, limit=5):
+            calls.append(limit)
+            return []
+
+    class Engine:
+        search = Searcher()
+
+    provider = LLMWikiMemoryProvider()
+    provider.initialize("s1", hermes_home=str(tmp_path), agent_context="primary")
+    monkeypatch.setattr(provider, "_engine", lambda: Engine())
+
+    provider.handle_tool_call("wiki_search", {"query": "memory", "limit": 9999})
+    provider.handle_tool_call("wiki_search", {"query": "memory", "limit": -5})
+
+    assert calls == [20, 1]
+
+
+def test_read_page_is_output_bounded(tmp_path):
+    page = tmp_path / "wiki" / "personal" / "concepts" / "large.md"
+    page.parent.mkdir(parents=True)
+    page.write_text("x" * 150_000, encoding="utf-8")
+    provider = LLMWikiMemoryProvider()
+    provider.initialize("s1", hermes_home=str(tmp_path), agent_context="primary")
+
+    result = provider.handle_tool_call("wiki_read", {"page": "concepts/large.md"})
+
+    assert len(result) < 70_000
+    assert "truncated" in result.lower()
+
+
+def test_plugin_loader_returns_llm_wiki_provider():
+    provider = load_memory_provider("llm_wiki")
+
+    assert isinstance(provider, LLMWikiMemoryProvider)
+
+
+def test_memory_manager_routes_llm_wiki_tools(monkeypatch, tmp_path):
+    fake_engine = FakeEngine()
+    provider = LLMWikiMemoryProvider()
+    manager = MemoryManager()
+    manager.add_provider(provider)
+    manager.initialize_all("s1", hermes_home=str(tmp_path), agent_context="primary")
+    monkeypatch.setattr(provider, "_engine", lambda: fake_engine)
+
+    assert manager.has_tool("wiki_status")
+    result = manager.handle_tool_call("wiki_status", {})
+
+    assert "total_pages" in result
+
+
+def test_memory_manager_prefetches_llm_wiki_context(monkeypatch, tmp_path):
+    class Result:
+        page_path = "concepts/memory.md"
+        title = "Memory"
+        text = "Durable source-backed memory"
+        score = 0.99
+
+    class Searcher:
+        def search(self, query, limit=3, exclude_sources=True):
+            return [Result()]
+
+    class Engine:
+        search = Searcher()
+
+    provider = LLMWikiMemoryProvider()
+    manager = MemoryManager()
+    manager.add_provider(provider)
+    manager.initialize_all("s1", hermes_home=str(tmp_path), agent_context="primary")
+    monkeypatch.setattr(provider, "_engine", lambda: Engine())
+
+    result = manager.prefetch_all("memory")
+
+    assert "LLM Wiki relevant context" in result
+    assert "concepts/memory.md" in result

--- a/tests/plugins/memory/test_llm_wiki_retrieval_introspection.py
+++ b/tests/plugins/memory/test_llm_wiki_retrieval_introspection.py
@@ -1,0 +1,181 @@
+import json
+
+import pytest
+
+from hermes_wiki.search import WikiSearchResult
+
+
+class FakeSearcher:
+    def __init__(self, results):
+        self.results = results
+        self.calls = []
+
+    def search(self, query, limit=5, **kwargs):
+        self.calls.append({"query": query, "limit": limit, **kwargs})
+        return self.results[:limit]
+
+
+def _hit(page_path, *, score=0.5, chunk_index=0, page_type="concept", title=None, text="body text"):
+    return WikiSearchResult(
+        page_path=page_path,
+        title=title or page_path.rsplit("/", 1)[-1].removesuffix(".md"),
+        page_type=page_type,
+        chunk_index=chunk_index,
+        text=text,
+        score=score,
+        tags=["memory"],
+    )
+
+
+def test_introspect_retrieval_reports_ranked_chunks_and_page_coverage():
+    from hermes_wiki.retrieval_introspection import introspect_retrieval, introspection_to_dict
+
+    searcher = FakeSearcher([
+        _hit("concepts/memory.md", score=0.91, chunk_index=0, text="First memory chunk"),
+        _hit("concepts/memory.md", score=0.83, chunk_index=1, text="Second memory chunk"),
+        _hit("entities/hermes.md", score=0.77, page_type="entity", text="Hermes entity chunk"),
+    ])
+
+    report = introspect_retrieval(
+        searcher,
+        "How should Hermes use memory?",
+        top_k=3,
+        expected_pages={"concepts/memory.md", "entities/missing.md"},
+    )
+    data = introspection_to_dict(report)
+
+    assert searcher.calls == [{"query": "How should Hermes use memory?", "limit": 3}]
+    assert data["query"] == "How should Hermes use memory?"
+    assert data["search_mode"] == "dense"
+    assert data["top_k"] == 3
+    assert [hit["rank"] for hit in data["hits"]] == [1, 2, 3]
+    assert data["hits"][0] == {
+        "rank": 1,
+        "page_path": "concepts/memory.md",
+        "title": "memory",
+        "page_type": "concept",
+        "chunk_index": 0,
+        "score": 0.91,
+        "tags": ["memory"],
+        "text_preview": "First memory chunk",
+    }
+    assert data["pages"] == [
+        {"page_path": "concepts/memory.md", "best_rank": 1, "best_score": 0.91, "hit_count": 2},
+        {"page_path": "entities/hermes.md", "best_rank": 3, "best_score": 0.77, "hit_count": 1},
+    ]
+    assert data["expected_pages"] == ["concepts/memory.md", "entities/missing.md"]
+    assert data["missing_expected_pages"] == ["entities/missing.md"]
+    assert not data["passed_expected_pages"]
+
+
+def test_introspect_retrieval_passes_page_type_and_exclude_source_filters():
+    from hermes_wiki.retrieval_introspection import introspect_retrieval
+
+    searcher = FakeSearcher([_hit("entities/hermes.md", page_type="entity")])
+
+    introspect_retrieval(
+        searcher,
+        "Hermes",
+        top_k=1,
+        page_type="entity",
+        exclude_sources=True,
+        search_mode="hybrid",
+    )
+
+    assert searcher.calls == [
+        {"query": "Hermes", "limit": 1, "page_type": "entity", "exclude_sources": True, "search_mode": "hybrid"}
+    ]
+
+
+def test_introspect_retrieval_rejects_unsafe_expected_pages():
+    from hermes_wiki.retrieval_introspection import introspect_retrieval
+
+    with pytest.raises(ValueError, match="expected pages must be relative"):
+        introspect_retrieval(FakeSearcher([]), "query", expected_pages={"../secrets.md"})
+
+
+def test_render_introspection_markdown_is_agent_readable():
+    from hermes_wiki.retrieval_introspection import introspect_retrieval, render_introspection_markdown
+
+    report = introspect_retrieval(
+        FakeSearcher([_hit("concepts/memory.md", score=0.91, text="A" * 300)]),
+        "memory query",
+        expected_pages={"concepts/memory.md"},
+    )
+
+    markdown = render_introspection_markdown(report)
+
+    assert "# LLM Wiki Retrieval Introspection" in markdown
+    assert "Query: `memory query`" in markdown
+    assert "- ✅ Expected page coverage passed" in markdown
+    assert "| 1 | `concepts/memory.md` | 0.91 | concept | 0 |" in markdown
+    assert "A" * 220 not in markdown
+
+
+def test_cli_json_uses_explicit_config_and_prints_stable_shape(tmp_path, monkeypatch, capsys):
+    from hermes_wiki import retrieval_introspection
+
+    config_path = tmp_path / "config.yaml"
+    wiki_path = tmp_path / "wiki"
+    config_path.write_text(f"wiki:\n  path: {wiki_path}\n  name: test\n", encoding="utf-8")
+
+    class FakeWikiSearch:
+        def __init__(self, config, ensure_collection=False):
+            self.config = config
+            self.ensure_collection = ensure_collection
+
+        def search(self, query, limit=5, **kwargs):
+            return [_hit("concepts/memory.md", score=0.99)]
+
+    monkeypatch.setattr(retrieval_introspection, "WikiSearch", FakeWikiSearch)
+
+    rc = retrieval_introspection.main([
+        "memory query",
+        "--config",
+        str(config_path),
+        "--expected-page",
+        "concepts/memory.md",
+        "--json",
+    ])
+    out = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert out["query"] == "memory query"
+    assert out["hits"][0]["page_path"] == "concepts/memory.md"
+    assert out["passed_expected_pages"] is True
+
+
+def test_cli_returns_nonzero_when_expected_pages_are_missing(tmp_path, monkeypatch, capsys):
+    from hermes_wiki import retrieval_introspection
+
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(f"wiki:\n  path: {tmp_path / 'wiki'}\n  name: test\n", encoding="utf-8")
+
+    class FakeWikiSearch:
+        def __init__(self, config, ensure_collection=False):
+            pass
+
+        def search(self, query, limit=5, **kwargs):
+            return [_hit("entities/hermes.md")]
+
+    monkeypatch.setattr(retrieval_introspection, "WikiSearch", FakeWikiSearch)
+
+    rc = retrieval_introspection.main([
+        "memory query",
+        "--config",
+        str(config_path),
+        "--expected-page",
+        "concepts/missing.md",
+        "--json",
+    ])
+    out = json.loads(capsys.readouterr().out)
+
+    assert rc == 1
+    assert out["missing_expected_pages"] == ["concepts/missing.md"]
+
+
+def test_cli_requires_explicit_config_when_requested_path_is_missing(tmp_path):
+    from hermes_wiki.retrieval_introspection import main
+
+    with pytest.raises(SystemExit):
+        main(["query", "--config", str(tmp_path / "missing.yaml")])

--- a/tests/tools/test_discord_tool.py
+++ b/tests/tools/test_discord_tool.py
@@ -476,6 +476,129 @@ class TestCreateThread:
 
 
 # ---------------------------------------------------------------------------
+# Actions: create_channel / create_role / edit_channel_permissions
+# ---------------------------------------------------------------------------
+
+class TestDiscordAdminManagement:
+    @patch("tools.discord_tool._discord_request")
+    def test_create_text_channel_with_parent_topic_and_overwrites(self, mock_req, monkeypatch):
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+        mock_req.return_value = {"id": "22", "name": "ops", "type": 0, "parent_id": "10"}
+        overwrites = '[{"id":"1","type":0,"allow":"117760","deny":"0"}]'
+
+        result = json.loads(discord_admin_handler(
+            action="create_channel",
+            guild_id="111",
+            name="ops",
+            channel_type=0,
+            parent_id="10",
+            topic="Operations",
+            permission_overwrites_json=overwrites,
+        ))
+
+        assert result["success"] is True
+        assert result["channel_id"] == "22"
+        mock_req.assert_called_once_with(
+            "POST", "/guilds/111/channels", "test-token",
+            body={
+                "name": "ops",
+                "type": 0,
+                "parent_id": "10",
+                "topic": "Operations",
+                "permission_overwrites": [{"id": "1", "type": 0, "allow": "117760", "deny": "0"}],
+            },
+        )
+
+    @patch("tools.discord_tool._discord_request")
+    def test_create_role(self, mock_req, monkeypatch):
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+        mock_req.return_value = {"id": "333", "name": "Hermes Friend"}
+
+        result = json.loads(discord_admin_handler(
+            action="create_role",
+            guild_id="111",
+            name="Hermes Friend",
+            color=65535,
+            hoist=True,
+            mentionable=True,
+        ))
+
+        assert result["success"] is True
+        assert result["role_id"] == "333"
+        mock_req.assert_called_once_with(
+            "POST", "/guilds/111/roles", "test-token",
+            body={"name": "Hermes Friend", "color": 65535, "hoist": True, "mentionable": True},
+        )
+
+    @patch("tools.discord_tool._discord_request")
+    def test_edit_channel_permissions(self, mock_req, monkeypatch):
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+        mock_req.return_value = None
+
+        result = json.loads(discord_admin_handler(
+            action="edit_channel_permissions",
+            channel_id="22",
+            overwrite_id="1",
+            overwrite_type=0,
+            allow="117760",
+            deny="0",
+        ))
+
+        assert result["success"] is True
+        mock_req.assert_called_once_with(
+            "PUT", "/channels/22/permissions/1", "test-token",
+            body={"type": 0, "allow": "117760", "deny": "0"},
+        )
+
+    @patch("tools.discord_tool._discord_request")
+    def test_create_channel_rejects_invalid_channel_type(self, mock_req, monkeypatch):
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+
+        result = json.loads(discord_admin_handler(
+            action="create_channel",
+            guild_id="111",
+            name="bad",
+            channel_type=2,
+        ))
+
+        assert "error" in result
+        assert "channel_type" in result["error"]
+        mock_req.assert_not_called()
+
+    @patch("tools.discord_tool._discord_request")
+    def test_edit_channel_permissions_rejects_non_numeric_bitfield(self, mock_req, monkeypatch):
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+
+        result = json.loads(discord_admin_handler(
+            action="edit_channel_permissions",
+            channel_id="22",
+            overwrite_id="1",
+            overwrite_type=0,
+            allow="abc",
+        ))
+
+        assert "error" in result
+        assert "allow" in result["error"]
+        mock_req.assert_not_called()
+
+    @patch("tools.discord_tool._discord_request")
+    def test_permission_overwrites_rejects_path_like_id(self, mock_req, monkeypatch):
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+        overwrites = '[{"id":"../roles","type":0,"allow":"117760","deny":"0"}]'
+
+        result = json.loads(discord_admin_handler(
+            action="create_channel",
+            guild_id="111",
+            name="bad",
+            permission_overwrites_json=overwrites,
+        ))
+
+        assert "error" in result
+        assert "permission_overwrites_json[0].id" in result["error"]
+        mock_req.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
 # Actions: add_role / remove_role
 # ---------------------------------------------------------------------------
 

--- a/tests/tools/test_lazy_deps.py
+++ b/tests/tools/test_lazy_deps.py
@@ -69,6 +69,15 @@ class TestSpecSafety:
         assert not ld._spec_is_safe(spec), \
             f"expected {spec!r} to be rejected"
 
+    def test_vetted_vector_core_git_spec_is_allowed_for_llm_wiki(self):
+        specs = ld.feature_specs("memory.llm_wiki")
+        vector_specs = [spec for spec in specs if spec.startswith("vector-core @ git+")]
+
+        assert len(vector_specs) == 1
+        assert ld._spec_is_safe(vector_specs[0])
+        assert "github.com/michaelkrauty/vector-core.git" in vector_specs[0]
+        assert vector_specs[0].rsplit("@", 1)[-1]
+
 
 # ---------------------------------------------------------------------------
 # Allowlist enforcement

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1121,6 +1121,7 @@ def _build_child_agent(
         ephemeral_system_prompt=child_prompt,
         log_prefix=f"[subagent-{task_index}]",
         platform=parent_agent.platform,
+        agent_context="subagent",
         skip_context_files=True,
         skip_memory=True,
         clarify_callback=None,

--- a/tools/discord_tool.py
+++ b/tools/discord_tool.py
@@ -28,6 +28,7 @@ actionable guidance the model can relay to the user.
 import json
 import logging
 import os
+import re
 import urllib.error
 import urllib.parse
 import urllib.request
@@ -53,6 +54,45 @@ _FLAG_GATEWAY_MESSAGE_CONTENT_LIMITED = 1 << 19
 def _get_bot_token() -> Optional[str]:
     """Resolve the Discord bot token from environment."""
     return os.getenv("DISCORD_BOT_TOKEN", "").strip() or None
+
+
+_DIGIT_ID_RE = re.compile(r"^[0-9]{1,20}$")
+_BITFIELD_RE = re.compile(r"^[0-9]+$")
+
+
+def _validate_discord_id(value: str, field_name: str) -> str:
+    """Validate IDs used in REST paths so tool input cannot alter endpoints."""
+    value = str(value or "").strip()
+    if not _DIGIT_ID_RE.fullmatch(value):
+        raise ValueError(f"{field_name} must be a Discord numeric ID")
+    return value
+
+
+def _validate_enum_int(value: Any, field_name: str, allowed: set[int]) -> int:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{field_name} must be one of {sorted(allowed)}") from exc
+    if parsed not in allowed:
+        raise ValueError(f"{field_name} must be one of {sorted(allowed)}")
+    return parsed
+
+
+def _validate_color(value: Any) -> int:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("color must be an integer between 0 and 16777215") from exc
+    if parsed < 0 or parsed > 0xFFFFFF:
+        raise ValueError("color must be an integer between 0 and 16777215")
+    return parsed
+
+
+def _validate_bitfield(value: Any, field_name: str) -> str:
+    value = str(value or "0").strip()
+    if not _BITFIELD_RE.fullmatch(value):
+        raise ValueError(f"{field_name} must be a numeric permission bitfield string")
+    return value
 
 
 def _discord_request(
@@ -454,6 +494,99 @@ def _create_thread(
     })
 
 
+def _parse_permission_overwrites(raw: str = "") -> Optional[List[Dict[str, Any]]]:
+    """Parse and validate a JSON permission-overwrites list supplied through the tool schema."""
+    if not raw:
+        return None
+    parsed = json.loads(raw)
+    if not isinstance(parsed, list):
+        raise ValueError("permission_overwrites_json must be a JSON list")
+    validated: list[dict[str, Any]] = []
+    for index, item in enumerate(parsed):
+        if not isinstance(item, dict):
+            raise ValueError(f"permission_overwrites_json[{index}] must be an object")
+        overwrite_id = _validate_discord_id(str(item.get("id", "")), f"permission_overwrites_json[{index}].id")
+        overwrite_type = _validate_enum_int(item.get("type", 0), f"permission_overwrites_json[{index}].type", {0, 1})
+        overwrite: dict[str, Any] = {"id": overwrite_id, "type": overwrite_type}
+        if "allow" in item:
+            overwrite["allow"] = _validate_bitfield(item.get("allow"), f"permission_overwrites_json[{index}].allow")
+        if "deny" in item:
+            overwrite["deny"] = _validate_bitfield(item.get("deny"), f"permission_overwrites_json[{index}].deny")
+        validated.append(overwrite)
+    return validated
+
+
+def _create_channel(
+    token: str,
+    guild_id: str,
+    name: str,
+    channel_type: int = 0,
+    parent_id: str = "",
+    topic: str = "",
+    permission_overwrites_json: str = "",
+    **_kwargs: Any,
+) -> str:
+    """Create a guild channel or category."""
+    guild_id = _validate_discord_id(guild_id, "guild_id")
+    channel_type = _validate_enum_int(channel_type, "channel_type", {0, 4})
+    body: Dict[str, Any] = {"name": name, "type": channel_type}
+    if parent_id:
+        body["parent_id"] = _validate_discord_id(parent_id, "parent_id")
+    if topic and channel_type == 0:
+        body["topic"] = topic
+    overwrites = _parse_permission_overwrites(permission_overwrites_json)
+    if overwrites is not None:
+        body["permission_overwrites"] = overwrites
+
+    channel = _discord_request("POST", f"/guilds/{guild_id}/channels", token, body=body)
+    return json.dumps({
+        "success": True,
+        "channel_id": channel.get("id"),
+        "name": channel.get("name"),
+        "type": channel.get("type"),
+        "parent_id": channel.get("parent_id"),
+    })
+
+
+def _create_role(
+    token: str,
+    guild_id: str,
+    name: str,
+    color: int = 0,
+    hoist: bool = False,
+    mentionable: bool = False,
+    **_kwargs: Any,
+) -> str:
+    """Create a guild role."""
+    guild_id = _validate_discord_id(guild_id, "guild_id")
+    body = {"name": name, "color": _validate_color(color), "hoist": bool(hoist), "mentionable": bool(mentionable)}
+    role = _discord_request("POST", f"/guilds/{guild_id}/roles", token, body=body)
+    return json.dumps({"success": True, "role_id": role.get("id"), "name": role.get("name")})
+
+
+def _edit_channel_permissions(
+    token: str,
+    channel_id: str,
+    overwrite_id: str,
+    overwrite_type: int = 0,
+    allow: str = "0",
+    deny: str = "0",
+    **_kwargs: Any,
+) -> str:
+    """Create or update a channel permission overwrite for a role or member."""
+    channel_id = _validate_discord_id(channel_id, "channel_id")
+    overwrite_id = _validate_discord_id(overwrite_id, "overwrite_id")
+    overwrite_type = _validate_enum_int(overwrite_type, "overwrite_type", {0, 1})
+    body = {"type": overwrite_type, "allow": _validate_bitfield(allow, "allow"), "deny": _validate_bitfield(deny, "deny")}
+    _discord_request("PUT", f"/channels/{channel_id}/permissions/{overwrite_id}", token, body=body)
+    return json.dumps({
+        "success": True,
+        "channel_id": channel_id,
+        "overwrite_id": overwrite_id,
+        "type": int(overwrite_type),
+    })
+
+
 def _add_role(token: str, guild_id: str, user_id: str, role_id: str, **_kwargs: Any) -> str:
     """Add a role to a guild member."""
     _discord_request("PUT", f"/guilds/{guild_id}/members/{user_id}/roles/{role_id}", token)
@@ -484,6 +617,9 @@ _ACTIONS = {
     "unpin_message": _unpin_message,
     "delete_message": _delete_message,
     "create_thread": _create_thread,
+    "create_channel": _create_channel,
+    "create_role": _create_role,
+    "edit_channel_permissions": _edit_channel_permissions,
     "add_role": _add_role,
     "remove_role": _remove_role,
 }
@@ -511,6 +647,9 @@ _ACTION_MANIFEST: List[Tuple[str, str, str]] = [
     ("unpin_message", "(channel_id, message_id)", "unpin a message"),
     ("delete_message", "(channel_id, message_id)", "delete a message"),
     ("create_thread", "(channel_id, name)", "create a public thread; optional message_id anchor"),
+    ("create_channel", "(guild_id, name)", "create a text channel/category; optional parent_id/topic/permission overwrites"),
+    ("create_role", "(guild_id, name)", "create a role"),
+    ("edit_channel_permissions", "(channel_id, overwrite_id)", "set a channel overwrite for a role/user"),
     ("add_role", "(guild_id, user_id, role_id)", "assign a role"),
     ("remove_role", "(guild_id, user_id, role_id)", "remove a role"),
 ]
@@ -532,6 +671,9 @@ _REQUIRED_PARAMS: Dict[str, List[str]] = {
     "unpin_message": ["channel_id", "message_id"],
     "delete_message": ["channel_id", "message_id"],
     "create_thread": ["channel_id", "name"],
+    "create_channel": ["guild_id", "name"],
+    "create_role": ["guild_id", "name"],
+    "edit_channel_permissions": ["channel_id", "overwrite_id"],
     "add_role": ["guild_id", "user_id", "role_id"],
     "remove_role": ["guild_id", "user_id", "role_id"],
 }
@@ -691,7 +833,53 @@ def _build_schema(
         },
         "name": {
             "type": "string",
-            "description": "New thread name (create_thread).",
+            "description": "Name for create_thread, create_channel, or create_role.",
+        },
+        "channel_type": {
+            "type": "integer",
+            "enum": [0, 4],
+            "description": "Channel type for create_channel: 0=text channel, 4=category.",
+        },
+        "parent_id": {
+            "type": "string",
+            "description": "Parent category channel ID for create_channel.",
+        },
+        "topic": {
+            "type": "string",
+            "description": "Topic for create_channel text channels.",
+        },
+        "permission_overwrites_json": {
+            "type": "string",
+            "description": "JSON list of Discord permission overwrites for create_channel, e.g. [{\"id\":\"role_id\",\"type\":0,\"allow\":\"1024\",\"deny\":\"0\"}].",
+        },
+        "overwrite_id": {
+            "type": "string",
+            "description": "Role or user ID for edit_channel_permissions.",
+        },
+        "overwrite_type": {
+            "type": "integer",
+            "enum": [0, 1],
+            "description": "Overwrite type for edit_channel_permissions: 0=role, 1=member.",
+        },
+        "allow": {
+            "type": "string",
+            "description": "Permission bitfield string to allow in edit_channel_permissions.",
+        },
+        "deny": {
+            "type": "string",
+            "description": "Permission bitfield string to deny in edit_channel_permissions.",
+        },
+        "color": {
+            "type": "integer",
+            "description": "Decimal RGB color for create_role (default 0).",
+        },
+        "hoist": {
+            "type": "boolean",
+            "description": "Whether create_role should display separately.",
+        },
+        "mentionable": {
+            "type": "boolean",
+            "description": "Whether create_role should be mentionable.",
         },
         "limit": {
             "type": "integer",
@@ -773,6 +961,15 @@ _ACTION_403_HINT = {
     "create_thread": (
         "Bot lacks CREATE_PUBLIC_THREADS in this channel, or cannot view it."
     ),
+    "create_channel": (
+        "Bot lacks MANAGE_CHANNELS permission, or cannot create channels in this guild."
+    ),
+    "edit_channel_permissions": (
+        "Bot lacks MANAGE_CHANNELS permission for this channel."
+    ),
+    "create_role": (
+        "Bot lacks MANAGE_ROLES permission in this guild."
+    ),
     "add_role": (
         "Either the bot lacks MANAGE_ROLES, or the target role sits higher "
         "than the bot's highest role. Roles can only be assigned below the "
@@ -839,6 +1036,17 @@ def _run_discord_action(
     before: str = "",
     after: str = "",
     auto_archive_duration: int = 1440,
+    channel_type: int = 0,
+    parent_id: str = "",
+    topic: str = "",
+    permission_overwrites_json: str = "",
+    overwrite_id: str = "",
+    overwrite_type: int = 0,
+    allow: str = "0",
+    deny: str = "0",
+    color: int = 0,
+    hoist: bool = False,
+    mentionable: bool = False,
 ) -> str:
     """Shared handler logic for both discord tools."""
     token = _get_bot_token()
@@ -872,6 +1080,7 @@ def _run_discord_action(
         "message_id": message_id,
         "query": query,
         "name": name,
+        "overwrite_id": overwrite_id,
     }
 
     missing = [p for p in _REQUIRED_PARAMS.get(action, []) if not local_vars.get(p)]
@@ -894,6 +1103,17 @@ def _run_discord_action(
             before=before,
             after=after,
             auto_archive_duration=auto_archive_duration,
+            channel_type=channel_type,
+            parent_id=parent_id,
+            topic=topic,
+            permission_overwrites_json=permission_overwrites_json,
+            overwrite_id=overwrite_id,
+            overwrite_type=overwrite_type,
+            allow=allow,
+            deny=deny,
+            color=color,
+            hoist=hoist,
+            mentionable=mentionable,
         )
     except DiscordAPIError as e:
         logger.warning("Discord API error in %s action '%s': %s", tool_label, action, e)
@@ -923,6 +1143,9 @@ _HANDLER_DEFAULTS = {
     "action": "", "guild_id": "", "channel_id": "", "user_id": "",
     "role_id": "", "message_id": "", "query": "", "name": "",
     "limit": 50, "before": "", "after": "", "auto_archive_duration": 1440,
+    "channel_type": 0, "parent_id": "", "topic": "", "permission_overwrites_json": "",
+    "overwrite_id": "", "overwrite_type": 0, "allow": "0", "deny": "0",
+    "color": 0, "hoist": False, "mentionable": False,
 }
 
 

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -26,9 +26,11 @@ Security model:
 
 * **Venv-scoped only.** Installs target ``sys.executable`` in the active
   venv. We never touch the system Python.
-* **PyPI by package name only.** Specs may be ``"package>=1.0,<2"`` etc.
-  We do NOT support ``--index-url`` overrides, ``git+https://``, file:
-  paths, or any other input that could be hijacked by a malicious config.
+* **PyPI by package name by default.** Specs may be ``"package>=1.0,<2"`` etc.
+  Direct Git references are rejected except for explicitly vetted,
+  commit-pinned public GitHub dependencies that appear in :data:`LAZY_DEPS`.
+  We do NOT support ``--index-url`` overrides, file: paths, or any other
+  input that could be hijacked by a malicious config.
 * **Allowlist.** Only specs that appear in :data:`LAZY_DEPS` can be
   installed via this path. A typo in feature name doesn't get the user
   install-anything semantics.
@@ -118,6 +120,10 @@ LAZY_DEPS: dict[str, tuple[str, ...]] = {
     # ─── Memory providers ──────────────────────────────────────────────────
     "memory.honcho": ("honcho-ai==2.0.1",),
     "memory.hindsight": ("hindsight-client==0.6.1",),
+    "memory.llm_wiki": (
+        "qdrant-client==1.16.1",
+        "vector-core @ git+https://github.com/michaelkrauty/vector-core.git@551056769b66d35c56dbc48475785fbb646afbef",
+    ),
 
     # ─── Messaging platforms (lazy-installable on demand) ──────────────────
     "platform.telegram": ("python-telegram-bot[webhooks]==22.6",),
@@ -183,6 +189,11 @@ _SAFE_SPEC = re.compile(
     r"$"
 )
 
+_SAFE_DIRECT_GIT_SPEC = re.compile(
+    r"^vector-core @ git\+https://github\.com/michaelkrauty/vector-core\.git@"
+    r"[0-9a-f]{40}$"
+)
+
 
 class FeatureUnavailable(RuntimeError):
     """A lazily-installable feature is missing and cannot be made available.
@@ -238,11 +249,13 @@ def _allow_lazy_installs() -> bool:
 
 
 def _spec_is_safe(spec: str) -> bool:
-    """Reject pip specs that contain URLs, paths, or shell metacharacters."""
+    """Reject pip specs that contain unvetted URLs, paths, or shell metacharacters."""
     if not spec or len(spec) > 200:
         return False
     if any(ch in spec for ch in (";", "|", "&", "`", "$", "\n", "\r", "\t", "\\")):
         return False
+    if _SAFE_DIRECT_GIT_SPEC.match(spec):
+        return True
     if spec.startswith(("-", "/", ".")) or "://" in spec or "@" in spec:
         return False
     return bool(_SAFE_SPEC.match(spec))
@@ -265,6 +278,9 @@ def _specifier_from_spec(spec: str) -> str:
     ``"mautrix[encryption]>=0.20,<1"`` → ``">=0.20,<1"``
     ``"package"`` → ``""`` (no version constraint)
     """
+    if _SAFE_DIRECT_GIT_SPEC.match(spec):
+        return ""
+
     # Strip the package name + optional [extras] block.
     m = re.match(r"^[A-Za-z0-9_][A-Za-z0-9_.\-]*(?:\[[A-Za-z0-9_,\-]+\])?", spec)
     if not m:

--- a/uv.lock
+++ b/uv.lock
@@ -1562,6 +1562,57 @@ wheels = [
 ]
 
 [[package]]
+name = "grpcio"
+version = "1.80.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b7/48/af6173dbca4454f4637a4678b67f52ca7e0c1ed7d5894d89d434fecede05/grpcio-1.80.0.tar.gz", hash = "sha256:29aca15edd0688c22ba01d7cc01cb000d72b2033f4a3c72a81a19b56fd143257", size = 12978905, upload-time = "2026-03-30T08:49:10.502Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/db/1d56e5f5823257b291962d6c0ce106146c6447f405b60b234c4f222a7cde/grpcio-1.80.0-cp311-cp311-linux_armv7l.whl", hash = "sha256:dfab85db094068ff42e2a3563f60ab3dddcc9d6488a35abf0132daec13209c8a", size = 6055009, upload-time = "2026-03-30T08:46:46.265Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/18/c83f3cad64c5ca63bca7e91e5e46b0d026afc5af9d0a9972472ceba294b3/grpcio-1.80.0-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:5c07e82e822e1161354e32da2662f741a4944ea955f9f580ec8fb409dd6f6060", size = 12035295, upload-time = "2026-03-30T08:46:49.099Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/8e/e14966b435be2dda99fbe89db9525ea436edc79780431a1c2875a3582644/grpcio-1.80.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ba0915d51fd4ced2db5ff719f84e270afe0e2d4c45a7bdb1e8d036e4502928c2", size = 6610297, upload-time = "2026-03-30T08:46:52.123Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/26/d5eb38f42ce0e3fdc8174ea4d52036ef8d58cc4426cb800f2610f625dd75/grpcio-1.80.0-cp311-cp311-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:3cb8130ba457d2aa09fa6b7c3ed6b6e4e6a2685fce63cb803d479576c4d80e21", size = 7300208, upload-time = "2026-03-30T08:46:54.859Z" },
+    { url = "https://files.pythonhosted.org/packages/25/51/bd267c989f85a17a5b3eea65a6feb4ff672af41ca614e5a0279cc0ea381c/grpcio-1.80.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:09e5e478b3d14afd23f12e49e8b44c8684ac3c5f08561c43a5b9691c54d136ab", size = 6813442, upload-time = "2026-03-30T08:46:57.056Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/d9/d80eef735b19e9169e30164bbf889b46f9df9127598a83d174eb13a48b26/grpcio-1.80.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:00168469238b022500e486c1c33916acf2f2a9b2c022202cf8a1885d2e3073c1", size = 7414743, upload-time = "2026-03-30T08:46:59.682Z" },
+    { url = "https://files.pythonhosted.org/packages/de/f2/567f5bd5054398ed6b0509b9a30900376dcf2786bd936812098808b49d8d/grpcio-1.80.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:8502122a3cc1714038e39a0b071acb1207ca7844208d5ea0d091317555ee7106", size = 8426046, upload-time = "2026-03-30T08:47:02.474Z" },
+    { url = "https://files.pythonhosted.org/packages/62/29/73ef0141b4732ff5eacd68430ff2512a65c004696997f70476a83e548e7e/grpcio-1.80.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ce1794f4ea6cc3ca29463f42d665c32ba1b964b48958a66497917fe9069f26e6", size = 7851641, upload-time = "2026-03-30T08:47:05.462Z" },
+    { url = "https://files.pythonhosted.org/packages/46/69/abbfa360eb229a8623bab5f5a4f8105e445bd38ce81a89514ba55d281ad0/grpcio-1.80.0-cp311-cp311-win32.whl", hash = "sha256:51b4a7189b0bef2aa30adce3c78f09c83526cf3dddb24c6a96555e3b97340440", size = 4154368, upload-time = "2026-03-30T08:47:08.027Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/d4/ae92206d01183b08613e846076115f5ac5991bae358d2a749fa864da5699/grpcio-1.80.0-cp311-cp311-win_amd64.whl", hash = "sha256:02e64bb0bb2da14d947a49e6f120a75e947250aebe65f9629b62bb1f5c14e6e9", size = 4894235, upload-time = "2026-03-30T08:47:10.839Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/e8/a2b749265eb3415abc94f2e619bbd9e9707bebdda787e61c593004ec927a/grpcio-1.80.0-cp312-cp312-linux_armv7l.whl", hash = "sha256:c624cc9f1008361014378c9d776de7182b11fe8b2e5a81bc69f23a295f2a1ad0", size = 6015616, upload-time = "2026-03-30T08:47:13.428Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/97/b1282161a15d699d1e90c360df18d19165a045ce1c343c7f313f5e8a0b77/grpcio-1.80.0-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:f49eddcac43c3bf350c0385366a58f36bed8cc2c0ec35ef7b74b49e56552c0c2", size = 12014204, upload-time = "2026-03-30T08:47:15.873Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/5e/d319c6e997b50c155ac5a8cb12f5173d5b42677510e886d250d50264949d/grpcio-1.80.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d334591df610ab94714048e0d5b4f3dd5ad1bee74dfec11eee344220077a79de", size = 6563866, upload-time = "2026-03-30T08:47:18.588Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/f6/fdd975a2cb4d78eb67769a7b3b3830970bfa2e919f1decf724ae4445f42c/grpcio-1.80.0-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:0cb517eb1d0d0aaf1d87af7cc5b801d686557c1d88b2619f5e31fab3c2315921", size = 7273060, upload-time = "2026-03-30T08:47:21.113Z" },
+    { url = "https://files.pythonhosted.org/packages/db/f0/a3deb5feba60d9538a962913e37bd2e69a195f1c3376a3dd44fe0427e996/grpcio-1.80.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4e78c4ac0d97dc2e569b2f4bcbbb447491167cb358d1a389fc4af71ab6f70411", size = 6782121, upload-time = "2026-03-30T08:47:23.827Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/84/36c6dcfddc093e108141f757c407902a05085e0c328007cb090d56646cdf/grpcio-1.80.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2ed770b4c06984f3b47eb0517b1c69ad0b84ef3f40128f51448433be904634cd", size = 7383811, upload-time = "2026-03-30T08:47:26.517Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/ef/f3a77e3dc5b471a0ec86c564c98d6adfa3510d38f8ee99010410858d591e/grpcio-1.80.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:256507e2f524092f1473071a05e65a5b10d84b82e3ff24c5b571513cfaa61e2f", size = 8393860, upload-time = "2026-03-30T08:47:29.439Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/8d/9d4d27ed7f33d109c50d6b5ce578a9914aa68edab75d65869a17e630a8d1/grpcio-1.80.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:9a6284a5d907c37db53350645567c522be314bac859a64a7a5ca63b77bb7958f", size = 7830132, upload-time = "2026-03-30T08:47:33.254Z" },
+    { url = "https://files.pythonhosted.org/packages/14/e4/9990b41c6d7a44e1e9dee8ac11d7a9802ba1378b40d77468a7761d1ad288/grpcio-1.80.0-cp312-cp312-win32.whl", hash = "sha256:c71309cfce2f22be26aa4a847357c502db6c621f1a49825ae98aa0907595b193", size = 4140904, upload-time = "2026-03-30T08:47:35.319Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/2c/296f6138caca1f4b92a31ace4ae1b87dab692fc16a7a3417af3bb3c805bf/grpcio-1.80.0-cp312-cp312-win_amd64.whl", hash = "sha256:9fe648599c0e37594c4809d81a9e77bd138cc82eb8baa71b6a86af65426723ff", size = 4880944, upload-time = "2026-03-30T08:47:37.831Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/3a/7c3c25789e3f069e581dc342e03613c5b1cb012c4e8c7d9d5cf960a75856/grpcio-1.80.0-cp313-cp313-linux_armv7l.whl", hash = "sha256:e9e408fc016dffd20661f0126c53d8a31c2821b5c13c5d67a0f5ed5de93319ad", size = 6017243, upload-time = "2026-03-30T08:47:40.075Z" },
+    { url = "https://files.pythonhosted.org/packages/04/19/21a9806eb8240e174fd1ab0cd5b9aa948bb0e05c2f2f55f9d5d7405e6d08/grpcio-1.80.0-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:92d787312e613754d4d8b9ca6d3297e69994a7912a32fa38c4c4e01c272974b0", size = 12010840, upload-time = "2026-03-30T08:47:43.11Z" },
+    { url = "https://files.pythonhosted.org/packages/18/3a/23347d35f76f639e807fb7a36fad3068aed100996849a33809591f26eca6/grpcio-1.80.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8ac393b58aa16991a2f1144ec578084d544038c12242da3a215966b512904d0f", size = 6567644, upload-time = "2026-03-30T08:47:46.806Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/40/96e07ecb604a6a67ae6ab151e3e35b132875d98bc68ec65f3e5ab3e781d7/grpcio-1.80.0-cp313-cp313-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:68e5851ac4b9afe07e7f84483803ad167852570d65326b34d54ca560bfa53fb6", size = 7277830, upload-time = "2026-03-30T08:47:49.643Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/e2/da1506ecea1f34a5e365964644b35edef53803052b763ca214ba3870c856/grpcio-1.80.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:873ff5d17d68992ef6605330127425d2fc4e77e612fa3c3e0ed4e668685e3140", size = 6783216, upload-time = "2026-03-30T08:47:52.817Z" },
+    { url = "https://files.pythonhosted.org/packages/44/83/3b20ff58d0c3b7f6caaa3af9a4174d4023701df40a3f39f7f1c8e7c48f9d/grpcio-1.80.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:2bea16af2750fd0a899bf1abd9022244418b55d1f37da2202249ba4ba673838d", size = 7385866, upload-time = "2026-03-30T08:47:55.687Z" },
+    { url = "https://files.pythonhosted.org/packages/47/45/55c507599c5520416de5eefecc927d6a0d7af55e91cfffb2e410607e5744/grpcio-1.80.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:ba0db34f7e1d803a878284cd70e4c63cb6ae2510ba51937bf8f45ba997cefcf7", size = 8391602, upload-time = "2026-03-30T08:47:58.303Z" },
+    { url = "https://files.pythonhosted.org/packages/10/bb/dd06f4c24c01db9cf11341b547d0a016b2c90ed7dbbb086a5710df7dd1d7/grpcio-1.80.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8eb613f02d34721f1acf3626dfdb3545bd3c8505b0e52bf8b5710a28d02e8aa7", size = 7826752, upload-time = "2026-03-30T08:48:01.311Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/1e/9d67992ba23371fd63d4527096eb8c6b76d74d52b500df992a3343fd7251/grpcio-1.80.0-cp313-cp313-win32.whl", hash = "sha256:93b6f823810720912fd131f561f91f5fed0fda372b6b7028a2681b8194d5d294", size = 4142310, upload-time = "2026-03-30T08:48:04.594Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/e6/283326a27da9e2c3038bc93eeea36fb118ce0b2d03922a9cda6688f53c5b/grpcio-1.80.0-cp313-cp313-win_amd64.whl", hash = "sha256:e172cf795a3ba5246d3529e4d34c53db70e888fa582a8ffebd2e6e48bc0cba50", size = 4882833, upload-time = "2026-03-30T08:48:07.363Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/6d/e65307ce20f5a09244ba9e9d8476e99fb039de7154f37fb85f26978b59c3/grpcio-1.80.0-cp314-cp314-linux_armv7l.whl", hash = "sha256:3d4147a97c8344d065d01bbf8b6acec2cf86fb0400d40696c8bdad34a64ffc0e", size = 6017376, upload-time = "2026-03-30T08:48:10.005Z" },
+    { url = "https://files.pythonhosted.org/packages/69/10/9cef5d9650c72625a699c549940f0abb3c4bfdb5ed45a5ce431f92f31806/grpcio-1.80.0-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:d8e11f167935b3eb089ac9038e1a063e6d7dbe995c0bb4a661e614583352e76f", size = 12018133, upload-time = "2026-03-30T08:48:12.927Z" },
+    { url = "https://files.pythonhosted.org/packages/04/82/983aabaad82ba26113caceeb9091706a0696b25da004fe3defb5b346e15b/grpcio-1.80.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f14b618fc30de822681ee986cfdcc2d9327229dc4c98aed16896761cacd468b9", size = 6574748, upload-time = "2026-03-30T08:48:16.386Z" },
+    { url = "https://files.pythonhosted.org/packages/07/d7/031666ef155aa0bf399ed7e19439656c38bbd143779ae0861b038ce82abd/grpcio-1.80.0-cp314-cp314-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:4ed39fbdcf9b87370f6e8df4e39ca7b38b3e5e9d1b0013c7b6be9639d6578d14", size = 7277711, upload-time = "2026-03-30T08:48:19.627Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/43/f437a78f7f4f1d311804189e8f11fb311a01049b2e08557c1068d470cb2e/grpcio-1.80.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2dcc70e9f0ba987526e8e8603a610fb4f460e42899e74e7a518bf3c68fe1bf05", size = 6785372, upload-time = "2026-03-30T08:48:22.373Z" },
+    { url = "https://files.pythonhosted.org/packages/93/3d/f6558e9c6296cb4227faa5c43c54a34c68d32654b829f53288313d16a86e/grpcio-1.80.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:448c884b668b868562b1bda833c5fce6272d26e1926ec46747cda05741d302c1", size = 7395268, upload-time = "2026-03-30T08:48:25.638Z" },
+    { url = "https://files.pythonhosted.org/packages/06/21/0fdd77e84720b08843c371a2efa6f2e19dbebf56adc72df73d891f5506f0/grpcio-1.80.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:a1dc80fe55685b4a543555e6eef975303b36c8db1023b1599b094b92aa77965f", size = 8392000, upload-time = "2026-03-30T08:48:28.974Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/68/67f4947ed55d2e69f2cc199ab9fd85e0a0034d813bbeef84df6d2ba4d4b7/grpcio-1.80.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:31b9ac4ad1aa28ffee5503821fafd09e4da0a261ce1c1281c6c8da0423c83b6e", size = 7828477, upload-time = "2026-03-30T08:48:32.054Z" },
+    { url = "https://files.pythonhosted.org/packages/44/b6/8d4096691b2e385e8271911a0de4f35f0a6c7d05aff7098e296c3de86939/grpcio-1.80.0-cp314-cp314-win32.whl", hash = "sha256:367ce30ba67d05e0592470428f0ec1c31714cab9ef19b8f2e37be1f4c7d32fae", size = 4218563, upload-time = "2026-03-30T08:48:34.538Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/8c/bbe6baf2557262834f2070cf668515fa308b2d38a4bbf771f8f7872a7036/grpcio-1.80.0-cp314-cp314-win_amd64.whl", hash = "sha256:3b01e1f5464c583d2f567b2e46ff0d516ef979978f72091fd81f5ab7fa6e2e7f", size = 5019457, upload-time = "2026-03-30T08:48:37.308Z" },
+]
+
+[[package]]
 name = "grpclib"
 version = "0.4.9"
 source = { registry = "https://pypi.org/simple" }
@@ -1706,6 +1757,10 @@ homeassistant = [
 ]
 honcho = [
     { name = "honcho-ai" },
+]
+llm-wiki = [
+    { name = "qdrant-client" },
+    { name = "vector-core" },
 ]
 matrix = [
     { name = "aiohttp-socks" },
@@ -1868,6 +1923,7 @@ requires-dist = [
     { name = "python-telegram-bot", extras = ["webhooks"], marker = "extra == 'termux'", specifier = "==22.6" },
     { name = "pywinpty", marker = "sys_platform == 'win32' and extra == 'pty'", specifier = "==2.0.15" },
     { name = "pyyaml", specifier = "==6.0.3" },
+    { name = "qdrant-client", marker = "extra == 'llm-wiki'", specifier = "==1.16.1" },
     { name = "qrcode", marker = "extra == 'dingtalk'", specifier = "==7.4.2" },
     { name = "qrcode", marker = "extra == 'feishu'", specifier = "==7.4.2" },
     { name = "qrcode", marker = "extra == 'messaging'", specifier = "==7.4.2" },
@@ -1885,10 +1941,11 @@ requires-dist = [
     { name = "ty", marker = "extra == 'dev'", specifier = "==0.0.21" },
     { name = "tzdata", marker = "sys_platform == 'win32'", specifier = "==2025.3" },
     { name = "uvicorn", extras = ["standard"], marker = "extra == 'web'", specifier = "==0.41.0" },
+    { name = "vector-core", marker = "extra == 'llm-wiki'", git = "https://github.com/michaelkrauty/vector-core.git?rev=551056769b66d35c56dbc48475785fbb646afbef" },
     { name = "vercel", marker = "extra == 'vercel'", specifier = "==0.5.7" },
     { name = "youtube-transcript-api", marker = "extra == 'youtube'", specifier = "==1.2.4" },
 ]
-provides-extras = ["anthropic", "exa", "firecrawl", "parallel-web", "fal", "edge-tts", "modal", "daytona", "vercel", "hindsight", "dev", "messaging", "cron", "slack", "matrix", "cli", "tts-premium", "voice", "pty", "honcho", "mcp", "homeassistant", "sms", "computer-use", "acp", "bedrock", "azure-identity", "termux", "termux-all", "dingtalk", "feishu", "google", "youtube", "web", "all"]
+provides-extras = ["anthropic", "exa", "firecrawl", "parallel-web", "fal", "edge-tts", "modal", "daytona", "vercel", "hindsight", "llm-wiki", "dev", "messaging", "cron", "slack", "matrix", "cli", "tts-premium", "voice", "pty", "honcho", "mcp", "homeassistant", "sms", "computer-use", "acp", "bedrock", "azure-identity", "termux", "termux-all", "dingtalk", "feishu", "google", "youtube", "web", "all"]
 
 [[package]]
 name = "hf-xet"
@@ -2039,6 +2096,9 @@ wheels = [
 ]
 
 [package.optional-dependencies]
+http2 = [
+    { name = "h2" },
+]
 socks = [
     { name = "socksio" },
 ]
@@ -3015,12 +3075,33 @@ wheels = [
 ]
 
 [[package]]
+name = "pathspec"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/82/42f767fc1c1143d6fd36efb827202a2d997a375e160a71eb2888a925aac1/pathspec-1.1.1.tar.gz", hash = "sha256:17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a", size = 135180, upload-time = "2026-04-27T01:46:08.907Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl", hash = "sha256:a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189", size = 57328, upload-time = "2026-04-27T01:46:07.06Z" },
+]
+
+[[package]]
 name = "pluggy"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "portalocker"
+version = "3.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5e/77/65b857a69ed876e1951e88aaba60f5ce6120c33703f7cb61a3c894b8c1b6/portalocker-3.2.0.tar.gz", hash = "sha256:1f3002956a54a8c3730586c5c77bf18fae4149e07eaf1c29fc3faf4d5a3f89ac", size = 95644, upload-time = "2025-06-14T13:20:40.03Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4b/a6/38c8e2f318bf67d338f4d629e93b0b4b9af331f455f0390ea8ce4a099b26/portalocker-3.2.0-py3-none-any.whl", hash = "sha256:3cdc5f565312224bc570c49337bd21428bba0ef363bbcf58b9ef4a9f11779968", size = 22424, upload-time = "2025-06-14T13:20:38.083Z" },
 ]
 
 [[package]]
@@ -3666,6 +3747,24 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
     { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
     { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "qdrant-client"
+version = "1.16.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "grpcio" },
+    { name = "httpx", extra = ["http2"] },
+    { name = "numpy" },
+    { name = "portalocker" },
+    { name = "protobuf" },
+    { name = "pydantic" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d9/68/fec3816a223c0b73b0e0036460be45c61ce2770ffb9197ac371e4f615ddc/qdrant_client-1.16.1.tar.gz", hash = "sha256:676c7c10fd4d4cb2981b8fcb32fd764f5f661b04b7334d024034d07212f971fd", size = 332130, upload-time = "2025-11-25T04:31:54.212Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/60/e2/60a20d04b0595c641516463168909c5bbcc192d3d6eacb637c1677109c6a/qdrant_client-1.16.1-py3-none-any.whl", hash = "sha256:1eefe89f66e8a468ba0de1680e28b441e69825cfb62e8fb2e457c15e24ce5e3b", size = 378481, upload-time = "2025-11-25T04:31:52.629Z" },
 ]
 
 [[package]]
@@ -4384,6 +4483,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c1/37/945b4ca0ac27e3dc4952642d4c900edd030b3da6c9634875af6e13ae80e5/uvloop-0.22.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b91328c72635f6f9e0282e4a57da7470c7350ab1c9f48546c0f2866205349d21", size = 4467065, upload-time = "2025-10-16T22:16:58.206Z" },
     { url = "https://files.pythonhosted.org/packages/97/cc/48d232f33d60e2e2e0b42f4e73455b146b76ebe216487e862700457fbf3c/uvloop-0.22.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:daf620c2995d193449393d6c62131b3fbd40a63bf7b307a1527856ace637fe88", size = 4328384, upload-time = "2025-10-16T22:16:59.36Z" },
     { url = "https://files.pythonhosted.org/packages/e4/16/c1fd27e9549f3c4baf1dc9c20c456cd2f822dbf8de9f463824b0c0357e06/uvloop-0.22.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6cde23eeda1a25c75b2e07d39970f3374105d5eafbaab2a4482be82f272d5a5e", size = 4296730, upload-time = "2025-10-16T22:17:00.744Z" },
+]
+
+[[package]]
+name = "vector-core"
+version = "1.0.2"
+source = { git = "https://github.com/michaelkrauty/vector-core.git?rev=551056769b66d35c56dbc48475785fbb646afbef#551056769b66d35c56dbc48475785fbb646afbef" }
+dependencies = [
+    { name = "httpx" },
+    { name = "pathspec" },
+    { name = "pydantic" },
+    { name = "pydantic-settings" },
+    { name = "qdrant-client" },
 ]
 
 [[package]]

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -859,7 +859,7 @@ auxiliary:
 
   # Context compression timeout (separate from compression.* config)
   compression:
-    timeout: 120               # seconds — compression summarizes long conversations, needs more time
+    timeout: 120               # seconds — compression summarizes long conversations; set 0 to disable
 
   # Skills hub — skill matching and search
   skills_hub:
@@ -891,7 +891,7 @@ auxiliary:
 ```
 
 :::tip
-Each auxiliary task has a configurable `timeout` (in seconds). Defaults: vision 120s, web_extract 360s, approval 30s, compression 120s. Increase these if you use slow local models for auxiliary tasks. Vision also has a separate `download_timeout` (default 30s) for the HTTP image download — increase this for slow connections or self-hosted image servers.
+Each auxiliary task has a configurable `timeout` (in seconds). Defaults: vision 120s, web_extract 360s, approval 30s, compression 120s. Increase these if you use slow local models for auxiliary tasks, or set an auxiliary task timeout to `0` to disable its request timeout entirely. Vision also has a separate `download_timeout` (default 30s) for the HTTP image download — increase this for slow connections or self-hosted image servers.
 :::
 
 :::info

--- a/website/docs/user-guide/features/honcho.md
+++ b/website/docs/user-guide/features/honcho.md
@@ -96,7 +96,7 @@ Passes bail out early if the prior pass returned strong signal (long, structured
 
 ### Session-Start Prewarm
 
-On session init, Honcho fires a dialectic call in the background at the full configured `dialecticDepth` and hands the result directly to turn 1's context assembly. A single-pass prewarm on a cold peer often returns thin output — multi-pass depth runs the audit/reconcile cycle before the user ever speaks. If prewarm hasn't landed by turn 1, turn 1 falls back to a synchronous call with a bounded timeout.
+On session init, Honcho fires a dialectic call in the background at the full configured `dialecticDepth` and hands the result directly to turn 1's context assembly if it has landed by then. A single-pass prewarm on a cold peer often returns thin output — multi-pass depth runs the audit/reconcile cycle before the user ever speaks. If prewarm hasn't landed by turn 1, turn 1 queues an async recovery prefetch without imposing a Hermes-side timeout; the result is picked up when it naturally completes.
 
 ### Query-Adaptive Reasoning Level
 

--- a/website/docs/user-guide/features/llm-wiki-memory.md
+++ b/website/docs/user-guide/features/llm-wiki-memory.md
@@ -1,0 +1,285 @@
+---
+sidebar_position: 5
+title: "LLM Wiki Memory"
+description: "Local-first, source-backed durable memory for Hermes Agent"
+---
+
+# LLM Wiki Memory
+
+LLM Wiki is a local-first memory provider that stores durable knowledge as an inspectable Markdown wiki and indexes it for semantic retrieval. It is designed for knowledge you want to curate, cite, edit, back up, diff, and publish like documentation.
+
+It is intentionally **not** an automatic transcript summarizer. Normal conversation turns are not written into the wiki. Hermes can search and read the wiki during chat, but durable writes require explicit tool calls and are blocked in unsafe contexts. Use it when you want source-backed memory that stays under your control instead of a hidden hosted memory database.
+
+## When to use it
+
+Use LLM Wiki for:
+
+- project architecture and operating manuals
+- durable policy and conventions
+- research notes and source-backed conclusions
+- memory that should remain inspectable in Git or a folder backup
+- local/offline-first deployments
+
+Use other memory paths for other jobs:
+
+- **Built-in `MEMORY.md` / `USER.md`**: tiny boot-critical facts and preferences.
+- **Session search**: chronological recall of past conversations.
+- **Honcho/Mem0/Supermemory/etc.**: automatic user modeling or hosted semantic memory.
+
+## Install
+
+LLM Wiki's provider package is bundled with Hermes. Heavy vector-store dependencies are optional and lazy-loaded so normal Hermes installs stay small. The `llm-wiki` extra installs Qdrant plus Hermes's shared vector infrastructure dependency, `vector-core`, from a commit-pinned public GitHub ref until `vector-core` is published on PyPI.
+
+For an explicit install, use the optional dependency group:
+
+```bash
+pip install 'hermes-agent[llm-wiki]'
+```
+
+If you only configure the provider, Hermes can still discover it without `qdrant-client` or `vector-core` installed. The first real engine/tool use will ask the lazy-dependency system to install the pinned optional dependencies, unless lazy installs are disabled in your security config.
+
+LLM Wiki also expects:
+
+- a Qdrant HTTP endpoint, default `http://localhost:6333`
+- an OpenAI-compatible embedding endpoint, default `http://localhost:22222`
+- an OpenAI-compatible chat endpoint for `wiki_query`, default `http://localhost:8011/v1`
+
+For a local Qdrant server:
+
+```bash
+docker run -p 6333:6333 -v "$PWD/qdrant_storage:/qdrant/storage" qdrant/qdrant
+```
+
+## Configure
+
+Run the memory setup wizard and select `llm_wiki`:
+
+```bash
+hermes memory setup
+```
+
+Manual `~/.hermes/config.yaml` example:
+
+```yaml
+memory:
+  provider: llm_wiki
+
+wiki:
+  path: ~/.hermes/wiki/personal
+  name: personal
+  embedding:
+    url: http://localhost:22222
+    model: Qwen3-Embedding-8B
+    dim: 4096
+    # Optional; defaults to <wiki path>/.cache/embeddings.sqlite3
+    cache_path: ~/.hermes/wiki/personal/.cache/embeddings.sqlite3
+    cache_max_entries: 100000
+  vector_store:
+    url: http://localhost:6333
+    collection_prefix: hermes_wiki
+  llm:
+    url: http://localhost:8011/v1
+    model: gpt-5.5
+```
+
+Do not put secrets in wiki pages. If an endpoint needs an API key, keep it in `.env` or your provider-specific config; do not commit it with the wiki.
+
+:::tip Local privacy profile
+For sensitive personal or company memory, point both embedding and chat URLs at local OpenAI-compatible services. Search indexing sends wiki/source text to the embedding endpoint, and `wiki_query` sends retrieved snippets plus your question to the configured chat endpoint. Local endpoints keep that loop on your machine.
+:::
+
+## Wiki layout
+
+A wiki is a folder with Markdown files:
+
+```text
+~/.hermes/wiki/personal/
+├── SCHEMA.md
+├── index.md
+├── log.md
+├── entities/
+├── concepts/
+├── comparisons/
+├── queries/
+└── raw/
+    ├── articles/
+    ├── papers/
+    └── transcripts/
+```
+
+Raw sources live under `raw/`. Generated or curated pages cite those sources with provenance markers such as:
+
+```markdown
+This fact came from a source. ^[raw/articles/example.md]
+```
+
+## Tools
+
+When enabled, the provider exposes these tools:
+
+| Tool | Purpose | Mutates durable memory? |
+| --- | --- | --- |
+| `wiki_status` | Show wiki path, page counts, collection stats, recent activity | No |
+| `wiki_orient` | Read orientation/index information | No |
+| `wiki_search` | Semantic search over indexed wiki chunks | No |
+| `wiki_read` | Read a wiki page by slug or relative path | No |
+| `wiki_query` | Ask an LLM-backed question against wiki context | No by default |
+| `wiki_lint` | Validate links, provenance, source hashes, vector health | No by default |
+| `wiki_ingest` | Ingest a curated source file | Dry-run by default; primary context only |
+| `wiki_reindex` | Rebuild vector index and index.md | Yes; gated |
+
+Safe defaults:
+
+- `wiki_query`: `file_result=false`, `log_query=false`
+- `wiki_lint`: `write_log=false`
+- `wiki_ingest`: `dry_run=true`; blocked outside the primary agent context because even dry-runs read local files and submit their content for analysis
+- `wiki_search.limit` is clamped to a small bounded range
+- `wiki_read` rejects path traversal and truncates oversized pages
+- `sync_turn()` is a no-op; chat turns are not automatically canonized
+- prefetch is bounded, cited, and retrieval-only
+- writes are blocked outside the primary agent context
+
+## Operational workflow
+
+1. Put a source document somewhere on disk.
+2. Ask Hermes to dry-run ingestion first:
+
+   ```text
+   Use wiki_ingest on /path/to/source.md with dry_run=true.
+   ```
+
+3. Review the proposed ingest.
+4. If it is safe and intentional, run the actual ingest from a primary Hermes session:
+
+   ```text
+   Ingest /path/to/source.md into LLM Wiki with dry_run=false.
+   ```
+
+5. Run lint and reindex when needed:
+
+   ```text
+   Run wiki_lint with write_log=false, then wiki_reindex if the index is stale.
+   ```
+
+6. Keep a small retrieval eval file for important recall expectations and run it after changes:
+
+   ```yaml
+   # ~/.hermes/wiki/personal/evals/retrieval.yaml
+   cases:
+     - query: How autonomous should Hermes be?
+       expected_pages:
+         - concepts/user-autonomy-operating-policy.md
+         - entities/hermes.md
+       top_k: 5
+   ```
+
+   ```bash
+   hermes-wiki-eval ~/.hermes/wiki/personal/evals/retrieval.yaml --config ~/.hermes/config.yaml --pretty
+   # or: python -m hermes_wiki.eval ...
+   ```
+
+   `--config` is authoritative when supplied: the file must exist and contain the intended `wiki:` settings; the runner will not silently fall back to another profile/config.
+
+   Retrieval evals are read-only. They validate that expected page paths appear in search results; they do not generate answers, write wiki pages, ingest sources, or reindex vectors. They still embed eval query text and read from the configured vector store, so use local/private endpoints for sensitive eval cases.
+
+7. Inspect retrieval hits for one query when evals fail or recall looks suspicious:
+
+   ```bash
+   hermes-wiki-introspect "How autonomous should Hermes be?" \
+     --config ~/.hermes/config.yaml \
+     --expected-page concepts/user-autonomy-operating-policy.md
+   hermes-wiki-introspect "What should Hermes call the user?" --config ~/.hermes/config.yaml --json
+   hermes-wiki-introspect "Qwen3-Embedding-8B" --config ~/.hermes/config.yaml --search-mode hybrid --json
+   ```
+
+   Retrieval introspection is read-only. It reports the original query, search mode, top-k, ranked chunk hits, scores, page/source paths, deduplicated page coverage, and missing expected pages. `--search-mode` can be `dense` (default/backward compatible), `sparse` (lexical payload matching for literal names, commands, config keys, and paths), or `hybrid` (dense+sparse Reciprocal Rank Fusion). It does not generate answers, write wiki pages, ingest sources, reindex vectors, log queries, or queue proposals. Like evals, dense/hybrid modes may embed the inspected query and read from the configured vector store; sparse mode scans indexed payload text.
+
+8. Draft proposed durable-memory updates without automatically ingesting them:
+
+   ```bash
+   hermes-wiki-propose \
+     --title "Remember a stable preference" \
+     --rationale "Prevents repeated correction" \
+     --change "Add the preference to the relevant source-backed page" \
+     --source "discord:<message-or-thread-id>" \
+     --target concepts/example.md
+   ```
+
+   By default this prints markdown only. Add `--queue --config ~/.hermes/config.yaml` to explicitly write a pending review artifact under `<wiki>/proposals/`. `--queue` requires `--config` and fails closed rather than falling back to an ambient/default wiki path. Queueing does not ingest, reindex, or mutate canonical wiki pages.
+
+9. Review queued proposal artifacts explicitly:
+
+   ```bash
+   hermes-wiki-proposals --config ~/.hermes/config.yaml list
+   hermes-wiki-proposals --config ~/.hermes/config.yaml show <slug>
+   hermes-wiki-proposals --config ~/.hermes/config.yaml accept <slug> --note "Applied through curated ingest"
+   hermes-wiki-proposals --config ~/.hermes/config.yaml reject <slug> --note "Not durable enough"
+   hermes-wiki-proposals --config ~/.hermes/config.yaml close <slug>
+   ```
+
+   The lifecycle command manages proposal review artifacts only. `accept`, `reject`, and `close` require explicit `--config` and update the proposal frontmatter status under `<wiki>/proposals/`; they do not edit canonical wiki pages, ingest sources, or reindex vectors. Accepting a proposal means the reviewed artifact has been accepted by a separate curated workflow, not that this command silently applied target-page edits.
+
+10. Generate a read-only maintenance report:
+
+   ```bash
+   hermes-wiki-maintenance --config ~/.hermes/config.yaml
+   hermes-wiki-maintenance --config ~/.hermes/config.yaml --json
+   ```
+
+   This checks broken wikilinks, orphan pages, pending proposals, and pages without source coverage. By default it only prints a report. `--write-report reports/maintenance.md` requires explicit `--config` and writes only under the dedicated `reports/` namespace; it does not ingest sources, reindex vectors, or mutate canonical entity/concept pages.
+
+11. Run the agent-native caretaker loop for cron/watchdog-style memory health:
+
+   ```bash
+   hermes-wiki-caretaker --config ~/.hermes/config.yaml
+   hermes-wiki-caretaker --config ~/.hermes/config.yaml --quiet
+   hermes-wiki-caretaker --config ~/.hermes/config.yaml --json
+   ```
+
+   The caretaker combines maintenance checks with retrieval evals from `<wiki>/evals/retrieval.yaml` when present, then classifies next actions for Hermes (`review_pending_proposal`, `repair_broken_link`, `fix_retrieval_regression`, etc.). It is read-first and agent-native: no ingest, no reindex, no canonical page mutation, no query logging, and no chat-model calls. `--quiet` prints nothing when there are no blockers, making it suitable for watchdog scripts that only alert on retrieval regressions or hard maintenance errors. `--write-report reports/caretaker.md` requires explicit `--config` and writes only under `reports/`.
+
+12. Draft proposal artifacts from caretaker findings:
+
+   ```bash
+   hermes-wiki-caretaker-propose --config ~/.hermes/config.yaml
+   hermes-wiki-caretaker-propose --config ~/.hermes/config.yaml --json
+   hermes-wiki-caretaker-propose --config ~/.hermes/config.yaml --queue --json
+   ```
+
+   The caretaker proposal orchestrator turns actionable caretaker findings into reviewable `MemoryProposal` drafts: broken-link repairs, graph-link strengthening, missing-source evidence work, and retrieval-regression fixes. It prints drafts by default. `--queue` requires explicit `--config` and writes only under `<wiki>/proposals/`; it still does not edit canonical pages, ingest sources, or reindex vectors.
+
+## Safety model
+
+LLM Wiki treats durable memory like a curated knowledge base, not a scratchpad.
+
+- No automatic writes from normal conversation flow.
+- No whole-wiki prompt dumps.
+- No path traversal in `wiki_read`.
+- Durable write tools are blocked in cron/subagent/batch/compression/retrieval contexts.
+- Ingest source categories are allowlisted before they become paths.
+- Reindexing upserts replacement vectors before deleting stale chunks, so embedding failures do not wipe existing search results.
+- Dense embedding calls use vector-core's persistent SQLite embedding cache and OpenAI-compatible embedding client. Hermes namespaces cache keys by model, embedding dimension, and text content hash; cache values are JSON-serialized and LRU-evicted by `wiki.embedding.cache_max_entries`.
+- Raw sources are hash-checked by lint so accidental drift is visible.
+- Markdown pages are human-readable and can be reviewed with normal Git tools.
+
+## Troubleshooting
+
+**Provider not available**
+
+Install the extra and restart Hermes:
+
+```bash
+pip install 'hermes-agent[llm-wiki]'
+```
+
+**Search fails**
+
+Check Qdrant and embedding endpoint health. The embedding URL should be OpenAI-compatible; Hermes normalizes a URL like `http://localhost:22222` to `http://localhost:22222/v1` internally.
+
+**Lint reports empty vector index**
+
+Run `wiki_reindex` from a primary agent context after confirming Qdrant and the embedding endpoint are available.
+
+**Writes are blocked**
+
+This is expected in cron, subagents, batch jobs, and retrieval-only contexts. Re-run the operation from a primary interactive agent session, or keep `dry_run=true` for inspection.

--- a/website/docs/user-guide/features/memory-providers.md
+++ b/website/docs/user-guide/features/memory-providers.md
@@ -1,12 +1,12 @@
 ---
 sidebar_position: 4
 title: "Memory Providers"
-description: "External memory provider plugins — Honcho, OpenViking, Mem0, Hindsight, Holographic, RetainDB, ByteRover, Supermemory"
+description: "External memory provider plugins — LLM Wiki, Honcho, OpenViking, Mem0, Hindsight, Holographic, RetainDB, ByteRover, Supermemory"
 ---
 
 # Memory Providers
 
-Hermes Agent ships with 8 external memory provider plugins that give the agent persistent, cross-session knowledge beyond the built-in MEMORY.md and USER.md. Only **one** external provider can be active at a time — the built-in memory is always active alongside it.
+Hermes Agent ships with external memory provider plugins that give the agent persistent, cross-session knowledge beyond the built-in MEMORY.md and USER.md. Only **one** external provider can be active at a time — the built-in memory is always active alongside it.
 
 ## Quick Start
 
@@ -22,7 +22,7 @@ Or set manually in `~/.hermes/config.yaml`:
 
 ```yaml
 memory:
-  provider: openviking   # or honcho, mem0, hindsight, holographic, retaindb, byterover, supermemory
+  provider: llm_wiki     # or honcho, openviking, mem0, hindsight, holographic, retaindb, byterover, supermemory
 ```
 
 ## How It Works
@@ -39,6 +39,58 @@ When a memory provider is active, Hermes automatically:
 The built-in memory (MEMORY.md / USER.md) continues to work exactly as before. The external provider is additive.
 
 ## Available Providers
+
+### LLM Wiki
+
+Local-first, source-backed durable memory stored as an inspectable Markdown wiki with semantic search. Unlike providers that automatically canonize every conversation turn, LLM Wiki is intentionally **read-first and curated**: it exposes bounded, cited retrieval and explicit ingestion tools while keeping raw session history, logs, and durable knowledge separate.
+
+| | |
+|---|---|
+| **Best for** | Inspectable long-term knowledge, architecture notes, policy, project memory, open-source/local-first setups |
+| **Requires** | `qdrant-client` extra, a Qdrant endpoint, and OpenAI-compatible embedding/LLM endpoints for search/query |
+| **Data storage** | Local Markdown wiki + Qdrant vector collection |
+| **Cost** | Free/local if using local endpoints; depends on configured embedding/LLM services |
+
+**Tools (8):** `wiki_status`, `wiki_orient`, `wiki_search`, `wiki_read`, `wiki_query`, `wiki_lint`, `wiki_ingest`, `wiki_reindex`
+
+**Runtime behavior:**
+
+- Adds only a tiny system-prompt note that wiki memory exists.
+- Uses bounded, cited prefetch instead of dumping the whole wiki into context.
+- `sync_turn()` is a no-op: conversations are not automatically converted into durable wiki facts.
+- `wiki_query` defaults to read-only (`file_result=false`, `log_query=false`).
+- `wiki_lint` defaults to non-mutating (`write_log=false`).
+- `wiki_ingest` defaults to `dry_run=true`.
+- Durable writes such as actual ingest/reindex are blocked outside the primary agent context, so cron jobs, subagents, batch jobs, and compression paths do not mutate canonical memory by accident.
+
+**Setup Wizard:**
+
+```bash
+hermes memory setup        # select "llm_wiki"
+```
+
+**Manual config:**
+
+```yaml
+memory:
+  provider: llm_wiki
+
+wiki:
+  path: ~/.hermes/wiki/personal
+  name: personal
+  embedding:
+    url: http://localhost:22222
+    model: Qwen3-Embedding-8B
+    dim: 4096
+  vector_store:
+    url: http://localhost:6333
+    collection_prefix: hermes_wiki
+  llm:
+    url: http://localhost:8011/v1
+    model: gpt-5.5
+```
+
+Use LLM Wiki when you want memory that can be inspected, edited, linted, backed up, and cited like documentation. See the dedicated [LLM Wiki Memory](./llm-wiki-memory) guide for setup, operations, and troubleshooting. Use session search for chronological recall of past conversations; use built-in MEMORY.md / USER.md for tiny boot-critical facts.
 
 ### Honcho
 

--- a/website/docs/user-guide/skills/optional/autonomous-ai-agents/autonomous-ai-agents-honcho.md
+++ b/website/docs/user-guide/skills/optional/autonomous-ai-agents/autonomous-ai-agents-honcho.md
@@ -196,7 +196,7 @@ If `dialecticDepthLevels` is omitted, rounds use **proportional levels** derived
 
 This keeps earlier passes cheap while using full depth on the final synthesis.
 
-**Depth at session start.** The session-start prewarm runs the full configured `dialecticDepth` in the background before turn 1. A single-pass prewarm on a cold peer often returns thin output — multi-pass depth runs the audit/reconcile cycle before the user ever speaks. Turn 1 consumes the prewarm result directly; if prewarm hasn't landed in time, turn 1 falls back to a synchronous call with a bounded timeout.
+**Depth at session start.** The session-start prewarm runs the full configured `dialecticDepth` in the background before turn 1. A single-pass prewarm on a cold peer often returns thin output — multi-pass depth runs the audit/reconcile cycle before the user ever speaks. Turn 1 consumes the prewarm result directly if it has landed; if prewarm hasn't landed in time, turn 1 queues an async recovery prefetch without imposing a Hermes-side timeout, and the result is picked up when it naturally completes.
 
 ### Level (how hard)
 

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -53,6 +53,7 @@ const sidebars: SidebarsConfig = {
             'user-guide/features/curator',
             'user-guide/features/memory',
             'user-guide/features/memory-providers',
+            'user-guide/features/llm-wiki-memory',
             'user-guide/features/context-files',
             'user-guide/features/context-references',
             'user-guide/features/personality',


### PR DESCRIPTION
## Summary
- Adds the `llm_wiki` memory provider and `hermes_wiki` package for source-backed durable memory.
- Adds read-first wiki tools, bounded prefetch, safe proposal/maintenance/caretaker CLIs, retrieval evals, retrieval introspection, hybrid sparse+dense search, and vector-core backed embedding/cache integration.
- Propagates `agent_context` into memory providers so cron/subagent contexts can be read-only/write-gated, and hardens Honcho auto-injected context filtering.
- Documents LLM Wiki setup/operations and wires package data, console scripts, and lazy dependencies.

## Safety / Privacy
- LLM Wiki `sync_turn()` is a no-op; normal conversation turns are not automatically canonicalized into durable wiki memory.
- Mutating wiki operations are gated to primary context; cron/subagent contexts do not perform durable writes.
- `wiki_query`, `wiki_lint`, and `wiki_ingest` default to non-mutating/read-first behavior.
- Read-only WikiSearch disables the persistent embedding cache to avoid incidental filesystem writes.
- Lazy dependency Git URL handling remains allowlist-only and only accepts the vetted commit-pinned `vector-core` URL.
- Public-diff hygiene reviewed: no secrets, private local paths, Discord IDs, or personal-name fixture slugs intentionally included.

## Test Plan
- `python -m pytest -o addopts='' -q tests/agent/test_memory_provider.py tests/tools/test_lazy_deps.py tests/plugins/memory/test_llm_wiki_provider.py tests/plugins/memory/test_llm_wiki_proposals.py tests/plugins/memory/test_llm_wiki_maintenance.py tests/plugins/memory/test_llm_wiki_caretaker.py tests/plugins/memory/test_llm_wiki_proposal_lifecycle.py tests/plugins/memory/test_llm_wiki_caretaker_orchestrator.py tests/plugins/memory/test_llm_wiki_retrieval_introspection.py tests/plugins/memory/test_llm_wiki_hybrid_search.py tests/plugins/memory/test_llm_wiki_embedding_cache.py` — 265 passed
- `ruff check agent/agent_init.py cron/scheduler.py plugins/memory/honcho/__init__.py run_agent.py tools/delegate_tool.py tools/lazy_deps.py hermes_wiki plugins/memory/llm_wiki tests/agent/test_memory_provider.py tests/tools/test_lazy_deps.py tests/plugins/memory/test_llm_wiki_*.py`
- `git diff --check`
- `uv lock --check`
- Live caretaker dogfood: `python -m hermes_wiki.caretaker --config ~/.hermes/config.yaml --json` — blockers false, retrieval eval failures 0/5
- Independent no-write code review subagent passed after privacy/read-only fixes

## Notes
- `vector-core` is pinned to public commit `551056769b66d35c56dbc48475785fbb646afbef` until it has a normal release channel.
