### PR TITLE
fix(cron): handle bare-list jobs.json in load_jobs()

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -410,15 +410,25 @@ def load_jobs() -> List[Dict[str, Any]]:
     try:
         with open(JOBS_FILE, 'r', encoding='utf-8') as f:
             data = json.load(f)
+            # Accept both {"jobs": [...]} and bare [...] formats.
+            # Bare lists can appear from older versions, distribution installs,
+            # or snapshot restores. Auto-repair to canonical format.
+            if isinstance(data, list):
+                logger.warning("Auto-repaired jobs.json (bare list → {\"jobs\": [...]})")
+                save_jobs(data)
+                return data
             return data.get("jobs", [])
     except json.JSONDecodeError:
         # Retry with strict=False to handle bare control chars in string values
         try:
             with open(JOBS_FILE, 'r', encoding='utf-8') as f:
                 data = json.loads(f.read(), strict=False)
-                jobs = data.get("jobs", [])
+                if isinstance(data, list):
+                    jobs = data
+                else:
+                    jobs = data.get("jobs", [])
                 if jobs:
-                    # Auto-repair: rewrite with proper escaping
+                    # Auto-repair: rewrite with proper escaping and canonical format
                     save_jobs(jobs)
                     logger.warning("Auto-repaired jobs.json (had invalid control characters)")
                 return jobs


### PR DESCRIPTION
## Problem

`load_jobs()` in `cron/jobs.py` assumes `jobs.json` is always in the canonical dict format `{"jobs": [...]}`, calling `data.get("jobs", [])` unconditionally. However, bare list format `[...]` can appear from:

- **Distribution installs** — `shutil.copytree` copies `cron/` as-is during `_copy_dist_payload()`
- **Quick snapshot restores** — `shutil.copy2` does raw file copy in `restore_quick_snapshot()`
- **Older hermes versions or manual edits**

When `jobs.json` contains a bare list, every `cronjob(action='list')` call fails with:
```
'list' object has no attribute 'get'
```
This breaks all cron management until the file is manually repaired.

## Fix

Add `isinstance(data, list)` checks to `load_jobs()` in both the normal parse path and the `JSONDecodeError` retry path. When a bare list is detected, auto-repair it to the canonical `{"jobs": [...]}` format via `save_jobs()`.

Note: `curator_backup.py` already handled both formats (line 424: `# accept both that shape and a bare list for forward compat`), but the primary `load_jobs()` did not.

## Testing

Verified locally:
1. Wrote a bare list to `jobs.json`
2. Called `load_jobs()` — returned correct job data
3. Confirmed `jobs.json` was auto-repaired to `{"jobs": [...]}` format
4. `cronjob(action='list')` works correctly after repair
