### PR TITLE
docs: make README more nonchalant

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,23 +12,25 @@
   <a href="README.zh-CN.md"><img src="https://img.shields.io/badge/Lang-中文-red?style=for-the-badge" alt="中文"></a>
 </p>
 
-**The self-improving AI agent built by [Nous Research](https://nousresearch.com).** It's the only agent with a built-in learning loop — it creates skills from experience, improves them during use, nudges itself to persist knowledge, searches its own past conversations, and builds a deepening model of who you are across sessions. Run it on a $5 VPS, a GPU cluster, or serverless infrastructure that costs nearly nothing when idle. It's not tied to your laptop — talk to it from Telegram while it works on a cloud VM.
+Hermes is an AI agent you can actually live with.
 
-Use any model you want — [Nous Portal](https://portal.nousresearch.com), [OpenRouter](https://openrouter.ai) (200+ models), [NovitaAI](https://novita.ai) (AI-native cloud for Model API, Agent Sandbox, and GPU Cloud), [NVIDIA NIM](https://build.nvidia.com) (Nemotron), [Xiaomi MiMo](https://platform.xiaomimimo.com), [z.ai/GLM](https://z.ai), [Kimi/Moonshot](https://platform.moonshot.ai), [MiniMax](https://www.minimax.io), [Hugging Face](https://huggingface.co), OpenAI, or your own endpoint. Switch with `hermes model` — no code changes, no lock-in.
+It runs in your terminal, your messages, or a cheap little server somewhere. It remembers useful stuff, learns repeatable workflows as skills, can search old conversations, run tools, schedule jobs, delegate work to subagents, and generally keep going without needing your laptop open.
 
-<table>
-<tr><td><b>A real terminal interface</b></td><td>Full TUI with multiline editing, slash-command autocomplete, conversation history, interrupt-and-redirect, and streaming tool output.</td></tr>
-<tr><td><b>Lives where you do</b></td><td>Telegram, Discord, Slack, WhatsApp, Signal, and CLI — all from a single gateway process. Voice memo transcription, cross-platform conversation continuity.</td></tr>
-<tr><td><b>A closed learning loop</b></td><td>Agent-curated memory with periodic nudges. Autonomous skill creation after complex tasks. Skills self-improve during use. FTS5 session search with LLM summarization for cross-session recall. <a href="https://github.com/plastic-labs/honcho">Honcho</a> dialectic user modeling. Compatible with the <a href="https://agentskills.io">agentskills.io</a> open standard.</td></tr>
-<tr><td><b>Scheduled automations</b></td><td>Built-in cron scheduler with delivery to any platform. Daily reports, nightly backups, weekly audits — all in natural language, running unattended.</td></tr>
-<tr><td><b>Delegates and parallelizes</b></td><td>Spawn isolated subagents for parallel workstreams. Write Python scripts that call tools via RPC, collapsing multi-step pipelines into zero-context-cost turns.</td></tr>
-<tr><td><b>Runs anywhere, not just your laptop</b></td><td>Seven terminal backends — local, Docker, SSH, Singularity, Modal, Daytona, and Vercel Sandbox. Daytona and Modal offer serverless persistence — your agent's environment hibernates when idle and wakes on demand, costing nearly nothing between sessions. Run it on a $5 VPS or a GPU cluster.</td></tr>
-<tr><td><b>Research-ready</b></td><td>Batch trajectory generation, trajectory compression for training the next generation of tool-calling models.</td></tr>
-</table>
+Use whatever model you want: [Nous Portal](https://portal.nousresearch.com), [OpenRouter](https://openrouter.ai), [NovitaAI](https://novita.ai), [NVIDIA NIM](https://build.nvidia.com), [Xiaomi MiMo](https://platform.xiaomimimo.com), [z.ai/GLM](https://z.ai), [Kimi/Moonshot](https://platform.moonshot.ai), [MiniMax](https://www.minimax.io), [Hugging Face](https://huggingface.co), OpenAI, or your own endpoint. Switch with `hermes model`. That's kind of the point.
+
+## The gist
+
+- **Terminal UI:** multiline editing, slash commands, history, interrupts, streaming tool output. Normal agent stuff, but less annoying.
+- **Messaging:** talk to the same agent from Telegram, Discord, Slack, WhatsApp, Signal, email, or the CLI.
+- **Memory + skills:** Hermes keeps durable notes, turns repeatable workflows into skills, and can improve those skills when they break.
+- **Scheduled work:** daily briefings, backups, reminders, audits, whatever. Tell it once; it can run later.
+- **Subagents:** split work into isolated agents when one brain is too crowded.
+- **Runs wherever:** local, Docker, SSH, Singularity, Modal, Daytona, Vercel Sandbox. Laptop, VPS, GPU box — pick your vibe.
+- **Research-friendly:** batch trajectory generation and compression are built in if you're training/evaluating tool-using models.
 
 ---
 
-## Quick Install
+## Install
 
 ### Linux, macOS, WSL2, Termux
 
@@ -36,136 +38,117 @@ Use any model you want — [Nous Portal](https://portal.nousresearch.com), [Open
 curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash
 ```
 
-### Windows (native, PowerShell) — Early Beta
+### Windows, native PowerShell — early beta
 
-> **Heads up:** Native Windows support is **early beta**. It installs and runs, but hasn't been road-tested as broadly as our Linux/macOS/WSL2 paths. Please [file issues](https://github.com/NousResearch/hermes-agent/issues) when you hit rough edges. For the most battle-tested Windows setup today, run the Linux/macOS one-liner above inside **WSL2**.
-
-Run this in PowerShell:
+Native Windows works, but it is still the less-traveled path. If something feels cursed, WSL2 is still the chill option.
 
 ```powershell
 iex (irm https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.ps1)
 ```
 
-The installer handles everything: uv, Python 3.11, Node.js, ripgrep, ffmpeg, **and a portable Git Bash** (MinGit, unpacked to `%LOCALAPPDATA%\hermes\git` — no admin required, completely isolated from any system Git install).  Hermes uses this bundled Git Bash to run shell commands.
+The Windows installer brings its own basics: uv, Python 3.11, Node.js, ripgrep, ffmpeg, and a portable Git Bash if you do not already have Git. No admin required.
 
-If you already have Git installed, the installer detects it and uses that instead.  Otherwise a ~45MB MinGit download is all you need — it won't touch or interfere with any system Git.
+For Android / Termux, use the [Termux guide](https://hermes-agent.nousresearch.com/docs/getting-started/termux).
 
-> **Android / Termux:** The tested manual path is documented in the [Termux guide](https://hermes-agent.nousresearch.com/docs/getting-started/termux). On Termux, Hermes installs a curated `.[termux]` extra because the full `.[all]` extra currently pulls Android-incompatible voice dependencies.
->
-> **Windows:** Native Windows is supported as an **early beta** — the PowerShell one-liner above installs everything, but expect rough edges and please file issues when you hit them. If you'd rather use WSL2 (our most battle-tested Windows path), the Linux command works there too. Native Windows install lives under `%LOCALAPPDATA%\hermes`; WSL2 installs under `~/.hermes` as on Linux.  The only Hermes feature that currently needs WSL2 specifically is the browser-based dashboard chat pane (it uses a POSIX PTY — classic CLI and gateway both run natively).
-
-After installation:
+After install:
 
 ```bash
-source ~/.bashrc    # reload shell (or: source ~/.zshrc)
-hermes              # start chatting!
+source ~/.bashrc    # or source ~/.zshrc
+hermes              # start chatting
 ```
 
 ---
 
-## Getting Started
+## First things to try
 
 ```bash
-hermes              # Interactive CLI — start a conversation
-hermes model        # Choose your LLM provider and model
-hermes tools        # Configure which tools are enabled
-hermes config set   # Set individual config values
-hermes gateway      # Start the messaging gateway (Telegram, Discord, etc.)
-hermes setup        # Run the full setup wizard (configures everything at once)
-hermes claw migrate # Migrate from OpenClaw (if coming from OpenClaw)
-hermes update       # Update to the latest version
-hermes doctor       # Diagnose any issues
+hermes              # open the interactive CLI
+hermes model        # pick your provider/model
+hermes tools        # choose enabled tools
+hermes config set   # tweak config values
+hermes gateway      # run Telegram/Discord/etc.
+hermes setup        # full setup wizard
+hermes claw migrate # bring over OpenClaw stuff
+hermes update       # update Hermes
+hermes doctor       # debug the environment
 ```
 
-📖 **[Full documentation →](https://hermes-agent.nousresearch.com/docs/)**
-
-## CLI vs Messaging Quick Reference
-
-Hermes has two entry points: start the terminal UI with `hermes`, or run the gateway and talk to it from Telegram, Discord, Slack, WhatsApp, Signal, or Email. Once you're in a conversation, many slash commands are shared across both interfaces.
-
-| Action | CLI | Messaging platforms |
-|---------|-----|---------------------|
-| Start chatting | `hermes` | Run `hermes gateway setup` + `hermes gateway start`, then send the bot a message |
-| Start fresh conversation | `/new` or `/reset` | `/new` or `/reset` |
-| Change model | `/model [provider:model]` | `/model [provider:model]` |
-| Set a personality | `/personality [name]` | `/personality [name]` |
-| Retry or undo the last turn | `/retry`, `/undo` | `/retry`, `/undo` |
-| Compress context / check usage | `/compress`, `/usage`, `/insights [--days N]` | `/compress`, `/usage`, `/insights [days]` |
-| Browse skills | `/skills` or `/<skill-name>` | `/<skill-name>` |
-| Interrupt current work | `Ctrl+C` or send a new message | `/stop` or send a new message |
-| Platform-specific status | `/platforms` | `/status`, `/sethome` |
-
-For the full command lists, see the [CLI guide](https://hermes-agent.nousresearch.com/docs/user-guide/cli) and the [Messaging Gateway guide](https://hermes-agent.nousresearch.com/docs/user-guide/messaging).
+Docs are here: **[hermes-agent.nousresearch.com/docs](https://hermes-agent.nousresearch.com/docs/)**
 
 ---
 
-## Documentation
+## CLI or messages, same idea
 
-All documentation lives at **[hermes-agent.nousresearch.com/docs](https://hermes-agent.nousresearch.com/docs/)**:
+You can use Hermes directly in the terminal with `hermes`, or run the gateway and talk to it from Telegram, Discord, Slack, WhatsApp, Signal, or email.
 
-| Section | What's Covered |
-|---------|---------------|
-| [Quickstart](https://hermes-agent.nousresearch.com/docs/getting-started/quickstart) | Install → setup → first conversation in 2 minutes |
-| [CLI Usage](https://hermes-agent.nousresearch.com/docs/user-guide/cli) | Commands, keybindings, personalities, sessions |
-| [Configuration](https://hermes-agent.nousresearch.com/docs/user-guide/configuration) | Config file, providers, models, all options |
-| [Messaging Gateway](https://hermes-agent.nousresearch.com/docs/user-guide/messaging) | Telegram, Discord, Slack, WhatsApp, Signal, Home Assistant |
-| [Security](https://hermes-agent.nousresearch.com/docs/user-guide/security) | Command approval, DM pairing, container isolation |
-| [Tools & Toolsets](https://hermes-agent.nousresearch.com/docs/user-guide/features/tools) | 40+ tools, toolset system, terminal backends |
-| [Skills System](https://hermes-agent.nousresearch.com/docs/user-guide/features/skills) | Procedural memory, Skills Hub, creating skills |
-| [Memory](https://hermes-agent.nousresearch.com/docs/user-guide/features/memory) | Persistent memory, user profiles, best practices |
-| [MCP Integration](https://hermes-agent.nousresearch.com/docs/user-guide/features/mcp) | Connect any MCP server for extended capabilities |
-| [Cron Scheduling](https://hermes-agent.nousresearch.com/docs/user-guide/features/cron) | Scheduled tasks with platform delivery |
-| [Context Files](https://hermes-agent.nousresearch.com/docs/user-guide/features/context-files) | Project context that shapes every conversation |
-| [Architecture](https://hermes-agent.nousresearch.com/docs/developer-guide/architecture) | Project structure, agent loop, key classes |
-| [Contributing](https://hermes-agent.nousresearch.com/docs/developer-guide/contributing) | Development setup, PR process, code style |
-| [CLI Reference](https://hermes-agent.nousresearch.com/docs/reference/cli-commands) | All commands and flags |
-| [Environment Variables](https://hermes-agent.nousresearch.com/docs/reference/environment-variables) | Complete env var reference |
+Common commands work in both places:
+
+- Start over: `/new` or `/reset`
+- Change model: `/model [provider:model]`
+- Change personality: `/personality [name]`
+- Retry/undo: `/retry`, `/undo`
+- Compress context / inspect usage: `/compress`, `/usage`, `/insights`
+- Browse skills: `/skills` or `/<skill-name>`
+- Interrupt work: `Ctrl+C` in CLI, or `/stop` / send another message in chat
+
+Full guides:
+
+- [CLI guide](https://hermes-agent.nousresearch.com/docs/user-guide/cli)
+- [Messaging gateway guide](https://hermes-agent.nousresearch.com/docs/user-guide/messaging)
 
 ---
 
-## Migrating from OpenClaw
+## Docs, if you want the full tour
 
-If you're coming from OpenClaw, Hermes can automatically import your settings, memories, skills, and API keys.
+- [Quickstart](https://hermes-agent.nousresearch.com/docs/getting-started/quickstart) — install to first conversation
+- [CLI usage](https://hermes-agent.nousresearch.com/docs/user-guide/cli) — commands, keybindings, sessions
+- [Configuration](https://hermes-agent.nousresearch.com/docs/user-guide/configuration) — config file, providers, models
+- [Messaging gateway](https://hermes-agent.nousresearch.com/docs/user-guide/messaging) — Telegram, Discord, Slack, WhatsApp, Signal, Home Assistant
+- [Security](https://hermes-agent.nousresearch.com/docs/user-guide/security) — approvals, DM pairing, containers
+- [Tools & toolsets](https://hermes-agent.nousresearch.com/docs/user-guide/features/tools) — tools, permissions, terminal backends
+- [Skills](https://hermes-agent.nousresearch.com/docs/user-guide/features/skills) — reusable procedures for agents
+- [Memory](https://hermes-agent.nousresearch.com/docs/user-guide/features/memory) — persistent memory and user profiles
+- [MCP](https://hermes-agent.nousresearch.com/docs/user-guide/features/mcp) — bring your own MCP servers
+- [Cron](https://hermes-agent.nousresearch.com/docs/user-guide/features/cron) — scheduled agent runs
+- [Context files](https://hermes-agent.nousresearch.com/docs/user-guide/features/context-files) — repo/project instructions
+- [Architecture](https://hermes-agent.nousresearch.com/docs/developer-guide/architecture) — how the thing is wired
+- [Contributing](https://hermes-agent.nousresearch.com/docs/developer-guide/contributing) — dev setup and PR flow
+- [CLI reference](https://hermes-agent.nousresearch.com/docs/reference/cli-commands) — all commands
+- [Environment variables](https://hermes-agent.nousresearch.com/docs/reference/environment-variables) — all env vars
 
-**During first-time setup:** The setup wizard (`hermes setup`) automatically detects `~/.openclaw` and offers to migrate before configuration begins.
+---
 
-**Anytime after install:**
+## Coming from OpenClaw?
+
+Hermes can import your OpenClaw setup.
+
+First-time setup will notice `~/.openclaw` and offer to migrate. You can also do it later:
 
 ```bash
-hermes claw migrate              # Interactive migration (full preset)
-hermes claw migrate --dry-run    # Preview what would be migrated
-hermes claw migrate --preset user-data   # Migrate without secrets
-hermes claw migrate --overwrite  # Overwrite existing conflicts
+hermes claw migrate                    # interactive migration
+hermes claw migrate --dry-run          # preview only
+hermes claw migrate --preset user-data # skip secrets
+hermes claw migrate --overwrite        # overwrite conflicts
 ```
 
-What gets imported:
-- **SOUL.md** — persona file
-- **Memories** — MEMORY.md and USER.md entries
-- **Skills** — user-created skills → `~/.hermes/skills/openclaw-imports/`
-- **Command allowlist** — approval patterns
-- **Messaging settings** — platform configs, allowed users, working directory
-- **API keys** — allowlisted secrets (Telegram, OpenRouter, OpenAI, Anthropic, ElevenLabs)
-- **TTS assets** — workspace audio files
-- **Workspace instructions** — AGENTS.md (with `--workspace-target`)
-
-See `hermes claw migrate --help` for all options, or use the `openclaw-migration` skill for an interactive agent-guided migration with dry-run previews.
+It can bring over persona files, memories, skills, command allowlists, messaging settings, selected API keys, TTS assets, and workspace instructions.
 
 ---
 
 ## Contributing
 
-We welcome contributions! See the [Contributing Guide](https://hermes-agent.nousresearch.com/docs/developer-guide/contributing) for development setup, code style, and PR process.
+PRs are welcome. The [contributing guide](https://hermes-agent.nousresearch.com/docs/developer-guide/contributing) has the official details.
 
-Quick start for contributors — clone and go with `setup-hermes.sh`:
+Fast path:
 
 ```bash
 git clone https://github.com/NousResearch/hermes-agent.git
 cd hermes-agent
-./setup-hermes.sh     # installs uv, creates venv, installs .[all], symlinks ~/.local/bin/hermes
-./hermes              # auto-detects the venv, no need to `source` first
+./setup-hermes.sh
+./hermes
 ```
 
-Manual path (equivalent to the above):
+Manual path:
 
 ```bash
 curl -LsSf https://astral.sh/uv/install.sh | sh
@@ -177,13 +160,13 @@ scripts/run_tests.sh
 
 ---
 
-## Community
+## Around the project
 
-- 💬 [Discord](https://discord.gg/NousResearch)
-- 📚 [Skills Hub](https://agentskills.io)
-- 🐛 [Issues](https://github.com/NousResearch/hermes-agent/issues)
-- 🔌 [computer-use-linux](https://github.com/avifenesh/computer-use-linux) — Linux desktop-control MCP server for Hermes and other MCP hosts, with AT-SPI accessibility trees, Wayland/X11 input, screenshots, and compositor window targeting.
-- 🔌 [HermesClaw](https://github.com/AaronWong1999/hermesclaw) — Community WeChat bridge: Run Hermes Agent and OpenClaw on the same WeChat account.
+- [Discord](https://discord.gg/NousResearch)
+- [Skills Hub](https://agentskills.io)
+- [Issues](https://github.com/NousResearch/hermes-agent/issues)
+- [computer-use-linux](https://github.com/avifenesh/computer-use-linux) — Linux desktop-control MCP server for Hermes and other MCP hosts.
+- [HermesClaw](https://github.com/AaronWong1999/hermesclaw) — community WeChat bridge for Hermes Agent and OpenClaw.
 
 ---
 


### PR DESCRIPTION
## Summary
- Rewrites the README in a more casual, nonchalant tone
- Keeps install commands, docs links, OpenClaw migration, contributing, and community links

## Test Plan
- `git diff --check -- README.md`