### PR TITLE
fix(gateway): pass Weixin video attachments into agent context

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -944,6 +944,8 @@ def _build_media_placeholder(event) -> str:
         mtype = media_types[i] if i < len(media_types) else ""
         if mtype.startswith("image/") or getattr(event, "message_type", None) == MessageType.PHOTO:
             parts.append(f"[User sent an image: {url}]")
+        elif mtype.startswith("video/") or getattr(event, "message_type", None) == MessageType.VIDEO:
+            parts.append(f"[User sent a video: {url}]")
         elif mtype.startswith("audio/"):
             parts.append(f"[User sent audio: {url}]")
         else:
@@ -7686,47 +7688,55 @@ class GatewayRunner:
                 )
                 message_text = f"{_note}\n\n{message_text}"
 
-        if event.media_urls and event.message_type == MessageType.DOCUMENT:
+        if event.media_urls:
             import mimetypes as _mimetypes
             from tools.credential_files import to_agent_visible_cache_path
 
-            _TEXT_EXTENSIONS = {".txt", ".md", ".csv", ".log", ".json", ".xml", ".yaml", ".yml", ".toml", ".ini", ".cfg"}
-            for i, path in enumerate(event.media_urls):
-                mtype = event.media_types[i] if i < len(event.media_types) else ""
-                if mtype in {"", "application/octet-stream"}:
-                    _ext = os.path.splitext(path)[1].lower()
-                    if _ext in _TEXT_EXTENSIONS:
-                        mtype = "text/plain"
-                    else:
+            for idx, path in enumerate(event.media_urls):
+                mtype = event.media_types[idx] if idx < len(event.media_types) else ""
+                if not mtype:
+                    try:
                         guessed, _ = _mimetypes.guess_type(path)
                         if guessed:
                             mtype = guessed
-                if not mtype.startswith(("application/", "text/")):
-                    continue
+                    except Exception:
+                        pass
 
                 basename = os.path.basename(path)
                 parts = basename.split("_", 2)
                 display_name = parts[2] if len(parts) >= 3 else basename
-                display_name = re.sub(r'[^\w.\- ]', '_', display_name)
+                try:
+                    display_name = urllib.parse.unquote(display_name)
+                except Exception:
+                    pass
 
-                # Translate host cache path to in-container path if running under Docker backend.
-                # This ensures the agent receives a path it can open inside its sandbox, as the
+                # Convert host-local cache path to the agent-visible path. In containerized tool environments,
                 # cache directories are auto-mounted at /root/.hermes/cache/* by get_cache_directory_mounts().
                 agent_path = to_agent_visible_cache_path(path)
 
-                if mtype.startswith("text/"):
+                if event.message_type == MessageType.DOCUMENT and mtype.startswith(("application/", "text/")):
+                    if mtype.startswith("text/"):
+                        context_note = (
+                            f"[The user sent a text document: '{display_name}'. "
+                            f"Its content has been included below. "
+                            f"The file is also saved at: {agent_path}]"
+                        )
+                    else:
+                        context_note = (
+                            f"[The user sent a document: '{display_name}'. "
+                            f"The file is saved at: {agent_path}. "
+                            f"Ask the user what they'd like you to do with it.]"
+                        )
+                    message_text = f"{context_note}\n\n{message_text}"
+                    continue
+
+                if mtype.startswith("video/") or event.message_type == MessageType.VIDEO:
                     context_note = (
-                        f"[The user sent a text document: '{display_name}'. "
-                        f"Its content has been included below. "
-                        f"The file is also saved at: {agent_path}]"
-                    )
-                else:
-                    context_note = (
-                        f"[The user sent a document: '{display_name}'. "
+                        f"[The user sent a video: '{display_name}'. "
                         f"The file is saved at: {agent_path}. "
-                        f"Ask the user what they'd like you to do with it.]"
+                        f"You can inspect this path with video/media tools or ask a follow-up question if needed.]"
                     )
-                message_text = f"{context_note}\n\n{message_text}"
+                    message_text = f"{context_note}\n\n{message_text}"
 
         if getattr(event, "reply_to_text", None) and event.reply_to_message_id:
             # Always inject the reply-to pointer — even when the quoted text

--- a/tests/gateway/test_video_attachment_context.py
+++ b/tests/gateway/test_video_attachment_context.py
@@ -1,0 +1,76 @@
+from unittest.mock import patch
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform
+from gateway.platforms.base import MessageEvent, MessageType
+from gateway.run import GatewayRunner, _build_media_placeholder
+from gateway.session import SessionSource
+
+
+def _make_runner() -> GatewayRunner:
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner.config = GatewayConfig()
+    runner.adapters = {}
+    runner._model = "test-model"
+    runner._base_url = ""
+    runner._has_setup_skill = lambda: False
+    runner._consume_pending_native_image_paths = lambda _session_key: []
+    runner._session_key_for_source = lambda source: f"{source.platform.value}:{source.chat_id}"
+    return runner
+
+
+def _source() -> SessionSource:
+    return SessionSource(platform=Platform.WEIXIN, chat_id="wxid_123", chat_type="dm")
+
+
+def _video_event(text: str = "") -> MessageEvent:
+    return MessageEvent(
+        text=text,
+        message_type=MessageType.VIDEO,
+        source=_source(),
+        media_urls=["/tmp/doc_deadbeef_video.mp4"],
+        media_types=["video/mp4"],
+    )
+
+
+@pytest.mark.asyncio
+async def test_prepare_inbound_message_text_includes_video_path_note_for_media_only_event():
+    runner = _make_runner()
+    event = _video_event("")
+    source = _source()
+
+    with patch("tools.credential_files.to_agent_visible_cache_path", side_effect=lambda p: p):
+        result = await runner._prepare_inbound_message_text(
+            event=event,
+            source=source,
+            history=[],
+        )
+
+    assert result is not None
+    assert "user sent a video" in result.lower()
+    assert "/tmp/doc_deadbeef_video.mp4" in result
+
+
+@pytest.mark.asyncio
+async def test_prepare_inbound_message_text_preserves_caption_and_adds_video_path_note():
+    runner = _make_runner()
+    event = _video_event("[引用媒体] 我这里不是给你发了一个视频吗")
+    source = _source()
+
+    with patch("tools.credential_files.to_agent_visible_cache_path", side_effect=lambda p: p):
+        result = await runner._prepare_inbound_message_text(
+            event=event,
+            source=source,
+            history=[],
+        )
+
+    assert result is not None
+    assert "user sent a video" in result.lower()
+    assert "/tmp/doc_deadbeef_video.mp4" in result
+    assert "[引用媒体] 我这里不是给你发了一个视频吗" in result
+
+
+def test_build_media_placeholder_labels_video_as_video_not_generic_file():
+    placeholder = _build_media_placeholder(_video_event(""))
+    assert placeholder == "[User sent a video: /tmp/doc_deadbeef_video.mp4]"


### PR DESCRIPTION
## Summary
- label Weixin video attachments as videos in `_build_media_placeholder()`
- inject cached video paths into inbound gateway message text so the agent can use them
- add regression tests covering media-only and captioned video messages

## Test Plan
- `python -m pytest tests/gateway/test_video_attachment_context.py -v --tb=short -n 0 -o addopts=''`
