### PR TITLE
Shrink Hermes backup archives

### DIFF
--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -36,7 +36,11 @@ _EXCLUDED_DIRS = {
     "__pycache__",      # bytecode caches — regenerated on import
     ".git",             # nested git dirs (profiles shouldn't have these, but safety)
     "node_modules",     # js deps if website/ somehow leaks in
+    ".venv",            # plugin/tool virtualenvs are dependency caches; reinstall instead of porting
+    "venv",             # same as .venv for tools that use an unhidden env name
+    ".curator_backups", # generated skill-curation backups; main backup already protects current skills
     "backups",          # prior auto-backups — don't nest backups exponentially
+    "state-snapshots",  # quick rollback snapshots duplicate state.db; do not re-zip them
     "checkpoints",      # session-local trajectory caches — regenerated per-session,
                         # session-hash-keyed so they don't port to another machine anyway
 }

--- a/tests/hermes_cli/test_backup.py
+++ b/tests/hermes_cli/test_backup.py
@@ -103,6 +103,25 @@ class TestShouldExclude:
         from hermes_cli.backup import _should_exclude
         assert _should_exclude(Path("backups/pre-update-2026-04-27-063400.zip"))
 
+    def test_excludes_state_snapshots_dir(self):
+        """state-snapshots/ contains rollback artifacts that duplicate state.db.
+        Full backups already include current state.db, so nesting snapshots causes
+        pre-update backups to balloon without improving the current-state restore.
+        """
+        from hermes_cli.backup import _should_exclude
+        assert _should_exclude(Path("state-snapshots/20260520-173300-pre-update/state.db"))
+        assert _should_exclude(Path("state-snapshots/20260520-173300-pre-update/manifest.json"))
+
+    def test_excludes_dependency_and_generated_backup_dirs(self):
+        """Plugin virtualenvs and curator rollback bundles are generated caches.
+        Keeping them in full backups makes archives large without improving restore
+        of the current Hermes configuration, skills, sessions, or state.
+        """
+        from hermes_cli.backup import _should_exclude
+        assert _should_exclude(Path("plugins/hindsight/.venv/bin/python"))
+        assert _should_exclude(Path("tools/some-tool/venv/lib/python/site-packages/pkg.py"))
+        assert _should_exclude(Path("skills/.curator_backups/20260518/skill/SKILL.md"))
+
     def test_excludes_sqlite_sidecars(self):
         """SQLite WAL/SHM/journal sidecars must not ship alongside the
         safe-copied .db — pairing a fresh snapshot with stale sidecar state

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -605,6 +605,9 @@ The backup uses SQLite's `backup()` API for safe copying, so it works correctly 
 **What's excluded from the zip:**
 
 - `*.db-wal`, `*.db-shm`, `*.db-journal` — SQLite's WAL / shared-memory / journal sidecars. The `*.db` file already got a consistent snapshot via `sqlite3.backup()`; shipping the live sidecars alongside it would let a restore see a half-committed state.
+- `backups/` and `state-snapshots/` — generated rollback archives. Full backups already include the current state, so nesting previous archives causes runaway backup growth.
+- `.venv/`, `venv/`, and `node_modules/` — dependency caches for plugins/tools. Reinstall them on the target machine instead of porting machine-local packages.
+- `.curator_backups/` — generated skill-curator rollback bundles. The current skill tree is already included.
 - `checkpoints/` — per-session trajectory caches. Hash-keyed and regenerated per session; wouldn't port cleanly to another install anyway.
 - The `hermes-agent` code itself (this is a user-data backup, not a repo snapshot).
 


### PR DESCRIPTION
## Summary
- Exclude generated state snapshots, virtualenvs, and curator backup archives from Hermes full backups.
- Add regression coverage for backup exclusion behavior.
- Update CLI backup documentation with the generated/reconstructible exclusion policy.

## Test plan
- [x] python -m pytest tests/hermes_cli/test_backup.py -q

🤖 Generated with [Claude Code](https://claude.com/claude-code)