### PR TITLE
fix(gateway): use --no-block for systemctl restart to avoid D-Bus hang

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -3389,7 +3389,7 @@ def systemd_restart(system: bool = False):
                 timeout=30,
             )
             _run_systemctl(
-                ["restart", svc],
+                ["--no-block", "restart", svc],
                 system=system,
                 check=False,
                 timeout=90,
@@ -3410,7 +3410,7 @@ def systemd_restart(system: bool = False):
             timeout=30,
         )
         try:
-            _run_systemctl(["restart", svc], system=system, check=True, timeout=90)
+            _run_systemctl(["--no-block", "restart", svc], system=system, check=True, timeout=90)
         except subprocess.CalledProcessError as exc:
             if _systemd_error_indicates_start_limit(
                 exc
@@ -3439,7 +3439,10 @@ def systemd_restart(system: bool = False):
     )
     try:
         _run_systemctl(
-            ["restart", get_service_name()], system=system, check=True, timeout=90
+            ["--no-block", "restart", get_service_name()],
+            system=system,
+            check=True,
+            timeout=90,
         )
     except subprocess.CalledProcessError as exc:
         if _systemd_error_indicates_start_limit(

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -3210,7 +3210,9 @@ def systemd_restart(system: bool = False):
         _escalate_wedged_gateway(pid)
         svc = get_service_name()
         _run_systemctl(["reset-failed", svc], system=system, check=False, timeout=30)
-        _run_systemctl(["restart", svc], system=system, check=False, timeout=90)
+        _run_systemctl(
+            ["--no-block", "restart", svc], system=system, check=False, timeout=90
+        )
         _wait_for_systemd_service_restart(system=system, previous_pid=pid)
         return
     if pid is not None:
@@ -3278,7 +3280,10 @@ def _systemd_reset_and_run(action: str, *, system: bool, previous_pid) -> None:
     svc = get_service_name()
     _run_systemctl(["reset-failed", svc], system=system, check=False, timeout=30)
     try:
-        _run_systemctl([action, svc], system=system, check=True, timeout=90)
+        systemctl_args = [action, svc]
+        if action == "restart":
+            systemctl_args.insert(0, "--no-block")
+        _run_systemctl(systemctl_args, system=system, check=True, timeout=90)
     except subprocess.CalledProcessError as exc:
         if _systemd_error_indicates_start_limit(exc) or _systemd_service_is_start_limited(system=system):
             _print_systemd_start_limit_wait(system=system)

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -840,6 +840,37 @@ class TestGatewaySystemServiceRouting:
         assert "21627" not in out  # must use the mocked budget, not live defaults
         assert "27" in out
 
+    def test_systemd_restart_forced_recovery_uses_non_blocking_systemctl(
+        self, monkeypatch
+    ):
+        calls = []
+
+        monkeypatch.setattr(gateway_cli, "_select_systemd_scope", lambda system=False: False)
+        monkeypatch.setattr(gateway_cli, "_preflight_user_systemd", lambda **kwargs: None)
+        monkeypatch.setattr(gateway_cli, "_require_service_installed", lambda action, system=False: None)
+        monkeypatch.setattr(gateway_cli, "refresh_systemd_unit_if_needed", lambda system=False: None)
+        monkeypatch.setattr(gateway_cli, "_get_restart_exit_wait_budget", lambda: 27.0)
+        monkeypatch.setattr("gateway.status.get_running_pid", lambda: 654)
+        monkeypatch.setattr(gateway_cli, "_graceful_restart_via_sigusr1", lambda pid, timeout: False)
+        monkeypatch.setattr(
+            gateway_cli,
+            "_run_systemctl",
+            lambda args, **kwargs: calls.append((args, kwargs))
+            or SimpleNamespace(returncode=0, stdout="", stderr=""),
+        )
+        monkeypatch.setattr(
+            gateway_cli,
+            "_wait_for_systemd_service_restart",
+            lambda **kwargs: True,
+        )
+
+        gateway_cli.systemd_restart()
+
+        assert [call[0] for call in calls] == [
+            ["reset-failed", gateway_cli.get_service_name()],
+            ["--no-block", "restart", gateway_cli.get_service_name()],
+        ]
+
     def test_systemd_restart_forces_recovery_only_when_handoff_has_no_replacement(
         self, monkeypatch, capsys
     ):

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -494,6 +494,7 @@ class TestGatewaySystemServiceRouting:
         calls = []
 
         monkeypatch.setattr(gateway_cli, "_select_systemd_scope", lambda system=False: False)
+        monkeypatch.setattr(gateway_cli, "_preflight_user_systemd", lambda: None)
         monkeypatch.setattr(gateway_cli, "_require_service_installed", lambda action, system=False: None)
         monkeypatch.setattr(gateway_cli, "refresh_systemd_unit_if_needed", lambda system=False: calls.append(("refresh", system)))
         monkeypatch.setattr(gateway_cli, "_get_restart_drain_timeout", lambda: 12.0)
@@ -530,7 +531,10 @@ class TestGatewaySystemServiceRouting:
 
         assert ("graceful", 654, 17.0) in calls
         assert any(call[0] == "reset-failed" for call in calls)
-        assert any(call[0] == "restart" for call in calls)
+        assert (
+            "restart",
+            ["systemctl", "--user", "--no-block", "restart", gateway_cli.get_service_name()],
+        ) in calls
         assert ("wait", False, 654) in calls
         out = capsys.readouterr().out.lower()
         assert "restarting gracefully" in out


### PR DESCRIPTION
## What changed and why

Calling `systemctl (--user) restart` makes a synchronous D-Bus call that blocks indefinitely when the D-Bus session bus loses its connection during the restart handoff. This reproduces reliably on Ubuntu 24.04 ARM64 with a Linuxbrew-installed Hermes user unit (issue #29421).

Per the reporter's diagnostics on 2026-05-21: both `hermes gateway restart` and the raw `systemctl --user restart hermes-gateway` hang, while `systemctl --user --no-block restart hermes-gateway` returns immediately (exit 0), pointing squarely at the D-Bus job-wait.

Added `--no-block` to every `systemctl restart` invocation inside `systemd_restart()` (three call sites: post-graceful-drain, forced-restart fallback, and cold-start). The existing `_wait_for_systemd_service_restart()` poll loop already handles waiting for the new PID and printing progress messages, so operator-visible behaviour is unchanged.

## How to test

1. Install Hermes as a systemd user unit on Ubuntu 24.04 ARM64 (or any host that exhibits the D-Bus session bus drop during restart).
2. Run `hermes gateway restart` — it should complete and print `✓ User service restarted (PID N)` instead of hanging.
3. Alternatively: `strace -e trace=sendmsg,recvmsg hermes gateway restart` — confirm that the `systemctl` child exits quickly rather than blocking on D-Bus receives.

## What platforms tested on

- macOS 14 (unit tests only; systemd tests skipped due to platform)
- CI (Linux): existing test suite passes; 5 pre-existing macOS-only systemd preflight failures are unrelated and unchanged from main

Fixes #29421

<!-- autocontrib:worker-id=issue-followup-c023aad5 kind=pr-open -->