### PR TITLE
fix(azure-foundry): surface Bitwarden source label in API key confirmation

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -3938,7 +3938,9 @@ def _model_flow_azure_foundry(config, current_model=""):
     if current_auth_mode == "entra_id":
         print(f"  Current auth mode: Microsoft Entra ID (keyless)")
     elif current_api_key:
-        print(f"  Current auth mode: API key ({current_api_key[:8]}...)")
+        from hermes_cli.env_loader import format_secret_source_suffix
+        _bw = format_secret_source_suffix("AZURE_FOUNDRY_API_KEY")
+        print(f"  Current auth mode: API key ({current_api_key[:8]}...){_bw}")
     print()
 
     # ── Step 1: endpoint URL ─────────────────────────────────────────


### PR DESCRIPTION
## Summary

`_model_flow_azure_foundry` showed the current API key prefix with no indication of whether it came from Bitwarden Secrets Manager or a plain `.env` file.

**Before:**
```
  Current auth mode: API key (sk-az123...)
```

**After (when AZURE_FOUNDRY_API_KEY was injected by BSM):**
```
  Current auth mode: API key (sk-az123...) (from Bitwarden)
```

Every sibling credential-display path already calls `format_secret_source_suffix`:
- `_prompt_api_key` (generic key providers) ✓
- `_model_flow_bedrock_api_key` ✓
- `_model_flow_anthropic` ✓
- `_model_flow_copilot` (GITHUB_TOKEN / GH_TOKEN paths) ✓

This brings `_model_flow_azure_foundry` to parity with all of the above.

## Change

```python
# hermes_cli/main.py — _model_flow_azure_foundry
elif current_api_key:
+    from hermes_cli.env_loader import format_secret_source_suffix
+    _bw = format_secret_source_suffix("AZURE_FOUNDRY_API_KEY")
-    print(f"  Current auth mode: API key ({current_api_key[:8]}...)")
+    print(f"  Current auth mode: API key ({current_api_key[:8]}...){_bw}")
```

1 file, 2 lines added, 1 line removed. No behavior change when BSM is not in use (`format_secret_source_suffix` returns `""` when the var is not in `_SECRET_SOURCES`).

## Test plan

- [ ] Run `hermes model` → Azure Foundry with `AZURE_FOUNDRY_API_KEY` set via BSM → confirmation line shows `(from Bitwarden)`
- [ ] Run `hermes model` → Azure Foundry with key set in `.env` only → no suffix (existing behavior preserved)
- [ ] Run `hermes model` → Azure Foundry with `auth_mode: entra_id` → Entra ID branch unaffected