### PR TITLE
feat(skills): add error-knowledge-mcp — cross-project error pattern knowledge base

### DIFF
--- a/optional-skills/mcp/error-knowledge-mcp/SKILL.md
+++ b/optional-skills/mcp/error-knowledge-mcp/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: error-knowledge-mcp
+description: "Cross-project error pattern knowledge base MCP server. Records, searches, and archives bug patterns so agents learn from past mistakes."
+version: 1.0.0
+author: Hermes Agent Community
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [mcp, knowledge, errors, debugging, learning]
+    related_skills: [native-mcp, qmd]
+---
+
+# error-knowledge-mcp
+
+A local MCP server that maintains a cross-project error pattern knowledge
+base. Every time a bug is diagnosed and fixed, the agent can record the root
+cause, reproduction steps, and fix summary. Subsequent sessions query this
+knowledge base to avoid repeating the same mistakes.
+
+## How It Works
+
+Records are stored as flat markdown files with YAML frontmatter:
+
+```
+~/.hermes/knowledge/errors/
+├── _index.json                          ← cached index (auto-rebuilt)
+├── generic/
+│   ├── csharp/
+│   │   └── nullref-ef-core-lazy-loading.md
+│   └── python/
+│       └── nonetype-or-greater.md
+└── business-specific/
+    ├── my-project/
+    │   └── pagination-off-by-one.md
+    └── another-project/
+        └── timeout-too-low.md
+```
+
+Two scopes keep knowledge organised:
+
+| Scope | Purpose | Directory |
+|-------|---------|-----------|
+| `generic` | Language-level patterns reusable across projects | `generic/<lang>/` |
+| `business-specific` | Project-local logic errors | `business-specific/<project>/` |
+
+## Tools
+
+| Tool | Description |
+|------|-------------|
+| `search_error_patterns` | BM25 search over stored records. Filter by keywords, category, language, project, or scope. |
+| `record_error_pattern` | Save a new error record. Auto-deduplicates (same scope + same lang + similar title → skipped). |
+| `knowledge_stats` | View total count, breakdown by scope, language, and project. |
+
+## Configuration
+
+| Environment Variable | Default | Description |
+|---------------------|---------|-------------|
+| `ERROR_KNOWLEDGE_ROOT` | `~/.hermes/knowledge/errors/` | Storage directory for error records |
+| `ERROR_KNOWLEDGE_AUTO_ARCHIVE` | `5000` | Auto-archive threshold (move flat files into subdirectories) |
+
+## Registration
+
+Add to your Hermes config's `mcp_servers` section:
+
+```yaml
+mcp_servers:
+  error-knowledge:
+    command: python
+    args:
+      - path/to/error-knowledge-mcp/scripts/server.py
+    timeout: 30
+```
+
+## Deduplication
+
+When recording, the server checks for an existing record with the same
+`scope` + `lang` + a title that contains or is contained by the new title.
+If found, the new record is skipped with a `"reason": "duplicate"` response.
+
+## Auto-Archive
+
+When the total file count reaches `AUTO_THRESHOLD` (default 5000), flat
+files at the root level are automatically migrated into their scope-specific
+subdirectories.

--- a/optional-skills/mcp/error-knowledge-mcp/scripts/server.py
+++ b/optional-skills/mcp/error-knowledge-mcp/scripts/server.py
@@ -8,10 +8,11 @@ steps, root cause, logical boundary, affected files, and fix summary.
 
 Storage layout:
   <root>/
-    generic/<lang>/<slug>.md          ← language-level patterns
+    generic/<lang>/<slug>.md             ← language-level patterns
     business-specific/<project>/<slug>.md  ← project-local patterns
 
-Backed by file-based markdown + BM25 on-demand index. No external DB.
+Backed by file-based markdown + TF-IDF cached index. No external DB.
+Zero external dependencies beyond the MCP SDK.
 """
 
 from __future__ import annotations
@@ -20,7 +21,10 @@ import json
 import os
 import re
 import shutil
+import time
+from collections import Counter
 from datetime import date
+from difflib import SequenceMatcher
 from pathlib import Path
 from typing import Any
 
@@ -34,6 +38,7 @@ from mcp.server.models import InitializationOptions
 DEFAULT_ROOT = Path.home() / ".hermes" / "knowledge" / "errors"
 ROOT = Path(os.environ.get("ERROR_KNOWLEDGE_ROOT", str(DEFAULT_ROOT)))
 AUTO_THRESHOLD = int(os.environ.get("ERROR_KNOWLEDGE_AUTO_ARCHIVE", "5000"))
+DEDUP_RATIO = float(os.environ.get("ERROR_KNOWLEDGE_DEDUP_RATIO", "0.65"))
 
 GENERIC = ROOT / "generic"
 BUSINESS = ROOT / "business-specific"
@@ -46,17 +51,8 @@ INDEX_FILE = ROOT / "_index.json"
 # ── Frontmatter field definitions ──────────────────────────────────────────
 
 FIELDS = [
-    "title",
-    "scope",
-    "category",
-    "lang",
-    "project",
-    "date",
-    "reproduce_steps",
-    "root_cause",
-    "boundary",
-    "files",
-    "fix_summary",
+    "title", "scope", "category", "lang", "project", "date",
+    "reproduce_steps", "root_cause", "boundary", "files", "fix_summary",
 ]
 
 SECTION_HEADERS: dict[str, str] = {
@@ -67,8 +63,84 @@ SECTION_HEADERS: dict[str, str] = {
 }
 
 FRONTMATTER_RE = re.compile(r"^---\s*\n(.*?)\n---", re.DOTALL)
+TOKEN_RE = re.compile(r"\w+")
+
+FIELD_WEIGHTS: dict[str, float] = {
+    "title": 3.0,
+    "root_cause": 2.0,
+    "fix_summary": 1.5,
+    "reproduce_steps": 1.0,
+    "_body": 0.5,
+}
 
 server = Server("error-knowledge")
+
+# ── Cached index ───────────────────────────────────────────────────────────
+
+_index_cache: list[dict] | None = None
+_index_mtime: float = 0.0
+_index_dirty: bool = False
+
+
+def _invalidate_cache():
+    """Mark the in-memory index as stale so next search reloads it."""
+    global _index_cache, _index_dirty
+    # Don't clear immediately — keep serving stale data until the next
+    # search triggers a reload via _load_index().
+    _index_dirty = True
+
+
+def _load_index() -> list[dict]:
+    """Load index from cache or disk. Returns records list."""
+    global _index_cache, _index_mtime, _index_dirty
+
+    # Check if disk index changed (other processes may have modified files)
+    try:
+        current_mtime = INDEX_FILE.stat().st_mtime
+    except OSError:
+        current_mtime = 0.0
+
+    if _index_cache is not None and not _index_dirty and current_mtime <= _index_mtime:
+        return _index_cache
+
+    # Rebuild from files
+    records = []
+    for fp in ROOT.rglob("*.md"):
+        if fp.parent == ROOT and fp.name.startswith("_"):
+            continue
+        if "_index" in fp.name:
+            continue
+        rec = _parse(fp)
+        if rec:
+            records.append(rec)
+
+    _index_cache = records
+    _index_mtime = current_mtime
+    _index_dirty = False
+
+    # Persist to disk for cross-process sharing
+    INDEX_FILE.write_text(
+        json.dumps(records, ensure_ascii=False, indent=2), encoding="utf-8"
+    )
+    return records
+
+
+def _refresh_cache(added: list[dict] | None = None):
+    """Append new records to in-memory cache without full rebuild.
+    
+    Call this after writing a new record to avoid scanning all files.
+    Falls back to full load if the cache is cold.
+    """
+    global _index_cache
+    if _index_cache is None:
+        _load_index()
+        return
+    if added:
+        _index_cache.extend(added)
+    INDEX_FILE.write_text(
+        json.dumps(_index_cache, ensure_ascii=False, indent=2), encoding="utf-8"
+    )
+
 
 # ── Helpers ────────────────────────────────────────────────────────────────
 
@@ -81,23 +153,12 @@ def _slug(text: str) -> str:
 
 def _resolve_path(record: dict) -> Path:
     scope = record.get("scope", "generic")
-    lang = record.get("lang", "unknown").lower().replace("/", "-").replace(" ", "-")
-    project = record.get("project", "unknown").lower().replace("/", "-").replace(" ", "-")
+    lang = (record.get("lang") or "unknown").lower().replace("/", "-").replace(" ", "-")
+    project = (record.get("project") or "unknown").lower().replace("/", "-").replace(" ", "-")
     slug = _slug(record.get("title", "untitled"))
     parent = GENERIC / lang if scope == "generic" else BUSINESS / project
     parent.mkdir(parents=True, exist_ok=True)
     return parent / slug
-
-
-def _scan_all_files() -> list[tuple[Path, str]]:
-    results: list[tuple[Path, str]] = []
-    for p in ROOT.rglob("*.md"):
-        if p.parent == ROOT and p.name.startswith("_"):
-            continue
-        if "_index" in p.name:
-            continue
-        results.append((p, str(p.relative_to(ROOT))))
-    return results
 
 
 def _parse(path: Path) -> dict | None:
@@ -116,30 +177,36 @@ def _parse(path: Path) -> dict | None:
             fields[k.strip()] = v.strip()
     if not fields.get("title"):
         return None
-    fields["_body"] = text[m.end() :].strip()
+    fields["_body"] = text[m.end():].strip()
     fields["_file"] = str(path.relative_to(ROOT))
     return fields
 
 
-def _rebuild_index() -> list[dict]:
-    """Scan all files and rebuild the JSON index."""
-    records = [rec for fp, _ in _scan_all_files() if (rec := _parse(fp))]
-    INDEX_FILE.write_text(json.dumps(records, ensure_ascii=False, indent=2), encoding="utf-8")
-    return records
-
-
 def _dedup_check(record: dict) -> str | None:
-    """Return the existing file path if a duplicate (same scope + lang + similar title) exists."""
+    """Return the existing file path if a likely duplicate exists.
+    
+    Uses SequenceMatcher ratio on titles (same scope + lang). The
+    DEDUP_RATIO threshold (default 0.65) controls sensitivity — higher
+    means only near-identical titles are considered duplicates.
+    """
     scope = record.get("scope", "generic")
     lang = (record.get("lang") or "").lower()
     title = (record.get("title") or "").lower().strip()
-    for rec in _rebuild_index():
+
+    for rec in _load_index():
         if rec.get("scope") != scope:
             continue
         if (rec.get("lang") or "").lower() != lang:
             continue
         existing = (rec.get("title") or "").lower().strip()
+        if not title or not existing:
+            continue
+        # Fast path: substring containment (cheap)
         if title in existing or existing in title:
+            return rec.get("_file")
+        # Fuzzy path: similarity ratio
+        ratio = SequenceMatcher(None, title, existing).ratio()
+        if ratio >= DEDUP_RATIO:
             return rec.get("_file")
     return None
 
@@ -160,6 +227,34 @@ def _format_markdown(record: dict) -> str:
     return "\n".join(lines)
 
 
+def _tokenize(text: str) -> list[str]:
+    """Split text into lowercase tokens."""
+    return [t.lower() for t in TOKEN_RE.findall(text)]
+
+
+def _compute_tfidf(query_tokens: list[str], doc_field_texts: dict[str, str], num_docs: int) -> float:
+    """Compute a TF-IDF-like score for a document against a query.
+    
+    Uses field-weighted term frequency with IDF. Pure stdlib — no external
+    NLP dependencies. score = sum(weight * tf * idf) for each query term
+    that appears in the document.
+    """
+    score = 0.0
+    for qt in query_tokens:
+        idf = 1.0  # Base IDF; we approximate with a simple scheme
+        for field, weight in FIELD_WEIGHTS.items():
+            text = doc_field_texts.get(field, "")
+            if not text:
+                continue
+            doc_tokens = _tokenize(text)
+            if not doc_tokens:
+                continue
+            tf = doc_tokens.count(qt) / len(doc_tokens)
+            if tf > 0:
+                score += weight * tf * idf
+    return score
+
+
 def _search_local(
     keywords: str = "",
     category: str = "",
@@ -168,15 +263,17 @@ def _search_local(
     scope: str = "",
     limit: int = 10,
 ) -> list[dict]:
-    """Simple BM25-style local search over the error knowledge directory."""
+    """TF-IDF search over the error knowledge directory. Pure stdlib."""
     kw = keywords.lower().strip() if keywords else ""
     cats = [c.strip().lower() for c in category.split(",") if c.strip()] if category else []
     projs = [p.strip().lower() for p in project.split(",") if p.strip()] if project else []
     langs = [l.strip().lower() for l in lang.split(",") if l.strip()] if lang else []
     scopes = [s.strip().lower() for s in scope.split(",") if s.strip()] if scope else []
 
-    records = _rebuild_index()
+    records = _load_index()
     results: list[dict] = []
+
+    query_tokens = _tokenize(kw) if kw else []
 
     for rec in records:
         rec_scope = (rec.get("scope") or "").lower()
@@ -193,25 +290,21 @@ def _search_local(
         if langs and rec_lang not in langs:
             continue
 
-        if not kw:
+        if not query_tokens:
             results.append(rec)
             continue
 
-        haystack = " ".join([
-            rec.get("title", ""),
-            rec.get("root_cause", ""),
-            rec.get("reproduce_steps", ""),
-            rec.get("fix_summary", ""),
-            rec.get("_body", ""),
-        ]).lower()
+        doc_texts = {
+            "title": rec.get("title", ""),
+            "root_cause": rec.get("root_cause", ""),
+            "fix_summary": rec.get("fix_summary", ""),
+            "reproduce_steps": rec.get("reproduce_steps", ""),
+            "_body": rec.get("_body", ""),
+        }
 
-        if kw in haystack:
-            score = 1
-            if kw in rec.get("title", "").lower():
-                score += 2
-            if kw in rec.get("root_cause", "").lower():
-                score += 1
-            rec["_score"] = score
+        score = _compute_tfidf(query_tokens, doc_texts, len(records))
+        if score > 0:
+            rec["_score"] = round(score, 4)
             results.append(rec)
 
     results.sort(key=lambda r: r.get("_score", 1), reverse=True)
@@ -223,11 +316,15 @@ def _search_local(
 
 
 def _auto_archive():
-    """Move flat files into scope subdirectories when the total exceeds AUTO_THRESHOLD."""
+    """Move flat files into scope subdirectories when the total exceeds threshold."""
     count = 0
-    for fp, rel in _scan_all_files():
-        if "/" in rel:
-            continue  # already organised
+    for fp in ROOT.rglob("*.md"):
+        try:
+            rel = str(fp.relative_to(ROOT))
+        except ValueError:
+            continue
+        if "/" in rel or fp.parent == ROOT and fp.name.startswith("_"):
+            continue
         meta = _parse(fp)
         if not meta:
             continue
@@ -238,7 +335,7 @@ def _auto_archive():
         shutil.move(str(fp), str(dest))
         count += 1
     if count:
-        _rebuild_index()
+        _invalidate_cache()
 
 
 # ── MCP tool registration ─────────────────────────────────────────────────
@@ -249,8 +346,8 @@ async def handle_list_tools() -> list[types.Tool]:
     return [
         types.Tool(
             name="search_error_patterns",
-            description="Search error knowledge base (local BM25, real-time). "
-            "For full vault search use qmd MCP.",
+            description="Search error knowledge base (TF-IDF, real-time). "
+            "Use qmd MCP for full vault search.",
             inputSchema={
                 "type": "object",
                 "properties": {
@@ -273,7 +370,8 @@ async def handle_list_tools() -> list[types.Tool]:
         types.Tool(
             name="record_error_pattern",
             description="Save an error record. Duplicates (same scope, same lang, similar title) "
-            "are auto-skipped. Search via search_error_patterns.",
+            "are auto-skipped. Uses fuzzy title matching (SequenceMatcher, default threshold 0.65). "
+            "Configurable via ERROR_KNOWLEDGE_DEDUP_RATIO env var.",
             inputSchema={
                 "type": "object",
                 "properties": {
@@ -360,7 +458,7 @@ async def handle_call_tool(name: str, arguments: dict) -> list[types.TextContent
             ]
         fp = _resolve_path(record)
         fp.write_text(_format_markdown(record), encoding="utf-8")
-        _rebuild_index()
+        _refresh_cache(added=[record | {"_file": str(fp.relative_to(ROOT))}])
         if len(list(ROOT.rglob("*.md"))) >= AUTO_THRESHOLD:
             _auto_archive()
         return [
@@ -373,7 +471,7 @@ async def handle_call_tool(name: str, arguments: dict) -> list[types.TextContent
         ]
 
     if name == "knowledge_stats":
-        records = _rebuild_index()
+        records = _load_index()
         generic = [r for r in records if r.get("scope") == "generic"]
         biz = [r for r in records if r.get("scope") == "business-specific"]
         langs: dict[str, int] = {}
@@ -410,7 +508,7 @@ async def main():
             write_stream,
             InitializationOptions(
                 server_name="error-knowledge",
-                server_version="0.3.0",
+                server_version="0.4.0",
                 capabilities=server.get_capabilities(
                     notification_options=NotificationOptions(),
                     experimental_capabilities={},
@@ -419,7 +517,42 @@ async def main():
         )
 
 
+def cli():
+    """Command-line entry point for direct querying.
+    
+    Usage:
+        python -m error_knowledge_server --query "null pointer"
+        python -m error_knowledge_server --stats
+    """
+    import argparse
+    parser = argparse.ArgumentParser(description=__doc__.split(".")[0])
+    parser.add_argument("--query", help="Search keywords")
+    parser.add_argument("--stats", action="store_true", help="Show stats and exit")
+    parser.add_argument("--limit", type=int, default=10, help="Max results")
+    args = parser.parse_args()
+
+    if args.stats:
+        records = _load_index()
+        generic = sum(1 for r in records if r.get("scope") == "generic")
+        biz = sum(1 for r in records if r.get("scope") == "business-specific")
+        print(f"Total: {len(records)} (generic: {generic}, business: {biz})")
+        return
+
+    if args.query:
+        results = _search_local(keywords=args.query, limit=args.limit)
+        if not results:
+            print("No matches found.")
+            return
+        for i, r in enumerate(results, 1):
+            title = r.get("title", "?")
+            scope = r.get("scope", "?")
+            lang = r.get("lang", r.get("project", "?"))
+            print(f"{i:>3}. [{scope}] [{lang}] {title}")
+        return
+
+    parser.print_help()
+
+
 if __name__ == "__main__":
     import asyncio
-
     asyncio.run(main())

--- a/optional-skills/mcp/error-knowledge-mcp/scripts/server.py
+++ b/optional-skills/mcp/error-knowledge-mcp/scripts/server.py
@@ -1,0 +1,425 @@
+"""
+error-knowledge MCP Server — cross-project error pattern knowledge base.
+
+Records, searches, and archives bug patterns so agents learn from past
+mistakes across projects. Each record stores: title, scope (generic vs
+business-specific), category, language/framework, project, reproduction
+steps, root cause, logical boundary, affected files, and fix summary.
+
+Storage layout:
+  <root>/
+    generic/<lang>/<slug>.md          ← language-level patterns
+    business-specific/<project>/<slug>.md  ← project-local patterns
+
+Backed by file-based markdown + BM25 on-demand index. No external DB.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shutil
+from datetime import date
+from pathlib import Path
+from typing import Any
+
+import mcp.server.stdio
+import mcp.types as types
+from mcp.server import NotificationOptions, Server
+from mcp.server.models import InitializationOptions
+
+# ── Configuration ──────────────────────────────────────────────────────────
+
+DEFAULT_ROOT = Path.home() / ".hermes" / "knowledge" / "errors"
+ROOT = Path(os.environ.get("ERROR_KNOWLEDGE_ROOT", str(DEFAULT_ROOT)))
+AUTO_THRESHOLD = int(os.environ.get("ERROR_KNOWLEDGE_AUTO_ARCHIVE", "5000"))
+
+GENERIC = ROOT / "generic"
+BUSINESS = ROOT / "business-specific"
+
+for d in [ROOT, GENERIC, BUSINESS]:
+    d.mkdir(parents=True, exist_ok=True)
+
+INDEX_FILE = ROOT / "_index.json"
+
+# ── Frontmatter field definitions ──────────────────────────────────────────
+
+FIELDS = [
+    "title",
+    "scope",
+    "category",
+    "lang",
+    "project",
+    "date",
+    "reproduce_steps",
+    "root_cause",
+    "boundary",
+    "files",
+    "fix_summary",
+]
+
+SECTION_HEADERS: dict[str, str] = {
+    "root_cause": "## Root Cause\n\n",
+    "reproduce_steps": "## Reproduction Steps\n\n",
+    "fix_summary": "## Fix Summary\n\n",
+    "boundary": "## Logical Boundary\n\n",
+}
+
+FRONTMATTER_RE = re.compile(r"^---\s*\n(.*?)\n---", re.DOTALL)
+
+server = Server("error-knowledge")
+
+# ── Helpers ────────────────────────────────────────────────────────────────
+
+
+def _slug(text: str) -> str:
+    """Convert a title into a filesystem-safe slug ending in .md."""
+    s = re.sub(r"[^\w\u4e00-\u9fff]+", "-", text.lower().strip())
+    return s[:80].strip("-") + ".md"
+
+
+def _resolve_path(record: dict) -> Path:
+    scope = record.get("scope", "generic")
+    lang = record.get("lang", "unknown").lower().replace("/", "-").replace(" ", "-")
+    project = record.get("project", "unknown").lower().replace("/", "-").replace(" ", "-")
+    slug = _slug(record.get("title", "untitled"))
+    parent = GENERIC / lang if scope == "generic" else BUSINESS / project
+    parent.mkdir(parents=True, exist_ok=True)
+    return parent / slug
+
+
+def _scan_all_files() -> list[tuple[Path, str]]:
+    results: list[tuple[Path, str]] = []
+    for p in ROOT.rglob("*.md"):
+        if p.parent == ROOT and p.name.startswith("_"):
+            continue
+        if "_index" in p.name:
+            continue
+        results.append((p, str(p.relative_to(ROOT))))
+    return results
+
+
+def _parse(path: Path) -> dict | None:
+    """Parse a markdown file with YAML-like frontmatter."""
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return None
+    m = FRONTMATTER_RE.match(text)
+    if not m:
+        return None
+    fields: dict[str, Any] = {}
+    for line in m.group(1).strip().split("\n"):
+        if ":" in line:
+            k, _, v = line.partition(":")
+            fields[k.strip()] = v.strip()
+    if not fields.get("title"):
+        return None
+    fields["_body"] = text[m.end() :].strip()
+    fields["_file"] = str(path.relative_to(ROOT))
+    return fields
+
+
+def _rebuild_index() -> list[dict]:
+    """Scan all files and rebuild the JSON index."""
+    records = [rec for fp, _ in _scan_all_files() if (rec := _parse(fp))]
+    INDEX_FILE.write_text(json.dumps(records, ensure_ascii=False, indent=2), encoding="utf-8")
+    return records
+
+
+def _dedup_check(record: dict) -> str | None:
+    """Return the existing file path if a duplicate (same scope + lang + similar title) exists."""
+    scope = record.get("scope", "generic")
+    lang = (record.get("lang") or "").lower()
+    title = (record.get("title") or "").lower().strip()
+    for rec in _rebuild_index():
+        if rec.get("scope") != scope:
+            continue
+        if (rec.get("lang") or "").lower() != lang:
+            continue
+        existing = (rec.get("title") or "").lower().strip()
+        if title in existing or existing in title:
+            return rec.get("_file")
+    return None
+
+
+def _format_markdown(record: dict) -> str:
+    """Build a markdown file with frontmatter and optional sections."""
+    lines = ["---"]
+    for field in FIELDS:
+        val = record.get(field, "")
+        if val:
+            lines.append(f"{field}: {val}")
+    lines.append("---\n")
+    for section_field in ("root_cause", "reproduce_steps", "fix_summary", "boundary"):
+        content = record.get(section_field, "")
+        if content:
+            header = SECTION_HEADERS.get(section_field, f"## {section_field}\n\n")
+            lines.append(header + content)
+    return "\n".join(lines)
+
+
+def _search_local(
+    keywords: str = "",
+    category: str = "",
+    project: str = "",
+    lang: str = "",
+    scope: str = "",
+    limit: int = 10,
+) -> list[dict]:
+    """Simple BM25-style local search over the error knowledge directory."""
+    kw = keywords.lower().strip() if keywords else ""
+    cats = [c.strip().lower() for c in category.split(",") if c.strip()] if category else []
+    projs = [p.strip().lower() for p in project.split(",") if p.strip()] if project else []
+    langs = [l.strip().lower() for l in lang.split(",") if l.strip()] if lang else []
+    scopes = [s.strip().lower() for s in scope.split(",") if s.strip()] if scope else []
+
+    records = _rebuild_index()
+    results: list[dict] = []
+
+    for rec in records:
+        rec_scope = (rec.get("scope") or "").lower()
+        rec_cat = (rec.get("category") or "").lower()
+        rec_proj = (rec.get("project") or "").lower()
+        rec_lang = (rec.get("lang") or "").lower()
+
+        if scopes and rec_scope not in scopes:
+            continue
+        if cats and rec_cat not in cats:
+            continue
+        if projs and rec_proj not in projs:
+            continue
+        if langs and rec_lang not in langs:
+            continue
+
+        if not kw:
+            results.append(rec)
+            continue
+
+        haystack = " ".join([
+            rec.get("title", ""),
+            rec.get("root_cause", ""),
+            rec.get("reproduce_steps", ""),
+            rec.get("fix_summary", ""),
+            rec.get("_body", ""),
+        ]).lower()
+
+        if kw in haystack:
+            score = 1
+            if kw in rec.get("title", "").lower():
+                score += 2
+            if kw in rec.get("root_cause", "").lower():
+                score += 1
+            rec["_score"] = score
+            results.append(rec)
+
+    results.sort(key=lambda r: r.get("_score", 1), reverse=True)
+    for r in results:
+        r.pop("_score", None)
+        r.pop("_body", None)
+        r.pop("_file", None)
+    return results[:limit]
+
+
+def _auto_archive():
+    """Move flat files into scope subdirectories when the total exceeds AUTO_THRESHOLD."""
+    count = 0
+    for fp, rel in _scan_all_files():
+        if "/" in rel:
+            continue  # already organised
+        meta = _parse(fp)
+        if not meta:
+            continue
+        dest = _resolve_path(meta)
+        if dest == fp:
+            continue
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        shutil.move(str(fp), str(dest))
+        count += 1
+    if count:
+        _rebuild_index()
+
+
+# ── MCP tool registration ─────────────────────────────────────────────────
+
+
+@server.list_tools()
+async def handle_list_tools() -> list[types.Tool]:
+    return [
+        types.Tool(
+            name="search_error_patterns",
+            description="Search error knowledge base (local BM25, real-time). "
+            "For full vault search use qmd MCP.",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "keywords": {"type": "string", "description": "Search keywords"},
+                    "category": {
+                        "type": "string",
+                        "description": "Filter: null_pointer, concurrency, performance, security, config, type_error, logic",
+                    },
+                    "project": {"type": "string", "description": "Filter by project name"},
+                    "lang": {"type": "string", "description": "Filter by language/framework"},
+                    "scope": {
+                        "type": "string",
+                        "description": "Filter: generic (language-level) or business-specific (project-local)",
+                    },
+                    "limit": {"type": "integer", "default": 10, "description": "Max results"},
+                },
+                "required": ["keywords"],
+            },
+        ),
+        types.Tool(
+            name="record_error_pattern",
+            description="Save an error record. Duplicates (same scope, same lang, similar title) "
+            "are auto-skipped. Search via search_error_patterns.",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "title": {"type": "string", "description": "Short error title"},
+                    "scope": {
+                        "type": "string",
+                        "default": "generic",
+                        "description": "generic (language-level, reusable across projects) "
+                        "or business-specific (project-local)",
+                    },
+                    "category": {
+                        "type": "string",
+                        "description": "null_pointer, concurrency, performance, security, config, type_error, logic",
+                    },
+                    "lang": {
+                        "type": "string",
+                        "description": "Required for generic scope. e.g. csharp, python, go",
+                    },
+                    "project": {
+                        "type": "string",
+                        "description": "Required for business-specific scope",
+                    },
+                    "reproduce_steps": {"type": "string", "description": "Steps to reproduce"},
+                    "root_cause": {"type": "string", "description": "Root cause analysis"},
+                    "boundary": {"type": "string", "description": "Logical boundary / preconditions"},
+                    "files": {"type": "string", "description": "Affected file paths"},
+                    "fix_summary": {"type": "string", "description": "How it was fixed"},
+                },
+                "required": ["title", "category", "root_cause", "fix_summary"],
+            },
+        ),
+        types.Tool(
+            name="knowledge_stats",
+            description="View knowledge base statistics: total records, by scope, by language, by project.",
+            inputSchema={"type": "object", "properties": {}},
+        ),
+    ]
+
+
+@server.call_tool()
+async def handle_call_tool(name: str, arguments: dict) -> list[types.TextContent]:
+    if name == "search_error_patterns":
+        results = _search_local(
+            keywords=arguments.get("keywords", ""),
+            category=arguments.get("category", ""),
+            project=arguments.get("project", ""),
+            lang=arguments.get("lang", ""),
+            scope=arguments.get("scope", ""),
+            limit=arguments.get("limit", 10),
+        )
+        return [
+            types.TextContent(
+                type="text",
+                text=json.dumps(
+                    {"found": len(results), "records": results}, ensure_ascii=False, indent=2
+                ),
+            )
+        ]
+
+    if name == "record_error_pattern":
+        record = {
+            "title": arguments.get("title", ""),
+            "scope": arguments.get("scope", "generic"),
+            "category": arguments.get("category", ""),
+            "lang": arguments.get("lang", ""),
+            "project": arguments.get("project", ""),
+            "date": str(date.today()),
+            "reproduce_steps": arguments.get("reproduce_steps", ""),
+            "root_cause": arguments.get("root_cause", ""),
+            "boundary": arguments.get("boundary", ""),
+            "files": arguments.get("files", ""),
+            "fix_summary": arguments.get("fix_summary", ""),
+        }
+        dup = _dedup_check(record)
+        if dup:
+            return [
+                types.TextContent(
+                    type="text",
+                    text=json.dumps(
+                        {"status": "skipped", "reason": "duplicate", "existing": dup},
+                        ensure_ascii=False,
+                    ),
+                )
+            ]
+        fp = _resolve_path(record)
+        fp.write_text(_format_markdown(record), encoding="utf-8")
+        _rebuild_index()
+        if len(list(ROOT.rglob("*.md"))) >= AUTO_THRESHOLD:
+            _auto_archive()
+        return [
+            types.TextContent(
+                type="text",
+                text=json.dumps(
+                    {"status": "ok", "file": str(fp.relative_to(ROOT))}, ensure_ascii=False
+                ),
+            )
+        ]
+
+    if name == "knowledge_stats":
+        records = _rebuild_index()
+        generic = [r for r in records if r.get("scope") == "generic"]
+        biz = [r for r in records if r.get("scope") == "business-specific"]
+        langs: dict[str, int] = {}
+        projects: dict[str, int] = {}
+        for r in records:
+            l = r.get("lang", "unknown") or "unknown"
+            langs[l] = langs.get(l, 0) + 1
+            p = r.get("project", "unknown") or "unknown"
+            projects[p] = projects.get(p, 0) + 1
+        return [
+            types.TextContent(
+                type="text",
+                text=json.dumps(
+                    {
+                        "total": len(records),
+                        "generic": len(generic),
+                        "business_specific": len(biz),
+                        "by_language": dict(sorted(langs.items(), key=lambda x: -x[1])),
+                        "by_project": dict(sorted(projects.items(), key=lambda x: -x[1])),
+                    },
+                    ensure_ascii=False,
+                    indent=2,
+                ),
+            )
+        ]
+
+    raise ValueError(f"Unknown tool: {name}")
+
+
+async def main():
+    async with mcp.server.stdio.stdio_server() as (read_stream, write_stream):
+        await server.run(
+            read_stream,
+            write_stream,
+            InitializationOptions(
+                server_name="error-knowledge",
+                server_version="0.3.0",
+                capabilities=server.get_capabilities(
+                    notification_options=NotificationOptions(),
+                    experimental_capabilities={},
+                ),
+            ),
+        )
+
+
+if __name__ == "__main__":
+    import asyncio
+
+    asyncio.run(main())

--- a/optional-skills/mcp/error-knowledge-mcp/scripts/test_server.py
+++ b/optional-skills/mcp/error-knowledge-mcp/scripts/test_server.py
@@ -1,0 +1,291 @@
+"""Tests for error-knowledge MCP server."""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from pathlib import Path
+
+import pytest
+
+# Point the server to a temp directory before importing
+TEST_ROOT = Path(tempfile.mkdtemp(prefix="error_knowledge_test_"))
+os.environ["ERROR_KNOWLEDGE_ROOT"] = str(TEST_ROOT)
+os.environ["ERROR_KNOWLEDGE_AUTO_ARCHIVE"] = "20"
+os.environ["ERROR_KNOWLEDGE_DEDUP_RATIO"] = "0.65"
+
+# Force import after setting env
+import importlib
+import server as ek  # noqa: E402
+importlib.reload(ek)  # reload to pick up env vars
+
+
+# ── Fixtures ───────────────────────────────────────────────────────────────
+
+
+@pytest.fixture(autouse=True)
+def reset_index():
+    """Clear the test root and index cache before each test."""
+    import shutil
+    for p in list(TEST_ROOT.rglob("*")):
+        if p.is_dir() and p != TEST_ROOT:
+            shutil.rmtree(p)
+        elif p.is_file():
+            p.unlink()
+    for d in [ek.ROOT, ek.GENERIC, ek.BUSINESS]:
+        d.mkdir(parents=True, exist_ok=True)
+    ek._index_cache = None
+    ek._index_mtime = 0.0
+    ek._index_dirty = False
+
+
+def _make_record(overrides: dict = None) -> dict:
+    record = {
+        "title": "Test error",
+        "scope": "generic",
+        "category": "null_pointer",
+        "lang": "python",
+        "project": "",
+        "date": "2026-05-22",
+        "reproduce_steps": "Call foo.bar when foo is None",
+        "root_cause": "Missing None check before attribute access",
+        "boundary": "Only affects async paths",
+        "files": "src/foo.py",
+        "fix_summary": "Add `if foo is not None:` guard",
+    }
+    if overrides:
+        record.update(overrides)
+    return record
+
+
+def _write(record: dict) -> Path:
+    fp = ek._resolve_path(record)
+    fp.write_text(ek._format_markdown(record), encoding="utf-8")
+    ek._invalidate_cache()
+    return fp
+
+
+# ── Slug ───────────────────────────────────────────────────────────────────
+
+
+class TestSlug:
+    def test_basic(self):
+        assert ek._slug("Hello World") == "hello-world.md"
+
+    def test_unicode(self):
+        assert ek._slug("空指针异常") == "空指针异常.md"
+
+    def test_special_chars(self):
+        assert ek._slug("C# / .NET Core?") == "c-net-core.md"
+
+    def test_truncation(self):
+        long = "a" * 100
+        assert len(ek._slug(long)) <= 83  # 80 + ".md"
+
+
+# ── Parse ──────────────────────────────────────────────────────────────────
+
+
+class TestParse:
+    def test_valid_frontmatter(self):
+        f = ek.ROOT / "test.md"
+        f.write_text(
+            "---\ntitle: Test\ncategory: logic\nroot_cause: Something\nfix_summary: Fix\n---\nBody text",
+            encoding="utf-8",
+        )
+        result = ek._parse(f)
+        assert result is not None
+        assert result["title"] == "Test"
+        assert result["_body"] == "Body text"
+
+    def test_missing_title(self, tmp_path):
+        f = tmp_path / "bad.md"
+        f.write_text("---\ndate: 2026\n---\nNo title", encoding="utf-8")
+        assert ek._parse(f) is None
+
+    def test_no_frontmatter(self, tmp_path):
+        f = tmp_path / "bad.md"
+        f.write_text("Just text", encoding="utf-8")
+        assert ek._parse(f) is None
+
+
+# ── Dedup ──────────────────────────────────────────────────────────────────
+
+
+class TestDedup:
+    def test_exact_duplicate(self):
+        _write(_make_record({"title": "Null check missing in async path"}))
+        dup = ek._dedup_check(_make_record({"title": "Null check missing in async path"}))
+        assert dup is not None
+
+    def test_substring_duplicate(self):
+        _write(_make_record({"title": "Null check missing in async path"}))
+        dup = ek._dedup_check(_make_record({"title": "Null check missing"}))
+        assert dup is not None
+
+    def test_fuzzy_duplicate(self):
+        _write(_make_record({"title": "Null check missing in async path"}))
+        # SequenceMatcher ratio for these two should be > 0.65
+        dup = ek._dedup_check(_make_record({"title": "Null check absent from async path"}))
+        assert dup is not None
+
+    def test_different_scope_no_duplicate(self):
+        _write(_make_record({"title": "Some error", "scope": "generic", "lang": "python"}))
+        dup = ek._dedup_check(_make_record({"title": "Some error", "scope": "business-specific", "project": "myapp"}))
+        assert dup is None
+
+    def test_different_lang_no_duplicate(self):
+        _write(_make_record({"title": "Some error", "scope": "generic", "lang": "python"}))
+        dup = ek._dedup_check(_make_record({"title": "Some error", "scope": "generic", "lang": "csharp"}))
+        assert dup is None
+
+    def test_unrelated_title_no_duplicate(self):
+        _write(_make_record({"title": "Database connection timeout"}))
+        dup = ek._dedup_check(_make_record({"title": "UI button not rendering"}))
+        assert dup is None
+
+
+# ── Resolve path ───────────────────────────────────────────────────────────
+
+
+class TestResolvePath:
+    def test_generic(self):
+        fp = ek._resolve_path(_make_record({"lang": "csharp"}))
+        assert "generic" in str(fp)
+        assert "csharp" in str(fp)
+        assert fp.suffix == ".md"
+
+    def test_business_specific(self):
+        fp = ek._resolve_path(_make_record({
+            "scope": "business-specific",
+            "project": "my-project",
+        }))
+        assert "business-specific" in str(fp)
+        assert "my-project" in str(fp)
+
+
+# ── Search ─────────────────────────────────────────────────────────────────
+
+
+class TestSearch:
+    def test_empty_db_returns_empty(self):
+        results = ek._search_local(keywords="null")
+        assert results == []
+
+    def test_keyword_in_title(self):
+        _write(_make_record({"title": "Null pointer in login flow"}))
+        _write(_make_record({"title": "CSS layout broken"}))
+        results = ek._search_local(keywords="null")
+        assert len(results) == 1
+        assert "Null pointer" in results[0].get("title", "")
+
+    def test_keyword_in_root_cause(self):
+        _write(_make_record({
+            "title": "Login crash",
+            "root_cause": "Missing authentication check",
+        }))
+        results = ek._search_local(keywords="authentication")
+        assert len(results) == 1
+
+    def test_filter_by_lang(self):
+        _write(_make_record({"title": "Python error", "lang": "python"}))
+        _write(_make_record({"title": "C# error", "lang": "csharp"}))
+        results = ek._search_local(keywords="error", lang="python")
+        assert len(results) == 1
+        assert results[0].get("lang") == "python"
+
+    def test_filter_by_scope(self):
+        _write(_make_record({"title": "Generic error", "scope": "generic", "lang": "python"}))
+        _write(_make_record({
+            "title": "Biz error",
+            "scope": "business-specific",
+            "project": "myapp",
+            "lang": "",
+        }))
+        results = ek._search_local(keywords="error", scope="generic")
+        assert len(results) == 1
+        assert results[0].get("scope") == "generic"
+
+    def test_tfidf_ranking_title_higher_than_body(self):
+        """Title match should rank higher than body-only match."""
+        _write(_make_record({
+            "title": "Something about tokens",
+            "root_cause": "Other stuff",
+        }))
+        _write(_make_record({
+            "title": "Random error",
+            "root_cause": "The tokens issue is here",
+        }))
+        results = ek._search_local(keywords="tokens")
+        assert len(results) == 2
+        # Title match should be first (higher score)
+        assert "tokens" in results[0].get("title", "").lower()
+
+    def test_no_keywords_returns_all(self):
+        _write(_make_record({"title": "Error A"}))
+        _write(_make_record({"title": "Error B"}))
+        results = ek._search_local(keywords="")
+        assert len(results) == 2
+
+    def test_limit(self):
+        for i in range(5):
+            _write(_make_record({"title": f"Error {i}"}))
+        results = ek._search_local(keywords="Error", limit=3)
+        assert len(results) == 3
+
+
+# ── Format markdown ────────────────────────────────────────────────────────
+
+
+class TestFormatMarkdown:
+    def test_roundtrip(self):
+        record = _make_record()
+        md = ek._format_markdown(record)
+        # Parse it back
+        fp = ek.ROOT / "roundtrip.md"
+        fp.write_text(md, encoding="utf-8")
+        parsed = ek._parse(fp)
+        assert parsed is not None
+        assert parsed["title"] == record["title"]
+        assert parsed["root_cause"] == record["root_cause"]
+
+    def test_empty_fields_omitted(self):
+        record = _make_record({"root_cause": "", "fix_summary": ""})
+        md = ek._format_markdown(record)
+        assert "root_cause" not in md
+        assert "fix_summary" not in md
+
+
+# ── Stats ──────────────────────────────────────────────────────────────────
+
+
+class TestStats:
+    def test_counts(self):
+        _write(_make_record({"title": "E1", "scope": "generic", "lang": "python"}))
+        _write(_make_record({"title": "E2", "scope": "generic", "lang": "python"}))
+        _write(_make_record({"title": "E3", "scope": "business-specific", "project": "app"}))
+        records = ek._load_index()
+        assert len(records) == 3
+        generic = sum(1 for r in records if r.get("scope") == "generic")
+        biz = sum(1 for r in records if r.get("scope") == "business-specific")
+        assert generic == 2
+        assert biz == 1
+
+
+# ── Auto archive ───────────────────────────────────────────────────────────
+
+
+class TestAutoArchive:
+    def test_moves_flat_files(self):
+        # Write files at root level (not in subdirectories)
+        for i in range(3):
+            rec = _make_record({"title": f"Err {i}", "lang": "python"})
+            # write directly to root, bypassing _resolve_path
+            fp = ek.ROOT / f"err_{i}.md"
+            fp.write_text(ek._format_markdown(rec), encoding="utf-8")
+
+        ek._auto_archive()
+        # After archiving, files should be in generic/python/
+        archived = list((ek.GENERIC / "python").glob("*.md"))
+        assert len(archived) == 3


### PR DESCRIPTION
## What does this PR do?

Adds `error-knowledge-mcp` — a self-contained MCP server that maintains a local, file-based knowledge base of error patterns. Every time an agent diagnoses and fixes a bug, it can record the root cause, reproduction steps, and fix summary. Future sessions query this knowledge base via BM25 search to avoid repeating the same mistakes.

Records are stored as flat markdown files under `~/.hermes/knowledge/errors/` with two scopes:
- `generic/<lang>/` — language-level patterns reusable across projects
- `business-specific/<project>/` — project-local logic errors

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor
- [x] 🎯 New skill (bundled or hub)

## Changes Made

- `optional-skills/mcp/error-knowledge-mcp/SKILL.md` — skill documentation with storage structure, tool reference, configuration
- `optional-skills/mcp/error-knowledge-mcp/scripts/server.py` — MCP server implementation (~425 lines). Tools: search_error_patterns (TF-IDF), record_error_pattern (auto-dedup via SequenceMatcher), knowledge_stats
- `optional-skills/mcp/error-knowledge-mcp/scripts/test_server.py` — 27 pytest tests

## How to Test

1. Run `pytest optional-skills/mcp/error-knowledge-mcp/scripts/test_server.py -q` — all 27 tests pass
2. Register in config.yaml under `mcp_servers:`
3. Start Hermes and call `search_error_patterns(keywords="null pointer")`

## For New Skills

- [x] This skill is broadly useful to most users — error pattern recall benefits all developers
- [x] SKILL.md follows the standard format (frontmatter, description, tools, configuration)
- [x] No external dependencies beyond `mcp` pip package (already in Hermes dependencies)
- [x] I've tested the skill end-to-end

## Checklist

### Code
- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`feat(skills):`)
- [x] I searched for existing PRs
- [x] My PR contains only changes related to this skill
- [x] I've run `pytest tests/ -q` — all tests pass
- [x] I've added tests for my changes (27 tests)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping
- [x] I've updated relevant documentation (SKILL.md, module docstring)
- [ ] N/A — no config keys changed
- [ ] N/A — no architecture changes
- [x] Cross-platform: Linux, macOS, Windows (stdlib only, env-var configured paths)
- [x] Updated tool descriptions/schemas