### PR TITLE
fix(honcho): sanitize workspace/peer IDs to strip dots and special characters (#30246)

### DIFF
--- a/plugins/memory/honcho/client.py
+++ b/plugins/memory/honcho/client.py
@@ -31,6 +31,23 @@ logger = logging.getLogger(__name__)
 
 HOST = "hermes"
 
+# Honcho validates IDs with ^[a-zA-Z0-9_-]+$ — dots, colons, etc. are rejected.
+_HONCHO_ID_UNSAFE_RE = None  # lazy-compiled
+
+
+def _sanitize_honcho_id(raw: str) -> str:
+    """Replace characters outside ``[a-zA-Z0-9_-]`` with hyphens.
+
+    Honcho rejects workspace/peer IDs containing dots, colons, or other
+    special characters.  This helper normalises profile-derived identifiers
+    (e.g. ``hermes.asher`` → ``hermes-asher``) so they pass validation.
+    """
+    import re
+    global _HONCHO_ID_UNSAFE_RE
+    if _HONCHO_ID_UNSAFE_RE is None:
+        _HONCHO_ID_UNSAFE_RE = re.compile(r'[^a-zA-Z0-9_-]+')
+    return _HONCHO_ID_UNSAFE_RE.sub('-', raw).strip('-')
+
 
 def resolve_active_host() -> str:
     """Derive the Honcho host key from the active Hermes profile.
@@ -335,12 +352,12 @@ class HonchoClientConfig:
         timeout = _resolve_optional_float(os.environ.get("HONCHO_TIMEOUT"))
         return cls(
             host=resolved_host,
-            workspace_id=workspace_id,
+            workspace_id=_sanitize_honcho_id(workspace_id),
             api_key=api_key,
             environment=os.environ.get("HONCHO_ENVIRONMENT", "production"),
             base_url=base_url,
             timeout=timeout,
-            ai_peer=resolved_host,
+            ai_peer=_sanitize_honcho_id(resolved_host),
             enabled=bool(api_key or base_url),
         )
 
@@ -446,13 +463,13 @@ class HonchoClientConfig:
 
         return cls(
             host=resolved_host,
-            workspace_id=workspace,
+            workspace_id=_sanitize_honcho_id(workspace),
             api_key=api_key,
             environment=environment,
             base_url=base_url,
             timeout=timeout,
             peer_name=host_block.get("peerName") or raw.get("peerName"),
-            ai_peer=ai_peer,
+            ai_peer=_sanitize_honcho_id(ai_peer),
             pin_peer_name=_resolve_bool(
                 host_block.get("pinPeerName"),
                 raw.get("pinPeerName"),

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -696,6 +696,7 @@ AUTHOR_MAP = {
     "juan.ovalle@mistral.ai": "jjovalle99",
     "julien.talbot@ergonomia.re": "Julientalbot",
     "kagura.chen28@gmail.com": "kagura-agent",
+    "kagura.agent.ai@gmail.com": "kagura-agent",
     "1342088860@qq.com": "youngDoo",
     "kamil@gwozdz.me": "kamil-gwozdz",
     "skmishra1991@gmail.com": "bugkill3r",

--- a/tests/test_honcho_client_config.py
+++ b/tests/test_honcho_client_config.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 import pytest
 
-from plugins.memory.honcho.client import HonchoClientConfig
+from plugins.memory.honcho.client import HonchoClientConfig, _sanitize_honcho_id
 
 
 class TestHonchoClientConfigAutoEnable:
@@ -103,3 +103,63 @@ class TestHonchoClientConfigAutoEnable:
 
         assert cfg.api_key == "fallback-key"
         assert cfg.enabled is True  # from_env() sets enabled=True
+
+
+class TestSanitizeHonchoId:
+    """Test _sanitize_honcho_id replaces non-alphanumeric chars with hyphens."""
+
+    def test_dots_replaced(self):
+        assert _sanitize_honcho_id("hermes.asher") == "hermes-asher"
+
+    def test_multiple_dots(self):
+        assert _sanitize_honcho_id("a.b.c.d") == "a-b-c-d"
+
+    def test_colons_replaced(self):
+        assert _sanitize_honcho_id("hermes:profile") == "hermes-profile"
+
+    def test_valid_id_unchanged(self):
+        assert _sanitize_honcho_id("hermes-asher_01") == "hermes-asher_01"
+
+    def test_plain_host_unchanged(self):
+        assert _sanitize_honcho_id("hermes") == "hermes"
+
+    def test_leading_trailing_special_stripped(self):
+        assert _sanitize_honcho_id(".hermes.") == "hermes"
+
+    def test_consecutive_special_collapsed(self):
+        assert _sanitize_honcho_id("a..b") == "a-b"
+
+
+class TestDotProfileSanitization:
+    """Regression tests for #30246: dot-containing profiles produce valid IDs."""
+
+    def test_from_global_config_sanitizes_workspace_and_ai_peer(self, tmp_path, monkeypatch):
+        """workspace_id and ai_peer derived from a dotted host must be sanitized."""
+        config_path = tmp_path / "config.json"
+        config_path.write_text(json.dumps({
+            "apiKey": "test-key",
+        }))
+        # Simulate resolve_active_host() returning "hermes.asher"
+        monkeypatch.setattr(
+            "plugins.memory.honcho.client.resolve_active_host",
+            lambda: "hermes.asher",
+        )
+        cfg = HonchoClientConfig.from_global_config(config_path=config_path)
+        assert cfg.workspace_id == "hermes-asher"
+        assert cfg.ai_peer == "hermes-asher"
+
+    def test_from_env_sanitizes_ai_peer(self, monkeypatch):
+        """from_env() must sanitize ai_peer derived from a dotted host."""
+        monkeypatch.setattr(
+            "plugins.memory.honcho.client.resolve_active_host",
+            lambda: "hermes.asher",
+        )
+        monkeypatch.setenv("HONCHO_API_KEY", "test-key")
+        cfg = HonchoClientConfig.from_env()
+        assert cfg.ai_peer == "hermes-asher"
+
+    def test_from_env_sanitizes_explicit_workspace(self, monkeypatch):
+        """from_env() must sanitize a caller-supplied dotted workspace_id."""
+        monkeypatch.setenv("HONCHO_API_KEY", "test-key")
+        cfg = HonchoClientConfig.from_env(workspace_id="org.team")
+        assert cfg.workspace_id == "org-team"


### PR DESCRIPTION
## Summary

Fixes #30246 — Honcho memory plugin generates invalid workspace/peer IDs for profile names containing dots.

## Problem

`resolve_active_host()` produces host keys like `hermes.asher` for non-default profiles. These are used as `workspace_id` and `ai_peer` in `HonchoClientConfig`, but Honcho validates IDs with `^[a-zA-Z0-9_-]+$` — dots are rejected, causing session registration failures even when the Honcho backend is healthy and reachable.

## Fix

Add `_sanitize_honcho_id()` helper that replaces characters outside `[a-zA-Z0-9_-]` with hyphens (`hermes.asher` → `hermes-asher`). Applied to `workspace_id` and `ai_peer` in both `from_global_config()` and `from_env()`.

The sanitization pattern matches the existing `_sanitize_id()` in `session.py` (which already handles session/peer IDs at the session level) — this fix closes the gap for workspace and AI peer IDs at the config level.

## Testing

- 10 new tests in `test_honcho_client_config.py`:
  - 7 unit tests for `_sanitize_honcho_id()` (dots, colons, valid passthrough, edge cases)
  - 3 integration tests verifying `from_global_config()` and `from_env()` produce sanitized IDs
- All 17 tests pass locally