### PR TITLE
fix(gateway): resolve bash via shutil.which for detached /restart (#30342)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3793,17 +3793,25 @@ class GatewayRunner:
             f"while kill -0 {current_pid} 2>/dev/null; do sleep 0.2; done; "
             f"{cmd} gateway restart"
         )
+        # Resolve bash to an absolute path before spawning.  Bare "bash" can
+        # fail inside minimal containers when the parent's shutdown sequence
+        # trims PATH before subprocess.Popen runs execvp; the absolute path
+        # is immune.  Mirrors the existing setsid resolution below.
+        bash_bin = shutil.which("bash")
+        if not bash_bin:
+            logger.error("Could not locate bash for detached /restart")
+            return
         setsid_bin = shutil.which("setsid")
         if setsid_bin:
             subprocess.Popen(
-                [setsid_bin, "bash", "-lc", shell_cmd],
+                [setsid_bin, bash_bin, "-lc", shell_cmd],
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.DEVNULL,
                 start_new_session=True,
             )
         else:
             subprocess.Popen(
-                ["bash", "-lc", shell_cmd],
+                [bash_bin, "-lc", shell_cmd],
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.DEVNULL,
                 start_new_session=True,

--- a/tests/gateway/test_restart_detached.py
+++ b/tests/gateway/test_restart_detached.py
@@ -1,0 +1,99 @@
+"""Regression tests for ``GatewayRunner._launch_detached_restart_command``.
+
+Covers #30342 — in minimal containers the parent gateway may trim PATH during
+shutdown cleanup before the detached respawn subprocess runs ``execvp``.  A
+bare ``"bash"`` argv[0] then fails with ``No such file or directory: bash``
+and the gateway stays down after ``/restart``.  The fix resolves ``bash``
+to an absolute path via ``shutil.which`` before spawning, mirroring the
+existing ``setsid`` resolution.
+"""
+
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import gateway.run as gateway_run
+from tests.gateway.restart_test_helpers import make_restart_runner
+
+
+@pytest.mark.asyncio
+async def test_launch_detached_restart_resolves_bash_to_absolute_path(monkeypatch):
+    """When setsid is available, both setsid and bash are passed as absolute paths."""
+    if sys.platform == "win32":
+        pytest.skip("POSIX-only restart path")
+
+    runner, _adapter = make_restart_runner()
+    monkeypatch.setattr(
+        gateway_run, "_resolve_hermes_bin", lambda: ["/opt/hermes/bin/hermes"]
+    )
+
+    def fake_which(name):
+        return {"bash": "/usr/bin/bash", "setsid": "/usr/bin/setsid"}.get(name)
+
+    popen_mock = MagicMock()
+    with patch("shutil.which", side_effect=fake_which), patch(
+        "subprocess.Popen", popen_mock
+    ):
+        await runner._launch_detached_restart_command()
+
+    popen_mock.assert_called_once()
+    argv = popen_mock.call_args[0][0]
+    assert argv[0] == "/usr/bin/setsid"
+    assert argv[1] == "/usr/bin/bash"
+    assert "bash" not in {argv[0], argv[1]}, (
+        f"Bare 'bash' leaked into argv: {argv}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_launch_detached_restart_uses_absolute_bash_when_setsid_missing(
+    monkeypatch,
+):
+    """Without setsid, bash is still spawned via its absolute path."""
+    if sys.platform == "win32":
+        pytest.skip("POSIX-only restart path")
+
+    runner, _adapter = make_restart_runner()
+    monkeypatch.setattr(
+        gateway_run, "_resolve_hermes_bin", lambda: ["/opt/hermes/bin/hermes"]
+    )
+
+    def fake_which(name):
+        return {"bash": "/bin/bash"}.get(name)  # setsid → None
+
+    popen_mock = MagicMock()
+    with patch("shutil.which", side_effect=fake_which), patch(
+        "subprocess.Popen", popen_mock
+    ):
+        await runner._launch_detached_restart_command()
+
+    popen_mock.assert_called_once()
+    argv = popen_mock.call_args[0][0]
+    assert argv[0] == "/bin/bash"
+    assert argv[0] != "bash"
+
+
+@pytest.mark.asyncio
+async def test_launch_detached_restart_logs_and_returns_when_bash_missing(
+    monkeypatch, caplog
+):
+    """If bash is genuinely unavailable, log the error and skip the spawn."""
+    if sys.platform == "win32":
+        pytest.skip("POSIX-only restart path")
+
+    runner, _adapter = make_restart_runner()
+    monkeypatch.setattr(
+        gateway_run, "_resolve_hermes_bin", lambda: ["/opt/hermes/bin/hermes"]
+    )
+
+    popen_mock = MagicMock()
+    with patch("shutil.which", return_value=None), patch(
+        "subprocess.Popen", popen_mock
+    ), caplog.at_level("ERROR", logger="gateway.run"):
+        await runner._launch_detached_restart_command()
+
+    popen_mock.assert_not_called()
+    assert any(
+        "bash" in record.getMessage().lower() for record in caplog.records
+    )

--- a/tests/gateway/test_restart_drain.py
+++ b/tests/gateway/test_restart_drain.py
@@ -184,7 +184,13 @@ async def test_launch_detached_restart_command_uses_setsid(monkeypatch):
 
     monkeypatch.setattr(gateway_run, "_resolve_hermes_bin", lambda: ["/usr/bin/hermes"])
     monkeypatch.setattr(gateway_run.os, "getpid", lambda: 321)
-    monkeypatch.setattr(shutil, "which", lambda cmd: "/usr/bin/setsid" if cmd == "setsid" else None)
+    # bash must also be resolved to an absolute path so the spawn survives
+    # parent-shutdown PATH trimming inside containers (#30342).
+    monkeypatch.setattr(
+        shutil,
+        "which",
+        lambda cmd: {"setsid": "/usr/bin/setsid", "bash": "/usr/bin/bash"}.get(cmd),
+    )
 
     def fake_popen(cmd, **kwargs):
         popen_calls.append((cmd, kwargs))
@@ -196,7 +202,7 @@ async def test_launch_detached_restart_command_uses_setsid(monkeypatch):
 
     assert len(popen_calls) == 1
     cmd, kwargs = popen_calls[0]
-    assert cmd[:2] == ["/usr/bin/setsid", "bash"]
+    assert cmd[:2] == ["/usr/bin/setsid", "/usr/bin/bash"]
     assert "gateway restart" in cmd[-1]
     assert "kill -0 321" in cmd[-1]
     assert kwargs["start_new_session"] is True


### PR DESCRIPTION
## What does this PR do?

In minimal container environments the parent gateway can trim `PATH` during its shutdown sequence before the detached respawn subprocess runs `execvp`. A bare `"bash"` argv[0] then fails with `FileNotFoundError: bash` and the gateway stays down after `/restart` until manual intervention.

This PR resolves `bash` via `shutil.which("bash")` once before spawning in `gateway/run.py:_launch_detached_restart_command()`, mirroring the existing `setsid_bin = shutil.which("setsid")` pattern two lines below. Both `setsid` and `bash` are now passed as absolute paths in both the with-setsid and without-setsid branches, so the spawn is immune to a parent-trimmed `PATH`. When `bash` is genuinely not installed, the method logs an error and skips the spawn instead of raising.

alt-glitch already confirmed on the issue that this root cause is distinct from #25217 (tini killing detached subprocess) and #29619 (Termux Python-watcher refactor).

## Related Issue

Fixes #30342

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/run.py` — resolve `bash` via `shutil.which` before spawning the detached respawn subprocess; log + return when missing; use the absolute path in both setsid / no-setsid branches.
- `tests/gateway/test_restart_detached.py` — three regression tests: with setsid, without setsid, and bash-missing (logs + skips spawn).
- `tests/gateway/test_restart_drain.py` — update `test_launch_detached_restart_command_uses_setsid` to mock `shutil.which("bash")` and assert the absolute-path argv shape (`["/usr/bin/setsid", "/usr/bin/bash"]`).

## How to Test

1. ``uv run --with pytest --with pytest-xdist --with pytest-asyncio --with pytest-timeout python3 -m pytest tests/gateway/test_restart_detached.py tests/gateway/test_restart_drain.py -v``
2. Expected: 19 passed (3 new + 16 existing in `test_restart_drain.py`).
3. Without the production fix, all 3 new tests fail (`FileNotFoundError`-equivalent path; the no-bash test sees an unexpected `Popen` call).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run focused tests for the touched code and all pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15.x

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (internal helper, no user-facing surface)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — Windows path uses a separate Python-watcher branch and is unchanged; the fix only touches the POSIX branch.
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Before (from issue #30342):

```
ERROR gateway.run: Failed to launch detached gateway restart: [Errno 2] No such file or directory: bash
```

After: spawn succeeds because the absolute path bypasses `execvp`'s `PATH` lookup.

> Sibling code paths that may need the same fix: the Windows branch (`sys.platform == "win32"`) already spawns via `sys.executable`'s absolute path, so it is unaffected. The watcher's inner `subprocess.Popen(cmd, ...)` runs `cmd_argv = [*hermes_cmd, "gateway", "restart"]` where `hermes_cmd` is already resolved by `_resolve_hermes_bin()`. No widening needed on Windows.