### PR TITLE
feat(whatsapp): allow voice notes to bypass mention gate

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -838,6 +838,8 @@ def load_gateway_config() -> GatewayConfig:
                     bridged["free_response_channels"] = platform_cfg["free_response_channels"]
                 if "mention_patterns" in platform_cfg:
                     bridged["mention_patterns"] = platform_cfg["mention_patterns"]
+                if plat == Platform.WHATSAPP and "voice_bypass_mention" in platform_cfg:
+                    bridged["voice_bypass_mention"] = platform_cfg["voice_bypass_mention"]
                 if "exclusive_bot_mentions" in platform_cfg:
                     bridged["exclusive_bot_mentions"] = platform_cfg["exclusive_bot_mentions"]
                 if plat == Platform.TELEGRAM and "observe_unmentioned_group_messages" in platform_cfg:
@@ -1104,6 +1106,8 @@ def load_gateway_config() -> GatewayConfig:
                     os.environ["WHATSAPP_REQUIRE_MENTION"] = str(whatsapp_cfg["require_mention"]).lower()
                 if "mention_patterns" in whatsapp_cfg and not os.getenv("WHATSAPP_MENTION_PATTERNS"):
                     os.environ["WHATSAPP_MENTION_PATTERNS"] = json.dumps(whatsapp_cfg["mention_patterns"])
+                if "voice_bypass_mention" in whatsapp_cfg and not os.getenv("WHATSAPP_VOICE_BYPASS_MENTION"):
+                    os.environ["WHATSAPP_VOICE_BYPASS_MENTION"] = str(whatsapp_cfg["voice_bypass_mention"]).lower()
                 frc = whatsapp_cfg.get("free_response_chats")
                 if frc is not None and not os.getenv("WHATSAPP_FREE_RESPONSE_CHATS"):
                     if isinstance(frc, list):

--- a/gateway/platforms/whatsapp.py
+++ b/gateway/platforms/whatsapp.py
@@ -237,6 +237,8 @@ class WhatsAppAdapter(BasePlatformAdapter):
     - allow_from: List of sender IDs allowed in DMs (when dm_policy="allowlist")
     - group_policy: "open" | "allowlist" | "disabled" — which groups are processed (default: "open")
     - group_allow_from: List of group JIDs allowed (when group_policy="allowlist")
+    - voice_bypass_mention: If true, group voice/audio messages that pass
+      group policy are processed even when require_mention is true.
     """
     
     # WhatsApp message limits — practical UX limit, not protocol max.
@@ -305,6 +307,14 @@ class WhatsAppAdapter(BasePlatformAdapter):
             return bool(configured)
         return os.getenv("WHATSAPP_REQUIRE_MENTION", "false").lower() in {"true", "1", "yes", "on"}
 
+    def _whatsapp_voice_bypass_mention(self) -> bool:
+        configured = self.config.extra.get("voice_bypass_mention")
+        if configured is not None:
+            if isinstance(configured, str):
+                return configured.lower() in {"true", "1", "yes", "on"}
+            return bool(configured)
+        return os.getenv("WHATSAPP_VOICE_BYPASS_MENTION", "false").lower() in {"true", "1", "yes", "on"}
+
     def _whatsapp_free_response_chats(self) -> set[str]:
         raw = self.config.extra.get("free_response_chats")
         if raw is None:
@@ -341,6 +351,14 @@ class WhatsAppAdapter(BasePlatformAdapter):
         if cid.endswith("@broadcast") or cid.endswith("@newsletter"):
             return True
         return False
+
+    @staticmethod
+    def _is_voice_message(data: Dict[str, Any]) -> bool:
+        """True for inbound WhatsApp voice/audio media messages."""
+        if not data.get("hasMedia"):
+            return False
+        media_type = str(data.get("mediaType") or "").strip().lower()
+        return "audio" in media_type or "ptt" in media_type
 
     def _is_dm_allowed(self, sender_id: str) -> bool:
         """Check whether a DM from the given sender should be processed."""
@@ -475,6 +493,8 @@ class WhatsAppAdapter(BasePlatformAdapter):
         if chat_id in self._whatsapp_free_response_chats():
             return True
         if not self._whatsapp_require_mention():
+            return True
+        if self._whatsapp_voice_bypass_mention() and self._is_voice_message(data):
             return True
         body = str(data.get("body") or "").strip()
         if body.startswith("/"):

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1386,6 +1386,7 @@ DEFAULT_CONFIG = {
 
     # WhatsApp platform settings (gateway mode)
     "whatsapp": {
+        "voice_bypass_mention": False,   # If true, group voice messages bypass require_mention after group allowlist checks
         # Reply prefix prepended to every outgoing WhatsApp message.
         # Default (None) uses the built-in "⚕ *Hermes Agent*" header.
         # Set to "" (empty string) to disable the header entirely.

--- a/tests/gateway/test_whatsapp_group_gating.py
+++ b/tests/gateway/test_whatsapp_group_gating.py
@@ -4,7 +4,7 @@ from unittest.mock import AsyncMock
 from gateway.config import Platform, PlatformConfig, load_gateway_config
 
 
-def _make_adapter(require_mention=None, mention_patterns=None, free_response_chats=None,
+def _make_adapter(require_mention=None, mention_patterns=None, voice_bypass_mention=None, free_response_chats=None,
                   dm_policy=None, allow_from=None, group_policy=None, group_allow_from=None):
     from gateway.platforms.whatsapp import WhatsAppAdapter
 
@@ -13,6 +13,8 @@ def _make_adapter(require_mention=None, mention_patterns=None, free_response_cha
         extra["require_mention"] = require_mention
     if mention_patterns is not None:
         extra["mention_patterns"] = mention_patterns
+    if voice_bypass_mention is not None:
+        extra["voice_bypass_mention"] = voice_bypass_mention
     if free_response_chats is not None:
         extra["free_response_chats"] = free_response_chats
     if dm_policy is not None:
@@ -46,6 +48,17 @@ def _group_message(body="hello", **overrides):
         "botIds": ["15551230000@s.whatsapp.net", "15551230000@lid"],
         "quotedParticipant": "",
     }
+    data.update(overrides)
+    return data
+
+
+def _group_voice_message(body="[ptt received]", **overrides):
+    data = _group_message(
+        body=body,
+        hasMedia=True,
+        mediaType="ptt",
+        mediaUrls=["/tmp/voice.ogg"],
+    )
     data.update(overrides)
     return data
 
@@ -105,12 +118,54 @@ def test_invalid_regex_patterns_are_ignored():
     assert adapter._should_process_message(_group_message("hello everyone")) is False
 
 
+def test_voice_messages_do_not_bypass_mention_gating_by_default():
+    adapter = _make_adapter(require_mention=True)
+
+    assert adapter._should_process_message(_group_voice_message()) is False
+
+
+def test_voice_bypass_mention_allows_group_voice_after_group_policy():
+    adapter = _make_adapter(
+        require_mention=True,
+        voice_bypass_mention=True,
+        group_policy="allowlist",
+        group_allow_from=["120363001234567890@g.us"],
+    )
+
+    assert adapter._should_process_message(_group_voice_message()) is True
+
+
+def test_voice_bypass_mention_does_not_open_unlisted_groups():
+    adapter = _make_adapter(
+        require_mention=True,
+        voice_bypass_mention=True,
+        group_policy="allowlist",
+        group_allow_from=["999999999999@g.us"],
+    )
+
+    assert adapter._should_process_message(_group_voice_message()) is False
+
+
+def test_voice_bypass_mention_only_applies_to_voice_media():
+    adapter = _make_adapter(require_mention=True, voice_bypass_mention=True)
+
+    assert adapter._should_process_message(
+        _group_message(
+            body="[image received]",
+            hasMedia=True,
+            mediaType="image",
+            mediaUrls=["/tmp/image.jpg"],
+        )
+    ) is False
+
+
 def test_config_bridges_whatsapp_group_settings(monkeypatch, tmp_path):
     hermes_home = tmp_path / ".hermes"
     hermes_home.mkdir()
     (hermes_home / "config.yaml").write_text(
         "whatsapp:\n"
         "  require_mention: true\n"
+        "  voice_bypass_mention: true\n"
         "  mention_patterns:\n"
         "    - \"^\\\\s*chompy\\\\b\"\n",
         encoding="utf-8",
@@ -119,13 +174,16 @@ def test_config_bridges_whatsapp_group_settings(monkeypatch, tmp_path):
     monkeypatch.setenv("HERMES_HOME", str(hermes_home))
     monkeypatch.delenv("WHATSAPP_REQUIRE_MENTION", raising=False)
     monkeypatch.delenv("WHATSAPP_MENTION_PATTERNS", raising=False)
+    monkeypatch.delenv("WHATSAPP_VOICE_BYPASS_MENTION", raising=False)
 
     config = load_gateway_config()
 
     assert config is not None
     assert config.platforms[Platform.WHATSAPP].extra["require_mention"] is True
+    assert config.platforms[Platform.WHATSAPP].extra["voice_bypass_mention"] is True
     assert config.platforms[Platform.WHATSAPP].extra["mention_patterns"] == [r"^\s*chompy\b"]
     assert __import__("os").environ["WHATSAPP_REQUIRE_MENTION"] == "true"
+    assert __import__("os").environ["WHATSAPP_VOICE_BYPASS_MENTION"] == "true"
     assert json.loads(__import__("os").environ["WHATSAPP_MENTION_PATTERNS"]) == [r"^\s*chompy\b"]
 
 

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -300,6 +300,7 @@ For cloud sandbox backends, persistence is filesystem-oriented. `TERMINAL_LIFETI
 | `WHATSAPP_MODE` | `bot` (separate number) or `self-chat` (message yourself) |
 | `WHATSAPP_ALLOWED_USERS` | Comma-separated phone numbers (with country code, no `+`), or `*` to allow all senders |
 | `WHATSAPP_ALLOW_ALL_USERS` | Allow all WhatsApp senders without an allowlist (`true`/`false`) |
+| `WHATSAPP_VOICE_BYPASS_MENTION` | Process WhatsApp group voice/audio messages that pass group policy even when `WHATSAPP_REQUIRE_MENTION=true` |
 | `WHATSAPP_DEBUG` | Log raw message events in the bridge for troubleshooting (`true`/`false`) |
 | `SIGNAL_HTTP_URL` | signal-cli daemon HTTP endpoint (for example `http://127.0.0.1:8080`) |
 | `SIGNAL_ACCOUNT` | Bot phone number in E.164 format |

--- a/website/docs/user-guide/messaging/whatsapp.md
+++ b/website/docs/user-guide/messaging/whatsapp.md
@@ -115,10 +115,17 @@ unauthorized_dm_behavior: pair
 
 whatsapp:
   unauthorized_dm_behavior: ignore
+  require_mention: true
+  mention_patterns:
+    - "(^|\\W)@?hermes(\\W|$)"
+  voice_bypass_mention: true
 ```
 
 - `unauthorized_dm_behavior: pair` is the global default. Unknown DM senders get a pairing code.
 - `whatsapp.unauthorized_dm_behavior: ignore` makes WhatsApp stay silent for unauthorized DMs, which is usually the better choice for a private number.
+- `whatsapp.require_mention: true` keeps group chats quiet unless the message explicitly addresses Hermes.
+- `whatsapp.mention_patterns` accepts regex wake words for group messages, for example `hey hermes`.
+- `whatsapp.voice_bypass_mention: true` lets group voice notes that pass the group policy reach Hermes even when the transcript does not include the wake word.
 
 Then start the gateway:
 


### PR DESCRIPTION
## Goal

Make WhatsApp group voice notes usable in mention-gated groups without requiring the spoken transcript to include the bot wake word.

## What Changed

- Added `whatsapp.voice_bypass_mention` / `WHATSAPP_VOICE_BYPASS_MENTION`.
- When enabled, WhatsApp group voice/audio media messages bypass the `require_mention` text gate only after broadcast filtering and group policy checks have already passed.
- Left default behavior unchanged: the new option defaults to `false`.
- Added regression coverage for the default blocked behavior, the enabled bypass, group allowlist enforcement, and non-voice media staying gated.
- Documented the config key in the WhatsApp guide and env-var reference.

## Why

Captionless WhatsApp voice notes are bridged as media with placeholder text such as `[ptt received]`. In groups with `require_mention: true`, that placeholder cannot match a wake word, so legitimate voice notes are dropped before they become `MessageType.VOICE` events and before STT can help. Some private/group assistant setups intentionally treat voice notes as directed at the bot while keeping ordinary text mention-gated.

## Verification

- `uv sync --native-tls --extra dev --extra messaging`
- `.venv\Scripts\python.exe scripts\run_tests_parallel.py tests\gateway\test_whatsapp_group_gating.py -j 1 -- --timeout-method=thread`
  - Result: `30 tests passed, 0 failed`
- `.venv\Scripts\ruff.exe check gateway\platforms\whatsapp.py gateway\config.py hermes_cli\config.py tests\gateway\test_whatsapp_group_gating.py`
  - Result: `All checks passed!`
- `git diff --check`
  - Result: no whitespace errors

## Not Verified

- Full suite was not run locally. This session ran on Windows where the repo's canonical Bash wrapper was unavailable, so I ran the underlying per-file runner for the focused WhatsApp test file with the Windows-compatible pytest timeout method.
- No live WhatsApp bridge E2E was run from this checkout.

## Residual Risks

- This is intentionally opt-in to avoid changing existing group behavior.
- The bypass relies on bridge events marking voice notes with `hasMedia` and `mediaType` containing `audio` or `ptt`, which matches the current Baileys bridge.
- Review focus: naming of the config key and whether maintainers prefer a broader per-media gating option.

## Clean State

- Branch: `codex/whatsapp-voice-bypass-mention`
- Commit: `462163f5f feat(whatsapp): allow voice notes to bypass mention gate`