### PR TITLE
fix(codex transport): default reasoning_enabled=False for non-reasoning models

### DIFF
--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -80,8 +80,14 @@ class ResponsesApiTransport(ProviderTransport):
         is_xai_responses = params.get("is_xai_responses", False)
 
         # Resolve reasoning effort
+        # Default reasoning_enabled=False: non-reasoning models (gpt-4o-mini,
+        # gpt-4.1-mini, local MLX/Ollama, etc.) reject the Responses-API
+        # include[reasoning.encrypted_content] field with HTTP 400 "Encrypted
+        # content is not supported with this model." Reasoning-capable models
+        # (o1, o3, grok-thinking, etc.) still opt in via
+        # reasoning_config={"enabled": True} or {"effort": "medium"}.
         reasoning_effort = "medium"
-        reasoning_enabled = True
+        reasoning_enabled = False
         reasoning_config = params.get("reasoning_config")
         if reasoning_config and isinstance(reasoning_config, dict):
             if reasoning_config.get("enabled") is False:


### PR DESCRIPTION
## Summary

The Codex Responses transport (`agent/transports/codex.py`) defaults `reasoning_enabled = True`, which causes Hermes to add `include[\"reasoning.encrypted_content\"]` to every request through that path. Non-reasoning models reject this field with HTTP 400:

\`\`\`
Error code: 400 - {'error': {'message': 'Encrypted content is not supported with this model.', 'type': 'invalid_request_error', 'param': 'include', 'code': None}}
\`\`\`

## Who's affected

Anyone whose fallback chain (or primary chain) includes a non-reasoning OpenAI model. Common cases:

- `gpt-4o-mini` (small, cheap, frequently used as a fallback)
- `gpt-4.1-mini` (same)
- Local MLX or Ollama models routed through the OpenAI-compatible adapter
- Any custom-provider OpenAI-compat endpoint that doesn't speak the Responses API's reasoning protocol

I hit this on a personal-laptop deployment running MLX as primary with `gpt-4o-mini` as the fallback. When MLX OOM'd under memory pressure, Hermes correctly fell back to OpenAI but every request was rejected before reaching the model because the tool list contained the include field.

## The fix

One-line default flip in `build_kwargs()`:

\`\`\`diff
 # Resolve reasoning effort
 reasoning_effort = \"medium\"
-reasoning_enabled = True
+reasoning_enabled = False
 reasoning_config = params.get(\"reasoning_config\")
\`\`\`

Plus a comment block above explaining the rationale.

## Backward compatibility

The existing opt-in path is preserved. Reasoning-capable models (o1, o3, grok-thinking, the Codex backend itself, xAI Grok) still get reasoning when callers pass:

\`\`\`python
reasoning_config = {\"enabled\": True}
# or
reasoning_config = {\"effort\": \"medium\"}
\`\`\`

The if-branch at lines 86-90 that handles `reasoning_config` is unchanged. Only the default for callers that pass no config flips.

## Repro

\`\`\`bash
hermes chat -q 'hello' --model gpt-4o-mini
# Before: HTTP 400 'Encrypted content is not supported with this model'
# After:  responds normally
\`\`\`

## Risk

Low. The downstream branches at lines 116+ that gate on \`if reasoning_enabled\` already correctly skip when the flag is False, so the only behavioral change is: callers that previously got reasoning-by-default without setting any config now get no reasoning by default. Any code path that genuinely wants reasoning was already passing \`reasoning_config\` (the documented opt-in surface).

Tested in production for ~10 days on a multi-model deployment (MLX primary, OpenAI fallback) — no regressions observed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)