### PR TITLE
feat: add warm cache for NeuTTS synthesis

### DIFF
--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1367,7 +1367,13 @@ DEFAULT_CONFIG = {
             "ref_audio": "",  # Path to reference voice audio (empty = bundled default)
             "ref_text": "",   # Path to reference voice transcript (empty = bundled default)
             "model": "neuphonic/neutts-air-q4-gguf",  # HuggingFace model repo
+            "codec_repo": "neuphonic/neucodec",
             "device": "cpu",  # cpu, cuda, or mps
+            "output_format": "mp3",  # mp3, m4a/aac, wav, ogg, or flac
+            # Opt in to retaining the roughly 500 MB model in this process for
+            # lower latency across repeated synthesis requests.
+            "warm_cache": False,
+            "idle_unload_seconds": 1800,  # Release a warm model after 30 minutes idle
         },
         "piper": {
             # Voice name (e.g. "en_US-lessac-medium") downloaded on first

--- a/tests/tools/test_tts_neutts_warm_cache.py
+++ b/tests/tools/test_tts_neutts_warm_cache.py
@@ -1,4 +1,5 @@
 import json
+import subprocess
 import sys
 import time
 import types
@@ -38,6 +39,59 @@ def _install_fake_neutts(monkeypatch):
 def _reset_neutts_cache():
     if hasattr(tts_tool, "_clear_neutts_cache"):
         tts_tool._clear_neutts_cache("test")
+
+
+def test_neutts_warm_cache_is_opt_in(tmp_path, monkeypatch):
+    used = {"warm": False, "subprocess": False}
+
+    def fake_warm(text, output_path, tts_config):
+        used["warm"] = True
+        return output_path
+
+    def fake_subprocess(text, output_path, tts_config):
+        used["subprocess"] = True
+        return output_path
+
+    monkeypatch.setattr(tts_tool, "_generate_neutts_warm", fake_warm)
+    monkeypatch.setattr(tts_tool, "_generate_neutts_subprocess", fake_subprocess)
+
+    tts_tool._generate_neutts("hello", str(tmp_path / "out.wav"), {"neutts": {}})
+
+    assert used == {"warm": False, "subprocess": True}
+
+
+def test_neutts_warm_cache_config_defaults_to_off():
+    from hermes_cli.config import DEFAULT_CONFIG
+
+    neutts_config = DEFAULT_CONFIG["tts"]["neutts"]
+    assert neutts_config["codec_repo"] == "neuphonic/neucodec"
+    assert neutts_config["output_format"] == "mp3"
+    assert neutts_config["warm_cache"] is False
+    assert neutts_config["idle_unload_seconds"] == 1800
+
+
+def test_neutts_conversion_uses_windows_safe_subprocess_kwargs(tmp_path, monkeypatch):
+    wav_path = tmp_path / "source.wav"
+    output_path = tmp_path / "output.mp3"
+    wav_path.write_bytes(b"wav")
+    captured = {}
+
+    monkeypatch.setattr(tts_tool.shutil, "which", lambda name: "/usr/bin/ffmpeg")
+    monkeypatch.setattr(tts_tool, "windows_hide_flags", lambda: 0x08000000)
+
+    def fake_run(cmd, **kwargs):
+        captured["cmd"] = cmd
+        captured["kwargs"] = kwargs
+        output_path.write_bytes(b"mp3")
+        return types.SimpleNamespace(returncode=0)
+
+    monkeypatch.setattr(tts_tool.subprocess, "run", fake_run)
+
+    result = tts_tool._convert_neutts_wav(str(wav_path), str(output_path))
+
+    assert result == str(output_path)
+    assert captured["kwargs"]["stdin"] is subprocess.DEVNULL
+    assert captured["kwargs"]["creationflags"] == 0x08000000
 
 
 def test_neutts_warm_cache_reuses_model_and_reference(tmp_path, monkeypatch):

--- a/tests/tools/test_tts_neutts_warm_cache.py
+++ b/tests/tools/test_tts_neutts_warm_cache.py
@@ -1,0 +1,167 @@
+import json
+import sys
+import time
+import types
+from pathlib import Path
+
+from tools import tts_tool
+
+
+def _write_ref_files(tmp_path: Path):
+    ref_audio = tmp_path / "ref.wav"
+    ref_text = tmp_path / "ref.txt"
+    ref_audio.write_bytes(b"RIFF\x00\x00\x00\x00WAVE")
+    ref_text.write_text("reference words", encoding="utf-8")
+    return ref_audio, ref_text
+
+
+def _install_fake_neutts(monkeypatch):
+    calls = {"construct": 0, "encode": 0, "infer": 0}
+
+    class FakeNeuTTS:
+        def __init__(self, **kwargs):
+            calls["construct"] += 1
+            self.kwargs = kwargs
+
+        def encode_reference(self, path):
+            calls["encode"] += 1
+            return {"path": path}
+
+        def infer(self, text, ref_codes, ref_text):
+            calls["infer"] += 1
+            return [0.0, 0.1, -0.1, 0.0]
+
+    monkeypatch.setitem(sys.modules, "neutts", types.SimpleNamespace(NeuTTS=FakeNeuTTS))
+    return calls
+
+
+def _reset_neutts_cache():
+    if hasattr(tts_tool, "_clear_neutts_cache"):
+        tts_tool._clear_neutts_cache("test")
+
+
+def test_neutts_warm_cache_reuses_model_and_reference(tmp_path, monkeypatch):
+    _reset_neutts_cache()
+    calls = _install_fake_neutts(monkeypatch)
+    ref_audio, ref_text = _write_ref_files(tmp_path)
+    cfg = {
+        "neutts": {
+            "warm_cache": True,
+            "idle_unload_seconds": 60,
+            "ref_audio": str(ref_audio),
+            "ref_text": str(ref_text),
+            "model": "fake/model",
+            "device": "cpu",
+        }
+    }
+
+    out1 = tts_tool._generate_neutts("hello", str(tmp_path / "one.wav"), cfg)
+    out2 = tts_tool._generate_neutts("again", str(tmp_path / "two.wav"), cfg)
+
+    assert Path(out1).exists()
+    assert Path(out2).exists()
+    assert calls == {"construct": 1, "encode": 1, "infer": 2}
+    _reset_neutts_cache()
+
+
+def test_neutts_warm_cache_key_changes_on_model(tmp_path, monkeypatch):
+    _reset_neutts_cache()
+    calls = _install_fake_neutts(monkeypatch)
+    ref_audio, ref_text = _write_ref_files(tmp_path)
+    base = {
+        "warm_cache": True,
+        "idle_unload_seconds": 60,
+        "ref_audio": str(ref_audio),
+        "ref_text": str(ref_text),
+        "device": "cpu",
+    }
+
+    tts_tool._generate_neutts("hello", str(tmp_path / "one.wav"), {"neutts": {**base, "model": "fake/a"}})
+    tts_tool._generate_neutts("hello", str(tmp_path / "two.wav"), {"neutts": {**base, "model": "fake/b"}})
+
+    assert calls["construct"] == 2
+    assert calls["encode"] == 2
+    assert calls["infer"] == 2
+    _reset_neutts_cache()
+
+
+def test_neutts_idle_unload_clears_cache(tmp_path, monkeypatch):
+    _reset_neutts_cache()
+    calls = _install_fake_neutts(monkeypatch)
+    ref_audio, ref_text = _write_ref_files(tmp_path)
+    cfg = {
+        "neutts": {
+            "warm_cache": True,
+            "idle_unload_seconds": 0.05,
+            "ref_audio": str(ref_audio),
+            "ref_text": str(ref_text),
+            "model": "fake/model",
+            "device": "cpu",
+        }
+    }
+
+    tts_tool._generate_neutts("hello", str(tmp_path / "one.wav"), cfg)
+    time.sleep(0.15)
+    assert not getattr(tts_tool, "_neutts_cache", {})
+
+    tts_tool._generate_neutts("again", str(tmp_path / "two.wav"), cfg)
+    assert calls["construct"] == 2
+    _reset_neutts_cache()
+
+
+def test_neutts_warm_cache_can_be_disabled(tmp_path, monkeypatch):
+    _reset_neutts_cache()
+    used = {"subprocess": False}
+
+    def fake_subprocess(text, output_path, tts_config):
+        used["subprocess"] = True
+        Path(output_path).write_bytes(b"not real audio")
+        return output_path
+
+    monkeypatch.setattr(tts_tool, "_generate_neutts_subprocess", fake_subprocess, raising=False)
+
+    out = tts_tool._generate_neutts(
+        "hello",
+        str(tmp_path / "out.mp3"),
+        {"neutts": {"warm_cache": False}},
+    )
+
+    assert used["subprocess"] is True
+    assert out.endswith(".mp3")
+
+
+def test_neutts_output_format_m4a_uses_aac_container(tmp_path, monkeypatch):
+    _reset_neutts_cache()
+    calls = _install_fake_neutts(monkeypatch)
+    ref_audio, ref_text = _write_ref_files(tmp_path)
+    converted = {"cmd": None}
+
+    monkeypatch.setattr(tts_tool, "_load_tts_config", lambda: {
+        "provider": "neutts",
+        "neutts": {
+            "warm_cache": True,
+            "ref_audio": str(ref_audio),
+            "ref_text": str(ref_text),
+            "model": "fake/model",
+            "device": "cpu",
+            "output_format": "m4a",
+        },
+    })
+    monkeypatch.setattr(tts_tool, "_check_neutts_available", lambda: True)
+    monkeypatch.setattr(tts_tool.shutil, "which", lambda name: "/usr/bin/ffmpeg" if name == "ffmpeg" else None)
+
+    def fake_run(cmd, check=False, timeout=None, **kwargs):
+        converted["cmd"] = cmd
+        Path(cmd[-1]).write_bytes(b"m4a")
+        return types.SimpleNamespace(returncode=0)
+
+    monkeypatch.setattr(tts_tool.subprocess, "run", fake_run)
+
+    result = json.loads(tts_tool.text_to_speech_tool("hello", output_path=None))
+
+    assert result["success"] is True
+    assert result["file_path"].endswith(".m4a")
+    assert result["provider"] == "neutts"
+    assert calls["infer"] == 1
+    assert "aac" in converted["cmd"] or "-c:a" in converted["cmd"]
+    _reset_neutts_cache()

--- a/tests/tools/test_tts_neutts_warm_cache.py
+++ b/tests/tools/test_tts_neutts_warm_cache.py
@@ -5,6 +5,8 @@ import time
 import types
 from pathlib import Path
 
+import pytest
+
 from tools import tts_tool
 
 
@@ -94,6 +96,32 @@ def test_neutts_conversion_uses_windows_safe_subprocess_kwargs(tmp_path, monkeyp
     assert captured["kwargs"]["creationflags"] == 0x08000000
 
 
+def test_neutts_subprocess_passes_custom_codec_repo(tmp_path, monkeypatch):
+    captured = {}
+
+    def fake_run(cmd, **kwargs):
+        captured["cmd"] = cmd
+        return types.SimpleNamespace(returncode=0, stderr="")
+
+    monkeypatch.setattr(tts_tool.subprocess, "run", fake_run)
+    monkeypatch.setattr(
+        tts_tool,
+        "_convert_neutts_wav",
+        lambda wav_path, output_path: output_path,
+    )
+
+    output_path = str(tmp_path / "output.wav")
+    result = tts_tool._generate_neutts_subprocess(
+        "hello",
+        output_path,
+        {"neutts": {"codec_repo": "custom/codec"}},
+    )
+
+    assert result == output_path
+    codec_index = captured["cmd"].index("--codec-repo")
+    assert captured["cmd"][codec_index + 1] == "custom/codec"
+
+
 def test_neutts_warm_cache_reuses_model_and_reference(tmp_path, monkeypatch):
     _reset_neutts_cache()
     calls = _install_fake_neutts(monkeypatch)
@@ -163,9 +191,59 @@ def test_neutts_idle_unload_clears_cache(tmp_path, monkeypatch):
     _reset_neutts_cache()
 
 
+def test_failed_first_warm_synthesis_clears_cache(tmp_path, monkeypatch):
+    _reset_neutts_cache()
+    ref_audio, ref_text = _write_ref_files(tmp_path)
+
+    class FailingNeuTTS:
+        def __init__(self, **kwargs):
+            pass
+
+        def encode_reference(self, path):
+            return {"path": path}
+
+        def infer(self, text, ref_codes, ref_text_value):
+            raise RuntimeError("synthetic failure")
+
+    monkeypatch.setitem(
+        sys.modules,
+        "neutts",
+        types.SimpleNamespace(NeuTTS=FailingNeuTTS),
+    )
+    cfg = {
+        "neutts": {
+            "warm_cache": True,
+            "idle_unload_seconds": 60,
+            "ref_audio": str(ref_audio),
+            "ref_text": str(ref_text),
+        }
+    }
+
+    with pytest.raises(RuntimeError, match="synthetic failure"):
+        tts_tool._generate_neutts("hello", str(tmp_path / "out.wav"), cfg)
+
+    assert not tts_tool._neutts_cache
+    assert tts_tool._neutts_idle_timer is None
+
+
 def test_neutts_warm_cache_can_be_disabled(tmp_path, monkeypatch):
     _reset_neutts_cache()
     used = {"subprocess": False}
+    _install_fake_neutts(monkeypatch)
+    ref_audio, ref_text = _write_ref_files(tmp_path)
+    tts_tool._generate_neutts(
+        "warm",
+        str(tmp_path / "warm.wav"),
+        {
+            "neutts": {
+                "warm_cache": True,
+                "idle_unload_seconds": 60,
+                "ref_audio": str(ref_audio),
+                "ref_text": str(ref_text),
+            }
+        },
+    )
+    assert tts_tool._neutts_cache
 
     def fake_subprocess(text, output_path, tts_config):
         used["subprocess"] = True
@@ -182,6 +260,8 @@ def test_neutts_warm_cache_can_be_disabled(tmp_path, monkeypatch):
 
     assert used["subprocess"] is True
     assert out.endswith(".mp3")
+    assert not tts_tool._neutts_cache
+    assert tts_tool._neutts_idle_timer is None
 
 
 def test_neutts_output_format_m4a_uses_aac_container(tmp_path, monkeypatch):

--- a/tests/tools/test_tts_neutts_warm_cache.py
+++ b/tests/tools/test_tts_neutts_warm_cache.py
@@ -81,6 +81,30 @@ def test_neutts_null_config_uses_subprocess_default(tmp_path, monkeypatch):
     assert used == {"warm": False, "subprocess": True}
 
 
+def test_neutts_null_config_public_path_uses_default_output_format(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setattr(
+        tts_tool,
+        "_load_tts_config",
+        lambda: {"provider": "neutts", "neutts": None},
+    )
+    monkeypatch.setattr(tts_tool, "DEFAULT_OUTPUT_DIR", str(tmp_path))
+    monkeypatch.setattr(tts_tool, "_check_neutts_available", lambda: True)
+
+    def fake_generate(text, output_path, tts_config):
+        Path(output_path).write_bytes(b"not real audio")
+        return output_path
+
+    monkeypatch.setattr(tts_tool, "_generate_neutts", fake_generate)
+
+    result = json.loads(tts_tool.text_to_speech_tool("hello", output_path=None))
+
+    assert result["success"] is True
+    assert result["provider"] == "neutts"
+    assert result["file_path"].endswith(".mp3")
+
+
 def test_neutts_warm_cache_config_defaults_to_off():
     from hermes_cli.config import DEFAULT_CONFIG
 

--- a/tests/tools/test_tts_neutts_warm_cache.py
+++ b/tests/tools/test_tts_neutts_warm_cache.py
@@ -62,6 +62,25 @@ def test_neutts_warm_cache_is_opt_in(tmp_path, monkeypatch):
     assert used == {"warm": False, "subprocess": True}
 
 
+def test_neutts_null_config_uses_subprocess_default(tmp_path, monkeypatch):
+    used = {"warm": False, "subprocess": False}
+
+    def fake_warm(text, output_path, tts_config):
+        used["warm"] = True
+        return output_path
+
+    def fake_subprocess(text, output_path, tts_config):
+        used["subprocess"] = True
+        return output_path
+
+    monkeypatch.setattr(tts_tool, "_generate_neutts_warm", fake_warm)
+    monkeypatch.setattr(tts_tool, "_generate_neutts_subprocess", fake_subprocess)
+
+    tts_tool._generate_neutts("hello", str(tmp_path / "out.wav"), {"neutts": None})
+
+    assert used == {"warm": False, "subprocess": True}
+
+
 def test_neutts_warm_cache_config_defaults_to_off():
     from hermes_cli.config import DEFAULT_CONFIG
 

--- a/tests/tools/test_tts_neutts_warm_cache.py
+++ b/tests/tools/test_tts_neutts_warm_cache.py
@@ -189,6 +189,39 @@ def test_neutts_warm_cache_reuses_model_and_reference(tmp_path, monkeypatch):
     _reset_neutts_cache()
 
 
+def test_neutts_warm_cache_translates_cuda_for_backbone(tmp_path, monkeypatch):
+    _reset_neutts_cache()
+    captured = {}
+    ref_audio, ref_text = _write_ref_files(tmp_path)
+
+    class FakeNeuTTS:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+        def encode_reference(self, path):
+            return {"path": path}
+
+        def infer(self, text, ref_codes, ref_text_value):
+            return [0.0, 0.1, -0.1, 0.0]
+
+    monkeypatch.setitem(sys.modules, "neutts", types.SimpleNamespace(NeuTTS=FakeNeuTTS))
+    cfg = {
+        "neutts": {
+            "warm_cache": True,
+            "idle_unload_seconds": 60,
+            "ref_audio": str(ref_audio),
+            "ref_text": str(ref_text),
+            "device": "cuda",
+        }
+    }
+
+    tts_tool._generate_neutts("hello", str(tmp_path / "out.wav"), cfg)
+
+    assert captured["backbone_device"] == "gpu"
+    assert captured["codec_device"] == "cuda"
+    _reset_neutts_cache()
+
+
 def test_neutts_warm_cache_key_changes_on_model(tmp_path, monkeypatch):
     _reset_neutts_cache()
     calls = _install_fake_neutts(monkeypatch)

--- a/tests/tools/test_tts_neutts_warm_cache.py
+++ b/tests/tools/test_tts_neutts_warm_cache.py
@@ -144,9 +144,11 @@ def test_neutts_subprocess_passes_custom_codec_repo(tmp_path, monkeypatch):
 
     def fake_run(cmd, **kwargs):
         captured["cmd"] = cmd
+        captured["kwargs"] = kwargs
         return types.SimpleNamespace(returncode=0, stderr="")
 
     monkeypatch.setattr(tts_tool.subprocess, "run", fake_run)
+    monkeypatch.setattr(tts_tool, "windows_hide_flags", lambda: 0x08000000)
     monkeypatch.setattr(
         tts_tool,
         "_convert_neutts_wav",
@@ -163,6 +165,8 @@ def test_neutts_subprocess_passes_custom_codec_repo(tmp_path, monkeypatch):
     assert result == output_path
     codec_index = captured["cmd"].index("--codec-repo")
     assert captured["cmd"][codec_index + 1] == "custom/codec"
+    assert captured["kwargs"]["stdin"] is subprocess.DEVNULL
+    assert captured["kwargs"]["creationflags"] == 0x08000000
 
 
 def test_neutts_warm_cache_reuses_model_and_reference(tmp_path, monkeypatch):
@@ -222,6 +226,32 @@ def test_neutts_warm_cache_translates_cuda_for_backbone(tmp_path, monkeypatch):
     _reset_neutts_cache()
 
 
+def test_neutts_warm_cache_clears_after_conversion_failure(tmp_path, monkeypatch):
+    _reset_neutts_cache()
+    _install_fake_neutts(monkeypatch)
+    ref_audio, ref_text = _write_ref_files(tmp_path)
+    cfg = {
+        "neutts": {
+            "warm_cache": True,
+            "idle_unload_seconds": 60,
+            "ref_audio": str(ref_audio),
+            "ref_text": str(ref_text),
+        }
+    }
+
+    def fail_conversion(wav_path, output_path):
+        raise RuntimeError("synthetic conversion failure")
+
+    monkeypatch.setattr(tts_tool, "_convert_neutts_wav", fail_conversion)
+
+    with pytest.raises(RuntimeError, match="synthetic conversion failure"):
+        tts_tool._generate_neutts("hello", str(tmp_path / "out.mp3"), cfg)
+
+    assert not tts_tool._neutts_cache
+    assert tts_tool._neutts_idle_timer is None
+    assert not (tmp_path / "out.wav").exists()
+
+
 def test_neutts_warm_cache_key_changes_on_model(tmp_path, monkeypatch):
     _reset_neutts_cache()
     calls = _install_fake_neutts(monkeypatch)
@@ -241,6 +271,51 @@ def test_neutts_warm_cache_key_changes_on_model(tmp_path, monkeypatch):
     assert calls["encode"] == 2
     assert calls["infer"] == 2
     _reset_neutts_cache()
+
+
+def test_failed_cache_key_transition_releases_stale_model(tmp_path, monkeypatch):
+    _reset_neutts_cache()
+    _install_fake_neutts(monkeypatch)
+    ref_audio, ref_text = _write_ref_files(tmp_path)
+    base = {
+        "warm_cache": True,
+        "idle_unload_seconds": 60,
+        "ref_audio": str(ref_audio),
+        "ref_text": str(ref_text),
+        "device": "cpu",
+    }
+
+    tts_tool._generate_neutts(
+        "hello",
+        str(tmp_path / "first.wav"),
+        {"neutts": {**base, "model": "fake/first"}},
+    )
+    assert tts_tool._neutts_cache
+    assert tts_tool._neutts_idle_timer is not None
+
+    class FailingReplacementNeuTTS:
+        def __init__(self, **kwargs):
+            pass
+
+        def encode_reference(self, path):
+            raise RuntimeError("synthetic replacement failure")
+
+    monkeypatch.setitem(
+        sys.modules,
+        "neutts",
+        types.SimpleNamespace(NeuTTS=FailingReplacementNeuTTS),
+    )
+
+    with pytest.raises(RuntimeError, match="synthetic replacement failure"):
+        tts_tool._generate_neutts(
+            "again",
+            str(tmp_path / "second.wav"),
+            {"neutts": {**base, "model": "fake/replacement"}},
+        )
+
+    assert not tts_tool._neutts_cache
+    assert tts_tool._neutts_idle_timer is None
+    assert not (tmp_path / "second.wav").exists()
 
 
 def test_neutts_idle_unload_clears_cache(tmp_path, monkeypatch):

--- a/tools/neutts_synth.py
+++ b/tools/neutts_synth.py
@@ -48,6 +48,13 @@ def _write_wav(path: str, samples, sample_rate: int = 24000) -> None:
         f.write(pcm.tobytes())
 
 
+def resolve_neutts_devices(device: str) -> tuple[str, str]:
+    """Return the llama.cpp backbone and torch codec device names."""
+    # llama_cpp offloads only for the literal string "gpu", while torch uses
+    # "cuda". Keep this translation shared by subprocess and warm-cache paths.
+    return ("gpu" if device == "cuda" else device, device)
+
+
 def main():
     parser = argparse.ArgumentParser(description="NeuTTS synthesis helper")
     parser.add_argument("--text", required=True, help="Text to synthesize")
@@ -61,11 +68,7 @@ def main():
     parser.add_argument("--device", default="cpu", help="Device (cpu/cuda/mps)")
     args = parser.parse_args()
 
-    # llama_cpp (backbone) offloads to GPU only for the literal string "gpu";
-    # torch (codec) only accepts "cuda". A single --device value can't satisfy
-    # both — "cuda" silently no-ops on the backbone, leaving it on CPU.
-    backbone_device = "gpu" if args.device == "cuda" else args.device
-    codec_device = args.device
+    backbone_device, codec_device = resolve_neutts_devices(args.device)
 
     # Validate inputs
     ref_audio = Path(args.ref_audio).expanduser()

--- a/tools/neutts_synth.py
+++ b/tools/neutts_synth.py
@@ -56,6 +56,8 @@ def main():
     parser.add_argument("--ref-text", required=True, help="Reference voice transcript path")
     parser.add_argument("--model", default="neuphonic/neutts-air-q4-gguf",
                         help="HuggingFace backbone model repo")
+    parser.add_argument("--codec-repo", default="neuphonic/neucodec",
+                        help="HuggingFace codec model repo")
     parser.add_argument("--device", default="cpu", help="Device (cpu/cuda/mps)")
     args = parser.parse_args()
 
@@ -87,7 +89,7 @@ def main():
     tts = NeuTTS(
         backbone_repo=args.model,
         backbone_device=backbone_device,
-        codec_repo="neuphonic/neucodec",
+        codec_repo=args.codec_repo,
         codec_device=codec_device,
     )
     ref_codes = tts.encode_reference(str(ref_audio))

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -2675,9 +2675,13 @@ def _generate_neutts_warm(text: str, output_path: str, tts_config: Dict[str, Any
         else:
             entry["last_used_at"] = time.monotonic()
 
-        wav = entry["tts"].infer(text, entry["ref_codes"], entry["ref_text"])
-        entry["last_used_at"] = time.monotonic()
-        _write_neutts_wav(wav_path, wav, 24000)
+        try:
+            wav = entry["tts"].infer(text, entry["ref_codes"], entry["ref_text"])
+            entry["last_used_at"] = time.monotonic()
+            _write_neutts_wav(wav_path, wav, 24000)
+        except Exception:
+            _clear_neutts_cache("synthesis_error")
+            raise
         _schedule_neutts_idle_unload(_neutts_idle_unload_seconds(neutts_config))
 
     return _convert_neutts_wav(wav_path, output_path)
@@ -2701,6 +2705,7 @@ def _generate_neutts_subprocess(text: str, output_path: str, tts_config: Dict[st
         "--ref-audio", resolved["ref_audio"],
         "--ref-text", resolved["ref_text"],
         "--model", resolved["model"],
+        "--codec-repo", resolved["codec_repo"],
         "--device", resolved["device"],
     ]
 
@@ -2718,6 +2723,10 @@ def _generate_neutts(text: str, output_path: str, tts_config: Dict[str, Any]) ->
     neutts_config = tts_config.get("neutts", {}) if isinstance(tts_config, dict) else {}
     if _neutts_warm_cache_enabled(neutts_config):
         return _generate_neutts_warm(text, output_path, tts_config)
+    with _neutts_cache_lock:
+        cache_is_active = bool(_neutts_cache) or _neutts_idle_timer is not None
+    if cache_is_active:
+        _clear_neutts_cache("warm_cache_disabled")
     return _generate_neutts_subprocess(text, output_path, tts_config)
 
 

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -3140,7 +3140,7 @@ def text_to_speech_tool(
             fmt = _get_command_tts_output_format(command_provider_config)
             file_path = out_dir / f"tts_{timestamp}.{fmt}"
         elif provider == "neutts":
-            fmt = _neutts_output_format(tts_config.get("neutts", {}))
+            fmt = _neutts_output_format(tts_config.get("neutts") or {})
             file_path = out_dir / f"tts_{timestamp}.{fmt}"
         # Use .ogg for Telegram with providers that support native Opus output,
         # otherwise fall back to .mp3 (Edge TTS will attempt ffmpeg conversion later).

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -37,6 +37,7 @@ Usage:
 import asyncio
 import base64
 import datetime
+import gc
 import json
 import logging
 import os
@@ -45,6 +46,7 @@ import platform
 import re
 import shlex
 import shutil
+import struct
 import subprocess
 import tempfile
 import threading
@@ -2418,8 +2420,17 @@ def _generate_gemini_tts(text: str, output_path: str, tts_config: Dict[str, Any]
 
 
 # ===========================================================================
-# NeuTTS (local, on-device TTS via neutts_cli)
+# NeuTTS (local, on-device TTS via neutts)
 # ===========================================================================
+
+DEFAULT_NEUTTS_MODEL = "neuphonic/neutts-air-q4-gguf"
+DEFAULT_NEUTTS_CODEC_REPO = "neuphonic/neucodec"
+DEFAULT_NEUTTS_IDLE_UNLOAD_SECONDS = 30 * 60
+NEUTTS_OUTPUT_FORMATS = frozenset({"mp3", "m4a", "aac", "wav", "ogg", "flac"})
+
+_neutts_cache_lock = threading.RLock()
+_neutts_cache: Dict[str, Any] = {}
+_neutts_idle_timer: Optional[threading.Timer] = None
 
 def _check_neutts_available() -> bool:
     """Check if the neutts engine is importable (installed locally)."""
@@ -2449,57 +2460,259 @@ def _default_neutts_ref_text() -> str:
     return str(Path(__file__).parent / "neutts_samples" / "jo.txt")
 
 
-def _generate_neutts(text: str, output_path: str, tts_config: Dict[str, Any]) -> str:
-    """Generate speech using the local NeuTTS engine.
+def _bool_config(value: Any, default: bool = False) -> bool:
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        return default
+    if isinstance(value, (int, float)):
+        return bool(value)
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"1", "true", "yes", "on"}:
+            return True
+        if normalized in {"0", "false", "no", "off"}:
+            return False
+    return default
 
-    Runs synthesis in a subprocess via tools/neutts_synth.py to keep the
-    ~500MB model in a separate process that exits after synthesis.
-    Outputs WAV; the caller handles conversion for Telegram if needed.
-    """
+
+def _neutts_warm_cache_enabled(neutts_config: Dict[str, Any]) -> bool:
+    return _bool_config(neutts_config.get("warm_cache"), default=True)
+
+
+def _neutts_idle_unload_seconds(neutts_config: Dict[str, Any]) -> float:
+    raw = neutts_config.get("idle_unload_seconds", DEFAULT_NEUTTS_IDLE_UNLOAD_SECONDS)
+    try:
+        value = float(raw)
+    except (TypeError, ValueError):
+        return float(DEFAULT_NEUTTS_IDLE_UNLOAD_SECONDS)
+    return value if value > 0 else float(DEFAULT_NEUTTS_IDLE_UNLOAD_SECONDS)
+
+
+def _neutts_output_format(neutts_config: Dict[str, Any], default: str = "mp3") -> str:
+    raw = neutts_config.get("output_format") or neutts_config.get("format") or default
+    fmt = str(raw).lower().strip().lstrip(".")
+    if fmt == "aac":
+        # Raw .aac is less useful for iMessage/file previews; M4A is the common
+        # MPEG-4 container for AAC audio.
+        return "m4a"
+    if fmt in NEUTTS_OUTPUT_FORMATS:
+        return fmt
+    return default
+
+
+def _neutts_resolved_config(tts_config: Dict[str, Any]) -> Dict[str, str]:
+    neutts_config = tts_config.get("neutts", {}) if isinstance(tts_config, dict) else {}
+    return {
+        "ref_audio": str(Path(neutts_config.get("ref_audio", "") or _default_neutts_ref_audio()).expanduser()),
+        "ref_text": str(Path(neutts_config.get("ref_text", "") or _default_neutts_ref_text()).expanduser()),
+        "model": str(neutts_config.get("model", DEFAULT_NEUTTS_MODEL)),
+        "device": str(neutts_config.get("device", "cpu")),
+        "codec_repo": str(neutts_config.get("codec_repo", DEFAULT_NEUTTS_CODEC_REPO)),
+    }
+
+
+def _neutts_cache_key(resolved: Dict[str, str]) -> str:
+    ref_audio = Path(resolved["ref_audio"])
+    ref_text = Path(resolved["ref_text"])
+
+    def stamp(path: Path) -> tuple[str, int, int]:
+        try:
+            stat = path.stat()
+            return (str(path.resolve()), int(stat.st_mtime_ns), int(stat.st_size))
+        except OSError:
+            return (str(path), 0, 0)
+
+    return json.dumps({
+        "model": resolved["model"],
+        "device": resolved["device"],
+        "codec_repo": resolved["codec_repo"],
+        "ref_audio": stamp(ref_audio),
+        "ref_text": stamp(ref_text),
+    }, sort_keys=True)
+
+
+def _write_neutts_wav(path: str, samples, sample_rate: int = 24000) -> None:
+    """Write mono 16-bit WAV samples without requiring soundfile."""
+    try:
+        import soundfile as sf
+        sf.write(path, samples, sample_rate)
+        return
+    except ImportError:
+        pass
+
+    try:
+        import numpy as np
+    except ImportError:
+        # The real NeuTTS runtime depends on NumPy, but keeping this writer
+        # stdlib-capable makes the provider's fallback/test path independent of
+        # an optional audio-writing stack.
+        values = samples.tolist() if hasattr(samples, "tolist") else samples
+        pcm_bytes = b"".join(
+            struct.pack("<h", max(-32768, min(32767, round(float(sample) * 32767))))
+            for sample in values
+        )
+    else:
+        if not isinstance(samples, np.ndarray):
+            samples = np.array(samples, dtype=np.float32)
+        samples = samples.flatten()
+        samples = np.clip(samples, -1.0, 1.0)
+        pcm_bytes = (samples * 32767).astype(np.int16).tobytes()
+
+    num_channels = 1
+    bits_per_sample = 16
+    byte_rate = sample_rate * num_channels * (bits_per_sample // 8)
+    block_align = num_channels * (bits_per_sample // 8)
+    data_size = len(pcm_bytes)
+    with open(path, "wb") as f:
+        f.write(b"RIFF")
+        f.write(struct.pack("<I", 36 + data_size))
+        f.write(b"WAVE")
+        f.write(b"fmt ")
+        f.write(struct.pack("<IHHIIHH", 16, 1, num_channels, sample_rate, byte_rate, block_align, bits_per_sample))
+        f.write(b"data")
+        f.write(struct.pack("<I", data_size))
+        f.write(pcm_bytes)
+
+
+def _convert_neutts_wav(wav_path: str, output_path: str) -> str:
+    if wav_path == output_path:
+        return output_path
+    ffmpeg = shutil.which("ffmpeg")
+    if not ffmpeg:
+        os.replace(wav_path, output_path)
+        return output_path
+
+    suffix = Path(output_path).suffix.lower()
+    cmd = [ffmpeg, "-i", wav_path, "-y", "-loglevel", "error"]
+    if suffix == ".m4a":
+        cmd += ["-c:a", "aac", "-b:a", "128k"]
+    cmd.append(output_path)
+    subprocess.run(cmd, check=True, timeout=30)
+    try:
+        os.remove(wav_path)
+    except FileNotFoundError:
+        pass
+    return output_path
+
+
+def _schedule_neutts_idle_unload(idle_seconds: float) -> None:
+    global _neutts_idle_timer
+    if _neutts_idle_timer:
+        _neutts_idle_timer.cancel()
+
+    def _callback() -> None:
+        with _neutts_cache_lock:
+            if not _neutts_cache:
+                return
+            last_used = max(float(entry.get("last_used_at", 0.0)) for entry in _neutts_cache.values())
+            if time.monotonic() - last_used < idle_seconds:
+                _schedule_neutts_idle_unload(idle_seconds)
+                return
+            _clear_neutts_cache("idle")
+
+    _neutts_idle_timer = threading.Timer(idle_seconds, _callback)
+    _neutts_idle_timer.daemon = True
+    _neutts_idle_timer.start()
+
+
+def _clear_neutts_cache(reason: str = "manual") -> None:
+    global _neutts_idle_timer
+    with _neutts_cache_lock:
+        if _neutts_idle_timer:
+            _neutts_idle_timer.cancel()
+            _neutts_idle_timer = None
+        if _neutts_cache:
+            logger.info("[NeuTTS] clearing warm cache (%s)", reason)
+        _neutts_cache.clear()
+    gc.collect()
+
+
+def _generate_neutts_warm(text: str, output_path: str, tts_config: Dict[str, Any]) -> str:
+    """Generate speech with a cached in-process NeuTTS model/reference."""
+    neutts_config = tts_config.get("neutts", {}) if isinstance(tts_config, dict) else {}
+    resolved = _neutts_resolved_config(tts_config)
+    ref_audio = Path(resolved["ref_audio"])
+    ref_text_path = Path(resolved["ref_text"])
+    if not ref_audio.exists():
+        raise RuntimeError(f"NeuTTS reference audio not found: {ref_audio}")
+    if not ref_text_path.exists():
+        raise RuntimeError(f"NeuTTS reference text not found: {ref_text_path}")
+
+    key = _neutts_cache_key(resolved)
+    wav_path = output_path if output_path.endswith(".wav") else str(Path(output_path).with_suffix(".wav"))
+    Path(wav_path).parent.mkdir(parents=True, exist_ok=True)
+
+    with _neutts_cache_lock:
+        entry = _neutts_cache.get(key)
+        if entry is None:
+            from neutts import NeuTTS
+            tts = NeuTTS(
+                backbone_repo=resolved["model"],
+                backbone_device=resolved["device"],
+                codec_repo=resolved["codec_repo"],
+                codec_device=resolved["device"],
+            )
+            ref_codes = tts.encode_reference(str(ref_audio))
+            ref_text = ref_text_path.read_text(encoding="utf-8").strip()
+            entry = {
+                "tts": tts,
+                "ref_codes": ref_codes,
+                "ref_text": ref_text,
+                "loaded_at": time.monotonic(),
+                "last_used_at": time.monotonic(),
+                "resolved": resolved,
+            }
+            _neutts_cache.clear()
+            _neutts_cache[key] = entry
+            logger.info("[NeuTTS] warm cache loaded: model=%s device=%s", resolved["model"], resolved["device"])
+        else:
+            entry["last_used_at"] = time.monotonic()
+
+        wav = entry["tts"].infer(text, entry["ref_codes"], entry["ref_text"])
+        entry["last_used_at"] = time.monotonic()
+        _write_neutts_wav(wav_path, wav, 24000)
+        _schedule_neutts_idle_unload(_neutts_idle_unload_seconds(neutts_config))
+
+    return _convert_neutts_wav(wav_path, output_path)
+
+
+def _generate_neutts_subprocess(text: str, output_path: str, tts_config: Dict[str, Any]) -> str:
+    """Generate speech using the one-shot NeuTTS helper subprocess."""
     import sys
 
-    neutts_config = tts_config.get("neutts") or {}
-    ref_audio = neutts_config.get("ref_audio", "") or _default_neutts_ref_audio()
-    ref_text = neutts_config.get("ref_text", "") or _default_neutts_ref_text()
-    model = neutts_config.get("model", "neuphonic/neutts-air-q4-gguf")
-    device = neutts_config.get("device", "cpu")
-
-    # NeuTTS outputs WAV natively — use a .wav path for generation,
-    # let the caller convert to the final format afterward.
-    wav_path = output_path
-    if not output_path.endswith(".wav"):
-        wav_path = output_path.rsplit(".", 1)[0] + ".wav"
+    # Preserve the current upstream subprocess behavior while sharing the
+    # feature's normalized configuration and conversion path with warm mode.
+    resolved = _neutts_resolved_config(tts_config)
+    wav_path = output_path if output_path.endswith(".wav") else str(Path(output_path).with_suffix(".wav"))
+    Path(wav_path).parent.mkdir(parents=True, exist_ok=True)
 
     synth_script = str(Path(__file__).parent / "neutts_synth.py")
     cmd = [
         sys.executable, synth_script,
         "--text", text,
         "--out", wav_path,
-        "--ref-audio", ref_audio,
-        "--ref-text", ref_text,
-        "--model", model,
-        "--device", device,
+        "--ref-audio", resolved["ref_audio"],
+        "--ref-text", resolved["ref_text"],
+        "--model", resolved["model"],
+        "--device", resolved["device"],
     ]
 
     result = subprocess.run(cmd, capture_output=True, text=True, encoding='utf-8', errors='replace', timeout=120, stdin=subprocess.DEVNULL)
     if result.returncode != 0:
         stderr = result.stderr.strip()
-        # Filter out the "OK:" line from stderr
-        error_lines = [l for l in stderr.splitlines() if not l.startswith("OK:")]
+        error_lines = [line for line in stderr.splitlines() if not line.startswith("OK:")]
         raise RuntimeError(f"NeuTTS synthesis failed: {chr(10).join(error_lines) or 'unknown error'}")
 
-    # If the caller wanted .mp3 or .ogg, convert from WAV
-    if wav_path != output_path:
-        ffmpeg = shutil.which("ffmpeg")
-        if ffmpeg:
-            conv_cmd = [ffmpeg, "-i", wav_path, "-y", "-loglevel", "error", output_path]
-            subprocess.run(conv_cmd, check=True, timeout=30, stdin=subprocess.DEVNULL, creationflags=windows_hide_flags())
-            os.remove(wav_path)
-        else:
-            # No ffmpeg — just rename the WAV to the expected path
-            os.rename(wav_path, output_path)
+    return _convert_neutts_wav(wav_path, output_path)
 
-    return output_path
+
+def _generate_neutts(text: str, output_path: str, tts_config: Dict[str, Any]) -> str:
+    """Generate speech using NeuTTS, warm-cache by default with subprocess opt-out."""
+    neutts_config = tts_config.get("neutts", {}) if isinstance(tts_config, dict) else {}
+    if _neutts_warm_cache_enabled(neutts_config):
+        return _generate_neutts_warm(text, output_path, tts_config)
+    return _generate_neutts_subprocess(text, output_path, tts_config)
 
 
 # ===========================================================================
@@ -2910,6 +3123,9 @@ def text_to_speech_tool(
         out_dir.mkdir(parents=True, exist_ok=True)
         if command_provider_config is not None:
             fmt = _get_command_tts_output_format(command_provider_config)
+            file_path = out_dir / f"tts_{timestamp}.{fmt}"
+        elif provider == "neutts":
+            fmt = _neutts_output_format(tts_config.get("neutts", {}))
             file_path = out_dir / f"tts_{timestamp}.{fmt}"
         # Use .ogg for Telegram with providers that support native Opus output,
         # otherwise fall back to .mp3 (Edge TTS will attempt ffmpeg conversion later).

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -2477,7 +2477,7 @@ def _bool_config(value: Any, default: bool = False) -> bool:
 
 
 def _neutts_warm_cache_enabled(neutts_config: Dict[str, Any]) -> bool:
-    return _bool_config(neutts_config.get("warm_cache"), default=True)
+    return _bool_config(neutts_config.get("warm_cache"), default=False)
 
 
 def _neutts_idle_unload_seconds(neutts_config: Dict[str, Any]) -> float:
@@ -2588,7 +2588,13 @@ def _convert_neutts_wav(wav_path: str, output_path: str) -> str:
     if suffix == ".m4a":
         cmd += ["-c:a", "aac", "-b:a", "128k"]
     cmd.append(output_path)
-    subprocess.run(cmd, check=True, timeout=30)
+    subprocess.run(
+        cmd,
+        check=True,
+        timeout=30,
+        stdin=subprocess.DEVNULL,
+        creationflags=windows_hide_flags(),
+    )
     try:
         os.remove(wav_path)
     except FileNotFoundError:
@@ -2708,7 +2714,7 @@ def _generate_neutts_subprocess(text: str, output_path: str, tts_config: Dict[st
 
 
 def _generate_neutts(text: str, output_path: str, tts_config: Dict[str, Any]) -> str:
-    """Generate speech using NeuTTS, warm-cache by default with subprocess opt-out."""
+    """Generate speech using NeuTTS, with explicit opt-in warm caching."""
     neutts_config = tts_config.get("neutts", {}) if isinstance(tts_config, dict) else {}
     if _neutts_warm_cache_enabled(neutts_config):
         return _generate_neutts_warm(text, output_path, tts_config)

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -2502,7 +2502,7 @@ def _neutts_output_format(neutts_config: Dict[str, Any], default: str = "mp3") -
 
 
 def _neutts_resolved_config(tts_config: Dict[str, Any]) -> Dict[str, str]:
-    neutts_config = tts_config.get("neutts", {}) if isinstance(tts_config, dict) else {}
+    neutts_config = (tts_config.get("neutts") or {}) if isinstance(tts_config, dict) else {}
     return {
         "ref_audio": str(Path(neutts_config.get("ref_audio", "") or _default_neutts_ref_audio()).expanduser()),
         "ref_text": str(Path(neutts_config.get("ref_text", "") or _default_neutts_ref_text()).expanduser()),
@@ -2636,7 +2636,7 @@ def _clear_neutts_cache(reason: str = "manual") -> None:
 
 def _generate_neutts_warm(text: str, output_path: str, tts_config: Dict[str, Any]) -> str:
     """Generate speech with a cached in-process NeuTTS model/reference."""
-    neutts_config = tts_config.get("neutts", {}) if isinstance(tts_config, dict) else {}
+    neutts_config = (tts_config.get("neutts") or {}) if isinstance(tts_config, dict) else {}
     resolved = _neutts_resolved_config(tts_config)
     ref_audio = Path(resolved["ref_audio"])
     ref_text_path = Path(resolved["ref_text"])
@@ -2720,7 +2720,7 @@ def _generate_neutts_subprocess(text: str, output_path: str, tts_config: Dict[st
 
 def _generate_neutts(text: str, output_path: str, tts_config: Dict[str, Any]) -> str:
     """Generate speech using NeuTTS, with explicit opt-in warm caching."""
-    neutts_config = tts_config.get("neutts", {}) if isinstance(tts_config, dict) else {}
+    neutts_config = (tts_config.get("neutts") or {}) if isinstance(tts_config, dict) else {}
     if _neutts_warm_cache_enabled(neutts_config):
         return _generate_neutts_warm(text, output_path, tts_config)
     with _neutts_cache_lock:

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -2634,60 +2634,81 @@ def _clear_neutts_cache(reason: str = "manual") -> None:
     gc.collect()
 
 
+def _remove_neutts_partial_output(path: str) -> None:
+    """Best-effort cleanup for WAV files left by failed warm synthesis."""
+    try:
+        os.remove(path)
+    except FileNotFoundError:
+        pass
+    except OSError:
+        logger.debug("[NeuTTS] failed to remove partial output: %s", path, exc_info=True)
+
+
 def _generate_neutts_warm(text: str, output_path: str, tts_config: Dict[str, Any]) -> str:
     """Generate speech with a cached in-process NeuTTS model/reference."""
     neutts_config = (tts_config.get("neutts") or {}) if isinstance(tts_config, dict) else {}
     resolved = _neutts_resolved_config(tts_config)
     ref_audio = Path(resolved["ref_audio"])
     ref_text_path = Path(resolved["ref_text"])
-    if not ref_audio.exists():
-        raise RuntimeError(f"NeuTTS reference audio not found: {ref_audio}")
-    if not ref_text_path.exists():
-        raise RuntimeError(f"NeuTTS reference text not found: {ref_text_path}")
-
     key = _neutts_cache_key(resolved)
     wav_path = output_path if output_path.endswith(".wav") else str(Path(output_path).with_suffix(".wav"))
     Path(wav_path).parent.mkdir(parents=True, exist_ok=True)
 
     with _neutts_cache_lock:
-        entry = _neutts_cache.get(key)
-        if entry is None:
-            from neutts import NeuTTS
-            from tools.neutts_synth import resolve_neutts_devices
-
-            backbone_device, codec_device = resolve_neutts_devices(resolved["device"])
-            tts = NeuTTS(
-                backbone_repo=resolved["model"],
-                backbone_device=backbone_device,
-                codec_repo=resolved["codec_repo"],
-                codec_device=codec_device,
-            )
-            ref_codes = tts.encode_reference(str(ref_audio))
-            ref_text = ref_text_path.read_text(encoding="utf-8").strip()
-            entry = {
-                "tts": tts,
-                "ref_codes": ref_codes,
-                "ref_text": ref_text,
-                "loaded_at": time.monotonic(),
-                "last_used_at": time.monotonic(),
-                "resolved": resolved,
-            }
-            _neutts_cache.clear()
-            _neutts_cache[key] = entry
-            logger.info("[NeuTTS] warm cache loaded: model=%s device=%s", resolved["model"], resolved["device"])
-        else:
-            entry["last_used_at"] = time.monotonic()
-
         try:
+            entry = _neutts_cache.get(key)
+            if entry is None:
+                # A new configuration supersedes the old model immediately. If
+                # loading the replacement fails, retaining the stale ~500 MB
+                # model would violate the requested configuration and leak
+                # resources until the old idle timer fires.
+                if _neutts_cache or _neutts_idle_timer is not None:
+                    _clear_neutts_cache("config_changed")
+                if not ref_audio.exists():
+                    raise RuntimeError(f"NeuTTS reference audio not found: {ref_audio}")
+                if not ref_text_path.exists():
+                    raise RuntimeError(f"NeuTTS reference text not found: {ref_text_path}")
+
+                from neutts import NeuTTS
+                from tools.neutts_synth import resolve_neutts_devices
+
+                backbone_device, codec_device = resolve_neutts_devices(resolved["device"])
+                tts = NeuTTS(
+                    backbone_repo=resolved["model"],
+                    backbone_device=backbone_device,
+                    codec_repo=resolved["codec_repo"],
+                    codec_device=codec_device,
+                )
+                ref_codes = tts.encode_reference(str(ref_audio))
+                ref_text = ref_text_path.read_text(encoding="utf-8").strip()
+                entry = {
+                    "tts": tts,
+                    "ref_codes": ref_codes,
+                    "ref_text": ref_text,
+                    "loaded_at": time.monotonic(),
+                    "last_used_at": time.monotonic(),
+                    "resolved": resolved,
+                }
+                _neutts_cache[key] = entry
+                logger.info("[NeuTTS] warm cache loaded: model=%s device=%s", resolved["model"], resolved["device"])
+            else:
+                entry["last_used_at"] = time.monotonic()
+
             wav = entry["tts"].infer(text, entry["ref_codes"], entry["ref_text"])
             entry["last_used_at"] = time.monotonic()
             _write_neutts_wav(wav_path, wav, 24000)
+            _schedule_neutts_idle_unload(_neutts_idle_unload_seconds(neutts_config))
         except Exception:
             _clear_neutts_cache("synthesis_error")
+            _remove_neutts_partial_output(wav_path)
             raise
-        _schedule_neutts_idle_unload(_neutts_idle_unload_seconds(neutts_config))
 
-    return _convert_neutts_wav(wav_path, output_path)
+    try:
+        return _convert_neutts_wav(wav_path, output_path)
+    except Exception:
+        _clear_neutts_cache("conversion_error")
+        _remove_neutts_partial_output(wav_path)
+        raise
 
 
 def _generate_neutts_subprocess(text: str, output_path: str, tts_config: Dict[str, Any]) -> str:
@@ -2712,7 +2733,16 @@ def _generate_neutts_subprocess(text: str, output_path: str, tts_config: Dict[st
         "--device", resolved["device"],
     ]
 
-    result = subprocess.run(cmd, capture_output=True, text=True, encoding='utf-8', errors='replace', timeout=120, stdin=subprocess.DEVNULL)
+    result = subprocess.run(
+        cmd,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        timeout=120,
+        stdin=subprocess.DEVNULL,
+        creationflags=windows_hide_flags(),
+    )
     if result.returncode != 0:
         stderr = result.stderr.strip()
         error_lines = [line for line in stderr.splitlines() if not line.startswith("OK:")]

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -2653,11 +2653,14 @@ def _generate_neutts_warm(text: str, output_path: str, tts_config: Dict[str, Any
         entry = _neutts_cache.get(key)
         if entry is None:
             from neutts import NeuTTS
+            from tools.neutts_synth import resolve_neutts_devices
+
+            backbone_device, codec_device = resolve_neutts_devices(resolved["device"])
             tts = NeuTTS(
                 backbone_repo=resolved["model"],
-                backbone_device=resolved["device"],
+                backbone_device=backbone_device,
                 codec_repo=resolved["codec_repo"],
-                codec_device=resolved["device"],
+                codec_device=codec_device,
             )
             ref_codes = tts.encode_reference(str(ref_audio))
             ref_text = ref_text_path.read_text(encoding="utf-8").strip()

--- a/website/docs/guides/use-voice-mode-with-hermes.md
+++ b/website/docs/guides/use-voice-mode-with-hermes.md
@@ -194,8 +194,16 @@ tts:
     ref_audio: ''
     ref_text: ''
     model: neuphonic/neutts-air-q4-gguf
+    codec_repo: neuphonic/neucodec
     device: cpu
+    output_format: mp3
+    warm_cache: false
+    idle_unload_seconds: 1800
 ```
+
+Warm caching is disabled by default so the roughly 500 MB model exits with the
+one-shot synthesis subprocess. Enable `warm_cache` for lower repeat latency;
+`idle_unload_seconds` controls when the retained model is released.
 
 ## Use case 1: CLI voice mode
 

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1520,7 +1520,11 @@ tts:
     ref_audio: ''
     ref_text: ''
     model: neuphonic/neutts-air-q4-gguf
+    codec_repo: neuphonic/neucodec
     device: cpu
+    output_format: mp3            # mp3 | m4a/aac | wav | ogg | flac
+    warm_cache: false             # Opt in to lower repeat latency at a memory cost
+    idle_unload_seconds: 1800     # Release a warm model after 30 minutes idle
 ```
 
 This controls both the `text_to_speech` tool and spoken replies in voice mode (`/voice tts` in the CLI or messaging gateway).

--- a/website/docs/user-guide/features/tts.md
+++ b/website/docs/user-guide/features/tts.md
@@ -88,7 +88,11 @@ tts:
     ref_audio: ''
     ref_text: ''
     model: neuphonic/neutts-air-q4-gguf
+    codec_repo: neuphonic/neucodec
     device: cpu
+    output_format: mp3            # mp3 | m4a/aac | wav | ogg | flac
+    warm_cache: false             # Opt in to lower repeat latency at a memory cost
+    idle_unload_seconds: 1800     # Release a warm model after 30 minutes idle
   kittentts:
     model: KittenML/kitten-tts-nano-0.8-int8   # 25MB int8; also: kitten-tts-micro-0.8 (41MB), kitten-tts-mini-0.8 (80MB)
     voice: Jasper                               # Jasper, Bella, Luna, Bruno, Rosie, Hugo, Kiki, Leo
@@ -113,6 +117,8 @@ MiniMax TTS selects its region, endpoint, and credential together:
 - An explicitly selected region must have its matching credential. Hermes never borrows the other region's key. A `base_url` override does not change the selected credential, and an override pointing at the other region's official endpoint is rejected.
 
 **Speed control**: The global `tts.speed` value applies to all providers by default. Each provider can override it with its own `speed` setting (e.g., `tts.openai.speed: 1.5`). Provider-specific speed takes precedence over the global value. Default is `1.0` (normal speed).
+
+**NeuTTS warm cache**: NeuTTS continues to use a one-shot subprocess by default, so its roughly 500 MB model is released after each synthesis. Set `tts.neutts.warm_cache: true` to keep the model and encoded reference audio in the Hermes process for lower latency on repeated requests. When enabled, `idle_unload_seconds` controls how long the cache remains loaded after the most recent use.
 
 ### Gemini Persona Prompts
 


### PR DESCRIPTION
## Summary

- Adds an explicit opt-in in-process warm cache for NeuTTS synthesis, reusing the loaded model and encoded reference audio across calls while preserving the existing subprocess default.
- Retains the existing subprocess synthesis path when warm caching is disabled.
- Applies an idle-unload timeout so cached model resources are released after inactivity.
- Clears retained resources and partial warm WAVs when warm mode is disabled, synthesis/conversion fails, or a replacement configuration cannot load; forwards custom codec repositories through the subprocess path.
- Keeps native WAV generation and provider-safe conversion behavior, including
  the CUDA-to-llama.cpp device translation used by the subprocess path.

## Validation

Rebased onto current `main` and verified with focused NeuTTS lifecycle, output-routing, speed, text-length, and gateway-media coverage:

```text
uv run --with pytest --with pytest-asyncio --with pyyaml --with aiohttp python -m pytest tests/tools/test_tts_neutts_warm_cache.py tests/tools/test_tts_opus_routing.py tests/tools/test_tts_speed.py tests/tools/test_tts_max_text_length.py tests/gateway/test_tts_media_routing.py -q -o 'addopts='
80 passed in 1.61s

uv run --with ruff ruff check hermes_cli/config_defaults.py tools/neutts_synth.py tools/tts_tool.py tests/tools/test_tts_neutts_warm_cache.py
All checks passed!
```

## AI assistance disclosure

This PR was prepared with AI assistance under human direction and reviewed/tested locally before submission.
