### PR TITLE
fix(computer-use): clear stale app context on no match

### DIFF
--- a/tests/tools/test_computer_use.py
+++ b/tests/tools/test_computer_use.py
@@ -966,6 +966,9 @@ class TestCaptureAppFilterNoMatch:
              "is_on_screen": True, "title": "Calculator", "z_index": 1},
         ]
         backend = _make_cua_backend_with_windows(windows)
+        backend._active_pid = 999
+        backend._active_window_id = 888
+        backend._last_app = "PreviousApp"
 
         cap = backend.capture(mode="som", app="Calculator")
 
@@ -976,9 +979,25 @@ class TestCaptureAppFilterNoMatch:
         assert cap.elements == []
         assert "Calculator" in cap.window_title
         assert "list_apps" in cap.window_title
-        # _active_pid must remain unset so a subsequent click doesn't hit Fuwari.
+        # _active_pid must be cleared so a subsequent click doesn't hit Fuwari
+        # or a stale previously-targeted window.
         assert backend._active_pid is None
         assert backend._active_window_id is None
+        assert backend._last_app is None
+
+    def test_app_filter_no_windows_clears_stale_active_context(self):
+        backend = _make_cua_backend_with_windows([])
+        backend._active_pid = 999
+        backend._active_window_id = 888
+        backend._last_app = "PreviousApp"
+
+        cap = backend.capture(mode="som", app="Calculator")
+
+        assert cap.app == ""
+        assert cap.elements == []
+        assert backend._active_pid is None
+        assert backend._active_window_id is None
+        assert backend._last_app is None
 
     def test_app_filter_match_still_works(self):
         windows = [
@@ -1035,14 +1054,20 @@ class TestFocusAppFilterNoMatch:
              "is_on_screen": True, "title": "Calculator", "z_index": 1},
         ]
         backend = _make_cua_backend_with_windows(windows)
+        backend._active_pid = 999
+        backend._active_window_id = 888
+        backend._last_app = "PreviousApp"
 
         res = backend.focus_app("Calculator")
 
         assert res.ok is False
         assert res.action == "focus_app"
         assert "Calculator" in res.message
-        # _active_pid must remain unset so a subsequent click doesn't hit Fuwari.
+        # _active_pid must be cleared so a subsequent click doesn't hit Fuwari
+        # or a stale previously-targeted window.
         assert backend._active_pid is None
+        assert backend._active_window_id is None
+        assert backend._last_app is None
 
     def test_focus_app_match_still_works(self):
         windows = [

--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -389,6 +389,9 @@ class CuaDriverBackend(ComputerUseBackend):
             windows = _parse_windows_from_text(raw_text)
 
         if not windows:
+            self._active_pid = None
+            self._active_window_id = None
+            self._last_app = None
             return CaptureResult(mode=mode, width=0, height=0, png_b64=None,
                                  elements=[], app="", window_title="", png_bytes_len=0)
 
@@ -402,6 +405,9 @@ class CuaDriverBackend(ComputerUseBackend):
             app_lower = app.lower()
             filtered = [w for w in windows if app_lower in w["app_name"].lower()]
             if not filtered:
+                self._active_pid = None
+                self._active_window_id = None
+                self._last_app = None
                 return CaptureResult(
                     mode=mode, width=0, height=0, png_b64=None,
                     elements=[], app="",
@@ -677,7 +683,8 @@ class CuaDriverBackend(ComputerUseBackend):
         # Don't silently fall back to the frontmost window when the filter
         # matches nothing — that hides the real failure (often a localized
         # macOS app name mismatch, e.g. caller passed "Calculator" but
-        # list_windows returns "計算機").
+        # list_windows returns "計算機"). Clear any previous active context so
+        # the failed selection cannot be followed by an action on a stale window.
         target = matched[0] if matched else None
         if target:
             self._active_pid = target["pid"]
@@ -688,6 +695,9 @@ class CuaDriverBackend(ComputerUseBackend):
                 message=f"Targeted {target['app_name']} (pid {self._active_pid}, "
                         f"window {self._active_window_id}) without raising window.",
             )
+        self._active_pid = None
+        self._active_window_id = None
+        self._last_app = None
         return ActionResult(ok=False, action="focus_app",
                             message=f"No on-screen window found for app '{app}'.")
 


### PR DESCRIPTION
## Summary
- Clear `_active_pid`, `_active_window_id`, and `_last_app` when `capture(app=...)` fails to find a matching app window
- Preserve the no-frontmost-fallback behavior already on `main`, but make failed selection fail closed against stale previous targets
- Add regression tests for stale active context on app no-match and empty window lists

## Why
The current `main` already avoids falling back to the frontmost window when `app=...` does not match. However, a failed `capture(app=...)` could still leave an older active window context in place, so a follow-up action might target a stale previously-selected app. This closes that gap.

## Test Plan
- [x] `scripts/run_tests.sh tests/tools/test_computer_use.py`
- [x] `git diff origin/main...HEAD --check`
- [x] Added-line static scan for hardcoded secrets / shell injection / eval / pickle / SQL formatting returned no matches
