### PR TITLE
fix(qqbot): add INTERACTION_CREATE intent + preserve original filename

### DIFF
--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -704,6 +704,7 @@ class QQAdapter(BasePlatformAdapter):
             "d": {
                 "token": f"QQBot {token}",
                 "intents": (1 << 25)
+                           | (1 << 26)  # INTERACTION_CREATE (button clicks)
                            | (1 << 30)
                            | (
                                    1 << 12
@@ -1607,7 +1608,7 @@ class QQAdapter(BasePlatformAdapter):
             elif ct.startswith("image/"):
                 # Image: download and cache locally.
                 try:
-                    cached_path = await self._download_and_cache(url, ct)
+                    cached_path = await self._download_and_cache(url, ct, filename)
                     if cached_path and os.path.isfile(cached_path):
                         image_urls.append(cached_path)
                         image_media_types.append(ct or "image/jpeg")
@@ -1622,7 +1623,7 @@ class QQAdapter(BasePlatformAdapter):
             else:
                 # Other attachments (video, file, etc.): record as text.
                 try:
-                    cached_path = await self._download_and_cache(url, ct)
+                    cached_path = await self._download_and_cache(url, ct, filename)
                     if cached_path:
                         other_attachments.append(f"[Attachment: {filename or ct}]")
                 except Exception as exc:
@@ -1636,8 +1637,19 @@ class QQAdapter(BasePlatformAdapter):
             "attachment_info": attachment_info,
         }
 
-    async def _download_and_cache(self, url: str, content_type: str) -> Optional[str]:
-        """Download a URL and cache it locally."""
+    async def _download_and_cache(
+        self,
+        url: str,
+        content_type: str,
+        original_filename: Optional[str] = None,
+    ) -> Optional[str]:
+        """Download a URL and cache it locally.
+
+        Args:
+            url: The URL to download from.
+            content_type: MIME type of the attachment.
+            original_filename: Original filename from the QQ message (preferred).
+        """
         from tools.url_safety import is_safe_url
 
         if not is_safe_url(url):
@@ -1668,7 +1680,8 @@ class QQAdapter(BasePlatformAdapter):
             # Convert to .wav using ffmpeg so STT engines can process it.
             return await self._convert_audio_to_wav(data, url)
         else:
-            filename = Path(urlparse(url).path).name or "qq_attachment"
+            # Prefer original_filename from QQ message, then fall back to URL path.
+            filename = original_filename or Path(urlparse(url).path).name or "qq_attachment"
             return cache_document_from_bytes(data, filename)
 
     @staticmethod


### PR DESCRIPTION
## Summary

Two bugfixes for the QQBot adapter:

### 1. Missing INTERACTION_CREATE intent (button clicks broken)
Added `(1 << 26)  # INTERACTION_CREATE` to the intents flags. Without this, button click interactions are silently ignored by the QQ platform gateway.

### 2. Attachment filename extension lost
`_download_and_cache()` was using the URL path as the filename, losing the original extension (e.g. `.md` files were saved without extension). Now passes the `original_filename` from the QQ message so extensions are preserved.

## Files changed
- `gateway/platforms/qqbot/adapter.py`

---

*Submitted via Hermes Agent on behalf of ericshonnon-maker*