### PR TITLE
fix(signal): support group channel prompts

### DIFF
--- a/gateway/platforms/signal.py
+++ b/gateway/platforms/signal.py
@@ -37,6 +37,7 @@ from gateway.platforms.base import (
     cache_audio_from_bytes,
     cache_document_from_bytes,
     cache_image_from_url,
+    resolve_channel_prompt,
 )
 from gateway.platforms.helpers import redact_phone
 from gateway.platforms.signal_rate_limit import (
@@ -594,6 +595,12 @@ class SignalAdapter(BasePlatformAdapter):
             )
             return
 
+        channel_prompt = resolve_channel_prompt(
+            self.config.extra,
+            chat_id,
+            group_id if is_group else None,
+        )
+
         # Build session source
         source = self.build_source(
             chat_id=chat_id,
@@ -636,6 +643,7 @@ class SignalAdapter(BasePlatformAdapter):
             raw_message={"sender": sender, "timestamp_ms": ts_ms},
             reply_to_message_id=reply_to_id,
             reply_to_text=reply_to_text,
+            channel_prompt=channel_prompt,
         )
 
         logger.debug("Signal: message from %s in %s: %s",

--- a/tests/gateway/test_signal.py
+++ b/tests/gateway/test_signal.py
@@ -1889,6 +1889,68 @@ class TestSignalGroupV2Routing:
         assert captured[0].source.chat_id == "group:v2=="
 
     @pytest.mark.asyncio
+    async def test_group_channel_prompt_uses_gateway_chat_id(self, monkeypatch):
+        adapter = _make_signal_adapter(
+            monkeypatch,
+            group_allowed="*",
+            channel_prompts={"group:v2group==": "Use private health mode."},
+        )
+        captured = []
+
+        async def _capture(event):
+            captured.append(event)
+
+        adapter.handle_message = _capture
+
+        await adapter._handle_envelope(self._base_envelope({
+            "message": "hello v2",
+            "groupV2": {"id": "v2group=="},
+        }))
+
+        assert len(captured) == 1
+        assert captured[0].channel_prompt == "Use private health mode."
+
+    @pytest.mark.asyncio
+    async def test_group_channel_prompt_falls_back_to_raw_group_id(self, monkeypatch):
+        adapter = _make_signal_adapter(
+            monkeypatch,
+            group_allowed="*",
+            channel_prompts={"legacy==": "Use homeschool mode."},
+        )
+        captured = []
+
+        async def _capture(event):
+            captured.append(event)
+
+        adapter.handle_message = _capture
+
+        await adapter._handle_envelope(self._base_envelope({
+            "message": "hello legacy",
+            "groupInfo": {"groupId": "legacy=="},
+        }))
+
+        assert len(captured) == 1
+        assert captured[0].channel_prompt == "Use homeschool mode."
+
+    @pytest.mark.asyncio
+    async def test_group_without_channel_prompt_leaves_prompt_none(self, monkeypatch):
+        adapter = _make_signal_adapter(monkeypatch, group_allowed="*")
+        captured = []
+
+        async def _capture(event):
+            captured.append(event)
+
+        adapter.handle_message = _capture
+
+        await adapter._handle_envelope(self._base_envelope({
+            "message": "hello",
+            "groupV2": {"id": "v2group=="},
+        }))
+
+        assert len(captured) == 1
+        assert captured[0].channel_prompt is None
+
+    @pytest.mark.asyncio
     async def test_no_group_fields_routes_as_dm(self, monkeypatch):
         adapter = _make_signal_adapter(monkeypatch)
         captured = []

--- a/website/docs/user-guide/messaging/signal.md
+++ b/website/docs/user-guide/messaging/signal.md
@@ -141,6 +141,29 @@ Group access is controlled by the `SIGNAL_GROUP_ALLOWED_USERS` env var:
 | Set with group IDs | Only listed groups are monitored (e.g., `groupId1,groupId2`). |
 | Set to `*` | The bot responds in any group it's a member of. |
 
+### Per-Group Prompts
+
+Signal groups can have their own ephemeral system prompt via `signal.channel_prompts` in `~/.hermes/config.yaml`. Use the gateway chat id form, `group:<group_id>`, so it matches the Signal session id shown in logs and delivery targets:
+
+```yaml
+signal:
+  channel_prompts:
+    "group:YOUR_SIGNAL_GROUP_ID": |
+      You are the project triage assistant in this Signal group.
+      Keep replies concise and focus on action items.
+```
+
+The raw Signal group id is also accepted as a fallback key for convenience:
+
+```yaml
+signal:
+  channel_prompts:
+    "YOUR_SIGNAL_GROUP_ID": |
+      Use the family education assistant persona in this group.
+```
+
+Group access control still applies. A prompt does not enable a group by itself; the group must also be allowed through `SIGNAL_GROUP_ALLOWED_USERS` or `*`.
+
 ---
 
 ## Features


### PR DESCRIPTION
## Summary
- Wire Signal inbound message events to existing `channel_prompts` plumbing.
- Support canonical Signal group keys as `group:<group_id>` and raw group id fallback.
- Document `signal.channel_prompts` usage for per-group ephemeral system prompts.

## Why
Other messaging adapters already support per-channel prompts. Signal group messages had stable `chat_id` values such as `group:<group_id>`, but the Signal adapter never resolved `channel_prompts` or passed the resulting prompt into `MessageEvent`, so configured group prompts were silently ignored.

## Test Plan
- [x] Added Signal adapter tests for canonical `group:<group_id>` prompts.
- [x] Added Signal adapter tests for raw group id fallback prompts.
- [x] Added Signal adapter regression test for no prompt staying `None`.
- [x] Ran `./venv/bin/python -m pytest tests/gateway/test_signal.py -q` — 112 passed.
