### PR TITLE
fix(slack): dispatch @bot !cmd as command in threads

### DIFF
--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -112,6 +112,23 @@ def check_slack_requirements() -> bool:
     return ensure_and_bind("platform.slack", _import, globals(), prompt=False)
 
 
+def _rewrite_known_bang_command(text: str) -> str:
+    """Rewrite a known leading ``!cmd`` to the gateway ``/cmd`` form."""
+    if not text.startswith("!"):
+        return text
+
+    try:
+        from hermes_cli.commands import is_gateway_known_command
+
+        first_token = text[1:].split(maxsplit=1)[0]
+        cmd_name = first_token.split("@", 1)[0].lower()
+        if cmd_name and "/" not in cmd_name and is_gateway_known_command(cmd_name):
+            return "/" + text[1:]
+    except Exception:  # pragma: no cover - defensive
+        pass
+    return text
+
+
 def _extract_text_from_slack_blocks(blocks: list) -> str:
     """Extract readable text from Slack Block Kit blocks, including quoted/forwarded content.
 
@@ -2628,22 +2645,7 @@ class SlackAdapter(BasePlatformAdapter):
         # gateway dispatcher) handles it like a normal slash command.  Only
         # rewrite when the first token resolves to a known gateway command
         # so casual messages like "!nice work" pass through unchanged.
-        if original_text.startswith("!"):
-            try:
-                from hermes_cli.commands import is_gateway_known_command
-
-                first_token = original_text[1:].split(maxsplit=1)[0]
-                # Strip "@suffix" the same way get_command() does, so
-                # forms like ``!stop@hermes`` still resolve.
-                cmd_name = first_token.split("@", 1)[0].lower()
-                if (
-                    cmd_name
-                    and "/" not in cmd_name
-                    and is_gateway_known_command(cmd_name)
-                ):
-                    original_text = "/" + original_text[1:]
-            except Exception:  # pragma: no cover - defensive
-                pass
+        original_text = _rewrite_known_bang_command(original_text)
 
         text = original_text
 
@@ -2870,6 +2872,14 @@ class SlackAdapter(BasePlatformAdapter):
         if is_mentioned:
             # Strip the bot mention from the text
             text = text.replace(f"<@{bot_uid}>", "").strip()
+            # Re-run command normalization against the canonical Slack text,
+            # not the block-augmented agent text. Otherwise quoted/forwarded
+            # rich-text payload can become accidental command arguments.
+            mention_stripped = original_text.replace(f"<@{bot_uid}>", "").strip()
+            command_text = _rewrite_known_bang_command(mention_stripped)
+            if command_text != mention_stripped:
+                original_text = command_text
+                text = command_text
             # Register this thread so all future messages auto-trigger the bot.
             # Skipped in strict mode: strict_mention=true bots must be
             # re-mentioned every turn, so remembering the thread would
@@ -2885,10 +2895,14 @@ class SlackAdapter(BasePlatformAdapter):
 
         # When entering a thread for the first time (no existing session),
         # fetch thread context so the agent understands the conversation.
-        if is_thread_reply and not self._has_active_session_for_thread(
-            channel_id=channel_id,
-            thread_ts=event_thread_ts,
-            user_id=user_id,
+        if (
+            is_thread_reply
+            and not text.startswith("/")
+            and not self._has_active_session_for_thread(
+                channel_id=channel_id,
+                thread_ts=event_thread_ts,
+                user_id=user_id,
+            )
         ):
             thread_context = await self._fetch_thread_context(
                 channel_id=channel_id,

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -1200,6 +1200,107 @@ class TestBangPrefixCommands:
         assert msg_event.text.startswith("/queue")
         assert msg_event.message_type == MessageType.COMMAND
 
+    @pytest.mark.asyncio
+    async def test_mention_prefixed_bang_is_rewritten(self, adapter):
+        evt = self._make_event(
+            "<@U_BOT> !new",
+            thread_ts="1111111111.000001",
+            channel_type="channel",
+            channel="C123",
+        )
+        await adapter._handle_slack_message(evt)
+
+        msg_event = adapter.handle_message.call_args[0][0]
+        assert msg_event.text == "/new"
+        assert msg_event.message_type == MessageType.COMMAND
+
+    @pytest.mark.asyncio
+    async def test_mention_prefixed_bang_no_space(self, adapter):
+        evt = self._make_event(
+            "<@U_BOT>!new",
+            thread_ts="1111111111.000001",
+            channel_type="channel",
+            channel="C123",
+        )
+        await adapter._handle_slack_message(evt)
+
+        msg_event = adapter.handle_message.call_args[0][0]
+        assert msg_event.text == "/new"
+        assert msg_event.message_type == MessageType.COMMAND
+
+    @pytest.mark.asyncio
+    async def test_mention_prefixed_unknown_bang_passes_through(self, adapter):
+        evt = self._make_event(
+            "<@U_BOT> !nice work",
+            channel_type="channel",
+            channel="C123",
+        )
+        await adapter._handle_slack_message(evt)
+
+        msg_event = adapter.handle_message.call_args[0][0]
+        assert msg_event.text == "!nice work"
+        assert msg_event.message_type != MessageType.COMMAND
+
+    @pytest.mark.asyncio
+    async def test_thread_command_skips_context_prefix(self, adapter):
+        adapter._has_active_session_for_thread = MagicMock(return_value=False)
+        adapter._fetch_thread_context = AsyncMock(
+            side_effect=AssertionError(
+                "_fetch_thread_context must not be called for slash commands"
+            )
+        )
+        evt = self._make_event(
+            "<@U_BOT> !new",
+            thread_ts="1111111111.000001",
+            channel_type="channel",
+            channel="C123",
+        )
+        await adapter._handle_slack_message(evt)
+
+        msg_event = adapter.handle_message.call_args[0][0]
+        assert msg_event.text == "/new"
+        assert msg_event.message_type == MessageType.COMMAND
+
+    @pytest.mark.asyncio
+    async def test_mention_command_drops_rich_text_command_arguments(self, adapter):
+        evt = self._make_event(
+            "<@U_BOT> !model",
+            thread_ts="1111111111.000001",
+            channel_type="channel",
+            channel="C123",
+        )
+        evt["blocks"] = [
+            {
+                "type": "rich_text",
+                "elements": [
+                    {
+                        "type": "rich_text_section",
+                        "elements": [
+                            {"type": "user", "user_id": "U_BOT"},
+                            {"type": "text", "text": " !model"},
+                        ],
+                    },
+                    {
+                        "type": "rich_text_quote",
+                        "elements": [
+                            {
+                                "type": "rich_text_section",
+                                "elements": [
+                                    {"type": "text", "text": "quoted context"}
+                                ],
+                            }
+                        ],
+                    },
+                ],
+            }
+        ]
+        await adapter._handle_slack_message(evt)
+
+        msg_event = adapter.handle_message.call_args[0][0]
+        assert msg_event.text == "/model"
+        assert "quoted context" not in msg_event.text
+        assert msg_event.message_type == MessageType.COMMAND
+
 
 # ---------------------------------------------------------------------------
 # TestIncomingDocumentHandling


### PR DESCRIPTION
## What does this PR do?

Fixes mention-prefixed gateway commands in Slack threads. Inputs such as `@bot !new` are now normalized after the bot mention is removed and before Slack rich-content augmentation, so they dispatch as commands instead of becoming conversational text or acquiring serialized block content as arguments.

The command path also skips first-thread conversational-context backfill, which would otherwise prepend text before the slash and make command detection fail.

This is the targeted current-architecture port requested by the automated maintainer sweep; Slack now lives in `plugins/platforms/slack/adapter.py`.

## Related Issue

N/A — this was reproduced in a live Slack thread; no separate upstream issue is open.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `plugins/platforms/slack/adapter.py`
  - Re-normalizes recognized `!command` input after mention stripping.
  - Performs command recognition before rich Slack block augmentation and skips augmentation for recognized commands.
  - Skips first-thread context backfill for commands so command text remains slash-prefixed.
- `tests/gateway/test_slack.py`
  - Covers mention-prefixed bang commands, including no-space and unknown-token cases.
  - Covers thread-context bypass for commands.
  - Adds the requested combined mention + bang command + rich-text-block regression.

## How to Test

1. Run `HOME=/tmp/hermes-ci-home scripts/run_tests.sh -j 1 tests/gateway/test_slack.py`.
2. Confirm all 221 tests pass.
3. In a mention-required Slack thread, send `@bot !new` with rich block content and confirm it dispatches `/new` without block serialization being appended as arguments.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS, Python 3.11

The canonical full suite was run on the current-main rebase. It reported 27 failures and 8 timeout/collection files outside this two-file diff, in the macOS/environment-sensitive areas reproduced on clean current main. The complete Slack test file passes 221/221.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```text
tests/gateway/test_slack.py: 221 passed, 0 failed
ruff check .: passed
git diff --check upstream/main...HEAD: passed
check-windows-footguns.py --diff upstream/main: passed (2 files scanned)
```
