### PR TITLE
feat(gateway): route Codex credentials by source

### DIFF
--- a/gateway/credential_routing.py
+++ b/gateway/credential_routing.py
@@ -1,0 +1,245 @@
+"""Gateway-scoped credential routing helpers.
+
+This module intentionally keeps routing decisions close to the gateway
+source (platform/chat/thread) instead of changing global provider selection.
+Routes can allow/deny credential labels and can mark some labels as
+conditional on a fresh quota snapshot.  Conditional labels fail closed when
+quota data is absent, stale, invalid, or over threshold.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import Any, Callable, Iterable, Optional
+
+logger = logging.getLogger(__name__)
+
+
+def _as_list(value: Any) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        return [value]
+    if isinstance(value, Iterable) and not isinstance(value, (bytes, bytearray, dict)):
+        return [str(item) for item in value if str(item).strip()]
+    return []
+
+
+def _platform_value(source: Any) -> str:
+    platform = getattr(source, "platform", None)
+    return str(getattr(platform, "value", platform) or "").strip().lower()
+
+
+def _matches_any(value: Any, candidates: Any) -> bool:
+    allowed = {str(item) for item in _as_list(candidates)}
+    if not allowed:
+        return True
+    return str(value or "") in allowed
+
+
+def _route_matches(rule: dict[str, Any], source: Any, provider: str) -> bool:
+    rule_provider = str(rule.get("provider") or "").strip().lower()
+    if rule_provider and rule_provider != str(provider or "").strip().lower():
+        return False
+
+    rule_platform = str(rule.get("platform") or "").strip().lower()
+    if rule_platform and rule_platform != _platform_value(source):
+        return False
+
+    if not _matches_any(getattr(source, "chat_id", None), rule.get("chat_ids") or rule.get("chat_id")):
+        return False
+    if not _matches_any(getattr(source, "thread_id", None), rule.get("thread_ids") or rule.get("thread_id")):
+        return False
+    if not _matches_any(getattr(source, "chat_name", None), rule.get("chat_names") or rule.get("chat_name")):
+        return False
+    if not _matches_any(getattr(source, "chat_type", None), rule.get("chat_types") or rule.get("chat_type")):
+        return False
+    return True
+
+
+def resolve_gateway_credential_route(
+    *,
+    user_config: Optional[dict[str, Any]],
+    source: Any,
+    provider: str,
+) -> Optional[dict[str, Any]]:
+    """Return the first matching gateway credential route for a source."""
+    cfg = user_config or {}
+    routing = cfg.get("gateway_credential_routing")
+    if not isinstance(routing, dict):
+        return None
+    rules = routing.get("rules")
+    if not isinstance(rules, list):
+        return None
+    for rule in rules:
+        if isinstance(rule, dict) and _route_matches(rule, source, provider):
+            return rule
+    return None
+
+
+def _entry_label(entry: Any) -> str:
+    return str(getattr(entry, "label", "") or getattr(entry, "id", "") or "")
+
+
+def _quota_value(quota: dict[str, Any], *keys: str) -> Optional[float]:
+    for key in keys:
+        value = quota.get(key)
+        if value is None:
+            continue
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return None
+    return None
+
+
+def _timestamp(value: Any) -> Optional[float]:
+    if value is None or value == "":
+        return None
+    try:
+        numeric = float(value)
+        return numeric / 1000.0 if numeric > 1_000_000_000_000 else numeric
+    except (TypeError, ValueError):
+        pass
+    try:
+        from datetime import datetime
+        return datetime.fromisoformat(str(value).replace("Z", "+00:00")).timestamp()
+    except Exception:
+        return None
+
+
+def conditional_quota_allows(entry: Any, rule: dict[str, Any], *, now: Optional[float] = None) -> bool:
+    """Fail-closed quota gate for labels that require live/fresh quota proof."""
+    label = _entry_label(entry)
+    conditional = set(_as_list(rule.get("conditional_labels") or rule.get("quota_checked_labels")))
+    if label not in conditional:
+        return True
+
+    extra = getattr(entry, "extra", None)
+    quota = extra.get("quota") if isinstance(extra, dict) else None
+    if not isinstance(quota, dict):
+        logger.warning("gateway credential route: label=%s denied; quota missing", label)
+        return False
+
+    now = time.time() if now is None else now
+    ttl = float(rule.get("quota_refresh_ttl_seconds") or rule.get("quota_ttl_seconds") or 300)
+    observed = _timestamp(quota.get("observed_at"))
+    if observed is None or now - observed > ttl:
+        logger.warning("gateway credential route: label=%s denied; quota stale", label)
+        return False
+
+    primary = _quota_value(quota, "primary_percent", "primary_used_percent", "primary_usedPercent")
+    secondary = _quota_value(quota, "secondary_percent", "secondary_used_percent", "secondary_usedPercent")
+    max_primary = float(rule.get("max_primary_percent") or rule.get("primary_max_percent") or 80)
+    max_secondary = float(rule.get("max_secondary_percent") or rule.get("secondary_max_percent") or 80)
+
+    if primary is None or secondary is None:
+        logger.warning("gateway credential route: label=%s denied; incomplete quota", label)
+        return False
+    if primary >= max_primary or secondary >= max_secondary:
+        logger.info(
+            "gateway credential route: label=%s denied; quota primary=%.1f secondary=%.1f max_primary=%.1f max_secondary=%.1f",
+            label,
+            primary,
+            secondary,
+            max_primary,
+            max_secondary,
+        )
+        return False
+    return True
+
+
+def select_entry_for_gateway_route(pool: Any, rule: dict[str, Any]) -> Any:
+    """Select a credential entry for a matched route without mutating pool contents.
+
+    The selection is deliberately conservative: allow/deny filters first,
+    conditional quota labels fail closed, then pick the lowest priority/request
+    count among available entries.  This avoids constructing a temporary pool
+    whose persistence path could overwrite the full credential pool.
+    """
+    allow = set(_as_list(rule.get("allow_labels")))
+    deny = set(_as_list(rule.get("deny_labels")))
+
+    try:
+        entries = list(pool._available_entries(clear_expired=True, refresh=True))  # noqa: SLF001 - intentional internal gateway integration
+    except Exception:
+        entries = list(pool.entries()) if hasattr(pool, "entries") else []
+
+    candidates = []
+    for entry in entries:
+        label = _entry_label(entry)
+        if allow and label not in allow:
+            continue
+        if label in deny:
+            continue
+        if not conditional_quota_allows(entry, rule):
+            continue
+        candidates.append(entry)
+
+    if not candidates:
+        return None
+
+    selected = min(
+        candidates,
+        key=lambda entry: (
+            int(getattr(entry, "request_count", 0) or 0),
+            int(getattr(entry, "priority", 0) or 0),
+            _entry_label(entry),
+        ),
+    )
+    try:
+        from dataclasses import replace
+
+        updated = replace(selected, request_count=int(getattr(selected, "request_count", 0) or 0) + 1)
+        if hasattr(pool, "_replace_entry"):
+            pool._replace_entry(selected, updated)  # noqa: SLF001 - preserve full pool while recording route use
+        if hasattr(pool, "_persist"):
+            pool._persist()  # noqa: SLF001
+        return updated
+    except Exception:
+        return selected
+
+
+def route_runtime_kwargs(
+    runtime: dict[str, Any],
+    *,
+    source: Any,
+    user_config: Optional[dict[str, Any]],
+    pool_loader: Callable[[str], Any],
+) -> dict[str, Any]:
+    """Apply a matched gateway credential route to runtime kwargs."""
+    provider = str(runtime.get("provider") or "").strip().lower()
+    if not provider:
+        return runtime
+    rule = resolve_gateway_credential_route(user_config=user_config, source=source, provider=provider)
+    if not rule:
+        return runtime
+
+    pool = runtime.get("credential_pool")
+    if pool is None:
+        try:
+            pool = pool_loader(provider)
+        except Exception as exc:
+            logger.warning("gateway credential route: failed to load pool for provider=%s: %s", provider, exc)
+            return runtime
+
+    selected = select_entry_for_gateway_route(pool, rule)
+    if selected is None:
+        if str(rule.get("fallback_policy") or "").strip().lower() == "fail_closed":
+            raise RuntimeError(f"No gateway credential route candidates available for provider {provider}")
+        return runtime
+
+    routed = dict(runtime)
+    routed["api_key"] = getattr(selected, "runtime_api_key", None) or getattr(selected, "access_token", "")
+    routed["base_url"] = getattr(selected, "runtime_base_url", None) or getattr(selected, "base_url", None) or routed.get("base_url")
+    routed["credential_pool"] = None
+    routed["credential_label"] = _entry_label(selected)
+    logger.info(
+        "Gateway credential route applied: platform=%s chat_id=%s provider=%s label=%s",
+        _platform_value(source),
+        getattr(source, "chat_id", None),
+        provider,
+        routed["credential_label"],
+    )
+    return routed

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -843,12 +843,17 @@ logger = logging.getLogger(__name__)
 _AGENT_PENDING_SENTINEL = object()
 
 
-def _resolve_runtime_agent_kwargs() -> dict:
+def _resolve_runtime_agent_kwargs(
+    *,
+    source: Optional[SessionSource] = None,
+    user_config: Optional[dict] = None,
+) -> dict:
     """Resolve provider credentials for gateway-created AIAgent instances.
 
     If the primary provider fails with an authentication error, attempt to
     resolve credentials using the fallback provider chain from config.yaml
-    before giving up.
+    before giving up. When a gateway source is supplied, apply
+    config-driven gateway_credential_routing after provider resolution.
     """
     from hermes_cli.runtime_provider import (
         resolve_runtime_provider,
@@ -871,7 +876,7 @@ def _resolve_runtime_agent_kwargs() -> dict:
     except Exception as exc:
         raise RuntimeError(format_runtime_provider_error(exc)) from exc
 
-    return {
+    result = {
         "api_key": runtime.get("api_key"),
         "base_url": runtime.get("base_url"),
         "provider": runtime.get("provider"),
@@ -880,6 +885,20 @@ def _resolve_runtime_agent_kwargs() -> dict:
         "args": list(runtime.get("args") or []),
         "credential_pool": runtime.get("credential_pool"),
     }
+    if source is not None:
+        try:
+            from agent.credential_pool import load_pool
+            from gateway.credential_routing import route_runtime_kwargs
+            result = route_runtime_kwargs(
+                result,
+                source=source,
+                user_config=user_config if isinstance(user_config, dict) else _load_gateway_config(),
+                pool_loader=load_pool,
+            )
+        except Exception:
+            # fail_closed routes intentionally raise; preserve that behavior.
+            raise
+    return result
 
 
 def _try_resolve_fallback_provider() -> dict | None:
@@ -2138,7 +2157,7 @@ class GatewayRunner:
                 list(self._session_model_overrides.keys())[:5] if self._session_model_overrides else "[]",
             )
 
-        runtime_kwargs = _resolve_runtime_agent_kwargs()
+        runtime_kwargs = _resolve_runtime_agent_kwargs(source=source, user_config=user_config)
         runtime_model = runtime_kwargs.pop("model", None)
         if runtime_model:
             logger.info(
@@ -7744,10 +7763,10 @@ class GatewayRunner:
                 from agent.model_metadata import get_model_context_length
 
                 _msg_cwd = os.environ.get("TERMINAL_CWD", os.path.expanduser("~"))
-                _msg_runtime = _resolve_runtime_agent_kwargs()
+                _msg_cfg = _load_gateway_config()
+                _msg_runtime = _resolve_runtime_agent_kwargs(source=source, user_config=_msg_cfg)
                 _msg_config_ctx = None
                 try:
-                    _msg_cfg = _load_gateway_config()
                     _msg_model_cfg = _msg_cfg.get("model", {})
                     if isinstance(_msg_model_cfg, dict):
                         _msg_raw_ctx = _msg_model_cfg.get("context_length")

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -504,7 +504,11 @@ DEFAULT_CONFIG = {
     "model": "",
     "providers": {},
     "fallback_providers": [],
+    "pool_strategies": {},
+    "pool_policies": {},
+    "gateway_credential_routing": {"rules": []},
     "credential_pool_strategies": {},
+    "credential_pool_policies": {},
     "toolsets": ["hermes-cli"],
     "agent": {
         "max_turns": 90,
@@ -3298,7 +3302,9 @@ def check_config_version() -> Tuple[int, int]:
 # Fields that are valid at root level of config.yaml
 _KNOWN_ROOT_KEYS = {
     "_config_version", "model", "providers", "fallback_model",
-    "fallback_providers", "credential_pool_strategies", "toolsets",
+    "fallback_providers", "pool_strategies", "pool_policies",
+    "gateway_credential_routing",
+    "credential_pool_strategies", "credential_pool_policies", "toolsets",
     "agent", "terminal", "display", "compression", "delegation",
     "auxiliary", "custom_providers", "context", "memory", "gateway",
     "sessions",

--- a/tests/gateway/test_credential_routing.py
+++ b/tests/gateway/test_credential_routing.py
@@ -1,0 +1,160 @@
+import time
+from types import SimpleNamespace
+
+import pytest
+
+from gateway.config import Platform
+from gateway.credential_routing import route_runtime_kwargs, select_entry_for_gateway_route
+from gateway.session import SessionSource
+
+
+class FakeEntry:
+    def __init__(self, label, *, priority=0, request_count=0, quota=None, token=None):
+        self.id = label
+        self.label = label
+        self.priority = priority
+        self.request_count = request_count
+        self.extra = {"quota": quota} if quota is not None else {}
+        self.access_token = token or f"token-{label}"
+        self.runtime_api_key = self.access_token
+        self.base_url = "https://chatgpt.com/backend-api/codex"
+        self.runtime_base_url = self.base_url
+
+
+class FakePool:
+    def __init__(self, entries):
+        self._entries = list(entries)
+
+    def _available_entries(self, *, clear_expired=False, refresh=False):
+        return list(self._entries)
+
+    def entries(self):
+        return list(self._entries)
+
+
+def _fresh_quota(primary=1, secondary=20):
+    return {
+        "primary_percent": primary,
+        "secondary_percent": secondary,
+        "observed_at": time.time(),
+    }
+
+
+def test_select_route_prefers_allowed_pro_and_excludes_deny():
+    pool = FakePool([
+        FakeEntry("device_code", priority=0),
+        FakeEntry("gpt-pro-account-7", priority=5, request_count=0),
+        FakeEntry("gpt-pro-account-5", priority=1, request_count=2),
+    ])
+    rule = {
+        "allow_labels": ["gpt-pro-account-5", "gpt-pro-account-7"],
+        "deny_labels": ["device_code"],
+    }
+
+    selected = select_entry_for_gateway_route(pool, rule)
+
+    assert selected.label == "gpt-pro-account-7"
+
+
+def test_conditional_plus_requires_fresh_quota_and_fails_closed_when_missing():
+    pool = FakePool([
+        FakeEntry("codex-plus-account-3"),
+        FakeEntry("gpt-pro-account-7", priority=9),
+    ])
+    rule = {
+        "allow_labels": ["codex-plus-account-3", "gpt-pro-account-7"],
+        "conditional_labels": ["codex-plus-account-3"],
+        "max_secondary_percent": 80,
+    }
+
+    selected = select_entry_for_gateway_route(pool, rule)
+
+    assert selected.label == "gpt-pro-account-7"
+
+
+def test_conditional_plus_is_selectable_with_fresh_low_quota():
+    pool = FakePool([
+        FakeEntry("codex-plus-account-3", priority=0, quota=_fresh_quota(5, 20)),
+        FakeEntry("gpt-pro-account-7", priority=9),
+    ])
+    rule = {
+        "allow_labels": ["codex-plus-account-3", "gpt-pro-account-7"],
+        "conditional_labels": ["codex-plus-account-3"],
+        "max_primary_percent": 80,
+        "max_secondary_percent": 80,
+    }
+
+    selected = select_entry_for_gateway_route(pool, rule)
+
+    assert selected.label == "codex-plus-account-3"
+
+
+def test_conditional_plus_over_threshold_is_skipped():
+    pool = FakePool([
+        FakeEntry("codex-plus-account-3", priority=0, quota=_fresh_quota(1, 89)),
+        FakeEntry("gpt-pro-account-7", priority=9),
+    ])
+    rule = {
+        "allow_labels": ["codex-plus-account-3", "gpt-pro-account-7"],
+        "conditional_labels": ["codex-plus-account-3"],
+        "max_secondary_percent": 80,
+    }
+
+    selected = select_entry_for_gateway_route(pool, rule)
+
+    assert selected.label == "gpt-pro-account-7"
+
+
+def test_route_runtime_kwargs_applies_weixin_route_and_direct_binds_selected_token():
+    source = SessionSource(platform=Platform.WEIXIN, chat_id="wx-dm", chat_type="dm")
+    pool = FakePool([
+        FakeEntry("gpt-pro-account-7", token="secret-token"),
+    ])
+    cfg = {
+        "gateway_credential_routing": {
+            "rules": [
+                {
+                    "provider": "openai-codex",
+                    "platform": "weixin",
+                    "allow_labels": ["gpt-pro-account-7"],
+                    "fallback_policy": "fail_closed",
+                }
+            ]
+        }
+    }
+
+    routed = route_runtime_kwargs(
+        {"provider": "openai-codex", "api_key": "old", "credential_pool": pool},
+        source=source,
+        user_config=cfg,
+        pool_loader=lambda provider: pool,
+    )
+
+    assert routed["api_key"] == "secret-token"
+    assert routed["credential_pool"] is None
+    assert routed["credential_label"] == "gpt-pro-account-7"
+
+
+def test_fail_closed_route_raises_when_no_candidate():
+    source = SessionSource(platform=Platform.FEISHU, chat_id="feishu", chat_type="dm")
+    pool = FakePool([FakeEntry("device_code")])
+    cfg = {
+        "gateway_credential_routing": {
+            "rules": [
+                {
+                    "provider": "openai-codex",
+                    "platform": "feishu",
+                    "allow_labels": ["gpt-pro-account-7"],
+                    "fallback_policy": "fail_closed",
+                }
+            ]
+        }
+    }
+
+    with pytest.raises(RuntimeError):
+        route_runtime_kwargs(
+            {"provider": "openai-codex", "credential_pool": pool},
+            source=source,
+            user_config=cfg,
+            pool_loader=lambda provider: pool,
+        )

--- a/tests/hermes_cli/test_config_validation.py
+++ b/tests/hermes_cli/test_config_validation.py
@@ -193,6 +193,67 @@ class TestMissingModelSection:
         assert not any("no 'model' section" in i.message for i in issues)
 
 
+
+class TestAdaptivePoolConfigValidation:
+    def test_adaptive_pool_strategy_and_policy_are_known_root_keys(self):
+        issues = validate_config_structure({
+            "model": {"provider": "openai-codex", "default": "gpt-5.5"},
+            "pool_strategies": {"openai-codex": "adaptive"},
+            "pool_policies": {
+                "openai-codex": {
+                    "same_provider_failover_first": True,
+                    "max_transient_pool_failovers": 3,
+                    "transient_cooldown_seconds": 120,
+                    "quota_refresh_ttl_seconds": 300,
+                    "primary_hard_skip_percent": 98,
+                    "secondary_hard_skip_percent": 90,
+                    "secondary_soft_penalty_percent": 75,
+                    "circuit_breaker": {
+                        "max_fails": 3,
+                        "fail_timeout_seconds": 180,
+                        "half_open_probe_interval_seconds": 60,
+                    },
+                    "provider_fallback_after_pool_exhausted": True,
+                },
+            },
+        })
+
+        assert issues == []
+
+
+    def test_legacy_credential_pool_policy_alias_is_known_root_key(self):
+        issues = validate_config_structure({
+            "model": {"provider": "openai-codex", "default": "gpt-5.5"},
+            "credential_pool_strategies": {"openai-codex": "adaptive"},
+            "credential_pool_policies": {
+                "openai-codex": {
+                    "same_provider_failover_first": True,
+                    "max_transient_pool_failovers": 3,
+                },
+            },
+        })
+
+        assert issues == []
+
+
+    def test_gateway_credential_routing_is_known_root_key(self):
+        issues = validate_config_structure({
+            "model": {"provider": "openai-codex", "default": "gpt-5.5"},
+            "gateway_credential_routing": {
+                "rules": [
+                    {
+                        "provider": "openai-codex",
+                        "platform": "weixin",
+                        "allow_labels": ["gpt-pro-account-7"],
+                        "conditional_labels": ["codex-plus-account-3"],
+                    }
+                ]
+            },
+        })
+
+        assert issues == []
+
+
 class TestConfigIssueDataclass:
     """ConfigIssue should be a proper dataclass."""
 


### PR DESCRIPTION
## Summary
- add active gateway_credential_routing support for gateway-created agents
- allow routes to bind a selected credential label directly instead of relying on global pool selection
- add fail-closed conditional quota gates for Plus labels when quota data is missing, stale, invalid, or over threshold
- register gateway_credential_routing as a known config root

## Verification
- PYTHONPATH=/Users/wangrenzhu/work/hermes-agent-codex-routing /Users/wangrenzhu/work/hermes-agent/.venv/bin/python -m pytest -q tests/gateway/test_credential_routing.py tests/hermes_cli/test_config_validation.py -o addopts=
- PYTHONPATH=/Users/wangrenzhu/work/hermes-agent-codex-routing /Users/wangrenzhu/work/hermes-agent/.venv/bin/python -m py_compile gateway/credential_routing.py gateway/run.py hermes_cli/config.py

## Safety
- No production ~/.hermes/config.yaml changes are included in this PR.
- Plus labels require fresh quota snapshots via conditional_labels and fail closed when quota cannot prove headroom.
