### PR TITLE
fix(skills): resolve official index fallback paths

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1146,6 +1146,7 @@ AUTHOR_MAP = {
     "aviarchi1994@gmail.com": "avifenesh",  # PR #25902 (docs: computer-use-linux MCP)
     "55848801+avifenesh@users.noreply.github.com": "avifenesh",
     "279959838+BROCCOLO1D@users.noreply.github.com": "BROCCOLO1D",  # PR #26796 (docs: spotify + HA)
+    "hermes-agent@users.noreply.github.com": "BROCCOLO1D",  # PR #30510 (skills official index fallback)
     "m@matthewlai.ca": "matthewlai",  # PR #25293 (feat: gemma 4 reasoning allowlist)
     "4296245+matthewlai@users.noreply.github.com": "matthewlai",
     "109617724+0xchainer@users.noreply.github.com": "0xchainer",  # PR #27154/27138/27147 salvage

--- a/tests/tools/test_skills_hub.py
+++ b/tests/tools/test_skills_hub.py
@@ -15,6 +15,7 @@ from tools.skills_hub import (
     UrlSource,
     WellKnownSkillSource,
     OptionalSkillSource,
+    HermesIndexSource,
     SkillMeta,
     SkillBundle,
     HubLockFile,
@@ -1425,6 +1426,73 @@ class TestSkillMetaToDict:
         restored = SkillMeta(**d)
         assert restored.name == meta.name
         assert restored.trust_level == meta.trust_level
+
+
+# ---------------------------------------------------------------------------
+# Hermes centralized index source
+# ---------------------------------------------------------------------------
+
+
+class TestHermesIndexSource:
+    def test_official_entry_without_repo_falls_back_to_optional_skills_github_path(self):
+        """Bad docs indexes may omit repo/resolved_github_id for official skills.
+
+        The CLI should still be able to install them by resolving the
+        category-relative path into this repo's optional-skills tree.
+        """
+        bundle = SkillBundle(
+            name="3-statement-model",
+            files={"SKILL.md": "---\nname: 3-statement-model\n---\n"},
+            source="github",
+            identifier="placeholder",
+            trust_level="builtin",
+        )
+        github = MagicMock()
+        github.fetch.return_value = bundle
+        src = HermesIndexSource(auth=MagicMock())
+        src._index = {
+            "skills": [
+                {
+                    "name": "3-statement-model",
+                    "source": "official",
+                    "identifier": "official/finance/3-statement-model",
+                    "repo": "",
+                    "path": "finance/3-statement-model",
+                    "resolved_github_id": "",
+                    "trust_level": "builtin",
+                }
+            ]
+        }
+        src._loaded = True
+        src._github = github
+
+        result = src.fetch("official/finance/3-statement-model")
+
+        assert result is not None
+        assert result is bundle
+        github.fetch.assert_called_once_with(
+            "NousResearch/hermes-agent/optional-skills/finance/3-statement-model"
+        )
+        assert result.source == "official"
+        assert result.identifier == "official/finance/3-statement-model"
+
+    def test_github_id_for_entry_preserves_explicit_repo_path(self):
+        assert (
+            HermesIndexSource._github_id_for_entry({
+                "repo": "owner/repo",
+                "path": "skills/foo",
+                "source": "official",
+            })
+            == "owner/repo/skills/foo"
+        )
+
+    @pytest.mark.parametrize("path", ["..", "../secret", ""])
+    def test_github_id_for_entry_rejects_bad_official_paths(self, path):
+        assert HermesIndexSource._github_id_for_entry({
+            "source": "official",
+            "repo": "",
+            "path": path,
+        }) is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_skills_hub.py
+++ b/tests/tools/test_skills_hub.py
@@ -1486,7 +1486,18 @@ class TestHermesIndexSource:
             == "owner/repo/skills/foo"
         )
 
-    @pytest.mark.parametrize("path", ["..", "../secret", ""])
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "..",
+            "../secret",
+            "",
+            "/finance/3-statement-model",
+            "finance/foo/../../secret",
+            "optional-skills/../skills/foo",
+            r"finance\\foo",
+        ],
+    )
     def test_github_id_for_entry_rejects_bad_official_paths(self, path):
         assert HermesIndexSource._github_id_for_entry({
             "source": "official",

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -3261,9 +3261,16 @@ class HermesIndexSource(SkillSource):
         if source != "official" or not path:
             return None
 
-        rel = str(PurePosixPath(str(path)))
-        if rel in {"", "."} or rel.startswith("../") or rel == "..":
+        raw_path = str(path)
+        pure_path = PurePosixPath(raw_path)
+        if (
+            raw_path in {"", "."}
+            or pure_path.is_absolute()
+            or "\\" in raw_path
+            or any(part == ".." for part in pure_path.parts)
+        ):
             return None
+        rel = str(pure_path)
         if not rel.startswith("optional-skills/"):
             rel = f"optional-skills/{rel}"
         return f"NousResearch/hermes-agent/{rel}"

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -3235,11 +3235,12 @@ class HermesIndexSource(SkillSource):
                 bundle.identifier = identifier
                 return bundle
 
-        # Fall back to identifier-based fetch via repo/path
-        repo = entry.get("repo", "")
-        path = entry.get("path", "")
-        if repo and path:
-            github_id = f"{repo}/{path}"
+        # Fall back to identifier-based fetch via repo/path.  Official skills
+        # are shipped from this repository's optional-skills/ tree; tolerate
+        # older/bad index entries that omitted repo/resolved_github_id and only
+        # stored the category-relative path (e.g. "finance/foo").
+        github_id = self._github_id_for_entry(entry)
+        if github_id:
             bundle = self._get_github().fetch(github_id)
             if bundle:
                 bundle.source = entry.get("source", "hermes-index")
@@ -3247,6 +3248,25 @@ class HermesIndexSource(SkillSource):
                 return bundle
 
         return None
+
+    @staticmethod
+    def _github_id_for_entry(entry: dict) -> Optional[str]:
+        """Return a GitHubSource identifier for an index entry if possible."""
+        repo = entry.get("repo", "")
+        path = entry.get("path", "")
+        if repo and path:
+            return f"{repo}/{path}"
+
+        source = entry.get("source", "")
+        if source != "official" or not path:
+            return None
+
+        rel = str(PurePosixPath(str(path)))
+        if rel in {"", "."} or rel.startswith("../") or rel == "..":
+            return None
+        if not rel.startswith("optional-skills/"):
+            rel = f"optional-skills/{rel}"
+        return f"NousResearch/hermes-agent/{rel}"
 
     def inspect(self, identifier: str) -> Optional[SkillMeta]:
         """Return metadata from the index.  Zero API calls."""


### PR DESCRIPTION
## Summary
- Adds a fallback for malformed `official/*` centralized index entries that have `path` but no `repo` or `resolved_github_id`.
- Closes #30482.

## Why
- The published skills index currently lists official skills with empty GitHub fields, so `HermesIndexSource.fetch()` returns `None` instead of downloading from the repo.

## Changes
- `tools/skills_hub.py`: resolves official index paths like `finance/3-statement-model` to `NousResearch/hermes-agent/optional-skills/finance/3-statement-model` when explicit GitHub metadata is missing.
- `tests/tools/test_skills_hub.py`: covers the malformed official index entry, explicit repo/path preservation, and traversal-ish path rejection.

## Validation
- `/home/hermes/.hermes/hermes-agent/venv/bin/python -m pytest tests/tools/test_skills_hub.py -o 'addopts=' -q`
- `/home/hermes/.hermes/hermes-agent/venv/bin/python -m ruff check tools/skills_hub.py tests/tools/test_skills_hub.py`

## Scope
- In scope: official skills index fallback when repo/resolved path metadata is missing.
- Out of scope: changing the generated docs index data itself or unrelated skills source behavior.
