### PR TITLE
fix: keep session title aligned with conversation

### DIFF
--- a/agent/title_generator.py
+++ b/agent/title_generator.py
@@ -20,10 +20,34 @@ FailureCallback = Callable[[str, BaseException], None]
 TitleCallback = Callable[[str], None]
 
 _TITLE_PROMPT = (
-    "Generate a short, descriptive title (3-7 words) for a conversation that starts with the "
-    "following exchange. The title should capture the main topic or intent. "
+    "Generate a short, descriptive title (3-7 words) for the current direction of this "
+    "conversation. Prefer the latest active topic over earlier setup/context. "
     "Return ONLY the title text, nothing else. No quotes, no punctuation at the end, no prefixes."
 )
+
+
+def _title_context(
+    user_message: str,
+    assistant_response: str,
+    conversation_history: Optional[list] = None,
+) -> str:
+    """Build a compact title-generation context from recent conversation turns."""
+    if conversation_history:
+        lines = []
+        for message in conversation_history[-8:]:
+            role = message.get("role")
+            if role not in {"user", "assistant"}:
+                continue
+            content = str(message.get("content") or "").strip()
+            if not content:
+                continue
+            lines.append(f"{role.title()}: {content[:500]}")
+        if lines:
+            return "\n\n".join(lines)[-2000:]
+
+    user_snippet = user_message[:500] if user_message else ""
+    assistant_snippet = assistant_response[:500] if assistant_response else ""
+    return f"User: {user_snippet}\n\nAssistant: {assistant_snippet}"
 
 
 def generate_title(
@@ -32,6 +56,7 @@ def generate_title(
     timeout: float = 30.0,
     failure_callback: Optional[FailureCallback] = None,
     main_runtime: dict = None,
+    conversation_history: Optional[list] = None,
 ) -> Optional[str]:
     """Generate a session title from the first exchange.
 
@@ -44,13 +69,11 @@ def generate_title(
     ``AIAgent._emit_auxiliary_failure`` so the user sees a warning instead
     of silently accumulating untitled sessions.
     """
-    # Truncate long messages to keep the request small
-    user_snippet = user_message[:500] if user_message else ""
-    assistant_snippet = assistant_response[:500] if assistant_response else ""
+    context = _title_context(user_message, assistant_response, conversation_history)
 
     messages = [
         {"role": "system", "content": _TITLE_PROMPT},
-        {"role": "user", "content": f"User: {user_snippet}\n\nAssistant: {assistant_snippet}"},
+        {"role": "user", "content": context},
     ]
 
     try:
@@ -92,13 +115,17 @@ def auto_title_session(
     failure_callback: Optional[FailureCallback] = None,
     main_runtime: dict = None,
     title_callback: Optional[TitleCallback] = None,
+    conversation_history: Optional[list] = None,
+    update_existing: bool = False,
 ) -> None:
-    """Generate and set a session title if one doesn't already exist.
+    """Generate and set a session title.
 
-    Called in a background thread after the first exchange completes.
+    Called in a background thread after a response completes. By default it
+    preserves an existing title; when ``update_existing`` is true it refreshes
+    the title from recent conversation context so the title follows topic drift.
     Silently skips if:
     - session_db is None
-    - session already has a title (user-set or previously auto-generated)
+    - session already has a title and update_existing is false
     - title generation fails
     """
     if not session_db or not session_id:
@@ -107,15 +134,21 @@ def auto_title_session(
     # Check if title already exists (user may have set one via /title before first response)
     try:
         existing = session_db.get_session_title(session_id)
-        if existing:
+        if existing and not update_existing:
             return
     except Exception:
         return
 
     title = generate_title(
-        user_message, assistant_response, failure_callback=failure_callback, main_runtime=main_runtime
+        user_message,
+        assistant_response,
+        failure_callback=failure_callback,
+        main_runtime=main_runtime,
+        conversation_history=conversation_history,
     )
     if not title:
+        return
+    if existing and title == existing:
         return
 
     try:
@@ -140,22 +173,17 @@ def maybe_auto_title(
     main_runtime: dict = None,
     title_callback: Optional[TitleCallback] = None,
 ) -> None:
-    """Fire-and-forget title generation after the first exchange.
+    """Fire-and-forget title generation after each successful exchange.
 
-    Only generates a title when:
-    - This appears to be the first user→assistant exchange
-    - No title is already set
+    Early turns create the initial session title. Later turns refresh it from
+    recent conversation context so the visible title follows the session's
+    current direction instead of staying frozen on the first exchange.
     """
     if not session_db or not session_id or not user_message or not assistant_response:
         return
 
-    # Count user messages in history to detect first exchange.
-    # conversation_history includes the exchange that just happened,
-    # so for a first exchange we expect exactly 1 user message
-    # (or 2 counting system). Be generous: generate on first 2 exchanges.
     user_msg_count = sum(1 for m in (conversation_history or []) if m.get("role") == "user")
-    if user_msg_count > 2:
-        return
+    update_existing = user_msg_count > 2
 
     thread = threading.Thread(
         target=auto_title_session,
@@ -164,6 +192,8 @@ def maybe_auto_title(
             "failure_callback": failure_callback,
             "main_runtime": main_runtime,
             "title_callback": title_callback,
+            "conversation_history": conversation_history,
+            "update_existing": update_existing,
         },
         daemon=True,
         name="auto-title",

--- a/cli.py
+++ b/cli.py
@@ -362,6 +362,12 @@ def load_cli_config() -> Dict[str, Any]:
             "busy_input_mode": "interrupt",
             "persistent_output": True,
             "persistent_output_max_lines": 200,
+            "session_title_bar": {
+                "enabled": True,
+                "format": "{title}",
+                "foreground": "#87CEEB",
+                "background": "#1a1a2e",
+            },
 
             "skin": "default",
         },
@@ -619,6 +625,42 @@ def load_cli_config() -> Dict[str, Any]:
 
 # Load configuration at module startup
 CLI_CONFIG = load_cli_config()
+
+
+_DEFAULT_SESSION_TITLE_BAR_CONFIG = {
+    "enabled": True,
+    "format": "{title}",
+    "foreground": "#87CEEB",
+    "background": "#1a1a2e",
+}
+
+
+def _session_title_bar_config(config: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    display = (config or CLI_CONFIG or {}).get("display", {})
+    raw = display.get("session_title_bar", {}) if isinstance(display, dict) else {}
+    if isinstance(raw, bool):
+        raw = {"enabled": raw}
+    if not isinstance(raw, dict):
+        raw = {}
+    merged = dict(_DEFAULT_SESSION_TITLE_BAR_CONFIG)
+    merged.update(raw)
+    return merged
+
+
+def _clean_session_title(value: str) -> str:
+    text = str(value or "")
+    text = re.sub(r"\x1b\].*?(?:\x07|\x1b\\)", "", text)
+    cleaned = re.sub(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]", "", text)
+    cleaned = re.sub(r"\s+", " ", cleaned).strip()
+    return cleaned[:100]
+
+
+def _default_session_title() -> str:
+    try:
+        cwd = Path.cwd()
+        return cwd.name or str(cwd)
+    except Exception:
+        return "Hermes"
 
 
 # Initialize centralized logging early — agent.log + errors.log in ~/.hermes/logs/.
@@ -2906,6 +2948,8 @@ class HermesCLI:
             timestamp_str = self.session_start.strftime("%Y%m%d_%H%M%S")
             short_uuid = uuid.uuid4().hex[:6]
             self.session_id = f"{timestamp_str}_{short_uuid}"
+        self._session_title: str = ""
+        self._apply_session_title_bar()
         
         # History file for persistent input recall across sessions
         self._history_file = _hermes_home / ".hermes_history"
@@ -3130,6 +3174,31 @@ class HermesCLI:
         if percent_used >= 50:
             return "class:status-bar-warn"
         return "class:status-bar-good"
+
+    def _get_session_title_bar_text(self, width: Optional[int] = None) -> str:
+        """Return the persistent in-terminal session title line."""
+        cfg = _session_title_bar_config(getattr(self, "config", None))
+        if not cfg.get("enabled", True):
+            return ""
+        title = _clean_session_title(getattr(self, "_session_title", ""))
+        if not title:
+            return ""
+        rendered = _clean_session_title(
+            str(cfg.get("format") or "{title}").replace("{title}", title)
+        )
+        if not rendered:
+            return ""
+        text = f" {rendered} "
+        if width is None:
+            width = self._get_tui_terminal_width()
+        trimmed = self._trim_status_bar_text(text, width)
+        return trimmed.ljust(max(0, width or 0))
+
+    def _get_session_title_bar_fragments(self, width: Optional[int] = None):
+        text = self._get_session_title_bar_text(width=width)
+        if not text:
+            return []
+        return [("class:session-title-bar", text)]
 
     @staticmethod
     def _compression_count_style(count: int) -> str:
@@ -3595,6 +3664,8 @@ class HermesCLI:
                 plain_text = "".join(text for _, text in frags)
                 trimmed = self._trim_status_bar_text(plain_text, width)
                 return [("class:status-bar", trimmed)]
+            if total_width < width:
+                frags.append(("class:status-bar", " " * (width - total_width)))
             return frags
         except Exception:
             return [("class:status-bar", f" {self._build_status_bar_text()} ")]
@@ -4760,6 +4831,25 @@ class HermesCLI:
 
         self._console_print()
 
+    def _apply_session_title_bar(self, title: Optional[str] = None) -> bool:
+        """Update the persistent in-terminal session title bar."""
+        chosen = title
+        if not chosen and self._session_db and getattr(self, "session_id", None):
+            try:
+                chosen = self._session_db.get_session_title(self.session_id)
+            except Exception:
+                chosen = None
+        cleaned = _clean_session_title(chosen or _default_session_title())
+        changed = cleaned != getattr(self, "_session_title", "")
+        self._session_title = cleaned
+        if changed:
+            self._invalidate()
+        return bool(cleaned)
+
+    def _on_auto_title(self, title: str) -> None:
+        """Callback used by background session-title generation."""
+        self._apply_session_title_bar(title)
+
     def _preload_resumed_session(self) -> bool:
         """Load a resumed session's history from the DB early (before first chat).
 
@@ -4801,6 +4891,7 @@ class HermesCLI:
             if resolved_meta:
                 session_meta = resolved_meta
 
+        self._apply_session_title_bar(session_meta.get("title"))
         restored = self._session_db.get_messages_as_conversation(self.session_id)
         if restored:
             restored = [m for m in restored if m.get("role") != "session_meta"]
@@ -6113,6 +6204,7 @@ class HermesCLI:
                 print(f"(^_^)v New session started: {title}")
             else:
                 print("(^_^)v New session started!")
+        self._apply_session_title_bar(title)
 
     def _handle_handoff_command(self, cmd_original: str) -> bool:
         """Handle ``/handoff <platform>`` — transfer this CLI session to a gateway platform.
@@ -6367,6 +6459,7 @@ class HermesCLI:
                 pass
 
         title_part = f" \"{session_meta['title']}\"" if session_meta.get("title") else ""
+        self._apply_session_title_bar(session_meta.get("title"))
         msg_count = len([m for m in self.conversation_history if m.get("role") == "user"])
         if self.conversation_history:
             _cprint(
@@ -7945,6 +8038,7 @@ class HermesCLI:
                             # Session exists in DB — set title directly
                             try:
                                 if self._session_db.set_session_title(self.session_id, new_title):
+                                    self._apply_session_title_bar(new_title)
                                     _cprint(f"  Session title set: {new_title}")
                                 else:
                                     _cprint("  Session not found in database.")
@@ -7958,6 +8052,7 @@ class HermesCLI:
                                 _cprint(f"  Title '{new_title}' is already in use by session {existing['id']}")
                             else:
                                 self._pending_title = new_title
+                                self._apply_session_title_bar(new_title)
                                 _cprint(f"  Session title queued: {new_title} (will be saved on first message)")
                     else:
                         from hermes_state import format_session_db_unavailable
@@ -11411,6 +11506,7 @@ class HermesCLI:
                             "api_key": self.api_key,
                             "api_mode": self.api_mode,
                         },
+                        title_callback=self._on_auto_title,
                     )
                 except Exception:
                     pass
@@ -11728,6 +11824,14 @@ class HermesCLI:
             style_dict.update(get_prompt_toolkit_style_overrides())
         except Exception:
             pass
+        try:
+            title_cfg = _session_title_bar_config(getattr(self, "config", None))
+            fg = str(title_cfg.get("foreground") or "#87CEEB").strip()
+            bg = str(title_cfg.get("background") or "#1a1a2e").strip()
+            if fg and bg:
+                style_dict["session-title-bar"] = f"bg:{bg} {fg}"
+        except Exception:
+            pass
         # Light-mode remap on the style strings.  Each value is a pt
         # style string like "bg:#1a1a2e #C0C0C0 bold" — split on space,
         # rewrite any "#XXX" tokens (including "bg:#XXX") through the
@@ -11805,6 +11909,7 @@ class HermesCLI:
         spinner_widget=None,
         spacer,
         status_bar,
+        session_title_bar,
         input_rule_top,
         image_bar,
         input_area,
@@ -11831,6 +11936,7 @@ class HermesCLI:
                 spacer,
                 *self._get_extra_tui_widgets(),
                 status_bar,
+                session_title_bar,
                 input_rule_top,
                 image_bar,
                 input_area,
@@ -13585,6 +13691,19 @@ class HermesCLI:
             ),
         )
 
+        session_title_bar = ConditionalContainer(
+            Window(
+                content=FormattedTextControl(lambda: cli_ref._get_session_title_bar_fragments()),
+                height=1,
+                wrap_lines=False,
+            ),
+            filter=Condition(
+                lambda: cli_ref._status_bar_visible
+                and bool(cli_ref._get_session_title_bar_fragments())
+                and not getattr(cli_ref, "_status_bar_suppressed_after_resize", False)
+            ),
+        )
+
         # Allow wrapper CLIs to register extra keybindings.
         self._register_extra_tui_keybindings(kb, input_area=input_area)
 
@@ -13605,6 +13724,7 @@ class HermesCLI:
                     spinner_widget=spinner_widget,
                     spacer=spacer,
                     status_bar=status_bar,
+                    session_title_bar=session_title_bar,
                     input_rule_top=input_rule_top,
                     image_bar=image_bar,
                     input_area=input_area,
@@ -13635,6 +13755,7 @@ class HermesCLI:
             'status-bar-bad': 'bg:#1a1a2e #FF8C00 bold',
             'status-bar-critical': 'bg:#1a1a2e #FF6B6B bold',
             'status-bar-yolo': 'bg:#1a1a2e #FF4444 bold',
+            'session-title-bar': 'bg:#111827 #87CEEB',
             # Bronze horizontal rules around the input area
             'input-rule': '#CD7F32',
             # Clipboard image attachment badges

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1025,6 +1025,12 @@ DEFAULT_CONFIG = {
         "persistent_output": True,
         "persistent_output_max_lines": 200,
         "inline_diffs": True,     # Show inline diff previews for write actions (write_file, patch, skill_manage)
+        "session_title_bar": {
+            "enabled": True,      # Show persistent session title inside the interactive CLI
+            "format": "{title}",
+            "foreground": "#87CEEB",
+            "background": "#1a1a2e",
+        },
         # File-mutation verifier footer.  When true (default), the agent
         # appends a one-line advisory to its final response whenever a
         # write_file / patch call failed during the turn and was never

--- a/tests/agent/test_title_generator.py
+++ b/tests/agent/test_title_generator.py
@@ -163,8 +163,8 @@ class TestAutoTitleSession:
 class TestMaybeAutoTitle:
     """Tests for maybe_auto_title() — the fire-and-forget entry point."""
 
-    def test_skips_if_not_first_exchange(self):
-        """Should not fire for conversations with more than 2 user messages."""
+    def test_refreshes_after_topic_drift(self):
+        """Should refresh the title after later turns so it follows the session direction."""
         db = MagicMock()
         history = [
             {"role": "user", "content": "first"},
@@ -177,10 +177,19 @@ class TestMaybeAutoTitle:
 
         with patch("agent.title_generator.auto_title_session") as mock_auto:
             maybe_auto_title(db, "sess-1", "third", "response 3", history)
-            # Wait briefly for any thread to start
             import time
-            time.sleep(0.1)
-            mock_auto.assert_not_called()
+            time.sleep(0.3)
+            mock_auto.assert_called_once_with(
+                db,
+                "sess-1",
+                "third",
+                "response 3",
+                failure_callback=None,
+                main_runtime=None,
+                title_callback=None,
+                conversation_history=history,
+                update_existing=True,
+            )
 
     def test_fires_on_first_exchange(self):
         """Should fire a background thread for the first exchange."""
@@ -204,6 +213,8 @@ class TestMaybeAutoTitle:
                 failure_callback=None,
                 main_runtime=None,
                 title_callback=None,
+                conversation_history=history,
+                update_existing=False,
             )
 
     def test_forwards_failure_callback_to_worker(self):
@@ -230,6 +241,8 @@ class TestMaybeAutoTitle:
                 failure_callback=_cb,
                 main_runtime=None,
                 title_callback=None,
+                conversation_history=history,
+                update_existing=False,
             )
 
     def test_skips_if_no_response(self):

--- a/tests/cli/test_session_title_bar.py
+++ b/tests/cli/test_session_title_bar.py
@@ -1,0 +1,148 @@
+from unittest.mock import patch
+
+import cli
+
+
+BASE_CONFIG = {
+    "display": {
+        "session_title_bar": {
+            "enabled": True,
+            "format": "{title}",
+            "foreground": "#87CEEB",
+            "background": "#1a1a2e",
+        }
+    }
+}
+
+
+def _make_cli():
+    cli_obj = object.__new__(cli.HermesCLI)
+    cli_obj.config = BASE_CONFIG
+    cli_obj.session_id = "test-session"
+    cli_obj._session_db = None
+    cli_obj._app = None
+    cli_obj._session_title = ""
+    return cli_obj
+
+
+def test_session_title_bar_config_defaults_enabled():
+    cfg = cli._session_title_bar_config({"display": {}})
+
+    assert cfg["enabled"] is True
+    assert cfg["format"] == "{title}"
+    assert cfg["foreground"] == "#87CEEB"
+    assert cfg["background"] == "#1a1a2e"
+
+
+def test_session_title_bar_sanitizes_control_sequences():
+    assert cli._clean_session_title("Bad\033]0;Injected\007\nTitle") == "Bad Title"
+
+
+def test_session_title_bar_renders_current_title_fragments():
+    cli_obj = _make_cli()
+    cli_obj._session_title = "Builder Ledger"
+
+    fragments = cli_obj._get_session_title_bar_fragments(width=80)
+    text = "".join(part for _style, part in fragments)
+
+    assert text == " Builder Ledger ".ljust(80)
+    assert len(text) == 80
+    assert fragments[0][0] == "class:session-title-bar"
+
+
+def test_session_title_bar_trims_to_terminal_width():
+    cli_obj = _make_cli()
+    cli_obj._session_title = "A very long topic name that should not wrap the terminal chrome"
+
+    text = "".join(part for _style, part in cli_obj._get_session_title_bar_fragments(width=32))
+
+    assert len(text) == 32
+    assert text.rstrip().endswith("...")
+
+
+def test_session_title_bar_style_uses_configured_colors():
+    cli_obj = _make_cli()
+    cli_obj.config = {
+        "display": {
+            "session_title_bar": {
+                "enabled": True,
+                "foreground": "#FFD700",
+                "background": "#111827",
+            }
+        }
+    }
+    cli_obj._tui_style_base = {"session-title-bar": "bg:#1a1a2e #87CEEB"}
+
+    styles = cli_obj._build_tui_style_dict()
+
+    assert styles["session-title-bar"] == "bg:#111827 #FFD700"
+
+
+def test_session_title_bar_can_be_disabled():
+    cli_obj = _make_cli()
+    cli_obj.config = {"display": {"session_title_bar": {"enabled": False}}}
+    cli_obj._session_title = "Hidden"
+
+    assert cli_obj._get_session_title_bar_fragments(width=80) == []
+
+
+def test_title_command_updates_in_terminal_session_title(monkeypatch):
+    clean_config = {
+        "model": {"default": "test-model", "provider": "auto", "base_url": ""},
+        "display": {
+            "compact": False,
+            "tool_progress": "off",
+            "resume_display": "full",
+            "session_title_bar": {
+                "enabled": True,
+                "format": "{title}",
+            },
+        },
+        "agent": {},
+        "terminal": {"env_type": "local"},
+    }
+
+    with (
+        patch("cli.get_tool_definitions", return_value=[]),
+        patch.dict(cli.__dict__, {"CLI_CONFIG": clean_config}),
+    ):
+        cli_obj = cli.HermesCLI()
+        cli_obj._session_db.create_session(session_id=cli_obj.session_id, source="cli")
+        cli_obj.process_command("/title Builder Ledger")
+
+    assert cli_obj._session_title == "Builder Ledger"
+
+
+def test_auto_title_callback_updates_in_terminal_session_title():
+    cli_obj = _make_cli()
+
+    cli.HermesCLI._on_auto_title(cli_obj, "Server Cleanup")
+
+    assert cli_obj._session_title == "Server Cleanup"
+
+
+def test_status_bar_pads_to_terminal_width_for_uniform_chrome(monkeypatch):
+    cli_obj = _make_cli()
+    cli_obj._status_bar_visible = True
+    monkeypatch.setattr(cli_obj, "_get_tui_terminal_width", lambda: 80)
+    monkeypatch.setattr(
+        cli_obj,
+        "_get_status_bar_snapshot",
+        lambda: {
+            "model_short": "gpt-test",
+            "duration": "1m",
+            "context_percent": 42,
+            "context_length": 100000,
+            "context_tokens": 42000,
+            "compressions": 0,
+            "active_background_tasks": 0,
+            "prompt_elapsed": "⏲ 0s",
+        },
+    )
+
+    fragments = cli_obj._get_status_bar_fragments()
+    text = "".join(part for _style, part in fragments)
+
+    assert len(text) == 80
+    assert fragments[-1][0] == "class:status-bar"
+    assert fragments[-1][1].isspace()


### PR DESCRIPTION
## Summary
- Refreshes auto-generated session titles on later successful turns so titles follow the session's current direction instead of staying fixed on the first exchange.
- Uses recent conversation context for title generation, with a prompt that prefers the latest active topic.
- Adds session title bar defaults and focused regression coverage for both title refresh behavior and title bar rendering.

## Test Plan
- uv run python -m pytest tests/agent/test_title_generator.py tests/cli/test_session_title_bar.py -q -o 'addopts='