### PR TITLE
fix(skills): add official skills fallback when index has empty repo field (#30482)

### DIFF
--- a/tests/tools/test_skills_hub_official_fallback.py
+++ b/tests/tools/test_skills_hub_official_fallback.py
@@ -1,0 +1,200 @@
+"""Regression tests for HermesIndexSource official skills fallback.
+
+Issue #30482: skills index returns empty repo fields for all official skills,
+causing HermesIndexSource.fetch() to return None. The fix adds a fallback
+that constructs the GitHub path from NousResearch/hermes-agent/optional-skills/<path>
+when the source is "official" and repo is empty.
+"""
+
+import pytest
+from unittest.mock import MagicMock, patch, PropertyMock
+from tools.skills_hub import HermesIndexSource
+
+
+class TestHermesIndexSourceOfficialFallback:
+    """Tests for HermesIndexSource.fetch() official skills fallback (#30482)."""
+
+    def test_official_skill_fallback_with_empty_repo(self):
+        """When repo is empty but source is 'official' and path is set,
+        fetch should try NousResearch/hermes-agent/optional-skills/<path>."""
+        source = HermesIndexSource(auth=MagicMock())
+
+        # Mock the index to return an official skill with empty repo
+        mock_index = {
+            "skills": [
+                {
+                    "identifier": "official/finance/3-statement-model",
+                    "source": "official",
+                    "repo": "",
+                    "path": "finance/3-statement-model",
+                    "name": "3-statement-model",
+                    "resolved_github_id": "",
+                }
+            ]
+        }
+
+        # Mock the GitHub source to avoid real API calls
+        mock_github = MagicMock()
+        mock_bundle = MagicMock()
+        mock_bundle.source = None
+        mock_bundle.identifier = None
+        mock_github.fetch.return_value = mock_bundle
+
+        with patch.object(HermesIndexSource, "_ensure_loaded", return_value=mock_index):
+            with patch.object(HermesIndexSource, "_get_github", return_value=mock_github):
+                result = source.fetch("official/finance/3-statement-model")
+
+        # Verify the fallback path was tried
+        mock_github.fetch.assert_any_call(
+            "NousResearch/hermes-agent/optional-skills/finance/3-statement-model"
+        )
+        assert result is mock_bundle
+
+    def test_official_skill_fallback_not_used_when_repo_present(self):
+        """When repo is non-empty, the fallback should NOT be tried.
+        The normal repo/path path should be used."""
+        source = HermesIndexSource(auth=MagicMock())
+
+        mock_index = {
+            "skills": [
+                {
+                    "identifier": "official/some-skill",
+                    "source": "official",
+                    "repo": "someone/some-repo",
+                    "path": "skills/some-skill",
+                    "name": "some-skill",
+                    "resolved_github_id": "",
+                }
+            ]
+        }
+
+        mock_github = MagicMock()
+        mock_bundle = MagicMock()
+        mock_github.fetch.return_value = mock_bundle
+
+        with patch.object(HermesIndexSource, "_ensure_loaded", return_value=mock_index):
+            with patch.object(HermesIndexSource, "_get_github", return_value=mock_github):
+                result = source.fetch("official/some-skill")
+
+        # Verify the normal repo/path was used, not the fallback
+        mock_github.fetch.assert_any_call("someone/some-repo/skills/some-skill")
+        # Should NOT have been called with the fallback path
+        for call in mock_github.fetch.call_args_list:
+            assert "NousResearch/hermes-agent/optional-skills" not in str(call)
+        assert result is mock_bundle
+
+    def test_official_skill_fallback_not_used_when_resolved_github_id_present(self):
+        """When resolved_github_id is present (even with empty repo),
+        it should be used directly without falling back to the official fallback."""
+        source = HermesIndexSource(auth=MagicMock())
+
+        mock_index = {
+            "skills": [
+                {
+                    "identifier": "official/some-skill",
+                    "source": "official",
+                    "repo": "",
+                    "path": "skills/some-skill",
+                    "name": "some-skill",
+                    "resolved_github_id": "someone/some-repo/skills/some-skill",
+                }
+            ]
+        }
+
+        mock_github = MagicMock()
+        mock_bundle = MagicMock()
+        mock_github.fetch.return_value = mock_bundle
+
+        with patch.object(HermesIndexSource, "_ensure_loaded", return_value=mock_index):
+            with patch.object(HermesIndexSource, "_get_github", return_value=mock_github):
+                result = source.fetch("official/some-skill")
+
+        # Verify resolved_github_id was used
+        mock_github.fetch.assert_any_call("someone/some-repo/skills/some-skill")
+        assert result is mock_bundle
+
+    def test_official_skill_fallback_not_used_for_community_source(self):
+        """When source is 'community' (not 'official'), the fallback should NOT be used."""
+        source = HermesIndexSource(auth=MagicMock())
+
+        mock_index = {
+            "skills": [
+                {
+                    "identifier": "community/some-skill",
+                    "source": "community",
+                    "repo": "",
+                    "path": "skills/some-skill",
+                    "name": "some-skill",
+                    "resolved_github_id": "",
+                }
+            ]
+        }
+
+        mock_github = MagicMock()
+
+        with patch.object(HermesIndexSource, "_ensure_loaded", return_value=mock_index):
+            with patch.object(HermesIndexSource, "_get_github", return_value=mock_github):
+                result = source.fetch("community/some-skill")
+
+        # Should NOT have tried the official fallback
+        for call in mock_github.fetch.call_args_list:
+            assert "NousResearch/hermes-agent/optional-skills" not in str(call)
+        # And fetch should NOT have been called at all (no valid source)
+        assert result is None
+
+    def test_official_skill_fallback_not_used_when_no_path(self):
+        """When both repo and path are empty, fetch should return None."""
+        source = HermesIndexSource(auth=MagicMock())
+
+        mock_index = {
+            "skills": [
+                {
+                    "identifier": "official/broken-skill",
+                    "source": "official",
+                    "repo": "",
+                    "path": "",
+                    "name": "broken-skill",
+                    "resolved_github_id": "",
+                }
+            ]
+        }
+
+        mock_github = MagicMock()
+
+        with patch.object(HermesIndexSource, "_ensure_loaded", return_value=mock_index):
+            with patch.object(HermesIndexSource, "_get_github", return_value=mock_github):
+                result = source.fetch("official/broken-skill")
+
+        mock_github.fetch.assert_not_called()
+        assert result is None
+
+    def test_source_field_preserved_on_fallback(self):
+        """When fallback is used, the bundle.source should be set to the entry's source."""
+        source = HermesIndexSource(auth=MagicMock())
+
+        mock_index = {
+            "skills": [
+                {
+                    "identifier": "official/org/skill-name",
+                    "source": "official",
+                    "repo": "",
+                    "path": "org/skill-name",
+                    "name": "skill-name",
+                    "resolved_github_id": "",
+                }
+            ]
+        }
+
+        mock_github = MagicMock()
+        mock_bundle = MagicMock()
+        mock_bundle.source = None
+        mock_bundle.identifier = None
+        mock_github.fetch.return_value = mock_bundle
+
+        with patch.object(HermesIndexSource, "_ensure_loaded", return_value=mock_index):
+            with patch.object(HermesIndexSource, "_get_github", return_value=mock_github):
+                source.fetch("official/org/skill-name")
+
+        # After fetch, bundle.source should be "official"
+        assert mock_bundle.source == "official"
+        assert mock_bundle.identifier == "official/org/skill-name"

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -3247,13 +3247,26 @@ class HermesIndexSource(SkillSource):
                 return bundle
 
         # Fall back to identifier-based fetch via repo/path
-        repo = entry.get("repo", "")
-        path = entry.get("path", "")
+        repo = (entry.get("repo") or "").strip()
+        path = (entry.get("path") or "").strip()
+        source = entry.get("source", "")
         if repo and path:
             github_id = f"{repo}/{path}"
             bundle = self._get_github().fetch(github_id)
             if bundle:
-                bundle.source = entry.get("source", "hermes-index")
+                bundle.source = source
+                bundle.identifier = identifier
+                return bundle
+
+        # Fallback for official skills when the index has empty repo fields.
+        # The skills live at NousResearch/hermes-agent/optional-skills/<path>.
+        # When repo is empty but the source is "official" and a path is present,
+        # construct the GitHub ID from the canonical repo.
+        if not repo and source == "official" and path:
+            github_id = f"NousResearch/hermes-agent/optional-skills/{path}"
+            bundle = self._get_github().fetch(github_id)
+            if bundle:
+                bundle.source = source
                 bundle.identifier = identifier
                 return bundle
 


### PR DESCRIPTION
## What does this PR do?

When the Hermes skills index returns empty `repo` fields for official skills (which is currently the case for all 81 official skills), `hermes skills install official/<skill>` fails with:

```
Error: Could not fetch official/finance/3-statement-model from any source.
```

This PR adds a client-side fallback in `HermesIndexSource.fetch()`: when `repo` is empty but the source is `"official"` and a `path` is present, we construct the GitHub ID as `NousResearch/hermes-agent/optional-skills/<path>` — the canonical location for all official skills.

## Related Issue

Fixes #30482

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/skills_hub.py`: In `HermesIndexSource.fetch()`, after the normal repo/path path, add a fallback that constructs the GitHub path from `NousResearch/hermes-agent/optional-skills/<path>` when the source is `"official"` and `repo` is empty.
- Also tightened the existing repo/path extraction to use `.strip()` for whitespace safety.

## How to Test

```bash
pytest tests/tools/test_skills_hub_official_fallback.py -v
```

6 regression tests cover:
- Fallback constructs correct path when repo is empty
- Fallback NOT used when repo is present (normal path still works)
- Fallback NOT used when resolved_github_id is present (fast path still works)
- Fallback NOT used for community-source skills
- Returns None when both repo and path are empty
- Bundle.source is correctly preserved on fallback

## Verification

- 6/6 tests pass (verified on macOS Python 3.14)
- Fail-without-fix confirmed: reverting the production change causes the positive-case test to fail
- No new dependencies
- No AI attribution

## Checklist

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've added tests for my changes