### PR TITLE
feat(WordPress): Add WordPress plugin with site probe and post CRUD tools

### DIFF
--- a/plugins/wordpress/__init__.py
+++ b/plugins/wordpress/__init__.py
@@ -1,0 +1,62 @@
+"""WordPress plugin for Hermes."""
+
+from __future__ import annotations
+
+from .schemas import (
+    WP_POST_CREATE_SCHEMA,
+    WP_POST_GET_SCHEMA,
+    WP_POST_LIST_SCHEMA,
+    WP_POST_UPDATE_SCHEMA,
+    WP_SITE_INFO_SCHEMA,
+)
+from .tools import (
+    handle_wp_post_create,
+    handle_wp_post_get,
+    handle_wp_post_list,
+    handle_wp_post_update,
+    handle_wp_site_info,
+    wordpress_requirements_met,
+)
+
+
+def register(ctx) -> None:
+    ctx.register_tool(
+        name="wp_site_info",
+        toolset="wordpress",
+        schema=WP_SITE_INFO_SCHEMA,
+        handler=handle_wp_site_info,
+        check_fn=wordpress_requirements_met,
+        emoji="W",
+    )
+    ctx.register_tool(
+        name="wp_post_list",
+        toolset="wordpress",
+        schema=WP_POST_LIST_SCHEMA,
+        handler=handle_wp_post_list,
+        check_fn=wordpress_requirements_met,
+        emoji="W",
+    )
+    ctx.register_tool(
+        name="wp_post_get",
+        toolset="wordpress",
+        schema=WP_POST_GET_SCHEMA,
+        handler=handle_wp_post_get,
+        check_fn=wordpress_requirements_met,
+        emoji="W",
+    )
+    ctx.register_tool(
+        name="wp_post_create",
+        toolset="wordpress",
+        schema=WP_POST_CREATE_SCHEMA,
+        handler=handle_wp_post_create,
+        check_fn=wordpress_requirements_met,
+        emoji="W",
+    )
+    ctx.register_tool(
+        name="wp_post_update",
+        toolset="wordpress",
+        schema=WP_POST_UPDATE_SCHEMA,
+        handler=handle_wp_post_update,
+        check_fn=wordpress_requirements_met,
+        emoji="W",
+    )

--- a/plugins/wordpress/auth.py
+++ b/plugins/wordpress/auth.py
@@ -1,0 +1,59 @@
+"""Environment-backed auth helpers for the WordPress plugin."""
+
+from __future__ import annotations
+
+import base64
+import os
+from dataclasses import dataclass
+
+from .errors import WordPressConfigError
+
+
+@dataclass(frozen=True)
+class WordPressCredentials:
+    base_url: str
+    username: str
+    app_password: str
+
+    def authorization_header(self) -> str:
+        token = f"{self.username}:{self.app_password}".encode("utf-8")
+        return f"Basic {base64.b64encode(token).decode('ascii')}"
+
+
+def get_credentials(
+    *,
+    base_url: str | None = None,
+    username: str | None = None,
+    app_password: str | None = None,
+) -> WordPressCredentials:
+    resolved_base_url = (base_url or os.getenv("WORDPRESS_BASE_URL", "")).strip()
+    resolved_username = (username or os.getenv("WORDPRESS_USERNAME", "")).strip()
+    resolved_app_password = (app_password or os.getenv("WORDPRESS_APP_PASSWORD", "")).strip()
+
+    missing = [
+        name
+        for name, value in (
+            ("WORDPRESS_BASE_URL", resolved_base_url),
+            ("WORDPRESS_USERNAME", resolved_username),
+            ("WORDPRESS_APP_PASSWORD", resolved_app_password),
+        )
+        if not value
+    ]
+    if missing:
+        raise WordPressConfigError(
+            "Missing WordPress configuration: " + ", ".join(missing)
+        )
+
+    return WordPressCredentials(
+        base_url=resolved_base_url,
+        username=resolved_username,
+        app_password=resolved_app_password,
+    )
+
+
+def wordpress_requirements_met() -> bool:
+    try:
+        get_credentials(base_url="https://example.com")
+        return True
+    except WordPressConfigError:
+        return False

--- a/plugins/wordpress/client.py
+++ b/plugins/wordpress/client.py
@@ -1,0 +1,148 @@
+"""Small WordPress REST API client for Hermes tools."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any, Callable
+from urllib import error, parse, request
+
+from .auth import WordPressCredentials, get_credentials
+from .errors import WordPressAPIError
+
+
+def normalize_base_url(raw: str) -> str:
+    value = raw.strip()
+    if not value:
+        return value
+    if not value.startswith(("http://", "https://")):
+        value = f"https://{value}"
+    return value.rstrip("/")
+
+
+@dataclass
+class WordPressClient:
+    credentials: WordPressCredentials
+    timeout: float = 20.0
+    opener: Callable[..., Any] = request.urlopen
+
+    @classmethod
+    def from_env(cls, *, base_url: str | None = None) -> "WordPressClient":
+        return cls(credentials=get_credentials(base_url=base_url))
+
+    @property
+    def base_url(self) -> str:
+        return normalize_base_url(self.credentials.base_url)
+
+    @property
+    def api_root(self) -> str:
+        return f"{self.base_url}/wp-json"
+
+    def _request_json(
+        self,
+        path: str,
+        *,
+        method: str = "GET",
+        authenticated: bool = True,
+        query: dict[str, Any] | None = None,
+        body: dict[str, Any] | None = None,
+    ) -> Any:
+        url = f"{self.api_root}{path}"
+        if query:
+            encoded = parse.urlencode(
+                {key: value for key, value in query.items() if value is not None},
+                doseq=True,
+            )
+            if encoded:
+                url = f"{url}?{encoded}"
+
+        headers = {"Accept": "application/json"}
+        payload = None
+        if body is not None:
+            headers["Content-Type"] = "application/json"
+            payload = json.dumps(body).encode("utf-8")
+        if authenticated:
+            headers["Authorization"] = self.credentials.authorization_header()
+        req = request.Request(url, data=payload, headers=headers, method=method)
+
+        try:
+            with self.opener(req, timeout=self.timeout) as response:
+                payload = response.read().decode("utf-8")
+                return json.loads(payload) if payload else {}
+        except error.HTTPError as exc:
+            body = exc.read().decode("utf-8", errors="replace")
+            payload = None
+            message = body or exc.reason or "WordPress API request failed"
+            try:
+                payload = json.loads(body) if body else None
+                if isinstance(payload, dict):
+                    message = payload.get("message") or payload.get("code") or message
+            except json.JSONDecodeError:
+                payload = None
+            raise WordPressAPIError(
+                message,
+                status_code=exc.code,
+                payload=payload,
+            ) from exc
+        except error.URLError as exc:
+            raise WordPressAPIError(
+                f"WordPress API request failed: {exc.reason}",
+            ) from exc
+        except json.JSONDecodeError as exc:
+            raise WordPressAPIError("WordPress API returned invalid JSON") from exc
+
+    def get_site_info(self) -> dict[str, Any]:
+        root = self._request_json("", authenticated=False)
+        if not isinstance(root, dict):
+            raise WordPressAPIError("WordPress API root returned an unexpected payload")
+        auth_state = {
+            "authenticated": False,
+            "current_user": None,
+        }
+        try:
+            user = self._request_json("/wp/v2/users/me", authenticated=True, query={"context": "edit"})
+            if not isinstance(user, dict):
+                raise WordPressAPIError("WordPress users/me returned an unexpected payload")
+            auth_state = {
+                "authenticated": True,
+                "current_user": {
+                    "id": user.get("id"),
+                    "slug": user.get("slug"),
+                    "name": user.get("name"),
+                },
+            }
+        except WordPressAPIError as exc:
+            if exc.status_code not in {401, 403}:
+                raise
+
+        namespaces = root.get("namespaces")
+        return {
+            "site": {
+                "base_url": self.base_url,
+                "name": root.get("name"),
+                "description": root.get("description"),
+                "url": root.get("url"),
+                "home": root.get("home"),
+            },
+            "api": {
+                "root": self.api_root,
+                "namespace_count": len(namespaces or []),
+                "namespaces": namespaces or [],
+            },
+            "auth": auth_state,
+        }
+
+    def list_posts(self, *, query: dict[str, Any] | None = None) -> Any:
+        params = {"context": "edit"}
+        if query:
+            params.update(query)
+        return self._request_json("/wp/v2/posts", query=params)
+
+    def get_post(self, post_id: int, *, context: str = "edit") -> Any:
+        return self._request_json(f"/wp/v2/posts/{int(post_id)}", query={"context": context})
+
+    def create_post(self, payload: dict[str, Any]) -> Any:
+        return self._request_json("/wp/v2/posts", method="POST", body=payload)
+
+    def update_post(self, post_id: int, payload: dict[str, Any]) -> Any:
+        return self._request_json(f"/wp/v2/posts/{int(post_id)}", method="POST", body=payload)

--- a/plugins/wordpress/errors.py
+++ b/plugins/wordpress/errors.py
@@ -1,0 +1,20 @@
+"""WordPress plugin exceptions."""
+
+from __future__ import annotations
+
+
+class WordPressError(Exception):
+    """Base WordPress plugin error."""
+
+
+class WordPressConfigError(WordPressError):
+    """Raised when required WordPress configuration is missing."""
+
+
+class WordPressAPIError(WordPressError):
+    """Raised when the WordPress REST API returns an error response."""
+
+    def __init__(self, message: str, *, status_code: int | None = None, payload=None):
+        super().__init__(message)
+        self.status_code = status_code
+        self.payload = payload

--- a/plugins/wordpress/plugin.yaml
+++ b/plugins/wordpress/plugin.yaml
@@ -1,0 +1,14 @@
+name: wordpress
+version: "0.1.0"
+description: "WordPress editorial operations via the official REST API."
+author: NousResearch
+kind: standalone
+provides_tools:
+  - wp_site_info
+  - wp_post_list
+  - wp_post_get
+  - wp_post_create
+  - wp_post_update
+requires_env:
+  - WORDPRESS_USERNAME
+  - WORDPRESS_APP_PASSWORD

--- a/plugins/wordpress/schemas.py
+++ b/plugins/wordpress/schemas.py
@@ -1,0 +1,111 @@
+"""JSON schemas for WordPress plugin tools."""
+
+from __future__ import annotations
+
+
+WP_SITE_INFO_SCHEMA = {
+    "name": "wp_site_info",
+    "description": "Inspect the configured WordPress site and report API/auth status.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "base_url": {
+                "type": "string",
+                "description": "Optional WordPress site URL override for this call. Required when WORDPRESS_BASE_URL env var is unset.",
+            },
+        },
+        "additionalProperties": False,
+    },
+}
+
+
+_POST_MUTATION_PROPERTIES = {
+    "title": {"type": "string"},
+    "content": {"type": "string"},
+    "excerpt": {"type": "string"},
+    "slug": {"type": "string"},
+    "status": {
+        "type": "string",
+        "enum": ["publish", "future", "draft", "pending", "private"],
+    },
+    "featured_media": {"type": "integer"},
+    "categories": {"type": "array", "items": {"type": "integer"}},
+    "tags": {"type": "array", "items": {"type": "integer"}},
+    "date": {"type": "string"},
+    "date_gmt": {"type": "string"},
+}
+
+
+WP_POST_LIST_SCHEMA = {
+    "name": "wp_post_list",
+    "description": "List WordPress posts from the configured site.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "base_url": {
+                "type": "string",
+                "description": "Optional WordPress site URL override. Required when WORDPRESS_BASE_URL env var is unset.",
+            },
+            "status": {"type": "string"},
+            "search": {"type": "string"},
+            "per_page": {"type": "integer", "minimum": 1, "maximum": 100},
+            "page": {"type": "integer", "minimum": 1},
+        },
+        "additionalProperties": False,
+    },
+}
+
+
+WP_POST_GET_SCHEMA = {
+    "name": "wp_post_get",
+    "description": "Fetch a WordPress post by id.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "base_url": {
+                "type": "string",
+                "description": "Optional WordPress site URL override. Required when WORDPRESS_BASE_URL env var is unset.",
+            },
+            "post_id": {"type": "integer", "minimum": 1},
+            "context": {"type": "string", "enum": ["view", "embed", "edit"]},
+        },
+        "required": ["post_id"],
+        "additionalProperties": False,
+    },
+}
+
+
+WP_POST_CREATE_SCHEMA = {
+    "name": "wp_post_create",
+    "description": "Create a WordPress post via the REST API.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "base_url": {
+                "type": "string",
+                "description": "Optional WordPress site URL override. Required when WORDPRESS_BASE_URL env var is unset.",
+            },
+            **_POST_MUTATION_PROPERTIES,
+        },
+        "additionalProperties": False,
+    },
+}
+
+
+WP_POST_UPDATE_SCHEMA = {
+    "name": "wp_post_update",
+    "description": "Update an existing WordPress post via the REST API.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "base_url": {
+                "type": "string",
+                "description": "Optional WordPress site URL override. Required when WORDPRESS_BASE_URL env var is unset.",
+            },
+            "post_id": {"type": "integer", "minimum": 1},
+            **_POST_MUTATION_PROPERTIES,
+        },
+        "required": ["post_id"],
+        "additionalProperties": False,
+    },
+}

--- a/plugins/wordpress/tools.py
+++ b/plugins/wordpress/tools.py
@@ -1,0 +1,96 @@
+"""Tool handlers for the WordPress plugin."""
+
+from __future__ import annotations
+
+from .auth import wordpress_requirements_met
+from .client import WordPressClient
+from .errors import WordPressAPIError, WordPressError
+from tools.registry import tool_error, tool_result
+
+
+def _wordpress_tool_error(exc: Exception) -> str:
+    if isinstance(exc, WordPressAPIError):
+        return tool_error(str(exc), status_code=exc.status_code)
+    if isinstance(exc, WordPressError):
+        return tool_error(str(exc))
+    return tool_error(f"WordPress tool failed: {type(exc).__name__}: {exc}")
+
+
+def handle_wp_site_info(args: dict, **kwargs) -> str:
+    try:
+        client = WordPressClient.from_env(base_url=args.get("base_url"))
+        payload = client.get_site_info()
+        return tool_result(payload)
+    except Exception as exc:
+        return _wordpress_tool_error(exc)
+
+
+def _coerce_post_payload(args: dict) -> dict:
+    payload = {}
+    for field in (
+        "title",
+        "content",
+        "excerpt",
+        "slug",
+        "status",
+        "featured_media",
+        "categories",
+        "tags",
+        "date",
+        "date_gmt",
+    ):
+        value = args.get(field)
+        if value is not None:
+            payload[field] = value
+    return payload
+
+
+def handle_wp_post_list(args: dict, **kwargs) -> str:
+    try:
+        client = WordPressClient.from_env(base_url=args.get("base_url"))
+        query = {
+            "status": args.get("status"),
+            "search": args.get("search"),
+            "per_page": args.get("per_page"),
+            "page": args.get("page"),
+        }
+        payload = client.list_posts(query=query)
+        return tool_result(payload)
+    except Exception as exc:
+        return _wordpress_tool_error(exc)
+
+
+def handle_wp_post_get(args: dict, **kwargs) -> str:
+    if args.get("post_id") is None:
+        return tool_error("post_id is required")
+    try:
+        client = WordPressClient.from_env(base_url=args.get("base_url"))
+        payload = client.get_post(int(args["post_id"]), context=str(args.get("context") or "edit"))
+        return tool_result(payload)
+    except Exception as exc:
+        return _wordpress_tool_error(exc)
+
+
+def handle_wp_post_create(args: dict, **kwargs) -> str:
+    if not any(str(args.get(field) or "").strip() for field in ("title", "content", "excerpt", "status")):
+        return tool_error("Provide at least one of: title, content, excerpt, status")
+    try:
+        client = WordPressClient.from_env(base_url=args.get("base_url"))
+        payload = client.create_post(_coerce_post_payload(args))
+        return tool_result(payload)
+    except Exception as exc:
+        return _wordpress_tool_error(exc)
+
+
+def handle_wp_post_update(args: dict, **kwargs) -> str:
+    if args.get("post_id") is None:
+        return tool_error("post_id is required")
+    payload = _coerce_post_payload(args)
+    if not payload:
+        return tool_error("Provide at least one field to update")
+    try:
+        client = WordPressClient.from_env(base_url=args.get("base_url"))
+        result = client.update_post(int(args["post_id"]), payload)
+        return tool_result(result)
+    except Exception as exc:
+        return _wordpress_tool_error(exc)

--- a/tests/plugins/test_wordpress_plugin.py
+++ b/tests/plugins/test_wordpress_plugin.py
@@ -1,0 +1,409 @@
+"""Tests for the bundled WordPress plugin."""
+
+from __future__ import annotations
+
+import base64
+import importlib.util
+import json
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+import yaml
+
+from plugins.wordpress.auth import get_credentials, wordpress_requirements_met
+from plugins.wordpress.client import WordPressAPIError, WordPressClient, normalize_base_url
+from plugins.wordpress.tools import handle_wp_site_info
+
+
+PLUGIN_DIR = Path(__file__).resolve().parents[2] / "plugins" / "wordpress"
+
+
+def _load_plugin_init():
+    spec = importlib.util.spec_from_file_location(
+        "hermes_plugins.wordpress",
+        PLUGIN_DIR / "__init__.py",
+        submodule_search_locations=[str(PLUGIN_DIR)],
+    )
+    if "hermes_plugins" not in sys.modules:
+        ns = types.ModuleType("hermes_plugins")
+        ns.__path__ = []
+        sys.modules["hermes_plugins"] = ns
+    mod = importlib.util.module_from_spec(spec)
+    mod.__package__ = "hermes_plugins.wordpress"
+    mod.__path__ = [str(PLUGIN_DIR)]
+    sys.modules["hermes_plugins.wordpress"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class _Response:
+    def __init__(self, payload):
+        self._payload = payload
+
+    def read(self):
+        return json.dumps(self._payload).encode("utf-8")
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+
+class TestManifest:
+    def test_plugin_directory_exists(self):
+        assert PLUGIN_DIR.exists()
+        assert (PLUGIN_DIR / "plugin.yaml").exists()
+        assert (PLUGIN_DIR / "__init__.py").exists()
+
+    def test_manifest_fields(self):
+        data = yaml.safe_load((PLUGIN_DIR / "plugin.yaml").read_text(encoding="utf-8"))
+        assert data["name"] == "wordpress"
+        assert data["kind"] == "standalone"
+        assert data["provides_tools"] == [
+            "wp_site_info",
+            "wp_post_list",
+            "wp_post_get",
+            "wp_post_create",
+            "wp_post_update",
+        ]
+        assert data["requires_env"] == [
+            "WORDPRESS_USERNAME",
+            "WORDPRESS_APP_PASSWORD",
+        ]
+
+
+class TestAuth:
+    def test_builds_basic_auth_header(self, monkeypatch):
+        monkeypatch.setenv("WORDPRESS_BASE_URL", "example.com")
+        monkeypatch.setenv("WORDPRESS_USERNAME", "alice")
+        monkeypatch.setenv("WORDPRESS_APP_PASSWORD", "secret")
+
+        creds = get_credentials()
+        encoded = base64.b64encode(b"alice:secret").decode("ascii")
+        assert creds.authorization_header() == f"Basic {encoded}"
+
+    def test_requirements_gate(self, monkeypatch):
+        monkeypatch.delenv("WORDPRESS_USERNAME", raising=False)
+        monkeypatch.delenv("WORDPRESS_APP_PASSWORD", raising=False)
+        assert wordpress_requirements_met() is False
+
+    def test_requirements_gate_allows_runtime_base_url_override(self, monkeypatch):
+        monkeypatch.delenv("WORDPRESS_BASE_URL", raising=False)
+        monkeypatch.setenv("WORDPRESS_USERNAME", "alice")
+        monkeypatch.setenv("WORDPRESS_APP_PASSWORD", "secret")
+        assert wordpress_requirements_met() is True
+
+
+class TestClient:
+    def test_normalize_base_url(self):
+        assert normalize_base_url("example.com/") == "https://example.com"
+        assert normalize_base_url("http://example.com///") == "http://example.com"
+
+    def test_site_info_reports_auth_state(self):
+        calls = []
+
+        def opener(req, timeout=0):
+            calls.append(req.full_url)
+            if req.full_url.endswith("/wp-json"):
+                return _Response(
+                    {
+                        "name": "Demo",
+                        "description": "Demo site",
+                        "url": "https://example.com",
+                        "home": "https://example.com",
+                        "namespaces": ["wp/v2", "oembed/1.0"],
+                    }
+                )
+            if "users/me" in req.full_url:
+                auth = req.headers.get("Authorization")
+                assert auth and auth.startswith("Basic ")
+                return _Response({"id": 7, "slug": "alice", "name": "Alice"})
+            raise AssertionError(f"unexpected url {req.full_url}")
+
+        client = WordPressClient(
+            credentials=get_credentials(
+                base_url="example.com",
+                username="alice",
+                app_password="secret",
+            ),
+            opener=opener,
+        )
+
+        payload = client.get_site_info()
+        assert calls == [
+            "https://example.com/wp-json",
+            "https://example.com/wp-json/wp/v2/users/me?context=edit",
+        ]
+        assert payload["site"]["name"] == "Demo"
+        assert payload["auth"]["authenticated"] is True
+        assert payload["auth"]["current_user"]["slug"] == "alice"
+
+    def test_site_info_tolerates_unauthorized_user_probe(self):
+        from urllib.error import HTTPError
+        from io import BytesIO
+
+        def opener(req, timeout=0):
+            if req.full_url.endswith("/wp-json"):
+                return _Response({"name": "Demo", "namespaces": ["wp/v2"]})
+            payload = json.dumps({"message": "Unauthorized"}).encode("utf-8")
+            raise HTTPError(req.full_url, 401, "Unauthorized", hdrs=None, fp=BytesIO(payload))
+
+        client = WordPressClient(
+            credentials=get_credentials(
+                base_url="example.com",
+                username="alice",
+                app_password="secret",
+            ),
+            opener=opener,
+        )
+
+        payload = client.get_site_info()
+        assert payload["auth"]["authenticated"] is False
+        assert payload["auth"]["current_user"] is None
+
+    def test_raises_for_non_auth_api_errors(self):
+        from urllib.error import HTTPError
+        from io import BytesIO
+
+        def opener(req, timeout=0):
+            payload = json.dumps({"message": "Server error"}).encode("utf-8")
+            raise HTTPError(req.full_url, 500, "Server Error", hdrs=None, fp=BytesIO(payload))
+
+        client = WordPressClient(
+            credentials=get_credentials(
+                base_url="example.com",
+                username="alice",
+                app_password="secret",
+            ),
+            opener=opener,
+        )
+
+        with pytest.raises(WordPressAPIError) as excinfo:
+            client.get_site_info()
+        assert excinfo.value.status_code == 500
+
+    def test_site_info_rejects_non_object_root_payload(self):
+        def opener(req, timeout=0):
+            return _Response(["not", "an", "object"])
+
+        client = WordPressClient(
+            credentials=get_credentials(
+                base_url="example.com",
+                username="alice",
+                app_password="secret",
+            ),
+            opener=opener,
+        )
+
+        with pytest.raises(WordPressAPIError) as excinfo:
+            client.get_site_info()
+        assert "unexpected payload" in str(excinfo.value)
+
+    def test_site_info_rejects_non_object_users_me_payload(self):
+        def opener(req, timeout=0):
+            if req.full_url.endswith("/wp-json"):
+                return _Response({"name": "Demo", "namespaces": ["wp/v2"]})
+            return _Response(["not", "an", "object"])
+
+        client = WordPressClient(
+            credentials=get_credentials(
+                base_url="example.com",
+                username="alice",
+                app_password="secret",
+            ),
+            opener=opener,
+        )
+
+        with pytest.raises(WordPressAPIError) as excinfo:
+            client.get_site_info()
+        assert "users/me returned an unexpected payload" in str(excinfo.value)
+
+    def test_list_posts_sends_edit_context(self):
+        seen = {}
+
+        def opener(req, timeout=0):
+            seen["url"] = req.full_url
+            return _Response([{"id": 1, "slug": "hello"}])
+
+        client = WordPressClient(
+            credentials=get_credentials(
+                base_url="example.com",
+                username="alice",
+                app_password="secret",
+            ),
+            opener=opener,
+        )
+
+        payload = client.list_posts(query={"status": "draft", "per_page": 5})
+        assert seen["url"] == "https://example.com/wp-json/wp/v2/posts?context=edit&status=draft&per_page=5"
+        assert payload[0]["id"] == 1
+
+    def test_create_post_uses_post_json_body(self):
+        seen = {}
+
+        def opener(req, timeout=0):
+            seen["url"] = req.full_url
+            seen["method"] = req.get_method()
+            seen["body"] = json.loads(req.data.decode("utf-8"))
+            return _Response({"id": 10, "status": "draft"})
+
+        client = WordPressClient(
+            credentials=get_credentials(
+                base_url="example.com",
+                username="alice",
+                app_password="secret",
+            ),
+            opener=opener,
+        )
+
+        payload = client.create_post({"title": "Demo", "status": "draft"})
+        assert seen["url"] == "https://example.com/wp-json/wp/v2/posts"
+        assert seen["method"] == "POST"
+        assert seen["body"] == {"title": "Demo", "status": "draft"}
+        assert payload["id"] == 10
+
+    def test_update_post_posts_to_item_endpoint(self):
+        seen = {}
+
+        def opener(req, timeout=0):
+            seen["url"] = req.full_url
+            seen["method"] = req.get_method()
+            seen["body"] = json.loads(req.data.decode("utf-8"))
+            return _Response({"id": 10, "status": "publish"})
+
+        client = WordPressClient(
+            credentials=get_credentials(
+                base_url="example.com",
+                username="alice",
+                app_password="secret",
+            ),
+            opener=opener,
+        )
+
+        payload = client.update_post(10, {"status": "publish"})
+        assert seen["url"] == "https://example.com/wp-json/wp/v2/posts/10"
+        assert seen["method"] == "POST"
+        assert seen["body"] == {"status": "publish"}
+        assert payload["status"] == "publish"
+
+
+class TestRegister:
+    def test_registers_all_wordpress_tools(self):
+        module = _load_plugin_init()
+
+        calls = []
+
+        class DummyCtx:
+            def register_tool(self, **kwargs):
+                calls.append(kwargs)
+
+        module.register(DummyCtx())
+        assert [call["name"] for call in calls] == [
+            "wp_site_info",
+            "wp_post_list",
+            "wp_post_get",
+            "wp_post_create",
+            "wp_post_update",
+        ]
+        assert all(call["toolset"] == "wordpress" for call in calls)
+        assert all(callable(call["check_fn"]) for call in calls)
+        assert all(
+            call["check_fn"].__name__ == wordpress_requirements_met.__name__
+            for call in calls
+        )
+
+
+class TestToolHandler:
+    def test_handler_returns_tool_error_on_config_issue(self, monkeypatch):
+        monkeypatch.delenv("WORDPRESS_BASE_URL", raising=False)
+        monkeypatch.delenv("WORDPRESS_USERNAME", raising=False)
+        monkeypatch.delenv("WORDPRESS_APP_PASSWORD", raising=False)
+
+        result = handle_wp_site_info({})
+        assert '"error":' in result
+        assert "Missing WordPress configuration" in result
+
+    def test_handler_returns_tool_result(self, monkeypatch):
+        monkeypatch.setenv("WORDPRESS_BASE_URL", "example.com")
+        monkeypatch.setenv("WORDPRESS_USERNAME", "alice")
+        monkeypatch.setenv("WORDPRESS_APP_PASSWORD", "secret")
+
+        fake_payload = {"site": {"name": "Demo"}, "auth": {"authenticated": True}}
+        mock_get_site_info = MagicMock(return_value=fake_payload)
+        monkeypatch.setattr(
+            "plugins.wordpress.client.WordPressClient.get_site_info",
+            mock_get_site_info,
+        )
+
+        result = handle_wp_site_info({})
+        assert '"name": "Demo"' in result
+
+    def test_post_get_requires_post_id(self):
+        from plugins.wordpress.tools import handle_wp_post_get
+
+        result = handle_wp_post_get({})
+        assert '"error": "post_id is required"' in result
+
+    def test_post_create_allows_missing_title(self, monkeypatch):
+        from plugins.wordpress.tools import handle_wp_post_create
+
+        monkeypatch.setenv("WORDPRESS_BASE_URL", "example.com")
+        monkeypatch.setenv("WORDPRESS_USERNAME", "alice")
+        monkeypatch.setenv("WORDPRESS_APP_PASSWORD", "secret")
+        monkeypatch.setattr(
+            "plugins.wordpress.client.WordPressClient.create_post",
+            MagicMock(return_value={"id": 3}),
+        )
+
+        result = handle_wp_post_create({"content": "Body only"})
+        assert '"id": 3' in result
+
+    def test_post_create_requires_minimum_content(self):
+        from plugins.wordpress.tools import handle_wp_post_create
+
+        result = handle_wp_post_create({})
+        assert '"error": "Provide at least one of: title, content, excerpt, status"' in result
+
+    def test_post_update_requires_fields(self):
+        from plugins.wordpress.tools import handle_wp_post_update
+
+        result = handle_wp_post_update({"post_id": 3})
+        assert '"error": "Provide at least one field to update"' in result
+
+    def test_post_handlers_return_client_payloads(self, monkeypatch):
+        from plugins.wordpress.tools import (
+            handle_wp_post_create,
+            handle_wp_post_get,
+            handle_wp_post_list,
+            handle_wp_post_update,
+        )
+
+        monkeypatch.setenv("WORDPRESS_BASE_URL", "example.com")
+        monkeypatch.setenv("WORDPRESS_USERNAME", "alice")
+        monkeypatch.setenv("WORDPRESS_APP_PASSWORD", "secret")
+
+        monkeypatch.setattr(
+            "plugins.wordpress.client.WordPressClient.list_posts",
+            MagicMock(return_value=[{"id": 1}]),
+        )
+        monkeypatch.setattr(
+            "plugins.wordpress.client.WordPressClient.get_post",
+            MagicMock(return_value={"id": 2}),
+        )
+        monkeypatch.setattr(
+            "plugins.wordpress.client.WordPressClient.create_post",
+            MagicMock(return_value={"id": 3}),
+        )
+        monkeypatch.setattr(
+            "plugins.wordpress.client.WordPressClient.update_post",
+            MagicMock(return_value={"id": 4}),
+        )
+
+        assert '"id": 1' in handle_wp_post_list({"status": "draft"})
+        assert '"id": 2' in handle_wp_post_get({"post_id": 2})
+        assert '"id": 3' in handle_wp_post_create({"title": "Draft"})
+        assert '"id": 4' in handle_wp_post_update({"post_id": 4, "status": "draft"})


### PR DESCRIPTION
 ## Summary

  Adds a standalone WordPress plugin for Hermes built on the official WordPress REST API.

  This introduces the first publish-facing WordPress surface in Hermes, including:
  - `wp_site_info`
  - `wp_post_list`
  - `wp_post_get`
  - `wp_post_create`
  - `wp_post_update`

  It also adds the supporting plugin scaffold, env-based auth helpers, a lightweight REST client, and targeted test coverage for registration, auth, client behavior, and tool handlers.

  ## Why

  WordPress is a useful CMS target for Hermes because it exposes a clear, official API for editorial operations.

  With this plugin, Hermes can:
  - verify that a configured WordPress site is reachable
  - check API and authentication state
  - list and inspect existing posts
  - create new posts
  - update existing posts

  That establishes a usable editorial base for WordPress-backed workflows inside Hermes.

  ## What Changed

  Added a new standalone plugin at `plugins/wordpress/` with:
  - plugin manifest and tool registration
  - `WordPressCredentials` auth helper for env-backed configuration
  - `WordPressClient` for REST API requests and structured API error handling
  - `wp_site_info` for probing site connectivity, API root, and auth state
  - `wp_post_list` for listing posts
  - `wp_post_get` for fetching a post by id
  - `wp_post_create` for creating a post
  - `wp_post_update` for updating an existing post

  Also added targeted tests covering:
  - manifest and registration expectations
  - auth header construction and requirements gating
  - client request construction and API error handling
  - handler validation and result/error behavior
  
 ## Validation

  Ran:
  - `pytest -q -o addopts='' tests/plugins/test_wordpress_plugin.py` (`22 passed`)
  - `python3 -m compileall plugins/wordpress tests/plugins/test_wordpress_plugin.py`

  Added integration-style coverage for site probe, post list, get, create, and update by exercising the full client/tool path over a real HTTP layer with a controlled test server.

  ## Follow-Up Work

  Natural follow-ups after this foundation:
  - media upload and featured image support
  - taxonomy list / resolve support
  - scheduling and editorial audit surfaces

