### PR TITLE
fix(mcp): sanitize subprocess PATH

### DIFF
--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -1318,7 +1318,7 @@ class TestBuildSafeEnv:
             result = _build_safe_env(None)
 
         # Safe vars present
-        assert result["PATH"] == "/usr/bin"
+        assert result["PATH"] == os.pathsep.join(["/usr/bin", "/bin"])
         assert result["HOME"] == "/home/test"
         assert result["USER"] == "test"
         assert result["LANG"] == "en_US.UTF-8"
@@ -1334,7 +1334,7 @@ class TestBuildSafeEnv:
         with patch.dict("os.environ", {"PATH": "/usr/bin"}, clear=True):
             result = _build_safe_env({"MY_CUSTOM_VAR": "hello"})
 
-        assert result["PATH"] == "/usr/bin"
+        assert result["PATH"] == os.pathsep.join(["/usr/bin", "/bin"])
         assert result["MY_CUSTOM_VAR"] == "hello"
 
     def test_user_env_overrides_safe(self):
@@ -1344,7 +1344,60 @@ class TestBuildSafeEnv:
         with patch.dict("os.environ", {"PATH": "/usr/bin"}, clear=True):
             result = _build_safe_env({"PATH": "/custom/bin"})
 
-        assert result["PATH"] == "/custom/bin"
+        assert result["PATH"] == os.pathsep.join(["/custom/bin", "/usr/bin", "/bin"])
+
+    def test_sanitizes_literal_path_token_and_ensures_system_bins(self):
+        """Literal $PATH entries are expanded to safe defaults for MCP subprocesses."""
+        from tools.mcp_tool import _build_safe_env
+
+        fake_path = os.pathsep.join([
+            "/home/test/.local/bin",
+            "$PATH",
+            "/home/test/.local/bin",
+            "",
+            "/opt/homebrew/bin",
+        ])
+        with patch.dict("os.environ", {"PATH": fake_path, "HOME": "/home/test"}, clear=True):
+            result = _build_safe_env(None)
+
+        path_parts = result["PATH"].split(os.pathsep)
+        assert "$PATH" not in path_parts
+        assert "${PATH}" not in path_parts
+        assert path_parts.count("/home/test/.local/bin") == 1
+        assert "/usr/bin" in path_parts
+        assert "/bin" in path_parts
+        assert "" not in path_parts
+
+    def test_sanitizes_configured_path_with_home_expansion(self):
+        """User-configured PATH overrides are sanitized too."""
+        from tools.mcp_tool import _build_safe_env
+
+        with patch.dict("os.environ", {"PATH": "/bad/bin", "HOME": "/home/test"}, clear=True):
+            result = _build_safe_env({"PATH": "$HOME/bin:${PATH}:/usr/bin"})
+
+        path_parts = result["PATH"].split(os.pathsep)
+        assert "$HOME/bin" not in path_parts
+        assert "${PATH}" not in path_parts
+        assert "/home/test/bin" in path_parts
+        assert "/usr/bin" in path_parts
+        assert "/bin" in path_parts
+        assert path_parts.count("/usr/bin") == 1
+
+    def test_sanitized_path_does_not_expand_filtered_parent_secrets(self):
+        """PATH expansion must not smuggle filtered parent env vars to MCP servers."""
+        from tools.mcp_tool import _build_safe_env
+
+        with patch.dict(
+            "os.environ",
+            {"PATH": "/usr/bin", "HOME": "/home/test", "SECRET_TOKEN": "super-secret"},
+            clear=True,
+        ):
+            result = _build_safe_env({"PATH": "$SECRET_TOKEN/bin:$HOME/bin"})
+
+        path_parts = result["PATH"].split(os.pathsep)
+        assert "super-secret/bin" not in path_parts
+        assert "/home/test/bin" in path_parts
+        assert all("SECRET_TOKEN" not in part for part in path_parts)
 
     def test_none_user_env(self):
         """None user_env still returns safe vars from os.environ."""
@@ -1354,7 +1407,7 @@ class TestBuildSafeEnv:
             result = _build_safe_env(None)
 
         assert isinstance(result, dict)
-        assert result["PATH"] == "/usr/bin"
+        assert result["PATH"] == os.pathsep.join(["/usr/bin", "/bin"])
         assert result["HOME"] == "/root"
 
     def test_secret_vars_excluded(self):

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -287,6 +287,8 @@ _CREDENTIAL_PATTERN = re.compile(
 # Supports any non-} characters in the variable name (hyphens, dots, etc.)
 # so providers like MY-VAR or my.var work correctly.
 _ENV_VAR_PATTERN = re.compile(r"\$\{([^}]+)\}")
+_PATH_ENV_VAR_PATTERN = re.compile(r"\$\{([^}]+)\}|\$([A-Za-z_][A-Za-z0-9_]*)")
+_MCP_REQUIRED_PATH_DIRS = ("/usr/bin", "/bin")
 
 
 # ---------------------------------------------------------------------------
@@ -309,7 +311,44 @@ def _build_safe_env(user_env: Optional[dict]) -> dict:
             env[key] = value
     if user_env:
         env.update(user_env)
+    env["PATH"] = _sanitize_mcp_path(env.get("PATH", ""), env)
     return env
+
+
+def _sanitize_mcp_path(path_value: Any, env: Optional[dict] = None) -> str:
+    """Return a robust PATH for stdio MCP subprocesses.
+
+    MCP subprocesses inherit a deliberately filtered environment, so a malformed
+    parent PATH such as ``$HOME/.local/bin:$PATH`` can otherwise leave literal
+    variable references in the child environment and omit basic system tools.
+    Expand simple variable references, drop empty/duplicate entries, and ensure
+    core POSIX command locations are available.
+    """
+    env = env or {}
+    raw_path = str(path_value or "")
+    fallback_path = os.defpath or os.pathsep.join(_MCP_REQUIRED_PATH_DIRS)
+    parts: list[str] = []
+
+    def replacement(match: re.Match) -> str:
+        name = match.group(1) or match.group(2) or ""
+        if name == "PATH":
+            return fallback_path
+        value = env.get(name, "")
+        return str(value) if value is not None else ""
+
+    source = raw_path if raw_path else fallback_path
+    for entry in source.split(os.pathsep):
+        expanded = _PATH_ENV_VAR_PATTERN.sub(replacement, entry.strip())
+        expanded = os.path.expanduser(expanded)
+        for subentry in expanded.split(os.pathsep):
+            subentry = subentry.strip()
+            if subentry and subentry not in parts:
+                parts.append(subentry)
+
+    for directory in _MCP_REQUIRED_PATH_DIRS:
+        if directory not in parts:
+            parts.append(directory)
+    return os.pathsep.join(parts)
 
 
 def _sanitize_error(text: str) -> str:


### PR DESCRIPTION
## Summary
- sanitize MCP stdio subprocess PATH values to expand safe references and remove literal `$PATH`/`${PATH}` entries
- preserve configured PATH precedence while ensuring `/usr/bin` and `/bin` are available
- add regressions for literal PATH tokens, configured PATH overrides, and filtered parent secrets

Closes #30369

## Test Plan
- [x] python -m pytest tests/tools/test_mcp_tool.py -q
- [x] independent reviewer pass after fixes