### PR TITLE
fix(acp): honour --profile from CLI and hermes-acp direct entry (#30571)

### DIFF
--- a/acp_adapter/entry.py
+++ b/acp_adapter/entry.py
@@ -178,10 +178,15 @@ def _apply_profile_override(profile_name: str | None) -> None:
         print(f"Error: {exc}", file=sys.stderr)
         sys.exit(1)
     except Exception as exc:
-        # Profile resolution must never prevent ACP from starting; surface
-        # the issue and fall back to whatever environment the caller had.
+        # Unexpected resolver bug must never prevent ACP from starting;
+        # surface the issue and fall back to whatever HERMES_HOME /
+        # HERMES_PROFILE the caller already had (which may itself be
+        # non-default — we don't know, so don't claim "default").
+        # ValueError / FileNotFoundError above are deliberately fatal so
+        # the user notices a typoed profile name.
         print(
-            f"Warning: profile override failed ({exc}), using default",
+            f"Warning: profile override failed ({exc}), "
+            f"using existing environment",
             file=sys.stderr,
         )
         return

--- a/acp_adapter/entry.py
+++ b/acp_adapter/entry.py
@@ -27,6 +27,7 @@ except ModuleNotFoundError:
 import argparse
 import asyncio
 import logging
+import os
 import sys
 from pathlib import Path
 from hermes_constants import get_hermes_home
@@ -138,7 +139,54 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         help="Accept all prompts (currently used by --setup-browser to skip the "
              "~400 MB Chromium download confirmation).",
     )
+    parser.add_argument(
+        "--profile",
+        "-p",
+        default=None,
+        help=(
+            "Hermes profile name to run ACP under. Selects the profile's "
+            "config.yaml, .env, skills, memory, and gateway state. Lets "
+            "editor configs expose multiple ACP agents (e.g. "
+            "``hermes-acp -p code-reviewer``)."
+        ),
+    )
     return parser.parse_args(argv)
+
+
+def _apply_profile_override(profile_name: str | None) -> None:
+    """Resolve ``--profile`` and publish HERMES_HOME / HERMES_PROFILE.
+
+    Runs at ACP startup so that ``hermes-acp -p <name>`` direct invocations
+    (used by editor configs like Zed agent commands) end up with the same
+    environment as ``hermes -p <name> acp`` — i.e. ``get_hermes_home()``
+    returns the profile directory and downstream callers that branch on
+    ``HERMES_PROFILE`` see the canonical name.
+
+    When the env is *already* pointing at this profile (because the parent
+    ``hermes_cli.main._apply_profile_override`` ran first), the resolver is
+    a no-op: ``setdefault`` preserves the inherited HERMES_PROFILE and the
+    HERMES_HOME assignment writes the same string back.
+    """
+    if not profile_name:
+        return
+    try:
+        from hermes_cli.profiles import normalize_profile_name, resolve_profile_env
+
+        hermes_home = resolve_profile_env(profile_name)
+        canonical_name = normalize_profile_name(profile_name)
+    except (ValueError, FileNotFoundError) as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        sys.exit(1)
+    except Exception as exc:
+        # Profile resolution must never prevent ACP from starting; surface
+        # the issue and fall back to whatever environment the caller had.
+        print(
+            f"Warning: profile override failed ({exc}), using default",
+            file=sys.stderr,
+        )
+        return
+    os.environ["HERMES_HOME"] = hermes_home
+    os.environ.setdefault("HERMES_PROFILE", canonical_name)
 
 
 def _print_version() -> None:
@@ -212,6 +260,11 @@ def _run_setup_browser(assume_yes: bool = False) -> int:
 def main(argv: list[str] | None = None) -> None:
     """Entry point: load env, configure logging, run the ACP agent."""
     args = _parse_args(argv)
+    # Apply ``--profile`` BEFORE any subcommand branch so ``--check`` /
+    # ``--setup`` / ``--setup-browser`` and the default server start path
+    # all observe the profile-scoped HERMES_HOME (.env, config.yaml,
+    # skills, memory, gateway state).
+    _apply_profile_override(args.profile)
     if args.version:
         _print_version()
         return

--- a/acp_adapter/entry.py
+++ b/acp_adapter/entry.py
@@ -27,7 +27,6 @@ except ModuleNotFoundError:
 import argparse
 import asyncio
 import logging
-import os
 import sys
 from pathlib import Path
 from hermes_constants import get_hermes_home
@@ -166,32 +165,16 @@ def _apply_profile_override(profile_name: str | None) -> None:
     ``hermes_cli.main._apply_profile_override`` ran first), the resolver is
     a no-op: ``setdefault`` preserves the inherited HERMES_PROFILE and the
     HERMES_HOME assignment writes the same string back.
+
+    Delegates to ``hermes_cli.profiles.apply_profile_env`` so the two ACP
+    entry points (``hermes acp`` and ``hermes-acp``) share validation,
+    exit semantics, and env writes verbatim.
     """
     if not profile_name:
         return
-    try:
-        from hermes_cli.profiles import normalize_profile_name, resolve_profile_env
+    from hermes_cli.profiles import apply_profile_env
 
-        hermes_home = resolve_profile_env(profile_name)
-        canonical_name = normalize_profile_name(profile_name)
-    except (ValueError, FileNotFoundError) as exc:
-        print(f"Error: {exc}", file=sys.stderr)
-        sys.exit(1)
-    except Exception as exc:
-        # Unexpected resolver bug must never prevent ACP from starting;
-        # surface the issue and fall back to whatever HERMES_HOME /
-        # HERMES_PROFILE the caller already had (which may itself be
-        # non-default — we don't know, so don't claim "default").
-        # ValueError / FileNotFoundError above are deliberately fatal so
-        # the user notices a typoed profile name.
-        print(
-            f"Warning: profile override failed ({exc}), "
-            f"using existing environment",
-            file=sys.stderr,
-        )
-        return
-    os.environ["HERMES_HOME"] = hermes_home
-    os.environ.setdefault("HERMES_PROFILE", canonical_name)
+    apply_profile_env(profile_name)
 
 
 def _print_version() -> None:

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -294,6 +294,18 @@ def _apply_profile_override() -> None:
     hermes_home_env = os.environ.get("HERMES_HOME", "")
     if profile_name is None and hermes_home_env:
         if Path(hermes_home_env).parent.name == "profiles":
+            # Mirror the late-path setdefault so downstream callers (kanban,
+            # gateway adapters, ACP entry) can read HERMES_PROFILE even when
+            # the caller already pointed HERMES_HOME at a profile directory.
+            try:
+                from hermes_cli.profiles import normalize_profile_name
+
+                os.environ.setdefault(
+                    "HERMES_PROFILE",
+                    normalize_profile_name(Path(hermes_home_env).name),
+                )
+            except (ValueError, ImportError):
+                pass  # malformed dir name or import-time failure — skip silently
             return
 
     # 2. If no flag, check active_profile in the hermes root

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -324,28 +324,16 @@ def _apply_profile_override() -> None:
 
     # 3. If we found a profile, resolve and set HERMES_HOME
     if profile_name is not None:
-        try:
-            from hermes_cli.profiles import normalize_profile_name, resolve_profile_env
+        from hermes_cli.profiles import apply_profile_env
 
-            hermes_home = resolve_profile_env(profile_name)
-            canonical_name = normalize_profile_name(profile_name)
-        except (ValueError, FileNotFoundError) as exc:
-            print(f"Error: {exc}", file=sys.stderr)
-            sys.exit(1)
-        except Exception as exc:
-            # A bug in profiles.py must NEVER prevent hermes from starting
-            print(
-                f"Warning: profile override failed ({exc}), using default",
-                file=sys.stderr,
-            )
+        # ``apply_profile_env`` writes HERMES_HOME + HERMES_PROFILE on
+        # success, ``sys.exit(1)``s on user-typo errors, and returns False
+        # on unexpected resolver bugs (warning printed). When it returns
+        # False we must NOT strip the flag from argv — argparse will then
+        # surface the unknown flag instead of running with a half-applied
+        # profile override.
+        if not apply_profile_env(profile_name):
             return
-        os.environ["HERMES_HOME"] = hermes_home
-        # Also publish the canonical profile name so downstream code that
-        # branches on profile identity (kanban, gateway adapters, ACP entry)
-        # can pick it up without re-parsing HERMES_HOME. Honour any value the
-        # caller already exported — a deliberate ``HERMES_PROFILE=...`` on
-        # the spawning shell should win over this best-effort default.
-        os.environ.setdefault("HERMES_PROFILE", canonical_name)
         # Strip the flag from argv so argparse doesn't choke
         if consume > 0:
             for i, arg in enumerate(argv):
@@ -11931,6 +11919,39 @@ def _try_termux_fast_cli_launch() -> bool:
     return False
 
 
+def _build_acp_argv(args, env: dict[str, str] | None = None) -> list[str]:
+    """Build the argv that ``hermes acp`` forwards to ``hermes-acp``.
+
+    Extracted from the nested ``cmd_acp`` closure so the argv-shape can be
+    unit-tested without standing up the full argparse plumbing. ``args``
+    is the argparse Namespace returned for the ``acp`` subcommand; ``env``
+    defaults to ``os.environ`` so callers can pin a deterministic env in
+    tests.
+
+    Profile forwarding contract: ``--profile <name>`` is appended iff
+    ``HERMES_PROFILE`` is set, non-empty after stripping, and not the
+    literal string ``default`` (the default profile is implicit — passing
+    it explicitly would force a redundant resolver pass downstream).
+    """
+    if env is None:
+        env = os.environ
+    acp_argv: list[str] = []
+    if getattr(args, "acp_version", False):
+        acp_argv.append("--version")
+    if getattr(args, "check", False):
+        acp_argv.append("--check")
+    if getattr(args, "setup", False):
+        acp_argv.append("--setup")
+    if getattr(args, "setup_browser", False):
+        acp_argv.append("--setup-browser")
+    if getattr(args, "assume_yes", False):
+        acp_argv.append("--yes")
+    active_profile = env.get("HERMES_PROFILE", "").strip()
+    if active_profile and active_profile != "default":
+        acp_argv.extend(["--profile", active_profile])
+    return acp_argv
+
+
 def _try_termux_fast_tui_launch() -> bool:
     """Launch obvious Termux TUI invocations before building every subparser.
 
@@ -14626,26 +14647,12 @@ Examples:
         try:
             from acp_adapter.entry import main as acp_main
 
-            acp_argv = []
-            if getattr(args, "acp_version", False):
-                acp_argv.append("--version")
-            if getattr(args, "check", False):
-                acp_argv.append("--check")
-            if getattr(args, "setup", False):
-                acp_argv.append("--setup")
-            if getattr(args, "setup_browser", False):
-                acp_argv.append("--setup-browser")
-            if getattr(args, "assume_yes", False):
-                acp_argv.append("--yes")
-            # Forward the active profile name so ACP can announce it in logs
-            # and so direct ``hermes-acp`` invocations from editor configs
-            # behave the same as ``hermes -p <name> acp``. The env var is
-            # populated by ``_apply_profile_override`` when ``-p/--profile``
-            # was passed; absence means the default profile.
-            active_profile = os.environ.get("HERMES_PROFILE", "").strip()
-            if active_profile and active_profile != "default":
-                acp_argv.extend(["--profile", active_profile])
-            acp_main(acp_argv)
+            # Forward the active profile name so ACP can announce it in
+            # logs and so direct ``hermes-acp`` invocations from editor
+            # configs behave the same as ``hermes -p <name> acp``.
+            # HERMES_PROFILE is populated by ``_apply_profile_override``
+            # when ``-p/--profile`` was passed; absence means default.
+            acp_main(_build_acp_argv(args))
         except ImportError:
             print("ACP dependencies not installed.", file=sys.stderr)
             print("Install them with:  pip install -e '.[acp]'", file=sys.stderr)

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -313,9 +313,10 @@ def _apply_profile_override() -> None:
     # 3. If we found a profile, resolve and set HERMES_HOME
     if profile_name is not None:
         try:
-            from hermes_cli.profiles import resolve_profile_env
+            from hermes_cli.profiles import normalize_profile_name, resolve_profile_env
 
             hermes_home = resolve_profile_env(profile_name)
+            canonical_name = normalize_profile_name(profile_name)
         except (ValueError, FileNotFoundError) as exc:
             print(f"Error: {exc}", file=sys.stderr)
             sys.exit(1)
@@ -327,6 +328,12 @@ def _apply_profile_override() -> None:
             )
             return
         os.environ["HERMES_HOME"] = hermes_home
+        # Also publish the canonical profile name so downstream code that
+        # branches on profile identity (kanban, gateway adapters, ACP entry)
+        # can pick it up without re-parsing HERMES_HOME. Honour any value the
+        # caller already exported — a deliberate ``HERMES_PROFILE=...`` on
+        # the spawning shell should win over this best-effort default.
+        os.environ.setdefault("HERMES_PROFILE", canonical_name)
         # Strip the flag from argv so argparse doesn't choke
         if consume > 0:
             for i, arg in enumerate(argv):
@@ -14618,6 +14625,14 @@ Examples:
                 acp_argv.append("--setup-browser")
             if getattr(args, "assume_yes", False):
                 acp_argv.append("--yes")
+            # Forward the active profile name so ACP can announce it in logs
+            # and so direct ``hermes-acp`` invocations from editor configs
+            # behave the same as ``hermes -p <name> acp``. The env var is
+            # populated by ``_apply_profile_override`` when ``-p/--profile``
+            # was passed; absence means the default profile.
+            active_profile = os.environ.get("HERMES_PROFILE", "").strip()
+            if active_profile and active_profile != "default":
+                acp_argv.extend(["--profile", active_profile])
             acp_main(acp_argv)
         except ImportError:
             print("ACP dependencies not installed.", file=sys.stderr)

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -1605,3 +1605,38 @@ def resolve_profile_env(profile_name: str) -> str:
         )
 
     return str(profile_dir)
+
+
+def apply_profile_env(profile_name: str) -> bool:
+    """Resolve ``profile_name`` and publish HERMES_HOME / HERMES_PROFILE.
+
+    Shared between ``hermes_cli.main._apply_profile_override`` and
+    ``acp_adapter.entry._apply_profile_override`` so the two entry points
+    stay in lockstep on validation, exit semantics, and env writes.
+
+    On a malformed or missing profile (``ValueError`` / ``FileNotFoundError``
+    from the resolver), prints the resolver's user-facing message to stderr
+    and exits with status 1 — these are user-typo signals and the CLI
+    should not silently fall back. On any other resolver bug, prints a
+    warning and returns ``False`` so the caller can treat the override as a
+    no-op without taking the process down.
+
+    HERMES_HOME is overwritten unconditionally on success; HERMES_PROFILE
+    uses ``setdefault`` so a deliberate caller-set value wins.
+    """
+    try:
+        hermes_home = resolve_profile_env(profile_name)
+        canonical_name = normalize_profile_name(profile_name)
+    except (ValueError, FileNotFoundError) as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        sys.exit(1)
+    except Exception as exc:
+        print(
+            f"Warning: profile override failed ({exc}), "
+            f"using existing environment",
+            file=sys.stderr,
+        )
+        return False
+    os.environ["HERMES_HOME"] = hermes_home
+    os.environ.setdefault("HERMES_PROFILE", canonical_name)
+    return True

--- a/tests/acp/test_entry.py
+++ b/tests/acp/test_entry.py
@@ -1,6 +1,8 @@
 """Tests for acp_adapter.entry startup wiring."""
 
+import os
 import sys
+from pathlib import Path
 
 import acp
 import pytest
@@ -153,3 +155,140 @@ def test_main_setup_browser_propagates_browser_failure(monkeypatch):
     with pytest.raises(SystemExit) as excinfo:
         entry.main(["--setup-browser"])
     assert excinfo.value.code == 1
+
+
+# ---------------------------------------------------------------------------
+# --profile propagation (#30571)
+# ---------------------------------------------------------------------------
+
+
+def _bootstrap_profile(tmp_path: Path, monkeypatch, name: str) -> Path:
+    """Lay down ``<tmp>/.hermes/profiles/<name>`` and point Path.home() at it."""
+    profile_dir = tmp_path / ".hermes" / "profiles" / name
+    profile_dir.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    return profile_dir
+
+
+def test_main_profile_flag_sets_hermes_home_before_load_env(monkeypatch, tmp_path):
+    """``hermes-acp --profile <name>`` must repoint HERMES_HOME at the
+    profile dir before ``_load_env`` runs, so the profile's .env is what
+    gets loaded.
+    """
+    profile_dir = _bootstrap_profile(tmp_path, monkeypatch, "code-reviewer")
+    monkeypatch.delenv("HERMES_HOME", raising=False)
+    monkeypatch.delenv("HERMES_PROFILE", raising=False)
+
+    observed = {}
+
+    def fake_load_env():
+        observed["HERMES_HOME"] = os.environ.get("HERMES_HOME")
+        observed["HERMES_PROFILE"] = os.environ.get("HERMES_PROFILE")
+
+    async def fake_run_agent(agent, **kwargs):
+        observed["ran"] = True
+
+    monkeypatch.setattr(entry, "_setup_logging", lambda: None)
+    monkeypatch.setattr(entry, "_load_env", fake_load_env)
+    monkeypatch.setattr(acp, "run_agent", fake_run_agent)
+
+    entry.main(["--profile", "code-reviewer"])
+
+    assert observed["HERMES_HOME"] == str(profile_dir)
+    assert observed["HERMES_PROFILE"] == "code-reviewer"
+    assert observed.get("ran") is True
+
+
+def test_main_short_profile_flag_is_equivalent(monkeypatch, tmp_path):
+    """``-p`` is the same as ``--profile``."""
+    profile_dir = _bootstrap_profile(tmp_path, monkeypatch, "fast-coder")
+    monkeypatch.delenv("HERMES_HOME", raising=False)
+    monkeypatch.delenv("HERMES_PROFILE", raising=False)
+
+    monkeypatch.setattr(entry, "_setup_logging", lambda: None)
+    monkeypatch.setattr(entry, "_load_env", lambda: None)
+
+    async def fake_run_agent(agent, **kwargs):
+        pass
+
+    monkeypatch.setattr(acp, "run_agent", fake_run_agent)
+
+    entry.main(["-p", "fast-coder"])
+
+    assert os.environ.get("HERMES_HOME") == str(profile_dir)
+    assert os.environ.get("HERMES_PROFILE") == "fast-coder"
+
+
+def test_main_profile_flag_applies_before_check_subcommand(monkeypatch, tmp_path, capsys):
+    """``--check`` short-circuits the server start but still has to honour
+    ``--profile`` so a check run under the requested profile uses the right
+    config / dependencies."""
+    profile_dir = _bootstrap_profile(tmp_path, monkeypatch, "research-agent")
+    monkeypatch.delenv("HERMES_HOME", raising=False)
+    monkeypatch.delenv("HERMES_PROFILE", raising=False)
+    monkeypatch.setattr(entry, "_setup_logging", lambda: (_ for _ in ()).throw(AssertionError("started server")))
+
+    entry.main(["--check", "--profile", "research-agent"])
+
+    assert os.environ.get("HERMES_HOME") == str(profile_dir)
+    assert os.environ.get("HERMES_PROFILE") == "research-agent"
+    assert capsys.readouterr().out.strip() == "Hermes ACP check OK"
+
+
+def test_main_omitting_profile_leaves_environment_untouched(monkeypatch, tmp_path):
+    """Without ``--profile`` the ACP entry must not clobber HERMES_HOME /
+    HERMES_PROFILE — the parent ``hermes`` CLI or the spawning shell may
+    have already set them."""
+    inherited_home = tmp_path / "inherited"
+    inherited_home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(inherited_home))
+    monkeypatch.setenv("HERMES_PROFILE", "inherited-profile")
+
+    monkeypatch.setattr(entry, "_setup_logging", lambda: None)
+    monkeypatch.setattr(entry, "_load_env", lambda: None)
+
+    async def fake_run_agent(agent, **kwargs):
+        pass
+
+    monkeypatch.setattr(acp, "run_agent", fake_run_agent)
+
+    entry.main([])
+
+    assert os.environ.get("HERMES_HOME") == str(inherited_home)
+    assert os.environ.get("HERMES_PROFILE") == "inherited-profile"
+
+
+def test_main_profile_flag_rejects_unknown_profile(monkeypatch, tmp_path):
+    """Missing profile directory exits with a clear error instead of silently
+    falling back to the default profile."""
+    _bootstrap_profile(tmp_path, monkeypatch, "exists")
+    monkeypatch.delenv("HERMES_HOME", raising=False)
+    monkeypatch.delenv("HERMES_PROFILE", raising=False)
+
+    with pytest.raises(SystemExit) as excinfo:
+        entry.main(["--profile", "does-not-exist"])
+    assert excinfo.value.code == 1
+    assert os.environ.get("HERMES_PROFILE") is None
+
+
+def test_main_profile_flag_does_not_overwrite_explicit_hermes_profile(monkeypatch, tmp_path):
+    """A deliberate ``HERMES_PROFILE`` from the spawning shell wins over the
+    setdefault inside ``_apply_profile_override`` — same contract as
+    ``hermes_cli.main._apply_profile_override``."""
+    profile_dir = _bootstrap_profile(tmp_path, monkeypatch, "named")
+    monkeypatch.delenv("HERMES_HOME", raising=False)
+    monkeypatch.setenv("HERMES_PROFILE", "operator-override")
+
+    monkeypatch.setattr(entry, "_setup_logging", lambda: None)
+    monkeypatch.setattr(entry, "_load_env", lambda: None)
+
+    async def fake_run_agent(agent, **kwargs):
+        pass
+
+    monkeypatch.setattr(acp, "run_agent", fake_run_agent)
+
+    entry.main(["--profile", "named"])
+
+    # HERMES_HOME is repointed (filesystem-truth), HERMES_PROFILE preserved.
+    assert os.environ.get("HERMES_HOME") == str(profile_dir)
+    assert os.environ.get("HERMES_PROFILE") == "operator-override"

--- a/tests/hermes_cli/test_apply_profile_override.py
+++ b/tests/hermes_cli/test_apply_profile_override.py
@@ -216,3 +216,44 @@ class TestApplyProfileOverridePublishesProfileName:
 
         assert os.environ.get("HERMES_PROFILE") is None
         assert os.environ.get("HERMES_HOME") is None
+
+    def test_inherited_profile_hermes_home_publishes_hermes_profile(
+        self, tmp_path, monkeypatch
+    ):
+        """Child-process inheritance contract: when HERMES_HOME already
+        points at ``.../profiles/<name>``, the function returns early —
+        but downstream callers still need ``HERMES_PROFILE``. Mirror the
+        late-path setdefault from the basename of HERMES_HOME."""
+        hermes_root = tmp_path / ".hermes"
+        profile_dir = hermes_root / "profiles" / "coder"
+        profile_dir.mkdir(parents=True, exist_ok=True)
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(profile_dir))
+        monkeypatch.delenv("HERMES_PROFILE", raising=False)
+        monkeypatch.setattr(sys, "argv", ["hermes", "gateway", "start"])
+
+        from hermes_cli.main import _apply_profile_override
+        _apply_profile_override()
+
+        assert os.environ.get("HERMES_PROFILE") == "coder"
+        assert os.environ.get("HERMES_HOME") == str(profile_dir)
+
+    def test_inherited_profile_does_not_override_existing_hermes_profile(
+        self, tmp_path, monkeypatch
+    ):
+        """``setdefault`` semantics in the inherited-HERMES_HOME early-return
+        path: a deliberate caller-set ``HERMES_PROFILE`` must win."""
+        hermes_root = tmp_path / ".hermes"
+        profile_dir = hermes_root / "profiles" / "coder"
+        profile_dir.mkdir(parents=True, exist_ok=True)
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(profile_dir))
+        monkeypatch.setenv("HERMES_PROFILE", "operator-set")
+        monkeypatch.setattr(sys, "argv", ["hermes", "gateway", "start"])
+
+        from hermes_cli.main import _apply_profile_override
+        _apply_profile_override()
+
+        assert os.environ.get("HERMES_PROFILE") == "operator-set"

--- a/tests/hermes_cli/test_apply_profile_override.py
+++ b/tests/hermes_cli/test_apply_profile_override.py
@@ -33,7 +33,14 @@ def _run_apply_profile_override(
         (hermes_root / "active_profile").write_text(active_profile)
 
     if active_profile and active_profile != "default":
-        (hermes_root / "profiles" / active_profile).mkdir(parents=True, exist_ok=True)
+        # Profile directories are stored lowercase on disk (see
+        # hermes_cli.profiles.normalize_profile_name). When the test exercises
+        # the title-cased input path (e.g. ``-p Coder``), the resolver looks
+        # up ``profiles/coder``, not ``profiles/Coder`` — create the canonical
+        # directory so the fixture matches production layout.
+        (hermes_root / "profiles" / active_profile.lower()).mkdir(
+            parents=True, exist_ok=True
+        )
 
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
     if hermes_home is not None:

--- a/tests/hermes_cli/test_apply_profile_override.py
+++ b/tests/hermes_cli/test_apply_profile_override.py
@@ -138,3 +138,74 @@ class TestApplyProfileOverrideHermesHomeGuard:
         _apply_profile_override()
 
         assert os.environ.get("HERMES_HOME") is None
+
+
+class TestApplyProfileOverridePublishesProfileName:
+    """Regression guard for #30571.
+
+    The override must publish ``HERMES_PROFILE`` alongside ``HERMES_HOME``
+    so downstream callers that branch on the active profile name (ACP
+    entry, kanban, gateway adapters) can read it without re-parsing the
+    HERMES_HOME path.
+    """
+
+    def test_explicit_flag_sets_hermes_profile_canonical_name(self, tmp_path, monkeypatch):
+        """``hermes -p Coder gateway`` must export ``HERMES_PROFILE=coder``
+        (the canonical, lower-cased name)."""
+        monkeypatch.delenv("HERMES_PROFILE", raising=False)
+
+        _run_apply_profile_override(
+            tmp_path,
+            monkeypatch,
+            hermes_home=None,
+            active_profile="Coder",
+            argv=["hermes", "-p", "Coder", "acp"],
+        )
+
+        assert os.environ.get("HERMES_PROFILE") == "coder"
+
+    def test_active_profile_file_sets_hermes_profile(self, tmp_path, monkeypatch):
+        """Sticky default profile picked up from ``active_profile`` must
+        also publish ``HERMES_PROFILE``."""
+        monkeypatch.delenv("HERMES_PROFILE", raising=False)
+
+        _run_apply_profile_override(
+            tmp_path,
+            monkeypatch,
+            hermes_home=None,
+            active_profile="coder",
+        )
+
+        assert os.environ.get("HERMES_PROFILE") == "coder"
+
+    def test_existing_hermes_profile_is_preserved(self, tmp_path, monkeypatch):
+        """A deliberate ``HERMES_PROFILE`` exported by the spawning shell
+        must win — setdefault, not overwrite."""
+        monkeypatch.setenv("HERMES_PROFILE", "operator-set")
+
+        _run_apply_profile_override(
+            tmp_path,
+            monkeypatch,
+            hermes_home=None,
+            active_profile="coder",
+        )
+
+        assert os.environ.get("HERMES_PROFILE") == "operator-set"
+
+    def test_default_profile_does_not_publish_hermes_profile(self, tmp_path, monkeypatch):
+        """``active_profile=default`` is the no-op case — neither
+        HERMES_HOME nor HERMES_PROFILE should be assigned."""
+        hermes_root = tmp_path / ".hermes"
+        hermes_root.mkdir(parents=True, exist_ok=True)
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.delenv("HERMES_HOME", raising=False)
+        monkeypatch.delenv("HERMES_PROFILE", raising=False)
+        monkeypatch.setattr(sys, "argv", ["hermes", "gateway", "start"])
+        (hermes_root / "active_profile").write_text("default")
+
+        from hermes_cli.main import _apply_profile_override
+        _apply_profile_override()
+
+        assert os.environ.get("HERMES_PROFILE") is None
+        assert os.environ.get("HERMES_HOME") is None

--- a/tests/hermes_cli/test_build_acp_argv.py
+++ b/tests/hermes_cli/test_build_acp_argv.py
@@ -1,0 +1,105 @@
+"""Argv-forwarding regression tests for ``hermes acp`` (issue #30571).
+
+``hermes acp`` is a thin shim that re-dispatches into ``hermes-acp``
+(``acp_adapter.entry.main``) with a synthesised argv built from the
+parsed argparse Namespace plus the current process env. The interesting
+contract is the ``HERMES_PROFILE`` → ``--profile <name>`` forwarding:
+
+* Set + non-default → forward ``--profile <name>``
+* Set to literal ``default`` → do NOT forward (default is implicit)
+* Unset / empty → do NOT forward
+
+Without this, direct ``hermes-acp`` invocations (used by editor configs
+like Zed agent commands) would not honour the parent ``hermes -p <name>
+acp`` profile selection, breaking config.yaml / .env / skills isolation.
+"""
+
+from __future__ import annotations
+
+from argparse import Namespace
+
+from hermes_cli.main import _build_acp_argv
+
+
+class TestBuildAcpArgvFlags:
+    """The non-profile flags pass through as plain switches."""
+
+    def test_no_flags_returns_empty(self):
+        argv = _build_acp_argv(Namespace(), env={})
+        assert argv == []
+
+    def test_version_flag(self):
+        argv = _build_acp_argv(Namespace(acp_version=True), env={})
+        assert argv == ["--version"]
+
+    def test_check_flag(self):
+        argv = _build_acp_argv(Namespace(check=True), env={})
+        assert argv == ["--check"]
+
+    def test_setup_flag(self):
+        argv = _build_acp_argv(Namespace(setup=True), env={})
+        assert argv == ["--setup"]
+
+    def test_setup_browser_flag(self):
+        argv = _build_acp_argv(Namespace(setup_browser=True), env={})
+        assert argv == ["--setup-browser"]
+
+    def test_assume_yes_flag(self):
+        argv = _build_acp_argv(Namespace(assume_yes=True), env={})
+        assert argv == ["--yes"]
+
+    def test_multiple_flags_preserve_order(self):
+        argv = _build_acp_argv(
+            Namespace(setup_browser=True, assume_yes=True), env={}
+        )
+        assert argv == ["--setup-browser", "--yes"]
+
+
+class TestBuildAcpArgvProfileForwarding:
+    """HERMES_PROFILE → ``--profile`` forwarding rules (the #30571 fix)."""
+
+    def test_profile_set_forwards_flag(self):
+        argv = _build_acp_argv(Namespace(), env={"HERMES_PROFILE": "coder"})
+        assert argv == ["--profile", "coder"]
+
+    def test_profile_default_does_not_forward(self):
+        """``HERMES_PROFILE=default`` is the implicit no-op case."""
+        argv = _build_acp_argv(Namespace(), env={"HERMES_PROFILE": "default"})
+        assert argv == []
+
+    def test_profile_unset_does_not_forward(self):
+        argv = _build_acp_argv(Namespace(), env={})
+        assert "--profile" not in argv
+
+    def test_profile_empty_does_not_forward(self):
+        argv = _build_acp_argv(Namespace(), env={"HERMES_PROFILE": ""})
+        assert "--profile" not in argv
+
+    def test_profile_whitespace_does_not_forward(self):
+        """Whitespace-only HERMES_PROFILE is treated as unset."""
+        argv = _build_acp_argv(Namespace(), env={"HERMES_PROFILE": "   "})
+        assert "--profile" not in argv
+
+    def test_profile_strips_surrounding_whitespace(self):
+        argv = _build_acp_argv(Namespace(), env={"HERMES_PROFILE": "  coder  "})
+        assert argv == ["--profile", "coder"]
+
+    def test_profile_forwarded_after_other_flags(self):
+        """``--profile`` is appended last so the receiving argparse sees a
+        stable shape regardless of which other flags are set."""
+        argv = _build_acp_argv(
+            Namespace(check=True), env={"HERMES_PROFILE": "coder"}
+        )
+        assert argv == ["--check", "--profile", "coder"]
+
+    def test_env_defaults_to_os_environ(self, monkeypatch):
+        """Omitting ``env`` should fall back to ``os.environ`` so the
+        production call site (``cmd_acp``) behaves the same."""
+        monkeypatch.setenv("HERMES_PROFILE", "coder")
+        argv = _build_acp_argv(Namespace())
+        assert argv == ["--profile", "coder"]
+
+    def test_env_defaults_to_os_environ_unset(self, monkeypatch):
+        monkeypatch.delenv("HERMES_PROFILE", raising=False)
+        argv = _build_acp_argv(Namespace())
+        assert "--profile" not in argv


### PR DESCRIPTION
## What does this PR do?

Plumbs `--profile` propagation through both ACP entrypoints so `hermes -p <name> acp` AND direct `hermes-acp -p <name>` invocations (used by editor configs like Zed agent commands) run ACP under the requested profile — config.yaml, .env, skills, memory, gateway state, and the canonical profile name all visible to downstream callers.

Root cause split:

1. `hermes_cli.main._apply_profile_override` set `HERMES_HOME` for `hermes -p <name> acp` but never published the canonical profile name. Downstream code that branches on `HERMES_PROFILE` (kanban, gateway adapters) couldn't see the active profile.
2. `acp_adapter.entry._parse_args` had no `--profile` flag at all, so `hermes-acp -p code-reviewer` — the form an editor config would use — failed with "unrecognized arguments".

Mirrors `_apply_profile_override` precedence: explicit `--profile`/`-p` arg wins, then falls through to the inherited `HERMES_HOME`/`HERMES_PROFILE` from the parent shell. Uses `setdefault` for `HERMES_PROFILE` so a deliberately-exported value from the spawning shell is preserved.

Sibling code paths I considered: `lsaether`'s [PR #30560](https://github.com/NousResearch/hermes-agent/pull/30560) (open) wires `--skills` from CLI → `acp_main` → `HermesACPAgent` → `SessionManager` for the same family of bugs. This PR uses an env-var-based propagation instead because profile activation is a process-wide concern (HERMES_HOME flips multiple subsystems at once), whereas `--skills` is per-session ephemeral state. Both PRs touch `acp_adapter/entry.py` but in independent ways and should merge cleanly side by side.

## Related Issue

Fixes #30571

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/main.py` — `_apply_profile_override` now publishes `HERMES_PROFILE` (canonical, setdefault-only) alongside `HERMES_HOME`; `cmd_acp` forwards the active profile to `acp_main` via argv so the two invocation paths converge on the same environment.
- `acp_adapter/entry.py` — adds `--profile/-p` to the argument parser and a new `_apply_profile_override(profile_name)` helper that calls `resolve_profile_env`, sets `HERMES_HOME`, and seeds `HERMES_PROFILE`. Runs BEFORE every subcommand branch (`--version`, `--check`, `--setup`, `--setup-browser`, server start) so all of them observe the profile-scoped environment.
- `tests/acp/test_entry.py` — six new tests covering: `--profile X` sets `HERMES_HOME` before `_load_env`; `-p` equivalent to `--profile`; `--check` short-circuit still honours `--profile`; absence of `--profile` leaves inherited env untouched; unknown profile exits with status 1; explicit `HERMES_PROFILE` from the shell wins over setdefault.
- `tests/hermes_cli/test_apply_profile_override.py` — four new tests covering the parent `_apply_profile_override`: explicit flag sets canonical name; sticky `active_profile` sets canonical name; existing `HERMES_PROFILE` is preserved; `default` profile does not publish either env var.

## How to Test

1. Create two profiles with different default models:
   ```bash
   hermes profile create code-reviewer
   hermes profile create fast-coder
   # Edit ~/.hermes/profiles/code-reviewer/config.yaml + .env
   ```

2. Direct ACP entrypoint (the form editor configs use):
   ```bash
   hermes-acp -p code-reviewer --check  # exits "Hermes ACP check OK" under code-reviewer
   HERMES_PROFILE=  hermes-acp --profile code-reviewer  # picks up code-reviewer's config
   ```

3. CLI entrypoint:
   ```bash
   hermes -p fast-coder acp  # cmd_acp forwards --profile fast-coder into acp_argv
   ```

4. Focused tests:
   ```bash
   uv run --with pytest --with pytest-xdist --with pytest-asyncio --with pytest-timeout --with 'agent-client-protocol==0.9.0' python3 -m pytest tests/acp/test_entry.py tests/hermes_cli/test_apply_profile_override.py -v
   ```
   24 tests pass locally (10 pre-existing + 10 new across the two files; 4 of the new tests fail on a baseline-revert check, confirming the regression guard).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(acp): …`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run focused tests for the touched code and all pass
- [x] I've added tests for my changes (10 new tests across `tests/acp/test_entry.py` and `tests/hermes_cli/test_apply_profile_override.py`)
- [x] I've tested on my platform: macOS 15.x

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (the `--help` text on the new `--profile` flag is self-describing)
- [x] I've updated `cli-config.yaml.example` — N/A (no new config keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A (no architecture change)
- [x] I've considered cross-platform impact (Windows, macOS) — env-var-based, no platform-specific paths
- [x] I've updated tool descriptions/schemas — N/A

## Contract Protected

**Invariant:** Both `hermes -p <name> acp` and `hermes-acp -p <name>` (and `hermes-acp --profile=<name>`) MUST leave the process with `HERMES_HOME` pointing at the profile directory and `HERMES_PROFILE` set to the canonical name, before any session manager, runtime provider, or `.env` loader runs.

**Known-bad inputs covered:** unknown profile name (exits 1, doesn't silently fall back); empty `--profile` (no env mutation); operator-set `HERMES_PROFILE` from the shell (preserved via setdefault).

**Negative case:** `test_main_profile_flag_rejects_unknown_profile` proves the bad path fails loudly instead of silently using the default profile.

**Repro case from the issue:** `test_main_profile_flag_sets_hermes_home_before_load_env` exercises the exact scenario from #30571's "Steps to Reproduce" — launch with `--profile <name>`, observe `_load_env` sees the profile-scoped `HERMES_HOME`.

## Related / Positioning

> Sibling code paths that may need the same fix: none identified for this PR — `_apply_profile_override` in both `hermes_cli/main.py` and `acp_adapter/entry.py` are the two profile-activation entrypoints in the codebase, and both are covered here. The runtime resolver chain (`get_hermes_home()` → `HERMES_HOME` env var) is the single source of truth, and this PR feeds it from both entry points.