### PR TITLE
fix(ci): expose multi-arch digest from merge job and add cosign sign step

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -225,6 +225,7 @@ jobs:
     outputs:
       pushed_release_tag: ${{ steps.mark_release_pushed.outputs.pushed }}
       release_tag: ${{ steps.tag.outputs.tag }}
+      digest: ${{ steps.manifest_digest.outputs.digest }}
     steps:
       - name: Checkout code
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
@@ -327,6 +328,7 @@ jobs:
       # Gate the manifest push on the ancestor check for main pushes.
       # For releases there is no gate — the check doesn't even run.
       - name: Create manifest list and push
+        id: push_manifest
         if: github.event_name != 'push' || steps.main_check.outputs.push_main == 'true'
         working-directory: /tmp/digests
         run: |
@@ -338,6 +340,25 @@ jobs:
           docker buildx imagetools create \
             -t "${IMAGE_NAME}:${TAG}" \
             "${args[@]}"
+        env:
+          IMAGE_NAME: ${{ env.IMAGE_NAME }}
+          TAG: ${{ steps.tag.outputs.tag }}
+
+      # Read the digest of the multi-arch manifest list we just pushed.
+      # Downstream jobs (e.g. cosign signing) need this to reference the
+      # exact manifest, not a mutable tag.
+      - name: Read manifest digest
+        if: steps.push_manifest.outcome == 'success'
+        id: manifest_digest
+        run: |
+          set -euo pipefail
+          digest=$(
+            docker buildx imagetools inspect "${IMAGE_NAME}:${TAG}" \
+              --format '{{json .Manifest}}' \
+              | jq -r '.digest'
+          )
+          echo "digest=${digest}" >> "$GITHUB_OUTPUT"
+          echo "Multi-arch manifest digest: ${digest}"
         env:
           IMAGE_NAME: ${{ env.IMAGE_NAME }}
           TAG: ${{ steps.tag.outputs.tag }}
@@ -469,3 +490,47 @@ jobs:
           docker buildx imagetools create \
             --tag "${image}:latest" \
             "${image}:${RELEASE_TAG}"
+
+  # ---------------------------------------------------------------------------
+  # Sign the multi-arch manifest with cosign (keyless, Sigstore OIDC).
+  #
+  # Runs after merge pushes the tagged manifest list.  Uses the digest
+  # output (not the mutable tag) so the signature binds to the exact
+  # manifest, not whatever the tag points at later.
+  # ---------------------------------------------------------------------------
+  sign:
+    if: |
+      github.repository == 'NousResearch/hermes-agent'
+      && (github.event_name == 'push' && github.ref == 'refs/heads/main' || github.event_name == 'release')
+    needs: merge
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      id-token: write   # keyless cosign signing via Sigstore OIDC
+      contents: read
+    steps:
+      - name: Check out code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@ba7bc0a3fef59531c69a25acd34668d6d3fe6f22  # v4.1.0
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121  # v4.1.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Sign image with cosign
+        env:
+          DIGEST: ${{ needs.merge.outputs.digest }}
+          IMAGE_NAME: ${{ env.IMAGE_NAME }}
+        run: |
+          set -euo pipefail
+          if [ -z "${DIGEST}" ]; then
+            echo "::error::No digest from merge job — cannot sign."
+            exit 1
+          fi
+          image="${IMAGE_NAME}@${DIGEST}"
+          echo "Signing ${image}"
+          cosign sign --yes "${image}"

--- a/scripts/verify-release-digest.py
+++ b/scripts/verify-release-digest.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Verify docker-publish.yml digest output wiring for cosign signing.
+
+Checks:
+1. merge job declares a 'digest' output
+2. merge job has a 'Read manifest digest' step with id 'manifest_digest'
+3. merge's digest output references steps.manifest_digest.outputs.digest
+4. sign job exists and needs: merge
+5. sign job reads needs.merge.outputs.digest
+6. sign job has id-token: write permission for keyless OIDC signing
+7. sign job uses cosign-installer action
+8. sign job runs 'cosign sign' with the digest reference
+"""
+
+import sys
+import yaml
+
+
+def load_workflow(path):
+    with open(path) as f:
+        return yaml.safe_load(f)
+
+
+def check(wf, label, condition):
+    status = "PASS" if condition else "FAIL"
+    print(f"  [{status}] {label}")
+    return condition
+
+
+def main():
+    wf = load_workflow(".github/workflows/docker-publish.yml")
+    jobs = wf["jobs"]
+    all_pass = True
+
+    # 1. merge job exists
+    assert "merge" in jobs, "merge job missing"
+    merge = jobs["merge"]
+
+    # 2. merge declares digest output
+    outputs = merge.get("outputs", {})
+    all_pass &= check(wf, "merge declares 'digest' output", "digest" in outputs)
+
+    # 3. digest output references manifest_digest step
+    digest_expr = outputs.get("digest", "")
+    all_pass &= check(
+        wf,
+        "digest output references manifest_digest step",
+        "manifest_digest" in str(digest_expr),
+    )
+
+    # 4. merge has 'Read manifest digest' step
+    steps = merge.get("steps", [])
+    digest_step = next(
+        (s for s in steps if s.get("id") == "manifest_digest"), None
+    )
+    all_pass &= check(wf, "merge has manifest_digest step", digest_step is not None)
+
+    # 5. manifest_digest step uses imagetools inspect
+    if digest_step:
+        run = digest_step.get("run", "")
+        all_pass &= check(
+            wf,
+            "manifest_digest step uses 'imagetools inspect'",
+            "imagetools inspect" in run,
+        )
+        all_pass &= check(
+            wf,
+            "manifest_digest step writes to GITHUB_OUTPUT",
+            "GITHUB_OUTPUT" in run,
+        )
+
+    # 6. sign job exists
+    assert "sign" in jobs, "sign job missing"
+    sign = jobs["sign"]
+
+    # 7. sign job needs merge
+    needs = sign.get("needs", [])
+    all_pass &= check(wf, "sign needs merge", "merge" in needs)
+
+    # 8. sign job has id-token: write
+    perms = sign.get("permissions", {})
+    all_pass &= check(
+        wf, "sign has id-token: write", perms.get("id-token") == "write"
+    )
+
+    # 9. sign job installs cosign
+    sign_steps = sign.get("steps", [])
+    cosign_install = next(
+        (s for s in sign_steps if "cosign-installer" in str(s.get("uses", ""))),
+        None,
+    )
+    all_pass &= check(wf, "sign installs cosign", cosign_install is not None)
+
+    # 10. sign step reads needs.merge.outputs.digest
+    sign_step = next(
+        (s for s in sign_steps if "cosign sign" in s.get("run", "")), None
+    )
+    all_pass &= check(wf, "sign has 'cosign sign' step", sign_step is not None)
+
+    if sign_step:
+        env = sign_step.get("env", {})
+        digest_env = env.get("DIGEST", "")
+        all_pass &= check(
+            wf,
+            "sign step DIGEST reads from merge output",
+            "needs.merge.outputs.digest" in str(digest_env),
+        )
+        run = sign_step.get("run", "")
+        all_pass &= check(
+            wf,
+            "sign step references DIGEST in run",
+            "${DIGEST}" in run or "${image}" in run,
+        )
+
+    # Summary
+    print()
+    if all_pass:
+        print("ALL CHECKS PASSED — digest output wiring is correct.")
+        return 0
+    else:
+        print("SOME CHECKS FAILED — see above.")
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Problem

The `merge` job in `docker-publish.yml` pushes a tagged multi-arch manifest
list but never exposes its digest. Downstream cosign signing jobs have no
reference to the exact manifest — the digest output was simply missing.

## Fix

### merge job — digest output wiring
- Add `id: push_manifest` to the manifest creation step
- New "Read manifest digest" step uses `imagetools inspect --format '{{json .Manifest}}' | jq -r '.digest'` to capture the multi-arch manifest digest
- Wire through `steps.manifest_digest.outputs.digest` to the job-level `digest` output

### sign job — cosign keyless signing
- Depends on `merge` (reads `needs.merge.outputs.digest`)
- SHA-pinned actions: checkout, cosign-installer v4.1.0, docker login
- `id-token: write` permission for Sigstore OIDC keyless signing
- Signs by digest (not mutable tag): `cosign sign --yes "${IMAGE_NAME}@${DIGEST}"`
- Guards against empty digest with `::error::` + exit 1

### Verification
- `scripts/verify-release-digest.py` — 11 structural checks on the YAML:
  - merge declares digest output
  - manifest_digest step uses imagetools inspect + GITHUB_OUTPUT
  - sign job needs merge, has id-token write, installs cosign, reads digest
  - All 11 checks pass

## Data flow

```
build-amd64 ─┐
              ├─ merge ─── digest output ──→ sign (cosign)
build-arm64 ─┘
```

## Notes
- Only runs on push-to-main and release events (same gating as existing jobs)
- PR runs skip the sign job entirely (no Docker Hub login, no push, no sign)
- All new actions SHA-pinned per repo supply chain policy