### PR TITLE
fix(docker): include anthropic, bedrock, azure-identity extras in image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -75,10 +75,14 @@ RUN npm install --prefer-offline --no-audit && \
 # git), `[yc-bench]` (another git dep), and `[termux-all]` (Android
 # redundancy), none of which belong in the published container.
 #
+# Provider packages (anthropic, bedrock, azure-identity) are included
+# so Docker users can use these providers without requiring runtime
+# lazy-install access to PyPI (often blocked in containerized envs).
+#
 # The editable link is created after the source copy below.
 COPY pyproject.toml uv.lock ./
 RUN touch ./README.md
-RUN uv sync --frozen --no-install-project --extra all --extra messaging
+RUN uv sync --frozen --no-install-project --extra all --extra messaging --extra anthropic --extra bedrock --extra azure-identity
 
 # ---------- Source code ----------
 # .dockerignore excludes node_modules, so the installs above survive.


### PR DESCRIPTION
Fixes #30394

## Problem
Docker containers often run in isolated networks without access to PyPI. The lazy-install mechanism fails silently in these environments, causing ImportError when users try to use Anthropic, Bedrock, or Azure providers.

Error message:
```
Sorry, I encountered an error (ImportError).
The 'anthropic' package is required for the Anthropic provider. Install it with: pip install 'anthropic>=0.39.0'
```

## Root Cause
The `[all]` extra was intentionally slimmed down on 2026-05-12 to avoid quarantined PyPI packages breaking installs. Provider packages like `anthropic`, `bedrock`, and `azure-identity` were moved to lazy-install.

However, Docker containers in air-gapped or restricted networks cannot reach PyPI at runtime, so lazy-install fails.

## Solution
Add `--extra anthropic`, `--extra bedrock`, and `--extra azure-identity` to the Dockerfile's `uv sync` command so these provider packages are pre-installed in the published image.

This ensures Docker users can use these common providers without requiring runtime network access to PyPI.