### PR TITLE
fix(terminal): reuse persistent Docker container across restarts (#30336)

### DIFF
--- a/tests/tools/test_docker_environment.py
+++ b/tests/tools/test_docker_environment.py
@@ -1,3 +1,4 @@
+import json
 import logging
 from io import StringIO
 import subprocess
@@ -202,13 +203,33 @@ def test_auto_mount_replaces_persistent_workspace_bind(monkeypatch, tmp_path):
     assert "/sandboxes/docker/test-persistent-auto-mount/workspace:/workspace" not in run_args_str
 
 
-def _make_persistent_mock_run(monkeypatch, inspect_result):
+def _make_persistent_mock_run(monkeypatch, inspect_result, *, inspect_labels="match"):
     """Mock subprocess.run with a configurable docker inspect response.
 
-    ``inspect_result`` is either a tuple ``(returncode, stdout)`` or None.
-    None means inspect is never called (i.e. inspect would error / not exist).
+    ``inspect_result`` is either ``(returncode, status, container_id)`` or
+    ``None``. ``None`` means inspect returns "no such object" (the fresh-create
+    path). ``inspect_labels`` controls the labels embedded in the inspect
+    JSON output:
+
+      * ``"match"`` (default) — labels that match this Hermes config. To
+        keep the helper standalone, ``_compute_config_fingerprint`` is
+        patched to a constant ``"test-fp"`` so the helper can emit a
+        matching label without recomputing it.
+      * ``"missing"`` — empty labels dict (simulates a pre-existing
+        unlabeled same-name container, e.g. created outside Hermes).
+      * ``"mismatched"`` — Hermes-shaped labels but with a different
+        config fingerprint (simulates the container being from an older
+        Hermes config with different mounts / caps / user).
+      * dict — explicit label map.
+
     Returns the list of captured ``(cmd, kwargs)`` tuples.
     """
+    # Pin the fingerprint so the helper can synthesise matching labels
+    # without recomputing across every test fixture's run-args shape.
+    monkeypatch.setattr(
+        docker_env, "_compute_config_fingerprint", lambda *a, **kw: "test-fp"
+    )
+
     calls = []
 
     def _run(cmd, **kwargs):
@@ -219,16 +240,54 @@ def _make_persistent_mock_run(monkeypatch, inspect_result):
             if cmd[1] == "inspect":
                 if inspect_result is None:
                     return subprocess.CompletedProcess(cmd, 1, stdout="", stderr="No such object")
-                rc, stdout = inspect_result
+                rc, status, container_id = inspect_result
+                # ``cmd[-1]`` is the container name (last arg to inspect).
+                # Recover the task_id-shaped suffix from that name.
+                container_name = cmd[-1]
+                suffix = container_name.split("-", 1)[1] if "-" in container_name else ""
+                labels = _resolve_labels_for_inspect_by_suffix(suffix)
+                labels_json = json.dumps(labels) if labels is not None else "null"
+                stdout = f"{status}\t{container_id}\t{labels_json}\n"
                 return subprocess.CompletedProcess(cmd, rc, stdout=stdout, stderr="")
             if cmd[1] == "start":
+                return subprocess.CompletedProcess(cmd, 0, stdout=cmd[-1] + "\n", stderr="")
+            if cmd[1] == "rm":
+                # docker rm -f for stale-container cleanup
                 return subprocess.CompletedProcess(cmd, 0, stdout=cmd[-1] + "\n", stderr="")
             if cmd[1] == "run":
                 return subprocess.CompletedProcess(cmd, 0, stdout="fresh-container-id\n", stderr="")
         return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
 
+    def _resolve_labels_for_inspect_by_suffix(suffix: str) -> dict | None:
+        if inspect_labels == "match":
+            return {
+                docker_env._HERMES_OWNER_LABEL: "true",
+                docker_env._SANDBOX_KEY_LABEL: suffix,
+                docker_env._CONFIG_FP_LABEL: "test-fp",
+            }
+        if inspect_labels == "missing":
+            return {}
+        if inspect_labels == "mismatched":
+            return {
+                docker_env._HERMES_OWNER_LABEL: "true",
+                docker_env._SANDBOX_KEY_LABEL: suffix,
+                docker_env._CONFIG_FP_LABEL: "stale-fp-from-old-config",
+            }
+        if isinstance(inspect_labels, dict):
+            return inspect_labels
+        return None
+
     monkeypatch.setattr(docker_env.subprocess, "run", _run)
     return calls
+
+
+def _expected_sandbox_key_suffix(task_id: str) -> str:
+    """Mirror the suffix that ``DockerEnvironment`` derives from ``task_id``."""
+    import hashlib
+    from tools.environments.base import get_sandbox_dir
+
+    sandbox_key = str(get_sandbox_dir() / "docker" / task_id)
+    return hashlib.sha1(sandbox_key.encode("utf-8")).hexdigest()[:12]
 
 
 def test_persistent_container_name_is_deterministic(monkeypatch):
@@ -261,7 +320,7 @@ def test_persistent_reuses_running_container(monkeypatch):
     monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
     calls = _make_persistent_mock_run(
         monkeypatch,
-        inspect_result=(0, "running\texisting-container-id\n"),
+        inspect_result=(0, "running", "existing-container-id"),
     )
 
     env = _make_dummy_env(persistent_filesystem=True, task_id="docker-reuse-running")
@@ -276,7 +335,7 @@ def test_persistent_restarts_stopped_container(monkeypatch):
     monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
     calls = _make_persistent_mock_run(
         monkeypatch,
-        inspect_result=(0, "exited\tstopped-container-id\n"),
+        inspect_result=(0, "exited", "stopped-container-id"),
     )
 
     env = _make_dummy_env(persistent_filesystem=True, task_id="docker-restart-stopped")
@@ -316,7 +375,7 @@ def test_non_persistent_uses_random_name_and_skips_inspect(monkeypatch):
     monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
     calls = _make_persistent_mock_run(
         monkeypatch,
-        inspect_result=(0, "running\tshould-not-be-used\n"),
+        inspect_result=(0, "running", "should-not-be-used"),
     )
 
     env = _make_dummy_env(persistent_filesystem=False, task_id="docker-ephemeral")
@@ -324,6 +383,121 @@ def test_non_persistent_uses_random_name_and_skips_inspect(monkeypatch):
     cmds = [c[0] for c in calls if isinstance(c[0], list)]
     inspect_calls = [c for c in cmds if len(c) >= 2 and c[1] == "inspect"]
     assert inspect_calls == [], "non-persistent mode must not consult docker inspect"
+    assert env._container_id == "fresh-container-id"
+
+
+def test_persistent_creates_includes_identity_labels(monkeypatch):
+    """The fresh-create path must label the container with Hermes identity.
+
+    Without these labels, a later Hermes process couldn't tell whether a
+    same-name container came from us or from outside, and the reuse gate
+    in ``_try_reuse_persistent_container`` would have nothing to check.
+    """
+    monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
+    calls = _make_persistent_mock_run(monkeypatch, inspect_result=None)
+
+    env = _make_dummy_env(persistent_filesystem=True, task_id="docker-labels-test")
+
+    run_calls = [c[0] for c in calls if isinstance(c[0], list) and len(c[0]) >= 2 and c[0][1] == "run"]
+    assert len(run_calls) == 1
+    run_args = run_calls[0]
+    # Each label is passed as two adjacent argv entries: "--label" then "k=v".
+    labels = {
+        run_args[i + 1].split("=", 1)[0]: run_args[i + 1].split("=", 1)[1]
+        for i in range(len(run_args) - 1)
+        if run_args[i] == "--label" and "=" in run_args[i + 1]
+    }
+    assert labels.get(docker_env._HERMES_OWNER_LABEL) == "true"
+    assert labels.get(docker_env._SANDBOX_KEY_LABEL) == env._sandbox_key_suffix
+    assert labels.get(docker_env._CONFIG_FP_LABEL) == "test-fp"
+
+
+def test_persistent_rejects_unlabeled_same_name_container(monkeypatch):
+    """A pre-existing same-name container without Hermes labels must NOT be
+    reused. Hermes-owned identity is the only signal that the container was
+    created under the current security posture — without it, a stray
+    container could be adopted with looser caps / different mounts / a
+    different user, and then receive init-time env forwarding.
+    """
+    monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
+    calls = _make_persistent_mock_run(
+        monkeypatch,
+        inspect_result=(0, "running", "preexisting-foreign-container-id"),
+        inspect_labels="missing",
+    )
+
+    env = _make_dummy_env(
+        persistent_filesystem=True, task_id="docker-unlabeled-reject"
+    )
+
+    cmds = [c[0] for c in calls if isinstance(c[0], list)]
+    rm_calls = [c for c in cmds if len(c) >= 2 and c[1] == "rm"]
+    run_calls = [c for c in cmds if len(c) >= 2 and c[1] == "run"]
+    assert len(rm_calls) == 1, (
+        "unlabeled same-name container must be force-removed before recreate"
+    )
+    assert "-f" in rm_calls[0], "docker rm must use -f to clear a running stale container"
+    assert rm_calls[0][-1] == env._container_name
+    assert len(run_calls) == 1, "a fresh container must be created after the stale one is removed"
+    assert env._container_id == "fresh-container-id", (
+        "the stale container's id must NOT be adopted"
+    )
+
+
+def test_persistent_rejects_mismatched_config_fingerprint(monkeypatch):
+    """A Hermes-labeled same-name container whose config fingerprint differs
+    from the current run's config must NOT be reused. Config drift
+    (changed mounts, caps, user, network mode, security args, env config,
+    extra args) is exactly the security-relevant case the fingerprint
+    label is designed to catch.
+    """
+    monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
+    calls = _make_persistent_mock_run(
+        monkeypatch,
+        inspect_result=(0, "running", "stale-config-container-id"),
+        inspect_labels="mismatched",
+    )
+
+    env = _make_dummy_env(
+        persistent_filesystem=True, task_id="docker-fingerprint-reject"
+    )
+
+    cmds = [c[0] for c in calls if isinstance(c[0], list)]
+    rm_calls = [c for c in cmds if len(c) >= 2 and c[1] == "rm"]
+    run_calls = [c for c in cmds if len(c) >= 2 and c[1] == "run"]
+    assert len(rm_calls) == 1, (
+        "mismatched-fingerprint container must be force-removed before recreate"
+    )
+    assert len(run_calls) == 1, "a fresh container must be created after the stale one is removed"
+    assert env._container_id == "fresh-container-id"
+
+
+def test_persistent_rejects_wrong_owner_label_value(monkeypatch):
+    """A same-name container with the Hermes owner-label key but an
+    unexpected value (e.g. someone manually set ``=false``) must still be
+    rejected. Label presence alone isn't trustworthy — Hermes only writes
+    the literal value ``true``.
+    """
+    monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
+    calls = _make_persistent_mock_run(
+        monkeypatch,
+        inspect_result=(0, "running", "wrong-owner-value-id"),
+        inspect_labels={
+            docker_env._HERMES_OWNER_LABEL: "false",
+            docker_env._SANDBOX_KEY_LABEL: _expected_sandbox_key_suffix(
+                "docker-wrong-owner"
+            ),
+            docker_env._CONFIG_FP_LABEL: "test-fp",
+        },
+    )
+
+    env = _make_dummy_env(
+        persistent_filesystem=True, task_id="docker-wrong-owner"
+    )
+
+    cmds = [c[0] for c in calls if isinstance(c[0], list)]
+    rm_calls = [c for c in cmds if len(c) >= 2 and c[1] == "rm"]
+    assert len(rm_calls) == 1, "owner-label mismatch must trigger force-remove"
     assert env._container_id == "fresh-container-id"
 
 

--- a/tests/tools/test_docker_environment.py
+++ b/tests/tools/test_docker_environment.py
@@ -202,6 +202,131 @@ def test_auto_mount_replaces_persistent_workspace_bind(monkeypatch, tmp_path):
     assert "/sandboxes/docker/test-persistent-auto-mount/workspace:/workspace" not in run_args_str
 
 
+def _make_persistent_mock_run(monkeypatch, inspect_result):
+    """Mock subprocess.run with a configurable docker inspect response.
+
+    ``inspect_result`` is either a tuple ``(returncode, stdout)`` or None.
+    None means inspect is never called (i.e. inspect would error / not exist).
+    Returns the list of captured ``(cmd, kwargs)`` tuples.
+    """
+    calls = []
+
+    def _run(cmd, **kwargs):
+        calls.append((list(cmd) if isinstance(cmd, list) else cmd, kwargs))
+        if isinstance(cmd, list) and len(cmd) >= 2:
+            if cmd[1] == "version":
+                return subprocess.CompletedProcess(cmd, 0, stdout="Docker version", stderr="")
+            if cmd[1] == "inspect":
+                if inspect_result is None:
+                    return subprocess.CompletedProcess(cmd, 1, stdout="", stderr="No such object")
+                rc, stdout = inspect_result
+                return subprocess.CompletedProcess(cmd, rc, stdout=stdout, stderr="")
+            if cmd[1] == "start":
+                return subprocess.CompletedProcess(cmd, 0, stdout=cmd[-1] + "\n", stderr="")
+            if cmd[1] == "run":
+                return subprocess.CompletedProcess(cmd, 0, stdout="fresh-container-id\n", stderr="")
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(docker_env.subprocess, "run", _run)
+    return calls
+
+
+def test_persistent_container_name_is_deterministic(monkeypatch):
+    """Persistent mode must derive a stable container name from the sandbox path.
+
+    Two instances with the same task_id should pick the same container name,
+    so a restart of the Hermes process can reattach instead of spawning a fresh
+    container on every run (#30336).
+    """
+    monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
+    _make_persistent_mock_run(monkeypatch, inspect_result=None)
+
+    env1 = _make_dummy_env(persistent_filesystem=True, task_id="docker-persist-task")
+    env2 = _make_dummy_env(persistent_filesystem=True, task_id="docker-persist-task")
+
+    assert env1._container_name == env2._container_name
+    assert env1._container_name.startswith("hermes-")
+    # 12-char sha1 prefix has 48 bits of entropy — wide enough to avoid
+    # colliding with a non-persistent uuid (which would be 8 chars).
+    assert len(env1._container_name) == len("hermes-") + 12
+
+
+def test_persistent_reuses_running_container(monkeypatch):
+    """When a container with the deterministic name is already running, reuse it.
+
+    No second ``docker run`` should be issued — the existing container ID is
+    adopted as ``_container_id`` so subsequent exec calls land on the same
+    container.
+    """
+    monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
+    calls = _make_persistent_mock_run(
+        monkeypatch,
+        inspect_result=(0, "running\texisting-container-id\n"),
+    )
+
+    env = _make_dummy_env(persistent_filesystem=True, task_id="docker-reuse-running")
+
+    assert env._container_id == "existing-container-id"
+    run_calls = [c for c in calls if isinstance(c[0], list) and len(c[0]) >= 2 and c[0][1] == "run"]
+    assert run_calls == [], "docker run must not be invoked when an existing container is reused"
+
+
+def test_persistent_restarts_stopped_container(monkeypatch):
+    """A stopped persistent container should be restarted, not duplicated."""
+    monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
+    calls = _make_persistent_mock_run(
+        monkeypatch,
+        inspect_result=(0, "exited\tstopped-container-id\n"),
+    )
+
+    env = _make_dummy_env(persistent_filesystem=True, task_id="docker-restart-stopped")
+
+    assert env._container_id == "stopped-container-id"
+    cmds = [c[0] for c in calls if isinstance(c[0], list)]
+    start_calls = [c for c in cmds if len(c) >= 2 and c[1] == "start"]
+    run_calls = [c for c in cmds if len(c) >= 2 and c[1] == "run"]
+    assert len(start_calls) == 1, "stopped persistent container should be started exactly once"
+    assert start_calls[0][-1] == env._container_name
+    assert run_calls == [], "docker run must not be invoked when the existing container is restarted"
+
+
+def test_persistent_creates_when_no_existing_container(monkeypatch):
+    """When no container with the deterministic name exists, fall back to create."""
+    monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
+    calls = _make_persistent_mock_run(monkeypatch, inspect_result=None)
+
+    env = _make_dummy_env(persistent_filesystem=True, task_id="docker-create-new")
+
+    assert env._container_id == "fresh-container-id"
+    run_calls = [c[0] for c in calls if isinstance(c[0], list) and len(c[0]) >= 2 and c[0][1] == "run"]
+    assert len(run_calls) == 1
+    # The newly-created container must use the deterministic name so the next
+    # process can find it via docker inspect.
+    assert "--name" in run_calls[0]
+    name_idx = run_calls[0].index("--name")
+    assert run_calls[0][name_idx + 1] == env._container_name
+
+
+def test_non_persistent_uses_random_name_and_skips_inspect(monkeypatch):
+    """Non-persistent containers must keep ephemeral random names (no reuse path).
+
+    Reuse semantics only make sense when the container's filesystem persists
+    across restarts. For tmpfs-backed containers, reattaching would leak state.
+    """
+    monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
+    calls = _make_persistent_mock_run(
+        monkeypatch,
+        inspect_result=(0, "running\tshould-not-be-used\n"),
+    )
+
+    env = _make_dummy_env(persistent_filesystem=False, task_id="docker-ephemeral")
+
+    cmds = [c[0] for c in calls if isinstance(c[0], list)]
+    inspect_calls = [c for c in cmds if len(c) >= 2 and c[1] == "inspect"]
+    assert inspect_calls == [], "non-persistent mode must not consult docker inspect"
+    assert env._container_id == "fresh-container-id"
+
+
 def test_non_persistent_cleanup_removes_container(monkeypatch):
     """When persistent=false, cleanup() must schedule docker stop + rm."""
     monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")

--- a/tools/environments/docker.py
+++ b/tools/environments/docker.py
@@ -6,6 +6,7 @@ persistence via bind mounts.
 """
 
 import hashlib
+import json
 import logging
 import os
 import re
@@ -186,6 +187,33 @@ def _build_security_args(run_as_host_user: bool) -> list[str]:
     if run_as_host_user:
         return list(_BASE_SECURITY_ARGS)
     return list(_BASE_SECURITY_ARGS) + list(_PRIVDROP_CAP_ARGS)
+
+
+# Hermes-owned identity labels applied to every persistent container we
+# create. They let ``_try_reuse_persistent_container`` reject any same-name
+# container that wasn't created by Hermes (or was created under a different
+# security/config posture) before it would otherwise be exec'd into and
+# fed init-time env forwarding. See PR #30511 review.
+_HERMES_OWNER_LABEL = "org.hermes-agent.container"
+_SANDBOX_KEY_LABEL = "org.hermes-agent.sandbox-key"
+_CONFIG_FP_LABEL = "org.hermes-agent.config-fingerprint"
+
+
+def _compute_config_fingerprint(image: str, cwd: str, run_args: list[str]) -> str:
+    """Deterministic fingerprint of the security-relevant container config.
+
+    Persists on the container as a label so a later Hermes process can
+    detect drift (extra volumes, looser caps, changed user/network args,
+    altered env config) and refuse to reuse a stale container that was
+    created under a different security posture.
+
+    ``run_args`` is the assembled list passed to ``docker run`` minus the
+    name/labels (which are not part of the security surface). Order is
+    preserved because the docker CLI is order-sensitive for some flags.
+    """
+    parts = [image, cwd, *run_args]
+    blob = "\x00".join(parts).encode("utf-8")
+    return hashlib.sha256(blob).hexdigest()[:16]
 
 
 def _resolve_host_user_spec() -> Optional[str]:
@@ -515,12 +543,36 @@ class DockerEnvironment(BaseEnvironment):
             name_suffix = hashlib.sha1(sandbox_key.encode("utf-8")).hexdigest()[:12]
             container_name = f"hermes-{name_suffix}"
         else:
+            sandbox_key = ""
+            name_suffix = ""
             container_name = f"hermes-{uuid.uuid4().hex[:8]}"
         self._container_name = container_name
 
+        # Identity + config fingerprint labels — only meaningful in
+        # persistent mode (the only path that reuses an existing container).
+        # Computed from the same arg list that goes into ``docker run`` so a
+        # later inspect can detect drift in any security-relevant input.
+        config_fingerprint = _compute_config_fingerprint(image, cwd, all_run_args)
+        if self._persistent:
+            self._sandbox_key_suffix = name_suffix
+            self._config_fingerprint = config_fingerprint
+            label_args = [
+                "--label", f"{_HERMES_OWNER_LABEL}=true",
+                "--label", f"{_SANDBOX_KEY_LABEL}={name_suffix}",
+                "--label", f"{_CONFIG_FP_LABEL}={config_fingerprint}",
+            ]
+        else:
+            self._sandbox_key_suffix = ""
+            self._config_fingerprint = ""
+            label_args = []
+
         reused = False
         if self._persistent:
-            reused = self._try_reuse_persistent_container(container_name)
+            reused = self._try_reuse_persistent_container(
+                container_name,
+                expected_sandbox_key=name_suffix,
+                expected_config_fingerprint=config_fingerprint,
+            )
 
         if not reused:
             # Start the container directly via `docker run -d`.
@@ -529,6 +581,7 @@ class DockerEnvironment(BaseEnvironment):
                 "--init",           # tini/catatonit as PID 1 — reaps zombie children
                 "--name", container_name,
                 "-w", cwd,
+                *label_args,
                 *all_run_args,
                 image,
                 "sleep", "infinity",  # no fixed lifetime — idle reaper handles cleanup
@@ -552,18 +605,33 @@ class DockerEnvironment(BaseEnvironment):
         # Initialize session snapshot inside the container
         self.init_session()
 
-    def _try_reuse_persistent_container(self, container_name: str) -> bool:
+    def _try_reuse_persistent_container(
+        self,
+        container_name: str,
+        expected_sandbox_key: str,
+        expected_config_fingerprint: str,
+    ) -> bool:
         """Reattach to an existing persistent container with this name, if any.
 
         Returns True when ``self._container_id`` was populated from an existing
         container (running or restarted), False when the caller should create a
         new container. Any docker-side failure falls back to creation rather
         than blocking the agent.
+
+        Security gate: only containers we labeled ourselves under the same
+        sandbox key AND with a matching config fingerprint are eligible for
+        reuse. An unlabeled same-name container (created outside Hermes, or
+        by an older Hermes version, or after a config change) is force-removed
+        and the caller creates a fresh container under the current security
+        posture. Without this gate, a pre-existing local container could be
+        adopted with looser caps / different mounts / different user and then
+        receive init-time env forwarding from ``init_session()``.
         """
         try:
             inspect = subprocess.run(
                 [self._docker_exe, "inspect", "--format",
-                 "{{.State.Status}}\t{{.Id}}", container_name],
+                 "{{.State.Status}}\t{{.Id}}\t{{json .Config.Labels}}",
+                 container_name],
                 capture_output=True, text=True, timeout=10,
             )
         except (OSError, subprocess.TimeoutExpired) as exc:
@@ -571,10 +639,28 @@ class DockerEnvironment(BaseEnvironment):
             return False
         if inspect.returncode != 0:
             return False
-        parts = inspect.stdout.strip().split("\t", 1)
-        if len(parts) != 2 or not parts[1]:
+        parts = inspect.stdout.strip().split("\t", 2)
+        if len(parts) != 3 or not parts[1]:
             return False
-        status, container_id = parts[0], parts[1]
+        status, container_id, labels_json = parts
+        try:
+            labels = json.loads(labels_json) if labels_json else {}
+        except json.JSONDecodeError:
+            labels = {}
+        if not isinstance(labels, dict):
+            labels = {}
+
+        if not self._labels_match_expected(
+            labels, expected_sandbox_key, expected_config_fingerprint
+        ):
+            logger.warning(
+                "Refusing to reuse container %s (%s): labels missing or do not "
+                "match this Hermes config — recreating under current security "
+                "posture",
+                container_name, container_id[:12],
+            )
+            self._force_remove_stale_container(container_name)
+            return False
 
         if status != "running":
             try:
@@ -601,6 +687,58 @@ class DockerEnvironment(BaseEnvironment):
             container_name, container_id[:12], status,
         )
         return True
+
+    @staticmethod
+    def _labels_match_expected(
+        labels: dict,
+        expected_sandbox_key: str,
+        expected_config_fingerprint: str,
+    ) -> bool:
+        """Return True iff every Hermes identity label is present and matches.
+
+        Owner label must be the literal string ``"true"`` — its presence
+        AND value together prove Hermes set it (a stray ``--label
+        org.hermes-agent.container`` from outside would not have the value
+        either). Sandbox key must match the per-task suffix we expect.
+        Config fingerprint must match the current run's fingerprint —
+        catches drift in image / cwd / mounts / caps / user / network /
+        env / extra args.
+        """
+        if labels.get(_HERMES_OWNER_LABEL) != "true":
+            return False
+        if labels.get(_SANDBOX_KEY_LABEL) != expected_sandbox_key:
+            return False
+        if labels.get(_CONFIG_FP_LABEL) != expected_config_fingerprint:
+            return False
+        return True
+
+    def _force_remove_stale_container(self, container_name: str) -> None:
+        """Best-effort ``docker rm -f`` of a mismatched same-name container.
+
+        Failing closed instead would leave the agent unable to start at all
+        whenever a stray same-name container existed; failing open by reusing
+        the mismatched container is the exact security regression this gate
+        was added to prevent. Force-remove with a loud warning is the
+        documented behaviour.
+        """
+        try:
+            result = subprocess.run(
+                [self._docker_exe, "rm", "-f", container_name],
+                capture_output=True, text=True, timeout=30,
+            )
+        except (OSError, subprocess.TimeoutExpired) as exc:
+            logger.warning(
+                "docker rm -f failed for stale container %s: %s — fresh "
+                "create may fail with a name conflict",
+                container_name, exc,
+            )
+            return
+        if result.returncode != 0:
+            logger.warning(
+                "docker rm -f refused to remove stale container %s: %s — "
+                "fresh create may fail with a name conflict",
+                container_name, result.stderr.strip(),
+            )
 
     def _build_init_env_args(self) -> list[str]:
         """Build -e KEY=VALUE args for injecting host env vars into init_session.

--- a/tools/environments/docker.py
+++ b/tools/environments/docker.py
@@ -5,6 +5,7 @@ configurable resource limits (CPU, memory, disk), and optional filesystem
 persistence via bind mounts.
 """
 
+import hashlib
 import logging
 import os
 import re
@@ -504,27 +505,44 @@ class DockerEnvironment(BaseEnvironment):
         # /usr/local/bin is not in PATH (common on macOS gateway/service).
         self._docker_exe = find_docker() or "docker"
 
-        # Start the container directly via `docker run -d`.
-        container_name = f"hermes-{uuid.uuid4().hex[:8]}"
-        run_cmd = [
-            self._docker_exe, "run", "-d",
-            "--init",           # tini/catatonit as PID 1 — reaps zombie children
-            "--name", container_name,
-            "-w", cwd,
-            *all_run_args,
-            image,
-            "sleep", "infinity",  # no fixed lifetime — idle reaper handles cleanup
-        ]
-        logger.debug(f"Starting container: {' '.join(run_cmd)}")
-        result = subprocess.run(
-            run_cmd,
-            capture_output=True,
-            text=True,
-            timeout=120,  # image pull may take a while
-            check=True,
-        )
-        self._container_id = result.stdout.strip()
-        logger.info(f"Started container {container_name} ({self._container_id[:12]})")
+        # Persistent containers reuse a deterministic name derived from the
+        # per-(profile, task_id) sandbox path so successive Hermes processes
+        # reconnect to the same container instead of leaving a trail of
+        # orphaned ``sleep infinity`` containers. Non-persistent containers
+        # stay ephemeral with a random name (no reuse semantics).
+        if self._persistent:
+            sandbox_key = str(get_sandbox_dir() / "docker" / task_id)
+            name_suffix = hashlib.sha1(sandbox_key.encode("utf-8")).hexdigest()[:12]
+            container_name = f"hermes-{name_suffix}"
+        else:
+            container_name = f"hermes-{uuid.uuid4().hex[:8]}"
+        self._container_name = container_name
+
+        reused = False
+        if self._persistent:
+            reused = self._try_reuse_persistent_container(container_name)
+
+        if not reused:
+            # Start the container directly via `docker run -d`.
+            run_cmd = [
+                self._docker_exe, "run", "-d",
+                "--init",           # tini/catatonit as PID 1 — reaps zombie children
+                "--name", container_name,
+                "-w", cwd,
+                *all_run_args,
+                image,
+                "sleep", "infinity",  # no fixed lifetime — idle reaper handles cleanup
+            ]
+            logger.debug(f"Starting container: {' '.join(run_cmd)}")
+            result = subprocess.run(
+                run_cmd,
+                capture_output=True,
+                text=True,
+                timeout=120,  # image pull may take a while
+                check=True,
+            )
+            self._container_id = result.stdout.strip()
+            logger.info(f"Started container {container_name} ({self._container_id[:12]})")
 
         # Build the init-time env forwarding args (used only by init_session
         # to inject host env vars into the snapshot; subsequent commands get
@@ -533,6 +551,56 @@ class DockerEnvironment(BaseEnvironment):
 
         # Initialize session snapshot inside the container
         self.init_session()
+
+    def _try_reuse_persistent_container(self, container_name: str) -> bool:
+        """Reattach to an existing persistent container with this name, if any.
+
+        Returns True when ``self._container_id`` was populated from an existing
+        container (running or restarted), False when the caller should create a
+        new container. Any docker-side failure falls back to creation rather
+        than blocking the agent.
+        """
+        try:
+            inspect = subprocess.run(
+                [self._docker_exe, "inspect", "--format",
+                 "{{.State.Status}}\t{{.Id}}", container_name],
+                capture_output=True, text=True, timeout=10,
+            )
+        except (OSError, subprocess.TimeoutExpired) as exc:
+            logger.debug("docker inspect failed for %s: %s", container_name, exc)
+            return False
+        if inspect.returncode != 0:
+            return False
+        parts = inspect.stdout.strip().split("\t", 1)
+        if len(parts) != 2 or not parts[1]:
+            return False
+        status, container_id = parts[0], parts[1]
+
+        if status != "running":
+            try:
+                start = subprocess.run(
+                    [self._docker_exe, "start", container_name],
+                    capture_output=True, text=True, timeout=30,
+                )
+            except (OSError, subprocess.TimeoutExpired) as exc:
+                logger.warning(
+                    "docker start failed for %s (status=%s): %s",
+                    container_name, status, exc,
+                )
+                return False
+            if start.returncode != 0:
+                logger.warning(
+                    "docker start refused container %s (status=%s): %s",
+                    container_name, status, start.stderr.strip(),
+                )
+                return False
+
+        self._container_id = container_id
+        logger.info(
+            "Reusing persistent container %s (%s, prior status=%s)",
+            container_name, container_id[:12], status,
+        )
+        return True
 
     def _build_init_env_args(self) -> list[str]:
         """Build -e KEY=VALUE args for injecting host env vars into init_session.


### PR DESCRIPTION
## What does this PR do?

`terminal.backend: docker` + `terminal.container_persistent: true` was leaving an unbounded trail of `hermes-<random>` `sleep infinity` containers because `DockerEnvironment` derived the container name from a fresh `uuid.uuid4()` per process. The bind-mounted sandbox dir (`get_sandbox_dir() / "docker" / <task_id>`) persisted across restarts, but the container itself did not — every gateway restart, cron run, or new Hermes process spawned a new one. Persistent mode now mirrors the bind-mount key: the container name is a sha1 of the sandbox path, so successive Hermes processes reattach to the same container.

Before `docker run -d`, `docker inspect --format '{{.State.Status}}\t{{.Id}}' <name>` is consulted. A running container with that name is reused, a stopped one is `docker start`-ed, and only a true miss falls through to creation. Non-persistent (tmpfs) containers keep their random uuid name and skip the inspect path entirely — reattaching to a tmpfs container would leak ephemeral state across logical sessions.

Any docker-side failure (inspect timeout, start refusal, etc.) silently falls back to fresh creation so the agent never blocks on container introspection.

> Audited siblings: `tools/environments/singularity.py` uses the same `f\"hermes_{uuid.uuid4().hex[:12]}\"` pattern with `persistent_filesystem=True` (`instance_id` at line 178) and may benefit from an equivalent reuse path — left out of this PR to keep the diff small; happy to widen if preferred. The cloud sandboxes (modal, daytona, vercel, managed_modal) manage persistence through their provider APIs, not local names, so they aren't affected.

## Related Issue

Fixes #30336

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/environments/docker.py` — derive a deterministic `hermes-<sha1[:12]>` container name for persistent mode; add `_try_reuse_persistent_container()` to reattach to running / restart stopped containers via `docker inspect` + `docker start`; preserve the random uuid name for ephemeral (`persistent_filesystem=False`) containers.
- `tests/tools/test_docker_environment.py` — five new cases: deterministic naming, reuse-running, restart-stopped, create-when-missing, and a guard that non-persistent mode never consults `docker inspect`.

## How to Test

1. Configure Hermes with `terminal.backend: docker` and `terminal.container_persistent: true`.
2. Run a Hermes session that initialises the terminal/file tools, then stop the process.
3. Start Hermes again and run another command — verify with `docker ps --filter name=hermes-` that the same container ID is reused, not a fresh one.
4. `uv run --with pytest --with pytest-xdist --with pytest-asyncio --with pytest-timeout python3 -m pytest tests/tools/test_docker_environment.py -v` — all 28 cases pass; the five new ones fail on `origin/main` (regression-proofed by stashing the production change).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run focused tests for the touched code and all pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.x

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no new keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — sha1 hash of the sandbox path normalises platform differences; container reuse works wherever `docker inspect` / `docker start` work, i.e. every supported platform.
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

When reusing an existing container the new log line is:

```
Reusing persistent container hermes-<sha1[:12]> (<id[:12]>, prior status=exited)
```

so operators can confirm reuse is happening without grepping `docker ps`.