### PR TITLE
feat(skills): add antigravity-cli operator skill

### DIFF
--- a/skills/productivity/antigravity-cli/SKILL.md
+++ b/skills/productivity/antigravity-cli/SKILL.md
@@ -1,0 +1,206 @@
+---
+name: antigravity-cli
+description: Antigravity CLI (`agy`) usage, configuration, authentication, plugins, permissions, sandboxing, slash commands, and troubleshooting.
+version: 1.0.0
+author: Hermes Agent
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [antigravity, agy, cli, productivity, auth, plugins, sandbox, permissions]
+---
+
+# Antigravity CLI (`agy`)
+
+Use this skill when working with the Antigravity CLI, invoked as `agy`.
+
+## Mental model
+
+Antigravity has two layers:
+
+1. **Shell wrapper commands** like `agy help`, `agy install`, `agy plugin`, `agy update`, and `agy changelog`
+2. **Interactive in-session slash commands** like `/config`, `/permissions`, `/skills`, and `/agents`
+
+Do not blur those together. `agy help` shows the shell wrapper surface, not the in-session slash command list.
+
+## Core paths
+
+- Binary / entrypoint: `agy`
+- App data dir: `~/.gemini/antigravity-cli/`
+- Settings file: `~/.gemini/antigravity-cli/settings.json`
+- Keybindings file: `~/.gemini/antigravity-cli/keybindings.json`
+- Logs: `~/.gemini/antigravity-cli/log/cli-*.log`
+- Conversations: `~/.gemini/antigravity-cli/conversations/`
+- Brain artifacts: `~/.gemini/antigravity-cli/brain/`
+- History: `~/.gemini/antigravity-cli/history.jsonl`
+- Plugin staging: `~/.gemini/antigravity-cli/plugins/<plugin_name>/`
+
+## Shell surface
+
+### Verified wrapper commands
+
+- `agy changelog`
+- `agy help`
+- `agy install`
+- `agy plugin` / `agy plugins`
+- `agy update`
+
+### Useful flags
+
+- `--add-dir`
+- `--continue` / `-c`
+- `--conversation`
+- `--dangerously-skip-permissions`
+- `--print` / `-p`
+- `--print-timeout`
+- `--prompt`
+- `--prompt-interactive` / `-i`
+- `--sandbox`
+- `--log-file`
+- `--version`
+
+### Plugin subcommands
+
+`agy plugin --help` shows:
+
+- `list`
+- `import [source]`
+- `install <target>`
+- `uninstall <name>`
+- `enable <name>`
+- `disable <name>`
+- `validate [path]`
+- `link <mp> <target>`
+- `help`
+
+### Install flags
+
+`agy install --help` shows:
+
+- `--dir`
+- `--skip-aliases`
+- `--skip-path`
+
+### Version check gotcha
+
+- `agy --version` is the safe non-interactive version check.
+- `agy version` is interactive and can fail without a real TTY.
+
+## In-session slash commands
+
+### Conversation control
+
+- `/resume` or `/switch`
+- `/rewind` or `/undo`
+- `/rename <name>`
+- `/clear`
+- `/fork`
+- `/reset`
+- `/new`
+
+### Settings and tools
+
+- `/config`
+- `/settings`
+- `/permissions`
+- `/model`
+- `/keybindings`
+- `/statusline`
+- `/tasks`
+- `/skills`
+- `/mcp`
+- `/open <path>`
+- `/usage`
+- `/logout`
+- `/agents`
+
+### Prompt helpers
+
+- `@` starts path autocomplete
+- `esc esc` clears the prompt when nothing is streaming
+- `!` at the start runs a terminal command directly
+- `?` opens help and the slash command list
+
+## Settings and permissions
+
+### Common settings keys
+
+The local `settings.json` typically contains keys such as:
+
+- `allowNonWorkspaceAccess`
+- `colorScheme`
+- `permissions.allow`
+- `trustedWorkspaces`
+
+### Permission modes
+
+Docs and runtime logs show these permission modes / concepts:
+
+- `request-review`
+- `always-proceed`
+- `strict`
+- `proceed-in-sandbox`
+
+### Sandbox behavior
+
+- `enableTerminalSandbox` is a boolean in `settings.json`
+- Default is `false`
+- Launch-time overrides such as `--sandbox` and `--dangerously-skip-permissions` can supersede persistent settings for the current session
+
+## Authentication behavior
+
+- The CLI tries the OS secure keyring first.
+- If no saved session exists, it falls back to browser-based Google sign-in.
+- On a local machine, it opens the default browser.
+- Over SSH, it prints a secure authorization URL and expects the auth code to be pasted back.
+- `/logout` removes saved credentials.
+
+## Plugins
+
+- Plugins are staged under `~/.gemini/antigravity-cli/plugins/<plugin_name>/`.
+- Plugins can bundle skills, agents, rules, MCP servers, and hooks.
+- `agy plugin list` returning no imported plugins is a valid empty state.
+
+## Prompt-mode verification
+
+`agy --print` is useful for non-interactive smoke tests and one-shot prompts.
+Use it when you want the CLI to answer without opening the full TUI.
+
+## Troubleshooting and gotchas
+
+- `agy help` shows wrapper commands, not the interactive slash commands.
+- The first place to look for failures is `~/.gemini/antigravity-cli/log/cli-*.log`.
+- Do not confuse persistent JSON settings with launch-time overrides.
+- `~/.gemini/antigravity-cli/bin/agentapi` is only a thin wrapper to `agy agentapi`.
+- On WSL, token storage is file-based, so auth issues are often local-file or session-state problems, not browser-only problems.
+- Workspace identity can depend on launch directory and the `.antigravitycli` project marker.
+
+## Practical verification checklist
+
+When you need to confirm the install is real and usable:
+
+1. `command -v agy`
+2. `agy --version`
+3. `agy help`
+4. `agy plugin list`
+5. Read `~/.gemini/antigravity-cli/settings.json`
+6. Read the latest `~/.gemini/antigravity-cli/log/cli-*.log`
+7. If needed, inspect `~/.gemini/antigravity-cli/keybindings.json`
+
+## Good support posture
+
+Be explicit about the distinction between:
+
+- shell-level `agy` commands
+- in-session slash commands
+- settings-file config
+- plugin staging
+- auth state
+- WSL token storage
+- workspace/project discovery
+
+If you blur those, the guidance will be wrong.
+
+## Support files
+
+- `references/cli-docs.md` — condensed notes from the getting-started, usage, and features docs.

--- a/skills/productivity/antigravity-cli/references/cli-docs.md
+++ b/skills/productivity/antigravity-cli/references/cli-docs.md
@@ -1,0 +1,64 @@
+# Antigravity CLI docs, condensed
+
+Source pages reviewed:
+- `/docs/cli-getting-started`
+- `/docs/cli-using`
+- `/docs/cli-features`
+
+## Install
+- macOS/Linux: `curl -fsSL https://antigravity.google/cli/install.sh | bash`
+- Windows PowerShell: `irm https://antigravity.google/cli/install.ps1 | iex`
+- Windows CMD: `curl -fsSL https://antigravity.google/cli/install.cmd -o install.cmd && install.cmd && del install.cmd`
+
+## Authentication
+- Tries secure keyring first.
+- If no saved session exists, falls back to browser-based Google sign-in.
+- Local machine: opens the default browser.
+- SSH/remote: prints a secure authorization URL, then expects the auth code to be pasted back.
+- `/logout` removes saved credentials.
+
+## Config and files
+- Settings: `~/.gemini/antigravity-cli/settings.json`
+- Keybindings: `~/.gemini/antigravity-cli/keybindings.json`
+- Plugins: `~/.gemini/antigravity-cli/plugins/<plugin_name>/`
+
+## Useful slash commands
+- `/config`, `/settings`
+- `/permissions`
+- `/resume` / `/switch`
+- `/rewind` / `/undo`
+- `/rename <name>`
+- `/model`
+- `/keybindings`
+- `/statusline`
+- `/tasks`
+- `/skills`
+- `/mcp`
+- `/open <path>`
+- `/usage`
+- `/logout`
+- `/agents`
+
+## Prompt helpers
+- `@` path autocomplete
+- `esc esc` clears prompt when not streaming
+- `!` runs a terminal command
+- `?` opens help / slash command list
+
+## Permissions and sandbox
+- Permission modes: `request-review`, `always-proceed`, `strict`, `proceed-in-sandbox`
+- Launch overrides: `--sandbox`, `--dangerously-skip-permissions`
+- Sandbox setting: `enableTerminalSandbox` in `settings.json` (default `false`)
+
+## Plugins
+- Plugins can bundle skills, agents, rules, MCP servers, and hooks.
+- They are staged locally and auto-discovered once installed.
+
+## Subagents
+- `/agents` opens the panel for active/completed subagents.
+- Subagents can run in parallel and request approvals.
+
+## Keybindings
+- `~/.gemini/antigravity-cli/keybindings.json`
+- Malformed JSON falls back to defaults for broken actions.
+- Docs list default bindings for clear, submit, cancel, exit, suspend, editor, approval yes/no, navigation, clipboard, undo/redo, and newline insertion.


### PR DESCRIPTION
## Summary

Add a new official `antigravity-cli` skill under `skills/productivity/`, plus a compact reference file with the reviewed docs notes.

This gives Hermes a proper operator guide for Antigravity CLI instead of leaving it as an ad hoc local artifact.

## What’s included

- `skills/productivity/antigravity-cli/SKILL.md`
- `skills/productivity/antigravity-cli/references/cli-docs.md`

## What the skill covers

- Shell wrapper commands vs in-session slash commands
- Core paths for settings, keybindings, logs, conversations, brain artifacts, and plugin staging
- Authentication flow and logout behavior
- Permissions and sandbox modes
- Plugin commands and install flags
- Prompt helpers and troubleshooting notes

## Why this matters

Antigravity CLI is now documented as a first-class Hermes skill, so operators can use it consistently without re-discovering the same file paths, commands, and gotchas every time.

## Validation

Locally reviewed the staged diff and smoke-checked the installed `agy` binary behavior, including:
- `agy --version`
- `agy help`
- `agy plugin list`
- `agy --print`
- `/model`
- `/permissions`
- `/mcp`
- `/skills`
- `/agents`

## Notes

This is a docs and skill addition only. No runtime code changes.
