### PR TITLE
fix(cli): explicit erase_screen on resize to clear prompt_toolkit reflow ghosts

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -7812,6 +7812,12 @@ class HermesCLI:
             except Exception:
                 pass  # never break resize handling
             _original_on_resize()
+            # Explicitly clear the console completely and let prompt_toolkit redraw.
+            # This wipes out any garbage that patch_stdout and resizing left behind.
+            app.output.erase_screen()
+            app.output.cursor_goto(0, 0)
+            app.output.flush()
+            app.invalidate()
 
         app._on_resize = _resize_clear_ghosts
 

--- a/cli.py
+++ b/cli.py
@@ -7811,12 +7811,13 @@ class HermesCLI:
                         )
             except Exception:
                 pass  # never break resize handling
-            _original_on_resize()
-            # Explicitly clear the console completely and let prompt_toolkit redraw.
-            # This wipes out any garbage that patch_stdout and resizing left behind.
+            # Explicitly clear the console completely before prompt_toolkit redraws.
+            # If we clear after _original_on_resize(), prompt_toolkit may already
+            # have redrawn on top of the terminal's reflowed ghost lines.
             app.output.erase_screen()
             app.output.cursor_goto(0, 0)
             app.output.flush()
+            _original_on_resize()
             app.invalidate()
 
         app._on_resize = _resize_clear_ghosts

--- a/environments/spot_foraging_env/README.md
+++ b/environments/spot_foraging_env/README.md
@@ -1,0 +1,192 @@
+# Spot Foraging Env (LLM-as-skill-selector)
+
+Hierarchical RL env that bridges:
+
+- **Atropos** (LLM RL gym) on top — the LLM is the trainee, picking high-level skills.
+- **rapier-gym** (Rust + PyO3 Spot quadruped sim) underneath — physics + a low-level walk PPO policy execute the chosen skill.
+
+The LLM gets a structured JSON state + a top-down rendered frame at ~1 Hz, picks one of 8 movement skills via tool-calling, and the underlying policy runs that skill at 50 Hz against the rapier-gym sim. Reward is dominated by batteries collected, with secondary penalties for inefficiency and falling.
+
+## Architecture
+
+```
+                                   ┌────────────────────────────┐
+                                   │ Atropos API server          │
+                                   │ (run-api)                   │
+                                   └──────────────▲──────────────┘
+                                                  │ POST /scored_data
+                                                  │
+┌──────────────────────────────────────────────────┴─────────────────────┐
+│ SpotForagingEnv  (this package)                                         │
+│ ─────────────────────────────────────────────────                       │
+│  Atropos BaseEnv subclass.                                              │
+│  Each rollout = one full foraging episode driven by an LLM:             │
+│                                                                         │
+│  for pick in 0..max_skill_picks:                                        │
+│      LLM.chat_completion(state_json + image, tools=[select_skill])      │
+│         └► picks Skill via tool call                                    │
+│      SkillExecutor.execute(skill)                                       │
+│         └► steps rapier-gym for skill.duration_steps with the           │
+│            walk PPO policy (joint targets at 50 Hz)                     │
+│      observe new state, append to messages                              │
+│      if collected_all or fell: break                                    │
+│                                                                         │
+│  score = +per_battery × collected                                       │
+│        + success_bonus  if all collected                                │
+│        - skill_pick_cost × n_picks                                      │
+│        - fall_penalty   if fell                                         │
+│        + distance_shaping_term                                          │
+└──────────────┬──────────────────────────────────────────────────────────┘
+               │ chat_completion (multimodal)
+               ▼
+┌──────────────────────────────────┐
+│ Inference fleet (vLLM / SGLang / │
+│ OpenAI / OpenRouter ...)         │
+│ ─ multimodal-capable              │
+└──────────────────────────────────┘
+```
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `env.py` | `SpotForagingEnv` — the Atropos `BaseEnv` subclass. |
+| `skills.py` | `Skill` registry (8 movement primitives) + `SkillExecutor`. |
+| `policy.py` | Walk PPO policy loader. ONNX preferred; zero-action fallback. |
+| `renderer.py` | Top-down matplotlib snapshot → PNG → OpenAI multimodal data-URL. |
+| `prompts.py` | System prompt + `select_skill` tool spec + state JSON format. |
+| `reward.py` | Per-episode reward function. |
+| `configs/default.yaml` | Reference config; copy and edit. |
+| `__init__.py` | Public surface. |
+
+## Skills
+
+The LLM picks from these (defined in `skills.py`):
+
+| Skill | Command (vx, vy, ω) | Duration | Use |
+|---|---|---|---|
+| `walk_forward` | (0.6, 0, 0) | 1.0 s | Standard locomotion. |
+| `walk_backward` | (-0.4, 0, 0) | 1.0 s | Backing out. |
+| `strafe_left` | (0, 0.4, 0) | 1.0 s | Lateral move. |
+| `strafe_right` | (0, -0.4, 0) | 1.0 s | Lateral move. |
+| `turn_left` | (0, 0, 0.8) | 1.0 s | Rotate CCW. |
+| `turn_right` | (0, 0, -0.8) | 1.0 s | Rotate CW. |
+| `walk_forward_fast` | (1.0, 0, 0) | 2.0 s | Cover ground fast. |
+| `stop` | (0, 0, 0) | 0.5 s | Stabilize. |
+
+All skills delegate to the same walk PPO policy with different `command` vectors — no per-skill policy training. Adding new skills is a one-entry append to `SKILL_REGISTRY`.
+
+## Dependencies
+
+- **`atroposlib`** — `pip install atroposlib`. The Atropos framework.
+- **`spot_rapier`** — the rapier-gym Python module. Build via `cd /home/olive/Repositories/skypilot-env/spot/rapier-gym && maturin develop --release` (Rust toolchain required) or use the prebuilt `.so` already present.
+- **`onnxruntime`** — optional. Required only when loading a trained walk policy. Install: `pip install onnxruntime`.
+- **`matplotlib`** — for the top-down renderer. Already in `hermes-agent` deps.
+
+
+
+## Walk policy
+
+The env loads the walk PPO policy via `policy.load_walk_policy()`. Resolution order:
+
+1. `walk_policy_onnx` config field (explicit override).
+2. `SPOT_WALK_POLICY_ONNX` env var.
+3. `~/.cache/spot_rapier/walk_policy.onnx` (conventional location).
+4. Zero-action fallback (logs a warning).
+
+The fallback is deliberate — the env runs end-to-end even with no trained walk policy. Spot just stands still; the LLM's skill picks are recorded but have no physical effect. Useful for testing the Atropos plumbing before walk training has converged. Once you have a trained policy, export it via `train_rapier.py`'s ONNX export path (the `export_onnx` helper) and either drop it at `~/.cache/spot_rapier/walk_policy.onnx` or set `walk_policy_onnx` in the config.
+
+## Running
+
+### Quick local test (no trainer, no API — `process` mode)
+
+```bash
+cd /home/olive/Repositories/hermes-agent
+python -m environments.spot_foraging_env.env process \
+    --config environments/spot_foraging_env/configs/default.yaml \
+    --env.data_path_to_save_groups /tmp/spot_foraging.jsonl \
+    --env.total_steps 4 \
+    --openai.base_url "https://openrouter.ai/api/v1" \
+    --openai.api_key "$OPENROUTER_API_KEY" \
+    --openai.model_name "anthropic/claude-sonnet-4.5" \
+    --openai.server_type openai \
+    --openai.health_check false
+```
+
+This runs 4 scenarios end-to-end against any OpenAI-compatible multimodal endpoint, dumps `ScoredDataGroup`s to `/tmp/spot_foraging.jsonl`, and writes a static HTML viz alongside it. Good first sanity check.
+
+### Live training loop (`serve` mode)
+
+Three terminals:
+
+```bash
+# A: API server
+run-api &
+
+# B: Env server (this package)
+cd /home/olive/Repositories/hermes-agent
+python -m environments.spot_foraging_env.env serve \
+    --config environments/spot_foraging_env/configs/default.yaml \
+    --slurm False
+
+# C: Trainer (whatever you use — example_trainer/grpo.py, Axolotl, custom)
+python /tmp/atropos/example_trainer/grpo.py
+```
+
+### Inference setup
+
+The env is multimodal-capable (sends rendered PNGs as `image_url` parts when `enable_image=true`). Pick a multimodal endpoint:
+
+- **OpenRouter**: `--openai.base_url https://openrouter.ai/api/v1 --openai.model_name anthropic/claude-sonnet-4.5 --openai.health_check false` — cheapest path to test.
+- **vLLM with a multimodal trainee** (e.g. Llava-Next, InternVL): `--openai.base_url http://localhost:8001/v1 --openai.server_type vllm`.
+- **Text-only model** (no images): set `--env.enable_image False` and the env falls back to JSON-only state.
+
+## Reward shape
+
+```
+score = +10.0  per battery collected
+      + 20.0  if ALL collected before timeout (success bonus)
+      -  0.05 × n_skill_picks   (efficiency penalty)
+      -  5.0  if Spot fell      (terminal failure)
+      +  0.5  × cumulative-best-distance-decrement   (dense shaping)
+
+clipped to ±200.0
+```
+
+A successful 5-battery episode in ~15 picks scores ~ 10×5 + 20 - 0.05×15 + shaping ≈ 70-80. A faller after collecting 1 scores ~10 - 5 - some penalty ≈ 0-5. A timeout-no-collect scores ~0 plus whatever shaping accumulated.
+
+Tunable in `RewardConfig` (per-episode) or `SpotForagingEnvConfig` (CLI/YAML).
+
+## Group construction
+
+Each `collect_trajectories` call runs `group_size` rollouts on the **same scenario** (same seed, same battery layout, same spawn). The differential is the LLM's stochastic skill picks. This gives Atropos a clean GRPO contrastive group: same starting state, varying scores driven by varying skill sequences.
+
+For PPO-style training without contrastive grouping, set `group_size=1` and the same env works.
+
+## Observability
+
+Per-train-step (logged via `wandb_log`):
+- `train/avg_collected` — mean batteries collected over recent episodes.
+- `train/avg_skill_picks` — mean episode length in picks.
+- `train/fall_rate` — fraction of recent episodes that ended in a fall.
+- `train/success_rate` — fraction that collected all batteries.
+
+Per-eval (logged when `evaluate()` runs every `steps_per_eval` steps):
+- `eval/success_rate`, `eval/avg_collected`, `eval/avg_skill_picks`, `eval/fall_rate`, `eval/n_episodes`.
+
+Plus the base-class rollout-table (set `num_rollouts_to_keep` in the config to control table size).
+
+## Known limitations / TODOs
+
+- **`set_battery_positions`** isn't yet exposed by rapier-gym's PyO3 layer. Currently the env relies on `spawn_targets=True` letting the rapier sim place batteries via its own random sampling — the explicit `battery_positions` we sample in `ScenarioItem` is used for shaping/scoring but not enforced in-sim. Will land properly once the Rust side exposes the setter.
+- **Yaw heading in the renderer** is estimated from recent displacement (atan2 of trail). When Spot is stationary it shows whatever the last motion direction was. Cleanup: expose body quaternion via the rapier-gym Python API and read it directly.
+- **The walk policy fallback is zero-action.** Episodes still run, but Spot stands still. Until walk training (v23) ships an ONNX checkpoint, the env exercises only the LLM-loop, not the physical execution.
+
+- **Image encoding cost**: rendering a 256×256 PNG every skill pick adds ~10-20ms latency. For high-throughput training, consider lowering `image_pixels` or disabling images entirely.
+
+## Future directions
+
+- **Multi-skill policy training**: train per-skill policies (sit, stand, climb, etc.) instead of reusing the walk policy with command overrides. Each skill becomes a separate ONNX checkpoint.
+- **WASM render integration**: replace the matplotlib top-down with rendered frames from the existing in-cluster Rerun viewer pods or the WASM browser sim — the LLM gets a third-person rendering matching what humans see.
+- **Curriculum**: start with `n_batteries=1` in a small arena, scale up as the trainee succeeds. Atropos doesn't ship curriculum support; implement via overriding `get_next_item`.
+- **Federated rollouts**: this env is stateless across episodes. Multiple env-server replicas pointed at one Atropos API gives free horizontal scale of rollout collection.

--- a/environments/spot_foraging_env/__init__.py
+++ b/environments/spot_foraging_env/__init__.py
@@ -1,0 +1,20 @@
+"""LLM-as-skill-selector hierarchical RL env for Spot foraging.
+
+The LLM picks a movement skill at ~1 Hz; the underlying walk PPO policy
+executes the chosen skill at 50 Hz against the rapier-gym physics sim.
+The Atropos training signal is the LLM's success at directing Spot to
+collect scattered batteries.
+
+See README.md for architecture, conventions, and run instructions.
+"""
+
+from .env import SpotForagingEnv, SpotForagingEnvConfig
+from .skills import SKILL_REGISTRY, Skill, SkillExecutor
+
+__all__ = [
+    "SpotForagingEnv",
+    "SpotForagingEnvConfig",
+    "SKILL_REGISTRY",
+    "Skill",
+    "SkillExecutor",
+]

--- a/environments/spot_foraging_env/configs/default.yaml
+++ b/environments/spot_foraging_env/configs/default.yaml
@@ -1,0 +1,38 @@
+env:
+  n_batteries: 5
+  arena_half_size_m: 4.0
+  spawn_radius_m: 0.5
+  max_skill_picks: 30
+  fall_terminates: true
+  enable_image: true
+  image_pixels: 256
+
+  walk_policy_onnx: null   # null = auto-resolve via SPOT_WALK_POLICY_ONNX env var or ~/.cache/spot_rapier/walk_policy.onnx
+
+  skill_pick_temperature: 1.0
+  skill_pick_max_tokens: 256
+
+  reward_per_battery: 10.0
+  reward_success_bonus: 20.0
+  reward_skill_pick_cost: 0.05
+  reward_fall_penalty: 5.0
+  reward_distance_decrement_weight: 0.5
+
+  group_size: 4
+  max_token_length: 8192
+  steps_per_eval: 50
+  use_wandb: true
+  include_messages: true
+  tokenizer_name: NousResearch/DeepHermes-3-Llama-3-3B-Preview
+  rollout_server_url: http://localhost:8000
+
+slurm: false
+
+openai:
+  base_url: http://localhost:8001/v1   # vLLM serving the trainee
+  api_key: x
+  model_name: NousResearch/DeepHermes-3-Llama-3-3B-Preview
+  server_type: vllm
+  health_check: true
+  timeout: 600
+  num_max_requests_at_once: 32

--- a/environments/spot_foraging_env/env.py
+++ b/environments/spot_foraging_env/env.py
@@ -318,6 +318,7 @@ class SpotForagingEnv(BaseEnv):
         ]
 
         tools = build_tool_spec()
+        tool_choice_value = {"type": "function", "function": {"name": "select_skill"}}
 
         # Run the episode under a single ManagedServer context — multi-turn
         # tokens accumulate correctly with proper masking across all picks.
@@ -329,11 +330,17 @@ class SpotForagingEnv(BaseEnv):
                     max_tokens=self.config.skill_pick_max_tokens,
                     temperature=self.config.skill_pick_temperature,
                     tools=tools,
-                    tool_choice="auto",
+                    tool_choice=tool_choice_value,
                 )
 
                 assistant_msg = chat.choices[0].message
                 messages.append(_assistant_message_to_dict(assistant_msg))
+                print(
+                    f"[LLM RESPONSE] content={repr(assistant_msg.content)[:80]}"
+                    f" tool_calls={bool(assistant_msg.tool_calls)}"
+                    f" n_tools={len(assistant_msg.tool_calls) if assistant_msg.tool_calls else 0}",
+                    flush=True,
+                )
 
                 skill = _parse_skill_from_message(assistant_msg)
                 if skill is None:
@@ -352,6 +359,13 @@ class SpotForagingEnv(BaseEnv):
 
                 skill_history.append(skill.name)
                 result: SkillResult = executor.execute(skill)
+                print(
+                    f"[SKILL] {skill.name} disp=({result.displacement[0]:.3f},{result.displacement[1]:.3f})"
+                    f" pre=({result.pre_xy[0]:.2f},{result.pre_xy[1]:.2f})"
+                    f" post=({result.post_xy[0]:.2f},{result.post_xy[1]:.2f})"
+                    f" collected={result.collected_during_burst} fell={result.fell}",
+                    flush=True,
+                )
 
                 # Update post-skill state.
                 trail.append(

--- a/environments/spot_foraging_env/env.py
+++ b/environments/spot_foraging_env/env.py
@@ -1,0 +1,571 @@
+"""SpotForagingEnv — the Atropos BaseEnv for LLM-as-skill-selector foraging.
+
+Architecture (one rollout):
+    1. Reset rapier-gym to a scenario (random spawn, batteries scattered).
+    2. Build initial chat: system prompt + first state JSON + rendered frame.
+    3. Loop until terminal:
+       a. LLM chat_completion (under ManagedServer for token tracking).
+       b. Parse the `select_skill` tool call → Skill name.
+       c. SkillExecutor runs the skill against the gym (50 physics ticks
+          driven by the walk PPO policy + skill's command vector).
+       d. Append assistant message; append new user message with updated
+          state JSON + new frame.
+    4. Score the LLM's full skill-pick trajectory (battery collection,
+       efficiency, fall penalty, distance shaping).
+    5. Return ScoredDataGroup with concatenated multi-turn tokens/masks.
+
+Group construction: `group_size` parallel rollouts from the SAME scenario
+(seed shared) — gives GRPO contrastive groups where the differential
+across rollouts is the LLM's skill-pick noise.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import math
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+import numpy as np
+
+
+# Atropos imports — fail loudly with a useful message if not installed.
+try:
+    from atroposlib.envs.base import (
+        BaseEnv,
+        BaseEnvConfig,
+        Item,
+        ScoredDataGroup,
+    )
+    from atroposlib.envs.server_handling.server_manager import (
+        ServerBaseline,
+    )
+except ImportError as e:  # pragma: no cover
+    raise ImportError(
+        "atroposlib not installed. Run `pip install atroposlib` or install "
+        "from the cloned repo with `pip install -e .[all]`."
+    ) from e
+
+from .policy import PolicyFn, load_walk_policy
+from .prompts import (
+    SYSTEM_PROMPT,
+    build_tool_spec,
+    build_user_message_content,
+    format_state_json,
+)
+from .renderer import (
+    SceneSnapshot,
+    make_image_content_part,
+    snapshot_from_gym,
+)
+from .reward import EpisodeMetrics, RewardConfig, compute_reward
+from .skills import (
+    SKILL_REGISTRY,
+    Skill,
+    SkillExecutor,
+    SkillResult,
+    get_skill,
+)
+
+
+logger = logging.getLogger(__name__)
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Config
+
+
+class SpotForagingEnvConfig(BaseEnvConfig):
+    """Foraging-specific knobs on top of BaseEnvConfig."""
+
+    # Scenario params
+    n_batteries: int = 5
+    arena_half_size_m: float = 4.0
+    spawn_radius_m: float = 0.5
+
+    # Episode shape
+    max_skill_picks: int = 30                 # episode timeout in skill-picks
+    fall_terminates: bool = True
+
+    # Image rendering
+    enable_image: bool = True
+    image_pixels: int = 256
+
+    # Walk policy
+    walk_policy_onnx: Optional[str] = None    # explicit override; else env-resolution
+
+    # LLM control
+    skill_pick_temperature: float = 1.0
+    skill_pick_max_tokens: int = 256
+
+    # Reward
+    reward_per_battery: float = 10.0
+    reward_success_bonus: float = 20.0
+    reward_skill_pick_cost: float = 0.05
+    reward_fall_penalty: float = 5.0
+    reward_distance_decrement_weight: float = 0.5
+
+    # Override BaseEnv defaults — sensible for this env
+    group_size: int = 4                       # 4 LLM rollouts per scenario
+    max_token_length: int = 8192              # multi-turn chat is long
+    steps_per_eval: int = 50
+    use_wandb: bool = True
+    include_messages: bool = True             # multimodal — keep messages on the wire
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Scenario item
+
+
+@dataclass
+class ScenarioItem:
+    """One foraging scenario: where to spawn Spot, where to put batteries."""
+
+    seed: int
+    spot_start_xy: Tuple[float, float]
+    battery_positions: List[Tuple[float, float]]
+
+
+def _sample_scenario(
+    cfg: SpotForagingEnvConfig, rng: np.random.Generator
+) -> ScenarioItem:
+    """Produce a fresh scenario respecting arena/spawn config."""
+    half = cfg.arena_half_size_m
+    spot_xy = tuple(
+        rng.uniform(-cfg.spawn_radius_m, cfg.spawn_radius_m, size=2).astype(float)
+    )
+
+    # Sample battery positions, rejection-sampling to avoid spawn-overlap.
+    batteries: List[Tuple[float, float]] = []
+    attempts = 0
+    while len(batteries) < cfg.n_batteries and attempts < 200:
+        b = tuple(rng.uniform(-half, half, size=2).astype(float))
+        if all(math.hypot(b[0] - x, b[1] - y) > 0.6 for x, y in batteries + [spot_xy]):
+            batteries.append(b)
+        attempts += 1
+
+    return ScenarioItem(
+        seed=int(rng.integers(0, 2**31 - 1)),
+        spot_start_xy=spot_xy,  # type: ignore[arg-type]
+        battery_positions=batteries,
+    )
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Env
+
+
+class SpotForagingEnv(BaseEnv):
+    """LLM-as-skill-selector foraging env, Atropos style."""
+
+    name = "spot_foraging"
+    env_config_cls = SpotForagingEnvConfig
+
+    @classmethod
+    def config_init(cls) -> Tuple[SpotForagingEnvConfig, ServerBaseline]:
+        return cls.env_config_cls(), ServerBaseline()
+
+    # ── lifecycle ─────────────────────────────────────────────────────────
+
+    async def setup(self) -> None:
+        # Lazy import: SpotEnvRapier needs the .so, which we may have just
+        # added to sys.path. Doing it here avoids hard-failing if someone
+        # imports SpotForagingEnv on a box without rapier-gym.
+        from spot_rapier import SpotEnvRapier
+
+        self._SpotEnvRapier = SpotEnvRapier
+        self._policy: PolicyFn = load_walk_policy(
+            self.config.walk_policy_onnx
+        )
+        self._reward_cfg = RewardConfig(
+            per_battery=self.config.reward_per_battery,
+            success_bonus=self.config.reward_success_bonus,
+            skill_pick_cost=self.config.reward_skill_pick_cost,
+            fall_penalty=self.config.reward_fall_penalty,
+            distance_decrement_weight=self.config.reward_distance_decrement_weight,
+        )
+
+        # Train / eval scenario RNGs.
+        self._train_rng = np.random.default_rng(seed=42)
+        self._eval_scenarios = [
+            _sample_scenario(self.config, np.random.default_rng(seed=1000 + i))
+            for i in range(16)
+        ]
+
+        # Episode metrics for wandb summary (last N episodes).
+        self._recent_metrics: List[EpisodeMetrics] = []
+
+        logger.info(
+            "SpotForagingEnv setup complete. n_batteries=%d max_picks=%d "
+            "image_enabled=%s policy=%s",
+            self.config.n_batteries,
+            self.config.max_skill_picks,
+            self.config.enable_image,
+            "onnx" if self.config.walk_policy_onnx else "auto",
+        )
+
+    async def get_next_item(self) -> Optional[Item]:
+        return _sample_scenario(self.config, self._train_rng)
+
+    # ── main rollout ──────────────────────────────────────────────────────
+
+    async def collect_trajectories(
+        self, item: ScenarioItem
+    ) -> Tuple[Optional[ScoredDataGroup], List[Item]]:
+        """Run `group_size` rollouts on the same scenario; build group."""
+        rollouts = await asyncio.gather(
+            *[
+                self._run_episode(item)
+                for _ in range(self.config.group_size)
+            ]
+        )
+
+        # Drop any rollouts that errored.
+        rollouts = [r for r in rollouts if r is not None]
+        if not rollouts:
+            return None, []
+
+        scores = [r["score"] for r in rollouts]
+        if (
+            self.config.ensure_scores_are_not_same
+            and all(s == scores[0] for s in scores)
+        ):
+            # Atropos convention — drop unprobeable groups.
+            return None, []
+
+        group: ScoredDataGroup = {
+            "tokens": [r["tokens"] for r in rollouts],
+            "masks": [r["masks"] for r in rollouts],
+            "scores": scores,
+        }
+        if self.config.include_messages:
+            group["messages"] = [r["messages"] for r in rollouts]
+
+        # Stash metrics for wandb_log.
+        for r in rollouts:
+            self._recent_metrics.append(r["metrics"])
+        self._recent_metrics = self._recent_metrics[-100:]
+
+        return group, []
+
+    async def _run_episode(self, item: ScenarioItem) -> Optional[Dict[str, Any]]:
+        """One rollout: full LLM-driven foraging episode → tokens/masks/score."""
+        try:
+            return await asyncio.wait_for(self._run_episode_inner(item), timeout=600)
+        except Exception as e:
+            logger.warning("Episode failed: %s", e, exc_info=True)
+            return None
+
+    async def _run_episode_inner(self, item: ScenarioItem) -> Dict[str, Any]:
+        # Build a fresh gym env per rollout (state isolation).
+        gym_env = self._SpotEnvRapier(
+            config={
+                "behavior": "forage",
+                "spawn_targets": True,
+                "n_targets": self.config.n_batteries,
+                "seed": item.seed,
+            }
+        )
+        # Reset to spawn at the scenario's start position.
+        gym_env.reset(seed=item.seed)
+        # Override battery positions if rapier-gym supports explicit placement.
+        # Falls back to whatever the env spawned via its own random sampling
+        # if direct placement isn't exposed.
+        if hasattr(gym_env.sim, "set_battery_positions"):
+            try:
+                gym_env.sim.set_battery_positions([
+                    [b[0], 0.0, b[1]] for b in item.battery_positions
+                ])
+            except Exception as e:
+                logger.debug("set_battery_positions not supported: %s", e)
+
+        executor = SkillExecutor(gym_env, self._policy)
+
+        # State for distance shaping.
+        trail: List[Tuple[float, float]] = []
+        nearest_dist_history: List[float] = []
+        skill_history: List[str] = []
+        terminated = False
+
+        # Build initial chat state.
+        initial_snapshot = snapshot_from_gym(gym_env, trail)
+        initial_state_json = format_state_json(
+            spot_xy=initial_snapshot.spot_xy,
+            spot_yaw_deg=math.degrees(initial_snapshot.spot_yaw),
+            batteries=initial_snapshot.batteries,
+            collected=initial_snapshot.collected_count,
+            skill_history=skill_history,
+            steps_remaining=self.config.max_skill_picks,
+            energy=initial_snapshot.energy,
+        )
+
+        image_part = (
+            make_image_content_part(initial_snapshot, pixels=self.config.image_pixels)
+            if self.config.enable_image
+            else None
+        )
+
+        messages: List[Dict] = [
+            {"role": "system", "content": SYSTEM_PROMPT},
+            {
+                "role": "user",
+                "content": build_user_message_content(initial_state_json, image_part),
+            },
+        ]
+
+        tools = build_tool_spec()
+
+        # Run the episode under a single ManagedServer context — multi-turn
+        # tokens accumulate correctly with proper masking across all picks.
+        async with self.server.managed_server(tokenizer=self.tokenizer) as managed:
+            for pick_idx in range(self.config.max_skill_picks):
+                chat = await managed.chat_completion(
+                    messages=messages,
+                    n=1,
+                    max_tokens=self.config.skill_pick_max_tokens,
+                    temperature=self.config.skill_pick_temperature,
+                    tools=tools,
+                    tool_choice="auto",
+                )
+
+                assistant_msg = chat.choices[0].message
+                messages.append(_assistant_message_to_dict(assistant_msg))
+
+                skill = _parse_skill_from_message(assistant_msg)
+                if skill is None:
+                    # LLM whiffed: nudge it back on track and let it retry.
+                    messages.append(
+                        {
+                            "role": "user",
+                            "content": (
+                                "I couldn't parse a `select_skill` tool call. "
+                                "Try again: call `select_skill` with one of "
+                                f"{sorted(SKILL_REGISTRY.keys())}."
+                            ),
+                        }
+                    )
+                    continue
+
+                skill_history.append(skill.name)
+                result: SkillResult = executor.execute(skill)
+
+                # Update post-skill state.
+                trail.append(
+                    (
+                        float(gym_env.sim.get_base_position()[0]),
+                        float(gym_env.sim.get_base_position()[2]),
+                    )
+                )
+
+                # Track nearest-battery distance for shaping.
+                snap = snapshot_from_gym(gym_env, trail)
+                if snap.batteries:
+                    sx, sz = snap.spot_xy
+                    nearest = min(
+                        math.hypot(sx - bx, sz - bz) for bx, bz in snap.batteries
+                    )
+                else:
+                    nearest = 0.0
+                nearest_dist_history.append(nearest)
+
+                # Tool-result message (compact).
+                tool_summary = {
+                    "skill_executed": skill.name,
+                    "displacement_xy": [round(d, 2) for d in result.displacement],
+                    "collected_in_burst": result.collected_during_burst,
+                    "total_collected": int(gym_env.collected_targets),
+                    "fell": bool(result.fell),
+                }
+                tool_call_id = _first_tool_call_id(assistant_msg)
+                if tool_call_id is not None:
+                    messages.append(
+                        {
+                            "role": "tool",
+                            "tool_call_id": tool_call_id,
+                            "content": json.dumps(tool_summary),
+                        }
+                    )
+
+                # Terminal conditions.
+                if result.fell and self.config.fall_terminates:
+                    terminated = True
+                    break
+                if int(gym_env.collected_targets) >= len(item.battery_positions):
+                    terminated = True
+                    break
+
+                # Append next state for the LLM.
+                state_json = format_state_json(
+                    spot_xy=snap.spot_xy,
+                    spot_yaw_deg=math.degrees(snap.spot_yaw),
+                    batteries=snap.batteries,
+                    collected=snap.collected_count,
+                    skill_history=skill_history,
+                    steps_remaining=self.config.max_skill_picks - (pick_idx + 1),
+                    energy=snap.energy,
+                )
+                next_image_part = (
+                    make_image_content_part(snap, pixels=self.config.image_pixels)
+                    if self.config.enable_image
+                    else None
+                )
+                messages.append(
+                    {
+                        "role": "user",
+                        "content": build_user_message_content(
+                            state_json, next_image_part
+                        ),
+                    }
+                )
+
+            nodes = managed.get_state()["nodes"]
+
+        # Concat multi-turn tokens/masks into one sequence.
+        all_tokens = []
+        all_masks = []
+        for node in nodes:
+            all_tokens.extend(node.tokens)
+            all_masks.extend(node.masked_tokens)
+
+        # Compute episode score.
+        metrics = EpisodeMetrics(
+            batteries_collected=int(gym_env.collected_targets),
+            total_batteries=len(item.battery_positions),
+            skill_picks=len(skill_history),
+            fell=terminated and any(
+                m.get("fell")
+                for m in messages
+                if isinstance(m.get("content"), str)
+            ),
+            timed_out=not terminated,
+            nearest_battery_distance_history=nearest_dist_history,
+        )
+        score = compute_reward(metrics, self._reward_cfg)
+
+        return {
+            "tokens": all_tokens,
+            "masks": all_masks,
+            "messages": messages,
+            "score": score,
+            "metrics": metrics,
+        }
+
+    # ── eval ──────────────────────────────────────────────────────────────
+
+    async def evaluate(self, *args, **kwargs) -> None:
+        """Run held-out scenarios; log eval/* metrics to wandb."""
+        eval_metrics: List[EpisodeMetrics] = []
+        for scenario in self._eval_scenarios:
+            try:
+                rollout = await self._run_episode_inner(scenario)
+                eval_metrics.append(rollout["metrics"])
+            except Exception as e:
+                logger.warning("Eval episode failed: %s", e)
+
+        if not eval_metrics:
+            return
+
+        n = len(eval_metrics)
+        success_rate = sum(
+            1 for m in eval_metrics
+            if m.batteries_collected == m.total_batteries
+        ) / n
+        avg_collected = sum(m.batteries_collected for m in eval_metrics) / n
+        avg_picks = sum(m.skill_picks for m in eval_metrics) / n
+        fall_rate = sum(1 for m in eval_metrics if m.fell) / n
+
+        # Stash for wandb_log to pick up.
+        self._last_eval_metrics = {
+            "eval/success_rate": success_rate,
+            "eval/avg_collected": avg_collected,
+            "eval/avg_skill_picks": avg_picks,
+            "eval/fall_rate": fall_rate,
+            "eval/n_episodes": n,
+        }
+
+    async def wandb_log(self, wandb_metrics: Optional[Dict] = None) -> None:
+        if wandb_metrics is None:
+            wandb_metrics = {}
+
+        if self._recent_metrics:
+            collected = [m.batteries_collected for m in self._recent_metrics]
+            picks = [m.skill_picks for m in self._recent_metrics]
+            falls = [m.fell for m in self._recent_metrics]
+            wandb_metrics["train/avg_collected"] = sum(collected) / len(collected)
+            wandb_metrics["train/avg_skill_picks"] = sum(picks) / len(picks)
+            wandb_metrics["train/fall_rate"] = sum(falls) / len(falls)
+            wandb_metrics["train/success_rate"] = sum(
+                1 for m in self._recent_metrics
+                if m.batteries_collected == m.total_batteries
+            ) / len(self._recent_metrics)
+
+        if hasattr(self, "_last_eval_metrics"):
+            wandb_metrics.update(self._last_eval_metrics)
+
+        await super().wandb_log(wandb_metrics)
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Tool-call parsing helpers
+
+
+def _assistant_message_to_dict(msg: Any) -> Dict:
+    """Coerce an OpenAI-format assistant message (with tool_calls) to a dict."""
+    out: Dict[str, Any] = {"role": "assistant"}
+    if getattr(msg, "content", None):
+        out["content"] = msg.content
+    tool_calls = getattr(msg, "tool_calls", None) or []
+    if tool_calls:
+        out["tool_calls"] = [
+            {
+                "id": tc.id,
+                "type": "function",
+                "function": {
+                    "name": tc.function.name,
+                    "arguments": tc.function.arguments,
+                },
+            }
+            for tc in tool_calls
+        ]
+    return out
+
+
+def _first_tool_call_id(msg: Any) -> Optional[str]:
+    tcs = getattr(msg, "tool_calls", None)
+    if tcs:
+        return tcs[0].id
+    return None
+
+
+def _parse_skill_from_message(msg: Any) -> Optional[Skill]:
+    """Extract a Skill from a `select_skill` tool call. Returns None on miss."""
+    tcs = getattr(msg, "tool_calls", None) or []
+    for tc in tcs:
+        if getattr(tc, "type", "") != "function":
+            continue
+        fn = getattr(tc, "function", None)
+        if fn is None or fn.name != "select_skill":
+            continue
+        try:
+            args = json.loads(fn.arguments or "{}")
+        except json.JSONDecodeError:
+            continue
+        skill_name = args.get("skill")
+        if not isinstance(skill_name, str):
+            continue
+        skill = get_skill(skill_name)
+        if skill is not None:
+            return skill
+    return None
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# CLI entrypoint
+
+
+if __name__ == "__main__":
+    SpotForagingEnv.cli()

--- a/environments/spot_foraging_env/policy.py
+++ b/environments/spot_foraging_env/policy.py
@@ -45,6 +45,60 @@ def make_random_policy(scale: float = 0.05, seed: int = 0) -> PolicyFn:
     return policy
 
 
+def make_cpg_policy(freq_hz: float = 2.0, amplitude: float = 0.3) -> PolicyFn:
+    """Central Pattern Generator (CPG) heuristic walk policy.
+
+    Produces a trot gait via sinusoidal joint targets, sufficient for Spot to
+    physically move in the rapier-gym sim when no trained ONNX policy is
+    available. Not a substitute for a trained policy — gaits will be unstable
+    at high amplitudes — but generates non-zero displacement so the Atropos
+    foraging env produces meaningful reward gradients.
+
+    The obs vector contains the command in indices 45:48 (v_x, v_lat, w_z)
+    based on the rapier-gym observation layout:
+      [0:3]   ang_vel, [3:6] lin_vel, [6:9] proj_grav
+      [9:21]  joint_pos, [21:33] joint_vel, [33:45] prev_action
+      [45:48] cmd (v_x, v_lat, w_z)
+      ... rest: foot_contacts, torques, body_contact, obstacle_rays, behavior, forage, gait_phase
+
+    Joint ordering (12 dims): FL_hip, FL_upper, FL_lower, FR_hip, FR_upper, FR_lower,
+                               RL_hip, RL_upper, RL_lower, RR_hip, RR_upper, RR_lower
+    """
+    _phase = [0.0]  # mutable closure for phase accumulation
+    _dt = 1.0 / 50.0  # 50 Hz policy rate
+
+    # Trot: FL+RR swing together, FR+RL swing together (180° phase offset)
+    _leg_phase_offsets = np.array([0.0, 0.0, 0.0,   # FL hip/upper/lower
+                                    np.pi, np.pi, np.pi,  # FR
+                                    np.pi, np.pi, np.pi,  # RL
+                                    0.0, 0.0, 0.0],       # RR
+                                   dtype=np.float32)
+
+    # Hip: small lateral sway; upper-leg: main swing; lower-leg: follow
+    _joint_amp_weights = np.array([0.05, 1.0, -0.5,  # FL
+                                    0.05, 1.0, -0.5,  # FR
+                                    0.05, 1.0, -0.5,  # RL
+                                    0.05, 1.0, -0.5], # RR
+                                   dtype=np.float32)
+
+    def policy(obs: np.ndarray) -> np.ndarray:
+        # Read command from obs if available.
+        cmd_vx = float(obs[45]) if len(obs) > 47 else 1.0
+        cmd_lat = float(obs[46]) if len(obs) > 47 else 0.0
+        cmd_yaw = float(obs[47]) if len(obs) > 47 else 0.0
+
+        speed = abs(cmd_vx) + abs(cmd_lat) * 0.5 + abs(cmd_yaw) * 0.3
+        effective_amp = amplitude * max(0.1, min(1.0, speed))
+
+        phase = _phase[0] + 2 * np.pi * freq_hz * _dt
+        _phase[0] = phase % (2 * np.pi)
+
+        action = effective_amp * _joint_amp_weights * np.sin(phase + _leg_phase_offsets)
+        return np.clip(action, -0.5, 0.5).astype(np.float32)
+
+    return policy
+
+
 def make_onnx_policy(onnx_path: str | os.PathLike) -> PolicyFn:
     """Load an ONNX policy via onnxruntime. CPU is fine — the policy is tiny."""
     import onnxruntime as ort  # lazy: not all installs have it
@@ -108,9 +162,9 @@ def load_walk_policy(
                 continue
 
     logger.warning(
-        "No walk policy ONNX found (tried %s). Falling back to zero-action "
-        "policy. Train walk via train_rapier.py and export to ONNX, or set "
-        "SPOT_WALK_POLICY_ONNX.",
+        "No walk policy ONNX found (tried %s). Falling back to CPG heuristic "
+        "trot policy. Train walk via train_rapier.py and export to ONNX, or "
+        "set SPOT_WALK_POLICY_ONNX.",
         [str(c) for c in candidates],
     )
-    return make_zero_policy()
+    return make_cpg_policy(amplitude=0.04)  # very small — avoids falls while still non-zero

--- a/environments/spot_foraging_env/policy.py
+++ b/environments/spot_foraging_env/policy.py
@@ -1,0 +1,116 @@
+"""Low-level walk PPO policy loader.
+
+Loads a trained walk policy in ONNX format (the artifact produced by
+`export_pipeline.export_onnx` in the rapier-gym tree) and returns a
+callable suitable for `SkillExecutor`.
+
+Falls back to a "stand-still" zero-action policy when no checkpoint is
+available — lets the rest of the env be tested before walk training has
+converged. Falling-still-on-the-spot is a degenerate but stable behavior
+that keeps episodes running.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+from typing import Callable, Optional
+
+import numpy as np
+
+
+logger = logging.getLogger(__name__)
+
+
+PolicyFn = Callable[[np.ndarray], np.ndarray]
+
+
+def make_zero_policy() -> PolicyFn:
+    """Always-zero action. Spot stands still (modulo any default joint biases)."""
+
+    def policy(_obs: np.ndarray) -> np.ndarray:
+        return np.zeros(12, dtype=np.float32)
+
+    return policy
+
+
+def make_random_policy(scale: float = 0.05, seed: int = 0) -> PolicyFn:
+    """Tiny gaussian noise. For sanity-testing the env loop produces motion."""
+    rng = np.random.default_rng(seed)
+
+    def policy(_obs: np.ndarray) -> np.ndarray:
+        return (rng.standard_normal(12) * scale).astype(np.float32)
+
+    return policy
+
+
+def make_onnx_policy(onnx_path: str | os.PathLike) -> PolicyFn:
+    """Load an ONNX policy via onnxruntime. CPU is fine — the policy is tiny."""
+    import onnxruntime as ort  # lazy: not all installs have it
+
+    sess = ort.InferenceSession(
+        str(onnx_path),
+        providers=["CPUExecutionProvider"],
+    )
+    in_name = sess.get_inputs()[0].name
+    out_name = sess.get_outputs()[0].name
+
+    expected_obs_dim = sess.get_inputs()[0].shape[-1]
+    if isinstance(expected_obs_dim, int):
+        logger.info(
+            "Loaded walk policy from %s (obs_dim=%d)", onnx_path, expected_obs_dim
+        )
+
+    def policy(obs: np.ndarray) -> np.ndarray:
+        if obs.ndim == 1:
+            obs = obs[None, :]  # add batch dim
+        action = sess.run([out_name], {in_name: obs.astype(np.float32)})[0]
+        if action.ndim == 2:
+            action = action[0]
+        return action.astype(np.float32)
+
+    return policy
+
+
+def load_walk_policy(
+    onnx_path: Optional[str | os.PathLike] = None,
+) -> PolicyFn:
+    """Load the configured walk policy, falling back to zero if missing.
+
+    Resolution order:
+      1. Explicit `onnx_path` argument.
+      2. `SPOT_WALK_POLICY_ONNX` env var.
+      3. Conventional location: $HOME/.cache/spot_rapier/walk_policy.onnx.
+      4. Zero-action fallback (logs a warning).
+
+    The fallback is deliberate — the foraging env is meant to be runnable
+    end-to-end for testing the LLM-loop / Atropos plumbing even when no
+    walk policy has been trained yet. With zero actions Spot just stands
+    there and the LLM's skill picks have no physical effect, but episodes
+    still run, reward is computed, and the trainer can collect data.
+    """
+    candidates = []
+    if onnx_path:
+        candidates.append(Path(onnx_path).expanduser())
+    if os.environ.get("SPOT_WALK_POLICY_ONNX"):
+        candidates.append(Path(os.environ["SPOT_WALK_POLICY_ONNX"]).expanduser())
+    candidates.append(
+        Path.home() / ".cache" / "spot_rapier" / "walk_policy.onnx"
+    )
+
+    for c in candidates:
+        if c.exists():
+            try:
+                return make_onnx_policy(c)
+            except Exception as e:
+                logger.warning("Failed to load ONNX policy %s: %s", c, e)
+                continue
+
+    logger.warning(
+        "No walk policy ONNX found (tried %s). Falling back to zero-action "
+        "policy. Train walk via train_rapier.py and export to ONNX, or set "
+        "SPOT_WALK_POLICY_ONNX.",
+        [str(c) for c in candidates],
+    )
+    return make_zero_policy()

--- a/environments/spot_foraging_env/prompts.py
+++ b/environments/spot_foraging_env/prompts.py
@@ -1,0 +1,132 @@
+"""System prompt + tool spec for the LLM-as-skill-selector.
+
+Keep the prompt tight. The state JSON gives the LLM the spatial info it
+needs; the rendered top-down adds spatial intuition; the tool spec
+constrains output to a known skill name.
+"""
+
+from __future__ import annotations
+
+import json
+from textwrap import dedent
+from typing import Dict, List, Tuple
+
+from .skills import SKILL_REGISTRY
+
+
+SYSTEM_PROMPT = dedent(
+    """\
+    You are the high-level controller for a Spot quadruped robot in a
+    foraging task. Your goal is to direct the robot to walk over and
+    collect every yellow battery scattered on the ground.
+
+    You DO NOT control joints directly. You pick a movement skill from
+    a fixed library; a low-level locomotion policy executes that skill
+    for ~1 second and then returns control to you for the next pick.
+
+    World frame: +X east, +Z north (top-down). The robot's heading is
+    the direction it is currently facing (and walking when "walk_forward").
+    Batteries are collected when the robot's body passes within ~0.4m of
+    them. The robot can fall — if it does, the episode ends in failure.
+    Your reward is dominated by batteries collected; secondary penalties
+    encourage efficiency (fewer skill picks per battery).
+
+    Each turn you receive:
+      - A JSON status block with the robot's xy, heading, battery
+        positions, recent skill history, and time remaining.
+      - A top-down rendered view of the scene.
+
+    Pick the next skill by calling the `select_skill` tool. Do not write
+    long explanations — the trainee model needs to learn fast skill
+    selection, not verbose reasoning. One short sentence of rationale
+    before the tool call is fine; multi-paragraph chain-of-thought is
+    counterproductive at this control rate.
+    """
+).strip()
+
+
+def build_tool_spec() -> List[Dict]:
+    """OpenAI-format tool spec exposing only the available skills."""
+    skill_names = sorted(SKILL_REGISTRY.keys())
+    return [
+        {
+            "type": "function",
+            "function": {
+                "name": "select_skill",
+                "description": (
+                    "Choose the next movement skill for the robot. The "
+                    "low-level policy will execute it for the skill's "
+                    "fixed duration, then return control to you."
+                ),
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "skill": {
+                            "type": "string",
+                            "enum": skill_names,
+                            "description": (
+                                "Skill name. Available skills (with brief "
+                                "descriptions):\n"
+                                + "\n".join(
+                                    f"  - {s.name}: {s.description}"
+                                    for s in SKILL_REGISTRY.values()
+                                )
+                            ),
+                        },
+                        "rationale": {
+                            "type": "string",
+                            "description": (
+                                "One short sentence: why this skill, given "
+                                "the current state. Keep under 20 words."
+                            ),
+                        },
+                    },
+                    "required": ["skill"],
+                },
+            },
+        }
+    ]
+
+
+def format_state_json(
+    *,
+    spot_xy: Tuple[float, float],
+    spot_yaw_deg: float,
+    batteries: List[Tuple[float, float]],
+    collected: int,
+    skill_history: List[str],
+    steps_remaining: int,
+    energy: float | None = None,
+) -> str:
+    """Compact JSON the LLM can parse quickly."""
+    state = {
+        "robot": {
+            "position": [round(spot_xy[0], 2), round(spot_xy[1], 2)],
+            "heading_deg": round(spot_yaw_deg, 1),
+        },
+        "batteries_remaining": [
+            [round(x, 2), round(z, 2)] for x, z in batteries
+        ],
+        "batteries_collected": collected,
+        "skill_history_recent": skill_history[-5:],
+        "skill_picks_remaining": steps_remaining,
+    }
+    if energy is not None:
+        state["robot"]["energy"] = round(energy, 2)
+    return json.dumps(state, indent=2)
+
+
+def build_user_message_content(state_json: str, image_part: Dict | None) -> List[Dict]:
+    """Compose the multimodal user message for one skill-pick turn."""
+    parts: List[Dict] = [
+        {"type": "text", "text": f"Current state:\n```json\n{state_json}\n```"}
+    ]
+    if image_part is not None:
+        parts.append(image_part)
+    parts.append(
+        {
+            "type": "text",
+            "text": "Call `select_skill` with the next movement skill.",
+        }
+    )
+    return parts

--- a/environments/spot_foraging_env/renderer.py
+++ b/environments/spot_foraging_env/renderer.py
@@ -1,0 +1,192 @@
+"""Top-down scene renderer.
+
+Produces a small PNG image showing Spot's pose, the batteries, and recent
+trajectory. Encoded as data-URL for OpenAI multimodal `image_url` content
+parts. Cheap (matplotlib + io.BytesIO) so we can call it every skill pick.
+
+Why top-down vs WASM/rerun? The WASM/rerun viewers need a running Atropos
+training-side viewer pod (or a JS runtime), while matplotlib is pure-python
+and works in any process. The image carries the same spatial signal —
+position, heading, battery layout — without the rendering pipeline
+overhead. Swap to the WASM render later once we have a clean reuse path.
+"""
+
+from __future__ import annotations
+
+import base64
+import io
+import math
+from dataclasses import dataclass
+from typing import List, Optional, Sequence, Tuple
+
+import numpy as np
+
+# Lazy-import matplotlib so the env package imports fast even when only
+# the env metadata is needed (e.g. for Atropos `serve`'s schema dump).
+try:
+    import matplotlib
+
+    matplotlib.use("Agg")  # non-interactive backend; mandatory in headless training pods
+    import matplotlib.pyplot as plt
+    from matplotlib.patches import Circle, FancyArrow
+
+    _MATPLOTLIB_OK = True
+except Exception as e:  # pragma: no cover
+    _MATPLOTLIB_OK = False
+    _IMPORT_ERROR = e
+
+
+@dataclass
+class SceneSnapshot:
+    """Minimal spatial state needed to render the foraging scene top-down."""
+
+    spot_xy: Tuple[float, float]
+    spot_yaw: float                     # radians, world frame, +Z = up
+    batteries: List[Tuple[float, float]]
+    collected_count: int
+    trail: List[Tuple[float, float]]    # historical xy, oldest first
+    energy: Optional[float] = None      # 0-1, optional
+
+
+def render_top_down(
+    snap: SceneSnapshot,
+    *,
+    side_meters: float = 8.0,
+    pixels: int = 256,
+    title: Optional[str] = None,
+) -> bytes:
+    """Render the snapshot as a PNG byte string.
+
+    `side_meters` is the world half-extent the view spans (so the figure
+    shows ±side_meters in X and Z). `pixels` is the output resolution.
+    """
+    if not _MATPLOTLIB_OK:
+        raise RuntimeError(
+            f"matplotlib not available for renderer ({_IMPORT_ERROR}). "
+            "Install matplotlib in the env-server container."
+        )
+
+    fig, ax = plt.subplots(figsize=(pixels / 100.0, pixels / 100.0), dpi=100)
+    ax.set_xlim(-side_meters, side_meters)
+    ax.set_ylim(-side_meters, side_meters)
+    ax.set_aspect("equal", adjustable="box")
+    ax.set_facecolor("#1a1a1a")
+    ax.tick_params(colors="#888888", labelsize=6)
+    ax.grid(True, color="#333333", linewidth=0.3)
+
+    # Trail (faded blue).
+    if len(snap.trail) >= 2:
+        xs = [p[0] for p in snap.trail]
+        ys = [p[1] for p in snap.trail]
+        ax.plot(xs, ys, color="#4a90e2", linewidth=0.8, alpha=0.5)
+
+    # Batteries (yellow circles).
+    for bx, bz in snap.batteries:
+        ax.add_patch(Circle((bx, bz), 0.15, color="#ffcc33", zorder=3))
+
+    # Spot (triangle/arrow showing heading).
+    sx, sz = snap.spot_xy
+    arrow_len = 0.4
+    dx = arrow_len * math.cos(snap.spot_yaw)
+    dz = arrow_len * math.sin(snap.spot_yaw)
+    ax.add_patch(
+        FancyArrow(
+            sx, sz, dx, dz,
+            width=0.08, head_width=0.22, head_length=0.18,
+            color="#7dd3fc", zorder=4,
+        )
+    )
+    ax.add_patch(Circle((sx, sz), 0.18, color="#0ea5e9", zorder=4))
+
+    # Compass / scale annotations.
+    ax.text(0, side_meters - 0.4, "+X (east)", color="#666", fontsize=5,
+            ha="center", va="top")
+    ax.text(side_meters - 0.4, 0, "+Z (north)", color="#666", fontsize=5,
+            ha="right", va="center", rotation=-90)
+
+    # Status overlay.
+    status_lines = [
+        f"collected: {snap.collected_count}",
+        f"remaining: {len(snap.batteries)}",
+    ]
+    if snap.energy is not None:
+        status_lines.append(f"energy: {snap.energy:.2f}")
+    ax.text(
+        -side_meters + 0.2, side_meters - 0.4,
+        "\n".join(status_lines),
+        color="#cccccc", fontsize=6, va="top",
+        family="monospace",
+    )
+
+    if title:
+        ax.set_title(title, color="#cccccc", fontsize=7)
+
+    buf = io.BytesIO()
+    fig.tight_layout(pad=0.2)
+    fig.savefig(buf, format="png", facecolor=fig.get_facecolor())
+    plt.close(fig)
+    return buf.getvalue()
+
+
+def encode_data_url(png_bytes: bytes) -> str:
+    """OpenAI multimodal-style data URL for chat `image_url` payloads."""
+    b64 = base64.b64encode(png_bytes).decode("ascii")
+    return f"data:image/png;base64,{b64}"
+
+
+def make_image_content_part(snap: SceneSnapshot, **kwargs) -> dict:
+    """OpenAI-format `{"type": "image_url", "image_url": {"url": ...}}` part."""
+    return {
+        "type": "image_url",
+        "image_url": {"url": encode_data_url(render_top_down(snap, **kwargs))},
+    }
+
+
+def snapshot_from_gym(gym_env, trail: Sequence[Tuple[float, float]]) -> SceneSnapshot:
+    """Pull a SceneSnapshot from a SpotEnvRapier instance (rapier-gym)."""
+    sim = gym_env.sim
+    base_pos = np.array(sim.get_base_position(), dtype=np.float32)
+    spot_xy = (float(base_pos[0]), float(base_pos[2]))
+
+    # Yaw from the body orientation. SpotEnvRapier's _compute_observation
+    # exposes proj_grav at obs[6:9]; for yaw we'd want the world-frame
+    # heading, computed from base orientation (we can read it from the
+    # raw obs[3:6] which is proj_grav rotated, but the cleanest source is
+    # base velocity direction OR a dedicated quaternion accessor).
+    # Falling back to estimating heading from recent displacement keeps
+    # us decoupled from spot-physics' orientation API surface.
+    yaw = 0.0
+    if hasattr(sim, "get_base_quaternion"):
+        q = sim.get_base_quaternion()
+        if len(q) == 4:
+            qi, qj, qk, qw = q[0], q[1], q[2], q[3]
+            # Rapier uses Y-up. Yaw is rotation around Y.
+            # Forward vector projection on X-Z plane:
+            yaw = math.atan2(2.0 * (qw * qj + qi * qk), 1.0 - 2.0 * (qj * qj + qk * qk))
+    else:
+        # Fallback if quaternion API isn't available
+        if len(trail) >= 2:
+            dx = trail[-1][0] - trail[-2][0]
+            dz = trail[-1][1] - trail[-2][1]
+            if abs(dx) + abs(dz) > 1e-3:
+                yaw = math.atan2(dz, dx)
+
+    batteries_raw = sim.get_battery_positions() or []
+    batteries = [(float(b[0]), float(b[2])) for b in batteries_raw]
+
+    collected = int(getattr(gym_env, "collected_targets", 0))
+
+    energy: Optional[float] = None
+    try:
+        energy = float(sim.get_energy())
+    except Exception:
+        pass
+
+    return SceneSnapshot(
+        spot_xy=spot_xy,
+        spot_yaw=yaw,
+        batteries=batteries,
+        collected_count=collected,
+        trail=list(trail),
+        energy=energy,
+    )

--- a/environments/spot_foraging_env/reward.py
+++ b/environments/spot_foraging_env/reward.py
@@ -1,0 +1,83 @@
+"""Reward shaping for the LLM-as-skill-selector foraging env.
+
+The LLM-side reward is computed *per episode*, not per skill burst.
+ScoredDataGroup gets one score per rollout (Atropos convention for chat
+envs). We attribute the score to the LLM's full sequence of skill picks.
+
+Components:
+    +10.0 per battery collected
+    +20.0 bonus if all batteries collected before timeout (success)
+    -0.05 per skill pick (efficiency penalty — fewer picks = higher score)
+    -5.0  if the robot fell (terminal failure)
+    +0.5  × Δ(distance-to-nearest-battery) summed over picks (dense shaping)
+
+Tunable via `RewardConfig`. Defaults chosen so a successful 5-battery
+episode scores ~70-90 and a failure scores ~-5 to 0.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List
+
+import math
+
+
+@dataclass
+class RewardConfig:
+    per_battery: float = 10.0
+    success_bonus: float = 20.0
+    skill_pick_cost: float = 0.05
+    fall_penalty: float = 5.0
+    distance_decrement_weight: float = 0.5
+    max_episode_score_clip: float = 200.0  # safety against runaway shaping
+
+
+@dataclass
+class EpisodeMetrics:
+    """Per-rollout aggregates handed to the reward function."""
+
+    batteries_collected: int
+    total_batteries: int
+    skill_picks: int
+    fell: bool
+    timed_out: bool
+    nearest_battery_distance_history: List[float]  # one entry per pick
+
+
+def compute_reward(metrics: EpisodeMetrics, cfg: RewardConfig | None = None) -> float:
+    """Single scalar score for the LLM's full skill-pick trajectory."""
+    cfg = cfg or RewardConfig()
+
+    # Collection.
+    score = cfg.per_battery * metrics.batteries_collected
+
+    # Success bonus.
+    if (
+        metrics.batteries_collected == metrics.total_batteries
+        and metrics.total_batteries > 0
+    ):
+        score += cfg.success_bonus
+
+    # Efficiency penalty.
+    score -= cfg.skill_pick_cost * metrics.skill_picks
+
+    # Death penalty.
+    if metrics.fell:
+        score -= cfg.fall_penalty
+
+    # Distance shaping: positive when distances trend down across picks.
+    dists = metrics.nearest_battery_distance_history
+    if len(dists) >= 2:
+        # Total decrement: how much closer we got over the episode.
+        # Use the cumulative best-distance progression so we don't reward
+        # walking-toward-and-then-away cycles.
+        best = math.inf
+        decrement_sum = 0.0
+        for d in dists:
+            if d < best:
+                decrement_sum += (best - d) if best != math.inf else 0.0
+                best = d
+        score += cfg.distance_decrement_weight * decrement_sum
+
+    return float(max(-cfg.max_episode_score_clip, min(cfg.max_episode_score_clip, score)))

--- a/environments/spot_foraging_env/scripts/patch_atroposlib.sh
+++ b/environments/spot_foraging_env/scripts/patch_atroposlib.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Apply patches to atroposlib site-packages to fix OpenRouter/OpenAI API routing.
+# Run after installing atroposlib into the venv.
+#
+# Fixes:
+#   1. ServerManager respects non-localhost base_url when given single APIServerConfig
+#   2. resolve_openai_configs ServerBaseline branch builds real APIServerConfig from CLI
+#   3. DummyManagedServer._messages_to_text handles tool-call messages (no 'content' key)
+#   4. OpenAIServer: lazy client init inside event loop + keepalive disabled
+
+set -euo pipefail
+
+VENV="${SPOT_ATROPOS_VENV:-/home/olive/Repositories/hermes-agent/.venv-atropos}"
+SITE="${VENV}/lib/python3.13/site-packages"
+ATROPOS="${SITE}/atroposlib/envs/server_handling"
+
+echo "Patching atroposlib in $ATROPOS ..."
+
+# ── 1. server_manager.py: respect non-localhost base_url ──────────────────────
+python3 - <<'PYEOF'
+import re, pathlib, sys
+
+p = pathlib.Path("${ATROPOS}/server_manager.py".replace("${ATROPOS}", sys.argv[1]))
+text = p.read_text()
+
+old = "        if not isinstance(configs, list):\n            urls = []"
+new = (
+    "        if not isinstance(configs, list):\n"
+    "            _base = getattr(configs, 'base_url', '') or ''\n"
+    "            if _base and 'localhost' not in _base and '127.0.0.1' not in _base:\n"
+    "                self.servers = [server_class(configs, reasoning_config=reasoning_config)]\n"
+    "            else:\n"
+    "                urls = []"
+)
+if old not in text:
+    if "_base and 'localhost' not in _base" in text:
+        print("server_manager.py patch already applied, skipping.")
+    else:
+        print("ERROR: server_manager.py patch anchor not found!", file=sys.stderr)
+        sys.exit(1)
+else:
+    text = text.replace(old, new, 1)
+    p.write_text(text)
+    print("server_manager.py: applied non-localhost base_url patch.")
+PYEOF "$ATROPOS"
+
+# ── 2. managed_server.py: m.get('content','') ─────────────────────────────────
+python3 - <<'PYEOF'
+import pathlib, sys
+
+p = pathlib.Path("${ATROPOS}/managed_server.py".replace("${ATROPOS}", sys.argv[1]))
+text = p.read_text()
+
+old = 'return "\\n\\n".join([f"{m[\'role\']}:{m[\'content\']}" for m in messages])'
+new = 'return "\\n\\n".join([f"{m[\'role\']}:{m.get(\'content\', \'\')}" for m in messages])'
+if old not in text:
+    if "m.get('content', '')" in text:
+        print("managed_server.py patch already applied, skipping.")
+    else:
+        print("ERROR: managed_server.py patch anchor not found!", file=sys.stderr)
+        sys.exit(1)
+else:
+    text = text.replace(old, new, 1)
+    p.write_text(text)
+    print("managed_server.py: applied get('content','') patch.")
+PYEOF "$ATROPOS"
+
+echo "All patches applied."

--- a/environments/spot_foraging_env/scripts/run_atropos_process.sh
+++ b/environments/spot_foraging_env/scripts/run_atropos_process.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# Run SpotForagingEnv in Atropos process-mode (data collection, no trainer).
+# Writes groups to /tmp/spot_foraging_test_N.jsonl (auto-incremented).
+#
+# Usage: bash scripts/run_atropos_process.sh [total_steps] [group_size]
+#
+set -a
+source ~/.config/litellm/.env 2>/dev/null
+source ~/.hermes/.env 2>/dev/null
+set +a
+
+TOTAL_STEPS="${1:-2}"
+GROUP_SIZE="${2:-2}"
+
+export WANDB_MODE=disabled
+export WANDB_DISABLED=true
+export ATROPOS_ALLOW_DUMMY_MANAGED_SERVER=1
+export PYTHONUNBUFFERED=1
+export LD_LIBRARY_PATH=/nix/store/xm08aqdd7pxcdhm0ak6aqb1v7hw5q6ri-gcc-14.3.0-lib/lib
+export PYTHONPATH=/home/olive/Repositories/skypilot-env/spot/rapier-gym/python:/home/olive/Repositories/hermes-agent
+cd /home/olive/Repositories/hermes-agent
+
+exec /home/olive/Repositories/hermes-agent/.venv-atropos/bin/python \
+  -m environments.spot_foraging_env.env process \
+  --env.total_steps "$TOTAL_STEPS" \
+  --env.group_size "$GROUP_SIZE" \
+  --env.data_path_to_save_groups /tmp/spot_foraging_test.jsonl \
+  --env.fall_terminates false \
+  --env.ensure_scores_are_not_same false \
+  --env.use_wandb false \
+  --openai.base_url "https://openrouter.ai/api/v1" \
+  --openai.api_key "$OPENROUTER_API_KEY" \
+  --openai.model_name "google/gemini-2.5-flash" \
+  --openai.server_type openai \
+  --openai.health_check false \
+  --openai.timeout 60 \
+  --env.tokenizer_name gpt2 \
+  --env.enable_image false \
+  2>&1

--- a/environments/spot_foraging_env/skills.py
+++ b/environments/spot_foraging_env/skills.py
@@ -1,0 +1,210 @@
+"""Skill library for the LLM-as-skill-selector Spot foraging env.
+
+Skills are short bursts of low-level locomotion executed by the walk PPO
+policy with a fixed command vector. Each skill maps to:
+    (command_velocity, duration_steps, semantic_label)
+
+The LLM picks skills by name; the SkillExecutor runs them against the
+rapier-gym SpotSim by stepping the underlying gym env with the policy
+producing 12-D joint targets at every physics tick.
+
+This file is intentionally agnostic to the policy implementation — pass
+any callable that maps `obs -> action` (numpy 12-D float32). See
+`policy.py` for the loader that pulls a trained ONNX policy when one is
+available.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, Dict, List, Optional, Tuple
+
+import numpy as np
+
+
+# Control-rate context: the underlying SpotSim runs physics at 200 Hz with a
+# decimation of 4, giving 50 Hz policy steps. One LLM-skill burst is the
+# duration_steps below × 1/50s = 1.0s for the default 50-step skills.
+PHYSICS_HZ = 200
+DECIMATION = 4
+POLICY_HZ = PHYSICS_HZ // DECIMATION  # 50
+
+
+@dataclass(frozen=True)
+class Skill:
+    """One movement primitive available to the LLM.
+
+    The command vector is what gets fed to the walk PPO policy:
+      command[0] = forward velocity   (m/s, body-frame X+)
+      command[1] = lateral velocity   (m/s, body-frame Z+)  // strafe
+      command[2] = yaw rate           (rad/s, world-up)
+    """
+
+    name: str
+    command: Tuple[float, float, float]  # (v_x, v_y_lat, w_z)
+    duration_steps: int = POLICY_HZ      # default: 1 second
+    description: str = ""
+
+
+SKILL_REGISTRY: Dict[str, Skill] = {
+    s.name: s
+    for s in [
+        Skill(
+            name="walk_forward",
+            command=(0.6, 0.0, 0.0),
+            duration_steps=POLICY_HZ,
+            description="Walk forward at moderate pace for ~1 second.",
+        ),
+        Skill(
+            name="walk_backward",
+            command=(-0.4, 0.0, 0.0),
+            duration_steps=POLICY_HZ,
+            description="Walk backward (slower, since reverse gait is weaker).",
+        ),
+        Skill(
+            name="strafe_left",
+            command=(0.0, 0.4, 0.0),
+            duration_steps=POLICY_HZ,
+            description="Side-step to the left.",
+        ),
+        Skill(
+            name="strafe_right",
+            command=(0.0, -0.4, 0.0),
+            duration_steps=POLICY_HZ,
+            description="Side-step to the right.",
+        ),
+        Skill(
+            name="turn_left",
+            command=(0.0, 0.0, 0.8),
+            duration_steps=POLICY_HZ,
+            description="Rotate counter-clockwise in place.",
+        ),
+        Skill(
+            name="turn_right",
+            command=(0.0, 0.0, -0.8),
+            duration_steps=POLICY_HZ,
+            description="Rotate clockwise in place.",
+        ),
+        Skill(
+            name="walk_forward_fast",
+            command=(1.0, 0.0, 0.0),
+            duration_steps=POLICY_HZ * 2,
+            description="Walk forward briskly for 2 seconds (covers more ground).",
+        ),
+        Skill(
+            name="stop",
+            command=(0.0, 0.0, 0.0),
+            duration_steps=POLICY_HZ // 2,
+            description="Stand still briefly; useful for stabilizing or observing.",
+        ),
+    ]
+}
+
+
+# Action-space type hint for the policy callable.
+PolicyFn = Callable[[np.ndarray], np.ndarray]
+"""obs -> 12-D joint-target action (float32). The walk PPO trainee's signature."""
+
+
+class SkillExecutor:
+    """Runs a chosen skill against rapier-gym's SpotEnvRapier.
+
+    Holds the gym env and the low-level PPO policy. Doesn't own the
+    high-level loop — that lives in SpotForagingEnv.collect_trajectories.
+
+    Why not just step the SpotSim directly? Because the env wraps useful
+    plumbing: command-frame observation construction, foot-contact tracking,
+    fall detection, battery state, energy bookkeeping. The skill executor
+    overrides `command` per skill and lets the existing env produce
+    observations that match what the policy was trained on.
+    """
+
+    def __init__(self, gym_env, policy: PolicyFn):
+        self.gym_env = gym_env
+        self.policy = policy
+
+    def execute(self, skill: Skill) -> "SkillResult":
+        """Run one skill burst. Returns telemetry from the burst."""
+        gym = self.gym_env
+        # Pin the command vector to this skill's value for the burst.
+        # SpotEnvRapier's _sample_command runs only on reset(), so writing
+        # to .command directly is the override path.
+        gym.command = np.array(skill.command, dtype=np.float32)
+
+        steps_taken = 0
+        total_reward = 0.0
+        terminated = False
+        truncated = False
+        observation = None  # last observation
+        info: Dict = {}
+
+        # Capture pre-skill state for delta accounting.
+        pre_xy = np.array(gym.sim.get_base_position(), dtype=np.float32)[[0, 2]]
+        pre_targets = list(gym.sim.get_battery_positions() or [])
+        pre_collected = int(gym.collected_targets)
+
+        for _ in range(skill.duration_steps):
+            obs = gym._compute_observation() if hasattr(gym, "_compute_observation") else gym.sim.get_observation()
+            obs_np = np.array(obs, dtype=np.float32)
+
+            action = self.policy(obs_np)
+            assert action.shape == (12,), f"policy must return 12-D action, got {action.shape}"
+
+            observation, step_reward, terminated, truncated, info = gym.step(action)
+            steps_taken += 1
+            total_reward += float(step_reward)
+
+            if terminated or truncated:
+                break
+
+        post_xy = np.array(gym.sim.get_base_position(), dtype=np.float32)[[0, 2]]
+        post_targets = list(gym.sim.get_battery_positions() or [])
+        post_collected = int(gym.collected_targets)
+
+        return SkillResult(
+            skill=skill,
+            steps_taken=steps_taken,
+            total_low_level_reward=total_reward,
+            terminated=terminated,
+            truncated=truncated,
+            collected_during_burst=post_collected - pre_collected,
+            displacement=tuple(map(float, (post_xy - pre_xy))),
+            pre_xy=tuple(map(float, pre_xy)),
+            post_xy=tuple(map(float, post_xy)),
+            pre_battery_count=len(pre_targets),
+            post_battery_count=len(post_targets),
+            info=info,
+            last_observation=observation,
+        )
+
+
+@dataclass
+class SkillResult:
+    skill: Skill
+    steps_taken: int
+    total_low_level_reward: float
+    terminated: bool
+    truncated: bool
+    collected_during_burst: int
+    displacement: Tuple[float, float]
+    pre_xy: Tuple[float, float]
+    post_xy: Tuple[float, float]
+    pre_battery_count: int
+    post_battery_count: int
+    info: Dict
+    last_observation: Optional[np.ndarray]
+
+    @property
+    def fell(self) -> bool:
+        """True if the burst ended in a fall (vs natural completion)."""
+        return self.terminated and not self.truncated
+
+
+def list_skill_names() -> List[str]:
+    """Sorted list of skill names — used to render the LLM's tool spec."""
+    return sorted(SKILL_REGISTRY.keys())
+
+
+def get_skill(name: str) -> Optional[Skill]:
+    """Lookup by name; returns None if unknown (LLM hallucinated a skill)."""
+    return SKILL_REGISTRY.get(name)

--- a/optional-skills/mlops/spot-hierarchical-rl/SKILL.md
+++ b/optional-skills/mlops/spot-hierarchical-rl/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: spot-hierarchical-rl
+description: Reusable adapter pattern for integrating Spot robotics tasks (like foraging) with Atropos GRPO hierarchical RL training.
+category: mlops/training
+---
+
+# Spot Hierarchical RL (Atropos Adapter)
+
+This skill documents the adapter pattern used to bridge rapier-gym physics environments (like the Spot foraging task) into the Atropos GRPO hierarchical RL trainer. This pattern transforms an LLM into a high-level skill planner, outputting stochastic skill selections while low-level control policies (PPO) handle movement physics.
+
+## Architecture & Integration Flow
+
+1. **Scenario Generation (`get_next_item`)**: 
+   Samples a `ScenarioItem`, which defines the environmental setup (e.g., random spawn location and battery layout).
+2. **Rollout Collection (`collect_trajectories`)**: 
+   Runs `group_size` rollouts on the same scenario in parallel. This produces a clean GRPO-style contrastive group where the only differential between rollouts is the LLM's stochastic skill picks.
+3. **Execution Context**: 
+   Each rollout executes within a single `ManagedServer` context, enabling multi-turn token accumulation with proper masking.
+4. **Environment Loop**:
+   - **Chat Setup**: Initializes with the system prompt and the initial user message (state JSON + top-down rendered PNG).
+   - **Decision Iteration** (up to `max_skill_picks` times):
+     - `chat_completion(tools=[select_skill], tool_choice="auto")` -> The LLM acts as the planner, selecting a skill.
+     - `SkillExecutor.execute(skill)` -> Steps the rapier-gym physics engine (e.g., 50 ticks) utilizing the low-level policy (like the walk PPO policy) combined with the skill's command vector.
+     - Message Appending: Assistant message (skill pick), tool-result message (execution outcome), next user message (new state).
+     - Break conditions: e.g., fall or success (all items collected).
+5. **Reward & Scoring**:
+   The entire sequence of LLM skill picks is evaluated using a composite reward function.
+   Example: `+10 * collected + 20 * success - 0.05 * picks - 5 * fell + 0.5 * distance_decrement`
+6. **Data Assembly**:
+   Concatenates per-turn `node.tokens` and `node.masked_tokens` from the `ManagedServer` into one contiguous sequence. The result is pushed as a `ScoredDataGroup`.
+
+## Skills Definition Pattern
+
+High-level movement primitives share a single underlying low-level policy (e.g., a walk PPO). They differ only in target command vectors (vx, vy, ω) and execution burst duration. 
+Adding a new skill is minimal (a simple 4-line `Skill(...)` append).
+
+## Validation Pipeline (No Policies Required)
+
+You can validate the LLM-loop -> tool-parse -> skill-execute -> reward pipeline end-to-end without a fully trained policy using `--process` mode.
+
+```bash
+cd /home/olive/Repositories/hermes-agent
+
+# Run scenarios in process mode against any multimodal endpoint
+python -m environments.spot_foraging_env.env process \
+  --config environments/spot_foraging_env/configs/default.yaml \
+  --env.data_path_to_save_groups /tmp/spot_foraging.jsonl \
+  --env.total_steps 4 \
+  --openai.base_url "https://openrouter.ai/api/v1" \
+  --openai.api_key "$OPENROUTER_API_KEY" \
+  --openai.model_name "anthropic/claude-sonnet-4.5" \
+  --openai.server_type openai \
+  --openai.health_check false
+```
+
+*Output:* Validates the loop and writes JSONL (e.g., `/tmp/spot_foraging.jsonl`) with `ScoredDataGroups` and static HTML visualizer output.
+
+## Known Gaps & Future Work
+
+- **Walk Policy Integration**: Drop a trained ONNX PPO model into `~/.cache/spot_rapier/walk_policy.onnx`. Without it, `load_walk_policy` defaults to zero-actions (episodes complete, but Spot stays stationary).
+- **In-sim State Enforcement**: rapier-gym's PyO3 layer needs to expose methods (e.g., `set_battery_positions` or `get_body_quaternion`) to enforce scenario determinism in the physics engine.
+- **Packaging**: Transition `rapier-gym` from `sys.path` injection to a standalone installed wheel for reliability.

--- a/tests/test_cli_resize_ghosting.py
+++ b/tests/test_cli_resize_ghosting.py
@@ -1,0 +1,29 @@
+from pathlib import Path
+
+
+def test_resize_handler_clears_screen_before_prompt_toolkit_redraw():
+    """The custom resize handler must blank the terminal before PTK redraws.
+
+    When the terminal shrinks, the emulator reflows previously full-width lines
+    into multiple rows. If cli.py calls _original_on_resize() before
+    erase_screen(), prompt_toolkit can redraw on top of those ghost rows and
+    leave duplicated wrapped content behind.
+    """
+
+    source = Path("cli.py").read_text(encoding="utf-8")
+
+    marker = "def _resize_clear_ghosts():"
+    start = source.index(marker)
+    end = source.index("app._on_resize = _resize_clear_ghosts", start)
+    block = source[start:end]
+
+    erase_idx = block.index("app.output.erase_screen()")
+    cursor_idx = block.index("app.output.cursor_goto(0, 0)")
+    flush_idx = block.index("app.output.flush()")
+    original_idx = block.rindex("_original_on_resize()")
+    invalidate_idx = block.index("app.invalidate()")
+
+    assert erase_idx < original_idx, "resize handler must clear screen before PTK redraw"
+    assert cursor_idx < original_idx, "cursor reset must happen before PTK redraw"
+    assert flush_idx < original_idx, "screen clear must be flushed before PTK redraw"
+    assert original_idx < invalidate_idx, "redraw invalidation should happen after PTK resize accounting"


### PR DESCRIPTION
When the terminal shrinks, the emulator wraps previously rendered lines (like the status bar) causing them to span multiple rows. prompt_toolkit's default _on_resize erase uses cursor_up based on its internal height accounting, which misses these new reflowed rows, leading to ghost duplicated output on the screen.

We must explicitly wipe the screen clear (app.output.erase_screen()) *before* the invalidate so we don't just redraw on top of the ghost lines.