### PR TITLE
fix(approval): add reasoning_content fallback for smart approvals

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1426,6 +1426,8 @@ DEFAULT_CONFIG = {
         "mode": "manual",
         "timeout": 60,
         "cron_mode": "deny",
+        # Token budget for smart approval LLM; reasoning models need >64.
+        "smart_max_tokens": 128,
         # When true, /reload-mcp asks the user to confirm before rebuilding
         # the MCP tool set for the active session.  Reloading invalidates
         # the provider prompt cache (tool schemas are baked into the system

--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -33,14 +33,46 @@ class TestSmartApproval:
         response = SimpleNamespace(
             choices=[SimpleNamespace(message=SimpleNamespace(content="APPROVE"))]
         )
-        with mock_patch("agent.auxiliary_client.call_llm", return_value=response) as mock_call:
+        with (
+            mock_patch("hermes_cli.config.load_config", return_value={"approvals": {}}),
+            mock_patch("agent.auxiliary_client.call_llm", return_value=response) as mock_call,
+        ):
             result = _smart_approve("python -c \"print('hello')\"", "script execution via -c flag")
 
         assert result == "approve"
         mock_call.assert_called_once()
         assert mock_call.call_args.kwargs["task"] == "approval"
         assert mock_call.call_args.kwargs["temperature"] == 0
-        assert mock_call.call_args.kwargs["max_tokens"] == 16
+        assert mock_call.call_args.kwargs["max_tokens"] == 128
+
+    def test_smart_approval_reads_max_tokens_from_config(self):
+        response = SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content="APPROVE"))]
+        )
+        config = {"approvals": {"smart_max_tokens": 256}}
+        with (
+            mock_patch("hermes_cli.config.load_config", return_value=config),
+            mock_patch("agent.auxiliary_client.call_llm", return_value=response) as mock_call,
+        ):
+            _smart_approve("python -c \"print('hi')\"", "script execution via -c flag")
+
+        assert mock_call.call_args.kwargs["max_tokens"] == 256
+
+    def test_smart_approval_falls_back_on_invalid_max_tokens(self):
+        """Non-integer or sub-1 values in config fall back to the default budget."""
+        response = SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content="APPROVE"))]
+        )
+        for bad_value in ("not-an-int", 0, -5):
+            config = {"approvals": {"smart_max_tokens": bad_value}}
+            with (
+                mock_patch("hermes_cli.config.load_config", return_value=config),
+                mock_patch("agent.auxiliary_client.call_llm", return_value=response) as mock_call,
+            ):
+                _smart_approve("python -c \"print('hi')\"", "script execution via -c flag")
+            assert mock_call.call_args.kwargs["max_tokens"] == 128, (
+                f"expected fallback to 128 for {bad_value!r}, got {mock_call.call_args.kwargs['max_tokens']}"
+            )
 
 
 class TestDetectDangerousRm:

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -909,6 +909,11 @@ Respond with exactly one word: APPROVE, DENY, or ESCALATE"""
         )
 
         answer = (response.choices[0].message.content or "").strip().upper()
+        # Reasoning models (e.g. Z.AI GLM, DeepSeek-R1) may put the answer
+        # in reasoning_content when content is empty
+        if not answer:
+            rc = getattr(response.choices[0].message, "reasoning_content", None) or ""
+            answer = rc.strip().upper()
 
         if "APPROVE" in answer:
             return "approve"

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -863,6 +863,9 @@ def _get_cron_approval_mode() -> str:
         return "deny"
 
 
+_SMART_APPROVE_DEFAULT_MAX_TOKENS = 128
+
+
 def _smart_approve(command: str, description: str) -> str:
     """Use the auxiliary LLM to assess risk and decide approval.
 
@@ -874,6 +877,15 @@ def _smart_approve(command: str, description: str) -> str:
     """
     try:
         from agent.auxiliary_client import call_llm
+
+        try:
+            smart_max_tokens = int(
+                _get_approval_config().get("smart_max_tokens", _SMART_APPROVE_DEFAULT_MAX_TOKENS)
+            )
+            if smart_max_tokens < 1:
+                smart_max_tokens = _SMART_APPROVE_DEFAULT_MAX_TOKENS
+        except (ValueError, TypeError):
+            smart_max_tokens = _SMART_APPROVE_DEFAULT_MAX_TOKENS
 
         prompt = f"""You are a security reviewer for an AI coding agent. A terminal command was flagged by pattern matching as potentially dangerous.
 
@@ -893,7 +905,7 @@ Respond with exactly one word: APPROVE, DENY, or ESCALATE"""
             task="approval",
             messages=[{"role": "user", "content": prompt}],
             temperature=0,
-            max_tokens=16,
+            max_tokens=smart_max_tokens,
         )
 
         answer = (response.choices[0].message.content or "").strip().upper()


### PR DESCRIPTION
## What does this PR do?

Adds a `reasoning_content` fallback in `_smart_approve` so that reasoning models (Z.AI GLM, DeepSeek-R1, etc.) that emit chain-of-thought into `reasoning_content` instead of `message.content` are handled correctly.

## Relationship to PR #29517

This PR is **rebased on top of** `savanne-kham/hermes-agent:fix/smart-approval-configurable-max-tokens` (#29517). That PR makes `max_tokens` configurable — a necessary prerequisite — and explicitly lists `reasoning_content` support as future work:

> *"Read `reasoning_content` when `content` is empty instead of relying on a wider budget. Provider-specific field names (`reasoning_content`, Anthropic thinking blocks, etc.) and free-text parsing make it a larger refactor — out of scope here."*

This PR delivers that future work. If #29517 merges first, this branch can be rebased onto `main` cleanly. Alternatively, the maintainers can merge this into #29517's branch if they prefer a single PR.

## The Problem

Even with a generous `max_tokens` budget, some reasoning models still occasionally emit an empty `message.content` with the actual answer in `reasoning_content`. Without this fallback, such responses are treated as `escalate`, falling back to manual approval and defeating smart mode.

## Changes Made

- `tools/approval.py` — after checking `message.content`, if empty, check `reasoning_content` via `getattr()` (safe for providers that do not include this field):

```python
if not answer:
    rc = getattr(response.choices[0].message, "reasoning_content", None) or ""
    answer = rc.strip().upper()
```

## Testing

Tested locally with Z.AI GLM-5-Turbo as the approval auxiliary model:
- `python3 -c "print('hi')"` → auto-approved (reasoning model put verdict in `reasoning_content`)
- `rm /tmp/test-file.json` → auto-approved (correctly assessed as safe temp file deletion)
- Previous behavior: both required manual approval despite being benign

## Checklist

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for existing PRs — #29517 addresses the token budget; this adds the complementary fallback
- [x] My PR contains only changes related to this fix
- [x] Cross-platform: pure Python, no platform-specific behavior