### PR TITLE
fix(tests): stub _try_lazy_install_stt in tests/tools/ to unblock CI

### DIFF
--- a/tests/tools/conftest.py
+++ b/tests/tools/conftest.py
@@ -48,3 +48,25 @@ def web_registry_populated():
     yield
     from agent.web_search_registry import _reset_for_tests
     _reset_for_tests()
+
+
+@pytest.fixture(autouse=True)
+def _no_lazy_install_stt(request, monkeypatch):
+    """Prevent transcription tests from triggering real faster-whisper install.
+
+    ``tools.transcription_tools._try_lazy_install_stt()`` calls
+    ``tools.lazy_deps.ensure("stt.faster_whisper")`` and re-probes via
+    ``importlib.util.find_spec``. In a dev environment with the package already
+    installed, the probe returns True and ``_get_provider()`` reports ``"local"``
+    even when tests have patched ``_HAS_FASTER_WHISPER`` to ``False`` to simulate
+    the unavailable state. That breaks ~15 tests that expect cloud fallback or
+    ``"none"`` when local is unavailable.
+
+    Default the helper to ``False`` everywhere; tests that specifically exercise
+    the lazy-install path can still re-patch it locally.
+    """
+    try:
+        import tools.transcription_tools as _tt
+    except Exception:
+        return
+    monkeypatch.setattr(_tt, "_try_lazy_install_stt", lambda: False, raising=False)


### PR DESCRIPTION
## Summary

Unblocks main CI by isolating transcription provider-selection tests from real `faster-whisper` lazy-install behavior.

PR b5c6d9ac0 ("wire STT lazy-install into transcription_tools.py") added `_try_lazy_install_stt()` as a fallback in `_get_provider()` and `_transcribe_local()` before reporting the local backend unavailable.

The helper calls `tools.lazy_deps.ensure("stt.faster_whisper")` and then re-probes with `importlib.util.find_spec("faster_whisper")`. In dev / CI environments where the package is already installed, `find_spec` returns a real spec and the helper returns `True` — overriding the test patch of `_HAS_FASTER_WHISPER=False`. `_get_provider()` then reports `"local"` instead of falling through to cloud providers or `"none"`.

This broke 14 tests across:

- `tests/tools/test_transcription.py`
- `tests/tools/test_transcription_tools.py`
- `tests/tools/test_transcription_dotenv_fallback.py`

Latest failing run on `main`: https://github.com/NousResearch/hermes-agent/actions/runs/26277114434

## Fix

Add an autouse fixture in `tests/tools/conftest.py` that patches `tools.transcription_tools._try_lazy_install_stt` to return `False` by default. Tests that specifically need to exercise the lazy-install code path can still re-patch it locally.

Rationale for stubbing in tests rather than changing production code:

- Production behavior (lazy install on cold start) is the desired runtime UX.
- The lazy install attempt is exactly what these tests need to suppress — they simulate "package not installed" via `_HAS_FASTER_WHISPER=False` and want the rest of `_get_provider()` to behave accordingly.
- Real package installation in tests is slow, network-dependent, and side-effectful.

## Test plan

- `pytest tests/tools/test_transcription.py tests/tools/test_transcription_tools.py tests/tools/test_transcription_dotenv_fallback.py` → **131 passed** (was 14 failing).
- Adjacent suites (`test_voice_mode.py`, `test_voice_cli_integration.py`, `test_managed_media_gateways.py`, gateway STT tests): **452 passed**, no regressions.
- Fixture scope is limited to `tests/tools/` — gateway/agent/CLI suites unaffected.
