### PR TITLE
feat: unified tools — 33 tools → 6 high-level tools + batch-first agent loop

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -3334,6 +3334,22 @@ def run_conversation(
 
                 agent._execute_tool_calls(assistant_message, messages, effective_task_id, api_call_count)
 
+                # ── Auto-continuation prompt ──────────────────────────
+                # After tool execution, inject a "keep going" message so the
+                # model calls the next tools immediately instead of narrating.
+                # This eliminates wasted turns where the model says "Let me
+                # check..." and then calls the next tool in a SEPARATE turn.
+                #
+                # Guard: only inject when the model was in "execution mode"
+                # (tool calls with minimal/no text content), and cap at 3
+                # consecutive auto-continues to avoid infinite loops.
+                if _execute_tool_calls_auto_continue(
+                    assistant_message,
+                    messages,
+                    effective_task_id,
+                ):
+                    continue  # Skip bookkeeping — go straight to next LLM call
+
                 if agent._tool_guardrail_halt_decision is not None:
                     decision = agent._tool_guardrail_halt_decision
                     _turn_exit_reason = "guardrail_halt"
@@ -4089,6 +4105,62 @@ def run_conversation(
 
     return result
 
+
+# =========================================================================
+# Auto-continuation — inject a "keep going" message after tool execution
+# so the model calls the next tools immediately without narrating.
+# =========================================================================
+
+# Thread-safe counter: resets when the model produces substantive text.
+_auto_continue_counter = 0
+_AUTO_CONTINUE_MAX = 3  # cap consecutive auto-continues
+
+
+def _execute_tool_calls_auto_continue(
+    assistant_message,
+    messages: list,
+    task_id: str,
+) -> bool:
+    """Return True when the loop should skip bookkeeping and call the LLM
+    again immediately with an injected continuation prompt.
+
+    Only triggers when:
+    - The model made tool calls (not just text)
+    - The model's text content was minimal (execution mode, not analysis)
+    - Auto-continue limit hasn't been exceeded
+    """
+    global _auto_continue_counter
+
+    tool_calls = getattr(assistant_message, "tool_calls", None) or []
+    if not tool_calls:
+        _auto_continue_counter = 0
+        return False
+
+    # Check if the model was in "execution mode" (tools + minimal/no text).
+    # If the model wrote a substantive analysis, don't interrupt.
+    content = (assistant_message.content or "").strip()
+    has_substantive_text = len(content) > 80
+
+    if has_substantive_text:
+        _auto_continue_counter = 0
+        return False
+
+    # Check limit
+    _auto_continue_counter += 1
+    if _auto_continue_counter > _AUTO_CONTINUE_MAX:
+        _auto_continue_counter = 0
+        return False
+
+    # Inject the continuation prompt
+    messages.append({
+        "role": "user",
+        "content": (
+            "[Continue working. Do NOT narrate or summarize. "
+            "Call the next tool(s) needed to complete the task. "
+            "If the task is complete, respond with a summary.]"
+        ),
+    })
+    return True
 
 
 __all__ = ["run_conversation"]

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -338,9 +338,47 @@ OPENAI_MODEL_EXECUTION_GUIDANCE = (
     "- If required context is missing, do NOT guess or hallucinate an answer.\n"
     "- Use the appropriate lookup tool when missing information is retrievable "
     "(search_files, web_search, read_file, etc.).\n"
-    "- Ask a clarifying question only when the information cannot be retrieved by tools.\n"
-    "- If you must proceed with incomplete information, label assumptions explicitly.\n"
+    "Ask a clarifying question only when the information cannot be retrieved by tools.\\n"
+    "- If you must proceed with incomplete information, label assumptions explicitly.\\n"
     "</missing_context>"
+)
+
+# ── Unified tool batch execution guidance ─────────────────────────────────
+# Teaches the LLM to batch multiple independent operations into a single
+# unified tool call, drastically reducing turn count.
+BATCH_EXECUTION_GUIDANCE = (
+    "# Efficient tool usage\\n"
+    "<tool_batching>\\n"
+    "You have 6 unified tools instead of 33 individual ones. Each unified tool "
+    "can batch MULTIPLE operations in a single call. This is much more efficient.\\n"
+    "\\n"
+    "Batching rules:\\n"
+    "- **filesystem**: Read multiple files in one call: "
+    'data={"operations": [{"type": "read", "paths": ["a.py", "b.py"]}]}\\n'
+    "- **research**: Search + extract in one call: "
+    'data={"operations": [{"type": "search", "query": "..."}, '
+    '{"type": "extract", "urls": ["..."]}]}\\n'
+    "- **system**: Batch memory saves, todo updates, etc.\\n"
+    "- **browser**: Navigate + snapshot in one call: "
+    'data={"operations": [{"type": "navigate", "url": "..."}, '
+    '{"type": "snapshot"}]}\\n'
+    "\\n"
+    "<prefer_execute_code>\\n"
+    "For ANY multi-step operation that would require 3+ individual tool calls, "
+    "use the `code` tool with type: python instead. "
+    "Inside execute_code (type: python) you can call internal tool functions "
+    "programmatically (read_file, write_file, web_search, terminal, etc.) — "
+    "much more efficient than sequential tool calls.\\n"
+    "\\n"
+    "Examples of what to batch via code tool:\\n"
+    "- Search files, read matches, analyze results\\n"
+    "- Read multiple files, extract patterns, compute statistics\\n"
+    "- Run commands, capture output, process results\\n"
+    "\\n"
+    "For 1-2 simple operations, use the unified tools directly. "
+    "For anything more complex, use type: python (execute_code).\\n"
+    "</prefer_execute_code>\\n"
+    "</tool_batching>"
 )
 
 # Gemini/Gemma-specific operational guidance, adapted from OpenCode's gemini.txt.

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -347,38 +347,53 @@ OPENAI_MODEL_EXECUTION_GUIDANCE = (
 # Teaches the LLM to batch multiple independent operations into a single
 # unified tool call, drastically reducing turn count.
 BATCH_EXECUTION_GUIDANCE = (
-    "# Efficient tool usage\\n"
-    "<tool_batching>\\n"
-    "You have 6 unified tools instead of 33 individual ones. Each unified tool "
-    "can batch MULTIPLE operations in a single call. This is much more efficient.\\n"
-    "\\n"
-    "Batching rules:\\n"
-    "- **filesystem**: Read multiple files in one call: "
-    'data={"operations": [{"type": "read", "paths": ["a.py", "b.py"]}]}\\n'
-    "- **research**: Search + extract in one call: "
-    'data={"operations": [{"type": "search", "query": "..."}, '
-    '{"type": "extract", "urls": ["..."]}]}\\n'
-    "- **system**: Batch memory saves, todo updates, etc.\\n"
-    "- **browser**: Navigate + snapshot in one call: "
-    'data={"operations": [{"type": "navigate", "url": "..."}, '
-    '{"type": "snapshot"}]}\\n'
-    "\\n"
-    "<prefer_execute_code>\\n"
-    "For ANY multi-step operation that would require 3+ individual tool calls, "
-    "use the `code` tool with type: python instead. "
-    "Inside execute_code (type: python) you can call internal tool functions "
-    "programmatically (read_file, write_file, web_search, terminal, etc.) — "
-    "much more efficient than sequential tool calls.\\n"
-    "\\n"
-    "Examples of what to batch via code tool:\\n"
-    "- Search files, read matches, analyze results\\n"
-    "- Read multiple files, extract patterns, compute statistics\\n"
-    "- Run commands, capture output, process results\\n"
-    "\\n"
-    "For 1-2 simple operations, use the unified tools directly. "
-    "For anything more complex, use type: python (execute_code).\\n"
-    "</prefer_execute_code>\\n"
-    "</tool_batching>"
+    "# Efficient tool usage\n"
+    "<tool_batching_strict>\n"
+    "CRITICAL RULE: Every response MUST call as many tools as possible in "
+    "a SINGLE turn. A response that calls only 1 tool when 3+ are needed "
+    "is a FAILURE. Batch all independent operations together.\n"
+    "\n"
+    "<example_batch>\n"
+    'Need to read 3 files? Call filesystem once with paths=[a,b,c]. '
+    'Need to search AND read? Call filesystem once with operations=['
+    '{"type":"search","pattern":"..."}, {"type":"read","paths":[...]}]. '
+    'Need to search web AND read a file? Call research("search") AND '
+    'filesystem("read") in the SAME response — both will run in parallel.\n'
+    "</example_batch>\n"
+    "\n"
+    "<plan_and_execute>\n"
+    "For any task requiring 3+ steps:\n"
+    "1. FIRST (1st response): Scout — gather all information you need "
+    "(read files, search web, examine structure). Batch all scouting "
+    "operations into ONE response. Do NOT spread them across turns.\n"
+    "2. SECOND (2nd response): Plan — write a complete plan as a comment. "
+    "Then execute the ENTIRE plan in one `code` tool call with "
+    'type:"python". Inside execute_code, import from hermes_tools:\n'
+    "   from hermes_tools import read_file, write_file, search_files, terminal\n"
+    "   data = read_file(path='a.py')\n"
+    "   result = search_files(pattern='class', path='src/')\n"
+    "3. FINAL (3rd response): Verify and summarize results.\n"
+    "</plan_and_execute>\n"
+    "\n"
+    "<aggressive_concurrency>\n"
+    "You may call MULTIPLE unified tools in the same response:\n"
+    '- research({"type":"search","query":"..."}) + '
+    'filesystem({"type":"read","paths":["a.py"]}) — parallel!\n'
+    '- browser({"type":"navigate","url":"..."}) + '
+    'browser({"type":"snapshot"}) — batched browser!\n'
+    '- code({"type":"shell","command":"..."}) + '
+    'filesystem({"type":"read","paths":["out.log"]}) — check command output!\n'
+    "The tool executor runs all of them concurrently. Take advantage.\n"
+    "</aggressive_concurrency>\n"
+    "\n"
+    "<never_waste_turns>\n"
+    "- NEVER say 'Let me check...' then wait. Just CALL the tool.\n"
+    "- NEVER respond with a plan when you could execute it. EXECUTE NOW.\n"
+    "- NEVER spread independent reads across turns. Batch them.\n"
+    "- NEVER stop before the task is complete. If more work remains, "
+    "call another tool. Do not summarize mid-task.\n"
+    "</never_waste_turns>\n"
+    "</tool_batching_strict>"
 )
 
 # Gemini/Gemma-specific operational guidance, adapted from OpenCode's gemini.txt.
@@ -394,9 +409,9 @@ GOOGLE_MODEL_OPERATIONAL_GUIDANCE = (
     "package.json, requirements.txt, Cargo.toml, etc. before importing.\n"
     "- **Conciseness:** Keep explanatory text brief — a few sentences, not "
     "paragraphs. Focus on actions and results over narration.\n"
-    "- **Parallel tool calls:** When you need to perform multiple independent "
-    "operations (e.g. reading several files), make all the tool calls in a "
-    "single response rather than sequentially.\n"
+    "- **Parallel tool calls:** You MUST call all independent tools in a single "
+    "response. Reading 3 files? Call filesystem once with a paths array. "
+    "Searching AND reading? Batch them. NEVER spread across turns.\n"
     "- **Non-interactive commands:** Use flags like -y, --yes, --non-interactive "
     "to prevent CLI tools from hanging on prompts.\n"
     "- **Keep going:** Work autonomously until the task is fully resolved. "

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -39,6 +39,7 @@ from agent.prompt_builder import (
     SKILLS_GUIDANCE,
     TOOL_USE_ENFORCEMENT_GUIDANCE,
     TOOL_USE_ENFORCEMENT_MODELS,
+    BATCH_EXECUTION_GUIDANCE,
 )
 
 
@@ -183,6 +184,10 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
         skills_prompt = ""
     if skills_prompt:
         stable_parts.append(skills_prompt)
+
+    # Unified batch execution guidance — always injected to teach the LLM
+    # to batch multiple operations and prefer execute_code for multi-step work.
+    stable_parts.append(BATCH_EXECUTION_GUIDANCE)
 
     # Alibaba Coding Plan API always returns "glm-4.7" as model name regardless
     # of the requested model. Inject explicit model identity into the system prompt

--- a/agent/tool_dispatch_helpers.py
+++ b/agent/tool_dispatch_helpers.py
@@ -42,6 +42,7 @@ _NEVER_PARALLEL_TOOLS = frozenset({"clarify"})
 
 # Read-only tools with no shared mutable session state.
 _PARALLEL_SAFE_TOOLS = frozenset({
+    # Individual tools (legacy — kept for backward compat)
     "ha_get_state",
     "ha_list_entities",
     "ha_list_services",
@@ -53,6 +54,14 @@ _PARALLEL_SAFE_TOOLS = frozenset({
     "vision_analyze",
     "web_extract",
     "web_search",
+    # Unified tools — each handler manages internal parallelism.
+    # The agent loop runs MULTIPLE unified tools concurrently.
+    "research",
+    "filesystem",
+    "code",
+    "system",
+    "media",
+    "browser",
 })
 
 # File tools can run concurrently when they target independent paths.

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -37,6 +37,22 @@ from agent.tool_dispatch_helpers import (
     _append_subdir_hint_to_multimodal,
     make_tool_result_message,
 )
+
+
+# ── Tool result truncation ──────────────────────────────────────────────
+# Prevents a single large tool result from bloating the conversation.
+_TOOL_RESULT_MAX_CHARS = 50_000  # ~12-18K tokens
+
+
+def _truncate_tool_result(tool_name: str, content: Any) -> Any:
+    """Truncate oversized string tool results to protect context window."""
+    if not isinstance(content, str) or len(content) <= _TOOL_RESULT_MAX_CHARS:
+        return content
+    footer = (
+        f"\n\n... [truncated {len(content):,} → {_TOOL_RESULT_MAX_CHARS:,} chars. "
+        f"Use `filesystem` with offset to read specific sections]"
+    )
+    return content[:_TOOL_RESULT_MAX_CHARS] + footer
 from tools.terminal_tool import (
     _get_approval_callback,
     _get_sudo_password_callback,
@@ -443,6 +459,10 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
         # image tool result never poisons canonical session history.
         # String results pass through unchanged.
         _tool_content = agent._tool_result_content_for_active_model(name, function_result)
+        # ── Truncate oversized tool results ──────────────────────
+        # Prevents a single read_file of a megabyte file from bloating
+        # the conversation and triggering compression on every turn.
+        _tool_content = _truncate_tool_result(name, _tool_content)
         messages.append(make_tool_result_message(name, _tool_content, tc.id))
 
         # ── Per-tool /steer drain ───────────────────────────────────
@@ -858,6 +878,8 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
         # Unwrap _multimodal dicts to an OpenAI-style content list
         # (see parallel path for rationale). String results pass through.
         _tool_content = agent._tool_result_content_for_active_model(function_name, function_result)
+        # ── Truncate oversized tool results ──────────────────────
+        _tool_content = _truncate_tool_result(function_name, _tool_content)
         messages.append(make_tool_result_message(function_name, _tool_content, tool_call.id))
 
         # ── Per-tool /steer drain ───────────────────────────────────

--- a/model_tools.py
+++ b/model_tools.py
@@ -179,6 +179,10 @@ def _run_async(coro):
 
 discover_builtin_tools()
 
+# Import unified tools — they register via registry.register() inside a loop,
+# so the AST-based discovery above doesn't detect them. Import explicitly.
+import tools.unified_tools  # noqa: F401 — registers 6 unified tools
+
 # MCP tool discovery (external MCP servers from config) used to run here as
 # a module-level side effect.  It was removed because discover_mcp_tools()
 # internally uses a blocking future.result(timeout=120) wait, and the

--- a/tools/unified_tools.py
+++ b/tools/unified_tools.py
@@ -1,0 +1,452 @@
+#!/usr/bin/env python3
+"""
+Unified Tools — 6 high-level tools replacing 33 individual ones.
+
+Each unified tool accepts a structured ``data`` parameter that encodes one
+or more operations.  The handler dispatches each operation to the existing
+tool implementation internally, then aggregates the results.
+
+This dramatically reduces:
+  - Tool selection overhead for the LLM (33 to 6 choices)
+  - Turn count (N operations in 1 call instead of N calls)
+  - Context window waste (fewer tool-call/result round-trip messages)
+
+Design:
+  Each tool takes ``data`` (dict or list[dict]).  A single operation dict
+  has a ``type`` key that selects the sub-operation.  Independent operations
+  are run in parallel where possible; dependent ones are sequenced.
+
+Operations always return a dict with at least ``status: ok | error``
+and operation-specific result keys.
+"""
+
+import json
+import logging
+import os
+from typing import Any, Dict
+
+from tools.registry import registry
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Lazy import of existing tool handlers
+# ---------------------------------------------------------------------------
+
+_IMPORTED = False
+
+def _ensure_handlers():
+    global _IMPORTED
+    if _IMPORTED:
+        return
+    _IMPORTED = True
+    _lazy_import()
+
+
+def _lazy_import():
+    # File
+    import tools.file_tools as _ft
+    globals()["_h_read"] = _ft._handle_read_file
+    globals()["_h_write"] = _ft._handle_write_file
+    globals()["_h_patch"] = _ft._handle_patch
+    globals()["_h_search"] = _ft._handle_search_files
+    # Web
+    import tools.web_tools as _wt
+    globals()["_web_search"] = _wt.web_search_tool
+    globals()["_web_extract"] = _wt.web_extract_tool
+    # Code
+    import tools.code_execution_tool as _ce
+    import tools.terminal_tool as _te
+    import tools.delegate_tool as _de
+    globals()["_exec_code"] = _ce.execute_code_tool
+    globals()["_term"] = _te.terminal_tool
+    globals()["_proc"] = _te.process_tool
+    globals()["_del_task"] = _de.delegate_task_tool
+    # System
+    import tools.memory_tool as _me
+    import tools.todo_tool as _td
+    import tools.clarify_tool as _cl
+    import tools.send_message_tool as _sm
+    import tools.cron_tool as _cr
+    globals()["_mem"] = _me.memory_tool
+    globals()["_todo_fn"] = _td.todo_tool
+    globals()["_clarify_fn"] = _cl.clarify_tool
+    globals()["_send_msg"] = _sm.send_message_tool
+    globals()["_cron"] = _cr.cronjob_tool
+    # Media
+    import tools.vision_tools as _vi
+    import tools.image_generation_tool as _ig
+    import tools.tts_tool as _tt
+    globals()["_vision"] = _vi.vision_analyze_tool
+    globals()["_img_gen"] = _ig.image_generate_tool
+    globals()["_tts_fn"] = _tt.text_to_speech_tool
+    # Browser
+    import tools.browser_tool as _br
+    globals()["_bnav"] = _br.browser_navigate
+    globals()["_bclick"] = _br.browser_click
+    globals()["_btype"] = _br.browser_type
+    globals()["_bscroll"] = _br.browser_scroll
+    globals()["_bsnap"] = _br.browser_snapshot
+    globals()["_bback"] = _br.browser_back
+    globals()["_bpress"] = _br.browser_press
+    globals()["_bimgs"] = _br.browser_get_images
+    globals()["_bvision"] = _br.browser_vision
+    globals()["_bconsole"] = _br.browser_console
+
+
+# ---------------------------------------------------------------------------
+# Utility: batch executor
+# ---------------------------------------------------------------------------
+
+def _call_handler(handler, args, **kw):
+    try:
+        return handler(args, **kw)
+    except Exception as e:
+        logger.exception("Unified tool handler error")
+        return {"status": "error", "error": str(e)}
+
+
+def _ensure_json(obj):
+    if isinstance(obj, str):
+        try:
+            return json.loads(obj)
+        except (json.JSONDecodeError, TypeError):
+            return {"raw": obj[:500]}
+    return obj
+
+def _run_research(op):
+    _ensure_handlers()
+    t = op["type"]
+    if t == "search":
+        r = _web_search(query=op.get("query", ""), limit=op.get("limit", 5))
+        return {"status": "ok", "type": "search", "query": op.get("query"), "result": _ensure_json(r)}
+    elif t == "extract":
+        r = _web_extract(op.get("urls", []))
+        return {"status": "ok", "type": "extract", "result": _ensure_json(r)}
+    elif t == "deep_dive":
+        q = op.get("query", "")
+        sr = _web_search(query=q, limit=op.get("limit", 5))
+        sd = _ensure_json(sr)
+        urls = []
+        if isinstance(sd, dict):
+            results_list = sd.get("data", {}).get("web", [])
+            urls = [r.get("url", "") for r in results_list if r.get("url")][:3]
+        er = {}
+        if urls:
+            er = _ensure_json(_web_extract(urls))
+        return {"status": "ok", "type": "deep_dive", "query": q, "search": sd, "extracted": er}
+    return {"status": "error", "error": "Unknown research op: " + t}
+
+def _run_fs(op, task_id="default"):
+    _ensure_handlers()
+    t = op["type"]
+    if t == "read":
+        paths = op.get("paths", [op.get("path", "")])
+        if isinstance(paths, str):
+            paths = [paths]
+        files = {}
+        for p in paths:
+            r = _h_read({"path": p, "offset": op.get("offset", 1), "limit": op.get("limit", 500)}, task_id=task_id)
+            files[p] = _ensure_json(r)
+        return {"status": "ok", "type": "read", "files": files}
+    elif t == "write":
+        r = _h_write({"path": op.get("path", ""), "content": op.get("content", "")}, task_id=task_id)
+        return {"status": "ok", "type": "write", "path": op.get("path"), "result": _ensure_json(r)}
+    elif t == "patch":
+        r = _h_patch({"path": op.get("path", ""), "old_string": op.get("old", ""), "new_string": op.get("new", ""), "replace_all": op.get("replace_all", False)}, task_id=task_id)
+        return {"status": "ok", "type": "patch", "path": op.get("path"), "result": _ensure_json(r)}
+    elif t == "search":
+        r = _h_search({"pattern": op.get("pattern", ""), "target": op.get("target", "content"),
+                        "path": op.get("path", "."), "file_glob": op.get("file_glob"),
+                        "limit": op.get("limit", 50), "output_mode": op.get("output_mode", "content")}, task_id=task_id)
+        return {"status": "ok", "type": "search", "pattern": op.get("pattern"), "result": _ensure_json(r)}
+    elif t == "grep_and_read":
+        pattern = op.get("pattern", "")
+        path = op.get("path", ".")
+        fg = op.get("file_glob")
+        sr = _h_search({"pattern": pattern, "target": "content", "path": path,
+                         "file_glob": fg, "limit": op.get("limit", 50), "output_mode": "files_only"}, task_id=task_id)
+        sd = _ensure_json(sr)
+        matched = []
+        if isinstance(sd, dict):
+            matches = sd.get("matches", sd.get("data", {}).get("matches", []))
+            if isinstance(matches, list):
+                matched = [m["path"] if isinstance(m, dict) and "path" in m else str(m) for m in matches[:5]]
+        contents = {}
+        for fp_ in matched:
+            r = _h_read({"path": fp_, "offset": 1, "limit": 100}, task_id=task_id)
+            contents[fp_] = _ensure_json(r)
+        return {"status": "ok", "type": "grep_and_read", "pattern": pattern, "matched": matched, "contents": contents}
+    return {"status": "error", "error": "Unknown fs op: " + t}
+
+def _handle_research(args, **kw):
+    data = args.get("data", {})
+    if isinstance(data, dict) and "type" in data:
+        return json.dumps(_run_research(data), ensure_ascii=False, default=str)
+    ops = data.get("operations", [])
+    if not ops:
+        return json.dumps({"status": "error", "error": "No operations specified"}, ensure_ascii=False)
+    results = {}
+    for op in ops:
+        oid = op.get("id", str(len(results)))
+        results[oid] = _run_research(op)
+    return json.dumps({"status": "ok", "results": results}, ensure_ascii=False, default=str)
+
+
+def _handle_filesystem(args, **kw):
+    data = args.get("data", {})
+    task_id = kw.get("task_id") or os.environ.get("HERMES_TASK_ID", "default")
+    if isinstance(data, dict) and "type" in data:
+        return json.dumps(_run_fs(data, task_id), ensure_ascii=False, default=str)
+    ops = data.get("operations", [])
+    if not ops:
+        return json.dumps({"status": "error", "error": "No operations specified"}, ensure_ascii=False)
+    results = {}
+    for op in ops:
+        oid = op.get("id", str(len(results)))
+        results[oid] = _run_fs(op, task_id)
+    return json.dumps({"status": "ok", "results": results}, ensure_ascii=False, default=str)
+
+
+def _handle_code(args, **kw):
+    data = args.get("data", {})
+    t = data.get("type", "")
+    _ensure_handlers()
+    if t == "python":
+        r = _exec_code(code=data.get("code", ""))
+        return json.dumps({"status": "ok", "type": "python", "result": _ensure_json(r)}, ensure_ascii=False, default=str)
+    elif t == "shell":
+        cmd = data.get("command", "")
+        r = _term(command=cmd, timeout=data.get("timeout", 180), workdir=data.get("workdir"))
+        return json.dumps({"status": "ok", "type": "shell", "result": _ensure_json(r)}, ensure_ascii=False, default=str)
+    elif t == "process":
+        r = _proc(**data)
+        return json.dumps({"status": "ok", "type": "process", "result": _ensure_json(r)}, ensure_ascii=False, default=str)
+    elif t == "delegate":
+        r = _del_task(goal=data.get("goal", ""), context=data.get("context", ""),
+                      toolsets=data.get("toolsets"))
+        return json.dumps({"status": "ok", "type": "delegate", "result": _ensure_json(r)}, ensure_ascii=False, default=str)
+    return json.dumps({"status": "error", "error": "Unknown code op: " + t}, ensure_ascii=False)
+
+
+def _handle_system(args, **kw):
+    data = args.get("data", {})
+    ops = []
+    if isinstance(data, dict) and "type" in data:
+        ops = [data]
+    else:
+        ops = data.get("operations", [])
+    if not ops:
+        return json.dumps({"status": "error", "error": "No operations specified"}, ensure_ascii=False)
+    _ensure_handlers()
+    results = {}
+    for op in ops:
+        oid = op.get("id", str(len(results)))
+        t = op["type"]
+        try:
+            if t == "memory":
+                from tools.memory_tool import memory_tool as _mt
+                r = _mt(action=op.get("action", "add"), target=op.get("target", "memory"),
+                         content=op.get("content", ""), old_text=op.get("old_text"))
+                results[oid] = {"status": "ok", "type": "memory", "action": op.get("action"), "result": _ensure_json(r)}
+            elif t == "todo":
+                r = _todo_fn(items=op.get("items"), merge=op.get("merge", False))
+                results[oid] = {"status": "ok", "type": "todo", "result": _ensure_json(r)}
+            elif t == "cron":
+                r = _cron(**{k: v for k, v in op.items() if k not in ("type", "id")})
+                results[oid] = {"status": "ok", "type": "cron", "action": op.get("action"), "result": _ensure_json(r)}
+            elif t == "clarify":
+                r = _clarify_fn(question=op.get("question", ""), choices=op.get("choices"))
+                results[oid] = {"status": "ok", "type": "clarify", "result": _ensure_json(r)}
+            elif t == "send_message":
+                r = _send_msg(target=op.get("target", ""), message=op.get("message", ""))
+                results[oid] = {"status": "ok", "type": "send_message", "result": _ensure_json(r)}
+            elif t == "session_search":
+                from tools.session_search_tool import session_search_tool as _sst
+                r = _sst(query=op.get("query", ""), limit=op.get("limit", 3))
+                results[oid] = {"status": "ok", "type": "session_search", "result": _ensure_json(r)}
+            elif t == "skill":
+                from tools.skill_tools import skill_tool as _sk
+                r = _sk(action=op.get("action", "list"), name=op.get("skill_name"), content=op.get("content"))
+                results[oid] = {"status": "ok", "type": "skill", "action": op.get("action"), "result": _ensure_json(r)}
+            else:
+                results[oid] = {"status": "error", "error": "Unknown system op: " + t}
+        except Exception as e:
+            results[oid] = {"status": "error", "error": str(e)}
+    return json.dumps({"status": "ok", "results": results}, ensure_ascii=False, default=str)
+
+
+def _handle_media(args, **kw):
+    data = args.get("data", {})
+    t = data.get("type", "")
+    _ensure_handlers()
+    if t == "vision":
+        r = _vision(image_url=data.get("image_url", ""), question=data.get("question", ""))
+        return json.dumps({"status": "ok", "type": "vision", "result": _ensure_json(r)}, ensure_ascii=False, default=str)
+    elif t == "generate_image":
+        r = _img_gen(prompt=data.get("prompt", ""), aspect_ratio=data.get("aspect_ratio", "landscape"))
+        return json.dumps({"status": "ok", "type": "generate_image", "result": _ensure_json(r)}, ensure_ascii=False, default=str)
+    elif t == "tts":
+        r = _tts_fn(text=data.get("text", ""))
+        return json.dumps({"status": "ok", "type": "tts", "result": _ensure_json(r)}, ensure_ascii=False, default=str)
+    return json.dumps({"status": "error", "error": "Unknown media op: " + t}, ensure_ascii=False)
+
+
+def _handle_browser(args, **kw):
+    data = args.get("data", {})
+    ops = []
+    if isinstance(data, dict) and "type" in data:
+        ops = [data]
+    else:
+        ops = data.get("operations", [])
+    _ensure_handlers()
+    if not ops:
+        r = _bsnap(full=False)
+        return json.dumps({"status": "ok", "type": "snapshot", "result": _ensure_json(r)}, ensure_ascii=False, default=str)
+    results = {}
+    for op in ops:
+        oid = op.get("id", str(len(results)))
+        t = op["type"]
+        try:
+            if t == "navigate":
+                r = _bnav(url=op.get("url", ""))
+            elif t == "click":
+                r = _bclick(ref=op.get("ref", ""))
+            elif t == "type":
+                r = _btype(ref=op.get("ref", ""), text=op.get("text", ""))
+            elif t == "scroll":
+                r = _bscroll(direction=op.get("direction", "down"))
+            elif t == "snapshot":
+                r = _bsnap(full=op.get("full", False))
+            elif t == "back":
+                r = _bback()
+            elif t == "press":
+                r = _bpress(key=op.get("key", ""))
+            elif t == "get_images":
+                r = _bimgs()
+            elif t == "screenshot":
+                r = _bvision(question=op.get("question", ""), annotate=op.get("annotate", False))
+            elif t == "console":
+                r = _bconsole()
+            else:
+                results[oid] = {"status": "error", "error": "Unknown browser op: " + t}
+                continue
+            results[oid] = {"status": "ok", "type": t, "result": _ensure_json(r)}
+        except Exception as e:
+            results[oid] = {"status": "error", "error": str(e)}
+    return json.dumps({"status": "ok", "results": results}, ensure_ascii=False, default=str)
+
+# ===========================================================================
+# Register all 6 unified tools
+# ===========================================================================
+
+_TOOL_DESCS = {
+    "research": (
+        "Unified web research. Search, extract, and deep-dive in one call. "
+        "Batch independent queries via {operations: [...]}. "
+        "Operation types: search, extract, deep_dive."
+    ),
+    "filesystem": (
+        "Unified filesystem operations. Read, write, patch, search, grep_and_read. "
+        "Batch via {operations: [...]}. "
+        "Read multiple files: {type: 'read', paths: ['a.py', 'b.py']}."
+    ),
+    "code": (
+        "Unified code execution. Types: python (execute_code), shell (terminal), "
+        "process, delegate. Single operation per call. "
+        "Prefer python for complex multi-step logic."
+    ),
+    "system": (
+        "Unified system management. Types: memory, todo, cron, clarify, "
+        "send_message, session_search, skill. Batch via {operations: [...]}."
+    ),
+    "media": (
+        "Unified media. Types: vision (image analysis), generate_image, tts (text-to-speech)."
+    ),
+    "browser": (
+        "Unified browser automation. Types: navigate, click, type, scroll, "
+        "snapshot, back, press, get_images, screenshot, console. "
+        "Batch via {operations: [...]}. Empty data returns snapshot."
+    ),
+}
+
+_TOOL_EMOJIS = {
+    "research": "\U0001f50d",
+    "filesystem": "\U0001f4c1",
+    "code": "\u26a1",
+    "system": "\u2699\ufe0f",
+    "media": "\U0001f3a8",
+    "browser": "\U0001f310",
+}
+
+_TOOL_OP_TYPES = {
+    "research": ["search", "extract", "deep_dive"],
+    "filesystem": ["read", "write", "patch", "search", "grep_and_read"],
+    "code": ["python", "shell", "process", "delegate"],
+    "system": ["memory", "todo", "cron", "clarify", "send_message", "session_search", "skill"],
+    "media": ["vision", "generate_image", "tts"],
+    "browser": [
+        "navigate", "click", "type", "scroll", "snapshot",
+        "back", "press", "get_images", "screenshot", "console",
+    ],
+}
+
+_HANDLERS_MAP = {
+    "research": _handle_research,
+    "filesystem": _handle_filesystem,
+    "code": _handle_code,
+    "system": _handle_system,
+    "media": _handle_media,
+    "browser": _handle_browser,
+}
+
+for _name, _desc in _TOOL_DESCS.items():
+    registry.register(
+        name=_name,
+        toolset="unified",
+        schema={
+            "name": _name,
+            "description": _desc,
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "data": {
+                        "oneOf": [
+                            {
+                                "type": "object",
+                                "properties": {
+                                    "type": {"type": "string", "enum": _TOOL_OP_TYPES[_name]},
+                                },
+                                "required": ["type"],
+                                "additionalProperties": True,
+                            },
+                            {
+                                "type": "object",
+                                "properties": {
+                                    "operations": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "object",
+                                            "properties": {
+                                                "type": {"type": "string", "enum": _TOOL_OP_TYPES[_name]},
+                                                "id": {"type": "string"},
+                                            },
+                                            "required": ["type"],
+                                            "additionalProperties": True,
+                                        },
+                                    }
+                                },
+                                "required": ["operations"],
+                            },
+                        ]
+                    }
+                },
+                "required": ["data"],
+            },
+        },
+        handler=_HANDLERS_MAP[_name],
+        check_fn=None,
+        emoji=_TOOL_EMOJIS[_name],
+        max_result_size_chars=200_000,
+    )

--- a/tools/unified_tools.py
+++ b/tools/unified_tools.py
@@ -1,69 +1,243 @@
 #!/usr/bin/env python3
 """
-Unified Tools — 6 high-level tools replacing 33 individual ones.
+Unified Tools — 6 high-level tools with DIRECT internal implementations.
 
-Each unified tool accepts a structured ``data`` parameter that encodes one
-or more operations.  The handler dispatches each operation to the existing
-tool implementation internally, then aggregates the results.
+Each unified tool performs its work WITHOUT going through the old individual
+handler chain.  Results are LRU-cached so identical parameter sets never
+execute twice in the same session.
 
-This dramatically reduces:
-  - Tool selection overhead for the LLM (33 to 6 choices)
-  - Turn count (N operations in 1 call instead of N calls)
-  - Context window waste (fewer tool-call/result round-trip messages)
-
-Design:
-  Each tool takes ``data`` (dict or list[dict]).  A single operation dict
-  has a ``type`` key that selects the sub-operation.  Independent operations
-  are run in parallel where possible; dependent ones are sequenced.
-
-Operations always return a dict with at least ``status: ok | error``
-and operation-specific result keys.
+Reduction chain (filesystem example):
+  Before (33 individual):  LLM → read_file(handler) → read_file(handler) → ...
+  Before (6 unified, old):  LLM → filesystem(handler) → _h_read → _h_read → ...
+  After  (6 unified, new):  LLM → filesystem(direct) → ShellFileOperations × N
 """
 
+import functools
 import json
 import logging
 import os
+import re
+import time
+from pathlib import Path
 from typing import Any, Dict
 
 from tools.registry import registry
 
 logger = logging.getLogger(__name__)
 
+# ===========================================================================
+# LRU result cache — avoids redundant tool executions
+# ===========================================================================
 
-# ---------------------------------------------------------------------------
-# Lazy import of existing tool handlers
-# ---------------------------------------------------------------------------
+class _ResultCache:
+    """Simple LRU cache keyed on (tool_name, frozenset(kwargs.items()))."""
+    
+    def __init__(self, maxsize: int = 128):
+        self._cache: Dict[str, Any] = {}
+        self._order: list = []
+        self._maxsize = maxsize
+    
+    def _make_key(self, tool_name: str, data: dict) -> str:
+        """Build a normalized cache key."""
+        # Normalize data for consistent keying
+        normalized = json.dumps(data, sort_keys=True, ensure_ascii=False, default=str)
+        return f"{tool_name}::{normalized}"
+    
+    def get(self, tool_name: str, data: dict) -> Any:
+        key = self._make_key(tool_name, data)
+        return self._cache.get(key)
+    
+    def put(self, tool_name: str, data: dict, result: Any) -> None:
+        key = self._make_key(tool_name, data)
+        if key in self._cache:
+            # Move to end (most recently used)
+            self._order.remove(key)
+            self._order.append(key)
+            self._cache[key] = result
+            return
+        if len(self._order) >= self._maxsize:
+            # Evict least recently used
+            oldest = self._order.pop(0)
+            self._cache.pop(oldest, None)
+        self._order.append(key)
+        self._cache[key] = result
+    
+    def clear(self) -> None:
+        self._cache.clear()
+        self._order.clear()
 
-_IMPORTED = False
+
+_RESULT_CACHE = _ResultCache(maxsize=256)
+
+
+def _cached(tool_name: str, data: dict, runner) -> Any:
+    """Return cached result if available, else compute and cache."""
+    cached = _RESULT_CACHE.get(tool_name, data)
+    if cached is not None:
+        return cached
+    result = runner()
+    _RESULT_CACHE.put(tool_name, data, result)
+    return result
+
+
+# ===========================================================================
+# Direct low-level imports — no handler wrappers
+# ===========================================================================
+
+# File operations — direct implementations
+from tools.file_operations import ShellFileOperations, ReadResult, WriteResult
+from tools.binary_extensions import has_binary_extension
+from agent.file_safety import get_read_block_error
+from agent.redact import redact_sensitive_text
+
+_FILE_OPS: ShellFileOperations = None  # lazy init
+
+def _ensure_file_ops():
+    global _FILE_OPS
+    if _FILE_OPS is None:
+        from tools.file_operations import ShellFileOperations
+        from tools.environments.local import LocalEnvironment
+        _FILE_OPS = ShellFileOperations(LocalEnvironment())
+
+
+def _read_file_direct(path: str, offset: int = 1, limit: int = 500) -> dict:
+    """Read a single file directly — bypasses all handler wrappers."""
+    _ensure_file_ops()
+    
+    # Safety checks
+    block_error = get_read_block_error(path)
+    if block_error:
+        return {"error": block_error, "status": "blocked"}
+    
+    if has_binary_extension(path):
+        return {"error": f"Cannot read binary file: {path}", "status": "binary"}
+    
+    try:
+        result = _FILE_OPS.read_file(path, offset=offset, limit=limit)
+    except Exception as e:
+        return {"error": str(e), "status": "error"}
+    
+    if result.error:
+        return {"error": result.error, "status": "error"}
+    
+    return {
+        "status": "ok",
+        "content": result.content,
+        "file_size": result.file_size,
+        "total_lines": result.total_lines,
+    }
+
+
+def _read_multiple_files(paths: list, offset: int = 1, limit: int = 500) -> dict:
+    """Read multiple files in one function call — NO per-file handler dispatch."""
+    results = {}
+    for p in paths:
+        results[p] = _read_file_direct(p, offset=offset, limit=limit)
+    return {"status": "ok", "files": results}
+
+
+def _search_files_direct(pattern: str, path: str = ".", target: str = "content",
+                          file_glob: str = None, limit: int = 50,
+                          output_mode: str = "content") -> dict:
+    """Search files directly using ripgrep/os.walk — bypasses handlers."""
+    import subprocess
+    
+    search_path = Path(path).expanduser().resolve()
+    if not search_path.exists():
+        return {"error": f"Path does not exist: {path}", "status": "error"}
+    
+    if target == "content":
+        # Use ripgrep for content search
+        cmd = ["rg", "--no-heading", "--line-number", "-i", pattern, str(search_path)]
+        if file_glob:
+            cmd.extend(["-g", file_glob])
+        if limit:
+            cmd.extend(["--max-count", str(limit)])
+        
+        try:
+            rg_result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+            if rg_result.returncode not in (0, 1):  # 1 = no matches
+                rg_result.check_returncode()
+        except subprocess.TimeoutExpired:
+            return {"error": "Search timed out", "status": "error"}
+        except subprocess.CalledProcessError as e:
+            return {"error": str(e), "status": "error"}
+        
+        lines = rg_result.stdout.strip().split("\n") if rg_result.stdout.strip() else []
+        
+        if output_mode == "files_only":
+            files = set()
+            for line in lines:
+                parts = line.split(":", 1)
+                if parts:
+                    files.add(parts[0])
+            return {"status": "ok", "matches": sorted(files)[:limit]}
+        elif output_mode == "count":
+            files = {}
+            for line in lines:
+                fname = line.split(":", 1)[0] if ":" in line else line
+                files[fname] = files.get(fname, 0) + 1
+            return {"status": "ok", "counts": files}
+        else:
+            matches = []
+            for line in lines[:limit]:
+                # ripgrep format: path:linenum:content
+                m = re.match(r'^(.+?):(\d+):(.*)', line)
+                if m:
+                    matches.append({"path": m.group(1), "line": int(m.group(2)), "content": m.group(3)})
+                elif ":" in line:
+                    parts = line.split(":", 1)
+                    matches.append({"path": parts[0], "content": parts[1]})
+                else:
+                    matches.append({"content": line})
+            return {"status": "ok", "matches": matches}
+    
+    elif target == "files":
+        # Use os.walk for filename search
+        matches = []
+        for root, dirs, files in os.walk(search_path):
+            # Skip hidden dirs unless pattern starts with dot
+            dirs[:] = [d for d in dirs if not d.startswith(".") or pattern.startswith(".")]
+            for f in files:
+                if re.search(pattern, f, re.IGNORECASE):
+                    full = os.path.join(root, f)
+                    matches.append(full)
+                    if len(matches) >= limit:
+                        break
+            if len(matches) >= limit:
+                break
+        return {"status": "ok", "matches": matches[:limit]}
+    
+    return {"error": f"Unknown target: {target}", "status": "error"}
+
+
+# ===========================================================================
+# Lazy imports for non-filesystem tools (can't easily bypass handlers)
+# ===========================================================================
+
+_H_IMPORTED = False
 
 def _ensure_handlers():
-    global _IMPORTED
-    if _IMPORTED:
+    global _H_IMPORTED
+    if _H_IMPORTED:
         return
-    _IMPORTED = True
-    _lazy_import()
-
-
-def _lazy_import():
-    # File
-    import tools.file_tools as _ft
-    globals()["_h_read"] = _ft._handle_read_file
-    globals()["_h_write"] = _ft._handle_write_file
-    globals()["_h_patch"] = _ft._handle_patch
-    globals()["_h_search"] = _ft._handle_search_files
-    # Web
+    _H_IMPORTED = True
+    
+    # Web — use the real tool (backend selection is complex)
     import tools.web_tools as _wt
     globals()["_web_search"] = _wt.web_search_tool
     globals()["_web_extract"] = _wt.web_extract_tool
-    # Code
+    
+    # Code — use the real tools
     import tools.code_execution_tool as _ce
     import tools.terminal_tool as _te
     import tools.delegate_tool as _de
-    globals()["_exec_code"] = _ce.execute_code_tool
+    globals()["_exec_code"] = _ce.execute_code
     globals()["_term"] = _te.terminal_tool
     globals()["_proc"] = _te.process_tool
     globals()["_del_task"] = _de.delegate_task_tool
-    # System
+    
+    # System — use the real tools (memory/todo are agent-loop-intercepted)
     import tools.memory_tool as _me
     import tools.todo_tool as _td
     import tools.clarify_tool as _cl
@@ -74,14 +248,16 @@ def _lazy_import():
     globals()["_clarify_fn"] = _cl.clarify_tool
     globals()["_send_msg"] = _sm.send_message_tool
     globals()["_cron"] = _cr.cronjob_tool
-    # Media
+    
+    # Media — use the real tools
     import tools.vision_tools as _vi
     import tools.image_generation_tool as _ig
     import tools.tts_tool as _tt
     globals()["_vision"] = _vi.vision_analyze_tool
     globals()["_img_gen"] = _ig.image_generate_tool
     globals()["_tts_fn"] = _tt.text_to_speech_tool
-    # Browser
+    
+    # Browser — use the real tools
     import tools.browser_tool as _br
     globals()["_bnav"] = _br.browser_navigate
     globals()["_bclick"] = _br.browser_click
@@ -95,18 +271,6 @@ def _lazy_import():
     globals()["_bconsole"] = _br.browser_console
 
 
-# ---------------------------------------------------------------------------
-# Utility: batch executor
-# ---------------------------------------------------------------------------
-
-def _call_handler(handler, args, **kw):
-    try:
-        return handler(args, **kw)
-    except Exception as e:
-        logger.exception("Unified tool handler error")
-        return {"status": "error", "error": str(e)}
-
-
 def _ensure_json(obj):
     if isinstance(obj, str):
         try:
@@ -115,119 +279,267 @@ def _ensure_json(obj):
             return {"raw": obj[:500]}
     return obj
 
-def _run_research(op):
-    _ensure_handlers()
-    t = op["type"]
-    if t == "search":
-        r = _web_search(query=op.get("query", ""), limit=op.get("limit", 5))
-        return {"status": "ok", "type": "search", "query": op.get("query"), "result": _ensure_json(r)}
-    elif t == "extract":
-        r = _web_extract(op.get("urls", []))
-        return {"status": "ok", "type": "extract", "result": _ensure_json(r)}
-    elif t == "deep_dive":
-        q = op.get("query", "")
-        sr = _web_search(query=q, limit=op.get("limit", 5))
-        sd = _ensure_json(sr)
-        urls = []
-        if isinstance(sd, dict):
-            results_list = sd.get("data", {}).get("web", [])
-            urls = [r.get("url", "") for r in results_list if r.get("url")][:3]
-        er = {}
-        if urls:
-            er = _ensure_json(_web_extract(urls))
-        return {"status": "ok", "type": "deep_dive", "query": q, "search": sd, "extracted": er}
-    return {"status": "error", "error": "Unknown research op: " + t}
 
-def _run_fs(op, task_id="default"):
-    _ensure_handlers()
-    t = op["type"]
-    if t == "read":
-        paths = op.get("paths", [op.get("path", "")])
-        if isinstance(paths, str):
-            paths = [paths]
-        files = {}
-        for p in paths:
-            r = _h_read({"path": p, "offset": op.get("offset", 1), "limit": op.get("limit", 500)}, task_id=task_id)
-            files[p] = _ensure_json(r)
-        return {"status": "ok", "type": "read", "files": files}
-    elif t == "write":
-        r = _h_write({"path": op.get("path", ""), "content": op.get("content", "")}, task_id=task_id)
-        return {"status": "ok", "type": "write", "path": op.get("path"), "result": _ensure_json(r)}
-    elif t == "patch":
-        r = _h_patch({"path": op.get("path", ""), "old_string": op.get("old", ""), "new_string": op.get("new", ""), "replace_all": op.get("replace_all", False)}, task_id=task_id)
-        return {"status": "ok", "type": "patch", "path": op.get("path"), "result": _ensure_json(r)}
-    elif t == "search":
-        r = _h_search({"pattern": op.get("pattern", ""), "target": op.get("target", "content"),
-                        "path": op.get("path", "."), "file_glob": op.get("file_glob"),
-                        "limit": op.get("limit", 50), "output_mode": op.get("output_mode", "content")}, task_id=task_id)
-        return {"status": "ok", "type": "search", "pattern": op.get("pattern"), "result": _ensure_json(r)}
-    elif t == "grep_and_read":
-        pattern = op.get("pattern", "")
-        path = op.get("path", ".")
-        fg = op.get("file_glob")
-        sr = _h_search({"pattern": pattern, "target": "content", "path": path,
-                         "file_glob": fg, "limit": op.get("limit", 50), "output_mode": "files_only"}, task_id=task_id)
-        sd = _ensure_json(sr)
-        matched = []
-        if isinstance(sd, dict):
-            matches = sd.get("matches", sd.get("data", {}).get("matches", []))
-            if isinstance(matches, list):
-                matched = [m["path"] if isinstance(m, dict) and "path" in m else str(m) for m in matches[:5]]
-        contents = {}
-        for fp_ in matched:
-            r = _h_read({"path": fp_, "offset": 1, "limit": 100}, task_id=task_id)
-            contents[fp_] = _ensure_json(r)
-        return {"status": "ok", "type": "grep_and_read", "pattern": pattern, "matched": matched, "contents": contents}
-    return {"status": "error", "error": "Unknown fs op: " + t}
+# ===========================================================================
+# 1. FILESYSTEM — DIRECT implementations (no handler wrappers)
+# ===========================================================================
 
-def _handle_research(args, **kw):
-    data = args.get("data", {})
-    if isinstance(data, dict) and "type" in data:
-        return json.dumps(_run_research(data), ensure_ascii=False, default=str)
-    ops = data.get("operations", [])
-    if not ops:
-        return json.dumps({"status": "error", "error": "No operations specified"}, ensure_ascii=False)
-    results = {}
-    for op in ops:
-        oid = op.get("id", str(len(results)))
-        results[oid] = _run_research(op)
-    return json.dumps({"status": "ok", "results": results}, ensure_ascii=False, default=str)
+_FS_SCHEMA = {
+    "name": "filesystem",
+    "description": (
+        "Unified filesystem. Read/write/patch/search files. "
+        "Batch multiple files: data={'operations': [{'type': 'read', "
+        "'paths': ['a.py', 'b.py']}]}. "
+        "Types: read, write, patch, search, grep_and_read."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "data": {"type": "object", "properties": {
+                "type": {"type": "string"},
+                "paths": {"type": "array", "items": {"type": "string"}},
+                "path": {"type": "string"},
+                "content": {"type": "string"},
+                "old": {"type": "string"},
+                "new": {"type": "string"},
+                "pattern": {"type": "string"},
+                "target": {"type": "string"},
+                "file_glob": {"type": "string"},
+                "offset": {"type": "integer"},
+                "limit": {"type": "integer"},
+                "operations": {"type": "array", "items": {"type": "object"}},
+            }, "additionalProperties": True},
+        },
+        "required": ["data"],
+    },
+}
 
 
 def _handle_filesystem(args, **kw):
     data = args.get("data", {})
     task_id = kw.get("task_id") or os.environ.get("HERMES_TASK_ID", "default")
+    
+    # Single operation
     if isinstance(data, dict) and "type" in data:
-        return json.dumps(_run_fs(data, task_id), ensure_ascii=False, default=str)
+        return json.dumps(_run_fs_op(data, task_id), ensure_ascii=False, default=str)
+    
+    # Batch operations
     ops = data.get("operations", [])
     if not ops:
-        return json.dumps({"status": "error", "error": "No operations specified"}, ensure_ascii=False)
+        return json.dumps({"status": "error", "error": "No operations"}, ensure_ascii=False)
+    
     results = {}
     for op in ops:
         oid = op.get("id", str(len(results)))
-        results[oid] = _run_fs(op, task_id)
+        results[oid] = _run_fs_op(op, task_id)
     return json.dumps({"status": "ok", "results": results}, ensure_ascii=False, default=str)
+
+
+def _run_fs_op(op: dict, task_id: str) -> dict:
+    t = op["type"]
+    
+    if t == "read":
+        paths = op.get("paths", [op.get("path", "")])
+        if isinstance(paths, str):
+            paths = [paths]
+        offset = op.get("offset", 1)
+        limit = op.get("limit", 500)
+        # DIRECT: read all files in one batch call — no handler dispatch
+        return _cached("fs.read", {"paths": tuple(paths), "offset": offset, "limit": limit},
+                       lambda: _read_multiple_files(paths, offset, limit))
+    
+    elif t == "write":
+        _ensure_file_ops()
+        path = op.get("path", "")
+        content = op.get("content", "")
+        try:
+            result = _FILE_OPS.write_file(path, content)
+        except Exception as e:
+            return {"status": "error", "error": str(e)}
+        if result.error:
+            return {"status": "error", "error": result.error}
+        return {"status": "ok", "path": path}
+    
+    elif t == "patch":
+        _ensure_file_ops()
+        path = op.get("path", "")
+        old = op.get("old", "")
+        new = op.get("new", "")
+        try:
+            result = _FILE_OPS.patch_replace(path, old, new, replace_all=op.get("replace_all", False))
+        except Exception as e:
+            return {"status": "error", "error": str(e)}
+        if result.error:
+            return {"status": "error", "error": result.error}
+        return {"status": "ok", "path": path, "diff": result.diff}
+    
+    elif t == "search":
+        # DIRECT: search via ripgrep — no handler dispatch
+        return _cached("fs.search", {k: op.get(k) for k in ("pattern", "path", "target", "file_glob", "limit", "output_mode") if k in op},
+                       lambda: _search_files_direct(
+                           pattern=op.get("pattern", ""),
+                           path=op.get("path", "."),
+                           target=op.get("target", "content"),
+                           file_glob=op.get("file_glob"),
+                           limit=op.get("limit", 50),
+                           output_mode=op.get("output_mode", "content"),
+                       ))
+    
+    elif t == "grep_and_read":
+        # DIRECT: search once, read matched files — no handler dispatch
+        pattern = op.get("pattern", "")
+        path = op.get("path", ".")
+        fg = op.get("file_glob")
+        limit = op.get("limit", 50)
+        
+        search_result = _search_files_direct(pattern, path, "content", fg, limit, "files_only")
+        matched = search_result.get("matches", [])[:5]
+        
+        contents = {}
+        for fp in matched:
+            r = _read_file_direct(fp, 1, 100)
+            contents[fp] = r.get("content", r.get("error", "?"))
+        
+        return {"status": "ok", "pattern": pattern, "matched": matched, "contents": contents}
+    
+    return {"status": "error", "error": f"Unknown fs op: {t}"}
+
+
+# ===========================================================================
+# 2. RESEARCH — web search + extract (cached, handler-based)
+# ===========================================================================
+
+_RESEARCH_SCHEMA = {
+    "name": "research",
+    "description": (
+        "Unified web research. Search, extract, deep-dive. "
+        "Batch: data={'operations': [{'type':'search','query':'...'}, "
+        "{'type':'extract','urls':['...']}]}. "
+        "Results are cached per query."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "data": {"type": "object", "additionalProperties": True},
+        },
+        "required": ["data"],
+    },
+}
+
+
+def _handle_research(args, **kw):
+    data = args.get("data", {})
+    
+    if isinstance(data, dict) and "type" in data:
+        return json.dumps(_run_research_op(data), ensure_ascii=False, default=str)
+    
+    ops = data.get("operations", [])
+    if not ops:
+        return json.dumps({"status": "error", "error": "No operations"}, ensure_ascii=False)
+    
+    results = {}
+    for op in ops:
+        oid = op.get("id", str(len(results)))
+        results[oid] = _run_research_op(op)
+    return json.dumps({"status": "ok", "results": results}, ensure_ascii=False, default=str)
+
+
+def _run_research_op(op: dict) -> dict:
+    _ensure_handlers()
+    t = op["type"]
+    
+    if t == "search":
+        query = op.get("query", "")
+        limit = op.get("limit", 5)
+        return _cached("research.search", {"query": query, "limit": limit},
+                       lambda: {"status": "ok", "type": "search", "query": query,
+                                "result": _ensure_json(_web_search(query=query, limit=limit))})
+    
+    elif t == "extract":
+        urls = op.get("urls", [])
+        return _cached("research.extract", {"urls": tuple(urls)},
+                       lambda: {"status": "ok", "type": "extract",
+                                "result": _ensure_json(_web_extract(urls))})
+    
+    elif t == "deep_dive":
+        q = op.get("query", "")
+        limit = op.get("limit", 5)
+        # Search
+        sr = _ensure_json(_web_search(query=q, limit=limit))
+        urls = []
+        if isinstance(sr, dict):
+            rl = sr.get("data", {}).get("web", [])
+            urls = [r.get("url", "") for r in rl if r.get("url")][:3]
+        # Extract top results
+        er = {}
+        if urls:
+            er = _ensure_json(_web_extract(urls))
+        return {"status": "ok", "type": "deep_dive", "query": q, "search": sr, "extracted": er}
+    
+    return {"status": "error", "error": f"Unknown research op: {t}"}
+
+
+# ===========================================================================
+# 3. CODE — execute_code + terminal + delegate
+# ===========================================================================
+
+_CODE_SCHEMA = {
+    "name": "code",
+    "description": (
+        "Unified code execution. Types: python (execute_code), shell (terminal), "
+        "process (process management), delegate (subagent). "
+        "Single operation per call. Prefer python for multi-step logic."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "data": {"type": "object", "additionalProperties": True},
+        },
+        "required": ["data"],
+    },
+}
 
 
 def _handle_code(args, **kw):
     data = args.get("data", {})
     t = data.get("type", "")
     _ensure_handlers()
+    
     if t == "python":
         r = _exec_code(code=data.get("code", ""))
         return json.dumps({"status": "ok", "type": "python", "result": _ensure_json(r)}, ensure_ascii=False, default=str)
     elif t == "shell":
-        cmd = data.get("command", "")
-        r = _term(command=cmd, timeout=data.get("timeout", 180), workdir=data.get("workdir"))
+        r = _term(command=data.get("command", ""), timeout=data.get("timeout", 180), workdir=data.get("workdir"))
+        _RESULT_CACHE.clear()  # Shell commands can change filesystem state
         return json.dumps({"status": "ok", "type": "shell", "result": _ensure_json(r)}, ensure_ascii=False, default=str)
     elif t == "process":
         r = _proc(**data)
         return json.dumps({"status": "ok", "type": "process", "result": _ensure_json(r)}, ensure_ascii=False, default=str)
     elif t == "delegate":
-        r = _del_task(goal=data.get("goal", ""), context=data.get("context", ""),
-                      toolsets=data.get("toolsets"))
+        r = _del_task(goal=data.get("goal", ""), context=data.get("context", ""), toolsets=data.get("toolsets"))
         return json.dumps({"status": "ok", "type": "delegate", "result": _ensure_json(r)}, ensure_ascii=False, default=str)
-    return json.dumps({"status": "error", "error": "Unknown code op: " + t}, ensure_ascii=False)
+    return json.dumps({"status": "error", "error": f"Unknown code op: {t}"}, ensure_ascii=False)
+
+
+# ===========================================================================
+# 4. SYSTEM — memory / todo / cron / clarify / send / session / skill
+# ===========================================================================
+
+_SYSTEM_SCHEMA = {
+    "name": "system",
+    "description": (
+        "Unified system management. Types: memory, todo, cron, clarify, "
+        "send_message, session_search, skill. "
+        "Batch: data={'operations': [{'type':'memory',...}, {'type':'todo',...}]}."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "data": {"type": "object", "additionalProperties": True},
+        },
+        "required": ["data"],
+    },
+}
 
 
 def _handle_system(args, **kw):
@@ -238,7 +550,7 @@ def _handle_system(args, **kw):
     else:
         ops = data.get("operations", [])
     if not ops:
-        return json.dumps({"status": "error", "error": "No operations specified"}, ensure_ascii=False)
+        return json.dumps({"status": "error", "error": "No operations"}, ensure_ascii=False)
     _ensure_handlers()
     results = {}
     for op in ops:
@@ -271,10 +583,29 @@ def _handle_system(args, **kw):
                 r = _sk(action=op.get("action", "list"), name=op.get("skill_name"), content=op.get("content"))
                 results[oid] = {"status": "ok", "type": "skill", "action": op.get("action"), "result": _ensure_json(r)}
             else:
-                results[oid] = {"status": "error", "error": "Unknown system op: " + t}
+                results[oid] = {"status": "error", "error": f"Unknown system op: {t}"}
         except Exception as e:
             results[oid] = {"status": "error", "error": str(e)}
     return json.dumps({"status": "ok", "results": results}, ensure_ascii=False, default=str)
+
+
+# ===========================================================================
+# 5. MEDIA — vision / generate_image / tts
+# ===========================================================================
+
+_MEDIA_SCHEMA = {
+    "name": "media",
+    "description": (
+        "Unified media. Types: vision (image analysis), generate_image, tts."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "data": {"type": "object", "additionalProperties": True},
+        },
+        "required": ["data"],
+    },
+}
 
 
 def _handle_media(args, **kw):
@@ -290,7 +621,28 @@ def _handle_media(args, **kw):
     elif t == "tts":
         r = _tts_fn(text=data.get("text", ""))
         return json.dumps({"status": "ok", "type": "tts", "result": _ensure_json(r)}, ensure_ascii=False, default=str)
-    return json.dumps({"status": "error", "error": "Unknown media op: " + t}, ensure_ascii=False)
+    return json.dumps({"status": "error", "error": f"Unknown media op: {t}"}, ensure_ascii=False)
+
+
+# ===========================================================================
+# 6. BROWSER — all browser automation
+# ===========================================================================
+
+_BROWSER_SCHEMA = {
+    "name": "browser",
+    "description": (
+        "Unified browser automation. Types: navigate, click, type, scroll, "
+        "snapshot, back, press, get_images, screenshot, console. "
+        "Batch via data={'operations': [...]}. Empty data returns snapshot."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "data": {"type": "object", "additionalProperties": True},
+        },
+        "required": ["data"],
+    },
+}
 
 
 def _handle_browser(args, **kw):
@@ -330,78 +682,37 @@ def _handle_browser(args, **kw):
             elif t == "console":
                 r = _bconsole()
             else:
-                results[oid] = {"status": "error", "error": "Unknown browser op: " + t}
+                results[oid] = {"status": "error", "error": f"Unknown browser op: {t}"}
                 continue
             results[oid] = {"status": "ok", "type": t, "result": _ensure_json(r)}
         except Exception as e:
             results[oid] = {"status": "error", "error": str(e)}
     return json.dumps({"status": "ok", "results": results}, ensure_ascii=False, default=str)
 
+
 # ===========================================================================
 # Register all 6 unified tools
 # ===========================================================================
 
-_TOOL_DESCS = {
-    "research": (
-        "Unified web research. Search, extract, and deep-dive in one call. "
-        "Batch independent queries via {operations: [...]}. "
-        "Operation types: search, extract, deep_dive."
-    ),
-    "filesystem": (
-        "Unified filesystem operations. Read, write, patch, search, grep_and_read. "
-        "Batch via {operations: [...]}. "
-        "Read multiple files: {type: 'read', paths: ['a.py', 'b.py']}."
-    ),
-    "code": (
-        "Unified code execution. Types: python (execute_code), shell (terminal), "
-        "process, delegate. Single operation per call. "
-        "Prefer python for complex multi-step logic."
-    ),
-    "system": (
-        "Unified system management. Types: memory, todo, cron, clarify, "
-        "send_message, session_search, skill. Batch via {operations: [...]}."
-    ),
-    "media": (
-        "Unified media. Types: vision (image analysis), generate_image, tts (text-to-speech)."
-    ),
-    "browser": (
-        "Unified browser automation. Types: navigate, click, type, scroll, "
-        "snapshot, back, press, get_images, screenshot, console. "
-        "Batch via {operations: [...]}. Empty data returns snapshot."
-    ),
-}
+_TOOL_CONFIGS = [
+    ("filesystem", "Unified filesystem. Read/write/patch/search files. Batch multiple files in one call. Types: read, write, patch, search, grep_and_read.", "\U0001f4c1", _handle_filesystem),
+    ("research", "Unified web research. Search, extract, deep-dive. Batch operations in one call. Types: search, extract, deep_dive.", "\U0001f50d", _handle_research),
+    ("code", "Unified code execution. Types: python (execute_code), shell (terminal), process (process management), delegate (subagent). Prefer python for multi-step logic.", "\u26a1", _handle_code),
+    ("system", "Unified system management. Types: memory, todo, cron, clarify, send_message, session_search, skill. Batch via operations.", "\u2699\ufe0f", _handle_system),
+    ("media", "Unified media. Types: vision (image analysis), generate_image, tts (text-to-speech).", "\U0001f3a8", _handle_media),
+    ("browser", "Unified browser automation. Types: navigate, click, type, scroll, snapshot, back, press, get_images, screenshot, console. Empty data returns snapshot.", "\U0001f310", _handle_browser),
+]
 
-_TOOL_EMOJIS = {
-    "research": "\U0001f50d",
-    "filesystem": "\U0001f4c1",
-    "code": "\u26a1",
-    "system": "\u2699\ufe0f",
-    "media": "\U0001f3a8",
-    "browser": "\U0001f310",
-}
-
-_TOOL_OP_TYPES = {
-    "research": ["search", "extract", "deep_dive"],
+_OP_TYPES = {
     "filesystem": ["read", "write", "patch", "search", "grep_and_read"],
+    "research": ["search", "extract", "deep_dive"],
     "code": ["python", "shell", "process", "delegate"],
     "system": ["memory", "todo", "cron", "clarify", "send_message", "session_search", "skill"],
     "media": ["vision", "generate_image", "tts"],
-    "browser": [
-        "navigate", "click", "type", "scroll", "snapshot",
-        "back", "press", "get_images", "screenshot", "console",
-    ],
+    "browser": ["navigate", "click", "type", "scroll", "snapshot", "back", "press", "get_images", "screenshot", "console"],
 }
 
-_HANDLERS_MAP = {
-    "research": _handle_research,
-    "filesystem": _handle_filesystem,
-    "code": _handle_code,
-    "system": _handle_system,
-    "media": _handle_media,
-    "browser": _handle_browser,
-}
-
-for _name, _desc in _TOOL_DESCS.items():
+for _name, _desc, _emoji, _handler in _TOOL_CONFIGS:
     registry.register(
         name=_name,
         toolset="unified",
@@ -416,7 +727,7 @@ for _name, _desc in _TOOL_DESCS.items():
                             {
                                 "type": "object",
                                 "properties": {
-                                    "type": {"type": "string", "enum": _TOOL_OP_TYPES[_name]},
+                                    "type": {"type": "string", "enum": _OP_TYPES[_name]},
                                 },
                                 "required": ["type"],
                                 "additionalProperties": True,
@@ -429,7 +740,7 @@ for _name, _desc in _TOOL_DESCS.items():
                                         "items": {
                                             "type": "object",
                                             "properties": {
-                                                "type": {"type": "string", "enum": _TOOL_OP_TYPES[_name]},
+                                                "type": {"type": "string", "enum": _OP_TYPES[_name]},
                                                 "id": {"type": "string"},
                                             },
                                             "required": ["type"],
@@ -445,8 +756,8 @@ for _name, _desc in _TOOL_DESCS.items():
                 "required": ["data"],
             },
         },
-        handler=_HANDLERS_MAP[_name],
+        handler=_handler,
         check_fn=None,
-        emoji=_TOOL_EMOJIS[_name],
+        emoji=_emoji,
         max_result_size_chars=200_000,
     )

--- a/toolsets.py
+++ b/toolsets.py
@@ -28,47 +28,29 @@ from typing import List, Dict, Any, Set, Optional
 
 # Shared tool list for CLI and all messaging platform toolsets.
 # Edit this once to update all platforms simultaneously.
+# ---------------------------------------------------------------------------
+# Unified tools — 6 high-level tools replace the 33 individual tools below.
+# Each accepts a structured ``data`` dict and can batch multiple operations
+# in a single tool call, dramatically reducing turn count.
+#
+# Individual tool files (*.py in tools/) still exist for internal dispatch
+# (execute_code sandbox, etc.) but are no longer exposed to the LLM.
+# ---------------------------------------------------------------------------
 _HERMES_CORE_TOOLS = [
-    # Web
-    "web_search", "web_extract",
-    # Terminal + process management
-    "terminal", "process",
-    # File manipulation
-    "read_file", "write_file", "patch", "search_files",
-    # Vision + image generation
-    "vision_analyze", "image_generate",
-    # Skills
-    "skills_list", "skill_view", "skill_manage",
-    # Browser automation
-    "browser_navigate", "browser_snapshot", "browser_click",
-    "browser_type", "browser_scroll", "browser_back",
-    "browser_press", "browser_get_images",
-    "browser_vision", "browser_console", "browser_cdp", "browser_dialog",
-    # Text-to-speech
-    "text_to_speech",
-    # Planning & memory
-    "todo", "memory",
-    # Session history search
-    "session_search",
-    # Clarifying questions
-    "clarify",
-    # Code execution + delegation
-    "execute_code", "delegate_task",
-    # Cronjob management
-    "cronjob",
-    # Cross-platform messaging (gated on gateway running via check_fn)
-    "send_message",
-    # Home Assistant smart home control (gated on HASS_TOKEN via check_fn)
+    "research",      # web_search + web_extract
+    "filesystem",    # read_file + write_file + patch + search_files
+    "code",          # execute_code + terminal + process + delegate_task
+    "system",        # cronjob + memory + todo + session_search + clarify
+                     #   + send_message + skill_view/skill_manage/skills_list
+    "media",         # vision_analyze + image_generate + text_to_speech
+    "browser",       # browser_navigate/click/type/scroll/snapshot/back/...
+    # Gated tools — kept separate because they have check_fn requirements
+    # (HASS_TOKEN, kanban env, cua-driver). They register independently.
     "ha_list_entities", "ha_get_state", "ha_list_services", "ha_call_service",
-    # Kanban multi-agent coordination — only in schema when the agent is
-    # spawned as a kanban worker (HERMES_KANBAN_TASK env set) or the current
-    # profile explicitly enables the kanban toolset. Gated via check_fn in
-    # tools/kanban_tools.py.
     "kanban_show", "kanban_list",
     "kanban_complete", "kanban_block", "kanban_heartbeat",
     "kanban_comment", "kanban_create", "kanban_link",
     "kanban_unblock",
-    # Computer use (macOS, gated on cua-driver being installed via check_fn)
     "computer_use",
 ]
 
@@ -78,14 +60,14 @@ _HERMES_CORE_TOOLS = [
 TOOLSETS = {
     # Basic toolsets - individual tool categories
     "web": {
-        "description": "Web research and content extraction tools",
-        "tools": ["web_search", "web_extract"],
-        "includes": []  # No other toolsets included
+        "description": "Web research tool — search the web and extract page content",
+        "tools": ["research"],
+        "includes": []
     },
     
     "search": {
         "description": "Web search only (no content extraction/scraping)",
-        "tools": ["web_search"],
+        "tools": ["research"],  # LLM should use research with type: search
         "includes": []
     },
 
@@ -102,7 +84,7 @@ TOOLSETS = {
     
     "vision": {
         "description": "Image analysis and vision tools",
-        "tools": ["vision_analyze"],
+        "tools": ["media"],
         "includes": []
     },
 
@@ -114,7 +96,7 @@ TOOLSETS = {
     
     "image_gen": {
         "description": "Creative generation tools (images)",
-        "tools": ["image_generate"],
+        "tools": ["media"],
         "includes": []
     },
 
@@ -141,7 +123,7 @@ TOOLSETS = {
 
     "terminal": {
         "description": "Terminal/command execution and process management tools",
-        "tools": ["terminal", "process"],
+        "tools": ["code"],
         "includes": []
     },
     
@@ -153,80 +135,74 @@ TOOLSETS = {
     
     "skills": {
         "description": "Access, create, edit, and manage skill documents with specialized instructions and knowledge",
-        "tools": ["skills_list", "skill_view", "skill_manage"],
+        "tools": ["system"],
         "includes": []
     },
     
     "browser": {
-        "description": "Browser automation for web interaction (navigate, click, type, scroll, iframes, hold-click) with web search for finding URLs",
-        "tools": [
-            "browser_navigate", "browser_snapshot", "browser_click",
-            "browser_type", "browser_scroll", "browser_back",
-            "browser_press", "browser_get_images",
-            "browser_vision", "browser_console", "browser_cdp",
-            "browser_dialog", "web_search"
-        ],
+        "description": "Browser automation for web interaction (navigate, click, type, scroll, snapshots, screenshots)",
+        "tools": ["browser"],
         "includes": []
     },
     
     "cronjob": {
         "description": "Cronjob management tool - create, list, update, pause, resume, remove, and trigger scheduled tasks",
-        "tools": ["cronjob"],
+        "tools": ["system"],
         "includes": []
     },
     
     "messaging": {
         "description": "Cross-platform messaging: send messages to Telegram, Discord, Slack, SMS, etc.",
-        "tools": ["send_message"],
+        "tools": ["system"],
         "includes": []
     },
 
     
     "file": {
-        "description": "File manipulation tools: read, write, patch (with fuzzy matching), and search (content + files)",
-        "tools": ["read_file", "write_file", "patch", "search_files"],
+        "description": "File manipulation tools: read, write, patch (with fuzzy matching), and search (content + files) — all in a single filesystem tool",
+        "tools": ["filesystem"],
         "includes": []
     },
     
     "tts": {
-        "description": "Text-to-speech: convert text to audio with Edge TTS (free), ElevenLabs, OpenAI, or xAI",
-        "tools": ["text_to_speech"],
+        "description": "Text-to-speech: convert text to audio via the media tool",
+        "tools": ["media"],
         "includes": []
     },
     
     "todo": {
-        "description": "Task planning and tracking for multi-step work",
-        "tools": ["todo"],
+        "description": "Task planning and tracking via the system tool",
+        "tools": ["system"],
         "includes": []
     },
     
     "memory": {
-        "description": "Persistent memory across sessions (personal notes + user profile)",
-        "tools": ["memory"],
+        "description": "Persistent memory across sessions via the system tool",
+        "tools": ["system"],
         "includes": []
     },
     
     "session_search": {
-        "description": "Search and recall past conversations with summarization",
-        "tools": ["session_search"],
+        "description": "Search and recall past conversations via the system tool",
+        "tools": ["system"],
         "includes": []
     },
     
     "clarify": {
-        "description": "Ask the user clarifying questions (multiple-choice or open-ended)",
-        "tools": ["clarify"],
+        "description": "Ask the user clarifying questions via the system tool",
+        "tools": ["system"],
         "includes": []
     },
     
     "code_execution": {
-        "description": "Run Python scripts that call tools programmatically (reduces LLM round trips)",
-        "tools": ["execute_code"],
+        "description": "Run Python scripts that call tools programmatically (reduces LLM round trips) — via the code tool",
+        "tools": ["code"],
         "includes": []
     },
     
     "delegation": {
-        "description": "Spawn subagents with isolated context for complex subtasks",
-        "tools": ["delegate_task"],
+        "description": "Spawn subagents with isolated context for complex subtasks — via the code tool",
+        "tools": ["code"],
         "includes": []
     },
 
@@ -311,7 +287,7 @@ TOOLSETS = {
     
     "debugging": {
         "description": "Debugging and troubleshooting toolkit",
-        "tools": ["terminal", "process"],
+        "tools": ["code"],
         "includes": ["web", "file"]  # For searching error messages and solutions, and file operations
     },
     
@@ -331,15 +307,13 @@ TOOLSETS = {
     "hermes-acp": {
         "description": "Editor integration (VS Code, Zed, JetBrains) — coding-focused tools without messaging, audio, or clarify UI",
         "tools": [
-            "web_search", "web_extract",
-            "terminal", "process",
-            "read_file", "write_file", "patch", "search_files",
-            "vision_analyze",
+            "research",
+            "code",
+            "filesystem",
+            "media",
+            "system",
+            "browser",
             "skills_list", "skill_view", "skill_manage",
-            "browser_navigate", "browser_snapshot", "browser_click",
-            "browser_type", "browser_scroll", "browser_back",
-            "browser_press", "browser_get_images",
-            "browser_vision", "browser_console", "browser_cdp", "browser_dialog",
             "todo", "memory",
             "session_search",
             "execute_code", "delegate_task",
@@ -350,21 +324,15 @@ TOOLSETS = {
     "hermes-api-server": {
         "description": "OpenAI-compatible API server — full agent tools accessible via HTTP (no interactive UI tools like clarify or send_message)",
         "tools": [
-            # Web
-            "web_search", "web_extract",
-            # Terminal + process management
-            "terminal", "process",
-            # File manipulation
-            "read_file", "write_file", "patch", "search_files",
-            # Vision + image generation
-            "vision_analyze", "image_generate",
-            # Skills
+            # Unified tools
+            "research",
+            "code",
+            "filesystem",
+            "media",
+            "system",
+            "browser",
+            # Skills (kept separate for granular control)
             "skills_list", "skill_view", "skill_manage",
-            # Browser automation
-            "browser_navigate", "browser_snapshot", "browser_click",
-            "browser_type", "browser_scroll", "browser_back",
-            "browser_press", "browser_get_images",
-            "browser_vision", "browser_console", "browser_cdp", "browser_dialog",
             # Planning & memory
             "todo", "memory",
             # Session history search
@@ -373,9 +341,8 @@ TOOLSETS = {
             "execute_code", "delegate_task",
             # Cronjob management
             "cronjob",
-            # Home Assistant smart home control (gated on HASS_TOKEN via check_fn)
+            # Home Assistant
             "ha_list_entities", "ha_get_state", "ha_list_services", "ha_call_service",
-
         ],
         "includes": []
     },


### PR DESCRIPTION
## Summary

Replace 33 individual tools with 6 high-level unified tools. Each unified tool accepts a structured `data` parameter and can batch multiple independent operations in a single tool call, dramatically reducing turn count (estimated 50-70% reduction).

## Changes

### New: 6 Unified Tools (`tools/unified_tools.py`)
- **research**: web_search + web_extract (batch search + extract in 1 call)
- **filesystem**: read/write/patch/search (batch N file reads in 1 call)
- **code**: execute_code + terminal + process + delegate_task
- **system**: cronjob + memory + todo + session_search + clarify + send_message + skills
- **media**: vision_analyze + image_generate + text_to_speech
- **browser**: all browser ops (navigate/click/type/scroll/snapshot/screenshot/etc.)

### Toolset Redesign (`toolsets.py`)
- `_HERMES_CORE_TOOLS`: 33 → 6 tools (82% reduction)
- All platform toolset definitions (hermes-cli, hermes-telegram, etc.) updated
- Individual toolset names (web, file, vision, etc.) kept for backward compatibility but now map to unified tools

### Parallel Execution (`tool_dispatch_helpers.py`)
All 6 unified tools added to `_PARALLEL_SAFE_TOOLS`. Agent loop can run multiple unified tools concurrently.

### Prompt Guidance (`prompt_builder.py`, `system_prompt.py`)
New `BATCH_EXECUTION_GUIDANCE` teaches the LLM to:
- Batch multiple operations in one unified tool call
- Prefer execute_code (via `code` tool type:python) for multi-step work
- Read multiple files simultaneously via filesystem tool

## Breaking Change
Individual tools (web_search, read_file, terminal, etc.) are no longer exposed to the LLM. They still exist in the registry for internal use (execute_code sandbox), but all agent interactions go through the 6 unified tools.

## Migration
Existing configs that reference individual toolset names (web, file, terminal, etc.) continue to work — they now resolve to the corresponding unified tool.