### PR TITLE
fix(agent): log warning when fallback model normalization fails instead of silently swallowing

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -776,8 +776,11 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
             from hermes_cli.model_normalize import normalize_model_for_provider
 
             fb_model = normalize_model_for_provider(fb_model, fb_provider)
-        except Exception:
-            pass
+        except Exception as _norm_err:
+            logger.warning(
+                "Could not normalize fallback model %r for provider %r: %s",
+                fb_model, fb_provider, _norm_err,
+            )
 
         # Determine api_mode from provider / base URL / model
         fb_api_mode = "chat_completions"


### PR DESCRIPTION
## What does this PR do?

In the fallback provider path inside `agent/chat_completion_helpers.py`, the call to `normalize_model_for_provider()` is wrapped in a bare `except Exception: pass`. If normalization fails (import error, unexpected model string, provider mismatch), the exception is silently discarded and `fb_model` is sent to the fallback provider in its raw un-normalized form. For providers with strict identifier requirements (Anthropic canonical names, Bedrock ARNs, regional variants) this causes the fallback API call to fail immediately — the recovery mechanism used to escape a primary failure produces an equally-hard failure with no diagnostic.

## Type of Change
- [x] Bug fix

## Changes Made
- Replaced `except Exception: pass` with `except Exception as _norm_err: logger.warning(...)`
- Warning includes the raw model name, provider, and the exception — enough to diagnose without changing fallback behavior

## How to Test
1. Review `agent/chat_completion_helpers.py` around line 775
2. Trigger a fallback with a model string that fails normalization — warning should appear in logs
3. Run `python -m pytest tests/ -q` — no regressions expected

## Checklist
### Code
- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've tested on my platform: Ubuntu 24.04 (WSL2)

### Documentation & Housekeeping
- [x] No documentation changes needed
- [x] Cross-platform considered — logging change only, no platform-specific impact