### PR TITLE
feat(tools): add reference_images support to image generation tool

### DIFF
--- a/agent/transports/hermes_tools_mcp_server.py
+++ b/agent/transports/hermes_tools_mcp_server.py
@@ -50,6 +50,59 @@ import os
 import sys
 from typing import Any, Optional
 
+
+def _normalize_tool_kwargs(kwargs: dict[str, Any]) -> dict[str, Any]:
+    """Normalize MCP clients that wrap dynamic tool args in a single
+    ``kwargs`` parameter.
+
+    ``FastMCP.add_tool`` cannot infer per-tool schemas from dynamic runtime
+    JSON schemas here, so some clients (notably Codex) expose/call every tool
+    as ``kwargs: string``. Hermes' ``handle_function_call`` expects the real
+    tool arguments (e.g. ``{"prompt": ...}`` for ``image_generate``), so unwrap
+    common shapes before dispatch.
+    """
+    if set(kwargs.keys()) != {"kwargs"}:
+        return kwargs
+
+    raw = kwargs.get("kwargs")
+    if isinstance(raw, dict):
+        nested = raw.get("kwargs")
+        return nested if isinstance(nested, dict) else raw
+    if not isinstance(raw, str):
+        return kwargs
+
+    text = raw.strip()
+    if not text:
+        return {}
+
+    # JSON object, optionally nested as {"kwargs": {...}}.
+    if text.startswith("{"):
+        try:
+            parsed = json.loads(text)
+            if isinstance(parsed, dict):
+                nested = parsed.get("kwargs")
+                return nested if isinstance(nested, dict) else parsed
+        except Exception:
+            pass
+
+    # Simple key:value lines, good enough for Codex retries like:
+    # prompt: ...\naspect_ratio: landscape
+    parsed_lines: dict[str, str] = {}
+    for line in text.splitlines():
+        if ":" not in line:
+            continue
+        key, value = line.split(":", 1)
+        key = key.strip()
+        if key:
+            parsed_lines[key] = value.strip()
+    if parsed_lines:
+        return parsed_lines
+
+    # Last-resort compatibility: treat a raw string as a prompt for the image
+    # generation tool path. Other tools will return their normal validation
+    # errors if this is not suitable.
+    return {"prompt": text}
+
 logger = logging.getLogger(__name__)
 
 
@@ -162,7 +215,7 @@ def _build_server() -> Any:
         def _make_handler(tool_name: str):
             def _dispatch(**kwargs: Any) -> str:
                 try:
-                    return handle_function_call(tool_name, kwargs or {})
+                    return handle_function_call(tool_name, _normalize_tool_kwargs(kwargs or {}))
                 except Exception as exc:
                     logger.exception("tool %s raised", tool_name)
                     return json.dumps({"error": str(exc), "tool": tool_name})

--- a/tests/tools/test_image_generation.py
+++ b/tests/tools/test_image_generation.py
@@ -363,15 +363,67 @@ class TestAspectRatioNormalization:
 
 class TestRegistryIntegration:
 
-    def test_schema_exposes_only_prompt_and_aspect_ratio_to_agent(self, image_tool):
+    def test_schema_exposes_prompt_aspect_ratio_and_reference_images_to_agent(self, image_tool):
         """The agent-facing schema must stay tight — model selection is a
-        user-level config choice, not an agent-level arg."""
+        user-level config choice, while reference images are an intentional
+        image-editing input for providers that support them."""
         props = image_tool.IMAGE_GENERATE_SCHEMA["parameters"]["properties"]
-        assert set(props.keys()) == {"prompt", "aspect_ratio"}
+        assert set(props.keys()) == {"prompt", "aspect_ratio", "reference_images"}
+        assert props["reference_images"]["type"] == "array"
 
     def test_aspect_ratio_enum_is_three_values(self, image_tool):
         enum = image_tool.IMAGE_GENERATE_SCHEMA["parameters"]["properties"]["aspect_ratio"]["enum"]
         assert set(enum) == {"landscape", "square", "portrait"}
+
+    def test_plugin_dispatch_passes_reference_images(self, image_tool, monkeypatch):
+        """Core owns the tool contract; backend plugins own the edit behavior."""
+        import hermes_cli.plugins as plugins_mod
+        from agent.image_gen_provider import ImageGenProvider, success_response
+        from agent.image_gen_registry import _reset_for_tests, register_provider
+
+        captured = {}
+
+        class FakeReferenceProvider(ImageGenProvider):
+            @property
+            def name(self):
+                return "fake-ref"
+
+            def generate(self, prompt, aspect_ratio="landscape", **kwargs):
+                captured.update(kwargs)
+                return success_response(
+                    image="/tmp/fake.png",
+                    model="fake-model",
+                    prompt=prompt,
+                    aspect_ratio=aspect_ratio,
+                    provider=self.name,
+                )
+
+        _reset_for_tests()
+        register_provider(FakeReferenceProvider())
+        monkeypatch.setattr(image_tool, "_read_configured_image_provider", lambda: "fake-ref")
+        monkeypatch.setattr(image_tool, "_read_configured_image_model", lambda: None)
+        monkeypatch.setattr(plugins_mod, "_ensure_plugins_discovered", lambda force=False: None)
+
+        result = image_tool._dispatch_to_plugin_provider(
+            "use this reference",
+            "square",
+            reference_images=["/tmp/ref.png"],
+        )
+
+        assert '"success": true' in result.lower()
+        assert captured["reference_images"] == ["/tmp/ref.png"]
+        _reset_for_tests()
+
+    def test_fal_path_rejects_reference_images_instead_of_prompt_only(self, image_tool):
+        result = image_tool.image_generate_tool(
+            prompt="use this reference",
+            aspect_ratio="square",
+            reference_images=["/tmp/ref.png"],
+        )
+
+        assert '"success": false' in result.lower()
+        assert "reference_images" in result
+        assert "image_gen.provider" in result
 
 
 # ---------------------------------------------------------------------------

--- a/tools/image_generation_tool.py
+++ b/tools/image_generation_tool.py
@@ -656,6 +656,7 @@ def _upscale_image(image_url: str, original_prompt: str) -> Optional[Dict[str, A
 def image_generate_tool(
     prompt: str,
     aspect_ratio: str = DEFAULT_ASPECT_RATIO,
+    reference_images: Optional[list[str]] = None,
     num_inference_steps: Optional[int] = None,
     guidance_scale: Optional[float] = None,
     num_images: Optional[int] = None,
@@ -696,6 +697,13 @@ def image_generate_tool(
     try:
         if not prompt or not isinstance(prompt, str) or len(prompt.strip()) == 0:
             raise ValueError("Prompt is required and must be a non-empty string")
+
+        if reference_images:
+            raise ValueError(
+                "reference_images were provided, but the built-in FAL image path "
+                "is text-to-image only. Set image_gen.provider to a plugin that "
+                "supports reference images (for example openai-codex-ref)."
+            )
 
         if not (fal_key_is_configured() or _resolve_managed_fal_gateway()):
             raise ValueError(_build_no_backend_setup_message())
@@ -948,6 +956,11 @@ IMAGE_GENERATE_SCHEMA = {
                 "description": "The aspect ratio of the generated image. 'landscape' is 16:9 wide, 'portrait' is 16:9 tall, 'square' is 1:1.",
                 "default": DEFAULT_ASPECT_RATIO,
             },
+            "reference_images": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Optional image reference paths or URLs to guide likeness/style when the active backend supports reference-image generation or editing.",
+            },
         },
         "required": ["prompt"],
     },
@@ -990,7 +1003,7 @@ def _read_configured_image_provider():
     return None
 
 
-def _dispatch_to_plugin_provider(prompt: str, aspect_ratio: str):
+def _dispatch_to_plugin_provider(prompt: str, aspect_ratio: str, reference_images=None):
     """Route the call to a plugin-registered provider when one is selected.
 
     Returns a JSON string on dispatch, or ``None`` to fall through to the
@@ -1046,6 +1059,8 @@ def _dispatch_to_plugin_provider(prompt: str, aspect_ratio: str):
         kwargs = {"prompt": prompt, "aspect_ratio": aspect_ratio}
         if configured_model:
             kwargs["model"] = configured_model
+        if reference_images is not None:
+            kwargs["reference_images"] = reference_images
         result = provider.generate(**kwargs)
     except Exception as exc:
         logger.warning(
@@ -1073,16 +1088,18 @@ def _handle_image_generate(args, **kw):
     if not prompt:
         return tool_error("prompt is required for image generation")
     aspect_ratio = args.get("aspect_ratio", DEFAULT_ASPECT_RATIO)
+    reference_images = args.get("reference_images")
 
     # Route to a plugin-registered provider if one is active (and it's
     # not the in-tree FAL path).
-    dispatched = _dispatch_to_plugin_provider(prompt, aspect_ratio)
+    dispatched = _dispatch_to_plugin_provider(prompt, aspect_ratio, reference_images=reference_images)
     if dispatched is not None:
         return dispatched
 
     return image_generate_tool(
         prompt=prompt,
         aspect_ratio=aspect_ratio,
+        reference_images=reference_images,
     )
 
 


### PR DESCRIPTION
## What does this PR do?

Adds an optional `reference_images` parameter to the `image_generate` tool schema and dispatch pipeline, enabling plugin providers that support reference-based generation (e.g., OpenAI gpt-image-2 with reference images) to receive image paths/URLs for style or likeness guidance.

Also fixes a compatibility issue where MCP clients (notably Codex ACP) wrap all tool arguments in a single `kwargs` parameter, causing dispatch failures. The `_normalize_tool_kwargs` helper unwraps common shapes before `handle_function_call`.

## Related Issue

No existing issue — discovered and implemented during local plugin development.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- **`tools/image_generation_tool.py`** — Add `reference_images` parameter to tool schema, handler, and plugin dispatch. Built-in FAL path rejects `reference_images` with a clear error directing users to configure a compatible plugin provider.
- **`agent/transports/hermes_tools_mcp_server.py`** — Add `_normalize_tool_kwargs()` helper to unwrap MCP client kwargs wrapping (Codex ACP sends `{"kwargs": "{\"prompt\": ...}"}` or `{"kwargs": {"kwargs": {...}}}`).
- **`tests/tools/test_image_generation.py`** — Add 3 tests: schema exposure, plugin dispatch with reference images, FAL rejection of reference images.

## How to Test

1. Run the test suite: `pytest tests/tools/test_image_generation.py -v` (57/57 pass)
2. Configure a plugin provider that accepts `reference_images` (e.g., `openai-codex-ref`)
3. Call `image_generate` with `reference_images: ["/path/to/ref.jpg"]` — should dispatch to the plugin
4. Without a plugin provider, calling with `reference_images` returns a clear error suggesting `image_gen.provider` configuration

## Checklist

### Code

- [x] I have read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat(tools):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this is not a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I have run `pytest tests/ -q` and all tests pass
- [x] I have added tests for my changes
- [x] I have tested on my platform: macOS 15 (Sequoia)

### Documentation and Housekeeping

- [x] I have updated tool descriptions/schemas if I changed tool behavior
- N/A — no config keys added
- N/A — no architecture changes