### PR TITLE
fix(cli): clear screen before resize redraw

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -3043,26 +3043,19 @@ class HermesCLI:
             pass
 
     def _recover_after_resize(self, app, original_on_resize) -> None:
-        """Recover a resized classic CLI without desynchronizing cursor state.
+        """Recover a resized classic CLI without redrawing over reflow ghosts.
 
-        Unlike _force_full_redraw, we do NOT clear the physical screen or
-        scrollback here.  The startup banner and tool summary are printed
-        before prompt_toolkit owns the live chrome, so they live in normal
-        terminal scrollback.  Erasing the screen on SIGWINCH removes that
-        startup UI and ``_replay_output_history`` cannot reconstruct it
-        (the banner was never added to ``_OUTPUT_HISTORY``).
+        When the terminal shrinks, the emulator can reflow previously rendered
+        full-width chrome rows into multiple narrower rows before
+        prompt_toolkit's normal resize logic runs. If we let prompt_toolkit
+        redraw first, it can paint on top of those stale rows and leave wrapped
+        duplicate lines behind.
 
-        Instead we just reset prompt_toolkit's renderer cache so the next
-        incremental redraw starts from a clean slate, then let
-        ``original_on_resize`` recalculate layout for the new size.
-
-        We also flag ``_status_bar_suppressed_after_resize`` so the dynamic
-        status bar and input separator rules stay hidden until the next user
-        input.  On column shrink the terminal reflows already-rendered status
-        bar rows into scrollback before prompt_toolkit can erase them; drawing
-        a fresh full-width bar immediately makes the old and new versions
-        look duplicated (#19280, #22976).  Clearing the suppression on the
-        next prompt restores the bar cleanly.
+        Fix: reset the renderer cache, then explicitly blank the visible screen
+        before prompt_toolkit recalculates layout for the new size. We still
+        suppress the status bar/input rules until the next real user input so a
+        freshly drawn footer does not immediately collide with recently reflowed
+        chrome during the resize burst.
         """
         self._status_bar_suppressed_after_resize = True
         try:
@@ -3070,10 +3063,16 @@ class HermesCLI:
         except Exception:
             pass
         try:
-            app.invalidate()
+            app.output.erase_screen()
+            app.output.cursor_goto(0, 0)
+            app.output.flush()
         except Exception:
             pass
         original_on_resize()
+        try:
+            app.invalidate()
+        except Exception:
+            pass
 
     def _schedule_resize_recovery(self, app, original_on_resize, delay: float = 0.12) -> None:
         """Debounce resize redraws so footer chrome is not stamped into scrollback."""

--- a/tests/cli/test_cli_force_redraw.py
+++ b/tests/cli/test_cli_force_redraw.py
@@ -71,39 +71,40 @@ class TestForceFullRedraw:
             "invalidate",
         ]
 
-    def test_resize_preserves_scrollback_and_resets_renderer(self, bare_cli, monkeypatch):
-        """Resize recovery must NOT erase screen or scrollback.
+    def test_resize_recovery_clears_visible_screen_before_prompt_toolkit_redraw(self, bare_cli, monkeypatch):
+        """Resize recovery must blank the visible screen before PTK redraws.
 
-        The startup banner lives in normal terminal scrollback (printed
-        before prompt_toolkit owns the chrome).  Clearing scrollback on
-        SIGWINCH removes it and ``_replay_output_history`` cannot
-        reconstruct it.  The fix is to only reset the renderer cache and
-        let ``original_on_resize`` recalculate layout.
+        On column shrink the terminal can reflow previously rendered footer rows
+        into extra wrapped lines before prompt_toolkit handles SIGWINCH. If PTK
+        redraws first, those stale rows remain visible as duplicated ghost lines.
 
-        Additionally, ``_status_bar_suppressed_after_resize`` must be set
-        so the input rules and status bar hide until the next user input,
-        preventing duplicated-bar artifacts on column shrink (#19280).
+        We still avoid scrollback-specific escape sequences (write_raw) and keep
+        status bar suppression until the next user input.
         """
         app = MagicMock()
         events = []
         app.renderer.reset.side_effect = lambda **_: events.append("renderer_reset")
+        app.output.erase_screen.side_effect = lambda: events.append("erase")
+        app.output.cursor_goto.side_effect = lambda *_: events.append("home")
+        app.output.flush.side_effect = lambda: events.append("flush")
         app.invalidate.side_effect = lambda: events.append("invalidate")
         original_on_resize = lambda: events.append("original_resize")
 
-        # bare_cli skips __init__, so seed the attribute the way __init__ would.
         bare_cli._status_bar_suppressed_after_resize = False
         bare_cli._recover_after_resize(app, original_on_resize)
 
         assert events == [
             "renderer_reset",
-            "invalidate",
+            "erase",
+            "home",
+            "flush",
             "original_resize",
+            "invalidate",
         ]
-        # Must NOT clear the screen or scrollback — those destroy the banner.
-        app.renderer.output.erase_screen.assert_not_called()
+        app.output.erase_screen.assert_called_once()
+        app.output.cursor_goto.assert_called_once_with(0, 0)
+        app.output.flush.assert_called_once()
         app.renderer.output.write_raw.assert_not_called()
-        app.renderer.output.cursor_goto.assert_not_called()
-        # Status bar / input rules must be suppressed until the next prompt.
         assert bare_cli._status_bar_suppressed_after_resize is True
 
     def test_force_redraw_uses_full_screen_clear_without_scrollback_clear(self, bare_cli):

--- a/tests/test_cli_resize_ghosting.py
+++ b/tests/test_cli_resize_ghosting.py
@@ -1,0 +1,29 @@
+from pathlib import Path
+
+
+def test_resize_handler_clears_screen_before_prompt_toolkit_redraw():
+    """The custom resize handler must blank the terminal before PTK redraws.
+
+    When the terminal shrinks, the emulator reflows previously full-width lines
+    into multiple rows. If cli.py calls _original_on_resize() before
+    erase_screen(), prompt_toolkit can redraw on top of those ghost rows and
+    leave duplicated wrapped content behind.
+    """
+
+    source = Path("cli.py").read_text(encoding="utf-8")
+
+    marker = "def _resize_clear_ghosts():"
+    start = source.index(marker)
+    end = source.index("app._on_resize = _resize_clear_ghosts", start)
+    block = source[start:end]
+
+    erase_idx = block.index("app.output.erase_screen()")
+    cursor_idx = block.index("app.output.cursor_goto(0, 0)")
+    flush_idx = block.index("app.output.flush()")
+    original_idx = block.rindex("_original_on_resize()")
+    invalidate_idx = block.index("app.invalidate()")
+
+    assert erase_idx < original_idx, "resize handler must clear screen before PTK redraw"
+    assert cursor_idx < original_idx, "cursor reset must happen before PTK redraw"
+    assert flush_idx < original_idx, "screen clear must be flushed before PTK redraw"
+    assert original_idx < invalidate_idx, "redraw invalidation should happen after PTK resize accounting"


### PR DESCRIPTION
## Summary
- clear the visible screen before prompt_toolkit redraws after terminal resize
- keep resize recovery debounced while preserving status-bar suppression semantics
- add regression coverage for resize recovery and redraw ordering

## Testing
- source ../../venv/bin/activate && python -m pytest -q tests/cli/test_cli_force_redraw.py tests/cli/test_cli_secret_capture.py tests/cli/test_cli_background_tui_refresh.py tests/tools/test_voice_cli_integration.py