### PR TITLE
fix(anthropic): guard credential-pool recovery check

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -82,6 +82,42 @@ def _ra():
     return run_agent
 
 
+def _pool_may_recover_from_rate_limit(pool, *, provider: str = "", base_url: Optional[str] = None) -> bool:
+    """Return True when credential-pool rotation may recover from a rate-limit/billing hit.
+
+    This is intentionally conservative: only suppress eager fallback when there is
+    at least one *other* credential in the pool that is not currently exhausted.
+    Single-credential pools cannot recover by rotation, so callers should continue
+    to the normal fallback path.
+    """
+    if pool is None or not getattr(pool, "has_credentials", lambda: False)():
+        return False
+
+    try:
+        from agent.credential_pool import STATUS_EXHAUSTED, _exhausted_until
+    except Exception:
+        return False
+
+    entries = list(getattr(pool, "entries", lambda: [])() or [])
+    if len(entries) <= 1:
+        return False
+
+    current = getattr(pool, "current", lambda: None)()
+    current_id = getattr(current, "id", None)
+    now = time.time()
+
+    for entry in entries:
+        if getattr(entry, "id", None) == current_id:
+            continue
+        if getattr(entry, "last_status", None) != STATUS_EXHAUSTED:
+            return True
+        exhausted_until = _exhausted_until(entry)
+        if exhausted_until is None or exhausted_until <= now:
+            return True
+
+    return False
+
+
 def run_conversation(
     agent,
     user_message: str,

--- a/docs/00_INDEX.md
+++ b/docs/00_INDEX.md
@@ -1,0 +1,42 @@
+# Docs Index
+
+> Discoverability surface for repo-safe planning and coordination docs.
+
+## Active planning docs
+
+- [Account Segmentation Map](plans/2026-05-17-account-segmentation-map.md)
+  - Purpose: split testing, business, and research access.
+  - State: ready.
+- [Telegram DM User-Managed Multi-Session Topics Implementation Plan](plans/2026-05-02-telegram-dm-user-managed-multisession-topics.md)
+  - Purpose: define Telegram topic lanes.
+  - State: plan only.
+
+## Coordination / review surfaces
+
+- [Account Segmentation Handoff](control/2026-05-17_account-segmentation_handoff.md)
+  - Purpose: **Handoff** for the account split.
+- [Account Segmentation QC Checklist](qc/2026-05-17_account_segmentation_qc.md)
+  - Purpose: **QC** for the account pack.
+- [Business Account Rollout Checklist](control/2026-05-17_business-account-rollout-checklist.md)
+  - Purpose: **Checklist** for business accounts.
+- [Account Registry Template](control/2026-05-17_account-registry-template.md)
+  - Purpose: **Template** for safe fields.
+- [Account Registry Draft](control/2026-05-17_account-registry-draft.md)
+  - Purpose: **Draft** for the first set.
+- [Browser Profile Map](control/2026-05-17_browser-profile-map.md)
+  - Purpose: **Profile map**.
+- [Recovery + MFA Setup Checklist](control/2026-05-17_recovery-mfa-setup-checklist.md)
+  - Purpose: **Recovery + MFA** checklist.
+- [Account Setup Start Here](control/2026-05-17_account-setup-start-here.md)
+  - Purpose: **Front door**.
+- [Account Setup Operating Sequence](control/2026-05-17_account-setup-operating-sequence.md)
+  - Purpose: **Sequence** for setup.
+
+## Discoverability surfaces
+
+- [Docs Manifest](manifest.md)
+  - Purpose: canonical listing of the coordination docs in this repo.
+
+## Maintenance note
+
+When new coordination docs are added, update this index and the manifest together.

--- a/docs/control/2026-05-17_account-registry-draft.md
+++ b/docs/control/2026-05-17_account-registry-draft.md
@@ -1,0 +1,111 @@
+# Account Registry Draft
+
+> Working draft for the first account set. Repo-safe only.
+
+**Support draft**
+**Decision owner:** Haz
+
+## Accounts
+
+### `qa-testing`
+
+- **Account name:** qa-testing
+- **Role:** testing / QA
+- **Purpose:** testing and demos
+- **Owner:** Haz
+- **Login identity:** to be assigned
+- **Recovery path:** to be assigned
+- **MFA method:** to be assigned
+- **Browser profile:** dedicated testing profile on the MacBook
+- **Allowed device(s):** MacBook only unless later expanded
+- **Trust level:** low
+- **Notes:** disposable
+
+### `research-m3-global`
+
+- **Account name:** research-m3-global
+- **Role:** research / high-trust
+- **Purpose:** secure research
+- **Owner:** Haz
+- **Login identity:** to be assigned
+- **Recovery path:** to be assigned
+- **MFA method:** to be assigned
+- **Browser profile:** dedicated secure research profile
+- **Allowed device(s):** MacBook only unless later expanded
+- **Trust level:** high
+- **Notes:** minimal extensions, minimal sign-ins
+
+### `recovery-admin`
+
+- **Account name:** recovery-admin
+- **Role:** recovery / backup control
+- **Purpose:** recovery and emergency access
+- **Owner:** Haz
+- **Login identity:** to be assigned
+- **Recovery path:** to be assigned
+- **MFA method:** to be assigned
+- **Browser profile:** recovery-only profile
+- **Allowed device(s):** MacBook only unless later expanded
+- **Trust level:** highest
+- **Notes:** never for daily use
+
+## Future business accounts
+
+Use this section only when a real business workflow exists.
+
+### `business-admin-<brand>`
+
+- **Account name:** business-admin-<brand>
+- **Role:** live admin / operations
+- **Purpose:** billing, settings, admin
+- **Owner:** Haz unless another explicit business owner is named
+- **Login identity:** to be assigned
+- **Recovery path:** to be assigned
+- **MFA method:** to be assigned
+- **Browser profile:** dedicated business admin profile
+- **Allowed device(s):** to be defined
+- **Trust level:** high
+- **Notes:** one per brand; avoid mixing client access
+
+### `business-support-<brand>`
+
+- **Account name:** business-support-<brand>
+- **Role:** support / day-to-day ops
+- **Purpose:** support and ops
+- **Owner:** Haz or designated ops lead
+- **Login identity:** to be assigned
+- **Recovery path:** to be assigned
+- **MFA method:** to be assigned
+- **Browser profile:** dedicated support profile
+- **Allowed device(s):** to be defined
+- **Trust level:** medium-high
+- **Notes:** keep separate from admin if possible
+
+### Optional client-facing sub-accounts
+
+- **Account name:** client/workstream-specific
+- **Role:** per-client or per-workstream access
+- **Purpose:** separate access boundary only when needed
+- **Owner:** named business owner or client lead
+- **Login identity:** to be assigned
+- **Recovery path:** to be assigned
+- **MFA method:** to be assigned
+- **Browser profile:** only if permissions alone are not enough
+- **Allowed device(s):** to be defined
+- **Trust level:** based on the workflow
+- **Notes:** do not create early
+
+## Fill-in rule
+
+If any of these are unknown, stop before the account matters:
+
+- login identity
+- recovery path
+- MFA method
+- browser profile
+- allowed device(s)
+- trust level
+
+## Safe handling rule
+
+Do not add passwords, backup codes, or any live credential material to this document.

--- a/docs/control/2026-05-17_account-registry-template.md
+++ b/docs/control/2026-05-17_account-registry-template.md
@@ -1,0 +1,27 @@
+# Account Registry Template
+
+> Minimum safe fields for one account.
+
+**Template**
+
+## One entry per account
+
+- **Account name:**
+- **Role:**
+- **Purpose:**
+- **Owner:**
+- **Login identity:**
+- **Recovery path:**
+- **MFA method:**
+- **Browser profile:**
+- **Allowed device(s):**
+- **Trust level:**
+- **Notes:**
+
+## Rules
+
+- Do not store passwords.
+- Do not store backup codes in this template.
+- Do not store live credentials.
+- Keep testing, business, and research entries separate.
+- If the recovery path is unknown, stop and fix that first.

--- a/docs/control/2026-05-17_account-segmentation_handoff.md
+++ b/docs/control/2026-05-17_account-segmentation_handoff.md
@@ -1,0 +1,40 @@
+# Account Segmentation Handoff
+
+> Keep accounts split by role.
+
+**Support handoff**
+
+**Decision:** split by role, not convenience.
+
+## What is already decided
+
+- One QA account stays the sandbox.
+- One high-trust research account stays locked down.
+- Add business accounts only with a named purpose and owner.
+- Browser/profile separation is the floor.
+- No cookie reuse. No shared passwords. MFA everywhere.
+- No VPN blocking is a fact, not the security model.
+
+## Recommended structure
+
+- `qa-testing` for messy flows.
+- `business-admin` / `business-support` for live ops.
+- `research-secure` for sensitive research.
+- `recovery-admin` for recovery only.
+
+## What still needs doing
+
+- Assign owners for future business accounts.
+- Record recovery before business accounts matter.
+- Choose the browser profile naming on the MacBook.
+- Decide whether any account needs extra hardening.
+
+## Discoverability surfaces
+
+- Use `docs/control/2026-05-17_account-setup-start-here.md` as the front door.
+- The index and manifest point here.
+- The QC checklist is ready.
+
+## Next safe move
+
+Create business accounts only after purpose, owner, recovery path, profile, and trust level are named.

--- a/docs/control/2026-05-17_account-segmentation_handoff.md
+++ b/docs/control/2026-05-17_account-segmentation_handoff.md
@@ -19,7 +19,7 @@
 
 - `qa-testing` for messy flows.
 - `business-admin` / `business-support` for live ops.
-- `research-secure` for sensitive research.
+- `research-m3-global` for sensitive research.
 - `recovery-admin` for recovery only.
 
 ## What still needs doing

--- a/docs/control/2026-05-17_account-setup-operating-sequence.md
+++ b/docs/control/2026-05-17_account-setup-operating-sequence.md
@@ -1,0 +1,103 @@
+# Account Setup Operating Sequence
+
+> Safest order for the first account lanes.
+
+**Support sequence**
+**Decision owner:** Haz
+
+## Goal
+
+Create the accounts in order. No role bleed. No credential reuse. No recovery confusion.
+
+## Operating order
+
+### 1) Create the browser profiles first
+
+Create these profiles before login:
+
+- `profile-qa-testing`
+- `profile-research-secure`
+- `profile-recovery-admin`
+- `profile-business-admin-<brand>` when business rollout begins
+- `profile-business-support-<brand>` when business rollout begins
+
+Rules:
+
+- one family, one profile
+- no cross-use
+- keep secure profiles minimal
+
+### 2) Set up the recovery lane
+
+Use the recovery profile to set up recovery.
+
+Do:
+
+- assign recovery email
+- assign recovery phone if needed
+- generate backup codes
+- store backup material outside this repo
+- confirm recovery works
+
+### 3) Set up the secure research lane
+
+Use the secure profile for the high-trust account.
+
+Do:
+
+- log in only there
+- keep extensions minimal
+- keep sign-ins limited
+- confirm MFA works
+
+### 4) Set up the testing lane
+
+Use the testing profile for the messy account.
+
+Do:
+
+- create or confirm the testing account
+- keep it low-friction
+- store nothing valuable there
+- treat it as resettable
+
+### 5) Only then create business accounts
+
+Create business accounts only when each one has a real workflow.
+
+For each business account, confirm:
+
+- purpose
+- owner
+- recovery path
+- MFA method
+- browser profile
+- allowed device(s)
+- trust level
+
+If any are missing, stop.
+
+## Creation sequence for a new business account
+
+1. Name the role and brand
+2. Decide the owner
+3. Choose the browser profile
+4. Set the recovery path
+5. Enable MFA
+6. Record the safe metadata
+7. Test sign-out and recovery
+8. Confirm isolation
+
+## Pause triggers
+
+Stop and review if:
+
+- two roles share one profile
+- recovery details are unclear
+- MFA is untested
+- business accounts appear without a real workflow
+- convenience starts beating separation
+
+## Handoff
+
+When this sequence is followed, fill in the registry draft and fix any missing fields before the account matters.

--- a/docs/control/2026-05-17_account-setup-start-here.md
+++ b/docs/control/2026-05-17_account-setup-start-here.md
@@ -1,0 +1,48 @@
+# Account Setup Start Here
+
+> Front door for the MacBook account lanes. Read this first.
+
+**Front door**
+**Decision owner:** Haz
+
+## What this is
+
+Keep the lanes clear. Read top to bottom.
+
+## Recommended reading order
+
+1. [Account Segmentation Map](../plans/2026-05-17-account-segmentation-map.md)
+   - Why: sets the lanes.
+2. [Browser Profile Map](2026-05-17_browser-profile-map.md)
+   - Why: splits the profiles.
+3. [Account Registry Draft](2026-05-17_account-registry-draft.md)
+   - Why: records the fields.
+4. [Recovery + MFA Setup Checklist](2026-05-17_recovery-mfa-setup-checklist.md)
+   - Why: locks recovery and MFA.
+5. [Account Setup Operating Sequence](2026-05-17_account-setup-operating-sequence.md)
+   - Why: gives the order.
+6. [Business Account Rollout Checklist](2026-05-17_business-account-rollout-checklist.md)
+   - Why: only for real business accounts.
+7. [Account Setup Handoff](2026-05-17_account-setup-handoff.md)
+   - Why: status and next move.
+8. [Account Segmentation QC](../qc/2026-05-17_account_segmentation_qc.md)
+   - Why: final check.
+
+## Current lane summary
+
+- `qa-testing` — testing lane
+- `research-m3-global` — secure research lane
+- `recovery-admin` — recovery lane
+- `business-admin-<brand>` — only for real business work
+- `business-support-<brand>` — only for real business work
+
+## Safe rules
+
+- One family, one profile.
+- No shared cookies.
+- No passwords, backup codes, or live credentials in repo docs.
+- No extra business accounts without a real purpose, owner, recovery path, profile, and trust level.
+
+## If you are unsure
+
+Start with the segmentation map, then the profile map, then the registry draft. If the account has no real job, leave it out of business.

--- a/docs/control/2026-05-17_browser-profile-map.md
+++ b/docs/control/2026-05-17_browser-profile-map.md
@@ -1,0 +1,72 @@
+# Browser Profile Map
+
+> Map each account family to one browser profile. Keep state isolated.
+
+**Support doc**
+**Decision owner:** Haz
+
+## Purpose
+
+Keep roles separate.
+
+## Core rule
+
+One profile per account family. No shared cookies. No cross-login. No reuse.
+
+## Recommended profiles
+
+### `profile-qa-testing`
+
+- **Purpose:** testing and demos
+- **Linked account:** `qa-testing`
+- **Trust level:** low
+- **Use for:** disposable work
+- **Do not use for:** business, recovery, or secure research
+
+### `profile-research-secure`
+
+- **Purpose:** secure research
+- **Linked account:** `research-m3-global`
+- **Trust level:** high
+- **Use for:** locked-down sessions
+- **Do not use for:** testing clutter
+
+### `profile-recovery-admin`
+
+- **Purpose:** recovery only
+- **Linked account:** `recovery-admin`
+- **Trust level:** highest
+- **Use for:** setup and emergencies
+- **Do not use for:** daily work
+
+### `profile-business-admin-<brand>`
+
+- **Purpose:** live admin for one brand
+- **Linked account:** `business-admin-<brand>`
+- **Trust level:** high
+- **Use for:** billing and admin
+- **Do not use for:** testing or unrelated work
+
+### `profile-business-support-<brand>`
+
+- **Purpose:** support and ops
+- **Linked account:** `business-support-<brand>`
+- **Trust level:** medium-high
+- **Use for:** inbox and support work
+- **Do not use for:** admin or recovery
+
+## Setup rules
+
+- Create the profile before first login.
+- Name it by role.
+- Keep secure profiles minimal.
+- Do not sync across profiles unless needed.
+- Split mixed-use profiles.
+
+## Expansion rule
+
+Only add a profile when a real role exists.
+
+## Safe handling
+
+This document should never contain passwords, backup codes, or live credential material.

--- a/docs/control/2026-05-17_business-account-rollout-checklist.md
+++ b/docs/control/2026-05-17_business-account-rollout-checklist.md
@@ -1,0 +1,49 @@
+# Business Account Rollout Checklist
+
+> Use only for real business work.
+
+**Support checklist**
+
+**Decision owner:** Haz
+
+## Before creating any account
+
+- [ ] Purpose named.
+- [ ] Owner named.
+- [ ] Real business workflow exists.
+- [ ] Recovery path known.
+- [ ] MFA method chosen.
+- [ ] Browser profile chosen.
+- [ ] Trust level written down.
+- [ ] No password or cookie reuse.
+
+## Before first login
+
+- [ ] Recovery email ready.
+- [ ] Recovery phone ready if needed.
+- [ ] Backup codes stored separately.
+- [ ] Dedicated browser profile ready.
+- [ ] Any extra hardening is decided.
+
+## After creation
+
+- [ ] Record login identity.
+- [ ] Record recovery method.
+- [ ] Record MFA method.
+- [ ] Record allowed device(s).
+- [ ] Record browser profile.
+- [ ] Record the business purpose.
+
+## Pause triggers
+
+Stop and review if:
+
+- the account has no clear owner
+- it is being created "just in case"
+- the recovery path is unclear
+- it would mix testing and business
+- shared credentials start creeping in
+
+## Handoff
+
+If it passes, it is ready. If it fails, keep it out of live workflow.

--- a/docs/control/2026-05-17_recovery-mfa-setup-checklist.md
+++ b/docs/control/2026-05-17_recovery-mfa-setup-checklist.md
@@ -1,0 +1,57 @@
+# Recovery + MFA Setup Checklist
+
+> Make each account recoverable and harder to compromise. No secrets in repo.
+
+**Support checklist**
+**Decision owner:** Haz
+
+## Purpose
+
+Keep recovery explicit. Test MFA. No secrets in repo.
+
+## Checklist
+
+### Before setup
+
+- [ ] Owner named.
+- [ ] Purpose named.
+- [ ] Recovery path known.
+- [ ] Browser profile assigned.
+- [ ] Allowed device(s) known.
+- [ ] Trust level written down.
+
+### Recovery setup
+
+- [ ] Recovery email assigned.
+- [ ] Recovery phone assigned if needed.
+- [ ] Backup codes saved outside this repo.
+- [ ] Recovery access is separate from daily login.
+
+### MFA setup
+
+- [ ] MFA enabled.
+- [ ] MFA method chosen on purpose.
+- [ ] Primary MFA works.
+- [ ] Backup MFA is tested.
+- [ ] Account still works without the main device.
+
+### Validation
+
+- [ ] Sign out and re-check recovery.
+- [ ] Recovery works without role mix.
+- [ ] Recovery profile is not daily-use.
+- [ ] No live credentials or backup codes in repo.
+
+## Pause triggers
+
+Stop and fix the setup if:
+
+- recovery path is unclear
+- backup codes are not stored safely elsewhere
+- MFA is on but untested
+- the account shares a profile
+- recovery and daily login blur together
+
+## Safe handling
+
+Do not store passwords, backup codes, QR codes, or live credential material in this document.

--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -1,0 +1,44 @@
+# Docs Manifest
+
+> Canonical listing of the small coordination set in this repo.
+
+## Active docs
+
+- `docs/plans/2026-05-17-account-segmentation-map.md`
+  - Role: account separation plan.
+  - Status: ready.
+- `docs/plans/2026-05-02-telegram-dm-user-managed-multisession-topics.md`
+  - Role: **Plan**.
+  - Status: plan only.
+- `docs/control/2026-05-17_account-segmentation_handoff.md`
+  - Role: **Handoff**.
+  - Status: handoff.
+- `docs/control/2026-05-17_business-account-rollout-checklist.md`
+  - Role: **Checklist**.
+  - Status: checklist.
+- `docs/control/2026-05-17_account-registry-template.md`
+  - Role: **Template**.
+  - Status: template.
+- `docs/control/2026-05-17_account-registry-draft.md`
+  - Role: **Draft**.
+  - Status: draft.
+- `docs/control/2026-05-17_browser-profile-map.md`
+  - Role: **Profile map**.
+  - Status: map.
+- `docs/control/2026-05-17_recovery-mfa-setup-checklist.md`
+  - Role: **Recovery + MFA**.
+  - Status: checklist.
+- `docs/control/2026-05-17_account-setup-start-here.md`
+  - Role: **Front door**.
+  - Status: front door.
+- `docs/control/2026-05-17_account-setup-operating-sequence.md`
+  - Role: **Sequence**.
+  - Status: sequence.
+- `docs/qc/2026-05-17_account_segmentation_qc.md`
+  - Role: **QC**.
+  - Status: qc.
+
+## Notes
+
+- Keep future coordination docs in `docs/plans/`, `docs/control/`, or `docs/qc/`.
+- Update this file when adding a new coordination doc.

--- a/docs/plans/2026-05-17-account-segmentation-map.md
+++ b/docs/plans/2026-05-17-account-segmentation-map.md
@@ -1,0 +1,148 @@
+# Account Segmentation Map
+
+> **Purpose:** keep testing, business, and high-trust research access separated so one compromised or messy account doesn't spill into the others.
+
+**Goal:** define a simple account structure for the MacBook setup now, then extend it cleanly when business accounts come online.
+
+**Approach:** use one account per role, keep browser/profile state isolated, and make recovery/ownership explicit from day one. No account pile-up without a named job.
+
+---
+
+## 1. Account tiers
+
+### 1) Testing / QA account
+
+Use this for:
+
+- user testing flows
+- product walkthroughs
+- low-trust or disposable access
+- anything that might get messy
+
+Rules:
+
+- keep it separate from business and research accounts
+- use a dedicated browser profile
+- avoid storing sensitive data here
+- if it breaks, reset it instead of repairing around bad state
+
+### 2) Business / operations account
+
+Use this for:
+
+- customer-facing business workflows
+- billing, admin, and support access
+- anything that should survive long term
+
+Rules:
+
+- one owner per account
+- MFA on day one
+- recovery email/phone documented
+- only business-approved browser profile and password manager entry
+- no testing clutter inside this account
+
+### 3) Research / high-trust account
+
+Use this for:
+
+- sensitive research
+- secure vendor or global-research workflows
+- accounts that need tighter access discipline
+
+Rules:
+
+- locked-down browser profile
+- minimal extensions
+- minimal sign-ins
+- only used when the task actually needs that trust level
+
+### 4) Admin / recovery account
+
+Use this only for:
+
+- account creation
+- recovery
+- backup codes
+- recovery email/phone management
+
+Rules:
+
+- never used for day-to-day work
+- never mixed with testing sessions
+- recovery codes stored separately from live logins
+
+---
+
+## 2. Separation rules
+
+- **One role per account.** No hybrid accounts unless there is a real reason.
+- **One browser profile per account family.** At minimum, separate profiles for testing, business, and research.
+- **No cookie reuse.** If one account signs in, that session stays there.
+- **No shared passwords.** Every account gets its own credential entry.
+- **MFA everywhere.** Treat MFA as baseline, not a special case.
+- **Keep recovery explicit.** If you can't name the recovery path, the account isn't ready.
+
+---
+
+## 3. Naming convention
+
+Keep names boring and obvious:
+
+- `qa-testing`
+- `business-admin`
+- `business-support`
+- `research-secure`
+- `recovery-admin`
+
+If there are multiple business accounts later, add the role or function first, then the client or brand.
+
+Examples:
+
+- `business-admin-floorlight`
+- `business-support-trymata`
+- `research-m3-global`
+
+---
+
+## 4. What to record for each account
+
+For every account, record:
+
+- purpose
+- owner
+- email / login identity
+- recovery method
+- MFA method
+- browser profile used
+- device(s) allowed
+- notes on trust level
+
+If a field is unknown, fix that before the account becomes important.
+
+---
+
+## 5. Rollout rule for business accounts
+
+Do not create extra business accounts until each one has:
+
+1. a named purpose
+2. a named owner
+3. a recovery path
+4. a browser profile
+5. a clear yes/no on whether it needs higher security
+
+If those five things aren't true, it's not ready.
+
+---
+
+## 6. Practical recommendation
+
+Based on the current setup:
+
+- keep the testing account as the low-friction sandbox
+- keep the secure research account as the locked-down lane
+- add business accounts only when the business side has a real workflow to attach them to
+- treat "no VPN blocking" as useful flexibility, not as the security model
+
+That gives you three clean lanes instead of one big account swamp.

--- a/docs/plans/2026-05-17-account-segmentation-map.md
+++ b/docs/plans/2026-05-17-account-segmentation-map.md
@@ -146,3 +146,81 @@ Based on the current setup:
 - treat "no VPN blocking" as useful flexibility, not as the security model
 
 That gives you three clean lanes instead of one big account swamp.
+
+---
+
+## 7. Suggested first-wave rollout
+
+This is the cleanest first pass if you want the structure to stay manageable as business work comes online.
+
+### Now
+
+#### `qa-testing`
+
+- **Role:** testing / QA / messy flows
+- **Purpose:** user testing, demos, throwaway sign-ins, breakable workflows
+- **Owner:** Haz
+- **Trust level:** low
+- **Browser profile:** dedicated testing profile on the MacBook
+- **Notes:** keep it intentionally disposable; do not let business or research state leak in
+
+#### `research-m3-global`
+
+- **Role:** high-trust research
+- **Purpose:** secure research, sensitive vendor work, locked-down sessions
+- **Owner:** Haz
+- **Trust level:** high
+- **Browser profile:** dedicated secure research profile
+- **Notes:** keep extensions minimal and sign-ins limited
+
+#### `recovery-admin`
+
+- **Role:** recovery / backup control
+- **Purpose:** account setup, recovery email/phone, backup codes, emergency access
+- **Owner:** Haz
+- **Trust level:** highest
+- **Browser profile:** separate recovery-only profile
+- **Notes:** never use for day-to-day work
+
+### When business accounts come online
+
+Create these only when there is a real workflow attached:
+
+#### `business-admin-<brand>`
+
+- **Role:** live admin / operations
+- **Purpose:** billing, settings, ownership, core admin tasks
+- **Owner:** Haz unless another human is the explicit business owner
+- **Trust level:** high
+- **Browser profile:** dedicated business admin profile
+- **Notes:** one per brand or business entity; avoid mixing clients in one login unless the platform forces it
+
+#### `business-support-<brand>`
+
+- **Role:** support / day-to-day ops
+- **Purpose:** customer support, inbox handling, low-risk operational work
+- **Owner:** Haz or designated ops lead
+- **Trust level:** medium-high
+- **Browser profile:** dedicated support profile
+- **Notes:** separate from admin if the platform supports that split
+
+#### Optional client-facing sub-accounts
+
+- **Role:** per-client or per-workstream access
+- **Purpose:** only if the platform needs separate access boundaries
+- **Owner:** named business owner or client lead
+- **Trust level:** based on the workflow
+- **Browser profile:** only if the platform cannot cleanly separate by permissions alone
+- **Notes:** do not create these pre-emptively
+
+### Rollout rule
+
+If the account does not have:
+
+1. a named purpose
+2. a named owner
+3. a recovery path
+4. a browser profile
+5. a clear trust level
+
+then it is not ready to create.

--- a/docs/plans/2026-05-17-account-segmentation-map.md
+++ b/docs/plans/2026-05-17-account-segmentation-map.md
@@ -92,7 +92,7 @@ Keep names boring and obvious:
 - `qa-testing`
 - `business-admin`
 - `business-support`
-- `research-secure`
+- `research-m3-global`
 - `recovery-admin`
 
 If there are multiple business accounts later, add the role or function first, then the client or brand.

--- a/docs/qc/2026-05-17_account_segmentation_qc.md
+++ b/docs/qc/2026-05-17_account_segmentation_qc.md
@@ -1,0 +1,31 @@
+# Account Segmentation QC Checklist
+
+> Quick QC for the account pack.
+
+**Support qc**
+**Decision owner:** Haz
+
+## Check before using the plan
+
+- [ ] Testing, business, and research are split.
+- [ ] Each account has a purpose.
+- [ ] Each account has an owner.
+- [ ] Recovery is explicit.
+- [ ] MFA is required.
+- [ ] Browser profile separation is defined.
+- [ ] No shared passwords or cookie reuse.
+- [ ] VPN blocking is a fact, not the model.
+
+## Check before adding business accounts
+
+- [ ] No extra business account without a real workflow.
+- [ ] The account has a clear job.
+- [ ] Trust level is written down.
+- [ ] Recovery and backup access are known.
+
+## Repo-safe doc check
+
+- [ ] No secrets or live credentials in the docs.
+- [ ] The handoff points to the next safe action.
+- [ ] The docs index includes the planning docs.
+- [ ] Missing surfaces are called out.

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -3179,6 +3179,22 @@ def test_config_default_dispatch_in_gateway_is_true():
     )
 
 
+def test_config_default_auto_decompose_is_enabled_and_bounded():
+    """Auto-decompose should be on by default, with a conservative per-tick cap.
+    That keeps fresh triage graphs moving while avoiding surprise LLM bursts."""
+    from hermes_cli.config import DEFAULT_CONFIG
+    kanban = DEFAULT_CONFIG.get("kanban", {})
+    assert kanban.get("auto_decompose") is True, (
+        "kanban.auto_decompose default should be True; got "
+        f"{kanban.get('auto_decompose')!r}"
+    )
+    per_tick = kanban.get("auto_decompose_per_tick")
+    assert per_tick == 3, (
+        "kanban.auto_decompose_per_tick default should stay at 3; got "
+        f"{per_tick!r}"
+    )
+
+
 def test_check_dispatcher_presence_silent_when_gateway_running(monkeypatch):
     from hermes_cli import kanban as kb_cli
     monkeypatch.setattr("gateway.status.get_running_pid", lambda: 12345)
@@ -3958,6 +3974,8 @@ def test_detect_crashed_workers_increments_counter(kanban_home):
         conn.close()
 
 
+@pytest.mark.skipif("linux" not in __import__("sys").platform,
+                    reason="clean-exit protocol-violation handling is Linux-specific")
 def test_detect_crashed_workers_protocol_violation_auto_blocks(kanban_home):
     """A worker that exited rc=0 while its task was still ``running``
     is a protocol violation (agent answered conversationally without
@@ -3969,7 +3987,7 @@ def test_detect_crashed_workers_protocol_violation_auto_blocks(kanban_home):
     against small local models (gemma4-e2b q4) where the model writes
     the answer as plain text and the CLI exits rc=0 cleanly.
     """
-    import hermes_cli.kanban_db as _kb
+
     conn = kb.connect()
     try:
         tid = kb.create_task(conn, title="quiet", assignee="worker")


### PR DESCRIPTION
This patch adds the missing _pool_may_recover_from_rate_limit helper used by the Anthropic/API-billing recovery path. Without it, the recovery path can crash with NameError after a provider failure. The helper is conservative: it returns false when there is no pool or only one credential, true only when another credential can realistically recover, and otherwise falls back normally. Verified with python -m py_compile agent\conversation_loop.py and targeted helper cases covering no pool, single credential, healthy alternate credential, future cooldown, expired cooldown, and exhausted/no-reset status.