### PR TITLE
fix(hermes_cli): omit hardcoded temperature in direct API calls for Kimi compatibility

### DIFF
--- a/hermes_cli/goals.py
+++ b/hermes_cli/goals.py
@@ -443,7 +443,6 @@ def judge_goal(
                 {"role": "system", "content": JUDGE_SYSTEM_PROMPT},
                 {"role": "user", "content": prompt},
             ],
-            temperature=0,
             max_tokens=_goal_judge_max_tokens(),
             timeout=timeout,
             extra_body=get_auxiliary_extra_body() or None,

--- a/hermes_cli/kanban_decompose.py
+++ b/hermes_cli/kanban_decompose.py
@@ -330,7 +330,6 @@ def decompose_task(
                 {"role": "system", "content": _SYSTEM_PROMPT},
                 {"role": "user", "content": user_msg},
             ],
-            temperature=0.3,
             max_tokens=4000,
             timeout=timeout or 180,
             extra_body=get_auxiliary_extra_body() or None,

--- a/hermes_cli/kanban_specify.py
+++ b/hermes_cli/kanban_specify.py
@@ -189,7 +189,6 @@ def specify_task(
                 {"role": "system", "content": _SYSTEM_PROMPT},
                 {"role": "user", "content": user_msg},
             ],
-            temperature=0.3,
             max_tokens=HERMES_KANBAN_SPECIFY_MAX_TOKENS,
             timeout=timeout or 120,
             extra_body=get_auxiliary_extra_body() or None,

--- a/hermes_cli/profile_describer.py
+++ b/hermes_cli/profile_describer.py
@@ -244,7 +244,6 @@ def describe_profile(
                 {"role": "system", "content": _SYSTEM_PROMPT},
                 {"role": "user", "content": user_msg},
             ],
-            temperature=0.3,
             max_tokens=400,
             timeout=timeout or 60,
             extra_body=get_auxiliary_extra_body() or None,


### PR DESCRIPTION
## fix(hermes_cli): omit hardcoded temperature in direct API calls for Kimi compatibility

**Problem**
PRs #12773, #12668, and #12806 fixed the public Moonshot temperature contract for Kimi models in the centralized `agent/` call paths (e.g. `_fixed_temperature_for_model()` returns `OMIT_TEMPERATURE` for Kimi), but four `hermes_cli/` modules still bypass that guardrail and hardcode `temperature` directly into raw `client.chat.completions.create()` calls.

When the Kanban decomposer/specifier or profile auto-describer routes to `kimi-k2.6` via the public Moonshot endpoint (`api.moonshot.ai/v1`), the API rejects the request with:

```
invalid temperature: only 1 is allowed for this model
```

This breaks:
- `hermes kanban create` (triage specify step)
- `hermes kanban decompose` 
- `hermes profile describe --auto`
- Goal judging in the CLI

**Affected files**
- `hermes_cli/kanban_specify.py` — `temperature=0.3`
- `hermes_cli/kanban_decompose.py` — `temperature=0.3`
- `hermes_cli/profile_describer.py` — `temperature=0.3`
- `hermes_cli/goals.py` — `temperature=0`

**Solution**
Remove the hardcoded `temperature=` kwarg from each direct call. The centralized `agent/auxiliary_client.py` already handles model-specific temperature rules when callers use the official `call_llm()` path; for these direct-call sites, omitting the parameter entirely lets the API default apply, which is safe across all current providers.

**Verification**
- Live API test: `kimi-k2.6` @ `api.moonshot.ai/v1` returns `200` when `temperature` is omitted from the request body, and `400` when `temperature=0.3` is present.
- Kanban triage pipeline successfully auto-specified a test task after the patch.

**Related**
- PR #12773 — core agent temperature guardrails
- Issue #12835 — `kimi-k2.5` public endpoint temperature requirements
