### PR TITLE
fix(acp): honor agent reasoning config

### DIFF
--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -8,7 +8,7 @@ history.
 """
 from __future__ import annotations
 
-from hermes_constants import get_hermes_home
+from hermes_constants import get_hermes_home, parse_reasoning_effort
 
 import copy
 import json
@@ -24,6 +24,24 @@ from threading import Lock
 from typing import Any, Dict, List, Optional
 
 logger = logging.getLogger(__name__)
+
+
+def _parse_agent_reasoning_config(agent_config: dict[str, Any]) -> dict[str, Any] | None:
+    effort = str(agent_config.get("reasoning_effort", "") or "").strip()
+    parsed = parse_reasoning_effort(effort)
+    if effort and parsed is None:
+        logger.warning("Unknown ACP reasoning_effort '%s', using provider default", effort)
+    return parsed
+
+
+def _parse_agent_service_tier(agent_config: dict[str, Any]) -> str | None:
+    raw = str(agent_config.get("service_tier", "") or "").strip().lower()
+    if not raw or raw in {"normal", "default", "standard", "off", "none"}:
+        return None
+    if raw in {"fast", "priority", "on"}:
+        return "priority"
+    logger.warning("Unknown ACP service_tier '%s', ignoring", raw)
+    return None
 
 
 def _normalize_cwd_for_compare(cwd: str | None) -> str:
@@ -537,12 +555,18 @@ class SessionManager:
         elif isinstance(model_cfg, str) and model_cfg.strip():
             default_model = model_cfg.strip()
 
+        agent_config = config.get("agent") if isinstance(config.get("agent"), dict) else {}
+        reasoning_config = _parse_agent_reasoning_config(agent_config)
+        service_tier = _parse_agent_service_tier(agent_config)
+
         kwargs = {
             "platform": "acp",
             "enabled_toolsets": ["hermes-acp"],
             "quiet_mode": True,
             "session_id": session_id,
             "model": model or default_model,
+            "reasoning_config": reasoning_config,
+            "service_tier": service_tier,
         }
 
         try:

--- a/tests/acp_adapter/test_session_make_agent_config.py
+++ b/tests/acp_adapter/test_session_make_agent_config.py
@@ -1,0 +1,69 @@
+from types import SimpleNamespace
+from unittest.mock import patch
+
+
+RUNTIME = {
+    "provider": "custom",
+    "base_url": "https://example.test/v1",
+    "api_key": "***",
+    "api_mode": "codex_responses",
+    "command": None,
+    "args": None,
+}
+
+
+def test_make_agent_passes_agent_reasoning_effort_to_aiagent():
+    from acp_adapter.session import SessionManager
+
+    cfg = {
+        "model": {"default": "gpt-5.5", "provider": "custom"},
+        "agent": {"reasoning_effort": "xhigh"},
+    }
+
+    with (
+        patch("acp_adapter.session._register_task_cwd"),
+        patch("hermes_cli.config.load_config", return_value=cfg),
+        patch("hermes_cli.runtime_provider.resolve_runtime_provider", return_value=RUNTIME),
+        patch("run_agent.AIAgent", return_value=SimpleNamespace(model="gpt-5.5")) as mock_agent,
+    ):
+        SessionManager()._make_agent(session_id="sid-reasoning", cwd=".")
+
+    assert mock_agent.call_args.kwargs["reasoning_config"] == {
+        "enabled": True,
+        "effort": "xhigh",
+    }
+
+
+def test_make_agent_leaves_reasoning_default_when_agent_config_missing():
+    from acp_adapter.session import SessionManager
+
+    cfg = {"model": {"default": "gpt-5.5", "provider": "custom"}}
+
+    with (
+        patch("acp_adapter.session._register_task_cwd"),
+        patch("hermes_cli.config.load_config", return_value=cfg),
+        patch("hermes_cli.runtime_provider.resolve_runtime_provider", return_value=RUNTIME),
+        patch("run_agent.AIAgent", return_value=SimpleNamespace(model="gpt-5.5")) as mock_agent,
+    ):
+        SessionManager()._make_agent(session_id="sid-default", cwd=".")
+
+    assert mock_agent.call_args.kwargs["reasoning_config"] is None
+
+
+def test_make_agent_passes_agent_service_tier_to_aiagent():
+    from acp_adapter.session import SessionManager
+
+    cfg = {
+        "model": {"default": "gpt-5.5", "provider": "custom"},
+        "agent": {"service_tier": "fast"},
+    }
+
+    with (
+        patch("acp_adapter.session._register_task_cwd"),
+        patch("hermes_cli.config.load_config", return_value=cfg),
+        patch("hermes_cli.runtime_provider.resolve_runtime_provider", return_value=RUNTIME),
+        patch("run_agent.AIAgent", return_value=SimpleNamespace(model="gpt-5.5")) as mock_agent,
+    ):
+        SessionManager()._make_agent(session_id="sid-service-tier", cwd=".")
+
+    assert mock_agent.call_args.kwargs["service_tier"] == "priority"


### PR DESCRIPTION
## Summary
- Pass `agent.reasoning_effort` from ACP session creation into `AIAgent` via the shared `parse_reasoning_effort()` helper.
- Pass `agent.service_tier` through the same ACP path so Responses API priority settings behave like CLI sessions.
- Add regression coverage for ACP agent construction with reasoning and service-tier config.

## Background
ACP sessions currently create `AIAgent` without the main agent reasoning config, so providers with Responses-style defaults can fall back to medium effort even when the user's persisted agent config sets `agent.reasoning_effort: xhigh`. This also makes the persisted-config workaround described in #18326 unreliable.

Related to #18326.

## Test Plan
- `./scripts/run_tests.sh tests/acp_adapter/test_session_make_agent_config.py -q`
- `./scripts/run_tests.sh tests/agent/test_copilot_acp_client.py -q`
- `python3 -m py_compile acp_adapter/session.py tests/acp_adapter/test_session_make_agent_config.py`
