### PR TITLE
Fix local browser launch from Playwright Chromium cache

### DIFF
--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -2006,6 +2006,10 @@ def _run_browser_command(
             idle_ms = str(BROWSER_SESSION_INACTIVITY_TIMEOUT * 1000)
             browser_env["AGENT_BROWSER_IDLE_TIMEOUT_MS"] = idle_ms
 
+        chromium_executable = _get_chromium_executable()
+        if chromium_executable and "AGENT_BROWSER_EXECUTABLE_PATH" not in browser_env:
+            browser_env["AGENT_BROWSER_EXECUTABLE_PATH"] = chromium_executable
+
         # Inject --no-sandbox when needed (issue #15765):
         # - Running as root: Chromium always refuses to start without it
         # - Ubuntu 23.10+ / AppArmor systems: unprivileged user namespaces
@@ -3470,7 +3474,7 @@ def cleanup_all_browsers() -> None:
     # Reset cached lookups so they are re-evaluated on next use.
     global _cached_agent_browser, _agent_browser_resolved
     global _cached_command_timeout, _command_timeout_resolved
-    global _cached_chromium_installed
+    global _cached_chromium_installed, _cached_chromium_executable
     global _cached_browser_engine, _browser_engine_resolved
     _cached_agent_browser = None
     _agent_browser_resolved = False
@@ -3478,6 +3482,7 @@ def cleanup_all_browsers() -> None:
     _cached_command_timeout = None
     _command_timeout_resolved = False
     _cached_chromium_installed = None
+    _cached_chromium_executable = None
     _cached_browser_engine = None
     _browser_engine_resolved = False
 
@@ -3488,6 +3493,7 @@ def cleanup_all_browsers() -> None:
 
 # Cache for Chromium discovery. Invalidated by _reset_browser_caches.
 _cached_chromium_installed: Optional[bool] = None
+_cached_chromium_executable: Optional[str] = None
 
 
 def _chromium_search_roots() -> List[str]:
@@ -3537,14 +3543,16 @@ def _chromium_installed() -> bool:
     the tool behind this check prevents advertising a capability that will
     fail at runtime.
     """
-    global _cached_chromium_installed
+    global _cached_chromium_installed, _cached_chromium_executable
     if _cached_chromium_installed is not None:
         return _cached_chromium_installed
 
     # 1. AGENT_BROWSER_EXECUTABLE_PATH — explicit user-configured browser
     ab_path = os.environ.get("AGENT_BROWSER_EXECUTABLE_PATH", "").strip()
     if ab_path:
-        if os.path.isfile(ab_path) or shutil.which(ab_path):
+        resolved = ab_path if os.path.isfile(ab_path) else shutil.which(ab_path)
+        if resolved:
+            _cached_chromium_executable = resolved
             _cached_chromium_installed = True
             return True
 
@@ -3556,6 +3564,7 @@ def _chromium_installed() -> bool:
         or shutil.which("chrome")
     )
     if system_chrome:
+        _cached_chromium_executable = system_chrome
         _cached_chromium_installed = True
         return True
 
@@ -3573,11 +3582,30 @@ def _chromium_installed() -> bool:
             if entry.startswith("chromium-") or entry.startswith(
                 "chromium_headless_shell-"
             ):
+                entry_path = os.path.join(root, entry)
+                for rel in (
+                    os.path.join("chrome-linux", "chrome"),
+                    os.path.join("chrome-linux", "headless_shell"),
+                    os.path.join("chrome-mac", "Chromium.app", "Contents", "MacOS", "Chromium"),
+                    os.path.join("chrome-win", "chrome.exe"),
+                ):
+                    candidate = os.path.join(entry_path, rel)
+                    if os.path.isfile(candidate) and os.access(candidate, os.X_OK):
+                        _cached_chromium_executable = candidate
+                        _cached_chromium_installed = True
+                        return True
                 _cached_chromium_installed = True
                 return True
 
     _cached_chromium_installed = False
     return False
+
+
+def _get_chromium_executable() -> Optional[str]:
+    """Return the concrete Chrome/Chromium executable discovered by _chromium_installed."""
+    if _cached_chromium_installed is None:
+        _chromium_installed()
+    return _cached_chromium_executable
 
 
 def _running_in_docker() -> bool:


### PR DESCRIPTION
## Summary

This PR fixes local browser launch when Hermes detects Chromium from a Playwright browser cache, but `agent-browser` cannot find Chrome at runtime.

Changes:
- track the concrete Chrome/Chromium executable discovered during browser requirement checks
- pass that executable to `agent-browser` via `AGENT_BROWSER_EXECUTABLE_PATH`
- clear the cached executable path during browser cleanup/reset

## Problem

Hermes currently treats a Playwright Chromium cache as satisfying local browser requirements. However, `agent-browser` does not automatically launch from that cache.

On systems without system Chrome/Chromium or an agent-browser-managed browser cache, this creates a mismatch:

1. Hermes advertises browser tools because Chromium exists in Playwright cache.
2. The model calls `browser_navigate`.
3. `agent-browser` launches without knowing the Playwright Chromium path.
4. Navigation fails with a Chrome-not-found error.

This is common in server/container environments where Playwright has installed Chromium but system Chrome is not installed.

## Repro

Environment:
- `agent-browser@0.27.0`
- Playwright Chromium installed under the standard Playwright cache
- no system `google-chrome`, `chromium`, `chromium-browser`, or `chrome`
- local browser mode

Steps:

1. Install Playwright Chromium, for example:

   bash
   npx playwright install chromium

2. Ensure system Chrome/Chromium is not installed.
3. Start Hermes with browser tools enabled.
4. Run a browser navigation, for example:

   browser_navigate("https://example.com")

Before this PR:
- `check_browser_requirements()` may pass because Playwright Chromium exists.
- `browser_navigate` can still fail because `agent-browser` cannot locate Chrome.

After this PR:
- Hermes passes the resolved Playwright Chromium executable path to `agent-browser`.
- Local navigation can launch using the already-detected Chromium binary.

## Implementation

When `_chromium_installed()` finds a usable browser, it also records the executable path when available.

Then `_run_browser_command()` sets:
AGENT_BROWSER_EXECUTABLE_PATH=<resolved chromium path>

for the `agent-browser` subprocess unless the user already provided `AGENT_BROWSER_EXECUTABLE_PATH`.

This preserves user overrides and avoids changing cloud/CDP behavior.

## Validation

Ran:
python -m py_compile tools/browser_tool.py

Also validated the behavior manually in an environment where Playwright Chromium existed but system Chrome was unavailable.