### PR TITLE
fix(bedrock): surface Bitwarden source label in native-auth flow

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -5312,7 +5312,9 @@ def _model_flow_bedrock(config, current_model=""):
 
     auth_var = resolve_aws_auth_env_var()
     if auth_var:
-        print(f"  AWS credentials: {auth_var} ✓")
+        from hermes_cli.env_loader import format_secret_source_suffix
+        source_suffix = format_secret_source_suffix(auth_var)
+        print(f"  AWS credentials: {auth_var} ✓{source_suffix}")
     else:
         print("  AWS credentials: boto3 default chain (instance role / SSO)")
     print()

--- a/tests/hermes_cli/test_bedrock_model_picker.py
+++ b/tests/hermes_cli/test_bedrock_model_picker.py
@@ -335,6 +335,55 @@ class TestBedrockRegionRouting:
 # 4. providers.py overlay registration
 # ---------------------------------------------------------------------------
 
+class TestBedrockNativeAuthBitwarden:
+    """_model_flow_bedrock shows '(from Bitwarden)' when AWS creds came from BSM."""
+
+    def _run_flow(self, monkeypatch, auth_var, bw_label=None):
+        """Run _model_flow_bedrock up to the credentials print, then bail."""
+        from hermes_cli import env_loader
+
+        env_loader._SECRET_SOURCES.clear()
+        if bw_label:
+            env_loader._SECRET_SOURCES[auth_var] = bw_label
+
+        bedrock_mock = MagicMock()
+        bedrock_mock.has_aws_credentials.return_value = True
+        bedrock_mock.resolve_aws_auth_env_var.return_value = auth_var
+        # Abort after the credentials line so we don't need to mock the full flow.
+        bedrock_mock.resolve_bedrock_region.side_effect = KeyboardInterrupt
+
+        import sys
+        sys.modules["agent.bedrock_adapter"] = bedrock_mock
+
+        from hermes_cli.main import _model_flow_bedrock
+        import io
+
+        buf = io.StringIO()
+        with patch("builtins.input", side_effect=KeyboardInterrupt):
+            with patch("sys.stdout", buf):
+                try:
+                    _model_flow_bedrock({})
+                except (KeyboardInterrupt, SystemExit):
+                    pass
+
+        env_loader._SECRET_SOURCES.clear()
+        del sys.modules["agent.bedrock_adapter"]
+        return buf.getvalue()
+
+    def test_shows_bitwarden_suffix_when_aws_key_from_bsm(self, monkeypatch):
+        output = self._run_flow(monkeypatch, "AWS_ACCESS_KEY_ID", bw_label="bitwarden")
+        assert "AWS_ACCESS_KEY_ID ✓ (from Bitwarden)" in output
+
+    def test_no_suffix_when_aws_key_not_from_bsm(self, monkeypatch):
+        output = self._run_flow(monkeypatch, "AWS_ACCESS_KEY_ID", bw_label=None)
+        assert "AWS_ACCESS_KEY_ID ✓" in output
+        assert "(from Bitwarden)" not in output
+
+    def test_bearer_token_var_also_gets_suffix(self, monkeypatch):
+        output = self._run_flow(monkeypatch, "AWS_BEARER_TOKEN_BEDROCK", bw_label="bitwarden")
+        assert "AWS_BEARER_TOKEN_BEDROCK ✓ (from Bitwarden)" in output
+
+
 class TestBedrockOverlayRegistration:
     """bedrock entry in HERMES_OVERLAYS is correctly configured."""
 


### PR DESCRIPTION
## Problem

`_model_flow_bedrock_api_key` already calls `format_secret_source_suffix()` when displaying the detected AWS bearer token, but the sibling native-auth flow (`_model_flow_bedrock`) does not.

When a user has AWS credentials (`AWS_ACCESS_KEY_ID`, `AWS_PROFILE`, etc.) injected by Bitwarden Secrets Manager, running `hermes model` and selecting the native Bedrock (boto3) path shows:

```
  AWS credentials: AWS_ACCESS_KEY_ID ✓
```

...with no hint that the key came from BSM. This is the same UX confusion PR #30364 fixed for the bearer-token path: users assume Bitwarden isn't wired up and try to re-enter credentials.

## Fix

Wire `format_secret_source_suffix(auth_var)` into the `if auth_var:` branch of `_model_flow_bedrock`, symmetric with `_model_flow_bedrock_api_key`:

```python
# Before
if auth_var:
    print(f"  AWS credentials: {auth_var} ✓")

# After
if auth_var:
    from hermes_cli.env_loader import format_secret_source_suffix
    source_suffix = format_secret_source_suffix(auth_var)
    print(f"  AWS credentials: {auth_var} ✓{source_suffix}")
```

## Tests

`TestBedrockNativeAuthBitwarden` — 3 new regression tests:
- `test_shows_bitwarden_suffix_when_aws_key_from_bsm` — `AWS_ACCESS_KEY_ID` in BSM → suffix shown
- `test_no_suffix_when_aws_key_not_from_bsm` — `.env` key → no suffix
- `test_bearer_token_var_also_gets_suffix` — `AWS_BEARER_TOKEN_BEDROCK` via native flow → suffix shown

## Checklist

- [x] Parity fix: symmetric with `_model_flow_bedrock_api_key` (already correct)
- [x] No behavior change for credentials from `.env` or shell
- [x] `format_secret_source_suffix` returns `""` for non-BSM sources — safe no-op
- [x] `ruff check` passes
- [x] 24/24 tests pass in `test_bedrock_model_picker.py`