### PR TITLE
fix(tui): handle composer input bursts immediately

### DIFF
--- a/ui-tui/src/components/textInput.tsx
+++ b/ui-tui/src/components/textInput.tsx
@@ -34,6 +34,7 @@ const DIM_OFF = `${ESC}[22m`
 const FWD_DEL_RE = new RegExp(`${ESC}\\[3(?:[~$^]|;)`)
 const PRINTABLE = /^[ -~\u00a0-\uffff]+$/
 const BRACKET_PASTE = new RegExp(`${ESC}?\\[20[01]~`, 'g')
+const KEY_BURST_MS = 16
 const MULTI_CLICK_MS = 500
 
 const invert = (s: string) => INV + s + INV_OFF
@@ -400,10 +401,7 @@ export function TextInput({
   const selRef = useRef<null | { end: number; start: number }>(null)
   const vRef = useRef(value)
   const self = useRef(false)
-  const pasteBuf = useRef('')
-  const pasteEnd = useRef<null | number>(null)
-  const pasteTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
-  const pastePos = useRef(0)
+  const keyBurstTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
   const editVersionRef = useRef(0)
   const parentChangeTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
   const pendingParentValue = useRef<string | null>(null)
@@ -536,8 +534,8 @@ export function TextInput({
 
   useEffect(
     () => () => {
-      if (pasteTimer.current) {
-        clearTimeout(pasteTimer.current)
+      if (keyBurstTimer.current) {
+        clearTimeout(keyBurstTimer.current)
       }
 
       if (parentChangeTimer.current) {
@@ -695,21 +693,26 @@ export function TextInput({
     return !!h
   }
 
-  const flushPaste = () => {
-    const text = pasteBuf.current
-    const at = pastePos.current
-    const end = pasteEnd.current ?? at
-    pasteBuf.current = ''
-    pasteEnd.current = null
-    pasteTimer.current = null
+  const flushKeyBurst = () => {
+    if (keyBurstTimer.current) {
+      clearTimeout(keyBurstTimer.current)
+      keyBurstTimer.current = null
+    }
 
-    if (!text) {
+    flushParentChange()
+  }
+
+  const scheduleKeyBurstCommit = (next: string, nextCur: number) => {
+    commit(next, nextCur, true, false, false)
+
+    if (keyBurstTimer.current) {
       return
     }
 
-    if (!emitPaste({ cursor: at, text, value: vRef.current }) && PRINTABLE.test(text)) {
-      commit(vRef.current.slice(0, at) + text + vRef.current.slice(end), at + text.length)
-    }
+    keyBurstTimer.current = setTimeout(() => {
+      keyBurstTimer.current = null
+      flushParentChange()
+    }, KEY_BURST_MS)
   }
 
   const clearSel = () => {
@@ -850,6 +853,8 @@ export function TextInput({
       // follow-up on #19835). The pass-through predicate is a no-op for
       // ordinary typing and plain paste when voice is unbound to 'v'.
       if (shouldPassThroughToGlobalHandler(inp, k, voiceRecordKey)) {
+        flushKeyBurst()
+
         return
       }
 
@@ -859,6 +864,8 @@ export function TextInput({
         eventRaw === '\x16' ||
         (isMac && isActionMod(k) && inp.toLowerCase() === 'v')
       ) {
+        flushKeyBurst()
+
         if (cbPaste.current) {
           return void emitPaste({ cursor: curRef.current, hotkey: true, text: '', value: vRef.current })
         }
@@ -875,6 +882,8 @@ export function TextInput({
       }
 
       if (isMac && isActionMod(k) && inp.toLowerCase() === 'c') {
+        flushKeyBurst()
+
         const range = selRange()
 
         if (range) {
@@ -887,6 +896,8 @@ export function TextInput({
       }
 
       if (k.upArrow || k.downArrow) {
+        flushKeyBurst()
+
         const next = lineNav(vRef.current, curRef.current, k.upArrow ? -1 : 1)
 
         if (next !== null) {
@@ -899,11 +910,11 @@ export function TextInput({
       }
 
       if (k.return) {
+        flushKeyBurst()
+
         if (k.shift || k.ctrl || (isMac ? isActionMod(k) : k.meta)) {
-          flushParentChange()
           commit(ins(vRef.current, curRef.current, '\n'), curRef.current + 1)
         } else {
-          flushParentChange()
           cbSubmit.current?.(vRef.current)
         }
 
@@ -921,6 +932,11 @@ export function TextInput({
       const actionDeleteWord = (mod && inp === 'w') || isMacActionFallback(k, inp, 'w')
       const range = selRange()
       const delFwd = k.delete || fwdDel.current
+      const isPrintableInput = (event.keypress.isPasted || inp.length > 0) && PRINTABLE.test(inp.replace(BRACKET_PASTE, ''))
+
+      if (!isPrintableInput) {
+        flushKeyBurst()
+      }
 
       if (mod && inp === 'z') {
         return swap(undo, redo)
@@ -1050,18 +1066,19 @@ export function TextInput({
         }
 
         if (text.length > 1 || text.includes('\n')) {
-          if (!pasteBuf.current) {
-            pastePos.current = range ? range.start : c
-            pasteEnd.current = range ? range.end : pastePos.current
+          if (!PRINTABLE.test(text)) {
+            return
           }
 
-          pasteBuf.current += text
-
-          if (pasteTimer.current) {
-            clearTimeout(pasteTimer.current)
+          if (range) {
+            v = v.slice(0, range.start) + text + v.slice(range.end)
+            c = range.start + text.length
+          } else {
+            v = v.slice(0, c) + text + v.slice(c)
+            c += text.length
           }
 
-          pasteTimer.current = setTimeout(flushPaste, 50)
+          scheduleKeyBurstCommit(v, c)
 
           return
         }


### PR DESCRIPTION
## What does this PR do?

Fixes a TUI composer race where non-bracketed multi-character input bursts were treated like delayed paste input. On WSL2 / Windows Terminal, holding a key can deliver chunks such as `xxxxx` as one input event. The old composer buffered those chunks for 50ms as pseudo-paste, so later single-key input or Backspace could edit the current value before a stale buffered chunk was inserted.

This keeps real bracketed paste on the existing `emitPaste` path, but routes non-bracketed printable multi-character keyboard bursts through a small frame-sized buffer. The burst updates the local input/cursor state immediately, then flushes parent state once per 16ms frame. Non-text actions such as Return, arrows/history, paste/copy, and editing shortcuts flush the pending burst first so they operate on the current value.

## Related Issue

Support thread: <https://discord.com/channels/1053877538025386074/1507402239558418534>

Related broader PR with a similar direction: #29051

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `ui-tui/src/components/textInput.tsx`: remove the 50ms pseudo-paste buffer for non-bracketed multi-character input bursts.
- `ui-tui/src/components/textInput.tsx`: add a 16ms keyboard-burst coalescer that updates local input state immediately while batching parent state flushes.
- `ui-tui/src/components/textInput.tsx`: flush any pending keyboard burst before non-text actions so Backspace, Return, arrows/history, paste/copy, and shortcuts see the current input.

## How to Test

1. In Windows Terminal / WSL2, launch `hermes --tui`.
2. Hold a printable key such as `x` until the composer spans multiple visual lines.
3. Move to the end and hold Backspace. The composer should shrink normally and should not re-grow from delayed buffered chunks.
4. Stress-test held printable input around the previous lockup threshold and check that the TUI remains responsive.

Validation run locally from the main checkout with the same `ui-tui/src/components/textInput.tsx` content as this branch:

- `cd ui-tui && npx vitest run --maxWorkers 4 --testTimeout 15000 src/__tests__/textInputFastEcho.test.ts src/__tests__/textInputCursorSourceOfTruth.test.ts src/__tests__/textInputWrap.test.ts src/__tests__/textInputLineNav.test.ts src/__tests__/cursorDriftRegression.test.ts` — passed, 5 files / 64 tests
- `cd ui-tui && npx eslint src/components/textInput.tsx` — no errors; existing warnings remain
- `cd ui-tui && npm run build` — passed

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: WSL2 / Windows Terminal repro path, plus targeted UI-TUI tests listed above

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

No screenshot attached. Repro is the Discord support thread linked above.
