### PR TITLE
Add Charity Charge agent workspace scaffolding

### DIFF
--- a/docs/agent-guides/hermes-development-guide-full.md
+++ b/docs/agent-guides/hermes-development-guide-full.md
@@ -1,0 +1,989 @@
+# Hermes Agent - Development Guide
+
+Instructions for AI coding assistants and developers working on the hermes-agent codebase.
+
+## Development Environment
+
+```bash
+# Prefer .venv; fall back to venv if that's what your checkout has.
+source .venv/bin/activate   # or: source venv/bin/activate
+```
+
+`scripts/run_tests.sh` probes `.venv` first, then `venv`, then
+`$HOME/.hermes/hermes-agent/venv` (for worktrees that share a venv with the
+main checkout).
+
+## Project Structure
+
+File counts shift constantly — don't treat the tree below as exhaustive.
+The canonical source is the filesystem. The notes call out the load-bearing
+entry points you'll actually edit.
+
+```
+hermes-agent/
+├── run_agent.py          # AIAgent class — core conversation loop (~12k LOC)
+├── model_tools.py        # Tool orchestration, discover_builtin_tools(), handle_function_call()
+├── toolsets.py           # Toolset definitions, _HERMES_CORE_TOOLS list
+├── cli.py                # HermesCLI class — interactive CLI orchestrator (~11k LOC)
+├── hermes_state.py       # SessionDB — SQLite session store (FTS5 search)
+├── hermes_constants.py   # get_hermes_home(), display_hermes_home() — profile-aware paths
+├── hermes_logging.py     # setup_logging() — agent.log / errors.log / gateway.log (profile-aware)
+├── batch_runner.py       # Parallel batch processing
+├── agent/                # Agent internals (provider adapters, memory, caching, compression, etc.)
+├── hermes_cli/           # CLI subcommands, setup wizard, plugins loader, skin engine
+├── tools/                # Tool implementations — auto-discovered via tools/registry.py
+│   └── environments/     # Terminal backends (local, docker, ssh, modal, daytona, singularity)
+├── gateway/              # Messaging gateway — run.py + session.py + platforms/
+│   ├── platforms/        # Adapter per platform (telegram, discord, slack, whatsapp,
+│   │                     #   homeassistant, signal, matrix, mattermost, email, sms,
+│   │                     #   dingtalk, wecom, weixin, feishu, qqbot, bluebubbles,
+│   │                     #   yuanbao, webhook, api_server, ...). See ADDING_A_PLATFORM.md.
+│   └── builtin_hooks/    # Extension point for always-registered gateway hooks (none shipped)
+├── plugins/              # Plugin system (see "Plugins" section below)
+│   ├── memory/           # Memory-provider plugins (honcho, mem0, supermemory, ...)
+│   ├── context_engine/   # Context-engine plugins
+│   ├── model-providers/  # Inference backend plugins (openrouter, anthropic, gmi, ...)
+│   ├── kanban/           # Multi-agent board dispatcher + worker plugin
+│   ├── hermes-achievements/  # Gamified achievement tracking
+│   ├── observability/    # Metrics / traces / logs plugin
+│   ├── image_gen/        # Image-generation providers
+│   └── <others>/         # disk-cleanup, example-dashboard, google_meet, platforms,
+│                         #   spotify, strike-freedom-cockpit, ...
+├── optional-skills/      # Heavier/niche skills shipped but NOT active by default
+├── skills/               # Built-in skills bundled with the repo
+├── ui-tui/               # Ink (React) terminal UI — `hermes --tui`
+│   └── src/              # entry.tsx, app.tsx, gatewayClient.ts + app/components/hooks/lib
+├── tui_gateway/          # Python JSON-RPC backend for the TUI
+├── acp_adapter/          # ACP server (VS Code / Zed / JetBrains integration)
+├── cron/                 # Scheduler — jobs.py, scheduler.py
+├── environments/         # RL training environments (Atropos)
+├── scripts/              # run_tests.sh, release.py, auxiliary scripts
+├── website/              # Docusaurus docs site
+└── tests/                # Pytest suite (~17k tests across ~900 files as of May 2026)
+```
+
+**User config:** `~/.hermes/config.yaml` (settings), `~/.hermes/.env` (API keys only).
+**Logs:** `~/.hermes/logs/` — `agent.log` (INFO+), `errors.log` (WARNING+),
+`gateway.log` when running the gateway. Profile-aware via `get_hermes_home()`.
+Browse with `hermes logs [--follow] [--level ...] [--session ...]`.
+
+## File Dependency Chain
+
+```
+tools/registry.py  (no deps — imported by all tool files)
+       ↑
+tools/*.py  (each calls registry.register() at import time)
+       ↑
+model_tools.py  (imports tools/registry + triggers tool discovery)
+       ↑
+run_agent.py, cli.py, batch_runner.py, environments/
+```
+
+---
+
+## AIAgent Class (run_agent.py)
+
+The real `AIAgent.__init__` takes ~60 parameters (credentials, routing, callbacks,
+session context, budget, credential pool, etc.). The signature below is the
+minimum subset you'll usually touch — read `run_agent.py` for the full list.
+
+```python
+class AIAgent:
+    def __init__(self,
+        base_url: str = None,
+        api_key: str = None,
+        provider: str = None,
+        api_mode: str = None,              # "chat_completions" | "codex_responses" | ...
+        model: str = "",                   # empty → resolved from config/provider later
+        max_iterations: int = 90,          # tool-calling iterations (shared with subagents)
+        enabled_toolsets: list = None,
+        disabled_toolsets: list = None,
+        quiet_mode: bool = False,
+        save_trajectories: bool = False,
+        platform: str = None,              # "cli", "telegram", etc.
+        session_id: str = None,
+        skip_context_files: bool = False,
+        skip_memory: bool = False,
+        credential_pool=None,
+        # ... plus callbacks, thread/user/chat IDs, iteration_budget, fallback_model,
+        # checkpoints config, prefill_messages, service_tier, reasoning_config, etc.
+    ): ...
+
+    def chat(self, message: str) -> str:
+        """Simple interface — returns final response string."""
+
+    def run_conversation(self, user_message: str, system_message: str = None,
+                         conversation_history: list = None, task_id: str = None) -> dict:
+        """Full interface — returns dict with final_response + messages."""
+```
+
+### Agent Loop
+
+The core loop is inside `run_conversation()` — entirely synchronous, with
+interrupt checks, budget tracking, and a one-turn grace call:
+
+```python
+while (api_call_count < self.max_iterations and self.iteration_budget.remaining > 0) \
+        or self._budget_grace_call:
+    if self._interrupt_requested: break
+    response = client.chat.completions.create(model=model, messages=messages, tools=tool_schemas)
+    if response.tool_calls:
+        for tool_call in response.tool_calls:
+            result = handle_function_call(tool_call.name, tool_call.args, task_id)
+            messages.append(tool_result_message(result))
+        api_call_count += 1
+    else:
+        return response.content
+```
+
+Messages follow OpenAI format: `{"role": "system/user/assistant/tool", ...}`.
+Reasoning content is stored in `assistant_msg["reasoning"]`.
+
+---
+
+## CLI Architecture (cli.py)
+
+- **Rich** for banner/panels, **prompt_toolkit** for input with autocomplete
+- **KawaiiSpinner** (`agent/display.py`) — animated faces during API calls, `┊` activity feed for tool results
+- `load_cli_config()` in cli.py merges hardcoded defaults + user config YAML
+- **Skin engine** (`hermes_cli/skin_engine.py`) — data-driven CLI theming; initialized from `display.skin` config key at startup; skins customize banner colors, spinner faces/verbs/wings, tool prefix, response box, branding text
+- `process_command()` is a method on `HermesCLI` — dispatches on canonical command name resolved via `resolve_command()` from the central registry
+- Skill slash commands: `agent/skill_commands.py` scans `~/.hermes/skills/`, injects as **user message** (not system prompt) to preserve prompt caching
+
+### Slash Command Registry (`hermes_cli/commands.py`)
+
+All slash commands are defined in a central `COMMAND_REGISTRY` list of `CommandDef` objects. Every downstream consumer derives from this registry automatically:
+
+- **CLI** — `process_command()` resolves aliases via `resolve_command()`, dispatches on canonical name
+- **Gateway** — `GATEWAY_KNOWN_COMMANDS` frozenset for hook emission, `resolve_command()` for dispatch
+- **Gateway help** — `gateway_help_lines()` generates `/help` output
+- **Telegram** — `telegram_bot_commands()` generates the BotCommand menu
+- **Slack** — `slack_subcommand_map()` generates `/hermes` subcommand routing
+- **Autocomplete** — `COMMANDS` flat dict feeds `SlashCommandCompleter`
+- **CLI help** — `COMMANDS_BY_CATEGORY` dict feeds `show_help()`
+
+### Adding a Slash Command
+
+1. Add a `CommandDef` entry to `COMMAND_REGISTRY` in `hermes_cli/commands.py`:
+```python
+CommandDef("mycommand", "Description of what it does", "Session",
+           aliases=("mc",), args_hint="[arg]"),
+```
+2. Add handler in `HermesCLI.process_command()` in `cli.py`:
+```python
+elif canonical == "mycommand":
+    self._handle_mycommand(cmd_original)
+```
+3. If the command is available in the gateway, add a handler in `gateway/run.py`:
+```python
+if canonical == "mycommand":
+    return await self._handle_mycommand(event)
+```
+4. For persistent settings, use `save_config_value()` in `cli.py`
+
+**CommandDef fields:**
+- `name` — canonical name without slash (e.g. `"background"`)
+- `description` — human-readable description
+- `category` — one of `"Session"`, `"Configuration"`, `"Tools & Skills"`, `"Info"`, `"Exit"`
+- `aliases` — tuple of alternative names (e.g. `("bg",)`)
+- `args_hint` — argument placeholder shown in help (e.g. `"<prompt>"`, `"[name]"`)
+- `cli_only` — only available in the interactive CLI
+- `gateway_only` — only available in messaging platforms
+- `gateway_config_gate` — config dotpath (e.g. `"display.tool_progress_command"`); when set on a `cli_only` command, the command becomes available in the gateway if the config value is truthy. `GATEWAY_KNOWN_COMMANDS` always includes config-gated commands so the gateway can dispatch them; help/menus only show them when the gate is open.
+
+**Adding an alias** requires only adding it to the `aliases` tuple on the existing `CommandDef`. No other file changes needed — dispatch, help text, Telegram menu, Slack mapping, and autocomplete all update automatically.
+
+---
+
+## TUI Architecture (ui-tui + tui_gateway)
+
+The TUI is a full replacement for the classic (prompt_toolkit) CLI, activated via `hermes --tui` or `HERMES_TUI=1`.
+
+### Process Model
+
+```
+hermes --tui
+  └─ Node (Ink)  ──stdio JSON-RPC──  Python (tui_gateway)
+       │                                  └─ AIAgent + tools + sessions
+       └─ renders transcript, composer, prompts, activity
+```
+
+TypeScript owns the screen. Python owns sessions, tools, model calls, and slash command logic.
+
+### Transport
+
+Newline-delimited JSON-RPC over stdio. Requests from Ink, events from Python. See `tui_gateway/server.py` for the full method/event catalog.
+
+### Key Surfaces
+
+| Surface | Ink component | Gateway method |
+|---------|---------------|----------------|
+| Chat streaming | `app.tsx` + `messageLine.tsx` | `prompt.submit` → `message.delta/complete` |
+| Tool activity | `thinking.tsx` | `tool.start/progress/complete` |
+| Approvals | `prompts.tsx` | `approval.respond` ← `approval.request` |
+| Clarify/sudo/secret | `prompts.tsx`, `maskedPrompt.tsx` | `clarify/sudo/secret.respond` |
+| Session picker | `sessionPicker.tsx` | `session.list/resume` |
+| Slash commands | Local handler + fallthrough | `slash.exec` → `_SlashWorker`, `command.dispatch` |
+| Completions | `useCompletion` hook | `complete.slash`, `complete.path` |
+| Theming | `theme.ts` + `branding.tsx` | `gateway.ready` with skin data |
+
+### Slash Command Flow
+
+1. Built-in client commands (`/help`, `/quit`, `/clear`, `/resume`, `/copy`, `/paste`, etc.) handled locally in `app.tsx`
+2. Everything else → `slash.exec` (runs in persistent `_SlashWorker` subprocess) → `command.dispatch` fallback
+
+### Dev Commands
+
+```bash
+cd ui-tui
+npm install       # first time
+npm run dev       # watch mode (rebuilds hermes-ink + tsx --watch)
+npm start         # production
+npm run build     # full build (hermes-ink + tsc)
+npm run type-check # typecheck only (tsc --noEmit)
+npm run lint      # eslint
+npm run fmt       # prettier
+npm test          # vitest
+```
+
+### TUI in the Dashboard (`hermes dashboard` → `/chat`)
+
+The dashboard embeds the real `hermes --tui` — **not** a rewrite.  See `hermes_cli/pty_bridge.py` + the `@app.websocket("/api/pty")` endpoint in `hermes_cli/web_server.py`.
+
+- Browser loads `web/src/pages/ChatPage.tsx`, which mounts xterm.js's `Terminal` with the WebGL renderer, `@xterm/addon-fit` for container-driven resize, and `@xterm/addon-unicode11` for modern wide-character widths.
+- `/api/pty?token=…` upgrades to a WebSocket; auth uses the same ephemeral `_SESSION_TOKEN` as REST, via query param (browsers can't set `Authorization` on WS upgrade).
+- The server spawns whatever `hermes --tui` would spawn, through `ptyprocess` (POSIX PTY — WSL works, native Windows does not).
+- Frames: raw PTY bytes each direction; resize via `\x1b[RESIZE:<cols>;<rows>]` intercepted on the server and applied with `TIOCSWINSZ`.
+
+**Do not re-implement the primary chat experience in React.** The main transcript, composer/input flow (including slash-command behavior), and PTY-backed terminal belong to the embedded `hermes --tui` — anything new you add to Ink shows up in the dashboard automatically. If you find yourself rebuilding the transcript or composer for the dashboard, stop and extend Ink instead.
+
+**Structured React UI around the TUI is allowed when it is not a second chat surface.** Sidebar widgets, inspectors, summaries, status panels, and similar supporting views (e.g. `ChatSidebar`, `ModelPickerDialog`, `ToolCall`) are fine when they complement the embedded TUI rather than replacing the transcript / composer / terminal. Keep their state independent of the PTY child's session and surface their failures non-destructively so the terminal pane keeps working unimpaired.
+
+---
+
+## Adding New Tools
+
+For most custom or local-only tools, do **not** edit Hermes core. Use the plugin
+route instead: create `~/.hermes/plugins/<name>/plugin.yaml` and
+`~/.hermes/plugins/<name>/__init__.py`, then register tools with
+`ctx.register_tool(...)`. Plugin toolsets are discovered automatically and can be
+enabled or disabled without touching `tools/` or `toolsets.py`.
+
+Use the built-in route below only when the user is explicitly contributing a new
+core Hermes tool that should ship in the base system.
+
+Built-in/core tools require changes in **2 files**:
+
+**1. Create `tools/your_tool.py`:**
+```python
+import json, os
+from tools.registry import registry
+
+def check_requirements() -> bool:
+    return bool(os.getenv("EXAMPLE_API_KEY"))
+
+def example_tool(param: str, task_id: str = None) -> str:
+    return json.dumps({"success": True, "data": "..."})
+
+registry.register(
+    name="example_tool",
+    toolset="example",
+    schema={"name": "example_tool", "description": "...", "parameters": {...}},
+    handler=lambda args, **kw: example_tool(param=args.get("param", ""), task_id=kw.get("task_id")),
+    check_fn=check_requirements,
+    requires_env=["EXAMPLE_API_KEY"],
+)
+```
+
+**2. Add to `toolsets.py`** — either `_HERMES_CORE_TOOLS` (all platforms) or a new toolset. **This step is required:** auto-discovery imports the tool and registers its schema, but the tool is only *exposed to an agent* if its name appears in a toolset. `_HERMES_CORE_TOOLS` is not dead code — it's the default bundle every platform's base toolset inherits from.
+
+Auto-discovery: any `tools/*.py` file with a top-level `registry.register()` call is imported automatically — no manual import list to maintain. Wiring into a toolset is still a deliberate, manual step.
+
+The registry handles schema collection, dispatch, availability checking, and error wrapping. All handlers MUST return a JSON string.
+
+**Path references in tool schemas**: If the schema description mentions file paths (e.g. default output directories), use `display_hermes_home()` to make them profile-aware. The schema is generated at import time, which is after `_apply_profile_override()` sets `HERMES_HOME`.
+
+**State files**: If a tool stores persistent state (caches, logs, checkpoints), use `get_hermes_home()` for the base directory — never `Path.home() / ".hermes"`. This ensures each profile gets its own state.
+
+**Agent-level tools** (todo, memory): intercepted by `run_agent.py` before `handle_function_call()`. See `tools/todo_tool.py` for the pattern.
+
+---
+
+## Adding Configuration
+
+### config.yaml options:
+1. Add to `DEFAULT_CONFIG` in `hermes_cli/config.py`
+2. Bump `_config_version` (check the current value at the top of `DEFAULT_CONFIG`)
+   ONLY if you need to actively migrate/transform existing user config
+   (renaming keys, changing structure). Adding a new key to an existing
+   section is handled automatically by the deep-merge and does NOT require
+   a version bump.
+
+### Top-level `config.yaml` sections (non-exhaustive):
+
+`model`, `agent`, `terminal`, `compression`, `display`, `stt`, `tts`,
+`memory`, `security`, `delegation`, `smart_model_routing`, `checkpoints`,
+`auxiliary`, `curator`, `skills`, `gateway`, `logging`, `cron`, `profiles`,
+`plugins`, `honcho`.
+
+`auxiliary` holds per-task overrides for side-LLM work (curator, vision,
+embedding, title generation, session_search, etc.) — each task can pin
+its own provider/model/base_url/max_tokens/reasoning_effort. See
+`agent/auxiliary_client.py::_resolve_auto` for resolution order.
+
+`curator` holds the background skill-maintenance config —
+`enabled`, `interval_hours`, `min_idle_hours`, `stale_after_days`,
+`archive_after_days`, `backup` (nested).
+
+### .env variables (SECRETS ONLY — API keys, tokens, passwords):
+1. Add to `OPTIONAL_ENV_VARS` in `hermes_cli/config.py` with metadata:
+```python
+"NEW_API_KEY": {
+    "description": "What it's for",
+    "prompt": "Display name",
+    "url": "https://...",
+    "password": True,
+    "category": "tool",  # provider, tool, messaging, setting
+},
+```
+
+Non-secret settings (timeouts, thresholds, feature flags, paths, display
+preferences) belong in `config.yaml`, not `.env`. If internal code needs an
+env var mirror for backward compatibility, bridge it from `config.yaml` to
+the env var in code (see `gateway_timeout`, `terminal.cwd` → `TERMINAL_CWD`).
+
+### Config loaders (three paths — know which one you're in):
+
+| Loader | Used by | Location |
+|--------|---------|----------|
+| `load_cli_config()` | CLI mode | `cli.py` — merges CLI-specific defaults + user YAML |
+| `load_config()` | `hermes tools`, `hermes setup`, most CLI subcommands | `hermes_cli/config.py` — merges `DEFAULT_CONFIG` + user YAML |
+| Direct YAML load | Gateway runtime | `gateway/run.py` + `gateway/config.py` — reads user YAML raw |
+
+If you add a new key and the CLI sees it but the gateway doesn't (or vice
+versa), you're on the wrong loader. Check `DEFAULT_CONFIG` coverage.
+
+### Working directory:
+- **CLI** — uses the process's current directory (`os.getcwd()`).
+- **Messaging** — uses `terminal.cwd` from `config.yaml`. The gateway bridges this
+  to the `TERMINAL_CWD` env var for child tools. **`MESSAGING_CWD` has been
+  removed** — the config loader prints a deprecation warning if it's set in
+  `.env`. Same for `TERMINAL_CWD` in `.env`; the canonical setting is
+  `terminal.cwd` in `config.yaml`.
+
+---
+
+## Skin/Theme System
+
+The skin engine (`hermes_cli/skin_engine.py`) provides data-driven CLI visual customization. Skins are **pure data** — no code changes needed to add a new skin.
+
+### Architecture
+
+```
+hermes_cli/skin_engine.py    # SkinConfig dataclass, built-in skins, YAML loader
+~/.hermes/skins/*.yaml       # User-installed custom skins (drop-in)
+```
+
+- `init_skin_from_config()` — called at CLI startup, reads `display.skin` from config
+- `get_active_skin()` — returns cached `SkinConfig` for the current skin
+- `set_active_skin(name)` — switches skin at runtime (used by `/skin` command)
+- `load_skin(name)` — loads from user skins first, then built-ins, then falls back to default
+- Missing skin values inherit from the `default` skin automatically
+
+### What skins customize
+
+| Element | Skin Key | Used By |
+|---------|----------|---------|
+| Banner panel border | `colors.banner_border` | `banner.py` |
+| Banner panel title | `colors.banner_title` | `banner.py` |
+| Banner section headers | `colors.banner_accent` | `banner.py` |
+| Banner dim text | `colors.banner_dim` | `banner.py` |
+| Banner body text | `colors.banner_text` | `banner.py` |
+| Response box border | `colors.response_border` | `cli.py` |
+| Spinner faces (waiting) | `spinner.waiting_faces` | `display.py` |
+| Spinner faces (thinking) | `spinner.thinking_faces` | `display.py` |
+| Spinner verbs | `spinner.thinking_verbs` | `display.py` |
+| Spinner wings (optional) | `spinner.wings` | `display.py` |
+| Tool output prefix | `tool_prefix` | `display.py` |
+| Per-tool emojis | `tool_emojis` | `display.py` → `get_tool_emoji()` |
+| Agent name | `branding.agent_name` | `banner.py`, `cli.py` |
+| Welcome message | `branding.welcome` | `cli.py` |
+| Response box label | `branding.response_label` | `cli.py` |
+| Prompt symbol | `branding.prompt_symbol` | `cli.py` |
+
+### Built-in skins
+
+- `default` — Classic Hermes gold/kawaii (the current look)
+- `ares` — Crimson/bronze war-god theme with custom spinner wings
+- `mono` — Clean grayscale monochrome
+- `slate` — Cool blue developer-focused theme
+
+### Adding a built-in skin
+
+Add to `_BUILTIN_SKINS` dict in `hermes_cli/skin_engine.py`:
+
+```python
+"mytheme": {
+    "name": "mytheme",
+    "description": "Short description",
+    "colors": { ... },
+    "spinner": { ... },
+    "branding": { ... },
+    "tool_prefix": "┊",
+},
+```
+
+### User skins (YAML)
+
+Users create `~/.hermes/skins/<name>.yaml`:
+
+```yaml
+name: cyberpunk
+description: Neon-soaked terminal theme
+
+colors:
+  banner_border: "#FF00FF"
+  banner_title: "#00FFFF"
+  banner_accent: "#FF1493"
+
+spinner:
+  thinking_verbs: ["jacking in", "decrypting", "uploading"]
+  wings:
+    - ["⟨⚡", "⚡⟩"]
+
+branding:
+  agent_name: "Cyber Agent"
+  response_label: " ⚡ Cyber "
+
+tool_prefix: "▏"
+```
+
+Activate with `/skin cyberpunk` or `display.skin: cyberpunk` in config.yaml.
+
+---
+
+## Plugins
+
+Hermes has two plugin surfaces. Both live under `plugins/` in the repo so
+repo-shipped plugins can be discovered alongside user-installed ones in
+`~/.hermes/plugins/` and pip-installed entry points.
+
+### General plugins (`hermes_cli/plugins.py` + `plugins/<name>/`)
+
+`PluginManager` discovers plugins from `~/.hermes/plugins/`, `./.hermes/plugins/`,
+and pip entry points. Each plugin exposes a `register(ctx)` function that
+can:
+
+- Register Python-callback lifecycle hooks:
+  `pre_tool_call`, `post_tool_call`, `pre_llm_call`, `post_llm_call`,
+  `on_session_start`, `on_session_end`
+- Register new tools via `ctx.register_tool(...)`
+- Register CLI subcommands via `ctx.register_cli_command(...)` — the
+  plugin's argparse tree is wired into `hermes` at startup so
+  `hermes <pluginname> <subcmd>` works with no change to `main.py`
+
+Hooks are invoked from `model_tools.py` (pre/post tool) and `run_agent.py`
+(lifecycle). **Discovery timing pitfall:** `discover_plugins()` only runs
+as a side effect of importing `model_tools.py`. Code paths that read plugin
+state without importing `model_tools.py` first must call `discover_plugins()`
+explicitly (it's idempotent).
+
+### Memory-provider plugins (`plugins/memory/<name>/`)
+
+Separate discovery system for pluggable memory backends. Current built-in
+providers include **honcho, mem0, supermemory, byterover, hindsight,
+holographic, openviking, retaindb**.
+
+Each provider implements the `MemoryProvider` ABC (see `agent/memory_provider.py`)
+and is orchestrated by `agent/memory_manager.py`. Lifecycle hooks include
+`sync_turn(turn_messages)`, `prefetch(query)`, `shutdown()`, and optional
+`post_setup(hermes_home, config)` for setup-wizard integration.
+
+**CLI commands via `plugins/memory/<name>/cli.py`:** if a memory plugin
+defines `register_cli(subparser)`, `discover_plugin_cli_commands()` finds
+it at argparse setup time and wires it into `hermes <plugin>`. The
+framework only exposes CLI commands for the **currently active** memory
+provider (read from `memory.provider` in config.yaml), so disabled
+providers don't clutter `hermes --help`.
+
+**Rule (Teknium, May 2026):** plugins MUST NOT modify core files
+(`run_agent.py`, `cli.py`, `gateway/run.py`, `hermes_cli/main.py`, etc.).
+If a plugin needs a capability the framework doesn't expose, expand the
+generic plugin surface (new hook, new ctx method) — never hardcode
+plugin-specific logic into core. PR #5295 removed 95 lines of hardcoded
+honcho argparse from `main.py` for exactly this reason.
+
+### Model-provider plugins (`plugins/model-providers/<name>/`)
+
+Every inference backend (openrouter, anthropic, gmi, deepseek, nvidia, …)
+ships as a plugin here. Each plugin's `__init__.py` calls
+`providers.register_provider(ProviderProfile(...))` at module load.
+`providers/__init__.py._discover_providers()` is a **lazy, separate
+discovery system** — scanned on first `get_provider_profile()` or
+`list_providers()` call, NOT by the general PluginManager.
+
+Scan order:
+1. Bundled: `<repo>/plugins/model-providers/<name>/`
+2. User: `$HERMES_HOME/plugins/model-providers/<name>/`
+3. Legacy: `<repo>/providers/<name>.py` (back-compat)
+
+User plugins of the same name override bundled ones — `register_provider()`
+is last-writer-wins. This lets third parties swap out any built-in
+profile without a repo patch.
+
+The general PluginManager records `kind: model-provider` manifests but does
+NOT import them (would double-instantiate `ProviderProfile`). Plugins
+without an explicit `kind:` get auto-coerced via a source-text heuristic
+(`register_provider` + `ProviderProfile` in `__init__.py`).
+
+Full authoring guide: `website/docs/developer-guide/model-provider-plugin.md`.
+
+### Dashboard / context-engine / image-gen plugin directories
+
+`plugins/context_engine/`, `plugins/image_gen/`, etc. follow the same
+pattern (ABC + orchestrator + per-plugin directory). Context engines
+plug into `agent/context_engine.py`; image-gen providers into
+`agent/image_gen_provider.py`. Reference / docs-companion plugins
+(`example-dashboard`, `strike-freedom-cockpit`, `plugin-llm-example`,
+`plugin-llm-async-example`) live in the
+[`hermes-example-plugins`](https://github.com/NousResearch/hermes-example-plugins)
+companion repo, not in this tree.
+
+---
+
+## Skills
+
+Two parallel surfaces:
+
+- **`skills/`** — built-in skills shipped and loadable by default.
+  Organized by category directories (e.g. `skills/github/`, `skills/mlops/`).
+- **`optional-skills/`** — heavier or niche skills shipped with the repo but
+  NOT active by default. Installed explicitly via
+  `hermes skills install official/<category>/<skill>`. Adapter lives in
+  `tools/skills_hub.py` (`OptionalSkillSource`). Categories include
+  `autonomous-ai-agents`, `blockchain`, `communication`, `creative`,
+  `devops`, `email`, `health`, `mcp`, `migration`, `mlops`, `productivity`,
+  `research`, `security`, `web-development`.
+
+When reviewing skill PRs, check which directory they target — heavy-dep or
+niche skills belong in `optional-skills/`.
+
+### SKILL.md frontmatter
+
+Standard fields: `name`, `description`, `version`, `author`, `license`,
+`platforms` (OS-gating list: `[macos]`, `[linux, macos]`, ...),
+`metadata.hermes.tags`, `metadata.hermes.category`,
+`metadata.hermes.related_skills`, `metadata.hermes.config` (config.yaml
+settings the skill needs — stored under `skills.config.<key>`, prompted
+during setup, injected at load time).
+
+Top-level `tags:` and `category:` are also accepted and mirrored from
+`metadata.hermes.*` by the loader.
+
+---
+
+## Toolsets
+
+All toolsets are defined in `toolsets.py` as a single `TOOLSETS` dict.
+Each platform's adapter picks a base toolset (e.g. Telegram uses
+`"messaging"`); `_HERMES_CORE_TOOLS` is the default bundle most
+platforms inherit from.
+
+Current toolset keys: `browser`, `clarify`, `code_execution`, `cronjob`,
+`debugging`, `delegation`, `discord`, `discord_admin`, `feishu_doc`,
+`feishu_drive`, `file`, `homeassistant`, `image_gen`, `kanban`, `memory`,
+`messaging`, `moa`, `rl`, `safe`, `search`, `session_search`, `skills`,
+`spotify`, `terminal`, `todo`, `tts`, `video`, `vision`, `web`, `yuanbao`.
+
+Enable/disable per platform via `hermes tools` (the curses UI) or the
+`tools.<platform>.enabled` / `tools.<platform>.disabled` lists in
+`config.yaml`.
+
+---
+
+## Delegation (`delegate_task`)
+
+`tools/delegate_tool.py` spawns a subagent with an isolated
+context + terminal session. Synchronous: the parent waits for the
+child's summary before continuing its own loop — if the parent is
+interrupted, the child is cancelled.
+
+Two shapes:
+
+- **Single:** pass `goal` (+ optional `context`, `toolsets`).
+- **Batch (parallel):** pass `tasks: [...]` — each gets its own subagent
+  running concurrently. Concurrency is capped by
+  `delegation.max_concurrent_children` (default 3).
+
+Roles:
+
+- `role="leaf"` (default) — focused worker. Cannot call `delegate_task`,
+  `clarify`, `memory`, `send_message`, `execute_code`.
+- `role="orchestrator"` — retains `delegate_task` so it can spawn its
+  own workers. Gated by `delegation.orchestrator_enabled` (default true)
+  and bounded by `delegation.max_spawn_depth` (default 2).
+
+Key config knobs (under `delegation:` in `config.yaml`):
+`max_concurrent_children`, `max_spawn_depth`, `child_timeout_seconds`,
+`orchestrator_enabled`, `subagent_auto_approve`, `inherit_mcp_toolsets`,
+`max_iterations`.
+
+Synchronicity rule: delegate_task is **not** durable. For long-running
+work that must outlive the current turn, use `cronjob` or
+`terminal(background=True, notify_on_complete=True)` instead.
+
+---
+
+## Curator (skill lifecycle)
+
+Background skill-maintenance system that tracks usage on agent-created
+skills and auto-archives stale ones. Users never lose skills; archives
+go to `~/.hermes/skills/.archive/` and are restorable.
+
+- **Core:** `agent/curator.py` (review loop, auto-transitions, LLM review
+  prompt) + `agent/curator_backup.py` (pre-run tar.gz snapshots).
+- **CLI:** `hermes_cli/curator.py` wires `hermes curator <verb>` where
+  verbs are: `status`, `run`, `pause`, `resume`, `pin`, `unpin`,
+  `archive`, `restore`, `prune`, `backup`, `rollback`.
+- **Telemetry:** `tools/skill_usage.py` owns the sidecar
+  `~/.hermes/skills/.usage.json` — per-skill `use_count`, `view_count`,
+  `patch_count`, `last_activity_at`, `state` (active / stale /
+  archived), `pinned`.
+
+Invariants:
+- Curator only touches skills with `created_by: "agent"` provenance —
+  bundled + hub-installed skills are off-limits.
+- Never deletes; max destructive action is archive.
+- Pinned skills are exempt from every auto-transition and from the
+  LLM review pass.
+- `skill_manage(action="delete")` refuses pinned skills; patch/edit/
+  write_file/remove_file go through so the agent can keep improving
+  pinned skills.
+
+Config section (`curator:` in `config.yaml`):
+`enabled`, `interval_hours`, `min_idle_hours`, `stale_after_days`,
+`archive_after_days`, `backup.*`.
+
+Full user-facing docs: `website/docs/user-guide/features/curator.md`.
+
+---
+
+## Cron (scheduled jobs)
+
+`cron/jobs.py` (job store) + `cron/scheduler.py` (tick loop). Agents
+schedule jobs via the `cronjob` tool; users via `hermes cron <verb>`
+(`list`, `add`, `edit`, `pause`, `resume`, `run`, `remove`) or the
+`/cron` slash command.
+
+Supported schedule formats:
+- Duration: `"30m"`, `"2h"`, `"1d"`
+- "every" phrase: `"every 2h"`, `"every monday 9am"`
+- 5-field cron expression: `"0 9 * * *"`
+- ISO timestamp (one-shot): `"2026-06-01T09:00:00Z"`
+
+Per-job fields include `skills` (load specific skills), `model` /
+`provider` overrides, `script` (pre-run data-collection script whose
+stdout is injected into the prompt; `no_agent=True` turns the script
+into the entire job), `context_from` (chain job A's last output into
+job B's prompt), `workdir` (run in a specific directory with its
+`AGENTS.md`/`CLAUDE.md` loaded), and multi-platform delivery.
+
+Hardening invariants:
+- **3-minute hard interrupt** on cron sessions — runaway agent loops
+  cannot monopolize the scheduler.
+- Catchup window: half the job's period, clamped to 120s–2h.
+- Grace window: 120s for one-shot jobs whose fire time was missed.
+- File lock at `~/.hermes/cron/.tick.lock` prevents duplicate ticks
+  across processes.
+- Cron sessions pass `skip_memory=True` by default; memory providers
+  intentionally do not run during cron.
+
+Cron deliveries are **not** mirrored into the target gateway session —
+they land in their own cron session with a header/footer frame so the
+main conversation's message-role alternation stays intact.
+
+---
+
+## Kanban (multi-agent work queue)
+
+Durable SQLite-backed board that lets multiple profiles / workers
+collaborate on shared tasks. Users drive it via `hermes kanban <verb>`;
+workers spawned by the dispatcher drive it via a dedicated `kanban_*`
+toolset so their schema footprint is zero when they're not inside a
+kanban task.
+
+- **CLI:** `hermes_cli/kanban.py` wires `hermes kanban` with verbs
+  `init`, `create`, `list` (alias `ls`), `show`, `assign`, `link`,
+  `unlink`, `comment`, `complete`, `block`, `unblock`, `archive`,
+  `tail`, plus less-commonly-used `watch`, `stats`, `runs`, `log`,
+  `assignees`, `heartbeat`, `notify-*`, `dispatch`, `daemon`, `gc`.
+- **Worker toolset:** `tools/kanban_tools.py` exposes `kanban_show`,
+  `kanban_complete`, `kanban_block`, `kanban_heartbeat`, `kanban_comment`,
+  `kanban_create`, `kanban_link` — gated by `HERMES_KANBAN_TASK` so
+  the schema only appears for processes actually running as a worker.
+- **Dispatcher:** long-lived loop that (default every 60s) reclaims
+  stale claims, promotes ready tasks, atomically claims, and spawns
+  assigned profiles. Runs **inside the gateway** by default via
+  `kanban.dispatch_in_gateway: true`.
+- **Plugin assets:** `plugins/kanban/dashboard/` (web UI) +
+  `plugins/kanban/systemd/` (`hermes-kanban-dispatcher.service` for
+  standalone dispatcher deployment).
+
+Isolation model:
+- **Board** is the hard boundary — workers are spawned with
+  `HERMES_KANBAN_BOARD` pinned in their env so they can't see other
+  boards.
+- **Tenant** is a soft namespace *within* a board — one specialist
+  fleet can serve multiple businesses with workspace-path + memory-key
+  isolation.
+- After ~5 consecutive spawn failures on the same task the dispatcher
+  auto-blocks it to prevent spin loops.
+
+Full user-facing docs: `website/docs/user-guide/features/kanban.md`.
+
+---
+
+## Important Policies
+
+### Prompt Caching Must Not Break
+
+Hermes-Agent ensures caching remains valid throughout a conversation. **Do NOT implement changes that would:**
+- Alter past context mid-conversation
+- Change toolsets mid-conversation
+- Reload memories or rebuild system prompts mid-conversation
+
+Cache-breaking forces dramatically higher costs. The ONLY time we alter context is during context compression.
+
+Slash commands that mutate system-prompt state (skills, tools, memory, etc.)
+must be **cache-aware**: default to deferred invalidation (change takes
+effect next session), with an opt-in `--now` flag for immediate
+invalidation. See `/skills install --now` for the canonical pattern.
+
+### Background Process Notifications (Gateway)
+
+When `terminal(background=true, notify_on_complete=true)` is used, the gateway runs a watcher that
+detects process completion and triggers a new agent turn. Control verbosity of background process
+messages with `display.background_process_notifications`
+in config.yaml (or `HERMES_BACKGROUND_NOTIFICATIONS` env var):
+
+- `all` — running-output updates + final message (default)
+- `result` — only the final completion message
+- `error` — only the final message when exit code != 0
+- `off` — no watcher messages at all
+
+---
+
+## Profiles: Multi-Instance Support
+
+Hermes supports **profiles** — multiple fully isolated instances, each with its own
+`HERMES_HOME` directory (config, API keys, memory, sessions, skills, gateway, etc.).
+
+The core mechanism: `_apply_profile_override()` in `hermes_cli/main.py` sets
+`HERMES_HOME` before any module imports. All `get_hermes_home()` references
+automatically scope to the active profile.
+
+### Rules for profile-safe code
+
+1. **Use `get_hermes_home()` for all HERMES_HOME paths.** Import from `hermes_constants`.
+   NEVER hardcode `~/.hermes` or `Path.home() / ".hermes"` in code that reads/writes state.
+   ```python
+   # GOOD
+   from hermes_constants import get_hermes_home
+   config_path = get_hermes_home() / "config.yaml"
+
+   # BAD — breaks profiles
+   config_path = Path.home() / ".hermes" / "config.yaml"
+   ```
+
+2. **Use `display_hermes_home()` for user-facing messages.** Import from `hermes_constants`.
+   This returns `~/.hermes` for default or `~/.hermes/profiles/<name>` for profiles.
+   ```python
+   # GOOD
+   from hermes_constants import display_hermes_home
+   print(f"Config saved to {display_hermes_home()}/config.yaml")
+
+   # BAD — shows wrong path for profiles
+   print("Config saved to ~/.hermes/config.yaml")
+   ```
+
+3. **Module-level constants are fine** — they cache `get_hermes_home()` at import time,
+   which is AFTER `_apply_profile_override()` sets the env var. Just use `get_hermes_home()`,
+   not `Path.home() / ".hermes"`.
+
+4. **Tests that mock `Path.home()` must also set `HERMES_HOME`** — since code now uses
+   `get_hermes_home()` (reads env var), not `Path.home() / ".hermes"`:
+   ```python
+   with patch.object(Path, "home", return_value=tmp_path), \
+        patch.dict(os.environ, {"HERMES_HOME": str(tmp_path / ".hermes")}):
+       ...
+   ```
+
+5. **Gateway platform adapters should use token locks** — if the adapter connects with
+   a unique credential (bot token, API key), call `acquire_scoped_lock()` from
+   `gateway.status` in the `connect()`/`start()` method and `release_scoped_lock()` in
+   `disconnect()`/`stop()`. This prevents two profiles from using the same credential.
+   See `gateway/platforms/telegram.py` for the canonical pattern.
+
+6. **Profile operations are HOME-anchored, not HERMES_HOME-anchored** — `_get_profiles_root()`
+   returns `Path.home() / ".hermes" / "profiles"`, NOT `get_hermes_home() / "profiles"`.
+   This is intentional — it lets `hermes -p coder profile list` see all profiles regardless
+   of which one is active.
+
+## Known Pitfalls
+
+### DO NOT hardcode `~/.hermes` paths
+Use `get_hermes_home()` from `hermes_constants` for code paths. Use `display_hermes_home()`
+for user-facing print/log messages. Hardcoding `~/.hermes` breaks profiles — each profile
+has its own `HERMES_HOME` directory. This was the source of 5 bugs fixed in PR #3575.
+
+### DO NOT introduce new `simple_term_menu` usage
+Existing call sites in `hermes_cli/main.py` remain for legacy fallback only;
+the preferred UI is curses (stdlib) because `simple_term_menu` has
+ghost-duplication rendering bugs in tmux/iTerm2 with arrow keys. New
+interactive menus must use `hermes_cli/curses_ui.py` — see
+`hermes_cli/tools_config.py` for the canonical pattern.
+
+### DO NOT use `\033[K` (ANSI erase-to-EOL) in spinner/display code
+Leaks as literal `?[K` text under `prompt_toolkit`'s `patch_stdout`. Use space-padding: `f"\r{line}{' ' * pad}"`.
+
+### `_last_resolved_tool_names` is a process-global in `model_tools.py`
+`_run_single_child()` in `delegate_tool.py` saves and restores this global around subagent execution. If you add new code that reads this global, be aware it may be temporarily stale during child agent runs.
+
+### DO NOT hardcode cross-tool references in schema descriptions
+Tool schema descriptions must not mention tools from other toolsets by name (e.g., `browser_navigate` saying "prefer web_search"). Those tools may be unavailable (missing API keys, disabled toolset), causing the model to hallucinate calls to non-existent tools. If a cross-reference is needed, add it dynamically in `get_tool_definitions()` in `model_tools.py` — see the `browser_navigate` / `execute_code` post-processing blocks for the pattern.
+
+### The gateway has TWO message guards — both must bypass approval/control commands
+When an agent is running, messages pass through two sequential guards:
+(1) **base adapter** (`gateway/platforms/base.py`) queues messages in
+`_pending_messages` when `session_key in self._active_sessions`, and
+(2) **gateway runner** (`gateway/run.py`) intercepts `/stop`, `/new`,
+`/queue`, `/status`, `/approve`, `/deny` before they reach
+`running_agent.interrupt()`. Any new command that must reach the runner
+while the agent is blocked (e.g. approval prompts) MUST bypass BOTH
+guards and be dispatched inline, not via `_process_message_background()`
+(which races session lifecycle).
+
+### Squash merges from stale branches silently revert recent fixes
+Before squash-merging a PR, ensure the branch is up to date with `main`
+(`git fetch origin main && git reset --hard origin/main` in the worktree,
+then re-apply the PR's commits). A stale branch's version of an unrelated
+file will silently overwrite recent fixes on main when squashed. Verify
+with `git diff HEAD~1..HEAD` after merging — unexpected deletions are a
+red flag.
+
+### Don't wire in dead code without E2E validation
+Unused code that was never shipped was dead for a reason. Before wiring an
+unused module into a live code path, E2E test the real resolution chain
+with actual imports (not mocks) against a temp `HERMES_HOME`.
+
+### Tests must not write to `~/.hermes/`
+The `_isolate_hermes_home` autouse fixture in `tests/conftest.py` redirects `HERMES_HOME` to a temp dir. Never hardcode `~/.hermes/` paths in tests.
+
+**Profile tests**: When testing profile features, also mock `Path.home()` so that
+`_get_profiles_root()` and `_get_default_hermes_home()` resolve within the temp dir.
+Use the pattern from `tests/hermes_cli/test_profiles.py`:
+```python
+@pytest.fixture
+def profile_env(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    return home
+```
+
+---
+
+## Testing
+
+**ALWAYS use `scripts/run_tests.sh`** — do not call `pytest` directly. The script enforces
+hermetic environment parity with CI (unset credential vars, TZ=UTC, LANG=C.UTF-8,
+4 xdist workers matching GHA ubuntu-latest). Direct `pytest` on a 16+ core
+developer machine with API keys set diverges from CI in ways that have caused
+multiple "works locally, fails in CI" incidents (and the reverse).
+
+```bash
+scripts/run_tests.sh                                  # full suite, CI-parity
+scripts/run_tests.sh tests/gateway/                   # one directory
+scripts/run_tests.sh tests/agent/test_foo.py::test_x  # one test
+scripts/run_tests.sh -v --tb=long                     # pass-through pytest flags
+```
+
+### Why the wrapper (and why the old "just call pytest" doesn't work)
+
+Five real sources of local-vs-CI drift the script closes:
+
+| | Without wrapper | With wrapper |
+|---|---|---|
+| Provider API keys | Whatever is in your env (auto-detects pool) | All `*_API_KEY`/`*_TOKEN`/etc. unset |
+| HOME / `~/.hermes/` | Your real config+auth.json | Temp dir per test |
+| Timezone | Local TZ (PDT etc.) | UTC |
+| Locale | Whatever is set | C.UTF-8 |
+| xdist workers | `-n auto` = all cores (20+ on a workstation) | `-n 4` matching CI |
+
+`tests/conftest.py` also enforces points 1-4 as an autouse fixture so ANY pytest
+invocation (including IDE integrations) gets hermetic behavior — but the wrapper
+is belt-and-suspenders.
+
+### Running without the wrapper (only if you must)
+
+If you can't use the wrapper (e.g. on Windows or inside an IDE that shells
+pytest directly), at minimum activate the venv and pass `-n 4`:
+
+```bash
+source .venv/bin/activate   # or: source venv/bin/activate
+python -m pytest tests/ -q -n 4
+```
+
+Worker count above 4 will surface test-ordering flakes that CI never sees.
+
+Always run the full suite before pushing changes.
+
+### Don't write change-detector tests
+
+A test is a **change-detector** if it fails whenever data that is **expected
+to change** gets updated — model catalogs, config version numbers,
+enumeration counts, hardcoded lists of provider models. These tests add no
+behavioral coverage; they just guarantee that routine source updates break
+CI and cost engineering time to "fix."
+
+**Do not write:**
+
+```python
+# catalog snapshot — breaks every model release
+assert "gemini-2.5-pro" in _PROVIDER_MODELS["gemini"]
+assert "MiniMax-M2.7" in models
+
+# config version literal — breaks every schema bump
+assert DEFAULT_CONFIG["_config_version"] == 21
+
+# enumeration count — breaks every time a skill/provider is added
+assert len(_PROVIDER_MODELS["huggingface"]) == 8
+```
+
+**Do write:**
+
+```python
+# behavior: does the catalog plumbing work at all?
+assert "gemini" in _PROVIDER_MODELS
+assert len(_PROVIDER_MODELS["gemini"]) >= 1
+
+# behavior: does migration bump the user's version to current latest?
+assert raw["_config_version"] == DEFAULT_CONFIG["_config_version"]
+
+# invariant: no plan-only model leaks into the legacy list
+assert not (set(moonshot_models) & coding_plan_only_models)
+
+# invariant: every model in the catalog has a context-length entry
+for m in _PROVIDER_MODELS["huggingface"]:
+    assert m.lower() in DEFAULT_CONTEXT_LENGTHS_LOWER
+```
+
+The rule: if the test reads like a snapshot of current data, delete it. If
+it reads like a contract about how two pieces of data must relate, keep it.
+When a PR adds a new provider/model and you want a test, make the test
+assert the relationship (e.g. "catalog entries all have context lengths"),
+not the specific names.
+
+Reviewers should reject new change-detector tests; authors should convert
+them into invariants before re-requesting review.

--- a/docs/audits/agent-swarms-workspace-audit.md
+++ b/docs/audits/agent-swarms-workspace-audit.md
@@ -1,0 +1,319 @@
+# Agent Swarms Workspace Audit
+
+Date: 2026-05-12
+Audited root: `/Users/officemacmini/.hermes/hermes-agent`
+
+I treated the current Hermes Agent checkout as the "agent swarms workspace" because no dedicated `agent-swarms` directory exists under `~/.hermes/projects` or the current repo, and this session is running from the Hermes Agent workspace.
+
+## Coverage
+
+Scanned the repository excluding common dependency/runtime directories: `.git`, `venv`, `.venv`, `node_modules`, `__pycache__`, `.pytest_cache`, `.mypy_cache`, `.ruff_cache`, `dist`, `build`, `.next`, and `coverage`.
+
+- Files counted: 3,355
+- Text files read: 3,168
+- Source summary: 3,142 files, 1,240,676 lines
+- Tests counted: 1,064
+- Skill files: 167
+- Hook-related files: 62
+- Guardrail/security-related files: 60
+- Harness/test/eval-related files: 1,146
+
+Top-level file distribution:
+
+- `tests`: 1,057 files
+- `skills`: 532 files
+- `website`: 367 files
+- `ui-tui`: 318 files
+- `optional-skills`: 255 files
+- `plugins`: 159 files
+- `web`: 112 files
+- `tools`: 103 files
+- `hermes_cli`: 96 files
+- `gateway`: 63 files
+- `agent`: 60 files
+
+## Verification run
+
+Targeted guardrail harness passed:
+
+```txt
+python -m pytest \
+  tests/agent/test_tool_guardrails.py \
+  tests/tools/test_tirith_security.py \
+  tests/tools/test_approval.py \
+  tests/agent/test_shell_hooks_consent.py \
+  tests/agent/test_prompt_builder.py \
+  -q -o 'addopts='
+
+373 passed, 1 skipped in 2.24s
+```
+
+## Key findings
+
+### 1. High: client-specific Charity Charge assets are sitting untracked in the core Hermes repo
+
+Evidence from `git status --short`:
+
+```txt
+?? charity-charge-brand.zip
+?? charity-charge-brand/
+```
+
+Evidence from size/listing:
+
+```txt
+136K charity-charge-brand
+80K  charity-charge-brand.zip
+16 files under charity-charge-brand/
+```
+
+Why this matters:
+
+- This is project-specific context living inside the global Hermes Agent source tree.
+- It risks accidental commit, accidental context loading during repo work, and confusing future agents about whether Charity Charge is part of core Hermes.
+- It duplicates the separate dedicated Charity Charge workspace pattern already present under `~/.hermes/projects/charity-charge`.
+
+Recommended fix:
+
+- Move `charity-charge-brand/` and `charity-charge-brand.zip` out of this repo, ideally into `/Users/officemacmini/.hermes/projects/charity-charge/brand-kit/` if not already there.
+- Add a repo-level ignore for `charity-charge-brand/` and `charity-charge-brand.zip` if they may recur.
+
+### 2. Medium-high: `AGENTS.md` is useful but too large to be a default always-loaded context file
+
+Evidence:
+
+- `AGENTS.md`: 989 lines, 45,991 bytes.
+- It contains valuable contributor guidance, but it is broad enough that every repo-scoped agent run pays a context tax before knowing which subsystem matters.
+
+What is good:
+
+- It identifies load-bearing files and architecture.
+- It explicitly says the filesystem is canonical, avoiding stale tree reliance.
+- It includes critical safety notes around config/secrets and tool usage.
+
+Risk:
+
+- Default context injection of a nearly 1,000-line file increases token usage and raises the chance that unrelated subsystem guidance competes with task-specific instructions.
+
+Recommended fix:
+
+- Keep `AGENTS.md`, but slim the default file to a 150-250 line routing map.
+- Move long subsystem guidance into `docs/agent-guides/*.md` or `references/*.md`.
+- Add a small "load these when needed" table at the top.
+
+### 3. Medium: guardrails exist, but hard loop-stops are disabled in live config
+
+Current config snapshot:
+
+```json
+{
+  "tool_loop_guardrails": {
+    "warnings_enabled": true,
+    "hard_stop_enabled": false,
+    "warn_after": {
+      "exact_failure": 2,
+      "same_tool_failure": 3,
+      "idempotent_no_progress": 2
+    },
+    "hard_stop_after": {
+      "exact_failure": 5,
+      "same_tool_failure": 8,
+      "idempotent_no_progress": 5
+    }
+  }
+}
+```
+
+Code evidence:
+
+- `agent/tool_guardrails.py` implements warning and hard-stop decisions.
+- `hard_stop_enabled` gates the actual blocking behavior.
+
+Risk:
+
+- Warnings reduce wasted tokens only if the model listens. Hard stops are the actual circuit breaker against repeated failed/no-progress tool loops.
+
+Recommended fix:
+
+- For Discord and long-running gateway contexts, enable hard stops after a short soak period:
+
+```bash
+hermes config set tool_loop_guardrails.hard_stop_enabled true
+```
+
+- Keep thresholds as currently configured unless testing shows false positives.
+
+### 4. Medium: agent-created skill scanning is available but disabled
+
+Current config snapshot:
+
+```json
+{
+  "skills": {
+    "guard_agent_created": false,
+    "inline_shell": false,
+    "external_dirs": [],
+    "disabled": []
+  }
+}
+```
+
+Code evidence:
+
+- `tools/skills_guard.py` contains a strong threat scanner for exfiltration, prompt injection, destructive commands, persistence, network tunnels, obfuscation, etc.
+- It notes `agent-created` behavior is only active when `skills.guard_agent_created` is enabled.
+
+Risk:
+
+- Agent-authored skills can become persistent instructions and tool recipes. If a bad or bloated procedure is saved, it can re-enter future sessions.
+- External skill install is guarded, but local agent-created skills are the place where accidental bloat and hidden context most often creep in.
+
+Recommended fix:
+
+```bash
+hermes config set skills.guard_agent_created true
+```
+
+### 5. Medium: Tirith security is enabled but fail-open
+
+Current config snapshot:
+
+```json
+{
+  "security": {
+    "redact_secrets": true,
+    "tirith_enabled": true,
+    "tirith_fail_open": true
+  }
+}
+```
+
+What is good:
+
+- Secret redaction is on.
+- Tirith is enabled.
+- Approval mode is manual and cron mode is deny.
+
+Risk:
+
+- `tirith_fail_open: true` means a failure in the security classifier allows execution instead of blocking. That is good for availability, weaker for high-risk automation.
+
+Recommended fix:
+
+- If this workspace is used for autonomous / multi-agent runs, consider fail-closed for safer operations:
+
+```bash
+hermes config set security.tirith_fail_open false
+```
+
+- If availability matters more than strict blocking, keep fail-open but add a periodic `hermes doctor` or startup check that confirms Tirith is reachable.
+
+### 6. Medium: Discord toolset is broad, which is powerful but token-heavy
+
+Current Discord platform toolsets include:
+
+```txt
+browser, clarify, code_execution, computer_use, cronjob, delegation, file,
+image_gen, kanban, memory, messaging, session_search, skills, terminal,
+todo, tts, vision, web
+```
+
+Risk:
+
+- This is maximum-capability mode. It is great for Salty's operator style, but it increases tool schema footprint and the chance of expensive exploratory behavior.
+
+Recommended fix:
+
+- Keep broad tools for `#chat` if desired.
+- For project-specific channels or worker profiles, use narrower profiles/toolsets.
+- For cron jobs, continue using job-level `enabled_toolsets`; the repo has support for it and documentation in `cron/jobs.py` and `cron/scheduler.py`.
+
+### 7. Low-medium: optional skills contain massive reference files
+
+Largest text/context-relevant files:
+
+- `optional-skills/mlops/training/unsloth/references/llms-full.md`: 16,800 lines, 1.08 MB
+- `optional-skills/mlops/training/unsloth/references/llms-txt.md`: 12,045 lines, 813 KB
+- `optional-skills/mlops/training/axolotl/references/api.md`: 5,549 lines
+- `optional-skills/mlops/pytorch-fsdp/references/other.md`: 4,262 lines
+
+What is good:
+
+- They live in `optional-skills`, not active default skills.
+- Supporting files are not injected automatically by slash skill invocation; they are listed and loaded on demand via `skill_view(file_path=...)`.
+
+Risk:
+
+- If a skill tells the agent to read entire reference files, it can waste a lot of context quickly.
+
+Recommended fix:
+
+- Add or enforce a convention in large optional skills: every huge reference should have a short `references/index.md` or `references/summary.md` with routing instructions.
+- Prefer chunked `read_file(offset, limit)` reads for these files.
+
+### 8. Low: built dashboard/static assets are correctly ignored, but present in the working tree
+
+Large present files include:
+
+- `hermes_cli/web_dist/assets/index-CKodqInF.js`: 1.56 MB
+- `hermes_cli/web_dist/ds-assets/filler-bg0.jpg`: 3.87 MB
+- `web/public/ds-assets/filler-bg0.jpg`: 3.87 MB
+
+What is good:
+
+- `.gitignore` excludes `hermes_cli/web_dist/`, `web/public/fonts/`, and `web/public/ds-assets/`.
+
+Risk:
+
+- Low repo risk, but they can pollute naive file scans if tools do not honor ignore rules.
+
+Recommended fix:
+
+- Audit scripts and agents should skip ignored/generated asset dirs by default.
+
+## Guardrail and harness inventory
+
+Present and healthy:
+
+- Context injection scanner in `agent/prompt_builder.py` blocks suspicious `AGENTS.md`, `.cursorrules`, and similar context-file patterns.
+- Tool-use enforcement and execution discipline are injected for GPT/Codex/Gemini/Gemma/Grok-like models.
+- Tool loop guardrail controller exists in `agent/tool_guardrails.py`.
+- Shell hooks are consent-gated via `~/.hermes/shell-hooks-allowlist.json` and run with `shell=False`.
+- Skill guard exists in `tools/skills_guard.py`.
+- Approval mode is manual, cron approvals deny by default.
+- Secret redaction is enabled.
+- Context compression is enabled with `threshold=0.5`, `target_ratio=0.2`, `protect_last_n=20`, and `hygiene_hard_message_limit=400`.
+- Cron supports per-job `enabled_toolsets`, `workdir`, `no_agent`, and disables recursive cron/messaging/clarify in agent jobs.
+
+Needs tightening:
+
+- Enable `tool_loop_guardrails.hard_stop_enabled`.
+- Enable `skills.guard_agent_created`.
+- Decide whether Tirith should fail-closed for this workspace.
+- Remove client-specific untracked Charity Charge files from the Hermes repo.
+- Slim default `AGENTS.md` to a routing map.
+
+## Prioritized fix list
+
+### P0, do now
+
+1. Move or delete untracked `charity-charge-brand/` and `charity-charge-brand.zip` from the Hermes Agent repo.
+2. Add ignore rules for those exact paths if they may be regenerated.
+
+### P1, next
+
+3. Enable agent-created skill guard:
+   `hermes config set skills.guard_agent_created true`
+4. Enable tool loop hard stops:
+   `hermes config set tool_loop_guardrails.hard_stop_enabled true`
+5. Slim `AGENTS.md` default load path and move detail to referenced docs.
+
+### P2, soon
+
+6. Add summaries/indexes to large optional-skill reference directories.
+7. Add a workspace audit script under `scripts/` that produces this inventory automatically and honors skip dirs.
+8. Consider `security.tirith_fail_open false` for autonomous worker profiles.
+
+## Bottom line
+
+The workspace has real guardrails and test coverage. The most important issues are not missing safety infrastructure; they are operational hygiene: client context accidentally sitting in the core repo, large always-loaded guidance, and two protective switches that exist but are not fully engaged.

--- a/scripts/bulk_rename_discord_threads.py
+++ b/scripts/bulk_rename_discord_threads.py
@@ -1,0 +1,438 @@
+#!/usr/bin/env python3
+"""Bulk-rename accessible Discord threads to short content descriptors.
+
+Uses the configured DISCORD_BOT_TOKEN but never prints it. The script:
+- discovers guilds/channels visible to the bot
+- collects active + archived public/private threads
+- samples recent/oldest thread messages for content
+- derives a short descriptor using Hermes' Discord title heuristic
+- PATCHes thread names via Discord REST
+- records renamed thread IDs in ~/.hermes/discord_auto_renamed_threads.json
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import re
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import aiohttp
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from hermes_cli.env_loader import load_hermes_dotenv  # noqa: E402
+from hermes_cli.config import get_hermes_home  # noqa: E402
+from gateway.platforms.discord import DiscordAdapter  # noqa: E402
+
+API_BASE = "https://discord.com/api/v10"
+THREAD_TYPES = {10, 11, 12}  # news_public_thread, public_thread, private_thread
+PARENT_TYPES_WITH_THREADS = {0, 5, 15, 16}  # text, news, forum, media
+GENERIC_NAME_PATTERNS = [
+    re.compile(r"^new thread$", re.I),
+    re.compile(r"^thread$", re.I),
+    re.compile(r"^chat$", re.I),
+    re.compile(r"^miso chat$", re.I),
+    re.compile(r"^hermes chat$", re.I),
+    re.compile(r"^help$", re.I),
+    re.compile(r"^question$", re.I),
+    re.compile(r"^untitled", re.I),
+]
+
+
+@dataclass
+class ThreadInfo:
+    id: str
+    name: str
+    parent_id: str | None = None
+    guild_id: str | None = None
+    parent_name: str | None = None
+    category_name: str | None = None
+    archived: bool = False
+
+
+class DiscordREST:
+    def __init__(self, token: str, *, verbose: bool = False):
+        self.token = token
+        self.verbose = verbose
+        self.session: aiohttp.ClientSession | None = None
+
+    async def __aenter__(self):
+        self.session = aiohttp.ClientSession(
+            headers={
+                "Authorization": f"Bot {self.token}",
+                "User-Agent": "HermesThreadRenamer/1.0",
+                "Content-Type": "application/json",
+            }
+        )
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        if self.session:
+            await self.session.close()
+
+    async def request(self, method: str, path: str, **kwargs) -> Any:
+        assert self.session is not None
+        url = f"{API_BASE}{path}"
+        for attempt in range(6):
+            async with self.session.request(method, url, **kwargs) as resp:
+                text = await resp.text()
+                if resp.status == 429:
+                    try:
+                        data = json.loads(text)
+                        delay = float(data.get("retry_after", 1.0))
+                    except Exception:
+                        delay = float(resp.headers.get("Retry-After", "1"))
+                    await asyncio.sleep(delay + 0.15)
+                    continue
+                if resp.status in {500, 502, 503, 504} and attempt < 5:
+                    await asyncio.sleep(1 + attempt)
+                    continue
+                if resp.status == 204:
+                    return None
+                if 200 <= resp.status < 300:
+                    return json.loads(text) if text else None
+                raise RuntimeError(f"{method} {path} -> HTTP {resp.status}: {text[:500]}")
+        raise RuntimeError(f"{method} {path} exhausted retries")
+
+    async def get(self, path: str) -> Any:
+        return await self.request("GET", path)
+
+    async def patch(self, path: str, payload: dict[str, Any], reason: str) -> Any:
+        headers = {"X-Audit-Log-Reason": reason[:512]}
+        return await self.request("PATCH", path, json=payload, headers=headers)
+
+
+def load_token() -> str:
+    load_hermes_dotenv()
+    token = os.getenv("DISCORD_BOT_TOKEN", "").strip()
+    if not token:
+        raise SystemExit("DISCORD_BOT_TOKEN is not configured in environment/.env")
+    return token
+
+
+def normalize_title(name: str) -> str:
+    name = re.sub(r"\s+", " ", name or "").strip()
+    name = name[:80].strip(" -_")
+    return name or "Hermes Chat"
+
+
+def is_generic_name(name: str) -> bool:
+    stripped = (name or "").strip()
+    lower = stripped.lower()
+    if any(p.search(stripped) for p in GENERIC_NAME_PATTERNS):
+        return True
+    if stripped.endswith("...") or len(stripped) >= 70:
+        return True
+    if re.match(r"^(hey|hi|hello)\s+miso\b", lower):
+        return True
+    if lower in {"rename all existing threads across", "review last message respond"}:
+        return True
+    return False
+
+
+def clean_content(text: str) -> str:
+    text = text or ""
+    text = re.sub(r"\[CONTEXT COMPACTION[^\]]*\].*", " ", text, flags=re.I | re.S)
+    text = re.sub(r"```.*?```", " ", text, flags=re.S)
+    text = re.sub(r"\[[^\]]+\]\s*", " ", text)  # Discord gateway sender prefixes like [Salty]
+    text = re.sub(r"\b(CONTEXT|Active Task|Completed Actions|Critical Context)\b.*", " ", text, flags=re.I | re.S)
+    text = re.sub(r"\s+", " ", text).strip()
+    return text
+
+
+def title_from_existing_thread_name(thread: ThreadInfo) -> str | None:
+    raw = (thread.name or "").strip()
+    if not raw:
+        return None
+    lower = raw.lower()
+    if lower == "rename all existing threads across":
+        return "Bulk Thread Rename"
+    if lower == "review last message respond":
+        return "Review Last Message"
+    if "agent status channel" in lower:
+        return "Agent Status Purpose"
+    if "daily briefing channel" in lower:
+        return "Daily Briefing Purpose"
+    if "decisions channel" in lower:
+        return "Decisions Purpose"
+    if "gpt 5.5 codex usage" in lower or "codex usage" in lower:
+        return "GPT 5.5 Codex Usage"
+    if "backup all of the files" in lower and "herm" in lower:
+        return "Hermes Backup"
+    if "lovable build prompt" in lower:
+        return "Lovable Build Skill"
+    if "new channel called skills" in lower:
+        return "Skills Channel Setup"
+    parent = (thread.parent_name or "").strip().replace("-", " ").replace("_", " ")
+    if parent and "purpose of this channel" in lower:
+        return normalize_title(f"{DiscordAdapter._derive_thread_descriptor(parent)} Purpose")
+
+    # Existing Discord auto-thread titles often contain the original prompt and
+    # get truncated with an ellipsis. The prompt is usually better than recent
+    # thread tail chatter, so clean it before falling back to messages.
+    if raw.endswith("...") or len(raw) >= 70 or re.match(r"^(hey|hi|hello)\b", lower):
+        text = raw.replace("…", "...").replace("’", "'").replace("‘", "'")
+        text = re.sub(r"\.\.\.$", "", text).strip()
+        text = re.sub(r"^(hey|hi|hello)\s+miso[,\s]*", "", text, flags=re.I)
+        text = re.sub(r"^(are you able to|can you|could you|please)\s+", "", text, flags=re.I)
+        text = re.sub(r"\bwhat('?s| is)\s+the\s+purpose\s+of\s+(the|this)\b", "", text, flags=re.I)
+        text = re.sub(r"\bwhat('?s| is)\b", "", text, flags=re.I)
+        text = re.sub(r"\bto make it useful\b", "", text, flags=re.I)
+        if text:
+            return normalize_title(DiscordAdapter._derive_thread_descriptor(text))
+    return None
+
+
+def derive_descriptor(thread: ThreadInfo, messages: list[dict[str, Any]]) -> str:
+    from_existing = title_from_existing_thread_name(thread)
+    if from_existing:
+        return from_existing
+
+    # Prefer human-authored content. If unavailable, fall back to existing name.
+    chunks: list[str] = []
+    for msg in messages:
+        author = msg.get("author") or {}
+        if author.get("bot"):
+            continue
+        content = clean_content(msg.get("content") or "")
+        if content:
+            chunks.append(content)
+    if not chunks:
+        for msg in messages:
+            content = clean_content(msg.get("content") or "")
+            if content:
+                chunks.append(content)
+    seed = " ".join(chunks[:2]) or thread.name
+    title = DiscordAdapter._derive_thread_descriptor(seed)
+    return normalize_title(title)
+
+
+async def paginate_archived(rest: DiscordREST, channel_id: str, kind: str) -> list[dict[str, Any]]:
+    # kind: public/private/joined_private
+    threads: list[dict[str, Any]] = []
+    before: str | None = None
+    while True:
+        suffix = f"/threads/archived/{kind}?limit=100"
+        if before:
+            suffix += f"&before={before}"
+        data = await rest.get(f"/channels/{channel_id}{suffix}")
+        batch = data.get("threads", []) if isinstance(data, dict) else []
+        threads.extend(batch)
+        has_more = bool(data.get("has_more")) if isinstance(data, dict) else False
+        if not has_more or not batch:
+            break
+        meta = batch[-1].get("thread_metadata") or {}
+        before = meta.get("archive_timestamp")
+        if not before:
+            break
+        await asyncio.sleep(0.15)
+    return threads
+
+
+async def collect_threads(rest: DiscordREST) -> tuple[dict[str, ThreadInfo], dict[str, int]]:
+    stats = {"guilds": 0, "channels": 0, "active": 0, "archived_public": 0, "archived_private": 0, "archived_joined_private": 0, "collect_errors": 0}
+    found: dict[str, ThreadInfo] = {}
+    guilds = await rest.get("/users/@me/guilds")
+    stats["guilds"] = len(guilds or [])
+    for guild in guilds or []:
+        guild_id = str(guild.get("id"))
+        channel_names: dict[str, str] = {}
+        channel_category: dict[str, str] = {}
+        parent_channels: list[dict[str, Any]] = []
+        try:
+            channels = await rest.get(f"/guilds/{guild_id}/channels")
+            categories = {str(c.get("id")): c.get("name", "") for c in channels or [] if c.get("type") == 4}
+            channel_names = {str(c.get("id")): c.get("name", "") for c in channels or []}
+            channel_category = {
+                str(c.get("id")): categories.get(str(c.get("parent_id") or ""), "")
+                for c in channels or []
+            }
+            parent_channels = [c for c in channels or [] if c.get("type") in PARENT_TYPES_WITH_THREADS]
+            stats["channels"] += len(parent_channels)
+        except Exception as exc:
+            stats["collect_errors"] += 1
+            print(f"WARN channels guild={guild_id}: {exc}")
+
+        try:
+            active = await rest.get(f"/guilds/{guild_id}/threads/active")
+            for t in active.get("threads", []) if isinstance(active, dict) else []:
+                tid = str(t["id"])
+                parent_id = str(t.get("parent_id") or "")
+                found[tid] = ThreadInfo(
+                    tid,
+                    t.get("name", ""),
+                    parent_id,
+                    guild_id,
+                    channel_names.get(parent_id),
+                    channel_category.get(parent_id),
+                    bool((t.get("thread_metadata") or {}).get("archived")),
+                )
+            stats["active"] += len(active.get("threads", []) if isinstance(active, dict) else [])
+        except Exception as exc:
+            stats["collect_errors"] += 1
+            print(f"WARN active threads guild={guild_id}: {exc}")
+
+        for ch in parent_channels:
+            cid = str(ch.get("id"))
+            for kind, key in (("public", "archived_public"), ("private", "archived_private"), ("joined-private", "archived_joined_private")):
+                try:
+                    batch = await paginate_archived(rest, cid, kind)
+                    stats[key] += len(batch)
+                    for t in batch:
+                        tid = str(t["id"])
+                        parent_id = str(t.get("parent_id") or cid)
+                        found.setdefault(
+                            tid,
+                            ThreadInfo(
+                                tid,
+                                t.get("name", ""),
+                                parent_id,
+                                guild_id,
+                                channel_names.get(parent_id),
+                                channel_category.get(parent_id),
+                                bool((t.get("thread_metadata") or {}).get("archived")),
+                            ),
+                        )
+                except Exception as exc:
+                    # Missing permissions for private archives is common. Keep moving.
+                    stats["collect_errors"] += 1
+                    if "HTTP 403" not in str(exc) and "HTTP 404" not in str(exc):
+                        print(f"WARN archived {kind} channel={cid}: {exc}")
+                await asyncio.sleep(0.08)
+    return found, stats
+
+
+async def fetch_message_samples(rest: DiscordREST, thread_id: str) -> list[dict[str, Any]]:
+    samples: list[dict[str, Any]] = []
+    try:
+        recent = await rest.get(f"/channels/{thread_id}/messages?limit=20")
+        if isinstance(recent, list):
+            samples.extend(reversed(recent))  # oldest-ish among recent first
+    except Exception as exc:
+        print(f"WARN messages thread={thread_id}: {exc}")
+        return samples
+    # Try the first messages in the thread by snowflake lower-bound.
+    try:
+        early = await rest.get(f"/channels/{thread_id}/messages?limit=10&after=0")
+        if isinstance(early, list):
+            seen = {m.get("id") for m in samples}
+            samples = [m for m in reversed(early) if m.get("id") not in seen] + samples
+    except Exception:
+        pass
+    return samples[:30]
+
+
+async def maybe_unarchive(rest: DiscordREST, thread: ThreadInfo) -> bool:
+    if not thread.archived:
+        return False
+    try:
+        await rest.patch(f"/channels/{thread.id}", {"archived": False}, "Hermes bulk thread rename: temporary unarchive")
+        await asyncio.sleep(0.25)
+        return True
+    except Exception as exc:
+        print(f"WARN cannot unarchive thread={thread.id}: {exc}")
+        return False
+
+
+async def rename_thread(rest: DiscordREST, thread: ThreadInfo, desired: str, *, dry_run: bool) -> tuple[str, str | None]:
+    if dry_run:
+        return "dry_run", None
+    rearchive = await maybe_unarchive(rest, thread)
+    payload = {"name": desired}
+    if rearchive:
+        payload["archived"] = True
+    try:
+        await rest.patch(f"/channels/{thread.id}", payload, "Hermes bulk thread descriptor rename")
+        return "renamed", None
+    except Exception as exc:
+        return "failed", str(exc)
+
+
+def load_renamed_state() -> set[str]:
+    path = get_hermes_home() / "discord_auto_renamed_threads.json"
+    try:
+        if path.exists():
+            data = json.loads(path.read_text(encoding="utf-8"))
+            if isinstance(data, list):
+                return {str(x) for x in data}
+    except Exception:
+        pass
+    return set()
+
+
+def save_renamed_state(ids: set[str]) -> None:
+    path = get_hermes_home() / "discord_auto_renamed_threads.json"
+    path.write_text(json.dumps(sorted(ids), separators=(",", ":")), encoding="utf-8")
+
+
+async def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--include-already-marked", action="store_true", help="Also rename threads already present in Hermes auto-rename state")
+    parser.add_argument("--force", action="store_true", help="Rename even when current title does not look generic/stale")
+    parser.add_argument("--limit", type=int, default=0, help="Limit renames for testing")
+    args = parser.parse_args()
+
+    token = load_token()
+    renamed_state = load_renamed_state()
+    started = time.time()
+    async with DiscordREST(token) as rest:
+        me = await rest.get("/users/@me")
+        print(f"Authenticated Discord bot: {me.get('username')}#{me.get('discriminator')} ({me.get('id')})")
+        threads, stats = await collect_threads(rest)
+        print("Discovery:", json.dumps({**stats, "unique_threads": len(threads)}, sort_keys=True))
+
+        results = {"considered": 0, "skipped_marked": 0, "skipped_same": 0, "skipped_specific": 0, "dry_run": 0, "renamed": 0, "failed": 0}
+        failures: list[dict[str, str]] = []
+        changes: list[dict[str, str]] = []
+
+        for thread in sorted(threads.values(), key=lambda t: int(t.id)):
+            if args.limit and (results["renamed"] + results["dry_run"] >= args.limit):
+                break
+            results["considered"] += 1
+            if not args.include_already_marked and thread.id in renamed_state:
+                results["skipped_marked"] += 1
+                continue
+            messages = await fetch_message_samples(rest, thread.id)
+            desired = derive_descriptor(thread, messages)
+            if desired == thread.name:
+                results["skipped_same"] += 1
+                renamed_state.add(thread.id)
+                continue
+            if not args.force and not is_generic_name(thread.name):
+                # Existing name already looks intentional; skip unless force was requested.
+                results["skipped_specific"] += 1
+                continue
+            status, error = await rename_thread(rest, thread, desired, dry_run=args.dry_run)
+            results[status] = results.get(status, 0) + 1
+            if status in {"renamed", "dry_run"}:
+                changes.append({"id": thread.id, "from": thread.name, "to": desired})
+                renamed_state.add(thread.id)
+                print(f"{status.upper()}: {thread.name!r} -> {desired!r} ({thread.id})")
+            else:
+                failures.append({"id": thread.id, "name": thread.name, "desired": desired, "error": error or "unknown"})
+                print(f"FAILED: {thread.name!r} -> {desired!r} ({thread.id}) :: {error}")
+            await asyncio.sleep(0.25)
+
+        if not args.dry_run:
+            save_renamed_state(renamed_state)
+        out = {
+            "elapsed_sec": round(time.time() - started, 2),
+            "results": results,
+            "changes": changes[-50:],
+            "failures": failures[:25],
+        }
+        print("SUMMARY:", json.dumps(out, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))

--- a/tools/charity_charge_data.py
+++ b/tools/charity_charge_data.py
@@ -1,0 +1,360 @@
+"""Charity Charge Phase 1 data-plane tool scaffolds.
+
+These tools intentionally do not perform live API calls yet. They provide stable
+schemas, credential gating, and stub responses so the Phase 1 handlers can be
+filled in once Charity Charge credentials land.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from hermes_constants import get_hermes_home
+from hermes_cli.config import get_env_value
+from tools.registry import registry
+
+TOOLSET = "charity-charge-data"
+STUB_MESSAGE = "Tool scaffolded but handler not implemented"
+
+BIGQUERY_CREDENTIALS = ["~/.hermes/secrets/bq-service-account.json"]
+HUBSPOT_CREDENTIALS = ["HUBSPOT_ACCESS_TOKEN"]
+GOOGLE_ADS_CREDENTIALS = [
+    "GOOGLE_ADS_DEVELOPER_TOKEN",
+    "GOOGLE_ADS_OAUTH_CLIENT_ID",
+    "GOOGLE_ADS_OAUTH_CLIENT_SECRET",
+    "GOOGLE_ADS_REFRESH_TOKEN",
+    "GOOGLE_ADS_CUSTOMER_ID",
+]
+AHREFS_CREDENTIALS = ["AHREFS_API_KEY"]
+GSC_CREDENTIALS = ["~/.hermes/secrets/gsc-oauth.json", "GSC_PROPERTY_URL"]
+
+
+def _hermes_secret_path(filename: str) -> Path:
+    return get_hermes_home() / "secrets" / filename
+
+
+def _missing_env_vars(names: list[str]) -> list[str]:
+    return [name for name in names if not str(get_env_value(name) or "").strip()]
+
+
+def _missing_files(paths: list[Path]) -> list[str]:
+    missing: list[str] = []
+    hermes_home = get_hermes_home()
+    for path in paths:
+        if not path.exists() or not path.is_file():
+            try:
+                display = "~/.hermes/" + str(path.relative_to(hermes_home))
+            except ValueError:
+                display = str(path)
+            missing.append(display)
+    return missing
+
+
+def _missing_bigquery_credentials() -> list[str]:
+    return _missing_files([_hermes_secret_path("bq-service-account.json")])
+
+
+def _missing_hubspot_credentials() -> list[str]:
+    return _missing_env_vars(HUBSPOT_CREDENTIALS)
+
+
+def _missing_google_ads_credentials() -> list[str]:
+    return _missing_env_vars(GOOGLE_ADS_CREDENTIALS)
+
+
+def _missing_ahrefs_credentials() -> list[str]:
+    return _missing_env_vars(AHREFS_CREDENTIALS)
+
+
+def _missing_gsc_credentials() -> list[str]:
+    return _missing_files([_hermes_secret_path("gsc-oauth.json")]) + _missing_env_vars(["GSC_PROPERTY_URL"])
+
+
+def check_bigquery_requirements() -> bool:
+    """Return True when the BigQuery service account file is present."""
+    return not _missing_bigquery_credentials()
+
+
+def check_hubspot_requirements() -> bool:
+    """Return True when the HubSpot access token is present."""
+    return not _missing_hubspot_credentials()
+
+
+def check_google_ads_requirements() -> bool:
+    """Return True when all Google Ads OAuth/developer credentials are present."""
+    return not _missing_google_ads_credentials()
+
+
+def check_ahrefs_requirements() -> bool:
+    """Return True when the Ahrefs API key is present."""
+    return not _missing_ahrefs_credentials()
+
+
+def check_gsc_requirements() -> bool:
+    """Return True when GSC OAuth file and property URL are present."""
+    return not _missing_gsc_credentials()
+
+
+def _stub_response(expected_credentials: list[str], missing: list[str]) -> str:
+    if missing:
+        return json.dumps(
+            {
+                "error": f"not configured: missing {', '.join(missing)}",
+                "expected_credentials": expected_credentials,
+            }
+        )
+    return json.dumps(
+        {
+            "status": "stub",
+            "message": STUB_MESSAGE,
+            "expected_credentials": expected_credentials,
+        }
+    )
+
+
+def _tool_bigquery_query(args: dict[str, Any], **_: Any) -> str:
+    return _stub_response(BIGQUERY_CREDENTIALS, _missing_bigquery_credentials())
+
+
+def _tool_hubspot_query(args: dict[str, Any], **_: Any) -> str:
+    return _stub_response(HUBSPOT_CREDENTIALS, _missing_hubspot_credentials())
+
+
+def _tool_google_ads_query(args: dict[str, Any], **_: Any) -> str:
+    return _stub_response(GOOGLE_ADS_CREDENTIALS, _missing_google_ads_credentials())
+
+
+def _tool_ahrefs_query(args: dict[str, Any], **_: Any) -> str:
+    return _stub_response(AHREFS_CREDENTIALS, _missing_ahrefs_credentials())
+
+
+def _tool_gsc_query(args: dict[str, Any], **_: Any) -> str:
+    return _stub_response(GSC_CREDENTIALS, _missing_gsc_credentials())
+
+
+BIGQUERY_SCHEMA = {
+    "name": "tool_bigquery_query",
+    "description": "Run a read-only BigQuery SQL query for Charity Charge Phase 1 analytics. Scaffold only until handler implementation lands.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "query": {
+                "type": "string",
+                "description": "StandardSQL query to run. Handler should reject mutation statements when implemented.",
+            },
+            "parameters": {
+                "type": "object",
+                "description": "Optional named query parameters for parameterized StandardSQL.",
+                "additionalProperties": True,
+            },
+            "max_results": {
+                "type": "integer",
+                "description": "Maximum rows to return from the completed query.",
+                "minimum": 1,
+                "maximum": 1000,
+                "default": 100,
+            },
+            "dry_run": {
+                "type": "boolean",
+                "description": "Validate and estimate the query without executing it.",
+                "default": False,
+            },
+        },
+        "required": ["query"],
+        "additionalProperties": False,
+    },
+}
+
+HUBSPOT_SCHEMA = {
+    "name": "tool_hubspot_query",
+    "description": "Query HubSpot CRM objects for Charity Charge Phase 1. Scaffold only until handler implementation lands.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "object_type": {
+                "type": "string",
+                "description": "HubSpot CRM object type, such as contacts, companies, deals, tickets, or a custom object name.",
+            },
+            "properties": {
+                "type": "array",
+                "description": "CRM properties to include in the response.",
+                "items": {"type": "string"},
+                "default": [],
+            },
+            "filters": {
+                "type": "array",
+                "description": "HubSpot search filter groups or simplified filters for the eventual handler.",
+                "items": {"type": "object", "additionalProperties": True},
+                "default": [],
+            },
+            "limit": {
+                "type": "integer",
+                "description": "Maximum HubSpot records to return.",
+                "minimum": 1,
+                "maximum": 100,
+                "default": 10,
+            },
+            "after": {
+                "type": "string",
+                "description": "Optional HubSpot paging cursor.",
+            },
+        },
+        "required": ["object_type"],
+        "additionalProperties": False,
+    },
+}
+
+GOOGLE_ADS_SCHEMA = {
+    "name": "tool_google_ads_query",
+    "description": "Run a Google Ads GAQL query for Charity Charge Phase 1. Scaffold only until handler implementation lands.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "query": {
+                "type": "string",
+                "description": "Google Ads Query Language (GAQL) query.",
+            },
+            "customer_id": {
+                "type": "string",
+                "description": "Optional Google Ads customer ID override. Defaults to GOOGLE_ADS_CUSTOMER_ID.",
+                "pattern": "^(\\d{10}|\\d{3}-\\d{3}-\\d{4})$",
+            },
+            "page_size": {
+                "type": "integer",
+                "description": "Requested page size for SearchGoogleAds when implemented.",
+                "minimum": 1,
+                "maximum": 10000,
+                "default": 1000,
+            },
+        },
+        "required": ["query"],
+        "additionalProperties": False,
+    },
+}
+
+AHREFS_SCHEMA = {
+    "name": "tool_ahrefs_query",
+    "description": "Query Ahrefs API v3 for Charity Charge Phase 1 SEO data. Scaffold only until handler implementation lands.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "endpoint": {
+                "type": "string",
+                "description": "Ahrefs API v3 endpoint path, for example site-explorer/backlinks or subscription-info/limits-and-usage.",
+            },
+            "params": {
+                "type": "object",
+                "description": "Query string parameters for the Ahrefs endpoint.",
+                "additionalProperties": {"type": ["string", "number", "integer", "boolean", "array"]},
+                "default": {},
+            },
+        },
+        "required": ["endpoint"],
+        "additionalProperties": False,
+    },
+}
+
+GSC_SCHEMA = {
+    "name": "tool_gsc_query",
+    "description": "Query Google Search Console search analytics for Charity Charge Phase 1. Scaffold only until handler implementation lands.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "property_url": {
+                "type": "string",
+                "description": "Optional Search Console site URL override. Defaults to GSC_PROPERTY_URL.",
+            },
+            "start_date": {
+                "type": "string",
+                "description": "Start date in YYYY-MM-DD format.",
+                "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+            },
+            "end_date": {
+                "type": "string",
+                "description": "End date in YYYY-MM-DD format.",
+                "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+            },
+            "dimensions": {
+                "type": "array",
+                "description": "Search Analytics dimensions such as query, page, country, device, date, or searchAppearance.",
+                "items": {
+                    "type": "string",
+                    "enum": ["query", "page", "country", "device", "date", "searchAppearance"],
+                },
+                "default": ["query"],
+            },
+            "row_limit": {
+                "type": "integer",
+                "description": "Maximum Search Console rows to return.",
+                "minimum": 1,
+                "maximum": 25000,
+                "default": 1000,
+            },
+            "start_row": {
+                "type": "integer",
+                "description": "Zero-based result offset for pagination.",
+                "minimum": 0,
+                "default": 0,
+            },
+        },
+        "required": ["start_date", "end_date"],
+        "additionalProperties": False,
+    },
+}
+
+registry.register(
+    name="tool_bigquery_query",
+    toolset=TOOLSET,
+    schema=BIGQUERY_SCHEMA,
+    handler=_tool_bigquery_query,
+    check_fn=check_bigquery_requirements,
+    requires_env=BIGQUERY_CREDENTIALS,
+    description=BIGQUERY_SCHEMA["description"],
+    emoji="📊",
+)
+
+registry.register(
+    name="tool_hubspot_query",
+    toolset=TOOLSET,
+    schema=HUBSPOT_SCHEMA,
+    handler=_tool_hubspot_query,
+    check_fn=check_hubspot_requirements,
+    requires_env=HUBSPOT_CREDENTIALS,
+    description=HUBSPOT_SCHEMA["description"],
+    emoji="🧲",
+)
+
+registry.register(
+    name="tool_google_ads_query",
+    toolset=TOOLSET,
+    schema=GOOGLE_ADS_SCHEMA,
+    handler=_tool_google_ads_query,
+    check_fn=check_google_ads_requirements,
+    requires_env=GOOGLE_ADS_CREDENTIALS,
+    description=GOOGLE_ADS_SCHEMA["description"],
+    emoji="📣",
+)
+
+registry.register(
+    name="tool_ahrefs_query",
+    toolset=TOOLSET,
+    schema=AHREFS_SCHEMA,
+    handler=_tool_ahrefs_query,
+    check_fn=check_ahrefs_requirements,
+    requires_env=AHREFS_CREDENTIALS,
+    description=AHREFS_SCHEMA["description"],
+    emoji="🔎",
+)
+
+registry.register(
+    name="tool_gsc_query",
+    toolset=TOOLSET,
+    schema=GSC_SCHEMA,
+    handler=_tool_gsc_query,
+    check_fn=check_gsc_requirements,
+    requires_env=GSC_CREDENTIALS,
+    description=GSC_SCHEMA["description"],
+    emoji="📈",
+)


### PR DESCRIPTION
## Summary
- add Charity Charge Phase 1 data-plane tool scaffolds with credential checks and stubbed handlers
- add a Discord bulk thread rename utility using existing Hermes descriptor heuristics
- add agent workspace audit notes and a full Hermes development guide snapshot

## Test Plan
- python -m py_compile scripts/bulk_rename_discord_threads.py tools/charity_charge_data.py
- python -m pytest tests/tools/test_registry.py tests/test_model_tools.py -q -o 'addopts='

Note: upstream main is ahead of the local checkout, so this was pushed from a fork branch instead of directly to origin.