### PR TITLE
fix: upstream local reliability hardening

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -998,26 +998,41 @@ class MessageEvent:
         """Check if this is a command message (e.g., /new, /reset)."""
         return self.text.startswith("/")
     
-    def get_command(self) -> Optional[str]:
-        """Extract command name if this is a command message."""
+    def _split_command_text(self) -> tuple[Optional[str], str]:
+        """Return ``(command, args)`` for slash commands.
+
+        Humans sometimes type ``/ restart`` or ``/ reload-mcp`` on mobile.
+        Treat that as the intended slash command instead of sending the text
+        through the LLM. A bare slash still returns an empty command, matching
+        the historical behavior used by tests and unknown-command handling.
+        """
         if not self.is_command():
-            return None
-        # Split on space and get first word, strip the /
-        parts = self.text.split(maxsplit=1)
-        raw = parts[0][1:].lower() if parts else None
+            return None, self.text
+
+        body = self.text[1:]
+        # Tolerate whitespace after the slash before the command name.
+        body = body.lstrip()
+        if not body:
+            return "", ""
+
+        parts = body.split(maxsplit=1)
+        raw = parts[0].lower()
+        args = parts[1] if len(parts) > 1 else ""
         if raw and "@" in raw:
             raw = raw.split("@", 1)[0]
         # Reject file paths: valid command names never contain /
         if raw and "/" in raw:
-            return None
+            return None, args
+        return raw, args
+
+    def get_command(self) -> Optional[str]:
+        """Extract command name if this is a command message."""
+        raw, _ = self._split_command_text()
         return raw
     
     def get_command_args(self) -> str:
         """Get the arguments after a command."""
-        if not self.is_command():
-            return self.text
-        parts = self.text.split(maxsplit=1)
-        args = parts[1] if len(parts) > 1 else ""
+        _, args = self._split_command_text()
         # iOS auto-corrects -- to — (em dash) and - to – (en dash)
         args = args.replace("\u2014\u2014", "--").replace("\u2014", "--").replace("\u2013", "-")
         return args

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -4,6 +4,7 @@ Doctor command for hermes CLI.
 Diagnoses issues with Hermes Agent setup.
 """
 
+import json
 import os
 import sys
 import subprocess
@@ -195,6 +196,191 @@ def check_info(text: str):
     print(f"    {color('→', Colors.CYAN)} {text}")
 
 
+def _operator_home_channels_from_env() -> list[str]:
+    """Return platform names with a configured cron/gateway home target."""
+    try:
+        from cron.scheduler import _HOME_TARGET_ENV_VARS, _LEGACY_HOME_TARGET_ENV_VARS
+    except Exception:
+        _HOME_TARGET_ENV_VARS = {
+            "matrix": "MATRIX_HOME_ROOM",
+            "telegram": "TELEGRAM_HOME_CHANNEL",
+            "discord": "DISCORD_HOME_CHANNEL",
+            "slack": "SLACK_HOME_CHANNEL",
+            "signal": "SIGNAL_HOME_CHANNEL",
+            "mattermost": "MATTERMOST_HOME_CHANNEL",
+            "sms": "SMS_HOME_CHANNEL",
+            "email": "EMAIL_HOME_ADDRESS",
+            "dingtalk": "DINGTALK_HOME_CHANNEL",
+            "feishu": "FEISHU_HOME_CHANNEL",
+            "wecom": "WECOM_HOME_CHANNEL",
+            "weixin": "WEIXIN_HOME_CHANNEL",
+            "bluebubbles": "BLUEBUBBLES_HOME_CHANNEL",
+            "qqbot": "QQBOT_HOME_CHANNEL",
+            "whatsapp": "WHATSAPP_HOME_CHANNEL",
+        }
+        _LEGACY_HOME_TARGET_ENV_VARS = {"QQBOT_HOME_CHANNEL": "QQ_HOME_CHANNEL"}
+
+    configured: list[str] = []
+    for platform, env_var in sorted(_HOME_TARGET_ENV_VARS.items()):
+        value = os.getenv(env_var, "").strip()
+        if not value:
+            legacy = _LEGACY_HOME_TARGET_ENV_VARS.get(env_var)
+            if legacy:
+                value = os.getenv(legacy, "").strip()
+        if value:
+            configured.append(platform)
+    return configured
+
+
+def _operator_cron_job_counts(hermes_home: Path | None = None) -> tuple[int, int]:
+    """Return (enabled_jobs, total_jobs) without mutating cron storage."""
+    home = hermes_home or HERMES_HOME
+    jobs_file = home / "cron" / "jobs.json"
+    if not jobs_file.exists():
+        return 0, 0
+    try:
+        payload = json.loads(jobs_file.read_text(encoding="utf-8"), strict=False)
+    except Exception:
+        return 0, 0
+    jobs = payload.get("jobs", []) if isinstance(payload, dict) else []
+    if not isinstance(jobs, list):
+        return 0, 0
+    total = len([j for j in jobs if isinstance(j, dict)])
+    enabled = len([
+        j for j in jobs
+        if isinstance(j, dict)
+        and j.get("enabled", True)
+        and j.get("state", "scheduled") != "paused"
+    ])
+    return enabled, total
+
+
+def _operator_auxiliary_summary(config: dict) -> tuple[list[str], list[str]]:
+    """Return (configured_tasks, auto_or_unset_tasks) for latency-sensitive aux tasks."""
+    aux = config.get("auxiliary") if isinstance(config, dict) else {}
+    if not isinstance(aux, dict):
+        aux = {}
+    latency_sensitive = (
+        "web_extract",
+        "compression",
+        "session_search",
+        "approval",
+        "title_generation",
+        "mcp",
+    )
+    configured: list[str] = []
+    auto_or_unset: list[str] = []
+    for task in latency_sensitive:
+        task_cfg = aux.get(task)
+        if not isinstance(task_cfg, dict):
+            auto_or_unset.append(task)
+            continue
+        provider = str(task_cfg.get("provider") or "").strip()
+        model = str(task_cfg.get("model") or "").strip()
+        base_url = str(task_cfg.get("base_url") or "").strip()
+        if base_url or (provider and provider != "auto" and model):
+            configured.append(task)
+        else:
+            auto_or_unset.append(task)
+    return configured, auto_or_unset
+
+
+def _operator_reasoning_effort(config: dict) -> str:
+    agent = config.get("agent") if isinstance(config, dict) else {}
+    if not isinstance(agent, dict):
+        return "medium"
+    value = str(agent.get("reasoning_effort") or "").strip().lower()
+    return value or "medium"
+
+
+def run_operator_doctor(args=None) -> None:
+    """Focused readiness check for Hermes as an autonomous operator."""
+    print()
+    print(color("┌─────────────────────────────────────────────────────────┐", Colors.CYAN))
+    print(color("│              🧭 Hermes Operator Doctor                  │", Colors.CYAN))
+    print(color("└─────────────────────────────────────────────────────────┘", Colors.CYAN))
+    _section("Proactive execution")
+
+    try:
+        from hermes_cli.gateway import get_gateway_runtime_snapshot
+        snapshot = get_gateway_runtime_snapshot(system=getattr(args, "system", False))
+        if snapshot.running:
+            detail = f"({snapshot.manager}"
+            if snapshot.gateway_pids:
+                detail += f", pid(s): {', '.join(str(p) for p in snapshot.gateway_pids[:3])}"
+            detail += ")"
+            check_ok("Gateway running", detail)
+        elif snapshot.service_installed:
+            check_warn("Gateway service installed but not running", "(cron, Kanban dispatcher, and messaging delivery may be idle)")
+            check_info("Run: hermes gateway start")
+        else:
+            check_warn("Gateway service not installed/running", "(Hermes cannot work while you are away)")
+            check_info("Run: hermes gateway install && hermes gateway start")
+    except Exception as e:
+        check_warn("Could not inspect gateway runtime", f"({e})")
+
+    home_channels = _operator_home_channels_from_env()
+    if home_channels:
+        check_ok("Home channel configured", f"({', '.join(home_channels)})")
+    else:
+        check_warn("No home channel configured", "(scheduled work may have nowhere to report)")
+        check_info("In your preferred gateway chat, run: /sethome")
+
+    enabled_jobs, total_jobs = _operator_cron_job_counts()
+    if enabled_jobs:
+        check_ok("Cron jobs configured", f"({enabled_jobs} enabled, {total_jobs} total)")
+    else:
+        check_warn("No enabled cron jobs found", "(no recurring review/monitor loop)")
+        check_info("Create a review loop with: hermes cron create '0 7 * * 1-5' --name 'Morning review packet'")
+
+    try:
+        from hermes_cli.config import load_config
+        cfg = load_config()
+    except Exception as e:
+        cfg = {}
+        check_warn("Could not load config for operator tuning", f"({e})")
+
+    kanban_cfg = cfg.get("kanban") if isinstance(cfg, dict) else {}
+    dispatch_in_gateway = True if not isinstance(kanban_cfg, dict) else bool(kanban_cfg.get("dispatch_in_gateway", True))
+    if dispatch_in_gateway:
+        check_ok("Kanban dispatcher enabled in gateway")
+    else:
+        check_warn("Kanban dispatcher disabled in gateway", "(durable project work needs a separate dispatcher)")
+        check_info("Either run a separate dispatcher or set kanban.dispatch_in_gateway true")
+
+    _section("Speed and focus tuning")
+    reasoning = _operator_reasoning_effort(cfg)
+    if reasoning in {"high", "xhigh"}:
+        check_warn("Main reasoning effort is high", f"({reasoning}; good for hard review, slow for routine operator work)")
+        check_info("Use lower-effort profiles for routing/status work; reserve high/xhigh for reviewer tasks")
+    else:
+        check_ok("Main reasoning effort not over-tuned", f"({reasoning})")
+
+    configured_aux, auto_aux = _operator_auxiliary_summary(cfg)
+    if auto_aux:
+        check_warn("Latency-sensitive auxiliary tasks use auto/default routing", f"({', '.join(auto_aux)})")
+        check_info("Set fast auxiliary providers/models for web_extract, compression, session_search, approval, and title_generation")
+    else:
+        check_ok("Latency-sensitive auxiliary tasks explicitly routed", f"({', '.join(configured_aux)})")
+
+    try:
+        from hermes_cli.profiles import list_profiles
+        profiles = list_profiles()
+        if len(profiles) >= 2:
+            check_ok("Multiple profiles available", f"({len(profiles)} profiles for role splitting)")
+        else:
+            check_warn("Only one profile detected", "(consider operator/researcher/reviewer profiles for durable work)")
+    except Exception:
+        check_info("Could not inspect profiles; run: hermes profile list")
+
+    print()
+    print(color("Recommended operating loop:", Colors.BOLD))
+    print("  1. Put durable projects on Kanban, not just in chat.")
+    print("  2. Use cron for daily review packets and monitoring.")
+    print("  3. Use /goal for one long objective that should continue across turns.")
+    print("  4. Require final packets: status, evidence, decision points, risks, next action.")
+
+
 def _section(title: str) -> None:
     """Print a doctor section banner: blank line + bold cyan ◆ title."""
     print()
@@ -336,6 +522,10 @@ def _build_apikey_providers_list() -> list:
 
 def run_doctor(args):
     """Run diagnostic checks."""
+    if getattr(args, "operator", False):
+        run_operator_doctor(args)
+        return
+
     should_fix = getattr(args, 'fix', False)
     ack_target = getattr(args, 'ack', None)
 

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1220,7 +1220,6 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
         _add_column_if_missing(
             conn, "tasks", "session_id", "session_id TEXT"
         )
-
     # Indexes over additive ``tasks`` columns must be created after the
     # columns exist. Keeping them in SCHEMA_SQL breaks legacy boards: SQLite
     # parses each statement in ``executescript`` against the live schema, so a
@@ -5762,6 +5761,11 @@ def _to_epoch(val) -> Optional[int]:
         return int(dt.timestamp())
     except (ValueError, OSError):
         return None
+
+
+def _safe_int(val) -> Optional[int]:
+    """Backwards-compatible integer timestamp parser used by task_age."""
+    return _to_epoch(val)
 
 
 def task_age(task: Task) -> dict:

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -11850,6 +11850,11 @@ def main():
         "--fix", action="store_true", help="Attempt to fix issues automatically"
     )
     doctor_parser.add_argument(
+        "--operator",
+        action="store_true",
+        help="Check autonomous-operator readiness (gateway, cron, Kanban, and speed tuning)",
+    )
+    doctor_parser.add_argument(
         "--ack",
         metavar="ADVISORY_ID",
         default=None,

--- a/plugins/web/jina/__init__.py
+++ b/plugins/web/jina/__init__.py
@@ -1,0 +1,15 @@
+"""Jina AI Reader extraction plugin.
+
+Uses Jina Reader (https://r.jina.ai/) to fetch markdown-ish page content by
+prefixing the target URL. No API key is required, so this is a good local-first
+fallback for web_extract when paid extract backends are absent or invalid.
+"""
+
+from __future__ import annotations
+
+from plugins.web.jina.provider import JinaWebExtractProvider
+
+
+def register(ctx) -> None:
+    """Register the Jina extract provider with the plugin context."""
+    ctx.register_web_search_provider(JinaWebExtractProvider())

--- a/plugins/web/jina/plugin.yaml
+++ b/plugins/web/jina/plugin.yaml
@@ -1,0 +1,7 @@
+name: web-jina
+version: 1.0.0
+description: "Jina AI Reader web extraction — no API key required."
+author: NousResearch
+kind: backend
+provides_web_providers:
+  - jina

--- a/plugins/web/jina/provider.py
+++ b/plugins/web/jina/provider.py
@@ -1,0 +1,107 @@
+"""Jina AI Reader web extraction provider.
+
+Jina Reader turns a public web page into plain markdown-like text. It is
+extract-only (no search/crawl) and requires no API key.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, List
+from urllib.parse import quote, urlparse
+
+from agent.web_search_provider import WebSearchProvider
+
+logger = logging.getLogger(__name__)
+
+
+class JinaWebExtractProvider(WebSearchProvider):
+    """No-key extract provider backed by https://r.jina.ai/."""
+
+    @property
+    def name(self) -> str:
+        return "jina"
+
+    @property
+    def display_name(self) -> str:
+        return "Jina Reader"
+
+    def is_available(self) -> bool:
+        """Jina Reader is network-only and needs no local credentials."""
+        return True
+
+    def supports_search(self) -> bool:
+        return False
+
+    def supports_extract(self) -> bool:
+        return True
+
+    def extract(self, urls: List[str], **kwargs: Any) -> List[Dict[str, Any]]:
+        """Extract URL content through Jina Reader.
+
+        Return the legacy list-of-documents shape consumed by
+        tools.web_tools.web_extract_tool.
+        """
+        import httpx
+
+        timeout = float(kwargs.get("timeout") or 60)
+        documents: List[Dict[str, Any]] = []
+        with httpx.Client(timeout=timeout, follow_redirects=True) as client:
+            for url in urls:
+                try:
+                    reader_url = self._reader_url(url)
+                    response = client.get(reader_url, headers={"Accept": "text/plain"})
+                    response.raise_for_status()
+                    content = response.text.strip()
+                    documents.append(
+                        {
+                            "url": url,
+                            "title": self._title_from_content(content),
+                            "content": content,
+                            "raw_content": content,
+                            "metadata": {"sourceURL": url, "provider": "jina", "readerURL": reader_url},
+                        }
+                    )
+                except Exception as exc:  # noqa: BLE001 — provider boundary
+                    logger.warning("Jina extract error for %s: %s", url, exc)
+                    documents.append(
+                        {
+                            "url": url,
+                            "title": "",
+                            "content": "",
+                            "raw_content": "",
+                            "error": f"Jina extract failed: {exc}",
+                            "metadata": {"sourceURL": url, "provider": "jina"},
+                        }
+                    )
+        return documents
+
+    @staticmethod
+    def _reader_url(url: str) -> str:
+        parsed = urlparse(url)
+        if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+            raise ValueError(f"Unsupported URL for Jina Reader: {url}")
+        # Jina Reader accepts the target URL as the path following /http://.
+        # Quote only characters that would break the reader URL path while
+        # preserving the target URL's own scheme separators and query syntax.
+        return "https://r.jina.ai/http://" + quote(url, safe=":/?#[]@!$&'()*+,;=%")
+
+    @staticmethod
+    def _title_from_content(content: str) -> str:
+        for line in content.splitlines():
+            stripped = line.strip()
+            if not stripped:
+                continue
+            if stripped.startswith("Title:"):
+                return stripped.partition(":")[2].strip()
+            if stripped.startswith("#"):
+                return stripped.lstrip("#").strip()
+        return ""
+
+    def get_setup_schema(self) -> Dict[str, Any]:
+        return {
+            "name": "Jina Reader",
+            "badge": "free · no key · extract only",
+            "tag": "Extract page content through r.jina.ai without an API key (pair with any search provider)",
+            "env_vars": [],
+        }

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -92,6 +92,14 @@ class TestMessageEventGetCommand:
         event = MessageEvent(text="/")
         assert event.get_command() == ""
 
+    def test_mobile_space_after_slash_command(self):
+        event = MessageEvent(text="/ reload-mcp")
+        assert event.get_command() == "reload-mcp"
+
+    def test_mobile_space_after_slash_command_with_args(self):
+        event = MessageEvent(text="/ model openai/gpt-5.5")
+        assert event.get_command() == "model"
+
     def test_command_with_at_botname(self):
         event = MessageEvent(text="/new@TigerNanoBot")
         assert event.get_command() == "new"
@@ -117,6 +125,10 @@ class TestMessageEventGetCommandArgs:
     def test_not_a_command_returns_full_text(self):
         event = MessageEvent(text="hello world")
         assert event.get_command_args() == "hello world"
+
+    def test_mobile_space_after_slash_command_args(self):
+        event = MessageEvent(text="/ reload-mcp now")
+        assert event.get_command_args() == "now"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -14,6 +14,7 @@ import hermes_cli.doctor as doctor
 import hermes_cli.gateway as gateway_cli
 from hermes_cli import doctor as doctor_mod
 from hermes_cli.doctor import _has_provider_env_config
+from hermes_cli.gateway import GatewayRuntimeSnapshot
 
 
 class TestDoctorPlatformHints:
@@ -49,6 +50,90 @@ class TestProviderEnvDetection:
     def test_returns_false_when_no_provider_settings(self):
         content = "TERMINAL_ENV=local\n"
         assert not _has_provider_env_config(content)
+
+
+class TestOperatorDoctor:
+    def test_cron_job_counts_ignore_disabled_and_paused_jobs(self, tmp_path):
+        cron_dir = tmp_path / "cron"
+        cron_dir.mkdir()
+        (cron_dir / "jobs.json").write_text(
+            '{"jobs": ['
+            '{"id": "enabled"},'
+            '{"id": "disabled", "enabled": false},'
+            '{"id": "paused", "state": "paused"}'
+            ']}'
+        )
+
+        assert doctor._operator_cron_job_counts(tmp_path) == (1, 3)
+
+    def test_operator_doctor_reports_readiness_gaps(self, monkeypatch, tmp_path, capsys):
+        cron_dir = tmp_path / "cron"
+        cron_dir.mkdir()
+        (cron_dir / "jobs.json").write_text(
+            '{"jobs": [{"id": "morning", "enabled": true, "state": "scheduled"}]}'
+        )
+        monkeypatch.setattr(doctor_mod, "HERMES_HOME", tmp_path)
+        monkeypatch.setenv("TELEGRAM_HOME_CHANNEL", "12345")
+        monkeypatch.delenv("DISCORD_HOME_CHANNEL", raising=False)
+        monkeypatch.setattr(
+            gateway_cli,
+            "get_gateway_runtime_snapshot",
+            lambda system=False: GatewayRuntimeSnapshot(
+                manager="launchd",
+                service_installed=True,
+                service_running=False,
+                gateway_pids=(),
+            ),
+        )
+        config_mod = __import__("hermes_cli.config", fromlist=["load_config"])
+        monkeypatch.setattr(
+            config_mod,
+            "load_config",
+            lambda: {
+                "agent": {"reasoning_effort": "xhigh"},
+                "kanban": {"dispatch_in_gateway": False},
+                "auxiliary": {
+                    "web_extract": {"provider": "auto", "model": ""},
+                    "compression": {"provider": "fast", "model": "tiny"},
+                    "session_search": {},
+                    "approval": {"base_url": "http://127.0.0.1:8000/v1"},
+                    "title_generation": {"provider": "", "model": ""},
+                    "mcp": {"provider": "fast", "model": "tiny"},
+                },
+            },
+        )
+        monkeypatch.setitem(
+            sys.modules,
+            "hermes_cli.profiles",
+            types.SimpleNamespace(list_profiles=lambda: ["operator"]),
+        )
+
+        doctor_mod.run_operator_doctor(Namespace(system=False))
+
+        out = capsys.readouterr().out
+        assert "Hermes Operator Doctor" in out
+        assert "Gateway service installed but not running" in out
+        assert "Home channel configured" in out
+        assert "telegram" in out
+        assert "Cron jobs configured" in out
+        assert "1 enabled, 1 total" in out
+        assert "Kanban dispatcher disabled in gateway" in out
+        assert "Main reasoning effort is high" in out
+        assert "xhigh" in out
+        assert "Latency-sensitive auxiliary tasks use auto/default routing" in out
+        assert "web_extract" in out
+        assert "session_search" in out
+        assert "title_generation" in out
+        assert "12345" not in out
+
+
+def test_run_doctor_delegates_operator_mode(monkeypatch):
+    seen = {}
+    monkeypatch.setattr(doctor_mod, "run_operator_doctor", lambda args: seen.setdefault("operator", args.operator))
+
+    doctor_mod.run_doctor(Namespace(operator=True, fix=False))
+
+    assert seen == {"operator": True}
 
 
 class TestDoctorEnvFileEncoding:

--- a/tests/hermes_cli/test_kanban_db_init.py
+++ b/tests/hermes_cli/test_kanban_db_init.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import sqlite3
 import threading
 from pathlib import Path
 
@@ -36,3 +37,62 @@ def test_connect_initialization_is_thread_safe(tmp_path, monkeypatch):
     with kb.connect(board="default") as conn:
         cols = {row["name"] for row in conn.execute("PRAGMA table_info(tasks)")}
     assert "max_retries" in cols
+
+
+def test_legacy_tasks_table_without_session_id_migrates(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+    db_path = kb.kanban_db_path(board="default")
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.execute(
+            """
+            CREATE TABLE tasks (
+                id TEXT PRIMARY KEY,
+                title TEXT NOT NULL,
+                body TEXT,
+                assignee TEXT,
+                status TEXT NOT NULL,
+                priority INTEGER NOT NULL DEFAULT 0,
+                created_by TEXT,
+                created_at INTEGER NOT NULL,
+                started_at INTEGER,
+                completed_at INTEGER,
+                workspace_kind TEXT,
+                workspace_path TEXT,
+                claim_lock TEXT,
+                claim_expires INTEGER,
+                tenant TEXT,
+                result TEXT,
+                idempotency_key TEXT,
+                consecutive_failures INTEGER NOT NULL DEFAULT 0,
+                worker_pid INTEGER,
+                last_failure_error TEXT,
+                max_runtime_seconds INTEGER,
+                last_heartbeat_at INTEGER,
+                current_run_id INTEGER,
+                workflow_template_id TEXT,
+                current_step_key TEXT,
+                skills TEXT,
+                max_retries INTEGER
+            )
+            """
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    kb._INITIALIZED_PATHS.discard(str(db_path.resolve()))
+    kb.init_db(board="default")
+
+    with kb.connect(board="default") as migrated:
+        cols = {row["name"] for row in migrated.execute("PRAGMA table_info(tasks)")}
+        indexes = {
+            row["name"] for row in migrated.execute("PRAGMA index_list(tasks)")
+        }
+    assert "session_id" in cols
+    assert "idx_tasks_session_id" in indexes

--- a/tests/plugins/web/test_web_search_provider_plugins.py
+++ b/tests/plugins/web/test_web_search_provider_plugins.py
@@ -71,23 +71,24 @@ def _isolate_env(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 class TestBundledPluginsRegister:
-    """All eight bundled web plugins discover and register correctly."""
+    """Bundled web plugins discover and register correctly."""
 
-    def test_all_seven_plugins_present_in_registry(self) -> None:
+    def test_core_plugins_present_in_registry(self) -> None:
         _ensure_plugins_loaded()
         from agent.web_search_registry import list_providers
 
-        names = sorted(p.name for p in list_providers())
-        assert names == [
+        names = {p.name for p in list_providers()}
+        assert {
             "brave-free",
             "ddgs",
             "exa",
             "firecrawl",
+            "jina",
             "parallel",
             "searxng",
             "tavily",
             "xai",
-        ]
+        }.issubset(names)
 
     @pytest.mark.parametrize(
         "plugin_name,expected_search,expected_extract,expected_crawl",
@@ -98,6 +99,7 @@ class TestBundledPluginsRegister:
             ("exa", True, True, False),
             ("parallel", True, True, False),
             ("tavily", True, True, True),
+            ("jina", False, True, False),
             # firecrawl: search + extract + crawl. Crawl was originally
             # disabled in the migration (fell through to a legacy inline
             # path); the follow-up commit enabled it natively.
@@ -124,7 +126,7 @@ class TestBundledPluginsRegister:
 
     @pytest.mark.parametrize(
         "plugin_name",
-        ["brave-free", "ddgs", "searxng", "exa", "parallel", "tavily", "firecrawl", "xai"],
+        ["brave-free", "ddgs", "searxng", "exa", "parallel", "tavily", "firecrawl", "xai", "jina"],
     )
     def test_each_plugin_has_name_and_display_name(self, plugin_name: str) -> None:
         _ensure_plugins_loaded()
@@ -137,7 +139,7 @@ class TestBundledPluginsRegister:
 
     @pytest.mark.parametrize(
         "plugin_name",
-        ["brave-free", "ddgs", "searxng", "exa", "parallel", "tavily", "firecrawl", "xai"],
+        ["brave-free", "ddgs", "searxng", "exa", "parallel", "tavily", "firecrawl", "xai", "jina"],
     )
     def test_each_plugin_has_setup_schema(self, plugin_name: str) -> None:
         """``get_setup_schema()`` returns a dict the picker can consume."""
@@ -158,7 +160,7 @@ class TestBundledPluginsRegister:
 
 
 class TestIsAvailable:
-    """Each plugin's ``is_available()`` returns False without env config."""
+    """Each plugin's ``is_available()`` reflects its actual setup requirements."""
 
     def test_brave_free_requires_api_key(self, monkeypatch: pytest.MonkeyPatch) -> None:
         _ensure_plugins_loaded()
@@ -228,7 +230,7 @@ class TestIsAvailable:
         assert p.is_available() is True
 
     def test_ddgs_always_available_when_package_importable(self) -> None:
-        """DDGS is the always-on fallback — no API key required.
+        """DDGS is a no-key fallback gated by the optional package import.
 
         It may report unavailable if the ``ddgs`` package itself isn't
         installed in the env (legitimate — the plugin's post_setup hook
@@ -252,6 +254,15 @@ class TestIsAvailable:
         assert p is not None
         assert p.is_available() is False  # no XAI_API_KEY, no auth.json
         monkeypatch.setenv("XAI_API_KEY", "real")
+        assert p.is_available() is True
+
+    def test_jina_reader_requires_no_local_credentials(self) -> None:
+        """Jina Reader is extract-only and available without API keys."""
+        _ensure_plugins_loaded()
+        from agent.web_search_registry import get_provider
+
+        p = get_provider("jina")
+        assert p is not None
         assert p.is_available() is True
 
 

--- a/tests/tools/test_schema_sanitizer.py
+++ b/tests/tools/test_schema_sanitizer.py
@@ -144,6 +144,27 @@ def test_well_formed_schema_unchanged():
     assert out[0]["function"]["parameters"] == schema
 
 
+def test_boolean_numeric_validation_keywords_are_dropped():
+    """Osaurus MCP emitted ``minimum: false``; strict backends require numbers."""
+    tools = [_tool("mcp_osaurus_schedule_next_run", {
+        "type": "object",
+        "properties": {
+            "in_seconds": {
+                "type": "integer",
+                "minimum": False,
+                "exclusiveMinimum": False,
+                "maximum": 3600,
+            },
+        },
+    })]
+
+    out = sanitize_tool_schemas(tools)
+    prop = out[0]["function"]["parameters"]["properties"]["in_seconds"]
+    assert "minimum" not in prop
+    assert "exclusiveMinimum" not in prop
+    assert prop["maximum"] == 3600
+
+
 def test_additional_properties_bool_preserved():
     tools = [_tool("t", {
         "type": "object",

--- a/tests/tools/test_web_providers.py
+++ b/tests/tools/test_web_providers.py
@@ -301,25 +301,19 @@ class TestUnconfiguredErrorEnvelopeParity:
         ):
             monkeypatch.delenv(k, raising=False)
 
-    def test_unconfigured_search_emits_top_level_error(self, monkeypatch):
-        """``web_search_tool`` with no creds returns ``{"error": "Error searching web: ..."}``
-        — matching main's ``tool_error()`` envelope, not a per-result shape.
-        """
+    def test_unconfigured_search_uses_free_fallback_when_available(self, monkeypatch):
+        """``web_search_tool`` can use no-key search providers when installed."""
         import json
         from tools import web_tools
 
         self._clear_web_creds(monkeypatch)
-        # Reset firecrawl client cache so the unconfigured state is re-evaluated
         monkeypatch.setattr(web_tools, "_firecrawl_client", None, raising=False)
         monkeypatch.setattr(web_tools, "_firecrawl_client_config", None, raising=False)
         monkeypatch.setattr(web_tools, "_load_web_config", lambda: {})
 
         result = json.loads(web_tools.web_search_tool("hello world", limit=3))
-        assert "error" in result, f"expected top-level 'error' key, got {result}"
-        # ``Error searching web:`` prefix comes from web_tools' top-level except handler
-        assert "Error searching web:" in result["error"]
-        assert "FIRECRAWL_API_KEY" in result["error"]
-        # No per-result burying
+        assert result.get("success") is True, result
+        assert "web" in result.get("data", {})
         assert "results" not in result
 
     def test_unconfigured_crawl_emits_top_level_error(self, monkeypatch):
@@ -340,6 +334,6 @@ class TestUnconfiguredErrorEnvelopeParity:
         result = json.loads(asyncio.run(web_tools.web_crawl_tool("https://example.com", use_llm_processing=False)))
         assert result.get("success") is False
         assert "error" in result, f"expected top-level 'error' key, got {result}"
-        assert "web_crawl requires Firecrawl" in result["error"]
+        assert "search-only backend and cannot crawl" in result["error"]
         # Crucially: no per-page burying
         assert "results" not in result

--- a/tests/tools/test_web_tools_config.py
+++ b/tests/tools/test_web_tools_config.py
@@ -383,10 +383,18 @@ class TestBackendSelection:
              patch.dict(os.environ, {"FIRECRAWL_API_KEY": "fc-test"}):
             assert _get_backend() == "firecrawl"
 
-    def test_fallback_no_keys_defaults_to_firecrawl(self):
-        """No keys, no config → 'firecrawl' (will fail at client init)."""
+    def test_fallback_no_keys_uses_free_ddgs_when_installed(self):
+        """No keys, no config → free ddgs when the package is installed."""
         from tools.web_tools import _get_backend
-        with patch("tools.web_tools._load_web_config", return_value={}):
+        with patch("tools.web_tools._load_web_config", return_value={}), \
+             patch("tools.web_tools._ddgs_package_importable", return_value=True):
+            assert _get_backend() == "ddgs"
+
+    def test_fallback_no_keys_defaults_to_firecrawl_without_free_search_backend(self):
+        """No keys and no free search backend → 'firecrawl' backward-compatible default."""
+        from tools.web_tools import _get_backend
+        with patch("tools.web_tools._load_web_config", return_value={}), \
+             patch("tools.web_tools._ddgs_package_importable", return_value=False):
             assert _get_backend() == "firecrawl"
 
     def test_invalid_config_falls_through_to_fallback(self):
@@ -601,9 +609,14 @@ class TestCheckWebApiKey:
             from tools.web_tools import check_web_api_key
             assert check_web_api_key() is True
 
-    def test_no_keys_returns_false(self):
+    def test_no_keys_returns_true_for_free_backends(self):
         from tools.web_tools import check_web_api_key
-        assert check_web_api_key() is False
+        assert check_web_api_key() is True
+
+    def test_no_key_backend_can_be_selected_for_extract(self):
+        from tools.web_tools import _get_extract_backend
+        with patch("tools.web_tools._load_web_config", return_value={"extract_backend": "jina"}):
+            assert _get_extract_backend() == "jina"
 
     def test_both_keys_returns_true(self):
         with patch.dict(os.environ, {

--- a/tools/schema_sanitizer.py
+++ b/tools/schema_sanitizer.py
@@ -20,6 +20,10 @@ The failure modes we've seen in the wild:
 * ``anyOf`` / ``oneOf`` unions whose only purpose is to permit ``null`` for
   optional fields (common Pydantic/MCP shape). Anthropic rejects these at
   the top of ``input_schema``; collapse them to the non-null branch.
+* Numeric validation keywords (``minimum``, ``exclusiveMinimum``, etc.) whose
+  value is a boolean instead of a number. Some MCP servers emit legacy/buggy
+  shapes like ``minimum: false``; strict OpenAI-compatible backends reject the
+  entire tool list with ``False is not of type 'number'``.
 * Unconstrained ``additionalProperties`` on objects with empty properties.
 
 This module walks the final tool schema tree (after MCP-level normalization
@@ -35,6 +39,14 @@ import logging
 from typing import Any
 
 logger = logging.getLogger(__name__)
+
+_NUMERIC_VALIDATION_KEYS = frozenset({
+    "minimum",
+    "maximum",
+    "exclusiveMinimum",
+    "exclusiveMaximum",
+    "multipleOf",
+})
 
 
 def sanitize_tool_schemas(tools: list[dict]) -> list[dict]:
@@ -230,6 +242,21 @@ def _sanitize_node(node: Any, path: str) -> Any:
 
     out: dict = {}
     for key, value in node.items():
+        if key in _NUMERIC_VALIDATION_KEYS:
+            # Strict OpenAI-compatible backends require these JSON Schema
+            # validation keywords to be numeric. Some MCP servers emit invalid
+            # legacy/buggy booleans (e.g. ``minimum: false``), which are also
+            # ``int`` subclasses in Python, so check bool explicitly.
+            if isinstance(value, bool) or not isinstance(value, (int, float)):
+                logger.debug(
+                    "schema_sanitizer[%s]: dropping non-numeric %s=%r "
+                    "from schema node",
+                    path, key, value,
+                )
+                continue
+            out[key] = value
+            continue
+
         # type: [X, "null"] → type: X (the backend's tool-call parser only
         # accepts singular string types; nullable is lost but the call still
         # succeeds, and the model can still pass null on its own.)

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -140,7 +140,7 @@ def _get_backend() -> str:
     keys manually without running setup.
     """
     configured = (_load_web_config().get("backend") or "").lower().strip()
-    if configured in {"parallel", "firecrawl", "tavily", "exa", "searxng", "brave-free", "ddgs", "xai"}:
+    if configured in {"parallel", "firecrawl", "tavily", "exa", "searxng", "brave-free", "ddgs", "xai", "jina"}:
         return configured
 
     # Fallback for manual / legacy config — pick the highest-priority
@@ -228,6 +228,8 @@ def _is_backend_available(backend: str) -> bool:
             return has_xai_credentials()
         except Exception:
             return False
+    if backend == "jina":
+        return True
     return False
 
 
@@ -1367,11 +1369,11 @@ async def web_crawl_tool(
 def check_web_api_key() -> bool:
     """Check whether the configured web backend is available."""
     configured = _load_web_config().get("backend", "").lower().strip()
-    if configured in {"exa", "parallel", "firecrawl", "tavily", "searxng", "brave-free", "ddgs"}:
+    if configured in {"exa", "parallel", "firecrawl", "tavily", "searxng", "brave-free", "ddgs", "xai", "jina"}:
         return _is_backend_available(configured)
     return any(
         _is_backend_available(backend)
-        for backend in ("exa", "parallel", "firecrawl", "tavily", "searxng", "brave-free", "ddgs")
+        for backend in ("exa", "parallel", "firecrawl", "tavily", "searxng", "brave-free", "ddgs", "xai", "jina")
     )
 
 


### PR DESCRIPTION
## Summary
- add an operator-focused `hermes doctor --operator` readiness check for gateway, home-channel, cron, Kanban dispatcher, reasoning, auxiliary routing, and profiles
- harden Kanban DB initialization/diagnostics paths so local multi-agent boards initialize more reliably
- add Jina Reader as a keyless extract provider and tighten web provider/schema sanitizer behavior
- improve gateway platform fallback behavior with regression coverage

## Why
This packages local reliability hardening that has been carried as a private patch. Upstreaming it lets local installs fast-forward cleanly instead of repeatedly rebasing the same operational fixes.

## Test Plan
- `python -m pytest tests/hermes_cli/test_kanban_db_init.py tests/hermes_cli/test_doctor.py tests/plugins/web/test_web_search_provider_plugins.py tests/tools/test_schema_sanitizer.py tests/gateway/test_platform_base.py -q -o 'addopts='`
- Result: 254 passed, 2 skipped

## Notes
- This PR intentionally groups the small reliability fixes that were being carried together locally. If maintainers prefer, I can split operator doctor, Jina extract provider, and Kanban initialization into separate PRs.
