### PR TITLE
fix(gateway): refuse --replace across HERMES_PROFILE mismatch (#30155)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -19588,11 +19588,16 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
     # Prevent two gateways from running under the same HERMES_HOME.
     # The PID file is scoped to HERMES_HOME, so future multi-profile
     # setups (each profile using a distinct HERMES_HOME) will naturally
-    # allow concurrent instances without tripping this guard.
+    # allow concurrent instances without tripping this guard. When
+    # --replace is used and the existing pidfile names a different
+    # HERMES_PROFILE, we refuse the takeover instead of cross-killing a
+    # sibling profile that shares this HERMES_HOME (#30155).
     from gateway.status import (
+        _read_pid_record,
         acquire_gateway_runtime_lock,
         get_running_pid,
         get_process_start_time,
+        pidfile_records_different_profile,
         release_gateway_runtime_lock,
         remove_pid_file,
         terminate_pid,
@@ -19600,6 +19605,30 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
     existing_pid = get_running_pid()
     if existing_pid is not None and existing_pid != os.getpid():
         if replace:
+            current_profile = os.environ.get("HERMES_PROFILE")
+            existing_record = _read_pid_record()
+            if pidfile_records_different_profile(existing_record, current_profile):
+                existing_profile = (existing_record or {}).get("hermes_profile")
+                hermes_home = str(get_hermes_home())
+                logger.error(
+                    "Refusing --replace: existing gateway (PID %d) is running with "
+                    "HERMES_PROFILE=%r but this invocation has HERMES_PROFILE=%r "
+                    "under shared HERMES_HOME=%s. Set a distinct HERMES_HOME per "
+                    "profile to run them concurrently.",
+                    existing_pid, existing_profile, current_profile, hermes_home,
+                )
+                print(
+                    f"\n❌ Refusing --replace: another gateway is running under this "
+                    f"HERMES_HOME with a different HERMES_PROFILE.\n"
+                    f"   Existing gateway (PID {existing_pid}): HERMES_PROFILE={existing_profile!r}\n"
+                    f"   This invocation:                       HERMES_PROFILE={current_profile!r}\n"
+                    f"   HERMES_HOME={hermes_home}\n"
+                    f"\n"
+                    f"   Set a distinct HERMES_HOME for each profile (e.g. "
+                    f"/var/lib/hermes-<profile>) so each gets its own gateway.pid.\n",
+                    file=sys.stderr,
+                )
+                return False
             existing_start_time = get_process_start_time(existing_pid)
             logger.info(
                 "Replacing existing gateway instance (PID %d) with --replace.",

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -19593,11 +19593,11 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
     # HERMES_PROFILE, we refuse the takeover instead of cross-killing a
     # sibling profile that shares this HERMES_HOME (#30155).
     from gateway.status import (
-        _read_pid_record,
         acquire_gateway_runtime_lock,
         get_running_pid,
         get_process_start_time,
         pidfile_records_different_profile,
+        read_pid_record,
         release_gateway_runtime_lock,
         remove_pid_file,
         terminate_pid,
@@ -19606,7 +19606,7 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
     if existing_pid is not None and existing_pid != os.getpid():
         if replace:
             current_profile = os.environ.get("HERMES_PROFILE")
-            existing_record = _read_pid_record()
+            existing_record = read_pid_record()
             if pidfile_records_different_profile(existing_record, current_profile):
                 existing_profile = (existing_record or {}).get("hermes_profile")
                 hermes_home = str(get_hermes_home())

--- a/gateway/status.py
+++ b/gateway/status.py
@@ -393,13 +393,28 @@ def _record_matches_live_gateway_pid(
     return _record_looks_like_gateway(record)
 
 
+def _normalize_hermes_profile(profile: Optional[str]) -> Optional[str]:
+    """Canonicalize a HERMES_PROFILE value for storage and comparison.
+
+    An unset, empty, or whitespace-only value all mean "no profile" and must
+    compare equal, otherwise a stray ``HERMES_PROFILE=`` (or a value padded
+    with whitespace) would be treated as a distinct profile and could
+    spuriously refuse — or allow — a --replace takeover. Non-empty values are
+    stripped so equivalent values agree across the read and write paths.
+    """
+    if profile is None:
+        return None
+    stripped = profile.strip()
+    return stripped or None
+
+
 def _build_pid_record() -> dict:
     return {
         "pid": os.getpid(),
         "kind": _GATEWAY_KIND,
         "argv": list(sys.argv),
         "start_time": _get_process_start_time(os.getpid()),
-        "hermes_profile": os.environ.get("HERMES_PROFILE"),
+        "hermes_profile": _normalize_hermes_profile(os.environ.get("HERMES_PROFILE")),
     }
 
 
@@ -413,10 +428,15 @@ def pidfile_records_different_profile(
     ``hermes_profile`` field (e.g. written by an older gateway build) returns
     False so we preserve the prior "one HERMES_HOME, one gateway" behavior on
     upgrade. Same-profile records (including both-None) also return False.
+
+    Both sides are normalized (empty/whitespace-only treated as "no profile",
+    non-empty values stripped) so a stray ``HERMES_PROFILE=`` or whitespace
+    padding is not mistaken for a distinct profile.
     """
     if not isinstance(existing_record, dict) or "hermes_profile" not in existing_record:
         return False
-    return existing_record.get("hermes_profile") != current_profile
+    existing_profile = _normalize_hermes_profile(existing_record.get("hermes_profile"))
+    return existing_profile != _normalize_hermes_profile(current_profile)
 
 
 def _build_runtime_status_record() -> dict[str, Any]:

--- a/gateway/status.py
+++ b/gateway/status.py
@@ -504,6 +504,16 @@ def _read_pid_record(pid_path: Optional[Path] = None) -> Optional[dict]:
     return None
 
 
+def read_pid_record(pid_path: Optional[Path] = None) -> Optional[dict]:
+    """Public wrapper around :func:`_read_pid_record`.
+
+    Lets callers outside this module (e.g. ``gateway.run``'s --replace
+    takeover check) read the gateway pidfile record without reaching into the
+    private ``_read_pid_record`` and coupling to pidfile-parsing internals.
+    """
+    return _read_pid_record(pid_path)
+
+
 def _read_gateway_lock_record(lock_path: Optional[Path] = None) -> Optional[dict[str, Any]]:
     return _read_pid_record(lock_path or _get_gateway_lock_path())
 

--- a/gateway/status.py
+++ b/gateway/status.py
@@ -399,7 +399,24 @@ def _build_pid_record() -> dict:
         "kind": _GATEWAY_KIND,
         "argv": list(sys.argv),
         "start_time": _get_process_start_time(os.getpid()),
+        "hermes_profile": os.environ.get("HERMES_PROFILE"),
     }
+
+
+def pidfile_records_different_profile(
+    existing_record: Optional[dict[str, Any]],
+    current_profile: Optional[str],
+) -> bool:
+    """Return True when the existing pidfile names a different HERMES_PROFILE.
+
+    Used by --replace to refuse cross-profile takeover. A pidfile without the
+    ``hermes_profile`` field (e.g. written by an older gateway build) returns
+    False so we preserve the prior "one HERMES_HOME, one gateway" behavior on
+    upgrade. Same-profile records (including both-None) also return False.
+    """
+    if not isinstance(existing_record, dict) or "hermes_profile" not in existing_record:
+        return False
+    return existing_record.get("hermes_profile") != current_profile
 
 
 def _build_runtime_status_record() -> dict[str, Any]:

--- a/tests/gateway/test_runner_startup_failures.py
+++ b/tests/gateway/test_runner_startup_failures.py
@@ -422,6 +422,51 @@ async def test_start_gateway_replace_clears_marker_on_permission_denied(
 
 
 @pytest.mark.asyncio
+async def test_start_gateway_replace_refuses_cross_profile_takeover(monkeypatch, tmp_path):
+    """--replace must not SIGKILL a sibling gateway running under a different HERMES_PROFILE.
+
+    Regression for #30155: when two gateways share HERMES_HOME but have different
+    HERMES_PROFILE values, the second --replace invocation used to read the
+    sibling's pidfile and kill it. Now we read the existing pidfile's profile
+    field, compare to the current env, and refuse the takeover with a clear
+    error if they differ.
+    """
+    import json
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("HERMES_PROFILE", "beta")
+
+    (tmp_path / "gateway.pid").write_text(json.dumps({
+        "pid": 42,
+        "kind": "hermes-gateway",
+        "argv": ["python", "-m", "hermes_cli.main", "gateway", "run"],
+        "start_time": 111,
+        "hermes_profile": "alpha",
+    }))
+
+    terminate_calls: list = []
+
+    monkeypatch.setattr("gateway.status.get_running_pid", lambda: 42)
+    monkeypatch.setattr(
+        "gateway.status.terminate_pid",
+        lambda pid, force=False: terminate_calls.append((pid, force)),
+    )
+    monkeypatch.setattr("gateway.run.os.getpid", lambda: 100)
+    monkeypatch.setattr("tools.skills_sync.sync_skills", lambda quiet=True: None)
+    monkeypatch.setattr("hermes_logging.setup_logging", lambda hermes_home, mode: tmp_path)
+    monkeypatch.setattr("hermes_logging._add_rotating_handler", lambda *args, **kwargs: None)
+
+    from gateway.run import start_gateway
+
+    ok = await start_gateway(config=GatewayConfig(), replace=True, verbosity=None)
+
+    assert ok is False
+    assert terminate_calls == [], "Cross-profile sibling must not be SIGKILLed"
+    # The legitimate sibling's pidfile must remain on disk for it to keep running.
+    assert (tmp_path / "gateway.pid").exists()
+
+
+@pytest.mark.asyncio
 async def test_runner_degrades_gracefully_when_all_adapters_missing(monkeypatch, tmp_path, caplog):
     """When all enabled platforms have no adapter (missing library or credentials),
     the gateway should NOT return failure — it should warn and continue running for

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -1542,6 +1542,15 @@ class TestCorruptStatusFiles:
         p.write_text("4242", encoding="utf-8")
         assert status._read_pid_record(p) == {"pid": 4242}
 
+    def test_public_read_pid_record_matches_private(self, tmp_path):
+        # The public wrapper exists so callers outside gateway.status (e.g.
+        # gateway.run's --replace takeover check) don't reach into the private
+        # _read_pid_record. It must delegate with identical behavior.
+        p = tmp_path / "gateway.pid"
+        p.write_text(json.dumps({"pid": 99, "hermes_profile": "alpha"}), encoding="utf-8")
+        assert status.read_pid_record(p) == {"pid": 99, "hermes_profile": "alpha"}
+        assert status.read_pid_record(tmp_path / "missing.pid") is None
+
 
 class TestParseActiveAgents:
     """The shared read-side coercion used by BOTH HTTP surfaces (/api/status

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -294,6 +294,75 @@ class TestGatewayPidState:
             status.release_gateway_runtime_lock()
 
 
+class TestGatewayPidProfile:
+    """--replace must refuse cross-profile takeover when HERMES_HOME is shared (#30155)."""
+
+    def test_build_pid_record_includes_hermes_profile(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setenv("HERMES_PROFILE", "alpha")
+
+        record = status._build_pid_record()
+
+        assert record["hermes_profile"] == "alpha"
+
+    def test_build_pid_record_records_none_when_profile_unset(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.delenv("HERMES_PROFILE", raising=False)
+
+        record = status._build_pid_record()
+
+        assert "hermes_profile" in record
+        assert record["hermes_profile"] is None
+
+    def test_write_pid_file_persists_hermes_profile(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setenv("HERMES_PROFILE", "beta")
+
+        status.write_pid_file()
+
+        payload = json.loads((tmp_path / "gateway.pid").read_text())
+        assert payload["hermes_profile"] == "beta"
+
+    def test_pidfile_records_different_profile_flags_cross_profile_takeover(self):
+        existing = {"pid": 1000, "hermes_profile": "alpha"}
+
+        assert status.pidfile_records_different_profile(existing, "beta") is True
+
+    def test_pidfile_records_different_profile_allows_same_profile(self):
+        existing = {"pid": 1000, "hermes_profile": "alpha"}
+
+        assert status.pidfile_records_different_profile(existing, "alpha") is False
+
+    def test_pidfile_records_different_profile_allows_both_unset(self):
+        existing = {"pid": 1000, "hermes_profile": None}
+
+        assert status.pidfile_records_different_profile(existing, None) is False
+
+    def test_pidfile_records_different_profile_flags_asymmetric_unset(self):
+        # Existing gateway uses a profile; new invocation does not (or vice versa).
+        # Either way, the user is mixing profile-aware and profile-unaware launches
+        # under a shared HERMES_HOME — same footgun as the alpha/beta case.
+        existing_with_profile = {"pid": 1000, "hermes_profile": "alpha"}
+        assert status.pidfile_records_different_profile(existing_with_profile, None) is True
+
+        existing_without_profile = {"pid": 1000, "hermes_profile": None}
+        assert status.pidfile_records_different_profile(existing_without_profile, "alpha") is True
+
+    def test_pidfile_records_different_profile_skips_legacy_record_without_field(self):
+        # An old pidfile written before this change has no ``hermes_profile`` key.
+        # We can't infer the running gateway's profile, so we preserve the prior
+        # "one HERMES_HOME, one gateway" behavior and let --replace proceed.
+        legacy_existing = {"pid": 1000, "kind": "hermes-gateway"}
+
+        assert status.pidfile_records_different_profile(legacy_existing, "alpha") is False
+        assert status.pidfile_records_different_profile(legacy_existing, None) is False
+
+    def test_pidfile_records_different_profile_handles_missing_record(self):
+        # If the pidfile vanished between get_running_pid() and the profile read,
+        # _read_pid_record() returns None — treat as "nothing to refuse".
+        assert status.pidfile_records_different_profile(None, "alpha") is False
+
+
 class TestGatewayRuntimeStatus:
     def test_write_json_file_uses_atomic_json_write(self, tmp_path, monkeypatch):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -362,6 +362,34 @@ class TestGatewayPidProfile:
         # _read_pid_record() returns None — treat as "nothing to refuse".
         assert status.pidfile_records_different_profile(None, "alpha") is False
 
+    def test_pidfile_records_different_profile_treats_blank_as_unset(self):
+        # A stray ``HERMES_PROFILE=`` (or whitespace-only) must NOT be treated as
+        # a distinct profile: empty/whitespace and unset both mean "no profile",
+        # so neither read nor write path should spuriously refuse a --replace.
+        existing_none = {"pid": 1000, "hermes_profile": None}
+        for blank in ("", "   ", "\t", "\n"):
+            assert status.pidfile_records_different_profile(existing_none, blank) is False
+
+        existing_blank = {"pid": 1000, "hermes_profile": "  "}
+        assert status.pidfile_records_different_profile(existing_blank, None) is False
+        assert status.pidfile_records_different_profile(existing_blank, "") is False
+
+        # Whitespace padding around a real profile name still compares equal.
+        existing_alpha = {"pid": 1000, "hermes_profile": "alpha"}
+        assert status.pidfile_records_different_profile(existing_alpha, "  alpha  ") is False
+        # ...and a genuinely different profile still flags.
+        assert status.pidfile_records_different_profile(existing_alpha, " beta ") is True
+
+    def test_build_pid_record_normalizes_blank_profile_to_none(self, tmp_path, monkeypatch):
+        # A blank HERMES_PROFILE written into the pid record must canonicalize to
+        # None so the read path agrees with an unset launch.
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setenv("HERMES_PROFILE", "   ")
+
+        record = status._build_pid_record()
+
+        assert record["hermes_profile"] is None
+
 
 class TestGatewayRuntimeStatus:
     def test_write_json_file_uses_atomic_json_write(self, tmp_path, monkeypatch):


### PR DESCRIPTION
## What does this PR do?

`hermes gateway run --replace` resolves the pidfile via `get_hermes_home()`
only (`gateway/status.py:45-47`), so two gateways sharing a HERMES_HOME but
launched with different HERMES_PROFILE values share
`{HERMES_HOME}/gateway.pid`. The newer invocation reads the sibling's PID
and SIGKILLs it, then the killed sibling's systemd unit restarts and races
back — surfaces as a Telegram 409 conflict flap (or equivalent on other
transports).

The documented design contract is "one HERMES_HOME, one gateway"
(`gateway/run.py:17765-17769` and the `gateway/status.py` module docstring):
each profile is expected to use a distinct HERMES_HOME. That contract is
correct but never surfaced to operators who set HERMES_PROFILE without
per-profile HERMES_HOME.

This PR implements option (b) from the issue (the option the reporter
explicitly preferred): fail-loud at startup on profile collision instead of
silently cross-killing.

Mirrors the existing pidfile contract — keyed by HERMES_HOME, so different
profiles must use different HERMES_HOMEs to run concurrently. The fix
surfaces that requirement loudly instead of changing it.

## Related Issue

Fixes #30155

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- ``gateway/status.py`` — record ``hermes_profile`` (the value of
  ``os.environ.get(\"HERMES_PROFILE\")``) in ``_build_pid_record()``
  alongside the existing pid/kind/argv/start_time metadata. Persisted via
  ``write_pid_file()`` into ``{HERMES_HOME}/gateway.pid``.
- ``gateway/status.py`` — new ``pidfile_records_different_profile()``
  helper. Returns True only when the existing record contains a
  ``hermes_profile`` field that differs from the current process's
  HERMES_PROFILE. Legacy records (no field) and missing records return
  False so single-profile deployments and upgrade-in-place behavior are
  unchanged.
- ``gateway/run.py`` — in ``start_gateway()``'s ``--replace`` branch, read
  the existing pidfile via ``_read_pid_record()`` before terminating. If
  the helper flags a profile mismatch, log + print a clear error citing
  both profiles and HERMES_HOME, and return ``False`` without killing the
  sibling.
- ``tests/gateway/test_status.py`` — 9 unit tests covering the new field
  on ``_build_pid_record``, ``write_pid_file``, and every branch of the
  ``pidfile_records_different_profile`` predicate (same-profile,
  cross-profile, asymmetric-unset, legacy-without-field, missing-record).
- ``tests/gateway/test_runner_startup_failures.py`` — one integration
  test wiring the helper into the real ``start_gateway`` ``--replace``
  branch: writes a sibling pidfile with ``hermes_profile=\"alpha\"``, runs
  ``start_gateway(replace=True)`` under ``HERMES_PROFILE=beta``, and
  asserts ``terminate_pid`` was never called and the sibling pidfile is
  still on disk.

## How to Test

1. Run the new tests:
   ```
   uv run --with pytest --with pytest-xdist --with pytest-asyncio --with pytest-timeout python3 -m pytest tests/gateway/test_status.py tests/gateway/test_runner_startup_failures.py -v
   ```
2. Result: 69 passed (existing 59 in ``test_status.py`` + 9 new + 1 new
   integration test in ``test_runner_startup_failures.py`` alongside the
   existing 9 there).
3. To reproduce the original bug, check out ``main`` and run the new
   ``test_start_gateway_replace_refuses_cross_profile_takeover``
   integration test — it fails because ``terminate_pid`` is called and
   ``start_gateway`` returns True. With the fix, ``terminate_pid`` is
   never called and the function returns False.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (``fix(scope):``, ``feat(scope):``, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run focused tests for the touched code and all pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.x

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, ``docs/``, docstrings) — module docstring on the gateway/status.py change is internal-only and the existing one already describes the HERMES_HOME-scoping contract this fix surfaces
- [x] I've updated ``cli-config.yaml.example`` if I added/changed config keys — N/A (no new config keys)
- [x] I've updated ``CONTRIBUTING.md`` or ``AGENTS.md`` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pidfile path resolution is unchanged; only the JSON payload gained a field
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Contract Protected

The pidfile's "one HERMES_HOME, one gateway" invariant from
``gateway/run.py:17765-17769``. The fix doesn't change the invariant; it
catches the case where a user *implicitly* tries to violate it by reusing
HERMES_HOME across profiles, and refuses the cross-profile takeover with a
clear remediation hint (set a distinct HERMES_HOME per profile).

Known-bad input covered by the unit tests: existing-profile=\"alpha\" /
current-profile=\"beta\", asymmetric existing-profile=\"alpha\" /
current=None, and the reverse. Same-profile and both-None pass through to
the existing takeover path unchanged. Legacy pidfiles that predate this
change have no ``hermes_profile`` field and are treated as "unknown profile"
— the helper returns False and ``--replace`` proceeds as before, so the
upgrade story is non-disruptive.

> Audited siblings: ``gateway/status.py`` has a single pidfile resolver
> (``_get_pid_path``) and a single record builder (``_build_pid_record``);
> ``gateway/run.py`` has a single ``--replace`` branch in
> ``start_gateway``. No other call site reads ``gateway.pid`` to decide
> whether to terminate another gateway. No widening needed.