### PR TITLE
fix(achievements): honor base path for reverse-proxy dashboards (HA add-on 404)

### DIFF
--- a/plugins/hermes-achievements/dashboard/dist/index.js
+++ b/plugins/hermes-achievements/dashboard/dist/index.js
@@ -49,7 +49,8 @@
   };
 
   async function api(path, options) {
-    const url = "/api/plugins/hermes-achievements" + path;
+    const basePath = (window.__HERMES_BASE_PATH__ || "").replace(/\/$/, "");
+    const url = basePath + "/api/plugins/hermes-achievements" + path;
     const token = window.__HERMES_SESSION_TOKEN__ || "";
     const headers = { ...((options && options.headers) || {}) };
     if (token) headers["X-Hermes-Session-Token"] = token;


### PR DESCRIPTION
## Summary

The Achievements dashboard plugin bundles an API URL builder that hardcodes `/api/plugins/hermes-achievements` as an absolute root path. When the Hermes dashboard is served behind a reverse-proxy prefix — most commonly the Home Assistant add-on at `/dashboard/...` — those requests bypass the dashboard proxy route, hit the host at `/api/...` directly, and return **404**. The Achievements page then renders:

```
Error: 404: 404: Not Found
```

The dashboard already injects `window.__HERMES_BASE_PATH__` for exactly this case (see `hermes_cli/web_server.py` and `web/src/lib/api.ts`), and other built-in plugin entry points (kanban, gateway client, plugin loader) already respect it. This one-line change makes the achievements bundle do the same.

## Change

`plugins/hermes-achievements/dashboard/dist/index.js`:

```diff
   async function api(path, options) {
-    const url = "/api/plugins/hermes-achievements" + path;
+    const basePath = (window.__HERMES_BASE_PATH__ || "").replace(/\/$/, "");
+    const url = basePath + "/api/plugins/hermes-achievements" + path;
```

When no prefix is in use, `basePath` is the empty string, so the URL is unchanged for the default dashboard.

## Verification

Locally under the Home Assistant add-on (dashboard mounted at `/dashboard/`):

```
$ curl -s -o /dev/null -w '%{http_code}\n' \
    http://127.0.0.1:49169/dashboard/api/plugins/hermes-achievements/achievements
200

$ curl -s -o /dev/null -w '%{http_code}\n' \
    http://127.0.0.1:49169/api/plugins/hermes-achievements/achievements
404   # expected — nginx doesn't proxy /api/... outside the dashboard prefix
```

With the old code, the dashboard plugin called the second URL and surfaced the nginx 404. With the patched bundle the page loads its full payload (54 achievements discovered, 6 unlocked) and the live scan progresses normally.

## Note on the bundled source

`plugins/hermes-achievements/` only vendors the built `dist/` (the upstream TS source lives in [PCinkusz/hermes-achievements](https://github.com/PCinkusz/hermes-achievements)), so the patch is applied to `dist/index.js` directly. Happy to also open the same fix against the upstream source repo so the next vendored build keeps it.
