### PR TITLE
feat(honcho): prompt for local JWT during self-hosted setup

### DIFF
--- a/plugins/memory/honcho/cli.py
+++ b/plugins/memory/honcho/cli.py
@@ -388,21 +388,58 @@ def cmd_setup(args) -> None:
     cfg.pop("base_url", None)
 
     if is_local:
-        # --- Local: ask for base URL, skip or clear API key ---
+        # --- Local: ask for base URL, optionally accept a JWT for auth ---
         current_url = cfg.get("baseUrl") or ""
         new_url = _prompt("Base URL", default=current_url or "http://localhost:8000")
         if new_url:
             cfg["baseUrl"] = new_url
 
-        # For local no-auth, the SDK must not send an API key.
-        # We keep the key in config (for cloud switching later) but
-        # the client should skip auth when baseUrl is local.
-        current_key = cfg.get("apiKey", "")
-        if current_key:
-            print(f"\n  API key present in config (kept for cloud/hybrid use).")
-            print("  Local connections will skip auth automatically.")
+        # Self-hosted Honcho can run with AUTH_USE_AUTH=true and an
+        # AUTH_JWT_SECRET on the server side. In that case clients must
+        # send a JWT signed with that secret as the bearer token (the
+        # Honcho SDK takes it via ``api_key=``). Cloud users got prompted
+        # for a key already; the local path historically skipped this and
+        # forced users to disable auth on the server. Offer the prompt
+        # here too. We store it under the host block (not the top-level
+        # apiKey) so ``get_honcho_client`` recognises it as an explicit
+        # local auth opt-in (see ``_host_has_key`` in client.py) and
+        # cloud/hybrid switching is unaffected.
+        current_host_key = hermes_host.get("apiKey", "")
+        masked = (
+            f"...{current_host_key[-8:]}"
+            if len(current_host_key) > 8
+            else ("set" if current_host_key else "not set")
+        )
+        print(
+            "\n  Local Honcho auth (JWT signed with the server's "
+            "AUTH_JWT_SECRET)."
+        )
+        print(
+            "  Leave blank if your server runs with AUTH_USE_AUTH=false. "
+            f"Current: {masked}"
+        )
+        new_local_key = _prompt(
+            "Local JWT / bearer token (blank to skip / keep current)",
+            secret=True,
+        )
+        if new_local_key:
+            hermes_host["apiKey"] = new_local_key
+        elif current_host_key:
+            print("  Keeping existing local JWT.")
         else:
-            print("\n  No API key set. Local no-auth ready.")
+            # Surface the top-level key situation for transparency.
+            top_key = cfg.get("apiKey", "")
+            if top_key:
+                print(
+                    "\n  Top-level API key present in config (kept for "
+                    "cloud/hybrid use)."
+                )
+                print(
+                    "  Local connections will skip auth automatically "
+                    "until a local JWT is set above."
+                )
+            else:
+                print("\n  No local JWT set. Local no-auth ready.")
     else:
         # --- Cloud: set default base URL, require API key ---
         cfg.pop("baseUrl", None)  # cloud uses SDK default

--- a/tests/honcho_plugin/test_cli.py
+++ b/tests/honcho_plugin/test_cli.py
@@ -100,6 +100,84 @@ class TestResolveApiKey:
                 f"expected local sentinel for legacy schemeless {legacy!r}"
 
 
+class TestCmdSetupLocalJwt:
+    """Local-deployment setup must allow configuring a JWT for AUTH_JWT_SECRET-backed Honcho servers."""
+
+    def _run_setup(self, monkeypatch, tmp_path, initial_cfg, prompt_answers):
+        import plugins.memory.honcho.cli as honcho_cli
+
+        # Avoid touching real config / SDK / filesystem.
+        cfg_path = tmp_path / "honcho.json"
+        monkeypatch.setattr(honcho_cli, "_read_config", lambda: dict(initial_cfg))
+        monkeypatch.setattr(honcho_cli, "_local_config_path", lambda: cfg_path)
+        monkeypatch.setattr(honcho_cli, "_config_path", lambda: cfg_path)
+        monkeypatch.setattr(honcho_cli, "_host_key", lambda: "hermes")
+        monkeypatch.setattr(honcho_cli, "_ensure_sdk_installed", lambda: True)
+
+        written = {}
+
+        def _capture_write(cfg, path=None):
+            written["cfg"] = cfg
+            written["path"] = path
+
+        monkeypatch.setattr(honcho_cli, "_write_config", _capture_write)
+
+        # Feed scripted prompt answers in order.
+        answers = list(prompt_answers)
+
+        def _fake_prompt(label, default=None, secret=False):
+            if not answers:
+                # Default-through any remaining prompts to keep the wizard moving.
+                return default or ""
+            return answers.pop(0)
+
+        monkeypatch.setattr(honcho_cli, "_prompt", _fake_prompt)
+
+        honcho_cli.cmd_setup(SimpleNamespace())
+        return written.get("cfg")
+
+    def test_local_setup_stores_jwt_under_host_block(self, monkeypatch, tmp_path):
+        """Self-hosted users supplying a JWT must have it written under hosts.<host>.apiKey,
+        not as the top-level cloud apiKey, so cloud/hybrid switching is preserved and
+        get_honcho_client treats it as an explicit local auth opt-in."""
+        cfg = self._run_setup(
+            monkeypatch,
+            tmp_path,
+            initial_cfg={},
+            prompt_answers=[
+                "local",                       # deployment
+                "http://localhost:8000",       # base URL
+                "my-local-jwt-token",          # local JWT
+            ],
+        )
+        assert cfg is not None
+        assert cfg.get("baseUrl") == "http://localhost:8000"
+        # Top-level apiKey must remain unset (cloud field).
+        assert not cfg.get("apiKey")
+        # The new local JWT belongs under the host block.
+        host_block = (cfg.get("hosts") or {}).get("hermes") or {}
+        assert host_block.get("apiKey") == "my-local-jwt-token"
+
+    def test_local_setup_blank_jwt_keeps_local_no_auth(self, monkeypatch, tmp_path):
+        """Blank JWT prompt response on a fresh local config must not introduce an apiKey
+        anywhere (local no-auth Honcho deployments must still work out of the box)."""
+        cfg = self._run_setup(
+            monkeypatch,
+            tmp_path,
+            initial_cfg={},
+            prompt_answers=[
+                "local",
+                "http://localhost:8000",
+                "",  # blank JWT
+            ],
+        )
+        assert cfg is not None
+        assert cfg.get("baseUrl") == "http://localhost:8000"
+        assert not cfg.get("apiKey")
+        host_block = (cfg.get("hosts") or {}).get("hermes") or {}
+        assert not host_block.get("apiKey")
+
+
 class TestCmdStatus:
     def test_reports_connection_failure_when_session_setup_fails(self, monkeypatch, capsys, tmp_path):
         import plugins.memory.honcho.cli as honcho_cli

--- a/website/docs/user-guide/features/honcho.md
+++ b/website/docs/user-guide/features/honcho.md
@@ -106,6 +106,10 @@ The auto-injected dialectic scales `dialecticReasoningLevel` by query length: +1
 
 Honcho is configured in `~/.honcho/config.json` (global) or `$HERMES_HOME/honcho.json` (profile-local). The setup wizard handles this for you.
 
+### Self-Hosted Honcho with Authentication
+
+When pointing Hermes at a self-hosted Honcho server, `hermes honcho setup` (and `hermes memory setup`) ask for a **local JWT / bearer token** after the base URL. Paste a JWT signed with the server's `AUTH_JWT_SECRET` (the Honcho compose env var) to enable authenticated access; leave it blank for servers running with `AUTH_USE_AUTH=false`. The local token is stored under the host block (`hosts.<host>.apiKey` in `honcho.json`), separate from any cloud `apiKey`, so you can flip the `Cloud or local?` prompt back to `cloud` later without losing either credential.
+
 ### Full Config Reference
 
 | Key | Default | Description |


### PR DESCRIPTION
## Summary
- Adds a local JWT / bearer token prompt to the self-hosted (`local`) branch of `hermes honcho setup`. Users running Honcho with `AUTH_USE_AUTH=true` and an `AUTH_JWT_SECRET` can now paste their server-signed JWT through the wizard instead of disabling auth entirely (the previous workaround called out by the issue).
- The local token is stored under the host block (`hosts.<host>.apiKey` in `honcho.json`), **not** the top-level `apiKey` field. `get_honcho_client` already treats a host-block `apiKey` on a `localhost`/`127.0.0.1` base URL as an explicit local-auth opt-in (`_host_has_key` path), so the SDK call now sends the JWT as the bearer token instead of the `"local"` placeholder. Cloud/hybrid switching is unaffected (top-level `apiKey` is left alone).
- Blank input keeps the existing local no-auth behaviour, so existing self-hosted deployments without `AUTH_USE_AUTH` keep working unchanged.
- Adds a `Self-Hosted Honcho with Authentication` subsection to the user-guide Honcho docs.

## Test Plan
- [x] `python -m pytest tests/honcho_plugin/test_cli.py -q -o 'addopts='`
  - Covers two new cases: local setup with a JWT writes to `hosts.<host>.apiKey` (and leaves the cloud `apiKey` untouched); blank JWT on a fresh local config leaves both `apiKey` slots unset.

Closes #29885