### PR TITLE
fix: add missing extensions (.md, .yaml, .json, etc.) to extract_media() MEDIA: regex

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2159,7 +2159,7 @@ class BasePlatformAdapter(ABC):
         # Extract MEDIA:<path> tags, allowing optional whitespace after the colon
         # and quoted/backticked paths for LLM-formatted outputs.
         media_pattern = re.compile(
-            r'''[`"']?MEDIA:\s*(?P<path>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|(?:~/|/)\S+(?:[^\S\n]+\S+)*?\.(?:png|jpe?g|gif|webp|mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|flac|epub|pdf|zip|rar|7z|docx?|xlsx?|pptx?|txt|csv|apk|ipa)(?=[\s`"',;:)\]}]|$))[`"']?'''
+            r'''[`"']?MEDIA:\s*(?P<path>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|(?:~/|/)\S+(?:[^\S\n]+\S+)*?\.(?:png|jpe?g|gif|webp|mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|flac|epub|pdf|zip|rar|7z|docx?|xlsx?|pptx?|txt|csv|apk|ipa|md|ya?ml|json|xml|html?|odt|rtf|ods|tsv)(?=[\s`"',;:)\]}]|$))[`"']?'''
         )
         for match in media_pattern.finditer(content):
             path = match.group("path").strip()


### PR DESCRIPTION
## Problem

`extract_media()` in `gateway/platforms/base.py` uses a regex to parse `MEDIA:<path>` tags from agent responses. The regex has a hardcoded extension whitelist:

```
png|jpe?g|gif|webp|mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|flac|epub|pdf|zip|rar|7z|docx?|xlsx?|pptx?|txt|csv|apk|ipa
```

Several common document/data formats are **missing** — most notably `.md`, `.yaml`/`.yml`, `.json`, `.xml`, `.html`/`.htm`, `.odt`, `.rtf`, `.ods`, and `.tsv`.

This causes `MEDIA:/path/to/file.md` to be silently ignored: the tag is never parsed, no upload is attempted, and the raw `MEDIA:` tag may leak into the user-visible message.

Notably, the sister method `extract_local_files()` in the same file already includes all of these extensions in its `_LOCAL_MEDIA_EXTS` tuple (line ~2204). The two lists should be consistent.

## Impact

- `.md` file attachments fail on Matrix (and all other platforms) when sent via `send_message` tool with `MEDIA:` tag
- Same issue for `.yaml`, `.json`, `.xml`, `.html`, and other common data/doc formats
- `extract_local_files()` (bare path detection in gateway responses) works fine for these extensions — only the explicit `MEDIA:` tag path is broken

## Fix

Added the missing extensions to the `extract_media()` regex to align with `extract_local_files()`:

```
md|ya?ml|json|xml|html?|odt|rtf|ods|tsv
```

## Testing

Verified the regex change matches `MEDIA:/tmp/report.md`, `MEDIA:/tmp/data.yaml`, `MEDIA:/tmp/config.json`, etc. where previously they were silently dropped.