### PR TITLE
Harden msgraph webhook authentication requirements

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -424,7 +424,9 @@ _PLATFORM_CONNECTED_CHECKERS: dict[Platform, Callable[[PlatformConfig], bool]] =
     Platform.SMS: lambda cfg: bool(os.getenv("TWILIO_ACCOUNT_SID")),
     Platform.API_SERVER: lambda cfg: True,
     Platform.WEBHOOK: lambda cfg: True,
-    Platform.MSGRAPH_WEBHOOK: lambda cfg: True,
+    Platform.MSGRAPH_WEBHOOK: lambda cfg: bool(
+        str(cfg.extra.get("client_state") or "").strip()
+    ),
     Platform.FEISHU: lambda cfg: bool(cfg.extra.get("app_id")),
     Platform.WECOM: lambda cfg: bool(cfg.extra.get("bot_id")),
     Platform.WECOM_CALLBACK: lambda cfg: bool(

--- a/gateway/platforms/msgraph_webhook.py
+++ b/gateway/platforms/msgraph_webhook.py
@@ -133,6 +133,12 @@ class MSGraphWebhookAdapter(BasePlatformAdapter):
         self._notification_scheduler = scheduler
 
     async def connect(self) -> bool:
+        if self._client_state is None:
+            logger.error(
+                "[msgraph_webhook] Refusing to start without extra.client_state configured"
+            )
+            return False
+
         app = web.Application()
         app.router.add_get(self._health_path, self._handle_health)
         app.router.add_get(self._webhook_path, self._handle_validation)
@@ -310,7 +316,7 @@ class MSGraphWebhookAdapter(BasePlatformAdapter):
         """
         expected = self._client_state
         if expected is None:
-            return True
+            return False
         provided = self._string_or_none(notification.get("clientState"))
         if provided is None:
             return False

--- a/tests/gateway/test_msgraph_webhook.py
+++ b/tests/gateway/test_msgraph_webhook.py
@@ -6,7 +6,7 @@ import json
 import pytest
 
 from gateway.config import GatewayConfig, Platform, PlatformConfig, _apply_env_overrides
-from gateway.platforms.msgraph_webhook import MSGraphWebhookAdapter
+from gateway.platforms.msgraph_webhook import AIOHTTP_AVAILABLE, MSGraphWebhookAdapter
 
 
 def _make_adapter(**extra_overrides) -> MSGraphWebhookAdapter:
@@ -71,6 +71,15 @@ class TestMSGraphWebhookConfig:
 
 class TestMSGraphValidationHandshake:
     @pytest.mark.anyio
+    async def test_connect_requires_client_state(self):
+        if not AIOHTTP_AVAILABLE:
+            pytest.skip("aiohttp not installed")
+        adapter = MSGraphWebhookAdapter(PlatformConfig(enabled=True, extra={}))
+        connected = await adapter.connect()
+        assert connected is False
+        assert adapter.is_connected() is False
+
+    @pytest.mark.anyio
     async def test_validation_token_echo_on_get(self):
         adapter = _make_adapter()
         resp = await adapter._handle_validation(
@@ -99,6 +108,22 @@ class TestMSGraphValidationHandshake:
 
 
 class TestMSGraphNotifications:
+    @pytest.mark.anyio
+    async def test_missing_client_state_is_auth_rejected(self):
+        adapter = _make_adapter(client_state=None)
+        payload = {
+            "value": [
+                {
+                    "id": "notif-no-client-state",
+                    "subscriptionId": "sub-1",
+                    "changeType": "updated",
+                    "resource": "communications/onlineMeetings/meeting-1",
+                }
+            ]
+        }
+        resp = await adapter._handle_notification(_FakeRequest(json_payload=payload))
+        assert resp.status == 403
+
     @pytest.mark.anyio
     async def test_valid_notification_accepted_and_scheduled(self):
         adapter = _make_adapter()

--- a/tests/gateway/test_platform_connected_checkers.py
+++ b/tests/gateway/test_platform_connected_checkers.py
@@ -79,10 +79,11 @@ def test_checker_returns_true_when_configured(platform, checker, monkeypatch):
     elif platform in {
         Platform.API_SERVER,
         Platform.WEBHOOK,
-        Platform.MSGRAPH_WEBHOOK,
         Platform.WHATSAPP,
     }:
         mock_config.extra = {}
+    elif platform == Platform.MSGRAPH_WEBHOOK:
+        mock_config.extra = {"client_state": "expected-client-state"}
     elif platform == Platform.FEISHU:
         mock_config.extra = {"app_id": "app"}
     elif platform == Platform.WECOM:


### PR DESCRIPTION
### Motivation
- A newly added Microsoft Graph webhook adapter could be enabled without a secret and converted incoming notifications into `MessageEvent` objects marked `internal=True`, bypassing gateway authorization and allowing unauthenticated remote prompts to drive the agent runtime. 
- The change forces a conservative default: the webhook platform must be configured with a shared `client_state` secret and verify it, otherwise the listener will not start or accept notifications.

### Description
- `gateway/platforms/msgraph_webhook.py`: refuse to start the aiohttp listener when `extra.client_state` is missing in `connect()`, and change `_verify_client_state()` to treat a missing configured secret as an authentication failure (return `False` when `self._client_state` is `None`).
- `gateway/config.py`: make the `_PLATFORM_CONNECTED_CHECKERS` entry for `Platform.MSGRAPH_WEBHOOK` require a non-empty `extra.client_state` so the platform is only considered connected when a secret is supplied.
- `tests/gateway/test_msgraph_webhook.py`: add `test_connect_requires_client_state` (skips when `aiohttp` is not installed) and `test_missing_client_state_is_auth_rejected` to assert start-up refusal and auth rejection behavior.
- `tests/gateway/test_platform_connected_checkers.py`: update the platform-checker fixture to provide a synthetic `client_state` for `Platform.MSGRAPH_WEBHOOK` so the checker test remains consistent with the new requirement.

### Testing
- Added unit tests in `tests/gateway/test_msgraph_webhook.py` and updated `tests/gateway/test_platform_connected_checkers.py` to cover the new behavior; these tests were added to the branch and committed.
- Attempted to run `pytest -q tests/gateway/test_msgraph_webhook.py tests/gateway/test_platform_connected_checkers.py`, which failed due to repository `addopts` including a timeout plugin not available in the execution environment (pytest error: unrecognized arguments `--timeout=30 --timeout-method=signal`).
- Attempted `pytest -q -o addopts='' tests/gateway/test_msgraph_webhook.py tests/gateway/test_platform_connected_checkers.py`, which failed during collection with `ModuleNotFoundError: No module named 'yaml'` because `PyYAML` is not installed in the runner environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f281370108325b7a953d8a841c695)