### PR TITLE
fix(webhook): enforce INSECURE_NO_AUTH safety rail on dynamic route reloads

### DIFF
--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -326,6 +326,17 @@ class WebhookAdapter(BasePlatformAdapter):
                         _INSECURE_NO_AUTH,
                     )
                     continue
+                if (
+                    effective_secret == _INSECURE_NO_AUTH
+                    and not _is_loopback_host(self._host)
+                ):
+                    logger.warning(
+                        "[webhook] Dynamic route '%s' skipped: INSECURE_NO_AUTH "
+                        "is only allowed on loopback hosts. Current host: '%s'.",
+                        k,
+                        self._host,
+                    )
+                    continue
                 new_dynamic[k] = v
             self._dynamic_routes = new_dynamic
             self._routes = {**self._dynamic_routes, **self._static_routes}

--- a/tests/gateway/test_webhook_dynamic_routes.py
+++ b/tests/gateway/test_webhook_dynamic_routes.py
@@ -138,9 +138,19 @@ class TestDynamicRouteSecretValidation:
         (tmp_path / _DYNAMIC_ROUTES_FILENAME).write_text(
             json.dumps({"test": {"secret": _INSECURE_NO_AUTH, "prompt": "p"}})
         )
-        adapter = _make_adapter()
+        adapter = _make_adapter(extra={"host": "127.0.0.1"})
         adapter._reload_dynamic_routes()
         assert "test" in adapter._routes
+
+    def test_insecure_no_auth_rejected_on_non_loopback_bind(self, tmp_path):
+        # Dynamic INSECURE_NO_AUTH routes are only valid on loopback hosts.
+        (tmp_path / _DYNAMIC_ROUTES_FILENAME).write_text(
+            json.dumps({"pub": {"secret": _INSECURE_NO_AUTH, "prompt": "p"}})
+        )
+        adapter = _make_adapter(extra={"host": "0.0.0.0"})
+        adapter._reload_dynamic_routes()
+        assert "pub" not in adapter._routes
+        assert "pub" not in adapter._dynamic_routes
 
     def test_warning_logged_on_skip(self, tmp_path, caplog):
         import logging


### PR DESCRIPTION
## What does this PR do?

This PR closes a security gap in the webhook dynamic-route hot-reload path.  
`INSECURE_NO_AUTH` is now accepted only on loopback binds (`127.0.0.1`, `localhost`, `::1`); on non-loopback hosts, dynamic routes using it are skipped.

This aligns runtime dynamic-route behavior with the existing startup safety rail in `connect()`.

## Related Issue

Fixes #N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 🔒 Security fix
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `gateway/platforms/webhook.py`
  - Added a non-loopback safety check in `_reload_dynamic_routes()` for `INSECURE_NO_AUTH`.
  - Dynamic routes that violate this rule are skipped with a warning log.
- `tests/gateway/test_webhook_dynamic_routes.py`
  - Updated the existing `INSECURE_NO_AUTH` test to assert allowed behavior on loopback host.
  - Added a new regression test to assert rejection on non-loopback host.

## How to Test

1. Run:

   pytest tests/gateway/test_webhook_dynamic_routes.py -q -o addopts=""
   
   Verify all tests pass (13 passed).

Confirm that dynamic routes with INSECURE_NO_AUTH load only on loopback host configs and are skipped on public/non-loopback binds.
