### PR TITLE
fix(gateway): echo Telegram voice transcripts

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -222,6 +222,36 @@ def _sanitize_gateway_final_response(platform: Any, text: str) -> str:
     return redacted
 
 
+_VOICE_TRANSCRIPT_PREFIX_MARKERS = (
+    "🎙️ You said:",
+    "🎙️ You said: ",
+)
+
+
+def _format_voice_transcript_echo(transcripts: List[str]) -> str:
+    """Build the user-visible Telegram voice transcript audit block."""
+    clean = [str(t or "").strip() for t in transcripts if str(t or "").strip()]
+    if not clean:
+        return ""
+    transcript = "\n\n".join(clean)
+    if "\n" in transcript or len(transcript) > 180:
+        return f'🎙️ You said:\n"{transcript}"'
+    return f'🎙️ You said: "{transcript}"'
+
+
+def _prefix_voice_transcript_echo(response: str, transcripts: List[str]) -> str:
+    """Prefix a final reply with the Telegram voice transcript, without duplicates."""
+    if not response:
+        return response
+    body = str(response).lstrip()
+    if body.startswith(_VOICE_TRANSCRIPT_PREFIX_MARKERS):
+        return response
+    prefix = _format_voice_transcript_echo(transcripts)
+    if not prefix:
+        return response
+    return f"{prefix}\n\n{response}"
+
+
 def _prepare_gateway_status_message(platform: Any, event_type: str, message: str) -> Optional[str]:
     """Filter/sanitize agent status callbacks before platform delivery."""
     text = str(message or "").strip()
@@ -1478,6 +1508,7 @@ class GatewayRunner:
         # preserve the queue.
         self._queued_events: Dict[str, List[MessageEvent]] = {}
         self._pending_native_image_paths_by_session: Dict[str, List[str]] = {}
+        self._voice_transcript_echo_by_session: Dict[str, List[str]] = {}
         self._busy_ack_ts: Dict[str, float] = {}  # last busy-ack timestamp per session (debounce)
         self._session_run_generation: Dict[str, int] = {}
         # LRU cache of live SessionSources keyed by session_key. Used by
@@ -7576,6 +7607,9 @@ class GatewayRunner:
         # Reset only this session's per-call buffer; other sessions may be
         # concurrently preparing multimodal turns on the same runner.
         self._consume_pending_native_image_paths(session_key)
+        voice_transcript_cache = getattr(self, "_voice_transcript_echo_by_session", None)
+        if voice_transcript_cache is not None:
+            voice_transcript_cache.pop(session_key, None)
 
         _is_shared_multi_user = is_shared_multi_user_session(
             source,
@@ -7638,10 +7672,22 @@ class GatewayRunner:
                     )
 
             if audio_paths:
-                message_text = await self._enrich_message_with_transcription(
+                _enriched_voice = await self._enrich_message_with_transcription(
                     message_text,
                     audio_paths,
+                    return_transcripts=True,
                 )
+                message_text, voice_transcripts = _enriched_voice
+                if (
+                    source.platform == Platform.TELEGRAM
+                    and event.message_type == MessageType.VOICE
+                    and voice_transcripts
+                ):
+                    transcript_cache = getattr(self, "_voice_transcript_echo_by_session", None)
+                    if transcript_cache is None:
+                        transcript_cache = {}
+                        self._voice_transcript_echo_by_session = transcript_cache
+                    transcript_cache[session_key] = list(voice_transcripts)
                 _stt_fail_markers = (
                     "No STT provider",
                     "STT is disabled",
@@ -8767,6 +8813,16 @@ class GatewayRunner:
             _already_sent = bool(agent_result.get("already_sent"))
             if self._should_send_voice_reply(event, response, agent_messages, already_sent=_already_sent):
                 await self._send_voice_reply(event, response)
+
+            if (
+                response
+                and not _already_sent
+                and source.platform == Platform.TELEGRAM
+                and event.message_type == MessageType.VOICE
+            ):
+                transcript_cache = getattr(self, "_voice_transcript_echo_by_session", {}) or {}
+                voice_transcripts = transcript_cache.pop(session_key, [])
+                response = _prefix_voice_transcript_echo(response, voice_transcripts)
 
             # If streaming already delivered the response, extract and
             # deliver any MEDIA: files before returning None.  Streaming
@@ -14259,7 +14315,9 @@ class GatewayRunner:
         self,
         user_text: str,
         audio_paths: List[str],
-    ) -> str:
+        *,
+        return_transcripts: bool = False,
+    ):
         """
         Auto-transcribe user voice/audio messages using the configured STT provider
         and prepend the transcript to the message text.
@@ -14271,6 +14329,13 @@ class GatewayRunner:
         Returns:
             The enriched message string with transcriptions prepended.
         """
+        captured_transcripts: List[str] = []
+
+        def _finish(text: str):
+            if return_transcripts:
+                return text, captured_transcripts
+            return text
+
         if not getattr(self.config, "stt_enabled", True):
             notes = []
             for path in audio_paths:
@@ -14283,14 +14348,14 @@ class GatewayRunner:
                 else:
                     notes.append(f"[The user sent a voice message: {abs_path}]")
             if not notes:
-                return user_text
+                return _finish(user_text)
             prefix = "\n\n".join(notes)
             _placeholder = "(The user sent a message with no text content)"
             if user_text and user_text.strip() == _placeholder:
-                return prefix
+                return _finish(prefix)
             if user_text:
-                return f"{prefix}\n\n{user_text}"
-            return prefix
+                return _finish(f"{prefix}\n\n{user_text}")
+            return _finish(prefix)
 
         from tools.transcription_tools import transcribe_audio
 
@@ -14301,6 +14366,7 @@ class GatewayRunner:
                 result = await asyncio.to_thread(transcribe_audio, path)
                 if result["success"]:
                     transcript = result["transcript"]
+                    captured_transcripts.append(transcript)
                     enriched_parts.append(
                         f'[The user sent a voice message~ '
                         f'Here\'s what they said: "{transcript}"]'
@@ -14343,11 +14409,11 @@ class GatewayRunner:
             # when we successfully transcribed the audio — it's redundant.
             _placeholder = "(The user sent a message with no text content)"
             if user_text and user_text.strip() == _placeholder:
-                return prefix
+                return _finish(prefix)
             if user_text:
-                return f"{prefix}\n\n{user_text}"
-            return prefix
-        return user_text
+                return _finish(f"{prefix}\n\n{user_text}")
+            return _finish(prefix)
+        return _finish(user_text)
 
     def _build_process_event_source(self, evt: dict):
         """Resolve the canonical source for a synthetic background-process event.

--- a/tests/gateway/test_stt_config.py
+++ b/tests/gateway/test_stt_config.py
@@ -140,3 +140,58 @@ async def test_prepare_inbound_message_text_transcribes_queued_voice_event():
     assert result is not None
     assert "queued voice transcript" in result
     assert "voice message" in result.lower()
+    assert runner._voice_transcript_echo_by_session["agent:main:telegram:dm:123"] == [
+        "queued voice transcript"
+    ]
+
+
+def test_voice_transcript_echo_prefixes_final_reply_once():
+    from gateway.run import _prefix_voice_transcript_echo
+
+    result = _prefix_voice_transcript_echo(
+        "Done — I wired it in.",
+        ["Yeah, let's definitely wire this into the durable version."],
+    )
+
+    assert result.startswith(
+        "🎙️ You said: \"Yeah, let's definitely wire this into the durable version.\""
+    )
+    assert result.endswith("Done — I wired it in.")
+
+    assert _prefix_voice_transcript_echo(result, ["duplicate"]) == result
+
+
+@pytest.mark.asyncio
+async def test_prepare_inbound_message_text_does_not_echo_audio_attachment_transcript():
+    from gateway.run import GatewayRunner
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner.config = GatewayConfig(stt_enabled=True)
+    runner.adapters = {}
+    runner._model = "test-model"
+    runner._base_url = ""
+    runner._has_setup_skill = lambda: False
+    runner._voice_transcript_echo_by_session = {}
+
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="123",
+        chat_type="dm",
+    )
+    event = MessageEvent(
+        text="",
+        message_type=MessageType.AUDIO,
+        source=source,
+        media_urls=["/tmp/audio-file.mp3"],
+        media_types=["audio/mpeg"],
+    )
+
+    result = await runner._prepare_inbound_message_text(
+        event=event,
+        source=source,
+        history=[],
+    )
+
+    assert result is not None
+    assert "audio file attachment" in result
+    assert runner._voice_transcript_echo_by_session == {}


### PR DESCRIPTION
## Summary
- capture successful Telegram voice STT transcripts as structured per-session metadata
- prefix final non-streamed Telegram voice replies with the user-visible transcript audit block
- keep audio file attachments unchanged and guard against duplicate transcript prefixes

## Test Plan
- python -m pytest tests/gateway/test_stt_config.py tests/gateway/test_telegram_audio_vs_voice.py -q
- python -m py_compile gateway/run.py