### PR TITLE
docs(config): fix invalid 'hermes config get' references in 3 guides

### DIFF
--- a/website/docs/guides/migrate-from-openclaw.md
+++ b/website/docs/guides/migrate-from-openclaw.md
@@ -225,7 +225,7 @@ The migration resolves all three formats. For env templates and SecretRef object
 
 5. **Test messaging** — if you migrated platform tokens, restart the gateway: `systemctl --user restart hermes-gateway`
 
-6. **Check session policies** — verify `hermes config get session_reset` matches your expectations.
+6. **Check session policies** — verify the `session_reset` section of `hermes config show` matches your expectations.
 
 7. **Re-pair WhatsApp** — WhatsApp uses QR code pairing (Baileys), not token migration. Run `hermes whatsapp` to pair.
 

--- a/website/docs/guides/work-with-skills.md
+++ b/website/docs/guides/work-with-skills.md
@@ -161,8 +161,8 @@ Manage skill config from the CLI:
 # Interactive config for a specific skill
 hermes skills config gif-search
 
-# View all skill config
-hermes config get skills.config
+# View all skill config (look under skills.config in the output)
+hermes config show
 ```
 
 ---

--- a/website/docs/user-guide/configuring-models.md
+++ b/website/docs/user-guide/configuring-models.md
@@ -192,7 +192,7 @@ hermes model            # Interactive provider + model picker (the canonical way
 
 `hermes model` walks you through picking a provider, authenticating (OAuth flows open a browser; API-key providers prompt for the key), and then choosing a specific model from that provider's curated catalog. The choice is written to `model.provider` and `model.model` in `~/.hermes/config.yaml`.
 
-To list providers/models without launching the picker, use the dashboard or the REST endpoints below. To inspect what the CLI will actually use right now: `hermes config get model` and `hermes status`.
+To list providers/models without launching the picker, use the dashboard or the REST endpoints below. To inspect what the CLI will actually use right now: see `model.provider` / `model.model` in `hermes config show`, and run `hermes status`.
 
 ### Direct config edit
 


### PR DESCRIPTION
Closes #30195.

`hermes config get <key>` is referenced in three guides but is not a valid subcommand — the closest existing form is `hermes config show`, which dumps the entire resolved config and accepts no positional arguments. Following the docs verbatim produces `unrecognized arguments` errors.

Going with the docs-only fix (Option 1 in the issue). The issue body suggested `hermes config show | grep '^<key>'`, but that doesn't work for nested keys in YAML output (e.g. `skills.config` lives under a `skills:` parent), so I went with plain `hermes config show` plus a short "look at X in the output" hint where it reads naturally.

Changed:
- `website/docs/guides/work-with-skills.md:165` — `hermes config get skills.config` → `hermes config show` (comment now points the reader at `skills.config` in the output)
- `website/docs/guides/migrate-from-openclaw.md:228` — `hermes config get session_reset` → "the `session_reset` section of `hermes config show`"
- `website/docs/user-guide/configuring-models.md:195` — `hermes config get model` → "see `model.provider` / `model.model` in `hermes config show`"

Verified no remaining `hermes config get` references in `website/docs/` (the one remaining `config get` hit in `mcp-mcporter.md` is for the unrelated `mcporter` binary).

Option 2 in the issue (adding a real `hermes config show <key>` per-key getter) is the better UX but is a CLI change — happy to leave that for a follow-up if maintainers want it.