### PR TITLE
fix(gateway): populate start_time off Linux via psutil fallback

### DIFF
--- a/gateway/status.py
+++ b/gateway/status.py
@@ -115,6 +115,18 @@ def _get_process_start_time(pid: int) -> Optional[int]:
         # Field 22 in /proc/<pid>/stat is process start time (clock ticks).
         return int(stat_path.read_text(encoding="utf-8").split()[21])
     except (FileNotFoundError, IndexError, PermissionError, ValueError, OSError):
+        pass
+
+    # Non-Linux fallback (Windows / macOS): psutil is a core dependency,
+    # already used by _pid_exists() and _read_process_cmdline().  create_time()
+    # returns a stable per-process epoch timestamp that changes when a PID is
+    # reused, which is exactly what start_time is used for here.  Without this
+    # fallback start_time was always None off Linux, weakening PID liveness /
+    # PID-reuse detection in the gateway state files.
+    try:
+        import psutil  # type: ignore
+        return int(psutil.Process(pid).create_time())
+    except Exception:
         return None
 
 


### PR DESCRIPTION
## Summary

`gateway/status.py::_get_process_start_time()` reads the process start time **only** from `/proc/<pid>/stat`, which exists on Linux only. On Windows and macOS every call raises `FileNotFoundError` and the function returns `None`.

`start_time` is the field the gateway uses to distinguish "the recorded PID is still the same gateway process" from "that PID died and was reused by something else". With `start_time` permanently `None` off Linux:

- `gateway.pid`, `gateway.lock`, and `gateway_state.json` all store `"start_time": null`.
- After an unclean shutdown (crash, hard kill, power-off), the stale state file keeps `gateway_state: "running"` with a dead PID, and the PID-reuse guard can't catch it.

The sibling function `_read_process_cmdline()` in the same module already handles this with a three-tier strategy (Linux `/proc` → macOS `ps` → Windows `psutil`). `_get_process_start_time()` simply never got the psutil fallback.

## Fix

Add a psutil fallback after the `/proc` attempt, mirroring `_read_process_cmdline()`:

```python
try:
    import psutil  # type: ignore
    return int(psutil.Process(pid).create_time())
except Exception:
    return None
```

`psutil` is already a core dependency. `create_time()` returns a stable, per-process value that changes when a PID is reused — exactly what `start_time` is compared against. The value's epoch (Linux clock-ticks vs. psutil epoch seconds) never matters because `start_time` is only ever compared to another `start_time` produced by the same function on the same host.

## Testing

Reproduced and verified on Windows 11 (Python 3.11, psutil 7.2.2):

| Step | Result |
|------|--------|
| `_get_process_start_time(os.getpid())` before fix | `None` (FileNotFoundError) — RED |
| `_get_process_start_time(os.getpid())` after fix | valid int, e.g. `1779416596` — GREEN |
| `_build_pid_record()` after fix | `start_time` populated (was `null`) |
| `_build_runtime_status_record()` after fix | `start_time` populated (was `null`) |
| Live gateway restart | `gateway_state.json` / `gateway.pid` / `gateway.lock` all carry a real `start_time`, cross-checked against `psutil.Process(pid).create_time()` |
| `import gateway.status` | OK, no syntax errors |

No behaviour change on Linux: the `/proc` path still wins; the psutil fallback only runs when `/proc` is unavailable.

## Notes

- Affects all non-Linux platforms (Windows + macOS), not just Windows.
- Minimal, self-contained change to a single function; no public API change.
