### PR TITLE
fix(#30152): warn on api_mode: gemini and reject Vertex action-verb base_urls at init

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -257,6 +257,30 @@ def init_agent(
     else:
         agent.api_mode = "chat_completions"
 
+    # ── Misconfiguration tripwire (#30152) ────────────────────────────
+    # The OpenAI SDK rewrites any ``base_url`` to end with ``/`` before
+    # appending ``/chat/completions``. When the operator pastes a full
+    # Vertex AI action URL (e.g. ``.../models/<m>:generateContent``)
+    # into ``base_url`` and lands on ``chat_completions`` (either
+    # explicitly or via the autodetect fallback above), every request
+    # 404s and the only signal is the fallback cascade. Surface the
+    # configuration error at init time with the correct alternatives
+    # instead of letting the cascade hide the root cause.
+    if agent.api_mode == "chat_completions" and agent.base_url:
+        try:
+            from hermes_cli.runtime_provider import (
+                _validate_base_url_for_openai_sdk,
+            )
+            _validate_base_url_for_openai_sdk(
+                base_url=agent.base_url,
+                provider=agent.provider,
+            )
+        except ValueError as exc:
+            # ValueError → ConfigurationError-ish; re-raise so the caller
+            # (CLI / gateway) surfaces it to the operator instead of
+            # swallowing it into a generic startup failure.
+            raise ValueError(str(exc)) from exc
+
     # Eagerly warm the transport cache so import errors surface at init,
     # not mid-conversation.  Also validates the api_mode is registered.
     try:

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -250,14 +250,144 @@ _VALID_API_MODES = {
     "codex_app_server",
 }
 
+# Common aliases / typos for ``api_mode`` values that operators reach for
+# but Hermes does not support directly. Used by ``_parse_api_mode`` to
+# give an actionable hint instead of silently dropping the value and
+# falling back to OpenAI SDK ``chat_completions`` — the silent fallback
+# is exactly the failure mode reported in #30152, where ``api_mode:
+# gemini`` was paired with a Vertex ``:generateContent`` base_url and
+# the OpenAI SDK's trailing-slash normalisation produced HTTP 404 on
+# every call with no actionable error in the log.
+_API_MODE_ALIASES: Dict[str, str] = {
+    "gemini": (
+        "Gemini providers use api_mode='chat_completions' with either "
+        "(a) Vertex's OpenAI-compatible endpoint "
+        "(base_url='https://aiplatform.googleapis.com/v1/projects/<PROJECT>"
+        "/locations/<LOC>/endpoints/openapi'), or "
+        "(b) Google AI Studio's native API "
+        "(base_url='https://generativelanguage.googleapis.com/v1beta'). "
+        "Hermes routes both through the existing chat_completions pipeline; "
+        "there is no separate 'gemini' api_mode."
+    ),
+    "google": "Use api_mode='chat_completions' (see the 'gemini' note in #30152).",
+    "openai": "Use api_mode='chat_completions'.",
+    "anthropic": "Use api_mode='anthropic_messages'.",
+    "bedrock": "Use api_mode='bedrock_converse'.",
+    "codex": "Use api_mode='codex_responses'.",
+}
+
+# Vertex AI / Gemini REST action verbs that can appear at the tail of a
+# full endpoint URL. When an operator copies the full Vertex action URL
+# into ``base_url`` (instead of the API root), the OpenAI SDK appends a
+# trailing slash to that URL — which Vertex answers with HTTP 404. Used
+# by ``_validate_base_url_for_openai_sdk`` (and exposed for tests) to
+# detect this misuse before any request is issued. See #30152.
+_VERTEX_ACTION_VERBS = (
+    ":generateContent",
+    ":streamGenerateContent",
+    ":countTokens",
+    ":embedContent",
+    ":batchEmbedContents",
+    ":predict",
+    ":rawPredict",
+    ":serverStreamingPredict",
+)
+
 
 def _parse_api_mode(raw: Any) -> Optional[str]:
-    """Validate an api_mode value from config. Returns None if invalid."""
-    if isinstance(raw, str):
-        normalized = raw.strip().lower()
-        if normalized in _VALID_API_MODES:
-            return normalized
+    """Validate an api_mode value from config. Returns None if invalid.
+
+    Logs a single ``WARNING`` for non-empty values that don't match the
+    allowlist so operators don't lose hours diagnosing a silent fall
+    through to ``chat_completions`` — see #30152 ("api_mode: gemini
+    providers route through OpenAI SDK; URL trailing-slash breaks
+    :generateContent"). The hint for known aliases (``gemini``,
+    ``openai``, …) points the operator at the correct mode +
+    ``base_url`` pairing.
+    """
+    if not isinstance(raw, str):
+        return None
+    normalized = raw.strip().lower()
+    if not normalized:
+        return None
+    if normalized in _VALID_API_MODES:
+        return normalized
+
+    hint = _API_MODE_ALIASES.get(normalized)
+    valid_list = ", ".join(sorted(_VALID_API_MODES))
+    if hint:
+        logger.warning(
+            "Ignoring unsupported api_mode=%r. %s "
+            "Falling back to autodetection (which usually picks chat_completions).",
+            raw, hint,
+        )
+    else:
+        logger.warning(
+            "Ignoring unsupported api_mode=%r. Valid values: %s. "
+            "Falling back to autodetection (which usually picks chat_completions).",
+            raw, valid_list,
+        )
     return None
+
+
+def _base_url_has_vertex_action_verb(base_url: Any) -> Optional[str]:
+    """Return the offending action verb if *base_url* tail-ends with one.
+
+    The OpenAI SDK rewrites ``base_url`` to end with ``/`` before
+    concatenating ``/chat/completions``; when the base URL is actually a
+    full Vertex action endpoint (``.../models/<m>:generateContent``),
+    Vertex returns HTTP 404 because there is no
+    ``:generateContent/chat/completions`` route. Used by
+    ``_validate_base_url_for_openai_sdk`` to short-circuit this misuse
+    before any request is dispatched. See #30152.
+    """
+    if not isinstance(base_url, str):
+        return None
+    trimmed = base_url.strip().rstrip("/")
+    if not trimmed:
+        return None
+    for verb in _VERTEX_ACTION_VERBS:
+        if trimmed.endswith(verb):
+            return verb
+    return None
+
+
+def _validate_base_url_for_openai_sdk(
+    *,
+    base_url: Any,
+    provider: str = "",
+) -> None:
+    """Raise ``ValueError`` if *base_url* would silently break the OpenAI SDK.
+
+    Currently catches the #30152 failure mode: a Vertex AI action-verb
+    endpoint (``.../models/<m>:generateContent``) passed where Hermes
+    expects an OpenAI-compatible base_url. The OpenAI SDK normalises the
+    URL by appending ``/`` to it before concatenating ``/chat/
+    completions``, and Vertex returns HTTP 404 — the operator only saw
+    a fallback cascade with no root cause unless they tailed the
+    gateway log.
+    """
+    verb = _base_url_has_vertex_action_verb(base_url)
+    if verb is None:
+        return
+    suffix = f" (provider={provider!r})" if provider else ""
+    raise ValueError(
+        f"Invalid base_url for the OpenAI-compatible transport{suffix}: "
+        f"{base_url!r} ends with the Vertex AI action verb {verb!r}, which "
+        f"is a full endpoint URL — not a base URL. The OpenAI SDK appends "
+        f"'/chat/completions' to base URLs, and Vertex responds HTTP 404 to "
+        f"'{verb}/chat/completions'.\n"
+        f"Use one of these instead:\n"
+        f"  (a) Vertex OpenAI-compatible endpoint:\n"
+        f"      base_url: https://aiplatform.googleapis.com/v1/projects/<PROJECT>"
+        f"/locations/<LOC>/endpoints/openapi\n"
+        f"      api_mode: chat_completions   (model: google/<model-id>)\n"
+        f"  (b) Google AI Studio native Gemini API:\n"
+        f"      base_url: https://generativelanguage.googleapis.com/v1beta\n"
+        f"      api_mode: chat_completions   (Hermes auto-routes through the "
+        f"native adapter)\n"
+        f"See https://github.com/NousResearch/hermes-agent/issues/30152."
+    )
 
 
 def _maybe_apply_codex_app_server_runtime(

--- a/tests/hermes_cli/test_api_mode_validation_30152.py
+++ b/tests/hermes_cli/test_api_mode_validation_30152.py
@@ -1,0 +1,302 @@
+"""Regression tests for #30152.
+
+#30152: ``api_mode: gemini`` providers silently routed through the OpenAI
+SDK, and a ``base_url`` that ended with the Vertex AI action verb
+``:generateContent`` got mangled to ``...:generateContent/`` by the
+OpenAI SDK's trailing-slash normalisation. The result was HTTP 404 on
+every call with no actionable error in the gateway log — only a
+fallback cascade.
+
+These tests pin down the two safety nets that #30152 introduced:
+
+1. ``_parse_api_mode`` emits a single ``WARNING`` (with an actionable
+   hint for known aliases like ``gemini`` / ``openai`` / ``anthropic``)
+   when the operator supplies an unsupported ``api_mode`` value,
+   instead of silently dropping it.
+2. ``_validate_base_url_for_openai_sdk`` raises ``ValueError`` with the
+   two valid Gemini/Vertex alternatives spelled out when the
+   ``base_url`` tail-ends with a Vertex action verb
+   (``:generateContent``, ``:streamGenerateContent``, …).
+"""
+
+from __future__ import annotations
+
+import logging
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from hermes_cli.runtime_provider import (
+    _API_MODE_ALIASES,
+    _VALID_API_MODES,
+    _VERTEX_ACTION_VERBS,
+    _base_url_has_vertex_action_verb,
+    _parse_api_mode,
+    _validate_base_url_for_openai_sdk,
+)
+
+
+# ──────────────────────────────────────────────────────────────────────
+# _parse_api_mode
+# ──────────────────────────────────────────────────────────────────────
+class TestParseApiModeAcceptsValidValues:
+    """Round-trip every value in ``_VALID_API_MODES`` and assert no warnings."""
+
+    @pytest.mark.parametrize("mode", sorted(_VALID_API_MODES))
+    def test_valid_api_mode_round_trips(
+        self, mode: str, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        caplog.set_level(logging.WARNING, logger="hermes_cli.runtime_provider")
+        assert _parse_api_mode(mode) == mode
+        assert caplog.records == []
+
+    def test_valid_api_mode_is_case_insensitive(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        caplog.set_level(logging.WARNING, logger="hermes_cli.runtime_provider")
+        assert _parse_api_mode("Chat_Completions") == "chat_completions"
+        assert _parse_api_mode("ANTHROPIC_MESSAGES") == "anthropic_messages"
+        assert caplog.records == []
+
+    def test_valid_api_mode_strips_whitespace(self) -> None:
+        assert _parse_api_mode("  chat_completions  ") == "chat_completions"
+
+
+class TestParseApiModeRejectsInvalidValues:
+    """Unknown ``api_mode`` values must return None *and* log a warning."""
+
+    @pytest.mark.parametrize(
+        "raw",
+        [None, 123, [], {}, object()],
+        ids=["none", "int", "list", "dict", "object"],
+    )
+    def test_non_string_returns_none_silently(
+        self, raw: Any, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        caplog.set_level(logging.WARNING, logger="hermes_cli.runtime_provider")
+        assert _parse_api_mode(raw) is None
+        # Non-strings are not a config typo to warn about — leave silent.
+        assert caplog.records == []
+
+    @pytest.mark.parametrize("raw", ["", "   ", "\n\t"])
+    def test_empty_string_returns_none_silently(
+        self, raw: str, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        caplog.set_level(logging.WARNING, logger="hermes_cli.runtime_provider")
+        assert _parse_api_mode(raw) is None
+        assert caplog.records == []
+
+    def test_gemini_alias_warns_with_specific_hint(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """The exact failure mode in #30152: api_mode: gemini in config."""
+        caplog.set_level(logging.WARNING, logger="hermes_cli.runtime_provider")
+        assert _parse_api_mode("gemini") is None
+        assert len(caplog.records) == 1
+        rec = caplog.records[0]
+        msg = rec.getMessage()
+        assert "gemini" in msg
+        assert "chat_completions" in msg
+        # Both correct alternatives must be present so the operator can
+        # pick the right one without re-reading the issue.
+        assert "aiplatform.googleapis.com" in msg
+        assert "generativelanguage.googleapis.com" in msg
+
+    def test_gemini_alias_warns_uppercase_too(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        caplog.set_level(logging.WARNING, logger="hermes_cli.runtime_provider")
+        assert _parse_api_mode("GEMINI") is None
+        assert any("gemini" in r.getMessage().lower() for r in caplog.records)
+
+    @pytest.mark.parametrize(
+        "alias,expected_in_hint",
+        [
+            ("openai", "chat_completions"),
+            ("anthropic", "anthropic_messages"),
+            ("bedrock", "bedrock_converse"),
+            ("codex", "codex_responses"),
+            ("google", "chat_completions"),
+        ],
+    )
+    def test_known_aliases_get_specific_hints(
+        self,
+        alias: str,
+        expected_in_hint: str,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        caplog.set_level(logging.WARNING, logger="hermes_cli.runtime_provider")
+        assert _parse_api_mode(alias) is None
+        joined = " ".join(r.getMessage() for r in caplog.records)
+        assert expected_in_hint in joined
+
+    def test_unknown_value_lists_all_valid_modes(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        caplog.set_level(logging.WARNING, logger="hermes_cli.runtime_provider")
+        assert _parse_api_mode("not_a_real_mode") is None
+        assert len(caplog.records) == 1
+        msg = caplog.records[0].getMessage()
+        for mode in _VALID_API_MODES:
+            assert mode in msg
+
+    def test_warning_does_not_double_log(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Repeated parsing must not silently accumulate handlers; one
+        call → exactly one warning record."""
+        caplog.set_level(logging.WARNING, logger="hermes_cli.runtime_provider")
+        _parse_api_mode("gemini")
+        assert len(caplog.records) == 1
+
+
+class TestAliasTableInvariants:
+    """The alias table must not list any value that is already valid —
+    otherwise the warning would fire for a perfectly legal config."""
+
+    def test_aliases_disjoint_from_valid_modes(self) -> None:
+        assert set(_API_MODE_ALIASES) & _VALID_API_MODES == set()
+
+
+# ──────────────────────────────────────────────────────────────────────
+# _base_url_has_vertex_action_verb / _validate_base_url_for_openai_sdk
+# ──────────────────────────────────────────────────────────────────────
+_VERTEX_BASE = (
+    "https://aiplatform.googleapis.com/v1/projects/anolasco-gemini"
+    "/locations/global/publishers/google/models"
+    "/gemini-3.1-pro-preview-customtools"
+)
+
+
+class TestBaseUrlActionVerbDetection:
+    """``_base_url_has_vertex_action_verb`` must spot every Vertex
+    action verb that the OpenAI SDK would silently corrupt."""
+
+    @pytest.mark.parametrize("verb", _VERTEX_ACTION_VERBS)
+    def test_each_verb_is_detected(self, verb: str) -> None:
+        url = f"{_VERTEX_BASE}{verb}"
+        assert _base_url_has_vertex_action_verb(url) == verb
+
+    def test_trailing_slash_is_ignored(self) -> None:
+        """The reporter's actual log shows ``.../:generateContent/`` —
+        the trailing slash injected by the OpenAI SDK must still match
+        so we can diagnose post-mortem URLs too."""
+        url = f"{_VERTEX_BASE}:generateContent/"
+        assert _base_url_has_vertex_action_verb(url) == ":generateContent"
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            None,
+            "",
+            "   ",
+            123,
+            "https://api.openai.com/v1",
+            "https://api.anthropic.com",
+            "https://generativelanguage.googleapis.com/v1beta",
+            "https://aiplatform.googleapis.com/v1/projects/p/locations/l/endpoints/openapi",
+        ],
+    )
+    def test_safe_inputs_return_none(self, url: Any) -> None:
+        assert _base_url_has_vertex_action_verb(url) is None
+
+    def test_verb_must_be_a_suffix(self) -> None:
+        """A URL containing ``:generateContent`` in the middle (e.g. a
+        query string) must NOT be flagged — only tail-suffix matters."""
+        url = "https://example.com/api?action=:generateContent&model=x"
+        assert _base_url_has_vertex_action_verb(url) is None
+
+
+class TestValidateBaseUrlForOpenAiSdk:
+    """The init-time tripwire from #30152."""
+
+    def test_clean_base_url_passes(self) -> None:
+        _validate_base_url_for_openai_sdk(
+            base_url="https://api.openai.com/v1", provider="openai"
+        )
+
+    def test_empty_inputs_pass(self) -> None:
+        _validate_base_url_for_openai_sdk(base_url=None)
+        _validate_base_url_for_openai_sdk(base_url="")
+
+    def test_vertex_action_url_raises_with_actionable_message(self) -> None:
+        url = f"{_VERTEX_BASE}:generateContent"
+        with pytest.raises(ValueError) as ei:
+            _validate_base_url_for_openai_sdk(
+                base_url=url, provider="vertex-gemini-pro-customtools"
+            )
+        msg = str(ei.value)
+        # 1) the issue number is cited so operators can find context.
+        assert "#30152" in msg or "30152" in msg
+        # 2) the offending URL is echoed back verbatim.
+        assert url in msg
+        # 3) the offending verb is named.
+        assert ":generateContent" in msg
+        # 4) both correct alternatives are spelled out.
+        assert "aiplatform.googleapis.com" in msg
+        assert "/endpoints/openapi" in msg
+        assert "generativelanguage.googleapis.com" in msg
+        # 5) the provider context is included in the error.
+        assert "vertex-gemini-pro-customtools" in msg
+
+    def test_provider_is_optional_in_error_message(self) -> None:
+        url = f"{_VERTEX_BASE}:streamGenerateContent"
+        with pytest.raises(ValueError) as ei:
+            _validate_base_url_for_openai_sdk(base_url=url)
+        assert ":streamGenerateContent" in str(ei.value)
+
+    @pytest.mark.parametrize("verb", _VERTEX_ACTION_VERBS)
+    def test_every_vertex_verb_raises(self, verb: str) -> None:
+        url = f"{_VERTEX_BASE}{verb}"
+        with pytest.raises(ValueError):
+            _validate_base_url_for_openai_sdk(base_url=url)
+
+
+# ──────────────────────────────────────────────────────────────────────
+# End-to-end: agent_init must surface the tripwire as a startup error
+# ──────────────────────────────────────────────────────────────────────
+class TestAgentInitWiresUpTripwire:
+    """``initialize_agent`` must call the tripwire so the operator sees
+    a clear startup error instead of the cryptic 404 fallback cascade."""
+
+    @pytest.fixture
+    def fake_agent(self) -> SimpleNamespace:
+        agent = SimpleNamespace()
+        agent._get_transport = lambda: None
+        return agent
+
+    def test_chat_completions_with_generateContent_url_raises(
+        self, fake_agent: SimpleNamespace
+    ) -> None:
+        from agent import agent_init
+
+        url = f"{_VERTEX_BASE}:generateContent"
+        with pytest.raises(ValueError) as ei:
+            # ``initialize_agent`` has a huge signature; we only need to
+            # drive the api_mode + base_url branch, so we hit the
+            # helper via the same code path agent_init uses.
+            from hermes_cli.runtime_provider import (
+                _validate_base_url_for_openai_sdk,
+            )
+            _validate_base_url_for_openai_sdk(
+                base_url=url, provider="vertex"
+            )
+        # Sanity: the helper is the same one agent_init.py imports.
+        msg = str(ei.value)
+        assert ":generateContent" in msg
+        # And the symbol must be importable from agent_init's import
+        # site — guards against accidental rename / dead-code removal.
+        from hermes_cli import runtime_provider as rp
+        assert callable(rp._validate_base_url_for_openai_sdk)
+
+    def test_helper_is_imported_by_agent_init(self) -> None:
+        """Read the source of agent_init to make sure the tripwire
+        import line is still there (and didn't get reverted)."""
+        import inspect
+
+        from agent import agent_init
+
+        src = inspect.getsource(agent_init)
+        assert "_validate_base_url_for_openai_sdk" in src
+        assert "#30152" in src


### PR DESCRIPTION
## Description

Fixes #30152.

When an operator wrote a provider config like

```yaml
providers:
  vertex-gemini-pro-customtools:
    api_mode: gemini
    base_url: https://aiplatform.googleapis.com/v1/projects/<PROJECT>/locations/global/publishers/google/models/gemini-3.1-pro-preview-customtools:generateContent
```

Hermes silently routed every request through the OpenAI SDK and got HTTP 404 on every call with no actionable signal in the gateway log — only a fallback cascade.

Two compounding bugs caused this:

1. `hermes_cli/runtime_provider.py::_parse_api_mode` silently dropped any string outside `_VALID_API_MODES` (returned `None`), so `api_mode: gemini` fell through to autodetect → `chat_completions`. The operator had no way to know their `api_mode` value was bogus.
2. The OpenAI SDK normalises any `base_url` to end with `/` before concatenating `/chat/completions`. When the operator pasted a full Vertex AI action URL (`.../models/<m>:generateContent`) into `base_url`, the resulting `:generateContent/chat/completions` returned HTTP 404.

This PR adds two safety nets so the operator sees the actual misconfiguration immediately at startup instead of after a fallback cascade in production:

* **`_parse_api_mode` warns on unrecognised values.** Known aliases (`gemini`, `openai`, `anthropic`, `bedrock`, `codex`, `google`) get a specific hint that names the correct `api_mode` *and* the matching `base_url` form. Unknown strings get the full valid-mode list. Non-string / empty inputs stay silent because they're legitimate "value absent" signals from upstream.
* **`_validate_base_url_for_openai_sdk` rejects Vertex action-verb base_urls at init.** Called from `agent/agent_init.py` when `api_mode` lands on `chat_completions`. Recognises every Vertex action verb (`:generateContent`, `:streamGenerateContent`, `:countTokens`, `:embedContent`, `:batchEmbedContents`, `:predict`, `:rawPredict`, `:serverStreamingPredict`) — including the trailing slash variant that appears in the bug report's log line — and raises `ValueError` with the two supported alternatives spelled out:
  - **(a)** Vertex OpenAI-compatible endpoint: `https://aiplatform.googleapis.com/v1/projects/<PROJECT>/locations/<LOC>/endpoints/openapi` + `api_mode: chat_completions`.
  - **(b)** Google AI Studio native API: `https://generativelanguage.googleapis.com/v1beta` + `api_mode: chat_completions` (Hermes already auto-routes through `agent/gemini_native_adapter.py`).

This matches the workaround the reporter verified in the issue (option (a)).

Both safety nets are conservative: behaviour for any valid config (`api_mode` in the allowlist, or `base_url` without an action verb) is byte-identical. Only previously broken configs change — they now fail loudly at startup instead of silently 404'ing in production.

## Test plan

- [x] 57 new unit tests in `tests/hermes_cli/test_api_mode_validation_30152.py`:
  - Every value in `_VALID_API_MODES` round-trips with zero warnings (positive control).
  - The literal alias from the bug report (`api_mode: gemini`, both cases) produces exactly **one** WARNING whose text names `chat_completions` and both correct `base_url` alternatives.
  - Other known aliases (`openai`, `anthropic`, `bedrock`, `codex`, `google`) each receive a hint pointing at the right mode.
  - Non-string / empty inputs return `None` silently.
  - `_API_MODE_ALIASES` is disjoint from `_VALID_API_MODES` (warning never fires for a legal config).
  - Every Vertex action verb is detected as a suffix; the trailing slash injected by the OpenAI SDK is ignored; mid-string occurrences are **not** flagged (no false positives on query strings).
  - The tripwire raises `ValueError` on every action verb, echoes the URL + verb verbatim, cites #30152, and spells out both supported alternatives.
  - The `agent_init.py` import + call site is guarded by an inspection test so it can't be silently reverted.
- [x] `pytest tests/hermes_cli/test_runtime_provider_resolution.py tests/hermes_cli/test_api_mode_validation_30152.py` → **182 passed**.
- [x] Wider sweep `pytest tests/hermes_cli/test_model_validation.py tests/cli/test_cli_provider_resolution.py tests/run_agent/test_run_agent.py tests/agent/test_gemini_native_adapter.py tests/agent/test_gemini_cloudcode.py tests/agent/transports/test_codex_app_server_runtime.py` → **565 passed**.
- [x] Manual repro: instantiating `_parse_api_mode("gemini")` now prints the actionable warning; instantiating `_validate_base_url_for_openai_sdk(base_url=":generateContent URL")` now raises `ValueError` with the workaround spelled out.

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas (only where intent is non-obvious; mechanical narration avoided).
- [x] I have made corresponding changes to the documentation (N/A — error message itself is the documentation, and it cites #30152).
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective.
- [x] New and existing unit tests pass locally with my changes.