### PR TITLE
fix(memory): raise default char limits to reduce write-retry thrashing

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1047,8 +1047,8 @@ def init_agent(
             if agent._memory_enabled or agent._user_profile_enabled:
                 from tools.memory_tool import MemoryStore
                 agent._memory_store = MemoryStore(
-                    memory_char_limit=mem_config.get("memory_char_limit", 2200),
-                    user_char_limit=mem_config.get("user_char_limit", 1375),
+                    memory_char_limit=mem_config.get("memory_char_limit", 8000),
+                    user_char_limit=mem_config.get("user_char_limit", 4000),
                 )
                 agent._memory_store.load_from_disk()
         except Exception:

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1191,8 +1191,8 @@ DEFAULT_CONFIG = {
     "memory": {
         "memory_enabled": True,
         "user_profile_enabled": True,
-        "memory_char_limit": 2200,   # ~800 tokens at 2.75 chars/token
-        "user_char_limit": 1375,     # ~500 tokens at 2.75 chars/token
+        "memory_char_limit": 8000,   # ~2900 tokens at 2.75 chars/token
+        "user_char_limit": 4000,     # ~1450 tokens at 2.75 chars/token
         # External memory provider plugin (empty = built-in only).
         # Set to a provider name to activate: "openviking", "mem0",
         # "hindsight", "holographic", "retaindb", "byterover".

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -115,7 +115,7 @@ class MemoryStore:
         Tool responses always reflect this live state.
     """
 
-    def __init__(self, memory_char_limit: int = 2200, user_char_limit: int = 1375):
+    def __init__(self, memory_char_limit: int = 8000, user_char_limit: int = 4000):
         self.memory_entries: List[str] = []
         self.user_entries: List[str] = []
         self.memory_char_limit = memory_char_limit


### PR DESCRIPTION
## Summary

The default `memory_char_limit` (2200) and `user_char_limit` (1375) are too tight for long improvement sessions. The agent repeatedly hits the cap, burns 3-7 iterations per write retrying with shorter wording, then fails anyway.

Raise defaults to 8000/4000 respectively — still tiny relative to a 100K+ context window.

## Changes

| File | Change |
|------|--------|
| `hermes_cli/config.py` | `memory_char_limit`: 2200 → 8000, `user_char_limit`: 1375 → 4000 |
| `tools/memory_tool.py` | `MemoryStore()` parameter defaults updated |
| `agent/agent_init.py` | Hardcoded fallback defaults updated |

## Testing

- `tests/tools/test_memory_tool.py` — 33 passed

## Related

Closes #30267