### PR TITLE
fix(image): route direct calls through plugin providers

### DIFF
--- a/tests/tools/test_image_generation_plugin_dispatch.py
+++ b/tests/tools/test_image_generation_plugin_dispatch.py
@@ -23,11 +23,30 @@ class _FakeCodexProvider(ImageGenProvider):
         return {
             "success": True,
             "image": "/tmp/codex-test.png",
-            "model": "gpt-5.2-codex",
+            "model": kwargs.get("model", "gpt-5.2-codex"),
             "prompt": prompt,
             "aspect_ratio": aspect_ratio,
             "provider": "codex",
+            "kwargs": kwargs,
         }
+
+
+class _DelegatingFalProvider(ImageGenProvider):
+    @property
+    def name(self) -> str:
+        return "fal"
+
+    def generate(self, prompt, aspect_ratio="landscape", **kwargs):
+        from tools import image_generation_tool
+
+        return json.loads(
+            image_generation_tool.image_generate_tool(
+                prompt=prompt,
+                aspect_ratio=aspect_ratio,
+                num_images=kwargs.get("num_images"),
+                seed=kwargs.get("seed"),
+            )
+        )
 
 
 class TestPluginDispatch:
@@ -97,3 +116,62 @@ class TestPluginDispatch:
         assert payload["success"] is True
         assert payload["provider"] == "codex"
         assert payload["aspect_ratio"] == "portrait"
+
+    def test_direct_image_generate_tool_uses_explicit_plugin_provider(self, monkeypatch, tmp_path):
+        from tools import image_generation_tool
+        from hermes_cli import plugins as plugins_module
+        from agent import image_gen_registry as registry_module
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        (tmp_path / "config.yaml").write_text(
+            "image_gen:\n  provider: codex\n  model: gpt-image-test\n"
+        )
+
+        monkeypatch.setattr(image_generation_tool, "_read_configured_image_provider", lambda: "codex")
+        monkeypatch.setattr(image_generation_tool, "_read_configured_image_model", lambda: "gpt-image-test")
+        monkeypatch.setattr(plugins_module, "_ensure_plugins_discovered", lambda force=False: None)
+        monkeypatch.setattr(registry_module, "get_provider", lambda name: _FakeCodexProvider() if name == "codex" else None)
+
+        result = image_generation_tool.image_generate_tool(
+            prompt="draw direct cat",
+            aspect_ratio="square",
+            num_images=2,
+            seed=123,
+        )
+        payload = json.loads(result)
+
+        assert payload["success"] is True
+        assert payload["provider"] == "codex"
+        assert payload["model"] == "gpt-image-test"
+        assert payload["prompt"] == "draw direct cat"
+        assert payload["aspect_ratio"] == "square"
+        assert payload["kwargs"]["num_images"] == 2
+        assert payload["kwargs"]["seed"] == 123
+
+    def test_direct_image_generate_tool_does_not_recurse_for_fal_plugin(self, monkeypatch, tmp_path):
+        from tools import image_generation_tool
+        from hermes_cli import plugins as plugins_module
+        from agent import image_gen_registry as registry_module
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        (tmp_path / "config.yaml").write_text("image_gen:\n  provider: fal\n")
+
+        monkeypatch.setattr(image_generation_tool, "_read_configured_image_provider", lambda: "fal")
+        monkeypatch.setattr(image_generation_tool, "_read_configured_image_model", lambda: None)
+        monkeypatch.setattr(plugins_module, "_ensure_plugins_discovered", lambda force=False: None)
+        monkeypatch.setattr(registry_module, "get_provider", lambda name: _DelegatingFalProvider() if name == "fal" else None)
+        monkeypatch.setattr(image_generation_tool, "fal_key_is_configured", lambda: False)
+        monkeypatch.setattr(image_generation_tool, "_resolve_managed_fal_gateway", lambda: None)
+
+        result = image_generation_tool.image_generate_tool(
+            prompt="draw direct fal cat",
+            aspect_ratio="square",
+            num_images=2,
+            seed=123,
+        )
+        payload = json.loads(result)
+
+        assert payload["success"] is False
+        assert payload["error_type"] == "ValueError"
+        assert "Image generation is unavailable" in payload["error"]
+        assert "maximum recursion depth" not in payload["error"]

--- a/tools/image_generation_tool.py
+++ b/tools/image_generation_tool.py
@@ -70,6 +70,7 @@ from tools.tool_backend_helpers import (
 )
 
 logger = logging.getLogger(__name__)
+_plugin_dispatch_state = threading.local()
 
 
 # ---------------------------------------------------------------------------
@@ -566,6 +567,22 @@ def image_generate_tool(
     Returns a JSON string with ``{"success": bool, "image": url | None,
     "error": str, "error_type": str}``.
     """
+    # Route direct Python callers through the same explicit plugin-provider
+    # dispatch path as the registered tool handler. An unset provider still
+    # falls through to the legacy in-tree FAL backend for compatibility.
+    if not getattr(_plugin_dispatch_state, "active", False):
+        dispatched = _dispatch_to_plugin_provider(
+            prompt,
+            aspect_ratio,
+            num_inference_steps=num_inference_steps,
+            guidance_scale=guidance_scale,
+            num_images=num_images,
+            output_format=output_format,
+            seed=seed,
+        )
+        if dispatched is not None:
+            return dispatched
+
     model_id, meta = _resolve_fal_model()
 
     debug_call_data = {
@@ -887,7 +904,11 @@ def _read_configured_image_provider():
     return None
 
 
-def _dispatch_to_plugin_provider(prompt: str, aspect_ratio: str):
+def _dispatch_to_plugin_provider(
+    prompt: str,
+    aspect_ratio: str,
+    **provider_kwargs: Any,
+):
     """Route the call to a plugin-registered provider when one is selected.
 
     Returns a JSON string on dispatch, or ``None`` to fall through to the
@@ -941,10 +962,19 @@ def _dispatch_to_plugin_provider(prompt: str, aspect_ratio: str):
         })
 
     try:
-        kwargs = {"prompt": prompt, "aspect_ratio": aspect_ratio}
+        kwargs = {
+            "prompt": prompt,
+            "aspect_ratio": aspect_ratio,
+            **{k: v for k, v in provider_kwargs.items() if v is not None},
+        }
         if configured_model:
             kwargs["model"] = configured_model
-        result = provider.generate(**kwargs)
+        previous_active = getattr(_plugin_dispatch_state, "active", False)
+        _plugin_dispatch_state.active = True
+        try:
+            result = provider.generate(**kwargs)
+        finally:
+            _plugin_dispatch_state.active = previous_active
     except Exception as exc:
         logger.warning(
             "Image gen provider '%s' raised: %s",


### PR DESCRIPTION
## Summary
- route direct Python image_generate_tool callers through explicitly configured image_gen plugin providers
- preserve legacy in-tree FAL fallback for unset provider and nested FAL plugin delegation
- add regression coverage for direct plugin dispatch, kwargs/model forwarding, and FAL recursion guard

## Verification
- python -m pytest tests/tools/test_image_generation_plugin_dispatch.py tests/tools/test_image_generation.py tests/tools/test_image_generation_env.py tests/agent/test_image_gen_registry.py tests/hermes_cli/test_image_gen_picker.py tests/plugins/image_gen/test_fal_provider.py -q
- python -m compileall -q tools/image_generation_tool.py tests/tools/test_image_generation_plugin_dispatch.py
- git diff --check
- Codex review verdict: PASS