### PR TITLE
fix(cli): enqueue leftover /steer before interrupt follow-up

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -12313,36 +12313,14 @@ class HermesCLI:
                 self._voice_speak_response_async(response)
 
 
-            # Re-queue the interrupt message (and any that arrived while we were
-            # processing the first) as the next prompt for process_loop.
+            # Re-queue interrupt follow-up(s) and any leftover /steer as the
+            # next prompt(s) for process_loop. Order matters: leftover steer
+            # must land BEFORE the interrupt follow-up so the next turn honors
+            # the steer first (#30323).
             # Only reached when busy_input_mode == "interrupt" (the default).
             # In "queue" mode Enter routes directly to _pending_input so this
             # block is never hit.
-            if pending_message and hasattr(self, '_pending_input'):
-                all_parts = [pending_message]
-                while not self._interrupt_queue.empty():
-                    try:
-                        extra = self._interrupt_queue.get_nowait()
-                        if extra:
-                            all_parts.append(extra)
-                    except queue.Empty:
-                        break
-                combined = "\n".join(all_parts)
-                n = len(all_parts)
-                preview = combined[:50] + ("..." if len(combined) > 50 else "")
-                if n > 1:
-                    print(f"\n⚡ Sending {n} messages after interrupt: '{preview}'")
-                else:
-                    print(f"\n⚡ Sending after interrupt: '{preview}'")
-                self._pending_input.put(combined)
-
-            # If a /steer was left over (agent finished before another tool
-            # batch could absorb it), deliver it as the next user turn.
-            _leftover_steer = result.get("pending_steer") if result else None
-            if _leftover_steer and hasattr(self, '_pending_input'):
-                preview = _leftover_steer[:60] + ("..." if len(_leftover_steer) > 60 else "")
-                print(f"\n⏩ Delivering leftover /steer as next turn: '{preview}'")
-                self._pending_input.put(_leftover_steer)
+            self._enqueue_post_run_followups(pending_message, result)
 
             return response
             
@@ -12364,6 +12342,47 @@ class HermesCLI:
             if tts_thread is not None and tts_thread.is_alive():
                 tts_thread.join(timeout=5)
     
+    def _enqueue_post_run_followups(self, pending_message, result):
+        """Enqueue post-run follow-up turns onto ``self._pending_input``.
+
+        Deterministic ordering: leftover ``pending_steer`` is enqueued first
+        so the next turn honors the user's steer before any interrupt
+        follow-up text. Otherwise the queue (FIFO) would surface the
+        interrupt follow-up first and the steer guidance would be applied
+        too late or appear dropped. See #30323.
+        """
+        if not hasattr(self, '_pending_input'):
+            return
+
+        # Leftover /steer first: agent finished before another tool batch
+        # could absorb it (returned in result["pending_steer"]).
+        _leftover_steer = result.get("pending_steer") if result else None
+        if _leftover_steer:
+            preview = _leftover_steer[:60] + ("..." if len(_leftover_steer) > 60 else "")
+            print(f"\n⏩ Delivering leftover /steer as next turn: '{preview}'")
+            self._pending_input.put(_leftover_steer)
+
+        # Interrupt follow-up second: re-queue the interrupt message and any
+        # that arrived while we were processing the first as the next prompt
+        # for process_loop.
+        if pending_message:
+            all_parts = [pending_message]
+            while not self._interrupt_queue.empty():
+                try:
+                    extra = self._interrupt_queue.get_nowait()
+                    if extra:
+                        all_parts.append(extra)
+                except queue.Empty:
+                    break
+            combined = "\n".join(all_parts)
+            n = len(all_parts)
+            preview = combined[:50] + ("..." if len(combined) > 50 else "")
+            if n > 1:
+                print(f"\n⚡ Sending {n} messages after interrupt: '{preview}'")
+            else:
+                print(f"\n⚡ Sending after interrupt: '{preview}'")
+            self._pending_input.put(combined)
+
     def _print_exit_summary(self):
         """Print session resume info on exit, similar to Claude Code."""
         print()

--- a/tests/hermes_cli/test_pending_steer_order.py
+++ b/tests/hermes_cli/test_pending_steer_order.py
@@ -1,0 +1,105 @@
+"""Regression tests for #30323: leftover /steer ordering vs interrupt follow-up.
+
+The CLI keeps a single FIFO ``_pending_input`` queue feeding ``process_loop``.
+When a run ends with both:
+
+  * leftover ``pending_steer`` (steer arrived after the final tool batch
+    could absorb it, so the agent returned it in ``result["pending_steer"]``)
+  * a queued normal follow-up message (via the interrupt path)
+
+then the leftover steer MUST be applied first on the next turn, otherwise
+``/steer`` guidance arrives too late and appears dropped.
+"""
+
+from __future__ import annotations
+
+import queue
+
+from cli import HermesCLI
+
+
+def _make_cli_under_test():
+    """Construct a HermesCLI without running its heavy __init__."""
+    cli = HermesCLI.__new__(HermesCLI)
+    cli._pending_input = queue.Queue()
+    cli._interrupt_queue = queue.Queue()
+    return cli
+
+
+def _drain(q):
+    out = []
+    while not q.empty():
+        out.append(q.get_nowait())
+    return out
+
+
+def test_leftover_steer_enqueued_before_interrupt_followup():
+    cli = _make_cli_under_test()
+
+    cli._enqueue_post_run_followups(
+        pending_message="please continue with the refactor",
+        result={"pending_steer": "actually focus on the bug first"},
+    )
+
+    assert _drain(cli._pending_input) == [
+        "actually focus on the bug first",
+        "please continue with the refactor",
+    ]
+
+
+def test_steer_only_when_no_interrupt_followup():
+    cli = _make_cli_under_test()
+
+    cli._enqueue_post_run_followups(
+        pending_message=None,
+        result={"pending_steer": "use rg not grep"},
+    )
+
+    assert _drain(cli._pending_input) == ["use rg not grep"]
+
+
+def test_interrupt_only_when_no_leftover_steer():
+    cli = _make_cli_under_test()
+
+    cli._enqueue_post_run_followups(
+        pending_message="follow-up question",
+        result={},
+    )
+
+    assert _drain(cli._pending_input) == ["follow-up question"]
+
+
+def test_no_result_no_pending_message_is_noop():
+    cli = _make_cli_under_test()
+
+    cli._enqueue_post_run_followups(pending_message=None, result=None)
+
+    assert _drain(cli._pending_input) == []
+
+
+def test_interrupt_followup_combines_with_extra_interrupt_queue_messages():
+    cli = _make_cli_under_test()
+    cli._interrupt_queue.put("second interrupt")
+    cli._interrupt_queue.put("third interrupt")
+
+    cli._enqueue_post_run_followups(
+        pending_message="first interrupt",
+        result={"pending_steer": "steer guidance"},
+    )
+
+    drained = _drain(cli._pending_input)
+    assert drained[0] == "steer guidance"
+    # Combined interrupt batch preserves arrival order within the batch.
+    assert drained[1] == "first interrupt\nsecond interrupt\nthird interrupt"
+
+
+def test_missing_pending_input_attribute_is_safe():
+    """Method short-circuits when ``_pending_input`` was never initialized."""
+    cli = HermesCLI.__new__(HermesCLI)
+    # Deliberately no _pending_input and no _interrupt_queue.
+
+    cli._enqueue_post_run_followups(
+        pending_message="ignored",
+        result={"pending_steer": "ignored"},
+    )
+    # No AttributeError raised → pass.


### PR DESCRIPTION
## What does this PR do?

When a run ends with both a queued interrupt follow-up message and leftover `pending_steer` (steer arrived after the final tool batch could absorb it, so the agent returned it in `result["pending_steer"]`), the post-run enqueue block in `HermesCLI` puts the combined interrupt follow-up onto `_pending_input` first and the leftover steer second. Because `_pending_input` is a single FIFO `queue.Queue`, the next-turn drain surfaces the follow-up first and the steer second — so `/steer` guidance is applied too late or appears dropped.

Extract `_enqueue_post_run_followups(pending_message, result)` and deliver leftover steer first, then the interrupt follow-up batch. The helper is a pure method against `_pending_input` / `_interrupt_queue` so the ordering invariant can be unit-tested directly without standing up a full `HermesCLI` run loop.

## Related Issue

Fixes #30323

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [x] ♻️ Refactor (no behavior change) — helper extraction for testability
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `cli.py` — extract the post-run enqueue block into `HermesCLI._enqueue_post_run_followups(pending_message, result)` and swap the order so leftover `pending_steer` lands on `_pending_input` before the combined interrupt follow-up.
- `tests/hermes_cli/test_pending_steer_order.py` — 6 focused tests covering: steer-before-follow-up ordering (the regression), steer-only, follow-up-only, both-empty no-op, interrupt-queue batch combining, and the `hasattr(_pending_input)` short-circuit.

## How to Test

1. Reproduction (manual): start a run with tool calls, send `/steer ...` mid-run, then trigger a normal follow-up via the interrupt path before the run settles; let the run finish with `result["pending_steer"]` set. Before the fix, the next turn processes the normal follow-up first and the steer second. After the fix, the steer lands first.
2. Focused tests:
   ```
   uv run --with pytest --with pytest-xdist --with pytest-asyncio --with pytest-timeout \
       python3 -m pytest tests/hermes_cli/test_pending_steer_order.py -v
   ```
3. Adjacent steer regression suite:
   ```
   uv run --with pytest --with pytest-xdist --with pytest-asyncio --with pytest-timeout \
       python3 -m pytest tests/run_agent/test_steer.py -v
   ```
   Expected: 6 + 21 = 27 passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(cli): …`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run focused tests for the touched code and all pass
- [x] I've added tests for my changes (required for bug fixes)
- [x] I've tested on my platform: macOS 15.x

### Documentation & Housekeeping

- [x] N/A — no user-facing docs, config keys, or workflow changes
- [x] N/A — no `cli-config.yaml.example` impact
- [x] N/A — no `CONTRIBUTING.md` / `AGENTS.md` impact
- [x] N/A — change is cross-platform (pure Python queue ordering)
- [x] N/A — no tool descriptions/schemas changed

## Related / Positioning

`alt-glitch` noted on the issue that #28808 ("steer breakout — defer remaining tools on /steer") addresses a different `/steer` ordering issue in tool execution. This PR is specifically about the post-run enqueue ordering of leftover `pending_steer` vs interrupt follow-up messages onto `_pending_input` — the gateway sibling in `gateway/run.py` does not have the bug because it gates leftover steer behind `if not pending`, but `cli.py` enqueues both unconditionally onto the same FIFO.

> Audited siblings: `gateway/run.py` post-run path uses mutually-exclusive `if not pending` for leftover steer (no FIFO ordering issue). `_pending_input` is the only FIFO that needs the explicit ordering. No widening needed.

## Screenshots / Logs

_N/A — behavioral fix observable only via the regression test queue-drain order._