### PR TITLE
fix(copilot): include COPILOT_GITHUB_TOKEN in Bitwarden source label check

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -4664,7 +4664,7 @@ def _model_flow_copilot(config, current_model=""):
         api_key = creds.get("api_key", "")
         source = creds.get("source", "")
     else:
-        if source in {"GITHUB_TOKEN", "GH_TOKEN"}:
+        if source in {"COPILOT_GITHUB_TOKEN", "GITHUB_TOKEN", "GH_TOKEN"}:
             from hermes_cli.env_loader import format_secret_source_suffix
             bw_suffix = format_secret_source_suffix(source)
             print(f"  GitHub token: {api_key[:8]}... ✓ ({source}{bw_suffix})")


### PR DESCRIPTION
## Summary

`_model_flow_copilot` shows `(from Bitwarden)` when the GitHub token came from Bitwarden Secrets Manager — but only for `GH_TOKEN` and `GITHUB_TOKEN`. `COPILOT_GITHUB_TOKEN`, the **dedicated, highest-priority** Copilot token var (first entry in `COPILOT_ENV_VARS`), was excluded and fell through to the bare `✓` branch.

**Before (COPILOT_GITHUB_TOKEN injected by BSM):**
```
  GitHub token: ✓
```

**After:**
```
  GitHub token: ghp_abc1... ✓ (COPILOT_GITHUB_TOKEN) (from Bitwarden)
```

## Root cause

`COPILOT_ENV_VARS = ("COPILOT_GITHUB_TOKEN", "GH_TOKEN", "GITHUB_TOKEN")` — the primary var is `COPILOT_GITHUB_TOKEN`, yet the set check only covered the two lower-priority aliases:

```python
# before
if source in {"GITHUB_TOKEN", "GH_TOKEN"}:
# after
if source in {"COPILOT_GITHUB_TOKEN", "GITHUB_TOKEN", "GH_TOKEN"}:
```

## Change

1 file, 1 line changed. No behavior change when BSM is not in use.

The `gh auth token` branch and the final `else` branch (credential pool fallback) are untouched — those sources cannot originate from BSM.

## Test plan

- [ ] Set `COPILOT_GITHUB_TOKEN` via Bitwarden Secrets Manager, run `hermes model` → Copilot → token line shows `(COPILOT_GITHUB_TOKEN) (from Bitwarden)`
- [ ] Set `GH_TOKEN` via BSM → still shows `(GH_TOKEN) (from Bitwarden)` (existing behavior preserved)
- [ ] Token from `gh auth token` → unchanged: `GitHub token: ✓ (from \`gh auth token\`)`
- [ ] Token set in `.env` only → no Bitwarden suffix (existing behavior preserved)