### PR TITLE
fix(lazy-deps): use pip --user fallback on PEP 668 system Python

### DIFF
--- a/tests/tools/test_lazy_deps.py
+++ b/tests/tools/test_lazy_deps.py
@@ -405,3 +405,109 @@ class TestRefreshActiveFeatures:
         result = ld.refresh_active_features()
         assert result["a.ok"] == "current"
         assert result["b.fail"].startswith("failed:")
+
+
+# ---------------------------------------------------------------------------
+# PEP 668 / system-Python handling
+# ---------------------------------------------------------------------------
+
+
+class TestVenvPipInstallPEP668:
+    """When Hermes is installed against a system Python (no venv), PEP 668
+    distros (Debian/Ubuntu/Kali) refuse bare ``pip install``. The installer
+    must fall back to ``pip install --user`` and skip the uv tier (which
+    would either silently write to the system or refuse with the same error).
+
+    Inside a venv, the original fast-path must remain unchanged: uv first,
+    pip without --user.
+    """
+
+    def _capture_subprocess_run(self, monkeypatch, returncode=0, stderr=""):
+        """Capture each subprocess.run call without actually executing."""
+        import subprocess as _sp
+        calls: list[list[str]] = []
+
+        def fake_run(cmd, *args, **kwargs):
+            calls.append(list(cmd))
+            return _sp.CompletedProcess(cmd, returncode, "", stderr)
+
+        monkeypatch.setattr(ld.subprocess, "run", fake_run)
+        return calls
+
+    def test_running_in_venv_detects_real_venv(self, monkeypatch):
+        monkeypatch.setattr(ld.sys, "prefix", "/opt/myvenv")
+        monkeypatch.setattr(ld.sys, "base_prefix", "/usr")
+        assert ld._running_in_venv() is True
+
+    def test_running_in_venv_detects_system_python(self, monkeypatch):
+        # PEP 668 system interpreter: prefix == base_prefix
+        monkeypatch.setattr(ld.sys, "prefix", "/usr")
+        monkeypatch.setattr(ld.sys, "base_prefix", "/usr")
+        assert ld._running_in_venv() is False
+
+    def test_system_python_uses_pip_user_and_skips_uv(self, monkeypatch):
+        # System Python: should never invoke uv (would target system
+        # site-packages), and pip must include --user.
+        monkeypatch.setattr(ld, "_running_in_venv", lambda: False)
+        monkeypatch.setattr(ld.shutil, "which", lambda name: "/usr/bin/uv"
+                            if name == "uv" else None)
+        calls = self._capture_subprocess_run(monkeypatch, returncode=0)
+
+        result = ld._venv_pip_install(("somepkg>=1.0",))
+
+        assert result.success is True
+        # No uv calls — uv was skipped entirely.
+        assert not any("/usr/bin/uv" in c[0] for c in calls), (
+            f"uv must not be invoked against system Python; saw {calls!r}"
+        )
+        # Find the actual install call (probe --version may come first).
+        install_calls = [c for c in calls if "install" in c]
+        assert install_calls, f"no install call recorded: {calls!r}"
+        assert "--user" in install_calls[0], (
+            f"pip --user flag missing on system Python: {install_calls[0]!r}"
+        )
+
+    def test_venv_uses_uv_first_without_user_flag(self, monkeypatch):
+        # Real venv: original behavior. uv tier wins, no --user flag.
+        monkeypatch.setattr(ld, "_running_in_venv", lambda: True)
+        monkeypatch.setattr(ld.shutil, "which", lambda name: "/opt/uv/bin/uv"
+                            if name == "uv" else None)
+        calls = self._capture_subprocess_run(monkeypatch, returncode=0)
+
+        result = ld._venv_pip_install(("somepkg>=1.0",))
+
+        assert result.success is True
+        assert calls, "expected at least one subprocess call"
+        # First call should be uv pip install (no --user, no --break-system).
+        assert calls[0][0] == "/opt/uv/bin/uv"
+        assert "--user" not in calls[0]
+        assert "--break-system-packages" not in calls[0]
+
+    def test_venv_pip_fallback_no_user_flag(self, monkeypatch):
+        # Real venv, uv unavailable: pip tier runs without --user.
+        monkeypatch.setattr(ld, "_running_in_venv", lambda: True)
+        monkeypatch.setattr(ld.shutil, "which", lambda name: None)
+        calls = self._capture_subprocess_run(monkeypatch, returncode=0)
+
+        result = ld._venv_pip_install(("somepkg>=1.0",))
+
+        assert result.success is True
+        install_calls = [c for c in calls if "install" in c]
+        assert install_calls
+        assert "--user" not in install_calls[0], (
+            f"--user should not appear in venv install: {install_calls[0]!r}"
+        )
+
+    def test_system_python_uv_present_still_skipped(self, monkeypatch):
+        # Defense in depth: even if uv is on PATH and the env happens to
+        # have VIRTUAL_ENV set (e.g. user's shell), _running_in_venv()
+        # is the source of truth and uv must be skipped.
+        monkeypatch.setattr(ld, "_running_in_venv", lambda: False)
+        monkeypatch.setattr(ld.shutil, "which", lambda name: "/usr/bin/uv"
+                            if name == "uv" else None)
+        monkeypatch.setenv("VIRTUAL_ENV", "/some/stale/path")
+        calls = self._capture_subprocess_run(monkeypatch, returncode=0)
+
+        ld._venv_pip_install(("somepkg>=1.0",))
+
+        assert not any("/usr/bin/uv" in c[0] for c in calls)

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -336,20 +336,46 @@ def _is_present(spec: str) -> bool:
         return False
 
 
+def _running_in_venv() -> bool:
+    """True if ``sys.executable`` belongs to a virtual environment.
+
+    PEP 405 venvs (and virtualenv) always set ``sys.prefix`` to the venv
+    root, which differs from ``sys.base_prefix`` (the underlying system
+    Python). When they match, Hermes was installed against the system
+    interpreter directly — common for ``pip install --user hermes-agent``
+    on Debian/Ubuntu/Kali/Termux containers.
+    """
+    return sys.prefix != sys.base_prefix
+
+
 def _venv_pip_install(specs: tuple[str, ...], *, timeout: int = 300) -> _InstallResult:
-    """Install ``specs`` into the active venv using uv → pip → ensurepip ladder.
+    """Install ``specs`` into the active interpreter using uv → pip ladder.
 
     Mirrors the strategy in ``hermes_cli.tools_config._pip_install`` but
     kept independent here so this module has no CLI dependency.
+
+    PEP 668 handling: when Hermes is installed against a system Python
+    (no venv — ``sys.prefix == sys.base_prefix``), modern Debian-based
+    distros refuse ``pip install`` without ``--break-system-packages``.
+    Rather than mutate the system site-packages, we install into the
+    user-site (``pip install --user`` / ``uv pip install --system
+    --target=<user-site>``) which is writable without root and respects
+    PEP 668. Inside a real venv the original fast-path is unchanged.
     """
     if not specs:
         return _InstallResult(True, "", "")
 
+    in_venv = _running_in_venv()
     venv_root = Path(sys.executable).parent.parent
-    uv_env = {**os.environ, "VIRTUAL_ENV": str(venv_root)}
+    uv_env = {**os.environ, "VIRTUAL_ENV": str(venv_root)} if in_venv else None
 
-    # Tier 1: uv (preferred — fast, doesn't need pip in the venv)
-    uv_bin = shutil.which("uv")
+    # Tier 1: uv (preferred — fast, doesn't need pip in the venv).
+    # Skip uv when running against a system Python: uv's --system flag
+    # writes to the system site-packages (e.g. /usr/lib), which is
+    # exactly what PEP 668 was designed to prevent. We want the same
+    # user-site fallback that pip --user gives us; uv has no equivalent
+    # flag today, so fall through to pip Tier 2 in that case.
+    uv_bin = shutil.which("uv") if in_venv else None
     if uv_bin:
         try:
             r = subprocess.run(
@@ -381,9 +407,16 @@ def _venv_pip_install(specs: tuple[str, ...], *, timeout: int = 300) -> _Install
             return _InstallResult(False, "",
                                   f"pip not available and ensurepip failed: {e}")
 
+    pip_args = pip_cmd + ["install", *specs]
+    if not in_venv:
+        # --user writes to ~/.local/lib/.../site-packages, which is on
+        # sys.path for the same interpreter and is exempt from PEP 668.
+        # No root, no system site-packages mutation.
+        pip_args.insert(3, "--user")
+
     try:
         r = subprocess.run(
-            pip_cmd + ["install", *specs],
+            pip_args,
             capture_output=True, text=True, timeout=timeout,
         )
         return _InstallResult(r.returncode == 0, r.stdout or "", r.stderr or "")


### PR DESCRIPTION
Fixes #30594.

## Problem

`hermes update` fails the lazy plugin dependency refresh step on any host where Hermes runs against the system Python interpreter (Debian 12+, Ubuntu 23.04+, Kali, etc.). All 5 plugin refreshes that go through `tools.lazy_deps._venv_pip_install` (discord, telegram, dingtalk, feishu, dashboard) hit:

```
error: externally-managed-environment
× This environment is externally managed
```

per PEP 668. The same code path also fires on first feature use, so users see this on more than just update.

This is the same class of bug as #2648 (fixed earlier in the main install path via `_install_python_dependencies_with_optional_fallback`), but in a separate codepath that was missed.

## Root cause

`tools/lazy_deps.py::_venv_pip_install` assumed it was always inside a real venv. When `sys.prefix == sys.base_prefix`, it still shells out to `pip install <spec>` against the system interpreter, which PEP 668 refuses.

## Fix

Add a `_running_in_venv()` helper that checks `sys.prefix != sys.base_prefix`, and branch in `_venv_pip_install`:

- **System Python:** skip the uv tier entirely (uv has no `--user` equivalent; `uv pip install --system` writes to `/usr/lib`, which is exactly what PEP 668 was designed to prevent), and add `--user` to `python -m pip install`. Packages land in `~/.local/lib/.../site-packages`, which is on `sys.path` for the same interpreter and is exempt from PEP 668.
- **Real venv:** unchanged. uv first, pip without `--user`.

No `--break-system-packages` shenanigans, no root, no mutation of system site-packages.

## Tests

Added 6 unit tests under `tests/tools/test_lazy_deps.py::TestVenvPipInstallPEP668` covering:

- `_running_in_venv()` correctly detects both venv and system Python
- System Python path uses `pip --user` and skips uv even when uv is on PATH
- Venv path still uses uv first, no `--user`, no `--break-system-packages`
- Venv fallback to pip (no uv) doesn't add `--user`
- Stale `VIRTUAL_ENV` env var doesn't fool the system-Python detection

All 67 tests in `tests/tools/test_lazy_deps.py` pass locally.

## Verification

Repro env: Kali base image, `pip install --user hermes-agent`, Python 3.13 at `/usr/bin/python3`.

Before: `hermes update` reports 5 failed plugin refreshes with PEP 668 errors.
After (with this branch installed in-place): refreshes succeed, packages land in `~/.local/lib/python3.13/site-packages`.
