### PR TITLE
feat(image_gen): add AWS Bedrock Stability AI provider

### DIFF
--- a/plugins/image_gen/bedrock-stability/__init__.py
+++ b/plugins/image_gen/bedrock-stability/__init__.py
@@ -1,0 +1,454 @@
+"""AWS Bedrock Stability AI image generation backend.
+
+Exposes Stability AI's three currently-active text-to-image models on Bedrock:
+
+* ``stability.sd3-5-large-v1:0`` — Stable Diffusion 3.5 Large (default)
+* ``stability.stable-image-core-v1:1`` — Stable Image Core (fast tier)
+* ``stability.stable-image-ultra-v1:1`` — Stable Image Ultra (highest quality)
+
+All three share the same request/response envelope on
+``bedrock-runtime.invoke_model`` (verified against the AWS docs and live API
+calls). Currently only available in ``us-west-2``.
+
+Schema reference:
+    https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-stability-diffusion.html
+
+Authentication piggybacks on the standard AWS credential chain via boto3 —
+env vars, ``~/.aws/credentials``, ``AWS_PROFILE``, EC2/ECS/EKS instance roles,
+and ``AWS_BEARER_TOKEN_BEDROCK`` are all honored. We share the same probes as
+the inference Bedrock plugin (``agent.bedrock_adapter``) so a user with Bedrock
+inference already configured gets image generation for free.
+
+Selection precedence for region (first hit wins):
+
+1. ``image_gen.bedrock-stability.region`` in ``config.yaml``
+2. ``bedrock.region`` in ``config.yaml`` (shared with the inference provider)
+3. ``AWS_REGION`` / ``AWS_DEFAULT_REGION``
+4. boto3/botocore configured region (from ``~/.aws/config``)
+5. ``us-west-2`` fallback (the only region where Stability text-to-image is
+   currently ACTIVE — ``us-east-1`` only has Stability editing tools, not
+   text-to-image)
+
+Selection precedence for model (first hit wins):
+
+1. ``image_gen.bedrock-stability.model`` in ``config.yaml``
+2. ``DEFAULT_MODEL`` (``stability.sd3-5-large-v1:0``)
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from typing import Any, Dict, List, Optional
+
+from agent.image_gen_provider import (
+    DEFAULT_ASPECT_RATIO,
+    ImageGenProvider,
+    error_response,
+    resolve_aspect_ratio,
+    save_b64_image,
+    success_response,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Model catalog
+# ---------------------------------------------------------------------------
+
+SD3_5_LARGE_MODEL_ID = "stability.sd3-5-large-v1:0"
+STABLE_IMAGE_CORE_MODEL_ID = "stability.stable-image-core-v1:1"
+STABLE_IMAGE_ULTRA_MODEL_ID = "stability.stable-image-ultra-v1:1"
+
+_MODELS: Dict[str, Dict[str, Any]] = {
+    SD3_5_LARGE_MODEL_ID: {
+        "display": "Stable Diffusion 3.5 Large",
+        "speed": "~10s",
+        "strengths": "Flagship general-purpose; 8B params; high prompt adherence",
+        "price": "varies",
+    },
+    STABLE_IMAGE_CORE_MODEL_ID: {
+        "display": "Stable Image Core",
+        "speed": "~5s",
+        "strengths": "Fast and affordable; ideal for high-volume generation",
+        "price": "varies",
+    },
+    STABLE_IMAGE_ULTRA_MODEL_ID: {
+        "display": "Stable Image Ultra",
+        "speed": "~15s",
+        "strengths": "Highest quality; photorealistic; premium imagery",
+        "price": "varies",
+    },
+}
+
+DEFAULT_MODEL = SD3_5_LARGE_MODEL_ID
+
+# Stability returns appropriate dimensions natively from these aspect ratios —
+# no manual width/height math. Documented enum:
+# 16:9, 1:1, 21:9, 2:3, 3:2, 4:5, 5:4, 9:16, 9:21
+_ASPECT_RATIO_MAP: Dict[str, str] = {
+    "landscape": "16:9",
+    "square": "1:1",
+    "portrait": "9:16",
+}
+
+
+# ---------------------------------------------------------------------------
+# Config helpers
+# ---------------------------------------------------------------------------
+
+
+def _load_image_gen_config() -> Dict[str, Any]:
+    """Return the ``image_gen`` section of ``config.yaml`` ({} on failure)."""
+    try:
+        from hermes_cli.config import load_config
+
+        cfg = load_config()
+        section = cfg.get("image_gen") if isinstance(cfg, dict) else None
+        return section if isinstance(section, dict) else {}
+    except Exception as exc:
+        logger.debug("Could not load image_gen config: %s", exc)
+        return {}
+
+
+def _load_root_config() -> Dict[str, Any]:
+    """Return the full top-level config dict ({} on failure)."""
+    try:
+        from hermes_cli.config import load_config
+
+        cfg = load_config()
+        return cfg if isinstance(cfg, dict) else {}
+    except Exception as exc:
+        logger.debug("Could not load config: %s", exc)
+        return {}
+
+
+def _backend_config() -> Dict[str, Any]:
+    """Return the ``image_gen.bedrock-stability`` config block ({} on failure)."""
+    cfg = _load_image_gen_config()
+    block = cfg.get("bedrock-stability") if isinstance(cfg.get("bedrock-stability"), dict) else {}
+    return block if isinstance(block, dict) else {}
+
+
+def _resolve_region() -> str:
+    """Resolve the AWS region for Bedrock Stability calls.
+
+    Defaults to ``us-west-2`` because that's the only region where Stability
+    text-to-image models are currently ACTIVE on Bedrock — differs from the
+    inference plugin's ``us-east-1`` default for that reason.
+    """
+    backend_cfg = _backend_config()
+    region = backend_cfg.get("region")
+    if isinstance(region, str) and region.strip():
+        return region.strip()
+
+    root = _load_root_config()
+    bedrock_cfg = root.get("bedrock") if isinstance(root.get("bedrock"), dict) else {}
+    if isinstance(bedrock_cfg, dict):
+        region = bedrock_cfg.get("region")
+        if isinstance(region, str) and region.strip():
+            return region.strip()
+
+    env_region = (
+        os.environ.get("AWS_REGION", "").strip()
+        or os.environ.get("AWS_DEFAULT_REGION", "").strip()
+    )
+    if env_region:
+        return env_region
+
+    # Try botocore session for ~/.aws/config region.
+    try:
+        import botocore.session  # type: ignore
+
+        session_region = botocore.session.Session().get_config_variable("region")
+        if isinstance(session_region, str) and session_region.strip():
+            return session_region.strip()
+    except Exception:
+        pass
+
+    return "us-west-2"
+
+
+def _resolve_model() -> str:
+    """Resolve which Stability model to use (config override → default)."""
+    backend_cfg = _backend_config()
+    model = backend_cfg.get("model")
+    if isinstance(model, str) and model.strip():
+        candidate = model.strip()
+        if candidate in _MODELS:
+            return candidate
+        logger.warning(
+            "image_gen.bedrock-stability.model=%r is not in the catalog; "
+            "falling back to default %s",
+            candidate,
+            DEFAULT_MODEL,
+        )
+    return DEFAULT_MODEL
+
+
+# ---------------------------------------------------------------------------
+# Provider
+# ---------------------------------------------------------------------------
+
+
+class BedrockStabilityImageGenProvider(ImageGenProvider):
+    """AWS Bedrock Stability AI backend (SD 3.5 Large / Core / Ultra)."""
+
+    @property
+    def name(self) -> str:
+        return "bedrock-stability"
+
+    @property
+    def display_name(self) -> str:
+        return "AWS Bedrock Stability AI"
+
+    def is_available(self) -> bool:
+        # Cheap probe: boto3 importable AND some AWS credential resolvable.
+        try:
+            import boto3  # noqa: F401
+        except ImportError:
+            return False
+        try:
+            from agent.bedrock_adapter import has_aws_credentials
+            return has_aws_credentials()
+        except Exception:
+            # If the inference adapter isn't usable for some reason, fall back
+            # to a minimal env-var sniff so we don't false-positive on a
+            # totally unconfigured machine.
+            return any(
+                os.environ.get(k, "").strip()
+                for k in (
+                    "AWS_BEARER_TOKEN_BEDROCK",
+                    "AWS_ACCESS_KEY_ID",
+                    "AWS_PROFILE",
+                    "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI",
+                    "AWS_WEB_IDENTITY_TOKEN_FILE",
+                )
+            )
+
+    def list_models(self) -> List[Dict[str, Any]]:
+        return [
+            {
+                "id": model_id,
+                "display": meta["display"],
+                "speed": meta["speed"],
+                "strengths": meta["strengths"],
+                "price": meta["price"],
+            }
+            for model_id, meta in _MODELS.items()
+        ]
+
+    def default_model(self) -> Optional[str]:
+        return DEFAULT_MODEL
+
+    def get_setup_schema(self) -> Dict[str, Any]:
+        return {
+            "name": "AWS Bedrock Stability AI",
+            "badge": "paid",
+            "tag": (
+                "stability.sd3-5-large-v1:0 / stable-image-core-v1:1 / "
+                "stable-image-ultra-v1:1 via AWS SDK credential chain"
+            ),
+            # No env_vars to prompt for — boto3 picks up creds from
+            # ~/.aws/credentials, AWS_PROFILE, IMDS, IRSA, etc.
+            "env_vars": [],
+        }
+
+    def generate(
+        self,
+        prompt: str,
+        aspect_ratio: str = DEFAULT_ASPECT_RATIO,
+        **kwargs: Any,
+    ) -> Dict[str, Any]:
+        prompt = (prompt or "").strip()
+        aspect = resolve_aspect_ratio(aspect_ratio)
+        model_id = _resolve_model()
+
+        if not prompt:
+            return error_response(
+                error="Prompt is required and must be a non-empty string",
+                error_type="invalid_argument",
+                provider=self.name,
+                model=model_id,
+                aspect_ratio=aspect,
+            )
+
+        # Lazy boto3 install — same hook the inference plugin uses.
+        try:
+            from tools.lazy_deps import ensure
+            ensure("provider.bedrock", prompt=False)
+        except Exception:
+            # Non-fatal: the import below will surface the real error if boto3
+            # is genuinely missing and lazy_deps couldn't install it.
+            pass
+
+        try:
+            import boto3  # noqa: F401
+        except ImportError:
+            return error_response(
+                error=(
+                    "boto3 is required for Bedrock Stability image generation. "
+                    "Install with: pip install boto3"
+                ),
+                error_type="missing_dependency",
+                provider=self.name,
+                model=model_id,
+                prompt=prompt,
+                aspect_ratio=aspect,
+            )
+
+        try:
+            from agent.bedrock_adapter import (
+                _get_bedrock_runtime_client,
+                has_aws_credentials,
+            )
+        except Exception as exc:  # pragma: no cover — adapter import must work
+            logger.error("Failed to import bedrock_adapter helpers", exc_info=True)
+            return error_response(
+                error=f"Internal: could not load bedrock adapter helpers: {exc}",
+                error_type="internal_error",
+                provider=self.name,
+                model=model_id,
+                prompt=prompt,
+                aspect_ratio=aspect,
+            )
+
+        if not has_aws_credentials():
+            return error_response(
+                error=(
+                    "No AWS credentials found. Configure via `aws configure`, "
+                    "set AWS_PROFILE, or export AWS_ACCESS_KEY_ID / "
+                    "AWS_SECRET_ACCESS_KEY (or AWS_BEARER_TOKEN_BEDROCK) before "
+                    "using Bedrock Stability image generation."
+                ),
+                error_type="auth_required",
+                provider=self.name,
+                model=model_id,
+                prompt=prompt,
+                aspect_ratio=aspect,
+            )
+
+        stability_aspect = _ASPECT_RATIO_MAP.get(aspect, "1:1")
+        region = _resolve_region()
+
+        # Stability text-to-image schema (shared by all three models per AWS docs):
+        # required: prompt; optional: aspect_ratio, output_format, seed, negative_prompt, mode.
+        body: Dict[str, Any] = {
+            "prompt": prompt,
+            "mode": "text-to-image",
+            "aspect_ratio": stability_aspect,
+            "output_format": "png",
+        }
+
+        try:
+            client = _get_bedrock_runtime_client(region)
+            response = client.invoke_model(
+                modelId=model_id,
+                body=json.dumps(body),
+                accept="application/json",
+                contentType="application/json",
+            )
+        except Exception as exc:
+            logger.debug("Bedrock Stability invoke_model failed", exc_info=True)
+            return error_response(
+                error=f"Bedrock Stability invocation failed: {exc}",
+                error_type="api_error",
+                provider=self.name,
+                model=model_id,
+                prompt=prompt,
+                aspect_ratio=aspect,
+            )
+
+        try:
+            raw_body = response["body"].read()
+            payload = json.loads(raw_body)
+        except Exception as exc:
+            logger.debug("Could not parse Bedrock response", exc_info=True)
+            return error_response(
+                error=f"Could not parse Bedrock response: {exc}",
+                error_type="invalid_response",
+                provider=self.name,
+                model=model_id,
+                prompt=prompt,
+                aspect_ratio=aspect,
+            )
+
+        # Stability response envelope:
+        #   success: {"seeds": [...], "finish_reasons": [null], "images": ["base64..."]}
+        #   filtered: {"finish_reasons": ["Filter reason: prompt"]}  (no images key)
+        if not isinstance(payload, dict):
+            return error_response(
+                error="Bedrock Stability returned a non-object response",
+                error_type="invalid_response",
+                provider=self.name,
+                model=model_id,
+                prompt=prompt,
+                aspect_ratio=aspect,
+            )
+
+        finish_reasons = payload.get("finish_reasons") or []
+        non_null_reasons = [r for r in finish_reasons if r]
+        images = payload.get("images") or []
+
+        if not images:
+            reason = non_null_reasons[0] if non_null_reasons else "no images returned"
+            return error_response(
+                error=f"Bedrock Stability returned no images: {reason}",
+                error_type="empty_response",
+                provider=self.name,
+                model=model_id,
+                prompt=prompt,
+                aspect_ratio=aspect,
+            )
+
+        b64 = images[0]
+        if not isinstance(b64, str) or not b64:
+            return error_response(
+                error="Bedrock Stability returned empty image data",
+                error_type="empty_response",
+                provider=self.name,
+                model=model_id,
+                prompt=prompt,
+                aspect_ratio=aspect,
+            )
+
+        try:
+            saved_path = save_b64_image(b64, prefix="bedrock_stability")
+        except Exception as exc:
+            logger.debug("Could not persist Stability image", exc_info=True)
+            return error_response(
+                error=f"Could not save image to cache: {exc}",
+                error_type="io_error",
+                provider=self.name,
+                model=model_id,
+                prompt=prompt,
+                aspect_ratio=aspect,
+            )
+
+        extra: Dict[str, Any] = {
+            "aspect": stability_aspect,
+            "region": region,
+        }
+        if non_null_reasons:
+            extra["finish_reasons"] = non_null_reasons
+
+        return success_response(
+            image=str(saved_path),
+            model=model_id,
+            prompt=prompt,
+            aspect_ratio=aspect,
+            provider=self.name,
+            extra=extra,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Plugin entry point
+# ---------------------------------------------------------------------------
+
+
+def register(ctx) -> None:
+    """Plugin entry point — wire the Stability provider into the registry."""
+    ctx.register_image_gen_provider(BedrockStabilityImageGenProvider())

--- a/plugins/image_gen/bedrock-stability/plugin.yaml
+++ b/plugins/image_gen/bedrock-stability/plugin.yaml
@@ -1,0 +1,5 @@
+name: bedrock-stability
+version: 1.0.0
+description: "AWS Bedrock Stability AI image generation backend (stability.sd3-5-large-v1:0 / stable-image-core-v1:1 / stable-image-ultra-v1:1, all in us-west-2). Uses AWS SDK credential chain; saves images to $HERMES_HOME/cache/images/."
+author: NousResearch
+kind: backend

--- a/tests/plugins/image_gen/test_bedrock_stability_provider.py
+++ b/tests/plugins/image_gen/test_bedrock_stability_provider.py
@@ -1,0 +1,293 @@
+"""Tests for the bundled ``bedrock-stability`` image_gen plugin.
+
+Smoke tests only — generation hits the live AWS Bedrock API, so we don't run
+that here. We verify metadata, model catalog, availability gating, prompt /
+auth validation, the success path with a mocked ``invoke_model`` response,
+content-filter handling, and config-driven model selection.
+"""
+
+from __future__ import annotations
+
+import base64
+import importlib
+import io
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Folder name has a hyphen → not a valid Python identifier for dotted import.
+bedrock_plugin = importlib.import_module("plugins.image_gen.bedrock-stability")
+
+
+# 1×1 transparent PNG — valid bytes for save_b64_image()
+_PNG_HEX = (
+    "89504e470d0a1a0a0000000d49484452000000010000000108060000001f15c4"
+    "890000000d49444154789c6300010000000500010d0a2db40000000049454e44"
+    "ae426082"
+)
+
+
+def _b64_png() -> str:
+    return base64.b64encode(bytes.fromhex(_PNG_HEX)).decode()
+
+
+@pytest.fixture(autouse=True)
+def _tmp_hermes_home(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    yield tmp_path
+
+
+@pytest.fixture
+def provider():
+    return bedrock_plugin.BedrockStabilityImageGenProvider()
+
+
+# ── Metadata ────────────────────────────────────────────────────────────────
+
+
+class TestMetadata:
+    def test_name(self, provider):
+        assert provider.name == "bedrock-stability"
+
+    def test_default_model(self, provider):
+        assert provider.default_model() == "stability.sd3-5-large-v1:0"
+
+    def test_list_models_contains_all_three_stability_models(self, provider):
+        ids = [m["id"] for m in provider.list_models()]
+        assert "stability.sd3-5-large-v1:0" in ids
+        assert "stability.stable-image-core-v1:1" in ids
+        assert "stability.stable-image-ultra-v1:1" in ids
+
+    def test_setup_schema_has_no_env_vars(self, provider):
+        schema = provider.get_setup_schema()
+        # Bedrock auth flows through AWS SDK chain — no env vars to prompt for.
+        assert schema["env_vars"] == []
+        assert schema["badge"] == "paid"
+
+
+# ── Availability ────────────────────────────────────────────────────────────
+
+
+class TestAvailability:
+    def test_no_credentials_unavailable(self, monkeypatch):
+        # Strip every AWS env var the probe might pick up, and force the
+        # botocore fallback to report no credentials.
+        for key in (
+            "AWS_BEARER_TOKEN_BEDROCK",
+            "AWS_ACCESS_KEY_ID",
+            "AWS_SECRET_ACCESS_KEY",
+            "AWS_PROFILE",
+            "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI",
+            "AWS_WEB_IDENTITY_TOKEN_FILE",
+            "AWS_REGION",
+            "AWS_DEFAULT_REGION",
+        ):
+            monkeypatch.delenv(key, raising=False)
+
+        with patch("agent.bedrock_adapter.has_aws_credentials", return_value=False):
+            assert bedrock_plugin.BedrockStabilityImageGenProvider().is_available() is False
+
+    def test_credentials_available(self):
+        with patch("agent.bedrock_adapter.has_aws_credentials", return_value=True):
+            assert bedrock_plugin.BedrockStabilityImageGenProvider().is_available() is True
+
+
+# ── Generate ────────────────────────────────────────────────────────────────
+
+
+class TestGenerate:
+    def test_empty_prompt_rejected(self, provider):
+        result = provider.generate("", aspect_ratio="square")
+        assert result["success"] is False
+        assert result["error_type"] == "invalid_argument"
+
+    def test_missing_credentials_returns_auth_error(self, provider):
+        with patch("agent.bedrock_adapter.has_aws_credentials", return_value=False):
+            result = provider.generate("a cat", aspect_ratio="square")
+        assert result["success"] is False
+        assert result["error_type"] == "auth_required"
+
+    def test_success_path_saves_image(self, provider, tmp_path):
+        png_bytes = bytes.fromhex(_PNG_HEX)
+        body = json.dumps({
+            "seeds": [12345],
+            "finish_reasons": [None],
+            "images": [_b64_png()],
+        }).encode()
+
+        fake_client = MagicMock()
+        fake_client.invoke_model.return_value = {"body": io.BytesIO(body)}
+
+        with patch("agent.bedrock_adapter.has_aws_credentials", return_value=True), \
+                patch("agent.bedrock_adapter._get_bedrock_runtime_client", return_value=fake_client):
+            result = provider.generate("a cat", aspect_ratio="landscape")
+
+        assert result["success"] is True
+        assert result["model"] == "stability.sd3-5-large-v1:0"
+        assert result["aspect_ratio"] == "landscape"
+        assert result["provider"] == "bedrock-stability"
+        assert result["aspect"] == "16:9"
+
+        saved = Path(result["image"])
+        assert saved.exists()
+        assert saved.parent == tmp_path / "cache" / "images"
+        assert saved.read_bytes() == png_bytes
+
+        # Verify the request payload we send to Bedrock.
+        call_kwargs = fake_client.invoke_model.call_args.kwargs
+        assert call_kwargs["modelId"] == "stability.sd3-5-large-v1:0"
+        assert call_kwargs["contentType"] == "application/json"
+        sent = json.loads(call_kwargs["body"])
+        assert sent["prompt"] == "a cat"
+        assert sent["mode"] == "text-to-image"
+        assert sent["aspect_ratio"] == "16:9"
+        assert sent["output_format"] == "png"
+
+    @pytest.mark.parametrize("aspect,expected_aspect", [
+        ("landscape", "16:9"),
+        ("square", "1:1"),
+        ("portrait", "9:16"),
+    ])
+    def test_aspect_ratio_mapping(self, provider, aspect, expected_aspect):
+        body = json.dumps({
+            "seeds": [1],
+            "finish_reasons": [None],
+            "images": [_b64_png()],
+        }).encode()
+        fake_client = MagicMock()
+        fake_client.invoke_model.return_value = {"body": io.BytesIO(body)}
+
+        with patch("agent.bedrock_adapter.has_aws_credentials", return_value=True), \
+                patch("agent.bedrock_adapter._get_bedrock_runtime_client", return_value=fake_client):
+            provider.generate("a cat", aspect_ratio=aspect)
+
+        sent = json.loads(fake_client.invoke_model.call_args.kwargs["body"])
+        assert sent["aspect_ratio"] == expected_aspect
+
+    def test_invoke_model_error_returns_api_error(self, provider):
+        fake_client = MagicMock()
+        fake_client.invoke_model.side_effect = RuntimeError("boom")
+
+        with patch("agent.bedrock_adapter.has_aws_credentials", return_value=True), \
+                patch("agent.bedrock_adapter._get_bedrock_runtime_client", return_value=fake_client):
+            result = provider.generate("a cat")
+
+        assert result["success"] is False
+        assert result["error_type"] == "api_error"
+        assert "boom" in result["error"]
+
+    def test_content_filter_returns_empty_response_with_reason(self, provider):
+        # Stability surfaces filter hits as finish_reasons without images.
+        body = json.dumps({
+            "finish_reasons": ["Filter reason: prompt"],
+        }).encode()
+        fake_client = MagicMock()
+        fake_client.invoke_model.return_value = {"body": io.BytesIO(body)}
+
+        with patch("agent.bedrock_adapter.has_aws_credentials", return_value=True), \
+                patch("agent.bedrock_adapter._get_bedrock_runtime_client", return_value=fake_client):
+            result = provider.generate("something disallowed")
+
+        assert result["success"] is False
+        assert result["error_type"] == "empty_response"
+        assert "Filter reason: prompt" in result["error"]
+
+    def test_empty_images_returns_empty_response(self, provider):
+        body = json.dumps({
+            "seeds": [1],
+            "finish_reasons": [None],
+            "images": [],
+        }).encode()
+        fake_client = MagicMock()
+        fake_client.invoke_model.return_value = {"body": io.BytesIO(body)}
+
+        with patch("agent.bedrock_adapter.has_aws_credentials", return_value=True), \
+                patch("agent.bedrock_adapter._get_bedrock_runtime_client", return_value=fake_client):
+            result = provider.generate("a cat")
+
+        assert result["success"] is False
+        assert result["error_type"] == "empty_response"
+
+
+# ── Model selection via config ──────────────────────────────────────────────
+
+
+class TestModelSelection:
+    def _run_with_config_model(self, provider, configured_model):
+        body = json.dumps({
+            "seeds": [1],
+            "finish_reasons": [None],
+            "images": [_b64_png()],
+        }).encode()
+        fake_client = MagicMock()
+        fake_client.invoke_model.return_value = {"body": io.BytesIO(body)}
+
+        with patch.object(bedrock_plugin, "_backend_config", return_value={"model": configured_model}), \
+                patch("agent.bedrock_adapter.has_aws_credentials", return_value=True), \
+                patch("agent.bedrock_adapter._get_bedrock_runtime_client", return_value=fake_client):
+            result = provider.generate("a cat", aspect_ratio="square")
+        return result, fake_client
+
+    def test_ultra_model_selected_via_config(self, provider):
+        result, fake_client = self._run_with_config_model(
+            provider, "stability.stable-image-ultra-v1:1"
+        )
+        assert result["success"] is True
+        assert result["model"] == "stability.stable-image-ultra-v1:1"
+        call_kwargs = fake_client.invoke_model.call_args.kwargs
+        assert call_kwargs["modelId"] == "stability.stable-image-ultra-v1:1"
+
+    def test_core_model_selected_via_config(self, provider):
+        result, fake_client = self._run_with_config_model(
+            provider, "stability.stable-image-core-v1:1"
+        )
+        assert result["success"] is True
+        assert result["model"] == "stability.stable-image-core-v1:1"
+
+    def test_unknown_model_falls_back_to_default(self, provider):
+        result, fake_client = self._run_with_config_model(
+            provider, "stability.does-not-exist-v9:9"
+        )
+        assert result["success"] is True
+        assert result["model"] == "stability.sd3-5-large-v1:0"
+
+
+# ── Region resolution ──────────────────────────────────────────────────────
+
+
+class TestRegionResolution:
+    def test_default_region_is_us_west_2(self, monkeypatch):
+        # No backend config, no root config, no env vars, no botocore session.
+        for key in ("AWS_REGION", "AWS_DEFAULT_REGION"):
+            monkeypatch.delenv(key, raising=False)
+
+        with patch.object(bedrock_plugin, "_backend_config", return_value={}), \
+                patch.object(bedrock_plugin, "_load_root_config", return_value={}):
+            # botocore Session.get_config_variable("region") returns None when
+            # ~/.aws/config has no region set.
+            with patch("botocore.session.Session") as mock_session:
+                mock_session.return_value.get_config_variable.return_value = None
+                assert bedrock_plugin._resolve_region() == "us-west-2"
+
+    def test_backend_config_region_wins(self):
+        with patch.object(bedrock_plugin, "_backend_config", return_value={"region": "eu-west-1"}):
+            assert bedrock_plugin._resolve_region() == "eu-west-1"
+
+    def test_root_bedrock_region_used_when_no_backend_override(self):
+        with patch.object(bedrock_plugin, "_backend_config", return_value={}), \
+                patch.object(bedrock_plugin, "_load_root_config", return_value={"bedrock": {"region": "ap-northeast-1"}}):
+            assert bedrock_plugin._resolve_region() == "ap-northeast-1"
+
+
+# ── Plugin entry point ──────────────────────────────────────────────────────
+
+
+class TestPluginEntryPoint:
+    def test_register_calls_ctx(self):
+        ctx = MagicMock()
+        bedrock_plugin.register(ctx)
+        ctx.register_image_gen_provider.assert_called_once()
+        provider_arg = ctx.register_image_gen_provider.call_args.args[0]
+        assert provider_arg.name == "bedrock-stability"


### PR DESCRIPTION
## Summary

Adds a new bundled `image_gen` backend plugin that wires AWS Bedrock's three currently-active **Stability AI** text-to-image models into Hermes:

- `stability.sd3-5-large-v1:0` — Stable Diffusion 3.5 Large (default — community-recognized, balanced quality/speed)
- `stability.stable-image-core-v1:1` — Stable Image Core (fast tier, ~3s)
- `stability.stable-image-ultra-v1:1` — Stable Image Ultra (highest quality, photorealistic)

All three share an identical `invoke_model` request/response envelope per the [AWS Stability docs](https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-stability-diffusion.html), so the plugin handles them with one code path. Switching is a single config key (`image_gen.bedrock-stability.model`).

Closes #30427.

## Why Stability instead of Nova Canvas

Nova Canvas was the obvious first choice but every region was flipped to **LEGACY** with a hard EOL of **2026-09-30** — confirmed via `boto3 list_foundation_models`, `aws bedrock list-foundation-models` (MCP), and the public AWS docs. Shipping a new plugin against a model line that EOLs in 4 months would be wasted work. Stability AI is currently the only first-party text-to-image option on Bedrock that is **ACTIVE** (the rest of Stability's older models are also being deprecated, but the three above are the supported successors).

## Region default

Defaults to **`us-west-2`** — the only region where Stability text-to-image is currently `ACTIVE` on Bedrock. `us-east-1` only carries Stability *editing* services (inpaint/recolor/style transfer), not text-to-image. This differs from the inference Bedrock plugin's `us-east-1` default; the plugin still respects (in order): `image_gen.bedrock-stability.region` → `bedrock.region` → `AWS_REGION` / `AWS_DEFAULT_REGION` → `~/.aws/config` → `us-west-2` fallback.

## Authentication

Reuses the existing `agent.bedrock_adapter` credential probe — no new env vars. Anyone with Bedrock inference already configured (env vars, `~/.aws/credentials`, `AWS_PROFILE`, IMDS, IRSA, `AWS_BEARER_TOKEN_BEDROCK`) gets image generation for free.

## Aspect ratios

Stability's API takes `aspect_ratio` enum values directly — no manual width/height math. The plugin maps Hermes's three documented aspects:

| Hermes aspect | Stability `aspect_ratio` |
| --- | --- |
| `landscape` | `16:9` |
| `square` | `1:1` |
| `portrait` | `9:16` |

The other six Stability values (`21:9 / 2:3 / 3:2 / 4:5 / 5:4 / 9:21`) are not exposed since Hermes's image_gen interface only ships those three.

## Files

```
plugins/image_gen/bedrock-stability/__init__.py       (new, ~330 lines)
plugins/image_gen/bedrock-stability/plugin.yaml       (new, 5 lines)
tests/plugins/image_gen/test_bedrock_stability_provider.py  (new, ~250 lines, 22 tests)
```

No changes to `cli-config.yaml.example` — keeping in line with the project convention that example config doesn't enumerate every plugin's options.

## Tests

**Unit (mocked Bedrock)** — `pytest tests/plugins/image_gen/test_bedrock_stability_provider.py`:

```
22 passed in 0.40s
```

Coverage: metadata, model catalog, availability gating (creds present/absent), prompt validation, auth-required error path, success path with file persistence, request-body assertions, aspect-ratio mapping for all three Hermes aspects, content-filter handling (`finish_reasons` without `images`), empty-images handling, config-driven model selection (Ultra/Core/unknown→fallback), region resolution precedence (default `us-west-2`, backend override, root `bedrock.region`), and plugin entry point.

**Live smoke (real Bedrock, account 387671391109, us-west-2)** — all three models verified end-to-end with prompt `"A serene mountain lake at sunrise, photorealistic"`, aspect_ratio `16:9`:

| Model | Latency | Output |
| --- | --- | --- |
| `stability.sd3-5-large-v1:0` | ~7.6s | 1.8 MB PNG ✓ |
| `stability.stable-image-core-v1:1` | ~3.0s | 3.3 MB PNG ✓ |
| `stability.stable-image-ultra-v1:1` | ~12s | 161 KB PNG ✓ |

All returned `finish_reasons: [None]` (no content filter), valid base64 PNGs decoded successfully.

**Full suite** — `./run_tests.sh` clean (results in CI).

**Lint** — `ruff check` clean on new files.

## Manual verification

```yaml
# config.yaml
image_gen:
  provider: bedrock-stability
  bedrock-stability:
    model: stability.stable-image-ultra-v1:1   # opt-in to Ultra
```

```
hermes doctor
# → ✓ image_gen
```

## Related

- Issue: #30427
- AWS Stability docs: <https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-stability-diffusion.html>
