### PR TITLE
fix(ci): supply-chain-audit two-dot diff causes false positives on stale-branch PRs

### DIFF
--- a/.github/workflows/supply-chain-audit.yml
+++ b/.github/workflows/supply-chain-audit.yml
@@ -47,14 +47,17 @@ jobs:
           HEAD="${{ github.event.pull_request.head.sha }}"
 
           # Added lines only, excluding lockfiles.
-          DIFF=$(git diff "$BASE".."$HEAD" -- . ':!uv.lock' ':!*.lock' ':!package-lock.json' ':!yarn.lock' || true)
+          # Three-dot diff (base...head) diffs from the merge base to HEAD,
+          # so only changes introduced by this PR are included — not changes
+          # that landed on main after the PR branched off.
+          DIFF=$(git diff "$BASE"..."$HEAD" -- . ':!uv.lock' ':!*.lock' ':!package-lock.json' ':!yarn.lock' || true)
 
           FINDINGS=""
 
           # --- .pth files (auto-execute on Python startup) ---
           # The exact mechanism used in the litellm supply chain attack:
           # https://github.com/BerriAI/litellm/issues/24512
-          PTH_FILES=$(git diff --name-only "$BASE".."$HEAD" | grep '\.pth$' || true)
+          PTH_FILES=$(git diff --name-only "$BASE"..."$HEAD" | grep '\.pth$' || true)
           if [ -n "$PTH_FILES" ]; then
             FINDINGS="${FINDINGS}
           ### 🚨 CRITICAL: .pth file added or modified
@@ -97,7 +100,7 @@ jobs:
 
           # --- Install-hook files (setup.py/sitecustomize/usercustomize/__init__.pth) ---
           # These execute during pip install or interpreter startup.
-          SETUP_HITS=$(git diff --name-only "$BASE".."$HEAD" | grep -E '(^|/)(setup\.py|setup\.cfg|sitecustomize\.py|usercustomize\.py|__init__\.pth)$' || true)
+          SETUP_HITS=$(git diff --name-only "$BASE"..."$HEAD" | grep -E '(^|/)(setup\.py|setup\.cfg|sitecustomize\.py|usercustomize\.py|__init__\.pth)$' || true)
           if [ -n "$SETUP_HITS" ]; then
             FINDINGS="${FINDINGS}
           ### 🚨 CRITICAL: Install-hook file added or modified
@@ -158,7 +161,7 @@ jobs:
           HEAD="${{ github.event.pull_request.head.sha }}"
 
           # Only check added lines in pyproject.toml
-          ADDED=$(git diff "$BASE".."$HEAD" -- pyproject.toml | grep '^+' | grep -v '^+++' || true)
+          ADDED=$(git diff "$BASE"..."$HEAD" -- pyproject.toml | grep '^+' | grep -v '^+++' || true)
 
           if [ -z "$ADDED" ]; then
             echo "found=false" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## What does this PR do?

The supply-chain-audit workflow uses `git diff "$BASE".."$HEAD"` (two-dot), which compares the tip-of-main tree directly against the PR tip. When files land on main after a PR branched off, they appear in the diff even though the PR never touched them — triggering false-positive CRITICAL findings.

**Example:** PR #30609 was flagged for `hermes_cli/setup.py`, a file added to main by an unrelated commit after that PR branched. The PR itself never touched `setup.py`.

Switches all four diff commands to three-dot syntax (`"$BASE"..."$HEAD"`), which diffs from the merge base to the PR tip — only changes actually introduced by the PR are included.

## Related Issue

N/A — discovered via a real false positive on PR #30609.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `.github/workflows/supply-chain-audit.yml` line 50: `"$BASE".."$HEAD"` → `"$BASE"..."$HEAD"` (content diff in `scan` job)
- `.github/workflows/supply-chain-audit.yml` line 57: same fix (`.pth` file-name check)
- `.github/workflows/supply-chain-audit.yml` line 100: same fix (install-hook file-name check)
- `.github/workflows/supply-chain-audit.yml` line 161: same fix (`dep-bounds` job pyproject.toml diff)
- Added inline comment explaining why three-dot is used

## How to Test

1. Open a PR from a branch that diverged from main before `hermes_cli/setup.py` was added
2. Observe that the supply-chain-audit scan job no longer flags `setup.py` as an install-hook finding
3. Verify that a PR that actually adds a `.pth` file or `base64+exec` combo still correctly triggers the scanner

Alternatively: `git diff A..B` vs `git diff A...B` on any branch pair where main has moved past the merge base — the two-dot diff will show spurious changes from main, the three-dot diff will not.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've added tests for my changes — N/A (workflow-only change, no test surface)
- [x] I've tested on my platform: NixOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A



closes https://github.com/NousResearch/hermes-agent/pull/23592
closes https://github.com/NousResearch/hermes-agent/pull/13411

both did the same fix, but didn't catch the pyproject.toml one.


## Infographic

![supply-chain-audit-diff-fix](https://v3b.fal.media/files/b/0a9b4893/RinaRBjYz542z104a8x3Z_hhBme87k.png)
