### PR TITLE
feat(codex): add apply_patch tool projection

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -821,10 +821,17 @@ def init_agent(
         quiet_mode=agent.quiet_mode,
     )
     
-    # Show tool configuration and store valid tool names for validation
+    def _refresh_projected_tool_names(*, freeze: bool = False) -> None:
+        from agent.tool_projection import refresh_agent_tool_projection
+
+        refresh_agent_tool_projection(agent, freeze=freeze)
+
+    agent._refresh_projected_tool_names = _refresh_projected_tool_names
+
+    # Show tool configuration and store valid projected tool names for validation
     agent.valid_tool_names = set()
     if agent.tools:
-        agent.valid_tool_names = {tool["function"]["name"] for tool in agent.tools}
+        agent._refresh_projected_tool_names()
         tool_names = sorted(agent.valid_tool_names)
         if not agent.quiet_mode:
             print(f"🛠️  Loaded {len(agent.tools)} tools: {', '.join(tool_names)}")
@@ -1053,6 +1060,7 @@ def init_agent(
             if _tname:
                 agent.valid_tool_names.add(_tname)
                 _existing_tool_names.add(_tname)
+        agent._refresh_projected_tool_names()
 
     # Skills config: nudge interval for skill creation reminders
     agent._skill_nudge_interval = 10
@@ -1364,6 +1372,7 @@ def init_agent(
                 agent.valid_tool_names.add(_tname)
                 agent._context_engine_tool_names.add(_tname)
                 _existing_tool_names.add(_tname)
+        agent._refresh_projected_tool_names()
 
     # Notify context engine of session start
     if hasattr(agent, "context_compressor") and agent.context_compressor:

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -232,11 +232,23 @@ def interruptible_api_call(agent, api_kwargs: dict):
 
 def build_api_kwargs(agent, api_messages: list) -> dict:
     """Build the keyword arguments dict for the active API mode."""
+    if hasattr(agent, "_refresh_projected_tool_names"):
+        agent._refresh_projected_tool_names(freeze=True)
+
+    from agent.tool_projection import (
+        PatchToolSurface,
+        project_messages_for_patch_surface,
+    )
+
     tools_for_api = agent.tools
 
     if agent.api_mode == "anthropic_messages":
         _transport = agent._get_transport()
-        anthropic_messages = agent._prepare_anthropic_messages_for_api(api_messages)
+        projected_messages = project_messages_for_patch_surface(
+            api_messages,
+            patch_surface=PatchToolSurface.HERMES_PATCH,
+        )
+        anthropic_messages = agent._prepare_anthropic_messages_for_api(projected_messages)
         ctx_len = getattr(agent, "context_compressor", None)
         ctx_len = ctx_len.context_length if ctx_len else None
         ephemeral_out = getattr(agent, "_ephemeral_max_output_tokens", None)
@@ -262,9 +274,13 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
         _bt = agent._get_transport()
         region = getattr(agent, "_bedrock_region", None) or "us-east-1"
         guardrail = getattr(agent, "_bedrock_guardrail_config", None)
+        projected_messages = project_messages_for_patch_surface(
+            api_messages,
+            patch_surface=PatchToolSurface.HERMES_PATCH,
+        )
         return _bt.build_kwargs(
             model=agent.model,
-            messages=api_messages,
+            messages=projected_messages,
             tools=tools_for_api,
             max_tokens=agent.max_tokens or 4096,
             region=region,
@@ -316,6 +332,9 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
             session_id=getattr(agent, "session_id", None),
             max_tokens=agent.max_tokens,
             request_overrides=agent.request_overrides,
+            provider=agent.provider,
+            base_url=agent.base_url,
+            patch_surface=getattr(agent, "_patch_tool_surface", None),
             is_github_responses=is_github_responses,
             is_codex_backend=is_codex_backend,
             is_xai_responses=is_xai_responses,
@@ -402,7 +421,10 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
         # Strip image parts for non-vision models that have provider profiles
         # (e.g. DeepSeek, Kimi). The legacy path below already does this, but
         # registered providers with profiles were bypassing the strip.
-        api_messages = agent._prepare_messages_for_non_vision_model(api_messages)
+        api_messages = project_messages_for_patch_surface(
+            agent._prepare_messages_for_non_vision_model(api_messages),
+            patch_surface=PatchToolSurface.HERMES_PATCH,
+        )
 
         return _ct.build_kwargs(
             model=agent.model,
@@ -434,7 +456,10 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
         agent._ephemeral_max_output_tokens = None
 
     # Strip image parts for non-vision models (no-op when vision-capable).
-    _msgs_for_chat = agent._prepare_messages_for_non_vision_model(api_messages)
+    _msgs_for_chat = project_messages_for_patch_surface(
+        agent._prepare_messages_for_non_vision_model(api_messages),
+        patch_surface=PatchToolSurface.HERMES_PATCH,
+    )
 
     return _ct.build_kwargs(
         model=agent.model,
@@ -640,10 +665,13 @@ def build_assistant_message(agent, assistant_message, finish_reason: str) -> dic
                 _, embedded_response_item_id = agent._split_responses_tool_id(raw_id)
                 response_item_id = embedded_response_item_id
 
-            response_item_id = agent._derive_responses_function_call_id(
-                call_id,
-                response_item_id if isinstance(response_item_id, str) else None,
-            )
+            if getattr(tool_call, "type", "function") == "apply_patch":
+                response_item_id = response_item_id if isinstance(response_item_id, str) else None
+            else:
+                response_item_id = agent._derive_responses_function_call_id(
+                    call_id,
+                    response_item_id if isinstance(response_item_id, str) else None,
+                )
 
             tc_dict = {
                 "id": call_id,
@@ -804,6 +832,8 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
         agent.api_mode = fb_api_mode
         if hasattr(agent, "_transport_cache"):
             agent._transport_cache.clear()
+        if hasattr(agent, "_refresh_projected_tool_names"):
+            agent._refresh_projected_tool_names()
         agent._fallback_activated = True
 
         # Honor per-provider / per-model request_timeout_seconds for the
@@ -952,6 +982,17 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
         # Same safety net as the main loop: drop thinking-only assistant
         # turns so Anthropic-family providers don't 400 the summary call.
         api_messages = agent._drop_thinking_only_and_merge_users(api_messages)
+        if agent.api_mode != "codex_responses":
+            from agent.tool_projection import (
+                PatchToolSurface,
+                project_messages_for_patch_surface,
+            )
+            if hasattr(agent, "_refresh_projected_tool_names"):
+                agent._refresh_projected_tool_names()
+            api_messages = project_messages_for_patch_surface(
+                api_messages,
+                patch_surface=PatchToolSurface.HERMES_PATCH,
+            )
 
         summary_extra_body = {}
         try:

--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -19,6 +19,10 @@ from types import SimpleNamespace
 from typing import Any, Dict, List, Optional
 
 from agent.prompt_builder import DEFAULT_AGENT_IDENTITY
+from agent.tool_projection import (
+    PatchToolSurface,
+    responses_tools_for_surface,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -202,25 +206,18 @@ def _derive_responses_function_call_id(
 # Schema conversion
 # ---------------------------------------------------------------------------
 
-def _responses_tools(tools: Optional[List[Dict[str, Any]]] = None) -> Optional[List[Dict[str, Any]]]:
+def _responses_tools(
+    tools: Optional[List[Dict[str, Any]]] = None,
+    *,
+    apply_patch_tool_kind: Optional[str] = None,
+) -> Optional[List[Dict[str, Any]]]:
     """Convert chat-completions tool schemas to Responses function-tool schemas."""
-    if not tools:
-        return None
-
-    converted: List[Dict[str, Any]] = []
-    for item in tools:
-        fn = item.get("function", {}) if isinstance(item, dict) else {}
-        name = fn.get("name")
-        if not isinstance(name, str) or not name.strip():
-            continue
-        converted.append({
-            "type": "function",
-            "name": name,
-            "description": fn.get("description", ""),
-            "strict": False,
-            "parameters": fn.get("parameters", {"type": "object", "properties": {}}),
-        })
-    return converted or None
+    surface = (
+        PatchToolSurface.CODEX_FREEFORM_APPLY_PATCH
+        if apply_patch_tool_kind == "freeform"
+        else PatchToolSurface.HERMES_PATCH
+    )
+    return responses_tools_for_surface(tools, patch_surface=surface)
 
 
 # ---------------------------------------------------------------------------
@@ -261,6 +258,7 @@ def _chat_messages_to_responses_input(
     """
     items: List[Dict[str, Any]] = []
     seen_item_ids: set = set()
+    custom_apply_patch_call_ids: set[str] = set()
 
     for msg in messages:
         if not isinstance(msg, dict):
@@ -407,6 +405,24 @@ def _chat_messages_to_responses_input(
                             arguments = str(arguments)
                         arguments = arguments.strip() or "{}"
 
+                        tc_type = str(tc.get("type") or "function").strip()
+                        if tc_type == "apply_patch" and fn_name == "apply_patch":
+                            try:
+                                parsed_args = json.loads(arguments)
+                            except Exception:
+                                parsed_args = {}
+                            patch = parsed_args.get("patch") if isinstance(parsed_args, dict) else None
+                            if not isinstance(patch, str):
+                                patch = arguments
+                            items.append({
+                                "type": "custom_tool_call",
+                                "call_id": call_id,
+                                "name": "apply_patch",
+                                "input": patch,
+                            })
+                            custom_apply_patch_call_ids.add(call_id)
+                            continue
+
                         items.append({
                             "type": "function_call",
                             "call_id": call_id,
@@ -450,11 +466,23 @@ def _chat_messages_to_responses_input(
             else:
                 output_value = str(tool_content or "")
 
-            items.append({
-                "type": "function_call_output",
-                "call_id": call_id,
-                "output": output_value,
-            })
+            if call_id in custom_apply_patch_call_ids or msg.get("name") == "apply_patch":
+                output_text = (
+                    output_value
+                    if isinstance(output_value, str)
+                    else json.dumps(output_value, ensure_ascii=False)
+                )
+                items.append({
+                    "type": "custom_tool_call_output",
+                    "call_id": call_id,
+                    "output": output_text,
+                })
+            else:
+                items.append({
+                    "type": "function_call_output",
+                    "call_id": call_id,
+                    "output": output_value,
+                })
 
     return items
 
@@ -497,6 +525,30 @@ def _preflight_codex_input_items(raw_items: Any) -> List[Dict[str, Any]]:
                     "arguments": arguments,
                 }
             )
+            continue
+
+        if item_type == "custom_tool_call":
+            call_id = item.get("call_id")
+            name = item.get("name")
+            if not isinstance(call_id, str) or not call_id.strip():
+                raise ValueError(f"Codex Responses input[{idx}] custom_tool_call is missing call_id.")
+            if not isinstance(name, str) or not name.strip():
+                raise ValueError(f"Codex Responses input[{idx}] custom_tool_call is missing name.")
+            custom_input = item.get("input", "")
+            if custom_input is None:
+                custom_input = ""
+            elif not isinstance(custom_input, str):
+                custom_input = str(custom_input)
+            normalized_item = {
+                "type": "custom_tool_call",
+                "call_id": call_id.strip(),
+                "name": name.strip(),
+                "input": custom_input,
+            }
+            item_id = item.get("id")
+            if isinstance(item_id, str) and item_id.strip():
+                normalized_item["id"] = item_id.strip()
+            normalized.append(normalized_item)
             continue
 
         if item_type == "function_call_output":
@@ -544,6 +596,24 @@ def _preflight_codex_input_items(raw_items: Any) -> List[Dict[str, Any]]:
             normalized.append(
                 {
                     "type": "function_call_output",
+                    "call_id": call_id.strip(),
+                    "output": output,
+                }
+            )
+            continue
+
+        if item_type == "custom_tool_call_output":
+            call_id = item.get("call_id")
+            if not isinstance(call_id, str) or not call_id.strip():
+                raise ValueError(f"Codex Responses input[{idx}] custom_tool_call_output is missing call_id.")
+            output = item.get("output", "")
+            if output is None:
+                output = ""
+            elif not isinstance(output, str):
+                output = str(output)
+            normalized.append(
+                {
+                    "type": "custom_tool_call_output",
                     "call_id": call_id.strip(),
                     "output": output,
                 }
@@ -709,7 +779,22 @@ def _preflight_codex_api_kwargs(
         for idx, tool in enumerate(tools):
             if not isinstance(tool, dict):
                 raise ValueError(f"Codex Responses tools[{idx}] must be an object.")
-            if tool.get("type") != "function":
+            tool_type = tool.get("type")
+            if tool_type == "custom":
+                name = tool.get("name")
+                if not isinstance(name, str) or not name.strip():
+                    raise ValueError(f"Codex Responses tools[{idx}] custom tool is missing a valid name.")
+                normalized_tool = {
+                    "type": "custom",
+                    "name": name.strip(),
+                    "description": str(tool.get("description") or ""),
+                }
+                fmt = tool.get("format")
+                if isinstance(fmt, dict):
+                    normalized_tool["format"] = fmt
+                normalized_tools.append(normalized_tool)
+                continue
+            if tool_type != "function":
                 raise ValueError(f"Codex Responses tools[{idx}] has unsupported type {tool.get('type')!r}.")
 
             name = tool.get("name")
@@ -1001,6 +1086,10 @@ def _normalize_codex_response(response: Any) -> tuple[Any, str]:
             arguments = getattr(item, "input", "{}")
             if not isinstance(arguments, str):
                 arguments = json.dumps(arguments, ensure_ascii=False)
+            tool_type = "function"
+            if fn_name == "apply_patch":
+                tool_type = "apply_patch"
+                arguments = json.dumps({"patch": arguments}, ensure_ascii=False)
             raw_call_id = getattr(item, "call_id", None)
             raw_item_id = getattr(item, "id", None)
             embedded_call_id, _ = _split_responses_tool_id(raw_item_id)
@@ -1014,7 +1103,7 @@ def _normalize_codex_response(response: Any) -> tuple[Any, str]:
                 id=call_id,
                 call_id=call_id,
                 response_item_id=response_item_id,
-                type="function",
+                type=tool_type,
                 function=SimpleNamespace(name=fn_name, arguments=arguments),
             ))
 

--- a/agent/tool_dispatch_helpers.py
+++ b/agent/tool_dispatch_helpers.py
@@ -56,7 +56,7 @@ _PARALLEL_SAFE_TOOLS = frozenset({
 })
 
 # File tools can run concurrently when they target independent paths.
-_PATH_SCOPED_TOOLS = frozenset({"read_file", "write_file", "patch"})
+_PATH_SCOPED_TOOLS = frozenset({"read_file", "write_file", "patch", "apply_patch"})
 
 # Patterns that indicate a terminal command may modify/delete files.
 _DESTRUCTIVE_PATTERNS = re.compile(
@@ -247,6 +247,19 @@ def _extract_file_mutation_targets(tool_name: str, args: Dict[str, Any]) -> List
     if tool_name == "write_file":
         p = args.get("path")
         return [str(p)] if p else []
+    if tool_name == "apply_patch":
+        body = args.get("patch") or ""
+        if not isinstance(body, str) or not body:
+            return []
+        return [
+            m.group(1).strip()
+            for m in re.finditer(
+                r'^\*\*\*\s+(?:Update|Add|Delete)\s+File:\s*(.+)$',
+                body,
+                re.MULTILINE,
+            )
+            if m.group(1).strip()
+        ]
     # tool_name == "patch"
     mode = args.get("mode") or "replace"
     if mode == "replace":

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -101,7 +101,7 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
             function_args = {}
 
         # Checkpoint for file-mutating tools
-        if function_name in {"write_file", "patch"} and agent._checkpoint_mgr.enabled:
+        if function_name in {"write_file", "patch", "apply_patch"} and agent._checkpoint_mgr.enabled:
             try:
                 file_path = function_args.get("path", "")
                 if file_path:
@@ -567,7 +567,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                 logging.debug(f"Tool start callback error: {cb_err}")
 
         # Checkpoint: snapshot working dir before file-mutating tools
-        if not _execution_blocked and function_name in {"write_file", "patch"} and agent._checkpoint_mgr.enabled:
+        if not _execution_blocked and function_name in {"write_file", "patch", "apply_patch"} and agent._checkpoint_mgr.enabled:
             try:
                 file_path = function_args.get("path", "")
                 if file_path:

--- a/agent/tool_projection.py
+++ b/agent/tool_projection.py
@@ -1,0 +1,339 @@
+"""Model-aware projection for provider-facing tool shapes.
+
+Hermes keeps file editing semantics in the canonical ``patch`` tool.  Some
+providers, notably Codex Responses, perform better when the patch surface is a
+freeform ``apply_patch`` custom tool.  This module centralizes that translation
+so transports do not grow one-off patch special cases.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+import os
+from enum import Enum
+from typing import Any, Iterable, Optional
+from urllib.parse import urlparse
+
+
+INTENT_KEY = "_hermes_patch_tool_intent"
+
+APPLY_PATCH_LARK_GRAMMAR = """start: begin_patch hunk+ end_patch
+begin_patch: "*** Begin Patch" LF
+end_patch: "*** End Patch" LF?
+
+hunk: add_hunk | delete_hunk | update_hunk
+add_hunk: "*** Add File: " filename LF add_line+
+delete_hunk: "*** Delete File: " filename LF
+update_hunk: "*** Update File: " filename LF change_move? change?
+
+filename: /(.+)/
+add_line: "+" /(.*)/ LF -> line
+
+change_move: "*** Move to: " filename LF
+change: (change_context | change_line)+ eof_line?
+change_context: ("@@" | "@@ " /(.+)/) LF
+change_line: ("+" | "-" | " ") /(.*)/ LF
+eof_line: "*** End of File" LF
+
+%import common.LF
+"""
+
+
+class PatchToolSurface(str, Enum):
+    HERMES_PATCH = "hermes_patch"
+    CODEX_FREEFORM_APPLY_PATCH = "codex_freeform_apply_patch"
+
+
+def _env_flag_enabled(name: str, *, default: bool = True) -> bool:
+    value = os.environ.get(name)
+    if value is None:
+        return default
+    return value.strip().lower() not in {"0", "false", "no", "off"}
+
+
+def _tool_function_name(tool: Any) -> Optional[str]:
+    if not isinstance(tool, dict):
+        return None
+    fn = tool.get("function")
+    if not isinstance(fn, dict):
+        return None
+    name = fn.get("name")
+    return name.strip() if isinstance(name, str) and name.strip() else None
+
+
+def _tool_names(tools: Optional[Iterable[dict]]) -> set[str]:
+    return {name for tool in tools or [] if (name := _tool_function_name(tool))}
+
+
+def _hostname(value: str | None) -> str:
+    if not value:
+        return ""
+    try:
+        return (urlparse(value).hostname or "").lower()
+    except Exception:
+        return ""
+
+
+def _is_codex_compatible_responses_runtime(
+    *,
+    provider: str | None = None,
+    base_url: str | None = None,
+    model: str | None = None,
+    is_codex_backend: bool = False,
+) -> bool:
+    provider_norm = (provider or "").strip().lower()
+    model_norm = (model or "").strip().lower()
+    host = _hostname(base_url)
+    base_url_norm = (base_url or "").strip().lower()
+
+    return (
+        bool(is_codex_backend)
+        or provider_norm == "openai-codex"
+        or (host == "chatgpt.com" and "/backend-api/codex" in base_url_norm)
+        or (provider_norm == "openai" and "codex" in model_norm)
+    )
+
+
+def resolve_patch_tool_surface(
+    tools: Optional[list[dict]] = None,
+    *,
+    api_mode: str | None = None,
+    provider: str | None = None,
+    base_url: str | None = None,
+    model: str | None = None,
+    is_codex_backend: bool = False,
+    is_github_responses: bool = False,
+    is_xai_responses: bool = False,
+) -> PatchToolSurface:
+    """Return the provider-facing patch surface for the active runtime."""
+    if "patch" not in _tool_names(tools):
+        return PatchToolSurface.HERMES_PATCH
+    if api_mode != "codex_responses":
+        return PatchToolSurface.HERMES_PATCH
+    if is_github_responses or is_xai_responses:
+        return PatchToolSurface.HERMES_PATCH
+    if not _env_flag_enabled("HERMES_CODEX_NATIVE_APPLY_PATCH", default=True):
+        return PatchToolSurface.HERMES_PATCH
+    if not _is_codex_compatible_responses_runtime(
+        provider=provider,
+        base_url=base_url,
+        model=model,
+        is_codex_backend=is_codex_backend,
+    ):
+        return PatchToolSurface.HERMES_PATCH
+    return PatchToolSurface.CODEX_FREEFORM_APPLY_PATCH
+
+
+def freeform_apply_patch_tool() -> dict[str, Any]:
+    return {
+        "type": "custom",
+        "name": "apply_patch",
+        "description": (
+            "Use the `apply_patch` tool to edit files. This is a FREEFORM "
+            "tool, so do not wrap the patch in JSON."
+        ),
+        "format": {
+            "type": "grammar",
+            "syntax": "lark",
+            "definition": APPLY_PATCH_LARK_GRAMMAR,
+        },
+    }
+
+
+def projected_valid_tool_names(
+    tools: Optional[list[dict]],
+    *,
+    patch_surface: PatchToolSurface,
+) -> set[str]:
+    names = _tool_names(tools)
+    if patch_surface == PatchToolSurface.CODEX_FREEFORM_APPLY_PATCH and "patch" in names:
+        names.remove("patch")
+        names.add("apply_patch")
+    else:
+        names.discard("apply_patch")
+    return names
+
+
+def _coerce_patch_surface(value: Any) -> Optional[PatchToolSurface]:
+    if isinstance(value, PatchToolSurface):
+        return value
+    if isinstance(value, str):
+        try:
+            return PatchToolSurface(value)
+        except ValueError:
+            return None
+    return None
+
+
+def refresh_agent_tool_projection(agent: Any, *, freeze: bool = False) -> None:
+    """Refresh runtime patch surface and valid tool names for an agent."""
+    patch_surface = None
+    if getattr(agent, "_patch_tool_surface_frozen", False):
+        patch_surface = _coerce_patch_surface(getattr(agent, "_patch_tool_surface", None))
+
+    if patch_surface is None:
+        patch_surface = resolve_patch_tool_surface(
+            getattr(agent, "tools", None),
+            api_mode=getattr(agent, "api_mode", None),
+            provider=getattr(agent, "provider", None),
+            base_url=getattr(agent, "base_url", None),
+            model=getattr(agent, "model", None),
+        )
+    agent._patch_tool_surface = patch_surface
+    if freeze:
+        agent._patch_tool_surface_frozen = True
+    agent.valid_tool_names = projected_valid_tool_names(
+        getattr(agent, "tools", None),
+        patch_surface=patch_surface,
+    )
+
+
+def responses_tools_for_surface(
+    tools: Optional[list[dict]],
+    *,
+    patch_surface: PatchToolSurface,
+) -> Optional[list[dict]]:
+    """Convert canonical OpenAI tool schemas to Responses tool schemas."""
+    if not tools:
+        if patch_surface == PatchToolSurface.CODEX_FREEFORM_APPLY_PATCH:
+            return [freeform_apply_patch_tool()]
+        return None
+
+    converted: list[dict[str, Any]] = []
+    for item in tools:
+        fn = item.get("function", {}) if isinstance(item, dict) else {}
+        name = fn.get("name")
+        if not isinstance(name, str) or not name.strip():
+            continue
+        if patch_surface == PatchToolSurface.CODEX_FREEFORM_APPLY_PATCH and name == "patch":
+            continue
+        converted.append({
+            "type": "function",
+            "name": name,
+            "description": fn.get("description", ""),
+            "strict": False,
+            "parameters": fn.get("parameters", {"type": "object", "properties": {}}),
+        })
+
+    if patch_surface == PatchToolSurface.CODEX_FREEFORM_APPLY_PATCH:
+        converted.append(freeform_apply_patch_tool())
+    return converted or None
+
+
+def _json_args(value: dict[str, Any]) -> str:
+    return json.dumps(value, ensure_ascii=False, separators=(",", ":"), sort_keys=True)
+
+
+def _parse_args(raw: Any) -> dict[str, Any]:
+    if isinstance(raw, dict):
+        return raw
+    if isinstance(raw, str):
+        try:
+            parsed = json.loads(raw)
+        except Exception:
+            return {}
+        return parsed if isinstance(parsed, dict) else {}
+    return {}
+
+
+def _coerce_apply_patch_to_patch_args(tool_call: dict[str, Any]) -> dict[str, Any]:
+    intent = tool_call.get(INTENT_KEY)
+    if isinstance(intent, dict) and intent.get("canonical_tool") == "patch":
+        args = intent.get("canonical_arguments")
+        if isinstance(args, dict):
+            return copy.deepcopy(args)
+
+    fn = tool_call.get("function", {}) if isinstance(tool_call, dict) else {}
+    args = _parse_args(fn.get("arguments", "{}") if isinstance(fn, dict) else "{}")
+    patch = args.get("patch")
+    if isinstance(patch, str):
+        return {"mode": "patch", "patch": patch}
+
+    return {"mode": "patch", "patch": str(fn.get("arguments", ""))}
+
+
+def _patch_args_to_freeform_patch(args: dict[str, Any]) -> Optional[str]:
+    mode = str(args.get("mode") or "replace")
+    if mode == "patch" and isinstance(args.get("patch"), str):
+        return args["patch"]
+
+    if mode != "replace":
+        return None
+    path = args.get("path")
+    old_string = args.get("old_string")
+    new_string = args.get("new_string")
+    if (
+        not isinstance(path, str)
+        or not isinstance(old_string, str)
+        or not isinstance(new_string, str)
+    ):
+        return None
+
+    old_lines = old_string.split("\n")
+    new_lines = new_string.split("\n")
+    return "\n".join([
+        "*** Begin Patch",
+        f"*** Update File: {path}",
+        "@@",
+        *(f"-{line}" for line in old_lines),
+        *(f"+{line}" for line in new_lines),
+        "*** End Patch",
+    ])
+
+
+def _project_tool_call(tool_call: Any, *, patch_surface: PatchToolSurface) -> Any:
+    if not isinstance(tool_call, dict):
+        return tool_call
+
+    tc = {k: copy.deepcopy(v) for k, v in tool_call.items() if k != INTENT_KEY}
+    fn = tc.get("function")
+    if not isinstance(fn, dict):
+        return tc
+    name = fn.get("name")
+
+    if patch_surface == PatchToolSurface.HERMES_PATCH and name == "apply_patch":
+        patch_args = _coerce_apply_patch_to_patch_args(tool_call)
+        tc["type"] = "function"
+        fn["name"] = "patch"
+        fn["arguments"] = _json_args(patch_args)
+        return tc
+
+    if patch_surface == PatchToolSurface.CODEX_FREEFORM_APPLY_PATCH and name == "patch":
+        args = _parse_args(fn.get("arguments", "{}"))
+        patch = _patch_args_to_freeform_patch(args)
+        if isinstance(patch, str):
+            tc["type"] = "apply_patch"
+            fn["name"] = "apply_patch"
+            fn["arguments"] = _json_args({"patch": patch})
+        return tc
+
+    return tc
+
+
+def project_messages_for_patch_surface(
+    messages: list[dict[str, Any]],
+    *,
+    patch_surface: PatchToolSurface,
+) -> list[dict[str, Any]]:
+    """Return API-bound message copies projected for the target patch surface."""
+    projected: list[dict[str, Any]] = []
+    for msg in messages:
+        if not isinstance(msg, dict):
+            projected.append(msg)
+            continue
+        api_msg = {k: copy.deepcopy(v) for k, v in msg.items() if k != INTENT_KEY}
+        tool_calls = api_msg.get("tool_calls")
+        if isinstance(tool_calls, list):
+            api_msg["tool_calls"] = [
+                _project_tool_call(tc, patch_surface=patch_surface)
+                for tc in tool_calls
+            ]
+        if api_msg.get("role") == "tool" and api_msg.get("name") == "apply_patch":
+            if patch_surface == PatchToolSurface.HERMES_PATCH:
+                api_msg["name"] = "patch"
+        elif api_msg.get("role") == "tool" and api_msg.get("name") == "patch":
+            if patch_surface == PatchToolSurface.CODEX_FREEFORM_APPLY_PATCH:
+                api_msg["name"] = "apply_patch"
+        projected.append(api_msg)
+    return projected

--- a/agent/tool_result_classification.py
+++ b/agent/tool_result_classification.py
@@ -6,7 +6,7 @@ import json
 from typing import Any
 
 
-FILE_MUTATING_TOOL_NAMES = frozenset({"write_file", "patch"})
+FILE_MUTATING_TOOL_NAMES = frozenset({"write_file", "patch", "apply_patch"})
 
 
 def file_mutation_result_landed(tool_name: str, result: Any) -> bool:
@@ -21,6 +21,6 @@ def file_mutation_result_landed(tool_name: str, result: Any) -> bool:
         return False
     if tool_name == "write_file":
         return "bytes_written" in data
-    if tool_name == "patch":
+    if tool_name in {"patch", "apply_patch"}:
         return data.get("success") is True
     return False

--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -61,7 +61,12 @@ class ResponsesApiTransport(ProviderTransport):
         """
         from agent.codex_responses_adapter import (
             _chat_messages_to_responses_input,
-            _responses_tools,
+        )
+        from agent.tool_projection import (
+            PatchToolSurface,
+            project_messages_for_patch_surface,
+            resolve_patch_tool_surface,
+            responses_tools_for_surface,
         )
 
         from run_agent import DEFAULT_AGENT_IDENTITY
@@ -92,7 +97,29 @@ class ResponsesApiTransport(ProviderTransport):
         _effort_clamp = {"minimal": "low"}
         reasoning_effort = _effort_clamp.get(reasoning_effort, reasoning_effort)
 
-        response_tools = _responses_tools(tools)
+        patch_surface = params.get("patch_surface")
+        if not isinstance(patch_surface, PatchToolSurface):
+            try:
+                patch_surface = PatchToolSurface(str(patch_surface))
+            except Exception:
+                patch_surface = resolve_patch_tool_surface(
+                    tools,
+                    api_mode="codex_responses",
+                    provider=params.get("provider"),
+                    base_url=params.get("base_url"),
+                    model=model,
+                    is_codex_backend=is_codex_backend,
+                    is_github_responses=is_github_responses,
+                    is_xai_responses=is_xai_responses,
+                )
+        payload_messages = project_messages_for_patch_surface(
+            payload_messages,
+            patch_surface=patch_surface,
+        )
+        response_tools = responses_tools_for_surface(
+            tools,
+            patch_surface=patch_surface,
+        )
         kwargs = {
             "model": model,
             "instructions": instructions,
@@ -213,6 +240,8 @@ class ResponsesApiTransport(ProviderTransport):
                     provider_data["call_id"] = tc.call_id
                 if hasattr(tc, "response_item_id") and tc.response_item_id:
                     provider_data["response_item_id"] = tc.response_item_id
+                if hasattr(tc, "type") and tc.type:
+                    provider_data["type"] = tc.type
                 tool_calls.append(ToolCall(
                     id=tc.id if hasattr(tc, "id") else (tc.function.name if hasattr(tc, "function") else None),
                     name=tc.function.name if hasattr(tc, "function") else getattr(tc, "name", ""),

--- a/agent/transports/types.py
+++ b/agent/transports/types.py
@@ -44,7 +44,7 @@ class ToolCall:
     # shim, while keeping ToolCall's canonical fields flat.
     @property
     def type(self) -> str:
-        return "function"
+        return str((self.provider_data or {}).get("type") or "function")
 
     @property
     def function(self) -> ToolCall:

--- a/model_tools.py
+++ b/model_tools.py
@@ -799,7 +799,7 @@ def handle_function_call(
                 return edit_block_message
         except Exception as _edit_approval_err:
             logger.debug("ACP edit approval guard error: %s", _edit_approval_err)
-            if function_name in {"write_file", "patch"}:
+            if function_name in {"write_file", "patch", "apply_patch"}:
                 return json.dumps({"error": "Edit approval denied: approval guard failed"}, ensure_ascii=False)
 
         # Notify the read-loop tracker when a non-read/search tool runs,
@@ -819,7 +819,13 @@ def handle_function_call(
         # to wrap every tool manually.  We use monotonic() so the value is
         # unaffected by wall-clock adjustments during the call.
         _dispatch_start = time.monotonic()
-        if function_name == "execute_code":
+        if function_name == "apply_patch":
+            from tools.file_tools import apply_patch_tool
+            result = apply_patch_tool(
+                patch=function_args.get("patch"),
+                task_id=task_id or "default",
+            )
+        elif function_name == "execute_code":
             # Prefer the caller-provided list so subagents can't overwrite
             # the parent's tool set via the process-global.
             sandbox_enabled = enabled_tools if enabled_tools is not None else _last_resolved_tool_names

--- a/run_agent.py
+++ b/run_agent.py
@@ -3682,7 +3682,7 @@ class AIAgent:
         tool_calls = api_msg.get("tool_calls")
         if not isinstance(tool_calls, list):
             return api_msg
-        _STRIP_KEYS = {"call_id", "response_item_id"}
+        _STRIP_KEYS = {"call_id", "response_item_id", "_hermes_patch_tool_intent"}
         api_msg["tool_calls"] = [
             {k: v for k, v in tc.items() if k not in _STRIP_KEYS}
             if isinstance(tc, dict) else tc

--- a/tests/run_agent/test_apply_patch_conversion_properties.py
+++ b/tests/run_agent/test_apply_patch_conversion_properties.py
@@ -1,0 +1,524 @@
+"""Property-style tests for Hermes patch vs Codex freeform apply_patch.
+
+These tests intentionally avoid Hypothesis to keep the project dependency
+surface unchanged.  They use deterministic pseudo-random generation so failures
+are reproducible by seed and case index.
+"""
+
+import json
+import random
+import string
+from types import SimpleNamespace
+
+
+from agent.codex_responses_adapter import (
+    _chat_messages_to_responses_input,
+    _normalize_codex_response,
+)
+from agent.tool_projection import (
+    INTENT_KEY,
+    PatchToolSurface,
+    project_messages_for_patch_surface,
+)
+from tools.file_tools import apply_patch_tool
+
+
+SEED = 0xA9917A
+CASES = 400
+
+
+def _text(rng: random.Random, *, min_len: int = 0, max_len: int = 40) -> str:
+    alphabet = string.ascii_letters + string.digits + " _-./:[]{}()'\",=+\\"
+    n = rng.randint(min_len, max_len)
+    return "".join(rng.choice(alphabet) for _ in range(n))
+
+
+def _path(rng: random.Random) -> str:
+    stem = _text(rng, min_len=1, max_len=14).strip(" ./\\") or "file"
+    stem = stem.replace("\\", "_").replace(":", "_")
+    suffix = rng.choice([".py", ".txt", ".md", ".json", ""])
+    directory = rng.choice(["src", "tests", "docs", "pkg/sub dir", ""])
+    if directory:
+        return f"{directory}/{stem}{suffix}"
+    return f"{stem}{suffix}"
+
+
+def _add_hunk(rng: random.Random) -> str:
+    lines = []
+    for _ in range(rng.randint(1, 8)):
+        lines.append("+" + _text(rng, max_len=60))
+    return "\n".join(lines)
+
+
+def _update_hunk(rng: random.Random) -> str:
+    lines = []
+    if rng.choice([True, False]):
+        hint = _text(rng, min_len=1, max_len=24)
+        lines.append(rng.choice(["@@", f"@@ {hint}"]))
+    for _ in range(rng.randint(1, 8)):
+        prefix = rng.choice([" ", "-", "+"])
+        lines.append(prefix + _text(rng, max_len=60))
+    if rng.randrange(20) == 0:
+        lines.append("*** End of File")
+    return "\n".join(lines)
+
+
+def _codex_freeform_patch(rng: random.Random) -> str:
+    """Generate patches accepted by the Codex Lark grammar shape.
+
+    This intentionally avoids ``*** Move to`` because Hermes' existing V4A
+    parser does not execute that Codex grammar variant today.
+    """
+    parts = ["*** Begin Patch"]
+    for _ in range(rng.randint(1, 5)):
+        kind = rng.choice(["add", "delete", "update"])
+        path = _path(rng)
+        if kind == "add":
+            parts.extend([f"*** Add File: {path}", _add_hunk(rng)])
+        elif kind == "delete":
+            parts.append(f"*** Delete File: {path}")
+        else:
+            parts.extend([f"*** Update File: {path}", _update_hunk(rng)])
+    parts.append("*** End Patch")
+    if rng.choice([True, False]):
+        return "\n".join(parts) + "\n"
+    return "\n".join(parts)
+
+
+def _json_args(value: dict) -> str:
+    return json.dumps(value, separators=(",", ":"), sort_keys=True)
+
+
+def _apply_hermes_replace(content: str, *, old_string: str, new_string: str, replace_all: bool) -> str:
+    return content.replace(old_string, new_string) if replace_all else content.replace(old_string, new_string, 1)
+
+
+def _lower_replace_to_apply_patch_call(
+    *,
+    call_id: str,
+    path: str,
+    content: str,
+    old_string: str,
+    new_string: str,
+    replace_all: bool,
+) -> dict:
+    """Lower a Hermes replace call to apply_patch plus private intent.
+
+    This is intentionally a test-local reference lowering.  It proves the
+    equivalence boundary we want from production code: preserve original
+    structured intent in sidecar metadata while sending the active model only
+    concrete freeform patch text.
+    """
+    expected = _apply_hermes_replace(
+        content,
+        old_string=old_string,
+        new_string=new_string,
+        replace_all=replace_all,
+    )
+    removed_lines = content.split("\n")
+    added_lines = expected.split("\n")
+    patch = "\n".join([
+        "*** Begin Patch",
+        f"*** Update File: {path}",
+        "@@",
+        *(f"-{line}" for line in removed_lines),
+        *(f"+{line}" for line in added_lines),
+        "*** End Patch",
+    ])
+    original_args = {
+        "mode": "replace",
+        "path": path,
+        "old_string": old_string,
+        "new_string": new_string,
+        "replace_all": replace_all,
+    }
+    return {
+        "id": call_id,
+        "call_id": call_id,
+        "type": "apply_patch",
+        "function": {
+            "name": "apply_patch",
+            "arguments": _json_args({"patch": patch}),
+        },
+        INTENT_KEY: {
+            "canonical_tool": "patch",
+            "canonical_arguments": original_args,
+            "lowered_to": "apply_patch",
+        },
+    }
+
+
+def _project_apply_patch_call_to_hermes_patch(tool_call: dict) -> dict:
+    """Recover the canonical Hermes patch call through production projection."""
+    projected = project_messages_for_patch_surface(
+        [{"role": "assistant", "content": "", "tool_calls": [tool_call]}],
+        patch_surface=PatchToolSurface.HERMES_PATCH,
+    )
+    return projected[0]["tool_calls"][0]
+
+
+def test_custom_apply_patch_wire_roundtrip_preserves_patch_bytes_for_generated_patches():
+    """Freeform apply_patch replay is lossless for raw patch text.
+
+    The invariant is byte-for-byte preservation of the patch string when a
+    Codex Responses custom tool call is normalized into Hermes history and
+    replayed back to Responses input items.
+    """
+    rng = random.Random(SEED)
+    for case_idx in range(CASES):
+        patch = _codex_freeform_patch(rng)
+        call_id = f"call_{case_idx}"
+        response = SimpleNamespace(
+            status="completed",
+            output=[
+                SimpleNamespace(
+                    type="custom_tool_call",
+                    id=f"ctc_{case_idx}",
+                    call_id=call_id,
+                    name="apply_patch",
+                    input=patch,
+                )
+            ],
+        )
+
+        message, finish_reason = _normalize_codex_response(response)
+
+        assert finish_reason == "tool_calls"
+        assert message.tool_calls[0].type == "apply_patch"
+        args = json.loads(message.tool_calls[0].function.arguments)
+        assert args == {"patch": patch}, f"case={case_idx}"
+
+        replay = _chat_messages_to_responses_input([
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": call_id,
+                        "call_id": call_id,
+                        "type": "apply_patch",
+                        "function": {
+                            "name": "apply_patch",
+                            "arguments": message.tool_calls[0].function.arguments,
+                        },
+                    }
+                ],
+            },
+            {
+                "role": "tool",
+                "name": "apply_patch",
+                "tool_call_id": call_id,
+                "content": "{\"success\": true}",
+            },
+        ])
+
+        assert replay[0] == {
+            "type": "custom_tool_call",
+            "call_id": call_id,
+            "name": "apply_patch",
+            "input": patch,
+        }, f"case={case_idx}"
+        assert replay[1]["type"] == "custom_tool_call_output"
+
+
+def test_apply_patch_with_private_intent_projects_back_to_original_patch_replace_calls():
+    """With sidecar intent, ``patch`` and ``apply_patch`` are representationally equivalent.
+
+    The model-facing ``apply_patch`` call carries concrete patch text.  The
+    private ``_hermes_patch_tool_intent`` field carries the original Hermes
+    structured operation, including ``replace_all``.  Projection back to a
+    non-native provider can therefore recover the exact original patch call.
+    """
+    rng = random.Random(SEED ^ 0x1A17E17)
+    for case_idx in range(CASES):
+        old_string = f"needle_{case_idx % 17}"
+        new_string = f"replacement_{case_idx}"
+        occurrences = rng.randint(1, 6)
+        replace_all = rng.choice([False, True])
+        path = _path(rng)
+        chunks = []
+        for i in range(occurrences):
+            chunks.append(f"prefix {case_idx} {i}")
+            chunks.append(old_string)
+        chunks.append(f"suffix {case_idx}")
+        content = "\n".join(chunks)
+
+        tool_call = _lower_replace_to_apply_patch_call(
+            call_id=f"call_{case_idx}",
+            path=path,
+            content=content,
+            old_string=old_string,
+            new_string=new_string,
+            replace_all=replace_all,
+        )
+        projected = _project_apply_patch_call_to_hermes_patch(tool_call)
+
+        assert projected == {
+            "id": f"call_{case_idx}",
+            "call_id": f"call_{case_idx}",
+            "type": "function",
+            "function": {
+                "name": "patch",
+                "arguments": _json_args({
+                    "mode": "replace",
+                    "path": path,
+                    "old_string": old_string,
+                    "new_string": new_string,
+                    "replace_all": replace_all,
+                }),
+            },
+        }, f"case={case_idx}"
+
+
+def test_lowered_apply_patch_is_state_equivalent_to_patch_replace_with_known_file_snapshot():
+    """A replace call can be lowered to equivalent concrete patch text for a snapshot.
+
+    This proves the execution equivalence part: for a known file state, the
+    lowered patch encodes the same final file content as Hermes replace mode.
+    The sidecar intent is what makes the conversion reversible as a tool call.
+    """
+    rng = random.Random(SEED ^ 0xE9EC71)
+    for case_idx in range(CASES):
+        old_string = f"token_{case_idx % 23}"
+        new_string = f"value_{case_idx}"
+        replace_all = rng.choice([False, True])
+        occurrences = rng.randint(1, 8)
+        lines = []
+        for i in range(occurrences):
+            lines.append(_text(rng, max_len=24))
+            lines.append(old_string)
+        lines.append(_text(rng, max_len=24))
+        content = "\n".join(lines)
+
+        tool_call = _lower_replace_to_apply_patch_call(
+            call_id=f"call_{case_idx}",
+            path=_path(rng),
+            content=content,
+            old_string=old_string,
+            new_string=new_string,
+            replace_all=replace_all,
+        )
+        patch = json.loads(tool_call["function"]["arguments"])["patch"]
+
+        removed = [
+            line[1:]
+            for line in patch.splitlines()
+            if line.startswith("-") and not line.startswith("***")
+        ]
+        added = [
+            line[1:]
+            for line in patch.splitlines()
+            if line.startswith("+") and not line.startswith("***")
+        ]
+
+        assert "\n".join(removed) == content
+        assert "\n".join(added) == _apply_hermes_replace(
+            content,
+            old_string=old_string,
+            new_string=new_string,
+            replace_all=replace_all,
+        )
+
+
+def test_apply_patch_execution_alias_delegates_to_hermes_patch_mode_losslessly(monkeypatch):
+    """Execution is lossless for the patch-text subset.
+
+    ``apply_patch(patch=P)`` must pass exactly ``P`` to Hermes'
+    environment-aware ``patch(mode="patch")`` implementation.  This is the
+    remote-terminal safety property: native-looking patch calls still execute
+    through Hermes file ops for the active task environment.
+    """
+    captured = []
+
+    def fake_patch_tool(**kwargs):
+        captured.append(kwargs)
+        return json.dumps({"success": True, "patch": kwargs["patch"]})
+
+    monkeypatch.setattr("tools.file_tools.patch_tool", fake_patch_tool)
+
+    rng = random.Random(SEED ^ 0xBAD5EED)
+    for case_idx in range(CASES):
+        patch = _codex_freeform_patch(rng)
+        result = json.loads(apply_patch_tool(patch=patch, task_id=f"task-{case_idx}"))
+
+        assert result == {"success": True, "patch": patch}
+        assert captured[-1] == {
+            "mode": "patch",
+            "patch": patch,
+            "task_id": f"task-{case_idx}",
+        }
+
+
+def test_project_messages_for_patch_surface_is_idempotent_under_repeated_application():
+    """Projecting twice under the same surface equals projecting once.
+
+    Locks in the invariant the codex build_kwargs path relies on: the
+    projection layer must be safe to run more than once on the same history
+    (e.g. when ``build_api_kwargs`` projects upstream and a transport projects
+    again).  A regression here turns a no-op into a silent corruption.
+    """
+    rng = random.Random(SEED ^ 0x1D3777)
+    surfaces = (
+        PatchToolSurface.HERMES_PATCH,
+        PatchToolSurface.CODEX_FREEFORM_APPLY_PATCH,
+    )
+    for case_idx in range(CASES):
+        patch = _codex_freeform_patch(rng)
+        call_id = f"call_{case_idx}"
+        # Mix both starting shapes — half stored as canonical ``patch``,
+        # half stored as ``apply_patch`` with private intent — so the
+        # idempotency check exercises both branches of _project_tool_call.
+        if case_idx % 2 == 0:
+            messages = [
+                {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "id": call_id,
+                            "type": "function",
+                            "function": {
+                                "name": "patch",
+                                "arguments": _json_args({"mode": "patch", "patch": patch}),
+                            },
+                        }
+                    ],
+                },
+                {
+                    "role": "tool",
+                    "name": "patch",
+                    "tool_call_id": call_id,
+                    "content": '{"success": true}',
+                },
+            ]
+        else:
+            messages = [
+                {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "id": call_id,
+                            "type": "apply_patch",
+                            "function": {
+                                "name": "apply_patch",
+                                "arguments": _json_args({"patch": patch}),
+                            },
+                            INTENT_KEY: {
+                                "canonical_tool": "patch",
+                                "canonical_arguments": {"mode": "patch", "patch": patch},
+                                "lowered_to": "apply_patch",
+                            },
+                        }
+                    ],
+                },
+                {
+                    "role": "tool",
+                    "name": "apply_patch",
+                    "tool_call_id": call_id,
+                    "content": '{"success": true}',
+                },
+            ]
+
+        for surface in surfaces:
+            once = project_messages_for_patch_surface(messages, patch_surface=surface)
+            twice = project_messages_for_patch_surface(once, patch_surface=surface)
+            assert twice == once, f"case={case_idx} surface={surface}"
+
+
+def test_patch_mode_call_round_trips_through_codex_freeform_back_to_canonical_patch():
+    """``patch(mode=patch)`` → CODEX_FREEFORM → HERMES_PATCH is lossless.
+
+    For freeform-mode patches the model itself emits, no private intent is
+    needed: the canonical Hermes arguments are recoverable from the projected
+    apply_patch call alone.  This guards the no-intent return path the model
+    will exercise on every Codex turn.
+    """
+    rng = random.Random(SEED ^ 0x517C77)
+    for case_idx in range(CASES):
+        patch = _codex_freeform_patch(rng)
+        call_id = f"call_{case_idx}"
+        canonical_args = {"mode": "patch", "patch": patch}
+        canonical = [
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": call_id,
+                        "type": "function",
+                        "function": {
+                            "name": "patch",
+                            "arguments": _json_args(canonical_args),
+                        },
+                    }
+                ],
+            },
+            {
+                "role": "tool",
+                "name": "patch",
+                "tool_call_id": call_id,
+                "content": '{"success": true}',
+            },
+        ]
+
+        lowered = project_messages_for_patch_surface(
+            canonical,
+            patch_surface=PatchToolSurface.CODEX_FREEFORM_APPLY_PATCH,
+        )
+        assert lowered[0]["tool_calls"][0]["function"]["name"] == "apply_patch"
+        assert lowered[1]["name"] == "apply_patch"
+
+        recovered = project_messages_for_patch_surface(
+            lowered,
+            patch_surface=PatchToolSurface.HERMES_PATCH,
+        )
+        recovered_tc = recovered[0]["tool_calls"][0]
+
+        assert recovered_tc["type"] == "function", f"case={case_idx}"
+        assert recovered_tc["function"]["name"] == "patch", f"case={case_idx}"
+        assert json.loads(recovered_tc["function"]["arguments"]) == canonical_args, f"case={case_idx}"
+        assert recovered[1]["name"] == "patch", f"case={case_idx}"
+
+
+def test_patch_replace_mode_needs_private_intent_for_lossless_call_shape_recovery():
+    """Without private intent, ``replace_all`` cannot be recovered from patch text.
+
+    Hermes ``patch`` has replace-mode fields that do not exist in the
+    freeform Codex grammar.  The private intent sidecar is what preserves
+    those fields when the provider-facing call is lowered to apply_patch.
+    """
+    replace_call = {
+        "mode": "replace",
+        "path": "src/example.py",
+        "old_string": "value = 1",
+        "new_string": "value = 2",
+        "replace_all": True,
+    }
+
+    lowered_without_intent = {
+        "id": "call_without_intent",
+        "type": "apply_patch",
+        "function": {
+            "name": "apply_patch",
+            "arguments": _json_args({
+                "patch": (
+                    "*** Begin Patch\n"
+                    "*** Update File: src/example.py\n"
+                    "@@\n"
+                    "-value = 1\n"
+                    "+value = 2\n"
+                    "*** End Patch"
+                )
+            }),
+        },
+    }
+
+    projected = _project_apply_patch_call_to_hermes_patch(lowered_without_intent)
+
+    assert json.loads(projected["function"]["arguments"]) == {
+        "mode": "patch",
+        "patch": json.loads(lowered_without_intent["function"]["arguments"])["patch"],
+    }
+    assert projected["function"]["name"] == "patch"
+    assert projected["function"]["arguments"] != _json_args(replace_call)

--- a/tests/run_agent/test_file_mutation_verifier.py
+++ b/tests/run_agent/test_file_mutation_verifier.py
@@ -349,10 +349,10 @@ class TestVerifierEnabled:
 
 
 def test_file_mutating_tools_set_shape():
-    """write_file + patch are the only tools the verifier tracks.
+    """Known file mutation tools are the only tools the verifier tracks.
 
     Guard rail: if someone adds a third file-mutating tool (e.g. a new
     ``append_file``), they should also audit whether the verifier should
     track it.  This test fails loudly on unilateral additions.
     """
-    assert _FILE_MUTATING_TOOLS == frozenset({"write_file", "patch"})
+    assert _FILE_MUTATING_TOOLS == frozenset({"write_file", "patch", "apply_patch"})

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -1,3 +1,5 @@
+import copy
+import json
 import sys
 import types
 from types import SimpleNamespace
@@ -311,6 +313,257 @@ def test_build_api_kwargs_codex(monkeypatch):
     assert "timeout" not in kwargs
     assert "max_tokens" not in kwargs
     assert "extra_body" not in kwargs
+
+
+def test_build_api_kwargs_codex_projects_patch_history_to_custom_apply_patch(monkeypatch):
+    patch_text = "*** Begin Patch\n*** Delete File: old.txt\n*** End Patch\n"
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "patch",
+                "description": "Hermes patch",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        },
+        {
+            "type": "function",
+            "function": {
+                "name": "read_file",
+                "description": "Read",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        },
+    ]
+    monkeypatch.setattr(run_agent, "get_tool_definitions", lambda **kwargs: tools)
+    monkeypatch.setattr(run_agent, "check_toolset_requirements", lambda: {})
+    agent = run_agent.AIAgent(
+        model="gpt-5-codex",
+        base_url="https://chatgpt.com/backend-api/codex",
+        api_key="codex-token",
+        quiet_mode=True,
+        max_iterations=4,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+    messages = [
+        {"role": "system", "content": "You are Hermes."},
+        {"role": "user", "content": "edit"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "call_patch",
+                    "type": "function",
+                    "function": {
+                        "name": "patch",
+                        "arguments": json.dumps({"mode": "patch", "patch": patch_text}),
+                    },
+                }
+            ],
+        },
+        {
+            "role": "tool",
+            "name": "patch",
+            "tool_call_id": "call_patch",
+            "content": "{\"success\": true}",
+        },
+    ]
+    stored_messages = copy.deepcopy(messages)
+
+    kwargs = agent._build_api_kwargs(messages)
+
+    assert agent.valid_tool_names == {"apply_patch", "read_file"}
+    assert messages == stored_messages
+    assert [tool.get("name") for tool in kwargs["tools"] if tool["type"] == "function"] == ["read_file"]
+    custom_tools = [tool for tool in kwargs["tools"] if tool["type"] == "custom"]
+    assert len(custom_tools) == 1
+    assert custom_tools[0]["name"] == "apply_patch"
+    assert {"type": "apply_patch"} not in kwargs["tools"]
+    assert kwargs["input"][1] == {
+        "type": "custom_tool_call",
+        "call_id": "call_patch",
+        "name": "apply_patch",
+        "input": patch_text,
+    }
+    assert kwargs["input"][2]["type"] == "custom_tool_call_output"
+
+
+def test_build_api_kwargs_keeps_apply_patch_surface_after_fallback_like_mutation(monkeypatch):
+    patch_text = "*** Begin Patch\n*** Delete File: old.txt\n*** End Patch\n"
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "patch",
+                "description": "Hermes patch",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        },
+        {
+            "type": "function",
+            "function": {
+                "name": "read_file",
+                "description": "Read",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        },
+    ]
+    monkeypatch.setattr(run_agent, "get_tool_definitions", lambda **kwargs: tools)
+    monkeypatch.setattr(run_agent, "check_toolset_requirements", lambda: {})
+    agent = run_agent.AIAgent(
+        model="gpt-5-codex",
+        base_url="https://chatgpt.com/backend-api/codex",
+        api_key="codex-token",
+        quiet_mode=True,
+        max_iterations=4,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+    messages = [
+        {"role": "system", "content": "You are Hermes."},
+        {"role": "user", "content": "edit"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "call_patch",
+                    "type": "apply_patch",
+                    "function": {
+                        "name": "apply_patch",
+                        "arguments": json.dumps({"patch": patch_text}),
+                    },
+                }
+            ],
+        },
+        {
+            "role": "tool",
+            "name": "apply_patch",
+            "tool_call_id": "call_patch",
+            "content": "{\"success\": true}",
+        },
+    ]
+
+    first_kwargs = agent._build_api_kwargs(messages)
+    assert first_kwargs["input"][1]["type"] == "custom_tool_call"
+
+    agent.provider = "openai"
+    agent.base_url = "https://api.openai.com/v1"
+    agent.model = "gpt-5.4-mini"
+    agent._base_url_hostname = "api.openai.com"
+    agent._base_url_lower = "https://api.openai.com/v1"
+    agent.api_mode = "codex_responses"
+
+    fallback_kwargs = agent._build_api_kwargs(messages)
+
+    assert agent.valid_tool_names == {"apply_patch", "read_file"}
+    assert fallback_kwargs["input"][1] == first_kwargs["input"][1]
+    assert fallback_kwargs["input"][1] == {
+        "type": "custom_tool_call",
+        "call_id": "call_patch",
+        "name": "apply_patch",
+        "input": patch_text,
+    }
+    assert fallback_kwargs["input"][2]["type"] == "custom_tool_call_output"
+
+
+def test_responses_tools_can_replace_patch_with_codex_freeform_apply_patch(monkeypatch):
+    from agent.codex_responses_adapter import _responses_tools
+
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "patch",
+                "description": "Hermes patch",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        },
+        {
+            "type": "function",
+            "function": {
+                "name": "read_file",
+                "description": "Read",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        },
+    ]
+
+    converted = _responses_tools(tools, apply_patch_tool_kind="freeform")
+
+    assert [tool.get("name") for tool in converted if tool["type"] == "function"] == ["read_file"]
+    custom_tools = [tool for tool in converted if tool["type"] == "custom"]
+    assert len(custom_tools) == 1
+    assert custom_tools[0]["name"] == "apply_patch"
+    assert custom_tools[0]["format"]["type"] == "grammar"
+    assert custom_tools[0]["format"]["syntax"] == "lark"
+    assert "begin_patch" in custom_tools[0]["format"]["definition"]
+
+
+def test_custom_apply_patch_call_round_trips_as_responses_items(monkeypatch):
+    from agent.codex_responses_adapter import (
+        _chat_messages_to_responses_input,
+        _normalize_codex_response,
+    )
+
+    patch = "*** Begin Patch\n*** Add File: hello.txt\n+hello\n*** End Patch\n"
+    response = SimpleNamespace(
+        status="completed",
+        output=[
+            SimpleNamespace(
+                type="custom_tool_call",
+                id="ctc_123",
+                call_id="call_123",
+                name="apply_patch",
+                input=patch,
+            )
+        ],
+    )
+    message, finish_reason = _normalize_codex_response(response)
+
+    assert finish_reason == "tool_calls"
+    assert message.tool_calls[0].type == "apply_patch"
+    assert message.tool_calls[0].function.name == "apply_patch"
+
+    replay = _chat_messages_to_responses_input([
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "call_123",
+                    "call_id": "call_123",
+                    "type": "apply_patch",
+                    "function": {
+                        "name": "apply_patch",
+                        "arguments": message.tool_calls[0].function.arguments,
+                    },
+                }
+            ],
+        },
+        {
+            "role": "tool",
+            "name": "apply_patch",
+            "tool_call_id": "call_123",
+            "content": "{\"success\": true}",
+        },
+    ])
+
+    assert replay == [
+        {
+            "type": "custom_tool_call",
+            "call_id": "call_123",
+            "name": "apply_patch",
+            "input": patch,
+        },
+        {
+            "type": "custom_tool_call_output",
+            "call_id": "call_123",
+            "output": "{\"success\": true}",
+        },
+    ]
 
 
 def test_build_api_kwargs_codex_clamps_minimal_effort(monkeypatch):

--- a/tests/run_agent/test_tool_projection.py
+++ b/tests/run_agent/test_tool_projection.py
@@ -1,0 +1,195 @@
+import copy
+import json
+from types import SimpleNamespace
+
+from agent.tool_projection import (
+    INTENT_KEY,
+    PatchToolSurface,
+    project_messages_for_patch_surface,
+    projected_valid_tool_names,
+    refresh_agent_tool_projection,
+    resolve_patch_tool_surface,
+    responses_tools_for_surface,
+)
+
+
+def _patch_tool():
+    return {
+        "type": "function",
+        "function": {
+            "name": "patch",
+            "description": "Hermes patch",
+            "parameters": {"type": "object", "properties": {}},
+        },
+    }
+
+
+def _read_tool():
+    return {
+        "type": "function",
+        "function": {
+            "name": "read_file",
+            "description": "Read",
+            "parameters": {"type": "object", "properties": {}},
+        },
+    }
+
+
+def test_codex_responses_gets_freeform_apply_patch_surface():
+    tools = [_patch_tool(), _read_tool()]
+
+    surface = resolve_patch_tool_surface(
+        tools,
+        api_mode="codex_responses",
+        provider="openai-codex",
+        model="gpt-5.3-codex",
+    )
+
+    assert surface == PatchToolSurface.CODEX_FREEFORM_APPLY_PATCH
+    assert projected_valid_tool_names(tools, patch_surface=surface) == {
+        "apply_patch",
+        "read_file",
+    }
+
+
+def test_unknown_responses_provider_keeps_hermes_patch_surface():
+    tools = [_patch_tool(), _read_tool()]
+
+    surface = resolve_patch_tool_surface(
+        tools,
+        api_mode="codex_responses",
+        provider="custom",
+        base_url="https://example.invalid/v1",
+        model="gpt-5.3",
+    )
+
+    assert surface == PatchToolSurface.HERMES_PATCH
+    assert projected_valid_tool_names(tools, patch_surface=surface) == {
+        "patch",
+        "read_file",
+    }
+
+
+def test_frozen_agent_projection_survives_fallback_provider_mutation():
+    agent = SimpleNamespace(
+        tools=[_patch_tool(), _read_tool()],
+        api_mode="codex_responses",
+        provider="openai-codex",
+        base_url="https://chatgpt.com/backend-api/codex",
+        model="gpt-5.4-mini",
+    )
+
+    refresh_agent_tool_projection(agent, freeze=True)
+    assert agent._patch_tool_surface == PatchToolSurface.CODEX_FREEFORM_APPLY_PATCH
+    assert agent.valid_tool_names == {"apply_patch", "read_file"}
+
+    agent.provider = "openai"
+    agent.base_url = "https://api.openai.com/v1"
+    agent.model = "gpt-5.4-mini"
+    refresh_agent_tool_projection(agent)
+
+    assert agent._patch_tool_surface == PatchToolSurface.CODEX_FREEFORM_APPLY_PATCH
+    assert agent.valid_tool_names == {"apply_patch", "read_file"}
+
+
+def test_responses_schema_uses_custom_freeform_tool_not_hosted_apply_patch():
+    converted = responses_tools_for_surface(
+        [_patch_tool(), _read_tool()],
+        patch_surface=PatchToolSurface.CODEX_FREEFORM_APPLY_PATCH,
+    )
+
+    assert {"type": "apply_patch"} not in converted
+    assert [tool.get("name") for tool in converted if tool["type"] == "function"] == ["read_file"]
+    custom = [tool for tool in converted if tool["type"] == "custom"]
+    assert len(custom) == 1
+    assert custom[0]["name"] == "apply_patch"
+    assert custom[0]["format"]["syntax"] == "lark"
+
+
+def test_patch_mode_history_projects_to_apply_patch_without_mutating_storage():
+    patch = "*** Begin Patch\n*** Delete File: old.txt\n*** End Patch\n"
+    messages = [
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {
+                        "name": "patch",
+                        "arguments": json.dumps({"mode": "patch", "patch": patch}),
+                    },
+                }
+            ],
+        },
+        {
+            "role": "tool",
+            "name": "patch",
+            "tool_call_id": "call_1",
+            "content": '{"success": true}',
+        },
+    ]
+    stored = copy.deepcopy(messages)
+
+    projected = project_messages_for_patch_surface(
+        messages,
+        patch_surface=PatchToolSurface.CODEX_FREEFORM_APPLY_PATCH,
+    )
+
+    assert messages == stored
+    tc = projected[0]["tool_calls"][0]
+    assert tc["type"] == "apply_patch"
+    assert tc["function"]["name"] == "apply_patch"
+    assert json.loads(tc["function"]["arguments"]) == {"patch": patch}
+    assert projected[1]["name"] == "apply_patch"
+
+
+def test_apply_patch_history_projects_to_hermes_patch_and_strips_private_intent():
+    original_args = {
+        "mode": "replace",
+        "path": "src/app.py",
+        "old_string": "foo",
+        "new_string": "bar",
+        "replace_all": True,
+    }
+    messages = [
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "call_2",
+                    "type": "apply_patch",
+                    "function": {
+                        "name": "apply_patch",
+                        "arguments": json.dumps({"patch": "ignored when intent exists"}),
+                    },
+                    INTENT_KEY: {
+                        "canonical_tool": "patch",
+                        "canonical_arguments": original_args,
+                        "lowered_to": "apply_patch",
+                    },
+                }
+            ],
+        },
+        {
+            "role": "tool",
+            "name": "apply_patch",
+            "tool_call_id": "call_2",
+            "content": '{"success": true}',
+        },
+    ]
+
+    projected = project_messages_for_patch_surface(
+        messages,
+        patch_surface=PatchToolSurface.HERMES_PATCH,
+    )
+
+    tc = projected[0]["tool_calls"][0]
+    assert INTENT_KEY not in tc
+    assert tc["type"] == "function"
+    assert tc["function"]["name"] == "patch"
+    assert json.loads(tc["function"]["arguments"]) == original_args
+    assert projected[1]["name"] == "patch"
+    assert INTENT_KEY in messages[0]["tool_calls"][0]

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -943,6 +943,13 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
         return tool_error(str(e))
 
 
+def apply_patch_tool(patch: str = None, task_id: str = "default") -> str:
+    """Apply a freeform Codex-style patch through Hermes file operations."""
+    if not patch:
+        return tool_error("apply_patch requires patch")
+    return patch_tool(mode="patch", patch=patch, task_id=task_id)
+
+
 def search_tool(pattern: str, target: str = "content", path: str = ".",
                 file_glob: str = None, limit: int = 50, offset: int = 0,
                 output_mode: str = "content", context: int = 0,


### PR DESCRIPTION
## What does this PR do?

Models perform best on tasks that are similar to the tasks they were trained on OpenAI [recommends, \[and trains for\]](https://developers.openai.com/api/docs/guides/tools-apply-patch), the apply_patch tool.

This PR adds a lossless bidirectional projection that transparently translates from the Hermes-native (Cline-style) patch tool calls to OpenAI apply_patch calls, and back.

**It should be noted that this does not perform better than the currnt patch tool (See below, Benchmark results). This PR should not be merged, unless it shows performance improvements.**

## Type of Change

<!-- Check the one that applies. -->

- [x] Experiment
- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)

## Changes Made

- added lossless conversion between Hermes-native patch calls and OpenAI `apply_patch` calls
- projects patch requests to `apply_patch` for OpenAI model compatibility, then converts responses back to Hermes-native form
- preserves existing patch behavior while improving model alignment with OpenAI’s recommended patch workflow

## Benchmark results

Setup:

- Backend/model: `openai-codex`, `gpt-5.4-mini`, high reasoning
- Budget: `max_iterations=500`, 20-minute timeout
- Tool surfaces: Hermes JSON `patch` vs Codex-style freeform `apply_patch`
- Instances: `pallets__flask-4045`, `pallets__flask-4992`, `pallets__flask-5063`, `pytest-dev__pytest-11143`, `pytest-dev__pytest-11148`

| Tool surface | Solved | Timeouts | API calls | Tool calls | Patch calls | Reasoning tokens | Agent time |
|---|---:|---:|---:|---:|---:|---:|---:|
| Hermes JSON `patch` | 5/5 | 0 | 103 | 153 | 8 | 17,281 | 722.9s |
| Codex freeform `apply_patch` | 5/5 | 0 | 98 | 136 | 11 | 30,116 | 803.8s |

Paired outcome:

- Both solved: 5
- Native `apply_patch` only: 0
- Hermes JSON `patch` only: 0
- Both failed: 0

Interpretation: on a tiny clean subset where the local environment does not dominate the outcome, both patch surfaces solved every task. Native `apply_patch` used fewer API calls and fewer total tool calls, but more patch calls, more reasoning tokens, and more wall time in this run.


## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Fedora 44

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] N/A I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] N/A  I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior