### PR TITLE
fix(custom-provider): preserve base URL for anthropic_messages api_mode

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -3270,7 +3270,13 @@ def resolve_provider_client(
     # ── Custom endpoint (OPENAI_BASE_URL + OPENAI_API_KEY) ───────────
     if provider == "custom":
         if explicit_base_url:
-            custom_base = _to_openai_base_url(explicit_base_url).strip()
+            # anthropic_messages mode: keep the original /anthropic base URL so
+            # the Anthropic SDK appends /v1/messages correctly.  Rewriting to /v1
+            # would produce /v1/v1/messages (404).  Only rewrite for OpenAI-wire paths.
+            if api_mode == "anthropic_messages":
+                custom_base = explicit_base_url.strip().rstrip("/")
+            else:
+                custom_base = _to_openai_base_url(explicit_base_url).strip()
             custom_key = (
                 (explicit_api_key or "").strip()
                 or os.getenv("OPENAI_API_KEY", "").strip()


### PR DESCRIPTION
## Problem

When a custom provider is configured with `api_mode: anthropic_messages`, the code in `resolve_provider_client()` unconditionally rewrites the base URL via `_to_openai_base_url()`, converting e.g. `http://host/anthropic` → `http://host/v1`.

The Anthropic SDK then appends `/v1/messages` to the base URL, resulting in a request to `/v1/v1/messages` → **404**.

## Root Cause

The generic `custom` provider branch (~line 3271) lacks the `api_mode` guard that the named custom-provider branch (~line 3380) already has:

```python
# named-custom branch (correct)
if entry_api_mode == "anthropic_messages":
    # keeps custom_base as-is
else:
    openai_base = _to_openai_base_url(custom_base)
```

The generic branch was missing this check entirely.

## Fix

Apply the same guard to the generic `custom` branch: when `api_mode == "anthropic_messages"`, keep the original base URL (only strip trailing slash). For all other api_modes, the existing `_to_openai_base_url()` rewrite is preserved.

## Testing

Reproduced and verified with a local Anthropic-compatible proxy (`base_url: http://localhost:6655/anthropic`, `api_mode: anthropic_messages`). Before the fix: 404 on every call. After: requests route correctly to `/anthropic/v1/messages`.