### PR TITLE
feat(security): add ToolExecutionAudit middleware with secret redaction

### DIFF
--- a/agent/tool_audit.py
+++ b/agent/tool_audit.py
@@ -1,0 +1,149 @@
+"""Tool-Execution-Audit Middleware fuer Hermes.
+
+Schreibt Tool-Calls VOR Execution in ~/.hermes/audit_logs/ via externes
+audit-logger.sh Skript (siehe Memory: reference_audit_logger_2026_05_22).
+
+Architektur-Vertrag:
+- **Fail-Soft im Workflow:** Logger-Fehler blockt Tool-Execution NIE.
+- **Fail-Hard im Log:** entweder vollstaendige Zeile oder gar nichts (Skript-Seite).
+- **Singleton via Modul-Cache:** ein Pfad-Check beim ersten Call.
+- **Secret-Redaction:** Werte sensibler Keys werden vor Serialisierung redacted.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import subprocess
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_LOGGER_PATH = Path.home() / ".hermes" / "audit_logs" / "audit-logger.sh"
+_TIMEOUT_SECONDS = 2.0
+_REDACTED = "<redacted>"
+
+# Sensible Schluessel: substring case-insensitive Match.
+# Trade-off: "monkey_var" wuerde "key" matchen → redact. Lieber zu viel als zu wenig.
+_SECRET_KEY_PATTERN = re.compile(
+    r"(?i)(key|token|secret|password|auth|pwd)"
+)
+
+
+def _redact_secrets(obj: Any) -> Any:
+    """Rekursive Redaction: Werte von Keys mit sensiblem Namen → <redacted>.
+
+    Walks dict/list/scalar. Andere Container (set/tuple/...) bleiben unangetastet,
+    werden aber durchgereicht (Best-Effort). Keys werden gegen
+    _SECRET_KEY_PATTERN gematcht (case-insensitive, substring).
+    """
+    if isinstance(obj, dict):
+        out = {}
+        for k, v in obj.items():
+            if isinstance(k, str) and _SECRET_KEY_PATTERN.search(k):
+                out[k] = _REDACTED
+            else:
+                out[k] = _redact_secrets(v)
+        return out
+    if isinstance(obj, list):
+        return [_redact_secrets(item) for item in obj]
+    return obj
+
+
+class ToolExecutionAudit:
+    """Middleware fuer Tool-Call-Audit via externes POSIX-Skript."""
+
+    def __init__(
+        self,
+        logger_path: Optional[Path] = None,
+        timeout: float = _TIMEOUT_SECONDS,
+    ):
+        self.logger_path = logger_path or _DEFAULT_LOGGER_PATH
+        self.timeout = timeout
+        self._enabled = self._check_enabled()
+
+    def _check_enabled(self) -> bool:
+        """Audit nur aktiv wenn Skript existiert UND ausfuehrbar ist."""
+        if not self.logger_path.exists():
+            logger.warning(
+                "ToolExecutionAudit disabled: %s nicht gefunden",
+                self.logger_path,
+            )
+            return False
+        if not os.access(self.logger_path, os.X_OK):
+            logger.warning(
+                "ToolExecutionAudit disabled: %s nicht ausfuehrbar",
+                self.logger_path,
+            )
+            return False
+        return True
+
+    def audit(
+        self,
+        agent_id: str,
+        tool_name: str,
+        args: Dict[str, Any],
+    ) -> None:
+        """Logge Tool-Call. Fail-Soft: blockt Tool-Execution nie.
+
+        Args:
+            agent_id: Agent-Identifier (z.B. agent.session_id).
+            tool_name: Tool-Funktion-Name.
+            args: Tool-Argumente. Sensible Werte werden vorher redacted.
+        """
+        if not self._enabled:
+            return
+
+        # Redact BEFORE serialize — Secrets nie in JSON oder Log
+        try:
+            safe_args = _redact_secrets(args) if isinstance(args, dict) else args
+        except Exception as e:  # Defensive — Redact darf nie blockieren
+            logger.error("ToolExecutionAudit redact failed: %s", e)
+            safe_args = {"_redact_error": str(e)}
+
+        try:
+            payload = json.dumps(
+                {"agent_id": agent_id, "tool": tool_name, "args": safe_args},
+                separators=(",", ":"),
+                ensure_ascii=False,
+                default=str,  # nicht-serialisierbare Objekte → str-Fallback
+            )
+        except (TypeError, ValueError) as e:
+            logger.error("ToolExecutionAudit payload-encode failed: %s", e)
+            return
+
+        try:
+            result = subprocess.run(
+                [str(self.logger_path)],
+                input=payload,
+                text=True,
+                capture_output=True,
+                timeout=self.timeout,
+            )
+            if result.returncode != 0:
+                logger.error(
+                    "ToolExecutionAudit logger rc=%d stderr=%s",
+                    result.returncode,
+                    result.stderr.strip()[:200],
+                )
+        except subprocess.TimeoutExpired:
+            logger.error(
+                "ToolExecutionAudit logger timeout (%.1fs)", self.timeout
+            )
+        except (FileNotFoundError, PermissionError, OSError) as e:
+            logger.error("ToolExecutionAudit logger spawn failed: %s", e)
+        except Exception as e:  # Defensive: NIE durchschlagen lassen
+            logger.error("ToolExecutionAudit unexpected error: %s", e)
+
+
+_singleton: Optional[ToolExecutionAudit] = None
+
+
+def get_audit() -> ToolExecutionAudit:
+    """Lazy-Singleton fuer Modul-weiten Audit-Zugriff."""
+    global _singleton
+    if _singleton is None:
+        _singleton = ToolExecutionAudit()
+    return _singleton

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -233,6 +233,16 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
             except Exception:
                 pass
         start = time.time()
+        # ToolExecutionAudit: vor echter Execution (Fail-Soft, blockt nie)
+        try:
+            from agent.tool_audit import get_audit
+            get_audit().audit(
+                agent_id=getattr(agent, "session_id", "unknown"),
+                tool_name=function_name,
+                args=function_args,
+            )
+        except Exception:
+            pass  # Defensive: get_audit() raise darf Tool-Call nie blocken
         try:
             result = agent._invoke_tool(
                 function_name,
@@ -532,6 +542,18 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
             else:
                 args_preview = args_str[:agent.log_prefix_chars] + "..." if len(args_str) > agent.log_prefix_chars else args_str
                 print(f"  📞 Tool {i}: {function_name}({list(function_args.keys())}) - {args_preview}")
+
+        # ToolExecutionAudit: vor echter Execution (nicht bei blockierten Calls)
+        if not _execution_blocked:
+            try:
+                from agent.tool_audit import get_audit
+                get_audit().audit(
+                    agent_id=getattr(agent, "session_id", "unknown"),
+                    tool_name=function_name,
+                    args=function_args,
+                )
+            except Exception:
+                pass  # Defensive: get_audit() raise darf Tool-Call nie blocken
 
         if not _execution_blocked:
             agent._current_tool = function_name

--- a/tests/test_tool_audit.py
+++ b/tests/test_tool_audit.py
@@ -1,0 +1,172 @@
+"""Unit-Tests fuer agent.tool_audit — Redaction + Fail-Soft-Vertrag.
+
+Run: .venv/bin/pytest tests/test_tool_audit.py -v
+"""
+import json
+import logging
+import subprocess
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from agent.tool_audit import (
+    ToolExecutionAudit,
+    _redact_secrets,
+    get_audit,
+)
+
+
+# ── Redaction ──────────────────────────────────────────────────────────────
+
+class TestRedaction:
+    def test_redact_top_level_api_key(self):
+        result = _redact_secrets({"api_key": "secret123", "name": "X"})
+        assert result["api_key"] == "<redacted>"
+        assert result["name"] == "X"
+
+    def test_redact_case_insensitive(self):
+        result = _redact_secrets({"TOKEN": "x", "Auth_Header": "y", "PWD": "z"})
+        assert all(v == "<redacted>" for v in result.values())
+
+    def test_redact_nested_dict(self):
+        result = _redact_secrets({"outer": {"secret_key": "x", "public": "y"}})
+        assert result["outer"]["secret_key"] == "<redacted>"
+        assert result["outer"]["public"] == "y"
+
+    def test_redact_list_of_dicts(self):
+        result = _redact_secrets({"arr": [{"token": "x"}, {"name": "y"}]})
+        assert result["arr"][0]["token"] == "<redacted>"
+        assert result["arr"][1]["name"] == "y"
+
+    def test_redact_all_six_patterns(self):
+        cases = {
+            "user_key": "k",
+            "access_token": "t",
+            "client_secret": "s",
+            "user_password": "p",
+            "AUTH_HEADER": "a",
+            "user_pwd": "pw",
+        }
+        result = _redact_secrets(cases)
+        assert all(v == "<redacted>" for v in result.values()), result
+
+    def test_redact_no_match_passes_through(self):
+        result = _redact_secrets({"user_id": "42", "command": "ls"})
+        assert result == {"user_id": "42", "command": "ls"}
+
+    def test_redact_scalar_input_unchanged(self):
+        assert _redact_secrets("just a string") == "just a string"
+        assert _redact_secrets(42) == 42
+        assert _redact_secrets(None) is None
+
+    def test_redact_substring_match_is_conservative(self):
+        # "monkey" enthaelt "key" → bewusste False-Positive (lieber redact als leak)
+        result = _redact_secrets({"monkey": "X"})
+        assert result["monkey"] == "<redacted>"
+
+
+# ── ToolExecutionAudit ─────────────────────────────────────────────────────
+
+class TestToolExecutionAudit:
+    def test_disabled_when_script_missing(self, tmp_path):
+        nonexistent = tmp_path / "nonexistent.sh"
+        audit = ToolExecutionAudit(logger_path=nonexistent)
+        assert audit._enabled is False
+
+    def test_disabled_when_script_not_executable(self, tmp_path):
+        script = tmp_path / "not_exec.sh"
+        script.write_text("#!/bin/bash\necho hi\n")
+        script.chmod(0o644)  # no exec bit
+        audit = ToolExecutionAudit(logger_path=script)
+        assert audit._enabled is False
+
+    def test_enabled_when_script_executable(self, tmp_path):
+        script = tmp_path / "exec.sh"
+        script.write_text("#!/bin/bash\nexit 0\n")
+        script.chmod(0o700)
+        audit = ToolExecutionAudit(logger_path=script)
+        assert audit._enabled is True
+
+    def test_audit_noop_when_disabled(self, tmp_path):
+        audit = ToolExecutionAudit(logger_path=tmp_path / "missing.sh")
+        # Darf nicht raise + nicht subprocess.run aufrufen
+        with patch("subprocess.run") as mock_run:
+            audit.audit("agent-1", "tool-x", {"k": "v"})
+            mock_run.assert_not_called()
+
+    def test_audit_redacts_before_serialize(self, tmp_path):
+        script = tmp_path / "exec.sh"
+        script.write_text("#!/bin/bash\ncat > /dev/null\nexit 0\n")
+        script.chmod(0o700)
+        audit = ToolExecutionAudit(logger_path=script)
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stderr="")
+            audit.audit("a1", "tool", {"api_key": "SECRET", "name": "X"})
+            payload = mock_run.call_args.kwargs["input"]
+            data = json.loads(payload)
+            assert data["args"]["api_key"] == "<redacted>"
+            assert data["args"]["name"] == "X"
+            assert "SECRET" not in payload
+
+    def test_audit_fail_soft_on_timeout(self, tmp_path, caplog):
+        script = tmp_path / "exec.sh"
+        script.write_text("#!/bin/bash\nexit 0\n")
+        script.chmod(0o700)
+        audit = ToolExecutionAudit(logger_path=script, timeout=0.5)
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.side_effect = subprocess.TimeoutExpired(cmd="x", timeout=0.5)
+            with caplog.at_level(logging.ERROR, logger="agent.tool_audit"):
+                audit.audit("a1", "tool", {})  # darf nicht raise
+            assert "timeout" in caplog.text.lower()
+
+    def test_audit_fail_soft_on_nonzero_rc(self, tmp_path, caplog):
+        script = tmp_path / "exec.sh"
+        script.write_text("#!/bin/bash\nexit 0\n")
+        script.chmod(0o700)
+        audit = ToolExecutionAudit(logger_path=script)
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=1, stderr="oops")
+            with caplog.at_level(logging.ERROR, logger="agent.tool_audit"):
+                audit.audit("a1", "tool", {})
+            assert "rc=1" in caplog.text
+
+    def test_audit_fail_soft_on_oserror(self, tmp_path, caplog):
+        script = tmp_path / "exec.sh"
+        script.write_text("#!/bin/bash\nexit 0\n")
+        script.chmod(0o700)
+        audit = ToolExecutionAudit(logger_path=script)
+
+        with patch("subprocess.run", side_effect=PermissionError("nope")):
+            with caplog.at_level(logging.ERROR, logger="agent.tool_audit"):
+                audit.audit("a1", "tool", {})  # darf nicht raise
+            assert "spawn failed" in caplog.text
+
+    def test_audit_handles_non_serializable_args(self, tmp_path):
+        """Tool-Args mit nicht-JSON-serialisierbaren Objekten → default=str fallback."""
+        script = tmp_path / "exec.sh"
+        script.write_text("#!/bin/bash\ncat > /dev/null\nexit 0\n")
+        script.chmod(0o700)
+        audit = ToolExecutionAudit(logger_path=script)
+
+        class Weird:
+            def __str__(self):
+                return "weird-instance"
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stderr="")
+            audit.audit("a1", "tool", {"obj": Weird()})
+            payload = mock_run.call_args.kwargs["input"]
+            assert "weird-instance" in payload
+
+
+# ── Singleton ──────────────────────────────────────────────────────────────
+
+class TestSingleton:
+    def test_get_audit_returns_same_instance(self):
+        a1 = get_audit()
+        a2 = get_audit()
+        assert a1 is a2


### PR DESCRIPTION
## Summary
- Middleware-pattern hook into both tool dispatch paths (sequential + concurrent) in `agent/tool_executor.py`
- Logs every tool call BEFORE invocation to an external append-only NDJSON logger script (out-of-tree at `~/.hermes/audit_logs/audit-logger.sh`)
- Secret redaction (6 patterns case-insensitive substring) protects API keys/tokens/secrets/passwords/auth/pwd from leaking into audit log

## Components
- **NEW `agent/tool_audit.py`** (+149 LOC) — `ToolExecutionAudit` class, lazy singleton, recursive `_redact_secrets` helper
- **NEW `tests/test_tool_audit.py`** (+172 LOC) — 18 unit tests (redaction, fail-soft, singleton, mocked subprocess)
- **PATCH `agent/tool_executor.py`** (+22 LOC) — two insert points after pre-tool-call block hooks + guardrails, before `_invoke_tool()`

## Fail-Soft Contract (3 layers)
1. `subprocess.run(..., timeout=2.0)` with `TimeoutExpired` handler
2. All errors via `logger.error`, never raise
3. `try/except` wrapper in caller, `_enabled` gate in singleton init

Logger failures or timeouts NEVER block the actual tool execution.

## Secret Redaction
Case-insensitive substring match on: `key`, `token`, `secret`, `password`, `auth`, `pwd`. Walks dict and list-of-dict recursively. Conservative false-positives accepted (e.g. `monkey` → `<redacted>`) — preferring over-redaction to leak risk.

## External Dependency
The middleware shells out to `~/.hermes/audit_logs/audit-logger.sh`, a POSIX append-only logger with `flock` + tag-rotation. Lives outside this repo (system-specific). If absent or not executable, middleware self-disables with a one-time `logger.warning` and stays no-op.

## Test plan
- [x] All 18 new unit tests pass (`pytest tests/test_tool_audit.py -v`)
- [x] All 5 existing tool_executor regression tests pass (`tests/run_agent/test_tool_executor_contextvar_propagation.py`)
- [x] All 26 related tool-tests pass (`test_get_tool_definitions_cache_isolation`, `test_sanitize_tool_error`)
- [x] Live smoke test: real audit log entry written with redacted `api_key` field
- [ ] Reviewer: confirm middleware overhead acceptable for high-frequency tool callers (~5-20ms per call for subprocess fork+exec)

## Open Items (out-of-scope this PR)
- Async variant with `asyncio.create_subprocess_exec` (would avoid subprocess fork blocking)
- Per-tool redaction config instead of global regex patterns
- Tamper-detection via `chattr +a` on log files (requires root)