### PR TITLE
fix(gateway): bridge terminal.docker_extra_args to env for gateway sessions (#30415)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -631,6 +631,7 @@ if _config_path.exists():
                 "container_memory": "TERMINAL_CONTAINER_MEMORY",
                 "container_disk": "TERMINAL_CONTAINER_DISK",
                 "container_persistent": "TERMINAL_CONTAINER_PERSISTENT",
+                "docker_extra_args": "TERMINAL_DOCKER_EXTRA_ARGS",
                 "docker_volumes": "TERMINAL_DOCKER_VOLUMES",
                 "docker_env": "TERMINAL_DOCKER_ENV",
                 "docker_mount_cwd_to_workspace": "TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE",


### PR DESCRIPTION
## Summary

Fixes #30415. The `_terminal_env_map` in `gateway/run.py` bridges `terminal.*` config keys into `TERMINAL_*` env vars at gateway startup so the agent process can read them. `docker_extra_args` was the only `docker_*` key missing from this map, causing it to be silently dropped in gateway mode.

## Fix

One line: add `"docker_extra_args": "TERMINAL_DOCKER_EXTRA_ARGS"` to `_terminal_env_map`.

The existing serialization logic at `run.py:482-485` already handles list/dict values by JSON-encoding them before export, so no additional encoding logic is needed.

## Testing

Existing config parsing test passes. This is a one-line config bridge fix — the behavior is already covered by the terminal tool's ability to read the `TERMINAL_DOCKER_EXTRA_ARGS` env var.