### PR TITLE
fix: use time.monotonic() for tool duration measurement in TUI

### DIFF
--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1623,7 +1623,7 @@ def _on_tool_start(sid: str, tool_call_id: str, name: str, args: dict):
                 session.setdefault("edit_snapshots", {})[tool_call_id] = snapshot
         except Exception:
             pass
-        session.setdefault("tool_started_at", {})[tool_call_id] = time.time()
+        session.setdefault("tool_started_at", {})[tool_call_id] = time.monotonic()
     if _tool_progress_enabled(sid):
         payload = {
             "tool_id": tool_call_id,
@@ -1647,7 +1647,7 @@ def _on_tool_complete(sid: str, tool_call_id: str, name: str, args: dict, result
     if session is not None:
         snapshot = session.setdefault("edit_snapshots", {}).pop(tool_call_id, None)
         started_at = session.setdefault("tool_started_at", {}).pop(tool_call_id, None)
-    duration_s = time.time() - started_at if started_at else None
+    duration_s = time.monotonic() - started_at if started_at else None
     if duration_s is not None:
         payload["duration_s"] = duration_s
     summary = _tool_summary(name, result, duration_s)


### PR DESCRIPTION
## Problem

`tui_gateway/server.py` used `time.time()` (wall clock) to measure tool execution duration at two sites:
- Line 1626: `session["tool_started_at"][tool_call_id] = time.time()`
- Line 1650: `duration_s = time.time() - started_at`

`time.time()` returns wall-clock time which is subject to NTP adjustments, leap seconds, and manual clock changes. This can cause:
- Negative durations (clock jumped backward)
- Wildly inflated durations (clock jumped forward)
- Incorrect tool timing displayed in the TUI

## Fix

Replace `time.time()` with `time.monotonic()` at both sites. `time.monotonic()` is guaranteed to be monotonic and never go backward, making it the correct clock for elapsed time measurements.

This matches the fix applied to `agent/conversation_loop.py` and `agent/rate_limit_tracker.py` in PR #29561.

## Not changed (correct wall-clock usage)

The following `time.time()` calls in the same file are correct and NOT changed:
- Line 2995: `finished_at` timestamp (wall-clock for display/storage)
- Lines 3212, 3247: unique ID generation (`int(time.time() * 1000)`)
- Line 6006: date-based DB filtering (`time.time() - days * 86400`)
