### PR TITLE
fix(computer_use): consult config.yaml supports_vision override in capture routing

### DIFF
--- a/tools/computer_use/vision_routing.py
+++ b/tools/computer_use/vision_routing.py
@@ -76,8 +76,26 @@ def _explicit_aux_vision_override(cfg: Optional[Dict[str, Any]]) -> bool:
     return True
 
 
-def _lookup_supports_vision(provider: str, model: str) -> Optional[bool]:
-    """Return models.dev ``supports_vision`` for *(provider, model)* or None."""
+def _lookup_supports_vision(
+    provider: str,
+    model: str,
+    cfg: Optional[Dict[str, Any]] = None,
+) -> Optional[bool]:
+    """Return ``supports_vision`` for *(provider, model)* or None.
+
+    Checks the user's config.yaml override first (parity with
+    ``agent.image_routing._lookup_supports_vision``), then falls back to
+    models.dev metadata.
+    """
+    try:
+        from agent.image_routing import _supports_vision_override
+        override = _supports_vision_override(cfg, provider, model)
+        if override is not None:
+            return override
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.debug(
+            "computer_use vision_routing: config override lookup failed: %s", exc
+        )
     if not provider or not model:
         return None
     try:
@@ -141,7 +159,7 @@ def should_route_capture_to_aux_vision(
     if accepts_tool_image is None or accepts_tool_image is False:
         return True
 
-    supports_vision = _lookup_supports_vision(provider, model)
+    supports_vision = _lookup_supports_vision(provider, model, cfg)
     if supports_vision is True:
         return False
     return True


### PR DESCRIPTION
## Problem

`vision_routing._lookup_supports_vision` (added in #30126) only queries
models.dev metadata. It misses the user's `supports_vision` config.yaml
override that `agent.image_routing._lookup_supports_vision` has checked
since #29679.

A user with a custom or local vision-capable model not in models.dev
(e.g. `providers.my-vllm.models.my-model.supports_vision: true`) will
have captures routed through `auxiliary.vision` even when their main
model handles images natively — an unnecessary extra LLM call and the
wrong routing decision.

## Fix

Add a `cfg` parameter to `_lookup_supports_vision` and call
`image_routing._supports_vision_override(cfg, provider, model)` before
falling through to models.dev — symmetric with the sibling function.

`should_route_capture_to_aux_vision` already receives `cfg`; it now
passes it through to `_lookup_supports_vision`.

## Behaviour

- No change for models already in models.dev.
- No change when `cfg` is None (default).
- Custom/local models with `supports_vision: true` in config.yaml now
  keep the multimodal path instead of being incorrectly routed to aux.

## Checklist

- [x] Parity fix — symmetric with `agent.image_routing._lookup_supports_vision`
- [x] No behaviour change for existing configs
- [x] 1 file, bounded scope