### PR TITLE
fix(test): cap default runner workers

### DIFF
--- a/scripts/run_tests_parallel.py
+++ b/scripts/run_tests_parallel.py
@@ -462,8 +462,8 @@ def main() -> int:
         "-j",
         "--jobs",
         type=int,
-        default=int(os.environ.get("HERMES_TEST_WORKERS") or (os.cpu_count() or 4) * 2),
-        help="Parallel worker count (default: $HERMES_TEST_WORKERS or cpu_count*2)",
+        default=int(os.environ.get("HERMES_TEST_WORKERS") or min(4, os.cpu_count() or 4)),
+        help="Parallel worker count (default: $HERMES_TEST_WORKERS or up to 4)",
     )
     parser.add_argument(
         "--paths",

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -65,11 +65,11 @@ class TestCompress:
         assert result == msgs
 
     def test_truncation_fallback_no_client(self, compressor):
-        # compressor has client=None and abort_on_summary_failure=False (default),
-        # so the LEGACY fallback path inserts a static "summary unavailable"
-        # placeholder and the middle window is dropped.
+        # Simulate "no summarizer available" explicitly. call_llm can otherwise
+        # discover the developer's real auxiliary credentials from auth state.
         msgs = [{"role": "system", "content": "System prompt"}] + self._make_messages(10)
-        result = compressor.compress(msgs)
+        with patch("agent.context_compressor.call_llm", side_effect=RuntimeError("no provider")):
+            result = compressor.compress(msgs)
         assert len(result) < len(msgs)
         # Should keep system message and last N
         assert result[0]["role"] == "system"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -358,6 +358,10 @@ def _hermetic_environment(tmp_path, monkeypatch):
     monkeypatch.setenv("AWS_EC2_METADATA_DISABLED", "true")
     monkeypatch.setenv("AWS_METADATA_SERVICE_TIMEOUT", "1")
     monkeypatch.setenv("AWS_METADATA_SERVICE_NUM_ATTEMPTS", "1")
+    # Tirith auto-installs from GitHub when enabled and missing. Unit tests
+    # should never perform that implicit network/bootstrap path; Tirith-specific
+    # tests opt back in by patching the security config directly.
+    monkeypatch.setenv("TIRITH_ENABLED", "false")
 
     # 5. Reset plugin singleton so tests don't leak plugins from
     #    ~/.hermes/plugins/ (which, per step 3, is now empty — but the

--- a/tests/gateway/test_runner_startup_failures.py
+++ b/tests/gateway/test_runner_startup_failures.py
@@ -207,6 +207,7 @@ async def test_start_gateway_replace_force_uses_terminate_pid(monkeypatch, tmp_p
         lambda **kwargs: 0,
     )
     monkeypatch.setattr("gateway.status.terminate_pid", lambda pid, force=False: calls.append((pid, force)))
+    monkeypatch.setattr("gateway.status._pid_exists", lambda pid: True)
     monkeypatch.setattr("gateway.run.os.getpid", lambda: 100)
     monkeypatch.setattr("gateway.run.os.kill", lambda pid, sig: None)
     monkeypatch.setattr("time.sleep", lambda _: None)

--- a/tests/tools/test_tirith_security.py
+++ b/tests/tools/test_tirith_security.py
@@ -831,7 +831,8 @@ class TestDiskFailureMarker:
         with patch("tools.tirith_security._failure_marker_path", return_value=marker):
             from tools.tirith_security import _mark_install_failed, _is_install_failed_on_disk
             _mark_install_failed("cosign_missing")
-            assert _is_install_failed_on_disk()  # cosign still absent
+            with patch("tools.tirith_security.shutil.which", return_value=None):
+                assert _is_install_failed_on_disk()  # cosign still absent
 
             # Now cosign appears on PATH
             with patch("tools.tirith_security.shutil.which", return_value="/usr/local/bin/cosign"):

--- a/tests/tools/test_voice_mode.py
+++ b/tests/tools/test_voice_mode.py
@@ -10,6 +10,18 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 
+def _non_wsl_proc_version(real_open):
+    """Return an open() shim that makes host WSL detection deterministic."""
+    def _fake_open(file, *args, **kwargs):
+        if file == "/proc/version":
+            from io import StringIO
+
+            return StringIO("Linux test-kernel")
+        return real_open(file, *args, **kwargs)
+
+    return _fake_open
+
+
 # ============================================================================
 # Fixtures
 # ============================================================================
@@ -68,6 +80,7 @@ class TestDetectAudioEnvironment:
         monkeypatch.delenv("SSH_CONNECTION", raising=False)
         monkeypatch.setattr("tools.voice_mode._import_audio",
                             lambda: (MagicMock(), MagicMock()))
+        monkeypatch.setattr("builtins.open", _non_wsl_proc_version(open))
 
         from tools.voice_mode import detect_audio_environment
         result = detect_audio_environment()
@@ -225,6 +238,7 @@ class TestDetectAudioEnvironment:
         monkeypatch.setattr("tools.voice_mode.shutil.which", lambda cmd: "/data/data/com.termux/files/usr/bin/termux-microphone-record" if cmd == "termux-microphone-record" else None)
         monkeypatch.setattr("tools.voice_mode._termux_api_app_installed", lambda: True)
         monkeypatch.setattr("tools.voice_mode._import_audio", lambda: (_ for _ in ()).throw(ImportError("no audio libs")))
+        monkeypatch.setattr("builtins.open", _non_wsl_proc_version(open))
 
         from tools.voice_mode import detect_audio_environment
         result = detect_audio_environment()


### PR DESCRIPTION
## What does this PR do?

Caps the default worker count for `scripts/run_tests_parallel.py` at 4 instead of using `cpu_count * 2`.

The current default can spawn dozens of per-file pytest subprocesses on high-core developer machines. That pegs CPU and creates heavy disk churn from repeated Python startup, pytest collection, cache/temp writes, and hermetic `HERMES_HOME` setup. Explicit `-j/--jobs` and `HERMES_TEST_WORKERS` still override the default.

This is the current-main replacement for #8628. #8628 fixed the older xdist `-n auto` path, but #29016 replaced that runner with per-file subprocess isolation, so the same local-machine footgun moved to `scripts/run_tests_parallel.py`.

This also includes a small CI/test cleanup group needed to make the full suite hermetic on a normal developer machine instead of depending on host auth state, host PIDs, host WSL detection, or globally installed binaries.

## Related Issue

No issue filed.

Related: #8628, #29016

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- changed `scripts/run_tests_parallel.py` default jobs from `cpu_count * 2` to `min(4, cpu_count)`
- kept `HERMES_TEST_WORKERS` and explicit `-j/--jobs` overrides working as before
- updated the `--jobs` help text to match the new default
- disabled Tirith auto-bootstrap in the generic hermetic test environment; Tirith-specific tests can still opt in by patching config
- made the Tirith cosign-missing test independent of whether `cosign` is installed on the host
- made the context-compressor no-client fallback test explicitly simulate no summarizer instead of discovering real auxiliary credentials from user auth state
- made the gateway replace/force startup test independent of whether PID `42` happens to exist on the host
- made voice environment tests independent of host WSL detection when the test is specifically exercising non-WSL paths

## How to Test

1. Run `scripts/run_tests.sh tests/test_run_tests_parallel.py -- -q` and verify the runner prints `running with -j 4` when no `-j` is provided.
2. Run `scripts/run_tests.sh -j 4 tests/agent/test_context_compressor.py tests/gateway/test_runner_startup_failures.py tests/tools/test_voice_mode.py tests/tools/test_tirith_security.py tests/test_run_tests_parallel.py -- -q` and verify the hermetic cleanup coverage passes.
3. Run `scripts/run_tests.sh -j 4` and verify the full local suite passes.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: WSL2 / Ubuntu under Windows 11 Terminal

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A

## Screenshots / Logs

- `scripts/run_tests.sh tests/test_run_tests_parallel.py -- -q` → `1 tests passed`, runner output shows default `running with -j 4`
- `scripts/run_tests.sh -j 4 tests/test_run_tests_parallel.py -- -q` → `1 tests passed`, runner output shows explicit `running with -j 4`
- `scripts/run_tests.sh -j 4 tests/agent/test_context_compressor.py tests/gateway/test_runner_startup_failures.py tests/tools/test_voice_mode.py tests/tools/test_tirith_security.py tests/test_run_tests_parallel.py -- -q` → `245 tests passed, 0 failed`
- `scripts/run_tests.sh -j 4` → `1139 files, 25007 tests passed, 0 failed` in `757.3s` with `4 workers`
- `/usr/bin/time -v scripts/run_tests.sh` → `1139 files, 25007 tests passed, 0 failed` in `660.4s` suite time / `13:11.66` wall time; plain no-`-j` invocation used the new `4 workers` default; CPU `230%`, max RSS `738312 KB`, filesystem inputs `165920`, outputs `4271720`

