### PR TITLE
fix(honcho): flatten multimodal list content in sync_turn (#30252)

### DIFF
--- a/plugins/memory/honcho/__init__.py
+++ b/plugins/memory/honcho/__init__.py
@@ -1117,11 +1117,52 @@ class HonchoMemoryProvider(MemoryProvider):
             ),
         }
 
+    @staticmethod
+    def _flatten_content(content):
+        """Flatten OpenAI multimodal list content to a plain string.
+
+        ``sync_turn`` is sometimes invoked with the OpenAI vision-style
+        list shape (e.g. ``[{"type": "text", "text": ...},
+        {"type": "image_url", ...}]``). ``sanitize_context`` expects a
+        string, so we collapse list content into a newline-joined
+        textual representation here — image / non-text parts become
+        ``[image]`` / ``[<type>]`` placeholders so the resulting
+        Honcho turn still reflects that visuals were exchanged.
+        """
+        if not isinstance(content, list):
+            return content
+        parts = []
+        for item in content:
+            if isinstance(item, str):
+                if item:
+                    parts.append(item)
+                continue
+            if not isinstance(item, dict):
+                continue
+            t = item.get("type")
+            if t in ("text", "input_text", "output_text"):
+                text = item.get("text", "")
+                if not isinstance(text, str):
+                    text = str(text) if text is not None else ""
+                if text:
+                    parts.append(text)
+            elif t in ("image_url", "input_image"):
+                parts.append("[image]")
+            elif t:
+                parts.append(f"[{t}]")
+        return "\n".join(parts)
+
     def sync_turn(self, user_content: str, assistant_content: str, *, session_id: str = "") -> None:
         """Record the conversation turn in Honcho (non-blocking).
 
         Messages exceeding the Honcho API limit (default 25k chars) are
         split into multiple messages with continuation markers.
+
+        ``user_content`` / ``assistant_content`` may be either a plain
+        string or the OpenAI multimodal list shape; the latter is
+        flattened to text before sanitisation so vision turns are
+        still recorded (with ``[image]`` markers) instead of being
+        silently dropped (#30252).
         """
         if self._cron_skipped:
             return
@@ -1129,6 +1170,8 @@ class HonchoMemoryProvider(MemoryProvider):
             return
 
         msg_limit = self._config.message_max_chars if self._config else 25000
+        user_content = self._flatten_content(user_content)
+        assistant_content = self._flatten_content(assistant_content)
         clean_user_content = sanitize_context(user_content or "").strip()
         clean_assistant_content = sanitize_context(assistant_content or "").strip()
 

--- a/tests/honcho_plugin/test_sync_turn_multimodal.py
+++ b/tests/honcho_plugin/test_sync_turn_multimodal.py
@@ -1,0 +1,181 @@
+"""Regression tests for HonchoMemoryProvider.sync_turn with multimodal content.
+
+See https://github.com/NousResearch/hermes-agent/issues/30252 — the OpenAI
+vision-style ``list`` content shape used to crash ``sync_turn`` because
+``sanitize_context`` only accepts strings, causing vision turns to be
+silently dropped from Honcho memory.
+"""
+
+from __future__ import annotations
+
+import threading
+
+import pytest
+
+from plugins.memory.honcho import HonchoMemoryProvider
+
+
+# ---------------------------------------------------------------------------
+# _flatten_content unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_flatten_passthrough_string():
+    assert HonchoMemoryProvider._flatten_content("hello") == "hello"
+
+
+def test_flatten_passthrough_none():
+    assert HonchoMemoryProvider._flatten_content(None) is None
+
+
+def test_flatten_text_and_image_url():
+    content = [
+        {"type": "text", "text": "what colour is this?"},
+        {"type": "image_url", "image_url": {"url": "data:image/png;base64,AAA"}},
+    ]
+    assert (
+        HonchoMemoryProvider._flatten_content(content)
+        == "what colour is this?\n[image]"
+    )
+
+
+def test_flatten_input_image_alias():
+    content = [{"type": "input_image", "image": "..."}]
+    assert HonchoMemoryProvider._flatten_content(content) == "[image]"
+
+
+def test_flatten_unknown_type_becomes_placeholder():
+    content = [{"type": "foo", "data": "..."}]
+    assert HonchoMemoryProvider._flatten_content(content) == "[foo]"
+
+
+def test_flatten_empty_list():
+    assert HonchoMemoryProvider._flatten_content([]) == ""
+
+
+def test_flatten_bare_strings_in_list():
+    content = ["alpha", "beta"]
+    assert HonchoMemoryProvider._flatten_content(content) == "alpha\nbeta"
+
+
+def test_flatten_skips_empty_text_parts():
+    content = [
+        {"type": "text", "text": ""},
+        {"type": "text", "text": "kept"},
+    ]
+    assert HonchoMemoryProvider._flatten_content(content) == "kept"
+
+
+def test_flatten_skips_non_dict_non_str_items():
+    content = [42, None, {"type": "text", "text": "ok"}]
+    assert HonchoMemoryProvider._flatten_content(content) == "ok"
+
+
+def test_flatten_skips_type_missing():
+    content = [{"text": "no type field"}]
+    # No "type" → entry produces no part.
+    assert HonchoMemoryProvider._flatten_content(content) == ""
+
+
+# ---------------------------------------------------------------------------
+# sync_turn integration: list-shaped content must NOT raise, and the
+# flattened text must reach the mocked Honcho session.
+# ---------------------------------------------------------------------------
+
+
+class _FakeSession:
+    def __init__(self):
+        self.messages: list[tuple[str, str]] = []
+
+    def add_message(self, role, chunk):
+        self.messages.append((role, chunk))
+
+
+class _FakeManager:
+    def __init__(self):
+        self.session = _FakeSession()
+
+    def get_or_create(self, _key):
+        return self.session
+
+    def _flush_session(self, _session):
+        pass
+
+
+def _make_provider(monkeypatch=None):
+    """Build a minimally-wired HonchoMemoryProvider without running __init__."""
+    p = HonchoMemoryProvider.__new__(HonchoMemoryProvider)
+    p._cron_skipped = False
+    p._manager = _FakeManager()
+    p._session_key = "test-session"
+    p._config = None
+    p._sync_thread = None
+
+    # _chunk_message normally lives on the class — fall back to a passthrough
+    # if it isn't trivially callable on this lean instance.
+    if not hasattr(p, "_chunk_message"):
+        p._chunk_message = lambda text, _limit: [text] if text else []
+    return p
+
+
+def _run_sync_turn(provider, user_content, assistant_content):
+    provider.sync_turn(user_content, assistant_content)
+    if provider._sync_thread is not None:
+        provider._sync_thread.join(timeout=5.0)
+
+
+def test_sync_turn_accepts_multimodal_user_content():
+    provider = _make_provider()
+    user_content = [
+        {"type": "text", "text": "what colour is this?"},
+        {"type": "image_url", "image_url": {"url": "data:image/png;base64,AAA"}},
+    ]
+
+    _run_sync_turn(provider, user_content, "it is red")
+
+    roles = [r for r, _ in provider._manager.session.messages]
+    bodies = [c for _, c in provider._manager.session.messages]
+    assert "user" in roles
+    assert "assistant" in roles
+    # Flattened user content must include both the text and the image marker.
+    user_body = next(c for r, c in provider._manager.session.messages if r == "user")
+    assert "what colour is this?" in user_body
+    assert "[image]" in user_body
+    # Assistant string content passes through unchanged.
+    assert any("it is red" in b for b in bodies)
+
+
+def test_sync_turn_does_not_raise_on_list_assistant_content():
+    provider = _make_provider()
+    assistant_content = [{"type": "text", "text": "ok"}]
+    _run_sync_turn(provider, "hi", assistant_content)
+
+    bodies = [c for _, c in provider._manager.session.messages]
+    assert any("hi" == b for b in bodies)
+    assert any("ok" == b for b in bodies)
+
+
+def test_sync_turn_string_content_still_works():
+    provider = _make_provider()
+    _run_sync_turn(provider, "plain user", "plain assistant")
+
+    msgs = provider._manager.session.messages
+    assert ("user", "plain user") in msgs
+    assert ("assistant", "plain assistant") in msgs
+
+
+def test_flatten_input_text_canonicalized():
+    content = [{"type": "input_text", "text": "hello"}]
+    assert HonchoMemoryProvider._flatten_content(content) == "hello"
+
+
+def test_flatten_output_text_canonicalized():
+    content = [{"type": "output_text", "text": "assistant said"}]
+    assert HonchoMemoryProvider._flatten_content(content) == "assistant said"
+
+
+def test_flatten_non_string_text_value_does_not_raise():
+    content = [{"type": "text", "text": 123}, {"type": "text", "text": None}]
+    # Non-string text values are coerced (or skipped for None); join must not raise.
+    out = HonchoMemoryProvider._flatten_content(content)
+    assert "123" in out


### PR DESCRIPTION
## Summary

Fixes #30252.

`HonchoMemoryProvider.sync_turn` previously passed `user_content` /
`assistant_content` straight into `sanitize_context`, which expects a
string. When the gateway forwarded an OpenAI vision-style multimodal
turn (`content` as a list of `{type: text|image_url, ...}` parts),
`sanitize_context` raised `expected string or bytes-like object, got 'list'`.
The exception was caught and logged at WARNING by the memory manager, so
the chat completion still succeeded — but the turn was silently dropped
from Honcho's memory and the user representation never learned about
anything visual the assistant was shown.

## Fix

Add a small `_flatten_content` helper on `HonchoMemoryProvider` and call
it from `sync_turn` before sanitisation:

- `text` / `input_text` / `output_text` parts contribute their `text`
  (non-string values coerced via `str()` so a malformed part can't crash
  `"\n".join(...)`).
- `image_url` / `input_image` parts become a literal `[image]` marker so
  the Honcho turn still records that visuals were exchanged.
- Other typed parts become `[<type>]`. Bare strings inside the list are
  kept; non-dict / non-str items are skipped.
- Plain string callers are untouched — the helper returns its input
  unchanged when it isn't a list.

## Scope

Per the issue's scope note, only the Honcho plugin is patched. Other
memory providers (`mem0`, `supermemory`, `byterover`, `retaindb`,
`holographic`, `openviking`) may share the same defect at their
`sync_turn(user_content: str, ...)` boundary but were not investigated
in this change.

## Tests

New file `tests/honcho_plugin/test_sync_turn_multimodal.py` — 16 tests:

- `_flatten_content` unit coverage: string passthrough, `None`,
  text+image_url flattening, `input_text` / `output_text`
  canonicalisation, non-string `text` coercion, `input_image` alias,
  unknown-type placeholder, empty list, bare strings inside lists,
  items missing `type`, non-dict/non-str items.
- `sync_turn` integration: with a mocked `_manager` / session, passing
  list-shaped multimodal `user_content` no longer raises and the
  flattened text (`"what colour is this?\n[image]"`) reaches the
  session; list-shaped `assistant_content` also works; plain string
  callers still produce the unchanged messages.

```
$ pytest tests/honcho_plugin/test_sync_turn_multimodal.py -q
................                                                         [100%]
16 passed in 0.09s
```

## Checklist

- [x] Bugfix scoped to one plugin file + one new test file.
- [x] No behavior change for string callers.
- [x] New tests pass locally against the project venv.
- [x] Commit SSH-signed.
