### PR TITLE
fix: refresh child agent prompt context

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,9 @@ web/public/ds-assets/
 .release_notes.md
 mini-swe-agent/
 
+# Local Hermes workspace artifacts/plans
+.hermes/
+
 # Nix
 .direnv/
 .nix-stamps/

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -369,6 +369,49 @@ class TestDelegateTask(unittest.TestCase):
             self.assertEqual(kwargs["provider"], parent.provider)
             self.assertEqual(kwargs["api_mode"], parent.api_mode)
 
+    def test_child_spawn_loads_soul_identity_even_when_project_context_skipped(self):
+        parent = _make_mock_parent(depth=0)
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            mock_child = MagicMock()
+            MockAgent.return_value = mock_child
+
+            _build_child_agent(
+                task_index=0,
+                goal="Use current profile identity",
+                context=None,
+                toolsets=None,
+                model=None,
+                max_iterations=10,
+                parent_agent=parent,
+                task_count=1,
+            )
+
+        _, kwargs = MockAgent.call_args
+        self.assertTrue(kwargs["skip_context_files"])
+        self.assertTrue(kwargs["load_soul_identity"])
+
+    def test_child_spawn_refreshes_skill_prompt_cache_before_agent_construction(self):
+        parent = _make_mock_parent(depth=0)
+
+        with patch("agent.prompt_builder.clear_skills_system_prompt_cache") as clear_cache, \
+             patch("run_agent.AIAgent") as MockAgent:
+            mock_child = MagicMock()
+            MockAgent.return_value = mock_child
+
+            _build_child_agent(
+                task_index=0,
+                goal="Use current skill index",
+                context=None,
+                toolsets=None,
+                model=None,
+                max_iterations=10,
+                parent_agent=parent,
+                task_count=1,
+            )
+
+        clear_cache.assert_called_once_with(clear_snapshot=True)
+
     def test_child_inherits_parent_print_fn(self):
         parent = _make_mock_parent(depth=0)
         sink = MagicMock()

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1017,6 +1017,17 @@ def _build_child_agent(
 
         child_thinking_cb = _child_thinking
 
+    # A task spawn must see the current on-disk profile/skill guidance, not a
+    # stale index held by a long-running parent gateway/CLI process.  SOUL.md is
+    # read by the child AIAgent via load_soul_identity=True below, and clearing
+    # the skills prompt caches forces SKILL.md metadata to be revalidated before
+    # the child system prompt is assembled.
+    try:
+        from agent.prompt_builder import clear_skills_system_prompt_cache
+        clear_skills_system_prompt_cache(clear_snapshot=True)
+    except Exception as exc:
+        logger.debug("Could not refresh prompt inputs before subagent spawn: %s", exc)
+
     # Resolve effective credentials: config override > parent inherit
     effective_model = model or parent_agent.model
     effective_provider = override_provider or getattr(parent_agent, "provider", None)
@@ -1122,6 +1133,7 @@ def _build_child_agent(
         log_prefix=f"[subagent-{task_index}]",
         platform=parent_agent.platform,
         skip_context_files=True,
+        load_soul_identity=True,
         skip_memory=True,
         clarify_callback=None,
         thinking_callback=child_thinking_cb,


### PR DESCRIPTION
## Summary
- Refresh skill prompt cache before constructing delegated child agents so long-running parent processes do not spawn children with stale skill guidance
- Load SOUL identity for child agents even when project context files are skipped
- Ignore local .hermes workspace artifacts in this checkout

## Test Plan
- venv/bin/python -m pytest tests/tools/test_delegate.py -q