### PR TITLE
fix(background_review): inherit parent's reasoning_config to keep `thinking`/`output_config` cache-stable (~38% fewer cache-write tokens on long sessions)

### DIFF
--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -696,6 +696,10 @@ def _run_review_in_thread(
             if isinstance(_rt.get("command"), str) and _rt["command"]:
                 _fork_kwargs["acp_command"] = _rt["command"]
                 _fork_kwargs["acp_args"] = _rt.get("args") or []
+            # Match parent's reasoning config so the fork's ``thinking`` /
+            # ``output_config`` are byte-identical in the request body —
+            # Anthropic's cache key is namespaced by ``thinking`` presence.
+            _fork_kwargs["reasoning_config"] = getattr(agent, "reasoning_config", None)
             review_agent = AIAgent(
                 model=_rt.get("model") or agent.model,
                 max_iterations=16,

--- a/tests/run_agent/test_background_review_cache_parity.py
+++ b/tests/run_agent/test_background_review_cache_parity.py
@@ -41,6 +41,9 @@ def _make_agent_stub(agent_cls):
     # Non-None so the test catches a missing-kwarg regression.
     agent.enabled_toolsets = ["memory", "skills", "terminal"]
     agent.disabled_toolsets = ["spotify", "feishu_doc"]
+    # Non-None so the test catches reasoning_config NOT being inherited —
+    # which would put the fork into a different Anthropic cache namespace.
+    agent.reasoning_config = {"enabled": True, "effort": "medium"}
     return agent
 
 
@@ -236,4 +239,50 @@ def test_review_fork_inherits_parent_toolset_config():
     assert captured.get("disabled_toolsets") == agent.disabled_toolsets, (
         f"disabled_toolsets mismatch: {captured.get('disabled_toolsets')!r} "
         f"vs expected {agent.disabled_toolsets!r}"
+    )
+
+
+def test_review_fork_inherits_parent_reasoning_config():
+    """``reasoning_config`` parity: fork must inherit parent's value so the request body's ``thinking`` / ``output_config`` match (Anthropic cache is namespaced by ``thinking`` presence)."""
+    import run_agent
+
+    agent = _make_agent_stub(run_agent.AIAgent)
+
+    captured = {}
+
+    class _Recorder:
+        def __init__(self, *args, **kwargs):
+            captured["reasoning_config"] = kwargs.get("reasoning_config")
+            self._cached_system_prompt = None
+            self._memory_write_origin = None
+            self._memory_write_context = None
+            self._memory_store = None
+            self._memory_enabled = None
+            self._user_profile_enabled = None
+            self._memory_nudge_interval = None
+            self._skill_nudge_interval = None
+            self.suppress_status_output = None
+            self.session_start = None
+            self.session_id = None
+
+        def run_conversation(self, *args, **kwargs):
+            raise RuntimeError("stop after recording — don't actually call the API")
+
+        def shutdown_memory_provider(self):
+            pass
+
+        def close(self):
+            pass
+
+    with patch.object(run_agent, "AIAgent", _Recorder), \
+         patch("threading.Thread", _SyncThread):
+        agent._spawn_background_review(
+            messages_snapshot=[],
+            review_memory=True,
+            review_skills=False,
+        )
+
+    assert captured.get("reasoning_config") == agent.reasoning_config, (
+        f"reasoning_config mismatch: {captured.get('reasoning_config')!r} "
+        f"vs expected {agent.reasoning_config!r}"
     )


### PR DESCRIPTION
# fix(background_review): inherit parent's reasoning_config to keep `thinking`/`output_config` cache-stable

## Summary

Fixes #30531. The background skill/memory-review fork (`agent/background_review.py`) constructs its child `AIAgent` without propagating `reasoning_config` from the parent. The fork's default `reasoning_config=None` causes `build_anthropic_kwargs` (`agent/anthropic_adapter.py`) to omit the top-level `thinking` and `output_config` fields from the fork's request body. Anthropic's prompt cache is namespaced by `thinking` presence, so the fork lands in a different cache namespace from the parent and the entire shared prefix is re-written on every review-fork "birth" call.

Same class of bug as #25322 / PR #17276 (`system`-bytes invariant) and #29567 / PR #29704 (`tools[]` invariant) — this is the remaining cache-key slot.

## Goal

Eliminate cache-write overhead on the background review path. On a captured ~2-day Sonnet-class session, fork-birth requests account for ~38% of the session's total `cache_creation_input_tokens` even though they share `messages[0..N]`, `system`, and `tools[]` with the parent byte-for-byte — the divergence in `thinking`/`output_config` alone is enough to push every fork-birth req into a cache miss. After the fix, fork-birth requests read from the parent's warmed cache instead of rewriting.

Direct API verification (independent of Hermes) that `thinking` is part of the cache key:

```
T1: same prompt, thinking=enabled, fresh     cache_read=     0   cache_write= 24026
T2: same prompt, thinking=enabled, repeat    cache_read= 24026   cache_write=     0
T3: same prompt, thinking removed            cache_read=     0   cache_write= 24004
T4: same prompt, thinking removed, repeat    cache_read= 24004   cache_write=     0
T5: same prompt, thinking=enabled again      cache_read= 24026   cache_write=     0
```

The safety contract from #15204 (the review fork must not dispatch terminal / send_message / delegate_task) is preserved: it is enforced by the post-construction `set_thread_tool_whitelist({memory, skills, …})` call a few lines below, which gates *dispatch*, not what the request body *transmits*.

## Implementation

`agent/background_review.py` — one added kwarg in the `AIAgent(...)` call inside `_spawn_background_review`:

```python
reasoning_config=getattr(agent, "reasoning_config", None),
```

Plus a three-line comment that calls out the cache-key dependency, matching the style of the existing toolset-parity comment one block above (added in PR #29704).

Symmetric inheritance: when the parent's value is `None`, the fork's is also `None` and both omit `thinking` identically; when the parent has reasoning configured, the fork inherits it verbatim.

## Reproduction

Captured by routing the Anthropic API through a local HTTP-capture proxy (https://github.com/ziliangpeng/midagent — small FastAPI logger that records `request_body` + `response_body` per request) and inspecting outbound `/v1/messages` traffic during a long real-world session.

Fork-shape requests are identifiable as: (a) `messages[-1]` carries one of `_SKILL_REVIEW_PROMPT` / `_MEMORY_REVIEW_PROMPT` / `_COMBINED_REVIEW_PROMPT` as the last user message; (b) the top-level `thinking` and `output_config` keys are absent (when the parent has reasoning enabled). The first such request after a `_spawn_background_review` is the "birth" call this PR addresses.

## Cost-impact measurement

From the captured 2-day window (~2,040 `/v1/messages` requests total, Sonnet-class model, parent has reasoning enabled):

| Quantity | Main reqs | Review-fork reqs (all) | of which fork "birth" |
|---|---:|---:|---:|
| Request count | 1,389 | 650 | 72 |
| `cache_creation_input_tokens` total | 8.77 M | 11.96 M | **7.82 M** |
| `cache_read_input_tokens` total | 133.07 M | 96.38 M | 0 |

**Fork-birth requests alone account for ~37.7% of the session's total `cache_creation_input_tokens`** — these are exactly the requests this PR converts from `cache_write` to `cache_read`. The remaining fork cache-writes (4.14 M) come from the fork's own internal iteration loop and are not affected by this fix.

The percentage is model-pricing-independent. On Opus the same wire pattern costs substantially more per token than on Sonnet, but the structural inefficiency is identical.

## Testing

`tests/run_agent/test_background_review_cache_parity.py` — new positive assertion `test_review_fork_inherits_parent_reasoning_config` confirms `reasoning_config` reaches the constructor with the parent's value. The stub gains a non-`None` `reasoning_config` so a regression that drops the kwarg surfaces (rather than spuriously passing because both sides default to `None`) — same pattern PR #29704 used for the toolset stub.

Sanity check: the new positive test fails on `origin/main` and passes with this PR.

```bash
python -m pytest tests/run_agent/test_background_review.py \
                 tests/run_agent/test_background_review_summary.py \
                 tests/run_agent/test_background_review_toolset_restriction.py \
                 tests/run_agent/test_background_review_cache_parity.py -q
```

**Output:**

```
19 passed in 0.79s
```

## Scope

- `agent/background_review.py`: one added kwarg + 3-line comment.
- `tests/run_agent/test_background_review_cache_parity.py`: one new positive test, stub updated.
- No production code paths outside the review fork; no schema, public-API, or runtime-whitelist changes.
- No new dependencies.

Related: extends PR #17276 / #25434 (`system` slot) and PR #29568 / #29704 (`tools[]` slot) to the `thinking` / `output_config` slot — completes the cache-key parity invariant for the background review fork.
