### PR TITLE
fix(slack): suppress no-reply sentinel sends

### DIFF
--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -52,6 +52,11 @@ from gateway.platforms.base import (
 
 logger = logging.getLogger(__name__)
 
+
+def _is_no_reply_sentinel(content: Any) -> bool:
+    """Return True when ``content`` is the explicit Slack no-reply sentinel."""
+    return isinstance(content, str) and content.strip() == "NO_REPLY"
+
 # ContextVar carrying the user_id of the slash-command invoker.
 # Set in _handle_slash_command, read in send() to match the correct
 # stashed response_url when multiple users issue commands on the same
@@ -765,6 +770,10 @@ class SlackAdapter(BasePlatformAdapter):
         """Send a message to a Slack channel or DM."""
         if not self._app:
             return SendResult(success=False, error="Not connected")
+
+        if _is_no_reply_sentinel(content):
+            logger.debug("[Slack] Suppressed explicit no-reply sentinel for channel %s", chat_id)
+            return SendResult(success=True, raw_response={"suppressed": "NO_REPLY"})
 
         try:
             # Check for a pending slash-command context.  When the user ran a

--- a/tests/gateway/test_slack_no_reply_sentinel.py
+++ b/tests/gateway/test_slack_no_reply_sentinel.py
@@ -1,0 +1,56 @@
+import asyncio
+
+from gateway.config import PlatformConfig
+from gateway.platforms.slack import SlackAdapter, _is_no_reply_sentinel
+
+
+class _FakeSlackClient:
+    def __init__(self):
+        self.posts = []
+
+    async def chat_postMessage(self, **kwargs):
+        self.posts.append(kwargs)
+        return {"ts": "123.456"}
+
+
+class _FakeSlackApp:
+    def __init__(self, client):
+        self.client = client
+
+
+def _connected_adapter():
+    client = _FakeSlackClient()
+    adapter = SlackAdapter(PlatformConfig(enabled=True))
+    adapter._app = _FakeSlackApp(client)
+    return adapter, client
+
+
+def test_no_reply_sentinel_matches_exact_trimmed_text_only():
+    assert _is_no_reply_sentinel("NO_REPLY")
+    assert _is_no_reply_sentinel("  NO_REPLY\n")
+    assert not _is_no_reply_sentinel("Please do not use NO_REPLY here")
+    assert not _is_no_reply_sentinel("")
+    assert not _is_no_reply_sentinel(None)
+
+
+def test_slack_send_suppresses_no_reply_sentinel_without_posting():
+    adapter, client = _connected_adapter()
+
+    result = asyncio.run(adapter.send("C123", "  NO_REPLY\n"))
+
+    assert result.success is True
+    assert result.message_id is None
+    assert result.raw_response == {"suppressed": "NO_REPLY"}
+    assert client.posts == []
+
+
+def test_slack_send_posts_regular_messages_containing_no_reply_text():
+    adapter, client = _connected_adapter()
+
+    result = asyncio.run(adapter.send("C123", "I would not use NO_REPLY here"))
+
+    assert result.success is True
+    assert result.message_id == "123.456"
+    assert len(client.posts) == 1
+    assert client.posts[0]["channel"] == "C123"
+    assert client.posts[0]["text"] == "I would not use NO_REPLY here"


### PR DESCRIPTION
## What does this PR do?

Treats an exact `NO_REPLY` response from the Slack adapter as intentional silence instead of user-visible message text.

Slack channels and threads are shared human surfaces, so a gateway-backed agent may intentionally decide that a message should not receive a visible response. This adds a small final-send guard so the Slack adapter suppresses the explicit sentinel before `chat_postMessage`, while still allowing ordinary messages that merely contain the text `NO_REPLY`.

Reference PRs/context from this repo:

- #18073 surfaced self-improvement review summaries across gateway surfaces; this PR follows the same gateway-boundary discipline by handling a Slack-specific final-send concern at the adapter boundary.
- #3293 added gateway delivery for background review notifications; this PR is another narrow gateway delivery behaviour fix, but for explicit final-response suppression.
- #13248 is adjacent issue context around Slack group-thread non-reply handling.

## Related Issue

Fixes #30644

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/platforms/slack.py`
  - Adds `_is_no_reply_sentinel()` for exact trimmed `NO_REPLY` detection.
  - Suppresses exact sentinel sends before Slack `chat_postMessage` is called.
  - Returns a successful `SendResult` with suppression metadata so callers do not treat the turn as a send failure.
- `tests/gateway/test_slack_no_reply_sentinel.py`
  - Adds regression coverage for exact sentinel matching.
  - Verifies whitespace-trimmed `NO_REPLY` does not call `chat_postMessage`.
  - Verifies longer messages containing `NO_REPLY` still post normally.

## How to Test

1. Run the targeted regression test:
   ```bash
   python -m pytest tests/gateway/test_slack_no_reply_sentinel.py -q -o 'addopts='
   ```
2. Run the relevant Slack gateway tests:
   ```bash
   python -m pytest tests/gateway/test_slack.py tests/gateway/test_slack_approval_buttons.py tests/gateway/test_slack_no_reply_sentinel.py -q -o 'addopts='
   ```
3. Optional broader gateway sweep:
   ```bash
   python -m pytest tests/gateway -q -o 'addopts='
   ```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu/Linux container

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A

## Screenshots / Logs

Targeted regression:

```text
$ python -m pytest tests/gateway/test_slack_no_reply_sentinel.py -q -o 'addopts='
...                                                                      [100%]
3 passed in 0.29s
```

Relevant Slack gateway tests:

```text
$ python -m pytest tests/gateway/test_slack.py tests/gateway/test_slack_approval_buttons.py tests/gateway/test_slack_no_reply_sentinel.py -q -o 'addopts='
212 passed, 37 warnings in 2.02s
```

Broader gateway sweep was also run. It reached `5599 passed, 74 skipped`; 6 Telegram tests failed on existing `ParseMode` repr expectations (`'MarkdownV2'` vs `MARKDOWN_V2`) and are unrelated to this Slack-only change.
