### PR TITLE
feat(skills): add parallel-orchestration skill to autonomous-ai-agents

### DIFF
--- a/skills/autonomous-ai-agents/parallel-orchestration/SKILL.md
+++ b/skills/autonomous-ai-agents/parallel-orchestration/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: parallel-orchestration
+description: "Decompose a raw high-level goal into parallel subagent workers, assign toolsets, and synthesize results into a unified output."
+version: 1.0.0
+author: Hermes Agent
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [delegation, orchestration, parallel, multi-agent, synthesis, fan-out]
+    requires_toolsets: [delegation]
+    related_skills: [subagent-driven-development]
+---
+
+# Parallel Orchestration
+
+**Core principle:** One raw goal → N independent workers → one synthesized answer.
+
+## When to Use
+
+Use when a goal splits into two or more **independent** sub-goals too large to handle serially in your own context.
+
+Use `subagent-driven-development` instead when you already have a plan file.  
+Call `delegate_task` directly when you already know the task array.  
+Handle it yourself when only 1 sub-goal exists — no parallelism, only overhead.
+
+## Prerequisites
+
+Requires the `delegation` toolset. Grandchild workers (workers spawning their own sub-workers) require `delegation.max_spawn_depth: 2` in `config.yaml`; default is `1`. Workers passed `role="orchestrator"` silently degrade to `"leaf"` when the depth limit is reached.
+
+## Decompose
+
+Write the breakdown out before calling anything so the user can redirect.
+
+```
+Goal: Compare Pinecone, Weaviate, and Qdrant on cost, latency, and DX
+→ Worker A: Pinecone
+→ Worker B: Weaviate
+→ Worker C: Qdrant
+→ You: reconcile and synthesize
+```
+
+## Assign Toolsets
+
+| Task type | Toolsets |
+|---|---|
+| Web research, competitive analysis | `["web"]` |
+| Code implementation (write + run) | `["terminal", "file"]` |
+| Code audit / read-only review | `["file"]` |
+| Browser-dependent tasks (JS-heavy, login flows) | `["browser"]` |
+| Sandboxed code execution or testing | `["code_execution"]` |
+| Image or document visual analysis | `["file", "vision"]` |
+| Pure reasoning / synthesis | `[]` |
+
+## Invoke
+
+```python
+delegate_task(
+    tasks=[
+        {
+            "goal": "Research Pinecone: pricing, query latency, and developer experience. Return a structured summary with specific numbers.",
+            "context": "User wants a vector DB comparison. Your scope is Pinecone only.",
+            "toolsets": ["web"]
+        },
+        {
+            "goal": "Research Weaviate: pricing, query latency, and developer experience. Return a structured summary with specific numbers.",
+            "context": "User wants a vector DB comparison. Your scope is Weaviate only.",
+            "toolsets": ["web"]
+        },
+        {
+            "goal": "Research Qdrant: pricing, query latency, and developer experience. Return a structured summary with specific numbers.",
+            "context": "User wants a vector DB comparison. Your scope is Qdrant only.",
+            "toolsets": ["web"]
+        },
+    ]
+)
+```
+
+Each result has `status` (`"completed"` / `"failed"` / `"interrupted"` / `"timeout"` / `"error"`). Gate synthesis on `status == "completed"`; only completed workers have usable `summary` output.
+
+Pass workers exactly: the original user goal, the worker's specific scope, and prior phase output for sequential steps. Per-task `toolsets` override the top-level parameter.
+
+## Synthesize
+
+Structure the output around the user's original goal, not the worker breakdown.
+
+- **Reconcile conflicts** — prefer: more recent source > specific measurement > primary source. When unresolvable, present both and mark the uncertainty.
+- **Note every gap** — if a worker failed, say so: *"A and B covered; C was unavailable."*
+- **Don't list workers** — synthesize into the user's framing, not "Worker A found..."
+
+## Never
+
+- Spawn a single worker when you can handle it yourself
+- Use `role="orchestrator"` without `delegation.max_spawn_depth: 2` in config — silently degrades, no error
+- Silently drop failed workers
+- Present a partial result as complete


### PR DESCRIPTION
Adds `skills/autonomous-ai-agents/parallel-orchestration/SKILL.md`. No code changes.

---

`delegate_task` already supports parallel batch execution, but there's no bundled skill that tells the agent how to handle a *raw goal it hasn't decomposed yet*. Without guidance, the agent either handles everything in its own context (context bloat, shallow results across N targets) or improvises decomposition with inconsistent quality.

Two existing skills are adjacent but don't cover this:
- `subagent-driven-development` — sequential plan execution with spec + quality review gates; expects a plan file as input
- `codex` — delegates coding tasks to the Codex CLI

The missing piece is: raw goal → decompose → parallel workers → synthesized answer. That's what this adds.

---

## Use cases

**Competitive / framework research.** "Compare Pinecone, Weaviate, and Qdrant on cost, latency, and DX." Three parallel workers on `["web"]`, each focused on one target with fresh context. Without this, the third framework reliably gets shallower coverage as context fills from the first two. Parent synthesizes a comparison table; wall time ≈ one worker instead of three.

**Parallel codebase audit.** "Find all SQL injection vulnerabilities across these five modules." Five parallel workers on `["file"]`, each auditing one module independently. Sequential review means later modules compete with earlier ones for context — findings from module A are half-gone by module D. Parent reconciles and deduplicates.

**Multi-workstream build.** "Build the auth feature: schema migration, route handlers, and integration tests." Schema and routes share no mutable state during the design phase, so they fan out. Tests are dispatched after both complete, with both outputs passed in context. Reduces context accumulation compared to doing all three serially.

**Multi-source research synthesis.** N sources that would individually overflow the parent's context get dispatched to N workers. Parent receives N summaries and synthesizes with a clean head instead of trying to read and reason simultaneously.

---

## Why `requires_toolsets: [delegation]`

The skill auto-injects whenever the `delegation` toolset is active — the same mechanism `duckduckgo-search` and `searxng-search` use via `fallback_for_toolsets: [web]`. No opt-in, no slash command, no config key. Verified against `agent/prompt_builder.py:987` and `agent/skill_utils.py:298`.

---

## Verified against the codebase

| Claim in skill | Source |
|---|---|
| `status` values: `"completed"` / `"failed"` / `"interrupted"` / `"timeout"` / `"error"` | `delegate_tool.py:1626-1633, 1569, 1597` |
| `role="orchestrator"` silently degrades to `"leaf"` at depth limit | `delegate_tool.py:911-913` |
| Default `max_spawn_depth` is `1` — grandchildren blocked without config | `delegate_tool.py:133, 394-419` |
| Toolset names (`web`, `file`, `terminal`, `browser`, `code_execution`, `vision`) | `toolsets.py:80, 142, 185, 160, 221, 103` |
| Per-task `toolsets` override top-level parameter | `delegate_tool.py:2065` |

Worth calling out: the natural instinct for a successful worker's status is `"ok"`, but `delegate_tool.py` actually assigns `"completed"`. Would have been a silent bug if the synthesis gate used the wrong value.

---

## Relation to `subagent-driven-development`

The two skills handle different inputs. `subagent-driven-development` takes a plan file and executes it sequentially with review after every task — the right choice when correctness and spec compliance matter more than speed. This skill takes a raw goal, decomposes it, and fans out — the right choice when the bottleneck is context saturation across N independent targets.

The skill's "When to Use" section explicitly defers to `subagent-driven-development` when a plan file already exists, so they don't compete when both are injected.