### PR TITLE
fix(setup): check all api_key_env_vars for Bitwarden source label

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -4926,7 +4926,11 @@ def _prompt_api_key(pconfig, existing_key: str, provider_id: str = "") -> tuple:
     # Already configured — offer K / R / C ────────────────────────────────
     from hermes_cli.env_loader import format_secret_source_suffix
 
-    source_suffix = format_secret_source_suffix(key_env) if key_env else ""
+    source_suffix = ""
+    for _ev in pconfig.api_key_env_vars:
+        source_suffix = format_secret_source_suffix(_ev)
+        if source_suffix:
+            break
     print(f"  {pconfig.name} API key: {existing_key[:8]}... ✓{source_suffix}")
     if not key_env:
         # Nothing we can rewrite; just acknowledge and move on.


### PR DESCRIPTION
## Summary

`_prompt_api_key` always called `format_secret_source_suffix` on `api_key_env_vars[0]` — the primary env var. For providers that expose multiple aliases, if Bitwarden Secrets Manager supplied a **secondary** var the label was silently dropped.

**Before (GEMINI_API_KEY injected by BSM, GOOGLE_API_KEY not set):**
```
  Google Gemini API key: AIza1234... ✓
```

**After:**
```
  Google Gemini API key: AIza1234... ✓ (from Bitwarden)
```

## Root cause

```python
# before — always checks index 0
key_env = pconfig.api_key_env_vars[0] if pconfig.api_key_env_vars else ""
source_suffix = format_secret_source_suffix(key_env) if key_env else ""

# after — walks all vars, stops at first BSM hit
source_suffix = ""
for _ev in pconfig.api_key_env_vars:
    source_suffix = format_secret_source_suffix(_ev)
    if source_suffix:
        break
```

`key_env` (used for the input prompt and `save_env_value`) is unchanged — only the suffix lookup is widened.

## Affected providers

| Provider | Env vars |
|---|---|
| `gemini` | `GOOGLE_API_KEY`, **`GEMINI_API_KEY`** |
| `zai` | `GLM_API_KEY`, **`ZAI_API_KEY`**, `Z_AI_API_KEY` |
| `kimi-coding` | `KIMI_API_KEY`, **`KIMI_CODING_API_KEY`** |
| `alibaba-coding-plan` | `ALIBABA_CODING_PLAN_API_KEY`, **`DASHSCOPE_API_KEY`** |

Bold = secondary var a BSM user might store by name.

## Behavior unchanged for

- Single-var providers: loop runs once, same result as before
- `api_key_env_vars=()`: loop doesn't execute, `source_suffix = ""`
- Keys not sourced from BSM: `format_secret_source_suffix` returns `""` for all vars, suffix stays `""`

## Test plan

- [ ] Store `GEMINI_API_KEY` in BSM (not `GOOGLE_API_KEY`), run `hermes model` → Gemini → shows `(from Bitwarden)`
- [ ] Store `ZAI_API_KEY` in BSM (not `GLM_API_KEY`), run `hermes model` → Z.AI → shows `(from Bitwarden)`
- [ ] Single-var provider (e.g. DeepSeek) sourced from BSM → suffix still shown (existing behavior preserved)
- [ ] Key set in `.env` only → no suffix (existing behavior preserved)