### PR TITLE
feat(latens): add slice 1 provenance foundation

### DIFF
--- a/hermes-mission/latens/slice-1/README.md
+++ b/hermes-mission/latens/slice-1/README.md
@@ -1,0 +1,56 @@
+# LATENS Slice 1 Site Foundation
+
+Issue: chipoto69/latens#2
+Task: t_24194b8d
+Status: draft implementation artifact, local-only until founder approval
+
+## Purpose
+
+Slice 1 establishes the minimum public site spine for LATENS, FERROGLYPH, and OZVENA before any generated artifacts are published. It defines stable routes, lexicon canonical URLs, and provenance metadata so later editions can be cited, reviewed, redacted, and approved without changing their public URLs.
+
+## Site foundation
+
+The site is intentionally static-first for Slice 1. A later app can render these manifests as pages, but the first durable contract is the route and provenance data in this directory.
+
+Top-level durable routes:
+
+| Route | Owner concept | Public purpose | Private data allowed? |
+|---|---|---|---|
+| `/` | LATENS | Entry page explaining the project scope and review gates | No |
+| `/latens` | LATENS | Public index of LATENS editions/artifacts | No |
+| `/ferroglyph` | FERROGLYPH | Public index of FERROGLYPH editions/artifacts | No |
+| `/ozvena` | OZVENA | Public index of OZVENA editions/artifacts | No |
+| `/lexicon` | Shared | Human-readable glossary index | No |
+| `/lexicon/{term}` | Shared | Canonical definition page for a kickoff term | No |
+| `/artifacts/{artifact_id}` | Shared | Public artifact landing page with sanitized provenance | No |
+| `/editions/{edition_id}` | Shared | Public edition landing page linking approved artifacts | No |
+| `/provenance/{run_id}` | Shared | Public provenance view for a run after approval/redaction | No |
+| `/review/{run_id}` | Internal | Private review packet before approval | Yes; never public |
+
+## Rendering contract
+
+1. Public pages only read `packet_scope: "public"` packets and the top-level `public` object from `provenance.schema.json`.
+2. Public provenance packets must not include the top-level `private_review` object. Review pages may read `private_review` fields only from `packet_scope: "internal_review"` packets, must require local/operator access, and must not be indexed or deployed without a separate approval gate.
+3. Each public artifact page must link to:
+   - its edition route,
+   - its canonical concept route (`/latens`, `/ferroglyph`, or `/ozvena`),
+   - every lexicon term referenced by the artifact,
+   - its sanitized public provenance route.
+4. Every canonical URL must be lowercase, hyphenated, and stable. Renames require redirects, not replacement.
+5. Claims must remain descriptive. No medical, financial, legal, or scientific-performance claims are allowed unless a source reference and approval explicitly support them.
+
+## Files in this slice
+
+- `site-routes.json` — durable public/private route manifest.
+- `lexicon-routes.json` — kickoff term to canonical URL map.
+- `provenance.schema.json` — JSON Schema for public/private provenance packets.
+- `provenance-example.public.json` — example sanitized public packet.
+- `qa-security-checklist.md` — gate evidence checklist for QA/security review.
+- `../../../tests/hermes_mission/test_latens_slice1_artifacts.py` — validation tests for the manifests and schema.
+
+## Explicit non-goals
+
+- No deploy or publish.
+- No push or PR publish without Rudy's explicit YES.
+- No account creation, credential changes, or production dispatch.
+- No use of secrets or private source material in public files.

--- a/hermes-mission/latens/slice-1/lexicon-routes.json
+++ b/hermes-mission/latens/slice-1/lexicon-routes.json
@@ -1,0 +1,91 @@
+{
+  "version": "slice-1",
+  "issue": "chipoto69/latens#2",
+  "canonical_host_policy": "host-agnostic-relative-paths-until-founder-approval",
+  "terms": [
+    {
+      "term": "LATENS",
+      "slug": "latens",
+      "canonical_path": "/lexicon/latens",
+      "concept_route": "/latens",
+      "definition": "The parent public corpus/site spine that holds reviewed editions, artifacts, lexicon entries, and provenance packets."
+    },
+    {
+      "term": "FERROGLYPH",
+      "slug": "ferroglyph",
+      "canonical_path": "/lexicon/ferroglyph",
+      "concept_route": "/ferroglyph",
+      "definition": "A LATENS concept lane reserved for FERROGLYPH editions and artifacts."
+    },
+    {
+      "term": "OZVENA",
+      "slug": "ozvena",
+      "canonical_path": "/lexicon/ozvena",
+      "concept_route": "/ozvena",
+      "definition": "A LATENS concept lane reserved for OZVENA editions and artifacts."
+    },
+    {
+      "term": "provenance spine",
+      "slug": "provenance-spine",
+      "canonical_path": "/lexicon/provenance-spine",
+      "concept_route": "/provenance/{run_id}",
+      "definition": "The required metadata chain that lets a public artifact be traced to its model, prompt seed, run, sources, approvals, and redaction boundary."
+    },
+    {
+      "term": "emotion signature",
+      "slug": "emotion-signature",
+      "canonical_path": "/lexicon/emotion-signature",
+      "concept_route": "/provenance/{run_id}",
+      "definition": "A reviewed descriptive tag set for the artifact's intended affective profile; it is not a psychological diagnosis or user inference."
+    },
+    {
+      "term": "prompt seed",
+      "slug": "prompt-seed",
+      "canonical_path": "/lexicon/prompt-seed",
+      "concept_route": "/provenance/{run_id}",
+      "definition": "The stable, redacted prompt descriptor used to reproduce or audit the generation without exposing private notes or credentials."
+    },
+    {
+      "term": "run id",
+      "slug": "run-id",
+      "canonical_path": "/lexicon/run-id",
+      "concept_route": "/provenance/{run_id}",
+      "definition": "The durable identifier for one generation or editorial run."
+    },
+    {
+      "term": "edition id",
+      "slug": "edition-id",
+      "canonical_path": "/lexicon/edition-id",
+      "concept_route": "/editions/{edition_id}",
+      "definition": "The durable identifier for an approved release grouping one or more public artifacts."
+    },
+    {
+      "term": "artifact id",
+      "slug": "artifact-id",
+      "canonical_path": "/lexicon/artifact-id",
+      "concept_route": "/artifacts/{artifact_id}",
+      "definition": "The durable identifier for one public artifact within an edition."
+    },
+    {
+      "term": "source refs",
+      "slug": "source-refs",
+      "canonical_path": "/lexicon/source-refs",
+      "concept_route": "/provenance/{run_id}",
+      "definition": "The reviewed references that support public context or claims. Private notes are represented by redacted descriptors only."
+    },
+    {
+      "term": "approval gate",
+      "slug": "approval-gate",
+      "canonical_path": "/lexicon/approval-gate",
+      "concept_route": "/review/{run_id}",
+      "definition": "The documented human review step required before public publication, push, merge, deploy, or production dispatch."
+    },
+    {
+      "term": "public/private split",
+      "slug": "public-private-split",
+      "canonical_path": "/lexicon/public-private-split",
+      "concept_route": "/provenance/{run_id}",
+      "definition": "The rule that public pages may expose only sanitized metadata while private review packets may contain restricted operational context."
+    }
+  ]
+}

--- a/hermes-mission/latens/slice-1/provenance-example.public.json
+++ b/hermes-mission/latens/slice-1/provenance-example.public.json
@@ -1,0 +1,82 @@
+{
+  "schema_version": "slice-1",
+  "packet_scope": "public",
+  "public": {
+    "model": {
+      "provider": "example-provider",
+      "name": "example-model",
+      "version": "redacted-or-pinned-version"
+    },
+    "prompt_seed": {
+      "id": "prompt-slice-1-example",
+      "redacted_summary": "Public-safe prompt descriptor for a LATENS foundation artifact. Raw prompts stay in private review storage.",
+      "hash": "sha256:0000000000000000000000000000000000000000000000000000000000000000"
+    },
+    "run_id": "run-slice-1-example",
+    "emotion_signature": {
+      "labels": ["measured", "archival", "speculative"],
+      "intensity": "low",
+      "review_note": "Descriptive editorial tags only; not a user inference, diagnosis, or safety classification."
+    },
+    "source_refs": [
+      {
+        "id": "src-github-issue-2",
+        "kind": "internal_redacted",
+        "citation": "chipoto69/latens issue #2 acceptance criteria, redacted for public packet until repository access is approved.",
+        "public_url": null,
+        "claim_scope": "Supports route/provenance requirements only; does not support external factual claims."
+      }
+    ],
+    "edition_id": "edition-slice-1-example",
+    "artifact_id": "artifact-site-foundation-example",
+    "approvals": {
+      "pm": {
+        "status": "pending",
+        "reviewer": null,
+        "reviewed_at": null,
+        "notes": "PM gate required before publication."
+      },
+      "qa": {
+        "status": "pending",
+        "reviewer": null,
+        "reviewed_at": null,
+        "notes": "QA must verify links, accessibility, mobile behavior, and console cleanliness."
+      },
+      "security": {
+        "status": "pending",
+        "reviewer": null,
+        "reviewed_at": null,
+        "notes": "Security must verify no public data leakage, unsafe claims, or credential exposure."
+      },
+      "founder_publication": {
+        "status": "pending",
+        "reviewer": null,
+        "reviewed_at": null,
+        "notes": "Rudy explicit YES required before push, publish, deploy, merge, or production dispatch."
+      }
+    },
+    "public_private_split": {
+      "public_fields": [
+        "schema_version",
+        "packet_scope",
+        "public.model",
+        "public.prompt_seed.id",
+        "public.prompt_seed.redacted_summary",
+        "public.prompt_seed.hash",
+        "public.run_id",
+        "public.emotion_signature",
+        "public.source_refs",
+        "public.edition_id",
+        "public.artifact_id",
+        "public.approvals",
+        "public.public_private_split.redaction_summary"
+      ],
+      "private_fields": [
+        "private_review.raw_prompt_ref",
+        "private_review.operator_notes_ref",
+        "private_review.credential_handling"
+      ],
+      "redaction_summary": "Public packet excludes the private_review object, raw prompts, operator notes, credentials, private repo context, and unapproved source material."
+    }
+  }
+}

--- a/hermes-mission/latens/slice-1/provenance.schema.json
+++ b/hermes-mission/latens/slice-1/provenance.schema.json
@@ -1,0 +1,163 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://latens.local/schemas/provenance.schema.json",
+  "title": "LATENS Slice 1 Provenance Packet",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "packet_scope",
+    "public"
+  ],
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "const": "slice-1"
+    },
+    "packet_scope": {
+      "type": "string",
+      "enum": ["public", "internal_review"]
+    },
+    "public": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "model",
+        "prompt_seed",
+        "run_id",
+        "emotion_signature",
+        "source_refs",
+        "edition_id",
+        "artifact_id",
+        "approvals",
+        "public_private_split"
+      ],
+      "properties": {
+        "model": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["provider", "name", "version"],
+          "properties": {
+            "provider": {"type": "string", "minLength": 1},
+            "name": {"type": "string", "minLength": 1},
+            "version": {"type": "string", "minLength": 1}
+          }
+        },
+        "prompt_seed": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["id", "redacted_summary", "hash"],
+          "properties": {
+            "id": {"type": "string", "pattern": "^prompt-[a-z0-9-]+$"},
+            "redacted_summary": {"type": "string", "minLength": 1},
+            "hash": {"type": "string", "pattern": "^sha256:[a-f0-9]{64}$"}
+          }
+        },
+        "run_id": {"type": "string", "pattern": "^run-[a-z0-9-]+$"},
+        "emotion_signature": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["labels", "intensity", "review_note"],
+          "properties": {
+            "labels": {
+              "type": "array",
+              "minItems": 1,
+              "items": {"type": "string", "minLength": 1},
+              "uniqueItems": true
+            },
+            "intensity": {"type": "string", "enum": ["low", "medium", "high"]},
+            "review_note": {"type": "string", "minLength": 1}
+          }
+        },
+        "source_refs": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["id", "kind", "citation", "public_url", "claim_scope"],
+            "properties": {
+              "id": {"type": "string", "pattern": "^src-[a-z0-9-]+$"},
+              "kind": {"type": "string", "enum": ["public_url", "book", "paper", "internal_redacted", "operator_note_redacted"]},
+              "citation": {"type": "string", "minLength": 1},
+              "public_url": {"type": ["string", "null"]},
+              "claim_scope": {"type": "string", "minLength": 1}
+            }
+          }
+        },
+        "edition_id": {"type": "string", "pattern": "^edition-[a-z0-9-]+$"},
+        "artifact_id": {"type": "string", "pattern": "^artifact-[a-z0-9-]+$"},
+        "approvals": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["pm", "qa", "security", "founder_publication"],
+          "properties": {
+            "pm": {"$ref": "#/$defs/approval"},
+            "qa": {"$ref": "#/$defs/approval"},
+            "security": {"$ref": "#/$defs/approval"},
+            "founder_publication": {"$ref": "#/$defs/approval"}
+          }
+        },
+        "public_private_split": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["public_fields", "private_fields", "redaction_summary"],
+          "properties": {
+            "public_fields": {
+              "type": "array",
+              "items": {"type": "string"},
+              "uniqueItems": true
+            },
+            "private_fields": {
+              "type": "array",
+              "items": {"type": "string"},
+              "uniqueItems": true
+            },
+            "redaction_summary": {"type": "string", "minLength": 1}
+          }
+        }
+      }
+    },
+    "private_review": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["access", "raw_prompt_ref", "operator_notes_ref", "credential_handling"],
+      "properties": {
+        "access": {"type": "string", "const": "internal-review-only"},
+        "raw_prompt_ref": {"type": "string", "minLength": 1},
+        "operator_notes_ref": {"type": "string", "minLength": 1},
+        "credential_handling": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["secrets_present", "notes"],
+          "properties": {
+            "secrets_present": {"type": "boolean", "const": false},
+            "notes": {"type": "string", "minLength": 1}
+          }
+        }
+      }
+    }
+  },
+  "allOf": [
+    {
+      "if": {"properties": {"packet_scope": {"const": "internal_review"}}},
+      "then": {"required": ["private_review"]}
+    },
+    {
+      "if": {"properties": {"packet_scope": {"const": "public"}}},
+      "then": {"not": {"required": ["private_review"]}}
+    }
+  ],
+  "$defs": {
+    "approval": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["status", "reviewer", "reviewed_at", "notes"],
+      "properties": {
+        "status": {"type": "string", "enum": ["pending", "approved", "blocked"]},
+        "reviewer": {"type": ["string", "null"]},
+        "reviewed_at": {"type": ["string", "null"], "format": "date-time"},
+        "notes": {"type": "string"}
+      }
+    }
+  }
+}

--- a/hermes-mission/latens/slice-1/qa-security-checklist.md
+++ b/hermes-mission/latens/slice-1/qa-security-checklist.md
@@ -1,0 +1,63 @@
+# LATENS Slice 1 QA and Security Checklist
+
+Issue: chipoto69/latens#2
+Task: t_24194b8d
+
+This checklist is the review gate for the Slice 1 site/provenance foundation. Each item is phrased as evidence QA/security can verify from local files before any push, PR publish, merge, deploy, or production dispatch.
+
+## Public-data leakage
+
+- [ ] Public route files contain only relative paths and public-safe descriptions.
+- [ ] Public provenance packets use `packet_scope: "public"` and expose only `schema_version`, `packet_scope`, and the `public` object.
+- [ ] Public provenance packets do not include the top-level `private_review` object.
+- [ ] Raw prompts, operator notes, private repo details, and credential context stay in internal-review-only packets or local review storage only.
+- [ ] No tokens, cookies, API keys, personal data, or private source bodies appear in committed artifacts.
+
+## Unsafe claims
+
+- [ ] Emotion signatures are described as editorial tags, not diagnoses or user inferences.
+- [ ] Source refs include `claim_scope` so public claims cannot exceed their cited support.
+- [ ] No medical, financial, legal, scientific-performance, or safety claims are present without approval notes and source refs.
+
+## Credential handling
+
+- [ ] Public examples omit `private_review`; internal-review packets set `private_review.credential_handling.secrets_present` to false before any approval.
+- [ ] No `.env`, key file, token, or generated credential is added by Slice 1.
+- [ ] Review routes are marked internal and are not public render targets.
+
+## Publish/deploy boundaries
+
+- [ ] Route policy states `deploy_requires_founder_yes: true`.
+- [ ] Founder publication approval is a required approval object and remains pending in examples.
+- [ ] No remote push, PR publish, merge, deploy, account creation, spend, credential change, or production dispatch occurred during implementation.
+
+## Accessibility
+
+- [ ] Route descriptions are human-readable and can become page headings/landmarks.
+- [ ] Lexicon definitions avoid image-only or color-only meaning.
+- [ ] Later renderers must expose each route with a semantic heading and link text matching the canonical term.
+
+## Mobile behavior
+
+- [ ] Routes are static/data-first and do not require hover, drag, wide tables, or desktop-only interactions.
+- [ ] Later renderers should treat tables as progressively enhanced content and keep lexicon pages readable at narrow widths.
+
+## Link integrity
+
+- [ ] Every lexicon `canonical_path` begins with `/lexicon/`.
+- [ ] Every lexicon `concept_route` exists as either a route manifest path or a documented route template.
+- [ ] Route manifest paths are unique.
+- [ ] Dynamic route templates use `{term_slug}`, `{artifact_id}`, `{edition_id}`, or `{run_id}` consistently.
+
+## Console cleanliness
+
+- [ ] Slice 1 adds only static manifests/docs/tests; there is no browser runtime code that can emit console errors.
+- [ ] When a renderer is added, QA must run a browser console pass before publication.
+
+## Local validation command
+
+Run from `/Users/rudlord/.hermes/hermes-agent`:
+
+```bash
+python3 -m pytest tests/hermes_mission/test_latens_slice1_artifacts.py -q
+```

--- a/hermes-mission/latens/slice-1/site-routes.json
+++ b/hermes-mission/latens/slice-1/site-routes.json
@@ -1,0 +1,92 @@
+{
+  "version": "slice-1",
+  "issue": "chipoto69/latens#2",
+  "route_policy": {
+    "canonical_urls": "lowercase-kebab-case",
+    "renames": "redirect-only-after-publication",
+    "public_default": false,
+    "deploy_requires_founder_yes": true
+  },
+  "routes": [
+    {
+      "path": "/",
+      "name": "Home",
+      "concept": "LATENS",
+      "audience": "public",
+      "data_scope": "public",
+      "description": "Entry page describing LATENS, FERROGLYPH, OZVENA, and the approval boundary."
+    },
+    {
+      "path": "/latens",
+      "name": "LATENS index",
+      "concept": "LATENS",
+      "audience": "public",
+      "data_scope": "public",
+      "description": "Canonical public index for LATENS editions and artifacts."
+    },
+    {
+      "path": "/ferroglyph",
+      "name": "FERROGLYPH index",
+      "concept": "FERROGLYPH",
+      "audience": "public",
+      "data_scope": "public",
+      "description": "Canonical public index for FERROGLYPH editions and artifacts."
+    },
+    {
+      "path": "/ozvena",
+      "name": "OZVENA index",
+      "concept": "OZVENA",
+      "audience": "public",
+      "data_scope": "public",
+      "description": "Canonical public index for OZVENA editions and artifacts."
+    },
+    {
+      "path": "/lexicon",
+      "name": "Lexicon",
+      "concept": "shared",
+      "audience": "public",
+      "data_scope": "public",
+      "description": "Index of durable kickoff-term definitions."
+    },
+    {
+      "path": "/lexicon/{term_slug}",
+      "name": "Lexicon term",
+      "concept": "shared",
+      "audience": "public",
+      "data_scope": "public",
+      "description": "Canonical glossary page for one kickoff term."
+    },
+    {
+      "path": "/artifacts/{artifact_id}",
+      "name": "Artifact",
+      "concept": "shared",
+      "audience": "public",
+      "data_scope": "public",
+      "description": "Approved public artifact page with sanitized provenance."
+    },
+    {
+      "path": "/editions/{edition_id}",
+      "name": "Edition",
+      "concept": "shared",
+      "audience": "public",
+      "data_scope": "public",
+      "description": "Approved public edition page aggregating artifact pages."
+    },
+    {
+      "path": "/provenance/{run_id}",
+      "name": "Public provenance",
+      "concept": "shared",
+      "audience": "public",
+      "data_scope": "public",
+      "description": "Sanitized provenance packet after redaction and approval."
+    },
+    {
+      "path": "/review/{run_id}",
+      "name": "Private review packet",
+      "concept": "shared",
+      "audience": "internal",
+      "data_scope": "private_review",
+      "description": "Local/internal review packet. Must not be deployed publicly."
+    }
+  ]
+}

--- a/tests/hermes_mission/test_latens_slice1_artifacts.py
+++ b/tests/hermes_mission/test_latens_slice1_artifacts.py
@@ -1,0 +1,114 @@
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SLICE = ROOT / "hermes-mission" / "latens" / "slice-1"
+
+
+def load_json(name: str):
+    with (SLICE / name).open(encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def test_required_slice_artifacts_exist():
+    expected = {
+        "README.md",
+        "site-routes.json",
+        "lexicon-routes.json",
+        "provenance.schema.json",
+        "provenance-example.public.json",
+        "qa-security-checklist.md",
+    }
+    assert expected <= {path.name for path in SLICE.iterdir()}
+
+
+def test_site_routes_are_unique_and_public_private_scoped():
+    manifest = load_json("site-routes.json")
+    paths = [route["path"] for route in manifest["routes"]]
+
+    assert len(paths) == len(set(paths))
+    assert manifest["route_policy"]["deploy_requires_founder_yes"] is True
+    assert "/review/{run_id}" in paths
+
+    for route in manifest["routes"]:
+        assert route["path"].startswith("/")
+        assert route["data_scope"] in {"public", "private_review"}
+        if route["audience"] == "public":
+            assert route["data_scope"] == "public"
+        if route["data_scope"] == "private_review":
+            assert route["audience"] == "internal"
+
+
+def test_lexicon_terms_map_to_canonical_urls_and_known_routes():
+    routes = {route["path"] for route in load_json("site-routes.json")["routes"]}
+    dynamic_routes = {"/provenance/{run_id}", "/review/{run_id}", "/editions/{edition_id}", "/artifacts/{artifact_id}"}
+    allowed_concept_routes = routes | dynamic_routes
+    lexicon = load_json("lexicon-routes.json")
+
+    terms = {entry["term"] for entry in lexicon["terms"]}
+    assert {"LATENS", "FERROGLYPH", "OZVENA", "provenance spine"} <= terms
+
+    slugs = [entry["slug"] for entry in lexicon["terms"]]
+    canonical_paths = [entry["canonical_path"] for entry in lexicon["terms"]]
+    assert len(slugs) == len(set(slugs))
+    assert len(canonical_paths) == len(set(canonical_paths))
+
+    for entry in lexicon["terms"]:
+        assert entry["canonical_path"] == f"/lexicon/{entry['slug']}"
+        assert entry["concept_route"] in allowed_concept_routes
+        assert entry["definition"].strip()
+
+
+def test_provenance_schema_covers_required_spine_fields_and_scopes():
+    schema = load_json("provenance.schema.json")
+    assert "packet_scope" in schema["required"]
+    assert set(schema["properties"]["packet_scope"]["enum"]) == {"public", "internal_review"}
+
+    public_required = set(schema["properties"]["public"]["required"])
+    assert {
+        "model",
+        "prompt_seed",
+        "run_id",
+        "emotion_signature",
+        "source_refs",
+        "edition_id",
+        "artifact_id",
+        "approvals",
+        "public_private_split",
+    } <= public_required
+
+    approvals_required = set(
+        schema["properties"]["public"]["properties"]["approvals"]["required"]
+    )
+    assert {"pm", "qa", "security", "founder_publication"} <= approvals_required
+
+    private_required = set(schema["properties"]["private_review"]["required"])
+    assert {"access", "raw_prompt_ref", "operator_notes_ref", "credential_handling"} <= private_required
+
+    schema_text = json.dumps(schema)
+    assert '"const": "internal_review"' in schema_text
+    assert '"required": ["private_review"]' in schema_text
+    assert '"const": "public"' in schema_text
+    assert '"not": {"required": ["private_review"]}' in schema_text
+
+
+def test_public_example_omits_private_review_and_keeps_approvals_pending():
+    example = load_json("provenance-example.public.json")
+    public = example["public"]
+
+    assert set(example) == {"schema_version", "packet_scope", "public"}
+    assert example["schema_version"] == "slice-1"
+    assert example["packet_scope"] == "public"
+    assert "private_review" not in example
+
+    for approval in public["approvals"].values():
+        assert approval["status"] == "pending"
+
+    split = public["public_private_split"]
+    private_fields = set(split["private_fields"])
+    public_fields = set(split["public_fields"])
+    assert private_fields
+    assert public_fields
+    assert private_fields.isdisjoint(public_fields)
+    assert "credentials" in split["redaction_summary"].lower()
+    assert "private_review" in split["redaction_summary"]


### PR DESCRIPTION
## Summary
- Adds LATENS Slice 1 public provenance foundation artifacts.
- Adds public lexicon/site route manifests and QA/security checklist.
- Adds targeted artifact validation tests.
- Rewrites author/committer metadata to GitHub noreply before public push.

## Test Plan
- [x] python -m pytest tests/hermes_mission/test_latens_slice1_artifacts.py -q (5 passed)

## Gate Evidence
- Founder approval gate cleared in kanban task t_33ee931d.
- Issue gate: https://github.com/chipoto69/latens/issues/4
- QA parent t_77e4465d approved targeted artifact tests 5/5.
- Security parent t_d95bb1b1 approved; no Critical/High blockers.

## Included Files
- hermes-mission/latens/slice-1/README.md
- hermes-mission/latens/slice-1/lexicon-routes.json
- hermes-mission/latens/slice-1/provenance-example.public.json
- hermes-mission/latens/slice-1/provenance.schema.json
- hermes-mission/latens/slice-1/qa-security-checklist.md
- hermes-mission/latens/slice-1/site-routes.json
- tests/hermes_mission/test_latens_slice1_artifacts.py

## Rollback
Revert this PR/commit, or remove `hermes-mission/latens/slice-1` plus `tests/hermes_mission/test_latens_slice1_artifacts.py`.

