### PR TITLE
fix: harden gateway update handling

### DIFF
--- a/agent/lsp/manager.py
+++ b/agent/lsp/manager.py
@@ -210,6 +210,7 @@ class LSPService:
         wait_mode = lsp_cfg.get("wait_mode", "document")
         wait_timeout = float(lsp_cfg.get("wait_timeout", DIAGNOSTICS_DOCUMENT_WAIT))
         install_strategy = lsp_cfg.get("install_strategy", "auto")
+        idle_timeout = float(lsp_cfg.get("idle_timeout", DEFAULT_IDLE_TIMEOUT))
         servers_cfg = lsp_cfg.get("servers") or {}
         disabled = []
         binary_overrides: Dict[str, List[str]] = {}
@@ -240,6 +241,7 @@ class LSPService:
             env_overrides=env_overrides,
             init_overrides=init_overrides,
             disabled_servers=disabled,
+            idle_timeout=idle_timeout,
         )
 
     # ------------------------------------------------------------------
@@ -249,6 +251,40 @@ class LSPService:
     def is_active(self) -> bool:
         """Return True iff this service should be consulted at all."""
         return self._enabled
+
+    def reap_idle_clients(self, *, now: Optional[float] = None) -> int:
+        """Shutdown language-server clients idle beyond ``idle_timeout``.
+
+        Long-running Hermes gateway/TUI processes can touch many git
+        workspaces over days.  Without an explicit idle sweep, each touched
+        TypeScript/Python/etc. workspace keeps its language-server subprocess
+        and file descriptors open until process exit.  On macOS that slowly
+        walks the gateway toward EMFILE / "too many open files".
+        """
+        if not self._enabled:
+            return 0
+        ts = time.time() if now is None else now
+        idle_keys: List[Tuple[str, str]] = []
+        with self._state_lock:
+            for key, client in list(self._clients.items()):
+                last_used = self._last_used.get(key, 0)
+                if ts - last_used > self._idle_timeout:
+                    idle_keys.append(key)
+            clients = [self._clients.pop(key) for key in idle_keys if key in self._clients]
+            for key in idle_keys:
+                self._last_used.pop(key, None)
+        for client in clients:
+            try:
+                self._loop.run(client.shutdown(), timeout=2.0)
+            except Exception:
+                # Unit tests and shutdown paths may have already stopped the
+                # background loop.  Fall back to a one-off loop so the client
+                # still gets a chance to close stdio pipes and child processes.
+                try:
+                    asyncio.run(client.shutdown())
+                except Exception as e:  # noqa: BLE001
+                    logger.debug("idle LSP client shutdown error: %s", e)
+        return len(clients)
 
     def enabled_for(self, file_path: str) -> bool:
         """Return True iff LSP should run for this specific file.
@@ -386,6 +422,10 @@ class LSPService:
             eventlog.log_diagnostics(server_id, file_path, len(diags))
         else:
             eventlog.log_clean(server_id, file_path)
+        try:
+            self.reap_idle_clients()
+        except Exception as e:  # noqa: BLE001
+            logger.debug("idle LSP reap failed: %s", e)
         return diags
 
     def _mark_broken_for_file(self, file_path: str, exc: BaseException) -> None:

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -15,6 +15,7 @@ import os
 import tempfile
 import html as _html
 import re
+from collections import OrderedDict
 from datetime import datetime, timezone
 from typing import Dict, List, Optional, Any
 
@@ -425,6 +426,16 @@ class TelegramAdapter(BasePlatformAdapter):
         )
         self._pending_text_batches: Dict[str, MessageEvent] = {}
         self._pending_text_batch_tasks: Dict[str, asyncio.Task] = {}
+        # PTB normally advances offsets for us, but webhook retries, shutdown
+        # ACK failures, or direct process_update tests can replay the same
+        # update object. Keep a small in-memory LRU so duplicated Telegram
+        # updates do not spawn duplicate agent turns or duplicate button actions.
+        self._seen_update_ids: "OrderedDict[int, None]" = OrderedDict()
+        try:
+            seen_limit = int(os.getenv("HERMES_TELEGRAM_SEEN_UPDATE_ID_LIMIT", "2048") or "2048")
+        except (TypeError, ValueError):
+            seen_limit = 2048
+        self._seen_update_id_limit = max(100, seen_limit)
         self._polling_error_task: Optional[asyncio.Task] = None
         self._polling_conflict_count: int = 0
         self._polling_network_error_count: int = 0
@@ -1445,6 +1456,10 @@ class TelegramAdapter(BasePlatformAdapter):
             self._app.add_handler(TelegramMessageHandler(
                 filters.PHOTO | filters.VIDEO | filters.AUDIO | filters.VOICE | filters.Document.ALL | filters.Sticker.ALL,
                 self._handle_media_message
+            ))
+            self._app.add_handler(TelegramMessageHandler(
+                filters.ALL,
+                self._handle_unsupported_message
             ))
             # Handle inline keyboard button callbacks (update prompts)
             self._app.add_handler(CallbackQueryHandler(self._handle_callback_query))
@@ -2897,6 +2912,8 @@ class TelegramAdapter(BasePlatformAdapter):
         self, update: "Update", context: "ContextTypes.DEFAULT_TYPE"
     ) -> None:
         """Handle inline keyboard button clicks."""
+        if not self._claim_update_for_processing(update, "callback_query"):
+            return
         query = update.callback_query
         if not query or not query.data:
             return
@@ -4742,6 +4759,68 @@ class TelegramAdapter(BasePlatformAdapter):
         """
         return getattr(update, "effective_message", None) or getattr(update, "message", None)
 
+    def _claim_update_for_processing(self, update: Any, handler_name: str) -> bool:
+        """Return True exactly once for each well-formed Telegram update id.
+
+        Telegram's update_id is the only stable id that covers text, media,
+        commands, callback queries, and webhook/polling delivery. Dedupe at the
+        adapter edge so retry/replay scenarios cannot produce duplicate agent
+        turns, duplicate sends, or repeated approval-button actions.
+        """
+        if update is None:
+            logger.warning("[Telegram] Ignoring malformed update in %s: update is None", handler_name)
+            return False
+
+        raw_update_id = getattr(update, "update_id", None)
+        if raw_update_id is None:
+            # Real python-telegram-bot Update objects always have update_id,
+            # but many focused unit tests pass tiny SimpleNamespace stand-ins.
+            # Process without dedupe rather than breaking those call sites; the
+            # concrete handler still validates whether a message/callback exists.
+            logger.warning(
+                "[Telegram] Processing update without update_id in %s; dedupe unavailable",
+                handler_name,
+            )
+            return True
+
+        if not isinstance(raw_update_id, (int, str)):
+            # MagicMock stand-ins manufacture attributes on demand, including
+            # update_id. Treat non-scalar ids as absent rather than converting
+            # every mock to int(1) and accidentally deduping unrelated updates.
+            logger.warning(
+                "[Telegram] Processing update with non-scalar update_id in %s; dedupe unavailable: %r",
+                handler_name,
+                raw_update_id,
+            )
+            return True
+
+        try:
+            update_id = int(raw_update_id)
+        except (TypeError, ValueError):
+            logger.warning(
+                "[Telegram] Ignoring malformed update in %s: invalid update_id=%r",
+                handler_name,
+                raw_update_id,
+            )
+            return False
+
+        seen = getattr(self, "_seen_update_ids", None)
+        if seen is None:
+            seen = OrderedDict()
+            self._seen_update_ids = seen
+
+        if update_id in seen:
+            # Refresh recency so high-volume chats keep the active duplicate key.
+            seen.move_to_end(update_id)
+            logger.info("[Telegram] Ignoring duplicate update_id=%s in %s", update_id, handler_name)
+            return False
+
+        seen[update_id] = None
+        limit = getattr(self, "_seen_update_id_limit", 2048) or 2048
+        while len(seen) > max(100, int(limit)):
+            seen.popitem(last=False)
+        return True
+
     async def _handle_text_message(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         """Handle incoming text messages.
 
@@ -4749,6 +4828,8 @@ class TelegramAdapter(BasePlatformAdapter):
         rapid successive text messages from the same user/chat and aggregate
         them into a single MessageEvent before dispatching.
         """
+        if not self._claim_update_for_processing(update, "text"):
+            return
         msg = self._effective_update_message(update)
         if not msg or not msg.text:
             return
@@ -4756,7 +4837,7 @@ class TelegramAdapter(BasePlatformAdapter):
             if self._should_observe_unmentioned_group_message(msg):
                 self._observe_unmentioned_group_message(msg, MessageType.TEXT, update_id=update.update_id)
             return
-        await self._ensure_forum_commands(update.message)
+        await self._ensure_forum_commands(msg)
 
         event = self._build_message_event(msg, MessageType.TEXT, update_id=update.update_id)
         event.text = self._clean_bot_trigger_text(event.text)
@@ -4765,6 +4846,8 @@ class TelegramAdapter(BasePlatformAdapter):
 
     async def _handle_command(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         """Handle incoming command messages."""
+        if not self._claim_update_for_processing(update, "command"):
+            return
         msg = self._effective_update_message(update)
         if not msg or not msg.text:
             return
@@ -4779,6 +4862,8 @@ class TelegramAdapter(BasePlatformAdapter):
 
     async def _handle_location_message(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         """Handle incoming location/venue pin messages."""
+        if not self._claim_update_for_processing(update, "location"):
+            return
         msg = self._effective_update_message(update)
         if not msg:
             return
@@ -4816,6 +4901,72 @@ class TelegramAdapter(BasePlatformAdapter):
         event.text = "\n".join(parts)
         event = self._apply_telegram_group_observe_attribution(event)
         await self.handle_message(event)
+
+    def _unsupported_message_label(self, message: Any) -> Optional[str]:
+        """Return a concise label for Telegram payloads we intentionally skip."""
+        payload_attrs = (
+            ("contact", "contact card"),
+            ("poll", "poll"),
+            ("dice", "dice roll"),
+            ("game", "game"),
+            ("animation", "animation"),
+            ("video_note", "video note"),
+            ("invoice", "invoice"),
+            ("successful_payment", "payment receipt"),
+            ("passport_data", "passport data"),
+        )
+        for attr, label in payload_attrs:
+            if getattr(message, attr, None):
+                return label
+        return None
+
+    async def _handle_unsupported_message(self, update: "Update", context: "ContextTypes.DEFAULT_TYPE") -> None:
+        """Handle unsupported but delivered Telegram message payloads gracefully."""
+        if not self._claim_update_for_processing(update, "unsupported"):
+            return
+
+        msg = getattr(update, "message", None) or getattr(update, "effective_message", None)
+        if not msg:
+            logger.warning(
+                "[Telegram] Ignoring malformed update without message: update_id=%s",
+                getattr(update, "update_id", None),
+            )
+            return
+        if not self._should_process_message(msg):
+            return
+
+        label = self._unsupported_message_label(msg)
+        if not label:
+            # Status/service messages (chat member changes, topic edits, pins,
+            # etc.) should not produce noisy bot replies.
+            logger.info(
+                "[Telegram] Ignoring unsupported service update: update_id=%s message_id=%s",
+                getattr(update, "update_id", None),
+                getattr(msg, "message_id", None),
+            )
+            return
+
+        chat = getattr(msg, "chat", None)
+        chat_id = getattr(msg, "chat_id", None) or getattr(chat, "id", None)
+        thread_id = getattr(msg, "message_thread_id", None)
+        logger.info(
+            "[Telegram] Unsupported message type %s in chat %s (message_id=%s)",
+            label,
+            chat_id,
+            getattr(msg, "message_id", None),
+        )
+        if chat_id is None:
+            return
+
+        metadata: Dict[str, Any] = {"notify": True}
+        if thread_id is not None:
+            metadata["thread_id"] = str(thread_id)
+        await self.send(
+            str(chat_id),
+            f"I can't process that Telegram {label} yet. Please send text, a supported file, an image, audio, video, voice, sticker, location, or venue.",
+            reply_to=str(getattr(msg, "message_id", "")) if getattr(msg, "message_id", None) is not None else None,
+            metadata=metadata,
+        )
 
     # ------------------------------------------------------------------
     # Text message aggregation (handles Telegram client-side splits)
@@ -4956,6 +5107,8 @@ class TelegramAdapter(BasePlatformAdapter):
 
     async def _handle_media_message(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         """Handle incoming media messages, downloading images to local cache."""
+        if not self._claim_update_for_processing(update, "media"):
+            return
         if not update.message:
             return
         if not self._should_process_message(update.message):
@@ -5446,11 +5599,11 @@ class TelegramAdapter(BasePlatformAdapter):
         # Determine chat type.  Normalize through ``str`` so tests/mocks and
         # python-telegram-bot enum values both work (``ChatType.CHANNEL`` is
         # string-like, but mocks often provide plain strings).
-        telegram_chat_type = str(getattr(chat, "type", "")).split(".")[-1].lower()
+        telegram_chat_type = str(getattr(chat, "type", "")).split(".")[-1].strip("<>'\"").lower()
         chat_type = "dm"
-        if telegram_chat_type in {"group", "supergroup"}:
+        if telegram_chat_type in {"group", "supergroup"} or "supergroup" in telegram_chat_type:
             chat_type = "group"
-        elif telegram_chat_type == "channel":
+        elif telegram_chat_type == "channel" or "channel" in telegram_chat_type:
             chat_type = "channel"
 
         # Resolve Telegram topic name and skill binding.

--- a/tests/agent/test_lsp_idle_reap.py
+++ b/tests/agent/test_lsp_idle_reap.py
@@ -1,0 +1,39 @@
+import time
+
+from agent.lsp.manager import LSPService
+
+
+class DummyClient:
+    def __init__(self):
+        self.shutdown_calls = 0
+
+    async def shutdown(self):
+        self.shutdown_calls += 1
+
+
+def test_reap_idle_clients_shuts_down_only_clients_past_idle_timeout():
+    service = LSPService(
+        enabled=True,
+        wait_mode="document",
+        wait_timeout=0.1,
+        install_strategy="never",
+        idle_timeout=10,
+    )
+    service._loop.stop()
+
+    old_client = DummyClient()
+    fresh_client = DummyClient()
+    old_key = ("typescript", "/tmp/old")
+    fresh_key = ("typescript", "/tmp/fresh")
+    now = time.time()
+
+    service._clients = {old_key: old_client, fresh_key: fresh_client}
+    service._last_used = {old_key: now - 30, fresh_key: now}
+
+    reaped = service.reap_idle_clients(now=now)
+
+    assert reaped == 1
+    assert old_client.shutdown_calls == 1
+    assert fresh_client.shutdown_calls == 0
+    assert old_key not in service._clients
+    assert fresh_key in service._clients

--- a/tests/gateway/test_telegram_update_admission.py
+++ b/tests/gateway/test_telegram_update_admission.py
@@ -1,0 +1,211 @@
+import logging
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from gateway.config import PlatformConfig
+from gateway.platforms.base import MessageType
+from gateway.platforms.telegram import ChatType, TelegramAdapter
+
+
+def _make_adapter() -> TelegramAdapter:
+    adapter = TelegramAdapter(PlatformConfig(enabled=True, token="fake-token", extra={}))
+    adapter._bot = SimpleNamespace(id=999, username="hermes_bot")
+    return adapter
+
+
+def _dm_message(**overrides):
+    msg = SimpleNamespace(
+        text="hello",
+        caption=None,
+        entities=[],
+        caption_entities=[],
+        message_id=42,
+        message_thread_id=None,
+        is_topic_message=False,
+        chat_id=123,
+        chat=SimpleNamespace(id=123, type=ChatType.PRIVATE, title=None, full_name="User"),
+        from_user=SimpleNamespace(id=123, full_name="User"),
+        reply_to_message=None,
+        quote=None,
+        date=None,
+    )
+    for key, value in overrides.items():
+        setattr(msg, key, value)
+    return msg
+
+
+def test_claim_update_rejects_duplicate_and_malformed_updates(caplog):
+    caplog.set_level(logging.INFO)
+    adapter = _make_adapter()
+
+    assert adapter._claim_update_for_processing(SimpleNamespace(update_id=100), "text") is True
+    assert adapter._claim_update_for_processing(SimpleNamespace(update_id=100), "text") is False
+    assert adapter._claim_update_for_processing(SimpleNamespace(update_id=None), "text") is True
+    assert adapter._claim_update_for_processing(SimpleNamespace(update_id="not-int"), "text") is False
+
+    log_text = "\n".join(record.getMessage() for record in caplog.records)
+    assert "duplicate update_id=100" in log_text
+    assert "dedupe unavailable" in log_text
+    assert "invalid update_id" in log_text
+
+
+@pytest.mark.asyncio
+async def test_text_handler_dedupes_before_enqueueing_agent_turn(monkeypatch):
+    adapter = _make_adapter()
+    enqueued = []
+
+    monkeypatch.setattr(adapter, "_should_process_message", lambda message, is_command=False: True)
+    monkeypatch.setattr(
+        adapter,
+        "_build_message_event",
+        lambda message, msg_type, update_id=None: SimpleNamespace(text=message.text),
+    )
+    monkeypatch.setattr(adapter, "_clean_bot_trigger_text", lambda text: text)
+    monkeypatch.setattr(adapter, "_enqueue_text_event", lambda event: enqueued.append(event.text))
+
+    update = SimpleNamespace(update_id=200, message=_dm_message(text="hello"))
+
+    await adapter._handle_text_message(update, SimpleNamespace())
+    await adapter._handle_text_message(update, SimpleNamespace())
+
+    assert enqueued == ["hello"]
+
+
+def test_build_message_event_parses_group_topic_reply_and_update_id():
+    adapter = TelegramAdapter(
+        PlatformConfig(
+            enabled=True,
+            token="fake-token",
+            extra={
+                "group_topics": [
+                    {
+                        "chat_id": "-100123",
+                        "topics": [
+                            {"thread_id": "7", "name": "Ops", "skill": "ops-runbook"}
+                        ],
+                    }
+                ]
+            },
+        )
+    )
+    message = SimpleNamespace(
+        text="status?",
+        caption=None,
+        message_id=55,
+        message_thread_id=7,
+        is_topic_message=True,
+        chat_id=-100123,
+        chat=SimpleNamespace(
+            id=-100123,
+            type=ChatType.SUPERGROUP,
+            title="Ops Group",
+            full_name=None,
+            is_forum=True,
+        ),
+        from_user=SimpleNamespace(id=321, full_name="Operator"),
+        reply_to_message=SimpleNamespace(message_id=54, text="full prior message", caption=None),
+        quote=SimpleNamespace(text="selected quote"),
+        date=None,
+    )
+
+    event = adapter._build_message_event(message, MessageType.TEXT, update_id=202)
+
+    assert event.text == "status?"
+    assert event.message_id == "55"
+    assert event.platform_update_id == 202
+    assert event.reply_to_message_id == "54"
+    assert event.reply_to_text == "selected quote"
+    assert event.source.chat_id == "-100123"
+    assert event.source.chat_type == "group"
+    assert event.source.thread_id == "7"
+    assert event.source.chat_topic == "Ops"
+    assert event.auto_skill == "ops-runbook"
+
+
+@pytest.mark.asyncio
+async def test_command_handler_routes_normalized_event_to_hermes_agent(monkeypatch):
+    adapter = _make_adapter()
+    adapter.handle_message = AsyncMock()
+    monkeypatch.setattr(adapter, "_should_process_message", lambda message, is_command=False: is_command)
+
+    update = SimpleNamespace(update_id=201, message=_dm_message(text="/help"))
+
+    await adapter._handle_command(update, SimpleNamespace())
+
+    adapter.handle_message.assert_awaited_once()
+    handle_call = adapter.handle_message.await_args
+    assert handle_call is not None
+    event = handle_call.args[0]
+    assert event.text == "/help"
+    assert event.message_type is MessageType.COMMAND
+    assert event.platform_update_id == 201
+    assert event.source.chat_id == "123"
+
+
+@pytest.mark.asyncio
+async def test_unsupported_user_payload_gets_clear_user_facing_reply(monkeypatch):
+    adapter = _make_adapter()
+    adapter.send = AsyncMock()
+    monkeypatch.setattr(adapter, "_should_process_message", lambda message, is_command=False: True)
+
+    update = SimpleNamespace(
+        update_id=300,
+        message=_dm_message(text=None, contact=SimpleNamespace(phone_number="example-phone")),
+    )
+
+    await adapter._handle_unsupported_message(update, SimpleNamespace())
+
+    adapter.send.assert_awaited_once()
+    send_call = adapter.send.await_args
+    assert send_call is not None
+    chat_id, content = send_call.args[:2]
+    assert chat_id == "123"
+    assert "contact card" in content
+    assert "can't process" in content
+    assert send_call.kwargs["reply_to"] == "42"
+
+
+@pytest.mark.asyncio
+async def test_unsupported_service_payload_is_logged_not_sent(monkeypatch):
+    adapter = _make_adapter()
+    adapter.send = AsyncMock()
+    monkeypatch.setattr(adapter, "_should_process_message", lambda message, is_command=False: True)
+
+    update = SimpleNamespace(
+        update_id=301,
+        message=_dm_message(text=None, new_chat_members=[SimpleNamespace(id=999)]),
+    )
+
+    await adapter._handle_unsupported_message(update, SimpleNamespace())
+
+    adapter.send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_send_formats_markdown_and_falls_back_to_plain_text(monkeypatch):
+    adapter = _make_adapter()
+    calls = []
+
+    class FakeBot:
+        async def send_message(self, **kwargs):
+            calls.append(kwargs)
+            if kwargs.get("parse_mode") is not None:
+                raise Exception("can't parse MarkdownV2")
+            return SimpleNamespace(message_id=777)
+
+    adapter._bot = FakeBot()
+    monkeypatch.setattr(adapter, "send_typing", AsyncMock())
+
+    result = await adapter.send("123", "**done** (ok)", reply_to="42")
+
+    assert result.success is True
+    assert result.message_id == "777"
+    assert len(calls) == 2
+    assert calls[0]["parse_mode"] is not None
+    assert calls[0]["text"] == "*done* \\(ok\\)"
+    assert calls[0]["reply_to_message_id"] == 42
+    assert calls[1]["parse_mode"] is None
+    assert calls[1]["text"] == "done (ok)"
+    assert calls[1]["reply_to_message_id"] == 42

--- a/website/docs/user-guide/messaging/telegram.md
+++ b/website/docs/user-guide/messaging/telegram.md
@@ -138,6 +138,91 @@ hermes gateway
 
 The bot should come online within seconds. Send it a message on Telegram to verify.
 
+## Operational Runbook
+
+Use this runbook when validating a new Telegram bot, deploying a config change, or recovering from an incident.
+
+### Local validation
+
+1. Install the Telegram dependency set and run the focused gateway tests:
+
+```bash
+python -m pytest tests/gateway/test_telegram_*.py -q
+```
+
+2. Start the gateway in the foreground so logs stay visible:
+
+```bash
+hermes gateway run
+```
+
+3. In Telegram, send the bot a direct text message. Expected result: the gateway logs an inbound Telegram update, routes it into a Hermes session, and sends one formatted reply back to the same chat.
+4. Validate key edge cases before handing the bot to users:
+   - Send `/help` or another slash command and confirm it routes as a command.
+   - Reply to a bot message and confirm Hermes receives the reply context.
+   - Send an unsupported payload such as a contact card and confirm the bot replies with a clear "can't process" message instead of crashing.
+   - Re-send or replay a captured update in tests and confirm duplicate `update_id` values are ignored.
+
+### Deployment configuration
+
+Required values:
+
+```bash
+TELEGRAM_BOT_TOKEN=<bot-token-from-botfather>
+TELEGRAM_ALLOWED_USERS=<comma-separated-telegram-user-ids>
+```
+
+Optional values:
+
+```bash
+TELEGRAM_WEBHOOK_URL=https://<public-host>/<telegram-path>
+TELEGRAM_WEBHOOK_SECRET=<random-webhook-secret>
+TELEGRAM_WEBHOOK_PORT=8443
+TELEGRAM_PROXY=socks5://127.0.0.1:1080
+```
+
+Store secrets in `~/.hermes/.env` for local installs or in the platform secret manager for cloud deploys. Do not put bot tokens in `config.yaml`, docs, issue comments, or logs.
+
+### Startup mode
+
+- Polling mode is the default. Use it for local machines and always-on hosts: leave `TELEGRAM_WEBHOOK_URL` unset, then run `hermes gateway run` or manage the service with `hermes gateway start` / `hermes gateway restart`.
+- Webhook mode is for public HTTPS deployments. Set `TELEGRAM_WEBHOOK_URL` and `TELEGRAM_WEBHOOK_SECRET`, expose `TELEGRAM_WEBHOOK_PORT`, then restart the gateway. The gateway log should report that Telegram connected in webhook mode.
+- Use only one active receiver per bot token. If another gateway, old OpenClaw process, or staging deployment is polling the same bot token, Telegram updates will conflict or disappear from the expected environment.
+
+### Verification after deploy
+
+1. Check service health:
+
+```bash
+hermes gateway status
+```
+
+2. Inspect recent gateway errors:
+
+```bash
+grep -i "telegram\|error\|conflict\|failed" ~/.hermes/logs/gateway.log | tail -50
+```
+
+3. Send a direct message from an allowed Telegram user and confirm a reply.
+4. If the bot is used in a group, mention the bot or reply to it. If the bot should see all group messages, verify BotFather privacy mode is off or the bot is a group admin, then remove and re-add the bot to the group after changing privacy settings.
+
+### Troubleshooting
+
+- No reply in DMs: confirm `TELEGRAM_ALLOWED_USERS` contains the numeric Telegram user ID, not the username; then restart the gateway.
+- Bot silent in groups: check BotFather privacy mode, group admin status, and whether `require_mention` is enabled.
+- `Conflict` or duplicate receiver errors: stop every other process using the same bot token, including old local gateways and cloud replicas, then start one gateway instance.
+- Webhook requests fail: verify the public URL is HTTPS, the route path matches `TELEGRAM_WEBHOOK_URL`, the port is exposed, and `TELEGRAM_WEBHOOK_SECRET` is set on both Telegram registration and the gateway.
+- Markdown send failures: the adapter should fall back to plain text. If users see missing replies, check the gateway log for `MarkdownV2 parse failed` followed by `Failed to send Telegram message`.
+- Duplicate agent turns: inspect the gateway log for repeated update IDs; replay protection should log `Ignoring duplicate update_id=...` when Telegram redelivers an update.
+
+### Rollback
+
+1. Stop the new gateway process or deployment.
+2. Restore the previous environment variables or redeploy the previous release.
+3. If webhook mode caused the incident, unset `TELEGRAM_WEBHOOK_URL` and restart in polling mode, or point Telegram back to the previous stable webhook URL.
+4. Verify with a DM from an allowed user and inspect `~/.hermes/logs/gateway.log` for new Telegram errors.
+5. If a bot token leaked during the incident, revoke it in BotFather, issue a new token, update `TELEGRAM_BOT_TOKEN`, and restart the gateway.
+
 ## Sending Generated Files from Docker-backed Terminals
 
 If your terminal backend is `docker`, keep in mind that Telegram attachments are


### PR DESCRIPTION
## Summary
- dedupe Telegram updates by update_id to avoid duplicate turns/actions after retry/replay
- handle unsupported Telegram payloads with clear user-facing responses
- reap idle LSP clients to reduce file descriptor pressure in long-lived gateway/TUI processes
- document Telegram gateway stability troubleshooting

## Tests
- python -m pytest tests/gateway/test_telegram_update_admission.py tests/agent/test_lsp_idle_reap.py -q -o 'addopts='