### PR TITLE
feat(feishu): log original message create_time for debugging delivery delays

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -2158,14 +2158,23 @@ class FeishuAdapter(BasePlatformAdapter):
         )
         reply_to_text = await self._fetch_message_text(reply_to_message_id) if reply_to_message_id else None
 
+        # Extract original message creation time from Feishu event
+        create_time_raw = getattr(message, "create_time", None)
+        if create_time_raw:
+            # Feishu create_time is in milliseconds
+            msg_timestamp = datetime.fromtimestamp(int(create_time_raw) / 1000)
+        else:
+            msg_timestamp = datetime.now()
+
         logger.info(
-            "[Feishu] Inbound %s message received: id=%s type=%s chat_id=%s text=%r media=%d",
+            "[Feishu] Inbound %s message received: id=%s type=%s chat_id=%s text=%r media=%d create_time=%s",
             "dm" if chat_type == "p2p" else "group",
             message_id,
             inbound_type.value,
             getattr(message, "chat_id", "") or "",
             text[:120],
             len(media_urls),
+            msg_timestamp.isoformat() if create_time_raw else "N/A",
         )
 
         chat_id = getattr(message, "chat_id", "") or ""
@@ -2190,7 +2199,7 @@ class FeishuAdapter(BasePlatformAdapter):
             media_types=media_types,
             reply_to_message_id=reply_to_message_id,
             reply_to_text=reply_to_text,
-            timestamp=datetime.now(),
+            timestamp=msg_timestamp,
         )
         await self._dispatch_inbound_event(normalized)
 


### PR DESCRIPTION
## Problem
When Feishu WebSocket disconnects, messages can arrive hours after being sent. The current code uses `datetime.now()` for the message timestamp, making it impossible to diagnose delivery delays.

## Solution
Extract `create_time` from Feishu SDK `EventMessage` and:
1. Include it in the inbound message log (`create_time=ISO format`)
2. Use it as `MessageEvent.timestamp` instead of `datetime.now()`

## Example
Before: `Inbound dm message received: id=xxx text='善存' ...`
After:  `Inbound dm message received: id=xxx text='善存' ... create_time=2026-05-21T23:00:00+08:00`

This makes it clear the message was sent at 23:00 but processed at 06:28 — a 7.5 hour delivery delay.

## Notes
- `EventMessage.create_time` is milliseconds since epoch (standard Feishu format)
- Falls back to `datetime.now()` if create_time is missing
- Feels free to modify the log format or timestamp handling as needed