### PR TITLE
fix(tools): warn when toolsets are filtered by missing env vars

### DIFF
--- a/tests/tools/test_discord_tool.py
+++ b/tests/tools/test_discord_tool.py
@@ -64,9 +64,11 @@ class TestCheckRequirements:
         assert check_discord_tool_requirements() is True
 
     def test_check_tool_availability_warns_when_token_missing(self, monkeypatch, caplog):
-        from tools.registry import ToolRegistry
+        from tools.registry import ToolRegistry, _WARNED_FILTERED_TOOLSETS
 
         monkeypatch.delenv("DISCORD_BOT_TOKEN", raising=False)
+        _WARNED_FILTERED_TOOLSETS.clear()  # isolate from other tests
+
         reg = ToolRegistry()
         reg.register(
             name="discord",
@@ -93,9 +95,20 @@ class TestCheckRequirements:
         assert any(
             "Toolset discord unavailable" in record.message
             and "DISCORD_BOT_TOKEN" in record.message
-            and "Check ~/.hermes/.env or export in your shell" in record.message
             for record in caplog.records
-        )
+        ), "expected WARNING listing missing DISCORD_BOT_TOKEN"
+
+        # Second call within the same process must not re-emit the warning.
+        caplog.clear()
+        with caplog.at_level(logging.WARNING, logger="tools.registry"):
+            reg.check_tool_availability()
+
+        assert not any(
+            "Toolset discord unavailable" in record.message
+            for record in caplog.records
+        ), "warning should be deduplicated per (process, toolset)"
+
+        _WARNED_FILTERED_TOOLSETS.clear()  # leave clean for downstream tests
 
     def test_get_bot_token(self, monkeypatch):
         monkeypatch.setenv("DISCORD_BOT_TOKEN", "  my-token  ")

--- a/tests/tools/test_discord_tool.py
+++ b/tests/tools/test_discord_tool.py
@@ -1,6 +1,7 @@
 """Tests for the Discord server introspection and management tool."""
 
 import json
+import logging
 import os
 import urllib.error
 from io import BytesIO
@@ -61,6 +62,40 @@ class TestCheckRequirements:
     def test_valid_token(self, monkeypatch):
         monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token-123")
         assert check_discord_tool_requirements() is True
+
+    def test_check_tool_availability_warns_when_token_missing(self, monkeypatch, caplog):
+        from tools.registry import ToolRegistry
+
+        monkeypatch.delenv("DISCORD_BOT_TOKEN", raising=False)
+        reg = ToolRegistry()
+        reg.register(
+            name="discord",
+            toolset="discord",
+            schema={
+                "name": "discord",
+                "description": "Discord test tool",
+                "parameters": {"type": "object", "properties": {}},
+            },
+            handler=lambda *_args, **_kwargs: "{}",
+            check_fn=check_discord_tool_requirements,
+            requires_env=["DISCORD_BOT_TOKEN"],
+        )
+
+        with caplog.at_level(logging.WARNING, logger="tools.registry"):
+            available, unavailable = reg.check_tool_availability()
+
+        assert "discord" not in available
+        assert unavailable == [{
+            "name": "discord",
+            "env_vars": ["DISCORD_BOT_TOKEN"],
+            "tools": ["discord"],
+        }]
+        assert any(
+            "Toolset discord unavailable" in record.message
+            and "DISCORD_BOT_TOKEN" in record.message
+            and "Check ~/.hermes/.env or export in your shell" in record.message
+            for record in caplog.records
+        )
 
     def test_get_bot_token(self, monkeypatch):
         monkeypatch.setenv("DISCORD_BOT_TOKEN", "  my-token  ")

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -18,6 +18,7 @@ import ast
 import importlib
 import json
 import logging
+import os
 import threading
 import time
 from pathlib import Path
@@ -532,10 +533,23 @@ class ToolRegistry:
             if self._evaluate_toolset_check(ts, toolset_checks.get(ts)):
                 available.append(ts)
             else:
+                toolset_entries = [e for e in entries if e.toolset == ts]
+                env_vars = []
+                for ts_entry in toolset_entries:
+                    for env in ts_entry.requires_env:
+                        if env not in env_vars:
+                            env_vars.append(env)
+                missing_env_vars = [env for env in env_vars if not os.getenv(env)]
+                logger.warning(
+                    "Toolset %s unavailable; missing env vars: %s. "
+                    "Check ~/.hermes/.env or export in your shell.",
+                    ts,
+                    ", ".join(missing_env_vars or env_vars) or "none",
+                )
                 unavailable.append({
                     "name": ts,
-                    "env_vars": entry.requires_env,
-                    "tools": [e.name for e in entries if e.toolset == ts],
+                    "env_vars": env_vars,
+                    "tools": [e.name for e in toolset_entries],
                 })
         return available, unavailable
 

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -149,6 +149,15 @@ def invalidate_check_fn_cache() -> None:
         _check_fn_cache.clear()
 
 
+# Toolsets we've already warned about being unavailable. ``check_tool_availability``
+# can be called many times per process (banner refresh on MCP reload, ``hermes
+# tools`` invocations, doctor runs); emit the warning once per (process,
+# toolset) pair so a stable misconfiguration doesn't spam logs. Mirrors the
+# ``_WARNED_KEYS`` pattern in ``hermes_cli/env_loader.py``.
+_WARNED_FILTERED_TOOLSETS: set[str] = set()
+_WARNED_FILTERED_TOOLSETS_LOCK = threading.Lock()
+
+
 class ToolRegistry:
     """Singleton registry that collects tool schemas + handlers from tool files."""
 
@@ -540,12 +549,17 @@ class ToolRegistry:
                         if env not in env_vars:
                             env_vars.append(env)
                 missing_env_vars = [env for env in env_vars if not os.getenv(env)]
-                logger.warning(
-                    "Toolset %s unavailable; missing env vars: %s. "
-                    "Check ~/.hermes/.env or export in your shell.",
-                    ts,
-                    ", ".join(missing_env_vars or env_vars) or "none",
-                )
+                with _WARNED_FILTERED_TOOLSETS_LOCK:
+                    should_warn = ts not in _WARNED_FILTERED_TOOLSETS
+                    if should_warn:
+                        _WARNED_FILTERED_TOOLSETS.add(ts)
+                if should_warn:
+                    logger.warning(
+                        "Toolset %s unavailable; missing env vars: %s. "
+                        "Check ~/.hermes/.env or export in your shell.",
+                        ts,
+                        ", ".join(missing_env_vars or env_vars) or "none",
+                    )
                 unavailable.append({
                     "name": ts,
                     "env_vars": env_vars,


### PR DESCRIPTION
## Summary

When a toolset's `requires_env` vars are unset (or its `check_fn` returns `False`), the toolset is silently filtered from the agent's tool list — no log line, no banner mention, no agent-visible signal. Users hit absent tools and have no path to diagnose short of running `hermes doctor` or reading source.

This PR adds diagnostic logging for filtered toolsets. The root cause of #30565 (Discord tools silently missing) remains open and is tracked separately on that issue.

## Changes

- `tools/registry.py`: emit a `logger.warning` per filtered toolset listing its missing env vars; guarded by `_WARNED_FILTERED_TOOLSETS` for per-process dedup
- `tests/tools/test_discord_tool.py`: assert the warning fires on first call with `DISCORD_BOT_TOKEN` unset; assert it does *not* re-fire on a second call within the same process

## Out of scope

- Diagnosing or fixing #30565's actual root cause
- Auto-recovery (re-reading `~/.hermes/.env` inside `check_fn`) — would mask the underlying bug instead of surfacing it
- Banner/doctor wiring — both already surface this; the warning is the missing automatic path