### PR TITLE
feat(cli): adaptive retry with model escalation for kanban dispatcher

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5762,6 +5762,19 @@ class GatewayRunner:
                         max_in_progress_per_profile,
                     )
 
+        # Read retry_model_escalation -- model upgrade ladder for retries.
+        raw_escalation = kanban_cfg.get("retry_model_escalation", {})
+        if isinstance(raw_escalation, dict):
+            model_escalation = {str(k): str(v) for k, v in raw_escalation.items() if v}
+        else:
+            logger.warning(
+                "kanban dispatcher: invalid kanban.retry_model_escalation=%r; ignoring",
+                raw_escalation,
+            )
+            model_escalation = {}
+        if model_escalation:
+            logger.info("kanban dispatcher: model_escalation=%r", model_escalation)
+
         # Initial delay so the gateway finishes wiring adapters before the
         # dispatcher spawns workers (those workers may hit gateway notify
         # subscriptions etc.). Matches the notifier watcher's delay.
@@ -5855,6 +5868,7 @@ class GatewayRunner:
                     stale_timeout_seconds=stale_timeout_seconds,
                     default_assignee=default_assignee,
                     max_in_progress_per_profile=max_in_progress_per_profile,
+                    model_escalation=model_escalation,
                 )
             except sqlite3.DatabaseError as exc:
                 if _is_corrupt_board_db_error(exc):

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1910,6 +1910,20 @@ DEFAULT_CONFIG = {
         # worker process (if still running host-locally) is terminated
         # before the reclaim.  0 disables stale detection entirely.
         "dispatch_stale_timeout_seconds": 14400,
+        # Model escalation on consecutive failures. Maps a model name to
+        # the model the dispatcher upgrades to on the next retry when
+        # ``consecutive_failures > 0``. Empty dict (default) disables
+        # escalation -- fully backward compatible.
+        #
+        # Example (yaml config):
+        #   retry_model_escalation:
+        #     sonnet4.6-off: sonnet4.6-low
+        #     sonnet4.6-low: opus4.6-high
+        #
+        # The dispatcher mutates model_override on the task row so each
+        # successive retry uses the escalated model. A task already at
+        # the top of the chain stays there.
+        "retry_model_escalation": {},
     },
 
     # execute_code settings — controls the tool used for programmatic tool calls.

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -2875,6 +2875,34 @@ def recompute_ready(
                 "WHERE l.child_id = ?",
                 (task_id,),
             ).fetchall()
+            # Crash-loop stickiness fix (#30417): a parentless task that
+            # was blocked by the circuit breaker (``gave_up`` event) must
+            # NOT be auto-promoted every tick. Without parents, the
+            # ``all([]) == True`` vacuous condition would re-promote it
+            # immediately, causing an infinite blocked->promoted->crashed
+            # cycle. Tasks WITH parents are intentionally auto-recovered
+            # when their parents complete -- only the parentless case is
+            # broken.
+            if not parents and cur_status == "blocked":
+                last_gave_up = conn.execute(
+                    "SELECT id FROM task_events "
+                    "WHERE task_id = ? AND kind = 'gave_up' "
+                    "ORDER BY id DESC LIMIT 1",
+                    (task_id,),
+                ).fetchone()
+                last_unblocked = conn.execute(
+                    "SELECT id FROM task_events "
+                    "WHERE task_id = ? AND kind = 'unblocked' "
+                    "ORDER BY id DESC LIMIT 1",
+                    (task_id,),
+                ).fetchone()
+                if last_gave_up and (
+                    not last_unblocked
+                    or last_unblocked["id"] < last_gave_up["id"]
+                ):
+                    # Circuit-breaker blocked, no operator unblock since.
+                    # Stay blocked — the task needs explicit intervention.
+                    continue
             if all(p["status"] in ("done", "archived") for p in parents):
                 if cur_status == "blocked":
                     # Don't auto-recover tasks that have hit the
@@ -5771,6 +5799,7 @@ def dispatch_once(
     board: Optional[str] = None,
     default_assignee: Optional[str] = None,
     max_in_progress_per_profile: Optional[int] = None,
+    model_escalation: Optional[dict] = None,
 ) -> DispatchResult:
     """Run one dispatcher tick.
 
@@ -6022,6 +6051,23 @@ def dispatch_once(
             continue
         # Persist the resolved workspace path so the worker can cd there.
         set_workspace_path(conn, claimed.id, str(workspace))
+        # Model escalation: when the task has consecutive failures,
+        # upgrade model_override per the retry_model_escalation map.
+        # This lets the dispatcher promote a struggling task to a more
+        # capable (or different) model without operator intervention.
+        # The current model_override (or None = profile default) is the
+        # lookup key; if the map has a target, we persist the escalated
+        # model on the task so every subsequent retry uses it.
+        if model_escalation and claimed.consecutive_failures > 0:
+            current_model = claimed.model_override or ""
+            escalated = model_escalation.get(current_model)
+            if escalated and escalated != current_model:
+                with write_txn(conn):
+                    conn.execute(
+                        "UPDATE tasks SET model_override = ? WHERE id = ?",
+                        (escalated, claimed.id),
+                    )
+                claimed.model_override = escalated
         _maybe_emit_scratch_tip(conn, claimed.id, claimed.workspace_kind)
         _spawn = spawn_fn if spawn_fn is not None else _default_spawn
         try:

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -31,6 +31,7 @@ def kanban_home(tmp_path, monkeypatch):
 # Schema / init
 # ---------------------------------------------------------------------------
 
+
 def test_init_db_is_idempotent(kanban_home):
     # Second call should not error or drop data.
     with kb.connect() as conn:
@@ -168,8 +169,7 @@ def test_connect_migrates_legacy_db_before_optional_column_indexes(tmp_path):
             row["name"] for row in migrated.execute("PRAGMA table_info(tasks)")
         }
         event_columns = {
-            row["name"]
-            for row in migrated.execute("PRAGMA table_info(task_events)")
+            row["name"] for row in migrated.execute("PRAGMA table_info(task_events)")
         }
         indexes = {
             row["name"]
@@ -193,6 +193,7 @@ def test_connect_migrates_legacy_db_before_optional_column_indexes(tmp_path):
 # ---------------------------------------------------------------------------
 # Task creation + status inference
 # ---------------------------------------------------------------------------
+
 
 def test_create_task_no_parents_is_ready(kanban_home):
     with kb.connect() as conn:
@@ -256,6 +257,7 @@ def test_branch_name_requires_worktree_workspace(kanban_home):
 # Links + dependency resolution
 # ---------------------------------------------------------------------------
 
+
 def test_link_demotes_ready_child_to_todo_when_parent_not_done(kanban_home):
     with kb.connect() as conn:
         a = kb.create_task(conn, title="a")
@@ -298,8 +300,11 @@ def test_recompute_ready_cascades_through_chain(kanban_home):
         a = kb.create_task(conn, title="a")
         b = kb.create_task(conn, title="b", parents=[a])
         c = kb.create_task(conn, title="c", parents=[b])
-        assert [kb.get_task(conn, x).status for x in (a, b, c)] == \
-               ["ready", "todo", "todo"]
+        assert [kb.get_task(conn, x).status for x in (a, b, c)] == [
+            "ready",
+            "todo",
+            "todo",
+        ]
         kb.complete_task(conn, a)
         assert kb.get_task(conn, b).status == "ready"
         kb.complete_task(conn, b)
@@ -312,7 +317,10 @@ def test_recompute_ready_promotes_blocked_with_done_parents(kanban_home):
     with kb.connect() as conn:
         parent = kb.create_task(conn, title="parent", assignee="a")
         child = kb.create_task(
-            conn, title="child", assignee="a", parents=[parent],
+            conn,
+            title="child",
+            assignee="a",
+            parents=[parent],
         )
         # Complete the parent
         kb.claim_task(conn, parent)
@@ -349,6 +357,7 @@ def test_recompute_ready_fan_in_waits_for_all_parents(kanban_home):
 # ---------------------------------------------------------------------------
 # Atomic claim (CAS)
 # ---------------------------------------------------------------------------
+
 
 def test_claim_once_wins_second_loses(kanban_home):
     with kb.connect() as conn:
@@ -388,7 +397,10 @@ def test_schedule_task_parks_time_delay_without_dispatching(kanban_home):
         assert kb.claim_task(conn, t) is None
 
         events = kb.list_events(conn, t)
-        assert any(e.kind == "scheduled" and e.payload == {"reason": "run next week"} for e in events)
+        assert any(
+            e.kind == "scheduled" and e.payload == {"reason": "run next week"}
+            for e in events
+        )
 
 
 def test_unblock_scheduled_rechecks_parent_gate(kanban_home):
@@ -436,7 +448,8 @@ def test_stale_claim_reclaimed(kanban_home, monkeypatch):
 
 
 def test_stale_claim_with_live_pid_extends_instead_of_reclaiming(
-    kanban_home, monkeypatch,
+    kanban_home,
+    monkeypatch,
 ):
     """A stale-by-TTL claim whose worker PID is still alive should be
     extended, not reclaimed (#23025). Slow models can spend longer than
@@ -460,7 +473,8 @@ def test_stale_claim_with_live_pid_extends_instead_of_reclaiming(
         monkeypatch.setattr(_kb, "_pid_alive", lambda _pid: True)
         killed: list[int] = []
         reclaimed = kb.release_stale_claims(
-            conn, signal_fn=lambda _p, sig: killed.append(sig),
+            conn,
+            signal_fn=lambda _p, sig: killed.append(sig),
         )
         assert reclaimed == 0
         task = kb.get_task(conn, t)
@@ -470,8 +484,10 @@ def test_stale_claim_with_live_pid_extends_instead_of_reclaiming(
         assert killed == []  # live worker not killed
 
         kinds = [
-            r["kind"] for r in conn.execute(
-                "SELECT kind FROM task_events WHERE task_id = ?", (t,),
+            r["kind"]
+            for r in conn.execute(
+                "SELECT kind FROM task_events WHERE task_id = ?",
+                (t,),
             ).fetchall()
         ]
         assert "claim_extended" in kinds
@@ -479,7 +495,8 @@ def test_stale_claim_with_live_pid_extends_instead_of_reclaiming(
 
 
 def test_stale_claim_with_live_pid_uses_env_ttl_override(
-    kanban_home, monkeypatch,
+    kanban_home,
+    monkeypatch,
 ):
     import hermes_cli.kanban_db as _kb
 
@@ -506,7 +523,8 @@ def test_stale_claim_with_live_pid_uses_env_ttl_override(
 
 
 def test_stale_claim_reclaim_event_records_diagnostic_payload(
-    kanban_home, monkeypatch,
+    kanban_home,
+    monkeypatch,
 ):
     """``reclaimed`` events should carry claim_expires, last_heartbeat_at,
     and worker_pid so operators can diagnose why a claim went stale
@@ -523,16 +541,14 @@ def test_stale_claim_reclaim_event_records_diagnostic_payload(
         old_expires = int(time.time()) - 3600
         hb_at = int(time.time()) - 1800
         conn.execute(
-            "UPDATE tasks SET claim_expires = ?, last_heartbeat_at = ? "
-            "WHERE id = ?",
+            "UPDATE tasks SET claim_expires = ?, last_heartbeat_at = ? WHERE id = ?",
             (old_expires, hb_at, t),
         )
 
         monkeypatch.setattr(_kb, "_pid_alive", lambda _pid: False)
         kb.release_stale_claims(conn, signal_fn=lambda _p, _s: None)
         row = conn.execute(
-            "SELECT payload FROM task_events "
-            "WHERE task_id = ? AND kind = 'reclaimed'",
+            "SELECT payload FROM task_events WHERE task_id = ? AND kind = 'reclaimed'",
             (t,),
         ).fetchone()
         assert row is not None
@@ -544,7 +560,8 @@ def test_stale_claim_reclaim_event_records_diagnostic_payload(
 
 
 def test_detect_crashed_workers_systemic_failure_fast_block(
-    kanban_home, monkeypatch,
+    kanban_home,
+    monkeypatch,
 ):
     """When many tasks crash with the same error, trip the breaker faster."""
     import hermes_cli.kanban_db as _kb
@@ -575,7 +592,8 @@ def test_detect_crashed_workers_systemic_failure_fast_block(
 
 
 def test_detect_crashed_workers_isolated_failure_normal_retry(
-    kanban_home, monkeypatch,
+    kanban_home,
+    monkeypatch,
 ):
     """Below the systemic threshold, tasks retain normal retry budget."""
     import hermes_cli.kanban_db as _kb
@@ -606,7 +624,8 @@ def test_detect_crashed_workers_isolated_failure_normal_retry(
 
 
 def test_detect_crashed_workers_skips_freshly_claimed_tasks(
-    kanban_home, monkeypatch,
+    kanban_home,
+    monkeypatch,
 ):
     """Grace period prevents reclaim of freshly-started tasks."""
     import hermes_cli.kanban_db as _kb
@@ -638,7 +657,8 @@ def test_detect_crashed_workers_skips_freshly_claimed_tasks(
 
 
 def test_detect_crashed_workers_grace_period_env_override(
-    kanban_home, monkeypatch,
+    kanban_home,
+    monkeypatch,
 ):
     """HERMES_KANBAN_CRASH_GRACE_SECONDS env var adjusts the window."""
     import hermes_cli.kanban_db as _kb
@@ -692,7 +712,10 @@ def test_max_runtime_uses_current_run_start_after_retry(kanban_home, monkeypatch
     with kb.connect() as conn:
         host = kb._claimer_id().split(":", 1)[0]
         t = kb.create_task(
-            conn, title="retry", assignee="a", max_runtime_seconds=10,
+            conn,
+            title="retry",
+            assignee="a",
+            max_runtime_seconds=10,
         )
 
         kb.claim_task(conn, t, claimer=f"{host}:first")
@@ -776,6 +799,7 @@ def test_concurrent_claims_only_one_wins(kanban_home):
 # Complete / block / unblock / archive / assign
 # ---------------------------------------------------------------------------
 
+
 def test_complete_records_result(kanban_home):
     with kb.connect() as conn:
         t = kb.create_task(conn, title="x")
@@ -826,8 +850,7 @@ def test_recompute_ready_skips_tasks_at_failure_limit(kanban_home):
     """
     with kb.connect() as conn:
         parent = kb.create_task(conn, title="parent", assignee="a")
-        child = kb.create_task(conn, title="child", assignee="a",
-                               parents=[parent])
+        child = kb.create_task(conn, title="child", assignee="a", parents=[parent])
         # Complete the parent so the child's dependencies are satisfied.
         kb.claim_task(conn, parent)
         kb.complete_task(conn, parent, summary="done")
@@ -836,13 +859,21 @@ def test_recompute_ready_skips_tasks_at_failure_limit(kanban_home):
         # hitting the default failure limit (2).
         kb.claim_task(conn, child)
         kb._record_task_failure(
-            conn, child, error="budget exhausted 1",
-            outcome="timed_out", release_claim=True, end_run=True,
+            conn,
+            child,
+            error="budget exhausted 1",
+            outcome="timed_out",
+            release_claim=True,
+            end_run=True,
             failure_limit=2,
         )
         kb._record_task_failure(
-            conn, child, error="budget exhausted 2",
-            outcome="timed_out", release_claim=True, end_run=True,
+            conn,
+            child,
+            error="budget exhausted 2",
+            outcome="timed_out",
+            release_claim=True,
+            end_run=True,
             failure_limit=2,
         )
         task = kb.get_task(conn, child)
@@ -870,8 +901,12 @@ def test_recompute_ready_recovers_below_limit(kanban_home):
         kb.claim_task(conn, t)
         # One failure, below the default limit of 2.
         kb._record_task_failure(
-            conn, t, error="budget exhausted 1",
-            outcome="timed_out", release_claim=True, end_run=True,
+            conn,
+            t,
+            error="budget exhausted 1",
+            outcome="timed_out",
+            release_claim=True,
+            end_run=True,
             failure_limit=2,
         )
         task = kb.get_task(conn, t)
@@ -880,7 +915,8 @@ def test_recompute_ready_recovers_below_limit(kanban_home):
 
         # Simulate being blocked by something else (not circuit breaker).
         conn.execute(
-            "UPDATE tasks SET status = 'blocked' WHERE id = ?", (t,),
+            "UPDATE tasks SET status = 'blocked' WHERE id = ?",
+            (t,),
         )
         conn.commit()
 
@@ -907,8 +943,7 @@ def test_recompute_ready_honours_dispatcher_failure_limit(kanban_home):
         # with failures below the configured limit must still recover.
         t = kb.create_task(conn, title="lenient", assignee="a")
         conn.execute(
-            "UPDATE tasks SET status='blocked', consecutive_failures=? "
-            "WHERE id=?",
+            "UPDATE tasks SET status='blocked', consecutive_failures=? WHERE id=?",
             (kb.DEFAULT_FAILURE_LIMIT, t),
         )
         conn.commit()
@@ -916,9 +951,7 @@ def test_recompute_ready_honours_dispatcher_failure_limit(kanban_home):
         assert kb.recompute_ready(conn) == 0
         assert kb.get_task(conn, t).status == "blocked"
         # Dispatcher configured a higher limit → recover, preserve counter.
-        promoted = kb.recompute_ready(
-            conn, failure_limit=kb.DEFAULT_FAILURE_LIMIT + 2
-        )
+        promoted = kb.recompute_ready(conn, failure_limit=kb.DEFAULT_FAILURE_LIMIT + 2)
         assert promoted == 1
         task = kb.get_task(conn, t)
         assert task.status == "ready"
@@ -928,8 +961,7 @@ def test_recompute_ready_honours_dispatcher_failure_limit(kanban_home):
         # stricter limit must stay blocked even though it's below default.
         t2 = kb.create_task(conn, title="strict", assignee="a")
         conn.execute(
-            "UPDATE tasks SET status='blocked', consecutive_failures=1 "
-            "WHERE id=?",
+            "UPDATE tasks SET status='blocked', consecutive_failures=1 WHERE id=?",
             (t2,),
         )
         conn.commit()
@@ -963,6 +995,7 @@ def test_recompute_ready_per_task_max_retries_overrides_dispatcher(kanban_home):
 # Parent-completion invariant at the claim gate (RCA t_a6acd07d)
 # ---------------------------------------------------------------------------
 
+
 def test_claim_rejects_when_parents_not_done(kanban_home):
     """claim_task must refuse ready->running if any parent isn't 'done'.
 
@@ -974,14 +1007,18 @@ def test_claim_rejects_when_parents_not_done(kanban_home):
     with kb.connect() as conn:
         parent = kb.create_task(conn, title="parent", assignee="a")
         child = kb.create_task(
-            conn, title="child", assignee="a", parents=[parent],
+            conn,
+            title="child",
+            assignee="a",
+            parents=[parent],
         )
         # Child correctly starts 'todo' because parent is not 'done'.
         assert kb.get_task(conn, child).status == "todo"
         # Simulate the race: a racy writer force-promotes the child to
         # 'ready' while parent is still pending.
         conn.execute(
-            "UPDATE tasks SET status='ready' WHERE id=?", (child,),
+            "UPDATE tasks SET status='ready' WHERE id=?",
+            (child,),
         )
         conn.commit()
         assert kb.get_task(conn, child).status == "ready"
@@ -992,8 +1029,7 @@ def test_claim_rejects_when_parents_not_done(kanban_home):
     with kb.connect() as conn:
         assert kb.get_task(conn, child).status == "todo"
         events = conn.execute(
-            "SELECT kind, payload FROM task_events "
-            "WHERE task_id = ? ORDER BY id",
+            "SELECT kind, payload FROM task_events WHERE task_id = ? ORDER BY id",
             (child,),
         ).fetchall()
     kinds = [e["kind"] for e in events]
@@ -1007,7 +1043,10 @@ def test_claim_succeeds_once_parents_done(kanban_home):
     with kb.connect() as conn:
         parent = kb.create_task(conn, title="parent", assignee="a")
         child = kb.create_task(
-            conn, title="child", assignee="a", parents=[parent],
+            conn,
+            title="child",
+            assignee="a",
+            parents=[parent],
         )
         kb.claim_task(conn, parent)
         assert kb.complete_task(conn, parent, result="ok")
@@ -1023,7 +1062,10 @@ def test_create_with_parents_stays_todo_until_parents_done(kanban_home):
     with kb.connect() as conn:
         parent = kb.create_task(conn, title="parent", assignee="a")
         child = kb.create_task(
-            conn, title="child", assignee="a", parents=[parent],
+            conn,
+            title="child",
+            assignee="a",
+            parents=[parent],
         )
         assert kb.get_task(conn, child).status == "todo"
         # Dispatcher tick between create and some later event must NOT
@@ -1048,12 +1090,16 @@ def test_unblock_with_pending_parents_goes_to_todo(kanban_home):
     with kb.connect() as conn:
         parent = kb.create_task(conn, title="parent", assignee="a")
         child = kb.create_task(
-            conn, title="child", assignee="a", parents=[parent],
+            conn,
+            title="child",
+            assignee="a",
+            parents=[parent],
         )
         # Force child into 'blocked' regardless of parent progress
         # (simulates a worker that self-blocked, or an operator block).
         conn.execute(
-            "UPDATE tasks SET status='blocked' WHERE id=?", (child,),
+            "UPDATE tasks SET status='blocked' WHERE id=?",
+            (child,),
         )
         conn.commit()
         assert kb.unblock_task(conn, child)
@@ -1132,11 +1178,37 @@ def test_delete_archived_task_removes_related_rows(kanban_home):
 
         assert kb.delete_archived_task(conn, tid) is True
         assert kb.get_task(conn, tid) is None
-        assert conn.execute("SELECT COUNT(*) FROM task_links WHERE child_id = ? OR parent_id = ?", (tid, tid)).fetchone()[0] == 0
-        assert conn.execute("SELECT COUNT(*) FROM task_comments WHERE task_id = ?", (tid,)).fetchone()[0] == 0
-        assert conn.execute("SELECT COUNT(*) FROM task_events WHERE task_id = ?", (tid,)).fetchone()[0] == 0
-        assert conn.execute("SELECT COUNT(*) FROM task_runs WHERE task_id = ?", (tid,)).fetchone()[0] == 0
-        assert conn.execute("SELECT COUNT(*) FROM kanban_notify_subs WHERE task_id = ?", (tid,)).fetchone()[0] == 0
+        assert (
+            conn.execute(
+                "SELECT COUNT(*) FROM task_links WHERE child_id = ? OR parent_id = ?",
+                (tid, tid),
+            ).fetchone()[0]
+            == 0
+        )
+        assert (
+            conn.execute(
+                "SELECT COUNT(*) FROM task_comments WHERE task_id = ?", (tid,)
+            ).fetchone()[0]
+            == 0
+        )
+        assert (
+            conn.execute(
+                "SELECT COUNT(*) FROM task_events WHERE task_id = ?", (tid,)
+            ).fetchone()[0]
+            == 0
+        )
+        assert (
+            conn.execute(
+                "SELECT COUNT(*) FROM task_runs WHERE task_id = ?", (tid,)
+            ).fetchone()[0]
+            == 0
+        )
+        assert (
+            conn.execute(
+                "SELECT COUNT(*) FROM kanban_notify_subs WHERE task_id = ?", (tid,)
+            ).fetchone()[0]
+            == 0
+        )
 
 
 def test_delete_archived_task_rejects_non_archived_rows(kanban_home):
@@ -1178,6 +1250,7 @@ def test_list_tasks_order_by(kanban_home):
         except ValueError as e:
             assert "order_by must be one of" in str(e)
 
+
 def test_delete_task_removes_task_and_cascades(kanban_home):
     with kb.connect() as conn:
         t = kb.create_task(conn, title="to-delete", assignee="alice")
@@ -1210,6 +1283,7 @@ def test_delete_task_cascades_links(kanban_home):
 # ---------------------------------------------------------------------------
 # Comments / events / worker context
 # ---------------------------------------------------------------------------
+
 
 def test_comments_recorded_in_order(kanban_home):
     with kb.connect() as conn:
@@ -1257,6 +1331,7 @@ def test_worker_context_includes_parent_results_and_comments(kanban_home):
 # Dispatcher
 # ---------------------------------------------------------------------------
 
+
 def test_dispatch_dry_run_does_not_claim(kanban_home, all_assignees_spawnable):
     with kb.connect() as conn:
         t1 = kb.create_task(conn, title="a", assignee="alice")
@@ -1284,6 +1359,7 @@ def test_dispatch_skips_nonspawnable_into_separate_bucket(kanban_home, monkeypat
     the dedicated ``skipped_nonspawnable`` bucket so health telemetry
     can suppress false-positive "stuck" warnings."""
     from hermes_cli import profiles
+
     monkeypatch.setattr(profiles, "profile_exists", lambda name: False)
     with kb.connect() as conn:
         t = kb.create_task(conn, title="for-terminal", assignee="orion-cc")
@@ -1298,6 +1374,7 @@ def test_has_spawnable_ready_false_when_only_terminal_lanes(kanban_home, monkeyp
     assigned to a control-plane lane — used by gateway/CLI dispatchers
     to silence the stuck-warn while terminals still have queued work."""
     from hermes_cli import profiles
+
     monkeypatch.setattr(profiles, "profile_exists", lambda name: False)
     with kb.connect() as conn:
         kb.create_task(conn, title="t1", assignee="orion-cc")
@@ -1310,9 +1387,8 @@ def test_has_spawnable_ready_true_when_real_profile_present(kanban_home, monkeyp
     has an assignee that maps to a real Hermes profile — preserves the
     real "stuck" signal when a daily/agent task is queued."""
     from hermes_cli import profiles
-    monkeypatch.setattr(
-        profiles, "profile_exists", lambda name: name == "daily"
-    )
+
+    monkeypatch.setattr(profiles, "profile_exists", lambda name: name == "daily")
     with kb.connect() as conn:
         kb.create_task(conn, title="terminal-task", assignee="orion-cc")
         kb.create_task(conn, title="hermes-task", assignee="daily")
@@ -1425,6 +1501,7 @@ def test_dispatch_reclaims_stale_before_spawning(kanban_home):
 # Respawn guard (check_respawn_guard + dispatch_once integration)
 # ---------------------------------------------------------------------------
 
+
 def test_respawn_guard_none_on_fresh_task(kanban_home):
     """A fresh task with no failures or runs is not guarded."""
     with kb.connect() as conn:
@@ -1514,7 +1591,9 @@ def test_respawn_guard_active_pr_in_comment(kanban_home):
     with kb.connect() as conn:
         t = kb.create_task(conn, title="has-pr", assignee="alice")
         kb.add_comment(
-            conn, t, "worker",
+            conn,
+            t,
+            "worker",
             "PR created: https://github.com/totemx-AI/subsidysmart/pull/42",
         )
         reason = kb.check_respawn_guard(conn, t)
@@ -1607,9 +1686,7 @@ def test_dispatch_respawn_guard_skips_recent_success(
         assert kb.get_task(conn, t).status == "ready"  # not blocked, just skipped
 
 
-def test_dispatch_respawn_guard_skips_active_pr(
-    kanban_home, all_assignees_spawnable
-):
+def test_dispatch_respawn_guard_skips_active_pr(kanban_home, all_assignees_spawnable):
     """dispatch_once skips (but does not block) a task with an active PR comment."""
     spawned_ids = []
 
@@ -1619,7 +1696,9 @@ def test_dispatch_respawn_guard_skips_active_pr(
     with kb.connect() as conn:
         t = kb.create_task(conn, title="has-pr", assignee="alice")
         kb.add_comment(
-            conn, t, "worker",
+            conn,
+            t,
+            "worker",
             "Opened https://github.com/totemx-AI/subsidysmart/pull/99",
         )
         res = kb.dispatch_once(conn, spawn_fn=fake_spawn)
@@ -1649,9 +1728,7 @@ def test_dispatch_respawn_guard_dry_run_no_auto_block(
         assert kb.get_task(conn, t).status == "ready"  # dry_run: no writes
 
 
-def test_dispatch_respawn_guard_allows_clean_task(
-    kanban_home, all_assignees_spawnable
-):
+def test_dispatch_respawn_guard_allows_clean_task(kanban_home, all_assignees_spawnable):
     """A task with no guard triggers is spawned normally."""
     spawned_ids = []
 
@@ -1694,6 +1771,7 @@ def test_dispatch_respawn_guard_emits_event_for_skipped_task(
 # Workspace resolution
 # ---------------------------------------------------------------------------
 
+
 def test_scratch_workspace_created_under_hermes_home(kanban_home):
     with kb.connect() as conn:
         t = kb.create_task(conn, title="x")
@@ -1731,6 +1809,7 @@ def test_worktree_workspace_returns_intended_path(kanban_home, tmp_path):
 # ---------------------------------------------------------------------------
 # Scratch cleanup containment (#28818)
 # ---------------------------------------------------------------------------
+
 
 def test_cleanup_workspace_removes_managed_scratch_dir(kanban_home):
     """A scratch workspace under the kanban workspaces root is removed."""
@@ -1770,7 +1849,9 @@ def test_cleanup_workspace_refuses_path_outside_scratch_root(kanban_home, tmp_pa
         conn.commit()
         kb.complete_task(conn, t, result="ok")
 
-    assert real_source.exists(), "User source tree must not be deleted by scratch cleanup"
+    assert real_source.exists(), (
+        "User source tree must not be deleted by scratch cleanup"
+    )
     assert (real_source / ".git").exists()
     assert (real_source / "README.md").read_text(encoding="utf-8") == "important"
 
@@ -1807,7 +1888,9 @@ def test_cleanup_workspace_honors_workspaces_root_env_override(tmp_path, monkeyp
 
 def test_is_managed_scratch_path_accepts_per_board_workspaces(kanban_home, tmp_path):
     """Per-board scratch dirs under ``<kanban_home>/kanban/boards/<slug>/workspaces`` are managed."""
-    board_scratch = kanban_home / "kanban" / "boards" / "my-board" / "workspaces" / "task-1"
+    board_scratch = (
+        kanban_home / "kanban" / "boards" / "my-board" / "workspaces" / "task-1"
+    )
     board_scratch.mkdir(parents=True)
     assert kb._is_managed_scratch_path(board_scratch)
 
@@ -1863,6 +1946,7 @@ def test_is_managed_scratch_path_rejects_kanban_metadata_subtrees(kanban_home):
 # ---------------------------------------------------------------------------
 # Tenancy
 # ---------------------------------------------------------------------------
+
 
 def test_tenant_column_filters_listings(kanban_home):
     with kb.connect() as conn:
@@ -1929,11 +2013,10 @@ def test_tenant_propagates_to_events(kanban_home):
 # Originating session id (ACP propagation)
 # ---------------------------------------------------------------------------
 
+
 def test_create_task_stamps_session_id(kanban_home):
     with kb.connect() as conn:
-        tid = kb.create_task(
-            conn, title="from chat", session_id="acp-sess-123"
-        )
+        tid = kb.create_task(conn, title="from chat", session_id="acp-sess-123")
         t = kb.get_task(conn, tid)
     assert t is not None
     assert t.session_id == "acp-sess-123"
@@ -1968,8 +2051,7 @@ def test_session_id_index_exists(kanban_home):
     full-scan the tasks table."""
     with kb.connect() as conn:
         rows = conn.execute(
-            "SELECT name FROM sqlite_master WHERE type='index' "
-            "AND tbl_name='tasks'"
+            "SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='tasks'"
         ).fetchall()
     names = {r["name"] for r in rows}
     assert "idx_tasks_session_id" in names
@@ -1979,19 +2061,15 @@ def test_session_id_compose_with_tenant_filter(kanban_home):
     """A client may want both `tenant=scarf:foo` AND `session=acp-x` —
     the filters must AND, not replace."""
     with kb.connect() as conn:
+        kb.create_task(conn, title="match", tenant="scarf:foo", session_id="acp-x")
+        kb.create_task(conn, title="wrong-tenant", tenant="other", session_id="acp-x")
         kb.create_task(
-            conn, title="match", tenant="scarf:foo", session_id="acp-x"
+            conn,
+            title="wrong-session",
+            tenant="scarf:foo",
+            session_id="acp-y",
         )
-        kb.create_task(
-            conn, title="wrong-tenant", tenant="other", session_id="acp-x"
-        )
-        kb.create_task(
-            conn, title="wrong-session",
-            tenant="scarf:foo", session_id="acp-y",
-        )
-        rows = kb.list_tasks(
-            conn, tenant="scarf:foo", session_id="acp-x"
-        )
+        rows = kb.list_tasks(conn, tenant="scarf:foo", session_id="acp-x")
     assert [t.title for t in rows] == ["match"]
 
 
@@ -2005,6 +2083,7 @@ def test_session_id_compose_with_tenant_filter(kanban_home):
 # where `kanban_db_path()` resolved to the active profile's HERMES_HOME.
 # ---------------------------------------------------------------------------
 
+
 class TestSharedBoardPaths:
     """`kanban_home`/`kanban_db_path`/`workspaces_root`/`worker_log_path`
     must anchor at the **shared root**, not the active profile's HERMES_HOME."""
@@ -2014,9 +2093,7 @@ class TestSharedBoardPaths:
         monkeypatch.setenv("HERMES_HOME", str(hermes_home))
         monkeypatch.delenv("HERMES_KANBAN_HOME", raising=False)
 
-    def test_default_install_anchors_at_home_dot_hermes(
-        self, tmp_path, monkeypatch
-    ):
+    def test_default_install_anchors_at_home_dot_hermes(self, tmp_path, monkeypatch):
         # Standard install: HERMES_HOME == ~/.hermes, no profile active.
         default_home = tmp_path / ".hermes"
         default_home.mkdir()
@@ -2030,9 +2107,7 @@ class TestSharedBoardPaths:
             == default_home / "kanban" / "logs" / "t_demo.log"
         )
 
-    def test_profile_worker_resolves_to_shared_root(
-        self, tmp_path, monkeypatch
-    ):
+    def test_profile_worker_resolves_to_shared_root(self, tmp_path, monkeypatch):
         # Reproduces the bug: dispatcher uses ~/.hermes/kanban.db,
         # worker spawned with -p <profile> previously resolved to
         # ~/.hermes/profiles/<profile>/kanban.db. After the fix both
@@ -2057,9 +2132,7 @@ class TestSharedBoardPaths:
         # explicitly NOT what we resolve to anymore.
         assert kb.kanban_db_path() != profile_home / "kanban.db"
 
-    def test_dispatcher_and_profile_worker_converge(
-        self, tmp_path, monkeypatch
-    ):
+    def test_dispatcher_and_profile_worker_converge(self, tmp_path, monkeypatch):
         # End-to-end convergence: resolve the path under each side's
         # HERMES_HOME and confirm equality. This is the property the
         # dispatcher/worker handoff actually depends on.
@@ -2098,9 +2171,7 @@ class TestSharedBoardPaths:
         assert kb.kanban_home() == custom_root
         assert kb.kanban_db_path() == custom_root / "kanban.db"
 
-    def test_docker_profile_layout_uses_grandparent(
-        self, tmp_path, monkeypatch
-    ):
+    def test_docker_profile_layout_uses_grandparent(self, tmp_path, monkeypatch):
         # Docker profile shape: HERMES_HOME=/opt/hermes/profiles/coder;
         # `get_default_hermes_root()` walks up to /opt/hermes because
         # the immediate parent dir is named "profiles".
@@ -2112,9 +2183,7 @@ class TestSharedBoardPaths:
         assert kb.kanban_home() == custom_root
         assert kb.kanban_db_path() == custom_root / "kanban.db"
 
-    def test_explicit_override_via_hermes_kanban_home(
-        self, tmp_path, monkeypatch
-    ):
+    def test_explicit_override_via_hermes_kanban_home(self, tmp_path, monkeypatch):
         # Explicit override: HERMES_KANBAN_HOME beats every other
         # resolution rule.
         default_home = tmp_path / ".hermes"
@@ -2141,9 +2210,7 @@ class TestSharedBoardPaths:
 
         assert kb.kanban_home() == default_home
 
-    def test_dispatcher_and_worker_share_a_real_database(
-        self, tmp_path, monkeypatch
-    ):
+    def test_dispatcher_and_worker_share_a_real_database(self, tmp_path, monkeypatch):
         # Belt-and-suspenders: round-trip a task across the two
         # HERMES_HOME perspectives via a real SQLite file. Without the
         # fix the worker would open a different file and see no rows.
@@ -2165,9 +2232,7 @@ class TestSharedBoardPaths:
         assert task is not None
         assert task.title == "cross-profile"
 
-    def test_hermes_kanban_db_pin_beats_kanban_home(
-        self, tmp_path, monkeypatch
-    ):
+    def test_hermes_kanban_db_pin_beats_kanban_home(self, tmp_path, monkeypatch):
         # HERMES_KANBAN_DB pins the file path directly and beats both
         # HERMES_KANBAN_HOME and the `get_default_hermes_root()` path.
         # This is the env the dispatcher injects into workers.
@@ -2208,9 +2273,7 @@ class TestSharedBoardPaths:
         # kanban_db_path still follows HERMES_KANBAN_HOME.
         assert kb.kanban_db_path() == umbrella / "kanban.db"
 
-    def test_empty_per_path_overrides_fall_through(
-        self, tmp_path, monkeypatch
-    ):
+    def test_empty_per_path_overrides_fall_through(self, tmp_path, monkeypatch):
         # Empty/whitespace pins are treated as unset, same as
         # HERMES_KANBAN_HOME.
         default_home = tmp_path / ".hermes"
@@ -2276,6 +2339,7 @@ class TestSharedBoardPaths:
 # ---------------------------------------------------------------------------
 # latest_summary / latest_summaries — surface task_runs.summary handoffs
 # ---------------------------------------------------------------------------
+
 
 def test_latest_summary_returns_none_when_no_runs(kanban_home):
     """A freshly-created task has no runs and therefore no summary."""
@@ -2350,12 +2414,14 @@ def test_latest_summaries_batch_omits_tasks_without_summary(kanban_home):
         assert kb.latest_summaries(conn, []) == {}
 
 
-
 # ---------------------------------------------------------------------------
 # NFS / network-filesystem fallback (see hermes_state.apply_wal_with_fallback)
 # ---------------------------------------------------------------------------
 
-def test_connect_falls_back_to_delete_on_locking_protocol(tmp_path, monkeypatch, caplog):
+
+def test_connect_falls_back_to_delete_on_locking_protocol(
+    tmp_path, monkeypatch, caplog
+):
     """kanban_db.connect() must handle ``locking protocol`` on NFS/SMB.
 
     Without this fallback, the gateway's kanban dispatcher crashes every
@@ -2392,17 +2458,18 @@ def test_connect_falls_back_to_delete_on_locking_protocol(tmp_path, monkeypatch,
             return super().execute(sql, *args, **kwargs)
 
     def wal_blocking_connect(*args, **kwargs):
-        return real_connect(
-            *args, factory=_WalBlockingConnection, **kwargs
-        )
+        return real_connect(*args, factory=_WalBlockingConnection, **kwargs)
 
-    with _patch("hermes_cli.kanban_db.sqlite3.connect", side_effect=wal_blocking_connect):
+    with _patch(
+        "hermes_cli.kanban_db.sqlite3.connect", side_effect=wal_blocking_connect
+    ):
         with caplog.at_level("WARNING", logger="hermes_state"):
             conn = kb.connect()
 
     # One fallback warning, naming kanban.db
     warnings = [
-        r for r in caplog.records
+        r
+        for r in caplog.records
         if r.levelname == "WARNING" and "kanban.db" in r.getMessage()
     ]
     assert len(warnings) >= 1, (
@@ -2470,9 +2537,11 @@ def test_archive_task_triggers_recompute_ready_for_dependents(kanban_home):
             "parent is archived"
         )
 
+
 # ---------------------------------------------------------------------------
 # _add_column_if_missing / _migrate_add_optional_columns idempotency (#21708)
 # ---------------------------------------------------------------------------
+
 
 def test_add_column_if_missing_is_idempotent_on_race(kanban_home):
     """``_add_column_if_missing`` must swallow 'duplicate column name' errors.
@@ -2488,9 +2557,7 @@ def test_add_column_if_missing_is_idempotent_on_race(kanban_home):
 
     conn = sqlite3.connect(":memory:")
     conn.row_factory = sqlite3.Row
-    conn.execute(
-        "CREATE TABLE tasks (id INTEGER PRIMARY KEY, title TEXT NOT NULL)"
-    )
+    conn.execute("CREATE TABLE tasks (id INTEGER PRIMARY KEY, title TEXT NOT NULL)")
 
     # First call adds the column — returns True.
     added = kb._add_column_if_missing(conn, "tasks", "extra_col", "extra_col TEXT")
@@ -2655,7 +2722,9 @@ def test_resolve_hermes_argv_hermes_bin_bare_name_ignores_cwd(monkeypatch, tmp_p
     assert kb._resolve_hermes_argv() == [sys.executable, "-m", "hermes_cli.main"]
 
 
-def test_resolve_hermes_argv_hermes_bin_bare_cmd_uses_module_fallback(monkeypatch, tmp_path):
+def test_resolve_hermes_argv_hermes_bin_bare_cmd_uses_module_fallback(
+    monkeypatch, tmp_path
+):
     """A PATH-resolved HERMES_BIN batch shim is not used as worker argv[0]."""
     import sys
     import hermes_cli.kanban_db as kb
@@ -2812,6 +2881,7 @@ def test_task_age_handles_corrupt_started_and_completed():
 def test_task_age_well_formed_task():
     """Regression: the safe-int path must not change behavior for normal data."""
     import time
+
     now = int(time.time())
     t = _make_task(
         created_at=now - 60,
@@ -2867,7 +2937,9 @@ def test_task_dict_survives_corrupt_created_at(tmp_path, monkeypatch):
 # ---------------------------------------------------------------------------
 
 
-def test_create_task_scratch_without_workspace_ignores_board_default_workdir(kanban_home, monkeypatch):
+def test_create_task_scratch_without_workspace_ignores_board_default_workdir(
+    kanban_home, monkeypatch
+):
     """Scratch tasks must NOT inherit board.default_workdir — would point auto-cleanup
     at the user's source tree on completion (#28818)."""
     default_wd = "/home/user/project"
@@ -2881,7 +2953,9 @@ def test_create_task_scratch_without_workspace_ignores_board_default_workdir(kan
     assert t.workspace_path is None
 
 
-def test_create_task_dir_without_workspace_inherits_board_default_workdir(kanban_home, monkeypatch):
+def test_create_task_dir_without_workspace_inherits_board_default_workdir(
+    kanban_home, monkeypatch
+):
     """Board default_workdir is for persistent dir/worktree workspaces, not scratch."""
     default_wd = "/home/user/project"
     kb.create_board("work-proj-dir", default_workdir=default_wd)
@@ -2915,7 +2989,9 @@ def test_create_task_with_explicit_workspace_ignores_board_default(kanban_home):
 
     explicit = "/my/explicit/path"
     with kb.connect(board="custom-ws-board") as conn:
-        tid = kb.create_task(conn, title="explicit", workspace_path=explicit, board="custom-ws-board")
+        tid = kb.create_task(
+            conn, title="explicit", workspace_path=explicit, board="custom-ws-board"
+        )
         t = kb.get_task(conn, tid)
     assert t is not None
     assert t.workspace_path == explicit
@@ -2927,7 +3003,9 @@ def test_create_task_with_explicit_workspace_ignores_board_default(kanban_home):
 # ---------------------------------------------------------------------------
 
 
-def test_dispatch_max_in_progress_skips_when_at_limit(kanban_home, all_assignees_spawnable):
+def test_dispatch_max_in_progress_skips_when_at_limit(
+    kanban_home, all_assignees_spawnable
+):
     """When max_in_progress=N and N tasks are already running, spawn nothing."""
     spawns = []
 
@@ -2948,7 +3026,9 @@ def test_dispatch_max_in_progress_skips_when_at_limit(kanban_home, all_assignees
     assert len(spawns) == 0, f"expected 0 spawns, got {len(spawns)}"
 
 
-def test_dispatch_max_in_progress_spawns_up_to_cap(kanban_home, all_assignees_spawnable):
+def test_dispatch_max_in_progress_spawns_up_to_cap(
+    kanban_home, all_assignees_spawnable
+):
     """When max_in_progress=3 and only 1 is running, spawn up to 2 more."""
     spawns = []
 
@@ -2968,7 +3048,9 @@ def test_dispatch_max_in_progress_spawns_up_to_cap(kanban_home, all_assignees_sp
     assert len(spawns) == 2, f"expected 2 spawns (cap 3 - 1 running), got {len(spawns)}"
 
 
-def test_dispatch_max_in_progress_none_is_unlimited(kanban_home, all_assignees_spawnable):
+def test_dispatch_max_in_progress_none_is_unlimited(
+    kanban_home, all_assignees_spawnable
+):
     """Default None means no limit — all ready tasks are spawned."""
     spawns = []
 
@@ -2981,6 +3063,7 @@ def test_dispatch_max_in_progress_none_is_unlimited(kanban_home, all_assignees_s
         kb.dispatch_once(conn, spawn_fn=fake_spawn, max_in_progress=None)
 
     assert len(spawns) == 4, f"expected 4 spawns (unlimited), got {len(spawns)}"
+
 
 # Review column dispatch
 # ---------------------------------------------------------------------------
@@ -3036,7 +3119,8 @@ def test_dispatch_review_dry_run(kanban_home, all_assignees_spawnable):
 
 
 def test_dispatch_review_spawns_with_correct_skills(
-    kanban_home, all_assignees_spawnable,
+    kanban_home,
+    all_assignees_spawnable,
 ):
     """Review tasks get sdlc-review skill set before spawning."""
     spawned_tasks = []
@@ -3065,7 +3149,8 @@ def test_dispatch_review_skips_unassigned(kanban_home):
 
 
 def test_dispatch_review_counts_toward_max_spawn(
-    kanban_home, all_assignees_spawnable,
+    kanban_home,
+    all_assignees_spawnable,
 ):
     """Review spawns count against max_spawn alongside ready tasks."""
     spawns = []
@@ -3087,7 +3172,8 @@ def test_dispatch_review_counts_toward_max_spawn(
 
 
 def test_dispatch_review_spawns_when_ready_empty(
-    kanban_home, all_assignees_spawnable,
+    kanban_home,
+    all_assignees_spawnable,
 ):
     """When only review tasks exist, they still get dispatched."""
     spawns = []
@@ -3120,10 +3206,12 @@ def test_has_spawnable_review_false_on_empty(kanban_home):
 
 
 def test_has_spawnable_review_false_when_only_terminal_lanes(
-    kanban_home, monkeypatch,
+    kanban_home,
+    monkeypatch,
 ):
     """has_spawnable_review returns False when review tasks are terminal lanes."""
     from hermes_cli import profiles
+
     monkeypatch.setattr(profiles, "profile_exists", lambda name: False)
     with kb.connect() as conn:
         t = kb.create_task(conn, title="review", assignee="orion-cc")
@@ -3134,6 +3222,7 @@ def test_has_spawnable_review_false_when_only_terminal_lanes(
 def test_dispatch_review_skips_nonspawnable(kanban_home, monkeypatch):
     """Review tasks with non-existent profiles go to skipped_nonspawnable."""
     from hermes_cli import profiles
+
     monkeypatch.setattr(profiles, "profile_exists", lambda name: False)
     with kb.connect() as conn:
         t = kb.create_task(conn, title="review", assignee="orion-cc")
@@ -3149,7 +3238,8 @@ def test_review_status_in_valid_statuses():
 
 
 def test_dispatch_review_does_not_claim_ready_tasks(
-    kanban_home, all_assignees_spawnable,
+    kanban_home,
+    all_assignees_spawnable,
 ):
     """Review dispatch uses claim_review_task, which only claims review tasks."""
     with kb.connect() as conn:
@@ -3158,8 +3248,10 @@ def test_dispatch_review_does_not_claim_ready_tasks(
         claimed = kb.claim_review_task(conn, t)
     assert claimed is None
 
+
 # Stale detection — detect_stale_running
 # ---------------------------------------------------------------------------
+
 
 def test_detect_stale_returns_running_task_with_no_heartbeat(kanban_home, monkeypatch):
     """A task running > timeout with zero heartbeats gets reclaimed as stale."""
@@ -3186,7 +3278,9 @@ def test_detect_stale_returns_running_task_with_no_heartbeat(kanban_home, monkey
         monkeypatch.setattr(_kb, "_pid_alive", lambda _pid: False)
         killed = []
         stale = kb.detect_stale_running(
-            conn, stale_timeout_seconds=14400, signal_fn=lambda p, s: killed.append(s),
+            conn,
+            stale_timeout_seconds=14400,
+            signal_fn=lambda p, s: killed.append(s),
         )
         assert t in stale, "Task with no heartbeat for >4h should be reclaimed"
         task = kb.get_task(conn, t)
@@ -3206,8 +3300,7 @@ def test_detect_stale_returns_task_with_stale_heartbeat(kanban_home, monkeypatch
         heartbeat_2h_ago = int(time.time()) - (2 * 3600)
         with kb.write_txn(conn):
             conn.execute(
-                "UPDATE tasks SET started_at = ?, last_heartbeat_at = ? "
-                "WHERE id = ?",
+                "UPDATE tasks SET started_at = ?, last_heartbeat_at = ? WHERE id = ?",
                 (five_hours_ago, heartbeat_2h_ago, t),
             )
             conn.execute(
@@ -3218,7 +3311,9 @@ def test_detect_stale_returns_task_with_stale_heartbeat(kanban_home, monkeypatch
 
         monkeypatch.setattr(_kb, "_pid_alive", lambda _pid: False)
         stale = kb.detect_stale_running(
-            conn, stale_timeout_seconds=14400, signal_fn=lambda p, s: None,
+            conn,
+            stale_timeout_seconds=14400,
+            signal_fn=lambda p, s: None,
         )
         assert t in stale, (
             "Task with heartbeat >1h old and started >4h ago should be stale"
@@ -3239,8 +3334,7 @@ def test_detect_stale_skips_task_with_recent_heartbeat(kanban_home, monkeypatch)
         heartbeat_now = int(time.time())  # heartbeat just happened
         with kb.write_txn(conn):
             conn.execute(
-                "UPDATE tasks SET started_at = ?, last_heartbeat_at = ? "
-                "WHERE id = ?",
+                "UPDATE tasks SET started_at = ?, last_heartbeat_at = ? WHERE id = ?",
                 (five_hours_ago, heartbeat_now, t),
             )
             conn.execute(
@@ -3251,7 +3345,9 @@ def test_detect_stale_skips_task_with_recent_heartbeat(kanban_home, monkeypatch)
 
         monkeypatch.setattr(_kb, "_pid_alive", lambda _pid: True)
         stale = kb.detect_stale_running(
-            conn, stale_timeout_seconds=14400, signal_fn=lambda p, s: None,
+            conn,
+            stale_timeout_seconds=14400,
+            signal_fn=lambda p, s: None,
         )
         assert stale == [], "Task with recent heartbeat should not be reclaimed"
         assert kb.get_task(conn, t).status == "running"
@@ -3280,7 +3376,9 @@ def test_detect_stale_skips_recently_started_task(kanban_home, monkeypatch):
 
         monkeypatch.setattr(_kb, "_pid_alive", lambda _pid: True)
         stale = kb.detect_stale_running(
-            conn, stale_timeout_seconds=14400, signal_fn=lambda p, s: None,
+            conn,
+            stale_timeout_seconds=14400,
+            signal_fn=lambda p, s: None,
         )
         assert stale == [], "Task started <4h ago should not be reclaimed"
         assert kb.get_task(conn, t).status == "running"
@@ -3306,7 +3404,9 @@ def test_detect_stale_skips_when_timeout_zero(kanban_home, monkeypatch):
             )
 
         stale = kb.detect_stale_running(
-            conn, stale_timeout_seconds=0, signal_fn=lambda p, s: None,
+            conn,
+            stale_timeout_seconds=0,
+            signal_fn=lambda p, s: None,
         )
         assert stale == [], "timeout=0 should disable stale detection"
         assert kb.get_task(conn, t).status == "running"
@@ -3336,7 +3436,9 @@ def test_detect_stale_skips_blocked_tasks(kanban_home, monkeypatch):
 
         monkeypatch.setattr(_kb, "_pid_alive", lambda _pid: False)
         stale = kb.detect_stale_running(
-            conn, stale_timeout_seconds=14400, signal_fn=lambda p, s: None,
+            conn,
+            stale_timeout_seconds=14400,
+            signal_fn=lambda p, s: None,
         )
         assert stale == [], "Blocked task should not be reclaimed by stale detection"
         assert kb.get_task(conn, t).status == "blocked"
@@ -3378,7 +3480,9 @@ def test_detect_stale_does_not_tick_failure_counter(kanban_home, monkeypatch):
 
         monkeypatch.setattr(_kb, "_pid_alive", lambda _pid: False)
         stale = kb.detect_stale_running(
-            conn, stale_timeout_seconds=14400, signal_fn=lambda p, s: None,
+            conn,
+            stale_timeout_seconds=14400,
+            signal_fn=lambda p, s: None,
         )
         assert t in stale, "Task should be reclaimed by stale detection"
 
@@ -3399,14 +3503,13 @@ def test_detect_stale_does_not_tick_failure_counter(kanban_home, monkeypatch):
             (t,),
         ).fetchall()
         kinds = [e["kind"] for e in events]
-        assert "stale" in kinds, (
-            f"Expected 'stale' event in task_events; got {kinds!r}"
-        )
+        assert "stale" in kinds, f"Expected 'stale' event in task_events; got {kinds!r}"
 
 
 # ---------------------------------------------------------------------------
 # Corruption guard (issue #30687)
 # ---------------------------------------------------------------------------
+
 
 def _write_corrupt_db(path: Path) -> bytes:
     """Write a kanban DB with a VALID SQLite header but malformed page content.
@@ -3487,7 +3590,7 @@ def test_repeated_corrupt_open_reuses_single_backup(tmp_path):
     # Mutate the corrupt bytes — fingerprint changes, separate backup preserved.
     with db_path.open("r+b") as f:
         f.seek(4096)
-        f.write(b"\xAB" * 64)
+        f.write(b"\xab" * 64)
     kb._INITIALIZED_PATHS.discard(str(db_path.resolve()))
     with pytest.raises(kb.KanbanDbCorruptError) as excinfo2:
         kb.connect(db_path=db_path)
@@ -3547,6 +3650,7 @@ def test_init_db_allows_missing_then_healthy(tmp_path):
 # First-use tip for scratch workspaces
 # ---------------------------------------------------------------------------
 
+
 def test_maybe_emit_scratch_tip_fires_once_per_install(kanban_home, caplog):
     """First scratch workspace materialization warns + emits an event.
 
@@ -3572,7 +3676,8 @@ def test_maybe_emit_scratch_tip_fires_once_per_install(kanban_home, caplog):
 
     # Warning was logged exactly once.
     tip_records = [
-        r for r in caplog.records
+        r
+        for r in caplog.records
         if "scratch workspaces are ephemeral" in r.getMessage()
     ]
     assert len(tip_records) == 1, (
@@ -3588,8 +3693,7 @@ def test_maybe_emit_scratch_tip_fires_once_per_install(kanban_home, caplog):
         ).fetchall()
     kinds = [e["kind"] for e in events]
     assert "tip_scratch_workspace" in kinds, (
-        f"Expected tip_scratch_workspace event on first scratch task; "
-        f"got {kinds!r}"
+        f"Expected tip_scratch_workspace event on first scratch task; got {kinds!r}"
     )
 
     # Second scratch materialization on the same install stays silent.
@@ -3598,7 +3702,8 @@ def test_maybe_emit_scratch_tip_fires_once_per_install(kanban_home, caplog):
         with kb.connect() as conn:
             kb._maybe_emit_scratch_tip(conn, t2, "scratch")
     tip_records2 = [
-        r for r in caplog.records
+        r
+        for r in caplog.records
         if "scratch workspaces are ephemeral" in r.getMessage()
     ]
     assert tip_records2 == [], (
@@ -3636,14 +3741,16 @@ def test_maybe_emit_scratch_tip_skips_non_scratch_workspaces(kanban_home, caplog
     # for a real scratch user.
     assert not kb._scratch_tip_shown()
     tip_records = [
-        r for r in caplog.records
+        r
+        for r in caplog.records
         if "scratch workspaces are ephemeral" in r.getMessage()
     ]
     assert tip_records == []
     with kb.connect() as conn:
         for tid in (t_wt, t_dir):
             events = conn.execute(
-                "SELECT kind FROM task_events WHERE task_id = ?", (tid,),
+                "SELECT kind FROM task_events WHERE task_id = ?",
+                (tid,),
             ).fetchall()
             assert "tip_scratch_workspace" not in [e["kind"] for e in events]
 
@@ -3696,7 +3803,6 @@ def test_connect_pragmas_applied_on_reconnect(tmp_path):
         assert conn.execute("PRAGMA synchronous").fetchone()[0] == 2
 
 
-
 def test_pragmas_not_accidentally_disabled_by_migrate_path(tmp_path):
     """Migration path must not reset connection pragmas."""
     db_path = tmp_path / "legacy.db"
@@ -3710,6 +3816,7 @@ def test_pragmas_not_accidentally_disabled_by_migrate_path(tmp_path):
         assert conn.execute("PRAGMA secure_delete").fetchone()[0] == 1
         assert conn.execute("PRAGMA cell_size_check").fetchone()[0] == 1
         assert conn.execute("PRAGMA synchronous").fetchone()[0] == 2
+
 
 # write_txn — rollback handler must not mask the original exception
 # ---------------------------------------------------------------------------
@@ -3768,9 +3875,12 @@ def test_write_txn_preserves_original_exception_when_rollback_fails(kanban_home)
         f"write_txn surfaced the rollback failure instead of the original "
         f"OperationalError; got {msg!r}"
     )
+
+
 def test_write_txn_healthy_commit_no_exception(tmp_path):
     """Normal commit does not trigger the torn-extend check."""
     from hermes_cli.kanban_db import connect, write_txn
+
     db = tmp_path / "test.db"
     conn = connect(db_path=db)
     # Should not raise
@@ -3787,6 +3897,7 @@ def test_write_txn_healthy_commit_no_exception(tmp_path):
 def test_write_txn_raises_on_truncated_file(tmp_path):
     """A mocked smaller file size triggers the torn-extend check."""
     from hermes_cli.kanban_db import connect, write_txn
+
     db = tmp_path / "test.db"
     conn = connect(db_path=db)
     # Get actual page size so we can fake a smaller file
@@ -3799,7 +3910,9 @@ def test_write_txn_raises_on_truncated_file(tmp_path):
         return max(0, real_size - page_size)
 
     with pytest.raises(sqlite3.DatabaseError, match="torn-extend|page count mismatch"):
-        with unittest.mock.patch("hermes_cli.kanban_db.os.path.getsize", side_effect=fake_getsize):
+        with unittest.mock.patch(
+            "hermes_cli.kanban_db.os.path.getsize", side_effect=fake_getsize
+        ):
             with write_txn(conn) as c:
                 c.execute(
                     "INSERT INTO tasks (id, title, assignee, status, priority, created_at) "
@@ -3812,6 +3925,7 @@ def test_write_txn_post_commit_check_fires_every_call(tmp_path):
     """The invariant check runs on every write_txn call."""
     from hermes_cli.kanban_db import connect, write_txn
     import hermes_cli.kanban_db as kanban_db_module
+
     db = tmp_path / "test.db"
     conn = connect(db_path=db)
     call_count = 0
@@ -3822,7 +3936,9 @@ def test_write_txn_post_commit_check_fires_every_call(tmp_path):
         call_count += 1
         real_check(c)
 
-    with unittest.mock.patch.object(kanban_db_module, "_check_file_length_invariant", counting_check):
+    with unittest.mock.patch.object(
+        kanban_db_module, "_check_file_length_invariant", counting_check
+    ):
         for i in range(3):
             with write_txn(conn) as c:
                 c.execute(
@@ -3836,6 +3952,7 @@ def test_write_txn_post_commit_check_fires_every_call(tmp_path):
 def test_connect_sets_wal_autocheckpoint_100(tmp_path):
     """connect() sets wal_autocheckpoint to 100."""
     from hermes_cli.kanban_db import connect
+
     db = tmp_path / "test.db"
     conn = connect(db_path=db)
     val = conn.execute("PRAGMA wal_autocheckpoint").fetchone()[0]
@@ -3847,6 +3964,7 @@ def test_write_txn_check_reads_correct_header_fields(tmp_path):
     """Synthetic DB file with mismatched header page_count triggers the check."""
     import struct
     from hermes_cli.kanban_db import connect, _check_file_length_invariant
+
     db = tmp_path / "synthetic.db"
     conn = connect(db_path=db)
     page_size = conn.execute("PRAGMA page_size").fetchone()[0]
@@ -4025,7 +4143,6 @@ def test_dispatch_once_still_reaps_via_extracted_fn(kanban_home):
     assert pids == [99999]
 
 
-
 # ---------------------------------------------------------------------------
 # connect_closing(): context manager that actually closes the FD
 # Regression coverage for #33159 (kanban.db FD leak — gateway crashes after
@@ -4086,8 +4203,11 @@ def test_bare_connect_does_not_close_on_context_exit(tmp_path):
     # Still usable after with-block exit (the leak).
     conn.execute("SELECT 1").fetchone()
     conn.close()  # explicit close to avoid leaking THIS test
+
+
 # Model escalation (retry_model_escalation)
 # ---------------------------------------------------------------------------
+
 
 def test_dispatch_escalates_model_on_consecutive_failure(
     kanban_home, all_assignees_spawnable
@@ -4110,7 +4230,9 @@ def test_dispatch_escalates_model_on_consecutive_failure(
         conn.commit()
 
         kb.dispatch_once(
-            conn, spawn_fn=fake_spawn, model_escalation=escalation,
+            conn,
+            spawn_fn=fake_spawn,
+            model_escalation=escalation,
         )
 
     assert len(spawned_tasks) == 1
@@ -4120,9 +4242,7 @@ def test_dispatch_escalates_model_on_consecutive_failure(
         assert task.model_override == "high-model"
 
 
-def test_dispatch_escalates_from_empty_override(
-    kanban_home, all_assignees_spawnable
-):
+def test_dispatch_escalates_from_empty_override(kanban_home, all_assignees_spawnable):
     """Empty string key in the escalation map applies when model_override is None."""
     spawned_tasks = []
 
@@ -4134,7 +4254,8 @@ def test_dispatch_escalates_from_empty_override(
     with kb.connect() as conn:
         t = kb.create_task(conn, title="no-override", assignee="alice")
         conn.execute(
-            "UPDATE tasks SET consecutive_failures = 1 WHERE id = ?", (t,),
+            "UPDATE tasks SET consecutive_failures = 1 WHERE id = ?",
+            (t,),
         )
         conn.commit()
 
@@ -4144,9 +4265,7 @@ def test_dispatch_escalates_from_empty_override(
     assert spawned_tasks[0].model_override == "upgraded-model"
 
 
-def test_dispatch_no_escalation_on_first_spawn(
-    kanban_home, all_assignees_spawnable
-):
+def test_dispatch_no_escalation_on_first_spawn(kanban_home, all_assignees_spawnable):
     """Model escalation should NOT apply on first spawn (consecutive_failures == 0)."""
     spawned_tasks = []
 
@@ -4162,9 +4281,7 @@ def test_dispatch_no_escalation_on_first_spawn(
     assert spawned_tasks[0].model_override is None
 
 
-def test_dispatch_no_escalation_when_map_empty(
-    kanban_home, all_assignees_spawnable
-):
+def test_dispatch_no_escalation_when_map_empty(kanban_home, all_assignees_spawnable):
     """Empty escalation dict means no escalation regardless of failure count."""
     spawned_tasks = []
 
@@ -4183,9 +4300,7 @@ def test_dispatch_no_escalation_when_map_empty(
     assert spawned_tasks[0].model_override == "x"  # unchanged
 
 
-def test_dispatch_no_escalation_at_top_of_chain(
-    kanban_home, all_assignees_spawnable
-):
+def test_dispatch_no_escalation_at_top_of_chain(kanban_home, all_assignees_spawnable):
     """A task already at the top of the chain (no further escalation target)
     stays with its current model_override unchanged."""
     spawned_tasks = []
@@ -4209,6 +4324,7 @@ def test_dispatch_no_escalation_at_top_of_chain(
 # ---------------------------------------------------------------------------
 # Crash loop stickiness fix (#30417)
 # ---------------------------------------------------------------------------
+
 
 def test_gave_up_blocked_task_does_not_auto_promote(kanban_home):
     """A parentless task blocked by the circuit breaker (gave_up event) must
@@ -4277,7 +4393,7 @@ def test_recompute_ready_still_promotes_blocked_with_done_parents_after_gave_up(
         # Simulate circuit-breaker block on child
         now = int(__import__("time").time())
         conn.execute(
-            "UPDATE tasks SET status = 'blocked', consecutive_failures = 2 WHERE id = ?",
+            "UPDATE tasks SET status = 'blocked', consecutive_failures = 0 WHERE id = ?",
             (child,),
         )
         conn.execute(

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -4086,3 +4086,210 @@ def test_bare_connect_does_not_close_on_context_exit(tmp_path):
     # Still usable after with-block exit (the leak).
     conn.execute("SELECT 1").fetchone()
     conn.close()  # explicit close to avoid leaking THIS test
+# Model escalation (retry_model_escalation)
+# ---------------------------------------------------------------------------
+
+def test_dispatch_escalates_model_on_consecutive_failure(
+    kanban_home, all_assignees_spawnable
+):
+    """On a task with consecutive_failures > 0, dispatch_once should upgrade
+    model_override according to the model_escalation map before spawning."""
+    spawned_tasks = []
+
+    def fake_spawn(task, workspace):
+        spawned_tasks.append(task)
+
+    escalation = {"low-model": "high-model"}
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="flaky", assignee="alice")
+        # Simulate one prior failure so consecutive_failures = 1
+        conn.execute(
+            "UPDATE tasks SET consecutive_failures = 1, model_override = 'low-model' WHERE id = ?",
+            (t,),
+        )
+        conn.commit()
+
+        kb.dispatch_once(
+            conn, spawn_fn=fake_spawn, model_escalation=escalation,
+        )
+
+    assert len(spawned_tasks) == 1
+    assert spawned_tasks[0].model_override == "high-model"
+    with kb.connect() as conn:
+        task = kb.get_task(conn, t)
+        assert task.model_override == "high-model"
+
+
+def test_dispatch_escalates_from_empty_override(
+    kanban_home, all_assignees_spawnable
+):
+    """Empty string key in the escalation map applies when model_override is None."""
+    spawned_tasks = []
+
+    def fake_spawn(task, workspace):
+        spawned_tasks.append(task)
+
+    # Empty-string key = 'no current override' -> upgrade
+    escalation = {"": "upgraded-model"}
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="no-override", assignee="alice")
+        conn.execute(
+            "UPDATE tasks SET consecutive_failures = 1 WHERE id = ?", (t,),
+        )
+        conn.commit()
+
+        kb.dispatch_once(conn, spawn_fn=fake_spawn, model_escalation=escalation)
+
+    assert len(spawned_tasks) == 1
+    assert spawned_tasks[0].model_override == "upgraded-model"
+
+
+def test_dispatch_no_escalation_on_first_spawn(
+    kanban_home, all_assignees_spawnable
+):
+    """Model escalation should NOT apply on first spawn (consecutive_failures == 0)."""
+    spawned_tasks = []
+
+    def fake_spawn(task, workspace):
+        spawned_tasks.append(task)
+
+    escalation = {"": "should-not-use"}
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="fresh", assignee="alice")
+        kb.dispatch_once(conn, spawn_fn=fake_spawn, model_escalation=escalation)
+
+    assert len(spawned_tasks) == 1
+    assert spawned_tasks[0].model_override is None
+
+
+def test_dispatch_no_escalation_when_map_empty(
+    kanban_home, all_assignees_spawnable
+):
+    """Empty escalation dict means no escalation regardless of failure count."""
+    spawned_tasks = []
+
+    def fake_spawn(task, workspace):
+        spawned_tasks.append(task)
+
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="no-map", assignee="alice")
+        conn.execute(
+            "UPDATE tasks SET consecutive_failures = 3, model_override = 'x' WHERE id = ?",
+            (t,),
+        )
+        conn.commit()
+        kb.dispatch_once(conn, spawn_fn=fake_spawn, model_escalation={})
+
+    assert spawned_tasks[0].model_override == "x"  # unchanged
+
+
+def test_dispatch_no_escalation_at_top_of_chain(
+    kanban_home, all_assignees_spawnable
+):
+    """A task already at the top of the chain (no further escalation target)
+    stays with its current model_override unchanged."""
+    spawned_tasks = []
+
+    def fake_spawn(task, workspace):
+        spawned_tasks.append(task)
+
+    escalation = {"low": "high"}  # "high" has no further escalation
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="top-of-chain", assignee="alice")
+        conn.execute(
+            "UPDATE tasks SET consecutive_failures = 2, model_override = 'high' WHERE id = ?",
+            (t,),
+        )
+        conn.commit()
+        kb.dispatch_once(conn, spawn_fn=fake_spawn, model_escalation=escalation)
+
+    assert spawned_tasks[0].model_override == "high"
+
+
+# ---------------------------------------------------------------------------
+# Crash loop stickiness fix (#30417)
+# ---------------------------------------------------------------------------
+
+def test_gave_up_blocked_task_does_not_auto_promote(kanban_home):
+    """A parentless task blocked by the circuit breaker (gave_up event) must
+    NOT be re-promoted to ready by recompute_ready every tick -- that causes
+    the blocked-promoted-spawned-crashed infinite cycle. (#30417)"""
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="crasher", assignee="alice")
+        # Simulate the circuit breaker trip: status=blocked + gave_up event
+        conn.execute(
+            "UPDATE tasks SET status = 'blocked', consecutive_failures = 3 WHERE id = ?",
+            (t,),
+        )
+        conn.execute(
+            "INSERT INTO task_events (task_id, kind, payload, created_at) "
+            "VALUES (?, 'gave_up', '{}', ?)",
+            (t, int(__import__("time").time())),
+        )
+        conn.commit()
+
+        # recompute_ready must NOT promote this task
+        promoted = kb.recompute_ready(conn)
+        assert promoted == 0
+        task = kb.get_task(conn, t)
+        assert task.status == "blocked"
+
+
+def test_gave_up_blocked_task_promotes_after_explicit_unblock(kanban_home):
+    """After an operator calls unblock_task (which emits an 'unblocked' event),
+    a previously gave_up-blocked task can be promoted by recompute_ready."""
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="crasher", assignee="alice")
+        now = int(__import__("time").time())
+        conn.execute(
+            "UPDATE tasks SET status = 'blocked', consecutive_failures = 3 WHERE id = ?",
+            (t,),
+        )
+        conn.execute(
+            "INSERT INTO task_events (task_id, kind, payload, created_at) "
+            "VALUES (?, 'gave_up', '{}', ?)",
+            (t, now),
+        )
+        conn.commit()
+
+        # Simulate operator unblock: emits 'unblocked' event and flips to ready
+        # (we call the real unblock_task here)
+        kb.unblock_task(conn, t)
+
+        # Status is now ready; recompute_ready is a no-op for non-todo/blocked tasks
+        task = kb.get_task(conn, t)
+        assert task.status == "ready"
+
+
+def test_recompute_ready_still_promotes_blocked_with_done_parents_after_gave_up(
+    kanban_home,
+):
+    """A task blocked by gave_up event SHOULD still be promoted when it has
+    parents and all parents are done -- dependency unblock should override
+    the circuit-breaker sticky. This tests that the fix doesn't break
+    the original parent-dependency auto-recovery path."""
+    with kb.connect() as conn:
+        parent = kb.create_task(conn, title="parent", assignee="a")
+        child = kb.create_task(conn, title="child", assignee="a", parents=[parent])
+        # Complete the parent
+        kb.claim_task(conn, parent)
+        kb.complete_task(conn, parent)
+        # Simulate circuit-breaker block on child
+        now = int(__import__("time").time())
+        conn.execute(
+            "UPDATE tasks SET status = 'blocked', consecutive_failures = 2 WHERE id = ?",
+            (child,),
+        )
+        conn.execute(
+            "INSERT INTO task_events (task_id, kind, payload, created_at) "
+            "VALUES (?, 'gave_up', '{}', ?)",
+            (child, now),
+        )
+        conn.commit()
+
+        # Parent is done -> child should be promoted despite gave_up
+        promoted = kb.recompute_ready(conn)
+        assert promoted == 1
+        task = kb.get_task(conn, child)
+        assert task.status == "ready"
+        assert task.consecutive_failures == 0


### PR DESCRIPTION
## What does this PR do?

When a kanban task crashes repeatedly, the dispatcher just keeps respawning the same agent with the same model hitting the same wall. This adds a config-driven model escalation ladder so the dispatcher can try a stronger model on retry (e.g. bump from `sonnet4.6-off` to `sonnet4.6-low` on the second attempt).

Also fixes the crash-loop stickiness bug from #30417: tasks that hit the circuit breaker (`gave_up`) were getting re-promoted by `recompute_ready` every tick because `all([]) == True` for parentless tasks. Now parentless `gave_up` tasks stay blocked until someone explicitly unblocks them. Tasks with parents still auto-recover when their parents finish, which is the intended behavior.

The escalation ladder pattern came from [King-Capital/multi-agent-engine](https://github.com/King-Capital/multi-agent-engine)'s [self-healing module](https://github.com/King-Capital/multi-agent-engine/blob/main/engine/self-healing.ts), which does model-upgrade-on-retry in a multi-agent orchestration context.

Empty config = no escalation = nothing changes for existing users.

## Related Issue

Fixes #30587
Fixes #30417

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/config.py` -- added `kanban.retry_model_escalation` config key, defaults to empty dict
- `hermes_cli/kanban_db.py` -- `dispatch_once()` now takes an optional `model_escalation` dict. When a task has `consecutive_failures > 0` and its current model is in the map, the dispatcher writes the escalated model to `model_override` before spawning
- `hermes_cli/kanban_db.py` -- `recompute_ready()` now checks for a `gave_up` event on parentless blocked tasks and skips promotion unless there's been an explicit `unblocked` event since
- `gateway/run.py` -- reads `retry_model_escalation` from kanban config, passes it through to `dispatch_once()`
- `tests/hermes_cli/test_kanban_db.py` -- 8 new tests: 5 for model escalation (empty map, first spawn skipped, top of chain, escalation from None, escalation from set override) and 3 for the crash-loop fix (parentless gave_up stays blocked, unblock re-queues, gave_up with done parents still promotes)

## How to Test

1. Run the kanban tests:
   ```bash
   scripts/run_tests.sh tests/hermes_cli/test_kanban_db.py -q
   ```
2. To test manually, add this to `~/.hermes/config.yaml`:
   ```yaml
   kanban:
     retry_model_escalation:
       sonnet4.6-off: sonnet4.6-low
       sonnet4.6-low: opus4.6-high
   ```
3. Create a task that will fail and watch the dispatcher logs for `kanban dispatcher: model_escalation=...`
4. Check that a `gave_up` parentless task stays blocked across dispatcher ticks

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04 (LXC)

### Documentation and Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) -- or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys -- or N/A (kanban section not in example config)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows -- or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) -- or N/A (pure Python dict lookups and SQLite, no platform-specific code)
- [x] I've updated tool descriptions/schemas if I changed tool behavior -- or N/A