### PR TITLE
fix(slack): resolve file events with cached workspace team

### DIFF
--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -1925,6 +1925,11 @@ class SlackAdapter(BasePlatformAdapter):
             or assistant_meta.get("team_id", "")
         )
 
+        # File-upload events sometimes omit team_id. Resolve from the channel
+        # workspace cache so multi-workspace token lookup uses the right bot.
+        if not team_id and channel_id in self._channel_team:
+            team_id = self._channel_team[channel_id]
+
         # Track which workspace owns this channel
         if team_id and channel_id:
             self._channel_team[channel_id] = team_id

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -819,6 +819,33 @@ class TestIncomingDocumentHandling:
         assert msg_event.media_types == ["application/pdf"]
 
     @pytest.mark.asyncio
+    async def test_uses_cached_channel_team_for_file_events_without_team_id(self, adapter):
+        """File events use the channel workspace cache when Slack omits team_id."""
+        content = b"Hello from workspace two"
+        adapter._channel_team["D123"] = "T_SECOND"
+
+        with patch.object(adapter, "_download_slack_file_bytes", new_callable=AsyncMock) as dl:
+            dl.return_value = content
+            event = self._make_event(
+                text="summarize this",
+                files=[{
+                    "mimetype": "text/plain",
+                    "name": "workspace-two.txt",
+                    "url_private_download": "https://files.slack.com/workspace-two.txt",
+                    "size": len(content),
+                }],
+            )
+            assert "team" not in event
+            assert "team_id" not in event
+
+            await adapter._handle_slack_message(event)
+
+        dl.assert_awaited_once()
+        assert dl.await_args.kwargs["team_id"] == "T_SECOND"
+        msg_event = adapter.handle_message.call_args[0][0]
+        assert "Hello from workspace two" in msg_event.text
+
+    @pytest.mark.asyncio
     async def test_txt_document_injects_content(self, adapter):
         """A .txt file under 100KB should have its content injected into event text."""
         content = b"Hello from a text file"


### PR DESCRIPTION
## What does this PR do?

Fixes Slack file handling for multi-workspace gateway setups where Slack file-upload events omit `team` / `team_id`.

When Hermes has multiple Slack workspaces configured, file downloads need the correct workspace bot token. Regular messages populate the channel-to-team cache, but some file events arrive without workspace metadata. This PR falls back to the cached channel workspace before downloading attachments, so Hermes uses the correct Slack client/token.

## Related Issue

No existing issue. This PR adds a regression test for the reported multi-workspace Slack file-event behavior.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- Updated `gateway/platforms/slack.py` to resolve missing Slack `team_id` from the cached channel workspace mapping.
- Added regression coverage in `tests/gateway/test_slack.py` for file events that omit `team` / `team_id`.

## How to Test

1. Run the Slack-related test suite:

   ```bash
   scripts/run_tests.sh tests/gateway/test_slack.py tests/gateway/test_slack_approval_buttons.py tests/gateway/test_slack_channel_skills.py tests/gateway/test_slack_mention.py tests/hermes_cli/test_slack_cli.py
   ```

2. Confirm all Slack tests pass:

   ```text
   279 tests passed, 0 failed
   ```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the relevant test suite and all targeted tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

N/A
