### PR TITLE
Fix TUI prompt and picker width alignment

### DIFF
--- a/ui-tui/src/components/appOverlays.tsx
+++ b/ui-tui/src/components/appOverlays.tsx
@@ -29,7 +29,7 @@ export function PromptZone({
   if (overlay.approval) {
     return (
       <Box flexDirection="column" flexShrink={0} paddingX={1} paddingY={1}>
-        <ApprovalPrompt onChoice={onApprovalChoice} req={overlay.approval} t={theme} />
+        <ApprovalPrompt cols={cols} onChoice={onApprovalChoice} req={overlay.approval} t={theme} />
       </Box>
     )
   }
@@ -46,7 +46,7 @@ export function PromptZone({
 
     return (
       <Box flexDirection="column" flexShrink={0} paddingX={1} paddingY={1}>
-        <ConfirmPrompt onCancel={onCancel} onConfirm={onConfirm} req={req} t={theme} />
+        <ConfirmPrompt cols={cols} onCancel={onCancel} onConfirm={onConfirm} req={req} t={theme} />
       </Box>
     )
   }
@@ -122,6 +122,7 @@ export function FloatingOverlays({
       {overlay.picker && (
         <FloatBox color={theme.color.border}>
           <SessionPicker
+            cols={cols}
             gw={gw}
             onCancel={() => patchOverlayState({ picker: false })}
             onSelect={onPickerSelect}
@@ -133,6 +134,7 @@ export function FloatingOverlays({
       {overlay.modelPicker && (
         <FloatBox color={theme.color.border}>
           <ModelPicker
+            cols={cols}
             gw={gw}
             onCancel={() => patchOverlayState({ modelPicker: false })}
             onSelect={onModelSelect}
@@ -144,7 +146,7 @@ export function FloatingOverlays({
 
       {overlay.skillsHub && (
         <FloatBox color={theme.color.border}>
-          <SkillsHub gw={gw} onClose={() => patchOverlayState({ skillsHub: false })} t={theme} />
+          <SkillsHub cols={cols} gw={gw} onClose={() => patchOverlayState({ skillsHub: false })} t={theme} />
         </FloatBox>
       )}
 

--- a/ui-tui/src/components/modelPicker.tsx
+++ b/ui-tui/src/components/modelPicker.tsx
@@ -1,4 +1,4 @@
-import { Box, Text, useInput, useStdout } from '@hermes/ink'
+import { Box, Text, useInput } from '@hermes/ink'
 import { useEffect, useMemo, useState } from 'react'
 
 import { providerDisplayNames } from '../domain/providers.js'
@@ -8,15 +8,14 @@ import type { ModelOptionProvider, ModelOptionsResponse } from '../gatewayTypes.
 import { asRpcResult, rpcErrorMessage } from '../lib/rpc.js'
 import type { Theme } from '../theme.js'
 
-import { OverlayHint, useOverlayKeys, windowItems } from './overlayControls.js'
+import { OverlayHint, overlayPanelWidth, useOverlayKeys, windowItems } from './overlayControls.js'
 
 const VISIBLE = 12
-const MIN_WIDTH = 40
 const MAX_WIDTH = 90
 
 type Stage = 'provider' | 'key' | 'model' | 'disconnect'
 
-export function ModelPicker({ gw, onCancel, onSelect, sessionId, t }: ModelPickerProps) {
+export function ModelPicker({ cols, gw, onCancel, onSelect, sessionId, t }: ModelPickerProps) {
   const [providers, setProviders] = useState<ModelOptionProvider[]>([])
   const [currentModel, setCurrentModel] = useState('')
   const [err, setErr] = useState('')
@@ -29,12 +28,9 @@ export function ModelPicker({ gw, onCancel, onSelect, sessionId, t }: ModelPicke
   const [keySaving, setKeySaving] = useState(false)
   const [keyError, setKeyError] = useState('')
 
-  const { stdout } = useStdout()
-  // Pin the picker to a stable width so the FloatBox parent (which shrinks-
-  // to-fit with alignSelf="flex-start") doesn't resize as long provider /
-  // model names scroll into view, and so `wrap="truncate-end"` on each row
-  // has an actual constraint to truncate against.
-  const width = Math.max(MIN_WIDTH, Math.min(MAX_WIDTH, (stdout?.columns ?? 80) - 6))
+  // Pin the picker to the composer width so the FloatBox chrome and its
+  // right border stay aligned with the actual overlay lane, not the full TTY.
+  const width = overlayPanelWidth(cols, MAX_WIDTH)
 
   useEffect(() => {
     gw.request<ModelOptionsResponse>('model.options', sessionId ? { session_id: sessionId } : {})
@@ -366,6 +362,7 @@ export function ModelPicker({ gw, onCancel, onSelect, sessionId, t }: ModelPicke
       (p, i) => {
         const authMark = p.authenticated === false ? '○' : p.is_current ? '*' : '●'
         const modelCount = p.total_models ?? p.models?.length ?? 0
+
         const suffix = p.authenticated === false
           ? (p.auth_type === 'api_key' ? '(no key)' : '(needs setup)')
           : `${modelCount} models`
@@ -498,6 +495,7 @@ export function ModelPicker({ gw, onCancel, onSelect, sessionId, t }: ModelPicke
 }
 
 interface ModelPickerProps {
+  cols: number
   gw: GatewayClient
   onCancel: () => void
   onSelect: (value: string) => void

--- a/ui-tui/src/components/overlayControls.tsx
+++ b/ui-tui/src/components/overlayControls.tsx
@@ -38,6 +38,9 @@ export function windowItems<T>(items: T[], selected: number, visible: number) {
   }
 }
 
+export const overlayPanelWidth = (availableCols: number, max: number) =>
+  Math.max(1, Math.min(max, Math.max(1, availableCols - 6)))
+
 interface OverlayHintProps {
   children: string
   t: Theme

--- a/ui-tui/src/components/prompts.tsx
+++ b/ui-tui/src/components/prompts.tsx
@@ -10,6 +10,7 @@ import { TextInput } from './textInput.js'
 const OPTS = ['once', 'session', 'always', 'deny'] as const
 const LABELS = { always: 'Always allow', deny: 'Deny', once: 'Allow once', session: 'Allow this session' } as const
 const CMD_PREVIEW_LINES = 10
+const promptPanelWidth = (cols: number) => Math.max(1, cols - 2)
 
 type ApprovalKey = {
   downArrow?: boolean
@@ -60,8 +61,9 @@ export function approvalAction(ch: string, key: ApprovalKey, sel: number): Appro
   return { kind: 'noop' }
 }
 
-export function ApprovalPrompt({ onChoice, req, t }: ApprovalPromptProps) {
+export function ApprovalPrompt({ cols = 80, onChoice, req, t }: ApprovalPromptProps) {
   const [sel, setSel] = useState(0)
+  const width = promptPanelWidth(cols)
 
   useInput((ch, key) => {
     const action = approvalAction(ch, key, sel)
@@ -78,9 +80,9 @@ export function ApprovalPrompt({ onChoice, req, t }: ApprovalPromptProps) {
   const overflow = rawLines.length - shown.length
 
   return (
-    <Box borderColor={t.color.warn} borderStyle="double" flexDirection="column" paddingX={1}>
-      <Text bold color={t.color.warn}>
-        ⚠ approval required · {req.description}
+    <Box borderColor={t.color.warn} borderStyle="double" flexDirection="column" paddingX={1} width={width}>
+      <Text bold color={t.color.warn} wrap="truncate-end">
+        !  approval required · {req.description}
       </Text>
 
       <Box flexDirection="column" paddingLeft={1}>
@@ -100,15 +102,21 @@ export function ApprovalPrompt({ onChoice, req, t }: ApprovalPromptProps) {
       <Text />
 
       {OPTS.map((o, i) => (
-        <Text key={o}>
-          <Text bold={sel === i} color={sel === i ? t.color.warn : t.color.muted} inverse={sel === i}>
-            {sel === i ? '▸ ' : '  '}
-            {i + 1}. {LABELS[o]}
-          </Text>
+        <Text
+          bold={sel === i}
+          color={sel === i ? t.color.warn : t.color.muted}
+          inverse={sel === i}
+          key={o}
+          wrap="wrap"
+        >
+          {sel === i ? '▸ ' : '  '}
+          {i + 1}. {LABELS[o]}
         </Text>
       ))}
 
-      <Text color={t.color.muted}>↑/↓ select · Enter confirm · 1-4 quick pick · Esc/Ctrl+C deny</Text>
+      <Text color={t.color.muted} wrap="truncate-end">
+        ↑/↓ select · Enter confirm · 1-4 quick pick · Esc/Ctrl+C deny
+      </Text>
     </Box>
   )
 }
@@ -118,9 +126,11 @@ export function ClarifyPrompt({ cols = 80, onAnswer, onCancel, req, t }: Clarify
   const [custom, setCustom] = useState('')
   const [typing, setTyping] = useState(false)
   const choices = req.choices ?? []
+  const width = promptPanelWidth(cols)
+  const contentWidth = Math.max(1, width - 2)
 
   const heading = (
-    <Text bold>
+    <Text bold wrap="truncate-end">
       <Text color={t.color.accent}>ask</Text>
       <Text color={t.color.text}> {req.question}</Text>
     </Text>
@@ -158,7 +168,7 @@ export function ClarifyPrompt({ cols = 80, onAnswer, onCancel, req, t }: Clarify
 
   if (typing || !choices.length) {
     return (
-      <Box flexDirection="column">
+      <Box flexDirection="column" width={width}>
         {heading}
 
         <Box>
@@ -166,7 +176,7 @@ export function ClarifyPrompt({ cols = 80, onAnswer, onCancel, req, t }: Clarify
           <TextInput columns={Math.max(20, cols - 6)} onChange={setCustom} onSubmit={onAnswer} value={custom} />
         </Box>
 
-        <Text color={t.color.muted}>
+        <Text color={t.color.muted} wrap="truncate-end">
           Enter send · Esc {choices.length ? 'back' : 'cancel'} ·{' '}
           {isMac ? 'Cmd+C copy · Cmd+V paste · Ctrl+C cancel' : 'Ctrl+C cancel'}
         </Text>
@@ -175,25 +185,44 @@ export function ClarifyPrompt({ cols = 80, onAnswer, onCancel, req, t }: Clarify
   }
 
   return (
-    <Box flexDirection="column">
+    <Box flexDirection="column" width={width}>
       {heading}
 
-      {[...choices, 'Other (type your answer)'].map((c, i) => (
-        <Text key={i}>
-          <Text bold={sel === i} color={sel === i ? t.color.label : t.color.muted} inverse={sel === i}>
-            {sel === i ? '▸ ' : '  '}
-            {i + 1}. {c}
-          </Text>
-        </Text>
-      ))}
+      {[...choices, 'Other (type your answer)'].map((c, i) => {
+        const prefix = `${sel === i ? '▸ ' : '  '}${i + 1}. `
 
-      <Text color={t.color.muted}>↑/↓ select · Enter confirm · 1-{choices.length} quick pick · Esc/Ctrl+C cancel</Text>
+        return (
+          <Box key={i}>
+            <Box width={prefix.length}>
+              <Text bold={sel === i} color={sel === i ? t.color.label : t.color.muted} inverse={sel === i}>
+                {prefix}
+              </Text>
+            </Box>
+            <Box width={Math.max(1, contentWidth - prefix.length)}>
+              <Text
+                bold={sel === i}
+                color={sel === i ? t.color.label : t.color.muted}
+                inverse={sel === i}
+                wrap="wrap-trim"
+              >
+                {c}
+              </Text>
+            </Box>
+          </Box>
+        )
+      })}
+
+      <Text color={t.color.muted} wrap="truncate-end">
+        ↑/↓ select · Enter confirm · 1-{choices.length} quick pick · Esc/Ctrl+C cancel
+      </Text>
     </Box>
   )
 }
 
-export function ConfirmPrompt({ onCancel, onConfirm, req, t }: ConfirmPromptProps) {
+export function ConfirmPrompt({ cols = 80, onCancel, onConfirm, req, t }: ConfirmPromptProps) {
   const [sel, setSel] = useState(0)
+  const width = promptPanelWidth(cols)
+  const contentWidth = Math.max(1, width - 4)
 
   useInput((ch, key) => {
     const lower = ch.toLowerCase()
@@ -227,14 +256,14 @@ export function ConfirmPrompt({ onCancel, onConfirm, req, t }: ConfirmPromptProp
   ]
 
   return (
-    <Box borderColor={accent} borderStyle="double" flexDirection="column" paddingX={1}>
-      <Text bold color={accent}>
-        {req.danger ? '⚠' : '?'} {req.title}
+    <Box borderColor={accent} borderStyle="double" flexDirection="column" paddingX={1} width={width}>
+      <Text bold color={accent} wrap="truncate-end">
+        {req.danger ? '!' : '?'}  {req.title}
       </Text>
 
       {req.detail ? (
         <Box paddingLeft={1}>
-          <Text color={t.color.text} wrap="truncate-end">
+          <Text color={t.color.text} wrap="wrap">
             {req.detail}
           </Text>
         </Box>
@@ -243,18 +272,27 @@ export function ConfirmPrompt({ onCancel, onConfirm, req, t }: ConfirmPromptProp
       <Text />
 
       {rows.map((row, i) => (
-        <Text key={row.label}>
-          <Text color={sel === i ? accent : t.color.muted}>{sel === i ? '▸ ' : '  '}</Text>
-          <Text color={sel === i ? row.color : t.color.muted}>{row.label}</Text>
-        </Text>
+        <Box key={row.label}>
+          <Box width={2}>
+            <Text color={sel === i ? accent : t.color.muted}>{sel === i ? '▸ ' : '  '}</Text>
+          </Box>
+          <Box width={Math.max(1, contentWidth - 2)}>
+            <Text color={sel === i ? row.color : t.color.muted} wrap="wrap-trim">
+              {row.label}
+            </Text>
+          </Box>
+        </Box>
       ))}
 
-      <Text color={t.color.muted}>↑/↓ select · Enter confirm · Y/N quick · Esc cancel</Text>
+      <Text color={t.color.muted} wrap="truncate-end">
+        ↑/↓ select · Enter confirm · Y/N quick · Esc cancel
+      </Text>
     </Box>
   )
 }
 
 interface ApprovalPromptProps {
+  cols?: number
   onChoice: (s: string) => void
   req: ApprovalReq
   t: Theme
@@ -269,6 +307,7 @@ interface ClarifyPromptProps {
 }
 
 interface ConfirmPromptProps {
+  cols?: number
   onCancel: () => void
   onConfirm: () => void
   req: ConfirmReq

--- a/ui-tui/src/components/sessionPicker.tsx
+++ b/ui-tui/src/components/sessionPicker.tsx
@@ -1,4 +1,4 @@
-import { Box, Text, useInput, useStdout } from '@hermes/ink'
+import { Box, Text, useInput } from '@hermes/ink'
 import { useEffect, useState } from 'react'
 
 import type { GatewayClient } from '../gatewayClient.js'
@@ -6,10 +6,9 @@ import type { SessionDeleteResponse, SessionListItem, SessionListResponse } from
 import { asRpcResult, rpcErrorMessage } from '../lib/rpc.js'
 import type { Theme } from '../theme.js'
 
-import { OverlayHint, useOverlayKeys, windowOffset } from './overlayControls.js'
+import { OverlayHint, overlayPanelWidth, useOverlayKeys, windowOffset } from './overlayControls.js'
 
 const VISIBLE = 15
-const MIN_WIDTH = 60
 const MAX_WIDTH = 120
 
 const age = (ts: number) => {
@@ -26,7 +25,7 @@ const age = (ts: number) => {
   return `${Math.floor(d)}d ago`
 }
 
-export function SessionPicker({ gw, onCancel, onSelect, t }: SessionPickerProps) {
+export function SessionPicker({ cols, gw, onCancel, onSelect, t }: SessionPickerProps) {
   const [items, setItems] = useState<SessionListItem[]>([])
   const [err, setErr] = useState('')
   const [sel, setSel] = useState(0)
@@ -36,8 +35,7 @@ export function SessionPicker({ gw, onCancel, onSelect, t }: SessionPickerProps)
   const [confirmDelete, setConfirmDelete] = useState<null | number>(null)
   const [deleting, setDeleting] = useState(false)
 
-  const { stdout } = useStdout()
-  const width = Math.max(MIN_WIDTH, Math.min(MAX_WIDTH, (stdout?.columns ?? 80) - 6))
+  const width = overlayPanelWidth(cols, MAX_WIDTH)
 
   useOverlayKeys({ onClose: onCancel })
 
@@ -220,6 +218,7 @@ export function SessionPicker({ gw, onCancel, onSelect, t }: SessionPickerProps)
 }
 
 interface SessionPickerProps {
+  cols: number
   gw: GatewayClient
   onCancel: () => void
   onSelect: (id: string) => void

--- a/ui-tui/src/components/skillsHub.tsx
+++ b/ui-tui/src/components/skillsHub.tsx
@@ -1,17 +1,16 @@
-import { Box, Text, useInput, useStdout } from '@hermes/ink'
+import { Box, Text, useInput } from '@hermes/ink'
 import { useEffect, useState } from 'react'
 
 import type { GatewayClient } from '../gatewayClient.js'
 import { rpcErrorMessage } from '../lib/rpc.js'
 import type { Theme } from '../theme.js'
 
-import { OverlayHint, useOverlayKeys, windowItems, windowOffset } from './overlayControls.js'
+import { OverlayHint, overlayPanelWidth, useOverlayKeys, windowItems, windowOffset } from './overlayControls.js'
 
 const VISIBLE = 12
-const MIN_WIDTH = 40
 const MAX_WIDTH = 90
 
-export function SkillsHub({ gw, onClose, t }: SkillsHubProps) {
+export function SkillsHub({ cols, gw, onClose, t }: SkillsHubProps) {
   const [skillsByCat, setSkillsByCat] = useState<Record<string, string[]>>({})
   const [selectedCat, setSelectedCat] = useState('')
   const [catIdx, setCatIdx] = useState(0)
@@ -22,8 +21,7 @@ export function SkillsHub({ gw, onClose, t }: SkillsHubProps) {
   const [err, setErr] = useState('')
   const [loading, setLoading] = useState(true)
 
-  const { stdout } = useStdout()
-  const width = Math.max(MIN_WIDTH, Math.min(MAX_WIDTH, (stdout?.columns ?? 80) - 6))
+  const width = overlayPanelWidth(cols, MAX_WIDTH)
 
   useEffect(() => {
     gw.request<{ skills?: Record<string, string[]> }>('skills.manage', { action: 'list' })
@@ -302,6 +300,7 @@ interface SkillInfo {
 }
 
 interface SkillsHubProps {
+  cols: number
   gw: GatewayClient
   onClose: () => void
   t: Theme


### PR DESCRIPTION
## Summary

Fix TUI prompt and picker alignment when prompt text or option labels have mixed lengths.

- Pin approval, confirm, and clarify prompt panels to the composer width.
- Wrap long clarify/confirm option text with stable hanging indentation.
- Use fixed-width ASCII prompt title prefixes to avoid ambiguous terminal glyph widths shifting the right border.
- Pin floating pickers to the composer width instead of the full stdout column count.

## Root Cause

Several TUI overlays sized themselves from content or full terminal width instead of the composer lane. Long/short option text and ambiguous-width title glyphs could make the visible prompt border or row content appear misaligned.

## Validation

- `npx eslint src/components/prompts.tsx src/components/appOverlays.tsx src/components/overlayControls.tsx src/components/modelPicker.tsx src/components/sessionPicker.tsx src/components/skillsHub.tsx`
- Render smoke check with a fixed 50-column prompt lane and mixed-length prompt content:
  - approval prompt with a short title and a long command preview; the double border stayed at 48 display columns on every rendered row.
  - confirm prompt with Chinese title text, a long detail string, and a long confirm label; detail and label wrapped inside the border with stable hanging indentation, and every border row stayed 48 display columns wide.
  - clarify prompt with short, medium, and long Chinese option labels; long option text wrapped under the option body instead of shifting the prefix column or widening the panel.
- Manually checked that using ASCII title prefixes avoids ambiguous-width warning glyph drift in terminals that render `⚠` differently.

Note: `npm run type-check` is currently blocked by existing Node type errors in `packages/hermes-ink/src/utils/execFileNoThrow.ts`, unrelated to this change.