### PR TITLE
feat(memory): add Memanto memory agent provider

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -514,7 +514,7 @@ explicitly (it's idempotent).
 
 Separate discovery system for pluggable memory backends. Current built-in
 providers include **honcho, mem0, supermemory, byterover, hindsight,
-holographic, openviking, retaindb**.
+holographic, openviking, retaindb, memanto**.
 
 Each provider implements the `MemoryProvider` ABC (see `agent/memory_provider.py`)
 and is orchestrated by `agent/memory_manager.py`. Lifecycle hooks include

--- a/plugins/memory/memanto/README.md
+++ b/plugins/memory/memanto/README.md
@@ -1,0 +1,96 @@
+# Memanto Memory Agent Provider
+
+[Memanto](https://memanto.ai) is a **memory agent** — typed long-term memory with
+confidence and provenance, semantic recall, and RAG-style answers, backed by the
+[Moorcheh](https://moorcheh.ai) vector platform. Each Memanto namespace is a
+first-class *agent* (`memanto agent create/activate`), so this provider maps one
+Hermes identity to one Memanto agent.
+
+## Requirements
+
+- `pip install memanto`
+- Moorcheh API key from [console.moorcheh.ai/api-keys](https://console.moorcheh.ai/api-keys)
+
+## Setup
+
+```bash
+hermes memory setup    # select "memanto"
+```
+
+Or manually:
+
+```bash
+hermes config set memory.provider memanto
+echo 'MOORCHEH_API_KEY=***' >> ~/.hermes/.env
+```
+
+## Config
+
+Config file: `$HERMES_HOME/memanto.json`
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `agent_id` | `hermes-{identity}` | The Memanto agent id (memory namespace). Supports the `{identity}` template for per-profile scoping (e.g. `hermes-coder`). |
+| `pattern` | `tool` | Memanto agent pattern used when auto-creating: `support`, `project`, or `tool`. |
+| `auto_recall` | `true` | Inject relevant memories before each turn. |
+| `auto_capture` | `true` | Store cleaned user/assistant turns as `event` memories. |
+| `auto_create` | `true` | Create the agent on first use if it does not exist. |
+| `mirror_memory_writes` | `true` | Echo Hermes built-in `memory` writes into Memanto. |
+| `max_recall_results` | `10` | Max memories formatted into prefetch context (1–100). |
+| `min_confidence` | `null` | Drop recalled memories below this confidence (0.0–1.0). |
+| `session_duration_hours` | `null` | Override Memanto session lifetime (defaults to Memanto's config). |
+
+### Environment Variables
+
+| Variable | Description |
+|----------|-------------|
+| `MOORCHEH_API_KEY` | Moorcheh API key (required). |
+| `MEMANTO_AGENT_ID` | Override the agent id (takes priority over the config file). |
+
+## Tools
+
+| Tool | Description |
+|------|-------------|
+| `memanto_remember` | Store a durable fact, preference, decision, goal, or instruction. |
+| `memanto_recall` | Search memories by semantic similarity. |
+| `memanto_answer` | Answer a question grounded only in stored memories (RAG). |
+
+## Behavior
+
+When enabled, Hermes can:
+
+- prefetch relevant memories before each turn (`auto_recall`)
+- store cleaned conversation turns as `event` memories after each response (`auto_capture`)
+- mirror Hermes built-in `memory`/`user` writes into Memanto (`mirror_memory_writes`)
+- expose explicit `remember` / `recall` / `answer` tools
+
+Memory types follow Memanto's taxonomy: `fact`, `preference`, `goal`, `decision`,
+`artifact`, `learning`, `event`, `instruction`, `relationship`, `context`,
+`observation`, `commitment`, `error`.
+
+## Profile-Scoped Agents
+
+Use `{identity}` in `agent_id` to scope memories per Hermes profile:
+
+```json
+{
+  "agent_id": "hermes-{identity}"
+}
+```
+
+A profile named `coder` resolves to `hermes-coder`; the default profile resolves
+to `hermes-default`. Without `{identity}`, all profiles share one Memanto agent.
+
+## Notes
+
+- The session is warmed up (agent ensured + activated) in the background at
+  startup, so the first turn's recall does not also pay activation latency.
+- Writes are skipped in `cron`, `flush`, and `subagent` contexts to avoid
+  corrupting the user's memory representation.
+- Only one external memory provider runs at a time, selected via
+  `memory.provider` in `config.yaml`.
+
+## Support
+
+- [memanto.ai](https://memanto.ai)
+- [moorcheh.ai](https://moorcheh.ai)

--- a/plugins/memory/memanto/__init__.py
+++ b/plugins/memory/memanto/__init__.py
@@ -1,0 +1,667 @@
+"""Memanto memory agent plugin using the MemoryProvider interface.
+
+Memanto (https://memanto.ai) is a *memory agent*: typed long-term memory with
+confidence + provenance, semantic recall, and RAG-style answers, backed by the
+Moorcheh vector platform. Unlike a passive "memory layer", every namespace in
+Memanto is a first-class **agent** (``memanto agent create/activate``), so this
+provider maps one Hermes identity to one Memanto agent.
+
+What it gives Hermes:
+  * Auto-recall — relevant memories injected before each turn (prefetch).
+  * Turn capture — conversation turns persisted as ``event`` memories.
+  * Explicit tools — ``memanto_remember`` / ``memanto_recall`` / ``memanto_answer``.
+  * Built-in memory mirroring — Hermes ``memory`` writes echoed into Memanto.
+
+The Memanto SDK (``memanto``) is imported lazily so this module loads even when
+the package isn't installed; ``is_available()`` then returns False and the
+provider stays inert.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import threading
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from agent.memory_provider import MemoryProvider
+from tools.registry import tool_error
+
+logger = logging.getLogger(__name__)
+
+# -- Defaults -----------------------------------------------------------------
+
+_DEFAULT_AGENT_ID = "hermes-{identity}"
+_DEFAULT_PATTERN = "tool"
+_VALID_PATTERNS = ("support", "project", "tool")
+_DEFAULT_MAX_RECALL_RESULTS = 10
+_DEFAULT_CONFIDENCE = 0.85
+_CAPTURE_CONFIDENCE = 0.6
+_MIN_CAPTURE_LENGTH = 10
+_MAX_TITLE_LENGTH = 100
+_MAX_AGENT_ID_LENGTH = 64
+
+# Memory taxonomy mirrored from memanto.app.constants.VALID_MEMORY_TYPES so the
+# tool schema matches what the backend validates. Kept as a literal list to
+# avoid importing memanto at module-import time.
+_VALID_MEMORY_TYPES = (
+    "fact", "preference", "goal", "decision", "artifact", "learning", "event",
+    "instruction", "relationship", "context", "observation", "commitment", "error",
+)
+
+_TRIVIAL_RE = re.compile(
+    r"^(ok|okay|thanks|thank you|got it|sure|yes|no|yep|nope|k|ty|thx|np)\.?$",
+    re.IGNORECASE,
+)
+_CONTEXT_STRIP_RE = re.compile(
+    r"<memanto-memory>[\s\S]*?</memanto-memory>\s*", re.DOTALL
+)
+
+
+def _default_config() -> dict:
+    return {
+        "agent_id": _DEFAULT_AGENT_ID,
+        "pattern": _DEFAULT_PATTERN,
+        "auto_recall": True,
+        "auto_capture": True,
+        "auto_create": True,
+        "mirror_memory_writes": True,
+        "max_recall_results": _DEFAULT_MAX_RECALL_RESULTS,
+        "min_confidence": None,
+        "session_duration_hours": None,
+    }
+
+
+def _as_bool(value: Any, default: bool) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        lowered = value.strip().lower()
+        if lowered in {"true", "1", "yes", "y", "on"}:
+            return True
+        if lowered in {"false", "0", "no", "n", "off"}:
+            return False
+    return default
+
+
+def _sanitize_agent_id(raw: str) -> str:
+    """Coerce to Memanto's id charset (letters, digits, ``-``, ``_``)."""
+    cleaned = re.sub(r"[^a-zA-Z0-9_-]", "-", raw or "")
+    cleaned = re.sub(r"-+", "-", cleaned).strip("-")
+    cleaned = cleaned[:_MAX_AGENT_ID_LENGTH].strip("-")
+    return cleaned or "hermes"
+
+
+def _detect_memory_type(text: str) -> str:
+    lowered = text.lower()
+    if re.search(r"prefer|like|love|hate|want", lowered):
+        return "preference"
+    if re.search(r"decided|will use|going with|chose", lowered):
+        return "decision"
+    if re.search(r"\bis\b|\bare\b|\bhas\b|\bhave\b", lowered):
+        return "fact"
+    return "observation"
+
+
+def _load_memanto_config(hermes_home: str) -> dict:
+    config = _default_config()
+    config_path = Path(hermes_home) / "memanto.json"
+    if config_path.exists():
+        try:
+            raw = json.loads(config_path.read_text(encoding="utf-8"))
+            if isinstance(raw, dict):
+                config.update({k: v for k, v in raw.items() if v is not None})
+        except Exception:
+            logger.debug("Failed to parse %s", config_path, exc_info=True)
+
+    # agent_id is kept raw here — the {identity} template is resolved (and the
+    # result sanitized) in initialize() once agent_identity is known.
+    config["agent_id"] = str(config.get("agent_id") or _DEFAULT_AGENT_ID).strip() or _DEFAULT_AGENT_ID
+    pattern = str(config.get("pattern") or _DEFAULT_PATTERN).strip().lower()
+    config["pattern"] = pattern if pattern in _VALID_PATTERNS else _DEFAULT_PATTERN
+    config["auto_recall"] = _as_bool(config.get("auto_recall"), True)
+    config["auto_capture"] = _as_bool(config.get("auto_capture"), True)
+    config["auto_create"] = _as_bool(config.get("auto_create"), True)
+    config["mirror_memory_writes"] = _as_bool(config.get("mirror_memory_writes"), True)
+    try:
+        config["max_recall_results"] = max(1, min(100, int(config.get("max_recall_results", _DEFAULT_MAX_RECALL_RESULTS))))
+    except Exception:
+        config["max_recall_results"] = _DEFAULT_MAX_RECALL_RESULTS
+    if config.get("min_confidence") is not None:
+        try:
+            config["min_confidence"] = max(0.0, min(1.0, float(config["min_confidence"])))
+        except Exception:
+            config["min_confidence"] = None
+    if config.get("session_duration_hours") is not None:
+        try:
+            config["session_duration_hours"] = max(1, min(24 * 30, int(config["session_duration_hours"])))
+        except Exception:
+            config["session_duration_hours"] = None
+    return config
+
+
+def _save_memanto_config(values: dict, hermes_home: str) -> None:
+    config_path = Path(hermes_home) / "memanto.json"
+    existing: dict = {}
+    if config_path.exists():
+        try:
+            raw = json.loads(config_path.read_text(encoding="utf-8"))
+            if isinstance(raw, dict):
+                existing = raw
+        except Exception:
+            existing = {}
+    existing.update(values)
+    config_path.write_text(json.dumps(existing, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _clean_text_for_capture(text: str) -> str:
+    return _CONTEXT_STRIP_RE.sub("", text or "").strip()
+
+
+def _is_trivial_message(text: str) -> bool:
+    return bool(_TRIVIAL_RE.match((text or "").strip()))
+
+
+def _memory_score(raw: dict) -> Optional[float]:
+    """Coalesce the score key Memanto uses across endpoints."""
+    score = raw.get("score")
+    if score is None:
+        score = raw.get("similarity_score")
+    try:
+        return float(score) if score is not None else None
+    except (TypeError, ValueError):
+        return None
+
+
+def _format_recall_block(memories: List[dict], max_results: int) -> str:
+    """Render recall hits into a context block for prefetch injection."""
+    lines = []
+    for item in (memories or [])[:max_results]:
+        content = (item.get("content") or item.get("title") or "").strip()
+        if not content:
+            continue
+        prefix_bits = []
+        mem_type = item.get("type")
+        if mem_type:
+            prefix_bits.append(f"[{mem_type}]")
+        score = _memory_score(item)
+        if score is not None:
+            prefix_bits.append(f"[{round(score * 100)}%]")
+        prefix = " ".join(prefix_bits)
+        lines.append(f"- {prefix} {content}".strip())
+    if not lines:
+        return ""
+    intro = (
+        "Background from your Memanto memory agent. Use it silently when relevant; "
+        "do not force memories into the conversation."
+    )
+    body = "## Relevant Memories\n" + "\n".join(lines)
+    return f"<memanto-memory>\n{intro}\n\n{body}\n</memanto-memory>"
+
+
+class _MemantoClient:
+    """Thin wrapper over Memanto's ``SdkClient`` pinned to one agent.
+
+    Mirrors the MCP integration's lifecycle: ensure the agent exists (creating
+    it on first use when ``auto_create``) and activate a session once, lazily,
+    guarded by a lock. A permanent-for-session failure flag stops us from
+    re-hitting the network on every turn when the backend is unreachable.
+    """
+
+    def __init__(self, api_key: str, agent_id: str, *, pattern: str = "tool",
+                 auto_create: bool = True, session_duration_hours: Optional[int] = None):
+        from memanto.cli.client.sdk_client import SdkClient
+
+        self._agent_id = agent_id
+        self._pattern = pattern
+        self._auto_create = auto_create
+        self._session_duration_hours = session_duration_hours
+        self._client = SdkClient(api_key=api_key)
+        self._lock = threading.Lock()
+        self._ready = False
+        self._failed = False
+
+    @property
+    def agent_id(self) -> str:
+        return self._agent_id
+
+    def ensure_session(self) -> None:
+        if self._ready:
+            return
+        with self._lock:
+            if self._ready:
+                return
+            if self._failed:
+                raise RuntimeError("Memanto session activation previously failed this session")
+            from memanto.app.utils.errors import (
+                AgentAlreadyExistsError,
+                AgentNotFoundError,
+            )
+            try:
+                try:
+                    self._client.get_agent(self._agent_id)
+                except AgentNotFoundError:
+                    if not self._auto_create:
+                        raise
+                    try:
+                        self._client.create_agent(
+                            self._agent_id,
+                            pattern=self._pattern,
+                            description="Created by Hermes",
+                        )
+                    except AgentAlreadyExistsError:
+                        pass  # race: another caller created it
+                self._client.activate_agent(
+                    self._agent_id,
+                    duration_hours=self._session_duration_hours,
+                )
+                self._ready = True
+            except Exception:
+                self._failed = True
+                raise
+
+    def remember(self, *, memory_type: str, title: str, content: str,
+                 confidence: float, tags: Optional[List[str]] = None,
+                 source: str = "hermes", provenance: str = "explicit_statement") -> dict:
+        self.ensure_session()
+        return self._client.remember(
+            agent_id=self._agent_id,
+            memory_type=memory_type,
+            title=title,
+            content=content,
+            confidence=confidence,
+            tags=tags or [],
+            source=source,
+            provenance=provenance,
+        )
+
+    def recall(self, query: str, *, limit: int, type: Optional[List[str]] = None,
+               min_confidence: Optional[float] = None) -> List[dict]:
+        self.ensure_session()
+        result = self._client.recall(
+            agent_id=self._agent_id,
+            query=query,
+            limit=limit,
+            type=type,
+            min_confidence=min_confidence,
+        )
+        return result.get("memories", [])
+
+    def answer(self, question: str, *, limit: Optional[int] = None) -> dict:
+        self.ensure_session()
+        return self._client.answer(
+            agent_id=self._agent_id,
+            question=question,
+            limit=limit,
+        )
+
+
+# -- Tool schemas -------------------------------------------------------------
+
+REMEMBER_SCHEMA = {
+    "name": "memanto_remember",
+    "description": "Store a durable fact, preference, decision, goal, or instruction in the Memanto memory agent for future recall.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "content": {"type": "string", "description": "The memory itself — one atomic, self-contained statement."},
+            "type": {
+                "type": "string",
+                "enum": list(_VALID_MEMORY_TYPES),
+                "description": "Semantic memory type. Use 'preference' for likes/styles, 'fact' for stable claims, 'decision' for choices, 'goal' for objectives, 'instruction' for directives.",
+            },
+            "tags": {"type": "array", "items": {"type": "string"}, "description": "Optional lowercase tags for later filtering."},
+            "confidence": {"type": "number", "description": "How sure you are this is true, 0.0-1.0. Use 1.0 only for explicit statements."},
+        },
+        "required": ["content"],
+    },
+}
+
+RECALL_SCHEMA = {
+    "name": "memanto_recall",
+    "description": "Search the Memanto memory agent by semantic similarity. Use this FIRST before asking the user to repeat information.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "query": {"type": "string", "description": "Natural-language search query."},
+            "limit": {"type": "integer", "description": "Maximum results to return, 1 to 100."},
+            "type": {
+                "type": "array",
+                "items": {"type": "string", "enum": list(_VALID_MEMORY_TYPES)},
+                "description": "Optional type filter, e.g. ['preference'].",
+            },
+        },
+        "required": ["query"],
+    },
+}
+
+ANSWER_SCHEMA = {
+    "name": "memanto_answer",
+    "description": "Ask a natural-language question and get an answer grounded ONLY in the Memanto memory agent's stored memories (RAG). Prefer over memanto_recall when you need a synthesized answer rather than a ranked list.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "question": {"type": "string", "description": "The question to answer from memory."},
+            "limit": {"type": "integer", "description": "Number of context memories to retrieve, 1 to 100."},
+        },
+        "required": ["question"],
+    },
+}
+
+
+class MemantoMemoryProvider(MemoryProvider):
+    """Memanto-backed memory provider for Hermes."""
+
+    def __init__(self):
+        self._config = _default_config()
+        self._api_key = ""
+        self._client: Optional[_MemantoClient] = None
+        self._agent_id = "hermes"
+        self._hermes_home = ""
+        self._auto_recall = True
+        self._auto_capture = True
+        self._mirror_memory_writes = True
+        self._max_recall_results = _DEFAULT_MAX_RECALL_RESULTS
+        self._min_confidence: Optional[float] = None
+        self._write_enabled = True
+        self._active = False
+        self._warmup_thread: Optional[threading.Thread] = None
+        self._sync_thread: Optional[threading.Thread] = None
+        self._write_thread: Optional[threading.Thread] = None
+
+    @property
+    def name(self) -> str:
+        return "memanto"
+
+    def is_available(self) -> bool:
+        if not os.environ.get("MOORCHEH_API_KEY", "").strip():
+            return False
+        try:
+            __import__("memanto")
+            return True
+        except Exception:
+            return False
+
+    def get_config_schema(self):
+        return [
+            {
+                "key": "api_key",
+                "description": "Moorcheh API key (powers Memanto)",
+                "secret": True,
+                "required": True,
+                "env_var": "MOORCHEH_API_KEY",
+                "url": "https://console.moorcheh.ai/api-keys",
+            },
+            {
+                "key": "agent_id",
+                "description": "Memory agent id / namespace ({identity} expands to the profile name)",
+                "secret": False,
+                "required": False,
+                "default": _DEFAULT_AGENT_ID,
+            },
+        ]
+
+    def save_config(self, values, hermes_home):
+        sanitized = dict(values or {})
+        # Keep the {identity} template intact; only sanitize concrete ids.
+        if "agent_id" in sanitized and "{identity}" not in str(sanitized["agent_id"]):
+            sanitized["agent_id"] = _sanitize_agent_id(str(sanitized["agent_id"]))
+        if "pattern" in sanitized:
+            pattern = str(sanitized["pattern"]).strip().lower()
+            sanitized["pattern"] = pattern if pattern in _VALID_PATTERNS else _DEFAULT_PATTERN
+        _save_memanto_config(sanitized, hermes_home)
+
+    def initialize(self, session_id: str, **kwargs) -> None:
+        from hermes_constants import get_hermes_home
+
+        self._hermes_home = kwargs.get("hermes_home") or str(get_hermes_home())
+        self._config = _load_memanto_config(self._hermes_home)
+        self._api_key = os.environ.get("MOORCHEH_API_KEY", "").strip()
+
+        # Resolve the agent id: env override > config, with {identity} template.
+        identity = kwargs.get("agent_identity", "default") or "default"
+        raw_id = os.environ.get("MEMANTO_AGENT_ID", "").strip() or self._config["agent_id"]
+        self._agent_id = _sanitize_agent_id(raw_id.replace("{identity}", identity))
+
+        self._auto_recall = self._config["auto_recall"]
+        self._auto_capture = self._config["auto_capture"]
+        self._mirror_memory_writes = self._config["mirror_memory_writes"]
+        self._max_recall_results = self._config["max_recall_results"]
+        self._min_confidence = self._config["min_confidence"]
+
+        agent_context = kwargs.get("agent_context", "")
+        self._write_enabled = agent_context not in {"cron", "flush", "subagent"}
+
+        self._active = False
+        self._client = None
+        if not self._api_key:
+            return
+        try:
+            self._client = _MemantoClient(
+                self._api_key,
+                self._agent_id,
+                pattern=self._config["pattern"],
+                auto_create=self._config["auto_create"],
+                session_duration_hours=self._config["session_duration_hours"],
+            )
+            self._active = True
+        except Exception:
+            logger.warning("Memanto initialization failed", exc_info=True)
+            self._client = None
+            self._active = False
+            return
+
+        # Warm up the session in the background so the first turn's recall does
+        # not also pay agent-create + activate latency.
+        self._warmup_thread = threading.Thread(
+            target=self._warmup, daemon=True, name="memanto-warmup"
+        )
+        self._warmup_thread.start()
+
+    def _warmup(self) -> None:
+        try:
+            self._client.ensure_session()
+        except Exception:
+            logger.debug("Memanto warmup activation failed", exc_info=True)
+
+    def system_prompt_block(self) -> str:
+        if not self._active:
+            return ""
+        return (
+            "# Memanto Memory Agent\n"
+            f"Active. Memory agent: {self._agent_id}.\n"
+            "Use memanto_recall to look up stored memories, memanto_remember to save durable "
+            "facts/preferences/decisions/goals, and memanto_answer for a synthesized answer "
+            "grounded in memory."
+        )
+
+    def prefetch(self, query: str, *, session_id: str = "") -> str:
+        if not self._active or not self._auto_recall or not self._client or not query.strip():
+            return ""
+        try:
+            memories = self._client.recall(
+                query[:2000],
+                limit=self._max_recall_results,
+                min_confidence=self._min_confidence,
+            )
+            return _format_recall_block(memories, self._max_recall_results)
+        except Exception:
+            logger.debug("Memanto prefetch failed", exc_info=True)
+            return ""
+
+    def sync_turn(self, user_content: str, assistant_content: str, *, session_id: str = "") -> None:
+        if not self._active or not self._auto_capture or not self._write_enabled or not self._client:
+            return
+        clean_user = _clean_text_for_capture(user_content)
+        clean_assistant = _clean_text_for_capture(assistant_content)
+        if len(clean_user) < _MIN_CAPTURE_LENGTH or len(clean_assistant) < _MIN_CAPTURE_LENGTH:
+            return
+        if _is_trivial_message(clean_user):
+            return
+
+        title = clean_user[:_MAX_TITLE_LENGTH - 3] + "..." if len(clean_user) > _MAX_TITLE_LENGTH else clean_user
+        content = f"User: {clean_user}\n\nAssistant: {clean_assistant}"
+
+        def _run():
+            try:
+                self._client.remember(
+                    memory_type="event",
+                    title=title,
+                    content=content,
+                    confidence=_CAPTURE_CONFIDENCE,
+                    tags=["conversation"],
+                    source="hermes",
+                    provenance="observed",
+                )
+            except Exception:
+                logger.debug("Memanto sync_turn failed", exc_info=True)
+
+        if self._sync_thread and self._sync_thread.is_alive():
+            self._sync_thread.join(timeout=2.0)
+        self._sync_thread = threading.Thread(target=_run, daemon=True, name="memanto-sync")
+        self._sync_thread.start()
+
+    def on_memory_write(self, action: str, target: str, content: str,
+                        metadata: Optional[Dict[str, Any]] = None) -> None:
+        if not self._active or not self._write_enabled or not self._mirror_memory_writes or not self._client:
+            return
+        if action != "add" or not (content or "").strip():
+            return
+        clean = content.strip()
+        title = clean[:_MAX_TITLE_LENGTH - 3] + "..." if len(clean) > _MAX_TITLE_LENGTH else clean
+        mem_type = "preference" if target == "user" else _detect_memory_type(clean)
+
+        def _run():
+            try:
+                self._client.remember(
+                    memory_type=mem_type,
+                    title=title,
+                    content=clean,
+                    confidence=0.9,
+                    tags=["hermes-memory", target],
+                    source="hermes-memory",
+                    provenance="explicit_statement",
+                )
+            except Exception:
+                logger.debug("Memanto on_memory_write failed", exc_info=True)
+
+        if self._write_thread and self._write_thread.is_alive():
+            self._write_thread.join(timeout=2.0)
+        self._write_thread = threading.Thread(target=_run, daemon=False, name="memanto-memory-write")
+        self._write_thread.start()
+
+    def shutdown(self) -> None:
+        for attr_name in ("_warmup_thread", "_sync_thread", "_write_thread"):
+            thread = getattr(self, attr_name, None)
+            if thread and thread.is_alive():
+                thread.join(timeout=5.0)
+            setattr(self, attr_name, None)
+
+    # -- Tools ----------------------------------------------------------------
+
+    def get_tool_schemas(self) -> List[Dict[str, Any]]:
+        return [REMEMBER_SCHEMA, RECALL_SCHEMA, ANSWER_SCHEMA]
+
+    def _tool_remember(self, args: dict) -> str:
+        content = str(args.get("content") or "").strip()
+        if not content:
+            return tool_error("content is required")
+        mem_type = str(args.get("type") or "").strip()
+        if mem_type not in _VALID_MEMORY_TYPES:
+            mem_type = _detect_memory_type(content)
+        tags = args.get("tags") or []
+        if not isinstance(tags, list):
+            tags = []
+        try:
+            confidence = float(args.get("confidence", _DEFAULT_CONFIDENCE))
+        except (TypeError, ValueError):
+            confidence = _DEFAULT_CONFIDENCE
+        confidence = max(0.0, min(1.0, confidence))
+        title = content[:_MAX_TITLE_LENGTH - 3] + "..." if len(content) > _MAX_TITLE_LENGTH else content
+        try:
+            result = self._client.remember(
+                memory_type=mem_type,
+                title=title,
+                content=content,
+                confidence=confidence,
+                tags=[str(t) for t in tags],
+                source="hermes-tool",
+                provenance="explicit_statement",
+            )
+            return json.dumps({
+                "saved": True,
+                "memory_id": result.get("memory_id"),
+                "agent_id": self._agent_id,
+                "type": mem_type,
+            })
+        except Exception as exc:
+            return tool_error(f"Failed to store memory: {exc}")
+
+    def _tool_recall(self, args: dict) -> str:
+        query = str(args.get("query") or "").strip()
+        if not query:
+            return tool_error("query is required")
+        try:
+            limit = max(1, min(100, int(args.get("limit", self._max_recall_results) or self._max_recall_results)))
+        except (TypeError, ValueError):
+            limit = self._max_recall_results
+        type_filter = args.get("type")
+        if type_filter is not None and not isinstance(type_filter, list):
+            type_filter = [type_filter]
+        try:
+            memories = self._client.recall(
+                query, limit=limit, type=type_filter, min_confidence=self._min_confidence
+            )
+            formatted = []
+            for item in memories:
+                entry: Dict[str, Any] = {
+                    "id": item.get("id"),
+                    "type": item.get("type"),
+                    "content": item.get("content") or item.get("title", ""),
+                }
+                score = _memory_score(item)
+                if score is not None:
+                    entry["score"] = round(score * 100)
+                formatted.append(entry)
+            return json.dumps({"results": formatted, "count": len(formatted)})
+        except Exception as exc:
+            return tool_error(f"Recall failed: {exc}")
+
+    def _tool_answer(self, args: dict) -> str:
+        question = str(args.get("question") or "").strip()
+        if not question:
+            return tool_error("question is required")
+        limit = args.get("limit")
+        if limit is not None:
+            try:
+                limit = max(1, min(100, int(limit)))
+            except (TypeError, ValueError):
+                limit = None
+        try:
+            result = self._client.answer(question, limit=limit)
+            sources = result.get("sources", []) or []
+            return json.dumps({
+                "answer": result.get("answer", ""),
+                "sources": sources,
+                "count": len(sources),
+            })
+        except Exception as exc:
+            return tool_error(f"Answer failed: {exc}")
+
+    def handle_tool_call(self, tool_name: str, args: Dict[str, Any], **kwargs) -> str:
+        if not self._active or not self._client:
+            return tool_error("Memanto is not configured")
+        if tool_name == "memanto_remember":
+            return self._tool_remember(args)
+        if tool_name == "memanto_recall":
+            return self._tool_recall(args)
+        if tool_name == "memanto_answer":
+            return self._tool_answer(args)
+        return tool_error(f"Unknown tool: {tool_name}")
+
+
+def register(ctx):
+    ctx.register_memory_provider(MemantoMemoryProvider())

--- a/plugins/memory/memanto/plugin.yaml
+++ b/plugins/memory/memanto/plugin.yaml
@@ -1,0 +1,5 @@
+name: memanto
+version: 1.0.0
+description: "Memanto memory agent — typed long-term memory (remember/recall/answer) backed by Moorcheh, with auto-recall, turn capture, and RAG."
+pip_dependencies:
+  - memanto

--- a/tests/plugins/memory/test_memanto_provider.py
+++ b/tests/plugins/memory/test_memanto_provider.py
@@ -1,0 +1,343 @@
+import json
+
+import pytest
+
+from plugins.memory.memanto import (
+    MemantoMemoryProvider,
+    _detect_memory_type,
+    _format_recall_block,
+    _load_memanto_config,
+    _sanitize_agent_id,
+    _save_memanto_config,
+)
+
+
+class FakeClient:
+    """Stand-in for ``_MemantoClient`` — records calls, returns canned data."""
+
+    def __init__(self, api_key, agent_id, *, pattern="tool", auto_create=True,
+                 session_duration_hours=None):
+        self.api_key = api_key
+        self._agent_id = agent_id
+        self.pattern = pattern
+        self.auto_create = auto_create
+        self.session_duration_hours = session_duration_hours
+        self.ensure_calls = 0
+        self.remember_calls = []
+        self.answer_calls = []
+        self.recall_results = []
+        self.answer_response = {"answer": "", "sources": []}
+
+    @property
+    def agent_id(self):
+        return self._agent_id
+
+    def ensure_session(self):
+        self.ensure_calls += 1
+
+    def remember(self, *, memory_type, title, content, confidence,
+                 tags=None, source="hermes", provenance="explicit_statement"):
+        self.remember_calls.append({
+            "memory_type": memory_type,
+            "title": title,
+            "content": content,
+            "confidence": confidence,
+            "tags": tags or [],
+            "source": source,
+            "provenance": provenance,
+        })
+        return {"memory_id": "mem_123", "agent_id": self._agent_id, "status": "queued"}
+
+    def recall(self, query, *, limit, type=None, min_confidence=None):
+        return self.recall_results
+
+    def answer(self, question, *, limit=None):
+        self.answer_calls.append({"question": question, "limit": limit})
+        return self.answer_response
+
+
+@pytest.fixture
+def provider(monkeypatch, tmp_path):
+    monkeypatch.setenv("MOORCHEH_API_KEY", "test-key")
+    monkeypatch.delenv("MEMANTO_AGENT_ID", raising=False)
+    monkeypatch.setattr("plugins.memory.memanto._MemantoClient", FakeClient)
+    p = MemantoMemoryProvider()
+    p.initialize("session-1", hermes_home=str(tmp_path), platform="cli")
+    if p._warmup_thread:
+        p._warmup_thread.join(timeout=1)
+    return p
+
+
+# -- Availability -------------------------------------------------------------
+
+
+def test_is_available_false_without_api_key(monkeypatch):
+    monkeypatch.delenv("MOORCHEH_API_KEY", raising=False)
+    p = MemantoMemoryProvider()
+    assert p.is_available() is False
+
+
+def test_is_available_false_when_import_missing(monkeypatch):
+    monkeypatch.setenv("MOORCHEH_API_KEY", "test-key")
+
+    import builtins
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "memanto":
+            raise ImportError("missing")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    p = MemantoMemoryProvider()
+    assert p.is_available() is False
+
+
+# -- Helpers ------------------------------------------------------------------
+
+
+def test_sanitize_agent_id_coerces_charset():
+    assert _sanitize_agent_id("Hermes Coder!@#") == "Hermes-Coder"
+    assert _sanitize_agent_id("") == "hermes"
+    assert _sanitize_agent_id("a" * 100) == "a" * 64
+
+
+def test_detect_memory_type():
+    assert _detect_memory_type("User prefers dark mode") == "preference"
+    assert _detect_memory_type("We decided to use Postgres") == "decision"
+    assert _detect_memory_type("The API is rate limited") == "fact"
+
+
+def test_load_and_save_config_round_trip(tmp_path):
+    _save_memanto_config({"agent_id": "Demo Agent", "auto_capture": False}, str(tmp_path))
+    cfg = _load_memanto_config(str(tmp_path))
+    # save_config is invoked via the provider; here we only check load defaults.
+    assert cfg["agent_id"] == "Demo Agent"
+    assert cfg["auto_capture"] is False
+    assert cfg["auto_recall"] is True
+    assert cfg["pattern"] == "tool"
+
+
+def test_save_config_sanitizes_concrete_agent_id(tmp_path):
+    p = MemantoMemoryProvider()
+    p.save_config({"agent_id": "My Agent!"}, str(tmp_path))
+    cfg = _load_memanto_config(str(tmp_path))
+    assert cfg["agent_id"] == "My-Agent"
+
+
+def test_save_config_preserves_identity_template(tmp_path):
+    p = MemantoMemoryProvider()
+    p.save_config({"agent_id": "hermes-{identity}"}, str(tmp_path))
+    cfg = _load_memanto_config(str(tmp_path))
+    assert cfg["agent_id"] == "hermes-{identity}"
+
+
+def test_format_recall_block_renders_types_and_scores():
+    block = _format_recall_block(
+        [
+            {"type": "preference", "content": "Prefers dark mode", "score": 0.91},
+            {"type": "fact", "content": "Lives in Berlin"},
+        ],
+        max_results=10,
+    )
+    assert "<memanto-memory>" in block
+    assert "[preference] [91%] Prefers dark mode" in block
+    assert "[fact] Lives in Berlin" in block
+
+
+def test_format_recall_block_empty():
+    assert _format_recall_block([], max_results=10) == ""
+
+
+# -- Identity / config resolution --------------------------------------------
+
+
+def test_identity_template_resolved(monkeypatch, tmp_path):
+    monkeypatch.setenv("MOORCHEH_API_KEY", "test-key")
+    monkeypatch.delenv("MEMANTO_AGENT_ID", raising=False)
+    monkeypatch.setattr("plugins.memory.memanto._MemantoClient", FakeClient)
+    _save_memanto_config({"agent_id": "hermes-{identity}"}, str(tmp_path))
+    p = MemantoMemoryProvider()
+    p.initialize("s1", hermes_home=str(tmp_path), platform="cli", agent_identity="coder")
+    assert p._agent_id == "hermes-coder"
+
+
+def test_identity_template_default_profile(monkeypatch, tmp_path):
+    monkeypatch.setenv("MOORCHEH_API_KEY", "test-key")
+    monkeypatch.delenv("MEMANTO_AGENT_ID", raising=False)
+    monkeypatch.setattr("plugins.memory.memanto._MemantoClient", FakeClient)
+    _save_memanto_config({"agent_id": "hermes-{identity}"}, str(tmp_path))
+    p = MemantoMemoryProvider()
+    p.initialize("s1", hermes_home=str(tmp_path), platform="cli")
+    assert p._agent_id == "hermes-default"
+
+
+def test_agent_id_env_override(monkeypatch, tmp_path):
+    monkeypatch.setenv("MOORCHEH_API_KEY", "test-key")
+    monkeypatch.setenv("MEMANTO_AGENT_ID", "env-agent")
+    monkeypatch.setattr("plugins.memory.memanto._MemantoClient", FakeClient)
+    p = MemantoMemoryProvider()
+    p.initialize("s1", hermes_home=str(tmp_path), platform="cli")
+    assert p._agent_id == "env-agent"
+
+
+# -- Prefetch -----------------------------------------------------------------
+
+
+def test_prefetch_formats_recall(provider):
+    provider._client.recall_results = [
+        {"id": "m1", "type": "preference", "content": "Prefers dark mode", "score": 0.88}
+    ]
+    result = provider.prefetch("ui preferences")
+    assert "Relevant Memories" in result
+    assert "Prefers dark mode" in result
+
+
+def test_prefetch_empty_query_returns_blank(provider):
+    assert provider.prefetch("   ") == ""
+
+
+def test_prefetch_disabled_when_auto_recall_off(monkeypatch, tmp_path):
+    monkeypatch.setenv("MOORCHEH_API_KEY", "test-key")
+    monkeypatch.setattr("plugins.memory.memanto._MemantoClient", FakeClient)
+    _save_memanto_config({"auto_recall": False}, str(tmp_path))
+    p = MemantoMemoryProvider()
+    p.initialize("s1", hermes_home=str(tmp_path), platform="cli")
+    if p._warmup_thread:
+        p._warmup_thread.join(timeout=1)
+    p._client.recall_results = [{"type": "fact", "content": "x", "score": 0.9}]
+    assert p.prefetch("anything") == ""
+
+
+# -- Turn capture -------------------------------------------------------------
+
+
+def test_sync_turn_skips_trivial(provider):
+    provider.sync_turn("ok", "sure", session_id="session-1")
+    assert provider._client.remember_calls == []
+
+
+def test_sync_turn_persists_event(provider):
+    provider.sync_turn(
+        "Please remember I work in Pacific time",
+        "Got it — noting your timezone as Pacific.",
+        session_id="session-1",
+    )
+    provider._sync_thread.join(timeout=1)
+    assert len(provider._client.remember_calls) == 1
+    call = provider._client.remember_calls[0]
+    assert call["memory_type"] == "event"
+    assert "User:" in call["content"] and "Assistant:" in call["content"]
+
+
+def test_sync_turn_skipped_in_cron_context(monkeypatch, tmp_path):
+    monkeypatch.setenv("MOORCHEH_API_KEY", "test-key")
+    monkeypatch.setattr("plugins.memory.memanto._MemantoClient", FakeClient)
+    p = MemantoMemoryProvider()
+    p.initialize("s1", hermes_home=str(tmp_path), platform="cron", agent_context="cron")
+    if p._warmup_thread:
+        p._warmup_thread.join(timeout=1)
+    p.sync_turn(
+        "Remember this long enough message to pass the filter",
+        "Acknowledged, storing the long enough message now.",
+        session_id="s1",
+    )
+    assert p._client.remember_calls == []
+
+
+# -- Built-in memory mirroring ------------------------------------------------
+
+
+def test_on_memory_write_mirrors_to_memanto(provider):
+    provider.on_memory_write("add", "memory", "The deploy pipeline lives in gh actions")
+    provider._write_thread.join(timeout=1)
+    assert len(provider._client.remember_calls) == 1
+    assert provider._client.remember_calls[0]["source"] == "hermes-memory"
+
+
+def test_on_memory_write_user_target_is_preference(provider):
+    provider.on_memory_write("add", "user", "Name is Jordan")
+    provider._write_thread.join(timeout=1)
+    assert provider._client.remember_calls[0]["memory_type"] == "preference"
+
+
+def test_on_memory_write_ignores_non_add(provider):
+    provider.on_memory_write("remove", "memory", "something")
+    assert provider._write_thread is None
+
+
+# -- Tools --------------------------------------------------------------------
+
+
+def test_get_tool_schemas_names(provider):
+    names = {s["name"] for s in provider.get_tool_schemas()}
+    assert names == {"memanto_remember", "memanto_recall", "memanto_answer"}
+
+
+def test_remember_tool(provider):
+    result = json.loads(provider.handle_tool_call(
+        "memanto_remember", {"content": "Prefers TypeScript", "type": "preference"}
+    ))
+    assert result["saved"] is True
+    assert result["memory_id"] == "mem_123"
+    assert result["type"] == "preference"
+    assert provider._client.remember_calls[0]["source"] == "hermes-tool"
+
+
+def test_remember_tool_infers_type_when_invalid(provider):
+    json.loads(provider.handle_tool_call(
+        "memanto_remember", {"content": "User prefers vim", "type": "not-a-type"}
+    ))
+    assert provider._client.remember_calls[0]["memory_type"] == "preference"
+
+
+def test_remember_tool_requires_content(provider):
+    result = json.loads(provider.handle_tool_call("memanto_remember", {"content": "  "}))
+    assert "error" in result
+
+
+def test_recall_tool_formats_results(provider):
+    provider._client.recall_results = [
+        {"id": "m1", "type": "fact", "content": "Lives in Berlin", "similarity_score": 0.77}
+    ]
+    result = json.loads(provider.handle_tool_call("memanto_recall", {"query": "where"}))
+    assert result["count"] == 1
+    assert result["results"][0]["score"] == 77
+    assert result["results"][0]["type"] == "fact"
+
+
+def test_answer_tool(provider):
+    provider._client.answer_response = {
+        "answer": "They prefer dark mode.",
+        "sources": [{"id": "m1"}],
+    }
+    result = json.loads(provider.handle_tool_call("memanto_answer", {"question": "ui pref?"}))
+    assert result["answer"] == "They prefer dark mode."
+    assert result["count"] == 1
+
+
+def test_handle_tool_call_unknown(provider):
+    result = json.loads(provider.handle_tool_call("memanto_unknown", {}))
+    assert "error" in result
+
+
+def test_handle_tool_call_unconfigured_returns_error(monkeypatch):
+    monkeypatch.delenv("MOORCHEH_API_KEY", raising=False)
+    p = MemantoMemoryProvider()
+    result = json.loads(p.handle_tool_call("memanto_recall", {"query": "x"}))
+    assert "error" in result
+
+
+def test_get_config_schema(provider):
+    schema = provider.get_config_schema()
+    keys = {f["key"] for f in schema}
+    assert "api_key" in keys and "agent_id" in keys
+    api_field = next(f for f in schema if f["key"] == "api_key")
+    assert api_field["secret"] is True
+    assert api_field["env_var"] == "MOORCHEH_API_KEY"
+
+
+def test_system_prompt_block_mentions_agent(provider):
+    block = provider.system_prompt_block()
+    assert "Memanto Memory Agent" in block
+    assert provider._agent_id in block

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -935,7 +935,7 @@ See [Hooks](../user-guide/features/hooks.md) for event signatures and payload sh
 hermes memory <subcommand>
 ```
 
-Set up and manage external memory provider plugins. Available providers: honcho, openviking, mem0, hindsight, holographic, retaindb, byterover, supermemory. Only one external provider can be active at a time. Built-in memory (MEMORY.md/USER.md) is always active.
+Set up and manage external memory provider plugins. Available providers: honcho, openviking, mem0, hindsight, holographic, retaindb, byterover, supermemory, memanto. Only one external provider can be active at a time. Built-in memory (MEMORY.md/USER.md) is always active.
 
 Subcommands:
 

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -156,6 +156,8 @@ For native Anthropic auth, Hermes prefers Claude Code's own credential files whe
 | `HONCHO_BASE_URL` | Base URL for self-hosted Honcho instances (default: Honcho cloud). No API key required for local instances |
 | `HINDSIGHT_TIMEOUT` | Timeout in seconds for Hindsight memory-provider API calls (default: `60`). Bump this if your Hindsight instance is slow to respond during `/sync` or `on_session_switch` and you're seeing timeouts in `errors.log`. |
 | `SUPERMEMORY_API_KEY` | Semantic long-term memory with profile recall and session ingest ([supermemory.ai](https://supermemory.ai)) |
+| `MOORCHEH_API_KEY` | Memanto memory agent — typed long-term memory with recall + RAG ([memanto.ai](https://memanto.ai)) |
+| `MEMANTO_AGENT_ID` | Override the Memanto agent id / memory namespace (default from `memanto.json`) |
 | `DAYTONA_API_KEY` | Daytona cloud sandboxes ([daytona.io](https://daytona.io/)) |
 | `VERCEL_TOKEN` | Vercel Sandbox access token ([vercel.com](https://vercel.com/)) |
 | `VERCEL_PROJECT_ID` | Vercel project ID (required with `VERCEL_TOKEN`) |

--- a/website/docs/user-guide/features/memory-providers.md
+++ b/website/docs/user-guide/features/memory-providers.md
@@ -1,12 +1,12 @@
 ---
 sidebar_position: 4
 title: "Memory Providers"
-description: "External memory provider plugins — Honcho, OpenViking, Mem0, Hindsight, Holographic, RetainDB, ByteRover, Supermemory"
+description: "External memory provider plugins — Honcho, OpenViking, Mem0, Hindsight, Holographic, RetainDB, ByteRover, Supermemory, Memanto"
 ---
 
 # Memory Providers
 
-Hermes Agent ships with 8 external memory provider plugins that give the agent persistent, cross-session knowledge beyond the built-in MEMORY.md and USER.md. Only **one** external provider can be active at a time — the built-in memory is always active alongside it.
+Hermes Agent ships with 9 external memory provider plugins that give the agent persistent, cross-session knowledge beyond the built-in MEMORY.md and USER.md. Only **one** external provider can be active at a time — the built-in memory is always active alongside it.
 
 ## Quick Start
 
@@ -22,7 +22,7 @@ Or set manually in `~/.hermes/config.yaml`:
 
 ```yaml
 memory:
-  provider: openviking   # or honcho, mem0, hindsight, holographic, retaindb, byterover, supermemory
+  provider: openviking   # or honcho, mem0, hindsight, holographic, retaindb, byterover, supermemory, memanto
 ```
 
 ## How It Works
@@ -522,6 +522,54 @@ echo 'SUPERMEMORY_API_KEY=***' >> ~/.hermes/.env
 
 ---
 
+### Memanto
+
+A typed long-term memory **agent** backed by the Moorcheh vector platform. Each Memanto namespace is a first-class *agent* (`memanto agent create/activate`), so one Hermes identity maps to one Memanto agent. Memories carry a semantic type, confidence, and provenance, and can be retrieved by similarity or synthesized into a grounded answer (RAG).
+
+| | |
+|---|---|
+| **Best for** | Typed memory with confidence/provenance and RAG-style answers grounded only in stored memory |
+| **Requires** | `pip install memanto` + [Moorcheh API key](https://console.moorcheh.ai/api-keys) |
+| **Data storage** | Moorcheh Cloud |
+| **Cost** | Moorcheh pricing |
+
+**Tools:** `memanto_remember` (store a typed memory), `memanto_recall` (semantic search), `memanto_answer` (RAG answer grounded in stored memories)
+
+**Setup:**
+```bash
+hermes memory setup    # select "memanto"
+# Or manually:
+hermes config set memory.provider memanto
+echo 'MOORCHEH_API_KEY=***' >> ~/.hermes/.env
+```
+
+**Config:** `$HERMES_HOME/memanto.json`
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `agent_id` | `hermes-{identity}` | Memanto agent id (memory namespace). `{identity}` expands to the profile name (e.g. `hermes-coder`). |
+| `pattern` | `tool` | Memanto agent pattern used when auto-creating: `support`, `project`, or `tool`. |
+| `auto_recall` | `true` | Inject relevant memories before each turn |
+| `auto_capture` | `true` | Store cleaned user/assistant turns as `event` memories |
+| `auto_create` | `true` | Create the agent on first use if it does not exist |
+| `mirror_memory_writes` | `true` | Echo Hermes built-in `memory`/`user` writes into Memanto |
+| `max_recall_results` | `10` | Max memories formatted into prefetch context (1–100) |
+| `min_confidence` | `null` | Drop recalled memories below this confidence (0.0–1.0) |
+| `session_duration_hours` | `null` | Override Memanto session lifetime |
+
+**Environment variables:** `MOORCHEH_API_KEY` (required), `MEMANTO_AGENT_ID` (overrides the config agent id).
+
+**Key features:**
+- 13-type memory taxonomy (`fact`, `preference`, `decision`, `goal`, `instruction`, `event`, `observation`, …) with confidence + provenance
+- RAG answers grounded only in stored memory via `memanto_answer`
+- **Profile-scoped agents** — use `{identity}` in `agent_id` to isolate memories per Hermes profile
+- Background session warmup so the first turn's recall doesn't also pay agent activation latency
+- Writes skipped in `cron`, `flush`, and `subagent` contexts
+
+**Support:** [memanto.ai](https://memanto.ai) · [moorcheh.ai](https://moorcheh.ai)
+
+---
+
 ## Provider Comparison
 
 | Provider | Storage | Cost | Tools | Dependencies | Unique Feature |
@@ -534,13 +582,14 @@ echo 'SUPERMEMORY_API_KEY=***' >> ~/.hermes/.env
 | **RetainDB** | Cloud | $20/mo | 5 | `requests` | Delta compression |
 | **ByteRover** | Local/Cloud | Free/Paid | 3 | `brv` CLI | Pre-compression extraction |
 | **Supermemory** | Cloud | Paid | 4 | `supermemory` | Context fencing + session graph ingest + multi-container |
+| **Memanto** | Cloud | Paid | 3 | `memanto` | Typed memory (confidence + provenance) + RAG answers |
 
 ## Profile Isolation
 
 Each provider's data is isolated per [profile](/docs/user-guide/profiles):
 
 - **Local storage providers** (Holographic, ByteRover) use `$HERMES_HOME/` paths which differ per profile
-- **Config file providers** (Honcho, Mem0, Hindsight, Supermemory) store config in `$HERMES_HOME/` so each profile has its own credentials
+- **Config file providers** (Honcho, Mem0, Hindsight, Supermemory, Memanto) store config in `$HERMES_HOME/` so each profile has its own credentials
 - **Cloud providers** (RetainDB) auto-derive profile-scoped project names
 - **Env var providers** (OpenViking) are configured via each profile's `.env` file
 


### PR DESCRIPTION
## What does this PR do?

Adds an in-tree memory provider for [Memanto](https://memanto.ai) - a typed long-term memory **agent** backed by the Moorcheh vector platform. Each Memanto namespace is a
  first-class *agent* (`memanto agent create/activate`), so one Hermes identity maps to one Memanto agent.

  It follows the existing provider pattern (closest analog: `supermemory`) — `plugin.yaml` + `register(ctx)` wrapping Memanto's `SdkClient` directly. No core files are touched;
   it's discovered through the standard memory-plugin path and activated via `hermes memory setup`. Gives the agent auto-recall, turn capture, built-in memory-write mirroring,
  and `remember` / `recall` / `answer` (RAG) tools.


## Related Issue

_No related issue - new growing memory-provider contribution._

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `plugins/memory/memanto/__init__.py` - `MemantoMemoryProvider` on the `MemoryProvider` ABC: lazy `SdkClient` wrapper with background session warmup, auto-recall `prefetch`,
turn capture as `event` memories, `on_memory_write` mirroring, and `memanto_remember` / `memanto_recall` / `memanto_answer` tools. `agent_id` supports the `{identity}`
template for per-profile scoping.
- `plugins/memory/memanto/plugin.yaml` - metadata + `memanto` pip dependency.
- `plugins/memory/memanto/README.md` - setup, config keys, env vars, tools.
- `tests/plugins/memory/test_memanto_provider.py` - 31 tests (mocked `SdkClient`, no network).
- `website/docs/user-guide/features/memory-providers.md`, `website/docs/reference/cli-commands.md`, `website/docs/reference/environment-variables.md`, `AGENTS.md` - added
Memanto to the maintained provider enumerations.

## How to Test

1. `pip install memanto` and add `MOORCHEH_API_KEY=...` to `~/.hermes/.env` (key from https://console.moorcheh.ai/api-keys).
2. `hermes memory setup` → select `memanto` (or `hermes config set memory.provider memanto`), then start a new session.
3. Confirm `memanto_remember` / `memanto_recall` / `memanto_answer` are exposed, that stored facts are auto-recalled on later turns, and `hermes memory status` shows memanto
active.
4. Run the unit tests: `pytest tests/plugins/memory/test_memanto_provider.py -q` → 31 passed. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
