### PR TITLE
fix(skills): publish fetchable metadata for official skills

### DIFF
--- a/tests/tools/test_skills_hub.py
+++ b/tests/tools/test_skills_hub.py
@@ -1432,6 +1432,26 @@ class TestSkillMetaToDict:
 # ---------------------------------------------------------------------------
 
 
+class TestOptionalSkillSourceMetadata:
+    def test_scan_all_emits_repo_root_relative_metadata(self, tmp_path):
+        optional_root = tmp_path / "optional-skills"
+        skill_dir = optional_root / "finance" / "3-statement-model"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: 3-statement-model\ndescription: test\n---\n\nBody\n",
+            encoding="utf-8",
+        )
+
+        src = OptionalSkillSource()
+        src._optional_dir = optional_root
+
+        meta = src.inspect("official/finance/3-statement-model")
+
+        assert meta is not None
+        assert meta.repo == "NousResearch/hermes-agent"
+        assert meta.path == "optional-skills/finance/3-statement-model"
+
+
 class TestOptionalSkillSourceBinaryAssets:
     def test_fetch_preserves_binary_assets(self, tmp_path):
         optional_root = tmp_path / "optional-skills"

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -2542,6 +2542,8 @@ class OptionalSkillSource(SkillSource):
     (search / install / inspect) and labelled "official" with "builtin" trust.
     """
 
+    OFFICIAL_REPO = "NousResearch/hermes-agent"
+
     def __init__(self):
         from hermes_constants import get_optional_skills_dir
 
@@ -2672,7 +2674,7 @@ class OptionalSkillSource(SkillSource):
                 if isinstance(hermes_meta, dict):
                     tags = hermes_meta.get("tags", [])
 
-            rel_path = str(parent.relative_to(self._optional_dir))
+            rel_path = parent.relative_to(self._optional_dir).as_posix()
 
             results.append(SkillMeta(
                 name=name,
@@ -2680,7 +2682,9 @@ class OptionalSkillSource(SkillSource):
                 source="official",
                 identifier=f"official/{rel_path}",
                 trust_level="builtin",
-                path=rel_path,
+                repo=self.OFFICIAL_REPO,
+                # The centralized skills index consumes repo-root-relative paths.
+                path=f"optional-skills/{rel_path}",
                 tags=tags if isinstance(tags, list) else [],
             ))
 


### PR DESCRIPTION
## Summary
- publish `repo=NousResearch/hermes-agent` for `official/*` optional skills
- publish repo-root-relative `path=optional-skills/<category>/<skill>` metadata
- keep `official` identifiers posix-normalized so generated index entries are fetchable on GitHub

## Why
`official/*` installs in source checkouts can succeed via the local `OptionalSkillSource`, but the centralized skills index currently emits empty `repo` metadata and non-repo-root `path` values for official skills. That makes index-driven installs fail for environments that rely on the hosted index entry instead of the local repo tree.

## Verification
- `../.base/.venv/bin/pytest -o addopts='' tests/tools/test_skills_hub.py -k 'OptionalSkillSourceMetadata or OptionalSkillSourceBinaryAssets'`
- `../.base/.venv/bin/ruff check tools/skills_hub.py tests/tools/test_skills_hub.py`
- `git diff --check`

Closes #30482.
