### PR TITLE
fix(telegram): eliminate 409 polling race between PTB retry loop and conflict handler

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -15,7 +15,7 @@ import os
 import tempfile
 import html as _html
 import re
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import Dict, List, Optional, Any
 
 logger = logging.getLogger(__name__)
@@ -429,6 +429,7 @@ class TelegramAdapter(BasePlatformAdapter):
         self._polling_conflict_count: int = 0
         self._polling_network_error_count: int = 0
         self._polling_error_callback_ref = None
+        self._polling_conflict_recovery_in_progress: bool = False
         # DM Topics: map of topic_name -> message_thread_id (populated at startup)
         self._dm_topics: Dict[str, int] = {}
         # Track forum chats where we've already registered bot commands
@@ -902,6 +903,7 @@ class TelegramAdapter(BasePlatformAdapter):
                 allowed_updates=Update.ALL_TYPES,
                 drop_pending_updates=False,
                 error_callback=self._polling_error_callback_ref,
+                timeout=timedelta(seconds=60),
             )
             logger.info(
                 "[%s] Telegram polling resumed after network error (attempt %d)",
@@ -977,6 +979,18 @@ class TelegramAdapter(BasePlatformAdapter):
     async def _handle_polling_conflict(self, error: Exception) -> None:
         if self.has_fatal_error and self.fatal_error_code == "telegram_polling_conflict":
             return
+        # Guard against double-fire: PTB's network_retry_loop may keep invoking
+        # our error callback while a recovery is already underway. Only one
+        # recovery cycle runs at a time; concurrent invocations no-op.
+        if self._polling_conflict_recovery_in_progress:
+            return
+        self._polling_conflict_recovery_in_progress = True
+        try:
+            await self._handle_polling_conflict_inner(error)
+        finally:
+            self._polling_conflict_recovery_in_progress = False
+
+    async def _handle_polling_conflict_inner(self, error: Exception) -> None:
         # Transient 409 Conflict errors arise when the previous gateway process
         # has been killed (e.g. during `hermes update` or `--replace` handoffs)
         # but its long-poll connection hasn't yet expired on Telegram's servers.
@@ -1028,6 +1042,7 @@ class TelegramAdapter(BasePlatformAdapter):
                     allowed_updates=Update.ALL_TYPES,
                     drop_pending_updates=False,
                     error_callback=self._polling_error_callback_ref,
+                    timeout=timedelta(seconds=60),
                 )
                 logger.info(
                     "[%s] Telegram polling resumed after conflict retry %d/%d",
@@ -1529,6 +1544,12 @@ class TelegramAdapter(BasePlatformAdapter):
                 loop = asyncio.get_running_loop()
 
                 def _polling_error_callback(error: Exception) -> None:
+                    # Suppress callbacks while a conflict recovery is in
+                    # progress: PTB's network_retry_loop will keep calling
+                    # us between retries while updater.stop() is awaiting,
+                    # and we don't want to queue or race additional handlers.
+                    if self._polling_conflict_recovery_in_progress:
+                        return
                     if self._polling_error_task and not self._polling_error_task.done():
                         return
                     if self._looks_like_polling_conflict(error):
@@ -1546,6 +1567,7 @@ class TelegramAdapter(BasePlatformAdapter):
                     allowed_updates=Update.ALL_TYPES,
                     drop_pending_updates=True,
                     error_callback=_polling_error_callback,
+                    timeout=timedelta(seconds=60),
                 )
             
             # Register bot commands so Telegram shows a hint menu when users type /

--- a/tests/gateway/test_telegram_conflict.py
+++ b/tests/gateway/test_telegram_conflict.py
@@ -309,3 +309,98 @@ async def test_disconnect_skips_inactive_updater_and_app(monkeypatch):
     app.stop.assert_not_awaited()
     app.shutdown.assert_awaited_once()
     warning.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_start_polling_passes_long_timeout(monkeypatch):
+    """start_polling() must pass a `timeout` > 10s to avoid frequent 409 races."""
+    from datetime import timedelta
+
+    adapter = TelegramAdapter(PlatformConfig(enabled=True, token="***"))
+
+    monkeypatch.setattr(
+        "gateway.status.acquire_scoped_lock",
+        lambda scope, identity, metadata=None: (True, None),
+    )
+    monkeypatch.setattr(
+        "gateway.status.release_scoped_lock",
+        lambda scope, identity: None,
+    )
+
+    captured_kwargs = {}
+
+    async def fake_start_polling(**kwargs):
+        captured_kwargs.update(kwargs)
+
+    updater = SimpleNamespace(
+        start_polling=AsyncMock(side_effect=fake_start_polling),
+        stop=AsyncMock(),
+        running=True,
+    )
+    bot = SimpleNamespace(set_my_commands=AsyncMock(), delete_webhook=AsyncMock())
+    app = SimpleNamespace(
+        bot=bot, updater=updater, add_handler=MagicMock(),
+        initialize=AsyncMock(), start=AsyncMock(),
+    )
+    builder = MagicMock()
+    builder.token.return_value = builder
+    builder.request.return_value = builder
+    builder.get_updates_request.return_value = builder
+    builder.build.return_value = app
+    monkeypatch.setattr(
+        "gateway.platforms.telegram.Application",
+        SimpleNamespace(builder=MagicMock(return_value=builder)),
+    )
+
+    ok = await adapter.connect()
+    assert ok is True
+    assert "timeout" in captured_kwargs, "start_polling must be called with timeout="
+    t = captured_kwargs["timeout"]
+    seconds = t.total_seconds() if isinstance(t, timedelta) else float(t)
+    assert seconds > 10, f"timeout must exceed PTB default of 10s, got {seconds}"
+
+
+@pytest.mark.asyncio
+async def test_handle_polling_conflict_is_idempotent(monkeypatch):
+    """Concurrent invocations while a recovery is in progress must not spawn duplicates."""
+    adapter = TelegramAdapter(PlatformConfig(enabled=True, token="***"))
+
+    start_calls = {"n": 0}
+
+    # Set the flag manually so a second invocation is rejected as expected.
+    adapter._polling_conflict_recovery_in_progress = True
+
+    async def fake_start_polling(**kwargs):
+        start_calls["n"] += 1
+
+    updater = SimpleNamespace(
+        start_polling=AsyncMock(side_effect=fake_start_polling),
+        stop=AsyncMock(),
+        running=True,
+    )
+    adapter._app = SimpleNamespace(bot=SimpleNamespace(), updater=updater)
+    adapter._polling_error_callback_ref = lambda e: None
+
+    async def noop_drain():
+        return None
+    monkeypatch.setattr(adapter, "_drain_polling_connections", noop_drain)
+    monkeypatch.setattr("asyncio.sleep", AsyncMock())
+
+    conflict = type("Conflict", (Exception,), {})
+
+    # While a recovery is in progress, additional invocations must no-op
+    # and must NOT call start_polling or even enter the retry branch.
+    await adapter._handle_polling_conflict(conflict("c2"))
+    await adapter._handle_polling_conflict(conflict("c3"))
+
+    assert start_calls["n"] == 0, "No restart should be attempted while recovery in progress"
+    assert adapter._polling_conflict_count == 0, "Count must not advance for suppressed calls"
+    # Flag stays set because the (simulated) outer recovery still owns it.
+    assert adapter._polling_conflict_recovery_in_progress is True
+
+    # Once the outer recovery clears the flag, a new invocation proceeds.
+    adapter._polling_conflict_recovery_in_progress = False
+    await adapter._handle_polling_conflict(conflict("c4"))
+    assert start_calls["n"] == 1
+    assert adapter._polling_conflict_recovery_in_progress is False
+


### PR DESCRIPTION
## What does this PR do?

Fixes a persistent race condition in the Telegram gateway where polling enters a ~31-second cycle of "409 Conflict, retry, resume, Conflict", causing missed updates during the recovery window.

Two independent retry paths were racing inside `gateway/platforms/telegram.py`:

1. **PTB internal `network_retry_loop`** (configured with `max_retries=-1`) — after invoking our error callback, PTB still independently retried `getUpdates` with exponential backoff (1s, 1.5s, ..., 30s).
2. **Our `_handle_polling_conflict` handler** — `await updater.stop()`, 20s sleep, drain pools, then `start_polling()` again.

Because both ran as concurrent asyncio tasks and `start_polling()` defaulted to a 10s long-poll timeout, PTB retried `getUpdates` (with a fresh httpx connection) overlapped with the stale one from the previous session, triggering another 409 almost immediately. The cycle repeated forever.

## Related Issue

Fixes #30130

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/telegram.py`
  - Add `_polling_conflict_recovery_in_progress` flag on `TelegramAdapter` (initialised in `__init__`).
  - Split `_handle_polling_conflict` into a guarded outer wrapper plus `_handle_polling_conflict_inner`. The wrapper sets the flag, runs the inner method under `try/finally`, and clears the flag, making concurrent invocations no-op cleanly (idempotent).
  - Make `_polling_error_callback` early-return while a conflict recovery is in progress so PTB retry loop cannot queue overlapping handlers or race the restart.
  - Pass `timeout=timedelta(seconds=60)` to all three `start_polling()` call sites (initial startup, network-error retry path, conflict-recovery retry). This raises the long-poll cycle from PTB 10s default to 60s, dramatically shrinking the overlap window between sessions.
  - Add `timedelta` to the existing `datetime` import.

- `tests/gateway/test_telegram_conflict.py`
  - `test_start_polling_passes_long_timeout` asserts `start_polling()` is invoked with a `timeout` kwarg greater than 10s.
  - `test_handle_polling_conflict_is_idempotent` asserts that while the recovery flag is set, additional invocations do not trigger another restart attempt or advance the conflict counter; once the flag clears, a new invocation proceeds normally.

## How to Test

1. Repro setup (per the issue): Telegram gateway with a token still held open by a prior session, observe the recurring 409 cycle without this patch.
2. Apply this PR. The first 409 still triggers a single recovery, but PTB retry loop no longer races the restart, and the new 60s long-poll dramatically reduces re-conflict probability.
3. Unit tests: `pytest tests/gateway/test_telegram_conflict.py -q` to 8 passed.

## Checklist

### Code

- [x] I have read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(telegram): ...`)
- [x] I searched for existing PRs to make sure this is not a duplicate
- [x] My PR contains only changes related to this fix
- [x] I have added tests for my changes
- [x] I have tested on my platform: macOS 15

### Documentation and Housekeeping

- [x] N/A, no docs/config/architecture changes
- [x] N/A, no tool/schema changes

## Notes

- `python-telegram-bot==22.6` is pinned in this repo. `Updater.start_polling` `timeout` signature is `int | datetime.timedelta` (verified against the installed package), so `timedelta(seconds=60)` is the correct API surface.
- `read_timeout` (configured via `HERMES_TELEGRAM_HTTP_READ_TIMEOUT`) is intentionally left alone, it is user-tunable and the 60s long-poll is the more impactful knob.
- Behaviour for non-conflict errors (network errors, fatal errors after `MAX_CONFLICT_RETRIES`) is preserved unchanged.
