### PR TITLE
fix(skills): enforce shared path exclusion metrics inside docs generator discovery

### DIFF
--- a/tests/website/test_generate_skill_docs.py
+++ b/tests/website/test_generate_skill_docs.py
@@ -114,3 +114,37 @@ def test_bundled_catalog_explains_missing_local_skills(gen_module):
     result = gen_module.build_catalog_md_bundled([])
     assert "respects local deletions and user edits" in result
     assert "hermes skills reset <name> --restore" in result
+
+
+def test_discover_skills_skips_dependency_dirs(gen_module, tmp_path):
+    """Dependency and venv trees must not contribute ghost skills to docs generation."""
+    source_dir = tmp_path / "skills"
+    real_skill = source_dir / "dev" / "real-skill"
+    real_skill.mkdir(parents=True)
+    (real_skill / "SKILL.md").write_text(
+        "---\n"
+        "name: real-skill\n"
+        "description: Real skill.\n"
+        "---\n"
+        "Body\n",
+        encoding="utf-8",
+    )
+    ghost_skill = source_dir / ".venv" / "Lib" / "site-packages" / "ghost-skill"
+    ghost_skill.mkdir(parents=True)
+    (ghost_skill / "SKILL.md").write_text(
+        "---\n"
+        "name: ghost-skill\n"
+        "description: Ghost skill.\n"
+        "---\n"
+        "Body\n",
+        encoding="utf-8",
+    )
+
+    original_sources = gen_module.SKILL_SOURCES
+    gen_module.SKILL_SOURCES = [("bundled", source_dir)]
+    try:
+        entries = gen_module.discover_skills()
+    finally:
+        gen_module.SKILL_SOURCES = original_sources
+
+    assert [meta["slug"] for meta, _ in entries] == ["real-skill"]

--- a/website/scripts/generate-skill-docs.py
+++ b/website/scripts/generate-skill-docs.py
@@ -21,6 +21,7 @@ from textwrap import dedent
 from typing import Any
 
 import yaml
+from agent.skill_utils import is_excluded_skill_path
 
 REPO = Path(__file__).resolve().parent.parent.parent
 DOCS = REPO / "website" / "docs"
@@ -455,6 +456,8 @@ def discover_skills() -> list[tuple[dict[str, Any], dict[str, Any]]]:
     results: list[tuple[dict[str, Any], dict[str, Any]]] = []
     for kind, source_dir in SKILL_SOURCES:
         for skill_md in sorted(source_dir.rglob("SKILL.md")):
+            if is_excluded_skill_path(skill_md):
+                continue
             meta = derive_skill_meta(skill_md, source_dir, kind)
             parsed = parse_skill_md(skill_md)
             results.append((meta, parsed))


### PR DESCRIPTION
## What does this PR do?

Prevents generated skill docs from picking up ghost skills from dependency or virtualenv directories by applying the shared skill-path exclusion logic in docs discovery. Adds a regression test to lock that behavior in.

## Related Issue

Fixes #

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- Reused the shared excluded-skill path check in docs skill discovery
- Added a regression test covering ghost `SKILL.md` files under dependency/venv trees

## How to Test

1. Run the website skill docs test file
2. Verify the full test file passes
3. Confirm nested dependency/venv skill stubs are ignored during discovery

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- Targeted test file passes locally