### PR TITLE
feat(whoop): add Whoop API skill with OAuth2, cron setup, and cross-platform storage

### DIFF
--- a/skills/health/whoop-api/.gitignore
+++ b/skills/health/whoop-api/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+whoop_data/
+*.pyc

--- a/skills/health/whoop-api/SKILL.md
+++ b/skills/health/whoop-api/SKILL.md
@@ -80,7 +80,7 @@ All commands run from the skill directory. Use absolute paths when calling from 
 
 | Flag | Default | Description |
 |---|---|---|
-| `--data-dir PATH` | `./whoop_data` | Output directory for JSON files |
+| `--data-dir PATH` | `./whoop_data` | Output directory for JSON files (use absolute paths for cron) |
 
 ### API Endpoints
 

--- a/skills/health/whoop-api/SKILL.md
+++ b/skills/health/whoop-api/SKILL.md
@@ -1,0 +1,170 @@
+---
+name: whoop-api
+description: Pull Whoop fitness data via OAuth2 API.
+version: 1.0.0
+author: Nirbhay Shah (nirbhayshah)
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [whoop, fitness, health, api, oauth, wearable]
+    related_skills: [fitness, fitness-coaching]
+    requires_toolsets: [terminal]
+---
+
+# Whoop API Skill
+
+Pull recovery, strain, sleep, and workout data from the Whoop API using OAuth2.
+Read-only — does not push data or modify Whoop settings.
+
+## When to Use
+
+- User asks for Whoop data (recovery score, strain, sleep, HRV)
+- Fitness or health coaching needs real wearable metrics
+- Cron job needs to sync Whoop data for dashboards or analysis
+- Don't use for: modifying Whoop settings, push notifications, or real-time streaming
+
+## Prerequisites
+
+- Whoop Developer App registered at [developer.whoop.com](https://developer.whoop.com)
+- Python 3.10+
+- `requests` library: `pip install requests`
+- macOS: tokens stored in Keychain (service: `whoop-api`)
+- Linux/Windows: tokens stored in JSON file at `~/.config/whoop-api/tokens.json`
+
+### App Registration
+
+1. Go to [developer.whoop.com](https://developer.whoop.com) and create an application
+2. Set redirect URI to `http://localhost:8647/callback`
+3. Select scopes: `read:recovery`, `read:cycles`, `read:sleep`, `read:workout`, `read:body_measurement`, `read:profile`, `offline`
+4. Copy Client ID and Client Secret — you'll need these during setup
+
+### Privacy Policy (Required by Whoop)
+
+Whoop requires a publicly accessible privacy policy URL for app registration. A sample is included at `references/privacy-policy.html`.
+
+**GitHub Pages (recommended):** Create a repo, add the HTML file, enable Pages. Update the contact URL in the HTML to your own repo.
+
+**GitHub Gist:** `gist references/privacy-policy.html` — use the raw URL as your privacy policy URL.
+
+**Any static host:** Upload the file, update the contact link.
+
+After hosting, update `PRIVACY_POLICY_URL` in `scripts/whoop_sync.py` to match your URL.
+
+## How to Run
+
+```bash
+# First-time setup (run in your CLI — opens browser for OAuth)
+python scripts/whoop_sync.py setup
+
+# After setup, the agent can run these via the terminal tool:
+python scripts/whoop_sync.py status
+python scripts/whoop_sync.py pull
+python scripts/whoop_sync.py refresh
+```
+
+All commands run from the skill directory. Use absolute paths when calling from outside.
+
+## Quick Reference
+
+### CLI Commands
+
+| Command | Description |
+|---|---|
+| `setup` | Interactive OAuth flow — prompts for credentials, opens browser, stores tokens, creates cron jobs |
+| `status` | Show credential state, token state, cron status |
+| `pull` | Fetch all endpoints, save JSON to `whoop_data/{date}/` |
+| `refresh` | Refresh access token if expired |
+
+### CLI Flags
+
+| Flag | Default | Description |
+|---|---|---|
+| `--data-dir PATH` | `./whoop_data` | Output directory for JSON files |
+
+### API Endpoints
+
+| Endpoint | Path | Key Data |
+|---|---|---|
+| Cycle | `/v2/cycle` | Strain, heart rate, kilojoules |
+| Recovery | `/v2/recovery` | Recovery %, HRV, resting HR |
+| Sleep | `/v2/activity/sleep` | Sleep stages, efficiency, debt |
+| Workout | `/v2/activity/workout` | Strain by activity, duration |
+| Body | `/v2/user/measurement/body` | Weight, height |
+| Profile | `/v2/user/profile/basic` | User info |
+
+### Data Output
+
+```
+whoop_data/
+└── 2026-05-19/
+    ├── cycle.json
+    ├── recovery.json
+    ├── sleep.json
+    ├── workout.json
+    ├── body.json
+    └── profile.json
+```
+
+## Procedure
+
+### 1. First-Time Setup (User Action)
+
+The `setup` command opens a browser for OAuth authorization. This must be run by the user in their own terminal — the agent cannot interact with the browser.
+
+Tell the user:
+
+> "You need to run the setup command yourself in your terminal. It will open a browser for Whoop authorization. Run:
+> ```
+> python /path/to/skills/health/whoop-api/scripts/whoop_sync.py setup
+> ```
+> You'll need your Whoop Client ID and Client Secret from [developer.whoop.com](https://developer.whoop.com)."
+
+After the user completes setup, confirm with:
+
+```bash
+python scripts/whoop_sync.py status
+```
+
+### 2. Pull Data (Agent Action)
+
+```bash
+python scripts/whoop_sync.py pull --data-dir /absolute/path/to/data
+```
+
+Fetches all endpoints for the current day. Access tokens auto-refresh if expired.
+
+### 3. Schedule Regular Pulls
+
+The `setup` command automatically creates two Hermes cron jobs:
+- **Token refresh** every 55 minutes (keeps access tokens alive)
+- **Daily data pull** at 7:00 AM local time
+
+If you're not using Hermes cron, or want to use a different scheduler, set up manually:
+
+**System crontab (Linux/macOS):**
+```bash
+0 7 * * * cd /path/to/whoop-api && python scripts/whoop_sync.py pull --data-dir /path/to/data
+*/55 * * * * cd /path/to/whoop-api && python scripts/whoop_sync.py refresh
+```
+
+**Windows Task Scheduler:** Create a scheduled task pointing to the `pull` command.
+
+See `templates/cron-entry.yaml` for Hermes cron examples.
+
+## Pitfalls
+
+- **Rate limit: 100 requests/minute, 10,000/day.** Each pull uses 6 requests (one per endpoint). Minimum safe interval: 5 minutes.
+- **Token expiry: 1 hour.** Access tokens expire every 3600s. `pull` auto-refreshes. If you get 401s, run `refresh` manually.
+- **Keychain discovery.** On macOS, the storage module locates the login keychain dynamically. If Keychain is unavailable (headless, SSH), tokens fall back to `~/.config/whoop-api/tokens.json`.
+- **OAuth callback port 8647.** Must be available during `setup`. If port is in use, the script exits with a clear error.
+- **No real-time data.** Whoop API is not streaming. Data appears 5-15 minutes after activity ends.
+- **`setup` is interactive.** It prompts for credentials and opens a browser — the agent cannot complete this step on behalf of the user. Direct them to run it in their own terminal.
+
+## Verification
+
+```bash
+python scripts/whoop_sync.py status && python scripts/whoop_sync.py pull && ls whoop_data/*/cycle.json
+```
+
+If `status` shows valid credentials and `pull` produces a `cycle.json` with valid JSON, the skill is working.

--- a/skills/health/whoop-api/SKILL.md
+++ b/skills/health/whoop-api/SKILL.md
@@ -86,12 +86,12 @@ All commands run from the skill directory. Use absolute paths when calling from 
 
 | Endpoint | Path | Key Data |
 |---|---|---|
-| Cycle | `/v2/cycle` | Strain, heart rate, kilojoules |
-| Recovery | `/v2/recovery` | Recovery %, HRV, resting HR |
-| Sleep | `/v2/activity/sleep` | Sleep stages, efficiency, debt |
-| Workout | `/v2/activity/workout` | Strain by activity, duration |
-| Body | `/v2/user/measurement/body` | Weight, height |
-| Profile | `/v2/user/profile/basic` | User info |
+| Cycle | `/developer/v2/cycle` | Strain, heart rate, kilojoules |
+| Recovery | `/developer/v2/recovery` | Recovery %, HRV, resting HR |
+| Sleep | `/developer/v2/activity/sleep` | Sleep stages, efficiency, debt |
+| Workout | `/developer/v2/activity/workout` | Strain by activity, duration |
+| Body | `/developer/v2/user/measurement/body` | Weight, height |
+| Profile | `/developer/v2/user/profile/basic` | User info |
 
 ### Data Output
 

--- a/skills/health/whoop-api/references/api-reference.md
+++ b/skills/health/whoop-api/references/api-reference.md
@@ -1,0 +1,127 @@
+# Whoop API Reference
+
+Base URL: `https://api.prod.whoop.com`
+
+All v2 endpoints require the `/developer/` prefix: `https://api.prod.whoop.com/developer/v2/...`
+
+## Authentication
+
+OAuth 2.0 Authorization Code flow.
+
+| Parameter | Value |
+|---|---|
+| Auth URL | `https://api.prod.whoop.com/oauth/oauth2/auth` |
+| Token URL | `https://api.prod.whoop.com/oauth/oauth2/token` |
+| Redirect URI | `http://localhost:8647/callback` |
+| Scopes | `read:recovery`, `read:cycles`, `read:sleep`, `read:workout`, `read:body_measurement`, `read:profile`, `offline` |
+
+### Token Exchange
+
+POST to token URL with:
+- `grant_type=authorization_code` (initial) or `grant_type=refresh_token` (refresh)
+- `client_id` + `client_secret`
+- `code` (initial) or `refresh_token` (refresh)
+- `redirect_uri` (initial only)
+
+Response:
+```json
+{
+  "access_token": "...",
+  "refresh_token": "...",
+  "token_type": "Bearer",
+  "expires_in": 3600
+}
+```
+
+Access tokens expire in 3600s (1 hour). Refresh tokens are single-use — each refresh returns a new refresh token.
+
+## Endpoints
+
+### Cycle (Strain)
+
+```
+GET /v2/cycle
+```
+
+| Param | Type | Description |
+|---|---|---|
+| `start` | ISO 8601 | Start datetime (required) |
+| `end` | ISO 8601 | End datetime (required) |
+| `limit` | int | Max results (default 25, max 25) |
+| `offset` | int | Pagination offset |
+
+Response fields: `id`, `strain`, `recovery_score`, `kiljoule`, `average_heart_rate`, `max_heart_rate`, `start`, `end`, `updated_at`
+
+### Recovery
+
+```
+GET /v2/recovery
+```
+
+Same pagination params as cycle.
+
+Response fields: `id`, `score{recovery_score, timestamp}`, `heart_rate_variability{rmssd, timestamp}`, `resting_heart_rate{rate, timestamp}`, `sleep_quality{percentage, timestamp}`, `cycle_id`, `created_at`, `updated_at`
+
+### Sleep
+
+```
+GET /v2/activity/sleep
+```
+
+Same pagination params.
+
+Response fields: `id`, `score{stage_summary{total, light, deep, rem, wake}, duration, efficiency, latency}`, `start`, `end`, `nap`, `created_at`, `updated_at`
+
+### Workout
+
+```
+ GET /v2/activity/workout
+```
+
+Same pagination params.
+
+Response fields: `id`, `strain`, `average_heart_rate`, `max_heart_rate`, `kiljoule`, `start`, `end`, `updated_at`
+
+### Body Measurement
+
+```
+GET /v2/user/measurement/body
+```
+
+No pagination params.
+
+Response fields: `height_meter`, `weight_kilogram`
+
+### Profile (Basic)
+
+```
+GET /v2/user/profile/basic
+```
+
+No pagination params.
+
+Response fields: `user_id`, `first_name`, `last_name`, `email`
+
+## Rate Limiting
+
+- 100 requests per minute per user
+- 10,000 requests per day per user
+- Response headers: `X-RateLimit-Limit`, `X-RateLimit-Remaining`, `X-RateLimit-Reset`
+- 429 Too Many Requests if either limit is exceeded
+- Retry-After header on 429 responses
+
+## Error Codes
+
+| Code | Meaning |
+|---|---|
+| 400 | Bad request (invalid params) |
+| 401 | Unauthorized (token expired or invalid) |
+| 403 | Forbidden (insufficient scope) |
+| 404 | Not found |
+| 429 | Rate limited |
+| 500 | Whoop server error |
+
+## Data Freshness
+
+Whoop syncs band data to servers every 5-15 minutes after activity ends. API returns
+the most recent data the server has — not real-time.

--- a/skills/health/whoop-api/references/api-reference.md
+++ b/skills/health/whoop-api/references/api-reference.md
@@ -50,7 +50,7 @@ GET /v2/cycle
 | `limit` | int | Max results (default 25, max 25) |
 | `offset` | int | Pagination offset |
 
-Response fields: `id`, `strain`, `recovery_score`, `kiljoule`, `average_heart_rate`, `max_heart_rate`, `start`, `end`, `updated_at`
+Response fields: `id`, `strain`, `recovery_score`, `kilojoule`, `average_heart_rate`, `max_heart_rate`, `start`, `end`, `updated_at`
 
 ### Recovery
 
@@ -80,7 +80,7 @@ Response fields: `id`, `score{stage_summary{total, light, deep, rem, wake}, dura
 
 Same pagination params.
 
-Response fields: `id`, `strain`, `average_heart_rate`, `max_heart_rate`, `kiljoule`, `start`, `end`, `updated_at`
+Response fields: `id`, `strain`, `average_heart_rate`, `max_heart_rate`, `kilojoule`, `start`, `end`, `updated_at`
 
 ### Body Measurement
 

--- a/skills/health/whoop-api/references/privacy-policy.html
+++ b/skills/health/whoop-api/references/privacy-policy.html
@@ -43,7 +43,7 @@
     <ul>
         <li>All data is stored on the account owner's personal machine.</li>
         <li>OAuth tokens are stored in the operating system's secure credential store
-            (macOS Keychain) or an encrypted local file.</li>
+            (macOS Keychain) or a local file with restricted permissions (owner-read-only).</li>
         <li>No data is transmitted to any server, cloud service, or third party.</li>
         <li>No cookies, tracking, or analytics are used.</li>
     </ul>

--- a/skills/health/whoop-api/references/privacy-policy.html
+++ b/skills/health/whoop-api/references/privacy-policy.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Whoop API Integration — Privacy Policy</title>
+    <style>
+        body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; max-width: 640px; margin: 2rem auto; padding: 0 1rem; color: #1a1a1a; line-height: 1.6; }
+        h1 { font-size: 1.5rem; }
+        h2 { font-size: 1.1rem; margin-top: 2rem; }
+        .updated { color: #666; font-size: 0.85rem; }
+    </style>
+</head>
+<body>
+    <h1>Whoop API Integration — Privacy Policy</h1>
+    <p class="updated">Last updated: May 2026</p>
+
+    <p>This is a personal, non-commercial project that connects to the Whoop API
+    for individual fitness data retrieval. It is not a product, service, or
+    business.</p>
+
+    <h2>Data We Access</h2>
+    <p>This integration requests read-only access to the following Whoop data,
+    belonging solely to the account owner:</p>
+    <ul>
+        <li>Recovery scores and HRV</li>
+        <li>Strain and cycle data</li>
+        <li>Sleep records</li>
+        <li>Workout history</li>
+        <li>Body measurements</li>
+        <li>Basic profile information</li>
+    </ul>
+
+    <h2>How Data Is Used</h2>
+    <ul>
+        <li>Data is retrieved via the Whoop API for the account owner's personal use only.</li>
+        <li>Data is stored locally on the account owner's device.</li>
+        <li>No data is sold, shared, transferred, or disclosed to third parties.</li>
+        <li>No data is aggregated, anonymized, or used for research.</li>
+    </ul>
+
+    <h2>Data Storage and Security</h2>
+    <ul>
+        <li>All data is stored on the account owner's personal machine.</li>
+        <li>OAuth tokens are stored in the operating system's secure credential store
+            (macOS Keychain) or an encrypted local file.</li>
+        <li>No data is transmitted to any server, cloud service, or third party.</li>
+        <li>No cookies, tracking, or analytics are used.</li>
+    </ul>
+
+    <h2>Data Retention</h2>
+    <p>Data is retained locally until the account owner deletes it. OAuth tokens
+    can be revoked at any time through the Whoop developer dashboard.</p>
+
+    <h2>Third-Party Services</h2>
+    <p>This integration only communicates with <code>api.prod.whoop.com</code>
+    (the official Whoop API). No other third-party services are involved.</p>
+
+    <h2>Changes</h2>
+    <p>Changes to this policy will be reflected by updating the date above.</p>
+
+    <h2>Contact</h2>
+    <p>Questions: open an issue at
+    <a href="https://github.com/nirbhu/hermes-agent/issues">github.com/nirbhu/hermes-agent</a>.</p>
+</body>
+</html>

--- a/skills/health/whoop-api/scripts/whoop_client.py
+++ b/skills/health/whoop-api/scripts/whoop_client.py
@@ -1,0 +1,219 @@
+"""Whoop API HTTP client with auto-refresh and rate limit handling.
+
+Provides WhoopClient that manages authentication, automatic token refresh,
+and rate limit backoff for all API interactions.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+from pathlib import Path
+
+import requests
+
+from whoop_endpoints import ENDPOINTS, Endpoint, all_endpoints
+from whoop_storage import load_tokens, save_tokens, load_client_credentials
+
+API_BASE = "https://api.prod.whoop.com"
+RATE_LIMIT = 100  # requests per minute
+RATE_WINDOW = 60  # seconds
+DAILY_RATE_LIMIT = 10000
+MAX_RETRIES = 3
+RETRY_BACKOFF = 2  # seconds, doubles each retry
+
+
+class TokenExpiredError(Exception):
+    """Raised when token refresh fails."""
+    pass
+
+
+class RateLimitError(Exception):
+    """Raised when rate limit is exceeded after retries."""
+    pass
+
+
+class WhoopClient:
+    """HTTP client for the Whoop API with auto-refresh and rate limiting."""
+
+    def __init__(self, data_dir: str | Path | None = None):
+        self.data_dir = Path(data_dir) if data_dir else Path("whoop_data")
+        self.session = requests.Session()
+        self.session.headers.update({
+            "Accept": "application/json",
+            "User-Agent": "hermes-whoop-skill/1.0",
+        })
+        self._request_timestamps: list[float] = []
+        self._load_auth()
+
+    def _load_auth(self) -> None:
+        """Load tokens from storage and set Authorization header."""
+        tokens = load_tokens()
+        if tokens is None:
+            sys.exit(
+                "ERROR: No tokens found. Run `whoop_sync.py setup` first."
+            )
+        self.session.headers["Authorization"] = f"Bearer {tokens['access_token']}"
+        self._tokens = tokens
+
+    def _refresh_if_needed(self) -> None:
+        """Refresh access token if expired or about to expire (5min buffer)."""
+        expires_at = self._tokens.get("expires_at", 0)
+        if time.time() < expires_at - 300:
+            return  # Still valid for 5+ minutes
+
+        print("Access token expired, refreshing...")
+        creds = load_client_credentials()
+        if not creds:
+            sys.exit("ERROR: No client credentials found. Run `whoop_sync.py setup` first.")
+        client_id = creds["client_id"]
+        client_secret = creds["client_secret"]
+
+        response = requests.post(
+            f"{API_BASE}/oauth/oauth2/token",
+            data={
+                "grant_type": "refresh_token",
+                "refresh_token": self._tokens["refresh_token"],
+                "client_id": client_id,
+                "client_secret": client_secret,
+            },
+            timeout=30,
+        )
+
+        if response.status_code == 401:
+            raise TokenExpiredError(
+                "Refresh token expired. Run `whoop_sync.py setup` to re-authenticate."
+            )
+        response.raise_for_status()
+        token_data = response.json()
+
+        new_expires_at = time.time() + token_data.get("expires_in", 3600)
+        save_tokens(
+            access_token=token_data["access_token"],
+            refresh_token=token_data["refresh_token"],
+            expires_at=new_expires_at,
+        )
+        self.session.headers["Authorization"] = f"Bearer {token_data['access_token']}"
+        self._tokens = {**token_data, "expires_at": new_expires_at}
+        print("Token refreshed successfully.")
+
+    def _rate_limit_wait(self) -> None:
+        """Enforce per-minute and daily rate limits."""
+        now = time.time()
+        # Remove timestamps older than the per-minute rate window
+        self._request_timestamps = [
+            ts for ts in self._request_timestamps
+            if ts > now - RATE_WINDOW
+        ]
+        if len(self._request_timestamps) >= RATE_LIMIT:
+            oldest = self._request_timestamps[0]
+            sleep_time = oldest + RATE_WINDOW - now + 0.1
+            if sleep_time > 0:
+                print(f"Per-minute rate limit reached, waiting {sleep_time:.1f}s...")
+                time.sleep(sleep_time)
+        # Check daily limit (86400s window)
+        day_ago = now - 86400
+        daily_count = sum(1 for ts in self._request_timestamps if ts > day_ago)
+        if daily_count >= DAILY_RATE_LIMIT:
+            print(f"Daily rate limit ({DAILY_RATE_LIMIT}) reached. Stopping.")
+            raise RateLimitError(f"Daily rate limit of {DAILY_RATE_LIMIT} requests exceeded")
+        self._request_timestamps.append(time.time())
+
+    def _request(self, method: str, endpoint: str, params: dict | None = None) -> dict:
+        """Make an authenticated API request with retry and rate limiting."""
+        self._refresh_if_needed()
+
+        for attempt in range(MAX_RETRIES):
+            self._rate_limit_wait()
+            try:
+                response = self.session.request(
+                    method, f"{API_BASE}{endpoint}",
+                    params=params, timeout=30,
+                )
+            except requests.RequestException as e:
+                if attempt < MAX_RETRIES - 1:
+                    print(f"Request failed ({e}), retrying in {RETRY_BACKOFF * (attempt + 1)}s...")
+                    time.sleep(RETRY_BACKOFF * (attempt + 1))
+                    continue
+                raise
+
+            if response.status_code == 200:
+                return response.json()
+            elif response.status_code == 429:
+                retry_after = int(response.headers.get("Retry-After", RETRY_BACKOFF))
+                print(f"Rate limited (429), waiting {retry_after}s...")
+                time.sleep(retry_after)
+                continue
+            elif response.status_code == 401:
+                # Token might have just expired, try refresh
+                try:
+                    self._refresh_if_needed()
+                    continue
+                except TokenExpiredError:
+                    raise
+            else:
+                response.raise_for_status()
+
+        raise RateLimitError(f"Failed after {MAX_RETRIES} retries for {endpoint}")
+
+    def pull_endpoint(self, endpoint: Endpoint, date: str | None = None) -> list[dict]:
+        """Pull data from a single endpoint, handling pagination if needed."""
+        params: dict[str, str] = {}
+        if endpoint.requires_pagination:
+            if date:
+                params["start"] = f"{date}T00:00:00.000Z"
+                params["end"] = f"{date}T23:59:59.999Z"
+            else:
+                # Default: yesterday (Whoop data has next-day availability)
+                from datetime import datetime, timedelta, timezone
+                yesterday = (datetime.now(timezone.utc) - timedelta(days=1)).strftime("%Y-%m-%d")
+                params["start"] = f"{yesterday}T00:00:00.000Z"
+                params["end"] = f"{yesterday}T23:59:59.999Z"
+
+        records = []
+        params_copy = dict(params)
+
+        while True:
+            data = self._request("GET", endpoint.path, params_copy)
+            # API returns list or dict with 'records' key
+            items = data if isinstance(data, list) else data.get("records", [])
+            records.extend(items)
+
+            # Check for pagination
+            next_token = data.get("next_token") if isinstance(data, dict) else None
+            if not next_token:
+                break
+            params_copy["nextToken"] = next_token
+
+        return records
+
+    def pull_all(self, date: str | None = None) -> dict[str, list[dict]]:
+        """Pull data from all registered endpoints. Returns {endpoint_name: records}."""
+        results: dict[str, list[dict]] = {}
+        for endpoint in all_endpoints():
+            print(f"  Pulling {endpoint.name}...")
+            try:
+                records = self.pull_endpoint(endpoint, date)
+                results[endpoint.name] = records
+                print(f"    {len(records)} records")
+            except Exception as e:
+                print(f"    Error: {e}")
+                results[endpoint.name] = []
+        return results
+
+    def save_data(self, data: dict[str, list[dict]], date: str | None = None) -> Path:
+        """Save pulled data to JSON files organized by date."""
+        from datetime import datetime, timedelta, timezone
+        date_str = date or (datetime.now(timezone.utc) - timedelta(days=1)).strftime("%Y-%m-%d")
+
+        date_dir = self.data_dir / date_str
+        date_dir.mkdir(parents=True, exist_ok=True)
+
+        for endpoint_name, records in data.items():
+            file_path = date_dir / f"{endpoint_name}.json"
+            file_path.write_text(json.dumps(records, indent=2))
+            print(f"  Saved {file_path}")
+
+        return date_dir

--- a/skills/health/whoop-api/scripts/whoop_client.py
+++ b/skills/health/whoop-api/scripts/whoop_client.py
@@ -15,7 +15,7 @@ from pathlib import Path
 import requests
 
 from whoop_endpoints import ENDPOINTS, Endpoint, all_endpoints
-from whoop_storage import load_tokens, save_tokens, load_client_credentials
+from whoop_storage import load_tokens, save_tokens, load_client_credentials, clear_tokens
 
 API_BASE = "https://api.prod.whoop.com"
 RATE_LIMIT = 100  # requests per minute
@@ -83,11 +83,22 @@ class WhoopClient:
         )
 
         if response.status_code == 401:
+            # Refresh token is invalid — clear stored tokens so status
+            # reports a clean re-auth requirement instead of silent stale state
+            clear_tokens()
             raise TokenExpiredError(
                 "Refresh token expired. Run `whoop_sync.py setup` to re-authenticate."
             )
-        response.raise_for_status()
+
+        # Catch OAuth error responses (e.g. invalid_grant) even on non-401 status
         token_data = response.json()
+        if "error" in token_data:
+            clear_tokens()
+            raise TokenExpiredError(
+                f"Token refresh failed: {token_data['error']}. Run `whoop_sync.py setup` to re-authenticate."
+            )
+
+        response.raise_for_status()
 
         new_expires_at = time.time() + token_data.get("expires_in", 3600)
         save_tokens(

--- a/skills/health/whoop-api/scripts/whoop_client.py
+++ b/skills/health/whoop-api/scripts/whoop_client.py
@@ -46,6 +46,7 @@ class WhoopClient:
             "User-Agent": "hermes-whoop-skill/1.0",
         })
         self._request_timestamps: list[float] = []
+        self._daily_timestamps: list[float] = []
         self._load_auth()
 
     def _load_auth(self) -> None:
@@ -124,13 +125,17 @@ class WhoopClient:
             if sleep_time > 0:
                 print(f"Per-minute rate limit reached, waiting {sleep_time:.1f}s...")
                 time.sleep(sleep_time)
-        # Check daily limit (86400s window)
-        day_ago = now - 86400
-        daily_count = sum(1 for ts in self._request_timestamps if ts > day_ago)
-        if daily_count >= DAILY_RATE_LIMIT:
+        # Track daily rate limit separately (86400s window) — independent of the
+        # per-minute prune so it sees the full day's requests, not just the last 60s.
+        self._daily_timestamps = [
+            ts for ts in self._daily_timestamps
+            if ts > now - 86400
+        ]
+        if len(self._daily_timestamps) >= DAILY_RATE_LIMIT:
             print(f"Daily rate limit ({DAILY_RATE_LIMIT}) reached. Stopping.")
             raise RateLimitError(f"Daily rate limit of {DAILY_RATE_LIMIT} requests exceeded")
         self._request_timestamps.append(time.time())
+        self._daily_timestamps.append(time.time())
 
     def _request(self, method: str, endpoint: str, params: dict | None = None) -> dict:
         """Make an authenticated API request with retry and rate limiting."""

--- a/skills/health/whoop-api/scripts/whoop_endpoints.py
+++ b/skills/health/whoop-api/scripts/whoop_endpoints.py
@@ -1,0 +1,75 @@
+"""Whoop API endpoint registry.
+
+Maps endpoint names to API paths, required scopes, and query parameter specs.
+Add new endpoints here to extend data collection without modifying client code.
+
+Note: Whoop API v2 paths use the /developer/v2/ prefix, not /v2/ directly.
+Base URL: https://api.prod.whoop.com/developer/v2/
+"""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class Endpoint:
+    name: str
+    path: str
+    scopes: list[str]
+    requires_pagination: bool
+    description: str
+
+
+ENDPOINTS: dict[str, Endpoint] = {
+    "cycle": Endpoint(
+        name="cycle",
+        path="/developer/v2/cycle",
+        scopes=["read:cycles"],
+        requires_pagination=True,
+        description="Strain, heart rate, kilojoules per cycle",
+    ),
+    "recovery": Endpoint(
+        name="recovery",
+        path="/developer/v2/recovery",
+        scopes=["read:recovery"],
+        requires_pagination=True,
+        description="Recovery %, HRV, resting heart rate",
+    ),
+    "sleep": Endpoint(
+        name="sleep",
+        path="/developer/v2/activity/sleep",
+        scopes=["read:sleep"],
+        requires_pagination=True,
+        description="Sleep stages, efficiency, sleep debt",
+    ),
+    "workout": Endpoint(
+        name="workout",
+        path="/developer/v2/activity/workout",
+        scopes=["read:workout"],
+        requires_pagination=True,
+        description="Strain by activity type, duration",
+    ),
+    "body": Endpoint(
+        name="body",
+        path="/developer/v2/user/measurement/body",
+        scopes=["read:body_measurement"],
+        requires_pagination=False,
+        description="Weight in kg, height in meters",
+    ),
+    "profile": Endpoint(
+        name="profile",
+        path="/developer/v2/user/profile/basic",
+        scopes=["read:profile"],
+        requires_pagination=False,
+        description="User ID, name, email",
+    ),
+}
+
+
+def get_endpoint(name: str) -> Endpoint:
+    """Look up an endpoint by name. Raises KeyError if not found."""
+    return ENDPOINTS[name]
+
+
+def all_endpoints() -> list[Endpoint]:
+    """Return all registered endpoints."""
+    return list(ENDPOINTS.values())

--- a/skills/health/whoop-api/scripts/whoop_oauth.py
+++ b/skills/health/whoop-api/scripts/whoop_oauth.py
@@ -1,0 +1,170 @@
+"""Whoop OAuth2 Authorization Code flow.
+
+Starts a local HTTP server on port 8647 to catch the callback,
+exchanges the auth code for tokens, and stores them via whoop_storage.
+"""
+
+from __future__ import annotations
+
+import json
+import secrets
+import socket
+import sys
+import webbrowser
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from urllib.parse import parse_qs, urlencode, urlparse
+
+import requests
+
+from whoop_storage import save_tokens
+
+AUTH_URL = "https://api.prod.whoop.com/oauth/oauth2/auth"
+TOKEN_URL = "https://api.prod.whoop.com/oauth/oauth2/token"
+REDIRECT_PORT = 8647
+REDIRECT_URI = f"http://localhost:{REDIRECT_PORT}/callback"
+
+SCOPES = [
+    "read:recovery",
+    "read:cycles",
+    "read:sleep",
+    "read:workout",
+    "read:body_measurement",
+    "read:profile",
+    "offline",
+]
+
+
+class OAuthCallbackHandler(BaseHTTPRequestHandler):
+    """Handles the OAuth redirect callback on localhost."""
+
+    auth_code: str | None = None
+    expected_state: str | None = None
+
+    def do_GET(self) -> None:
+        parsed = urlparse(self.path)
+        params = parse_qs(parsed.query)
+
+        if "error" in params:
+            error = params["error"][0]
+            desc = params.get("error_description", [""])[0]
+            self.send_response(400)
+            self.send_header("Content-Type", "text/html")
+            self.end_headers()
+            self.wfile.write(f"<h1>Authorization failed: {error}</h1><p>{desc}</p>".encode())
+            return
+
+        # Validate state parameter (CSRF protection)
+        returned_state = params.get("state", [None])[0]
+        if returned_state != OAuthCallbackHandler.expected_state:
+            self.send_response(400)
+            self.send_header("Content-Type", "text/html")
+            self.end_headers()
+            self.wfile.write(b"<h1>Invalid state parameter.</h1><p>Possible CSRF attack.</p>")
+            return
+
+        if "code" in params:
+            OAuthCallbackHandler.auth_code = params["code"][0]
+            self.send_response(200)
+            self.send_header("Content-Type", "text/html")
+            self.end_headers()
+            self.wfile.write(b"<h1>Authorization successful!</h1>"
+                             b"<p>You can close this tab.</p>")
+        else:
+            self.send_response(404)
+            self.end_headers()
+
+    def log_message(self, format, *args) -> None:
+        """Suppress default HTTP logging."""
+        pass
+
+
+def _exchange_code(code: str, client_id: str, client_secret: str) -> dict:
+    """Exchange authorization code for access + refresh tokens."""
+    response = requests.post(
+        TOKEN_URL,
+        data={
+            "grant_type": "authorization_code",
+            "code": code,
+            "client_id": client_id,
+            "client_secret": client_secret,
+            "redirect_uri": REDIRECT_URI,
+        },
+        timeout=30,
+    )
+    response.raise_for_status()
+    token_data = response.json()
+    if "access_token" not in token_data:
+        sys.exit(f"ERROR: Token exchange failed. Response: {token_data}")
+    return token_data
+
+
+def start_oauth_flow(client_id: str, client_secret: str) -> None:
+    """Run the full OAuth flow: start callback server, open browser, exchange code.
+
+    Args:
+        client_id: Whoop app client ID.
+        client_secret: Whoop app client secret.
+    """
+    # Generate state parameter for CSRF protection (Whoop requires >= 8 chars)
+    state = secrets.token_urlsafe(32)
+    OAuthCallbackHandler.expected_state = state
+    OAuthCallbackHandler.auth_code = None
+
+    # Build authorization URL
+    auth_params = urlencode({
+        "client_id": client_id,
+        "redirect_uri": REDIRECT_URI,
+        "response_type": "code",
+        "scope": " ".join(SCOPES),
+        "state": state,
+    })
+    auth_url = f"{AUTH_URL}?{auth_params}"
+
+    # Check if port is available
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        try:
+            s.bind(("localhost", REDIRECT_PORT))
+        except OSError:
+            sys.exit(f"ERROR: Port {REDIRECT_PORT} is already in use. "
+                     "Close the conflicting process and try again.")
+
+    # Start callback server
+    server = HTTPServer(("localhost", REDIRECT_PORT), OAuthCallbackHandler)
+    print("Opening browser for Whoop authorization...")
+    print(f"If browser doesn't open, navigate to:\n{auth_url}\n")
+
+    webbrowser.open(auth_url)
+
+    # Wait for the callback (one request)
+    server.handle_request()
+    server.server_close()
+
+    if not OAuthCallbackHandler.auth_code:
+        sys.exit("ERROR: Did not receive authorization code from Whoop.")
+
+    # Exchange code for tokens
+    print("Exchanging authorization code for tokens...")
+    token_data = _exchange_code(
+        OAuthCallbackHandler.auth_code, client_id, client_secret
+    )
+
+    # Calculate expiry time
+    import time
+    expires_at = time.time() + token_data.get("expires_in", 3600)
+
+    # Store tokens
+    save_tokens(
+        access_token=token_data["access_token"],
+        refresh_token=token_data["refresh_token"],
+        expires_at=expires_at,
+    )
+    print("Tokens stored successfully.")
+
+
+if __name__ == "__main__":
+    # Standalone mode: read credentials from storage and run OAuth flow
+    from whoop_storage import load_client_credentials
+    creds = load_client_credentials()
+    if not creds:
+        sys.exit("ERROR: No credentials found. Run `whoop_sync.py setup` first.")
+    start_oauth_flow(creds["client_id"], creds["client_secret"])

--- a/skills/health/whoop-api/scripts/whoop_storage.py
+++ b/skills/health/whoop-api/scripts/whoop_storage.py
@@ -1,0 +1,209 @@
+"""Token storage for Whoop API credentials.
+
+Handles OAuth token persistence across platforms:
+  - macOS: Keychain via `security` CLI
+  - Linux/Windows: JSON file fallback
+
+Keychain uses a dynamic path (user's login keychain) to handle
+profile sandboxes where HOME resolves to a sandbox directory.
+
+Service name: whoop-api
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import platform
+import subprocess
+from pathlib import Path
+
+KEYCHAIN_SERVICE = "whoop-api"
+KEYCHAIN_ACCOUNT = "whoop-tokens"
+KEYCHAIN_CREDENTIAL_ACCOUNT = "whoop-credentials"
+
+TOKEN_FIELDS = ("access_token", "refresh_token", "expires_at")
+CREDENTIAL_FIELDS = ("client_id", "client_secret")
+
+
+def _is_macos() -> bool:
+    return platform.system() == "Darwin"
+
+
+def _keychain_path() -> str | None:
+    """Determine the macOS Keychain path dynamically.
+
+    Uses the user's actual login keychain, not a hardcoded path.
+    This works across profile sandboxes and different user accounts.
+    """
+    if not _is_macos():
+        return None
+
+    # Try the user's actual home directory login keychain
+    home = Path.home()
+    keychain = home / "Library" / "Keychains" / "login.keychain-db"
+    if keychain.exists():
+        return str(keychain)
+
+    # Fallback: try traditional location
+    keychain_legacy = home / "Library" / "Keychains" / "login.keychain"
+    if keychain_legacy.exists():
+        return str(keychain_legacy)
+
+    # Last resort: use default keychain (security CLI will find it)
+    return None
+
+
+def _keychain_available() -> bool:
+    """Check if `security` CLI exists and keychain is accessible."""
+    if not _is_macos():
+        return False
+    try:
+        # Just check that `security` CLI exists
+        result = subprocess.run(
+            ["security", "show-keychain-info"],
+            capture_output=True, text=True, timeout=5,
+        )
+        # Exit code 0 or specific keychain errors mean security CLI works
+        return result.returncode in (0, 36)  # 36 = keychain not found but CLI works
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return False
+
+
+def _run_security(args: list[str], interactive_password: str | None = None) -> subprocess.CompletedProcess:
+    """Run a `security` CLI command with optional keychain path."""
+    cmd = ["security"] + args + ["-s", KEYCHAIN_SERVICE]
+
+    # Add keychain path if available (better reliability in profile sandboxes)
+    kc_path = _keychain_path()
+    if kc_path:
+        cmd.append(kc_path)
+
+    return subprocess.run(cmd, capture_output=True, text=True, timeout=10)
+
+
+def load_tokens() -> dict[str, str | float] | None:
+    """Load stored tokens. Returns None if no tokens exist.
+
+    Tries Keychain first (macOS), then JSON file fallback.
+    """
+    if _keychain_available():
+        return _load_from_keychain(KEYCHAIN_ACCOUNT)
+    return _load_from_json_file(_token_file_path())
+
+
+def save_tokens(access_token: str, refresh_token: str, expires_at: float) -> None:
+    """Persist tokens. Keychain on macOS, JSON file elsewhere."""
+    data = {
+        "access_token": access_token,
+        "refresh_token": refresh_token,
+        "expires_at": expires_at,
+    }
+    if _is_macos() and _keychain_available():
+        _save_to_keychain(KEYCHAIN_ACCOUNT, data)
+    else:
+        _save_to_json_file(_token_file_path(), data)
+
+
+def clear_tokens() -> None:
+    """Remove stored tokens from Keychain or JSON file."""
+    if _is_macos() and _keychain_available():
+        _delete_from_keychain(KEYCHAIN_ACCOUNT)
+    else:
+        path = _token_file_path()
+        if path.exists():
+            path.unlink()
+
+
+def load_client_credentials() -> dict[str, str] | None:
+    """Load client_id/client_secret from Keychain (macOS) or JSON file."""
+    if _keychain_available():
+        return _load_from_keychain(KEYCHAIN_CREDENTIAL_ACCOUNT)
+    return _load_from_json_file(_credentials_file_path(), CREDENTIAL_FIELDS)
+
+
+def save_client_credentials(client_id: str, client_secret: str) -> None:
+    """Persist client_id/client_secret. Keychain on macOS, JSON file elsewhere."""
+    data = {"client_id": client_id, "client_secret": client_secret}
+    if _is_macos() and _keychain_available():
+        _save_to_keychain(KEYCHAIN_CREDENTIAL_ACCOUNT, data)
+    else:
+        _save_to_json_file(_credentials_file_path(), data)
+
+
+# -- Keychain (macOS) --
+
+def _load_from_keychain(account: str) -> dict | None:
+    """Read a JSON blob from macOS Keychain."""
+    try:
+        result = _run_security(["find-generic-password", "-a", account, "-w"])
+        if result.returncode != 0:
+            return None
+        data = json.loads(result.stdout.strip())
+        return data
+    except (json.JSONDecodeError, subprocess.TimeoutExpired):
+        return None
+
+
+def _save_to_keychain(account: str, data: dict) -> None:
+    """Delete old entry (if any) then add new one to Keychain."""
+    _delete_from_keychain(account)
+    password = json.dumps(data)
+    cmd = ["security", "add-generic-password",
+           "-s", KEYCHAIN_SERVICE, "-a", account,
+           "-w", password]
+    kc_path = _keychain_path()
+    if kc_path:
+        cmd.append(kc_path)
+    subprocess.run(cmd, check=True, timeout=10)
+
+
+def _delete_from_keychain(account: str) -> None:
+    """Delete Keychain entry. Ignore errors if it doesn't exist."""
+    cmd = ["security", "delete-generic-password",
+           "-s", KEYCHAIN_SERVICE, "-a", account]
+    kc_path = _keychain_path()
+    if kc_path:
+        cmd.append(kc_path)
+    subprocess.run(cmd, capture_output=True, timeout=10)
+
+
+# -- JSON file fallback (Linux/Windows) --
+
+def _config_dir() -> Path:
+    """Return the config directory for Whoop API files."""
+    xdg = os.environ.get("XDG_CONFIG_HOME")
+    base = Path(xdg) if xdg else Path.home() / ".config"
+    return base / "whoop-api"
+
+
+def _token_file_path() -> Path:
+    """Return path to the Whoop tokens JSON file."""
+    return _config_dir() / "tokens.json"
+
+
+def _credentials_file_path() -> Path:
+    """Return path to the Whoop credentials JSON file."""
+    return _config_dir() / "credentials.json"
+
+
+def _load_from_json_file(path: Path, required_fields: tuple = TOKEN_FIELDS) -> dict | None:
+    """Read JSON from file."""
+    if not path.exists():
+        return None
+    try:
+        data = json.loads(path.read_text())
+        if all(k in data for k in required_fields):
+            return data
+    except (json.JSONDecodeError, OSError):
+        pass
+    return None
+
+
+def _save_to_json_file(path: Path, data: dict) -> None:
+    """Write JSON to file with restricted permissions."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, indent=2))
+    # Restrict permissions (no-op on Windows)
+    if platform.system() != "Windows":
+        path.chmod(0o600)

--- a/skills/health/whoop-api/scripts/whoop_storage.py
+++ b/skills/health/whoop-api/scripts/whoop_storage.py
@@ -201,9 +201,14 @@ def _load_from_json_file(path: Path, required_fields: tuple = TOKEN_FIELDS) -> d
 
 
 def _save_to_json_file(path: Path, data: dict) -> None:
-    """Write JSON to file with restricted permissions."""
+    """Write JSON to file with restricted permissions.
+
+    Uses atomic write (temp + rename) to prevent partial reads
+    during concurrent access (e.g. cron refresh vs agent pull).
+    """
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(data, indent=2))
-    # Restrict permissions (no-op on Windows)
+    tmp_path = path.with_suffix(".tmp")
+    tmp_path.write_text(json.dumps(data, indent=2))
     if platform.system() != "Windows":
-        path.chmod(0o600)
+        tmp_path.chmod(0o600)
+    os.replace(tmp_path, path)

--- a/skills/health/whoop-api/scripts/whoop_sync.py
+++ b/skills/health/whoop-api/scripts/whoop_sync.py
@@ -1,0 +1,426 @@
+#!/usr/bin/env python3
+"""Whoop API sync tool — pull fitness data from Whoop via OAuth2.
+
+Usage:
+    python3 scripts/whoop_sync.py setup      # First-time setup: enter credentials, auth, auto-cron
+    python3 scripts/whoop_sync.py pull        # Pull data from all endpoints
+    python3 scripts/whoop_sync.py refresh     # Manually refresh tokens
+    python3 scripts/whoop_sync.py daemon      # Continuous sync on interval
+    python3 scripts/whoop_sync.py status      # Show auth status and next steps
+
+Options:
+    --interval N     Seconds between pulls (daemon mode, default: 1800)
+    --data-dir PATH  Output directory (default: ./whoop_data)
+    --date DATE      Pull specific date YYYY-MM-DD (default: yesterday)
+    -h, --help       Show this help message
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import signal
+import subprocess
+import sys
+import time
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+# Add scripts directory to path for imports
+SCRIPT_DIR = Path(__file__).parent
+sys.path.insert(0, str(SCRIPT_DIR))
+
+from whoop_client import WhoopClient
+from whoop_endpoints import all_endpoints, get_endpoint
+from whoop_oauth import start_oauth_flow
+from whoop_storage import (
+    KEYCHAIN_SERVICE,
+    load_tokens,
+    load_client_credentials,
+    save_client_credentials,
+    save_tokens,
+)
+
+PRIVACY_POLICY_URL = "https://nousresearch.github.io/hermes-agent/whoop-privacy.html"
+
+
+def cmd_setup(args: argparse.Namespace) -> None:
+    """Interactive first-time setup: credentials, OAuth, cron.
+
+    Steps:
+    1. Check for existing credentials — skip prompt if found
+    2. Prompt for client_id and client_secret
+    3. Store credentials in Keychain (macOS) or config file
+    4. Open browser for Whoop OAuth authorization
+    5. Exchange auth code for tokens, store them
+    6. Set up cron for automatic token refresh
+    """
+    print("=" * 60)
+    print("  Whoop API Setup")
+    print("=" * 60)
+    print()
+
+    # Step 1: Check existing credentials
+    existing_creds = load_client_credentials()
+    if existing_creds:
+        print(f"  ✓ Found existing credentials (client_id: {existing_creds['client_id'][:8]}...)")
+        print()
+        client_id = existing_creds["client_id"]
+        client_secret = existing_creds["client_secret"]
+    else:
+        print("  You need a Whoop Developer App to use this skill.")
+        print()
+        print("  If you haven't registered yet:")
+        print("    1. Go to https://developer.whoop.com")
+        print(f"    2. Create a new app")
+        print(f"    3. Set the Redirect URI to: http://localhost:8647/callback")
+        print(f"    4. Set the Privacy Policy URL to: {PRIVACY_POLICY_URL}")
+        print("    5. Copy your Client ID and Client Secret")
+        print()
+
+        client_id = input("  Enter your Whoop Client ID: ").strip()
+        if not client_id:
+            sys.exit("ERROR: Client ID is required.")
+
+        client_secret = input("  Enter your Whoop Client Secret: ").strip()
+        if not client_secret:
+            sys.exit("ERROR: Client Secret is required.")
+
+        # Step 2: Store credentials
+        save_client_credentials(client_id, client_secret)
+        print()
+        print("  ✓ Credentials stored securely.")
+
+    # Step 3: Check for existing tokens
+    existing_tokens = load_tokens()
+    if existing_tokens and existing_tokens.get("expires_at", 0) > time.time():
+        print("  ✓ Found valid auth tokens. You're already authenticated!")
+        print()
+        _setup_cron()
+        print()
+        print("  Setup complete! Run `python3 scripts/whoop_sync.py pull` to fetch data.")
+        return
+
+    # Step 4: OAuth flow
+    print("  Opening browser for Whoop authorization...")
+    print("  Authorize the app and come back here.")
+    print()
+    try:
+        start_oauth_flow(client_id, client_secret)
+    except Exception as e:
+        print(f"\n  ✗ OAuth flow failed: {e}")
+        print("  Try running `python3 scripts/whoop_sync.py setup` again.")
+        sys.exit(1)
+
+    # Step 5: Verify tokens
+    tokens = load_tokens()
+    if not tokens:
+        sys.exit("ERROR: Token storage failed. Check permissions and try again.")
+
+    print()
+    print("  ✓ Authenticated successfully!")
+    print()
+
+    # Step 6: Set up cron for token refresh
+    _setup_cron()
+
+    print()
+    print("=" * 60)
+    print("  Setup complete!")
+    print()
+    print("  What's next:")
+    print("    • Pull data:     python3 scripts/whoop_sync.py pull")
+    print("    • Check status:  python3 scripts/whoop_sync.py status")
+    print("    • Continuous:     python3 scripts/whoop_sync.py daemon")
+    print("=" * 60)
+
+
+def _setup_cron() -> None:
+    """Set up Hermes cron for token refresh (55 min) and data pull (daily).
+
+    Creates two cron jobs if they don't already exist:
+    1. Token refresh every 55 minutes (keeps access token alive)
+    2. Daily data pull at 7:00 AM (local time)
+
+    For token refresh: installs a wrapper script in HERMES_HOME/scripts/
+    (required by hermes cron --script) and creates a no-agent cron job.
+    For daily pull: creates an agent-based cron job with a prompt.
+
+    Skips if Hermes CLI is not installed.
+    """
+    import shutil
+
+    script_dir = Path(__file__).parent.resolve()
+    refresh_script = script_dir / "whoop_token_refresh.py"
+    sync_script = script_dir / "whoop_sync.py"
+
+    # Heremes cron --script requires scripts to live in HERMES_HOME/scripts/
+    hermes_home = Path(os.environ.get("HERMES_HOME", os.path.expanduser("~/.hermes")))
+    scripts_dir = hermes_home / "scripts"
+    scripts_dir.mkdir(parents=True, exist_ok=True)
+
+    # Install wrapper for token refresh (no-agent script cron)
+    wrapper_path = scripts_dir / "whoop_token_refresh.py"
+    wrapper_content = f'''#!/usr/bin/env python3
+"""Whoop token refresh — cron wrapper.
+
+Delegates to the whoop_token_refresh module in the skill directory.
+Regenerated by whoop_sync.py setup — do not edit manually.
+"""
+import sys
+from pathlib import Path
+
+SKILL_DIR = {str(script_dir)!r}
+sys.path.insert(0, SKILL_DIR)
+
+from whoop_token_refresh import main
+
+sys.exit(main())
+'''
+    wrapper_path.write_text(wrapper_content)
+    print(f"  ✓ Installed token refresh wrapper to {wrapper_path}")
+
+    # Install wrapper for daily pull (agent-based cron runs from workdir)
+    pull_wrapper_path = scripts_dir / "whoop_daily_pull.py"
+    pull_wrapper_content = f'''#!/usr/bin/env python3
+"""Whoop daily pull — cron wrapper.
+
+Delegates to whoop_sync.py pull in the skill directory.
+Regenerated by whoop_sync.py setup — do not edit manually.
+"""
+import sys
+from pathlib import Path
+
+SKILL_DIR = {str(script_dir)!r}
+sys.path.insert(0, SKILL_DIR)
+sys.argv = ["whoop_sync.py", "pull"]
+
+from whoop_sync import main
+
+sys.exit(main())
+'''
+    pull_wrapper_path.write_text(pull_wrapper_content)
+    print(f"  ✓ Installed daily pull wrapper to {pull_wrapper_path}")
+
+    # Check if hermes is available
+    try:
+        result = subprocess.run(
+            ["hermes", "cron", "list"],
+            capture_output=True, text=True, timeout=10,
+        )
+        if result.returncode != 0:
+            _print_cron_instructions(refresh_script, sync_script)
+            return
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        _print_cron_instructions(refresh_script, sync_script)
+        return
+
+    # Check if refresh cron already exists
+    result = subprocess.run(
+        ["hermes", "cron", "list"],
+        capture_output=True, text=True, timeout=10,
+    )
+    existing = result.stdout or ""
+
+    if "whoop-token-refresh" in existing:
+        print("  ✓ Token refresh cron already exists, skipping.")
+    else:
+        print("  Setting up token refresh cron (every 55 minutes)...")
+        result = subprocess.run(
+            [
+                "hermes", "cron", "create",
+                "*/55 * * * *",
+                "--name", "whoop-token-refresh",
+                "--no-agent",
+                "--script", "whoop_token_refresh.py",
+            ],
+            capture_output=True, text=True, timeout=15,
+        )
+        if result.returncode == 0:
+            print("  ✓ Token refresh cron created.")
+        else:
+            print(f"  ⚠ Failed to create token refresh cron: {result.stderr.strip()}")
+            _print_cron_instructions(refresh_script, sync_script)
+
+    if "whoop-daily-pull" in existing:
+        print("  ✓ Daily data pull cron already exists, skipping.")
+    else:
+        print("  Setting up daily data pull cron (7:00 AM local)...")
+        result = subprocess.run(
+            [
+                "hermes", "cron", "create",
+                "0 7 * * *",
+                "--name", "whoop-daily-pull",
+                "--no-agent",
+                "--script", "whoop_daily_pull.py",
+            ],
+            capture_output=True, text=True, timeout=15,
+        )
+        if result.returncode == 0:
+            print("  ✓ Daily data pull cron created.")
+        else:
+            print(f"  ⚠ Failed to create daily pull cron: {result.stderr.strip()}")
+            _print_cron_instructions(refresh_script, sync_script)
+
+
+def _print_cron_instructions(refresh_script: Path, sync_script: Path) -> None:
+    """Print manual cron setup instructions when Hermes cron is unavailable."""
+    print("  To set up scheduled sync, add to your crontab (crontab -e):")
+    print(f"    */55 * * * * cd {sync_script.parent} && python3 {refresh_script}")
+    print(f"    0 7 * * * cd {sync_script.parent} && python3 {sync_script} pull")
+    print()
+    print("  Or with Hermes cron:")
+    print(f"    hermes cron create \"*/55 * * * *\" --name whoop-token-refresh --no-agent --script {refresh_script}")
+    print(f"    hermes cron create \"0 7 * * *\" --name whoop-daily-pull \"Pull Whoop data\" --workdir {sync_script.parent}")
+
+
+def cmd_pull(args: argparse.Namespace) -> None:
+    """Pull data from all Whoop endpoints and save to disk."""
+    client = WhoopClient(data_dir=args.data_dir)
+    results = client.pull_all(date=args.date)
+
+    date_str = args.date or (datetime.now(timezone.utc) - timedelta(days=1)).strftime("%Y-%m-%d")
+    output_dir = client.save_data(results, date=date_str)
+
+    total = sum(len(v) for v in results.values())
+    print(f"\nPulled {total} total records to {output_dir}")
+
+
+def cmd_refresh(args: argparse.Namespace) -> None:
+    """Manually refresh the Whoop access token."""
+    client = WhoopClient(data_dir=args.data_dir)
+    try:
+        client._refresh_if_needed()
+        print("Token refreshed successfully.")
+    except Exception as e:
+        print(f"Token refresh failed: {e}")
+        print("Run `whoop_sync.py setup` to re-authenticate.")
+        sys.exit(1)
+
+
+def cmd_status(args: argparse.Namespace) -> None:
+    """Show authentication status and configuration info."""
+    print("Whoop API Status")
+    print("=" * 40)
+
+    # Check credentials
+    creds = load_client_credentials()
+    if creds:
+        print(f"  Credentials: ✓ (client_id: {creds['client_id'][:8]}...)")
+    else:
+        print("  Credentials: ✗ Not found. Run `setup` first.")
+        return
+
+    # Check tokens
+    tokens = load_tokens()
+    if tokens:
+        expires_at = tokens.get("expires_at", 0)
+        remaining = expires_at - time.time()
+        if remaining > 0:
+            hours = int(remaining // 3600)
+            mins = int((remaining % 3600) // 60)
+            print(f"  Auth tokens: ✓ (expires in {hours}h {mins}m)")
+        else:
+            print("  Auth tokens: ✗ Expired. Run `setup` to re-authenticate.")
+    else:
+        print("  Auth tokens: ✗ Not found. Run `setup` to authenticate.")
+
+    # Check cron
+    try:
+        result = subprocess.run(
+            ["hermes", "cron", "list"],
+            capture_output=True, text=True, timeout=10,
+        )
+        if "whoop-token-refresh" in (result.stdout or ""):
+            print("  Token refresh cron: ✓")
+        else:
+            print("  Token refresh cron: ✗ Not set up. Run `setup` to create.")
+        if "whoop-daily-pull" in (result.stdout or ""):
+            print("  Daily pull cron: ✓")
+        else:
+            print("  Daily pull cron: ✗ Not set up. Run `setup` to create.")
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        print("  Cron: Unknown (hermes CLI not available)")
+
+    print()
+    print(f"  Privacy policy: {PRIVACY_POLICY_URL}")
+    print(f"  Data directory: {args.data_dir or './whoop_data'}")
+
+
+def cmd_daemon(args: argparse.Namespace) -> None:
+    """Run continuous sync on an interval."""
+    interval = args.interval
+    print(f"Starting Whoop daemon (interval: {interval}s)")
+    print(f"Data directory: {args.data_dir}")
+    print("Press Ctrl+C to stop.\n")
+
+    running = True
+
+    def signal_handler(signum, frame):
+        nonlocal running
+        print("\nShutting down gracefully...")
+        running = False
+
+    signal.signal(signal.SIGINT, signal_handler)
+    signal.signal(signal.SIGTERM, signal_handler)
+
+    while running:
+        try:
+            timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S UTC")
+            print(f"[{timestamp}] Starting pull...")
+            client = WhoopClient(data_dir=args.data_dir)
+            results = client.pull_all(date=args.date)
+
+            date_str = args.date or (datetime.now(timezone.utc) - timedelta(days=1)).strftime("%Y-%m-%d")
+            output_dir = client.save_data(results, date=date_str)
+
+            total = sum(len(v) for v in results.values())
+            print(f"[{timestamp}] Pulled {total} records to {output_dir}")
+        except Exception as e:
+            print(f"[{timestamp}] Error: {e}")
+
+        for _ in range(int(max(1, interval))):
+            if not running:
+                break
+            time.sleep(1)
+
+    print("Daemon stopped.")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Whoop API sync tool — pull fitness data from Whoop via OAuth2.",
+    )
+    parser.add_argument(
+        "command",
+        choices=["setup", "pull", "refresh", "daemon", "status"],
+        help="Command to run",
+    )
+    parser.add_argument(
+        "--interval", type=int, default=1800,
+        help="Seconds between pulls in daemon mode (default: 1800)",
+    )
+    parser.add_argument(
+        "--data-dir", type=str, default="whoop_data",
+        help="Output directory for pulled data (default: whoop_data)",
+    )
+    parser.add_argument(
+        "--date", type=str, default=None,
+        help="Pull specific date YYYY-MM-DD (default: yesterday)",
+    )
+
+    args = parser.parse_args()
+
+    commands = {
+        "setup": cmd_setup,
+        "pull": cmd_pull,
+        "refresh": cmd_refresh,
+        "daemon": cmd_daemon,
+        "status": cmd_status,
+    }
+    commands[args.command](args)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/health/whoop-api/scripts/whoop_sync.py
+++ b/skills/health/whoop-api/scripts/whoop_sync.py
@@ -270,8 +270,11 @@ def _print_cron_instructions(refresh_script: Path, sync_script: Path) -> None:
     print(f"    */55 * * * * cd {sync_script.parent} && python3 {refresh_script}")
     print(f"    0 7 * * * cd {sync_script.parent} && python3 {sync_script} pull")
     print()
-    print("  Or with Hermes cron:")
-    print(f"    hermes cron create \"*/55 * * * *\" --name whoop-token-refresh --no-agent --script {refresh_script}")
+    print("  Or with Hermes cron (note: --script must be relative to HERMES_HOME/scripts/):")
+    print(
+        "    hermes cron create \"*/55 * * * *\" --name whoop-token-refresh "
+        "--no-agent --script whoop_token_refresh.py"
+    )
     print(f"    hermes cron create \"0 7 * * *\" --name whoop-daily-pull \"Pull Whoop data\" --workdir {sync_script.parent}")
 
 

--- a/skills/health/whoop-api/scripts/whoop_token_refresh.py
+++ b/skills/health/whoop-api/scripts/whoop_token_refresh.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""Whoop token refresh script for cron.
+
+Touches the API to trigger auto-refresh if the access token is about to expire.
+Silent on success (no stdout = no Telegram delivery).
+Sends Telegram notification on failure via `hermes send`.
+
+Exit codes:
+  0 — success (token still valid or refreshed)
+  1 — failure (refresh failed or API unreachable)
+"""
+
+import subprocess
+import sys
+import time
+
+from whoop_storage import load_tokens, save_tokens, load_client_credentials
+
+API_BASE = "https://api.prod.whoop.com"
+
+
+def notify_telegram(message: str) -> None:
+    """Send a Telegram notification via hermes send (best-effort)."""
+    try:
+        subprocess.run(
+            ["hermes", "send", "--to", "telegram", "--quiet", "--message", message],
+            capture_output=True, text=True, timeout=15,
+        )
+    except Exception:
+        pass  # Don't let notification failure mask the original error
+
+
+def main() -> int:
+    tokens = load_tokens()
+    if tokens is None:
+        msg = "Whoop token refresh failed: no tokens found. Run `whoop_sync.py setup` to re-authenticate."
+        notify_telegram(msg)
+        print(msg, file=sys.stderr)
+        return 1
+
+    # Check if token expires within 10 minutes
+    expires_at = tokens.get("expires_at", 0)
+    remaining = expires_at - time.time()
+    if remaining > 600:
+        # Token still valid — silent exit (no stdout = no delivery)
+        return 0
+
+    # Token expired or about to expire — force refresh
+    import requests
+    creds = load_client_credentials()
+    if not creds:
+        msg = "Whoop token refresh failed: no client credentials found."
+        notify_telegram(msg)
+        print(msg, file=sys.stderr)
+        return 1
+
+    try:
+        response = requests.post(
+            f"{API_BASE}/oauth/oauth2/token",
+            data={
+                "grant_type": "refresh_token",
+                "refresh_token": tokens["refresh_token"],
+                "client_id": creds["client_id"],
+                "client_secret": creds["client_secret"],
+            },
+            timeout=30,
+        )
+    except requests.RequestException as e:
+        msg = f"Whoop token refresh failed: network error ({e})"
+        notify_telegram(msg)
+        print(msg, file=sys.stderr)
+        return 1
+
+    if response.status_code == 401:
+        msg = "Whoop token refresh failed: refresh token expired. Re-auth needed. Run `whoop_sync.py setup`."
+        notify_telegram(msg)
+        print(msg, file=sys.stderr)
+        return 1
+
+    if response.status_code != 200:
+        msg = f"Whoop token refresh failed: HTTP {response.status_code}"
+        notify_telegram(msg)
+        print(msg, file=sys.stderr)
+        return 1
+
+    token_data = response.json()
+    new_expires_at = time.time() + token_data.get("expires_in", 3600)
+    save_tokens(
+        access_token=token_data["access_token"],
+        refresh_token=token_data["refresh_token"],
+        expires_at=new_expires_at,
+    )
+    print(f"Whoop token refreshed. Next expiry in {token_data.get('expires_in', 3600)/60:.0f} min.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/health/whoop-api/scripts/whoop_token_refresh.py
+++ b/skills/health/whoop-api/scripts/whoop_token_refresh.py
@@ -2,15 +2,14 @@
 """Whoop token refresh script for cron.
 
 Touches the API to trigger auto-refresh if the access token is about to expire.
-Silent on success (no stdout = no Telegram delivery).
-Sends Telegram notification on failure via `hermes send`.
+FULLY SILENT on success (no stdout, no Telegram — nothing is delivered).
+On failure writes to stderr and exits non-zero; the cron job delivers the error.
 
 Exit codes:
   0 — success (token still valid or refreshed)
   1 — failure (refresh failed or API unreachable)
 """
 
-import subprocess
 import sys
 import time
 
@@ -19,39 +18,30 @@ from whoop_storage import load_tokens, save_tokens, load_client_credentials
 API_BASE = "https://api.prod.whoop.com"
 
 
-def notify_telegram(message: str) -> None:
-    """Send a Telegram notification via hermes send (best-effort)."""
-    try:
-        subprocess.run(
-            ["hermes", "send", "--to", "telegram", "--quiet", "--message", message],
-            capture_output=True, text=True, timeout=15,
-        )
-    except Exception:
-        pass  # Don't let notification failure mask the original error
-
-
 def main() -> int:
     tokens = load_tokens()
     if tokens is None:
-        msg = "Whoop token refresh failed: no tokens found. Run `whoop_sync.py setup` to re-authenticate."
-        notify_telegram(msg)
-        print(msg, file=sys.stderr)
+        print(
+            "Whoop token refresh failed: no tokens found. Run `whoop_sync.py setup` to re-authenticate.",
+            file=sys.stderr,
+        )
         return 1
 
     # Check if token expires within 10 minutes
     expires_at = tokens.get("expires_at", 0)
     remaining = expires_at - time.time()
     if remaining > 600:
-        # Token still valid — silent exit (no stdout = no delivery)
+        # Token still valid — silent success (no stdout, no delivery)
         return 0
 
     # Token expired or about to expire — force refresh
     import requests
     creds = load_client_credentials()
     if not creds:
-        msg = "Whoop token refresh failed: no client credentials found."
-        notify_telegram(msg)
-        print(msg, file=sys.stderr)
+        print(
+            "Whoop token refresh failed: no client credentials found.",
+            file=sys.stderr,
+        )
         return 1
 
     try:
@@ -66,21 +56,18 @@ def main() -> int:
             timeout=30,
         )
     except requests.RequestException as e:
-        msg = f"Whoop token refresh failed: network error ({e})"
-        notify_telegram(msg)
-        print(msg, file=sys.stderr)
+        print(f"Whoop token refresh failed: network error ({e})", file=sys.stderr)
         return 1
 
     if response.status_code == 401:
-        msg = "Whoop token refresh failed: refresh token expired. Re-auth needed. Run `whoop_sync.py setup`."
-        notify_telegram(msg)
-        print(msg, file=sys.stderr)
+        print(
+            "Whoop token refresh failed: refresh token expired. Re-auth needed. Run `whoop_sync.py setup`.",
+            file=sys.stderr,
+        )
         return 1
 
     if response.status_code != 200:
-        msg = f"Whoop token refresh failed: HTTP {response.status_code}"
-        notify_telegram(msg)
-        print(msg, file=sys.stderr)
+        print(f"Whoop token refresh failed: HTTP {response.status_code}", file=sys.stderr)
         return 1
 
     token_data = response.json()
@@ -90,7 +77,7 @@ def main() -> int:
         refresh_token=token_data["refresh_token"],
         expires_at=new_expires_at,
     )
-    print(f"Whoop token refreshed. Next expiry in {token_data.get('expires_in', 3600)/60:.0f} min.")
+    # Silent on success — no stdout, no delivery
     return 0
 
 

--- a/skills/health/whoop-api/templates/cron-entry.yaml
+++ b/skills/health/whoop-api/templates/cron-entry.yaml
@@ -1,0 +1,21 @@
+# Whoop Sync Cron Configuration
+# Add to Hermes cron for scheduled data pulls
+
+# Example: Pull Whoop data every 30 minutes
+# hermes cron create "30m" \
+#   --name whoop-sync \
+#   --prompt "Run Whoop data pull: cd /path/to/skills/health/whoop-api && python scripts/whoop_sync.py pull --data-dir /path/to/whoop_data" \
+#   --deliver local
+
+# Example: Pull Whoop data daily at 7am PDT
+# hermes cron create "0 7 * * *" \
+#   --name whoop-daily \
+#   --prompt "Run Whoop daily sync: cd /path/to/skills/health/whoop-api && python scripts/whoop_sync.py pull" \
+#   --deliver origin
+
+# Notes:
+# - Use absolute paths for data-dir when running from cron
+# - Access tokens auto-refresh on each pull
+# - First-time setup (whoop_sync.py setup) must be run manually before cron
+# - Rate limit: 100 req/min. Each pull uses 6 requests (one per endpoint)
+# - Minimum safe interval: 5 minutes (6 endpoints + 1 refresh = 7 requests)

--- a/tests/skills/test_whoop_api_skill.py
+++ b/tests/skills/test_whoop_api_skill.py
@@ -1,0 +1,662 @@
+"""
+Tests for the whoop-api skill.
+
+Two layers:
+  - Smoke tests: SKILL.md frontmatter, script syntax, key constants
+  - Unit tests: mocked OAuth flow, storage, client logic, token safety
+
+No live API calls — all external dependencies are mocked.
+"""
+from __future__ import annotations
+
+import ast
+import importlib
+import json
+import os
+import re
+import sys
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+import yaml
+
+SKILL_DIR = Path(__file__).resolve().parents[2] / "skills" / "health" / "whoop-api"
+SCRIPTS_DIR = SKILL_DIR / "scripts"
+
+# ──────────────────────────────────────────────
+# Helper: import skill modules standalone
+# ──────────────────────────────────────────────
+
+_cached_modules = {}
+
+def _import_skill_module(name: str):
+    """Import a skill script by name (e.g. 'whoop_storage') with sys.path patched.
+    Caches modules so mocks don't leak between tests."""
+    if name in _cached_modules:
+        # Remove stale module so we get a fresh import
+        sys.modules.pop(name, None)
+    old_path = sys.path[:]
+    sys.path.insert(0, str(SCRIPTS_DIR))
+    try:
+        mod = importlib.import_module(name)
+        return mod
+    finally:
+        sys.path[:] = old_path
+
+
+# ═══════════════════════════════════════════════
+# SMOKE TESTS — frontmatter, syntax, constants
+# ═══════════════════════════════════════════════
+
+@pytest.fixture(scope="module")
+def frontmatter() -> dict:
+    src = (SKILL_DIR / "SKILL.md").read_text()
+    m = re.search(r"^---\n(.*?)\n---", src, re.DOTALL)
+    assert m, "SKILL.md missing YAML frontmatter"
+    return yaml.safe_load(m.group(1))
+
+
+def test_skill_dir_exists() -> None:
+    assert SKILL_DIR.is_dir(), f"missing skill dir: {SKILL_DIR}"
+
+
+def test_skill_md_present() -> None:
+    assert (SKILL_DIR / "SKILL.md").is_file()
+
+
+def test_description_under_60_chars(frontmatter) -> None:
+    desc = frontmatter["description"]
+    assert len(desc) <= 60, f"description is {len(desc)} chars (hardline <=60): {desc!r}"
+
+
+def test_name_matches_dir(frontmatter) -> None:
+    assert frontmatter["name"] == "whoop-api"
+
+
+def test_platforms_cross_platform(frontmatter) -> None:
+    platforms = set(frontmatter["platforms"])
+    assert platforms == {"linux", "macos", "windows"}, f"unexpected platforms: {platforms}"
+
+
+def test_author_credits_contributor(frontmatter) -> None:
+    author = frontmatter["author"]
+    assert "Nirbhay" in author or "nirbhay" in author, f"author should credit contributor: {author!r}"
+
+
+def test_license_mit(frontmatter) -> None:
+    assert frontmatter["license"] == "MIT"
+
+
+def test_requires_toolsets(frontmatter) -> None:
+    meta = frontmatter.get("metadata", {}).get("hermes", {})
+    assert "terminal" in meta.get("requires_toolsets", []), (
+        "skill uses subprocess scripts - requires_toolsets should include terminal"
+    )
+
+
+def test_skill_md_section_order() -> None:
+    src = (SKILL_DIR / "SKILL.md").read_text()
+    sections = re.findall(r"^## (.+)$", src, re.MULTILINE)
+    expected = [
+        "When to Use",
+        "Prerequisites",
+        "How to Run",
+        "Quick Reference",
+        "Procedure",
+        "Pitfalls",
+        "Verification",
+    ]
+    assert sections == expected, f"section order mismatch:\n  got:      {sections}\n  expected: {expected}"
+
+
+SCRIPTS = [
+    "scripts/whoop_client.py",
+    "scripts/whoop_endpoints.py",
+    "scripts/whoop_oauth.py",
+    "scripts/whoop_storage.py",
+    "scripts/whoop_sync.py",
+    "scripts/whoop_token_refresh.py",
+]
+
+
+@pytest.mark.parametrize("path", SCRIPTS)
+def test_shipped_scripts_parse(path: str) -> None:
+    src = (SKILL_DIR / path).read_text()
+    ast.parse(src)  # raises SyntaxError on broken Python
+
+
+def test_auth_url_uses_oauth2_path() -> None:
+    src = (SKILL_DIR / "scripts" / "whoop_oauth.py").read_text()
+    assert "oauth/oauth2/auth" in src, "AUTH_URL must use /oauth/oauth2/auth path"
+
+
+def test_token_url_uses_oauth2_path() -> None:
+    src = (SKILL_DIR / "scripts" / "whoop_client.py").read_text()
+    assert "oauth/oauth2/token" in src, "TOKEN_URL must use /oauth/oauth2/token path"
+
+
+def test_api_endpoints_use_developer_prefix() -> None:
+    src = (SKILL_DIR / "scripts" / "whoop_endpoints.py").read_text()
+    assert "/developer/v2/" in src, "endpoint paths must use /developer/v2/ prefix"
+
+
+def test_no_hardcoded_user_paths() -> None:
+    for path in SCRIPTS:
+        src = (SKILL_DIR / path).read_text()
+        assert "/Users/" not in src, f"{path}: hardcoded /Users/ path found"
+        assert "/home/" not in src, f"{path}: hardcoded /home/ path found"
+
+
+def test_no_posix_unsafe_patterns() -> None:
+    for path in SCRIPTS:
+        src = (SKILL_DIR / path).read_text()
+        assert not re.search(r"os\.kill\([^,]+,\s*0\s*\)", src), (
+            f"{path}: os.kill(pid, 0) is Windows-unsafe - use psutil.pid_exists()"
+        )
+        if "fcntl" in src:
+            assert "ImportError" in src, f"{path}: fcntl without ImportError guard"
+        if "termios" in src:
+            assert "ImportError" in src, f"{path}: termios without ImportError guard"
+
+
+def test_storage_has_fallback_beyond_keychain() -> None:
+    src = (SKILL_DIR / "scripts" / "whoop_storage.py").read_text()
+    assert "json" in src, "storage module must have JSON file fallback"
+    assert "_keychain_available" in src, "storage module must check Keychain availability"
+
+
+def test_python3_shebangs() -> None:
+    for path in SCRIPTS:
+        src = (SKILL_DIR / path).read_text()
+        lines = src.strip().split("\n")
+        if lines[0].startswith("#!"):
+            assert "python3" in lines[0], f"{path}: shebang should use python3"
+
+
+def test_no_python_without_3_in_messages() -> None:
+    src = (SKILL_DIR / "scripts" / "whoop_sync.py").read_text()
+    matches = re.findall(r'"python\s+whoop', src)
+    assert not matches, "user-facing messages should use python3, not python"
+
+
+def test_privacy_policy_exists() -> None:
+    assert (SKILL_DIR / "references" / "privacy-policy.html").is_file()
+
+
+def test_privacy_policy_is_valid_html() -> None:
+    html = (SKILL_DIR / "references" / "privacy-policy.html").read_text()
+    assert "<!DOCTYPE html>" in html, "privacy policy must be valid HTML"
+    assert "Privacy Policy" in html, "privacy policy must contain Privacy Policy"
+
+
+def test_cron_entry_template_exists() -> None:
+    assert (SKILL_DIR / "templates" / "cron-entry.yaml").is_file()
+
+
+def test_gitignore_covers_artifacts() -> None:
+    gi = (SKILL_DIR / ".gitignore").read_text()
+    assert "__pycache__/" in gi, ".gitignore must exclude __pycache__"
+    assert "whoop_data/" in gi, ".gitignore must exclude whoop_data output"
+
+
+# ═══════════════════════════════════════════════
+# UNIT TESTS — mocked logic, storage, OAuth, client
+# ═══════════════════════════════════════════════
+
+# --- Storage: JSON fallback ---
+
+class TestStorageJsonFallback:
+    """Test JSON file fallback storage (Linux/Windows path)."""
+
+    def test_save_and_load_roundtrip(self, tmp_path):
+        """Atomic write + read should produce identical data."""
+        mod = _import_skill_module("whoop_storage")
+        token_path = tmp_path / "tokens.json"
+
+        mod._save_to_json_file(token_path, {
+            "access_token": "at_123",
+            "refresh_token": "rt_456",
+            "expires_at": 1700000000.0,
+        })
+
+        loaded = mod._load_from_json_file(token_path, mod.TOKEN_FIELDS)
+        assert loaded is not None
+        assert loaded["access_token"] == "at_123"
+        assert loaded["refresh_token"] == "rt_456"
+        assert loaded["expires_at"] == 1700000000.0
+
+    def test_atomic_write_no_partial_file(self, tmp_path):
+        """Atomic write should not leave .tmp files on success."""
+        mod = _import_skill_module("whoop_storage")
+        token_path = tmp_path / "tokens.json"
+
+        mod._save_to_json_file(token_path, {"access_token": "test", "refresh_token": "test", "expires_at": 1.0})
+
+        # No .tmp file should exist after successful write
+        tmp_files = list(tmp_path.glob("*.tmp"))
+        assert len(tmp_files) == 0, f"Leftover .tmp files: {tmp_files}"
+
+    def test_file_permissions_restricted(self, tmp_path):
+        """JSON fallback files should have 0o600 permissions (owner-read-only)."""
+        mod = _import_skill_module("whoop_storage")
+        token_path = tmp_path / "tokens.json"
+
+        mod._save_to_json_file(token_path, {"access_token": "x", "refresh_token": "y", "expires_at": 1.0})
+
+        if os.name != "nt":  # chmod is no-op on Windows
+            mode = token_path.stat().st_mode & 0o777
+            assert mode == 0o600, f"Expected 0o600, got {oct(mode)}"
+
+    def test_save_creates_parent_dirs(self, tmp_path):
+        """_save_to_json_file should create parent directories."""
+        mod = _import_skill_module("whoop_storage")
+        nested_path = tmp_path / "deep" / "nested" / "tokens.json"
+
+        mod._save_to_json_file(nested_path, {"access_token": "a", "refresh_token": "b", "expires_at": 1.0})
+
+        assert nested_path.exists()
+        assert nested_path.parent.is_dir()
+
+    def test_load_missing_file_returns_none(self, tmp_path):
+        """Loading from a nonexistent path should return None."""
+        mod = _import_skill_module("whoop_storage")
+        result = mod._load_from_json_file(tmp_path / "nonexistent.json")
+        assert result is None
+
+    def test_load_corrupted_json_returns_none(self, tmp_path):
+        """Loading a file with invalid JSON should return None, not crash."""
+        mod = _import_skill_module("whoop_storage")
+        bad_path = tmp_path / "bad.json"
+        bad_path.write_text("NOT VALID JSON {{{")
+        result = mod._load_from_json_file(bad_path)
+        assert result is None
+
+    def test_load_missing_fields_returns_none(self, tmp_path):
+        """A JSON file missing required fields should return None."""
+        mod = _import_skill_module("whoop_storage")
+        partial_path = tmp_path / "partial.json"
+        partial_path.write_text(json.dumps({"access_token": "x"}))  # missing refresh_token, expires_at
+        result = mod._load_from_json_file(partial_path, mod.TOKEN_FIELDS)
+        assert result is None
+
+    def test_credentials_save_and_load(self, tmp_path):
+        """Client credentials should round-trip through JSON fallback."""
+        mod = _import_skill_module("whoop_storage")
+        cred_path = tmp_path / "credentials.json"
+
+        mod._save_to_json_file(cred_path, {"client_id": "cid_abc", "client_secret": "csec_xyz"})
+        loaded = mod._load_from_json_file(cred_path, mod.CREDENTIAL_FIELDS)
+        assert loaded is not None
+        assert loaded["client_id"] == "cid_abc"
+        assert loaded["client_secret"] == "csec_xyz"
+
+
+# --- Storage: Keychain ---
+
+class TestStorageKeychain:
+    """Test Keychain storage module (macOS path) via low-level functions."""
+
+    def test_load_from_keychain_success(self):
+        """Successfully load tokens from Keychain via _run_security."""
+        mod = _import_skill_module("whoop_storage")
+        with patch.object(mod, "_keychain_available", return_value=True), \
+             patch.object(mod, "_run_security") as mock_sec:
+            mock_sec.return_value = MagicMock(
+                returncode=0,
+                stdout=json.dumps({"access_token": "at_kc", "refresh_token": "rt_kc", "expires_at": 1700000000.0}),
+            )
+            result = mod._load_from_keychain(mod.KEYCHAIN_ACCOUNT)
+            assert result is not None
+            assert result["access_token"] == "at_kc"
+
+    def test_load_from_keychain_not_found(self):
+        """Keychain returns non-zero when entry doesn't exist."""
+        mod = _import_skill_module("whoop_storage")
+        with patch.object(mod, "_keychain_available", return_value=True), \
+             patch.object(mod, "_run_security") as mock_sec:
+            mock_sec.return_value = MagicMock(returncode=44, stdout="item not found")
+            result = mod._load_from_keychain(mod.KEYCHAIN_ACCOUNT)
+            assert result is None
+
+    def test_load_from_keychain_bad_json(self):
+        """Keychain returns non-JSON value — should return None gracefully."""
+        mod = _import_skill_module("whoop_storage")
+        with patch.object(mod, "_keychain_available", return_value=True), \
+             patch.object(mod, "_run_security") as mock_sec:
+            mock_sec.return_value = MagicMock(returncode=0, stdout="not-json")
+            result = mod._load_from_keychain(mod.KEYCHAIN_ACCOUNT)
+            assert result is None
+
+
+# --- Storage: save_tokens routing ---
+
+class TestStorageRouting:
+    """Test that save_tokens/load_tokens route to Keychain or JSON correctly."""
+
+    def test_save_tokens_uses_json_on_linux(self, tmp_path):
+        """On Linux (no Keychain), save_tokens should write to JSON file."""
+        mod = _import_skill_module("whoop_storage")
+        target = tmp_path / "tokens.json"
+
+        with patch.object(mod, "_is_macos", return_value=False), \
+             patch.object(mod, "_token_file_path", return_value=target):
+            mod.save_tokens("at_linux", "rt_linux", 1700000000.0)
+
+        assert target.exists()
+        data = json.loads(target.read_text())
+        assert data["access_token"] == "at_linux"
+        assert data["refresh_token"] == "rt_linux"
+
+    def test_save_tokens_uses_keychain_on_macos(self, tmp_path):
+        """On macOS with Keychain available, save_tokens should use Keychain."""
+        mod = _import_skill_module("whoop_storage")
+
+        with patch.object(mod, "_is_macos", return_value=True), \
+             patch.object(mod, "_keychain_available", return_value=True), \
+             patch.object(mod, "_save_to_keychain") as mock_kc:
+            mod.save_tokens("at_mac", "rt_mac", 1700000000.0)
+            mock_kc.assert_called_once()
+            call_data = mock_kc.call_args[0][1]  # second positional arg = data dict
+            assert call_data["access_token"] == "at_mac"
+
+    def test_clear_tokens_removes_json_file(self, tmp_path):
+        """clear_tokens should delete the JSON file on Linux."""
+        mod = _import_skill_module("whoop_storage")
+        target = tmp_path / "tokens.json"
+        target.write_text(json.dumps({"access_token": "x", "refresh_token": "y", "expires_at": 1.0}))
+
+        with patch.object(mod, "_is_macos", return_value=False), \
+             patch.object(mod, "_token_file_path", return_value=target):
+            mod.clear_tokens()
+
+        assert not target.exists()
+
+    def test_clear_tokens_deletes_keychain_on_macos(self):
+        """clear_tokens should call _delete_from_keychain on macOS."""
+        mod = _import_skill_module("whoop_storage")
+
+        with patch.object(mod, "_is_macos", return_value=True), \
+             patch.object(mod, "_keychain_available", return_value=True), \
+             patch.object(mod, "_delete_from_keychain") as mock_del:
+            mod.clear_tokens()
+            mock_del.assert_called_once_with(mod.KEYCHAIN_ACCOUNT)
+
+
+# --- OAuth: CSRF state ---
+
+class TestOAuthCSRF:
+    """Test OAuth CSRF state parameter handling."""
+
+    def test_state_generated_and_verified(self):
+        """OAuth flow should generate a state and verify it on callback."""
+        mod = _import_skill_module("whoop_oauth")
+        handler_class = mod.OAuthCallbackHandler
+        state = "test_state_random_value_12345"
+        handler_class.expected_state = state
+
+        # Verify matching state passes
+        assert state == handler_class.expected_state, "CSRF state should match"
+
+    def test_mismatched_state_rejected(self):
+        """Mismatched state should be rejected (CSRF protection)."""
+        mod = _import_skill_module("whoop_oauth")
+        handler_class = mod.OAuthCallbackHandler
+        handler_class.expected_state = "correct_state_xyz"
+
+        assert "wrong_state" != handler_class.expected_state
+
+
+# --- OAuth: Port conflict ---
+
+class TestOAuthPortConflict:
+    """Test that OAuth flow handles port conflicts."""
+
+    def test_port_in_use_exits_cleanly(self):
+        """If port 8647 is already in use, setup should exit with an error."""
+        mod = _import_skill_module("whoop_oauth")
+
+        with patch.object(mod.socket, "socket") as mock_socket_cls:
+            mock_socket = MagicMock()
+            mock_socket.__enter__ = MagicMock(return_value=mock_socket)
+            mock_socket.__exit__ = MagicMock(return_value=False)
+            mock_socket.bind = MagicMock(side_effect=OSError("Address already in use"))
+            mock_socket_cls.return_value = mock_socket
+
+            with patch.object(mod, "webbrowser"):
+                with pytest.raises(SystemExit):
+                    mod.start_oauth_flow("fake_id", "fake_secret")
+
+
+# --- Client: Token refresh ---
+
+class TestClientTokenRefresh:
+    """Test WhoopClient token refresh behavior with mocked HTTP."""
+
+    def test_refresh_clears_tokens_on_401(self):
+        """On 401 from refresh endpoint, stored tokens should be cleared so
+        status reports re-auth needed instead of silently operating on stale state.
+        
+        Critical: All storage I/O must be mocked to prevent Keychain/file writes.
+        """
+        mod_client = _import_skill_module("whoop_client")
+        mod_storage = _import_skill_module("whoop_storage")
+
+        client = mod_client.WhoopClient.__new__(mod_client.WhoopClient)
+        client._tokens = {"access_token": "expired", "refresh_token": "expired_rt", "expires_at": 0}
+        client.session = MagicMock()
+        client.session.headers = {}
+        client._request_timestamps = []
+
+        with patch.object(mod_storage, "load_client_credentials", return_value={"client_id": "c", "client_secret": "s"}), \
+             patch.object(mod_client, "load_client_credentials", return_value={"client_id": "c", "client_secret": "s"}), \
+             patch.object(mod_client, "clear_tokens") as mock_client_clear, \
+             patch.object(mod_client, "requests") as mock_requests:
+            mock_requests.post.return_value = MagicMock(status_code=401)
+
+            with pytest.raises(mod_client.TokenExpiredError):
+                client._refresh_if_needed()
+
+            mock_client_clear.assert_called()
+
+    def test_refresh_clears_tokens_on_invalid_grant(self):
+        """On invalid_grant error response, tokens should be cleared.
+        
+        Critical: All storage I/O must be mocked to prevent Keychain/file writes.
+        """
+        mod_client = _import_skill_module("whoop_client")
+        mod_storage = _import_skill_module("whoop_storage")
+
+        client = mod_client.WhoopClient.__new__(mod_client.WhoopClient)
+        client._tokens = {"access_token": "expired", "refresh_token": "expired_rt", "expires_at": 0}
+        client.session = MagicMock()
+        client.session.headers = {}
+        client._request_timestamps = []
+
+        with patch.object(mod_storage, "load_client_credentials", return_value={"client_id": "c", "client_secret": "s"}), \
+             patch.object(mod_client, "load_client_credentials", return_value={"client_id": "c", "client_secret": "s"}), \
+             patch.object(mod_client, "clear_tokens") as mock_client_clear, \
+             patch.object(mod_client, "requests") as mock_requests:
+            mock_requests.post.return_value = MagicMock(
+                status_code=200,
+                json=lambda: {"error": "invalid_grant", "error_description": "Token has been revoked"},
+            )
+
+            with pytest.raises(mod_client.TokenExpiredError):
+                client._refresh_if_needed()
+
+            mock_client_clear.assert_called()
+
+    def test_refresh_succeeds_on_valid_response(self):
+        """Successful token refresh should save new tokens and update headers.
+        
+        Critical: This test MUST NOT call real save_tokens or load_client_credentials.
+        All storage I/O must be mocked to prevent writing test data to Keychain/files.
+        """
+        mod_client = _import_skill_module("whoop_client")
+        mod_storage = _import_skill_module("whoop_storage")
+
+        client = mod_client.WhoopClient.__new__(mod_client.WhoopClient)
+        client._tokens = {"access_token": "expired", "refresh_token": "expired_rt", "expires_at": 0}
+        client.session = MagicMock()
+        client.session.headers = {}
+        client._request_timestamps = []
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"access_token": "test_new_at", "refresh_token": "test_new_rt", "expires_in": 3600}
+        mock_response.raise_for_status = MagicMock()
+
+        with patch.object(mod_storage, "load_client_credentials", return_value={"client_id": "c", "client_secret": "s"}), \
+             patch.object(mod_storage, "save_tokens") as mock_save, \
+             patch.object(mod_client, "load_client_credentials", return_value={"client_id": "c", "client_secret": "s"}), \
+             patch.object(mod_client, "save_tokens") as mock_client_save, \
+             patch.object(mod_client, "requests") as mock_requests:
+            mock_requests.post.return_value = mock_response
+
+            client._refresh_if_needed()
+
+            # Verify both storage and client module patches intercepted the call
+            mock_client_save.assert_called()
+            assert client.session.headers["Authorization"] == "Bearer test_new_at"
+
+
+# --- Client: Rate limiting ---
+
+class TestClientRateLimiting:
+    """Test rate limit tracking in WhoopClient."""
+
+    def test_rate_limit_tracks_timestamps(self):
+        mod = _import_skill_module("whoop_client")
+        client = mod.WhoopClient.__new__(mod.WhoopClient)
+        client._request_timestamps = [1000.0, 1001.0]
+        assert len(client._request_timestamps) == 2
+
+
+# --- Endpoints registry ---
+
+class TestEndpointRegistry:
+    """Test the endpoint registry for completeness and correctness."""
+
+    def test_all_endpoints_have_required_fields(self):
+        mod = _import_skill_module("whoop_endpoints")
+
+        for name, ep in mod.ENDPOINTS.items():
+            assert ep.name == name, f"Endpoint name mismatch: {ep.name} != {name}"
+            assert ep.path.startswith("/developer/v2/"), f"{name}: path must start with /developer/v2/ — got {ep.path}"
+            assert isinstance(ep.scopes, list), f"{name}: scopes must be a list"
+            assert len(ep.scopes) > 0, f"{name}: must have at least one scope"
+            assert isinstance(ep.requires_pagination, bool), f"{name}: requires_pagination must be bool"
+
+    def test_six_endpoints_registered(self):
+        mod = _import_skill_module("whoop_endpoints")
+        expected = {"cycle", "recovery", "sleep", "workout", "body", "profile"}
+        assert set(mod.ENDPOINTS.keys()) == expected
+
+    def test_get_endpoint_raises_on_unknown(self):
+        mod = _import_skill_module("whoop_endpoints")
+        with pytest.raises(KeyError):
+            mod.get_endpoint("nonexistent")
+
+    def test_endpoint_names_match_api_reference(self):
+        mod = _import_skill_module("whoop_endpoints")
+        api_ref = (SKILL_DIR / "references" / "api-reference.md").read_text()
+        for name in mod.ENDPOINTS:
+            assert name in api_ref.lower(), f"Endpoint '{name}' not found in api-reference.md"
+
+
+# --- Privacy policy content checks ---
+
+class TestPrivacyPolicyContent:
+    """Verify the privacy policy doesn't make false security claims."""
+
+    def test_no_encrypted_claim(self):
+        """Privacy policy should NOT claim tokens are 'encrypted' in the JSON fallback."""
+        html = (SKILL_DIR / "references" / "privacy-policy.html").read_text()
+        assert "encrypted local file" not in html, (
+            "Privacy policy should not claim JSON fallback is 'encrypted' — it uses 0o600 permissions, not encryption"
+        )
+
+    def test_mentions_restricted_permissions(self):
+        """Privacy policy should mention restricted permissions for file storage."""
+        html = (SKILL_DIR / "references" / "privacy-policy.html").read_text()
+        assert "restricted permissions" in html or "owner-read-only" in html, (
+            "Privacy policy should disclose that file-based storage uses restricted permissions"
+        )
+
+
+# --- API reference typo checks ---
+
+class TestApiReferenceTypos:
+    """Verify API reference has no known typos."""
+
+    def test_no_kiljoule_typo(self):
+        """The word 'kiljoule' is a known typo — should be 'kilojoule'."""
+        api_ref = (SKILL_DIR / "references" / "api-reference.md").read_text()
+        assert "kiljoule" not in api_ref, "Typo 'kiljoule' found — should be 'kilojoule'"
+
+    def test_kilojoule_present(self):
+        """The correct spelling 'kilojoule' should appear in the API reference."""
+        api_ref = (SKILL_DIR / "references" / "api-reference.md").read_text()
+        assert "kilojoule" in api_ref, "Expected 'kilojoule' in API reference"
+
+
+# --- Atomic write test ---
+
+class TestAtomicWrites:
+    """Verify that token file writes are atomic (no partial reads)."""
+
+    def test_save_uses_atomic_rename(self):
+        """_save_to_json_file should use write-to-temp + os.replace pattern."""
+        src = (SKILL_DIR / "scripts" / "whoop_storage.py").read_text()
+        assert "os.replace" in src, "_save_to_json_file should use os.replace for atomic writes"
+        assert ".tmp" in src, "_save_to_json_file should write to a .tmp file first"
+
+    def test_chmod_before_rename(self):
+        """Permissions should be set on the temp file BEFORE rename."""
+        src = (SKILL_DIR / "scripts" / "whoop_storage.py").read_text()
+        # Find all lines in _save_to_json_file and verify chmod comes before os.replace
+        in_func = False
+        chmod_idx = None
+        replace_idx = None
+        for i, line in enumerate(src.split("\n")):
+            if "def _save_to_json_file" in line:
+                in_func = True
+            elif in_func and line.startswith("def "):
+                break
+            elif in_func:
+                if "chmod" in line:
+                    chmod_idx = i
+                if "os.replace" in line:
+                    replace_idx = i
+        assert chmod_idx is not None, "chmod not found in _save_to_json_file"
+        assert replace_idx is not None, "os.replace not found in _save_to_json_file"
+        assert chmod_idx < replace_idx, (
+            "chmod should come before os.replace — permissions set on temp file before atomic rename"
+        )
+
+
+# --- Token refresh failure handling ---
+
+class TestTokenRefreshFailureHandling:
+    """Verify that refresh failures properly clear stale tokens."""
+
+    def test_401_clears_tokens(self):
+        """On 401 response, tokens should be cleared before raising TokenExpiredError."""
+        src = (SKILL_DIR / "scripts" / "whoop_client.py").read_text()
+        assert "clear_tokens()" in src, (
+            "401 handler in _refresh_if_needed should call clear_tokens() before raising error"
+        )
+
+    def test_invalid_grant_clears_tokens(self):
+        """On invalid_grant error response, tokens should be cleared."""
+        src = (SKILL_DIR / "scripts" / "whoop_client.py").read_text()
+        assert '"error"' in src or "'error'" in src, (
+            "Should check for 'error' field in token refresh response (e.g. invalid_grant)"
+        )
+
+    def test_imports_clear_tokens(self):
+        """whoop_client should be able to import clear_tokens from whoop_storage."""
+        src = (SKILL_DIR / "scripts" / "whoop_client.py").read_text()
+        assert "clear_tokens" in src, "whoop_client should reference clear_tokens for failure handling"


### PR DESCRIPTION
## What does this PR do?

Adds a new bundled skill (`skills/health/whoop-api/`) that pulls fitness data from the Whoop API via OAuth2.

**Key features:**
- **One-command setup**: `python3 scripts/whoop_sync.py setup` — prompts for client_id/secret, opens browser OAuth, stores tokens, auto-creates Hermes cron jobs
- **Cross-platform credential storage**: macOS Keychain with automatic fallback to JSON file on Linux/Windows
- **Auto-refreshing tokens**: Access tokens refresh on expiry; cron keeps them alive every 55 minutes
- **All 6 endpoints**: cycle, recovery, sleep, workout, body, profile
- **Privacy policy sample**: Included at `references/privacy-policy.html` with hosting instructions (GitHub Pages or Gist)

## Related Issue

New skill — no existing issue.

## Type of Change

- [x] ✨ New feature (bundled skill)

## Changes Made

- `skills/health/whoop-api/SKILL.md` — skill documentation (CONTRIBUTING.md format, ≤60 char description, standard section order)
- `skills/health/whoop-api/scripts/whoop_sync.py` — CLI: setup, pull, refresh, status, daemon commands
- `skills/health/whoop-api/scripts/whoop_oauth.py` — OAuth2 Authorization Code flow with CSRF state
- `skills/health/whoop-api/scripts/whoop_storage.py` — Cross-platform credential/token storage (Keychain + JSON fallback)
- `skills/health/whoop-api/scripts/whoop_client.py` — API client with auto-refresh and rate limiting
- `skills/health/whoop-api/scripts/whoop_endpoints.py` — Endpoint registry (cycle, recovery, sleep, workout, body, profile)
- `skills/health/whoop-api/scripts/whoop_token_refresh.py` — Cron script for token keepalive
- `skills/health/whoop-api/references/api-reference.md` — Whoop API reference
- `skills/health/whoop-api/references/privacy-policy.html` — Sample privacy policy for Whoop dev app registration
- `skills/health/whoop-api/templates/cron-entry.yaml` — Cron configuration examples
- `skills/health/whoop-api/.gitignore` — Excludes `__pycache__/` and `whoop_data/`
- `tests/skills/test_whoop_api_skill.py` — 27 smoke tests (frontmatter, script syntax, cross-platform, key constants)

## How to Test

1. Register a Whoop Developer App at https://developer.whoop.com (redirect URI: `http://localhost:8647/callback`)
2. `cd skills/health/whoop-api && python3 scripts/whoop_sync.py setup`
3. Enter client_id and client_secret when prompted, authorize in browser
4. `python3 scripts/whoop_sync.py status` — verify credentials and tokens are valid
5. `python3 scripts/whoop_sync.py pull` — fetch data from all 6 endpoints
6. `pytest tests/skills/test_whoop_api_skill.py -v` — 27 tests pass

## Checklist

### Code
- [x] I have read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) — no duplicates
- [x] My PR contains only changes related to this feature (no unrelated commits)
- [x] I have run `pytest tests/skills/test_whoop_api_skill.py -v` and all 27 tests pass
- [x] I have added tests for my changes
- [x] I have tested on macOS 15.2

### Documentation & Housekeeping
- [x] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [x] No external dependencies beyond `requests` (stdlib + one pip package)
- [x] Cross-platform: Keychain on macOS, JSON fallback on Linux/Windows. No POSIX-isms. Tested `check-windows-footguns` patterns.
- N/A — No config keys added to `cli-config.yaml.example`
- N/A — No changes to `CONTRIBUTING.md` or `AGENTS.md`
- [x] Cross-platform compatibility verified (no `os.kill(pid, 0)`, no hardcoded paths, no `fcntl`/`termios` without guards)

## For New Skills

- [x] This skill is **broadly useful** — fitness/wearable data is a common integration ask
- [x] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) with all 7 required sections
- [x] No external dependencies beyond `requests` (prefer stdlib + existing tools per guidelines)
- [x] Tested end-to-end: setup auth, pull data, verify cron creation