### PR TITLE
fix(security): restrict write access to Anthropic OAuth credential store

### DIFF
--- a/agent/file_safety.py
+++ b/agent/file_safety.py
@@ -41,6 +41,11 @@ def build_write_denied_paths(home: str) -> set[str]:
             # Top-level .env, even when running under a profile — overwriting it
             # leaks credentials across every profile that inherits from root (#15981).
             str(hermes_root / ".env"),
+            # Active profile Anthropic PKCE credential store.
+            str(hermes_home / ".anthropic_oauth.json"),
+            # Top-level Anthropic PKCE credential store remains sensitive even
+            # when a profile is active; default/non-profile sessions still read it.
+            str(hermes_root / ".anthropic_oauth.json"),
             os.path.join(home, ".bashrc"),
             os.path.join(home, ".zshrc"),
             os.path.join(home, ".profile"),

--- a/tests/tools/test_file_operations.py
+++ b/tests/tools/test_file_operations.py
@@ -66,12 +66,13 @@ class TestIsWriteDenied:
             "auth.json",
             "config.yaml",
             "webhook_subscriptions.json",
+            ".anthropic_oauth.json",
             "mcp-tokens/token1.json",
             "mcp-tokens/subdir/token2.json",
         ],
     )
-    def test_hermes_control_files_and_mcp_tokens_denied(self, path):
-        """Hermes control files and mcp-tokens entries must be write-denied."""
+    def test_hermes_control_files_oauth_and_mcp_tokens_denied(self, path):
+        """Hermes control files, PKCE creds, and mcp-tokens must be write-denied."""
         from hermes_constants import get_hermes_home
         hermes_home = get_hermes_home()
         full_path = str(hermes_home / path)
@@ -82,11 +83,12 @@ class TestIsWriteDenied:
         [
             "dummy/../config.yaml",
             "./auth.json",
+            "./.anthropic_oauth.json",
             "mcp-tokens/../config.yaml",
         ],
     )
-    def test_hermes_control_files_traversal_denied(self, path):
-        """Path traversal attempts to control files must be blocked by realpath."""
+    def test_hermes_control_files_and_oauth_traversal_denied(self, path):
+        """Path traversal attempts to protected Hermes files must be blocked."""
         from hermes_constants import get_hermes_home
         hermes_home = get_hermes_home()
         full_path = str(hermes_home / path)
@@ -106,14 +108,15 @@ class TestIsWriteDenied:
 
     @pytest.mark.parametrize(
         "name",
-        ["auth.json", "config.yaml", "webhook_subscriptions.json"],
+        ["auth.json", "config.yaml", "webhook_subscriptions.json", ".anthropic_oauth.json"],
     )
-    def test_control_files_protected_in_profile_mode(self, tmp_path, monkeypatch, name):
+    def test_control_files_and_oauth_protected_in_profile_mode(self, tmp_path, monkeypatch, name):
         """Under a profile, BOTH <profile>/X and <root>/X must be denied (#15981 shape).
 
         Without the root-level pass, a profile-mode session leaves the
-        global ~/.hermes/{auth.json,config.yaml,webhook_subscriptions.json}
-        writable — the same gap PR #15981 fixed for .env.
+        global ~/.hermes/{auth.json,config.yaml,webhook_subscriptions.json,
+        .anthropic_oauth.json} writable — the same gap PR #15981 fixed
+        for .env.
         """
         # Simulate a profile-mode HERMES_HOME layout:
         #   <root>/profiles/coder/{auth.json,config.yaml,...}


### PR DESCRIPTION
## What does this PR do?

Closes a write-protection gap for a sensitive OAuth credential store so prompt-injected file writes cannot overwrite it. The fix follows the existing denylist pattern and adds regression coverage for direct, traversal, and profile-mode cases.


## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 🔒 Security fix
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- Added the sensitive OAuth credential store to the write-deny protection list.
- Extended regression coverage for normal paths, traversal attempts, and profile-mode behavior.

## How to Test

1. Run the file-operations test module.
2. Verify the new credential-store deny cases pass.
3. Confirm write-deny behavior still works for existing protected paths.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform:

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Targeted regression tests passed.