### PR TITLE
fix: use atomic write for .env file in memory_setup.py

### DIFF
--- a/hermes_cli/memory_setup.py
+++ b/hermes_cli/memory_setup.py
@@ -11,6 +11,7 @@ import getpass
 import os
 import sys
 import shlex
+import tempfile
 from pathlib import Path
 
 from hermes_constants import get_hermes_home
@@ -378,7 +379,21 @@ def _write_env_vars(env_path: Path, env_writes: dict) -> None:
         if key not in updated_keys:
             new_lines.append(f"{key}={val}")
 
-    env_path.write_text("\n".join(new_lines) + "\n", encoding="utf-8")
+    # Atomic write: .env holds API keys — never leave it partially written.
+    content = "\n".join(new_lines) + "\n"
+    fd, tmp_path = tempfile.mkstemp(
+        dir=str(env_path.parent), prefix=f".{env_path.name}.tmp.",
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(content)
+        os.replace(tmp_path, env_path)
+    except Exception:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
     # Restrict permissions — .env holds API keys and tokens.
     try:
         import stat


### PR DESCRIPTION
## Problem

`_write_env_vars()` in `hermes_cli/memory_setup.py` writes the user's `.env` file (which holds API keys and tokens) using `Path.write_text()`. A crash or power loss mid-write produces a truncated `.env`, and Hermes can't authenticate to any provider on next startup.

The `.env` file is critical infrastructure — it stores credentials for OpenAI, Anthropic, Nous, and other providers. A corrupted `.env` requires the user to re-enter all API keys.

## Fix

Replace `Path.write_text()` with `tempfile.mkstemp()` + `os.replace()` for atomic write. This matches the pattern already used in:
- `tools/skill_manager_tool.py:_atomic_write_text()`
- `utils.py:atomic_json_write()`
- `gateway/delivery.py` (tmp.write_text + tmp.replace)

The atomic write ensures the target file is never left in a partially-written state — `os.replace()` is guaranteed to be atomic on POSIX systems.
