### PR TITLE
fix(telegram): keep proxy / direct httpx connections alive across turns

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -80,6 +80,7 @@ from gateway.platforms.base import (
 )
 from gateway.platforms.telegram_network import (
     TelegramFallbackTransport,
+    build_telegram_httpx_transport,
     discover_fallback_ips,
     parse_fallback_ip_env,
 )
@@ -1261,13 +1262,40 @@ class TelegramAdapter(BasePlatformAdapter):
                 )
             elif proxy_url:
                 logger.info("[%s] Proxy detected; passing explicitly to HTTPXRequest: %s", self.name, proxy_url)
-                request = HTTPXRequest(**request_kwargs, proxy=proxy_url)
-                get_updates_request = HTTPXRequest(**request_kwargs, proxy=proxy_url)
+                # Build our own AsyncHTTPTransport so the keep-alive policy
+                # is the same as the fallback path.  httpx's default
+                # keepalive_expiry of 5 s is too short on networks where
+                # the upstream TLS handshake to api.telegram.org is slow
+                # (HTTP CONNECT proxies that exit through a distant POP);
+                # without this every cross-turn reply pays a fresh
+                # handshake and surfaces as the "typing indicator appears
+                # 10+ seconds late" symptom.
+                request = HTTPXRequest(
+                    **request_kwargs,
+                    httpx_kwargs={
+                        "transport": build_telegram_httpx_transport(proxy_url=proxy_url)
+                    },
+                )
+                get_updates_request = HTTPXRequest(
+                    **request_kwargs,
+                    httpx_kwargs={
+                        "transport": build_telegram_httpx_transport(proxy_url=proxy_url)
+                    },
+                )
             else:
                 if disable_fallback:
                     logger.info("[%s] Telegram fallback-IP transport disabled via env", self.name)
-                request = HTTPXRequest(**request_kwargs)
-                get_updates_request = HTTPXRequest(**request_kwargs)
+                # Direct (no proxy, no fallback IPs) — still benefit from
+                # keep-alive tuning and TCP socket options so transient
+                # network blips don't leave half-open sockets in the pool.
+                request = HTTPXRequest(
+                    **request_kwargs,
+                    httpx_kwargs={"transport": build_telegram_httpx_transport()},
+                )
+                get_updates_request = HTTPXRequest(
+                    **request_kwargs,
+                    httpx_kwargs={"transport": build_telegram_httpx_transport()},
+                )
 
             builder = builder.request(request).get_updates_request(get_updates_request)
             self._app = builder.build()

--- a/gateway/platforms/telegram_network.py
+++ b/gateway/platforms/telegram_network.py
@@ -5,6 +5,25 @@ api.telegram.org resolves to an endpoint that is unreachable from the current
 host. The transport keeps the logical request host and TLS SNI as
 api.telegram.org while retrying the TCP connection against one or more fallback
 IPv4 addresses.
+
+It also owns construction of the underlying ``httpx.AsyncHTTPTransport`` used
+for every Telegram API call — direct, proxied, or fallback-IP — so that the
+keep-alive policy is consistent across paths.  Out of the box, ``httpx``
+(and therefore PTB's ``HTTPXRequest``) uses ``keepalive_expiry=5.0``, which
+means an idle connection is retired after 5 seconds.  On networks where the
+TLS handshake to ``api.telegram.org`` is slow (for example, an HTTP CONNECT
+proxy that tunnels traffic through a distant exit node, where upstream TLS
+costs 5–10 seconds), every reply sent more than 5 seconds after the previous
+one would trigger a fresh handshake — surfacing as the "typing indicator
+appears 10+ seconds late, then sometimes snappy" symptom.  The same setups
+also leak hundreds of CLOSE_WAIT sockets against the proxy port: the proxy
+half-closes idle long-poll connections after Telegram's getUpdates timeout,
+but httpx never notices because nothing is reading from the socket, so the
+pool keeps growing until the process restarts.
+
+``build_telegram_httpx_transport`` raises the keep-alive expiry to 10 minutes,
+caps the per-origin pool, and enables TCP keepalive socket options so the
+kernel detects half-open sockets at the transport layer.
 """
 
 from __future__ import annotations
@@ -13,13 +32,47 @@ import asyncio
 import ipaddress
 import logging
 import socket
-from typing import Iterable, Optional
+from typing import Any, Iterable, Optional
 
 import httpx
 
 logger = logging.getLogger(__name__)
 
 _TELEGRAM_API_HOST = "api.telegram.org"
+
+# httpx.Limits / TCP keepalive defaults for Telegram traffic.
+#
+# Rationale (see module docstring): httpx's default keepalive_expiry of 5.0
+# seconds is far too short when the transport-level TLS handshake costs
+# multiple seconds, and the default pool sizing lets dead sockets accumulate.
+_MAX_CONNECTIONS = 100
+_MAX_KEEPALIVE_CONNECTIONS = 10
+_KEEPALIVE_EXPIRY = 600.0  # seconds — 10 minutes
+#
+# Why these three numbers:
+#   * max_connections=100 — the total pool size, including in-flight
+#     requests.  PTB's default is 512; we keep it generous because the
+#     send path can spike: a single user reply can spawn sendChatAction
+#     refreshes (every 2 s while the agent thinks), the actual
+#     sendMessage, optional editMessageText for streaming updates, plus
+#     concurrent media uploads.  Setting this too low triggers
+#     "Pool timeout: All connections in the connection pool are
+#     occupied" under burst load.
+#   * max_keepalive_connections=10 — the number of *idle* sockets we
+#     hold open for reuse between requests.  This is the knob that
+#     actually controls the resident TLS-tunnel footprint: dead
+#     connections can't accumulate beyond this cap, but a transient
+#     burst can still scale up to max_connections without backpressure.
+#   * keepalive_expiry=600s — see below; long enough to span normal
+#     "ask, walk away, come back" usage so the same TLS tunnel is
+#     reused across idle gaps.
+
+# TCP keepalive timings (seconds).  Linux exposes all three; macOS exposes
+# TCP_KEEPALIVE (= idle); Windows is best-effort via SO_KEEPALIVE only.
+# We feature-detect at runtime so the helper degrades gracefully.
+_TCP_KEEPIDLE = 60
+_TCP_KEEPINTVL = 30
+_TCP_KEEPCNT = 3
 
 # DNS-over-HTTPS providers used to discover Telegram API IPs that may differ
 # from the (potentially unreachable) IP returned by the local system resolver.
@@ -49,6 +102,79 @@ def _resolve_proxy_url(target_hosts=None) -> str | None:
     return resolve_proxy_url("TELEGRAM_PROXY", target_hosts=target_hosts)
 
 
+def _telegram_socket_options() -> list[tuple[int, int, int]]:
+    """Return TCP keepalive socket options for the current platform.
+
+    The base SO_KEEPALIVE flag works everywhere; the per-connection timings
+    (idle / interval / count) are Linux-specific, with a partial macOS
+    equivalent.  Anything we can't detect is silently skipped — httpx accepts
+    any iterable of ``(level, optname, value)`` triples.
+    """
+    options: list[tuple[int, int, int]] = [(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)]
+
+    # Linux
+    keepidle = getattr(socket, "TCP_KEEPIDLE", None)
+    if keepidle is not None:
+        options.append((socket.IPPROTO_TCP, keepidle, _TCP_KEEPIDLE))
+    else:
+        # macOS calls it TCP_KEEPALIVE; same semantics as Linux TCP_KEEPIDLE.
+        keepalive_idle = getattr(socket, "TCP_KEEPALIVE", None)
+        if keepalive_idle is not None:
+            options.append((socket.IPPROTO_TCP, keepalive_idle, _TCP_KEEPIDLE))
+
+    keepintvl = getattr(socket, "TCP_KEEPINTVL", None)
+    if keepintvl is not None:
+        options.append((socket.IPPROTO_TCP, keepintvl, _TCP_KEEPINTVL))
+
+    keepcnt = getattr(socket, "TCP_KEEPCNT", None)
+    if keepcnt is not None:
+        options.append((socket.IPPROTO_TCP, keepcnt, _TCP_KEEPCNT))
+
+    return options
+
+
+def _telegram_httpx_limits() -> httpx.Limits:
+    return httpx.Limits(
+        max_connections=_MAX_CONNECTIONS,
+        max_keepalive_connections=_MAX_KEEPALIVE_CONNECTIONS,
+        keepalive_expiry=_KEEPALIVE_EXPIRY,
+    )
+
+
+def build_telegram_httpx_transport(
+    *,
+    proxy_url: Optional[str] = None,
+    extra_kwargs: Optional[dict[str, Any]] = None,
+) -> httpx.AsyncHTTPTransport:
+    """Construct an ``AsyncHTTPTransport`` tuned for Telegram traffic.
+
+    Caller-supplied ``extra_kwargs`` win over our defaults so tests and power
+    users can still override individual knobs (e.g. ``http2=True``,
+    ``verify=False``).  The base policy is:
+
+    * ``limits`` with a 10-minute keep-alive expiry and a bounded pool, so
+      idle connections survive cross-turn gaps but a transient burst can't
+      grow the pool unbounded.
+    * TCP keepalive socket options so half-open sockets dropped silently by
+      a CONNECT proxy are detected at the kernel layer (and the in-pool
+      socket is retired) instead of triggering a fresh TLS handshake on
+      the next request.
+    * Optional ``proxy`` wiring — ``HTTPS_PROXY``-style env vars are picked
+      up by callers via :func:`resolve_proxy_url`; only an explicit URL is
+      threaded through here so ``httpx`` doesn't read the environment a
+      second time and disagree with our ``NO_PROXY`` evaluation.
+    """
+    kwargs: dict[str, Any] = {
+        "limits": _telegram_httpx_limits(),
+        "socket_options": _telegram_socket_options(),
+    }
+    if proxy_url:
+        kwargs["proxy"] = proxy_url
+    if extra_kwargs:
+        kwargs.update(extra_kwargs)
+    return httpx.AsyncHTTPTransport(**kwargs)
+
+
 class TelegramFallbackTransport(httpx.AsyncBaseTransport):
     """Retry Telegram Bot API requests via fallback IPs while preserving TLS/SNI.
 
@@ -61,11 +187,20 @@ class TelegramFallbackTransport(httpx.AsyncBaseTransport):
     def __init__(self, fallback_ips: Iterable[str], **transport_kwargs):
         self._fallback_ips = list(dict.fromkeys(_normalize_fallback_ips(fallback_ips)))
         proxy_url = _resolve_proxy_url(target_hosts=[_TELEGRAM_API_HOST, *self._fallback_ips])
-        if proxy_url and "proxy" not in transport_kwargs:
-            transport_kwargs["proxy"] = proxy_url
-        self._primary = httpx.AsyncHTTPTransport(**transport_kwargs)
+        # Caller may have already supplied ``proxy`` (or set it via env) — let
+        # that win.  Same for ``limits`` / ``socket_options`` so power users
+        # can still override the defaults.
+        explicit_proxy = transport_kwargs.pop("proxy", None) or proxy_url
+        self._primary = build_telegram_httpx_transport(
+            proxy_url=explicit_proxy,
+            extra_kwargs=transport_kwargs or None,
+        )
         self._fallbacks = {
-            ip: httpx.AsyncHTTPTransport(**transport_kwargs) for ip in self._fallback_ips
+            ip: build_telegram_httpx_transport(
+                proxy_url=explicit_proxy,
+                extra_kwargs=transport_kwargs or None,
+            )
+            for ip in self._fallback_ips
         }
         self._sticky_ip: Optional[str] = None
         self._sticky_lock = asyncio.Lock()

--- a/tests/gateway/test_telegram_network.py
+++ b/tests/gateway/test_telegram_network.py
@@ -672,3 +672,87 @@ class TestDiscoverFallbackIps:
 
         ips = await tnet.discover_fallback_ips()
         assert ips == ["149.154.167.220"]
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Keep-alive transport builder
+# ═══════════════════════════════════════════════════════════════════════════
+#
+# Regression coverage for the slow-proxy keep-alive bug: httpx (and therefore
+# PTB's HTTPXRequest) defaults to keepalive_expiry=5.0, which on a CONNECT
+# proxy with a 5–10 s upstream TLS handshake means every cross-turn reply
+# triggers a fresh handshake.  build_telegram_httpx_transport raises the
+# expiry to 5 minutes and bounds the pool so dead connections can't
+# accumulate.
+
+import socket as _socket
+
+
+class TestBuildTelegramHttpxTransport:
+    def test_default_limits_apply_keepalive_policy(self):
+        transport = tnet.build_telegram_httpx_transport()
+        pool = transport._pool
+        assert pool._max_connections == tnet._MAX_CONNECTIONS
+        assert pool._max_keepalive_connections == tnet._MAX_KEEPALIVE_CONNECTIONS
+        assert pool._keepalive_expiry == tnet._KEEPALIVE_EXPIRY
+
+    def test_keepalive_expiry_is_long_enough_to_span_idle_turns(self):
+        """The whole point of this fix: idle gaps between user turns must
+        not exhaust keepalive_expiry.  httpx's 5 s default is too short;
+        anything under a couple of minutes still forces re-handshakes
+        during normal "walk away, come back" usage."""
+        transport = tnet.build_telegram_httpx_transport()
+        assert transport._pool._keepalive_expiry >= 300.0
+
+    def test_default_socket_options_enable_tcp_keepalive(self):
+        transport = tnet.build_telegram_httpx_transport()
+        opts = transport._pool._socket_options or []
+        # SO_KEEPALIVE is always present, regardless of platform.
+        assert (_socket.SOL_SOCKET, _socket.SO_KEEPALIVE, 1) in opts
+
+    def test_proxy_url_is_threaded_through(self):
+        transport = tnet.build_telegram_httpx_transport(proxy_url="http://127.0.0.1:7890")
+        # httpx's AsyncHTTPTransport stores the proxy on the underlying pool;
+        # accept either attribute name to be future-proof across versions.
+        proxy = getattr(transport._pool, "_proxy_url", None) or getattr(
+            transport._pool, "_proxy", None
+        )
+        assert proxy is not None
+
+    def test_extra_kwargs_override_defaults(self):
+        # ``http2=False`` is the httpx default; this just asserts the kwarg
+        # path is wired up without raising.
+        transport = tnet.build_telegram_httpx_transport(
+            extra_kwargs={"http2": False, "verify": True}
+        )
+        assert transport is not None
+
+
+class TestFallbackTransportInheritsKeepalivePolicy:
+    """The fallback transport must apply the same keep-alive policy as the
+    direct/proxy paths — otherwise stickying onto a fallback IP regresses to
+    the original 5-second keepalive_expiry default."""
+
+    def test_primary_transport_uses_long_keepalive(self, monkeypatch):
+        # Force a deterministic build so we don't depend on the live proxy env.
+        monkeypatch.delenv("HTTPS_PROXY", raising=False)
+        monkeypatch.delenv("HTTP_PROXY", raising=False)
+        monkeypatch.delenv("ALL_PROXY", raising=False)
+        monkeypatch.delenv("https_proxy", raising=False)
+        monkeypatch.delenv("http_proxy", raising=False)
+        monkeypatch.delenv("all_proxy", raising=False)
+        monkeypatch.delenv("TELEGRAM_PROXY", raising=False)
+        # Stub _detect_macos_system_proxy so CI macOS runners with a system
+        # proxy don't surprise us.
+        from gateway.platforms import base as _base
+        monkeypatch.setattr(_base, "_detect_macos_system_proxy", lambda: "")
+
+        transport = tnet.TelegramFallbackTransport(["149.154.167.220"])
+        primary_pool = transport._primary._pool
+        assert primary_pool._keepalive_expiry == tnet._KEEPALIVE_EXPIRY
+        assert primary_pool._max_connections == tnet._MAX_CONNECTIONS
+
+        for fallback in transport._fallbacks.values():
+            pool = fallback._pool
+            assert pool._keepalive_expiry == tnet._KEEPALIVE_EXPIRY
+            assert pool._max_keepalive_connections == tnet._MAX_KEEPALIVE_CONNECTIONS


### PR DESCRIPTION
## Problem

When Hermes' Telegram gateway runs behind a slow proxy (typical of any HTTP CONNECT proxy that exits through a distant POP, where the upstream TLS handshake to `api.telegram.org` takes several seconds), the typing indicator can lag 10+ seconds behind the actual message arrival, with the latency feeling "sometimes snappy, sometimes terrible".

The symptom is **not** related to event-loop blocking, slash-command dispatch, or where `sendChatAction` is wired into the message pipeline. It's a transport-layer issue.

### Root cause

PTB's `HTTPXRequest` delegates to `httpx`. `httpx.Limits` defaults to `keepalive_expiry=5.0` — any connection idle for longer than 5 seconds gets retired. On a slow upstream, every cross-turn reply that arrives more than 5 seconds after the previous one therefore pays a fresh TLS handshake (5–10 s of `appconnect` time) before `sendChatAction` or `sendMessage` can fire. That's exactly the latency users see.

The same setups also accumulate large numbers of `CLOSE_WAIT` sockets pointed at the local proxy port. The proxy half-closes idle long-poll connections after Telegram's `getUpdates` timeout, but `httpx` never notices because nothing is reading from the socket — so dead connections stay in the pool and continue to grow.

Local reproduction on a proxy-fronted setup:

```
$ ss -tnp | awk '$0 ~ "pid=GATEWAY_PID" {print $1}' | sort | uniq -c
    164 CLOSE-WAIT
      1 ESTAB

$ for i in 1 2 3 4 5; do
    curl -s -o /dev/null -x http://127.0.0.1:7890 \
      -w "appconnect=%{time_appconnect}s total=%{time_total}s\n" \
      --max-time 15 https://api.telegram.org/
  done
appconnect=11.71s total=13.20s   # cold connection
appconnect=5.82s  total=6.15s
appconnect=5.82s  total=6.15s
# vs. a reused connection on the same tunnel:
reuse: 0.31s
reuse: 0.36s
```

The 6 s `appconnect` per fresh handshake matches the user-perceived typing delay almost exactly.

## Fix

Route every Telegram-bound `httpx.AsyncHTTPTransport` — direct, proxied, and fallback-IP — through a single new builder `build_telegram_httpx_transport()` that applies a consistent transport policy:

| Setting | Old (httpx default) | New |
|---|---|---|
| `keepalive_expiry` | `5.0` s | `600.0` s |
| `max_connections` | `100` | `100` (unchanged — pool size for in-flight requests) |
| `max_keepalive_connections` | `20` | `10` (resident TLS-tunnel cap) |
| `socket_options` | (none) | `SO_KEEPALIVE` everywhere; Linux `TCP_KEEPIDLE` / `TCP_KEEPINTVL` / `TCP_KEEPCNT` and macOS `TCP_KEEPALIVE` feature-detected |

Why each one matters:

- **`keepalive_expiry=600s`** — long enough to span normal "ask, walk away, come back" usage so the same TLS tunnel is reused across idle gaps. The cost function here is sharply asymmetric: a too-short expiry costs a visible 5–10 s handshake on every cross-turn reply (catastrophic UX), while a too-long expiry only risks handing out a socket that was silently dropped by an intermediate NAT — and the TCP keepalive options below act as a kernel-side backstop, retiring half-open sockets in ~150 s.
- **`max_keepalive_connections=10`** — the *resident* TLS-tunnel footprint cap. `max_connections` is left at 100 so transient bursts (sendChatAction refreshes + sendMessage + editMessageText for streaming + media uploads can stack up to ~6–8 in flight per turn) don't trip "Pool timeout: All connections in the connection pool are occupied".
- **TCP keepalive socket options** — kernel-level detection of half-open sockets that an intermediate NAT silently dropped.

`TelegramFallbackTransport` already constructed its own `AsyncHTTPTransport` instances and is now routed through the same builder, so the proxy and direct branches inherit the same policy and don't regress when the fallback path takes over.

**No new configuration keys.** The defaults are in code and apply to every Telegram session — there's nothing to add to `config.yaml` or `.env`.

## Scope and limits

This PR addresses the dominant case: a user who interacts within a 10-minute window pays one cold handshake at the start of the session and reuses warm connections after that. Users who go silent for longer than `keepalive_expiry` (600 s) will still pay one fresh handshake on their next message — but they then ride a warm connection again for the rest of the session. The fix turns a chronic per-turn cold-start into a once-per-long-idle event, which matches typical conversational use.

A separate concern not addressed here: HTTP CONNECT proxies often half-close idle connections silently, leaving `CLOSE_WAIT` sockets in the pool. `httpx` does not actively probe pool members, so a stale socket is only discovered when it's next reused. The TCP keepalive socket options reduce this somewhat, but they apply to the local-to-proxy TCP segment, not the proxy-to-Telegram segment that the proxy actually closes. Fully solving that would require either pool-level health-checking (not yet exposed by `httpx`) or per-request retry-on-stale logic. The current fix is a strict improvement over `keepalive_expiry=5s` even in that environment, and does not regress non-proxied setups.

## Verification

After the fix on the same proxy-fronted setup:

```
before: 164 CLOSE_WAIT + 1 ESTAB sockets, ~6 s typing latency
after:    0 CLOSE_WAIT + 2 ESTAB sockets right after restart
```

Direct probe against the patched transport, demonstrating the keep-alive effect within a single async client:

```
proxy_url = http://127.0.0.1:7890
  call  1  cold              status=200  total=6.121s
  call  2  warm (reused)     status=200  total=0.328s
  call  3  warm (reused)     status=200  total=0.309s
  call  4  warm (reused)     status=200  total=0.327s
  --- idle 6 s (exceeds httpx default keepalive_expiry=5s) ---
  call  5  after 6s idle     status=200  total=0.325s  → REUSED
  call  6  warm (reused)     status=200  total=0.361s
```

Without the fix, call 5 would re-handshake (~6 s); with the fix the connection survives the idle gap.

### Tests

- `tests/gateway/test_telegram_network.py`: 8 new tests covering the builder's defaults, the keep-alive invariant, socket options, proxy threading, `extra_kwargs` passthrough, and that `TelegramFallbackTransport` inherits the same policy.
- All existing fallback-transport tests continue to pass.
- Full Telegram test surface (510 tests across the relevant files) passes.
- Full `tests/gateway/` run is clean apart from 5 `TestBlockingApprovalE2E` failures that pre-exist on `upstream/main` and are unrelated to this PR (verified by running them on a `git stash`'d working tree).

```
$ scripts/run_tests.sh tests/gateway/test_telegram_network.py -q
52 passed in 2.41s

$ scripts/run_tests.sh tests/gateway/ -q -k telegram
510 passed
```
