### PR TITLE
feat(openviking): add isolation flags for shorthand URI expansion

### DIFF
--- a/plugins/memory/openviking/__init__.py
+++ b/plugins/memory/openviking/__init__.py
@@ -464,6 +464,18 @@ class OpenVikingMemoryProvider(MemoryProvider):
                 "default": "hermes",
                 "env_var": "OPENVIKING_AGENT",
             },
+            {
+                "key": "isolate_user_by_agent",
+                "description": "Expand user-scope shorthands with /agent/{id} (viking://user/memories → viking://user/{user}/agent/{agent}/memories) (default: false)",
+                "default": False,
+                "env_var": "OPENVIKING_ISOLATE_USER_BY_AGENT",
+            },
+            {
+                "key": "isolate_agent_by_user",
+                "description": "Expand agent-scope shorthands with /user/{id} (viking://agent/memories → viking://agent/{agent}/user/{user}/memories) (default: false)",
+                "default": False,
+                "env_var": "OPENVIKING_ISOLATE_AGENT_BY_USER",
+            },
         ]
 
     def initialize(self, session_id: str, **kwargs) -> None:
@@ -472,6 +484,8 @@ class OpenVikingMemoryProvider(MemoryProvider):
         self._account = os.environ.get("OPENVIKING_ACCOUNT", "default")
         self._user = os.environ.get("OPENVIKING_USER", "default")
         self._agent = os.environ.get("OPENVIKING_AGENT", "hermes")
+        self._isolate_user_by_agent = os.environ.get("OPENVIKING_ISOLATE_USER_BY_AGENT", "false").lower() in ("true", "1", "yes")
+        self._isolate_agent_by_user = os.environ.get("OPENVIKING_ISOLATE_AGENT_BY_USER", "false").lower() in ("true", "1", "yes")
         self._session_id = session_id
         self._turn_count = 0
 
@@ -631,6 +645,42 @@ class OpenVikingMemoryProvider(MemoryProvider):
         slug = uuid.uuid4().hex[:12]
         return f"viking://user/{self._user}/memories/{subdir}/mem_{slug}.md"
 
+    def _expand_scope(self, uri: str) -> str:
+        """Expand OpenViking shorthand URIs to canonical paths based on isolation flags.
+
+        Expands shorthand URIs to canonical paths based on isolation flags:
+          viking://user/memories  →  viking://user/{user}[/agent/{agent}]/memories
+          viking://agent/memories →  viking://agent/{agent}[/user/{user}]/memories
+        Non-shorthand URIs pass through unchanged.
+        """
+        if not uri.startswith("viking://"):
+            return uri
+
+        parts = uri[len("viking://"):].split("/")
+        if len(parts) < 2:
+            return uri
+
+        scope = parts[0]
+        second = parts[1]
+        suffix = parts[2:] if len(parts) > 2 else []
+        suffix_str = f"/{'/'.join(suffix)}" if suffix else ""
+
+        # User scope shorthands: viking://user/{memories|profile.md|...}
+        user_shorthands = {"memories", "profile.md", ".abstract.md", ".overview.md"}
+        if scope == "user" and second in user_shorthands:
+            if self._isolate_user_by_agent:
+                return f"viking://user/{self._user}/agent/{self._agent}/{second}{suffix_str}"
+            return f"viking://user/{self._user}/{second}{suffix_str}"
+
+        # Agent scope shorthands: viking://agent/{memories|skills|...}
+        agent_shorthands = {"memories", "skills", "instructions", "workspaces"}
+        if scope == "agent" and second in agent_shorthands:
+            if self._isolate_agent_by_user:
+                return f"viking://agent/{self._agent}/user/{self._user}/{second}{suffix_str}"
+            return f"viking://agent/{self._agent}/{second}{suffix_str}"
+
+        return uri
+
     def on_memory_write(
         self,
         action: str,
@@ -746,7 +796,7 @@ class OpenVikingMemoryProvider(MemoryProvider):
         if mode != "auto":
             payload["mode"] = mode
         if args.get("scope"):
-            payload["target_uri"] = args["scope"]
+            payload["target_uri"] = self._expand_scope(args["scope"])
         if args.get("limit"):
             payload["top_k"] = args["limit"]
 
@@ -853,7 +903,7 @@ class OpenVikingMemoryProvider(MemoryProvider):
 
     def _tool_browse(self, args: dict) -> str:
         action = args.get("action", "list")
-        path = args.get("path", "viking://")
+        path = self._expand_scope(args.get("path", "viking://"))
 
         # Map action to the correct fs endpoint (all GET with uri= param)
         endpoint_map = {"tree": "/api/v1/fs/tree", "list": "/api/v1/fs/ls", "stat": "/api/v1/fs/stat"}


### PR DESCRIPTION
## What

Add two environment-variable flags that control how OpenViking's shorthand URIs are expanded for search and browse operations:

- `OPENVIKING_ISOLATE_USER_BY_AGENT` (default: `false`) — when set to `true`, expands `viking://user/memories` (and similar user-scope shorthands) to `viking://user/{user}/agent/{agent}/memories`, isolating each agent's memory namespace under a per-agent subdirectory.
- `OPENVIKING_ISOLATE_AGENT_BY_USER` (default: `false`) — when set to `true`, expands `viking://agent/memories` (and similar agent-scope shorthands) to `viking://agent/{agent}/user/{user}/memories`.

Non-shorthand URIs (e.g. `viking://resources`, `viking://session/{id}`) pass through unchanged. The write path (`_build_memory_uri`) is not affected — memories are always stored to the flat shared path.

This is a purely additive change: existing deployments keep the current flat behavior (both flags default to `false`).

## Why

When multiple agents share a single OpenViking instance, search and browse operations via shorthand URIs (like `viking://user/memories`) all resolve to the same flat path. These flags give operators opt-in control to scope memory visibility per agent or per user, enabling multi-agent deployments where each agent sees only its own memory namespace without server-side changes.

## How to test

1. Set `OPENVIKING_ISOLATE_USER_BY_AGENT=true` and `OPENVIKING_ISOLATE_AGENT_BY_USER=true` in the environment.
2. Call `viking_search(scope="viking://user/memories")` — the `target_uri` sent to OpenViking should be `viking://user/{user}/agent/{agent}/memories`.
3. Call `viking_browse(path="viking://user/memories")` — should list entries under the agent-scoped directory.
4. Call `viking_browse(path="viking://agent/skills")` — should resolve to `viking://agent/{agent}/user/{user}/skills`.
5. Verify `viking_remember` writes to the flat path (`viking://user/{user}/memories/...`) regardless of flag values.
6. With both flags set to `false` (default), behavior is unchanged.

## Checklist

- [x] Single logical change (one `feat` commit)
- [x] Conventional commit format
- [x] Tests pass (30/30 existing tests)
- [x] Backward compatible (defaults to `false`)
