### PR TITLE
fix(env_loader): correct Bitwarden override_existing default to True

### DIFF
--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -203,7 +203,7 @@ def _apply_external_secret_sources(home_path: Path) -> None:
         enabled=True,
         access_token_env=bw_cfg.get("access_token_env", "BWS_ACCESS_TOKEN"),
         project_id=bw_cfg.get("project_id", ""),
-        override_existing=bool(bw_cfg.get("override_existing", False)),
+        override_existing=bool(bw_cfg.get("override_existing", True)),
         cache_ttl_seconds=float(bw_cfg.get("cache_ttl_seconds", 300)),
         auto_install=bool(bw_cfg.get("auto_install", True)),
     )


### PR DESCRIPTION
## Problem

`_apply_external_secret_sources()` in `hermes_cli/env_loader.py` calls
`apply_bitwarden_secrets()` with `override_existing` falling back to
`False` when the key is absent from `config.yaml`:

```python
# env_loader.py:206 — BEFORE
override_existing=bool(bw_cfg.get("override_existing", False)),
```

But both authoritative sources specify `True` as the intended default:

- **Config template** (`hermes_cli/config.py:1773`):
  ```python
  "override_existing": True,  # default True because the point of using BSM is centralized rotation
  ```
- **Setup wizard** (`hermes_cli/secrets_cli.py:226`):
  ```python
  secrets_cfg.setdefault("override_existing", True)
  ```

## Impact

Users who enable Bitwarden Secrets Manager by manually editing
`config.yaml` (without running `hermes setup`) get `override_existing=False`
silently. This means rotated secrets fetched from BSM are ignored if the
old value is already present in `os.environ` (loaded earlier from `.env`
or a shell export). The whole point of BSM integration — centralized key
rotation — stops working without any error or warning.

## Fix

Change the `.get()` fallback from `False` to `True`:

```python
# env_loader.py:206 — AFTER
override_existing=bool(bw_cfg.get("override_existing", True)),
```

No behavior change for users who ran the wizard or who set
`override_existing` explicitly in `config.yaml`.

## Checklist

- [x] 1-line change, no refactor
- [x] Symmetric with config template and wizard defaults
- [x] No behavior change for explicit configs
- [x] No new dependencies