### PR TITLE
feat: add stable webhook sessions

### DIFF
--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -526,7 +526,16 @@ class WebhookAdapter(BasePlatformAdapter):
 
         # Use delivery_id in session key so concurrent webhooks on the
         # same route get independent agent runs (not queued/interrupted).
-        session_chat_id = f"webhook:{route_name}:{delivery_id}"
+        # AXIS PATCH (01): routes can opt-in to STABLE session keys via
+        # `stable_session: true` in webhook_subscriptions.json. Every
+        # delivery for that route then maps to ONE continuous Hermes
+        # session, giving the agent memory across turns. Required for
+        # conversational voice flows (operator-message). Default kept
+        # for batch/concurrent webhooks.
+        if route_config.get("stable_session"):
+            session_chat_id = f"webhook:{route_name}"
+        else:
+            session_chat_id = f"webhook:{route_name}:{delivery_id}"
 
         # Store delivery info for send().  Read by every send() invocation
         # for this chat_id (interim status messages and the final response),

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -9208,6 +9208,14 @@ def main():
         "message. Zero LLM cost. Requires --deliver to be a real target "
         "(not 'log').",
     )
+    wh_sub.add_argument(
+        "--stable-session",
+        action="store_true",
+        help=(
+            "Keep the route on one continuous Hermes session across deliveries. "
+            "Use for conversational reply threads that may continue across turns."
+        ),
+    )
 
     webhook_subparsers.add_parser(
         "list", aliases=["ls"], help="List all dynamic subscriptions"

--- a/hermes_cli/webhook.py
+++ b/hermes_cli/webhook.py
@@ -168,6 +168,9 @@ def _cmd_subscribe(args):
     if args.deliver_chat_id:
         route["deliver_extra"] = {"chat_id": args.deliver_chat_id}
 
+    if getattr(args, "stable_session", False):
+        route["stable_session"] = True
+
     subs[name] = route
     _save_subscriptions(subs)
 
@@ -184,6 +187,8 @@ def _cmd_subscribe(args):
     print(f"  Deliver: {route['deliver']}")
     if route.get("deliver_only"):
         print("  Mode: direct delivery (no agent, zero LLM cost)")
+    if route.get("stable_session"):
+        print("  Session: stable (one continuous chat per route)")
     if route.get("prompt"):
         prompt_preview = route["prompt"][:80] + ("..." if len(route["prompt"]) > 80 else "")
         label = "Message" if route.get("deliver_only") else "Prompt"
@@ -207,6 +212,8 @@ def _cmd_list(args):
         deliver = route.get("deliver", "log")
         if route.get("deliver_only"):
             deliver = f"{deliver} (direct — no agent)"
+        if route.get("stable_session"):
+            deliver = f"{deliver} (stable session)"
         desc = route.get("description", "")
         print(f"  ◆ {name}")
         if desc:

--- a/tests/gateway/test_webhook_adapter.py
+++ b/tests/gateway/test_webhook_adapter.py
@@ -306,8 +306,39 @@ class TestEventFilter:
 
 
 # ===================================================================
-# HTTP handling
+# Session routing
 # ===================================================================
+
+
+class TestStableSessionRouting:
+    @pytest.mark.asyncio
+    async def test_stable_session_route_uses_route_name_only(self):
+        routes = {
+            "operator-message": {
+                "secret": _INSECURE_NO_AUTH,
+                "prompt": "Reply to the operator",
+                "stable_session": True,
+            }
+        }
+        adapter = _make_adapter(routes=routes)
+        adapter.handle_message = AsyncMock()
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/webhooks/operator-message",
+                json={"message": "hello"},
+                headers={"X-Webhook-Signature": ""},
+            )
+            assert resp.status == 202
+
+        await asyncio.sleep(0.05)
+
+        assert adapter.handle_message.await_count == 1
+        event = adapter.handle_message.await_args.args[0]
+        assert event.source.chat_id == "webhook:operator-message"
+
+
 
 
 class TestHTTPHandling:

--- a/tests/hermes_cli/test_webhook_cli.py
+++ b/tests/hermes_cli/test_webhook_cli.py
@@ -34,6 +34,7 @@ def _make_args(**kwargs):
         "skills": "",
         "deliver": "log",
         "deliver_chat_id": "",
+        "stable_session": False,
         "secret": "",
         "payload": "",
     }
@@ -66,6 +67,15 @@ class TestSubscribe:
         assert route["prompt"] == "Issue: {issue.title}"
         assert route["deliver"] == "telegram"
         assert route["deliver_extra"] == {"chat_id": "12345"}
+
+    def test_stable_session_flag(self):
+        webhook_command(_make_args(
+            webhook_action="subscribe",
+            name="operator-message",
+            stable_session=True,
+        ))
+        route = _load_subscriptions()["operator-message"]
+        assert route["stable_session"] is True
 
     def test_custom_secret(self):
         webhook_command(_make_args(

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -433,6 +433,7 @@ hermes webhook subscribe <name> [options]
 | `--deliver-chat-id` | Target chat/channel ID for cross-platform delivery. |
 | `--secret` | Custom HMAC secret. Auto-generated if omitted. |
 | `--deliver-only` | Skip the agent — deliver the rendered `--prompt` as the literal message. Zero LLM cost, sub-second delivery. Requires `--deliver` to be a real target (not `log`). |
+| `--stable-session` | Reuse one Hermes session across deliveries for this route. Use for conversational reply threads that may continue across turns. |
 
 Subscriptions persist to `~/.hermes/webhook_subscriptions.json` and are hot-reloaded by the webhook adapter without a gateway restart.
 

--- a/website/docs/user-guide/messaging/webhooks.md
+++ b/website/docs/user-guide/messaging/webhooks.md
@@ -85,6 +85,7 @@ Routes define how different webhook sources are handled. Each route is a named e
 | `deliver` | No | Where to send the response: `github_comment`, `telegram`, `discord`, `slack`, `signal`, `sms`, `whatsapp`, `matrix`, `mattermost`, `homeassistant`, `email`, `dingtalk`, `feishu`, `wecom`, `weixin`, `bluebubbles`, `qqbot`, or `log` (default). |
 | `deliver_extra` | No | Additional delivery config — keys depend on `deliver` type (e.g. `repo`, `pr_number`, `chat_id`). Values support the same `{dot.notation}` templates as `prompt`. |
 | `deliver_only` | No | If `true`, skip the agent entirely — the rendered `prompt` template becomes the literal message that gets delivered. Zero LLM cost, sub-second delivery. See [Direct Delivery Mode](#direct-delivery-mode) for use cases. Requires `deliver` to be a real target (not `log`). |
+| `stable_session` | No | If `true`, every delivery for this route reuses one stable Hermes session instead of a per-delivery session ID. Use this for conversational reply routes that may continue across turns. |
 
 ### Full example
 
@@ -99,6 +100,7 @@ platforms:
         github-pr:
           events: ["pull_request"]
           secret: "github-webhook-secret"
+          stable_session: true
           prompt: |
             Review this pull request:
             Repository: {repository.full_name}


### PR DESCRIPTION
## Summary
- Add a --stable-session flag to webhook subscribe
- Persist stable_session in webhook subscriptions and surface it in webhook list
- Route stable-session webhooks through one continuous Hermes session
- Document the behavior and add CLI/adapter tests

## Verification
- scripts/run_tests.sh tests/hermes_cli/test_webhook_cli.py tests/gateway/test_webhook_adapter.py -q
