### PR TITLE
fix(agent): re-anchor before session_search for ambiguous continuations

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -173,7 +173,12 @@ MEMORY_GUIDANCE = (
 SESSION_SEARCH_GUIDANCE = (
     "When the user references something from a past conversation or you suspect "
     "relevant cross-session context exists, use session_search to recall it before "
-    "asking them to repeat themselves."
+    "asking them to repeat themselves. Treat session_search as cross-session "
+    "history lookup, not as the source of truth for ambiguous continuations in "
+    "the current active session/thread. For requests like 'continue', 'remaining "
+    "work', or 'what were we doing' inside a gateway thread, first re-anchor on "
+    "the active session/thread and inspect current project or board state; only "
+    "use session_search afterward for explicitly historical context."
 )
 
 SKILLS_GUIDANCE = (

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -49,6 +49,15 @@ class TestGuidanceConstants:
         assert "relevant cross-session context exists" in SESSION_SEARCH_GUIDANCE
         assert "recent turns of the current session" not in SESSION_SEARCH_GUIDANCE
 
+    def test_session_search_guidance_requires_reanchoring_for_ambiguous_continuations(self):
+        # For ambiguous continuations ('continue', 'remaining work'), the agent
+        # should re-anchor on the current session/thread before session_search.
+        assert "re-anchor" in SESSION_SEARCH_GUIDANCE
+        assert "current active session" in SESSION_SEARCH_GUIDANCE
+        assert "ambiguous continuations" in SESSION_SEARCH_GUIDANCE
+        # Cross-session recall is still supported
+        assert "cross-session" in SESSION_SEARCH_GUIDANCE
+
 
 # =========================================================================
 # Context injection scanning


### PR DESCRIPTION
Fixes #30498

## Problem
`SESSION_SEARCH_GUIDANCE` encouraged `session_search` whenever cross-session context might exist, but did not distinguish between:
- explicit historical recall (where `session_search` should be used)
- ambiguous continuation requests in gateway threads (where current session/thread/project state should be checked first)

For ambiguous continuations like "continue", "remaining work", or "what were we doing" in a gateway thread, the agent could pick a cross-thread search result and treat it as the active task context, leading to incorrect file edits or status reports.

## Solution
Update `SESSION_SEARCH_GUIDANCE` to include re-anchoring rule:
- Treat `session_search` as cross-session history lookup, not the source of truth for ambiguous continuations
- For ambiguous continuation requests, first re-anchor on the active session/thread and inspect current project/board state
- Only use `session_search` afterward for explicitly historical context

## Tests
Added test `test_session_search_guidance_requires_reanchoring_for_ambiguous_continuations` asserting the new guidance includes:
- re-anchoring requirement
- current active session handling
- ambiguous continuation distinction
- cross-session recall still supported