### PR TITLE
fix: guard float(os.getenv()) against non-numeric env var values

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -64,6 +64,18 @@ from utils import base_url_host_matches, base_url_hostname
 logger = logging.getLogger(__name__)
 
 
+def _safe_float_env(var_name: str, default: float) -> float:
+    """Read env var as float, returning *default* if missing or non-numeric."""
+    raw = os.getenv(var_name)
+    if raw is None:
+        return default
+    try:
+        return float(raw)
+    except (ValueError, TypeError):
+        logger.warning("Invalid %s=%r, using default %s", var_name, raw, default)
+        return default
+
+
 def _ra():
     """Lazy ``run_agent`` reference.
 
@@ -1314,14 +1326,14 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
         _base_timeout = (
             _provider_timeout_cfg
             if _provider_timeout_cfg is not None
-            else float(os.getenv("HERMES_API_TIMEOUT", 1800.0))
+            else _safe_float_env("HERMES_API_TIMEOUT", 1800.0)
         )
         # Read timeout: config wins here too.  Otherwise use
         # HERMES_STREAM_READ_TIMEOUT (default 120s) for cloud providers.
         if _provider_timeout_cfg is not None:
             _stream_read_timeout = _provider_timeout_cfg
         else:
-            _stream_read_timeout = float(os.getenv("HERMES_STREAM_READ_TIMEOUT", 120.0))
+            _stream_read_timeout = _safe_float_env("HERMES_STREAM_READ_TIMEOUT", 120.0)
             # Local providers (Ollama, llama.cpp, vLLM) can take minutes for
             # prefill on large contexts before producing the first token.
             # Auto-increase the httpx read timeout unless the user explicitly
@@ -1926,7 +1938,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
     if _cfg_stale is not None:
         _stream_stale_timeout_base = _cfg_stale
     else:
-        _stream_stale_timeout_base = float(os.getenv("HERMES_STREAM_STALE_TIMEOUT", 180.0))
+        _stream_stale_timeout_base = _safe_float_env("HERMES_STREAM_STALE_TIMEOUT", 180.0)
     # Local providers (Ollama, oMLX, llama-cpp) can take 300+ seconds
     # for prefill on large contexts.  Disable the stale detector unless
     # the user explicitly set HERMES_STREAM_STALE_TIMEOUT.

--- a/run_agent.py
+++ b/run_agent.py
@@ -323,6 +323,18 @@ class _StreamErrorEvent(Exception):
         }
 
 
+def _safe_float_env(var_name: str, default: float) -> float:
+    """Read env var as float, returning *default* if missing or non-numeric."""
+    raw = os.getenv(var_name)
+    if raw is None:
+        return default
+    try:
+        return float(raw)
+    except (ValueError, TypeError):
+        logger.warning("Invalid %s=%r, using default %s", var_name, raw, default)
+        return default
+
+
 class AIAgent:
     """
     AI Agent with tool calling capabilities.
@@ -875,7 +887,7 @@ class AIAgent:
         cfg = get_provider_request_timeout(self.provider, self.model)
         if cfg is not None:
             return cfg
-        return float(os.getenv("HERMES_API_TIMEOUT", 1800.0))
+        return _safe_float_env("HERMES_API_TIMEOUT", 1800.0)
 
     def _resolved_api_call_stale_timeout_base(self) -> tuple[float, bool]:
         """Resolve the base non-stream stale timeout and whether it is implicit.
@@ -897,7 +909,7 @@ class AIAgent:
 
         env_timeout = os.getenv("HERMES_API_CALL_STALE_TIMEOUT")
         if env_timeout is not None:
-            return float(env_timeout), False
+            return _safe_float_env("HERMES_API_CALL_STALE_TIMEOUT", 300.0), False
 
         return 300.0, True
 


### PR DESCRIPTION
## Problem

`float(os.getenv('VAR', '1800'))` raises `ValueError` when the env var is set to a non-numeric string like `"abc"`. The `or default` pattern doesn't help because non-empty strings are truthy — `float("abc" or 1800)` still raises.

This affects 5 call sites in the **core request path** (hit on every API call):

| File | Env Var | Impact |
|------|---------|--------|
| `run_agent.py` | `HERMES_API_TIMEOUT` | Every request timeout resolution |
| `run_agent.py` | `HERMES_API_CALL_STALE_TIMEOUT` | Stale detector base timeout |
| `chat_completion_helpers.py` | `HERMES_API_TIMEOUT` | Streaming request timeout |
| `chat_completion_helpers.py` | `HERMES_STREAM_READ_TIMEOUT` | Stream read timeout |
| `chat_completion_helpers.py` | `HERMES_STREAM_STALE_TIMEOUT` | Stream stale detector |

## Fix

Add `_safe_float_env(var_name, default)` helper that wraps `float()` in `try/except (ValueError, TypeError)` with a warning log. Applied to all 5 unguarded call sites in the core request path.

Additional unguarded sites exist in gateway platforms (discord, wecom, telegram) and CLI auth — those only affect startup and can be addressed in a follow-up.

## Tests

- `py_compile` passes on both files
- Helper returns default when env var is None
- Helper returns default when env var is non-numeric
- Helper returns parsed value when env var is valid numeric string
