### PR TITLE
feat(tui): show prefill/decode token indicator in status bar

### DIFF
--- a/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
+++ b/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
@@ -139,6 +139,7 @@ describe('createGatewayEventHandler', () => {
     const verdict = '✓ Goal achieved: long judge reason goes only in transcript, not merged with cwd label.'
 
     vi.useFakeTimers()
+
     try {
       onEvent({
         payload: { kind: 'goal', text: verdict },
@@ -949,5 +950,60 @@ describe('createGatewayEventHandler', () => {
       vi.runAllTimers()
       vi.useRealTimers()
     }
+  })
+
+  describe('stream token indicator', () => {
+    it('flips to prefill on message.start, decode on delta, accumulates across phases, resets on message.complete', () => {
+      const onEvent = createGatewayEventHandler(buildCtx([]))
+
+      expect(getUiState().streamTokens).toEqual({ phase: null, tokens: 0 })
+
+      onEvent({ payload: {}, type: 'message.start' } as any)
+      expect(getUiState().streamTokens.phase).toBe('prefill')
+      expect(getUiState().streamTokens.tokens).toBe(0)
+
+      const first = 'Hello, world! '.repeat(4)
+      onEvent({ payload: { text: first }, type: 'message.delta' } as any)
+      const expectedAfterDelta = estimateTokensRough(first)
+      expect(getUiState().streamTokens).toEqual({ phase: 'decode', tokens: expectedAfterDelta })
+
+      onEvent({ payload: { name: 'read_file', tool_id: 't1' }, type: 'tool.start' } as any)
+      expect(getUiState().streamTokens.phase).toBe('prefill')
+      expect(getUiState().streamTokens.tokens).toBe(expectedAfterDelta)
+
+      const second = 'follow-up text'
+      onEvent({ payload: { text: second }, type: 'message.delta' } as any)
+      expect(getUiState().streamTokens).toEqual({
+        phase: 'decode',
+        tokens: expectedAfterDelta + estimateTokensRough(second)
+      })
+
+      onEvent({ payload: { text: 'done' }, type: 'message.complete' } as any)
+      expect(getUiState().streamTokens).toEqual({ phase: null, tokens: 0 })
+    })
+
+    it('counts reasoning/thinking deltas toward the decode total', () => {
+      const onEvent = createGatewayEventHandler(buildCtx([]))
+
+      onEvent({ payload: {}, type: 'message.start' } as any)
+      const reasoning = 'pondering the question deeply'
+      onEvent({ payload: { text: reasoning }, type: 'reasoning.delta' } as any)
+
+      expect(getUiState().streamTokens).toEqual({
+        phase: 'decode',
+        tokens: estimateTokensRough(reasoning)
+      })
+    })
+
+    it('resets on error', () => {
+      const onEvent = createGatewayEventHandler(buildCtx([]))
+
+      onEvent({ payload: {}, type: 'message.start' } as any)
+      onEvent({ payload: { text: 'abc def ghi' }, type: 'message.delta' } as any)
+      expect(getUiState().streamTokens.tokens).toBeGreaterThan(0)
+
+      onEvent({ payload: { message: 'boom' }, type: 'error' } as any)
+      expect(getUiState().streamTokens).toEqual({ phase: null, tokens: 0 })
+    })
   })
 })

--- a/ui-tui/src/app/createGatewayEventHandler.ts
+++ b/ui-tui/src/app/createGatewayEventHandler.ts
@@ -1,6 +1,6 @@
 import { STARTUP_IMAGE, STARTUP_QUERY } from '../config/env.js'
 import { STREAM_BATCH_MS } from '../config/timing.js'
-import { SETUP_REQUIRED_TITLE, buildSetupRequiredSections } from '../content/setup.js'
+import { buildSetupRequiredSections, SETUP_REQUIRED_TITLE } from '../content/setup.js'
 import type {
   CommandsCatalogResponse,
   ConfigFullResponse,
@@ -11,7 +11,7 @@ import type {
 } from '../gatewayTypes.js'
 import { rpcErrorMessage } from '../lib/rpc.js'
 import { topLevelSubagents } from '../lib/subagentTree.js'
-import { formatToolCall, stripAnsi } from '../lib/text.js'
+import { estimateTokensRough, formatToolCall, stripAnsi } from '../lib/text.js'
 import { fromSkin } from '../theme.js'
 import type { Msg, SubagentProgress, SubagentStatus } from '../types.js'
 
@@ -134,6 +134,38 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
     rpc<DelegationStatusResponse>('delegation.status', {})
       .then(r => applyDelegationStatus(r))
       .catch(() => {})
+  }
+
+  const setStreamPhase = (phase: 'decode' | 'prefill' | null) =>
+    patchUiState(state => {
+      const current = state.streamTokens
+
+      if (phase === null) {
+        if (current.phase === null && current.tokens === 0) {
+          return state
+        }
+
+        return { ...state, streamTokens: { phase: null, tokens: 0 } }
+      }
+
+      if (current.phase === phase) {
+        return state
+      }
+
+      return { ...state, streamTokens: { ...current, phase } }
+    })
+
+  const addStreamTokens = (text: string) => {
+    const n = estimateTokensRough(text)
+
+    if (n <= 0) {
+      return
+    }
+
+    patchUiState(state => ({
+      ...state,
+      streamTokens: { phase: 'decode', tokens: state.streamTokens.tokens + n }
+    }))
   }
 
   const setStatus = (status: string) => {
@@ -321,6 +353,7 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
 
           if (value) {
             turnController.recordReasoningDelta(value)
+            addStreamTokens(value)
           }
         }
 
@@ -329,6 +362,7 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
 
       case 'message.start':
         turnController.startMessage()
+        setStreamPhase('prefill')
 
         return
       case 'status.update': {
@@ -340,6 +374,7 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
 
         if (p.kind === 'goal') {
           sys(p.text)
+
           const brief = p.text.startsWith('✓')
             ? '✓ goal complete'
             : p.text.startsWith('↻')
@@ -347,8 +382,10 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
               : p.text.startsWith('⏸')
                 ? '⏸ goal paused'
                 : 'ready'
+
           setStatus(brief)
           restoreStatusAfter(6000)
+
           return
         }
 
@@ -356,6 +393,7 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
 
         if (p.kind === 'compressing') {
           sys(p.text)
+
           return
         }
 
@@ -492,6 +530,7 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
       case 'reasoning.delta':
         if (ev.payload?.text) {
           turnController.recordReasoningDelta(ev.payload.text, Boolean(ev.payload.verbose))
+          addStreamTokens(ev.payload.text)
         }
 
         return
@@ -523,11 +562,13 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
           ev.payload.context ?? '',
           ev.payload.args_text ? stripAnsi(String(ev.payload.args_text)) : undefined
         )
+        setStreamPhase('prefill')
 
         return
       case 'tool.complete': {
         const inlineDiffText =
           ev.payload.inline_diff && getUiState().inlineDiffs ? stripAnsi(String(ev.payload.inline_diff)).trim() : ''
+
         const resultText = ev.payload.result_text ? stripAnsi(String(ev.payload.result_text)) : undefined
 
         if (inlineDiffText) {
@@ -589,7 +630,6 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
         sys(`[bg ${ev.payload.task_id}] ${ev.payload.text}`)
 
         return
-
       case 'review.summary': {
         // Self-improvement background review emitted a persistent summary
         // of what it saved to memory/skills. Surface it as a system line
@@ -597,6 +637,7 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
         // flash. Python-side already formats it as "💾 Self-improvement
         // review: …".
         const text = String(ev.payload?.text ?? '').trim()
+
         if (text) {
           sys(text)
         }
@@ -696,6 +737,7 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
 
       case 'message.delta':
         turnController.recordMessageDelta(ev.payload ?? {})
+        addStreamTokens(ev.payload?.text ?? ev.payload?.rendered ?? '')
 
         return
       case 'message.complete': {
@@ -711,6 +753,7 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
         }
 
         setStatus('ready')
+        setStreamPhase(null)
 
         if (ev.payload?.usage) {
           patchUiState(state => ({ ...state, usage: { ...state.usage, ...ev.payload!.usage } }))
@@ -721,6 +764,7 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
 
       case 'error':
         turnController.recordError()
+        setStreamPhase(null)
 
         {
           const message = String(ev.payload?.message || 'unknown error')

--- a/ui-tui/src/app/interfaces.ts
+++ b/ui-tui/src/app/interfaces.ts
@@ -113,8 +113,14 @@ export interface UiState {
   status: string
   statusBar: StatusBarMode
   streaming: boolean
+  streamTokens: StreamTokenStatus
   theme: Theme
   usage: Usage
+}
+
+export interface StreamTokenStatus {
+  phase: 'decode' | 'prefill' | null
+  tokens: number
 }
 
 export interface VirtualHistoryState {

--- a/ui-tui/src/app/uiStore.ts
+++ b/ui-tui/src/app/uiStore.ts
@@ -24,6 +24,7 @@ const buildUiState = (): UiState => ({
   status: 'summoning hermes…',
   statusBar: 'top',
   streaming: true,
+  streamTokens: { phase: null, tokens: 0 },
   theme: DEFAULT_THEME,
   usage: ZERO
 })

--- a/ui-tui/src/components/appChrome.tsx
+++ b/ui-tui/src/components/appChrome.tsx
@@ -4,7 +4,7 @@ import { type ReactNode, type RefObject, useEffect, useMemo, useRef, useState } 
 import unicodeSpinners from 'unicode-animations'
 
 import { $delegationState } from '../app/delegationStore.js'
-import type { IndicatorStyle } from '../app/interfaces.js'
+import type { IndicatorStyle, StreamTokenStatus } from '../app/interfaces.js'
 import { useTurnSelector } from '../app/turnStore.js'
 import { $uiState } from '../app/uiStore.js'
 import { FACES } from '../content/faces.js'
@@ -283,6 +283,7 @@ export function StatusRule({
   bgCount,
   sessionStartedAt,
   showCost,
+  streamTokens,
   turnStartedAt,
   voiceLabel,
   t
@@ -310,6 +311,14 @@ export function StatusRule({
             <Text color={statusColor}>{status}</Text>
           )}
           <Text color={t.color.muted}> │ {modelLabel(model, modelReasoningEffort, modelFast)}</Text>
+          {streamTokens.phase ? (
+            <Text color={t.color.muted}>
+              {' │ '}
+              <Text color={t.color.accent}>
+                {streamTokens.phase === 'prefill' ? '↑' : '↓'} {fmtK(streamTokens.tokens)}
+              </Text>
+            </Text>
+          ) : null}
           {ctxLabel ? <Text color={t.color.muted}> │ {ctxLabel}</Text> : null}
           {bar ? (
             <Text color={t.color.muted}>
@@ -468,6 +477,7 @@ interface StatusRuleProps {
   t: Theme
   turnStartedAt?: null | number
   usage: Usage
+  streamTokens: StreamTokenStatus
   voiceLabel?: string
 }
 

--- a/ui-tui/src/components/appLayout.tsx
+++ b/ui-tui/src/components/appLayout.tsx
@@ -361,6 +361,7 @@ const StatusRulePane = memo(function StatusRulePane({
         showCost={ui.showCost}
         status={ui.status}
         statusColor={status.statusColor}
+        streamTokens={ui.streamTokens}
         t={ui.theme}
         turnStartedAt={status.turnStartedAt}
         usage={ui.usage}


### PR DESCRIPTION
## Summary

Adds a Claude-Code-style streaming token indicator to the `hermes --tui` status bar, sitting alongside the existing `23k/128k` context-window readout. While the model is streaming, the bar shows:

- `↑ 12k` — Hermes is sending context to the LLM (**prefill**)
- `↓ 12k` — the LLM is generating tokens back (**decode**)

The counter accumulates across phase swaps within the same streaming turn (e.g. decode → tool call → prefill of tool result → decode again) and resets to `0` once the stream ends.

## What changed

- `UiState.streamTokens` — new `{ phase: 'prefill' | 'decode' | null, tokens: number }` field with a zeroed initial value.
- `createGatewayEventHandler` — flips phase on `message.start` / `tool.start` (prefill) vs. `message.delta` / `reasoning.delta` / `thinking.delta` (decode), accumulates tokens via the existing `estimateTokensRough`, and resets on `message.complete` or `error`.
- `StatusRule` (in `appChrome.tsx`) — renders the chip only while a phase is active, using the theme accent / muted colors so it visually pairs with the `ctxLabel` segment next to it.
- `appLayout.tsx` — plumbs the new prop through `StatusRulePane`.
- Tests — three new cases in `createGatewayEventHandler.test.ts` cover phase transitions, cross-phase accumulation across a tool cycle, reasoning-only deltas, and the error-reset path.

## Why

Matches a UX cue that Claude Code users already rely on for "is it stuck thinking or stuck waiting on the network?" feedback. The existing `23k/128k` only updates at message boundaries, so users have no live signal between submit and first token.

## How to test

```bash
cd ui-tui
npm install
npm run build --prefix packages/hermes-ink
npx vitest run src/__tests__/createGatewayEventHandler.test.ts
```

Then exercise the UI:

```bash
hermes --tui
# submit any prompt; watch the indicator next to `model │` in the status bar:
#   ↑ 0    immediately after submit (prefill, no decode tokens yet)
#   ↓ Nk   once tokens start arriving
#   indicator disappears at end of stream
```

## Platforms tested

- Linux (WSL2)

## Notes

- Token count uses the same rough `(len + 3) >> 2` estimator already used elsewhere in the TUI for reasoning. It's an approximation, not provider-reported usage.
- Pre-existing TS / lint / test issues in `packages/hermes-ink` and `cursorDriftRegression.test.ts` are unrelated and untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)