### PR TITLE
fix: gate kanban dispatch by board policy

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5215,6 +5215,8 @@ class GatewayRunner:
             out: list[tuple[str, "Optional[object]"]] = []
             for b in boards:
                 slug = b.get("slug") or _kb.DEFAULT_BOARD
+                if not _kb.board_dispatch_enabled(slug):
+                    continue
                 out.append((slug, _tick_once_for_board(slug)))
             return out
 
@@ -5236,6 +5238,8 @@ class GatewayRunner:
                 boards = [_kb.read_board_metadata(_kb.DEFAULT_BOARD)]
             for b in boards:
                 slug = b.get("slug") or _kb.DEFAULT_BOARD
+                if not _kb.board_dispatch_enabled(slug):
+                    continue
                 conn = None
                 try:
                     conn = _kb.connect(board=slug)
@@ -5289,6 +5293,8 @@ class GatewayRunner:
             successes = 0
             for b in boards:
                 slug = b.get("slug") or _kb.DEFAULT_BOARD
+                if not _kb.board_auto_decompose_enabled(slug):
+                    continue
                 if attempted >= auto_decompose_per_tick:
                     break
                 # Pin this board for the duration of the call — same

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -436,6 +436,9 @@ def write_board_metadata(
     color: Optional[str] = None,
     archived: Optional[bool] = None,
     default_workdir: Optional[str] = None,
+    board_class: Optional[str] = None,
+    dispatch: Optional[bool] = None,
+    auto_decompose: Optional[bool] = None,
 ) -> dict:
     """Create / update ``board.json`` for ``board``.
 
@@ -459,6 +462,16 @@ def write_board_metadata(
         meta["archived"] = bool(archived)
     if default_workdir is not None:
         meta["default_workdir"] = str(default_workdir) if default_workdir else None
+    if board_class is not None:
+        value = str(board_class).strip().lower()
+        if value:
+            meta["board_class"] = value
+        else:
+            meta.pop("board_class", None)
+    if dispatch is not None:
+        meta["dispatch"] = bool(dispatch)
+    if auto_decompose is not None:
+        meta["auto_decompose"] = bool(auto_decompose)
     if not meta.get("created_at"):
         meta["created_at"] = int(time.time())
     path = board_metadata_path(slug)
@@ -469,6 +482,76 @@ def write_board_metadata(
     )
     meta["db_path"] = str(kanban_db_path(slug))
     return meta
+
+
+_EXECUTION_BOARD_CLASSES = frozenset({
+    "execution-domain",
+})
+
+_PROTECTED_BOARD_CLASSES = frozenset({
+    "archive",
+    "governance-proposal",
+    "human-backlog",
+    "human-decision-inbox",
+    "human_inbox",
+    "human-inbox",
+    "inbox",
+    "quarantine",
+    "protected",
+    "read-only",
+    "readonly",
+    "test-canary",
+})
+
+
+def _metadata_bool(meta: dict, key: str, default: bool) -> bool:
+    value = meta.get(key, default)
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return bool(value)
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"0", "false", "no", "off", "disabled"}:
+            return False
+        if normalized in {"1", "true", "yes", "on", "enabled"}:
+            return True
+    return default
+
+
+def board_dispatch_enabled(board: Optional[str] = None) -> bool:
+    """Return whether worker dispatch is allowed for ``board`` metadata.
+
+    Board-level protection is enforced at runtime, not just documented.
+    ``dispatch: false`` always blocks dispatch. Only boards explicitly
+    classified as ``execution-domain`` may dispatch, and they must opt in
+    with ``dispatch: true``. Human/protected/archive/proposal boards,
+    unknown classes, unclassified legacy boards, and archived boards are
+    non-dispatchable.
+    """
+    slug = _normalize_board_slug(board)
+    if slug is None:
+        slug = get_current_board()
+    meta = read_board_metadata(slug)
+    if bool(meta.get("archived")):
+        return False
+    board_class = str(meta.get("board_class") or "").strip().lower()
+    if board_class in _PROTECTED_BOARD_CLASSES:
+        return False
+    if board_class not in _EXECUTION_BOARD_CLASSES:
+        return False
+    return _metadata_bool(meta, "dispatch", False)
+
+
+def board_auto_decompose_enabled(board: Optional[str] = None) -> bool:
+    """Return whether automatic triage decomposition is allowed for ``board``."""
+    slug = _normalize_board_slug(board)
+    if slug is None:
+        slug = get_current_board()
+    meta = read_board_metadata(slug)
+    if not board_dispatch_enabled(slug):
+        return False
+    return _metadata_bool(meta, "auto_decompose", True)
 
 
 def create_board(
@@ -4739,6 +4822,13 @@ def dispatch_once(
     ``board`` pins workspace/log/db resolution for this tick to a specific
     board. When omitted, the current-board resolution chain is used.
     """
+    dispatch_board = _normalize_board_slug(board)
+    if dispatch_board is None:
+        dispatch_board = get_current_board()
+    result = DispatchResult()
+    if not board_dispatch_enabled(dispatch_board):
+        return result
+
     # Reap zombie children from previously spawned workers.
     # The gateway-embedded dispatcher is the parent of every worker spawned
     # via _default_spawn (start_new_session=True only detaches the
@@ -4772,7 +4862,6 @@ def dispatch_once(
         except Exception:
             pass
 
-    result = DispatchResult()
     result.reclaimed = release_stale_claims(conn)
     result.stale = detect_stale_running(
         conn, stale_timeout_seconds=stale_timeout_seconds,

--- a/hermes_cli/kanban_decompose.py
+++ b/hermes_cli/kanban_decompose.py
@@ -281,6 +281,17 @@ def decompose_task(
     configured, API error, malformed response, decomposer returned
     fanout=true with empty task list) — those surface via ``ok=False``.
     """
+    # Protected/non-execution boards must never be decomposed. The
+    # `auto_decompose` board flag gates only the gateway's automatic
+    # `author="auto-decomposer"` path; an explicit operator/dashboard
+    # decompose on an execution-domain board remains available even when
+    # automatic decomposition is off.
+    if author == "auto-decomposer":
+        if not kb.board_auto_decompose_enabled():
+            return DecomposeOutcome(task_id, False, "board auto_decompose disabled")
+    elif not kb.board_dispatch_enabled():
+        return DecomposeOutcome(task_id, False, "board dispatch disabled")
+
     with kb.connect() as conn:
         task = kb.get_task(conn, task_id)
     if task is None:
@@ -467,6 +478,8 @@ def decompose_task(
 
 def list_triage_ids(*, tenant: Optional[str] = None) -> list[str]:
     """Return task ids currently in the triage column."""
+    if not kb.board_auto_decompose_enabled():
+        return []
     with kb.connect() as conn:
         rows = kb.list_tasks(
             conn,

--- a/tests/hermes_cli/test_kanban_boards.py
+++ b/tests/hermes_cli/test_kanban_boards.py
@@ -242,6 +242,58 @@ class TestBoardCRUD:
         assert again["description"] == "desc"
         assert again["icon"] == "📦"
 
+    def test_board_policy_requires_execution_domain_and_explicit_dispatch(self, fresh_home):
+        kb.create_board("normal")
+        assert kb.board_dispatch_enabled("normal") is False
+        assert kb.board_auto_decompose_enabled("normal") is False
+
+        kb.write_board_metadata(
+            "normal",
+            board_class="execution-domain",
+            dispatch=True,
+            auto_decompose=True,
+        )
+        assert kb.board_dispatch_enabled("normal") is True
+        assert kb.board_auto_decompose_enabled("normal") is True
+
+    def test_board_policy_blocks_human_owned_classes(self, fresh_home):
+        for slug, board_class in {
+            "ideas": "human-backlog",
+            "inbox": "human-decision-inbox",
+            "proposal": "governance-proposal",
+        }.items():
+            kb.create_board(slug)
+            kb.write_board_metadata(
+                slug,
+                board_class=board_class,
+                dispatch=True,
+                auto_decompose=True,
+            )
+            assert kb.board_dispatch_enabled(slug) is False
+            assert kb.board_auto_decompose_enabled(slug) is False
+
+    def test_board_policy_explicit_flags_block_execution(self, fresh_home):
+        kb.create_board("protected")
+        kb.write_board_metadata("protected", dispatch=False, auto_decompose=False)
+        assert kb.board_dispatch_enabled("protected") is False
+        assert kb.board_auto_decompose_enabled("protected") is False
+
+    def test_dispatch_once_noops_when_board_policy_disables_dispatch(self, fresh_home, monkeypatch):
+        kb.create_board("protected")
+        kb.write_board_metadata("protected", dispatch=False)
+        monkeypatch.setattr("hermes_cli.profiles.profile_exists", lambda name: True)
+        with kb.connect(board="protected") as conn:
+            tid = kb.create_task(conn, title="must not run", assignee="worker")
+            res = kb.dispatch_once(
+                conn,
+                board="protected",
+                spawn_fn=lambda *_args, **_kwargs: 12345,
+            )
+            task = kb.get_task(conn, tid)
+        assert res.spawned == []
+        assert task.status == "ready"
+        assert task.claim_lock is None
+
     def test_remove_archive(self, fresh_home):
         kb.create_board("toremove")
         res = kb.remove_board("toremove")

--- a/tests/hermes_cli/test_kanban_decompose.py
+++ b/tests/hermes_cli/test_kanban_decompose.py
@@ -26,6 +26,12 @@ def kanban_home(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_HOME", str(home))
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
     kb.init_db()
+    kb.write_board_metadata(
+        kb.DEFAULT_BOARD,
+        board_class="execution-domain",
+        dispatch=True,
+        auto_decompose=True,
+    )
     return home
 
 
@@ -112,6 +118,64 @@ def test_decompose_with_fanout_creates_children(kanban_home):
     assert c1.status == "todo"
     assert c0.assignee == "researcher"
     assert c1.assignee == "engineer"
+
+
+def test_decompose_task_respects_board_auto_decompose_policy(kanban_home, monkeypatch):
+    kb.create_board("ideas")
+    kb.write_board_metadata("ideas", board_class="human-backlog")
+    monkeypatch.setenv("HERMES_KANBAN_BOARD", "ideas")
+    with kb.connect(board="ideas") as conn:
+        tid = kb.create_task(conn, title="raw idea", triage=True)
+
+    outcome = decomp.decompose_task(tid, author="auto-decomposer")
+
+    assert outcome.ok is False
+    assert "auto_decompose disabled" in outcome.reason
+    with kb.connect(board="ideas") as conn:
+        task = kb.get_task(conn, tid)
+    assert task is not None
+    assert task.status == "triage"
+
+
+def test_list_triage_ids_respects_board_auto_decompose_policy(kanban_home, monkeypatch):
+    kb.create_board("ideas")
+    kb.write_board_metadata("ideas", auto_decompose=False)
+    monkeypatch.setenv("HERMES_KANBAN_BOARD", "ideas")
+    with kb.connect(board="ideas") as conn:
+        kb.create_task(conn, title="raw idea", triage=True)
+
+    assert decomp.list_triage_ids() == []
+
+
+def test_manual_decompose_allowed_when_only_auto_decompose_disabled(kanban_home):
+    kb.write_board_metadata(kb.DEFAULT_BOARD, auto_decompose=False)
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="operator requested", triage=True)
+
+    llm_payload = jsonlib.dumps({
+        "fanout": False,
+        "rationale": "manual operator path",
+        "title": "Manual title",
+        "body": "Manual body",
+    })
+    patches = _patch_list_profiles(["orchestrator", "fallback"])
+    for p in patches:
+        p.start()
+    try:
+        with _patch_aux_client(llm_payload), _patch_extra_body(), patch(
+            "hermes_cli.kanban_decompose._load_config",
+            return_value={"kanban": {"default_assignee": "fallback"}},
+        ):
+            outcome = decomp.decompose_task(tid, author="operator")
+    finally:
+        for p in patches:
+            p.stop()
+
+    assert outcome.ok, outcome.reason
+    with kb.connect() as conn:
+        task = kb.get_task(conn, tid)
+    assert task is not None
+    assert task.status == "ready"
 
 
 def test_decompose_fanout_false_assigns_default_when_unassigned(kanban_home):


### PR DESCRIPTION
## Summary\n- Add board metadata policy flags for dispatch and auto-decomposition\n- Skip gateway dispatch/auto-decompose on protected, archived, or unclassified boards\n- Add regression coverage for board policy gating\n\n## Test plan\n- uv run --extra dev ruff check gateway/run.py hermes_cli/kanban_db.py hermes_cli/kanban_decompose.py tests/hermes_cli/test_kanban_boards.py tests/hermes_cli/test_kanban_decompose.py\n- uv run --extra dev python -m pytest tests/hermes_cli/test_kanban_boards.py tests/hermes_cli/test_kanban_decompose.py -q