### PR TITLE
fix: catch OSError from fcntl.flock(LOCK_UN) in google_oauth.py

### DIFF
--- a/agent/google_oauth.py
+++ b/agent/google_oauth.py
@@ -227,7 +227,7 @@ def _credentials_lock(timeout_seconds: float = LOCK_TIMEOUT_SECONDS):
                     import fcntl
 
                     fcntl.flock(fd, fcntl.LOCK_UN)
-                except ImportError:
+                except (ImportError, OSError):
                     try:
                         import msvcrt  # type: ignore[import-not-found]
 


### PR DESCRIPTION
## Problem

In `agent/google_oauth.py`, the `fcntl` branch of the file-lock release only catches `ImportError`, not `OSError`. If `fcntl.flock(fd, fcntl.LOCK_UN)` raises `OSError` (e.g. `EBADF`), the exception propagates uncaught through the outer `finally` block, masking the original exception from the `yield` body.

The `msvcrt` branch (line 236) already correctly catches `OSError`, confirming this is an oversight — the `fcntl` branch should mirror it.

## Fix

Change `except ImportError:` to `except (ImportError, OSError):` on line 230 so both branches handle unlock failures consistently.

## Context

This is the same pattern that was fixed in 5 other files (PR #20529, #23819, #23873) — `agent/shell_hooks.py`, `tools/skill_usage.py`, `tools/memory_tool.py`, `tools/environments/file_sync.py`, `hermes_cli/auth.py`. This instance in `google_oauth.py` was missed by those earlier scans because it's nested inside an `except ImportError` block rather than a standalone `finally`.
