### PR TITLE
fix: preserve api_version and auth_mode through custom provider normalization

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -643,6 +643,7 @@ def build_anthropic_client(
     timeout: float = None,
     *,
     drop_context_1m_beta: bool = False,
+    api_version: str = None,  # type: ignore[assignment]
 ):
     """Create an Anthropic client, auto-detecting setup-tokens vs API keys.
 
@@ -702,7 +703,7 @@ def build_anthropic_client(
         # malformed paths like /anthropic?api-version=.../v1/messages).
         if _is_azure_anthropic_endpoint(normalized_base_url) and "api-version" not in normalized_base_url:
             kwargs["base_url"] = normalized_base_url.rstrip("/")
-            kwargs["default_query"] = {"api-version": "2025-04-15"}
+            kwargs["default_query"] = {"api-version": api_version or "2025-04-15"}
         else:
             kwargs["base_url"] = normalized_base_url
     common_betas = _common_betas_for_base_url(

--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -643,7 +643,7 @@ def build_anthropic_client(
     timeout: float = None,
     *,
     drop_context_1m_beta: bool = False,
-    api_version: str = None,  # type: ignore[assignment]
+    api_version: Optional[str] = None,
 ):
     """Create an Anthropic client, auto-detecting setup-tokens vs API keys.
 

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -161,7 +161,6 @@ _PROVIDER_ALIASES = {
     "tencentmaas": "tencent-tokenhub",
     "azure_foundry": "azure-foundry",
     "azurefoundry": "azure-foundry",
-    "azure": "azure-foundry",
 }
 
 
@@ -3397,7 +3396,7 @@ def resolve_provider_client(
                 if entry_api_mode == "anthropic_messages":
                     try:
                         from agent.anthropic_adapter import build_anthropic_client
-                        _entry_api_version = custom_entry.get("api_version") or None
+                        _entry_api_version = str(custom_entry.get("api_version") or "").strip() or None
                         real_client = build_anthropic_client(custom_key, custom_base,
                                                              api_version=_entry_api_version)
                     except ImportError:

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -159,6 +159,9 @@ _PROVIDER_ALIASES = {
     "tokenhub": "tencent-tokenhub",
     "tencent-cloud": "tencent-tokenhub",
     "tencentmaas": "tencent-tokenhub",
+    "azure_foundry": "azure-foundry",
+    "azurefoundry": "azure-foundry",
+    "azure": "azure-foundry",
 }
 
 
@@ -3394,7 +3397,9 @@ def resolve_provider_client(
                 if entry_api_mode == "anthropic_messages":
                     try:
                         from agent.anthropic_adapter import build_anthropic_client
-                        real_client = build_anthropic_client(custom_key, custom_base)
+                        _entry_api_version = custom_entry.get("api_version") or None
+                        real_client = build_anthropic_client(custom_key, custom_base,
+                                                             api_version=_entry_api_version)
                     except ImportError:
                         logger.warning(
                             "Named custom provider %r declares api_mode="

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3049,6 +3049,7 @@ def _normalize_custom_provider_entry(
         "context_length", "rate_limit_delay",
         "request_timeout_seconds", "stale_timeout_seconds",
         "discover_models", "extra_body",
+        "api_version", "auth_mode",
     }
     for camel, snake in _CAMEL_ALIASES.items():
         if camel in entry and snake not in entry:
@@ -3146,6 +3147,14 @@ def _normalize_custom_provider_entry(
     extra_body = entry.get("extra_body")
     if isinstance(extra_body, dict):
         normalized["extra_body"] = dict(extra_body)
+
+    api_version = entry.get("api_version")
+    if isinstance(api_version, str) and api_version.strip():
+        normalized["api_version"] = api_version.strip()
+
+    auth_mode = entry.get("auth_mode")
+    if isinstance(auth_mode, str) and auth_mode.strip():
+        normalized["auth_mode"] = auth_mode.strip()
 
     return normalized
 

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -541,6 +541,9 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
                     api_mode = _parse_api_mode(entry.get("api_mode") or entry.get("transport"))
                     if api_mode:
                         result["api_mode"] = api_mode
+                    api_version = str(entry.get("api_version") or "").strip()
+                    if api_version:
+                        result["api_version"] = api_version
                     return result
             # Also check the 'name' field if present
             display_name = entry.get("name", "")
@@ -562,6 +565,9 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
                         api_mode = _parse_api_mode(entry.get("api_mode") or entry.get("transport"))
                         if api_mode:
                             result["api_mode"] = api_mode
+                        api_version = str(entry.get("api_version") or "").strip()
+                        if api_version:
+                            result["api_version"] = api_version
                         return result
 
     # Fall back to custom_providers: list (legacy format)

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -501,6 +501,26 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
             if (canonical or "").strip().lower() == requested_norm:
                 return None
 
+    def _extract_provider_fields(entry: Dict[str, Any], name: str, base_url: str, api_key: str) -> Dict[str, Any]:
+        """Build a resolved provider result dict from a raw config entry."""
+        result: Dict[str, Any] = {
+            "name": name,
+            "base_url": base_url.strip(),
+            "api_key": api_key,
+            "model": entry.get("default_model", ""),
+        }
+        extra_body = entry.get("extra_body")
+        if isinstance(extra_body, dict):
+            result["extra_body"] = dict(extra_body)
+        # Accept both legacy ``api_mode`` and new ``transport`` spellings.
+        api_mode = _parse_api_mode(entry.get("api_mode") or entry.get("transport"))
+        if api_mode:
+            result["api_mode"] = api_mode
+        api_version = str(entry.get("api_version") or "").strip()
+        if api_version:
+            result["api_version"] = api_version
+        return result
+
     config = load_config()
     
     # First check providers: dict (new-style user-defined providers)
@@ -522,29 +542,7 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
                 # Found match by provider key
                 base_url = entry.get("api") or entry.get("url") or entry.get("base_url") or ""
                 if base_url:
-                    result = {
-                        "name": entry.get("name", ep_name),
-                        "base_url": base_url.strip(),
-                        "api_key": resolved_api_key,
-                        "model": entry.get("default_model", ""),
-                    }
-                    extra_body = entry.get("extra_body")
-                    if isinstance(extra_body, dict):
-                        result["extra_body"] = dict(extra_body)
-                    # The v11→v12 migration writes the API mode under the new
-                    # ``transport`` field, but hand-edited configs may still
-                    # use the legacy ``api_mode`` spelling.  Accept both —
-                    # the runtime normaliser ``_normalize_custom_provider_entry``
-                    # already does, so without this lift every migrated config
-                    # silently downgrades codex_responses / anthropic_messages
-                    # providers to chat_completions in the resolved runtime.
-                    api_mode = _parse_api_mode(entry.get("api_mode") or entry.get("transport"))
-                    if api_mode:
-                        result["api_mode"] = api_mode
-                    api_version = str(entry.get("api_version") or "").strip()
-                    if api_version:
-                        result["api_version"] = api_version
-                    return result
+                    return _extract_provider_fields(entry, entry.get("name", ep_name), base_url, resolved_api_key)
             # Also check the 'name' field if present
             display_name = entry.get("name", "")
             if display_name:
@@ -553,22 +551,7 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
                     # Found match by display name
                     base_url = entry.get("api") or entry.get("url") or entry.get("base_url") or ""
                     if base_url:
-                        result = {
-                            "name": display_name,
-                            "base_url": base_url.strip(),
-                            "api_key": resolved_api_key,
-                            "model": entry.get("default_model", ""),
-                        }
-                        extra_body = entry.get("extra_body")
-                        if isinstance(extra_body, dict):
-                            result["extra_body"] = dict(extra_body)
-                        api_mode = _parse_api_mode(entry.get("api_mode") or entry.get("transport"))
-                        if api_mode:
-                            result["api_mode"] = api_mode
-                        api_version = str(entry.get("api_version") or "").strip()
-                        if api_version:
-                            result["api_version"] = api_version
-                        return result
+                        return _extract_provider_fields(entry, display_name, base_url, resolved_api_key)
 
     # Fall back to custom_providers: list (legacy format)
     custom_providers = config.get("custom_providers")


### PR DESCRIPTION
## Problem

When a custom provider (under `providers:`) declares `api_version` and/or `auth_mode`, the config normalizer was silently discarding them. This caused HTTP 404 errors on all auxiliary tasks (title generation, context compression, etc.) for users with an Azure-hosted Anthropic endpoint that requires a non-default `api-version`.

The `errors.log` showed the symptoms clearly:
```
WARNING hermes_cli.config: providers.azure_foundry: unknown config keys ignored: api_version, auth_mode
WARNING agent.title_generator: Title generation failed: Error code: 404 - Resource not found
```

## Root Cause

`_normalize_custom_provider_entry()` in `hermes_cli/config.py` builds a fresh `normalized` dict that only copies explicitly-known fields. Neither `api_version` nor `auth_mode` were in `_KNOWN_KEYS`, so they were silently dropped. By the time `resolve_provider_client` called `custom_entry.get("api_version")`, it was already `None` — causing the Azure client to use the hardcoded default `api-version: 2025-04-15` instead of the user-configured one.

## Changes

### `hermes_cli/config.py`
- Add `"api_version"` and `"auth_mode"` to `_KNOWN_KEYS` (suppresses the warning)
- Explicitly copy both fields into the normalized return dict

### `agent/anthropic_adapter.py`
- `build_anthropic_client()` accepts an optional `api_version` parameter
- Uses it for the Azure `api-version` query param, falling back to `"2025-04-15"`

### `agent/auxiliary_client.py`
- Named-custom-provider branch reads `api_version` from the entry and passes it to `build_anthropic_client()`

### `hermes_cli/runtime_provider.py`
- `_get_named_custom_provider()` reads and forwards `api_version` from the provider entry in both key-match and display-name-match branches

## Verification

```python
from hermes_cli.config import _normalize_custom_provider_entry
entry = {"base_url": "https://...", "api_mode": "anthropic_messages", "api_version": "2023-06-01"}
r = _normalize_custom_provider_entry(entry, provider_key="azure_foundry")
assert r.get("api_version") == "2023-06-01", "FAIL"
print("PASS:", r["api_version"])
```