### PR TITLE
fix(cron): avoid standalone fallback on rate limit

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -596,6 +596,16 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                         raise
                     if send_result and not getattr(send_result, "success", True):
                         err = getattr(send_result, "error", "unknown")
+                        err_text = str(err).lower()
+                        # Avoid duplicate send storms on upstream rate limits.
+                        # When live adapter returns rate-limit style errors, do NOT
+                        # immediately fall back to standalone (which hits the same
+                        # upstream API again). Surface delivery error directly.
+                        if ("rate limited" in err_text) or ("rate limit" in err_text) or ("ret=-2" in err_text):
+                            msg = f"delivery error: {err}"
+                            logger.error("Job '%s': %s", job["id"], msg)
+                            delivery_errors.append(msg)
+                            continue
                         logger.warning(
                             "Job '%s': live adapter send to %s:%s failed (%s), falling back to standalone",
                             job["id"], platform_name, chat_id, err,

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -804,6 +804,57 @@ class TestDeliverResultErrorReturns:
         assert result is not None
         assert "no delivery target" in result
 
+    def test_live_adapter_rate_limit_does_not_fallback_to_standalone(self):
+        """Rate-limited live-adapter sends should return delivery error directly
+        and must NOT trigger standalone fallback (prevents duplicate send storms)."""
+        from gateway.config import Platform
+        from concurrent.futures import Future
+
+        adapter = AsyncMock()
+        adapter.send.return_value = MagicMock(
+            success=False,
+            error="iLink sendmessage rate limited: ret=-2 errcode=None errmsg=rate limited",
+        )
+
+        pconfig = MagicMock()
+        pconfig.enabled = True
+        mock_cfg = MagicMock()
+        mock_cfg.platforms = {Platform.WEIXIN: pconfig}
+
+        loop = MagicMock()
+        loop.is_running.return_value = True
+
+        def fake_run_coro(coro, _loop):
+            future = Future()
+            future.set_result(MagicMock(
+                success=False,
+                error="iLink sendmessage rate limited: ret=-2 errcode=None errmsg=rate limited",
+            ))
+            coro.close()
+            return future
+
+        job = {
+            "id": "wx-rate-limit-job",
+            "deliver": "origin",
+            "origin": {"platform": "weixin", "chat_id": "o9cq80-qjsrglS3v5UNo29vHCtNw@im.wechat"},
+        }
+
+        with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}), \
+             patch("asyncio.run_coroutine_threadsafe", side_effect=fake_run_coro), \
+             patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True})) as standalone_send:
+            result = _deliver_result(
+                job,
+                "hello",
+                adapters={Platform.WEIXIN: adapter},
+                loop=loop,
+            )
+
+        assert result is not None
+        assert "delivery error:" in result
+        assert "rate limited" in result.lower()
+        standalone_send.assert_not_called()
+
 
 class TestRunJobSessionPersistence:
     def test_run_job_passes_session_db_and_cron_platform(self, tmp_path):


### PR DESCRIPTION
## Summary
- Avoid standalone fallback when live cron delivery fails due to upstream rate limiting
- Prevent duplicate send attempts against the same Weixin/iLink API during rate-limit windows
- Add regression coverage for the no-fallback path

## Test Plan
- `pytest -q tests/cron/test_scheduler.py::TestDeliverResultErrorReturns::test_live_adapter_rate_limit_does_not_fallback_to_standalone`
