### PR TITLE
docs: replace invalid 'hermes config get <key>' with 'hermes config show'

### DIFF
--- a/website/docs/guides/migrate-from-openclaw.md
+++ b/website/docs/guides/migrate-from-openclaw.md
@@ -225,7 +225,7 @@ The migration resolves all three formats. For env templates and SecretRef object
 
 5. **Test messaging** — if you migrated platform tokens, restart the gateway: `systemctl --user restart hermes-gateway`
 
-6. **Check session policies** — verify `hermes config get session_reset` matches your expectations.
+6. **Check session policies** — run `hermes config show` and verify the `session_reset` value matches your expectations.
 
 7. **Re-pair WhatsApp** — WhatsApp uses QR code pairing (Baileys), not token migration. Run `hermes whatsapp` to pair.
 

--- a/website/docs/guides/work-with-skills.md
+++ b/website/docs/guides/work-with-skills.md
@@ -162,7 +162,7 @@ Manage skill config from the CLI:
 hermes skills config gif-search
 
 # View all skill config
-hermes config get skills.config
+hermes config show
 ```
 
 ---

--- a/website/docs/user-guide/configuring-models.md
+++ b/website/docs/user-guide/configuring-models.md
@@ -192,7 +192,7 @@ hermes model            # Interactive provider + model picker (the canonical way
 
 `hermes model` walks you through picking a provider, authenticating (OAuth flows open a browser; API-key providers prompt for the key), and then choosing a specific model from that provider's curated catalog. The choice is written to `model.provider` and `model.model` in `~/.hermes/config.yaml`.
 
-To list providers/models without launching the picker, use the dashboard or the REST endpoints below. To inspect what the CLI will actually use right now: `hermes config get model` and `hermes status`.
+To list providers/models without launching the picker, use the dashboard or the REST endpoints below. To inspect what the CLI will actually use right now: run `hermes config show` and look for the `model` key, or use `hermes status`.
 
 ### Direct config edit
 


### PR DESCRIPTION
## What

`hermes config get <key>` is referenced in three doc files but does not exist as a valid CLI subcommand (only `show`/`edit`/`set`/`path`/`env-path`/`check`/`migrate` are valid). Fixes:

- `website/docs/guides/work-with-skills.md:165` - View all skill config: replaced with `hermes config show`
- `website/docs/guides/migrate-from-openclaw.md:228` - Session policy check: replaced with `hermes config show` + look for the key
- `website/docs/user-guide/configuring-models.md:195` - Inspect model config: replaced with `hermes config show` + look for the key

## Why

Surfaced in user error logs -- 27 hits in one week of `unrecognized arguments` from users following the docs verbatim.

Closes #30195