### PR TITLE
fix(openviking): store memories via content/write API instead of session messages

### DIFF
--- a/plugins/memory/openviking/__init__.py
+++ b/plugins/memory/openviking/__init__.py
@@ -608,7 +608,7 @@ class OpenVikingMemoryProvider(MemoryProvider):
             logger.warning("OpenViking session commit failed: %s", e)
 
     def on_memory_write(self, action: str, target: str, content: str) -> None:
-        """Mirror built-in memory writes to OpenViking as explicit memories."""
+        """Mirror built-in memory writes to OpenViking via content/write."""
         if not self._client or action != "add" or not content:
             return
 
@@ -618,13 +618,12 @@ class OpenVikingMemoryProvider(MemoryProvider):
                     self._endpoint, self._api_key,
                     account=self._account, user=self._user, agent=self._agent,
                 )
-                # Add as a user message with memory context so the commit
-                # picks it up as an explicit memory during extraction
-                client.post(f"/api/v1/sessions/{self._session_id}/messages", {
-                    "role": "user",
-                    "parts": [
-                        {"type": "text", "text": f"[Memory note — {target}] {content}"},
-                    ],
+                slug = uuid.uuid4().hex[:12]
+                uri = f"viking://user/{client._user}/memories/preferences/mem_{slug}.md"
+                client.post("/api/v1/content/write", {
+                    "uri": uri,
+                    "content": content,
+                    "mode": "create",
                 })
             except Exception as e:
                 logger.debug("OpenViking memory mirror failed: %s", e)
@@ -858,24 +857,40 @@ class OpenVikingMemoryProvider(MemoryProvider):
         if not content:
             return tool_error("content is required")
 
-        # Store as a session message that will be extracted during commit.
-        # The category hint helps OpenViking's extraction classify correctly.
         category = args.get("category", "")
-        text = f"[Remember] {content}"
-        if category:
-            text = f"[Remember — {category}] {content}"
 
-        self._client.post(f"/api/v1/sessions/{self._session_id}/messages", {
-            "role": "user",
-            "parts": [
-                {"type": "text", "text": text},
-            ],
-        })
+        # Map category to a viking:// subdirectory for organized storage
+        subdir_map = {
+            "preference": "preferences",
+            "entity": "entities",
+            "event": "events",
+            "case": "cases",
+            "pattern": "patterns",
+        }
+        subdir = subdir_map.get(category, "preferences")
 
-        return json.dumps({
-            "status": "stored",
-            "message": "Memory recorded. Will be extracted and indexed on session commit.",
-        })
+        # Build a deterministic URI with UUID to avoid collisions
+        usr = self._user
+        slug = uuid.uuid4().hex[:12]
+        uri = f"viking://user/{usr}/memories/{subdir}/mem_{slug}.md"
+
+        # Write directly via content/write API.
+        # This creates the file, stores the content, and queues vector indexing
+        # in a single call — no dependency on session commit / VLM extraction.
+        try:
+            result = self._client.post("/api/v1/content/write", {
+                "uri": uri,
+                "content": content,
+                "mode": "create",
+            })
+            written = result.get("result", {}).get("written_bytes", 0)
+            return json.dumps({
+                "status": "stored",
+                "message": f"Memory stored ({written}b) and queued for vector indexing.",
+            })
+        except Exception as e:
+            logger.error("OpenViking content/write failed: %s", e)
+            return tool_error(f"Failed to store memory: {e}")
 
     def _tool_add_resource(self, args: dict) -> str:
         url = args.get("url", "")

--- a/plugins/memory/openviking/__init__.py
+++ b/plugins/memory/openviking/__init__.py
@@ -47,6 +47,25 @@ _DEFAULT_ENDPOINT = "http://127.0.0.1:1933"
 _TIMEOUT = 30.0
 _REMOTE_RESOURCE_PREFIXES = ("http://", "https://", "git@", "ssh://", "git://")
 
+# Maps the viking_remember `category` enum to a viking:// subdirectory.
+# Keep in sync with REMEMBER_SCHEMA.parameters.properties.category.enum.
+_CATEGORY_SUBDIR_MAP = {
+    "preference": "preferences",
+    "entity": "entities",
+    "event": "events",
+    "case": "cases",
+    "pattern": "patterns",
+}
+_DEFAULT_MEMORY_SUBDIR = "preferences"
+
+# Maps the built-in memory tool's `target` ("user" vs "memory") to a subdir
+# for on_memory_write mirroring. User profile facts → preferences; agent
+# notes / observations → patterns. Anything unknown falls back to the default.
+_MEMORY_WRITE_TARGET_SUBDIR_MAP = {
+    "user": "preferences",
+    "memory": "patterns",
+}
+
 
 # ---------------------------------------------------------------------------
 # Process-level atexit safety net — ensures pending sessions are committed
@@ -607,10 +626,24 @@ class OpenVikingMemoryProvider(MemoryProvider):
         except Exception as e:
             logger.warning("OpenViking session commit failed: %s", e)
 
-    def on_memory_write(self, action: str, target: str, content: str) -> None:
+    def _build_memory_uri(self, subdir: str) -> str:
+        """Build a viking:// memory URI under the configured user/subdir."""
+        slug = uuid.uuid4().hex[:12]
+        return f"viking://user/{self._user}/memories/{subdir}/mem_{slug}.md"
+
+    def on_memory_write(
+        self,
+        action: str,
+        target: str,
+        content: str,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> None:
         """Mirror built-in memory writes to OpenViking via content/write."""
         if not self._client or action != "add" or not content:
             return
+
+        subdir = _MEMORY_WRITE_TARGET_SUBDIR_MAP.get(target, _DEFAULT_MEMORY_SUBDIR)
+        uri = self._build_memory_uri(subdir)
 
         def _write():
             try:
@@ -618,8 +651,6 @@ class OpenVikingMemoryProvider(MemoryProvider):
                     self._endpoint, self._api_key,
                     account=self._account, user=self._user, agent=self._agent,
                 )
-                slug = uuid.uuid4().hex[:12]
-                uri = f"viking://user/{client._user}/memories/preferences/mem_{slug}.md"
                 client.post("/api/v1/content/write", {
                     "uri": uri,
                     "content": content,
@@ -858,21 +889,8 @@ class OpenVikingMemoryProvider(MemoryProvider):
             return tool_error("content is required")
 
         category = args.get("category", "")
-
-        # Map category to a viking:// subdirectory for organized storage
-        subdir_map = {
-            "preference": "preferences",
-            "entity": "entities",
-            "event": "events",
-            "case": "cases",
-            "pattern": "patterns",
-        }
-        subdir = subdir_map.get(category, "preferences")
-
-        # Build a deterministic URI with UUID to avoid collisions
-        usr = self._user
-        slug = uuid.uuid4().hex[:12]
-        uri = f"viking://user/{usr}/memories/{subdir}/mem_{slug}.md"
+        subdir = _CATEGORY_SUBDIR_MAP.get(category, _DEFAULT_MEMORY_SUBDIR)
+        uri = self._build_memory_uri(subdir)
 
         # Write directly via content/write API.
         # This creates the file, stores the content, and queues vector indexing

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -64,6 +64,7 @@ AUTHOR_MAP = {
     "nat@nthrow.io": "nthrow",
     "m@mobrienv.dev": "mikeyobrien",
     "saeed919@pm.me": "falasi",
+    "chrisdlc119@outlook.com": "chdlc",
     "omar@techdeveloper.site": "nycomar",
     "qiyin.zuo@pcitc.com": "qiyin-code",
     "mr.aashiz@gmail.com": "aashizpoudel",


### PR DESCRIPTION
## Summary

`viking_remember` and `on_memory_write` now persist memories synchronously via `POST /api/v1/content/write?mode=create` instead of dropping notes into session messages that depend on VLM extraction at commit time. With `extraction_enabled: false` (the common no-VLM setup), memories were silently lost; this fixes that.

Closes #17998. Salvages PR #29733 by @chdlc with follow-up polish on top.

## Changes

- `_tool_remember`: direct write to `content/write`, category → viking:// subdirectory (preferences / entities / events / cases / patterns), returns actual `written_bytes` from server.
- `on_memory_write`: same direct-write path; **target-aware** subdir — `user` → `preferences/`, `memory` → `patterns/` (was hardcoded `preferences/` in the original PR).
- Extracted `_build_memory_uri()` helper + module-level `_CATEGORY_SUBDIR_MAP` / `_MEMORY_WRITE_TARGET_SUBDIR_MAP` so the two code paths share construction logic.
- Restored `on_memory_write` signature parity with `MemoryProvider` base (adds `metadata: Optional[Dict[str, Any]] = None`); clears the Pyright incompatible-override warning. Compatible with `MemoryManager`'s `legacy`/`positional`/`keyword` auto-detection.
- Dropped `client._user` (private-attr access) in favor of `self._user`.
- `AUTHOR_MAP` entry for `chrisdlc119@outlook.com` → `chdlc`.

## Validation

| | Before | After |
|---|---|---|
| `viking_remember` with extraction off | Reports success, creates empty session, 0 memories indexed | File written + queued for indexing in one call |
| Error reporting | Silent (success message even on failure) | `tool_error` with HTTP error code/message |
| Tool response | `"Will be extracted... on session commit"` (never happened) | `"Memory stored (Nb) and queued for vector indexing"` |
| `on_memory_write` mirror subdir | Hardcoded `preferences/` for both targets | `user` → `preferences/`, `memory` → `patterns/` |
| Pyright override-signature warning | Present | Cleared |

E2E validation with mocked httpx layer covers: 5 category enum mappings, target-aware on_memory_write subdir, action filter (`replace`/`remove` correctly skipped), header injection (`X-OpenViking-Account/User/Agent`), error path propagation, empty-content rejection. 104/104 pass across `tests/plugins/memory/test_openviking_provider.py`, `tests/openviking_plugin/test_openviking.py`, `tests/agent/test_memory_provider.py`.

API contract verified against [OpenViking docs](https://docs.openviking.ai/en/api/03-filesystem): body shape `{uri, content, mode}`, response includes `written_bytes`, `mode=create` auto-creates parent dirs, `.md` extension allowed, semantic refresh is automatic.

Co-authored-by: Christian de la Cruz <chrisdlc119@outlook.com>

## Infographic

![openviking-viking-remember-content-write](https://v3b.fal.media/files/b/0a9b3506/I287-OE5jhizw3mVNfwDR_N8TFXt86.png)
