### PR TITLE
fix(gateway): batch Telegram document bursts

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -763,6 +763,8 @@ class TelegramAdapter(BasePlatformAdapter):
         self._media_batch_delay_seconds = env_float("HERMES_TELEGRAM_MEDIA_BATCH_DELAY_SECONDS", 0.8)
         self._pending_photo_batches: Dict[str, MessageEvent] = {}
         self._pending_photo_batch_tasks: Dict[str, asyncio.Task] = {}
+        self._pending_document_batches: Dict[str, MessageEvent] = {}
+        self._pending_document_batch_tasks: Dict[str, asyncio.Task] = {}
         self._media_group_events: Dict[str, MessageEvent] = {}
         self._media_group_tasks: Dict[str, asyncio.Task] = {}
         # Buffer rapid text messages so Telegram client-side splits of long
@@ -4290,6 +4292,8 @@ class TelegramAdapter(BasePlatformAdapter):
             collect(task)
         for task in list(self._pending_photo_batch_tasks.values()):
             collect(task)
+        for task in list(self._pending_document_batch_tasks.values()):
+            collect(task)
         for task in list(self._pending_text_batch_tasks.values()):
             collect(task)
         collect(getattr(self, "_polling_error_task", None))
@@ -4304,6 +4308,8 @@ class TelegramAdapter(BasePlatformAdapter):
         self._media_group_events.clear()
         self._pending_photo_batch_tasks.clear()
         self._pending_photo_batches.clear()
+        self._pending_document_batch_tasks.clear()
+        self._pending_document_batches.clear()
         self._pending_text_batch_tasks.clear()
         self._pending_text_batches.clear()
         if getattr(self, "_polling_error_task", None) is not current_task:
@@ -9175,6 +9181,60 @@ class TelegramAdapter(BasePlatformAdapter):
 
         self._pending_photo_batch_tasks[batch_key] = asyncio.create_task(self._flush_photo_batch(batch_key))
 
+    def _document_batch_key(self, event: MessageEvent) -> str:
+        """Session-scoped key for batching rapid Telegram document uploads."""
+        from gateway.session import build_session_key
+
+        return build_session_key(
+            event.source,
+            group_sessions_per_user=self.config.extra.get("group_sessions_per_user", True),
+            thread_sessions_per_user=self.config.extra.get("thread_sessions_per_user", False),
+        )
+
+    async def _flush_document_batch(self, batch_key: str) -> None:
+        """Send a buffered document burst as a single MessageEvent."""
+        current_task = asyncio.current_task()
+        try:
+            await asyncio.sleep(self._media_batch_delay_seconds)
+            event = self._pending_document_batches.pop(batch_key, None)
+            if not event:
+                return
+            if self._should_drop_delayed_delivery():
+                logger.debug("[Telegram] Dropping document batch flush after disconnect started")
+                return
+            logger.info(
+                "[Telegram] Flushing document batch %s with %d file(s)",
+                batch_key,
+                len(event.media_urls),
+            )
+            await self.handle_message(event)
+        finally:
+            if self._pending_document_batch_tasks.get(batch_key) is current_task:
+                self._pending_document_batch_tasks.pop(batch_key, None)
+
+    def _enqueue_document_event(self, batch_key: str, event: MessageEvent) -> None:
+        """Merge document events into a pending batch and schedule flush."""
+        if self._should_drop_delayed_delivery():
+            logger.debug("[Telegram] Dropping document batch enqueue after disconnect started")
+            return
+
+        existing = self._pending_document_batches.get(batch_key)
+        if existing is None:
+            self._pending_document_batches[batch_key] = event
+        else:
+            existing.media_urls.extend(event.media_urls)
+            existing.media_types.extend(event.media_types)
+            if event.text:
+                existing.text = self._merge_caption(existing.text, event.text)
+
+        prior_task = self._pending_document_batch_tasks.get(batch_key)
+        if prior_task and not prior_task.done():
+            prior_task.cancel()
+
+        self._pending_document_batch_tasks[batch_key] = asyncio.create_task(
+            self._flush_document_batch(batch_key)
+        )
+
     async def _handle_media_message(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         """Handle incoming media messages, downloading images to local cache."""
         if not update.message:
@@ -9460,6 +9520,14 @@ class TelegramAdapter(BasePlatformAdapter):
                         # Binary file — agent has the cached path and can use
                         # terminal/read_file against it. No inline injection.
                         pass
+
+                media_group_id = getattr(msg, "media_group_id", None)
+                if media_group_id:
+                    await self._queue_media_group_event(str(media_group_id), event)
+                else:
+                    batch_key = self._document_batch_key(event)
+                    self._enqueue_document_event(batch_key, event)
+                return
 
             except Exception as e:
                 logger.warning("[Telegram] Failed to cache document: %s", _redact_telegram_error_text(e), exc_info=True)

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -4292,7 +4292,8 @@ class TelegramAdapter(BasePlatformAdapter):
             collect(task)
         for task in list(self._pending_photo_batch_tasks.values()):
             collect(task)
-        for task in list(self._pending_document_batch_tasks.values()):
+        document_tasks = getattr(self, "_pending_document_batch_tasks", {}) or {}
+        for task in list(document_tasks.values()):
             collect(task)
         for task in list(self._pending_text_batch_tasks.values()):
             collect(task)
@@ -4308,8 +4309,10 @@ class TelegramAdapter(BasePlatformAdapter):
         self._media_group_events.clear()
         self._pending_photo_batch_tasks.clear()
         self._pending_photo_batches.clear()
-        self._pending_document_batch_tasks.clear()
-        self._pending_document_batches.clear()
+        if hasattr(self, "_pending_document_batch_tasks"):
+            self._pending_document_batch_tasks.clear()
+        if hasattr(self, "_pending_document_batches"):
+            self._pending_document_batches.clear()
         self._pending_text_batch_tasks.clear()
         self._pending_text_batches.clear()
         if getattr(self, "_polling_error_task", None) is not current_task:

--- a/tests/gateway/test_telegram_document_burst.py
+++ b/tests/gateway/test_telegram_document_burst.py
@@ -1,0 +1,99 @@
+"""Focused regressions for non-album Telegram document bursts."""
+
+import asyncio
+import os
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.config import PlatformConfig
+from plugins.platforms.telegram.adapter import TelegramAdapter
+
+
+def _file(data=b"payload"):
+    value = AsyncMock()
+    value.download_as_bytearray = AsyncMock(return_value=bytearray(data))
+    value.file_path = "documents/file.bin"
+    return value
+
+
+def _document(name, mime, data):
+    value = MagicMock()
+    value.file_name = name
+    value.mime_type = mime
+    value.file_size = len(data)
+    value.get_file = AsyncMock(return_value=_file(data))
+    return value
+
+
+def _update(document, caption=None):
+    message = MagicMock()
+    message.message_id = 42
+    message.text = caption or ""
+    message.caption = caption
+    message.date = None
+    message.photo = None
+    message.video = None
+    message.audio = None
+    message.voice = None
+    message.sticker = None
+    message.document = document
+    message.media_group_id = None
+    message.chat = MagicMock(id=100, type="private", title=None, full_name="User")
+    message.from_user = MagicMock(id=1, full_name="User")
+    message.message_thread_id = None
+    message.reply_text = AsyncMock()
+    update = MagicMock()
+    update.message = message
+    return update
+
+
+@pytest.fixture
+def adapter(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        "gateway.platforms.base.DOCUMENT_CACHE_DIR", tmp_path / "documents"
+    )
+    value = TelegramAdapter(PlatformConfig(enabled=True, token="fake"))
+    value.handle_message = AsyncMock()
+    value._is_callback_user_authorized = lambda _user_id, **_kwargs: True
+    return value
+
+
+@pytest.mark.asyncio
+async def test_document_burst_is_buffered_and_combined(adapter):
+    await adapter._handle_media_message(
+        _update(_document("a.pdf", "application/pdf", b"first"), "read these"),
+        MagicMock(),
+    )
+    await adapter._handle_media_message(
+        _update(_document("b.txt", "text/plain", b"hello")),
+        MagicMock(),
+    )
+    adapter.handle_message.assert_not_awaited()
+
+    await asyncio.sleep(adapter._media_batch_delay_seconds + 0.05)
+
+    adapter.handle_message.assert_awaited_once()
+    event = adapter.handle_message.await_args.args[0]
+    assert os.path.basename(event.media_urls[0]).endswith("_a.pdf")
+    assert os.path.basename(event.media_urls[1]).endswith("_b.txt")
+    assert event.media_types == ["application/pdf", "text/plain"]
+    assert "read these" in event.text
+    assert "[Content of b.txt]" in event.text
+
+
+@pytest.mark.asyncio
+async def test_disconnect_cancels_pending_document_batch_flush(adapter):
+    await adapter._handle_media_message(
+        _update(_document("a.pdf", "application/pdf", b"first")),
+        MagicMock(),
+    )
+    assert adapter._pending_document_batches
+    assert adapter._pending_document_batch_tasks
+
+    await adapter.disconnect()
+    await asyncio.sleep(adapter._media_batch_delay_seconds + 0.05)
+
+    assert adapter._pending_document_batches == {}
+    assert adapter._pending_document_batch_tasks == {}
+    adapter.handle_message.assert_not_awaited()

--- a/tests/gateway/test_telegram_documents.py
+++ b/tests/gateway/test_telegram_documents.py
@@ -166,6 +166,7 @@ class TestDocumentTypeDetection:
         msg = _make_message(document=doc)
         update = _make_update(msg)
         await adapter._handle_media_message(update, MagicMock())
+        await asyncio.sleep(adapter._media_batch_delay_seconds + 0.05)
         event = adapter.handle_message.call_args[0][0]
         assert event.message_type == MessageType.DOCUMENT
 
@@ -195,6 +196,7 @@ class TestDocumentDownloadBlock:
         update = _make_update(msg)
 
         await adapter._handle_media_message(update, MagicMock())
+        await asyncio.sleep(adapter._media_batch_delay_seconds + 0.05)
         event = adapter.handle_message.call_args[0][0]
         assert "Hello from a text file" in event.text
         assert "[Content of notes.txt]" in event.text
@@ -211,6 +213,7 @@ class TestDocumentDownloadBlock:
         update = _make_update(msg)
 
         await adapter._handle_media_message(update, MagicMock())
+        await asyncio.sleep(adapter._media_batch_delay_seconds + 0.05)
         event = adapter.handle_message.call_args[0][0]
         assert "# Title" in event.text
 
@@ -226,6 +229,7 @@ class TestDocumentDownloadBlock:
         update = _make_update(msg)
 
         await adapter._handle_media_message(update, MagicMock())
+        await asyncio.sleep(adapter._media_batch_delay_seconds + 0.05)
         event = adapter.handle_message.call_args[0][0]
         assert "file text" in event.text
         assert "Please summarize" in event.text
@@ -244,6 +248,7 @@ class TestDocumentDownloadBlock:
         update = _make_update(msg)
 
         await adapter._handle_media_message(update, MagicMock())
+        await asyncio.sleep(adapter._media_batch_delay_seconds + 0.05)
         event = adapter.handle_message.call_args[0][0]
         # File should be cached
         assert len(event.media_urls) == 1


### PR DESCRIPTION
## Summary

- Buffer rapid Telegram document uploads that arrive without `media_group_id`.
- Merge their cached paths/types and caption into one logical `MessageEvent`.
- Cancel pending document-burst flush tasks during adapter disconnect.

## Why

Telegram can deliver a multi-document upload as several document messages without a shared `media_group_id`. Immediate dispatch lets the first files start a turn before the remaining files arrive, so the user can receive a partial answer followed by interrupts.

True `media_group_id` albums continue to use the existing album path. Non-album document bursts reuse the adapter's existing media debounce, configured by `HERMES_TELEGRAM_MEDIA_BATCH_DELAY_SECONDS` with the current default of **0.8 seconds**. This PR does not introduce a document-specific environment variable.

## Testing

- `python -m pytest -q -o 'addopts=' tests/gateway/test_telegram_documents.py`
- `python -m pytest -q -o 'addopts=' tests/gateway/test_telegram_documents.py tests/gateway/test_telegram_caption_merge.py tests/gateway/test_telegram_text_batching.py`
- `python -m ruff check plugins/platforms/telegram/adapter.py tests/gateway/test_telegram_documents.py`
- `git diff --check`
