### PR TITLE
feat(signal): add outbound quote/reply-to support

### DIFF
--- a/gateway/platforms/signal.py
+++ b/gateway/platforms/signal.py
@@ -633,6 +633,7 @@ class SignalAdapter(BasePlatformAdapter):
             media_urls=media_urls,
             media_types=media_types,
             timestamp=timestamp,
+            message_id=str(ts_ms) if ts_ms else None,
             raw_message={"sender": sender, "timestamp_ms": ts_ms},
             reply_to_message_id=reply_to_id,
             reply_to_text=reply_to_text,
@@ -988,6 +989,13 @@ class SignalAdapter(BasePlatformAdapter):
                 params["textStyle"] = text_styles[0]
             else:
                 params["textStyles"] = text_styles
+
+        if reply_to is not None:
+            try:
+                params["quoteTimestamp"] = int(reply_to)
+                params["quoteAuthor"] = chat_id
+            except (ValueError, TypeError):
+                pass
 
         if chat_id.startswith("group:"):
             params["groupId"] = chat_id[6:]


### PR DESCRIPTION
## Summary

Enables native Signal quote bubbles on outbound replies. Previously, when Hermes replied to a user's message on Signal, the response always arrived as a fresh message with no quote context — the `reply_to` parameter was accepted by `send()` but never forwarded to signal-cli.

## Changes

### 1. `gateway/platforms/signal.py` — Set message_id on MessageEvent
The Signal adapter now sets `message_id=str(ts_ms)` when creating the MessageEvent. Signal uses envelope timestamps as message identifiers. Without this, `_reply_anchor_for_event()` returned `None` for Signal messages, so `initial_reply_to_id` was never set and no reply context was available downstream.

### 2. `gateway/platforms/signal.py` — Forward quoteTimestamp to signal-cli
In the `send()` method, when `reply_to` is a numeric timestamp string, it is now passed as `quoteTimestamp` (integer) in the signal-cli JSON-RPC `send` params. This enables native Signal quote bubbles on outbound replies.

## Testing
- Verified inbound quote extraction still works (unchanged)
- Verified timestamp is correctly parsed and forwarded
- Confirmed the RPC call now includes `quoteTimestamp` when reply context exists
- Tested in production with live Signal gateway — quote bubbles render correctly on the receiving end