### PR TITLE
fix(computer-use): cap elements array in aux-vision routing path

### DIFF
--- a/tests/tools/test_computer_use_capture_routing.py
+++ b/tests/tools/test_computer_use_capture_routing.py
@@ -428,4 +428,116 @@ class TestBugReproductionAnchor:
         # 'No endpoints found that support image input' on the reporter's
         # main provider in #24015.
         assert "data:image" not in resp
+
+
+# ---------------------------------------------------------------------------
+# Elements cap parity: aux-vision path must honour max_elements (#22865 shape)
+# ---------------------------------------------------------------------------
+
+class TestAuxVisionElementsCap:
+    """Regression: _route_capture_through_aux_vision must respect the
+    max_elements cap that _capture_response computes.
+
+    Prior to the fix, the aux-vision path returned cap.elements verbatim
+    (all 600 on a dense UI) while the AX path correctly sliced to
+    visible_elements[:max_elements]. Dense SOM captures routed via
+    auxiliary.vision therefore produced oversized tool results that could
+    exhaust session context — the same #22865 shape as the AX-path fix.
+    """
+
+    def _make_dense_capture(self, count: int):
+        from tools.computer_use.backend import CaptureResult, UIElement
+
+        elements = [
+            UIElement(index=i + 1, role="AXButton", label=f"btn-{i}",
+                      bounds=(0, i * 10, 80, 10))
+            for i in range(count)
+        ]
+        return CaptureResult(
+            mode="som",
+            width=1280,
+            height=800,
+            png_b64=(
+                "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42m"
+                "NkYAAAAAYAAjCB0C8AAAAASUVORK5CYII="
+            ),
+            elements=elements,
+            app="Electron",
+            window_title="Dense UI",
+        )
+
+    def test_aux_vision_caps_elements_at_default_for_dense_som(
+        self, tmp_cache_dir,
+    ):
+        """600-element SOM routed via aux vision must not dump all 600 into JSON."""
+        from tools.computer_use import tool as cu_tool
+
+        cap = self._make_dense_capture(600)
+
+        def _fake_run_async(_coro):
+            return json.dumps({"success": True, "analysis": "dense UI"})
+
+        fake_vat = MagicMock(return_value="<coro>")
+
+        with patch.object(cu_tool, "_should_route_through_aux_vision",
+                          return_value=True), \
+             patch("model_tools._run_async", side_effect=_fake_run_async), \
+             patch("tools.vision_tools.vision_analyze_tool",
+                   new_callable=lambda: fake_vat):
+            resp = cu_tool._capture_response(cap)
+
+        body = json.loads(resp)
+        assert len(body["elements"]) == cu_tool._DEFAULT_MAX_ELEMENTS
+        assert body["total_elements"] == 600
+        assert body["truncated_elements"] == 600 - cu_tool._DEFAULT_MAX_ELEMENTS
+
+    def test_aux_vision_honors_explicit_max_elements_override(
+        self, tmp_cache_dir,
+    ):
+        """Caller-supplied max_elements must flow through to the aux-vision path."""
+        from tools.computer_use import tool as cu_tool
+
+        cap = self._make_dense_capture(300)
+
+        def _fake_run_async(_coro):
+            return json.dumps({"success": True, "analysis": "dense UI"})
+
+        fake_vat = MagicMock(return_value="<coro>")
+
+        with patch.object(cu_tool, "_should_route_through_aux_vision",
+                          return_value=True), \
+             patch("model_tools._run_async", side_effect=_fake_run_async), \
+             patch("tools.vision_tools.vision_analyze_tool",
+                   new_callable=lambda: fake_vat):
+            resp = cu_tool._capture_response(cap, max_elements=50)
+
+        body = json.loads(resp)
+        assert len(body["elements"]) == 50
+        assert body["total_elements"] == 300
+        assert body["truncated_elements"] == 250
+
+    def test_aux_vision_no_truncated_field_when_under_cap(
+        self, tmp_cache_dir,
+    ):
+        """Small captures must not surface a truncated_elements field."""
+        from tools.computer_use import tool as cu_tool
+
+        cap = self._make_dense_capture(5)
+
+        def _fake_run_async(_coro):
+            return json.dumps({"success": True, "analysis": "small UI"})
+
+        fake_vat = MagicMock(return_value="<coro>")
+
+        with patch.object(cu_tool, "_should_route_through_aux_vision",
+                          return_value=True), \
+             patch("model_tools._run_async", side_effect=_fake_run_async), \
+             patch("tools.vision_tools.vision_analyze_tool",
+                   new_callable=lambda: fake_vat):
+            resp = cu_tool._capture_response(cap)
+
+        body = json.loads(resp)
+        assert len(body["elements"]) == 5
+        assert body["total_elements"] == 5
+        assert "truncated_elements" not in body
         assert "image_url" not in resp

--- a/tools/computer_use/tool.py
+++ b/tools/computer_use/tool.py
@@ -486,7 +486,7 @@ def _capture_response(cap: CaptureResult, max_elements: int = _DEFAULT_MAX_ELEME
         # main models tripped HTTP 404 / 400 at the provider boundary even
         # when auxiliary.vision was explicitly configured to handle this.
         if _should_route_through_aux_vision():
-            routed = _route_capture_through_aux_vision(cap, summary)
+            routed = _route_capture_through_aux_vision(cap, summary, visible_elements)
             if routed is not None:
                 return routed
             # Aux routing was requested but failed (no vision client, aux
@@ -575,6 +575,7 @@ def _should_route_through_aux_vision() -> bool:
 def _route_capture_through_aux_vision(
     cap: CaptureResult,
     summary: str,
+    visible_elements: Optional[list] = None,
 ) -> Optional[str]:
     """Pre-analyse the captured PNG via ``vision_analyze`` and return a text result.
 
@@ -657,17 +658,24 @@ def _route_capture_through_aux_vision(
     if not analysis_text:
         return None
 
-    return json.dumps({
+    _effective_elements = visible_elements if visible_elements is not None else cap.elements
+    _total = len(cap.elements)
+    _truncated = max(0, _total - len(_effective_elements))
+    _payload: Dict[str, Any] = {
         "mode": cap.mode,
         "width": cap.width,
         "height": cap.height,
         "app": cap.app,
         "window_title": cap.window_title,
-        "elements": [_element_to_dict(e) for e in cap.elements],
+        "elements": [_element_to_dict(e) for e in _effective_elements],
+        "total_elements": _total,
         "summary": summary,
         "vision_analysis": analysis_text,
         "vision_analysis_routed_via": "auxiliary.vision",
-    })
+    }
+    if _truncated:
+        _payload["truncated_elements"] = _truncated
+    return json.dumps(_payload)
 
 
 def _maybe_follow_capture(


### PR DESCRIPTION
## Root Cause

`_route_capture_through_aux_vision` returned `cap.elements` verbatim —
bypassing the `max_elements` cap that `_capture_response` computes for the
AX and multimodal paths.

On a dense UI (Electron app, Slack, JetBrains IDE), SOM captures produce
600+ AX nodes. When `auxiliary.vision` is configured or the main model is
not vision-capable, those captures route through `_route_capture_through_aux_vision`,
which was returning all nodes uncapped. The AX-only path was fixed by #30145,
but the aux-vision routing path was not updated symmetrically.

## Failure Path

1. User has `auxiliary.vision` configured (or main model doesn't support vision).
2. Agent calls `computer_use(action="capture", mode="som")` on a dense UI (600 elements).
3. `_capture_response` computes `visible_elements = cap.elements[:max_elements]` (100 nodes).
4. `_should_route_through_aux_vision()` returns `True`.
5. `_route_capture_through_aux_vision(cap, summary)` is called with the full `cap` object.
6. Return statement: `"elements": [_element_to_dict(e) for e in cap.elements]` — all 600 nodes emitted, context blowup.

## Fix

Pass `visible_elements` (already capped) from `_capture_response` to
`_route_capture_through_aux_vision`. Add `total_elements` and conditional
`truncated_elements` fields for parity with the AX path so the model knows
the response is partial.

```diff
-routed = _route_capture_through_aux_vision(cap, summary)
+routed = _route_capture_through_aux_vision(cap, summary, visible_elements)
```

```diff
-"elements": [_element_to_dict(e) for e in cap.elements],
+"elements": [_element_to_dict(e) for e in _effective_elements],
+"total_elements": _total,
 "summary": summary,
+# "truncated_elements": _truncated  (only when truncated)
```

Symmetric with the AX path fix in #30145. No behaviour change for captures
with fewer than `max_elements` nodes.

## Tests

3 regression tests added to `test_computer_use_capture_routing.py`:

- [ ] 600-element SOM capture routed via aux vision is capped to `_DEFAULT_MAX_ELEMENTS` (100)
- [ ] Explicit `max_elements=50` override flows through to the aux-vision response
- [ ] Captures under the cap do not surface a `truncated_elements` field

All 90 computer-use tests pass (`test_computer_use.py` + `test_computer_use_capture_routing.py`).