### PR TITLE
fix: improve Discord gateway restart handling

### DIFF
--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -19,6 +19,8 @@ import subprocess
 import tempfile
 import threading
 import time
+import urllib.error
+import urllib.request
 from collections import defaultdict
 from typing import Callable, Dict, List, Optional, Any, Tuple
 
@@ -3075,6 +3077,64 @@ class DiscordAdapter(BasePlatformAdapter):
         @discord.app_commands.describe(prompt="The prompt to run in the background")
         async def slash_background(interaction: discord.Interaction, prompt: str):
             await self._run_simple_slash(interaction, f"/background {prompt}", "Background task started~")
+
+        async def _post_voice_transcriber(path: str, payload: dict[str, Any]) -> dict[str, Any]:
+            url = os.getenv("SCHOOLBRAIN_VOICE_CONTROL_URL", "http://127.0.0.1:8765") + path
+
+            def _send() -> dict[str, Any]:
+                body = json.dumps(payload).encode("utf-8")
+                req = urllib.request.Request(
+                    url,
+                    data=body,
+                    method="POST",
+                    headers={"Content-Type": "application/json", "User-Agent": "Hermes/voice-control"},
+                )
+                try:
+                    with urllib.request.urlopen(req, timeout=20) as resp:
+                        return json.loads(resp.read().decode("utf-8"))
+                except urllib.error.HTTPError as exc:
+                    raw = exc.read().decode("utf-8", errors="replace")
+                    try:
+                        data = json.loads(raw)
+                    except Exception:
+                        data = {"error": raw or str(exc)}
+                    data["ok"] = False
+                    return data
+
+            return await asyncio.to_thread(_send)
+
+        @tree.command(name="meeting_start", description="Start recording your current Discord voice channel")
+        @discord.app_commands.describe(title="Meeting title")
+        async def slash_meeting_start(interaction: discord.Interaction, title: str):
+            if not await self._check_slash_authorization(interaction, "/meeting_start"):
+                return
+            await interaction.response.defer(ephemeral=True)
+            voice = getattr(interaction.user, "voice", None)
+            voice_channel = getattr(voice, "channel", None)
+            if not voice_channel:
+                await interaction.edit_original_response(content="You are not in a voice channel. Join one, then run /meeting_start again.")
+                return
+            result = await _post_voice_transcriber("/start", {
+                "guild_id": int(interaction.guild_id or 0),
+                "voice_channel_id": int(voice_channel.id),
+                "text_channel_id": int(getattr(interaction.channel, "id", 0) or getattr(interaction, "channel_id", 0)),
+                "title": title,
+            })
+            if result.get("ok"):
+                await interaction.edit_original_response(content=result.get("message", f"Started recording: {title}"))
+            else:
+                await interaction.edit_original_response(content=f"Voice recorder start failed: {result.get('error', 'unknown error')}")
+
+        @tree.command(name="meeting_stop", description="Stop recording and write Schoolbrain meeting notes")
+        async def slash_meeting_stop(interaction: discord.Interaction):
+            if not await self._check_slash_authorization(interaction, "/meeting_stop"):
+                return
+            await interaction.response.defer(ephemeral=True)
+            result = await _post_voice_transcriber("/stop", {"guild_id": int(interaction.guild_id or 0)})
+            if result.get("ok"):
+                await interaction.edit_original_response(content=result.get("message", "Stopped recording."))
+            else:
+                await interaction.edit_original_response(content=f"Voice recorder stop failed: {result.get('error', 'unknown error')}")
 
         # ── Auto-register any gateway-available commands not yet on the tree ──
         # This ensures new commands added to COMMAND_REGISTRY in

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9715,11 +9715,13 @@ class GatewayRunner:
         # Docker/Podman container, use the service restart path: exit with
         # code 75 so the service manager / container restart policy restarts
         # us.  The detached subprocess approach (setsid + bash) doesn't work
-        # under systemd (KillMode=mixed kills the cgroup) or Docker (tini
-        # exits when the gateway dies, taking the detached helper with it).
-        _under_service = bool(os.environ.get("INVOCATION_ID"))  # systemd sets this
+        # reliably under systemd (KillMode=mixed kills the cgroup), launchd
+        # (the helper can race the LaunchAgent state), or Docker (tini exits
+        # when the gateway dies, taking the detached helper with it).
+        _under_systemd = bool(os.environ.get("INVOCATION_ID"))
+        _under_launchd = os.environ.get("XPC_SERVICE_NAME") == "ai.hermes.gateway"
         _in_container = os.path.exists("/.dockerenv") or os.path.exists("/run/.containerenv")
-        if _under_service or _in_container:
+        if _under_systemd or _under_launchd or _in_container:
             self.request_restart(detached=False, via_service=True)
         else:
             self.request_restart(detached=True, via_service=False)

--- a/tests/gateway/test_restart_drain.py
+++ b/tests/gateway/test_restart_drain.py
@@ -16,9 +16,10 @@ from tests.gateway.restart_test_helpers import make_restart_runner, make_restart
 
 @pytest.mark.asyncio
 async def test_restart_command_while_busy_requests_drain_without_interrupt(monkeypatch):
-    # Ensure INVOCATION_ID is NOT set — systemd sets this in service mode,
-    # which changes the restart call signature.
+    # Ensure service-manager env vars are NOT set — systemd/launchd service
+    # mode changes the restart call signature.
     monkeypatch.delenv("INVOCATION_ID", raising=False)
+    monkeypatch.delenv("XPC_SERVICE_NAME", raising=False)
     runner, _adapter = make_restart_runner()
     runner.request_restart = MagicMock(return_value=True)
     event = MessageEvent(
@@ -45,6 +46,26 @@ async def test_restart_command_while_busy_requests_drain_without_interrupt(monke
     assert "Draining" in expected and "1" in expected
     running_agent.interrupt.assert_not_called()
     runner.request_restart.assert_called_once_with(detached=True, via_service=False)
+
+
+@pytest.mark.asyncio
+async def test_restart_command_under_launchd_uses_service_restart(monkeypatch):
+    monkeypatch.delenv("INVOCATION_ID", raising=False)
+    monkeypatch.setenv("XPC_SERVICE_NAME", "ai.hermes.gateway")
+    runner, _adapter = make_restart_runner()
+    runner.request_restart = MagicMock(return_value=True)
+    event = MessageEvent(
+        text="/restart",
+        message_type=MessageType.TEXT,
+        source=make_restart_source(),
+        message_id="m1-launchd",
+    )
+
+    result = await runner._handle_message(event)
+
+    assert result is not None
+    assert "Restarting gateway" in result
+    runner.request_restart.assert_called_once_with(detached=False, via_service=True)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Route Discord /restart through service-manager restart when running under macOS launchd
- Add regression coverage for launchd restart handling
- Add Discord /meeting_start and /meeting_stop slash commands for voice recorder control

## Test Plan
- python -m pytest tests/gateway/test_restart_drain.py -q -o 'addopts='
- python -m py_compile gateway/platforms/discord.py gateway/run.py
