### PR TITLE
fix(cli,gateway): handle sessions slash command

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -6301,23 +6301,38 @@ class HermesCLI:
 
         from hermes_cli.main import _relative_time
 
-        print()
+        def _emit_session_line(text: str = "") -> None:
+            # In the active prompt_toolkit TUI, route output through _cprint so
+            # it renders above/redraws around the fixed input area. Outside the
+            # TUI (unit tests, scripts, plain stdout), keep normal print()
+            # semantics so output remains capturable and pipe-friendly.
+            try:
+                from prompt_toolkit.application import get_app_or_none
+                app = get_app_or_none()
+            except Exception:
+                app = None
+            if app is not None and getattr(app, "_is_running", False):
+                _cprint(text)
+            else:
+                print(text)
+
+        _emit_session_line()
         if reason == "history":
-            print("(._.) No messages in the current chat yet — here are recent sessions you can resume:")
+            _emit_session_line("(._.) No messages in the current chat yet — here are recent sessions you can resume:")
         else:
-            print("  Recent sessions:")
-        print()
-        print(f"  {'#':<3} {'Title':<32} {'Preview':<40} {'Last Active':<13} {'ID'}")
-        print(f"  {'─' * 3} {'─' * 32} {'─' * 40} {'─' * 13} {'─' * 24}")
+            _emit_session_line("  Recent sessions:")
+        _emit_session_line()
+        _emit_session_line(f"  {'#':<3} {'Title':<32} {'Preview':<40} {'Last Active':<13} {'ID'}")
+        _emit_session_line(f"  {'─' * 3} {'─' * 32} {'─' * 40} {'─' * 13} {'─' * 24}")
         for idx, session in enumerate(sessions, start=1):
             title = session.get("title") or "—"
             preview = (session.get("preview") or "")[:38]
             last_active = _relative_time(session.get("last_active"))
-            print(f"  {idx:<3} {title:<32} {preview:<40} {last_active:<13} {session['id']}")
-        print()
-        print("  Use /resume <number>, /resume <session id>, or /resume <session title> to continue.")
-        print("  Example: /resume 2")
-        print()
+            _emit_session_line(f"  {idx:<3} {title:<32} {preview:<40} {last_active:<13} {session['id']}")
+        _emit_session_line()
+        _emit_session_line("  Use /resume <number>, /resume <session id>, or /resume <session title> to continue.")
+        _emit_session_line("  Example: /resume 2")
+        _emit_session_line()
         return True
 
     def show_history(self):

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7559,6 +7559,9 @@ class GatewayRunner:
         if canonical == "title":
             return await self._handle_title_command(event)
 
+        if canonical == "sessions":
+            return await self._handle_resume_command(event)
+
         if canonical == "resume":
             return await self._handle_resume_command(event)
 

--- a/tests/gateway/test_resume_command.py
+++ b/tests/gateway/test_resume_command.py
@@ -93,6 +93,25 @@ class TestHandleResumeCommand:
         assert "/resume 1" in result
         db.close()
 
+
+    @pytest.mark.asyncio
+    async def test_sessions_lists_named_sessions_when_no_arg(self, tmp_path):
+        """/sessions should reuse the gateway session browser semantics."""
+        from hermes_state import SessionDB
+        db = SessionDB(db_path=tmp_path / "state.db")
+        db.create_session("sess_001", "telegram")
+        db.create_session("sess_002", "telegram")
+        db.set_session_title("sess_001", "Research")
+        db.set_session_title("sess_002", "Coding")
+
+        event = _make_event(text="/sessions")
+        runner = _make_runner(session_db=db, event=event)
+        result = await runner._handle_resume_command(event)
+        assert "Research" in result
+        assert "Coding" in result
+        assert "Named Sessions" in result
+        db.close()
+
     @pytest.mark.asyncio
     async def test_list_shows_usage_when_no_titled(self, tmp_path):
         """With no arg and no titled sessions, shows instructions."""
@@ -166,6 +185,30 @@ class TestHandleResumeCommand:
         assert "My Project" in result
         # Verify switch_session was called with the old session ID
         runner.session_store.switch_session.assert_called_once()
+        call_args = runner.session_store.switch_session.call_args
+        assert call_args[0][1] == "old_session_abc"
+        db.close()
+
+
+    @pytest.mark.asyncio
+    async def test_sessions_resumes_by_name(self, tmp_path):
+        """/sessions <name> should resume the named session on gateway platforms."""
+        from hermes_state import SessionDB
+        db = SessionDB(db_path=tmp_path / "state.db")
+        db.create_session("old_session_abc", "telegram")
+        db.set_session_title("old_session_abc", "My Project")
+        db.create_session("current_session_001", "telegram")
+
+        event = _make_event(text="/sessions My Project")
+        runner = _make_runner(
+            session_db=db,
+            current_session_id="current_session_001",
+            event=event,
+        )
+        result = await runner._handle_resume_command(event)
+
+        assert "Resumed" in result
+        assert "My Project" in result
         call_args = runner.session_store.switch_session.call_args
         assert call_args[0][1] == "old_session_abc"
         db.close()


### PR DESCRIPTION
## What does this PR do?

The `/sessions` command path was not handled consistently across CLI/gateway command surfaces. This PR adds the sessions alias/handling path and keeps session rendering behavior aligned with existing resume/session command expectations.

## Related Issue

Fixes #30353

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add `/sessions` handling in the CLI/gateway command surface.
- Preserve existing resume command behavior.
- Add focused gateway resume/session command regression coverage.

## How to Test

1. Check out this PR branch.
2. Run: `.venv/bin/python -m pytest -o 'addopts=' tests/gateway/test_resume_command.py -q`
3. Expected result: 16 passed

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — focused pytest passed; full suite was not run in this salvage pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux container / Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Focused verification:

```text
`.venv/bin/python -m pytest -o 'addopts=' tests/gateway/test_resume_command.py -q` — 16 passed
```
