### PR TITLE
fix(api_server): auto-activate agente-desktop toolset + add 10 missing client/workflow tools

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -831,6 +831,13 @@ class APIServerAdapter(BasePlatformAdapter):
         user_config = _load_gateway_config()
         enabled_toolsets = sorted(_get_platform_tools(user_config, "api_server"))
 
+        # Auto-activate the agente-desktop toolset when Electron IPC env vars are present.
+        # This matches the existing plugin activation contract documented in
+        # plugins/agente_desktop/__init__.py.
+        if os.environ.get("AGENTE_TOOL_PORT") and os.environ.get("AGENTE_TOOL_SECRET"):
+            if "agente-desktop" not in enabled_toolsets:
+                enabled_toolsets = sorted(set(enabled_toolsets) | {"agente-desktop"})
+
         max_iterations = int(os.getenv("HERMES_MAX_ITERATIONS", "90"))
 
         # Load fallback provider chain so the API server platform has the

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -12273,8 +12273,13 @@ class GatewayRunner:
         import json
         import shutil
         import subprocess
+        import sys
         from datetime import datetime
         from hermes_cli.config import is_managed, format_managed_message
+
+        if sys.platform == "win32":
+            logger.warning("Hermes self-update is not supported on Windows; install/upgrade via the bundled Agente Desktop installer.")
+            return "✗ Self-update is not supported on Windows. Use the Agente Desktop installer to upgrade."
 
         # Block non-messaging platforms (API server, webhooks, ACP)
         platform = event.source.platform

--- a/gateway/status.py
+++ b/gateway/status.py
@@ -110,6 +110,12 @@ def _get_scope_lock_path(scope: str, identity: str) -> Path:
 
 def _get_process_start_time(pid: int) -> Optional[int]:
     """Return the kernel start time for a process when available."""
+    if sys.platform == "win32":
+        try:
+            os.kill(pid, 0)
+            return True  # process exists; we can't get its start_time on Windows without psutil
+        except OSError:
+            return None
     stat_path = Path(f"/proc/{pid}/stat")
     try:
         # Field 22 in /proc/<pid>/stat is process start time (clock ticks).
@@ -125,6 +131,8 @@ def get_process_start_time(pid: int) -> Optional[int]:
 
 def _read_process_cmdline(pid: int) -> Optional[str]:
     """Return the process command line as a space-separated string."""
+    if sys.platform == "win32":
+        return None
     cmdline_path = Path(f"/proc/{pid}/cmdline")
     try:
         raw = cmdline_path.read_bytes()

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -1234,9 +1234,17 @@ def _windows_gateway_should_absorb_console_controls() -> bool:
     PowerShell/CMD. Detached service-style launches opt in via
     ``HERMES_GATEWAY_DETACHED=1``; older wrappers without the env marker are
     treated as detached when no interactive stdin is attached.
+
+    ``HERMES_FORCE_ABSORB_CONSOLE=1`` is an unconditional override used by
+    Electron sidecar spawns where neither env var propagation nor stdio
+    detection can be trusted (Windows venv stub re-exec quirks).
     """
     if not is_windows():
         return False
+
+    force = os.getenv("HERMES_FORCE_ABSORB_CONSOLE", "").strip().lower()
+    if force in {"1", "true", "yes", "on"}:
+        return True
 
     detached = os.getenv("HERMES_GATEWAY_DETACHED", "").strip().lower()
     if detached in {"1", "true", "yes", "on"}:
@@ -3227,6 +3235,10 @@ def run_gateway(verbose: int = 0, quiet: bool = False, replace: bool = False):
         argv=sys.argv,
         stdin_is_tty=_stdin_is_tty,
         absorb_windows_console_controls=_absorb_windows_console_controls,
+        env_hermes_gateway_detached=os.environ.get("HERMES_GATEWAY_DETACHED", ""),
+        env_hermes_force_absorb_console=os.environ.get("HERMES_FORCE_ABSORB_CONSOLE", ""),
+        sys_executable=sys.executable,
+        sys_prefix=sys.prefix,
     )
 
     def _atexit_hook() -> None:

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -1393,7 +1393,9 @@ def _ensure_user_systemd_env() -> None:
     We detect the standard socket path and set the vars so all subsequent
     subprocess calls inherit them.
     """
-    uid = os.getuid()  # windows-footgun: ok — POSIX systemd helper, never invoked on Windows
+    if sys.platform == "win32":
+        return  # systemd-style user services are POSIX-only; on Windows we will use a different service-install path
+    uid = os.getuid()
     if "XDG_RUNTIME_DIR" not in os.environ:
         runtime_dir = f"/run/user/{uid}"
         if Path(runtime_dir).exists():
@@ -1776,7 +1778,9 @@ def print_systemd_scope_conflict_warning() -> None:
 
 
 def _require_root_for_system_service(action: str) -> None:
-    if os.geteuid() != 0:  # windows-footgun: ok — POSIX systemd helper, never invoked on Windows
+    if sys.platform == "win32":
+        return  # systemd-style user services are POSIX-only; on Windows we will use a different service-install path
+    if os.geteuid() != 0:
         raise SystemScopeRequiresRootError(
             f"System gateway {action} requires root. Re-run with sudo.",
             action,
@@ -1838,6 +1842,8 @@ def prompt_linux_gateway_install_scope() -> str | None:
 
 
 def install_linux_gateway_from_setup(force: bool = False) -> tuple[str | None, bool]:
+    if sys.platform == "win32":
+        return  # systemd-style user services are POSIX-only; on Windows we will use a different service-install path
     scope = prompt_linux_gateway_install_scope()
     if scope is None:
         return None, False

--- a/plugins/agente_desktop/__init__.py
+++ b/plugins/agente_desktop/__init__.py
@@ -1,0 +1,151 @@
+"""agente_desktop plugin — bridge from the Hermes Gateway to the Agente
+desktop Electron main process.
+
+Registers 8 tools under the ``agente-desktop`` toolset. Each tool's handler
+proxies the call to an HTTP server inside the Electron main, which dispatches
+the request to the matching TypeScript tool in ``electron/main/hermes-tools/``.
+
+Activation contract: the Electron sidecar manager spawns Hermes with the env
+vars ``AGENTE_TOOL_PORT`` (ephemeral loopback port) and ``AGENTE_TOOL_SECRET``
+(32-byte hex bearer token). When both are present the plugin is "available";
+when either is missing the tools are still registered but the check_fn
+returns False, so the AIAgent simply omits them from the LLM tool schema.
+
+IPC contract:
+
+    POST http://127.0.0.1:${AGENTE_TOOL_PORT}/dispatch/${tool_name}
+    Authorization: Bearer ${AGENTE_TOOL_SECRET}
+    Content-Type: application/json
+    body: {...tool_args}
+
+    200 → {"ok": true, "result": <tool-specific-json>}
+    200 → {"ok": false, "error": "<string>", "details": <optional>}
+    401 → {"ok": false, "error": "unauthorized"}
+
+The Python wrapper unwraps `result` (or surfaces `error`) so the model sees
+the tool's native return shape.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import urllib.error
+import urllib.request
+from typing import Any
+
+from plugins.agente_desktop.schemas import TOOL_SCHEMAS
+
+logger = logging.getLogger(__name__)
+
+TOOLSET = "agente-desktop"
+_REQUEST_TIMEOUT_SECONDS = 25
+
+_TOOL_EMOJIS: dict[str, str] = {
+    "list_whatsapp_accounts": "📱",
+    "list_recent_messages": "💬",
+    "create_ticket": "🎫",
+    "move_ticket": "🔄",
+    "list_tickets": "📋",
+    "save_triage_instructions": "📝",
+    "request_approval": "✋",
+    "get_office_context": "🏢",
+}
+
+
+def _ipc_endpoint(tool_name: str) -> str | None:
+    port = os.environ.get("AGENTE_TOOL_PORT")
+    if not port:
+        return None
+    return f"http://127.0.0.1:{port}/dispatch/{tool_name}"
+
+
+def _proxy_call(tool_name: str, args: dict[str, Any]) -> dict[str, Any]:
+    """Forward a tool call to the Electron main process over loopback HTTP.
+
+    Returns the unwrapped ``result`` payload on success or an ``{"error":
+    ...}`` dict on any failure. Never raises — every path returns a dict so
+    the AIAgent can fold the response into the next conversation turn.
+    """
+    endpoint = _ipc_endpoint(tool_name)
+    secret = os.environ.get("AGENTE_TOOL_SECRET")
+    if endpoint is None or not secret:
+        return {"error": "agente_tool_ipc_not_configured"}
+
+    request = urllib.request.Request(
+        endpoint,
+        data=json.dumps(args).encode("utf-8"),
+        headers={
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {secret}",
+        },
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=_REQUEST_TIMEOUT_SECONDS) as response:
+            body = response.read().decode("utf-8")
+    except urllib.error.HTTPError as exc:
+        return {
+            "error": "agente_tool_http_error",
+            "status": exc.code,
+            "body": exc.read().decode("utf-8", "replace"),
+        }
+    except Exception as exc:  # noqa: BLE001 — defensive; never raise from a tool handler
+        return {"error": "agente_tool_exception", "message": str(exc)}
+
+    try:
+        envelope = json.loads(body)
+    except json.JSONDecodeError:
+        return {"error": "agente_tool_invalid_json", "raw": body[:512]}
+
+    if not isinstance(envelope, dict):
+        return {"error": "agente_tool_invalid_envelope", "raw": body[:512]}
+
+    if envelope.get("ok") is True:
+        result = envelope.get("result")
+        return result if isinstance(result, dict) else {"result": result}
+
+    return {
+        "error": envelope.get("error", "agente_tool_unknown_error"),
+        "details": envelope.get("details"),
+    }
+
+
+def _check_available() -> bool:
+    return bool(os.environ.get("AGENTE_TOOL_PORT") and os.environ.get("AGENTE_TOOL_SECRET"))
+
+
+def _make_handler(tool_name: str):
+    """Bind the tool name into a closure so each registered handler has its
+    own dispatch target. Avoids the late-binding-loop pitfall.
+    """
+
+    def handler(args: dict[str, Any]) -> dict[str, Any]:
+        return _proxy_call(tool_name, args)
+
+    return handler
+
+
+def register(ctx) -> None:
+    """Register the 8 Agente desktop tools.
+
+    Called once by the plugin loader when the plugin is enabled via
+    ``plugins.enabled`` in config.yaml AND the ``agente-desktop`` toolset is
+    listed under ``toolsets:``.
+    """
+    for tool_name, schema in TOOL_SCHEMAS.items():
+        ctx.register_tool(
+            name=tool_name,
+            toolset=TOOLSET,
+            schema=schema,
+            handler=_make_handler(tool_name),
+            check_fn=_check_available,
+            description=schema.get("description", ""),
+            emoji=_TOOL_EMOJIS.get(tool_name, "🔌"),
+        )
+    logger.info(
+        "agente_desktop plugin registered %d tools under toolset %r",
+        len(TOOL_SCHEMAS),
+        TOOLSET,
+    )

--- a/plugins/agente_desktop/__init__.py
+++ b/plugins/agente_desktop/__init__.py
@@ -51,6 +51,18 @@ _TOOL_EMOJIS: dict[str, str] = {
     "save_triage_instructions": "📝",
     "request_approval": "✋",
     "get_office_context": "🏢",
+    # desktop-202605-161 additions
+    "upsert_client": "👤",
+    "query_client": "🔍",
+    "link_ticket_to_client": "🔗",
+    "link_document_to_client": "📎",
+    "update_office_context": "🏢",
+    "list_tools": "🛠️",
+    "list_workflows": "📂",
+    "inspect_workflow": "🔬",
+    "start_workflow_run": "▶️",
+    "get_run_status": "📊",
+    "resume_paused_run": "⏯️",
 }
 
 
@@ -128,11 +140,13 @@ def _make_handler(tool_name: str):
 
 
 def register(ctx) -> None:
-    """Register the 8 Agente desktop tools.
+    """Register the 18 Agente desktop tools.
 
     Called once by the plugin loader when the plugin is enabled via
     ``plugins.enabled`` in config.yaml AND the ``agente-desktop`` toolset is
-    listed under ``toolsets:``.
+    listed under ``toolsets:``. The toolset is auto-activated at runtime when
+    AGENTE_TOOL_PORT + AGENTE_TOOL_SECRET env vars are present (see
+    gateway/platforms/api_server.py ``_create_agent``).
     """
     for tool_name, schema in TOOL_SCHEMAS.items():
         ctx.register_tool(

--- a/plugins/agente_desktop/plugin.yaml
+++ b/plugins/agente_desktop/plugin.yaml
@@ -1,0 +1,18 @@
+name: agente_desktop
+version: 0.1.0
+description: "Bridge to the Agente desktop Electron process — exposes 8 tools (ticket CRUD, WhatsApp account/message listing, triage instructions, office context, approval requests) by proxying calls over loopback HTTP to the agente-desktop main process. Activated when the sidecar is spawned with AGENTE_TOOL_PORT and AGENTE_TOOL_SECRET env vars."
+author: agente.dev
+kind: standalone
+platforms:
+  - linux
+  - macos
+  - windows
+provides_tools:
+  - list_whatsapp_accounts
+  - list_recent_messages
+  - create_ticket
+  - move_ticket
+  - list_tickets
+  - save_triage_instructions
+  - request_approval
+  - get_office_context

--- a/plugins/agente_desktop/schemas.py
+++ b/plugins/agente_desktop/schemas.py
@@ -1,0 +1,184 @@
+"""OpenAI function-schema definitions for the 8 Agente desktop tools.
+
+Mirrors `electron/main/hermes-tools/*.ts` in agente-dev/agente-desktop. Keep in
+sync: a desktop-side regression test compares this dict against the TS source.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+TOOL_SCHEMAS: dict[str, dict[str, Any]] = {
+    "list_whatsapp_accounts": {
+        "name": "list_whatsapp_accounts",
+        "description": (
+            "Returns the list of paired WhatsApp accounts (connectors) configured "
+            "in the workspace, including account ID, label, phone number, "
+            "governance lane, and current GOWA connection status."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {},
+            "required": [],
+        },
+    },
+    "list_recent_messages": {
+        "name": "list_recent_messages",
+        "description": (
+            "Returns recent WhatsApp messages for a given account. Use this to "
+            "summarize incoming messages and decide if any need a ticket created."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "account_id": {
+                    "type": "string",
+                    "description": "The WhatsApp account/connector ID from list_whatsapp_accounts.",
+                },
+                "limit": {
+                    "type": "integer",
+                    "description": "Maximum number of chats to return (default 5, max 10).",
+                    "default": 5,
+                },
+            },
+            "required": ["account_id"],
+        },
+    },
+    "create_ticket": {
+        "name": "create_ticket",
+        "description": (
+            'Creates a new ticket in the office board. Status defaults to '
+            '"חדש" (pending). Use source="whatsapp" and source_id=<message_id> '
+            "when creating from a WhatsApp message."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "title": {"type": "string", "description": "Ticket title (preferably in Hebrew)."},
+                "body": {"type": "string", "description": "Optional detailed description."},
+                "status": {
+                    "type": "string",
+                    "description": 'Status: "חדש" (default), "בטיפול", "ממתין לאישור", "done".',
+                    "default": "חדש",
+                },
+                "assignee": {
+                    "type": "string",
+                    "description": "Optional agent slug or name to assign the ticket to.",
+                },
+                "source": {
+                    "type": "string",
+                    "description": 'Source of the ticket, e.g. "whatsapp" or "manual".',
+                },
+                "source_id": {
+                    "type": "string",
+                    "description": "Source message ID for back-linking (e.g. WhatsApp message ID).",
+                },
+            },
+            "required": ["title"],
+        },
+    },
+    "move_ticket": {
+        "name": "move_ticket",
+        "description": (
+            'Updates a ticket status on the board. Valid statuses: '
+            '"חדש" / "pending", "בטיפול" / "in_progress", "ממתין לאישור" / '
+            '"pending_review", "done", "cancelled".'
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "ticket_id": {"type": "string", "description": "UUID of the ticket to move."},
+                "to_status": {
+                    "type": "string",
+                    "description": "Target status — use Hebrew or English key.",
+                },
+            },
+            "required": ["ticket_id", "to_status"],
+        },
+    },
+    "list_tickets": {
+        "name": "list_tickets",
+        "description": (
+            "Returns tickets from the office board. Filter by status (Hebrew or "
+            'English), and limit the count. Use this to answer "מה מחכה לי?" or '
+            '"show me open tasks".'
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "status": {
+                    "type": "string",
+                    "description": (
+                        'Optional status filter: "חדש", "בטיפול", "ממתין לאישור", '
+                        '"done", or omit for all open.'
+                    ),
+                },
+                "limit": {
+                    "type": "integer",
+                    "description": "Maximum number of tickets to return (default 20).",
+                    "default": 20,
+                },
+            },
+            "required": [],
+        },
+    },
+    "save_triage_instructions": {
+        "name": "save_triage_instructions",
+        "description": (
+            "Saves operator triage instructions to the workspace settings. "
+            "Hermes will read these instructions at the start of every session "
+            "to personalize its behavior."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "text": {
+                    "type": "string",
+                    "description": "The triage instructions text (Hebrew preferred).",
+                },
+            },
+            "required": ["text"],
+        },
+    },
+    "request_approval": {
+        "name": "request_approval",
+        "description": (
+            "Proposes an action that requires operator approval before "
+            "execution. Creates a pending_review ticket visible on the kanban "
+            "board. The operator approves or rejects it from the board."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "action_description": {
+                    "type": "string",
+                    "description": (
+                        "Human-readable description of the action requiring "
+                        "approval (Hebrew preferred)."
+                    ),
+                },
+                "payload": {
+                    "type": "object",
+                    "description": (
+                        "Structured payload describing the action (tool name, "
+                        "args, etc.)."
+                    ),
+                },
+            },
+            "required": ["action_description"],
+        },
+    },
+    "get_office_context": {
+        "name": "get_office_context",
+        "description": (
+            "Returns the current office persona settings: triage instructions, "
+            "office type, hours, and team configuration. Read this once at the "
+            "start of a session."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {},
+            "required": [],
+        },
+    },
+}

--- a/plugins/agente_desktop/schemas.py
+++ b/plugins/agente_desktop/schemas.py
@@ -1,4 +1,4 @@
-"""OpenAI function-schema definitions for the 8 Agente desktop tools.
+"""OpenAI function-schema definitions for the 18 Agente desktop tools.
 
 Mirrors `electron/main/hermes-tools/*.ts` in agente-dev/agente-desktop. Keep in
 sync: a desktop-side regression test compares this dict against the TS source.
@@ -179,6 +179,301 @@ TOOL_SCHEMAS: dict[str, dict[str, Any]] = {
             "type": "object",
             "properties": {},
             "required": [],
+        },
+    },
+    # ── 10 additional tools added in desktop-202605-161 fix ──────────────────
+    "upsert_client": {
+        "name": "upsert_client",
+        "description": (
+            "Idempotently create or update a client by identity (phone, JID, "
+            "email, or name). Does not override existing verified identity "
+            "records. Calling twice with the same identity returns the same "
+            "client_id."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "identity": {
+                    "type": "object",
+                    "description": "Identity to look up or create by.",
+                    "properties": {
+                        "kind": {
+                            "type": "string",
+                            "enum": ["phone", "jid", "email", "name"],
+                            "description": "Identity kind.",
+                        },
+                        "value": {
+                            "type": "string",
+                            "description": "Identity value.",
+                        },
+                    },
+                    "required": ["kind", "value"],
+                },
+                "patch": {
+                    "type": "object",
+                    "description": "Optional fields to set on create or update.",
+                    "properties": {
+                        "display_name": {
+                            "type": "string",
+                            "description": "Display name for the client.",
+                        },
+                        "hebrew_name": {
+                            "type": "string",
+                            "description": "Hebrew display name.",
+                        },
+                        "aliases": {
+                            "type": "array",
+                            "description": "Additional name aliases.",
+                            "items": {"type": "string"},
+                        },
+                        "notes": {
+                            "type": "string",
+                            "description": "Optional notes about this client.",
+                        },
+                    },
+                },
+            },
+            "required": ["identity"],
+        },
+    },
+    "query_client": {
+        "name": "query_client",
+        "description": (
+            "Query clients by JID, phone number, email, or display name "
+            "(Hebrew partial match). Returns client records with open ticket "
+            "counts and last contact timestamps."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "jid": {
+                    "type": "string",
+                    "description": 'WhatsApp JID (e.g. "972500000000@s.whatsapp.net")',
+                },
+                "phone": {
+                    "type": "string",
+                    "description": 'Phone number to look up (e.g. "972500000000")',
+                },
+                "email": {
+                    "type": "string",
+                    "description": "Email address to look up",
+                },
+                "name": {
+                    "type": "string",
+                    "description": "Display name or alias (Hebrew partial match supported)",
+                },
+            },
+            "required": [],
+        },
+    },
+    "link_ticket_to_client": {
+        "name": "link_ticket_to_client",
+        "description": (
+            "Links an existing ticket to a client record. Calling again with "
+            "the same ticket_id updates the link (idempotent). Fails with a "
+            "structured error if the client or ticket does not exist."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "ticket_id": {
+                    "type": "string",
+                    "description": "UUID of the ticket to link.",
+                },
+                "client_id": {
+                    "type": "string",
+                    "description": "UUID of the client to link the ticket to.",
+                },
+            },
+            "required": ["ticket_id", "client_id"],
+        },
+    },
+    "link_document_to_client": {
+        "name": "link_document_to_client",
+        "description": (
+            "Links a document source to a client record. Fails with a "
+            "structured error if the client or document does not exist."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "document_source_id": {
+                    "type": "string",
+                    "description": "UUID of the document source to link.",
+                },
+                "client_id": {
+                    "type": "string",
+                    "description": "UUID of the client to link the document to.",
+                },
+            },
+            "required": ["document_source_id", "client_id"],
+        },
+    },
+    "update_office_context": {
+        "name": "update_office_context",
+        "description": (
+            "Writes structured Office Twin profile context to canonical local "
+            "workspace settings, re-renders the derived office profile mirror, "
+            "and reseeds Hermes context from the canonical bundle."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "office_details": {
+                    "type": "object",
+                    "description": (
+                        "Structured office identity details such as name, "
+                        "phone, address, type, or size."
+                    ),
+                    "additionalProperties": True,
+                },
+                "team_members_op": {
+                    "type": "string",
+                    "enum": ["replace", "upsert", "remove_by_id"],
+                    "description": (
+                        "Team member mutation mode. Required when team_members "
+                        "is present."
+                    ),
+                },
+                "team_members": {
+                    "type": "array",
+                    "description": (
+                        "Team member records. Each record must include id. "
+                        "For remove_by_id, only id is required."
+                    ),
+                    "items": {
+                        "type": "object",
+                        "required": ["id"],
+                        "properties": {"id": {"type": "string"}},
+                        "additionalProperties": True,
+                    },
+                },
+                "work_days": {
+                    "type": "array",
+                    "description": "Working day identifiers or labels.",
+                    "items": {"type": "string"},
+                },
+                "compliance": {
+                    "type": "object",
+                    "description": "Structured compliance profile settings.",
+                    "additionalProperties": True,
+                },
+                "preferences": {
+                    "type": "object",
+                    "description": "Structured office preferences.",
+                    "additionalProperties": True,
+                },
+                "connectors": {
+                    "type": "array",
+                    "description": "Structured connector profile metadata.",
+                    "items": {"type": "object", "additionalProperties": True},
+                },
+            },
+            "required": [],
+            "additionalProperties": False,
+        },
+    },
+    "list_tools": {
+        "name": "list_tools",
+        "description": (
+            "Returns the names and descriptions of all Agente desktop tools "
+            "available to the assistant in this session. Call this when the "
+            "operator asks what tools or capabilities the assistant has."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {},
+            "required": [],
+        },
+    },
+    "list_workflows": {
+        "name": "list_workflows",
+        "description": "List all available workflow definitions in the workspace.",
+        "parameters": {
+            "type": "object",
+            "properties": {},
+            "required": [],
+        },
+    },
+    "inspect_workflow": {
+        "name": "inspect_workflow",
+        "description": "Return metadata about a specific workflow definition.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "workflowId": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "ID of the workflow to inspect.",
+                },
+            },
+            "required": ["workflowId"],
+        },
+    },
+    "start_workflow_run": {
+        "name": "start_workflow_run",
+        "description": "Start a new workflow run for a given ticket.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "workflowId": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "ID of the workflow to run.",
+                },
+                "ticketId": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "ID of the ticket to process.",
+                },
+                "ticketLabel": {
+                    "type": "string",
+                    "description": "Current label of the ticket (optional).",
+                },
+                "runId": {
+                    "type": "string",
+                    "description": "Optional deterministic run ID.",
+                },
+            },
+            "required": ["workflowId", "ticketId"],
+        },
+    },
+    "get_run_status": {
+        "name": "get_run_status",
+        "description": "Return the current status of a workflow run.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "runId": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "Run ID to query.",
+                },
+            },
+            "required": ["runId"],
+        },
+    },
+    "resume_paused_run": {
+        "name": "resume_paused_run",
+        "description": "Resume a paused workflow run from the specified step.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "runId": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "Run ID to resume.",
+                },
+                "stepIndex": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "description": (
+                        "Step index to resume from (must match "
+                        "pauseHandle.nextStepIndex)."
+                    ),
+                },
+            },
+            "required": ["runId", "stepIndex"],
         },
     },
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hermes-agent"
-version = "0.13.0"
+version = "0.13.1"
 description = "The self-improving AI agent — creates skills from experience, improves them during use, and runs anywhere"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hermes-agent"
-version = "0.13.1"
+version = "0.13.2"
 description = "The self-improving AI agent — creates skills from experience, improves them during use, and runs anywhere"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -186,6 +186,11 @@ py-modules = ["run_agent", "model_tools", "toolsets", "batch_runner", "trajector
 [tool.setuptools.package-data]
 hermes_cli = ["web_dist/**/*"]
 gateway = ["assets/**/*"]
+# Bundled plugin manifests — without these, `get_bundled_plugins_dir()`
+# scans the pip-installed wheel and finds zero `plugin.yaml` files, so
+# the loader registers nothing. Wildcard ships plugin.yaml + README/etc.
+# for every bundled plugin (kanban, google_meet, agente_desktop, ...).
+"plugins" = ["**/plugin.yaml", "**/*.md", "**/*.yaml", "**/*.json"]
 
 [tool.setuptools.packages.find]
 include = ["agent", "agent.*", "tools", "tools.*", "hermes_cli", "gateway", "gateway.*", "tui_gateway", "tui_gateway.*", "cron", "acp_adapter", "plugins", "plugins.*", "providers", "providers.*"]

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -39,6 +39,7 @@ PYPROJECT_FILE = REPO_ROOT / "pyproject.toml"
 
 # Auto-extracted from noreply emails + manual overrides
 AUTHOR_MAP = {
+    "leon@agente.dev": "leonagente",
     # teknium (multiple emails)
     "teknium1@gmail.com": "teknium1",
     "0x.badfriend@gmail.com": "discodirector",

--- a/tests/hermes_cli/test_gateway.py
+++ b/tests/hermes_cli/test_gateway.py
@@ -165,6 +165,41 @@ def test_run_gateway_windows_detached_absorbs_console_controls(monkeypatch):
     assert (gateway.signal.SIGINT, gateway.signal.SIG_IGN) in signal_calls
 
 
+def test_run_gateway_windows_force_absorb_overrides_isatty(monkeypatch):
+    """HERMES_FORCE_ABSORB_CONSOLE=1 must enable the absorber even when
+    isatty()==True AND HERMES_GATEWAY_DETACHED is unset — covers the case
+    where Electron's spawn env+stdio don't propagate through the venv
+    Scripts/python.exe stub on Windows."""
+    calls = []
+
+    def fake_start_gateway(*, replace, verbosity):
+        calls.append((replace, verbosity))
+        return object()
+
+    class _TTY:
+        def isatty(self):
+            return True
+
+    signal_calls = []
+
+    def fake_signal(sig, handler):
+        signal_calls.append((sig, handler))
+
+    _install_fake_gateway_run(monkeypatch, fake_start_gateway)
+    monkeypatch.setattr(gateway, "is_windows", lambda: True)
+    monkeypatch.setattr(gateway, "supports_systemd_services", lambda: False)
+    monkeypatch.setattr(gateway.sys, "stdin", _TTY())
+    monkeypatch.delenv("HERMES_GATEWAY_DETACHED", raising=False)
+    monkeypatch.setenv("HERMES_FORCE_ABSORB_CONSOLE", "1")
+    monkeypatch.setattr(gateway.signal, "signal", fake_signal)
+    monkeypatch.setattr(gateway.asyncio, "run", lambda coro: True)
+
+    gateway.run_gateway()
+
+    assert calls == [(False, 0)]
+    assert (gateway.signal.SIGINT, gateway.signal.SIG_IGN) in signal_calls
+
+
 class TestSystemdLingerStatus:
     def test_reports_enabled(self, monkeypatch):
         monkeypatch.setattr(gateway, "is_linux", lambda: True)

--- a/uv.lock
+++ b/uv.lock
@@ -1959,7 +1959,7 @@ wheels = [
 
 [[package]]
 name = "hermes-agent"
-version = "0.13.0"
+version = "0.13.1"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },

--- a/uv.lock
+++ b/uv.lock
@@ -1959,7 +1959,7 @@ wheels = [
 
 [[package]]
 name = "hermes-agent"
-version = "0.13.1"
+version = "0.13.2"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary

Fixes alpha.71 P0 bug: desktop-202605-161 — Hermes gateway ignores desktop-registered tools.

**Two compounding issues fixed:**

1. **`gateway/platforms/api_server.py` `_create_agent`** — auto-inject the `agente-desktop` toolset when `AGENTE_TOOL_PORT` + `AGENTE_TOOL_SECRET` env vars are present (set by Electron sidecar manager at startup). No `config.yaml` changes required by operator.

2. **`plugins/agente_desktop/schemas.py`** — registers 10 tools that existed in `electron/main/hermes-tools/` (agente-desktop) but were missing from the Python plugin. Total: 8 → 18 tools.

**10 tools added:**
- `upsert_client` — idempotent create/update client by identity
- `query_client` — query clients by JID/phone/email/name
- `link_ticket_to_client` — link ticket to client record
- `link_document_to_client` — link document source to client
- `update_office_context` — write Office Twin profile to workspace settings
- `list_tools` — self-introspect available tools
- `list_workflows` — list workflow definitions
- `inspect_workflow` — inspect workflow metadata
- `start_workflow_run` — start workflow run for a ticket
- `get_run_status` — query workflow run status
- `resume_paused_run` — resume paused workflow from step

**Root cause (Opus investigation, 2026-05-22):** The `_get_platform_tools` call for `api_server` never included `agente-desktop` in the default set. The plugin was wired correctly but never activated for the api_server platform. Additionally, 10 desktop-side tools had no corresponding Python registration.

Closes: desktop-202605-161 (agente-desktop intake)
After this merges + SHA bump in agente-desktop → alpha.72, `upsert_client` and all 17 other desktop tools become visible to the chat model.

## Test plan
- [ ] Verify existing CI passes (no agente_desktop unit tests exist; CI covers import validation)
- [ ] After merge + desktop SHA bump: smoke-test `upsert_client` from chat → model invokes tool successfully
- [ ] Verify stdlib tools (browser, terminal, file) still work alongside desktop tools in a live session