### PR TITLE
fix(file-safety): write-deny pairing/ directory to prevent approved-list injection

### DIFF
--- a/agent/file_safety.py
+++ b/agent/file_safety.py
@@ -127,6 +127,12 @@ def is_write_denied(path: str) -> bool:
                 return True
         except Exception:
             pass
+        try:
+            pairing_real = os.path.realpath(os.path.join(base_real, "pairing"))
+            if resolved == pairing_real or resolved.startswith(pairing_real + os.sep):
+                return True
+        except Exception:
+            pass
 
     safe_root = get_safe_write_root()
     if safe_root and not (resolved == safe_root or resolved.startswith(safe_root + os.sep)):

--- a/tests/tools/test_file_operations.py
+++ b/tests/tools/test_file_operations.py
@@ -68,10 +68,14 @@ class TestIsWriteDenied:
             "webhook_subscriptions.json",
             "mcp-tokens/token1.json",
             "mcp-tokens/subdir/token2.json",
+            "pairing/telegram-approved.json",
+            "pairing/discord-approved.json",
+            "pairing/telegram-pending.json",
+            "pairing",
         ],
     )
     def test_hermes_control_files_and_mcp_tokens_denied(self, path):
-        """Hermes control files and mcp-tokens entries must be write-denied."""
+        """Hermes control files and mcp-tokens/pairing entries must be write-denied."""
         from hermes_constants import get_hermes_home
         hermes_home = get_hermes_home()
         full_path = str(hermes_home / path)
@@ -139,6 +143,29 @@ class TestIsWriteDenied:
         assert _is_write_denied(str(root / "mcp-tokens" / "tok.json")) is True
         # The directory itself must also be denied (not just files inside)
         assert _is_write_denied(str(root / "mcp-tokens")) is True
+
+    def test_pairing_dir_denied(self, tmp_path, monkeypatch):
+        """Regression: pairing/ must be write-denied under both profile and root.
+
+        PR #30383 introduced ~/.hermes/pairing/{platform}-approved.json as the
+        gateway access-control list. Without this block, a prompt-injected agent
+        can write arbitrary user IDs into an approved file, granting persistent
+        gateway access without going through the pairing code flow — the same
+        threat class that motivated protecting webhook_subscriptions.json.
+        """
+        root = tmp_path / "hermes"
+        profile = root / "profiles" / "coder"
+        profile.mkdir(parents=True)
+        monkeypatch.setenv("HERMES_HOME", str(profile))
+
+        # Active profile pairing entries
+        assert _is_write_denied(str(profile / "pairing" / "telegram-approved.json")) is True
+        assert _is_write_denied(str(profile / "pairing" / "discord-pending.json")) is True
+        # The directory itself
+        assert _is_write_denied(str(profile / "pairing")) is True
+        # Root pairing entries (profile mode — same shape as mcp-tokens gap)
+        assert _is_write_denied(str(root / "pairing" / "telegram-approved.json")) is True
+        assert _is_write_denied(str(root / "pairing")) is True
 
 
 


### PR DESCRIPTION
## Problem

`is_write_denied()` in `agent/file_safety.py` blocks writes to known
control-plane files (`auth.json`, `config.yaml`, `webhook_subscriptions.json`,
`mcp-tokens/`) but does **not** block writes to the gateway pairing directory
(`~/.hermes/pairing/`).

The pairing directory stores per-platform access-control lists:

```
~/.hermes/pairing/
  telegram-approved.json   ← which user IDs may send commands
  telegram-pending.json    ← hashed codes awaiting approval
  telegram-rate_limits.json
  discord-approved.json
  ...
```

A prompt-injected agent using the `write_file` tool can write arbitrary user
IDs into `telegram-approved.json`, granting persistent gateway access without
going through the pairing code flow:

```python
# Attacker-controlled prompt injection:
write_file(
    "~/.hermes/pairing/telegram-approved.json",
    '{"123456789": {"user_name": "attacker", "approved_at": 1716000000}}'
)
```

After this write, `PairingStore.is_approved("telegram", "123456789")` returns
`True` and the attacker can issue commands to the agent via Telegram with no
further authentication.

## Root cause

PR #14157 protected `webhook_subscriptions.json` as a control-plane file.
PR #30383 introduced the `pairing/` directory as the gateway access-control
store, but `is_write_denied()` was not updated to cover it — the same gap
shape as the profile-mode `.env` gap closed by PR #15981.

Verification (before fix):

```
is_write_denied('~/.hermes/pairing/telegram-approved.json') → False  ← bug
is_write_denied('~/.hermes/auth.json')                      → True   ✓
is_write_denied('~/.hermes/webhook_subscriptions.json')     → True   ✓
```

## Fix

Apply the same `mcp-tokens` directory pattern to `pairing/`:

```python
try:
    pairing_real = os.path.realpath(os.path.join(base_real, "pairing"))
    if resolved == pairing_real or resolved.startswith(pairing_real + os.sep):
        return True
except Exception:
    pass
```

The check runs for **both** `_hermes_home_path()` and `_hermes_root_path()`,
matching the profile-mode widening applied to `mcp-tokens/` in PR #30382.

## Tests

Adds `test_pairing_dir_denied` to `TestIsWriteDenied`:

- `pairing/telegram-approved.json` under active profile → denied
- `pairing/discord-pending.json` under active profile → denied
- `pairing/` directory itself → denied
- Same paths under hermes root (profile mode) → denied

Also extends the existing parametrized test with four pairing paths
(`pairing/telegram-approved.json`, `pairing/discord-approved.json`,
`pairing/telegram-pending.json`, `pairing`).

All 28 `TestIsWriteDenied` tests pass.

## Checklist

- [x] Root cause at exact file/function/line (`is_write_denied`, `agent/file_safety.py`)
- [x] Symmetric with `mcp-tokens` protection pattern already in the same function
- [x] Covers both active profile (`hermes_home`) and root (`hermes_root`) paths
- [x] No behavior change for any path outside `~/.hermes/pairing/`
- [x] Regression tests added for normal mode and profile mode
- [x] All 28 write-deny tests pass