### PR TITLE
fix(bluebubbles): cap _guid_cache with LRU eviction to prevent unbounded growth

### DIFF
--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -14,6 +14,7 @@ import logging
 import os
 import re
 import uuid
+from collections import OrderedDict
 from datetime import datetime
 from typing import Any, Dict, List, Optional
 from urllib.parse import quote
@@ -128,7 +129,8 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         self._runner = None
         self._private_api_enabled: Optional[bool] = None
         self._helper_connected: bool = False
-        self._guid_cache: Dict[str, str] = {}
+        self._guid_cache: OrderedDict[str, str] = OrderedDict()
+        self._GUID_CACHE_MAX = 500
 
     # ------------------------------------------------------------------
     # API helpers
@@ -352,6 +354,7 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         if ";" in target:
             return target
         if target in self._guid_cache:
+            self._guid_cache.move_to_end(target)
             return self._guid_cache[target]
         try:
             payload = await self._api_post(
@@ -364,10 +367,16 @@ class BlueBubblesAdapter(BasePlatformAdapter):
                 if identifier == target:
                     if guid:
                         self._guid_cache[target] = guid
+                        self._guid_cache.move_to_end(target)
+                        if len(self._guid_cache) > self._GUID_CACHE_MAX:
+                            self._guid_cache.popitem(last=False)
                     return guid
                 for part in chat.get("participants", []) or []:
                     if (part.get("address") or "").strip() == target and guid:
                         self._guid_cache[target] = guid
+                        self._guid_cache.move_to_end(target)
+                        if len(self._guid_cache) > self._GUID_CACHE_MAX:
+                            self._guid_cache.popitem(last=False)
                         return guid
         except Exception:
             pass


### PR DESCRIPTION
## Problem

`BlueBubblesAdapter._guid_cache` is a plain `Dict[str, str]` that grows without bound as new contacts/groups are resolved in `_resolve_chat_guid()`. In a long-running gateway instance this becomes a slow memory leak.

## Solution

Replace the plain dict with an `OrderedDict` capped at 500 entries. Each cache write immediately checks the cap and evicts the oldest entry if exceeded. On cache hit, `move_to_end()` promotes the entry so recently-used targets survive eviction.

## Changes

- `gateway/platforms/bluebubbles.py`: `_guid_cache` → `OrderedDict`, added `_GUID_CACHE_MAX = 500`, eviction after each write

## How to test

```bash
bash scripts/run_tests.sh tests/gateway/test_bluebubbles.py