### PR TITLE
fix(kanban): surface parked dispatch blockers

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -1935,7 +1935,11 @@ def _cmd_schedule(args: argparse.Namespace) -> int:
                 failed.append(tid)
                 print(f"cannot schedule {tid}", file=sys.stderr)
             else:
-                print(f"Scheduled {tid}" + (f": {reason}" if reason else ""))
+                print(
+                    f"Scheduled {tid}" + (f": {reason}" if reason else "")
+                    + "\n  note: scheduled is a parked/non-dispatchable state; "
+                    + "run `hermes kanban unblock " + tid + "` when it should be picked up."
+                )
     return 0 if not failed else 1
 
 
@@ -2023,6 +2027,11 @@ def _cmd_dispatch(args: argparse.Namespace) -> int:
             ],
             "skipped_unassigned": res.skipped_unassigned,
             "skipped_nonspawnable": res.skipped_nonspawnable,
+            "parked_scheduled": res.parked_scheduled,
+            "blocked_by_parent": [
+                {"task_id": child, "parent_id": parent, "parent_status": status}
+                for (child, parent, status) in res.blocked_by_parent
+            ],
         }, indent=2))
         return 0
     print(f"Reclaimed:    {res.reclaimed}")
@@ -2049,6 +2058,21 @@ def _cmd_dispatch(args: argparse.Namespace) -> int:
         print(
             f"Skipped (non-spawnable assignee — terminal lane, OK): "
             f"{', '.join(res.skipped_nonspawnable)}"
+        )
+    if res.parked_scheduled:
+        print(
+            "Parked scheduled (not dispatchable; run `hermes kanban unblock <id>` "
+            f"when it should run): {', '.join(res.parked_scheduled)}"
+        )
+    if res.blocked_by_parent:
+        formatted = ", ".join(
+            f"{child} waits on {parent} ({status})"
+            for child, parent, status in res.blocked_by_parent
+        )
+        print(
+            "Blocked by parent dependency: " + formatted + "\n"
+            "  If one of these is a rescue/unblock/remediation task for its "
+            "blocked parent, unlink the dependency before unblocking it."
         )
     return 0
 

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -3580,6 +3580,16 @@ class DispatchResult:
     operator-actionable failure. Tracked separately so health telemetry
     can distinguish "real stuck" (nothing spawned but spawnable work
     available) from "correctly idle" (nothing spawnable in the queue)."""
+    parked_scheduled: list[str] = field(default_factory=list)
+    """Assigned, unclaimed tasks parked in ``scheduled``. Scheduled is a
+    non-dispatchable hold state: the dispatcher will not claim these until
+    an operator/automation calls ``unblock``. Surfacing them in dispatch
+    output prevents the false impression that the watchdog ignored work."""
+    blocked_by_parent: list[tuple[str, str, str]] = field(default_factory=list)
+    """Child tasks waiting on a blocked parent, as
+    ``(child_id, parent_id, parent_status)``. Normal todo dependencies are
+    fine, but a child created to repair/unblock its blocked parent must not
+    be linked under that parent or it can never run."""
     crashed: list[str] = field(default_factory=list)
     """Task ids reclaimed because their worker PID disappeared."""
     auto_blocked: list[str] = field(default_factory=list)
@@ -4673,6 +4683,34 @@ def dispatch_once(
         result.auto_blocked.extend(_crash_auto_blocked)
     result.timed_out = enforce_max_runtime(conn)
     result.promoted = recompute_ready(conn)
+
+    # Make non-dispatchable "why didn't the watchdog pick this up?" states
+    # visible in the normal dispatch result. These are read-only diagnostics:
+    # scheduled tasks remain parked by design, and todo children still wait for
+    # their parents, but operators get a concrete explanation instead of an
+    # empty spawned=[] result.
+    result.parked_scheduled = [
+        str(r["id"])
+        for r in conn.execute(
+            "SELECT id FROM tasks "
+            "WHERE status = 'scheduled' "
+            "  AND assignee IS NOT NULL "
+            "  AND claim_lock IS NULL "
+            "ORDER BY priority DESC, created_at ASC"
+        ).fetchall()
+    ]
+    result.blocked_by_parent = [
+        (str(r["child_id"]), str(r["parent_id"]), str(r["parent_status"]))
+        for r in conn.execute(
+            "SELECT c.id AS child_id, p.id AS parent_id, p.status AS parent_status "
+            "FROM tasks c "
+            "JOIN task_links l ON l.child_id = c.id "
+            "JOIN tasks p ON p.id = l.parent_id "
+            "WHERE c.status IN ('todo', 'scheduled') "
+            "  AND p.status = 'blocked' "
+            "ORDER BY c.priority DESC, c.created_at ASC"
+        ).fetchall()
+    ]
 
     # Count tasks already running so max_spawn enforces concurrency rather
     # than a per-tick spawn budget. See the docstring above for the full

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -4419,3 +4419,45 @@ def test_dispatch_once_stale_disabled_when_timeout_zero(kanban_home, monkeypatch
         )
         assert res.stale == [], "stale_timeout_seconds=0 should disable detection"
         assert kb.get_task(conn, t).status == "running"
+
+
+def test_dispatch_reports_scheduled_tasks_as_parked(kanban_home, all_assignees_spawnable):
+    """Scheduled is a parked state, not a dispatcher queue. Dispatch output
+    must make that visible so operators don't mistake spawned=[] for a dead
+    watchdog.
+    """
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="later", assignee="worker")
+        assert kb.schedule_task(conn, tid, reason="wait for window")
+
+        res = kb.dispatch_once(conn, dry_run=True)
+
+        assert tid in res.parked_scheduled
+        assert res.spawned == []
+    finally:
+        conn.close()
+
+
+def test_dispatch_reports_children_waiting_on_blocked_parent(kanban_home, all_assignees_spawnable):
+    """A rescue/remediation ticket linked under the blocked task it should fix
+    is a deadlock. The dispatcher can't infer intent safely, but it should
+    report the blocked-parent dependency in its normal result.
+    """
+    conn = kb.connect()
+    try:
+        parent = kb.create_task(conn, title="blocked parent", assignee="worker")
+        child = kb.create_task(
+            conn,
+            title="rescue blocked parent",
+            assignee="worker",
+            parents=[parent],
+        )
+        assert kb.block_task(conn, parent, reason="needs rescue")
+
+        res = kb.dispatch_once(conn, dry_run=True)
+
+        assert (child, parent, "blocked") in res.blocked_by_parent
+        assert child not in [tid for tid, _who, _ws in res.spawned]
+    finally:
+        conn.close()


### PR DESCRIPTION
## Summary
- surface assigned `scheduled` tasks in `hermes kanban dispatch` output as parked/non-dispatchable
- surface `todo`/`scheduled` children waiting on blocked parents so rescue-task dependency deadlocks are visible
- add CLI copy explaining that scheduled tasks require `hermes kanban unblock <id>` before dispatch

## Why
A remediation/unblock task can look ignored by the watchdog when it is either parked in `scheduled` or linked under the blocked task it is meant to repair. The dispatcher was doing the safe thing, but the operator got an empty `spawned=[]` result with no actionable reason.

## Test plan
- `python -m pytest tests/hermes_cli/test_kanban_core_functionality.py -q -k 'scheduled_tasks_as_parked or children_waiting_on_blocked_parent' -o 'addopts='`
