### PR TITLE
fix: route cron delivery through job profile

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -577,6 +577,27 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
 
     Returns None on success, or an error string on failure.
     """
+    profile = (job.get("profile") or "").strip()
+    if profile:
+        with _job_profile_context(job.get("id", "?"), profile):
+            try:
+                from dotenv import load_dotenv
+                try:
+                    load_dotenv(str(_get_hermes_home() / ".env"), override=True, encoding="utf-8")
+                except UnicodeDecodeError:
+                    load_dotenv(str(_get_hermes_home() / ".env"), override=True, encoding="latin-1")
+            except Exception as exc:
+                logger.debug("Job '%s': failed to load profile .env before delivery: %s", job.get("id", "?"), exc)
+            # Profile-scoped cron deliveries must use the job profile's own
+            # platform credentials and home-channel configuration, not the
+            # scheduler/gateway process profile's live adapter.
+            return _deliver_result_impl(job, content, adapters=None, loop=None)
+
+    return _deliver_result_impl(job, content, adapters=adapters, loop=loop)
+
+
+def _deliver_result_impl(job: dict, content: str, adapters=None, loop=None) -> Optional[str]:
+    """Implementation for _deliver_result; caller is responsible for profile scoping."""
     targets = _resolve_delivery_targets(job)
     if not targets:
         if job.get("deliver", "local") != "local":

--- a/tests/cron/test_cron_profile.py
+++ b/tests/cron/test_cron_profile.py
@@ -378,6 +378,61 @@ class TestRunJobProfileContext:
         assert observed["hermes_home_during_init"] == str(root)
         assert os.environ["HERMES_HOME"] == str(root)
 
+    def test_profile_delivery_uses_profile_home_channel_and_restores_env(
+        self, isolated_cron_profile_home, monkeypatch
+    ):
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        import cron.scheduler as sched
+        from gateway.config import Platform
+
+        root, profile_home = isolated_cron_profile_home
+        (profile_home / ".env").write_text(
+            "TELEGRAM_HOME_CHANNEL=profile-chat\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(sched, "_hermes_home", None)
+        monkeypatch.setenv("TELEGRAM_HOME_CHANNEL", "root-chat")
+
+        pconfig = MagicMock()
+        pconfig.enabled = True
+        mock_cfg = MagicMock()
+        mock_cfg.platforms = {Platform.TELEGRAM: pconfig}
+        root_adapter = AsyncMock()
+        root_adapter.send.return_value = MagicMock(success=True)
+        loop = MagicMock()
+        loop.is_running.return_value = True
+
+        job = {
+            "id": "profile-delivery",
+            "name": "profile-delivery-job",
+            "profile": "support",
+            "deliver": "telegram",
+        }
+
+        with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch(
+                 "tools.send_message_tool._send_to_platform",
+                 new=AsyncMock(return_value={"success": True}),
+             ) as send_mock, \
+             patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}):
+            err = sched._deliver_result(
+                job,
+                "profile payload",
+                adapters={Platform.TELEGRAM: root_adapter},
+                loop=loop,
+            )
+
+        assert err is None
+        root_adapter.send.assert_not_called()
+        send_mock.assert_called_once()
+        args, _kwargs = send_mock.call_args
+        assert args[2] == "profile-chat"
+        assert args[3] == "profile payload"
+        assert os.environ["TELEGRAM_HOME_CHANNEL"] == "root-chat"
+        assert os.environ["HERMES_HOME"] == str(root)
+        assert sched._get_hermes_home() == root
+
 
 class TestTickProfilePartition:
     def test_profile_and_workdir_combined(self, isolated_cron_profile_home, monkeypatch):


### PR DESCRIPTION
## What this fixes

Cron jobs can be configured with a per-job `profile`, which is intended to make the job run with that profile's Hermes home, config, environment, platform credentials, and delivery defaults.

Before this change, the agent execution path respected the job profile, but result delivery could still be resolved from the scheduler/gateway process profile. In a multi-profile setup, that means a job may do its work under one profile but send its final message using another profile's live adapter, home channel, or platform environment.

That breaks profile isolation and can route cron output to the wrong destination.

## Why it happens

`run_job()` enters `_job_profile_context(...)` while executing the job. However, `_deliver_result(...)` is called after that execution block has unwound. At that point, delivery target resolution can fall back to the scheduler process profile instead of the cron job's configured profile.

The previous implementation also preferred the scheduler's live adapter when available. For profile-scoped jobs, that adapter belongs to the scheduler/gateway runtime profile, not necessarily to the job profile.

## What changed

- If a cron job has `profile` set, delivery now re-enters that profile context before resolving delivery targets.
- The job profile's `.env` is loaded for delivery, so profile-specific platform credentials and home-channel settings are available.
- Profile-scoped delivery avoids reusing the scheduler process live adapter, forcing delivery resolution to occur under the job profile.
- The existing delivery implementation was moved into `_deliver_result_impl(...)` so the profile wrapper stays small and targeted.
- Added regression coverage for:
  - using the job profile's home channel during delivery,
  - not calling the scheduler/root live adapter for profile-scoped delivery,
  - restoring the original Hermes home and environment after delivery.

## Test plan

- `python -m pytest tests/cron/test_cron_profile.py tests/cron/test_scheduler.py::TestDeliverResultWrapping -q -o 'addopts='`

Locally this passed with `31 passed`.

## Notes

This is intentionally scoped to cron delivery routing. It does not change how jobs execute; it makes the final result delivery follow the same profile boundary that job execution already uses.