### PR TITLE
fix(agent): support 'retry in' preposition in Gemini rate-limit parsing

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2039,7 +2039,7 @@ def extract_api_error_context(error: Exception) -> Dict[str, Any]:
                 context["reset_at"] = time.time() + seconds
             else:
                 sec_match = re.search(
-                    r"retry\s+(?:after\s+)?(\d+(?:\.\d+)?)\s*(?:sec|secs|seconds|s\b)",
+                    r"retry\s+(?:after\s+|in\s+)?(\d+(?:\.\d+)?)\s*(?:sec|secs|seconds|s\b)",
                     message,
                     re.IGNORECASE,
                 )

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -2843,14 +2843,36 @@ def run_conversation(
                 # For rate limits, respect the Retry-After header if present
                 _retry_after = None
                 if is_rate_limited:
-                    _resp_headers = getattr(getattr(api_error, "response", None), "headers", None)
-                    if _resp_headers and hasattr(_resp_headers, "get"):
-                        _ra_raw = _resp_headers.get("retry-after") or _resp_headers.get("Retry-After")
-                        if _ra_raw:
-                            try:
-                                _retry_after = min(float(_ra_raw), 120)  # Cap at 2 minutes
-                            except (TypeError, ValueError):
-                                pass
+                    # 1. Respect custom .retry_after attribute on error if present
+                    if hasattr(api_error, "retry_after") and getattr(api_error, "retry_after") is not None:
+                        try:
+                            _retry_after = float(getattr(api_error, "retry_after"))
+                        except (TypeError, ValueError):
+                            pass
+
+                    # 2. Extract reset_at from error_context if present
+                    if not _retry_after and error_context and "reset_at" in error_context:
+                        from agent.credential_pool import _parse_absolute_timestamp
+                        try:
+                            _reset_epoch = _parse_absolute_timestamp(error_context["reset_at"])
+                            if _reset_epoch is not None:
+                                _retry_after = max(0.1, _reset_epoch - time.time())
+                        except Exception:
+                            pass
+
+                    # 3. Fall back to response headers
+                    if not _retry_after:
+                        _resp_headers = getattr(getattr(api_error, "response", None), "headers", None)
+                        if _resp_headers and hasattr(_resp_headers, "get"):
+                            _ra_raw = _resp_headers.get("retry-after") or _resp_headers.get("Retry-After")
+                            if _ra_raw:
+                                try:
+                                    _retry_after = float(_ra_raw)
+                                except (TypeError, ValueError):
+                                    pass
+
+                    if _retry_after is not None:
+                        _retry_after = min(_retry_after, 120)  # Cap at 2 minutes
                 wait_time = _retry_after if _retry_after else jittered_backoff(retry_count, base_delay=2.0, max_delay=60.0)
                 if is_rate_limited:
                     agent._emit_status(f"⏱️ Rate limited. Waiting {wait_time:.1f}s (attempt {retry_count + 1}/{max_retries})...")

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -3994,6 +3994,24 @@ class TestCredentialPoolRecovery:
         assert context["reason"] == "usage_limit_reached"
         assert context["message"] == "The usage limit has been reached"
 
+    def test_extract_api_error_context_parses_gemini_please_retry_in_delay(self, agent):
+        class _FakeErrorWithStr(Exception):
+            def __str__(self):
+                return (
+                    "HTTP 429: Gemini HTTP 429 (RESOURCE_EXHAUSTED): You exceeded your current quota. "
+                    "Quota exceeded for metric: generativelanguage.googleapis.com/generate_content_paid_tier_input_token_count, "
+                    "limit: 2000000, model: gemini-3.5-flash\n"
+                    "Please retry in 35.145570922s."
+                )
+        fake_error = _FakeErrorWithStr()
+        fake_error.response = SimpleNamespace(headers={})
+
+        context = agent._extract_api_error_context(fake_error)
+
+        assert "reset_at" in context
+        import time
+        assert abs(context["reset_at"] - (time.time() + 35.145570922)) < 2.0
+
     def test_recover_with_pool_passes_error_context_on_rotated_429(self, agent):
         next_entry = SimpleNamespace(label="secondary")
         captured = {}


### PR DESCRIPTION
- Update error extraction regex to match 'retry in <duration>' messages
- Read custom retry_after attribute and error_context.reset_at within conversation loop
- Add TestCredentialPoolRecovery unit test to prevent regressions

## What does this PR do?

When trying to extract rate-limit cooldowns from error messages, Hermes currently only looks for "retry after", not "retry in" (how the Gemini API puts it)

Fixes #

## Type of Change


- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04



