### PR TITLE
fix(gateway): support launchd on macOS for SSH-only / headless users

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2777,7 +2777,23 @@ def get_launchd_label() -> str:
 
 
 def _launchd_domain() -> str:
-    return f"gui/{os.getuid()}"  # windows-footgun: ok — POSIX launchd (macOS) helper, never invoked on Windows
+    """Return the best available launchd domain for the current user.
+
+    On macOS, ``gui/<uid>`` only exists when the user owns a GUI (Aqua)
+    login session.  SSH-only / headless users get a ``user/<uid>`` domain
+    instead.  We probe both and return whichever is reachable.
+    """
+    uid = os.getuid()
+    gui_domain = f"gui/{uid}"
+    # gui domain exists only for the console (Aqua) user
+    result = subprocess.run(
+        ["launchctl", "print", gui_domain],
+        capture_output=True, timeout=5,
+    )
+    if result.returncode == 0:
+        return gui_domain
+    # Fall back to the per-user domain (available for SSH / login sessions)
+    return f"user/{uid}"
 
 
 def generate_launchd_plist() -> str:
@@ -2847,6 +2863,13 @@ def generate_launchd_plist() -> str:
         <key>HERMES_HOME</key>
         <string>{hermes_home}</string>
     </dict>
+    
+    <key>LimitLoadToSessionType</key>
+    <array>
+        <string>Aqua</string>
+        <string>Standard</string>
+        <string>Background</string>
+    </array>
     
     <key>RunAtLoad</key>
     <true/>


### PR DESCRIPTION
## Summary

The gateway service fails to start on macOS when the user has no GUI (Aqua) login session — e.g. SSH-only accounts on shared Mac minis, headless macOS servers, or CI runners. The `gui/<uid>` launchd domain only exists for the console user, so all `launchctl bootstrap`/`kickstart` calls return error 125:

```
Could not kickstart service "ai.hermes.gateway": 125: Domain does not support specified action
```

## Changes

1. **`_launchd_domain()`** — now probes whether `gui/<uid>` is reachable via `launchctl print` and falls back to `user/<uid>` for SSH/login sessions where the GUI domain does not exist.

2. **Plist template** — added `LimitLoadToSessionType` with `Aqua`, `Standard`, and `Background` so launchd loads the LaunchAgent in non-GUI session types as well.

## Reproduction

On a Mac where user `bart` (UID 7) connects only via SSH, while another user owns the console:

```
$ hermes gateway start
Could not kickstart service "ai.hermes.gateway": 125: Domain does not support specified action
```

After the fix:

```
$ hermes gateway start
✓ Service started
```

## Test Plan

- [x] Verified on macOS 26 (Tahoe) with an SSH-only user on a shared Mac mini
- [x] Gateway starts and runs correctly with PID confirmed via `hermes gateway status`
- [ ] Confirmed no regression for console/GUI users (the `gui/` domain is still preferred when available)