### PR TITLE
docs: remove duplicate Windows install note

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,6 @@ curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scri
 
 ### Windows (native, PowerShell) — Early Beta
 
-> **Heads up:** Native Windows support is **early beta**. It installs and runs, but hasn't been road-tested as broadly as our Linux/macOS/WSL2 paths. Please [file issues](https://github.com/NousResearch/hermes-agent/issues) when you hit rough edges. For the most battle-tested Windows setup today, run the Linux/macOS one-liner above inside **WSL2**.
-
 Run this in PowerShell:
 
 ```powershell


### PR DESCRIPTION
The Quick Install section currently explains the native Windows early-beta caveat twice: once immediately under the Windows heading and again after the installer details.

This keeps the more detailed note later in the section and removes the earlier duplicated callout so the install flow is a little easier to scan.