### PR TITLE
fix(gateway): restore .md extension to MEDIA extraction allowlist

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2159,7 +2159,7 @@ class BasePlatformAdapter(ABC):
         # Extract MEDIA:<path> tags, allowing optional whitespace after the colon
         # and quoted/backticked paths for LLM-formatted outputs.
         media_pattern = re.compile(
-            r'''[`"']?MEDIA:\s*(?P<path>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|(?:~/|/)\S+(?:[^\S\n]+\S+)*?\.(?:png|jpe?g|gif|webp|mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|flac|epub|pdf|zip|rar|7z|docx?|xlsx?|pptx?|txt|csv|apk|ipa)(?=[\s`"',;:)\]}]|$))[`"']?'''
+            r'''[`"']?MEDIA:\s*(?P<path>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|(?:~/|/)\S+(?:[^\S\n]+\S+)*?\.(?:png|jpe?g|gif|webp|mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|flac|epub|pdf|zip|rar|7z|docx?|xlsx?|pptx?|txt|csv|md|apk|ipa)(?=[\s`"',;:)\]}]|$))[`"']?'''
         )
         for match in media_pattern.finditer(content):
             path = match.group("path").strip()

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -16522,7 +16522,7 @@ class GatewayRunner:
                             r'MEDIA:((?:/|~\/)\S+\.(?:png|jpe?g|gif|webp|'
                             r'mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|'
                             r'flac|epub|pdf|zip|rar|7z|docx?|xlsx?|pptx?|'
-                            r'txt|csv|apk|ipa))',
+                            r'txt|csv|md|apk|ipa))',
                             re.IGNORECASE
                         )
                         for _match in _TOOL_MEDIA_RE.finditer(_hc):
@@ -16818,7 +16818,7 @@ class GatewayRunner:
                                 r'MEDIA:((?:/|~\/)\S+\.(?:png|jpe?g|gif|webp|'
                                 r'mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|'
                                 r'flac|epub|pdf|zip|rar|7z|docx?|xlsx?|pptx?|'
-                                r'txt|csv|apk|ipa))',
+                                r'txt|csv|md|apk|ipa))',
                                 re.IGNORECASE
                             )
                             for match in _TOOL_MEDIA_RE.finditer(content):

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -360,10 +360,19 @@ class TestExtractMedia:
         assert "[[audio_as_voice]]" not in cleaned
         assert "[[as_document]]" not in cleaned
 
+    def test_markdown_file_extraction(self):
+        """Regression: .md files delivered via MEDIA: tag must be extracted."""
+        content = "Here is your document:\nMEDIA:/tmp/report.md"
+        media, cleaned = BasePlatformAdapter.extract_media(content)
+        assert media == [("/tmp/report.md", False)]
+        assert "MEDIA:" not in cleaned
+        assert "Here is your document" in cleaned
 
-# ---------------------------------------------------------------------------
+
+# -----------------------------------------------------------------------------
 # should_send_media_as_audio
-# ---------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
+
 
 class TestShouldSendMediaAsAudio:
     """Audio-routing policy shared by gateway + scheduler + send_message."""


### PR DESCRIPTION
## Summary

Commit ea49b3862 ("tighten MEDIA extraction regex + silent skip on file-not-found") replaced the permissive `MEDIA:\\S+` regex with an explicit extension allowlist in three places. The `.md` (Markdown) extension was inadvertently omitted from that allowlist.

## Changes

- `gateway/platforms/base.py` — `extract_media()`: add `md` to the extension alternation
- `gateway/run.py` — `_TOOL_MEDIA_RE` (×2): add `md` to the extension alternation

All three patterns now include `|md` alongside `|txt|csv|apk|ipa`.

## Verification

- `python3 -m py_compile` passes on both modified files
- All 15 `TestExtractMedia` tests pass (including a new regression test added for this fix)
- No other extensions or behaviour are affected
- The fix is a pure additive change to three regex literals; no logic changes

Closes #30186
