### PR TITLE
fix(gateway-windows): atomic write for .cmd and startup launcher scripts

### DIFF
--- a/hermes_cli/gateway_windows.py
+++ b/hermes_cli/gateway_windows.py
@@ -365,7 +365,9 @@ def _write_task_script() -> Path:
 
     content = _build_gateway_cmd_script(python_path, working_dir, hermes_home, profile_arg)
     script_path = get_task_script_path()
-    script_path.write_text(content, encoding="utf-8", newline="")
+    tmp = script_path.with_suffix(".tmp")
+    tmp.write_text(content, encoding="utf-8", newline="")
+    tmp.replace(script_path)
     return script_path
 
 
@@ -436,7 +438,9 @@ def _install_startup_entry(script_path: Path) -> Path:
     """Write the Startup-folder fallback launcher. Returns its path."""
     entry = get_startup_entry_path()
     entry.parent.mkdir(parents=True, exist_ok=True)
-    entry.write_text(_build_startup_launcher(script_path), encoding="utf-8", newline="")
+    tmp = entry.with_suffix(".tmp")
+    tmp.write_text(_build_startup_launcher(script_path), encoding="utf-8", newline="")
+    tmp.replace(entry)
     return entry
 
 


### PR DESCRIPTION
## What does this PR do?

`_write_task_script()` and `_install_startup_entry()` both use `Path.write_text()` to write the scheduled-task `.cmd` script and the Startup-folder launcher directly. If the process is killed or crashes mid-write (OOM, power loss, SIGKILL during install), the target file is left partially written. On the next Windows login the Scheduled Task fires against a truncated script and the gateway silently never starts — with no diagnostic in Task Scheduler.

## Type of Change
- [x] Bug fix

## Changes Made
- `_write_task_script()`: write to `script_path.with_suffix('.tmp')` first, then `tmp.replace(script_path)`
- `_install_startup_entry()`: same temp-file + atomic rename pattern

This matches the pattern already used throughout the codebase (`cron/jobs.py`, `agent/google_oauth.py`, `agent/anthropic_adapter.py`, etc.).

## How to Test
1. Review `hermes_cli/gateway_windows.py` — `_write_task_script()` and `_install_startup_entry()`
2. Verify both now use `with_suffix('.tmp')` + `tmp.replace()` instead of direct `write_text()`
3. Run `python -m pytest tests/ -q` — no regressions expected

## Checklist
### Code
- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've tested on my platform: Ubuntu 24.04 (WSL2)

### Documentation & Housekeeping
- [x] No documentation changes needed
- [x] Cross-platform considered — fix is Windows-only code path, no Linux/macOS impact