### PR TITLE
fix: harden kanban sqlite durability

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1048,7 +1048,10 @@ def connect(
             # See hermes_state._WAL_INCOMPAT_MARKERS for detection logic.
             from hermes_state import apply_wal_with_fallback
             apply_wal_with_fallback(conn, db_label=f"kanban.db ({path.name})")
-            conn.execute("PRAGMA synchronous=NORMAL")
+            # Kanban is a durable coordination board, not a high-throughput cache.
+            # Use FULL durability so gateway/worker crashes or forced restarts are
+            # less likely to leave a malformed board after in-flight writes.
+            conn.execute("PRAGMA synchronous=FULL")
             conn.execute("PRAGMA foreign_keys=ON")
             needs_init = resolved not in _INITIALIZED_PATHS
             if needs_init:


### PR DESCRIPTION
## Summary

- switch the Kanban SQLite connection from `PRAGMA synchronous=NORMAL` to `FULL`
- document why Kanban favors durability over write-throughput
- reduce the chance of malformed board state after gateway/worker crashes or forced restarts during in-flight writes

## Test plan

- `python -m pytest tests/hermes_cli/test_kanban_db.py tests/hermes_cli/test_kanban_db_init.py tests/hermes_cli/test_kanban_core_functionality.py tests/hermes_cli/test_kanban_boards.py tests/hermes_cli/test_kanban_blocked_sticky.py tests/hermes_cli/test_kanban_diagnostics.py tests/hermes_cli/test_kanban_notify.py tests/hermes_cli/test_kanban_specify_db.py tests/hermes_cli/test_kanban_decompose_db.py tests/tools/test_kanban_tools.py tests/plugins/test_kanban_worker_runs.py tests/plugins/test_kanban_dashboard_plugin.py tests/gateway/test_kanban_notifier.py -q -o 'addopts='`
  - `654 passed, 1 skipped`

## Review

Independent reviewer verdict: passed. No security concerns or logic errors; non-blocking note to watch for write-latency impact.
