### PR TITLE
docs(curator): rewrite 'agent-created' definition for post-#19621 beh…

### DIFF
--- a/website/docs/user-guide/features/curator.md
+++ b/website/docs/user-guide/features/curator.md
@@ -130,28 +130,26 @@ The same subcommands are available as the `/curator` slash command inside a runn
 
 ## What "agent-created" means
 
-A skill is considered agent-created if its name is **not** in:
+A skill is considered agent-created when **all three** of the following hold:
 
-- `~/.hermes/skills/.bundled_manifest` (skills copied from the repo on install), and
-- `~/.hermes/skills/.hub/lock.json` (skills installed via `hermes skills install`).
+- its name is **not** in `~/.hermes/skills/.bundled_manifest` (skills copied from the repo on install),
+- its name is **not** in `~/.hermes/skills/.hub/lock.json` (skills installed via `hermes skills install`), and
+- its `.usage.json` carries the marker `"created_by": "agent"` (or the equivalent legacy `"agent_created": true`).
 
-Everything else in `~/.hermes/skills/` is fair game for the curator. This includes:
+The marker is set by the **background self-improvement review fork** when it sediments a skill through `skill_manage`. Skills you ask a foreground agent to write via `skill_manage(action="create")` during a normal conversation do **not** receive the marker and stay invisible to the curator.
 
-- Skills the agent saved via `skill_manage(action="create")` during a conversation.
-- Skills you created manually with a hand-written `SKILL.md`.
-- Skills added via external skill directories you've pointed Hermes at.
+In short:
 
-:::warning Your hand-written skills look the same as agent-saved ones
-Provenance here is **binary** (bundled/hub vs. everything else). The curator cannot tell a hand-authored skill you rely on for private workflows apart from a skill the self-improvement loop saved mid-session. Both land in the "agent-created" bucket.
+| How the skill was created | Marker set? | Visible to curator |
+|---|---|---|
+| Bundled / installed from Hub | No | No (excluded by manifest/lock) |
+| Hand-written `SKILL.md` | No | No |
+| Foreground `skill_manage(action="create")` | No | No |
+| Background self-improvement review | Yes | Yes |
 
-Before the first real pass (7 days after installation by default), take a moment to:
+So the curator only manages skills produced by the background review loop. If `hermes curator status` reports zero agent-created skills despite skills you saved in foreground sessions, that is expected — those skills don't carry the `created_by=agent` marker.
 
-1. Run `hermes curator run --dry-run` to see exactly what the curator would propose.
-2. Use `hermes curator pin <name>` to fence off anything you don't want touched.
-3. Or set `curator.enabled: false` in `config.yaml` if you'd rather manage the library yourself.
-
-Archives are always recoverable via `hermes curator restore <name>`, but it's easier to pin up-front than to chase down a consolidation after the fact.
-:::
+When there are no eligible candidates, the curator's run summary shows `Model: (not resolved) via (not resolved)` and `Duration: 0s`. That isn't a configuration error; it means the LLM pass was skipped because the candidate set was empty.
 
 If you want to protect a specific skill from ever being touched — for example a hand-authored skill you rely on — use `hermes curator pin <name>`. See the next section.
 


### PR DESCRIPTION
…avior

PR #19621 restricted the 'created_by=agent' marker to the background self-improvement review fork. Foreground 'skill_manage(action="create")' calls no longer mark the skill as agent-created, so the curator's candidate set now follows a 3-condition rule, not 2:

  1. not in .bundled_manifest
  2. not in .hub/lock.json
  3. .usage.json has 'created_by': 'agent' (or legacy 'agent_created': true)

Update the section to reflect the new behavior, add a quick-reference table contrasting creation paths, and document the '(not resolved)' run-summary text users see when the candidate set is empty.

Refs #29017

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

