### PR TITLE
fix: exponential backoff for rate-limit fallback cooldown

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -896,6 +896,7 @@ def restore_primary_runtime(agent) -> bool:
         # ── Reset fallback chain for the new turn ──
         agent._fallback_activated = False
         agent._fallback_index = 0
+        agent._rate_limit_backoff_count = 0  # reset exponential backoff counter
 
         logging.info(
             "Primary runtime restored for new turn: %s (%s)",

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -705,7 +705,16 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
         current_provider = (getattr(agent, "provider", "") or "").strip().lower()
         primary_provider = ((agent._primary_runtime or {}).get("provider") or "").strip().lower()
         if (not fallback_already_active) or (primary_provider and current_provider == primary_provider):
-            agent._rate_limited_until = time.monotonic() + 60
+            # Exponential backoff: 30min → 1h → 2h → 4h cap
+            # Counter is reset by restore_primary_runtime on successful restore.
+            backoff_count = getattr(agent, "_rate_limit_backoff_count", 0)
+            agent._rate_limit_backoff_count = backoff_count + 1
+            backoff_seconds = min(1800 * (2 ** backoff_count), 14400)
+            agent._rate_limited_until = time.monotonic() + backoff_seconds
+            logging.info(
+                "Rate-limit backoff level %d: cooldown %d s (%.1f min, backoff#%d)",
+                backoff_count, backoff_seconds, backoff_seconds / 60, backoff_count + 1,
+            )
     if agent._fallback_index >= len(agent._fallback_chain):
         return False
 


### PR DESCRIPTION
## Problem

When a provider returns rate-limit (429) or billing errors, the fallback mechanism sets a fixed 60-second cooldown before the primary provider can be retried. In sustained degradation scenarios, this causes the agent to re-hit the same rate-limited provider every 60 seconds until the fallback chain is exhausted — wasting tokens on guaranteed-to-fail requests.

## Solution

Replace the fixed 60-second cooldown with exponential backoff:

| Attempt | Cooldown |
|---------|----------|
| 1st     | 30 min   |
| 2nd     | 1 hour   |
| 3rd     | 2 hours  |
| 4th+    | 4 hours (cap) |

The backoff counter is reset by `restore_primary_runtime` when the primary provider is successfully restored, so backoff only applies to **consecutive** failures within a single degradation window. A healthy provider that fails once then recovers on the next turn resets the counter.

## Changes

- `agent/chat_completion_helpers.py`: Replace fixed cooldown in `try_activate_fallback` with `min(1800 * 2^n, 14400)` seconds
- `agent/agent_runtime_helpers.py`: Add counter reset in `restore_primary_runtime` alongside existing fallback chain resets

## Related

Closes #29702