### PR TITLE
Fix gateway restart status and kanban migration edge cases

### DIFF
--- a/gateway/status.py
+++ b/gateway/status.py
@@ -463,7 +463,13 @@ def is_gateway_runtime_lock_active(lock_path: Optional[Path] = None) -> bool:
     if not resolved_lock_path.exists():
         return False
 
-    handle = open(resolved_lock_path, "a+", encoding="utf-8")
+    try:
+        handle = open(resolved_lock_path, "a+", encoding="utf-8")
+    except (OSError, PermissionError):
+        # If the lock file exists but this process cannot open it, avoid
+        # treating it as stale.  Service managers may still be able to restart
+        # the gateway even when this CLI cannot inspect the lock directly.
+        return True
     try:
         if _try_acquire_file_lock(handle):
             _release_file_lock(handle)

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -111,25 +111,74 @@ def _get_service_pids() -> set:
     if is_macos():
         try:
             label = get_launchd_label()
-            result = subprocess.run(
-                ["launchctl", "list", label],
-                capture_output=True, text=True, timeout=5,
-            )
-            if result.returncode == 0:
-                # Output: "PID\tStatus\tLabel" header, then one data line
-                for line in result.stdout.strip().splitlines():
-                    parts = line.split()
-                    if len(parts) >= 3 and parts[2] == label:
-                        try:
-                            pid = int(parts[0])
-                            if pid > 0:
-                                pids.add(pid)
-                        except ValueError:
-                            pass
+            _, output = _launchd_service_loaded(timeout=5)
+            pids.update(_launchd_pids_from_output(output, label))
         except (FileNotFoundError, subprocess.TimeoutExpired):
             pass
 
     return pids
+
+
+def _launchd_pids_from_output(output: str, label: str) -> set[int]:
+    """Extract running gateway PIDs from launchctl output."""
+    pids: set[int] = set()
+    for line in output.strip().splitlines():
+        stripped = line.strip()
+        if stripped.startswith("pid ="):
+            try:
+                pid = int(stripped.split("=", 1)[1].strip())
+            except ValueError:
+                continue
+            if pid > 0:
+                pids.add(pid)
+            continue
+
+        # Legacy `launchctl list <label>` output:
+        # "PID\tStatus\tLabel" header, then one data line.
+        parts = stripped.split()
+        if len(parts) >= 3 and parts[2] == label:
+            try:
+                pid = int(parts[0])
+            except ValueError:
+                continue
+            if pid > 0:
+                pids.add(pid)
+    return pids
+
+
+def _launchd_service_loaded(timeout: float = 10) -> tuple[bool, str]:
+    """Return whether the current launchd job is loaded and its status text."""
+    label = get_launchd_label()
+    target = f"{_launchd_domain()}/{label}"
+    try:
+        result = subprocess.run(
+            ["launchctl", "print", target],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+        if result.returncode == 0:
+            return True, result.stdout
+        print_output = result.stdout or result.stderr or ""
+    except subprocess.TimeoutExpired:
+        raise
+    except FileNotFoundError:
+        raise
+
+    try:
+        result = subprocess.run(
+            ["launchctl", "list", label],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+        if result.returncode == 0:
+            return True, result.stdout
+        return False, result.stdout or result.stderr or print_output
+    except subprocess.TimeoutExpired:
+        raise
+    except FileNotFoundError:
+        raise
 
 
 def _get_parent_pid(pid: int) -> int | None:
@@ -958,15 +1007,10 @@ def _probe_launchd_service_running() -> bool:
     if not get_launchd_plist_path().exists():
         return False
     try:
-        result = subprocess.run(
-            ["launchctl", "list", get_launchd_label()],
-            capture_output=True,
-            text=True,
-            timeout=10,
-        )
-    except subprocess.TimeoutExpired:
+        loaded, _ = _launchd_service_loaded(timeout=10)
+    except (FileNotFoundError, subprocess.TimeoutExpired):
         return False
-    return result.returncode == 0
+    return loaded
 
 
 def get_gateway_runtime_snapshot(system: bool = False) -> GatewayRuntimeSnapshot:
@@ -3030,6 +3074,11 @@ def launchd_restart():
             print("✓ Service restart requested")
             return
         if pid is not None:
+            print(f"⏳ Launchd service restarting gracefully (PID {pid})...")
+            if _graceful_restart_via_sigusr1(pid, drain_timeout + 5):
+                print("✓ Service restart requested")
+                return
+        if pid is not None:
             try:
                 terminate_pid(pid, force=False)
             except (ProcessLookupError, PermissionError, OSError):
@@ -3052,17 +3101,9 @@ def launchd_restart():
 
 def launchd_status(deep: bool = False):
     plist_path = get_launchd_plist_path()
-    label = get_launchd_label()
     try:
-        result = subprocess.run(
-            ["launchctl", "list", label],
-            capture_output=True,
-            text=True,
-            timeout=10,
-        )
-        loaded = result.returncode == 0
-        loaded_output = result.stdout
-    except subprocess.TimeoutExpired:
+        loaded, loaded_output = _launchd_service_loaded(timeout=10)
+    except (FileNotFoundError, subprocess.TimeoutExpired):
         loaded = False
         loaded_output = ""
 
@@ -4187,12 +4228,9 @@ def _is_service_running() -> bool:
         return False
     elif is_macos() and get_launchd_plist_path().exists():
         try:
-            result = subprocess.run(
-                ["launchctl", "list", get_launchd_label()],
-                capture_output=True, text=True, timeout=10,
-            )
-            return result.returncode == 0
-        except subprocess.TimeoutExpired:
+            loaded, _ = _launchd_service_loaded(timeout=10)
+            return loaded
+        except (FileNotFoundError, subprocess.TimeoutExpired):
             return False
     elif is_windows():
         from hermes_cli import gateway_windows
@@ -5237,6 +5275,7 @@ def _gateway_command_inner(args):
         system = getattr(args, 'system', False)
         restart_all = getattr(args, 'all', False)
         service_configured = False
+        service_error = None
 
         if restart_all:
             # --all: stop every gateway process across all profiles, then start fresh
@@ -5291,15 +5330,15 @@ def _gateway_command_inner(args):
             try:
                 systemd_restart(system=system)
                 service_available = True
-            except subprocess.CalledProcessError:
-                pass
+            except subprocess.CalledProcessError as exc:
+                service_error = exc
         elif is_macos() and get_launchd_plist_path().exists():
             service_configured = True
             try:
                 launchd_restart()
                 service_available = True
-            except subprocess.CalledProcessError:
-                pass
+            except subprocess.CalledProcessError as exc:
+                service_error = exc
         elif is_windows():
             from hermes_cli import gateway_windows
             # Prefer the Windows-specific restart path: it supports both
@@ -5334,6 +5373,37 @@ def _gateway_command_inner(args):
                     return
 
             if service_configured:
+                err_text = ""
+                if service_error is not None:
+                    err_text = " ".join(
+                        str(part)
+                        for part in (
+                            getattr(service_error, "stderr", None),
+                            getattr(service_error, "stdout", None),
+                        )
+                        if part
+                    )
+                cmd = getattr(service_error, "cmd", None) if service_error is not None else None
+                cmd_parts = [str(part) for part in cmd] if isinstance(cmd, (list, tuple)) else []
+                launchctl_denied = (
+                    service_error is not None
+                    and getattr(service_error, "returncode", None) == 1
+                    and cmd_parts[:1] == ["launchctl"]
+                )
+                if is_macos() and (
+                    "operation not permitted" in err_text.lower() or launchctl_denied
+                ):
+                    cmd_text = " ".join(cmd_parts) if cmd_parts else str(cmd or "launchctl")
+                    print()
+                    print("✗ launchd denied the restart request.")
+                    if err_text.strip():
+                        print(f"  {err_text.strip()}")
+                    else:
+                        print("  launchctl exited with code 1; macOS usually reports this as Operation not permitted.")
+                    print("  Run the restart from an interactive user terminal that can control launchd:")
+                    print(f"    {cmd_text}")
+                    sys.exit(1)
+
                 print()
                 print("✗ Gateway service restart failed.")
                 print("  The service definition exists, but the service manager did not recover it.")

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -865,8 +865,6 @@ CREATE TABLE IF NOT EXISTS tasks (
     session_id           TEXT
 );
 
-CREATE INDEX IF NOT EXISTS idx_tasks_session_id ON tasks(session_id);
-
 CREATE TABLE IF NOT EXISTS task_links (
     parent_id  TEXT NOT NULL,
     child_id   TEXT NOT NULL,
@@ -1174,10 +1172,10 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
         _add_column_if_missing(
             conn, "tasks", "session_id", "session_id TEXT"
         )
-        conn.execute(
-            "CREATE INDEX IF NOT EXISTS idx_tasks_session_id "
-            "ON tasks(session_id)"
-        )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_tasks_session_id "
+        "ON tasks(session_id)"
+    )
 
     # task_events gained a run_id column; back-fill it as NULL for
     # historical events (they predate runs and can't be attributed).

--- a/run_agent.py
+++ b/run_agent.py
@@ -792,6 +792,9 @@ class AIAgent:
 
     def _emit_auxiliary_failure(self, task: str, exc: BaseException) -> None:
         """Surface a compact warning for failed auxiliary work."""
+        if (task or "").strip().lower().replace("_", " ") == "title generation":
+            logger.warning("Auxiliary title generation failed: %s", exc)
+            return
         try:
             detail = self._summarize_api_error(exc)
         except Exception:

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -244,6 +244,36 @@ class TestGatewayPidState:
         finally:
             status.release_gateway_runtime_lock()
 
+    def test_get_running_pid_treats_unopenable_runtime_lock_as_active(self, tmp_path, monkeypatch):
+        """Permission-denied lock probes must not crash restart/status commands."""
+        import builtins
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        pid_path = tmp_path / "gateway.pid"
+        lock_path = tmp_path / "gateway.lock"
+        record = {
+            "pid": os.getpid(),
+            "kind": "hermes-gateway",
+            "argv": ["python", "-m", "hermes_cli.main", "gateway", "run"],
+            "start_time": 123,
+        }
+        pid_path.write_text(json.dumps(record))
+        lock_path.write_text(json.dumps(record))
+
+        real_open = builtins.open
+
+        def deny_runtime_lock_open(path, *args, **kwargs):
+            if Path(path) == lock_path:
+                raise PermissionError("operation not permitted")
+            return real_open(path, *args, **kwargs)
+
+        monkeypatch.setattr(status, "open", deny_runtime_lock_open, raising=False)
+        monkeypatch.setattr(status.os, "kill", lambda pid, sig: None)
+        monkeypatch.setattr(status, "_get_process_start_time", lambda pid: 123)
+        monkeypatch.setattr(status, "_read_process_cmdline", lambda pid: None)
+
+        assert status.get_running_pid() == os.getpid()
+
 
 class TestGatewayRuntimeStatus:
     def test_write_json_file_uses_atomic_json_write(self, tmp_path, monkeypatch):

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -38,6 +38,10 @@ class TestUserSystemdPrivateSocketPreflight:
 
 
 class TestSystemdServiceRefresh:
+    @pytest.fixture(autouse=True)
+    def _skip_user_systemd_preflight(self, monkeypatch):
+        monkeypatch.setattr(gateway_cli, "_preflight_user_systemd", lambda: None)
+
     def test_systemd_install_repairs_outdated_unit_without_force(self, tmp_path, monkeypatch):
         unit_path = tmp_path / "hermes-gateway.service"
         unit_path.write_text("old unit\n", encoding="utf-8")
@@ -560,6 +564,11 @@ class TestLaunchdServiceRecovery:
 
         monkeypatch.setattr(gateway_cli, "_get_restart_drain_timeout", lambda: 12.0)
         monkeypatch.setattr(gateway_cli, "_request_gateway_self_restart", lambda pid: False)
+        monkeypatch.setattr(
+            gateway_cli,
+            "_graceful_restart_via_sigusr1",
+            lambda pid, timeout: calls.append(("graceful", pid, timeout)) or False,
+        )
         monkeypatch.setattr(gateway_cli, "_wait_for_gateway_exit", lambda timeout, force_after=None: True)
         monkeypatch.setattr(gateway_cli, "terminate_pid", lambda pid, force=False: calls.append(("term", pid, force)))
         monkeypatch.setattr(
@@ -576,6 +585,7 @@ class TestLaunchdServiceRecovery:
         gateway_cli.launchd_restart()
 
         assert calls == [
+            ("graceful", 321, 17.0),
             ("term", 321, False),
             ["launchctl", "kickstart", "-k", target],
         ]
@@ -602,6 +612,32 @@ class TestLaunchdServiceRecovery:
 
         assert calls == [("self", 321)]
         assert "restart requested" in capsys.readouterr().out.lower()
+
+    def test_launchd_restart_uses_sigusr1_before_kickstart(self, monkeypatch, capsys):
+        calls = []
+
+        monkeypatch.setattr(gateway_cli, "_get_restart_drain_timeout", lambda: 12.0)
+        monkeypatch.setattr("gateway.status.get_running_pid", lambda: 321)
+        monkeypatch.setattr(
+            gateway_cli,
+            "_request_gateway_self_restart",
+            lambda pid: calls.append(("self", pid)) or False,
+        )
+        monkeypatch.setattr(
+            gateway_cli,
+            "_graceful_restart_via_sigusr1",
+            lambda pid, timeout: calls.append(("graceful", pid, timeout)) or True,
+        )
+        monkeypatch.setattr(
+            gateway_cli.subprocess,
+            "run",
+            lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("launchctl should not run")),
+        )
+
+        gateway_cli.launchd_restart()
+
+        assert calls == [("self", 321), ("graceful", 321, 17.0)]
+        assert "restarting gracefully" in capsys.readouterr().out.lower()
 
     def test_launchd_stop_uses_bootout_not_kill(self, monkeypatch):
         """launchd_stop must bootout the service so KeepAlive doesn't respawn it."""
@@ -678,6 +714,36 @@ class TestLaunchdServiceRecovery:
         assert "stale" in output.lower()
         assert "not loaded" in output.lower()
 
+    def test_launchd_status_uses_print_for_gui_domain_job(self, tmp_path, monkeypatch, capsys):
+        plist_path = tmp_path / "ai.hermes.gateway-devops.plist"
+        plist_path.write_text("<plist>current content</plist>", encoding="utf-8")
+
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+        monkeypatch.setattr(gateway_cli, "launchd_plist_is_current", lambda: True)
+        monkeypatch.setattr(gateway_cli, "get_launchd_label", lambda: "ai.hermes.gateway-devops")
+        monkeypatch.setattr(gateway_cli, "_launchd_domain", lambda: "gui/501")
+
+        calls = []
+
+        def fake_run(cmd, **kwargs):
+            calls.append(cmd)
+            if cmd == ["launchctl", "print", "gui/501/ai.hermes.gateway-devops"]:
+                return SimpleNamespace(
+                    returncode=0,
+                    stdout="state = running\npid = 35002\n",
+                    stderr="",
+                )
+            raise AssertionError(f"Unexpected command: {cmd}")
+
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        gateway_cli.launchd_status()
+
+        output = capsys.readouterr().out
+        assert "Gateway service is loaded" in output
+        assert "pid = 35002" in output
+        assert calls == [["launchctl", "print", "gui/501/ai.hermes.gateway-devops"]]
+
 
 class TestGatewayServiceDetection:
     def test_supports_systemd_services_requires_systemctl_binary(self, monkeypatch):
@@ -736,7 +802,30 @@ class TestGatewayServiceDetection:
 
         assert gateway_cli._is_service_running() is False
 
+    def test_get_service_pids_parses_launchctl_print_output(self, monkeypatch):
+        monkeypatch.setattr(gateway_cli, "supports_systemd_services", lambda: False)
+        monkeypatch.setattr(gateway_cli, "is_macos", lambda: True)
+        monkeypatch.setattr(gateway_cli, "get_launchd_label", lambda: "ai.hermes.gateway-devops")
+        monkeypatch.setattr(gateway_cli, "_launchd_domain", lambda: "gui/501")
+
+        def fake_run(cmd, **kwargs):
+            if cmd == ["launchctl", "print", "gui/501/ai.hermes.gateway-devops"]:
+                return SimpleNamespace(
+                    returncode=0,
+                    stdout="state = running\npid = 35002\n",
+                    stderr="",
+                )
+            raise AssertionError(f"Unexpected command: {cmd}")
+
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        assert gateway_cli._get_service_pids() == {35002}
+
 class TestGatewaySystemServiceRouting:
+    @pytest.fixture(autouse=True)
+    def _skip_user_systemd_preflight(self, monkeypatch):
+        monkeypatch.setattr(gateway_cli, "_preflight_user_systemd", lambda: None)
+
     def test_systemd_restart_gracefully_restarts_running_service_and_waits(self, monkeypatch, capsys):
         calls = []
 
@@ -1136,6 +1225,70 @@ class TestGatewaySystemServiceRouting:
             raise AssertionError("Expected gateway_command to exit when service restart fails")
 
         assert run_calls == []
+
+    def test_gateway_restart_reports_launchd_permission_denied(self, tmp_path, monkeypatch, capsys):
+        plist_path = tmp_path / "ai.hermes.gateway.plist"
+        plist_path.write_text("plist\n", encoding="utf-8")
+
+        monkeypatch.setattr(gateway_cli, "is_linux", lambda: False)
+        monkeypatch.setattr(gateway_cli, "is_macos", lambda: True)
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+        monkeypatch.setattr(
+            gateway_cli,
+            "launchd_restart",
+            lambda: (_ for _ in ()).throw(
+                gateway_cli.subprocess.CalledProcessError(
+                    1,
+                    ["launchctl", "kickstart", "-k", "gui/501/ai.hermes.gateway"],
+                    stderr='Could not kickstart service "ai.hermes.gateway": 1: Operation not permitted',
+                )
+            ),
+        )
+        monkeypatch.setattr(gateway_cli, "run_gateway", lambda *args, **kwargs: None)
+        monkeypatch.setattr(gateway_cli, "kill_gateway_processes", lambda force=False: 0)
+
+        try:
+            gateway_cli.gateway_command(SimpleNamespace(gateway_command="restart", system=False))
+        except SystemExit as exc:
+            assert exc.code == 1
+        else:
+            raise AssertionError("Expected gateway_command to exit when launchd denies restart")
+
+        out = capsys.readouterr().out.lower()
+        assert "launchd denied the restart request" in out
+        assert "operation not permitted" in out
+        assert "launchctl kickstart" in out
+
+    def test_gateway_restart_reports_uncaptured_launchd_permission_denied(self, tmp_path, monkeypatch, capsys):
+        plist_path = tmp_path / "ai.hermes.gateway.plist"
+        plist_path.write_text("plist\n", encoding="utf-8")
+
+        monkeypatch.setattr(gateway_cli, "is_linux", lambda: False)
+        monkeypatch.setattr(gateway_cli, "is_macos", lambda: True)
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+        monkeypatch.setattr(
+            gateway_cli,
+            "launchd_restart",
+            lambda: (_ for _ in ()).throw(
+                gateway_cli.subprocess.CalledProcessError(
+                    1,
+                    ["launchctl", "kickstart", "-k", "gui/501/ai.hermes.gateway"],
+                )
+            ),
+        )
+        monkeypatch.setattr(gateway_cli, "run_gateway", lambda *args, **kwargs: None)
+        monkeypatch.setattr(gateway_cli, "kill_gateway_processes", lambda force=False: 0)
+
+        try:
+            gateway_cli.gateway_command(SimpleNamespace(gateway_command="restart", system=False))
+        except SystemExit as exc:
+            assert exc.code == 1
+        else:
+            raise AssertionError("Expected gateway_command to exit when launchd denies restart")
+
+        out = capsys.readouterr().out.lower()
+        assert "launchd denied the restart request" in out
+        assert "launchctl kickstart" in out
 
 
 class TestDetectVenvDir:

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -462,7 +462,7 @@ def test_detect_crashed_workers_isolated_failure_normal_retry(
             )
 
 
-def test_max_runtime_uses_current_run_start_after_retry(kanban_home):
+def test_max_runtime_uses_current_run_start_after_retry(kanban_home, monkeypatch):
     """A retry should get a fresh max-runtime window.
 
     ``tasks.started_at`` intentionally records the first time the task ever
@@ -470,6 +470,8 @@ def test_max_runtime_uses_current_run_start_after_retry(kanban_home):
     ``task_runs.started_at`` row; otherwise every retry of an old task is
     immediately timed out again.
     """
+    monkeypatch.setattr(kb, "_pid_alive", lambda _pid: False)
+
     with kb.connect() as conn:
         host = kb._claimer_id().split(":", 1)[0]
         t = kb.create_task(
@@ -1479,6 +1481,62 @@ def test_session_id_index_exists(kanban_home):
         ).fetchall()
     names = {r["name"] for r in rows}
     assert "idx_tasks_session_id" in names
+
+
+def test_connect_migrates_legacy_tasks_before_session_id_index(tmp_path):
+    """Opening a DB that predates session_id must add the column before indexing it."""
+    db_path = tmp_path / "legacy-kanban.db"
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        """
+        CREATE TABLE tasks (
+            id TEXT PRIMARY KEY,
+            title TEXT NOT NULL,
+            body TEXT,
+            assignee TEXT,
+            status TEXT NOT NULL,
+            priority INTEGER DEFAULT 0,
+            created_by TEXT,
+            created_at INTEGER NOT NULL DEFAULT 0,
+            started_at INTEGER,
+            completed_at INTEGER,
+            workspace_kind TEXT NOT NULL DEFAULT 'scratch',
+            workspace_path TEXT,
+            branch_name TEXT,
+            claim_lock TEXT,
+            claim_expires INTEGER,
+            tenant TEXT,
+            result TEXT,
+            idempotency_key TEXT,
+            consecutive_failures INTEGER NOT NULL DEFAULT 0,
+            worker_pid INTEGER,
+            last_failure_error TEXT,
+            max_runtime_seconds INTEGER,
+            last_heartbeat_at INTEGER,
+            current_run_id INTEGER,
+            workflow_template_id TEXT,
+            current_step_key TEXT,
+            skills TEXT,
+            model_override TEXT,
+            max_retries INTEGER
+        )
+        """
+    )
+    conn.close()
+    kb._INITIALIZED_PATHS.discard(str(db_path.resolve()))
+
+    with kb.connect(db_path) as migrated:
+        cols = {row["name"] for row in migrated.execute("PRAGMA table_info(tasks)")}
+        indexes = {
+            row["name"]
+            for row in migrated.execute(
+                "SELECT name FROM sqlite_master WHERE type='index' "
+                "AND tbl_name='tasks'"
+            )
+        }
+
+    assert "session_id" in cols
+    assert "idx_tasks_session_id" in indexes
 
 
 def test_session_id_compose_with_tenant_filter(kanban_home):

--- a/tests/run_agent/test_auxiliary_failure.py
+++ b/tests/run_agent/test_auxiliary_failure.py
@@ -1,0 +1,34 @@
+"""Tests for user-visible auxiliary failure handling."""
+
+from __future__ import annotations
+
+import logging
+
+import run_agent
+from run_agent import AIAgent
+
+
+def test_title_generation_failure_logs_without_user_warning(caplog):
+    agent = object.__new__(AIAgent)
+    warnings = []
+    agent._emit_warning = warnings.append
+    agent._summarize_api_error = lambda exc: (_ for _ in ()).throw(
+        AssertionError("title generation should not summarize provider errors")
+    )
+
+    with caplog.at_level(logging.WARNING, logger=run_agent.logger.name):
+        agent._emit_auxiliary_failure("title generation", RuntimeError("blocked"))
+
+    assert warnings == []
+    assert "Auxiliary title generation failed: blocked" in caplog.text
+
+
+def test_non_title_auxiliary_failure_still_emits_user_warning():
+    agent = object.__new__(AIAgent)
+    warnings = []
+    agent._emit_warning = warnings.append
+    agent._summarize_api_error = lambda exc: "compact detail"
+
+    agent._emit_auxiliary_failure("background review", RuntimeError("raw detail"))
+
+    assert warnings == ["⚠ Auxiliary background review failed: compact detail"]


### PR DESCRIPTION
## Summary
- Use launchctl print for macOS launchd service status/PID detection and improve permission-denied restart reporting.
- Treat unopenable gateway runtime locks as active instead of stale.
- Ensure legacy kanban DBs add session_id before creating its index.
- Keep title generation auxiliary failures out of user-visible warnings while preserving logs.

## Test Plan
- `git diff --check HEAD~1..HEAD`
- `venv/bin/python -m pytest tests/gateway/test_status.py tests/hermes_cli/test_gateway_service.py tests/hermes_cli/test_kanban_db.py tests/run_agent/test_auxiliary_failure.py tests/agent/test_title_generator.py tests/gateway/test_telegram_noise_filter.py`