### PR TITLE
fix(kanban): self-heal schema drift and rate-limit dispatcher tick errors

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5118,6 +5118,32 @@ class GatewayRunner:
         bad_ticks = 0
         last_warn_at = 0
         disabled_corrupt_boards: dict[str, tuple[str, int | None, int | None]] = {}
+        # Schema-drift parallel to disabled_corrupt_boards. Populated when a
+        # board reports "no such column" / "no such table" after one
+        # automatic repair attempt has already failed. Fingerprint-keyed so
+        # an mtime change re-enables the board, same as the corrupt path.
+        # Background: issue #28464 (legacy ``session_id`` migration trap,
+        # fixed in #28781) caused the dispatcher to log multi-line
+        # tracebacks per board per tick for hours when an in-place upgrade
+        # outran the gateway's per-process schema cache. The schema fix
+        # closed that specific bug; this branch is the general guard so the
+        # next additive-column bug of the same shape self-heals instead of
+        # bloating journald and the gateway RSS.
+        disabled_schema_boards: dict[str, tuple[str, int | None, int | None]] = {}
+        schema_repair_attempted: set[str] = set()
+
+        # Per-(board, error-class) throttle for ``logger.exception`` on the
+        # tick path. Before this, a board with a persistent SQL error
+        # logged a full traceback every tick — the speedway incident saw
+        # 20+ tracebacks per second per gateway from the dispatcher +
+        # notifier watchers, saturating journald and pushing the gateway
+        # to 3.5 GB RSS over 12h. The throttle keeps at most one traceback
+        # per (slug, exc_class) per ``_TICK_EXC_LOG_WINDOW_SECONDS`` and
+        # surfaces suppressed counts in the next permitted line so
+        # operators still see steady failures.
+        _TICK_EXC_LOG_WINDOW_SECONDS = 60.0
+        _tick_exc_last_at: dict[tuple[str, str], float] = {}
+        _tick_exc_suppressed: dict[tuple[str, str], int] = {}
 
         def _board_db_fingerprint(slug: str) -> tuple[str, int | None, int | None]:
             path = _kb.kanban_db_path(slug)
@@ -5140,6 +5166,51 @@ class GatewayRunner:
                 or "database disk image is malformed" in msg
             )
 
+        def _is_schema_drift_error(exc: Exception) -> Optional[str]:
+            """If ``exc`` is a SQLite "no such column"/"no such table"
+            error, return the missing identifier; else ``None``.
+
+            Matches the failure mode where a long-running gateway opened a
+            board's DB and cached its initialized-paths entry, and then an
+            in-place upgrade of ``hermes_cli/kanban_db.py`` added a new
+            column or table the running code now references. The cached
+            entry skips the additive migration on subsequent connects, so
+            queries reference a column the DB doesn't have.
+
+            See issue #28464 (specific session_id case, fixed in #28781).
+            """
+            if not isinstance(exc, sqlite3.OperationalError):
+                return None
+            msg = str(exc)
+            m = re.match(r"no such (?:column|table): (\S+)", msg)
+            return m.group(1) if m else None
+
+        def _log_tick_exception(slug: str, exc_class: str) -> None:
+            """Emit ``logger.exception`` for the current tick failure,
+            rate-limited to one line per ``(slug, exc_class)`` per
+            ``_TICK_EXC_LOG_WINDOW_SECONDS``. Suppressed counts are
+            surfaced in the next permitted line so persistent failures
+            stay visible without saturating journald.
+            """
+            now = time.monotonic()
+            key = (slug, exc_class)
+            last_at = _tick_exc_last_at.get(key, 0.0)
+            if now - last_at < _TICK_EXC_LOG_WINDOW_SECONDS:
+                _tick_exc_suppressed[key] = _tick_exc_suppressed.get(key, 0) + 1
+                return
+            suppressed = _tick_exc_suppressed.pop(key, 0)
+            _tick_exc_last_at[key] = now
+            if suppressed:
+                logger.exception(
+                    "kanban dispatcher: tick failed on board %s "
+                    "(%d similar errors suppressed in the last %.0fs)",
+                    slug, suppressed, _TICK_EXC_LOG_WINDOW_SECONDS,
+                )
+            else:
+                logger.exception(
+                    "kanban dispatcher: tick failed on board %s", slug,
+                )
+
         def _tick_once_for_board(slug: str) -> "Optional[object]":
             """Run one dispatch_once for a specific board.
 
@@ -5151,7 +5222,10 @@ class GatewayRunner:
             """
             conn = None
             fingerprint = _board_db_fingerprint(slug)
-            disabled_fingerprint = disabled_corrupt_boards.get(slug)
+            disabled_fingerprint = (
+                disabled_corrupt_boards.get(slug)
+                or disabled_schema_boards.get(slug)
+            )
             if disabled_fingerprint == fingerprint:
                 return None
             if disabled_fingerprint is not None:
@@ -5160,6 +5234,8 @@ class GatewayRunner:
                     slug,
                 )
                 disabled_corrupt_boards.pop(slug, None)
+                disabled_schema_boards.pop(slug, None)
+                schema_repair_attempted.discard(slug)
             try:
                 conn = _kb.connect(board=slug)
                 # `connect()` runs the schema + idempotent migration on
@@ -5189,10 +5265,71 @@ class GatewayRunner:
                         fingerprint[0],
                     )
                     return None
-                logger.exception("kanban dispatcher: tick failed on board %s", slug)
+                missing = _is_schema_drift_error(exc)
+                if missing is not None and slug not in schema_repair_attempted:
+                    schema_repair_attempted.add(slug)
+                    logger.warning(
+                        "kanban dispatcher: board %s reports missing %s — "
+                        "re-running additive-column migration and retrying "
+                        "once. Usually means the on-disk hermes-agent code "
+                        "was updated under a long-running gateway whose "
+                        "per-process schema cache is now stale.",
+                        slug, missing,
+                    )
+                    # schema-drift recovery: bust the per-process
+                    # ``_INITIALIZED_PATHS`` cache and re-run the additive
+                    # migration. ``init_db()`` is the right primitive — it
+                    # does exactly that. The regression test for issue
+                    # #21378
+                    # (``test_dispatcher_tick_does_not_call_init_db``)
+                    # forbids ``init_db`` from being called on every tick;
+                    # this call is gated behind the schema-drift exception
+                    # branch and the ``schema_repair_attempted`` set, so
+                    # it runs at most once per slug per gateway lifetime.
+                    try:
+                        _kb.init_db(board=slug)
+                    except Exception:
+                        logger.exception(
+                            "kanban dispatcher: schema repair init_db "
+                            "failed on board %s; disabling until file "
+                            "changes or gateway restarts",
+                            slug,
+                        )
+                        disabled_schema_boards[slug] = fingerprint
+                        return None
+                    retry_conn = None
+                    try:
+                        retry_conn = _kb.connect(board=slug)
+                        return _kb.dispatch_once(
+                            retry_conn,
+                            board=slug,
+                            max_spawn=max_spawn,
+                            max_in_progress=max_in_progress,
+                            failure_limit=failure_limit,
+                            stale_timeout_seconds=stale_timeout_seconds,
+                        )
+                    except Exception as retry_exc:
+                        logger.error(
+                            "kanban dispatcher: board %s still failing "
+                            "after schema repair (%s); disabling until "
+                            "file changes or gateway restarts. If `%s` is "
+                            "a new column added by an in-place update, "
+                            "ensure ``_migrate_add_optional_columns`` in "
+                            "``hermes_cli/kanban_db.py`` adds it.",
+                            slug, retry_exc, missing,
+                        )
+                        disabled_schema_boards[slug] = fingerprint
+                        return None
+                    finally:
+                        if retry_conn is not None:
+                            try:
+                                retry_conn.close()
+                            except Exception:
+                                pass
+                _log_tick_exception(slug, type(exc).__name__)
                 return None
-            except Exception:
-                logger.exception("kanban dispatcher: tick failed on board %s", slug)
+            except Exception as exc:
+                _log_tick_exception(slug, type(exc).__name__)
                 return None
             finally:
                 if conn is not None:

--- a/tests/hermes_cli/test_kanban_dispatcher_resilience.py
+++ b/tests/hermes_cli/test_kanban_dispatcher_resilience.py
@@ -1,0 +1,332 @@
+"""Resilience tests for the embedded kanban dispatcher in
+``GatewayRunner._kanban_dispatcher_watcher``.
+
+Background: issue #28464 (the legacy ``session_id`` migration trap, fixed
+in #28781 / #28754) put a long-running gateway into a per-tick SQL-error
+loop after an in-place upgrade. The dispatcher's exception handler
+logged a full ``logger.exception`` traceback every tick — on a multi-
+board install that surfaced as 20+ tracebacks per second per gateway,
+saturating journald and pushing the gateway RSS to multi-GB over hours.
+
+The schema bug itself is fixed at the migration layer (#28781). These
+tests pin the *dispatcher-layer* defense added afterwards so the next
+additive-column bug of the same shape self-heals instead of degrading
+the whole gateway:
+
+* ``no such column`` / ``no such table`` triggers one ``init_db``-based
+  schema repair attempt per slug per gateway lifetime — gated by the
+  ``schema_repair_attempted`` set so the per-tick race that #21378
+  fixed cannot return.
+* If the retry succeeds, the board stays enabled.
+* If the retry fails, the board is added to ``disabled_schema_boards``
+  (mtime-fingerprinted, mirroring the corrupt-board path) and skipped
+  on subsequent ticks until the file changes or the gateway restarts.
+* Any other persistent SQL error is rate-limited by
+  ``_log_tick_exception`` to at most one ``logger.exception`` per
+  ``(slug, exc_class)`` per ``_TICK_EXC_LOG_WINDOW_SECONDS``, with
+  suppressed counts surfaced in the next permitted line.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import sqlite3
+
+import pytest
+
+
+def _common_dispatcher_setup(monkeypatch, tmp_path, *, board_slug: str = "default"):
+    """Wire up the minimum surface so ``_kanban_dispatcher_watcher`` can be
+    invoked in a test without a real Hermes home or DB. Returns the runner
+    and the path the test should ``stat`` for fingerprint mtimes.
+    """
+    from gateway.run import GatewayRunner
+    import hermes_cli.config as _cfg_mod
+    import hermes_cli.kanban_db as _kb
+
+    runner = object.__new__(GatewayRunner)
+    runner._running = True
+
+    db_path = tmp_path / "kanban.db"
+    # Real on-disk file so ``_board_db_fingerprint`` can stat() it. Contents
+    # don't matter — the test stubs ``_kb.connect``.
+    db_path.write_bytes(b"")
+
+    monkeypatch.setattr(
+        _cfg_mod,
+        "load_config",
+        lambda: {
+            "kanban": {
+                "dispatch_in_gateway": True,
+                "dispatch_interval_seconds": 1,
+                "auto_decompose": False,
+            }
+        },
+    )
+    monkeypatch.setattr(
+        _kb,
+        "list_boards",
+        lambda include_archived=False: [{"slug": board_slug}],
+    )
+    monkeypatch.setattr(
+        _kb,
+        "read_board_metadata",
+        lambda slug: {"slug": slug},
+    )
+    monkeypatch.setattr(_kb, "kanban_db_path", lambda board=None: db_path)
+    return runner, db_path
+
+
+def _stub_asyncio(monkeypatch, runner, *, stop_after_ticks: int):
+    """Make ``asyncio.to_thread`` run synchronously and stop the watcher
+    after ``stop_after_ticks`` calls.
+    """
+    calls = {"to_thread": 0}
+
+    async def _to_thread(fn, *args, **kwargs):
+        calls["to_thread"] += 1
+        result = fn(*args, **kwargs)
+        if calls["to_thread"] >= stop_after_ticks:
+            runner._running = False
+        return result
+
+    async def _sleep(_delay):
+        return None
+
+    monkeypatch.setattr("gateway.run.asyncio.to_thread", _to_thread)
+    monkeypatch.setattr("gateway.run.asyncio.sleep", _sleep)
+    return calls
+
+
+def test_schema_drift_triggers_init_db_repair_and_retry_succeeds(
+    monkeypatch, tmp_path, caplog
+):
+    """First tick: ``connect`` raises ``no such column: session_id``. The
+    dispatcher must call ``init_db`` once, retry the tick, and on success
+    leave the board enabled. No ``tick failed`` error log.
+    """
+    import hermes_cli.kanban_db as _kb
+
+    runner, db_path = _common_dispatcher_setup(monkeypatch, tmp_path)
+
+    connect_calls = {"count": 0}
+    init_db_calls = {"count": 0}
+
+    class _FakeConn:
+        def close(self):
+            return None
+
+    def _connect(*args, **kwargs):
+        connect_calls["count"] += 1
+        if connect_calls["count"] == 1:
+            raise sqlite3.OperationalError("no such column: session_id")
+        return _FakeConn()
+
+    def _init_db(*args, **kwargs):
+        init_db_calls["count"] += 1
+        return db_path
+
+    def _dispatch_once(conn, **kwargs):
+        # Return a value with ``.spawned`` falsy so the watcher's quiet-by
+        # default log path is taken.
+        return type("R", (), {"spawned": []})()
+
+    monkeypatch.setattr(_kb, "connect", _connect)
+    monkeypatch.setattr(_kb, "init_db", _init_db)
+    monkeypatch.setattr(_kb, "dispatch_once", _dispatch_once)
+    monkeypatch.setattr(_kb, "has_spawnable_ready", lambda conn: False)
+    monkeypatch.setattr(_kb, "has_spawnable_review", lambda conn: False)
+
+    _stub_asyncio(monkeypatch, runner, stop_after_ticks=2)
+
+    with caplog.at_level(logging.DEBUG, logger="gateway.run"):
+        asyncio.run(
+            asyncio.wait_for(
+                runner._kanban_dispatcher_watcher(),
+                timeout=3.0,
+            )
+        )
+
+    assert init_db_calls["count"] == 1, (
+        "init_db must be called exactly once during schema-drift recovery"
+    )
+    messages = [r.getMessage() for r in caplog.records]
+    # The warn line that announces the repair is the contract for operators.
+    assert any(
+        "reports missing session_id" in m and "retrying" in m for m in messages
+    ), f"missing schema-repair warning; got: {messages}"
+    # And no traceback was logged.
+    assert not any(r.exc_info for r in caplog.records), (
+        "no exception tracebacks should be logged when the repair succeeds"
+    )
+    assert not any("tick failed on board" in m for m in messages)
+
+
+def test_schema_drift_persistent_failure_disables_board(
+    monkeypatch, tmp_path, caplog
+):
+    """If the retry also fails, the board moves into
+    ``disabled_schema_boards`` and subsequent ticks short-circuit without
+    further ``init_db`` calls.
+    """
+    import hermes_cli.kanban_db as _kb
+
+    runner, _ = _common_dispatcher_setup(monkeypatch, tmp_path)
+
+    connect_calls = {"count": 0}
+    init_db_calls = {"count": 0}
+
+    def _connect(*args, **kwargs):
+        connect_calls["count"] += 1
+        raise sqlite3.OperationalError("no such column: session_id")
+
+    def _init_db(*args, **kwargs):
+        init_db_calls["count"] += 1
+        return None
+
+    monkeypatch.setattr(_kb, "connect", _connect)
+    monkeypatch.setattr(_kb, "init_db", _init_db)
+    monkeypatch.setattr(_kb, "has_spawnable_ready", lambda conn: False)
+    monkeypatch.setattr(_kb, "has_spawnable_review", lambda conn: False)
+
+    _stub_asyncio(monkeypatch, runner, stop_after_ticks=5)
+
+    with caplog.at_level(logging.DEBUG, logger="gateway.run"):
+        asyncio.run(
+            asyncio.wait_for(
+                runner._kanban_dispatcher_watcher(),
+                timeout=3.0,
+            )
+        )
+
+    # One repair attempt across the whole lifetime of the watcher — not
+    # one per tick. The schema_repair_attempted guard is the contract.
+    assert init_db_calls["count"] == 1, (
+        f"init_db must be called exactly once across multiple failing "
+        f"ticks; got {init_db_calls['count']}"
+    )
+    # The disabled-board log line must mention the missing identifier so
+    # operators know which column to add to the migration.
+    messages = [r.getMessage() for r in caplog.records]
+    assert any(
+        "still failing after schema repair" in m and "session_id" in m
+        for m in messages
+    ), f"missing schema-disable error; got: {messages}"
+
+
+def test_persistent_unknown_sql_error_is_rate_limited(
+    monkeypatch, tmp_path, caplog
+):
+    """A persistent SQL error that's *not* a schema-drift error (and so
+    can't be self-healed) must be logged at most once per
+    ``(slug, exc_class)`` per window, with suppressed counts surfaced.
+    """
+    import hermes_cli.kanban_db as _kb
+
+    runner, _ = _common_dispatcher_setup(monkeypatch, tmp_path)
+
+    def _connect(*args, **kwargs):
+        # Not a schema-drift signature — so the schema branch is skipped
+        # and the generic rate-limited path takes over.
+        raise sqlite3.OperationalError("database is locked")
+
+    monkeypatch.setattr(_kb, "connect", _connect)
+    monkeypatch.setattr(_kb, "has_spawnable_ready", lambda conn: False)
+    monkeypatch.setattr(_kb, "has_spawnable_review", lambda conn: False)
+
+    _stub_asyncio(monkeypatch, runner, stop_after_ticks=10)
+
+    with caplog.at_level(logging.DEBUG, logger="gateway.run"):
+        asyncio.run(
+            asyncio.wait_for(
+                runner._kanban_dispatcher_watcher(),
+                timeout=3.0,
+            )
+        )
+
+    tick_failed_records = [
+        r for r in caplog.records if "tick failed on board" in r.getMessage()
+    ]
+    # Multiple ticks raised — must be at most one logged inside the 60s
+    # window. The throttle uses ``time.monotonic`` so the entire test runs
+    # well within a single window.
+    assert len(tick_failed_records) <= 1, (
+        f"expected ≤1 tick-failed log line under the rate-limit window; "
+        f"got {len(tick_failed_records)}: "
+        f"{[r.getMessage() for r in tick_failed_records]}"
+    )
+
+
+def test_schema_drift_recovery_state_clears_on_fingerprint_change(
+    monkeypatch, tmp_path, caplog
+):
+    """A board disabled by schema-drift must come back when its DB file
+    mtime changes — symmetric with the corrupt-board re-enable path.
+    """
+    import time as _time
+    import hermes_cli.kanban_db as _kb
+
+    runner, db_path = _common_dispatcher_setup(monkeypatch, tmp_path)
+
+    # First and second connects fail (drift + failed repair). Third onwards
+    # succeed — but the third only fires after the fingerprint changes.
+    connect_calls = {"count": 0}
+
+    class _FakeConn:
+        def close(self):
+            return None
+
+    def _connect(*args, **kwargs):
+        connect_calls["count"] += 1
+        if connect_calls["count"] <= 2:
+            raise sqlite3.OperationalError("no such column: session_id")
+        return _FakeConn()
+
+    def _init_db(*args, **kwargs):
+        return None
+
+    def _dispatch_once(conn, **kwargs):
+        return type("R", (), {"spawned": []})()
+
+    monkeypatch.setattr(_kb, "connect", _connect)
+    monkeypatch.setattr(_kb, "init_db", _init_db)
+    monkeypatch.setattr(_kb, "dispatch_once", _dispatch_once)
+    monkeypatch.setattr(_kb, "has_spawnable_ready", lambda conn: False)
+    monkeypatch.setattr(_kb, "has_spawnable_review", lambda conn: False)
+
+    tick_count = {"n": 0}
+
+    async def _to_thread(fn, *args, **kwargs):
+        tick_count["n"] += 1
+        result = fn(*args, **kwargs)
+        if tick_count["n"] == 2:
+            # Fingerprint change between tick 2 and tick 3: simulate the
+            # user touching the DB (e.g., ``hermes kanban init``).
+            _time.sleep(0.01)  # ensure mtime advances
+            db_path.write_bytes(b"\x00")
+        if tick_count["n"] >= 6:
+            runner._running = False
+        return result
+
+    async def _sleep(_delay):
+        return None
+
+    monkeypatch.setattr("gateway.run.asyncio.to_thread", _to_thread)
+    monkeypatch.setattr("gateway.run.asyncio.sleep", _sleep)
+
+    with caplog.at_level(logging.DEBUG, logger="gateway.run"):
+        asyncio.run(
+            asyncio.wait_for(
+                runner._kanban_dispatcher_watcher(),
+                timeout=3.0,
+            )
+        )
+
+    messages = [r.getMessage() for r in caplog.records]
+    assert any(
+        "database changed; retrying dispatch" in m for m in messages
+    ), (
+        "Schema-disabled board must re-enable on fingerprint change. "
+        f"Messages: {messages}"
+    )

--- a/tests/hermes_cli/test_kanban_notify.py
+++ b/tests/hermes_cli/test_kanban_notify.py
@@ -285,11 +285,18 @@ async def test_notifier_does_not_call_init_db(kanban_home):
 
 
 def test_dispatcher_tick_does_not_call_init_db(kanban_home, monkeypatch):
-    """`_tick_once_for_board` must not invoke `_kb.init_db` (issue #21378).
+    """`_tick_once_for_board` must not invoke `_kb.init_db` on the happy
+    path (issue #21378).
 
     `connect()` already runs the schema + idempotent migration on first open
-    per process. The explicit `init_db()` call was redundant and triggered a
-    second migration on a second connection that raced the first.
+    per process. An unconditional `init_db()` call was redundant and
+    triggered a second migration on a second connection that raced the
+    first.
+
+    A single guarded call inside the schema-drift recovery branch added
+    by the resilience patch is permitted: it runs at most once per slug
+    per gateway lifetime, gated by the `schema_repair_attempted` set, so
+    it cannot reintroduce the per-tick race.
     """
     import hermes_cli.kanban_db as kb
     from gateway.run import GatewayRunner
@@ -309,11 +316,31 @@ def test_dispatcher_tick_does_not_call_init_db(kanban_home, monkeypatch):
     # specific patterns that would reintroduce the bug are absent.
     import inspect
     src = inspect.getsource(GatewayRunner._kanban_dispatcher_watcher)
-    assert "_kb.init_db(board=slug)" not in src, (
-        "_kanban_dispatcher_watcher must not call _kb.init_db(board=slug) — "
-        "see issue #21378. Use connect() alone; it runs migrations on first "
-        "open per process."
-    )
+
+    # Any init_db call in the dispatcher source must be guarded by the
+    # schema-drift recovery branch. The branch is identified by the
+    # ``schema_repair_attempted`` set being populated before the call.
+    init_db_lines = [
+        (i, ln) for i, ln in enumerate(src.splitlines())
+        if "_kb.init_db(board=slug)" in ln
+    ]
+    if init_db_lines:
+        assert "schema_repair_attempted.add(slug)" in src, (
+            "_kanban_dispatcher_watcher calls _kb.init_db(board=slug) but "
+            "the schema-drift recovery marker "
+            "(`schema_repair_attempted.add(slug)`) is missing — that "
+            "marker is the contract that the call is gated to at most "
+            "once per slug per gateway lifetime. Without it the call "
+            "would reintroduce issue #21378."
+        )
+        # And there must be at most one such call site.
+        assert len(init_db_lines) == 1, (
+            f"_kanban_dispatcher_watcher has {len(init_db_lines)} "
+            "_kb.init_db(board=slug) call sites; only one is allowed "
+            "(schema-drift recovery branch). Additional call sites "
+            "would reintroduce issue #21378. Found at lines: "
+            f"{[i for i, _ in init_db_lines]}"
+        )
 
     notifier_src = inspect.getsource(GatewayRunner._kanban_notifier_watcher)
     assert "_kb.init_db(board=slug)" not in notifier_src, (


### PR DESCRIPTION
## What changed

Two defenses inside `_kanban_dispatcher_watcher`:

1. **Schema-drift self-heal.** `no such column` / `no such table` errors trigger one `init_db`-based repair attempt per slug per gateway lifetime, gated by a new `schema_repair_attempted` set. On retry success the board stays enabled; on retry failure the slug moves into `disabled_schema_boards` (same mtime-fingerprint shape as `disabled_corrupt_boards`) and is skipped on subsequent ticks until the file changes or the gateway restarts.
2. **Rate-limited exception logging.** `logger.exception` on the tick path is throttled to one line per `(slug, exc_class)` per `_TICK_EXC_LOG_WINDOW_SECONDS` (60s). Suppressed counts surface in the next permitted line.

## Why

The session_id migration trap from #28464 — fixed at the migration layer in #28781 and the follow-up 7552e0f3c — caused the dispatcher to log a full `logger.exception` traceback every tick on multi-board installs. Reproduced in the wild: 20+ tracebacks per second per gateway, journald saturated, gateway RSS climbed to 3.5 GB over 12h, ssh sessions degraded.

The schema-layer fix closes that specific bug, but the dispatcher's lack of any defense makes every future additive-column bug of the same shape catastrophic. This patch is the dispatcher-layer guard so the next one self-heals instead of taking the gateway down.

## #21378 compatibility

The existing regression test `test_dispatcher_tick_does_not_call_init_db` is updated to allow exactly one `init_db(board=slug)` call site, and only when it's accompanied by the `schema_repair_attempted.add(slug)` marker in the source. The marker is the contract that the call is gated to at most once per slug per gateway lifetime — the per-tick race that #21378 fixed cannot reappear. Any additional call site fails the test.

## How to test

```
scripts/run_tests.sh tests/hermes_cli/test_kanban_db.py \
                     tests/hermes_cli/test_kanban_db_init.py \
                     tests/hermes_cli/test_kanban_blocked_sticky.py \
                     tests/hermes_cli/test_kanban_core_functionality.py \
                     tests/hermes_cli/test_kanban_dispatcher_resilience.py \
                     tests/hermes_cli/test_kanban_notify.py
```

Result on this branch: 347/347 pass, 9.2s.

## New tests

`tests/hermes_cli/test_kanban_dispatcher_resilience.py`:

- `test_schema_drift_triggers_init_db_repair_and_retry_succeeds` — first tick raises `no such column: session_id`, second connect succeeds; `init_db` called exactly once, no traceback logged, board stays enabled.
- `test_schema_drift_persistent_failure_disables_board` — every connect raises drift; `init_db` called exactly once across 5 ticks (not per-tick), board moves into `disabled_schema_boards`, error log names the missing column so operators know which migration entry to add.
- `test_persistent_unknown_sql_error_is_rate_limited` — `database is locked` raised on 10 ticks; ≤1 tick-failed log line in the window.
- `test_schema_drift_recovery_state_clears_on_fingerprint_change` — disabled board re-enables when its DB file mtime advances, mirroring the corrupt-board path.

## Platforms tested

Linux (WSL2 Ubuntu, Python 3.11.15). The patch touches only Python dispatcher logic; no OS-specific surfaces.

## Related

Refs #28464 (the originating bug), #28781 (schema-layer fix, merged), 7552e0f3c (follow-up index hoist), #21378 (the per-tick init race this PR must not reintroduce). Does not close any open issue — the schema bug is already resolved; this is the orthogonal dispatcher hardening to prevent recurrence.