### PR TITLE
fix: avoid npm warnings during TUI install

### DIFF
--- a/ui-tui/package-lock.json
+++ b/ui-tui/package-lock.json
@@ -387,24 +387,6 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/@babel/plugin-proposal-private-methods": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-methods/-/plugin-proposal-private-methods-7.18.6.tgz",
-      "integrity": "sha512-nutsvktDItsNn4rpGItSNV2sz1XwS+nfU0Rg8aCx3W3NOKVzdMjJRu0O5OkgDp3ZGICSTbgRpxZoWsxoKRvbeA==",
-      "deprecated": "This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-private-methods instead.",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-create-class-features-plugin": "^7.18.6",
-        "@babel/helper-plugin-utils": "^7.18.6"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
     "node_modules/@babel/template": {
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
@@ -3153,6 +3135,24 @@
       },
       "peerDependencies": {
         "eslint": ">=7"
+      }
+    },
+    "node_modules/eslint-plugin-react-compiler/node_modules/@babel/plugin-proposal-private-methods": {
+      "name": "@babel/plugin-transform-private-methods",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-methods/-/plugin-transform-private-methods-7.28.6.tgz",
+      "integrity": "sha512-piiuapX9CRv7+0st8lmuUlRSmX6mBcVeNQ1b4AYzJxfCMuBfB0vBXDiGSmm03pKJw1v6cZ8KSeM+oUnM6yAExg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-create-class-features-plugin": "^7.28.6",
+        "@babel/helper-plugin-utils": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/eslint-plugin-react-compiler/node_modules/zod": {

--- a/ui-tui/package.json
+++ b/ui-tui/package.json
@@ -42,5 +42,8 @@
     "tsx": "^4.19.0",
     "typescript": "^5.7.0",
     "vitest": "^4.1.3"
+  },
+  "overrides": {
+    "@babel/plugin-proposal-private-methods": "npm:@babel/plugin-transform-private-methods@^7.28.6"
   }
 }

--- a/ui-tui/packages/hermes-ink/src/utils/execFileNoThrow.ts
+++ b/ui-tui/packages/hermes-ink/src/utils/execFileNoThrow.ts
@@ -1,4 +1,4 @@
-import { spawn } from 'child_process'
+import { type ChildProcess, spawn, type StdioOptions } from 'child_process'
 type ExecFileOptions = {
   input?: string
   timeout?: number
@@ -32,11 +32,11 @@ export function execFileNoThrow(
     // doesn't inherit those pipe FDs — prevents handle leaks that can
     // keep the parent process alive. No output data is collected in
     // this mode; both stdout and stderr will be empty strings.
-    const stdioConfig = options.resolveOnExit
-      ? ['pipe', 'ignore', 'ignore'] as const
-      : 'pipe' as const
+    const stdioConfig: StdioOptions = options.resolveOnExit
+      ? ['pipe', 'ignore', 'ignore']
+      : 'pipe'
 
-    const child = spawn(file, args, {
+    const child: ChildProcess = spawn(file, args, {
       cwd: options.useCwd ? process.cwd() : undefined,
       env: options.env,
       stdio: stdioConfig


### PR DESCRIPTION
## Summary
- Replace the deprecated `@babel/plugin-proposal-private-methods` transitive install with `@babel/plugin-transform-private-methods` via npm overrides.
- Keep `npm ci` / update output free of the Babel deprecation warning during TUI dependency refreshes.
- Type the `spawn` stdio config in `execFileNoThrow` so the TUI type-check passes with current Node typings.

## Test plan
- `npm ci --no-fund --no-audit --progress=false`
- `npm run build`
- `npm run type-check`
- `npx eslint packages/hermes-ink/src/utils/execFileNoThrow.ts`
- `npx vitest run packages/hermes-ink/src/utils/execFileNoThrow.test.ts`
