### PR TITLE
feat(ollama-cloud): add DeepSeek thinking-mode and reasoning_effort support

### DIFF
--- a/plugins/model-providers/ollama-cloud/__init__.py
+++ b/plugins/model-providers/ollama-cloud/__init__.py
@@ -1,9 +1,63 @@
 """Ollama Cloud provider profile."""
 
+from typing import Any
+
 from providers import register_provider
 from providers.base import ProviderProfile
 
-ollama_cloud = ProviderProfile(
+
+class OllamaCloudProfile(ProviderProfile):
+    """Ollama Cloud provider with DeepSeek thinking-mode support.
+
+    DeepSeek models accept a native ``{"thinking": {"type": "enabled"}}``
+    extra_body parameter that surfaces chain-of-thought reasoning content.
+    Without it the model still reasons internally but Hermes can't display
+    or replay the reasoning track.
+    """
+
+    # Models known to support reasoning_effort=max (verified 2026-05-22).
+    # ollama.com proxy rejects xhigh → 400; map to max for these.
+    _MAX_EFFORT_MODELS = frozenset({
+        "deepseek-v4-pro",
+        "deepseek-v4-flash",
+        "deepseek-v3.2",
+        "deepseek-v3.1:671b",
+    })
+
+    def build_extra_body(
+        self, *, session_id: str | None = None, **context: Any
+    ) -> dict[str, Any]:
+        extra: dict[str, Any] = {}
+        model = str(context.get("model", "") or "")
+        if "deepseek" in model.lower():
+            extra["thinking"] = {"type": "enabled"}
+        if session_id:
+            extra["session_id"] = session_id
+        return extra
+
+    def build_api_kwargs_extras(
+        self,
+        *,
+        reasoning_config: dict | None = None,
+        model: str | None = None,
+        **context: Any,
+    ) -> tuple[dict[str, Any], dict[str, Any]]:
+        """Emit reasoning_effort, translating xhigh→max for known models."""
+        if not reasoning_config or not reasoning_config.get("enabled"):
+            return {}, {}
+        effort = reasoning_config.get("effort", "")
+        if not effort:
+            return {}, {}
+        # ollama.com accepts: low, medium, high, max
+        # Map xhigh → max for models that support it.
+        if effort == "xhigh" and (model or "") in self._MAX_EFFORT_MODELS:
+            effort = "max"
+        if effort not in ("low", "medium", "high", "max"):
+            return {}, {}
+        return {}, {"reasoning_effort": effort}
+
+
+ollama_cloud = OllamaCloudProfile(
     name="ollama-cloud",
     aliases=("ollama_cloud",),
     default_aux_model="nemotron-3-nano:30b",


### PR DESCRIPTION
DeepSeek models on Ollama Cloud support `{"thinking": {"type": "enabled"}}` in `extra_body` to surface chain-of-thought reasoning content. Without this parameter the model still reasons internally but Hermes cannot display or replay the reasoning track.

## Changes

**`OllamaCloudProfile` subclass with two methods:**

1. **`build_extra_body()`** — auto-injects `thinking: {"type": "enabled"}` when model name contains `deepseek`. Also propagates `session_id`.

2. **`build_api_kwargs_extras()`** — emits `reasoning_effort` as a top-level kwarg and translates `xhigh` → `max` for known models. Ollama Cloud rejects `xhigh` with 400; only `low/medium/high/max/none` are accepted.

`_MAX_EFFORT_MODELS` tracks which models support `reasoning_effort=max` (verified 2026-05-22):
- `deepseek-v4-pro`
- `deepseek-v4-flash`
- `deepseek-v3.2`
- `deepseek-v3.1:671b`

## Verification

End-to-end API testing (3 runs averaged over same Monty Hall prompt):

```
effort=max  + thinking: ╬╝=7,055 chars reasoning (51-104s, 2,504-4,722 tokens)
thinking only:         ╬╝=  595 chars reasoning (25-35s,  1,477-1,590 tokens)
effort=high + thinking: ╬╝=  438 chars reasoning (21-25s,  1,250-1,484 tokens)
```

`max` effort provides ~11.8x more reasoning vs thinking-only. `high` is essentially the same as thinking-only on this model — the behavior is roughly binary.