### PR TITLE
feat: add Telegram inbox auto-topic routing

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -1014,6 +1014,12 @@ def load_gateway_config() -> GatewayConfig:
                         "disable_topic_auto_rename",
                         telegram_cfg["disable_topic_auto_rename"],
                     )
+                # Bridge custom Telegram runtime-only settings into
+                # gateway.platforms.telegram.extra so the adapter can read them.
+                if "inbox_auto_topic" in telegram_cfg:
+                    _tg_plat = platforms_data.setdefault(Platform.TELEGRAM.value, {})
+                    _tg_extra = _tg_plat.setdefault("extra", {})
+                    _tg_extra.setdefault("inbox_auto_topic", telegram_cfg["inbox_auto_topic"])
                 # Prefer telegram.require_mention; fall back to the top-level shorthand.
                 _effective_rm = telegram_cfg.get("require_mention", yaml_cfg.get("require_mention"))
                 if _effective_rm is not None and not os.getenv("TELEGRAM_REQUIRE_MENTION"):

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -4466,6 +4466,98 @@ class TelegramAdapter(BasePlatformAdapter):
         cleaned = re.sub(rf"(?i)@{username}\b[,:\-]*\s*", "", text).strip()
         return cleaned or text
 
+    def _inbox_auto_topic_config(self) -> Dict[str, Any]:
+        """Return Telegram forum Inbox auto-topic routing config."""
+        raw = self.config.extra.get("inbox_auto_topic") or {}
+        return raw if isinstance(raw, dict) else {}
+
+    def _is_inbox_auto_topic_message(self, message) -> bool:
+        """True when a group/forum message should spawn a fresh work topic."""
+        cfg = self._inbox_auto_topic_config()
+        if not cfg.get("enabled", False):
+            return False
+        chat = getattr(message, "chat", None)
+        if not chat or not getattr(chat, "is_forum", False):
+            return False
+        configured_chat_id = cfg.get("chat_id")
+        if configured_chat_id is not None and str(configured_chat_id) != str(getattr(chat, "id", "")):
+            return False
+        source_thread_id = str(cfg.get("source_thread_id", self._GENERAL_TOPIC_THREAD_ID))
+        thread_id = getattr(message, "message_thread_id", None)
+        message_thread_id = str(thread_id) if thread_id is not None else self._GENERAL_TOPIC_THREAD_ID
+        return message_thread_id == source_thread_id
+
+    def _title_for_inbox_auto_topic(self, text: str, message_id: Optional[int] = None) -> str:
+        """Derive a compact Telegram topic name from the user's Inbox request."""
+        cfg = self._inbox_auto_topic_config()
+        prefix = str(cfg.get("topic_prefix", "")).strip()
+        # Collapse markdown/code punctuation to keep the topic list readable.
+        title = re.sub(r"\s+", " ", (text or "").strip())
+        title = re.sub(r"[`*_~#>\[\](){}|]", "", title).strip(" -–—:;,.!?\t\n")
+        if not title:
+            title = f"Request {message_id}" if message_id is not None else "New request"
+        max_len = int(cfg.get("max_title_length", 80) or 80)
+        max_len = max(16, min(max_len, 128))
+        reserved = len(prefix) + (1 if prefix else 0)
+        title = title[: max_len - reserved].rstrip()
+        return f"{prefix} {title}".strip()[:128] or "New request"
+
+    async def _create_inbox_auto_topic(self, message) -> Optional[int]:
+        """Create a fresh Telegram forum topic for an Inbox request."""
+        if not self._bot:
+            return None
+        chat = getattr(message, "chat", None)
+        if not chat:
+            return None
+        title = self._title_for_inbox_auto_topic(getattr(message, "text", ""), getattr(message, "message_id", None))
+        cfg = self._inbox_auto_topic_config()
+        kwargs: Dict[str, Any] = {"chat_id": int(chat.id), "name": title}
+        if cfg.get("icon_color") is not None:
+            kwargs["icon_color"] = cfg.get("icon_color")
+        if cfg.get("icon_custom_emoji_id"):
+            kwargs["icon_custom_emoji_id"] = cfg.get("icon_custom_emoji_id")
+        try:
+            topic = await self._bot.create_forum_topic(**kwargs)
+        except Exception as first_err:
+            # Telegram rejects duplicate topic names. Retry once with the source
+            # message id so two similar Inbox requests still get distinct lanes.
+            if "topic_name_duplicate" not in str(first_err).lower():
+                logger.warning("[%s] Inbox auto-topic creation failed: %s", self.name, first_err)
+                return None
+            suffix = f" #{getattr(message, 'message_id', '')}"
+            kwargs["name"] = (title[: max(1, 128 - len(suffix))].rstrip() + suffix)[:128]
+            try:
+                topic = await self._bot.create_forum_topic(**kwargs)
+            except Exception as second_err:
+                logger.warning("[%s] Inbox auto-topic duplicate retry failed: %s", self.name, second_err)
+                return None
+        thread_id = getattr(topic, "message_thread_id", None)
+        logger.info(
+            "[%s] Inbox auto-topic created in chat %s: %s -> thread_id=%s",
+            self.name,
+            getattr(chat, "id", None),
+            kwargs.get("name"),
+            thread_id,
+        )
+        return int(thread_id) if thread_id is not None else None
+
+    async def _route_inbox_message_to_new_topic(self, event: MessageEvent) -> MessageEvent:
+        """Rewrite an Inbox MessageEvent so the agent works in a new topic."""
+        message = event.raw_message
+        if not message or not self._is_inbox_auto_topic_message(message):
+            return event
+        new_thread_id = await self._create_inbox_auto_topic(message)
+        if not new_thread_id:
+            return event
+        event.source.thread_id = str(new_thread_id)
+        event.source.chat_topic = self._title_for_inbox_auto_topic(
+            getattr(message, "text", ""), getattr(message, "message_id", None)
+        )
+        # Do not reply to the Inbox message itself; topic metadata is enough for
+        # Telegram forum routing and keeps the response inside the new topic.
+        event.reply_to_message_id = None
+        return event
+
     def _should_process_message(self, message: Message, *, is_command: bool = False) -> bool:
         """Apply Telegram group trigger rules.
 
@@ -4595,6 +4687,7 @@ class TelegramAdapter(BasePlatformAdapter):
 
         event = self._build_message_event(msg, MessageType.TEXT, update_id=update.update_id)
         event.text = self._clean_bot_trigger_text(event.text)
+        event = await self._route_inbox_message_to_new_topic(event)
         self._enqueue_text_event(event)
 
     async def _handle_command(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -454,6 +454,31 @@ class TestLoadGatewayConfig:
             "789": "Creative writing",
         }
 
+    def test_bridges_telegram_inbox_auto_topic_from_config_yaml(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "telegram:\n"
+            "  inbox_auto_topic:\n"
+            "    enabled: true\n"
+            "    chat_id: -1001234567\n"
+            "    source_thread_id: 1\n"
+            "    topic_prefix: cw\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        config = load_gateway_config()
+
+        assert config.platforms[Platform.TELEGRAM].extra["inbox_auto_topic"] == {
+            "enabled": True,
+            "chat_id": -1001234567,
+            "source_thread_id": 1,
+            "topic_prefix": "cw",
+        }
+
     def test_bridges_slack_channel_prompts_from_config_yaml(self, tmp_path, monkeypatch):
         hermes_home = tmp_path / ".hermes"
         hermes_home.mkdir()

--- a/tests/gateway/test_telegram_inbox_auto_topic.py
+++ b/tests/gateway/test_telegram_inbox_auto_topic.py
@@ -1,0 +1,113 @@
+"""Tests for Telegram Inbox auto-topic routing."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import MessageEvent, MessageType, SessionSource
+from gateway.platforms.telegram import TelegramAdapter
+
+
+class FakeBot:
+    username = "hermesbot"
+
+    def __init__(self, *, thread_id=777, fail_first=None):
+        self.calls = []
+        self.thread_id = thread_id
+        self.fail_first = fail_first
+
+    async def create_forum_topic(self, **kwargs):
+        self.calls.append(kwargs)
+        if self.fail_first and len(self.calls) == 1:
+            raise self.fail_first
+        return SimpleNamespace(message_thread_id=self.thread_id)
+
+
+def _make_adapter(extra):
+    adapter = TelegramAdapter(
+        PlatformConfig(enabled=True, token="test-token", extra={"inbox_auto_topic": extra})
+    )
+    bot = FakeBot()
+    adapter._bot = bot
+    return adapter, bot
+
+
+def _make_message(*, chat_id=-100123, thread_id=None, text="**Fix prod login?**", is_forum=True):
+    return SimpleNamespace(
+        chat=SimpleNamespace(id=chat_id, is_forum=is_forum),
+        message_thread_id=thread_id,
+        message_id=42,
+        text=text,
+    )
+
+
+def _make_event(message):
+    thread_id = str(message.message_thread_id) if message.message_thread_id is not None else "1"
+    return MessageEvent(
+        text=message.text,
+        message_type=MessageType.TEXT,
+        source=SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id=str(message.chat.id),
+            chat_type="group",
+            thread_id=thread_id,
+        ),
+        raw_message=message,
+        reply_to_message_id=str(message.message_id),
+    )
+
+
+@pytest.mark.asyncio
+async def test_inbox_auto_topic_routes_general_forum_message_to_new_topic():
+    adapter, bot = _make_adapter(
+        {
+            "enabled": True,
+            "chat_id": -100123,
+            "source_thread_id": "1",
+            "topic_prefix": "cw",
+        }
+    )
+    message = _make_message()
+    event = _make_event(message)
+
+    routed = await adapter._route_inbox_message_to_new_topic(event)
+
+    assert routed.source.thread_id == "777"
+    assert routed.source.chat_topic == "cw Fix prod login"
+    assert routed.reply_to_message_id is None
+    assert bot.calls == [{"chat_id": -100123, "name": "cw Fix prod login"}]
+
+
+@pytest.mark.asyncio
+async def test_inbox_auto_topic_ignores_non_source_topic():
+    adapter, bot = _make_adapter(
+        {"enabled": True, "chat_id": -100123, "source_thread_id": "1"}
+    )
+    message = _make_message(thread_id=99)
+    event = _make_event(message)
+
+    routed = await adapter._route_inbox_message_to_new_topic(event)
+
+    assert routed is event
+    assert routed.source.thread_id == "99"
+    assert bot.calls == []
+
+
+@pytest.mark.asyncio
+async def test_inbox_auto_topic_retries_duplicate_topic_name_with_message_id_suffix():
+    adapter, _bot = _make_adapter(
+        {"enabled": True, "chat_id": -100123, "source_thread_id": "1"}
+    )
+    duplicate_retry_bot = FakeBot(fail_first=Exception("Bad Request: TOPIC_NAME_DUPLICATE"))
+    adapter._bot = duplicate_retry_bot
+    message = _make_message(text="Repeated request")
+    event = _make_event(message)
+
+    routed = await adapter._route_inbox_message_to_new_topic(event)
+
+    assert routed.source.thread_id == "777"
+    assert duplicate_retry_bot.calls == [
+        {"chat_id": -100123, "name": "Repeated request"},
+        {"chat_id": -100123, "name": "Repeated request #42"},
+    ]


### PR DESCRIPTION
## Summary
- bridge `telegram.inbox_auto_topic` config into Telegram adapter runtime extras
- create a fresh Telegram forum topic for configured Inbox/source-topic messages
- route the resulting agent response into the new topic and handle duplicate topic names
- add config and routing regression tests

## Test Plan
- `python -m py_compile gateway/config.py gateway/platforms/telegram.py tests/gateway/test_telegram_inbox_auto_topic.py tests/gateway/test_config.py`
- `pytest -q -n 0 tests/gateway/test_config.py tests/gateway/test_telegram_topic_mode.py tests/gateway/test_telegram_group_gating.py tests/gateway/test_telegram_text_batching.py tests/gateway/test_telegram_inbox_auto_topic.py` — 125 passed
- `pytest -q -n 2 tests/gateway/test_config.py tests/gateway/test_telegram_topic_mode.py tests/gateway/test_telegram_group_gating.py tests/gateway/test_telegram_text_batching.py tests/gateway/test_telegram_inbox_auto_topic.py` — 125 passed
