### PR TITLE
fix: ensure CLI process exits after session ends (os._exit(0) guard)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -14194,8 +14194,18 @@ class HermesCLI:
             from hermes_cli.relaunch import relaunch
             relaunch(self._pending_relaunch, preserve_inherited=False)
 
+        # Force exit after the finally block completes. Non-daemon background
+        # threads (asyncio event loop workers, httpx transport pools, etc.)
+        # can keep the Python process alive indefinitely once the interactive
+        # session ends, especially on Windows where stdin-orphan detection is
+        # unreliable. All resource cleanup (MCP servers, browsers, terminals,
+        # session DB, voice recorder, memory providers) already ran in the
+        # finally block above, so os._exit(0) here is safe — nothing remains
+        # to finalize.
+        os._exit(0)
 
-# ============================================================================
+
+# =============================================================================
 # Main Entry Point
 # ============================================================================
 


### PR DESCRIPTION
## Problem
When an interactive Hermes CLI session ends (user types /quit, closes terminal, or session is interrupted), non-daemon background threads (asyncio event loop workers, httpx transport connection pools) can keep the Python process alive indefinitely. This results in orphan processes consuming 200+ MB of memory until manually killed.

This is especially visible on Windows where:
- stdin-orphan detection is unreliable (CTRL_CLOSE_EVENT does not always propagate through the process tree)
- os.execvp (used by relaunch on POSIX) is unavailable, so the Windows relaunch falls through to subprocess.run + sys.exit, which can also be blocked by dangling threads

## Fix
Added os._exit(0) after the finally block and deferred-relaunch check in HermesCLI.run(). All resource cleanup (MCP servers, browsers, terminals, session DB, voice recorder, memory providers) already runs in the finally block, so the process is safe to terminate.

The /update relaunch path on Windows calls sys.exit(returncode) inside relaunch() and never reaches this line, so the fix does not interfere with upgrades.

## Changes
- `cli.py`: Added `os._exit(0)` call at line ~14205, after the finally block and deferred-relaunch check, with a comment explaining why it is necessary and safe.