### PR TITLE
docs: fix 6 broken internal links in docs site

### DIFF
--- a/website/docs/getting-started/learning-path.md
+++ b/website/docs/getting-started/learning-path.md
@@ -24,7 +24,7 @@ If you haven't installed Hermes Agent yet, begin with the [Installation guide](/
 |---|---|---|---|
 | **Beginner** | Get up and running, have basic conversations, use built-in tools | [Installation](/docs/getting-started/installation) → [Quickstart](/docs/getting-started/quickstart) → [CLI Usage](/docs/user-guide/cli) → [Configuration](/docs/user-guide/configuration) | ~1 hour |
 | **Intermediate** | Set up messaging bots, use advanced features like memory, cron jobs, and skills | [Sessions](/docs/user-guide/sessions) → [Messaging](/docs/user-guide/messaging) → [Tools](/docs/user-guide/features/tools) → [Skills](/docs/user-guide/features/skills) → [Memory](/docs/user-guide/features/memory) → [Cron](/docs/user-guide/features/cron) | ~2–3 hours |
-| **Advanced** | Build custom tools, create skills, train models with RL, contribute to the project | [Architecture](/docs/developer-guide/architecture) → [Adding Tools](/docs/developer-guide/adding-tools) → [Creating Skills](/docs/developer-guide/creating-skills) → [RL Training](/docs/user-guide/features/rl-training) → [Contributing](/docs/developer-guide/contributing) | ~4–6 hours |
+| **Advanced** | Build custom tools, create skills, train models with RL, contribute to the project | [Architecture](/docs/developer-guide/architecture) → [Adding Tools](/docs/developer-guide/adding-tools) → [Creating Skills](/docs/developer-guide/creating-skills) → [RL Training](/docs/developer-guide/trajectory-format) → [Contributing](/docs/developer-guide/contributing) | ~4–6 hours |
 
 ## By Use Case
 
@@ -100,7 +100,7 @@ Use reinforcement learning to fine-tune model behavior with Hermes Agent's built
 
 1. [Quickstart](/docs/getting-started/quickstart)
 2. [Configuration](/docs/user-guide/configuration)
-3. [RL Training](/docs/user-guide/features/rl-training)
+3. [RL Training](/docs/developer-guide/trajectory-format)
 4. [Provider Routing](/docs/user-guide/features/provider-routing)
 5. [Architecture](/docs/developer-guide/architecture)
 
@@ -136,7 +136,7 @@ Not sure what's available? Here's a quick directory of major features:
 | **Browser** | Web browsing and scraping | [Browser](/docs/user-guide/features/browser) |
 | **Hooks** | Event-driven callbacks and middleware | [Hooks](/docs/user-guide/features/hooks) |
 | **Batch Processing** | Process multiple inputs in bulk | [Batch Processing](/docs/user-guide/features/batch-processing) |
-| **RL Training** | Fine-tune models with reinforcement learning | [RL Training](/docs/user-guide/features/rl-training) |
+| **RL Training** | Fine-tune models with reinforcement learning | [RL Training](/docs/developer-guide/trajectory-format) |
 | **Provider Routing** | Route requests across multiple LLM providers | [Provider Routing](/docs/user-guide/features/provider-routing) |
 
 ## What to Read Next

--- a/website/docs/user-guide/features/overview.md
+++ b/website/docs/user-guide/features/overview.md
@@ -43,7 +43,7 @@ Hermes Agent includes a rich set of capabilities that extend far beyond basic ch
 - **[Memory Providers](memory-providers.md)** — Plug in external memory backends (Honcho, OpenViking, Mem0, Hindsight, Holographic, RetainDB, ByteRover, Supermemory) for cross-session user modeling and personalization beyond the built-in memory system.
 - **[API Server](api-server.md)** — Expose Hermes as an OpenAI-compatible HTTP endpoint. Connect any frontend that speaks the OpenAI format — Open WebUI, LobeChat, LibreChat, and more.
 - **[IDE Integration (ACP)](acp.md)** — Use Hermes inside ACP-compatible editors such as VS Code, Zed, and JetBrains. Chat, tool activity, file diffs, and terminal commands render inside your editor.
-- **[RL Training](rl-training.md)** — Generate trajectory data from agent sessions for reinforcement learning and model fine-tuning.
+- **[RL Training](../../developer-guide/trajectory-format.md)** — Generate trajectory data from agent sessions for reinforcement learning and model fine-tuning.
 
 ## Customization
 

--- a/website/docs/user-guide/messaging/yuanbao.md
+++ b/website/docs/user-guide/messaging/yuanbao.md
@@ -336,6 +336,6 @@ hermes chat -q "Send 'Hello from CLI' to yuanbao:group:group_code"
 ## Related Documentation
 
 - [Messaging Gateway Overview](./index.md)
-- [Slash Commands Reference](/docs/reference/slash-commands.md)
-- [Cron Jobs](/docs/user-guide/features/cron.md)
+- [Slash Commands Reference](/docs/reference/slash-commands)
+- [Cron Jobs](/docs/user-guide/features/cron)
 - [Background Sessions](/docs/user-guide/cli#background-sessions)


### PR DESCRIPTION
Two distinct defects found while sweeping absolute \`/docs/\` links across the docs site.

### Defect 1: stray \`.md\` extension on absolute Docusaurus links

\`website/docs/user-guide/messaging/yuanbao.md\` had two links carrying a trailing \`.md\`:

\`\`\`
- [Slash Commands Reference](/docs/reference/slash-commands.md)
- [Cron Jobs](/docs/user-guide/features/cron.md)
\`\`\`

Docusaurus does not resolve the \`.md\` suffix on absolute \`/docs/\` paths — both lines 404 on the live site. Stripped the extension to match the convention used by the ~280 other absolute \`/docs/\` links in the corpus (none of which carry \`.md\`).

### Defect 2: dead \`/docs/user-guide/features/rl-training\` target

That page does not exist anywhere under \`website/docs/\`, but it was linked from four places:

- \`website/docs/getting-started/learning-path.md\` (3 occurrences — Advanced level table, "I want to train models" section, feature catalog table)
- \`website/docs/user-guide/features/overview.md\` (1 occurrence — relative-link form)

Redirected all four to \`/docs/developer-guide/trajectory-format\`, which is the only first-party page in the docs that actually covers RL trajectory data generation (the file opens with: *"for use as training data, debugging artifacts, and reinforcement learning datasets"*).

A dedicated user-facing \`features/rl-training\` page would be a better long-term home for these references and would let \`overview.md\` describe RL as a user feature again. I left that as follow-up rather than authoring new content under this PR — happy to do it as a separate PR if maintainers want.

### Verification

- \`grep -rEn '\]\(/docs/[^)]+\.md([)#])' website/docs/\` → no remaining hits after the fix.
- \`grep -rFn 'rl-training' website/docs/\` → only remaining hit is the literal skill name \`slime-rl-training\` in optional-skills-catalog.md (skill display text, not a URL target).
- All 4 new \`trajectory-format\` targets resolve to \`website/docs/developer-guide/trajectory-format.md\`.

No issue exists for these; happy to file one retroactively if that's preferred.