### PR TITLE
fix(mattermost): CRT Thread root post root_id empty causes progress messages to leak to channel

### DIFF
--- a/gateway/platforms/mattermost.py
+++ b/gateway/platforms/mattermost.py
@@ -787,7 +787,16 @@ class MattermostAdapter(BasePlatformAdapter):
         sender_name = data.get("sender_name", "").lstrip("@") or sender_id
 
         # Thread support: if the post is in a thread, use root_id.
-        thread_id = post.get("root_id") or None
+        # When root_id is empty but CRT mode is enabled, the post itself IS
+        # the thread root — use post_id so progress/notification messages
+        # stay in the Thread instead of leaking to the channel.
+        _raw_root = post.get("root_id")
+        if _raw_root:
+            thread_id = _raw_root
+        elif self._reply_mode == "thread":
+            thread_id = post_id
+        else:
+            thread_id = None
 
         # Determine message type.
         file_ids = post.get("file_ids") or []


### PR DESCRIPTION
## Problem

Mattermost CRT (Collapsed Reply Threads) mode sends `root_id=""` for thread-root posts via WebSocket. The existing code:

```python
thread_id = post.get("root_id") or None
```

evaluates `"" or None` → `None`, so `source.thread_id` is never set for thread-root messages.

**Impact chain:**
1. `source.thread_id` = None
2. `_progress_thread_id` = None → `_status_thread_metadata` = None  
3. All long-running tool-progress notifications (`⏳ Still working...`, iteration N/M) are sent without thread metadata
4. Mattermost renders them at channel level instead of inside the Thread

Users in CRT mode see progress messages leak into the main channel while they wait inside the Thread.

## Reproduction

1. Enable CRT in Mattermost (`reply_mode: "thread"`)
2. Send a message in a channel (creates a new Thread)
3. Ask the agent to perform a long-running task (e.g., web scraping 100 pages)
4. Watch progress messages appear in the channel, not the Thread

## Fix

Check `root_id` as a raw string instead of using `or None`:

```python
_raw_root = post.get("root_id")
if _raw_root:
    thread_id = _raw_root
elif self._reply_mode == "thread":
    thread_id = post_id  # root post ID IS the Thread ID
else:
    thread_id = None      # flat mode unaffected
```

Thread replies (which have a non-empty `root_id`) are unaffected — they keep working as before.

## Testing

- [x] Thread root posts get `thread_id = post_id` in CRT mode
- [x] Thread replies keep their original `root_id`  
- [x] Flat mode (non-CRT) keeps `thread_id = None`
- [x] Python syntax check passes