### PR TITLE
fix(kanban): show horizontal scrollbar for overflowing columns

### DIFF
--- a/plugins/kanban/dashboard/dist/style.css
+++ b/plugins/kanban/dashboard/dist/style.css
@@ -67,10 +67,19 @@
   gap: 0.75rem;
   align-items: start;
   overflow-x: auto;
-  scrollbar-width: none;
+  padding-bottom: 0.35rem;
+  scrollbar-width: thin;
+  scrollbar-color: color-mix(in srgb, var(--color-border) 85%, transparent) transparent;
 }
 .hermes-kanban-columns::-webkit-scrollbar {
-  display: none;
+  height: 0.55rem;
+}
+.hermes-kanban-columns::-webkit-scrollbar-thumb {
+  background: color-mix(in srgb, var(--color-border) 85%, transparent);
+  border-radius: 999px;
+}
+.hermes-kanban-columns::-webkit-scrollbar-track {
+  background: transparent;
 }
 
 .hermes-kanban-column {


### PR DESCRIPTION
## Summary
- stop hiding the Kanban board's horizontal scrollbar when columns overflow
- keep the scrollbar visible but low-contrast so users can discover the clipped rightmost column
- add a little bottom padding so the scrollbar stays usable

Fixes #30503.

## Testing
- git diff --check
- python3 headless Playwright check asserting `.hermes-kanban-columns` overflows horizontally and computed `scrollbar-width` is `thin`
