### PR TITLE
feat(skills): per-skill model preference via hermes.model frontmatter

### DIFF
--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -285,7 +285,11 @@ def get_all_skills_dirs() -> List[Path]:
 
 
 def extract_skill_conditions(frontmatter: Dict[str, Any]) -> Dict[str, List]:
-    """Extract conditional activation fields from parsed frontmatter."""
+    """Extract conditional activation and routing fields from parsed frontmatter.
+
+    Reads ``metadata.hermes.*`` for toolset conditions and the optional
+    ``model`` field that declares the skill's preferred model for delegation.
+    """
     metadata = frontmatter.get("metadata")
     # Handle cases where metadata is not a dict (e.g., a string from malformed YAML)
     if not isinstance(metadata, dict):
@@ -298,6 +302,7 @@ def extract_skill_conditions(frontmatter: Dict[str, Any]) -> Dict[str, List]:
         "requires_toolsets": hermes.get("requires_toolsets", []),
         "fallback_for_tools": hermes.get("fallback_for_tools", []),
         "requires_tools": hermes.get("requires_tools", []),
+        "model": hermes.get("model", ""),
     }
 
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -3828,6 +3828,7 @@ class AIAgent:
             acp_command=function_args.get("acp_command"),
             acp_args=function_args.get("acp_args"),
             role=function_args.get("role"),
+            model=function_args.get("model"),
             parent_agent=self,
         )
 

--- a/tests/agent/test_skill_utils.py
+++ b/tests/agent/test_skill_utils.py
@@ -31,6 +31,7 @@ def test_metadata_as_string_does_not_crash():
         "requires_toolsets": [],
         "fallback_for_tools": [],
         "requires_tools": [],
+        "model": "",
     }
 
 
@@ -43,6 +44,7 @@ def test_metadata_as_none():
         "requires_toolsets": [],
         "fallback_for_tools": [],
         "requires_tools": [],
+        "model": "",
     }
 
 
@@ -55,4 +57,23 @@ def test_metadata_missing_entirely():
         "requires_toolsets": [],
         "fallback_for_tools": [],
         "requires_tools": [],
+        "model": "",
     }
+
+
+def test_hermes_model_field():
+    """hermes.model declares the preferred model for delegation to this skill."""
+    frontmatter = {
+        "metadata": {"hermes": {"model": "anthropic/claude-opus-4-7"}}
+    }
+    result = extract_skill_conditions(frontmatter)
+    assert result["model"] == "anthropic/claude-opus-4-7"
+
+
+def test_hermes_model_field_absent():
+    """hermes.model defaults to empty string when not declared."""
+    frontmatter = {
+        "metadata": {"hermes": {"requires_toolsets": ["web"]}}
+    }
+    result = extract_skill_conditions(frontmatter)
+    assert result["model"] == ""

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1924,6 +1924,7 @@ def delegate_task(
     acp_command: Optional[str] = None,
     acp_args: Optional[List[str]] = None,
     role: Optional[str] = None,
+    model: Optional[str] = None,
     parent_agent=None,
 ) -> str:
     """
@@ -2017,7 +2018,7 @@ def delegate_task(
         task_list = tasks
     elif goal and isinstance(goal, str) and goal.strip():
         task_list = [
-            {"goal": goal, "context": context, "toolsets": toolsets, "role": top_role}
+            {"goal": goal, "context": context, "toolsets": toolsets, "role": top_role, "model": model}
         ]
     else:
         return tool_error("Provide either 'goal' (single task) or 'tasks' (batch).")
@@ -2058,12 +2059,14 @@ def delegate_task(
             # Per-task role beats top-level; normalise again so unknown
             # per-task values warn and degrade to leaf uniformly.
             effective_role = _normalize_role(t.get("role") or top_role)
+            # Per-task model > top-level model > delegation config model
+            task_model = t.get("model") or model or creds["model"]
             child = _build_child_agent(
                 task_index=i,
                 goal=t["goal"],
                 context=t.get("context"),
                 toolsets=t.get("toolsets") or toolsets,
-                model=creds["model"],
+                model=task_model,
                 max_iterations=effective_max_iter,
                 task_count=n_tasks,
                 parent_agent=parent_agent,
@@ -2736,6 +2739,14 @@ DELEGATE_TASK_SCHEMA = {
                             "enum": ["leaf", "orchestrator"],
                             "description": "Per-task role override. See top-level 'role' for semantics.",
                         },
+                        "model": {
+                            "type": "string",
+                            "description": (
+                                "Per-task model override "
+                                "(e.g. \"anthropic/claude-opus-4-7\"). "
+                                "Takes precedence over the top-level model."
+                            ),
+                        },
                     },
                     "required": ["goal"],
                 },
@@ -2748,6 +2759,15 @@ DELEGATE_TASK_SCHEMA = {
                 "type": "string",
                 "enum": ["leaf", "orchestrator"],
                 "description": "(rebuilt at get_definitions() time)",
+            },
+            "model": {
+                "type": "string",
+                "description": (
+                    "Model override for all subagents in this call "
+                    "(e.g. \"anthropic/claude-opus-4-7\"). "
+                    "Takes precedence over delegation.model in config. "
+                    "Sourced from the target skill's hermes.model frontmatter field."
+                ),
             },
             "acp_command": {
                 "type": "string",
@@ -2793,6 +2813,7 @@ registry.register(
         acp_command=args.get("acp_command"),
         acp_args=args.get("acp_args"),
         role=args.get("role"),
+        model=args.get("model"),
         parent_agent=kw.get("parent_agent"),
     ),
     check_fn=check_delegate_requirements,

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -605,11 +605,15 @@ def _find_all_skills(*, skip_disabled: bool = False) -> List[Dict[str, Any]]:
 
                 category = _get_category_from_path(skill_md)
 
+                from agent.skill_utils import extract_skill_conditions
+                conditions = extract_skill_conditions(frontmatter)
+
                 seen_names.add(name)
                 skills.append({
                     "name": name,
                     "description": description,
                     "category": category,
+                    "model": conditions.get("model") or "",
                 })
 
             except (UnicodeDecodeError, PermissionError) as e:


### PR DESCRIPTION
## What this does

Adds two composable pieces so skill authors can declare which model a skill works best with, and callers can honour that when delegating.

### 1. `metadata.hermes.model` in SKILL.md frontmatter

Parsed by `extract_skill_conditions` alongside the existing toolset conditions. Surfaced in `_find_all_skills` output (and `GET /api/skills`). Skills that omit the field default to `""` — fully backward-compatible.

```yaml
metadata:
  hermes:
    model: "anthropic/claude-opus-4-7"
    requires_toolsets: [web]
```

### 2. `model` parameter on `delegate_task`

A per-call override threaded through the task loop and `_build_child_agent`. Works for single-task and batch modes; in batch mode each task can set its own model independently.

**Precedence:** per-call `model` > `delegation.model` (config) > `parent_agent.model`

```
delegate_task(goal="Run account-research for Yettel", model="anthropic/claude-opus-4-7")
```

## What this doesn't do (intentional scope)

Automatic model injection without LLM involvement. A follow-up could add a `skill` parameter that looks up the model from frontmatter automatically without the LLM needing to pass it explicitly.

## Files changed

- `agent/skill_utils.py` — `extract_skill_conditions` returns `model` key
- `tools/skills_tool.py` — `_find_all_skills` surfaces `model` in output
- `tools/delegate_tool.py` — `model` in schema (top-level + per-task) and function signature; per-task model resolution in build loop; registry handler updated
- `run_agent.py` — `_dispatch_delegate_task` threads `model` through
- `tests/agent/test_skill_utils.py` — three updated assertions + two new tests