### PR TITLE
fix(docs): replace YouTube channel link with actual playlist in Quickstart

### DIFF
--- a/website/docs/getting-started/quickstart.md
+++ b/website/docs/getting-started/quickstart.md
@@ -10,7 +10,7 @@ This guide gets you from zero to a working Hermes setup that survives real use. 
 
 ## Prefer to watch?
 
-**Onchain AI Garage** put together a Masterclass walkthrough of installation, setup, and basic commands — a good companion to this page if you'd rather follow along on video. For more, see the full [Hermes Agent Tutorials & Use Cases](https://www.youtube.com/channel/UCqB1bhMwGsW-yefBxYwFCCg) playlist.
+**Onchain AI Garage** put together a Masterclass walkthrough of installation, setup, and basic commands — a good companion to this page if you'd rather follow along on video. For more, see the full [Hermes Agent Tutorials & Use Cases](https://www.youtube.com/playlist?list=PLmpUb_PWAkDxewld5ZYyKifuHxgIbiq2d) playlist.
 
 <div style={{position: 'relative', paddingBottom: '56.25%', height: 0, overflow: 'hidden', maxWidth: '100%', marginBottom: '1.5rem'}}>
   <iframe


### PR DESCRIPTION
## What does this PR do?
The "Hermes Agent Tutorials & Use Cases" link in the Quickstart page points 
to the YouTube channel page instead of the actual playlist. Users clicking 
"see the full playlist" land on the channel homepage, not the playlist.

## Related Issue
Fixes #

## Type of Change
- [x] 📝 Documentation update

## Changes Made
- `website/docs/getting-started/quickstart.md` — replaced YouTube channel URL 
with direct playlist URL

## How to Test
1. Open https://hermes-agent.nousresearch.com/docs/getting-started/quickstart
2. Click "Hermes Agent Tutorials & Use Cases" link
3. Confirm it now opens the playlist directly

## Checklist
### Code
- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` — N/A
- [ ] I've added tests — N/A
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping
- [x] I've updated relevant documentation — N/A
- [x] I've updated `cli-config.yaml.example` — N/A
- [x] I've updated `CONTRIBUTING.md` — N/A
- [x] I've considered cross-platform impact — N/A
- [x] I've updated tool descriptions/schemas — N/A

## Screenshots / Logs

**Before:** clicking the link opens YouTube channel homepage
<img width="1420" height="880" alt="image" src="https://github.com/user-attachments/assets/de894454-99c9-400d-81f9-070402332c43" />

**After:** clicking the link opens the actual playlist
<img width="1529" height="908" alt="image" src="https://github.com/user-attachments/assets/25c8e48d-9a74-4f33-ab01-fb1a9208fe66" />