### PR TITLE
fix(file-safety): block writes to event hooks

### DIFF
--- a/agent/file_safety.py
+++ b/agent/file_safety.py
@@ -97,13 +97,13 @@ def is_write_denied(path: str) -> bool:
         if resolved.startswith(prefix):
             return True
 
-    # Hermes control-plane files: block both the ACTIVE profile's view
+    # Hermes control-plane paths: block both the ACTIVE profile's view
     # (hermes_home) AND the global root view. Without the root pass, a
-    # profile-mode session leaves <root>/auth.json + <root>/config.yaml
-    # writable — letting a prompt-injected write_file overwrite the global
-    # files that every profile inherits from (same shape as #15981).
+    # profile-mode session leaves shared root control files writable.
+    # hooks/ is included because event hook handlers are auto-loaded Python
+    # modules, so file-writing tools should not create or modify them.
     control_file_names = ("auth.json", "config.yaml", "webhook_subscriptions.json")
-    mcp_tokens_dir_name = "mcp-tokens"
+    control_dir_names = ("mcp-tokens", "hooks")
 
     hermes_dirs = []
     for base in (_hermes_home_path(), _hermes_root_path()):
@@ -121,12 +121,13 @@ def is_write_denied(path: str) -> bool:
                     return True
             except Exception:
                 continue
-        try:
-            mcp_real = os.path.realpath(os.path.join(base_real, mcp_tokens_dir_name))
-            if resolved == mcp_real or resolved.startswith(mcp_real + os.sep):
-                return True
-        except Exception:
-            pass
+        for name in control_dir_names:
+            try:
+                control_dir_real = os.path.realpath(os.path.join(base_real, name))
+                if resolved == control_dir_real or resolved.startswith(control_dir_real + os.sep):
+                    return True
+            except OSError:
+                continue
 
     safe_root = get_safe_write_root()
     if safe_root and not (resolved == safe_root or resolved.startswith(safe_root + os.sep)):

--- a/tests/tools/test_file_operations.py
+++ b/tests/tools/test_file_operations.py
@@ -68,10 +68,12 @@ class TestIsWriteDenied:
             "webhook_subscriptions.json",
             "mcp-tokens/token1.json",
             "mcp-tokens/subdir/token2.json",
+            "hooks/example/HOOK.yaml",
+            "hooks/example/handler.py",
         ],
     )
-    def test_hermes_control_files_and_mcp_tokens_denied(self, path):
-        """Hermes control files and mcp-tokens entries must be write-denied."""
+    def test_hermes_control_files_and_control_dirs_denied(self, path):
+        """Hermes control files and auto-loaded control dirs must be write-denied."""
         from hermes_constants import get_hermes_home
         hermes_home = get_hermes_home()
         full_path = str(hermes_home / path)
@@ -83,10 +85,11 @@ class TestIsWriteDenied:
             "dummy/../config.yaml",
             "./auth.json",
             "mcp-tokens/../config.yaml",
+            "hooks/example/../example/handler.py",
         ],
     )
-    def test_hermes_control_files_traversal_denied(self, path):
-        """Path traversal attempts to control files must be blocked by realpath."""
+    def test_hermes_control_paths_traversal_denied(self, path):
+        """Path traversal attempts to control paths must be blocked by realpath."""
         from hermes_constants import get_hermes_home
         hermes_home = get_hermes_home()
         full_path = str(hermes_home / path)
@@ -139,6 +142,18 @@ class TestIsWriteDenied:
         assert _is_write_denied(str(root / "mcp-tokens" / "tok.json")) is True
         # The directory itself must also be denied (not just files inside)
         assert _is_write_denied(str(root / "mcp-tokens")) is True
+
+    def test_hooks_dir_protected_in_profile_mode(self, tmp_path, monkeypatch):
+        """Event hooks under profile AND under root must both be denied."""
+        root = tmp_path / "hermes"
+        profile = root / "profiles" / "coder"
+        profile.mkdir(parents=True)
+        monkeypatch.setenv("HERMES_HOME", str(profile))
+
+        assert _is_write_denied(str(profile / "hooks" / "x" / "handler.py")) is True
+        assert _is_write_denied(str(root / "hooks" / "x" / "handler.py")) is True
+        # The directory itself must also be denied (not just files inside)
+        assert _is_write_denied(str(root / "hooks")) is True
 
 
 


### PR DESCRIPTION

## What does this PR do?

Prevents file-writing tools from creating or modifying event hook files under Hermes control-plane hook directories.

Event hooks are loaded into the Hermes process as Python modules from `HERMES_HOME/hooks`. The existing file safety rules already protect Hermes control-plane paths such as `.env`, `auth.json`, `config.yaml`, `webhook_subscriptions.json`, and `mcp-tokens`. This change extends the same write protection to `hooks/` for both the active profile directory and the root Hermes directory.

This is a narrow hardening change. It does not change hook discovery or manual hook installation behavior; it only prevents agent file-write paths from writing into auto-loaded event hook directories.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/file_safety.py`
  - Treat `hooks/` as a Hermes control-plane directory, alongside `mcp-tokens/`.
  - Deny writes to `hooks/` under both the active `HERMES_HOME` profile and the root Hermes directory.
  - Preserve existing exact-file protections and `HERMES_WRITE_SAFE_ROOT` behavior.

- `tests/tools/test_file_operations.py`
  - Add regression coverage for writes to `hooks/example/HOOK.yaml` and `hooks/example/handler.py`.
  - Add traversal coverage for resolved paths under `hooks/`.
  - Add profile-mode coverage proving both profile-level and root-level `hooks/` directories are protected.

## How to Test

1. Run the focused file safety regression tests:

```bash
/private/tmp/hermes-agent-pr-venv/bin/python -m pytest -o addopts='' \
  tests/tools/test_file_operations.py::TestIsWriteDenied \
  -q
```

Result:

```text
27 passed in 0.34s
```

2. Run the adjacent write-deny safety tests:

```bash
/private/tmp/hermes-agent-pr-venv/bin/python -m pytest -o addopts='' \
  tests/tools/test_write_deny.py tests/tools/test_file_write_safety.py \
  -q
```

Result:

```text
36 passed in 0.23s
```

3. Check diff hygiene:

```bash
git diff --check
```

Result: no output.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5, Python 3.13.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — uses existing `os.path.realpath` and `os.sep` path logic
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## For New Skills

N/A

## Screenshots / Logs

```text
$ /private/tmp/hermes-agent-pr-venv/bin/python -m pytest -o addopts='' \
  tests/tools/test_file_operations.py::TestIsWriteDenied \
  -q
...........................                                              [100%]
27 passed in 0.34s

$ /private/tmp/hermes-agent-pr-venv/bin/python -m pytest -o addopts='' \
  tests/tools/test_write_deny.py tests/tools/test_file_write_safety.py \
  -q
....................................                                     [100%]
36 passed in 0.23s

$ git diff --check
# no output
```
