### PR TITLE
feat(cli): poll SQLite for out-of-process messages and repaint TUI

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -2906,7 +2906,21 @@ class HermesCLI:
             timestamp_str = self.session_start.strftime("%Y%m%d_%H%M%S")
             short_uuid = uuid.uuid4().hex[:6]
             self.session_id = f"{timestamp_str}_{short_uuid}"
-        
+
+        # Track last seen message id for out-of-process SQLite polling
+        self._last_seen_msg_id = 0
+        self._last_oop_poll = 0.0  # monotonic timestamp of last SQLite poll
+        if self._session_db:
+            try:
+                with self._session_db._lock:
+                    row = self._session_db._conn.execute(
+                        "SELECT COALESCE(MAX(id), 0) FROM messages WHERE session_id = ?",
+                        (self.session_id,),
+                    ).fetchone()
+                self._last_seen_msg_id = row[0] if row else 0
+            except Exception:
+                pass
+
         # History file for persistent input recall across sessions
         self._history_file = _hermes_home / ".hermes_history"
         self._last_invalidate: float = 0.0  # throttle UI repaints
@@ -5013,6 +5027,65 @@ class HermesCLI:
         with _suspend_output_history():
             console.print(panel)
         return buf.getvalue().rstrip("\n").splitlines()
+
+    def _poll_and_display_out_of_process_messages(self) -> None:
+        """Poll SQLite for messages written by another process and render them.
+
+        Throttled to OOP_POLL_INTERVAL seconds (matching the pattern used by
+        _check_config_mcp_changes) so we avoid a DB read on every ~100ms idle
+        tick when nothing has changed. The process_registry drain runs every tick
+        because it checks an in-memory queue — no IO. SQLite reads are fast but
+        not free, especially under concurrent writers using WAL.
+        """
+        OOP_POLL_INTERVAL = 1.0  # seconds between SQLite reads
+
+        now = time.monotonic()
+        if now - self._last_oop_poll < OOP_POLL_INTERVAL:
+            return
+        self._last_oop_poll = now
+
+        if not self._session_db:
+            return
+        new_msgs = self._session_db.get_messages_after(
+            self.session_id, self._last_seen_msg_id
+        )
+        if not new_msgs:
+            return
+        for msg in new_msgs:
+            role = msg.get("role")
+            content = msg.get("content", "")
+            msg_id = msg.get("id")
+            if role == "user":
+                self._print_user_message_preview(content)
+                self.conversation_history.append({"role": "user", "content": content})
+            elif role == "assistant":
+                try:
+                    from hermes_cli.skin_engine import get_active_skin
+                    _skin = get_active_skin()
+                    _oop_label = _skin.get_branding("response_label", "⚕ Hermes")
+                    _resp_color = _maybe_remap_for_light_mode(_skin.get_color("response_border", "#CD7F32"))
+                    _resp_text = _maybe_remap_for_light_mode(_skin.get_color("banner_text", "#FFF8DC"))
+                except Exception:
+                    _oop_label = "⚕ Hermes"
+                    _resp_color = _maybe_remap_for_light_mode("#CD7F32")
+                    _resp_text = _maybe_remap_for_light_mode("#FFF8DC")
+                ChatConsole().print(Panel(
+                    _render_final_assistant_content(content, mode=self.final_response_markdown),
+                    title=f"[{_resp_color} bold]{_oop_label}[/]",
+                    title_align="left",
+                    border_style=_resp_color,
+                    style=_resp_text,
+                    box=rich_box.HORIZONTALS,
+                    padding=(1, 4),
+                    width=self._scrollback_box_width(),
+                ))
+                self.conversation_history.append({"role": "assistant", "content": content})
+            elif role == "tool":
+                self.conversation_history.append({"role": "tool", "content": content})
+            if msg_id is not None and msg_id > self._last_seen_msg_id:
+                self._last_seen_msg_id = msg_id
+        # Repaint the status bar after rendering injected messages.
+        self._invalidate(min_interval=0.0)
 
     def _try_attach_clipboard_image(self) -> bool:
         """Check clipboard for an image and attach it if found.
@@ -11369,6 +11442,19 @@ class HermesCLI:
             # Update history with full conversation
             self.conversation_history = result.get("messages", self.conversation_history) if result else self.conversation_history
 
+            # Update _last_seen_msg_id so idle polling doesn't re-display messages
+            # that were already rendered by this local turn.
+            if self._session_db:
+                try:
+                    with self._session_db._lock:
+                        row = self._session_db._conn.execute(
+                            "SELECT COALESCE(MAX(id), 0) FROM messages WHERE session_id = ?",
+                            (self.session_id,),
+                        ).fetchone()
+                    self._last_seen_msg_id = row[0] if row else 0
+                except Exception:
+                    pass
+
             # If auto-compression fired mid-turn, the agent created a new
             # continuation session and mutated self.agent.session_id. Sync
             # the CLI's session_id so /status, /resume, title generation,
@@ -13793,6 +13879,11 @@ class HermesCLI:
                                 from tools.process_registry import process_registry
                                 for _evt, _synth in process_registry.drain_notifications():
                                     self._pending_input.put(_synth)
+                            except Exception:
+                                pass
+                            # Poll for out-of-process messages written to SQLite
+                            try:
+                                self._poll_and_display_out_of_process_messages()
                             except Exception:
                                 pass
                         continue

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1646,6 +1646,22 @@ class SessionDB:
             result.append(msg)
         return result
 
+    def get_messages_after(self, session_id: str, after_id: int) -> List[Dict[str, Any]]:
+        """Load messages for a session with id > after_id, ordered by insertion order."""
+        with self._lock:
+            cursor = self._conn.execute(
+                "SELECT id, role, content FROM messages WHERE session_id = ? AND id > ? ORDER BY id ASC",
+                (session_id, after_id),
+            )
+            rows = cursor.fetchall()
+        result = []
+        for row in rows:
+            msg = dict(row)
+            if "content" in msg:
+                msg["content"] = self._decode_content(msg["content"])
+            result.append(msg)
+        return result
+
     def get_messages_around(
         self,
         session_id: str,

--- a/tests/test_out_of_process_polling.py
+++ b/tests/test_out_of_process_polling.py
@@ -1,0 +1,282 @@
+"""Tests for out-of-process message polling.
+
+Covers:
+1. SessionDB.get_messages_after — the core query used by the poller
+2. HermesCLI._poll_and_display_out_of_process_messages — render + history update
+3. _last_seen_msg_id initialization on fresh and resumed sessions
+"""
+
+import pathlib
+import threading
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_db(tmp_path: pathlib.Path):
+    from hermes_state import SessionDB
+    return SessionDB(db_path=tmp_path / "state.db")
+
+
+# ---------------------------------------------------------------------------
+# 1. SessionDB.get_messages_after
+# ---------------------------------------------------------------------------
+
+class TestGetMessagesAfter:
+    def test_returns_empty_when_no_new_messages(self, tmp_path):
+        db = _make_db(tmp_path)
+        db.create_session("s1", source="cli", model="m")
+        id1 = db.append_message("s1", role="user", content="hello")
+        result = db.get_messages_after("s1", id1)
+        assert result == []
+
+    def test_returns_messages_after_watermark(self, tmp_path):
+        db = _make_db(tmp_path)
+        db.create_session("s1", source="cli", model="m")
+        id1 = db.append_message("s1", role="user", content="hello")
+        id2 = db.append_message("s1", role="assistant", content="world")
+        id3 = db.append_message("s1", role="user", content="again")
+
+        result = db.get_messages_after("s1", id1)
+        assert len(result) == 2
+        assert result[0]["id"] == id2
+        assert result[0]["role"] == "assistant"
+        assert result[0]["content"] == "world"
+        assert result[1]["id"] == id3
+        assert result[1]["role"] == "user"
+        assert result[1]["content"] == "again"
+
+    def test_zero_watermark_returns_all(self, tmp_path):
+        db = _make_db(tmp_path)
+        db.create_session("s1", source="cli", model="m")
+        db.append_message("s1", role="user", content="a")
+        db.append_message("s1", role="assistant", content="b")
+
+        result = db.get_messages_after("s1", 0)
+        assert len(result) == 2
+
+    def test_wrong_session_returns_empty(self, tmp_path):
+        db = _make_db(tmp_path)
+        db.create_session("s1", source="cli", model="m")
+        db.append_message("s1", role="user", content="hello")
+
+        result = db.get_messages_after("other-session", 0)
+        assert result == []
+
+    def test_ordering_is_ascending_by_id(self, tmp_path):
+        db = _make_db(tmp_path)
+        db.create_session("s1", source="cli", model="m")
+        ids = [db.append_message("s1", role="user", content=f"msg{i}") for i in range(5)]
+
+        result = db.get_messages_after("s1", 0)
+        returned_ids = [r["id"] for r in result]
+        assert returned_ids == sorted(returned_ids)
+        assert returned_ids == ids
+
+    def test_decodes_json_encoded_content(self, tmp_path):
+        db = _make_db(tmp_path)
+        db.create_session("s1", source="cli", model="m")
+        id1 = db.append_message("s1", role="user", content=[{"type": "text", "text": "hi"}])
+        id2 = db.append_message("s1", role="user", content="plain")
+
+        result = db.get_messages_after("s1", 0)
+        assert len(result) == 2
+        # Multimodal content is decoded back to a list
+        assert isinstance(result[0]["content"], list)
+        assert result[1]["content"] == "plain"
+
+    def test_thread_safe_concurrent_reads(self, tmp_path):
+        """Two threads calling get_messages_after simultaneously must not raise."""
+        db = _make_db(tmp_path)
+        db.create_session("s1", source="cli", model="m")
+        for i in range(20):
+            db.append_message("s1", role="user", content=f"msg{i}")
+
+        errors = []
+
+        def _read():
+            try:
+                db.get_messages_after("s1", 0)
+            except Exception as exc:
+                errors.append(exc)
+
+        threads = [threading.Thread(target=_read) for _ in range(10)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert errors == [], f"Thread errors: {errors}"
+
+
+# ---------------------------------------------------------------------------
+# 2. _poll_and_display_out_of_process_messages
+# ---------------------------------------------------------------------------
+
+class TestPollAndDisplayOutOfProcessMessages:
+    """Unit tests that mock the CLI plumbing so we only test the poller logic."""
+
+    def _make_cli(self, tmp_path):
+        """Return a minimal HermesCLI-like object with just the attributes the
+        poller reads.  We don't instantiate the real class because that pulls
+        in prompt_toolkit, Rich, and the agent — just duck-type the minimum."""
+        from hermes_state import SessionDB
+        from unittest.mock import MagicMock
+
+        db = SessionDB(db_path=tmp_path / "state.db")
+        db.create_session("sess", source="cli", model="m")
+
+        class FakeCLI:
+            _session_db = db
+            session_id = "sess"
+            _last_seen_msg_id = 0
+            _last_oop_poll = 0.0   # epoch 0 → always past the throttle window
+            conversation_history = []
+            final_response_markdown = "strip"
+
+            # Methods the poller calls — will be recorded
+            _print_user_message_preview = MagicMock()
+            _render_panel = MagicMock()
+            _invalidate = MagicMock()
+
+            def _scrollback_box_width(self):
+                return 80
+
+        # Bind the real method to our fake object
+        from cli import HermesCLI
+        fake = FakeCLI()
+        fake._poll_and_display_out_of_process_messages = (
+            HermesCLI._poll_and_display_out_of_process_messages.__get__(fake)
+        )
+        return fake, db
+
+    def test_no_op_when_no_new_messages(self, tmp_path):
+        fake, db = self._make_cli(tmp_path)
+        db.append_message("sess", role="user", content="old")
+        fake._last_seen_msg_id = db._conn.execute(
+            "SELECT MAX(id) FROM messages WHERE session_id='sess'"
+        ).fetchone()[0]
+
+        fake._poll_and_display_out_of_process_messages()
+
+        fake._print_user_message_preview.assert_not_called()
+        assert fake.conversation_history == []
+
+    def test_user_message_rendered_and_appended(self, tmp_path):
+        fake, db = self._make_cli(tmp_path)
+        id1 = db.append_message("sess", role="user", content="hello from outside")
+
+        fake._poll_and_display_out_of_process_messages()
+
+        fake._print_user_message_preview.assert_called_once_with("hello from outside")
+        assert len(fake.conversation_history) == 1
+        assert fake.conversation_history[0] == {"role": "user", "content": "hello from outside"}
+        assert fake._last_seen_msg_id == id1
+
+    def test_watermark_advances(self, tmp_path):
+        fake, db = self._make_cli(tmp_path)
+        id1 = db.append_message("sess", role="user", content="first")
+        id2 = db.append_message("sess", role="assistant", content="second")
+
+        fake._poll_and_display_out_of_process_messages()
+        assert fake._last_seen_msg_id == id2
+
+        # No new messages — calling again is a no-op
+        pre_history_len = len(fake.conversation_history)
+        fake._poll_and_display_out_of_process_messages()
+        assert len(fake.conversation_history) == pre_history_len
+
+    def test_throttle_suppresses_db_read(self, tmp_path):
+        """Poller must not hit SQLite within OOP_POLL_INTERVAL of the last read."""
+        import time
+        fake, db = self._make_cli(tmp_path)
+        db.append_message("sess", role="user", content="msg")
+
+        # First call — runs and renders
+        fake._poll_and_display_out_of_process_messages()
+        assert len(fake.conversation_history) == 1
+
+        # Second message written immediately after
+        db.append_message("sess", role="user", content="msg2")
+
+        # Second call within the throttle window — must be suppressed
+        fake._poll_and_display_out_of_process_messages()
+        assert len(fake.conversation_history) == 1  # still 1, throttled
+
+        # Expire the throttle by winding back _last_oop_poll
+        fake._last_oop_poll = 0.0
+        fake._poll_and_display_out_of_process_messages()
+        assert len(fake.conversation_history) == 2  # now sees msg2
+
+    def test_tool_message_appended_silently(self, tmp_path):
+        fake, db = self._make_cli(tmp_path)
+        db.append_message("sess", role="tool", content="tool output")
+
+        fake._poll_and_display_out_of_process_messages()
+
+        # Not rendered visually
+        fake._print_user_message_preview.assert_not_called()
+        # But added to history
+        assert len(fake.conversation_history) == 1
+        assert fake.conversation_history[0]["role"] == "tool"
+
+    def test_no_session_db_is_noop(self, tmp_path):
+        """When _session_db is None the poller must not crash."""
+        from cli import HermesCLI
+        from unittest.mock import MagicMock
+
+        class FakeCLI:
+            _session_db = None
+            session_id = "sess"
+            _last_seen_msg_id = 0
+            _last_oop_poll = 0.0   # epoch 0 → always past the throttle window
+            conversation_history = []
+            final_response_markdown = "strip"
+            _print_user_message_preview = MagicMock()
+            _invalidate = MagicMock()
+
+        fake = FakeCLI()
+        fake._poll_and_display_out_of_process_messages = (
+            HermesCLI._poll_and_display_out_of_process_messages.__get__(fake)
+        )
+        # Should not raise
+        fake._poll_and_display_out_of_process_messages()
+        assert fake.conversation_history == []
+
+
+# ---------------------------------------------------------------------------
+# 3. _last_seen_msg_id initialization
+# ---------------------------------------------------------------------------
+
+class TestLastSeenMsgIdInit:
+    def test_fresh_session_starts_at_zero(self, tmp_path):
+        """A brand-new session with no messages should start at 0."""
+        from hermes_state import SessionDB
+        db = SessionDB(db_path=tmp_path / "state.db")
+
+        # Verify the query returns 0 for an empty session
+        with db._lock:
+            row = db._conn.execute(
+                "SELECT COALESCE(MAX(id), 0) FROM messages WHERE session_id = ?",
+                ("brand-new-session",),
+            ).fetchone()
+        assert row[0] == 0
+
+    def test_resumed_session_starts_at_tip(self, tmp_path):
+        """A resumed session should start at the highest existing message id."""
+        from hermes_state import SessionDB
+        db = SessionDB(db_path=tmp_path / "state.db")
+        db.create_session("old-sess", source="cli", model="m")
+        id1 = db.append_message("old-sess", role="user", content="a")
+        id2 = db.append_message("old-sess", role="assistant", content="b")
+        id3 = db.append_message("old-sess", role="user", content="c")
+
+        with db._lock:
+            row = db._conn.execute(
+                "SELECT COALESCE(MAX(id), 0) FROM messages WHERE session_id = ?",
+                ("old-sess",),
+            ).fetchone()
+        assert row[0] == id3


### PR DESCRIPTION
## Summary

Adds a lightweight polling mechanism so that messages written to the session database by another process (e.g. `hermes chat -q "..." --continue` in a second terminal) are automatically displayed in the running interactive TUI within ~1 second, without user action.

The paradigm is deliberately simple: the external process owns writing; the running TUI only watches for new rows and renders them.

## Changes

**`hermes_state.py`**
- `SessionDB.get_messages_after(session_id, after_id)` — new read-only query returning all messages with `id > after_id` for a session, ordered `id ASC`. Selects only `id, role, content` and calls `_decode_content` so JSON-encoded multimodal content round-trips correctly. Uses the existing `_lock` pattern.

**`cli.py`**
- `HermesCLI.__init__`: initializes `_last_seen_msg_id` to `COALESCE(MAX(id), 0)` at startup. Fresh sessions start at `0`; resumed sessions start at the existing tip, preventing history replay on the first idle tick.
- `HermesCLI._poll_and_display_out_of_process_messages()`: renders new rows. Throttled to 1-second intervals via `_last_oop_poll` — matching the pattern used by `_check_config_mcp_changes` and for the same reason: SQLite reads are fast but not free under concurrent WAL writers, unlike the in-memory `process_registry.drain_notifications()` which runs every tick. User messages use `_print_user_message_preview`; assistant messages use the full skin-aware Rich Panel path (same `try/except get_active_skin()` block as `chat()` and the background task renderer — `response_label`, `response_border`, `banner_text` all respected); tool messages silently appended to `conversation_history` only. Calls `_invalidate()` after rendering to repaint the status bar.
- `process_loop()` idle tick: calls the poller inside the existing `if not self._agent_running:` block, alongside the MCP config watcher and process-registry drain.
- `chat()` post-turn: bumps `_last_seen_msg_id` to the current `MAX(id)` after each local agent turn, closing the race window where the idle poller would otherwise re-display rows the local turn just wrote.

**`tests/test_out_of_process_polling.py`** (new, 15 tests)
- `TestGetMessagesAfter` (7): empty result at watermark, correct rows returned, `after_id=0` returns all, wrong-session isolation, ascending order, JSON content decoding, thread safety
- `TestPollAndDisplayOutOfProcessMessages` (6): no-op when nothing new, user message rendered and appended, watermark advances, throttle suppresses DB read within interval, tool messages silent, `_session_db=None` guard
- `TestLastSeenMsgIdInit` (2): fresh session starts at 0, resumed session starts at tip

