### PR TITLE
fix(gateway): don't penalise approve_code when all pending entries are legacy format

### DIFF
--- a/gateway/pairing.py
+++ b/gateway/pairing.py
@@ -246,11 +246,13 @@ class PairingStore:
             # at their TTL by _cleanup_expired.
             matched_key = None
             matched_entry = None
+            any_new_format_checked = False
             for entry_id, entry in pending.items():
                 if not isinstance(entry, dict):
                     continue
                 if "salt" not in entry or "hash" not in entry:
                     continue
+                any_new_format_checked = True
                 try:
                     salt = bytes.fromhex(entry["salt"])
                 except ValueError:
@@ -262,7 +264,13 @@ class PairingStore:
                     break
 
             if matched_key is None:
-                self._record_failed_attempt(platform)
+                # Skip failure recording only when pending is non-empty but
+                # every entry is legacy format (no salt/hash). This is the
+                # post-upgrade window where admins still have plaintext codes
+                # pending. Empty pending or a real hash-format mismatch both
+                # count as genuine failures.
+                if not pending or any_new_format_checked:
+                    self._record_failed_attempt(platform)
                 return None
 
             del pending[matched_key]

--- a/tests/gateway/test_pairing.py
+++ b/tests/gateway/test_pairing.py
@@ -208,6 +208,29 @@ class TestLegacyPendingFileCompat:
             # Approved list must be empty
             assert store.is_approved("telegram", "legacy-user") is False
 
+    def test_legacy_only_pending_does_not_trigger_lockout(self, tmp_path):
+        """Regression: approve_code with only legacy entries must not count as a
+        failed attempt (#30383). A platform upgraded mid-session has pending.json
+        entries written by the old code (no salt/hash fields). Calling approve_code
+        before those entries expire must not penalise the platform's failure counter
+        and must not cause lockout after MAX_FAILED_ATTEMPTS such calls."""
+        with patch("gateway.pairing.PAIRING_DIR", tmp_path):
+            self._write_legacy(tmp_path, code="LEGACY01")
+            store = PairingStore()
+            # Drive approve_code more than MAX_FAILED_ATTEMPTS times —
+            # if the bug is present, this would lock the platform out.
+            for _ in range(MAX_FAILED_ATTEMPTS + 1):
+                result = store.approve_code("telegram", "LEGACY01")
+                assert result is None
+            # Platform must NOT be locked out.
+            assert store._is_locked_out("telegram") is False
+            # A legitimately generated new-format code must still work.
+            new_code = store.generate_code("telegram", "realuser", "Real")
+            assert new_code is not None
+            approved = store.approve_code("telegram", new_code)
+            assert approved is not None
+            assert approved["user_id"] == "realuser"
+
     def test_list_pending_handles_legacy_entries(self, tmp_path):
         """list_pending must not KeyError on a missing 'hash' field."""
         with patch("gateway.pairing.PAIRING_DIR", tmp_path):


### PR DESCRIPTION
## Problem

PR #30383 migrated gateway pairing codes from plaintext storage to salted SHA-256
hashes. The new `approve_code()` loop correctly skips legacy pending entries
(entries without `salt`/`hash` fields) to avoid crashing on in-place upgrades.

However, when `matched_key` is `None` at the end of the loop, `_record_failed_attempt()`
is unconditionally called — even when the *only* reason for no match is that every
entry in `pending` is a legacy pre-upgrade entry.

**Impact:** An admin who calls `approve_code` during the post-upgrade window (before
the 1-hour TTL prunes old entries) silently accumulates failure counts for calls that
are not real brute-force attempts. After `MAX_FAILED_ATTEMPTS` (5) such calls the
platform is locked out, blocking all new pairing requests.

## Root cause

```python
# gateway/pairing.py — approve_code(), post #30383
if matched_key is None:
    self._record_failed_attempt(platform)  # fires even for legacy-only pending
    return None
```

## Fix

Track whether at least one hash-format entry was examined. Skip
`_record_failed_attempt` only when `pending` is non-empty but every entry is
legacy format. Empty pending and real hash-format mismatches still count as
genuine failures, preserving brute-force protection.

```python
any_new_format_checked = False
for entry_id, entry in pending.items():
    if "salt" not in entry or "hash" not in entry:
        continue                        # legacy entry — do not set flag
    any_new_format_checked = True       # real hash entry examined
    ...

if matched_key is None:
    if not pending or any_new_format_checked:
        self._record_failed_attempt(platform)
    return None
```

## Behaviour matrix

| Scenario | Before | After |
|---|---|---|
| Legacy-only pending, admin approving | ❌ failure recorded → lockout | ✅ no failure |
| Empty pending | failure recorded | failure recorded (unchanged) |
| New-format entry, wrong code | failure recorded | failure recorded (unchanged) |
| New-format entry, correct code | approved | approved (unchanged) |
| Mixed legacy + new-format, match | approved | approved (unchanged) |
| Malformed hex salt (new-format) | failure recorded | failure recorded (unchanged) |

## Test

Adds `test_legacy_only_pending_does_not_trigger_lockout` to
`TestLegacyPendingFileCompat`: calls `approve_code` `MAX_FAILED_ATTEMPTS + 1`
times against a legacy-only pending file and asserts no lockout fires, then
confirms a legitimately generated new-format code still approves correctly.

All 41 existing tests pass.

## Checklist

- [x] Root cause identified at exact file/function/line
- [x] Fix is symmetric with the comment in the existing code ("legacy entries get pruned at TTL")
- [x] No behavior change for post-upgrade installs with only new-format entries
- [x] No behavior change for empty pending (brute-force protection intact)
- [x] Regression test added
- [x] Full test suite passes