### PR TITLE
fix: open dashboard browser in WSL via explorer.exe

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -7052,10 +7052,19 @@ def start_server(
         )
 
         if _has_display:
+            from hermes_constants import is_wsl
             def _open():
                 try:
                     time.sleep(1.0)
-                    webbrowser.open(f"http://{host}:{port}")
+                    if is_wsl():
+                        import subprocess
+                        subprocess.Popen(
+                            ["explorer.exe", f"http://{host}:{port}"],
+                            stdout=subprocess.DEVNULL,
+                            stderr=subprocess.DEVNULL,
+                        )
+                    else:
+                        webbrowser.open(f"http://{host}:{port}")
                 except Exception:
                     pass
 


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->

On WSL, webbrowser.open() resolves to gio, which fails with "Operation not supported" when launching the dashboard web UI. The browser auto-open is silently skipped, leaving the user to manually open the URL. This PR adds WSL detection via is_wsl() inside the browser-open path and delegates to explorer.exe to launch the Windows default browser instead.

## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- hermes_cli/web_server.py — moved is_wsl() check into the browser-open logic inside launch_dashboard_server(). When WSL is detected, uses subprocess.Popen(["explorer.exe", url]) instead of webbrowser.open().

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. Run hermes dashboard inside WSL2 (with WSLg)
2. Verify the browser opens automatically pointing to http://127.0.0.1:9119
3. Confirm no "gio: Operation not supported" error appears

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: WSL Ubuntu 24.04 on Windows 11

