### PR TITLE
fix(dashboard): bridge browser context-menu copy to xterm selection

### DIFF
--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -427,6 +427,20 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
 
     term.open(host);
 
+    // Bridge browser context-menu copy to xterm's selection.  When the user
+    // right-clicks and picks "Copy" from the browser menu, xterm.js fires a
+    // DOM copy event on the terminal host.  Without this listener, the
+    // browser copies whatever is selected in the DOM (usually nothing) rather
+    // than the text xterm has selected internally.
+    const onCopy = (ev: ClipboardEvent) => {
+      const sel = term.getSelection();
+      if (sel) {
+        ev.clipboardData?.setData("text/plain", sel);
+        ev.preventDefault();
+      }
+    };
+    host.addEventListener("copy", onCopy);
+
     // WebGL draws from a texture atlas sized with device pixels. On phones and
     // in DevTools device mode that often produces *visually* much larger cells
     // than `fontSize` suggests — users see "huge" text even at 7–9px settings.


### PR DESCRIPTION
When users right-click and pick 'Copy' from the browser context menu in the Dashboard Chat, xterm's internal selection was not bridged to the system clipboard. The keyboard shortcuts (Ctrl+C/Cmd+C) worked fine, but the browser context menu path copied random DOM content instead of the selected terminal text.

Adds a DOM 'copy' event listener on the xterm host element that reads `term.getSelection()` and writes it to `event.clipboardData`, matching the behavior of gnome-terminal and Windows Terminal.

Closes #30007