### PR TITLE
fix(tui): preserve scrollback when branching sessions

### DIFF
--- a/ui-tui/src/__tests__/createSlashHandler.test.ts
+++ b/ui-tui/src/__tests__/createSlashHandler.test.ts
@@ -222,6 +222,21 @@ describe('createSlashHandler', () => {
     expect(ctx.gateway.rpc).not.toHaveBeenCalled()
   })
 
+  it('keeps visible scrollback when branching a TUI session', async () => {
+    patchUiState({ sid: 'sid-parent' })
+    const rpc = vi.fn(() => Promise.resolve({ session_id: 'sid-branch', title: 'branch title' }))
+    const ctx = buildCtx({ gateway: { ...buildGateway(), rpc } })
+
+    expect(createSlashHandler(ctx)('/branch branch title')).toBe(true)
+
+    expect(rpc).toHaveBeenCalledWith('session.branch', { name: 'branch title', session_id: 'sid-parent' })
+    await vi.waitFor(() => {
+      expect(getUiState().sid).toBe('sid-branch')
+      expect(ctx.transcript.sys).toHaveBeenCalledWith('branched → branch title')
+    })
+    expect(ctx.transcript.setHistoryItems).not.toHaveBeenCalled()
+  })
+
   it('reloads skills in the live gateway and refreshes the catalog', async () => {
     const rpc = vi.fn((method: string) => {
       if (method === 'skills.reload') {

--- a/ui-tui/src/app/slash/commands/session.ts
+++ b/ui-tui/src/app/slash/commands/session.ts
@@ -212,7 +212,6 @@ export const sessionCommands: SlashCommand[] = [
           void ctx.session.closeSession(prevSid)
           patchUiState({ sid: r.session_id })
           ctx.session.setSessionStartedAt(Date.now())
-          ctx.transcript.setHistoryItems([])
           ctx.transcript.sys(`branched → ${r.title ?? ''}`)
         })
       )


### PR DESCRIPTION
## Symptom

`/branch` in the TUI switched to the new branched session, then removed the visible session scrollback. The backend had already copied the conversation history into the new session, so the branch was persisted correctly but the active UI looked empty.

## Root cause

The native TUI `/branch` handler called `ctx.transcript.setHistoryItems([])` immediately after updating the active session id:

```ts
patchUiState({ sid: r.session_id })
ctx.session.setSessionStartedAt(Date.now())
ctx.transcript.setHistoryItems([])
```

That clear belongs to fresh-session flows, not branch flows. A branch carries the existing transcript forward.

## Fix

Remove the transcript clear from `/branch`. The handler now keeps the mounted scrollback, updates the active TUI session id, closes the parent session in the gateway, and appends the branch confirmation line.

## Tests

- Added a regression test that runs `/branch branch title`, verifies the session id changes, and asserts `setHistoryItems` is not called.

## Verification

- [x] `cd ui-tui && npm test -- src/__tests__/createSlashHandler.test.ts` — 54 passed.
- [x] `ReadLints` on touched files — clean.
- [ ] `cd ui-tui && npm run type-check` — blocked by existing unrelated `packages/hermes-ink/src/utils/execFileNoThrow.ts` overload/type errors.
- [ ] `cd ui-tui && npm run lint` — blocked by existing unrelated repo-wide lint errors; touched files have no new errors.