### PR TITLE
fix(dashboard): stop ChatPage from clearing other pages' header slots

### DIFF
--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -217,14 +217,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
   useEffect(() => {
     // When hidden (non-chat tab) we must not register the header button —
     // another page owns the header's end slot at that point.
-    if (!isActive) {
-      setEnd(null);
-      return;
-    }
-    if (!narrow) {
-      setEnd(null);
-      return;
-    }
+    if (!isActive || !narrow) return;
     setEnd(
       <Button
         ghost


### PR DESCRIPTION
Fixes #30884

## Problem

When the dashboard is started with embedded TUI chat enabled (`hermes dashboard --tui`), navigating to the **Sessions** page shows the search box in the page header correctly on initial load. However, after 3–4 seconds the search box disappears.

This happens because `ChatPage` is mounted **persistently** outside `<Routes>` (so the PTY / WebSocket survive tab switches). Even when the user is on `/sessions`, `ChatPage` is still in the React tree with `isActive=false`. Its `useEffect` for the header button actively calls `setEnd(null)` on every render when `!isActive`, clobbering the search box that `SessionsPage` just placed in the same slot.

The trigger for the ~3–4 second timing is the **plugin load delay**: `usePlugins()` fetches manifests asynchronously and renders a loading state; once the promise settles (or 404s), the entire tree re-renders, ChatPage's effect fires, and the header slot is wiped.

## Root Cause

`ChatPage` uses an effect that **actively clears** the header slot when it shouldn't own it:

```tsx
useEffect(() => {
  if (!isActive) {
    setEnd(null);  // ← runs on EVERY render while on /sessions
    return;
  }
  if (!narrow) {
    setEnd(null);  // ← also clears on wide layout
    return;
  }
  setEnd(<Button ... />);
  return () => setEnd(null);
}, [...]);
```

Because `ChatPage` never unmounts, this effect re-runs whenever any state change causes a re-render (plugin loading, resize, etc.). `PageHeaderProvider` already clears all slots on `pathname` change via `useLayoutEffect`, so ChatPage's active clearing is redundant and harmful.

## Fix

Change the effect to **only register when Chat should own the slot**, and let the cleanup run only when it actually did:

```tsx
// Before (buggy): actively clears other pages' content
useEffect(() => {
  if (!isActive) {
    setEnd(null);  // ← clears Sessions search box!
    return;
  }
  if (!narrow) {
    setEnd(null);  // ← also clears!
    return;
  }
  setEnd(<Button ... />);
  return () => setEnd(null);
}, [...]);

// After (fixed): only cleanup on unmount / when Chat owned the slot
useEffect(() => {
  if (!isActive || !narrow) return;  // just don't register
  setEnd(<Button ... />);
  return () => setEnd(null);  // cleanup only when Chat owned the slot
}, [...]);
```

## Safety Analysis

| Scenario | Before | After |
|----------|--------|-------|
| Direct load /sessions | Slots cleared by pathname effect, then set by SessionsPage | Same |
| Navigate /sessions → /chat (wide) | ChatPage clears, pathname effect clears (redundant) | pathname effect clears, ChatPage doesn't set → Same result |
| Navigate /sessions → /chat (narrow) | ChatPage clears, then sets button | pathname effect clears, ChatPage sets button → Same result |
| Resize wide → narrow while on /chat | ChatPage clears, then sets button | ChatPage sets button → Same result |
| Plugin delay causes re-render on /sessions | ChatPage clears Sessions' search box | ChatPage does nothing; search box stays → **Fixed** |

No behavior change for Chat itself; only stops the erroneous clearing of other pages' header content.

## Verification

- Reproduced on clean community `main`: Sessions search box disappears after plugin 404 delay (~3–4 s)
- Fix applied: search box persists correctly across navigation and plugin delays

🤖 Generated with [Claude Code](https://claude.com/claude-code)