### PR TITLE
fix(feishu): in-process WS liveness watchdog for silent half-open connections

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -388,6 +388,8 @@ class FeishuAdapterSettings:
     ws_reconnect_interval: int = 120
     ws_ping_interval: Optional[int] = None
     ws_ping_timeout: Optional[int] = None
+    ws_watchdog_stale_seconds: int = 3600
+    ws_watchdog_check_interval: int = 60
     admins: frozenset[str] = frozenset()
     default_group_policy: str = ""
     group_rules: Dict[str, FeishuGroupRule] = field(default_factory=dict)
@@ -1427,6 +1429,9 @@ class FeishuAdapter(BasePlatformAdapter):
         # Feishu reaction deletion requires the opaque reaction_id returned
         # by create, so we cache it per message_id.
         self._pending_processing_reactions: "OrderedDict[str, str]" = OrderedDict()
+        # WS liveness watchdog: track last inbound activity, force reconnect when stale.
+        self._last_inbound_ts: float = time.time()
+        self._ws_watchdog_task: Optional[asyncio.Task] = None
         self._load_seen_message_ids()
 
     @staticmethod
@@ -1520,6 +1525,18 @@ class FeishuAdapter(BasePlatformAdapter):
             ws_reconnect_interval=_coerce_required_int(extra.get("ws_reconnect_interval"), default=120, min_value=1),
             ws_ping_interval=_coerce_int(extra.get("ws_ping_interval"), default=None, min_value=1),
             ws_ping_timeout=_coerce_int(extra.get("ws_ping_timeout"), default=None, min_value=1),
+            ws_watchdog_stale_seconds=_coerce_required_int(
+                extra.get("ws_watchdog_stale_seconds")
+                or os.getenv("FEISHU_WS_WATCHDOG_STALE_SECONDS"),
+                default=3600,
+                min_value=0,
+            ),
+            ws_watchdog_check_interval=_coerce_required_int(
+                extra.get("ws_watchdog_check_interval")
+                or os.getenv("FEISHU_WS_WATCHDOG_CHECK_INTERVAL"),
+                default=60,
+                min_value=5,
+            ),
             admins=admins,
             default_group_policy=default_group_policy,
             group_rules=group_rules,
@@ -1557,6 +1574,8 @@ class FeishuAdapter(BasePlatformAdapter):
         self._ws_reconnect_interval = settings.ws_reconnect_interval
         self._ws_ping_interval = settings.ws_ping_interval
         self._ws_ping_timeout = settings.ws_ping_timeout
+        self._ws_watchdog_stale_seconds = settings.ws_watchdog_stale_seconds
+        self._ws_watchdog_check_interval = settings.ws_watchdog_check_interval
         self._allow_bots = settings.allow_bots
         self._require_mention = settings.require_mention
 
@@ -1636,6 +1655,7 @@ class FeishuAdapter(BasePlatformAdapter):
     async def disconnect(self) -> None:
         """Disconnect from Feishu/Lark."""
         self._running = False
+        await self._stop_ws_watchdog()
         await self._cancel_pending_tasks(self._pending_text_batch_tasks)
         await self._cancel_pending_tasks(self._pending_media_batch_tasks)
         self._reset_batch_buffers()
@@ -1698,6 +1718,115 @@ class FeishuAdapter(BasePlatformAdapter):
             setattr(self._ws_client, "_auto_reconnect", False)
         except Exception:
             pass
+        finally:
+            self._ws_client = None
+
+    def _start_ws_watchdog(self) -> None:
+        """Start the WS liveness watchdog (if not already running).
+
+        The lark-oapi SDK relies on `_receive_message_loop` to detect breakage
+        via `recv()` exceptions. When TCP goes half-open silently (NAT idle
+        eviction, network flap) `recv()` blocks forever while the SDK's own
+        `_ping_loop` keeps writing successfully — the SDK never knows the
+        connection is dead. This watchdog catches that case by tracking
+        application-level inbound activity and force-closing the underlying
+        websocket so the SDK's recv loop raises and triggers `_reconnect()`.
+        """
+        if self._ws_watchdog_stale_seconds <= 0:
+            logger.info("[Feishu] WS watchdog disabled (stale_seconds=0)")
+            return
+        loop = self._loop
+        if loop is None or loop.is_closed():
+            return
+        existing = self._ws_watchdog_task
+        if existing is not None and not existing.done():
+            return
+        self._last_inbound_ts = time.time()
+        try:
+            self._ws_watchdog_task = loop.create_task(
+                self._ws_liveness_watchdog(),
+                name="feishu-ws-watchdog",
+            )
+        except Exception as exc:
+            logger.warning("[Feishu] WS watchdog failed to start: %s", exc)
+            self._ws_watchdog_task = None
+            return
+        logger.info(
+            "[Feishu] WS watchdog started (stale_seconds=%d, check_interval=%d)",
+            self._ws_watchdog_stale_seconds,
+            self._ws_watchdog_check_interval,
+        )
+
+    async def _stop_ws_watchdog(self) -> None:
+        task = self._ws_watchdog_task
+        self._ws_watchdog_task = None
+        if task is None or task.done():
+            return
+        task.cancel()
+        try:
+            await task
+        except (asyncio.CancelledError, Exception):
+            pass
+
+    async def _ws_liveness_watchdog(self) -> None:
+        """Periodic liveness check; force-close stale WS so SDK reconnects."""
+        check_interval = max(5, int(self._ws_watchdog_check_interval))
+        stale_seconds = int(self._ws_watchdog_stale_seconds)
+        while True:
+            try:
+                await asyncio.sleep(check_interval)
+            except asyncio.CancelledError:
+                return
+            try:
+                elapsed = time.time() - self._last_inbound_ts
+                if elapsed < stale_seconds:
+                    continue
+                ws_client = self._ws_client
+                if ws_client is None:
+                    continue
+                # Reset the timer before forcing close to avoid double-firing
+                # while reconnection is in flight.
+                self._last_inbound_ts = time.time()
+                logger.warning(
+                    "[Feishu] WS watchdog: no inbound activity for %.0fs "
+                    "(threshold=%ds); forcing reconnect.",
+                    elapsed,
+                    stale_seconds,
+                )
+                await self._force_ws_reconnect()
+            except asyncio.CancelledError:
+                return
+            except Exception:
+                logger.exception("[Feishu] WS watchdog iteration failed")
+
+    async def _force_ws_reconnect(self) -> None:
+        """Close the underlying websocket so SDK's recv loop triggers reconnect."""
+        ws_client = self._ws_client
+        if ws_client is None:
+            return
+        thread_loop = self._ws_thread_loop
+        conn = getattr(ws_client, "_conn", None)
+        if conn is None or thread_loop is None or thread_loop.is_closed():
+            logger.warning(
+                "[Feishu] WS watchdog: no live connection to close "
+                "(conn=%s, thread_loop=%s)",
+                conn is not None,
+                thread_loop is not None,
+            )
+            return
+
+        async def _close() -> None:
+            try:
+                await conn.close(code=1011, reason="watchdog-stale")
+            except Exception as exc:
+                logger.warning("[Feishu] WS watchdog close failed: %s", exc)
+
+        try:
+            fut = asyncio.run_coroutine_threadsafe(_close(), thread_loop)
+            await asyncio.wrap_future(fut)
+            logger.info("[Feishu] WS watchdog: forced socket close; SDK will reconnect")
+        except Exception as exc:
+            logger.warning("[Feishu] WS watchdog: failed to dispatch close: %s", exc)
         finally:
             self._ws_client = None
 
@@ -2223,6 +2352,8 @@ class FeishuAdapter(BasePlatformAdapter):
         during startup/restart or network-flap reconnect), the event is queued
         for replay instead of dropped.
         """
+        # Liveness signal for the WS watchdog — any inbound activity counts.
+        self._last_inbound_ts = time.time()
         loop = self._loop
         if not self._loop_accepts_callbacks(loop):
             start_drainer = self._enqueue_pending_inbound_event(data)
@@ -4404,6 +4535,7 @@ class FeishuAdapter(BasePlatformAdapter):
             self._ws_client,
             self,
         )
+        self._start_ws_watchdog()
 
     async def _connect_webhook(self) -> None:
         if not FEISHU_WEBHOOK_AVAILABLE:


### PR DESCRIPTION
## Problem

The lark-oapi SDK's `_receive_message_loop` only detects breakage when `recv()` raises. When a TCP connection goes half-open silently (NAT idle eviction, intermediate proxy timeout, network flap with no FIN/RST), `recv()` blocks forever while the SDK's own `_ping_loop` keeps writing successfully — the SDK never knows the socket is dead and never triggers `_reconnect()`.

### Observed

In production we lost inbound Feishu events for 20+ minutes after what looked like a clean SDK self-reconnect:

```
10:01:49  [Lark] ping timeout
10:02:12  [Lark] reconnected to wss://msg-frontier.feishu.cn/ws/v2
... 20 minutes of total silence, no errors, no [Lark] log lines ...
10:22:xx  user manually runs 'hermes gateway restart' — events flow again
```

The SDK believed it was healthy. Only a process restart cleared it.

Related upstream context: lark-oapi's `_ping_loop` writes opcode 0x09 every `ping_interval` but doesn't `await pong`. So once the kernel send buffer drains via TCP retransmits to a black hole, the SDK still thinks pings succeeded. We've seen this pattern multiple times — see [issue link if filed].

## Fix

An in-process watchdog that tracks application-level inbound activity (any `_on_message_event` call refreshes `_last_inbound_ts`). When no inbound is seen for `FEISHU_WS_WATCHDOG_STALE_SECONDS` (default 3600s), it dispatches `conn.close()` onto the SDK's internal thread loop. That makes `recv()` raise, and the SDK's existing reconnection path takes over — same code path that handles a normal disconnect.

### Knobs

| Setting | Env var | Default |
|---|---|---|
| `ws_watchdog_stale_seconds` | `FEISHU_WS_WATCHDOG_STALE_SECONDS` | `3600` |
| `ws_watchdog_check_interval` | `FEISHU_WS_WATCHDOG_CHECK_INTERVAL` | `60` |

Set `ws_watchdog_stale_seconds=0` to disable.

### Design notes

- Threshold defaults to **1 hour** — conservative; legitimate quiet bots (weekend, off-hours) won't bounce unnecessarily. Operators with chattier bots can lower it.
- The watchdog runs on the gateway's main asyncio loop (where `_on_message_event` schedules callbacks). The websocket itself lives on the SDK's own thread loop; we cross over via `asyncio.run_coroutine_threadsafe`.
- Started in `_connect_websocket`, stopped in `disconnect()`. Idempotent — won't double-start.
- After firing, the watchdog resets `_last_inbound_ts` and lets the SDK's existing retry/backoff handle reconnect. No new reconnect logic.

## Verification

```
pytest tests/gateway/test_feishu.py tests/gateway/test_feishu_bot_admission.py tests/gateway/test_feishu_bot_auth_bypass.py
264 passed in 6.01s
```

Live: deployed to local gateway, watchdog visible on startup:
```
[Feishu] WS watchdog started (stale_seconds=3600, check_interval=60)
[Feishu] Connected in websocket mode (feishu)
```

## Risk

- If `_last_inbound_ts` somehow isn't refreshed during a healthy-but-quiet hour, watchdog triggers a needless reconnect (1-2s gap). Mitigated by 1h default — bigger window than any normal quiet period.
- Doesn't touch the SDK; works as a guard around it. If lark-oapi later adds its own keepalive-pong tracking, this becomes a no-op (the inbound stream will keep `_last_inbound_ts` fresh).