### PR TITLE
fix: use time.monotonic() for duration, guard json.loads(), remove library basicConfig()

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -172,7 +172,7 @@ def interruptible_api_call(agent, api_kwargs: dict):
         api_kwargs.get("messages", [])
     )
 
-    _call_start = time.time()
+    _call_start = time.monotonic()
     agent._touch_activity("waiting for non-streaming API response")
 
     t = threading.Thread(target=_call, daemon=True)
@@ -185,14 +185,14 @@ def interruptible_api_call(agent, api_kwargs: dict):
         # Touch activity every ~30s so the gateway's inactivity
         # monitor knows we're alive while waiting for the response.
         if _poll_count % 100 == 0:  # 100 × 0.3s = 30s
-            _elapsed = time.time() - _call_start
+            _elapsed = time.monotonic() - _call_start
             agent._touch_activity(
                 f"waiting for non-streaming response ({int(_elapsed)}s elapsed)"
             )
 
         # Stale-call detector: kill the connection if no response
         # arrives within the configured timeout.
-        _elapsed = time.time() - _call_start
+        _elapsed = time.monotonic() - _call_start
         if _elapsed > _stale_timeout:
             _est_ctx = sum(len(str(v)) for v in api_kwargs.get("messages", [])) // 4
             logger.warning(
@@ -1295,7 +1295,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
     # Wall-clock timestamp of the last real streaming chunk.  The outer
     # poll loop uses this to detect stale connections that keep receiving
     # SSE keep-alive pings but no actual data.
-    last_chunk_time = {"t": time.time()}
+    last_chunk_time = {"t": time.monotonic()}
 
     def _fire_first_delta():
         if not first_delta_fired["done"] and on_first_delta:
@@ -1354,7 +1354,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
         )
         # Reset stale-stream timer so the detector measures from this
         # attempt's start, not a previous attempt's last chunk.
-        last_chunk_time["t"] = time.time()
+        last_chunk_time["t"] = time.monotonic()
         agent._touch_activity("waiting for provider response (streaming)")
         # Initialize per-attempt stream diagnostics so the retry block can
         # reach for them after the stream dies.  Lives on
@@ -1390,7 +1390,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
         reasoning_parts: list = []
         usage_obj = None
         for chunk in stream:
-            last_chunk_time["t"] = time.time()
+            last_chunk_time["t"] = time.monotonic()
             agent._touch_activity("receiving stream response")
 
             # Update per-attempt diagnostic counters.  Best-effort —
@@ -1603,7 +1603,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
         has_tool_use = False
 
         # Reset stale-stream timer for this attempt
-        last_chunk_time["t"] = time.time()
+        last_chunk_time["t"] = time.monotonic()
         # Per-attempt diagnostic dict for the retry block to consume.
         _diag = agent._stream_diag_init()
         request_client_holder["diag"] = _diag
@@ -1626,7 +1626,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                 # Opus streams after 180 s even when events are
                 # actively arriving (the chat_completions path
                 # already does this at the top of its chunk loop).
-                last_chunk_time["t"] = time.time()
+                last_chunk_time["t"] = time.monotonic()
                 agent._touch_activity("receiving stream response")
 
                 # Update per-attempt diagnostic counters (best-effort).
@@ -1949,7 +1949,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
 
     t = threading.Thread(target=_call, daemon=True)
     t.start()
-    _last_heartbeat = time.time()
+    _last_heartbeat = time.monotonic()
     _HEARTBEAT_INTERVAL = 30.0  # seconds between gateway activity touches
     while t.is_alive():
         t.join(timeout=0.3)
@@ -1962,7 +1962,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
         # activity on each chunk, but the gap between API call start
         # and first chunk can exceed the gateway timeout — especially
         # when the stale-stream timeout is disabled (local providers).
-        _hb_now = time.time()
+        _hb_now = time.monotonic()
         if _hb_now - _last_heartbeat >= _HEARTBEAT_INTERVAL:
             _last_heartbeat = _hb_now
             _waiting_secs = int(_hb_now - last_chunk_time["t"])
@@ -1973,7 +1973,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
         # Detect stale streams: connections kept alive by SSE pings
         # but delivering no real chunks.  Kill the client so the
         # inner retry loop can start a fresh connection.
-        _stale_elapsed = time.time() - last_chunk_time["t"]
+        _stale_elapsed = time.monotonic() - last_chunk_time["t"]
         if _stale_elapsed > _stream_stale_timeout:
             _est_ctx = sum(len(str(v)) for v in api_kwargs.get("messages", [])) // 4
             logger.warning(
@@ -2000,7 +2000,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                 pass
             # Reset the timer so we don't kill repeatedly while
             # the inner thread processes the closure.
-            last_chunk_time["t"] = time.time()
+            last_chunk_time["t"] = time.monotonic()
             agent._touch_activity(
                 f"stale stream detected after {int(_stale_elapsed)}s, reconnecting"
             )

--- a/agent/context_references.py
+++ b/agent/context_references.py
@@ -318,7 +318,10 @@ async def _default_url_fetcher(url: str) -> str:
     from tools.web_tools import web_extract_tool
 
     raw = await web_extract_tool([url], format="markdown", use_llm_processing=True)
-    payload = json.loads(raw)
+    try:
+        payload = json.loads(raw)
+    except (json.JSONDecodeError, TypeError):
+        return ""
     docs = payload.get("data", {}).get("documents", [])
     if not docs:
         return ""

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -978,7 +978,7 @@ def run_conversation(
             logging.debug(f"Last message role: {messages[-1]['role'] if messages else 'none'}")
             logging.debug(f"Total message size: ~{approx_tokens:,} tokens")
         
-        api_start_time = time.time()
+        api_start_time = time.monotonic()
         retry_count = 0
         max_retries = agent._api_max_retries
         primary_recovery_attempted = False
@@ -1144,7 +1144,7 @@ def run_conversation(
                 else:
                     response = agent._interruptible_api_call(api_kwargs)
                 
-                api_duration = time.time() - api_start_time
+                api_duration = time.monotonic() - api_start_time
                 
                 # Stop thinking spinner silently -- the response box or tool
                 # execution messages that follow are more informative.
@@ -1351,9 +1351,9 @@ def run_conversation(
                     logging.warning(f"Invalid API response (retry {retry_count}/{max_retries}): {', '.join(error_details)} | Provider: {provider_name}")
                     
                     # Sleep in small increments to stay responsive to interrupts
-                    sleep_end = time.time() + wait_time
+                    sleep_end = time.monotonic() + wait_time
                     _backoff_touch_counter = 0
-                    while time.time() < sleep_end:
+                    while time.monotonic() < sleep_end:
                         if agent._interrupt_requested:
                             agent._vprint(f"{agent.log_prefix}⚡ Interrupt detected during retry wait, aborting.", force=True)
                             agent._persist_session(messages, conversation_history)
@@ -1372,7 +1372,7 @@ def run_conversation(
                         if _backoff_touch_counter % 150 == 0:  # 150 × 0.2s = 30s
                             agent._touch_activity(
                                 f"retry backoff ({retry_count}/{max_retries}), "
-                                f"{int(sleep_end - time.time())}s remaining"
+                                f"{int(sleep_end - time.monotonic())}s remaining"
                             )
                     continue  # Retry the API call
 
@@ -1742,7 +1742,7 @@ def run_conversation(
                     thinking_spinner = None
                 if agent.thinking_callback:
                     agent.thinking_callback("")
-                api_elapsed = time.time() - api_start_time
+                api_elapsed = time.monotonic() - api_start_time
                 agent._vprint(f"{agent.log_prefix}⚡ Interrupted during API call.", force=True)
                 agent._persist_session(messages, conversation_history)
                 interrupted = True
@@ -2276,7 +2276,7 @@ def run_conversation(
                     )
 
                 retry_count += 1
-                elapsed_time = time.time() - api_start_time
+                elapsed_time = time.monotonic() - api_start_time
                 agent._touch_activity(
                     f"API error recovery (attempt {retry_count}/{max_retries})"
                 )
@@ -2958,9 +2958,9 @@ def run_conversation(
                 )
                 # Sleep in small increments so we can respond to interrupts quickly
                 # instead of blocking the entire wait_time in one sleep() call
-                sleep_end = time.time() + wait_time
+                sleep_end = time.monotonic() + wait_time
                 _backoff_touch_counter = 0
-                while time.time() < sleep_end:
+                while time.monotonic() < sleep_end:
                     if agent._interrupt_requested:
                         agent._vprint(f"{agent.log_prefix}⚡ Interrupt detected during retry wait, aborting.", force=True)
                         agent._persist_session(messages, conversation_history)
@@ -2979,7 +2979,7 @@ def run_conversation(
                     if _backoff_touch_counter % 150 == 0:  # 150 × 0.2s = 30s
                         agent._touch_activity(
                             f"error retry backoff ({retry_count}/{max_retries}), "
-                            f"{int(sleep_end - time.time())}s remaining"
+                            f"{int(sleep_end - time.monotonic())}s remaining"
                         )
         
         # If the API call was interrupted, skip response processing

--- a/agent/display.py
+++ b/agent/display.py
@@ -715,7 +715,7 @@ class KawaiiSpinner:
                 time.sleep(0.1)
                 continue
             frame = self.spinner_frames[self.frame_idx % len(self.spinner_frames)]
-            elapsed = time.time() - self.start_time
+            elapsed = time.monotonic() - self.start_time
             if wings:
                 left, right = wings[self.frame_idx % len(wings)]
                 line = f"  {left} {frame} {self.message} {right} ({elapsed:.1f}s)"
@@ -731,7 +731,7 @@ class KawaiiSpinner:
         if self.running:
             return
         self.running = True
-        self.start_time = time.time()
+        self.start_time = time.monotonic()
         self.thread = threading.Thread(target=self._animate, daemon=True)
         self.thread.start()
 
@@ -768,7 +768,7 @@ class KawaiiSpinner:
             blanks = ' ' * max(self.last_line_len + 5, 40)
             self._write(f"\r{blanks}\r", end='', flush=True)
         if final_message:
-            elapsed = f" ({time.time() - self.start_time:.1f}s)" if self.start_time else ""
+            elapsed = f" ({time.monotonic() - self.start_time:.1f}s)" if self.start_time else ""
             if is_tty:
                 self._write(f"  {final_message}", flush=True)
             else:

--- a/agent/google_oauth.py
+++ b/agent/google_oauth.py
@@ -571,6 +571,11 @@ def _post_form(url: str, data: Dict[str, str], timeout: float) -> Dict[str, Any]
             f"Google OAuth token request failed: {exc}",
             code="google_oauth_token_network_error",
         ) from exc
+    except json.JSONDecodeError as exc:
+        raise GoogleOAuthError(
+            f"Google OAuth token endpoint returned non-JSON response",
+            code="google_oauth_token_parse_error",
+        ) from exc
 
 
 def exchange_code(

--- a/agent/rate_limit_tracker.py
+++ b/agent/rate_limit_tracker.py
@@ -34,7 +34,7 @@ class RateLimitBucket:
     limit: int = 0
     remaining: int = 0
     reset_seconds: float = 0.0
-    captured_at: float = 0.0  # time.time() when this was captured
+    captured_at: float = 0.0  # time.monotonic() when this was captured
 
     @property
     def used(self) -> int:
@@ -49,7 +49,7 @@ class RateLimitBucket:
     @property
     def remaining_seconds_now(self) -> float:
         """Estimated seconds remaining until reset, adjusted for elapsed time."""
-        elapsed = time.time() - self.captured_at
+        elapsed = time.monotonic() - self.captured_at
         return max(0.0, self.reset_seconds - elapsed)
 
 
@@ -72,7 +72,7 @@ class RateLimitState:
     def age_seconds(self) -> float:
         if not self.has_data:
             return float("inf")
-        return time.time() - self.captured_at
+        return time.monotonic() - self.captured_at
 
 
 def _safe_int(value: Any, default: int = 0) -> int:
@@ -106,7 +106,7 @@ def parse_rate_limit_headers(
     if not has_any:
         return None
 
-    now = time.time()
+    now = time.monotonic()
 
     def _bucket(resource: str, suffix: str = "") -> RateLimitBucket:
         # e.g. resource="requests", suffix="" -> per-minute

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -232,7 +232,7 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
                 _set_sudo_password_callback(_parent_sudo_cb)
             except Exception:
                 pass
-        start = time.time()
+        start = time.monotonic()
         try:
             result = agent._invoke_tool(
                 function_name,
@@ -245,7 +245,7 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
         except Exception as tool_error:
             result = f"Error executing tool '{function_name}': {tool_error}"
             logger.error("_invoke_tool raised for %s: %s", function_name, tool_error, exc_info=True)
-        duration = time.time() - start
+        duration = time.monotonic() - start
         is_error, _ = _detect_tool_failure(function_name, result)
         if is_error:
             logger.info("tool %s failed (%.2fs): %s", function_name, duration, result[:200])
@@ -297,7 +297,7 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
                 # concurrent tool batches. Also check for user interrupts
                 # so we don't block indefinitely when the user sends /stop
                 # or a new message during concurrent tool execution.
-                _conc_start = time.time()
+                _conc_start = time.monotonic()
                 _interrupt_logged = False
                 while True:
                     done, not_done = concurrent.futures.wait(
@@ -326,7 +326,7 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
                         concurrent.futures.wait(not_done, timeout=3.0)
                         break
 
-                    _conc_elapsed = int(time.time() - _conc_start)
+                    _conc_elapsed = int(time.monotonic() - _conc_start)
                     # Heartbeat every ~30s (6 × 5s poll intervals)
                     if _conc_elapsed > 0 and _conc_elapsed % 30 < 6:
                         _still_running = [
@@ -584,7 +584,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
             except Exception:
                 pass  # never block tool execution
 
-        tool_start_time = time.time()
+        tool_start_time = time.monotonic()
 
         if _block_msg is not None:
             # Tool blocked by plugin policy — return error without executing.
@@ -602,7 +602,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                 merge=function_args.get("merge", False),
                 store=agent._todo_store,
             )
-            tool_duration = time.time() - tool_start_time
+            tool_duration = time.monotonic() - tool_start_time
             if agent._should_emit_quiet_tool_messages():
                 agent._vprint(f"  {_get_cute_tool_message_impl('todo', function_args, tool_duration, result=function_result)}")
         elif function_name == "session_search":
@@ -623,7 +623,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                     db=session_db,
                     current_session_id=agent.session_id,
                 )
-            tool_duration = time.time() - tool_start_time
+            tool_duration = time.monotonic() - tool_start_time
             if agent._should_emit_quiet_tool_messages():
                 agent._vprint(f"  {_get_cute_tool_message_impl('session_search', function_args, tool_duration, result=function_result)}")
         elif function_name == "memory":
@@ -650,7 +650,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                     )
                 except Exception:
                     pass
-            tool_duration = time.time() - tool_start_time
+            tool_duration = time.monotonic() - tool_start_time
             if agent._should_emit_quiet_tool_messages():
                 agent._vprint(f"  {_get_cute_tool_message_impl('memory', function_args, tool_duration, result=function_result)}")
         elif function_name == "clarify":
@@ -660,7 +660,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                 choices=function_args.get("choices"),
                 callback=agent.clarify_callback,
             )
-            tool_duration = time.time() - tool_start_time
+            tool_duration = time.monotonic() - tool_start_time
             if agent._should_emit_quiet_tool_messages():
                 agent._vprint(f"  {_get_cute_tool_message_impl('clarify', function_args, tool_duration, result=function_result)}")
         elif function_name == "delegate_task":
@@ -682,7 +682,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                 _delegate_result = function_result
             finally:
                 agent._delegate_spinner = None
-                tool_duration = time.time() - tool_start_time
+                tool_duration = time.monotonic() - tool_start_time
                 cute_msg = _get_cute_tool_message_impl('delegate_task', function_args, tool_duration, result=_delegate_result)
                 if spinner:
                     spinner.stop(cute_msg)
@@ -705,7 +705,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                 function_result = json.dumps({"error": f"Context engine tool '{function_name}' failed: {tool_error}"})
                 logger.error("context_engine.handle_tool_call raised for %s: %s", function_name, tool_error, exc_info=True)
             finally:
-                tool_duration = time.time() - tool_start_time
+                tool_duration = time.monotonic() - tool_start_time
                 cute_msg = _get_cute_tool_message_impl(function_name, function_args, tool_duration, result=_ce_result)
                 if spinner:
                     spinner.stop(cute_msg)
@@ -729,7 +729,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                 function_result = json.dumps({"error": f"Memory tool '{function_name}' failed: {tool_error}"})
                 logger.error("memory_manager.handle_tool_call raised for %s: %s", function_name, tool_error, exc_info=True)
             finally:
-                tool_duration = time.time() - tool_start_time
+                tool_duration = time.monotonic() - tool_start_time
                 cute_msg = _get_cute_tool_message_impl(function_name, function_args, tool_duration, result=_mem_result)
                 if spinner:
                     spinner.stop(cute_msg)
@@ -757,7 +757,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                 function_result = f"Error executing tool '{function_name}': {tool_error}"
                 logger.error("handle_function_call raised for %s: %s", function_name, tool_error, exc_info=True)
             finally:
-                tool_duration = time.time() - tool_start_time
+                tool_duration = time.monotonic() - tool_start_time
                 cute_msg = _get_cute_tool_message_impl(function_name, function_args, tool_duration, result=_spinner_result)
                 if spinner:
                     spinner.stop(cute_msg)
@@ -775,7 +775,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
             except Exception as tool_error:
                 function_result = f"Error executing tool '{function_name}': {tool_error}"
                 logger.error("handle_function_call raised for %s: %s", function_name, tool_error, exc_info=True)
-            tool_duration = time.time() - tool_start_time
+            tool_duration = time.monotonic() - tool_start_time
 
         if isinstance(function_result, str):
             result_preview = function_result if agent.verbose_logging else (

--- a/mini_swe_runner.py
+++ b/mini_swe_runner.py
@@ -199,11 +199,6 @@ class MiniSWERunner:
         self.cwd = cwd
         
         # Setup logging
-        logging.basicConfig(
-            level=logging.DEBUG if verbose else logging.INFO,
-            format='%(asctime)s - %(levelname)s - %(message)s',
-            datefmt='%H:%M:%S'
-        )
         self.logger = logging.getLogger(__name__)
         
         # Initialize LLM client via centralized provider router.

--- a/tests/agent/test_rate_limit_tracker.py
+++ b/tests/agent/test_rate_limit_tracker.py
@@ -92,11 +92,11 @@ class TestParseHeaders:
 
 class TestBucket:
     def test_used(self):
-        b = RateLimitBucket(limit=800, remaining=795, reset_seconds=45.0, captured_at=time.time())
+        b = RateLimitBucket(limit=800, remaining=795, reset_seconds=45.0, captured_at=time.monotonic())
         assert b.used == 5
 
     def test_usage_pct(self):
-        b = RateLimitBucket(limit=100, remaining=20, reset_seconds=30.0, captured_at=time.time())
+        b = RateLimitBucket(limit=100, remaining=20, reset_seconds=30.0, captured_at=time.monotonic())
         assert b.usage_pct == pytest.approx(80.0)
 
     def test_usage_pct_zero_limit(self):
@@ -104,13 +104,13 @@ class TestBucket:
         assert b.usage_pct == 0.0
 
     def test_remaining_seconds_now(self):
-        now = time.time()
+        now = time.monotonic()
         b = RateLimitBucket(limit=800, remaining=795, reset_seconds=60.0, captured_at=now - 10)
         # ~50 seconds should remain
         assert 49 <= b.remaining_seconds_now <= 51
 
     def test_remaining_seconds_expired(self):
-        b = RateLimitBucket(limit=800, remaining=795, reset_seconds=30.0, captured_at=time.time() - 60)
+        b = RateLimitBucket(limit=800, remaining=795, reset_seconds=30.0, captured_at=time.monotonic() - 60)
         assert b.remaining_seconds_now == 0.0
 
 

--- a/trajectory_compressor.py
+++ b/trajectory_compressor.py
@@ -352,11 +352,6 @@ class TrajectoryCompressor:
         # Initialize OpenRouter client
         self._init_summarizer()
         
-        logging.basicConfig(
-            level=logging.INFO,
-            format='%(asctime)s - %(levelname)s - %(message)s',
-            datefmt='%H:%M:%S'
-        )
         self.logger = logging.getLogger(__name__)
     
     def _init_tokenizer(self):


### PR DESCRIPTION
## Summary

Three classes of bugs fixed across 10 files:

### 1. `logging.basicConfig()` in library `__init__` (2 files)
- **trajectory_compressor.py** and **mini_swe_runner.py** called `logging.basicConfig()` inside class `__init__`, hijacking the root logger config on every instantiation. Removed the calls, keeping only `getLogger(__name__)`. Entry points (`cli.py`, `gateway`) are responsible for root logger configuration.

### 2. `json.loads()` without `try/except` on network/file input (2 files)
- **agent/context_references.py**: `web_extract_tool` result parsed without catching `JSONDecodeError`. Added `try/except` returning empty string on non-JSON response.
- **agent/google_oauth.py**: token endpoint response parsed without catching `JSONDecodeError`. Added except clause raising `GoogleOAuthError` with descriptive code.

### 3. `time.time()` for duration measurements (5 core files, 43 locations)
- **agent/tool_executor.py** (14): tool execution timing
- **agent/conversation_loop.py** (10): API call duration, sleep/deadline loops
- **agent/chat_completion_helpers.py** (12): stale stream detection, heartbeat intervals
- **agent/display.py** (3): spinner elapsed display
- **agent/rate_limit_tracker.py** (4): elapsed since capture

`time.time()` is the wall clock — subject to NTP adjustments, leap seconds, or manual clock changes. `time.monotonic()` is the correct clock for elapsed time intervals. Wall-clock timestamps (DB records, message IDs, etc.) are intentionally left unchanged.

## Test Plan
- [x] All 493 related tests pass
- [x] Updated `rate_limit_tracker` tests to use `time.monotonic()`
- [x] `py_compile` passes on all 10 modified files
