### PR TITLE
docs: replace invalid config get examples

### DIFF
--- a/website/docs/guides/migrate-from-openclaw.md
+++ b/website/docs/guides/migrate-from-openclaw.md
@@ -225,7 +225,7 @@ The migration resolves all three formats. For env templates and SecretRef object
 
 5. **Test messaging** — if you migrated platform tokens, restart the gateway: `systemctl --user restart hermes-gateway`
 
-6. **Check session policies** — verify `hermes config get session_reset` matches your expectations.
+6. **Check session policies** — run `hermes config show` and verify `session_reset` matches your expectations.
 
 7. **Re-pair WhatsApp** — WhatsApp uses QR code pairing (Baileys), not token migration. Run `hermes whatsapp` to pair.
 

--- a/website/docs/guides/work-with-skills.md
+++ b/website/docs/guides/work-with-skills.md
@@ -161,8 +161,8 @@ Manage skill config from the CLI:
 # Interactive config for a specific skill
 hermes skills config gif-search
 
-# View all skill config
-hermes config get skills.config
+# View the resolved config, including skills.config
+hermes config show
 ```
 
 ---

--- a/website/docs/user-guide/configuring-models.md
+++ b/website/docs/user-guide/configuring-models.md
@@ -192,7 +192,7 @@ hermes model            # Interactive provider + model picker (the canonical way
 
 `hermes model` walks you through picking a provider, authenticating (OAuth flows open a browser; API-key providers prompt for the key), and then choosing a specific model from that provider's curated catalog. The choice is written to `model.provider` and `model.model` in `~/.hermes/config.yaml`.
 
-To list providers/models without launching the picker, use the dashboard or the REST endpoints below. To inspect what the CLI will actually use right now: `hermes config get model` and `hermes status`.
+To list providers/models without launching the picker, use the dashboard or the REST endpoints below. To inspect what the CLI will actually use right now, run `hermes config show` and check the `model` section, then run `hermes status`.
 
 ### Direct config edit
 


### PR DESCRIPTION
## Problem
Three docs pages referenced `hermes config get <key>`, but `hermes config` does not provide a `get` subcommand. Following those snippets leads to an argparse error.

## Solution
Replace the invalid per-key examples with `hermes config show`, and adjust the surrounding prose to tell readers which section/key to inspect in the resolved config.

## Validation
```console
$ rg "hermes config get" website/docs
# no matches

$ $HOME/.hermes/hermes-agent/venv/bin/python -m hermes_cli.main config show --help
usage: hermes config show [-h]
```

## Confidence
Score: 88/100
Category: docs

Closes #30195
