### PR TITLE
fix(gateway): parse slash commands with non-ASCII sticky args

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -13,6 +13,10 @@ import os
 import random
 import re
 import socket as _socket
+
+# Slash-command name boundary: one or more ASCII [a-z0-9_-] chars.
+# Used to split "/cmd中文" into cmd + "中文" when there is no space.
+_ASCII_CMD_RE: re.Pattern[str] = re.compile(r"[a-z][a-z0-9_-]*")
 import subprocess
 import sys
 import uuid
@@ -1010,13 +1014,38 @@ class MessageEvent:
         # Reject file paths: valid command names never contain /
         if raw and "/" in raw:
             return None
+        # ASCII prefix fallback: when the user types "/cmd中文" without a
+        # space, *split()* keeps the whole thing as one token.  Command
+        # names are strictly ASCII, so extract the leading ASCII run.
+        if raw and not raw.isascii():
+            m = _ASCII_CMD_RE.match(raw)
+            raw = m.group(0) if m else None
         return raw
-    
+
     def get_command_args(self) -> str:
         """Get the arguments after a command."""
         if not self.is_command():
             return self.text
         parts = self.text.split(maxsplit=1)
+        first = parts[0] if parts else ""
+        cmd_name = self.get_command() or ""
+        # Detect sticky args: command name followed by non-space chars
+        # (e.g. "/queue中文" → cmd="queue", sticky="中文")
+        if cmd_name and not first[len(cmd_name) + 1 :].startswith((" ", "\t")):
+            sticky = first[len(cmd_name) + 1 :]  # +1 for leading "/"
+            # Strip @bot mention from sticky text
+            # e.g. "@bot如果" → "如果", "@bot如果test" → "如果test"
+            if sticky.startswith("@"):
+                m_at = re.match(r"@[a-z0-9_]+", sticky)
+                if m_at:
+                    sticky = sticky[m_at.end() :]
+                elif " " in sticky:
+                    sticky = sticky[sticky.index(" ") + 1 :]
+                else:
+                    sticky = ""
+            if sticky:
+                rest = parts[1] if len(parts) > 1 else ""
+                return (sticky + " " + rest).strip() if rest else sticky
         args = parts[1] if len(parts) > 1 else ""
         # iOS auto-corrects -- to — (em dash) and - to – (en dash)
         args = args.replace("\u2014\u2014", "--").replace("\u2014", "--").replace("\u2013", "-")


### PR DESCRIPTION
## Problem

When a user types a slash command followed by non-ASCII text (e.g. Chinese) **without a space**, the command is rejected as "Unknown command":

```
/queue如果 aosp16  →  "Unknown command /queue如果"
/queue测试         →  "Unknown command /queue测试"
/model小米         →  "Unknown command /model小米"
```

**Root cause:** `get_command()` uses `text.split(maxsplit=1)` which only splits on whitespace. When there's no space, the entire string `"/queue如果"` becomes one token → `"queue如果"` → no match in command registry.

This is a common pattern for CJK-language users who don't naturally type spaces between commands and arguments.

## Fix

Since command names are strictly ASCII (`[a-z0-9_-]*`), extract the leading ASCII run as the command name when the first token contains non-ASCII characters.

### Changes in `gateway/platforms/base.py`:

1. **Module-level pattern:** `_ASCII_CMD_RE = re.compile(r"[a-z][a-z0-9_-]*")`

2. **`get_command()`:** When the first token is non-ASCII, match the leading ASCII prefix:
   ```python
   if raw and not raw.isascii():
       m = _ASCII_CMD_RE.match(raw)
       raw = m.group(0) if m else None
   ```

3. **`get_command_args()`:** Extract sticky characters after the command name as args, with `@bot` mention stripping:
   ```python
   # "/queue中文" → cmd="queue", sticky="中文"
   if cmd_name and not first[len(cmd_name) + 1:].startswith((" ", "\t")):
       sticky = first[len(cmd_name) + 1:]
       # Strip @bot mention from sticky text
       ...
   ```

### Behavior matrix

| Input | Before | After |
|-------|--------|-------|
| `/queue如果` | Unknown command | cmd=queue, args=如果 ✅ |
| `/queue如果 aosp16` | Unknown command | cmd=queue, args=如果 aosp16 ✅ |
| `/queue@bot测试` | Unknown command | cmd=queue, args=测试 ✅ |
| `/model小米` | Unknown command | cmd=model, args=小米 ✅ |
| `/queue test` | cmd=queue, args=test | unchanged ✅ |
| `/new` | cmd=new | unchanged ✅ |
| `/codex-runtime` | cmd=codex-runtime | unchanged ✅ |
| `/modelgpt` | Unknown command | unchanged (ASCII-only, not affected) |
| `/你好世界` | Unknown command | cmd=None (no ASCII prefix) |

### Scope

- Only affects non-ASCII sticky text; pure-ASCII inputs are untouched
- All platforms benefit (Telegram, Discord, Slack, CLI) since all use `base.py`
- No changes to command registration or dispatch logic