### PR TITLE
feat: add autoreason optional skill (self-refinement pipeline)

### DIFF
--- a/optional-skills/autonomous-ai-agents/autoreason/SKILL.md
+++ b/optional-skills/autonomous-ai-agents/autoreason/SKILL.md
@@ -1,0 +1,149 @@
+---
+name: autoreason
+description: Autoreason: Self-Refinement That Knows When to Stop — iterative LLM output improvement via 3-version competition (A/B/AB) with blind Borda judging and automatic convergence detection. Based on NousResearch/autoreason by SHL0MS.
+version: 1.0.0
+author: SHL0MS, enhanced by Hermes Agent
+license: MIT
+metadata:
+  hermes:
+    tags: [self-refinement, iterative-improvement, llm-optimization, borda-count, convergence, autoreason]
+    category: autonomous-ai-agents
+    homepage: https://github.com/NousResearch/autoreason
+---
+
+# Autoreason: Self-Refinement That Knows When to Stop
+
+Iterative self-refinement fails for three structural reasons: *prompt bias* (models hallucinate flaws when asked to critique), *scope creep* (outputs expand unchecked each pass), and *lack of restraint* (models never say "no changes needed"). Autoreason fixes all three.
+
+Each iteration produces three competing versions — the **unchanged incumbent (A)**, an **adversarial revision (B)**, and a **synthesis (AB)** — judged by fresh agents with no shared context via blind Borda count. "Do nothing" is always a first-class option.
+
+## Flow
+
+```
+Task Prompt → Incumbent A (initial generation)
+                   ↓
+         Critic (fresh agent)   →   Critique (problems only, no fixes)
+         Author B (fresh)       →   Revision (B): address each critique
+         Synthesizer (fresh)    →   Synthesis (AB): best of A+B per dimension
+                   ↓
+         Judge Panel (3+ fresh agents, blind Borda count)
+                   ↓
+              Winner → new A   (if A wins 2 consecutive → converge)
+```
+
+## When to load this skill
+
+Load `/skill autoreason` when the user asks you to:
+
+- "Run autoreason on this task: [task]"
+- "Apply the self-refinement pipeline to improve this output"
+- "Use the three-version tournament to refine this proposal"
+- "Do autoreason self-refinement on this"
+
+## Usage instructions
+
+When loaded, apply the autoreason pipeline by calling `scripts/run_autoreason.py`:
+
+```bash
+python path/to/autoreason/experiments/v2/run_overnight.py  # if inside the autoreason repo
+```
+
+Or run the pipeline manually by following the flow above with these prompt templates:
+
+### Author System Prompt
+```
+You are a senior consultant producing professional deliverables.
+Be specific, concrete, and practical. Avoid generic advice.
+Tailor everything to the constraints stated in the task.
+```
+
+### Critic System Prompt
+```
+You are a critical reviewer. Your only job is to find real problems.
+Be specific and concrete. Do not suggest fixes.
+```
+
+### Author B (Revision) System Prompt
+```
+You are a senior consultant revising a proposal based on specific criticisms.
+Address each valid criticism directly. Do not make changes that aren't
+motivated by an identified problem.
+```
+
+### Synthesizer System Prompt
+```
+You are a senior consultant. You are given two versions as equal inputs.
+Take the strongest elements from each and produce a coherent synthesis.
+This is not a compromise — pick the best answer per dimension.
+```
+
+### Judge System Prompt
+```
+You are an independent evaluator. You have no authorship stake in any
+version. Evaluate which version best accomplishes the original task.
+```
+
+### Judge Ranking Prompt (3 versions)
+```
+ORIGINAL TASK:
+---
+{task_prompt}
+---
+
+Three proposals have been produced independently. Evaluate how well each accomplishes the stated task.
+
+{judge_proposals}
+
+For each proposal, state what it gets right and what it gets wrong.
+Then rank all three from best to worst:
+
+RANKING: [best], [second], [worst]
+
+Where each slot is 1, 2, or 3.
+```
+
+## Key parameters
+
+| Parameter | Default | Notes |
+|-----------|---------|-------|
+| Author temperature | 0.8 | Higher for creative generation |
+| Judge temperature | 0.3 | Lower for consistent evaluation |
+| Number of judges | 3 | 7 converges 3× faster but costs more |
+| Convergence | 2 consecutive A wins | A = "do nothing" wins twice → done |
+| Max passes | 30 | Safety limit |
+
+## Key design decisions
+
+1. **Tiebreak: A (incumbent) wins ties** — deliberate. Without this, "tinker unnecessarily" beats "keep the known good."
+2. **Critic must not suggest fixes** — doing so contaminates B's independence.
+3. **Synthesizer input order is randomized** — avoids position bias. Shuffle which is vx vs vy.
+4. **Each judge is a fresh agent** — zero shared context between judges and authors.
+5. **Labels are shuffled per judge** — no judge sees A/B/AB in the same order.
+
+## Known results
+
+| Finding | Detail |
+|---------|--------|
+| **42/42 perfect sweep** | Haiku 3.5 + autoreason scored perfect Borda across 5 tasks; all baselines degraded below single-pass |
+| **77% vs 73%** | Sonnet 4.6 on 150 CodeContests problems (private-test), autoreason vs single-pass |
+| **40% vs 31%** | Haiku 3.5 autoreason vs best-of-6 at matched compute |
+| **Haiku 4.5: transition point** | At 60% private accuracy, autoreason's held-out gains vanish — generation-evaluation gap closed |
+| **7 judges → 3× faster convergence** | Than 3 judges; 1 judge is noisy and slow |
+| **Both B and AB necessary** | Removing either collapses the tournament (converges in 2–3 passes vs 24) |
+| **Length-controlled: 21/28 wins** | Autoreason beats 3 of 4 baselines even at matched word count |
+| **Refinement destroys weak models** | Critique-and-revise reduced Haiku 3.5 outputs by 59–70% over 15 passes |
+
+## Pitfalls
+
+- **Token cost**: Each pass = 6–10 LLM calls. Accumulates fast on long texts.
+- **Weak judge model = noisy results**: Use the same or stronger model as the author.
+- **Not for simple Q&A**: Single pass suffices for trivial tasks.
+- **Code domain uses a different flow**: For code tasks, use test-feedback analysis on failure, not 3-version tournaments.
+
+## References
+
+- Paper: [NousResearch/autoreason](https://github.com/NousResearch/autoreason)
+- Paper PDF: [autoreason.pdf](https://github.com/NousResearch/autoreason/blob/main/paper/autoreason.pdf)
+- Experiment code: `experiments/v2/run_overnight.py` (writing tasks), `experiments/v2/run_code_overnight.py` (code tasks)
+- Ablations: `experiments/v2/run_ablations.py` (judge count, aggregation, component)
+- Statistics: `experiments/v2/compute_stats.py` (bootstrap CIs, McNemar tests)

--- a/optional-skills/autonomous-ai-agents/autoreason/SKILL.md
+++ b/optional-skills/autonomous-ai-agents/autoreason/SKILL.md
@@ -1,9 +1,10 @@
 ---
 name: autoreason
-description: Autoreason: Self-Refinement That Knows When to Stop — iterative LLM output improvement via 3-version competition (A/B/AB) with blind Borda judging and automatic convergence detection. Based on NousResearch/autoreason by SHL0MS.
-version: 1.0.0
-author: SHL0MS, enhanced by Hermes Agent
+description: Self-refine LLM outputs via a 3-version tournament.
+version: 1.1.0
+author: Xinyu Du (@Starfie1d1272), SHL0MS
 license: MIT
+platforms: [linux, macos, windows]
 metadata:
   hermes:
     tags: [self-refinement, iterative-improvement, llm-optimization, borda-count, convergence, autoreason]
@@ -11,73 +12,84 @@ metadata:
     homepage: https://github.com/NousResearch/autoreason
 ---
 
-# Autoreason: Self-Refinement That Knows When to Stop
+# Autoreason Skill
 
-Iterative self-refinement fails for three structural reasons: *prompt bias* (models hallucinate flaws when asked to critique), *scope creep* (outputs expand unchecked each pass), and *lack of restraint* (models never say "no changes needed"). Autoreason fixes all three.
+Autoreason is a self-refinement pipeline that iteratively improves LLM outputs via a 3-version competition: the unchanged incumbent (A), an adversarial revision (B), and a synthesis (AB), judged by fresh agents with no shared context via blind Borda count. "Do nothing" is always a first-class option — the pipeline stops when the incumbent wins twice in a row.
 
-Each iteration produces three competing versions — the **unchanged incumbent (A)**, an **adversarial revision (B)**, and a **synthesis (AB)** — judged by fresh agents with no shared context via blind Borda count. "Do nothing" is always a first-class option.
+It fixes the three structural failures of naive critique-and-revise: *prompt bias* (models hallucinate flaws when asked to critique), *scope creep* (outputs expand unchecked each pass), and *lack of restraint* (models never say "no changes needed").
 
-## Flow
-
-```
-Task Prompt → Incumbent A (initial generation)
-                   ↓
-         Critic (fresh agent)   →   Critique (problems only, no fixes)
-         Author B (fresh)       →   Revision (B): address each critique
-         Synthesizer (fresh)    →   Synthesis (AB): best of A+B per dimension
-                   ↓
-         Judge Panel (3+ fresh agents, blind Borda count)
-                   ↓
-              Winner → new A   (if A wins 2 consecutive → converge)
-```
-
-## When to load this skill
+## When to Use
 
 Load `/skill autoreason` when the user asks you to:
 
 - "Run autoreason on this task: [task]"
 - "Apply the self-refinement pipeline to improve this output"
 - "Use the three-version tournament to refine this proposal"
-- "Do autoreason self-refinement on this"
 
-## Usage instructions
+Do **not** use for: simple Q&A (a single pass suffices), high-frequency batch work, or models already near their capability ceiling.
 
-When loaded, apply the autoreason pipeline by calling `scripts/run_autoreason.py`:
+## Prerequisites
 
-```bash
-python path/to/autoreason/experiments/v2/run_overnight.py  # if inside the autoreason repo
+- Python 3.11+
+- `litellm` installed (`pip install litellm` or `uv pip install litellm`)
+- An API key for the target model (e.g. `ANTHROPIC_API_KEY`, `OPENROUTER_API_KEY`)
+
+## How to Run
+
+Run the bundled CLI via the `terminal` tool:
+
+```
+terminal(command="python scripts/run_autoreason.py --task 'Your task prompt here'")
 ```
 
-Or run the pipeline manually by following the flow above with these prompt templates:
+Options: `--model` (default `anthropic/claude-sonnet-4-20250514`), `--judges` (default 3; 7 converges ~3x faster but costs more), `--max-passes` (default 30), `--output`. Results land in `autoreason_output/` with per-pass logs, `final_output.md`, and `history.json`.
 
-### Author System Prompt
+## Quick Reference
+
+- Flow: Generate A → Critic (fresh agent, problems only) → Author B (revision) → Synthesizer (AB) → 3+ fresh judges via blind Borda count → winner becomes new A
+- Convergence: A wins 2 consecutive passes
+- Tiebreak: A wins ties (conservative — prefer the known-good incumbent)
+- Defaults: author temp 0.8, judge temp 0.3, 3 judges, max 30 passes
+
+## Procedure
+
+1. Get the task prompt and choose a model.
+2. Run the pipeline with `terminal`, e.g. `python scripts/run_autoreason.py --task '...' --model anthropic/claude-sonnet-4-20250514`.
+3. Inspect `autoreason_output/history.json` for the winner trajectory and word count per pass.
+4. Read `autoreason_output/final_output.md` and deliver it to the user.
+
+If the CLI is unavailable (no `litellm` or no API key), run the pipeline manually with native tools: spawn fresh Critic, Author B, Synthesizer, and Judge agents via `delegate_task` (each with no shared context), then aggregate rankings by Borda count. Prompt templates are below.
+
+## Prompt Templates
+
+### Author System
 ```
 You are a senior consultant producing professional deliverables.
 Be specific, concrete, and practical. Avoid generic advice.
 Tailor everything to the constraints stated in the task.
 ```
 
-### Critic System Prompt
+### Critic System
 ```
 You are a critical reviewer. Your only job is to find real problems.
 Be specific and concrete. Do not suggest fixes.
 ```
 
-### Author B (Revision) System Prompt
+### Author B (Revision) System
 ```
 You are a senior consultant revising a proposal based on specific criticisms.
 Address each valid criticism directly. Do not make changes that aren't
 motivated by an identified problem.
 ```
 
-### Synthesizer System Prompt
+### Synthesizer System
 ```
 You are a senior consultant. You are given two versions as equal inputs.
 Take the strongest elements from each and produce a coherent synthesis.
 This is not a compromise — pick the best answer per dimension.
 ```
 
-### Judge System Prompt
+### Judge System
 ```
 You are an independent evaluator. You have no authorship stake in any
 version. Evaluate which version best accomplishes the original task.
@@ -102,48 +114,23 @@ RANKING: [best], [second], [worst]
 Where each slot is 1, 2, or 3.
 ```
 
-## Key parameters
-
-| Parameter | Default | Notes |
-|-----------|---------|-------|
-| Author temperature | 0.8 | Higher for creative generation |
-| Judge temperature | 0.3 | Lower for consistent evaluation |
-| Number of judges | 3 | 7 converges 3× faster but costs more |
-| Convergence | 2 consecutive A wins | A = "do nothing" wins twice → done |
-| Max passes | 30 | Safety limit |
-
-## Key design decisions
-
-1. **Tiebreak: A (incumbent) wins ties** — deliberate. Without this, "tinker unnecessarily" beats "keep the known good."
-2. **Critic must not suggest fixes** — doing so contaminates B's independence.
-3. **Synthesizer input order is randomized** — avoids position bias. Shuffle which is vx vs vy.
-4. **Each judge is a fresh agent** — zero shared context between judges and authors.
-5. **Labels are shuffled per judge** — no judge sees A/B/AB in the same order.
-
-## Known results
-
-| Finding | Detail |
-|---------|--------|
-| **42/42 perfect sweep** | Haiku 3.5 + autoreason scored perfect Borda across 5 tasks; all baselines degraded below single-pass |
-| **77% vs 73%** | Sonnet 4.6 on 150 CodeContests problems (private-test), autoreason vs single-pass |
-| **40% vs 31%** | Haiku 3.5 autoreason vs best-of-6 at matched compute |
-| **Haiku 4.5: transition point** | At 60% private accuracy, autoreason's held-out gains vanish — generation-evaluation gap closed |
-| **7 judges → 3× faster convergence** | Than 3 judges; 1 judge is noisy and slow |
-| **Both B and AB necessary** | Removing either collapses the tournament (converges in 2–3 passes vs 24) |
-| **Length-controlled: 21/28 wins** | Autoreason beats 3 of 4 baselines even at matched word count |
-| **Refinement destroys weak models** | Critique-and-revise reduced Haiku 3.5 outputs by 59–70% over 15 passes |
-
 ## Pitfalls
 
 - **Token cost**: Each pass = 6–10 LLM calls. Accumulates fast on long texts.
 - **Weak judge model = noisy results**: Use the same or stronger model as the author.
+- **Judge temperature**: Keep at 0.3. Higher temps add ranking noise.
+- **Critic must not suggest fixes**: Fixes contaminate B's independence.
+- **Synthesizer input order is randomized**: Avoids position bias; the CLI shuffles which input is vx vs vy.
 - **Not for simple Q&A**: Single pass suffices for trivial tasks.
 - **Code domain uses a different flow**: For code tasks, use test-feedback analysis on failure, not 3-version tournaments.
+
+## Verification
+
+- A run converges: stdout prints "Converged at pass N (A won 2x consecutively)".
+- `autoreason_output/final_output.md` exists and differs from `initial_a.md` only when B/AB won.
+- `history.json` has one entry per pass with winner, scores, and word count.
 
 ## References
 
 - Paper: [NousResearch/autoreason](https://github.com/NousResearch/autoreason)
-- Paper PDF: [autoreason.pdf](https://github.com/NousResearch/autoreason/blob/main/paper/autoreason.pdf)
-- Experiment code: `experiments/v2/run_overnight.py` (writing tasks), `experiments/v2/run_code_overnight.py` (code tasks)
-- Ablations: `experiments/v2/run_ablations.py` (judge count, aggregation, component)
-- Statistics: `experiments/v2/compute_stats.py` (bootstrap CIs, McNemar tests)
+- Experimental results: see `references/results.md` in this skill

--- a/optional-skills/autonomous-ai-agents/autoreason/SKILL.md
+++ b/optional-skills/autonomous-ai-agents/autoreason/SKILL.md
@@ -18,6 +18,8 @@ Autoreason is a self-refinement pipeline that iteratively improves LLM outputs v
 
 It fixes the three structural failures of naive critique-and-revise: *prompt bias* (models hallucinate flaws when asked to critique), *scope creep* (outputs expand unchecked each pass), and *lack of restraint* (models never say "no changes needed").
 
+Unlike the Autoreason methodology embedded in `skills/research/research-paper-writing`, this optional skill is a general-purpose, independently installable execution entry point with a bundled runnable CLI.
+
 ## When to Use
 
 Load `/skill autoreason` when the user asks you to:
@@ -31,8 +33,8 @@ Do **not** use for: simple Q&A (a single pass suffices), high-frequency batch wo
 ## Prerequisites
 
 - Python 3.11+
-- `litellm` installed (`pip install litellm` or `uv pip install litellm`)
-- An API key for the target model (e.g. `ANTHROPIC_API_KEY`, `OPENROUTER_API_KEY`)
+- `litellm` available in the Python environment
+- An API key for the selected provider/model (e.g. `ANTHROPIC_API_KEY`, `OPENROUTER_API_KEY`)
 
 ## How to Run
 
@@ -55,8 +57,8 @@ Options: `--model` (default `anthropic/claude-sonnet-4-20250514`), `--judges` (d
 
 1. Get the task prompt and choose a model.
 2. Run the pipeline with `terminal`, e.g. `python scripts/run_autoreason.py --task '...' --model anthropic/claude-sonnet-4-20250514`.
-3. Inspect `autoreason_output/history.json` for the winner trajectory and word count per pass.
-4. Read `autoreason_output/final_output.md` and deliver it to the user.
+3. Use `read_file` on `autoreason_output/history.json` for the winner trajectory and word count per pass.
+4. Use `read_file` on `autoreason_output/final_output.md` and deliver it to the user.
 
 If the CLI is unavailable (no `litellm` or no API key), run the pipeline manually with native tools: spawn fresh Critic, Author B, Synthesizer, and Judge agents via `delegate_task` (each with no shared context), then aggregate rankings by Borda count. Prompt templates are below.
 

--- a/optional-skills/autonomous-ai-agents/autoreason/references/results.md
+++ b/optional-skills/autonomous-ai-agents/autoreason/references/results.md
@@ -1,0 +1,23 @@
+# Autoreason 论文核心结果速查
+
+## 规模缩放曲线（CodeContests private-test）
+
+- **Haiku 3.5**: 单次 ~31% → Autoreason ~40%（+9%）
+- **Haiku 4.5**: 单次 ~60% → Autoreason ~60%（~0%，转折点）
+- **Sonnet 4**: 单次 ~61% → Autoreason ~64%（+3%）
+- **Sonnet 4.6**: 单次 ~73% → Autoreason ~77%（+4%）
+
+关键洞察: Haiku 4.5 处 gain 消失——模型"生成能力"≈"评判能力"时迭代优化空间闭合。
+
+## 为什么 autoreason 有效
+
+- "不做改动"（A）是一等选项
+- 每个 agent 都是 fresh（无上下文污染）
+- 盲审 + Borda count 消除位置偏差
+- 三个独立声音而非"自己找问题自己修"
+
+## 消融实验
+
+- 去掉 B 或 AB: 收敛极快（2-3轮）但质量差
+- Judge 数量: 7 > 3 > 1
+- Borda vs Majority: Borda 更稳定

--- a/optional-skills/autonomous-ai-agents/autoreason/references/results.md
+++ b/optional-skills/autonomous-ai-agents/autoreason/references/results.md
@@ -1,23 +1,27 @@
-# Autoreason 论文核心结果速查
+# Autoreason Experimental Results
 
-## 规模缩放曲线（CodeContests private-test）
+Quick reference for the results reported in
+[NousResearch/autoreason](https://github.com/NousResearch/autoreason).
 
-- **Haiku 3.5**: 单次 ~31% → Autoreason ~40%（+9%）
-- **Haiku 4.5**: 单次 ~60% → Autoreason ~60%（~0%，转折点）
-- **Sonnet 4**: 单次 ~61% → Autoreason ~64%（+3%）
-- **Sonnet 4.6**: 单次 ~73% → Autoreason ~77%（+4%）
+## Code scaling
 
-关键洞察: Haiku 4.5 处 gain 消失——模型"生成能力"≈"评判能力"时迭代优化空间闭合。
+- **Haiku 3.5**: Autoreason reaches ~40% private-test accuracy on CodeContests.
+- **Haiku 4.5**: ~60% private-test accuracy; this is the transition point where
+  the held-out gain from Autoreason vanishes.
+- **Sonnet 4**: ~64% private-test accuracy with Autoreason.
+- **Sonnet 4.6**: ~77% private-test accuracy with Autoreason.
+- **Sonnet 4.6**: 77% Autoreason vs 73% single-pass on 150 CodeContests
+  problems.
+- **Haiku 3.5**: 40% Autoreason vs 31% best-of-6 sampling at matched compute
+  (150 problems).
 
-## 为什么 autoreason 有效
+## Writing / ablations
 
-- "不做改动"（A）是一等选项
-- 每个 agent 都是 fresh（无上下文污染）
-- 盲审 + Borda count 消除位置偏差
-- 三个独立声音而非"自己找问题自己修"
-
-## 消融实验
-
-- 去掉 B 或 AB: 收敛极快（2-3轮）但质量差
-- Judge 数量: 7 > 3 > 1
-- Borda vs Majority: Borda 更稳定
+- **Haiku 3.5 + Autoreason**: 42/42 perfect Borda across 3 tasks; all
+  baselines degraded below single-pass.
+- **Judge count**: 7 judges converge about 3× faster than 3 judges; 1 judge
+  is noisy and slow.
+- **Component necessity**: removing either B or AB collapses the tournament /
+  causes premature convergence.
+- **Design choices**: incumbent A as a first-class option and a conservative
+  A-favored tiebreak are central to the method.

--- a/optional-skills/autonomous-ai-agents/autoreason/scripts/run_autoreason.py
+++ b/optional-skills/autonomous-ai-agents/autoreason/scripts/run_autoreason.py
@@ -1,0 +1,424 @@
+#!/usr/bin/env python3
+"""
+Autoreason: Self-Refinement That Knows When to Stop
+
+A standalone CLI tool implementing the autoreason pipeline from
+NousResearch/autoreason (SHL0MS, 2026).
+
+Usage:
+    python run_autoreason.py --task "Your task prompt here"
+    python run_autoreason.py --task "Write a go-to-market strategy" --model openrouter/anthropic/claude-sonnet-4-20250514 --judges 3
+    python run_autoreason.py --file task_prompt.txt --output ./my_results
+
+Requires: litellm, and API keys in environment (e.g. ANTHROPIC_API_KEY, OPENROUTER_API_KEY)
+"""
+
+import argparse
+import asyncio
+import json
+import os
+import random
+import sys
+import time
+from pathlib import Path
+
+
+# ── Defaults ──────────────────────────────────────────────────────────────
+DEFAULT_MODEL = "anthropic/claude-sonnet-4-20250514"
+DEFAULT_AUTHOR_TEMP = 0.8
+DEFAULT_JUDGE_TEMP = 0.3
+DEFAULT_MAX_TOKENS = 4096
+DEFAULT_NUM_JUDGES = 3
+DEFAULT_CONVERGENCE = 2  # A must win this many consecutive times
+DEFAULT_MAX_PASSES = 30
+DEFAULT_OUTPUT_DIR = "autoreason_output"
+
+
+# ── Prompt templates (from paper experiments) ─────────────────────────────
+AUTHOR_SYSTEM = (
+    "You are a senior consultant producing professional deliverables. "
+    "Be specific, concrete, and practical. Avoid generic advice. "
+    "Tailor everything to the constraints stated in the task."
+)
+
+CRITIC_SYSTEM = (
+    "You are a critical reviewer. Your only job is to find real problems. "
+    "Be specific and concrete. Do not suggest fixes."
+)
+
+AUTHOR_B_SYSTEM = (
+    "You are a senior consultant revising a proposal based on specific criticisms. "
+    "Address each valid criticism directly. Do not make changes that aren't "
+    "motivated by an identified problem."
+)
+
+SYNTHESIZER_SYSTEM = (
+    "You are a senior consultant. You are given two versions as equal inputs. "
+    "Take the strongest elements from each and produce a coherent synthesis. "
+    "This is not a compromise — pick the best answer per dimension."
+)
+
+JUDGE_SYSTEM = (
+    "You are an independent evaluator. You have no authorship stake in any "
+    "version. Evaluate which version best accomplishes the original task."
+)
+
+GENERATE_A = "{task_prompt}\n\nProduce a complete, detailed proposal."
+
+CRITIC_PROMPT = """Here is a proposal:
+
+---
+{version_a}
+---
+
+Find real problems with this proposal. Focus on:
+- Things that won't work as described
+- Complexity that doesn't pay for itself
+- Assumptions that are wrong
+- Missing pieces that block the design
+
+Do NOT propose fixes. Just the problems."""
+
+AUTHOR_B_PROMPT = """ORIGINAL TASK:
+---
+{task_prompt}
+---
+
+Here is a proposal and the problems identified with it.
+
+CURRENT PROPOSAL:
+---
+{version_a}
+---
+
+PROBLEMS FOUND:
+---
+{critic}
+---
+
+Revise the proposal to address these problems.
+For each change, state which problem it fixes.
+Do not make changes that aren't motivated by an identified problem."""
+
+SYNTHESIZER_PROMPT = """ORIGINAL TASK:
+---
+{task_prompt}
+---
+
+Here are two versions of a proposal. Treat them as equal inputs.
+
+VERSION {vx_label}:
+---
+{version_x}
+---
+
+VERSION {vy_label}:
+---
+{version_y}
+---
+
+Produce a synthesis that keeps the strongest elements from both.
+Pick the best version of each section and make them cohere."""
+
+JUDGE_RANK_3_PROMPT = """ORIGINAL TASK:
+---
+{task_prompt}
+---
+
+Three proposals have been produced independently. Evaluate how well each accomplishes the stated task.
+
+{judge_proposals}
+
+For each proposal, state what it gets right and what it gets wrong.
+Then rank all three from best to worst:
+
+RANKING: [best], [second], [worst]
+
+Where each slot is 1, 2, or 3."""
+
+
+# ── LLM wrapper (paper's retry/rate-limit logic) ──────────────────────────
+async def call_llm(system: str, user: str, model: str, temperature: float,
+                   max_tokens: int, max_retries: int = 8) -> str:
+    """Call LLM with exponential backoff rate-limit handling (from paper code)."""
+    import litellm
+    litellm.suppress_debug_info = True
+
+    for attempt in range(max_retries):
+        try:
+            response = await litellm.acompletion(
+                model=model,
+                messages=[
+                    {"role": "system", "content": system},
+                    {"role": "user", "content": user},
+                ],
+                temperature=temperature,
+                max_tokens=max_tokens,
+            )
+            return response.choices[0].message.content
+        except Exception as e:
+            err = str(e).lower()
+            if "rate" in err or "429" in err or "overloaded" in err or "529" in err:
+                wait = min((2 ** attempt) * 5, 120)
+                print(f"      [Rate limited, retry {attempt+1}/{max_retries} in {wait}s]")
+                await asyncio.sleep(wait)
+            else:
+                if attempt < max_retries - 1:
+                    wait = 10
+                    print(f"      [Error: {str(e)[:80]}, retry in {wait}s]")
+                    await asyncio.sleep(wait)
+                else:
+                    raise
+    raise RuntimeError(f"Failed after {max_retries} retries")
+
+
+# ── Judging helpers ───────────────────────────────────────────────────────
+def randomize_for_judge(va: str, vb: str, vab: str) -> tuple[str, dict]:
+    """Randomly shuffle A, B, AB so judges see them blind. Returns (formatted, order_map)."""
+    versions = [("A", va), ("B", vb), ("AB", vab)]
+    random.shuffle(versions)
+    order = {}
+    parts = []
+    for i, (label, content) in enumerate(versions, 1):
+        order[str(i)] = label
+        parts.append(f"PROPOSAL {i}:\n---\n{content}\n---")
+    return "\n\n".join(parts), order
+
+
+def parse_ranking(text: str, valid_chars: str = "123") -> list[str] | None:
+    """Parse 'RANKING: [best], [second], [worst]' from judge output."""
+    for line in reversed(text.split("\n")):
+        line = line.strip().strip("*").strip().lstrip("#").strip()
+        if line.upper().startswith("RANKING:"):
+            raw = line.split(":", 1)[1].strip()
+            items = [c for c in raw if c in valid_chars]
+            if len(items) >= 2:
+                return items
+    return None
+
+
+def aggregate_rankings(rankings: list[list[str] | None],
+                       labels: list[str],
+                       tiebreak_winner: str | None = None) -> tuple[str, dict, int]:
+    """Borda count: each judge allocates (n-pos) points. Returns (winner, scores, valid_count)."""
+    scores = {l: 0 for l in labels}
+    n = len(labels)
+    valid = [r for r in rankings if r is not None]
+    for ranking in valid:
+        for pos, label in enumerate(ranking):
+            if label in scores and pos < n:
+                scores[label] += (n - pos)
+    if tiebreak_winner:
+        priority = {l: (0 if l == tiebreak_winner else i+1) for i, l in enumerate(labels)}
+    else:
+        priority = {l: i for i, l in enumerate(labels)}
+    ranked = sorted(scores.keys(), key=lambda k: (-scores[k], priority[k]))
+    return ranked[0], scores, len(valid)
+
+
+# ── Autoreason pass ───────────────────────────────────────────────────────
+async def run_autoreason_pass(task_prompt: str, current_a: str, pass_num: int,
+                               pass_dir: Path, model: str, author_temp: float,
+                               judge_temp: float, max_tokens: int,
+                               num_judges: int) -> tuple[str, str, dict]:
+    """Single autoreason iteration: Critic → Author B → Synthesizer → Judge panel."""
+    pass_dir.mkdir(parents=True, exist_ok=True)
+
+    t0 = time.time()
+
+    # Save incumbent
+    (pass_dir / "version_a.md").write_text(current_a)
+
+    # 1. Critic
+    print(f"    [Pass {pass_num}] Critic...", end=" ", flush=True)
+    critic = await call_llm(CRITIC_SYSTEM, CRITIC_PROMPT.format(
+        version_a=current_a), model, author_temp, max_tokens)
+    (pass_dir / "critic.md").write_text(critic)
+    print(f"ok")
+
+    # 2. Author B (revision)
+    print(f"    [Pass {pass_num}] Author B...", end=" ", flush=True)
+    vb = await call_llm(AUTHOR_B_SYSTEM, AUTHOR_B_PROMPT.format(
+        task_prompt=task_prompt, version_a=current_a, critic=critic),
+        model, author_temp, max_tokens)
+    (pass_dir / "version_b.md").write_text(vb)
+    print(f"ok")
+
+    # 3. Synthesizer (AB) — randomize input order to avoid position bias
+    print(f"    [Pass {pass_num}] Synthesizer...", end=" ", flush=True)
+    if random.random() < 0.5:
+        vx_label, vx, vy_label, vy = "X", current_a, "Y", vb
+    else:
+        vx_label, vx, vy_label, vy = "X", vb, "Y", current_a
+    vab = await call_llm(SYNTHESIZER_SYSTEM, SYNTHESIZER_PROMPT.format(
+        task_prompt=task_prompt, vx_label=vx_label, version_x=vx,
+        vy_label=vy_label, version_y=vy),
+        model, author_temp, max_tokens)
+    (pass_dir / "version_ab.md").write_text(vab)
+    print(f"ok")
+
+    # 4. Judge panel
+    print(f"    [Pass {pass_num}] Judges ({num_judges}x)...", end=" ", flush=True)
+    jtasks, jorders = [], []
+    for _ in range(num_judges):
+        proposals, order = randomize_for_judge(current_a, vb, vab)
+        jorders.append(order)
+        jtasks.append(call_llm(
+            JUDGE_SYSTEM,
+            JUDGE_RANK_3_PROMPT.format(task_prompt=task_prompt, judge_proposals=proposals),
+            model, judge_temp, max_tokens))
+
+    jresps = await asyncio.gather(*jtasks, return_exceptions=True)
+    rankings, jdetails = [], []
+    for j, (resp, order) in enumerate(zip(jresps, jorders)):
+        if isinstance(resp, Exception):
+            rankings.append(None)
+            jdetails.append({"error": str(resp)})
+        else:
+            raw_ranking = parse_ranking(resp, "123")
+            mapped = [order.get(r, r) for r in raw_ranking] if raw_ranking else None
+            rankings.append(mapped)
+            jdetails.append({"ranking": mapped, "order": order})
+
+    winner, scores, valid = aggregate_rankings(rankings, ["A", "B", "AB"], tiebreak_winner="A")
+    elapsed = time.time() - t0
+
+    vmap = {"A": current_a, "B": vb, "AB": vab}
+    result = {
+        "pass": pass_num, "winner": winner, "scores": scores,
+        "valid_judges": valid, "elapsed": round(elapsed, 1),
+        "judge_details": jdetails,
+    }
+    (pass_dir / "result.json").write_text(json.dumps(result, indent=2, ensure_ascii=False))
+    print(f"Winner: {winner} (A={scores.get('A',0)}, B={scores.get('B',0)}, AB={scores.get('AB',0)}) [{elapsed:.0f}s]")
+    return winner, vmap[winner], result
+
+
+# ── Full autoreason run ───────────────────────────────────────────────────
+async def run_autoreason(task_prompt: str, output_dir: Path,
+                          model: str = DEFAULT_MODEL,
+                          author_temp: float = DEFAULT_AUTHOR_TEMP,
+                          judge_temp: float = DEFAULT_JUDGE_TEMP,
+                          max_tokens: int = DEFAULT_MAX_TOKENS,
+                          num_judges: int = DEFAULT_NUM_JUDGES,
+                          convergence: int = DEFAULT_CONVERGENCE,
+                          max_passes: int = DEFAULT_MAX_PASSES) -> tuple[str, list[dict]]:
+    """Run the full autoreason pipeline until convergence or max passes."""
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    # Phase 1: Initial generation
+    print(f"\n  Generating initial version A...", end=" ", flush=True)
+    current_a = await call_llm(AUTHOR_SYSTEM, GENERATE_A.format(
+        task_prompt=task_prompt), model, author_temp, max_tokens)
+    (output_dir / "initial_a.md").write_text(current_a)
+    print(f"{len(current_a.split())} words\n")
+
+    # Phase 2: Iterative refinement
+    streak = 0
+    history = []
+    for p in range(1, max_passes + 1):
+        pass_dir = output_dir / f"pass_{p:02d}"
+        winner, winner_text, result = await run_autoreason_pass(
+            task_prompt, current_a, p, pass_dir, model,
+            author_temp, judge_temp, max_tokens, num_judges)
+
+        entry = {
+            "pass": p, "winner": winner,
+            "scores": result.get("scores", {}),
+            "words": len(winner_text.split()),
+            "elapsed": result.get("elapsed", 0),
+        }
+        history.append(entry)
+
+        if winner == "A":
+            streak += 1
+        else:
+            streak = 0
+            current_a = winner_text
+            (output_dir / f"incumbent_after_{p:02d}.md").write_text(current_a)
+
+        if streak >= convergence:
+            print(f"\n  ✔ Converged at pass {p} (A won {convergence}x consecutively)")
+            break
+
+    # Final output
+    (output_dir / "final_output.md").write_text(current_a)
+    (output_dir / "history.json").write_text(json.dumps(history, indent=2))
+
+    trajectory = " → ".join(h["winner"] for h in history)
+    print(f"\n  Final: {len(current_a.split())} words")
+    print(f"  Trajectory: {trajectory}")
+    return current_a, history
+
+
+# ── CLI ───────────────────────────────────────────────────────────────────
+def main():
+    parser = argparse.ArgumentParser(
+        description="Autoreason: Self-Refinement That Knows When to Stop",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  %(prog)s --task "Write a go-to-market strategy for a developer tool"
+  %(prog)s --file task_prompt.txt --model openrouter/anthropic/claude-sonnet-4-20250514
+  %(prog)s --task "Design an API" --judges 7 --max-passes 20 --output ./results
+
+Based on NousResearch/autoreason by SHL0MS (2026).
+        """,
+    )
+    parser.add_argument("--task", type=str, help="Task prompt (inline)")
+    parser.add_argument("--file", type=str, help="Task prompt file path")
+    parser.add_argument("--model", type=str, default=DEFAULT_MODEL,
+                        help=f"LLM model (default: {DEFAULT_MODEL})")
+    parser.add_argument("--author-temp", type=float, default=DEFAULT_AUTHOR_TEMP,
+                        help=f"Author temperature (default: {DEFAULT_AUTHOR_TEMP})")
+    parser.add_argument("--judge-temp", type=float, default=DEFAULT_JUDGE_TEMP,
+                        help=f"Judge temperature (default: {DEFAULT_JUDGE_TEMP})")
+    parser.add_argument("--max-tokens", type=int, default=DEFAULT_MAX_TOKENS,
+                        help=f"Max tokens per call (default: {DEFAULT_MAX_TOKENS})")
+    parser.add_argument("--judges", type=int, default=DEFAULT_NUM_JUDGES,
+                        help=f"Number of judges per pass (default: {DEFAULT_NUM_JUDGES})")
+    parser.add_argument("--convergence", type=int, default=DEFAULT_CONVERGENCE,
+                        help=f"Consecutive A wins to converge (default: {DEFAULT_CONVERGENCE})")
+    parser.add_argument("--max-passes", type=int, default=DEFAULT_MAX_PASSES,
+                        help=f"Max iterations (default: {DEFAULT_MAX_PASSES})")
+    parser.add_argument("--output", type=str, default=DEFAULT_OUTPUT_DIR,
+                        help=f"Output directory (default: {DEFAULT_OUTPUT_DIR})")
+    parser.add_argument("--quiet", "-q", action="store_true", help="Less verbose output")
+
+    args = parser.parse_args()
+
+    if not args.task and not args.file:
+        parser.error("Either --task or --file is required")
+
+    task_prompt = args.task if args.task else Path(args.file).read_text().strip()
+
+    output_dir = Path(args.output)
+    print(f"\n{'='*60}")
+    print(f"  Autoreason: Self-Refinement That Knows When to Stop")
+    print(f"  Model: {args.model}")
+    print(f"  Judges: {args.judges} per pass, convergence: {args.convergence}x A win")
+    print(f"  Max passes: {args.max_passes}")
+    print(f"  Output: {output_dir.absolute()}")
+    print(f"{'='*60}\n")
+
+    start = time.time()
+    asyncio.run(run_autoreason(
+        task_prompt=task_prompt,
+        output_dir=output_dir,
+        model=args.model,
+        author_temp=args.author_temp,
+        judge_temp=args.judge_temp,
+        max_tokens=args.max_tokens,
+        num_judges=args.judges,
+        convergence=args.convergence,
+        max_passes=args.max_passes,
+    ))
+    elapsed = time.time() - start
+    print(f"\n{'='*60}")
+    print(f"  Done in {elapsed/60:.1f} minutes")
+    print(f"  Results: {output_dir.absolute()}")
+    print(f"{'='*60}")
+
+
+if __name__ == "__main__":
+    main()

--- a/optional-skills/autonomous-ai-agents/autoreason/scripts/run_autoreason.py
+++ b/optional-skills/autonomous-ai-agents/autoreason/scripts/run_autoreason.py
@@ -18,6 +18,7 @@ import asyncio
 import json
 import os
 import random
+import re
 import sys
 import time
 from pathlib import Path
@@ -138,11 +139,23 @@ Where each slot is 1, 2, or 3."""
 
 
 # ── LLM wrapper (paper's retry/rate-limit logic) ──────────────────────────
+_LITELLM = None
+
+
+def _get_litellm():
+    """Lazily import litellm and configure debug suppression exactly once."""
+    global _LITELLM
+    if _LITELLM is None:
+        import litellm
+        litellm.suppress_debug_info = True
+        _LITELLM = litellm
+    return _LITELLM
+
+
 async def call_llm(system: str, user: str, model: str, temperature: float,
                    max_tokens: int, max_retries: int = 8) -> str:
     """Call LLM with exponential backoff rate-limit handling (from paper code)."""
-    import litellm
-    litellm.suppress_debug_info = True
+    litellm = _get_litellm()
 
     for attempt in range(max_retries):
         try:
@@ -186,15 +199,35 @@ def randomize_for_judge(va: str, vb: str, vab: str) -> tuple[str, dict]:
 
 
 def parse_ranking(text: str, valid_chars: str = "123") -> list[str] | None:
-    """Parse 'RANKING: [best], [second], [worst]' from judge output."""
+    """Parse 'RANKING: [best], [second], [worst]' from judge output.
+
+    Returns a complete permutation of ``valid_chars`` (e.g. ``["2", "1", "3"]``).
+    Truncated, duplicate, missing, or unexpected labels return ``None``.
+    """
     for line in reversed(text.split("\n")):
         line = line.strip().strip("*").strip().lstrip("#").strip()
         if line.upper().startswith("RANKING:"):
             raw = line.split(":", 1)[1].strip()
-            items = [c for c in raw if c in valid_chars]
-            if len(items) >= 2:
-                return items
+            items = re.findall(r"\d+", raw)
+            if len(items) != len(valid_chars):
+                return None
+            if any(len(item) != 1 or item not in valid_chars for item in items):
+                return None
+            if sorted(items) != sorted(valid_chars):
+                return None
+            return items
     return None
+
+
+def _is_valid_ballot(ranking: list[str] | None, labels: list[str]) -> bool:
+    """A ballot is valid only if it is a complete permutation of ``labels``."""
+    if ranking is None:
+        return False
+    if len(ranking) != len(labels):
+        return False
+    if len(set(ranking)) != len(labels):
+        return False
+    return set(ranking) == set(labels)
 
 
 def aggregate_rankings(rankings: list[list[str] | None],
@@ -203,11 +236,10 @@ def aggregate_rankings(rankings: list[list[str] | None],
     """Borda count: each judge allocates (n-pos) points. Returns (winner, scores, valid_count)."""
     scores = {l: 0 for l in labels}
     n = len(labels)
-    valid = [r for r in rankings if r is not None]
+    valid = [r for r in rankings if _is_valid_ballot(r, labels)]
     for ranking in valid:
         for pos, label in enumerate(ranking):
-            if label in scores and pos < n:
-                scores[label] += (n - pos)
+            scores[label] += (n - pos)
     if tiebreak_winner:
         priority = {l: (0 if l == tiebreak_winner else i+1) for i, l in enumerate(labels)}
     else:
@@ -383,7 +415,6 @@ Based on NousResearch/autoreason by SHL0MS (2026).
                         help=f"Max iterations (default: {DEFAULT_MAX_PASSES})")
     parser.add_argument("--output", type=str, default=DEFAULT_OUTPUT_DIR,
                         help=f"Output directory (default: {DEFAULT_OUTPUT_DIR})")
-    parser.add_argument("--quiet", "-q", action="store_true", help="Less verbose output")
 
     args = parser.parse_args()
 

--- a/tests/skills/test_autoreason_skill.py
+++ b/tests/skills/test_autoreason_skill.py
@@ -1,0 +1,156 @@
+"""
+Smoke tests for the autoreason optional skill.
+
+We can't actually run the autoreason loop in CI (it needs network + a paid LLM),
+so these tests verify:
+  - SKILL.md frontmatter conforms to the hardline format
+  - the shipped script parses as valid Python and is referenced correctly
+  - the core pure functions (ranking parsing, Borda aggregation, blind shuffle)
+    behave as documented
+"""
+from __future__ import annotations
+
+import ast
+import importlib.util
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+SKILL_DIR = Path(__file__).resolve().parents[2] / "optional-skills" / "autonomous-ai-agents" / "autoreason"
+SCRIPT = SKILL_DIR / "scripts" / "run_autoreason.py"
+
+
+@pytest.fixture(scope="module")
+def frontmatter() -> dict:
+    src = (SKILL_DIR / "SKILL.md").read_text()
+    m = re.search(r"^---\n(.*?)\n---", src, re.DOTALL)
+    assert m, "SKILL.md missing YAML frontmatter"
+    return yaml.safe_load(m.group(1))
+
+
+@pytest.fixture(scope="module")
+def mod():
+    """Load scripts/run_autoreason.py without executing any LLM call."""
+    spec = importlib.util.spec_from_file_location("autoreason_cli", SCRIPT)
+    assert spec is not None and spec.loader is not None, "cannot load scripts/run_autoreason.py"
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_skill_dir_exists() -> None:
+    assert SKILL_DIR.is_dir(), f"missing skill dir: {SKILL_DIR}"
+
+
+def test_skill_md_present() -> None:
+    assert (SKILL_DIR / "SKILL.md").is_file()
+
+
+def test_description_under_60_chars(frontmatter) -> None:
+    desc = frontmatter["description"]
+    assert len(desc) <= 60, f"description is {len(desc)} chars (hardline ≤60): {desc!r}"
+    assert desc.rstrip().endswith("."), "description must end with a period"
+
+
+def test_name_matches_dir(frontmatter) -> None:
+    assert frontmatter["name"] == "autoreason"
+
+
+def test_author_credits_contributor(frontmatter) -> None:
+    author = frontmatter["author"]
+    assert "Xinyu Du" in author, f"author should credit the human contributor first: {author!r}"
+    assert "@Starfie1d1272" in author, "author should include the GitHub handle"
+
+
+def test_author_retains_upstream(frontmatter) -> None:
+    assert "SHL0MS" in frontmatter["author"], "upstream SHL0MS attribution must be retained"
+
+
+def test_license_mit(frontmatter) -> None:
+    assert frontmatter["license"] == "MIT"
+
+
+def test_platforms_include_major(frontmatter) -> None:
+    # Pure-Python CLI over litellm — no POSIX-only primitives.
+    assert set(frontmatter["platforms"]) >= {"linux", "macos", "windows"}
+
+
+def test_script_exists() -> None:
+    assert SCRIPT.is_file(), "scripts/run_autoreason.py must ship with the skill"
+
+
+def test_script_parses() -> None:
+    ast.parse(SCRIPT.read_text())  # raises SyntaxError on broken Python
+
+
+def test_skill_documents_script_path() -> None:
+    src = (SKILL_DIR / "SKILL.md").read_text()
+    assert "scripts/run_autoreason.py" in src, "SKILL.md must reference the shipped script"
+    assert "terminal" in src, "SKILL.md must drive the CLI via the native `terminal` tool"
+
+
+def test_skill_has_modern_sections() -> None:
+    src = (SKILL_DIR / "SKILL.md").read_text()
+    for section in ["## When to Use", "## Prerequisites", "## How to Run",
+                    "## Procedure", "## Pitfalls", "## Verification"]:
+        assert section in src, f"SKILL.md missing required section {section}"
+
+
+# ── Core pure-function behavior ────────────────────────────────────────────
+
+def test_parse_ranking_extracts_order(mod) -> None:
+    text = "Proposal 2 is strongest.\nRANKING: 2, 1, 3"
+    assert mod.parse_ranking(text) == ["2", "1", "3"]
+
+
+def test_parse_ranking_ignores_suffix_noise(mod) -> None:
+    text = "RANKING: [3], [1], [2] (ordered by fit)"
+    assert mod.parse_ranking(text) == ["3", "1", "2"]
+
+
+def test_parse_ranking_missing_returns_none(mod) -> None:
+    assert mod.parse_ranking("No ranking given here") is None
+
+
+def test_borda_aggregation_picks_top(mod) -> None:
+    rankings = [["A", "B", "AB"], ["A", "AB", "B"]]
+    winner, scores, valid = mod.aggregate_rankings(rankings, ["A", "B", "AB"], tiebreak_winner="A")
+    assert winner == "A"
+    assert scores["A"] > scores["B"] and scores["A"] > scores["AB"]
+    assert valid == 2
+
+
+def test_borda_tiebreak_prefers_incumbent(mod) -> None:
+    # One judge ranks B first, the other ranks A first → tied scores, A must win.
+    rankings = [["B", "A", "AB"], ["A", "B", "AB"]]
+    winner, scores, _ = mod.aggregate_rankings(rankings, ["A", "B", "AB"], tiebreak_winner="A")
+    assert scores["A"] == scores["B"]
+    assert winner == "A", "tiebreak must prefer the incumbent"
+
+
+def test_borda_ignores_malformed_judges(mod) -> None:
+    rankings = [["A", "B", "AB"], None, ["AB", "A", "B"]]
+    winner, _, valid = mod.aggregate_rankings(rankings, ["A", "B", "AB"], tiebreak_winner="A")
+    assert valid == 2
+    assert winner in {"A", "AB"}
+
+
+def test_blind_shuffle_permutes_labels(mod) -> None:
+    for _ in range(20):
+        _, order = mod.randomize_for_judge("va", "vb", "vab")
+        assert sorted(order.values()) == ["A", "AB", "B"]
+        assert set(order) == {"1", "2", "3"}
+
+
+def test_script_does_not_import_litellm_at_top_level(mod) -> None:
+    """Top-level import must stay stdlib-only so CI can load the module."""
+    tree = ast.parse(SCRIPT.read_text())
+    top_imports = []
+    for node in tree.body:
+        if isinstance(node, (ast.Import, ast.ImportFrom)):
+            names = [a.name.split(".")[0] for a in node.names] if isinstance(node, ast.Import) \
+                else [node.module.split(".")[0] if node.module else ""]
+            top_imports.extend(names)
+    assert "litellm" not in top_imports, "litellm must be imported lazily inside call_llm()"

--- a/tests/skills/test_autoreason_skill.py
+++ b/tests/skills/test_autoreason_skill.py
@@ -16,18 +16,33 @@ import re
 from pathlib import Path
 
 import pytest
-import yaml
 
 SKILL_DIR = Path(__file__).resolve().parents[2] / "optional-skills" / "autonomous-ai-agents" / "autoreason"
 SCRIPT = SKILL_DIR / "scripts" / "run_autoreason.py"
 
 
+def _frontmatter_field(src: str, key: str) -> str:
+    match = re.search(rf"^{key}:\s*(.+)$", src, re.MULTILINE)
+    assert match, f"SKILL.md missing frontmatter field {key!r}"
+    return match.group(1).strip()
+
+
+def _frontmatter_platforms(src: str) -> list[str]:
+    match = re.search(r"^platforms:\s*\[(.*)\]$", src, re.MULTILINE)
+    assert match, "SKILL.md missing platforms frontmatter list"
+    return [item.strip() for item in match.group(1).split(",") if item.strip()]
+
+
 @pytest.fixture(scope="module")
 def frontmatter() -> dict:
     src = (SKILL_DIR / "SKILL.md").read_text()
-    m = re.search(r"^---\n(.*?)\n---", src, re.DOTALL)
-    assert m, "SKILL.md missing YAML frontmatter"
-    return yaml.safe_load(m.group(1))
+    return {
+        "name": _frontmatter_field(src, "name"),
+        "description": _frontmatter_field(src, "description"),
+        "author": _frontmatter_field(src, "author"),
+        "license": _frontmatter_field(src, "license"),
+        "platforms": _frontmatter_platforms(src),
+    }
 
 
 @pytest.fixture(scope="module")
@@ -91,10 +106,16 @@ def test_skill_documents_script_path() -> None:
     assert "terminal" in src, "SKILL.md must drive the CLI via the native `terminal` tool"
 
 
+def test_skill_documents_native_read_file() -> None:
+    src = (SKILL_DIR / "SKILL.md").read_text()
+    assert "read_file" in src, "SKILL.md must use native `read_file` for result files"
+
+
 def test_skill_has_modern_sections() -> None:
     src = (SKILL_DIR / "SKILL.md").read_text()
     for section in ["## When to Use", "## Prerequisites", "## How to Run",
-                    "## Procedure", "## Pitfalls", "## Verification"]:
+                    "## Quick Reference", "## Procedure", "## Pitfalls",
+                    "## Verification"]:
         assert section in src, f"SKILL.md missing required section {section}"
 
 
@@ -114,6 +135,18 @@ def test_parse_ranking_missing_returns_none(mod) -> None:
     assert mod.parse_ranking("No ranking given here") is None
 
 
+def test_parse_ranking_truncated_returns_none(mod) -> None:
+    assert mod.parse_ranking("RANKING: 2, 1") is None
+
+
+def test_parse_ranking_duplicate_returns_none(mod) -> None:
+    assert mod.parse_ranking("RANKING: 1, 1, 2") is None
+
+
+def test_parse_ranking_unexpected_label_returns_none(mod) -> None:
+    assert mod.parse_ranking("RANKING: 2, 1, 4") is None
+
+
 def test_borda_aggregation_picks_top(mod) -> None:
     rankings = [["A", "B", "AB"], ["A", "AB", "B"]]
     winner, scores, valid = mod.aggregate_rankings(rankings, ["A", "B", "AB"], tiebreak_winner="A")
@@ -130,11 +163,39 @@ def test_borda_tiebreak_prefers_incumbent(mod) -> None:
     assert winner == "A", "tiebreak must prefer the incumbent"
 
 
-def test_borda_ignores_malformed_judges(mod) -> None:
+def test_borda_ignores_none_ballot(mod) -> None:
     rankings = [["A", "B", "AB"], None, ["AB", "A", "B"]]
     winner, _, valid = mod.aggregate_rankings(rankings, ["A", "B", "AB"], tiebreak_winner="A")
     assert valid == 2
     assert winner in {"A", "AB"}
+
+
+def test_borda_ignores_truncated_ballot(mod) -> None:
+    rankings = [["A", "B", "AB"], ["A", "B"]]
+    winner, _, valid = mod.aggregate_rankings(rankings, ["A", "B", "AB"], tiebreak_winner="A")
+    assert valid == 1
+    assert winner == "A"
+
+
+def test_borda_ignores_duplicate_ballot(mod) -> None:
+    rankings = [["A", "B", "AB"], ["A", "A", "B"]]
+    winner, _, valid = mod.aggregate_rankings(rankings, ["A", "B", "AB"], tiebreak_winner="A")
+    assert valid == 1
+    assert winner == "A"
+
+
+def test_borda_ignores_unknown_label_ballot(mod) -> None:
+    rankings = [["A", "B", "AB"], ["A", "B", "X"]]
+    winner, _, valid = mod.aggregate_rankings(rankings, ["A", "B", "AB"], tiebreak_winner="A")
+    assert valid == 1
+    assert winner == "A"
+
+
+def test_borda_invalid_ballots_do_not_score(mod) -> None:
+    malformed = [None, ["A", "B"], ["A", "A", "B"], ["A", "B", "X"]]
+    _, scores, valid = mod.aggregate_rankings(malformed, ["A", "B", "AB"], tiebreak_winner="A")
+    assert valid == 0
+    assert all(score == 0 for score in scores.values())
 
 
 def test_blind_shuffle_permutes_labels(mod) -> None:


### PR DESCRIPTION
## Summary

Adds Autoreason as an optional, general-purpose self-refinement skill in the `autonomous-ai-agents` category. The bundled CLI implements the A/B/AB blind-Borda loop from [NousResearch/autoreason](https://github.com/NousResearch/autoreason).

Unlike the existing `skills/research/research-paper-writing` Autoreason methodology section, this PR provides a standalone install target and a runnable execution path.

## What this adds

- `optional-skills/autonomous-ai-agents/autoreason/SKILL.md`
- `optional-skills/autonomous-ai-agents/autoreason/references/results.md`
- `optional-skills/autonomous-ai-agents/autoreason/scripts/run_autoreason.py`
- `tests/skills/test_autoreason_skill.py`

## Current review fixes

- Strict complete/permutation judge-ballot validation (`parse_ranking` rejects truncated, duplicate, missing, or unexpected labels)
- Defensive Borda validation (`aggregate_rankings` excludes malformed ballots from scoring and `valid_count`)
- Removed dead `--quiet` CLI flag
- One-time lazy `litellm` setup via `_get_litellm()`
- English, source-aligned experimental results in `references/results.md`
- Stdlib + pytest-only skill tests (no PyYAML dependency)
- Refreshed onto current `main`

## Scope

- No Hermes core changes
- No network tests
- No new package-manifest dependency
- Existing `research-paper-writing` skill unchanged

## Validation

- `scripts/run_tests.sh tests/skills/test_autoreason_skill.py -q` → 28 passed, 0 failed
- `python -m py_compile optional-skills/autonomous-ai-agents/autoreason/scripts/run_autoreason.py` → passed
- `git diff --check` → passed
- `ruff check` on the changed Python files → passed

## Install

```bash
hermes skills install official/autonomous-ai-agents/autoreason
```
