### PR TITLE
fix(computer-use): skip capture_after when action failed (ok=False) (#22749)

### DIFF
--- a/tests/tools/test_computer_use.py
+++ b/tests/tools/test_computer_use.py
@@ -240,6 +240,39 @@ class TestDispatch:
         out = handle_computer_use({"action": "set_value"})
         parsed = json.loads(out)
         assert "error" in parsed
+    def test_capture_after_skipped_when_action_failed(self, noop_backend):
+        """capture_after must not fire when res.ok=False (regression guard).
+
+        A follow-up screenshot after a failed action shows the screen in a
+        normal state, misleading the model into thinking the action succeeded.
+        """
+        from unittest.mock import patch
+        from tools.computer_use.backend import ActionResult
+        from tools.computer_use.tool import handle_computer_use
+
+        # Make click() return a failure.
+        with patch.object(noop_backend, "click",
+                          return_value=ActionResult(ok=False, action="click",
+                                                    message="element not found")):
+            out = handle_computer_use({"action": "click", "element": 99,
+                                       "capture_after": True})
+
+        parsed = json.loads(out)
+        # Should return the error, not a multimodal capture.
+        assert parsed.get("ok") is False
+        assert parsed.get("action") == "click"
+        # No follow-up capture should have been issued.
+        capture_calls = [c for c in noop_backend.calls if c[0] == "capture"]
+        assert len(capture_calls) == 0, "capture must not be called after a failed action"
+
+    def test_capture_after_fires_when_action_succeeds(self, noop_backend):
+        """capture_after must trigger for successful actions."""
+        from tools.computer_use.tool import handle_computer_use
+        out = handle_computer_use({"action": "click", "element": 1,
+                                   "capture_after": True})
+        # Noop backend returns ok=True, so capture should have been called.
+        capture_calls = [c for c in noop_backend.calls if c[0] == "capture"]
+        assert len(capture_calls) == 1
 
 
 # ---------------------------------------------------------------------------

--- a/tools/computer_use/tool.py
+++ b/tools/computer_use/tool.py
@@ -675,6 +675,11 @@ def _maybe_follow_capture(
 ) -> Any:
     if not do_capture:
         return _text_response(res)
+    # Skip the follow-up capture when the action itself failed: showing a
+    # normal-looking screenshot after a failure misleads the model into thinking
+    # the action succeeded. Return the error text instead.
+    if not res.ok:
+        return _text_response(res)
     try:
         # Preserve the app context established by the preceding capture/focus_app so
         # that capture_after=True re-captures the same app rather than the frontmost


### PR DESCRIPTION
Salvages #22749 onto current main. Closes a misleading-feedback bug in `computer_use(capture_after=True)`.

## The problem
`_maybe_follow_capture()` in `tools/computer_use/tool.py` always performed a follow-up screenshot when `capture_after=True`, even when the action itself failed (`res.ok=False`). The model received a normal-looking screenshot, suggesting the action succeeded — making it harder to detect and recover from failures.

## The fix
Early-return guard immediately after the `do_capture` check:

```python
if not res.ok:
    return _text_response(res)
```

When the action fails, return the plain error text — no screenshot is taken. The error signal survives intact and the model can reason about what went wrong.

## Validation
- Cherry-pick had one test-file conflict (HEAD's drag + set_value test blocks from #30032 and #30270 vs incoming's failure-skip test blocks). Resolved by stacking both blocks — no overlap, both compile and pass.
- Targeted: `tests/tools/test_computer_use.py` — **74/74 passing** (72 prior + 2 new from this PR).
- New tests: `test_capture_after_skipped_when_action_failed`, `test_capture_after_fires_when_action_succeeds`.

Credit @rodrigoeqnit (PR #22749). Author in AUTHOR_MAP via #30270.

Closes #22749.

## Infographic

![pr-22749-capture-after-failure-skip](https://v3b.fal.media/files/b/0a9b34de/uBqP55HF613O1NhXaTLDp_FLGZUApc.png)
