### PR TITLE
fix: reflect configured execute_code limits in schema

### DIFF
--- a/tests/tools/test_code_execution.py
+++ b/tests/tools/test_code_execution.py
@@ -45,6 +45,7 @@ from tools.code_execution_tool import (
     EXECUTE_CODE_SCHEMA,
     _TOOL_DOC_LINES,
     _execute_remote,
+    _resolve_limits_config,
 )
 
 
@@ -645,11 +646,41 @@ class TestBuildExecuteCodeSchema(unittest.TestCase):
         self.assertNotIn("import , ...", code_desc)
 
     def test_description_mentions_limits(self):
-        schema = build_execute_code_schema()
+        with patch("tools.code_execution_tool._load_config", return_value={}):
+            schema = build_execute_code_schema(mode="project")
         desc = schema["description"]
         self.assertIn("5-minute timeout", desc)
         self.assertIn("50KB", desc)
         self.assertIn("50 tool calls", desc)
+
+    def test_description_uses_configured_limits(self):
+        with patch("tools.code_execution_tool._load_config",
+                   return_value={"timeout": 120, "max_tool_calls": 7}):
+            schema = build_execute_code_schema(mode="project")
+        desc = schema["description"]
+        self.assertIn("120-second timeout", desc)
+        self.assertIn("max 7 tool calls", desc)
+
+    def test_description_preserves_zero_configured_limits(self):
+        with patch("tools.code_execution_tool._load_config",
+                   return_value={"timeout": 0, "max_tool_calls": 0}):
+            schema = build_execute_code_schema(mode="project")
+        desc = schema["description"]
+        self.assertIn("0-second timeout", desc)
+        self.assertIn("max 0 tool calls", desc)
+        self.assertEqual(_resolve_limits_config({"timeout": 0, "max_tool_calls": 0}),
+                         (0, 0))
+
+    def test_description_falls_back_for_invalid_configured_limits(self):
+        with patch("tools.code_execution_tool._load_config",
+                   return_value={"timeout": "invalid", "max_tool_calls": "invalid"}):
+            schema = build_execute_code_schema(mode="project")
+        desc = schema["description"]
+        self.assertIn("5-minute timeout", desc)
+        self.assertIn("max 50 tool calls", desc)
+        self.assertEqual(_resolve_limits_config({"timeout": "invalid",
+                                                 "max_tool_calls": "invalid"}),
+                         (300, 50))
 
     def test_description_mentions_helpers(self):
         schema = build_execute_code_schema()

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -851,8 +851,7 @@ def _execute_remote(
     """
 
     _cfg = _load_config()
-    timeout = _cfg.get("timeout", DEFAULT_TIMEOUT)
-    max_tool_calls = _cfg.get("max_tool_calls", DEFAULT_MAX_TOOL_CALLS)
+    timeout, max_tool_calls = _resolve_limits_config(_cfg)
 
     session_tools = set(enabled_tools) if enabled_tools else set()
     sandbox_tools = frozenset(SANDBOX_ALLOWED_TOOLS & session_tools)
@@ -1076,8 +1075,7 @@ def execute_code(
 
     # Resolve config
     _cfg = _load_config()
-    timeout = _cfg.get("timeout", DEFAULT_TIMEOUT)
-    max_tool_calls = _cfg.get("max_tool_calls", DEFAULT_MAX_TOOL_CALLS)
+    timeout, max_tool_calls = _resolve_limits_config(_cfg)
 
     # Determine which tools the sandbox can call
     session_tools = set(enabled_tools) if enabled_tools else set()
@@ -1519,6 +1517,24 @@ def _load_config() -> dict:
         return {}
 
 
+def _parse_int_config(value: Any, default: int) -> int:
+    """Parse an integer config value, falling back only when invalid/missing."""
+    if value is None or value == "":
+        return default
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _resolve_limits_config(cfg: dict) -> tuple[int, int]:
+    """Return (timeout_seconds, max_tool_calls) from code_execution config."""
+    return (
+        _parse_int_config(cfg.get("timeout"), DEFAULT_TIMEOUT),
+        _parse_int_config(cfg.get("max_tool_calls"), DEFAULT_MAX_TOOL_CALLS),
+    )
+
+
 # ---------------------------------------------------------------------------
 # Execution mode resolution (strict vs project)
 # ---------------------------------------------------------------------------
@@ -1688,8 +1704,14 @@ def build_execute_code_schema(enabled_sandbox_tools: set = None,
     """
     if enabled_sandbox_tools is None:
         enabled_sandbox_tools = SANDBOX_ALLOWED_TOOLS
+    cfg = _load_config()
     if mode is None:
         mode = _get_execution_mode()
+    timeout_seconds, max_tool_calls = _resolve_limits_config(cfg)
+    if timeout_seconds == DEFAULT_TIMEOUT:
+        timeout_label = "5-minute timeout"
+    else:
+        timeout_label = f"{timeout_seconds}-second timeout"
 
     # Build tool documentation lines for only the enabled tools
     tool_lines = "\n".join(
@@ -1730,7 +1752,8 @@ def build_execute_code_schema(enabled_sandbox_tools: set = None,
         "or the task requires interactive user input.\n\n"
         f"Available via `from hermes_tools import ...`:\n\n"
         f"{tool_lines}\n\n"
-        "Limits: 5-minute timeout, 50KB stdout cap, max 50 tool calls per script. "
+        f"Limits: {timeout_label}, 50KB stdout cap, "
+        f"max {max_tool_calls} tool calls per script. "
         "terminal() is foreground-only (no background or pty).\n\n"
         f"{cwd_note}\n\n"
         "Print your final result to stdout. Use Python stdlib (json, re, math, csv, "


### PR DESCRIPTION
## Summary
- Parse `code_execution.timeout` and `code_execution.max_tool_calls` through a shared helper for both runtime execution paths and schema generation
- Make the `execute_code` tool description advertise configured limits instead of hard-coded defaults
- Add tests for default, configured, zero/falsy, and invalid configured limits

## Test Plan
- `python -m pytest tests/tools/test_code_execution.py -q`
- `python -m ruff check tools/code_execution_tool.py tests/tools/test_code_execution.py`

## Verification
- Independent pre-commit reviewer passed with no security concerns or logic errors
