### PR TITLE
Fix Docker image reporting in hermes status and avoid quiet custom oneshot stalls

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1063,11 +1063,19 @@ def run_conversation(
                 ):
                     _use_streaming = False
                 elif not agent._has_stream_consumers():
+                    # Quiet oneshot-style runs against custom OpenAI-
+                    # compatible endpoints are more reliable via the
+                    # non-streaming path. Some local providers keep the
+                    # stream open or emit empty deltas, which can stall a
+                    # quiet session that has no stream consumers.
+                    if agent.quiet_mode and agent.provider == "custom":
+                        _use_streaming = False
                     # No display/TTS consumer. Still prefer streaming for
-                    # health checking, but skip for Mock clients in tests
-                    # (mocks return SimpleNamespace, not stream iterators).
+                    # health checking otherwise, but skip for Mock clients
+                    # in tests (mocks return SimpleNamespace, not stream
+                    # iterators).
                     from unittest.mock import Mock
-                    if isinstance(getattr(agent, "client", None), Mock):
+                    if _use_streaming and isinstance(getattr(agent, "client", None), Mock):
                         _use_streaming = False
 
                 if _use_streaming:

--- a/hermes_cli/status.py
+++ b/hermes_cli/status.py
@@ -375,7 +375,11 @@ def show_status(args):
         print(f"  SSH Host:     {ssh_host or '(not set)'}")
         print(f"  SSH User:     {ssh_user or '(not set)'}")
     elif terminal_env == "docker":
-        docker_image = os.getenv("TERMINAL_DOCKER_IMAGE", "python:3.11-slim")
+        docker_image = (
+            os.getenv("TERMINAL_DOCKER_IMAGE")
+            or terminal_cfg.get("docker_image")
+            or "python:3.11-slim"
+        )
         print(f"  Docker Image: {docker_image}")
     elif terminal_env == "daytona":
         daytona_image = os.getenv("TERMINAL_DAYTONA_IMAGE", "nikolaik/python-nodejs:python3.11-nodejs20")


### PR DESCRIPTION
# Hermes PR Draft

## Title

Fix Docker image reporting in `hermes status` and avoid quiet custom oneshot stalls

## Summary

This change fixes two issues observed in a local Hermes setup using a custom OpenAI-compatible endpoint and Docker sandboxing:

1. `hermes status` ignored `terminal.docker_image` from config and showed the hardcoded fallback image when `TERMINAL_DOCKER_IMAGE` was unset.
2. Quiet-mode oneshot runs against a custom provider could stall because the conversation loop still preferred the streaming chat-completions path even when there were no stream consumers.

## Changes

### 1. Honor configured Docker image in `hermes status`

- Keep `TERMINAL_DOCKER_IMAGE` as the highest-priority override.
- Fall back to `terminal_cfg.get("docker_image")` before using the built-in default.

### 2. Prefer non-streaming for quiet custom-provider runs with no stream consumers

- In `agent/conversation_loop.py`, when a run is both `quiet_mode` and `provider == "custom"`, and there are no stream consumers, disable streaming.
- Preserve the existing mock-client guard, but only apply it when streaming is still enabled.

## Why

### Status output bug

Operators rely on `hermes status` to confirm which sandbox image is active. Showing the fallback image instead of the configured image is misleading and makes it harder to validate the security posture of Docker-backed runs.

### Oneshot reliability

For quiet oneshot executions, streaming provides little value when there are no stream consumers. Some OpenAI-compatible local endpoints keep the stream open or emit empty deltas, which can stall the session. Falling back to non-streaming for this narrow case improves reliability without affecting normal interactive sessions.

## Validation

Commands used locally:

```bash
cd ~/.hermes/hermes-agent
venv/bin/python -m py_compile hermes_cli/status.py
venv/bin/python -m py_compile agent/conversation_loop.py
~/.local/bin/hermes status | rg 'Docker Image|Backend'
~/.local/bin/hermes --ignore-rules -z "Reply with READY only. Do not use tools. Output exactly READY."
~/.local/bin/hermes --ignore-rules -t terminal -z "Use the terminal tool exactly once. Run this command: uname -s && pwd && if [ -d /Users ]; then echo host-users-visible; else echo host-users-hidden; fi. Do not answer until after the command succeeds. Then reply with exactly one sentence containing the OS, working directory, and host visibility result."
```

Observed results:

- `hermes status` reported the configured Docker image.
- Plain oneshot returned `READY`.
- Tool-using oneshot completed and reported Linux in `/workspace` with host `/Users` hidden from the sandbox.

## Risk

- The `status` change is low risk because it only adjusts configuration precedence for display.
- The oneshot change is intentionally narrow: it only affects quiet custom-provider runs with no stream consumers.

## Notes

- A reusable local patch and reapply script are available in the activity folder:
  - `hermes_local_fixes.patch`
  - `APPLY_LOCAL_FIXES.sh`