### PR TITLE
fix(cron): keep originless delivery local

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -351,21 +351,15 @@ def _resolve_single_delivery_target(job: dict, deliver_value: str) -> Optional[d
                 "chat_id": str(origin["chat_id"]),
                 "thread_id": origin.get("thread_id"),
             }
-        # Origin missing (e.g. job created via API/script) — try each
-        # platform's home channel as a fallback instead of silently dropping.
-        for platform_name in _iter_home_target_platforms():
-            chat_id = _get_home_target_chat_id(platform_name)
-            if chat_id:
-                logger.info(
-                    "Job '%s' has deliver=origin but no origin; falling back to %s home channel",
-                    job.get("name", job.get("id", "?")),
-                    platform_name,
-                )
-                return {
-                    "platform": platform_name,
-                    "chat_id": chat_id,
-                    "thread_id": _get_home_target_thread_id(platform_name),
-                }
+        # Origin missing (e.g. job created via API/script/CLI without a gateway
+        # session) means there is no evidence-backed destination. Keep it
+        # local-only instead of guessing a home channel; explicit platform
+        # targets such as ``telegram`` or ``telegram:<chat>`` still use the
+        # configured home/target path below.
+        logger.info(
+            "Job '%s' has deliver=origin but no origin; keeping result local-only",
+            job.get("name", job.get("id", "?")),
+        )
         return None
 
     if ":" in deliver_value:

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -87,25 +87,10 @@ class TestResolveDeliveryTarget:
             "thread_id": "17585",
         }
 
-    @pytest.mark.parametrize(
-        ("platform", "env_var", "chat_id"),
-        [
-            ("matrix", "MATRIX_HOME_ROOM", "!bot-room:example.org"),
-            ("signal", "SIGNAL_HOME_CHANNEL", "+15551234567"),
-            ("mattermost", "MATTERMOST_HOME_CHANNEL", "team-town-square"),
-            ("sms", "SMS_HOME_CHANNEL", "+15557654321"),
-            ("email", "EMAIL_HOME_ADDRESS", "home@example.com"),
-            ("dingtalk", "DINGTALK_HOME_CHANNEL", "cidNNN"),
-            ("feishu", "FEISHU_HOME_CHANNEL", "oc_home"),
-            ("wecom", "WECOM_HOME_CHANNEL", "wecom-home"),
-            ("weixin", "WEIXIN_HOME_CHANNEL", "wxid_home"),
-            ("qqbot", "QQ_HOME_CHANNEL", "group-openid-home"),
-        ],
-    )
-    def test_origin_delivery_without_origin_falls_back_to_supported_home_channels(
-        self, monkeypatch, platform, env_var, chat_id
+    def test_origin_delivery_without_origin_stays_local_even_with_home_channels(
+        self, monkeypatch
     ):
-        for fallback_env in (
+        for env_var in (
             "MATRIX_HOME_ROOM",
             "MATRIX_HOME_CHANNEL",
             "TELEGRAM_HOME_CHANNEL",
@@ -122,14 +107,9 @@ class TestResolveDeliveryTarget:
             "WEIXIN_HOME_CHANNEL",
             "QQ_HOME_CHANNEL",
         ):
-            monkeypatch.delenv(fallback_env, raising=False)
-        monkeypatch.setenv(env_var, chat_id)
+            monkeypatch.setenv(env_var, f"configured-{env_var.lower()}")
 
-        assert _resolve_delivery_target({"deliver": "origin"}) == {
-            "platform": platform,
-            "chat_id": chat_id,
-            "thread_id": None,
-        }
+        assert _resolve_delivery_target({"deliver": "origin"}) is None
 
     def test_bare_matrix_delivery_uses_matrix_home_room(self, monkeypatch):
         monkeypatch.delenv("MATRIX_HOME_CHANNEL", raising=False)


### PR DESCRIPTION
## Summary
- keeps `deliver=origin` jobs without captured origin provenance local-only instead of guessing a configured home channel
- preserves explicit platform delivery behavior (`telegram`, `discord`, `telegram:<chat>`, etc.) through the existing configured target path
- updates the regression test to cover configured home channels without origin provenance

## Rationale
For unattended or API/script-created jobs, `deliver=origin` without an `origin` object has no evidence-backed destination. Failing local-only is safer than silently delivering to an unrelated configured home channel.

## Verification
- `python3 -m py_compile cron/scheduler.py tests/cron/test_scheduler.py`
- `uv run --with pytest python -m pytest tests/cron/test_scheduler.py -k 'origin_delivery_without_origin or bare_matrix_delivery or bare_platform_delivery or telegram_cron_thread_id' -o 'addopts=' -q`
  - 6 passed, 112 deselected
- `uv run --with ruff ruff check cron/scheduler.py tests/cron/test_scheduler.py`
  - All checks passed
- `git diff --check origin/main..HEAD`
  - passed