### PR TITLE
feat(tools): add cursor_agent tool via Cursor SDK

### DIFF
--- a/agent/cursor_sdk_client.py
+++ b/agent/cursor_sdk_client.py
@@ -1,0 +1,211 @@
+"""Thin wrapper around the optional Cursor Agent SDK (cursor-sdk).
+
+Isolates beta API churn and optional dependency import failures from tool code.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_MODEL = "composer-2.5"
+SUMMARY_INSTRUCTION = (
+    "You are invoked as a coding sub-agent from Hermes Agent. "
+    "Complete the task, then reply with a concise structured summary covering: "
+    "(1) what you did, (2) files changed or created, (3) commands run, "
+    "(4) test/verification status if any, (5) blockers or follow-ups. "
+    "Do not ask the user questions — return the summary as your final message."
+)
+
+
+def cursor_sdk_available() -> bool:
+    """Return True when cursor_sdk is importable (after lazy install if needed)."""
+    try:
+        import cursor_sdk  # noqa: F401
+        return True
+    except ImportError:
+        pass
+    try:
+        from tools.lazy_deps import ensure
+
+        ensure("tools.cursor")
+        import cursor_sdk  # noqa: F401
+        return True
+    except Exception as exc:
+        logger.debug("cursor-sdk not available: %s", exc)
+        return False
+
+
+def _load_sdk():
+    from cursor_sdk import Agent, AgentOptions, CursorAgentError, LocalAgentOptions
+
+    try:
+        from cursor_sdk import CloudAgentOptions
+    except ImportError:
+        CloudAgentOptions = None  # type: ignore[misc, assignment]
+    return Agent, AgentOptions, CursorAgentError, LocalAgentOptions, CloudAgentOptions
+
+
+def _resolve_api_key(explicit: Optional[str] = None) -> Optional[str]:
+    key = (explicit or os.environ.get("CURSOR_API_KEY") or "").strip()
+    return key or None
+
+
+def _resolve_cwd(cwd: Optional[str]) -> str:
+    if cwd and str(cwd).strip():
+        path = Path(cwd).expanduser()
+        if not path.is_absolute():
+            path = Path(os.getcwd()) / path
+        return str(path.resolve())
+    return os.getcwd()
+
+
+def build_cursor_prompt(goal: str, context: Optional[str] = None) -> str:
+    """Compose the user message sent to the Cursor agent."""
+    goal = (goal or "").strip()
+    if not goal:
+        return SUMMARY_INSTRUCTION
+    parts = [SUMMARY_INSTRUCTION, "", "## Task", goal]
+    if context and str(context).strip():
+        parts.extend(["", "## Additional context", str(context).strip()])
+    return "\n".join(parts)
+
+
+def run_cursor_agent(
+    *,
+    goal: str,
+    context: Optional[str] = None,
+    cwd: Optional[str] = None,
+    model: str = DEFAULT_MODEL,
+    api_key: Optional[str] = None,
+    resume_agent_id: Optional[str] = None,
+    cloud_repo_url: Optional[str] = None,
+    cloud_starting_ref: Optional[str] = None,
+    on_progress: Optional[Callable[[str], None]] = None,
+) -> Dict[str, Any]:
+    """Run one Cursor SDK agent turn and return a Hermes-friendly result dict.
+
+    Raises CursorAgentError when the run never starts (caller maps to tool error).
+    """
+    if not cursor_sdk_available():
+        return {
+            "status": "error",
+            "error": (
+                "cursor-sdk is not installed. Install with: "
+                "uv pip install 'hermes-agent[cursor]'"
+            ),
+            "error_type": "dependency",
+        }
+
+    key = _resolve_api_key(api_key)
+    if not key:
+        return {
+            "status": "error",
+            "error": "CURSOR_API_KEY is not set",
+            "error_type": "auth",
+        }
+
+    (
+        Agent,
+        AgentOptions,
+        CursorAgentError,
+        LocalAgentOptions,
+        CloudAgentOptions,
+    ) = _load_sdk()
+
+    work_cwd = _resolve_cwd(cwd)
+    prompt = build_cursor_prompt(goal, context)
+    model_id = (model or DEFAULT_MODEL).strip() or DEFAULT_MODEL
+
+    options_kwargs: Dict[str, Any] = {
+        "api_key": key,
+        "model": model_id,
+    }
+
+    use_cloud = bool(cloud_repo_url and str(cloud_repo_url).strip())
+    if use_cloud and CloudAgentOptions is not None:
+        repo: Dict[str, Any] = {"url": str(cloud_repo_url).strip()}
+        if cloud_starting_ref and str(cloud_starting_ref).strip():
+            repo["startingRef"] = str(cloud_starting_ref).strip()
+        options_kwargs["cloud"] = CloudAgentOptions(repos=[repo])
+    else:
+        options_kwargs["local"] = LocalAgentOptions(cwd=work_cwd)
+
+    try:
+        if resume_agent_id and str(resume_agent_id).strip():
+            agent_ctx = Agent.resume(
+                str(resume_agent_id).strip(),
+                AgentOptions(**options_kwargs),
+            )
+        else:
+            agent_ctx = Agent.create(**options_kwargs)
+
+        with agent_ctx as agent:
+            run = agent.send(prompt)
+            run_id = getattr(run, "id", None) or getattr(run, "run_id", None)
+
+            if on_progress is not None:
+                try:
+                    for message in run.messages():
+                        if getattr(message, "type", None) == "assistant":
+                            msg = getattr(message, "message", message)
+                            content = getattr(msg, "content", None) or []
+                            for block in content:
+                                if getattr(block, "type", None) == "text":
+                                    text = getattr(block, "text", "") or ""
+                                    if text:
+                                        on_progress(text)
+                except Exception as stream_exc:
+                    logger.debug("cursor run.messages() failed: %s", stream_exc)
+
+            result = run.wait()
+            status = getattr(result, "status", None) or "unknown"
+            agent_id = getattr(agent, "agent_id", None) or getattr(agent, "agentId", None)
+            summary = getattr(result, "result", None) or getattr(result, "text", None) or ""
+
+            if status == "error":
+                return {
+                    "status": "error",
+                    "error": "Cursor agent run failed",
+                    "error_type": "run",
+                    "agent_id": agent_id,
+                    "run_id": run_id,
+                    "summary": str(summary) if summary else "",
+                }
+
+            return {
+                "status": "finished",
+                "agent_id": agent_id,
+                "run_id": run_id,
+                "model": model_id,
+                "cwd": work_cwd,
+                "cloud": use_cloud,
+                "summary": str(summary) if summary else "",
+            }
+    except CursorAgentError as err:
+        return {
+            "status": "error",
+            "error": str(err.message) if hasattr(err, "message") else str(err),
+            "error_type": "startup",
+            "retryable": bool(getattr(err, "is_retryable", False)),
+        }
+
+
+def probe_cursor_api_key(api_key: Optional[str] = None) -> Dict[str, Any]:
+    """Lightweight connectivity probe for hermes doctor."""
+    if not cursor_sdk_available():
+        return {"ok": False, "detail": "cursor-sdk not installed"}
+    key = _resolve_api_key(api_key)
+    if not key:
+        return {"ok": False, "detail": "CURSOR_API_KEY not set"}
+    try:
+        from cursor_sdk import Cursor
+
+        Cursor.models.list(api_key=key)
+        return {"ok": True, "detail": "models.list OK"}
+    except Exception as exc:
+        return {"ok": False, "detail": str(exc)}

--- a/docs/rfc/GITHUB_DISCUSSION_BODY.md
+++ b/docs/rfc/GITHUB_DISCUSSION_BODY.md
@@ -1,0 +1,22 @@
+## RFC: Cursor SDK (Composer 2.5) integration
+
+**Summary:** Add optional Cursor Agent SDK support to Hermes in two phases:
+
+1. **`cursor_agent` tool** — Hermes delegates bounded coding tasks to Composer via `cursor-sdk` (local `cwd` by default). Parent keeps memory/skills/messaging.
+2. **`integrations/cursor_bridge` (experimental)** — Local OpenAI-compatible HTTP shim so advanced users can point `provider: custom` at Composer. Documented as costly/slow; not default.
+
+**Why not a built-in provider?** Maintainer docs already recommend custom OpenAI-compatible endpoints for simple cases. The SDK is an agent runtime, not chat-completions-native.
+
+**Licensing:** `cursor-sdk` is proprietary — optional extra `hermes-agent[cursor]` only, lazy-install key `tools.cursor`, tool hidden without `CURSOR_API_KEY`.
+
+**Security:** Same surface as Cursor IDE agent for the target repo (files, shell, MCP). Bridge binds `127.0.0.1` by default.
+
+**Implementation:** See `docs/rfc/cursor-sdk-hermes-integration.md` and branch `feat/cursor-agent-tool`.
+
+### Open questions
+
+1. Should `cursor` toolset be included in `hermes-cli` default tools or stay opt-in via `hermes tools`?
+2. Interest in a bundled `plugins/model-providers/cursor-bridge` profile after the bridge stabilizes?
+3. Any concern shipping proprietary `cursor-sdk` as an optional extra under MIT Hermes?
+
+Feedback welcome before we open the PR.

--- a/docs/rfc/cursor-sdk-hermes-integration.md
+++ b/docs/rfc/cursor-sdk-hermes-integration.md
@@ -1,0 +1,55 @@
+# RFC: Cursor SDK (Composer 2.5) integration for Hermes Agent
+
+## Summary
+
+Integrate [Cursor Agent SDK](https://cursor.com/docs/sdk/python) (`cursor-sdk`) so Hermes can delegate focused coding work to Composer 2.5, with an optional local OpenAI-compatible bridge for advanced users who want Composer as the inference backend.
+
+## Motivation
+
+- Hermes excels at long-running orchestration (memory, skills, messaging, multi-backend terminals).
+- Cursor's agent runtime excels at IDE-grade repo editing with Composer models.
+- Users should combine both without nested confusion or undocumented cookie proxies.
+
+## Proposed design (two phases)
+
+### Phase 1 — `cursor_agent` tool (this RFC's primary deliverable)
+
+- New Hermes tool that spawns a **local** Cursor SDK agent (`composer-2.5` by default).
+- Input: `goal`, optional `context`, `cwd`, `resume_agent_id`.
+- Output: structured JSON summary (status, agent_id, run_id, summary, error).
+- Parent Hermes agent keeps its normal LLM and tool surface.
+
+### Phase 2 — `integrations/cursor_bridge` (experimental)
+
+- Sidecar HTTP server: `POST /v1/chat/completions`, `GET /v1/models`, `GET /health`.
+- Hermes `provider: custom` points at the bridge.
+- Documented as **high cost / high latency** — not recommended for default use.
+
+## Non-goals
+
+- Built-in `cursor` entry in `PROVIDER_REGISTRY` (custom provider + docs is enough).
+- Cookie/session scraping proxies.
+- Adding `cursor-sdk` to default `[all]` install (proprietary license, large wheels).
+
+## Dependencies and licensing
+
+- Optional extra: `hermes-agent[cursor]` → `cursor-sdk>=0.1.5,<0.2`
+- Lazy install key: `tools.cursor` in `tools/lazy_deps.py`
+- Users supply `CURSOR_API_KEY` from Cursor Dashboard → Integrations
+
+## Security
+
+- `cursor_agent` grants Cursor the same class of access as the Cursor IDE agent (files, shell, MCP on the target `cwd`).
+- Bridge binds to `127.0.0.1` by default; require `CURSOR_API_KEY` when exposed beyond loopback.
+- Never log API keys; redact errors returned to the model.
+
+## Open questions for maintainers
+
+1. Should `cursor_agent` join `hermes-acp` / `hermes-api-server` toolsets by default?
+2. Is a bundled `plugins/model-providers/cursor-bridge/` profile desirable after the bridge stabilizes?
+3. Any concern about shipping proprietary `cursor-sdk` as an optional extra under MIT Hermes?
+
+## Implementation PRs
+
+1. `feat(tools): add cursor_agent tool via Cursor SDK`
+2. `feat(integrations): experimental Cursor OpenAI bridge for custom provider`

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2291,6 +2291,14 @@ OPTIONAL_ENV_VARS = {
         "password": True,
         "category": "tool",
     },
+    "CURSOR_API_KEY": {
+        "description": "Cursor API key for cursor_agent tool and optional cursor_bridge",
+        "prompt": "Cursor API key",
+        "url": "https://cursor.com/dashboard/integrations",
+        "tools": ["cursor_agent"],
+        "password": True,
+        "category": "tool",
+    },
     "BROWSERBASE_API_KEY": {
         "description": "Browserbase API key for cloud browser (optional — local browser works without this)",
         "prompt": "Browserbase API key",

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -1781,6 +1781,45 @@ def run_doctor(args):
         for _issue in _issues_to_add:
             issues.append(_issue)
 
+    _section("Cursor SDK (optional)")
+    try:
+        sys.path.insert(0, str(PROJECT_ROOT))
+        from agent.cursor_sdk_client import cursor_sdk_available, probe_cursor_api_key
+
+        if os.environ.get("CURSOR_API_KEY", "").strip():
+            if cursor_sdk_available():
+                probe = probe_cursor_api_key()
+                if probe.get("ok"):
+                    check_ok("Cursor SDK", probe.get("detail", ""))
+                else:
+                    check_warn("Cursor SDK", f"({probe.get('detail', 'probe failed')})")
+                    issues.append("CURSOR_API_KEY is set but Cursor API probe failed")
+            else:
+                check_warn(
+                    "cursor-sdk package",
+                    f"(install: {_python_install_cmd()} 'hermes-agent[cursor]')",
+                )
+        else:
+            check_info("CURSOR_API_KEY not set (cursor_agent tool disabled)")
+        bridge_port = os.environ.get("CURSOR_BRIDGE_PORT", "18765")
+        bridge_host = os.environ.get("CURSOR_BRIDGE_HOST", "127.0.0.1")
+        try:
+            import urllib.request
+
+            url = f"http://{bridge_host}:{bridge_port}/health"
+            with urllib.request.urlopen(url, timeout=2) as resp:
+                if resp.status == 200:
+                    check_ok("cursor_bridge", f"({url})")
+                else:
+                    check_info("cursor_bridge not running", f"(optional — {url})")
+        except Exception:
+            check_info(
+                "cursor_bridge not running",
+                f"(optional — http://{bridge_host}:{bridge_port}/health)",
+            )
+    except Exception as e:
+        check_warn("Cursor SDK check skipped", f"({e})")
+
     _section("Tool Availability")
     try:
         # Add project root to path for imports

--- a/integrations/__init__.py
+++ b/integrations/__init__.py
@@ -1,0 +1,1 @@
+"""Optional integration packages (sidecars, bridges)."""

--- a/integrations/cursor_bridge/README.md
+++ b/integrations/cursor_bridge/README.md
@@ -1,0 +1,40 @@
+# Cursor bridge (experimental)
+
+Local OpenAI-compatible HTTP server that forwards chat completions to Cursor Agent SDK (`composer-2.5` by default).
+
+## Install
+
+```bash
+uv pip install -e ".[cursor]"
+export CURSOR_API_KEY="cursor_..."
+```
+
+## Run
+
+```bash
+python -m integrations.cursor_bridge
+# Listens on http://127.0.0.1:18765/v1 by default
+```
+
+Environment variables:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `CURSOR_API_KEY` | (required) | Cursor API key; also used as Bearer token for bridge auth |
+| `CURSOR_BRIDGE_HOST` | `127.0.0.1` | Bind address |
+| `CURSOR_BRIDGE_PORT` | `18765` | Port |
+| `CURSOR_BRIDGE_CWD` | process cwd | Local agent working directory |
+| `CURSOR_BRIDGE_MODEL` | `composer-2.5` | Model id passed to SDK |
+| `CURSOR_BRIDGE_CHAT_ONLY` | off | Prepend chat-only system guidance |
+
+## Hermes config
+
+```yaml
+model:
+  provider: custom
+  base_url: http://127.0.0.1:18765/v1
+  api_key: ${CURSOR_API_KEY}  # or paste key; must match bridge Bearer token
+  api_mode: chat_completions
+```
+
+**Warning:** Each Hermes turn may start a full Cursor agent run (slow and costly). Prefer the `cursor_agent` tool for coding subtasks.

--- a/integrations/cursor_bridge/__init__.py
+++ b/integrations/cursor_bridge/__init__.py
@@ -1,0 +1,1 @@
+"""Experimental OpenAI-compatible bridge to Cursor Agent SDK."""

--- a/integrations/cursor_bridge/__main__.py
+++ b/integrations/cursor_bridge/__main__.py
@@ -1,0 +1,25 @@
+"""Run: python -m integrations.cursor_bridge"""
+
+from __future__ import annotations
+
+import logging
+import sys
+
+from integrations.cursor_bridge.server import serve_forever
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
+
+
+def main() -> int:
+    httpd = serve_forever()
+    try:
+        httpd.serve_forever()
+    except KeyboardInterrupt:
+        print("\nShutting down cursor_bridge", file=sys.stderr)
+    finally:
+        httpd.server_close()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/integrations/cursor_bridge/adapter.py
+++ b/integrations/cursor_bridge/adapter.py
@@ -1,0 +1,183 @@
+"""Map OpenAI Chat Completions payloads to Cursor SDK prompts and responses."""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+import uuid
+from typing import Any, Dict, List, Optional, Tuple
+
+
+CHAT_ONLY_PREFIX = (
+    "You are answering as a chat model behind an OpenAI-compatible API bridge. "
+    "Respond concisely in plain language. Avoid broad repo refactors unless the "
+    "user explicitly asks for code changes.\n\n"
+)
+
+
+def _extract_text(content: Any) -> str:
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        chunks: List[str] = []
+        for part in content:
+            if not isinstance(part, dict):
+                continue
+            if part.get("type") in ("text", "input_text"):
+                chunks.append(str(part.get("text", "")))
+            elif part.get("type") == "image_url":
+                chunks.append("[image omitted]")
+        return "\n".join(c for c in chunks if c)
+    return str(content)
+
+
+def messages_to_prompt(messages: List[Dict[str, Any]], *, chat_only: bool = False) -> str:
+    """Flatten OpenAI-style messages into one prompt for Agent.prompt()."""
+    lines: List[str] = []
+    for msg in messages or []:
+        if not isinstance(msg, dict):
+            continue
+        role = str(msg.get("role", "user"))
+        text = _extract_text(msg.get("content"))
+        if not text.strip():
+            continue
+        lines.append(f"[{role}]\n{text.strip()}")
+    body = "\n\n".join(lines) if lines else "Hello"
+    if chat_only:
+        return CHAT_ONLY_PREFIX + body
+    return body
+
+
+def build_completion_response(
+    *,
+    assistant_text: str,
+    model: str,
+    prompt_tokens: int = 0,
+    completion_tokens: int = 0,
+) -> Dict[str, Any]:
+    """Return an OpenAI chat.completion object."""
+    total = prompt_tokens + completion_tokens
+    return {
+        "id": f"chatcmpl-{uuid.uuid4().hex[:24]}",
+        "object": "chat.completion",
+        "created": int(time.time()),
+        "model": model,
+        "choices": [
+            {
+                "index": 0,
+                "message": {"role": "assistant", "content": assistant_text},
+                "finish_reason": "stop",
+            }
+        ],
+        "usage": {
+            "prompt_tokens": prompt_tokens,
+            "completion_tokens": completion_tokens,
+            "total_tokens": total,
+        },
+    }
+
+
+def run_chat_completion(
+    body: Dict[str, Any],
+    *,
+    default_model: str = "composer-2.5",
+    default_cwd: Optional[str] = None,
+) -> Tuple[int, Dict[str, Any]]:
+    """Execute one chat completion via Cursor SDK. Returns (http_status, json_body)."""
+    from agent.cursor_sdk_client import (
+        DEFAULT_MODEL,
+        _resolve_api_key,
+        _resolve_cwd,
+        cursor_sdk_available,
+    )
+
+    if not cursor_sdk_available():
+        return 503, {
+            "error": {
+                "message": "cursor-sdk not installed (pip install 'hermes-agent[cursor]')",
+                "type": "server_error",
+            }
+        }
+
+    api_key = _resolve_api_key(body.get("api_key") or os.environ.get("CURSOR_API_KEY"))
+    if not api_key:
+        return 401, {
+            "error": {
+                "message": "CURSOR_API_KEY required",
+                "type": "authentication_error",
+            }
+        }
+
+    messages = body.get("messages") or []
+    if not isinstance(messages, list):
+        return 400, {"error": {"message": "messages must be an array", "type": "invalid_request_error"}}
+
+    model = str(body.get("model") or default_model or DEFAULT_MODEL).strip()
+    cwd = _resolve_cwd(body.get("cwd") or default_cwd)
+    chat_only = os.environ.get("CURSOR_BRIDGE_CHAT_ONLY", "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+    prompt = messages_to_prompt(messages, chat_only=chat_only)
+
+    try:
+        from cursor_sdk import Agent, AgentOptions, CursorAgentError, LocalAgentOptions
+
+        result = Agent.prompt(
+            prompt,
+            AgentOptions(
+                api_key=api_key,
+                model=model,
+                local=LocalAgentOptions(cwd=cwd),
+            ),
+        )
+        status = getattr(result, "status", None)
+        text = getattr(result, "result", None) or getattr(result, "text", None) or ""
+        if status == "error":
+            return 502, {
+                "error": {
+                    "message": "Cursor agent run failed",
+                    "type": "server_error",
+                    "cursor_status": status,
+                }
+            }
+        return 200, build_completion_response(
+            assistant_text=str(text),
+            model=model,
+        )
+    except CursorAgentError as err:
+        msg = str(getattr(err, "message", err))
+        return 502, {"error": {"message": msg, "type": "server_error"}}
+    except Exception as exc:
+        return 500, {"error": {"message": str(exc), "type": "server_error"}}
+
+
+def models_list_payload(default_model: str = "composer-2.5") -> Dict[str, Any]:
+    return {
+        "object": "list",
+        "data": [
+            {
+                "id": default_model,
+                "object": "model",
+                "created": int(time.time()),
+                "owned_by": "cursor",
+            }
+        ],
+    }
+
+
+def parse_json_body(raw: bytes) -> Tuple[Optional[Dict[str, Any]], Optional[str]]:
+    if not raw:
+        return {}, None
+    try:
+        data = json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        return None, str(exc)
+    if not isinstance(data, dict):
+        return None, "JSON body must be an object"
+    return data, None

--- a/integrations/cursor_bridge/server.py
+++ b/integrations/cursor_bridge/server.py
@@ -1,0 +1,126 @@
+"""Minimal OpenAI-compatible HTTP server for Cursor SDK (stdlib + optional threading)."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Any, Dict, Optional, Tuple
+from urllib.parse import urlparse
+
+from integrations.cursor_bridge.adapter import (
+    models_list_payload,
+    parse_json_body,
+    run_chat_completion,
+)
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_HOST = "127.0.0.1"
+DEFAULT_PORT = 18765
+
+
+def _env_int(name: str, default: int) -> int:
+    try:
+        return int(os.environ.get(name, default))
+    except (TypeError, ValueError):
+        return default
+
+
+def _check_auth(headers: Any, required_key: Optional[str]) -> bool:
+    if not required_key:
+        return True
+    auth = headers.get("Authorization") if hasattr(headers, "get") else None
+    if not auth or not str(auth).startswith("Bearer "):
+        return False
+    token = str(auth)[7:].strip()
+    return token == required_key
+
+
+class CursorBridgeHandler(BaseHTTPRequestHandler):
+    """Serve /v1/chat/completions and /v1/models for Hermes custom provider."""
+
+    server_version = "CursorBridge/0.1"
+
+    def log_message(self, format: str, *args: Any) -> None:
+        logger.info("%s - %s", self.address_string(), format % args)
+
+    def _send_json(self, status: int, payload: Dict[str, Any]) -> None:
+        body = json.dumps(payload).encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _read_body(self) -> bytes:
+        length = int(self.headers.get("Content-Length", 0) or 0)
+        if length <= 0:
+            return b""
+        return self.rfile.read(length)
+
+    def _default_model(self) -> str:
+        return os.environ.get("CURSOR_BRIDGE_MODEL", "composer-2.5")
+
+    def _default_cwd(self) -> Optional[str]:
+        value = os.environ.get("CURSOR_BRIDGE_CWD", "").strip()
+        return value or None
+
+    def _required_api_key(self) -> Optional[str]:
+        return (os.environ.get("CURSOR_API_KEY") or "").strip() or None
+
+    def do_GET(self) -> None:
+        path = urlparse(self.path).path
+        if path in ("/health", "/v1/health"):
+            self._send_json(200, {"status": "ok", "service": "cursor_bridge"})
+            return
+        if path == "/v1/models":
+            if not _check_auth(self.headers, self._required_api_key()):
+                self._send_json(401, {"error": {"message": "Unauthorized"}})
+                return
+            self._send_json(200, models_list_payload(self._default_model()))
+            return
+        self._send_json(404, {"error": {"message": "Not found"}})
+
+    def do_POST(self) -> None:
+        path = urlparse(self.path).path
+        if path != "/v1/chat/completions":
+            self._send_json(404, {"error": {"message": "Not found"}})
+            return
+        if not _check_auth(self.headers, self._required_api_key()):
+            self._send_json(401, {"error": {"message": "Unauthorized"}})
+            return
+        body_bytes = self._read_body()
+        data, err = parse_json_body(body_bytes)
+        if err:
+            self._send_json(400, {"error": {"message": err}})
+            return
+        if data is None:
+            self._send_json(400, {"error": {"message": "Invalid JSON"}})
+            return
+        if data.get("stream"):
+            self._send_json(501, {
+                "error": {
+                    "message": "Streaming not implemented; set stream=false",
+                    "type": "not_implemented",
+                }
+            })
+            return
+        status, payload = run_chat_completion(
+            data,
+            default_model=self._default_model(),
+            default_cwd=self._default_cwd(),
+        )
+        self._send_json(status, payload)
+
+
+def serve_forever(
+    host: Optional[str] = None,
+    port: Optional[int] = None,
+) -> ThreadingHTTPServer:
+    bind_host = host or os.environ.get("CURSOR_BRIDGE_HOST", DEFAULT_HOST)
+    bind_port = port if port is not None else _env_int("CURSOR_BRIDGE_PORT", DEFAULT_PORT)
+    httpd = ThreadingHTTPServer((bind_host, bind_port), CursorBridgeHandler)
+    logger.info("cursor_bridge listening on http://%s:%s/v1", bind_host, bind_port)
+    return httpd

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,6 +112,8 @@ sms = ["aiohttp==3.13.3"]
 # to it, which is already provided by the `mcp` extra.
 computer-use = ["mcp==1.26.0"]
 acp = ["agent-client-protocol==0.9.0"]
+# Cursor Agent SDK — optional; proprietary license; see docs/integrations/cursor.md
+cursor = ["cursor-sdk>=0.1.5,<0.2"]
 # mistral: extra REMOVED 2026-05-12 — `mistralai` PyPI project quarantined
 # after malicious 2.4.6 release (Mini Shai-Hulud worm). Every version of
 # `mistralai` returns 404 on PyPI right now, so any pin we'd write is

--- a/tests/agent/test_cursor_sdk_client.py
+++ b/tests/agent/test_cursor_sdk_client.py
@@ -1,0 +1,80 @@
+"""Tests for agent.cursor_sdk_client (mocked — no live Cursor API)."""
+
+import json
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+class TestBuildCursorPrompt:
+    def test_includes_goal_and_context(self):
+        from agent.cursor_sdk_client import build_cursor_prompt
+
+        prompt = build_cursor_prompt("fix tests", context="use pytest")
+        assert "fix tests" in prompt
+        assert "pytest" in prompt
+        assert "structured summary" in prompt.lower() or "summary" in prompt.lower()
+
+
+class TestRunCursorAgent:
+    @patch("agent.cursor_sdk_client.cursor_sdk_available", return_value=False)
+    def test_missing_sdk(self, _avail):
+        from agent.cursor_sdk_client import run_cursor_agent
+
+        out = run_cursor_agent(goal="hello")
+        assert out["status"] == "error"
+        assert out["error_type"] == "dependency"
+
+    @patch("agent.cursor_sdk_client.cursor_sdk_available", return_value=True)
+    @patch("agent.cursor_sdk_client._resolve_api_key", return_value=None)
+    def test_missing_api_key(self, _key, _avail):
+        from agent.cursor_sdk_client import run_cursor_agent
+
+        out = run_cursor_agent(goal="hello")
+        assert out["status"] == "error"
+        assert out["error_type"] == "auth"
+
+    @patch("agent.cursor_sdk_client.cursor_sdk_available", return_value=True)
+    @patch("agent.cursor_sdk_client._resolve_api_key", return_value="cursor_test")
+    @patch("agent.cursor_sdk_client._load_sdk")
+    def test_successful_run(self, mock_load, _key, _avail):
+        from agent.cursor_sdk_client import run_cursor_agent
+
+        mock_agent = MagicMock()
+        mock_agent.agent_id = "agent-abc"
+        mock_run = MagicMock()
+        mock_run.id = "run-xyz"
+        mock_run.messages.return_value = []
+        mock_result = SimpleNamespace(status="finished", result="done summary")
+        mock_run.wait.return_value = mock_result
+
+        mock_agent.send.return_value = mock_run
+        mock_ctx = MagicMock()
+        mock_ctx.__enter__.return_value = mock_agent
+        mock_ctx.__exit__.return_value = False
+
+        MockAgent = MagicMock()
+        MockAgent.create.return_value = mock_ctx
+        CursorAgentError = type("CursorAgentError", (Exception,), {})
+        mock_load.return_value = (
+            MockAgent,
+            MagicMock(),
+            CursorAgentError,
+            MagicMock(),
+            None,
+        )
+
+        out = run_cursor_agent(goal="add readme", cwd="/tmp/repo")
+        assert out["status"] == "finished"
+        assert out["agent_id"] == "agent-abc"
+        assert out["run_id"] == "run-xyz"
+        assert "done summary" in out["summary"]
+
+
+class TestProbe:
+    @patch("agent.cursor_sdk_client.cursor_sdk_available", return_value=False)
+    def test_probe_no_sdk(self, _a):
+        from agent.cursor_sdk_client import probe_cursor_api_key
+
+        assert probe_cursor_api_key()["ok"] is False

--- a/tests/integrations/test_cursor_bridge.py
+++ b/tests/integrations/test_cursor_bridge.py
@@ -1,0 +1,80 @@
+"""Tests for integrations.cursor_bridge (no live Cursor API)."""
+
+import json
+from unittest.mock import patch
+
+import pytest
+
+
+class TestMessagesToPrompt:
+    def test_flattens_roles(self):
+        from integrations.cursor_bridge.adapter import messages_to_prompt
+
+        prompt = messages_to_prompt(
+            [
+                {"role": "system", "content": "You are helpful"},
+                {"role": "user", "content": "Hi"},
+            ]
+        )
+        assert "[system]" in prompt
+        assert "[user]" in prompt
+        assert "Hi" in prompt
+
+    def test_chat_only_prefix(self):
+        from integrations.cursor_bridge.adapter import messages_to_prompt
+
+        prompt = messages_to_prompt(
+            [{"role": "user", "content": "ping"}],
+            chat_only=True,
+        )
+        assert "chat model" in prompt.lower() or "plain language" in prompt.lower()
+
+
+class TestRunChatCompletion:
+    @patch("agent.cursor_sdk_client.cursor_sdk_available", return_value=False)
+    def test_sdk_missing(self, _a):
+        from integrations.cursor_bridge.adapter import run_chat_completion
+
+        status, body = run_chat_completion({"messages": []})
+        assert status == 503
+
+    @patch("agent.cursor_sdk_client.cursor_sdk_available", return_value=True)
+    @patch("agent.cursor_sdk_client._resolve_api_key", return_value=None)
+    def test_auth_required(self, _k, _a):
+        from integrations.cursor_bridge.adapter import run_chat_completion
+
+        status, body = run_chat_completion({"messages": [{"role": "user", "content": "x"}]})
+        assert status == 401
+
+    @patch("agent.cursor_sdk_client.cursor_sdk_available", return_value=True)
+    @patch("agent.cursor_sdk_client._resolve_api_key", return_value="key")
+    def test_success(self, _k, _a):
+        from types import SimpleNamespace
+        from unittest.mock import MagicMock
+        import sys
+
+        mock_cursor = MagicMock()
+        mock_cursor.Agent.prompt.return_value = SimpleNamespace(
+            status="finished", result="hello from cursor"
+        )
+        mock_cursor.AgentOptions = MagicMock()
+        mock_cursor.LocalAgentOptions = MagicMock()
+        mock_cursor.CursorAgentError = type("CursorAgentError", (Exception,), {})
+
+        with patch.dict(sys.modules, {"cursor_sdk": mock_cursor}):
+            from integrations.cursor_bridge.adapter import run_chat_completion
+
+            status, body = run_chat_completion(
+                {"messages": [{"role": "user", "content": "say hi"}]}
+            )
+        assert status == 200
+        assert body["choices"][0]["message"]["content"] == "hello from cursor"
+
+
+class TestParseJsonBody:
+    def test_invalid_json(self):
+        from integrations.cursor_bridge.adapter import parse_json_body
+
+        data, err = parse_json_body(b"{not json")
+        assert data is None
+        assert err

--- a/tests/tools/test_cursor_tool.py
+++ b/tests/tools/test_cursor_tool.py
@@ -1,0 +1,45 @@
+"""Tests for tools.cursor_tool."""
+
+import json
+import os
+from unittest.mock import patch
+
+import pytest
+
+
+class TestCursorToolRegistration:
+    def test_schema_registered(self):
+        import tools.cursor_tool  # noqa: F401 — registers with registry
+        from tools.registry import registry
+
+        entry = registry.get_entry("cursor_agent")
+        assert entry is not None
+        assert entry.toolset == "cursor"
+        assert "goal" in entry.schema["parameters"]["properties"]
+
+
+class TestCheckRequirements:
+    def test_false_without_key(self, monkeypatch):
+        monkeypatch.delenv("CURSOR_API_KEY", raising=False)
+        from tools.cursor_tool import check_cursor_agent_requirements
+
+        assert check_cursor_agent_requirements() is False
+
+    @patch("agent.cursor_sdk_client.cursor_sdk_available", return_value=True)
+    def test_true_with_key_and_sdk(self, _sdk, monkeypatch):
+        monkeypatch.setenv("CURSOR_API_KEY", "cursor_test")
+        from tools.cursor_tool import check_cursor_agent_requirements
+
+        assert check_cursor_agent_requirements() is True
+
+
+class TestHandler:
+    @patch("agent.cursor_sdk_client.run_cursor_agent")
+    def test_returns_json(self, mock_run):
+        mock_run.return_value = {"status": "finished", "summary": "ok"}
+        from tools.cursor_tool import cursor_agent
+
+        raw = cursor_agent(goal="test goal")
+        data = json.loads(raw)
+        assert data["status"] == "finished"
+        mock_run.assert_called_once()

--- a/tools/cursor_tool.py
+++ b/tools/cursor_tool.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""
+Cursor Agent tool — delegate focused coding work to Composer via Cursor SDK.
+
+Requires optional install: uv pip install 'hermes-agent[cursor]'
+and CURSOR_API_KEY from https://cursor.com/dashboard/integrations
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from typing import Any, Dict, Optional
+
+from tools.registry import registry
+
+logger = logging.getLogger(__name__)
+
+CURSOR_AGENT_SCHEMA: Dict[str, Any] = {
+    "name": "cursor_agent",
+    "description": (
+        "Run a Cursor IDE agent (Composer) on a repository directory for focused "
+        "coding tasks. Returns a structured summary only — use for implementation "
+        "work, refactors, or test fixes. Requires CURSOR_API_KEY and the optional "
+        "cursor-sdk package. Prefer this over delegate_task when you want Cursor's "
+        "native editing agent rather than Hermes subagents."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "goal": {
+                "type": "string",
+                "description": "What the Cursor agent should accomplish.",
+            },
+            "context": {
+                "type": "string",
+                "description": "Optional extra context (constraints, file paths, patterns).",
+            },
+            "cwd": {
+                "type": "string",
+                "description": (
+                    "Repository/working directory for the Cursor agent. "
+                    "Defaults to the current process working directory."
+                ),
+            },
+            "model": {
+                "type": "string",
+                "description": 'Cursor model id (default: "composer-2.5").',
+                "default": "composer-2.5",
+            },
+            "resume_agent_id": {
+                "type": "string",
+                "description": (
+                    "Resume a previous Cursor agent by id for multi-step work "
+                    "within the same parent turn."
+                ),
+            },
+            "cloud_repo_url": {
+                "type": "string",
+                "description": (
+                    "Optional Git repo URL for a Cursor cloud agent instead of local cwd."
+                ),
+            },
+            "cloud_starting_ref": {
+                "type": "string",
+                "description": "Git ref for cloud_repo_url (e.g. main).",
+            },
+        },
+        "required": ["goal"],
+    },
+}
+
+
+def check_cursor_agent_requirements() -> bool:
+    """Tool is available when API key is set and cursor-sdk can be loaded."""
+    if not os.environ.get("CURSOR_API_KEY", "").strip():
+        return False
+    try:
+        from agent.cursor_sdk_client import cursor_sdk_available
+
+        return cursor_sdk_available()
+    except Exception:
+        return False
+
+
+def cursor_agent(
+    goal: str,
+    context: Optional[str] = None,
+    cwd: Optional[str] = None,
+    model: str = "composer-2.5",
+    resume_agent_id: Optional[str] = None,
+    cloud_repo_url: Optional[str] = None,
+    cloud_starting_ref: Optional[str] = None,
+) -> str:
+    """Invoke Cursor SDK and return JSON string."""
+    try:
+        from agent.cursor_sdk_client import run_cursor_agent
+
+        payload = run_cursor_agent(
+            goal=goal,
+            context=context,
+            cwd=cwd,
+            model=model,
+            resume_agent_id=resume_agent_id,
+            cloud_repo_url=cloud_repo_url,
+            cloud_starting_ref=cloud_starting_ref,
+        )
+        return json.dumps(payload, ensure_ascii=False)
+    except Exception as exc:
+        logger.exception("cursor_agent failed")
+        return json.dumps({"status": "error", "error": str(exc), "error_type": "internal"})
+
+
+def _handle_cursor_agent(args: Dict[str, Any], **kwargs) -> str:
+    del kwargs
+    return cursor_agent(
+        goal=args.get("goal", ""),
+        context=args.get("context"),
+        cwd=args.get("cwd"),
+        model=args.get("model", "composer-2.5"),
+        resume_agent_id=args.get("resume_agent_id"),
+        cloud_repo_url=args.get("cloud_repo_url"),
+        cloud_starting_ref=args.get("cloud_starting_ref"),
+    )
+
+
+registry.register(
+    name="cursor_agent",
+    toolset="cursor",
+    schema=CURSOR_AGENT_SCHEMA,
+    handler=_handle_cursor_agent,
+    check_fn=check_cursor_agent_requirements,
+    requires_env=["CURSOR_API_KEY"],
+)

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -149,6 +149,9 @@ LAZY_DEPS: dict[str, tuple[str, ...]] = {
         "qrcode==7.4.2",
     ),
 
+    # ─── External agent runtimes ───────────────────────────────────────────
+    "tools.cursor": ("cursor-sdk>=0.1.5,<0.2",),
+
     # ─── Terminal backends ─────────────────────────────────────────────────
     "terminal.modal": ("modal==1.3.4",),
     "terminal.daytona": ("daytona==0.155.0",),

--- a/toolsets.py
+++ b/toolsets.py
@@ -230,6 +230,15 @@ TOOLSETS = {
         "includes": []
     },
 
+    "cursor": {
+        "description": (
+            "Delegate focused coding work to Cursor Agent SDK (Composer) — "
+            "requires CURSOR_API_KEY and optional cursor-sdk install"
+        ),
+        "tools": ["cursor_agent"],
+        "includes": []
+    },
+
     # "honcho" toolset removed — Honcho is now a memory provider plugin.
     # Tools are injected via MemoryManager, not the toolset system.
 
@@ -344,7 +353,7 @@ TOOLSETS = {
             "session_search",
             "execute_code", "delegate_task",
         ],
-        "includes": []
+        "includes": ["cursor"]
     },
 
     "hermes-api-server": {
@@ -377,7 +386,7 @@ TOOLSETS = {
             "ha_list_entities", "ha_get_state", "ha_list_services", "ha_call_service",
 
         ],
-        "includes": []
+        "includes": ["cursor"]
     },
     
     "hermes-cli": {

--- a/website/docs/integrations/cursor.md
+++ b/website/docs/integrations/cursor.md
@@ -1,0 +1,90 @@
+---
+title: "Cursor Agent SDK"
+sidebar_label: "Cursor SDK"
+description: "Delegate coding work to Composer via Cursor SDK and optional OpenAI bridge"
+---
+
+# Cursor Agent SDK integration
+
+Hermes can delegate focused repository work to **Cursor's agent runtime** (Composer 2.5 by default) using the official [Cursor Python SDK](https://cursor.com/docs/sdk/python). This keeps Hermes orchestration (memory, skills, messaging, cron) while Cursor handles IDE-grade editing in a target directory.
+
+## Install (optional)
+
+The SDK is **not** included in the default install (proprietary package, large wheels).
+
+```bash
+uv pip install -e ".[cursor]"
+```
+
+Add to `~/.hermes/.env`:
+
+```bash
+CURSOR_API_KEY=cursor_...   # https://cursor.com/dashboard/integrations
+```
+
+Verify:
+
+```bash
+hermes doctor
+```
+
+## `cursor_agent` tool (recommended)
+
+Use when you want Cursor Composer to implement or refactor code, not when you need Hermes subagents (`delegate_task`).
+
+| Parameter | Description |
+|-----------|-------------|
+| `goal` | Required task description |
+| `context` | Optional constraints, paths, conventions |
+| `cwd` | Repo directory (default: process cwd) |
+| `model` | Default `composer-2.5` |
+| `resume_agent_id` | Continue a prior Cursor agent in the same parent turn |
+| `cloud_repo_url` | Optional — run on Cursor cloud instead of local `cwd` |
+
+Returns JSON: `status`, `agent_id`, `run_id`, `summary`, and `error` on failure.
+
+The tool is in the **`cursor`** toolset (included by `hermes-acp` and `hermes-api-server`). Enable globally via `hermes tools` if needed.
+
+### vs `delegate_task`
+
+| | `cursor_agent` | `delegate_task` |
+|--|----------------|-----------------|
+| Runtime | Cursor SDK (Composer) | Hermes `AIAgent` subagent |
+| Tools | Cursor-native | Hermes tool registry |
+| Best for | Repo editing with Composer | Parallel Hermes workers |
+
+## Experimental: OpenAI bridge (Composer as LLM)
+
+**Not recommended for most users.** Each Hermes chat turn may spawn a full Cursor agent run (slow, costly).
+
+### 1. Start the bridge
+
+```bash
+export CURSOR_API_KEY=cursor_...
+python -m integrations.cursor_bridge
+# http://127.0.0.1:18765/v1
+```
+
+Optional: `CURSOR_BRIDGE_CHAT_ONLY=1` adds guidance to answer in chat-only mode.
+
+### 2. Point Hermes custom provider at the bridge
+
+```yaml
+model:
+  provider: custom
+  base_url: http://127.0.0.1:18765/v1
+  api_key: ${CURSOR_API_KEY}
+  api_mode: chat_completions
+```
+
+Bearer auth on bridge requests must match `CURSOR_API_KEY`.
+
+See [integrations/cursor_bridge/README.md](https://github.com/NousResearch/hermes-agent/blob/main/integrations/cursor_bridge/README.md) for environment variables.
+
+## RFC and upstream contribution
+
+Design notes: [docs/rfc/cursor-sdk-hermes-integration.md](https://github.com/NousResearch/hermes-agent/blob/main/docs/rfc/cursor-sdk-hermes-integration.md).
+
+## Security
+
+`cursor_agent` and the bridge grant Cursor the same class of access as the Cursor IDE agent for the chosen `cwd` (files, shell, MCP). Use on trusted repositories only.

--- a/website/docs/integrations/index.md
+++ b/website/docs/integrations/index.md
@@ -68,6 +68,7 @@ Speech-to-text supports six providers: local faster-whisper (free, runs on-devic
 ## IDE & Editor Integration
 
 - **[IDE Integration (ACP)](/docs/user-guide/features/acp)** — Use Hermes Agent inside ACP-compatible editors such as VS Code, Zed, and JetBrains. Hermes runs as an ACP server, rendering chat messages, tool activity, file diffs, and terminal commands inside your editor.
+- **[Cursor Agent SDK](/docs/integrations/cursor)** — Delegate coding tasks to Cursor Composer via the `cursor_agent` tool, with an optional local OpenAI-compatible bridge for advanced setups.
 
 ## Programmatic Access
 

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -598,6 +598,8 @@ The base URL can be overridden with `HF_BASE_URL`.
 
 Hermes Agent works with **any OpenAI-compatible API endpoint**. If a server implements `/v1/chat/completions`, you can point Hermes at it. This means you can use local models, GPU inference servers, multi-provider routers, or any third-party API.
 
+For **Cursor Composer** specifically, see [Cursor Agent SDK](/docs/integrations/cursor) (`cursor_agent` tool and optional experimental bridge).
+
 ### General Setup
 
 Three ways to configure a custom endpoint:

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -647,6 +647,7 @@ const sidebars: SidebarsConfig = {
       items: [
         'integrations/index',
         'integrations/providers',
+        'integrations/cursor',
         'user-guide/features/mcp',
         'user-guide/features/acp',
         'user-guide/features/api-server',


### PR DESCRIPTION
## Summary

Adds optional [Cursor Agent SDK](https://cursor.com/docs/sdk/python) integration so Hermes can delegate focused coding work to Composer 2.5, plus an experimental local OpenAI-compatible bridge for advanced setups.

- **`cursor_agent` tool** — spawns a local Cursor agent (`composer-2.5` default), returns structured JSON summary
- **`integrations/cursor_bridge`** — optional `POST /v1/chat/completions` shim on `127.0.0.1:18765` for `provider: custom`
- Optional extra: `hermes-agent[cursor]` (proprietary `cursor-sdk`, not in `[all]`)
- Lazy install: `tools.cursor`
- Docs: `website/docs/integrations/cursor.md`, RFC in `docs/rfc/`

Closes discussion request in #30640 (RFC posted as issue because repo discussions are disabled).

## Install / test

```bash
uv pip install -e ".[cursor]"
export CURSOR_API_KEY="cursor_..."
hermes doctor
python -m pytest tests/agent/test_cursor_sdk_client.py tests/tools/test_cursor_tool.py tests/integrations/test_cursor_bridge.py -q
```

Optional bridge:

```bash
python -m integrations.cursor_bridge
```

## Design notes

- Tool-first integration (not a built-in provider) per [adding-providers](https://github.com/NousResearch/hermes-agent/blob/main/website/docs/developer-guide/adding-providers.md)
- `cursor` toolset included in `hermes-acp` and `hermes-api-server` only
- Bridge documented as costly/slow — prefer `cursor_agent` for coding

## Test plan

- [x] Unit tests (mocked, no live Cursor API)
- [ ] Maintainer smoke: `hermes chat -q "..."` with `[cursor]` extra and key set
- [ ] macOS / Linux manual check of `cursor_bridge` health endpoint


Made with [Cursor](https://cursor.com)