### PR TITLE
fix(feishu): prevent unwanted topic creation on DM quote-reply

### DIFF
--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -3253,7 +3253,11 @@ class FeishuAdapter(BasePlatformAdapter):
             if hint:
                 text = f"{hint}\n\n{text}" if text else hint
 
-        thread_id = getattr(message, "thread_id", None) or getattr(message, "root_id", None) or None
+        thread_id = getattr(message, "thread_id", None) or None
+        # In p2p chats, root_id identifies quoted-message reply context rather
+        # than a Feishu topic. Group/channel chats still use it as a thread.
+        if chat_type != "p2p":
+            thread_id = thread_id or getattr(message, "root_id", None) or None
         reply_to_message_id = (
             getattr(message, "parent_id", None)
             or getattr(message, "upper_message_id", None)

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -4604,9 +4604,51 @@ class TestFeishuProcessInboundMessage(unittest.TestCase):
             return_value={"user_id": "u1", "user_name": "Alice", "user_id_alt": None}
         )
         adapter._resolve_source_chat_type = Mock(return_value="group")
-        adapter.build_source = Mock(return_value=SimpleNamespace(thread_id=None))
+        adapter.build_source = Mock(
+            side_effect=lambda **kwargs: SimpleNamespace(thread_id=kwargs["thread_id"])
+        )
         adapter._dispatch_inbound_event = AsyncMock()
         return adapter
+
+    def _process_root_id_reply(self, chat_type):
+        adapter = self._build_adapter()
+        adapter._fetch_message_text = AsyncMock(return_value="quoted message")
+        message = SimpleNamespace(
+            content=json.dumps({"text": "reply"}),
+            message_type="text",
+            message_id=f"m_{chat_type}_reply",
+            mentions=None,
+            chat_id=f"oc_{chat_type}",
+            parent_id=None,
+            upper_message_id=None,
+            thread_id=None,
+            root_id="om_quoted",
+        )
+
+        asyncio.run(
+            adapter._process_inbound_message(
+                data=message,
+                message=message,
+                sender_id=None,
+                chat_type=chat_type,
+                message_id=message.message_id,
+            )
+        )
+        return adapter._dispatch_inbound_event.call_args.args[0]
+
+    def test_p2p_root_id_keeps_reply_context_without_thread(self):
+        event = self._process_root_id_reply("p2p")
+
+        self.assertIsNone(event.source.thread_id)
+        self.assertEqual(event.reply_to_message_id, "om_quoted")
+        self.assertEqual(event.reply_to_text, "quoted message")
+
+    def test_group_root_id_is_preserved_as_thread(self):
+        event = self._process_root_id_reply("group")
+
+        self.assertEqual(event.source.thread_id, "om_quoted")
+        self.assertEqual(event.reply_to_message_id, "om_quoted")
+        self.assertEqual(event.reply_to_text, "quoted message")
 
     def test_leading_self_mention_stripped_for_command(self):
         from gateway.platforms.base import MessageType


### PR DESCRIPTION
When a user quotes a message in a Feishu DM (`p2p` chat), the SDK sets `root_id` on the inbound message object. Promoting that value to `source.thread_id` makes outbound replies use `reply_in_thread=True`, which creates an unwanted Feishu topic on the quoted DM message.

This keeps `root_id` as quoted-message reply context in DMs while preserving the `root_id -> thread_id` fallback for group/channel chats.

## What does this PR do?

- Prevents quoted Feishu DM messages from being treated as threaded topic replies.
- Preserves quoted-message context through `reply_to_message_id` and `reply_to_text`.
- Preserves topic/thread behavior for group/channel chats.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/platforms/feishu/adapter.py`: skip the `root_id -> thread_id` fallback for `p2p` chats.
- `tests/gateway/test_feishu.py`: add p2p and group `root_id` regression coverage.

## How to Test

```bash
scripts/run_tests.sh -j 1 tests/gateway/test_feishu.py -k "p2p_root_id_keeps_reply_context_without_thread or group_root_id_is_preserved_as_thread" -q
python -m py_compile plugins/platforms/feishu/adapter.py tests/gateway/test_feishu.py
ruff check plugins/platforms/feishu/adapter.py tests/gateway/test_feishu.py
```

Local results on Windows 11 / Python 3.12:

- Root-id regression cases: `2 passed, 210 deselected`
- Related inbound-message class: `7 passed, 205 deselected`
- `py_compile`: passed
- `ruff check`: passed

## Checklist

### Code

- [x] My commit message follows Conventional Commits.
- [x] My PR contains only changes related to this fix.
- [x] I've added regression tests for the bug.
- [ ] I've run the full repository test suite.
- [x] I've tested on Windows 11 / Python 3.12.

### Documentation & Housekeeping

- [x] Documentation changes are not required.
- [x] No configuration keys or schemas changed.
- [x] Cross-platform impact was considered.