### PR TITLE
[codex] Fix Grok Build context for xAI OAuth

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -209,6 +209,7 @@ DEFAULT_CONTEXT_LENGTHS = {
     # via a custom provider. Values sourced from models.dev (2026-04).
     # Keys use substring matching (longest-first), so e.g. "grok-4.20"
     # matches "grok-4.20-0309-reasoning" / "-non-reasoning" / "-multi-agent-0309".
+    "grok-build": 256000,       # grok-build-0.1
     "grok-code-fast": 256000,   # grok-code-fast-1
     "grok-4-1-fast": 2000000,   # grok-4-1-fast-(non-)reasoning
     "grok-2-vision": 8192,      # grok-2-vision, -1212, -latest

--- a/agent/models_dev.py
+++ b/agent/models_dev.py
@@ -167,6 +167,9 @@ PROVIDER_TO_MODELS_DEV: Dict[str, str] = {
     "gemini": "google",
     "google": "google",
     "xai": "xai",
+    # xAI OAuth is an authentication/transport path for the same xAI model
+    # catalog, so model metadata should resolve through the xAI provider.
+    "xai-oauth": "xai",
     "xiaomi": "xiaomi",
     "nvidia": "nvidia",
     "groq": "groq",

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -164,6 +164,7 @@ class TestDefaultContextLengths:
             "grok-4-1-fast": 2000000,
             "grok-4-fast": 2000000,
             "grok-4": 256000,
+            "grok-build": 256000,
             "grok-code-fast": 256000,
             "grok-3": 131072,
             "grok-2": 131072,
@@ -195,6 +196,7 @@ class TestDefaultContextLengths:
                 ("grok-4-fast-non-reasoning", 2000000),
                 ("grok-4", 256000),
                 ("grok-4-0709", 256000),
+                ("grok-build-0.1", 256000),
                 ("grok-code-fast-1", 256000),
                 ("grok-3", 131072),
                 ("grok-3-mini", 131072),
@@ -209,6 +211,32 @@ class TestDefaultContextLengths:
                 assert actual == expected_ctx, (
                     f"{model_id}: expected {expected_ctx}, got {actual}"
                 )
+
+    def test_xai_oauth_grok_build_uses_xai_models_dev_context(self):
+        """xAI OAuth should share the xAI provider metadata path.
+
+        The xAI /v1/models endpoint does not currently include context fields
+        for grok-build-0.1, so this guards against falling through to the
+        generic "grok" 131k fallback when using OAuth credentials.
+        """
+        registry = {
+            "xai": {
+                "models": {
+                    "grok-build-0.1": {
+                        "limit": {"context": 256000, "output": 64000},
+                    },
+                },
+            },
+        }
+        with patch("agent.model_metadata.get_cached_context_length", return_value=None), \
+             patch("agent.model_metadata._query_ollama_api_show", return_value=None), \
+             patch("agent.models_dev.fetch_models_dev", return_value=registry):
+            assert get_model_context_length(
+                "grok-build-0.1",
+                provider="xai-oauth",
+                base_url="https://api.x.ai/v1",
+                api_key="oauth-token",
+            ) == 256000
 
     def test_deepseek_v4_models_1m_context(self):
         from agent.model_metadata import get_model_context_length

--- a/tests/agent/test_models_dev.py
+++ b/tests/agent/test_models_dev.py
@@ -41,6 +41,16 @@ SAMPLE_REGISTRY = {
             },
         },
     },
+    "xai": {
+        "id": "xai",
+        "name": "xAI",
+        "models": {
+            "grok-build-0.1": {
+                "id": "grok-build-0.1",
+                "limit": {"context": 256000, "output": 64000},
+            },
+        },
+    },
     "kilo": {
         "id": "kilo",
         "name": "Kilo Gateway",
@@ -85,6 +95,10 @@ class TestProviderMapping:
         assert PROVIDER_TO_MODELS_DEV["stepfun"] == "stepfun"
         assert PROVIDER_TO_MODELS_DEV["kilocode"] == "kilo"
         assert PROVIDER_TO_MODELS_DEV["ai-gateway"] == "vercel"
+
+    def test_xai_oauth_uses_xai_catalog(self):
+        assert PROVIDER_TO_MODELS_DEV["xai"] == "xai"
+        assert PROVIDER_TO_MODELS_DEV["xai-oauth"] == "xai"
 
     def test_unmapped_provider_not_in_dict(self):
         assert "nous" not in PROVIDER_TO_MODELS_DEV
@@ -143,6 +157,12 @@ class TestLookupModelsDevContext:
         assert lookup_models_dev_context("anthropic", "claude-opus-4-6") == 1000000
         # GitHub Copilot: only 128K for same model
         assert lookup_models_dev_context("copilot", "claude-opus-4.6") == 128000
+
+    @patch("agent.models_dev.fetch_models_dev")
+    def test_xai_oauth_resolves_xai_context(self, mock_fetch):
+        """xAI OAuth is an auth path, not a separate model catalog."""
+        mock_fetch.return_value = SAMPLE_REGISTRY
+        assert lookup_models_dev_context("xai-oauth", "grok-build-0.1") == 256000
 
     @patch("agent.models_dev.fetch_models_dev")
     def test_zero_context_filtered(self, mock_fetch):


### PR DESCRIPTION
## Summary
- map the `xai-oauth` auth path to the same models.dev provider catalog as `xai`
- add an offline `grok-build` context fallback so Grok Build does not fall through to the generic 131k Grok fallback
- add regression coverage for `grok-build-0.1` resolving to 256k with xAI OAuth

## Root cause
`xai-oauth` was treated as a separate provider for models.dev metadata, so `grok-build-0.1` missed the xAI catalog entry. Because xAI's `/v1/models` response does not include context metadata for this slug, Hermes fell through to the broad `grok` fallback and reported 131,072 tokens instead of 256,000.

## Validation
- `.venv/bin/python -m pytest tests/agent/test_models_dev.py::TestProviderMapping::test_xai_oauth_uses_xai_catalog tests/agent/test_models_dev.py::TestLookupModelsDevContext::test_xai_oauth_resolves_xai_context tests/agent/test_model_metadata.py::TestDefaultContextLengths::test_grok_models_context_lengths tests/agent/test_model_metadata.py::TestDefaultContextLengths::test_grok_substring_matching tests/agent/test_model_metadata.py::TestDefaultContextLengths::test_xai_oauth_grok_build_uses_xai_models_dev_context -q`
- `.venv/bin/python -m pytest tests/agent/test_models_dev.py tests/agent/test_model_metadata.py -q --timeout=120`
- `.venv/bin/python -m pytest tests/run_agent/test_codex_xai_oauth_recovery.py::test_grok_4_3_context_length_is_1m tests/run_agent/test_codex_xai_oauth_recovery.py::test_grok_4_still_resolves_to_256k -q --timeout=120`
- `.venv/bin/ruff check agent/models_dev.py agent/model_metadata.py tests/agent/test_models_dev.py tests/agent/test_model_metadata.py`
- `git diff --check`

Note: I also tried the full `tests/run_agent/test_codex_xai_oauth_recovery.py` locally, but its first stream-prelude test stalled in this Python 3.14 environment before reaching this patch's metadata path, so I stopped it and ran the context-specific tests from that file instead.