### PR TITLE
fix(honcho): flatten multimodal list content in sync_turn (#30252)

### DIFF
--- a/plugins/memory/honcho/__init__.py
+++ b/plugins/memory/honcho/__init__.py
@@ -1116,8 +1116,44 @@ class HonchoMemoryProvider(MemoryProvider):
             ),
         }
 
-    def sync_turn(self, user_content: str, assistant_content: str, *, session_id: str = "") -> None:
+    @staticmethod
+    def _flatten_content(content: "str | list | None") -> str:
+        """Normalise OpenAI-style multimodal list content to a plain string.
+
+        Text parts are concatenated with a space; image_url / image parts are
+        replaced with the literal placeholder ``[image]`` so Honcho's user
+        representation still knows visuals were exchanged without storing raw
+        base-64 data.
+        """
+        if content is None:
+            return ""
+        if isinstance(content, str):
+            return content
+        # Multimodal list: [{"type": "text", "text": "..."},
+        #                   {"type": "image_url", "image_url": {...}}, ...]
+        parts: list[str] = []
+        for item in content:
+            if not isinstance(item, dict):
+                parts.append(str(item))
+                continue
+            kind = item.get("type", "")
+            if kind == "text":
+                parts.append(item.get("text", ""))
+            elif kind in ("image_url", "image"):
+                parts.append("[image]")
+            else:
+                # Unknown block type — include a generic placeholder
+                parts.append(f"[{kind}]")
+        return " ".join(filter(None, parts))
+
+    def sync_turn(self, user_content: "str | list | None", assistant_content: "str | list | None", *, session_id: str = "") -> None:
         """Record the conversation turn in Honcho (non-blocking).
+
+        *user_content* and *assistant_content* may be either a plain string or
+        an OpenAI-style multimodal list (``[{"type": "text", ...}, {"type":
+        "image_url", ...}]``).  Multimodal lists are flattened to a plain
+        string before sanitisation so that vision turns are recorded rather
+        than silently dropped.
 
         Messages exceeding the Honcho API limit (default 25k chars) are
         split into multiple messages with continuation markers.
@@ -1128,8 +1164,8 @@ class HonchoMemoryProvider(MemoryProvider):
             return
 
         msg_limit = self._config.message_max_chars if self._config else 25000
-        clean_user_content = sanitize_context(user_content or "").strip()
-        clean_assistant_content = sanitize_context(assistant_content or "").strip()
+        clean_user_content = sanitize_context(self._flatten_content(user_content)).strip()
+        clean_assistant_content = sanitize_context(self._flatten_content(assistant_content)).strip()
 
         def _sync():
             try:

--- a/tests/honcho_plugin/test_session.py
+++ b/tests/honcho_plugin/test_session.py
@@ -592,6 +592,87 @@ class TestConcludeToolDispatch:
         assert session.add_message.call_args_list[1].args == ("assistant", "Visible answer")
 
 
+class TestSyncTurnMultimodalContent:
+    """sync_turn must handle OpenAI-style multimodal list content without raising.
+
+    Regression test for: honcho memory: sync_turn fails on multimodal (list)
+    content — vision turns not recorded (issue #30252).
+    """
+
+    def _make_provider(self):
+        from types import SimpleNamespace
+
+        provider = HonchoMemoryProvider()
+        provider._session_key = "telegram:999"
+        provider._manager = MagicMock()
+        provider._cron_skipped = False
+        provider._config = SimpleNamespace(message_max_chars=25000)
+        provider._session_initialized = True
+        session = MagicMock()
+        provider._manager.get_or_create.return_value = session
+        return provider, session
+
+    def test_multimodal_user_content_is_recorded(self):
+        """A multimodal list as user_content should not raise and should record text."""
+        provider, session = self._make_provider()
+        multimodal_content = [
+            {"type": "text", "text": "what colour is this?"},
+            {"type": "image_url", "image_url": {"url": "data:image/png;base64,abc"}},
+        ]
+        # Must not raise
+        provider.sync_turn(multimodal_content, "It is red.")
+        provider._sync_thread.join(timeout=1.0)
+
+        calls = session.add_message.call_args_list
+        assert calls[0].args[0] == "user"
+        assert "what colour is this?" in calls[0].args[1]
+        assert "[image]" in calls[0].args[1]
+        assert calls[1].args == ("assistant", "It is red.")
+
+    def test_image_only_content_uses_placeholder(self):
+        """A list with only an image block should record [image] placeholder."""
+        provider, session = self._make_provider()
+        provider.sync_turn(
+            [{"type": "image_url", "image_url": {"url": "data:image/jpeg;base64,xyz"}}],
+            "I see a cat.",
+        )
+        provider._sync_thread.join(timeout=1.0)
+
+        calls = session.add_message.call_args_list
+        assert "[image]" in calls[0].args[1]
+
+    def test_plain_string_content_unchanged(self):
+        """Plain string content still passes through _flatten_content unchanged."""
+        provider, session = self._make_provider()
+        provider.sync_turn("hello world", "sure")
+        provider._sync_thread.join(timeout=1.0)
+
+        assert session.add_message.call_args_list[0].args == ("user", "hello world")
+
+    def test_none_content_does_not_raise(self):
+        """None user/assistant content should produce empty strings, not crash."""
+        provider, session = self._make_provider()
+        provider.sync_turn(None, None)  # type: ignore[arg-type]
+        provider._sync_thread.join(timeout=1.0)
+        # No messages should be recorded for empty content (both sides empty)
+        # — or they may be empty strings; either way no exception.
+
+    def test_flatten_content_static_method(self):
+        """_flatten_content handles all known block types correctly."""
+        assert HonchoMemoryProvider._flatten_content(None) == ""
+        assert HonchoMemoryProvider._flatten_content("hello") == "hello"
+        assert HonchoMemoryProvider._flatten_content([]) == ""
+        result = HonchoMemoryProvider._flatten_content([
+            {"type": "text", "text": "describe"},
+            {"type": "image_url", "image_url": {}},
+            {"type": "image", "source": {}},
+            {"type": "custom_block"},
+        ])
+        assert "describe" in result
+        assert "[image]" in result
+        assert "[custom_block]" in result
+
+
 # ---------------------------------------------------------------------------
 # Message chunking
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

`HonchoMemoryProvider.sync_turn` errors when called with OpenAI-style multimodal list content (the shape used for vision turns):

```python
user_content = [
    {"type": "text", "text": "what colour is this?"},
    {"type": "image_url", "image_url": {"url": "data:image/png;base64,..."}},
]
```

The call `sanitize_context(user_content or "")` receives a `list`, raising:
```
TypeError: expected string or bytes-like object, got 'list'
```

The exception is caught silently by the `_sync()` wrapper and the turn is **silently dropped** from Honcho's memory — the user representation never learns about anything visual the assistant was shown.

Closes #30252.

## Fix

Add a `_flatten_content()` static method that normalises list-shaped content to a plain string before sanitisation:

- Plain strings pass through unchanged (zero regression risk)
- `text` parts are joined with a space  
- `image_url` / `image` parts become the literal placeholder `[image]`
- Unknown block types fall back to `[<type>]`

`sync_turn` now accepts `str | list | None` for both arguments.

## Tests

5 new tests in `TestSyncTurnMultimodalContent`:
- multimodal user content is recorded (text + image placeholder)
- image-only list uses `[image]` placeholder
- plain string passes through unchanged
- `None` content does not raise
- `_flatten_content` static method handles all known block types

All 120 existing honcho plugin tests pass.