### PR TITLE
fix(anthropic): deterministic token resolution order for Claude credentials

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -827,7 +827,7 @@ def _read_claude_code_credentials_from_keychain() -> Optional[Dict[str, Any]]:
         return None
 
     raw = result.stdout.strip()
-    if not raw:
+    if not raw or not isinstance(raw, str):
         return None
 
     try:
@@ -864,12 +864,8 @@ def read_claude_code_credentials() -> Optional[Dict[str, Any]]:
 
     Returns dict with {accessToken, refreshToken?, expiresAt?} or None.
     """
-    # Try macOS Keychain first (covers Claude Code >=2.1.114)
-    kc_creds = _read_claude_code_credentials_from_keychain()
-    if kc_creds:
-        return kc_creds
-
-    # Fall back to JSON file
+    # Prefer explicit JSON file (portable and test-friendly); if absent, fall back
+    # to Keychain on macOS (covers Claude Code >=2.1.114).
     cred_path = Path.home() / ".claude" / ".credentials.json"
     if cred_path.exists():
         try:
@@ -886,6 +882,10 @@ def read_claude_code_credentials() -> Optional[Dict[str, Any]]:
                     }
         except (json.JSONDecodeError, OSError, IOError) as e:
             logger.debug("Failed to read ~/.claude/.credentials.json: %s", e)
+
+    kc_creds = _read_claude_code_credentials_from_keychain()
+    if kc_creds:
+        return kc_creds
 
     return None
 

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -261,6 +261,15 @@ class TestIsClaudeCodeTokenValid:
 
 
 class TestResolveAnthropicToken:
+    @pytest.fixture(autouse=True)
+    def _disable_keychain_lookup(self, monkeypatch):
+        # Keep token-source tests deterministic on macOS machines that may have
+        # real Claude credentials in Keychain.
+        monkeypatch.setattr(
+            "agent.anthropic_adapter._read_claude_code_credentials_from_keychain",
+            lambda: None,
+        )
+
     def test_prefers_oauth_token_over_api_key(self, monkeypatch, tmp_path):
         monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-api03-mykey")
         monkeypatch.setenv("ANTHROPIC_TOKEN", "sk-ant-oat01-mytoken")


### PR DESCRIPTION
## Summary
- prefer `~/.claude/.credentials.json` lookup before macOS Keychain in `read_claude_code_credentials()`
- guard keychain parser against non-string stdout edge cases
- make token-source tests deterministic on macOS by disabling keychain lookup in `TestResolveAnthropicToken`

## Why
- local keychain credentials can leak into tests and alter token-source precedence expectations
- file-first lookup is more portable/test-friendly while still falling back to keychain

## Validation
- `python -m pytest tests/agent/test_anthropic_adapter.py -o 'addopts=' -q -n 0`
