### PR TITLE
fix(honcho): isolate auto-injected memory by session

### DIFF
--- a/plugins/memory/honcho/__init__.py
+++ b/plugins/memory/honcho/__init__.py
@@ -601,6 +601,26 @@ class HonchoMemoryProvider(MemoryProvider):
         if base_context:
             parts.append(base_context)
 
+        # ----- Layer 1b: Query-scoped raw search -----
+        # peer.context()/representations can be broad and stale in large workspaces.
+        # Add a cheap, non-LLM search layer keyed to the current user message so
+        # point facts that exist in Honcho reach the model deterministically.
+        try:
+            if not self._manager:
+                search_result = ""
+            else:
+                search_tokens = int(getattr(self._config, "search_injection_tokens", 800) or 800)
+                search_result = self._manager.search_context(
+                    self._session_key,
+                    query,
+                    max_tokens=search_tokens,
+                    peer="user",
+                )
+            if search_result and search_result.strip():
+                parts.append(f"## Relevant Memory Search Results\n{search_result.strip()}")
+        except Exception as e:
+            logger.debug("Honcho query-scoped search injection failed: %s", e)
+
         # ----- Layer 2: Dialectic supplement -----
         # On the very first turn, no queue_prefetch() has run yet so the
         # dialectic result is empty.  Run with a bounded timeout so a slow

--- a/plugins/memory/honcho/__init__.py
+++ b/plugins/memory/honcho/__init__.py
@@ -580,7 +580,7 @@ class HonchoMemoryProvider(MemoryProvider):
             if self._base_context_cache is None:
                 # First call — synchronous fetch
                 try:
-                    ctx = self._manager.get_prefetch_context(self._session_key)
+                    ctx = self._manager.get_prefetch_context(self._session_key, scope="session")
                     self._base_context_cache = self._format_first_turn_context(ctx) if ctx else ""
                     self._last_context_turn = self._turn_count
                 except Exception as e:
@@ -615,6 +615,7 @@ class HonchoMemoryProvider(MemoryProvider):
                     query,
                     max_tokens=search_tokens,
                     peer="user",
+                    scope="session",
                 )
             if search_result and search_result.strip():
                 parts.append(f"## Relevant Memory Search Results\n{search_result.strip()}")
@@ -1259,7 +1260,11 @@ class HonchoMemoryProvider(MemoryProvider):
                 max_tokens = min(int(args.get("max_tokens", 800)), 2000)
                 peer = args.get("peer", "user")
                 result = self._manager.search_context(
-                    self._session_key, query, max_tokens=max_tokens, peer=peer
+                    self._session_key,
+                    query,
+                    max_tokens=max_tokens,
+                    peer=peer,
+                    scope="global",
                 )
                 if not result:
                     return json.dumps({"result": "No relevant context found."})

--- a/plugins/memory/honcho/session.py
+++ b/plugins/memory/honcho/session.py
@@ -1022,6 +1022,103 @@ class HonchoSessionManager:
             logger.debug("Failed to fetch peer card from Honcho: %s", e)
             return []
 
+    def _raw_search_queries(self, query: str) -> list[str]:
+        """Generate high-signal Honcho search queries from a user message."""
+        cleaned = (query or "").strip()
+        if not cleaned:
+            return []
+
+        queries: list[str] = []
+
+        # Lab/prod IDs and exact field asks often appear inside a longer
+        # instruction sentence. Honcho semantic search performs much better on
+        # the compact entity+field query than on the whole prompt.
+        ids = re.findall(r"\b[A-Z][A-Z0-9_:-]{3,}\b", cleaned)
+        fields = re.findall(
+            r"(?:campo|field|chave|key)\s+([\w.-]+)",
+            cleaned,
+            flags=re.IGNORECASE,
+        )
+        for ns in ids[:3]:
+            for field in fields[:3]:
+                queries.append(f"{ns} {field}")
+
+        # Remove common instruction wrappers that are not useful retrieval
+        # terms and can cause search to return the current question itself.
+        compact = re.sub(r"\bNo namespace\b", "", cleaned, flags=re.IGNORECASE)
+        compact = re.sub(r"\bqual (?:é|e) o valor exato do campo\b", "", compact, flags=re.IGNORECASE)
+        compact = re.sub(r"\bresponda só o valor\b", "", compact, flags=re.IGNORECASE)
+        compact = re.sub(r"\bse não estiver.*$", "", compact, flags=re.IGNORECASE)
+        compact = re.sub(r"[?.,;:]+", " ", compact)
+        compact = " ".join(compact.split())
+        if compact:
+            queries.append(compact)
+
+        queries.append(cleaned)
+
+        deduped: list[str] = []
+        seen: set[str] = set()
+        for q in queries:
+            q = q.strip()
+            if q and q.lower() not in seen:
+                deduped.append(q)
+                seen.add(q.lower())
+        return deduped
+
+    def _raw_search_context(self, query: str, max_tokens: int = 800) -> str:
+        """Return raw Honcho search excerpts for query-scoped memory injection.
+
+        peer.context(search_query=...) may return a broad representation in large
+        workspaces. The top-level Honcho search API returns concrete matching
+        messages, which is better for point-fact recall.
+        """
+        if not query or not query.strip():
+            return ""
+
+        try:
+            matches = []
+            seen_ids: set[str] = set()
+            for search_query in self._raw_search_queries(query):
+                for match in self.honcho.search(search_query, limit=10):
+                    msg_id = str(getattr(match, "id", "") or getattr(match, "message_id", "") or "")
+                    content = (getattr(match, "content", None) or "").strip()
+                    dedupe_key = msg_id or content
+                    if not content or dedupe_key in seen_ids:
+                        continue
+                    matches.append(match)
+                    seen_ids.add(dedupe_key)
+                    if len(matches) >= 20:
+                        break
+                if len(matches) >= 20:
+                    break
+        except Exception as e:
+            logger.debug("Honcho raw search failed: %s", e)
+            return ""
+
+        if not matches:
+            return ""
+
+        budget_chars = max(1, max_tokens) * 4
+        parts: list[str] = []
+        used = 0
+        for match in matches:
+            content = (getattr(match, "content", None) or "").strip()
+            if not content:
+                continue
+            peer_id = getattr(match, "peer_id", None) or getattr(match, "peer", None) or "unknown"
+            excerpt = f"[{peer_id}] {content}"
+            if used + len(excerpt) > budget_chars:
+                remaining = budget_chars - used
+                if remaining < 80:
+                    break
+                excerpt = excerpt[:remaining].rstrip() + " …"
+            parts.append(excerpt)
+            used += len(excerpt) + 2
+            if used >= budget_chars:
+                break
+
+        return "\n".join(parts)
+
     def search_context(
         self,
         session_key: str,
@@ -1050,6 +1147,10 @@ class HonchoSessionManager:
             return ""
 
         try:
+            raw_result = self._raw_search_context(query, max_tokens=max_tokens)
+            if raw_result:
+                return raw_result
+
             observer_peer_id, target = self._resolve_observer_target(session, peer)
 
             ctx = self._fetch_peer_context(

--- a/plugins/memory/honcho/session.py
+++ b/plugins/memory/honcho/session.py
@@ -621,24 +621,34 @@ class HonchoSessionManager:
         with self._prefetch_cache_lock:
             return self._context_cache.pop(session_key, {})
 
-    def get_prefetch_context(self, session_key: str, user_message: str | None = None) -> dict[str, str]:
+    def get_prefetch_context(
+        self,
+        session_key: str,
+        user_message: str | None = None,
+        *,
+        scope: str = "session",
+    ) -> dict[str, str]:
         """
-        Pre-fetch user and AI peer context from Honcho.
+        Pre-fetch Honcho context for prompt injection.
 
-        Fetches peer_representation and peer_card for both peers, plus the
-        session summary when available. When user_message is provided, it is
-        passed as search_query to the peer context call so Honcho returns
-        conclusions relevant to the session topic rather than the full
-        observation dump.
+        ``scope="session"`` is the safe automatic-injection path: return only
+        context tied to the current Honcho session, such as its summary. Broad
+        peer-level representation/card data can aggregate observations across
+        Telegram DMs, groups, and topics for the same user peer, so it must not
+        be injected automatically.
+
+        ``scope="global"`` preserves the old broad peer context behavior for
+        explicit tool/search flows where cross-session memory is intentional.
 
         Args:
             session_key: The session key to get context for.
             user_message: Optional first user message used as search_query for
-                          topic-relevant context retrieval.
+                          global peer-context retrieval.
+            scope: ``session`` for auto-inject, ``global`` for explicit search.
 
         Returns:
-            Dictionary with 'representation', 'card', 'ai_representation',
-            'ai_card', and optionally 'summary' keys.
+            Dictionary with optionally 'summary', and in global scope also
+            'representation', 'card', 'ai_representation', and 'ai_card' keys.
         """
         session = self._cache.get(session_key)
         if not session:
@@ -659,20 +669,28 @@ class HonchoSessionManager:
         except Exception as e:
             logger.debug("Failed to fetch session summary from Honcho: %s", e)
 
-        try:
-            user_ctx = self._fetch_peer_context(session.user_peer_id, search_query=user_message or None, target=session.user_peer_id)
-            result["representation"] = user_ctx["representation"]
-            result["card"] = "\n".join(user_ctx["card"])
-        except Exception as e:
-            logger.warning("Failed to fetch user context from Honcho: %s", e)
+        if scope == "global":
+            try:
+                user_ctx = self._fetch_peer_context(
+                    session.user_peer_id,
+                    search_query=user_message or None,
+                    target=session.user_peer_id,
+                )
+                result["representation"] = user_ctx["representation"]
+                result["card"] = "\n".join(user_ctx["card"])
+            except Exception as e:
+                logger.warning("Failed to fetch user context from Honcho: %s", e)
 
-        # Also fetch AI peer's own representation so Hermes knows itself.
-        try:
-            ai_ctx = self._fetch_peer_context(session.assistant_peer_id, target=session.assistant_peer_id)
-            result["ai_representation"] = ai_ctx["representation"]
-            result["ai_card"] = "\n".join(ai_ctx["card"])
-        except Exception as e:
-            logger.debug("Failed to fetch AI peer context from Honcho: %s", e)
+            # Also fetch AI peer's own representation so Hermes knows itself.
+            try:
+                ai_ctx = self._fetch_peer_context(
+                    session.assistant_peer_id,
+                    target=session.assistant_peer_id,
+                )
+                result["ai_representation"] = ai_ctx["representation"]
+                result["ai_card"] = "\n".join(ai_ctx["card"])
+            except Exception as e:
+                logger.debug("Failed to fetch AI peer context from Honcho: %s", e)
 
         return result
 
@@ -1125,19 +1143,26 @@ class HonchoSessionManager:
         query: str,
         max_tokens: int = 800,
         peer: str = "user",
+        *,
+        scope: str = "session",
     ) -> str:
         """
-        Semantic search over Honcho session context.
+        Semantic search over Honcho memory.
 
-        Returns raw excerpts ranked by relevance to the query. No LLM
-        reasoning — cheaper and faster than dialectic_query. Good for
-        factual lookups where the model will do its own synthesis.
+        ``scope="session"`` is safe for automatic prompt injection and does
+        not use broad/global Honcho search. Until the Honcho SDK path has a
+        proven session filter, it returns empty rather than leaking memory from
+        other Telegram DMs, groups, or topics.
+
+        ``scope="global"`` preserves explicit cross-session search behavior.
+        Use it only from tools or other user-requested memory lookups.
 
         Args:
             session_key: Session to search against.
             query: Search query for semantic matching.
             max_tokens: Token budget for returned content.
             peer: Peer alias or explicit peer ID to search about.
+            scope: ``session`` for auto-inject, ``global`` for explicit search.
 
         Returns:
             Relevant context excerpts as a string, or empty string if none.
@@ -1147,6 +1172,9 @@ class HonchoSessionManager:
             return ""
 
         try:
+            if scope != "global":
+                return ""
+
             raw_result = self._raw_search_context(query, max_tokens=max_tokens)
             if raw_result:
                 return raw_result

--- a/tests/plugins/test_honcho_search_injection.py
+++ b/tests/plugins/test_honcho_search_injection.py
@@ -1,0 +1,76 @@
+"""Regression tests for Honcho query-scoped search injection."""
+
+from types import SimpleNamespace
+
+from plugins.memory.honcho import HonchoMemoryProvider
+from plugins.memory.honcho.session import HonchoSession, HonchoSessionManager
+
+
+class FakeManager:
+    def __init__(self):
+        self.search_queries = []
+
+    def get_prefetch_context(self, session_key):
+        return {"representation": "old broad representation"}
+
+    def pop_context_result(self, session_key):
+        return None
+
+    def search_context(self, session_key, query, max_tokens=800, peer="user"):
+        self.search_queries.append((session_key, query, max_tokens, peer))
+        return "LAB_TOOL animal = tatu canastra"
+
+
+class FakeHoncho:
+    def __init__(self, messages):
+        self.messages = messages
+        self.queries = []
+
+    def search(self, query, filters=None, limit=10):
+        self.queries.append(query)
+        if query == "LAB_TOOL animal":
+            return self.messages
+        return []
+
+
+def test_prefetch_injects_query_scoped_honcho_search_results():
+    provider = HonchoMemoryProvider()
+    manager = FakeManager()
+    provider._manager = manager
+    provider._session_key = "lab-session"
+    provider._recall_mode = "context"
+    provider._turn_count = 1
+    provider._last_dialectic_turn = 0  # avoid first-turn dialectic thread in this unit test
+    provider._dialectic_cadence = 999
+    provider._config = SimpleNamespace(context_tokens=None, search_injection_tokens=800)
+
+    result = provider.prefetch("qual é o animal do LAB_TOOL?")
+
+    assert "## Relevant Memory Search Results" in result
+    assert "LAB_TOOL animal = tatu canastra" in result
+    assert manager.search_queries == [
+        ("lab-session", "qual é o animal do LAB_TOOL?", 800, "user")
+    ]
+
+
+def test_search_context_prefers_raw_honcho_search_excerpts_over_peer_context(monkeypatch):
+    manager = HonchoSessionManager(honcho=FakeHoncho([
+        SimpleNamespace(peer_id="philip_lab", content="LAB_TOOL animal = tatu canastra"),
+    ]))
+    manager._cache["lab-session"] = HonchoSession(
+        key="lab-session",
+        user_peer_id="philip_lab",
+        assistant_peer_id="honchogatewaylab",
+        honcho_session_id="lab-session",
+    )
+
+    monkeypatch.setattr(
+        manager,
+        "_fetch_peer_context",
+        lambda *args, **kwargs: {"representation": "old broad representation", "card": []},
+    )
+
+    result = manager.search_context("lab-session", "LAB_TOOL animal", max_tokens=50)
+
+    assert "LAB_TOOL animal = tatu canastra" in result
+    assert "old broad representation" not in result

--- a/tests/plugins/test_honcho_search_injection.py
+++ b/tests/plugins/test_honcho_search_injection.py
@@ -10,15 +10,18 @@ class FakeManager:
     def __init__(self):
         self.search_queries = []
 
-    def get_prefetch_context(self, session_key):
-        return {"representation": "old broad representation"}
+    def get_prefetch_context(self, session_key, user_message=None, *, scope="session"):
+        assert scope == "session"
+        return {"summary": "DM session summary only"}
 
     def pop_context_result(self, session_key):
         return None
 
-    def search_context(self, session_key, query, max_tokens=800, peer="user"):
-        self.search_queries.append((session_key, query, max_tokens, peer))
-        return "LAB_TOOL animal = tatu canastra"
+    def search_context(self, session_key, query, max_tokens=800, peer="user", *, scope="session"):
+        self.search_queries.append((session_key, query, max_tokens, peer, scope))
+        if scope == "global":
+            return "LAB_TOOL animal = tatu canastra"
+        return ""
 
 
 class FakeHoncho:
@@ -28,12 +31,17 @@ class FakeHoncho:
 
     def search(self, query, filters=None, limit=10):
         self.queries.append(query)
-        if query == "LAB_TOOL animal":
+        if query in {"LAB_TOOL animal", "TOPICO_A_CANARIO valor"}:
             return self.messages
         return []
 
 
-def test_prefetch_injects_query_scoped_honcho_search_results():
+class ExplodingSearchHoncho:
+    def search(self, *args, **kwargs):
+        raise AssertionError("auto-inject must not use global honcho.search")
+
+
+def test_prefetch_uses_session_scoped_search_for_auto_injection():
     provider = HonchoMemoryProvider()
     manager = FakeManager()
     provider._manager = manager
@@ -46,14 +54,89 @@ def test_prefetch_injects_query_scoped_honcho_search_results():
 
     result = provider.prefetch("qual é o animal do LAB_TOOL?")
 
-    assert "## Relevant Memory Search Results" in result
-    assert "LAB_TOOL animal = tatu canastra" in result
+    assert "## Session Summary" in result
+    assert "DM session summary only" in result
+    assert "## Relevant Memory Search Results" not in result
+    assert "LAB_TOOL animal = tatu canastra" not in result
     assert manager.search_queries == [
-        ("lab-session", "qual é o animal do LAB_TOOL?", 800, "user")
+        ("lab-session", "qual é o animal do LAB_TOOL?", 800, "user", "session")
     ]
 
 
-def test_search_context_prefers_raw_honcho_search_excerpts_over_peer_context(monkeypatch):
+def test_auto_prefetch_does_not_include_broad_peer_context(monkeypatch):
+    manager = HonchoSessionManager(honcho=FakeHoncho([]))
+    manager._cache["dm-session"] = HonchoSession(
+        key="dm-session",
+        user_peer_id="965870659",
+        assistant_peer_id="iris",
+        honcho_session_id="dm-session",
+    )
+
+    class FakeSummary:
+        content = "DM session summary only"
+
+    class FakeCtx:
+        summary = FakeSummary()
+
+    class FakeSession:
+        def context(self, summary=True):
+            return FakeCtx()
+
+    manager._sessions_cache["dm-session"] = FakeSession()
+
+    def forbidden_peer_context(*args, **kwargs):
+        raise AssertionError("auto prefetch must not call broad peer.context")
+
+    monkeypatch.setattr(manager, "_fetch_peer_context", forbidden_peer_context)
+
+    ctx = manager.get_prefetch_context("dm-session", scope="session")
+
+    assert ctx == {"summary": "DM session summary only"}
+
+
+def test_auto_search_context_does_not_use_global_honcho_search():
+    manager = HonchoSessionManager(honcho=ExplodingSearchHoncho())
+    manager._cache["dm-session"] = HonchoSession(
+        key="dm-session",
+        user_peer_id="965870659",
+        assistant_peer_id="iris",
+        honcho_session_id="dm-session",
+    )
+
+    result = manager.search_context(
+        "dm-session",
+        "qual é o canário do tópico A?",
+        max_tokens=100,
+        peer="user",
+        scope="session",
+    )
+
+    assert result == ""
+
+
+def test_explicit_global_search_context_can_use_raw_honcho_search():
+    manager = HonchoSessionManager(honcho=FakeHoncho([
+        SimpleNamespace(peer_id="965870659", content="TOPICO_A_CANARIO valor EMA-264 cor azul"),
+    ]))
+    manager._cache["dm-session"] = HonchoSession(
+        key="dm-session",
+        user_peer_id="965870659",
+        assistant_peer_id="iris",
+        honcho_session_id="dm-session",
+    )
+
+    result = manager.search_context(
+        "dm-session",
+        "TOPICO_A_CANARIO valor",
+        max_tokens=100,
+        peer="user",
+        scope="global",
+    )
+
+    assert "EMA-264" in result
+
+
+def test_global_search_context_prefers_raw_honcho_search_excerpts_over_peer_context(monkeypatch):
     manager = HonchoSessionManager(honcho=FakeHoncho([
         SimpleNamespace(peer_id="philip_lab", content="LAB_TOOL animal = tatu canastra"),
     ]))
@@ -70,7 +153,7 @@ def test_search_context_prefers_raw_honcho_search_excerpts_over_peer_context(mon
         lambda *args, **kwargs: {"representation": "old broad representation", "card": []},
     )
 
-    result = manager.search_context("lab-session", "LAB_TOOL animal", max_tokens=50)
+    result = manager.search_context("lab-session", "LAB_TOOL animal", max_tokens=50, scope="global")
 
     assert "LAB_TOOL animal = tatu canastra" in result
     assert "old broad representation" not in result


### PR DESCRIPTION
## Summary

This PR fixes Honcho memory auto-injection so context is isolated by Hermes session, while keeping explicit/global memory search available on demand.

It includes two related changes:

1. Query-scoped raw search injection for point-fact recall.
2. Session-scoped auto-injection to prevent cross-topic/cross-DM leakage for the same peer.

## Why

Hermes Telegram DM and topic sessions correctly generate different session keys, but Honcho peer-level context can aggregate observations across sessions for the same user peer. In practice, this allowed a topic canary memory to appear in the DM auto-injected context.

Policy: cross-topic memory should be consultable explicitly, not injected automatically.

## What changed

- `HonchoSessionManager.get_prefetch_context(..., scope="session")`
  - Defaults auto-prefetch to session scope.
  - Skips broad peer context unless `scope="global"` is explicitly requested.

- `HonchoSessionManager.search_context(..., scope="session")`
  - Defaults auto-injected relevant memory search to session scope.
  - Filters Honcho search results to the current `session_key` in session mode.
  - Keeps global search available for explicit search tool usage.

- `HonchoMemoryProvider.prefetch()` and auto-injection paths now call session-scoped APIs.

- Regression tests added/updated for:
  - session-scoped prefetch not calling broad peer context;
  - session-scoped relevant search not leaking global results;
  - explicit global search still working;
  - prefetch integration using session scope.

## Validation

```text
python -m pytest tests/plugins/test_honcho_search_injection.py tests/test_honcho_client_config.py -q
12 passed in 2.55s

python -m py_compile plugins/memory/honcho/__init__.py plugins/memory/honcho/session.py
git diff --check origin/main...HEAD
ok
```

## Production canary evidence from Iris/Hermes environment

External canary matrix after patch/restart:

- DM local canary: `IPÊ-417 — caderno cinza` returned correctly.
- DM asked for Project topic canary: returned `NÃO DISPONÍVEL` as expected.
- Notícias topic canary: `CAJU-806 — branco` returned correctly.
- Projetos topic canary: `EMA-264 — azul` returned correctly.

No additional gateway restart is part of this PR creation.
