### PR TITLE
fix(provider/gemini): clarify RESOURCE_EXHAUSTED 429 error — distinguish free-tier routing from per-minute limits

### DIFF
--- a/agent/gemini_cloudcode_adapter.py
+++ b/agent/gemini_cloudcode_adapter.py
@@ -873,10 +873,40 @@ def _gemini_http_error(response: httpx.Response) -> CodeAssistError:
         if retry_delay_seconds is not None:
             message += f" Google suggests retrying in {retry_delay_seconds:g}s."
     elif status == 429 and err_status == "RESOURCE_EXHAUSTED":
-        message = (
-            f"Gemini quota exhausted ({err_message or 'RESOURCE_EXHAUSTED'}). "
-            f"Check /gquota for remaining daily requests."
-        )
+        # Detect whether Google applied a free-tier bucket (limit=0) to the
+        # request — a distinct failure mode from per-minute TPM/RPM exhaustion.
+        # The signal comes from structured ErrorInfo metadata when present, or
+        # from the raw message string for endpoints that don't include it.
+        _metric = str(error_metadata.get("metric") or "")
+        _limit = str(error_metadata.get("limit") or "")
+        if not _metric:
+            _msg_lower = err_message.lower()
+            _mi = _msg_lower.find("metric:")
+            if _mi >= 0:
+                _metric = err_message[_mi + len("metric:"):].split(",")[0].strip()
+        if not _limit and ", limit: 0," in err_message:
+            _limit = "0"
+        _is_free_tier_zero = "free_tier_" in _metric and _limit == "0"
+
+        if _is_free_tier_zero:
+            _model_str = model_hint or str(error_metadata.get("model") or "")
+            message = (
+                f"Google applied free-tier quota (limit=0) for "
+                f"{_model_str or 'this model'} (metric: {_metric}). "
+                f"The Code Assist backend is routing to a free-tier bucket "
+                f"regardless of your subscription; setting "
+                f"HERMES_GEMINI_PROJECT_ID does not change this routing. "
+                f"Workarounds: switch to gemini-3.x-flash-lite-preview or "
+                f"gemini-2.5-flash (non-zero free-tier allowances), or add a "
+                f"Google AI Studio API key (GOOGLE_API_KEY) as a "
+                f"fallback_providers entry."
+            )
+        else:
+            message = (
+                f"Gemini quota exhausted ({err_message or 'RESOURCE_EXHAUSTED'}). "
+                f"/gquota shows daily limits only — per-minute TPM/RPM limits "
+                f"are separate and may be hit even when daily quota is available."
+            )
         if retry_delay_seconds is not None:
             message += f" Retry suggested in {retry_delay_seconds:g}s."
     elif status == 404:

--- a/tests/agent/test_gemini_cloudcode.py
+++ b/tests/agent/test_gemini_cloudcode.py
@@ -1027,6 +1027,63 @@ class TestGeminiHttpErrorParsing:
         assert err.code == "code_assist_rate_limited"
         message = str(err)
         assert "quota" in message.lower()
+        # Message must clarify that /gquota shows daily limits, not per-minute.
+        assert "per-minute" in message.lower() or "daily" in message.lower()
+
+    def test_free_tier_zero_limit_from_metadata(self):
+        """free_tier_* metric + limit=0 in ErrorInfo metadata → specific guidance."""
+        from agent.gemini_cloudcode_adapter import _gemini_http_error
+
+        body = {
+            "error": {
+                "code": 429,
+                "message": (
+                    "Quota exceeded for metric: "
+                    "generate_content_free_tier_input_token_count, "
+                    "limit: 0, model: gemini-3.1-pro"
+                ),
+                "status": "RESOURCE_EXHAUSTED",
+                "details": [
+                    {
+                        "@type": "type.googleapis.com/google.rpc.ErrorInfo",
+                        "reason": "RATE_LIMIT_EXCEEDED",
+                        "metadata": {
+                            "metric": "generate_content_free_tier_input_token_count",
+                            "limit": "0",
+                            "model": "gemini-3.1-pro",
+                        },
+                    }
+                ],
+            }
+        }
+        err = _gemini_http_error(self._fake_response(429, body))
+        assert err.status_code == 429
+        assert err.code == "code_assist_rate_limited"
+        message = str(err)
+        assert "free-tier" in message.lower()
+        assert "limit=0" in message or "limit: 0" in message.lower()
+        assert "HERMES_GEMINI_PROJECT_ID" in message
+
+    def test_free_tier_zero_limit_from_raw_message(self):
+        """free_tier_* + limit: 0 detected from raw message when no ErrorInfo."""
+        from agent.gemini_cloudcode_adapter import _gemini_http_error
+
+        body = {
+            "error": {
+                "code": 429,
+                "message": (
+                    "Quota exceeded for metric: "
+                    "generate_content_free_tier_requests, "
+                    "limit: 0, model: gemini-3.1-flash"
+                ),
+                "status": "RESOURCE_EXHAUSTED",
+            }
+        }
+        err = _gemini_http_error(self._fake_response(429, body))
+        assert err.status_code == 429
+        message = str(err)
+        assert "free-tier" in message.lower()
+        assert "HERMES_GEMINI_PROJECT_ID" in message
 
     def test_404_model_not_found_produces_model_retired_message(self):
         from agent.gemini_cloudcode_adapter import _gemini_http_error


### PR DESCRIPTION
## What changed and why

The `RESOURCE_EXHAUSTED` 429 branch in the Code Assist error handler previously told users to "Check /gquota for remaining daily requests". This message is misleading in two distinct failure modes reported in #15895:

1. **Per-minute TPM/RPM exhaustion** — the full agent session payload (system prompt + tool schemas + memory + history) easily exceeds per-minute limits on the free tier even when daily quota appears fine in `/gquota`.
2. **Free-tier bucket applied to paid account** — the Code Assist backend routes requests to a free-tier quota bucket where Pro models have `limit=0`, even for AI Pro/Ultra subscribers. Setting `HERMES_GEMINI_PROJECT_ID` does not change this routing (confirmed by AI Ultra user @jiangshengwu in the latest reply).

The fix:
- Detects the free-tier-zero-limit case from structured `ErrorInfo` metadata (preferred) or raw message string (fallback) and surfaces a specific explanation: names the metric, explains Google-side routing, notes that project ID won't help, and suggests concrete workarounds (Flash-lite/2.5-Flash models or `GOOGLE_API_KEY` fallback).
- For all other `RESOURCE_EXHAUSTED` 429s, adds a clarifying note that `/gquota` shows daily limits only and per-minute limits are tracked separately.

Per the reporter's follow-up on 2026-05-22, the project-ID workaround suggested in the prior bot comment does not resolve the issue, so this PR focuses on giving users accurate diagnostic information instead.

## How to test

```
pytest tests/agent/test_gemini_cloudcode.py::TestGeminiHttpErrorParsing -v
```

Three new test cases cover:
- `test_resource_exhausted_without_reason` — updated to assert the per-minute note is present
- `test_free_tier_zero_limit_from_metadata` — `free_tier_*` metric + `limit=0` via structured `ErrorInfo`
- `test_free_tier_zero_limit_from_raw_message` — same signal parsed from raw error message string

All 9 tests in `TestGeminiHttpErrorParsing` pass.

## What platforms tested on

- macOS (darwin aarch64, Python 3.11)

Fixes #15895

<!-- autocontrib:worker-id=issue-followup-279ab8a9 kind=pr-open -->