### PR TITLE
fix(tui): set PWD env var to match cwd in npm subprocess calls

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1294,7 +1294,7 @@ def _make_tui_argv(tui_dir: Path, tui_dev: bool) -> tuple[list[str], Path]:
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             text=True,
-            env={**os.environ, "CI": "1"},
+            env={**os.environ, "CI": "1", "PWD": str(tui_dir)},
         )
         if result.returncode != 0:
             combined = f"{result.stdout or ''}\n{result.stderr or ''}".strip()
@@ -1318,6 +1318,7 @@ def _make_tui_argv(tui_dir: Path, tui_dev: bool) -> tuple[list[str], Path]:
             cwd=str(ink_dir),
             capture_output=True,
             text=True,
+            env={**os.environ, "PWD": str(ink_dir)},
         )
         if result.returncode != 0:
             combined = f"{result.stdout or ''}{result.stderr or ''}".strip()
@@ -1346,6 +1347,7 @@ def _make_tui_argv(tui_dir: Path, tui_dev: bool) -> tuple[list[str], Path]:
             cwd=str(tui_dir),
             capture_output=True,
             text=True,
+            env={**os.environ, "PWD": str(tui_dir)},
         )
         if result.returncode != 0:
             combined = f"{result.stdout or ''}{result.stderr or ''}".strip()


### PR DESCRIPTION
## Summary

- `subprocess.run(cwd=X)` changes the process CWD but **does not update `$PWD`** in the child's environment
- When the parent process has `$PWD` pointing to the same directory via a different symlink path (e.g. `$PWD=/home/casaos/.hermes` while CWD is `/data/casaos/home/.hermes`), Go's `os.Getwd()` uses the `$PWD` shortcut and returns the symlinked path
- esbuild then resolves file paths against this wrong canonical base, producing errors like `Cannot read file: /data/casaos/DATA/casaos/home/.hermes/hermes-agent/ui-tui/src/entry.tsx`

Fix: explicitly set `PWD=str(cwd)` in all three `npm` subprocess calls inside `_make_tui_argv`.

## Test plan

- [ ] `hermes --tui` builds successfully when the process `$PWD` points to the home directory via a symlink (e.g. `$PWD=/home/user` → real path `/data/disk/home/user`)
- [ ] `hermes --tui --dev` prebuild of `@hermes/ink` succeeds under the same conditions
- [ ] No regression on systems without symlinked home directories

🤖 Generated with [Claude Code](https://claude.ai/claude-code)