### PR TITLE
fix(tui): propagate verbose flag from thinking.delta to recordReasoningDelta

### DIFF
--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1774,7 +1774,11 @@ def _agent_cbs(sid: str) -> dict:
         ),
         "tool_gen_callback": lambda name: _tool_progress_enabled(sid)
         and _emit("tool.generating", sid, {"name": name}),
-        "thinking_callback": lambda text: _emit("thinking.delta", sid, {"text": text}),
+        "thinking_callback": lambda text: _emit(
+            "thinking.delta",
+            sid,
+            {"text": text, **({"verbose": True} if _session_verbose(sid) else {})},
+        ),
         "reasoning_callback": lambda text: _emit(
             "reasoning.delta",
             sid,

--- a/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
+++ b/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
@@ -361,6 +361,25 @@ describe('createGatewayEventHandler', () => {
     }
   })
 
+  it('shows verbose thinking.delta even when normal reasoning display is off', () => {
+    vi.useFakeTimers()
+    patchUiState({ showReasoning: false })
+    const appended: Msg[] = []
+    const streamed = 'verbose-only thinking'
+
+    try {
+      const onEvent = createGatewayEventHandler(buildCtx(appended))
+
+      onEvent({ payload: { text: streamed, verbose: true }, type: 'thinking.delta' } as any)
+      vi.runOnlyPendingTimers()
+
+      expect(turnController.reasoningText).toBe(streamed)
+      expect(getTurnState().reasoning).toBe(streamed)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('ignores fallback reasoning.available when streamed reasoning already exists', () => {
     const appended: Msg[] = []
     const streamed = 'short streamed reasoning'

--- a/ui-tui/src/app/createGatewayEventHandler.ts
+++ b/ui-tui/src/app/createGatewayEventHandler.ts
@@ -320,7 +320,7 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
           scheduleThinkingStatus(value || statusFromBusy())
 
           if (value) {
-            turnController.recordReasoningDelta(value)
+            turnController.recordReasoningDelta(value, Boolean(ev.payload?.verbose))
           }
         }
 


### PR DESCRIPTION
## Problem

`thinking_callback` in `tui_gateway/server.py` emits `thinking.delta` without a `verbose` field, while the sibling `reasoning_callback` (added in #30225) already sets `verbose: True` when the session is in verbose mode (`/verbose verbose`).

On the client side, the `thinking.delta` case in `createGatewayEventHandler.ts` calls `recordReasoningDelta(value)` without the force flag, while `reasoning.delta` correctly passes `Boolean(ev.payload.verbose)`:

```typescript
// thinking.delta — BEFORE (force always false)
turnController.recordReasoningDelta(value)

// reasoning.delta — correct
turnController.recordReasoningDelta(ev.payload.text, Boolean(ev.payload.verbose))
```

`recordReasoningDelta` bails early when `force=false` and `showReasoning=false`:

```typescript
recordReasoningDelta(text: string, force = false) {
  if (this.interrupted || (!force && !getUiState().showReasoning)) {
    return   // ← thinking blocks silently dropped
  }
  ...
}
```

Result: in `/verbose verbose` mode, extended-thinking blocks from the model are silently dropped when the user has reasoning display off (the default), even though the user explicitly enabled verbose output to see them. The `reasoning.delta` path works correctly for the same scenario.

## Fix

**Server** (`tui_gateway/server.py`): mirror `reasoning_callback` in `thinking_callback` — emit `verbose: True` under `_session_verbose()`.

**Client** (`createGatewayEventHandler.ts`): read `ev.payload?.verbose` in the `thinking.delta` case and pass it as the force flag to `recordReasoningDelta`.

## Tests

Added `"shows verbose thinking.delta even when normal reasoning display is off"` — symmetric with the existing `"shows verbose reasoning even when normal reasoning display is off"` test from #30225.

```
✓ shows verbose thinking.delta even when normal reasoning display is off
```

43/43 tests pass in `createGatewayEventHandler.test.ts`.

## Checklist

- [x] Parity fix: symmetric with `reasoning_callback` / `reasoning.delta` (already correct since #30225)
- [x] No behavior change when `_session_verbose()` is false — `verbose` field is omitted, `force` stays `false`
- [x] `ruff check tui_gateway/server.py` passes
- [x] 43/43 TS tests pass