### PR TITLE
feat(optional-skills/finance): add longbridge — live financial markets skill

### DIFF
--- a/optional-skills/finance/longbridge/SKILL.md
+++ b/optional-skills/finance/longbridge/SKILL.md
@@ -1,0 +1,174 @@
+---
+name: longbridge
+description: Live financial market data, trading, and portfolio analysis via Longbridge Securities — quotes, K-lines, news, filings, fundamentals, earnings, options, insider trades, institutional holdings, watchlist, account positions and P&L. Covers US, HK, A-share, SG markets.
+version: 1.0.0
+author: Longbridge (https://longbridge.com)
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [Finance, Stocks, Trading, Market-Data, Portfolio, HK-Stocks, US-Stocks, A-Shares, Options, Fundamentals]
+    category: finance
+    related_skills: [stocks, dcf-model, comps-analysis]
+    requires_setup: true
+---
+
+# Longbridge Developers Platform
+
+Full-stack financial data and trading platform: CLI, Python/Rust SDK, MCP, and LLM integration.
+
+> **Response language**: match the user's input language — Simplified Chinese / Traditional Chinese / English.
+
+**Official docs:** https://open.longbridge.com
+**llms.txt:** https://open.longbridge.com/llms.txt
+
+For setup and authentication details, see [references/setup.md](references/setup.md).
+
+---
+
+## Investment Analysis Workflow
+
+When the user asks about stock performance, portfolio advice, or market analysis:
+
+1. **Get live data** via CLI — quotes, positions, K-line history, intraday
+2. **Get news/catalysts** via CLI — **prefer Longbridge first**; fall back to WebSearch only if insufficient
+3. **Combine** — price action + volume + catalyst → analysis + suggestion
+
+```bash
+# Market data
+longbridge quote SYMBOL.US
+longbridge positions                # stock positions
+longbridge portfolio                # P/L, asset distribution, holdings, cash (always pull when user asks about "my portfolio")
+longbridge portfolio short-margin   # short-selling margin deposit details per position
+longbridge kline history SYMBOL.US --start YYYY-MM-DD --end YYYY-MM-DD --period day
+longbridge intraday SYMBOL.US
+
+# News & content (prefer these over WebSearch)
+longbridge news SYMBOL.US           # latest news articles
+longbridge news detail <id>         # full article content
+longbridge news search "keyword"    # keyword search across news articles
+longbridge filing SYMBOL.US         # regulatory filings list (8-K, 10-Q, 10-K, etc.)
+longbridge topic SYMBOL.US          # community discussion
+longbridge topic search "keyword"   # keyword search across community topics
+longbridge market-temp              # market sentiment index (0–100)
+
+# Fundamentals & analysis
+longbridge financial-statement SYMBOL.US --kind ALL   # hierarchical IS/BS/CF with YoY
+longbridge financial-report SYMBOL.US --latest        # key KPI summary (revenue/EPS/ROE)
+longbridge analyst-estimates SYMBOL.US                # EPS consensus (high/low/mean/median)
+longbridge valuation-rank SYMBOL.US                   # daily PE/PB/PS industry percentile rank
+
+# IPO
+longbridge ipo subscriptions        # HK IPOs in subscription stage
+longbridge ipo calendar             # all upcoming and recent IPOs
+longbridge ipo us-subscriptions     # US IPOs in subscription stage
+
+# Account
+longbridge assets                   # full asset overview: cash, buying power, margin, risk level
+longbridge statement --help         # check subcommands for statement export options
+longbridge bank-cards               # bank cards linked to the account
+longbridge withdrawals              # withdrawal history
+longbridge deposits                 # deposit history
+
+# Institutional investors (SEC 13F)
+longbridge investors                # top active fund managers by AUM
+longbridge investors <CIK>          # holdings for a specific investor by CIK
+longbridge insider-trades SYMBOL.US # SEC Form 4 insider transaction history
+```
+
+For commands with complex flags, always run `longbridge <command> --help` for current options.
+
+Only fall back to WebSearch when Longbridge news is insufficient (e.g., breaking news not yet indexed, macro events unrelated to a specific symbol).
+
+---
+
+## Choose the Right Tool
+
+```
+User wants to...                         → Use
+─────────────────────────────────────────────────────────────────
+Quick quote / one-off data lookup        CLI
+Interactive terminal workflows           CLI
+Script market data, save to file         CLI + jq  (or Python SDK)
+Loops, conditions, transformations       Python SDK (sync)
+Async pipelines, concurrent fetches      Python SDK (async)
+Production service, high throughput      Rust SDK
+Real-time WebSocket subscription loop    SDK (Python or Rust)
+Programmatic order strategy              SDK
+Talk to AI about stocks (no code)        MCP (hosted or self-hosted)
+Use Cursor/Claude for trading analysis   MCP
+Add Longbridge API docs to IDE/RAG       LLMs.txt / Markdown API
+```
+
+## Symbol Format
+
+`<CODE>.<MARKET>` — applies to all tools.
+
+| Market         | Suffix | Examples                        |
+| -------------- | ------ | ------------------------------- |
+| Hong Kong      | `HK`   | `700.HK`, `9988.HK`, `2318.HK`  |
+| United States  | `US`   | `TSLA.US`, `AAPL.US`, `NVDA.US` |
+| China Shanghai | `SH`   | `600519.SH`, `000001.SH`        |
+| China Shenzhen | `SZ`   | `000568.SZ`, `300750.SZ`        |
+| Singapore      | `SG`   | `D05.SG`, `U11.SG`              |
+| Crypto         | `HAS`  | `BTCUSD.HAS`, `ETHUSD.HAS`      |
+
+## Reference Files
+
+### CLI (Terminal)
+
+- **Overview** — install, auth, output formats, patterns: [references/cli/overview.md](references/cli/overview.md)
+
+**Always use `longbridge --help` to list available commands, and `longbridge <command> --help` for specific options and flags.** Do not rely on hardcoded documentation — the CLI's built-in help is always up-to-date.
+
+### Python SDK
+
+- **Overview** — install, Config, auth, HttpClient: [references/python-sdk/overview.md](references/python-sdk/overview.md)
+- **QuoteContext** — all quote methods + subscriptions: [references/python-sdk/quote-context.md](references/python-sdk/quote-context.md)
+- **TradeContext** — orders, account, executions: [references/python-sdk/trade-context.md](references/python-sdk/trade-context.md)
+- **Types & Enums** — Period, OrderType, SubType, push types: [references/python-sdk/types.md](references/python-sdk/types.md)
+
+### Rust SDK
+
+- **Overview** — Cargo.toml, Config, auth, error handling: [references/rust-sdk/overview.md](references/rust-sdk/overview.md)
+- **QuoteContext** — all methods, SubFlags, PushEvent: [references/rust-sdk/quote-context.md](references/rust-sdk/quote-context.md)
+- **TradeContext** — orders, SubmitOrderOptions builder, account: [references/rust-sdk/trade-context.md](references/rust-sdk/trade-context.md)
+- **Content** — news, filings, topics (ContentContext + Python fallback): [references/rust-sdk/content.md](references/rust-sdk/content.md)
+- **Types & Enums** — all Rust enums and structs: [references/rust-sdk/types.md](references/rust-sdk/types.md)
+
+### AI Integration
+
+- **MCP** — hosted service, self-hosted server, setup & auth: [references/mcp.md](references/mcp.md)
+- **LLMs & Markdown** — llms.txt, `open.longbridge.com` doc Markdown, `longbridge.com` live news/quote pages (`.md` suffix + Accept header), Cursor/IDE integration: [references/llm.md](references/llm.md)
+
+Load specific reference files on demand — do not load all at once.
+
+---
+
+## Related skills
+
+The skills below are siblings in the `longbridge/skills` family. If they're installed, defer to them for the listed user intents — they're more specialised and produce better-formatted output. If they're **not** installed, this skill's own CLI workflow above can handle the same queries with less specialised formatting; the foundation skill remains usable standalone.
+
+| If the user wants … | Use |
+|---|---|
+| Live quote / static reference / valuation indices for a single name | [`longbridge-quote`](../longbridge-quote) |
+| Candlestick / intraday chart | [`longbridge-kline`](../longbridge-kline) |
+| Orderbook depth / brokers / tick trades | [`longbridge-depth`](../longbridge-depth) |
+| Capital flow / large-order distribution | [`longbridge-capital-flow`](../longbridge-capital-flow) |
+| Market-level state — open / close, sentiment temperature, calendar | [`longbridge-market-temp`](../longbridge-market-temp) |
+| Options / warrants | [`longbridge-derivatives`](../longbridge-derivatives) |
+| US overnight-eligible securities catalog / HK broker dictionary | [`longbridge-security-list`](../longbridge-security-list) |
+| Stock + fund holdings, multi-currency assets, margin ratio, max-buy quantity | [`longbridge-positions`](../longbridge-positions) |
+| Today's / historical orders, executions, cash flow | [`longbridge-orders`](../longbridge-orders) |
+| Read-only watchlist groups | [`longbridge-watchlist`](../longbridge-watchlist) |
+| Watchlist mutations (create / rename / add / remove) | [`longbridge-watchlist-admin`](../longbridge-watchlist-admin) |
+| Active real-time WebSocket subscription diagnostics | [`longbridge-subscriptions`](../longbridge-subscriptions) |
+| "Is X expensive?" — historical PE / PB percentile, industry context | [`longbridge-valuation`](../longbridge-valuation) |
+| 5-dimension fundamentals (KPIs, dividends, consensus, ratings) | [`longbridge-fundamental`](../longbridge-fundamental) |
+| 2–5 symbol comparison matrix | [`longbridge-peer-comparison`](../longbridge-peer-comparison) |
+| Account-level P&L and contribution analysis | [`longbridge-portfolio`](../longbridge-portfolio) |
+| Classified news + filings + community sentiment for a single name | [`longbridge-news`](../longbridge-news) |
+| Daily incremental briefing across the watchlist | [`longbridge-catalyst-radar`](../longbridge-catalyst-radar) |
+| Institutional-grade post-earnings DOCX report (8–12 pages) | [`longbridge-earnings`](../longbridge-earnings) |
+
+This skill (`longbridge`) stays in scope when the user asks about: SDK syntax (Python / Rust), MCP server setup, LLMs.txt / IDE / RAG integration, raw CLI subcommand discovery, or anything cross-cutting that doesn't map cleanly to one specialised skill.

--- a/optional-skills/finance/longbridge/SKILL.md
+++ b/optional-skills/finance/longbridge/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: longbridge
-description: Live financial market data, trading, and portfolio analysis via Longbridge Securities — quotes, K-lines, news, filings, fundamentals, earnings, options, insider trades, institutional holdings, watchlist, account positions and P&L. Covers US, HK, A-share, SG markets.
+description: Live quotes, trading, and portfolio data via Longbridge.
 version: 1.0.0
-author: Longbridge (https://longbridge.com)
+author: Hogan (hogan-yuan), Longbridge
 license: MIT
 platforms: [linux, macos, windows]
 metadata:
@@ -13,98 +13,107 @@ metadata:
     requires_setup: true
 ---
 
-# Longbridge Developers Platform
+# Longbridge Skill
 
-Full-stack financial data and trading platform: CLI, Python/Rust SDK, MCP, and LLM integration.
+Full-stack financial data and trading platform for Longbridge Securities — CLI, Python/Rust
+SDKs, and MCP server, covering US, HK, A-share, and Singapore markets. Handles live quotes,
+fundamentals, news/filings, options, and account/portfolio/order management. Requires a
+Longbridge brokerage account and OAuth login; it does not work standalone without setup.
 
-> **Response language**: match the user's input language — Simplified Chinese / Traditional Chinese / English.
+> **Response language**: match the user's input language — Simplified Chinese / Traditional
+> Chinese / English.
 
-**Official docs:** https://open.longbridge.com
-**llms.txt:** https://open.longbridge.com/llms.txt
+## When to Use
 
-For setup and authentication details, see [references/setup.md](references/setup.md).
+- User asks about stock price, portfolio, positions, or P&L for a symbol on US, HK, China
+  A-share, or Singapore exchanges
+- User wants news, SEC/regulatory filings, or community discussion for a symbol
+- User wants fundamentals, valuation percentile, or analyst estimates
+- User wants to place, replace, or cancel a real brokerage order (confirmation required — see
+  Pitfalls)
+- User asks about Longbridge SDK syntax (Python/Rust), MCP server setup, or LLMs.txt/IDE/RAG
+  integration
 
----
+## Prerequisites
 
-## Investment Analysis Workflow
+- A Longbridge brokerage account, OAuth-authenticated via one of:
+  - **CLI** — install + `longbridge auth login` (full steps in
+    [references/setup.md](references/setup.md))
+  - **MCP** — hosted endpoint, no local install (full steps in
+    [references/mcp.md](references/mcp.md))
+- `requires_setup: true` — this skill cannot answer live-data questions until authentication is
+  done. If the user hasn't set up either path yet, walk them through
+  [references/setup.md](references/setup.md) first.
 
-When the user asks about stock performance, portfolio advice, or market analysis:
+## How to Run
 
-1. **Get live data** via CLI — quotes, positions, K-line history, intraday
-2. **Get news/catalysts** via CLI — **prefer Longbridge first**; fall back to WebSearch only if insufficient
-3. **Combine** — price action + volume + catalyst → analysis + suggestion
+Invoke the CLI through the `terminal` tool:
+
+```bash
+longbridge <command> [flags]
+```
+
+**Always run `longbridge --help` and `longbridge <command> --help` before relying on a flag** —
+the CLI evolves and this file does not attempt to enumerate every option.
+
+## Quick Reference
 
 ```bash
 # Market data
 longbridge quote SYMBOL.US
 longbridge positions                # stock positions
-longbridge portfolio                # P/L, asset distribution, holdings, cash (always pull when user asks about "my portfolio")
-longbridge portfolio short-margin   # short-selling margin deposit details per position
+longbridge portfolio                # P/L, asset distribution, holdings, cash
 longbridge kline history SYMBOL.US --start YYYY-MM-DD --end YYYY-MM-DD --period day
 longbridge intraday SYMBOL.US
 
-# News & content (prefer these over WebSearch)
+# News & content (prefer these over web_search)
 longbridge news SYMBOL.US           # latest news articles
-longbridge news detail <id>         # full article content
-longbridge news search "keyword"    # keyword search across news articles
-longbridge filing SYMBOL.US         # regulatory filings list (8-K, 10-Q, 10-K, etc.)
+longbridge filing SYMBOL.US         # regulatory filings (8-K, 10-Q, 10-K, etc.)
 longbridge topic SYMBOL.US          # community discussion
-longbridge topic search "keyword"   # keyword search across community topics
-longbridge market-temp              # market sentiment index (0–100)
+longbridge market-temp              # market sentiment index (0-100)
 
 # Fundamentals & analysis
 longbridge financial-statement SYMBOL.US --kind ALL   # hierarchical IS/BS/CF with YoY
 longbridge financial-report SYMBOL.US --latest        # key KPI summary (revenue/EPS/ROE)
 longbridge analyst-estimates SYMBOL.US                # EPS consensus (high/low/mean/median)
-longbridge valuation-rank SYMBOL.US                   # daily PE/PB/PS industry percentile rank
-
-# IPO
-longbridge ipo subscriptions        # HK IPOs in subscription stage
-longbridge ipo calendar             # all upcoming and recent IPOs
-longbridge ipo us-subscriptions     # US IPOs in subscription stage
+longbridge valuation-rank SYMBOL.US                   # daily PE/PB/PS industry percentile
 
 # Account
-longbridge assets                   # full asset overview: cash, buying power, margin, risk level
-longbridge statement --help         # check subcommands for statement export options
-longbridge bank-cards               # bank cards linked to the account
-longbridge withdrawals              # withdrawal history
-longbridge deposits                 # deposit history
-
-# Institutional investors (SEC 13F)
-longbridge investors                # top active fund managers by AUM
-longbridge investors <CIK>          # holdings for a specific investor by CIK
+longbridge assets                   # cash, buying power, margin, risk level
 longbridge insider-trades SYMBOL.US # SEC Form 4 insider transaction history
 ```
 
-For commands with complex flags, always run `longbridge <command> --help` for current options.
+## Procedure
 
-Only fall back to WebSearch when Longbridge news is insufficient (e.g., breaking news not yet indexed, macro events unrelated to a specific symbol).
+**Investment analysis workflow** — when the user asks about stock performance, portfolio
+advice, or market analysis:
 
----
+1. **Get live data** via CLI — quotes, positions, K-line history, intraday
+2. **Get news/catalysts** via CLI — prefer Longbridge first; fall back to `web_search` only if
+   Longbridge's results are insufficient (e.g. breaking news not yet indexed, macro events
+   unrelated to a specific symbol)
+3. **Combine** — price action + volume + catalyst → analysis + suggestion
 
-## Choose the Right Tool
+**Choose the right tool:**
 
 ```
-User wants to...                         → Use
-─────────────────────────────────────────────────────────────────
+User wants to...                         -> Use
+--------------------------------------------------------------------
 Quick quote / one-off data lookup        CLI
 Interactive terminal workflows           CLI
-Script market data, save to file         CLI + jq  (or Python SDK)
+Script market data, save to file         CLI + jq (or Python SDK)
 Loops, conditions, transformations       Python SDK (sync)
 Async pipelines, concurrent fetches      Python SDK (async)
 Production service, high throughput      Rust SDK
 Real-time WebSocket subscription loop    SDK (Python or Rust)
 Programmatic order strategy              SDK
 Talk to AI about stocks (no code)        MCP (hosted or self-hosted)
-Use Cursor/Claude for trading analysis   MCP
 Add Longbridge API docs to IDE/RAG       LLMs.txt / Markdown API
 ```
 
-## Symbol Format
+**Symbol format** — `<CODE>.<MARKET>`, applies to all tools:
 
-`<CODE>.<MARKET>` — applies to all tools.
-
-| Market         | Suffix | Examples                        |
+| Market         | Suffix | Examples                       |
 | -------------- | ------ | ------------------------------- |
 | Hong Kong      | `HK`   | `700.HK`, `9988.HK`, `2318.HK`  |
 | United States  | `US`   | `TSLA.US`, `AAPL.US`, `NVDA.US` |
@@ -113,62 +122,98 @@ Add Longbridge API docs to IDE/RAG       LLMs.txt / Markdown API
 | Singapore      | `SG`   | `D05.SG`, `U11.SG`              |
 | Crypto         | `HAS`  | `BTCUSD.HAS`, `ETHUSD.HAS`      |
 
+## Pitfalls
+
+- **Order placement is state-changing — always confirm first.** Before calling
+  `submit_order`/`replace_order`/`cancel_order` (SDK) or an order-placing MCP tool, read back
+  symbol, side, quantity, and price and get an explicit "yes" from the user. See the warnings in
+  [references/python-sdk/trade-context.md](references/python-sdk/trade-context.md) and
+  [references/rust-sdk/trade-context.md](references/rust-sdk/trade-context.md).
+- **Don't over-rely on `web_search` for symbol news.** Longbridge's `news`/`filing`/`topic`
+  commands are the primary source; only fall back when they're genuinely insufficient.
+- **CLI flags change across versions.** Don't hardcode a flag from memory — check
+  `longbridge <command> --help` first.
+- **Python SDK does have `ContentContext`.** Some third-party docs claim otherwise; it exists
+  with `news()`/`topics()` methods — see
+  [references/python-sdk/content-context.md](references/python-sdk/content-context.md). Filings
+  are on `QuoteContext.filings()` instead, not on `ContentContext`.
+
+## Verification
+
+```bash
+longbridge quote AAPL.US
+```
+
+Should print a quote for AAPL with a non-empty price field. If it instead errors with an auth
+message, walk the user through [references/setup.md](references/setup.md).
+
 ## Reference Files
 
 ### CLI (Terminal)
 
-- **Overview** — install, auth, output formats, patterns: [references/cli/overview.md](references/cli/overview.md)
-
-**Always use `longbridge --help` to list available commands, and `longbridge <command> --help` for specific options and flags.** Do not rely on hardcoded documentation — the CLI's built-in help is always up-to-date.
+- **Overview** — install, auth, output formats, patterns:
+  [references/cli/overview.md](references/cli/overview.md)
 
 ### Python SDK
 
-- **Overview** — install, Config, auth, HttpClient: [references/python-sdk/overview.md](references/python-sdk/overview.md)
-- **QuoteContext** — all quote methods + subscriptions: [references/python-sdk/quote-context.md](references/python-sdk/quote-context.md)
-- **TradeContext** — orders, account, executions: [references/python-sdk/trade-context.md](references/python-sdk/trade-context.md)
-- **Types & Enums** — Period, OrderType, SubType, push types: [references/python-sdk/types.md](references/python-sdk/types.md)
+- **Overview** — install, Config, auth, HttpClient:
+  [references/python-sdk/overview.md](references/python-sdk/overview.md)
+- **QuoteContext** — all quote methods + subscriptions:
+  [references/python-sdk/quote-context.md](references/python-sdk/quote-context.md)
+- **ContentContext** — news + topics:
+  [references/python-sdk/content-context.md](references/python-sdk/content-context.md)
+- **TradeContext** — orders, account, executions:
+  [references/python-sdk/trade-context.md](references/python-sdk/trade-context.md)
+- **Types & Enums** — Period, OrderType, SubType, push types:
+  [references/python-sdk/types.md](references/python-sdk/types.md)
 
 ### Rust SDK
 
-- **Overview** — Cargo.toml, Config, auth, error handling: [references/rust-sdk/overview.md](references/rust-sdk/overview.md)
-- **QuoteContext** — all methods, SubFlags, PushEvent: [references/rust-sdk/quote-context.md](references/rust-sdk/quote-context.md)
-- **TradeContext** — orders, SubmitOrderOptions builder, account: [references/rust-sdk/trade-context.md](references/rust-sdk/trade-context.md)
-- **Content** — news, filings, topics (ContentContext + Python fallback): [references/rust-sdk/content.md](references/rust-sdk/content.md)
-- **Types & Enums** — all Rust enums and structs: [references/rust-sdk/types.md](references/rust-sdk/types.md)
+- **Overview** — Cargo.toml, Config, auth, error handling:
+  [references/rust-sdk/overview.md](references/rust-sdk/overview.md)
+- **QuoteContext** — all methods, SubFlags, PushEvent:
+  [references/rust-sdk/quote-context.md](references/rust-sdk/quote-context.md)
+- **TradeContext** — orders, SubmitOrderOptions builder, account:
+  [references/rust-sdk/trade-context.md](references/rust-sdk/trade-context.md)
+- **Content** — news, filings, topics (with Python-SDK cross-reference):
+  [references/rust-sdk/content.md](references/rust-sdk/content.md)
+- **Types & Enums** — all Rust enums and structs:
+  [references/rust-sdk/types.md](references/rust-sdk/types.md)
 
 ### AI Integration
 
-- **MCP** — hosted service, self-hosted server, setup & auth: [references/mcp.md](references/mcp.md)
-- **LLMs & Markdown** — llms.txt, `open.longbridge.com` doc Markdown, `longbridge.com` live news/quote pages (`.md` suffix + Accept header), Cursor/IDE integration: [references/llm.md](references/llm.md)
+- **MCP** — hosted service, self-hosted server, setup & auth:
+  [references/mcp.md](references/mcp.md)
+- **LLMs & Markdown** — llms.txt, `open.longbridge.com` doc Markdown, Cursor/IDE integration:
+  [references/llm.md](references/llm.md)
 
 Load specific reference files on demand — do not load all at once.
 
----
+## Related Skills
 
-## Related skills
+The skills below are siblings in the `longbridge/skills` family. If they're installed, defer to
+them for the listed user intents — they're more specialised and produce better-formatted
+output. If they're **not** installed, this skill's own CLI workflow above handles the same
+queries with less specialised formatting.
 
-The skills below are siblings in the `longbridge/skills` family. If they're installed, defer to them for the listed user intents — they're more specialised and produce better-formatted output. If they're **not** installed, this skill's own CLI workflow above can handle the same queries with less specialised formatting; the foundation skill remains usable standalone.
+| If the user wants ...                                                          | Use                                                       |
+| -------------------------------------------------------------------------------- | ---------------------------------------------------------- |
+| Live quote / static reference / valuation indices for a single name            | [`longbridge-quote`](../longbridge-quote)                 |
+| Candlestick / intraday chart                                                    | [`longbridge-kline`](../longbridge-kline)                 |
+| Orderbook depth / brokers / tick trades                                        | [`longbridge-depth`](../longbridge-depth)                 |
+| Capital flow / large-order distribution                                        | [`longbridge-capital-flow`](../longbridge-capital-flow)   |
+| Market-level state — open/close, sentiment temperature, calendar               | [`longbridge-market-temp`](../longbridge-market-temp)     |
+| Options / warrants                                                             | [`longbridge-derivatives`](../longbridge-derivatives)     |
+| Stock + fund holdings, multi-currency assets, margin ratio, max-buy quantity   | [`longbridge-positions`](../longbridge-positions)         |
+| Today's / historical orders, executions, cash flow                            | [`longbridge-orders`](../longbridge-orders)               |
+| Read-only watchlist groups                                                      | [`longbridge-watchlist`](../longbridge-watchlist)         |
+| Watchlist mutations (create / rename / add / remove)                          | [`longbridge-watchlist-admin`](../longbridge-watchlist-admin) |
+| "Is X expensive?" — historical PE/PB percentile, industry context             | [`longbridge-valuation`](../longbridge-valuation)         |
+| 5-dimension fundamentals (KPIs, dividends, consensus, ratings)                 | [`longbridge-fundamental`](../longbridge-fundamental)     |
+| Account-level P&L and contribution analysis                                    | [`longbridge-portfolio`](../longbridge-portfolio)         |
+| Classified news + filings + community sentiment for a single name             | [`longbridge-news`](../longbridge-news)                   |
+| Institutional-grade post-earnings report                                       | [`longbridge-earnings`](../longbridge-earnings)           |
 
-| If the user wants … | Use |
-|---|---|
-| Live quote / static reference / valuation indices for a single name | [`longbridge-quote`](../longbridge-quote) |
-| Candlestick / intraday chart | [`longbridge-kline`](../longbridge-kline) |
-| Orderbook depth / brokers / tick trades | [`longbridge-depth`](../longbridge-depth) |
-| Capital flow / large-order distribution | [`longbridge-capital-flow`](../longbridge-capital-flow) |
-| Market-level state — open / close, sentiment temperature, calendar | [`longbridge-market-temp`](../longbridge-market-temp) |
-| Options / warrants | [`longbridge-derivatives`](../longbridge-derivatives) |
-| US overnight-eligible securities catalog / HK broker dictionary | [`longbridge-security-list`](../longbridge-security-list) |
-| Stock + fund holdings, multi-currency assets, margin ratio, max-buy quantity | [`longbridge-positions`](../longbridge-positions) |
-| Today's / historical orders, executions, cash flow | [`longbridge-orders`](../longbridge-orders) |
-| Read-only watchlist groups | [`longbridge-watchlist`](../longbridge-watchlist) |
-| Watchlist mutations (create / rename / add / remove) | [`longbridge-watchlist-admin`](../longbridge-watchlist-admin) |
-| Active real-time WebSocket subscription diagnostics | [`longbridge-subscriptions`](../longbridge-subscriptions) |
-| "Is X expensive?" — historical PE / PB percentile, industry context | [`longbridge-valuation`](../longbridge-valuation) |
-| 5-dimension fundamentals (KPIs, dividends, consensus, ratings) | [`longbridge-fundamental`](../longbridge-fundamental) |
-| 2–5 symbol comparison matrix | [`longbridge-peer-comparison`](../longbridge-peer-comparison) |
-| Account-level P&L and contribution analysis | [`longbridge-portfolio`](../longbridge-portfolio) |
-| Classified news + filings + community sentiment for a single name | [`longbridge-news`](../longbridge-news) |
-| Daily incremental briefing across the watchlist | [`longbridge-catalyst-radar`](../longbridge-catalyst-radar) |
-| Institutional-grade post-earnings DOCX report (8–12 pages) | [`longbridge-earnings`](../longbridge-earnings) |
-
-This skill (`longbridge`) stays in scope when the user asks about: SDK syntax (Python / Rust), MCP server setup, LLMs.txt / IDE / RAG integration, raw CLI subcommand discovery, or anything cross-cutting that doesn't map cleanly to one specialised skill.
+This skill (`longbridge`) stays in scope for SDK syntax questions, MCP setup, LLMs.txt/IDE/RAG
+integration, raw CLI subcommand discovery, or anything cross-cutting that doesn't map to one
+specialised skill.

--- a/optional-skills/finance/longbridge/references/cli/overview.md
+++ b/optional-skills/finance/longbridge/references/cli/overview.md
@@ -1,0 +1,128 @@
+# CLI Overview
+
+**GitHub:** https://github.com/longbridge/longbridge-terminal
+
+AI-native CLI covering every Longbridge OpenAPI endpoint. Designed for scripting, AI-agent tool-calling, and daily trading workflows from the terminal.
+
+## Discovering Commands
+
+Always use the CLI's built-in help — it reflects the currently installed version:
+
+```bash
+longbridge --help                  # List all available commands
+longbridge <command> --help        # Options and flags for a specific command
+```
+
+Do not rely on hardcoded documentation for command syntax or flags — use `--help` instead.
+
+## Installation
+
+```bash
+# macOS (Homebrew — recommended)
+brew install --cask longbridge/tap/longbridge-terminal
+
+# macOS / Linux (install script)
+curl -sSL https://open.longbridge.com/longbridge/longbridge-terminal/install | sh
+# Installs `longbridge` binary to /usr/local/bin
+```
+
+Windows (Scoop or PowerShell):
+
+```powershell
+# Scoop
+scoop install https://open.longbridge.com/longbridge/longbridge-terminal/longbridge.json
+
+# Or PowerShell install script
+iwr https://open.longbridge.com/longbridge/longbridge-terminal/install.ps1 | iex
+```
+
+## Update
+
+```bash
+# Built-in updater
+longbridge update
+
+# Or re-run the install script (any platform)
+curl -sSL https://open.longbridge.com/longbridge/longbridge-terminal/install | sh
+```
+
+## Authentication
+
+Uses OAuth 2.0 — no manual token or key management needed:
+
+```bash
+longbridge auth login    # Opens browser OAuth flow; token saved to
+                         # ~/.longbridge/terminal/.openapi-session
+longbridge auth logout   # Clear saved session token
+longbridge check    # Verify connectivity and token (no auth required)
+```
+
+**China Mainland:** The CLI auto-detects CN by probing `geotest.lbkrs.com` on startup (non-blocking). Result cached at `~/.longbridge/openapi/region-cache`. CN users automatically use `.cn` endpoints.
+
+## Environment Variables
+
+| Variable         | Value     | Description                                                                                                                 |
+| ---------------- | --------- | --------------------------------------------------------------------------------------------------------------------------- |
+| `LONGBRIDGE_ENV` | `staging` | Switch all endpoints to the staging environment (`openapi.longbridge.xyz`). Useful for testing against non-production data. |
+
+```bash
+# Run any command against the staging environment
+LONGBRIDGE_ENV=staging longbridge auth login
+LONGBRIDGE_ENV=staging longbridge statement list
+
+# Or export for the entire shell session
+export LONGBRIDGE_ENV=staging
+```
+
+When set, OAuth, HTTP API, and WebSocket endpoints are all redirected to staging. Unset the variable (or omit it) to use production.
+
+## Output Formats
+
+```bash
+--format table   # Human-readable table (default)
+--format json    # Machine-readable JSON — use for piping to jq, AI agents, scripts
+```
+
+All commands support `--format json`. Example with `jq`:
+
+```bash
+longbridge positions --format json | jq '.[] | {symbol, quantity, cost_price}'
+longbridge order --format json | jq '.[] | select(.status == "New")'
+```
+
+## AI Agent Integration
+
+### Count / limit alias
+
+All commands with a `--count` flag also accept `--limit` as an alias. Both are equivalent — use whichever feels natural in generated commands.
+
+### Parallel execution pattern
+
+Use `&` and `wait` to run multiple queries concurrently (faster results):
+
+```bash
+longbridge quote TSLA.US & longbridge quote AAPL.US & wait
+longbridge kline TSLA.US --period day --count 30 & longbridge kline NVDA.US --period day --count 30 & wait
+```
+
+### Earnings analysis pattern
+
+```bash
+# Step 1: discover filing IDs
+longbridge filing list TSLA.US
+# Step 2: pull full Markdown content of a specific filing
+longbridge filing detail TSLA.US 610186794100660481 --file-index 0
+```
+
+## Extended Hours (Pre/Post Market)
+
+`quote`, `intraday`, `kline`, `kline history` all support extended-hours data. Use `longbridge <command> --help` for exact flags — key points:
+
+- **`quote`**: always returns `pre_market_quote` / `post_market_quote` / `overnight_quote` when available (US only). Table format appends an "Extended Hours" section; JSON includes them as nested objects.
+- **`intraday` / `kline` / `kline history`**: default to intraday session only; pass `--session all` to include pre/post-market data. `kline`/`kline history` add a **Session** column when `--session all` is used.
+
+## Rate Limits
+
+- Max **10 API calls/second**
+- Token is auto-refreshed; no manual renewal needed
+- WebSocket subscriptions are not available in the CLI (use SDK for real-time push)

--- a/optional-skills/finance/longbridge/references/llm.md
+++ b/optional-skills/finance/longbridge/references/llm.md
@@ -1,0 +1,202 @@
+# LLM & AI Integration
+
+Longbridge provides several components for integrating with LLMs and AI tools.
+
+## llms.txt
+
+The OpenAPI documentation follows the [LLMs.txt standard](https://llmstxt.org/):
+
+- **URL:** `https://open.longbridge.com/llms.txt`
+- **Size:** ~2,100 tokens
+- Provides an index of all documentation with links to individual Markdown files
+
+### Add to Cursor
+
+1. Open Cursor → Command Palette (`Cmd+Shift+P`)
+2. Search **"Add New Custom Docs"**
+3. Enter: `https://open.longbridge.com/llms.txt`
+4. In AI chat, use **@Add Context → docs** to include this as context
+
+---
+
+## Markdown API — open.longbridge.com (Developer Docs)
+
+Every documentation page is available in Markdown format. Append `.md` to any doc URL:
+
+```
+https://open.longbridge.com/docs/getting-started.md
+https://open.longbridge.com/docs/quote/pull/static.md
+https://open.longbridge.com/docs/trade/order/submit.md
+```
+
+Useful for:
+- Feeding specific API docs to an LLM as context
+- RAG indexing of the full documentation
+- Tool-based content ingestion
+
+---
+
+## Markdown API — longbridge.com (Product Pages)
+
+Pages on `https://longbridge.com` support Markdown retrieval — useful for AI reading live market data, news, and stock profiles.
+
+### How to access
+
+**Method 1 — URL suffix (recommended):**
+
+Add `.md` to any page URL. Locale prefix is optional (`/en/`, `/zh-CN/`, `/zh-HK/`):
+
+```bash
+curl https://longbridge.com/en/news.md
+curl https://longbridge.com/zh-CN/news.md
+curl https://longbridge.com/en/quote/TSLA.US.md
+curl https://longbridge.com/en/quote/700.HK.md
+```
+
+**Method 2 — Accept header:**
+
+```bash
+curl -H "Accept: text/markdown" https://longbridge.com/en/news
+curl -H "Accept: text/markdown" https://longbridge.com/en/quote/TSLA.US
+```
+
+---
+
+### Response format
+
+Every `.md` response includes a YAML frontmatter block followed by Markdown content:
+
+```yaml
+---
+title: "Tesla, Inc. (TSLA.US)"
+type: "Symbol"           # or "News"
+locale: "en"
+url: "https://longbridge.com/en/quote/TSLA.US.md"
+symbol: "TSLA.US"        # only on Symbol pages
+datetime: "2026-03-23T09:07:14.203Z"
+locales:
+  - [en](https://longbridge.com/en/quote/TSLA.US.md)
+  - [zh-CN](https://longbridge.com/zh-CN/quote/TSLA.US.md)
+  - [zh-HK](https://longbridge.com/zh-HK/quote/TSLA.US.md)
+---
+```
+
+---
+
+### Available page types
+
+#### News index
+
+```
+https://longbridge.com/en/news.md
+```
+
+Returns a chronological list of today's top financial news. Each item includes:
+- Headline (links to full article `.md`)
+- `datetime` (ISO 8601)
+- Summary paragraph
+- Related stock symbols as links
+
+Example response excerpt:
+```markdown
+# Longbridge News
+
+- [Alibaba will release important chip products...](https://longbridge.com/en/news/280093541.md)
+  - Datetime: 2026-03-23T03:41:04.000Z
+  - Summary: According to media reports, Alibaba's Damo Academy...
+```
+
+#### Individual news article
+
+```
+https://longbridge.com/en/news/{id}.md
+```
+
+Returns full article body in Markdown. Frontmatter includes `title`, `description`, `datetime`, and locale links.
+
+Example:
+```
+https://longbridge.com/en/news/280093541.md
+```
+
+#### Stock quote page
+
+```
+https://longbridge.com/en/quote/{SYMBOL}.md
+```
+
+Returns a structured stock profile with:
+- Company overview and business description
+- **Longbridge Financial Score™** (letter grade + multi-factor breakdown)
+- Key metrics table: revenue YoY, net profit YoY, market cap, ROE, gross margin
+- Valuation analysis: PE, P/B, P/S vs. industry benchmarks
+- Analyst consensus: buy/hold/sell counts, price target range
+- Peer comparison table
+
+Example response excerpt:
+```markdown
+# Tesla, Inc. (TSLA.US)
+
+## Company Overview
+Tesla, Inc. designs, develops, manufactures, leases, and sells electric vehicles...
+
+| Item | Detail |
+|------|--------|
+| Industry | Automobile Manufacturers |
+| Exchange | US Market |
+| Website | [www.tesla.com](https://www.tesla.com) |
+
+## Longbridge Financial Score™: C
+**Overall: C (0.45)**
+| Metric | Value |
+|--------|-------|
+| Industry Ranking | 10 / 53 |
+```
+
+---
+
+### Locale support
+
+All pages support 3 locales:
+
+| Locale | URL prefix |
+|--------|-----------|
+| English | `/en/` |
+| Simplified Chinese | `/zh-CN/` |
+| Traditional Chinese | `/zh-HK/` |
+
+Each response includes `locales` links in frontmatter pointing to the same page in other languages.
+
+---
+
+### Use cases for AI
+
+| Goal | URL |
+|------|-----|
+| Today's financial news | `longbridge.com/en/news.md` |
+| Full news article text | `longbridge.com/en/news/{id}.md` |
+| Stock fundamentals + analyst view | `longbridge.com/en/quote/TSLA.US.md` |
+| HK stock profile | `longbridge.com/en/quote/700.HK.md` |
+| Chinese-language news | `longbridge.com/zh-CN/news.md` |
+
+**For live price data** (bid/ask, volume, candlesticks), use the MCP tools or SDK — the `.md` pages contain fundamentals and analysis, not real-time quotes.
+
+---
+
+## MCP (Model Context Protocol)
+
+For AI tools that can call functions, use the MCP server instead of text-based docs.
+See [mcp.md](./mcp.md) for setup and full tool list.
+
+---
+
+## Summary: Which Integration to Use
+
+| Use Case | Method |
+|----------|--------|
+| AI coding assistant understanding the API | Add `llms.txt` to Cursor/Claude/etc. |
+| Fetch a specific doc page in AI context | Append `.md` to `open.longbridge.com` doc URL |
+| Read today's news in AI context | `longbridge.com/en/news.md` |
+| Read stock fundamentals + analyst data | `longbridge.com/en/quote/{SYMBOL}.md` |
+| AI tool that needs live price/order data | Use MCP server |
+| RAG system indexing all API docs | Crawl from `llms.txt` links |

--- a/optional-skills/finance/longbridge/references/mcp.md
+++ b/optional-skills/finance/longbridge/references/mcp.md
@@ -1,0 +1,72 @@
+# MCP Server
+
+Longbridge provides MCP (Model Context Protocol) support in two modes: a hosted cloud service and a self-hosted binary.
+
+## Hosted MCP Service
+
+**Endpoint:** `https://openapi.longbridge.com/mcp`
+
+No API keys needed — uses OAuth 2.1. The AI client handles the browser authorization flow automatically.
+
+### Client Configuration
+
+Add to MCP config in any compatible client:
+
+```json
+{
+  "mcpServers": {
+    "longbridge": {
+      "url": "https://openapi.longbridge.com/mcp"
+    }
+  }
+}
+```
+
+**Per-client setup:**
+
+- **Cursor**: Settings → MCP Servers → Add Remote MCP Server
+- **Claude Code**: `claude mcp add longbridge https://openapi.longbridge.com/mcp`
+- **ChatGPT**: Settings → Connectors
+- **Zed**: `context_servers` in `settings.json`
+- **Cherry Studio**: Settings → MCP Servers → Add (requires latest version for OAuth support)
+
+### OAuth Authorization Flow
+
+1. Add the config and call any tool — this triggers the OAuth flow
+2. Client opens a browser tab to Longbridge login & consent page
+3. Sign in with your Longbridge account and approve scopes
+4. Credentials are stored by the client; tokens refresh automatically
+5. To revoke: Longbridge account → Security Settings
+
+### Security Recommendations
+
+- Only approve scopes required for the task (least privilege)
+- For order placement, instruct AI to always ask for confirmation before executing
+- Periodically review and revoke unused authorizations
+
+---
+
+## Available MCP Tools
+
+When the MCP server is connected, available tools are automatically exposed to the AI — no hardcoded list needed. The AI can directly inspect and call all tools.
+
+If you need to know what tools are available, ask the AI to list the connected MCP tools, or check the official docs: https://open.longbridge.com
+
+---
+
+## Example AI Prompts
+
+```
+# Market data
+"What is the current price and PE ratio of TSLA.US?"
+
+# Trade analysis
+"Show my current HK stock positions and unrealized P&L"
+
+# Order placement (always confirm first)
+"I want to buy 100 shares of 700.HK at limit price 50 HKD.
+ Please confirm the order details before placing it."
+
+# Research
+"Get the latest news and filings for AAPL.US"
+```

--- a/optional-skills/finance/longbridge/references/python-sdk/content-context.md
+++ b/optional-skills/finance/longbridge/references/python-sdk/content-context.md
@@ -1,0 +1,71 @@
+# Python SDK — ContentContext
+
+`ContentContext` (sync) / `AsyncContentContext` (async) — news and discussion topics for securities.
+
+## Creation
+
+```python
+from longbridge.openapi import ContentContext, AsyncContentContext, Config
+
+# Sync
+ctx = ContentContext(config)
+
+# Async
+ctx = AsyncContentContext.create(config)
+```
+
+## Methods
+
+### news
+
+Get news articles for a symbol.
+
+```python
+items = ctx.news("700.HK")   # List[NewsItem]
+# Fields: id, title, description, url, published_at,
+#         likes_count, comments_count, shares_count
+```
+
+### topics
+
+Get discussion topics (community posts) for a symbol.
+
+```python
+items = ctx.topics("700.HK")   # List[TopicItem]
+# Fields: id, title, description, url, published_at,
+#         likes_count, comments_count, shares_count
+```
+
+## Async Example
+
+```python
+import asyncio
+from longbridge.openapi import AsyncContentContext, Config
+
+async def main():
+    config = Config.from_apikey_env()
+    ctx = AsyncContentContext.create(config)
+
+    news = await ctx.news("700.HK")
+    for item in news:
+        print(item.title, item.published_at)
+
+    topics = await ctx.topics("AAPL.US")
+    for item in topics:
+        print(item.title, item.likes_count)
+
+asyncio.run(main())
+```
+
+## Sync Example
+
+```python
+from longbridge.openapi import ContentContext, Config
+
+config = Config.from_apikey_env()
+ctx = ContentContext(config)
+
+news = ctx.news("700.HK")
+for item in news:
+    print(item.title, item.url)
+```

--- a/optional-skills/finance/longbridge/references/python-sdk/overview.md
+++ b/optional-skills/finance/longbridge/references/python-sdk/overview.md
@@ -1,0 +1,151 @@
+# Python SDK Overview
+
+**Docs:** https://longbridge.github.io/openapi/python/index.html
+
+## Install
+
+```bash
+pip install longbridge
+```
+
+> **Note:** The package was previously named `longport`. If upgrading, run `pip uninstall longport` first.
+
+## Import
+
+```python
+from longbridge.openapi import (
+    Config, OAuthBuilder,
+    QuoteContext, AsyncQuoteContext,
+    TradeContext, AsyncTradeContext,
+    ContentContext, AsyncContentContext,
+    HttpClient,
+)
+```
+
+## Authentication
+
+### OAuth 2.0 (Recommended)
+
+Token cached at `~/.longbridge/openapi/tokens/<client_id>`. Re-runs browser auth only when token is expired.
+
+**Register once:**
+
+```bash
+curl -X POST https://openapi.longbridge.com/oauth2/register \
+  -H "Content-Type: application/json" \
+  -d '{"client_name":"My App","redirect_uris":["http://localhost:60355/callback"],"grant_types":["authorization_code","refresh_token"],"response_types":["code"]}'
+# Response: {"client_id": "your-client-id", ...}
+```
+
+**Sync:**
+
+```python
+from longbridge.openapi import OAuthBuilder, Config
+
+oauth = OAuthBuilder("your-client-id").build(
+    lambda url: print(f"Open this URL to authorize: {url}")
+)
+config = Config.from_oauth(oauth)
+```
+
+**Async:**
+
+```python
+import asyncio
+from longbridge.openapi import OAuthBuilder, Config
+
+async def main():
+    oauth = await OAuthBuilder("your-client-id").build_async(
+        lambda url: print(f"Open this URL to authorize: {url}")
+    )
+    config = Config.from_oauth(oauth)
+
+asyncio.run(main())
+```
+
+## Config Options
+
+```python
+Config.from_oauth(
+    oauth,
+    http_url=None,           # override LONGBRIDGE_HTTP_URL
+    quote_ws_url=None,       # override LONGBRIDGE_QUOTE_WS_URL
+    trade_ws_url=None,       # override LONGBRIDGE_TRADE_WS_URL
+    language=None,           # Language.ZH_CN / Language.ZH_HK / Language.EN
+    enable_overnight=False,  # enable overnight quote
+    push_candlestick_mode=PushCandlestickMode.Realtime,
+    enable_print_quote_packages=True,
+    log_path=None,           # path to log directory
+)
+```
+
+## Environment Variables
+
+| Variable                           | Description               | Default                                 |
+| ---------------------------------- | ------------------------- | --------------------------------------- |
+| `LONGBRIDGE_LANGUAGE`              | `zh-CN`, `zh-HK`, `en`    | `en`                                    |
+| `LONGBRIDGE_HTTP_URL`              | HTTP endpoint             | `https://openapi.longbridge.com`        |
+| `LONGBRIDGE_QUOTE_WS_URL`          | Quote WebSocket           | `wss://openapi-quote.longbridge.com/v2` |
+| `LONGBRIDGE_TRADE_WS_URL`          | Trade WebSocket           | `wss://openapi-trade.longbridge.com/v2` |
+| `LONGBRIDGE_ENABLE_OVERNIGHT`      | Enable overnight quotes   | `false`                                 |
+| `LONGBRIDGE_PUSH_CANDLESTICK_MODE` | `realtime` or `confirmed` | `realtime`                              |
+| `LONGBRIDGE_PRINT_QUOTE_PACKAGES`  | Print packages on connect | `true`                                  |
+| `LONGBRIDGE_LOG_PATH`              | Log file directory        | (no logs)                               |
+
+**China Mainland:** SDK auto-selects `.cn` endpoints. To force: `LONGBRIDGE_REGION=cn` or `LONGBRIDGE_REGION=hk`.
+
+## HttpClient (Raw HTTP)
+
+For endpoints not wrapped by the typed SDK contexts:
+
+```python
+from longbridge.openapi import HttpClient, OAuthBuilder
+
+oauth = OAuthBuilder("your-client-id").build(lambda url: print(url))
+http_cli = HttpClient.from_oauth(oauth)
+
+# Sync GET
+resp = http_cli.request("get", "/v1/trade/execution/today")
+print(resp)  # parsed JSON dict/list
+
+# Sync POST
+resp = http_cli.request("post", "/v1/trade/order",
+    body={"symbol": "700.HK", "order_type": "LO", "side": "Buy",
+          "submitted_quantity": "100", "time_in_force": "Day",
+          "submitted_price": "50.00"})
+
+# Async GET
+resp = await http_cli.request_async("get", "/v1/trade/execution/today")
+
+# With custom headers
+resp = http_cli.request("get", "/v1/some/endpoint",
+    headers={"X-Custom-Header": "value"})
+```
+
+
+## Sync vs Async
+
+| Class                 | Nature          | When to use                                |
+| --------------------- | --------------- | ------------------------------------------ |
+| `QuoteContext`        | Sync            | Scripts, data pipelines, simple tools      |
+| `AsyncQuoteContext`   | Async (asyncio) | Concurrent fetches, FastAPI, Jupyter async |
+| `TradeContext`        | Sync            | Scripts, command-line tools                |
+| `AsyncTradeContext`   | Async (asyncio) | Async servers, concurrent trade ops        |
+| `ContentContext`      | Sync            | Fetch news and discussion topics           |
+| `AsyncContentContext` | Async (asyncio) | Async news/topics fetching                 |
+
+Both variants share identical method signatures — async versions return awaitables instead of values.
+
+## Error Handling
+
+```python
+from longbridge.openapi import OpenApiException
+
+try:
+    quotes = ctx.quote(["INVALID.XX"])
+except OpenApiException as e:
+    print(f"kind={e.kind}, code={e.code}, trace_id={e.trace_id}")
+    print(f"message={e.message}")
+```
+
+`e.kind`: `ErrorKind.Http`, `ErrorKind.OpenApi`, or `ErrorKind.Other`

--- a/optional-skills/finance/longbridge/references/python-sdk/quote-context.md
+++ b/optional-skills/finance/longbridge/references/python-sdk/quote-context.md
@@ -1,0 +1,235 @@
+# Python SDK — QuoteContext
+
+`QuoteContext` (sync) / `AsyncQuoteContext` (async) — market data, subscriptions, watchlist.
+
+## Creation
+
+```python
+# Sync
+ctx = QuoteContext(config)
+
+# Async — use classmethod, NOT constructor
+ctx = AsyncQuoteContext.create(config)
+# or with explicit loop for async callbacks:
+ctx = AsyncQuoteContext.create(config, loop_=asyncio.get_running_loop())
+```
+
+## Push Subscriptions
+
+### Set callbacks (both sync and async contexts)
+
+```python
+ctx.set_on_quote(lambda symbol, event: print(symbol, event))
+ctx.set_on_depth(lambda symbol, event: print(symbol, event))
+ctx.set_on_brokers(lambda symbol, event: print(symbol, event))
+ctx.set_on_trades(lambda symbol, event: print(symbol, event))
+ctx.set_on_candlestick(lambda symbol, event: print(symbol, event))
+```
+
+`AsyncQuoteContext` callbacks may be `async def` — they are scheduled on the running event loop.
+
+Push types: `PushQuote`, `PushDepth`, `PushBrokers`, `PushTrades`, `PushCandlestick`
+
+### subscribe / unsubscribe
+
+```python
+ctx.subscribe(["700.HK", "AAPL.US"], [SubType.Quote, SubType.Depth])
+ctx.unsubscribe(["AAPL.US"], [SubType.Quote])
+resp = ctx.subscriptions()  # List[Subscription]
+```
+
+### subscribe_candlesticks
+
+```python
+# Returns initial snapshot; push arrives via set_on_candlestick
+candles = ctx.subscribe_candlesticks("700.HK", Period.Min_1, TradeSessions.Intraday)
+ctx.unsubscribe_candlesticks("700.HK", Period.Min_1)
+```
+
+## Market Data (pull)
+
+### static_info
+
+```python
+resp = ctx.static_info(["700.HK", "AAPL.US"])  # List[SecurityStaticInfo]
+# Fields: symbol, name_en, name_zh, exchange, currency, lot_size,
+#         total_shares, circulating_shares, eps, eps_ttm, bps, dividend_yield
+```
+
+### quote
+
+```python
+resp = ctx.quote(["700.HK", "AAPL.US", "TSLA.US"])  # List[SecurityQuote]
+# Fields: symbol, last_done, prev_close_price, open, high, low, volume, turnover,
+#         trade_session, trade_status, pre_market_quote, post_market_quote
+```
+
+### option_quote / warrant_quote
+
+```python
+resp = ctx.option_quote(["AAPL230317P160000.US"])   # List[OptionQuote]
+resp = ctx.warrant_quote(["21125.HK"])              # List[WarrantQuote]
+```
+
+### depth
+
+```python
+resp = ctx.depth("700.HK")     # SecurityDepth
+# resp.asks: List[Depth], resp.bids: List[Depth]
+# Depth fields: position, price, volume, order_num
+```
+
+### brokers
+
+```python
+resp = ctx.brokers("700.HK")   # SecurityBrokers
+# resp.ask_brokers: List[Brokers], resp.bid_brokers: List[Brokers]
+```
+
+### participants
+
+```python
+resp = ctx.participants()      # List[ParticipantInfo]  (HK only)
+```
+
+### trades
+
+```python
+resp = ctx.trades("700.HK", 50)   # List[Trade], max count=1000
+```
+
+### intraday
+
+```python
+resp = ctx.intraday("700.HK")                                 # List[IntradayLine]
+resp = ctx.intraday("700.HK", TradeSessions.All)              # include pre/post
+```
+
+### candlesticks (recent N)
+
+```python
+resp = ctx.candlesticks("700.HK", Period.Day, 100, AdjustType.NoAdjust)
+resp = ctx.candlesticks("700.HK", Period.Min_5, 200, AdjustType.ForwardAdjust, TradeSessions.All)
+# Returns: List[Candlestick]
+# Fields: close, open, high, low, volume, turnover, trade_session, timestamp
+```
+
+### history_candlesticks_by_offset
+
+```python
+# forward=True: query forward from `time`; forward=False: backward
+resp = ctx.history_candlesticks_by_offset(
+    "700.HK", Period.Day, AdjustType.NoAdjust,
+    forward=False, count=100, time=datetime(2024, 1, 1)
+)
+```
+
+### history_candlesticks_by_date
+
+```python
+resp = ctx.history_candlesticks_by_date(
+    "700.HK", Period.Day, AdjustType.ForwardAdjust,
+    start=date(2024, 1, 1), end=date(2024, 12, 31)
+)
+```
+
+## Options
+
+```python
+dates = ctx.option_chain_expiry_date_list("AAPL.US")    # List[date]
+strikes = ctx.option_chain_info_by_date("AAPL.US", date(2024, 1, 19))
+# List[StrikePriceInfo]: price, call_symbol, put_symbol, standard
+```
+
+## Warrants
+
+```python
+issuers = ctx.warrant_issuers()  # List[IssuerInfo]
+
+resp = ctx.warrant_list(
+    "700.HK",
+    sort_by=WarrantSortBy.LastDone,
+    sort_order=SortOrderType.Ascending,
+    warrant_type=[WarrantType.Call],     # optional filters
+)  # List[WarrantInfo]
+```
+
+## Trading Calendar
+
+```python
+sessions = ctx.trading_session()   # List[MarketTradingSession]
+days = ctx.trading_days(Market.HK, date(2024, 1, 1), date(2024, 3, 31))
+# MarketTradingDays: trading_days: List[date], half_trading_days: List[date]
+# Constraint: interval < 1 month, only last year supported
+```
+
+## Capital & Indexes
+
+```python
+flow = ctx.capital_flow("700.HK")          # List[CapitalFlowLine]
+dist = ctx.capital_distribution("700.HK")  # CapitalDistributionResponse
+
+indexes = ctx.calc_indexes(
+    ["700.HK", "AAPL.US"],
+    [CalcIndex.LastDone, CalcIndex.PeTtmRatio, CalcIndex.PbRatio, CalcIndex.TotalMarketValue]
+)  # List[SecurityCalcIndex]
+```
+
+## Watchlist
+
+```python
+groups = ctx.watchlist()   # List[WatchlistGroup]
+
+group_id = ctx.create_watchlist_group("My Group", securities=["700.HK", "AAPL.US"])
+
+ctx.update_watchlist_group(
+    group_id,
+    name="Updated Name",
+    securities=["TSLA.US"],
+    mode=SecuritiesUpdateMode.Add    # Add | Remove | Replace
+)
+
+ctx.delete_watchlist_group(group_id, purge=False)
+```
+
+## Security List & Market Temperature
+
+```python
+securities = ctx.security_list(Market.HK)                                   # List[Security]
+securities = ctx.security_list(Market.US, SecurityListCategory.Overnight)
+
+temp = ctx.market_temperature(Market.HK)          # MarketTemperature: temperature (0-100)
+hist = ctx.history_market_temperature(            # HistoryMarketTemperatureResponse
+    Market.HK, date(2024, 1, 1), date(2024, 3, 31)
+)
+```
+
+## Realtime Cache (after subscribe)
+
+These return data from the local push cache without making a network call:
+
+```python
+ctx.subscribe(["700.HK"], [SubType.Quote, SubType.Depth, SubType.Brokers, SubType.Trade])
+from time import sleep; sleep(2)
+
+quotes   = ctx.realtime_quote(["700.HK"])          # List[RealtimeQuote]
+depth    = ctx.realtime_depth("700.HK")            # SecurityDepth
+brokers  = ctx.realtime_brokers("700.HK")          # SecurityBrokers
+trades   = ctx.realtime_trades("700.HK", 100)      # List[Trade]
+candles  = ctx.realtime_candlesticks("AAPL.US", Period.Min_1, 50)  # List[Candlestick]
+```
+
+## Filings
+
+```python
+items = ctx.filings("700.HK")   # List of filing objects
+# Each item: symbol, name, title, lang, type, url, published_at
+```
+
+## Account Info
+
+```python
+member_id = ctx.member_id()                    # int
+level     = ctx.quote_level()                  # str (e.g. "2")
+packages  = ctx.quote_package_details()        # List[QuotePackageDetail]
+```

--- a/optional-skills/finance/longbridge/references/python-sdk/trade-context.md
+++ b/optional-skills/finance/longbridge/references/python-sdk/trade-context.md
@@ -1,0 +1,197 @@
+# Python SDK — TradeContext
+
+`TradeContext` (sync) / `AsyncTradeContext` (async) — order management, positions, account.
+
+## Creation
+
+```python
+# Sync
+ctx = TradeContext(config)
+
+# Async
+ctx = AsyncTradeContext.create(config)
+```
+
+## Order Push
+
+```python
+def on_order_changed(event: PushOrderChanged):
+    print(event.symbol, event.status, event.filled_qty)
+
+ctx.set_on_order_changed(on_order_changed)
+ctx.subscribe([TopicType.Private])    # start receiving push
+ctx.unsubscribe([TopicType.Private])
+```
+
+## Submit Order
+
+```python
+from decimal import Decimal
+from longbridge.openapi import TradeContext, Config, OrderSide, OrderType, TimeInForceType
+
+ctx = TradeContext(config)
+
+resp = ctx.submit_order(
+    symbol="700.HK",
+    order_type=OrderType.LO,
+    side=OrderSide.Buy,
+    submitted_quantity=Decimal(200),
+    time_in_force=TimeInForceType.Day,
+    submitted_price=Decimal("50.00"),  # required for LO/ELO/ALO/ODD
+    remark="my order",                 # optional, max 64 chars
+)
+# resp.order_id: str
+```
+
+**Optional parameters by order type:**
+
+| Parameter | Required for |
+|-----------|-------------|
+| `submitted_price` | LO, ELO, ALO, ODD, LIT |
+| `trigger_price` | LIT, MIT |
+| `limit_offset` | TSLPAMT, TSLPPCT |
+| `trailing_amount` | TSLPAMT |
+| `trailing_percent` | TSLPPCT |
+| `expire_date` | GTD time_in_force |
+| `outside_rth` | US only: `OutsideRTH.RTHOnly / AnyTime / Overnight` |
+
+## Replace / Cancel Order
+
+```python
+ctx.replace_order(
+    order_id="709043056541253632",
+    quantity=Decimal(100),
+    price=Decimal("100.00"),
+)
+
+ctx.cancel_order("709043056541253632")
+```
+
+## Query Orders
+
+```python
+# Today's orders
+orders = ctx.today_orders(
+    symbol="700.HK",                              # optional
+    status=[OrderStatus.Filled, OrderStatus.New], # optional
+    side=OrderSide.Buy,                           # optional
+    market=Market.HK,                             # optional
+    order_id="123456",                            # optional
+)  # List[Order]
+
+# Historical orders (no today)
+orders = ctx.history_orders(
+    symbol="700.HK",
+    status=[OrderStatus.Filled],
+    side=OrderSide.Buy,
+    market=Market.HK,
+    start_at=datetime(2024, 1, 1),
+    end_at=datetime(2024, 12, 31),
+)  # List[Order]
+
+# Order detail (includes charge breakdown)
+detail = ctx.order_detail("701276261045858304")  # OrderDetail
+```
+
+**Order fields:** `order_id`, `symbol`, `order_type`, `side`, `status`, `submitted_quantity`,
+`submitted_price`, `executed_qty`, `executed_price`, `submitted_at`, `updated_at`, `tag`,
+`time_in_force`, `expire_date`, `outside_rth`, `remark`
+
+## Executions
+
+```python
+# Today's fills
+execs = ctx.today_executions(symbol="700.HK", order_id=None)  # List[Execution]
+
+# Historical fills
+execs = ctx.history_executions(
+    symbol="700.HK",
+    start_at=datetime(2024, 1, 1),
+    end_at=datetime(2024, 12, 31),
+)  # List[Execution]
+# Execution fields: order_id, trade_id, symbol, trade_done_at, quantity, price
+```
+
+## Account Balance
+
+```python
+balances = ctx.account_balance()              # List[AccountBalance]
+balances = ctx.account_balance("HKD")        # filter by currency
+
+# AccountBalance fields:
+# currency, total_cash, max_finance_amount, remaining_finance_amount,
+# risk_level, margin_call, net_assets, buy_power, cash_infos: List[CashInfo]
+```
+
+## Cash Flow
+
+```python
+flows = ctx.cash_flow(
+    start_at=datetime(2024, 1, 1),
+    end_at=datetime(2024, 12, 31),
+    business_type=BalanceType.Cash,  # optional: Cash | Stock | Fund
+    symbol="700.HK",                 # optional
+    page=1,                          # optional, default 1
+    size=50,                         # optional, default 50
+)  # List[CashFlow]
+```
+
+## Positions
+
+```python
+stock_pos = ctx.stock_positions()                       # StockPositionsResponse
+stock_pos = ctx.stock_positions(symbols=["700.HK"])     # filter
+
+fund_pos  = ctx.fund_positions()                        # FundPositionsResponse
+fund_pos  = ctx.fund_positions(symbols=["HK123"])
+```
+
+**StockPositionsResponse:** `.channels: List[StockPositionChannel]`
+Each channel: `account_channel`, `positions: List[StockPosition]`
+
+**StockPosition fields:** `symbol`, `symbol_name`, `quantity`, `available_quantity`,
+`currency`, `cost_price`, `market`, `init_quantity`
+
+## Margin & Estimation
+
+```python
+ratio = ctx.margin_ratio("TSLA.US")   # MarginRatio
+# Fields: im_factor (initial), mm_factor (maintenance), fm_factor (forced liq.)
+
+est = ctx.estimate_max_purchase_quantity(
+    symbol="700.HK",
+    order_type=OrderType.LO,
+    side=OrderSide.Buy,
+    price=Decimal("50.00"),
+    currency="HKD",          # optional
+    fractional_shares=False, # optional
+)  # EstimateMaxPurchaseQuantityResponse
+# Fields: cash_max_qty, margin_max_qty
+```
+
+## Async Example (FastAPI / asyncio)
+
+```python
+import asyncio
+from decimal import Decimal
+from longbridge.openapi import OAuthBuilder, Config, AsyncTradeContext, OrderSide, OrderType, TimeInForceType
+
+async def main():
+    oauth = await OAuthBuilder("your-client-id").build_async(
+        lambda url: print("Visit:", url)
+    )
+    config = Config.from_oauth(oauth)
+    ctx = AsyncTradeContext.create(config)
+
+    resp = await ctx.submit_order(
+        symbol="700.HK",
+        order_type=OrderType.LO,
+        side=OrderSide.Buy,
+        submitted_quantity=Decimal(100),
+        time_in_force=TimeInForceType.Day,
+        submitted_price=Decimal("50.00"),
+    )
+    print(resp.order_id)
+
+asyncio.run(main())
+```

--- a/optional-skills/finance/longbridge/references/python-sdk/trade-context.md
+++ b/optional-skills/finance/longbridge/references/python-sdk/trade-context.md
@@ -25,6 +25,12 @@ ctx.unsubscribe([TopicType.Private])
 
 ## Submit Order
 
+> ⚠️ **State-changing — confirm before executing.** `submit_order` places a real order against
+> the user's brokerage account. Read back symbol, side, quantity, and price and get an explicit
+> "yes, place it" from the user immediately before calling this — never chain a submission
+> straight off a data lookup. Same rule as `mcp.md`'s "always ask for confirmation before
+> executing."
+
 ```python
 from decimal import Decimal
 from longbridge.openapi import TradeContext, Config, OrderSide, OrderType, TimeInForceType
@@ -56,6 +62,10 @@ resp = ctx.submit_order(
 | `outside_rth` | US only: `OutsideRTH.RTHOnly / AnyTime / Overnight` |
 
 ## Replace / Cancel Order
+
+> ⚠️ **State-changing — confirm before executing.** Both calls immediately mutate a live order.
+> Confirm the target `order_id` and the new price/quantity (for `replace_order`) with the user
+> right before calling — same confirmation gate as Submit Order above.
 
 ```python
 ctx.replace_order(

--- a/optional-skills/finance/longbridge/references/python-sdk/types.md
+++ b/optional-skills/finance/longbridge/references/python-sdk/types.md
@@ -1,0 +1,197 @@
+# Python SDK — Types & Enums
+
+All types imported from `longbridge.openapi`.
+
+## SubType — Quote subscription flags
+
+```python
+SubType.Quote    # Real-time quote (price, volume)
+SubType.Depth    # Level 2 order book
+SubType.Brokers  # HK broker queue
+SubType.Trade    # Tick-by-tick trades
+```
+
+## Period — Candlestick periods
+
+```python
+Period.Min_1    Period.Min_2    Period.Min_3
+Period.Min_5    Period.Min_10   Period.Min_15
+Period.Min_20   Period.Min_30   Period.Min_45
+Period.Min_60   Period.Min_120  Period.Min_180   Period.Min_240
+Period.Day      Period.Week     Period.Month
+Period.Quarter  Period.Year
+```
+
+## AdjustType
+
+```python
+AdjustType.NoAdjust       # Actual (unadjusted)
+AdjustType.ForwardAdjust  # Forward-adjusted for splits/dividends
+```
+
+## TradeSessions
+
+```python
+TradeSessions.Intraday   # Regular trading hours only (default)
+TradeSessions.All        # All sessions (pre, intraday, post, overnight)
+```
+
+## Market
+
+```python
+Market.HK   # Hong Kong
+Market.US   # United States
+Market.CN   # China (SH/SZ)
+Market.SG   # Singapore
+```
+
+## OrderSide
+
+```python
+OrderSide.Buy
+OrderSide.Sell
+```
+
+## OrderType
+
+```python
+OrderType.LO       # Limit Order (price required)
+OrderType.ELO      # Enhanced Limit Order (HK only)
+OrderType.MO       # Market Order
+OrderType.AO       # At-Auction Order
+OrderType.ALO      # At-Auction Limit Order
+OrderType.ODD      # Odd Lots Order
+OrderType.LIT      # Limit If Touched (price + trigger_price)
+OrderType.MIT      # Market If Touched (trigger_price)
+OrderType.TSLPAMT  # Trailing Limit If Touched (Trailing Amount)
+OrderType.TSLPPCT  # Trailing Limit If Touched (Trailing Percent)
+OrderType.TSMAMT   # Trailing Market If Touched (Trailing Amount)
+OrderType.TSMPCT   # Trailing Market If Touched (Trailing Percent)
+OrderType.SLO      # Special Limit Order (HK only, no replace)
+```
+
+## OrderStatus
+
+```python
+OrderStatus.NotReported          # Pending broker submission
+OrderStatus.New                  # Accepted by exchange
+OrderStatus.WaitToNew            # In transit to exchange
+OrderStatus.PartialFilled        # Partially executed
+OrderStatus.Filled               # Fully executed
+OrderStatus.WaitToReplace        # Replace request in transit
+OrderStatus.PendingReplace       # Replace pending on exchange
+OrderStatus.Replaced             # Successfully replaced
+OrderStatus.WaitToCancel         # Cancel request in transit
+OrderStatus.PendingCancel        # Cancel pending on exchange
+OrderStatus.Rejected             # Rejected
+OrderStatus.Canceled             # Canceled
+OrderStatus.Expired              # Expired
+OrderStatus.PartialWithdrawal    # Partially canceled
+```
+
+## TimeInForceType
+
+```python
+TimeInForceType.Day              # Valid today only
+TimeInForceType.GoodTilCanceled  # GTC
+TimeInForceType.GoodTilDate      # GTD — requires expire_date
+```
+
+## OutsideRTH (US only)
+
+```python
+OutsideRTH.RTHOnly    # Regular trading hours only (default)
+OutsideRTH.AnyTime    # Pre and post market allowed
+OutsideRTH.Overnight  # Overnight session
+```
+
+## TopicType (trade push)
+
+```python
+TopicType.Private   # Order change notifications
+```
+
+## CalcIndex — Financial indexes
+
+```python
+# Price & volume
+CalcIndex.LastDone           CalcIndex.ChangeValue       CalcIndex.ChangeRate
+CalcIndex.Volume             CalcIndex.Turnover          CalcIndex.Amplitude
+CalcIndex.VolumeRatio        CalcIndex.TurnoverRate      CalcIndex.TotalMarketValue
+CalcIndex.CapitalFlow        CalcIndex.YtdChangeRate
+
+# Period returns
+CalcIndex.FiveDayChangeRate  CalcIndex.TenDayChangeRate
+CalcIndex.HalfYearChangeRate CalcIndex.FiveMinutesChangeRate
+
+# Valuation
+CalcIndex.PeTtmRatio         CalcIndex.PbRatio           CalcIndex.DividendRatioTtm
+
+# Options / Warrants
+CalcIndex.ExpiryDate         CalcIndex.StrikePrice       CalcIndex.UpperStrikePrice
+CalcIndex.LowerStrikePrice   CalcIndex.OutstandingQty    CalcIndex.OutstandingRatio
+CalcIndex.Premium            CalcIndex.ItmOtm            CalcIndex.ImpliedVolatility
+CalcIndex.WarrantDelta       CalcIndex.CallPrice         CalcIndex.ToCallPrice
+CalcIndex.EffectiveLeverage  CalcIndex.LeverageRatio     CalcIndex.ConversionRatio
+CalcIndex.BalancePoint       CalcIndex.OpenInterest
+CalcIndex.Delta              CalcIndex.Gamma             CalcIndex.Theta
+CalcIndex.Vega               CalcIndex.Rho
+```
+
+## SecuritiesUpdateMode (watchlist)
+
+```python
+SecuritiesUpdateMode.Add      # Append securities
+SecuritiesUpdateMode.Remove   # Remove securities
+SecuritiesUpdateMode.Replace  # Replace all securities
+```
+
+## SecurityListCategory
+
+```python
+SecurityListCategory.Overnight  # Overnight-eligible securities
+```
+
+## BalanceType (cash flow)
+
+```python
+BalanceType.Cash   # Cash transactions
+BalanceType.Stock  # Stock transactions
+BalanceType.Fund   # Fund transactions
+```
+
+## WarrantSortBy / SortOrderType
+
+```python
+WarrantSortBy.LastDone   WarrantSortBy.ChangeRate  WarrantSortBy.Volume
+WarrantSortBy.Price      WarrantSortBy.Premium     WarrantSortBy.Leverage
+# ... and more
+
+SortOrderType.Ascending
+SortOrderType.Descending
+```
+
+## Push Types
+
+| Class | Carrier | Fields |
+|-------|---------|--------|
+| `PushQuote` | `set_on_quote` | `last_done`, `open`, `high`, `low`, `volume`, `turnover`, `trade_session` |
+| `PushDepth` | `set_on_depth` | `asks: List[Depth]`, `bids: List[Depth]` |
+| `PushBrokers` | `set_on_brokers` | `ask_brokers: List[Brokers]`, `bid_brokers: List[Brokers]` |
+| `PushTrades` | `set_on_trades` | `trades: List[Trade]` |
+| `PushCandlestick` | `set_on_candlestick` | `candlestick: Candlestick`, `period: Period` |
+| `PushOrderChanged` | `set_on_order_changed` | `order_id`, `symbol`, `status`, `side`, `filled_qty`, `price`, `msg` |
+
+## Error Handling
+
+```python
+from longbridge.openapi import OpenApiException, ErrorKind
+
+try:
+    resp = ctx.quote(["INVALID.XX"])
+except OpenApiException as e:
+    print(e.kind)       # ErrorKind.Http | ErrorKind.OpenApi | ErrorKind.Other
+    print(e.code)       # API error code (int)
+    print(e.message)    # Human-readable message
+    print(e.trace_id)   # Request trace ID for support
+```

--- a/optional-skills/finance/longbridge/references/rust-sdk/content.md
+++ b/optional-skills/finance/longbridge/references/rust-sdk/content.md
@@ -97,16 +97,24 @@ async fn main() -> anyhow::Result<()> {
 
 ## Note: Python SDK
 
-The Python SDK does not expose a `ContentContext`. For news/filings/topics in Python, use:
+The Python SDK **does** expose `ContentContext` / `AsyncContentContext` with the same
+`news(symbol)` / `topics(symbol)` methods shown above — see
+[python-sdk/content-context.md](../python-sdk/content-context.md). Filings are on
+`QuoteContext.filings(symbol)` instead (there is no separate content-filings call), documented in
+[python-sdk/quote-context.md](../python-sdk/quote-context.md). Other equivalent options:
 
 1. **CLI** — `longbridge news SYMBOL`, `longbridge filing SYMBOL`, `longbridge topic SYMBOL`
-2. **HttpClient** — raw HTTP calls to `/v1/content/{symbol}/news`, `/v1/content/{symbol}/topics`, `/v1/quote/filings`
-3. **MCP** — `news`, `topics`, `filings` tools
+2. **MCP** — `news`, `topics`, `filings` tools
 
 ```python
-# Python: via HttpClient
-http = HttpClient.from_oauth(oauth)
-news = http.request("get", "/v1/content/TSLA.US/news")
-topics = http.request("get", "/v1/content/TSLA.US/topics")
-filings = http.request("get", "/v1/quote/filings", body={"symbol": "TSLA.US"})
+# Python: via ContentContext + QuoteContext
+from longbridge.openapi import ContentContext, QuoteContext, Config
+
+config = Config.from_apikey_env()
+content = ContentContext(config)
+quote = QuoteContext(config)
+
+news = content.news("TSLA.US")
+topics = content.topics("TSLA.US")
+filings = quote.filings("TSLA.US")
 ```

--- a/optional-skills/finance/longbridge/references/rust-sdk/content.md
+++ b/optional-skills/finance/longbridge/references/rust-sdk/content.md
@@ -1,0 +1,112 @@
+# Rust SDK — Content (News, Filings, Topics)
+
+## ContentContext
+
+Used for news and community discussion topics. Requires a separate context from QuoteContext.
+
+```rust
+use longbridge::{Config, content::ContentContext};
+use std::sync::Arc;
+
+let config = Arc::new(Config::from_apikey_env()?);
+let content_ctx = ContentContext::try_new(config)?;
+```
+
+### news
+
+```rust
+let news = content_ctx.news("TSLA.US").await?;  // Vec<NewsItem>
+for item in &news {
+    println!("{}: {} ({})", item.published_at, item.title, item.url);
+}
+```
+
+**NewsItem fields:**
+- `id: String` — News ID
+- `title: String` — Headline
+- `description: String` — Summary
+- `url: String` — Full article URL
+- `published_at: OffsetDateTime`
+- `comments_count: i32`
+- `likes_count: i32`
+- `shares_count: i32`
+
+### topics
+
+```rust
+let topics = content_ctx.topics("700.HK").await?;  // Vec<TopicItem>
+for item in &topics {
+    println!("{}: {} ({} likes)", item.published_at, item.title, item.likes_count);
+}
+```
+
+**TopicItem fields:** same structure as `NewsItem`.
+
+---
+
+## Filings (via QuoteContext)
+
+Regulatory filings are accessed through `QuoteContext`, not `ContentContext`.
+
+```rust
+let (quote_ctx, _rx) = QuoteContext::new(config.clone());
+
+let filings = quote_ctx.filings("AAPL.US").await?;  // Vec<FilingItem>
+for f in &filings {
+    println!("{}: {} — files: {:?}", f.published_at, f.title, f.file_urls);
+}
+```
+
+**FilingItem fields:**
+- `id: String` — Filing ID
+- `title: String` — Filing title
+- `description: String` — Summary
+- `file_name: String` — Primary file name
+- `file_urls: Vec<String>` — Download URLs
+- `published_at: OffsetDateTime`
+
+---
+
+## Complete Example
+
+```rust
+use std::sync::Arc;
+use longbridge::{Config, QuoteContext, content::ContentContext};
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let config = Arc::new(Config::from_apikey_env()?);
+    let content = ContentContext::try_new(config.clone())?;
+    let (quote, _rx) = QuoteContext::new(config);
+
+    // Fetch all content in parallel
+    let (news, topics, filings) = tokio::join!(
+        content.news("TSLA.US"),
+        content.topics("TSLA.US"),
+        quote.filings("TSLA.US"),
+    );
+
+    println!("News: {}", news?.len());
+    println!("Topics: {}", topics?.len());
+    println!("Filings: {}", filings?.len());
+    Ok(())
+}
+```
+
+---
+
+## Note: Python SDK
+
+The Python SDK does not expose a `ContentContext`. For news/filings/topics in Python, use:
+
+1. **CLI** — `longbridge news SYMBOL`, `longbridge filing SYMBOL`, `longbridge topic SYMBOL`
+2. **HttpClient** — raw HTTP calls to `/v1/content/{symbol}/news`, `/v1/content/{symbol}/topics`, `/v1/quote/filings`
+3. **MCP** — `news`, `topics`, `filings` tools
+
+```python
+# Python: via HttpClient
+http = HttpClient.from_oauth(oauth)
+news = http.request("get", "/v1/content/TSLA.US/news")
+topics = http.request("get", "/v1/content/TSLA.US/topics")
+filings = http.request("get", "/v1/quote/filings", body={"symbol": "TSLA.US"})
+```

--- a/optional-skills/finance/longbridge/references/rust-sdk/overview.md
+++ b/optional-skills/finance/longbridge/references/rust-sdk/overview.md
@@ -1,0 +1,132 @@
+# Rust SDK Overview
+
+**Crate:** `longbridge` v4.0.5
+**Docs:** https://longbridge.github.io/openapi/rust/longbridge/
+
+## Add to Cargo.toml
+
+```toml
+[dependencies]
+longbridge = "4.0.5"
+tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
+rust_decimal = "1"
+time = "0.3"
+```
+
+> **Note:** Previously named `longport`. The crate was renamed to `longbridge`.
+
+## Import
+
+```rust
+use longbridge::{
+    Config, Market, QuoteContext, TradeContext,
+    quote::{Period, SubFlags, AdjustType, TradeSessions, PushEvent},
+    trade::{OrderType, OrderSide, TimeInForceType, OutsideRTH, SubmitOrderOptions},
+    Decimal,
+};
+```
+
+## Authentication
+
+### OAuth 2.0 (Recommended)
+
+```rust
+use longbridge::{Config, QuoteContext};
+use longbridge_oauth::OAuthBuilder;  // in oauth crate
+
+// Token cached at ~/.longbridge/openapi/tokens/<client_id>
+let oauth = OAuthBuilder::new("your-client-id")
+    .build(|url| println!("Open URL to authorize: {url}"))
+    .await?;
+let config = Config::from_oauth(oauth);
+```
+
+## Config Options
+
+```rust
+use std::sync::Arc;
+use longbridge::{Config, Language, PushCandlestickMode};
+
+let config = Arc::new(
+    Config::from_oauth(oauth)
+        .language(Language::EN)
+        .enable_overnight(false)
+        .push_candlestick_mode(PushCandlestickMode::Realtime)
+);
+```
+
+## Creating Contexts
+
+The Rust SDK is **async-only** (tokio). Both contexts return a channel receiver for push events.
+
+```rust
+use std::sync::Arc;
+use longbridge::{Config, QuoteContext, TradeContext};
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let oauth = OAuthBuilder::new("your-client-id")
+        .build(|url| println!("Open URL to authorize: {url}"))
+        .await?;
+    let config = Arc::new(Config::from_oauth(oauth));
+
+    // Returns (context, push_receiver)
+    let (quote_ctx, mut push_rx) = QuoteContext::new(config.clone());
+    let (trade_ctx, mut order_rx) = TradeContext::new(config);
+
+    // Spawn push handler
+    tokio::spawn(async move {
+        while let Some(event) = push_rx.recv().await {
+            println!("Push: {:?}", event);
+        }
+    });
+
+    Ok(())
+}
+```
+
+## Push Event Handling
+
+`QuoteContext::new` returns `mpsc::UnboundedReceiver<PushEvent>`.
+
+```rust
+use longbridge::quote::PushEvent;
+
+while let Some(event) = push_rx.recv().await {
+    match event {
+        PushEvent::Quote(e)       => println!("{}: last={}", e.symbol, e.last_done),
+        PushEvent::Depth(e)       => println!("{}: {} asks", e.symbol, e.asks.len()),
+        PushEvent::Brokers(e)     => println!("brokers: {}", e.symbol),
+        PushEvent::Trade(e)       => println!("trade: {}", e.symbol),
+        PushEvent::Candlestick(e) => println!("candle: {}", e.symbol),
+    }
+}
+```
+
+`TradeContext::new` returns `mpsc::UnboundedReceiver<longbridge::trade::PushEvent>`.
+
+```rust
+use longbridge::trade::PushEvent as TradePushEvent;
+
+while let Some(event) = order_rx.recv().await {
+    match event {
+        TradePushEvent::OrderChanged(o) => println!("Order {} -> {:?}", o.order_id, o.status),
+    }
+}
+```
+
+## Error Handling
+
+```rust
+use longbridge::Error;
+
+match ctx.quote(["INVALID.XX"]).await {
+    Ok(quotes) => { /* ... */ }
+    Err(Error::OpenApi { code, message, .. }) => eprintln!("API error {code}: {message}"),
+    Err(e) => eprintln!("Other error: {e}"),
+}
+```
+
+## Environment Variables
+
+Same as Python SDK — see [Python overview](../python-sdk/overview.md#environment-variables).

--- a/optional-skills/finance/longbridge/references/rust-sdk/quote-context.md
+++ b/optional-skills/finance/longbridge/references/rust-sdk/quote-context.md
@@ -1,0 +1,246 @@
+# Rust SDK — QuoteContext
+
+All methods are `async` and return `Result<T>`.
+
+## Creation
+
+```rust
+let (ctx, push_rx) = QuoteContext::new(Arc::new(config));
+```
+
+## Subscriptions
+
+### subscribe / unsubscribe
+
+```rust
+use longbridge::quote::SubFlags;
+
+// SubFlags are bit-flags, combine with |
+ctx.subscribe(["700.HK", "AAPL.US"], SubFlags::QUOTE | SubFlags::DEPTH).await?;
+ctx.unsubscribe(["AAPL.US"], SubFlags::QUOTE).await?;
+
+let subs = ctx.subscriptions().await?;  // Vec<Subscription>
+```
+
+**SubFlags:**
+```rust
+SubFlags::QUOTE    // Real-time quote
+SubFlags::DEPTH    // Level 2 order book
+SubFlags::BROKER   // HK broker queue
+SubFlags::TRADE    // Tick-by-tick trades
+```
+
+### subscribe_candlesticks
+
+```rust
+use longbridge::quote::{Period, TradeSessions};
+
+// Returns initial snapshot; push arrives via push_rx
+let candles = ctx.subscribe_candlesticks("700.HK", Period::Day).await?;
+ctx.unsubscribe_candlesticks("700.HK", Period::Day).await?;
+```
+
+## Market Data
+
+### static_info
+
+```rust
+let infos = ctx.static_info(["700.HK", "AAPL.US"]).await?;
+// Vec<SecurityStaticInfo>: symbol, name_en, name_zh, exchange, currency, lot_size, etc.
+```
+
+### quote
+
+```rust
+let quotes = ctx.quote(["700.HK", "AAPL.US"]).await?;
+// Vec<SecurityQuote>: symbol, last_done, prev_close_price, open, high, low, volume, turnover
+```
+
+### option_quote / warrant_quote
+
+```rust
+let opt = ctx.option_quote(["AAPL230317P160000.US"]).await?;  // Vec<OptionQuote>
+let war = ctx.warrant_quote(["21125.HK"]).await?;              // Vec<WarrantQuote>
+```
+
+### depth
+
+```rust
+let depth = ctx.depth("700.HK").await?;
+// SecurityDepth { asks: Vec<Depth>, bids: Vec<Depth> }
+// Depth { position, price, volume, order_num }
+```
+
+### brokers
+
+```rust
+let brokers = ctx.brokers("700.HK").await?;
+// SecurityBrokers { ask_brokers: Vec<Brokers>, bid_brokers: Vec<Brokers> }
+```
+
+### participants
+
+```rust
+let participants = ctx.participants().await?;  // Vec<ParticipantInfo> (HK only)
+```
+
+### trades
+
+```rust
+let trades = ctx.trades("700.HK", 50).await?;  // Vec<Trade>, max 1000
+```
+
+### intraday
+
+```rust
+use longbridge::quote::TradeSessions;
+
+let lines = ctx.intraday("700.HK", TradeSessions::Intraday).await?;  // Vec<IntradayLine>
+let lines = ctx.intraday("700.HK", TradeSessions::All).await?;       // include pre/post
+```
+
+### candlesticks (recent N)
+
+```rust
+use longbridge::quote::{Period, AdjustType, TradeSessions};
+
+let candles = ctx.candlesticks("700.HK", Period::Day, 100, AdjustType::NoAdjust, TradeSessions::Intraday).await?;
+// Vec<Candlestick>: close, open, high, low, volume, turnover, trade_session, timestamp
+```
+
+### history_candlesticks_by_offset
+
+```rust
+use time::macros::datetime;
+
+let candles = ctx.history_candlesticks_by_offset(
+    "700.HK",
+    Period::Day,
+    AdjustType::NoAdjust,
+    false,      // forward: false = look backward from `time`
+    100,
+    Some(datetime!(2024-01-01 00:00 UTC)),
+    TradeSessions::Intraday,
+).await?;
+```
+
+### history_candlesticks_by_date
+
+```rust
+use time::macros::date;
+
+let candles = ctx.history_candlesticks_by_date(
+    "700.HK",
+    Period::Day,
+    AdjustType::ForwardAdjust,
+    Some(date!(2024-01-01)),
+    Some(date!(2024-12-31)),
+    TradeSessions::Intraday,
+).await?;
+```
+
+## Options
+
+```rust
+use time::macros::date;
+
+let dates   = ctx.option_chain_expiry_date_list("AAPL.US").await?;   // Vec<Date>
+let strikes = ctx.option_chain_info_by_date("AAPL.US", date!(2024-01-19)).await?;
+// Vec<StrikePriceInfo>: price, call_symbol, put_symbol, standard
+```
+
+## Warrants
+
+```rust
+use longbridge::quote::{WarrantSortBy, SortOrderType};
+
+let issuers = ctx.warrant_issuers().await?;   // Vec<IssuerInfo>
+
+let warrants = ctx.warrant_list(
+    "700.HK",
+    WarrantSortBy::LastDone,
+    SortOrderType::Ascending,
+    Default::default(),  // WarrantListOptions (optional filters)
+).await?;  // Vec<WarrantInfo>
+```
+
+## Trading Calendar
+
+```rust
+use longbridge::Market;
+use time::macros::date;
+
+let sessions = ctx.trading_session().await?;
+// Vec<MarketTradingSession>
+
+let days = ctx.trading_days(Market::HK, date!(2024-01-01), date!(2024-03-31)).await?;
+// MarketTradingDays { trading_days, half_trading_days }
+```
+
+## Capital & Indexes
+
+```rust
+use longbridge::quote::CalcIndex;
+
+let flow = ctx.capital_flow("700.HK").await?;          // Vec<CapitalFlowLine>
+let dist = ctx.capital_distribution("700.HK").await?;  // CapitalDistributionResponse
+
+let indexes = ctx.calc_indexes(
+    ["700.HK", "AAPL.US"],
+    [CalcIndex::LastDone, CalcIndex::PeTtmRatio, CalcIndex::PbRatio],
+).await?;  // Vec<SecurityCalcIndex>
+```
+
+## Watchlist
+
+```rust
+use longbridge::quote::{RequestCreateWatchlistGroup, RequestUpdateWatchlistGroup};
+
+let groups = ctx.watchlist().await?;   // Vec<WatchlistGroup>
+
+let group_id = ctx.create_watchlist_group(RequestCreateWatchlistGroup {
+    name: "My Group".into(),
+    securities: vec!["700.HK".into(), "AAPL.US".into()],
+}).await?;  // i64
+
+ctx.update_watchlist_group(RequestUpdateWatchlistGroup {
+    id: group_id,
+    name: Some("Updated".into()),
+    securities: vec!["TSLA.US".into()],
+    mode: Some(SecuritiesUpdateMode::Add),
+}).await?;
+
+ctx.delete_watchlist_group(group_id, false).await?;
+```
+
+## Security List & Market Temperature
+
+```rust
+use longbridge::{Market, quote::SecurityListCategory};
+use time::macros::date;
+
+let secs = ctx.security_list(Market::HK, None).await?;   // Vec<Security>
+let temp = ctx.market_temperature(Market::HK).await?;    // MarketTemperature
+let hist = ctx.history_market_temperature(
+    Market::HK, date!(2024-01-01), date!(2024-03-31)
+).await?;
+```
+
+## Realtime Cache
+
+After subscribing, get cached data without a network call:
+
+```rust
+let quotes   = ctx.realtime_quote(["700.HK"]).await?;      // Vec<RealtimeQuote>
+let depth    = ctx.realtime_depth("700.HK").await?;         // SecurityDepth
+let brokers  = ctx.realtime_brokers("700.HK").await?;       // SecurityBrokers
+let trades   = ctx.realtime_trades("700.HK", 100).await?;   // Vec<Trade>
+```
+
+## Account Info
+
+```rust
+let id       = ctx.member_id().await?;               // i64
+let level    = ctx.quote_level().await?;              // String
+let packages = ctx.quote_package_details().await?;    // Vec<QuotePackageDetail>
+```

--- a/optional-skills/finance/longbridge/references/rust-sdk/trade-context.md
+++ b/optional-skills/finance/longbridge/references/rust-sdk/trade-context.md
@@ -1,0 +1,204 @@
+# Rust SDK — TradeContext
+
+All methods are `async` and return `Result<T>`.
+
+## Creation
+
+```rust
+let (ctx, order_rx) = TradeContext::new(Arc::new(config));
+
+// Spawn push handler
+tokio::spawn(async move {
+    use longbridge::trade::PushEvent;
+    while let Some(event) = order_rx.recv().await {
+        match event {
+            PushEvent::OrderChanged(o) => println!("Order {} -> {:?}", o.order_id, o.status),
+        }
+    }
+});
+```
+
+## Subscribe to Order Push
+
+```rust
+use longbridge::trade::TopicType;
+
+ctx.subscribe([TopicType::Private]).await?;
+ctx.unsubscribe([TopicType::Private]).await?;
+```
+
+## Submit Order
+
+```rust
+use longbridge::{Decimal, trade::{SubmitOrderOptions, OrderType, OrderSide, TimeInForceType}};
+
+let opts = SubmitOrderOptions::new(
+    "700.HK",
+    OrderType::LO,
+    OrderSide::Buy,
+    Decimal::from(200),
+    TimeInForceType::Day,
+)
+.submitted_price(Decimal::from_str("50.00").unwrap())
+.remark("my order".into());
+
+let resp = ctx.submit_order(opts).await?;
+println!("Order ID: {}", resp.order_id);
+```
+
+**Builder methods for special order types:**
+
+```rust
+// LIT / MIT
+opts.trigger_price(Decimal::from_str("48.00")?)
+
+// Trailing orders (TSLPAMT)
+opts.limit_offset(Decimal::from_str("1.00")?)
+    .trailing_amount(Decimal::from_str("2.00")?)
+
+// GTD
+opts.expire_date(date!(2024-12-31))
+
+// US pre/post market
+opts.outside_rth(OutsideRTH::AnyTime)
+```
+
+## Replace / Cancel Order
+
+```rust
+use longbridge::trade::ReplaceOrderOptions;
+
+let opts = ReplaceOrderOptions::new("709043056541253632", Decimal::from(100))
+    .price(Decimal::from_str("100.00")?);
+ctx.replace_order(opts).await?;
+
+ctx.cancel_order("709043056541253632").await?;
+```
+
+## Query Orders
+
+```rust
+use longbridge::trade::{GetHistoryOrdersOptions, GetTodayOrdersOptions, OrderStatus, OrderSide};
+
+// Today's orders
+let orders = ctx.today_orders(None).await?;  // Vec<Order>
+
+// With filters
+let orders = ctx.today_orders(Some(GetTodayOrdersOptions::new()
+    .symbol("700.HK")
+    .status([OrderStatus::Filled, OrderStatus::New])
+    .side(OrderSide::Buy)
+)).await?;
+
+// Historical orders (does not include today)
+let orders = ctx.history_orders(
+    GetHistoryOrdersOptions::new()
+        .symbol("700.HK")
+        .start_at(datetime!(2024-01-01 00:00 UTC))
+        .end_at(datetime!(2024-12-31 23:59 UTC))
+).await?;
+
+// Order detail
+let detail = ctx.order_detail("701276261045858304").await?;  // OrderDetail
+```
+
+## Executions
+
+```rust
+use longbridge::trade::GetHistoryExecutionsOptions;
+
+// Today's fills
+let execs = ctx.today_executions(None).await?;    // Vec<Execution>
+
+// Historical fills
+let execs = ctx.history_executions(
+    GetHistoryExecutionsOptions::new()
+        .symbol("700.HK")
+        .start_at(datetime!(2024-01-01 00:00 UTC))
+        .end_at(datetime!(2024-12-31 23:59 UTC))
+).await?;
+// Execution: order_id, trade_id, symbol, trade_done_at, quantity, price
+```
+
+## Account Balance
+
+```rust
+let balances = ctx.account_balance(None).await?;         // Vec<AccountBalance>
+let balances = ctx.account_balance(Some("HKD")).await?;  // filter by currency
+```
+
+## Cash Flow
+
+```rust
+use longbridge::trade::GetCashFlowOptions;
+
+let flows = ctx.cash_flow(
+    GetCashFlowOptions::new(
+        datetime!(2024-01-01 00:00 UTC),
+        datetime!(2024-12-31 23:59 UTC),
+    )
+    .symbol("700.HK")     // optional
+).await?;  // Vec<CashFlow>
+```
+
+## Positions
+
+```rust
+let stock = ctx.stock_positions(None).await?;
+// StockPositionsResponse { channels: Vec<StockPositionChannel> }
+// StockPositionChannel { account_channel, positions: Vec<StockPosition> }
+// StockPosition: symbol, symbol_name, quantity, available_quantity, currency, cost_price
+
+let fund = ctx.fund_positions(None).await?;
+// FundPositionsResponse { channels: Vec<FundPositionChannel> }
+```
+
+## Margin & Estimation
+
+```rust
+let ratio = ctx.margin_ratio("TSLA.US").await?;
+// MarginRatio { im_factor, mm_factor, fm_factor }
+
+let est = ctx.estimate_max_purchase_quantity(
+    "700.HK",
+    OrderType::LO,
+    OrderSide::Buy,
+    Some(Decimal::from_str("50.00")?),
+    None,   // currency
+    None,   // order_id
+    false,  // fractional_shares
+).await?;
+// EstimateMaxPurchaseQuantityResponse { cash_max_qty, margin_max_qty }
+```
+
+## Complete Example
+
+```rust
+use std::sync::Arc;
+use longbridge::{Config, TradeContext, Decimal, trade::{SubmitOrderOptions, OrderType, OrderSide, TimeInForceType}};
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let config = Arc::new(Config::from_apikey_env()?);
+    let (ctx, _rx) = TradeContext::new(config);
+
+    // Check balance before trading
+    let balances = ctx.account_balance(None).await?;
+    println!("Balance: {:?}", balances);
+
+    // Place a limit buy order
+    let resp = ctx.submit_order(
+        SubmitOrderOptions::new(
+            "700.HK",
+            OrderType::LO,
+            OrderSide::Buy,
+            Decimal::from(100),
+            TimeInForceType::Day,
+        )
+        .submitted_price(Decimal::from_str("45.00")?)
+    ).await?;
+    println!("Order placed: {}", resp.order_id);
+
+    Ok(())
+}
+```

--- a/optional-skills/finance/longbridge/references/rust-sdk/trade-context.md
+++ b/optional-skills/finance/longbridge/references/rust-sdk/trade-context.md
@@ -29,6 +29,12 @@ ctx.unsubscribe([TopicType::Private]).await?;
 
 ## Submit Order
 
+> ⚠️ **State-changing — confirm before executing.** `submit_order` places a real order against
+> the user's brokerage account. Read back symbol, side, quantity, and price and get an explicit
+> "yes, place it" from the user immediately before calling this — never chain a submission
+> straight off a data lookup. Same rule as `mcp.md`'s "always ask for confirmation before
+> executing."
+
 ```rust
 use longbridge::{Decimal, trade::{SubmitOrderOptions, OrderType, OrderSide, TimeInForceType}};
 
@@ -64,6 +70,10 @@ opts.outside_rth(OutsideRTH::AnyTime)
 ```
 
 ## Replace / Cancel Order
+
+> ⚠️ **State-changing — confirm before executing.** Both calls immediately mutate a live order.
+> Confirm the target order ID and the new price/quantity (for `replace_order`) with the user
+> right before calling — same confirmation gate as Submit Order above.
 
 ```rust
 use longbridge::trade::ReplaceOrderOptions;

--- a/optional-skills/finance/longbridge/references/rust-sdk/types.md
+++ b/optional-skills/finance/longbridge/references/rust-sdk/types.md
@@ -1,0 +1,220 @@
+# Rust SDK — Types & Enums
+
+All types are in the `longbridge` crate. Key modules: `longbridge::quote`, `longbridge::trade`.
+
+## SubFlags — Quote subscription (bit-flags)
+
+```rust
+use longbridge::quote::SubFlags;
+
+SubFlags::QUOTE    // Real-time quote
+SubFlags::DEPTH    // Level 2 order book
+SubFlags::BROKER   // HK broker queue
+SubFlags::TRADE    // Tick-by-tick trades
+
+// Combine:
+SubFlags::QUOTE | SubFlags::DEPTH
+```
+
+## Period — Candlestick periods
+
+```rust
+use longbridge::quote::Period;
+
+Period::OneMinute    Period::TwoMinute     Period::ThreeMinute
+Period::FiveMinute   Period::TenMinute     Period::FifteenMinute
+Period::TwentyMinute Period::ThirtyMinute  Period::FortyFiveMinute
+Period::SixtyMinute  Period::TwoHour       Period::ThreeHour    Period::FourHour
+Period::Day          Period::Week          Period::Month
+Period::Quarter      Period::Year
+```
+
+**MCP string equivalents:** `"1m"`, `"2m"`, `"3m"`, `"5m"`, `"10m"`, `"15m"`, `"20m"`, `"30m"`, `"45m"`, `"60m"`, `"120m"`, `"180m"`, `"240m"`, `"day"`, `"week"`, `"month"`, `"quarter"`, `"year"`
+
+## AdjustType
+
+```rust
+use longbridge::quote::AdjustType;
+
+AdjustType::NoAdjust       // Actual (unadjusted)
+AdjustType::ForwardAdjust  // Forward-adjusted for splits/dividends
+```
+
+## TradeSessions
+
+```rust
+use longbridge::quote::TradeSessions;
+
+TradeSessions::Intraday   // Regular trading hours only
+TradeSessions::All        // All sessions (pre, intraday, post, overnight)
+```
+
+## Market
+
+```rust
+use longbridge::Market;
+
+Market::HK    // Hong Kong
+Market::US    // United States
+Market::CN    // China (SH/SZ)
+Market::SG    // Singapore
+```
+
+## OrderSide
+
+```rust
+use longbridge::trade::OrderSide;
+
+OrderSide::Buy
+OrderSide::Sell
+```
+
+## OrderType
+
+```rust
+use longbridge::trade::OrderType;
+
+OrderType::LO        // Limit Order
+OrderType::ELO       // Enhanced Limit Order (HK only)
+OrderType::MO        // Market Order
+OrderType::AO        // At-Auction Order
+OrderType::ALO       // At-Auction Limit Order
+OrderType::ODD       // Odd Lots Order
+OrderType::LIT       // Limit If Touched
+OrderType::MIT       // Market If Touched
+OrderType::TSLPAMT   // Trailing Limit (Trailing Amount)
+OrderType::TSLPPCT   // Trailing Limit (Trailing Percent)
+OrderType::TSMAMT    // Trailing Market (Trailing Amount)
+OrderType::TSMPCT    // Trailing Market (Trailing Percent)
+OrderType::SLO       // Special Limit Order (HK only)
+```
+
+## OrderStatus
+
+```rust
+use longbridge::trade::OrderStatus;
+
+OrderStatus::NotReported      OrderStatus::New             OrderStatus::WaitToNew
+OrderStatus::PartialFilled    OrderStatus::Filled          OrderStatus::WaitToReplace
+OrderStatus::PendingReplace   OrderStatus::Replaced        OrderStatus::WaitToCancel
+OrderStatus::PendingCancel    OrderStatus::Rejected        OrderStatus::Canceled
+OrderStatus::Expired          OrderStatus::PartialWithdrawal
+```
+
+## TimeInForceType
+
+```rust
+use longbridge::trade::TimeInForceType;
+
+TimeInForceType::Day              // Day order
+TimeInForceType::GoodTilCanceled  // GTC
+TimeInForceType::GoodTilDate      // GTD — use .expire_date()
+```
+
+## OutsideRTH (US only)
+
+```rust
+use longbridge::trade::OutsideRTH;
+
+OutsideRTH::RTH_Only   // Regular hours only (default)
+OutsideRTH::AnyTime    // Pre and post market
+OutsideRTH::Overnight  // Overnight session
+```
+
+## TopicType (trade push)
+
+```rust
+use longbridge::trade::TopicType;
+
+TopicType::Private  // Order change notifications
+```
+
+## CalcIndex
+
+```rust
+use longbridge::quote::CalcIndex;
+
+// Key indexes:
+CalcIndex::LastDone          CalcIndex::ChangeValue       CalcIndex::ChangeRate
+CalcIndex::Volume            CalcIndex::Turnover          CalcIndex::TotalMarketValue
+CalcIndex::PeTtmRatio        CalcIndex::PbRatio           CalcIndex::DividendRatioTtm
+CalcIndex::YtdChangeRate     CalcIndex::ImpliedVolatility CalcIndex::Delta
+CalcIndex::Gamma             CalcIndex::Theta             CalcIndex::Vega
+// ... see Python types.md for full list
+```
+
+## Push Events
+
+### QuoteContext push
+
+```rust
+use longbridge::quote::PushEvent;
+
+PushEvent::Quote(PushQuote)          // last_done, open, high, low, volume, turnover
+PushEvent::Depth(PushDepth)          // asks: Vec<Depth>, bids: Vec<Depth>
+PushEvent::Brokers(PushBrokers)      // ask_brokers, bid_brokers
+PushEvent::Trade(PushTrades)         // trades: Vec<Trade>
+PushEvent::Candlestick(PushCandlestick)  // candlestick, period
+```
+
+### TradeContext push
+
+```rust
+use longbridge::trade::PushEvent;
+
+PushEvent::OrderChanged(PushOrderChanged)
+// Fields: order_id, symbol, status, side, filled_qty, price, msg
+```
+
+## Language
+
+```rust
+use longbridge::Language;
+
+Language::EN     // English (default)
+Language::ZH_CN  // Simplified Chinese
+Language::ZH_HK  // Traditional Chinese
+```
+
+## PushCandlestickMode
+
+```rust
+use longbridge::PushCandlestickMode;
+
+PushCandlestickMode::Realtime   // Push every tick update
+PushCandlestickMode::Confirmed  // Push only after candle closes
+```
+
+## Decimal
+
+Rust SDK uses `rust_decimal::Decimal` for all prices and quantities:
+
+```rust
+use longbridge::Decimal;  // re-export of rust_decimal::Decimal
+use std::str::FromStr;
+
+let price = Decimal::from_str("50.00")?;
+let qty   = Decimal::from(200u32);
+```
+
+## SecuritiesUpdateMode (watchlist)
+
+```rust
+use longbridge::quote::SecuritiesUpdateMode;
+
+SecuritiesUpdateMode::Add     // Append securities
+SecuritiesUpdateMode::Remove  // Remove securities
+SecuritiesUpdateMode::Replace // Replace all
+```
+
+## Error Type
+
+```rust
+use longbridge::Error;
+
+match result {
+    Err(Error::OpenApi { code, message, trace_id, .. }) => { /* API error */ }
+    Err(Error::Http { .. })  => { /* network/HTTP error */ }
+    Err(e) => { /* other */ }
+}
+```

--- a/optional-skills/finance/longbridge/references/setup.md
+++ b/optional-skills/finance/longbridge/references/setup.md
@@ -1,0 +1,63 @@
+# Longbridge Setup & Authentication
+
+## CLI Installation
+
+```bash
+# macOS (Homebrew)
+brew install --cask longbridge/tap/longbridge-terminal
+
+# macOS / Linux
+curl -sSL https://open.longbridge.com/longbridge/longbridge-terminal/install | sh
+```
+
+Windows (Scoop or PowerShell):
+
+```powershell
+# Scoop
+scoop install https://open.longbridge.com/longbridge/longbridge-terminal/longbridge.json
+
+# Or PowerShell install script
+iwr https://open.longbridge.com/longbridge/longbridge-terminal/install.ps1 | iex
+```
+
+Authenticate:
+
+```bash
+longbridge auth login
+```
+
+## CLI Update
+
+```bash
+# Built-in updater
+longbridge update
+
+# Or re-run the install script
+curl -sSL https://open.longbridge.com/longbridge/longbridge-terminal/install | sh
+```
+
+## MCP (for AI tools — no code)
+
+```bash
+# Claude Code
+claude mcp add longbridge https://openapi.longbridge.com/mcp
+```
+
+First tool call triggers an OAuth browser flow. See [references/mcp.md](references/mcp.md) for Cursor, ChatGPT, Zed.
+
+## Revoking Authorization
+
+To revoke access, go to your Longbridge account → Security Settings → manage authorized apps.
+
+## Authentication
+
+All tools use **OAuth 2.0** — no manual token or API key management needed.
+
+**Token cache:** `~/.longbridge/openapi/tokens/<client_id>`
+**Register OAuth client:** POST `https://openapi.longbridge.com/oauth2/register`
+
+## Rate Limits
+
+- REST API: max **10 calls/second**
+- SDK auto-refreshes OAuth tokens
+- WebSocket subscriptions: subject to quote package limits

--- a/optional-skills/finance/longbridge/references/setup.md
+++ b/optional-skills/finance/longbridge/references/setup.md
@@ -43,7 +43,7 @@ curl -sSL https://open.longbridge.com/longbridge/longbridge-terminal/install | s
 claude mcp add longbridge https://openapi.longbridge.com/mcp
 ```
 
-First tool call triggers an OAuth browser flow. See [references/mcp.md](references/mcp.md) for Cursor, ChatGPT, Zed.
+First tool call triggers an OAuth browser flow. See [mcp.md](mcp.md) for Cursor, ChatGPT, Zed.
 
 ## Revoking Authorization
 

--- a/tests/skills/test_longbridge_skill.py
+++ b/tests/skills/test_longbridge_skill.py
@@ -1,0 +1,216 @@
+"""
+Smoke tests for the longbridge optional skill.
+
+This skill is a pure prose wrapper around the third-party `longbridge` CLI/SDKs —
+there's no bundled script to unit-test and no way to hit the live brokerage API in
+CI (needs a real, authenticated Longbridge account). Instead these tests verify:
+  - SKILL.md frontmatter conforms to the hardline format
+  - the modern section order is present
+  - referenced doc files exist and internal relative links resolve
+  - state-changing SDK calls (submit/replace/cancel order) carry an explicit
+    confirm-before-executing warning
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+SKILL_DIR = Path(__file__).resolve().parents[2] / "optional-skills" / "finance" / "longbridge"
+
+
+@pytest.fixture(scope="module")
+def frontmatter() -> dict:
+    src = (SKILL_DIR / "SKILL.md").read_text()
+    m = re.search(r"^---\n(.*?)\n---", src, re.DOTALL)
+    assert m, "SKILL.md missing YAML frontmatter"
+    return yaml.safe_load(m.group(1))
+
+
+@pytest.fixture(scope="module")
+def skill_body() -> str:
+    return (SKILL_DIR / "SKILL.md").read_text()
+
+
+def test_skill_dir_exists() -> None:
+    assert SKILL_DIR.is_dir(), f"missing skill dir: {SKILL_DIR}"
+
+
+def test_skill_md_present() -> None:
+    assert (SKILL_DIR / "SKILL.md").is_file()
+
+
+def test_description_under_60_chars(frontmatter) -> None:
+    desc = frontmatter["description"]
+    assert len(desc) <= 60, f"description is {len(desc)} chars (hardline <=60): {desc!r}"
+    assert desc.endswith("."), f"description must end with a period: {desc!r}"
+
+
+def test_name_matches_dir(frontmatter) -> None:
+    assert frontmatter["name"] == "longbridge"
+
+
+def test_author_credits_human_contributor(frontmatter) -> None:
+    author = frontmatter["author"]
+    assert "Hogan" in author, f"author should credit the human contributor first: {author!r}"
+
+
+def test_license_mit(frontmatter) -> None:
+    assert frontmatter["license"] == "MIT"
+
+
+def test_requires_setup_flagged(frontmatter) -> None:
+    # Longbridge needs OAuth login before any live-data call works — the loader
+    # surfaces this to the user via metadata.hermes.requires_setup.
+    assert frontmatter["metadata"]["hermes"]["requires_setup"] is True
+
+
+@pytest.mark.parametrize(
+    "heading",
+    [
+        "## When to Use",
+        "## Prerequisites",
+        "## How to Run",
+        "## Quick Reference",
+        "## Procedure",
+        "## Pitfalls",
+        "## Verification",
+    ],
+)
+def test_modern_section_order_headings_present(skill_body, heading: str) -> None:
+    assert heading in skill_body, f"missing hardline section: {heading}"
+
+
+def test_modern_sections_appear_in_order(skill_body) -> None:
+    required = [
+        "## When to Use",
+        "## Prerequisites",
+        "## How to Run",
+        "## Quick Reference",
+        "## Procedure",
+        "## Pitfalls",
+        "## Verification",
+    ]
+    positions = [skill_body.index(h) for h in required]
+    assert positions == sorted(positions), "hardline sections are out of order"
+
+
+REFERENCE_FILES = [
+    "references/setup.md",
+    "references/mcp.md",
+    "references/llm.md",
+    "references/cli/overview.md",
+    "references/python-sdk/overview.md",
+    "references/python-sdk/quote-context.md",
+    "references/python-sdk/content-context.md",
+    "references/python-sdk/trade-context.md",
+    "references/python-sdk/types.md",
+    "references/rust-sdk/overview.md",
+    "references/rust-sdk/quote-context.md",
+    "references/rust-sdk/trade-context.md",
+    "references/rust-sdk/content.md",
+    "references/rust-sdk/types.md",
+]
+
+
+@pytest.mark.parametrize("rel_path", REFERENCE_FILES)
+def test_referenced_files_exist(rel_path: str) -> None:
+    assert (SKILL_DIR / rel_path).is_file(), f"SKILL.md links to missing file: {rel_path}"
+
+
+def _extract_markdown_links(text: str) -> list[str]:
+    return re.findall(r"\[[^\]]+\]\(([^)]+)\)", text)
+
+
+@pytest.mark.parametrize(
+    "doc_path",
+    [
+        "SKILL.md",
+        "references/setup.md",
+        "references/mcp.md",
+        "references/rust-sdk/content.md",
+    ],
+)
+def test_relative_links_resolve(doc_path: str) -> None:
+    """Every relative (non-http) link in these docs must resolve to a real file,
+    relative to the *linking file's own directory* — not the skill root. This is
+    exactly the bug class flagged in review (references/setup.md wrongly linked
+    to references/references/mcp.md by writing "references/mcp.md" from within
+    references/)."""
+    full_path = SKILL_DIR / doc_path
+    text = full_path.read_text()
+    # The "Related Skills" table intentionally links to sibling skills (e.g.
+    # ../longbridge-quote) from the wider longbridge/skills family that aren't
+    # vendored into this optional skill — those are "defer to it if installed"
+    # pointers, not files this skill ships. Only check links above that table.
+    text = text.split("## Related Skills")[0]
+    for link in _extract_markdown_links(text):
+        if link.startswith(("http://", "https://", "#")):
+            continue
+        resolved = (full_path.parent / link).resolve()
+        assert resolved.is_file(), (
+            f"{doc_path} links to {link!r}, which resolves to {resolved} (missing)"
+        )
+
+
+def test_setup_md_links_to_sibling_mcp_not_nested() -> None:
+    text = (SKILL_DIR / "references" / "setup.md").read_text()
+    assert "references/mcp.md" not in text, (
+        "setup.md is itself inside references/ — linking to 'references/mcp.md' "
+        "resolves to a nonexistent nested path; use 'mcp.md'"
+    )
+    assert "(mcp.md)" in text
+
+
+def test_rust_content_doc_agrees_python_has_content_context() -> None:
+    rust_content = (SKILL_DIR / "references" / "rust-sdk" / "content.md").read_text()
+    python_content = (SKILL_DIR / "references" / "python-sdk" / "content-context.md").read_text()
+
+    assert "ContentContext" in python_content
+    assert "does not expose a `ContentContext`" not in rust_content, (
+        "rust-sdk/content.md must not claim Python lacks ContentContext — "
+        "the Python SDK does expose it (see python-sdk/content-context.md)"
+    )
+    assert "does" in rust_content and "ContentContext" in rust_content
+
+
+@pytest.mark.parametrize(
+    "doc_path",
+    [
+        "references/python-sdk/trade-context.md",
+        "references/rust-sdk/trade-context.md",
+    ],
+)
+def test_state_changing_order_calls_have_confirmation_guard(doc_path: str) -> None:
+    text = (SKILL_DIR / doc_path).read_text()
+
+    submit_idx = text.index("submit_order")
+    preceding = text[:submit_idx]
+    # The nearest confirmation warning before the first submit_order call must be
+    # closer than the nearest preceding section heading (i.e. it lives directly
+    # above this call, not just somewhere earlier in the doc).
+    last_heading = preceding.rfind("## Submit Order")
+    assert last_heading != -1, f"{doc_path} missing '## Submit Order' heading"
+    section = text[last_heading:submit_idx]
+    assert "confirm" in section.lower(), (
+        f"{doc_path}: no confirmation warning between '## Submit Order' and the "
+        f"first submit_order call"
+    )
+
+    replace_heading_idx = text.find("## Replace / Cancel Order")
+    assert replace_heading_idx != -1, f"{doc_path} missing '## Replace / Cancel Order' heading"
+    cancel_idx = text.index("cancel_order", replace_heading_idx)
+    section = text[replace_heading_idx:cancel_idx]
+    assert "confirm" in section.lower(), (
+        f"{doc_path}: no confirmation warning between '## Replace / Cancel Order' "
+        f"and the cancel_order call"
+    )
+
+
+def test_pitfalls_mentions_order_confirmation(skill_body) -> None:
+    pitfalls_idx = skill_body.index("## Pitfalls")
+    verification_idx = skill_body.index("## Verification")
+    pitfalls_section = skill_body[pitfalls_idx:verification_idx]
+    assert "confirm" in pitfalls_section.lower()


### PR DESCRIPTION
## Summary

Adds **Longbridge** to `optional-skills/finance` — a live financial market data and trading skill for US, HK, A-share, and Singapore markets via the Longbridge Securities CLI.

## Why optional-skills?

Longbridge requires a paid brokerage account + CLI authentication (`longbridge auth login`), making it a natural fit for `optional-skills` rather than bundled skills.

## What it does

- **Market data**: real-time quotes, K-lines, intraday, capital flow, market temperature
- **Fundamentals**: income statement, cash flow, consensus EPS, valuation percentile
- **News & filings**: news, SEC filings, regulatory filings, community topics
- **Options**: chain, volume, IV
- **Portfolio**: positions, P&L, orders, watchlist, account assets
- **Institutional**: 13F holdings, insider trades (Form 4), short positions
- **Platform**: CLI, Python SDK, Rust SDK, MCP server

## Setup

```bash
# Install CLI
brew install longportapp/tap/longbridge   # macOS
# or download from https://github.com/longbridge/longbridge-terminal

# Authenticate
longbridge auth login
```

## Source

Upstream: https://github.com/longbridge/skills/tree/main/skills/longbridge  
Full skill library: https://github.com/longbridge/skills (125+ skills)