### PR TITLE
Feat: Webhook run model override

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -991,6 +991,18 @@ class MessageEvent:
     # completion notifications) that must bypass user authorization checks.
     internal: bool = False
 
+    # Per-event LLM provider/model override.
+    # When set, the gateway runner installs this as a session-scoped override
+    # in _session_model_overrides BEFORE the agent runs, so the dispatched
+    # task uses the requested provider regardless of the global default.
+    # Currently populated by the webhook adapter from per-subscription config
+    # (hermes webhook subscribe --provider <p> --model <m>); other adapters
+    # may opt in later. Keys mirror the existing override schema:
+    # {"model": str, "provider": str, "api_key": str?, "base_url": str?, "api_mode": str?}
+    # model/provider are required when set; the rest are optional and
+    # resolved from env / OAuth state when omitted (e.g. openai-codex).
+    provider_override: Optional[Dict[str, Any]] = None
+
     # Timestamps
     timestamp: datetime = field(default_factory=datetime.now)
     

--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -13,6 +13,8 @@ Each route defines:
   - skills: optional list of skills to load for the agent
   - deliver: where to send the response (github_comment, telegram, etc.)
   - deliver_extra: additional delivery config (repo, pr_number, chat_id)
+  - model: optional model name override for this route's agent runs
+  - provider: optional provider override for this route's agent runs
   - deliver_only: if true, skip the agent — the rendered prompt IS the
     message that gets delivered.  Use for external push notifications
     (Supabase, monitoring alerts, inter-agent pings) where zero LLM cost
@@ -558,6 +560,20 @@ class WebhookAdapter(BasePlatformAdapter):
         self._delivery_info_created[session_chat_id] = now
         self._prune_delivery_info(now)
 
+        # Per-subscription provider/model override. When set on the
+        # subscription, the gateway runner installs this as a session-scoped
+        # override before the agent runs, so this webhook's dispatch uses
+        # the requested provider regardless of the global default.
+        provider_override: Optional[Dict[str, Any]] = None
+        sub_provider = (route_config.get("provider") or "").strip()
+        sub_model = (route_config.get("model") or "").strip()
+        if sub_provider or sub_model:
+            provider_override = {}
+            if sub_provider:
+                provider_override["provider"] = sub_provider
+            if sub_model:
+                provider_override["model"] = sub_model
+
         # Build source and event
         source = self.build_source(
             chat_id=session_chat_id,
@@ -572,15 +588,20 @@ class WebhookAdapter(BasePlatformAdapter):
             source=source,
             raw_message=payload,
             message_id=delivery_id,
+            provider_override=provider_override,
         )
 
         logger.info(
-            "[webhook] %s event=%s route=%s prompt_len=%d delivery=%s",
+            "[webhook] %s event=%s route=%s prompt_len=%d delivery=%s%s",
             request.method,
             event_type,
             route_name,
             len(prompt),
             delivery_id,
+            (
+                f" override=provider:{sub_provider or '-'},model:{sub_model or '-'}"
+                if provider_override else ""
+            ),
         )
 
         # Non-blocking — return 202 Accepted immediately

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6535,6 +6535,67 @@ class GatewayRunner:
         # Otherwise control/session commands like /new or /help get silently
         # consumed as update answers instead of being dispatched normally.
         _quick_key = self._session_key_for_source(source)
+
+        # Per-event provider/model override (currently populated by the
+        # webhook adapter from per-subscription config). Resolve via the
+        # same switch_model pipeline the /model command uses, so OAuth
+        # providers (openai-codex) get correct base_url + api_mode rather
+        # than inheriting whatever the gateway default left in place.
+        # The override auto-clears when the session ends (existing pop
+        # calls in this file).
+        _ev_override = getattr(event, "provider_override", None)
+        if _ev_override and isinstance(_ev_override, dict):
+            try:
+                from hermes_cli.model_switch import switch_model as _ev_switch
+
+                _user_cfg = _load_gateway_config()
+                _cur_model = _resolve_gateway_model(_user_cfg)
+                _cur_provider = _user_cfg.get("provider", "") or ""
+                _ev_provider = (_ev_override.get("provider") or "").strip()
+                _ev_model = (_ev_override.get("model") or "").strip()
+                # Use the requested model if given, else the gateway default
+                # (switch_model will auto-detect on the target provider).
+                _raw_input = _ev_model or _cur_model
+                _result = _ev_switch(
+                    raw_input=_raw_input,
+                    current_provider=_cur_provider,
+                    current_model=_cur_model,
+                    current_base_url="",
+                    current_api_key="",
+                    is_global=False,
+                    explicit_provider=_ev_provider,
+                    user_providers=_user_cfg.get("providers", {}),
+                    custom_providers=_user_cfg.get("custom_providers"),
+                )
+                if getattr(_result, "success", False):
+                    self._session_model_overrides[_quick_key] = {
+                        "model": _result.new_model,
+                        "provider": _result.target_provider,
+                        "api_key": getattr(_result, "api_key", "") or "",
+                        "base_url": getattr(_result, "base_url", "") or "",
+                        "api_mode": getattr(_result, "api_mode", "") or "",
+                    }
+                    logger.info(
+                        "Per-event provider override applied: session=%s provider=%s model=%s base_url=%s",
+                        _quick_key[:30],
+                        _result.target_provider,
+                        _result.new_model,
+                        getattr(_result, "base_url", "") or "(default)",
+                    )
+                    if hasattr(self, "_evict_cached_agent"):
+                        try:
+                            self._evict_cached_agent(_quick_key)
+                        except Exception:
+                            pass
+                else:
+                    logger.warning(
+                        "Per-event provider override failed to resolve: provider=%s model=%s error=%s",
+                        _ev_provider, _ev_model,
+                        getattr(_result, "error_message", "(unknown)"),
+                    )
+            except Exception as _e:
+                logger.warning("Failed to apply event provider override: %s", _e, exc_info=True)
+
         _update_prompts = getattr(self, "_update_prompt_pending", {})
         if _update_prompts.get(_quick_key):
             raw = (event.text or "").strip()

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -11762,6 +11762,18 @@ def main():
         "--secret", default="", help="HMAC secret (auto-generated if omitted)"
     )
     wh_sub.add_argument(
+        "--provider",
+        default="",
+        help="Override LLM provider for this webhook (e.g. openai-codex, anthropic). "
+        "Defaults to the gateway's auto-selected provider.",
+    )
+    wh_sub.add_argument(
+        "--model",
+        default="",
+        help="Override model for this webhook (e.g. gpt-5.4, claude-sonnet-4-6). "
+        "Used together with --provider; defaults to the provider's default model.",
+    )
+    wh_sub.add_argument(
         "--deliver-only",
         action="store_true",
         help="Skip the agent — deliver the rendered prompt directly as the "

--- a/hermes_cli/webhook.py
+++ b/hermes_cli/webhook.py
@@ -168,6 +168,18 @@ def _cmd_subscribe(args):
     if args.deliver_chat_id:
         route["deliver_extra"] = {"chat_id": args.deliver_chat_id}
 
+    # Optional per-subscription provider/model override. Persisted in the
+    # subscription JSON; the webhook adapter forwards them on every dispatch
+    # so the agent runs through the requested provider regardless of the
+    # gateway's default (e.g. routing webhooks through openai-codex so
+    # native MCP tools fire over OAuth).
+    sub_provider = (getattr(args, "provider", "") or "").strip()
+    sub_model = (getattr(args, "model", "") or "").strip()
+    if sub_provider:
+        route["provider"] = sub_provider
+    if sub_model:
+        route["model"] = sub_model
+
     subs[name] = route
     _save_subscriptions(subs)
 
@@ -182,6 +194,8 @@ def _cmd_subscribe(args):
     else:
         print("  Events: (all)")
     print(f"  Deliver: {route['deliver']}")
+    if sub_provider or sub_model:
+        print(f"  Override: provider={sub_provider or '(default)'} model={sub_model or '(default)'}")
     if route.get("deliver_only"):
         print("  Mode: direct delivery (no agent, zero LLM cost)")
     if route.get("prompt"):
@@ -214,6 +228,11 @@ def _cmd_list(args):
         print(f"    URL:     {base_url}/webhooks/{name}")
         print(f"    Events:  {events}")
         print(f"    Deliver: {deliver}")
+        if route.get("provider") or route.get("model"):
+            print(
+                f"    Override: provider={route.get('provider') or '(default)'} "
+                f"model={route.get('model') or '(default)'}"
+            )
         print()
 
 

--- a/tests/gateway/test_webhook_adapter.py
+++ b/tests/gateway/test_webhook_adapter.py
@@ -835,3 +835,141 @@ class TestInsecureNoAuthSafetyRail:
         finally:
             await adapter.disconnect()
 
+
+# ===================================================================
+# Per-subscription provider/model override
+# ===================================================================
+
+
+class TestProviderOverride:
+    """A subscription's provider/model config rides the dispatched
+    MessageEvent so the gateway runner can install a session-scoped
+    override before the agent runs. The webhook adapter itself stays out
+    of provider resolution — it only forwards the hint."""
+
+    @pytest.mark.asyncio
+    async def test_override_attached_when_subscription_has_provider(self):
+        """When the subscription declares provider, the dispatched
+        MessageEvent.provider_override carries the value."""
+        routes = {
+            "ovr": {
+                "secret": _INSECURE_NO_AUTH,
+                "prompt": "task",
+                "provider": "openai-codex",
+                "model": "gpt-5.4",
+            }
+        }
+        adapter = _make_adapter(routes=routes)
+        captured = {}
+
+        async def _capture(event):
+            captured["event"] = event
+
+        adapter.handle_message = _capture
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post("/webhooks/ovr", json={"x": 1})
+            assert resp.status == 202
+            for _ in range(20):
+                if captured.get("event") is not None:
+                    break
+                await asyncio.sleep(0.01)
+
+        evt = captured["event"]
+        assert evt is not None, "handle_message was never invoked"
+        assert evt.provider_override == {
+            "provider": "openai-codex",
+            "model": "gpt-5.4",
+        }
+
+    @pytest.mark.asyncio
+    async def test_override_partial_provider_only(self):
+        """Provider without model still carries through (gateway uses provider
+        default model when model is absent)."""
+        routes = {
+            "ovr-p": {
+                "secret": _INSECURE_NO_AUTH,
+                "prompt": "task",
+                "provider": "openai-codex",
+            }
+        }
+        adapter = _make_adapter(routes=routes)
+        captured = {}
+
+        async def _capture(event):
+            captured["event"] = event
+
+        adapter.handle_message = _capture
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post("/webhooks/ovr-p", json={})
+            assert resp.status == 202
+            for _ in range(20):
+                if captured.get("event") is not None:
+                    break
+                await asyncio.sleep(0.01)
+
+        evt = captured["event"]
+        assert evt is not None
+        assert evt.provider_override == {"provider": "openai-codex"}
+
+    @pytest.mark.asyncio
+    async def test_no_override_when_subscription_silent(self):
+        """A subscription without provider/model produces no override
+        (gateway uses its global default)."""
+        routes = {"plain": {"secret": _INSECURE_NO_AUTH, "prompt": "task"}}
+        adapter = _make_adapter(routes=routes)
+        captured = {}
+
+        async def _capture(event):
+            captured["event"] = event
+
+        adapter.handle_message = _capture
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post("/webhooks/plain", json={})
+            assert resp.status == 202
+            for _ in range(20):
+                if captured.get("event") is not None:
+                    break
+                await asyncio.sleep(0.01)
+
+        evt = captured["event"]
+        assert evt is not None
+        assert evt.provider_override is None
+
+    @pytest.mark.asyncio
+    async def test_override_empty_strings_treated_as_absent(self):
+        """Empty-string provider/model fields don't produce an override."""
+        routes = {
+            "ovr-empty": {
+                "secret": _INSECURE_NO_AUTH,
+                "prompt": "task",
+                "provider": "",
+                "model": " ",
+            }
+        }
+        adapter = _make_adapter(routes=routes)
+        captured = {}
+
+        async def _capture(event):
+            captured["event"] = event
+
+        adapter.handle_message = _capture
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post("/webhooks/ovr-empty", json={})
+            assert resp.status == 202
+            for _ in range(20):
+                if captured.get("event") is not None:
+                    break
+                await asyncio.sleep(0.01)
+
+        evt = captured["event"]
+        assert evt is not None
+        assert evt.provider_override is None
+

--- a/website/docs/user-guide/messaging/webhooks.md
+++ b/website/docs/user-guide/messaging/webhooks.md
@@ -84,6 +84,8 @@ Routes define how different webhook sources are handled. Each route is a named e
 | `skills` | No | List of skill names to load for the agent run. |
 | `deliver` | No | Where to send the response: `github_comment`, `telegram`, `discord`, `slack`, `signal`, `sms`, `whatsapp`, `matrix`, `mattermost`, `homeassistant`, `email`, `dingtalk`, `feishu`, `wecom`, `weixin`, `bluebubbles`, `qqbot`, or `log` (default). |
 | `deliver_extra` | No | Additional delivery config — keys depend on `deliver` type (e.g. `repo`, `pr_number`, `chat_id`). Values support the same `{dot.notation}` templates as `prompt`. |
+| `model` | No | Model name override for this route's agent runs (e.g. `claude-sonnet-4-20250514`, `gpt-5.4`). When set, the gateway uses this model instead of the global default. Requires `provider` or resolves via the gateway's auto-detection. |
+| `provider` | No | Provider override for this route's agent runs (e.g. `anthropic`, `openai-codex`). Resolved via the `/model` pipeline — OAuth providers like `openai-codex` get their real endpoint and credentials automatically. |
 | `deliver_only` | No | If `true`, skip the agent entirely — the rendered `prompt` template becomes the literal message that gets delivered. Zero LLM cost, sub-second delivery. See [Direct Delivery Mode](#direct-delivery-mode) for use cases. Requires `deliver` to be a real target (not `log`). |
 
 ### Full example
@@ -327,6 +329,61 @@ hermes webhook subscribe antenna-matches \
 
 ---
 
+## Per-Route Provider/Model Override {#per-route-override}
+
+By default, webhook-triggered agent runs use the gateway's globally configured model and provider. You can override these on a per-route basis so that specific webhooks route through a different provider — for example, routing a CI webhook through `openai-codex` (which supports MCP tool execution over OAuth) while other webhooks use the default provider.
+
+### How it works
+
+When a route specifies `provider` and/or `model`, the webhook adapter attaches the override to the dispatched `MessageEvent`. The gateway runner resolves it through the same `switch_model` pipeline used by the `/model` slash command — this means OAuth providers (like `openai-codex`) are fully resolved with correct `base_url` and credentials, not just a label swap.
+
+The override is session-scoped: it applies only to the agent run triggered by that webhook, then auto-clears when the session resets.
+
+### Static route example
+
+```yaml
+platforms:
+  webhook:
+    enabled: true
+    extra:
+      routes:
+        codex-ci:
+          secret: "ci-webhook-secret"
+          prompt: "Analyze the build result: {__raw__}"
+          provider: "openai-codex"
+          model: "gpt-5.4"
+          deliver: "log"
+```
+
+### Dynamic subscription via CLI
+
+```bash
+hermes webhook subscribe codex-ci \
+  --provider openai-codex \
+  --model gpt-5.4 \
+  --secret ci-webhook-secret \
+  --deliver log \
+  --prompt "Analyze the build result: {__raw__}"
+```
+
+The `--provider` and `--model` flags are persisted in the subscription and shown in `hermes webhook list`:
+
+```
+◆ codex-ci
+    URL:     http://localhost:8644/webhooks/codex-ci
+    Events:  (all)
+    Deliver: log
+    Override: provider=openai-codex model=gpt-5.4
+```
+
+### Partial overrides
+
+- `provider` only: the gateway auto-detects the default model for that provider.
+- `model` only: resolves the model on the current default provider.
+- Both: uses the exact provider and model specified.
+
+---
+
 ## Dynamic Subscriptions (CLI) {#dynamic-subscriptions}
 
 In addition to static routes in `config.yaml`, you can create webhook subscriptions dynamically using the `hermes webhook` CLI command. This is especially useful when the agent itself needs to set up event-driven triggers.
@@ -340,6 +397,17 @@ hermes webhook subscribe github-issues \
   --deliver telegram \
   --deliver-chat-id "-100123456789" \
   --description "Triage new GitHub issues"
+```
+
+Optional flags `--provider` and `--model` override the gateway's default LLM backend for this subscription (see [Per-Route Provider/Model Override](#per-route-override)):
+
+```bash
+hermes webhook subscribe codex-ci \
+  --provider openai-codex \
+  --model gpt-5.4 \
+  --secret ci-webhook-secret \
+  --deliver log \
+  --prompt "Analyze the build result: {__raw__}"
 ```
 
 This returns the webhook URL and an auto-generated HMAC secret. Configure your service to POST to that URL.


### PR DESCRIPTION
## What does this PR do?

Adds per-route model/provider override support for webhook subscriptions, allowing each webhook route to target a specific LLM provider and model regardless of the gateway's global default. This enables integrations (e.g. external orchestrators like PaperClip) to route specific webhooks through a particular provider, for example, routing through openai-codex so that Hermes' native MCP tools fire over OAuth rather than falling through a bridge text-relay path.

The implementation uses the existing `switch_model` pipeline (same code path as the `/model` slash command) to fully resolve provider credentials, including OAuth providers like openai-codex. The override is carried on the MessageEvent from the webhook adapter and installed into `_session_model_overrides` by the gateway runner before the agent runs, then auto-clears when the session ends.

This is a revival and improved version of two previously closed PRs:
- #12909 (kagura-agent):  simple approach that wrote directly to _session_model_overrides from the adapter
- #18382 (MachoMaheen): improved approach with MessageEvent.provider_override field and switch_model resolution

This PR takes the #18382 approach (clean separation of concerns, proper OAuth resolution) while adapting it to the current codebase.

## Related Issue

Fixes #12788 

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [X] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- gateway/platforms/base.py: Added provider_override: Optional[Dict[str, Any]] = None field to MessageEvent dataclass. Carries per-event provider/model hints from webhook adapter to gateway runner.
- gateway/platforms/webhook.py: Updated route config docstring to document model and provider fields. Added extraction of provider/model from route_config, construction of provider_override dict, injection into MessageEvent, and extended log output to show override info on accept.
- gateway/run.py: Added handler block in _handle_message() that reads provider_override from the incoming MessageEvent, resolves it via switch_model (same pipeline as /model command), writes the fully-resolved credentials into _session_model_overrides, and evicts the cached agent so the next turn picks up the override. Falls back gracefully if switch_model fails (logs warning, continues with global default).
- hermes_cli/main.py: Added --provider and --model argparse flags to the webhook subscribe subcommand.
- hermes_cli/webhook.py: Added persistence of provider/model to webhook_subscriptions.json, display of override info on subscribe output, and display in webhook list.
  - tests/gateway/test_webhook_adapter.py: Added TestProviderOverride class with 4 tests:
  - test_override_attached_when_subscription_has_provider: full provider+model override
  - test_override_partial_provider_only: provider-only override (model falls to default)
  - test_no_override_when_subscription_silent: no override when route has no provider/model
  - test_override_empty_strings_treated_as_absent: empty/whitespace strings don't produce override 

## How to Test

1. CLI subscribe with override:
    - ```
      hermes webhook subscribe my-route \
        --secret INSECURE_NO_AUTH \
        --provider openai-codex \
        --model gpt-5.4 \
        --deliver log \
        --prompt 'Summarize {action}'
      ```
    - Verify the output shows Override: provider=openai-codex model=gpt-5.4.
2. CLI list displays override:
    - `hermes webhook list`
    - Verify the route shows Override: provider=openai-codex model=gpt-5.4.
3. Webhook POST triggers correct provider:
    - ```
      curl -X POST -H 'Content-Type: application/json' \
        -d '{"action": "deploy"}' \
        http://localhost:8644/webhooks/my-route
      ```
    - Verify in gateway logs: Per-event provider override applied: session=... provider=openai-codex model=gpt-5.4 base_url=https://chatgpt.com/backend-api/codex
4. Unit tests:
    - `pytest tests/gateway/test_webhook_adapter.py -v`
    - All 58 tests pass (54 existing + 4 new TestProviderOverride).


## Checklist

<!-- Complete these before requesting review. -->

### Code

- [X] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [X] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [X] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [X] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [X] I've run `pytest tests/ -q` and all tests pass
- [X] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [X] I've tested on my platform: Fedora 44 system python, Docker with podman-Sandboxing

### Documentation & Housekeeping

- [X] I've updated relevant documentation (README, `docs/`, docstrings)
- [x] ~~I've updated `cli-config.yaml.example` if I added/changed config keys~~ _(not required, no webhook specific section with examples)_
- [x] ~~I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows~~
- [X] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] ~~I've updated tool descriptions/schemas if I changed tool behavior~~ _(not an agent tool)_
