### PR TITLE
fix(cli): correct stale command references in user-facing messages

### DIFF
--- a/hermes_cli/claw.py
+++ b/hermes_cli/claw.py
@@ -177,7 +177,7 @@ def _warn_if_gateway_running(auto_yes: bool) -> None:
         "conflicts (Telegram, Discord, and Slack only allow one active "
         "session per token)."
     )
-    print_info("Recommendation: stop the gateway first with 'hermes stop'.")
+    print_info("Recommendation: stop the gateway first with 'hermes gateway stop'.")
     print()
     if not auto_yes and not prompt_yes_no("Continue anyway?", default=False):
         print_info("Migration cancelled. Stop the gateway and try again.")

--- a/hermes_cli/tips.py
+++ b/hermes_cli/tips.py
@@ -102,7 +102,7 @@ TIPS = [
     "hermes webhook subscribe creates event-driven webhook routes with HMAC validation.",
     "Save money: hermes tools disables unused tools, hermes skills config trims skills down.",
     "/reasoning low or /reasoning minimal cuts thinking depth below the default (medium) — faster, cheaper responses.",
-    "hermes models routes vision, compression, and aux tasks to cheaper models — cuts background token cost 85%+ without downgrading your main chat model.",
+    "hermes model has an interactive auxiliary-model configuration menu that routes vision, compression, and aux tasks to cheaper models — cuts background token cost 85%+ without downgrading your main chat model.",
 
     # --- Configuration ---
     "Set display.bell_on_complete: true in config.yaml to hear a bell when long tasks finish.",


### PR DESCRIPTION
## Summary

Two outdated CLI command references shown to users:

- [hermes_cli/claw.py:180](hermes_cli/claw.py#L180) — OpenClaw migration safety warning recommends running `hermes stop`, which isn't a top-level command. The real one is `hermes gateway stop` (registered at [hermes_cli/main.py:11161](hermes_cli/main.py#L11161)). Hit this during a real migration.
- [hermes_cli/tips.py:105](hermes_cli/tips.py#L105) — a startup tip mentions `hermes models` (plural). The command is `hermes model` (singular), and the auxiliary-routing flow it's pitching lives inside that command's interactive auxiliary-model configuration menu. Reworded so the tip matches reality.

## Test plan

- [x] `hermes gateway stop --help` succeeds; `hermes stop --help` errors with "invalid choice".
- [x] `hermes model` is registered; `hermes models` is not.
- [ ] Trigger the OpenClaw migration warning by running `hermes claw migrate` with the gateway active — confirm the new copy renders.
- [ ] Reviewer skim of the diff (2 lines).