### PR TITLE
fix(kanban): allow review gates with active PRs

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -4493,11 +4493,17 @@ def check_respawn_guard(conn: sqlite3.Connection, task_id: str) -> Optional[str]
     genuinely dead (no live PID on this host).
     """
     row = conn.execute(
-        "SELECT last_failure_error FROM tasks WHERE id = ?",
+        "SELECT title, body, last_failure_error FROM tasks WHERE id = ?",
         (task_id,),
     ).fetchone()
     if row is None:
         return None
+    title_body = f"{row['title'] or ''}\n{row['body'] or ''}".lower()
+    is_review_gate = (
+        "review/merge/close" in title_body
+        or "independent review gate" in title_body
+        or "review gate" in title_body
+    )
 
     # 1. Quota / auth blocker: retrying immediately will not help.
     err = row["last_failure_error"]
@@ -4516,6 +4522,11 @@ def check_respawn_guard(conn: sqlite3.Connection, task_id: str) -> Optional[str]
         return "recent_success"
 
     # 3. GitHub PR URL in a recent comment — prior worker already opened a PR.
+    # Do not apply this to explicit review/merge/close gates: their whole job
+    # is to inspect an active PR, and blocking them on ``active_pr`` strands
+    # the workflow after a remediation task completes.
+    if is_review_gate:
+        return None
     pr_cutoff = now - _RESPAWN_GUARD_PR_WINDOW
     for c in conn.execute(
         "SELECT body FROM task_comments WHERE task_id = ? AND created_at >= ?",

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -4419,3 +4419,33 @@ def test_dispatch_once_stale_disabled_when_timeout_zero(kanban_home, monkeypatch
         )
         assert res.stale == [], "stale_timeout_seconds=0 should disable detection"
         assert kb.get_task(conn, t).status == "running"
+
+
+def test_respawn_guard_allows_review_gate_with_active_pr_comment(kanban_home, all_assignees_spawnable):
+    """Review/merge/close gates must be allowed to spawn even when comments
+    contain PR URLs; reviewing an active PR is their purpose.
+    """
+    conn = kb.connect()
+    try:
+        parent = kb.create_task(conn, title="implementation", assignee="worker")
+        kb.complete_task(conn, parent, summary="opened PR")
+        review = kb.create_task(
+            conn,
+            title="Review/Merge/Close #123: feature",
+            body="Independent review gate for implementation task.",
+            assignee="worker",
+            parents=[parent],
+        )
+        kb.add_comment(
+            conn,
+            review,
+            "worker",
+            "PR is https://github.com/example/repo/pull/123 and needs review",
+        )
+
+        assert kb.check_respawn_guard(conn, review) is None
+        res = kb.dispatch_once(conn, dry_run=True)
+
+        assert review in [tid for tid, _who, _ws in res.spawned]
+    finally:
+        conn.close()


### PR DESCRIPTION
## Summary
- detect explicit review/merge/close Kanban gates in `check_respawn_guard`
- bypass the `active_pr` respawn guard for those review gates
- add regression coverage for a review gate with a recent PR URL comment

## Why
The `active_pr` guard is useful for implementation tasks because it prevents duplicate PR-producing workers. It is wrong for review gates, whose purpose is to inspect an already-open PR. In that case the guard strands the workflow after remediation completes.

## Test plan
- `python -m pytest tests/hermes_cli/test_kanban_core_functionality.py -q -k 'review_gate_with_active_pr_comment' -o 'addopts='`
