### PR TITLE
fix: allow ZWJ inside emoji grapheme clusters in scanners

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -46,20 +46,18 @@ _CONTEXT_THREAT_PATTERNS = [
     (r'cat\s+[^\n]*(\.env|credentials|\.netrc|\.pgpass)', "read_secrets"),
 ]
 
-_CONTEXT_INVISIBLE_CHARS = {
-    '\u200b', '\u200c', '\u200d', '\u2060', '\ufeff',
-    '\u202a', '\u202b', '\u202c', '\u202d', '\u202e',
-}
+# Backward-compatible alias — tests and external code may reference this set.
+# The canonical source of truth is agent.unicode_scanner.INVISIBLE_CHARS_BLOCKLIST.
+from agent.unicode_scanner import find_unsafe_invisibles, INVISIBLE_CHARS_BLOCKLIST as _CONTEXT_INVISIBLE_CHARS  # noqa: E402
 
 
 def _scan_context_content(content: str, filename: str) -> str:
     """Scan context file content for injection. Returns sanitized content."""
     findings = []
 
-    # Check invisible unicode
-    for char in _CONTEXT_INVISIBLE_CHARS:
-        if char in content:
-            findings.append(f"invisible unicode U+{ord(char):04X}")
+    # Check invisible unicode (ZWJ inside emoji clusters is allowed)
+    for _char, cp in find_unsafe_invisibles(content):
+        findings.append(f"invisible unicode U+{cp:04X}")
 
     # Check threat patterns
     for pattern, pid in _CONTEXT_THREAT_PATTERNS:

--- a/agent/unicode_scanner.py
+++ b/agent/unicode_scanner.py
@@ -1,0 +1,118 @@
+"""Shared invisible-unicode scanner for context files, memory, cron, and skills.
+
+Centralises the blocklist and the ZWJ-aware scan logic so that all scanners
+behave consistently.  The key insight is that ZWJ (U+200D) is a **required
+component** of emoji grapheme clusters (🧙‍♂️, 👩‍⚕️, 👨‍👩‍👧, 🏳️‍🌈) and should
+not be treated as malicious when it appears **between two pictographic
+codepoints**.
+
+Public API
+----------
+find_unsafe_invisibles(content, blocklist)
+    Return a list of ``(char, code_point)`` tuples for invisible chars that
+    are genuinely suspicious — i.e. not ZWJ inside an emoji grapheme cluster.
+"""
+
+import unicodedata
+from typing import AbstractSet, List, Tuple
+
+# ── Blocklist ──────────────────────────────────────────────────────────────
+
+# Characters that are invisible / zero-width and could be used for prompt
+# injection.  ZWJ (U+200D) is *included* here because it IS dangerous when
+# used outside emoji sequences; the scanner below filters out the safe cases.
+INVISIBLE_CHARS_BLOCKLIST: frozenset[str] = frozenset({
+    '\u200b',  # ZERO WIDTH SPACE
+    '\u200c',  # ZERO WIDTH NON-JOINER
+    '\u200d',  # ZERO WIDTH JOINER  (safe inside emoji clusters)
+    '\u2060',  # WORD JOINER
+    '\ufeff',  # BYTE ORDER MARK / ZERO WIDTH NO-BREAK SPACE
+    '\u202a',  # LEFT-TO-RIGHT EMBEDDING
+    '\u202b',  # RIGHT-TO-LEFT EMBEDDING
+    '\u202c',  # POP DIRECTIONAL FORMATTING
+    '\u202d',  # LEFT-TO-RIGHT OVERRIDE
+    '\u202e',  # RIGHT-TO-LEFT OVERRIDE
+})
+
+# ── Pictographic predicate ────────────────────────────────────────────────
+
+# Unicode categories and ranges that count as "pictographic" for the purpose
+# of deciding whether a ZWJ between two characters is part of an emoji
+# grapheme cluster.
+_EMOJI_CATEGORIES = {"So", "Sk"}  # Symbol-other, Modifier-symbol
+_EMOJI_RANGES: List[Tuple[int, int]] = [
+    (0x1F600, 0x1F64F),  # Emoticons
+    (0x1F300, 0x1F5FF),  # Misc Symbols and Pictographs
+    (0x1F680, 0x1F6FF),  # Transport and Map
+    (0x1F900, 0x1F9FF),  # Supplemental Symbols and Pictographs
+    (0x1FA00, 0x1FA6F),  # Chess Symbols
+    (0x1FA70, 0x1FAFF),  # Symbols and Pictographs Extended-A
+    (0x2600,  0x26FF),   # Misc Symbols
+    (0x2700,  0x27BF),   # Dingbats
+    (0xFE00,  0xFE0F),   # Variation Selectors (VS1–VS16)
+    (0x200D,  0x200D),   # ZWJ itself (so ZWJ+ZWJ is not "safe")
+    (0x20E3,  0x20E3),   # Combining Enclosing Keycap
+    (0x00A9,  0x00AE),   # © ®
+    (0x203C,  0x3299),   # ‼ through㊙ (misc symbols in BMP)
+    (0x1F018, 0x1F270),  # Additional emoji
+    (0x2388,  0x2388),   # ⎈
+    (0x2B50,  0x2B55),   # ⭐–⭕
+    (0x231A,  0x231B),   # ⌚ ⌛
+    (0x23E9,  0x23F3),   # ⏩–⏳
+    (0x23F8,  0x23FA),   # ⏸–⏺
+    (0x25AA,  0x25FE),   # ▪–◾
+    (0x2934,  0x2935),   # ⤴ ⤵
+    (0x2B05,  0x2B07),   # ⬅⬆⬇
+]
+
+ZWJ = '\u200d'
+
+
+def _is_pictographic(cp: int) -> bool:
+    """Return True if *cp* is a pictographic / emoji codepoint."""
+    try:
+        cat = unicodedata.category(chr(cp))
+    except (ValueError, OverflowError):
+        return False
+    if cat in _EMOJI_CATEGORIES:
+        return True
+    for lo, hi in _EMOJI_RANGES:
+        if lo <= cp <= hi:
+            return True
+    return False
+
+
+# ── Public scanner ────────────────────────────────────────────────────────
+
+def find_unsafe_invisibles(
+    content: str,
+    blocklist: AbstractSet[str] = INVISIBLE_CHARS_BLOCKLIST,
+) -> List[Tuple[str, int]]:
+    """Return suspicious invisible characters found in *content*.
+
+    Each entry is ``(character, code_point)``.  ZWJ (U+200D) is excluded
+    from the result when it sits **between two pictographic codepoints**
+    (i.e. it is part of an emoji grapheme cluster like 🧙‍♂️).
+
+    All other invisible characters from *blocklist* are always reported.
+    """
+    findings: List[Tuple[str, int]] = []
+    chars = list(content)
+
+    for idx, ch in enumerate(chars):
+        if ch not in blocklist:
+            continue
+
+        # ZWJ between two pictographic neighbours is safe — skip it.
+        if ch == ZWJ:
+            left_ok = (idx > 0 and _is_pictographic(ord(chars[idx - 1])))
+            right_ok = (idx + 1 < len(chars) and _is_pictographic(ord(chars[idx + 1])))
+            if left_ok and right_ok:
+                continue
+            # Also allow ZWJ preceded by VS16 (U+FE0F) — flag sequences etc.
+            if idx > 0 and ord(chars[idx - 1]) == 0xFE0F and right_ok:
+                continue
+
+        findings.append((ch, ord(ch)))
+
+    return findings

--- a/tests/agent/test_unicode_scanner.py
+++ b/tests/agent/test_unicode_scanner.py
@@ -1,0 +1,112 @@
+"""Tests for agent.unicode_scanner — ZWJ-aware invisible-unicode detection."""
+
+import pytest
+
+from agent.unicode_scanner import find_unsafe_invisibles, INVISIBLE_CHARS_BLOCKLIST, ZWJ
+
+
+class TestFindUnsafeInvisibles:
+    """Core scanner: find_unsafe_invisibles()."""
+
+    def test_clean_content_returns_empty(self):
+        assert find_unsafe_invisibles("Hello, world! 🧙‍♂️ 👨‍👩‍👧") == []
+
+    def test_zero_width_space_detected(self):
+        content = "normal\u200btext"
+        result = find_unsafe_invisibles(content)
+        assert len(result) == 1
+        assert result[0] == ('\u200b', 0x200B)
+
+    def test_bom_detected(self):
+        content = "\ufeffleading BOM"
+        result = find_unsafe_invisibles(content)
+        assert len(result) == 1
+        assert result[0] == ('\ufeff', 0xFEFF)
+
+    def test_directional_override_detected(self):
+        content = "\u202esuspicious"
+        result = find_unsafe_invisibles(content)
+        assert len(result) == 1
+        assert result[0] == ('\u202e', 0x202E)
+
+    # ── ZWJ in emoji clusters (should be ALLOWED) ────────────────────────
+
+    def test_zwj_in_gendered_emoji_allowed(self):
+        """🧙‍♂️ = U+1F9D9 + ZWJ + U+2642 — ZWJ should be allowed."""
+        assert find_unsafe_invisibles("🧙‍♂️") == []
+
+    def test_zwj_in_family_emoji_allowed(self):
+        """👨‍👩‍👧 = U+1F468 + ZWJ + U+1F469 + ZWJ + U+1F467 — ZWJs allowed."""
+        assert find_unsafe_invisibles("👨‍👩‍👧") == []
+
+    def test_zwj_in_flag_emoji_allowed(self):
+        """🏳️‍🌈 = 🏳 + VS16 + ZWJ + 🌈 — ZWJ after VS16 should be allowed."""
+        assert find_unsafe_invisibles("🏳️‍🌈") == []
+
+    def test_zwj_in_health_emoji_allowed(self):
+        """👩‍⚕️ = U+1F469 + ZWJ + U+2695 — ZWJ should be allowed."""
+        assert find_unsafe_invisibles("👩‍⚕️") == []
+
+    def test_zwj_in_runner_emoji_allowed(self):
+        """🏃‍♀️ — ZWJ should be allowed."""
+        assert find_unsafe_invisibles("🏃‍♀️") == []
+
+    # ── ZWJ in suspicious positions (should be BLOCKED) ──────────────────
+
+    def test_standalone_zwj_blocked(self):
+        """ZWJ with non-pictographic neighbours is suspicious."""
+        content = "ignore\u200dprevious"
+        result = find_unsafe_invisibles(content)
+        assert len(result) == 1
+        assert result[0][1] == 0x200D
+
+    def test_zwj_at_start_of_content_blocked(self):
+        """ZWJ at the very start with no left neighbour."""
+        content = "\u200dhello"
+        result = find_unsafe_invisibles(content)
+        assert len(result) == 1
+        assert result[0][1] == 0x200D
+
+    def test_zwj_at_end_of_content_blocked(self):
+        """ZWJ at the end with no right neighbour."""
+        content = "hello\u200d"
+        result = find_unsafe_invisibles(content)
+        assert len(result) == 1
+        assert result[0][1] == 0x200D
+
+    def test_zwj_between_letters_blocked(self):
+        """ZWJ between two ASCII letters is suspicious."""
+        content = "a\u200db"
+        result = find_unsafe_invisibles(content)
+        assert len(result) == 1
+        assert result[0][1] == 0x200D
+
+    # ── Multiple issues ──────────────────────────────────────────────────
+
+    def test_mixed_invisible_chars(self):
+        """ZWJ in emoji allowed, other invisibles detected."""
+        content = "🧙‍♂️ has a zero-width space\u200bhere"
+        result = find_unsafe_invisibles(content)
+        assert len(result) == 1
+        assert result[0] == ('\u200b', 0x200B)
+
+    def test_multiple_dangerous_invisibles(self):
+        content = "\u200b\u202etext"
+        result = find_unsafe_invisibles(content)
+        assert len(result) == 2
+
+    # ── Custom blocklist ─────────────────────────────────────────────────
+
+    def test_custom_blocklist(self):
+        content = "normal\u200btext"
+        # Only scan for directional overrides, not ZWSP
+        result = find_unsafe_invisibles(content, blocklist={'\u202e'})
+        assert result == []
+
+    # ── Blocklist contents ───────────────────────────────────────────────
+
+    def test_blocklist_contains_all_original_chars(self):
+        """The shared blocklist must contain every char from the original sets."""
+        original = {'\u200b', '\u200c', '\u200d', '\u2060', '\ufeff',
+                    '\u202a', '\u202b', '\u202c', '\u202d', '\u202e'}
+        assert INVISIBLE_CHARS_BLOCKLIST == original

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -65,10 +65,8 @@ _CRON_EXFIL_COMMAND_PATTERNS = [
     (rf'curl\s+[^\n]*(?:-H|--header)\s+["\']Authorization:\s*(?:Bearer|token)\s+{_CRON_SECRET_VAR_RE}["\']', "exfil_curl_auth_header"),
 ]
 
-_CRON_INVISIBLE_CHARS = {
-    '\u200b', '\u200c', '\u200d', '\u2060', '\ufeff',
-    '\u202a', '\u202b', '\u202c', '\u202d', '\u202e',
-}
+# Backward-compatible alias — tests and external code may reference this set.
+from agent.unicode_scanner import find_unsafe_invisibles, INVISIBLE_CHARS_BLOCKLIST as _CRON_INVISIBLE_CHARS  # noqa: E402
 
 # U+200D Zero-Width Joiner is also a legitimate, required part of many
 # Unicode emoji sequences (for example 👨‍👩‍👧, 🏳️‍🌈, ❤️‍🩹, 🧑‍💻).
@@ -127,10 +125,9 @@ def _scan_cron_prompt(prompt: str) -> str:
         # Allow the bundled GitHub skill fallback shape without opening a
         # blanket exemption for arbitrary Authorization-header exfiltration.
         prompt_to_scan = prompt.replace(github_auth_header.group(0), "curl https://api.github.com/user")
-    prompt_for_invisible_scan = _strip_legitimate_emoji_zwj(prompt_to_scan)
-    for char in _CRON_INVISIBLE_CHARS:
-        if char in prompt_for_invisible_scan:
-            return f"Blocked: prompt contains invisible unicode U+{ord(char):04X} (possible injection)."
+    # Check invisible unicode (ZWJ inside emoji clusters is allowed)
+    for _char, cp in find_unsafe_invisibles(prompt_to_scan):
+        return f"Blocked: prompt contains invisible unicode U+{cp:04X} (possible injection)." (fix: allow ZWJ inside emoji grapheme clusters in context/memory/cron scanners)
     for pattern, pid in _CRON_THREAT_PATTERNS:
         if re.search(pattern, prompt_to_scan, re.IGNORECASE):
             return f"Blocked: prompt matches threat pattern '{pid}'. Cron prompts must not contain injection or exfiltration payloads."

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -82,19 +82,15 @@ _MEMORY_THREAT_PATTERNS = [
     (r'\$HOME/\.hermes/\.env|\~/\.hermes/\.env', "hermes_env"),
 ]
 
-# Subset of invisible chars for injection detection
-_INVISIBLE_CHARS = {
-    '\u200b', '\u200c', '\u200d', '\u2060', '\ufeff',
-    '\u202a', '\u202b', '\u202c', '\u202d', '\u202e',
-}
+# Backward-compatible alias — tests and external code may reference this set.
+from agent.unicode_scanner import find_unsafe_invisibles, INVISIBLE_CHARS_BLOCKLIST as _INVISIBLE_CHARS  # noqa: E402
 
 
 def _scan_memory_content(content: str) -> Optional[str]:
     """Scan memory content for injection/exfil patterns. Returns error string if blocked."""
-    # Check invisible unicode
-    for char in _INVISIBLE_CHARS:
-        if char in content:
-            return f"Blocked: content contains invisible unicode character U+{ord(char):04X} (possible injection)."
+    # Check invisible unicode (ZWJ inside emoji clusters is allowed)
+    for _char, cp in find_unsafe_invisibles(content):
+        return f"Blocked: content contains invisible unicode character U+{cp:04X} (possible injection)."
 
     # Check threat patterns
     for pattern, pid in _MEMORY_THREAT_PATTERNS:


### PR DESCRIPTION
Fixes #12673

ZWJ (U+200D) is required for emoji grapheme clusters. Previous scanner blocked all ZWJ, breaking legitimate emoji.

Solution: centralized unicode_scanner.py with emoji-aware ZWJ handling.