### PR TITLE
Add mumo skill to optional-skills/software-development/

### DIFF
--- a/optional-skills/software-development/mumo/SKILL.md
+++ b/optional-skills/software-development/mumo/SKILL.md
@@ -1,0 +1,232 @@
+---
+name: mumo
+description: Runs structured multi-model deliberations across frontier AI panels (Claude, GPT, Gemini, Grok, Qwen, GLM, Kimi) via mumo's MCP server. Use when independent perspectives are needed on contested architecture/product decisions, design reviews, pre-launch pressure tests, tradeoffs with multiple defensible framings, or explicit user requests for a mumo panel.
+version: 0.1.5
+author: mumo
+license: MIT
+platforms: [linux, macos, windows]
+required_environment_variables:
+  - name: MUMO_API_KEY
+    prompt: "mumo platform API key (mmo_live_*)"
+    help: "Create one at https://mumo.chat/settings/api-keys"
+    required_for: mumo MCP server authentication
+metadata:
+  hermes:
+    tags:
+      - deliberation
+      - decision-support
+      - multi-model
+      - design-review
+      - architecture-review
+      - plan-review
+      - mcp
+    related_skills:
+      - writing-plans
+      - plan
+      - requesting-code-review
+    requires_tools:
+      - mcp_mumo_create_deliberation
+---
+
+# mumo
+
+mumo runs deliberations across multiple AI models. Use it when independent perspectives are useful — especially for high-regret decisions where a single model's confidence is a real risk.
+
+## Setup
+
+The mumo MCP server is configured in `~/.hermes/config.yaml` under `mcp_servers`. If this skill was installed from HermesHub, Hermes prompts for `MUMO_API_KEY` at install time and auto-saves it to `.env`. If installed via `git clone`, see `config/mumo.yaml` in this skill's directory for the canonical block to merge under your `mcp_servers:` key, with the placeholder `mmo_live_YOUR_KEY_HERE` replaced by your real key.
+
+Either way, after the config lands, **fully exit and restart Hermes** (the `/reload-mcp` slash command is unreliable across versions).
+
+If tools return auth errors, the API key is missing or invalid. Direct the user to https://mumo.chat/settings/api-keys to create one (keys start with `mmo_live_`).
+
+## When to use
+
+Use mumo when **the cost of being wrong is greater than the cost of deliberation** — especially when the solution space is wide, failure modes are hidden, you may be anchored on a design, or rollback would be hard. Examples:
+
+architecture decisions with non-obvious tradeoffs, plan or design review before commitment, pre-launch pressure tests, stuck debugging after N failed repair attempts, pre-commit adversarial review on risky diffs, memory/skill promotion gates, strategy questions with multiple defensible framings, explicit user requests.
+
+Skip mumo for factual lookups, syntax help, routine refactors, formatting, dependency bumps with clear errors, or normal edit-test cycles. The deliberation tax is real — extra tokens, extra latency, extra moderation work — so spend it on decisions where mistakes compound.
+
+## Playbooks
+
+Load at most one playbook when it clearly fits:
+
+| Playbook | When |
+|---|---|
+| `contested-decision` | choosing between options with real tradeoffs |
+| `design-review` | reviewing a proposed system, API, plan, or code shape |
+| `uncertainty-expansion` | exploring unknowns, stress-testing assumptions |
+| `red-team` | finding failure modes, abuse cases, or launch risks |
+
+If none clearly fits, use this kernel only.
+
+## User preferences
+
+These are defaults. If the user prefers more autonomy (e.g., "don't ask before appending" or "always use GPT-5.5 and Gemini"), follow their preferences over this guidance.
+
+## Basic loop
+
+1. Call `create_deliberation` with the user's problem. Set `application` to `"Hermes Agent"`. Set `moderator_name` to your own model identity (e.g., the model Hermes is currently running as — Claude, GPT, Gemini, or the local model) for audit clarity — not the user's name; their identity is already on the session. Optionally set `recap_round: true` for a structured round 0 summary — see [Recap and synthesis](#recap-and-synthesis-opt-in).
+2. **Verify the response contains `session_id` and `round_id`, and keep those exact returned IDs for downstream calls.** UUID shape is a sanity check; identity continuity is the real check. If fields are missing, malformed, or inconsistent with `list_sessions`, recover via [Verifying the call actually fired](#verifying-the-call-actually-fired) before proceeding.
+3. Call `wait_for_round` with the returned `session_id` and `round_id`. **Long waits are normal** — frontier-model panels typically take 15–120s, and 60+ seconds isn't a failure signal. Tell the user upfront ("running a panel — expect ~30–60s") so the wait doesn't feel broken.
+4. Branch on the response's `structuredContent.recommended_client_action` rather than parsing prose. The 5-value enum tells you exactly what to do:
+
+   | Action | What it means | What to do |
+   |---|---|---|
+   | `proceed_with_complete_result` | All target models completed | Read the round normally |
+   | `proceed_with_partial_result` | Some failed, ≥1 succeeded (`is_usable: true`) | Read what's there; note absent models if relevant to the user |
+   | `poll_again` | Round still in progress | Call `wait_for_round` again with the same args |
+   | `retry` | Round failed with at least one transient failure (rate-limit, provider error, internal deadline) | The failed round is auto-refunded; call `append_round` with the same prompt to retry |
+   | `abandon` | Round failed with no transient failures | Don't retry; report failure to the user |
+
+   The server derives this from `round_status` + per-model `error_code` — it's the canonical "what next?" signal. Treat transport / tool-call errors separately from mumo round status: catch transport failures around the call; branch on `recommended_client_action` for everything else.
+
+5. On a usable round, read the **claim map first**, then relevant participant prose. The claim map is the navigation layer; prose is the supporting evidence.
+6. Create snippets as your primary response to the round. Optionally add a round prompt for broad steering.
+7. Call `append_round` if another round would help. Optionally set `recap_round: true` for a per-round summary, or `recap_session: true` on the round you intend as the final round to trigger session-level synthesis (cascade — see [Recap and synthesis](#recap-and-synthesis-opt-in)). Otherwise stop and synthesize for the user yourself.
+
+## Verifying the call actually fired
+
+Autonomous agent loops occasionally fabricate tool-call results — reporting a deliberation as sent when it wasn't. If you suspect this (the response is missing the expected `session_id` / `round_id`, or the values you're about to pass downstream don't match what `create_deliberation` actually returned), treat the call as not successfully established and recover:
+
+1. Call `list_sessions`. Match by prompt content to confirm whether your `create_deliberation` actually ran.
+2. If it's not there, fire `create_deliberation` again — don't continue downstream as if the session exists.
+3. If it IS there, use the IDs `list_sessions` returned (not whatever was in your context) for the next call.
+
+mumo's `session_id` and `round_id` are UUIDs as a service contract — a returned value that doesn't match UUID format is one signal something is off, but **identity continuity matters more than format**. The strongest check is whether the `session_id` your subsequent calls reference matches what `create_deliberation` actually returned in its response.
+
+## Snippets
+
+Snippets are moderator attention. They mark what mattered in the prior round and optionally explain why.
+
+| Type | Reaction |
+|---|---|
+| KEEP | this seems worth preserving |
+| EXPLORE | there's something here |
+| CHALLENGE | I'm not convinced |
+| CORE | this feels central |
+| SHIFT | this changed the frame |
+
+A snippet comment can be reflective, evaluative, clarifying, skeptical, or directive. "This feels like the crux" and "I'm least convinced by this" are valid comments. You do not need an action verb or next-step directive. The quality bar is: *is this a genuine, situated reaction to what the model said?*
+
+Use the round prompt for broad comments that don't attach to a specific quote. Use snippets for quote-grounded attention.
+
+Avoid huge quote dumps, generic praise repeated across many snippets, or comments that shift participants away from the problem into platform meta. More guidance: `references/snippets.md`.
+
+## What to keep out of the deliberation
+
+Use this test:
+
+> Does this note help participants think about the user's problem, or does it mainly report on the platform, session, or process?
+
+Don't use snippet comments to narrate your own moderation process ("I'm using CHALLENGE to redirect the panel"). Don't include platform meta ("this model used the most tokens"). Just react.
+
+## Reading the claim map
+
+The claim map encodes consensus and contestation as structured reactions on quoted claims. Each claim shows:
+
+- The verbatim quote
+- Who originated it
+- How other models reacted (KEEP / CORE / EXPLORE / CHALLENGE / SHIFT) with optional commentary
+
+Reading discipline:
+
+- **CORE / KEEP from multiple models** = settled. Treat as panel consensus.
+- **CHALLENGE** = live disagreement. The decision likely hinges here.
+- **EXPLORE** = a thread someone wanted to develop further. Worth a follow-up snippet if the thread matters.
+- **SHIFT** = a model changed framing. Often the most valuable signal — somebody saw the problem differently.
+- **No reactions on a claim** = either obvious or ignored. Read the prose to tell which.
+
+The claim map is not a verdict. It compresses argumentative structure but loses rhetorical nuance and confidence texture. Use it to navigate; read prose to understand.
+
+## Confidence scores
+
+If responses include `claim_confidence` or `snippets[].comment_confidence`, these are self-reported and not calibrated across models. Surface the `confidence_disclaimer` string if displaying scores.
+
+## Deliberation is advisory
+
+Mumo surfaces fault lines and supporting arguments; it does not produce the decision. The decision belongs to you (the agent) and the user. When acting on a deliberation:
+
+- **Do not** treat panel consensus as authority. The panel can be confidently wrong as a unit.
+- **Do** use the claim map to identify which assumptions drove the disagreement, and check whether those assumptions hold for the user's specific situation.
+- **Do not** mutate the workspace based on a model's suggestion without verifying with tests or the user.
+- **Do** weight CORE / SHIFT signals more heavily than KEEP / EXPLORE — they mark where the decision actually hinges.
+
+## Recovery: lost session context
+
+If you lose track of `session_id` or `round_id` mid-conversation (long chats, context compaction, dropped tool result), recover before starting a new deliberation:
+
+1. Call `list_sessions` to find your latest sessions. Match by prompt content.
+2. Call `get_session` with the recovered ID for full state, or `wait_for_round(session_id, round_id)` if you suspect a round is still in flight.
+3. Don't fire a fresh `create_deliberation` if the original is recoverable — duplicate sessions waste tokens and produce confusing parallel state.
+
+## Recap and synthesis (opt-in)
+
+Two optional flags request LLM-curated summaries on top of the raw round output:
+
+- **`recap_round`** (default `false`) — accepted on `create_deliberation` AND `append_round`. Generates `round_recap` for that round; surfaces on `get_session`.
+- **`recap_session`** (default `false`) — accepted on `append_round` ONLY (rejected on `create_deliberation`). Generates session-level `session_synthesis`. **Setting this on round N backfills `round_recap` for every prior round that doesn't have one** — cost adds up on long sessions; check expectations first.
+
+Set `recap_round` liberally when round-level summaries may matter. Set `recap_session` only on the round you intend as the final round. Both bill through the standard credit wallet.
+
+Full mechanics, cost detail, and artifact field reference: `references/recap.md`.
+
+## After each round
+
+After each usable round you have one job before deciding whether to continue: synthesize what the panel said for the user. There are two paths, and which one applies depends on whether you opted into a recap when you called the tool:
+
+- **If you set `recap_round: true` on this round**, `get_session` returns a structured `round_recap` (`title`, `tldr`, `agenda`, `sections`). Use it as your read path — it's produced for agent consumption and saves you from re-summarizing prose.
+- **If you didn't**, synthesize from the claim map and participant prose. State the consensus or split clearly, offer your own assessment marked as yours, organize by importance rather than forcing a recommendation.
+
+Either way, don't dump the transcript. Mumo produces structure; your job is to translate it into "here's what the panel thinks and what to do next."
+
+Then align with the user on whether to append a round. If the user signals they're done deliberating and wants a session-level takeaway, your final `append_round` is the right place to set `recap_session: true` — but not earlier (see [Recap and synthesis](#recap-and-synthesis-opt-in)).
+
+More at `references/synthesis.md`.
+
+## When to continue
+
+Append another round when:
+
+- A decision-relevant claim has unresolved tension
+- A model introduced a useful frame that others didn't engage
+- An isolated concern feels real but underdeveloped
+- Your moderator reaction would help the next round develop
+- The user narrows or changes the question
+
+Stop when:
+
+- You can explain the tradeoff clearly to the user
+- Remaining disagreements wouldn't change the user's next action
+- Another round would mostly seek reassurance
+
+The panel does not need to converge. Sometimes the right output is a clear map of why the decision remains contested — that's actionable for the user, even without a verdict.
+
+## Tools
+
+| Need | Tool |
+|---|---|
+| Start a session | `create_deliberation` |
+| Wait for model responses | `wait_for_round` |
+| Add a follow-up round | `append_round` |
+| Recover/read full state | `get_session` |
+| Find prior sessions | `list_sessions` |
+| Confirm model IDs | `list_models` |
+| Check wallet balance | `get_credit` |
+
+In Hermes' tool registry these surface as `mcp_mumo_create_deliberation`, `mcp_mumo_wait_for_round`, etc.
+
+If the user names specific models, call `list_models` first. Otherwise omit `models` and let mumo select the panel. More on model selection: `references/model-selection.md`.
+
+## Reference
+
+- MCP docs: https://mumo.chat/docs/mcp
+- REST API: https://mumo.chat/docs/api
+- Install guide: https://mumo.chat/install/hermes
+- Claim map guidance: `references/claim-maps.md`
+- Recap and synthesis mechanics: `references/recap.md`
+- Snippet examples: `references/snippets.md`
+- Model selection: `references/model-selection.md`
+- Synthesis guidance: `references/synthesis.md`
+- Recovery and operations: `references/operating-notes.md`

--- a/optional-skills/software-development/mumo/config/mumo.yaml
+++ b/optional-skills/software-development/mumo/config/mumo.yaml
@@ -1,0 +1,23 @@
+# Add this block to ~/.hermes/config.yaml under the mcp_servers key.
+# If you already have mcp_servers configured, merge mumo as a sibling entry.
+# After saving, fully exit and restart Hermes — /reload-mcp is unreliable across versions.
+
+mcp_servers:
+  mumo:
+    url: "https://mumo.chat/api/mcp"
+    headers:
+      Authorization: "Bearer mmo_live_YOUR_KEY_HERE"
+    connect_timeout: 60
+    timeout: 180
+    supports_parallel_tool_calls: true
+    tools:
+      include:
+        - create_deliberation
+        - wait_for_round
+        - append_round
+        - get_session
+        - list_sessions
+        - list_models
+        - get_credit
+      resources: false
+      prompts: false

--- a/optional-skills/software-development/mumo/playbooks/contested-decision.md
+++ b/optional-skills/software-development/mumo/playbooks/contested-decision.md
@@ -1,0 +1,29 @@
+# Contested Decision
+
+Use when the user is choosing between options with real tradeoffs — technology choices, design approaches, product directions, pricing structures, migration strategies.
+
+## Shaping the prompt
+
+Frame the deliberation around the actual decision, not around describing the options. "Should we use Postgres or DynamoDB for this workload?" is better than "Compare Postgres and DynamoDB." Include the constraints that make the decision hard — scale requirements, team expertise, timeline, reversibility. The more concrete the constraints, the more useful the disagreement.
+
+If the user has a leaning, include it. Models that know the current favorite can attack it specifically rather than giving balanced pros/cons lists.
+
+## What to look for in round 1
+
+The claim map will usually show agreement on easy dimensions and disagreement on the dimensions that actually matter. The useful signal is *where* the panel splits, not whether it agrees overall.
+
+Watch for:
+- **Criteria smuggling** — models agree on the answer but disagree on *why*, which means they'd diverge on a slightly different version of the question.
+- **Unstated assumptions** — one model assumes the team has Postgres expertise, another doesn't. The disagreement isn't about the technology; it's about a context gap.
+- **Reversibility asymmetry** — if one option is easy to reverse and the other isn't, that often dominates the other tradeoffs. Flag it with CORE if a model names it.
+- **An option nobody defends well** — sometimes the best choice lacks an advocate. That's worth an EXPLORE.
+
+## When to append
+
+Append when the claim map shows a contested claim that's load-bearing for the decision. Use CHALLENGE on the weakest link in whichever position you find less convincing. Use EXPLORE if a model gestured at a consideration without developing it.
+
+Don't append just because the panel is split. Some decisions are genuinely close calls — the deliberation's job is to surface why, not to force convergence.
+
+## When to stop
+
+Stop when you can articulate: "The panel agrees on X and Y. They disagree on Z, and the disagreement comes down to [specific assumption or priority]." That's usually enough for the user to decide. You don't need the panel to reach consensus.

--- a/optional-skills/software-development/mumo/playbooks/design-review.md
+++ b/optional-skills/software-development/mumo/playbooks/design-review.md
@@ -1,0 +1,29 @@
+# Design Review
+
+Use when the user has a proposed system, API, architecture, schema, or plan and wants it critiqued. The input is a design; the question is "what's wrong with it" or "what would we regret."
+
+## Shaping the prompt
+
+Include the design itself — paste the spec, schema, API surface, or plan into the prompt or the `reference` field. Models can't review what they can't see.
+
+Frame it as a review, not a redesign. "Review this API surface for consistency, missing edge cases, and things we'd regret at scale" is better than "Design a better API." If you want alternatives, make that a separate deliberation.
+
+State the constraints the design was built under. Models that don't know the constraints will critique decisions that were already intentional.
+
+## What to look for in round 1
+
+Design reviews produce two kinds of signal:
+- **Convergent concerns** — multiple models flag the same issue. These are almost always real. Mark them CORE.
+- **Isolated concerns** — one model raises something the others didn't. These are either the most valuable insight in the session or noise. Use EXPLORE to find out which.
+
+Watch for models critiquing style rather than substance. The claim map can flatten severity — naming conventions and concurrency bugs get equal-weight rows. Read the prose to distinguish what actually matters.
+
+## When to append
+
+Append when a model raised a concern that feels real but underdeveloped. Use EXPLORE with a comment like "this seems important — can you be more specific about the failure mode?" or just "say more about this."
+
+Also append when models disagree about whether something is actually a problem — a CHALLENGE on a design critique forces the critic to defend it with specifics, or when a hidden constraint needs to be injected that would change the analysis.
+
+## When to stop
+
+Stop when the review has surfaced concrete, actionable concerns. The user doesn't need the models to agree on a revised design — they need a list of things to worry about, ranked by the panel's attention pattern. Summarize: "Three models flagged X. Two raised Y but disagreed on severity. One raised Z, which the others didn't engage with — worth investigating."

--- a/optional-skills/software-development/mumo/playbooks/red-team.md
+++ b/optional-skills/software-development/mumo/playbooks/red-team.md
@@ -1,0 +1,29 @@
+# Red Team
+
+Use when the user wants adversarial review — finding failure modes, abuse cases, security gaps, things that will break under pressure, or reasons a plan will fail.
+
+## Shaping the prompt
+
+Be explicit that you want adversarial thinking: "Try to break this. What fails first?" or "What's the most likely way this goes wrong in production?" Models default to helpful analysis; you need to push them toward constructive hostility.
+
+Include the thing being attacked in full — the API spec, the auth flow, the launch plan, the pricing model. Vague descriptions produce vague attacks.
+
+If there's a specific threat model, state it. "Assume a motivated attacker with a valid API key" produces better results than "find security issues."
+
+## What to look for in round 1
+
+Red team rounds produce two kinds of findings:
+- **Concrete attack paths** — "If you send X to endpoint Y, Z happens." These are immediately actionable. Mark them CORE.
+- **Structural concerns** — "This design assumes trusted clients." These are often more important but harder to act on. Mark them EXPLORE to force specifics.
+
+Watch for models pulling punches. If a response reads like "this is generally well-designed but you might consider..." that model is being helpful, not adversarial. Use CHALLENGE: "Be more specific. What actually breaks?"
+
+## When to append
+
+Append when attacks were shallow or when a model identified a category of risk without a concrete scenario. Use the round prompt to escalate: "Assume the easy fixes are done. What's the next layer of risk?"
+
+Also append when models disagreed about severity — a CHALLENGE on "this is a minor issue" forces justification.
+
+## When to stop
+
+Stop when the attacks have gotten specific enough to be actionable. Present findings by severity, not by model. The user needs a punch list, not a transcript. Don't keep appending until every conceivable failure mode is exhausted.

--- a/optional-skills/software-development/mumo/playbooks/uncertainty-expansion.md
+++ b/optional-skills/software-development/mumo/playbooks/uncertainty-expansion.md
@@ -1,0 +1,27 @@
+# Uncertainty Expansion
+
+Use when the user needs to explore unknowns rather than choose between knowns — early-stage scoping, "what are we missing," risk discovery, research synthesis, or any situation where premature convergence is the main danger.
+
+## Shaping the prompt
+
+Ask open questions, not binary ones. "What risks are we not seeing in this migration plan?" is better than "Is this migration plan risky?" Include what you already know so models don't waste the round on obvious points.
+
+Explicitly invite divergence: "I'm less interested in agreement than in perspectives we haven't considered." This counters models' default tendency to converge quickly.
+
+## What to look for in round 1
+
+The claim map in an expansion round will typically be fragmented — many isolated claims, few convergence points. That's the intended outcome, not a sign the deliberation failed.
+
+The valuable signal is in the claims that only one model raised. Use EXPLORE on promising threads that were dropped after a single mention. Use KEEP on surprising frames that recast the problem.
+
+Resist the urge to CHALLENGE in round 1 of an expansion session. Challenges narrow; this playbook is about widening.
+
+## When to append
+
+Append when a model opened a thread worth pursuing but didn't develop it. Your round prompt should narrow the next round to 2-3 of the most promising threads: "Let's focus on [X] and [Y] that came up in the first round. What are the concrete implications?"
+
+This is the one playbook where a round 2 is almost always worth it — round 1 generates breadth, round 2 generates depth on the best leads.
+
+## When to stop
+
+Stop when you have a list of concerns, risks, or possibilities that the user didn't start with. The goal is not to resolve them — it's to name them. Present them to the user as "things the panel surfaced that you may want to investigate" rather than as conclusions.

--- a/optional-skills/software-development/mumo/references/claim-maps.md
+++ b/optional-skills/software-development/mumo/references/claim-maps.md
@@ -1,0 +1,54 @@
+# Claim Maps
+
+The claim map is the structured output of each round. It shows which claims were made, who originated them, and how other models reacted.
+
+## Reading order
+
+Read the claim map before diving into full prose. The map tells you *where* the interesting structure is; prose tells you *why*. If you read prose first, you can anchor on whichever model writes most persuasively.
+
+Exception: in small sessions with only a few claims, read however is natural.
+
+## What a claim row contains
+
+- **The quoted claim** — a specific passage from a model's response.
+- **The quoted model** — who originated the claim.
+- **Reactions** — how other models (and the moderator, in later rounds) reacted, each with a snippet type and optional comment.
+
+Agreement shows as multiple KEEP/CORE reactions on the same claim. Disagreement shows as CHALLENGE reactions. Isolated claims have few or no reactions.
+
+## Continuation signals
+
+The claim map is your primary signal for whether to continue.
+
+**Continue when:**
+- A decision-relevant claim has unresolved CHALLENGE reactions.
+- A promising claim has no reactions — it was raised but not engaged with.
+- A SHIFT reaction suggests a model changed its position, but the implications haven't been explored.
+
+**Stop when:**
+- Key claims show convergent reactions (mostly KEEP/CORE).
+- Remaining disagreements are on claims that don't affect the decision.
+- The map is stable across rounds — same claims, same positions, no movement.
+
+Don't continue just because unresolved claims exist. Only unresolved claims on the decision-relevant subset warrant another round. Peripheral disagreements are noise, not signal.
+
+## Snippet selection from the claim map
+
+Use the claim map to decide where to focus, then choose exact quotes from the prose.
+
+Good targets:
+- Claims that multiple models reacted to differently.
+- Claims that one model challenged and others ignored.
+- Isolated claims that seem important.
+- Shifts in framing.
+- Core constraints that need anchoring.
+
+## Attribution accuracy
+
+If two participants say the same thing, the claim map must not imply the words came from only one. If attribution is unknown, it should stay unknown rather than be guessed.
+
+Misattribution is worse than a slightly less dense map because users can audit snippets against raw responses.
+
+## Claim maps are not verdicts
+
+The map compresses argumentative structure but loses rhetorical nuance and confidence texture. It's a map of where attention clustered, not a ruling on who's right. Use it to navigate, then read the prose to understand.

--- a/optional-skills/software-development/mumo/references/model-selection.md
+++ b/optional-skills/software-development/mumo/references/model-selection.md
@@ -1,0 +1,32 @@
+# Model Selection
+
+Default behavior: omit `models` and let mumo select the panel. mumo's defaults evolve as model quality and pricing change. Hardcoded model strategy in the skill will go stale.
+
+## When to call `list_models`
+
+- The user names specific models.
+- The user asks for a cheap gut-check or a premium panel.
+- A previous call failed because a model was unavailable.
+- You need to confirm model IDs.
+
+## Selection principles
+
+When selecting yourself:
+
+- **Provider diversity over intra-family differences.** A panel with models from three different providers is more valuable than three variants from one.
+- **Include your own family only when the user wants it** or the comparison specifically benefits from it. You're already in the conversation as moderator.
+- **Avoid nano/fast variants for high-stakes decisions** unless the user explicitly prioritizes cost.
+- **Don't present model choice as a leaderboard judgment.** You're picking for diversity, not ranking.
+
+## Cost awareness
+
+`get_credit` is useful when balance is uncertain or the user asks about cost.
+
+Don't make cost preflight a default ritual before every deliberation — it creates friction and can bias agents away from using mumo when the task genuinely warrants a panel.
+
+If cost is part of the user's problem, translate it into problem context:
+
+Good: "Assume this workflow can afford at most one additional model call per important decision."
+Weak: "The previous mumo round cost $0.34."
+
+Frontier panels typically cost $0.20-0.60 per round. Mid-tier panels are significantly cheaper.

--- a/optional-skills/software-development/mumo/references/operating-notes.md
+++ b/optional-skills/software-development/mumo/references/operating-notes.md
@@ -1,0 +1,33 @@
+# Operating Notes
+
+Practical agent mechanics that don't belong in the kernel but matter during real sessions.
+
+## Recovery
+
+Use `list_sessions` to recover sessions when:
+
+- the agent restarted mid-session
+- a round timed out but may still be running
+- multiple sessions are active
+
+Use `get_session` for full state. Prefer `wait_for_round` while a round is in flight.
+
+## Idempotency
+
+MCP write tools are idempotent by arguments. Retrying the same call after a transport failure replays the same operation rather than creating duplicates.
+
+Don't make meaningless edits to a prompt just to "try again" — that creates a new operation.
+
+## Synthesis boundary
+
+mumo's deliberation surface is raw participant output plus moderator attention. Don't write your synthesis back into mumo as an `append_round` unless the user explicitly wants a synthesis round.
+
+Your final answer to the user can freely synthesize your read of the panel. Make the distinction clear: mumo produced the raw material; your response is your interpretation for the user.
+
+## Platform meta in edge cases
+
+The kernel's test — "does this help participants think about the user's problem?" — covers most cases. A few edge cases worth noting:
+
+- **Model behavior is the user's topic.** If the user is evaluating model capabilities, model-comparative observations are problem context, not platform meta. Include them.
+- **Budget constraints are real.** If the user has said they're watching costs, "this is a $0.50/round panel" is useful context for deciding whether to append. But frame it as a decision input, not a report.
+- **Tool failures.** If a model failed to respond and the round is incomplete, that's worth noting in your prompt or to the user. It changes the epistemic state of the session.

--- a/optional-skills/software-development/mumo/references/recap.md
+++ b/optional-skills/software-development/mumo/references/recap.md
@@ -1,0 +1,40 @@
+# Recap and synthesis
+
+Reference for the `recap_round` and `recap_session` flags on `create_deliberation` and `append_round`, and the `round_recap` / `session_synthesis` artifacts they produce.
+
+## Flags
+
+| Flag | Accepted on | Effect |
+|---|---|---|
+| `recap_round` | `create_deliberation` AND `append_round` | Generates a structured `round_recap` for that round (`title`, `tldr`, `agenda`, `sections`). Surfaces on `get_session` once written. |
+| `recap_session` | `append_round` ONLY (rejected on `create_deliberation` with a 400) | Generates `session_synthesis` (`title`, `tldr`, `origin`, `arcs`) over the round-recap set when this round completes. Implicitly covers `recap_round` for the trigger round. |
+
+Both default `false` — no behavior change unless you opt in. `recap_session` is rejected on `create_deliberation` because synthesis requires ≥2 rounds; on round 0 it would degenerate to a round-recap-only behavior.
+
+## Cascade behavior
+
+Setting `recap_session: true` triggers `round_recap` generation for every prior round that doesn't already have one — session synthesis needs the round-recap set as input.
+
+Example: if you only opted into `recap_round` for rounds 2 and 4 and then set `recap_session: true` on round 5, the cascade backfills `round_recap` for rounds 1 and 3 as well. The trigger round (5) is recap'd automatically — you don't need to set `recap_round: true` alongside `recap_session: true`.
+
+## Cost
+
+Recap and synthesis bill via the standard credit wallet at **0 bps markup** (at-cost passthrough). A typical 3-round cascade lands around ~$0.04 in inference cost — the cascade is the surprising part of the bill, so check session length before flipping `recap_session: true` on a long session.
+
+## Reading the artifacts
+
+`get_session` returns:
+
+- `rounds[].round_recap` — per-round, populated for rounds whose recap generation has completed (either directly opted in via `recap_round` or backfilled via the `recap_session` cascade). Null otherwise.
+- `session_synthesis` — session-level, populated once the cascade completes. Null until then.
+
+Use these as the structured "what happened" read path instead of parsing raw prose — they're produced specifically for the agent-consumption surface.
+
+## When to set them
+
+- `recap_round` is cheap and worth setting any time the user might want a round-level summary later, or any time the round's claim map has significant structure you may need to reference.
+- `recap_session` is the right move when the user signals they're done deliberating and wants a session-level takeaway — set it on the final `append_round`, not earlier. Setting mid-session triggers the cascade and surprises the cost.
+
+## Public contract
+
+Full contract: https://mumo.chat/docs/mcp#recap-artifacts

--- a/optional-skills/software-development/mumo/references/snippets.md
+++ b/optional-skills/software-development/mumo/references/snippets.md
@@ -1,0 +1,52 @@
+# Snippets — Extended Guidance
+
+Snippets are moderator attention. This reference expands on the kernel's snippet guidance with examples and edge cases.
+
+## What makes a good snippet
+
+A good snippet has a specific quote and a genuine reaction. The reaction can take many forms:
+
+- **Reflective** — "This feels like the crux of the disagreement."
+- **Evaluative** — "This reasoning is strong but assumes constant network latency."
+- **Skeptical** — "I'm not convinced this scales past 10K users."
+- **Clarifying** — "This seems to be saying X — is that right?"
+- **Directive** — "Develop this further in the next round."
+- **Minimal** — No comment at all. The snippet type alone is sometimes enough.
+
+You do not need a next-step directive before selecting a snippet.
+
+## What makes a bad snippet
+
+- **Block quotes** — Quoting a 500-word passage. Quote the specific claim that sparked your reaction.
+- **Process narration** — "I am using this CHALLENGE to redirect the panel." Just react.
+- **Detached platform meta** — "This model used the most tokens." That's about the session, not the problem.
+- **Private audit notes** — "I think this model is underperforming today." Keep that local unless model behavior is the user's actual topic.
+
+## Types in practice
+
+**KEEP** is "this resonates with me." Use it when a claim is valuable and should remain visible.
+
+**EXPLORE** is "there's an undeveloped thread here." Use it when a model mentioned something promising but moved on. EXPLORE without a comment is fine — the type itself says "say more."
+
+**CHALLENGE** is "I'm not sold." Use it when you have a specific reason for skepticism, even if you can't fully articulate the counter-argument. "I don't think this holds under load" is a good CHALLENGE comment.
+
+**CORE** is "this is what it comes down to." Use it sparingly — maybe once or twice per round. It marks the claim that the decision hinges on. If everything feels equally important, nothing is CORE.
+
+**SHIFT** is "this changed the frame." Use it when a model recast the problem in a way that reorients your reasoning. SHIFT is the rarest type and the most powerful.
+
+## Snippet count
+
+There is no ideal number. Your goal is to steer additional deliberation via directly attributed reactions and commentary.
+
+## Prompt vs. snippets
+
+Use `append_round.prompt` for broad steering:
+- "Focus on the caching layer. The storage question seems resolved."
+- "Assume attribution accuracy matters more than density."
+
+Use snippets for situated reactions:
+- CORE on the exact trust invariant.
+- CHALLENGE on a claim that over-merges null attribution.
+- EXPLORE on an underdeveloped mitigation.
+
+If both are useful, use both.

--- a/optional-skills/software-development/mumo/references/synthesis.md
+++ b/optional-skills/software-development/mumo/references/synthesis.md
@@ -1,0 +1,48 @@
+# Synthesis
+
+After each round, share your read of the panel with the user. This reference covers how to do that.
+
+## Read before writing
+
+Before summarizing:
+
+1. Scan the claim map for convergence and live disagreement.
+2. Read prose behind the central claims.
+3. Identify which points are panel consensus, which are contested, and which are your own judgment.
+
+## Outcome-specific guidance
+
+### Convergent outcome (panel mostly agrees)
+
+State the consensus position and the reasoning behind it. Note any dissents and whether they're substantive or stylistic. Give the user a clear recommendation grounded in the panel's shared reasoning.
+
+Don't over-qualify. If three models converged on an answer for compatible reasons, say so directly.
+
+### Divergent outcome (panel genuinely split)
+
+Present the competing positions and what drives each — different assumptions, different priorities, different risk tolerances. State which position you find more compelling and why, but frame it as your read, not the panel's verdict.
+
+Make the driver of the split explicit: "The disagreement comes down to whether [assumption X] holds. If it does, Position A is stronger. If not, Position B."
+
+### Expansion outcome (many threads, no single answer)
+
+Organize the threads by importance or urgency. Don't force them into a recommendation. Present them as "things the panel surfaced" with your assessment of which deserve follow-up.
+
+Group related threads. A session that produced 8 isolated concerns is more useful when organized into 3 clusters with a note on which cluster matters most.
+
+## Language
+
+Use clear attribution:
+
+- "The panel converged on..."
+- "The main split was..."
+- "My read is..."
+
+Do not present your synthesis as the panel's raw output. The user should know what came from the deliberation and what came from you.
+
+## What to leave out
+
+- Per-model quality commentary ("GPT had the best answer").
+- Hedging that adds no information ("Of course, this is just one perspective...").
+
+Offer to share the session when the user might want to review raw responses or the claim map directly.


### PR DESCRIPTION
## What

Adds the **mumo** skill — multi-model deliberation via mumo's MCP server. Runs structured panels across frontier AI models (Claude, GPT, Gemini, Grok, Qwen, GLM, Kimi) and returns a cross-model claim map for contested architecture/product decisions, design reviews, pre-launch pressure tests, and tradeoff analysis.

## Why `software-development/`

mumo is a *tool* the native Hermes agent calls — not another autonomous agent — so `autonomous-ai-agents/` would mis-categorize it. It shares the "structured methodology before acting" shape with `writing-plans`, `plan`, and `requesting-code-review`, all of which already live in `software-development/`. `related_skills` cross-references all three.

## Layout

```
optional-skills/software-development/mumo/
├── SKILL.md           # deliberation kernel
├── references/        # 6 docs (claim-maps, snippets, recap, etc.)
├── playbooks/         # 4 cognitive-shape playbooks (loaded on demand)
└── config/mumo.yaml   # MCP server config users merge into ~/.hermes/config.yaml
```

## Source of truth

Canonical at [github.com/mumo-chat/mumo-hermes](https://github.com/mumo-chat/mumo-hermes) (currently `v0.1.5`). This contribution is a **verbatim snapshot** of the canonical SKILL.md — no separate PR-version frontmatter to maintain. Frontmatter conventions match approved optional-skill samples (`dcf-model`, `kanban-video-orchestrator`, `concept-diagrams`): unquoted version, lowercase tags. Future updates will be PR'd from the canonical source.

Two fields per the canonical [creating-skills](https://hermes-agent.nousresearch.com/docs/developer-guide/creating-skills) doc are kept — `required_environment_variables` (enables hub interactive install prompt for `MUMO_API_KEY`) and `metadata.hermes.requires_tools` (hides skill when mumo MCP server isn't registered). I didn't see them in the optional-skill samples I checked; happy to drop if review prefers.

## Setup

Users need a mumo platform API key (`mmo_live_*`) from https://mumo.chat/settings/api-keys, then add the MCP server block from `config/mumo.yaml` to `~/.hermes/config.yaml` under `mcp_servers:`.