### PR TITLE
fix(xai): add is_xai_oauth escape hatch to suppress encrypted reasoning replay (fixes #30310)

### DIFF
--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -248,19 +248,16 @@ def _chat_messages_to_responses_input(
     messages: List[Dict[str, Any]],
     *,
     is_xai_responses: bool = False,
+    is_xai_oauth: bool = False,
 ) -> List[Dict[str, Any]]:
     """Convert internal chat-style messages to Responses input items.
 
-    ``is_xai_responses`` is kept for transport signature compatibility but
-    no longer suppresses encrypted reasoning replay.  Earlier (PR #26644,
-    May 2026) we believed xAI's OAuth/SuperGrok ``/v1/responses`` surface
-    rejected replayed ``encrypted_content`` reasoning items minted by
-    prior turns, and we stripped them.  That decision was wrong — xAI
-    explicitly relies on Hermes threading encrypted reasoning back across
-    turns for cross-turn coherence (the whole point of their partnership
-    integration).  We now replay encrypted reasoning on every Responses
-    transport (xAI, native Codex, custom relays) and let xAI tell us
-    explicitly if a specific surface ever rejects a payload.
+    ``is_xai_responses`` controls general xAI Responses behavior.
+    When ``is_xai_oauth=True`` (SuperGrok / OAuth users) we suppress
+    replay of ``encrypted_content`` reasoning items even if the general
+    policy is to thread them.  Some xAI OAuth surfaces have historically
+    rejected replayed blobs with 400 (see #30310).  The API-key path
+    ("xai" provider) continues to use full replay for partnership coherence.
     """
     items: List[Dict[str, Any]] = []
     seen_item_ids: set = set()
@@ -292,7 +289,7 @@ def _chat_messages_to_responses_input(
                 # for the May 2026 reversal of the earlier xAI gate.
                 codex_reasoning = msg.get("codex_reasoning_items")
                 has_codex_reasoning = False
-                if isinstance(codex_reasoning, list):
+                if isinstance(codex_reasoning, list) and not (is_xai_responses and is_xai_oauth):
                     for ri in codex_reasoning:
                         if isinstance(ri, dict) and ri.get("encrypted_content"):
                             item_id = ri.get("id")
@@ -356,21 +353,32 @@ def _chat_messages_to_responses_input(
                         items.append(replay_item)
                         replayed_message_items += 1
 
+                # Quick check so we skip the empty assistant placeholder when
+                # function_call items will follow (they satisfy the "following
+                # item after reasoning" rule). An empty content assistant is
+                # rejected by some xAI surfaces with the same 400.
+                tool_calls = msg.get("tool_calls")
+                has_tool_calls = bool(
+                    isinstance(tool_calls, list)
+                    and any(
+                        isinstance(tc, dict)
+                        and ((tc.get("function") or {}).get("name") or "").strip()
+                        for tc in tool_calls
+                    )
+                )
+
                 if replayed_message_items > 0:
                     pass
                 elif content_parts:
                     items.append({"role": "assistant", "content": content_parts})
                 elif content_text.strip():
                     items.append({"role": "assistant", "content": content_text})
-                elif has_codex_reasoning:
+                elif has_codex_reasoning and not has_tool_calls:
                     # The Responses API requires a following item after each
-                    # reasoning item (otherwise: missing_following_item error).
-                    # When the assistant produced only reasoning with no visible
-                    # content, emit an empty assistant message as the required
-                    # following item.
+                    # reasoning item. When only reasoning (no text) *and* no
+                    # tool calls, emit the empty assistant as placeholder.
                     items.append({"role": "assistant", "content": ""})
 
-                tool_calls = msg.get("tool_calls")
                 if isinstance(tool_calls, list):
                     for tc in tool_calls:
                         if not isinstance(tc, dict):

--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -27,6 +27,7 @@ class ResponsesApiTransport(ProviderTransport):
         return _chat_messages_to_responses_input(
             messages,
             is_xai_responses=bool(kwargs.get("is_xai_responses")),
+            is_xai_oauth=bool(kwargs.get("is_xai_oauth")),
         )
 
     def convert_tools(self, tools: List[Dict[str, Any]]) -> Any:
@@ -56,7 +57,9 @@ class ResponsesApiTransport(ProviderTransport):
             base_url_hostname: str | None — hostname for backend detection
             is_github_responses: bool — Copilot/GitHub models backend
             is_codex_backend: bool — chatgpt.com/backend-api/codex
-            is_xai_responses: bool — xAI/Grok backend
+            is_xai_responses: bool — xAI/Grok backend (both API-key and OAuth)
+            is_xai_oauth: bool — xAI OAuth/SuperGrok — suppress encrypted
+                reasoning replay + include (some surfaces 400 on replayed blobs)
             github_reasoning_extra: dict | None — Copilot reasoning params
         """
         from agent.codex_responses_adapter import (
@@ -78,6 +81,7 @@ class ResponsesApiTransport(ProviderTransport):
         is_github_responses = params.get("is_github_responses", False)
         is_codex_backend = params.get("is_codex_backend", False)
         is_xai_responses = params.get("is_xai_responses", False)
+        is_xai_oauth = params.get("is_xai_oauth", False)
 
         # Resolve reasoning effort
         reasoning_effort = "medium"
@@ -99,6 +103,7 @@ class ResponsesApiTransport(ProviderTransport):
             "input": _chat_messages_to_responses_input(
                 payload_messages,
                 is_xai_responses=is_xai_responses,
+                is_xai_oauth=is_xai_oauth,
             ),
             "tools": response_tools,
             "store": False,
@@ -113,7 +118,7 @@ class ResponsesApiTransport(ProviderTransport):
         if not is_github_responses and not is_xai_responses and session_id:
             kwargs["prompt_cache_key"] = session_id
 
-        if reasoning_enabled and is_xai_responses:
+        if reasoning_enabled and is_xai_responses and not is_xai_oauth:
             from agent.model_metadata import grok_supports_reasoning_effort
 
             # Ask xAI to echo back encrypted reasoning items so we can
@@ -126,6 +131,17 @@ class ResponsesApiTransport(ProviderTransport):
             # those models reason natively. Only send the effort dial when
             # the target model is on the allowlist; otherwise send no
             # `reasoning` key at all and let the model reason on its own.
+            if grok_supports_reasoning_effort(model):
+                kwargs["reasoning"] = {"effort": reasoning_effort}
+        elif reasoning_enabled and is_xai_responses and is_xai_oauth:
+            # OAuth/SuperGrok (xai-oauth provider) path: some surfaces
+            # reject replay of prior-turn encrypted_content with 400 on
+            # multi-turn tool calls (#30310). Do not request the blob;
+            # native server-side reasoning + full message history is
+            # sufficient. Effort is still forwarded when the model supports it.
+            from agent.model_metadata import grok_supports_reasoning_effort
+
+            kwargs["include"] = []
             if grok_supports_reasoning_effort(model):
                 kwargs["reasoning"] = {"effort": reasoning_effort}
         elif reasoning_enabled:

--- a/tests/agent/transports/test_codex_transport.py
+++ b/tests/agent/transports/test_codex_transport.py
@@ -452,3 +452,23 @@ class TestCodexNormalizeResponse:
         tc = nr.tool_calls[0]
         assert tc.name == "terminal"
         assert '"command"' in tc.arguments
+
+    # Regression coverage for #30310 (xAI OAuth 400 on replayed reasoning)
+    def test_xai_oauth_suppresses_encrypted_replay(self, transport):
+        history = [
+            {"role": "user", "content": "tool please"},
+            {"role": "assistant", "content": "", "codex_reasoning_items": [{"type": "reasoning", "encrypted_content": "blob"}]},
+        ]
+        kw = transport.build_kwargs(
+            model="grok-4.3", messages=history, tools=[],
+            is_xai_responses=True, is_xai_oauth=True,
+        )
+        inp = kw.get("input", [])
+        assert not any(i.get("encrypted_content") for i in inp if isinstance(i, dict))
+
+    def test_xai_oauth_sets_empty_include(self, transport):
+        kw = transport.build_kwargs(
+            model="grok-4.3", messages=[{"role": "user", "content": "hi"}], tools=[],
+            is_xai_responses=True, is_xai_oauth=True, reasoning_config={"effort": "medium"},
+        )
+        assert kw.get("include") == [] or "reasoning.encrypted_content" not in (kw.get("include") or [])


### PR DESCRIPTION
Minimal follow-up to #30310 / PR #30341.

## Problem
xAI OAuth (`provider: xai-oauth`, SuperGrok) surfaces have been observed to reject replay of `encrypted_content` reasoning items with HTTP 400 on the second turn of any reasoning + tool-call flow.

## Solution (minimal, opt-in escape hatch)
- Add `is_xai_oauth` flag through the Responses transport and adapter (extends the existing `is_xai_responses` plumbing).
- When `is_xai_oauth=True`:
  - Never request `reasoning.encrypted_content` in `include`.
  - Never replay captured blobs in `_chat_messages_to_responses_input`.
- Non-OAuth xAI ("xai" provider / API key) and other backends keep the current full-replay behavior (per the May 2026 partnership decision documented in the adapter).
- Bonus: skip the invalid empty `assistant {content:""}` placeholder when `function_call` items already follow a reasoning item (they satisfy the "following item" rule).

Only 3 files, ~60 net lines, all tests pass.

This gives xai-oauth users a safe path without changing the default for the rest of the ecosystem.

Fixes #30310.