### PR TITLE
Strip reasoning_content + <think> blocks from outbound chat-completions messages

### DIFF
--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -10,6 +10,7 @@ reasoning configuration, temperature handling, and extra_body assembly.
 """
 
 import copy
+import re
 from typing import Any, Dict, List, Optional
 
 from agent.lmstudio_reasoning import resolve_lmstudio_effort
@@ -127,7 +128,30 @@ class ChatCompletionsTransport(ProviderTransport):
           ``Extra inputs are not permitted, field: 'messages[N].tool_name'``.
           Permissive providers (OpenRouter, MiniMax) silently ignore the
           field, which masked the bug for months.
+        - Reasoning fields on assistant messages: ``reasoning_content``,
+          ``reasoning``, and ``reasoning_details``. OpenAI reasoning models
+          (gpt-5.5, o1, o3), DeepSeek-R1 (via Anthropic-format adapter), and
+          Moonshot Kimi emit these alongside ``content`` in responses. When
+          conversation history is replayed to non-reasoning chat-completions
+          providers (Groq llama-3.3, Anthropic-on-OpenRouter, Ollama, etc.),
+          those providers reject with HTTP 400 ``property "reasoning_content"
+          is unsupported``. Stripping at the transport keeps cross-provider
+          fallback chains working without surfacing reasoning-only fields.
+        - Inline ``<think>...</think>`` and ``<reasoning>...</reasoning>``
+          blocks in assistant message ``content`` — DeepSeek-R1 served via
+          Ollama emits chain-of-thought as inline tags rather than the
+          ``reasoning_content`` field. Stripping here keeps history clean
+          and avoids confusing downstream models with prior CoT exhaust.
         """
+        _THINK_RE = re.compile(r"<think>.*?</think>\s*", re.DOTALL | re.IGNORECASE)
+        _REASON_TAG_RE = re.compile(r"<reasoning>.*?</reasoning>\s*", re.DOTALL | re.IGNORECASE)
+        _REASONING_KEYS = ("reasoning_content", "reasoning", "reasoning_details")
+
+        def _has_inline_reasoning(s: Any) -> bool:
+            if not isinstance(s, str):
+                return False
+            return "<think>" in s or "<reasoning>" in s
+
         needs_sanitize = False
         for msg in messages:
             if not isinstance(msg, dict):
@@ -139,6 +163,20 @@ class ChatCompletionsTransport(ProviderTransport):
             ):
                 needs_sanitize = True
                 break
+            if any(k in msg for k in _REASONING_KEYS):
+                needs_sanitize = True
+                break
+            content = msg.get("content")
+            if isinstance(content, str) and _has_inline_reasoning(content):
+                needs_sanitize = True
+                break
+            if isinstance(content, list):
+                if any(
+                    isinstance(part, dict) and _has_inline_reasoning(part.get("text"))
+                    for part in content
+                ):
+                    needs_sanitize = True
+                    break
             tool_calls = msg.get("tool_calls")
             if isinstance(tool_calls, list):
                 for tc in tool_calls:
@@ -160,6 +198,19 @@ class ChatCompletionsTransport(ProviderTransport):
             msg.pop("codex_reasoning_items", None)
             msg.pop("codex_message_items", None)
             msg.pop("tool_name", None)
+            for k in _REASONING_KEYS:
+                msg.pop(k, None)
+            content = msg.get("content")
+            if isinstance(content, str):
+                stripped = _THINK_RE.sub("", content)
+                stripped = _REASON_TAG_RE.sub("", stripped).strip()
+                msg["content"] = stripped
+            elif isinstance(content, list):
+                for part in content:
+                    if isinstance(part, dict) and isinstance(part.get("text"), str):
+                        t = _THINK_RE.sub("", part["text"])
+                        t = _REASON_TAG_RE.sub("", t).strip()
+                        part["text"] = t
             tool_calls = msg.get("tool_calls")
             if isinstance(tool_calls, list):
                 for tc in tool_calls:

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -67,6 +67,89 @@ class TestChatCompletionsBasic:
         assert msgs[2]["tool_name"] == "execute_code"
 
 
+    def test_convert_messages_strips_reasoning_content_field(self, transport):
+        """``reasoning_content`` (DeepSeek/Moonshot/o1-via-OpenRouter) on assistant
+        messages is rejected by non-reasoning providers (Groq, Ollama) with HTTP 400.
+        """
+        msgs = [
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "ok", "reasoning_content": "thinking..."},
+        ]
+        result = transport.convert_messages(msgs)
+        assert "reasoning_content" not in result[1]
+        assert result[1]["content"] == "ok"
+        # Original untouched
+        assert msgs[1]["reasoning_content"] == "thinking..."
+
+    def test_convert_messages_strips_reasoning_field(self, transport):
+        """``reasoning`` (unified format used by some adapters) is also stripped."""
+        msgs = [
+            {"role": "assistant", "content": "ok", "reasoning": "step-by-step..."},
+        ]
+        result = transport.convert_messages(msgs)
+        assert "reasoning" not in result[0]
+        assert result[0]["content"] == "ok"
+
+    def test_convert_messages_strips_reasoning_details_field(self, transport):
+        msgs = [
+            {"role": "assistant", "content": "ok",
+             "reasoning_details": [{"type": "thinking", "text": "..."}]},
+        ]
+        result = transport.convert_messages(msgs)
+        assert "reasoning_details" not in result[0]
+
+    def test_convert_messages_strips_inline_think_block(self, transport):
+        """DeepSeek-R1 via Ollama emits chain-of-thought as <think>...</think>
+        inside ``message.content``. Strip it before replaying history.
+        """
+        msgs = [
+            {"role": "assistant",
+             "content": "<think>The user said hi, I should greet back.</think>Hello!"},
+        ]
+        result = transport.convert_messages(msgs)
+        assert "<think>" not in result[0]["content"]
+        assert result[0]["content"] == "Hello!"
+
+    def test_convert_messages_strips_inline_think_block_multiline(self, transport):
+        msgs = [
+            {"role": "assistant",
+             "content": "<think>\nLine one of thinking.\nLine two.\n</think>\n\nFinal answer."},
+        ]
+        result = transport.convert_messages(msgs)
+        assert "<think>" not in result[0]["content"]
+        assert "Line one" not in result[0]["content"]
+        assert result[0]["content"] == "Final answer."
+
+    def test_convert_messages_strips_inline_reasoning_block(self, transport):
+        """Some adapters use <reasoning>...</reasoning> instead of <think>."""
+        msgs = [
+            {"role": "assistant",
+             "content": "<reasoning>internal CoT</reasoning>Done."},
+        ]
+        result = transport.convert_messages(msgs)
+        assert "<reasoning>" not in result[0]["content"]
+        assert result[0]["content"] == "Done."
+
+    def test_convert_messages_strips_think_in_content_parts(self, transport):
+        """Content can be a list of typed parts (vision/multimodal); strip <think>
+        from each text part too.
+        """
+        msgs = [
+            {"role": "assistant",
+             "content": [{"type": "text",
+                          "text": "<think>thinking</think>Visible response."}]},
+        ]
+        result = transport.convert_messages(msgs)
+        assert "<think>" not in result[0]["content"][0]["text"]
+        assert result[0]["content"][0]["text"] == "Visible response."
+
+    def test_convert_messages_no_strip_when_no_reasoning(self, transport):
+        """A normal assistant message without reasoning fields is identity-returned
+        (no deepcopy)."""
+        msgs = [{"role": "assistant", "content": "plain reply"}]
+        result = transport.convert_messages(msgs)
+        assert result is msgs  # no copy needed
+
 class TestChatCompletionsBuildKwargs:
 
     def test_basic_kwargs(self, transport):


### PR DESCRIPTION
## Problem

Reasoning fields and inline chain-of-thought blocks emitted by reasoning
models (gpt-5.5, o1/o3, DeepSeek-R1, Kimi) accumulate in conversation
history. When the same conversation falls through to a non-reasoning
chat-completions provider (Groq llama, Ollama qwen, etc.), the request is
rejected with:

```
HTTP 400: 'messages.N' : property 'reasoning_content' is unsupported
```

### Reproduction

Set up Hermes with:
- Primary: `openai-codex` provider, model `gpt-5.5`
- Fallback: `custom` provider pointed at Groq, model `llama-3.3-70b-versatile`

Trigger a 429 `usage_limit_reached` on the primary (easy with a Plus subscription
account — heavy usage day). Hermes routes to the Groq fallback. Groq immediately
returns HTTP 400 `reasoning_content is unsupported` because the prior gpt-5.5
assistant turn's `reasoning_content` is still in the message list.

The fallback chain is poisoned and unrecoverable until the affected assistant
turns are removed from history.

## Fix

Extend `convert_messages()` — already the central outbound sanitizer for the
chat-completions transport — to additionally drop:

- `reasoning_content` / `reasoning` / `reasoning_details` fields on assistant
  messages
- Inline `<think>...</think>` blocks in `message.content` (DeepSeek-R1 via
  Ollama emits chain-of-thought as inline tags rather than the structured field)
- Inline `<reasoning>...</reasoning>` blocks (Kimi/Moonshot variant)

This keeps the existing `codex_reasoning_items`, `codex_message_items`,
`tool_name`, `call_id`, and `response_item_id` handling intact.

## Why this transport

Anthropic and Gemini adapters maintain their own `reasoning_content` handling
paths and do not flow through `chat_completions.py` — they keep working as-is.
The chat-completions transport is shared by Groq, Ollama, OpenRouter, LM Studio,
Together, Fireworks, and other openai-compat endpoints, all of which reject
`reasoning_content` on input.

## Tests

8 new test cases under `TestChatCompletionsBasic`. All 11 `convert_messages`
tests pass (3 existing + 8 new). See `tests/agent/transports/test_chat_completions.py`.

## Verified in production

Patch is currently deployed at hermes-on-Hetzner (mine) via a docker-compose
bind-mount, restoring the Groq fallback after both Codex accounts hit
`usage_limit_reached` simultaneously.