### PR TITLE
fix: suppress internal status banners on customer-facing platforms (refs #28208)

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -2911,12 +2911,40 @@ class AIAgent:
             and getattr(self, "platform", "") == "cli"
         )
 
-    def _emit_status(self, message: str) -> None:
-        """Emit a lifecycle status message to both CLI and gateway channels.
+    # Platforms whose end-users are external customers (vs. the operator/admin
+    # running Hermes via CLI or API). Internal-status banners are suppressed on
+    # these surfaces to avoid leaking implementation details into chat threads.
+    # Refs: https://github.com/NousResearch/hermes-agent/issues/28208
+    _CUSTOMER_FACING_PLATFORMS = frozenset({
+        "whatsapp", "slack", "signal", "telegram", "discord",
+    })
+
+    # Defensive glyph fallback for call sites that haven't been migrated to
+    # the explicit ``customer_facing=False`` kwarg yet. Kept narrow on purpose
+    # (compression banners only) — broader category suppression is tracked in
+    # Issue #28208's larger scope and will land via separate PRs.
+    _INTERNAL_STATUS_PREFIXES = (
+        "\U0001f5dc",  # 🗜  context-pressure / compression banner family
+    )
+
+    def _emit_status(self, message: str, customer_facing: bool = True) -> None:
+        """Emit a lifecycle status message to CLI and (selectively) gateway.
 
         CLI users see the message via ``_vprint(force=True)`` so it is always
-        visible regardless of verbose/quiet mode.  Gateway consumers receive
-        it through ``status_callback("lifecycle", ...)``.
+        visible regardless of verbose/quiet mode.
+
+        Gateway consumers receive it through ``status_callback("lifecycle", ...)``
+        UNLESS the runtime ``platform`` is in ``_CUSTOMER_FACING_PLATFORMS``
+        AND either:
+
+        * ``customer_facing=False`` was passed explicitly by the caller, OR
+        * the message starts with an internal-status glyph in
+          ``_INTERNAL_STATUS_PREFIXES`` (defensive fallback for un-migrated
+          call sites).
+
+        This shields end-user chats on platforms like WhatsApp from internal
+        Hermes diagnostics (compression progress, retry warnings, rate-limit
+        notices) without affecting admin/CLI visibility. See Issue #28208.
 
         This helper never raises — exceptions are swallowed so it cannot
         interrupt the retry/fallback logic.
@@ -2925,6 +2953,12 @@ class AIAgent:
             self._vprint(f"{self.log_prefix}{message}", force=True)
         except Exception:
             pass
+        platform = (getattr(self, "platform", "") or "").lower()
+        if platform in self._CUSTOMER_FACING_PLATFORMS:
+            if not customer_facing:
+                return
+            if message.startswith(self._INTERNAL_STATUS_PREFIXES):
+                return
         if self.status_callback:
             try:
                 self.status_callback("lifecycle", message)
@@ -14391,7 +14425,10 @@ class AIAgent:
                                 "failed": True,
                                 "compression_exhausted": True,
                             }
-                        self._emit_status(f"⚠️  Request payload too large (413) — compression attempt {compression_attempts}/{max_compression_attempts}...")
+                        self._emit_status(
+                            f"⚠️  Request payload too large (413) — compression attempt {compression_attempts}/{max_compression_attempts}...",
+                            customer_facing=False,
+                        )
 
                         original_len = len(messages)
                         messages, active_system_prompt = self._compress_context(
@@ -14404,7 +14441,10 @@ class AIAgent:
                         conversation_history = None
 
                         if len(messages) < original_len:
-                            self._emit_status(f"🗜️ Compressed {original_len} → {len(messages)} messages, retrying...")
+                            self._emit_status(
+                                f"🗜️ Compressed {original_len} → {len(messages)} messages, retrying...",
+                                customer_facing=False,
+                            )
                             time.sleep(2)  # Brief pause between compression retries
                             restart_with_compressed_messages = True
                             break
@@ -14548,7 +14588,10 @@ class AIAgent:
                                 "failed": True,
                                 "compression_exhausted": True,
                             }
-                        self._emit_status(f"🗜️ Context too large (~{approx_tokens:,} tokens) — compressing ({compression_attempts}/{max_compression_attempts})...")
+                        self._emit_status(
+                            f"🗜️ Context too large (~{approx_tokens:,} tokens) — compressing ({compression_attempts}/{max_compression_attempts})...",
+                            customer_facing=False,
+                        )
 
                         original_len = len(messages)
                         messages, active_system_prompt = self._compress_context(
@@ -14562,7 +14605,10 @@ class AIAgent:
 
                         if len(messages) < original_len or new_ctx and new_ctx < old_ctx:
                             if len(messages) < original_len:
-                                self._emit_status(f"🗜️ Compressed {original_len} → {len(messages)} messages, retrying...")
+                                self._emit_status(
+                                f"🗜️ Compressed {original_len} → {len(messages)} messages, retrying...",
+                                customer_facing=False,
+                            )
                             time.sleep(2)  # Brief pause between compression retries
                             restart_with_compressed_messages = True
                             break

--- a/tests/run_agent/test_emit_status_customer_facing_filter.py
+++ b/tests/run_agent/test_emit_status_customer_facing_filter.py
@@ -1,0 +1,119 @@
+# -*- coding: utf-8 -*-
+"""Unit tests for the ``_emit_status`` customer-facing platform filter.
+
+Refs: https://github.com/NousResearch/hermes-agent/issues/28208
+
+When AIRA-style production deployments run Hermes over WhatsApp (or any other
+customer-facing messaging platform), internal Hermes diagnostics like the
+compression banner ``"🗜️ Context too large (~156k tokens) — compressing..."``
+were being delivered straight into end-user chat threads. The fix routes
+these emissions through a platform-aware filter in ``AIAgent._emit_status``:
+
+* CLI / admin / api surfaces still receive every status (existing behavior).
+* Customer-facing platforms (whatsapp, slack, signal, telegram, discord)
+  drop messages flagged ``customer_facing=False`` AND, defensively, any
+  message starting with the compression-banner glyph for un-migrated callers.
+
+These tests exercise the filter directly without booting a full agent
+session, mirroring the lightweight ``_stub_agent`` pattern used in other
+``tests/run_agent`` modules.
+"""
+from __future__ import annotations
+
+import pytest
+
+import run_agent
+
+
+def _stub_agent(platform: str = "") -> tuple[object, list[tuple[str, str]]]:
+    """Build a minimal AIAgent for _emit_status testing without full init."""
+    agent = run_agent.AIAgent.__new__(run_agent.AIAgent)
+    agent.platform = platform
+    agent.log_prefix = ""
+    captured: list[tuple[str, str]] = []
+    agent.status_callback = lambda evt, msg: captured.append((evt, msg))
+    agent._vprint = lambda *a, **k: None  # silence the CLI path
+    return agent, captured
+
+
+@pytest.mark.parametrize(
+    "platform", ["whatsapp", "slack", "signal", "telegram", "discord"],
+)
+def test_compression_status_suppressed_on_customer_facing_platforms(platform):
+    """Explicit customer_facing=False compression banner stays out of customer chats."""
+    agent, captured = _stub_agent(platform)
+    agent._emit_status(
+        "🗜️ Context too large (~156,287 tokens) — compressing (1/3)...",
+        customer_facing=False,
+    )
+    assert captured == [], (
+        f"compression status leaked to {platform}: {captured!r}"
+    )
+
+
+@pytest.mark.parametrize("platform", ["whatsapp", "slack"])
+def test_glyph_fallback_drops_unmigrated_callers(platform):
+    """Defensive glyph detection drops 🗜 banners even without the kwarg."""
+    agent, captured = _stub_agent(platform)
+    # Caller does NOT pass customer_facing=False — defensive fallback fires.
+    agent._emit_status("🗜️ Compressed 120 → 7 messages, retrying...")
+    assert captured == [], (
+        f"glyph-fallback failed on {platform}: {captured!r}"
+    )
+
+
+def test_customer_facing_default_lets_normal_messages_through_on_wa():
+    """Real customer-facing messages (no glyph) still reach the gateway."""
+    agent, captured = _stub_agent("whatsapp")
+    agent._emit_status("Müberra Hanım, kalite skoru hazır")
+    assert captured == [
+        ("lifecycle", "Müberra Hanım, kalite skoru hazır")
+    ]
+
+
+def test_explicit_customer_facing_false_drops_message_without_glyph():
+    """customer_facing=False suppresses even messages without a glyph prefix."""
+    agent, captured = _stub_agent("whatsapp")
+    agent._emit_status("any internal-only banner", customer_facing=False)
+    assert captured == []
+
+
+def test_cli_platform_receives_compression_status():
+    """CLI/admin surface keeps full diagnostic visibility — no suppression."""
+    agent, captured = _stub_agent("cli")
+    agent._emit_status(
+        "🗜️ Context too large (~156k)",
+        customer_facing=False,
+    )
+    assert captured == [
+        ("lifecycle", "🗜️ Context too large (~156k)")
+    ]
+
+
+def test_non_customer_facing_platform_passes_through():
+    """Platforms outside the customer-facing set (api_server, …) keep visibility."""
+    agent, captured = _stub_agent("api_server")
+    agent._emit_status("🗜️ Compressed", customer_facing=False)
+    assert captured == [("lifecycle", "🗜️ Compressed")]
+
+
+def test_empty_platform_treated_as_non_customer_facing():
+    """A blank ``platform`` attribute (test scaffolding default) is admin-equivalent."""
+    agent, captured = _stub_agent("")
+    agent._emit_status("🗜️ Context too large", customer_facing=False)
+    assert captured == [("lifecycle", "🗜️ Context too large")]
+
+
+def test_status_callback_exception_is_swallowed():
+    """An exception inside ``status_callback`` must not escape ``_emit_status``."""
+    agent = run_agent.AIAgent.__new__(run_agent.AIAgent)
+    agent.platform = "whatsapp"
+    agent.log_prefix = ""
+    agent._vprint = lambda *a, **k: None
+
+    def _explode(evt, msg):  # pragma: no cover - body unused, only signature matters
+        raise RuntimeError("boom")
+
+    agent.status_callback = _explode
+    # Must NOT raise — fault tolerance preserved from the original implementation.
+    agent._emit_status("Normal customer message")


### PR DESCRIPTION
## Summary

Partial fix for #28208. The WhatsApp gateway (and any other customer-facing
platform) currently delivers Hermes-internal diagnostic banners straight
into end-user chat threads — for example:

```
🗜️ Context too large (~156,287 tokens) — compressing (1/3)...
🗜️ Compressed 120 → 7 messages, retrying...
```

Root cause: `AIAgent._emit_status` dispatches to the gateway adapter via
`status_callback` directly, which bypasses the `transform_llm_output`
plugin hook that sanitiser plugins typically attach to.

This PR adds a platform-aware filter to `_emit_status`:

- New `customer_facing: bool = True` kwarg (backwards-compatible default).
- New `_CUSTOMER_FACING_PLATFORMS = {whatsapp, slack, signal, telegram, discord}`.
- New `_INTERNAL_STATUS_PREFIXES` defensive glyph fallback — kept narrow
  (compression-banner category only).
- The four compression-recovery emit sites (1× 413 payload, 1× context-
  too-large, 2× compressed-retrying) now opt out explicitly with
  `customer_facing=False`.
- CLI / admin / api surfaces still receive every status — operator
  visibility unchanged.

## Why "partial"

#28208 also requests silent-success for empty responses, broader provider-
diagnostic suppression, and a `whatsapp.allow_silent_response` config flag.
Those are deferred to follow-ups so this PR stays small enough to review
and land quickly. The compression-banner scope was chosen because:

- It is the one currently leaking into a real production customer chat
  (live incident 2026-05-22 in an AIRA-on-Hermes deployment), so the
  marginal value is highest.
- It is strictly subtractive on customer-facing platforms — zero
  behavioural impact on CLI / API surfaces, no public-API breakage.

## Test plan

- [x] `tests/run_agent/test_emit_status_customer_facing_filter.py` — 13
      new cases covering:
  - all five customer-facing platforms drop compression status when
    `customer_facing=False`
  - glyph fallback drops compression banners from un-migrated callers
  - real customer messages still reach the gateway on WhatsApp
  - explicit `customer_facing=False` drops even non-glyph messages
  - CLI / api_server / empty-platform surfaces always receive status
  - `status_callback` exceptions remain swallowed (fault-tolerance kept)
- [x] Existing `test_empty_response_emits_status_for_gateway` still passes.
- [x] Existing `test_context_compression_triggered` still passes.
- [x] No new dependencies; no public-API breakage (new kwarg has a default).

## Out of scope (follow-up PRs)

Tracked under #28208 — happy to take any of these in this PR if the
maintainers prefer a wider scope:

1. Silent-success path for empty model responses (config-gated).
2. `whatsapp.allow_silent_response: true` / `suppress_diagnostics: true`
   config flag wiring.
3. Broader internal-banner suppression beyond compression: empty-response
   retry (`⚠️ Empty/malformed`), rate-limit (`⏱️/⚠️/❌`), retrying (`⏳`),
   max-retries (`⚠️/❌`), non-retryable (`⚠️`), provider-auth (`⚠️`),
   proxy (`⚠️`). My local deployment ships these in the glyph fallback
   for defensive coverage, but each touches an additional set of emit
   sites and felt big enough to deserve its own review.