### PR TITLE
fix(tools_config): rerun browser bootstrap when saved provider is re-enabled

### DIFF
--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -1807,6 +1807,7 @@ _POST_SETUP_INSTALLED: dict = {
     # entry when (a) the post_setup is the ONLY install side-effect for
     # a no-key provider, and (b) an installed-state check is cheap and
     # doesn't trigger a heavy import.
+    "agent_browser": lambda: (PROJECT_ROOT / "node_modules" / "agent-browser").exists(),
     "cua_driver": lambda: bool(shutil.which(_cua_driver_cmd())),
 }
 
@@ -1830,11 +1831,19 @@ def _toolset_needs_configuration_prompt(ts_key: str, config: dict) -> bool:
     if not cat:
         return not _toolset_has_keys(ts_key, config)
 
+    providers = _visible_providers(cat, config)
+    active_providers = [provider for provider in providers if _is_provider_active(provider, config)]
+    post_setup_candidates = active_providers or providers
+
     # If any visible provider has a registered post_setup install-state
     # check that hasn't been satisfied (e.g. cua-driver binary not on
     # PATH yet), force the configuration flow so `_configure_provider`
-    # invokes `_run_post_setup` and the install actually runs.
-    for provider in _visible_providers(cat, config):
+    # invokes `_run_post_setup` and the install actually runs. When the
+    # toolset already has an active provider in config, only that
+    # provider's post_setup gap should count; otherwise unrelated rows can
+    # spuriously force setup (for example Browserbase inheriting the
+    # Local Browser bootstrap requirement).
+    for provider in post_setup_candidates:
         post_setup = provider.get("post_setup")
         if post_setup and not _post_setup_already_installed(post_setup):
             return True

--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -839,6 +839,76 @@ def test_computer_use_post_setup_missing_override_does_not_accept_default_binary
     assert "curl" in seen
 
 
+def test_browser_needs_configuration_when_agent_browser_bootstrap_missing(monkeypatch, tmp_path):
+    """Re-enabling browser with a saved provider should rerun missing bootstrap."""
+    from hermes_cli import tools_config as mod
+
+    monkeypatch.setattr(mod, "PROJECT_ROOT", tmp_path)
+    monkeypatch.setattr(
+        mod,
+        "_visible_providers",
+        lambda cat, config: [
+            {
+                "name": "Browser Use",
+                "browser_provider": "browser-use",
+                "env_vars": [],
+                "post_setup": "agent_browser",
+            }
+        ],
+    )
+
+    config = {"browser": {"cloud_provider": "browser-use"}}
+    assert _toolset_needs_configuration_prompt("browser", config) is True
+
+
+def test_browser_skips_configuration_when_agent_browser_bootstrap_present(monkeypatch, tmp_path):
+    """Saved browser providers stay no-op once agent-browser is installed."""
+    from hermes_cli import tools_config as mod
+
+    monkeypatch.setattr(mod, "PROJECT_ROOT", tmp_path)
+    monkeypatch.setattr(
+        mod,
+        "_visible_providers",
+        lambda cat, config: [
+            {
+                "name": "Browser Use",
+                "browser_provider": "browser-use",
+                "env_vars": [],
+                "post_setup": "agent_browser",
+            }
+        ],
+    )
+    (tmp_path / "node_modules" / "agent-browser").mkdir(parents=True)
+
+    config = {"browser": {"cloud_provider": "browser-use"}}
+    assert _toolset_needs_configuration_prompt("browser", config) is False
+
+
+def test_browser_only_checks_active_provider_post_setup(monkeypatch):
+    """An unrelated provider's bootstrap gap must not force browser re-setup."""
+    from hermes_cli import tools_config as mod
+
+    providers = [
+        {"name": "Browserbase", "browser_provider": "browserbase", "env_vars": []},
+        {
+            "name": "Local Browser",
+            "browser_provider": "local",
+            "env_vars": [],
+            "post_setup": "agent_browser",
+        },
+    ]
+
+    monkeypatch.setattr(mod, "_visible_providers", lambda cat, config: providers)
+    monkeypatch.setattr(
+        mod,
+        "_post_setup_already_installed",
+        lambda key: False if key == "agent_browser" else True,
+    )
+
+    config = {"browser": {"cloud_provider": "browserbase"}}
+    assert _toolset_needs_configuration_prompt("browser", config) is False
+
+
 class TestImagegenBackendRegistry:
     """IMAGEGEN_BACKENDS tags drive the model picker flow in tools_config."""
 


### PR DESCRIPTION
## Summary

This fixes a browser-tooling parity gap in `hermes tools`.

Commit `70d53d8b7` established an important invariant for no-key toolsets: if enabling a toolset still requires a missing `post_setup` side effect, the enable/re-enable flow must reopen setup instead of silently doing nothing. That fix covered `computer_use`, but the same behavior was still missing for the `browser` toolset.

With a saved `browser.cloud_provider` and a missing `agent-browser` bootstrap, re-enabling browser tools could skip setup entirely. In practice this shows up after a fresh checkout/worktree, a deleted `node_modules`, or a partial local install: the config says browser is enabled, but the required local bootstrap is gone, so the first real browser use fails later at runtime.

## Root cause

`_toolset_needs_configuration_prompt()` treated browser as already configured once `browser.cloud_provider` existed in config, but it had no install-state gate for the `agent_browser` post-setup path.

There was also a second issue in the same decision path: post-setup checks were effectively driven by the visible provider surface rather than the active configured provider. That means an unrelated provider row could influence whether setup was forced.

## What changed

- Added an install-state predicate for `agent_browser` in `_POST_SETUP_INSTALLED`.
- Updated `_toolset_needs_configuration_prompt()` to:
  - reopen setup when the active browser provider still needs the `agent-browser` bootstrap
  - restrict post-setup gating to the active provider when one is already configured
  - fall back to the full visible provider list only when no provider is yet active

This keeps the fix minimal and aligned with the existing `computer_use` pattern rather than introducing a new setup model.

## User impact

Before this change, users could hit a misleading state where browser tools looked configured but were not actually runnable because the local bootstrap had disappeared.

After this change, re-enabling browser tools correctly re-triggers setup when the required local browser bootstrap is missing, while avoiding false-positive setup prompts from unrelated provider rows.

## Tests

Added regression coverage for:

- re-enabling browser when `agent-browser` bootstrap is missing
- skipping setup when the bootstrap is already present
- ensuring only the active provider’s `post_setup` state is considered

## Verification

Ran targeted regression tests with `scripts/run_tests.sh` for the new browser post-setup cases.

```bash
C:\Program Files\Git\bin\bash.exe scripts/run_tests.sh -j 1 tests/hermes_cli/test_tools_config.py -- -o addopts='' -q -k "browser_needs_configuration_when_agent_browser_bootstrap_missing or browser_skips_configuration_when_agent_browser_bootstrap_present or browser_only_checks_active_provider_post_setup"

3 passed, 0 failed
