### PR TITLE
fix(agent): honor disabled_toolsets in memory/context-engine injection gates

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1126,16 +1126,19 @@ def init_agent(
     # 400 errors on providers that enforce unique names (e.g. Xiaomi
     # MiMo via Nous Portal).
     #
-    # Respect the platform's enabled_toolsets configuration (#5544):
+    # Respect toolset policy:
     #   enabled_toolsets is None        → no filter, inject (backward compat)
     #   "memory" in enabled_toolsets    → user opted in, inject
     #   otherwise (incl. [])            → user excluded memory, skip injection
+    #   "memory" in disabled_toolsets   → force skip (disabled wins)
     #
     # Without this gate, `platform_toolsets: telegram: []` still leaks memory
     # provider tools (fact_store, etc.) into the tool surface — a 10x latency
     # penalty on local models and a frequent trigger of tool-call loops.
+    _disabled_toolsets = set(agent.disabled_toolsets or [])
     if agent._memory_manager and agent.tools is not None and (
-        agent.enabled_toolsets is None or "memory" in agent.enabled_toolsets
+        (agent.enabled_toolsets is None or "memory" in agent.enabled_toolsets)
+        and "memory" not in _disabled_toolsets
     ):
         _existing_tool_names = {
             t.get("function", {}).get("name")
@@ -1447,9 +1450,9 @@ def init_agent(
     # against plugin paths that may register the same schemas via
     # ctx.register_tool(). Mirrors the memory tools dedup above.
     #
-    # Respect the platform's enabled_toolsets configuration (#5544):
+    # Respect toolset policy:
     # context engine tools follow the same gating pattern as memory
-    # provider tools — without the gate, `platform_toolsets: telegram: []`
+    # provider tools (including disabled_toolsets override) — without the gate, `platform_toolsets: telegram: []`
     # would still leak lcm_* tools into the tool surface and incur the
     # same local-model latency penalty.
     agent._context_engine_tool_names: set = set()
@@ -1458,8 +1461,8 @@ def init_agent(
         and agent.context_compressor
         and agent.tools is not None
         and (
-            agent.enabled_toolsets is None
-            or "context_engine" in agent.enabled_toolsets
+            (agent.enabled_toolsets is None or "context_engine" in agent.enabled_toolsets)
+            and "context_engine" not in _disabled_toolsets
         )
     ):
         _existing_tool_names = {

--- a/tests/agent/test_memory_provider.py
+++ b/tests/agent/test_memory_provider.py
@@ -1081,13 +1081,17 @@ class TestMemoryToolToolsetGate:
     """
 
     @staticmethod
-    def _run_memory_injection(enabled_toolsets, memory_manager):
+    def _run_memory_injection(
+        enabled_toolsets, memory_manager, disabled_toolsets=None
+    ):
         """Simulate the gated memory-tool injection block from agent_init.py."""
         tools = []
         valid_tool_names = set()
+        _disabled = set(disabled_toolsets or [])
 
         if memory_manager and tools is not None and (
-            enabled_toolsets is None or "memory" in enabled_toolsets
+            (enabled_toolsets is None or "memory" in enabled_toolsets)
+            and "memory" not in _disabled
         ):
             _existing = {
                 t.get("function", {}).get("name")
@@ -1135,6 +1139,24 @@ class TestMemoryToolToolsetGate:
         assert tools == []
         assert names == set()
 
+    def test_disabled_toolsets_blocks_injection_when_enabled_is_none(self):
+        """disabled_toolsets must suppress memory tools even with enabled_toolsets=None."""
+        mgr = self._mgr_with_tools("fact_store")
+        tools, names = self._run_memory_injection(
+            None, mgr, disabled_toolsets=["memory"]
+        )
+        assert tools == []
+        assert names == set()
+
+    def test_disabled_toolsets_overrides_enabled_memory(self):
+        """disabled_toolsets must win even if enabled_toolsets includes memory."""
+        mgr = self._mgr_with_tools("fact_store")
+        tools, names = self._run_memory_injection(
+            ["terminal", "memory"], mgr, disabled_toolsets=["memory"]
+        )
+        assert tools == []
+        assert names == set()
+
     def test_toolsets_without_memory_blocks_injection(self):
         """Toolset list that doesn't name 'memory' must suppress injection."""
         mgr = self._mgr_with_tools("fact_store")
@@ -1171,18 +1193,21 @@ class TestContextEngineToolsetGate:
     """
 
     @staticmethod
-    def _run_context_engine_injection(enabled_toolsets, compressor):
+    def _run_context_engine_injection(
+        enabled_toolsets, compressor, disabled_toolsets=None
+    ):
         """Simulate the gated context-engine injection block from agent_init.py."""
         tools = []
         valid_tool_names = set()
         engine_tool_names = set()
+        _disabled = set(disabled_toolsets or [])
 
         if (
             compressor is not None
             and tools is not None
             and (
-                enabled_toolsets is None
-                or "context_engine" in enabled_toolsets
+                (enabled_toolsets is None or "context_engine" in enabled_toolsets)
+                and "context_engine" not in _disabled
             )
         ):
             _existing = {
@@ -1232,6 +1257,26 @@ class TestContextEngineToolsetGate:
         """`platform_toolsets: telegram: []` must suppress context-engine tools."""
         c = self._compressor_with("lcm_grep")
         tools, names, engine_names = self._run_context_engine_injection([], c)
+        assert tools == []
+        assert engine_names == set()
+
+    def test_disabled_toolsets_blocks_injection_when_enabled_is_none(self):
+        """disabled_toolsets must suppress context-engine tools with no enabled filter."""
+        c = self._compressor_with("lcm_grep")
+        tools, names, engine_names = self._run_context_engine_injection(
+            None, c, disabled_toolsets=["context_engine"]
+        )
+        assert tools == []
+        assert engine_names == set()
+
+    def test_disabled_toolsets_overrides_enabled_context_engine(self):
+        """disabled_toolsets must win over enabled_toolsets for context-engine."""
+        c = self._compressor_with("lcm_grep")
+        tools, names, engine_names = self._run_context_engine_injection(
+            ["terminal", "context_engine"],
+            c,
+            disabled_toolsets=["context_engine"],
+        )
         assert tools == []
         assert engine_names == set()
 


### PR DESCRIPTION
## What does this PR do?

Fixes a toolset-policy inconsistency in `agent_init`: memory/context-engine tool injection now respects `agent.disabled_toolsets` as well as `enabled_toolsets`.

Before this change, `enabled_toolsets=None` could still inject memory/context-engine tools even when those toolsets were globally disabled.

## Related Issue

Fixes #<issue-number>

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- Updated `agent/agent_init.py`:
  - Added disabled-toolset exclusion to memory tool injection gate.
  - Added disabled-toolset exclusion to context-engine tool injection gate.
- Updated `tests/agent/test_memory_provider.py`:
  - Added regression tests to verify `disabled_toolsets` overrides:
    - `enabled_toolsets=None`
    - `enabled_toolsets` explicitly includes the toolset

## How to Test

1. Run:
   `pytest tests/agent/test_memory_provider.py -q --timeout-method=thread`
2. Verify new disabled-toolset gate tests pass.

## Screenshots / Logs

Test result:
`78 passed in 0.88s`