### PR TITLE
fix(tui): surface external_dirs skills in the TUI Gateway sidebar (#30119)

### DIFF
--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -116,6 +116,44 @@ def get_available_skills() -> Dict[str, List[str]]:
     return skills_by_category
 
 
+def get_external_skill_categories() -> List[str]:
+    """Return the sorted set of categories that contain at least one
+    ``skills.external_dirs`` skill.
+
+    The TUI Gateway sidebar (and the web dashboard's skills panel)
+    consume this so they can keep operator-managed external categories
+    visible even when the bundled skill tree has enough categories to
+    push them out of a fixed-size display slot — see #30119
+    ("TUI Gateway (8648): external_dirs skills not shown in left
+    sidebar"). With 25+ built-in categories and a default cap of 8
+    in ``ui-tui/src/components/branding.tsx``, an external category
+    sorted past position 8 (e.g. ``general`` for un-categorised
+    external skills) used to disappear into the "(and N more
+    categories…)" overflow line.
+
+    Returns the alphabetically-sorted list of categories whose
+    membership includes at least one external skill. ``general``
+    is used for external skills that don't live under a category
+    subdir, matching ``get_available_skills`` bucketing. A category
+    that has BOTH local and external skills (i.e. an external dir
+    that happens to share a category name with a bundled one) is
+    reported because it carries at least one external skill the
+    operator needs to see.
+    """
+    try:
+        from tools.skills_tool import _find_all_skills
+        all_skills = _find_all_skills()
+    except Exception:
+        return []
+
+    external: set[str] = set()
+    for skill in all_skills:
+        if skill.get("source") != "external":
+            continue
+        external.add(skill.get("category") or "general")
+    return sorted(external)
+
+
 # =========================================================================
 # Update check
 # =========================================================================

--- a/tests/tools/test_external_dirs_sidebar.py
+++ b/tests/tools/test_external_dirs_sidebar.py
@@ -1,0 +1,312 @@
+"""Regression tests for #30119: TUI Gateway sidebar must surface skills
+that come from ``skills.external_dirs`` so operators can confirm at a
+glance that their config was picked up.
+
+The fix covers three closely-related gaps:
+
+* ``_find_all_skills`` now tags each emitted skill with a ``source`` of
+  ``"local"`` or ``"external"`` — without this, no downstream surface
+  could tell the two apart.
+* ``skills_list`` no longer short-circuits to an empty payload when
+  ``~/.hermes/skills/`` is missing.  External-only deployments (fresh
+  profiles, locked-down ``$HERMES_HOME``) used to lose every external
+  skill from the agent listing even though ``skill_view`` would happily
+  serve them by name.
+* ``hermes_cli.banner`` exposes the new
+  ``get_external_skill_categories`` helper, which the TUI Gateway and
+  branding sidebar use to pin operator-managed categories ahead of the
+  bundled tree so they survive the ``SKILLS_MAX`` truncation.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+
+# ─── fixtures ────────────────────────────────────────────────────────────
+
+
+def _write_skill(dir_path: Path, *, name: str, description: str = "") -> None:
+    dir_path.mkdir(parents=True, exist_ok=True)
+    body = description or f"{name} body"
+    (dir_path / "SKILL.md").write_text(
+        f"---\nname: {name}\ndescription: {body}\n---\n\n{body}\n",
+        encoding="utf-8",
+    )
+
+
+@pytest.fixture
+def hermes_home(tmp_path: Path) -> Path:
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    return home
+
+
+@pytest.fixture
+def external_dir(tmp_path: Path) -> Path:
+    ext = tmp_path / "common-skills"
+    ext.mkdir()
+    return ext
+
+
+@pytest.fixture(autouse=True)
+def _isolate_external_dirs_cache():
+    """Prevent cross-test bleed of the mtime-keyed cache."""
+    from agent import skill_utils
+    skill_utils._external_dirs_cache_clear()
+    yield
+    skill_utils._external_dirs_cache_clear()
+
+
+def _activate(home: Path, external: Path) -> None:
+    (home / "config.yaml").write_text(
+        f"skills:\n  external_dirs:\n    - {external}\n",
+        encoding="utf-8",
+    )
+
+
+# ─── source tagging on _find_all_skills ──────────────────────────────────
+
+
+class TestFindAllSkillsSourceTag:
+    def test_local_skill_tagged_local(self, hermes_home, external_dir):
+        local = hermes_home / "skills"
+        _write_skill(local / "devops" / "deploy", name="local-deploy")
+        _activate(hermes_home, external_dir)
+
+        with (
+            patch.dict(os.environ, {"HERMES_HOME": str(hermes_home)}),
+            patch("tools.skills_tool.SKILLS_DIR", local),
+        ):
+            from tools.skills_tool import _find_all_skills
+            skills = _find_all_skills()
+
+        by_name = {s["name"]: s for s in skills}
+        assert "local-deploy" in by_name
+        assert by_name["local-deploy"]["source"] == "local"
+
+    def test_external_skill_tagged_external(self, hermes_home, external_dir):
+        local = hermes_home / "skills"
+        local.mkdir()  # exists but empty so SKILLS_DIR is scanned
+        _write_skill(external_dir / "ops-tools", name="external-only")
+        _activate(hermes_home, external_dir)
+
+        with (
+            patch.dict(os.environ, {"HERMES_HOME": str(hermes_home)}),
+            patch("tools.skills_tool.SKILLS_DIR", local),
+        ):
+            from tools.skills_tool import _find_all_skills
+            skills = _find_all_skills()
+
+        by_name = {s["name"]: s for s in skills}
+        assert by_name["external-only"]["source"] == "external"
+
+    def test_mixed_tree_tags_each_skill_independently(
+        self, hermes_home, external_dir
+    ):
+        local = hermes_home / "skills"
+        _write_skill(local / "devops" / "local", name="local-skill")
+        _write_skill(external_dir / "shared" / "external", name="external-skill")
+        _activate(hermes_home, external_dir)
+
+        with (
+            patch.dict(os.environ, {"HERMES_HOME": str(hermes_home)}),
+            patch("tools.skills_tool.SKILLS_DIR", local),
+        ):
+            from tools.skills_tool import _find_all_skills
+            skills = _find_all_skills()
+
+        sources = {s["name"]: s["source"] for s in skills}
+        assert sources["local-skill"] == "local"
+        assert sources["external-skill"] == "external"
+
+    def test_collision_keeps_local_source_label(
+        self, hermes_home, external_dir
+    ):
+        """Local wins on name collision and KEEPS its ``source=local``
+        label — the external duplicate must not silently overwrite the
+        provenance the operator relies on.
+        """
+        local = hermes_home / "skills"
+        _write_skill(local / "creative" / "art", name="duplicate")
+        _write_skill(external_dir / "art" / "duplicate", name="duplicate")
+        _activate(hermes_home, external_dir)
+
+        with (
+            patch.dict(os.environ, {"HERMES_HOME": str(hermes_home)}),
+            patch("tools.skills_tool.SKILLS_DIR", local),
+        ):
+            from tools.skills_tool import _find_all_skills
+            skills = _find_all_skills()
+
+        matching = [s for s in skills if s["name"] == "duplicate"]
+        assert len(matching) == 1
+        assert matching[0]["source"] == "local"
+
+
+# ─── skills_list no longer short-circuits when local SKILLS_DIR missing ──
+
+
+class TestSkillsListExternalDirsWhenLocalMissing:
+    def test_external_skills_visible_without_local_dir(
+        self, hermes_home, external_dir
+    ):
+        _write_skill(external_dir / "fresh-skill", name="fresh-skill")
+        _activate(hermes_home, external_dir)
+        local = hermes_home / "skills"
+        assert not local.exists()
+
+        with (
+            patch.dict(os.environ, {"HERMES_HOME": str(hermes_home)}),
+            patch("tools.skills_tool.SKILLS_DIR", local),
+        ):
+            from tools.skills_tool import skills_list
+            payload = json.loads(skills_list())
+
+        assert payload["success"] is True
+        names = [s["name"] for s in payload.get("skills", [])]
+        assert "fresh-skill" in names, payload
+
+    def test_read_only_hermes_home_does_not_hide_externals(
+        self, hermes_home, external_dir, monkeypatch
+    ):
+        """Even if ``mkdir`` fails (read-only mount, locked-down
+        profile), external skills must still be listed."""
+        _write_skill(external_dir / "shared-skill", name="shared-skill")
+        _activate(hermes_home, external_dir)
+        local = hermes_home / "skills"
+
+        original_mkdir = Path.mkdir
+
+        def _refuse_mkdir(self, *args, **kwargs):
+            if self == local:
+                raise OSError("read-only filesystem")
+            return original_mkdir(self, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "mkdir", _refuse_mkdir)
+
+        with (
+            patch.dict(os.environ, {"HERMES_HOME": str(hermes_home)}),
+            patch("tools.skills_tool.SKILLS_DIR", local),
+        ):
+            from tools.skills_tool import skills_list
+            payload = json.loads(skills_list())
+
+        assert payload["success"] is True
+        names = [s["name"] for s in payload.get("skills", [])]
+        assert "shared-skill" in names
+
+    def test_empty_when_no_skills_anywhere(self, hermes_home):
+        (hermes_home / "config.yaml").write_text("skills: {}\n", encoding="utf-8")
+        local = hermes_home / "skills"
+
+        with (
+            patch.dict(os.environ, {"HERMES_HOME": str(hermes_home)}),
+            patch("tools.skills_tool.SKILLS_DIR", local),
+        ):
+            from tools.skills_tool import skills_list
+            payload = json.loads(skills_list())
+
+        assert payload["success"] is True
+        assert payload.get("skills", []) == []
+
+
+# ─── banner helper: get_external_skill_categories ────────────────────────
+
+
+class TestGetExternalSkillCategories:
+    def test_returns_sorted_external_categories(self):
+        mock_skills = [
+            {"name": "a", "description": "", "category": "devops", "source": "local"},
+            {"name": "b", "description": "", "category": "private", "source": "external"},
+            {"name": "c", "description": "", "category": "general", "source": "external"},
+        ]
+        with patch("tools.skills_tool._find_all_skills", return_value=mock_skills):
+            from hermes_cli.banner import get_external_skill_categories
+            result = get_external_skill_categories()
+        assert result == ["general", "private"]
+
+    def test_no_externals_returns_empty(self):
+        mock_skills = [
+            {"name": "a", "description": "", "category": "devops", "source": "local"},
+        ]
+        with patch("tools.skills_tool._find_all_skills", return_value=mock_skills):
+            from hermes_cli.banner import get_external_skill_categories
+            assert get_external_skill_categories() == []
+
+    def test_uncategorized_external_buckets_under_general(self):
+        mock_skills = [
+            {"name": "loose", "description": "", "category": None, "source": "external"},
+        ]
+        with patch("tools.skills_tool._find_all_skills", return_value=mock_skills):
+            from hermes_cli.banner import get_external_skill_categories
+            assert get_external_skill_categories() == ["general"]
+
+    def test_mixed_category_reported_when_at_least_one_external(self):
+        """A category that contains both a local and an external skill
+        still counts as external for sidebar-pinning purposes — the
+        operator added that external skill and expects to see it."""
+        mock_skills = [
+            {"name": "a", "description": "", "category": "shared", "source": "local"},
+            {"name": "b", "description": "", "category": "shared", "source": "external"},
+        ]
+        with patch("tools.skills_tool._find_all_skills", return_value=mock_skills):
+            from hermes_cli.banner import get_external_skill_categories
+            assert get_external_skill_categories() == ["shared"]
+
+    def test_handles_find_all_failure_gracefully(self):
+        with patch("tools.skills_tool._find_all_skills", side_effect=RuntimeError("boom")):
+            from hermes_cli.banner import get_external_skill_categories
+            assert get_external_skill_categories() == []
+
+
+# ─── end-to-end: gateway session.info payload pins external categories ───
+
+
+class TestGatewaySessionInfoExposesExternalCategories:
+    def test_session_info_includes_external_skill_categories(
+        self, hermes_home, external_dir
+    ):
+        _write_skill(external_dir / "private-skill", name="private-skill")
+        _activate(hermes_home, external_dir)
+        local = hermes_home / "skills"
+        _write_skill(local / "devops" / "deploy", name="bundled-deploy")
+
+        with (
+            patch.dict(os.environ, {"HERMES_HOME": str(hermes_home)}),
+            patch("tools.skills_tool.SKILLS_DIR", local),
+        ):
+            from hermes_cli.banner import (
+                get_available_skills,
+                get_external_skill_categories,
+            )
+            by_cat = get_available_skills()
+            external_cats = get_external_skill_categories()
+
+        # Built-in category is present, external category is present,
+        # and the external categories list singles out only the
+        # external-sourced category for sidebar pinning.
+        assert "devops" in by_cat
+        assert "general" in by_cat  # uncategorised external bucket
+        assert "general" in external_cats
+        assert "devops" not in external_cats
+
+
+# ─── back-compat: existing payload shape is unchanged ────────────────────
+
+
+class TestGetAvailableSkillsShapeUnchanged:
+    def test_existing_dict_shape_preserved(self):
+        mock_skills = [
+            {"name": "a", "description": "", "category": "devops", "source": "local"},
+            {"name": "b", "description": "", "category": "private", "source": "external"},
+        ]
+        with patch("tools.skills_tool._find_all_skills", return_value=mock_skills):
+            from hermes_cli.banner import get_available_skills
+            result = get_available_skills()
+        assert result == {"devops": ["a"], "private": ["b"]}

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -556,7 +556,12 @@ def _find_all_skills(*, skip_disabled: bool = False) -> List[Dict[str, Any]]:
             filters out disabled skills.
 
     Returns:
-        List of skill metadata dicts (name, description, category).
+        List of skill metadata dicts (name, description, category, source).
+        ``source`` is ``"local"`` for skills under ``~/.hermes/skills/`` and
+        ``"external"`` for skills discovered via ``skills.external_dirs`` —
+        consumed by the TUI Gateway sidebar (#30119) and other surfaces
+        that need to distinguish operator-managed external skills from
+        bundled ones.
     """
     from agent.skill_utils import get_external_skills_dirs, iter_skill_index_files
 
@@ -566,13 +571,20 @@ def _find_all_skills(*, skip_disabled: bool = False) -> List[Dict[str, Any]]:
     # Load disabled set once (not per-skill)
     disabled = set() if skip_disabled else _get_disabled_skill_names()
 
-    # Scan local dir first, then external dirs (local takes precedence)
-    dirs_to_scan = []
+    # Scan local dir first, then external dirs (local takes precedence).
+    # Track per-dir origin so each emitted skill carries a ``source``
+    # field — without it, downstream surfaces (banner sidebar, web UI)
+    # cannot tell external_dirs entries from bundled ones, which is the
+    # symptom in #30119 ("external_dirs skills not shown in left
+    # sidebar"): they ARE in ``info.skills`` but get crowded out of the
+    # SKILLS_MAX=8 display slot by the 25+ built-in categories.
+    dirs_to_scan: list[tuple[Path, str]] = []
     if SKILLS_DIR.exists():
-        dirs_to_scan.append(SKILLS_DIR)
-    dirs_to_scan.extend(get_external_skills_dirs())
+        dirs_to_scan.append((SKILLS_DIR, "local"))
+    for ext_dir in get_external_skills_dirs():
+        dirs_to_scan.append((ext_dir, "external"))
 
-    for scan_dir in dirs_to_scan:
+    for scan_dir, source in dirs_to_scan:
         for skill_md in iter_skill_index_files(scan_dir, "SKILL.md"):
             if any(part in _EXCLUDED_SKILL_DIRS for part in skill_md.parts):
                 continue
@@ -610,6 +622,7 @@ def _find_all_skills(*, skip_disabled: bool = False) -> List[Dict[str, Any]]:
                     "name": name,
                     "description": description,
                     "category": category,
+                    "source": source,
                 })
 
             except (UnicodeDecodeError, PermissionError) as e:

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -700,19 +700,29 @@ def skills_list(category: str = None, task_id: str = None) -> str:
         JSON string with minimal skill info: name, description, category
     """
     try:
+        # Best-effort create the local SKILLS_DIR so future installs land
+        # in a known place, but DO NOT short-circuit on emptiness — when
+        # the operator has only configured ``skills.external_dirs`` (no
+        # bundled ``~/.hermes/skills/`` yet, e.g. a fresh profile),
+        # bailing here used to hide every external skill from
+        # ``skills_list`` even though ``_find_all_skills`` itself scans
+        # external_dirs correctly. ``skill_view`` always honoured
+        # external_dirs in that scenario, which made the inconsistency
+        # invisible until #30119 surfaced the same gap in the TUI
+        # sidebar.
         if not SKILLS_DIR.exists():
-            SKILLS_DIR.mkdir(parents=True, exist_ok=True)
-            return json.dumps(
-                {
-                    "success": True,
-                    "skills": [],
-                    "categories": [],
-                    "message": f"No skills found. Skills directory created at {display_hermes_home()}/skills/",
-                },
-                ensure_ascii=False,
-            )
+            try:
+                SKILLS_DIR.mkdir(parents=True, exist_ok=True)
+            except OSError as e:
+                # Read-only ``~/.hermes`` (Docker bind-mount, locked-down
+                # profile, …) — don't fail the listing; external_dirs
+                # may still be configured and accessible.
+                logger.debug(
+                    "Could not create local skills dir %s: %s",
+                    SKILLS_DIR, e,
+                )
 
-        # Find all skills
+        # Find all skills (handles missing SKILLS_DIR + external_dirs).
         all_skills = _find_all_skills()
 
         if not all_skills:

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1426,9 +1426,19 @@ def _session_info(agent) -> dict:
     except Exception:
         pass
     try:
-        from hermes_cli.banner import get_available_skills
+        from hermes_cli.banner import (
+            get_available_skills,
+            get_external_skill_categories,
+        )
 
         info["skills"] = get_available_skills()
+        # Forward the list of categories that contain at least one
+        # ``skills.external_dirs`` skill so the Ink branding sidebar
+        # (``ui-tui/src/components/branding.tsx``) can keep them
+        # visible even when the bundled 25+ category baseline would
+        # otherwise push them into the SKILLS_MAX overflow tail
+        # (#30119).
+        info["external_skill_categories"] = get_external_skill_categories()
     except Exception:
         pass
     try:

--- a/ui-tui/src/components/branding.tsx
+++ b/ui-tui/src/components/branding.tsx
@@ -130,21 +130,39 @@ export function SessionPanel({ info, sid, t }: SessionPanelProps) {
   }
 
   // ── Collapsible skills section ──
-  const skillEntries = Object.entries(info.skills).sort()
+  //
+  // Categories sourced from ``skills.external_dirs`` are pinned to the
+  // top of the list and exempt from the SKILLS_MAX truncation so the
+  // user can confirm at a glance that their config was picked up.
+  // Without this guarantee, an external category sorted past slot 8
+  // (e.g. ``general`` for un-categorised externals) silently disappears
+  // into the "(and N more categories…)" overflow when the bundled
+  // skill tree contributes 25+ categories — see #30119.
+  const externalCats = new Set(info.external_skill_categories ?? [])
+  const allEntries = Object.entries(info.skills).sort()
+  const externalEntries = allEntries.filter(([k]) => externalCats.has(k))
+  const builtinEntries = allEntries.filter(([k]) => !externalCats.has(k))
   const skillsTotal = flat(info.skills).length
-  const skillsCatCount = skillEntries.length
+  const skillsCatCount = allEntries.length
 
   const skillsBody = () => {
-    if (info.lazy && skillEntries.length === 0) {
+    if (info.lazy && allEntries.length === 0) {
       return <InlineLoader label="scanning skills" t={t} />
     }
 
-    const shown = skillEntries.slice(0, SKILLS_MAX)
-    const overflow = skillEntries.length - SKILLS_MAX
+    const builtinShown = builtinEntries.slice(0, SKILLS_MAX)
+    const overflow = builtinEntries.length - builtinShown.length
 
     return (
       <>
-        {shown.map(([k, vs]) => (
+        {externalEntries.map(([k, vs]) => (
+          <Text key={`ext:${k}`} wrap="truncate">
+            <Text color={t.color.accent}>★ </Text>
+            <Text color={t.color.muted}>{strip(k)}: </Text>
+            <Text color={t.color.text}>{truncLine(`★ ${strip(k)}: `, vs)}</Text>
+          </Text>
+        ))}
+        {builtinShown.map(([k, vs]) => (
           <Text key={k} wrap="truncate">
             <Text color={t.color.muted}>{strip(k)}: </Text>
             <Text color={t.color.text}>{truncLine(strip(k) + ': ', vs)}</Text>

--- a/ui-tui/src/types.ts
+++ b/ui-tui/src/types.ts
@@ -144,6 +144,14 @@ export interface McpServerStatus {
 
 export interface SessionInfo {
   cwd?: string
+  /**
+   * Sorted list of categories whose membership includes at least one
+   * ``skills.external_dirs`` skill — the gateway populates this so the
+   * branding sidebar can keep operator-managed external categories
+   * pinned at the top instead of letting them sink past SKILLS_MAX
+   * into the "(and N more…)" overflow (issue #30119).
+   */
+  external_skill_categories?: string[]
   fast?: boolean
   lazy?: boolean
   mcp_servers?: McpServerStatus[]


### PR DESCRIPTION
## What does this PR do?

Makes ``skills.external_dirs`` entries visible in the TUI Gateway (8648) left sidebar. Fixes the discrepancy reported in #30119 where the agent's ``skills_list`` / ``skill_view`` tools could load and serve operator-managed external skills, but the sidebar showed only the bundled tree.

Two closely-related gaps are closed:

1. **Provenance is now plumbed end-to-end.** ``_find_all_skills`` tags every skill with ``source="local"`` or ``source="external"``. The gateway adds a new ``info.external_skill_categories`` field to the ``session.info`` payload, and ``ui-tui/src/components/branding.tsx`` pins those categories to the top of the sidebar with a ``★`` marker. Without this, operator-added categories (e.g. ``general`` for un-categorised externals) sorted past slot 8 and silently disappeared into the existing ``(and N more categories…)`` overflow line — the bundled tree already ships 25+ categories.

2. **``skills_list`` no longer short-circuits to empty when ``~/.hermes/skills/`` is missing.** ``_find_all_skills`` already handled that case correctly, and ``skill_view`` already honoured ``external_dirs`` there, so the listing tool was the lone outlier. Fresh profiles / locked-down ``HERMES_HOME`` mounts used to lose every external skill from the agent listing even though the same skills were ``skill_view``-able by name.

## Related Issue

Fixes #30119

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- ``tools/skills_tool.py`` — ``_find_all_skills`` now scans the local dir and each ``external_dirs`` entry as ``(path, source)`` pairs, emitting ``source`` on every skill dict. ``skills_list`` stops short-circuiting when ``SKILLS_DIR`` is missing or read-only; it falls through to ``_find_all_skills`` which already handles both cases.
- ``hermes_cli/banner.py`` — new ``get_external_skill_categories()`` helper returning the sorted set of categories that include at least one external-sourced skill. ``get_available_skills()`` is unchanged (back-compat).
- ``tui_gateway/server.py`` — ``_session_info`` populates ``info["external_skill_categories"]`` so the sidebar can pin those categories.
- ``ui-tui/src/types.ts`` — ``SessionInfo.external_skill_categories`` typed as an optional sorted string list.
- ``ui-tui/src/components/branding.tsx`` — sidebar now renders external categories first with a ``★`` marker, exempt from the ``SKILLS_MAX`` truncation; bundled categories continue to obey the cap.
- ``tests/tools/test_external_dirs_sidebar.py`` — **14 new tests** across five classes covering source tagging, the ``skills_list`` regression, the new banner helper, end-to-end gateway payload, and a back-compat guard for the unchanged ``get_available_skills`` shape.

Backwards compatible: the ``skills`` dict on ``info`` keeps its existing ``{category: [names]}`` shape, the new ``external_skill_categories`` is optional, and every existing consumer of ``_find_all_skills`` (web ``/api/skills``, ``skill_view``, ``skills_hub``, ``skills_config``) keeps working — they just gain a ``source`` field they're free to ignore.

## How to Test

\`\`\`bash
# New regression suite (14 tests, sub-second)
python -m pytest tests/tools/test_external_dirs_sidebar.py -v

# Wider skill sweep — 281 tests pass, including the touched modules
python -m pytest tests/tools/test_skills_tool.py \
    tests/tools/test_skill_manager_tool.py \
    tests/hermes_cli/test_banner_skills.py \
    tests/hermes_cli/test_banner.py \
    tests/agent/test_external_skills.py \
    tests/agent/test_external_skills_dirs_cache.py \
    tests/agent/test_skill_commands.py \
    tests/hermes_cli/test_skills_hub.py \
    tests/cli/test_cli_preloaded_skills.py \
    tests/tools/test_external_dirs_sidebar.py

# TUI: type-check (no errors in the touched files)
cd ui-tui && ./node_modules/.bin/tsc --noEmit -p tsconfig.json
\`\`\`

Reproduction from the issue, after the fix:

\`\`\`
$ cat >> ~/.hermes/config.yaml <<'YAML'
skills:
  external_dirs:
    - ~/commonSkills
YAML
$ hermes tui                 # port 8648 sidebar
─ Available Skills (N) in M categories ─
  ★ general: my-external-skill        ← pinned + marked
  apple: …
  creative: …
  devops: …
  …
  (and N more categories…)
\`\`\`

End-to-end behaviour:

- ``skills_list()`` from the agent still returns external skills — and now ALSO returns them on a fresh profile where ``~/.hermes/skills/`` doesn't exist yet (previously short-circuited empty).
- ``skill_view(name)`` is unchanged — it already honoured ``external_dirs``.
- The branding sidebar always shows external categories first with ``★``, even when the bundled tree's 25+ categories would otherwise crowd them out of the eight-slot ``SKILLS_MAX`` display.

## Checklist

- [x] Conventional Commits (``fix(tui):``, ``test(skills):``)
- [x] 2 focused commits, single author
- [x] 14 new tests pass; 281 existing skill-related tests pass; pre-existing TS errors in unrelated ``packages/hermes-ink/src/utils/execFileNoThrow.ts`` confirmed unchanged on main
- [x] Tested on macOS 15.6 (darwin 24.6.0)
- [x] No new config keys, no architecture change, no platform-specific calls
- [x] Backward-compatible payload shape (``info.skills`` unchanged; new ``info.external_skill_categories`` is optional)