### PR TITLE
fix(agent): use atomic_json_write for request debug dumps instead of bare write_text

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1064,10 +1064,7 @@ def dump_api_request_debug(
 
         timestamp = datetime.now().strftime("%Y%m%d_%H%M%S_%f")
         dump_file = agent.logs_dir / f"request_dump_{agent.session_id}_{timestamp}.json"
-        dump_file.write_text(
-            json.dumps(dump_payload, ensure_ascii=False, indent=2, default=str),
-            encoding="utf-8",
-        )
+        atomic_json_write(dump_file, dump_payload)
 
         agent._vprint(f"{agent.log_prefix}🧾 Request debug dump written to: {dump_file}")
 


### PR DESCRIPTION
## What does this PR do?

`dump_api_request_debug()` in `agent/agent_runtime_helpers.py` writes the request debug dump with bare `write_text()`. If the process is killed mid-write (OOM, SIGKILL during a bad API call storm), the dump file is left partially written — this is the file most likely to be examined post-mortem, so corruption here hurts diagnosis of the very failures it was meant to capture.

`atomic_json_write` is already imported from `utils` at the top of the file but unused here.

## Type of Change
- [x] Bug fix

## Changes Made
- Replaced 4-line `write_text(json.dumps(...))` block with a single `atomic_json_write(dump_file, dump_payload)` call
- No behavioral change — same output, same file path, now crash-safe

## How to Test
1. Review `agent/agent_runtime_helpers.py` around line 1065
2. Verify `atomic_json_write` is now used instead of `write_text`
3. Run `python -m pytest tests/ -q` — no regressions expected

## Checklist
### Code
- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've tested on my platform: Ubuntu 24.04 (WSL2)

### Documentation & Housekeeping
- [x] No documentation changes needed
- [x] Cross-platform considered — no platform-specific impact