### PR TITLE
Fix skills install resolution exit code

### DIFF
--- a/hermes_cli/skills_hub.py
+++ b/hermes_cli/skills_hub.py
@@ -13,6 +13,7 @@ handler are thin wrappers that parse args and delegate.
 import json
 import re
 import shutil
+import sys
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
@@ -414,7 +415,7 @@ def do_browse(page: int = 1, page_size: int = 20, source: str = "all",
 def do_install(identifier: str, category: str = "", force: bool = False,
                console: Optional[Console] = None, skip_confirm: bool = False,
                invalidate_cache: bool = True,
-               name_override: str = "") -> None:
+               name_override: str = "") -> bool:
     """Fetch, quarantine, scan, confirm, and install a skill.
 
     ``name_override`` lets non-interactive callers (slash commands, gateway,
@@ -423,6 +424,10 @@ def do_install(identifier: str, category: str = "", force: bool = False,
     triggers a prompt instead; ``skip_confirm=True`` means "non-interactive"
     (so pair it with ``name_override`` when installing from a URL that has
     no frontmatter).
+
+    Returns ``True`` when the requested skill is installed or already present,
+    and ``False`` when resolution, fetch, scan, confirmation, or installation
+    prevents the install from completing.
     """
     from tools.skills_hub import (
         GitHubAuth, create_source_router, ensure_hub_dirs,
@@ -441,7 +446,7 @@ def do_install(identifier: str, category: str = "", force: bool = False,
     if "/" not in identifier:
         identifier = _resolve_short_name(identifier, sources, c)
         if not identifier:
-            return
+            return False
 
     c.print(f"\n[bold]Fetching:[/] {identifier}")
 
@@ -465,7 +470,7 @@ def do_install(identifier: str, category: str = "", force: bool = False,
             )
         else:
             c.print()
-        return
+        return False
 
     # URL-sourced skills may arrive with an empty name when SKILL.md has no
     # ``name:`` in frontmatter AND the URL path doesn't yield a valid
@@ -482,7 +487,7 @@ def do_install(identifier: str, category: str = "", force: bool = False,
                 "Must be a lowercase identifier (letters, digits, hyphens, "
                 "underscores; starts with a letter).\n"
             )
-            return
+            return False
         elif skip_confirm:
             # Non-interactive surface (slash command / TUI / gateway). Can't
             # prompt — emit an actionable error.
@@ -497,14 +502,14 @@ def do_install(identifier: str, category: str = "", force: bool = False,
                 "[dim]Or ask the SKILL.md's author to add a `name:` field to "
                 "its YAML frontmatter.[/]\n"
             )
-            return
+            return False
         else:
             # Interactive TTY — prompt.
             url = bundle_meta.get("url") or identifier
             chosen = _prompt_for_skill_name(c, url)
             if not chosen:
                 c.print("[dim]Installation cancelled.[/]\n")
-                return
+                return False
             bundle.name = chosen
             bundle_meta["awaiting_name"] = False
         # Keep SkillMeta in sync so downstream "already installed" checks,
@@ -532,7 +537,7 @@ def do_install(identifier: str, category: str = "", force: bool = False,
         c.print(f"[yellow]Warning:[/] '{bundle.name}' is already installed at {existing['install_path']}")
         if not force:
             c.print("Use --force to reinstall.\n")
-            return
+            return True
 
     extra_metadata = dict(getattr(meta, "extra", {}) or {})
     extra_metadata.update(getattr(bundle, "metadata", {}) or {})
@@ -545,7 +550,7 @@ def do_install(identifier: str, category: str = "", force: bool = False,
         from tools.skills_hub import append_audit_log
         append_audit_log("BLOCKED", bundle.name, bundle.source,
                          bundle.trust_level, "invalid_path", str(exc))
-        return
+        return False
     c.print(f"[dim]Quarantined to {q_path.relative_to(q_path.parent.parent.parent)}[/]")
 
     # Scan
@@ -564,7 +569,7 @@ def do_install(identifier: str, category: str = "", force: bool = False,
         append_audit_log("BLOCKED", bundle.name, bundle.source,
                          bundle.trust_level, result.verdict,
                          f"{len(result.findings)}_findings")
-        return
+        return False
 
     if extra_metadata:
         metadata_lines = _format_extra_metadata_lines(extra_metadata)
@@ -602,7 +607,7 @@ def do_install(identifier: str, category: str = "", force: bool = False,
         if answer not in {"y", "yes"}:
             c.print("[dim]Installation cancelled.[/]\n")
             shutil.rmtree(q_path, ignore_errors=True)
-            return
+            return False
 
     # Install
     try:
@@ -613,7 +618,7 @@ def do_install(identifier: str, category: str = "", force: bool = False,
         from tools.skills_hub import append_audit_log
         append_audit_log("BLOCKED", bundle.name, bundle.source,
                          bundle.trust_level, "invalid_path", str(exc))
-        return
+        return False
     from tools.skills_hub import SKILLS_DIR
     c.print(f"[bold green]Installed:[/] {install_dir.relative_to(SKILLS_DIR)}")
     c.print(f"[dim]Files: {', '.join(bundle.files.keys())}[/]\n")
@@ -628,6 +633,8 @@ def do_install(identifier: str, category: str = "", force: bool = False,
     else:
         c.print("[dim]Skill will be available in your next session.[/]")
         c.print("[dim]Use /reset to start a new session now, or --now to activate immediately (invalidates prompt cache).[/]\n")
+
+    return True
 
 
 def do_inspect(identifier: str, console: Optional[Console] = None) -> None:
@@ -1328,9 +1335,11 @@ def skills_command(args) -> None:
     elif action == "search":
         do_search(args.query, source=args.source, limit=args.limit)
     elif action == "install":
-        do_install(args.identifier, category=args.category, force=args.force,
-                   skip_confirm=getattr(args, "yes", False),
-                   name_override=getattr(args, "name", "") or "")
+        installed = do_install(args.identifier, category=args.category, force=args.force,
+                               skip_confirm=getattr(args, "yes", False),
+                               name_override=getattr(args, "name", "") or "")
+        if installed is False:
+            sys.exit(1)
     elif action == "inspect":
         do_inspect(args.identifier)
     elif action == "list":

--- a/tests/hermes_cli/test_skills_hub.py
+++ b/tests/hermes_cli/test_skills_hub.py
@@ -1,4 +1,5 @@
 from io import StringIO
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
@@ -316,6 +317,75 @@ def test_do_install_scans_with_resolved_identifier(monkeypatch, tmp_path, hub_en
     do_install("skils-sh/anthropics/skills/frontend-design", console=console, skip_confirm=True)
 
     assert scanned["source"] == canonical_identifier
+
+
+def test_do_install_unknown_short_name_returns_false(monkeypatch):
+    import tools.skills_hub as hub
+
+    monkeypatch.setattr(hub, "ensure_hub_dirs", lambda: None)
+    monkeypatch.setattr(hub, "GitHubAuth", lambda: object())
+    monkeypatch.setattr(hub, "create_source_router", lambda auth: [])
+    monkeypatch.setattr(
+        hub,
+        "unified_search",
+        lambda query, sources, source_filter="all", limit=20: [],
+    )
+
+    sink = StringIO()
+    console = Console(file=sink, force_terminal=False, color_system=None)
+
+    assert do_install(
+        "definitely-not-a-real-skill-zzz",
+        console=console,
+        skip_confirm=True,
+    ) is False
+    assert "No skill named 'definitely-not-a-real-skill-zzz' found" in sink.getvalue()
+
+
+def test_do_install_suggested_short_name_returns_false(monkeypatch):
+    import tools.skills_hub as hub
+
+    monkeypatch.setattr(hub, "ensure_hub_dirs", lambda: None)
+    monkeypatch.setattr(hub, "GitHubAuth", lambda: object())
+    monkeypatch.setattr(hub, "create_source_router", lambda auth: [])
+    monkeypatch.setattr(
+        hub,
+        "unified_search",
+        lambda query, sources, source_filter="all", limit=20: [
+            SimpleNamespace(
+                name="conceptual-diagram",
+                identifier="official/creative/conceptual-diagram",
+            )
+        ],
+    )
+
+    sink = StringIO()
+    console = Console(file=sink, force_terminal=False, color_system=None)
+
+    assert do_install("concept-diagram", console=console, skip_confirm=True) is False
+    output = sink.getvalue()
+    assert "No exact match for 'concept-diagram'" in output
+    assert "official/creative/conceptual-diagram" in output
+
+
+def test_skills_command_exits_nonzero_when_install_fails(monkeypatch):
+    import hermes_cli.skills_hub as cli_hub
+
+    monkeypatch.setattr(cli_hub, "do_install", lambda *args, **kwargs: False)
+
+    args = SimpleNamespace(
+        skills_action="install",
+        identifier="definitely-not-a-real-skill-zzz",
+        category="",
+        force=False,
+        yes=True,
+        name="",
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        cli_hub.skills_command(args)
+
+    assert exc.value.code == 1
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- make `hermes skills install <short-name>` report install failure back to the argparse CLI
- exit with status 1 when a short-name resolution or install path fails
- keep shared slash-command behavior intact by only converting failure to `SystemExit(1)` in the CLI wrapper

Closes #30631

## Tests
- `uv run --extra dev python -m pytest tests/hermes_cli/test_skills_hub.py tests/hermes_cli/test_skills_install_flags.py tests/hermes_cli/test_skills_skip_confirm.py -q --timeout-method=thread` -> `46 passed in 2.12s`
- `uv run --extra dev ruff check hermes_cli/skills_hub.py tests/hermes_cli/test_skills_hub.py` -> `All checks passed!`
- `uv run --extra dev python -m compileall hermes_cli/skills_hub.py tests/hermes_cli/test_skills_hub.py`

## Manual smoke
- `HERMES_HOME=C:\tmp\hermes-pr-30631\.tmp-hermes-smoke hermes skills install definitely-not-a-real-skill-zzz --yes` printed `Error: No skill named 'definitely-not-a-real-skill-zzz' found in any source.` and returned `EXIT_CODE=1`
- `HERMES_HOME=C:\tmp\hermes-pr-30631\.tmp-hermes-smoke hermes skills install concept-diagram --yes` printed `No exact match for 'concept-diagram'. Did you mean one of these?` and returned `EXIT_CODE=1`
