### PR TITLE
test(tools): disarm lazy-install probe so _HAS_FASTER_WHISPER patches work

### DIFF
--- a/tests/tools/conftest.py
+++ b/tests/tools/conftest.py
@@ -8,6 +8,8 @@ depend on the registry being populated should use it explicitly or via
 ``@pytest.mark.usefixtures("web_registry_populated")``.
 """
 
+from unittest.mock import patch
+
 import pytest
 
 
@@ -48,3 +50,20 @@ def web_registry_populated():
     yield
     from agent.web_search_registry import _reset_for_tests
     _reset_for_tests()
+
+
+@pytest.fixture
+def disable_lazy_stt_install():
+    """Disarm the runtime lazy-install probe so static ``_HAS_FASTER_WHISPER``
+    patches accurately simulate 'faster-whisper not installed'.
+
+    Without this, ``_try_lazy_install_stt()`` calls
+    ``importlib.util.find_spec("faster_whisper")``, which returns truthy
+    whenever the package is installed in the dev / CI environment —
+    defeating the test's ``_HAS_FASTER_WHISPER=False`` patch.
+
+    Opt in at module scope with
+    ``pytestmark = pytest.mark.usefixtures("disable_lazy_stt_install")``.
+    """
+    with patch("tools.transcription_tools._try_lazy_install_stt", return_value=False):
+        yield

--- a/tests/tools/test_transcription.py
+++ b/tests/tools/test_transcription.py
@@ -28,6 +28,20 @@ def _clear_openai_env(monkeypatch):
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
 
 
+@pytest.fixture(autouse=True)
+def _disable_lazy_stt_install():
+    """Disarm the runtime lazy-install probe so static ``_HAS_FASTER_WHISPER``
+    patches accurately simulate 'faster-whisper not installed'.
+
+    Without this, ``_try_lazy_install_stt()`` calls
+    ``importlib.util.find_spec("faster_whisper")``, which returns truthy
+    whenever the package is installed in the dev / CI environment —
+    defeating the test's ``_HAS_FASTER_WHISPER=False`` patch.
+    """
+    with patch("tools.transcription_tools._try_lazy_install_stt", return_value=False):
+        yield
+
+
 class TestGetProvider:
     """_get_provider() picks the right backend based on config + availability."""
 

--- a/tests/tools/test_transcription.py
+++ b/tests/tools/test_transcription.py
@@ -23,23 +23,12 @@ def _fake_faster_whisper_module(mock_model):
 # ---------------------------------------------------------------------------
 
 
+pytestmark = pytest.mark.usefixtures("disable_lazy_stt_install")
+
+
 @pytest.fixture(autouse=True)
 def _clear_openai_env(monkeypatch):
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
-
-
-@pytest.fixture(autouse=True)
-def _disable_lazy_stt_install():
-    """Disarm the runtime lazy-install probe so static ``_HAS_FASTER_WHISPER``
-    patches accurately simulate 'faster-whisper not installed'.
-
-    Without this, ``_try_lazy_install_stt()`` calls
-    ``importlib.util.find_spec("faster_whisper")``, which returns truthy
-    whenever the package is installed in the dev / CI environment —
-    defeating the test's ``_HAS_FASTER_WHISPER=False`` patch.
-    """
-    with patch("tools.transcription_tools._try_lazy_install_stt", return_value=False):
-        yield
 
 
 class TestGetProvider:

--- a/tests/tools/test_transcription_dotenv_fallback.py
+++ b/tests/tools/test_transcription_dotenv_fallback.py
@@ -28,6 +28,20 @@ def isolate_env(monkeypatch):
         monkeypatch.delenv(key, raising=False)
 
 
+@pytest.fixture(autouse=True)
+def _disable_lazy_stt_install():
+    """Disarm the runtime lazy-install probe so static ``_HAS_FASTER_WHISPER``
+    patches accurately simulate 'faster-whisper not installed'.
+
+    Without this, ``_try_lazy_install_stt()`` calls
+    ``importlib.util.find_spec("faster_whisper")``, which returns truthy
+    whenever the package is installed in the dev / CI environment —
+    defeating the test's ``_HAS_FASTER_WHISPER=False`` patch.
+    """
+    with patch("tools.transcription_tools._try_lazy_install_stt", return_value=False):
+        yield
+
+
 class TestProviderSelectionGate:
     """``_get_provider`` picks the STT backend. If it only consulted
     ``os.environ`` a user with keys in ``~/.hermes/.env`` would be told

--- a/tests/tools/test_transcription_dotenv_fallback.py
+++ b/tests/tools/test_transcription_dotenv_fallback.py
@@ -12,6 +12,9 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 
+pytestmark = pytest.mark.usefixtures("disable_lazy_stt_install")
+
+
 @pytest.fixture(autouse=True)
 def isolate_env(monkeypatch):
     """Strip every STT-related env var so the test really exercises the
@@ -26,20 +29,6 @@ def isolate_env(monkeypatch):
         "XAI_STT_BASE_URL",
     ):
         monkeypatch.delenv(key, raising=False)
-
-
-@pytest.fixture(autouse=True)
-def _disable_lazy_stt_install():
-    """Disarm the runtime lazy-install probe so static ``_HAS_FASTER_WHISPER``
-    patches accurately simulate 'faster-whisper not installed'.
-
-    Without this, ``_try_lazy_install_stt()`` calls
-    ``importlib.util.find_spec("faster_whisper")``, which returns truthy
-    whenever the package is installed in the dev / CI environment —
-    defeating the test's ``_HAS_FASTER_WHISPER=False`` patch.
-    """
-    with patch("tools.transcription_tools._try_lazy_install_stt", return_value=False):
-        yield
 
 
 class TestProviderSelectionGate:

--- a/tests/tools/test_transcription_tools.py
+++ b/tests/tools/test_transcription_tools.py
@@ -42,6 +42,9 @@ def sample_ogg(tmp_path):
     return str(ogg_path)
 
 
+pytestmark = pytest.mark.usefixtures("disable_lazy_stt_install")
+
+
 @pytest.fixture(autouse=True)
 def clean_env(monkeypatch):
     """Ensure no real API keys leak into tests."""
@@ -51,20 +54,6 @@ def clean_env(monkeypatch):
     monkeypatch.delenv("MISTRAL_API_KEY", raising=False)
     monkeypatch.delenv("HERMES_LOCAL_STT_COMMAND", raising=False)
     monkeypatch.delenv("HERMES_LOCAL_STT_LANGUAGE", raising=False)
-
-
-@pytest.fixture(autouse=True)
-def _disable_lazy_stt_install():
-    """Disarm the runtime lazy-install probe so static ``_HAS_FASTER_WHISPER``
-    patches accurately simulate 'faster-whisper not installed'.
-
-    Without this, ``_try_lazy_install_stt()`` calls
-    ``importlib.util.find_spec("faster_whisper")``, which returns truthy
-    whenever the package is installed in the dev / CI environment —
-    defeating the test's ``_HAS_FASTER_WHISPER=False`` patch.
-    """
-    with patch("tools.transcription_tools._try_lazy_install_stt", return_value=False):
-        yield
 
 
 # ============================================================================

--- a/tests/tools/test_transcription_tools.py
+++ b/tests/tools/test_transcription_tools.py
@@ -53,6 +53,20 @@ def clean_env(monkeypatch):
     monkeypatch.delenv("HERMES_LOCAL_STT_LANGUAGE", raising=False)
 
 
+@pytest.fixture(autouse=True)
+def _disable_lazy_stt_install():
+    """Disarm the runtime lazy-install probe so static ``_HAS_FASTER_WHISPER``
+    patches accurately simulate 'faster-whisper not installed'.
+
+    Without this, ``_try_lazy_install_stt()`` calls
+    ``importlib.util.find_spec("faster_whisper")``, which returns truthy
+    whenever the package is installed in the dev / CI environment —
+    defeating the test's ``_HAS_FASTER_WHISPER=False`` patch.
+    """
+    with patch("tools.transcription_tools._try_lazy_install_stt", return_value=False):
+        yield
+
+
 # ============================================================================
 # _get_provider — full permutation matrix
 # ============================================================================


### PR DESCRIPTION
## What does this PR do?

Unbreaks the transcription test suite (16 baseline failures across three files) that started failing on every open PR after `b5c6d9ac0` ("fix: wire STT lazy-install into transcription_tools.py") landed on `main` ~3h ago.

The new helper `_try_lazy_install_stt()` calls `importlib.util.find_spec("faster_whisper")` *after* `ensure()` runs. In the dev / CI environment `faster_whisper` is already installed, so the probe returns truthy and `_get_provider()` returns `"local"` even when the test has patched `_HAS_FASTER_WHISPER=False` to simulate "not installed".

Adds a per-file autouse fixture that patches `_try_lazy_install_stt` to return `False`, so the static `_HAS_FASTER_WHISPER=False` patches in existing tests accurately simulate "faster-whisper not installed". Production behaviour is unchanged at runtime — the fixture only fires inside these three test files.

## Related Issue

Follows up production commit [`b5c6d9ac0`](https://github.com/NousResearch/hermes-agent/commit/b5c6d9ac08a841b466bc39b9569ff1ceacd4ff97) ("fix: wire STT lazy-install into transcription_tools.py", 2026-05-22). No issue to close.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tests/tools/test_transcription_tools.py` — autouse fixture `_disable_lazy_stt_install` that patches `tools.transcription_tools._try_lazy_install_stt` to return False for the duration of each test.
- `tests/tools/test_transcription.py` — same autouse fixture, same rationale.
- `tests/tools/test_transcription_dotenv_fallback.py` — same autouse fixture, same rationale.

## How to Test

1. On clean `origin/main` (e.g. `d61785889`):
   ```
   uv run --with pytest --with pytest-xdist --with pytest-asyncio --with pytest-timeout python3 -m pytest tests/tools/test_transcription_tools.py tests/tools/test_transcription.py tests/tools/test_transcription_dotenv_fallback.py
   ```
   Result: **16 failed, 108 passed, 7 skipped** — every failure is `AssertionError: assert 'local' == '<expected>'` or `'not installed' in <wrong-error>`.

2. With this PR applied:
   ```
   uv run --with pytest --with pytest-xdist --with pytest-asyncio --with pytest-timeout python3 -m pytest tests/tools/test_transcription_tools.py tests/tools/test_transcription.py tests/tools/test_transcription_dotenv_fallback.py
   ```
   Result: **124 passed, 7 skipped** (108 prior + 16 fixed).

3. The autouse fixture can be overridden per-test if a future test wants to verify the lazy-install path itself (just nest another `patch("tools.transcription_tools._try_lazy_install_stt", return_value=True)` in the test body).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`test(tools):` here)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate — `gh search prs "_try_lazy_install_stt OR _HAS_FASTER_WHISPER"` returned nothing in flight.
- [x] My PR contains **only** changes related to this fix (test files only, 42-line diff)
- [x] I've run focused tests for the touched code and all pass
- [x] I've added tests for my changes — N/A; this PR repairs existing tests broken by a production change
- [x] I've tested on my platform: macOS 15.x (Python 3.11.14)

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (test-fixture-only change)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — N/A; the autouse fixture is a `patch.object` call with no OS-specific behaviour
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Related / Positioning

The production behaviour from `b5c6d9ac0` is intentional and correct — `_try_lazy_install_stt()` should re-check dynamically so the first voice message after a fresh install triggers auto-installation without a process restart. The test suite just needs to be told that the simulated "not installed" state is now a two-flag condition (`_HAS_FASTER_WHISPER=False` AND lazy-install probe disabled), not a single-flag condition. The fixture encodes that.

> Audited siblings: confirmed `tools/transcription_tools.py` is the only module with `_try_lazy_install_stt`; the parallel TTS module (`tools/tts_tool.py`) and `agent/voice/` do not currently have an equivalent lazy-install bypass, so no widening is needed.

## Screenshots / Logs

Sample failing test pre-fix (full set: 16 failures, all identical pattern):

```
FAILED tests/tools/test_transcription_tools.py::TestGetProviderMistral::test_auto_detect_skips_mistral
  - AssertionError: assert 'local' == 'none'
FAILED tests/tools/test_transcription.py::TestGetProvider::test_explicit_local_no_cloud_fallback
  - AssertionError: assert 'local' == 'none'
FAILED tests/tools/test_transcription.py::TestTranscribeLocal::test_not_installed
  - assert 'not installed' in "Local transcription failed: [Errno 2] No such file or directory: '/tmp/test.ogg'"
FAILED tests/tools/test_transcription_dotenv_fallback.py::TestProviderSelectionGate::test_auto_detect_sees_dotenv_groq
  - AssertionError: assert 'local' == 'groq'
```

After the fix: `124 passed, 7 skipped in 1.02s`.