### PR TITLE
fix(kanban): reject truncated sqlite boards before WAL setup

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -989,10 +989,40 @@ def _validate_sqlite_header(path: Path) -> None:
         return
     try:
         with path.open("rb") as handle:
-            head = handle.read(64)
+            head = handle.read(100)
     except OSError:
         return
     if head.startswith(_SQLITE_HEADER):
+        if stat.st_size < 100:
+            raise sqlite3.DatabaseError(
+                "truncated SQLite file for "
+                f"{path}: size_bytes={stat.st_size} shorter than 100-byte header"
+            )
+        raw_page_size = int.from_bytes(head[16:18], "big")
+        page_size = 65536 if raw_page_size == 1 else raw_page_size
+        valid_page_size = page_size in {512, 1024, 2048, 4096, 8192, 16384, 32768, 65536}
+        if not valid_page_size:
+            raise sqlite3.DatabaseError(
+                "file is not a database: invalid SQLite page size for "
+                f"{path}; page_size={raw_page_size}; first_32={head[:32].hex(' ')}"
+            )
+        actual_pages, remainder = divmod(stat.st_size, page_size)
+        if remainder:
+            raise sqlite3.DatabaseError(
+                "truncated SQLite file for "
+                f"{path}: size_bytes={stat.st_size} is not a multiple of "
+                f"page_size={page_size}; remainder={remainder}"
+            )
+        header_pages = int.from_bytes(head[28:32], "big")
+        change_counter = int.from_bytes(head[24:28], "big")
+        version_valid_for = int.from_bytes(head[92:96], "big")
+        if header_pages and change_counter == version_valid_for and header_pages > actual_pages:
+            raise sqlite3.DatabaseError(
+                "truncated SQLite file for "
+                f"{path}: header_pages={header_pages} actual_pages={actual_pages} "
+                f"missing_pages={header_pages - actual_pages} page_size={page_size} "
+                f"size_bytes={stat.st_size}"
+            )
         return
     signature = ""
     if head.startswith(b"SQLit") and _looks_like_tls_record_at(head, 5):

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -69,6 +69,35 @@ def test_connect_rejects_tls_record_in_sqlite_header(tmp_path, monkeypatch):
     assert "53 51 4c 69 74 17 03 03 00 13" in msg
 
 
+def test_connect_rejects_truncated_sqlite_file_before_wal_setup(tmp_path, monkeypatch):
+    """Kanban should identify file-size/page-count truncation explicitly."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.delenv("HERMES_KANBAN_DB", raising=False)
+    monkeypatch.delenv("HERMES_KANBAN_HOME", raising=False)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+    truncated = home / "kanban.db"
+    with sqlite3.connect(truncated) as conn:
+        conn.execute("CREATE TABLE t(x TEXT)")
+        conn.execute("INSERT INTO t VALUES ('ok')")
+
+    data = bytearray(truncated.read_bytes())
+    page_size = int.from_bytes(data[16:18], "big")
+    actual_pages = len(data) // page_size
+    data[28:32] = (actual_pages + 2).to_bytes(4, "big")
+    truncated.write_bytes(data)
+
+    with pytest.raises(sqlite3.DatabaseError) as exc_info:
+        kb.connect(board="default")
+
+    msg = str(exc_info.value)
+    assert "truncated SQLite file" in msg
+    assert f"header_pages={actual_pages + 2}" in msg
+    assert f"actual_pages={actual_pages}" in msg
+
+
 def test_connect_migrates_legacy_db_before_optional_column_indexes(tmp_path):
     """Legacy DBs missing additive indexed columns must migrate cleanly.
 


### PR DESCRIPTION
## Summary
- Adds pre-WAL SQLite header validation for valid page size, file-size/page-size alignment, and header page count greater than actual pages
- Raises explicit truncated SQLite diagnostics before SQLite attempts WAL setup
- Adds focused regression coverage for truncated Kanban DB detection

## Scope control
- Scoped to only `hermes_cli/kanban_db.py` and `tests/hermes_cli/test_kanban_db.py`
- Excludes unrelated dirty worktree changes in dispatcher/gateway/memory/skills/terminal areas
- Excludes untracked Microsoft 365/O365 connector files from the prior working tree

## Verification
- `env -u HERMES_KANBAN_DB -u HERMES_KANBAN_BOARD -u HERMES_KANBAN_WORKSPACES_ROOT -u HERMES_KANBAN_TASK -u HERMES_KANBAN_WORKSPACE -u HERMES_KANBAN_RUN_ID -u HERMES_KANBAN_CLAIM_LOCK /home/jackdidur/.hermes/hermes-agent/venv/bin/python -m pytest tests/hermes_cli/test_kanban_db.py::test_connect_rejects_truncated_sqlite_file_before_wal_setup tests/hermes_cli/test_kanban_db.py::test_connect_rejects_tls_record_in_sqlite_header -q` -> 2 passed in 0.98s
- `env -u HERMES_KANBAN_DB -u HERMES_KANBAN_BOARD -u HERMES_KANBAN_WORKSPACES_ROOT -u HERMES_KANBAN_TASK -u HERMES_KANBAN_WORKSPACE -u HERMES_KANBAN_RUN_ID -u HERMES_KANBAN_CLAIM_LOCK /home/jackdidur/.hermes/hermes-agent/venv/bin/python -m pytest tests/hermes_cli/test_kanban*.py tests/tools/test_kanban_tools.py tests/tools/test_kanban_codex_lane_skill.py tests/plugins/test_kanban_worker_runs.py tests/plugins/test_kanban_dashboard_plugin.py tests/gateway/test_kanban_notifier.py -q` -> 737 passed in 78.08s
- `/home/jackdidur/.hermes/hermes-agent/venv/bin/python -m ruff check hermes_cli/kanban_db.py tests/hermes_cli/test_kanban_db.py` -> All checks passed
- `git diff --check` -> passed
- Static diff scan -> STATIC_SCAN_CLEAN
- Independent reviewer -> passed; no security concerns or logic errors
