### PR TITLE
feat: add Arcane Hermes event gateway

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -32,6 +32,7 @@ from typing import Any, Dict, List, Optional
 from urllib.parse import urlparse, parse_qs, urlunparse
 
 from agent.context_compressor import ContextCompressor
+from agent.events import NullAgentEventSink
 from agent.iteration_budget import IterationBudget
 from agent.memory_manager import StreamingContextScrubber
 from agent.model_metadata import (
@@ -168,6 +169,7 @@ def init_agent(
     tool_progress_callback: callable = None,
     tool_start_callback: callable = None,
     tool_complete_callback: callable = None,
+    event_sink=None,
     thinking_callback: callable = None,
     reasoning_callback: callable = None,
     clarify_callback: callable = None,
@@ -231,6 +233,7 @@ def init_agent(
             None or empty = let OpenRouter pick the strongest available coder.
         session_id (str): Pre-generated session ID for logging (optional, auto-generated if not provided)
         tool_progress_callback (callable): Callback function(tool_name, args_preview) for progress notifications
+        event_sink: Optional AgentEventSink for structured run/tool events. Defaults to a no-op sink.
         clarify_callback (callable): Callback function(question, choices) -> str for interactive user questions.
             Provided by the platform layer (CLI or gateway). If None, the clarify tool returns an error.
         max_tokens (int): Maximum tokens for model responses (optional, uses model default if not set)
@@ -392,6 +395,7 @@ def init_agent(
     agent.tool_progress_callback = tool_progress_callback
     agent.tool_start_callback = tool_start_callback
     agent.tool_complete_callback = tool_complete_callback
+    agent.event_sink = event_sink if event_sink is not None else NullAgentEventSink()
     agent.suppress_status_output = False
     agent.thinking_callback = thinking_callback
     agent.reasoning_callback = reasoning_callback

--- a/agent/events.py
+++ b/agent/events.py
@@ -1,0 +1,319 @@
+"""Structured event sink helpers for agent frontends.
+
+The default sink is intentionally a no-op. Frontends that need live run
+events can provide an ``AgentEventSink`` implementation without changing
+normal transcript or callback behavior.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from datetime import datetime, timezone
+from typing import Any, Mapping
+
+logger = logging.getLogger(__name__)
+
+MAX_PREVIEW_CHARS = 1000
+MAX_STRING_CHARS = 2000
+MAX_COLLECTION_ITEMS = 50
+MAX_EVENT_JSON_CHARS = 6000
+
+_SECRET_KEY_RE = re.compile(
+    r"(api[_-]?key|access[_-]?token|refresh[_-]?token|auth(?:orization)?|"
+    r"bearer|cookie|password|passwd|secret|private[_-]?key|token)",
+    re.IGNORECASE,
+)
+_SECRET_ASSIGNMENT_RE = re.compile(
+    r"(?i)\b(api[_-]?key|access[_-]?token|refresh[_-]?token|token|password|"
+    r"passwd|secret|authorization)\b\s*[:=]\s*([^\s,;]+)"
+)
+_BEARER_RE = re.compile(r"(?i)\bBearer\s+[A-Za-z0-9._~+/=-]+")
+_OPENAI_STYLE_TOKEN_RE = re.compile(r"\bsk-[A-Za-z0-9_-]{12,}\b")
+
+
+class AgentEventSink:
+    """Base class for consumers of structured agent events."""
+
+    def emit(self, event: dict[str, Any]) -> None:
+        """Receive one structured event."""
+        return None
+
+
+class NullAgentEventSink(AgentEventSink):
+    """Default event sink used when no frontend is listening."""
+
+    def emit(self, event: dict[str, Any]) -> None:
+        return None
+
+
+def emit_run_status(agent: Any, status: str = "thinking", message: str = "Agent is thinking.") -> None:
+    emit_agent_event(
+        agent,
+        {
+            "type": "run.status",
+            "status": status,
+            "message": message,
+            "updatedAt": utc_now_iso(),
+        },
+    )
+
+
+def emit_run_done(agent: Any) -> None:
+    emit_agent_event(agent, {"type": "run.done", "updatedAt": utc_now_iso()})
+
+
+def emit_run_cancelled(agent: Any, message: str = "Agent run cancelled.") -> None:
+    emit_agent_event(
+        agent,
+        {
+            "type": "run.cancelled",
+            "message": message,
+            "updatedAt": utc_now_iso(),
+        },
+    )
+
+
+def emit_run_error(agent: Any, error: Any) -> None:
+    emit_agent_event(
+        agent,
+        {
+            "type": "run.error",
+            "message": safe_preview(error, limit=MAX_PREVIEW_CHARS) or "Agent run failed.",
+            "debug": safe_debug(error),
+            "updatedAt": utc_now_iso(),
+        },
+    )
+
+
+def emit_assistant_message(agent: Any, content: Any) -> None:
+    emit_agent_event(
+        agent,
+        {
+            "type": "assistant.message",
+            "content": redact_string(str(content or "")),
+            "createdAt": utc_now_iso(),
+        },
+    )
+
+
+def emit_tool_started(agent: Any, tool_call_id: str | None, name: str, args: Any) -> None:
+    emit_agent_event(
+        agent,
+        {
+            "type": "tool.call.started",
+            "toolCallId": tool_call_id or "",
+            "name": name,
+            "args": sanitize_event_value(args),
+            "category": categorize_tool(name),
+            "createdAt": utc_now_iso(),
+        },
+    )
+
+
+def emit_tool_completed(
+    agent: Any,
+    tool_call_id: str | None,
+    name: str,
+    args: Any,
+    result: Any,
+    duration_s: float | None = None,
+) -> None:
+    payload = _tool_result_payload(result)
+    emit_agent_event(
+        agent,
+        {
+            "type": "tool.call.completed",
+            "toolCallId": tool_call_id or "",
+            "name": name,
+            "ok": True,
+            "args": sanitize_event_value(args),
+            "category": categorize_tool(name),
+            "durationMs": duration_ms(duration_s),
+            "completedAt": utc_now_iso(),
+            **payload,
+        },
+    )
+
+
+def emit_tool_failed(
+    agent: Any,
+    tool_call_id: str | None,
+    name: str,
+    args: Any,
+    error: Any,
+    duration_s: float | None = None,
+) -> None:
+    payload = _tool_result_payload(error)
+    preview = payload.get("resultPreview") or safe_preview(error, limit=MAX_PREVIEW_CHARS)
+    emit_agent_event(
+        agent,
+        {
+            "type": "tool.call.failed",
+            "toolCallId": tool_call_id or "",
+            "name": name,
+            "ok": False,
+            "args": sanitize_event_value(args),
+            "category": categorize_tool(name),
+            "durationMs": duration_ms(duration_s),
+            "error": preview or "Tool call failed.",
+            "resultPreview": preview or "",
+            "resultTruncated": payload.get("resultTruncated", False),
+            "completedAt": utc_now_iso(),
+        },
+    )
+
+
+def emit_agent_event(agent: Any, event: Mapping[str, Any]) -> None:
+    sink = getattr(agent, "event_sink", None)
+    if sink is None:
+        return
+    try:
+        sink.emit(dict(event))
+    except Exception:
+        logger.debug("agent event sink failed for %s", event.get("type"), exc_info=True)
+
+
+def utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def duration_ms(duration_s: float | None) -> int:
+    if duration_s is None:
+        return 0
+    try:
+        return max(0, int(float(duration_s) * 1000))
+    except (TypeError, ValueError):
+        return 0
+
+
+def categorize_tool(name: str) -> str:
+    lowered = (name or "").lower()
+    if lowered in {"terminal", "execute_code"}:
+        return "command"
+    if lowered in {"write_file", "read_file", "patch", "search_files", "list_files"}:
+        return "file"
+    if "browser" in lowered:
+        return "browser"
+    if "web" in lowered or lowered in {"crawl", "extract"}:
+        return "web"
+    if "memory" in lowered or lowered == "session_search":
+        return "memory"
+    if "delegate" in lowered:
+        return "agent"
+    return "tool"
+
+
+def sanitize_event_value(value: Any, *, depth: int = 0) -> Any:
+    if depth > 5:
+        return "[truncated]"
+    if value is None or isinstance(value, (bool, int, float)):
+        return value
+    if isinstance(value, str):
+        return truncate_text(redact_string(value), MAX_STRING_CHARS)
+    if isinstance(value, Mapping):
+        out: dict[str, Any] = {}
+        for index, (key, item) in enumerate(value.items()):
+            if index >= MAX_COLLECTION_ITEMS:
+                out["..."] = f"{len(value) - MAX_COLLECTION_ITEMS} more"
+                break
+            key_text = str(key)
+            if _is_secret_key(key_text):
+                out[key_text] = "[redacted]"
+            else:
+                out[key_text] = sanitize_event_value(item, depth=depth + 1)
+        return out
+    if isinstance(value, (list, tuple, set)):
+        items = list(value)
+        out = [sanitize_event_value(item, depth=depth + 1) for item in items[:MAX_COLLECTION_ITEMS]]
+        if len(items) > MAX_COLLECTION_ITEMS:
+            out.append(f"[{len(items) - MAX_COLLECTION_ITEMS} more]")
+        return out
+    return truncate_text(redact_string(str(value)), MAX_STRING_CHARS)
+
+
+def safe_preview(value: Any, *, limit: int = MAX_PREVIEW_CHARS) -> str:
+    sanitized = sanitize_event_value(value)
+    if isinstance(sanitized, str):
+        text = sanitized
+    else:
+        try:
+            text = json.dumps(sanitized, ensure_ascii=False, sort_keys=True)
+        except TypeError:
+            text = str(sanitized)
+    return truncate_text(text, limit)
+
+
+def safe_debug(error: Any) -> dict[str, Any]:
+    if isinstance(error, BaseException):
+        return {
+            "type": type(error).__name__,
+            "message": safe_preview(str(error), limit=MAX_PREVIEW_CHARS),
+        }
+    return {"value": sanitize_event_value(error)}
+
+
+def redact_string(text: str) -> str:
+    redacted = _SECRET_ASSIGNMENT_RE.sub(lambda match: f"{match.group(1)}=[redacted]", text)
+    redacted = _BEARER_RE.sub("Bearer [redacted]", redacted)
+    redacted = _OPENAI_STYLE_TOKEN_RE.sub("[redacted-token]", redacted)
+    return redacted
+
+
+def truncate_text(text: str, limit: int) -> str:
+    if len(text) <= limit:
+        return text
+    return f"{text[:limit]}..."
+
+
+def _tool_result_payload(result: Any) -> dict[str, Any]:
+    preview = safe_preview(result, limit=MAX_PREVIEW_CHARS)
+    payload: dict[str, Any] = {
+        "resultPreview": preview,
+        "resultTruncated": len(preview) >= MAX_PREVIEW_CHARS and preview.endswith("..."),
+    }
+    structured = _safe_structured_result(result)
+    if structured is not None:
+        try:
+            encoded = json.dumps(structured, ensure_ascii=False, sort_keys=True)
+        except TypeError:
+            encoded = ""
+        if encoded and len(encoded) <= MAX_EVENT_JSON_CHARS:
+            payload["resultJson"] = structured
+    return payload
+
+
+def _safe_structured_result(result: Any) -> Any | None:
+    if isinstance(result, (Mapping, list, tuple)):
+        return sanitize_event_value(result)
+    if isinstance(result, str):
+        stripped = result.strip()
+        if not stripped or stripped[0] not in "[{":
+            return None
+        try:
+            return sanitize_event_value(json.loads(stripped))
+        except Exception:
+            return None
+    return None
+
+
+def _is_secret_key(key: str) -> bool:
+    return bool(_SECRET_KEY_RE.search(key))
+
+
+__all__ = [
+    "AgentEventSink",
+    "NullAgentEventSink",
+    "emit_agent_event",
+    "emit_assistant_message",
+    "emit_run_cancelled",
+    "emit_run_done",
+    "emit_run_error",
+    "emit_run_status",
+    "emit_tool_completed",
+    "emit_tool_failed",
+    "emit_tool_started",
+    "safe_preview",
+    "sanitize_event_value",
+]

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -29,6 +29,7 @@ from agent.display import (
     get_tool_emoji as _get_tool_emoji,
     _detect_tool_failure,
 )
+from agent.events import emit_tool_completed, emit_tool_failed, emit_tool_started
 from agent.tool_guardrails import ToolGuardrailDecision
 from agent.tool_dispatch_helpers import (
     _is_destructive_command,
@@ -173,6 +174,7 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
                 agent.tool_start_callback(tc.id, name, args)
             except Exception as cb_err:
                 logging.debug(f"Tool start callback error: {cb_err}")
+        emit_tool_started(agent, tc.id, name, args)
 
     # ── Concurrent execution ─────────────────────────────────────────
     # Each slot holds (function_name, function_args, function_result, duration, error_flag, blocked_flag)
@@ -356,6 +358,7 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
             else:
                 function_result = f"Error executing tool '{name}': thread did not return a result"
             tool_duration = 0.0
+            is_error = True
         else:
             function_name, function_args, function_result, tool_duration, is_error, blocked = r
 
@@ -417,6 +420,11 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
                 agent.tool_complete_callback(tc.id, name, args, function_result)
             except Exception as cb_err:
                 logging.debug(f"Tool complete callback error: {cb_err}")
+
+        if blocked or is_error:
+            emit_tool_failed(agent, tc.id, name, args, function_result, tool_duration)
+        else:
+            emit_tool_completed(agent, tc.id, name, args, function_result, tool_duration)
 
         function_result = maybe_persist_tool_result(
             content=function_result,
@@ -559,6 +567,8 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                 agent.tool_start_callback(tool_call.id, function_name, function_args)
             except Exception as cb_err:
                 logging.debug(f"Tool start callback error: {cb_err}")
+        if not _execution_blocked:
+            emit_tool_started(agent, tool_call.id, function_name, function_args)
 
         # Checkpoint: snapshot working dir before file-mutating tools
         if not _execution_blocked and function_name in {"write_file", "patch"} and agent._checkpoint_mgr.enabled:
@@ -839,6 +849,11 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                 agent.tool_complete_callback(tool_call.id, function_name, function_args, function_result)
             except Exception as cb_err:
                 logging.debug(f"Tool complete callback error: {cb_err}")
+
+        if _execution_blocked or _is_error_result:
+            emit_tool_failed(agent, tool_call.id, function_name, function_args, function_result, tool_duration)
+        else:
+            emit_tool_completed(agent, tool_call.id, function_name, function_args, function_result, tool_duration)
 
         function_result = maybe_persist_tool_result(
             content=function_result,

--- a/run_agent.py
+++ b/run_agent.py
@@ -378,6 +378,7 @@ class AIAgent:
         tool_progress_callback: callable = None,
         tool_start_callback: callable = None,
         tool_complete_callback: callable = None,
+        event_sink=None,
         thinking_callback: callable = None,
         reasoning_callback: callable = None,
         clarify_callback: callable = None,
@@ -447,6 +448,7 @@ class AIAgent:
             tool_progress_callback=tool_progress_callback,
             tool_start_callback=tool_start_callback,
             tool_complete_callback=tool_complete_callback,
+            event_sink=event_sink,
             thinking_callback=thinking_callback,
             reasoning_callback=reasoning_callback,
             clarify_callback=clarify_callback,
@@ -3905,7 +3907,42 @@ class AIAgent:
     ) -> Dict[str, Any]:
         """Forwarder — see ``agent.conversation_loop.run_conversation``."""
         from agent.conversation_loop import run_conversation
-        return run_conversation(self, user_message, system_message, conversation_history, task_id, stream_callback, persist_user_message)
+        from agent.events import (
+            emit_assistant_message,
+            emit_run_cancelled,
+            emit_run_done,
+            emit_run_error,
+            emit_run_status,
+        )
+
+        emit_run_status(self, "thinking", "Agent is thinking.")
+        try:
+            result = run_conversation(
+                self,
+                user_message,
+                system_message,
+                conversation_history,
+                task_id,
+                stream_callback,
+                persist_user_message,
+            )
+        except Exception as exc:
+            emit_run_error(self, exc)
+            raise
+
+        if result.get("interrupted"):
+            emit_run_cancelled(self, str(result.get("interrupt_message") or "Agent run cancelled."))
+            return result
+
+        final_response = result.get("final_response")
+        if result.get("failed") or (result.get("error") and not final_response):
+            emit_run_error(self, result.get("error") or "Agent run failed.")
+            return result
+
+        if final_response is not None:
+            emit_assistant_message(self, final_response)
+        emit_run_done(self)
+        return result
 
     def chat(self, message: str, stream_callback: Optional[callable] = None) -> str:
         """

--- a/scripts/hermes_arcane_adapter.py
+++ b/scripts/hermes_arcane_adapter.py
@@ -1,0 +1,545 @@
+#!/usr/bin/env python3
+"""Hermes-to-Arcane JSONL adapter.
+
+Normal mode reads one JSON request from stdin and writes one Arcane run event
+per stdout line. Use ``--self-test`` to verify imports and JSONL output
+without starting a model run.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import threading
+from pathlib import Path
+from typing import Any, Optional
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from agent.events import AgentEventSink, safe_debug, safe_preview, utc_now_iso
+
+
+class StdoutArcaneEventSink(AgentEventSink):
+    def __init__(self, session_id: str, run_id: str):
+        self.session_id = session_id
+        self.run_id = run_id
+        self._lock = threading.Lock()
+
+    def emit(self, event: dict[str, Any]) -> None:
+        payload = dict(event)
+        payload.setdefault("sessionId", self.session_id)
+        payload.setdefault("runId", self.run_id)
+        self._normalize_timestamp(payload)
+        line = json.dumps(payload, ensure_ascii=False, separators=(",", ":"))
+        with self._lock:
+            sys.stdout.write(line + "\n")
+            sys.stdout.flush()
+
+    @staticmethod
+    def _normalize_timestamp(payload: dict[str, Any]) -> None:
+        now = utc_now_iso()
+        event_type = payload.get("type")
+        if event_type == "tool.call.started":
+            payload.setdefault("createdAt", now)
+        elif event_type in {"tool.call.completed", "tool.call.failed"}:
+            payload.setdefault("completedAt", now)
+        elif event_type in {"assistant.delta", "assistant.message"}:
+            payload.setdefault("createdAt", now)
+        else:
+            payload.setdefault("updatedAt", now)
+
+
+class ArcaneStreamEmitter:
+    """Emit Arcane assistant.delta events for visible assistant text."""
+
+    def __init__(self, sink: StdoutArcaneEventSink, run_id: str):
+        self.sink = sink
+        self.message_id = f"assistant-{run_id}"
+        self.index = 0
+
+    def emit(self, delta: Any) -> None:
+        if not isinstance(delta, str) or not delta:
+            return
+        self.sink.emit(
+            {
+                "type": "assistant.delta",
+                "messageId": self.message_id,
+                "delta": delta,
+                "index": self.index,
+                "createdAt": utc_now_iso(),
+            }
+        )
+        self.index += 1
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description="Run Hermes for an Arcane event-stream request.")
+    parser.add_argument("--self-test", action="store_true", help="emit a small JSONL event stream without a model call")
+    args = parser.parse_args(argv)
+
+    if args.self_test:
+        return self_test()
+
+    sink: StdoutArcaneEventSink | None = None
+    try:
+        request = read_request()
+        session_id = require_text(request, "sessionId")
+        run_id = require_text(request, "runId")
+        content = require_text(request, "content")
+        sink = StdoutArcaneEventSink(session_id, run_id)
+        configure_arcane_environment(request, session_id, run_id)
+
+        if handle_arcane_slash_command(content, request, sink):
+            return 0
+
+        agent = build_agent(request, sink)
+        result = agent.run_conversation(
+            content,
+            conversation_history=arcane_conversation_history(request.get("messages"), content),
+            task_id=run_id,
+        )
+        if result.get("failed") or (result.get("error") and not result.get("final_response")):
+            return 1
+        return 0
+    except Exception as exc:
+        message = safe_preview(exc) or "Hermes Arcane adapter failed."
+        print(f"hermes_arcane_adapter: {message}", file=sys.stderr)
+        if sink is not None:
+            sink.emit(
+                {
+                    "type": "run.error",
+                    "message": "Hermes Arcane adapter failed.",
+                    "debug": safe_debug(exc),
+                    "updatedAt": utc_now_iso(),
+                }
+            )
+        return 1
+
+
+def self_test() -> int:
+    from run_agent import AIAgent  # noqa: F401 - verifies runtime import path
+
+    sink = StdoutArcaneEventSink("self-test-session", "self-test-run")
+    sink.emit({"type": "run.status", "status": "thinking", "message": "adapter self-test"})
+    sink.emit({"type": "run.done"})
+    return 0
+
+
+def read_request() -> dict[str, Any]:
+    raw = sys.stdin.read()
+    if not raw.strip():
+        raise ValueError("stdin JSON request is required")
+    request = json.loads(raw)
+    if not isinstance(request, dict):
+        raise ValueError("stdin JSON request must be an object")
+    return request
+
+
+def require_text(request: dict[str, Any], key: str) -> str:
+    value = request.get(key)
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"request.{key} is required")
+    return value.strip()
+
+
+def configure_arcane_environment(request: dict[str, Any], session_id: str, run_id: str) -> None:
+    """Normalize Arcane env vars for Arcane tool handlers in this process."""
+    arcane_cfg = request.get("arcane") if isinstance(request.get("arcane"), dict) else {}
+    base_url = (
+        _optional_text(request.get("arcaneBaseUrl"))
+        or _optional_text(request.get("baseUrl"))
+        or _optional_text(arcane_cfg.get("baseUrl"))
+        or os.getenv("ARCANE_BASE_URL", "").strip()
+        or "http://127.0.0.1:8787"
+    )
+    access_token = (
+        _optional_text(request.get("arcaneAccessToken"))
+        or _optional_text(request.get("accessToken"))
+        or _optional_text(arcane_cfg.get("accessToken"))
+        or os.getenv("ARCANE_ACCESS_TOKEN", "")
+    )
+
+    os.environ["ARCANE_SESSION_ID"] = session_id
+    os.environ["ARCANE_RUN_ID"] = run_id
+    os.environ["ARCANE_BASE_URL"] = base_url.rstrip("/")
+    os.environ["ARCANE_ACCESS_TOKEN"] = access_token
+
+
+def _optional_text(value: Any) -> str:
+    return value.strip() if isinstance(value, str) and value.strip() else ""
+
+
+def handle_arcane_slash_command(
+    content: str,
+    request: dict[str, Any],
+    sink: StdoutArcaneEventSink,
+) -> bool:
+    parsed = parse_slash_command(content)
+    if parsed is None:
+        return False
+
+    name, args = parsed
+    from hermes_cli.commands import resolve_command
+
+    cmd = resolve_command(name)
+    if cmd is None:
+        emit_slash_response(
+            sink,
+            f"Unknown Hermes command `/{name}`. Type `/commands` to see commands available in Arcane.",
+        )
+        return True
+
+    if cmd.name == "help":
+        emit_slash_response(sink, arcane_help_text())
+        return True
+    if cmd.name == "commands":
+        emit_slash_response(sink, arcane_commands_text(args))
+        return True
+    if cmd.name == "profile":
+        emit_slash_response(sink, arcane_profile_text())
+        return True
+    if cmd.name == "status":
+        emit_slash_response(sink, arcane_status_text(request))
+        return True
+    if cmd.name == "model":
+        emit_slash_response(sink, arcane_model_text(args))
+        return True
+    if cmd.name == "reasoning":
+        emit_slash_response(sink, arcane_reasoning_text(args))
+        return True
+    if cmd.name in {"usage", "skills", "tools"}:
+        emit_slash_response(sink, arcane_unsupported_command_text(cmd.name, cli_only=cmd.cli_only))
+        return True
+
+    emit_slash_response(sink, arcane_unsupported_command_text(cmd.name, cli_only=cmd.cli_only))
+    return True
+
+
+def parse_slash_command(content: str) -> tuple[str, str] | None:
+    stripped = content.strip()
+    if not stripped.startswith("/") or stripped == "/":
+        return None
+    token, _, args = stripped[1:].partition(" ")
+    name = token.strip()
+    if not name or "/" in name:
+        return None
+    return name, args.strip()
+
+
+def emit_slash_response(sink: StdoutArcaneEventSink, content: str) -> None:
+    sink.emit({"type": "assistant.message", "content": content, "createdAt": utc_now_iso()})
+    sink.emit({"type": "run.done", "updatedAt": utc_now_iso()})
+
+
+def arcane_help_text() -> str:
+    from hermes_cli.commands import gateway_help_lines
+
+    lines = [
+        "Hermes commands available in Arcane:",
+        *gateway_help_lines()[:18],
+        "",
+        "Use `/commands` for the full paginated list.",
+    ]
+    return "\n".join(lines)
+
+
+def arcane_commands_text(args: str) -> str:
+    from hermes_cli.commands import gateway_help_lines
+
+    if args:
+        try:
+            requested_page = int(args.split()[0])
+        except ValueError:
+            return "Usage: `/commands [page]`"
+    else:
+        requested_page = 1
+
+    entries = gateway_help_lines()
+    if not entries:
+        return "No Hermes commands are currently available in Arcane."
+
+    page_size = 20
+    total_pages = max(1, (len(entries) + page_size - 1) // page_size)
+    page = max(1, min(requested_page, total_pages))
+    start = (page - 1) * page_size
+    page_entries = entries[start:start + page_size]
+    lines = [
+        f"Hermes commands ({len(entries)} total, page {page}/{total_pages}):",
+        "",
+        *page_entries,
+    ]
+    if total_pages > 1:
+        nav = []
+        if page > 1:
+            nav.append(f"`/commands {page - 1}`")
+        if page < total_pages:
+            nav.append(f"`/commands {page + 1}`")
+        if nav:
+            lines.extend(["", "More: " + " | ".join(nav)])
+    if page != requested_page:
+        lines.append(f"Requested page {requested_page} is out of range; showing page {page}.")
+    return "\n".join(lines)
+
+
+def arcane_profile_text() -> str:
+    from hermes_cli.profiles import get_active_profile_name
+    from hermes_constants import display_hermes_home
+
+    return "\n".join(
+        [
+            f"Active Hermes profile: `{get_active_profile_name()}`",
+            f"Hermes home: `{display_hermes_home()}`",
+        ]
+    )
+
+
+def arcane_status_text(request: dict[str, Any]) -> str:
+    from hermes_cli.config import load_config
+
+    cfg = load_config()
+    model, provider, _base_url = resolve_configured_model(cfg)
+    toolsets = resolve_arcane_toolsets(cfg)
+    session_id = _optional_text(request.get("sessionId")) or os.getenv("ARCANE_SESSION_ID", "")
+    run_id = _optional_text(request.get("runId")) or os.getenv("ARCANE_RUN_ID", "")
+    token_status = "configured" if os.getenv("ARCANE_ACCESS_TOKEN") else "not configured"
+    return "\n".join(
+        [
+            "Arcane Hermes status:",
+            f"- Arcane session: `{session_id}`",
+            f"- Arcane run: `{run_id}`",
+            f"- Hermes session: `{stable_hermes_session_id(session_id)}`",
+            f"- Model: `{model or '(auto)'}`",
+            f"- Provider: `{provider or '(auto)'}`",
+            f"- Arcane API: `{os.getenv('ARCANE_BASE_URL', 'http://127.0.0.1:8787')}`",
+            f"- Arcane token: {token_status}",
+            f"- Enabled toolsets: {', '.join(f'`{name}`' for name in toolsets) if toolsets else '(default)'}",
+        ]
+    )
+
+
+def arcane_model_text(args: str) -> str:
+    from hermes_cli.config import load_config
+
+    if args:
+        return (
+            "`/model` changes are not supported from Arcane yet. "
+            "Set `HERMES_INFERENCE_MODEL` or update Hermes config, then start a new Arcane run."
+        )
+    model, provider, base_url = resolve_configured_model(load_config())
+    lines = [
+        f"Current model: `{model or '(auto)'}`",
+        f"Provider: `{provider or '(auto)'}`",
+    ]
+    if base_url:
+        lines.append(f"Base URL: `{base_url}`")
+    return "\n".join(lines)
+
+
+def arcane_reasoning_text(args: str) -> str:
+    from hermes_cli.config import cfg_get, load_config
+
+    if args:
+        return (
+            "`/reasoning` changes are not supported from Arcane yet. "
+            "Set `agent.reasoning_effort` in Hermes config before starting the run."
+        )
+    cfg = load_config()
+    effort = cfg_get(cfg, "agent", "reasoning_effort", default="medium") or "medium"
+    show_reasoning = bool(cfg_get(cfg, "display", "show_reasoning", default=False))
+    return "\n".join(
+        [
+            f"Reasoning effort: `{effort}`",
+            f"Reasoning display: `{'on' if show_reasoning else 'off'}`",
+        ]
+    )
+
+
+def arcane_unsupported_command_text(command: str, *, cli_only: bool = False) -> str:
+    scope = "the interactive Hermes CLI" if cli_only else "the long-lived Hermes gateway runtime"
+    return (
+        f"`/{command}` is registered in Hermes but is not supported on the Arcane adapter. "
+        f"It depends on {scope}, so the command was not sent to the model."
+    )
+
+
+def resolve_configured_model(cfg: dict[str, Any]) -> tuple[str, str | None, str | None]:
+    from hermes_cli.models import detect_provider_for_model
+
+    model_cfg = cfg.get("model") or {}
+    if isinstance(model_cfg, str):
+        cfg_model = model_cfg
+        cfg_provider = ""
+    else:
+        cfg_model = model_cfg.get("default") or model_cfg.get("model") or ""
+        cfg_provider = str(model_cfg.get("provider") or "").strip().lower()
+
+    env_model = os.getenv("HERMES_INFERENCE_MODEL", "").strip()
+    effective_model = env_model or cfg_model
+    effective_provider = os.getenv("HERMES_INFERENCE_PROVIDER", "").strip().lower() or cfg_provider or None
+    explicit_base_url_from_alias = None
+
+    if effective_provider is None and env_model:
+        try:
+            from hermes_cli import model_switch as _ms
+
+            _ms._ensure_direct_aliases()
+            direct = _ms.DIRECT_ALIASES.get(env_model.strip().lower())
+        except Exception:
+            direct = None
+        if direct is not None:
+            effective_model = direct.model
+            effective_provider = direct.provider
+            explicit_base_url_from_alias = direct.base_url.rstrip("/") if direct.base_url else None
+        else:
+            detected = detect_provider_for_model(env_model, cfg_provider or "auto")
+            if detected:
+                effective_provider, effective_model = detected
+
+    return effective_model, effective_provider, explicit_base_url_from_alias
+
+
+def resolve_arcane_toolsets(cfg: dict[str, Any]) -> list[str]:
+    from hermes_cli.tools_config import _get_platform_tools
+
+    arcane_toolsets = set(_get_platform_tools(cfg, "arcane"))
+    cli_toolsets = set(_get_platform_tools(cfg, "cli"))
+    if not arcane_toolsets:
+        arcane_toolsets = set(cli_toolsets)
+    # Arcane runs should always expose the workspace tools in addition to
+    # the normal useful Hermes tool surface.
+    arcane_toolsets.add("arcane")
+    if arcane_toolsets == {"arcane"} and cli_toolsets:
+        arcane_toolsets.update(cli_toolsets)
+    return sorted(arcane_toolsets)
+
+
+def build_agent(request: dict[str, Any], sink: StdoutArcaneEventSink):
+    from hermes_cli.config import load_config
+    from hermes_cli.oneshot import _create_session_db_for_oneshot
+    from hermes_cli.runtime_provider import resolve_runtime_provider
+    from run_agent import AIAgent
+
+    cfg = load_config()
+    effective_model, effective_provider, explicit_base_url_from_alias = resolve_configured_model(cfg)
+
+    runtime = resolve_runtime_provider(
+        requested=effective_provider,
+        target_model=effective_model or None,
+        explicit_base_url=explicit_base_url_from_alias,
+    )
+
+    toolsets = _usable_toolsets(resolve_arcane_toolsets(cfg))
+
+    fallback = cfg.get("fallback_providers") or cfg.get("fallback_model") or []
+    if isinstance(fallback, dict):
+        fallback = [fallback] if fallback.get("provider") and fallback.get("model") else []
+
+    session_id = require_text(request, "sessionId")
+    run_id = require_text(request, "runId")
+    hermes_session_id = stable_hermes_session_id(session_id)
+    files = request.get("files") if isinstance(request.get("files"), list) else []
+    file_list = ", ".join(str(item) for item in files[:100]) or "(none)"
+    system_hint = (
+        f"You are responding inside Arcane session {session_id}. "
+        "Arcane is a local chat and canvas workspace. If Arcane tools are available, "
+        "use them to inspect or update the session artifact before replying. "
+        "When writing artifact HTML, link CSS/JS with relative paths like styles.css "
+        "and script.js. Keep the final reply concise. "
+        f"Relevant artifact files: {file_list}."
+    )
+
+    stream_emitter = ArcaneStreamEmitter(sink, run_id)
+
+    agent = AIAgent(
+        api_key=runtime.get("api_key"),
+        base_url=runtime.get("base_url"),
+        provider=runtime.get("provider"),
+        api_mode=runtime.get("api_mode"),
+        model=effective_model,
+        enabled_toolsets=toolsets,
+        quiet_mode=True,
+        platform="arcane",
+        session_id=hermes_session_id,
+        gateway_session_key=f"arcane:{session_id}",
+        chat_id=session_id,
+        chat_name="Arcane",
+        chat_type="arcane",
+        user_id=os.getenv("ARCANE_USER_ID", "arcane-local"),
+        session_db=_create_session_db_for_oneshot(),
+        credential_pool=runtime.get("credential_pool"),
+        fallback_model=fallback or None,
+        ephemeral_system_prompt=system_hint,
+        event_sink=sink,
+        clarify_callback=arcane_clarify_callback,
+        stream_delta_callback=stream_emitter.emit,
+        status_callback=lambda _kind, message: sink.emit(
+            {
+                "type": "run.status",
+                "status": "thinking",
+                "message": str(message),
+                "updatedAt": utc_now_iso(),
+            }
+        ),
+    )
+    agent.suppress_status_output = True
+    agent.tool_gen_callback = None
+    return agent
+
+
+def arcane_conversation_history(messages: Any, latest_content: str) -> list[dict[str, str]]:
+    if not isinstance(messages, list):
+        return []
+
+    history: list[dict[str, str]] = []
+    for message in messages:
+        if not isinstance(message, dict):
+            continue
+        role = message.get("role")
+        content = message.get("content")
+        if role not in {"user", "assistant"} or not isinstance(content, str) or not content:
+            continue
+        history.append({"role": role, "content": content})
+
+    if history and history[-1]["role"] == "user" and history[-1]["content"].strip() == latest_content.strip():
+        history.pop()
+    return history[-20:]
+
+
+def stable_hermes_session_id(arcane_session_id: str) -> str:
+    cleaned = re.sub(r"[^A-Za-z0-9_.:-]+", "-", arcane_session_id).strip("-")
+    return f"arcane-{cleaned[:100] or 'session'}"
+
+
+def _usable_toolsets(configured_toolsets: list[str]) -> list[str] | None:
+    """Return configured toolsets only if they resolve to at least one schema.
+
+    Arcane can be configured before the Arcane-specific toolset exists. Passing
+    only unknown/empty toolsets disables every normal Hermes tool, which makes
+    the adapter look alive while quietly amputated. Fallback to default tools in
+    that case.
+    """
+    if not configured_toolsets:
+        return None
+    try:
+        from model_tools import get_tool_definitions
+
+        if get_tool_definitions(enabled_toolsets=configured_toolsets, quiet_mode=True):
+            return configured_toolsets
+    except Exception:
+        return configured_toolsets
+    return None
+
+
+def arcane_clarify_callback(question: str, choices=None) -> str:
+    if choices:
+        return f"[Arcane adapter: no interactive clarification is available. Choose the best option from {choices} and continue.]"
+    return "[Arcane adapter: no interactive clarification is available. Make a reasonable assumption and continue.]"
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -29,6 +29,14 @@ from agent.prompt_builder import DEFAULT_AGENT_IDENTITY
 # ---------------------------------------------------------------------------
 
 
+class CaptureEventSink:
+    def __init__(self):
+        self.events = []
+
+    def emit(self, event):
+        self.events.append(event)
+
+
 def _make_tool_defs(*names: str) -> list:
     """Build minimal tool definition list accepted by AIAgent.__init__."""
     return [
@@ -151,6 +159,51 @@ def test_aiagent_reuses_existing_errors_log_handler():
             root_logger.addHandler(handler)
 
 
+def test_aiagent_event_sink_defaults_to_noop():
+    from agent.events import NullAgentEventSink
+
+    with (
+        patch(
+            "run_agent.get_tool_definitions",
+            return_value=_make_tool_defs("web_search"),
+        ),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        agent = AIAgent(
+            api_key="test-k...7890",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+
+    assert isinstance(agent.event_sink, NullAgentEventSink)
+
+
+def test_aiagent_accepts_custom_event_sink():
+    sink = CaptureEventSink()
+
+    with (
+        patch(
+            "run_agent.get_tool_definitions",
+            return_value=_make_tool_defs("web_search"),
+        ),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        agent = AIAgent(
+            api_key="test-k...7890",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+            event_sink=sink,
+        )
+
+    assert agent.event_sink is sink
+
+
 class TestProviderModelNormalization:
     def test_aiagent_strips_matching_native_provider_prefix(self):
         with (
@@ -249,6 +302,100 @@ def _mock_response(
     else:
         resp.usage = None
     return resp
+
+
+def test_run_conversation_emits_lifecycle_events(agent, monkeypatch):
+    sink = CaptureEventSink()
+    agent.event_sink = sink
+
+    def fake_run_conversation(agent_obj, *args, **kwargs):
+        return {
+            "final_response": "Done from Hermes",
+            "messages": [{"role": "assistant", "content": "Done from Hermes"}],
+            "api_calls": 1,
+            "completed": True,
+        }
+
+    import agent.conversation_loop as conversation_loop
+
+    monkeypatch.setattr(conversation_loop, "run_conversation", fake_run_conversation)
+
+    result = agent.run_conversation("hello")
+
+    assert result["final_response"] == "Done from Hermes"
+    assert [event["type"] for event in sink.events] == [
+        "run.status",
+        "assistant.message",
+        "run.done",
+    ]
+    assert sink.events[0]["status"] == "thinking"
+    assert sink.events[1]["content"] == "Done from Hermes"
+
+
+def test_run_conversation_emits_error_event_on_exception(agent, monkeypatch):
+    sink = CaptureEventSink()
+    agent.event_sink = sink
+
+    def fake_run_conversation(agent_obj, *args, **kwargs):
+        raise RuntimeError("provider token=secret failed")
+
+    import agent.conversation_loop as conversation_loop
+
+    monkeypatch.setattr(conversation_loop, "run_conversation", fake_run_conversation)
+
+    with pytest.raises(RuntimeError):
+        agent.run_conversation("hello")
+
+    assert [event["type"] for event in sink.events] == ["run.status", "run.error"]
+    assert "secret" not in json.dumps(sink.events[1])
+
+
+def test_sequential_tool_dispatch_emits_tool_lifecycle_events(agent, monkeypatch):
+    sink = CaptureEventSink()
+    agent.event_sink = sink
+    monkeypatch.setattr(run_agent, "handle_function_call", lambda *args, **kwargs: json.dumps({"ok": True, "value": "ready"}))
+
+    messages = []
+    assistant_message = _mock_assistant_msg(
+        content="",
+        tool_calls=[
+            _mock_tool_call(
+                name="web_search",
+                arguments=json.dumps({"query": "arcane", "api_key": "secret-value"}),
+                call_id="call_123",
+            )
+        ],
+    )
+
+    agent._execute_tool_calls_sequential(assistant_message, messages, "task-1")
+
+    assert [event["type"] for event in sink.events] == ["tool.call.started", "tool.call.completed"]
+    assert sink.events[0]["toolCallId"] == "call_123"
+    assert sink.events[0]["name"] == "web_search"
+    assert sink.events[0]["args"]["api_key"] == "[redacted]"
+    assert sink.events[1]["durationMs"] >= 0
+    assert sink.events[1]["resultPreview"] == '{"ok": true, "value": "ready"}'
+    assert messages[-1]["tool_call_id"] == "call_123"
+    assert messages[-1]["content"] == '{"ok": true, "value": "ready"}'
+
+
+def test_sequential_tool_dispatch_emits_failed_tool_event(agent, monkeypatch):
+    sink = CaptureEventSink()
+    agent.event_sink = sink
+    monkeypatch.setattr(run_agent, "handle_function_call", lambda *args, **kwargs: json.dumps({"error": "not found"}))
+
+    messages = []
+    assistant_message = _mock_assistant_msg(
+        content="",
+        tool_calls=[_mock_tool_call(name="web_search", arguments="{}", call_id="call_fail")],
+    )
+
+    agent._execute_tool_calls_sequential(assistant_message, messages, "task-1")
+
+    assert [event["type"] for event in sink.events] == ["tool.call.started", "tool.call.failed"]
+    assert sink.events[1]["toolCallId"] == "call_fail"
+    assert sink.events[1]["error"] == '{"error": "not found"}'
+    assert messages[-1]["content"] == '{"error": "not found"}'
 
 
 # ===================================================================

--- a/tests/scripts/test_hermes_arcane_adapter.py
+++ b/tests/scripts/test_hermes_arcane_adapter.py
@@ -1,0 +1,93 @@
+import io
+import json
+
+import pytest
+
+from scripts import hermes_arcane_adapter as adapter
+
+
+def _run_adapter(monkeypatch, request):
+    stdin = io.StringIO(json.dumps(request))
+    stdout = io.StringIO()
+    monkeypatch.setattr(adapter.sys, "stdin", stdin)
+    monkeypatch.setattr(adapter.sys, "stdout", stdout)
+    rc = adapter.main([])
+    events = [json.loads(line) for line in stdout.getvalue().splitlines() if line.strip()]
+    return rc, events
+
+
+def test_slash_help_emits_assistant_message_without_agent(monkeypatch):
+    def fail_build_agent(*_args, **_kwargs):
+        pytest.fail("slash commands must not construct AIAgent")
+
+    monkeypatch.setattr(adapter, "build_agent", fail_build_agent)
+    rc, events = _run_adapter(
+        monkeypatch,
+        {
+            "sessionId": "arcane-session",
+            "runId": "run-help",
+            "content": "/help",
+        },
+    )
+
+    assert rc == 0
+    assert [event["type"] for event in events] == ["assistant.message", "run.done"]
+    assert events[0]["sessionId"] == "arcane-session"
+    assert events[0]["runId"] == "run-help"
+    assert "Hermes commands available in Arcane" in events[0]["content"]
+    assert "`/status`" in events[0]["content"]
+
+
+def test_unknown_slash_command_returns_clear_message(monkeypatch):
+    monkeypatch.setattr(adapter, "build_agent", lambda *_args, **_kwargs: pytest.fail("unexpected model path"))
+    rc, events = _run_adapter(
+        monkeypatch,
+        {
+            "sessionId": "arcane-session",
+            "runId": "run-unknown",
+            "content": "/does-not-exist",
+        },
+    )
+
+    assert rc == 0
+    assert [event["type"] for event in events] == ["assistant.message", "run.done"]
+    assert "Unknown Hermes command `/does-not-exist`" in events[0]["content"]
+
+
+def test_adapter_sets_arcane_environment_for_tools(monkeypatch):
+    monkeypatch.delenv("ARCANE_ACCESS_TOKEN", raising=False)
+    monkeypatch.setattr(adapter, "build_agent", lambda *_args, **_kwargs: pytest.fail("unexpected model path"))
+
+    rc, _events = _run_adapter(
+        monkeypatch,
+        {
+            "sessionId": "sess-env",
+            "runId": "run-env",
+            "content": "/commands 1",
+            "arcaneBaseUrl": "http://arcane.local/",
+            "arcaneAccessToken": "token-from-request",
+        },
+    )
+
+    assert rc == 0
+    assert adapter.os.environ["ARCANE_SESSION_ID"] == "sess-env"
+    assert adapter.os.environ["ARCANE_RUN_ID"] == "run-env"
+    assert adapter.os.environ["ARCANE_BASE_URL"] == "http://arcane.local"
+    assert adapter.os.environ["ARCANE_ACCESS_TOKEN"] == "token-from-request"
+
+
+def test_stream_emitter_uses_stable_message_id_and_incrementing_index(monkeypatch):
+    stdout = io.StringIO()
+    monkeypatch.setattr(adapter.sys, "stdout", stdout)
+    sink = adapter.StdoutArcaneEventSink("sess-stream", "run-stream")
+    emitter = adapter.ArcaneStreamEmitter(sink, "run-stream")
+
+    emitter.emit("Hello")
+    emitter.emit(None)
+    emitter.emit(" world")
+
+    events = [json.loads(line) for line in stdout.getvalue().splitlines()]
+    assert [event["type"] for event in events] == ["assistant.delta", "assistant.delta"]
+    assert [event["messageId"] for event in events] == ["assistant-run-stream", "assistant-run-stream"]
+    assert [event["index"] for event in events] == [0, 1]
+    assert [event["delta"] for event in events] == ["Hello", " world"]

--- a/tests/tools/test_arcane_tools.py
+++ b/tests/tools/test_arcane_tools.py
@@ -1,0 +1,121 @@
+import json
+
+from model_tools import get_tool_definitions
+from tools import arcane_tools
+
+
+class _Response:
+    def __init__(self, status_code=200, json_data=None, text="", reason=""):
+        self.status_code = status_code
+        self._json_data = json_data
+        self.text = text
+        self.reason = reason
+
+    def json(self):
+        if self._json_data is None:
+            raise ValueError("no json")
+        return self._json_data
+
+
+def test_arcane_tool_schemas_are_discoverable():
+    names = {
+        tool["function"]["name"]
+        for tool in get_tool_definitions(enabled_toolsets=["arcane"], quiet_mode=True)
+    }
+
+    assert {
+        "arcane_list_files",
+        "arcane_read_file",
+        "arcane_write_file",
+        "arcane_create_snapshot",
+        "arcane_get_session",
+    }.issubset(names)
+
+
+def test_arcane_list_files_uses_session_api_and_token(monkeypatch):
+    calls = []
+
+    def fake_request(method, url, **kwargs):
+        calls.append((method, url, kwargs))
+        return _Response(
+            json_data={
+                "files": ["index.html", "styles.css"],
+                "artifactFiles": [{"path": "index.html", "size": 12}],
+            }
+        )
+
+    monkeypatch.setenv("ARCANE_BASE_URL", "http://arcane.test")
+    monkeypatch.setenv("ARCANE_SESSION_ID", "sess-1")
+    monkeypatch.setenv("ARCANE_ACCESS_TOKEN", "secret-token")
+    monkeypatch.setattr(arcane_tools.requests, "request", fake_request)
+
+    result = json.loads(arcane_tools.arcane_list_files())
+
+    assert result["success"] is True
+    assert result["files"] == ["index.html", "styles.css"]
+    assert calls[0][0] == "GET"
+    assert calls[0][1] == "http://arcane.test/api/sessions/sess-1"
+    assert calls[0][2]["headers"]["x-arcane-token"] == "secret-token"
+
+
+def test_arcane_read_file_encodes_artifact_path(monkeypatch):
+    calls = []
+
+    def fake_request(method, url, **kwargs):
+        calls.append((method, url, kwargs))
+        return _Response(text="<main>ready</main>")
+
+    monkeypatch.setenv("ARCANE_BASE_URL", "http://arcane.test")
+    monkeypatch.setenv("ARCANE_SESSION_ID", "sess-1")
+    monkeypatch.delenv("ARCANE_ACCESS_TOKEN", raising=False)
+    monkeypatch.setattr(arcane_tools.requests, "request", fake_request)
+
+    result = json.loads(arcane_tools.arcane_read_file("nested/file.html"))
+
+    assert result["success"] is True
+    assert result["content"] == "<main>ready</main>"
+    assert calls[0][0] == "GET"
+    assert calls[0][1] == "http://arcane.test/artifact/sess-1/nested%2Ffile.html"
+
+
+def test_arcane_write_file_encodes_path_and_sends_text(monkeypatch):
+    calls = []
+
+    def fake_request(method, url, **kwargs):
+        calls.append((method, url, kwargs))
+        return _Response(
+            json_data={
+                "file": {"path": "nested/file.html", "size": 17},
+                "files": ["nested/file.html"],
+                "artifactFiles": [{"path": "nested/file.html", "size": 17}],
+            }
+        )
+
+    monkeypatch.setenv("ARCANE_BASE_URL", "http://arcane.test")
+    monkeypatch.setenv("ARCANE_SESSION_ID", "sess-1")
+    monkeypatch.setattr(arcane_tools.requests, "request", fake_request)
+
+    result = json.loads(arcane_tools.arcane_write_file("nested/file.html", "<h1>Arcane</h1>"))
+
+    assert result["success"] is True
+    assert result["file"]["path"] == "nested/file.html"
+    assert calls[0][0] == "PUT"
+    assert calls[0][1] == "http://arcane.test/api/sessions/sess-1/files/nested%2Ffile.html"
+    assert calls[0][2]["data"] == b"<h1>Arcane</h1>"
+    assert calls[0][2]["headers"]["Content-Type"] == "text/plain; charset=utf-8"
+
+
+def test_arcane_http_errors_redact_access_token(monkeypatch):
+    def fake_request(method, url, **kwargs):
+        return _Response(status_code=401, text="bad token secret-token")
+
+    monkeypatch.setenv("ARCANE_BASE_URL", "http://arcane.test")
+    monkeypatch.setenv("ARCANE_SESSION_ID", "sess-1")
+    monkeypatch.setenv("ARCANE_ACCESS_TOKEN", "secret-token")
+    monkeypatch.setattr(arcane_tools.requests, "request", fake_request)
+
+    result = json.loads(arcane_tools.arcane_list_files())
+
+    assert result["success"] is False
+    assert "secret-token" not in result["error"]
+    assert "[redacted]" in result["error"]

--- a/tools/arcane_tools.py
+++ b/tools/arcane_tools.py
@@ -1,0 +1,437 @@
+"""Arcane workspace tools.
+
+These tools let a Hermes agent inspect and update the Arcane chat+artifact
+workspace through Arcane's HTTP API. They never read Arcane's filesystem
+directly; file paths are sent to Arcane as encoded API path parameters so
+Arcane remains the authority for traversal checks and artifact policy.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Any
+from urllib.parse import quote
+
+import requests
+
+from agent.events import redact_string
+from tools.registry import registry
+
+DEFAULT_ARCANE_BASE_URL = "http://127.0.0.1:8787"
+HTTP_TIMEOUT_SECONDS = 20
+MAX_FILE_CONTENT_CHARS = 20000
+MAX_MESSAGE_CONTENT_CHARS = 4000
+MAX_ERROR_CHARS = 1000
+
+
+def _json(data: dict[str, Any]) -> str:
+    return json.dumps(data, ensure_ascii=False, separators=(",", ":"))
+
+
+def _success(**payload: Any) -> str:
+    return _json({"success": True, **payload})
+
+
+def _error(message: Any, **payload: Any) -> str:
+    return _json({"success": False, "error": _redact(message), **payload})
+
+
+def _redact(value: Any) -> str:
+    text = redact_string(str(value or ""))
+    token = os.getenv("ARCANE_ACCESS_TOKEN", "")
+    if token:
+        text = text.replace(token, "[redacted]")
+    return text[:MAX_ERROR_CHARS]
+
+
+def _truncate(text: str, limit: int) -> tuple[str, bool]:
+    if len(text) <= limit:
+        return text, False
+    return text[:limit] + "\n[truncated]", True
+
+
+def _base_url() -> str:
+    return (os.getenv("ARCANE_BASE_URL", "").strip() or DEFAULT_ARCANE_BASE_URL).rstrip("/")
+
+
+def _session_id(session_id: Any = None) -> str:
+    value = str(session_id or os.getenv("ARCANE_SESSION_ID", "")).strip()
+    if not value:
+        raise ValueError("session_id is required or ARCANE_SESSION_ID must be set")
+    return value
+
+
+def _artifact_path(path: Any) -> str:
+    value = str(path or "").strip()
+    if not value:
+        raise ValueError("path is required")
+    return value
+
+
+def _encoded(value: str) -> str:
+    return quote(value, safe="")
+
+
+def _headers(*, accept_text: bool = False, content_type: str | None = None) -> dict[str, str]:
+    headers = {"Accept": "text/plain" if accept_text else "application/json"}
+    token = os.getenv("ARCANE_ACCESS_TOKEN", "")
+    if token:
+        headers["x-arcane-token"] = token
+    if content_type:
+        headers["Content-Type"] = content_type
+    return headers
+
+
+def _request_json(method: str, url: str, **kwargs: Any) -> dict[str, Any]:
+    try:
+        response = requests.request(method, url, timeout=HTTP_TIMEOUT_SECONDS, **kwargs)
+    except requests.RequestException as exc:
+        raise RuntimeError(f"Arcane HTTP request failed: {_redact(exc)}") from exc
+
+    if response.status_code >= 400:
+        detail = _redact(getattr(response, "text", "") or getattr(response, "reason", ""))
+        raise RuntimeError(f"Arcane API returned HTTP {response.status_code}: {detail}")
+    try:
+        data = response.json()
+    except ValueError as exc:
+        raise RuntimeError("Arcane API returned non-JSON response") from exc
+    if not isinstance(data, dict):
+        raise RuntimeError("Arcane API returned unexpected JSON payload")
+    return data
+
+
+def _request_text(method: str, url: str, **kwargs: Any) -> str:
+    try:
+        response = requests.request(method, url, timeout=HTTP_TIMEOUT_SECONDS, **kwargs)
+    except requests.RequestException as exc:
+        raise RuntimeError(f"Arcane HTTP request failed: {_redact(exc)}") from exc
+
+    if response.status_code >= 400:
+        detail = _redact(getattr(response, "text", "") or getattr(response, "reason", ""))
+        raise RuntimeError(f"Arcane API returned HTTP {response.status_code}: {detail}")
+    return response.text
+
+
+def _session_url(session_id: str) -> str:
+    return f"{_base_url()}/api/sessions/{_encoded(session_id)}"
+
+
+def _file_url(session_id: str, path: str) -> str:
+    return f"{_session_url(session_id)}/files/{_encoded(path)}"
+
+
+def _artifact_url(session_id: str, path: str) -> str:
+    return f"{_base_url()}/artifact/{_encoded(session_id)}/{_encoded(path)}"
+
+
+def _coerce_positive_int(value: Any, default: int, maximum: int) -> int:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return default
+    return max(0, min(parsed, maximum))
+
+
+def _compact_message(message: Any) -> Any:
+    if not isinstance(message, dict):
+        return message
+    compact = dict(message)
+    content = compact.get("content")
+    if isinstance(content, str):
+        compact["content"], compact["contentTruncated"] = _truncate(content, MAX_MESSAGE_CONTENT_CHARS)
+    return compact
+
+
+def _compact_session_payload(
+    payload: dict[str, Any],
+    *,
+    message_limit: int = 20,
+    run_event_limit: int = 50,
+) -> dict[str, Any]:
+    out = {
+        "session": payload.get("session"),
+        "files": payload.get("files") or [],
+        "artifactFiles": payload.get("artifactFiles") or [],
+        "run": payload.get("run"),
+        "runs": payload.get("runs") or [],
+    }
+    messages = payload.get("messages")
+    if isinstance(messages, list):
+        out["messages"] = [_compact_message(item) for item in messages[-message_limit:]]
+        out["messagesTruncated"] = len(messages) > message_limit
+    run_events = payload.get("runEvents")
+    if isinstance(run_events, list):
+        out["runEvents"] = run_events[-run_event_limit:]
+        out["runEventsTruncated"] = len(run_events) > run_event_limit
+    return out
+
+
+def arcane_get_session(
+    session_id: str | None = None,
+    message_limit: int = 20,
+    run_event_limit: int = 50,
+    task_id: str | None = None,
+) -> str:
+    """Get Arcane session metadata, recent messages, artifact files, and runs."""
+    try:
+        sid = _session_id(session_id)
+        payload = _request_json("GET", _session_url(sid), headers=_headers())
+        return _success(
+            session_id=sid,
+            **_compact_session_payload(
+                payload,
+                message_limit=_coerce_positive_int(message_limit, 20, 100),
+                run_event_limit=_coerce_positive_int(run_event_limit, 50, 200),
+            ),
+        )
+    except Exception as exc:
+        return _error(exc)
+
+
+def arcane_list_files(session_id: str | None = None, task_id: str | None = None) -> str:
+    """List artifact files in an Arcane session."""
+    try:
+        sid = _session_id(session_id)
+        payload = _request_json("GET", _session_url(sid), headers=_headers())
+        return _success(
+            session_id=sid,
+            files=payload.get("files") or [],
+            artifactFiles=payload.get("artifactFiles") or [],
+        )
+    except Exception as exc:
+        return _error(exc)
+
+
+def arcane_read_file(
+    path: str,
+    session_id: str | None = None,
+    task_id: str | None = None,
+) -> str:
+    """Read one artifact file from an Arcane session."""
+    try:
+        sid = _session_id(session_id)
+        rel_path = _artifact_path(path)
+        content = _request_text("GET", _artifact_url(sid, rel_path), headers=_headers(accept_text=True))
+        preview, truncated = _truncate(content, MAX_FILE_CONTENT_CHARS)
+        return _success(
+            session_id=sid,
+            path=rel_path,
+            content=preview,
+            size=len(content),
+            truncated=truncated,
+        )
+    except Exception as exc:
+        return _error(exc)
+
+
+def arcane_write_file(
+    path: str,
+    content: str,
+    session_id: str | None = None,
+    task_id: str | None = None,
+) -> str:
+    """Write one artifact file in an Arcane session."""
+    try:
+        sid = _session_id(session_id)
+        rel_path = _artifact_path(path)
+        text = str(content or "")
+        payload = _request_json(
+            "PUT",
+            _file_url(sid, rel_path),
+            headers=_headers(content_type="text/plain; charset=utf-8"),
+            data=text.encode("utf-8"),
+        )
+        return _success(
+            session_id=sid,
+            path=rel_path,
+            file=payload.get("file"),
+            files=payload.get("files") or [],
+            artifactFiles=payload.get("artifactFiles") or [],
+            bytes=len(text.encode("utf-8")),
+        )
+    except Exception as exc:
+        return _error(exc)
+
+
+def arcane_create_snapshot(
+    summary: str | None = None,
+    session_id: str | None = None,
+    task_id: str | None = None,
+) -> str:
+    """Create an Arcane artifact snapshot for rollback/review."""
+    try:
+        sid = _session_id(session_id)
+        payload = _request_json(
+            "POST",
+            f"{_session_url(sid)}/snapshots",
+            headers=_headers(content_type="application/json"),
+            json={"summary": str(summary or "")},
+        )
+        return _success(
+            session_id=sid,
+            snapshot=payload.get("snapshot") or {
+                key: payload.get(key)
+                for key in ("id", "summary", "createdAt")
+                if key in payload
+            },
+            files=payload.get("files") or [],
+            artifactFiles=payload.get("artifactFiles") or [],
+        )
+    except Exception as exc:
+        return _error(exc)
+
+
+def _arg(args: dict[str, Any], *names: str, default: Any = None) -> Any:
+    for name in names:
+        if name in args:
+            return args.get(name)
+    return default
+
+
+_SESSION_ID_SCHEMA = {
+    "type": "string",
+    "description": "Arcane session id. Defaults to ARCANE_SESSION_ID for the current Arcane run.",
+}
+
+registry.register(
+    name="arcane_get_session",
+    toolset="arcane",
+    schema={
+        "name": "arcane_get_session",
+        "description": "Get Arcane session metadata, recent messages, files, runs, and run events.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "session_id": _SESSION_ID_SCHEMA,
+                "message_limit": {
+                    "type": "integer",
+                    "description": "Maximum recent messages to include. Default 20, max 100.",
+                    "default": 20,
+                },
+                "run_event_limit": {
+                    "type": "integer",
+                    "description": "Maximum recent run events to include. Default 50, max 200.",
+                    "default": 50,
+                },
+            },
+            "additionalProperties": False,
+        },
+    },
+    handler=lambda args, **kw: arcane_get_session(
+        session_id=_arg(args, "session_id", "sessionId"),
+        message_limit=_arg(args, "message_limit", "messageLimit", default=20),
+        run_event_limit=_arg(args, "run_event_limit", "runEventLimit", default=50),
+        task_id=kw.get("task_id"),
+    ),
+    description="Get Arcane session metadata.",
+    emoji="🜁",
+)
+
+registry.register(
+    name="arcane_list_files",
+    toolset="arcane",
+    schema={
+        "name": "arcane_list_files",
+        "description": "List artifact files in the current Arcane workspace session.",
+        "parameters": {
+            "type": "object",
+            "properties": {"session_id": _SESSION_ID_SCHEMA},
+            "additionalProperties": False,
+        },
+    },
+    handler=lambda args, **kw: arcane_list_files(
+        session_id=_arg(args, "session_id", "sessionId"),
+        task_id=kw.get("task_id"),
+    ),
+    description="List Arcane artifact files.",
+    emoji="🜁",
+)
+
+registry.register(
+    name="arcane_read_file",
+    toolset="arcane",
+    schema={
+        "name": "arcane_read_file",
+        "description": "Read one artifact file from the current Arcane workspace session.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "string",
+                    "description": "Relative artifact path such as index.html, styles.css, or nested/file.js.",
+                },
+                "session_id": _SESSION_ID_SCHEMA,
+            },
+            "required": ["path"],
+            "additionalProperties": False,
+        },
+    },
+    handler=lambda args, **kw: arcane_read_file(
+        path=_arg(args, "path", default=""),
+        session_id=_arg(args, "session_id", "sessionId"),
+        task_id=kw.get("task_id"),
+    ),
+    description="Read an Arcane artifact file.",
+    emoji="🜁",
+)
+
+registry.register(
+    name="arcane_write_file",
+    toolset="arcane",
+    schema={
+        "name": "arcane_write_file",
+        "description": "Write one artifact file in the current Arcane workspace session.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "string",
+                    "description": "Relative artifact path such as index.html, styles.css, or nested/file.js.",
+                },
+                "content": {
+                    "type": "string",
+                    "description": "Full file content to write.",
+                },
+                "session_id": _SESSION_ID_SCHEMA,
+            },
+            "required": ["path", "content"],
+            "additionalProperties": False,
+        },
+    },
+    handler=lambda args, **kw: arcane_write_file(
+        path=_arg(args, "path", default=""),
+        content=_arg(args, "content", default=""),
+        session_id=_arg(args, "session_id", "sessionId"),
+        task_id=kw.get("task_id"),
+    ),
+    description="Write an Arcane artifact file.",
+    emoji="🜁",
+)
+
+registry.register(
+    name="arcane_create_snapshot",
+    toolset="arcane",
+    schema={
+        "name": "arcane_create_snapshot",
+        "description": "Create a snapshot of the current Arcane artifact files.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "summary": {
+                    "type": "string",
+                    "description": "Short summary of why the snapshot was created.",
+                },
+                "session_id": _SESSION_ID_SCHEMA,
+            },
+            "additionalProperties": False,
+        },
+    },
+    handler=lambda args, **kw: arcane_create_snapshot(
+        summary=_arg(args, "summary", default=""),
+        session_id=_arg(args, "session_id", "sessionId"),
+        task_id=kw.get("task_id"),
+    ),
+    description="Create an Arcane artifact snapshot.",
+    emoji="🜁",
+)

--- a/toolsets.py
+++ b/toolsets.py
@@ -187,6 +187,18 @@ TOOLSETS = {
         "tools": ["read_file", "write_file", "patch", "search_files"],
         "includes": []
     },
+
+    "arcane": {
+        "description": "Arcane workspace tools for chat artifacts, session metadata, files, and snapshots",
+        "tools": [
+            "arcane_list_files",
+            "arcane_read_file",
+            "arcane_write_file",
+            "arcane_create_snapshot",
+            "arcane_get_session",
+        ],
+        "includes": [],
+    },
     
     "tts": {
         "description": "Text-to-speech: convert text to audio with Edge TTS (free), ElevenLabs, OpenAI, or xAI",
@@ -525,6 +537,12 @@ TOOLSETS = {
         "description": "Webhook toolset - receive and process external webhook events",
         "tools": _HERMES_CORE_TOOLS,
         "includes": []
+    },
+
+    "hermes-arcane": {
+        "description": "Arcane chat and artifact workspace toolset - default Hermes tools plus Arcane workspace tools",
+        "tools": _HERMES_CORE_TOOLS,
+        "includes": ["arcane"],
     },
 
     "hermes-gateway": {


### PR DESCRIPTION
## Summary
- Add structured Hermes event sink lifecycle/tool events for frontend gateways
- Add Arcane JSONL adapter with slash command handling and assistant delta streaming
- Add Arcane workspace tools for session/files/snapshots over the Arcane HTTP API

## Test Plan
- python scripts/hermes_arcane_adapter.py --self-test
- python -m pytest tests/scripts/test_hermes_arcane_adapter.py tests/tools/test_arcane_tools.py -q -o 'addopts='
- python -m pytest tests/run_agent/test_run_agent.py -q -o 'addopts='
- python py_compile for adapter, arcane tools, event sink, run_agent, toolsets
