### PR TITLE
fix(config): quote .env values containing # to prevent truncation (#30355)

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -4807,6 +4807,18 @@ def _check_non_ascii_credential(key: str, value: str) -> str:
     return sanitized
 
 
+def _quote_env_value(value: str) -> str:
+    """Double-quote a .env value when it contains characters that
+    python-dotenv would misinterpret (``#`` as inline comment,
+    leading/trailing whitespace, embedded quotes, etc.).
+    """
+    # Characters that require quoting per python-dotenv's parser.
+    if any(c in value for c in ('#', '"', "'", ' ', '\t')):
+        escaped = value.replace('\\', '\\\\').replace('"', '\\"')
+        return f'"{escaped}"'
+    return value
+
+
 def save_env_value(key: str, value: str):
     """Save or update a value in ~/.hermes/.env."""
     if is_managed():
@@ -4836,7 +4848,7 @@ def save_env_value(key: str, value: str):
     found = False
     for i, line in enumerate(lines):
         if line.strip().startswith(f"{key}="):
-            lines[i] = f"{key}={value}\n"
+            lines[i] = f"{key}={_quote_env_value(value)}\n"
             found = True
             break
 
@@ -4844,7 +4856,7 @@ def save_env_value(key: str, value: str):
         # Ensure there's a newline at the end of the file before appending
         if lines and not lines[-1].endswith("\n"):
             lines[-1] += "\n"
-        lines.append(f"{key}={value}\n")
+        lines.append(f"{key}={_quote_env_value(value)}\n")
     
     fd, tmp_path = tempfile.mkstemp(dir=str(env_path.parent), suffix='.tmp', prefix='.env_')
     # Preserve original permissions so Docker volume mounts aren't clobbered.

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -696,6 +696,7 @@ AUTHOR_MAP = {
     "jake@nousresearch.com": "simpolism",
     "juan.ovalle@mistral.ai": "jjovalle99",
     "julien.talbot@ergonomia.re": "Julientalbot",
+    "kagura.agent.ai@gmail.com": "kagura-agent",
     "kagura.chen28@gmail.com": "kagura-agent",
     "1342088860@qq.com": "youngDoo",
     "kamil@gwozdz.me": "kamil-gwozdz",


### PR DESCRIPTION
## Summary

`save_env_value()` writes `KEY=value` to `~/.hermes/.env` without quoting the value. python-dotenv treats `#` as an inline comment in unquoted values, so tokens like `sk-ant-oat01-abc#xyz456` are silently truncated to `sk-ant-oat01-abc`, causing HTTP 401 authentication errors.

## Changes

Added `_quote_env_value()` helper that wraps values in double quotes when they contain `#`, quotes, or whitespace. Embedded backslashes and double-quotes are escaped so round-tripping through python-dotenv is lossless. Values without special characters are written unquoted (backward compatible).

**Before:**
```
ANTHROPIC_TOKEN=abc123#xyz456    ← # treated as comment, only "abc123" is read
```

**After:**
```
ANTHROPIC_TOKEN="abc123#xyz456"  ← full value preserved
```

## Testing

- Existing test suite passes (`pytest tests/cron/test_file_permissions.py`, `tests/cli/test_cli_provider_resolution.py`)
- Manual verification: `_quote_env_value("abc#xyz")` → `"abc#xyz"`, `_quote_env_value("simple")` → `simple`

Closes #30355