### PR TITLE
fix: wire STT lazy-install into transcription_tools.py

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -47,6 +47,7 @@ ACP_REGISTRY_MANIFEST = REPO_ROOT / "acp_registry" / "agent.json"
 AUTHOR_MAP = {
     # teknium (multiple emails)
     "teknium1@gmail.com": "teknium1",
+    "cipherframe@users.noreply.github.com": "CipherFrame",
     "me@promplate.dev": "CNSeniorious000",
     "yichengqiao21@gmail.com": "YarrowQiao",
     "erhanyasarx@gmail.com": "erhnysr",

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -197,6 +197,26 @@ def _normalize_local_command_model(model_name: Optional[str]) -> str:
     return _normalize_local_model(model_name)
 
 
+def _try_lazy_install_stt() -> bool:
+    """Attempt to lazy-install faster-whisper and return True on success.
+
+    The module-level ``_HAS_FASTER_WHISPER`` flag is set at import time and
+    cached. If the package wasn't installed at startup, calling ``ensure()``
+    installs it. This function re-checks dynamically after installation so
+    the provider can use it immediately without a process restart.
+    """
+    try:
+        from tools.lazy_deps import ensure
+        ensure("stt.faster_whisper")
+        # Re-check dynamically after install
+        import importlib.util as _iu
+        if _iu.find_spec("faster_whisper"):
+            return True
+    except Exception:
+        pass
+    return False
+
+
 def _get_provider(stt_config: dict) -> str:
     """Determine which STT provider to use.
 
@@ -218,6 +238,9 @@ def _get_provider(stt_config: dict) -> str:
                 return "local"
             if _has_local_command():
                 return "local_command"
+            # Try lazy-install before giving up
+            if _try_lazy_install_stt():
+                return "local"
             logger.warning(
                 "STT provider 'local' configured but unavailable "
                 "(install faster-whisper or set HERMES_LOCAL_STT_COMMAND)"
@@ -285,6 +308,9 @@ def _get_provider(stt_config: dict) -> str:
         return "local"
     if _has_local_command():
         return "local_command"
+    # Try lazy-install before falling through to cloud providers
+    if _try_lazy_install_stt():
+        return "local"
     if _HAS_OPENAI and get_env_value("GROQ_API_KEY"):
         logger.info("No local STT available, using Groq Whisper API")
         return "groq"
@@ -403,7 +429,8 @@ def _transcribe_local(file_path: str, model_name: str) -> Dict[str, Any]:
     global _local_model, _local_model_name
 
     if not _HAS_FASTER_WHISPER:
-        return {"success": False, "transcript": "", "error": "faster-whisper not installed"}
+        if not _try_lazy_install_stt():
+            return {"success": False, "transcript": "", "error": "faster-whisper not installed"}
 
     try:
         # Lazy-load the model (downloads on first use, ~150 MB for 'base')

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -212,8 +212,8 @@ def _try_lazy_install_stt() -> bool:
         import importlib.util as _iu
         if _iu.find_spec("faster_whisper"):
             return True
-    except Exception:
-        pass
+    except Exception as exc:
+        logger.debug("Lazy install of faster-whisper failed: %s", exc)
     return False
 
 


### PR DESCRIPTION
Salvage of #30056 (@CipherFrame) onto current main.

## Summary
Voice messages no longer drop silently when faster-whisper is missing from the active gateway environment. Three STT provider-selection gates now call `ensure("stt.faster_whisper")` and re-check via `find_spec` so a fresh container/venv self-heals on the first voice message instead of logging `STT provider 'local' configured but unavailable` and returning `"none"`.

## Root cause
`tools/lazy_deps.py` declared `stt.faster_whisper` (faster-whisper, sounddevice, numpy) but no caller ever invoked `ensure()`. The module-level `_HAS_FASTER_WHISPER` constant is cached at import — Docker users who installed faster-whisper into a running container saw it work, but `docker compose pull/up` recreated the container without the package and the cached `False` flag never re-evaluated.

## Changes
- `tools/transcription_tools.py`: `_try_lazy_install_stt()` helper, wired into both `_get_provider()` branches and the `_transcribe_local()` guard. Install errors logged at debug.
- `scripts/release.py`: AUTHOR_MAP entry for CipherFrame.

## Validation
- Targeted E2E (isolated HERMES_HOME, real `transcription_tools` import): with module-level `_HAS_FASTER_WHISPER=False` and `stt.provider='local'`, `_get_provider()` now returns `'local'` via the lazy-install rescue path instead of `'none'`.
- Discord ticket evidence: ticket repro is `stt.provider: local` + missing faster-whisper after container recreate. This is the exact path the fix exercises.

Closes #30056. Credit to @CipherFrame.

## Infographic

![stt-lazy-install](https://v3b.fal.media/files/b/0a9b328e/4XJm7I0tF5kvpu_F6_GQg_0TMEIBJ2.png)
