### PR TITLE
fix(xurl): correct image upload examples in SKILL.md

### DIFF
--- a/skills/social-media/xurl/SKILL.md
+++ b/skills/social-media/xurl/SKILL.md
@@ -150,7 +150,8 @@ After this, the agent can use any command below without further setup. OAuth 2.0
 | Mute / Unmute | `xurl mute @handle` / `xurl unmute @handle` |
 | Send DM | `xurl dm @handle "message"` |
 | List DMs | `xurl dms -n 10` |
-| Upload media | `xurl media upload path/to/file.mp4` |
+| Upload image | `xurl media upload --media-type image/jpeg --category tweet_image photo.jpg` |
+| Upload video | `xurl media upload video.mp4` |
 | Media status | `xurl media status MEDIA_ID` |
 | List apps | `xurl auth apps list` |
 | Remove app | `xurl auth apps remove NAME` |
@@ -257,19 +258,20 @@ xurl dms -n 25
 ### Media Upload
 
 ```bash
-# Auto-detect type
-xurl media upload photo.jpg
-xurl media upload video.mp4
-
-# Explicit type/category
+# Images — MUST specify --media-type and --category (default is amplify_video, which breaks image uploads)
 xurl media upload --media-type image/jpeg --category tweet_image photo.jpg
+xurl media upload --media-type image/png --category tweet_image photo.png
+xurl media upload --media-type image/gif --category tweet_gif photo.gif
+
+# Videos — bare command works because default category is amplify_video
+xurl media upload video.mp4
 
 # Videos need server-side processing — check status (or poll)
 xurl media status MEDIA_ID
 xurl media status --wait MEDIA_ID
 
 # Full workflow
-xurl media upload meme.png                  # returns media id
+xurl media upload --media-type image/png --category tweet_image photo.png   # returns media id
 xurl post "lol" --media-id MEDIA_ID
 ```
 
@@ -345,7 +347,8 @@ Errors are also JSON:
 
 ### Post with an image
 ```bash
-xurl media upload photo.jpg
+# --media-type and --category are required; bare upload defaults to amplify_video and breaks image uploads
+xurl media upload --media-type image/jpeg --category tweet_image photo.jpg
 xurl post "Check out this photo!" --media-id MEDIA_ID
 ```
 
@@ -408,7 +411,7 @@ xurl --app staging /2/users/me             # one-off against staging
 | 401 on every request | Token expired or wrong default app | Check `xurl auth status` — verify `▸` points to an app with oauth2 tokens |
 | `client-forbidden` / `client-not-enrolled` | X platform enrollment issue | Dashboard → Apps → Manage → Move to "Pay-per-use" package → Production environment |
 | `CreditsDepleted` | $0 balance on X API | Buy credits (min $5) in Developer Console → Billing |
-| `media processing failed` on image upload | Default category is `amplify_video` | Add `--category tweet_image --media-type image/png` |
+| `media processing failed` on image upload | Default category is `amplify_video` | Add `--category tweet_image` (or `tweet_gif` for GIF) and `--media-type` matching the file (`image/jpeg`, `image/png`, `image/gif`) |
 | Two "Client Secret" values in X dashboard | UI bug — first is actually Client ID | Confirm on the "Keys and tokens" page; ID ends in `MTpjaQ` |
 
 ---


### PR DESCRIPTION
 ## Summary

  Fixes wrong image upload examples in the agent skill file `skills/social-media/xurl/SKILL.md`. No change to the `xurl`   CLI itself.

  The skill told agents to run `xurl media upload photo.jpg`, but `xurl` defaults to `--category amplify_video`, which
  the X API rejects for image files — so agents following the skill always failed image uploads. The skill's own
  Troubleshooting table already noted this, but the examples above it still used the broken form.

  Updated all image examples (Quick Reference, Media Upload, Common Workflows, Troubleshooting) to pass `--media-type`
  and `--category tweet_image` (or `tweet_gif` for GIF). Video examples are unchanged — `amplify_video` is already the
  correct default for video.

  ## Test plan

  Tested all four media types end-to-end with the updated commands.

 | Format | Result | Test Detail | Tweet |
  | --- | --- | --- | --- |
  | JPEG | ✅ uploaded + posted | <img width="1102" height="497" alt="testuploadjpg" src="https://github.com/user-attachments/assets/2fda907e-cadf-46dd-877b-1d87cf6e1d2a" /> | https://x.com/LoongLab/status/2057765241145212974?s=20 |
  | PNG  | ✅ uploaded + posted | <img width="1103" height="495" alt="testuploadpng" src="https://github.com/user-attachments/assets/859dd6f6-fe13-4672-bb7f-d59f7b83fbec" />  | https://x.com/LoongLab/status/2057765686999683336?s=20 |
  | GIF  | ✅ uploaded + posted | <img width="1106" height="475" alt="testuploadgif" src="https://github.com/user-attachments/assets/a15ef973-7ac7-4daf-a863-497aa4121c9c" />  | https://x.com/LoongLab/status/2057765965837078881?s=20 |
  | MP4  | ✅ uploaded + posted | <img width="1106" height="459" alt="testuploadvedio" src="https://github.com/user-attachments/assets/f9999f6b-7df3-46c9-ad46-aa5281a822fe" /> | https://x.com/LoongLab/status/2057764704999837951?s=20 |







