### PR TITLE
feat: harden dashboard public access

### DIFF
--- a/.hermes/plans/phase-6-production-exposure-hardening.md
+++ b/.hermes/plans/phase-6-production-exposure-hardening.md
@@ -1,0 +1,141 @@
+# Phase 6 Production Exposure Hardening Implementation Plan
+
+> **For Hermes:** Implement directly in small verified steps; keep localhost defaults safe and preserve backward compatibility.
+
+**Goal:** Make `hermes dashboard` safely accessible on a LAN/reverse proxy without exposing the injected admin session token to every network visitor.
+
+**Architecture:** Keep the current localhost-only dashboard path unchanged. Add an explicit `--public` mode for network exposure that disables legacy HTML-injected token auth and uses first-admin/password login with an HttpOnly signed session cookie, CSRF protection for mutating API calls, strict Host allow-listing, proxy-aware secure cookies, and security headers. Keep legacy `--insecure` as the existing unsafe escape hatch.
+
+**Tech Stack:** FastAPI/uvicorn backend in `hermes_cli/web_server.py`; argparse CLI in `hermes_cli/main.py`; React/Vite frontend in `web/src`; pytest + FastAPI TestClient for regression coverage.
+
+---
+
+## Task 1: Add backend public-mode auth/security tests
+
+**Objective:** Capture desired public-mode behavior before implementation.
+
+**Files:**
+- Create: `tests/pallas_cli/test_production_exposure_hardening.py`
+- Modify if directory differs: use `tests/hermes_cli/` if `tests/pallas_cli/` is absent.
+
+**Checks:**
+- `--public` does not inject `window.__HERMES_SESSION_TOKEN__`.
+- public mode rejects legacy `X-Hermes-Session-Token` / bearer auth.
+- default localhost mode still accepts legacy token for backward compatibility.
+- `0.0.0.0` public mode rejects unlisted Host headers and accepts configured `--allowed-host` values.
+- `start_server(... production=True/public=True ...)` records safe app state.
+- CLI parser forwards `--public`, `--allowed-host`, `--secure-cookies`, and proxy trust flags.
+
+**Verify:**
+```bash
+python -m pytest tests/hermes_cli/test_production_exposure_hardening.py -q -o 'addopts='
+```
+Expected initially: failures proving tests cover missing behavior.
+
+## Task 2: Add dashboard runtime flags and Host allow-listing
+
+**Objective:** Make network binding safe by default and explicit.
+
+**Files:**
+- Modify: `hermes_cli/main.py`
+- Modify: `hermes_cli/web_server.py`
+
+**Implementation:**
+- Add CLI flags:
+  - `--public`: safe network exposure mode.
+  - `--allowed-host HOST`: repeatable Host allow-list for public/all-interface binds.
+  - `--secure-cookies`: force Secure on auth cookies.
+  - `--no-trust-proxy`: ignore `X-Forwarded-*` headers.
+- Keep `--insecure`, but label it as dangerous legacy token exposure.
+- In `start_server`, reject non-localhost unless `--public` or `--insecure` is set.
+- Store on `app.state`: `public_mode`, `legacy_token_auth_enabled`, `allowed_hosts`, `secure_cookies`, `trust_proxy_headers`.
+- Update `_is_accepted_host` to enforce explicit allow-list for `0.0.0.0`/`::` public mode.
+
+**Verify:** targeted pytest.
+
+## Task 3: Add cookie-session auth, first-admin setup, and CSRF
+
+**Objective:** Provide real browser authentication in public mode without exposing a bearer token in HTML.
+
+**Files:**
+- Modify: `hermes_cli/web_server.py`
+
+**Implementation:**
+- Store dashboard users at `$HERMES_HOME/dashboard-users.yaml`.
+- Password hashing: PBKDF2-HMAC-SHA256 with per-user salt.
+- Public endpoints:
+  - `GET /api/auth/status`
+  - `POST /api/auth/setup` only when no users exist; creates first admin.
+  - `POST /api/auth/login`
+  - `POST /api/auth/logout`
+  - `GET /api/auth/me`
+- Session cookie: signed, HttpOnly, SameSite=Lax, expiry, restart invalidation acceptable.
+- CSRF token: included in signed session and returned by login/status; required for cookie-authenticated unsafe methods.
+- Auth middleware accepts either legacy token in localhost/default mode or cookie auth in public mode; legacy token disabled when public mode is active.
+
+**Verify:** tests for first-admin setup, login, protected GET, mutating request CSRF rejection/acceptance.
+
+## Task 4: Update SPA API client and login/setup gate
+
+**Objective:** Make the React app usable in public mode with cookies and no injected session token.
+
+**Files:**
+- Modify: `web/src/lib/api.ts`
+- Modify: `web/src/App.tsx`
+- Modify: `web/src/pages/ChatPage.tsx`
+- Modify: `web/src/components/ChatSidebar.tsx` if it hard-requires the legacy token.
+
+**Implementation:**
+- Always send `credentials: 'same-origin'`.
+- Keep injecting `X-Hermes-Session-Token` only when present.
+- Store CSRF token returned by auth endpoints; add `X-Hermes-CSRF-Token` on mutating cookie-auth requests.
+- On app boot, call `/api/auth/status`; if public auth is disabled, render existing dashboard.
+- If setup needed, render first-admin setup form.
+- If login needed, render login form.
+- Logout clears cookie and returns to login.
+- Chat WebSockets use cookie auth in public mode; token query remains only for legacy mode.
+
+**Verify:** `npm run build` and browser smoke.
+
+## Task 5: Add production exposure docs
+
+**Objective:** Document safe LAN/reverse-proxy operation.
+
+**Files:**
+- Create: `docs/phase-6-production-exposure-runbook.md`
+
+**Content:**
+- Safe command examples:
+  - LAN: `hermes dashboard --public --host 0.0.0.0 --allowed-host <ip-or-dns>`
+  - Reverse proxy: `--allowed-host agents.example.com --secure-cookies`
+- Explain why `--insecure` is unsafe.
+- Caddy and nginx snippets.
+- systemd user service snippet.
+- Smoke checks for no injected session token, Host rejection, auth/login, and protected API behavior.
+
+## Task 6: Verify, smoke, commit, push
+
+**Objective:** Prove behavior and publish the changes.
+
+**Commands:**
+```bash
+python -m pytest tests/hermes_cli/test_production_exposure_hardening.py tests/hermes_cli/test_web_server_host_header.py tests/hermes_cli/test_web_server_public_api_auth.py -q -o 'addopts='
+cd web && npm run build
+python -m compileall -q hermes_cli
+python -m pytest tests/hermes_cli -q -o 'addopts='
+git diff --check
+git status --short
+git add hermes_cli/main.py hermes_cli/web_server.py web/src tests/hermes_cli docs .hermes/plans/phase-6-production-exposure-hardening.md
+git commit -m "feat: harden public dashboard exposure"
+git push origin HEAD
+```
+
+**Browser smoke:**
+- Start temporary dashboard with isolated `HERMES_HOME`.
+- Confirm first-admin screen.
+- Create admin.
+- Confirm no `window.__HERMES_SESSION_TOKEN__` in public-mode HTML.
+- Login/logout works.
+- Bad Host gets 400.
+- Legacy token gets 401.
+- Protected page/API works after cookie login.

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -10512,6 +10512,10 @@ def cmd_dashboard(args):
         port=args.port,
         open_browser=not args.no_open,
         allow_public=getattr(args, "insecure", False),
+        public=getattr(args, "public", False),
+        allowed_hosts=getattr(args, "allowed_host", None),
+        secure_cookies=getattr(args, "secure_cookies", False),
+        trust_proxy_headers=not getattr(args, "no_trust_proxy", False),
         embedded_chat=embedded_chat,
     )
 
@@ -13493,7 +13497,29 @@ Examples:
     dashboard_parser.add_argument(
         "--insecure",
         action="store_true",
-        help="Allow binding to non-localhost (DANGEROUS: exposes API keys on the network)",
+        help="Allow binding to non-localhost using legacy token-in-HTML auth (DANGEROUS)",
+    )
+    dashboard_parser.add_argument(
+        "--public",
+        action="store_true",
+        help="Safely expose dashboard on LAN/proxy with cookie login and no injected session token",
+    )
+    dashboard_parser.add_argument(
+        "--allowed-host",
+        action="append",
+        default=[],
+        metavar="HOST",
+        help="Allowed Host header for --public; repeat for DNS names/IPs users will browse to",
+    )
+    dashboard_parser.add_argument(
+        "--secure-cookies",
+        action="store_true",
+        help="Always mark dashboard auth cookies Secure (use behind HTTPS reverse proxies)",
+    )
+    dashboard_parser.add_argument(
+        "--no-trust-proxy",
+        action="store_true",
+        help="Ignore X-Forwarded-Proto when deciding cookie security",
     )
     dashboard_parser.add_argument(
         "--tui",

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -10,6 +10,8 @@ Usage:
 """
 
 import asyncio
+import base64
+import hashlib
 import hmac
 import importlib.util
 import json
@@ -23,7 +25,7 @@ import time
 import urllib.parse
 import urllib.request
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Set, Tuple
 
 import yaml
 
@@ -85,6 +87,9 @@ app = FastAPI(title="Hermes Agent", version=__version__)
 # ---------------------------------------------------------------------------
 _SESSION_TOKEN = secrets.token_urlsafe(32)
 _SESSION_HEADER_NAME = "X-Hermes-Session-Token"
+_CSRF_HEADER_NAME = "X-Hermes-CSRF-Token"
+_DASHBOARD_SESSION_COOKIE = "hermes_dashboard_session"
+_DASHBOARD_SESSION_TTL_SECONDS = 12 * 60 * 60
 
 # In-browser Chat tab (/chat, /api/pty, …).  Off unless ``hermes dashboard --tui``
 # or HERMES_DASHBOARD_TUI=1.  Set from :func:`start_server`.
@@ -119,17 +124,103 @@ _PUBLIC_API_PATHS: frozenset = frozenset({
     "/api/dashboard/themes",
     "/api/dashboard/plugins",
     "/api/dashboard/plugins/rescan",
+    "/api/auth/status",
+    "/api/auth/setup",
+    "/api/auth/login",
+    "/api/auth/logout",
+    "/api/auth/me",
 })
 
 
-def _has_valid_session_token(request: Request) -> bool:
-    """True if the request carries a valid dashboard session token.
+def _public_mode_enabled() -> bool:
+    return bool(getattr(app.state, "public_mode", False))
 
-    The dedicated session header avoids collisions with reverse proxies that
-    already use ``Authorization`` (for example Caddy ``basic_auth``). We still
-    accept the legacy Bearer path for backward compatibility with older
-    dashboard bundles.
-    """
+
+def _legacy_token_auth_enabled() -> bool:
+    return bool(getattr(app.state, "legacy_token_auth_enabled", True))
+
+
+def _dashboard_users_path() -> Path:
+    return get_hermes_home() / "dashboard-users.yaml"
+
+
+def _load_dashboard_users() -> Dict[str, Any]:
+    path = _dashboard_users_path()
+    if not path.exists():
+        return {"users": {}}
+    try:
+        data = yaml.safe_load(path.read_text()) or {}
+    except Exception:
+        return {"users": {}}
+    users = data.get("users") if isinstance(data, dict) else None
+    return {"users": users if isinstance(users, dict) else {}}
+
+
+def _save_dashboard_users(data: Dict[str, Any]) -> None:
+    path = _dashboard_users_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(yaml.safe_dump(data, sort_keys=True))
+    try:
+        path.chmod(0o600)
+    except OSError:
+        pass
+
+
+def _hash_password(password: str, salt: Optional[str] = None) -> Dict[str, str]:
+    salt = salt or secrets.token_urlsafe(16)
+    dk = hashlib.pbkdf2_hmac("sha256", password.encode(), salt.encode(), 240_000)
+    return {"salt": salt, "hash": base64.urlsafe_b64encode(dk).decode()}
+
+
+def _verify_password(password: str, record: Dict[str, Any]) -> bool:
+    salt = str(record.get("salt") or "")
+    expected = str(record.get("hash") or "")
+    if not salt or not expected:
+        return False
+    actual = _hash_password(password, salt)["hash"]
+    return hmac.compare_digest(actual.encode(), expected.encode())
+
+
+def _sign_session_payload(payload: Dict[str, Any]) -> str:
+    raw = json.dumps(payload, separators=(",", ":"), sort_keys=True).encode()
+    body = base64.urlsafe_b64encode(raw).decode().rstrip("=")
+    sig = hmac.new(_SESSION_TOKEN.encode(), body.encode(), hashlib.sha256).hexdigest()
+    return f"{body}.{sig}"
+
+
+def _read_session_cookie(request: Any) -> Optional[Dict[str, Any]]:
+    value = request.cookies.get(_DASHBOARD_SESSION_COOKIE, "")
+    if not value or "." not in value:
+        return None
+    body, sig = value.rsplit(".", 1)
+    expected = hmac.new(_SESSION_TOKEN.encode(), body.encode(), hashlib.sha256).hexdigest()
+    if not hmac.compare_digest(sig.encode(), expected.encode()):
+        return None
+    try:
+        padded = body + "=" * (-len(body) % 4)
+        payload = json.loads(base64.urlsafe_b64decode(padded.encode()).decode())
+    except Exception:
+        return None
+    try:
+        if int(payload.get("exp", 0)) < int(time.time()):
+            return None
+    except (TypeError, ValueError):
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def _request_is_cookie_authenticated(request: Request) -> bool:
+    return _read_session_cookie(request) is not None
+
+
+def _has_valid_session_token(request: Request) -> bool:
+    """True if the request carries valid dashboard credentials."""
+    if _request_is_cookie_authenticated(request):
+        return True
+
+    if not _legacy_token_auth_enabled():
+        return False
+
     session_header = request.headers.get(_SESSION_HEADER_NAME, "")
     if session_header and hmac.compare_digest(
         session_header.encode(),
@@ -143,9 +234,46 @@ def _has_valid_session_token(request: Request) -> bool:
 
 
 def _require_token(request: Request) -> None:
-    """Validate the ephemeral session token.  Raises 401 on mismatch."""
+    """Validate dashboard credentials. Raises 401 on mismatch."""
     if not _has_valid_session_token(request):
         raise HTTPException(status_code=401, detail="Unauthorized")
+
+
+def _csrf_is_valid(request: Request) -> bool:
+    sess = _read_session_cookie(request)
+    if not sess:
+        return True  # legacy token auth does not use CSRF
+    expected = str(sess.get("csrf") or "")
+    supplied = request.headers.get(_CSRF_HEADER_NAME, "")
+    return bool(expected) and hmac.compare_digest(supplied.encode(), expected.encode())
+
+
+def _cookie_secure_for_request(request: Request) -> bool:
+    if bool(getattr(app.state, "secure_cookies", False)):
+        return True
+    if bool(getattr(app.state, "trust_proxy_headers", True)):
+        return request.headers.get("x-forwarded-proto", "").split(",", 1)[0].strip().lower() == "https"
+    return request.url.scheme == "https"
+
+
+def _set_dashboard_session_cookie(response: Response, request: Request, username: str, role: str) -> str:
+    csrf = secrets.token_urlsafe(24)
+    payload = {
+        "sub": username,
+        "role": role,
+        "csrf": csrf,
+        "exp": int(time.time()) + _DASHBOARD_SESSION_TTL_SECONDS,
+    }
+    response.set_cookie(
+        _DASHBOARD_SESSION_COOKIE,
+        _sign_session_payload(payload),
+        max_age=_DASHBOARD_SESSION_TTL_SECONDS,
+        httponly=True,
+        secure=_cookie_secure_for_request(request),
+        samesite="lax",
+        path="/",
+    )
+    return csrf
 
 
 # Accepted Host header values for loopback binds. DNS rebinding attacks
@@ -159,40 +287,39 @@ _LOOPBACK_HOST_VALUES: frozenset = frozenset({
 })
 
 
-def _is_accepted_host(host_header: str, bound_host: str) -> bool:
+def _normalise_host_header(host_header: str) -> str:
+    if not host_header:
+        return ""
+    h = host_header.strip()
+    if h.startswith("["):
+        close = h.find("]")
+        host_only = h[1:close] if close != -1 else h.strip("[]")
+    else:
+        host_only = h.rsplit(":", 1)[0] if ":" in h else h
+    return host_only.lower()
+
+
+def _is_accepted_host(host_header: str, bound_host: str, allowed_hosts: Optional[Set[str]] = None) -> bool:
     """True if the Host header targets the interface we bound to.
 
     Accepts:
     - Exact bound host (with or without port suffix)
     - Loopback aliases when bound to loopback
-    - Any host when bound to 0.0.0.0 (explicit opt-in to non-loopback,
-      no protection possible at this layer)
+    - Explicit allowed_hosts when bound to all interfaces
     """
-    if not host_header:
+    host_only = _normalise_host_header(host_header)
+    if not host_only:
         return False
-    # Strip port suffix. IPv6 addresses use bracket notation:
-    #   [::1]         — no port
-    #   [::1]:9119    — with port
-    # Plain hosts/v4:
-    #   localhost:9119
-    #   127.0.0.1:9119
-    h = host_header.strip()
-    if h.startswith("["):
-        # IPv6 bracketed — port (if any) follows "]:"
-        close = h.find("]")
-        if close != -1:
-            host_only = h[1:close]  # strip brackets
-        else:
-            host_only = h.strip("[]")
-    else:
-        host_only = h.rsplit(":", 1)[0] if ":" in h else h
-    host_only = host_only.lower()
 
-    # 0.0.0.0 bind means operator explicitly opted into all-interfaces
-    # (requires --insecure per web_server.start_server). No Host-layer
-    # defence can protect that mode; rely on operator network controls.
-    if bound_host in {"0.0.0.0", "::"}:
+    allowed_lc = {h.lower() for h in allowed_hosts if h} if allowed_hosts is not None else set()
+    if allowed_lc and host_only in allowed_lc:
         return True
+
+    # 0.0.0.0 bind means all-interfaces. In safe public mode we require an
+    # explicit Host allow-list; legacy --insecure passes allowed_hosts=None and
+    # keeps the old any-host behavior.
+    if bound_host in {"0.0.0.0", "::"}:
+        return allowed_hosts is None
 
     # Loopback bind: accept the loopback names
     bound_lc = bound_host.lower()
@@ -220,7 +347,8 @@ async def host_header_middleware(request: Request, call_next):
     bound_host = getattr(app.state, "bound_host", None)
     if bound_host:
         host_header = request.headers.get("host", "")
-        if not _is_accepted_host(host_header, bound_host):
+        allowed_hosts = getattr(app.state, "allowed_hosts", None)
+        if not _is_accepted_host(host_header, bound_host, allowed_hosts):
             return JSONResponse(
                 status_code=400,
                 content={
@@ -235,7 +363,7 @@ async def host_header_middleware(request: Request, call_next):
 
 @app.middleware("http")
 async def auth_middleware(request: Request, call_next):
-    """Require the session token on all /api/ routes except the public list."""
+    """Require dashboard credentials on all /api/ routes except the public list."""
     path = request.url.path
     if path.startswith("/api/") and path not in _PUBLIC_API_PATHS:
         if not _has_valid_session_token(request):
@@ -243,7 +371,122 @@ async def auth_middleware(request: Request, call_next):
                 status_code=401,
                 content={"detail": "Unauthorized"},
             )
+        if request.method.upper() not in {"GET", "HEAD", "OPTIONS"} and not _csrf_is_valid(request):
+            return JSONResponse(
+                status_code=403,
+                content={"detail": "CSRF token required"},
+            )
     return await call_next(request)
+
+
+@app.middleware("http")
+async def security_headers_middleware(request: Request, call_next):
+    response = await call_next(request)
+    response.headers.setdefault("X-Content-Type-Options", "nosniff")
+    response.headers.setdefault("Referrer-Policy", "no-referrer")
+    response.headers.setdefault("X-Frame-Options", "DENY")
+    response.headers.setdefault("Permissions-Policy", "camera=(), microphone=(), geolocation=(), payment=()")
+    response.headers.setdefault(
+        "Content-Security-Policy",
+        "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; "
+        "img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self' ws: wss:; frame-ancestors 'none'",
+    )
+    return response
+
+
+class DashboardAuthRequest(BaseModel):
+    username: str
+    password: str
+
+
+@app.get("/api/auth/status")
+async def dashboard_auth_status(request: Request):
+    enabled = _public_mode_enabled()
+    users = _load_dashboard_users().get("users", {})
+    sess = _read_session_cookie(request)
+    return {
+        "enabled": enabled,
+        "needs_setup": enabled and not bool(users),
+        "authenticated": (not enabled) or bool(sess),
+        "user": ({"username": sess.get("sub"), "role": sess.get("role", "admin")} if sess else None),
+        "csrf_token": sess.get("csrf") if sess else None,
+    }
+
+
+@app.get("/api/auth/me")
+async def dashboard_auth_me(request: Request):
+    sess = _read_session_cookie(request)
+    if not _public_mode_enabled():
+        return {"authenticated": True, "user": None, "csrf_token": None}
+    if not sess:
+        raise HTTPException(status_code=401, detail="Unauthorized")
+    return {
+        "authenticated": True,
+        "user": {"username": sess.get("sub"), "role": sess.get("role", "admin")},
+        "csrf_token": sess.get("csrf"),
+    }
+
+
+@app.post("/api/auth/setup")
+async def dashboard_auth_setup(body: DashboardAuthRequest, request: Request):
+    if not _public_mode_enabled():
+        raise HTTPException(status_code=404, detail="Dashboard auth is disabled")
+    username = body.username.strip()
+    if len(username) < 3 or len(body.password) < 12:
+        raise HTTPException(status_code=400, detail="Username must be at least 3 chars and password at least 12 chars")
+    data = _load_dashboard_users()
+    if data.get("users"):
+        raise HTTPException(status_code=409, detail="Dashboard users already configured")
+    pw = _hash_password(body.password)
+    data["users"] = {username: {"role": "admin", **pw}}
+    _save_dashboard_users(data)
+    response = JSONResponse({
+        "ok": True,
+        "user": {"username": username, "role": "admin"},
+        "csrf_token": "",
+    })
+    csrf = _set_dashboard_session_cookie(response, request, username, "admin")
+    response.body = json.dumps({
+        "ok": True,
+        "user": {"username": username, "role": "admin"},
+        "csrf_token": csrf,
+    }).encode()
+    response.headers["content-length"] = str(len(response.body))
+    return response
+
+
+@app.post("/api/auth/login")
+async def dashboard_auth_login(body: DashboardAuthRequest, request: Request):
+    if not _public_mode_enabled():
+        raise HTTPException(status_code=404, detail="Dashboard auth is disabled")
+    username = body.username.strip()
+    users = _load_dashboard_users().get("users", {})
+    record = users.get(username)
+    if not isinstance(record, dict) or not _verify_password(body.password, record):
+        raise HTTPException(status_code=401, detail="Invalid username or password")
+    role = str(record.get("role") or "admin")
+    response = JSONResponse({
+        "ok": True,
+        "user": {"username": username, "role": role},
+        "csrf_token": "",
+    })
+    csrf = _set_dashboard_session_cookie(response, request, username, role)
+    response.body = json.dumps({
+        "ok": True,
+        "user": {"username": username, "role": role},
+        "csrf_token": csrf,
+    }).encode()
+    response.headers["content-length"] = str(len(response.body))
+    return response
+
+
+@app.post("/api/auth/logout")
+async def dashboard_auth_logout(request: Request):
+    if _public_mode_enabled() and _read_session_cookie(request) and not _csrf_is_valid(request):
+        raise HTTPException(status_code=403, detail="CSRF token required")
+    response = JSONResponse({"ok": True})
+    response.delete_cookie(_DASHBOARD_SESSION_COOKIE, path="/")
+    return response
 
 
 # ---------------------------------------------------------------------------
@@ -3409,8 +3652,9 @@ async def pty_ws(ws: WebSocket) -> None:
 
     # --- auth + loopback check (before accept so we can close cleanly) ---
     token = ws.query_params.get("token", "")
-    expected = _SESSION_TOKEN
-    if not hmac.compare_digest(token.encode(), expected.encode()):
+    token_ok = token and _legacy_token_auth_enabled() and hmac.compare_digest(token.encode(), _SESSION_TOKEN.encode())
+    cookie_ok = _read_session_cookie(ws) is not None
+    if not (token_ok or cookie_ok):
         await ws.close(code=4401)
         return
 
@@ -3683,11 +3927,13 @@ def mount_spa(application: FastAPI):
         """
         html = _index_path.read_text()
         chat_js = "true" if _DASHBOARD_EMBEDDED_CHAT_ENABLED else "false"
-        token_script = (
-            f'<script>window.__HERMES_SESSION_TOKEN__="{_SESSION_TOKEN}";'
+        runtime = (
             f"window.__HERMES_DASHBOARD_EMBEDDED_CHAT__={chat_js};"
-            f'window.__HERMES_BASE_PATH__="{prefix}";</script>'
+            f'window.__HERMES_BASE_PATH__="{prefix}";'
         )
+        if _legacy_token_auth_enabled():
+            runtime = f'window.__HERMES_SESSION_TOKEN__="{_SESSION_TOKEN}";' + runtime
+        token_script = f"<script>{runtime}</script>"
         if prefix:
             # Rewrite absolute asset URLs baked into the Vite build so the
             # browser fetches them through the same proxy prefix.
@@ -4519,6 +4765,10 @@ def start_server(
     open_browser: bool = True,
     allow_public: bool = False,
     *,
+    public: bool = False,
+    allowed_hosts: Optional[List[str]] = None,
+    secure_cookies: bool = False,
+    trust_proxy_headers: bool = True,
     embedded_chat: bool = False,
 ):
     """Start the web UI server."""
@@ -4528,16 +4778,22 @@ def start_server(
     _DASHBOARD_EMBEDDED_CHAT_ENABLED = embedded_chat
 
     _LOCALHOST = ("127.0.0.1", "localhost", "::1")
-    if host not in _LOCALHOST and not allow_public:
+    if host not in _LOCALHOST and not (allow_public or public):
         raise SystemExit(
             f"Refusing to bind to {host} — the dashboard exposes API keys "
-            f"and config without robust authentication.\n"
-            f"Use --insecure to override (NOT recommended on untrusted networks)."
+            f"and config.\n"
+            f"Use --public for cookie-authenticated LAN/reverse-proxy exposure, "
+            f"or --insecure for the legacy token-exposing override."
         )
-    if host not in _LOCALHOST:
+    if host not in _LOCALHOST and allow_public and not public:
         _log.warning(
-            "Binding to %s with --insecure — the dashboard has no robust "
-            "authentication. Only use on trusted networks.", host,
+            "Binding to %s with --insecure — legacy dashboard token auth is "
+            "injected into HTML. Only use on trusted networks.", host,
+        )
+    if host not in _LOCALHOST and public and not allowed_hosts:
+        raise SystemExit(
+            "--public with a non-localhost bind requires at least one "
+            "--allowed-host value (DNS name or IP users will browse to)."
         )
 
     # Record the bound host so host_header_middleware can validate incoming
@@ -4546,6 +4802,11 @@ def start_server(
     # PTY child uses to publish events to the dashboard sidebar.
     app.state.bound_host = host
     app.state.bound_port = port
+    app.state.public_mode = bool(public)
+    app.state.legacy_token_auth_enabled = not bool(public)
+    app.state.allowed_hosts = {h.lower() for h in (allowed_hosts or [])} if public else None
+    app.state.secure_cookies = bool(secure_cookies)
+    app.state.trust_proxy_headers = bool(trust_proxy_headers)
 
     if open_browser:
         import webbrowser

--- a/tests/hermes_cli/test_production_exposure_hardening.py
+++ b/tests/hermes_cli/test_production_exposure_hardening.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+import argparse
+import importlib
+from unittest.mock import patch
+
+from fastapi.testclient import TestClient
+
+
+def _reset_state(ws):
+    for name in (
+        "bound_host",
+        "bound_port",
+        "public_mode",
+        "legacy_token_auth_enabled",
+        "allowed_hosts",
+        "secure_cookies",
+        "trust_proxy_headers",
+    ):
+        if hasattr(ws.app.state, name):
+            delattr(ws.app.state, name)
+
+
+def test_public_mode_spa_does_not_inject_legacy_session_token(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    ws = importlib.import_module("hermes_cli.web_server")
+    _reset_state(ws)
+    ws.app.state.public_mode = True
+    ws.app.state.legacy_token_auth_enabled = False
+    html = "<html><head></head><body></body></html>"
+    index = tmp_path / "index.html"
+    index.write_text(html)
+    (tmp_path / "assets").mkdir()
+    monkeypatch.setattr(ws, "WEB_DIST", tmp_path)
+    app = ws.FastAPI()
+    ws.mount_spa(app)
+    client = TestClient(app)
+    resp = client.get("/", headers={"Host": "agents.lan"})
+    assert resp.status_code == 200
+    assert "__HERMES_SESSION_TOKEN__" not in resp.text
+    assert "__HERMES_DASHBOARD_EMBEDDED_CHAT__" in resp.text
+
+
+def test_public_mode_rejects_legacy_token_and_allows_cookie_login(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    ws = importlib.reload(importlib.import_module("hermes_cli.web_server"))
+    _reset_state(ws)
+    ws.app.state.public_mode = True
+    ws.app.state.legacy_token_auth_enabled = False
+    ws.app.state.allowed_hosts = {"agents.lan"}
+    client = TestClient(ws.app)
+
+    legacy = {"Host": "agents.lan", ws._SESSION_HEADER_NAME: ws._SESSION_TOKEN}
+    assert client.get("/api/config", headers=legacy).status_code == 401
+
+    setup = client.post(
+        "/api/auth/setup",
+        headers={"Host": "agents.lan"},
+        json={"username": "admin", "password": "correct horse battery staple"},
+    )
+    assert setup.status_code == 200, setup.text
+    csrf = setup.json()["csrf_token"]
+    assert client.get("/api/config", headers={"Host": "agents.lan"}).status_code == 200
+    assert client.put(
+        "/api/config",
+        headers={"Host": "agents.lan"},
+        json={"config": {}},
+    ).status_code == 403
+    assert client.put(
+        "/api/config",
+        headers={"Host": "agents.lan", "X-Hermes-CSRF-Token": csrf},
+        json={"config": {}},
+    ).status_code != 403
+    assert client.post("/api/auth/logout", headers={"Host": "agents.lan"}).status_code == 403
+    assert client.post(
+        "/api/auth/logout",
+        headers={"Host": "agents.lan", "X-Hermes-CSRF-Token": csrf},
+    ).status_code == 200
+
+
+def test_legacy_token_still_works_by_default(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    ws = importlib.reload(importlib.import_module("hermes_cli.web_server"))
+    _reset_state(ws)
+    client = TestClient(ws.app)
+    resp = client.get(
+        "/api/config",
+        headers={ws._SESSION_HEADER_NAME: ws._SESSION_TOKEN},
+    )
+    assert resp.status_code != 401
+
+
+def test_allowed_host_required_for_all_interface_public_bind():
+    ws = importlib.import_module("hermes_cli.web_server")
+    assert ws._is_accepted_host("agents.lan:9119", "0.0.0.0", {"agents.lan"})
+    assert not ws._is_accepted_host("evil.test:9119", "0.0.0.0", {"agents.lan"})
+
+
+def test_start_server_records_public_state(monkeypatch):
+    ws = importlib.import_module("hermes_cli.web_server")
+    _reset_state(ws)
+    called = {}
+
+    class FakeUvicorn:
+        @staticmethod
+        def run(app, **kwargs):
+            called.update(kwargs)
+
+    monkeypatch.setitem(importlib.import_module("sys").modules, "uvicorn", FakeUvicorn)
+    ws.start_server(
+        host="0.0.0.0",
+        port=9131,
+        open_browser=False,
+        public=True,
+        allowed_hosts=["agents.lan"],
+        secure_cookies=True,
+        trust_proxy_headers=True,
+    )
+    assert ws.app.state.public_mode is True
+    assert ws.app.state.legacy_token_auth_enabled is False
+    assert ws.app.state.allowed_hosts == {"agents.lan"}
+    assert ws.app.state.secure_cookies is True
+    assert called["host"] == "0.0.0.0"
+
+
+def test_cmd_dashboard_forwards_public_flags(monkeypatch):
+    import hermes_cli.main as main
+
+    captured = {}
+    fake_ws = type("FakeWS", (), {"start_server": staticmethod(lambda **kw: captured.update(kw))})
+    monkeypatch.setitem(importlib.import_module("sys").modules, "hermes_cli.web_server", fake_ws)
+    monkeypatch.setattr(main, "_build_web_ui", lambda *a, **kw: True)
+    args = argparse.Namespace(
+        host="0.0.0.0",
+        port=9131,
+        no_open=True,
+        insecure=False,
+        public=True,
+        allowed_host=["agents.lan"],
+        secure_cookies=True,
+        no_trust_proxy=False,
+        tui=False,
+        stop=False,
+        status=False,
+        skip_build=True,
+    )
+    main.cmd_dashboard(args)
+    assert captured["public"] is True
+    assert captured["allowed_hosts"] == ["agents.lan"]
+    assert captured["secure_cookies"] is True
+    assert captured["trust_proxy_headers"] is True

--- a/web/README.md
+++ b/web/README.md
@@ -30,6 +30,16 @@ npm run build
 
 This outputs to `../hermes_cli/web_dist/`, which the FastAPI server serves as a static SPA. The built assets are included in the Python package via `pyproject.toml` package-data.
 
+## Network access
+
+The dashboard is localhost-only by default. To expose it safely on a LAN or behind a reverse proxy, use public mode:
+
+```bash
+hermes dashboard --host 0.0.0.0 --public --allowed-host agents.example.lan --no-open
+```
+
+Public mode removes the token from the HTML bundle, enables cookie login + CSRF protection, and enforces an explicit Host allow-list. See `website/docs/guides/dashboard-network-access.md` for the full runbook.
+
 ## Structure
 
 ```

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -4,6 +4,7 @@ import {
   useMemo,
   useState,
   type ComponentType,
+  type FormEvent,
   type ReactNode,
 } from "react";
 import {
@@ -75,7 +76,7 @@ import { PluginPage, PluginSlot, usePlugins } from "@/plugins";
 import type { PluginManifest } from "@/plugins";
 import { useTheme } from "@/themes";
 import { isDashboardEmbeddedChatEnabled } from "@/lib/dashboard-flags";
-import { api } from "@/lib/api";
+import { api, setDashboardCsrfToken, type DashboardAuthStatus } from "@/lib/api";
 
 function RootRedirect() {
   return <Navigate to="/sessions" replace />;
@@ -305,6 +306,74 @@ function buildRoutes(
   return routes;
 }
 
+function DashboardAuthGate({
+  status,
+  onAuthenticated,
+}: {
+  status: DashboardAuthStatus;
+  onAuthenticated: (status: DashboardAuthStatus) => void;
+}) {
+  const [username, setUsername] = useState("admin");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+  const setup = status.needs_setup === true;
+
+  const submit = async (ev: FormEvent) => {
+    ev.preventDefault();
+    setBusy(true);
+    setError(null);
+    try {
+      const next = setup
+        ? await api.setupDashboardAdmin({ username, password })
+        : await api.loginDashboard({ username, password });
+      onAuthenticated(next);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="flex h-dvh items-center justify-center bg-black p-6 text-midground">
+      <form onSubmit={submit} className="w-full max-w-sm space-y-4 rounded border border-current/20 bg-background-base/90 p-6">
+        <div className="space-y-1">
+          <Typography variant="xl">{setup ? "Create dashboard admin" : "Dashboard login"}</Typography>
+          <p className="text-sm normal-case opacity-70">
+            {setup
+              ? "First public launch: create the local admin account."
+              : "Sign in to access this public Hermes dashboard."}
+          </p>
+        </div>
+        <label className="block space-y-1 text-sm">
+          <span>Username</span>
+          <input
+            className="w-full rounded border border-current/25 bg-black px-3 py-2 text-midground"
+            value={username}
+            onChange={(ev) => setUsername(ev.target.value)}
+            autoComplete="username"
+          />
+        </label>
+        <label className="block space-y-1 text-sm">
+          <span>Password</span>
+          <input
+            className="w-full rounded border border-current/25 bg-black px-3 py-2 text-midground"
+            type="password"
+            value={password}
+            onChange={(ev) => setPassword(ev.target.value)}
+            autoComplete={setup ? "new-password" : "current-password"}
+          />
+        </label>
+        {error ? <p className="text-sm normal-case text-red-400">{error}</p> : null}
+        <Button type="submit" disabled={busy || !username || !password} className="w-full">
+          {busy ? "Please wait…" : setup ? "Create admin" : "Login"}
+        </Button>
+      </form>
+    </div>
+  );
+}
+
 export default function App() {
   const { t } = useI18n();
   const { pathname } = useLocation();
@@ -316,6 +385,30 @@ export default function App() {
   const normalizedPath = pathname.replace(/\/$/, "") || "/";
   const isChatRoute = normalizedPath === "/chat";
   const embeddedChat = isDashboardEmbeddedChatEnabled();
+  const [authStatus, setAuthStatus] = useState<DashboardAuthStatus | null>(null);
+  const [authLoading, setAuthLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    api
+      .getAuthStatus()
+      .then((status) => {
+        if (cancelled) return;
+        setDashboardCsrfToken(status.csrf_token);
+        setAuthStatus(status);
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setAuthStatus({ enabled: false, authenticated: true });
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setAuthLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   // `dashboard.show_token_analytics` gates the Analytics nav item.  The
   // page itself remains reachable by URL (it renders an explanation when
@@ -323,6 +416,11 @@ export default function App() {
   // surfacing misleading token/cost numbers in the sidebar.  Default off.
   const [showTokenAnalytics, setShowTokenAnalytics] = useState(false);
   useEffect(() => {
+    if (authLoading) return;
+    if (authStatus?.enabled && !authStatus.authenticated) {
+      setShowTokenAnalytics(false);
+      return;
+    }
     api
       .getConfig()
       .then((cfg) => {
@@ -330,7 +428,7 @@ export default function App() {
         setShowTokenAnalytics(dash.show_token_analytics === true);
       })
       .catch(() => setShowTokenAnalytics(false));
-  }, []);
+  }, [authLoading, authStatus?.enabled, authStatus?.authenticated]);
 
   // A plugin can replace the built-in /chat page via `tab.override: "/chat"`
   // in its manifest.  When one does, `buildRoutes` already swaps the route
@@ -412,6 +510,26 @@ export default function App() {
     mql.addEventListener("change", onChange);
     return () => mql.removeEventListener("change", onChange);
   }, []);
+
+  if (authLoading) {
+    return (
+      <div className="flex h-dvh items-center justify-center bg-black text-midground">
+        <Spinner />
+      </div>
+    );
+  }
+
+  if (authStatus?.enabled && !authStatus.authenticated) {
+    return (
+      <DashboardAuthGate
+        status={authStatus}
+        onAuthenticated={(next) => {
+          setDashboardCsrfToken(next.csrf_token);
+          setAuthStatus({ ...next, authenticated: true });
+        }}
+      />
+    );
+  }
 
   return (
     <div

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -28,7 +28,13 @@ declare global {
   }
 }
 let _sessionToken: string | null = null;
+let _csrfToken: string | null = null;
 const SESSION_HEADER = "X-Hermes-Session-Token";
+const CSRF_HEADER = "X-Hermes-CSRF-Token";
+
+export function setDashboardCsrfToken(token: string | null | undefined): void {
+  _csrfToken = token || null;
+}
 
 function setSessionHeader(headers: Headers, token: string): void {
   if (!headers.has(SESSION_HEADER)) {
@@ -37,13 +43,19 @@ function setSessionHeader(headers: Headers, token: string): void {
 }
 
 export async function fetchJSON<T>(url: string, init?: RequestInit): Promise<T> {
-  // Inject the session token into all /api/ requests.
+  // Inject the legacy session token into all /api/ requests when the server
+  // provided one. Public mode intentionally omits it and relies on cookies.
   const headers = new Headers(init?.headers);
   const token = window.__HERMES_SESSION_TOKEN__;
   if (token) {
     setSessionHeader(headers, token);
+  } else if (_csrfToken && !headers.has(CSRF_HEADER)) {
+    const method = (init?.method ?? "GET").toUpperCase();
+    if (!["GET", "HEAD", "OPTIONS"].includes(method)) {
+      headers.set(CSRF_HEADER, _csrfToken);
+    }
   }
-  const res = await fetch(`${BASE}${url}`, { ...init, headers });
+  const res = await fetch(`${BASE}${url}`, { ...init, headers, credentials: "same-origin" });
   if (!res.ok) {
     const text = await res.text().catch(() => res.statusText);
     throw new Error(`${res.status}: ${text}`);
@@ -62,6 +74,30 @@ async function getSessionToken(): Promise<string> {
 }
 
 export const api = {
+  getAuthStatus: () => fetchJSON<DashboardAuthStatus>("/api/auth/status"),
+  setupDashboardAdmin: (body: DashboardAuthRequest) =>
+    fetchJSON<DashboardAuthStatus>("/api/auth/setup", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    }).then((res) => {
+      setDashboardCsrfToken(res.csrf_token);
+      return res;
+    }),
+  loginDashboard: (body: DashboardAuthRequest) =>
+    fetchJSON<DashboardAuthStatus>("/api/auth/login", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    }).then((res) => {
+      setDashboardCsrfToken(res.csrf_token);
+      return res;
+    }),
+  logoutDashboard: () =>
+    fetchJSON<{ ok: boolean }>("/api/auth/logout", { method: "POST" }).then((res) => {
+      setDashboardCsrfToken(null);
+      return res;
+    }),
   getStatus: () => fetchJSON<StatusResponse>("/api/status"),
   getSessions: (limit = 20, offset = 0) =>
     fetchJSON<PaginatedSessions>(`/api/sessions?limit=${limit}&offset=${offset}`),
@@ -362,6 +398,19 @@ export interface PlatformStatus {
   error_message?: string;
   state: string;
   updated_at: string;
+}
+
+export interface DashboardAuthRequest {
+  username: string;
+  password: string;
+}
+
+export interface DashboardAuthStatus {
+  enabled: boolean;
+  needs_setup?: boolean;
+  authenticated?: boolean;
+  csrf_token?: string | null;
+  user?: { username: string; role: string } | null;
 }
 
 export interface StatusResponse {

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -38,12 +38,13 @@ import { api } from "@/lib/api";
 import { PluginSlot } from "@/plugins";
 
 function buildWsUrl(
-  token: string,
+  token: string | undefined,
   resume: string | null,
   channel: string,
 ): string {
   const proto = window.location.protocol === "https:" ? "wss:" : "ws:";
-  const qs = new URLSearchParams({ token, channel });
+  const qs = new URLSearchParams({ channel });
+  if (token) qs.set("token", token);
   if (resume) qs.set("resume", resume);
   return `${proto}//${window.location.host}${HERMES_BASE_PATH}/api/pty?${qs.toString()}`;
 }
@@ -114,13 +115,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
   // collapses the host's box, so ResizeObserver never fires on return).
   const syncMetricsRef = useRef<(() => void) | null>(null);
   const [searchParams, setSearchParams] = useSearchParams();
-  // Lazy-init: the missing-token check happens at construction so the effect
-  // body doesn't have to setState (React 19's set-state-in-effect rule).
-  const [banner, setBanner] = useState<string | null>(() =>
-    typeof window !== "undefined" && !window.__HERMES_SESSION_TOKEN__
-      ? "Session token unavailable. Open this page through `hermes dashboard`, not directly."
-      : null,
-  );
+  const [banner, setBanner] = useState<string | null>(null);
   const [copyState, setCopyState] = useState<"idle" | "copied">("idle");
   const copyResetRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   // Raw state for the mobile side-sheet + a derived value that force-
@@ -270,10 +265,6 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
     if (!host) return;
 
     const token = window.__HERMES_SESSION_TOKEN__;
-    // Banner already initialised above; just bail before wiring xterm/WS.
-    if (!token) {
-      return;
-    }
 
     const tierW0 = terminalTierWidthPx(host);
     const term = new Terminal({
@@ -577,7 +568,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
         return;
       }
       if (ev.code === 4401) {
-        setBanner("Auth failed. Reload the page to refresh the session token.");
+        setBanner("Auth failed. Reload or sign in again to refresh the dashboard session.");
         return;
       }
       if (ev.code === 4403) {

--- a/website/docs/guides/dashboard-network-access.md
+++ b/website/docs/guides/dashboard-network-access.md
@@ -1,0 +1,90 @@
+# Expose the Hermes dashboard on your network
+
+The dashboard defaults to localhost because it can read and edit Hermes config, environment keys, sessions, cron jobs, profiles, and plugin state.
+
+Use public mode when you need LAN or reverse-proxy access:
+
+```bash
+hermes dashboard \
+  --host 0.0.0.0 \
+  --public \
+  --allowed-host agents.example.lan \
+  --no-open
+```
+
+Then browse to `http://agents.example.lan:9119`.
+
+## What public mode changes
+
+`--public` enables network-safe defaults:
+
+- does **not** inject the legacy ephemeral session token into the SPA HTML
+- requires a dashboard login backed by `$HERMES_HOME/dashboard-users.yaml`
+- creates the first local admin account on first launch
+- stores sessions in an HttpOnly, SameSite=Lax cookie
+- requires `X-Hermes-CSRF-Token` on cookie-authenticated mutating API calls
+- enforces an explicit Host allow-list for all-interface binds
+- adds baseline security headers: CSP, `X-Frame-Options`, `Referrer-Policy`, `X-Content-Type-Options`, and `Permissions-Policy`
+
+## Host allow-list
+
+When binding to `0.0.0.0` or `::`, public mode requires at least one host users will actually browse to:
+
+```bash
+hermes dashboard --host 0.0.0.0 --public \
+  --allowed-host agents.example.lan \
+  --allowed-host 192.168.1.50
+```
+
+Requests with any other `Host` header are rejected. This keeps DNS rebinding protections active even when the server listens on all interfaces.
+
+## HTTPS reverse proxy
+
+Recommended production shape:
+
+1. Keep Hermes bound to localhost or a private interface.
+2. Put Caddy, nginx, or another TLS reverse proxy in front.
+3. Pass the original `Host` header through.
+4. Use `--secure-cookies` when external access is HTTPS.
+
+Example:
+
+```bash
+hermes dashboard \
+  --host 127.0.0.1 \
+  --port 9119 \
+  --public \
+  --allowed-host agents.example.com \
+  --secure-cookies \
+  --no-open
+```
+
+Caddy example:
+
+```caddy
+agents.example.com {
+  reverse_proxy 127.0.0.1:9119
+}
+```
+
+If your proxy sends `X-Forwarded-Proto: https`, Hermes can also infer secure cookies. Use `--no-trust-proxy` to ignore proxy headers.
+
+## Legacy insecure mode
+
+`--insecure` still exists for backwards-compatible trusted-network debugging:
+
+```bash
+hermes dashboard --host 0.0.0.0 --insecure --no-open
+```
+
+Do not use it on untrusted networks. It keeps the legacy token-in-HTML behavior so older bundles continue to work, but anyone who can fetch the served page can obtain the token for that server process.
+
+## Resetting dashboard users
+
+Dashboard users are local to the active Hermes home/profile:
+
+```bash
+rm "$HERMES_HOME/dashboard-users.yaml"
+```
+
+Restart `hermes dashboard --public`; the first browser visit will show the setup form again.


### PR DESCRIPTION
## Summary
- Adds hardened public dashboard mode with cookie auth, CSRF protection, host allow-listing, and security headers.
- Updates the web UI to support setup/login/logout without exposing the legacy session token.
- Adds regression tests and network access runbook.

## Verification
- `python -m pytest tests/hermes_cli/test_production_exposure_hardening.py tests/hermes_cli/test_web_server_host_header.py tests/hermes_cli/test_dashboard_lifecycle_flags.py -q -o addopts=`
- `python -m pytest tests/hermes_cli/test_web_server.py tests/hermes_cli/test_web_server_cron_profiles.py tests/hermes_cli/test_production_exposure_hardening.py -q -o addopts=`
- `npm run build`
- Manual smoke: public setup/login, protected config auth, CSRF-enforced logout, no legacy SPA token injection

Note: a full `python -m pytest tests/ -q -o addopts=` run was attempted locally but the existing full-suite run exhausted macOS file descriptors (`OSError: [Errno 24] Too many open files`) outside this change scope.
