### PR TITLE
fix(acp): allow skipping config MCP servers in ACP sessions

### DIFF
--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -587,11 +587,18 @@ class SessionManager:
         elif isinstance(model_cfg, str) and model_cfg.strip():
             default_model = model_cfg.strip()
 
-        configured_mcp_servers = [
-            name
-            for name, cfg in (config.get("mcp_servers") or {}).items()
-            if not isinstance(cfg, dict) or cfg.get("enabled", True) is not False
-        ]
+        # Allow callers to suppress MCP server loading via env var.
+        # HERMES_ACP_SKIP_MCP=1 disables all config-based MCP servers for this session,
+        # significantly reducing system prompt size for focused subagent tasks.
+        skip_mcp = os.environ.get("HERMES_ACP_SKIP_MCP", "").strip().lower() in ("1", "true", "yes")
+        if skip_mcp:
+            configured_mcp_servers = []
+        else:
+            configured_mcp_servers = [
+                name
+                for name, cfg in (config.get("mcp_servers") or {}).items()
+                if not isinstance(cfg, dict) or cfg.get("enabled", True) is not False
+            ]
 
         kwargs = {
             "platform": "acp",

--- a/tests/acp/test_session.py
+++ b/tests/acp/test_session.py
@@ -275,18 +275,44 @@ class TestPersistence:
 
         assert captured["enabled_toolsets"] == ["hermes-acp", "mcp-olympus", "mcp-exa"]
 
-    def test_create_session_writes_to_db(self, manager):
-        state = manager.create_session(cwd="/project")
-        db = manager._get_db()
-        assert db is not None
-        row = db.get_session(state.session_id)
-        assert row is not None
-        assert row["source"] == "acp"
-        # cwd stored in model_config JSON
-        mc = json.loads(row["model_config"])
-        assert mc["cwd"] == "/project"
+    def test_create_session_can_skip_mcp_toolsets_with_env(self, tmp_path, monkeypatch):
+        captured = {}
 
-    def test_get_session_restores_from_db(self, manager):
+        def fake_resolve_runtime_provider(requested=None, **kwargs):
+            return {
+                "provider": "openrouter",
+                "api_mode": "chat_completions",
+                "base_url": "https://openrouter.example/v1",
+                "api_key": "***",
+                "command": None,
+                "args": [],
+            }
+
+        def fake_agent(**kwargs):
+            captured.update(kwargs)
+            return SimpleNamespace(model=kwargs.get("model"), enabled_toolsets=kwargs.get("enabled_toolsets"))
+
+        monkeypatch.setenv("HERMES_ACP_SKIP_MCP", "1")
+        monkeypatch.setattr("hermes_cli.config.load_config", lambda: {
+            "model": {"provider": "openrouter", "default": "test-model"},
+            "mcp_servers": {
+                "olympus": {"command": "python", "enabled": True},
+                "exa": {"url": "https://exa.ai/mcp"},
+            },
+        })
+        monkeypatch.setattr(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            fake_resolve_runtime_provider,
+        )
+        db = SessionDB(tmp_path / "state.db")
+
+        with patch("run_agent.AIAgent", side_effect=fake_agent):
+            manager = SessionManager(db=db)
+            manager.create_session(cwd="/work")
+
+        assert captured["enabled_toolsets"] == ["hermes-acp"]
+
+    def test_create_session_writes_to_db(self, manager):
         """Simulate process restart: create session, drop from memory, get again."""
         state = manager.create_session(cwd="/work")
         state.history.append({"role": "user", "content": "hello"})


### PR DESCRIPTION
## Summary\n- add HERMES_ACP_SKIP_MCP to skip config-based MCP server loading for ACP sessions\n- reduce ACP system prompt size for focused subagent tasks\n- add regression coverage in tests/acp/test_session.py\n\n## Why\nACP sessions were loading all configured MCP servers from ~/.hermes/config.yaml even when the subagent did not need them. That inflated the system prompt and contributed to timeout failures in Step 5.5.\n\n## Validation\n- pytest -q tests/acp/test_session.py\n\n## Notes\nThis keeps the default behavior unchanged unless HERMES_ACP_SKIP_MCP=1 is set.