### PR TITLE
fix(cli): enforce shared truthy coercion for YOLO mode banner status

### DIFF
--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -20,6 +20,7 @@ from rich.table import Table
 
 from prompt_toolkit import print_formatted_text as _pt_print
 from prompt_toolkit.formatted_text import ANSI as _PT_ANSI
+from utils import is_truthy_value
 
 logger = logging.getLogger(__name__)
 
@@ -514,7 +515,7 @@ def build_welcome_banner(console: Console, model: str, cwd: str,
     ctx_str = f" [dim {dim}]·[/] [dim {dim}]{_format_context_length(context_length)} context[/]" if context_length else ""
     left_lines.append(f"[{accent}]{model_short}[/]{ctx_str} [dim {dim}]·[/] [dim {dim}]Nous Research[/]")
 
-    if os.getenv("HERMES_YOLO_MODE"):
+    if is_truthy_value(os.getenv("HERMES_YOLO_MODE")):
         left_lines.append(f"[bold red]⚠ YOLO mode[/] [dim {dim}]— all approval prompts bypassed[/]")
     left_lines.append(f"[dim {dim}]{cwd}[/]")
     if session_id:

--- a/tests/hermes_cli/test_banner.py
+++ b/tests/hermes_cli/test_banner.py
@@ -1,5 +1,6 @@
 """Tests for banner toolset name normalization and skin color usage."""
 
+import os
 from unittest.mock import patch
 
 from rich.console import Console
@@ -68,6 +69,44 @@ def test_build_welcome_banner_uses_normalized_toolset_names():
     assert "homeassistant_tools:" not in output
     assert "honcho_tools:" not in output
     assert "web_tools:" not in output
+
+
+def test_build_welcome_banner_yolo_banner_uses_truthy_env_parsing():
+    with (
+        patch.object(
+            model_tools,
+            "check_tool_availability",
+            return_value=(["web"], []),
+        ),
+        patch.object(banner, "get_available_skills", return_value={}),
+        patch.object(banner, "get_update_result", return_value=None),
+        patch.object(tools.mcp_tool, "get_mcp_status", return_value=[]),
+    ):
+        with patch.dict(os.environ, {"HERMES_YOLO_MODE": "false"}):
+            console = Console(
+                record=True, force_terminal=False, color_system=None, width=160
+            )
+            banner.build_welcome_banner(
+                console=console,
+                model="anthropic/test-model",
+                cwd="/tmp/project",
+                tools=[{"function": {"name": "read_file"}}],
+                get_toolset_for_tool=lambda name: "file",
+            )
+            assert "all approval prompts bypassed" not in console.export_text()
+
+        with patch.dict(os.environ, {"HERMES_YOLO_MODE": "1"}):
+            console = Console(
+                record=True, force_terminal=False, color_system=None, width=160
+            )
+            banner.build_welcome_banner(
+                console=console,
+                model="anthropic/test-model",
+                cwd="/tmp/project",
+                tools=[{"function": {"name": "read_file"}}],
+                get_toolset_for_tool=lambda name: "file",
+            )
+            assert "all approval prompts bypassed" in console.export_text()
 
 
 def test_build_welcome_banner_title_is_hyperlinked_to_release():


### PR DESCRIPTION
## What does this PR do?

Fixes an inconsistency in YOLO mode detection so false-like env values do not show the bypass warning in the banner. This aligns the banner with the existing truthy parsing used elsewhere.


## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Tests (adding or improving test coverage)

## Changes Made

- Reused the shared truthy parser for YOLO banner detection
- Added a regression test for false-like and truthy env values

## How to Test

1. Set `HERMES_YOLO_MODE=false` and start the CLI banner flow.
2. Confirm the YOLO bypass warning is not shown.
3. Run `uv run --extra dev pytest tests/hermes_cli/test_banner.py -k yolo -o addopts="-m 'not integration' --timeout=30 --timeout-method=thread"`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: local development environment

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

