### PR TITLE
fix(auxiliary): add minimax-oauth support to resolve_provider_client

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -3660,7 +3660,7 @@ def resolve_provider_client(
         return (_to_async_client(client, final_model, is_vision=is_vision) if async_mode
                 else (client, final_model))
 
-    elif pconfig.auth_type in {"oauth_device_code", "oauth_external"}:
+    elif pconfig.auth_type in {"oauth_device_code", "oauth_external", "oauth_minimax"}:
         # OAuth providers — route through their specific try functions
         if provider == "nous":
             return resolve_provider_client("nous", model, async_mode)
@@ -3668,6 +3668,36 @@ def resolve_provider_client(
             return resolve_provider_client("openai-codex", model, async_mode)
         if provider == "xai-oauth":
             return resolve_provider_client("xai-oauth", model, async_mode)
+        if provider == "minimax-oauth":
+            # MiniMax OAuth uses Anthropic Messages API — read runtime
+            # credentials and build an Anthropic-compatible client.
+            try:
+                from hermes_cli.auth import resolve_minimax_oauth_runtime_credentials
+                from agent.anthropic_adapter import build_anthropic_client
+            except ImportError:
+                logger.warning(
+                    "resolve_provider_client: minimax-oauth requested but "
+                    "required modules not available"
+                )
+                return None, None
+            creds = resolve_minimax_oauth_runtime_credentials()
+            if not creds or not creds.get("api_key"):
+                logger.warning(
+                    "resolve_provider_client: minimax-oauth requested but "
+                    "no credentials found (run: hermes auth add minimax-oauth)"
+                )
+                return None, None
+            base_url = str(creds.get("base_url", "")).rstrip("/")
+            api_key = str(creds.get("api_key", ""))
+            default_model = _get_aux_model_for_provider(provider)
+            final_model = _normalize_resolved_model(model or default_model, provider)
+            real_client = build_anthropic_client(api_key, base_url)
+            client = AnthropicAuxiliaryClient(
+                real_client, final_model, api_key, base_url, is_oauth=True,
+            )
+            if async_mode:
+                return AsyncAnthropicAuxiliaryClient(client), final_model
+            return client, final_model
         # Other OAuth providers not directly supported
         logger.warning("resolve_provider_client: OAuth provider %s not "
                        "directly supported, try 'auto'", provider)

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -3674,30 +3674,31 @@ def resolve_provider_client(
             try:
                 from hermes_cli.auth import resolve_minimax_oauth_runtime_credentials
                 from agent.anthropic_adapter import build_anthropic_client
-            except ImportError:
+
+                creds = resolve_minimax_oauth_runtime_credentials()
+                if not creds or not creds.get("api_key"):
+                    logger.warning(
+                        "resolve_provider_client: minimax-oauth requested but "
+                        "no credentials found (run: hermes auth add minimax-oauth)"
+                    )
+                    return None, None
+                base_url = str(creds.get("base_url", "")).rstrip("/")
+                api_key = str(creds.get("api_key", ""))
+                default_model = _get_aux_model_for_provider(provider)
+                final_model = _normalize_resolved_model(model or default_model, provider)
+                real_client = build_anthropic_client(api_key, base_url)
+                client = AnthropicAuxiliaryClient(
+                    real_client, final_model, api_key, base_url, is_oauth=True,
+                )
+                if async_mode:
+                    return AsyncAnthropicAuxiliaryClient(client), final_model
+                return client, final_model
+            except Exception as exc:
                 logger.warning(
-                    "resolve_provider_client: minimax-oauth requested but "
-                    "required modules not available"
+                    "resolve_provider_client: minimax-oauth client creation failed: %s",
+                    exc,
                 )
                 return None, None
-            creds = resolve_minimax_oauth_runtime_credentials()
-            if not creds or not creds.get("api_key"):
-                logger.warning(
-                    "resolve_provider_client: minimax-oauth requested but "
-                    "no credentials found (run: hermes auth add minimax-oauth)"
-                )
-                return None, None
-            base_url = str(creds.get("base_url", "")).rstrip("/")
-            api_key = str(creds.get("api_key", ""))
-            default_model = _get_aux_model_for_provider(provider)
-            final_model = _normalize_resolved_model(model or default_model, provider)
-            real_client = build_anthropic_client(api_key, base_url)
-            client = AnthropicAuxiliaryClient(
-                real_client, final_model, api_key, base_url, is_oauth=True,
-            )
-            if async_mode:
-                return AsyncAnthropicAuxiliaryClient(client), final_model
-            return client, final_model
         # Other OAuth providers not directly supported
         logger.warning("resolve_provider_client: OAuth provider %s not "
                        "directly supported, try 'auto'", provider)


### PR DESCRIPTION
Fixes #22213

Adds minimax-oauth provider support to the auxiliary provider resolver.