### PR TITLE
fix(gateway): avoid flashing a console on Windows restart

### DIFF
--- a/hermes_cli/gateway_windows.py
+++ b/hermes_cli/gateway_windows.py
@@ -973,7 +973,15 @@ def status(deep: bool = False) -> None:
 
 
 def start() -> None:
-    """Start the gateway. Prefers /Run on the scheduled task if present."""
+    """Start the gateway with a direct detached spawn to avoid flashing a cmd window.
+
+    Keep the Scheduled Task / Startup item for login persistence, but don't use
+    ``schtasks /Run`` for manual starts because that launches the wrapper
+    ``gateway.cmd`` through ``cmd.exe`` and can flash a visible console window.
+    ``_spawn_detached()`` already launches ``pythonw.exe`` directly with the
+    Windows no-console creation flags, matching the quieter install(start_now)
+    path.
+    """
     _assert_windows()
     running_pids = _gateway_pids()
     if running_pids:
@@ -998,14 +1006,6 @@ def start() -> None:
             print("  If a UAC prompt opened, approve it, then run: hermes gateway start")
             return
 
-    if task_installed:
-        code, _out, err = _exec_schtasks(["/Run", "/TN", get_task_name()])
-        if code == 0:
-            _report_gateway_start(f"Scheduled Task {get_task_name()!r}")
-            return
-        print(f"⚠ schtasks /Run failed (code {code}): {err.strip()} — falling back to direct spawn")
-
-    # Startup fallback or failed /Run: direct spawn one foreground-detached gateway.
     pid = _spawn_detached()
     _report_gateway_start(f"direct spawn (PID {pid})")
 

--- a/tests/hermes_cli/test_gateway_windows.py
+++ b/tests/hermes_cli/test_gateway_windows.py
@@ -349,6 +349,26 @@ def test_start_noops_when_gateway_already_running(monkeypatch, capsys):
     assert "27128" in out
 
 
+def test_start_uses_direct_spawn_even_when_scheduled_task_is_installed(monkeypatch, capsys):
+    """Manual start should bypass schtasks /Run to avoid flashing gateway.cmd's console window."""
+    calls = []
+    monkeypatch.setattr(gateway_windows, "_assert_windows", lambda: None)
+    monkeypatch.setattr(gateway_windows, "_gateway_pids", lambda: [])
+    monkeypatch.setattr(gateway_windows, "is_task_registered", lambda: True)
+    monkeypatch.setattr(gateway_windows, "is_startup_entry_installed", lambda: False)
+    monkeypatch.setattr(gateway_windows, "_exec_schtasks", lambda args: calls.append(("schtasks", tuple(args))) or (0, "", ""))
+    monkeypatch.setattr(gateway_windows, "_spawn_detached", lambda path=None: calls.append(("spawn", path)) or 12345)
+    monkeypatch.setattr(gateway_windows, "_report_gateway_start", lambda via: calls.append(("report_start", via)))
+
+    gateway_windows.start()
+
+    assert not any(call[0] == "schtasks" for call in calls)
+    assert ("spawn", None) in calls
+    assert ("report_start", "direct spawn (PID 12345)") in calls
+    out = capsys.readouterr().out
+    assert out == ""
+
+
 def test_install_startup_fallback_does_not_spawn_when_gateway_already_running(monkeypatch, tmp_path, capsys):
     """Repeated Windows fallback installs should not spawn duplicate gateways."""
     script_path, calls = _arrange_startup_fallback(monkeypatch, tmp_path, [24476])


### PR DESCRIPTION
## Summary
- make Windows `gateway start` use the existing detached `pythonw.exe` spawn path even when a Scheduled Task is installed
- stop calling `schtasks /Run` for manual starts, which launches `gateway.cmd` through `cmd.exe` and flashes a visible console
- add regression coverage for the Scheduled Task installed case

## Test Plan
- `python -m pytest tests/hermes_cli/test_gateway_windows.py -k 'direct_spawn or already_running' -v --tb=short -n 0 -o addopts=''`
