### PR TITLE
docs(cron): move send_message delivery details from Schedule formats to Delivery options

### DIFF
--- a/website/docs/user-guide/features/cron.md
+++ b/website/docs/user-guide/features/cron.md
@@ -277,7 +277,7 @@ When scheduling jobs, you specify where the output goes:
 | `"telegram,discord"` | Fan out to a specific set of channels | Comma-separated list |
 | `"origin,all"` | Deliver to the origin **plus** every other connected channel | Combine any tokens |
 
-The agent's final response is automatically delivered. You do not need to call `send_message` in the cron prompt.
+The agent's final response is automatically delivered — you do **not** need to include `send_message` in the cron prompt for that same destination. If a cron run calls `send_message` to the exact target the scheduler will already deliver to, Hermes skips that duplicate send and tells the model to put the user-facing content in the final response instead. Use `send_message` only for additional or different targets.
 
 ### Routing intent (`all`)
 
@@ -451,8 +451,6 @@ Cron jobs inherit your configured fallback providers and credential pool rotatio
 This means cron jobs that run at high frequency or during peak hours are more resilient — a single rate-limited key won't fail the entire run.
 
 ## Schedule formats
-
-The agent's final response is automatically delivered — you do **not** need to include `send_message` in the cron prompt for that same destination. If a cron run calls `send_message` to the exact target the scheduler will already deliver to, Hermes skips that duplicate send and tells the model to put the user-facing content in the final response instead. Use `send_message` only for additional or different targets.
 
 ### Relative delays (one-shot)
 


### PR DESCRIPTION
## What does this PR do?

This PR improves the structure of the Scheduled Tasks (Cron) documentation by eliminating duplication and moving content to the logically correct section.

**What was done:**

1. **Moved** the detailed explanation from the **"Schedule formats"** section to the **"Delivery options"** section:

   **Moved text:**
   > The agent's final response is automatically delivered — you do **not** need to include `send_message` in the cron prompt for that same destination. If a cron run calls `send_message` to the exact target the scheduler will already deliver to, Hermes skips that duplicate send and tells the model to put the user-facing content in the final response instead. Use `send_message` only for additional or different targets.

2. **Removed** the short duplicate version that was previously in the **"Delivery options"** section:

   **Removed text:**
   > The agent's final response is automatically delivered. You do not need to call `send_message` in the cron prompt.

**Reasoning:**  
The paragraph about automatic delivery and `send_message` behavior is not related to schedule formats (relative delays, intervals, cron expressions, ISO timestamps, etc.). It belongs under delivery mechanics. By moving the more complete version to "Delivery options" and removing the shorter duplicate, we now have one clear, authoritative explanation in the right place. This makes the documentation cleaner, more maintainable, and easier to read.

## Related Issue
Documentation structure cleanup (no specific issue)

## Type of Change
- [x] 📝 Documentation update
- [x] ♻️ Refactor (no behavior change)

## Changes Made

**File:** `docs/user-guide/features/cron.md`

- Moved the detailed paragraph about automatic delivery and `send_message` from **Schedule formats** → **Delivery options**
- Removed the short duplicate paragraph from **Delivery options**
- Removed the misplaced paragraph from **Schedule formats**

## How to Test

1. Open `docs/user-guide/features/cron.md`
2. Verify that the section **"Delivery options"** contains the full detailed explanation about automatic delivery and `send_message` behavior.
3. Verify that the section **"Schedule formats"** no longer contains any text about `send_message` or automatic delivery (it should only show schedule format examples).
4. Quickly read both sections to ensure the documentation flows logically and no information was lost.

## Checklist
### Code
- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) — no duplicates found
- [x] My PR contains **only** changes related to this fix
- [x] N/A — documentation-only changes, no tests required

### Documentation & Housekeeping
- [x] I've updated relevant documentation (`docs/user-guide/features/cron.md`)
- [x] N/A no config changes
- [x] N/A no architecture changes
- [x] N/A no cross-platform impact
- [x] N/A no tool behavior changes

## Screenshots / Logs
N/A