### PR TITLE
feat(skills): add scholar-sidekick optional research skill

### DIFF
--- a/optional-skills/research/scholar-sidekick/SKILL.md
+++ b/optional-skills/research/scholar-sidekick/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: scholar-sidekick
-description: Resolve scholarly identifiers (DOI, PMID, PMCID, ISBN, arXiv, ISSN, ADS bibcode, WHO IRIS URL) into formatted citations (10,000+ CSL styles) and bibliography exports (BibTeX, RIS, EndNote, CSV…), and check retraction, open-access, and citation-fabrication status. Calls a documented REST API over plain HTTP — no install, no API key needed for the free tier.
+description: Cite, export, and verify papers from a DOI, PMID, or ISBN.
 version: 1.0.0
-author: Scholar Sidekick
+author: Mark Lavercombe (mlava)
 license: MIT
 metadata:
   hermes:
@@ -10,38 +10,53 @@ metadata:
     related_skills: [arxiv, research-paper-writing]
 ---
 
-# Scholar Sidekick — Citations, Retraction & Open-Access
+# Scholar Sidekick Skill
 
-Turn a scholarly identifier into a formatted citation, a bibliography file, or an
-integrity check (retraction / open-access / fabrication), via a documented REST API.
-**No API key and no install required** — plain HTTPS calls over `curl`. An optional
-RapidAPI key only raises rate limits.
+Turns a scholarly identifier (DOI, PMID, PMCID, ISBN, arXiv, ISSN, ADS bibcode, WHO IRIS
+URL) into a formatted citation, a bibliography file, or an integrity check — retraction,
+open access, or fabrication. It does **not** search for papers by topic: it assumes you
+already have an identifier. For discovery, use the `arxiv` skill instead.
 
 ## When to Use
-- The user has an identifier (DOI, PMID, PMCID, ISBN, arXiv, ISSN, ADS bibcode, WHO IRIS URL) and wants metadata, a formatted citation, or a bibliography file.
+- The user has an identifier and wants metadata, a formatted citation, or a bibliography file.
 - "Cite this in APA/Vancouver/Chicago…", "give me a BibTeX/RIS file", "export these refs".
 - "Has this been retracted?", "is this open access?", "is this citation real / did you make it up?"
-- Do NOT use to *search* for papers by topic — that's discovery (see the `arxiv` skill). This assumes you already have an identifier.
 
-## Surfaces — call the API, never scrape the UI
-The site is built for agents. The contract lives at:
-- https://scholar-sidekick.com/llms.txt (index of agent surfaces)
-- https://scholar-sidekick.com/AGENTS.md (REST + MCP guide)
-- https://scholar-sidekick.com/openapi/openapi.yml (OpenAPI 3.1)
+## Prerequisites
+None. The API is public and needs no install and no key — call it anonymously and it works.
 
-Always call the JSON REST API below. Do not drive the website form.
+Anonymous callers get a rate-limited free tier (~40 format / 10 export requests per
+window), which is ample for human-driven agent use. Two optional upgrades, neither
+required by this skill:
 
-## Authentication & limits
-Calls to `scholar-sidekick.com/api/*` work **anonymously — there is no first-party API
-key** — at a rate-limited free tier (~40 format / 10 export requests per window), which
-is plenty for normal, human-driven agent use. For higher limits, Scholar Sidekick is
-offered on RapidAPI: subscribe at
-https://rapidapi.com/scholar-sidekick-scholar-sidekick-api/api/scholar-sidekick and call
-it through the RapidAPI gateway with your `X-RapidAPI-Key`. Use the anonymous
-`scholar-sidekick.com` endpoints by default; move to RapidAPI only for volume.
+- **First-party key** — sign in at https://scholar-sidekick.com/account, issue an `ssk_`
+  key, and send `Authorization: Bearer ssk_…` for a higher allowance.
+- **RapidAPI gateway** — for volume, subscribe at
+  https://rapidapi.com/scholar-sidekick-scholar-sidekick-api/api/scholar-sidekick and
+  send `X-RapidAPI-Key` to the gateway host instead.
+
+The same six operations are also exposed as a hosted MCP server at
+`https://scholar-sidekick.com/api/mcp` (`resolveIdentifier`, `formatCitation`,
+`exportCitation`, `checkRetraction`, `checkOpenAccess`, `verifyCitation`), which also
+accepts anonymous calls. Use it only if you want tool-native access; the REST calls below
+need no setup at all.
+
+## How to Run
+Invoke every operation as a JSON POST through the `terminal` tool. Base URL
+`https://scholar-sidekick.com`; all endpoints take and return JSON:
+
+```bash
+curl -sS -X POST "https://scholar-sidekick.com/api/format" \
+  -H "Content-Type: application/json" \
+  -d '{"text": "10.1038/nphys1170", "style": "vancouver", "output": "text"}'
+```
+
+Call the JSON API, never the website form. The agent-facing contract is published at
+https://scholar-sidekick.com/llms.txt (index of surfaces),
+https://scholar-sidekick.com/AGENTS.md (REST + MCP guide), and
+https://scholar-sidekick.com/openapi/openapi.yml (OpenAPI 3.1).
 
 ## Quick Reference
-Base URL: `https://scholar-sidekick.com`
 
 | Need | Endpoint | Body |
 |------|----------|------|
@@ -54,7 +69,7 @@ Base URL: `https://scholar-sidekick.com`
 
 ## Procedure
 
-### Format a citation
+### 1. Format a citation
 ```bash
 curl -sS -X POST "https://scholar-sidekick.com/api/format" \
   -H "Content-Type: application/json" \
@@ -63,9 +78,10 @@ curl -sS -X POST "https://scholar-sidekick.com/api/format" \
 - `text`: one identifier, or several newline-separated for a batch. Pass verbatim — `PMID:`, `arXiv:`, ISBN hyphens, and `https://doi.org/…` are all tolerated.
 - `style`: `vancouver` (default), `ama`, `apa`, `ieee`, `cse`, or any CSL style ID (`chicago-author-date`, `harvard-cite-them-right`, `modern-language-association`, `nature`, `bmj`, `the-lancet`, …).
 - `output`: `text` or `json`.
+
 Response: `{ "ok": true, "items": [{ "formatted": "…" }], "text": "…" }`.
 
-### Export a bibliography file
+### 2. Export a bibliography file
 ```bash
 curl -sS -X POST "https://scholar-sidekick.com/api/export" \
   -H "Content-Type: application/json" \
@@ -74,25 +90,25 @@ curl -sS -X POST "https://scholar-sidekick.com/api/export" \
 ```
 - `format`: `bibtex`, `ris`, `csl-json`, `endnote-xml`, `refworks`, `nbib`, `rdf`, `csv`, `txt`.
 
-### Check retraction
+### 3. Check retraction
 ```bash
 curl -sS -X POST "https://scholar-sidekick.com/api/retraction-check" \
   -H "Content-Type: application/json" \
   -d '{"id": "10.1016/S0140-6736(97)11096-0"}'
 ```
 Returns `{ ok, doi, result: { isRetracted, hasCorrections, hasConcern, notices[], title } }`
-(Crossref + Retraction Watch). One identifier per call — field is **`id`**.
+(Crossref + Retraction Watch). One identifier per call — the field is **`id`**.
 
-### Check open access
+### 4. Check open access
 ```bash
 curl -sS -X POST "https://scholar-sidekick.com/api/oa-check" \
   -H "Content-Type: application/json" \
   -d '{"id": "10.1371/journal.pone.0173664"}'
 ```
 Returns `{ ok, doi, result: { isOa, oaStatus, bestLocation: {url, license, version}, locations[] } }`
-(Unpaywall). One identifier per call — field is **`id`**.
+(Unpaywall). One identifier per call — the field is **`id`**.
 
-### Verify a claimed citation (catch fabrication)
+### 5. Verify a claimed citation (catch fabrication)
 ```bash
 curl -sS -X POST "https://scholar-sidekick.com/api/verify" \
   -H "Content-Type: application/json" \
@@ -102,27 +118,20 @@ Citation fields go inside a **`claimed`** object: `title` (required) plus an ide
 (`doi`, `pmid`, … — recommended) and optional `authors` / `year` / `container`. Returns
 `{ ok, verdict, confidence, matched }`, verdict ∈ `matched` / `mismatch` / `ambiguous` /
 `not_found`. `mismatch` = the identifier resolves but the title doesn't — the dominant
-AI-fabrication pattern (real DOI + invented title; Topaz et al., Lancet 2026); `ambiguous` =
-the identifier resolves to one paper but the claimed title matches a different real paper
-(wrong-identifier citation error). Use this for "is this citation real?", not a plain
-format/resolve.
+AI-fabrication pattern (real DOI + invented title; Topaz et al., Lancet 2026). `ambiguous`
+= the identifier resolves to one paper but the claimed title matches a different real paper
+(a wrong-identifier citation error). Use this for "is this citation real?", not a plain
+format or resolve — those never catch a real DOI carrying an invented title.
 
 ## Pitfalls
 - Never scrape the web UI — the JSON API is faster and stable.
 - Pass identifiers verbatim; don't strip prefixes.
 - Body fields differ per endpoint: `format`/`export` use `text`; `retraction-check`/`oa-check` use `id` (one identifier per call); `verify` wraps fields in `claimed`. Don't mix them up.
-- ISBNs have no DOI, so retraction/OA return a "no DOI" result for books.
+- ISBNs have no DOI, so retraction and open-access checks return a "no DOI" result for books.
 - Don't fabricate a fallback: if a call fails or returns `ok:false`, report that — never invent a citation, retraction status, OA verdict, or a "matched" verdict.
 
 ## Verification
-- `curl -sS https://scholar-sidekick.com/api/health` returns `{ "ok": true, … }`.
-- A good `/api/format` response has `items[].formatted` non-empty.
-
-## Optional: MCP server (power users)
-Scholar Sidekick is also an MCP server (tools: `resolveIdentifier`, `formatCitation`,
-`exportCitation`, `checkRetraction`, `checkOpenAccess`, `verifyCitation`). That path
-requires installing the server and a RapidAPI key, so the REST calls above are the
-zero-setup default:
 ```bash
-npx -y scholar-sidekick-mcp@latest   # needs RAPIDAPI_KEY in env
+curl -sS https://scholar-sidekick.com/api/health
 ```
+Returns `{ "ok": true, … }`. A healthy `/api/format` response has `items[].formatted` non-empty.

--- a/optional-skills/research/scholar-sidekick/SKILL.md
+++ b/optional-skills/research/scholar-sidekick/SKILL.md
@@ -1,0 +1,126 @@
+---
+name: scholar-sidekick
+description: Resolve scholarly identifiers (DOI, PMID, PMCID, ISBN, arXiv, ISSN, ADS bibcode, WHO IRIS URL) into formatted citations (10,000+ CSL styles) and bibliography exports (BibTeX, RIS, EndNote, CSV…), and check retraction, open-access, and citation-fabrication status. Calls a documented REST API over plain HTTP — no install, no API key needed for the free tier.
+version: 1.0.0
+author: Scholar Sidekick
+license: MIT
+metadata:
+  hermes:
+    tags: [citations, bibliography, doi, pmid, arxiv, csl, bibtex, ris, retraction, open-access, citation-verification, research]
+    related_skills: [arxiv, research-paper-writing]
+---
+
+# Scholar Sidekick — Citations, Retraction & Open-Access
+
+Turn a scholarly identifier into a formatted citation, a bibliography file, or an
+integrity check (retraction / open-access / fabrication), via a documented REST API.
+**No API key and no install required** — plain HTTPS calls over `curl`. An optional
+RapidAPI key only raises rate limits.
+
+## When to Use
+- The user has an identifier (DOI, PMID, PMCID, ISBN, arXiv, ISSN, ADS bibcode, WHO IRIS URL) and wants metadata, a formatted citation, or a bibliography file.
+- "Cite this in APA/Vancouver/Chicago…", "give me a BibTeX/RIS file", "export these refs".
+- "Has this been retracted?", "is this open access?", "is this citation real / did you make it up?"
+- Do NOT use to *search* for papers by topic — that's discovery (see the `arxiv` skill). This assumes you already have an identifier.
+
+## Surfaces — call the API, never scrape the UI
+The site is built for agents. The contract lives at:
+- https://scholar-sidekick.com/llms.txt (index of agent surfaces)
+- https://scholar-sidekick.com/AGENTS.md (REST + MCP guide)
+- https://scholar-sidekick.com/openapi/openapi.yml (OpenAPI 3.1)
+
+Always call the JSON REST API below. Do not drive the website form.
+
+## Authentication & limits
+Calls to `scholar-sidekick.com/api/*` work **anonymously — there is no first-party API
+key** — at a rate-limited free tier (~40 format / 10 export requests per window), which
+is plenty for normal, human-driven agent use. For higher limits, Scholar Sidekick is
+offered on RapidAPI: subscribe at
+https://rapidapi.com/scholar-sidekick-scholar-sidekick-api/api/scholar-sidekick and call
+it through the RapidAPI gateway with your `X-RapidAPI-Key`. Use the anonymous
+`scholar-sidekick.com` endpoints by default; move to RapidAPI only for volume.
+
+## Quick Reference
+Base URL: `https://scholar-sidekick.com`
+
+| Need | Endpoint | Body |
+|------|----------|------|
+| Format a citation | `POST /api/format` | `{text, style, output}` |
+| Export a bibliography file | `POST /api/export` | `{text, format}` |
+| Retraction / correction / EoC check | `POST /api/retraction-check` | `{id}` |
+| Open-access status + best legal URL | `POST /api/oa-check` | `{id}` |
+| Verify a claimed citation (fabrication) | `POST /api/verify` | `{claimed: {title, doi}}` |
+| Service health | `GET /api/health` | — |
+
+## Procedure
+
+### Format a citation
+```bash
+curl -sS -X POST "https://scholar-sidekick.com/api/format" \
+  -H "Content-Type: application/json" \
+  -d '{"text": "10.1038/nphys1170", "style": "vancouver", "output": "text"}'
+```
+- `text`: one identifier, or several newline-separated for a batch. Pass verbatim — `PMID:`, `arXiv:`, ISBN hyphens, and `https://doi.org/…` are all tolerated.
+- `style`: `vancouver` (default), `ama`, `apa`, `ieee`, `cse`, or any CSL style ID (`chicago-author-date`, `harvard-cite-them-right`, `modern-language-association`, `nature`, `bmj`, `the-lancet`, …).
+- `output`: `text` or `json`.
+Response: `{ "ok": true, "items": [{ "formatted": "…" }], "text": "…" }`.
+
+### Export a bibliography file
+```bash
+curl -sS -X POST "https://scholar-sidekick.com/api/export" \
+  -H "Content-Type: application/json" \
+  -d '{"text": "10.1038/nphys1170\nPMID:30049270", "format": "bibtex"}' \
+  -o refs.bib
+```
+- `format`: `bibtex`, `ris`, `csl-json`, `endnote-xml`, `refworks`, `nbib`, `rdf`, `csv`, `txt`.
+
+### Check retraction
+```bash
+curl -sS -X POST "https://scholar-sidekick.com/api/retraction-check" \
+  -H "Content-Type: application/json" \
+  -d '{"id": "10.1016/S0140-6736(97)11096-0"}'
+```
+Returns `{ ok, doi, result: { isRetracted, hasCorrections, hasConcern, notices[], title } }`
+(Crossref + Retraction Watch). One identifier per call — field is **`id`**.
+
+### Check open access
+```bash
+curl -sS -X POST "https://scholar-sidekick.com/api/oa-check" \
+  -H "Content-Type: application/json" \
+  -d '{"id": "10.1371/journal.pone.0173664"}'
+```
+Returns `{ ok, doi, result: { isOa, oaStatus, bestLocation: {url, license, version}, locations[] } }`
+(Unpaywall). One identifier per call — field is **`id`**.
+
+### Verify a claimed citation (catch fabrication)
+```bash
+curl -sS -X POST "https://scholar-sidekick.com/api/verify" \
+  -H "Content-Type: application/json" \
+  -d '{"claimed": {"title": "The title exactly as cited", "doi": "10.xxxx/xxxxx"}}'
+```
+Citation fields go inside a **`claimed`** object: `title` (required) plus one identifier
+(`doi`, `pmid`, …) and optional `authors` / `year` / `container`. Returns
+`{ ok, verdict, confidence, matched }`, verdict ∈ `matched` / `mismatch` / `not_found` /
+`parsing_error`. `mismatch` = the identifier resolves but the title doesn't — the dominant
+AI-fabrication pattern (real DOI + invented title; Topaz et al., Lancet 2026). Use this for
+"is this citation real?", not a plain format/resolve.
+
+## Pitfalls
+- Never scrape the web UI — the JSON API is faster and stable.
+- Pass identifiers verbatim; don't strip prefixes.
+- Body fields differ per endpoint: `format`/`export` use `text`; `retraction-check`/`oa-check` use `id` (one identifier per call); `verify` wraps fields in `claimed`. Don't mix them up.
+- ISBNs have no DOI, so retraction/OA return a "no DOI" result for books.
+- Don't fabricate a fallback: if a call fails or returns `ok:false`, report that — never invent a citation, retraction status, OA verdict, or a "matched" verdict.
+
+## Verification
+- `curl -sS https://scholar-sidekick.com/api/health` returns `{ "ok": true, … }`.
+- A good `/api/format` response has `items[].formatted` non-empty.
+
+## Optional: MCP server (power users)
+Scholar Sidekick is also an MCP server (tools: `resolveIdentifier`, `formatCitation`,
+`exportCitation`, `checkRetraction`, `checkOpenAccess`, `verifyCitation`). That path
+requires installing the server and a RapidAPI key, so the REST calls above are the
+zero-setup default:
+```bash
+npx -y scholar-sidekick-mcp@latest   # needs RAPIDAPI_KEY in env
+```

--- a/optional-skills/research/scholar-sidekick/SKILL.md
+++ b/optional-skills/research/scholar-sidekick/SKILL.md
@@ -98,12 +98,14 @@ curl -sS -X POST "https://scholar-sidekick.com/api/verify" \
   -H "Content-Type: application/json" \
   -d '{"claimed": {"title": "The title exactly as cited", "doi": "10.xxxx/xxxxx"}}'
 ```
-Citation fields go inside a **`claimed`** object: `title` (required) plus one identifier
-(`doi`, `pmid`, …) and optional `authors` / `year` / `container`. Returns
-`{ ok, verdict, confidence, matched }`, verdict ∈ `matched` / `mismatch` / `not_found` /
-`parsing_error`. `mismatch` = the identifier resolves but the title doesn't — the dominant
-AI-fabrication pattern (real DOI + invented title; Topaz et al., Lancet 2026). Use this for
-"is this citation real?", not a plain format/resolve.
+Citation fields go inside a **`claimed`** object: `title` (required) plus an identifier
+(`doi`, `pmid`, … — recommended) and optional `authors` / `year` / `container`. Returns
+`{ ok, verdict, confidence, matched }`, verdict ∈ `matched` / `mismatch` / `ambiguous` /
+`not_found`. `mismatch` = the identifier resolves but the title doesn't — the dominant
+AI-fabrication pattern (real DOI + invented title; Topaz et al., Lancet 2026); `ambiguous` =
+the identifier resolves to one paper but the claimed title matches a different real paper
+(wrong-identifier citation error). Use this for "is this citation real?", not a plain
+format/resolve.
 
 ## Pitfalls
 - Never scrape the web UI — the JSON API is faster and stable.

--- a/optional-skills/research/scholar-sidekick/SKILL.md
+++ b/optional-skills/research/scholar-sidekick/SKILL.md
@@ -25,9 +25,9 @@ already have an identifier. For discovery, use the `arxiv` skill instead.
 ## Prerequisites
 None. The API is public and needs no install and no key — call it anonymously and it works.
 
-Anonymous callers get a rate-limited free tier (~40 format / 10 export requests per
-window), which is ample for human-driven agent use. Two optional upgrades, neither
-required by this skill:
+Anonymous callers get a rate-limited free tier per IP: 10/min each for `format` and
+`export`, 60/min for the retraction/open-access/verify checks, 8/min for `audit`. That's
+ample for human-driven agent use. Two optional upgrades, neither required by this skill:
 
 - **First-party key** — sign in at https://scholar-sidekick.com/account, issue an `ssk_`
   key, and send `Authorization: Bearer ssk_…` for a higher allowance.
@@ -35,11 +35,11 @@ required by this skill:
   https://rapidapi.com/scholar-sidekick-scholar-sidekick-api/api/scholar-sidekick and
   send `X-RapidAPI-Key` to the gateway host instead.
 
-The same six operations are also exposed as a hosted MCP server at
+The same seven operations are also exposed as a hosted MCP server at
 `https://scholar-sidekick.com/api/mcp` (`resolveIdentifier`, `formatCitation`,
-`exportCitation`, `checkRetraction`, `checkOpenAccess`, `verifyCitation`), which also
-accepts anonymous calls. Use it only if you want tool-native access; the REST calls below
-need no setup at all.
+`exportCitation`, `checkRetraction`, `checkOpenAccess`, `verifyCitation`,
+`auditBibliography`), which also accepts anonymous calls. Use it only if you want
+tool-native access; the REST calls below need no setup at all.
 
 ## How to Run
 Invoke every operation as a JSON POST through the `terminal` tool. Base URL
@@ -65,6 +65,7 @@ https://scholar-sidekick.com/openapi/openapi.yml (OpenAPI 3.1).
 | Retraction / correction / EoC check | `POST /api/retraction-check` | `{id}` |
 | Open-access status + best legal URL | `POST /api/oa-check` | `{id}` |
 | Verify a claimed citation (fabrication) | `POST /api/verify` | `{claimed: {title, doi}}` |
+| Audit a whole bibliography (fabrication + retraction, ≤25 entries) | `POST /api/audit` | `{claims: [{title}]}` |
 | Service health | `GET /api/health` | — |
 
 ## Procedure
@@ -123,10 +124,25 @@ AI-fabrication pattern (real DOI + invented title; Topaz et al., Lancet 2026). `
 (a wrong-identifier citation error). Use this for "is this citation real?", not a plain
 format or resolve — those never catch a real DOI carrying an invented title.
 
+### 6. Audit a whole bibliography
+```bash
+curl -sS -X POST "https://scholar-sidekick.com/api/audit" \
+  -H "Content-Type: application/json" \
+  -d '{"claims": [{"title": "Attention Is All You Need"}, {"title": "A fabricated title"}]}'
+```
+Runs `/api/verify` per entry plus a retraction check, in one call — use this instead of
+looping `/api/verify` over a reference list. Takes **exactly one** of:
+`claims[]` (max 25, each needs a `title`), `bibliography` (raw BibTeX/RIS/CSL-JSON string,
+max 128 KB, auto-detected), or `references[]` (max 25 raw prose reference strings).
+Returns `{ ok, entries: [{ index, status, verdict, confidence, matched, mismatches }],
+summary: { total, matched, mismatch, ambiguous, not_found, errored, retracted } }`.
+`entries[].index` is **1-based**. A single bad entry gets `status: "error"` without
+failing the batch.
+
 ## Pitfalls
 - Never scrape the web UI — the JSON API is faster and stable.
 - Pass identifiers verbatim; don't strip prefixes.
-- Body fields differ per endpoint: `format`/`export` use `text`; `retraction-check`/`oa-check` use `id` (one identifier per call); `verify` wraps fields in `claimed`. Don't mix them up.
+- Body fields differ per endpoint: `format`/`export` use `text`; `retraction-check`/`oa-check` use `id` (one identifier per call); `verify` wraps fields in `claimed`; `audit` takes `claims[]` (bare, no wrapper). Don't mix them up.
 - ISBNs have no DOI, so retraction and open-access checks return a "no DOI" result for books.
 - Don't fabricate a fallback: if a call fails or returns `ok:false`, report that — never invent a citation, retraction status, OA verdict, or a "matched" verdict.
 

--- a/tests/skills/test_scholar_sidekick_skill.py
+++ b/tests/skills/test_scholar_sidekick_skill.py
@@ -1,0 +1,134 @@
+"""
+Smoke tests for the scholar-sidekick optional skill.
+
+The skill is pure documentation over a public REST API — there are no shipped
+scripts and we make no live network calls in CI. These tests verify:
+  - SKILL.md frontmatter conforms to the hardline format
+  - the body uses the modern section order
+  - the documented request bodies stay in sync with the real API contract
+    (the per-endpoint field names are the thing agents get wrong most often)
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+SKILL_DIR = (
+    Path(__file__).resolve().parents[2]
+    / "optional-skills"
+    / "research"
+    / "scholar-sidekick"
+)
+
+
+@pytest.fixture(scope="module")
+def skill_md() -> str:
+    return (SKILL_DIR / "SKILL.md").read_text(encoding="utf-8")
+
+
+@pytest.fixture(scope="module")
+def frontmatter(skill_md: str) -> dict:
+    m = re.search(r"^---\n(.*?)\n---", skill_md, re.DOTALL)
+    assert m, "SKILL.md missing YAML frontmatter"
+    return yaml.safe_load(m.group(1))
+
+
+def test_skill_dir_exists() -> None:
+    assert SKILL_DIR.is_dir(), f"missing skill dir: {SKILL_DIR}"
+
+
+def test_skill_md_present() -> None:
+    assert (SKILL_DIR / "SKILL.md").is_file()
+
+
+def test_description_under_60_chars(frontmatter) -> None:
+    desc = frontmatter["description"]
+    assert len(desc) <= 60, f"description is {len(desc)} chars (hardline <=60): {desc!r}"
+
+
+def test_description_is_one_sentence_ending_in_period(frontmatter) -> None:
+    desc = frontmatter["description"]
+    assert desc.endswith("."), f"description must end with a period: {desc!r}"
+    assert desc.count(".") == 1, f"description must be one sentence: {desc!r}"
+
+
+def test_description_has_no_marketing_words(frontmatter) -> None:
+    banned = {"powerful", "comprehensive", "seamless", "advanced"}
+    words = set(re.findall(r"[a-z]+", frontmatter["description"].lower()))
+    assert not (words & banned), f"marketing words in description: {words & banned}"
+
+
+def test_name_matches_dir(frontmatter) -> None:
+    assert frontmatter["name"] == SKILL_DIR.name
+
+
+def test_author_credits_contributor(frontmatter) -> None:
+    author = frontmatter["author"]
+    assert "Mark Lavercombe" in author, f"author must credit the human first: {author!r}"
+    assert "mlava" in author, f"author must carry the GitHub handle: {author!r}"
+
+
+def test_license_mit(frontmatter) -> None:
+    assert frontmatter["license"] == "MIT"
+
+
+def test_modern_section_order(skill_md: str) -> None:
+    required = [
+        "## When to Use",
+        "## Prerequisites",
+        "## How to Run",
+        "## Quick Reference",
+        "## Procedure",
+        "## Pitfalls",
+        "## Verification",
+    ]
+    positions = []
+    for heading in required:
+        idx = skill_md.find(heading)
+        assert idx != -1, f"SKILL.md missing required section: {heading}"
+        positions.append(idx)
+    assert positions == sorted(positions), "sections are out of the mandated order"
+
+
+def test_no_api_key_required(skill_md: str) -> None:
+    """Anonymous access is the whole point — a key must never be a prerequisite."""
+    prereqs = skill_md.split("## Prerequisites", 1)[1].split("## How to Run", 1)[0]
+    assert "None." in prereqs, "Prerequisites must state that no setup is required"
+
+
+def test_documents_optional_first_party_key(skill_md: str) -> None:
+    """Anonymous is the default, but ssk_ keys exist — don't claim they don't."""
+    assert "Bearer ssk_" in skill_md
+    assert "X-RapidAPI-Key" in skill_md
+
+
+def test_endpoint_bodies_match_api_contract(skill_md: str) -> None:
+    """Field names differ per endpoint; drift here silently breaks every call."""
+    # /api/format and /api/export take `text`.
+    assert re.search(r"/api/format\S*\"[^`]*?\"text\"", skill_md, re.DOTALL)
+    assert re.search(r"/api/export\S*\"[^`]*?\"text\"", skill_md, re.DOTALL)
+    # /api/retraction-check and /api/oa-check take a single `id`.
+    assert re.search(r"/api/retraction-check\S*\"[^`]*?\"id\"", skill_md, re.DOTALL)
+    assert re.search(r"/api/oa-check\S*\"[^`]*?\"id\"", skill_md, re.DOTALL)
+    # /api/verify nests the citation under `claimed`.
+    assert re.search(r"/api/verify\S*\"[^`]*?\"claimed\"", skill_md, re.DOTALL)
+
+
+def test_verify_verdicts_are_the_real_enum(skill_md: str) -> None:
+    verify_section = skill_md.split("### 5.", 1)[1].split("## Pitfalls", 1)[0]
+    for verdict in ("matched", "mismatch", "ambiguous", "not_found"):
+        assert f"`{verdict}`" in verify_section, f"missing verify verdict: {verdict}"
+
+
+def test_warns_against_fabricating_fallbacks(skill_md: str) -> None:
+    pitfalls = skill_md.split("## Pitfalls", 1)[1].split("## Verification", 1)[0]
+    assert "never invent" in pitfalls.lower()
+
+
+def test_disclaims_paper_search(skill_md: str) -> None:
+    """This skill cites papers you already have; `arxiv` finds new ones."""
+    assert "`arxiv`" in skill_md

--- a/tests/skills/test_scholar_sidekick_skill.py
+++ b/tests/skills/test_scholar_sidekick_skill.py
@@ -116,6 +116,8 @@ def test_endpoint_bodies_match_api_contract(skill_md: str) -> None:
     assert re.search(r"/api/oa-check\S*\"[^`]*?\"id\"", skill_md, re.DOTALL)
     # /api/verify nests the citation under `claimed`.
     assert re.search(r"/api/verify\S*\"[^`]*?\"claimed\"", skill_md, re.DOTALL)
+    # /api/audit takes `claims` (bare, no wrapper).
+    assert re.search(r"/api/audit\S*\"[^`]*?\"claims\"", skill_md, re.DOTALL)
 
 
 def test_verify_verdicts_are_the_real_enum(skill_md: str) -> None:
@@ -132,3 +134,34 @@ def test_warns_against_fabricating_fallbacks(skill_md: str) -> None:
 def test_disclaims_paper_search(skill_md: str) -> None:
     """This skill cites papers you already have; `arxiv` finds new ones."""
     assert "`arxiv`" in skill_md
+
+
+def test_documents_all_seven_mcp_tools(skill_md: str) -> None:
+    """auditBibliography shipped after the original draft — don't undercount the surface."""
+    assert "seven operations" in skill_md
+    for tool in (
+        "resolveIdentifier",
+        "formatCitation",
+        "exportCitation",
+        "checkRetraction",
+        "checkOpenAccess",
+        "verifyCitation",
+        "auditBibliography",
+    ):
+        assert f"`{tool}`" in skill_md, f"missing MCP tool: {tool}"
+
+
+def test_audit_section_present(skill_md: str) -> None:
+    """Whole-bibliography audit is the highest-value operation for a research skill."""
+    assert "### 6. Audit a whole bibliography" in skill_md
+    audit_section = skill_md.split("### 6.", 1)[1].split("## Pitfalls", 1)[0]
+    assert "/api/audit" in audit_section
+    assert "max 25" in audit_section
+    assert "1-based" in audit_section
+
+
+def test_rate_limits_are_not_overstated(skill_md: str) -> None:
+    """Measured against prod: format and export are both 10/min, not ~40/10."""
+    prereqs = skill_md.split("## Prerequisites", 1)[1].split("## How to Run", 1)[0]
+    assert "~40" not in prereqs, "format rate limit was overstated 4x in the original draft"
+    assert "10/min" in prereqs


### PR DESCRIPTION
**What** — Adds `optional-skills/research/scholar-sidekick/` so Hermes can resolve scholarly identifiers (DOI, PMID, PMCID, ISBN, arXiv, ISSN, ADS bibcode, WHO IRIS URL) into formatted citations (10,000+ CSL styles) and bibliography exports (BibTeX, RIS, EndNote, CSV…), and check retraction, open-access, and citation-fabrication status.

**Why optional (not bundled)** — It's a third-party service integration, the same tier as the existing `optional-skills/research/searxng-search`. Broadly useful for research/writing workflows but not universally needed, so it belongs in `optional-skills/` per CONTRIBUTING.md ("a paid service integration … put it in `optional-skills/`").

**No heavyweight dependency, no key required** — The skill calls the documented public REST API over plain `curl`: no install, and the anonymous tier needs no API key (an optional RapidAPI key only raises rate limits). An MCP server also exists, but the skill mentions it solely as an optional power-user upgrade — there's no hard dependency.

**Notes**
- API-first; never scrapes the UI. Every request body in the skill was tested against the live API. Discovery surfaces: `llms.txt`, `AGENTS.md`, OpenAPI 3.1.
- Frontmatter + section layout follow the `searxng-search` exemplar.
- Complements the existing `arxiv` skill: `arxiv` *finds* papers; `scholar-sidekick` *cites / exports / verifies* ones you already have an identifier for.
