### PR TITLE
feat: add development ideas vault tools

### DIFF
--- a/docs/plans/vault-roadmap.md
+++ b/docs/plans/vault-roadmap.md
@@ -1,0 +1,101 @@
+# Vault Tools — Implementation Roadmap
+
+## Overview
+
+The **vault** toolset provides Hermes with native access to a local
+"development ideas" vault: a directory of Markdown files, JSONL entries, and
+reference sources stored under `HERMES_HOME/data/development_ideas/`.
+
+This document tracks what is implemented, what is pending, and the intended
+design direction.
+
+---
+
+## Phase 1 — Extractive Search (Implemented ✅)
+
+### Files
+| File | Purpose |
+|------|---------|
+| `tools/vault_tool.py` | Core search + ask logic, JSON schemas, registry calls |
+| `tests/tools/test_vault_tool.py` | pytest test suite |
+
+### Tools registered
+| Tool | Toolset | Description |
+|------|---------|-------------|
+| `vault_search` | `vault` | Case-insensitive substring search over README.md, ideas.jsonl, sources/*.md |
+| `ask_vault` | `vault` | Extractive Q&A — returns top snippets + answer_summary, no LLM call |
+
+### Vault layout expected
+```
+HERMES_HOME/
+  data/
+    development_ideas/
+      README.md         ← top-level index / overview
+      ideas.jsonl       ← one JSON object per line (title, body, tags, …)
+      sources/
+        *.md            ← reference material (optional)
+```
+
+### Scoring algorithm
+- Split query into whitespace-delimited terms
+- Per-line (Markdown) or per-entry (JSONL): score = `5 * exact_query_hits + sum(term_freq)`
+- Sort descending; truncate to `limit`
+
+### Safety / path handling
+- Default root: `get_hermes_home() / "data" / "development_ideas"`
+- Absolute `path` override: must exist and be a directory.  **Note:** there is
+  no restriction on *which* absolute path the caller may supply — users with
+  tool access can point it at any readable directory on the filesystem.  A
+  future hardening pass could add an allowlist or require the path to live
+  inside `HERMES_HOME`.
+- Relative `path` override: resolved under default root, `..` components
+  are rejected to prevent path traversal
+- `check_fn`: returns `True` only when default vault root exists
+- **File size guard (future):** very large Markdown or JSONL files are read
+  entirely into memory.  A per-file size limit (e.g. 10 MB) should be added
+  before the vault is exposed to arbitrary user-supplied paths.
+
+### Toolset registration in `toolsets.py`
+- `vault_search` and `ask_vault` added to `_HERMES_CORE_TOOLS`
+- `"vault"` entry added to `TOOLSETS` dict
+
+---
+
+## Phase 2 — Structured Indexing (Planned)
+
+- Build an on-disk index (e.g. SQLite FTS5) for faster large-vault search
+- Incremental re-index on file change (inotify / polling)
+- Tag-based filtering (`tags: [python, ml]` in JSONL entries)
+- Date-range filtering on `created_at` / `updated_at` fields
+
+---
+
+## Phase 3 — Semantic Search (Planned)
+
+- Embed vault entries with a local embedding model (e.g. `nomic-embed-text`
+  via Ollama) or a lightweight SentenceTransformers model
+- Store vectors alongside the SQLite index
+- `vault_search` gains `mode` parameter: `"keyword"` (default) | `"semantic"` | `"hybrid"`
+- `ask_vault` can optionally call the configured LLM for a synthesised answer
+  when `use_llm=True` is passed (gated on model availability)
+
+---
+
+## Phase 4 — Vault Management (Planned)
+
+- `vault_add_idea` — append a new entry to `ideas.jsonl`
+- `vault_edit_idea` — update an existing entry by ID or fuzzy title match
+- `vault_delete_idea` — soft-delete (move to `ideas.jsonl.archive`)
+- `vault_stats` — count entries, list tags, show recent additions
+
+---
+
+## Design Decisions
+
+| Decision | Rationale |
+|----------|-----------|
+| No LLM in Phase 1 | Fast, offline, no token cost; sufficient for most lookups |
+| JSONL over SQLite | Human-editable, diff-friendly, zero schema migration |
+| `check_fn` gates on dir existence | Avoids polluting tool schemas for users without a vault |
+| Path traversal guard for relative paths | Principle of least surprise; absolute override is explicit user intent |
+| `ask_vault` mode="extractive" | Honest about capabilities; avoids hallucinated "answers" |

--- a/tests/tools/test_vault_tool.py
+++ b/tests/tools/test_vault_tool.py
@@ -1,0 +1,354 @@
+"""Tests for tools/vault_tool.py — vault_search and ask_vault."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def vault_root(tmp_path: Path, monkeypatch) -> Path:
+    """Set up a temporary vault root and monkeypatch get_hermes_home."""
+
+    # Create a fake HERMES_HOME layout.
+    hermes_home = tmp_path / "hermes_home"
+    vault = hermes_home / "data" / "development_ideas"
+    vault.mkdir(parents=True)
+
+    # Patch get_hermes_home in the vault_tool module so the default root
+    # resolves to our tmp directory.
+    import tools.vault_tool as vt
+
+    monkeypatch.setattr(vt, "get_hermes_home", lambda: hermes_home)
+
+    return vault
+
+
+# ---------------------------------------------------------------------------
+# Helpers to populate the vault
+# ---------------------------------------------------------------------------
+
+
+def _write_readme(vault: Path, content: str) -> None:
+    (vault / "README.md").write_text(content, encoding="utf-8")
+
+
+def _write_ideas(vault: Path, entries: list[dict]) -> None:
+    (vault / "ideas.jsonl").write_text(
+        "\n".join(json.dumps(e) for e in entries), encoding="utf-8"
+    )
+
+
+def _write_source(vault: Path, name: str, content: str) -> None:
+    sources = vault / "sources"
+    sources.mkdir(exist_ok=True)
+    (sources / name).write_text(content, encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# vault_search tests
+# ---------------------------------------------------------------------------
+
+
+class TestVaultSearch:
+    def test_match_readme(self, vault_root):
+        """Finds a match in README.md."""
+        _write_readme(vault_root, "# Dev Ideas\n\nBuild a distributed cache system.\n")
+        import tools.vault_tool as vt
+
+        result = json.loads(vt.vault_search("distributed cache"))
+        assert result["success"] is True
+        assert result["total"] >= 1
+        assert any("distributed" in m["snippet"].lower() for m in result["matches"])
+        assert result["truncated"] is False
+
+    def test_match_jsonl(self, vault_root):
+        """Finds a match in ideas.jsonl."""
+        _write_ideas(
+            vault_root,
+            [
+                {"title": "Graph Database", "body": "Explore neo4j for recommendation engine"},
+                {"title": "Unrelated", "body": "Something completely different"},
+            ],
+        )
+        import tools.vault_tool as vt
+
+        result = json.loads(vt.vault_search("neo4j"))
+        assert result["success"] is True
+        assert result["total"] == 1
+        assert "neo4j" in result["matches"][0]["snippet"].lower()
+        assert result["matches"][0]["type"] == "jsonl"
+
+    def test_match_sources(self, vault_root):
+        """Finds a match in sources/*.md."""
+        _write_source(vault_root, "ref.md", "## Reference\n\nUsing vector embeddings for search.\n")
+        import tools.vault_tool as vt
+
+        result = json.loads(vt.vault_search("vector embeddings"))
+        assert result["success"] is True
+        assert result["total"] >= 1
+        assert result["matches"][0]["type"] == "source"
+
+    def test_no_results(self, vault_root):
+        """Returns success with empty matches when nothing found."""
+        _write_readme(vault_root, "# Ideas\n\nHello world.\n")
+        import tools.vault_tool as vt
+
+        result = json.loads(vt.vault_search("zzznomatch"))
+        assert result["success"] is True
+        assert result["matches"] == []
+        assert result["total"] == 0
+        assert result["truncated"] is False
+
+    def test_limit_and_truncated(self, vault_root):
+        """Respects limit and sets truncated=True when there are more results."""
+        # Write README with many matching lines.
+        lines = "\n".join(f"idea about caching line {i}" for i in range(20))
+        _write_readme(vault_root, lines)
+        import tools.vault_tool as vt
+
+        result = json.loads(vt.vault_search("caching", limit=5))
+        assert result["success"] is True
+        assert len(result["matches"]) == 5
+        assert result["total"] > 5
+        assert result["truncated"] is True
+
+    def test_empty_query_returns_error(self, vault_root):
+        """Empty query returns success=False."""
+        import tools.vault_tool as vt
+
+        result = json.loads(vt.vault_search(""))
+        assert result["success"] is False
+        assert "error" in result
+
+    def test_whitespace_only_query_returns_error(self, vault_root):
+        """Whitespace-only query returns success=False."""
+        import tools.vault_tool as vt
+
+        result = json.loads(vt.vault_search("   "))
+        assert result["success"] is False
+        assert "error" in result
+
+    @pytest.mark.parametrize("bad_limit", [0, -1])
+    def test_invalid_limit_returns_error(self, vault_root, bad_limit):
+        """limit <= 0 returns success=False with appropriate error."""
+        _write_readme(vault_root, "some content")
+        import tools.vault_tool as vt
+
+        result = json.loads(vt.vault_search("content", limit=bad_limit))
+        assert result["success"] is False
+        assert "limit" in result["error"].lower()
+
+    def test_include_sources_false(self, vault_root):
+        """When include_sources=False, sources/*.md are not searched."""
+        _write_source(vault_root, "ref.md", "embedded secrets in source file")
+        _write_readme(vault_root, "# Ideas")
+        import tools.vault_tool as vt
+
+        result = json.loads(vt.vault_search("embedded secrets", include_sources=False))
+        assert result["success"] is True
+        assert all(m["type"] != "source" for m in result["matches"])
+
+    def test_absolute_path_override(self, vault_root, tmp_path):
+        """Absolute path override works if directory exists."""
+        alt = tmp_path / "alt_vault"
+        alt.mkdir()
+        (alt / "README.md").write_text("unicorn magic here", encoding="utf-8")
+        import tools.vault_tool as vt
+
+        result = json.loads(vt.vault_search("unicorn", path=str(alt)))
+        assert result["success"] is True
+        assert result["total"] >= 1
+
+    def test_absolute_path_nonexistent_returns_error(self, vault_root, tmp_path):
+        """Absolute path that doesn't exist returns error."""
+        import tools.vault_tool as vt
+
+        result = json.loads(vt.vault_search("x", path=str(tmp_path / "does_not_exist")))
+        assert result["success"] is False
+        assert "error" in result
+
+    def test_relative_path_traversal_blocked(self, vault_root):
+        """Relative path with '..' is rejected."""
+        import tools.vault_tool as vt
+
+        result = json.loads(vt.vault_search("x", path="../../../etc"))
+        assert result["success"] is False
+        assert "error" in result
+
+    def test_result_fields(self, vault_root):
+        """Each match has path, type, line, snippet, score fields."""
+        _write_readme(vault_root, "This is a machine learning idea.\n")
+        import tools.vault_tool as vt
+
+        result = json.loads(vt.vault_search("machine learning"))
+        assert result["success"] is True
+        assert len(result["matches"]) >= 1
+        m = result["matches"][0]
+        assert "path" in m
+        assert "type" in m
+        assert "line" in m
+        assert "snippet" in m
+        assert "score" in m
+        assert m["score"] > 0
+
+    def test_results_sorted_by_score_desc(self, vault_root):
+        """Results are returned highest-score first."""
+        # Line with exact query match scores higher than line with single term.
+        _write_readme(
+            vault_root,
+            "blockchain ledger concept\n"
+            "distributed blockchain ledger technology for secure transactions\n",
+        )
+        import tools.vault_tool as vt
+
+        result = json.loads(vt.vault_search("blockchain ledger"))
+        scores = [m["score"] for m in result["matches"]]
+        assert scores == sorted(scores, reverse=True)
+
+
+# ---------------------------------------------------------------------------
+# ask_vault tests
+# ---------------------------------------------------------------------------
+
+
+class TestAskVault:
+    def test_basic_ask(self, vault_root):
+        """ask_vault returns expected top-level keys."""
+        _write_readme(vault_root, "# Ideas\n\nFast key-value store using LSM trees.\n")
+        import tools.vault_tool as vt
+
+        result = json.loads(vt.ask_vault("key-value store"))
+        assert result["success"] is True
+        assert result["mode"] == "extractive"
+        assert "answer_summary" in result
+        assert "candidate_context" in result
+        assert "sources" in result
+        assert isinstance(result["candidate_context"], list)
+
+    def test_answer_summary_mentions_extractive(self, vault_root):
+        """answer_summary always states it is extractive (no LLM)."""
+        _write_ideas(vault_root, [{"title": "Caching", "body": "Use Redis for caching"}])
+        import tools.vault_tool as vt
+
+        result = json.loads(vt.ask_vault("caching"))
+        assert "extractive" in result["answer_summary"].lower() or "no llm" in result["answer_summary"].lower()
+
+    def test_no_results_answer_summary(self, vault_root):
+        """When no matches, answer_summary still mentions extractive search."""
+        _write_readme(vault_root, "# Nothing relevant here.")
+        import tools.vault_tool as vt
+
+        result = json.loads(vt.ask_vault("zzznomatch"))
+        assert result["success"] is True
+        assert result["candidate_context"] == []
+        assert result["sources"] == []
+        assert "no matching" in result["answer_summary"].lower() or "extractive" in result["answer_summary"].lower()
+
+    def test_sources_deduped(self, vault_root):
+        """sources list contains unique file paths."""
+        content = "\n".join(f"line {i} about kafka" for i in range(5))
+        _write_readme(vault_root, content)
+        import tools.vault_tool as vt
+
+        result = json.loads(vt.ask_vault("kafka"))
+        assert result["success"] is True
+        assert len(result["sources"]) == len(set(result["sources"]))
+
+    def test_limit_applied_to_context(self, vault_root):
+        """limit restricts candidate_context length."""
+        lines = "\n".join(f"spark streaming event {i}" for i in range(20))
+        _write_readme(vault_root, lines)
+        import tools.vault_tool as vt
+
+        result = json.loads(vt.ask_vault("spark streaming", limit=3))
+        assert result["success"] is True
+        assert len(result["candidate_context"]) <= 3
+
+    def test_candidate_context_fields(self, vault_root):
+        """Each candidate_context entry has source, line, text, score."""
+        _write_ideas(vault_root, [{"title": "AI safety", "body": "Alignment research ideas"}])
+        import tools.vault_tool as vt
+
+        result = json.loads(vt.ask_vault("alignment"))
+        ctx = result["candidate_context"]
+        assert len(ctx) >= 1
+        for entry in ctx:
+            assert "source" in entry
+            assert "line" in entry
+            assert "text" in entry
+            assert "score" in entry
+
+    def test_empty_question_returns_error(self, vault_root):
+        """Empty question returns success=False."""
+        import tools.vault_tool as vt
+
+        result = json.loads(vt.ask_vault(""))
+        assert result["success"] is False
+        assert "error" in result
+
+    def test_whitespace_only_question_returns_error(self, vault_root):
+        """Whitespace-only question returns success=False."""
+        import tools.vault_tool as vt
+
+        result = json.loads(vt.ask_vault("   "))
+        assert result["success"] is False
+        assert "error" in result
+
+    @pytest.mark.parametrize("bad_limit", [0, -1])
+    def test_invalid_limit_returns_error(self, vault_root, bad_limit):
+        """limit <= 0 returns success=False with appropriate error."""
+        _write_readme(vault_root, "some content")
+        import tools.vault_tool as vt
+
+        result = json.loads(vt.ask_vault("content", limit=bad_limit))
+        assert result["success"] is False
+        assert "limit" in result["error"].lower()
+
+    def test_path_traversal_returns_error(self, vault_root):
+        """Relative path with '..' is rejected in ask_vault."""
+        import tools.vault_tool as vt
+
+        result = json.loads(vt.ask_vault("anything", path="../../../etc"))
+        assert result["success"] is False
+        assert "error" in result
+
+    def test_malformed_jsonl_line_does_not_crash(self, vault_root):
+        """A malformed JSONL line is skipped; valid subsequent lines are still found."""
+        (vault_root / "ideas.jsonl").write_text(
+            'this is not json\n'
+            '{"title": "Valid Entry", "body": "reachable content after bad line"}\n',
+            encoding="utf-8",
+        )
+        import tools.vault_tool as vt
+
+        result = json.loads(vt.ask_vault("reachable content"))
+        assert result["success"] is True
+        assert len(result["candidate_context"]) >= 1
+        assert any("reachable" in entry["text"].lower() for entry in result["candidate_context"])
+
+
+# ---------------------------------------------------------------------------
+# check_fn / availability
+# ---------------------------------------------------------------------------
+
+
+class TestCheckFn:
+    def test_check_fn_true_when_vault_exists(self, vault_root):
+        """_check_vault_available returns True when vault dir exists."""
+        import tools.vault_tool as vt
+
+        assert vt._check_vault_available() is True
+
+    def test_check_fn_false_when_vault_missing(self, tmp_path, monkeypatch):
+        """_check_vault_available returns False when vault dir is absent."""
+        import tools.vault_tool as vt
+
+        monkeypatch.setattr(vt, "get_hermes_home", lambda: tmp_path / "nonexistent_home")
+        assert vt._check_vault_available() is False

--- a/tools/vault_tool.py
+++ b/tools/vault_tool.py
@@ -1,0 +1,492 @@
+#!/usr/bin/env python3
+"""
+Vault Tool Module - Development Ideas Vault Search
+
+Provides search and Q&A over a local vault of development ideas stored as
+Markdown files and JSONL entries. No LLM is involved — results are purely
+extractive (substring scoring over local files).
+
+Vault layout (default: HERMES_HOME/data/development_ideas/):
+  README.md          — top-level description / index
+  ideas.jsonl        — one JSON object per line (each may have 'title', 'body', 'tags', ...)
+  sources/           — optional *.md files with reference material
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from pathlib import Path
+from typing import Any
+
+from hermes_constants import get_hermes_home
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Vault root helpers
+# ---------------------------------------------------------------------------
+
+
+def _default_vault_root() -> Path:
+    """Return the default vault root directory."""
+    return get_hermes_home() / "data" / "development_ideas"
+
+
+def _resolve_vault_root(path: str | None) -> tuple[Path, str | None]:
+    """Resolve the effective vault root from the optional *path* argument.
+
+    Returns ``(resolved_path, error_message_or_None)``.  If error is set the
+    caller should return a JSON error to the user immediately.
+
+    Rules
+    -----
+    * ``path=None`` → use the default vault root (no validation).
+    * Absolute path → expand user home (``~``), require the result is an
+      existing directory.
+    * Relative path → resolve against the default vault root, block ``..``
+      components (path-traversal guard), require the result is an existing
+      directory.
+    """
+    if path is None:
+        return _default_vault_root(), None
+
+    p = Path(path)
+
+    if p.is_absolute():
+        resolved = p.expanduser().resolve()
+        if not resolved.exists():
+            return resolved, f"Path does not exist: {path}"
+        if not resolved.is_dir():
+            return resolved, f"Path is not a directory: {path}"
+        return resolved, None
+
+    # Relative path — anchor to default vault root, block traversal.
+    if ".." in p.parts:
+        return _default_vault_root(), f"Relative path traversal is not allowed: {path}"
+
+    default_root = _default_vault_root()
+    resolved = (default_root / p).resolve()
+    # Ensure it stays inside the default vault root.
+    try:
+        resolved.relative_to(default_root.resolve())
+    except ValueError:
+        return default_root, f"Relative path escapes vault root: {path}"
+
+    if not resolved.exists():
+        return resolved, f"Path does not exist (relative to vault root): {path}"
+    if not resolved.is_dir():
+        return resolved, f"Path is not a directory: {path}"
+
+    return resolved, None
+
+
+# ---------------------------------------------------------------------------
+# Scoring / search helpers
+# ---------------------------------------------------------------------------
+
+
+def _score_text(text: str, query: str, terms: list[str]) -> float:
+    """Return a simple relevance score for *text* against the query."""
+    lower = text.lower()
+    score = 0.0
+    # Exact query match (higher weight)
+    if query.lower() in lower:
+        score += 5.0
+    # Per-term frequency
+    for term in terms:
+        score += lower.count(term)
+    return score
+
+
+def _snippet(line: str, max_len: int = 200) -> str:
+    """Return a trimmed snippet of *line*."""
+    stripped = line.strip()
+    if len(stripped) <= max_len:
+        return stripped
+    return stripped[:max_len] + "…"
+
+
+def _search_markdown(
+    file_path: Path,
+    query: str,
+    terms: list[str],
+    file_type: str,
+) -> list[dict[str, Any]]:
+    """Return per-line matches from a Markdown file."""
+    matches: list[dict[str, Any]] = []
+    try:
+        text = file_path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return matches
+
+    for lineno, line in enumerate(text.splitlines(), start=1):
+        score = _score_text(line, query, terms)
+        if score > 0:
+            matches.append(
+                {
+                    "path": str(file_path),
+                    "type": file_type,
+                    "line": lineno,
+                    "snippet": _snippet(line),
+                    "score": score,
+                }
+            )
+    return matches
+
+
+def _search_jsonl(
+    file_path: Path,
+    query: str,
+    terms: list[str],
+) -> list[dict[str, Any]]:
+    """Return per-entry matches from an ideas.jsonl file."""
+    matches: list[dict[str, Any]] = []
+    try:
+        lines = file_path.read_text(encoding="utf-8", errors="replace").splitlines()
+    except OSError:
+        return matches
+
+    for lineno, raw in enumerate(lines, start=1):
+        raw = raw.strip()
+        if not raw:
+            continue
+        try:
+            obj = json.loads(raw)
+        except json.JSONDecodeError:
+            obj = {}
+
+        # Collect searchable text: all string values in the object.
+        text_parts: list[str] = []
+        if isinstance(obj, dict):
+            for v in obj.values():
+                if isinstance(v, str):
+                    text_parts.append(v)
+                elif isinstance(v, list):
+                    text_parts.extend(str(i) for i in v if isinstance(i, str))
+        else:
+            text_parts.append(str(obj))
+
+        combined = " ".join(text_parts)
+        score = _score_text(combined, query, terms)
+        if score > 0:
+            # Build a human-readable snippet from the most relevant fields.
+            title = obj.get("title", "") if isinstance(obj, dict) else ""
+            body = obj.get("body", obj.get("description", combined)) if isinstance(obj, dict) else combined
+            snip = f"{title}: {body}" if title else body
+            matches.append(
+                {
+                    "path": str(file_path),
+                    "type": "jsonl",
+                    "line": lineno,
+                    "snippet": _snippet(snip),
+                    "score": score,
+                }
+            )
+    return matches
+
+
+def _run_search(
+    query: str,
+    include_sources: bool,
+    vault_root: Path,
+) -> list[dict[str, Any]]:
+    """Run the full search and return an unsorted-then-sorted match list."""
+    terms = [t.lower() for t in re.split(r"\s+", query.strip()) if t]
+    all_matches: list[dict[str, Any]] = []
+
+    # 1. README.md
+    readme = vault_root / "README.md"
+    if readme.is_file():
+        all_matches.extend(_search_markdown(readme, query, terms, "readme"))
+
+    # 2. ideas.jsonl
+    ideas = vault_root / "ideas.jsonl"
+    if ideas.is_file():
+        all_matches.extend(_search_jsonl(ideas, query, terms))
+
+    # 3. sources/*.md
+    if include_sources:
+        sources_dir = vault_root / "sources"
+        if sources_dir.is_dir():
+            for md_file in sorted(sources_dir.glob("*.md")):
+                all_matches.extend(_search_markdown(md_file, query, terms, "source"))
+
+    # Sort descending by score, stable (preserves file order for ties).
+    all_matches.sort(key=lambda m: m["score"], reverse=True)
+    return all_matches
+
+
+# ---------------------------------------------------------------------------
+# Public tool functions
+# ---------------------------------------------------------------------------
+
+
+def vault_search(
+    query: str,
+    limit: int = 10,
+    include_sources: bool = True,
+    path: str | None = None,
+) -> str:
+    """Search the development-ideas vault and return a JSON string.
+
+    Parameters
+    ----------
+    query:
+        Free-text search query.  Terms are split on whitespace and matched
+        case-insensitively against vault content.
+    limit:
+        Maximum number of matches to return.
+    include_sources:
+        Whether to search ``sources/*.md`` files in addition to README.md and
+        ideas.jsonl.
+    path:
+        Optional override for the vault root directory.  Absolute paths must
+        exist and be a directory.  Relative paths are resolved against the
+        default vault root and must not escape it (no ``..`` components).
+    """
+    vault_root, err = _resolve_vault_root(path)
+    if err:
+        return json.dumps({"success": False, "error": err}, ensure_ascii=False)
+
+    if not query or not query.strip():
+        return json.dumps(
+            {"success": False, "error": "query must not be empty"},
+            ensure_ascii=False,
+        )
+
+    if limit < 1:
+        return json.dumps(
+            {"success": False, "error": "limit must be >= 1"},
+            ensure_ascii=False,
+        )
+
+    all_matches = _run_search(query, include_sources, vault_root)
+    total = len(all_matches)
+    truncated = total > limit
+    returned = all_matches[:limit]
+
+    return json.dumps(
+        {
+            "success": True,
+            "query": query,
+            "root": str(vault_root),
+            "matches": returned,
+            "total": total,
+            "truncated": truncated,
+        },
+        ensure_ascii=False,
+        indent=None,
+    )
+
+
+def ask_vault(
+    question: str,
+    limit: int = 8,
+    path: str | None = None,
+) -> str:
+    """Answer a question about the vault using extractive search (no LLM).
+
+    Reuses the same scoring logic as ``vault_search`` and surfaces the top
+    matching snippets as the "answer".  This is intentionally lightweight:
+    no model call is made; the returned ``answer_summary`` explains this.
+
+    Parameters
+    ----------
+    question:
+        Natural-language question about the vault content.
+    limit:
+        Number of top matching snippets to include in the context.
+    path:
+        Optional override for the vault root directory (same rules as
+        ``vault_search``).
+    """
+    vault_root, err = _resolve_vault_root(path)
+    if err:
+        return json.dumps({"success": False, "error": err}, ensure_ascii=False)
+
+    if not question or not question.strip():
+        return json.dumps(
+            {"success": False, "error": "question must not be empty"},
+            ensure_ascii=False,
+        )
+
+    if limit < 1:
+        return json.dumps(
+            {"success": False, "error": "limit must be >= 1"},
+            ensure_ascii=False,
+        )
+
+    all_matches = _run_search(question, include_sources=True, vault_root=vault_root)
+    top = all_matches[:limit]
+
+    # Collect unique source files for attribution.
+    seen_sources: list[str] = []
+    seen_set: set[str] = set()
+    for m in top:
+        if m["path"] not in seen_set:
+            seen_set.add(m["path"])
+            seen_sources.append(m["path"])
+
+    candidate_context = [
+        {"source": m["path"], "line": m["line"], "text": m["snippet"], "score": m["score"]}
+        for m in top
+    ]
+
+    if top:
+        answer_summary = (
+            f"Based on {len(top)} local matching snippet(s) from the vault "
+            f"(extractive search — no LLM inference): the top result is: "
+            f'"{top[0]["snippet"]}"'
+        )
+    else:
+        answer_summary = (
+            "No matching content found in the vault for this question "
+            "(extractive search — no LLM inference)."
+        )
+
+    return json.dumps(
+        {
+            "success": True,
+            "question": question,
+            "mode": "extractive",
+            "answer_summary": answer_summary,
+            "candidate_context": candidate_context,
+            "sources": seen_sources,
+        },
+        ensure_ascii=False,
+        indent=None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# JSON schemas
+# ---------------------------------------------------------------------------
+
+VAULT_SEARCH_SCHEMA = {
+    "name": "vault_search",
+    "description": (
+        "Search the local development-ideas vault for content matching a query. "
+        "Searches README.md, ideas.jsonl, and optionally sources/*.md using "
+        "case-insensitive substring scoring. Returns ranked snippets with file "
+        "paths, line numbers, and relevance scores. Useful for quickly locating "
+        "ideas, notes, or references stored in the vault."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "query": {
+                "type": "string",
+                "description": "Search query. Terms are matched case-insensitively.",
+            },
+            "limit": {
+                "type": "integer",
+                "description": "Maximum number of results to return (default 10).",
+                "default": 10,
+                "minimum": 1,
+            },
+            "include_sources": {
+                "type": "boolean",
+                "description": (
+                    "Include sources/*.md files in the search (default true). "
+                    "Set to false to search only README.md and ideas.jsonl."
+                ),
+                "default": True,
+            },
+            "path": {
+                "type": "string",
+                "description": (
+                    "Optional override for the vault root directory. "
+                    "Absolute paths must exist and be a directory. "
+                    "Relative paths are resolved under the default vault root "
+                    "and must not contain '..' components."
+                ),
+            },
+        },
+        "required": ["query"],
+    },
+}
+
+ASK_VAULT_SCHEMA = {
+    "name": "ask_vault",
+    "description": (
+        "Answer a question about the local development-ideas vault using "
+        "extractive search (no LLM). Returns the top matching snippets and a "
+        "brief answer summary based purely on local content. Useful for "
+        "quick lookups when you want the raw context rather than a synthesised "
+        "answer."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "question": {
+                "type": "string",
+                "description": "Natural-language question about the vault content.",
+            },
+            "limit": {
+                "type": "integer",
+                "description": "Number of top snippets to include in context (default 8).",
+                "default": 8,
+                "minimum": 1,
+            },
+            "path": {
+                "type": "string",
+                "description": (
+                    "Optional override for the vault root directory. "
+                    "Same rules as vault_search: absolute paths must exist; "
+                    "relative paths resolve under the default vault root "
+                    "without '..' traversal."
+                ),
+            },
+        },
+        "required": ["question"],
+    },
+}
+
+
+# ---------------------------------------------------------------------------
+# check_fn
+# ---------------------------------------------------------------------------
+
+
+def _check_vault_available() -> bool:
+    """Return True if the default vault root directory exists."""
+    return _default_vault_root().exists()
+
+
+# ---------------------------------------------------------------------------
+# Registration
+# ---------------------------------------------------------------------------
+
+from tools.registry import registry  # noqa: E402
+
+registry.register(
+    name="vault_search",
+    toolset="vault",
+    schema=VAULT_SEARCH_SCHEMA,
+    handler=lambda args, **kw: vault_search(
+        query=args.get("query", ""),
+        limit=int(args.get("limit", 10)),
+        include_sources=bool(args.get("include_sources", True)),
+        path=args.get("path"),
+    ),
+    check_fn=_check_vault_available,
+    emoji="🗄️",
+    description="Search the local development-ideas vault",
+)
+
+registry.register(
+    name="ask_vault",
+    toolset="vault",
+    schema=ASK_VAULT_SCHEMA,
+    handler=lambda args, **kw: ask_vault(
+        question=args.get("question", ""),
+        limit=int(args.get("limit", 8)),
+        path=args.get("path"),
+    ),
+    check_fn=_check_vault_available,
+    emoji="💡",
+    description="Answer questions about the vault using extractive search",
+)

--- a/toolsets.py
+++ b/toolsets.py
@@ -70,6 +70,8 @@ _HERMES_CORE_TOOLS = [
     "kanban_unblock",
     # Computer use (macOS, gated on cua-driver being installed via check_fn)
     "computer_use",
+    # Vault — local development-ideas vault search (gated on vault dir existing)
+    "vault_search", "ask_vault",
 ]
 
 
@@ -203,6 +205,12 @@ TOOLSETS = {
     "memory": {
         "description": "Persistent memory across sessions (personal notes + user profile)",
         "tools": ["memory"],
+        "includes": []
+    },
+
+    "vault": {
+        "description": "Local development-ideas vault search (README.md, ideas.jsonl, sources/*.md)",
+        "tools": ["vault_search", "ask_vault"],
         "includes": []
     },
     


### PR DESCRIPTION
## Summary
- Add native vault_search and ask_vault tools for the local development ideas vault
- Register a vault toolset and include it in Hermes core tools
- Add roadmap doc for native tools, MCP, RAG embeddings, and CodeGraph phases
- Add unit tests for markdown/jsonl/source search, path safety, limits, malformed JSONL, and ask_vault extractive output

## Test Plan
- python -m pytest tests/tools/test_vault_tool.py -q -o 'addopts='
- python -m pytest tests/test_toolsets.py tests/test_toolset_distributions.py tests/tools/test_vault_tool.py -q -o 'addopts='

Local validation: 29 vault tests passed; 71 combined toolset/vault tests passed.