### PR TITLE
fix(terminal): require non-empty DAYTONA_API_KEY for daytona backend requirements

### DIFF
--- a/tests/tools/test_terminal_requirements.py
+++ b/tests/tools/test_terminal_requirements.py
@@ -1,5 +1,7 @@
 import importlib
 import logging
+import sys
+import types
 
 import pytest
 
@@ -22,6 +24,7 @@ def _clear_terminal_env(monkeypatch):
         "TERMINAL_SSH_USER",
         "TERMINAL_TIMEOUT",
         "TERMINAL_VERCEL_RUNTIME",
+        "DAYTONA_API_KEY",
         "MODAL_TOKEN_ID",
         "MODAL_TOKEN_SECRET",
         "VERCEL_OIDC_TOKEN",
@@ -314,3 +317,27 @@ def test_vercel_backend_rejects_malformed_disk_without_raising(monkeypatch, capl
         "Invalid value for TERMINAL_CONTAINER_DISK" in record.getMessage()
         for record in caplog.records
     )
+
+
+@pytest.mark.parametrize(
+    ("api_key", "expected"),
+    [
+        (None, False),
+        ("", False),
+        ("   ", False),
+        ("token", True),
+    ],
+)
+def test_daytona_backend_requires_non_empty_api_key(monkeypatch, api_key, expected):
+    _clear_terminal_env(monkeypatch)
+    monkeypatch.setenv("TERMINAL_ENV", "daytona")
+    fake_daytona = types.ModuleType("daytona")
+    fake_daytona.Daytona = object
+    monkeypatch.setitem(sys.modules, "daytona", fake_daytona)
+
+    if api_key is None:
+        monkeypatch.delenv("DAYTONA_API_KEY", raising=False)
+    else:
+        monkeypatch.setenv("DAYTONA_API_KEY", api_key)
+
+    assert terminal_tool_module.check_terminal_requirements() is expected

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -2244,7 +2244,7 @@ def check_terminal_requirements() -> bool:
 
         elif env_type == "daytona":
             from daytona import Daytona  # noqa: F401 — SDK presence check
-            return os.getenv("DAYTONA_API_KEY") is not None
+            return bool((os.getenv("DAYTONA_API_KEY") or "").strip())
 
         else:
             logger.error(


### PR DESCRIPTION
## What does this PR do?

Fixes Daytona terminal backend requirements validation.

`check_terminal_requirements()` previously treated an empty `DAYTONA_API_KEY` as valid because it only checked `is not None`.  
This PR now requires a non-empty, non-whitespace key and adds regression tests.

## Related Issue

Fixes #<issue-number>

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- Updated Daytona API key check in `tools/terminal_tool.py` to:
  - reject unset / empty / whitespace-only values
  - accept non-empty values
- Added regression coverage in `tests/tools/test_terminal_requirements.py`:
  - `None` -> `False`
  - `""` -> `False`
  - `"   "` -> `False`
  - `"token"` -> `True`

## How to Test

1. Run:
   - `pytest tests/tools/test_terminal_requirements.py -q --timeout-method=thread`
2. Verify all tests pass.
3. (Optional manual repro) set `TERMINAL_ENV=daytona` and check behavior with empty vs non-empty `DAYTONA_API_KEY`.

## Screenshots / Logs

- Test result:
  - `24 passed in 0.53s`