### PR TITLE
fix(hindsight): restore local pgvector on glibc mismatch

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -83,6 +83,78 @@ def _parse_int_setting(value: Any, default: int) -> int:
         return default
 
 
+def _ensure_pgvector_compatible() -> None:
+    """Restore a locally-built pgvector if pg0's bundled one targets a newer glibc.
+
+    pg0-embedded ships a ``vector.so`` linked against glibc 2.38+.  Hosts
+    with an older glibc (e.g. Ubuntu 22.04's 2.35) cannot load it, which
+    crashes the embedded PostgreSQL and hangs the Hindsight daemon.
+
+    When a mismatch is detected and a previously-built stash exists at
+    ``~/.pg0/installation/<version>/lib/vector.so.local``, restore it so the
+    daemon can start cleanly.  If no stash exists the mismatch is logged but
+    not fixed — use the ``hindsight-fix`` skill to create one.
+    """
+    import platform as _plat
+    if _plat.system() != "Linux":
+        return
+
+    import subprocess as _sp
+    from pathlib import Path as _P
+
+    # Bail out if the host glibc is already new enough.
+    try:
+        ver_out = _sp.run(
+            ["ldd", "--version"], capture_output=True, text=True, timeout=5
+        ).stdout
+        import re as _re
+        m = _re.search(r"(\d+)\.(\d+)", ver_out)
+        if not m or (int(m.group(1)), int(m.group(2))) >= (2, 38):
+            return
+    except Exception:
+        return
+
+    pg0_root = _P.home() / ".pg0" / "installation"
+    if not pg0_root.exists():
+        return
+
+    for pg_dir in sorted(pg0_root.iterdir()):
+        if not pg_dir.is_dir():
+            continue
+        vector_so = pg_dir / "lib" / "vector.so"
+        if not vector_so.exists():
+            continue
+
+        # Does the bundled extension ask for a glibc newer than the host?
+        try:
+            ldd_out = _sp.run(
+                ["ldd", str(vector_so)], capture_output=True, text=True, timeout=10
+            )
+            if "GLIBC_2.38" not in ldd_out.stderr and "GLIBC_2.39" not in ldd_out.stderr:
+                continue
+        except Exception:
+            continue
+
+        # Mismatch detected — try restoring from stash.
+        stash = vector_so.parent / "vector.so.local"
+        if not stash.exists():
+            logger.warning(
+                "pgvector in %s requires a newer glibc than this host — "
+                "the Hindsight daemon may fail to start.  "
+                "Fix: load the hindsight-fix skill to rebuild it, then run "
+                "`cp ~/.pg0/installation/%s/lib/vector.so "
+                "~/.pg0/installation/%s/lib/vector.so.local` to create a stash.",
+                pg_dir.name, pg_dir.name, pg_dir.name,
+            )
+            continue
+
+        import shutil as _shutil
+        _shutil.copy2(str(stash), str(vector_so))
+        logger.info(
+            "hindsight: restored pgvector from local stash (%s)", pg_dir.name,
+        )
+
+
 def _check_local_runtime() -> tuple[bool, str | None]:
     """Return whether local embedded Hindsight imports cleanly.
 
@@ -94,6 +166,7 @@ def _check_local_runtime() -> tuple[bool, str | None]:
     try:
         importlib.import_module("hindsight")
         importlib.import_module("hindsight_embed.daemon_embed_manager")
+        _ensure_pgvector_compatible()
         return True, None
     except Exception as exc:
         return False, str(exc)

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -20,6 +20,7 @@ from plugins.memory.hindsight import (
     RETAIN_SCHEMA,
     _load_config,
     _build_embedded_profile_env,
+    _ensure_pgvector_compatible,
     _normalize_retain_tags,
     _resolve_bank_id_template,
     _sanitize_bank_segment,
@@ -84,6 +85,33 @@ class _FakeSessionDB:
 
     def get_messages_as_conversation(self, session_id):
         return list(self._messages)
+
+
+def test_ensure_pgvector_compatible_restores_local_stash(monkeypatch, tmp_path):
+    """Older-glibc Linux hosts should restore a locally built pgvector stash."""
+    pg_dir = tmp_path / ".pg0" / "installation" / "17.5"
+    lib_dir = pg_dir / "lib"
+    lib_dir.mkdir(parents=True)
+    vector_so = lib_dir / "vector.so"
+    stash = lib_dir / "vector.so.local"
+    vector_so.write_text("bundled-new-glibc", encoding="utf-8")
+    stash.write_text("locally-built", encoding="utf-8")
+
+    monkeypatch.setattr("platform.system", lambda: "Linux")
+    monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+
+    def fake_run(cmd, **kwargs):
+        if cmd == ["ldd", "--version"]:
+            return SimpleNamespace(stdout="ldd (Ubuntu GLIBC 2.35)", stderr="")
+        if cmd == ["ldd", str(vector_so)]:
+            return SimpleNamespace(stdout="", stderr="version `GLIBC_2.38' not found")
+        raise AssertionError(f"unexpected command: {cmd}")
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+
+    _ensure_pgvector_compatible()
+
+    assert vector_so.read_text(encoding="utf-8") == "locally-built"
 
 
 @pytest.fixture()


### PR DESCRIPTION
## What does this PR do?

Adds a Linux-only compatibility guard for embedded Hindsight installs where pg0's bundled `vector.so` requires newer glibc symbols than the host provides.

On older Linux hosts, embedded PostgreSQL can fail to load pgvector if pg0 ships a `vector.so` linked against glibc 2.38+ while the host provides an older glibc such as 2.35. This prevents the Hindsight daemon from starting cleanly. The guard detects that mismatch and restores `vector.so` from a local `vector.so.local` stash when one exists.

If no stash exists, it logs a targeted warning and leaves files untouched.

## Related Issue

No public issue found.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `plugins/memory/hindsight/__init__.py`
  - Add `_ensure_pgvector_compatible()`.
  - Return immediately on non-Linux hosts.
  - Return immediately when host glibc is already 2.38+.
  - Scan `~/.pg0/installation/*/lib/vector.so` for `GLIBC_2.38` / `GLIBC_2.39` loader errors.
  - Restore from adjacent `vector.so.local` when available.
  - Log a remediation warning when a mismatch exists but no stash exists.
  - Call the guard during local embedded Hindsight runtime checks.
- `tests/plugins/memory/test_hindsight_provider.py`
  - Add a regression test proving an older-glibc mismatch restores the local pgvector stash.

## How to Test

Manual behavior to verify on an affected Linux host:

1. Have a pg0 installation where `~/.pg0/installation/<version>/lib/vector.so` requires glibc 2.38+.
2. Keep a locally built compatible copy at `~/.pg0/installation/<version>/lib/vector.so.local`.
3. Start Hermes with local embedded Hindsight enabled.
4. Confirm the guard restores `vector.so` from the local stash before the daemon starts.

Automated verification run:

```bash
scripts/run_tests.sh tests/plugins/memory/test_hindsight_provider.py
python -m py_compile plugins/memory/hindsight/__init__.py
python scripts/check-windows-footguns.py --all
```

Results:
- Hindsight provider tests: 97 passed.
- Python compile check passed.
- Windows footgun checker: no findings.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — targeted CI-parity wrapper tests were run instead
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux / Ubuntu, Python 3.11.14

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A; behavior is documented in the function docstring and warning text
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — guard is Linux-only and returns immediately elsewhere; footgun checker passed
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A — no new skill.

## Screenshots / Logs

```text
=== Summary: 1 files, 97 tests passed, 0 failed (100% complete) in 7.3s (4 workers) ===
✓ No Windows footguns found (495 file(s) scanned).
```
