### PR TITLE
fix(gateway): resolve uv-managed pythonw for Windows scheduled-task wrapper

### DIFF
--- a/hermes_cli/gateway_windows.py
+++ b/hermes_cli/gateway_windows.py
@@ -314,12 +314,17 @@ def _build_gateway_cmd_script(
     lines.append(f'set "HERMES_HOME={hermes_home}"')
     lines.append('set "PYTHONIOENCODING=utf-8"')
     lines.append('set "HERMES_GATEWAY_DETACHED=1"')
-    # VIRTUAL_ENV lets the gateway's own python detection find the venv
-    # if someone imports hermes_constants-based logic during startup.
-    venv_dir = str(Path(python_path).resolve().parent.parent)
-    lines.append(f'set "VIRTUAL_ENV={venv_dir}"')
+    # Mirror _build_gateway_argv: uv-managed venvs ship a shim pythonw.exe
+    # that respawns the base console python.exe, which surfaces as a visible
+    # cmd.exe window when launched from the Scheduled Task. Resolve to the
+    # base interpreter and inject site-packages on PYTHONPATH the same way
+    # the direct-spawn path does.
+    pythonw_path, venv_dir, extra_pythonpath = _resolve_detached_python(python_path)
+    lines.append(f'set "VIRTUAL_ENV={venv_dir.resolve()}"')
+    if extra_pythonpath:
+        pythonpath_value = os.pathsep.join([working_dir, *extra_pythonpath])
+        lines.append(f'set "PYTHONPATH={pythonpath_value}"')
 
-    pythonw_path = _derive_venv_pythonw(python_path)
     prog_args = [pythonw_path, "-m", "hermes_cli.main"]
     if profile_arg:
         prog_args.extend(profile_arg.split())

--- a/hermes_cli/gateway_windows.py
+++ b/hermes_cli/gateway_windows.py
@@ -302,6 +302,9 @@ def _build_gateway_cmd_script(
     The script:
       - cd's into the project directory
       - exports HERMES_HOME, PYTHONIOENCODING, VIRTUAL_ENV
+      - on uv-managed venvs (per ``_resolve_detached_python``), also exports
+        PYTHONPATH so the base ``pythonw.exe`` can import the venv's
+        ``site-packages``
       - invokes ``pythonw -m hermes_cli.main [--profile X] gateway run``
         directly so the wrapper cmd.exe exits without a visible gateway console
 
@@ -322,7 +325,11 @@ def _build_gateway_cmd_script(
     pythonw_path, venv_dir, extra_pythonpath = _resolve_detached_python(python_path)
     lines.append(f'set "VIRTUAL_ENV={venv_dir.resolve()}"')
     if extra_pythonpath:
-        pythonpath_value = os.pathsep.join([working_dir, *extra_pythonpath])
+        # The emitted ``.cmd`` is consumed by cmd.exe on Windows, so use the
+        # Windows path separator literally rather than ``os.pathsep`` — the
+        # latter would yield ``:`` if this script were ever generated off
+        # Windows (e.g. cross-platform build tooling or unit tests).
+        pythonpath_value = ";".join([working_dir, *extra_pythonpath])
         lines.append(f'set "PYTHONPATH={pythonpath_value}"')
 
     prog_args = [pythonw_path, "-m", "hermes_cli.main"]

--- a/tests/hermes_cli/test_gateway_windows.py
+++ b/tests/hermes_cli/test_gateway_windows.py
@@ -67,6 +67,53 @@ def test_build_gateway_argv_uses_base_pythonw_for_uv_venv_launcher(monkeypatch, 
     assert str(site_packages) in env_overlay["PYTHONPATH"].split(gateway_windows.os.pathsep)
 
 
+def test_build_gateway_cmd_script_uses_base_pythonw_for_uv_venv_launcher(monkeypatch, tmp_path):
+    """Scheduled-Task .cmd wrapper must mirror _build_gateway_argv on uv venvs.
+
+    The venv/Scripts/pythonw.exe shipped by uv is a launcher shim that
+    respawns the base console python.exe, which renders as a visible cmd.exe
+    window when started by the Scheduled Task. The .cmd generator must
+    resolve to the base pythonw.exe and inject the venv site-packages on
+    PYTHONPATH the same way the direct-spawn path does.
+    """
+    project = tmp_path / "project"
+    scripts = project / "venv" / "Scripts"
+    site_packages = project / "venv" / "Lib" / "site-packages"
+    base = tmp_path / "uv" / "python" / "cpython-3.11-windows-x86_64-none"
+    scripts.mkdir(parents=True)
+    site_packages.mkdir(parents=True)
+    base.mkdir(parents=True)
+
+    venv_python = scripts / "python.exe"
+    venv_pythonw = scripts / "pythonw.exe"
+    base_pythonw = base / "pythonw.exe"
+    for exe in (venv_python, venv_pythonw, base_pythonw):
+        exe.write_text("", encoding="utf-8")
+    (project / "venv" / "pyvenv.cfg").write_text(
+        f"home = {base}\nimplementation = CPython\nuv = 0.11.14\nversion_info = 3.11.15\n",
+        encoding="utf-8",
+    )
+
+    content = gateway_windows._build_gateway_cmd_script(
+        str(venv_python),
+        str(project),
+        str(tmp_path / "hermes-home"),
+        "--profile alice",
+    )
+
+    assert str(base_pythonw) in content
+    assert str(venv_pythonw) not in content
+    assert f'set "VIRTUAL_ENV={(project / "venv").resolve()}"' in content
+    pythonpath_line = next(
+        line for line in content.splitlines() if line.startswith('set "PYTHONPATH=')
+    )
+    pythonpath_value = pythonpath_line.split("=", 1)[1].rstrip('"')
+    pythonpath_entries = pythonpath_value.split(gateway_windows.os.pathsep)
+    assert str(project) in pythonpath_entries
+    assert str(site_packages) in pythonpath_entries
+    assert "gateway run" in content
+
+
 def _arrange_startup_fallback(monkeypatch, tmp_path, running_pids):
     script_path = tmp_path / "Hermes_Gateway_alice.cmd"
     startup_entry = tmp_path / "Startup" / "Hermes_Gateway_alice.cmd"

--- a/tests/hermes_cli/test_gateway_windows.py
+++ b/tests/hermes_cli/test_gateway_windows.py
@@ -108,7 +108,10 @@ def test_build_gateway_cmd_script_uses_base_pythonw_for_uv_venv_launcher(monkeyp
         line for line in content.splitlines() if line.startswith('set "PYTHONPATH=')
     )
     pythonpath_value = pythonpath_line.split("=", 1)[1].rstrip('"')
-    pythonpath_entries = pythonpath_value.split(gateway_windows.os.pathsep)
+    # The generated script is Windows-targeted, so its PYTHONPATH always
+    # uses ``;`` as the separator regardless of the host OS running this
+    # test. Use the literal Windows separator instead of os.pathsep.
+    pythonpath_entries = pythonpath_value.split(";")
     assert str(project) in pythonpath_entries
     assert str(site_packages) in pythonpath_entries
     assert "gateway run" in content


### PR DESCRIPTION
## What does this PR do?

`hermes gateway start` on Windows pops up a visible `cmd.exe` console window when Hermes is installed inside a uv-managed venv. Root cause is in `hermes_cli/gateway_windows.py::_build_gateway_cmd_script`, which derives the GUI interpreter via `_derive_venv_pythonw`. That helper only checks for a sibling `pythonw.exe` under `venv/Scripts/` — on uv venvs that sibling is a ~44KB launcher shim that respawns the base `python.exe` (console subsystem), so the Scheduled Task ends up running console Python despite asking for `pythonw.exe`.

The direct-spawn path (`_build_gateway_argv`) already handles this correctly via `_resolve_detached_python`, which inspects `pyvenv.cfg`, detects the `uv = ...` marker, and returns the base `pythonw.exe` plus the site-packages path that has to be injected on `PYTHONPATH`. This PR switches the Scheduled-Task `.cmd` generator to use the same resolver so both code paths mirror each other.

Mirrors `_resolve_detached_python` precedence used by `_build_gateway_argv`: `pyvenv.cfg.uv` + `home=` → base `pythonw.exe` + `PYTHONPATH` injection; non-uv venvs fall through to the previous `_derive_venv_pythonw` behavior.

## Related Issue

Fixes #30308

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/gateway_windows.py` — `_build_gateway_cmd_script` now calls `_resolve_detached_python(python_path)` instead of `_derive_venv_pythonw(python_path)`, and emits a `set "PYTHONPATH=<working_dir>;<site-packages>"` line when the resolver returns extra `PYTHONPATH` entries (uv-venv case). `VIRTUAL_ENV` continues to point at the venv dir.
- `tests/hermes_cli/test_gateway_windows.py` — new `test_build_gateway_cmd_script_uses_base_pythonw_for_uv_venv_launcher` mirrors the existing `_build_gateway_argv` test: arranges a uv-shaped venv (`pyvenv.cfg` with `uv = 0.11.14` + `home = <base>`), calls `_build_gateway_cmd_script` directly, and asserts the emitted script (a) references the **base** `pythonw.exe`, not the venv shim, (b) sets `VIRTUAL_ENV` to the resolved venv dir, and (c) sets `PYTHONPATH` to include both the project working dir and the venv site-packages.

## How to Test

1. On a Windows host with Hermes installed in a uv-managed venv: `hermes gateway install` then trigger the Scheduled Task. Before this PR a visible `cmd.exe` window appears; after this PR the task runs hidden.
2. `uv run --with pytest --with pytest-xdist --with pytest-asyncio --with pytest-timeout python3 -m pytest tests/hermes_cli/test_gateway_windows.py -v` — all 22 tests pass, including the new regression test (reverting the production change alone makes only the new test fail).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run focused tests for the touched code and all pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.x (Windows behavior verified via regression test)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — Windows-specific path; the resolver already gates on `pyvenv.cfg.uv` so non-uv venvs and non-Windows hosts are unaffected.
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Sibling code paths

> Sibling code paths that may need the same fix: `_launch_elevated_gateway_command` at line 156-174 also calls `_derive_venv_pythonw(sys.executable)` for the UAC-elevated handoff. That call site uses `ShellExecuteW` with `SW_HIDE`, so the visible-window symptom does not reproduce there in the same way, but on a uv venv the elevated child would still respawn through the launcher shim. Intentionally left out of this PR's scope to keep the diff small and the test surface focused; happy to widen if preferred.

## Screenshots / Logs

The issue includes a screenshot of the rogue `cmd.exe` window on Windows; after this PR the Scheduled Task action completes without surfacing a console window because the base `pythonw.exe` is genuinely a GUI-subsystem binary.