### PR TITLE
feat: adaptive retry with model escalation for kanban dispatcher

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5106,6 +5106,19 @@ class GatewayRunner:
             )
             stale_timeout_seconds = 0
 
+        # Read retry_model_escalation -- model upgrade ladder for retries.
+        raw_escalation = kanban_cfg.get("retry_model_escalation", {})
+        if isinstance(raw_escalation, dict):
+            model_escalation = {str(k): str(v) for k, v in raw_escalation.items() if k and v}
+        else:
+            logger.warning(
+                "kanban dispatcher: invalid kanban.retry_model_escalation=%r; ignoring",
+                raw_escalation,
+            )
+            model_escalation = {}
+        if model_escalation:
+            logger.info("kanban dispatcher: model_escalation=%r", model_escalation)
+
         # Initial delay so the gateway finishes wiring adapters before the
         # dispatcher spawns workers (those workers may hit gateway notify
         # subscriptions etc.). Matches the notifier watcher's delay.
@@ -5175,6 +5188,7 @@ class GatewayRunner:
                     max_in_progress=max_in_progress,
                     failure_limit=failure_limit,
                     stale_timeout_seconds=stale_timeout_seconds,
+                    model_escalation=model_escalation,
                 )
             except sqlite3.DatabaseError as exc:
                 if _is_corrupt_board_db_error(exc):

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1560,6 +1560,20 @@ DEFAULT_CONFIG = {
         # worker process (if still running host-locally) is terminated
         # before the reclaim.  0 disables stale detection entirely.
         "dispatch_stale_timeout_seconds": 14400,
+        # Model escalation on consecutive failures. Maps a model name to
+        # the model the dispatcher upgrades to on the next retry when
+        # ``consecutive_failures > 0``. Empty dict (default) disables
+        # escalation -- fully backward compatible.
+        #
+        # Example (yaml config):
+        #   retry_model_escalation:
+        #     sonnet4.6-off: sonnet4.6-low
+        #     sonnet4.6-low: opus4.6-high
+        #
+        # The dispatcher mutates model_override on the task row so each
+        # successive retry uses the escalated model. A task already at
+        # the top of the chain stays there.
+        "retry_model_escalation": {},
     },
 
     # execute_code settings — controls the tool used for programmatic tool calls.

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -2128,6 +2128,34 @@ def recompute_ready(conn: sqlite3.Connection) -> int:
                 "WHERE l.child_id = ?",
                 (task_id,),
             ).fetchall()
+            # Crash-loop stickiness fix (#30417): a parentless task that
+            # was blocked by the circuit breaker (``gave_up`` event) must
+            # NOT be auto-promoted every tick. Without parents, the
+            # ``all([]) == True`` vacuous condition would re-promote it
+            # immediately, causing an infinite blocked->promoted->crashed
+            # cycle. Tasks WITH parents are intentionally auto-recovered
+            # when their parents complete -- only the parentless case is
+            # broken.
+            if not parents and cur_status == "blocked":
+                last_gave_up = conn.execute(
+                    "SELECT id FROM task_events "
+                    "WHERE task_id = ? AND kind = 'gave_up' "
+                    "ORDER BY id DESC LIMIT 1",
+                    (task_id,),
+                ).fetchone()
+                last_unblocked = conn.execute(
+                    "SELECT id FROM task_events "
+                    "WHERE task_id = ? AND kind = 'unblocked' "
+                    "ORDER BY id DESC LIMIT 1",
+                    (task_id,),
+                ).fetchone()
+                if last_gave_up and (
+                    not last_unblocked
+                    or last_unblocked["id"] < last_gave_up["id"]
+                ):
+                    # Circuit-breaker blocked, no operator unblock since.
+                    # Stay blocked — the task needs explicit intervention.
+                    continue
             if all(p["status"] in ("done", "archived") for p in parents):
                 # Blocked tasks also get their failure counters reset —
                 # this is effectively an auto-unblock (circuit-breaker
@@ -4710,6 +4738,7 @@ def dispatch_once(
     failure_limit: int = DEFAULT_SPAWN_FAILURE_LIMIT,
     stale_timeout_seconds: int = 0,
     board: Optional[str] = None,
+    model_escalation: Optional[dict] = None,
 ) -> DispatchResult:
     """Run one dispatcher tick.
 
@@ -4892,6 +4921,23 @@ def dispatch_once(
             continue
         # Persist the resolved workspace path so the worker can cd there.
         set_workspace_path(conn, claimed.id, str(workspace))
+        # Model escalation: when the task has consecutive failures,
+        # upgrade model_override per the retry_model_escalation map.
+        # This lets the dispatcher promote a struggling task to a more
+        # capable (or different) model without operator intervention.
+        # The current model_override (or None = profile default) is the
+        # lookup key; if the map has a target, we persist the escalated
+        # model on the task so every subsequent retry uses it.
+        if model_escalation and claimed.consecutive_failures > 0:
+            current_model = claimed.model_override or ""
+            escalated = model_escalation.get(current_model)
+            if escalated and escalated != current_model:
+                with write_txn(conn):
+                    conn.execute(
+                        "UPDATE tasks SET model_override = ? WHERE id = ?",
+                        (escalated, claimed.id),
+                    )
+                claimed.model_override = escalated
         _spawn = spawn_fn if spawn_fn is not None else _default_spawn
         try:
             # Back-compat: older spawn_fn signatures accept only

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -2981,3 +2981,213 @@ def test_detect_stale_does_not_tick_failure_counter(kanban_home, monkeypatch):
         assert "stale" in kinds, (
             f"Expected 'stale' event in task_events; got {kinds!r}"
         )
+
+
+# ---------------------------------------------------------------------------
+# Model escalation (retry_model_escalation)
+# ---------------------------------------------------------------------------
+
+def test_dispatch_escalates_model_on_consecutive_failure(
+    kanban_home, all_assignees_spawnable
+):
+    """On a task with consecutive_failures > 0, dispatch_once should upgrade
+    model_override according to the model_escalation map before spawning."""
+    spawned_tasks = []
+
+    def fake_spawn(task, workspace):
+        spawned_tasks.append(task)
+
+    escalation = {"low-model": "high-model"}
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="flaky", assignee="alice")
+        # Simulate one prior failure so consecutive_failures = 1
+        conn.execute(
+            "UPDATE tasks SET consecutive_failures = 1, model_override = 'low-model' WHERE id = ?",
+            (t,),
+        )
+        conn.commit()
+
+        kb.dispatch_once(
+            conn, spawn_fn=fake_spawn, model_escalation=escalation,
+        )
+
+    assert len(spawned_tasks) == 1
+    assert spawned_tasks[0].model_override == "high-model"
+    with kb.connect() as conn:
+        task = kb.get_task(conn, t)
+        assert task.model_override == "high-model"
+
+
+def test_dispatch_escalates_from_empty_override(
+    kanban_home, all_assignees_spawnable
+):
+    """Empty string key in the escalation map applies when model_override is None."""
+    spawned_tasks = []
+
+    def fake_spawn(task, workspace):
+        spawned_tasks.append(task)
+
+    # Empty-string key = 'no current override' -> upgrade
+    escalation = {"": "upgraded-model"}
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="no-override", assignee="alice")
+        conn.execute(
+            "UPDATE tasks SET consecutive_failures = 1 WHERE id = ?", (t,),
+        )
+        conn.commit()
+
+        kb.dispatch_once(conn, spawn_fn=fake_spawn, model_escalation=escalation)
+
+    assert len(spawned_tasks) == 1
+    assert spawned_tasks[0].model_override == "upgraded-model"
+
+
+def test_dispatch_no_escalation_on_first_spawn(
+    kanban_home, all_assignees_spawnable
+):
+    """Model escalation should NOT apply on first spawn (consecutive_failures == 0)."""
+    spawned_tasks = []
+
+    def fake_spawn(task, workspace):
+        spawned_tasks.append(task)
+
+    escalation = {"": "should-not-use"}
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="fresh", assignee="alice")
+        kb.dispatch_once(conn, spawn_fn=fake_spawn, model_escalation=escalation)
+
+    assert len(spawned_tasks) == 1
+    assert spawned_tasks[0].model_override is None
+
+
+def test_dispatch_no_escalation_when_map_empty(
+    kanban_home, all_assignees_spawnable
+):
+    """Empty escalation dict means no escalation regardless of failure count."""
+    spawned_tasks = []
+
+    def fake_spawn(task, workspace):
+        spawned_tasks.append(task)
+
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="no-map", assignee="alice")
+        conn.execute(
+            "UPDATE tasks SET consecutive_failures = 3, model_override = 'x' WHERE id = ?",
+            (t,),
+        )
+        conn.commit()
+        kb.dispatch_once(conn, spawn_fn=fake_spawn, model_escalation={})
+
+    assert spawned_tasks[0].model_override == "x"  # unchanged
+
+
+def test_dispatch_no_escalation_at_top_of_chain(
+    kanban_home, all_assignees_spawnable
+):
+    """A task already at the top of the chain (no further escalation target)
+    stays with its current model_override unchanged."""
+    spawned_tasks = []
+
+    def fake_spawn(task, workspace):
+        spawned_tasks.append(task)
+
+    escalation = {"low": "high"}  # "high" has no further escalation
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="top-of-chain", assignee="alice")
+        conn.execute(
+            "UPDATE tasks SET consecutive_failures = 2, model_override = 'high' WHERE id = ?",
+            (t,),
+        )
+        conn.commit()
+        kb.dispatch_once(conn, spawn_fn=fake_spawn, model_escalation=escalation)
+
+    assert spawned_tasks[0].model_override == "high"
+
+
+# ---------------------------------------------------------------------------
+# Crash loop stickiness fix (#30417)
+# ---------------------------------------------------------------------------
+
+def test_gave_up_blocked_task_does_not_auto_promote(kanban_home):
+    """A parentless task blocked by the circuit breaker (gave_up event) must
+    NOT be re-promoted to ready by recompute_ready every tick -- that causes
+    the blocked-promoted-spawned-crashed infinite cycle. (#30417)"""
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="crasher", assignee="alice")
+        # Simulate the circuit breaker trip: status=blocked + gave_up event
+        conn.execute(
+            "UPDATE tasks SET status = 'blocked', consecutive_failures = 3 WHERE id = ?",
+            (t,),
+        )
+        conn.execute(
+            "INSERT INTO task_events (task_id, kind, payload, created_at) "
+            "VALUES (?, 'gave_up', '{}', ?)",
+            (t, int(__import__("time").time())),
+        )
+        conn.commit()
+
+        # recompute_ready must NOT promote this task
+        promoted = kb.recompute_ready(conn)
+        assert promoted == 0
+        task = kb.get_task(conn, t)
+        assert task.status == "blocked"
+
+
+def test_gave_up_blocked_task_promotes_after_explicit_unblock(kanban_home):
+    """After an operator calls unblock_task (which emits an 'unblocked' event),
+    a previously gave_up-blocked task can be promoted by recompute_ready."""
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="crasher", assignee="alice")
+        now = int(__import__("time").time())
+        conn.execute(
+            "UPDATE tasks SET status = 'blocked', consecutive_failures = 3 WHERE id = ?",
+            (t,),
+        )
+        conn.execute(
+            "INSERT INTO task_events (task_id, kind, payload, created_at) "
+            "VALUES (?, 'gave_up', '{}', ?)",
+            (t, now),
+        )
+        conn.commit()
+
+        # Simulate operator unblock: emits 'unblocked' event and flips to ready
+        # (we call the real unblock_task here)
+        kb.unblock_task(conn, t)
+
+        # Status is now ready; recompute_ready is a no-op for non-todo/blocked tasks
+        task = kb.get_task(conn, t)
+        assert task.status == "ready"
+
+
+def test_recompute_ready_still_promotes_blocked_with_done_parents_after_gave_up(
+    kanban_home,
+):
+    """A task blocked by gave_up event SHOULD still be promoted when it has
+    parents and all parents are done -- dependency unblock should override
+    the circuit-breaker sticky. This tests that the fix doesn't break
+    the original parent-dependency auto-recovery path."""
+    with kb.connect() as conn:
+        parent = kb.create_task(conn, title="parent", assignee="a")
+        child = kb.create_task(conn, title="child", assignee="a", parents=[parent])
+        # Complete the parent
+        kb.claim_task(conn, parent)
+        kb.complete_task(conn, parent)
+        # Simulate circuit-breaker block on child
+        now = int(__import__("time").time())
+        conn.execute(
+            "UPDATE tasks SET status = 'blocked', consecutive_failures = 2 WHERE id = ?",
+            (child,),
+        )
+        conn.execute(
+            "INSERT INTO task_events (task_id, kind, payload, created_at) "
+            "VALUES (?, 'gave_up', '{}', ?)",
+            (child, now),
+        )
+        conn.commit()
+
+        # Parent is done -> child should be promoted despite gave_up
+        promoted = kb.recompute_ready(conn)
+        assert promoted == 1
+        task = kb.get_task(conn, child)
+        assert task.status == "ready"
+        assert task.consecutive_failures == 0


### PR DESCRIPTION
## Summary

Implements adaptive model escalation for the kanban dispatcher when tasks fail repeatedly, plus fixes the crash-loop stickiness bug (#30417).

### What changed

**1. Config key: `kanban.retry_model_escalation`** (`hermes_cli/config.py`)
- New dict key, empty default -- fully backward compatible
- Maps model names to escalation targets; applies when `consecutive_failures > 0`
- Example:
  ```yaml
  retry_model_escalation:
    sonnet4.6-off: sonnet4.6-low
    sonnet4.6-low: opus4.6-high
  ```

**2. Dispatch logic** (`hermes_cli/kanban_db.py`)
- `dispatch_once()` gains a `model_escalation: Optional[dict]` parameter
- Before spawn, resolves the task's current model (from `model_override` or empty string for profile default), looks it up in the map, and persists the escalated model back to the task row so each retry uses the upgraded model
- No-op on first spawn (`consecutive_failures == 0`), empty map, or when already at the top of the chain

**3. Crash-loop stickiness fix (#30417)** (`hermes_cli/kanban_db.py`)
- Root cause: `recompute_ready` promotes `blocked` tasks when all parents are done; for parentless tasks `all([]) == True` (vacuous truth), so a circuit-breaker-blocked task re-promoted every tick
- Fix: in `recompute_ready`, when a parentless blocked task has a `gave_up` event with no subsequent `unblocked` event, skip promotion -- requires explicit `hermes kanban unblock` to re-queue
- Tasks WITH parents still auto-recover when their parents complete (original design preserved)

**4. Gateway wiring** (`gateway/run.py`)
- Reads `kanban.retry_model_escalation` from config and passes it to `dispatch_once` on every tick

### Tests

8 new tests in `tests/hermes_cli/test_kanban_db.py`:
- Model escalation: empty map, first-spawn no-op, already-at-top-of-chain, escalation from None override, escalation from set override
- Crash loop: parentless gave_up stays blocked, explicit unblock re-queues, gave_up with done parents still promotes

All 332 existing tests continue to pass.

### How to verify

```bash
source venv/bin/activate
python -m pytest tests/hermes_cli/test_kanban_db.py -k 'escalat or gave_up' -v
python -m pytest tests/hermes_cli/test_kanban_db.py tests/hermes_cli/test_kanban_core_functionality.py -q
```

Closes #30587
Fixes #30417