### PR TITLE
Add browser_only toolset

### DIFF
--- a/toolsets.py
+++ b/toolsets.py
@@ -168,6 +168,18 @@ TOOLSETS = {
         ],
         "includes": []
     },
+
+    "browser_only": {
+        "description": "Browser automation only, without web_search or web_extract fallbacks",
+        "tools": [
+            "browser_navigate", "browser_snapshot", "browser_click",
+            "browser_type", "browser_scroll", "browser_back",
+            "browser_press", "browser_get_images",
+            "browser_vision", "browser_console", "browser_cdp",
+            "browser_dialog"
+        ],
+        "includes": []
+    },
     
     "cronjob": {
         "description": "Cronjob management tool - create, list, update, pause, resume, remove, and trigger scheduled tasks",


### PR DESCRIPTION
## Summary

This PR adds a `browser_only` toolset containing browser automation tools without web search or extraction fallbacks.

The existing `browser` toolset remains unchanged.

## Problem

The current `browser` toolset includes browser automation tools plus `web_search` as a convenience:

- `browser_navigate`
- `browser_snapshot`
- `browser_click`
- etc.
- `web_search`

That is useful for many interactive browsing tasks, but it is not ideal for workflows that explicitly require direct browser interaction only.

Examples:
- browser-only cron jobs
- workflows where `web_search` is unavailable
- workflows where search/extraction would violate the intended behavior
- tasks where fallback to search creates misleading errors or unverified results

In those cases, users need a precise way to expose only browser automation tools.

## Change

Adds a new toolset:
browser_only

It includes:
browser_navigate
browser_snapshot
browser_click
browser_type
browser_scroll
browser_back
browser_press
browser_get_images
browser_vision
browser_console
browser_cdp
browser_dialog

It intentionally excludes:
web_search
web_extract

## Compatibility

This is additive only.

The existing `browser` toolset is unchanged, so current users keep the same behavior.

Users who want browser automation plus search can continue using:
browser

Users who want browser automation without search fallback can opt into:
browser_only

## Validation

Ran:
python -m py_compile toolsets.py

And verified:
from toolsets import validate_toolset, resolve_toolset
assert validate_toolset("browser_only")
tools = resolve_toolset("browser_only")
assert "browser_navigate" in tools
assert "web_search" not in tools
assert "web_extract" not in tools
