### PR TITLE
fix(gateway): make Telegram root-DM topic pinning opt-in (#30411)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2040,19 +2040,58 @@ class GatewayRunner:
             session_id=session_entry.session_id,
         )
 
+    def _telegram_pin_root_dm_replies_enabled(self, source: SessionSource) -> bool:
+        """Return True when the operator opted into pinning root-DM replies.
+
+        Controlled via ``gateway.platforms.telegram.extra.pin_root_dm_replies``.
+        Default is False: a new message from the root Telegram DM creates a
+        fresh topic (the original pre-#30411 behavior) and tool-call output
+        routes to that topic. Set True to opt into the legacy pin-to-current-
+        topic behavior introduced by ``_recover_telegram_topic_thread_id``;
+        useful when you specifically want a cross-topic Reply or a stripped
+        plain reply to fall back to the user's most-recent topic instead of
+        spawning a new session.
+        """
+        if source.platform != Platform.TELEGRAM:
+            return False
+        platform_cfg = (
+            self.config.platforms.get(source.platform)
+            if getattr(self, "config", None) and getattr(self.config, "platforms", None)
+            else None
+        )
+        if platform_cfg is None:
+            return False
+        extra = getattr(platform_cfg, "extra", None) or {}
+        value = extra.get("pin_root_dm_replies")
+        if value is None:
+            return False
+        if isinstance(value, bool):
+            return value
+        if isinstance(value, str):
+            return value.strip().lower() in {"1", "true", "yes", "on"}
+        return bool(value)
+
     def _recover_telegram_topic_thread_id(
         self,
         source: SessionSource,
     ) -> Optional[str]:
-        """Pin DM-topic routing to the user's last-active topic.
+        """Opt-in: pin DM-topic routing to the user's last-active topic.
 
         Telegram fragments topic-mode DMs two ways: a Reply on a message
         in another topic delivers ``message_thread_id`` for *that* topic,
         and ``_build_message_event`` strips the thread_id on plain replies
-        (#3206 — needed for non-topic users). Both route the user to the
-        wrong session. When topic mode is on, rewrite the thread_id to the
-        user's most-recent binding if the inbound id is missing/General or
-        not a known topic for this chat. Returns None to leave it alone.
+        (#3206 — needed for non-topic users). Both can route the user to a
+        different session than where they replied. When topic mode is on
+        *and* the operator opted in via ``extra.pin_root_dm_replies``,
+        rewrite the thread_id to the user's most-recent binding if the
+        inbound id is missing/General or not a known topic for this chat.
+
+        The flag defaults to off because the previous always-on behavior
+        broke the root-DM → new-topic flow (see #30411): a fresh root-DM
+        message would be silently pinned to the user's last topic instead
+        of spawning a new one, which also broke auto-topic-rename and
+        tool-call routing for the new session. Returns None to leave the
+        thread_id alone.
         """
         if (
             source.platform != Platform.TELEGRAM
@@ -2060,6 +2099,7 @@ class GatewayRunner:
             or not source.chat_id
             or not source.user_id
             or not self._telegram_topic_mode_enabled(source)
+            or not self._telegram_pin_root_dm_replies_enabled(source)
         ):
             return None
         session_db = getattr(self, "_session_db", None)

--- a/tests/gateway/test_telegram_topic_mode.py
+++ b/tests/gateway/test_telegram_topic_mode.py
@@ -1130,8 +1130,18 @@ async def test_topic_refuses_unauthorized_user(tmp_path, monkeypatch):
 
 
 # ──────────────────────────────────────────────────────────────────────
-# Cross-topic Reply leak / stripped-reply recovery
+# Cross-topic Reply leak / stripped-reply recovery (opt-in pinning)
 # ──────────────────────────────────────────────────────────────────────
+#
+# Pin-to-current-topic recovery is gated behind the
+# ``telegram.extra.pin_root_dm_replies`` flag (default off). See #30411 —
+# the always-on version broke the root-DM → new-topic flow plus the
+# downstream auto-rename and tool-call routing in that new topic.
+
+
+def _pin_root_dm_replies(runner, *, enabled: bool = True) -> None:
+    """Helper: toggle the opt-in pin_root_dm_replies flag on a fixture runner."""
+    runner.config.platforms[Platform.TELEGRAM].extra["pin_root_dm_replies"] = enabled
 
 
 def _seed_two_topic_bindings(session_db):
@@ -1171,24 +1181,28 @@ def test_recover_returns_none_for_known_topic(tmp_path):
     db = SessionDB(db_path=tmp_path / "state.db")
     _seed_two_topic_bindings(db)
     runner = _make_runner(session_db=db)
+    _pin_root_dm_replies(runner)
 
     assert runner._recover_telegram_topic_thread_id(_make_source(thread_id="222")) is None
 
 
 def test_recover_rewrites_unknown_thread_id_to_most_recent(tmp_path):
     # Cross-topic Reply leak: inbound thread_id is a Telegram-only id we never bound.
+    # Requires the operator to opt into pin_root_dm_replies.
     db = SessionDB(db_path=tmp_path / "state.db")
     _seed_two_topic_bindings(db)
     runner = _make_runner(session_db=db)
+    _pin_root_dm_replies(runner)
 
     assert runner._recover_telegram_topic_thread_id(_make_source(thread_id="9999")) == "222"
 
 
 def test_recover_rewrites_lobby_thread_id_to_most_recent(tmp_path):
-    # Stripped plain reply: thread_id is None, topic mode is on.
+    # Stripped plain reply: thread_id is None, topic mode is on, operator opted in.
     db = SessionDB(db_path=tmp_path / "state.db")
     _seed_two_topic_bindings(db)
     runner = _make_runner(session_db=db)
+    _pin_root_dm_replies(runner)
 
     assert runner._recover_telegram_topic_thread_id(_make_source(thread_id=None)) == "222"
 
@@ -1197,6 +1211,7 @@ def test_recover_returns_none_when_topic_mode_disabled(tmp_path):
     # Non-topic-mode DMs keep the existing strip-to-lobby behavior.
     db = SessionDB(db_path=tmp_path / "state.db")
     runner = _make_runner(session_db=db)
+    _pin_root_dm_replies(runner)
 
     assert runner._recover_telegram_topic_thread_id(_make_source(thread_id=None)) is None
 
@@ -1205,8 +1220,113 @@ def test_recover_returns_none_when_no_bindings_yet(tmp_path):
     db = SessionDB(db_path=tmp_path / "state.db")
     db.enable_telegram_topic_mode(chat_id="208214988", user_id="208214988")
     runner = _make_runner(session_db=db)
+    _pin_root_dm_replies(runner)
 
     assert runner._recover_telegram_topic_thread_id(_make_source(thread_id=None)) is None
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Regression: #30411 — opt-in default keeps root-DM → new-topic flow
+# ──────────────────────────────────────────────────────────────────────
+#
+# Before this fix, _recover_telegram_topic_thread_id() was unconditional
+# whenever topic mode was on, so a fresh root-DM message (lobby thread_id)
+# was silently pinned to the user's last topic. That broke the documented
+# behavior: a new root-DM message should create a NEW topic, get auto-
+# renamed after one turn, and have tool-call output routed to *that* new
+# topic. The fix makes the pinning opt-in via ``pin_root_dm_replies`` so
+# the default flow is restored. These tests pin the default-off contract.
+
+
+def test_pin_root_dm_replies_default_off(tmp_path):
+    """#30411: default-off — root-DM with existing topics is left alone so a new topic can spawn."""
+    db = SessionDB(db_path=tmp_path / "state.db")
+    _seed_two_topic_bindings(db)
+    runner = _make_runner(session_db=db)
+    # No extra.pin_root_dm_replies → flag is None → opt-out (default).
+
+    # Lobby/stripped: would have been pinned pre-fix; now returns None.
+    assert runner._recover_telegram_topic_thread_id(_make_source(thread_id=None)) is None
+    # Cross-topic Reply leak: would have been rewritten pre-fix; now returns None.
+    assert runner._recover_telegram_topic_thread_id(_make_source(thread_id="9999")) is None
+    # Sanity: helper agrees the flag is off.
+    assert runner._telegram_pin_root_dm_replies_enabled(_make_source(thread_id=None)) is False
+
+
+def test_pin_root_dm_replies_explicit_false(tmp_path):
+    """#30411: explicit False is also opt-out — no pinning, mirrors default."""
+    db = SessionDB(db_path=tmp_path / "state.db")
+    _seed_two_topic_bindings(db)
+    runner = _make_runner(session_db=db)
+    _pin_root_dm_replies(runner, enabled=False)
+
+    assert runner._recover_telegram_topic_thread_id(_make_source(thread_id=None)) is None
+    assert runner._recover_telegram_topic_thread_id(_make_source(thread_id="9999")) is None
+    assert runner._telegram_pin_root_dm_replies_enabled(_make_source(thread_id=None)) is False
+
+
+@pytest.mark.parametrize("truthy", ["true", "True", "1", "yes", "on"])
+def test_pin_root_dm_replies_truthy_string_opts_in(tmp_path, truthy):
+    """YAML often serializes booleans as strings; accept the same shapes as disable_topic_auto_rename."""
+    db = SessionDB(db_path=tmp_path / "state.db")
+    _seed_two_topic_bindings(db)
+    runner = _make_runner(session_db=db)
+    runner.config.platforms[Platform.TELEGRAM].extra["pin_root_dm_replies"] = truthy
+
+    # With the flag on, a stripped plain reply gets pinned to the most recent topic.
+    assert runner._recover_telegram_topic_thread_id(_make_source(thread_id=None)) == "222"
+    assert runner._telegram_pin_root_dm_replies_enabled(_make_source(thread_id=None)) is True
+
+
+def test_pin_root_dm_replies_disable_topic_auto_rename_decoupled(tmp_path):
+    """Auto-rename and the pin flag are independent — neither must clobber the other.
+
+    Reproduces the second half of #30411: ``disable_topic_auto_rename`` was
+    silently misbehaving because the always-on recovery rewrote thread_ids
+    out from under the rename path. With the fix, the auto-rename helper
+    keeps its own contract regardless of the pin flag.
+    """
+    db = SessionDB(db_path=tmp_path / "state.db")
+    runner = _make_runner(session_db=db)
+
+    # Default: auto-rename enabled (not disabled).
+    assert runner._telegram_topic_auto_rename_disabled(_make_source(thread_id="222")) is False
+    # Pin flag is independent of auto-rename and defaults off.
+    assert runner._telegram_pin_root_dm_replies_enabled(_make_source(thread_id="222")) is False
+
+    # Turn pin on — auto-rename must remain enabled (operator didn't ask to disable it).
+    _pin_root_dm_replies(runner)
+    assert runner._telegram_topic_auto_rename_disabled(_make_source(thread_id="222")) is False
+    assert runner._telegram_pin_root_dm_replies_enabled(_make_source(thread_id="222")) is True
+
+    # Turn auto-rename off — pin flag must remain whatever it was, independently.
+    runner.config.platforms[Platform.TELEGRAM].extra["disable_topic_auto_rename"] = True
+    assert runner._telegram_topic_auto_rename_disabled(_make_source(thread_id="222")) is True
+    assert runner._telegram_pin_root_dm_replies_enabled(_make_source(thread_id="222")) is True
+
+
+def test_pin_root_dm_replies_tool_call_routing_default(tmp_path):
+    """#30411 edge case: tool-call payload arriving with the inbound thread_id is left alone in default mode.
+
+    The bug: a tool-call event would carry the recovered (pinned) thread_id
+    instead of the topic the user actually replied in, so progress messages
+    surfaced in the wrong topic. With pinning off by default, the recovery
+    helper must not mutate the thread_id of an inbound event — leaving it
+    free to be routed to whichever topic the source actually points at.
+    """
+    db = SessionDB(db_path=tmp_path / "state.db")
+    _seed_two_topic_bindings(db)
+    runner = _make_runner(session_db=db)
+    # Default mode (flag unset). A tool-call inbound for topic "111" — the
+    # *older* topic, not the most-recent — must not be rewritten to "222".
+    src = _make_source(thread_id="111")
+    assert runner._recover_telegram_topic_thread_id(src) is None
+
+    # And opting in must not mangle a *known* topic either — pinning only
+    # ever rewrites unknown / lobby inbound ids, never a real bound topic.
+    _pin_root_dm_replies(runner)
+    assert runner._recover_telegram_topic_thread_id(_make_source(thread_id="111")) is None
+    assert runner._recover_telegram_topic_thread_id(_make_source(thread_id="222")) is None
 
 
 def test_list_telegram_topic_bindings_for_chat(tmp_path):


### PR DESCRIPTION
## Summary

Fixes #30411. Commit [`ede47a54b`](https://github.com/NousResearch/hermes-agent/commit/ede47a54b) added `_recover_telegram_topic_thread_id()` in `gateway/run.py` and wired it unconditionally for every inbound Telegram DM whenever topic mode is on. That silently broke the documented **root-DM → new-topic → auto-rename → tool-call routing** flow: a fresh message from the root Telegram DM (`thread_id` missing/General) gets rewritten to the user's most-recent bound topic before the session store ever sees it, so a brand-new topic is never spawned and the new session's auto-rename + tool-call payloads land in the wrong topic.

The pinning behavior is still genuinely useful for the original use case (cross-topic Reply leaks, stripped plain replies that would otherwise land in the lobby), so this PR **does not revert** it — it makes it opt-in behind a new flag, restoring the pre-`ede47a54b` default.

```yaml
gateway:
  platforms:
    telegram:
      extra:
        pin_root_dm_replies: true   # default: false
```

## Before / after

| Scenario (topic mode on)                                          | Before this PR                          | After (default, flag off)               | After (flag on)                           |
| ----------------------------------------------------------------- | --------------------------------------- | --------------------------------------- | ----------------------------------------- |
| New root-DM message, lobby `thread_id`                            | ❌ pinned to last topic                  | ✅ thread_id untouched → new topic spawn | pinned to last topic (legacy)             |
| Cross-topic Reply leak (inbound `thread_id` for a different topic) | rewritten to last topic                 | thread_id untouched                     | rewritten to last topic                   |
| Reply inside an already-bound topic (`thread_id` matches binding) | left alone                              | left alone                              | left alone                                |
| Auto-rename after first turn (`disable_topic_auto_rename` unset)   | ❌ no-op (rewrite hides the new topic)   | ✅ renames the new topic                 | renames whatever topic the pin selected   |
| Tool-call progress for an older topic                              | ❌ surfaces in pinned (newest) topic     | ✅ surfaces in the topic that produced it | surfaces in pinned topic (legacy)         |

## Reproduction (from the issue)

1. Run Hermes gateway with Telegram enabled, `telegram.extra.disable_topic_auto_rename` unset (defaults to `false`).
2. Send a message from the Telegram root DM — a new topic should be created.
3. Reply in that topic — it should get auto-renamed after one turn.
4. Send a **new** message from the root DM again — pre-fix, the response appears in the topic from step 2; post-fix, a fresh topic is created.

## Root cause

Commit [`ede47a54b`](https://github.com/NousResearch/hermes-agent/commit/ede47a54b) ("fix(gateway): pin Telegram DM-topic routing to user's current topic") added `_recover_telegram_topic_thread_id()` and wired it into the inbound-message path in `GatewayRunner` so it ran whenever:

- platform is Telegram,
- chat_type is `dm`,
- topic mode is enabled for the chat.

The function rewrites `source.thread_id` to the most recently bound topic whenever the inbound `thread_id` is missing/General or otherwise unknown. That matches the cross-topic Reply leak case it was written for, but **the same conditions also fire for every genuinely fresh root-DM message** — lobby `thread_id` is exactly how Telegram delivers a brand-new root-DM. There's no signal in the inbound payload that distinguishes "stripped plain reply" from "intentional new conversation in the lobby", so the always-on rewrite collapsed both into the pinned-to-last-topic branch.

That cascaded into two secondary bugs that look unrelated at the call site but share the same root:

- **Auto-rename:** `_telegram_topic_auto_rename_disabled` defaults to `False`, but the rename path operates on the post-recovery `source.thread_id`. After the rewrite, the helper "renames" the already-named older topic instead of the brand-new topic that was supposed to be created, so the rename appears silently broken.
- **Tool-call routing:** progress events use `source` from the inbound message; once it's been rewritten to the pinned topic, tool-call output surfaces in that pinned topic regardless of which topic the user actually replied in.

## Design — why opt-in instead of revert

`ede47a54b` solves a real problem (Telegram delivering `message_thread_id` for a *foreign* topic on cross-topic Replies, and `_build_message_event` stripping `thread_id` on plain replies via #3206). Reverting would re-break that for anyone who deployed against newer Hermes versions and started relying on the pinning. Instead:

- Default `pin_root_dm_replies = false` restores the pre-`ede47a54b` behavior — root-DM lobby messages flow through unmodified, new topics get created, auto-rename runs against the right topic, tool calls route to the originating topic.
- Operators who explicitly want pinning (the original use case in `ede47a54b`'s tests) opt in via `extra.pin_root_dm_replies: true`. The function body is otherwise unchanged.
- The flag is read via a small dedicated helper (`_telegram_pin_root_dm_replies_enabled`) that mirrors the shape of the sibling `_telegram_topic_auto_rename_disabled`: accepts `bool`, plus YAML-friendly truthy strings (`true`/`yes`/`on`/`1`).

## Migration note

If you previously relied on the recovery rewrite (root-DM lobby messages or cross-topic Replies getting pinned to your last active topic), add:

```yaml
gateway:
  platforms:
    telegram:
      extra:
        pin_root_dm_replies: true
```

If you didn't know that behavior existed (or actively wanted root-DM messages to spawn new topics), do nothing — the default now matches the pre-`ede47a54b` behavior.

## Architecture affected

```
inbound Telegram update
        │
        ▼
GatewayRunner.handle_message_event
        │
        ▼   ← recovery hook (this PR makes it opt-in)
_recover_telegram_topic_thread_id ──gated by─▶ extra.pin_root_dm_replies
        │
        ▼
source.thread_id (possibly rewritten)
        │
        ▼
SessionStore.get_or_create_session  ──▶ binding lookup / new topic spawn
        │
        ▼
session run ──▶ _schedule_telegram_topic_title_rename ──gated by─▶ extra.disable_topic_auto_rename
        │
        ▼
tool-call progress events ──▶ adapter.send(..., thread_id=source.thread_id)
```

The two `extra` flags are intentionally decoupled (covered by a dedicated test): flipping one must not silently mutate the other's effective behavior.

## Tests

All in `tests/gateway/test_telegram_topic_mode.py`. Existing 5 recovery tests were updated to opt in via the new flag (`_pin_root_dm_replies(runner)`). New tests pin the bug-fix contract:

- `test_pin_root_dm_replies_default_off` — #30411 regression: flag unset → lobby + unknown inbound thread_ids are no longer rewritten.
- `test_pin_root_dm_replies_explicit_false` — parity check: explicit `false` matches the default.
- `test_pin_root_dm_replies_truthy_string_opts_in[true|True|1|yes|on]` — YAML-friendly string parsing, parametrized to match the sibling `disable_topic_auto_rename` flag's accepted shapes.
- `test_pin_root_dm_replies_disable_topic_auto_rename_decoupled` — second half of the bug report: the two flags are independent; flipping one must not change the other's effective state.
- `test_pin_root_dm_replies_tool_call_routing_default` — edge case: a tool-call inbound carrying an *older* topic's `thread_id` is never rewritten to the most-recent topic, in either default or opt-in mode.

Test run on this branch:

```
tests/gateway/test_telegram_topic_mode.py ........................... 51 passed
```

Verified the new tests fail on the parent commit without the `gateway/run.py` change (`test_pin_root_dm_replies_default_off` asserts `None`, gets `'222'` from the unconditional pinning) and pass with it.

Fixes #30411
