### PR TITLE
fix(auxiliary): resolve fallback_chain endpoint overrides

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -2870,11 +2870,11 @@ def _resolve_single_provider(
     # Reuse resolve_provider_client which handles provider→client mapping.
     # Fallback-chain entries use base_url/api_key field names, but this
     # resolver's endpoint override contract is explicit_*.
-    client, _resolved_model = resolve_provider_client(
+    client, _ = resolve_provider_client(
         provider=provider,
-        model=model or "",
-        explicit_base_url=base_url or "",
-        explicit_api_key=api_key or "",
+        model=model,
+        explicit_base_url=base_url,
+        explicit_api_key=api_key,
     )
     return client
 

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -2867,12 +2867,14 @@ def _resolve_single_provider(
 
     Uses the existing provider resolution infrastructure where possible.
     """
-    # Reuse resolve_provider_client which handles provider→client mapping
-    client, resolved_model = resolve_provider_client(
+    # Reuse resolve_provider_client which handles provider→client mapping.
+    # Fallback-chain entries use base_url/api_key field names, but this
+    # resolver's endpoint override contract is explicit_*.
+    client, _resolved_model = resolve_provider_client(
         provider=provider,
-        model=model,
-        base_url=base_url,
-        api_key=api_key,
+        model=model or "",
+        explicit_base_url=base_url or "",
+        explicit_api_key=api_key or "",
     )
     return client
 

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -1195,6 +1195,63 @@ class TestAuxiliaryFallbackLayering:
         exc.status_code = 402
         return exc
 
+    def test_resolve_single_provider_passes_explicit_overrides(self):
+        """fallback_chain endpoint fields must map to resolve_provider_client explicit_* kwargs."""
+        from agent.auxiliary_client import _resolve_single_provider
+
+        fake_client = MagicMock()
+        with patch("agent.auxiliary_client.resolve_provider_client",
+                   return_value=(fake_client, "fallback-model")) as resolver:
+            client = _resolve_single_provider(
+                "custom",
+                model="fallback-model",
+                base_url="https://fallback.example/v1",
+                api_key="fallback-key",
+            )
+
+        assert client is fake_client
+        resolver.assert_called_once_with(
+            provider="custom",
+            model="fallback-model",
+            explicit_base_url="https://fallback.example/v1",
+            explicit_api_key="fallback-key",
+        )
+
+    def test_configured_fallback_chain_uses_base_url_api_key_entry(self, monkeypatch):
+        """A fallback_chain entry with endpoint overrides resolves and is returned."""
+        from agent.auxiliary_client import _try_configured_fallback_chain
+
+        fake_client = MagicMock()
+        monkeypatch.setattr(
+            "agent.auxiliary_client._get_auxiliary_task_config",
+            lambda task: {
+                "fallback_chain": [{
+                    "provider": "custom",
+                    "model": "fallback-model",
+                    "base_url": "https://fallback.example/v1",
+                    "api_key": "fallback-key",
+                }]
+            },
+        )
+
+        with patch("agent.auxiliary_client.resolve_provider_client",
+                   return_value=(fake_client, "fallback-model")) as resolver:
+            client, model, label = _try_configured_fallback_chain(
+                "compression",
+                failed_provider="primary-provider",
+                reason="rate limit",
+            )
+
+        assert client is fake_client
+        assert model == "fallback-model"
+        assert label == "fallback_chain[0](custom)"
+        resolver.assert_called_once_with(
+            provider="custom",
+            model="fallback-model",
+            explicit_base_url="https://fallback.example/v1",
+            explicit_api_key="fallback-key",
+        )
+
     def test_explicit_provider_uses_configured_chain_first(self, monkeypatch, caplog):
         """When a user has fallback_chain configured, it's tried BEFORE the main agent model."""
         monkeypatch.setenv("OPENROUTER_API_KEY", "or-key")


### PR DESCRIPTION
## Summary

Fix auxiliary `fallback_chain` resolution so entries that specify endpoint overrides are forwarded to `resolve_provider_client()` using its `explicit_*` parameter names.

Previously `_resolve_single_provider()` passed the fallback entry's endpoint fields with names that `resolve_provider_client()` does not accept. That raises during fallback entry resolution; `_try_configured_fallback_chain()` catches resolution failures, so a configured fallback chain can silently no-op and fall through to later fallback layers instead.

This reopens the fix from the closed PR #27718 with a cleaner patch and passing regression tests.

Closes #27555.

## Test plan

- `python3 -m compileall -q agent/auxiliary_client.py tests/agent/test_auxiliary_client.py`
- `python3 -m pytest tests/agent/test_auxiliary_client.py::TestAuxiliaryFallbackLayering::test_resolve_single_provider_passes_explicit_overrides tests/agent/test_auxiliary_client.py::TestAuxiliaryFallbackLayering::test_configured_fallback_chain_uses_base_url_api_key_entry tests/agent/test_auxiliary_client.py::TestAuxiliaryFallbackLayering::test_explicit_provider_uses_configured_chain_first tests/agent/test_auxiliary_client.py::TestAuxiliaryFallbackLayering::test_explicit_provider_falls_back_to_main_when_chain_exhausted tests/agent/test_auxiliary_client.py::TestAuxiliaryFallbackLayering::test_warning_emitted_when_all_fallbacks_exhausted -q -o 'addopts='`
- `python3 -m pytest tests/agent/test_auxiliary_client.py -q -o 'addopts='`
