### PR TITLE
fix: improve BlueBubbles voice message uploads

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -201,12 +201,19 @@ def build_auto_tts_output_path(platform) -> str:
     (``tools.tts_tool.OPUS_VOICE_PLATFORMS`` — the single source of truth)
     get an explicit ``.ogg`` path; the tool's central container repair
     (``_repair_ogg_container``) then guarantees real Ogg/Opus bytes for every
-    provider, including MP3-only backends like Edge TTS. Everything else
-    keeps the MP3 default.
+    provider, including MP3-only backends like Edge TTS. BlueBubbles gets a
+    24 kHz mono-normalizable WAV source for adapter-owned Opus CAF packaging;
+    everything else keeps the MP3 default.
     """
     from tools.tts_tool import OPUS_VOICE_PLATFORMS
 
-    ext = "ogg" if _platform_name(platform) in OPUS_VOICE_PLATFORMS else "mp3"
+    platform_name = _platform_name(platform)
+    if platform_name == "bluebubbles":
+        ext = "wav"
+    elif platform_name in OPUS_VOICE_PLATFORMS:
+        ext = "ogg"
+    else:
+        ext = "mp3"
     audio_path = os.path.join(
         tempfile.gettempdir(),
         "hermes_voice",

--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -727,6 +727,21 @@ class BlueBubblesAdapter(BasePlatformAdapter):
             content_type=_attachment_content_type(requested_name, is_audio_message=True),
         )
 
+    @staticmethod
+    def _cleanup_prepared_attachment(prepared: _PreparedAttachment) -> None:
+        if prepared.cleanup:
+            try:
+                os.unlink(prepared.path)
+            except OSError:
+                pass
+
+    def _cleanup_cancelled_preparation(self, task: asyncio.Task) -> None:
+        try:
+            prepared = task.result()
+        except BaseException:
+            return
+        self._cleanup_prepared_attachment(prepared)
+
     async def _send_attachment(
         self,
         chat_id: str,
@@ -745,15 +760,21 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         if not guid:
             return SendResult(success=False, error=f"Chat not found: {chat_id}")
 
-        prepared = (
-            await asyncio.to_thread(self._prepare_voice_attachment, file_path, filename)
-            if is_audio_message
-            else _PreparedAttachment(
+        if is_audio_message:
+            preparation_task = asyncio.create_task(
+                asyncio.to_thread(self._prepare_voice_attachment, file_path, filename)
+            )
+            try:
+                prepared = await asyncio.shield(preparation_task)
+            except asyncio.CancelledError:
+                preparation_task.add_done_callback(self._cleanup_cancelled_preparation)
+                raise
+        else:
+            prepared = _PreparedAttachment(
                 path=file_path,
                 filename=filename or os.path.basename(file_path),
                 content_type=_attachment_content_type(filename or os.path.basename(file_path)),
             )
-        )
         try:
             with open(prepared.path, "rb") as f:
                 files = {"attachment": (prepared.filename, f, prepared.content_type)}
@@ -791,11 +812,7 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         except Exception as e:
             return SendResult(success=False, error=str(e))
         finally:
-            if prepared.cleanup:
-                try:
-                    os.unlink(prepared.path)
-                except OSError:
-                    pass
+            self._cleanup_prepared_attachment(prepared)
 
     async def send_image(
         self,

--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -760,21 +760,26 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         if not guid:
             return SendResult(success=False, error=f"Chat not found: {chat_id}")
 
-        if is_audio_message:
-            preparation_task = asyncio.create_task(
-                asyncio.to_thread(self._prepare_voice_attachment, file_path, filename)
-            )
-            try:
-                prepared = await asyncio.shield(preparation_task)
-            except asyncio.CancelledError:
-                preparation_task.add_done_callback(self._cleanup_cancelled_preparation)
-                raise
-        else:
-            prepared = _PreparedAttachment(
-                path=file_path,
-                filename=filename or os.path.basename(file_path),
-                content_type=_attachment_content_type(filename or os.path.basename(file_path)),
-            )
+        try:
+            if is_audio_message:
+                preparation_task = asyncio.create_task(
+                    asyncio.to_thread(self._prepare_voice_attachment, file_path, filename)
+                )
+                try:
+                    prepared = await asyncio.shield(preparation_task)
+                except asyncio.CancelledError:
+                    preparation_task.add_done_callback(self._cleanup_cancelled_preparation)
+                    raise
+            else:
+                prepared = _PreparedAttachment(
+                    path=file_path,
+                    filename=filename or os.path.basename(file_path),
+                    content_type=_attachment_content_type(filename or os.path.basename(file_path)),
+                )
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            return SendResult(success=False, error=str(e))
         try:
             with open(prepared.path, "rb") as f:
                 files = {"attachment": (prepared.filename, f, prepared.content_type)}

--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -11,10 +11,15 @@ downloading from PR #4588 (YuhangLin).
 import asyncio
 import json
 import logging
+import mimetypes
 import os
 import re
+import shutil
+import subprocess
+import tempfile
 import uuid
 from collections import OrderedDict
+from dataclasses import dataclass
 from datetime import datetime
 from typing import Any, Dict, List, Optional
 from urllib.parse import quote
@@ -77,6 +82,14 @@ _EMAIL_RE = re.compile(r"[\w.+-]+@[\w-]+\.[\w.]+")
 _GUID_CACHE_SIZE = 500  # LRU cap for resolved chat-GUID lookups
 
 
+@dataclass(frozen=True)
+class _PreparedAttachment:
+    path: str
+    filename: str
+    content_type: str
+    cleanup: bool = False
+
+
 def _redact(text: str) -> str:
     """Redact phone numbers and emails from log output."""
     text = _PHONE_RE.sub("[REDACTED]", text)
@@ -106,10 +119,27 @@ def _normalize_server_url(raw: str) -> str:
     return value.rstrip("/")
 
 
+def _attachment_content_type(filename: str, is_audio_message: bool = False) -> str:
+    """Return a useful multipart content type for BlueBubbles uploads."""
+    ext = os.path.splitext(filename)[1].lower()
+    if ext == ".caf":
+        return "audio/x-caf"
+    if ext == ".mp3":
+        return "audio/mpeg"
+    if is_audio_message and ext in {".m4a", ".aac"}:
+        return "audio/mp4"
+    if is_audio_message and ext == ".wav":
+        return "audio/wav"
+    guessed, _ = mimetypes.guess_type(filename)
+    if guessed:
+        return guessed
+    return "application/octet-stream"
+
 
 
 
 # ---------------------------------------------------------------------------
+
 # Adapter
 # ---------------------------------------------------------------------------
 
@@ -563,6 +593,103 @@ class BlueBubblesAdapter(BasePlatformAdapter):
     # Media sending (outbound)
     # ------------------------------------------------------------------
 
+    def _convert_audio_to_caf(self, audio_path: str) -> Optional[str]:
+        """Transcode audio to mono 24 kHz CAF for iMessage voice bubbles."""
+        tmp = tempfile.NamedTemporaryFile(
+            prefix="hermes-bluebubbles-voice-", suffix=".caf", delete=False
+        )
+        tmp_path = tmp.name
+        tmp.close()
+
+        ffmpeg = shutil.which("ffmpeg")
+        afconvert = shutil.which("afconvert")
+        commands: List[List[str]] = []
+        if ffmpeg:
+            commands.append([
+                ffmpeg,
+                "-y",
+                "-i",
+                audio_path,
+                "-vn",
+                "-ac",
+                "1",
+                "-ar",
+                "24000",
+                "-c:a",
+                "opus",
+                "-f",
+                "caf",
+                tmp_path,
+            ])
+        if afconvert:
+            commands.append([
+                afconvert,
+                "-f",
+                "caff",
+                "-d",
+                "opus",
+                "-c",
+                "1",
+                "-r",
+                "24000",
+                audio_path,
+                tmp_path,
+            ])
+
+        for cmd in commands:
+            try:
+                subprocess.run(
+                    cmd,
+                    check=True,
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                    timeout=60,
+                )
+                if os.path.isfile(tmp_path) and os.path.getsize(tmp_path) > 0:
+                    return tmp_path
+            except Exception as exc:
+                logger.debug("BlueBubbles CAF transcode failed with %s: %s", cmd[0], exc)
+
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        return None
+
+    def _prepare_voice_attachment(
+        self, file_path: str, filename: Optional[str] = None
+    ) -> _PreparedAttachment:
+        """Prepare an outbound voice attachment using BlueBubbles/iMessage hints."""
+        requested_name = filename or os.path.basename(file_path)
+        ext = os.path.splitext(requested_name)[1].lower()
+        if ext == ".caf":
+            return _PreparedAttachment(
+                path=file_path,
+                filename=requested_name or "Audio Message.caf",
+                content_type="audio/x-caf",
+            )
+        if ext == ".mp3":
+            return _PreparedAttachment(
+                path=file_path,
+                filename=requested_name or "Audio Message.mp3",
+                content_type="audio/mpeg",
+            )
+
+        converted = self._convert_audio_to_caf(file_path)
+        if converted:
+            return _PreparedAttachment(
+                path=converted,
+                filename="Audio Message.caf",
+                content_type="audio/x-caf",
+                cleanup=True,
+            )
+
+        return _PreparedAttachment(
+            path=file_path,
+            filename=requested_name,
+            content_type=_attachment_content_type(requested_name, is_audio_message=True),
+        )
+
     async def _send_attachment(
         self,
         chat_id: str,
@@ -581,17 +708,27 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         if not guid:
             return SendResult(success=False, error=f"Chat not found: {chat_id}")
 
-        fname = filename or os.path.basename(file_path)
+        prepared = (
+            self._prepare_voice_attachment(file_path, filename)
+            if is_audio_message
+            else _PreparedAttachment(
+                path=file_path,
+                filename=filename or os.path.basename(file_path),
+                content_type=_attachment_content_type(filename or os.path.basename(file_path)),
+            )
+        )
         try:
-            with open(file_path, "rb") as f:
-                files = {"attachment": (fname, f, "application/octet-stream")}
+            with open(prepared.path, "rb") as f:
+                files = {"attachment": (prepared.filename, f, prepared.content_type)}
                 data: Dict[str, str] = {
                     "chatGuid": guid,
-                    "name": fname,
+                    "name": prepared.filename,
                     "tempGuid": uuid.uuid4().hex,
                 }
                 if is_audio_message:
                     data["isAudioMessage"] = "true"
+                    if self._private_api_enabled and self._helper_connected:
+                        data["method"] = "private-api"
                 res = await self.client.post(
                     self._api_url("/api/v1/message/attachment"),
                     files=files,
@@ -616,6 +753,12 @@ class BlueBubblesAdapter(BasePlatformAdapter):
             )
         except Exception as e:
             return SendResult(success=False, error=str(e))
+        finally:
+            if prepared.cleanup:
+                try:
+                    os.unlink(prepared.path)
+                except OSError:
+                    pass
 
     async def send_image(
         self,

--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -597,6 +597,8 @@ class BlueBubblesAdapter(BasePlatformAdapter):
     @staticmethod
     def _is_native_voice_wav_source(audio_path: str) -> bool:
         """Return True for WAV input that can go straight to Opus CAF."""
+        import wave
+
         if os.path.splitext(audio_path)[1].lower() != ".wav":
             return False
         try:

--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -28,6 +28,7 @@ from urllib.parse import quote
 import httpx
 
 from gateway.config import Platform, PlatformConfig
+from hermes_cli._subprocess_compat import windows_hide_flags
 from gateway.platforms.base import (
     BasePlatformAdapter,
     MessageEvent,
@@ -627,6 +628,7 @@ class BlueBubblesAdapter(BasePlatformAdapter):
 
         normalized_path = audio_path
         normalized_cleanup: Optional[str] = None
+        keep_tmp_path = False
         try:
             if not self._is_native_voice_wav_source(audio_path):
                 ffmpeg = shutil.which("ffmpeg")
@@ -652,9 +654,11 @@ class BlueBubblesAdapter(BasePlatformAdapter):
                         normalized_path,
                     ],
                     check=True,
+                    stdin=subprocess.DEVNULL,
                     stdout=subprocess.DEVNULL,
                     stderr=subprocess.DEVNULL,
                     timeout=60,
+                    creationflags=windows_hide_flags(),
                 )
                 if not os.path.isfile(normalized_path) or os.path.getsize(normalized_path) == 0:
                     return None
@@ -672,11 +676,14 @@ class BlueBubblesAdapter(BasePlatformAdapter):
                     tmp_path,
                 ],
                 check=True,
+                stdin=subprocess.DEVNULL,
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.DEVNULL,
                 timeout=60,
+                creationflags=windows_hide_flags(),
             )
             if os.path.isfile(tmp_path) and os.path.getsize(tmp_path) > 0:
+                keep_tmp_path = True
                 return tmp_path
         except Exception as exc:
             logger.debug("BlueBubbles Opus CAF transcode failed: %s", exc)
@@ -686,11 +693,11 @@ class BlueBubblesAdapter(BasePlatformAdapter):
                     os.unlink(normalized_cleanup)
                 except OSError:
                     pass
-
-        try:
-            os.unlink(tmp_path)
-        except OSError:
-            pass
+            if not keep_tmp_path:
+                try:
+                    os.unlink(tmp_path)
+                except OSError:
+                    pass
         return None
 
     def _prepare_voice_attachment(
@@ -705,13 +712,6 @@ class BlueBubblesAdapter(BasePlatformAdapter):
                 filename=requested_name or "Audio Message.caf",
                 content_type="audio/x-caf",
             )
-        if ext == ".mp3":
-            return _PreparedAttachment(
-                path=file_path,
-                filename=requested_name or "Audio Message.mp3",
-                content_type="audio/mpeg",
-            )
-
         converted = self._convert_audio_to_caf(file_path)
         if converted:
             return _PreparedAttachment(
@@ -746,7 +746,7 @@ class BlueBubblesAdapter(BasePlatformAdapter):
             return SendResult(success=False, error=f"Chat not found: {chat_id}")
 
         prepared = (
-            self._prepare_voice_attachment(file_path, filename)
+            await asyncio.to_thread(self._prepare_voice_attachment, file_path, filename)
             if is_audio_message
             else _PreparedAttachment(
                 path=file_path,

--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -18,6 +18,7 @@ import shutil
 import subprocess
 import tempfile
 import uuid
+import wave
 from collections import OrderedDict
 from dataclasses import dataclass
 from datetime import datetime
@@ -593,62 +594,96 @@ class BlueBubblesAdapter(BasePlatformAdapter):
     # Media sending (outbound)
     # ------------------------------------------------------------------
 
+    @staticmethod
+    def _is_native_voice_wav_source(audio_path: str) -> bool:
+        """Return True for WAV input that can go straight to Opus CAF."""
+        if os.path.splitext(audio_path)[1].lower() != ".wav":
+            return False
+        try:
+            with wave.open(audio_path, "rb") as wf:
+                return wf.getnchannels() == 1 and wf.getframerate() == 24000
+        except (OSError, wave.Error, EOFError):
+            return False
+
     def _convert_audio_to_caf(self, audio_path: str) -> Optional[str]:
-        """Transcode audio to mono 24 kHz CAF for iMessage voice bubbles."""
+        """Transcode audio to Opus-in-CAF for iMessage voice bubbles.
+
+        iMessage native voice bubbles expect Opus at 24 kHz mono in a CAF
+        container.  Some source files play as ordinary attachments but render
+        as unusable native voice bubbles if uploaded as PCM/AAC CAF, so keep
+        the final BlueBubbles voice payload on the Opus CAF path.
+        """
+        afconvert = shutil.which("afconvert")
+        if not afconvert:
+            return None
+
         tmp = tempfile.NamedTemporaryFile(
             prefix="hermes-bluebubbles-voice-", suffix=".caf", delete=False
         )
         tmp_path = tmp.name
         tmp.close()
 
-        ffmpeg = shutil.which("ffmpeg")
-        afconvert = shutil.which("afconvert")
-        commands: List[List[str]] = []
-        if ffmpeg:
-            commands.append([
-                ffmpeg,
-                "-y",
-                "-i",
-                audio_path,
-                "-vn",
-                "-ac",
-                "1",
-                "-ar",
-                "24000",
-                "-c:a",
-                "opus",
-                "-f",
-                "caf",
-                tmp_path,
-            ])
-        if afconvert:
-            commands.append([
-                afconvert,
-                "-f",
-                "caff",
-                "-d",
-                "opus",
-                "-c",
-                "1",
-                "-r",
-                "24000",
-                audio_path,
-                tmp_path,
-            ])
-
-        for cmd in commands:
-            try:
+        normalized_path = audio_path
+        normalized_cleanup: Optional[str] = None
+        try:
+            if not self._is_native_voice_wav_source(audio_path):
+                ffmpeg = shutil.which("ffmpeg")
+                if not ffmpeg:
+                    return None
+                normalized = tempfile.NamedTemporaryFile(
+                    prefix="hermes-bluebubbles-voice-src-", suffix=".wav", delete=False
+                )
+                normalized_path = normalized.name
+                normalized.close()
+                normalized_cleanup = normalized_path
                 subprocess.run(
-                    cmd,
+                    [
+                        ffmpeg,
+                        "-y",
+                        "-i",
+                        audio_path,
+                        "-vn",
+                        "-ac",
+                        "1",
+                        "-ar",
+                        "24000",
+                        normalized_path,
+                    ],
                     check=True,
                     stdout=subprocess.DEVNULL,
                     stderr=subprocess.DEVNULL,
                     timeout=60,
                 )
-                if os.path.isfile(tmp_path) and os.path.getsize(tmp_path) > 0:
-                    return tmp_path
-            except Exception as exc:
-                logger.debug("BlueBubbles CAF transcode failed with %s: %s", cmd[0], exc)
+                if not os.path.isfile(normalized_path) or os.path.getsize(normalized_path) == 0:
+                    return None
+
+            subprocess.run(
+                [
+                    afconvert,
+                    "-f",
+                    "caff",
+                    "-d",
+                    "opus@24000",
+                    "-c",
+                    "1",
+                    normalized_path,
+                    tmp_path,
+                ],
+                check=True,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                timeout=60,
+            )
+            if os.path.isfile(tmp_path) and os.path.getsize(tmp_path) > 0:
+                return tmp_path
+        except Exception as exc:
+            logger.debug("BlueBubbles Opus CAF transcode failed: %s", exc)
+        finally:
+            if normalized_cleanup:
+                try:
+                    os.unlink(normalized_cleanup)
+                except OSError:
+                    pass
 
         try:
             os.unlink(tmp_path)

--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -13,8 +13,12 @@ import json
 import logging
 import os
 import re
+import shutil
+import subprocess
+import tempfile
 import uuid
 from collections import OrderedDict
+from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional
@@ -23,6 +27,7 @@ from urllib.parse import quote
 import httpx
 
 from gateway.config import Platform, PlatformConfig
+from hermes_cli._subprocess_compat import windows_hide_flags
 from gateway.platforms.base import (
     BasePlatformAdapter,
     MessageEvent,
@@ -52,7 +57,7 @@ _BLUEBUBBLES_AUDIO_EXT_OVERRIDES = {
     "audio/mpeg": ".mp3",
     "audio/ogg": ".ogg",
     "audio/wav": ".wav",
-    "audio/x-caf": ".mp3",  # preserves historical bluebubbles mapping
+    "audio/x-caf": ".caf",
     "audio/mp4": ".m4a",
     "audio/aac": ".m4a",  # preserves historical bluebubbles mapping (shared table says .aac)
 }
@@ -154,7 +159,27 @@ def _normalize_server_url(raw: str) -> str:
     return value.rstrip("/")
 
 
+@dataclass(frozen=True)
+class _PreparedAttachment:
+    path: str
+    filename: str
+    content_type: str
+    cleanup: bool = False
+    native_voice: bool = False
 
+
+def _attachment_content_type(filename: str, is_audio_message: bool = False) -> str:
+    """Return a useful multipart MIME type for BlueBubbles voice uploads."""
+    ext = os.path.splitext(filename)[1].lower()
+    if ext == ".caf":
+        return "audio/x-caf"
+    if ext == ".mp3":
+        return "audio/mpeg"
+    if is_audio_message and ext in {".m4a", ".aac"}:
+        return "audio/mp4"
+    if is_audio_message and ext == ".wav":
+        return "audio/wav"
+    return "application/octet-stream"
 
 
 # ---------------------------------------------------------------------------
@@ -591,6 +616,170 @@ class BlueBubblesAdapter(BasePlatformAdapter):
     # Media sending (outbound)
     # ------------------------------------------------------------------
 
+    @staticmethod
+    def _is_native_voice_wav_source(audio_path: str) -> bool:
+        """Return True for 24 kHz mono WAV input ready for Opus CAF."""
+        import wave
+
+        if os.path.splitext(audio_path)[1].lower() != ".wav":
+            return False
+        try:
+            with wave.open(audio_path, "rb") as wav_file:
+                return (
+                    wav_file.getnchannels() == 1
+                    and wav_file.getframerate() == 24000
+                )
+        except (OSError, wave.Error, EOFError):
+            return False
+
+    def _convert_audio_to_caf(self, audio_path: str) -> Optional[str]:
+        """Transcode audio to 24 kHz mono Opus-in-CAF for iMessage voice."""
+        afconvert = shutil.which("afconvert")
+        if not afconvert:
+            logger.warning(
+                "BlueBubbles native voice conversion unavailable: afconvert not found"
+            )
+            return None
+
+        caf_file = tempfile.NamedTemporaryFile(
+            prefix="hermes-bluebubbles-voice-",
+            suffix=".caf",
+            delete=False,
+        )
+        caf_path = caf_file.name
+        caf_file.close()
+        normalized_path = audio_path
+        normalized_cleanup: Optional[str] = None
+        keep_caf = False
+        try:
+            if not self._is_native_voice_wav_source(audio_path):
+                ffmpeg = shutil.which("ffmpeg")
+                if not ffmpeg:
+                    raise RuntimeError(
+                        "ffmpeg not found for BlueBubbles voice normalization"
+                    )
+                normalized_file = tempfile.NamedTemporaryFile(
+                    prefix="hermes-bluebubbles-voice-src-",
+                    suffix=".wav",
+                    delete=False,
+                )
+                normalized_path = normalized_file.name
+                normalized_file.close()
+                normalized_cleanup = normalized_path
+                subprocess.run(
+                    [
+                        ffmpeg,
+                        "-y",
+                        "-i",
+                        audio_path,
+                        "-vn",
+                        "-ac",
+                        "1",
+                        "-ar",
+                        "24000",
+                        normalized_path,
+                    ],
+                    check=True,
+                    stdin=subprocess.DEVNULL,
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                    timeout=60,
+                    creationflags=windows_hide_flags(),
+                )
+                if (
+                    not os.path.isfile(normalized_path)
+                    or os.path.getsize(normalized_path) == 0
+                ):
+                    raise RuntimeError(
+                        "ffmpeg produced an empty BlueBubbles voice normalization file"
+                    )
+
+            subprocess.run(
+                [
+                    afconvert,
+                    "-f",
+                    "caff",
+                    "-d",
+                    "opus@24000",
+                    "-c",
+                    "1",
+                    normalized_path,
+                    caf_path,
+                ],
+                check=True,
+                stdin=subprocess.DEVNULL,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                timeout=60,
+                creationflags=windows_hide_flags(),
+            )
+            if os.path.isfile(caf_path) and os.path.getsize(caf_path) > 0:
+                keep_caf = True
+                return caf_path
+        except Exception as exc:
+            logger.warning("BlueBubbles Opus CAF transcode failed: %s", exc)
+        finally:
+            if normalized_cleanup:
+                try:
+                    os.unlink(normalized_cleanup)
+                except OSError:
+                    pass
+            if not keep_caf:
+                try:
+                    os.unlink(caf_path)
+                except OSError:
+                    pass
+        return None
+
+    def _prepare_voice_attachment(
+        self, file_path: str, filename: Optional[str] = None
+    ) -> _PreparedAttachment:
+        """Prepare one outbound BlueBubbles/iMessage native voice payload."""
+        requested_name = filename or os.path.basename(file_path)
+        if os.path.splitext(requested_name)[1].lower() == ".caf":
+            return _PreparedAttachment(
+                path=file_path,
+                filename=requested_name or "Audio Message.caf",
+                content_type="audio/x-caf",
+                native_voice=True,
+            )
+        converted = self._convert_audio_to_caf(file_path)
+        if converted:
+            return _PreparedAttachment(
+                path=converted,
+                filename="Audio Message.caf",
+                content_type="audio/x-caf",
+                cleanup=True,
+                native_voice=True,
+            )
+        logger.warning(
+            "BlueBubbles native voice conversion unavailable for %s; "
+            "sending an ordinary audio attachment instead",
+            requested_name,
+        )
+        return _PreparedAttachment(
+            path=file_path,
+            filename=requested_name,
+            content_type=_attachment_content_type(
+                requested_name, is_audio_message=True
+            ),
+        )
+
+    @staticmethod
+    def _cleanup_prepared_attachment(prepared: _PreparedAttachment) -> None:
+        if prepared.cleanup:
+            try:
+                os.unlink(prepared.path)
+            except OSError:
+                pass
+
+    def _cleanup_cancelled_preparation(self, task: asyncio.Task) -> None:
+        try:
+            prepared = task.result()
+        except BaseException:
+            return
+        self._cleanup_prepared_attachment(prepared)
+
     async def _send_attachment(
         self,
         chat_id: str,
@@ -609,20 +798,52 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         if not guid:
             return SendResult(success=False, error=f"Chat not found: {chat_id}")
 
-        fname = filename or os.path.basename(file_path)
+        try:
+            if is_audio_message:
+                preparation_task = asyncio.create_task(
+                    asyncio.to_thread(
+                        self._prepare_voice_attachment, file_path, filename
+                    )
+                )
+                try:
+                    prepared = await asyncio.shield(preparation_task)
+                except asyncio.CancelledError:
+                    preparation_task.add_done_callback(
+                        self._cleanup_cancelled_preparation
+                    )
+                    raise
+            else:
+                prepared = _PreparedAttachment(
+                    path=file_path,
+                    filename=filename or os.path.basename(file_path),
+                    content_type="application/octet-stream",
+                )
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            return SendResult(success=False, error=str(exc))
+
         try:
             # httpx's async multipart iterator reads file-like objects through
-            # a synchronous chunk generator. Read the file off the event-loop
-            # thread before handing bytes to the client.
-            payload = await asyncio.to_thread(Path(file_path).read_bytes)
-            files = {"attachment": (fname, payload, "application/octet-stream")}
+            # a synchronous chunk generator. Read the prepared payload off the
+            # event-loop thread before handing bytes to the client.
+            payload = await asyncio.to_thread(Path(prepared.path).read_bytes)
+            files = {
+                "attachment": (
+                    prepared.filename,
+                    payload,
+                    prepared.content_type,
+                )
+            }
             data: Dict[str, str] = {
                 "chatGuid": guid,
-                "name": fname,
+                "name": prepared.filename,
                 "tempGuid": uuid.uuid4().hex,
             }
-            if is_audio_message:
+            if prepared.native_voice:
                 data["isAudioMessage"] = "true"
+                if self._private_api_enabled and self._helper_connected:
+                    data["method"] = "private-api"
             res = await self.client.post(
                 self._api_url("/api/v1/message/attachment"),
                 files=files,
@@ -645,8 +866,10 @@ class BlueBubblesAdapter(BasePlatformAdapter):
                 success=False,
                 error=result.get("message", "Attachment upload failed"),
             )
-        except Exception as e:
-            return SendResult(success=False, error=str(e))
+        except Exception as exc:
+            return SendResult(success=False, error=str(exc))
+        finally:
+            self._cleanup_prepared_attachment(prepared)
 
     async def send_image(
         self,

--- a/tests/gateway/test_base_auto_tts_output_format.py
+++ b/tests/gateway/test_base_auto_tts_output_format.py
@@ -86,6 +86,11 @@ def test_output_path_is_mp3_for_non_opus_platforms(platform):
     assert path.endswith(".mp3"), path
 
 
+def test_output_path_is_wav_for_bluebubbles_native_packaging():
+    path = build_auto_tts_output_path(Platform.BLUEBUBBLES)
+    assert path.endswith(".wav"), path
+
+
 # ---------------------------------------------------------------------------
 # Base-adapter auto-TTS block: explicit output_path, no contextvar reliance
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_bluebubbles.py
+++ b/tests/gateway/test_bluebubbles.py
@@ -702,6 +702,29 @@ class TestBlueBubblesVoiceSend:
         assert captured["files"]["attachment"][0] == "Audio Message.caf"
         assert captured["files"]["attachment"][2] == "audio/x-caf"
 
+    @pytest.mark.asyncio
+    async def test_send_voice_returns_failure_when_preparation_raises(
+        self, monkeypatch, tmp_path
+    ):
+        adapter = _make_adapter(monkeypatch)
+        audio_path = tmp_path / "voice.mp3"
+        audio_path.write_bytes(b"mp3fake")
+        monkeypatch.setattr(adapter, "client", object())
+
+        async def fake_resolve_chat_guid(chat_id):
+            return "iMessage;-;user@example.com"
+
+        def fail_preparation(file_path, filename=None):
+            raise OSError("temporary file unavailable")
+
+        monkeypatch.setattr(adapter, "_resolve_chat_guid", fake_resolve_chat_guid)
+        monkeypatch.setattr(adapter, "_prepare_voice_attachment", fail_preparation)
+
+        result = await adapter.send_voice("user@example.com", str(audio_path))
+
+        assert result.success is False
+        assert result.error == "temporary file unavailable"
+
     def test_prepare_voice_attachment_transcodes_non_caf_audio_to_caf(self, monkeypatch, tmp_path):
         adapter = _make_adapter(monkeypatch)
         source = tmp_path / "voice.m4a"

--- a/tests/gateway/test_bluebubbles.py
+++ b/tests/gateway/test_bluebubbles.py
@@ -738,6 +738,8 @@ class TestBlueBubblesVoiceSend:
         assert "opus@24000" in calls[1]
 
     def test_prepare_voice_attachment_skips_ffmpeg_for_native_wav_source(self, monkeypatch, tmp_path):
+        import wave
+
         adapter = _make_adapter(monkeypatch)
         source = tmp_path / "voice.wav"
         with wave.open(str(source), "wb") as wf:

--- a/tests/gateway/test_bluebubbles.py
+++ b/tests/gateway/test_bluebubbles.py
@@ -1,6 +1,7 @@
 """Tests for the BlueBubbles iMessage gateway adapter."""
 import asyncio
 import json
+import wave
 
 import pytest
 
@@ -705,7 +706,7 @@ class TestBlueBubblesVoiceSend:
 
         monkeypatch.setattr(
             "gateway.platforms.bluebubbles.shutil.which",
-            lambda name: "/usr/bin/ffmpeg" if name == "ffmpeg" else None,
+            lambda name: f"/usr/bin/{name}" if name in {"ffmpeg", "afconvert"} else None,
         )
 
         calls = []
@@ -729,9 +730,48 @@ class TestBlueBubblesVoiceSend:
         assert prepared.filename == "Audio Message.caf"
         assert prepared.content_type == "audio/x-caf"
         assert prepared.cleanup is True
-        assert calls
+        assert len(calls) == 2
+        assert calls[0][0].endswith("ffmpeg")
         assert "-ar" in calls[0]
         assert "24000" in calls[0]
+        assert calls[1][0].endswith("afconvert")
+        assert "opus@24000" in calls[1]
+
+    def test_prepare_voice_attachment_skips_ffmpeg_for_native_wav_source(self, monkeypatch, tmp_path):
+        adapter = _make_adapter(monkeypatch)
+        source = tmp_path / "voice.wav"
+        with wave.open(str(source), "wb") as wf:
+            wf.setnchannels(1)
+            wf.setsampwidth(2)
+            wf.setframerate(24000)
+            wf.writeframes(b"\x00\x00" * 240)
+
+        monkeypatch.setattr(
+            "gateway.platforms.bluebubbles.shutil.which",
+            lambda name: f"/usr/bin/{name}" if name in {"ffmpeg", "afconvert"} else None,
+        )
+
+        calls = []
+
+        def fake_run(cmd, **kwargs):
+            calls.append(cmd)
+            output = cmd[-1]
+            with open(output, "wb") as f:
+                f.write(b"caffake")
+
+            class Completed:
+                returncode = 0
+
+            return Completed()
+
+        monkeypatch.setattr("gateway.platforms.bluebubbles.subprocess.run", fake_run)
+
+        prepared = adapter._prepare_voice_attachment(str(source), None)
+
+        assert prepared.path.endswith(".caf")
+        assert prepared.content_type == "audio/x-caf"
+        assert [call[0] for call in calls] == ["/usr/bin/afconvert"]
+        assert "opus@24000" in calls[0]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_bluebubbles.py
+++ b/tests/gateway/test_bluebubbles.py
@@ -10,6 +10,12 @@ from gateway.config import Platform, PlatformConfig
 def _make_adapter(monkeypatch, **extra):
     monkeypatch.setenv("BLUEBUBBLES_SERVER_URL", "http://localhost:1234")
     monkeypatch.setenv("BLUEBUBBLES_PASSWORD", "secret")
+    if "webhook_host" not in extra:
+        monkeypatch.delenv("BLUEBUBBLES_WEBHOOK_HOST", raising=False)
+    if "webhook_port" not in extra:
+        monkeypatch.delenv("BLUEBUBBLES_WEBHOOK_PORT", raising=False)
+    if "webhook_path" not in extra:
+        monkeypatch.delenv("BLUEBUBBLES_WEBHOOK_PATH", raising=False)
     from gateway.platforms.bluebubbles import BlueBubblesAdapter
 
     cfg = PlatformConfig(
@@ -650,6 +656,82 @@ class TestBlueBubblesAttachmentDownload:
             adapter._download_attachment("att-guid", {"mimeType": "image/png"})
         )
         assert result is None
+
+
+class TestBlueBubblesVoiceSend:
+    @pytest.mark.asyncio
+    async def test_send_voice_uploads_caf_as_private_api_audio_message(self, monkeypatch, tmp_path):
+        adapter = _make_adapter(monkeypatch)
+        adapter._private_api_enabled = True
+        adapter._helper_connected = True
+        audio_path = tmp_path / "Audio Message.caf"
+        audio_path.write_bytes(b"caffake")
+
+        async def fake_resolve_chat_guid(chat_id):
+            return "iMessage;-;user@example.com"
+
+        captured = {}
+
+        async def fake_post(self, url, *, files, data, timeout):
+            captured["url"] = url
+            captured["files"] = files
+            captured["data"] = data
+            captured["timeout"] = timeout
+
+            class R:
+                def raise_for_status(self):
+                    pass
+
+                def json(self):
+                    return {"status": 200, "data": {"guid": "out-guid"}}
+
+            return R()
+
+        adapter.client = type("MockClient", (), {"post": fake_post})()
+        monkeypatch.setattr(adapter, "_resolve_chat_guid", fake_resolve_chat_guid)
+
+        result = await adapter.send_voice("user@example.com", str(audio_path))
+
+        assert result.success is True
+        assert captured["data"]["isAudioMessage"] == "true"
+        assert captured["data"]["method"] == "private-api"
+        assert captured["files"]["attachment"][0] == "Audio Message.caf"
+        assert captured["files"]["attachment"][2] == "audio/x-caf"
+
+    def test_prepare_voice_attachment_transcodes_non_caf_audio_to_caf(self, monkeypatch, tmp_path):
+        adapter = _make_adapter(monkeypatch)
+        source = tmp_path / "voice.m4a"
+        source.write_bytes(b"m4afake")
+
+        monkeypatch.setattr(
+            "gateway.platforms.bluebubbles.shutil.which",
+            lambda name: "/usr/bin/ffmpeg" if name == "ffmpeg" else None,
+        )
+
+        calls = []
+
+        def fake_run(cmd, **kwargs):
+            calls.append(cmd)
+            output = cmd[-1]
+            with open(output, "wb") as f:
+                f.write(b"caffake")
+
+            class Completed:
+                returncode = 0
+
+            return Completed()
+
+        monkeypatch.setattr("gateway.platforms.bluebubbles.subprocess.run", fake_run)
+
+        prepared = adapter._prepare_voice_attachment(str(source), None)
+
+        assert prepared.path.endswith(".caf")
+        assert prepared.filename == "Audio Message.caf"
+        assert prepared.content_type == "audio/x-caf"
+        assert prepared.cleanup is True
+        assert calls
+        assert "-ar" in calls[0]
+        assert "24000" in calls[0]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_bluebubbles.py
+++ b/tests/gateway/test_bluebubbles.py
@@ -1,6 +1,7 @@
 """Tests for the BlueBubbles iMessage gateway adapter."""
 import asyncio
 import json
+import tempfile
 import wave
 
 import pytest
@@ -736,6 +737,135 @@ class TestBlueBubblesVoiceSend:
         assert "24000" in calls[0]
         assert calls[1][0].endswith("afconvert")
         assert "opus@24000" in calls[1]
+
+    def test_prepare_voice_attachment_transcodes_mp3_to_caf(self, monkeypatch, tmp_path):
+        adapter = _make_adapter(monkeypatch)
+        source = tmp_path / "voice.mp3"
+        source.write_bytes(b"mp3fake")
+
+        monkeypatch.setattr(
+            "gateway.platforms.bluebubbles.shutil.which",
+            lambda name: f"/usr/bin/{name}" if name in {"ffmpeg", "afconvert"} else None,
+        )
+
+        def fake_run(cmd, **kwargs):
+            with open(cmd[-1], "wb") as f:
+                f.write(b"audio")
+
+        monkeypatch.setattr("gateway.platforms.bluebubbles.subprocess.run", fake_run)
+
+        prepared = adapter._prepare_voice_attachment(str(source), None)
+
+        assert prepared.path.endswith(".caf")
+        assert prepared.filename == "Audio Message.caf"
+        assert prepared.content_type == "audio/x-caf"
+        assert prepared.cleanup is True
+
+    def test_prepare_voice_attachment_cleans_temp_caf_when_ffmpeg_missing(
+        self, monkeypatch, tmp_path
+    ):
+        adapter = _make_adapter(monkeypatch)
+        source = tmp_path / "voice.m4a"
+        source.write_bytes(b"m4afake")
+        real_named_temporary_file = tempfile.NamedTemporaryFile
+
+        def temp_in_test_dir(*args, **kwargs):
+            kwargs["dir"] = tmp_path
+            return real_named_temporary_file(*args, **kwargs)
+
+        monkeypatch.setattr(
+            "gateway.platforms.bluebubbles.tempfile.NamedTemporaryFile",
+            temp_in_test_dir,
+        )
+        monkeypatch.setattr(
+            "gateway.platforms.bluebubbles.shutil.which",
+            lambda name: "/usr/bin/afconvert" if name == "afconvert" else None,
+        )
+
+        prepared = adapter._prepare_voice_attachment(str(source), None)
+
+        assert prepared.path == str(source)
+        assert not list(tmp_path.glob("hermes-bluebubbles-voice-*.caf"))
+
+    def test_prepare_voice_attachment_cleans_all_temps_for_invalid_afconvert_output(
+        self, monkeypatch, tmp_path
+    ):
+        adapter = _make_adapter(monkeypatch)
+        source = tmp_path / "voice.m4a"
+        source.write_bytes(b"m4afake")
+        real_named_temporary_file = tempfile.NamedTemporaryFile
+
+        def temp_in_test_dir(*args, **kwargs):
+            kwargs["dir"] = tmp_path
+            return real_named_temporary_file(*args, **kwargs)
+
+        def fake_run(cmd, **kwargs):
+            if cmd[0].endswith("ffmpeg"):
+                with open(cmd[-1], "wb") as f:
+                    f.write(b"wav")
+
+        monkeypatch.setattr(
+            "gateway.platforms.bluebubbles.tempfile.NamedTemporaryFile",
+            temp_in_test_dir,
+        )
+        monkeypatch.setattr(
+            "gateway.platforms.bluebubbles.shutil.which",
+            lambda name: f"/usr/bin/{name}" if name in {"ffmpeg", "afconvert"} else None,
+        )
+        monkeypatch.setattr(
+            "gateway.platforms.bluebubbles.subprocess.run",
+            fake_run,
+        )
+
+        prepared = adapter._prepare_voice_attachment(str(source), None)
+
+        assert prepared.path == str(source)
+        assert not list(tmp_path.glob("hermes-bluebubbles-voice-*.caf"))
+        assert not list(tmp_path.glob("hermes-bluebubbles-voice-src-*.wav"))
+
+    @pytest.mark.asyncio
+    async def test_send_voice_offloads_attachment_preparation(self, monkeypatch, tmp_path):
+        from gateway.platforms.bluebubbles import _PreparedAttachment
+
+        adapter = _make_adapter(monkeypatch)
+        audio_path = tmp_path / "voice.mp3"
+        audio_path.write_bytes(b"mp3fake")
+        calls = []
+
+        async def fake_to_thread(func, *args):
+            calls.append((func, args))
+            return func(*args)
+
+        async def fake_resolve_chat_guid(chat_id):
+            return "iMessage;-;user@example.com"
+
+        async def fake_post(self, url, *, files, data, timeout):
+            class Response:
+                def raise_for_status(self):
+                    pass
+
+                def json(self):
+                    return {"status": 200, "data": {"guid": "out-guid"}}
+
+            return Response()
+
+        adapter.client = type("MockClient", (), {"post": fake_post})()
+        monkeypatch.setattr(adapter, "_resolve_chat_guid", fake_resolve_chat_guid)
+        monkeypatch.setattr(
+            adapter,
+            "_prepare_voice_attachment",
+            lambda path, filename: _PreparedAttachment(
+                path=path,
+                filename=filename or "voice.mp3",
+                content_type="audio/mpeg",
+            ),
+        )
+        monkeypatch.setattr(asyncio, "to_thread", fake_to_thread)
+
+        result = await adapter.send_voice("user@example.com", str(audio_path))
+
+        assert result.success is True
+        assert len(calls) == 1
 
     def test_prepare_voice_attachment_skips_ffmpeg_for_native_wav_source(self, monkeypatch, tmp_path):
         import wave

--- a/tests/gateway/test_bluebubbles.py
+++ b/tests/gateway/test_bluebubbles.py
@@ -2,7 +2,9 @@
 import asyncio
 import json
 import tempfile
+import threading
 import wave
+from pathlib import Path
 
 import pytest
 
@@ -727,16 +729,20 @@ class TestBlueBubblesVoiceSend:
 
         prepared = adapter._prepare_voice_attachment(str(source), None)
 
-        assert prepared.path.endswith(".caf")
-        assert prepared.filename == "Audio Message.caf"
-        assert prepared.content_type == "audio/x-caf"
-        assert prepared.cleanup is True
-        assert len(calls) == 2
-        assert calls[0][0].endswith("ffmpeg")
-        assert "-ar" in calls[0]
-        assert "24000" in calls[0]
-        assert calls[1][0].endswith("afconvert")
-        assert "opus@24000" in calls[1]
+        try:
+            assert prepared.path.endswith(".caf")
+            assert prepared.filename == "Audio Message.caf"
+            assert prepared.content_type == "audio/x-caf"
+            assert prepared.cleanup is True
+            assert len(calls) == 2
+            assert calls[0][0].endswith("ffmpeg")
+            assert "-ar" in calls[0]
+            assert "24000" in calls[0]
+            assert calls[1][0].endswith("afconvert")
+            assert "opus@24000" in calls[1]
+        finally:
+            if prepared.cleanup:
+                Path(prepared.path).unlink(missing_ok=True)
 
     def test_prepare_voice_attachment_transcodes_mp3_to_caf(self, monkeypatch, tmp_path):
         adapter = _make_adapter(monkeypatch)
@@ -756,10 +762,14 @@ class TestBlueBubblesVoiceSend:
 
         prepared = adapter._prepare_voice_attachment(str(source), None)
 
-        assert prepared.path.endswith(".caf")
-        assert prepared.filename == "Audio Message.caf"
-        assert prepared.content_type == "audio/x-caf"
-        assert prepared.cleanup is True
+        try:
+            assert prepared.path.endswith(".caf")
+            assert prepared.filename == "Audio Message.caf"
+            assert prepared.content_type == "audio/x-caf"
+            assert prepared.cleanup is True
+        finally:
+            if prepared.cleanup:
+                Path(prepared.path).unlink(missing_ok=True)
 
     def test_prepare_voice_attachment_cleans_temp_caf_when_ffmpeg_missing(
         self, monkeypatch, tmp_path
@@ -786,6 +796,39 @@ class TestBlueBubblesVoiceSend:
 
         assert prepared.path == str(source)
         assert not list(tmp_path.glob("hermes-bluebubbles-voice-*.caf"))
+
+    def test_prepare_voice_attachment_cleans_all_temps_for_empty_ffmpeg_output(
+        self, monkeypatch, tmp_path
+    ):
+        adapter = _make_adapter(monkeypatch)
+        source = tmp_path / "voice.mp3"
+        source.write_bytes(b"mp3fake")
+        real_named_temporary_file = tempfile.NamedTemporaryFile
+        calls = []
+
+        def temp_in_test_dir(*args, **kwargs):
+            kwargs["dir"] = tmp_path
+            return real_named_temporary_file(*args, **kwargs)
+
+        def fake_run(cmd, **kwargs):
+            calls.append(cmd)
+
+        monkeypatch.setattr(
+            "gateway.platforms.bluebubbles.tempfile.NamedTemporaryFile",
+            temp_in_test_dir,
+        )
+        monkeypatch.setattr(
+            "gateway.platforms.bluebubbles.shutil.which",
+            lambda name: f"/usr/bin/{name}" if name in {"ffmpeg", "afconvert"} else None,
+        )
+        monkeypatch.setattr("gateway.platforms.bluebubbles.subprocess.run", fake_run)
+
+        prepared = adapter._prepare_voice_attachment(str(source), None)
+
+        assert prepared.path == str(source)
+        assert [call[0] for call in calls] == ["/usr/bin/ffmpeg"]
+        assert not list(tmp_path.glob("hermes-bluebubbles-voice-*.caf"))
+        assert not list(tmp_path.glob("hermes-bluebubbles-voice-src-*.wav"))
 
     def test_prepare_voice_attachment_cleans_all_temps_for_invalid_afconvert_output(
         self, monkeypatch, tmp_path
@@ -824,22 +867,38 @@ class TestBlueBubblesVoiceSend:
         assert not list(tmp_path.glob("hermes-bluebubbles-voice-src-*.wav"))
 
     @pytest.mark.asyncio
-    async def test_send_voice_offloads_attachment_preparation(self, monkeypatch, tmp_path):
-        from gateway.platforms.bluebubbles import _PreparedAttachment
-
+    async def test_send_voice_converts_mp3_off_thread_and_cleans_output(
+        self, monkeypatch, tmp_path
+    ):
         adapter = _make_adapter(monkeypatch)
         audio_path = tmp_path / "voice.mp3"
         audio_path.write_bytes(b"mp3fake")
-        calls = []
+        real_named_temporary_file = tempfile.NamedTemporaryFile
+        captured = {}
+        offloaded = []
+
+        def temp_in_test_dir(*args, **kwargs):
+            kwargs["dir"] = tmp_path
+            return real_named_temporary_file(*args, **kwargs)
+
+        def fake_run(cmd, **kwargs):
+            Path(cmd[-1]).write_bytes(b"audio")
 
         async def fake_to_thread(func, *args):
-            calls.append((func, args))
+            offloaded.append((func, args))
             return func(*args)
 
         async def fake_resolve_chat_guid(chat_id):
             return "iMessage;-;user@example.com"
 
         async def fake_post(self, url, *, files, data, timeout):
+            attachment = files["attachment"]
+            captured["filename"] = attachment[0]
+            captured["path"] = attachment[1].name
+            captured["content_type"] = attachment[2]
+            captured["data"] = data
+            captured["exists_during_upload"] = Path(attachment[1].name).exists()
+
             class Response:
                 def raise_for_status(self):
                     pass
@@ -852,20 +911,73 @@ class TestBlueBubblesVoiceSend:
         adapter.client = type("MockClient", (), {"post": fake_post})()
         monkeypatch.setattr(adapter, "_resolve_chat_guid", fake_resolve_chat_guid)
         monkeypatch.setattr(
-            adapter,
-            "_prepare_voice_attachment",
-            lambda path, filename: _PreparedAttachment(
-                path=path,
-                filename=filename or "voice.mp3",
-                content_type="audio/mpeg",
-            ),
+            "gateway.platforms.bluebubbles.tempfile.NamedTemporaryFile",
+            temp_in_test_dir,
         )
+        monkeypatch.setattr(
+            "gateway.platforms.bluebubbles.shutil.which",
+            lambda name: f"/usr/bin/{name}" if name in {"ffmpeg", "afconvert"} else None,
+        )
+        monkeypatch.setattr("gateway.platforms.bluebubbles.subprocess.run", fake_run)
         monkeypatch.setattr(asyncio, "to_thread", fake_to_thread)
 
         result = await adapter.send_voice("user@example.com", str(audio_path))
 
         assert result.success is True
-        assert len(calls) == 1
+        assert len(offloaded) == 1
+        assert captured["filename"] == "Audio Message.caf"
+        assert captured["content_type"] == "audio/x-caf"
+        assert captured["data"]["isAudioMessage"] == "true"
+        assert captured["exists_during_upload"] is True
+        assert not Path(captured["path"]).exists()
+        assert not list(tmp_path.glob("hermes-bluebubbles-voice-src-*.wav"))
+
+    @pytest.mark.asyncio
+    async def test_send_voice_cancellation_cleans_completed_thread_result(
+        self, monkeypatch, tmp_path
+    ):
+        from gateway.platforms.bluebubbles import _PreparedAttachment
+
+        adapter = _make_adapter(monkeypatch)
+        monkeypatch.setattr(adapter, "client", object())
+        audio_path = tmp_path / "voice.mp3"
+        audio_path.write_bytes(b"mp3fake")
+        caf_path = tmp_path / "cancelled.caf"
+        caf_path.write_bytes(b"caffake")
+        started = threading.Event()
+        release = threading.Event()
+
+        async def fake_resolve_chat_guid(chat_id):
+            return "iMessage;-;user@example.com"
+
+        def blocking_prepare(path, filename):
+            started.set()
+            release.wait(timeout=2)
+            return _PreparedAttachment(
+                path=str(caf_path),
+                filename="Audio Message.caf",
+                content_type="audio/x-caf",
+                cleanup=True,
+            )
+
+        monkeypatch.setattr(adapter, "_resolve_chat_guid", fake_resolve_chat_guid)
+        monkeypatch.setattr(adapter, "_prepare_voice_attachment", blocking_prepare)
+
+        send_task = asyncio.create_task(
+            adapter.send_voice("user@example.com", str(audio_path))
+        )
+        assert await asyncio.to_thread(started.wait, 1)
+        send_task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await send_task
+
+        release.set()
+        for _ in range(50):
+            if not caf_path.exists():
+                break
+            await asyncio.sleep(0.01)
+
+        assert not caf_path.exists()
 
     def test_prepare_voice_attachment_skips_ffmpeg_for_native_wav_source(self, monkeypatch, tmp_path):
         import wave
@@ -900,10 +1012,14 @@ class TestBlueBubblesVoiceSend:
 
         prepared = adapter._prepare_voice_attachment(str(source), None)
 
-        assert prepared.path.endswith(".caf")
-        assert prepared.content_type == "audio/x-caf"
-        assert [call[0] for call in calls] == ["/usr/bin/afconvert"]
-        assert "opus@24000" in calls[0]
+        try:
+            assert prepared.path.endswith(".caf")
+            assert prepared.content_type == "audio/x-caf"
+            assert [call[0] for call in calls] == ["/usr/bin/afconvert"]
+            assert "opus@24000" in calls[0]
+        finally:
+            if prepared.cleanup:
+                Path(prepared.path).unlink(missing_ok=True)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_bluebubbles.py
+++ b/tests/gateway/test_bluebubbles.py
@@ -1,6 +1,8 @@
 """Tests for the BlueBubbles iMessage gateway adapter."""
 import asyncio
 import json
+import threading
+from pathlib import Path
 
 import httpx
 import pytest
@@ -275,6 +277,331 @@ class TestBlueBubblesAttachmentDownload:
         )
         assert result == "/tmp/test_image.png"
 
+    @pytest.mark.asyncio
+    async def test_download_caf_audio_preserves_caf_extension(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+
+        class MockResponse:
+            content = b"caffake"
+
+            def raise_for_status(self):
+                pass
+
+        async def mock_get(*args, **kwargs):
+            return MockResponse()
+
+        adapter.client = type("MockClient", (), {"get": mock_get})()  # type: ignore[reportAttributeAccessIssue]
+        captured = {}
+
+        def mock_cache_audio(data, ext):
+            captured["data"] = data
+            captured["ext"] = ext
+            return f"/tmp/test_audio{ext}"
+
+        monkeypatch.setattr(
+            "gateway.platforms.bluebubbles.cache_audio_from_bytes",
+            mock_cache_audio,
+        )
+        result = await adapter._download_attachment(
+            "att-guid-caf",
+            {"mimeType": "audio/x-caf", "transferName": "Audio Message.caf"},
+        )
+        assert result == "/tmp/test_audio.caf"
+        assert captured == {"data": b"caffake", "ext": ".caf"}
+
+
+# ---------------------------------------------------------------------------
+# Native voice sending
+# ---------------------------------------------------------------------------
+
+
+class TestBlueBubblesVoiceSend:
+    @pytest.mark.asyncio
+    async def test_existing_caf_uploads_as_private_api_audio_message(
+        self, monkeypatch, tmp_path
+    ):
+        adapter = _make_adapter(monkeypatch)
+        adapter._private_api_enabled = True
+        adapter._helper_connected = True
+        audio_path = tmp_path / "Audio Message.caf"
+        audio_path.write_bytes(b"caffake")
+
+        async def fake_resolve_chat_guid(chat_id):
+            return "iMessage;-;user@example.com"
+
+        captured = {}
+
+        async def fake_post(self, url, *, files, data, timeout):
+            captured["files"] = files
+            captured["data"] = data
+
+            class Response:
+                def raise_for_status(self):
+                    pass
+
+                def json(self):
+                    return {"status": 200, "data": {"guid": "out-guid"}}
+
+            return Response()
+
+        adapter.client = type("MockClient", (), {"post": fake_post})()  # type: ignore[reportAttributeAccessIssue]
+        monkeypatch.setattr(adapter, "_resolve_chat_guid", fake_resolve_chat_guid)
+
+        result = await adapter.send_voice("user@example.com", str(audio_path))
+
+        assert result.success is True
+        assert captured["data"]["isAudioMessage"] == "true"
+        assert captured["data"]["method"] == "private-api"
+        assert captured["files"]["attachment"][0] == "Audio Message.caf"
+        assert captured["files"]["attachment"][2] == "audio/x-caf"
+        assert audio_path.exists()
+
+    @pytest.mark.asyncio
+    async def test_native_caf_without_helper_omits_private_api_method(
+        self, monkeypatch, tmp_path
+    ):
+        adapter = _make_adapter(monkeypatch)
+        adapter._private_api_enabled = True
+        adapter._helper_connected = False
+        audio_path = tmp_path / "Audio Message.caf"
+        audio_path.write_bytes(b"caffake")
+
+        async def fake_resolve_chat_guid(chat_id):
+            return "iMessage;-;user@example.com"
+
+        captured = {}
+
+        async def fake_post(self, url, *, files, data, timeout):
+            captured["data"] = dict(data)
+
+            class Response:
+                def raise_for_status(self):
+                    pass
+
+                def json(self):
+                    return {"status": 200, "data": {"guid": "out-guid"}}
+
+            return Response()
+
+        adapter.client = type("MockClient", (), {"post": fake_post})()  # type: ignore[reportAttributeAccessIssue]
+        monkeypatch.setattr(adapter, "_resolve_chat_guid", fake_resolve_chat_guid)
+
+        result = await adapter.send_voice("user@example.com", str(audio_path))
+
+        assert result.success is True
+        assert captured["data"]["isAudioMessage"] == "true"
+        assert "method" not in captured["data"]
+        assert audio_path.exists()
+
+    def test_prepare_mp3_normalizes_to_24khz_mono_opus_caf(
+        self, monkeypatch, tmp_path
+    ):
+        adapter = _make_adapter(monkeypatch)
+        source = tmp_path / "voice.mp3"
+        source.write_bytes(b"mp3fake")
+        calls = []
+        monkeypatch.setattr(
+            "gateway.platforms.bluebubbles.shutil.which",
+            lambda name: f"/usr/bin/{name}"
+            if name in {"ffmpeg", "afconvert"}
+            else None,
+        )
+
+        def fake_run(command, **kwargs):
+            calls.append((command, kwargs))
+            Path(command[-1]).write_bytes(b"audio")
+
+        monkeypatch.setattr(
+            "gateway.platforms.bluebubbles.subprocess.run", fake_run
+        )
+        prepared = adapter._prepare_voice_attachment(str(source))
+        try:
+            assert prepared.filename == "Audio Message.caf"
+            assert prepared.content_type == "audio/x-caf"
+            assert prepared.cleanup is True
+            assert len(calls) == 2
+            assert calls[0][0][0] == "/usr/bin/ffmpeg"
+            assert calls[0][0][calls[0][0].index("-ac") + 1] == "1"
+            assert calls[0][0][calls[0][0].index("-ar") + 1] == "24000"
+            assert calls[1][0][0] == "/usr/bin/afconvert"
+            assert "opus@24000" in calls[1][0]
+            assert all(call[1]["stdin"] is not None for call in calls)
+        finally:
+            Path(prepared.path).unlink(missing_ok=True)
+
+    @pytest.mark.asyncio
+    async def test_send_voice_conversion_unavailable_is_ordinary_audio(
+        self, monkeypatch, tmp_path, caplog
+    ):
+        adapter = _make_adapter(monkeypatch)
+        adapter._private_api_enabled = True
+        adapter._helper_connected = True
+        source = tmp_path / "voice.mp3"
+        source.write_bytes(b"mp3fake")
+
+        async def fake_resolve_chat_guid(chat_id):
+            return "iMessage;-;user@example.com"
+
+        captured = {}
+
+        async def fake_post(self, url, *, files, data, timeout):
+            captured["filename"] = files["attachment"][0]
+            captured["content_type"] = files["attachment"][2]
+            captured["data"] = dict(data)
+
+            class Response:
+                def raise_for_status(self):
+                    pass
+
+                def json(self):
+                    return {"status": 200, "data": {"guid": "out-guid"}}
+
+            return Response()
+
+        adapter.client = type("MockClient", (), {"post": fake_post})()  # type: ignore[reportAttributeAccessIssue]
+        monkeypatch.setattr(adapter, "_resolve_chat_guid", fake_resolve_chat_guid)
+        monkeypatch.setattr(adapter, "_convert_audio_to_caf", lambda path: None)
+
+        result = await adapter.send_voice("user@example.com", str(source))
+
+        assert result.success is True
+        assert captured["filename"] == "voice.mp3"
+        assert captured["content_type"] == "audio/mpeg"
+        assert "isAudioMessage" not in captured["data"]
+        assert "method" not in captured["data"]
+        assert "ordinary audio attachment" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_send_voice_prepares_off_loop_and_cleans_generated_caf(
+        self, monkeypatch, tmp_path
+    ):
+        from gateway.platforms.bluebubbles import _PreparedAttachment
+
+        adapter = _make_adapter(monkeypatch)
+        adapter._private_api_enabled = True
+        adapter._helper_connected = True
+        source = tmp_path / "voice.wav"
+        source.write_bytes(b"wavfake")
+        generated = tmp_path / "generated.caf"
+        generated.write_bytes(b"caffake")
+        offloaded = []
+        captured = {}
+
+        async def fake_resolve_chat_guid(chat_id):
+            return "iMessage;-;user@example.com"
+
+        def fake_prepare(path, filename):
+            return _PreparedAttachment(
+                path=str(generated),
+                filename="Audio Message.caf",
+                content_type="audio/x-caf",
+                cleanup=True,
+                native_voice=True,
+            )
+
+        async def fake_to_thread(func, *args):
+            offloaded.append((func, args))
+            return func(*args)
+
+        async def fake_post(self, url, *, files, data, timeout):
+            captured["exists_during_upload"] = generated.exists()
+            captured["filename"] = files["attachment"][0]
+            captured["payload"] = files["attachment"][1]
+            captured["content_type"] = files["attachment"][2]
+            captured["data"] = dict(data)
+
+            class Response:
+                def raise_for_status(self):
+                    pass
+
+                def json(self):
+                    return {"status": 200, "data": {"guid": "out-guid"}}
+
+            return Response()
+
+        adapter.client = type("MockClient", (), {"post": fake_post})()  # type: ignore[reportAttributeAccessIssue]
+        monkeypatch.setattr(adapter, "_resolve_chat_guid", fake_resolve_chat_guid)
+        monkeypatch.setattr(adapter, "_prepare_voice_attachment", fake_prepare)
+        monkeypatch.setattr(asyncio, "to_thread", fake_to_thread)
+
+        result = await adapter.send_voice("user@example.com", str(source))
+
+        assert result.success is True
+        assert any(func is fake_prepare for func, _ in offloaded)
+        assert any(
+            getattr(func, "__name__", "") == "read_bytes" for func, _ in offloaded
+        )
+        assert captured["exists_during_upload"] is True
+        assert captured["filename"] == "Audio Message.caf"
+        assert captured["payload"] == b"caffake"
+        assert captured["content_type"] == "audio/x-caf"
+        assert captured["data"]["isAudioMessage"] == "true"
+        assert captured["data"]["method"] == "private-api"
+        assert not generated.exists()
+
+    @pytest.mark.asyncio
+    async def test_cancelled_preparation_cleans_completed_thread_result(
+        self, monkeypatch, tmp_path
+    ):
+        from gateway.platforms.bluebubbles import _PreparedAttachment
+
+        adapter = _make_adapter(monkeypatch)
+        adapter.client = object()  # type: ignore[reportAttributeAccessIssue]
+        source = tmp_path / "voice.mp3"
+        source.write_bytes(b"mp3fake")
+        generated = tmp_path / "cancelled.caf"
+        generated.write_bytes(b"caffake")
+        started = threading.Event()
+        release = threading.Event()
+
+        async def fake_resolve_chat_guid(chat_id):
+            return "iMessage;-;user@example.com"
+
+        def blocking_prepare(path, filename):
+            started.set()
+            release.wait(timeout=2)
+            return _PreparedAttachment(
+                path=str(generated),
+                filename="Audio Message.caf",
+                content_type="audio/x-caf",
+                cleanup=True,
+            )
+
+        monkeypatch.setattr(adapter, "_resolve_chat_guid", fake_resolve_chat_guid)
+        monkeypatch.setattr(adapter, "_prepare_voice_attachment", blocking_prepare)
+        send_task = asyncio.create_task(
+            adapter.send_voice("user@example.com", str(source))
+        )
+        assert await asyncio.to_thread(started.wait, 1)
+        send_task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await send_task
+        release.set()
+        for _ in range(50):
+            if not generated.exists():
+                break
+            await asyncio.sleep(0.01)
+        assert not generated.exists()
+
+    @pytest.mark.asyncio
+    async def test_preparation_failure_is_contained(self, monkeypatch, tmp_path):
+        adapter = _make_adapter(monkeypatch)
+        adapter.client = object()  # type: ignore[reportAttributeAccessIssue]
+        source = tmp_path / "voice.mp3"
+        source.write_bytes(b"mp3fake")
+
+        async def fake_resolve_chat_guid(chat_id):
+            return "iMessage;-;user@example.com"
+
+        def fail_prepare(path, filename):
+            raise OSError("temporary file unavailable")
+
+        monkeypatch.setattr(adapter, "_resolve_chat_guid", fake_resolve_chat_guid)
+        monkeypatch.setattr(adapter, "_prepare_voice_attachment", fail_prepare)
+        result = await adapter.send_voice("user@example.com", str(source))
+        assert result.success is False
+        assert result.error == "temporary file unavailable"
+
 
 class TestBlueBubblesAttachmentSend:
     @pytest.mark.asyncio
@@ -326,8 +653,9 @@ class TestBlueBubblesWebhookUrl:
     """_webhook_url property normalises local hosts to 'localhost'."""
 
     def test_default_host(self, monkeypatch):
+        monkeypatch.delenv("BLUEBUBBLES_WEBHOOK_HOST", raising=False)
         adapter = _make_adapter(monkeypatch)
-        # Default webhook_host is 0.0.0.0 → normalized to localhost
+        # Default local bind host is normalized to localhost for callbacks.
         assert "localhost" in adapter._webhook_url
         assert str(adapter.webhook_port) in adapter._webhook_url
         assert adapter.webhook_path in adapter._webhook_url


### PR DESCRIPTION
## What does this PR do?

Restores native iMessage voice-message delivery for outbound BlueBubbles voice replies on current Hermes `main`.

BlueBubbles can accept an ordinary MP3/WAV attachment while still rendering it as a generic audio file rather than a native iMessage audio message. This change prepares voice sends as mono 24 kHz Opus-in-CAF when the macOS conversion tools are available, uploads the payload as `audio/x-caf` with `isAudioMessage=true`, and requests the BlueBubbles Private API path when its helper is connected.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/platforms/base.py`
  - Requests a 24 kHz mono WAV source for BlueBubbles auto-TTS so the adapter can take the reliable native-voice packaging path.
- `gateway/platforms/bluebubbles.py`
  - Preserves CAF extensions on inbound audio caching.
  - Normalizes non-CAF sources through ffmpeg before final Opus CAF conversion with `afconvert`.
  - Skips redundant ffmpeg normalization for an already suitable mono 24 kHz WAV.
  - Uploads native payloads as `Audio Message.caf` / `audio/x-caf` with `isAudioMessage=true`.
  - Uses `method=private-api` when the BlueBubbles helper is connected.
  - Runs preparation and file reads off the event loop.
  - Contains preparation failures, propagates cancellation, and cleans temporary artifacts across success, failure, and cancelled-thread completion paths.
  - Falls back to an ordinary correctly typed audio attachment if native conversion is unavailable.
- Tests cover output-format routing, CAF preservation, native metadata with and without the helper, source normalization, fallback behavior, off-loop preparation/read behavior, cancellation cleanup, and preparation-failure containment.

## How to Test

```bash
python -m pytest \
  tests/gateway/test_bluebubbles.py \
  tests/gateway/test_base_auto_tts_output_format.py \
  tests/gateway/test_tts_media_routing.py \
  -q -o 'addopts='

ruff check \
  gateway/platforms/base.py \
  gateway/platforms/bluebubbles.py \
  tests/gateway/test_base_auto_tts_output_format.py \
  tests/gateway/test_bluebubbles.py
```

Current-main validation:

```text
47 passed
All checks passed
```

A real macOS conversion smoke also produced a non-empty CAF whose Apple `afinfo` metadata reported mono, 24 kHz, Opus, with nonzero duration.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [ ] I've run the complete repository test suite
- [x] I've added tests for the changed behavior
- [x] I've tested on macOS

### Documentation & Housekeeping

- [x] Documentation/config changes are N/A
- [x] No new config keys or tool schemas are introduced
- [x] Cross-platform behavior degrades to an ordinary audio attachment when macOS conversion tools are unavailable

## Screenshots / Logs

N/A

## AI assistance disclosure

This refresh was prepared with AI assistance under human direction and independently reviewed and tested before publication.
