### PR TITLE
fix(computer-use): add set_value to ComputerUseBackend ABC and _NoopBackend stub (#22748)

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -934,6 +934,7 @@ AUTHOR_MAP = {
     "holynn@placeholder.local": "holynn-q",
     "agent@hermes.local": "jacdevos",
     "sunsky.lau@gmail.com": "liuhao1024",
+    "fabianoeq@gmail.com": "rodrigoeqnit",
     "qiuqfang98@qq.com": "keepcalmqqf",
     "261867348+ai-ag2026@users.noreply.github.com": "ai-ag2026",
     "yanzh.su@gmail.com": "YanzhongSu",

--- a/tests/tools/test_computer_use.py
+++ b/tests/tools/test_computer_use.py
@@ -226,6 +226,21 @@ class TestDispatch:
         parsed = json.loads(out)
         assert "error" in parsed
 
+    def test_set_value_routes_to_backend(self, noop_backend):
+        """set_value must reach the backend — regression for missing _NoopBackend stub."""
+        from tools.computer_use.tool import handle_computer_use
+        out = handle_computer_use({"action": "set_value", "value": "Option A", "element": 5})
+        parsed = json.loads(out)
+        assert parsed.get("ok") is True
+        assert parsed.get("action") == "set_value"
+        assert any(c[0] == "set_value" for c in noop_backend.calls)
+
+    def test_set_value_missing_value_returns_error(self, noop_backend):
+        from tools.computer_use.tool import handle_computer_use
+        out = handle_computer_use({"action": "set_value"})
+        parsed = json.loads(out)
+        assert "error" in parsed
+
 
 # ---------------------------------------------------------------------------
 # Safety guards (type / key block lists)

--- a/tools/computer_use/backend.py
+++ b/tools/computer_use/backend.py
@@ -142,6 +142,14 @@ class ComputerUseBackend(ABC):
     def focus_app(self, app: str, raise_window: bool = False) -> ActionResult:
         """Route input to `app` (by name or bundle ID). Default: focus without raise."""
 
+    # ── Native-value mutation ────────────────────────────────────────
+    @abstractmethod
+    def set_value(self, value: str, element: Optional[int] = None) -> ActionResult:
+        """Set a native value on an element (e.g. AXPopUpButton selection).
+
+        `element` is the 1-based SOM index returned by a prior capture call.
+        """
+
     # ── Timing ──────────────────────────────────────────────────────
     def wait(self, seconds: float) -> ActionResult:
         """Default implementation: time.sleep."""

--- a/tools/computer_use/tool.py
+++ b/tools/computer_use/tool.py
@@ -200,6 +200,10 @@ class _NoopBackend(ComputerUseBackend):  # pragma: no cover
         self.calls.append(("focus_app", {"app": app, "raise": raise_window}))
         return ActionResult(ok=True, action="focus_app")
 
+    def set_value(self, value: str, element: Optional[int] = None) -> ActionResult:
+        self.calls.append(("set_value", {"value": value, "element": element}))
+        return ActionResult(ok=True, action="set_value")
+
 
 # ---------------------------------------------------------------------------
 # Dispatch


### PR DESCRIPTION
Salvages #22748 onto current main. Closes a contract gap on the `ComputerUseBackend` ABC.

## The problem
`_dispatch()` in `tools/computer_use/tool.py` already routes `set_value` to `backend.set_value(...)`, but `set_value` was never declared on the `ComputerUseBackend` ABC and was missing from the `_NoopBackend` test stub.

Consequences:
- Concrete backends that forget to implement `set_value` pass subclass validation silently — Python's ABC enforcement only fires when a method is declared `@abstractmethod`.
- In test mode, any handler exercising `set_value` raises `AttributeError` on `_NoopBackend` with no useful diagnostic.

## The fix
- `tools/computer_use/backend.py` — `set_value` declared as `@abstractmethod`. Concrete backends missing the impl now `TypeError` at construction time, exactly like every other action verb.
- `tools/computer_use/tool.py` — `_NoopBackend.set_value` records the call for test inspection (same shape as the other stub methods).
- `tests/tools/test_computer_use.py` — `test_set_value_routes_to_backend` verifies dispatch carries the args; `test_set_value_missing_value_returns_error` verifies missing `value` returns an error dict without raising.

## Validation
- One commit cherry-picked from #22748. One test-file conflict resolved against the drag-tests block landed in #30032 — both test sets preserved (drag tests + set_value tests), file compiles, all 72 tests pass.
- Targeted: `tests/tools/test_computer_use.py` — **72/72 passing** (70 baseline + 2 new from this PR).
- Added `fabianoeq@gmail.com → rodrigoeqnit` to `scripts/release.py` AUTHOR_MAP (separate follow-up commit).

Credit @rodrigoeqnit (PR #22748).

Closes #22748.

## Infographic

![pr-22748-set-value-abc](https://v3b.fal.media/files/b/0a9b32d4/FuY2nEmaPGvJaIms8UnuU_z0F1Iuk0.png)
