### PR TITLE
feat: add cron.model and cron.provider config keys for separate cron default model

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1424,6 +1424,18 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
                 with open(_cfg_path, encoding="utf-8") as _f:
                     _cfg = yaml.safe_load(_f) or {}
                 _cfg = _expand_env_vars(_cfg)
+
+                # Check cron-specific default before falling back to the main model
+                if not job.get("model"):
+                    _cron_cfg = _cfg.get("cron", {})
+                    if isinstance(_cron_cfg, dict):
+                        _cron_model = (_cron_cfg.get("model") or "").strip()
+                        _cron_provider = (_cron_cfg.get("provider") or "").strip()
+                        if _cron_model:
+                            model = _cron_model
+                            if _cron_provider:
+                                provider = _cron_provider
+
                 _model_cfg = _cfg.get("model", {})
                 if not job.get("model"):
                     if isinstance(_model_cfg, str):

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1508,6 +1508,11 @@ DEFAULT_CONFIG = {
         # 1 = serial (pre-v0.9 behaviour).
         # Also overridable via HERMES_CRON_MAX_PARALLEL env var.
         "max_parallel_jobs": None,
+        # Default model for cron jobs when no per-job model override is set.
+        # When empty, falls back to the main model.default from config (same as chat).
+        "model": "",
+        # Default provider for cron jobs, paired with cron.model above.
+        "provider": "",
     },
 
     # Kanban multi-agent coordination — controls the dispatcher loop that


### PR DESCRIPTION
## Summary

Adds `cron.model` and `cron.provider` config keys to the `cron:` section of `config.yaml`, allowing users to set a separate default model for all cron jobs without affecting their chat model.

## Problem

Cron jobs always fell back to `model.default` from config (same as chat), with no way to set a cron-specific default. Users had to pin a model on every individual job via the `model` parameter.

## Solution

The model resolution chain for cron jobs is now (strongest first):
1. Per-job pinned model (via `cronjob` tool `model` param)
2. `cron.model` / `cron.provider` ← **NEW**
3. `HERMES_MODEL` env var
4. `model.default` from config

## Changes

- **`hermes_cli/config.py`** — Added `"model": ""` and `"provider": ""` defaults to the `cron` section of DEFAULT_CONFIG
- **`cron/scheduler.py`** — Added a check for `cron.model` / `cron.provider` before falling back to the main `model.default`

## Example usage

```yaml
cron:
  wrap_response: true
  max_parallel_jobs: null
  model: gpt-4o-mini
  provider: openrouter
```

Any cron job without a per-job pinned model will use `gpt-4o-mini` via OpenRouter, while chat continues using whatever `model.default` is set to.