### PR TITLE
feat: add llmgateway provider with X-Source attribution

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -394,6 +394,14 @@ _AI_GATEWAY_HEADERS = {
     "User-Agent": f"HermesAgent/{_HERMES_VERSION}",
 }
 
+# LLM Gateway (llmgateway.io) app attribution headers. The gateway reads
+# ``X-Source`` for dashboard attribution, analogous to OpenRouter's
+# ``HTTP-Referer`` / ``X-Title`` pair.
+_LLMGATEWAY_HEADERS = {
+    "X-Source": "https://hermes-agent.nousresearch.com",
+    "User-Agent": f"HermesAgent/{_HERMES_VERSION}",
+}
+
 # Nous Portal extra_body for product attribution.
 # Callers should pass this as extra_body in chat.completions.create()
 # when the auxiliary client is backed by Nous Portal.

--- a/plugins/model-providers/llmgateway/__init__.py
+++ b/plugins/model-providers/llmgateway/__init__.py
@@ -1,0 +1,30 @@
+"""LLM Gateway (llmgateway.io) provider profile.
+
+LLM Gateway is a unified API gateway that routes to 100+ models across
+multiple providers. Hermes sends an ``X-Source`` attribution header so
+that requests originating from Hermes show up correctly in the LLM
+Gateway dashboard, mirroring the ``HTTP-Referer`` / ``X-Title`` pattern
+used for OpenRouter.
+"""
+
+from providers import register_provider
+from providers.base import ProviderProfile
+
+from hermes_cli import __version__ as _HERMES_VERSION
+
+
+llmgateway = ProviderProfile(
+    name="llmgateway",
+    aliases=("llm-gateway", "llm_gateway"),
+    env_vars=("LLM_GATEWAY_API_KEY",),
+    display_name="LLM Gateway",
+    description="LLM Gateway — unified API gateway for 100+ models",
+    signup_url="https://llmgateway.io/dashboard",
+    base_url="https://api.llmgateway.io/v1",
+    default_headers={
+        "X-Source": "https://hermes-agent.nousresearch.com",
+        "User-Agent": f"HermesAgent/{_HERMES_VERSION}",
+    },
+)
+
+register_provider(llmgateway)

--- a/plugins/model-providers/llmgateway/plugin.yaml
+++ b/plugins/model-providers/llmgateway/plugin.yaml
@@ -1,0 +1,5 @@
+name: llmgateway-provider
+kind: model-provider
+version: 1.0.0
+description: LLM Gateway (llmgateway.io)
+author: Nous Research

--- a/run_agent.py
+++ b/run_agent.py
@@ -2779,6 +2779,7 @@ class AIAgent:
     def _apply_client_headers_for_base_url(self, base_url: str) -> None:
         from agent.auxiliary_client import (
             _AI_GATEWAY_HEADERS,
+            _LLMGATEWAY_HEADERS,
             build_nvidia_nim_headers,
             build_or_headers,
         )
@@ -2787,6 +2788,8 @@ class AIAgent:
             self._client_kwargs["default_headers"] = build_or_headers()
         elif base_url_host_matches(base_url, "ai-gateway.vercel.sh"):
             self._client_kwargs["default_headers"] = dict(_AI_GATEWAY_HEADERS)
+        elif base_url_host_matches(base_url, "llmgateway.io"):
+            self._client_kwargs["default_headers"] = dict(_LLMGATEWAY_HEADERS)
         elif base_url_host_matches(base_url, "integrate.api.nvidia.com"):
             self._client_kwargs["default_headers"] = build_nvidia_nim_headers(base_url)
         elif base_url_host_matches(base_url, "api.routermint.com"):

--- a/tests/run_agent/test_provider_attribution_headers.py
+++ b/tests/run_agent/test_provider_attribution_headers.py
@@ -49,6 +49,25 @@ def test_ai_gateway_base_url_applies_attribution_headers(mock_openai):
 
 
 @patch("run_agent.OpenAI")
+def test_llmgateway_base_url_applies_attribution_headers(mock_openai):
+    mock_openai.return_value = MagicMock()
+    agent = AIAgent(
+        api_key="test-key",
+        base_url="https://openrouter.ai/api/v1",
+        model="test/model",
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+
+    agent._apply_client_headers_for_base_url("https://api.llmgateway.io/v1")
+
+    headers = agent._client_kwargs["default_headers"]
+    assert headers["X-Source"] == "https://hermes-agent.nousresearch.com"
+    assert headers["User-Agent"].startswith("HermesAgent/")
+
+
+@patch("run_agent.OpenAI")
 def test_routermint_base_url_applies_user_agent_header(mock_openai):
     mock_openai.return_value = MagicMock()
     agent = AIAgent(

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -22,6 +22,7 @@ You need at least one way to connect to an LLM. Use `hermes model` to switch pro
 | **OpenRouter** | `OPENROUTER_API_KEY` in `~/.hermes/.env` |
 | **NovitaAI** | `NOVITA_API_KEY` in `~/.hermes/.env` (provider: `novita`, 200+ models, Model API, Agent Sandbox, GPU Cloud) |
 | **AI Gateway** | `AI_GATEWAY_API_KEY` in `~/.hermes/.env` (provider: `ai-gateway`) |
+| **LLM Gateway** | `LLM_GATEWAY_API_KEY` in `~/.hermes/.env` (provider: `llmgateway`, aliases: `llm-gateway`, `llm_gateway`) |
 | **z.ai / GLM** | `GLM_API_KEY` in `~/.hermes/.env` (provider: `zai`) |
 | **Kimi / Moonshot** | `KIMI_API_KEY` in `~/.hermes/.env` (provider: `kimi-coding`) |
 | **Kimi / Moonshot (China)** | `KIMI_CN_API_KEY` in `~/.hermes/.env` (provider: `kimi-coding-cn`; aliases: `kimi-cn`, `moonshot-cn`) |


### PR DESCRIPTION
## Summary

- Adds a new provider profile for [LLM Gateway](https://llmgateway.io) (`llmgateway`, aliases `llm-gateway` / `llm_gateway`) at `plugins/model-providers/llmgateway/` with `LLM_GATEWAY_API_KEY` env and base URL `https://api.llmgateway.io/v1`.
- Sends an `X-Source: https://hermes-agent.nousresearch.com` header so Hermes-originated traffic is attributed correctly in the LLM Gateway dashboard, mirroring the OpenRouter (`HTTP-Referer` / `X-Title`) and AI Gateway attribution patterns.
- Adds URL-based detection in `AIAgent._apply_client_headers_for_base_url` so users who point a custom endpoint at `llmgateway.io` still get the attribution headers, even without setting `provider: llmgateway` explicitly.
- Documents the new provider in `website/docs/integrations/providers.md`.

## Test plan

- [ ] `pytest tests/run_agent/test_provider_attribution_headers.py::test_llmgateway_base_url_applies_attribution_headers`
- [ ] Existing `test_provider_attribution_headers.py` cases still pass (no regression to OpenRouter / AI Gateway / RouterMint / NVIDIA branches).
- [ ] `hermes model` lists "LLM Gateway" once `LLM_GATEWAY_API_KEY` is set in `~/.hermes/.env`.