### PR TITLE
fix(secrets): correct Bitwarden override_existing default from False …

### DIFF
--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -241,7 +241,7 @@ def _apply_external_secret_sources(home_path: Path) -> None:
         enabled=True,
         access_token_env=bw_cfg.get("access_token_env", "BWS_ACCESS_TOKEN"),
         project_id=bw_cfg.get("project_id", ""),
-        override_existing=bool(bw_cfg.get("override_existing", False)),
+        override_existing=bool(bw_cfg.get("override_existing", True)),
         cache_ttl_seconds=float(bw_cfg.get("cache_ttl_seconds", 300)),
         auto_install=bool(bw_cfg.get("auto_install", True)),
     )

--- a/hermes_cli/secrets_cli.py
+++ b/hermes_cli/secrets_cli.py
@@ -257,7 +257,7 @@ def cmd_status(args: argparse.Namespace) -> int:
     table.add_row("Token env var",   token_env)
     table.add_row("Token in env",    _yn(token_set))
     table.add_row("Project ID",      project_id or "[dim](unset)[/dim]")
-    table.add_row("Override existing", _yn(bool(bw_cfg.get("override_existing", False))))
+    table.add_row("Override existing", _yn(bool(bw_cfg.get("override_existing", True))))
     table.add_row("Cache TTL (s)",   str(bw_cfg.get("cache_ttl_seconds", 300)))
     table.add_row("Auto-install",    _yn(bool(bw_cfg.get("auto_install", True))))
 
@@ -320,7 +320,7 @@ def cmd_sync(args: argparse.Namespace) -> int:
         console.print("[yellow]No secrets in project.[/yellow]")
         return 0
 
-    override = bool(bw_cfg.get("override_existing", False)) or args.apply
+    override = bool(bw_cfg.get("override_existing", True)) or args.apply
     table = Table(show_header=True, header_style="bold")
     table.add_column("Name", style="cyan")
     table.add_column("Action")


### PR DESCRIPTION
    Bug: Bitwarden override_existing default contradicts config template and docs

    The three locations that read override_existing from config.yaml all fall back to False, but every other source says the default should be True:

    | Source                             | Default                                 |
    |------------------------------------|-----------------------------------------|
    | config.py default template (L1773) | True                                    |
    | Setup wizard (secrets_cli.py L226) | writes True                             |
    | Commit message of #30035           | "Bitwarden defaults to source of truth" |
    | bitwarden.md docs (L10, L88)       | true                                    |
    | env_loader.py L206                 | False                                   |
    | secrets_cli.py L260                | False                                   |
    | secrets_cli.py L323                | False                                   |

    Impact

    Users who manually configure Bitwarden (without the setup wizard) and omit override_existing — because the docs say the default is true — get silent key rotation failures. Hermes pulls the rotated key from BSM but discards it, keeping the stale .env value.

    Change

    Align the three bw_cfg.get("override_existing", ...) fallback values from False to True, matching the config template, wizard, docs, and commit intent.