### PR TITLE
fix(mcp): preserve 'definitions' as a property name in tool schemas

### DIFF
--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -186,6 +186,89 @@ class TestSchemaConversion:
         assert schema["parameters"]["properties"]["items"]["items"]["$ref"] == "#/$defs/Entry"
         assert schema["parameters"]["$defs"]["Entry"]["properties"]["child"]["$ref"] == "#/$defs/Child"
 
+    def test_definitions_as_property_name_is_preserved(self):
+        """A tool parameter literally named ``definitions`` must not be renamed.
+
+        Regression: the rewrite that promotes the legacy ``definitions``
+        meta-keyword to ``$defs`` used to fire for *any* key named
+        ``definitions`` anywhere in the tree, including inside ``properties``
+        dicts. That turned user-facing parameter names into ``$defs``, which
+        Anthropic and OpenAI both reject because ``$`` is not in the
+        ``^[a-zA-Z0-9_.-]{1,64}$`` property-name pattern. Real-world repro: a
+        CI/pipelines MCP tool whose ``definitions`` parameter is an array of
+        pipeline-definition IDs.
+        """
+        from tools.mcp_tool import _convert_mcp_schema
+
+        mcp_tool = _make_mcp_tool(
+            name="pipelines_build",
+            description="List pipeline builds",
+            input_schema={
+                "type": "object",
+                "properties": {
+                    "action": {"type": "string"},
+                    "definitions": {
+                        "description": "Array of build definition IDs to filter builds.",
+                    },
+                    "top": {"type": "integer"},
+                },
+            },
+        )
+
+        schema = _convert_mcp_schema("pipelines", mcp_tool)
+
+        props = schema["parameters"]["properties"]
+        assert "definitions" in props, "user-facing property name was renamed away"
+        assert "$defs" not in props, "user-facing property name was rewritten to $defs"
+        # And the meta-keyword promotion didn't happen at the root either,
+        # because there was no `definitions` meta-keyword to promote.
+        assert "$defs" not in schema["parameters"]
+        assert "definitions" not in schema["parameters"]
+
+    def test_definitions_property_and_meta_keyword_coexist(self):
+        """``definitions`` as both a property name AND a meta-keyword in the
+        same schema. The property name stays; the meta-keyword is promoted.
+
+        Note: Python source can't express both keys as literals (the second
+        would clobber the first), so build the dict explicitly.
+        """
+        from tools.mcp_tool import _convert_mcp_schema
+
+        input_schema = {
+            "type": "object",
+            "properties": {
+                # User-facing parameter literally named "definitions".
+                "definitions": {
+                    "description": "Array of build definition IDs.",
+                },
+                "payload": {"$ref": "#/definitions/Payload"},
+            },
+        }
+        # Meta-keyword (legacy draft-07 reusable defs), set after the literal.
+        input_schema["definitions"] = {
+            "Payload": {
+                "type": "object",
+                "properties": {"q": {"type": "string"}},
+            },
+        }
+
+        mcp_tool = _make_mcp_tool(
+            name="mixed",
+            description="Schema with both forms of `definitions`",
+            input_schema=input_schema,
+        )
+
+        schema = _convert_mcp_schema("mixed", mcp_tool)
+
+        # Property name preserved.
+        assert "definitions" in schema["parameters"]["properties"]
+        assert "$defs" not in schema["parameters"]["properties"]
+        # Meta-keyword promoted at the root.
+        assert "$defs" in schema["parameters"]
+        assert "definitions" not in schema["parameters"]
+        # The $ref into the legacy location was rewritten too.
+        assert schema["parameters"]["properties"]["payload"]["$ref"] == "#/$defs/Payload"
+
     def test_missing_type_on_object_is_coerced(self):
         """Schemas that describe an object but omit ``type`` get type='object'."""
         from tools.mcp_tool import _normalize_mcp_input_schema

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -2729,11 +2729,43 @@ def _normalize_mcp_input_schema(schema: dict | None) -> dict:
         return {"type": "object", "properties": {}}
 
     def _rewrite_local_refs(node):
+        """Walk the schema, promoting legacy ``definitions`` to ``$defs``.
+
+        The promotion is contextual: ``definitions`` is renamed only when it
+        appears as a JSON Schema *meta-keyword* (sibling of ``properties`` /
+        ``$ref`` at a schema node), never when it appears as the *name of a
+        property* (i.e., as a key inside a ``properties`` dict).
+
+        Without this gate, MCP servers that legitimately expose a tool
+        parameter named ``definitions`` (e.g. a CI/pipelines tool that uses
+        ``definitions`` for an array of pipeline-definition IDs) would have
+        that user-facing property name silently rewritten to ``$defs``.
+        Anthropic and OpenAI both reject ``$`` in property names
+        (``^[a-zA-Z0-9_.-]{1,64}$``), so the whole tool array gets a 400 and
+        every conversation breaks.
+
+        The gate works by treating ``properties`` and ``patternProperties``
+        specially during descent: we iterate the property-name -> schema map
+        directly, leaving the property names verbatim, then recurse into each
+        property's schema where ordinary JSON Schema semantics resume (so any
+        legitimately-nested ``definitions`` meta-keyword inside a property's
+        schema is still promoted).
+        """
         if isinstance(node, dict):
             normalized = {}
             for key, value in node.items():
-                out_key = "$defs" if key == "definitions" else key
-                normalized[out_key] = _rewrite_local_refs(value)
+                if key in ("properties", "patternProperties") and isinstance(value, dict):
+                    # Keys of this dict are user-facing property names, not
+                    # meta-keywords. Preserve them verbatim; recurse only into
+                    # each property's schema, where ``definitions`` again has
+                    # its JSON Schema meaning.
+                    normalized[key] = {
+                        prop_name: _rewrite_local_refs(prop_schema)
+                        for prop_name, prop_schema in value.items()
+                    }
+                else:
+                    out_key = "$defs" if key == "definitions" else key
+                    normalized[out_key] = _rewrite_local_refs(value)
             ref = normalized.get("$ref")
             if isinstance(ref, str) and ref.startswith("#/definitions/"):
                 normalized["$ref"] = "#/$defs/" + ref[len("#/definitions/"):]


### PR DESCRIPTION
## What does this PR do?

The MCP input-schema normalizer in `_normalize_mcp_input_schema` promotes the legacy JSON Schema `definitions` meta-keyword to `$defs` (draft 2019-09+) so local `$ref` resolution works downstream. The previous walk renamed **any** key named `definitions` anywhere in the tree, including inside `properties` dicts. That turned user-facing parameter names into `$defs`, producing property keys that contain `$`, which Anthropic and OpenAI both reject with HTTP 400 (pattern `^[a-zA-Z0-9_.-]{1,64}$`).

Real-world repro: a CI MCP server exposes a `pipelines_build` tool whose `definitions` parameter is an array of pipeline-definition IDs. Because the full tools array is sent on every request, the broken schema poisons every conversation, not just calls to that one tool.

Fix: when descending into a `properties` or `patternProperties` mapping, iterate property-name → schema pairs directly, leaving the property names verbatim. Ordinary JSON Schema semantics resume inside each property's schema, so a legitimately nested `definitions` meta-keyword inside a property's schema is still promoted.

Adds two regression tests:
- `test_definitions_as_property_name_is_preserved` (the regression case)
- `test_definitions_property_and_meta_keyword_coexist` (both forms in one schema; the property stays, the meta-keyword promotes)

## Related Issue

None filed. Happy to open one if you'd prefer the issue-first flow; the PR title and body are otherwise the canonical description.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/mcp_tool.py`: in `_normalize_mcp_input_schema._rewrite_local_refs`, special-case descent through `properties` / `patternProperties` so keys at that level are treated as property names rather than schema keywords. The `definitions` → `$defs` rename and the `#/definitions/...` → `#/$defs/...` `$ref` rewrite continue to apply everywhere else.
- `tests/tools/test_mcp_tool.py`: two new regression tests covering (1) `definitions` as a sole property name, and (2) the both-forms-in-one-schema case where the meta-keyword promotion must still happen.

## How to Test

1. Verify the regression tests cover the bug:
   ```
   pytest tests/tools/test_mcp_tool.py::TestMcpTool::test_definitions_as_property_name_is_preserved \
          tests/tools/test_mcp_tool.py::TestMcpTool::test_definitions_property_and_meta_keyword_coexist -v
   ```
2. Run the surrounding schema-handling suites to confirm no regressions in the legitimate meta-keyword rewrite path:
   ```
   pytest tests/tools/test_mcp_tool.py tests/agent/test_moonshot_schema.py tests/tools/test_schema_sanitizer.py -q
   ```
   (279 tests pass locally on this branch.)
3. Manual repro / proof, requires an MCP server whose tool input schema declares a property literally named `definitions`. Before the fix, every conversation 400s with `tools.N.custom.input_schema.properties: Property keys should match pattern '^[a-zA-Z0-9_.-]{1,64}$'`. After the fix, the same conversation succeeds; the affected tool's input schema arrives at the provider with `"definitions"` preserved as a property key.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(mcp): ...`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run `pytest tests/tools/test_mcp_tool.py tests/agent/test_moonshot_schema.py tests/tools/test_schema_sanitizer.py -q` and all 279 tests pass (did not run the full `tests/` suite; happy to if a maintainer wants it)
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu 24.04 on WSL2

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - docstring on `_rewrite_local_refs` rewritten to spell out the contextual-rename rule and the failure mode it prevents
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) - N/A; pure-Python schema transformation, no OS-specific paths
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A; this corrects unintended schema corruption, no tool behavior change

## Screenshots / Logs

Provider 400 before the fix (Anthropic-via-Copilot proxy; same wording on Anthropic direct and OpenAI):

```
HTTP 400: tools.19.custom.input_schema.properties: Property keys should match pattern '^[a-zA-Z0-9_.-]{1,64}$'
```

Inspecting the offending tool definition in the request body shows `properties: {..., "$defs": {...}, "top": {...}}` where the MCP server actually emits `properties: {..., "definitions": {...}, "top": {...}}`. After this change, the wire format matches the server's input.
