### PR TITLE
fix(tui): honor composer click position from parent row

### DIFF
--- a/ui-tui/src/__tests__/appLayoutMouse.test.ts
+++ b/ui-tui/src/__tests__/appLayoutMouse.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { startComposerMouseSelection } from '../components/appLayout.js'
+import type { TextInputMouseApi } from '../components/textInput.js'
+
+describe('startComposerMouseSelection', () => {
+  it('starts at the clicked prompt-row offset instead of forcing column 0', () => {
+    const startAt = vi.fn()
+    const stopImmediatePropagation = vi.fn()
+    const api: TextInputMouseApi = { dragAt: vi.fn(), end: vi.fn(), startAt }
+
+    startComposerMouseSelection(
+      api,
+      { button: 0, localCol: 11, localRow: 2, stopImmediatePropagation },
+      4
+    )
+
+    expect(stopImmediatePropagation).toHaveBeenCalledOnce()
+    expect(startAt).toHaveBeenCalledWith(2, 7)
+  })
+
+  it('pins spacer clicks to row 0 while still honoring the horizontal offset', () => {
+    const startAt = vi.fn()
+    const api: TextInputMouseApi = { dragAt: vi.fn(), end: vi.fn(), startAt }
+
+    startComposerMouseSelection(api, { button: 0, localCol: 9, localRow: 5 }, 4, true)
+
+    expect(startAt).toHaveBeenCalledWith(0, 5)
+  })
+
+  it('ignores non-left clicks', () => {
+    const startAt = vi.fn()
+    const api: TextInputMouseApi = { dragAt: vi.fn(), end: vi.fn(), startAt }
+
+    startComposerMouseSelection(api, { button: 2, localCol: 9, localRow: 1 }, 4)
+
+    expect(startAt).not.toHaveBeenCalled()
+  })
+})

--- a/ui-tui/src/components/appLayout.tsx
+++ b/ui-tui/src/components/appLayout.tsx
@@ -28,6 +28,20 @@ import { QueuedMessages } from './queuedMessages.js'
 import { LiveTodoPanel, StreamingAssistant } from './streamingAssistant.js'
 import { TextInput, type TextInputMouseApi } from './textInput.js'
 
+export function startComposerMouseSelection(
+  inputMouseApi: TextInputMouseApi | null,
+  e: GutterMouseEvent,
+  promptWidth: number,
+  spacer = false
+) {
+  if (e.button !== 0) {
+    return
+  }
+
+  e.stopImmediatePropagation?.()
+  inputMouseApi?.startAt(spacer ? 0 : (e.localRow ?? 0), (e.localCol ?? 0) - promptWidth)
+}
+
 const PromptPrefix = memo(function PromptPrefix({
   bold = false,
   color,
@@ -177,12 +191,10 @@ const ComposerPane = memo(function ComposerPane({
   const inputMouseRef = useRef<null | TextInputMouseApi>(null)
 
   const captureInputDrag = (e: GutterMouseEvent) => {
-    if (e.button !== 0) {
-      return
-    }
-
-    e.stopImmediatePropagation?.()
-    inputMouseRef.current?.startAtBeginning()
+    // Some terminals hit the outer composer row instead of the nested
+    // TextInput on press. Start at the real pointer position so a plain
+    // click still moves the caret before any drag begins.
+    startComposerMouseSelection(inputMouseRef.current, e, promptWidth)
   }
 
   // Drag origin matches the input box's top-left, so localRow / localCol
@@ -206,6 +218,10 @@ const ComposerPane = memo(function ComposerPane({
 
     e.stopImmediatePropagation?.()
     inputMouseRef.current?.dragAt(0, (e.localCol ?? 0) - promptWidth)
+  }
+
+  const captureFromSpacer = (e: GutterMouseEvent) => {
+    startComposerMouseSelection(inputMouseRef.current, e, promptWidth, true)
   }
 
   const endInputDrag = () => inputMouseRef.current?.end()
@@ -242,7 +258,12 @@ const ComposerPane = memo(function ComposerPane({
           {status.stickyPrompt}
         </Text>
       ) : (
-        <Box height={1} onMouseDown={captureInputDrag} onMouseDrag={dragFromSpacer} onMouseUp={endInputDrag} />
+        <Box
+          height={1}
+          onMouseDown={captureFromSpacer}
+          onMouseDrag={dragFromSpacer}
+          onMouseUp={endInputDrag}
+        />
       )}
 
       <StatusRulePane at="top" composer={composer} status={status} />

--- a/ui-tui/src/components/textInput.tsx
+++ b/ui-tui/src/components/textInput.tsx
@@ -834,9 +834,9 @@ export function TextInput({
 
   if (mouseApiRef) {
     mouseApiRef.current = {
+      startAt: (row, col) => startMouseSelection(offsetFromPosition(display, row, col, columns)),
       dragAt: (row, col) => dragMouseSelection(offsetFromPosition(display, row, col, columns)),
       end: endMouseSelection,
-      startAtBeginning: () => startMouseSelection(0)
     }
   }
 
@@ -1244,7 +1244,7 @@ export const shouldPassThroughToGlobalHandler = (
   isVoiceToggleKey(key, input, voiceRecordKey)
 
 export interface TextInputMouseApi {
+  startAt: (row: number, col: number) => void
   dragAt: (row: number, col: number) => void
   end: () => void
-  startAtBeginning: () => void
 }


### PR DESCRIPTION
## Summary
- route composer-row mouse down events into TextInput row/column coordinates instead of collapsing to column 0
- let spacer-row clicks seed selection at the correct horizontal offset on row 0
- cover the parent-row mapping with a focused TUI mouse regression test

Closes #30536

## Testing
- cd ui-tui && npm test -- src/__tests__/appLayoutMouse.test.ts src/__tests__/textInputWrap.test.ts
- git diff --check