### PR TITLE
fix(slack): chunk section-block content and surface postMessage errors (#18)

### DIFF
--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -303,6 +303,7 @@ class SlackAdapter(BasePlatformAdapter):
     """
 
     MAX_MESSAGE_LENGTH = 39000  # Slack API allows 40,000 chars; leave margin
+    MAX_SECTION_TEXT_LENGTH = 2900  # Slack hard limit per section block text is 3000; leave 100-char margin
 
     def __init__(self, config: PlatformConfig):
         super().__init__(config, Platform.SLACK)
@@ -755,6 +756,47 @@ class SlackAdapter(BasePlatformAdapter):
             return self._team_clients[team_id]
         return self._app.client  # fallback to primary
 
+    async def _safe_post_message(self, client: Any, **kwargs: Any) -> Any:
+        """Thin wrapper around chat_postMessage that surfaces error details.
+
+        On SlackApiError: logs the Slack error code, text length, block count,
+        and the longest section-block text length so silent failures become
+        visible in logs.  Re-raises so callers can handle or propagate.
+        """
+        try:
+            return await client.chat_postMessage(**kwargs)
+        except Exception as exc:
+            text_len = len(kwargs.get("text") or "")
+            blocks = kwargs.get("blocks") or []
+            blocks_count = len(blocks)
+            # Find the longest section block text to surface the likely culprit.
+            max_section_len = 0
+            for block in blocks:
+                if block.get("type") == "section":
+                    section_text = block.get("text", {}).get("text", "") or ""
+                    if len(section_text) > max_section_len:
+                        max_section_len = len(section_text)
+
+            # Try to extract the Slack API error code from SlackApiError.
+            try:
+                error_code = exc.response["error"]  # type: ignore[attr-defined]
+            except (AttributeError, TypeError, KeyError):
+                error_code = None
+
+            if error_code is not None:
+                logger.warning(
+                    "[Slack] chat_postMessage failed: error_code=%s text_len=%d "
+                    "blocks_count=%d max_section_len=%d",
+                    error_code, text_len, blocks_count, max_section_len,
+                )
+            else:
+                logger.warning(
+                    "[Slack] chat_postMessage failed: %s text_len=%d "
+                    "blocks_count=%d max_section_len=%d",
+                    exc, text_len, blocks_count, max_section_len,
+                )
+            raise
+
     async def send(
         self,
         chat_id: str,
@@ -803,7 +845,9 @@ class SlackAdapter(BasePlatformAdapter):
                     if broadcast and i == 0:
                         kwargs["reply_broadcast"] = True
 
-                last_result = await self._get_client(chat_id).chat_postMessage(**kwargs)
+                last_result = await self._safe_post_message(
+                    self._get_client(chat_id), **kwargs
+                )
 
             # Clear Slack Assistant status as soon as the final message is posted.
             if thread_ts:
@@ -2309,7 +2353,9 @@ class SlackAdapter(BasePlatformAdapter):
             if thread_ts:
                 kwargs["thread_ts"] = thread_ts
 
-            result = await self._get_client(chat_id).chat_postMessage(**kwargs)
+            result = await self._safe_post_message(
+                self._get_client(chat_id), **kwargs
+            )
             msg_ts = result.get("ts", "")
             if msg_ts:
                 self._approval_resolved[msg_ts] = False
@@ -2323,23 +2369,40 @@ class SlackAdapter(BasePlatformAdapter):
         self, chat_id: str, title: str, message: str, session_key: str,
         confirm_id: str, metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
-        """Send a Block Kit three-option slash-command confirmation prompt."""
+        """Send a Block Kit three-option slash-command confirmation prompt.
+
+        The section block's text field is capped at MAX_SECTION_TEXT_LENGTH to
+        stay inside Slack's 3000-char-per-text-element limit.  When the message
+        body exceeds that budget, only the first chunk goes into the button
+        block; the remainder is posted as plain-text threaded replies with
+        ``[i/N continued]`` markers so no content is silently dropped.
+        """
         if not self._app:
             return SendResult(success=False, error="Not connected")
 
         try:
-            body = message[:2900] + "..." if len(message) > 2900 else message
             thread_ts = self._resolve_thread_ts(None, metadata)
             # Encode session_key and confirm_id into the button value so the
             # callback handler can resolve without extra bookkeeping.
             value = f"{session_key}|{confirm_id}"
+
+            # Reserve room for the "*{title}*\n\n" wrapper inside the section.
+            title_str = title or "Confirm"
+            header = f"*{title_str}*\n\n"
+            max_body_in_section = self.MAX_SECTION_TEXT_LENGTH - len(header)
+
+            # Split the message body using the base chunker so code-block
+            # boundaries are preserved across continuation messages.
+            body_chunks = self.truncate_message(message, max_body_in_section)
+            # The first chunk goes into the section block alongside the buttons.
+            first_body = body_chunks[0]
 
             blocks = [
                 {
                     "type": "section",
                     "text": {
                         "type": "mrkdwn",
-                        "text": f"*{title or 'Confirm'}*\n\n{body}",
+                        "text": f"{header}{first_body}",
                     },
                 },
                 {
@@ -2371,14 +2434,37 @@ class SlackAdapter(BasePlatformAdapter):
 
             kwargs: Dict[str, Any] = {
                 "channel": chat_id,
-                "text": f"{title or 'Confirm'}: {body[:100]}",
+                "text": f"{title_str}: {first_body[:100]}",
                 "blocks": blocks,
             }
             if thread_ts:
                 kwargs["thread_ts"] = thread_ts
 
-            result = await self._get_client(chat_id).chat_postMessage(**kwargs)
-            return SendResult(success=True, message_id=result.get("ts", ""), raw_response=result)
+            result = await self._safe_post_message(
+                self._get_client(chat_id), **kwargs
+            )
+            msg_ts = result.get("ts", "")
+
+            # Post overflow chunks as plain-text threaded replies.
+            if len(body_chunks) > 1:
+                # Determine thread to reply under: prefer explicit thread_ts,
+                # else the just-posted message itself.
+                reply_thread = thread_ts or msg_ts
+                total = len(body_chunks)
+                for idx, continuation in enumerate(body_chunks[1:], start=2):
+                    marker = f"[{idx}/{total} continued]\n"
+                    follow_kwargs: Dict[str, Any] = {
+                        "channel": chat_id,
+                        "text": marker + continuation,
+                        "mrkdwn": True,
+                    }
+                    if reply_thread:
+                        follow_kwargs["thread_ts"] = reply_thread
+                    await self._safe_post_message(
+                        self._get_client(chat_id), **follow_kwargs
+                    )
+
+            return SendResult(success=True, message_id=msg_ts, raw_response=result)
         except Exception as e:
             logger.error("[Slack] send_slash_confirm failed: %s", e, exc_info=True)
             return SendResult(success=False, error=str(e))
@@ -2473,7 +2559,9 @@ class SlackAdapter(BasePlatformAdapter):
                 thread_ts = message.get("thread_ts") or msg_ts
                 if thread_ts:
                     post_kwargs["thread_ts"] = thread_ts
-                await self._get_client(channel_id).chat_postMessage(**post_kwargs)
+                await self._safe_post_message(
+                    self._get_client(channel_id), **post_kwargs
+                )
             logger.info(
                 "Slack button resolved slash-confirm for session %s (choice=%s, user=%s)",
                 session_key, choice, user_name,

--- a/tests/gateway/test_slack_chunking.py
+++ b/tests/gateway/test_slack_chunking.py
@@ -1,0 +1,329 @@
+"""
+Tests for Slack section-block chunking and _safe_post_message error surfacing.
+
+Covers:
+- send() with a 50KB report: posts N chunks via chat_postMessage; content
+  reconstructs across chunks.
+- send() with a 2KB report: posts exactly 1 chunk (no marker pollution).
+- send_slash_confirm() with a 5KB message: section block stays under 3000 chars;
+  remainder posts as threaded plain-text replies with continuation markers.
+- send_slash_confirm() with a 200-char message: posts 1 block, no follow-up.
+- _safe_post_message logs text_len + error code on SlackApiError.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch, call
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Ensure repo root is on sys.path
+# ---------------------------------------------------------------------------
+_repo = str(Path(__file__).resolve().parents[2])
+if _repo not in sys.path:
+    sys.path.insert(0, _repo)
+
+
+# ---------------------------------------------------------------------------
+# Minimal Slack SDK mock so SlackAdapter can be imported without real deps
+# ---------------------------------------------------------------------------
+
+def _ensure_slack_mock():
+    if "slack_bolt" in sys.modules:
+        return
+    slack_bolt = MagicMock()
+    slack_bolt.async_app.AsyncApp = MagicMock
+    sys.modules["slack_bolt"] = slack_bolt
+    sys.modules["slack_bolt.async_app"] = slack_bolt.async_app
+    handler_mod = MagicMock()
+    handler_mod.AsyncSocketModeHandler = MagicMock
+    sys.modules["slack_bolt.adapter"] = MagicMock()
+    sys.modules["slack_bolt.adapter.socket_mode"] = MagicMock()
+    sys.modules["slack_bolt.adapter.socket_mode.async_handler"] = handler_mod
+    sdk_mod = MagicMock()
+    sdk_mod.web = MagicMock()
+    sdk_mod.web.async_client = MagicMock()
+    sdk_mod.web.async_client.AsyncWebClient = MagicMock
+    sys.modules["slack_sdk"] = sdk_mod
+    sys.modules["slack_sdk.web"] = sdk_mod.web
+    sys.modules["slack_sdk.web.async_client"] = sdk_mod.web.async_client
+    sys.modules.setdefault("aiohttp", MagicMock())
+
+
+_ensure_slack_mock()
+
+import gateway.platforms.slack as _slack_mod
+_slack_mod.SLACK_AVAILABLE = True
+
+from gateway.platforms.slack import SlackAdapter  # noqa: E402
+from gateway.config import Platform, PlatformConfig  # noqa: E402
+from gateway.platforms.base import SendResult  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_adapter() -> SlackAdapter:
+    """Return a SlackAdapter wired with a mock Slack client on team T1 / channel C1."""
+    config = PlatformConfig(enabled=True, token="xoxb-test-token")
+    adapter = SlackAdapter(config)
+    adapter._app = MagicMock()
+    adapter._bot_user_id = "U_BOT"
+    adapter._team_clients = {"T1": AsyncMock()}
+    adapter._team_bot_user_ids = {"T1": "U_BOT"}
+    adapter._channel_team = {"C1": "T1"}
+    return adapter
+
+
+# ---------------------------------------------------------------------------
+# send() — top-level message chunking
+# ---------------------------------------------------------------------------
+
+class TestSendChunking:
+    """send() already chunks at MAX_MESSAGE_LENGTH; verify the plumbing still works."""
+
+    @pytest.mark.asyncio
+    async def test_large_report_posts_multiple_chunks(self):
+        """A 50KB report must be split into several chat_postMessage calls."""
+        adapter = _make_adapter()
+        client = adapter._team_clients["T1"]
+        client.chat_postMessage = AsyncMock(return_value={"ts": "111.1"})
+
+        big_message = "x" * 50_000
+
+        result = await adapter.send(chat_id="C1", content=big_message)
+
+        assert result.success is True
+        assert client.chat_postMessage.call_count > 1
+
+        # Reconstruct content across all calls (strip chunk markers).
+        all_text = "".join(
+            c[1]["text"]
+            for c in client.chat_postMessage.call_args_list
+        )
+        # All original x's must be present somewhere (markers are additions, not deletions).
+        raw_x_count = all_text.count("x")
+        assert raw_x_count == 50_000
+
+    @pytest.mark.asyncio
+    async def test_small_report_posts_one_chunk_no_marker(self):
+        """A 2KB report must post exactly one chunk with no continuation marker."""
+        adapter = _make_adapter()
+        client = adapter._team_clients["T1"]
+        client.chat_postMessage = AsyncMock(return_value={"ts": "222.2"})
+
+        small_message = "y" * 2_000
+
+        result = await adapter.send(chat_id="C1", content=small_message)
+
+        assert result.success is True
+        assert client.chat_postMessage.call_count == 1
+
+        sent_text = client.chat_postMessage.call_args[1]["text"]
+        assert "continued" not in sent_text
+        assert "/" not in sent_text or "http" in sent_text  # no i/N marker
+
+
+# ---------------------------------------------------------------------------
+# send_slash_confirm() — section-block chunking
+# ---------------------------------------------------------------------------
+
+class TestSendSlashConfirmChunking:
+    """Section block text must stay under MAX_SECTION_TEXT_LENGTH (2900 chars)."""
+
+    @pytest.mark.asyncio
+    async def test_large_message_keeps_section_under_limit(self):
+        """A 5KB message body: section block text must be ≤ MAX_SECTION_TEXT_LENGTH."""
+        adapter = _make_adapter()
+        client = adapter._team_clients["T1"]
+        client.chat_postMessage = AsyncMock(return_value={"ts": "333.3"})
+
+        big_message = "A" * 5_000
+
+        result = await adapter.send_slash_confirm(
+            chat_id="C1",
+            title="Big Report",
+            message=big_message,
+            session_key="sk",
+            confirm_id="cid",
+        )
+
+        assert result.success is True
+        # First call must carry the button blocks.
+        first_call_kwargs = client.chat_postMessage.call_args_list[0][1]
+        section_text = first_call_kwargs["blocks"][0]["text"]["text"]
+        assert len(section_text) <= adapter.MAX_SECTION_TEXT_LENGTH
+
+    @pytest.mark.asyncio
+    async def test_large_message_posts_continuation_replies(self):
+        """A 5KB message: overflow must arrive as threaded replies with [i/N continued] markers."""
+        adapter = _make_adapter()
+        client = adapter._team_clients["T1"]
+        client.chat_postMessage = AsyncMock(return_value={"ts": "444.4"})
+
+        big_message = "B" * 5_000
+
+        await adapter.send_slash_confirm(
+            chat_id="C1",
+            title="Big",
+            message=big_message,
+            session_key="sk",
+            confirm_id="cid",
+        )
+
+        assert client.chat_postMessage.call_count >= 2
+
+        # All calls after the first must be text-only (no blocks) continuations.
+        for follow_call in client.chat_postMessage.call_args_list[1:]:
+            kw = follow_call[1]
+            assert "blocks" not in kw
+            assert "continued" in kw["text"]
+
+    @pytest.mark.asyncio
+    async def test_large_message_full_content_preserved(self):
+        """The full message body must be recoverable by concatenating all sent text."""
+        adapter = _make_adapter()
+        client = adapter._team_clients["T1"]
+        client.chat_postMessage = AsyncMock(return_value={"ts": "555.5"})
+
+        big_message = "C" * 5_000
+
+        await adapter.send_slash_confirm(
+            chat_id="C1",
+            title="Preserve",
+            message=big_message,
+            session_key="sk",
+            confirm_id="cid",
+        )
+
+        all_sent = "".join(
+            c[1]["text"] if "blocks" not in c[1]
+            else c[1]["blocks"][0]["text"]["text"]
+            for c in client.chat_postMessage.call_args_list
+        )
+        assert all_sent.count("C") == 5_000
+
+    @pytest.mark.asyncio
+    async def test_small_message_single_post_no_follow_up(self):
+        """A 200-char message: exactly one chat_postMessage, no threaded follow-up."""
+        adapter = _make_adapter()
+        client = adapter._team_clients["T1"]
+        client.chat_postMessage = AsyncMock(return_value={"ts": "666.6"})
+
+        small_message = "D" * 200
+
+        result = await adapter.send_slash_confirm(
+            chat_id="C1",
+            title="Small",
+            message=small_message,
+            session_key="sk",
+            confirm_id="cid",
+        )
+
+        assert result.success is True
+        assert client.chat_postMessage.call_count == 1
+
+        kw = client.chat_postMessage.call_args[1]
+        assert "blocks" in kw
+        section_text = kw["blocks"][0]["text"]["text"]
+        assert "D" * 200 in section_text
+        assert "continued" not in section_text
+
+    @pytest.mark.asyncio
+    async def test_continuation_replies_are_threaded(self):
+        """Overflow chunks must include thread_ts equal to the first post's ts."""
+        adapter = _make_adapter()
+        client = adapter._team_clients["T1"]
+        # First call returns a ts; subsequent calls inherit it as thread_ts.
+        client.chat_postMessage = AsyncMock(return_value={"ts": "777.7"})
+
+        big_message = "E" * 5_000
+
+        await adapter.send_slash_confirm(
+            chat_id="C1",
+            title="Thread",
+            message=big_message,
+            session_key="sk",
+            confirm_id="cid",
+        )
+
+        for follow_call in client.chat_postMessage.call_args_list[1:]:
+            kw = follow_call[1]
+            assert kw.get("thread_ts") == "777.7"
+
+
+# ---------------------------------------------------------------------------
+# _safe_post_message — error surfacing
+# ---------------------------------------------------------------------------
+
+class TestSafePostMessage:
+    """_safe_post_message must log error details and re-raise on failure."""
+
+    @pytest.mark.asyncio
+    async def test_logs_error_code_on_slack_api_error(self, caplog):
+        """SlackApiError with a known error code must appear in WARNING logs."""
+        adapter = _make_adapter()
+
+        # Build a minimal SlackApiError-like exception.
+        mock_exc = Exception("slack api failure")
+        mock_exc.response = {"error": "invalid_blocks"}  # type: ignore[attr-defined]
+
+        mock_client = AsyncMock()
+        mock_client.chat_postMessage = AsyncMock(side_effect=mock_exc)
+
+        import logging
+        with caplog.at_level(logging.WARNING, logger="gateway.platforms.slack"):
+            with pytest.raises(Exception):
+                await adapter._safe_post_message(
+                    mock_client,
+                    channel="C1",
+                    text="hello",
+                    blocks=[
+                        {
+                            "type": "section",
+                            "text": {"type": "mrkdwn", "text": "A" * 3100},
+                        }
+                    ],
+                )
+
+        log_text = " ".join(caplog.messages)
+        assert "invalid_blocks" in log_text
+        assert "text_len" in log_text
+
+    @pytest.mark.asyncio
+    async def test_logs_text_len_and_section_len_on_generic_error(self, caplog):
+        """A generic (non-SlackApiError) exception must also log text_len."""
+        adapter = _make_adapter()
+
+        mock_client = AsyncMock()
+        mock_client.chat_postMessage = AsyncMock(
+            side_effect=RuntimeError("network error")
+        )
+
+        import logging
+        with caplog.at_level(logging.WARNING, logger="gateway.platforms.slack"):
+            with pytest.raises(RuntimeError):
+                await adapter._safe_post_message(
+                    mock_client,
+                    channel="C1",
+                    text="some text",
+                )
+
+        log_text = " ".join(caplog.messages)
+        assert "text_len" in log_text
+
+    @pytest.mark.asyncio
+    async def test_returns_result_on_success(self):
+        """_safe_post_message must pass through the response dict unchanged."""
+        adapter = _make_adapter()
+        expected = {"ts": "999.9", "ok": True}
+
+        mock_client = AsyncMock()
+        mock_client.chat_postMessage = AsyncMock(return_value=expected)
+
+        result = await adapter._safe_post_message(
+            mock_client, channel="C1", text="hi"
+        )
+        assert result == expected


### PR DESCRIPTION
## Summary

When an agents sends a ~2KB structured report via `send_slash_confirm`, Slack silently rejected it because the section block `text` field exceeded the 3000-char-per-element API limit — producing two empty-looking messages at the same timestamp. The top-level `text` field was fine (well under 40k), but the block-level limit is separate and was never enforced.

Root cause: `send_slash_confirm` used a hard truncation at 2900 chars (`message[:2900] + "..."`), which silently drops content rather than chunking it. More critically, no call site checked the Slack API response for error details, so the rejection was invisible in logs.

This PR makes the send path section-block-aware and adds error surfacing across all `chat_postMessage` call sites:

- **`MAX_SECTION_TEXT_LENGTH = 2900`** constant added near `MAX_MESSAGE_LENGTH` (Slack's 3000-char hard limit minus 100-char margin).
- **`send_slash_confirm` rewritten**: uses `BasePlatformAdapter.truncate_message` to split the message body at the section budget (preserving code-block boundaries). The first chunk goes in the button block; overflow posts as threaded plain-text replies with `[i/N continued]` markers — no content is ever silently dropped.
- **`_safe_post_message` helper** wraps every `chat_postMessage` call. On `SlackApiError` it logs `error_code`, `text_len`, `blocks_count`, and longest section-block text length at `WARNING` level before re-raising. Wired into `send()`, `send_exec_approval`, `send_slash_confirm`, and the button-action follow-up path.
- **10 new tests** in `tests/gateway/test_slack_chunking.py` covering: large/small `send()` chunking, section-block size ceiling, continuation threading, full content preservation, and `_safe_post_message` error-code logging. All 285 existing Slack tests continue to pass; ruff clean.

<!-- pr-mermaid:eval -->
new-pattern: yes
  what: send_slash_confirm now chunks at section-block level and routes all chat_postMessage calls through a logging wrapper
visualizable: no
  why: the change is a linear call-site refactor with no branching flow or state machine; a diagram would add no information over the prose description
decision: skip
<!-- /pr-mermaid:eval -->

## Test plan

- [x] `uv run --extra dev python -m pytest tests/gateway/test_slack_chunking.py -v` — 10/10 pass
- [x] `uv run --extra dev python -m pytest tests/gateway/test_slack.py tests/gateway/test_slack_approval_buttons.py tests/gateway/test_slack_mention.py tests/gateway/test_slack_channel_skills.py -v` — 275/275 pass
- [x] `uv run --extra dev ruff check gateway/platforms/slack.py tests/gateway/test_slack_chunking.py` — clean
- [ ] Reviewer: send a >3000-char report via `/hermes` slash command in a real workspace and confirm no empty-message pair appears

Closes #18